### PR TITLE
chore(common): Add crowdin strings for Kannada

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values-kn-rIN/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-kn-rIN/strings.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- app_name removed in 16.0 beta. Set in build.gradle -->
+  <!-- Context: Menu Action -->
+  <string name="action_share" comment="Menu action to send text content to another app">ಹಂಚಿಕೊಳ್ಳಿ</string>
+  <!-- Context: Menu Action -->
+  <string name="action_web" comment="Menu action to open Keyman browser">ವೆಬ್ ಬ್ರೌಸರ್</string>
+  <!-- Context: Menu Action -->
+  <string name="action_text_size" comment="Menu action to adjust text size">ಅಕ್ಷರದ ಗಾತ್ರ</string>
+  <!-- Context: Menu Action -->
+  <string name="action_overflow" comment="Show additional menu items">ಇನ್ನಷ್ಟು</string>
+  <!-- Context: Menu Action -->
+  <string name="action_clear_text" comment="Menu action to erase text">ಪಠ್ಯವನ್ನು ತೆರವುಗೊಳಿಸಿ</string>
+  <!-- Context: Menu Action -->
+  <string name="action_info" comment="Menu action to display Keyman help page">ಮಾಹಿತಿ</string>
+  <!-- Context: Menu Action -->
+  <string name="action_settings" comment="Menu action to open Settings menu">ಸೆಟ್ಟಿಂಗ್‌ಗಳು</string>
+  <!-- Context: Menu Action -->
+  <string name="action_install_updates" comment="Menu notification that keyboard or dictionary updates available">ನವೀಕರಣೆಯನ್ನು ಅಳವಡಿಸಿ</string>
+  <!-- Context: Title -->
+  <string name="title_version" comment="Title of Keyman for Android version">ಆವೃತ್ತಿ %1$s</string>
+  <!-- Context: Text label when old Chrome version installed -->
+  <string name="text_require_chrome_57" comment="Banner text when old version of Chrome is installed">ಕೀಮ್ಯಾನ್‌ಗೆ ಕ್ರೋಮ್ ಆವೃತ್ತಿ 57 ಅಥವಾ ಹೊಸತಿನ ಅಗತ್ಯವಿದೆ.</string>
+  <!-- Context: Button label -->
+  <string name="button_update_chrome" comment="Prompt to upgrade Chrome in the Play Store">ಕ್ರೋಮ್ ನವೀಕರಿಸು</string>
+  <!-- Context: Textfield prompt (&#8230; is the ellipsis character "...") -->
+  <string name="textview_hint" comment="Prompt to start typing">ಇಲ್ಲಿ ಟೈಪ್ ಮಾಡಲು ಪ್ರಾರಂಭಿಸಿ&#8230;</string>
+  <!-- Context: Splash screen (version/copyright info currently disabled -->
+  <!-- Context: Splash screen (version/copyright info currently disabled -->
+  <!-- Context: Text Size dialog -->
+  <string name="text_size" comment="Current text size (number)">ಅಕ್ಷರದ ಗಾತ್ರ: %1$d</string>
+  <!-- Context: Text Size dialog -->
+  <string name="ic_text_size_up" comment="Make text bigger">ಅಕ್ಷರದ ಗಾತ್ರ ಹೆಚ್ಚಿಸಿ</string>
+  <!-- Context: Text Size dialog -->
+  <string name="ic_text_size_down" comment="Make text smaller">ಅಕ್ಷರದ ಗಾತ್ರ ತಗ್ಗಿಸಿ</string>
+  <!-- Context: Clear Text dialog -->
+  <string name="all_text_will_be_cleared" comment="Erase all the text">\nಎಲ್ಲಾ ಪಠ್ಯವನ್ನು ತೆರವುಗೊಳಿಸಲಾಗುತ್ತದೆ\n</string>
+  <!-- Context: Get Started menu -->
+  <string name="get_started" comment="Menu for getting started">ಶುರುಮಾಡಿ</string>
+  <!-- Context: Get Started menu -->
+  <string name="add_a_keyboard" comment="Menu item to add a keyboard">ನಿಮ್ಮ ಭಾಷೆಗೆ ಕೀಲಿಮಣೆಯನ್ನು ಸೇರಿಸಿ</string>
+  <!-- Context: Get Started menu -->
+  <string name="enable_system_keyboard" comment="Menu item to enable Keyman as system keyboard">ಕೀಮ್ಯಾನ್‌ವನ್ನು ಸಿಸ್ಟಮ್-ಆದ್ಯಂತ ಕೀಲಿಮಣೆಯಾಗಿ ಸ್ಥಾಪಿಸು</string>
+  <!-- Context: Get Started menu -->
+  <string name="set_keyman_as_default" comment="Menu item to set Keyman as default system keyboard">ಕೀಮ್ಯಾನ್‌ಅನ್ನು ಪೂರ್ವನಿರ್ಧರಿತ (ಡೀಫಾಲ್ಟ್) ಕೀಲಿಮಣೆಯನ್ನಾಗಿ ಹೊಂದಿಸಿ</string>
+  <!-- Context: Get Started menu -->
+  <string name="more_info" comment="Open the Keyman for Android help page">ಹೆಚ್ಚಿನ ಮಾಹಿತಿ</string>
+  <!-- Context: Get Started menu -->
+  <string name="show_get_started" comment="Show the &quot;Get Started&quot; menu on startup">ಆರಂಭದಲ್ಲಿ \"%1$s\" ತೋರಿಸು</string>
+  <!-- Context: Android Storage Permission -->
+  <string name="request_storage_permission" comment="Request storage permission to access keyboard packages">ಕೀಲಿಮಣೆ ಪ್ಯಾಕೇಜ್‌ಗಳನ್ನು ಸ್ಥಾಪಿಸಲು, ಕೀಮ್ಯಾನ್‌ಗೆ (external storage) ಬಾಹ್ಯ ಸಂಗ್ರಹಣೆಯನ್ನು ಓದಲು ಅನುಮತಿ ನೀಡಿ.</string>
+  <!-- Context: Android Storage Permission -->
+  <string name="storage_permission_denied" comment="Keyboard package installation may fail since Android storage permission not granted">ಬಾಹ್ಯ ಸಂಗ್ರಹಣೆಯನ್ನು (external storage) ಓದಲು ಅನುಮತಿಯನ್ನು ನಿರಾಕರಿಸಲಾಗಿದೆ. ಕೀಲಿಮಣೆ ಪ್ಯಾಕೇಜ್‌ಅನ್ನು ಸ್ಥಾಪಿಸಲು ವಿಫಲವಾಗಬಹುದು</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="keyman_settings" comment="Settings menu title">ಸೆಟ್ಟಿಂಗ್‌ಗಳು</string>
+  <!-- Context: Keyman Settings menu -->
+  <plurals name="installed_languages">
+    <item quantity="one">ಸ್ಥಾಪಿಸಲಾದ ಭಾಷೆ (%1$d)</item>
+    <item quantity="other">ಸ್ಥಾಪಿಸಲಾದ ಭಾಷೆಗಳು (%1$d)</item>
+  </plurals>
+  <!-- Context: Keyman Settings menu -->
+  <string name="install_keyboard_or_dictionary" comment="Menu item to install keyboard or dictionary">ಕೀಲಿಮಣೆ ಅಥವ ಶಬ್ದಕೋಶವನ್ನು ಅನುಸ್ಥಾಪಿಸು</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="change_display_language" comment="Menu action to change interface language">ಪ್ರದರ್ಶನ ಭಾಷೆ</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="adjust_keyboard_height" comment="Menu action to adjust keyboard height">ಕೀಲಿಮಣೆಯ ಎತ್ತರವನ್ನು ಹೊಂದಿಸಿ</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="spacebar_caption" comment="Menu action to set the spacebar caption">ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_keyboard" comment="Spacebar caption option - keyboard">ಕೀಲಿಮಣೆ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language" comment="Spacebar caption option - language">ಭಾಷೆ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language_keyboard" comment="Spacebar caption option - language + keyboard">ಭಾಷೆ + ಕೀಲಿಮಣೆ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_blank" comment="Spacebar caption option - blank">ಖಾಲಿ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_keyboard" comment="Spacebar caption hint - keyboard">ಕೀಲಿಮಣೆ ಹೆಸರನ್ನು ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆಯನ್ನಾಗಿ ತೋರಿಸು</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language" comment="Spacebar caption hint - language">ಭಾಷೆಯನ್ನು ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆಯನ್ನಾಗಿ ತೋರಿಸು</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language_keyboard" comment="Spacebar caption hint - language + keyboard">ಭಾಷೆ ಮತ್ತು ಕೀಲಿಮಣೆ ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆಯನ್ನಾಗಿ ತೋರಿಸು</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_blank" comment="Spacebar caption hint - blank">ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆ ತೋರಿಸಬೇಡ</string>
+  <!-- Context: Keyman Settings menu / Haptic feedback -->
+  <string name="haptic_feedback" comment="haptic feedback on key press">ಟೈಪಿಂಗ್ ಮಾಡುವಾಗ ವೈಬ್ರೇಟ್ ಮಾಡು</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_banner" comment="text suggestions banner">ಯಾವಾಗಲೂ ಬ್ಯಾನರ್ ತೋರಿಸು</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_banner_on" comment="Description when toggle is on">ಅನುಷ್ಠಾನಗೊಳಿಸಲಾಗುವುದು</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_banner_off" comment="Description when toggle is off">ಇದು ಆಫ್ ಆಗಿರುವಾಗ, \"ಮುಂದಿನ ಪದವನ್ನು ಊಹಿಸಿ\" ಸಕ್ರಿಯಗೊಳಿಸಿದಾಗ ಮಾತ್ರ ತೋರಿಸಲಾಗುತ್ತದೆ</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_send_crash_report" comment="permission for sending crash reports">ಅಂತರ್ಜಾಲ ಮೂಲಕ ದೋಷದ ವರದಿಗಳನ್ನು ಕಳುಹಿಸಲು ಅನುಮತಿಸಿ</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_send_crash_report_on" comment="Description when toggle is on">ಇದು ಆನ್ ಆಗಿರುವಾಗ, ದೋಷದ ವರದಿಗಳನ್ನು ಕಳುಹಿಸಲಾಗುವುದು</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_send_crash_report_off" comment="Description when toggle is off">ಇದು ಆಫ್ ಆಗಿರುವಾಗ, ದೋಷದ ವರದಿಗಳನ್ನು ಕಳುಹಿಸಲಾಗುವುದಿಲ್ಲ</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="install_from_keyman_dot_com" comment="Install package from Keyman server">Keyman.com ನಿಂದ ಅನುಸ್ಥಾಪಿಸು</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="install_from_local_file" comment="Install package file from local device">ಸ್ಥಳೀಯ ಕಡತನಿಂದ ಅನುಸ್ಥಾಪಿಸು</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="install_from_other_device" comment="Scan QR Code">ಬೇರೊಂದು ಡಿವೈಸ್‌ನಿಂದ ಅನುಸ್ಥಾಪಿಸು</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="add_languages_to_installed_keyboard" comment="Install additional languages from a keyboard package">ಸ್ಥಾಪಿಸಲಾದ ಕೀಲಿಮಣೆಗೆ ಭಾಷೆಯನ್ನು ಸೇರಿಸು</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="add_language_subtext" comment="Additional information for adding another language">(ಕೀಲಿಮಣೆ ಪ್ಯಾಕೇಜ್‌ನಿಂದ)</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="title_select_keyboard_package_list" comment="Select a keyboard package to add languages">ಕೀಲಿಮಣೆ ಪ್ಯಾಕೇಜ್‌ವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="title_select_languages_for_package" comment="Select language names from the keyboard package">%1$s ಕೀಲಿಮಣೆಗೆ ಭಾಷೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿ</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="added_language_to_keyboard" comment="Notification that a language name is added to a keyboard">%1$s ಭಾಷೆಯನ್ನು %2$s ಕೀಲಿಮಣೆಗೆ ಸೇರಿಸಲಾಗಿದೆ</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="all_languages_installed" comment="Text when all languages from a keyboard package have been installed">ಎಲ್ಲಾ ಭಾಷೆಗಳನ್ನು ಈಗಾಗಲೇ ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="drag_the_keyboard" comment="First line of adjusting keyboard height">ಎತ್ತರವನ್ನು ಬದಲಾಯಿಸಲು ಕೀಲಿಮಣೆಯನ್ನು ಎಳೆಯಿರಿ</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="rotate_the_device" comment="Second line of adjusting keyboard height">ಪೋರ್ಟ್ರೇಟ್ ಮತ್ತು ಲ್ಯಾಂಡ್ಸ್ಕೇಪ್ ಹೊಂದಿಸಲು ಸಾಧನವನ್ನು ತಿರುಗಿಸಿ</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="reset_to_defaults" comment="Button to reset to default heights">ಡೀಫಾಲ್ಟ್ ಮರುಹೊಂದಿಸಿ</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="hint_text" comment="Prompt to type in the browser search bar">ಹುಡುಕು ಅಥವಾ URL ಟೈಪ್ ಮಾಡಿ</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="title_bookmarks" comment="Title for bookmarks">ಬುಕ್‍ಮಾರ್ಕ್‌ಗಳು</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="no_bookmarks" comment="Text when bookmark list is empty">ಯಾವುದೇ ಬುಕ್‍ಮಾರ್ಕ್‌ಗಳಿಲ್ಲ</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="add_bookmark" comment="Confirmation to add bookmark">ಬುಕ್‌ಮಾರ್ಕ್ ಸೇರಿಸಿ</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="hint_title" comment="Page title for saved bookmark">ಶೀರ್ಷಿಕೆ</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="hint_url" comment="Page URL for saved bookmark">ಯುಆರ್‌ಎಲ್‌</string>
+  <!-- Context: KMP Package strings -->
+  <string name="title_package_failed_to_install" comment="Error dialog title when package failed to install">ಪ್ಯಾಕೇಜ್ %1$s ಅನ್ನು ಅನುಸ್ಥಾಪಿಸಲು ವಿಫಲವಾಗಿದೆ</string>
+  <!-- Context: KMP Package strings -->
+  <string name="downloading_keyboard_package" comment="Confirmation to download keyboard package filename">ಕೆಳಗೆ ಉಲ್ಲೇಖಿಸಿರುವ ಕೀಲಿಮಣೆ ಪ್ಯಾಕೇಜ್ ಡೌನ್ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ\n%1$s&#8230;</string>
+  <!-- Context: KMP Package strings -->
+  <string name="failed_to_extract" comment="Notification that keyboard package failed to unzip">ಹೊರತೆಗೆಯಲು ವಿಫಲವಾಗಿದೆ</string>
+  <!-- Context: KMP Package strings -->
+  <string name="install_keyboard_package" comment="Title to install keyboard package">ಕೀಲಿಮಣೆಯನ್ನು ಅನುಸ್ಥಾಪಿಸು</string>
+  <!-- Context: KMP Package strings -->
+  <string name="install_predictive_text_package" comment="Title to install dictionary package">ಶಬ್ದಕೋಶವನ್ನು ಅನುಸ್ಥಾಪಿಸು</string>
+  <!-- Context: KMP Package strings -->
+  <string name="not_valid_package_file" comment="Notification when invalid package file cannot be installed">%1$s ಕೀಮ್ಯಾನ್ ಪ್ಯಾಕೇಜ್ ಕಡತ ಮಾನ್ಯವಾಗಿಲ್ಲ\n%2$s\"</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_new_touch_keyboards_to_install" comment="Notification when no touch-optimized keyboards can be installed">ಕೀಲಿಮಣೆ ಪ್ಯಾಕೇಜ್‌ನಲ್ಲಿ ಯಾವುದೆ ಕೀಲಿಮಣೆಯು (touch-optimized) ಟಚ್ ಹೊಂದುವಂತೆ ಮಾಡಲಾಗಿಲ್ಲ</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_new_predictive_text_to_install" comment="Notification when no dictionaries can be installed">ಮುಂದಿನ ಪದವನ್ನು ಊಹಿಸುವ ಪಟ್ಟಿಯನ್ನು ಸ್ಥಾಪಿಸಲು ಯಾವ ಹೊಸದು ಇಲ್ಲ</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_targets_to_install" comment="Notification when a package doesn't contain keyboards or dictionaries">ಕೀಲಿಮಣೆಗಳು ಅಥವ ಮುಂದಿನ ಪದವನ್ನು ಊಹಿಸುವ ಪಟ್ಟಿಯನ್ನು ಸ್ಥಾಪಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_associated_languages" comment="Notification when a keyboard package doesn't contain languages">ಕೀಲಿಮಣೆ ಪ್ಯಾಕೇಜ್‌ನಲ್ಲಿ ಯಾವುದೆ ಸಂಬಂಧಿತ ಭಾಷೆಗಳನ್ನು ಹೊಂದಿಲ್ಲ</string>
+  <!-- Context: KMP Package strings -->
+  <string name="invalid_metadata" comment="kmp.json metadata file is invalid or missing in package">ಪ್ಯಾಕೇಜ್‌ನಲ್ಲಿ ಅಮಾನ್ಯ/ಕಾಣೆಯಾದ (metadata)ಮೆಟಾಡೇಟಾ</string>
+  <!-- Context: KMP Package strings -->
+  <string name="minimum_keyboard_version_not_supported" comment="Notification when keyboard has functionality not supported by current Keyman">ಈ ಕೀಲಿಮಣೆಗೆ ಹೊಸ ಆವೃತ್ತಿಯ ಕೀಮ್ಯಾನ್ ಅಗತ್ಯವಿದೆ</string>
+  <!-- Context: anywhere -->
+  <string name="unable_to_open_browser" comment="Notification when a browser activity cannot be launched">ವೆಬ್ ಬ್ರೌಸರ್ ಅನ್ನು ಪ್ರಾರಂಭಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ</string>
+</resources>

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/DisplayLanguages.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/DisplayLanguages.java
@@ -50,6 +50,7 @@ public class DisplayLanguages {
       new DisplayLanguageType("in-ID", "Indonesian"),
       new DisplayLanguageType("it-IT", "Italiana"),
       new DisplayLanguageType("de-DE", "German"),
+      new DisplayLanguageType("kn-IN", "ಕನ್ನಡ (Kannada)"),
       new DisplayLanguageType("kr-NG", "Kanuri"),
       new DisplayLanguageType("km-KH", "Khmer"),
       new DisplayLanguageType("ckl-NG", "Kibaku"),

--- a/android/KMEA/app/src/main/res/values-kn-rIN/strings.xml
+++ b/android/KMEA/app/src/main/res/values-kn-rIN/strings.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Device type  -->
+    <!-- Application name (Keyman Engine for Android) -->
+    <!-- Context: Title for list -->
+    <plurals name="title_keyboards">
+        <item quantity="one">ಕೀಲಿಮಣೆ</item>
+        <item quantity="other">ಕೀಲಿಮಣೆಗಳು</item>
+    </plurals>
+    <!-- Context: Title for list -->
+    <plurals name="title_other_input_methods">
+        <item quantity="one">ಇತರೆ ಇನ್‌ಪುಟ್ ವಿಧಾನ</item>
+        <item quantity="other">ಇತರೆ ಇನ್‌ಪುಟ್ ವಿಧಾನಗಳು</item>
+    </plurals>
+    <!-- Context: Title for list -->
+    <string name="title_add_keyboard" comment="Add a new keyboard">ಹೊಸ ಕೀಲಿಮಣೆ ಸೇರಿಸಿ</string>
+    <!-- Context: Title for list -->
+    <string name="title_languages_settings" comment="List of installed languages">ಪ್ರತಿಷ್ಟಾಪಿಸಿದ ಭಾಷೆಗಳು</string>
+    <!-- Context: Title for list -->
+    <string name="title_language_settings" comment="Keyman Settings for a language">%1$s ಸೆಟ್ಟಿಂಗ್‌ಗಳು</string>
+    <!-- Context: Button label -->
+    <string name="label_add" comment="Button to add an item">ಸೇರಿಸು</string>
+    <!-- Context: Button label -->
+    <string name="label_back" comment="Button to go back">ಹಿಂದೆ</string>
+    <!-- Context: Button label -->
+    <string name="label_cancel" comment="Button to cancel an action">ರದ್ದುಮಾಡಿ</string>
+    <!-- Context: Button label -->
+    <string name="label_close" comment="Close a dialog">ಮುಚ್ಚು</string>
+    <!-- Context: Button label. Removed in Keyman 15 -->
+    <string name="label_close_keyman" comment="Close the Keyman application">ಕೀಮ್ಯಾನ್ ಮುಚ್ಚು</string>
+    <!-- Context: Button label -->
+    <string name="label_forward" comment="Button to go forward">ಮುಂದಕ್ಕೆ</string>
+    <!-- Context: Button label -->
+    <string name="label_next_input_method" comment="Switch to next input method (replaces label_close_keyman)">ಇತರೆ ಇನ್‌ಪುಟ್ ವಿಧಾನ</string>
+    <!-- Context: Button label -->
+    <string name="label_download" comment="Button to confirm downloading an item">ಡೌನ್ಲೋಡ್ ಮಾಡು</string>
+    <!-- Context: Button label -->
+    <string name="label_install" comment="Confirmation to install a package">ಅನುಸ್ಥಾಪಿಸು</string>
+    <!-- Context: Button label -->
+    <string name="label_later" comment="Do an action at a later time">ನಂತರ</string>
+    <!-- Context: Button label -->
+    <string name="label_next" comment="Go to the next screen">ಮುಂದಿನ</string>
+    <!-- Context: Button label -->
+    <string name="label_ok" comment="Button to acknowledge a dialog">ಸರಿ</string>
+    <!-- Context: Button label -->
+    <string name="label_update" comment="Dialog button to update a resource">ನವೀಕರಣ</string>
+    <!-- Context: No internet for updates -->
+    <string name="no_internet_connection" comment="Internet connection missing">ಇಂಟರ್ನೆಟ್ ಸಂಪರ್ಕವಿಲ್ಲ</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="cannot_connect" comment="Error message when network connection fails">ಕೀಮ್ಯಾನ್ ಸರ್ವರ್‌ಗೆ ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ!</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="confirm_delete_keyboard" comment="Confirmation to delete a keyboard">ಈ ಕೀಲಿಮಣೆಯನ್ನು ಅಸ್ಥಾಪಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="confirm_download_keyboard" comment="Confirmation to download a keyboard update">ಈ ಕೀಲಿಮಣೆಯ ಇತ್ತೀಚಿನ ಆವೃತ್ತಿಯನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ನೀವು ಬಯಸುವಿರಾ?</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="confirm_update" comment="Confirmation to update several resources">ಕೀಲಿಮಣೆ ಮತ್ತು ಶಬ್ದಕೋಶಗಳನ್ನು ನವೀಕರಿಸಲು ನೀವು ಬಯಸುವಿರಾ?</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="keyboard_updates_channel">ಸಂಪನ್ಮೂಲ ನವೀಕರಣಗಳು</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="keyboard_updates_available" comment="Notification when resource updates are available">ಸಂಪನ್ಮೂಲ ನವೀಕರಣಗಳು ಲಭ್ಯವಿದೆ</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="update_available" comment="Currently installed version of a resource with an available update">%1$s (ನವೀಕರಣ ಲಭ್ಯವಿದೆ)</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="keyboard_update_message" comment="language name: keyboard name">ನವೀಕರಣ ಲಭ್ಯವಿದೆ, ಕೀಲಿಮಣೆ %1$s: %2$s </string>
+    <!-- Context: Keyboard Updates -->
+    <string name="dictionary_update_message">ನವೀಕರಣ ಲಭ್ಯವಿದೆ, ಶಬ್ದಕೋಶ %1$s: %2$s </string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="keyboard_version" comment="Label for keyboard version">ಕೀಲಿಮಣೆ ಆವೃತ್ತಿ</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="help_link" comment="Label for help link">ಸಹಾಯ ಕೊಂಡಿ</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="uninstall_keyboard" comment="Label for uninstalling keyboard">ಕೀಲಿಮಣೆಯನ್ನು ಅಸ್ಥಾಪಿಸು</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="keyboard_picker_new_keyboard" comment="Mark a language name that's newly installed in keyboard list">[ಹೊಸ] %1$s</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="keyboard_qr_code" comment="QR Code description">ಈ ಕೀಲಿಮಣೆಯನ್ನು ಮತ್ತೊಂದು ಸಾಧನದಲ್ಲಿ ಸ್ಥಾಪಿಸಲು \nಈ ಕೋಡ್ಅನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡಿ</string>
+    <!-- Context: Keyboard Help welcome.htm title -->
+    <string name="welcome_package" comment="Title to welcome.htm page (name and version)">%1$s ಗೆ ಸ್ವಾಗತ</string>
+    <!-- Context: Keyboard app doesn't include FileProvider library needed to view help file -->
+    <string name="fileprovider_undefined" comment="FileProvider library needed to view help file">ಸಹಾಯ ಫೈಲ್ ವೀಕ್ಷಿಸಲು FileProvider ಲೈಬ್ರರಿ ಅಗತ್ಯವಿದೆ: %1$s</string>
+    <!-- Context: Fatal keyboard error. Will load default keyboard -->
+    <string name="fatal_keyboard_error" comment="Fatal keyboard error (keyboard ID::packageID for language). Will load default keyboard">%1$s:%2$s ಕೀಲಿಮಣೆಯಲ್ಲಿ %3$s ಭಾಷೆಯೊಂದಿಗೆ ದೋಷವಿದೆ. ಅದರ ಬದಲಿಗೆ ಪೂರ್ವನಿರ್ಧರಿತ ಕೀಲಿಮಣೆ ಲೋಡ್ ಆಗುತ್ತಿದೆ.</string>
+    <!-- Context: Fatal keyboard error.  -->
+    <string name="fatal_keyboard_error_short" comment="Error in keyboard (keyboard ID::packageID for language).">%1$s:%2$s ಕೀಲಿಮಣೆಯಲ್ಲಿ %3$s ಭಾಷೆಯೊಂದಿಗೆ ದೋಷವಿದೆ.</string>
+    <!-- Context: Query for associated dictionary -->
+    <string name="query_associated_model" comment="Check if there's an available dictionary to download">ಸಂಬಂಧಿಸಿದ ಶಬ್ದಕೋಶವನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ</string>
+    <string name="cannot_query_associated_model" comment="Cannot reach server to check if there's an available dictionary to download">ಸಂಬಂಧಿಸಿದ ಶಬ್ದಕೋಶವನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಕೀಮ್ಯಾನ್ ಸರ್ವರ್ ಅನ್ನು ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲಾ</string>
+    <!-- Context: Model Updates -->
+    <string name="confirm_download_model" comment="Confirmation to download a dictionary update">ಈ ಶಬ್ದಕೋಶದ ಇತ್ತೀಚಿನ ಆವೃತ್ತಿಯನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ನೀವು ಬಯಸುವಿರಾ?</string>
+    <!-- Context: No associated dictionary found -->
+    <string name="no_associated_model" comment="Confirmation there's no available dictionary to download">ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಯಾವುದೇ ಶಬ್ದಕೋಶ ಲಭ್ಯವಿಲ್ಲ</string>
+    <!-- Context: Model Updates -->
+    <string name="catalog_unavailable" comment="Notification that the cloud resource catalog can't be updated">ಸಂಪನ್ಮೂಲ ಕ್ಯಾಟಲಾಗ್ ಲಭ್ಯವಿಲ್ಲ</string>
+    <!-- Context: Background download messages-->
+    <string name="catalog_download_start_in_background" comment="Notification that the resource catalog update will begin">ಹಿನ್ನೆಲೆಯಲ್ಲಿ ಕ್ಯಾಟಲಾಗ್ ನವೀಕರಣ ಪ್ರಾರಂಭವಾಗಿದೆ</string>
+    <!-- Context: Background download messages-->
+    <string name="catalog_download_is_running_in_background" comment="Notification that the resource catalog update is still downloading">ಕ್ಯಾಟಲಾಗ್ ಇನ್ನೂ ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ; ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ!</string>
+    <!-- Context: Background download messages-->
+    <string name="progress_message_checking_resource_is_running" comment="Progress notification that the check for a resource is still running ">ಸಂಪನ್ಮೂಲಕ್ಕಾಗಿ ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ</string>
+    <!-- Context: Background download messages-->
+    <string name="keyboard_download_start_in_background" comment="Notification that a keyboard download has started">ತೆರೆಯ ಹಿಂದೆಯಲ್ಲಿ ಕೀಲಿಮಣೆಯನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ</string>
+    <!-- Context: Background download messages-->
+    <string name="keyboard_download_is_running_in_background" comment="Notification that a keyboard download is still running">ಆಯ್ಕೆಮಾಡಿದ ಕೀಲಿಮಣೆ ಈಗಾಗಲೇ ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ; ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ!</string>
+    <!-- Context: Background download messages-->
+    <string name="keyboard_download_finished" comment="Notification that a keyboard download has finished">ಕೀಲಿಮಣೆ ಡೌನ್‌ಲೋಡ್ ಪೂರ್ಣಗೊಂಡಿದೆ!</string>
+    <!-- Context: Background download messages-->
+    <string name="dictionary_download_start_in_background" comment="Notification that a dictionary download has started">ತೆರೆಯ ಹಿಂದೆಯಲ್ಲಿ ಶಬ್ದಕೋಶವನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ</string>
+    <!-- Context: Background download messages-->
+    <string name="dictionary_download_is_running_in_background" comment="Notification that a dictionary download is still running">ಆಯ್ಕೆಮಾಡಿದ ಶಬ್ದಕೋಶ ಈಗಾಗಲೇ ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ; ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ!</string>
+    <!-- Context: Background download messages-->
+    <string name="dictionary_download_finished" comment="Notification that a dictionary download has finished">ಶಬ್ದಕೋಶ ಡೌನ್‌ಲೋಡ್ ಪೂರ್ಣಗೊಂಡಿದೆ.</string>
+    <!-- Context: Background download messages -->
+    <string name="download_failed" comment="Notification that a download failed">ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ</string>
+    <!-- Context: Background download messages -->
+    <string name="failed_to_retrieve_file" comment="Failed to retrieve downloaded file">ಡೌನ್‌ಲೋಡ್ ಮಾಡಿದ ಕಡತವನ್ನು ಪಡೆಯಲು ವಿಫಲವಾಗಿದೆ</string>
+    <!-- Context: General Updates -->
+    <string name="update_check_unavailable" comment="Error message when a Keyman server can't be reached">ಸರ್ವರ್ ಅನ್ನು ಪ್ರವೇಶಿಸಲು ವಿಫಲವಾಗಿದೆ!</string>
+    <!-- Context: General Updates -->
+    <string name="update_check_current" comment="Notification that all resources are up to date">"ಎಲ್ಲಾ ಸಂಪನ್ಮೂಲಗಳು ನವೀಕರಿಸಲಾಗಿದೆ!"</string>
+    <!-- Context: General Updates -->
+    <string name="update_failed" comment="Notification that a resource update failed">ಒಂದು ಅಥವಾ ಹೆಚ್ಚಿನ ಸಂಪನ್ಮೂಲಗಳನ್ನು ನವೀಕರಿಸಲು ವಿಫಲವಾಗಿದೆ!</string>
+    <!-- Context: General Updates -->
+    <string name="update_success" comment="Notification that a resource update successfully updated">ಸಂಪನ್ಮೂಲಗಳನ್ನು ಯಶಸ್ವಿಯಾಗಿ ನವೀಕರಿಸಲಾಗಿದೆ!</string>
+    <!-- Context: Model Info -->
+    <string name="model_version" comment="Title for a dictionary version">ಶಬ್ದಕೋಶದ ಆವೃತ್ತಿ</string>
+    <!-- Context: Model Info -->
+    <string name="uninstall_model" comment="Label to uninstall a dictionary">ಶಬ್ದಕೋಶವನ್ನು ಅಸ್ಥಾಪಿಸು</string>
+    <!-- Context: Model Info -->
+    <string name="confirm_delete_model" comment="Confirmation to delete a dictionary">ಈ ಶಬ್ದಕೋಶವನ್ನು ಅಸ್ಥಾಪಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?</string>
+    <!-- Context: Model Deleted -->
+    <string name="model_deleted" comment="Notification when a dictionary is deleted">ಶಬ್ದಕೋಶ ಅಳಿಸಲಾಗಿದೆ</string>
+    <!-- Context: Language Settings Keyboard install strings -->
+    <string name="keyboard_install_toast" comment="Notification when a keyboard is installed">%1$s ಕೀಲಿಮಣೆ ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+    <!-- Context: Language Settings Keyboard uninstall strings -->
+    <string name="keyboard_deleted_toast" comment="Notification when a keyboard is deleted">ಕೀಲಿಮಣೆ ಅಳಿಸಲಾಗಿದೆ</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="enable_corrections" comment="Enable corrections from the suggestion banner">ತಿದ್ದುಪಡಿಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="enable_predictions" comment="Enable predictions from the suggestion banner">ಮುಂದಿನ ಪದವನ್ನು ಊಹಿಸಲು ಸಕ್ರಿಯಗೊಳಿಸಿ</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_label">ಶಬ್ದಕೋಶ</string>
+    <plurals name="model_count">
+        <item quantity="one">ಶಬ್ದಕೋಶ</item>
+        <item quantity="other">ಶಬ್ದಕೋಶಗಳು</item>
+    </plurals>
+    <!-- Context: Language Settings menu substring - Check for available dictionary -->
+    <string name="check_available_model" comment="Check for available dictionary">ಲಭ್ಯವಿರುವ ಶಬ್ದಕೋಶಗಾಗಿ ಪರಿಶೀಲಿಸಿ</string>
+    <string name="check_model_online" comment="Check for dictionaries online">ಆನ್ಲೈನ್‌ನಲ್ಲಿ ಲಭ್ಯವಿರುವ ಶಬ್ದಕೋಶಗಾಗಿ ಪರಿಶೀಲಿಸಿ</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_info_header" comment="Dictionary name">ಶಬ್ದಕೋಶ: %1$s</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_picker_header" comment="Dictionaries for a specified language">%1$s ಶಬ್ದಕೋಶಗಳು</string>
+    <!-- Context: Language Settings menu strings -->
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_install_toast" comment="Notification when a dictionary is installed">ಶಬ್ದಕೋಶ ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+    <!-- Context: Language Settings menu strings -->
+    <plurals name="keyboard_count">
+        <item quantity="one">(%1$d ಕೀಲಿಮಣೆ)</item>
+        <item quantity="other">(%1$d ಕೀಲಿಮಣೆಗಳು)</item>
+    </plurals>
+    <!-- Context: "Change Display Language" menu -->
+    <string name="default_locale" comment="Use the device's current locale">ಪೂರ್ವನಿರ್ಧರಿತ ಸ್ಥಳೀಯ ಭಾಷೆ</string>
+    <!-- Context: Content descriptions -->
+    <!-- Context: Content descriptions -->
+    <!-- Context: Popup menu labels -->
+    <string name="label_delete" comment="Confirmation to delete an item">ಅಳಿಸು</string>
+    <!-- Context: Shared preferences name -->
+    <!-- Context: Other strings -->
+    <string name="help_bubble_text">ಕೀಲಿಮಣೆಯನ್ನು ಬದಲಾಯಿಸಲು ಇಲ್ಲಿ ಟ್ಯಾಪ್ ಮಾಡಿ</string>
+    <!-- Context: anywhere -->
+    <string name="unable_to_open_browser" comment="Notification when a browser activity cannot be launched">ವೆಬ್ ಬ್ರೌಸರ್ ಅನ್ನು ಪ್ರಾರಂಭಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ</string>
+</resources>

--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -308,6 +308,9 @@
 		2949146F2738DA6700400732 /* ff-NG */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ff-NG"; path = "ff-NG.lproj/ResourceInfoView.strings"; sourceTree = "<group>"; };
 		294914702738DD7400400732 /* ff-NG */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ff-NG"; path = "ff-NG.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		294914712738DD9700400732 /* ff-NG */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "ff-NG"; path = "ff-NG.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
+		297810FE297FAEDF007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/ResourceInfoView.strings; sourceTree = "<group>"; };
+		297810FF297FAEF8007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Localizable.strings; sourceTree = "<group>"; };
+		29781100297FAF06007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = kn; path = kn.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		29B27FEF29062CF50036917E /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/ResourceInfoView.strings; sourceTree = "<group>"; };
 		29B27FF029062D100036917E /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		29B27FF129062D190036917E /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = nl; path = nl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -1195,6 +1198,7 @@
 				it,
 				pl,
 				nl,
+				kn,
 			);
 			mainGroup = F243887314BBD43000A3E055;
 			productRefGroup = F243887F14BBD43000A3E055 /* Products */;
@@ -1588,6 +1592,7 @@
 				29BFA760282934BB009FCCC3 /* it */,
 				29BFA76C28294833009FCCC3 /* pl */,
 				29B27FF129062D190036917E /* nl */,
+				29781100297FAF06007C886D /* kn */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";
@@ -1610,6 +1615,7 @@
 				29BFA75F282934B4009FCCC3 /* it */,
 				29BFA76B28294813009FCCC3 /* pl */,
 				29B27FF029062D100036917E /* nl */,
+				297810FF297FAEF8007C886D /* kn */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -1633,6 +1639,7 @@
 				29BFA75E28293287009FCCC3 /* it */,
 				29BFA76A28294746009FCCC3 /* pl */,
 				29B27FEF29062CF50036917E /* nl */,
+				297810FE297FAEDF007C886D /* kn */,
 			);
 			name = ResourceInfoView.xib;
 			sourceTree = "<group>";

--- a/ios/engine/KMEI/KeymanEngine/Classes/kn.lproj/ResourceInfoView.strings
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kn.lproj/ResourceInfoView.strings
@@ -1,0 +1,2 @@
+/* Class = "UILabel"; text = "Scan this code to load this keyboard on another device"; ObjectID = "z2O-MT-IoV"; */
+"z2O-MT-IoV.text" = "ಈ ಕೀಲಿಮಣೆಯನ್ನು ಮತ್ತೊಂದು ಸಾಧನದಲ್ಲಿ ಸ್ಥಾಪಿಸಲು ಈ ಕೋಡ್ಅನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡಿ";

--- a/ios/engine/KMEI/KeymanEngine/kn.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/kn.lproj/Localizable.strings
@@ -1,0 +1,257 @@
+/* A descriptive message used for errors when the app is already busy downloading */
+"alert-download-error-busy" = "ಈಗಾಗಲೇ ಡೌನ್‌ಲೋಡ್‌ನಲ್ಲಿ ನಿರತವಾಗಿದೆ.";
+
+/* A descriptive message used when a download fails */
+"alert-download-error-detail" = "ಡೌನ್‌ಲೋಡ್ ಮಾಡುವಾಗ ಅಥವ ಅನುಸ್ಥಾಪಿಸುವಾಗ ದೋಷ ಸಂಭವಿಸಿದೆ.";
+
+/* Title for a "download failed" alert */
+"alert-download-error-title" = "ಇಳಿಸುವಾಗ ದೋಷ";
+
+/* Title for a general alert about errors */
+"alert-error-title" = "ದೋಷ";
+
+/* A descriptive message used when no internet connection is detected */
+"alert-no-connection-detail" = "ಕೀಮ್ಯಾನ್ ಸರ್ವರ್ ಅನ್ನು ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲಾ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.";
+
+/* Title for a "no connection" alert */
+"alert-no-connection-title" = "ಸಂಪರ್ಕ ದೋಷ";
+
+/* Short text for a 'back' navigational command.  Used to return to the previous screen */
+"command-back" = "ಹಿಂದೆ";
+
+/* Short text for a 'cancel' command.  Used to back out of a menu or install process without making changes */
+"command-cancel" = "ರದ್ದುಮಾಡಿ";
+
+/* Short text for a 'done' command.  Used to back out of settings menus after changes have been made */
+"command-done" = "ಆಗಿದೆ";
+
+/* Short text for an 'install' command.  Used to confirm installation of a package. */
+"command-install" = "ಅನುಸ್ಥಾಪಿಸು";
+
+/* Short text for a 'next' navigational command.  Used to advance to the next screen */
+"command-next" = "ಮುಂದಿನ";
+
+/* Short text for an 'OK' command.  Used for some error alerts */
+"command-ok" = "ಸರಿ";
+
+/* Short text for confirmining 'uninstall' commands. */
+"command-uninstall" = "ಅಸ್ಥಾಪಿಸು";
+
+/* Text for the command to uninstall a keyboard */
+"command-uninstall-keyboard" = "ಕೀಲಿಮಣೆಯನ್ನು ಅಸ್ಥಾಪಿಸು";
+
+/* Confirmation text to display before uninstalling a keyboard */
+"command-uninstall-keyboard-confirm" = "ಈ ಕೀಲಿಮಣೆಯನ್ನು ಅಸ್ಥಾಪಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?";
+
+/* Text for the command to uninstall a lexical model */
+"command-uninstall-lexical-model" = "ನಿಘಂಟನ್ನು ಅಸ್ಥಾಪಿಸು";
+
+/* Confirmation text to display before uninstalling a lexical model */
+"command-uninstall-lexical-model-confirm" = "ಈ ಶಬ್ದಕೋಶವನ್ನು ಅಸ್ಥಾಪಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?";
+
+/* Text for error when a keyboard cannot load properly */
+"error-loading-keyboard" = "ವಿನಂತಿಸಿದ ಕೀಲಿಮಣೆಯನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ";
+
+/* Text for error when a lexical model cannot load properly */
+"error-loading-lexical-model" = "ವಿನಂತಿಸಿದ ಶಬ್ದಕೋಶವನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ";
+
+/* Text for error when an installed file is unexpectedly missing */
+"error-missing-file" = "ಅಗತ್ಯವಿರುವ ಒಂದು ಕಡತ ಕಂಡುಬಂದಿಲ್ಲ.";
+
+/* Text for error when an installed file is unexpectedly missing */
+"error-missing-file-critical" = "ಅಗತ್ಯವಿರುವ ಒಂದು ಕಡತ ಕಂಡುಬಂದಿಲ್ಲ. ದಯವಿಟ್ಟು ಅಪ್ಲಿಕೇಶನ್ ಅನ್ನು ಮರುಸ್ಥಾಪಿಸಲು ಪ್ರಯತ್ನಿಸಿ.";
+
+/* Text for errors in data received from search queries */
+"error-query-decoding" = "ಪ್ರಸ್ತುತದಲ್ಲಿ ಸರ್ವರ್ ತಾಂತ್ರಿಕ ತೊಂದರೆಗಳನ್ನು ಎದುರಿಸುತ್ತಿದೆ";
+
+/* A descriptive message used when a download fails */
+"error-query-general" = "ಸರ್ವರ್‌ನೊಂದಿಗೆ ಸಂವಹನ ಮಾಡುವಲ್ಲಿ ದೋಷ ಕಂಡುಬಂದಿದೆ";
+
+/* Text for error when a search query is unexpectedly empty */
+"error-query-no-data" = "ಸರ್ವರ್ ಪ್ರತಿಕ್ರಿಯಿಸಲು ವಿಫಲವಾಗಿದೆ";
+
+/* Text for general errors where not much information is known */
+"error-unknown" = "ಅನಿರೀಕ್ಷಿತ ದೋಷ ಸಂಭವಿಸಿದೆ";
+
+/* Text for error when updating a resource:  cannot download because no source is available */
+"error-update-no-link" = "ಈ ಪ್ಯಾಕೇಜ್‌ ಅನ್ನು ನವೀಕರಿಸಲು ಯಾವುದೇ ಮೂಲ ಲಭ್ಯವಿಲ್ಲ";
+
+/* Text for error when updating a resource:  Keyman does not know how to update the resource */
+"error-update-not-managed" = "ಕೀಮ್ಯಾನ್ ಎಂಜಿನ್ ನಿರ್ವಹಿಸದ ಸಂಪನ್ಮೂಲವನ್ನು ನಿರ್ವಹಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ";
+
+/* Text for the command to open the help page of a keyboard, as shown on resource information views */
+"info-command-help-keyboard" = "ಕೀಲಿಮಣೆ ಸಹಾಯ";
+
+/* Text for the command to open the help page of a lexical model, as shown on resource information views */
+"info-command-help-lexical-model" = "ನಿಘಂಟು ಸಹಾಯ";
+
+/* Text label for displaying a keyboard's version, as shown on resource information views */
+"info-label-version-keyboard" = "ಕೀಲಿಮಣೆ ಆವೃತ್ತಿ";
+
+/* Text label for displaying a lexical model's version, as shown on resource information views */
+"info-label-version-lexical-model" = "ನಿಘಂಟು ಆವೃತ್ತಿ";
+
+/* Label used for the "package info" / readme tab with the package installation prompt on phones. */
+"installer-label-package-info" = "ಪ್ಯಾಕೇಜ್ ಮಾಹಿತಿ";
+
+/* Label used for the language-selection tab with the package installation prompt on phones. */
+"installer-label-select-languages" = "ಭಾಷೆ(ಗಳನ್ನು) ಯನ್ನು ಆಯ್ಕೆಮಾಡಿ";
+
+/* Label used with a package's version, as seen within the package installation prompt.  Example:  "Version: 14.0.0" */
+"installer-label-version" = "ಆವೃತ್ತಿ: %@";
+
+/* Section header for languages supported by a package, as seen within the package installation prompt */
+"installer-section-available-languages" = "ಲಭ್ಯವಿರುವ ಭಾಷೆಗಳು";
+
+/* Text for the help popup for changing keyboards with the globe key */
+"keyboard-help-change" = "ಕೀಲಿಮಣೆಯನ್ನು ಬದಲಾಯಿಸಲು ಇಲ್ಲಿ ಟ್ಯಾಪ್ ಮಾಡಿ";
+
+/* Text for the command to exit the Keyman keyboard in favor of other keyboards installed on the system */
+"keyboard-menu-exit" = "%@ ಮುಚ್ಚಿ";
+
+/* Error installing a Keyman package - could not allocate a location to install it */
+"kmp-error-file-system" = "ಪ್ಯಾಕೇಜ್ ಅನ್ನು ಸ್ಥಾಪಿಸುವಲ್ಲಿ ದೋಷವುಂಟಾಗಿದೆ - ಫೈಲ್-ಸಿಸ್ಟಮ್ (file-system) ದೋಷ";
+
+/* Error installing a Keyman package - could not copy package files */
+"kmp-error-file-copying" = "ಪ್ಯಾಕೇಜ್ ಅನ್ನು ಸ್ಥಾಪಿಸುವಲ್ಲಿ ದೋಷವುಂಟಾಗಿದೆ - ಅಗತ್ಯವಿರುವ ಕಡತಗಳನ್ನು ನಕಲಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ";
+
+/* Error opening a Keyman package - package is not valid */
+"kmp-error-invalid" = "ಈ ಪ್ಯಾಕೇಜ್ ಕಡತದಲ್ಲಿ ದೋಷವಿದೆ.";
+
+/* Error opening a Keyman package - it does not exist / the specified location is wrong */
+"kmp-error-missing" = "ನಿರ್ದಿಷ್ಟಪಡಿಸಿದ ಪ್ಯಾಕೇಜ್ ಅಸ್ತಿತ್ವದಲ್ಲಿಲ್ಲ.";
+
+/* Error installing a Keyman package - expected resource (keyboard or dictionary) is missing */
+"kmp-error-missing-resource" = "ಈ ಪ್ಯಾಕೇಜ್‌ನಲ್ಲಿ ಉಲ್ಲೇಖಿಸಿರುವ ಕೀಲಿಮಣೆ ಅಥವ ಶಬ್ದಕೋಶವನ್ನು ಹೊಂದಿಲ್ಲ.";
+
+/* Error installing a Keyman package with a version of Keyman that does not support it */
+"kmp-error-unsupported-keyman-version" = "ಈ ಪ್ಯಾಕೇಜ್‌ಗೆ ಹೊಸ ಆವೃತ್ತಿಯ ಕೀಮ್ಯಾನ್ ಅಗತ್ಯವಿದೆ.";
+
+/* Error opening a Keyman package - cannot parse contents */
+"kmp-error-no-metadata" = "ಈ ಪ್ಯಾಕೇಜ್ ಅನ್ನು ಸರಿಯಾಗಿ ನಿರ್ಮಿಸಲಾಗಿಲ್ಲ - ವಿಷಯಗಳ ಕೊರತೆಯಿದೆ.";
+
+/* Error opening a Keyman package - package's contents are for desktop platforms only */
+"kmp-error-unsupported" = "ಈ ಪ್ಯಾಕೇಜ್ ನಿಮ್ಮ ಸಾಧನಕ್ಕೆ ಬೆಂಬಲವನ್ನು ಒಳಗೊಂಡಿಲ್ಲ.";
+
+/* Error opening a Keyman package - package contains unexpected resource (keyboard or dictionary) type */
+"kmp-error-wrong-type" = "ಈ ಪ್ಯಾಕೇಜ್‌ನಲ್ಲಿ ನಿರೀಕ್ಷಿತ ಸಂಪನ್ಮೂಲ ಪ್ರಕಾರವನ್ನು ಒಳಗೊಂಡಿಲ್ಲ.";
+
+/* Title for the Installed Languages menu */
+"menu-installed-languages-title" = "ಸ್ಥಾಪಿಸಲಾಗಿರುವ ಭಾಷೆಗಳು";
+
+/* Section header for lexical models within a language-specific settings menu */
+"menu-langsettings-label-lexical-models" = "ಶಬ್ದಕೋಶಗಳು";
+
+/* Section header for keyboards within a language-specific settings menu */
+"menu-langsettings-section-keyboards" = "ಕೀಲಿಮಣೆಗಳು";
+
+/* Section header for the settings toggles within a language-specific settings menu */
+"menu-langsettings-section-settings" = "ಭಾಷಾ ಸಂಯೋಜನೆಗಳು";
+
+/* Title for the language-specific settings menus */
+"menu-langsettings-title" = "%@ ಸೆಟ್ಟಿಂಗ್‌ಗಳು";
+
+/* Label for the toggle that enables corrections that is displayed within a language-specific settings menu */
+"menu-langsettings-toggle-correct" = "ತಿದ್ದುಪಡಿಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ";
+
+/* Label for the toggle that enables predictions that is displayed within a language-specific settings menu */
+"menu-langsettings-toggle-predict" = "ಮುಂದಿನ ಪದವನ್ನು ಊಹಿಸಲು ಸಕ್ರಿಯಗೊಳಿಸಿ";
+
+/* Help message for a prompt that appears for confirming a lexical model download:  language (1): lexical model (dictionary) name (2) */
+"menu-lexical-model-install-message" = "ಈ ಶಬ್ದಕೋಶವನ್ನು ಸ್ಥಾಪಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?";
+
+/* Title for a prompt that appears for confirming a lexical model download:  language (1): lexical model (dictionary) name (2) */
+"menu-lexical-model-install-title" = "%1$@: %2$@";
+
+/* Text for an info alert indicating that no lexical models are available */
+"menu-lexical-model-none-message" = "ಯಾವುದೇ ಶಬ್ದಕೋಶಗಳು ಲಭ್ಯವಿಲ್ಲ";
+
+/* Title for the lexical model menu, a submenu of the language-specific settings menus */
+"menu-lexical-model-title" = "%@ ಶಬ್ದಕೋಶಗಳು";
+
+/* Title for the keyboard picker */
+"menu-picker-title" = "ಕೀಲಿಮಣೆಗಳು";
+
+/* Primary text for the Settings menu option to report keyboard crashes */
+"menu-settings-error-report" = "ದೋಷ ವರದಿ ಮಾಡಲು ಅನುಮತಿ ನೀಡಿ";
+
+/* Secondary text for the Settings menu option to report keyboard crashes */
+"menu-settings-error-report-description" = "\"ಪೂರ್ಣ ಪ್ರವೇಶ\" (\"full access\") ಅನುಮತಿ ಬೇಕಾಗಬಹುದು";
+
+/* Primary text for the Settings menu local-file package installation option */
+"menu-settings-install-from-file" = "ಕಡತದಿಂದ ಅನುಸ್ಥಾಪಿಸು";
+
+/* Secondary text for the Settings menu local-file package installation option */
+"menu-settings-install-from-file-description" = ".kmp ಕಡತಗಳಿಗಾಗಿ ಬ್ರೌಸ್ ಮಾಡಿ";
+
+/* Primary text for the Settings menu option that displays the iOS system menu options for the app's keyboard */
+"menu-settings-system-keyboard-menu" = "ಸಿಸ್ಟಮ್ ಕೀಲಿಮಣೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳು";
+
+/* Label for the "Show Banner" toggle on the main settings screen */
+"menu-settings-show-banner" = "ಬ್ಯಾನರ್ ತೋರಿಸು";
+
+/* Label for the "Get Started" automatic display toggle seen in the Settings menu */
+"menu-settings-startup-get-started" = "ಆರಂಭದಲ್ಲಿ 'Get Started' ತೋರಿಸು";
+
+/* Title for the main Settings menu */
+"menu-settings-title" = "ಕೀಮ್ಯಾನ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳು";
+
+/* Secondary text showing current setting for spacebar caption - blank */
+"menu-settings-spacebar-hint-blank" = "ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆ ತೋರಿಸಬೇಡ";
+
+/* Secondary text showing current setting for spacebar caption - keyboard */
+"menu-settings-spacebar-hint-keyboard" = "ಕೀಲಿಮಣೆಯ ಹೆಸರನ್ನು ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆಯನ್ನಾಗಿ ತೋರಿಸು";
+
+/* Secondary text showing current setting for spacebar caption - language */
+"menu-settings-spacebar-hint-language" = "ಭಾಷೆಯನ್ನು ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆಯನ್ನಾಗಿ ತೋರಿಸು";
+
+/* Secondary text showing current setting for spacebar caption - language + keyboard */
+"menu-settings-spacebar-hint-languageKeyboard" = "ಭಾಷೆ ಮತ್ತು ಕೀಲಿಮಣೆ ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆಯನ್ನಾಗಿ ತೋರಿಸು";
+
+/* Label for the "Spacebar Caption" item on the main settings screen */
+"menu-settings-spacebar-text" = "ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆ";
+
+/* Title for the "Spacebar Caption" settings screen */
+"menu-settings-spacebar-title" = "ಸ್ಪೇಸ್‌ಬಾರ್ ಶೀರ್ಷಿಕೆ";
+
+/* Text showing name of spacebar caption - blank */
+"menu-settings-spacebar-item-blank" = "ಖಾಲಿ";
+
+/* Text showing name of spacebar caption - keyboard */
+"menu-settings-spacebar-item-keyboard" = "ಕೀಲಿಮಣೆ";
+
+/* Text showing name of spacebar caption - language */
+"menu-settings-spacebar-item-language" = "ಭಾಷೆ";
+
+/* Text showing name of spacebar caption - language + keyboard */
+"menu-settings-spacebar-item-languageKeyboard" = "ಭಾಷೆ ಮತ್ತು ಕೀಲಿಮಣೆ";
+
+/* Short text for notification:  download failure for keyboard */
+"notification-download-failure-keyboard" = "ಕೀಲಿಮಣೆ ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ";
+
+/* Short text for notification:  download failure for lexical model */
+"notification-download-failure-lexical-model" = "ಶಬ್ದಕೋಶವನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ";
+
+/* Short text for notification:  download success for keyboard */
+"notification-download-success-keyboard" = "ಕೀಲಿಮಣೆ ಯಶಸ್ವಿಯಾಗಿ ಡೌನ್‌ಲೋಡ್ ಪೂರ್ಣಗೊಂಡಿದೆ";
+
+/* Short text for notification:  download success for lexical model */
+"notification-download-success-lexical-model" = "ಶಬ್ದಕೋಶದ ಮಾದರಿ ಯಶಸ್ವಿಯಾಗಿ ಡೌನ್‌ಲೋಡ್ ಪೂರ್ಣಗೊಂಡಿದೆ";
+
+/* Short text for notification:  downloading a keyboard */
+"notification-downloading-keyboard" = "ಕೀಲಿಮಣೆಯನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ\U2026";
+
+/* Short text for notification:  downloading a lexical model */
+"notification-downloading-lexical-model" = "ಶಬ್ದಕೋಶವನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ\U2026";
+
+/* Short text for notification:  an update is available */
+"notification-update-available" = "ನವೀಕರಣ ಲಭ್ಯವಿದೆ";
+
+/* Short text for notification:  currently updating */
+"notification-update-processing" = "ನವೀಕರಿಸಲಾಗುತ್ತಿದೆ\U2026";
+
+/* Text indicating success at installing new keyboards or dictionaries */
+"success-install" = "ಯಶಸ್ವಿಯಾಗಿ ಸ್ಥಾಪಿಸಲಾಗಿದೆ.";
+
+/* A title to use in alerts indicating 'success' at whatever task the user requested */
+"success-title" = "ಯಶಸ್ವಿಯಾಗಿದೆ";

--- a/ios/engine/KMEI/KeymanEngine/kn.lproj/Localizable.stringsdict
+++ b/ios/engine/KMEI/KeymanEngine/kn.lproj/Localizable.stringsdict
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>menu-langsettings-lexical-model-count</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>one</key>
+        <string>%u ಶಬ್ದಕೋಶ ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+        <key>other</key>
+        <string>%u ಶಬ್ದಕೋಶಗಳನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+      </dict>
+    </dict>
+    <key>notification-update-failed</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>one</key>
+        <string>%u ನವೀಕರಣೆ ವಿಫಲವಾಯಿತು</string>
+        <key>other</key>
+        <string>%u ನವೀಕರಣೆಗಳು ವಿಫಲವಾಯಿತು</string>
+      </dict>
+    </dict>
+    <key>notification-update-success</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>one</key>
+        <string>%u ನವೀಕರಿಣೆ ಯಶಸ್ವಿಯಾಗಿದೆ</string>
+        <key>other</key>
+        <string>%u ನವೀಕರಿಣೆಗಳು ಯಶಸ್ವಿಯಾಗಿದೆ</string>
+      </dict>
+    </dict>
+    <key>settings-keyboards-installed-count</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>one</key>
+        <string>%u ಕೀಲಿಮಣೆಯನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+        <key>other</key>
+        <string>%u ಕೀಲಿಮಣೆಗಳನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+      </dict>
+    </dict>
+    <key>settings-languages-installed-count</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>one</key>
+        <string>%u ಭಾಷೆಯನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+        <key>other</key>
+        <string>%u ಭಾಷೆಗಳನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+      </dict>
+    </dict>
+    <key>package-default-found-keyboards</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>one</key>
+        <string>ಪ್ಯಾಕೇಜ್‌ನಲ್ಲಿ %u ಕೀಲಿಮಣೆ ಕಂಡುಬಂದಿದೆ:</string>
+        <key>other</key>
+        <string>ಪ್ಯಾಕೇಜ್‌ನಲ್ಲಿ %u ಕೀಲಿಮಣೆಗಳು ಕಂಡುಬಂದಿವೆ:</string>
+      </dict>
+    </dict>
+    <key>package-default-found-lexical-models</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>one</key>
+        <string>ಪ್ಯಾಕೇಜ್‌ನಲ್ಲಿ %u ಶಬ್ದಕೋಶ ಕಂಡುಬಂದಿದೆ:</string>
+        <key>other</key>
+        <string>ಪ್ಯಾಕೇಜ್‌ನಲ್ಲಿ %u ಶಬ್ದಕೋಶಗಳು ಕಂಡುಬಂದಿವೆ:</string>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
+++ b/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		16A9229D20325253003CC98E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Keyman/Info.plist; sourceTree = SOURCE_ROOT; };
 		293EA3E027059C6900545EED /* ha */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ha; path = ha.lproj/Localizable.strings; sourceTree = "<group>"; };
 		294914742738DF7700400732 /* ff-NG */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ff-NG"; path = "ff-NG.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		297810FD297FA818007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		29B27FEE29062BBC0036917E /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		29BFA75D282931F8009FCCC3 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		29BFA769282946EC009FCCC3 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -794,6 +795,7 @@
 				it,
 				pl,
 				nl,
+				kn,
 			);
 			mainGroup = 98ABADA7176935E400B62590;
 			productRefGroup = 98ABADB1176935E400B62590 /* Products */;
@@ -1101,6 +1103,7 @@
 				29BFA75D282931F8009FCCC3 /* it */,
 				29BFA769282946EC009FCCC3 /* pl */,
 				29B27FEE29062BBC0036917E /* nl */,
+				297810FD297FA818007C886D /* kn */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -1116,9 +1119,11 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Keyman/Keyman.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3YE4W86L3G;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 3YE4W86L3G;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Keyman/Keyman-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
@@ -1136,6 +1141,7 @@
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Keyman Development";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Keyman Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -1152,9 +1158,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Keyman/Keyman.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3YE4W86L3G;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 3YE4W86L3G;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Keyman/Keyman-Prefix.pch";
 				INFOPLIST_FILE = Keyman/Info.plist;
@@ -1171,6 +1179,7 @@
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Keyman Distribution";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Keyman Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
@@ -1442,9 +1451,11 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Keyman/Keyman.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3YE4W86L3G;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 3YE4W86L3G;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Keyman/Keyman-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
@@ -1462,6 +1473,7 @@
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Keyman Development";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Keyman Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;

--- a/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
+++ b/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
@@ -1119,11 +1119,9 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Keyman/Keyman.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3YE4W86L3G;
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 3YE4W86L3G;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Keyman/Keyman-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
@@ -1141,7 +1139,6 @@
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Keyman Development";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Keyman Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -1158,11 +1155,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Keyman/Keyman.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3YE4W86L3G;
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 3YE4W86L3G;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Keyman/Keyman-Prefix.pch";
 				INFOPLIST_FILE = Keyman/Info.plist;
@@ -1177,9 +1172,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Tavultesoft.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Keyman;
 				PROVISIONING_PROFILE = "";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Keyman Distribution";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Keyman Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
@@ -1451,11 +1444,9 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Keyman/Keyman.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 3YE4W86L3G;
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 3YE4W86L3G;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Keyman/Keyman-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
@@ -1473,7 +1464,6 @@
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Keyman Development";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Keyman Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;

--- a/ios/keyman/Keyman/Keyman/kn.lproj/Localizable.strings
+++ b/ios/keyman/Keyman/Keyman/kn.lproj/Localizable.strings
@@ -1,0 +1,81 @@
+/* Title for the bookmarks menu within the embedded browser */
+"browser-bookmarks-add-title" = "ಬುಕ್‌ಮಾರ್ಕ್ ಸೇರಿಸಿ";
+
+/* Title for the bookmarks menu within the embedded browser */
+"browser-bookmarks-none" = "ಯಾವುದೇ ಬುಕ್‍ಮಾರ್ಕ್‌ಗಳಿಲ್ಲ";
+
+/* Title for the bookmarks menu within the embedded browser */
+"browser-bookmarks-title" = "ಬುಕ್‍ಮಾರ್ಕ್‌ಗಳು";
+
+/* Used to confirm a user's desire to install a package */
+"confirm-install" = "ಅನುಸ್ಥಾಪಿಸು";
+
+/* The label for the toggle to stop automatically showing the "Get Started" tutorial popup. */
+"disable-get-started" = "ಪುನಃ ತೋರಿಸಬೇಡಿ";
+
+/* Indicates an error opening a web page requested by a user */
+"error-opening-page" = "ಪುಟವನ್ನು ತೆರೆಯಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ";
+
+/* Long-form used when installing a font in order to display a language properly. */
+"font-install-description" = "ನಿಮ್ಮ ಎಲ್ಲಾ ಅಪ್ಲಿಕೇಶನ್‌ಗಳಲ್ಲಿ %@ ಅನ್ನು ಸರಿಯಾಗಿ ಪ್ರದರ್ಶಿಸಲು 'ಸ್ಥಾಪನೆ'ಯನ್ನು ಸ್ಪರ್ಶಿಸಿ";
+
+/* The name of the iOS Settings menu option for keyboards */
+"ios-settings-keyboards" = "ಕೀಲಿಮಣೆಗಳು";
+
+/* The name of the iOS Settings menu option for giving the keyboard full access.  (The menu entry
+underneath the app's name within the app-specific keyboard menu.) */
+"ios-settings-allow-full-access" = "ಪೂರ್ಣ ಪ್ರವೇಶವನ್ನು ಅನುಮತಿಸಿ";
+
+/* Short-form used when installing a font in order to display a language properly. */
+"language-for-font" = "%@ ಅಕ್ಷರ ಶೈಲಿ";
+
+/* Used for 'add' options within menus */
+"menu-add" = "ಸೇರಿಸು";
+
+/* Used to indicate a sequence of menu options that a user needs to copy.  May be chained.  Example:  "Keyboards (1) > Enable Keyman (2)" */
+"menu-breadcrumbing" = "%1$@ > %2$@";
+
+/* Used to exit a menu without choosing an option */
+"menu-cancel" = "ರದ್ದುಮಾಡು";
+
+/* Menu option that erases all previously-typed text. */
+"menu-clear-text" = "ಪಠ್ಯವನ್ನು ತೆರವುಗೊಳಿಸಿ";
+
+/* Menu option that displays a list designed to help users start using the app */
+"menu-get-started" = "ಶುರುಮಾಡಿ";
+
+/* Menu option that displays help for the app */
+"menu-help" = "ಮಾಹಿತಿ";
+
+/* Menu option that displays the main screen's drop-down menu */
+"menu-more" = "ಇನ್ನಷ್ಟು";
+
+/* Menu option used to edit keyboard and dictionary settings */
+"menu-settings" = "ಸೆಟ್ಟಿಂಗ್‌ಗಳು";
+
+/* Menu option that displays the iOS Share menu */
+"menu-share" = "ಹಂಚಿಕೊಳ್ಳಿ";
+
+/* Menu option that displays an embedded web browser. */
+"menu-show-browser" = "ಬ್ರೌಸರ್";
+
+/* Menu option used to control in-app font size. */
+"menu-text-size" = "ಅಕ್ಷರದ ಗಾತ್ರ";
+
+/* Used to describe the current font size */
+"text-size-label" = "ಅಕ್ಷರದ ಗಾತ್ರ: %i";
+
+/* Text to indicate that a user should set a toggle within iOS Settings to 'active'. */
+"toggle-to-enable" = "%@ ಸಕ್ರಿಯಗೊಳಿಸಿ";
+
+/* First option on the Get Started tutorial - Add a keyboard for your language */
+"tutorial-add-keyboard" = "ನಿಮ್ಮ ಭಾಷೆಗೆ ಕೀಲಿಮಣೆಯನ್ನು ಸೇರಿಸಿ";
+
+/* Third option on the Get Started tutorial - Displays app help. */
+"tutorial-show-help" = "ಹೆಚ್ಚಿನ ಮಾಹಿತಿ";
+
+/* Second option on the Get Started tutorial - Set up Keyman as system-wide keyboard */
+"tutorial-system-keyboard" = "ಕೀಮ್ಯಾನ್‌ವನ್ನು ಸಿಸ್ಟಮ್-ಆದ್ಯಂತ ಕೀಲಿಮಣೆಯಾಗಿ ಸ್ಥಾಪಿಸು";
+
+/* Used to display app version (as in \"Version: 1.0.2\" */
+"version-label" = "ಆವೃತ್ತಿ: %@";

--- a/linux/keyman-config/locale/kn_IN.po
+++ b/linux/keyman-config/locale/kn_IN.po
@@ -1,0 +1,331 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: keyman\n"
+"Report-Msgid-Bugs-To: <support@keyman.com>\n"
+"POT-Creation-Date: 2020-08-19 19:17+0200\n"
+"PO-Revision-Date: 2023-01-03 04:05\n"
+"Last-Translator: \n"
+"Language-Team: Kannada\n"
+"Language: kn_IN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: keyman\n"
+"X-Crowdin-Project-ID: 386703\n"
+"X-Crowdin-Language: kn\n"
+"X-Crowdin-File: /master/linux/keyman-config.pot\n"
+"X-Crowdin-File-ID: 504\n"
+
+#: keyman_config/__init__.py:68
+msgid "Neither sentry-sdk nor raven is available. Not enabling Sentry error reporting."
+msgstr "sentry-sdk/ಸೆಂಟ್ರಿ-ಎಸ್‌ಡಿಕೆ ಅಥವಾ raven/ರಾವೆನ್ ಲಭ್ಯವಿಲ್ಲ. Sentry/ಸೆಂಟ್ರಿ ದೋಷ ವರದಿ ಮಾಡುಲು ಸಕ್ರಿಯಗೊಳಿಸುತ್ತಿಲ್ಲ."
+
+#: keyman_config/downloadkeyboard.py:23
+msgid "Download Keyman keyboards"
+msgstr "ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆಗಳನ್ನು ಡೌನ್ಲೋಡ್ ಮಾಡಿ"
+
+#: keyman_config/downloadkeyboard.py:37 keyman_config/keyboard_details.py:49
+#: keyman_config/keyboard_details.py:340 keyman_config/view_installed.py:205
+msgid "_Close"
+msgstr "_ಮುಚ್ಚು"
+
+#: keyman_config/install_kmp.py:99
+msgid "You do not have permissions to install the keyboard files to the shared area /usr/local/share/keyman"
+msgstr "(shared area) ಹಂಚಿಕೆಯ ಪ್ರದೇಶದಲ್ಲಿ /usr/local/share/keyman ಕೀಲಿಮಣೆ ಕಡತಗಳನ್ನು ಸ್ಥಾಪಿಸಲು, ನಿಮಗೆ ಅನುಮತಿ ಇಲ್ಲ"
+
+#: keyman_config/install_kmp.py:103
+msgid "You do not have permissions to install the documentation to the shared documentation area /usr/local/share/doc/keyman"
+msgstr "(shared area) ಹಂಚಿಕೆಯ ಪ್ರದೇಶದಲ್ಲಿ /usr/local/share/doc/keyman ದಾಖಲೆಗಳನ್ನು ಸ್ಥಾಪಿಸಲು, ನಿಮಗೆ ಅನುಮತಿ ಇಲ್ಲ"
+
+#: keyman_config/install_kmp.py:107
+msgid "You do not have permissions to install the font files to the shared font area /usr/local/share/fonts"
+msgstr "(shared area) ಹಂಚಿಕೆಯ ಪ್ರದೇಶದಲ್ಲಿ /usr/local/share/fonts ಅಕ್ಷರಶೈಲಿ/ಫಾಂಟ್‌ಗಳನ್ನು ಸ್ಥಾಪಿಸಲು, ನಿಮಗೆ ಅನುಮತಿ ಇಲ್ಲ"
+
+#: keyman_config/install_kmp.py:179
+#, python-brace-format
+msgid "install_kmp.py: error: No kmp.json or kmp.inf found in {package}"
+msgstr "install_kmp.py: ದೋಷ: No kmp.json or kmp.inf found in {package}"
+
+#: keyman_config/install_kmp.py:246
+#, python-brace-format
+msgid "install_kmp.py: error: No kmp.json or kmp.inf found in {packageFile}"
+msgstr "install_kmp.py: ದೋಷ: No kmp.json or kmp.inf found in {packageFile}"
+
+#: keyman_config/install_window.py:54
+#, python-brace-format
+msgid "Installing keyboard/package {keyboardid}"
+msgstr "{keyboardid} ಕೀಲಿಮಣೆ/ಪ್ಯಾಕೇಜ್ ಅನ್ನು ಸ್ಥಾಪಿಸಲಾಗುತ್ತಿದೆ"
+
+#: keyman_config/install_window.py:72 keyman_config/install_window.py:93
+msgid "Keyboard is installed already"
+msgstr "ಕೀಲಿಮಣೆಯನ್ನು ಈಗಾಗಲೇ ಸ್ಥಾಪಿಸಲಾಗಿದೆ"
+
+#: keyman_config/install_window.py:74
+#, python-brace-format
+msgid "The {name} keyboard is already installed at version {version}. Do you want to uninstall then reinstall it?"
+msgstr "ಈಗಾಗಲೇ {name} ಹೆಸರಿನ ಕೀಲಿಮಣೆ {version} ಆವೃತ್ತಿಯೊಂದಿಗೆ ಅನುಸ್ಥಾಪಿಸಲಾಗಿದೆ. ಇದನ್ನು ನೀವು ಅಸ್ಥಾಪಿಸಿದ ನಂತರ ಮರುಸ್ಥಾಪಿಸಲು ಬಯಸುವಿರಾ?"
+
+#: keyman_config/install_window.py:95
+#, python-brace-format
+msgid "The {name} keyboard is already installed with a newer version {installedversion}. Do you want to uninstall it and install the older version {version}?"
+msgstr "ಈಗಾಗಲೇ {name} ಹೆಸರಿನ ಕೀಲಿಮಣೆ {installedversion} ಹೊಸ ಆವೃತ್ತಿಯೊಂದಿಗೆ ಅನುಸ್ಥಾಪಿಸಲಾಗಿದೆ. ಇದನ್ನು ನೀವು ಅಸ್ಥಾಪಿಸಿದ ನಂತರ {version} ಹಳೆಯ ಆವೃತ್ತಿಯನ್ನು ಸ್ಥಾಪಿಸಲು ಬಯಸುವಿರಾ?"
+
+#: keyman_config/install_window.py:128
+msgid "Keyboard layouts:   "
+msgstr "ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸಗಳು:   "
+
+#: keyman_config/install_window.py:147
+msgid "Fonts:   "
+msgstr "ಅಕ್ಷರಶೈಲಿ/ಫಾಂಟ್‌ಗಳು:   "
+
+#: keyman_config/install_window.py:167 keyman_config/keyboard_details.py:96
+msgid "Package version:   "
+msgstr "ಪ್ಯಾಕೇಜ್ ಆವೃತ್ತಿ:   "
+
+#: keyman_config/install_window.py:179
+msgid "Author:   "
+msgstr "ಲೇಖಕ:   "
+
+#: keyman_config/install_window.py:197
+msgid "Website:   "
+msgstr "ವೆಬ್‌ಸೈಟ್:   "
+
+#: keyman_config/install_window.py:211
+msgid "Copyright:   "
+msgstr "ಕೃತಿಸ್ವಾಮ್ಯ:   "
+
+#: keyman_config/install_window.py:245
+msgid "Details"
+msgstr "ವಿವರಗಳು"
+
+#: keyman_config/install_window.py:248
+msgid "README"
+msgstr "ಸಂದೇಶವನ್ನು ಓದಿ"
+
+#: keyman_config/install_window.py:256 keyman_config/view_installed.py:200
+msgid "_Install"
+msgstr "_ಸ್ಥಾಪಿಸು"
+
+#: keyman_config/install_window.py:260
+msgid "_Cancel"
+msgstr "_ರದ್ದುಮಾಡು"
+
+#: keyman_config/install_window.py:305
+#, python-brace-format
+msgid "Keyboard {name} installed"
+msgstr "{name} ಕೀಲಿಮಣೆ ಸ್ಥಾಪಿಸಲಾಗಿದೆ"
+
+#: keyman_config/install_window.py:310 keyman_config/install_window.py:315
+#, python-brace-format
+msgid "Keyboard {name} could not be installed."
+msgstr "{name} ಕೀಲಿಮಣೆ ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ."
+
+#: keyman_config/install_window.py:311
+msgid "Error Message:"
+msgstr "ದೋಷದ ಸಂದೇಶ:"
+
+#: keyman_config/install_window.py:316
+msgid "Warning Message:"
+msgstr "ಎಚ್ಚರಿಕೆ ಸಂದೇಶ:"
+
+#: keyman_config/keyboard_details.py:37
+#, python-brace-format
+msgid "{name} keyboard"
+msgstr "{name} ಕೀಲಿಮಣೆ"
+
+#: keyman_config/keyboard_details.py:53
+msgid "ERROR: Keyboard metadata is damaged.\n"
+"Please \"Uninstall\" and then \"Install\" the keyboard."
+msgstr "ದೋಷ: ಕೀಲಿಮಣೆ (metadata) ಮೆಟಾಡೇಟಾ ಹಾನಿಯಾಗಿದೆ.\n"
+"ದಯವಿಟ್ಟು ಕೀಲಿಮಣೆಯನ್ನು \"ಅಸ್ಥಾಪಿಸಿ\" ಹಾಗು ಮತ್ತೆ \"ಸ್ಥಾಪಿಸಿ\"."
+
+#: keyman_config/keyboard_details.py:74
+msgid "Package name:   "
+msgstr "ಪ್ಯಾಕೇಜ್‌ ಹೆಸರು:   "
+
+#: keyman_config/keyboard_details.py:85
+msgid "Package id:   "
+msgstr "ಪ್ಯಾಕೇಜ್ id:   "
+
+#: keyman_config/keyboard_details.py:108
+msgid "Package description:   "
+msgstr "ಪ್ಯಾಕೇಜ್ ವಿವರಣೆ:   "
+
+#: keyman_config/keyboard_details.py:121
+msgid "Package author:   "
+msgstr "ಪ್ಯಾಕೇಜ್ ಲೇಖಕರು:   "
+
+#: keyman_config/keyboard_details.py:133
+msgid "Package copyright:   "
+msgstr "ಪ್ಯಾಕೇಜ್ ಕೃತಿಸ್ವಾಮ್ಯ:   "
+
+#: keyman_config/keyboard_details.py:174
+msgid "Keyboard filename:   "
+msgstr "ಕೀಲಿಮಣೆ ಕಡತದ ಹೆಸರು:   "
+
+#: keyman_config/keyboard_details.py:187
+msgid "Keyboard name:   "
+msgstr "ಕೀಲಿಮಣೆ ಹೆಸರು:   "
+
+#: keyman_config/keyboard_details.py:198
+msgid "Keyboard id:   "
+msgstr "ಕೀಲಿಮಣೆ ಐಡಿ:   "
+
+#: keyman_config/keyboard_details.py:209
+msgid "Keyboard version:   "
+msgstr "ಕೀಲಿಮಣೆ ಆವೃತ್ತಿ:   "
+
+#: keyman_config/keyboard_details.py:221
+msgid "Keyboard author:   "
+msgstr "ಕೀಲಿಮಣೆ ಲೇಖಕರು:   "
+
+#: keyman_config/keyboard_details.py:232
+msgid "Keyboard license:   "
+msgstr "ಕೀಲಿಮಣೆ ಪರವಾನಗಿ:   "
+
+#: keyman_config/keyboard_details.py:243
+msgid "Keyboard description:   "
+msgstr "ಕೀಲಿಮಣೆ ವಿವರಣೆ:   "
+
+#: keyman_config/keyboard_details.py:334
+#, python-brace-format
+msgid "Scan this code to load this keyboard\n"
+"on another device or <a href='{uri}'>share online</a>"
+msgstr "ಈ ಕೀಲಿಮಣೆಯನ್ನು ಮತ್ತೊಂದು ಸಾಧನದಲ್ಲಿ ಸ್ಥಾಪಿಸಲು ಈ ಕೋಡ್ಅನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡಿ ಅಥವಾ <a href='{uri}'>ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ ಹಂಚಿಕೊಳ್ಳಿ</a>"
+
+#: keyman_config/options.py:24
+#, python-brace-format
+msgid "{packageId} Settings"
+msgstr "{packageId} ಸೆಟ್ಟಿಂಗ್‌ಗಳು"
+
+#: keyman_config/view_installed.py:30
+msgid "Keyman Configuration"
+msgstr "ಕೀಮ್ಯಾನ್ ಸಂರಚನೆ (ಕಾನ್ಫಿಗರೇಷನ್)"
+
+#: keyman_config/view_installed.py:60
+msgid "Choose a kmp file..."
+msgstr "kmp ಕಡತವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ..."
+
+#. i18n: file type in file selection dialog
+#: keyman_config/view_installed.py:65
+msgid "KMP files"
+msgstr "KMP ಕಡತಗಳು"
+
+#. i18n: column header in table displaying installed keyboards
+#: keyman_config/view_installed.py:141
+msgid "Icon"
+msgstr "ಐಕಾನ್"
+
+#. i18n: column header in table displaying installed keyboards
+#: keyman_config/view_installed.py:145
+msgid "Name"
+msgstr "ಹೆಸರು"
+
+#. i18n: column header in table displaying installed keyboards
+#: keyman_config/view_installed.py:148
+msgid "Version"
+msgstr "ಆವೃತ್ತಿ"
+
+#: keyman_config/view_installed.py:161
+msgid "_Uninstall"
+msgstr "_ಅನುಸ್ಥಾಪಿಸು"
+
+#: keyman_config/view_installed.py:162 keyman_config/view_installed.py:304
+msgid "Uninstall keyboard"
+msgstr "ಕೀಲಿಮಣೆಯನ್ನು ಅನುಸ್ಥಾಪಿಸು"
+
+#: keyman_config/view_installed.py:167
+msgid "_About"
+msgstr "_ಬಗ್ಗೆ"
+
+#: keyman_config/view_installed.py:168 keyman_config/view_installed.py:306
+msgid "About keyboard"
+msgstr "ಕೀಲಿಮಣೆ ಬಗ್ಗೆ"
+
+#: keyman_config/view_installed.py:173
+msgid "_Help"
+msgstr "_ಸಹಾಯ"
+
+#: keyman_config/view_installed.py:174 keyman_config/view_installed.py:305
+msgid "Help for keyboard"
+msgstr "ಕೀಲಿಮಣೆಯ ಸಹಾಯ"
+
+#: keyman_config/view_installed.py:179
+msgid "_Options"
+msgstr "_ಆಯ್ಕೆಗಳು"
+
+#: keyman_config/view_installed.py:180 keyman_config/view_installed.py:307
+msgid "Settings for keyboard"
+msgstr "ಕೀಲಿಮಣೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳು"
+
+#: keyman_config/view_installed.py:190
+msgid "_Refresh"
+msgstr "_ಪುನಃಹೊಸದಾಗಿಸು"
+
+#: keyman_config/view_installed.py:191
+msgid "Refresh keyboard list"
+msgstr "ಕೀಲಿಮಣೆಯ ಪಟ್ಟಿಯನ್ನು ಪುನಃ ಹೊಸದಾಗಿಸು"
+
+#: keyman_config/view_installed.py:195
+msgid "_Download"
+msgstr "_ಡೌನ್ಲೋಡ್"
+
+#: keyman_config/view_installed.py:196
+msgid "Download and install a keyboard from the Keyman website"
+msgstr "ಕೀಮ್ಯಾನ್ ವೆಬ್‌ಸೈಟ್‌ನಿಂದ ಕೀಲಿಮಣೆಯನ್ನು ಡೌನ್ಲೋಡ್ ಮಾಡಿ ಹಾಗು ಅನುಸ್ಥಾಪಿಸಿ"
+
+#: keyman_config/view_installed.py:201
+msgid "Install a keyboard from a file"
+msgstr "ಕಡತದಿಂದ ಕೀಲಿಮಣೆಯನ್ನು ಅನುಸ್ಥಾಪಿಸು"
+
+#: keyman_config/view_installed.py:206
+msgid "Close window"
+msgstr "ವಿಂಡೋವನ್ನು ಮುಚ್ಚಿ"
+
+#: keyman_config/view_installed.py:278
+#, python-brace-format
+msgid "Uninstall keyboard {package}"
+msgstr "{package} ಕೀಲಿಮಣೆ ಅಸ್ಥಾಪಿಸು"
+
+#: keyman_config/view_installed.py:280
+#, python-brace-format
+msgid "Help for keyboard {package}"
+msgstr "{package} ಕೀಲಿಮಣೆಯ ಸಹಾಯ"
+
+#: keyman_config/view_installed.py:282
+#, python-brace-format
+msgid "About keyboard {package}"
+msgstr "{package} ಕೀಲಿಮಣೆ ಬಗ್ಗೆ"
+
+#: keyman_config/view_installed.py:284
+#, python-brace-format
+msgid "Settings for keyboard {package}"
+msgstr "{package} ಕೀಲಿಮಣೆಯ ಸೆಟ್ಟಿಂಗ್‌ಗಳು"
+
+#: keyman_config/view_installed.py:349
+msgid "Uninstall keyboard package?"
+msgstr "ಕೀಲಿಮಣೆ ಪ್ಯಾಕೇಜ್ ಅನ್ನು ಅಸ್ಥಾಪಿಸಬೇಕೆ?"
+
+#: keyman_config/view_installed.py:351
+#, python-brace-format
+msgid "Are you sure that you want to uninstall the {keyboard} keyboard and its fonts?"
+msgstr "{keyboard} ಕೀಲಿಮಣೆ ಮತ್ತು ಅದರ ಜೊತೆಯಲ್ಲಿ ಬಂದ ಫಾಂಟ್‌/ಅಕ್ಷರಶೈಲಿಗಳನ್ನು ಅಸ್ಥಾಪಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?"
+
+#: keyman_config/welcome.py:22
+#, python-brace-format
+msgid "{name} installed"
+msgstr "{name} ಸ್ಥಾಪಿಸಲಾಗಿದೆ"
+
+#: keyman_config/welcome.py:40
+msgid "Open in _Web browser"
+msgstr "_ವೆಬ್ ಬ್ರೌಸರ್‌ನಲ್ಲಿ ತೆರೆ"
+
+#: keyman_config/welcome.py:42
+msgid "Open in the default web browser to do things like printing"
+msgstr "ಮುದ್ರಣದಂತಹ ಕೆಲಸಗಳನ್ನು ಮಾಡಲು ಪೂರ್ವನಿರ್ಧರಿತ ವೆಬ್ ಬ್ರೌಸರ್ ನಲ್ಲಿ ತೆರೆ"
+
+#: keyman_config/welcome.py:45
+msgid "_OK"
+msgstr "_ಸರಿ"
+

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -149,6 +149,12 @@
 		293EA3F527181FDA00545EED /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		296FE2FA275DD21600F46898 /* KMPackageReader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KMPackageReader.h; sourceTree = "<group>"; };
 		296FE2FB275DD21600F46898 /* KMPackageReader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KMPackageReader.m; sourceTree = "<group>"; };
+		29781101297FB262007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/KMAboutWindowController.strings; sourceTree = "<group>"; };
+		29781102297FB262007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/preferences.strings; sourceTree = "<group>"; };
+		29781103297FB263007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/KMInfoWindowController.strings; sourceTree = "<group>"; };
+		29781104297FB263007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/KMKeyboardHelpWindowController.strings; sourceTree = "<group>"; };
+		29781105297FB263007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		29781106297FB27E007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		297A501228DF4D360074EB1B /* PrivacyWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PrivacyWindowController.m; sourceTree = "<group>"; };
 		297A501328DF4D360074EB1B /* PrivacyWindowController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PrivacyWindowController.xib; sourceTree = "<group>"; };
 		297A501428DF4D360074EB1B /* PrivacyConsent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrivacyConsent.h; sourceTree = "<group>"; };
@@ -748,6 +754,7 @@
 				nl,
 				"zh-Hans",
 				"ff-NG",
+				kn,
 			);
 			mainGroup = 989C9BFF1A7876DE00A20425;
 			productRefGroup = 989C9C091A7876DE00A20425 /* Products */;
@@ -995,6 +1002,7 @@
 				29B27FF229062FF50036917E /* nl */,
 				29B6BB5B292239B4008F04BD /* zh-Hans */,
 				2901BA8A292332B3009903EC /* ff-NG */,
+				29781101297FB262007C886D /* kn */,
 			);
 			name = KMAboutWindowController.xib;
 			sourceTree = "<group>";
@@ -1015,6 +1023,7 @@
 				29B27FF329062FF50036917E /* nl */,
 				29B6BB5C292239B4008F04BD /* zh-Hans */,
 				2901BA8B292332B3009903EC /* ff-NG */,
+				29781102297FB262007C886D /* kn */,
 			);
 			name = preferences.xib;
 			path = Keyman4MacIM/KMConfiguration;
@@ -1035,6 +1044,7 @@
 				29B27FF7290630170036917E /* nl */,
 				29B6BB60292239DC008F04BD /* zh-Hans */,
 				2901BA8F292332CF009903EC /* ff-NG */,
+				29781106297FB27E007C886D /* kn */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -1055,6 +1065,7 @@
 				29B27FF429062FF50036917E /* nl */,
 				29B6BB5D292239B4008F04BD /* zh-Hans */,
 				2901BA8C292332B3009903EC /* ff-NG */,
+				29781103297FB263007C886D /* kn */,
 			);
 			name = KMInfoWindowController.xib;
 			path = Keyman4MacIM/KMInfoWindow;
@@ -1076,6 +1087,7 @@
 				29B27FF529062FF60036917E /* nl */,
 				29B6BB5E292239B4008F04BD /* zh-Hans */,
 				2901BA8D292332B3009903EC /* ff-NG */,
+				29781104297FB263007C886D /* kn */,
 			);
 			name = KMKeyboardHelpWindowController.xib;
 			path = Keyman4MacIM/KMKeyboardHelpWindow;
@@ -1097,6 +1109,7 @@
 				29B27FF629062FF60036917E /* nl */,
 				29B6BB5F292239B4008F04BD /* zh-Hans */,
 				2901BA8E292332B4009903EC /* ff-NG */,
+				29781105297FB263007C886D /* kn */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/kn.lproj/KMAboutWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/kn.lproj/KMAboutWindowController.strings
@@ -1,0 +1,8 @@
+/* button text to close the About window */
+"Kab-Up-fYH.title" = "ಮುಚ್ಚು";
+
+/* text of link to the license agreement */
+"hYC-Bx-aoP.title" = "ಪರವಾನಗಿ ಒಪ್ಪಂದ";
+
+/* button text to open Configuration window  */
+"vkh-b5-vO7.title" = "ಸಂರಚನೆ (ಕಾನ್ಫಿಗರೇಷನ್)...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/kn.lproj/preferences.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/kn.lproj/preferences.strings
@@ -1,0 +1,38 @@
+/* Checkbox text to always show on-screen keyboard */
+"4UX-80-0Vo.title" = "ಯಾವಾಗಲೂ ತೆರೆಯ ಮೇಲೆ ಕೀಲಿಮಣೆ ತೋರಿಸು";
+
+/* Checkbox text to enable verbose Console logging */
+"7J6-zy-R20.title" = "ಹೆಚ್ಚಿನ ವಿವರಗಳನ್ನು ಕನ್ಸೋಲ್‌ನಲ್ಲಿ ದಾಖಲಿಸು";
+
+/* Support button text  */
+"93O-x6-RLF.label" = "ಸಹಾಯ";
+
+/* Download Keyboard button text */
+"CTw-kf-WNS.title" = "ಕೀಲಿಮಣೆ ಡೌನ್ಲೋಡ್ ಮಾಡಿ...";
+
+/* Keyman Configuration window title */
+"F0z-JX-Cv5.title" = "ಕೀಮ್ಯಾನ್ ಸಂರಚನೆ (ಕಾನ್ಫಿಗರೇಷನ್)";
+
+/* button text to go back to previous page */
+"JOK-JV-n8w.title" = "ಹಿಂದೆ";
+
+/* Keyboards button text */
+"MPN-9N-wWc.label" = "ಕೀಲಿಮಣೆಗಳು";
+
+/* text to explain verbose Console logging option */
+"MrI-GM-7d6.title" = "ವರ್ಬೋಸ್ ಲಾಗಿಂಗ್ ಆಯ್ಕೆಯು ಆನ್ ಆಗಿರುವಾಗ, ಕೀಮ್ಯಾನ್ (support) ಬೆಂಬಲವು ಸಮಸ್ಯೆಯನ್ನು ಪತ್ತೆಹಚ್ಚಲು ಸಹಾಯ ಮಾಡುವ ಕ್ರಿಯೆಗಳನ್ನು ಕೀಮ್ಯಾನ್ ಲಾಗ್ ಮಾಡುತ್ತದೆ. ಕೀಮ್ಯಾನ್‌ನಿಂದ ಸಂದೇಶಗಳ ಲಾಗ್ ಅನ್ನು ನೋಡಲು ಕನ್ಸೋಲ್ ಪ್ರೋಗ್ರಾಂ ಅನ್ನು ಬಳಸಬಹುದು. ಕನ್ಸೋಲ್‌ನಲ್ಲಿ, \"ಕೀಮ್ಯಾನ್\" ಪ್ರಕ್ರಿಯೆಯಿಂದ ಎಲ್ಲಾ ಸಂದೇಶಗಳನ್ನು ತೋರಿಸಲು ಫಿಲ್ಟರ್ ಮಾಡಿ. ಅಗತ್ಯವಿದ್ದರೆ ಈ ಲಾಗ್ ಅನ್ನು ರಫ್ತು ಮಾಡಬಹುದು ಮತ್ತು ಕೀಮ್ಯಾನ್ (support) ಬೆಂಬಲಕ್ಕೆ ಕಳುಹಿಸಬಹುದು.";
+
+/* button text to move forward to the next page */
+"eXr-8V-h1g.title" = "ಮುಂದಕ್ಕೆ";
+
+/* button text to return to the home help page */
+"fXS-aC-CMH.title" = "ಹೋಮ್";
+
+/* Options button text */
+"frd-No-seV.label" = "ಆಯ್ಕೆಗಳು";
+
+/* Installed Keyboard column heading */
+"jex-Nd-Qzg.headerCell.title" = "ಅನುಸ್ಥಾಪಿಸಲಾದ ಕೀಲಿಮಣೆಯನ್ನು";
+
+/* Verbose logging tooltip text */
+"uWx-3J-U0D.ibShadowedToolTip" = "ನಿರ್ದಿಷ್ಟ ಕೀಲಿಮಣೆ ಅಥವಾ ಸಾಮಾನ್ಯವಾಗಿ ಕೀಮ್ಯಾನ್‌ನೊಂದಿಗೆ ನೀವು ಸಮಸ್ಯೆಗಳನ್ನು ಹೊಂದಿದ್ದರೆ, ಇದನ್ನು ಆನ್ ಮಾಡಿ.";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/kn.lproj/KMInfoWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/kn.lproj/KMInfoWindowController.strings
@@ -1,0 +1,8 @@
+/* Package Information window title */
+"F0z-JX-Cv5.title" = "ಪ್ಯಾಕೇಜ್ ಮಾಹಿತಿ";
+
+/* button text to show Details */
+"Fvy-XJ-s38.label" = "ವಿವರಗಳು";
+
+/* button text to show Read Me */
+"waA-IW-Qyn.label" = "ಈ ಸಂದೇಶವನ್ನು ಓದಿ";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/kn.lproj/KMKeyboardHelpWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/kn.lproj/KMKeyboardHelpWindowController.strings
@@ -1,0 +1,8 @@
+/* Keyboard Help window title */
+"F0z-JX-Cv5.title" = "ಕೀಲಿಮಣೆ ಸಹಾಯ";
+
+/* OK button text */
+"Zla-QF-m0K.title" = "ಸರಿ";
+
+/* Print button text */
+"fYY-Uj-y4S.title" = "ಮುದ್ರಿಸು...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/kn.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/kn.lproj/Localizable.strings
@@ -1,0 +1,71 @@
+/* Message displayed to confirm delete of the Keyman keyboard selected by the user from the keyboard list  */
+"message-confirm-delete-keyboard" = "'%@' ಕೀಲಿಮಣೆಯನ್ನು ಅಸ್ಥಾಪಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?";
+
+/* Delete keyboard confirmation info indicating that the delete action cannot be undone  */
+"info-cannot-undo-delete-keyboard" = "ನೀವು ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ.";
+
+/* Button text to cancel delete of the specified installed Keyman keyboard  */
+"button-cancel-delete-keyboard" = "ರದ್ದುಮಾಡು";
+
+/* Button text to confirm delete of the specified installed Keyman keyboard  */
+"button-delete-keyboard" = "ಅಳಿಸು";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"message-confirm-install-keyboard" = "ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆ ಅನುಸ್ಥಾಪಿಸಬೇಕೆ?";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"info-install-keyboard-filename" = "ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆಯನ್ನು '%@' ಕಡತದಿಂದ ಅನುಸ್ಥಾಪಿಸಬೇಕೆ?";
+
+/* Button text to cancel installation of the double-clicked Keyman file  */
+"button-cancel-install-keyboard" = "ರದ್ದುಮಾಡು";
+
+/* Button text to confirm installation of the double-clicked Keyman file  */
+"button-install-keyboard" = "ಅನುಸ್ಥಾಪಿಸು";
+
+/* Message displayed to inform user that .kmp file could not be read/unzipped  */
+"message-keyboard-file-unreadable" = "ಕೀಮ್ಯಾನ್ ಕಡತವನ್ನು ಓದಲಾಗಲಿಲ್ಲ '%@'.";
+
+/* Message displayed in Configuration window when keyboard cannot be loaded */
+"message-error-loading-keyboard" = "(ಕೀಲಿಮಣೆಯನ್ನು ಲೋಡ್ ಮಾಡುವಲ್ಲಿ ದೋಷ ಕಂಡುಬಂದಿದೆ)";
+
+/* Message displayed in Configuration window when keyboard metadata cannot be loaded */
+"message-error-unknown-metadata" = "ಅಪರಿಚಿತ";
+
+/* Button text to acknowledge that .kmp file could not be read  */
+"button-keyboard-file-unreadable" = "ಸರಿ";
+
+/* label text to identify Keyman version */
+"version-label-text" = "ಆವೃತ್ತಿ %@";
+
+/* Status text for keyboard downloading  */
+"message-keyboard-downloading" = "ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ...";
+
+/* Status text for keyboard download complete  */
+"message-keyboard-download-complete" = "ಡೌನ್‌ಲೋಡ್ ಪೂರ್ಣಗೊಂಡಿದೆ.";
+
+/* Button text to cancel downloading keyboard  */
+"button-cancel-downloading" = "ರದ್ದುಮಾಡು";
+
+/* Button text keyboard download complete  */
+"button-download-complete" = "ಆಗಿದೆ";
+
+/* keyboards label in the Package Information window */
+"keyboards-label" = "ಕೀಲಿಮಣೆಗಳು:";
+
+/* fonts label in the Package Information window */
+"fonts-label" = "ಅಕ್ಷರಶೈಲಿ/ಫಾಂಟ್‌ಗಳು:";
+
+/* package version label in the Package Information window */
+"package-version-label" = "ಪ್ಯಾಕೇಜ್ ಆವೃತ್ತಿ:";
+
+/* author label in the Package Information window */
+"author-label" = "ಲೇಖಕರು:";
+
+/* website label in the Package Information window */
+"website-label" = "ವೆಬ್‌ಸೈಟ್:";
+
+/* copyright label in the Package Information window */
+"copyright-label" = "ಕೃತಿಸ್ವಾಮ್ಯ:";
+
+/* message displayed to alert user to need grant accessibility permission */
+"privacy-alert-text" = "ಕೀಮ್ಯಾನ್‌ ಸರಿಯಾಗಿ ಕಾರ್ಯನಿರ್ವಹಿಸಲು, ಕೀಮ್ಯಾನ್‌ಗೆ (accessibility features) ಪ್ರವೇಶಿಸುವಿಕೆ ವೈಶಿಷ್ಟ್ಯಗಳ ಅಗತ್ಯವಿದೆ:\n\nಸಿಸ್ಟಂ ಆದ್ಯತೆಗಳು, ಭದ್ರತೆ ಮತ್ತು ಗೌಪ್ಯತೆಗೆ ಪ್ರವೇಶವನ್ನು ನೀಡಿ.\nನಿಮ್ಮ ಸಿಸ್ಟಂ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿ.";

--- a/mac/Keyman4MacIM/Keyman4MacIM/kn.lproj/MainMenu.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/kn.lproj/MainMenu.strings
@@ -1,0 +1,14 @@
+/* Configuration window menu text */
+"P1b-lE-yFw.title" = "ಸಂರಚನೆ (ಕಾನ್ಫಿಗರೇಷನ್)...";
+
+/* Keyboards menu text */
+"bQa-j9-nHe.title" = "ಕೀಲಿಮಣೆಗಳು";
+
+/* Keyboards menu text */
+"goP-aK-3WB.title" = "ಕೀಲಿಮಣೆಗಳು";
+
+/* About menu text */
+"kb2-ww-RS3.title" = "ಬಗ್ಗೆ";
+
+/* On-Screen Keyboard menu text */
+"s96-JI-YDh.title" = "ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ";

--- a/windows/src/desktop/kmshell/locale/kn-IN/strings.xml
+++ b/windows/src/desktop/kmshell/locale/kn-IN/strings.xml
@@ -1,0 +1,911 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  strings.xml: Contains all localizable strings for Keyman for Windows
+  * Create a user interface translation for Keyman for Windows at https://translate.keyman.com/
+-->
+<resources>
+  <!-- Context: System -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.266.0 -->
+  <string name="S_LocaleAuthors" comment="Name(s) of people who created this translation - i.e. your name">ಪಾರ್ಥ ಕೆಂಪಣ್ಣ</string>
+  <!-- Context: _Font -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SK_UIFontName" comment="The standard font">Noto Sans Kannada</string>
+  <!-- Context: _Font -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SK_UIFontSize" comment="The standard font size">10</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKButtonYes" comment="Yes button in message boxes">&amp;ಹೌದು</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKButtonNo" comment="No button in message boxes">&amp;ಇಲ್ಲ</string>
+  <!-- Context: General Strings -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_OK" comment="Ok button term">ಸರಿ</string>
+  <!-- Context: General Strings -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_Cancel" comment="Cancel button term">ರದ್ದುಮಾಡು</string>
+  <!-- Context: General Strings -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_Close" comment="Close button term">ಮುಚ್ಚು</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKButtonOK" comment="OK button in message boxes">ಸರಿ</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKButtonCancel" comment="Cancel button in message boxes">ರದ್ದುಮಾಡು</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 16.0.47 -->
+  <string name="SKAddremove" comment="Add or Remove languages button opens a dialog window">ಭಾಷೆಯನ್ನು ಸೇರಿಸು/ತೆಗೆದುಹಾಕು...</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.330.0 -->
+  <string name="SKBalloonClickToSelectKeyboard" comment="Balloon that shows when Keyman icon is first shown during the tutorial">ಕೀಲಿಮಣೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಲು ಈ ಚಿತ್ರ(ಐಕಾನ್) ಅನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿ</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.330.0 -->
+  <string name="SKBalloonOSKClosed" comment="Balloon that shows when OSK is closed">Keyman ಇನ್ನೂ ಚಾಲನೆಯಲ್ಲಿದೆ. ನಿಮ್ಮ ಭಾಷೆ ಕೀಲಿಮಣೆಯನ್ನು ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ಬಳಸಲು ಈ ಚಿತ್ರ(ಐಕಾನ್) ಅನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿ</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 14.0.234 -->
+  <string name="SKBalloonKeymanIsRunning" comment="Balloon that shows when user tries to start Keyman but it is already running">ಕೀಮ್ಯಾನ್ ಈಗಾಗಲೇ ಚಾಲನೆಯಲ್ಲಿದೆ. ನಿಮ್ಮ ಭಾಷೆ ಕೀಲಿಮಣೆಯನ್ನು ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ಬಳಸಲು ನೋಟಿಫಿಕೇಶನ್ ಏರಿಯಾನಲ್ಲಿ ಕೀಮ್ಯಾನ್ ಐಕಾನ್‌ ಅನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿ</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ConfigurationTitle" comment="Configuration dialog title, which includes the product name">ಕೀಮ್ಯಾನ್ ಸಂರಚನೆ (ಕಾನ್ಫಿಗರೇಷನ್)</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.239.0 -->
+  <string name="S_Caption_Help" comment="Configuration dialog link to Help">ಸಹಾಯ</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47.0 -->
+  <string name="S_Caption_Uninstall" comment="Configuration dialog link to Uninstall Keyboard">ಅಸ್ಥಾಪಿಸು</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47.0 -->
+  <string name="S_Caption_Enable" comment="Configuration dialog link to Enable Keyboard">ಸಕ್ರಿಯಗೊಳಿಸು</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47.0 -->
+  <string name="S_Caption_Disable" comment="Configuration dialog link to Disable Keyboard">ನಿಷ್ಕ್ರಿಯಗೊಳಿಸು</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Keyboards" comment="Keyboard Layouts tab name">ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸಗಳು</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Keyboards_AccessChar" comment="Direct access to the Keyboard Layouts tab using alt+">ಕ</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Options" comment="Options tab name">ಆಯ್ಕೆಗಳು</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Options_AccessChar" comment="Direct access to the Options tab using alt+">ಆ</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkeys" comment="Hotkeys tab name">ನೇರ ಕೀಲಿಗಳು (ಹಾಟ್‌ಕೀ/ಶಾರ್ಟ್‌ಕಟ್‌ಕೀ)</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkeys_AccessChar" comment="Direct access to the Hotkeys tab using alt+">ನ</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Support" comment="Support tab name">ಸಹಾಯ</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Support_AccessChar" comment="Direct access to the Support tab using alt+">ಸ</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.493.0 -->
+  <string name="S_KeepInTouch" comment="Keep in touch tab name">ನಮ್ಮ ಸಂಪರ್ಕದಲ್ಲಿ ಇರಿ</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.492.0 -->
+  <string name="S_KeepInTouch_AccessChar" comment="Direct access to the Keep in Touch tab using alt+">ಪ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Filename" comment="Keyboard download window, etc. - term for filename">ಕಡತದ ಹೆಸರು:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Version" comment="Keyboard download window, etc. - term for package version">ಪ್ಯಾಕೇಜ್ ಆವೃತ್ತಿ:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.442.0 -->
+  <string name="S_Caption_KeyboardVersion" comment="Keyboard download window, etc. - term for keyboard version">ಕೀಲಿಮಣೆ ಆವೃತ್ತಿ:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Author" comment="Keyboard download window, etc. - term for author">ಲೇಖಕರು:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Website" comment="Keyboard download window, etc. - term for website">ವೆಬ್‌ಸೈಟ್:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Package" comment="Keyboard download window, etc. - term for package">ಪ್ಯಾಕೇಜ್:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Fonts" comment="Keyboard download window, etc. - term for fonts">ಅಕ್ಷರಶೈಲಿ/ಫಾಂಟ್‌ಗಳು:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Keyboards" comment="Keyboard download window, etc. - term for keyboard layouts">ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸಗಳು:</string>
+  <!-- Context: Keyboard Install Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Caption_Keyboard" comment="Keyboard install dialog - term for a single keyboard layout">ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸ:</string>
+  <!-- Context: Keyboard Install Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Caption_KeyboardLanguage" comment="Keyboard install dialog - term for caption for language selector a single keyboard layout">ಕೀಲಿಮಣೆಯ ಭಾಷೆ:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Encodings" comment="Keyboard download window, etc. - term for encodings (encodings include Unicode, ANSI, Non-Unicode, etc).">ಎನ್ಕೋಡಿಂಗ್‌ಗಳು:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_LayoutType" comment="Keyboard download window, etc. - term for keyboard layout type (keyboard layout types include Fixed and Mnemonic)">ವಿನ್ಯಾಸ ಪ್ರಕಾರ:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_LayoutType_Positional" comment="Keyboard download window, etc. - term for the fixed keyboard layout type">ಸ್ಥಿರ (ಸ್ಥಾನಿಕ-Positional)</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_LayoutType_Mnemonic" comment="Keyboard download window, etc. - term for the mnemonic keyboard layout type">ವಿಂಡೋಸ್ (Mnemonic) ಆವೃತ್ತಿಗೆ ಮ್ಯಾಪ್ ಮಾಡಲಾಗಿದೆ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.420.0 -->
+  <string name="S_Caption_Languages" comment="Text preceding linked language profiles">ಭಾಷೆಗಳು:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.420.0 -->
+  <string name="S_Languages_Uninstall" comment="Remove language profile">X</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.420.0 -->
+  <string name="S_Languages_Install" comment="Add language profile">ಬೇರೆ ಭಾಷೆಯನ್ನು ಈ ಕೀಲಿಮಣೆಗೆ ಸೇರಿಸು</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47 -->
+  <string name="S_Languages_Addremove" comment="Title for dialog to add or remove languages for keyboard layout">ಭಾಷೆಯನ್ನು ಸೇರಿಸು/ತೆಗೆದುಹಾಕು</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_OnScreenKeyboard" comment="Term for the On Screen Keyboard">ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.306.0 -->
+  <string name="S_OnScreenKeyboard_Custom" comment="(OSK) Custom term">ಕಸ್ಟಮ್</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OnScreenKeyboard_Installed" comment="(OSK) Installed term">ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OnScreenKeyboard_NotInstalled" comment="(OSK) Not installed term">ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.306.0 -->
+  <string name="S_Caption_Documentation" comment="Term for the Documentation">ದಾಖಲೆ:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.306.0 -->
+  <string name="S_Documentation_Installed" comment="(Documentation) Installed term">ಸ್ಥಾಪಿಸಲಾಗಿದೆ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.306.0 -->
+  <string name="S_Documentation_NotInstalled" comment="(Documentation) Not installed term">ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Message" comment="Keyboard download window, etc. - term for additional messages">ಸಂದೇಶ:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Copyright" comment="Keyboard download window, etc. - term for copyright">ಕೃತಿಸ್ವಾಮ್ಯ:</string>
+  <!-- Context: Configuration Dialog - Footer -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Footer_ChangesImmediate" comment="Short-term (14.0) message explaining why Ok and Cancel buttons are no longer present">ಬದಲಾವಣೆಗಳನ್ನು ತಕ್ಷಣವೇ ಅನ್ವಯಿಸಲಾಗುತ್ತದೆ</string>
+  <!-- Context: Configuration Dialog - Footer -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_InstallKeyboard" comment="Keyboard Layouts - install keyboard button">ಕೀಲಿಮಣೆಯನ್ನು ಅನುಸ್ಥಾಪಿಸು...</string>
+  <!-- Context: Configuration Dialog - Footer -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_DownloadKeyboard" comment="Keyboard Layouts - download keyboard button">ಕೀಲಿಮಣೆ ಡೌನ್ಲೋಡ್ ಮಾಡಿ</string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.287.0 -->
+  <string name="S_Menu_Options" comment="KL option button submenu - keyboard options">ಕೀಲಿಮಣೆಯ ಆಯ್ಕೆಗಳು...</string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Keyboards_NoKeyboardsInstalled" comment="Keyboard Layouts - notice of no keyboard layouts installed">ನೀವು ಯಾವುದೇ ಕೀಲಿಮಣೆಯನ್ನು ಸ್ಥಾಪಿಸಿಲ್ಲ. ಕೀಮ್ಯಾನ್ ವೆಬ್‌ಸೈಟ್‌ನಿಂದ ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸವನ್ನು ಸ್ಥಾಪಿಸಲು ಡೌನ್ಲೋಡ್ ಕೀಲಿಮಣೆ ಗುಂಡಿಯನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿ.</string>
+  <!-- Parameters: %1$s = keyboard layout name -->
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- Introduced: 7.1.251.0 -->
+  <!-- String Type: PlainText -->
+  <string name="SKUninstallRequireAdmin" comment="Keyboard Layouts - notice of ineligibility to uninstall a keyboard">ನಿರ್ವಾಹಕರಾಗಿದ್ದರೆ(ಅಡ್ಮಿನಿಸ್ಟ್ರೇಟರ್) ಮಾತ್ರ ಕೀಲಿಮಣೆ \'%1$s\' ಅನ್ನು ಅಸ್ಥಾಪಿಸಬಹುದು</string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 13.0.40.0 -->
+  <string name="S_Keyboard_Share" comment="Keyboard Layouts - share selected keyboard button">ಕೀಲಿಮಣೆಯನ್ನು ಹಂಚಿಕೊಳ್ಳಿ</string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 13.0.40.0 -->
+  <string name="S_Keyboard_Share_QRCode" comment="Keyboard Layouts - caption explaining QRCode, plus prefix to link to share">ಈ ಕೀಲಿಮಣೆಯನ್ನು ಮತ್ತೊಂದು ಸಾಧನದಲ್ಲಿ ಸ್ಥಾಪಿಸಲು ಈ ಕೋಡ್ಅನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡಿ ಅಥವಾ </string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 13.0.40.0 -->
+  <string name="S_Keyboard_Share_Link" comment="Keyboard Layouts - text for link to share">ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ ಹಂಚಿಕೊಳ್ಳಿ</string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 13.0.40.0 -->
+  <string name="S_Keyboard_Share_LinkSuffix" comment="Keyboard Layouts - suffix for link to share"></string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="kogGeneral" comment="Options section - General">ಸಾಮಾನ್ಯ</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="kogStartup" comment="Options section - Startup">ಆರಂಭಿಕ</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="kogOSK" comment="Options section - OSK">ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="kogAdvanced" comment="Options section - Advanced">ಸುಧಾರಿತ(ಅಡ್ವಾನ್ಸ್ಡ್)</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koKeyboardHotkeysAreToggle" comment="General options - hotkeys toggle on AND off a keyboard layout">ನೇರಕೀಲಿಗಳು (ಹಾಟ್‌ಕೀ/ಶಾರ್ಟ್‌ಕಟ್‌ಕೀ), ಕೀಲಿಮಣೆ ಕ್ರಿಯಾತ್ಮಕತೆಯನ್ನು ಟಾಗಲ್ ಮಾಡಲಿ</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koAltGrCtrlAlt" comment="General options - Ctrl+Alt simulates AltGr on computers without AltGr">AltGr ಅನ್ನು Ctrl+Alt ಆಗಿ ಅನುಕರಿಸು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 9.0.480.0 -->
+  <string name="koDeadkeyConversion" comment="Advanced options - Base keyboard deadkeys are treated as normal keys">ಹಾರ್ಡ್‌ವೇರ್ ಕೀಲಿಗಳನ್ನು ಸರಳ ಕೀಲಿಗಳಾಗಿ ಪರಿಗಣಿಸು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="koShowHints" comment="General options - show/hide hint messages (resets hint messages individually disabled)">ಸುಳಿವುಗಳನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 14.0 -->
+  <string name="koAutomaticallyReportErrors" comment="General options - report errors to Keyman team automatically">ದೋಷಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ keyman.com ಗೆ ವರದಿ ಮಾಡು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 14.0 -->
+  <string name="koAutomaticallyReportUsage" comment="General options - report anonymous usage to Keyman team automatically">keyman.com ಜೊತೆಗೆ ಅನಾಮಧೇಯ ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳನ್ನು ಹಂಚಿಕೊಳ್ಳಿ</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koStartWithWindows" comment="Startup options - Start Keyman with Windows start">ಕೀಮ್ಯಾನ್ ಚಲನೆಯನ್ನು ವಿಂಡೋಸ್ ಪ್ರಾರಂಭವಾದಾಗ ಪ್ರಾರಂಭಿಸು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koShowStartup" comment="Startup options - show/hide splash screen">ಸ್ಪ್ಲಾಶ್ ಪರದೆಯನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koShowWelcome" comment="Startup options - show/hide welcome screen">ಸ್ವಾಗತ ಪರದೆಯನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koCheckForUpdates" comment="Startup options - check online weekly for updates">ಸ್ವಯಂಚಾಲಿತವಾಗಿ ನವೀಕರಣಗಳನ್ನು www.keyman.com ನಲ್ಲಿ ಸಾಪ್ತಾಹಿಕವಾಗಿ ಪರಿಶೀಲಿಸು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.236.0 -->
+  <string name="koTestKeymanFunctioning" comment="Startup options - test for conflicting apps when Product starts">ಕೀಮ್ಯಾನ್ ಪ್ರಾರಂಭವಾದಾಗ ವೈಫಲ್ಯದ ಅನ್ವಯಗಳನ್ನು ಪರೀಕ್ಷಿಸು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.236.0 -->
+  <string name="koReleaseShiftKeysAfterKeyPress" comment="OSK options - Releases shift/ctrl/alt on OSK after key press">\"ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ\"ಯಲ್ಲಿ ಯಾವುದೆ ಕೀಲಿಯನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿದ ನಂತರ Shift/Ctrl/Alt ಅನ್ನು ಬಿಡುಗಡೆ ಮಾಡು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="koAutoOpenOSK" comment="OSK options - auto-open OSK">ಹೊಸ ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿದಾಗ ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆಯನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="koAutoSwitchOSKPages" comment="OSK options - when a keyboard is activated, switch to most appropriate page in OSK">ಬೇರೆ ಕೀಲಿಮಣೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿದಾಗ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸಹಾಯ ಅಥವಾ ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆಯನ್ನು ಬದಲಿಸು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">ಡೀಬಗ್ ಮಾಡುವುದು</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.445.0 -->
+  <string name="S_Button_BaseKeyboard" comment="Options tab - base keyboard button">ಮೂಲ(ಬೇಸ್) ಕೀಲಿಮಣೆ...</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.241.0 -->
+  <string name="S_Hotkey_Language_Prefix" comment="Hotkey - activation term preceding Windows language name. Note: include a space following."></string>
+  <!-- e.g. "Activate [Korean KORDA] Keyboard" -->
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.241.0 -->
+  <string name="S_Hotkey_Language_Suffix" comment="Hotkey - language term following Windows language name. Note: include an initial space."></string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkey_None" comment="Hotkey - text used when no hotkey set">(ನೇರಕೀಲಿ ಇಲ್ಲ)</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkey_TurnKeymanOff" comment="Hotkey - Turn Product Off">ಕೀಮ್ಯಾನ್ ಸ್ಥಗಿತಗೊಳಿಸಲು</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkey_OpenKeyboardMenu" comment="Hotkey - Open Keyman system tray menu">ಕೀಲಿಮಣೆ ಆಯ್ಕೆ ಪಟ್ಟಿಯನ್ನು ತೆರೆಯಲು</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkey_ShowOnScreenKeyboard" comment="Hotkey - show keyboard in OSK">ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ ಫಲಕ ತೋರಿಸಲು</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkey_OpenConfiguration" comment="Hotkey - open Keyman Configuration">ಸಂರಚನೆ(ಕಾನ್ಫಿಗರೇಷನ್) ತೋರಿಸು</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.275.0 -->
+  <string name="S_Hotkey_ShowFontHelper" comment="Hotkey - show font helper in OSK">ಅಕ್ಷರ ಶೈಲಿ(ಫಾಂಟ್) ಸಹಾಯಕ ಫಲಕವನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.275.0 -->
+  <string name="S_Hotkey_ShowCharacterMap" comment="Hotkey - show character map in OSK">ಅಕ್ಷರ ನಕ್ಷೆ ಫಲಕವನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.275.0 -->
+  <string name="S_Hotkey_OpenTextEditor" comment="Hotkey - open text editor">ಪಠ್ಯ ಸಂಪಾದಕವನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_Hotkey_SwitchLanguage" comment="Hotkey - switch language window">ಭಾಷಾ ಬದಲಾವಣೆ ಫಲಕವನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.274.0 -->
+  <string name="S_Hotkey_Control_Title" comment="Hotkey - Control Title">ಸಾಮಾನ್ಯ ನೇರ ಕೀಲಿಗಳು (ಹಾಟ್‌ಕೀ/ಶಾರ್ಟ್‌ಕಟ್‌ಕೀ)</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.274.0 -->
+  <string name="S_Hotkey_Keyboard_Title" comment="Hotkey - Keyboard Title">ಕೀಲಿಮಣೆಗಳು</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.465.0 -->
+  <string name="S_Support_ContactInstructions_Free" comment="">ಕೀಮ್ಯಾನ್‌ ಅನ್ನು ಬಳಸುವಾಗ ನಿಮಗೆ ಯಾವುದೇ ಸಮಸ್ಯೆಗಳು ಕಂಡು ಬಂದರೆ, ಕೀಮ್ಯಾನ್ ಸಮುದಾಯ ವೇದಿಕೆಯಲ್ಲಿ (Keyman Community Forum) ಪ್ರಶ್ನೆಯನ್ನು ಕೇಳಿ.</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.465.0 -->
+  <string name="S_Button_CommunitySupport" comment="">ಕೀಮ್ಯಾನ್ ಸಮುದಾಯ ವೇದಿಕೆ ತೆರೆಯಿರಿ</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 11.0.1500.0 -->
+  <string name="S_Support_CreatedBySIL" comment="Support - SIL statement">ಎಸ್‌ಐಎಲ್‌ ಇಂಟರ್‌ನ್ಯಾಷನಲ್‌ರವರ ಸೃಷ್ಟಿ</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Support_Copyright" comment="Support - Product Copyright">ಕೃತಿಸ್ವಾಮ್ಯ © ಎಸ್‌ಐಎಲ್‌ ಇಂಟರ್‌ನ್ಯಾಷನಲ್. ಎಲ್ಲ ಹಕ್ಕುಗಳನ್ನು ಕಾಯ್ದಿರಿಸಲಾಗಿದೆ.</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Support_Version" comment="Support - version">ಆವೃತ್ತಿ</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_Support_UsefulLinks" comment="Support - Useful Links heading">ಉಪಯುಕ್ತ ಕೊಂಡಿಗಳು</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_OnlineSupport" comment="Support button - links to online support">ಆನ್‌ಲೈನ್ ಸಹಾಯ</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_CheckForUpdates" comment="Support button - manually checks for product updates">ನವೀಕರಣಗಳಿಗಾಗಿ ಪರಿಶೀಲಿಸಿ</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_ProxyConfig" comment="Options button - allows manual adjustment of proxy settings">ಪ್ರಾಕ್ಸಿ ಸೆಟ್ಟಿಂಗ್‌ಗಳು...</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_SettingsManager" comment="Options button - access to the Settings Manager">ಕೀಮ್ಯಾನ್ ಸಿಸ್ಟಮ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳು...</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_Diagnostics_Diagnostics" comment="Support button submenu - performs a diagnostic report">ಡಯಗ್ನೊಸ್ಟಿಕ್</string>
+  <!-- Context: Download Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_DownloadKeyboard_Title" comment="Download keyboard layout from keyman.com dialog title">keyman.com ಯಿಂದ ಕೀಲಿಮಣೆ ಡೌನ್ಲೋಡ್ ಮಾಡಿ</string>
+  <!-- Context: Download Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_DownloadKeyboard_DownloadOnlyCheckbox" comment="Download only option checkbox">ಸ್ಥಾಪಿಸಬೇಡಿ, ಡೌನ್ಲೋಡ್ ಮಾಡಿ</string>
+  <!-- Parameters: %1$s = Error Message, %2$d Error Code -->
+  <!-- Context: Download Keyboard Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_DownloadKeyboard_DownloadError" comment="Message shown when there is an error downloading the keyboard package">ಕೀಲಿಮಣೆ ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ, ದೋಷ %2$d: %1$s</string>
+  <!-- Context: Download Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Button_Back" comment="Back button">&lt; ಹಿಂದೆ</string>
+  <!-- Context: Install Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_InstallKeyboard_Title" comment="Install keyboard/package dialog title">ಕೀಲಿಮಣೆ/ಪ್ಯಾಕೇಜ್ ಅನುಸ್ಥಾಪಿಸು</string>
+  <!-- Context: Install Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_InstallKeyboard_Tab_Details" comment="Install keyboard/package - details">ವಿವರಗಳು</string>
+  <!-- Context: Install Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_InstallKeyboard_Tab_Readme" comment="Install keyboard/package - readme">ಸಂದೇಶವನ್ನು ಓದಿ</string>
+  <!-- Context: Install Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_InstallKeyboard_Button_Install" comment="Install keyboard/package - install button">ಅನುಸ್ಥಾಪಿಸು</string>
+  <!-- Context: Proxy Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ProxyConfiguration_Title" comment="Proxy configuration dialog title">ಪ್ರಾಕ್ಸಿ ಸರ್ವರ್ ಸಂರಚನೆ(ಕಾನ್ಫಿಗರೇಷನ್)</string>
+  <!-- Context: Proxy Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ProxyConfiguration_Server" comment="Proxy dialog - fillable-field server">ಸರ್ವರ್(server):</string>
+  <!-- Context: Proxy Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ProxyConfiguration_Port" comment="Proxy dialog - fillable-field port">ಪೊರ್ಟ್(port):</string>
+  <!-- Context: Proxy Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ProxyConfiguration_Username" comment="Proxy dialog - fillable-field username">ಬಳಕೆದಾರರ ಹೆಸರು(username):</string>
+  <!-- Context: Proxy Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ProxyConfiguration_Password" comment="Proxy dialog - fillable-field password">ಪ್ರವೇಶಪದ(password):</string>
+  <!-- Context: Base Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.445.0 -->
+  <string name="S_BaseKeyboard_Title" comment="Base keyboard dialog title">ಮೂಲ(ಬೇಸ್) ಕೀಲಿಮಣೆ ಹೊಂದಿಸಿ</string>
+  <!-- Context: Base Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.445.0 -->
+  <string name="S_BaseKeyboard_Text" comment="Base keyboard dialog description">ನೀವು ವಿಂಡೋಸ್‌ನಲ್ಲಿ ಬಳಸುವ ಮೂಲ(ಬೇಸ್) ಲ್ಯಾಟಿನ್(ಇಂಗೀಷ್) ಸ್ಕ್ರಿಪ್ಟ್ ಕೀಲಿಮಣೆ ಆಯ್ಕೆಮಾಡಿ. ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆಯು ನಿಮ್ಮ ಆದ್ಯತೆಯ ವಿನ್ಯಾಸಕ್ಕೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊಂದಿಕೊಳ್ಳುತ್ತದೆ.</string>
+  <!-- Context: Hotkey Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKChangeHotkeyTitle" comment="Change Hotkey dialog title">ನೇರ ಕೀಲಿ ಬದಲಾಯಿಸು</string>
+  <!-- Parameters: %1$s = Name of keyboard -->
+  <!-- Context: Hotkey Dialog -->
+  <!-- Introduced: 7.0.241.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKSetHotkey_Language" comment="Hotkey dialog - message when setting hotkey for a language">ಭಾಷೆ %1$s ಗಾಗಿ ಪ್ರಮಾಣಿತ ನೇರಕೀಲಿಯನ್ನು ಆಯ್ಕೆಮಾಡಿ ಅಥವಾ \'ಕಸ್ಟಮ್\' ಆಯ್ಕೆಮಾಡಿ, Ctrl, Shift ಮತ್ತು/ಅಥವಾ Alt ಅನ್ನು ಒತ್ತಿ, ನಿಮಗೆ ಬೇಕಾದ ನೇರಕೀಲಿಯನ್ನು ಆಯ್ಕೆಮಾಡಬಹುದು:</string>
+  <!-- Context: Hotkey Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKSetHotkey_Interface" comment="Hotkey dialog - message displayed when changing a hotkey for a product feature (e.g. show menu or show on screen keyboard)">ಪ್ರಮಾಣಿತ ನೇರ ಕೀಲಿಯನ್ನು ಆಯ್ಕೆಮಾಡಿ ಅಥವಾ \'ಕಸ್ಟಮ್\' ಆಯ್ಕೆಮಾಡಿ ಮತ್ತು Ctrl, Shift ಮತ್ತು/ಅಥವಾ Alt ಅನ್ನು ಒತ್ತಿ ಮತ್ತು ನೀವು ಬಯಸಿದ ನೇರ ಕೀಲಿಯನ್ನು ಟೈಪ್ ಮಾಡಿ:</string>
+  <!-- Parameters: %1$s = Hotkey -->
+  <!-- Context: Hotkey Dialog -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUnsafeHotkey" comment="Hotkey dialog - warning of hotkey conflict with standard keyboard use">ನೇರ ಕೀಲಿ %1$s ಸಾಮಾನ್ಯ ಕೀಲಿಮಣೆ ಬಳಕೆಗೆ ತೊಂದರೆ ಮಾಡುತ್ತದೆ. ನೀವು ಕನಿಷ್ಠ Ctrl ಅಥವಾ Alt ಅನ್ನು ಬಳಸಬೇಕು. ಈಗ ನೀವು ಇದನ್ನು ಬದಲಾಯಿಸಲು ಬಯಸುವಿರಾ\?</string>
+  <!-- Parameters: %1$s = Hotkey, %2$s = Conflicting keyboard -->
+  <!-- Context: Hotkey Dialog -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKHotkeyConflicts_Keyboard" comment="Hotkey dialog - warning of hotkey conflict with hotkey for another keyboard">%1$s ನೇರ ಕೀಲಿ, %2$s ಕೀಲಿಮಣೆಗಾಗಿ ಆಯ್ಕೆ ಮಾಡಲಾಗಿದೆ. ನೀವು ಮುಂದುವರಿಸಿದರೆ, %2$s ಕೀಲಿಮಣೆಗಾಗಿ ನೇರ ಕೀಲಿಯನ್ನು ತೆರವುಗೊಳಿಸಲಾಗುತ್ತದೆ. ಮುಂದುವರಿಸಬೇಕೆ\?</string>
+  <!-- Parameters: %1$s = Hotkey -->
+  <!-- Context: Hotkey Dialog -->
+  <!-- Introduced: 14.0.117 -->
+  <!-- String Type: FormatString -->
+  <string name="SKHotkeyConflicts_Interface" comment="Hotkey dialog - warning of hotkey conflict with hotkey for another interface hotkey">%1$s ನೇರ ಕೀಲಿ, ಮತ್ತೊಂದು ನೇರ ಕೀಲಿಯೊಂದಿಗೆ ಬಳಕೆಯಾಗಿದೆ. ನೀವು ಮುಂದುವರಿಸಿದರೆ, ಇತ್ತೊಂದು ನೇರ ಕೀಲಿಯನ್ನು ತೆರವುಗೊಳಿಸಲಾಗುತ್ತದೆ. ಮುಂದುವರಿಸಬೇಕೆ\?</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Update_Title" comment="Update dialog title, where Keyman = product name">ನವೀಕೃತ ಕೀಮ್ಯಾನ್ ಘಟಕಗಳು ಲಭ್ಯವಿದೆ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Update_NewVersionAvailable" comment="Update dialog - updates available text">ನವೀಕೃತ ಕೀಮ್ಯಾನ್ ಲಭ್ಯವಿದೆ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.255.0 -->
+  <string name="S_Update_NewVersionPrompt" comment="Update dialog - prompt to select updates">ದಯವಿಟ್ಟು ನೀವು ಸ್ಥಾಪಿಸಲು ಬಯಸುವ ನವೀಕರಣಗಳನ್ನು ಆಯ್ಕೆ ಮಾಡಿ:</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Update_DownloadFrom" comment="Update dialog - download information">ನೀವು ಈ ಹೊಸ ಆವೃತ್ತಿಯನ್ನು ಡೌನ್ಲೋಡ್ ಮಾಡಬಹುದು:</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Update_Button_InstallNow" comment="Update dialog - install now button">ಈಗ ಅನುಸ್ಥಾಪಿಸು</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Update_Button_InstallLater" comment="Update dialog - cancel button">ರದ್ದುಮಾಡು</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.255.0 -->
+  <string name="S_Update_OldVersionHead" comment="Update dialog - old version">ಹಳೆಯ ಆವೃತ್ತಿ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.255.0 -->
+  <string name="S_Update_ComponentHead" comment="Update dialog - update component">ನವೀಕೃತ ಘಟಕಗಳು</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.255.0 -->
+  <string name="S_Update_SizeHead" comment="Update dialog - update size">ಗಾತ್ರ</string>
+  <!-- Parameters: %1$s = Current version number -->
+  <!-- Context: Online Update Dialog -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUpdate_KeymanText" comment="Update dialog - name and version of updatable product">ಕೀಮ್ಯಾನ್ %1$s</string>
+  <!-- Parameters: %1$s = Package description, %2$s = Current package version number -->
+  <!-- Context: Online Update Dialog -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUpdate_PackageText" comment="Update dialog - name and version of updatable keyboard layout package">ಕೀಲಿಮಣೆ %1$s %2$s</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKUpdate_UnableToContact" comment="Update dialog - unable to access keyman.com warning">keyman.com ವೆಬ್‌ಸೈಟ್‌ ಅನ್ನು ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲಾ - ದಯವಿಟ್ಟು ನೀವು ಸಕ್ರಿಯ ಇಂಟರ್ನೆಟ್ ಸಂಪರ್ಕವನ್ನು ಹೊಂದಿದ್ದೀರ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಂಡು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
+  <!-- Parameters: %1$s = Error message -->
+  <!-- Context: Online Update Dialog -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUpdate_UnableToContact_Error" comment="Update dialog - unable to access keyman.com error message">keyman.com ವೆಬ್‌ಸೈಟ್‌ ಅನ್ನು ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲಾ - ದಯವಿಟ್ಟು ನೀವು ಸಕ್ರಿಯ ಅಂತರ್ಜಾಲದ ಸಂಪರ್ಕವನ್ನು ಹೊಂದಿದ್ದೀರ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಂಡು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ. ಸ್ವೀಕರಿಸಿದ ದೋಷಗಳು: %1$s</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.288.0 -->
+  <string name="SKUpdate_IconTitle" comment="Update icon - title">ಕೀಮ್ಯಾನ್ ನವೀಕರಣಗಳು ಲಭ್ಯವಿದೆ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.288.0 -->
+  <string name="SKUpdate_IconText" comment="Update icon - text">ನವೀಕರಣಗಳನ್ನು ಡೌನ್ಲೋಡ್ ಮಾಡಿ ಮತ್ತು ಅನುಸ್ಥಾಪಿಸಲು ಈ ಐಕಾನ್ ಕ್ಲಿಕ್ ಮಾಡಿ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.288.0 -->
+  <string name="SKUpdate_IconMenuText" comment="Update icon - install menu item">ಕೀಮ್ಯಾನ್ ನವೀಕರಣಗಳನ್ನು &amp;ಪರಿಶೀಲಿಸಿ ಹಾಗು ಅನುಸ್ಥಾಪಿಸು</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.288.0 -->
+  <string name="SKUpdate_IconMenuExit" comment="Update icon - exit menu item">ಆನ್‌ಲೈನ್ ಅಪ್‌ಡೇಟ್ ಪರಿಶೀಲನೆಗೆ &amp;ನಿರ್ಗಮಿಸು</string>
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.288.0 -->
+  <string name="S_Splash_Name" comment="Splash major title">ಕೀಮ್ಯಾನ್</string>
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_Splash_Start" comment="Start Keyman button">ಕೀಮ್ಯಾನ್ ಪ್ರಾರಂಭಿಸು</string>
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_Splash_Exit" comment="Exit button">ನಿರ್ಗಮಿಸು</string>
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_Splash_Configuration" comment="Keyman Configuration link">ಸಂರಚನೆ</string>
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.341.0 -->
+  <string name="S_Splash_ShowAtStartup" comment="Show at Startup toggle">ಆರಂಭದಲ್ಲಿ ಈ ಪರದೆಯನ್ನು ತೋರಿಸು</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.278.0 -->
+  <string name="S_DisplayIn" comment="'Display In' text label for UI language menu">ಪ್ರದರ್ಶನ ಭಾಷೆ</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.278.0 -->
+  <string name="S_MoreUILanguagesMenu" comment="More UI languages online menu item">ಇತರ ಪ್ರದರ್ಶನ ಭಾಷೆಗಳನ್ನು ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ ಹುಡುಕಿ...</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.525.0 -->
+  <string name="S_ContributeUILanguagesMenu" comment="Link to contribute to language UI">ಪ್ರದರ್ಶನ ಭಾಷೆ ಭಾಷಾಂತರಿಸಲು ಸಹಾಯ ಮಾಡಿ</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKUILanguageName" comment="User interface language name in the UI language">ಕನ್ನಡ</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKUILanguageNameWithEnglish" comment="UI language name in the UI language with the English name in parentheses  (this message is used when the user gets stuck in a strange UI language)">ಕನ್ನಡ (Kannada)</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKLanguageCode" comment="The language code for the current translation">kn</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKDefaultLanguageCode" comment="The default language code for this product.  This should be the language that the product is created in. For Keyman this must stay 'en', for all translations.">en</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKShortApplicationTitle" comment="Product name">ಕೀಮ್ಯಾನ್</string>
+  <!-- Context: Hints -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="S_Button_ResetHints" comment="Hint - options tab button to reset hints">ಸುಳಿವುಗಳನ್ನು ಮರುಹೊಂದಿಸು</string>
+  <!-- Context: Hints -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="SKHintsReset" comment="Hint - options tab dialog confirming reset of hints">ಎಲ್ಲಾ ಸುಳಿವು ಸಂದೇಶಗಳನ್ನು ಮರುಹೊಂದಿಸಲಾಗಿದೆ ಮತ್ತು ಮತ್ತೆ ಪ್ರದರ್ಶಿಸಲಾಗುತ್ತದೆ.</string>
+  <!-- Context: Hints -->
+  <!-- Introduced: 7.0.244.0 -->
+  <!-- String Type: HintTitle -->
+  <!-- DevNote: this is a constructed identifier so won't appear in a search with i18n-check-unused-strings.sh -->
+  <string name="HintTitle_KH_EXITPRODUCT" comment="Hint - dialog title upon attempting to exit product">ಕೀಮ್ಯಾನ್ ನಿರ್ಗಮಿಸಬೇಕೆ\?</string>
+  <!-- Context: Hints -->
+  <!-- Introduced: 7.0.244.0 -->
+  <!-- String Type: Hint -->
+  <!-- DevNote: this is a constructed identifier so won't appear in a search with i18n-check-unused-strings.sh -->
+  <string name="Hint_KH_EXITPRODUCT" comment="Hint - asks for confirmation, explains the difference between de-activating a keyboard layout and closing Product">ನೀವು ಕೀಮ್ಯಾನ್ ನಿರ್ಗಮಸಲು ಬಯಸುತ್ತೀರಾ? ವಿಂಡೋಸ್ ಕೀಲಿಮಣೆಗಳ ಪಟ್ಟಿಯಲ್ಲಿ ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆ ಲಭ್ಯವಿರುತ್ತದೆ. ಆದರೆ ನೀವು ಕೀಮ್ಯಾನ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸುವವರೆಗೆ ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆಗಳು ಕ್ರಿಯಾತ್ಮಕವಾಗಿರುವುದಿಲ್ಲ.</string>
+  <!-- Context: Hints -->
+  <!-- Introduced: 7.0.244.0 -->
+  <!-- String Type: HintTitle -->
+  <!-- DevNote: this is a constructed identifier so won't appear in a search with i18n-check-unused-strings.sh -->
+  <string name="HintTitle_KH_CLOSEOSK" comment="Hint - dialog title upon closing the OSK">ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ ಮುಚ್ಚಲಾಗಿದೆ</string>
+  <!-- Context: Hints -->
+  <!-- Introduced: 7.0.244.0 -->
+  <!-- String Type: Hint -->
+  <!-- DevNote: this is a constructed identifier so won't appear in a search with i18n-check-unused-strings.sh -->
+  <string name="Hint_KH_CLOSEOSK" comment="Hint - explains that Product is still running and informs how to reopen OSK">ನೀವು \"ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ\"ಅನ್ನು ಮುಚ್ಚಿದ್ದೀರಿ. Keyman ಇನ್ನೂ ಚಾಲನೆಯಲ್ಲಿದೆ. Keyman ಚಿತ್ರ(ಐಕಾನ್) ಮೇಲೆ ನೀವು ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ಕ್ಲಿಕ್ ಮಾಡಿ ಮತ್ತು \"ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ\" ಆಯ್ಕೆಮಾಡುವ ಮೂಲಕ; \"ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ\"ಅನ್ನು ತೆರೆಯಬಹುದು.</string>
+  <!-- Context: Hints -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 10.0.836.0 -->
+  <string name="S_HintDialog_DontShowHintAgain" comment="Hint dialog - caption of checkbox at bottom of dialog">ಈ ಸುಳಿವನ್ನು ಮತ್ತೆ ತೋರಿಸಬೇಡ</string>
+  <!-- Context: Help Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_HelpTitle" comment="Help - product name help">ಕೀಮ್ಯಾನ್ ಸಹಾಯ</string>
+  <!-- Context: Help Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Help_Product" comment="Help - help contents link title">ಸಹಾಯ ಪರಿವಿಡಿ</string>
+  <!-- Context: Help Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Help_Keyboard_Prefix" comment="Help - text preceding keyboard name">\"</string>
+  <!-- Context: Help Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Help_Keyboard_Suffix" comment="Help - text following keyboard name">\" ಕೀಲಿಮಣೆಗೆ ಸಹಾಯ</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_ViewOnScreenKeyboard" comment="Toolbar help - View OSK pop-up text">\"ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ\" ತೋರಿಸು</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_ViewFontHelper" comment="Toolbar help - View Font Helper pop-up text">ಅಕ್ಷರ ಶೈಲಿ(ಫಾಂಟ್) ಸಹಾಯಕ ಫಲಕವನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_ViewCharacterMap" comment="Toolbar help - View Character Map pop-up text">ಅಕ್ಷರ ನಕ್ಷೆ ಫಲಕವನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_OpenConfiguration" comment="Toolbar help - Open Keyman Configuration pop-up text">ಕೀಮ್ಯಾನ್ ಸಂರಚನೆ(ಕಾನ್ಫಿಗರೇಷನ್) ತೋರಿಸು</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_OpenHelp" comment="Toolbar help - Open help pop-up text">ಸಹಾಯವನ್ನು ತೋರಿಸು</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_CloseOnScreenKeyboard" comment="Toolbar help - Close OSK pop-up text">\"ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ\" ಮುಚ್ಚು</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_SwitchKeymanOff" comment="Systray item - Switch Keyman Off [&amp; precedes alt + access-character]">ಕೀಮ್ಯಾನ್ &amp;ಬಳಕೆಯನ್ನು ನಿಲ್ಲಿಸು</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_OnScreenKeyboard" comment="Systray item - OSK [&amp; precedes alt + access-character]">&amp;ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_FontHelper" comment="Systray item - Font Helper [&amp; precedes alt + access-character]">ಅಕ್ಷ&amp;ರ ಶೈಲಿ (ಫಾಂಟ್) ಸಹಾಯಕ</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_CharacterMap" comment="Systray item - Character Map [&amp; precedes alt + access-character]">&amp;ಅಕ್ಷರ ನಕ್ಷೆ</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_TextEditor" comment="Systray item - Text Editor [&amp; precedes alt + access-character]">&amp;ಪಠ್ಯ ಸಂಪಾದಕ</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_Configuration" comment="Systray item - Configuration [&amp; precedes alt + access-character]">ಸಂರಚನೆ (&amp;ಕಾನ್ಫಿಗರೇಷನ್)</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_Help" comment="Systray item - Help [&amp; precedes alt + access-character]">&amp;ಸಹಾಯ...</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_Exit" comment="Systray item - Exit [&amp; precedes alt + access-character]">&amp;ನಿರ್ಗಮನ</string>
+  <!-- Context: On Screen Keyboard Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OSKContext_FadeWhenInactive" comment="OSK right-click menu - fade OSK when mouse is elsewhere">ನಿಷ್ಕ್ರಿಯವಾಗಿದ್ದಾಗ ಫೇಡ್ ಮಾಡಿ</string>
+  <!-- Context: On Screen Keyboard Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OSKContext_ShowToolbar" comment="OSK right-click menu - show/hide OSK toolbar">ಉಪಕರಣ ಪಟ್ಟಿ(ಟೂಲ್‌ಬಾರ್) ತೋರಿಸು</string>
+  <!-- Context: On Screen Keyboard Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OSKContext_SaveAsWebPage" comment="OSK right-click menu - save diagram of active keyboard layout as a web page">ವೆಬ್ ಪುಟದಂತೆ ಉಳಿಸು...</string>
+  <!-- Context: On Screen Keyboard Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OSKContext_Print" comment="OSK right-click menu - print diagram of active keyboard layout">ಮುದ್ರಿಸು...</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKApplicationTitle" comment="Product name used for the title of message boxes and message dialogs">ಕೀಮ್ಯಾನ್</string>
+  <!-- Parameters: %1$s = Version number string -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKSplashVersion" comment="Version number">ಆವೃತ್ತಿ %1$s</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.239.0 -->
+  <string name="SKButtonPrint" comment="Print button in Welcome dialog for keyboards">&amp;ಮುದ್ರಿಸು....</string>
+  <!-- Parameters: %1$s = Package to be uninstalled -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKPackageAlreadyInstalled" comment="Notice during package installation that a package with the same name is already installed.">%1$s ಹೆಸರಿನ ಪ್ಯಾಕೇಜ್‌ಅನ್ನು ಈಗಾಗಲೇ ಸ್ಥಾಪಿಸಲಾಗಿದೆ. ನೀವು ಅದನ್ನು ಅಸ್ಥಾಪಿಸಿ ಹೊಸ ಪ್ಯಾಕೇಜ್‌ಅನ್ನು ಅನುಸ್ಥಾಪಿಸಲು ಬಯಸುವಿರಾ\?</string>
+  <!-- Parameters: %1$s = Keyboard name -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKKeyboardAlreadyInstalled" comment="Notice during keyboard layout installation that a keyboard layout with the same name is already installed.">%1$s ಹೆಸರಿನ ಕೀಲಿಮಣೆ ಈಗಾಗಲೇ ಅನುಸ್ಥಾಪಿಸಲಾಗಿದೆ. ಈಗ ಅದನ್ನು ಅಸ್ಥಾಪಿಸಿ, ಹೊಸ ಕೀಲಿಮಣೆಯನ್ನು ಸ್ಥಾಪಿಸಲಾಗುವುದು. ಮುಂದುವರಿಸಬೇಕೆ\?</string>
+  <!-- Parameters: %1$s = Keyboard name, %2$s = Package name -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKKeyboardPartOfPackage" comment="Notice of need to uninstall an entire package">\'%1$s\' ಕೀಲಿಮಣೆ \'%2$s\' ಪ್ಯಾಕೇಜಿನ ಭಾಗವಾಗಿದೆ. ನೀವು ಸಂಪೂರ್ಣ ಪ್ಯಾಕೇಜ್‌ಅನ್ನು ಅಸ್ಥಾಪಿಸಬೇಕಾಗುತ್ತದೆ. ಮುಂದುವರಿಸಬೇಕೇ\?</string>
+  <!-- PArameters: %1$s = BCP 47 code -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 14.0.211 -->
+  <!-- String Type: FormatString -->
+  <string name="SKInstallLanguageTransientLimit" comment="Message shown when Keyman is unable to install a Windows language for a keyboard">ಕೀಲಿಮಣೆಯೊಂದಿಗೆ ಸೂಚಿಸಿರುವ ಭಾಷೆಯನ್ನು ಸ್ಥಾಪಿಸಲು ಆಗುತ್ತಿಲ್ಲ; ವಿಂಡೋಸ್ ೪ ಕಸ್ಟಮ್ \'transient-ಟ್ರಾನ್ಸಿಯೆಂಟ್\' ಭಾಷೆಗಳ ಮಿತಿಯನ್ನು ಹೊಂದಿದೆ, ನೀವು ಈ ಮಿತಿಯನ್ನು ತಲುಪಿರಬಹುದು.</string>
+  <!-- Parameters: %1$s = Package Name -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKPackageDoesNotIncludeWelcome" comment="Notice of lack of introductory help">ಈ \'%1$s\' ಪ್ಯಾಕೇಜ್ ಅಥವಾ ಕೀಲಿಮಣೆ ಯಾವುದೇ ಪರಿಚಯಾತ್ಮಕ ಸಹಾಯವನ್ನು ಒಳಗೊಂಡಿಲ್ಲ.</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKOSNotSupported" comment="Notice of unsupported operating system">ಈ ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಮ್‌ನಲ್ಲಿ ನಮ್ಮ ತಂತ್ರಾಂಶ ಕೆಲಸ ಮಾಡುವುದಿಲ್ಲ.</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKOnlineHelpFile" comment="File name of the help file - must be .chm format.  The locale folder will be checked first for the file">KeymanDesktop.chm</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKCouldNotFindHelp" comment="Notice of help file not found">ಸಹಾಯ ಕಡತ ಕಂಡುಬಂದಿಲ್ಲ.</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKANSIEncoding" comment="Keyboard with an ANSI or Codepage encoding">ಕೋಡ್‌ಪುಟ</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKUnicodeEncoding" comment="Keyboard with a Unicode encoding">ಯೂನಿಕೋಡ್</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKDownloadProgress_Title" comment="Notice of file downloading">ಡೌನ್ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ</string>
+  <!-- Parameters: %1$s = Keyboard name -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUninstallOnScreenKeyboard" comment="Request for confirmation to uninstall OSK for a keyboard layout">%1$s ಕೀಲಿಮಣೆಯ \"ತೆರೆಯ ಮೇಲಿನ ಕೀಲಿಮಣೆ ಫಲಕ\" ಅಸ್ಥಾಪಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ\?</string>
+  <!-- Parameters: %1$s = Keyboard name -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.239.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUninstallKeyboard" comment="Request for confirmation to uninstall keyboard layout">%1$s ಕೀಲಿಮಣೆಯನ್ನು ಅಸ್ಥಾಪಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ\?</string>
+  <!-- Parameters: %1$s = Package name, %2$s: Fonts list -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.239.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUninstallPackage" comment="Request for confirmation to uninstall a package">%1$s ಪ್ಯಾಕೇಜ್‌ಅನ್ನು ಹಾಗು ಕೆಳಗಿನ ನಮೂದಿಸಿರುವ ಅಕ್ಷರ ಶೈಲಿ-ಫಾಂಟ್‌ಗಳನ್ನು ಅಸ್ಥಾಪಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ\?\n\n%2$s</string>
+  <!-- Parameters: %1$s = Fonts list -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.1.270.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUninstallPackageFonts" comment="Text embedded in SKUninstallPackage when fonts are ready for uninstall.">ಕೆಳಗಿನ ಅಕ್ಷರ ಶೈಲಿ-ಫಾಂಟ್/ಗಳನ್ನು ಸಹ ಅಸ್ಥಾಪಿಸಲ್ಪಡುತ್ತದೆ: %1$s.</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKUnicodeData_Build" comment="Request to build Unicode Character Map database">ಅಕ್ಷರ ಮ್ಯಾಪ್ ಅನ್ನು ಬಳಸಬಹುದಾದ ಮೊದಲು ಅಕ್ಷರ ಡೇಟಾಬೇಸ್ ಅನ್ನು ನಿರ್ಮಿಸಬೇಕಾಗಿದೆ. ಈಗ ಅದನ್ನು ನಿರ್ಮಿಸಲು ಬಯಸುವಿರಾ\?</string>
+  <!-- Parameters: %1$s = Error detail string -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUnicodeData_DatabaseCouldNotBeDeleted" comment="Error deleting Unicode Character Map database">ಯುನಿಕೋಡ್ ಅಕ್ಷರ ಡೇಟಾಬೇಸ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ ಪುನರ್ನಿರ್ಮಾಣ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ದೋಷದ ವಿವರಗಳು: %1$s</string>
+  <!-- Parameters: %1$s = Error details -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUnicodeData_CouldNotCreateDatabase" comment="Error creating Unicode Character Map database">ಯುನಿಕೋಡ್ ಅಕ್ಷರ ಡೇಟಾಬೇಸ್ ಅನ್ನು ಪುನರ್ನಿರ್ಮಾಣ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ ಆದ್ದರಿಂದ ಅದನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ. ದೋಷದ ವಿವರಗಳು: %1$s</string>
+  <!-- Parameters: %1$s = Error message -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUnicodeData_DatabaseLoadFailedRebuild" comment="Error loading Unicode Character Map database. Request to rebuild.">ಯುನಿಕೋಡ್ ಅಕ್ಷರ ಡೇಟಾಬೇಸ್ ಯಶಸ್ವಿಯಾಗಿ ಲೋಡ್‌ಯಾಗಿಲ್ಲ (%1$s). ಈಗ ಅದನ್ನು ಪುನರ್ನಿರ್ಮಾಣ ಮಾಡುವುದೇ\?</string>
+  <!-- Parameters: %1$s: error message -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.241.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKCannotStartProduct" comment="Error from Keyman failing to start keyman.exe due to an access denied or file not found">ಕೀಮ್ಯಾನ್ ಪ್ರಾರಂಭಿಸಲು ವಿಫಲವಾಗಿದೆ. ಮುಂದುವರೆಯುವ ಮೊದಲು keyman.exe ಅನ್ನು ಆರಂಭಿಸಲು ಅನುಮತಿಸಲಾಗಿದೆಯೇ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಲು, ದಯವಿಟ್ಟು ನಿಮ್ಮ ಭದ್ರತೆ ಸೆಟ್ಟಿಂಗ್ಗಳನ್ನು(security settings) ಪರಿಶೀಲಿಸಿ. ಹಿಂದಿನ ದೋಷವೆಂದರೆ:\n\n\"%1$s\" \n\nಈಗ ನೀವು ಭದ್ರತೆ ಸೆಟ್ಟಿಂಗ್ಗಳನ್ನು(security settings) ಪರಿಶೀಲಿಸಿ, ಮತ್ತೆ ಕೀಮ್ಯಾನ್ ಪ್ರಾರಂಭಿಸಲು ಬಯಸುವಿರಾ\?</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKDebuggingWarning" comment="Warning upon starting debugging in the Options tab">ಕೀಮ್ಯಾನ್ ಡೀಬಗ್ ಮಾಹಿತಿಯನ್ನು ನಿಮ್ಮ ಡೆಸ್ಕ್‌ಟಾಪ್‌ನಲ್ಲಿ %LOCALAPPDATA%\Keyman\Diag\system#.etl (ಇಲ್ಲಿ # ಒಂದು ಸಂಖ್ಯೆ) ಕರೆಯಲಾಗುವ ಪಠ್ಯ ಫೈಲ್‌ನಲ್ಲಿ ಸಂಗ್ರಹಿಸಲಾಗುತ್ತದೆ. ಈ ಫೈಲ್ ಅನ್ನು ಓದುವ ಅಥವಾ ಅಳಿಸುವ ಮೊದಲು ನೀವು ಕೀಮ್ಯಾನ್ ನಿರ್ಗಮಿಸಬೇಕು. \n\nಎಚ್ಚರಿಕೆ: ಈ ಫೈಲ್ ಬಹಳ ಬೇಗನೆ ದೊಡ್ಡ ಗಾತ್ರವಾಗಿ ಬೆಳೆಯುತ್ತದೆ. ಡೀಬಗ್ ಮಾಡುವುದನ್ನು ಸಕ್ರಿಯಗೊಳಿಸುವುದರಿಂದ ನಿಮ್ಮ ಸಿಸ್ಟಮ್ ಅನ್ನು ನಿಧಾನಗೊಳಿಸುತ್ತದೆ ಹಾಗಾಗಿ \"ತಾಂತ್ರಿಕ ಬೆಂಬಲ\"ದಿಂದ ಸಲಹೆ ನೀಡಿದರೆ ಮಾತ್ರ ಇದನ್ನು ಸ್ಥಾಪಿಸಬೇಕು. \n\nಗೌಪ್ಯತೆಯ ಎಚ್ಚರಿಕೆ: ನೀವು ಟೈಪ್ ಮಾಡುವ ಎಲ್ಲಾ ಕೀಲಿಗಳನ್ನು ಡೀಬಗ್ ಲಾಗ್‌ಫೈಲ್ ದಾಖಲಿಸುತ್ತದೆ ಎಂಬುದನ್ನು ದಯವಿಟ್ಟು ಗಮನಿಸಿ. ಡೀಬಗ್ ಮಾಡುವಿಕೆ ಅಥವಾ ಡಯಗ್ನೊಸ್ಟಿಕ್ ಆಗುವ ಅವಧಿಯಲ್ಲಿ ಮಾತ್ರ ನೀವು ಡೀಬಗ್ ಸ್ಥಾಪಿಸಬೇಕು.</string>
+  <!-- Context: OSK Font Helper -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_OSK_FontHelper_PleaseWait" comment="OSK Font helper message">ಈ %1$s ಕೀಲಿಮಣೆಯೊಂದಿಗೆ ಸಂಬಂಧಿತ ಅಕ್ಷರ ಶೈಲಿಗಳನ್ನು ಹುಡುಕುತ್ತಿರುವುದು ದಯವಿಟ್ಟು ನಿರೀಕ್ಷಿಸಿ</string>
+  <!-- Context: OSK Font Helper -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_OSK_FontHelper_NonUnicode" comment="OSK Font helper non-Unicode keyboard">ಕೀಲಿಮಣೆ %1$s ಯುನಿಕೋಡ್ ಕೀಲಿಮಣೆ ಅಲ್ಲ. ಈ ಕೀಲಿಮಣೆಯೊಂದಿಗೆ ಅಕ್ಷರ ಶೈಲಿಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸ್ಥಾಪಿಸಲಾಗುವುದಿಲ್ಲ. ಅಕ್ಷರ ಶೈಲಿಗಳ ಮಾಹಿತಿಗಾಗಿ ದಯವಿಟ್ಟು ಕೀಲಿಮಣೆ ದಸ್ತಾವೇಜನ್ನು ಪರಿಶೀಲಿಸಿ.</string>
+  <!-- Context: OSK Font Helper -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_OSK_FontHelper_NoKeyboards" comment="OSK Font helper no keyboards">ನೀವು ಯಾವುದೇ ಕೀಲಿಮಣೆಯನ್ನು ಅನುಸ್ಥಾಪಿಸಿಲ್ಲ ಅಥವಾ ಲೋಡ್ ಮಾಡಲಾಗಿಲ್ಲ. ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸವನ್ನು ಅನುಸ್ಥಾಪಿಸಲು Keyman \"ಸಂರಚನೆ\"(ಕಾನ್ಫಿಗರೇಷನ್)ನಲ್ಲಿ \"ಡೌನ್ಲೋಡ್ ಕೀಲಿಮಣೆ\" ಗುಂಡಿಯನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿ.</string>
+  <!-- Context: OSK Font Helper -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_OSK_FontHelper_ChooseKeyboard" comment="OSK Font helper choose keyboard">ಅಕ್ಷರ ಶೈಲಿ(ಫಾಂಟ್)/ಗಳನ್ನು ಹುಡುಕಲು, ದಯವಿಟ್ಟು ಒಂದು ಕೀಮ್ಯಾನ್ ಕೀಲಿಮಣೆ ಆಯ್ಕೆಮಾಡಿ ಆಯ್ಕೆಮಾಡಿ.</string>
+  <!-- Context: Text Editor -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 10.0.836.0 -->
+  <string name="SKTextEditorCaption" comment="Caption of Text Editor">ಪಠ್ಯ ಸಂಪಾದಕ - ಕೀಮ್ಯಾನ್</string>
+</resources>

--- a/windows/src/desktop/setup/locale/kn-IN/strings.xml
+++ b/windows/src/desktop/setup/locale/kn-IN/strings.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="ssLanguageName" comment="User interface language name in the UI language">ಕನ್ನಡ</string>
+  <string name="ssApplicationTitle">$APPNAME $VERSION ಸೆಟ್ಅಪ್</string>
+  <string name="ssTitle">$APPNAME $VERSION ಸ್ಥಾಪಿಸಿ</string>
+  <string name="ssInstallSuccess">$APPNAME $VERSION ಯಶಸ್ವಿಯಾಗಿ ಸ್ಥಾಪಿಸಲಾಗಿದೆ.</string>
+  <string name="ssCancelQuery">$APPNAME ಸ್ಥಾಪನೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?</string>
+  <string name="ssBootstrapExtractingBundle">ಕಡತಗಳನ್ನು ಹೊರತೆಗೆಯಲಾಗುತ್ತಿದೆ...</string>
+  <string name="ssBootstrapCheckingPackages">ಪ್ಯಾಕೇಜ್‌ಗಳನ್ನು ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ...</string>
+  <string name="ssBootstrapCheckingForUpdates">ನವೀಕರಣಗಳಿಗಾಗಿ ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ...</string>
+  <string name="ssBootstrapCheckingInstalledVersions">ಸ್ಥಾಪಿಸಲಾದ ಆವೃತ್ತಿಗಳನ್ನು ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ...</string>
+  <string name="ssBootstrapReady">ಪೂರ್ಣಗೊಳಿಸುತ್ತಿದೆ...</string>
+  <!-- Parameters: %0:s: version, %1:s: ssActionDownload -->
+  <string name="ssActionInstallKeyman">$APPNAME %0:s %1:s</string>
+  <!-- Parameters: %0:s: package name %1:s: version %2:s: ssActionDownload -->
+  <string name="ssActionInstallPackage">• %0:s %1:s %2:s</string>
+  <!-- Parameters: %0:s: package name %1:s: version %2:s: language %3:s: ssActionDownload -->
+  <string name="ssActionInstallPackageLanguage">• %2:s ಗೆ %0:s %1:s %3:s</string>
+  <string name="ssActionNothingToInstall">ಸ್ಥಾಪಿಸಲು ಏನೂ ಇಲ್ಲ.</string>
+  <!-- Parameters: %0:s download size -->
+  <string name="ssActionDownload">(ಡೌನ್ಲೋಡ್ %0:s)</string>
+  <string name="ssActionInstall">ಸೆಟ್ಅಪ್ ಸ್ಥಾಪಿಸುತ್ತದೆ:</string>
+  <string name="ssFreeCaption">$APPNAME $VERSION ಉಚಿತ ಮತ್ತು ಮುಕ್ತ ಸಂಪನ್ಮೂಲವಾಗಿದೆ</string>
+  <string name="ssLicenseLink">&amp;ಪರವಾನಗಿಯನ್ನು ಓದಿ</string>
+  <string name="ssInstallOptionsLink">ಅನುಸ್ಥಾಪಿಸುವ &amp; ಆಯ್ಕೆಗಳು</string>
+  <string name="ssMessageBoxTitle">$APPNAME ಅನುಸ್ಥಾಪಿಸು</string>
+  <string name="ssOkButton">ಸರಿ</string>
+  <string name="ssInstallButton">&amp;ಅನುಸ್ಥಾಪಿಸು</string>
+  <string name="ssCancelButton">ರದ್ದುಮಾಡು</string>
+  <string name="ssExitButton">ನಿರ್ಗಮನ&amp;</string>
+  <string name="ssStatusInstalling">$APPNAME ಸ್ಥಾಪಿಸಲಾಗುತ್ತಿದೆ</string>
+  <string name="ssStatusRemovingOlderVersions">ಹಳೆಯ ಆವೃತ್ತಿಗಳನ್ನು ತೆಗೆದುಹಾಕಲಾಗುತ್ತಿದೆ</string>
+  <string name="ssStatusComplete">ಅನುಸ್ಥಾಪನೆಯು ಪೂರ್ಣಗೊಂಡಿದೆ</string>
+  <string name="ssQueryRestart">ಸೆಟ್‌ಅಪ್ ಅನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು ನೀವು ವಿಂಡೋಸ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಬೇಕು. ನೀವು ವಿಂಡೋಸ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿದಾಗ, ಸೆಟ್‌ಅಪ್ ಮುಂದುವರಿಯುತ್ತದೆ.
+
+ಈಗ ವಿಂಡೋಸ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಬಹುದೇ?</string>
+  <string name="ssErrorUnableToAutomaticallyRestart">ವಿಂಡೋಸ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ನೀವು $APPNAME ಅನ್ನು ಪ್ರಾರಂಭಿಸುವ ಮೊದಲು, ವಿಂಡೋಸ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಬೇಕು.</string>
+  <string name="ssMustRestart">ಸೆಟ್‌ಅಪ್ ಅನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು ನೀವು ವಿಂಡೋಸ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಬೇಕು. ನೀವು ವಿಂಡೋಸ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿದಾಗ, ಸೆಟ್‌ಅಪ್ ಮುಕ್ತಾಯಗೊಳ್ಳುತ್ತದೆ.</string>
+  <string name="ssOldOsVersionInstallKeyboards">$APPNAME $VERSION ಸ್ಥಾಪಿಸಲು (Windows 7) ವಿಂಡೋಸ್ ೭ ಅಥವಾ ನಂತರದ ಅಗತ್ಯವಿದೆ. ಆದಾಗ್ಯೂ, ಕೀಮನ್ ಡೆಸ್ಕ್‌ಟಾಪ್ 7, 8 ಅಥವಾ 9 ಅನ್ನು ಪತ್ತೆಹಚ್ಚಲಾಗಿದೆ. ಈ ಸ್ಥಾಪಕದಲ್ಲಿ ಸೇರಿಸಲಾದ ಕೀಲಿಮಣೆಗಳನ್ನು ಸ್ಥಾಪಿಸಲಾದ ಕೀಮ್ಯಾನ್ ಡೆಸ್ಕ್‌ಟಾಪ್ ಆವೃತ್ತಿಗೆ ಸ್ಥಾಪಿಸಲು ನೀವು ಬಯಸುವಿರಾ?</string>
+  <string name="ssOldOsVersionDownload">$APPNAME ನ ಈ ಆವೃತ್ತಿಯನ್ನು ಸ್ಥಾಪಿಸಲು (Windows 7) ವಿಂಡೋಸ್ ೭ ಅಥವಾ ನಂತರದ ಅಗತ್ಯವಿದೆ. ನೀವು ಕೀಮ್ಯಾನ್ ಡೆಸ್ಕ್‌ಟಾಪ್ ೮ ಅನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಬಯಸುವಿರಾ?</string>
+  <string name="ssOptionsTitle">ಸ್ಥಾಪಿಸುವ ಆಯ್ಕೆಗಳು</string>
+  <string name="ssOptionsTitleInstallOptions">ಅನುಸ್ಥಾಪನೆಯ ಆಯ್ಕೆಗಳು</string>
+  <string name="ssOptionsTitleDefaultKeymanSettings">ಪೂರ್ವನಿರ್ಧರಿತ $APPNAME ಸೆಟ್ಟಿಂಗ್‌ಗಳು</string>
+  <string name="ssOptionsTitleSelectModulesToInstall">ಸ್ಥಾಪಿಸಲು ಅಥವ ನವೀಕರಿಸಲು ಇರುವ ಮಾಡ್ಯೂಲ್‌ಗಳು</string>
+  <string name="ssOptionsTitleAssociatedKeyboardLanguage">ಕೀಲಿಮಣೆ ಸಂಬಂಧಿತ ಭಾಷೆಗಳು</string>
+  <string name="ssOptionsTitleLocation">ಸ್ಥಾಪಿಸಲು ಆವೃತ್ತಿ</string>
+  <string name="ssOptionsStartWithWindows">$APPNAME ಚಲನೆಯನ್ನು ವಿಂಡೋಸ್ ಪ್ರಾರಂಭವಾದಾಗ ಪ್ರಾರಂಭಿಸು</string>
+  <string name="ssOptionsStartAfterInstall">ಸ್ಥಾಪನೆ ಪೂರ್ಣಗೊಂಡಾಗ $APPNAME ಅನ್ನು ಪ್ರಾರಂಭಿಸಿ</string>
+  <string name="ssOptionsCheckForUpdates">ನವೀಕರಣಗಳಿಗೆ ನಿಯತಕಾಲಿಕವಾಗಿ ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ ಪರಿಶೀಲಿಸಿ</string>
+  <string name="ssOptionsUpgradeKeyboards">ಹಳೆಯ ಆವೃತ್ತಿಗಳೊಂದಿಗೆ ಸ್ಥಾಪಿಸಲಾದ ಕೀಲಿಮಣೆ‌ಗಳನ್ನು $VERSION ಆವೃತ್ತಿಗೆ ನವೀಕರಿಸು</string>
+  <string name="ssOptionsAutomaticallyReportUsage">keyman.com ಜೊತೆಗೆ ಅನಾಮಧೇಯ ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳನ್ನು ಹಂಚಿಕೊಳ್ಳಿ</string>
+  <!-- Parameters: %0:s: version of installer (may differ from Keyman version) -->
+  <string name="ssInstallerVersion">ಸೆಟ್ಅಪ್ ಆವೃತ್ತಿ: %0:s</string>
+  <string name="ssOptionsInstallKeyman">$APPNAME ಸ್ಥಾಪಿಸು</string>
+  <string name="ssOptionsUpgradeKeyman">$APPNAME ನವೀಕರಿಸು</string>
+  <!-- Parameters: %0:s: installed version -->
+  <string name="ssOptionsKeymanAlreadyInstalled">$APPNAME %0:s ಈಗಾಗಲೇ ಸ್ಥಾಪಿಸಲಾಗಿದೆ.</string>
+  <!-- Parameters: %0:s: version, %1:s: size -->
+  <string name="ssOptionsDownloadKeymanVersion">ಡೌನ್ಲೋಡ್ ಆವೃತ್ತಿ %0:s (%1:s)</string>
+  <!-- Parameters: %0:s: version -->
+  <string name="ssOptionsInstallKeymanVersion">ಆವೃತ್ತಿ %0:s</string>
+  <!-- Parameters: %0:s: package name %1:s -->
+  <string name="ssOptionsInstallPackage">%0:s ಸ್ಥಾಪಿಸು</string>
+  <!-- Parameters: %0:s: package version %1:s package size -->
+  <string name="ssOptionsDownloadPackageVersion">ಡೌನ್ಲೋಡ್ ಆವೃತ್ತಿ %0:s (%1:s)</string>
+  <!-- Parameters: %0:s: package version -->
+  <string name="ssOptionsInstallPackageVersion">ಆವೃತ್ತಿ %0:s</string>
+  <!-- Parameters: %0:s package name -->
+  <string name="ssOptionsPackageLanguageAssociation">%0:s ಕೀಲಿಮಣೆಗೆ ಸಂಬಂಧಿತ ಭಾಷೆಯನ್ನು ಆಯ್ಕೆಮಾಡಿ</string>
+  <string name="ssOptionsDefaultLanguage">ಪೂರ್ವನಿರ್ಧರಿತ ಭಾಷೆ</string>
+  <!-- Parameters: %0:s: filename -->
+  <string name="ssDownloadingTitle">%0:s ಡೌನ್ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ</string>
+  <!-- Parameters: %0:s: filename -->
+  <string name="ssDownloadingText">%0:s ಡೌನ್ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ</string>
+  <string name="ssOffline">$APPNAME ಹೆಚ್ಚಿನ ಸಂಪನ್ಮೂಲಗಳನ್ನು ಡೌನ್ಲೋಡ್ ಮಾಡಲು keyman.com ಅನ್ನು ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲಾ.
+
+ದಯವಿಟ್ಟು ನೀವು ಆನ್‌ಲೈನ್‌ನಲ್ಲಿರುವಿರಿ ಎಂಬುದನ್ನು ಪರಿಶೀಲಿಸಿ, ನಿಮ್ಮ (firewall settings) ಫೈರ್‌ವಾಲ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ $APPNAME ಗೆ ಇಂಟರ್ನೆಟ್ ಅನ್ನು ಪ್ರವೇಶಿಸಲು ಅನುಮತಿಯನ್ನು ಹೊಂದಿಸಿ.
+
+ಸೆಟ್ಅಪ್‌ನಿಂದ ಸ್ಥಗಿತಗೊಳಿಸು \"ನಿರ್ಗಮಿಸು\" ಕ್ಲಿಕ್ ಮಾಡಿ, ಸಂಪನ್ಮೂಲಗಳನ್ನು ಪುನಃ ಪ್ರಯತ್ನಿಸಲು ಮತ್ತು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಮರುಪ್ರಯತ್ನಿಸಿ ಅಥವಾ ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿ ಮುಂದುವರಿಯಲು ನಿರ್ಲಕ್ಷಿಸಿ.</string>
+</resources>


### PR DESCRIPTION
Fixes #7952 

This adds the crowdin strings for Kannada - locale kn-IN

TODO for @sgschantz 
- [x] Run XCode for iOS
- [x] Run XCode for macOS

## User Testing
Load the PR build for each platform and set the UI / Locale to "ಕನ್ನಡ" (and/or Kannada)

* **TEST_ANDROID** 
1. Load the PR build of Keyman for Android
2. In the Keyman app, go to Settings --> Display Language --> ಕನ್ನಡ (Kannada)
3. Return to the Keyman app 
4. Verify the UI is in Kannada (prompt, Settings strings, etc.). Note, the globe tip string stays in English and is a separate issue #7975

![kannada android menu](https://user-images.githubusercontent.com/7358010/210301713-382b14bf-7904-4edb-a7fb-92a348e81a49.png)


* **TEST_IOS**
1. Load the PR build of Keyman for iPhone and iPad
2. Set the device locale to Kannada
3. Return to the Keyman app
4. Verify the UI is in  Kannada

* **TEST_LINUX**
1. Start Keyman configuration with: LANGUAGE=kn_IN km-config
2. Verify Keyman UI is in Kannada

* **TEST_MACOS**
1. Load the PR build of Keyman for macOS
2. Set the locale to Kannada
3. Verify the Keyman UI is in Kannada

* **TEST_WINDOWS**
1. Load the PR build of Keyman for Windows
2. Set the UI to Kannada
3. Verify the Keyman UI is in Kannada

