### PR TITLE
chore(android): Update Gradle dependencies; targetSDKVersion to 33

### DIFF
--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -6,9 +6,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
-        classpath 'name.remal:gradle-plugins:1.3.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
+        // sentry-android-gradle-plugin 2.1.5+ requires AGP 7.0
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.2'
+        classpath 'name.remal:gradle-plugins:1.5.0'
 
         // From jcenter() which could be sunset in future
         // https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

--- a/android/KMAPro/gradle/wrapper/gradle-wrapper.properties
+++ b/android/KMAPro/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.application'
     id 'io.sentry.android.gradle'
     // https://github.com/Triple-T/gradle-play-publisher/issues/947#issuecomment-843634852
-    id 'com.github.triplet.play' version '3.5.0' apply false
+    id 'com.github.triplet.play' version '3.7.0-agp4.2' apply false
     id 'name.remal.default-plugins'
 }
 
@@ -10,8 +10,7 @@ ext.rootPath = '../../'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {
@@ -25,7 +24,7 @@ android {
     defaultConfig {
         applicationId "com.tavultesoft.kmapro"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         //println "===DUMPING PROPERTIES==="
         //dumpProperties(project) // Use this to dump all external properties for debugging TeamCity integration
@@ -148,18 +147,18 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
+    implementation 'com.google.android.material:material:1.6.0'
     implementation 'com.stepstone.stepper:material-stepper:4.3.1'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation 'io.sentry:sentry-android:4.3.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'io.sentry:sentry-android:6.9.2'
+    implementation 'androidx.preference:preference:1.2.0'
     implementation "com.android.installreferrer:installreferrer:2.2"
 
     // Add dependency for generating QR Codes
     // (Even though it's embedded in KMEA, because we're manually copying keyman-engine.aar,
     // we "lose" it in the dependency management)
-    implementation ('com.github.kenglxn.QRGen:android:2.6.0') {
+    implementation ('com.github.kenglxn.QRGen:android:2.7.0') {
         transitive = true
     }
 }

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -7,12 +7,11 @@ ext.rootPath = '../../'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         // VERSION_CODE and VERSION_NAME from version.gradle but Gradle removes them for libraries
         buildConfigField "String", "KEYMAN_ENGINE_VERSION_NAME", "\""+VERSION_NAME+"\""
@@ -61,19 +60,22 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
-    implementation 'com.google.android.material:material:1.3.0'
+    // 1.6.0-rc01 needed to resolve https://issuetracker.google.com/issues/238425626
+    implementation 'androidx.appcompat:appcompat:1.6.0-rc01' // 1.5.1
+    // material:1.7.0 will need Gradle plugin 7.1.0+
+    implementation 'com.google.android.material:material:1.6.0'
     implementation 'commons-io:commons-io:2.6'
-    implementation 'io.sentry:sentry-android:4.3.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'io.sentry:sentry-android:6.9.2'
+    implementation 'androidx.preference:preference:1.2.0'
 
     // Robolectric
-    testImplementation 'androidx.test:core:1.3.0'
-    testImplementation 'androidx.test.ext:junit:1.1.3'
-    testImplementation 'org.robolectric:robolectric:4.5.1'
+    testImplementation 'androidx.test:core:1.5.0'
+    testImplementation 'androidx.test.ext:junit:1.1.4'
+    testImplementation 'org.robolectric:robolectric:4.8.1'
 
     // Generate QR Codes
-    implementation ('com.github.kenglxn.QRGen:android:2.6.0') {
+    // 3.0.1 requires Java 11
+    implementation ('com.github.kenglxn.QRGen:android:2.7.0') {
         transitive = true
     }
 }

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
       </intent>
     </queries>
 
+    <!-- https://developer.android.com/develop/ui/views/notifications/notification-permission#declare -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <!-- Ensure these permissions aren't added by dependencies unless calling app intentionally adds them -->

--- a/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/tavultesoft/kmea/util/FileUtilsTest.java
@@ -23,13 +23,13 @@ public class FileUtilsTest {
     List<ShadowLog.LogItem> logs = ShadowLog.getLogs();
 
     // The logs contain type 4, but we only care about type 6 for connection messages
-    Assert.assertEquals(4, logs.size());
+    Assert.assertEquals(3, logs.size());
 
-    Assert.assertEquals("Connection", logs.get(2).tag);
-    Assert.assertEquals("Initialization failed:\njava.net.MalformedURLException: no protocol: invalidURL", logs.get(2).msg);
+    Assert.assertEquals("Connection", logs.get(1).tag);
+    Assert.assertEquals("Initialization failed:\njava.net.MalformedURLException: no protocol: invalidURL", logs.get(1).msg);
 
-    Assert.assertEquals("FileUtils", logs.get(3).tag);
-    Assert.assertEquals("Could not download filename ", logs.get(3).msg);
+    Assert.assertEquals("FileUtils", logs.get(2).tag);
+    Assert.assertEquals("Could not download filename ", logs.get(2).msg);
   }
 
   @Test

--- a/android/KMEA/build.gradle
+++ b/android/KMEA/build.gradle
@@ -5,10 +5,12 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        // Gradle plugin 7.3.0+ requires JDK 11
+        // https://developer.android.com/studio/releases/gradle-plugin#compatibility-7-3-0
+        classpath 'com.android.tools.build:gradle:4.2.2'
         // io.sentry:sentry-android-gradle-plugin not available for library project
-        classpath 'io.sentry:sentry-android:4.3.0'
-        classpath 'name.remal:gradle-plugins:1.3.1'
+        classpath 'io.sentry:sentry-android:6.9.2'
+        classpath 'name.remal:gradle-plugins:1.5.0'
     }
 }
 

--- a/android/KMEA/gradle/wrapper/gradle-wrapper.properties
+++ b/android/KMEA/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/README.md
+++ b/android/README.md
@@ -11,6 +11,11 @@ Keyman for Android (formerly named KMAPro) can be built from a command line (pre
 
 Building Keyman Web is a precursor for compiling KMEA, so verify your system has all the [Minimum Web Compilation Requirements](../web/README.md#minimum-web-compilation-requirements)
 
+When attempting to build via Android Studio the first time, you'll also need to accept the SDK licenses. Depending on your OS, you may need to run a command line similar to:
+```bash
+yes | ~/Library/Android/sdk/tools/bin/sdkmanager --licenses
+```
+
 ### Crash Reporting
 Keyman for Android uses [Sentry](https://sentry.io) for crash reporting at a server https://sentry.keyman.com. The analytics for Debug are associated with an App Bundle ID `com.tavultesoft.kmapro.debug`.
  
@@ -110,8 +115,7 @@ Keyman Engine for Android library (**keyman-engine.aar**) is now ready to be imp
 4. Check that the `android{}` object, includes the following:
 ```gradle
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {
@@ -134,14 +138,14 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
+    implementation 'com.google.android.material:material:1.6.0'
     api (name:'keyman-engine', ext:'aar')
-    implementation 'io.sentry:sentry-android:4.3.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'io.sentry:sentry-android:6.9.2'
+    implementation 'androidx.preference:preference:1.2.0'
 
     // Include this if you want to have QR Codes displayed on Keyboard Info
-    implementation ('com.github.kenglxn.QRGen:android:2.6.0') {
+    implementation ('com.github.kenglxn.QRGen:android:2.7.0') {
         transitive = true
     }
 }

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -1,11 +1,10 @@
 plugins {
     id 'com.android.application'
-    id 'io.sentry.android.gradle'
+    id 'io.sentry.android.gradle' // TODO: Remove in 7896
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {
@@ -19,7 +18,7 @@ android {
     defaultConfig {
         applicationId "com.keyman.kmsample1"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }
@@ -41,9 +40,9 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
+    implementation 'com.google.android.material:material:1.6.0'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation 'io.sentry:sentry-android:4.3.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'io.sentry:sentry-android:6.9.0' // Remove in #7896
+    implementation 'androidx.preference:preference:1.2.0'
 }

--- a/android/Samples/KMSample1/build.gradle
+++ b/android/Samples/KMSample1/build.gradle
@@ -7,8 +7,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.2' // Remove in #7896
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Samples/KMSample1/gradle/wrapper/gradle-wrapper.properties
+++ b/android/Samples/KMSample1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -1,11 +1,10 @@
 plugins {
     id 'com.android.application'
-    id 'io.sentry.android.gradle'
+    id 'io.sentry.android.gradle' // Remove in #7896
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {
@@ -19,7 +18,7 @@ android {
     defaultConfig {
         applicationId "com.keyman.kmsample2"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }
@@ -40,9 +39,9 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
+    implementation 'com.google.android.material:material:1.6.0'
     api (name:'keyman-engine', ext:'aar')
-    implementation 'io.sentry:sentry-android:4.3.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'io.sentry:sentry-android:6.9.2' // Remove in #7896
+    implementation 'androidx.preference:preference:1.2.0'
 }

--- a/android/Samples/KMSample2/build.gradle
+++ b/android/Samples/KMSample2/build.gradle
@@ -7,8 +7,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.2' // Remove in #7896
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Samples/KMSample2/gradle/wrapper/gradle-wrapper.properties
+++ b/android/Samples/KMSample2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -7,7 +7,7 @@ ext.rootPath = '../../../'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         applicationId "com.keyman.android.tests.keyboardHarness"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         // VERSION_CODE and VERSION_NAME from version.gradle
         versionCode VERSION_CODE as Integer
@@ -46,9 +46,9 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
+    implementation 'com.google.android.material:material:1.6.0'
     api (name:'keyman-engine', ext:'aar')
-    implementation 'io.sentry:sentry-android:4.3.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'io.sentry:sentry-android:6.9.2'
+    implementation 'androidx.preference:preference:1.2.0'
 }

--- a/android/Tests/KeyboardHarness/build.gradle
+++ b/android/Tests/KeyboardHarness/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Tests/KeyboardHarness/gradle/wrapper/gradle-wrapper.properties
+++ b/android/Tests/KeyboardHarness/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/android/Tests/keycode/.idea/.gitignore
+++ b/android/Tests/keycode/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/android/Tests/keycode/app/build.gradle
+++ b/android/Tests/keycode/app/build.gradle
@@ -4,11 +4,11 @@ ext.rootPath = '../../../'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.keyman.android.tests.keycode"
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 33
 
         // VERSION_CODE and VERSION_NAME from version.gradle
         versionCode VERSION_CODE as Integer
@@ -25,9 +25,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
+    implementation 'com.google.android.material:material:1.6.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'androidx.test:core:1.1.0'
-    testImplementation 'androidx.test.ext:junit:1.1.0'
+    testImplementation 'androidx.test:core:1.5.0'
+    testImplementation 'androidx.test.ext:junit:1.1.4'
 }

--- a/android/Tests/keycode/app/src/main/AndroidManifest.xml
+++ b/android/Tests/keycode/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+          android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/android/Tests/keycode/build.gradle
+++ b/android/Tests/keycode/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/Tests/keycode/gradle/wrapper/gradle-wrapper.properties
+++ b/android/Tests/keycode/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -1,15 +1,14 @@
 plugins {
     id 'com.android.application'
     id 'io.sentry.android.gradle'
-    id 'com.github.triplet.play' version '3.5.0' apply false
+    id 'com.github.triplet.play' version '3.7.0-agp4.2' apply false
 }
 
 ext.rootPath = '../../../../android'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -19,7 +18,7 @@ android {
     defaultConfig {
         applicationId "com.firstvoices.keyboards"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         // VERSION_CODE and VERSION_NAME from version.gradle
         versionCode VERSION_CODE as Integer
@@ -110,11 +109,11 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
+    implementation 'com.google.android.material:material:1.6.0'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation 'io.sentry:sentry-android:4.3.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'io.sentry:sentry-android:6.9.0'
+    implementation 'androidx.preference:preference:1.2.0'
 }
 
 apply plugin: 'com.android.application'

--- a/oem/firstvoices/android/build.gradle
+++ b/oem/firstvoices/android/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/oem/firstvoices/android/gradle/wrapper/gradle-wrapper.properties
+++ b/oem/firstvoices/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR is updating our Android Gradle dependencies for the start of 17.0 development.

Since we're remaining on Java 8, this limits what version of Android Gradle Plugin (AGP) we can upgrade to, which then limits some of the other dependencies.

The targetSDKVersion is also bumped to 33, which necessitates adding the `POST_NOTIFICATIONS` permission to the Android Manifest.

Updating junit impacted `FileUtilsTest.java`, where the expected log now contains 3 items instead of 4.

We'll also need to see if the nightly build successfully publishes (after PR merge) to verify the triplet.play plugin.

Some follow-on work could be done in #7896 to remove Sentry dependencies in the Sample/test apps.

## User Testing
**Setup** - Install the PR build on an Android emulator/device (minimum SDK version of 21)

* **TEST_KEYMAN_APP** - Verifies the Keyman app runs
1. Launch Keyman for Android
2. Dismiss the "Get Started" menu
3. From Keyman settings, search for the "khmer_angkor" keyboard and install the keyboard package
4. Verify Keyman installs the khmer_angkor keyboard
5. Verify the touch keyboard displays khmer_angkor keyboard.
6. Long-press on the globe-key to display the "Keyboard Picker" menu
7. Click the "i" info icon for khmer_angkor
8. Verify the keyboard info for khmer_angkor is displayed
9. Verify a QR code for sharing the khmer_angkor keyboard is displayed


