### PR TITLE
fix(developer): remove missing files from MRU list

### DIFF
--- a/developer/src/tike/main/mrulist.pas
+++ b/developer/src/tike/main/mrulist.pas
@@ -69,6 +69,9 @@ procedure TMRUList.Add(FileName: WideString);
 var
   n: Integer;
 begin
+  if not FileExists(FileName) then
+    Exit;
+
   n := FMRU.IndexOf(FileName);
 
   if n = 0 then Exit;
@@ -84,6 +87,9 @@ procedure TMRUList.Append(FileName: WideString);
 var
   n: Integer;
 begin
+  if not FileExists(FileName) then
+    Exit;
+
   n := FMRU.IndexOf(FileName);
   if n >= 0 then
   begin
@@ -123,7 +129,10 @@ begin
             GetValueNames(s);
             s.Sort;
             for i := 0 to s.Count - 1 do
-              FMRU.Add(ReadString(s[i]))
+            begin
+              if FileExists(s[i]) then
+                FMRU.Add(ReadString(s[i]))
+            end;
           finally
             s.Free;
           end;


### PR DESCRIPTION
Fixes #7808.

If a project is moved, then the MRU, which has absolute path names, will probably have references to files that don't exist. Rather than leave these in the list, to be opened and potentially recreated in the wrong place, we should just remove them entirely from the list.

@keymanapp-test-bot skip