### PR TITLE
fix(windows): shutdown fix masked modal result 🔥 🍒

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmWebContainer.pas
+++ b/windows/src/desktop/kmshell/main/UfrmWebContainer.pas
@@ -60,6 +60,7 @@ type
     FDialogName: WideString;
     FCanClose: Boolean;
     FIsClosing: Boolean;
+    FLastModalResult: Integer;
     procedure WMUser_FormShown(var Message: TMessage); message WM_USER_FormShown;
     procedure WMUser_ContentRender(var Message: TMessage); message WM_USER_ContentRender;
     procedure WMSysCommand(var Message: TWMSysCommand); message WM_SYSCOMMAND;
@@ -189,6 +190,7 @@ begin
     begin
       FIsClosing := True;
       Result := FInitializeCEF.StartShutdown(CEFShutdownComplete);
+      FLastModalResult := ModalResult;
     end
     else
       Result := FCanClose;
@@ -199,7 +201,9 @@ procedure TfrmWebContainer.CEFShutdownComplete(Sender: TObject);
 begin
 //  OutputDebugString(PChar('TfrmKeymanDeveloper.CEFShutdownComplete'));
   FCanClose := True;
-  Close;
+  if FLastModalResult <> 0
+    then ModalResult := FLastModalResult
+    else Close;
 end;
 
 


### PR DESCRIPTION
Cherry-pick of #7932.

Regression introduced in #7661 (17.0 alpha), #7825 (16.0 beta).

When shutting down CEF cleanly, we needed to pause the form destruction sequence in order for CEF to complete its shutdown tasks. However, for a dialog form, it will commonly be closed by setting `ModalResult` to a non-zero value. In our fix, we inadvertently lost any `ModalResult` value by calling `Close` after CEF was finished, which sets `ModalResult` to `mrCancel` (value of 2).

This fix caches the `ModalResult` value, and if non-zero, uses it instead after CEF shuts down, to achieve the same result.

# User Testing

**TEST_START_KEYMAN:** Do a clean install of Keyman for Windows, and verify that the Start Keyman button in the Splash screen actually starts Keyman.
**TEST_STOP_KEYMAN:** Select Exit Keyman from the Keyman tray icon, and verify that the OK button in the "Exit Keyman" dialog that appears actually does exit Keyman.