### PR TITLE
fix(windows): backout ms button style for add lang pop up

### DIFF
--- a/windows/src/desktop/kmshell/xml/config.css
+++ b/windows/src/desktop/kmshell/xml/config.css
@@ -170,36 +170,6 @@ input[type='submit']:disabled, input[type='button']:disabled, button:disabled
   background: #80808f;
 }
 
-/* Microsoft Window UI style buttons */
-input.ms_button
-{
-  background: #e1e1e1;
-  border-radius: 0px;
-  color: #33333f;
-  border: none;
-  border: 1px solid;
-  border-color: #adadad;
-  vertical-align: top;
-  outline-color: #0078d7;
-  padding: 0px 15px 0px 15px;
-
-}
-
-input.ms_button:hover
-{
-  background: #e5f1fb ;
-  border-color: #0078d7;
-}
-
-input.ms_button:focus
-{
-  background: #e5f1fb ;
-  border-color: #0078d7;
-  border-radius: 0px;
-}
-
-/* Microsoft Window UI style */
-
 a.hotkey:link, a.hotkey:visited
 {
   color: black;
@@ -1235,7 +1205,7 @@ th
   padding-top: 10px;
   position: fixed;
   top: 45%;
-  left: 45%;
+  left: 49%;
 }
 
 .modify .keyboard_language {

--- a/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
@@ -385,12 +385,12 @@
                 </div>
                 <div class='list_languages_add'>
                   <xsl:call-template name="button">
-                    <xsl:with-param name="className">ms_button</xsl:with-param>
+                    <xsl:with-param name="className">kbd_button</xsl:with-param>
                     <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Languages_Install']"/></xsl:with-param>
                     <xsl:with-param name="command">keyman:keyboardlanguage_install?id=<xsl:value-of select="id"/></xsl:with-param>
                   </xsl:call-template>
                   <xsl:call-template name="button">
-                    <xsl:with-param name="className">ms_button</xsl:with-param>
+                    <xsl:with-param name="className">kbd_button</xsl:with-param>
                     <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Button_Close']"/></xsl:with-param>
                     <xsl:with-param name="onclick">return hideModifyLink('<xsl:value-of select="../../id" />')</xsl:with-param>
                   </xsl:call-template>


### PR DESCRIPTION
Revert the MS CSS style for the add-remove language pop dialogue in the keyman configuration.
![image](https://user-images.githubusercontent.com/58423624/202636786-c77379a9-4678-4fbd-a740-45ee7fc9d6fd.png)

@keymanapp-test-bot skip