### PR TITLE
fix(linux): Fix CI build 🩹

### DIFF
--- a/linux/scripts/jenkins.sh
+++ b/linux/scripts/jenkins.sh
@@ -65,8 +65,8 @@ checkAndInstallRequirements
 echo_heading "cleaning previous builds of $1"
 
 rm -rf builddebs
-rm -rf "$sourcedir/${1}_*.{dsc,build,buildinfo,changes,tar.?z,log}"
-rm -rf "$sourcedir/../${1}_*.{dsc,build,buildinfo,changes,tar.?z,log}"
+rm -rf "$sourcedir/${1}"_*.{dsc,build,buildinfo,changes,tar.?z,log}
+rm -rf "$sourcedir/../${1}"_*.{dsc,build,buildinfo,changes,tar.?z,log}
 
 echo_heading "Make source package for $fullsourcename"
 echo_heading "reconfigure"

--- a/linux/scripts/package-build.inc.sh
+++ b/linux/scripts/package-build.inc.sh
@@ -48,8 +48,8 @@ function downloadSource() {
     mv "${proj}-${version}" "${BASEDIR}/${packageDir}"
     mv "${proj}_${version}.orig.tar.gz" "${BASEDIR}/${packageDir}"
     mv "${proj}-${version}.tar.gz" "${BASEDIR}/${packageDir}"
-    mv "${proj}*.asc" "${BASEDIR}/${packageDir}"
-    rm "${proj}*.debian.tar.xz"
+    mv "${proj}"*.asc "${BASEDIR}/${packageDir}"
+    rm "${proj}"*.debian.tar.xz
     cd "${BASEDIR}/${packageDir}" || exit
     wget -N https://downloads.keyman.com/linux/${TIER}/${dirversion}/SHA256SUMS
     sha256sum -c --ignore-missing SHA256SUMS |grep "${proj}"


### PR DESCRIPTION
This fixes the build on Jenkins and TC that got broken by including the wildcard in the quoted string (which causes it to be interpreted literally), introduced in #8102.

@keymanapp-test-bot skip