### PR TITLE
fix(windows): kmshell -ikl install language and enable keyboard

### DIFF
--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboardLanguage.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboardLanguage.pas
@@ -169,7 +169,7 @@ begin
     // The Keyboard was successully installed for the BCP47Code
     // for some reason the index look up has failed. Still pass through
     // the DoInstall reasult, however the keyboard will not be enabled.
-    TKeymanSentryClient.Client.MessageEvent(Sentry.Client.SENTRY_LEVEL_ERROR, 'KeyboardID: '+KeyboardID+' not found');
+    TKeymanSentryClient.Client.MessageEvent(Sentry.Client.SENTRY_LEVEL_ERROR, 'InstallKeyboardLanguage: KeyboardID "'+KeyboardID+'" not found, attempting to install for language "'+ISOCode+'".');
     Exit;
   end;
   kbd := kmcom.Keyboards[n];

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboardLanguage.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboardLanguage.pas
@@ -129,9 +129,11 @@ implementation
 uses
   System.Types,
   Vcl.Themes,
+  Sentry.Client,
 
   Keyman.Configuration.UI.MitigationForWin10_1803,
   Keyman.System.LanguageCodeUtils,
+  Keyman.System.KeymanSentryClient,
   Keyman.Configuration.System.TIPMaintenance,
   Keyman.UI.UfrmProgress,
   MessageIdentifierConsts,
@@ -165,13 +167,13 @@ begin
   if n < 0 then
   begin
     // The Keyboard was successully installed for the BCP47Code
-    // for some reason the index look up has failed. Still leave
-    // Result as true, the keyboard will not be enabled.
-    // TODO: Log error unexpected `KeyboardID` not found
+    // for some reason the index look up has failed. Still pass through
+    // the DoInstall reasult, however the keyboard will not be enabled.
+    TKeymanSentryClient.Client.MessageEvent(Sentry.Client.SENTRY_LEVEL_ERROR, 'KeyboardID: '+KeyboardID+' not found');
     Exit;
   end;
   kbd := kmcom.Keyboards[n];
-  kbd.Loaded := TRUE;
+  kbd.Loaded := True;
   kmcom.Apply;
   Result := True;
 end;

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboardLanguage.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboardLanguage.pas
@@ -147,6 +147,9 @@ uses
 { TfrmInstallKeyboardLanguage }
 
 function InstallKeyboardLanguage(Owner: TForm; const KeyboardID, ISOCode: string; Silent: Boolean): Boolean;
+var
+  n: Integer;
+  kbd: IKeymanKeyboardInstalled;
 begin
   Result := TTIPMaintenance.DoInstall(KeyboardID, ISOCode);
   if not Result then
@@ -157,7 +160,18 @@ begin
   end
   else
     CheckForMitigationWarningFor_Win10_1803(Silent, '');
-
+  // Enable the keyboard
+  n := kmcom.Keyboards.IndexOf(KeyboardID);
+  if n < 0 then
+  begin
+    // The Keyboard was successully installed for the BCP47Code
+    // for some reason the index look up has failed. Still leave
+    // Result as true, the keyboard will not be enabled.
+    // TODO: Log error unexpected `KeyboardID` not found
+    Exit;
+  end;
+  kbd := kmcom.Keyboards[n];
+  kbd.Loaded := TRUE;
   kmcom.Apply;
   Result := True;
 end;


### PR DESCRIPTION
Fixes #7670 
the `-ikl` sets up the language registration for the keyboard for the user whos shell runs the command. 
This calls a `InstallKeyboardLanguage` when following the command chain all the way through will update the windows registry
 in Line 560 of `Keyman.System.Process.KPInstallKeyboardLanguage` builds a registry key for the `KeyboardID` String Name under `Active Keyboards` and adds the BCP47Tag under the `Languages` path. It does not enable the keyboard. 

As reported in #7670, no KeymanID is written directly under `Active Keyboards` nor the corresponding `Active Keyboards\KeyboardId\keymanid` with the integer value. 

`InstallKeyboardLanguage` will now enable the just-installed active keyboard.  - I am not 100% sold on this solution either it works but it would probably be better to have a separate `EnableKeyboard` function, however, I am not sure where it would sit in the architecture.

Further discussion it was thought that this would be picked up on the keyboard load.
https://github.com/keymanapp/keyman/blob/58496402bba029acff7e33aa0270f4237a430691/windows/src/global/delphi/general/RegKeyboards.pas#L356-L370

However, the reason the else on line 367 will not be called is because the  ` Active Keyboards\KeyboardId` id exists, it doesn't have keymanid. Had the else been for the `if ValueExists(SRegValue_KeymanID) then`  on line 360 then it may have worked. This still doesn't seem like a good method to be catching and enabling a keyboard based on a registry state rather than an explicit request. 

---

# User Testing


# **TEST_CMD_LINE_OPTION**

You may prefer to do this test is with a VM you use for testing rather then you main windows machine. As you need a local test user. You can remove them once the test is finished.

Download a keyboard package to use for testing for example Tamil 99 Basic `basic_kbdtam99.kmp`

1. Add a local user to your machine, note you don’t need add user with microsoft cloud account. 
Follow these steps and this link [Create a local user or administrator account in Windows - Microsoft Support](https://support.microsoft.com/en-us/windows/create-a-local-user-or-administrator-account-in-windows-20de74e0-ac7f-3502-a866-32915af2a34d)
which has a tab for windows 11 or 10 depending on your windows version.

2. Install the keyman for windows attached with the PR if you haven’t already.

3. Now login into the new test user account don’t logout out of the current account. Click Start then click the user icon and click the local test account you created. 
![image](https://user-images.githubusercontent.com/58423624/207524122-8db9436a-d6eb-470c-a749-29df1c524cee.png)

4. In the new test account run keyman. If the icon is not on the desktop, press `window key` + `s` and type Keyman. This is the first time it has run for this user so will probably ask for the password of and administrator.
Once keyman is installed close it. 
 
5. Switch user back to you main account.

6.  Open an elevated command prompt. 
One way is to press `windows key` + `s` and type cmd you should see a command prompt icon right click and choose `Run as administrator` from the menu.
3. In the elevated command prompt change to where Keyman is installed - usually 
`>cd "c:\Program Files (x86)\Keyman\Keyman Desktop"`
5. Then type the cmd
`>kmshell.exe -s -i c:\Users\[User_name]\Downloads\basic_kbdtam99.kmp`
6. Now log into the test user account. 
7. Open a standard command prompt,( not as administrator) and change to where Keyman is installed usually:
`>cd "c:\Program Files (x86)\Keyman\Keyman Desktop"`
8. Then type the following command
`>kmshell -s -ikl basic_kbdtam99 ta-IN`

Expected Result:
- Opening Keyman you should be able to select the Tamil keyboard.  
- Also see that is enabled in the Keyboard Layout tab in Keyman Configuration.



