### PR TITLE
docs(linux): document fullbuild using docker

### DIFF
--- a/docs/build/linux-ubuntu.md
+++ b/docs/build/linux-ubuntu.md
@@ -78,9 +78,24 @@ docker build . -t keymanapp/keyman-linux-builder:latest
 
 Once the image is built, it may be used to build parts of Keyman.
 
+- core
+
 ```shell
+# build 'core' in docker
 cd ../core
 # keep linux build artifacts separate
 mkdir -p build/linux
 docker run -it --rm -v $(pwd)/..:/home/build -v $(pwd)/build/linux:/home/build/core/build keyman-linux-builder:latest bash -c 'cd core; bash build.sh -d'
 ```
+
+- linux
+
+```shell
+# build 'linux' installation in docker
+# runs as root!
+# note: run 'git clean -fdx linux' afterwards to cleanup
+cd keymanapp/keyman
+docker run -it --rm -v $(pwd):/home/build/src/keyman -u root -w /home/build/src/keyman keymanapp/keyman-linux-builder:latest bash -c "cd linux && make reconf && make fullbuild && make install"
+```
+
+


### PR DESCRIPTION
Follow-on to #7102 

Document how to do a full linux build in docker.

Note: instructions will fail until #7958 is merged due to ibus dep

@keymanapp-test-bot skip