### PR TITLE
fix(android/engine): Add null check on kmp filename

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/cloud/CloudDataJsonUtil.java
@@ -153,9 +153,11 @@ public class CloudDataJsonUtil {
             for (int i = 0; i < KeyboardController.getInstance().get().size(); i++) {
               Keyboard kbd = KeyboardController.getInstance().getKeyboardInfo(i);
               String version = kbd.getVersion();
+              String updateKMP = kbd.getUpdateKMP();
               if (keyboardID.equalsIgnoreCase(kbd.getKeyboardID()) &&
-                  (FileUtils.compareVersions(cloudVersion, version) == FileUtils.VERSION_GREATER) &&
-                  (!kbd.getUpdateKMP().equalsIgnoreCase(cloudKMP))) {
+                  FileUtils.compareVersions(cloudVersion, version) == FileUtils.VERSION_GREATER &&
+                  updateKMP != null &&
+                  updateKMP.equalsIgnoreCase(cloudKMP)) {
                 // Update keyboard with the latest KMP link
                 kbd.setUpdateKMP(cloudKMP);
                 KeyboardController.getInstance().add(kbd);


### PR DESCRIPTION
These lines were originally in #7781, but since I still have to investigate a few things on that PR, I'm splitting this to a separate one.

Fixes null pointer exception in `CloudDataJsonUtil` when the update KMP filename is null.


Sentry issue: [KEYMAN-ANDROID-20Y](https://sentry.io/organizations/keyman/issues/3659638286/?referrer=github_integration)

@keymanapp-test-bot skip
