### PR TITLE
fix(linux): Fix crash (un-)installing shared keyboard 🍒

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -86,6 +86,7 @@ Depends:
  python3-bs4,
  python3-gi,
  python3-sentry-sdk (>= 1.1) | python3-raven,
+ dbus-x11,
  ${misc:Depends},
  ${python3:Depends},
 Description: Keyman for Linux configuration


### PR DESCRIPTION
The reason for the crash is the missing file `dbus-launch` which gets called when running with `sudo`. This change adds a dependency to `dbus-x11` which provides `dbus-launch`.

Fixes #8012.

(🍒-picked from #8019)

@keymanapp-test-bot skip