### PR TITLE
fix(linux): Allow to build without patched ibus version

### DIFF
--- a/linux/ibus-keyman/configure.ac
+++ b/linux/ibus-keyman/configure.ac
@@ -93,6 +93,16 @@ AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Define to the read-only 
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION(0.19.7)
 
+# check if it's a patched ibus
+SAV_CFLAGS="$CFLAGS"
+CFLAGS="$IBUS_CFLAGS $CFLAGS"
+AC_CHECK_DECLS([IBUS_PREFILTER_MASK, IBUS_CAP_PREFILTER],
+    [AC_DEFINE(IBUS_HAS_PREFILTER, 1, [Does ibus support the prefilter flag])],
+    [],
+    [[#include <ibus.h>]]
+)
+CFLAGS="$SAV_CFLAGS"
+
 
 # OUTPUT files
 AC_CONFIG_FILES([ po/Makefile.in

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -40,10 +40,17 @@
 #include <keyman/keyboardprocessor.h>
 #include <keyman/keyboardprocessor_consts.h>
 
+#include "config.h"
 #include "keymanutil.h"
 #include "keyman-service.h"
 #include "engine.h"
 #include "keycodes.h"
+
+// Fallback for older ibus versions that don't define IBUS_PREFILTER_MASK
+#ifndef IBUS_HAS_PREFILTER
+#warning Updated ibus version is not installed. Ordered output will not be available.
+#define IBUS_PREFILTER_MASK (1 << 23)
+#endif
 
 #define MAXCONTEXT_ITEMS 128
 #define KEYMAN_BACKSPACE 14
@@ -229,7 +236,11 @@ static gboolean
 client_supports_prefilter(IBusEngine *engine)
 {
   g_assert(engine != NULL);
+#ifdef IBUS_HAS_PREFILTER
   return (engine->client_capabilities & IBUS_CAP_PREFILTER) != 0;
+#else
+  return FALSE;
+#endif
 }
 
 static gboolean

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -48,7 +48,7 @@
 
 // Fallback for older ibus versions that don't define IBUS_PREFILTER_MASK
 #ifndef IBUS_HAS_PREFILTER
-#warning Updated ibus version is not installed. Ordered output will not be available.
+#warning Compiling against ibus version that does not include prefilter mask patch (https://github.com/ibus/ibus/pull/2440). Output ordering guarantees will be disabled.
 #define IBUS_PREFILTER_MASK (1 << 23)
 #endif
 


### PR DESCRIPTION
This change makes it possible to compile even when the updated ibus version is not installed. Of course ordered output won't work in that case, but at least it will compile and the rest of Keyman will work.

Fixes #7774.

@keymanapp-test-bot skip