### PR TITLE
fix(android/app): Toggle keyboard update notifications for landscape and tablets

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -353,6 +353,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   @SuppressLint("RestrictedApi")
   @Override
   public boolean onPrepareOptionsMenu(final Menu menu) {
+    this.menu = menu;
     final MenuItem _overflowMenuItem = menu.findItem(R.id.action_overflow);
     if (_overflowMenuItem != null) {
       MenuItem updateKeyboards = this.menu.findItem(R.id.action_update_keyboards);
@@ -372,8 +373,8 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     }
 
     final MenuItem _keyboardupdate = menu.findItem(R.id.action_update_keyboards);
-    if (_keyboardupdate != null) {
-      updateUpdateCountIndicator(_keyboardupdate, anUpdateCount, true);
+    if (_keyboardupdate != null && anUpdateCount > 0) {
+      _keyboardupdate.setVisible(true);
     }
   }
 
@@ -452,6 +453,11 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
         KMManager.getUpdateTool().executeOpenUpdates();
         // Dismiss icon
         updateUpdateCountIndicator(0);
+        final MenuItem _keyboardupdate = menu.findItem(R.id.action_update_keyboards);
+        if (_keyboardupdate != null && _keyboardupdate.isVisible()) {
+          _keyboardupdate.setVisible(false);
+        }
+
         return true;
       default:
         return super.onOptionsItemSelected(item);

--- a/android/KMAPro/kMAPro/src/main/res/menu-land/main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu-land/main.xml
@@ -45,10 +45,12 @@
         android:title="@string/action_settings"
         android:icon="@drawable/ic_settings" />
 
-     <item
+    <!-- hidden until updates available -->
+    <item
       android:id="@+id/action_update_keyboards"
-      android:title="@string/action_install_updates"
       app:showAsAction="always"
-       app:actionLayout="@layout/update_count_view"/>
+      android:title="@string/action_install_updates"
+      android:visible="false"
+      android:icon="@drawable/ic_cloud_download" />
 
 </menu>

--- a/android/KMAPro/kMAPro/src/main/res/menu-sw600dp/main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu-sw600dp/main.xml
@@ -45,10 +45,12 @@
         android:title="@string/action_settings"
         android:icon="@drawable/ic_settings" />
 
+    <!-- hidden until updates available -->
     <item
-      android:id="@+id/action_update_keyboards"
-      android:title="@string/action_install_updates"
-      app:showAsAction="always"
-      app:actionLayout="@layout/update_count_view"/>
+        android:id="@+id/action_update_keyboards"
+        app:showAsAction="always"
+        android:title="@string/action_install_updates"
+        android:visible="false"
+        android:icon="@drawable/ic_cloud_download" />
 
 </menu>


### PR DESCRIPTION
Fixes #6731

Previously, the Keyman notification of keyboard updates could appear on 3 form factors:
* phone (portrait orientation) - notification on overflow menu
* phone (landscape orientation) - notification on menu
* tablet (> 600dp, either orientation) - notification on menu

The landscape and tablet layouts had a complexity of a dynamic layout "update_count_view" which turned out to be un-clickable.

This PR removes the usage of "update_count_view", and toggles the update icon when updates are available. (This removes the feature of a dynamic count of updates available). The minor loss in feature should be acceptable since long-term we plan to just automatically download keyboard/dictionary updates as they're available (#7171).

## User Testing
Setup - For each group, use the Android device and orientation as specified in the test.
1. On the device, download the old version [1.0 of sil_nko Keyman keyboard](https://downloads.keyman.com/keyboards/sil_nko/1.0/sil_nko.kmp)
2. Install the PR build of Keyman for Android

**GROUP_PHONE_PORTRAIT** - Verifies update installs for phone in portrait orientation
**GROUP_PHONE_LANDSCAPE** - Verifies update installs for phone in landscape orientation. Note - Keyman always starts up in portrait orientation, so you may need to re-orient the device back and forth to get Keyman in landscape orientation
**GROUP_TABLET_LANDSCAPE** - Verifies update installs for tablet (either orientation)

**TEST_KEYBOARD_UPDATE**
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. From the Keyman settings menu, install the version 1.0 of the sil_nko keyboard package (Install from local file).
3. During installation of sil_nko, choose "Mandingo" language
4. When sil_nko finishes installing, completely exit Keyman
5. Relaunch Keyman for Android
6. After a while, see if notifications appear about keyboard updates being available. If they don't appear, completely exit Keyman and try re-launching Keyman for Android.
7. When there's notifications about Keyman updates being available, click the appropriate menu to "Install Updates"
    * phone portrait - icon from the overflow menu
    * phone landscape - icon on the top menu next to "Settings"
    * tablet - icon on the top menu next to "Settings"
 8. Verify Keyman prompts confirmation to download a keyboard update for sil_nko
 9. Accept the dialog
 10. Verify after a while, the keyboard updates in the background.
 11. Long-press the globe key to display the keyboard picker menu.
 12. Verify the version of sil_nko is now 1.1.