### PR TITLE
feat(linux): Add Back button to "Download Keyman Keyboards" dialog

### DIFF
--- a/linux/keyman-config/keyman_config/downloadkeyboard.py
+++ b/linux/keyman-config/keyman_config/downloadkeyboard.py
@@ -30,19 +30,41 @@ class DownloadKmpWindow(Gtk.Dialog):
         s = Gtk.ScrolledWindow()
         self.webview = WebKit2.WebView()
         self.webview.connect("decide-policy", self._keyman_policy)
+        self.webview.connect("load-changed", self._update_back_button)
         url = KeymanComUrl + "/go/linux/" + __releaseversion__ + "/download-keyboards"
         self.webview.load_uri(url)
         s.add(self.webview)
 
         self.get_content_area().pack_start(s, True, True, 0)
 
-        self.add_button(_("_Close"), Gtk.ResponseType.CLOSE)
+        hbox = Gtk.Box(spacing=6)
+        self.get_content_area().pack_start(hbox, False, False, 0)
+
+        self.back_button = Gtk.Button.new_with_mnemonic(_("_Back"))
+        self.back_button.set_tooltip_text(_("Back to search"))
+        self.back_button.connect("clicked", self._on_back_clicked)
+        self.back_button.set_sensitive(False)
+        hbox.pack_start(self.back_button, False, False, 0)
+
+        close_button = Gtk.Button.new_with_mnemonic(_("_Close"))
+        close_button.set_tooltip_text(_("Close dialog"))
+        close_button.connect("clicked", self._on_close_clicked)
+        hbox.pack_end(close_button, False, False, 0)
 
         if self.parentWindow is not None:
             self.getinfo = GetInfo(self.parentWindow.incomplete_kmp)
 
         self.resize(800, 450)
         self.show_all()
+
+    def _update_back_button(self, webview, load_event):
+        self.back_button.set_sensitive(webview.can_go_back())
+
+    def _on_back_clicked(self, button):
+        self.webview.go_back()
+
+    def _on_close_clicked(self, button):
+        self.response(Gtk.ResponseType.CLOSE)
 
     def _process_kmp(self, url, downloadfile: str):
         logging.info("Downloading kmp file to %s", downloadfile)


### PR DESCRIPTION
Fixes #4828

Before:
![Screenshot from 2023-01-09 15-03-50](https://user-images.githubusercontent.com/181336/211326211-e0318632-3e77-4a3f-ab2e-1997e7b16666.png)

After:
![Screenshot from 2023-01-09 15-03-24](https://user-images.githubusercontent.com/181336/211326239-00bcd28c-f21c-4e37-be5a-aa9e48970c2e.png)

# User Testing

## Preparations

- start km-config
- click Downloads button

## Tests

**TEST_CLOSE_BTN**: Close button closes dialog

- click Close button
- verify that the "Download Keyman keyboards" dialog gets closed

**TEST_BACK_INITIAL_DISABLED**: Back button is disabled on the initial search page

- with the "Keyboard search" page showing (directly after opening the dialog), verify that the "Back" button is disabled

**TEST_BACK_ENABLED**: Back button works on keyboard page

- search for a language and click on a keyboard
- on the page that shows the keyboard details, verify that the "Back" button is enabled
- click the Back button and verify that it takes you back to the search page