### PR TITLE
chore(linux): Update recommended extension

### DIFF
--- a/docs/settings/linux/extensions.json
+++ b/docs/settings/linux/extensions.json
@@ -2,7 +2,7 @@
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
-    "asabil.meson",
+    "mesonbuild.mesonbuild",
     "editorconfig.editorconfig",
     "ms-python.python",
     "mads-hartmann.bash-ide-vscode",


### PR DESCRIPTION
The previously recommended extension is no longer available.

@keymanapp-test-bot skip