### PR TITLE
fix(android/engine): Add utility for localized strings

### DIFF
--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/BaseActivity.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/BaseActivity.java
@@ -49,6 +49,21 @@ public class BaseActivity extends AppCompatActivity {
     }
   }
 
+  /**
+   * Some classes aren't an AppCompatActivity and need this helper to retrieve localized Strings
+   * in the updated locale.
+   * @param defaultContext - the context to fallback if localUpdatedContext is null
+   * @param resID - the resource ID of the string
+   * @return String - localized string
+   */
+  public static String getString(Context defaultContext, int resID) {
+    Context context = (localeUpdatedContext != null) ? localeUpdatedContext : defaultContext;
+    if (context != null) {
+      return context.getString(resID);
+    };
+    return "";
+  }
+
   @Override
   protected void attachBaseContext(Context newBase) {
     // Override the app locale using the BCP 47 tag from shared preferences

--- a/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMKeyboard.java
@@ -1286,7 +1286,7 @@ final class KMKeyboard extends WebView {
     }
 
     try {
-      String hintText = context.getString(R.string.help_bubble_text);
+      String hintText = BaseActivity.getString(this.context, R.string.help_bubble_text);
 
       // To ensure that the localized text is properly escaped, we'll use JSON utilities.  Since
       // there's no direct string encoder, we'll just wrap it in an object and unwrap it in JS.


### PR DESCRIPTION
Fixes #7975 where the globe help tip was stuck in English and didn't match the UI locale.

Similar to the fix in #4588, this adds a BaseActivity utility so non AppCompatActivities can access localized strings.

## User Testing
Setup - Do a clean Install PR build of Keyman for Android on default English locale.

* **TEST_GLOBE_KEY_LOCALIZED** - Verifies the globe key text is localized and matches the current display language
1. Launch Keyman for Android
2. Verify the globe key text is in English 
3. From Keyman, go to Settings --> Display Language --> Khmer
4. Exit the Keyman settings menu
5. In the app, verify the UI is in Khmer, along with the globe key text
![khmer-globe](https://user-images.githubusercontent.com/7358010/210492908-63d774a1-0866-4416-9744-ef246fc610fd.jpg)

6. From Keyman, go to Settings --> Display Language --> German
7. Exit the Keyman settings menu
8. In the app, verify the UI is in German, along with the globe key text
 
![german-globe](https://user-images.githubusercontent.com/7358010/210492925-d8be78cf-0af7-41de-bbcd-0e3db355e2d9.jpg)
