### PR TITLE
fix(windows): modify disable keyboard display

### DIFF
--- a/windows/src/desktop/kmshell/xml/config.css
+++ b/windows/src/desktop/kmshell/xml/config.css
@@ -169,8 +169,8 @@ input.kbd_button:hover, input[type='button']:hover, button[type='button']:hover,
 
 input[type='submit']:disabled, input[type='button']:disabled, button:disabled
 {
-  color: #c0c0cf;
-  background: #80808f;
+  color: #929396;
+  background: #C9CACA;
 }
 
 a.hotkey:link, a.hotkey:visited
@@ -306,11 +306,6 @@ html
   display: none;
   border-bottom-left-radius: 5px;
   border-bottom-right-radius: 5px;
-}
-
-.list_detail.list_disabled
-{
-  opacity: 0.5;
 }
 
 .checkbox_hidden
@@ -502,6 +497,11 @@ table tr
   position: relative;
   grid-template-columns: max-content minmax(240px, 439px);
   padding: 1px 0 1px 10px;
+}
+
+.grid_container.grid_disabled
+{
+  opacity: 0.5;
 }
 
 .grid_item

--- a/windows/src/desktop/kmshell/xml/config.js
+++ b/windows/src/desktop/kmshell/xml/config.js
@@ -388,20 +388,23 @@ function keyboard_checkclick(n,toggle) {
 /* Disable/Enable Button replaces checkbox for now still use the "check" function in delphi webserver */
 function keyboard_toggle(keyboard_name) {
   const checkbox = document.getElementById('keyboardcheck_'+keyboard_name), li = document.getElementById('list_keyboard_'+keyboard_name);
-  const li_detail = document.getElementById('list_detail_keyboard_'+keyboard_name);
+  const grid_container = document.getElementById('keyboard_grid_'+keyboard_name);
   const disable_btn = document.getElementById('button_disable_'+keyboard_name);
   const enable_btn = document.getElementById('button_enable_'+keyboard_name);
+  const add_remove_btn = document.getElementById('button_add_remove_'+keyboard_name);
 
   checkbox.checked = !checkbox.checked;
   if (checkbox.checked){
     enable_btn.style.display = "none";
     disable_btn.style.display = "block";
-    li_detail.classList.remove("list_disabled");
+    grid_container.classList.remove("grid_disabled");
+    add_remove_btn.disabled = false;
   }
   else {
     disable_btn.style.display = "none";
     enable_btn.style.display = "block";
-    li_detail.classList.add("list_disabled");
+    grid_container.classList.add("grid_disabled");
+    add_remove_btn.disabled = true;
   }
 
   location.href='keyman:keyboard_clickcheck?id='+keyboard_name+'&value='+checkbox.checked;

--- a/windows/src/desktop/kmshell/xml/elements.xsl
+++ b/windows/src/desktop/kmshell/xml/elements.xsl
@@ -69,6 +69,7 @@
     <xsl:param name="visible" />
     <xsl:param name="background" />
     <xsl:param name="color" />
+    <xsl:param name="fontweight" />
 
     <xsl:choose>
       <xsl:when test="$shield = 1 and /Keyman/canelevate">
@@ -87,6 +88,7 @@
           <xsl:attribute name="tabindex"><xsl:value-of select="$tabid"/></xsl:attribute>
           <xsl:attribute name="style">
             font-size: 11px;
+            <xsl:choose><xsl:when test="$fontweight != ''">font-weight: <xsl:value-of select="$fontweight"/>;</xsl:when></xsl:choose>
             height: 25px;
             display: inline-block;
             text-align: center;
@@ -120,6 +122,7 @@
           <xsl:attribute name="style">
             <xsl:choose><xsl:when test="$width != ''">width: <xsl:value-of select="$width"/>;</xsl:when></xsl:choose>
             font-size: 11px;
+            <xsl:choose><xsl:when test="$fontweight != ''">font-weight: <xsl:value-of select="$fontweight"/>;</xsl:when></xsl:choose>
             height: 25px;
             display: inline-block;
             margin-right: 8px;

--- a/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
@@ -136,25 +136,31 @@
       </div>
         <div class="list_detail">
           <xsl:attribute name="id">list_detail_keyboard_<xsl:value-of select="id"/></xsl:attribute>
-          <xsl:attribute name='class'>
-           list_detail <xsl:choose><xsl:when test='loaded'></xsl:when><xsl:otherwise>list_disabled</xsl:otherwise></xsl:choose>
-          </xsl:attribute>
           <div class="flex_container">
             <div class="flex_container_buttons">
               <xsl:if test="//KeymanPackageContentKeyboardsInstalled/KeymanKeyboardInstalled[id=current()/id] and ../../options">
                 <xsl:call-template name="button">
+                  <xsl:with-param name="id">menu_options_<xsl:value-of select="id"/></xsl:with-param>
                   <xsl:with-param name="className">kbd_button</xsl:with-param>
                   <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Menu_Options']"/></xsl:with-param>
                   <xsl:with-param name="command">keyman:keyboard_options?id=<xsl:value-of select="id"/></xsl:with-param>
                 </xsl:call-template>
               </xsl:if>
               <xsl:call-template name="button">
+                <xsl:with-param name="id">add_remove_<xsl:value-of select="id"/></xsl:with-param>
                 <xsl:with-param name="className">kbd_button</xsl:with-param>
                 <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='SKAddremove']"/></xsl:with-param>
                 <xsl:with-param name="command">javascript:showModifyLink('<xsl:value-of select="../../id" />')</xsl:with-param>
+                <xsl:with-param name="disabled">
+                  <xsl:choose>
+                    <xsl:when test='loaded'>0</xsl:when>
+                    <xsl:otherwise>1</xsl:otherwise>
+                  </xsl:choose>
+                </xsl:with-param>
               </xsl:call-template>
               <xsl:if test="$singlekeyboardpackage = '1' or //KeymanPackageContentKeyboardsInstalled/KeymanKeyboardInstalled[id=current()/id]">
                 <xsl:call-template name="button">
+                  <xsl:with-param name="id">share_<xsl:value-of select="id"/></xsl:with-param>
                   <xsl:with-param name="className">kbd_button</xsl:with-param>
                   <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Keyboard_Share']"/></xsl:with-param>
                   <xsl:with-param name="command">javascript:showKeyboardLink('<xsl:value-of select="../../id" />')</xsl:with-param>
@@ -187,6 +193,7 @@
               </xsl:if>
               <xsl:if test="//KeymanPackageContentKeyboardsInstalled/KeymanKeyboardInstalled[id=current()/id]">
                 <xsl:call-template name="button">
+                  <xsl:with-param name="id">help_<xsl:value-of select="id"/></xsl:with-param>
                   <xsl:with-param name="className">kbd_button</xsl:with-param>
                   <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Caption_Help']"/></xsl:with-param>
                   <xsl:with-param name="command">keyman:package_welcome?id=<xsl:value-of select="$package_id" /></xsl:with-param>
@@ -214,6 +221,7 @@
                   <xsl:with-param name="id">enable_<xsl:value-of select="id"/></xsl:with-param>
                   <xsl:with-param name="onclick">return keyboard_toggle('<xsl:value-of select="id"/>')</xsl:with-param>
                   <xsl:with-param name="className">kbd_button</xsl:with-param>
+                  <xsl:with-param name="fontweight">bold</xsl:with-param>
                   <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Caption_Enable']"/></xsl:with-param>
                   <xsl:with-param name="visible">
                     <xsl:choose>
@@ -225,6 +233,7 @@
               <xsl:choose>
                 <xsl:when test="//KeymanPackageContentKeyboardsInstalled/KeymanKeyboardInstalled[id=current()/id]">
                   <xsl:call-template name="button">
+                  <xsl:with-param name="id">uninstall_package_<xsl:value-of select="id"/></xsl:with-param>
                     <xsl:with-param name="className">kbd_button</xsl:with-param>
                     <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Caption_Uninstall']"/></xsl:with-param>
                     <xsl:with-param name="command">keyman:package_uninstall?id=<xsl:value-of select="$package_id"/></xsl:with-param>
@@ -232,6 +241,7 @@
                 </xsl:when>
                 <xsl:otherwise>
                   <xsl:call-template name="button">
+                    <xsl:with-param name="id">uninstall_kbd_<xsl:value-of select="id"/></xsl:with-param>
                     <xsl:with-param name="className">kbd_button</xsl:with-param>
                     <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Caption_Uninstall']"/></xsl:with-param>
                     <xsl:with-param name="command">keyman:keyboard_uninstall?id=<xsl:value-of select="$id"/></xsl:with-param>
@@ -243,7 +253,10 @@
 
             <div class="flex_vertical_line"> </div><!--- Vertical seperator  -->
 
-            <div class="grid_container grid_rows_hide">
+            <div>
+              <xsl:attribute name='class'>
+                grid_container grid_rows_hide <xsl:choose><xsl:when test='loaded'></xsl:when><xsl:otherwise>grid_disabled</xsl:otherwise></xsl:choose>
+              </xsl:attribute>
               <xsl:attribute name="id">keyboard_grid_<xsl:value-of select="id"/></xsl:attribute>
               <div class="grid_item grid_item_title">
                 <xsl:if test="count(//KeymanLanguage[keymankeyboardid=$id]) = 0">


### PR DESCRIPTION
The Keyboard layouts tab: When a keyboard is disabled just the details text on the right is now 'greyed' out. The buttons on the left are no longer greyed out except for 'Add/remove' which is now disabled.  The disabled background and foreground text colours are from the Keyman design approach manual. See the screenshot for how it looks now.
![disable_button_lvl1](https://user-images.githubusercontent.com/58423624/207305103-5de67cf5-3be3-4a0a-8357-cddca30f7b0e.png)


# User Testing

* **TEST_ADD_REMOVE_DISABLED**
Pre-requests at least one keyboard layout needs to be installed

1. Open the Keyman Configuration 
2. Select the Keyboard Layouts tab
3. Select a Keyboard Layout
4. Click the `Disable` Button
5. Observe that: 

    - The details on the left are `greyed out`
    - The buttons are not `greyed out` except for `Add\remove languages...`
    - Clicking on `Add\remove languages...` does NOT pop up the add\remove languages.. dialog.
    - The `Enable` button text is **bold** 
6. Close the configuration Dialogue

* **TEST_ADD_REMOVE_ENABLED**

This test continues on from `TEST_ADD_REMOVE_DISABLED`
1. Open Keyman Configuration and return to the Keyboard layout that was disabled.
2. Make the same observations from step 5 in `TEST_ADD_REMOVE_DISABLED`
3. Click `Enable` button.
4 . Observe that:

  - The details are no longer greyed out
  - `Add\remove languages...` is no longer greyed out
  - Clicking on the `Add\remove languages...` pop up the `Add\remove languages...` dialog
  - The `Disable` button text is `normal` weight not bold.


 



