### PR TITLE
feat(common): ldml: import error messages from the compiler   🙀

### DIFF
--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -102,18 +102,18 @@ export default class LDMLKeyboardXMLSourceFileReader {
   }
 
   private resolveImports(obj: any, subtag: string) {
-    // first, the implied imports
+    // These are in reverse order, because the imports insert at the beginning of the array.
+    // first, the explicit imports
+    for (const asImport of ([...obj['import'] as LKImport[]].reverse())) {
+      this.resolveOneImport(obj, subtag, asImport);
+    }
+    // then, the implied imports
     if (subtag === 'keys') {
       // <import base="cldr" path="techpreview/keys-Latn-implied.xml"/>
       this.resolveOneImport(obj, subtag, {
         base: constants.cldr_import_base,
         path: constants.cldr_implied_keys_import
       });
-    }
-
-    // now, the explicit imports
-    for (const asImport of (obj['import'] as LKImport[])) {
-      this.resolveOneImport(obj, subtag, asImport);
     }
   }
 
@@ -142,7 +142,7 @@ export default class LDMLKeyboardXMLSourceFileReader {
       return;
     }
     // pull all children of importXml[subtag] into obj
-    for (const subsubtag of Object.keys(importRootNode)) { // e.g. <key/>
+    for (const subsubtag of Object.keys(importRootNode).reverse()) { // e.g. <key/>
       const subsubval = importRootNode[subsubtag];
       if (!Array.isArray(subsubval)) {
         // This is somewhat of an internal error, indicating that a non-mergeable XML file was imported

--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -32,6 +32,11 @@ export enum CompilerErrorNamespace {
  * Abstract interface for callbacks, to abstract out file i/o
  */
 export interface CompilerCallbacks {
+  /**
+   * Attempt to load a file. Return falsy if not found.
+   * @param baseFilename
+   * @param filename
+   */
   loadFile(baseFilename: string, filename: string | URL): Buffer;
   loadLdmlKeyboardSchema(): Buffer;
   reportMessage(event: CompilerEvent): void;

--- a/common/web/types/test/fixtures/import-minimal.xml
+++ b/common/web/types/test/fixtures/import-minimal.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="und" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+  <names>
+    <name value="Test Minimal Keyboard" />
+  </names>
+</keyboard>

--- a/common/web/types/test/fixtures/import-minimal1.xml
+++ b/common/web/types/test/fixtures/import-minimal1.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="und" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+  <names>
+    <name value="Test Minimal Keyboard" />
+  </names>
+  <keys>
+
+  </keys>
+</keyboard>

--- a/common/web/types/test/fixtures/import-minimal2.xml
+++ b/common/web/types/test/fixtures/import-minimal2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="und" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+  <names>
+    <name value="Test Minimal Keyboard" />
+  </names>
+  <keys>
+    <key id="a" to="å"/> <!-- override -->
+  </keys>
+</keyboard>

--- a/common/web/types/test/fixtures/import-symbols.xml
+++ b/common/web/types/test/fixtures/import-symbols.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="und" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+  <names>
+    <name value="Test Minimal Keyboard" />
+  </names>
+  <keys>
+    <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml"/>
+    <key id="zz" to="zz"/>
+    <key id="hash" to="##"/> <!-- override -->
+  </keys>
+</keyboard>

--- a/common/web/types/test/fixtures/invalid-conforms-to.xml
+++ b/common/web/types/test/fixtures/invalid-conforms-to.xml
@@ -4,7 +4,7 @@
   DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd"
   Disabling doctype for this invalid file, not used by compiler, and avoids complaints in IDEs etc.
 -->
-<keyboard locale="mt" conformsTo="nothing-anyone-ever-heard-of">
+<keyboard locale="mt" conformsTo="nothing-anyone-ever-heard-of"> <!-- invalid -->
   <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
 
   <names>

--- a/common/web/types/test/fixtures/invalid-import-base.xml
+++ b/common/web/types/test/fixtures/invalid-import-base.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+
+  <names>
+    <name value="TestKbd" />
+  </names>
+
+  <keys>
+    <import base="SOME_INVALID_BASE" path="abcd/keys-Zyyy-punctuation.xml"/> <!-- invalid -->
+    <key id="hmaqtugha" to="ħ" />
+    <key id="that" to="ថា" />
+  </keys>
+
+</keyboard>

--- a/common/web/types/test/fixtures/invalid-import-path.xml
+++ b/common/web/types/test/fixtures/invalid-import-path.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+
+  <names>
+    <name value="TestKbd" />
+  </names>
+
+  <keys>
+    <import base="cldr" path="techpreview/too/many/slashes/leading/to/nothing-Zxxx-does-not-exist.xml"/> <!-- invalid -->
+    <key id="hmaqtugha" to="ħ" />
+    <key id="that" to="ថា" />
+  </keys>
+
+</keyboard>

--- a/common/web/types/test/fixtures/invalid-import-readfail.xml
+++ b/common/web/types/test/fixtures/invalid-import-readfail.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+
+  <names>
+    <name value="TestKbd" />
+  </names>
+
+  <keys>
+    <import base="cldr" path="techpreview/none-Zxxx-does-not-exist.xml"/> <!-- invalid -->
+    <key id="hmaqtugha" to="ħ" />
+    <key id="that" to="ថា" />
+  </keys>
+
+</keyboard>

--- a/common/web/types/test/fixtures/invalid-import-wrongroot.xml
+++ b/common/web/types/test/fixtures/invalid-import-wrongroot.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+
+  <names>
+    <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml"/> <!-- wrong root! -->
+    <name value="TestKbd" />
+  </names>
+
+  <keys>
+    <key id="hmaqtugha" to="ħ" />
+    <key id="that" to="ថា" />
+  </keys>
+
+</keyboard>

--- a/common/web/types/test/helpers/index.ts
+++ b/common/web/types/test/helpers/index.ts
@@ -21,7 +21,7 @@ export function loadKeymanTouchLayoutCleanJsonSchema(): Buffer {
   return fs.readFileSync(new URL(path.join('..', '..', 'src', 'keyman-touch-layout.clean.spec.json'), import.meta.url));
 }
 
-export function loadFile(baseFilename: string, filename:string): Buffer {
+export function loadFile(baseFilename: string, filename: string | URL): Buffer {
   // TODO: translate filename based on the baseFilename
   return fs.readFileSync(filename);
 }

--- a/common/web/types/test/helpers/reader-callback-test.ts
+++ b/common/web/types/test/helpers/reader-callback-test.ts
@@ -41,6 +41,10 @@ class TestCompilerCallbacks implements CompilerCallbacks {
 
 export interface CompilationCase {
   /**
+   * If true, loading (validation) should fail
+   */
+  loadfail?: boolean;
+  /**
    * path to xml, such as 'sections/layr/invalid-case.xml'
    */
   subpath: string;
@@ -82,7 +86,11 @@ export function testReaderCases(cases : CompilationCase[]) {
       const data = loadFile(testcase.subpath, makePathToFixture(testcase.subpath));
       assert.ok(data, `reading ${testcase.subpath}`);
       const source = reader.load(data);
-      assert.ok(source, `loading ${testcase.subpath}`);
+      if (!testcase.loadfail) {
+        assert.ok(source, `loading ${testcase.subpath}`);
+      } else {
+        assert.notOk(source, `loading ${testcase.subpath} (expected failure)`);
+      }
       // special case for an expected exception
       if (testcase.throws) {
         assert.throws(() => reader.validate(source, loadLdmlKeyboardSchema()), testcase.throws);

--- a/common/web/types/test/helpers/reader-callback-test.ts
+++ b/common/web/types/test/helpers/reader-callback-test.ts
@@ -1,0 +1,109 @@
+import 'mocha';
+import {assert} from 'chai';
+import {loadLdmlKeyboardSchema, loadFile, makePathToFixture} from '../helpers/index.js';
+import LDMLKeyboardXMLSourceFileReader from '../../src/ldml-keyboard/ldml-keyboard-xml-reader.js';
+import { CompilerCallbacks, CompilerEvent } from '../../src/util/compiler-interfaces.js';
+import { LDMLKeyboardXMLSourceFile } from '../../src/ldml-keyboard/ldml-keyboard-xml.js';
+
+// TODO-LDML: this is largely a port from developer/src/kmc-keyboard/test/helpers/index.ts
+
+
+/**
+ * A CompilerCallbacks implementation for testing
+ */
+class TestCompilerCallbacks implements CompilerCallbacks {
+  loadLdmlKeyboardSchema(): Buffer {
+    return loadLdmlKeyboardSchema();
+  }
+  loadKvksJsonSchema(): Buffer {
+    throw new Error('loadKvksJsonSchema not implemented.');
+  }
+  clear() {
+    this.messages = [];
+  }
+  messages: CompilerEvent[] = [];
+  loadFile(baseFilename: string, filename: string | URL): Buffer {
+    try {
+      return loadFile(baseFilename, filename);
+    } catch(e) {
+      if (e.code === 'ENOENT') {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+  reportMessage(event: CompilerEvent): void {
+    // console.log(event.message);
+    this.messages.push(event);
+  }
+}
+
+export interface CompilationCase {
+  /**
+   * path to xml, such as 'sections/layr/invalid-case.xml'
+   */
+  subpath: string;
+  /**
+   * expected error messages. If falsy, expected to succeed. All must be present to pass.
+   */
+  errors?: CompilerEvent[];
+  /**
+   * expected warning messages. All must be present to pass.
+   */
+  warnings?: CompilerEvent[];
+  /**
+   * optional callback with the section
+   */
+  callback?: (data: Buffer, source: LDMLKeyboardXMLSourceFile, subpath: string, callbacks: TestCompilerCallbacks ) => void;
+  /**
+   * if present, expect compiler to throw (use .* to match all)
+   */
+  throws?: RegExp;
+}
+
+/**
+ * Run a bunch of cases
+ * @param cases cases to run
+ * @param compiler argument to loadSectionFixture()
+ * @param callbacks argument to loadSectionFixture()
+ */
+export function testReaderCases(cases : CompilationCase[]) {
+  // we need our own callbacks rather than using the global so messages don't get mixed
+  const callbacks = new TestCompilerCallbacks();
+  const reader = new LDMLKeyboardXMLSourceFileReader(callbacks);
+  for (let testcase of cases) {
+    const expectFailure = testcase.throws || !!(testcase.errors); // if true, we expect this to fail
+    const testHeading = expectFailure ? `should fail to load: ${testcase.subpath}`:
+                                        `should load: ${testcase.subpath}`;
+    it(testHeading, function () {
+      callbacks.clear();
+
+      const data = loadFile(testcase.subpath, makePathToFixture(testcase.subpath));
+      assert.ok(data, `reading ${testcase.subpath}`);
+      const source = reader.load(data);
+      assert.ok(source, `loading ${testcase.subpath}`);
+      // special case for an expected exception
+      if (testcase.throws) {
+        assert.throws(() => reader.validate(source, loadLdmlKeyboardSchema()), testcase.throws);
+      } else {
+        assert.doesNotThrow(() => reader.validate(source, loadLdmlKeyboardSchema()), `validating ${testcase.subpath}`);
+        // if we expected errors or warnings, show them
+        if (testcase.errors) {
+          assert.includeDeepMembers(callbacks.messages, testcase.errors, 'expected errors to be included');
+        }
+        if (testcase.warnings) {
+          assert.includeDeepMembers(callbacks.messages, testcase.warnings, 'expected warnings to be included');
+        } else if (!expectFailure) {
+          // no warnings, so expect zero messages
+          assert.strictEqual(callbacks.messages.length, 0, 'expected zero messages');
+        }
+
+        // run the user-supplied callback if any
+        if (testcase.callback) {
+          testcase.callback(data, source, testcase.subpath, callbacks);
+        }
+      }
+    });
+  }
+}

--- a/common/web/types/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
+++ b/common/web/types/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
@@ -1,6 +1,12 @@
+import { LKKey } from './../../src/ldml-keyboard/ldml-keyboard-xml';
 import 'mocha';
+import {assert} from 'chai';
 import { CommonTypesMessages } from '../../src/util/common-events.js';
 import { testReaderCases } from '../helpers/reader-callback-test.js';
+
+function pluckKeysFromKeybag(keys: LKKey[], ids: string[]) {
+  return keys.filter(({id}) => ids.indexOf(id) !== -1);
+}
 
 describe('ldml keyboard xml reader tests', function () {
   this.slow(500); // 0.5 sec -- json schema validation takes a while
@@ -21,24 +27,61 @@ describe('ldml keyboard xml reader tests', function () {
         instancePath: '/keyboard/conformsTo',
         keyword: 'enum',
         message: `must be equal to one of the allowed values`,
-        params: 'allowedValues="techPreview"',
+        params: 'allowedValues="techpreview"',
       })],
     },
     {
       subpath: 'import-minimal.xml',
-      // TODO-LDML: validate content
+      callback: (data, source, subpath, callbacks) => {
+        assert.ok(source?.keyboard?.keys);
+        const k = pluckKeysFromKeybag(source?.keyboard?.keys.key, ['a', 'b', 'c']);
+        assert.sameDeepOrderedMembers(k, [
+          {id: 'a', to: 'a'},
+          {id: 'b', to: 'b'},
+          {id: 'c', to: 'c'},
+        ]);
+      },
     },
     {
       subpath: 'import-minimal1.xml',
-      // TODO-LDML: validate content
+      callback: (data, source, subpath, callbacks) => {
+        assert.ok(source?.keyboard?.keys);
+        const k = pluckKeysFromKeybag(source?.keyboard?.keys.key, ['a', 'b', 'c']);
+        assert.sameDeepOrderedMembers(k, [
+          {id: 'a', to: 'a'},
+          {id: 'b', to: 'b'},
+          {id: 'c', to: 'c'},
+        ]);
+      },
     },
     {
       subpath: 'import-minimal2.xml',
-      // TODO-LDML: validate content
+      callback: (data, source, subpath, callbacks) => {
+        assert.ok(source?.keyboard?.keys);
+        const k = pluckKeysFromKeybag(source?.keyboard?.keys.key, ['a', 'b', 'c']);
+        assert.sameDeepOrderedMembers(k, [
+          {id: 'a', to: 'a'},
+          {id: 'b', to: 'b'},
+          {id: 'c', to: 'c'},
+          {id: 'a', to: 'å'}, // overridden
+        ]);
+      },
     },
     {
       subpath: 'import-symbols.xml',
-      // TODO-LDML: validate content
+      callback: (data, source, subpath, callbacks) => {
+        assert.ok(source?.keyboard?.keys);
+        const k = pluckKeysFromKeybag(source?.keyboard?.keys.key, ['a', 'b', 'c', 'zz', 'hash', 'hyphen']);
+        assert.sameDeepOrderedMembers(k, [
+          {id: 'a', to: 'a'},       // implied
+          {id: 'b', to: 'b'},
+          {id: 'c', to: 'c'},
+          {id: 'hash', to: '#'},    // imported symbols
+          {id: 'hyphen', to: '-'},
+          {id: 'zz', to: 'zz'},     // new key
+          {id: 'hash', to: '##'},   // override
+        ]);
+      },
     },
     {
       subpath: 'invalid-import-base.xml',

--- a/common/web/types/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
+++ b/common/web/types/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
@@ -85,6 +85,7 @@ describe('ldml keyboard xml reader tests', function () {
     },
     {
       subpath: 'invalid-import-base.xml',
+      loadfail: true,
       errors: [
         CommonTypesMessages.Error_ImportInvalidBase({
           base: 'SOME_INVALID_BASE',
@@ -95,6 +96,7 @@ describe('ldml keyboard xml reader tests', function () {
     },
     {
       subpath: 'invalid-import-path.xml',
+      loadfail: true,
       errors: [
         CommonTypesMessages.Error_ImportInvalidPath({
           base: null,
@@ -105,6 +107,7 @@ describe('ldml keyboard xml reader tests', function () {
     },
     {
       subpath: 'invalid-import-readfail.xml',
+      loadfail: true,
       errors: [
         CommonTypesMessages.Error_ImportReadFail({
           base: null,
@@ -115,6 +118,7 @@ describe('ldml keyboard xml reader tests', function () {
     },
     {
       subpath: 'invalid-import-wrongroot.xml',
+      loadfail: true,
       errors: [
         CommonTypesMessages.Error_ImportWrongRoot({
           base: null,

--- a/common/web/types/test/tsconfig.json
+++ b/common/web/types/test/tsconfig.json
@@ -11,7 +11,7 @@
   },
   "include": [
     "**/test-*.ts",
-    "./helpers/index.ts"
+    "./helpers/*.ts",
   ],
   "references": [
     { "path": "../../keyman-version/tsconfig.esm.json" },

--- a/developer/src/kmc-keyboard/src/compiler/compiler.ts
+++ b/developer/src/kmc-keyboard/src/compiler/compiler.ts
@@ -58,6 +58,10 @@ export default class Compiler {
   public load(filename: string): LDMLKeyboardXMLSourceFile | null {
     const reader = new LDMLKeyboardXMLSourceFileReader(this.callbacks);
     const data = this.callbacks.loadFile(filename, filename);
+    if(!data) {
+      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to read XML file'}));
+      return null;
+    }
     const source = reader.load(data);
     if(!source) {
       this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to load XML file'}));

--- a/developer/src/kmc-keyboard/test/helpers/index.ts
+++ b/developer/src/kmc-keyboard/test/helpers/index.ts
@@ -41,7 +41,15 @@ class TestCompilerCallbacks implements CompilerCallbacks {
   messages: CompilerEvent[] = [];
   loadFile(baseFilename: string, filename: string | URL): Buffer {
     // TODO: translate filename based on the baseFilename
-    return fs.readFileSync(filename);
+    try {
+      return fs.readFileSync(filename);
+    } catch(e) {
+      if (e.code === 'ENOENT') {
+        return null;
+      } else {
+        throw e;
+      }
+    }
   }
   reportMessage(event: CompilerEvent): void {
     // console.log(event.message);

--- a/developer/src/kmc/src/kmc.ts
+++ b/developer/src/kmc/src/kmc.ts
@@ -44,7 +44,15 @@ function exitDueToUsageError(message: string): never  {
 class NodeCompilerCallbacks implements CompilerCallbacks {
   loadFile(baseFilename: string, filename: string | URL): Buffer {
     // TODO: translate filename based on the baseFilename
-    return fs.readFileSync(filename);
+    try {
+      return fs.readFileSync(filename);
+    } catch(e) {
+      if (e.code === 'ENOENT') {
+        return null;
+      } else {
+        throw e;
+      }
+    }
   }
   reportMessage(event: CompilerEvent): void {
     console.log(kmc.CompilerMessages.severityName(event.code) + ' ' + event.code.toString(16) + ': ' + event.message);


### PR DESCRIPTION
For: #7534

- move the import related Errors into messages
- comprehensive test cases for import/implied

@keymanapp-test-bot skip