### PR TITLE
chore(common): Update crowdin strings for Shuwa (Latin)

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values-b+shu+latn/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-b+shu+latn/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <!-- app_name removed in 16.0 beta. Set in build.gradle -->
   <!-- Context: Menu Action -->
   <string name="action_share" comment="Menu action to send text content to another app">Gassuma</string>
   <!-- Context: Menu Action -->

--- a/android/KMEA/app/src/main/res/values-b+shu+latn/strings.xml
+++ b/android/KMEA/app/src/main/res/values-b+shu+latn/strings.xml
@@ -11,10 +11,10 @@
     </plurals>
     <!-- Context: Title for list -->
     <plurals name="title_other_input_methods">
-        <item quantity="one">Other Input Method</item>
-        <item quantity="two">Other Input Methods</item>
-        <item quantity="few">Other Input Methods</item>
-        <item quantity="other">Other Input Methods</item>
+        <item quantity="one">Darb gadey hana dassasan</item>
+        <item quantity="two">Durub gadey hana dassasan</item>
+        <item quantity="few">Durub gadey hana dassasan</item>
+        <item quantity="other">Durub gadey hana dassasan</item>
     </plurals>
     <!-- Context: Title for list -->
     <string name="title_add_keyboard" comment="Add a new keyboard">Zyd Keyboard jadid</string>

--- a/ios/engine/KMEI/KeymanEngine/shu-latn-n.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/shu-latn-n.lproj/Localizable.strings
@@ -119,7 +119,7 @@
 "kmp-error-invalid" = "Alshu'ul maknus.";
 
 /* Error opening a Keyman package - it does not exist / the specified location is wrong */
-"kmp-error-missing" = "The specified package does not exist.";
+"kmp-error-missing" = "Al package alkhassa da mafi.";
 
 /* Error installing a Keyman package - expected resource (keyboard or dictionary) is missing */
 "kmp-error-missing-resource" = "Alshu'ul da ma leya gudura layl keyboard walla kakkad hanal kalimat da.";
@@ -131,7 +131,7 @@
 "kmp-error-no-metadata" = "Ma sawwol shu'ul da zayn - shu'ul alfiya ma mil'araf.";
 
 /* Error opening a Keyman package - package's contents are for desktop platforms only */
-"kmp-error-unsupported" = "This package does not include support for your device.";
+"kmp-error-unsupported" = "Al package da ma bikun bidukhul ley shu'ulak.";
 
 /* Error opening a Keyman package - package contains unexpected resource (keyboard or dictionary) type */
 "kmp-error-wrong-type" = "Alshu'ul da ma leya shu'ul albinadawar minna.";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/shu-latn-n.lproj/KMAboutWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/shu-latn-n.lproj/KMAboutWindowController.strings
@@ -1,0 +1,8 @@
+/* button text to close the About window */
+"Kab-Up-fYH.title" = "Sidda";
+
+/* text of link to the license agreement */
+"hYC-Bx-aoP.title" = "Muwafiqa hana izin";
+
+/* button text to open Configuration window  */
+"vkh-b5-vO7.title" = "Wasiyana...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/shu-latn-n.lproj/preferences.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/shu-latn-n.lproj/preferences.strings
@@ -1,0 +1,38 @@
+/* Checkbox text to always show on-screen keyboard */
+"4UX-80-0Vo.title" = "Matakula war keyboard albinshaf";
+
+/* Checkbox text to enable verbose Console logging */
+"7J6-zy-R20.title" = "Annaf bey verbose console logging";
+
+/* Support button text  */
+"93O-x6-RLF.label" = "Mi'awana";
+
+/* Download Keyboard button text */
+"CTw-kf-WNS.title" = "Dyssal keyboard...";
+
+/* Keyman Configuration window title */
+"F0z-JX-Cv5.title" = "Ta'adil hana Keyman";
+
+/* button text to go back to previous page */
+"JOK-JV-n8w.title" = "Wara";
+
+/* Keyboards button text */
+"MPN-9N-wWc.label" = "Keyboards";
+
+/* text to explain verbose Console logging option */
+"MrI-GM-7d6.title" = "Kan verbose logging mafkuk da, alshu'ul bi'awwun Keyman ley eirfiyan shunu min mashakil kan gamma. Alshu'ul hanal console binnafu beya ley shafian risalat min Keyman. Fyl console da, dyssa ley eiwari risalat chatta min darb albisawwi hana \"Keyman\". Alshu'ul da bikun bisullu wa biluzzu ley Keyman kan murada gamma.";
+
+/* button text to move forward to the next page */
+"eXr-8V-h1g.title" = "Giddam";
+
+/* button text to return to the home help page */
+"fXS-aC-CMH.title" = "Bidaya";
+
+/* Options button text */
+"frd-No-seV.label" = "Durub";
+
+/* Installed Keyboard column heading */
+"jex-Nd-Qzg.headerCell.title" = "Dyssal keyboard";
+
+/* Verbose logging tooltip text */
+"uWx-3J-U0D.ibShadowedToolTip" = "Fukkal shu'ul da kan ligyt mashakil bey keyboard khassa walla bey Keyman zaata.";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/shu-latn-n.lproj/KMInfoWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/shu-latn-n.lproj/KMInfoWindowController.strings
@@ -1,0 +1,8 @@
+/* Package Information window title */
+"F0z-JX-Cv5.title" = "Package Information";
+
+/* button text to show Details */
+"Fvy-XJ-s38.label" = "Shu'ul alfiya";
+
+/* button text to show Read Me */
+"waA-IW-Qyn.label" = "Agurni";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/shu-latn-n.lproj/KMKeyboardHelpWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/shu-latn-n.lproj/KMKeyboardHelpWindowController.strings
@@ -1,0 +1,8 @@
+/* Keyboard Help window title */
+"F0z-JX-Cv5.title" = "Mi'awana faougal Keyboard";
+
+/* OK button text */
+"Zla-QF-m0K.title" = "Zayn";
+
+/* Print button text */
+"fYY-Uj-y4S.title" = "Sulla...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/shu-latn-n.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/shu-latn-n.lproj/Localizable.strings
@@ -1,0 +1,71 @@
+/* Message displayed to confirm delete of the Keyman keyboard selected by the user from the keyboard list  */
+"message-confirm-delete-keyboard" = "Tabbat tador tasulal keyboard wah '%@'?";
+
+/* Delete keyboard confirmation info indicating that the delete action cannot be undone  */
+"info-cannot-undo-delete-keyboard" = "Ma taddar tagulbal shu'ul da.";
+
+/* Button text to cancel delete of the specified installed Keyman keyboard  */
+"button-cancel-delete-keyboard" = "Halla";
+
+/* Button text to confirm delete of the specified installed Keyman keyboard  */
+"button-delete-keyboard" = "Chinna";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"message-confirm-install-keyboard" = "Dys keyman keyboard?";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"info-install-keyboard-filename" = "Tador Keyman eidissal keyboard minal shu'ul wah '%@'?";
+
+/* Button text to cancel installation of the double-clicked Keyman file  */
+"button-cancel-install-keyboard" = "Halla";
+
+/* Button text to confirm installation of the double-clicked Keyman file  */
+"button-install-keyboard" = "Dyssa";
+
+/* Message displayed to inform user that .kmp file could not be read/unzipped  */
+"message-keyboard-file-unreadable" = "Ma gudur gara shu'ul alfyl Keyman '%@'.";
+
+/* Message displayed in Configuration window when keyboard cannot be loaded */
+"message-error-loading-keyboard" = "(error loading keyboard)";
+
+/* Message displayed in Configuration window when keyboard metadata cannot be loaded */
+"message-error-unknown-metadata" = "unknown";
+
+/* Button text to acknowledge that .kmp file could not be read  */
+"button-keyboard-file-unreadable" = "Zayn";
+
+/* label text to identify Keyman version */
+"version-label-text" = "Nafar: %@";
+
+/* Status text for keyboard downloading  */
+"message-keyboard-downloading" = "Dakhalan...";
+
+/* Status text for keyboard download complete  */
+"message-keyboard-download-complete" = "Tammam dakhalan.";
+
+/* Button text to cancel downloading keyboard  */
+"button-cancel-downloading" = "Halla";
+
+/* Button text keyboard download complete  */
+"button-download-complete" = "Tamma";
+
+/* keyboards label in the Package Information window */
+"keyboards-label" = "Keyboards:";
+
+/* fonts label in the Package Information window */
+"fonts-label" = "Fonts:";
+
+/* package version label in the Package Information window */
+"package-version-label" = "Package Version:";
+
+/* author label in the Package Information window */
+"author-label" = "Author:";
+
+/* website label in the Package Information window */
+"website-label" = "Website:";
+
+/* copyright label in the Package Information window */
+"copyright-label" = "Copyright:";
+
+/* message displayed to alert user to need grant accessibility permission */
+"privacy-alert-text" = "To function properly, Keyman requires accessibility features:\n\nGrant access in System Preferences, Security & Privacy.\nRestart your system.";

--- a/mac/Keyman4MacIM/Keyman4MacIM/shu-latn-n.lproj/MainMenu.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/shu-latn-n.lproj/MainMenu.strings
@@ -1,0 +1,14 @@
+/* Configuration window menu text */
+"P1b-lE-yFw.title" = "Wasiyana...";
+
+/* Keyboards menu text */
+"bQa-j9-nHe.title" = "Keyboards";
+
+/* Keyboards menu text */
+"goP-aK-3WB.title" = "Keyboards";
+
+/* About menu text */
+"kb2-ww-RS3.title" = "Faoug";
+
+/* On-Screen Keyboard menu text */
+"s96-JI-YDh.title" = "Keyboard albinshaf";

--- a/windows/src/desktop/kmshell/locale/shu-latn/strings.xml
+++ b/windows/src/desktop/kmshell/locale/shu-latn/strings.xml
@@ -46,6 +46,10 @@
   <string name="SKButtonCancel" comment="Cancel button in message boxes">Halla</string>
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
+  <!-- Introduced: 16.0.47 -->
+  <string name="SKAddremove" comment="Add or Remove languages button opens a dialog window">Add/remove language...</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
   <!-- Introduced: 8.0.330.0 -->
   <string name="SKBalloonClickToSelectKeyboard" comment="Balloon that shows when Keyman icon is first shown during the tutorial">Assural shu\'ul da ley ta\'azzulal keyboard</string>
   <!-- Context: Formatted Messages -->
@@ -64,6 +68,18 @@
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.239.0 -->
   <string name="S_Caption_Help" comment="Configuration dialog link to Help">Mi\'awana</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47.0 -->
+  <string name="S_Caption_Uninstall" comment="Configuration dialog link to Uninstall Keyboard">Uninstall</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47.0 -->
+  <string name="S_Caption_Enable" comment="Configuration dialog link to Enable Keyboard">Enable</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47.0 -->
+  <string name="S_Caption_Disable" comment="Configuration dialog link to Disable Keyboard">Disable</string>
   <!-- Context: Configuration Dialog - Tab names -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -174,6 +190,10 @@
   <string name="S_Languages_Install" comment="Add language profile">Dys lugga</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47 -->
+  <string name="S_Languages_Addremove" comment="Title for dialog to add or remove languages for keyboard layout">Add/remove language</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Caption_OnScreenKeyboard" comment="Term for the On Screen Keyboard">Keyboard albinshaf:</string>
   <!-- Context: Configuration Dialog - Captions -->
@@ -223,7 +243,7 @@
   <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.287.0 -->
-  <string name="S_Menu_Options" comment="KL option button submenu - keyboard options">Nafar hanal keyboard</string>
+  <string name="S_Menu_Options" comment="KL option button submenu - keyboard options">Keyboard options...</string>
   <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -341,7 +361,7 @@
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_Hotkey_None" comment="Hotkey - text used when no hotkey set for an option">(mafi)</string>
+  <string name="S_Hotkey_None" comment="Hotkey - text used when no hotkey set">(no hotkey)</string>
   <!-- Context: Configuration Dialog - Hotkeys tab -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->

--- a/windows/src/desktop/setup/locale/shu-latn/strings.xml
+++ b/windows/src/desktop/setup/locale/shu-latn/strings.xml
@@ -72,9 +72,7 @@ Tasawwa dugut wah?</string>
   <string name="ssDownloadingTitle">Bidukhul %0:s</string>
   <!-- Parameters: %0:s: filename -->
   <string name="ssDownloadingText">Bidukhul %0:s</string>
-  <string name="ssOffline">$APPNAME Aldassasan ma gudur kan ley dassasan ziyada hana shu\'ul finshan ma gudur wassal keyman.com
-
-Albarak shyf kan internet hanak bikhadum, wa ath $APPNAME izin hana dassasan min internet hanak ley firewall hana browser hanak.
-
-Assur hallayt ley dabbaran dassasana, hawul ley dassasana addarey shiyakay, walla halla ley takhadum bala internet.</string>
+  <string name="ssOffline">$APPNAME Aldassasan ma gudur kan ley dassasan ziyada hana shu\'ul finshan ma gudur wassal keyman.com.</string>
+  <string name="ssOffline2">Albarak shyf kan internet hanak bikhadum, wa ath $APPNAME izin hana dassasan min internet hanak ley firewall hana browser hanak.</string>
+  <string name="ssOffline3">Assur hallayt ley dabbaran dassasana, hawul ley dassasana addarey shiyakay, walla halla ley takhadum bala internet.</string>
 </resources>


### PR DESCRIPTION
This updates some crowdin strings for Shuwa (Latin) - locale shu-Latn.
Strings are all new for macOS.

This adds the crowdin strings for Shuwa (Latin)

TODO for @sgschantz (unsupported on macOS)
~- [ ] Run XCode for macOS~

@keymanapp-test-bot skip

