### PR TITLE
feat(linux): Display error messages in the UI

### DIFF
--- a/linux/keyman-config/keyman_config/downloadkeyboard.py
+++ b/linux/keyman-config/keyman_config/downloadkeyboard.py
@@ -52,6 +52,12 @@ class DownloadKmpWindow(Gtk.Dialog):
             self.response(Gtk.ResponseType.OK)
             self.close()
             return True
+        logging.error(_("Downloading kmp file failed"))
+        dialog = Gtk.MessageDialog(
+                  self, 0, Gtk.MessageType.ERROR,
+                  Gtk.ButtonsType.OK, _("Downloading keyboard file failed"))
+        dialog.run()
+        dialog.destroy()
         return False
 
     def _keyman_policy(self, web_view, decision, decision_type):

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -37,31 +37,32 @@ def uninstall_kmp_shared(packageID):
     """
     kbdir = get_keyboard_dir(InstallLocation.Shared, packageID)
     if not os.path.isdir(kbdir):
-        logging.error("Keyboard directory for %s does not exist. Aborting", packageID)
-        exit(3)
+        msg = _("Keyboard directory for %s does not exist." % packageID)
+        logging.error(msg)
+        return msg
 
     kbdocdir = get_keyman_doc_dir(InstallLocation.Shared, packageID)
     kbfontdir = get_keyman_font_dir(InstallLocation.Shared, packageID)
 
     logging.info("Uninstalling shared keyboard: %s", packageID)
     if not os.access(kbdir, os.X_OK | os.W_OK):  # Check for write access of keyman dir
-        logging.error(
-          "You do not have permissions to uninstall the keyboard files. You need to run this with `sudo`")
-        exit(3)
+        msg = _("You do not have permissions to uninstall the keyboard files. You need to run this with `sudo`")
+        logging.error(msg)
+        return msg
     if os.path.isdir(kbdocdir):
         if not os.access(kbdocdir, os.X_OK | os.W_OK):  # Check for write access of keyman doc dir
-            logging.error(
-              "You do not have permissions to uninstall the documentation. You need to run this with `sudo`")
-            exit(3)
+            msg = _("You do not have permissions to uninstall the documentation. You need to run this with `sudo`")
+            logging.error(msg)
+            return msg
         delete_dir(kbdocdir)
         logging.info("Removed documentation directory: %s", kbdocdir)
     else:
         logging.info("No documentation directory")
     if os.path.isdir(kbfontdir):
         if not os.access(kbfontdir, os.X_OK | os.W_OK):  # Check for write access of keyman fonts
-            logging.error(
-              "You do not have permissions to uninstall the font files. You need to run this with `sudo`")
-            exit(3)
+            msg = _("You do not have permissions to uninstall the font files. You need to run this with `sudo`")
+            logging.error(msg)
+            return msg
         delete_dir(kbfontdir)
         logging.info("Removed font directory: %s", kbfontdir)
     else:
@@ -80,6 +81,7 @@ def uninstall_kmp_shared(packageID):
     delete_dir(kbdir)
     logging.info("Removed keyman directory: %s", kbdir)
     logging.info("Finished uninstalling shared keyboard: %s", packageID)
+    return ''
 
 
 def uninstall_keyboards_from_ibus(keyboards, packageDir):
@@ -130,8 +132,9 @@ def uninstall_kmp_user(packageID):
     """
     kbdir = get_keyboard_dir(InstallLocation.User, packageID)
     if not os.path.isdir(kbdir):
-        logging.error("Keyboard directory for %s does not exist. Aborting", packageID)
-        exit(3)
+        msg = _("Keyboard directory for %s does not exist." % packageID)
+        logging.error(msg)
+        return msg
     logging.info("Uninstalling local keyboard: %s", packageID)
     info, system, options, keyboards, files = get_metadata(kbdir)
     if keyboards:
@@ -150,6 +153,7 @@ def uninstall_kmp_user(packageID):
         delete_dir(fontdir)
         logging.info("Removed user keyman font directory: %s", fontdir)
     logging.info("Finished uninstalling local keyboard: %s", packageID)
+    return ''
 
 
 def uninstall_kmp(packageID, sharedarea=False):
@@ -161,8 +165,9 @@ def uninstall_kmp(packageID, sharedarea=False):
         sharedarea (str): whether to uninstall from shared /usr/local or ~/.local
     """
     if sharedarea:
-        uninstall_kmp_shared(packageID)
+        msg = uninstall_kmp_shared(packageID)
     else:
-        uninstall_kmp_user(packageID)
+        msg = uninstall_kmp_user(packageID)
 
     get_keyman_config_service().keyboard_list_changed()
+    return msg

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -362,7 +362,12 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             if response == Gtk.ResponseType.YES:
                 logging.info("Uninstalling keyboard" + model[treeiter][1])
                 # can only uninstall with the gui from user area
-                uninstall_kmp(model[treeiter][3])
+                msg = uninstall_kmp(model[treeiter][3])
+                if not msg == '':
+                    md = Gtk.MessageDialog(self, 0, Gtk.MessageType.ERROR,
+                            Gtk.ButtonsType.OK, _("Uninstalling keyboard failed.\n\nError message: ") + msg)
+                    md.run()
+                    md.destroy()
                 logging.info("need to restart window after uninstalling a keyboard")
                 self.restart()
             elif response == Gtk.ResponseType.NO:


### PR DESCRIPTION
Adds message dialogs in the UI for errors when downloading a keyboard and uninstalling a keyboard

Fixes #6288
# User Testing
## Preparations
- start km-config
## Tests

**TEST_DOWNLOAD_ERROR**: shows message dialog when download fails

- click "Downloads" button
- search for a language and click on a keyboard
- turn off the internet connection
- click "Install keyboard" button
- verify a message dialog is shown

**TEST_UNINSTALL_ERROR**: shows message dialog when uninstalling fails

- select installed "khmer angkor" keyboard
- click uninstall button
- delete the folder `~/.local/share/keyman/khmer_angkor`
- click "Yes" on the verification dialog
- verify a message dialog is shown
