### PR TITLE
fix(common): update USVirtualKeyMap to actually be US🙀

### DIFF
--- a/common/web/types/src/consts/virtual-key-constants.ts
+++ b/common/web/types/src/consts/virtual-key-constants.ts
@@ -136,8 +136,27 @@ export const USVirtualKeyMap: number[][] = [
   [ k.K_Q, k.K_W, k.K_E, k.K_R, k.K_T, k.K_Y, k.K_U, k.K_I, k.K_O, k.K_P, k.K_LBRKT, k.K_RBRKT, k.K_BKSLASH ],
   // [caps] A S D F G H J K L ; ' [enter]
   [ k.K_A, k.K_S, k.K_D, k.K_F, k.K_G, k.K_H, k.K_J, k.K_K, k.K_L, k.K_COLON, k.K_QUOTE ],
+  // [shift] Z X C V B N M , . / [shift] *=oE2
+  [ k.K_Z, k.K_X, k.K_C, k.K_V, k.K_B, k.K_N, k.K_M, k.K_COMMA, k.K_PERIOD, k.K_SLASH ],
+  // space
+  [ k.K_SPACE ],
+];
+
+/**
+ * TODO-LDML: WIP ISO layout for #7965
+ * May not be correct to use US codes?
+ */
+export const ISOVirtualKeyMap: number[][] = [
+  // ` 1 2 3 4 5 6 7 8 9 0 - = [bksp]
+  [ k.K_BKQUOTE, k.K_1, k.K_2, k.K_3, k.K_4, k.K_5, k.K_6, k.K_7, k.K_8, k.K_9, k.K_0, k.K_HYPHEN, k.K_EQUAL ],
+  // [tab] Q W E R T Y U I O P [ ]
+  [ k.K_Q, k.K_W, k.K_E, k.K_R, k.K_T, k.K_Y, k.K_U, k.K_I, k.K_O, k.K_P, k.K_LBRKT, k.K_RBRKT  ],
+  // [caps] A S D F G H J K L ; ' \ [enter]
+  [ k.K_A, k.K_S, k.K_D, k.K_F, k.K_G, k.K_H, k.K_J, k.K_K, k.K_L, k.K_COLON, k.K_QUOTE, k.K_BKSLASH ],
   // [shift] * Z X C V B N M , . / [shift] *=oE2
-  [ k.K_oE2, k.K_Z, k.K_X, k.K_C, k.K_V, k.K_B, k.K_N, k.K_M, k.K_COMMA, k.K_PERIOD, k.K_SLASH ]
+  [ k.K_oE2, k.K_Z, k.K_X, k.K_C, k.K_V, k.K_B, k.K_N, k.K_M, k.K_COMMA, k.K_PERIOD, k.K_SLASH ],
+  // space
+  [ k.K_SPACE ],
 ];
 
 /**

--- a/core/tests/unit/ldml/keyboards/k_003_transform.xml
+++ b/core/tests/unit/ldml/keyboards/k_003_transform.xml
@@ -49,7 +49,6 @@ Note: keys should start with [K_A][K_B][K_C] not [K_Y] when transforms are funct
     <key id="y" to="y" />
     <key id="z" to="z" />
     <key id="bquote" to="`"/>
-    <key id="backslash" to="\u{005c}"/>
   </keys>
 
   <layers form="hardware" hardware="us">
@@ -57,8 +56,8 @@ Note: keys should start with [K_A][K_B][K_C] not [K_Y] when transforms are funct
       <row keys="space" /> <!-- number row -->
       <row keys="q w e r t y u i o p" />
       <row keys="a s d f g h j k l" />
-      <row keys="backslash z x c v b n m" />
-      <!-- <row keys="space" /> --> <!-- Bug: 5 rows is 'too many'? -->
+      <row keys="z x c v b n m" />
+      <row keys="space" />
     </layer>
   </layers>
 

--- a/core/tests/unit/ldml/keyboards/k_010_mt.xml
+++ b/core/tests/unit/ldml/keyboards/k_010_mt.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+@@keys: [K_B][K_O][K_N][K_LBRKT][K_U][K_SPACE][K_S][K_A][K_RBRKT][K_RBRKT][K_A]
+@@expected: \u0062\u006f\u006e\u0121\u0075\u0020\u0073\u0061\u0127\u0127\u0061
+
+Note:
+    "bonġu saħħa".split('').map(s=>`\\u${s.codePointAt(0).toString(16)}`).join('')
+Gets part of the way,
+
+    Based on mt.xml from CLDR.  'TODO-LDML' denotes modifications.
+    Note this is the 47-key version.
+-->
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+    <locales>
+        <!-- English is also an official language in Malta.-->
+        <locale id="en" />
+    </locales>
+    <info author="Steven R. Loomis" normalization="NFC" layout="QWERTY" indicator="MT" />
+
+    <names>
+        <name value="Maltese (47-key)" />
+        <!-- <name value="MSA 100:2002" /> -->
+    </names>
+
+    <keys>
+        <!-- imports -->
+        <!-- TODO-LDML: Added next: see #7964 -->
+        <import base="cldr" path="techpreview/keys-Latn-implied.xml"/>
+        <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml"/>
+        <!-- TODO-LDML: Added next: see #7964 -->
+        <key id="space" to=" " width="5" />
+        <!-- TODO-LDML: added next -->
+        <key id="asterisk" to="*" />
+        <!-- accent grave -->
+        <key id="a-grave" to="à" />
+        <key id="A-grave" to="À" />
+        <key id="e-grave" to="è" />
+        <key id="E-grave" to="È" />
+        <key id="i-grave" to="ì" />
+        <key id="I-grave" to="Ì" />
+        <key id="o-grave" to="ò" />
+        <key id="O-grave" to="Ò" />
+        <key id="u-grave" to="ù" />
+        <key id="U-grave" to="Ù" />
+
+        <!-- tikka and maqtua -->
+        <key id="c-tikka" to="ċ" />
+        <key id="C-tikka" to="Ċ" />
+        <key id="g-tikka" to="ġ" />
+        <key id="G-tikka" to="Ġ" />
+        <key id="h-maqtugha" to="ħ" /> <!-- maqtugħa, i.e. cut -->
+        <key id="H-maqtugha" to="Ħ" /> <!-- maqtugħa, i.e. cut -->
+        <key id="z-tikka" to="ż" />
+        <key id="Z-tikka" to="Ż" />
+
+        <!-- Cedilla -->
+        <key id="c-cedilla" to="ç" />
+
+        <!-- gaps -->
+        <key id="gap" gap="true" width="1" />
+    </keys>
+
+
+    <!-- TODO-LDML: This has been modified to be the US 47-key format.
+        See MSA 100:2002, Appendix, figure A.1 -->
+
+    <layers form="hardware" hardware="us">
+        <layer modifier="none">
+            <row keys="c-tikka 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+            <row keys="q w e r t y u i o p g-tikka h-maqtugha z-tikka" />
+            <row keys="a s d f g h j k l semi-colon apos" />
+            <row keys="z x c v b n m comma period slash" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifier="shift">
+            <row keys="C-tikka bang at euro dollar percent caret amp asterisk open-paren close-paren underscore plus" />
+            <row keys="Q W E R T Y U I O P G-tikka H-maqtugha Z-tikka" />
+            <row keys="A S D F G H J K L colon double-quote" />
+            <row keys="Z X C V B N M open-angle close-angle question" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifier="altR">
+            <row keys="grave gap gap pound gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap e-grave gap gap gap u-grave i-grave o-grave gap open-square close-square backslash" />
+            <row keys="a-grave gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifier="altR-shift">
+            <row keys="tilde gap gap gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap E-grave gap gap gap U-grave I-grave O-grave gap open-curly close-curly pipe" />
+            <row keys="A-grave gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="space" />
+        </layer>
+    </layers>
+</keyboard>

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -10,6 +10,10 @@ tests = [
   'k_001_tiny',
   'k_002_tinyu32',
   'k_003_transform',
+  'k_010_mt',
+  'k_100_keytest',
+  'k_101_keytest',
+  'k_102_keytest',
 ]
 
 # Setup kmc

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -10,10 +10,8 @@ tests = [
   'k_001_tiny',
   'k_002_tinyu32',
   'k_003_transform',
-  'k_010_mt',
-  'k_100_keytest',
-  'k_101_keytest',
-  'k_102_keytest',
+# TODO-LDML: depends on implied keys
+#  'k_010_mt',
 ]
 
 # Setup kmc

--- a/developer/src/kmc-keyboard/test/fixtures/sections/keys/invalid-hardware-too-many-rows.xml
+++ b/developer/src/kmc-keyboard/test/fixtures/sections/keys/invalid-hardware-too-many-rows.xml
@@ -18,7 +18,7 @@
       <row keys="Q W" />
       <row keys="Q W" />
       <row keys="Q W" />
-      <row keys="Q W" />
+      <row keys="Q" />  <!-- space row -->
       <row keys="Q W" />
     </layer>
   </layers>


### PR DESCRIPTION
comon/web/types:
- the USVirtualKeyMap was actually somewhat ISO-ish. Correct it.
- also, add the spacebar row.
- create a new ISOVirtualKeyMap, but not linked in anywhere.

core/tests:
- add a new test keyboard, k_010_mt.xml which is Maltese 47-key
- update k_003 which was impacted by this

For: #7965

@keymanapp-test-bot skip