### PR TITLE
fix(linux): Fix dependency of ibus-keyman 🚑 🍒

### DIFF
--- a/linux/debian/libkmnkbp0-0.symbols
+++ b/linux/debian/libkmnkbp0-0.symbols
@@ -1,4 +1,4 @@
-libkmnkbp0.so.0 ibkmnkbp0-0 #MINVER#
+libkmnkbp0.so.0 libkmnkbp0-0 #MINVER#
 * Build-Depends-Package: libkmnkbp-dev
 
  kbp_state_get_intermediate_context@Base 15.0


### PR DESCRIPTION
When we added the API check we introduced a mis-spelled dependency which lead to Keyman being uninstallable. This change fixes things.

(🍒-picked from PR #7917)

@keymanapp-test-bot skip