### PR TITLE
feat(common): ldml different hardware support 🙀

### DIFF
--- a/common/web/types/src/consts/virtual-key-constants.ts
+++ b/common/web/types/src/consts/virtual-key-constants.ts
@@ -1,6 +1,10 @@
 
 // Define standard keycode numbers (exposed for use by other modules)
-// TODO: merge with common\web\keyboard-processor\src\text\codes.ts
+// TODO-LDML: merge with common\web\keyboard-processor\src\text\codes.ts
+
+/**
+ * May include non-US virtual key codes
+ */
 export const USVirtualKeyCodes = {
   K_BKSP:8,
   K_TAB:9,
@@ -129,7 +133,9 @@ export const USVirtualKeyCodes = {
 
 const k = USVirtualKeyCodes;
 
-export const USVirtualKeyMap: number[][] = [
+export type KeyMap = number[][];
+
+export const USVirtualKeyMap: KeyMap = [
   // ` 1 2 3 4 5 6 7 8 9 0 - = [bksp]
   [ k.K_BKQUOTE, k.K_1, k.K_2, k.K_3, k.K_4, k.K_5, k.K_6, k.K_7, k.K_8, k.K_9, k.K_0, k.K_HYPHEN, k.K_EQUAL ],
   // [tab] Q W E R T Y U I O P [ ] \
@@ -142,11 +148,7 @@ export const USVirtualKeyMap: number[][] = [
   [ k.K_SPACE ],
 ];
 
-/**
- * TODO-LDML: WIP ISO layout for #7965
- * May not be correct to use US codes?
- */
-export const ISOVirtualKeyMap: number[][] = [
+export const ISOVirtualKeyMap: KeyMap = [
   // ` 1 2 3 4 5 6 7 8 9 0 - = [bksp]
   [ k.K_BKQUOTE, k.K_1, k.K_2, k.K_3, k.K_4, k.K_5, k.K_6, k.K_7, k.K_8, k.K_9, k.K_0, k.K_HYPHEN, k.K_EQUAL ],
   // [tab] Q W E R T Y U I O P [ ]
@@ -158,6 +160,19 @@ export const ISOVirtualKeyMap: number[][] = [
   // space
   [ k.K_SPACE ],
 ];
+
+/**
+ * Map from a hardware constnat to a keymap
+ * For the 'key' see constants.layr_list_hardware_map
+ */
+export const HardwareToKeymap: Map<string, KeyMap> = new Map(
+  [
+    ["us", USVirtualKeyMap],
+    ["iso", ISOVirtualKeyMap],
+    //TODO-LDML: jis #8161
+    //TODO-LDML: abnt2 #8161
+  ]
+);
 
 /**
  * Maps LDML VKey Names from CLDR VKey Enum in TR35 to Keyman virtual key codes

--- a/common/web/types/src/consts/virtual-key-constants.ts
+++ b/common/web/types/src/consts/virtual-key-constants.ts
@@ -162,7 +162,7 @@ export const ISOVirtualKeyMap: KeyMap = [
 ];
 
 /**
- * Map from a hardware constnat to a keymap
+ * Map from a hardware constant to a keymap
  * For the 'key' see constants.layr_list_hardware_map
  */
 export const HardwareToKeymap: Map<string, KeyMap> = new Map(

--- a/core/tests/unit/ldml/keyboards/k_011_mt_iso.xml
+++ b/core/tests/unit/ldml/keyboards/k_011_mt_iso.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+@@keys: [SHIFT K_B][K_O][K_N][K_LBRKT][K_U][K_SPACE][K_S][K_A][K_RBRKT][K_RBRKT][K_A]
+@@expected: \u0042\u006f\u006e\u0121\u0075\u0020\u0073\u0061\u0127\u0127\u0061
+
+Note:
+    "Bonġu saħħa".split('').map(s=>`\\u${s.codePointAt(0).toString(16)}`).join('')
+Gets part of the way,
+
+Exact copy of mt.xml from CLDR, but with:
+  - an updated DTD path
+  - test case
+  - changed 'altR-shift' to 'altR shift'
+-->
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+    <locales>
+        <!-- English is also an official language in Malta.-->
+        <locale id="en" />
+    </locales>
+    <info author="Steven R. Loomis" normalization="NFC" layout="QWERTY" indicator="MT" />
+
+    <names>
+        <name value="Maltese (48-key)" />
+        <!-- <name value="MSA 100:2002" /> -->
+    </names>
+
+    <keys>
+        <!-- imports -->
+        <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml"/>
+
+        <!-- accent grave -->
+        <key id="a-grave" to="à" />
+        <key id="A-grave" to="À" />
+        <key id="e-grave" to="è" />
+        <key id="E-grave" to="È" />
+        <key id="i-grave" to="ì" />
+        <key id="I-grave" to="Ì" />
+        <key id="o-grave" to="ò" />
+        <key id="O-grave" to="Ò" />
+        <key id="u-grave" to="ù" />
+        <key id="U-grave" to="Ù" />
+
+        <!-- tikka and maqtua -->
+        <key id="c-tikka" to="ċ" />
+        <key id="C-tikka" to="Ċ" />
+        <key id="g-tikka" to="ġ" />
+        <key id="G-tikka" to="Ġ" />
+        <key id="h-maqtugha" to="ħ" /> <!-- maqtugħa, i.e. cut -->
+        <key id="H-maqtugha" to="Ħ" /> <!-- maqtugħa, i.e. cut -->
+        <key id="z-tikka" to="ż" />
+        <key id="Z-tikka" to="Ż" />
+
+        <!-- Cedilla -->
+        <key id="c-cedilla" to="ç" />
+    </keys>
+
+    <layers form="hardware" hardware="iso">
+        <layer modifier="none">
+            <row keys="c-tikka 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+            <row keys="q w e r t y u i o p g-tikka h-maqtugha" />
+            <row keys="a s d f g h j k l semi-colon hash" />
+            <row keys="z-tikka z x c v b n m comma period slash" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifier="shift">
+            <row keys="C-tikka bang double-quote euro dollar percent caret amp open-paren close-paren underscore plus" />
+            <row keys="Q W E R T Y U I O P G-tikka H-maqtugha" />
+            <row keys="A S D F G H J K L colon at tilde" />
+            <row keys="Z-tikka Z X C V B N M open-angle close-angle question" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifier="altR">
+            <row keys="grave gap gap pound gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap e-grave gap gap gap u-grave i-grave o-grave gap open-square close-square" />
+            <row keys="a-grave gap gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="backslash gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifier="altR shift">
+            <row keys="not gap gap gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap E-grave gap gap gap U-grave I-grave O-grave gap open-curly close-curly" />
+            <row keys="A-grave gap gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="pipe gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="space" />
+        </layer>
+    </layers>
+</keyboard>

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -12,6 +12,7 @@ tests = [
   'k_003_transform',
   'k_004_tinyshift',
   'k_010_mt',
+  'k_011_mt_iso',
   'k_100_keytest',
   'k_101_keytest',
   'k_102_keytest',

--- a/developer/src/kmc-keyboard/src/compiler/messages.ts
+++ b/developer/src/kmc-keyboard/src/compiler/messages.ts
@@ -16,7 +16,7 @@ export class CompilerMessages {
   static Error_HardwareLayerHasTooManyRows = () => m(this.ERROR_HardwareLayerHasTooManyRows, `'hardware' layer has too many rows`);
   static ERROR_HardwareLayerHasTooManyRows = SevError | 0x0003;
 
-  static Error_RowOnHardwareLayerHasTooManyKeys = (o:{row: number}) =>  m(this.ERROR_RowOnHardwareLayerHasTooManyKeys, `Row #${o.row} on 'hardware' layer has too many keys`);
+  static Error_RowOnHardwareLayerHasTooManyKeys = (o:{row: number, hardware: string}) =>  m(this.ERROR_RowOnHardwareLayerHasTooManyKeys, `Row #${o.row} on 'hardware' ${o.hardware} layer has too many keys`);
   static ERROR_RowOnHardwareLayerHasTooManyKeys = SevError | 0x0004;
 
   static Error_KeyNotFoundInKeyBag = (o:{keyId: string, col: number, row: number, layer: string, form: string}) =>
@@ -86,6 +86,10 @@ export class CompilerMessages {
   static Error_InvalidHardware = (o:{hardware: string}) => m(this.ERROR_InvalidHardware,
     `layers has invalid value hardware=${o.hardware}`);
   static ERROR_InvalidHardware = SevError | 0x0015;
+
+  static Error_InvalidModifier = (o:{layer: string, modifier: string}) => m(this.ERROR_InvalidModifier,
+    `layer has invalid modifier='${o.modifier}' on layer id=${o.layer}`);
+  static ERROR_InvalidModifier = SevError | 0x0016;
 
   static severityName(code: number): string {
     let severity = code & CompilerErrorSeverity.Severity_Mask;

--- a/developer/src/kmc-keyboard/src/compiler/visual-keyboard-compiler.ts
+++ b/developer/src/kmc-keyboard/src/compiler/visual-keyboard-compiler.ts
@@ -48,7 +48,7 @@ export default class VisualKeyboardCompiler {
           flags: VisualKeyboard.VisualKeyboardKeyFlags.kvkkUnicode,
           shift: shift,
           text: keydef.to, // TODO-LDML: displays
-          vkey: Constants.USVirtualKeyMap[y][x]
+          vkey: Constants.USVirtualKeyMap[y][x] // TODO-LDML: #7965  US-only
         });
       }
     }

--- a/developer/src/kmc-keyboard/src/util/util.ts
+++ b/developer/src/kmc-keyboard/src/util/util.ts
@@ -76,3 +76,19 @@ export function translateLayerAttrToModifier(layer: LDMLKeyboard.LKLayer) : numb
   // TODO-LDML: other modifiers, other ids?
   return constants.keys_mod_none;
 }
+
+/**
+ * @param modifier modifier sequence such as undefined, "none", "shift altR" etc
+ * @returns true if valid
+ */
+export function validModifier(modifier?: string) : boolean {
+  if (!modifier) return true;  // valid to have no modifier, == none
+  for (let str of modifier.split(' ')) {
+    if (!constants.keys_mod_map.has(str)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+

--- a/developer/src/kmc-keyboard/test/fixtures/sections/keys/hardware_iso.xml
+++ b/developer/src/kmc-keyboard/test/fixtures/sections/keys/hardware_iso.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <names>
+    <name value="hardware-minimal" />
+  </names>
+
+  <keys>
+    <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml"/>
+  </keys>
+
+  <layers form="hardware" hardware="iso">
+    <layer id="base" modifier="none">
+      <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+      <row keys="q w e r t y u i o p open-square close-square" />
+      <row keys="a s d f g h j k l semi-colon apos" />
+      <row keys="backslash z x c v b n m comma period slash" />
+      <row keys="space" />
+    </layer>
+  </layers>
+</keyboard>

--- a/developer/src/kmc-keyboard/test/fixtures/sections/keys/hardware_us.xml
+++ b/developer/src/kmc-keyboard/test/fixtures/sections/keys/hardware_us.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="mt" conformsTo="techpreview">
+  <names>
+    <name value="hardware-minimal" />
+  </names>
+
+  <keys>
+    <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml"/>
+  </keys>
+
+  <layers form="hardware" hardware="us">
+    <layer id="base" modifier="none">
+      <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+      <row keys="q w e r t y u i o p open-square close-square backslash" />
+      <row keys="a s d f g h j k l semi-colon apos" />
+      <row keys="z x c v b n m comma period slash" />
+      <row keys="space" />
+    </layer>
+  </layers>
+</keyboard>

--- a/developer/src/kmc-keyboard/test/fixtures/sections/keys/invalid-bad-modifier.xml
+++ b/developer/src/kmc-keyboard/test/fixtures/sections/keys/invalid-bad-modifier.xml
@@ -9,7 +9,7 @@
   <keys />
 
   <layers form="hardware" hardware="us">
-    <layer id="base" modifier="altR-shift"> <!-- invalid, should be "altR-shift" -->
+    <layer id="base" modifier="altR-shift"> <!-- invalid, should be "altR shift" -->
       <row keys="a b c" />
     </layer>
   </layers>

--- a/developer/src/kmc-keyboard/test/fixtures/sections/keys/invalid-bad-modifier.xml
+++ b/developer/src/kmc-keyboard/test/fixtures/sections/keys/invalid-bad-modifier.xml
@@ -6,13 +6,11 @@
     <name value="keys-minimal" />
   </names>
 
-  <keys>
-    <key id="grave" to="\u{1faa6}" />
-  </keys>
+  <keys />
 
   <layers form="hardware" hardware="us">
-    <layer id="base">
-      <row keys="grave" />
+    <layer id="base" modifier="altR-shift"> <!-- invalid, should be "altR-shift" -->
+      <row keys="a b c" />
     </layer>
   </layers>
 

--- a/developer/src/kmc-keyboard/test/test-utils.ts
+++ b/developer/src/kmc-keyboard/test/test-utils.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import {assert} from 'chai';
-import { isValidEnumValue, calculateUniqueKeys, allUsedKeyIdsInLayers, translateLayerAttrToModifier } from '../src/util/util.js';
+import { isValidEnumValue, calculateUniqueKeys, allUsedKeyIdsInLayers, translateLayerAttrToModifier, validModifier } from '../src/util/util.js';
 import { constants } from "@keymanapp/ldml-keyboard-constants";
 import { LDMLKeyboard } from '@keymanapp/common-types';
 
@@ -150,6 +150,22 @@ describe('test of util/util.ts', () => {
         };
         assert.equal(translateLayerAttrToModifier(layer),
           constants.keys_mod_map.get(str) | constants.keys_mod_altL, str);
+      }
+    });
+  });
+  describe('isValidModifier()', () => {
+    it('should treat falsy values as valid', () => {
+      for(let str of [
+        null, undefined, '', 'none'
+      ]) {
+        assert.ok(validModifier(str), `validModifier(${JSON.stringify(str)})`);
+      }
+    });
+    it('should treat bad values as invalid', () => {
+      for(let str of [
+        'asdfasdf', 'shift asdfasdf', 'altR-shift', 'altR-shift shift'
+      ]) {
+        assert.notOk(validModifier(str), `validModifier(${JSON.stringify(str)})`);
       }
     });
   });


### PR DESCRIPTION
### REDO OF #8162

- add HardwareToKeymap in common/web/types
- add a mt-iso keyboard, very close to stock mt.xml
- add machinery for parsing modifier key sequences
- more test machinery
- add assertions against invalid modifier sequences

Fixes: #7965

@keymanapp-test-bot skip
