### PR TITLE
fix(linux): Properly set context after changing IP 🍒

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -123,11 +123,11 @@ static void ibus_keyman_engine_focus_out  (IBusEngine             *engine);
 static void ibus_keyman_engine_reset      (IBusEngine             *engine);
 static void ibus_keyman_engine_enable     (IBusEngine             *engine);
 static void ibus_keyman_engine_disable    (IBusEngine             *engine);
-// static void ibus_keyman_engine_set_surrounding_text
-//                                           (IBusEngine             *engine,
-//                                            IBusText               *text,
-//                                            guint                   cursor_pos,
-//                                            guint                   anchor_pos);
+static void ibus_keyman_engine_set_surrounding_text
+                                          (IBusEngine             *engine,
+                                           IBusText               *text,
+                                           guint                   cursor_pos,
+                                           guint                   anchor_pos);
 // static void ibus_keyman_engine_set_cursor_location
 //                                           (IBusEngine             *engine,
 //                                            guint                   x,
@@ -201,7 +201,7 @@ ibus_keyman_engine_class_init (IBusKeymanEngineClass *klass)
     engine_class->enable = ibus_keyman_engine_enable;
     engine_class->disable = ibus_keyman_engine_disable;
 
-    // engine_class->set_surrounding_text = ibus_keyman_engine_set_surrounding_text;
+    engine_class->set_surrounding_text = ibus_keyman_engine_set_surrounding_text;
     // engine_class->set_cursor_location = ibus_keyman_engine_set_cursor_location;
 
 
@@ -978,23 +978,23 @@ ibus_keyman_engine_process_key_event(
   return TRUE;
 }
 
-// static void
-// ibus_keyman_engine_set_surrounding_text (IBusEngine *engine,
-//                                             IBusText    *text,
-//                                             guint       cursor_pos,
-//                                             guint       anchor_pos)
-// {
-//     gchar *surrounding_text;
-//     guint context_start = cursor_pos > MAXCONTEXT_ITEMS ? cursor_pos - MAXCONTEXT_ITEMS : 0;
-//     if (cursor_pos != anchor_pos){
-//         g_message("%s: There is a selection", __FUNCTION__);
-//     }
-//     parent_class->set_surrounding_text (engine, text, cursor_pos, anchor_pos);
-//     surrounding_text = g_utf8_substring(ibus_text_get_text(text), context_start, cursor_pos);
-//     g_message("%s: surrounding context is:%u:%s:", __FUNCTION__, cursor_pos - context_start, surrounding_text);
-//     g_free(surrounding_text);
-//     reset_context(engine);
-// }
+static void
+ibus_keyman_engine_set_surrounding_text (IBusEngine *engine,
+                                            IBusText    *text,
+                                            guint       cursor_pos,
+                                            guint       anchor_pos)
+{
+    // gchar *surrounding_text;
+    // guint context_start = cursor_pos > MAXCONTEXT_ITEMS ? cursor_pos - MAXCONTEXT_ITEMS : 0;
+    // if (cursor_pos != anchor_pos){
+    //     g_message("%s: There is a selection", __FUNCTION__);
+    // }
+    parent_class->set_surrounding_text (engine, text, cursor_pos, anchor_pos);
+    // surrounding_text = g_utf8_substring(ibus_text_get_text(text), context_start, cursor_pos);
+    // g_message("%s: surrounding context is:%u:%s:", __FUNCTION__, cursor_pos - context_start, surrounding_text);
+    // g_free(surrounding_text);
+    reset_context(engine);
+}
 
 // static void ibus_keyman_engine_set_cursor_location (IBusEngine             *engine,
 //                                              guint                    x,


### PR DESCRIPTION
This change fixes a bug where we the context was wrong after putting the IP in a new location by mouse-click.

Fixes #8024.

(🍒-picked from PR #8025)

@keymanapp-test-bot skip