### PR TITLE
chore(linux): log failures to `km_kbp_context_clear(context)`

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -277,12 +277,16 @@ reset_context(IBusEngine *engine) {
       if (km_kbp_context_items_from_utf8(surrounding_text, &context_items) == KM_KBP_STATUS_OK) {
         km_kbp_context_set(context, context_items);
         km_kbp_context_items_dispose(context_items);
+      } else {
+        km_kbp_context_clear(context);
+        g_message("%s: setting context failed", __FUNCTION__);
       }
     }
     g_free(surrounding_text);
     g_free(current_context_utf8);
   } else {
     km_kbp_context_clear(context);
+    g_message("%s: client does not support surrounding text", __FUNCTION__);
   }
 }
 

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -274,12 +274,13 @@ reset_context(IBusEngine *engine) {
     current_context_utf8 = get_current_context_text(context);
     if (!g_str_has_suffix(surrounding_text, current_context_utf8) || !g_utf8_strlen(current_context_utf8, -1)) {
       g_message("%s: setting context because it has changed from expected", __FUNCTION__);
-      if (km_kbp_context_items_from_utf8(surrounding_text, &context_items) == KM_KBP_STATUS_OK) {
+      enum km_kbp_status_codes status = km_kbp_context_items_from_utf8(surrounding_text, &context_items);
+      if (status == KM_KBP_STATUS_OK) {
         km_kbp_context_set(context, context_items);
         km_kbp_context_items_dispose(context_items);
       } else {
         km_kbp_context_clear(context);
-        g_message("%s: setting context failed", __FUNCTION__);
+        g_message("%s: setting context failed with status code %d", __FUNCTION__, status);
       }
     }
     g_free(surrounding_text);


### PR DESCRIPTION
This change adds behavior when setting the context fails. It then clears the context and logs the failure. 

Fixes #7540

@keymanapp-test-bot skip