### PR TITLE
feat(linux): List fonts in the uninstall confirmation dialog

### DIFF
--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -506,7 +506,6 @@ def get_metadata(tmpdirname):
     If it does not exist then will return get_and_convert_infdata
 
     Args:
-        inputfile (str): path to kmp file
         tmpdirname(str): temp directory to extract kmp
 
     Returns:


### PR DESCRIPTION
Fixes #3501

Before:
![Screenshot from 2023-01-09 16-45-08](https://user-images.githubusercontent.com/181336/211349317-de81e96c-c0d8-4d82-8235-f2260e18aa2c.png)

After:
![Screenshot from 2023-01-09 16-47-48](https://user-images.githubusercontent.com/181336/211349380-e41ba769-867d-44d0-acd6-326b88e4bb82.png)

# User Testing

## Tests

**TEST_UNINSTALL_FONTS_SHOWN**: fonts are shown in uninstall confirmation dialog

- select installed "khmer angkor" keyboard
- click uninstall button
- verify that the fonts are shown in the uninstall confirmation dialog

**TEST_UNINSTALL_NO_FONTS**: uninstall works if no fonts are included in keyboard

- select installed "US Basic" keyboard
- click uninstall button
- verify that uninstall works