### PR TITLE
feat(linux): Improve uninstallation

### DIFF
--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -131,7 +131,6 @@ def uninstall_kmp_user(packageID):
     Args:
         packageID (str): Keyboard package ID
     """
-    msg = ''
     kbdir = get_keyboard_dir(InstallLocation.User, packageID)
     logging.info("Uninstalling local keyboard: %s", packageID)
     info, system, options, keyboards, files = get_metadata(kbdir)
@@ -145,8 +144,7 @@ def uninstall_kmp_user(packageID):
     else:
         logging.warning("could not uninstall keyboards")
     if not os.path.isdir(kbdir):
-        msg = _("Keyboard directory for %s does not exist." % packageID)
-        logging.error(msg)
+        logging.error("Keyboard directory for %s does not exist." % packageID)
     else:
         delete_dir(kbdir)
         logging.info("Removed user keyman directory: %s", kbdir)
@@ -155,7 +153,7 @@ def uninstall_kmp_user(packageID):
         delete_dir(fontdir)
         logging.info("Removed user keyman font directory: %s", fontdir)
     logging.info("Finished uninstalling local keyboard: %s", packageID)
-    return msg
+    return ''
 
 
 def uninstall_kmp(packageID, sharedarea=False):

--- a/linux/keyman-config/tests/test_uninstall_kmp.py
+++ b/linux/keyman-config/tests/test_uninstall_kmp.py
@@ -2,7 +2,7 @@
 import unittest
 from unittest.mock import patch
 
-from keyman_config.uninstall_kmp import uninstall_keyboards_from_gnome
+from keyman_config.uninstall_kmp import _uninstall_keyboards_from_gnome
 
 
 class UninstallKmpTests(unittest.TestCase):
@@ -17,7 +17,7 @@ class UninstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = []
         # Execute
-        uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
+        _uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with([])
 
@@ -27,7 +27,7 @@ class UninstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
           ('ibus', 'fooDir/foo2.kmx')]
         # Execute
-        uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
+        _uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with([
           ('ibus', 'fooDir/foo2.kmx')])
@@ -38,7 +38,7 @@ class UninstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
           ('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx')]
         # Execute
-        uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
+        _uninstall_keyboards_from_gnome([{'id': 'foo1'}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
           [('xkb', 'en')])
@@ -49,7 +49,7 @@ class UninstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
           ('xkb', 'en'), ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
         # Execute
-        uninstall_keyboards_from_gnome([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
+        _uninstall_keyboards_from_gnome([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
           [('xkb', 'en')])
@@ -60,7 +60,7 @@ class UninstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
           ('ibus', 'fooDir/foo1.kmx'), ('ibus', 'fooDir/foo2.kmx')]
         # Execute
-        uninstall_keyboards_from_gnome([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
+        _uninstall_keyboards_from_gnome([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with([])
 
@@ -70,7 +70,7 @@ class UninstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
           ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')]
         # Execute
-        uninstall_keyboards_from_gnome([{'id': 'foo1', 'languages': [{'id': 'en'}]}], 'fooDir')
+        _uninstall_keyboards_from_gnome([{'id': 'foo1', 'languages': [{'id': 'en'}]}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
           [('xkb', 'en')])
@@ -81,7 +81,7 @@ class UninstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
           ('xkb', 'en'), ('ibus', 'fr:fooDir/foo1.kmx')]
         # Execute
-        uninstall_keyboards_from_gnome(
+        _uninstall_keyboards_from_gnome(
           [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
@@ -93,7 +93,7 @@ class UninstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
           ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx')]
         # Execute
-        uninstall_keyboards_from_gnome(
+        _uninstall_keyboards_from_gnome(
           [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
@@ -105,7 +105,7 @@ class UninstallKmpTests(unittest.TestCase):
         mockGnomeKeyboardsUtilInstance.read_input_sources.return_value = [
           ('xkb', 'en'), ('ibus', 'en:fooDir/foo1.kmx'), ('ibus', 'fr:fooDir/foo1.kmx')]
         # Execute
-        uninstall_keyboards_from_gnome(
+        _uninstall_keyboards_from_gnome(
           [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(


### PR DESCRIPTION
Even if the directory doesn't exist, we can still remove the keyboard from the keyboard list.

# User Testing

## Preparations
- start km-config
- install "Khmer Angkor" keyboard
- verify that it shows up in the language/keyboard dropdown in the taskbar

## Tests

**TEST_UNINSTALL**: Uninstallation with unavailable keyboard directory still removes keyboard from language dropdown

- start km-config
- in a terminal window, run the command `rm -rf ~/.local/share/keyman/khmer_angkor` (don't close km-config!)
- in km-config, select installed "khmer angkor" keyboard
- click uninstall button
- click "Yes" on the verification dialog
- verify a message dialog is shown that the keyboard directory doesn't exist
- verify that the Khmer Angkor keyboard no longer shows up in the language/keyboard dropdown in the taskbar
