### PR TITLE
fix(windows): fix checkbox and hint help button styles

### DIFF
--- a/windows/src/desktop/kmshell/xml/config.css
+++ b/windows/src/desktop/kmshell/xml/config.css
@@ -158,7 +158,7 @@ input.kbd_button
   border: 1px solid #dadddc;
 }
 
-input.kbd_button:hover, input[type='button']:hover, button[type='button']:hover
+input.kbd_button:hover, input[type='button']:hover, button[type='button']:hover, input[type='submit']:hover
 {
   background: #F69169;
   border-color: #F69169;
@@ -350,7 +350,7 @@ html
 }
 
 input[type=checkbox]+label {
-  background: #dadddc;
+  background: #79C3DA;
   border-radius: 4px;
   color: #33333f;
   border: none;
@@ -358,11 +358,10 @@ input[type=checkbox]+label {
   font-size: 12px;
   height: 25px;
   margin-right: 8px;
-  border: 1px solid #dadddc;
 }
 
 input[type=checkbox]:checked +label {
-  background: #CC3846;
+  background: #79C3DA;
   border-radius: 4px;
   color: #33333f;
   border: none;
@@ -370,7 +369,6 @@ input[type=checkbox]:checked +label {
   font-size: 12px;
   height: 25px;
   margin-right: 8px;
-  border: 1px solid #dadddc;
 }
 
 .list_item.kbd_list_item.expanded .list_detail

--- a/windows/src/desktop/kmshell/xml/help.xsl
+++ b/windows/src/desktop/kmshell/xml/help.xsl
@@ -116,7 +116,7 @@
 
           #buttons {
           float: right;
-          padding: 10px;
+          padding: 8px 10px 8px 10px;
           }
 
           #help {

--- a/windows/src/desktop/kmshell/xml/hint.css
+++ b/windows/src/desktop/kmshell/xml/hint.css
@@ -1,18 +1,18 @@
-* { 
-  font-size: 13.3px; 
+* {
+  font-size: 13.3px;
 }
 
 body {
-  padding: 0px; 
-  margin: 0px; 
-  overflow: hidden; 
-  background: white; 
-  border: none; 
+  padding: 0px;
+  margin: 0px;
+  overflow: hidden;
+  background: white;
+  border: none;
 }
 
-html { 
-  padding: 0px; 
-  margin: 0px; 
+html {
+  padding: 0px;
+  margin: 0px;
   overflow: hidden;
 }
 
@@ -53,7 +53,7 @@ html {
 
 #header {
   background: white;
-  top: 8px; 
+  top: 8px;
   left: 0;
   width: 100%;
   position: absolute;
@@ -72,17 +72,17 @@ html {
 
 #icon {
   position: absolute;
-  left: 0; 
+  left: 0;
   top: 16px;
   margin: 0 15px;
 }
 
-#exiticon { 
+#exiticon {
   float: left
 }
 
 #title {
-  left: 80px; 
+  left: 80px;
   top: 20px;
   position: absolute;
   font-size: 21.3px;
@@ -92,7 +92,7 @@ html {
 
 #hint {
   position: absolute;
-  left: 0; 
+  left: 0;
   top: 64px;
   font-size: 14.7px;
   padding: 20px;
@@ -107,10 +107,10 @@ html {
 
 #buttons {
   float: right;
-  padding: 10px;
+  padding: 8px 10px 8px 10px;
 }
 
 #buttons input {
-  width: 80px; 
+  width: 80px;
   margin: 0 4px;
 }


### PR DESCRIPTION
Fixes #7748
Also fixed the help dialogue which had the same issue. Fixed the over colour for the ok button.
![image](https://user-images.githubusercontent.com/58423624/202625832-5bc4e786-60f1-4d44-96d3-925aa344ea50.png)

![image](https://user-images.githubusercontent.com/58423624/202626104-c81a9b36-407e-4a85-b902-566494d5a4b3.png)

![image](https://user-images.githubusercontent.com/58423624/202626378-432952e0-aced-4f3d-b6e9-5227cf6c00c6.png)

@keymanapp-test-bot skip