### PR TITLE
fix: test builds should always run latest changes

### DIFF
--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -60,7 +60,7 @@ function triggerTestBuilds() {
         triggerJenkinsBuild "$job" "$branch" "$force"
       else
         echo "  -- Triggering build configuration $test_build on teamcity"
-        triggerTeamCityBuild "$test_build" "$vcs_test" "$branch"
+        triggerTeamCityBuild true "$test_build" "$vcs_test" "$branch"
       fi
     done
   done

--- a/resources/build/trigger-builds.inc.sh
+++ b/resources/build/trigger-builds.inc.sh
@@ -22,19 +22,20 @@ function triggerBuilds() {
         echo Triggering Jenkins build "$job" "$base" "true"
         triggerJenkinsBuild "$job" "$base" "true"
       else
-        echo Triggering TeamCity build $build $TEAMCITY_VCS_ID $base
-        triggerTeamCityBuild $build $TEAMCITY_VCS_ID $base
+        echo Triggering TeamCity build false $build $TEAMCITY_VCS_ID $base
+        triggerTeamCityBuild false $build $TEAMCITY_VCS_ID $base
       fi
     done
   done
 }
 
 function triggerTeamCityBuild() {
-  local TEAMCITY_BUILDTYPE="$1"
-  local TEAMCITY_VCS_ID="$2"
+  local isTestBuild="$1"
+  local TEAMCITY_BUILDTYPE="$2"
+  local TEAMCITY_VCS_ID="$3"
 
-  if [[ $# -gt 2 ]]; then
-    local TEAMCITY_BRANCH_NAME="$3"
+  if [[ $# -gt 3 ]]; then
+    local TEAMCITY_BRANCH_NAME="$4"
     #debug echo "  Triggering build for: $TEAMCITY_BRANCH_NAME"
     TEAMCITY_BRANCH_NAME="branchName='$TEAMCITY_BRANCH_NAME' defaultBranch='false'"
   else
@@ -44,7 +45,13 @@ function triggerTeamCityBuild() {
   local GIT_OID=`git rev-parse HEAD`
   local TEAMCITY_SERVER=https://build.palaso.org
 
-  local command="<build $TEAMCITY_BRANCH_NAME><buildType id='$TEAMCITY_BUILDTYPE' /><lastChanges><change vcsRootInstance='$TEAMCITY_VCS_ID' locator='version:$GIT_OID'/></lastChanges></build>"
+  local command
+
+  if $isTestBuild; then
+    command="<build $TEAMCITY_BRANCH_NAME><buildType id='$TEAMCITY_BUILDTYPE' /></build>"
+  else
+    command="<build $TEAMCITY_BRANCH_NAME><buildType id='$TEAMCITY_BUILDTYPE' /><lastChanges><change vcsRootInstance='$TEAMCITY_VCS_ID' locator='version:$GIT_OID'/></lastChanges></build>"
+  fi
   echo "TeamCity Build Command: $command"
 
   # adjust indentation for output of curl


### PR DESCRIPTION
While release builds need to build a specific commit hash, test builds should always build the HEAD of the branch. This stops multiple merges and/or pushes generating multiple test builds in the queue.

@keymanapp-test-bot skip