### PR TITLE
fix(linux): Revert "fix(linux): Fix a warning"

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -221,7 +221,7 @@ static gchar *get_current_context_text(km_kbp_context *context)
                             &buf_size);
     }
     km_kbp_context_items_dispose(context_items);
-    g_message("%s: current context is:%u:%u:%s:", __FUNCTION__, km_kbp_context_length(context), buf_size, current_context_utf8);
+    g_message("%s: current context is:%lu:%lu:%s:", __FUNCTION__, km_kbp_context_length(context), buf_size, current_context_utf8);
     return current_context_utf8;
 }
 

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -221,7 +221,7 @@ static gchar *get_current_context_text(km_kbp_context *context)
                             &buf_size);
     }
     km_kbp_context_items_dispose(context_items);
-    g_message("%s: current context is:%lu:%lu:%s:", __FUNCTION__, km_kbp_context_length(context), buf_size, current_context_utf8);
+    g_message("%s: current context is:%zu:%zu:%s:", __FUNCTION__, km_kbp_context_length(context), buf_size, current_context_utf8);
     return current_context_utf8;
 }
 


### PR DESCRIPTION
This reverts commit acab920de86a3fec1771bfd030bc13536c300000 (#7746).

I'm confused - now we're getting the same warning again - claiming that `size_t` is defined as `long unsigned int` and so we have to use `%lu`!? Is this related to the platform we're compiling on? This time, the warning we get is when compiling for x86_64:

```
engine.c: In function ‘get_current_context_text’:
engine.c:224:15: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  224 |     g_message("%s: current context is:%u:%lu:%s:", __FUNCTION__, km_kbp_context_length(context), buf_size, current_context_utf8);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                  |
      |                                                                  size_t {aka long unsigned int}
engine.c:224:40: note: format string is defined here
  224 |     g_message("%s: current context is:%u:%lu:%s:", __FUNCTION__, km_kbp_context_length(context), buf_size, current_context_utf8);
      |                                       ~^
      |                                        |
      |                                        unsigned int
      |                                       %lu

```

Reverting the previous fix for now.

@keymanapp-test-bot skip