### PR TITLE
fix(developer): EncodeURL was not handling spaces

### DIFF
--- a/common/windows/delphi/web/Keyman.System.HttpServer.Base.pas
+++ b/common/windows/delphi/web/Keyman.System.HttpServer.Base.pas
@@ -23,7 +23,7 @@ type
       AResponseInfo: TIdHTTPResponseInfo);
   end;
 
-function CrackUTF8ZeroExtendedString(const p: string): string;
+function CrackUTF8ZeroExtendedString(CommandType: THTTPCommandType; const p: string): string;
 
 implementation
 
@@ -32,11 +32,17 @@ uses
 
   System.SysUtils;
 
-function CrackUTF8ZeroExtendedString(const p: string): string;
+function CrackUTF8ZeroExtendedString(CommandType: THTTPCommandType; const p: string): string;
 var
   s: RawByteString;
   i: Integer;
 begin
+  if CommandType = hcPOST then
+  begin
+    // POSTed data is decoded correctly
+    Exit(p);
+  end;
+
   // Indy's UTF8 handling of URLs is *completely* broken.
   // We may need to check this with updated versions of Delphi
 {$IFNDEF VER330}

--- a/developer/src/tike/http/Keyman.Developer.System.HttpServer.App.pas
+++ b/developer/src/tike/http/Keyman.Developer.System.HttpServer.App.pas
@@ -102,7 +102,7 @@ procedure TAppHttpResponder.RespondProject(doc: string; AContext: TIdContext;
       Exit;
     end;
 
-    path := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['path']);
+    path := CrackUTF8ZeroExtendedString(ARequestInfo.CommandType, ARequestInfo.Params.Values['path']);
 
     if (Path <> '') and (not FileExists(path) or not SameText(ExtractFileExt(path), Ext_ProjectSource)) then
     begin
@@ -132,7 +132,7 @@ procedure TAppHttpResponder.RespondProject(doc: string; AContext: TIdContext;
       Exit;
     end;
 
-    path := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['path']);
+    path := CrackUTF8ZeroExtendedString(ARequestInfo.CommandType, ARequestInfo.Params.Values['path']);
 
     if not FileExists(path) or (
       not SameText(ExtractFileExt(path), '.ico') and

--- a/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
+++ b/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
@@ -100,7 +100,7 @@ begin
   if ARequestInfo.Document = '/app/source/file' then
   begin
     // TODO: We should be passing a token to the browser for future POST security
-    Filename := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['Filename']);
+    Filename := CrackUTF8ZeroExtendedString(ARequestInfo.CommandType, ARequestInfo.Params.Values['Filename']);
 
     if ARequestInfo.CommandType = hcGET then
     begin
@@ -116,12 +116,12 @@ begin
   else if ARequestInfo.Document = '/app/source/toucheditor' then
   begin
     // Respond files?
-    Filename := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['Filename']);
+    Filename := CrackUTF8ZeroExtendedString(ARequestInfo.CommandType, ARequestInfo.Params.Values['Filename']);
     RespondTouchEditor(Filename, AContext, ARequestInfo, AResponseInfo);
   end
   else if ARequestInfo.Document = '/app/source/toucheditor/state' then
   begin
-    Filename := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['Filename']);
+    Filename := CrackUTF8ZeroExtendedString(ARequestInfo.CommandType, ARequestInfo.Params.Values['Filename']);
     RespondTouchEditorState(Filename, AContext, ARequestInfo, AResponseInfo);
   end
   else if ARequestInfo.Document.StartsWith('/app/source/toucheditor/lib/') then
@@ -151,7 +151,8 @@ begin
   end
   else if ARequestInfo.CommandType = hcPOST then
   begin
-    FData := CrackUTF8ZeroExtendedString(ARequestInfo.Params.Values['State']);
+    // Posted data is already decoded correctly
+    FData := ARequestInfo.Params.Values['State'];
     RegisterSource(AFilename + '#state', FData, True);
   end;
 end;


### PR DESCRIPTION
Fixes #7810.

This addresses a regression introduced in #7631, where URL parameters with spaces would be encoded into `+` instead of `%20`. Looking a bit deeper at the Delphi `TNetEncoding.URL.Encode` function I realised that it was entirely inadequate. Some guy named Marc Durdin wrote a [blog](https://marc.durdin.net/2015/08/an-update-for-encodeuricomponent/) a good few years ago about the problem, and that's what I ended up using to fix this.

This encoding issue caused filenames with spaces (by default, project paths in Developer have spaces) to give a 404 when editing a touch layout, which meant that the touch keyboards could not be saved.

Also fixes [KEYMAN-DEVELOPER-74](https://sentry.io/organizations/keyman/issues/3081965404/?project=5983519), where the `+` encoding caused multiple entries to appear in the filename cache.

Amusing to Google this problem, find solid answer on SO, which pointed to my very own blog. Embarrassing that my own code didn't already include my own fix.

A secondary issue is also fixed here, where request parameters were double-decoded for formencoded POST requests. The fix for broken URL encodings was only required for GET requests.

This also showed up in KEYMAN-DEVELOPER-74, with double-encoded paths being registered as source files.

# User Testing

We need to verify that files are being loaded and saved correctly in the keyboard editor, keyboard project, and touch editor.

* **TEST_PATHS_WITH_SPACES:** Create a folder that contains spaces and English letters. Create a new keyboard project within that folder. In the Project view, press F12 to verify that no errors are raised in the Developer console. Do a basic regression test on working with the keyboard project, including editing, in particular the touch layout. Ensure that you make a change to the touch layout, save, compile and test it -- and make sure the change appears in the tested code.

* **TEST_NON_ASCII_PATHS:** Create a folder that contains non-ASCII letters, e.g. Khmer, Tamil or European diacritics. Create a new keyboard project within that folder. In the Project view, press F12 to verify that no errors are raised in the Developer console. Do a basic regression test on working with the keyboard project, including editing, in particular the touch layout. Note that keyboard compile may fail due to #7688; please don't fail this test on this basis.