### PR TITLE
fix(developer): Select BCP47 Code dialog inconsistencies

### DIFF
--- a/common/windows/delphi/general/BCP47Tag.pas
+++ b/common/windows/delphi/general/BCP47Tag.pas
@@ -124,7 +124,20 @@ var
 begin
   if not FIsValid and FIsValidated then
   begin
-    msg := '''' + OriginalTag + ''' is not a valid BCP 47 tag';
+    if OriginalTag = '' then
+    begin
+      msg := 'A valid BCP 47 tag must contain at least a language subtag';
+    end
+    else
+    begin
+      msg := '''' + OriginalTag + ''' is not a valid BCP 47 tag';
+    end;
+    Exit(False);
+  end;
+
+  if Tag = '' then
+  begin
+    msg := 'A valid BCP 47 tag must contain at least a language subtag';
     Exit(False);
   end;
 

--- a/developer/src/tike/dialogs/languages/Keyman.Developer.UI.UfrmSelectBCP47Language.pas
+++ b/developer/src/tike/dialogs/languages/Keyman.Developer.UI.UfrmSelectBCP47Language.pas
@@ -55,6 +55,7 @@ type
   private
     tag: TBCP47Tag;
     FCustomLanguageName: Boolean;
+    procedure EnableControls;
     function GetLanguageID: string;
     function GetLanguageName: string;
     procedure RefreshLanguageName;
@@ -106,6 +107,8 @@ begin
   PopulateComboBoxFromDict(cbLanguageTag, TLanguageCodeUtils.BCP47Languages);
   PopulateComboBoxFromDict(cbScriptTag, TLanguageCodeUtils.BCP47Scripts);
   PopulateComboBoxFromDict(cbRegionTag, TLanguageCodeUtils.BCP47Regions);
+  RefreshLanguageName;
+  EnableControls;
 end;
 
 procedure TfrmSelectBCP47Language.FormDestroy(Sender: TObject);
@@ -144,11 +147,18 @@ procedure TfrmSelectBCP47Language.cmdResetLanguageNameClick(Sender: TObject);
 begin
   editLanguageName.Text := LookupLanguageName;
   FCustomLanguageName := False;
+  EnableControls;
 end;
 
 procedure TfrmSelectBCP47Language.editLanguageNameChange(Sender: TObject);
 begin
   FCustomLanguageName := True;
+  EnableControls;
+end;
+
+procedure TfrmSelectBCP47Language.EnableControls;
+begin
+  cmdResetLanguageName.Enabled := FCustomLanguageName;
 end;
 
 procedure TfrmSelectBCP47Language.cbLanguageTagChange(Sender: TObject);
@@ -175,6 +185,7 @@ begin
   end;
   FCustomLanguageName := False; // Always reset when entering a language tag.
   RefreshLanguageName;
+  EnableControls;
 end;
 
 procedure TfrmSelectBCP47Language.cbRegionTagChange(Sender: TObject);
@@ -213,6 +224,7 @@ begin
   begin
     editLanguageName.Text := LookupLanguageName;
     FCustomLanguageName := False;
+    EnableControls;
   end;
   cmdOK.Enabled := tag.IsValid(True, msg);
   if not cmdOK.Enabled
@@ -228,12 +240,14 @@ begin
   cbScriptTag.Text := tag.Script;
   RefreshLanguageName;
   FCustomLanguageName := editLanguageName.Text <> LookupLanguageName;
+  EnableControls;
 end;
 
 procedure TfrmSelectBCP47Language.SetLanguageName(const Value: string);
 begin
   editLanguageName.Text := Value;
   FCustomLanguageName := editLanguageName.Text <> LookupLanguageName;
+  EnableControls;
 end;
 
 end.


### PR DESCRIPTION
Fixes #8157.

There are some limitations in this dialog as it stands; we will rework it completely when we revisit BCP 47 tagging.

However, for now, this addresses some strange behaviours around the Reset button and the displayed output:

* The Reset button will only be enabled if you change the text in the Language Name field.
* The messaging around a missing language subtag is clearer -- tells the user that they need to enter something there.
* The Reset button will now never insert default text strings into the Language Name field.

One example of something that is slightly weird, is if you enter a two-letter region subtag into the script box, it will show what looks like a valid tag in the output box (e.g. `en-Au`), but it will be considered invalid, because that two letter subtag needs to be entered into the region box.

# User Testing

* TEST_8157: Please re-test the scenarios documented in #8157.