### PR TITLE
docs(android/app): Add note of haptic feedback to whatsnew

### DIFF
--- a/android/help/about/whatsnew.md
+++ b/android/help/about/whatsnew.md
@@ -5,4 +5,5 @@ Here are some of the new features and major bug fixes we have added to Keyman 16
 
 * Dismiss long-press keys on multi-touch (#7388, #7472)
 * Don't show "Get Started" after setting Keyman as default system keyboard (#7587)
+* Add option for haptic feedback (#6626)
 * Add localization for Dutch


### PR DESCRIPTION
While updating a 16.0 retrospective for upcoming planning meetings, I noticed we actually do have release note for a 16.0 Keyman for Android feature.

@keymanapp-test-bot skip
