### PR TITLE
fix(linux): Fix autopkgtests 🍒

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -37,8 +37,8 @@ Build-Depends:
  metacity,
  gawk,
 Standards-Version: 4.6.1
-Vcs-Git: https://github.com/keymanapp/keyman.git [linux/debian]
-Vcs-Browser: https://github.com/keymanapp/keyman/tree/master/linux/debian
+Vcs-Git: https://github.com/keymanapp/keyman.git -b stable-16.0 [linux/debian]
+Vcs-Browser: https://github.com/keymanapp/keyman/tree/stable-16.0/linux/debian
 Homepage: https://www.keyman.com
 Rules-Requires-Root: binary-targets
 

--- a/linux/debian/tests/control
+++ b/linux/debian/tests/control
@@ -1,2 +1,4 @@
 Tests: test-build
-Depends: @, build-essential
+Depends: @,
+ build-essential,
+ pkg-config,

--- a/linux/debian/tests/test-build
+++ b/linux/debian/tests/test-build
@@ -7,7 +7,7 @@ set -e
 
 WORKDIR=$(mktemp -d)
 trap "rm -rf $WORKDIR" 0 INT QUIT ABRT PIPE TERM
-cd $WORKDIR
+cd "$WORKDIR"
 
 # Test all include files are available
 cat <<EOF > keymantest.c
@@ -15,7 +15,7 @@ cat <<EOF > keymantest.c
 km_kbp_context c;
 EOF
 
-gcc keymantest.c `pkg-config --cflags --libs keyman_kmn_processor`
+gcc keymantest.c "$(pkg-config --cflags --libs keyman_kmn_processor)"
 echo "build 1: OK"
 
 # Test pkg-config file - include without path
@@ -24,5 +24,5 @@ cat <<EOF > keymantest.c
 km_kbp_context c;
 EOF
 
-gcc keymantest.c `pkg-config --cflags --libs keyman_kmn_processor`
+gcc keymantest.c "$(pkg-config --cflags --libs keyman_kmn_processor)"
 echo "build 2: OK"


### PR DESCRIPTION
Autopkgtests couldn't find pkg-config, so this change adds that as test dependency.

(🍒 picked from PR #8180 )

@keymanapp-test-bot skip