### PR TITLE
fix(ios): allow duplicate languages in kmp file

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Data/InstallableKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Data/InstallableKeyboard.swift
@@ -106,7 +106,10 @@ public struct InstallableKeyboard: Codable, KMPInitializableLanguageResource {
     self.lgCode = lgCode
 
     let languageMatches = metadata.languages.compactMap { return $0.languageId == lgCode ? $0.name : nil }
-    guard languageMatches.count == 1 else {
+    if (languageMatches.isEmpty) {
+      SentryManager.captureAndLog("Could not find languageId '\(lgCode)' for package '\(packageID)'", sentryLevel: .warning)
+    }
+    guard languageMatches.count >= 1 else {
       return nil
     }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPKeyboard.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/kmp.json/KMPKeyboard.swift
@@ -76,8 +76,9 @@ class KMPKeyboard: Codable, KMPResource {
     var installableKeyboards : [InstallableKeyboard] = []
 
     for language in self.languages {
-      let keyboard = InstallableKeyboard(from: self, packageID: packageId!, lgCode: language.languageId)!
-      installableKeyboards.append( keyboard )
+      if let keyboard = InstallableKeyboard(from: self, packageID: packageId!, lgCode: language.languageId) {
+        installableKeyboards.append( keyboard )
+      }
     }
 
     return installableKeyboards


### PR DESCRIPTION
Fixes #8118.

When loading kmp file, Keyman will load successfully if there are duplicate entries in the languages array of the keyboard.

  ## User Testing

* **TEST_KMP_FILE_WITH_DUPLICATE_LANGUAGE**
1. On the iOS Simulator, install Keyman
2. Install the Khmer Angkor keyboard
3. Remove the default Euro Latin keyboard
4. In its place, install this [Euro Latin keyboard version 2.0.1 with duplicate languages](https://downloads.keyman.com/keyboards/sil_euro_latin/2.0.1/sil_euro_latin.kmp)
5. Verify that Keyman loads this keyboard OK and runs normally
