### PR TITLE
chore(linux): Remove unused JENKINS parameter

### DIFF
--- a/linux/scripts/jenkins.sh
+++ b/linux/scripts/jenkins.sh
@@ -70,7 +70,7 @@ rm -rf $sourcedir/../${1}_*.{dsc,build,buildinfo,changes,tar.?z,log}
 
 echo_heading "Make source package for $fullsourcename"
 echo_heading "reconfigure"
-JENKINS="yes" TIER="$tier" ./scripts/reconf.sh $sourcename
+TIER="$tier" ./scripts/reconf.sh $sourcename
 
 echo_heading "Make origdist"
 ./scripts/dist.sh origdist $sourcename

--- a/linux/scripts/reconf.sh
+++ b/linux/scripts/reconf.sh
@@ -2,9 +2,8 @@
 
 # autoreconf autotool projects
 
-# parameters: [BUILD_LEGACY=1] [JENKINS="yes"] ./reconf.sh [proj]
+# parameters: [BUILD_LEGACY=1] ./reconf.sh [proj]
 # BUILD_LEGACY=1 to also build legacy KMFL projects
-# JENKINS="yes" to set version for jenkins builds
 # proj = only reconf this project
 
 set -e


### PR DESCRIPTION
This change removes the unused JENKINS environment variable from `reconf.sh`. The code got refactored some time ago to use the common scripts to retrieve the version. That made the JENKINS variable obsolete.

@keymanapp-test-bot skip