### PR TITLE
fix(oem/fv/android): Fix keyboard version title (again)

### DIFF
--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
@@ -163,7 +163,7 @@ public final class FVKeyboardSettingsActivity extends AppCompatActivity {
     fvKeyboardTextView = (TextView) layout.findViewById(R.id.text1);
     fvKeyboardTextView.setText(getString(R.string.enable_keyboard));
     fvVersionTextView = (TextView) layout.findViewById(R.id.text2);
-    fvVersionTextView.setText(String.format(getString(R.string.keyboard_version2), version));
+    fvVersionTextView.setText(String.format(getString(R.string.fv_keyboard_version), version));
     fvKeyboardToggle = layout.findViewById(R.id.toggle);
     fvKeyboardToggle.setChecked(KeyboardController.getInstance().keyboardExists(FVShared.FVDefault_PackageID, kbId, null));
     fvKeyboardToggle.setOnClickListener(new View.OnClickListener() {

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
@@ -163,7 +163,7 @@ public final class FVKeyboardSettingsActivity extends AppCompatActivity {
     fvKeyboardTextView = (TextView) layout.findViewById(R.id.text1);
     fvKeyboardTextView.setText(getString(R.string.enable_keyboard));
     fvVersionTextView = (TextView) layout.findViewById(R.id.text2);
-    fvVersionTextView.setText(String.format(getString(R.string.keyboard_version), version));
+    fvVersionTextView.setText(String.format(getString(R.string.keyboard_version2), version));
     fvKeyboardToggle = layout.findViewById(R.id.toggle);
     fvKeyboardToggle.setChecked(KeyboardController.getInstance().keyboardExists(FVShared.FVDefault_PackageID, kbId, null));
     fvKeyboardToggle.setOnClickListener(new View.OnClickListener() {

--- a/oem/firstvoices/android/app/src/main/res/values/strings.xml
+++ b/oem/firstvoices/android/app/src/main/res/values/strings.xml
@@ -7,8 +7,7 @@
     <string name="dictionaries">Dictionaries</string>
     <string name="keyboard_settings">%1$s Settings</string>
     <string name="enable_keyboard">Enable keyboard</string>
-    <string name="keyboard_version">Version</string>
-    <string name="keyboard_version2">Version %1$s</string>
+    <string name="fv_keyboard_version">Version %1$s</string>
 
     <!-- Context: KMP Package strings -->
     <string name="title_package_failed_to_install" comment="Error dialog title when package failed to install">Package %1$s failed to install</string>

--- a/oem/firstvoices/android/app/src/main/res/values/strings.xml
+++ b/oem/firstvoices/android/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="keyboard_settings">%1$s Settings</string>
     <string name="enable_keyboard">Enable keyboard</string>
     <string name="keyboard_version">Version</string>
+    <string name="keyboard_version2">Version %1$s</string>
 
     <!-- Context: KMP Package strings -->
     <string name="title_package_failed_to_install" comment="Error dialog title when package failed to install">Package %1$s failed to install</string>


### PR DESCRIPTION
Fixes #7939 and follow-on to #7908

It turned out the we need two keyboard version strings
* one with a version number (on the keyboard enable page)
* one without a version number (on the keyboard info page - "i" from the keyboard picker menu)

## User Testing - Verifies the version title is fine on both menus
**Setup** - Install the PR build of "FV for Android" on an Android device/emulator

* **TEST_VERSION_STRINGS** - Verifies version strings are correct
1. Launch FV for Android
2. On the setup page, click "Select keyboards" --> BC Coast --> Diidiitidq
3. On the "Diidiitidq Settings" page, verify the version subtitle appears with a valid keyboard version
![settings page](https://user-images.githubusercontent.com/7358010/208863682-a288b95c-e4fc-416d-bc98-f18ff729df34.png)
4. Enable the keyboard and return to the setup page
5. On the setup page, click "Setup" --> Enable FirstVoices and choose FirstVoices as the current input method
6. On the device, launch a separate app (e.g. Chrome browser)
7. Launch a separate app (e.g. Chrome) and click on a text field
8. With the FV keyboard as a system keyboard, long-press the globe key to display the keyboard picker menu
9. On the keyboard picker menu, click the "i" icon to display the keyboard info
10. Verify the keyboard info menu is displayed
11. Verify the "version" subtitle has no extra characters (the version number is underneath)
![keyboard info](https://user-images.githubusercontent.com/7358010/208863867-be389118-debd-4716-94e1-ece0810899b5.png)
