### PR TITLE
chore(linux): Improve package build

### DIFF
--- a/linux/ibus-keyman/src/test/run-tests.sh
+++ b/linux/ibus-keyman/src/test/run-tests.sh
@@ -3,6 +3,15 @@
 SRCDIR=${top_srcdir:-$(realpath $(dirname $0)/../..)}
 PID_FILE=/tmp/keymanutil-tests-pids
 
+if [ -v KEYMAN_PKG_BUILD ]; then
+  # During package builds we skip these tests - they often fail, e.g.
+  # during Debian reproducibility testing with an error like
+  # "cannot open display: :32"
+  echo "1..1"
+  echo "ok 1 # SKIP on package build"
+  exit 0
+fi
+
 if ! which Xvfb > /dev/null || ! which Xephyr > /dev/null || ! which metacity > /dev/null; then
   echo "Please install Xvfb, Xephyr and metacity before running these tests!"
   exit 1


### PR DESCRIPTION
During package builds on Debian servers the build often failed with an error related to X11 when running the tests. This change skips the tests in `linux/ibus-keyman/src/test` when building packages, similar to the way we already do it for the tests in `linux/ibus-keyman/tests`.

@keymanapp-test-bot skip