### PR TITLE
feat(linux): Enhance tab completion in km-package-install

### DIFF
--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -10,6 +10,8 @@ from pkg_resources import parse_version
 from zipfile import is_zipfile
 
 from keyman_config import KeymanApiUrl, __version__, secure_lookup
+from keyman_config.install_kmp import extract_kmp
+from keyman_config.kmpmetadata import get_metadata
 from keyman_config.uninstall_kmp import uninstall_kmp
 
 
@@ -82,6 +84,33 @@ def list_keyboards():
         # file empty
         if os.path.getsize(kmpdirfile) == 0:
             write_kmpdirlist(kmpdirfile)
+
+
+def _list_languages_for_keyboard_impl(packageId, packageDir):
+    from keyman_config.get_kmp import keyman_cache_dir
+    kmpfile = os.path.join(keyman_cache_dir(), packageId)
+    if not os.path.exists(kmpfile):
+        kmpfile = kmpfile + '.kmp'
+        if not os.path.exists(kmpfile):
+            return ''
+    extract_kmp(kmpfile, packageDir)
+    info, system, options, keyboards, files = get_metadata(packageDir)
+    if not keyboards:
+        return ''
+    firstKeyboard = keyboards[0]
+    if not secure_lookup(firstKeyboard, 'languages') or len(firstKeyboard['languages']) <= 0:
+        return ''
+    result = ''
+    for lang in firstKeyboard['languages']:
+        if result:
+            result += '\n'
+        result += lang['id']
+    return result
+
+
+def list_languages_for_keyboard(packageId, packageDir):
+    result = _list_languages_for_keyboard_impl(packageId, packageDir)
+    print(result)
 
 
 def main():

--- a/linux/keyman-config/km-package-install.bash-completion
+++ b/linux/keyman-config/km-package-install.bash-completion
@@ -6,7 +6,7 @@ _km-package-install_completions()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="-h --help -v --verbose -vv --veryverbose --version -p --package -f --file -s --shared"
+    opts="-h --help -v --verbose -vv --veryverbose --version -p --package -f --file -s --shared -l --bcp47"
 
     cache=${XDG_CACHE_HOME:-~/.cache}/keyman/kmpdirlist
 
@@ -16,6 +16,14 @@ _km-package-install_completions()
         return 0
     fi
 
+    if [[ -e ./km-package-install ]]; then
+        pkg_install_path='./km-package-install'
+        get_kmp_path='keyman_config/get_kmp.py'
+    else
+        pkg_install_path='/usr/bin/km-package-install'
+        get_kmp_path='/usr/lib/python3/dist-packages/keyman_config/get_kmp.py'
+    fi
+
     case "${prev}" in
         "-p"|"--package")
             words=""
@@ -23,12 +31,8 @@ _km-package-install_completions()
                 # NOTE: identical code in `km-package-get.bash-completion`.
                 # Unfortunately with bash completion scripts it's not possible to factor out
                 # common code.
-                if [[ -e ./km-package-install ]]; then
-                    pkg_install_path='./km-package-install'
-                else
-                    pkg_install_path='/usr/bin/km-package-install'
-                fi
-                python3 -c "from importlib.machinery import SourceFileLoader;from importlib.util import module_from_spec, spec_from_loader;loader = SourceFileLoader('km_package_install', $pkg_install_path);spec = spec_from_loader(loader.name, loader);mod = module_from_spec(spec);loader.exec_module(mod);mod.list_keyboards()"
+
+                python3 -c "from importlib.machinery import SourceFileLoader;from importlib.util import module_from_spec, spec_from_loader;loader = SourceFileLoader('km_package_install', '$pkg_install_path');spec = spec_from_loader(loader.name, loader);mod = module_from_spec(spec);loader.exec_module(mod);mod.list_keyboards()"
             fi
 
             if [[ -r $cache ]] ; then
@@ -43,6 +47,42 @@ _km-package-install_completions()
             compopt -o filenames
             # shellcheck disable=SC2207
             COMPREPLY=( $(compgen -f -X "!"*.kmp -- "$cur") $(compgen -d -- "$cur") )
+            return 0
+            ;;
+        "-l"|"--bcp47")
+            local packageId=""
+            local packageDir
+            packageDir=$(mktemp -d)
+            for ((i=0;i<$COMP_CWORD;i++)); do
+                case ${COMP_WORDS[$i]} in
+                    "-p"|"--package")
+                        packageId="${COMP_WORDS[$i+1]}"
+                        # shellcheck disable=SC2086 # doesn't work with quotes
+                        if [ ! -f ${XDG_CACHE_HOME:-~/.cache}/keyman/$packageId ] && [ ! -f ${XDG_CACHE_HOME:-~/.cache}/keyman/${packageId}.kmp ]; then
+                            python3 -c "from importlib.machinery import SourceFileLoader;from importlib.util import module_from_spec, spec_from_loader;loader = SourceFileLoader('get_kmp', '$get_kmp_path');spec = spec_from_loader(loader.name, loader);mod = module_from_spec(spec);loader.exec_module(mod);mod.get_kmp('$packageId')"
+                        fi
+                        break
+                    ;;
+                    "-f"|"--file")
+                        package="${COMP_WORDS[$i+1]}"
+                        packageId=$(basename "$package")
+                        # shellcheck disable=SC2086 # doesn't work with quotes
+                        cp "$package" ${XDG_CACHE_HOME:-~/.cache}/keyman/${packageId}
+                        break
+                    ;;
+                    *)
+                    ;;
+                esac
+            done
+            if [ -z "$packageId" ]; then
+                return 0
+            fi
+            words=""
+            while read -r lang; do
+                words="$words $lang"
+            done < <(python3 -c "from importlib.machinery import SourceFileLoader;from importlib.util import module_from_spec, spec_from_loader;loader = SourceFileLoader('km_package_install', '$pkg_install_path');spec = spec_from_loader(loader.name, loader);mod = module_from_spec(spec);loader.exec_module(mod);mod.list_languages_for_keyboard('$packageId', '$packageDir')")
+            # shellcheck disable=SC2207
+            COMPREPLY=($(compgen -W "${words}" -- "${cur}"))
             return 0
             ;;
         *)

--- a/linux/keyman-config/km-package-list-installed.bash-completion
+++ b/linux/keyman-config/km-package-list-installed.bash-completion
@@ -9,7 +9,7 @@ _km-package-list-installed_completions()
 
     if [[ ${cur} == -* ]] ; then
         # shellcheck disable=SC2207
-        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
         return 0
     fi
 }

--- a/linux/keyman-config/tests/test_package_install_completion.py
+++ b/linux/keyman-config/tests/test_package_install_completion.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, ANY
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+
+
+class PackageInstallCompletionTests(unittest.TestCase):
+
+    def setUp(self):
+        patcher1 = patch('keyman_config.install_kmp.extract_kmp')
+        self.mockExtractKmp = patcher1.start()
+        self.addCleanup(patcher1.stop)
+        patcher2 = patch('keyman_config.kmpmetadata.get_metadata')
+        self.mockGetMetadata = patcher2.start()
+        self.addCleanup(patcher2.stop)
+
+        loader = SourceFileLoader('km_package_install', os.path.join(os.path.dirname(
+          os.path.abspath(__file__)), '../km-package-install'))
+        spec = spec_from_loader(loader.name, loader)
+        if spec:
+            self.mod = module_from_spec(spec)
+            loader.exec_module(self.mod)
+
+        self.tempDir = tempfile.TemporaryDirectory()
+        os.environ["XDG_CACHE_HOME"] = self.tempDir.name
+        self.cacheDir = os.path.join(self.tempDir.name, 'keyman')
+        os.makedirs(self.cacheDir)
+
+    def _list_languages_for_keyboard_impl(self, packageId):
+        return self.mod._list_languages_for_keyboard_impl(packageId, 'someDir')
+
+    def test_PackageCompletionNoLanguage(self):
+        open(os.path.join(self.cacheDir, 'foo'), 'w')
+        self.mockGetMetadata.return_value = (None, None, None, [{}], None)
+        result = self._list_languages_for_keyboard_impl('foo')
+        self.assertEqual(result, "")
+
+    def test_PackageCompletionOneLanguage(self):
+        open(os.path.join(self.cacheDir, 'khmer_angkor'), 'w')
+        self.mockGetMetadata.return_value = (
+          None, None, None,
+          [{'languages': [{'name': 'Central Khmer (Khmer, Cambodia)', 'id': 'km'}]}],
+          None)
+        result = self._list_languages_for_keyboard_impl('khmer_angkor')
+        self.assertEqual(result, "km")
+
+    def test_PackageCompletionMultipleLanguages(self):
+        open(os.path.join(self.cacheDir, 'sil_euro_latin'), 'w')
+        self.mockGetMetadata.return_value = (
+          None, None, None,
+          [{'languages': [
+            {'name': 'English', 'id': 'en'},
+            {'name': 'French', 'id': 'fr'},
+            {'name': 'German', 'id': 'de'}]}],
+          None)
+        result = self._list_languages_for_keyboard_impl('sil_euro_latin')
+        self.assertEqual(result, 'en\nfr\nde')


### PR DESCRIPTION
This change adds tab completion for the bcp-47 parameter in km-package-install.

Fixes #5361

# User Testing

## Tests

**TEST_NO_COMP**: shows no completions without specifying package or keyboard first

- open terminal window
- type `km-package-install -l ` (ending with a space)
- press tab-key. If nothing happens after a few seconds, press the tab-key again.
- verify that no completions are shown

**TEST_PKG_NOT_EXISTING**: shows completions if file doesn't exist previously

- delete `~/.cache/keyman/khmer_angkor` and `khmer_angkor.kmp` if they exist
- open terminal window
- type `km-package-install -p khmer_angkor -l ` (ending with a space)
- press tab-key. If nothing happens after a few seconds, press the tab-key again.
- verify that `km` is shown

**TEST_PKG_EXISTING**: shows completions if file does exist previously

- continuing from previous test
- press ctrl+c
- type `km-package-install -p khmer_angkor --bcp47 ` (ending with a space)
- press tab-key. If nothing happens after a few seconds, press the tab-key again.
- verify that `km` is shown

**TEST_FILE**: shows completions if kmp-file specified

- open terminal window
- run `km-package-get sil_euro_latin`
- run `mv ~/.cache/keyman/sil_euro_latin.kmp /tmp`
- type `km-package-install -f /tmp/sil_euro_latin.kmp -l ` (ending with a space)
- press tab-key. If nothing happens after a few seconds, press the tab-key again.
- verify that several completions are shown