### PR TITLE
fix(windows): no languages warning source changed

### DIFF
--- a/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
@@ -259,7 +259,7 @@
               </xsl:attribute>
               <xsl:attribute name="id">keyboard_grid_<xsl:value-of select="id"/></xsl:attribute>
               <div class="grid_item grid_item_title">
-                <xsl:if test="count(//KeymanLanguage[keymankeyboardid=$id]) = 0">
+                <xsl:if test="count(KeymanKeyboardLanguagesInstalled/KeymanKeyboardLanguageInstalled[isinstalled]) = 0">
                   <xsl:attribute name="style">color:red;</xsl:attribute>
                 </xsl:if>
                 <xsl:value-of select="$locale/string[@name='S_Caption_Languages']"/>


### PR DESCRIPTION
The purpose of the red colouring of the Languages: label was to warn the user when no languages were installed for the current keyboard layout. It was suffering from dirty cache, this actually made it more  confusing the helpful. 
The red colouring of the "Languages:" label was driven by an xml element which was taken from a registry value whose cache is not refreshed without restarting the app. The new xml element is driven by a registry language value that is refreshed straight away. 

# User Testing

* **TEST_LANG_RED_PT1**

1. Open Keyman Configuration and install `Tamil 99 Basic`
2. Click on the `Add/remove languages...` button
3. In the `Add/remove language` dialog pop up click the `x` to the right of the only language installed [ta-IN]. If there are other languages remove them also. This takes a while once the language is removed press the `close` button.
Expected result:
  The text of the "Languages:" label for the Tamil 99 Basic Keyboard layout should now be the colour red.
![image](https://user-images.githubusercontent.com/58423624/207498102-a76a4aea-a875-4ff6-9bc4-567d9e0ea000.png)

* **TEST_LANG_RED_PT2**
Continuing from `TEST_LANG_RED_PT!`
1. From the Keyman Configuration Keyboard Layout tab for `Tamil 99 Basic` Click the `Add/remove languages...` button.
2. In the `Add/remove language` dialog pop up click the `Add language` button and add `ta-IN`.
3. Once installed hit the the `close` button in the dialog pop up.
Expected result:
   The text of the "Languages:" label for the Tamil 99 Basic Keyboard layout should now be standard black colour.