### PR TITLE
chore(developer): kmcmpdll debug src path

### DIFF
--- a/developer/src/tike/main/RedistFiles.pas
+++ b/developer/src/tike/main/RedistFiles.pas
@@ -139,12 +139,17 @@ function GetDebugKMCmpDllPath: string;
 var
   root: string;
 const
+  DevPlatform={$IFDEF WIN64}'x64'{$ELSE}'Win32'{$ENDIF};
+  DevConfig={$IFDEF DEBUG}'Debug'{$ELSE}'Release'{$ENDIF};
+  DevSrcCompilerPath = 'developer\src\kmcmpdll\bin\'+DevPlatform+'\'+DevConfig;
   DevCompilerPath = 'developer\bin';
 begin
-  if TKeymanPaths.RunningFromSource(root) and
-    FileExists(root + DevCompilerPath + '\kmcmpdll.dll')
-    then Result := root + DevCompilerPath
-    else Result := ExtractFilePath(ParamStr(0));
+  if TKeymanPaths.RunningFromSource(root) and FileExists(root + DevSrcCompilerPath + '\kmcmpdll.dll') then
+    Result := root + DevSrcCompilerPath
+  else if TKeymanPaths.RunningFromSource(root) and FileExists(root + DevCompilerPath + '\kmcmpdll.dll') then
+    Result := root + DevCompilerPath
+  else
+    Result := ExtractFilePath(ParamStr(0));
   Result := GetDebugPath('Debug_KMCMPDLLPath', Result);
 end;
 


### PR DESCRIPTION
Adds the src build path in for kmcmpdll.dll for debugging purposes, when running from any subdirectory of the KEYMAN_ROOT path.

@keymanapp-test-bot skip