### PR TITLE
feat(common): ldml: refactor imports 🙀

### DIFF
--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -48,7 +48,7 @@ else
     CLDR_PATH=$(dirname "$CLDR_INFO_PATH")
     CLDR_VER=$(basename "$CLDR_PATH")
     mkdir -p "$THIS_SCRIPT_PATH/build/src/import/$CLDR_VER"
-    # TODO-LDML: When these are copied, the DOCTYPE will break due to the wrong path.
+    # TODO-LDML: When these are copied, the DOCTYPE will break due to the wrong path. We don't use the DTD so it should be OK.
     cp "$CLDR_INFO_PATH" "$CLDR_PATH/import/"*.xml "$THIS_SCRIPT_PATH/build/src/import/$CLDR_VER/"
   done
 fi

--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -1,14 +1,21 @@
 import * as xml2js from 'xml2js';
 import { LDMLKeyboardXMLSourceFile, LKImport } from './ldml-keyboard-xml.js';
 import Ajv from 'ajv';
-import * as fs from 'fs';
 import { boxXmlArray } from '../util/util.js';
+import { CompilerCallbacks } from 'src/util/compiler.js';
 
 export default class LDMLKeyboardXMLSourceFileReader {
+  callbacks: CompilerCallbacks;
+
+  constructor(callbacks : CompilerCallbacks) {
+    this.callbacks = callbacks;
+  }
+
   readImportFile(version: string, subpath: string): Buffer {
     // TODO-LDML: sanitize input string
     let importPath = new URL(`../import/${version}/${subpath}`, import.meta.url);
-    return fs.readFileSync(importPath);
+    // TODO-LDML: support baseFileName?
+    return this.callbacks.loadFile(importPath.pathname, importPath);
   }
 
   /**

--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -3,6 +3,7 @@ import { LDMLKeyboardXMLSourceFile, LKImport } from './ldml-keyboard-xml.js';
 import Ajv from 'ajv';
 import { boxXmlArray } from '../util/util.js';
 import { CompilerCallbacks } from 'src/util/compiler.js';
+import { constants } from '@keymanapp/ldml-keyboard-constants';
 
 export default class LDMLKeyboardXMLSourceFileReader {
   callbacks: CompilerCallbacks;
@@ -106,7 +107,7 @@ export default class LDMLKeyboardXMLSourceFileReader {
       // <import base="cldr" path="techpreview/keys-Latn-implied.xml"/>
       this.resolveOneImport(obj, subtag, {
         base: 'cldr',
-        path: 'techpreview/keys-Latn-implied.xml'
+        path: constants.cldr_implied_keys_import
       });
     }
 

--- a/common/web/types/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
+++ b/common/web/types/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
@@ -2,16 +2,33 @@ import 'mocha';
 import {assert} from 'chai';
 import {loadLdmlKeyboardSchema, loadFile, makePathToFixture} from '../helpers/index.js';
 import LDMLKeyboardXMLSourceFileReader from '../../src/ldml-keyboard/ldml-keyboard-xml-reader.js';
+import { CompilerCallbacks, CompilerEvent } from '../../src/util/compiler.js';
 
 describe('ldml keyboard xml reader tests', function() {
   this.slow(500); // 0.5 sec -- json schema validation takes a while
 
+  const callbacks : CompilerCallbacks = {
+    loadFile: function (baseFilename: string, filename: string | URL): Buffer {
+      throw new Error('Function not implemented.');
+    },
+    loadLdmlKeyboardSchema: function (): Buffer {
+      throw new Error('Function not implemented.');
+    },
+    reportMessage: function (event: CompilerEvent): void {
+      throw new Error('Function not implemented.');
+    },
+    loadKvksJsonSchema: function (): Buffer {
+      throw new Error('Function not implemented.');
+    }
+  };
+
   it("should fail to load files that don't conform to DTD", function() {
     const inputFilename = makePathToFixture('invalid-structure-per-dtd.xml');
-    let reader = new LDMLKeyboardXMLSourceFileReader();
+    let reader = new LDMLKeyboardXMLSourceFileReader(callbacks);
     const data = loadFile(inputFilename, inputFilename);
     const source = reader.load(data);
     assert.isNotNull(source);
+    // TODO-LDML: could report a messge instead of throw
     assert.throws(() => {
       reader.validate(source, loadLdmlKeyboardSchema());
     }, `/keyboard: required: must have required property 'names' {"missingProperty":"names"}`);
@@ -19,10 +36,11 @@ describe('ldml keyboard xml reader tests', function() {
 
   it("should fail to load files with an invalid conformsTo", function() {
     const inputFilename = makePathToFixture('invalid-conforms-to.xml');
-    let reader = new LDMLKeyboardXMLSourceFileReader();
+    let reader = new LDMLKeyboardXMLSourceFileReader(callbacks);
     const data = loadFile(inputFilename, inputFilename);
     const source = reader.load(data);
     assert.isNotNull(source);
+    // TODO-LDML: could report a messge instead of throw
     assert.throws(() => {
       reader.validate(source, loadLdmlKeyboardSchema());
     }, `/keyboard/conformsTo: enum: must be equal to one of the allowed values {"allowedValues":["techpreview"]}`);

--- a/common/web/types/tsconfig.json
+++ b/common/web/types/tsconfig.json
@@ -12,6 +12,6 @@
   ],
   "references": [
     { "path": "../keyman-version/tsconfig.esm.json" },
-    { "path": "../../../core/include/ldml/"},
+    { "path": "../../../core/include/ldml/tsconfig.json"},
   ]
 }

--- a/core/include/ldml/keyboardprocessor_ldml.h
+++ b/core/include/ldml/keyboardprocessor_ldml.h
@@ -1,6 +1,6 @@
 
 /*
-  Copyright:        Copyright (C) 2022 SIL International.
+  Copyright:        Copyright (C) 2022-2023 SIL International.
   Authors:          srl295
   This file provides constants for the KMX Plus (LDML support) binary format,
   to be shared between TypeScript and C++ via the generator (below)
@@ -16,6 +16,10 @@
 #pragma once
 
 #define LDML_BKSP_FLAGS_ERROR 0x1
+#define LDML_CLDR_IMPLIED_KEYS_IMPORT "techpreview/keys-Latn-implied.xml"
+#define LDML_CLDR_IMPORT_BASE "cldr"
+#define LDML_CLDR_VERSION_LATEST "techpreview"
+#define LDML_CLDR_VERSION_TECHPREVIEW "techpreview"
 #define LDML_ELEM_FLAGS_ORDER_BITSHIFT 0x10
 #define LDML_ELEM_FLAGS_ORDER_MASK 0xFF0000
 #define LDML_ELEM_FLAGS_PREBASE 0x4

--- a/core/include/ldml/keyboardprocessor_ldml.ts
+++ b/core/include/ldml/keyboardprocessor_ldml.ts
@@ -60,6 +60,22 @@ class Constants {
    */
   readonly version = '1.0';
   /**
+   * The techpreview CLDR version
+   */
+  readonly cldr_version_techpreview = 'techpreview';
+  /**
+   * The latest CLDR version
+   */
+  readonly cldr_version_latest = this.cldr_version_techpreview;
+  /**
+   * import base
+   */
+  readonly cldr_import_base = 'cldr';
+  /**
+   * implied keys file
+   */
+  readonly cldr_implied_keys_import = `${this.cldr_version_techpreview}/keys-Latn-implied.xml`;
+  /**
    * Length of a raw section header, in bytes
    */
   readonly length_header = 8;

--- a/core/include/ldml/ldml-const-builder.ts
+++ b/core/include/ldml/ldml-const-builder.ts
@@ -10,7 +10,7 @@ const keys = Object.keys(constants);
 keys.sort();
 console.log(`
 /*
-  Copyright:        Copyright (C) 2022 SIL International.
+  Copyright:        Copyright (C) 2022-2023 SIL International.
   Authors:          srl295
   This file provides constants for the KMX Plus (LDML support) binary format,
   to be shared between TypeScript and C++ via the generator (below)
@@ -29,35 +29,37 @@ console.log(`
 let errs = 0;
 
 for (const key of keys) {
-    const value : any = constants[key as keyof typeof constants];
-    const upkey = key.toUpperCase();
-    const type = typeof value;
-    if (type === 'number') {
-        console.log(`#define LDML_${upkey} 0x${value.toString(16).toUpperCase()}`);
-    } else if (type === 'string') {
-        console.log(`#define LDML_${upkey} "${value}"`);
-    } else if (key === 'section') {
-        // handle section table
-        const subkeys = Object.keys(value);
-        subkeys.sort();
-        for (const subkey of subkeys) {
-            const upsubkey = subkey.toUpperCase();
-            const subvalue = value[subkey];
-            if (subvalue !== subkey) {
-                // "can't happen" because tsc would complain
-                console.error(`In the SectionMap:  ${subkey}: '${subvalue}' - expected key and value to match.`);
-                errs++;
-            }
-            const asnum = constants.hex_section_id(subkey);
-            console.log(`#define LDML_${upkey}ID_${upsubkey} 0x${asnum.toString(16).toUpperCase()} /* "${subkey}" */`);
-            console.log(`#define LDML_${upkey}NAME_${upsubkey}             "${subkey}"`);
-        }
-    } else if (type !== 'function') {
-        console.error(`Don’t know what to do with constants[${key}] of type ${type}`);
+  const value: any = constants[key as keyof typeof constants];
+  const upkey = key.toUpperCase();
+  const type = typeof value;
+  if (type === 'number') {
+    console.log(`#define LDML_${upkey} 0x${value.toString(16).toUpperCase()}`);
+  } else if (type === 'string') {
+    console.log(`#define LDML_${upkey} "${value}"`);
+  } else if (key === 'section') {
+    // handle section table
+    const subkeys = Object.keys(value);
+    subkeys.sort();
+    for (const subkey of subkeys) {
+      const upsubkey = subkey.toUpperCase();
+      const subvalue = value[subkey];
+      if (subvalue !== subkey) {
+        // "can't happen" because tsc would complain
+        console.error(`In the SectionMap:  ${subkey}: '${subvalue}' - expected key and value to match.`);
         errs++;
+      }
+      const asnum = constants.hex_section_id(subkey);
+      console.log(`#define LDML_${upkey}ID_${upsubkey} 0x${asnum.toString(16).toUpperCase()} /* "${subkey}" */`);
+      console.log(`#define LDML_${upkey}NAME_${upsubkey}             "${subkey}"`);
     }
+  } else if (key === 'layr_list_hardware_map' || type === 'function') {
+    // ignored
+  } else {
+    console.error(`Don’t know what to do with constants[${key}] of type ${type}`);
+    errs++;
+  }
 }
 
 if (errs != 0) {
-    throw Error(`Fail: ${errs} error(s), see above.`);
+  throw Error(`Fail: ${errs} error(s), see above.`);
 }

--- a/core/tools/ldml-const-builder/build.sh
+++ b/core/tools/ldml-const-builder/build.sh
@@ -42,7 +42,7 @@ if builder_start_action build; then
 fi
 
 if builder_start_action run; then
-  node ../../include/ldml/ldml-const-builder/ldml-const-builder.js > ${KBP_LDML_H_FILE}
+  node --enable-source-maps ../../include/ldml/ldml-const-builder/ldml-const-builder.js > ${KBP_LDML_H_FILE}
   echo "Updated ${KBP_LDML_H_FILE}"
 
   builder_finish_action success run

--- a/developer/src/kmc-keyboard/src/compiler/compiler.ts
+++ b/developer/src/kmc-keyboard/src/compiler/compiler.ts
@@ -56,7 +56,7 @@ export default class Compiler {
    * @returns
    */
   public load(filename: string): LDMLKeyboardXMLSourceFile {
-    const reader = new LDMLKeyboardXMLSourceFileReader();
+    const reader = new LDMLKeyboardXMLSourceFileReader(this.callbacks);
     const data = this.callbacks.loadFile(filename, filename);
     const source = reader.load(data);
     if(!source) {

--- a/developer/src/kmc-keyboard/test/helpers/index.ts
+++ b/developer/src/kmc-keyboard/test/helpers/index.ts
@@ -71,7 +71,7 @@ export function loadSectionFixture(compilerClass: typeof SectionCompiler, filena
   const data = callbacks.loadFile(inputFilename, inputFilename);
   assert.isNotNull(data);
 
-  const reader = new LDMLKeyboardXMLSourceFileReader();
+  const reader = new LDMLKeyboardXMLSourceFileReader(callbacks);
   const source = reader.load(data);
   assert.isNotNull(source);
   assert.doesNotThrow(() => {

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -46,16 +46,6 @@ else
   # We need the schema file at runtime and bundled, so always copy it for all actions except `clean`
   mkdir -p "$THIS_SCRIPT_PATH/build/src/"
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  # Store imports
-  # load all versions that have a cldr_info.json
-  for CLDR_INFO_PATH in "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/"*/cldr_info.json
-  do
-    CLDR_PATH=$(dirname "$CLDR_INFO_PATH")
-    CLDR_VER=$(basename "$CLDR_PATH")
-    mkdir -p "$THIS_SCRIPT_PATH/build/src/import/$CLDR_VER"
-    # TODO-LDML: When these are copied, the DOCTYPE will break due to the wrong path.
-    cp "$CLDR_INFO_PATH" "$CLDR_PATH/import/"*.xml "$THIS_SCRIPT_PATH/build/src/import/$CLDR_VER/"
-  done
 fi
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
       "dependencies": {
         "@keymanapp/common-types": "file:common/web/types",
         "@keymanapp/hextobin": "file:common/tools/hextobin",
-        "@keymanapp/keyman-version": "file:common/web/keyman-version"
+        "@keymanapp/keyman-version": "file:common/web/keyman-version",
+        "@keymanapp/ldml-keyboard-constants": "file:core/include/ldml"
       },
       "devDependencies": {
         "chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@keymanapp/hextobin": "file:common/tools/hextobin",
     "@keymanapp/keyman-version": "file:common/web/keyman-version",
-    "@keymanapp/common-types": "file:common/web/types"
+    "@keymanapp/common-types": "file:common/web/types",
+    "@keymanapp/ldml-keyboard-constants": "file:core/include/ldml"
   }
 }


### PR DESCRIPTION
supports #7964

- change importer to use callbacks for fs
- see #7402 for the grandparent PR - feature complete, but needs refactor

@keymanapp-test-bot skip