### PR TITLE
fix(ios): use mobile mode for keyboard download pages

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/PackageWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/PackageWebViewController.swift
@@ -43,6 +43,16 @@ class PackageWebViewController: UIViewController, WKNavigationDelegate {
     let prefs = WKPreferences()
     prefs.javaScriptEnabled = true
 
+    if #available(iOS 13.0, *) {
+      /**
+        In iPadOS 16 and above WKWebView defaults to lying about its user-agent,
+        telling the web server that it is a mac. We can avoid this with .mobile:
+        */
+      let pref = WKWebpagePreferences.init()
+      pref.preferredContentMode = .mobile
+      config.defaultWebpagePreferences = pref
+    }
+
     // Inject a meta viewport tag into the head of the file if it doesn't exist
     let metaViewportInjection = """
       if(!document.querySelectorAll('meta[name=viewport]').length) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
@@ -101,7 +101,20 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
   }
 
   public override func loadView() {
-    let webView = WKWebView()
+
+    let config = WKWebViewConfiguration()
+
+    if #available(iOS 13.0, *) {
+      /**
+       In iPadOS 16 and above WKWebView defaults to lying about its user-agent,
+       telling the web server that it is a mac. We can avoid this with .mobile:
+       */
+      let pref = WKWebpagePreferences.init()
+      pref.preferredContentMode = .mobile
+      config.defaultWebpagePreferences = pref
+    }
+
+    let webView = WKWebView.init(frame: CGRect.zero, configuration: config)
     webView.navigationDelegate = self
     if let languageCode = languageCode {
       let baseURL = KeyboardSearchViewController.ENDPOINT_ROOT


### PR DESCRIPTION
Fixes #7915.

On iPadOS 16, it seems that WKWebView defaults to lying about its user agent to servers. We can switch this behaviour by using .mobile for the preferredContentMode.

We should also update the website to work around this, so that users always get the right downloads for their device, but the website currently uses server-side determination of user agent for this particular aspect of the keyboard search, so that's a much more significant refactor, to make it client-side, with greater risk and much more testing required.

This PR is a candidate for back-porting to 16.0-beta/stable.

# User Testing

TEST_INSTALL_MESOBE: Try installing the Amharic Mesobe Fidelat keyboard on an iPad (or simulator) running iOS 16.0 or later. The keyboard should be installable.