### PR TITLE
fix(android/engine): Use FLAG_IMMUTABLE for PendingIntent for Android S+

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/logic/ResourcesUpdateTool.java
@@ -426,7 +426,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
     stackBuilder.addNextIntentWithParentStack(intent);
     // Get the PendingIntent containing the entire back stack
     PendingIntent startUpdateIntent =
-      stackBuilder.getPendingIntent(notification_id, PendingIntent.FLAG_UPDATE_CURRENT);
+      stackBuilder.getPendingIntent(notification_id, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
 
     Builder builder = new Builder(currentContext, getClass().getName())
       .setSmallIcon(R.drawable.ic_keyboard)


### PR DESCRIPTION
Fixes #7843 
Starting with Android S+ (API 31), we need to use `FLAG_IMMUTABLE` for the PendingIntent used to download package updates.

From the Sentry crash report
```
IllegalArgumentException: com.tavultesoft.kmapro.debug: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
    at android.app.PendingIntent.checkFlags(PendingIntent.java:375)
    at android.app.PendingIntent.getActivitiesAsUser(PendingIntent.java:593)
    at android.app.PendingIntent.getActivities(PendingIntent.java:575)
    at android.app.TaskStackBuilder.getPendingIntent(TaskStackBuilder.java:275)
    at android.app.TaskStackBuilder.getPendingIntent(TaskStackBuilder.java:249)
...
(19 additional frame(s) were not displayed)

RuntimeException: Error receiving broadcast Intent { act=android.intent.action.DOWNLOAD_COMPLETE flg=0x10 pkg=com.tavultesoft.kmapro.debug (has extras) } in com.tavultesoft.kmea.cloud.CloudDownloadMgr$1@562b474
    at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$0$LoadedApk$ReceiverDispatcher$Args(LoadedApk.java:1689)
    at android.app.LoadedApk$ReceiverDispatcher$Args$$ExternalSyntheticLambda0.run
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:201)
...
(5 additional frame(s) were not displayed)
```

## User Testing - Based on tests for #7832
Setup - For each group, use the Android device, orientation, and Android OS as specified in the group.
1. On the device, download the old version [1.0 of sil_nko Keyman keyboard](https://downloads.keyman.com/keyboards/sil_nko/1.0/sil_nko.kmp)
2. Install the PR build of Keyman for Android

**GROUP_PHONE_PORTRAIT_API_21** - Verifies update installs for phone in portrait orientation on Android 5.0 (API 21)
**GROUP_TABLET_API_31** - Verifies update installs for tablet (either orientation) on Android 12.0 (API 31)

**TEST_KEYBOARD_UPDATE**
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. From the Keyman settings menu, install the version 1.0 of the sil_nko keyboard package (Install from local file).
3. During installation of sil_nko, choose "Mandingo" language
4. When sil_nko finishes installing, completely exit Keyman
5. Relaunch Keyman for Android
6. After a while, see if notifications appear about keyboard updates being available. If they don't appear, completely exit 
7. When there's notifications about Keyman updates being available, click the appropriate menu to "Install Updates"
    * phone portrait - icon from the overflow menu
    * tablet - icon on the top menu next to "Settings"
8. Verify Keyman prompts confirmation to download a keyboard update for sil_nko
9. Accept the dialog
10. Verify after a while, the keyboard updates in the background.
11. Long-press the globe key to display the keyboard picker menu.
12. Verify the version of sil_nko is now 1.1.
