### PR TITLE
fix(windows): Cleanup CEF more correctly in shutdown 🍒

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmWebContainer.pas
+++ b/windows/src/desktop/kmshell/main/UfrmWebContainer.pas
@@ -55,12 +55,18 @@ type
   TfrmWebContainer = class(TfrmKeymanBase)
     procedure TntFormCreate(Sender: TObject);
   private
+    class var WebContainerDepth: Integer;
+  private
     FDialogName: WideString;
+    FCanClose: Boolean;
+    FIsClosing: Boolean;
     procedure WMUser_FormShown(var Message: TMessage); message WM_USER_FormShown;
     procedure WMUser_ContentRender(var Message: TMessage); message WM_USER_ContentRender;
     procedure WMSysCommand(var Message: TWMSysCommand); message WM_SYSCOMMAND;
 
     procedure ContributeUILanguages;
+    procedure CEFShutdownComplete(Sender: TObject);
+    function IsTopLevel: Boolean;
   protected
     cef: TframeCEFHost;
     FRenderPage: string;
@@ -88,6 +94,8 @@ type
     procedure DoOpenHelp;
   public
     constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+    function CloseQuery: Boolean; override;
     procedure SetFocus; override;  // I2720
     property DialogName: WideString read FDialogName;
 
@@ -109,6 +117,7 @@ uses
   custinterfaces,
   ErrorControlledRegistry,
   Keyman.Configuration.System.UmodWebHttpServer,
+  Keyman.System.CEFManager,
   Keyman.System.KeymanSentryClient,
   kmint,
   UILanguages,
@@ -154,6 +163,7 @@ end;
 
 constructor TfrmWebContainer.Create(AOwner: TComponent);
 begin
+  Inc(WebContainerDepth);
   inherited Create(AOwner);
 end;
 
@@ -165,10 +175,44 @@ begin
   else ShowMessage(command + '?' + params.Text);
 end;
 
+function TfrmWebContainer.IsTopLevel: Boolean;
+begin
+  Result := WebContainerDepth = 1;
+end;
+
+function TfrmWebContainer.CloseQuery: Boolean;
+begin
+  Result := inherited;
+  if Result and IsTopLevel then
+  begin
+    if not FIsClosing then
+    begin
+      FIsClosing := True;
+      Result := FInitializeCEF.StartShutdown(CEFShutdownComplete);
+    end
+    else
+      Result := FCanClose;
+  end;
+end;
+
+procedure TfrmWebContainer.CEFShutdownComplete(Sender: TObject);
+begin
+//  OutputDebugString(PChar('TfrmKeymanDeveloper.CEFShutdownComplete'));
+  FCanClose := True;
+  Close;
+end;
+
+
 /// <summary>Returns true if url is from the local render server</summary>
 function TfrmWebContainer.IsLocalUrl(const url: string): Boolean;
 begin
   Result := url.StartsWith(modWebHttpServer.Host, True);
+end;
+
+destructor TfrmWebContainer.Destroy;
+begin
+  Dec(WebContainerDepth);
+  inherited Destroy;
 end;
 
 procedure TfrmWebContainer.DoOpenHelp;


### PR DESCRIPTION
Cherry-pick of #7661. Fixes #7824.

Hopefully fixes KEYMAN-WINDOWS-1MR, and probably many related crash reports.

This changes the form destruction sequence to make sure that it doesn't close the form until CEF has been shutdown correctly.

Will monitor this on beta before release and roll it back if other issues arise.

# User Testing

Please do a regression test on Keyman Configuration (just the user interface portions).

## SUITE_BASELINE: Keyman for Windows Base Line Tests

- **TEST_KEYBOARD_INSTALLATION_REMOTE**:
  - Start Keyman Configuration
  - Click Download Keyboard, select a keyboard from the download dialog and install it
  - If the package includes a readme file, verify that it appears in the install window.
  - If the package includes a welcome file, verify that it appears after installation.
  - Click OK to close Keyman Configuration
  - Start Notepad
  - Verify that the newly installed keyboard appears in the Keyman menu and can be selected

- **TEST_INSTALL_PKG_DISK**:
  - Install a package from disk ##
  - Locate a .kmp file on disk and double-click to install it
  - If the package includes a readme file, verify that it appears in the install window.
  - If the package includes a welcome file, verify that it appears after installation.
  - Start Notepad
  - Verify that the keyboard appears in the Keyman menu

## SUITE_CONFIGURATION: Testing of Keyman Configuration shutdown process

- **TEST_STRESS_CONFIGURATION**:
  - The purpose of this test is to stress test closing Keyman Configuration.
  - Open, and then close Keyman Configuration in as many ways as you can find.
  - For example Alt+F4, right-click Close on taskbar, etc.
  - Try opening and closing child dialogs such as 'Download Keyboard'
  - Open Keyman Configuration from the startup screen of Keyman, or from the Keyman icon, or from the Start Menu.
  - We are looking to see if we get any unexpected application behaviour or crashes.

- **TEST_CONFIGURATION_WINDOWS_SHUTDOWN**:
  - The purpose of this test is to verify that Keyman Configuration behaves correctly when restarting Windows.
  - Open Keyman Configuration, and leaving it open, restart Windows.
  - Try this a few times. Try also when you have a dialog such as 'Download Keyboard' open.
  - You may not see evidence of crash reports, but if any occur, we will see them in Sentry.