### PR TITLE
chore(developer): ldml setup for visual code coverage 🙀

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,9 @@ Thumbs.db
 # Code coverage tools for JS/TS - nyc and c8
 #
 .nyc_output/
+lcov-report/
+lcov.info
+
 # Linux packaging related
 /debian/
 /results/

--- a/common/web/types/package.json
+++ b/common/web/types/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "cd test && tsc -b && cd .. && c8 mocha",
+    "test": "cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
     "prepublishOnly": "npm run build"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",

--- a/developer/src/kmc-keyboard/package.json
+++ b/developer/src/kmc-keyboard/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "cd test && tsc -b && cd .. && c8 mocha",
+    "test": "cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
     "prepublishOnly": "npm run build"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",

--- a/developer/src/kmc-model-info/package.json
+++ b/developer/src/kmc-model-info/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "cd test && tsc -b && cd .. && c8 mocha",
+    "test": "cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
     "prepublishOnly": "npm run build"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -b && npm run build-cjs",
     "build-cjs": "esbuild build/src/lexical-model-compiler.js --bundle --platform=node --external:../../node_modules/* > build/cjs-src/lexical-model-compiler.cjs",
-    "test": "cd test && tsc -b && cd .. && c8 mocha",
+    "test": "cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
     "prepublishOnly": "npm run build"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",

--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "cd test && tsc -b && cd .. && mocha",
-    "coverage": "cd test && tsc -b && cd .. && c8 mocha",
+    "test": "cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
+    "coverage": "npm test",
     "prepublishOnly": "npm run build"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -16,7 +16,7 @@
     "bundle-kmlmc": "esbuild build/src/kmlmc.js --bundle --platform=node > build/cjs-src/kmlmc.cjs",
     "bundle-kmlmi": "esbuild build/src/kmlmi.js --bundle --platform=node > build/cjs-src/kmlmi.cjs",
     "bundle-kmlmp": "esbuild build/src/kmlmp.js --bundle --platform=node > build/cjs-src/kmlmp.cjs",
-    "test": "cd test && tsc -b && cd .. && c8 mocha",
+    "test": "cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
     "prepublishOnly": "npm run build"
   },
   "type": "module",


### PR DESCRIPTION
- generate coverage/lcov.info files in several places that were already using c8
- change kmc-package's 'npm test' to include coverage, leave 'coverage' as alias
- gitignore the lcov files

Fixes https://github.com/keymanapp/keyman/issues/8060

[coverage-gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) and others work well with this change.


@keymanapp-test-bot skip