### PR TITLE
fix(android/app): Only check Install Referrer API with Play Store installs

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
@@ -88,7 +88,9 @@ public class CheckInstallReferrer {
     if (installerInfo == null) {
       // Side loaded so just return
       return;
-    } else if (!installerInfo.equalsIgnoreCase(GOOGLE_PLAY)) {
+    }
+    
+    if (!installerInfo.equalsIgnoreCase(GOOGLE_PLAY)) {
       KMLog.LogInfo(TAG, "Skipping install referrer. Installed from " + installerInfo);
       return;
     }

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
@@ -25,6 +25,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.RemoteException;
 import android.util.Log;
+import java.lang.IllegalArgumentException;
 
 import com.android.installreferrer.api.InstallReferrerClient;
 import com.android.installreferrer.api.InstallReferrerStateListener;
@@ -71,16 +72,16 @@ public class CheckInstallReferrer {
     }
 
     // Determine if Keyman installed from Google Play store
-    PackageManager packageManager = context.getPackageManager();
     String installerInfo = null;
     try {
+      PackageManager packageManager = context.getPackageManager();
       String packageName = context.getPackageName();
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         installerInfo = packageManager.getInstallSourceInfo(packageName).getInstallingPackageName();
       } else {
         installerInfo = packageManager.getInstallerPackageName(packageName);
       }
-    } catch (PackageManager.NameNotFoundException e) {
+    } catch (PackageManager.NameNotFoundException|IllegalArgumentException e) {
       KMLog.LogException(TAG, "Error determining packageManager", e);
       return;
     }


### PR DESCRIPTION
Addresses a significant proportion of the Sentry errors [onInstallReferrerSetupFinished:FEATURE_NOT_SUPPORTED](https://sentry.io/organizations/keyman/issues/2700298447/?project=5983520&query=is%3Aunresolved+FEATURE_NOT_SUPPORTED&referrer=issue-stream&statsPeriod=90d)

#5230 added the feature to automatically install keyboard through Google Play Store. The API is only supported when Keyman is installed directly from the Google Play Store.

This updates CheckInstallReferrer to return before the Install Referrer API is called when Keyman is installed via:
* side loaded install (which includes nearly all local and test builds)
* package manager other than Google Play Store ("com.android.vending")

Unfortunately, we can't really do user-testing until the app is available on the pre-release Play Store...

@keymanapp-test-bot skip
