### PR TITLE
feat(web): suggestion overflow styling - fades near borders

### DIFF
--- a/web/src/engine/main/osk/banner.ts
+++ b/web/src/engine/main/osk/banner.ts
@@ -166,6 +166,7 @@ namespace com.keyman.osk {
 
   export class BannerSuggestion {
     div: HTMLDivElement;
+    scroller: HTMLDivElement;
     private display: HTMLSpanElement;
     private fontFamily?: string;
 
@@ -185,7 +186,7 @@ namespace com.keyman.osk {
       // Provides an empty, base SPAN for text display.  We'll swap these out regularly;
       // `Suggestion`s will have varying length and may need different styling.
       let display = this.display = keyman.util._CreateElement('span');
-      this.div.appendChild(display);
+      this.scroller.appendChild(display);
     }
 
     private constructRoot() {
@@ -216,6 +217,11 @@ namespace com.keyman.osk {
       ds.width = widthpc + '%';
 
       this.div['suggestion'] = this;
+
+      let scroller = this.scroller = keyman.util._CreateElement('div'), fadeStyle=scroller.style;
+      scroller.className = "kmw-suggestion-scroller";
+
+      div.appendChild(scroller);
     }
 
     get suggestion(): Suggestion {
@@ -235,7 +241,7 @@ namespace com.keyman.osk {
 
     private updateText() {
       let display = this.generateSuggestionText();
-      this.div.replaceChild(display, this.display);
+      this.scroller.replaceChild(display, this.display);
       this.display = display;
     }
 
@@ -305,6 +311,7 @@ namespace com.keyman.osk {
 
       // Finalize the suggestion text
       s.innerHTML = suggestionText;
+
       return s;
     }
   }
@@ -446,8 +453,21 @@ namespace com.keyman.osk {
           if(util.hasClass(e,'kmw-suggest-option')) {
             return e as HTMLDivElement;
           }
-          if(e.parentNode && util.hasClass(<HTMLElement> e.parentNode,'kmw-suggest-option')) {
+
+          if(!e.parentNode) {
+            return null;
+          }
+
+          if(util.hasClass(<HTMLElement> e.parentNode,'kmw-suggest-option')) {
             return e.parentNode as HTMLDivElement;
+          }
+
+          if(!e.parentNode.parentNode) {
+            return null;
+          }
+
+          if(util.hasClass(<HTMLElement> e.parentNode.parentNode,'kmw-suggest-option')) {
+            return e.parentNode.parentNode as HTMLDivElement;
           }
           // if(e.firstChild && util.hasClass(<HTMLElement> e.firstChild,'kmw-suggest-option')) {
           //   return e.firstChild as HTMLDivElement;
@@ -455,6 +475,10 @@ namespace com.keyman.osk {
         }
       } catch(ex) {}
       return null;
+    }
+
+    protected findScrollerForTarget(target: HTMLDivElement): HTMLElement {
+      return target.firstChild as HTMLElement;
     }
 
     protected highlight(t: HTMLDivElement, on: boolean): void {

--- a/web/src/engine/main/osk/touchEventEngine.ts
+++ b/web/src/engine/main/osk/touchEventEngine.ts
@@ -58,7 +58,7 @@ namespace com.keyman.osk {
 
     private preventPropagation(e: TouchEvent) {
       // Standard event maintenance
-      e.preventDefault();
+      // e.preventDefault();
       e.cancelBubble=true;
 
       if(typeof e.stopImmediatePropagation == 'function') {

--- a/web/src/engine/main/osk/uiTouchHandlerBase.ts
+++ b/web/src/engine/main/osk/uiTouchHandlerBase.ts
@@ -66,6 +66,14 @@ namespace com.keyman.osk {
     abstract findTargetFrom(e: HTMLElement): Target;
 
     /**
+     * Given the current target element, returns the component to be used for
+     * scrolling.
+     */
+    protected findScrollerForTarget(target: Target): HTMLElement {
+      return target;
+    }
+
+    /**
      * Highlights the target element as visual feedback representing
      * a pending touch.
      * @param t The `Target` to highlight
@@ -239,7 +247,8 @@ namespace com.keyman.osk {
       }
 
       // Establish scroll tracking.
-      let shouldScroll = (this.currentTarget.clientWidth < this.currentTarget.scrollWidth);
+      let targetScroller = this.findScrollerForTarget(this.currentTarget);
+      let shouldScroll = (targetScroller.clientWidth < targetScroller.scrollWidth);
       this.scrollTouchState = shouldScroll ? new ScrollState(coord) : null;
 
       // Alright, Target acquired!  Now to use it:
@@ -326,7 +335,6 @@ namespace com.keyman.osk {
      **/
     touchMove(coord: InputEventCoordinate) : void {
       let keyman = com.keyman.singleton;
-      let util = keyman.util;
 
       // Do not attempt to support reselection of target key for overlapped keystrokes
       if(coord.activeInputCount > 1 || this.touchCount == 0) {
@@ -334,8 +342,9 @@ namespace com.keyman.osk {
       }
 
       if(this.currentTarget && this.scrollTouchState != null) {
+        let scrollTarget = this.findScrollerForTarget(this.currentTarget);
         let deltaX = this.scrollTouchState.updateTo(coord).deltaX;
-        this.currentTarget.scrollLeft -= window.devicePixelRatio * deltaX;
+        scrollTarget.scrollLeft -= window.devicePixelRatio * deltaX;
 
         return;
       }

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -58,8 +58,6 @@
   display: block;
   line-height: normal;
   position: relative;
-  top: 50%;
-  transform: translateY(-50%);
 }
 
 .tablet .kmw-suggestion-text {
@@ -81,7 +79,6 @@
 .phone.ios .kmw-key.kmw-key-shift-on,
 .phone.ios .kmw-key.kmw-key-special-on {color:#fff;background-color:#88f;}
 .phone.ios .kmw-key.kmw-key-touched {background-color:#447;}
-.phone.ios .kmw-suggest-option.kmw-suggest-touched {background-color:#88f;}
 .phone.ios .kmw-key-deadkey{color:#048204;background-color:#fdfdfe;}
 
 /* Probably best to make this its own CSS that can be optionally included? */
@@ -104,6 +101,14 @@
   width: 100%;
 }
 
+.ios .kmw-suggest-option::before {
+  background: linear-gradient(90deg, #cfd3d9 0%, transparent 100%);
+}
+
+.ios .kmw-suggest-option::after {
+  background: linear-gradient(90deg, transparent 0%, #cfd3d9 100%);
+}
+
 .ios .kmw-banner-bar .kmw-suggest-option {
   display:inline-block;
   text-align: center;
@@ -118,7 +123,18 @@
   color: #000;
 }
 
-.phone.ios .kmw-suggest-option.kmw-suggest-touched {background-color:#88f;}
+.phone.ios .kmw-suggest-option.kmw-suggest-touched,
+.tablet.ios .kmw-suggest-option.kmw-suggest-touched {background-color:#88f;}
+
+.phone.ios .kmw-suggest-option.kmw-suggest-touched::before,
+.tablet.ios .kmw-suggest-option.kmw-suggest-touched::before {
+  background: linear-gradient(90deg, #88f 0%, transparent 100%);
+}
+
+.phone.ios .kmw-suggest-option.kmw-suggest-touched::after,
+.tablet.ios .kmw-suggest-option.kmw-suggest-touched::after {
+  background: linear-gradient(90deg, transparent 0%, #88f 100%);
+}
 
 .phone.ios.kmw-osk-frame,
 .tablet.ios.kmw-osk-frame {
@@ -134,6 +150,14 @@
 @media (prefers-color-scheme: dark) {
   .ios .kmw-banner-bar {
     background-color: #0f1319;
+  }
+
+  .ios .kmw-suggest-option::before {
+    background: linear-gradient(90deg, #0f1319 0%, transparent 100%);
+  }
+
+  .ios .kmw-suggest-option::after {
+    background: linear-gradient(90deg, transparent 0%, #0f1319 100%);
   }
 
   .ios .kmw-banner-bar .kmw-banner-separator {
@@ -174,6 +198,14 @@
   width: 100%;
 }
 
+.phone.android .kmw-suggest-option::before {
+  background: linear-gradient(90deg, #222 0%, transparent 100%);
+}
+
+.phone.android .kmw-suggest-option::after {
+  background: linear-gradient(90deg, transparent 0%, #222 100%);
+}
+
 .phone.android .kmw-banner-bar .kmw-suggest-option {
   display:inline-block;
   text-align: center;
@@ -185,6 +217,14 @@
 }
 
 .phone.android .kmw-suggest-option.kmw-suggest-touched {background-color:#bbb;}
+
+.phone.android .kmw-suggest-option.kmw-suggest-touched::before {
+  background: linear-gradient(90deg, #bbb 0%, transparent 100%);
+}
+
+.phone.android .kmw-suggest-option.kmw-suggest-touched::after {
+  background: linear-gradient(90deg, transparent 0%, #bbb 100%);
+}
 
 .tablet.kmw-osk-frame{left:0;bottom:0;width:100%;height:144px;overflow-y:visible;
         background-color:rgba(0,0,0,0.8);-webkit-user-select:none;}
@@ -206,7 +246,6 @@
 .tablet.ios .kmw-key.kmw-key-shift-on,
 .tablet.ios .kmw-key.kmw-key-special-on {color:#fff;background-color:#88f;}
 .tablet.ios .kmw-key.kmw-key-touched {background-color:#447;}
-.tablet.ios .kmw-suggest-option.kmw-suggest-touched {background-color:#88f;}
 .tablet.ios .kmw-key-deadkey{color:#048204;background-color:#fdfdfe;}
 
 /* Probably best to make this its own CSS that can be optionally included? */
@@ -244,6 +283,14 @@
   width: 100%;
 }
 
+.tablet.android .kmw-suggest-option::before {
+  background: linear-gradient(90deg, #b4b4b8 0px, transparent 100%);
+}
+
+.tablet.android .kmw-suggest-option::after {
+  background: linear-gradient(90deg, transparent 0%, #b4b4b8 100%);
+}
+
 .tablet.android .kmw-banner-bar .kmw-suggest-option {
   display:inline-block;
   text-align: center;
@@ -253,11 +300,20 @@
 .tablet.android .kmw-suggestion-text {
   color:#77f;
 }
+
 .tablet.android .kmw-suggest-option.kmw-suggest-touched {background-color:#447;}
+
+.tablet.android .kmw-suggest-option.kmw-suggest-touched::before {
+  background: linear-gradient(90deg, #447 0px, transparent 100%);
+}
+
+.tablet.android .kmw-suggest-option.kmw-suggest-touched::after {
+  background: linear-gradient(90deg, transparent 0%, #447 100%);
+}
 
 /* Vertical centering of text labels on keys */
 .kmw-key {text-align:center; white-space:nowrap;}
-.kmw-key:before {content:'.'; display:inline-block; height:100%; vertical-align:middle; max-width:0px; visibility:hidden;}
+.kmw-key::before {content:'.'; display:inline-block; height:100%; vertical-align:middle; max-width:0px; visibility:hidden;}
 .kmw-key span {display:inline-block}
 
 
@@ -271,7 +327,7 @@
 .desktop .kmw-key-label{position:absolute;left:2px;top:2px;font:0.5em Arial;color:#888;background-color:transparent;}
 
 /* Popup icon style (and content)*/
-.kmw-key-popup-icon:before{content:'\2022';}
+.kmw-key-popup-icon::before{content:'\2022';}
 
 .kmw-key-popup-icon{position:absolute;display:block;visibility:visible;right:4%;top:1%;/*width:8px;height:8px;*/
       font:bold 0.5em Arial;color:#aaa;}
@@ -292,22 +348,90 @@
 .kmw-footer-caption{color:#fff;font:0.7em Arial;margin:0 0 0 4px;}
 
 .kmw-banner-bar{height:100%; width:100%; margin:0; background-color:darkorange; display: inline-block; white-space: nowrap;}
+
+/* Creates a gradient to fade text at the borders, providing visual indication of overflow */
+/* Make sure the non-transparent color of the gradient matches .kmw-banner-bar's background-color. */
+.kmw-suggest-option::before,
+.kmw-suggest-option::after {
+  position:absolute;
+
+  /* Set scrollable-suggestion fade width here.  Make sure to also set .kmw-suggestion-text
+   * padding-left and padding-right accordingly!
+   */
+  width: 4px;
+  height: 100%;
+  content: '';
+  top: 0;
+  z-index:10999;  /* z-indexes this _behind_ the 'option' element that hosts the scrollable zone. */
+  user-select: none;
+  pointer-events: none; /* Ensures click-through! But apparently not touch-through. */
+  touch-action: none; /* Doesn't seem to allow touch-through, though - even with touch-action: none */
+                      /* https://stackoverflow.com/q/21474722 - poster never could find a solution, and settled*/
+                      /* on the same workaround:  a 'before' and 'after' piece instead of a single overlay.*/
+}
+
+.kmw-suggest-option::before {
+  background: linear-gradient(90deg, darkorange 0%, transparent 100%);
+  left: 0;
+}
+
+.kmw-suggest-option::after {
+  background: linear-gradient(90deg, transparent 0%, darkorange 100%);
+  right: 0;
+}
+
+/* Fallback suggestion-selection highlighting */
+.kmw-suggest-option.kmw-suggest-touched {
+  background: #bbb;
+}
+
+/* Creates a gradient to fade text at the borders, providing visual indication of overflow */
+/* Make sure the non-transparent color of the gradient matches .kmw-banner-bar's background-color. */
+.kmw-suggest-option.kmw-suggest-touched::before {
+  background: linear-gradient(90deg, #bbb 0%, transparent 100%);
+}
+
+.kmw-suggest-option.kmw-suggest-touched::after {
+  background: linear-gradient(90deg, transparent 0%, #bbb 100%);
+}
+
 .kmw-banner-bar .kmw-banner-separator {border-left: solid 1px #8a8d90; width: 0px; vertical-align: middle; height: 45%; display: inline-block;}
-.kmw-banner-bar .kmw-suggest-option {display:inline-block; text-align: center; height: 85%; overflow-x:hidden}
-.kmw-suggestion-text{color:#fff; line-height: normal; position: relative; vertical-align: middle;}
+.kmw-banner-bar .kmw-suggest-option {display:inline-block; text-align: center; height: 85%; position: relative; z-index: 11000}
+.kmw-suggestion-text {
+  color:#fff;
+  line-height: normal;
+  position: relative;
+  vertical-align: middle;
+  padding-left: 4px;   /* To prevent start & end of suggestion from being affected by gradient effects */
+  padding-right: 4px;  /* Set these to match scrollable-suggestion fade width set above. */
+  width: max-content;  /* Ensure the text span acts like it contains its text */
+  min-width: calc(100% - 8px); /* To ensure the span stays centered; also adjusts for scrollable-suggestion fade width. */
+  white-space: nowrap;
+}
+
+.kmw-suggestion-scroller {
+  overflow-x: auto;
+  width: 100%;
+  height: 100%;
+  scrollbar-width: none; /* Firefox */
+}
+
+.kmw-suggestion-scroller::-webkit-scrollbar {
+  display: none; /* Safari, Chrome, Chrome-based Edge */
+}
 
 .kmw-footer-resize{cursor:se-resize;position:absolute;right:2px;bottom:2px;width:16px;height:16px;overflow:hidden;
           font-family:SpecialOSK;color:white;}
 .kmw-footer-resize:hover{font-weight:bold;}
-.kmw-footer-resize:before {content:'\e023';}
+.kmw-footer-resize::before {content:'\e023';}
 
 .kmw-title-bar-image {cursor: default; float:right; padding: 2px 2px 0 0; width:16px; height:16px;
           font-family:SpecialOSK; color:white;}
 .kmw-title-bar-image:hover{font-weight:bold;}
-#kmw-pin-image:before{content:'\e024';}
-#kmw-config-image:before{content:'\e030';}
-#kmw-help-image:before{content:'\e042';}
-#kmw-close-button:before {content:'\e025';}
+#kmw-pin-image::before{content:'\e024';}
+#kmw-config-image::before{content:'\e030';}
+#kmw-help-image::before{content:'\e042';}
+#kmw-close-button::before {content:'\e025';}
 
 /* Common key appearance styles (can override with form-factor styles if necessary) */
 .kmw-key-default{color:#000;background-color:#eee;}
@@ -431,7 +555,7 @@ div.android div.kmw-keytip-cap {
 /* Box styles for keyboard-specific OSK (e.g. EuroLatin) and if no keyboard active (desktop only) */
 .kmw-osk-static, .kmw-osk-none{text-align:left;font:12px sans-serif;border:solid 1px #ad4a28;color:blue;background-color:white;}
 .kmw-osk-none{padding:4px 6px 6px}
-.kmw-osk-none:before{content:'Installing keyboard...';}
+.kmw-osk-none::before{content:'Installing keyboard...';}
 
 /* OSK language menu styles */
 #kmw-language-menu{position:fixed;left:0;width:232px;max-width:232px;z-index:10004;background-color:rgba(128,128,128,1);
@@ -519,7 +643,7 @@ div.android div.kmw-keytip-cap {
         border:3px solid #ad4a28;border-radius:8px;text-align:center;padding:0px;background:white;}
 .kmw-alert-close{float:right; height:24px; width:24px; font:1em bold Arial,sans-serif;color:#ad4a28;}
 /*.kmw-alert-close{float:right; height:24px; width:24px; font:2em bold Arial,sans-serif;color:#ad4a28;} */
-.kmw-alert-close:before{content:'\00d7'}
+.kmw-alert-close::before{content:'\00d7'}
 /*.kmw-alert-close{float:right;background:url('icons.gif') no-repeat -30px 0; height:13px; width:15px;}*/
 .kmw-wait-text{clear:both; margin:4px;white-space:nowrap;}
 .kmw-wait-graphic{width:100%;height:75%;background:url('ajax-loader.gif') no-repeat;background-position:center top;}


### PR DESCRIPTION
To help indicate that a suggestion is scrollable, and to provide better styling for overflowing suggestions, this PR adds a fade-out effect near the borders of long predictive-text suggestions:

**Before**:

![image](https://user-images.githubusercontent.com/25213402/207776009-75878c9b-c772-4986-bdb0-77dd7036e1b3.png)

**After**:

![image](https://user-images.githubusercontent.com/25213402/207776129-283b8e5f-86e3-4384-a4e8-49593ecbc976.png)

Note that this PR is based on the 📜 branch but is not part of it.  This PR should not be merged until that one is fully resolved.

TODO:  Unit tests:

- ensure that suggestions are still scrollable
- ensure that the new styling applies properly for both 'phone' and 'tablet' layouts for both mobile apps (Android, iOS)
    - Text fades out when touching borders
    - The "fade out" is clean - it fades to the suggestion's background color