### PR TITLE
docs(ios): Update help documentation about Install and Allow Full Access

### DIFF
--- a/ios/help/start/installing-system-keyboard.md
+++ b/ios/help/start/installing-system-keyboard.md
@@ -33,6 +33,7 @@ the default iOS keyboard layout by touching the globe key of the keyboard whenev
 ![](../ios_images/globe.png)
 
 ### On "Allow Full Access"
-For normal use of Keyman, there is no need to keep "Allow Full Access" enabled. It is needed only for making changes to some keyboard preferences.
+An issue with iOS 16 causes the Keyman system keyboard to not display unless "Allow Full Access" is enabled. Until the issue is addressed, this setting must be left in the on position for Keyman to operate normally.
 
-However, an issue with iOS 16 causes the Keyman system keyboard to not display unless "Allow Full Access" is enabled. Until the issue is addressed, this setting must be left in the on position for Keyman to operate normally.
+For normal use of Keyman with versions prior to iOS 16.0, there is no need to keep "Allow Full Access" enabled. It is needed only for making changes to some keyboard preferences.
+

--- a/ios/help/start/installing-system-keyboard.md
+++ b/ios/help/start/installing-system-keyboard.md
@@ -33,9 +33,6 @@ the default iOS keyboard layout by touching the globe key of the keyboard whenev
 ![](../ios_images/globe.png)
 
 ### On "Allow Full Access"
-After opening the Keyman system keyboard for the first time in an app, you can turn off the "Allow Full Access" option
-again.
+For normal use of Keyman, there is no need to keep "Allow Full Access" enabled. It is needed only for making changes to some keyboard preferences.
 
-You may need to temporarily switch this on again in the future for app updates and for some changes to keyboard preferences.
-
-It may always be safely deactivated immediately after opening the system keyboard again in an app.
+However, an issue with iOS 16 causes the Keyman system keyboard to not display unless "Allow Full Access" is enabled. Until the issue is addressed, this setting must be left in the on position for Keyman to operate normally.


### PR DESCRIPTION
Fixes #7763

Update [help page](https://help.keyman.com/products/iphone-and-ipad/current-version/start/installing-system-keyboard) text due to iOS 16 issue. Advise users to keep Allow Full Access enabled for normal Keyman operation.

@keymanapp-test-bot skip