### PR TITLE
fix(linux): html tags in package description in keyboard's About page

### DIFF
--- a/docs/linux/keyman-config.md
+++ b/docs/linux/keyman-config.md
@@ -10,7 +10,7 @@ then you will need to:
 ```bash
 sudo apt install python3-lxml python3-magic python3-numpy python3-qrcode python3-pil \
     python3-requests python3-requests-cache python3 python3-gi gir1.2-webkit2-4.0 dconf-cli \
-    python3-setuptools python3-pip python3-dbus ibus libglib2.0-bin liblocale-gettext-perl
+    python3-setuptools python3-pip python3-dbus ibus libglib2.0-bin liblocale-gettext-perl python3-bs4
 ```
 
 Either `python3-raven` or `python3-sentry-sdk` (>= 1.4) is required as well. On Ubuntu 22.04 and later run:

--- a/linux/build/agent/dependencies.config
+++ b/linux/build/agent/dependencies.config
@@ -20,4 +20,4 @@
 # any=@precise.any
 
 [common]
-any=git autotools-dev build-essential dh-autoreconf libibus-1.0-dev flex bison meson python3 python3-pip cargo xserver-xephyr xvfb metacity libx11-dev gawk libgtk-3-dev libjson-glib-dev
+any=git autotools-dev build-essential dh-autoreconf libibus-1.0-dev flex bison meson python3 python3-bs4 python3-pip cargo xserver-xephyr xvfb metacity libx11-dev gawk libgtk-3-dev libjson-glib-dev

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -14,6 +14,7 @@ Build-Depends:
  liblocale-gettext-perl,
  perl,
  python3-all (>= 3.5),
+ python3-bs4,
  python3-dbus,
  python3-gi,
  python3-lxml,

--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -2,6 +2,7 @@
 
 # Keyboard details window
 
+from bs4 import BeautifulSoup
 import json
 import logging
 import tempfile
@@ -120,7 +121,9 @@ class KeyboardDetailsView(Gtk.Dialog):
             grid.attach_next_to(lbl_pkg_desc, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
             prevlabel = lbl_pkg_desc
             label = Gtk.Label()
-            label.set_text(kbdata['description'])
+            description = BeautifulSoup(kbdata['description'])
+            label.set_text(description.get_text('\n'))
+            label.set_alignment(0,0)
             label.set_halign(Gtk.Align.START)
             label.set_selectable(True)
             label.set_line_wrap(80)
@@ -263,7 +266,9 @@ class KeyboardDetailsView(Gtk.Dialog):
                     prevlabel = lbl_kbd_desc
                     label = Gtk.Label()
                     if secure_lookup(kbdata, 'description'):
-                        label.set_text(kbdata['description'])
+                        description = BeautifulSoup(kbdata['description'])
+                        label.set_text(description.get_text('\n'))
+                    label.set_alignment(0,0)
                     label.set_halign(Gtk.Align.START)
                     label.set_selectable(True)
                     label.set_line_wrap(80)


### PR DESCRIPTION
This change fixes a bug where html tags were shown in the package description in a keyboard's About page.

Fixes #4769

# User Testing
## Preparations
  - install "khmer_angkor" keyboard 
 
## Tests

**TEST_NO_HTML_TAGS**: no html tags are shown in the package description in keyboard's About page
  - start `km-config`
  - select "Khmer Angkor" keyboard
  - click "About" button
  - verify that no html tags are shown in the package description
