### PR TITLE
chore(linux): Update changelog from Debian

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,11 @@
+keyman (16.0.138-2) unstable; urgency=medium
+
+  * Team upload
+  * debian/tests/control: Added missing autopkgtest dependency on
+    pkg-config (closes: #1030815).
+
+ -- Gunnar Hjalmarsson <gunnarhj@debian.org>  Tue, 07 Feb 2023 20:34:35 +0100
+
 keyman (16.0.138-1) unstable; urgency=medium
 
   [ Jelmer Vernooĳ ]

--- a/linux/debian/tests/control
+++ b/linux/debian/tests/control
@@ -1,2 +1,2 @@
 Tests: test-build
-Depends: @, build-essential
+Depends: @, build-essential, pkg-config


### PR DESCRIPTION
This overlaps with PR #8180, but it updates the changelog to a patched version on Debian, so we still need this change.

@keymanapp-test-bot skip