### PR TITLE
feat(common/models): directional quote insensitivity

### DIFF
--- a/developer/src/kmlmc/source/lexical-model-compiler/model-defaults.ts
+++ b/developer/src/kmlmc/source/lexical-model-compiler/model-defaults.ts
@@ -23,7 +23,13 @@ export function defaultSearchTermToKey(wordform: string): string {
   return wordform
       .normalize('NFKD')
       // Remove any combining diacritics (if input is in NFKD)
-      .replace(/[\u0300-\u036F]/g, '');
+      .replace(/[\u0300-\u036F]/g, '')
+      // Replace directional quotation marks with plain apostrophes
+      .replace(/‘/, "'")
+      .replace(/’/, "'")
+      // Also double-quote marks.
+      .replace(/“/, '"')
+      .replace(/”/, '"');
 }
 
 /**
@@ -57,7 +63,13 @@ export function defaultCasedSearchTermToKey(wordform: string, applyCasing: Casin
         .replace(/[\u0300-\u036F]/g, '')
       ) // end of `Array.from`
       .map(function(c) { return applyCasing('lower', c)})
-      .join('');
+      .join('')
+      // Replace directional quotation marks with plain apostrophes
+      .replace(/‘/, "'")
+      .replace(/’/, "'")
+      // Also double-quote marks.
+      .replace(/“/, '"')
+      .replace(/”/, '"');
 }
 
 /**

--- a/developer/src/kmlmc/tests/test-model-definitions.ts
+++ b/developer/src/kmlmc/tests/test-model-definitions.ts
@@ -38,7 +38,9 @@ describe('Model definition pseudoclosures', function () {
                                          // to make the distinction.  Both 'Σ's have the same char-code.
 
         // Uncased syntax and numbers should pass through unscathed:
-        ['1234.?!', '1234.?!', '1234.?!']
+        ['1234.?!', '1234.?!', '1234.?!'],
+        ['”', '”', '"'],
+        ["‘", "‘", "'"]
       ];
 
       for (let [input, cased, keyed] of testCases) {
@@ -81,7 +83,10 @@ describe('Model definition pseudoclosures', function () {
                                // to make the distinction.  Both 'Σ's have the same char-code.
 
         // Uncased syntax and numbers should pass through unscathed:
-        ['1234.?!', '1234.?!']
+        ['1234.?!', '1234.?!'],
+
+        ['”', '"'],
+        ["‘", "'"]
       ];
 
       for (let [input, keyed] of testCases) {


### PR DESCRIPTION
Fixes the following issue listed under https://github.com/keymanapp/lexical-models/issues/143#issuecomment-1096934795:

> If the lexical model uses U+0027 "apostrophe", what will happen when this model is used with a keyboard that changes apostrophe (U+0027) to "right single quotation mark" (U+2019) [?]

Note:  this is implemented within the lexical model compiler.  Models will only receive a fix when they are recompiled using an up-to-date version after this is merged.

@keymanapp-test-bot skip