### PR TITLE
fix(ios): make text size of in-app editor consistent with slider

### DIFF
--- a/ios/keyman/Keyman/Keyman/AppDelegate.swift
+++ b/ios/keyman/Keyman/Keyman/AppDelegate.swift
@@ -152,11 +152,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func applicationDidEnterBackground(_ application: UIApplication) {
     _overlayWindow = nil
     FontManager.shared.unregisterCustomFonts()
-    let userData = AppDelegate.activeUserDefaults()
-    // TODO: Have viewController save its data
-    userData.set(viewController?.textView?.text, forKey: userTextKey)
-    userData.set(viewController?.textSize.description, forKey: userTextSizeKey)
-    userData.synchronize()
+    
+    viewController?.saveTextSettings()
   }
 
   func applicationWillEnterForeground(_ application: UIApplication) {


### PR DESCRIPTION
Fixes #7185 

Modified the way that the text size setting is initialized during the creation of Keyman's in-app editor view so that it is always in sync with the user's saved value and the text size slider.

# User Testing

* **TEST_IPHONE_IN_APP_EDITOR:**

1. Run Keyman on an iPhone or simulator with no user data saved so that no previous text or installed keyboards appear in the app
2. Type some text in the in-app editor
3. The text should appear in a 16 point font, but it may be difficult to see if it is the correct size
4. Go to the three dots menu and choose Text Size, confirm that it is set to 16
5. While carefully watching the text you typed to make sure that it does not change size, tap on the slider control without moving it
* **TEST_IPAD_IN_APP_EDITOR:**

1. Run Keyman on an iPad or simulator with no user data saved so that no previous text or installed keyboards appear in the app
2. Type some text in the in-app editor
3. The text should appear in a 32 point font, but it may be difficult to see if it is the correct size
4. Go to the three dots menu and choose Text Size, confirm that it is set to 32
5. While carefully watching the text you typed to make sure that it does not change size, tap on the slider control without moving it

* **TEST_IPHONE_SAVE_TEXT_SIZE**

1. Run Keyman on an iPhone or simulator and type some text in the in-app editor
2. Go to the three dots menu and choose Text Size
3. Drag the slider to change the text to a different size
4. Close the app by switching to the home screen or another app
5. Use the task switcher to kill Keyman
6. Tap on Keyman to open it again
7. Verify that the text size setting in the Keyman editor is set to the same value as before you closed the app

