### PR TITLE
feat(windows): add additional registry keys to report

### DIFF
--- a/windows/src/engine/tsysinfo/si_language.pas
+++ b/windows/src/engine/tsysinfo/si_language.pas
@@ -145,6 +145,8 @@ begin
 
   regnode := xmlAddChild(subnode,'CurrentUser');
   AddRegistry(regnode, HKEY_CURRENT_USER, SRegKey_KeyboardLayout_CU);
+  AddRegistry(regnode, HKEY_CURRENT_USER, 'Software\Microsoft\CTF');
+  AddRegistry(regnode, HKEY_CURRENT_USER, SRegKey_ControlPanelInternationalUserProfile);
   subnode := xmlAddChild(node,'Uniscribe');
   AddFileVersion(subnode, GetFolderPath(CSIDL_SYSTEM) + 'usp10.dll');
   str := TStringList.Create;


### PR DESCRIPTION
Adds the following registry keys to the report:
* `HKCU\Software\Microsoft\CTF`
* `HKCU\Control Panel\International\User Profile`

@keymanapp-test-bot skip