### PR TITLE
refactor(android/engine): Consolidate Keyboard picker intent 🛋

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1905,21 +1905,22 @@ public final class KMManager {
   }
 
   public static void showKeyboardPicker(Context context, KeyboardType kbType) {
-    if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-      Intent i = new Intent(context, KeyboardPickerActivity.class);
-      i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
-      i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      i.putExtra(KMKey_DisplayKeyboardSwitcher, false);
-      context.startActivity(i);
-    } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-      Intent i = new Intent(context, KeyboardPickerActivity.class);
-      i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
+    if (kbType == KeyboardType.KEYBOARD_TYPE_UNDEFINED) {
+      KMLog.LogError(TAG, String.format("showKeyboardPicker with invalid %s", kbType.toString()));
+      return;
+    }
+
+    Intent i = new Intent(context, KeyboardPickerActivity.class);
+    i.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT); // Replaces FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
+    i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);     // Required to call startActivity() from outside of an Activity context
+
+    if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       i.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
       i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-      i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      i.putExtra(KMKey_DisplayKeyboardSwitcher, true);
-      context.startActivity(i);
     }
+
+    i.putExtra(KMKey_DisplayKeyboardSwitcher, kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM);
+    context.startActivity(i);
   }
 
   public static void setKeyboardPickerFont(Typeface typeface) {


### PR DESCRIPTION
More KMManager refactoring for #7881 

This cleans up  KMManager.showKeyboardPicker()

From the Intent documentation, I also saw that [FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET](https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET) is deprecated in API 21 and replaced by FLAG_ACTIVITY_NEW_DOCUMENT.

## User Testing
Setup - Install the PR build of Keyman for Android

* **TEST_INAPP** - Verifies keyboard picker works for inapp keyboard
1. Launch Keyman for Android
2. Dismiss the "Get Started" menu
3. In the Keyman app, long-press on the globe button
4. Verify Keyboard Picker menu appears
5. Verify other system keyboards **do not** appear on the keyboard picker menu
6. Click the "i" icon to display keyboard info for sil_euro_latin


* **TEST_SYSTEM** - Verifies keyboard picker works for system keyboard
1. Launch Keyman for Android 
2. On the "Get Started" menu, enable Keyman as a system keyboard and set as the default system keyboard.
3. Dismiss the "Get Started" menu
4. Launch a separate app (e.g. Google Chrome) and select a text area for typing
5. When Keyman appears as a system keyboard, long-press on the globe key
6. Verify the keyboard picker menu appears
7. Verify other system keyboards **do** appear at the bottom of the keyboard picker menu
8..Click the "i" icon to display keyboard info for sil_euro_latin
