### PR TITLE
chore(common): Update whatsnew for 16.0

### DIFF
--- a/android/help/about/whatsnew.md
+++ b/android/help/about/whatsnew.md
@@ -4,4 +4,5 @@ title: What's New
 Here are some of the new features we have added to Keyman 16.0 for Android:
 
 * Dismiss long-press keys on multi-touch (#7388, #7472)
+* Don't show "Get Started" after setting Keyman as default system keyboard (#7587)
 * Add localization for Dutch

--- a/android/help/about/whatsnew.md
+++ b/android/help/about/whatsnew.md
@@ -1,7 +1,7 @@
 ---
 title: What's New
 ---
-Here are some of the new features we have added to Keyman 16.0 for Android:
+Here are some of the new features and major bug fixes we have added to Keyman 16.0 for Android:
 
 * Dismiss long-press keys on multi-touch (#7388, #7472)
 * Don't show "Get Started" after setting Keyman as default system keyboard (#7587)

--- a/ios/help/about/whatsnew.md
+++ b/ios/help/about/whatsnew.md
@@ -2,6 +2,6 @@
 title: What's New
 ---
 
-Here are some of the new features we have added to Keyman for iPhone and iPad 16.0:
+Here are some of the new features and major bug fixes we have added to Keyman for iPhone and iPad 16.0:
 
 * Recognize iPad as tablet device (#7563)

--- a/ios/help/about/whatsnew.md
+++ b/ios/help/about/whatsnew.md
@@ -4,9 +4,4 @@ title: What's New
 
 Here are some of the new features we have added to Keyman for iPhone and iPad 16.0:
 
-* Verify Keyman supports a keyboard package before installing
-* Fix positioning and style of popup keys
-* Update minimum iOS version to 12.1
-
-[![](../ios_images/video.png) Watch a video](https://youtu.be/Tm-7Rvs-6Ig)
-that highlights some of these new features.
+* Recognize iPad as tablet device (#7563)

--- a/linux/help/about/whatsnew.md
+++ b/linux/help/about/whatsnew.md
@@ -12,4 +12,6 @@ Here are some of the new features and major bug fixes we have added to Keyman fo
       packages.sil.org and https://launchpad.net/~keymanapp/+archive/ubuntu/keyman
       repos contain the updated ibus versions.
 * Now supports Ubuntu 22.10 (Kinetic) (#6975)
+* System tray will now show icon defined in keyboard instead of generic Keyman icon (#7678)
+* Keyman 16 will be the last release that supports Ubuntu 18.04 Bionic.
 * Fix uninstallation when using fcitx5 (#6963)

--- a/linux/help/about/whatsnew.md
+++ b/linux/help/about/whatsnew.md
@@ -2,13 +2,13 @@
 title: What's New
 ---
 
-Here are some of the new features we have added to Keyman for Linux 16.0:
+Here are some of the new features and major bug fixes we have added to Keyman for Linux 16.0:
 
 * Improve setting context (#7084)
 * Improved reordering and backspace behavior in Chrome(ium) and other apps that
   don't support surrounding text (#7079)
     * Note, this currently requires an update to ibus to be installed, pending
-      upstream merge and distribution of ibus patches #2440 and 781119be. The 
+      upstream merge and distribution of ibus patches #2440 and 781119be. The
       packages.sil.org and https://launchpad.net/~keymanapp/+archive/ubuntu/keyman
       repos contain the updated ibus versions.
 * Now supports Ubuntu 22.10 (Kinetic) (#6975)

--- a/mac/help/about/whatsnew.md
+++ b/mac/help/about/whatsnew.md
@@ -6,3 +6,4 @@ Here are some of the new features and major bug fixes we have added to Keyman 16
 
 * Improved management of security configuration (#7354)
 * Update Keyman system menu icon to transparent background (#7610)
+* Minimum supported version of macOS is 10.10 Yosemite.

--- a/mac/help/about/whatsnew.md
+++ b/mac/help/about/whatsnew.md
@@ -4,7 +4,5 @@ title: What's New
 
 Here are some of the new features we have added to Keyman 16.0 for macOS:
 
-* Localizable UI through [translate.keyman.com](https://translate.keyman.com)
-* Display Unicode page name correctly instead of '????'
-* Increase OSK character size by 50%
-* Add support for M1 processor
+* Improved management of security configuration (#7354)
+* Update Keyman system menu icon to transparent background (#7610)

--- a/mac/help/about/whatsnew.md
+++ b/mac/help/about/whatsnew.md
@@ -2,7 +2,7 @@
 title: What's New
 ---
 
-Here are some of the new features we have added to Keyman 16.0 for macOS:
+Here are some of the new features and major bug fixes we have added to Keyman 16.0 for macOS:
 
 * Improved management of security configuration (#7354)
 * Update Keyman system menu icon to transparent background (#7610)

--- a/windows/src/desktop/help/about/whatsnew.md
+++ b/windows/src/desktop/help/about/whatsnew.md
@@ -4,8 +4,9 @@ title: What's New
 
 Here are some of the new features we have added to Keyman 16.0 for Windows:
 
--   Now uses Keyman Core internally which removes legacy code and improves stability of Keyman (\#5443)
--   Improved compatibility with speech recognition (\#5000)
+-   Revamp Configuration UI (\#7206)
+-   Fix keystrokes writing to wrong queue (\#7650)
+-   Change "None" to "No Hotkey" matching new configuration (\#7539)
 
 
 ## Related Topics

--- a/windows/src/desktop/help/about/whatsnew.md
+++ b/windows/src/desktop/help/about/whatsnew.md
@@ -5,8 +5,6 @@ title: What's New
 Here are some of the new features and major bug fixes we have added to Keyman 16.0 for Windows:
 
 -   Revamp Configuration UI (\#7206)
--   Fix keystrokes writing to wrong queue (\#7650)
--   Change "None" to "No Hotkey" matching new configuration (\#7539)
 
 
 ## Related Topics

--- a/windows/src/desktop/help/about/whatsnew.md
+++ b/windows/src/desktop/help/about/whatsnew.md
@@ -2,7 +2,7 @@
 title: What's New
 ---
 
-Here are some of the new features we have added to Keyman 16.0 for Windows:
+Here are some of the new features and major bug fixes we have added to Keyman 16.0 for Windows:
 
 -   Revamp Configuration UI (\#7206)
 -   Fix keystrokes writing to wrong queue (\#7650)


### PR DESCRIPTION
Follow-on to #7558 

This adds some more detail to the whatsnew pages. (And removes 15.0 content for some products)

@keymanapp-test-bot skip
