### PR TITLE
feat(linux): Add DBus method `SendText`

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -574,6 +574,14 @@ ibus_keyman_engine_destroy (IBusKeymanEngine *keyman)
     IBUS_OBJECT_CLASS (parent_class)->destroy ((IBusObject *)keyman);
 }
 
+void ibus_keyman_set_text(IBusEngine *engine, const gchar *text)
+{
+    IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
+    if (!keyman)
+        return;
+    commit_string(keyman, text);
+}
+
 static void commit_string(IBusKeymanEngine *keyman, const gchar *string)
 {
     IBusText *text;
@@ -1076,7 +1084,7 @@ ibus_keyman_engine_enable (IBusEngine *engine)
     {
         // own dbus name com.Keyman
         // expose properties LDMLFile and Name
-        KeymanService *service = km_service_get_default();
+        KeymanService *service = km_service_get_default(engine);
         km_service_set_ldmlfile (service, keyman->ldmlfile);
         km_service_set_name (service, keyman->kb_name);
     }
@@ -1093,7 +1101,7 @@ ibus_keyman_engine_disable (IBusEngine *engine)
     g_message("WDG: %s %s", __FUNCTION__, engine_name);
     ibus_keyman_engine_focus_out (engine);
     // stop owning dbus name com.Keyman
-    KeymanService *service = km_service_get_default();
+    KeymanService *service = km_service_get_default(engine);
     km_service_set_ldmlfile (service, "");
     km_service_set_name (service, "None");
     // g_clear_object(&service);

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -577,8 +577,10 @@ ibus_keyman_engine_destroy (IBusKeymanEngine *keyman)
 void ibus_keyman_set_text(IBusEngine *engine, const gchar *text)
 {
     IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
-    if (!keyman)
+    if (!keyman) {
+        g_error("%s: parameter `engine` is not an `IBusKeymanEngine` (%p)", __FUNCTION__, engine);
         return;
+    }
     commit_string(keyman, text);
 }
 

--- a/linux/ibus-keyman/src/engine.h
+++ b/linux/ibus-keyman/src/engine.h
@@ -31,4 +31,6 @@
 
 GType   ibus_keyman_engine_get_type    (void);
 
+extern void ibus_keyman_set_text(IBusEngine* engine, const gchar* text);
+
 #endif

--- a/linux/ibus-keyman/src/keyman-service.c
+++ b/linux/ibus-keyman/src/keyman-service.c
@@ -28,22 +28,23 @@
 
 #include <gio/gio.h>
 
+#include "engine.h"
 #include "keyman-service.h"
 
 struct _KeymanServicePrivate
 {
     guint          owner_id;
     GDBusNodeInfo *ispec;
+    IBusEngine    *engine;
 
     gchar *          name;
     gchar *          ldmlfile;
 };
 
-enum
-{
-    PROP_0,
-    PROP_NAME,
-    PROP_LDMLFILE
+enum {
+  PROP_0,
+  PROP_NAME,
+  PROP_LDMLFILE
 };
 
 static const gchar introspection_xml[] =
@@ -51,6 +52,9 @@ static const gchar introspection_xml[] =
     "  <interface name='com.Keyman'>"
     "    <property type='s' name='LDMLFile' access='read'/>"
     "    <property type='s' name='Name' access='read'/>"
+    "    <method name='SendText'>"
+    "        <arg type='s' name='text' direction='in' />"
+    "    </method>"
     "  </interface>"
     "</node>";
 
@@ -194,6 +198,32 @@ km_service_class_init (KeymanServiceClass *klass)
                                                           G_PARAM_STATIC_STRINGS));
 }
 
+static void
+handle_method_call(
+    GDBusConnection *connection,
+    const gchar *sender,
+    const gchar *object_path,
+    const gchar *interface_name,
+    const gchar *method_name,
+    GVariant *parameters,
+    GDBusMethodInvocation *invocation,
+    gpointer user_data)
+{
+    KeymanService *service = KM_SERVICE(user_data);
+
+    gsize sz;
+    if (g_strcmp0(method_name, "SendText") == 0) {
+        GVariant *param = g_variant_get_child_value(parameters, 0);
+        gchar *text     = g_variant_dup_string(param, &sz);
+
+        km_service_send_text(service, text);
+        g_dbus_method_invocation_return_value(invocation, NULL);
+
+        g_free(text);
+        g_variant_unref(param);
+    }
+}
+
 static GVariant *
 handle_get_property (GDBusConnection *connection,
                      const gchar     *sender,
@@ -240,9 +270,9 @@ handle_set_property (GDBusConnection *connection,
 
 static const GDBusInterfaceVTable interface_vtable =
 {
-    (GDBusInterfaceMethodCallFunc) NULL,
-    (GDBusInterfaceGetPropertyFunc) handle_get_property,
-    (GDBusInterfaceSetPropertyFunc) handle_set_property
+    (GDBusInterfaceMethodCallFunc)handle_method_call,
+    (GDBusInterfaceGetPropertyFunc)handle_get_property,
+    (GDBusInterfaceSetPropertyFunc)handle_set_property
 };
 
 static void
@@ -290,9 +320,7 @@ km_service_bus_acquired (GDBusConnection *connection,
                          gpointer         data)
 {
     KeymanService *service = data;
-
-    if (service->priv->ispec)
-    {
+    if (service->priv->ispec) {
         GError *error = NULL;
 
         g_dbus_connection_register_object (connection,
@@ -312,7 +340,7 @@ km_service_bus_acquired (GDBusConnection *connection,
 }
 
 KeymanService *
-km_service_get_default (void)
+km_service_get_default(IBusEngine *engine)
 {
     static KeymanService *service = NULL;
 
@@ -324,9 +352,13 @@ km_service_get_default (void)
     // }
     if (!service)
     {
-        service = g_object_new (KM_TYPE_SERVICE, NULL);
+        service = g_object_new(KM_TYPE_SERVICE, NULL);
         g_object_add_weak_pointer (G_OBJECT (service), (gpointer *) &service);
     }
+
+    KeymanServicePrivate *priv = KM_SERVICE(service)->priv;
+    priv->engine = engine;
+
     return service;
 }
 
@@ -373,3 +405,14 @@ km_service_set_ldmlfile (KeymanService       *service,
 
 //     return service->priv->ldmlfile;
 // }
+
+void
+km_service_send_text(KeymanService *service, const gchar *text) {
+    g_return_if_fail(KM_IS_SERVICE(service));
+
+    // engine will be NULL unless a keyman keyboard is active
+    if (!service->priv->engine)
+        return;
+
+    ibus_keyman_set_text(service->priv->engine, text);
+}

--- a/linux/ibus-keyman/src/keyman-service.h
+++ b/linux/ibus-keyman/src/keyman-service.h
@@ -30,6 +30,7 @@
 #define __KM_SERVICE_H__
 
 #include <glib-object.h>
+#include <ibus.h>
 
 G_BEGIN_DECLS
 
@@ -53,16 +54,18 @@ struct _KeymanService
 
 GType             km_service_get_type          (void) G_GNUC_CONST;
 
-KeymanService *       km_service_get_default       (void);
+KeymanService *       km_service_get_default       (IBusEngine *keyman);
 
-// const gchar *  km_service_get_ldmlfile    (KeymanService       *service);
-void              km_service_set_ldmlfile    (KeymanService       *service,
-                                                const gchar *xml);
+// const gchar *  km_service_get_ldmlfile(KeymanService *service);
+void              km_service_set_ldmlfile(KeymanService *service,
+                                          const gchar   *xml);
 
-// const gchar *  km_service_get_name    (KeymanService       *service);
-void              km_service_set_name    (KeymanService       *service,
-                                                const gchar *name);
+// const gchar *  km_service_get_name    (KeymanService *service);
+void              km_service_set_name    (KeymanService *service,
+                                          const gchar   *name);
 
+void              km_service_send_text   (KeymanService *service,
+                                          const gchar   *text);
 
 G_END_DECLS
 

--- a/linux/ibus-keyman/src/main.c
+++ b/linux/ibus-keyman/src/main.c
@@ -51,7 +51,7 @@ ibus_disconnected_cb (IBusBus  *bus,
                       gpointer  user_data)
 {
     g_debug ("bus disconnected");
-    KeymanService *service = km_service_get_default();
+    KeymanService *service = km_service_get_default(NULL);
     g_clear_object(&service);
 
     ibus_quit ();
@@ -92,7 +92,7 @@ start_component (void)
     }
 
     g_object_unref (component);
-    km_service_get_default(); // initialise dbus service
+    km_service_get_default(NULL); // initialise dbus service
 
     ibus_main ();
 }


### PR DESCRIPTION
This new DBus method allows an OSK to output a junk of text.

See [keyman-osk-poc-x11](https://github.com/ermshiperete/keyman-osk-poc-x11) for a simple POC client.

@keymanapp-test-bot skip