### PR TITLE
fix(developer): invalid charmap cell selection when updating to empty search result

### DIFF
--- a/common/windows/delphi/charmap/UfrmCharacterMapNew.pas
+++ b/common/windows/delphi/charmap/UfrmCharacterMapNew.pas
@@ -904,7 +904,7 @@ end;
 
 procedure TfrmCharacterMapNew.gridSelectCell(Sender: TObject; ACol, ARow: Integer; var CanSelect: Boolean);
 begin
-  CanSelect := ARow > 0;
+  CanSelect := (ARow > 0) or (grid.RowCount = 1);
 end;
 
 function TfrmCharacterMapNew.GetDragObject: TCharacterDragObject;


### PR DESCRIPTION
Fixes #7879.

If we enter a search string that results in zero results, the grid resize to one row attempts to select row zero. However, we prevent this. This leaves the current row outside the range of valid rows, which means the grid is in an invalid state.

This later causes a crash if the user attempts to mousewheel up. There may be other similar crashes in this situation, but I haven't found any yet.

Fix is to allow selection of row zero when there is only one row. I have not found any problems caused by allowing this.

@keymanapp-test-bot skip