### PR TITLE
fix(developer): OnlineUpdate crash on shutdown

### DIFF
--- a/developer/src/tike/update/Keyman.Developer.UI.TikeOnlineUpdateCheck.pas
+++ b/developer/src/tike/update/Keyman.Developer.UI.TikeOnlineUpdateCheck.pas
@@ -67,6 +67,7 @@ type
     function DownloadUpdate(URL: string; var DownloadPath: string): Boolean;
     procedure DoDownloadUpdate(AOwner: TfrmDownloadProgress; var Result: Boolean);
     function DoRun: TOnlineUpdateCheckResult;
+    procedure SyncShowError;
     procedure SyncShowUpdateForm;
     procedure SyncShutDown;
   private
@@ -134,10 +135,10 @@ end;
 destructor TOnlineUpdateCheck.Destroy;
 begin
   if (FErrorMessage <> '') and not FSilent and FShowErrors then
-    ShowMessage(FErrorMessage);
+    Synchronize(SyncShowError);
 
   if FParams.Result = oucShutDown then
-    SyncShutDown;
+    Synchronize(SyncShutDown);
 
   KL.Log('TOnlineUpdateCheck.Destroy: FErrorMessage = '+FErrorMessage);
   KL.Log('TOnlineUpdateCheck.Destroy: FParams.Result = '+IntToStr(Ord(FParams.Result)));
@@ -289,6 +290,11 @@ begin
     if Assigned(Application.MainForm) then
       Application.MainForm.Close;
   end;
+end;
+
+procedure TOnlineUpdateCheck.SyncShowError;
+begin
+  ShowMessage(FErrorMessage);
 end;
 
 function TOnlineUpdateCheck.DoRun: TOnlineUpdateCheckResult;


### PR DESCRIPTION
Fixes #7829.

Fixes [KEYMAN-DEVELOPER-9J](https://sentry.io/organizations/keyman/issues/3251936542/?project=5983519&referrer=regression_activity-email).

The online update check could crash on shutdown because the thread destructor would run from the wrong thread. This caused the main form destruction, which happens if the user chooses to install the update, to be triggered from the worker thread, leading to much pain.

@keymanapp-test-bot skip