### PR TITLE
feat(web): implements shell scripting for CI release-build configurations 📜

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -306,7 +306,7 @@ copy_sources ( ) {
     do
       echo "- $SOURCE/$SOURCE_FOLDER/ => $CONFIG_OUT_PATH/src/$SOURCE_FOLDER/"
       mkdir -p "$CONFIG_OUT_PATH/src/$SOURCE_FOLDER"
-      cp -Rf  "$SOURCE/$SOURCE_FOLDER/"    "$CONFIG_OUT_PATH/src/$SOURCE_FOLDER"
+      cp -Rf  "$SOURCE/$SOURCE_FOLDER/"*    "$CONFIG_OUT_PATH/src/$SOURCE_FOLDER/"
     done
 
     echo

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -36,6 +36,10 @@ builder_parse "$@"
 
 ####
 
+TIER=`cat ../TIER.md`
+BUILD_NUMBER=`cat ../VERSION.md`
+S_KEYMAN_COM=../../s.keyman.com
+
 if builder_start_action build; then
   # Build step:  since CI builds start (and should start) from scratch, run the following
   # three actions:
@@ -89,10 +93,6 @@ if builder_start_action validate-size; then
 fi
 
 if builder_start_action publish-s.keyman; then
-  TIER=`cat ../TIER.md`
-  BUILD_NUMBER=`cat ../VERSION.md`
-  S_KEYMAN_COM=../../s.keyman.com
-
   # First phase: make sure the s.keyman.com repo is locally-available and up to date.
   pushd "$S_KEYMAN_COM"
   if builder_has_option --password; then
@@ -130,7 +130,86 @@ if builder_start_action publish-s.keyman; then
   builder_finish_action success publish-s.keyman
 fi
 
+# Note:  for now, this command is used to prepare the artifacts used by the download site, but
+#        NOT to actually UPLOAD them via rsync or to produce related .download_info files.
 if builder_start_action publish-downloads; then
-#
+  VERSION_BUILD_REGEX="^[0-9]+\.[0-9]+\.([0-9]+)$"
+
+  if [[ $BUILD_NUMBER =~ $VERSION_BUILD_REGEX ]]; then
+    BUILD_COUNTER="${BASH_REMATCH[1]}"
+  else
+    builder_finish_action failure publish-downloads
+    exit 0
+  fi
+
+  UPLOAD_PATH="build/upload/$BUILD_NUMBER"
+
+  # --- First action artifact - the KMW zip file ---
+  ZIP="$UPLOAD_PATH/keymanweb-$BUILD_NUMBER.zip"
+
+  # RSYNC_HOME should be pre-set environment variables.
+  # (7Z_HOME is illegal as a variable name in BASH b/c leading digit.)
+  mkdir -p "$UPLOAD_PATH"
+
+  # Nifty tidbit:  https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script
+  # If we're fine with ensuring that the program is available via path, we can just use that on
+  # Win machines.  The decision was made to continue relying on an environment variable for 7-zip, though.
+
+  COMPRESS_CMD=
+  COMPRESS_ADD=
+
+  # Marc's preference; use $SEVEN_Z_HOME and have the BAs set up with THAT as an env var.
+  if [ -n "${SEVEN_Z_HOME+x}" ] &> /dev/null; then
+    echo "7z command available"
+    COMPRESS_CMD="$SEVEN_Z_HOME/7z"
+    COMPRESS_ADD="a -bd -bb0 -r" # add, hide progress, log level 0, recursive
+    COMPRESS_RENAME="rn"
+  fi
+
+  if [[ -z "${COMPRESS_CMD}" ]] ; then
+    if command -v zip &> /dev/null; then
+      echo "zip command available"
+      # Note:  does not support within-archive renames!
+      COMPRESS_CMD=zip
+      COMPRESS_ADD="-r"
+    else
+      echo "${COLOR_RED}Fallback approach failed: zip command unavailable${COLOR_RESET}" >&2
+      builder_finish_action failure publish-downloads
+      exit 1
+    fi
+  fi
+
+  pushd build/app/web/release
+  "${COMPRESS_CMD}" $COMPRESS_ADD ../../../../$ZIP *
+  cd ..
+  "${COMPRESS_CMD}" $COMPRESS_ADD ../../../$ZIP debug
+  popd
+
+  pushd build/app/ui/release
+  "${COMPRESS_CMD}" $COMPRESS_ADD ../../../../$ZIP *
+  cd ..
+  "${COMPRESS_CMD}" $COMPRESS_ADD ../../../$ZIP debug
+  popd
+
+  # --- Second action artifact - the 'static' folder (hosted user testing on downloads.keyman.com) ---
+
+  echo ""
+  echo "Building \`static/\` folder for long-term hosting of testing resources..."
+  STATIC="$UPLOAD_PATH/static"
+  mkdir -p "$STATIC"
+
+  mkdir -p "$STATIC/build"
+  cp -rf build/app    "$STATIC/build/app"
+  cp -rf build/engine "$STATIC/build/engine"
+  cp -rf build/tools  "$STATIC/build/tools"
+  # avoid build/upload, since that's the folder we're building!
+
+  cp -f index.html "$STATIC/index.html"
+
+  mkdir -p "$STATIC/src/tools"
+  cp -rf src/tools/testing "$STATIC/src/tools/testing"
+  cp -rf src/test          "$STATIC/src/test"
+  cp -rf src/samples       "$STATIC/src/samples"
+
   builder_finish_action success publish-downloads
 fi

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -114,15 +114,18 @@ if builder_start_action publish-s.keyman; then
   cp -Rf build/app/ui/release/* "$BASE_PUBLISH_FOLDER"
 
   # Third phase: tweak the sourcemaps
-  # TODO:  actual sourcemap tweaking.
+  # We can use an alt-mode of Web's sourcemap-root tool for this.
+  for sourcemap in "$BASE_PUBLISH_FOLDER/"*.map; do
+    node build/tools/building/sourcemap-root/index.mjs null "$sourcemap" --sourceRoot "https://s.keyman.com/kmw/engine/$BUILD_NUMBER/src"
+  done
 
   # Final phase:  build the PR and push it.
   cd "$S_KEYMAN_COM"
-  # git config user.name "Keyman Build Server"
-  # git config user.email "keyman-server@users.noreply.github.com"
+  git config user.name "Keyman Build Server"
+  git config user.email "keyman-server@users.noreply.github.com"
   git add "kmw/engine/$BUILD_NUMBER"
-  # git commit -m "KeymanWeb release $BUILD_NUMBER (automatic)"
-  # git push https://keyman-server:$PASSWORD@github.com/keymanapp/s.keyman.com.git master
+  git commit -m "KeymanWeb release $BUILD_NUMBER (automatic)"
+  git push https://keyman-server:$PASSWORD@github.com/keymanapp/s.keyman.com.git master
 
   builder_finish_action success publish-s.keyman
 fi

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -121,11 +121,15 @@ if builder_start_action publish-s.keyman; then
 
   # Final phase:  build the PR and push it.
   cd "$S_KEYMAN_COM"
-  git config user.name "Keyman Build Server"
-  git config user.email "keyman-server@users.noreply.github.com"
+  if builder_has_option --password; then
+    git config user.name "Keyman Build Server"
+    git config user.email "keyman-server@users.noreply.github.com"
+  fi
   git add "kmw/engine/$BUILD_NUMBER"
-  git commit -m "KeymanWeb release $BUILD_NUMBER (automatic)"
-  git push https://keyman-server:$PASSWORD@github.com/keymanapp/s.keyman.com.git master
+  if builder_has_option --password; then
+    git commit -m "KeymanWeb release $BUILD_NUMBER (automatic)"
+    git push https://keyman-server:$PASSWORD@github.com/keymanapp/s.keyman.com.git master
+  fi
 
   builder_finish_action success publish-s.keyman
 fi

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -133,15 +133,6 @@ fi
 # Note:  for now, this command is used to prepare the artifacts used by the download site, but
 #        NOT to actually UPLOAD them via rsync or to produce related .download_info files.
 if builder_start_action publish-downloads; then
-  VERSION_BUILD_REGEX="^[0-9]+\.[0-9]+\.([0-9]+)$"
-
-  if [[ $BUILD_NUMBER =~ $VERSION_BUILD_REGEX ]]; then
-    BUILD_COUNTER="${BASH_REMATCH[1]}"
-  else
-    builder_finish_action failure publish-downloads
-    exit 0
-  fi
-
   UPLOAD_PATH="build/upload/$BUILD_NUMBER"
 
   # --- First action artifact - the KMW zip file ---


### PR DESCRIPTION
This PR seeks to partially implement two Web release steps within in-repo shell scripting - in particular, the file-shuffling / archiving commands that prepare the artifacts we publish.  This is a fit for the 📜 PR chain because of all the pieces that are moved around; those configurations actively need an update to finalize all the changes... and #7474 provides a wonderful signal-file that may be conditioned upon so that the old and new build patterns may be handled by the actual configuration.

This should be the final piece needed to complete the 📜 PR set; kinda need to keep the build chain and the release artifact uploads properly connected before merging to `master`, which was the last remaining part left unhandled 'til now.

So, the two new action-target pairs defined within `web/ci.sh`:
- `prepare:s.keyman.com`:  designed to prepare the s.keyman.com PR that publishes the new KMW version to our cloud API
- `prepare:downloads.keyman.com`:  designed to prepare the .zip archive and the `static` testing folder that get uploaded to downloads.keyman.com.
    - does not actually upload them
    - does not supply related metadata files used during the upload
    - Both of the points above, for now, will continue to be handled by the CI server's existing script.

@keymanapp-test-bot skip

Note that, for now, I have not tweaked the current CI-server scripts to utilize this PR's new shell-script actions, just in case there's an issue with the implementation and possible issues with password handling.

### Other Notes

I have tested the `zip`-based handling of files in the `publish-downloads` action by following the notes found here: https://stackoverflow.com/a/55749636.  Note that said `zip` does not support file/folder renames, unlike 7-zip, so I've avoided renaming the `debug` folder to `unminified` at this time.

Just to be clear, the 7-zip-based handling has also been tested; that's the path our build agents would initially use, given our existing configurations and the need to maintain both for a time before fully transitioning.