### PR TITLE
fix(oem/fv/android): Cleanup version title

### DIFF
--- a/oem/firstvoices/android/app/src/main/res/values/strings.xml
+++ b/oem/firstvoices/android/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="dictionaries">Dictionaries</string>
     <string name="keyboard_settings">%1$s Settings</string>
     <string name="enable_keyboard">Enable keyboard</string>
-    <string name="keyboard_version">Version %1$s</string>
+    <string name="keyboard_version">Version</string>
 
     <!-- Context: KMP Package strings -->
     <string name="title_package_failed_to_install" comment="Error dialog title when package failed to install">Package %1$s failed to install</string>


### PR DESCRIPTION
Fixes #7905 

This removes the extraneous "$1%s" string on the version title of Keyboard List menu.

## User Testing
**Setup** - Install the PR build of FV for Android on an Android device/emulator of SDK 33.

* **TEST_KEYBOARD_INFO** - Verifies version string is fixed
1. Launch FV for Android
2. On the start page, click "Select keyboards" --> Select a region --> Select a keyboard --> Enable the keyboard
3. Return to the start page, click "Setup" --> Enable FirstVoices and choose FirstVoices as the current input method
4.  Launch a separate app (e.g. Chrome) and click on a text field
5. With the FV keyboard as a system keyboard, long-press the globe key to display the keyboard picker menu
6. On the keyboard picker menu, click the "i" icon to display the keyboard info
7. Verify the keyboard info menu is displayed
8. Verify the "version" subtitle has no extra characters

