### PR TITLE
bug(linux): Empty keyboard after failed installation

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -106,13 +106,13 @@ class InstallKmp():
         self.kmpdocdir = get_keyman_doc_dir(area, self.packageID)
         self.kmpfontdir = get_keyman_font_dir(area, self.packageID)
 
-        if not self._safeMakeDirs(self.packageDir):
-            return
-
         if not os.path.isfile(inputfile):
             message = _("File {kmpfile} doesn't exist").format(kmpfile=inputfile)
             logging.error("install_kmp.py: %s", message)
             raise InstallError(InstallStatus.Abort, message)
+
+        if not self._safeMakeDirs(self.packageDir):
+            return
 
         extract_kmp(inputfile, self.packageDir)
 


### PR DESCRIPTION
Fixes #8004

# User Testing
## Preparations
- start km-config
- don't have "khmer_angkor" keyboard installed
## Tests

**TEST_FAILED_INSTALLATION**: verify there is no bugged 'empty' keyboard after failed installation

- click "Downloads" button
- search for "khmer" and click on the "khmer_angkor" keyboard
- click "Install keyboard" button
- delete ~/.cache/keyman/khmer_angkor
- click "Install" button
- click "OK" on the message dialog
- verify that "Keyman Configuration" is shown and there is no bugged 'empty' keyboard in the list