### PR TITLE
fix(core): ldml: fix spelling of maqtugħa 🙀

### DIFF
--- a/common/web/types/test/fixtures/invalid-conforms-to.xml
+++ b/common/web/types/test/fixtures/invalid-conforms-to.xml
@@ -12,7 +12,7 @@
   </names>
 
   <keys>
-    <key id="hmaqtua" to="ħ" />
+    <key id="hmaqtugha" to="ħ" />
     <key id="that" to="ថា" />
   </keys>
 

--- a/core/src/kmx/kmx_plus.cpp
+++ b/core/src/kmx/kmx_plus.cpp
@@ -378,6 +378,7 @@ COMP_KMXPLUS_LAYR_Helper::setLayr(const COMP_KMXPLUS_LAYR *newLayr) {
     is_valid = false;
     return false;
   }
+  layr = newLayr;
   const uint8_t *rawdata = reinterpret_cast<const uint8_t *>(this);
   rawdata += LDML_LENGTH_LAYR;  // skip past non-dynamic portion
   // lists
@@ -532,10 +533,10 @@ kmx_plus::kmx_plus(const COMP_KEYBOARD *keyboard, size_t length)
     // these will be nullptr if they don't validate
     disp = section_from_sect<COMP_KMXPLUS_DISP>(sect);
     elem = section_from_sect<COMP_KMXPLUS_ELEM>(sect);
-    // TODO-LDML: // key2 = section_from_sect<COMP_KMXPLUS_KEY2>(sect);
+    key2 = section_from_sect<COMP_KMXPLUS_KEY2>(sect);
     keys = section_from_sect<COMP_KMXPLUS_KEYS>(sect);
-    // TODO-LDML: // layr = section_from_sect<COMP_KMXPLUS_LAYR>(sect);
-    // TODO-LDML: // list = section_from_sect<COMP_KMXPLUS_LIST>(sect);
+    layr = section_from_sect<COMP_KMXPLUS_LAYR>(sect);
+    list = section_from_sect<COMP_KMXPLUS_LIST>(sect);
     loca = section_from_sect<COMP_KMXPLUS_LOCA>(sect);
     meta = section_from_sect<COMP_KMXPLUS_META>(sect);
     strs = section_from_sect<COMP_KMXPLUS_STRS>(sect);

--- a/core/tests/unit/kmnkbd/test_kmx_xstring.cpp
+++ b/core/tests/unit/kmnkbd/test_kmx_xstring.cpp
@@ -1242,8 +1242,8 @@ test_utf32() {
 
   assert(Uni_IsBMP(u295));
 
-  const char16_t hmaqtua = Uni_UTF32BMPToUTF16(u295);
-  assert(hmaqtua == 0x0127);
+  const char16_t hmaqtugha = Uni_UTF32BMPToUTF16(u295);
+  assert(hmaqtugha == 0x0127);
 
   char16_single c0;
   int l0 = Utf32CharToUtf16(u295, c0);

--- a/core/tests/unit/ldml/keyboards/k_001_tiny.xml
+++ b/core/tests/unit/ldml/keyboards/k_001_tiny.xml
@@ -17,13 +17,13 @@
   </names>
 
   <keys>
-    <key id="hmaqtua" to="ħ" />
+    <key id="hmaqtugha" to="ħ" />
     <key id="that" to="ថា" />
   </keys>
 
   <layers form="hardware">
     <layer id="base">
-      <row keys="hmaqtua that" /> <!-- number row -->
+      <row keys="hmaqtugha that" /> <!-- number row -->
     </layer>
   </layers>
 </keyboard>

--- a/core/tests/unit/ldml/keyboards/k_002_tinyu32.xml
+++ b/core/tests/unit/ldml/keyboards/k_002_tinyu32.xml
@@ -15,14 +15,14 @@
   </names>
 
   <keys>
-    <key id="hmaqtua" to="ħ" />
+    <key id="hmaqtugha" to="ħ" />
     <key id="that" to="ថា" />
     <key id="screamcat" to="🙀" />
   </keys>
 
   <layers form="hardware">
     <layer id="base">
-      <row keys="hmaqtua that screamcat" /> <!-- number row -->
+      <row keys="hmaqtugha that screamcat" /> <!-- number row -->
     </layer>
   </layers>
 </keyboard>

--- a/developer/src/kmc-keyboard/test/fixtures/basic.txt
+++ b/developer/src/kmc-keyboard/test/fixtures/basic.txt
@@ -280,7 +280,7 @@ block(key2)                         # struct COMP_KMXPLUS_KEY2 {
   00 00 00 00                       #   KMX_DWORD vkey
   index(strNull,strKey1,2)          #   KMXPLUS_STR 'U+0127'
   01 00 00 00                       #   KMX_DWORD (flags: extend)
-  index(strNull,strHmaqtugha,2)       #   KMXPLUS_STR 'hmaqtugha'
+  index(strNull,strHmaqtugha,2)     #   KMXPLUS_STR 'hmaqtugha'
   00 00 00 00                       #   KMXPLUS_STR switch
   0A 00 00 00                       #   KMX_DWORD width*10
   01 00 00 00 # TODO: index(listNull,indexAe,4)         #   LIST longPress 'a e'
@@ -354,7 +354,7 @@ block(layr)                         # struct COMP_KMXPLUS_LAYR {
   00 00 00 00                       #   KMX_DWORD key index
   02 00 00 00                       #   KMX_DWORD count
   # keys
-  index(strNull,strHmaqtugha,2)       #   KMXPLUS_STR locale;       // 'hmaqtugha'
+  index(strNull,strHmaqtugha,2)     #   KMXPLUS_STR locale;       // 'hmaqtugha'
   index(strNull,strThat,2)          #   KMXPLUS_STR locale;       // 'that'
 
 # ----------------------------------------------------------------------------------------------------

--- a/developer/src/kmc-keyboard/test/fixtures/basic.txt
+++ b/developer/src/kmc-keyboard/test/fixtures/basic.txt
@@ -276,11 +276,11 @@ block(key2)                         # struct COMP_KMXPLUS_KEY2 {
   00 00 00 00                       #   KMX_DWORD flickCount
   00 00 00 00  00 00 00 00  00 00 00 00 # Reserved[3]
   # keys
-  #  hmaqtua
+  #  hmaqtugha
   00 00 00 00                       #   KMX_DWORD vkey
   index(strNull,strKey1,2)          #   KMXPLUS_STR 'U+0127'
   01 00 00 00                       #   KMX_DWORD (flags: extend)
-  index(strNull,strHmaqtua,2)       #   KMXPLUS_STR 'hmaqtua'
+  index(strNull,strHmaqtugha,2)       #   KMXPLUS_STR 'hmaqtugha'
   00 00 00 00                       #   KMXPLUS_STR switch
   0A 00 00 00                       #   KMX_DWORD width*10
   01 00 00 00 # TODO: index(listNull,indexAe,4)         #   LIST longPress 'a e'
@@ -291,7 +291,7 @@ block(key2)                         # struct COMP_KMXPLUS_KEY2 {
   00 00 00 00                       #   KMX_DWORD vkey
   index(strNull,strKey2,2)          #   KMXPLUS_STR 'U+0127'
   01 00 00 00                       #   KMX_DWORD flags = extend
-  index(strNull,strThat,2)          #   KMXPLUS_STR 'hmaqtua'
+  index(strNull,strThat,2)          #   KMXPLUS_STR 'hmaqtugha'
   00 00 00 00                       #   KMXPLUS_STR switch
   0A 00 00 00                       #   KMX_DWORD width*10
   00 00 00 00 # TODO: index(listNull,listNull,4)        #   LIST longPress
@@ -354,7 +354,7 @@ block(layr)                         # struct COMP_KMXPLUS_LAYR {
   00 00 00 00                       #   KMX_DWORD key index
   02 00 00 00                       #   KMX_DWORD count
   # keys
-  index(strNull,strHmaqtua,2)       #   KMXPLUS_STR locale;       // 'hmaqtua'
+  index(strNull,strHmaqtugha,2)       #   KMXPLUS_STR locale;       // 'hmaqtugha'
   index(strNull,strThat,2)          #   KMXPLUS_STR locale;       // 'that'
 
 # ----------------------------------------------------------------------------------------------------
@@ -462,7 +462,7 @@ block(strs)                         #  struct COMP_KMXPLUS_STRS {
   diff(strs,strElemTranFrom2)   sizeof(strElemTranFrom2,2)
   diff(strs,strBase)   sizeof(strBase,2)
   diff(strs,strElemBkspFrom2) sizeof(strElemBkspFrom2,2)
-  diff(strs,strHmaqtua) sizeof(strHmaqtua,2)
+  diff(strs,strHmaqtugha) sizeof(strHmaqtugha,2)
   diff(strs,strLocale)     sizeof(strLocale,2)
   diff(strs,strLayout)     sizeof(strLayout,2)
   diff(strs,strAuthor)     sizeof(strAuthor,2)
@@ -490,7 +490,7 @@ block(strs)                         #  struct COMP_KMXPLUS_STRS {
   block(strElemTranFrom2)    61 00 block(x) 00 00                                       # 'a'
   block(strBase)             62 00 61 00 73 00 65 00 block(x) 00 00                     # 'base'
   block(strElemBkspFrom2)    65 00 block(x) 00 00                                       # 'e'
-  block(strHmaqtua)          68 00 6d 00 61 00 71 00 74 00 75 00 61 00 block(x) 00 00   # 'hmaqtua'
+  block(strHmaqtugha)        68 00 6d 00 61 00 71 00 74 00 75 00 67 00 68 00 61 00 block(x) 00 00   # 'hmaqtugha'
   block(strLocale)           6d 00 74 00   block(x) 00 00                               # 'mt'
   block(strLayout)           71 00 77 00 65 00 72 00 74 00 79 00   block(x) 00 00       # 'qwerty'
   block(strAuthor)           73 00 72 00 6c 00 32 00 39 00 35 00   block(x) 00 00       # 'srl295'

--- a/developer/src/kmc-keyboard/test/fixtures/basic.xml
+++ b/developer/src/kmc-keyboard/test/fixtures/basic.xml
@@ -25,13 +25,13 @@
   </displays>
 
   <keys>
-    <key id="hmaqtua" to="ħ" longPress="a e" />
+    <key id="hmaqtugha" to="ħ" longPress="a e" />
     <key id="that" to="ថា" />
   </keys>
 
   <layers form="hardware" hardware="us" minDeviceWidth="123">
     <layer id="base">
-      <row keys="hmaqtua that" />
+      <row keys="hmaqtugha that" />
     </layer>
   </layers>
 


### PR DESCRIPTION
- maqtua should be maqtugħa (cut) but spelled as maqtugha where used as an NMTOKEN

@keymanapp-test-bot skip

-----

Minor, just an embarrassing typo…