### PR TITLE
fix(linux): JSON File missing after installation

### DIFF
--- a/linux/keyman-config/keyman_config/get_kmp.py
+++ b/linux/keyman-config/keyman_config/get_kmp.py
@@ -74,7 +74,10 @@ def get_keyboard_data(keyboardID, weekCache=False):
     os.chdir(cache_dir)
     requests_cache.install_cache(cache_name='keyman_cache', backend='sqlite', expire_after=expire_after)
     now = time.ctime(int(time.time()))
-    response = requests.get(api_url)
+    try:
+        response = requests.get(api_url)
+    except requests.exceptions.RequestException as e:  # This is the correct syntax
+        return None
     logging.debug('Time: {0} / Used Cache: {1}'.format(now, response.from_cache))
     os.chdir(current_dir)
     requests_cache.uninstall_cache()

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -74,13 +74,12 @@ class InstallKmp():
         packageID, ext = os.path.splitext(os.path.basename(inputfile))
         return packageID.lower()
 
-    def install_kmp_shared(self, inputfile, online=False, language=None):
+    def install_kmp_shared(self, inputfile, language=None):
         """
         Install a kmp file to /usr/local/share/keyman
 
         Args:
             inputfile (str): path to kmp file
-            online (bool, default=False): whether to attempt to get online keyboard data
         """
         self._check_keyman_dir(
           '/usr/local/share',
@@ -95,12 +94,12 @@ class InstallKmp():
           _("You do not have permissions to install the font files to the shared font area "
             "/usr/local/share/fonts"))
 
-        return self._install_kmp(inputfile, online, language, InstallLocation.Shared)
+        return self._install_kmp(inputfile, language, InstallLocation.Shared)
 
-    def install_kmp_user(self, inputfile, online=False, language=None):
-        return self._install_kmp(inputfile, online, language, InstallLocation.User)
+    def install_kmp_user(self, inputfile, language=None):
+        return self._install_kmp(inputfile, language, InstallLocation.User)
 
-    def _install_kmp(self, inputfile, online, language, area):
+    def _install_kmp(self, inputfile, language, area):
         self.packageID = self._extract_package_id(inputfile)
         self.packageDir = get_keyboard_dir(area, self.packageID)
         self.kmpdocdir = get_keyman_doc_dir(area, self.packageID)
@@ -136,11 +135,10 @@ class InstallKmp():
                 raise InstallError(InstallStatus.Abort, message)
         if keyboards:
             logging.info("Installing %s", secure_lookup(info, 'name', 'description'))
-            if online:
-                process_keyboard_data(self.packageID, self.packageDir)
-                for kb in keyboards:
-                    if kb['id'] != self.packageID:
-                        process_keyboard_data(kb['id'], self.packageDir)
+            process_keyboard_data(self.packageID, self.packageDir)
+            for kb in keyboards:
+                if kb['id'] != self.packageID:
+                    process_keyboard_data(kb['id'], self.packageDir)
 
             if files is None:
                 return self.install_keyboards(keyboards, self.packageDir, language)
@@ -309,21 +307,20 @@ def process_keyboard_data(keyboardID, packageDir) -> None:
     # 	raise InstallError(InstallStatus.Abort, message)
 
 
-def install_kmp(inputfile, online=False, sharedarea=False, language=None):
+def install_kmp(inputfile, sharedarea=False, language=None):
     """
     Install a kmp file
 
     Args:
         inputfile (str): path to kmp file
-        online(bool, default=False): whether to attempt to get online keyboard data
         sharedarea(bool, default=False): whether install kmp to shared area or user directory
         language(str, default=None): language to install keyboard for
         has_ui(bool, default=True): whether we're displaying a window or running UI less from the command line
     """
     if sharedarea:
-        return_value = InstallKmp().install_kmp_shared(inputfile, online, language)
+        return_value = InstallKmp().install_kmp_shared(inputfile, language)
     else:
-        return_value = InstallKmp().install_kmp_user(inputfile, online, language)
+        return_value = InstallKmp().install_kmp_user(inputfile, language)
 
     get_keyman_config_service().keyboard_list_changed()
     return return_value

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -47,10 +47,9 @@ def find_keyman_image(image_file):
 
 class InstallKmpWindow(Gtk.Dialog):
 
-    def __init__(self, kmpfile, online=False, viewkmp=None, language=None):
+    def __init__(self, kmpfile, viewkmp=None, language=None):
         logging.debug("InstallKmpWindow: kmpfile: %s", kmpfile)
         self.kmpfile = kmpfile
-        self.online = online
         self.viewwindow = viewkmp
         self.accelerators = None
         self.language = language
@@ -327,7 +326,7 @@ class InstallKmpWindow(Gtk.Dialog):
     def on_install_clicked(self, button):
         logging.info("Installing keyboard")
         try:
-            result = install_kmp(self.kmpfile, self.online, language=self.language)
+            result = install_kmp(self.kmpfile, language=self.language)
             if result:
                 # If install_kmp returns a string, it is an instruction for the end user,
                 # because for fcitx they will need to take extra steps to complete

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -151,9 +151,9 @@ def main():
     if os.path.exists(os.path.join(keyman_cache_dir(), 'kmpdirlist')):
         os.remove(os.path.join(keyman_cache_dir(), 'kmpdirlist'))
 
-    def try_install_kmp(inputfile, arg, language=None, online=False, sharedarea=False):
+    def try_install_kmp(inputfile, arg, language=None, sharedarea=False):
         try:
-            install_kmp(inputfile, online, sharedarea, language)
+            install_kmp(inputfile, sharedarea, language)
         except InstallError as e:
             if e.status == InstallStatus.Abort:
                 logging.error("km-package-install: error: Failed to install %s", arg)
@@ -173,7 +173,7 @@ def main():
             logging.error("km-package-install: Keyman kmp file %s not found.", args.file)
             logging.error("km-package-install -f <kmpfile>")
             sys.exit(2)
-        try_install_kmp(args.file, "file " + args.file, args.bcp47, False, args.shared)
+        try_install_kmp(args.file, "file " + args.file, args.bcp47, args.shared)
     elif args.package:
         if args.shared:
             if get_kmp_version_user(args.package):
@@ -205,7 +205,7 @@ def main():
 
         kmpfile = get_kmp(args.package)
         if kmpfile:
-            try_install_kmp(kmpfile, "keyboard package " + args.package, args.bcp47, True, args.shared)
+            try_install_kmp(kmpfile, "keyboard package " + args.package, args.bcp47, args.shared)
         else:
             logging.error("km-package-install: error: Could not download keyboard package %s", args.package)
             sys.exit(2)

--- a/linux/keyman-config/tests/test_install_kmp.py
+++ b/linux/keyman-config/tests/test_install_kmp.py
@@ -272,7 +272,7 @@ class InstallKmpTests(unittest.TestCase):
 
         # Execute
         with self.assertRaises(InstallError) as context:
-            InstallKmp()._install_kmp(kmpfile, False, 'km', InstallLocation.User)
+            InstallKmp()._install_kmp(kmpfile, 'km', InstallLocation.User)
 
         # Verify
         self.assertTrue('foo.kmp requires Keyman 99.0 or higher' in context.exception.message)
@@ -296,7 +296,7 @@ class InstallKmpTests(unittest.TestCase):
                 self._createKmpJson(packagedir, testcase['fileVersion'])
 
                 # Execute
-                InstallKmp()._install_kmp(kmpfile, False, 'km', InstallLocation.User)
+                InstallKmp()._install_kmp(kmpfile, 'km', InstallLocation.User)
 
                 # Verify
                 self.mockInstallToIbus.assert_called_once()


### PR DESCRIPTION
This change fixes a bug where a JSON file containing the package description was missing after initial installation.
For that it disposes of the `online` argument in `install_kmp`. 

Fixes #8017

# User Testing
## Preparations
  - delete all files in `~/.cache/keyman/` (especially `keyman_cache.sqlite`)
  - download "EuroLatin" (SIL) package into `~/.cache/keyman/` (https://keyman.com/go/package/download/sil_euro_latin?version=2.0&tier=stable)
  - don't have "khmer_angkor" or "sil_euro_latin" keyboard installed
 
## Tests

**TEST_DOWNLOAD**: JSON file gets downloaded and package description is shown
  - start `km-config`
  - click "Download" button
  - search for "khmer" and click on the "khmer_angkor" keyboard
  - click "Install keyboard" button
  - click "Install" button
  - click "OK" on the message dialog
  - select "Khmer Angkor" keyboard and click "About" button
  - verify that a package description is shown
  - verify that in `~/.local/share/keyman/khmer_angkor` the file `khmer_angkor.json` exists


**TEST_DOWNLOAD_NO_INTERNET**: Installation still works w/o internet connection
  - start `km-config`
  - click "Download" button
  - search for "khmer" and click on the "khmer_angkor" keyboard
  - click "Install keyboard" button
  - turn off internet connection
  - click "Install" button
  - click "OK" on the message dialog
  - verify that the installation works

**TEST_INSTALL**: JSON file gets downloaded and package description is shown
  - start `km-config`
  - click "Install" button
  - select `sil_euro_latin.kmp` from `~/.cache/keyman/`
  - click "Install" button
  - click "OK" on the message dialog
  - select "EuroLatin (SIL)" keyboard and click "About" button
  - verify that a package description is shown
  - verify that in `~/.local/share/keyman/sil_euro_latin` the file `sil_euro_latin.json` exists


**TEST_INSTALL_NO_INTERNET**: Installation still works w/o internet connection
  - start `km-config`
  - turn off internet connection
  - click "Install" button
  - select `sil_euro_latin.kmp` from `~/.cache/keyman/`
  - click "Install" button
  - click "OK" on the message dialog
  - verify that the installation works

**TEST_CL_FILE_INSTALL**: JSON file gets downloaded and package description is shown
  - open terminal
  - change directory to `keyman/linux/keyman-config`
  - run `./km-package-install -f ~/.cache/keyman/sil_euro_latin.kmp`
  - start `km-config`
  - select "EuroLatin (SIL)" keyboard and click "About" button
  - verify that a package description is shown
  - verify that in `~/.local/share/keyman/sil_euro_latin` the file `sil_euro_latin.json` exists

**TEST_CL_FILE_INSTALL_NO_INTERNET**: Installation still works w/o internet connection
  - open terminal
  - turn off internet connection
  - change directory to `keyman/linux/keyman-config`
  - run `./km-package-install -f ~/.cache/keyman/sil_euro_latin.kmp`
  - start `km-config`
  - verify that the installation worked

**TEST_CL_PACKAGE_INSTALL**: JSON file gets downloaded and package description is shown
  - open terminal
  - change directory to `keyman/linux/keyman-config`
  - run `./km-package-install -p sil_euro_latin`
  - start `km-config`
  - select "EuroLatin (SIL)" keyboard and click "About" button
  - verify that a package description is shown
  - verify that in `~/.local/share/keyman/sil_euro_latin` the file `sil_euro_latin.json` exists

**TEST_CL_PACKAGE_INSTALL_NO_INTERNET**: Downloading package fails
  - open terminal
  - turn off internet connection
  - change directory to `keyman/linux/keyman-config`
  - run `./km-package-install -p sil_euro_latin`
  - verify that `ERROR:km-package-install: error: Could not download keyboard data for sil_euro_latin` is shown
