### PR TITLE
fix(windows): modifer event is always serialized

### DIFF
--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -226,7 +226,6 @@ LRESULT _kmnLowLevelKeyboardProc(
   // any additional processing or other serialization of the input queue.
   if (isModifierKey(hs->vkCode) && flag_ShouldSerializeInput) {
       PostMessage(ISerialKeyEventServer::GetServer()->GetWindow(), WM_KEYMAN_MODIFIER_EVENT, hs->vkCode, LLKHFFlagstoWMKeymanKeyEventFlags(hs));
-    }
   }
 
   if(IsLanguageSwitchWindowVisible()) {

--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -59,6 +59,22 @@ LRESULT CALLBACK kmnLowLevelKeyboardProc(
   return res;
 }
 
+BOOL isModifierKey(DWORD vkCode) {
+  switch (vkCode) {
+    case VK_LCONTROL:
+    case VK_RCONTROL:
+    case VK_CONTROL:
+    case VK_LMENU:
+    case VK_RMENU:
+    case VK_MENU:
+    case VK_LSHIFT:
+    case VK_RSHIFT:
+    case VK_SHIFT:
+      return TRUE;
+  }
+  return FALSE;
+}
+
 BOOL KeyLanguageSwitchPress(WPARAM wParam, BOOL extended, BOOL isUp, DWORD ShiftState);
 int ProcessLanguageSwitchShiftKey(WPARAM wParam, BOOL isUp);
 BOOL IsLanguageSwitchWindowVisible();
@@ -201,12 +217,14 @@ LRESULT _kmnLowLevelKeyboardProc(
   if(Flag != 0) {
     if(isUp) FHotkeyShiftState &= ~Flag;
     else FHotkeyShiftState |= Flag;
-    // #7337 Post the modifier state ensuring the serialized queue is in sync
-    // Note that the modifier key may be posted again with WM_KEYMAN_KEY_EVENT,
-    // later in this function. This is intentional, as the WM_KEYMAN_MODIFIER_EVENT 
-    // message only updates our internal modifier state, and does not do 
-    // any additional processing or other serialization of the input queue.
-    if (flag_ShouldSerializeInput) {
+  }
+
+  // #7337 Post the modifier state ensuring the serialized queue is in sync
+  // Note that the modifier key may be posted again with WM_KEYMAN_KEY_EVENT,
+  // later in this function. This is intentional, as the WM_KEYMAN_MODIFIER_EVENT
+  // message only updates our internal modifier state, and does not do
+  // any additional processing or other serialization of the input queue.
+  if (isModifierKey(hs->vkCode) && flag_ShouldSerializeInput) {
       PostMessage(ISerialKeyEventServer::GetServer()->GetWindow(), WM_KEYMAN_MODIFIER_EVENT, hs->vkCode, LLKHFFlagstoWMKeymanKeyEventFlags(hs));
     }
   }


### PR DESCRIPTION
Fixes #7716 

PR #7449 added a `modifier event` to make ensure modifier events
were sent to the serializer even if the keystroke was determined
not to need serializing. However, a logic error was made
trying to use the existing 'Flag' however this was not set in the
!UseCachedHotkeyModifierState case. This change adds a helper function
to simply check if the key is a modifier key and send it to the
event serializer in that case. Separating from the other logic which
is more concerned with handling hotkeys.

PR #7779  was used in this investigation. The extra logging enabled the observation that modifier event was not being sent when not using cached hotkeys.  It also showed that for some users when cycling through the open applications using `ALT` + `Tab`  the initial pressing of  `ALT` is seen when a Keyman Keyboard is active. However, the release of the `ALT` is seen when a Keyman Keyboard is not active.  This was actually what was predicted back in the original #7449 fix but we were not able to confirm. So the extra logging has helped verify this. 
`ALT` down keyman keyboard is active so keyevent is sent through
![alt_down](https://user-images.githubusercontent.com/58423624/208828720-3ae6447a-4005-479d-82c7-f5d17a977448.png)

`ALT` key up keyman keyboard is not active so the keyevent is not sent through, just the modify event. 
![ALT_UP](https://user-images.githubusercontent.com/58423624/208828820-cb6b92fb-f55a-424d-b9b4-2b718ece870a.png)


# User Testing

This PR changes code around modifier keys. Therefore the tests need to cover interactions around these keys being pressed.

**GROUP_WIN10**  - Run the tests in a Windows 10 OS
**GROUP_WIN11** - Run the tests in Windows 11 OS

**TEST_ALTGR_IN_RULES** 
This is to test the key rules which contain <kbd>AltGr</kbd> or <kbd>Shift</kbd> + <kbd>AltGr</kbd> still work correctly.

* Load a keyboard `khmer_angkor` 
* Open LibreOffice or Notepad 
* Type a <kbd>AltGr</kbd> + <kbd>o</kbd> 
* Observe output of  ឱ​

* Type a <kbd>Shift</kbd> + <kbd>AltGr</kbd> + <kbd>o</kbd> 
* Observe output of ᧨


**TEST_HOTKEYS**
This is to test switching between non-keyman and keyman keyboards using hotkeys. To make sure this PR has not broken Hotkeys that use modifiers 
* Install two different keyman keyboards in addition to the default for the Windows installation.
* Use the Keyman Configuration to assign hotkeys to the default Keyboard as well as the two Keyman Keyboards that use modifiers for the hotkey for example <kbd>Ctrl</kbd> + <kbd>1</kbd>  or <kbd>Alt</kbd> + <kbd>K</kbd>
* Open Notepad 
* Use the hotkeys to switch between keyboards
* Verify that switching between the keyboards is working


**TEST_HOTKEYS_SWITCH_APPS** 
This extends the previous test to test switching between non-keyman and keyman keyboards using hotkeys and also using <kbd>Alt</kbd> + <kbd>Tab</kbd> to switch applications.
* Install two different keyman keyboards in addition to the default for the Windows installation.
* Use the Keyman Configuration to assign hotkeys to the default Keyboard as well as the two Keyman Keyboards
* Open two text input applications for example Libre Office and Notepad.
* Turn on the OSK keyboard
* Open Libre Office and select the default Keyboard with the Hotkeys type some text.
* Use <kbd>Alt</kbd> + <kbd>Tab</kbd> to switch to NotePad
* Use the Hotkeys to switch to a Keyman Keyboard and observe you can use that keyboard.
* Observe that on the <kbd>Alt</kbd> is not pressed down "stuck" on.
* Use the HotKeys to switch to the second Keyman keyboard
* Use <kbd>Alt</kbd> + <kbd>Tab</kbd> to switch to LibreOffice
* Type and observe the keyboard works correctly 
* Observe that the <kbd>Alt</kbd>does not get stuck
* Try a combination of switching between keyboards and applications. Pressing different modifier keys etc.
* We want to make use the ALT Key or any other modifier key does not stay down - become stuck.

**TEST_WIN_EMOJI_INPUT** 

* Start Keyman
* Select a non-keyman keyboard
* Open Notepad 
* Type some text on the physical keyboard. 
* Press the <kbd>&#x229E; Win</kbd> + <kbd>.</kbd> to bring up the emoji and gif window.
* In the search box type some characters.
* Does it allow input into the emoji panels text field? Verify that input still works and is not completely blocked.