### PR TITLE
fix(android/engine): Check if kmp.json is null

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/packages/PackageProcessor.java
@@ -420,6 +420,10 @@ public class PackageProcessor {
    * @return String of the package target ("keyboards", "lexicalModels", or "invalid")
    */
   public String getPackageTarget(JSONObject json) {
+    if (json == null) {
+      KMLog.LogError(TAG, "kmp.json is null");
+      return PP_TARGET_INVALID;
+    }
     try {
       if (json.has(PP_KEYBOARDS_KEY) && !json.has(PP_LEXICAL_MODELS_KEY)) {
         return PP_TARGET_KEYBOARDS;


### PR DESCRIPTION
This fixes PackageProcessor.getPackageTarget from throwing exceptions if kmp.json is null.

I'm still tracing the Sentry logs upstream for why the extracted kmp file would have null kmp.json. (maybe IOException if no space left on device?)


Fixes https://sentry.io/organizations/keyman/issues/2706237233/?project=5983520
