### PR TITLE
feat(developer): check for duplicated language codes in package editor and compiler

### DIFF
--- a/common/windows/delphi/packages/PackageInfo.pas
+++ b/common/windows/delphi/packages/PackageInfo.pas
@@ -337,6 +337,8 @@ type
     procedure SaveJSON(ARoot: TJSONObject); virtual;
     procedure LoadXML(ARoot: IXMLNode); virtual;
     procedure SaveXML(ARoot: IXMLNode); virtual;
+    function ContainsID(const id: string): Boolean;
+    function IndexOfID(const id: string): Integer;
   end;
 
   TPackageLexicalModel = class(TPackageBaseObject)
@@ -2261,6 +2263,21 @@ begin
 end;
 
 { TPackageKeyboardLanguageList }
+
+function TPackageKeyboardLanguageList.ContainsID(const id: string): Boolean;
+begin
+  Result := IndexOfID(id) >= 0;
+end;
+
+function TPackageKeyboardLanguageList.IndexOfID(const id: string): Integer;
+var
+  i: Integer;
+begin
+  for i := 0 to Count - 1 do
+    if SameText(Items[i].ID, id) then
+      Exit(i);
+  Result := -1;
+end;
 
 procedure TPackageKeyboardLanguageList.LoadJSON(ARoot: TJSONObject);
 var


### PR DESCRIPTION
Fixes #8119.

# User Testing

**GROUP_KEYBOARD:** Test with a keyboard package
**GROUP_LEXICAL_MODEL:** Test with a lexical model package

**TEST_PACKAGE_EDITOR_ADD:** In the keyboard/lm tab of the package editor, attempt to add two languages with the same BCP 47 tag. It should not add the second one.
**TEST_PACKAGE_EDITOR_EDIT:** In the keyboard/lm tab of the package editor, add a few different languages. Then, edit one of the languages to the same text as another one in the list. The language you edited should disappear from the list, and the selection should move to the duplicate.
**TEST_PACKAGE_COMPILE:** Go to the source tab of the package editor, and duplicate a `<Language>` tag in the `<Languages>` list for the keyboard or LM section of the file. Attempt to compile the package -- it should warn you that there are duplicated entries.