### PR TITLE
fix(developer): kmc-model esbuild node_modules path 🙀

### DIFF
--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "tsc -b && npm run build-cjs",
-    "build-cjs": "esbuild build/src/lexical-model-compiler.js --bundle --platform=node --external:./node_modules/* > build/cjs-src/lexical-model-compiler.cjs",
+    "build-cjs": "esbuild build/src/lexical-model-compiler.js --bundle --platform=node --external:../../node_modules/* > build/cjs-src/lexical-model-compiler.cjs",
     "test": "cd test && tsc -b && cd .. && c8 mocha",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
The node_modules path is relative to the build output, not package.json. This was causing the web tests to fail due to dependence on the lexical-model-compiler.cjs.

@keymanapp-test-bot skip