### PR TITLE
feat(linux): Implement Options page and option to disable Sentry error reporting

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -119,8 +119,8 @@ jobs:
         platform: "${{ matrix.arch }}"
         source_dir: "artifacts/keyman-srcpkg"
         sourcepackage: "keyman_${{ needs.sourcepackage.outputs.VERSION }}-1.dsc"
-        deb_fullname: $DEBFULLNAME
-        deb_email: $DEBEMAIL
+        deb_fullname: ${{env.DEBFULLNAME}}
+        deb_email: ${{env.DEBEMAIL}}
         prerelease_tag: ${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}
 
     - name: Output resulting .deb files

--- a/linux/keyman-config/build.sh
+++ b/linux/keyman-config/build.sh
@@ -29,6 +29,21 @@ clean_action() {
     keyman_config/standards/lang_tags_map.py
 }
 
+build_man_pages() {
+  local TEMP_DATA_DIR SCHEMA_DIR
+  TEMP_DATA_DIR=$(mktemp -d)
+  SCHEMA_DIR=$TEMP_DATA_DIR/glib-2.0/schemas
+  export XDG_DATA_DIRS=$TEMP_DATA_DIR:${XDG_DATA_DIRS-}
+  export GSETTINGS_SCHEMA_DIR=${SCHEMA_DIR}
+  mkdir -p "$SCHEMA_DIR"
+  cp ./com.keyman.gschema.xml "$SCHEMA_DIR"/
+  glib-compile-schemas "$SCHEMA_DIR"
+  ./build-help.sh --man --no-reconf
+  export XDG_DATA_DIRS=${XDG_DATA_DIRS#*:}
+  unset GSETTINGS_SCHEMA_DIR
+  rm -rf $TEMP_DATA_DIR
+}
+
 build_action() {
   builder_echo "Create version.py"
   pushd keyman_config
@@ -52,7 +67,7 @@ build_action() {
   fi
   popd
   builder_echo "Building man pages"
-  ./build-help.sh --man --no-reconf
+  build_man_pages
   builder_echo "Building keyman-config"
   python3 setup.py build
 }

--- a/linux/keyman-config/com.keyman.gschema.xml
+++ b/linux/keyman-config/com.keyman.gschema.xml
@@ -1,8 +1,12 @@
 <schemalist>
   <schema id="com.keyman.options" path="/desktop/ibus/keyman/options/">
-
     <child name="keyboard-options" schema="com.keyman.options.child"/>
 
+    <key name="error-reporting" type="b">
+        <default>true</default>
+        <summary>Automatic error reporting</summary>
+        <description>true to enable automatic reporting of errors to Sentry</description>
+    </key>
   </schema>
 
   <schema id="com.keyman.options.child">

--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -1,20 +1,18 @@
-import getpass
 import gettext
-import importlib
-import logging
-import os
-import platform
-import sys
 
-from .version import __version__
-from .version import __versionwithtag__
-from .version import __versiongittag__
-from .version import __majorversion__
-from .version import __releaseversion__
-from .version import __tier__
-from .version import __pkgversion__
-from .version import __environment__
-from .version import __uploadsentry__
+from keyman_config.sentry_handling import SentryErrorHandling
+
+from keyman_config.version import (
+  __version__,
+  __versionwithtag__,
+  __versiongittag__,
+  __majorversion__,
+  __releaseversion__,
+  __tier__,
+  __pkgversion__,
+  __environment__,
+  __uploadsentry__
+)
 
 
 def _(txt):
@@ -24,7 +22,7 @@ def _(txt):
     return translation
 
 
-def secure_lookup(data, key1, key2 = None):
+def secure_lookup(data, key1, key2=None):
     """
     Return data[key1][key2] while dealing with data being None or key1 or key2 not existing
     """
@@ -38,17 +36,9 @@ def secure_lookup(data, key1, key2 = None):
     return None
 
 
-def before_send(event, hint):
-    if 'exc_info' in hint:
-        exc_type, exc_value, tb = hint['exc_info']
-        if isinstance(exc_value, KeyboardInterrupt):
-            # Ignore KeyboardInterrupt exception
-            return None
-    return event
-
-
 gettext.bindtextdomain('keyman-config', '/usr/share/locale')
 gettext.textdomain('keyman-config')
+
 
 #if __tier__ == 'alpha' or __tier__ == 'beta':  // #7227 disabling:
     # Alpha and beta versions will work against the staging server so that they
@@ -60,60 +50,8 @@ gettext.textdomain('keyman-config')
 KeymanComUrl = 'https://keyman.com'
 KeymanApiUrl = 'https://api.keyman.com'
 
+
 # There's no staging site for downloads
 KeymanDownloadsUrl = 'https://downloads.keyman.com'
 
-if 'unittest' in sys.modules.keys():
-    print('Not reporting to Sentry', file=sys.stderr)
-elif os.environ.get('KEYMAN_NOSENTRY'):
-    print('Not reporting to Sentry because KEYMAN_NOSENTRY environment variable set', file=sys.stderr)
-elif not __uploadsentry__:
-    print('Not reporting to Sentry because UPLOAD_SENTRY is false (%s)' % __environment__, file=sys.stderr)
-else:
-    try:
-        # Try new sentry-sdk first
-        sentry_sdk = importlib.import_module('sentry_sdk')
-        from sentry_sdk import configure_scope, set_user
-        from sentry_sdk.integrations.logging import LoggingIntegration
-        HaveSentryNewSdk = True
-
-        sentry_logging = LoggingIntegration(
-            level=logging.INFO,           # Capture info and above as breadcrumbs
-            event_level=logging.CRITICAL  # Send critical errors as events
-        )
-        SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357@o1005580.ingest.sentry.io/5983525"
-        sentry_sdk.init(
-            dsn=SentryUrl,
-            environment=__environment__,
-            release=__versiongittag__,
-            integrations=[sentry_logging],
-            before_send=before_send
-        )
-        set_user({'id': hash(getpass.getuser())})
-        with configure_scope() as scope:
-            scope.set_tag("app", os.path.basename(sys.argv[0]))
-            scope.set_tag("pkgversion", __pkgversion__)
-            scope.set_tag("platform", platform.platform())
-            scope.set_tag("system", platform.system())
-            scope.set_tag("tier", __tier__)
-    except ImportError:
-        try:
-            # sentry-sdk is not available, so use older raven
-            raven = importlib.import_module('raven')
-            from raven import Client
-            HaveSentryNewSdk = False
-
-            # Note, legacy raven API requires secret (https://github.com/keymanapp/keyman/pull/5787#discussion_r721457909)
-            SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357:e6d5a81ee6944fc79bd9f0cbb1f2c2a4@o1005580.ingest.sentry.io/5983525"
-            client = Client(SentryUrl, environment=__environment__, release=__versiongittag__)
-            client.user_context({'id': hash(getpass.getuser())})
-            client.tags_context({
-                'app': os.path.basename(sys.argv[0]),
-                'pkgversion': __pkgversion__,
-                'platform': platform.platform(),
-                'system': platform.system(),
-                'tier': __tier__,
-            })
-        except ImportError:
-            # even raven is not available. This is the case on Ubuntu 16.04. Just ignore.
-            print(_('Neither sentry-sdk nor raven is available. Not enabling Sentry error reporting.'), file=sys.stderr)
+SentryErrorHandling().initialize_sentry()

--- a/linux/keyman-config/keyman_config/dconf_util.py
+++ b/linux/keyman-config/keyman_config/dconf_util.py
@@ -2,25 +2,25 @@
 
 from gi.repository import Gio
 
-# DConf path destkop/ibus/keyman/options
-DCONF_BASE = "com.keyman.options"
+# GSettings path destkop/ibus/keyman/options
+GSETTINGS_BASE = "com.keyman.options"
 
-# Utilities to get and set Keyman options in DConf:
+# Utilities to get and set Keyman options in GSettings:
 # /desktop/ibus/keyman/options/packageID/keyboardID/options
 
 
 def get_child_schema(info):
-    settings = Gio.Settings.new(DCONF_BASE)
+    settings = Gio.Settings.new(GSETTINGS_BASE)
     path = settings.get_property('path')
     if not path.endswith('/'):
         path += '/'
     path += info['packageID'] + '/' + info['keyboardID'] + '/'
-    return Gio.Settings(DCONF_BASE + '.child', path)
+    return Gio.Settings(GSETTINGS_BASE + '.child', path)
 
 
 def get_option(info):
     """
-    Get the Keyman keyboard options from DConf
+    Get the Keyman keyboard options from GSettings
     Convert from list of comma-separated strings into dictionary
 
     Args:
@@ -41,7 +41,7 @@ def get_option(info):
 
 def set_option(info, options):
     """
-    Store the Keyman keyboard options in DConf as a list of strings
+    Store the Keyman keyboard options in GSettings as a list of strings
 
     Args:
         info: dictionary

--- a/linux/keyman-config/keyman_config/sentry_handling.py
+++ b/linux/keyman-config/keyman_config/sentry_handling.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python3
+import getpass
+import importlib
+import logging
+import os
+import platform
+import sys
+from keyman_config.gsettings import GSettings
+from keyman_config.version import (
+  __version__,
+  __versionwithtag__,
+  __versiongittag__,
+  __majorversion__,
+  __releaseversion__,
+  __tier__,
+  __pkgversion__,
+  __environment__,
+  __uploadsentry__
+)
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gio, Gtk
+
+
+class SentryErrorHandling:
+    def __init__(self) -> None:
+        self.settings = Gio.Settings.new('com.keyman.options')
+
+    def initialize_sentry(self):
+        (enabled, reason) = self.is_sentry_enabled()
+        if not enabled:
+            print(reason, file=sys.stderr)
+            logging.info(reason)
+            return (enabled, reason)
+        else:
+            try:
+                self._sentry_sdk_initialize()
+            except ImportError:
+                try:
+                    self._raven_initialize()
+                except ImportError:
+                    # even raven is not available. This is the case on Ubuntu 16.04. Just ignore.
+                    print(_('Neither sentry-sdk nor raven is available. Not enabling Sentry error reporting.'),
+                          file=sys.stderr)
+                    logging.info('Neither sentry-sdk nor raven is available. Not enabling Sentry error reporting.')
+                    return (False, _('Neither sentry-sdk nor raven is available. Not enabling Sentry error reporting.'))
+            return (True, '')
+
+    def is_sentry_enabled(self):
+        if 'unittest' in sys.modules.keys():
+            return (False, 'Running unit tests, not reporting to Sentry')
+        elif self._get_environ_nosentry():
+            return (False, 'Not reporting to Sentry because KEYMAN_NOSENTRY environment variable set')
+        elif not __uploadsentry__:
+            return (False, f'Not reporting to Sentry because UPLOAD_SENTRY is false ({__environment__})')
+        elif not self._get_setting():
+            return (False, 'Not reporting to Sentry because disabled in GSettings')
+        return (True, 'Reporting to Sentry')
+
+    def is_sentry_disabled_by_variable(self):
+        return self._get_environ_nosentry() or not __uploadsentry__
+
+    def bind_checkbutton(self, button: Gtk.CheckButton):
+        self.settings.bind("error-reporting", button, "active", Gio.SettingsBindFlags.NO_SENSITIVITY)
+        self.settings.connect("changed::error-reporting", self._on_sentry_reporting_toggled)
+
+    def set_enabled(self, enabled):
+        assert not self.is_sentry_disabled_by_variable()
+        was_enabled = self.is_sentry_enabled()
+        self._save_setting(enabled)
+        if enabled != was_enabled:
+            self._handle_enabled(enabled)
+
+    def _get_environ_nosentry(self):
+        keyman_nosentry = os.environ.get('KEYMAN_NOSENTRY')
+        return keyman_nosentry and (int(keyman_nosentry) == 1)
+
+    def _handle_enabled(self, enabled):
+        if enabled:
+            self.initialize_sentry()
+        else:
+            self._close_sentry()
+
+    def _save_setting(self, enabled: bool):
+        self.settings.set_boolean('error-reporting', enabled)
+
+    def _get_setting(self) -> bool:
+        return self.settings.get_boolean('error-reporting')
+
+    def _on_sentry_reporting_toggled(self, settings, key):
+        self._handle_enabled(self.settings.get_boolean('error-reporting'))
+
+    def _close_sentry(self):
+        from sentry_sdk import Hub
+        logging.info("Shutting down Sentry error reporting")
+        client = Hub.current.client
+        if client is not None:
+            client.close(timeout=2.0)
+
+    def _sentry_sdk_initialize(self):
+        # Try new sentry-sdk first
+        sentry_sdk = importlib.import_module('sentry_sdk')
+        from sentry_sdk import configure_scope, set_user
+        from sentry_sdk.integrations.logging import LoggingIntegration
+
+        sentry_logging = LoggingIntegration(
+          level=logging.INFO,           # Capture info and above as breadcrumbs
+          event_level=logging.CRITICAL  # Send critical errors as events
+        )
+        SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357@o1005580.ingest.sentry.io/5983525"
+        sentry_sdk.init(
+          dsn=SentryUrl,
+          environment=__environment__,
+          release=__versiongittag__,
+          integrations=[sentry_logging],
+          before_send=self._before_send
+        )
+        set_user({'id': hash(getpass.getuser())})
+        with configure_scope() as scope:
+            scope.set_tag("app", os.path.basename(sys.argv[0]))
+            scope.set_tag("pkgversion", __pkgversion__)
+            scope.set_tag("platform", platform.platform())
+            scope.set_tag("system", platform.system())
+            scope.set_tag("tier", __tier__)
+        logging.info("Initialized Sentry error reporting")
+
+    def _raven_initialize(self):
+        # sentry-sdk is not available, so use older raven
+        raven = importlib.import_module('raven')
+        from raven import Client
+
+        # Note, legacy raven API requires secret (https://github.com/keymanapp/keyman/pull/5787#discussion_r721457909)
+        SentryUrl = "https://1d0edbf2d0dc411b87119b6e92e2c357:e6d5a81ee6944fc79bd9f0cbb1f2c2a4@o1005580.ingest.sentry.io/5983525"
+        client = Client(SentryUrl, environment=__environment__, release=__versiongittag__)
+        client.user_context({'id': hash(getpass.getuser())})
+        client.tags_context({
+          'app': os.path.basename(sys.argv[0]),
+          'pkgversion': __pkgversion__,
+          'platform': platform.platform(),
+          'system': platform.system(),
+          'tier': __tier__,
+        })
+        logging.info("Initialized Sentry error reporting (raven)")
+
+    def _before_send(self, event, hint):
+        if 'exc_info' in hint:
+            exc_type, exc_value, tb = hint['exc_info']
+            if isinstance(exc_value, KeyboardInterrupt):
+                # Ignore KeyboardInterrupt exception
+                return None
+        return event

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -94,7 +94,7 @@ class ViewInstalledWindowBase(Gtk.Window):
             self.close()
 
     def run(self):
-        self.resize(576, 324)
+        self.resize(776, 424)
         self.connect("destroy", Gtk.main_quit)
         self.show_all()
         Gtk.main()
@@ -191,23 +191,41 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         bbox_top.add(self.options_button)
 
         vbox.pack_start(bbox_top, False, False, 12)
+        hbox.pack_start(vbox, False, False, 12)
 
-        bbox_bottom = Gtk.ButtonBox(spacing=12, orientation=Gtk.Orientation.VERTICAL)
-        bbox_bottom.set_layout(Gtk.ButtonBoxStyle.END)
+        outerHbox = Gtk.HBox()
+        sidebar = Gtk.StackSidebar()
+        stack = Gtk.Stack()
 
-        button = Gtk.Button.new_with_mnemonic(_("_Refresh"))
-        button.set_tooltip_text(_("Refresh keyboard list"))
-        button.connect("clicked", self.on_refresh_clicked)
+        outerHbox.pack_start(sidebar, False, False, 0)
+        outerHbox.pack_end(Gtk.Separator(), False, False, 0)
+        outerHbox.pack_end(stack, True, True, 0)
+        stack.set_hexpand(True)
+        stack.set_vexpand(True)
+        sidebar.set_stack(stack)
+
+        stack.add_titled(hbox, "KeyboardLayouts", _("Keyboard Layouts"))
+        stack.add_titled(Gtk.Label("TODO - Options"), "Options", _("Options"))
+
+        outmostVBox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        outmostVBox.pack_start(outerHbox, True, True, 0)
+
+        bbox_bottom = Gtk.ButtonBox(spacing=12, orientation=Gtk.Orientation.HORIZONTAL)
+        bbox_bottom.set_layout(Gtk.ButtonBoxStyle.START)
+
+        button = Gtk.Button.new_with_mnemonic(_("_Install keyboard..."))
+        button.set_tooltip_text(_("Install a keyboard from a file"))
+        button.connect("clicked", self.on_installfile_clicked)
         bbox_bottom.add(button)
 
-        button = Gtk.Button.new_with_mnemonic(_("_Download"))
+        button = Gtk.Button.new_with_mnemonic(_("_Download keyboard..."))
         button.set_tooltip_text(_("Download and install a keyboard from the Keyman website"))
         button.connect("clicked", self.on_download_clicked)
         bbox_bottom.add(button)
 
-        button = Gtk.Button.new_with_mnemonic(_("_Install"))
-        button.set_tooltip_text(_("Install a keyboard from a file"))
-        button.connect("clicked", self.on_installfile_clicked)
+        button = Gtk.Button.new_with_mnemonic(_("_Refresh"))
+        button.set_tooltip_text(_("Refresh keyboard list"))
+        button.connect("clicked", self.on_refresh_clicked)
         bbox_bottom.add(button)
 
         button = Gtk.Button.new_with_mnemonic(_("_Close"))
@@ -217,10 +235,10 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         bind_accelerator(self.accelerators, button, '<Control>w')
         bbox_bottom.add(button)
 
-        vbox.pack_end(bbox_bottom, False, False, 12)
-
-        hbox.pack_start(vbox, False, False, 12)
-        self.add(hbox)
+        bbox_hbox = Gtk.HBox(spacing=12)
+        bbox_hbox.pack_start(bbox_bottom, True, True, 12)
+        outmostVBox.pack_end(bbox_hbox, False, True, 12)
+        self.add(outmostVBox)
 
     def addlistitems(self, installed_kmp, store, install_area):
         for kmp in sorted(installed_kmp):


### PR DESCRIPTION
This change displays tabs at the left and adds an "Options" page. This makes it look closer to the Windows version.
It also implements the option to disable Sentry error reporting (#5027).

New look:
![image](https://user-images.githubusercontent.com/181336/211070080-cbc1d9b4-538c-4511-930f-a868ad2a752e.png)

Previously:
![image](https://user-images.githubusercontent.com/181336/211070270-e915a285-7326-4b28-869f-58066943fcc0.png)

## The new Options tab:

![Screenshot from 2023-05-26 17-45-59](https://github.com/keymanapp/keyman/assets/181336/b2e244fa-f877-48ff-87b7-4e68233fad53)

# User Testing

## Preparations

- The tests can be run on any Linux platforms.
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot
- In a terminal window, run `unset KEYMAN_NOSENTRY`
- start the following tests from this terminal window!

## Tests

**TEST_UI_DEFAULT:**

- Start UI with `km-config`
- switch to `Options` tab
- verify that "Automatically report errors to keyman.com" is checked
- in the terminal run `gsettings get com.keyman.options error-reporting` and verify that the output is `true`

**TEST_UI_DEFAULT_PERSIST:**

- continuing from the previous test, close Keyman Configuration.
- restart it from the terminal by running `km-config`
- verify that "Automatically report errors to keyman.com" is checked

**TEST_UI_DISABLE:**

- continuing from the previous test
- uncheck "Automatically report errors to keyman.com"
- in the terminal run `gsettings get com.keyman.options error-reporting` and verify that the output is `false`

**TEST_UI_DISABLE_PERSIST:**

- continuing from the previous test, close Keyman Configuration.
- restart it from the terminal by running `km-config`
- verify that "Automatically report errors to keyman.com" is unchecked

**TEST_SETTINGS_ENABLED:**

- continuing from the previous test
- in the terminal, run `gsettings set com.keyman.options error-reporting true`
- verify that "Automatically report errors to keyman.com" on the Options tab is checked

**TEST_SETTINGS_ENABLED2:**

- continuing from the previous test
- in the terminal, run `gsettings set com.keyman.options error-reporting true`
- verify that "Automatically report errors to keyman.com" on the Options tab is still checked

**TEST_SETTINGS_DISABLED:**

- continuing from the previous test
- in the terminal, run `gsettings set com.keyman.options error-reporting false`
- verify that "Automatically report errors to keyman.com" on the Options tab is unchecked

**TEST_ENV_VAR_SET:**

- close Keyman Configuration
- in the terminal run `export KEYMAN_NOSENTRY=1`
- run `km-config`
- on the Options tab, verify that "Automatically report errors to keyman.com" is grayed out and can't be toggled
