### PR TITLE
fix(oem/fv/android): Add view permission of online help

### DIFF
--- a/oem/firstvoices/android/app/src/main/AndroidManifest.xml
+++ b/oem/firstvoices/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,12 @@
     <uses-permission android:name="android.permission.INTERNET" tools:node="replace" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVShared.java
@@ -43,7 +43,7 @@ final class FVShared {
     private FVRegionList regionList;
     private FVLoadedKeyboardList loadedKeyboards;
 
-    private static final String FVKeyboardHelpLink = "http://help.keyman.com/keyboard/";
+    private static final String FVKeyboardHelpLink = "https://help.keyman.com/keyboard/";
 
     public static final String FVDefault_PackageID = "fv_all";
     public static final String TAG = "FVShared";


### PR DESCRIPTION
Fixes #7907 and follow-on to #7897

On higher SDK versions of Android, the Manifest needs a query permission for the intent to launch.

[Reference](https://stackoverflow.com/questions/62535856/intent-resolveactivity-returns-null-in-api-30)

## User Testing
**Setup** - Install the PR build of FV for Android on an Android device/emulator of SDK version 33

* **TEST_HELP_LAUNCHES** - Verifies online help launches in a separate browser
1. Launch FV for Android
2. On the start page, click "Select keyboards" --> Select a region
3. On the keyboards list of the Region page, click on a question mark to display the online help
4. Verify a separate browser launches the keyboard  help page from help.keyman.com

