### PR TITLE
fix(linux): Fix dependency of ibus-keyman 🚑

### DIFF
--- a/linux/debian/libkmnkbp0-0.symbols
+++ b/linux/debian/libkmnkbp0-0.symbols
@@ -1,4 +1,4 @@
-libkmnkbp0.so.0 ibkmnkbp0-0 #MINVER#
+libkmnkbp0.so.0 libkmnkbp0-0 #MINVER#
 * Build-Depends-Package: libkmnkbp-dev
 
  kbp_state_get_intermediate_context@Base 15.0


### PR DESCRIPTION
When we added the API check we introduced a mis-spelled dependency which lead to Keyman being uninstallable. This change fixes things.

# User Testing

**TEST_INSTALLATION**: 
- It doesn't matter on which Linux platform these tests are run.
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Verify that there are no errors shown in the terminal window

