### PR TITLE
fix(developer): force ES3 code generation for LMs

### DIFF
--- a/developer/src/kmlmc/source/lexical-model-compiler/lexical-model-compiler.ts
+++ b/developer/src/kmlmc/source/lexical-model-compiler/lexical-model-compiler.ts
@@ -51,7 +51,7 @@ export default class LexicalModelCompiler {
         let filenames = modelSource.sources.map(filename => path.join(sourcePath, filename));
 
         let definitions = new ModelDefinitions(modelSource);
-        
+
         func += definitions.compileDefinitions();
 
         // Needs the actual searchTermToKey closure...
@@ -91,7 +91,10 @@ export default class LexicalModelCompiler {
 
   transpileSources(sources: Array<string>): Array<string> {
     return sources.map((source) => ts.transpileModule(source, {
-        compilerOptions: { module: ts.ModuleKind.None }
+        compilerOptions: {
+          target: ts.ScriptTarget.ES3,
+          module: ts.ModuleKind.None,
+        }
       }).outputText
     );
   };

--- a/developer/src/kmlmc/source/util/util.ts
+++ b/developer/src/kmlmc/source/util/util.ts
@@ -41,8 +41,8 @@ export function loadFromFilename(filename: string): LexicalModelSource {
   // NOTE: transpile module does a very simple TS to JS compilation.
   // It DOES NOT check for types!
   let compilationOutput = ts.transpile(sourceCode, {
-    // Our runtime should support ES6 with Node/CommonJS modules.
-    target: ts.ScriptTarget.ES2015,
+    // Our runtime only supports ES3 with Node/CommonJS modules on Android 5.0
+    target: ts.ScriptTarget.ES3,
     module: ts.ModuleKind.CommonJS,
   });
   // Turn the module into a function in which we can inject a global.

--- a/developer/src/kmlmc/source/util/util.ts
+++ b/developer/src/kmlmc/source/util/util.ts
@@ -41,7 +41,10 @@ export function loadFromFilename(filename: string): LexicalModelSource {
   // NOTE: transpile module does a very simple TS to JS compilation.
   // It DOES NOT check for types!
   let compilationOutput = ts.transpile(sourceCode, {
-    // Our runtime only supports ES3 with Node/CommonJS modules on Android 5.0
+    // Our runtime only supports ES3 with Node/CommonJS modules on Android 5.0.
+    // When we drop Android 5.0 support, we can update this to a `ScriptTarget` 
+    // matrix against target version of Keyman, here and in 
+    // lexical-model-compiler.ts.
     target: ts.ScriptTarget.ES3,
     module: ts.ModuleKind.CommonJS,
   });


### PR DESCRIPTION
Fixes #7926.

Android 5.0 (Chrome 37) only supports ES3. Thus, we should transpile our lexical models to ES3 rather than ES2015, for now at least.

For example, this forces constructs such as `const` to be replaced with `var`.

@keymanapp-test-bot skip

(I have verified that the code generation is correct; this will require version bumps on all affected LMs in order to deploy an updated version with the new version of the compiler once it lands.)