### PR TITLE
chore(common): automatically apply _builder_check_color

### DIFF
--- a/common/predictive-text/build.sh
+++ b/common/predictive-text/build.sh
@@ -22,8 +22,6 @@ cd "$(dirname "$THIS_SCRIPT")"
 
 ################################ Main script ################################
 
-builder_check_color "$@"
-
 # TODO: once these modules are builder-based, reference here too:
 #  "@../models/templates" \
 #  "@../models/types" \

--- a/common/web/input-processor/build.sh
+++ b/common/web/input-processor/build.sh
@@ -16,8 +16,6 @@ cd "$(dirname "$THIS_SCRIPT")"
 
 ################################ Main script ################################
 
-builder_check_color "$@"
-
 # TODO: for predictive-text, we only need :headless, perhaps we should be splitting modules?
 # TODO: remove :tools once kmlmc is a dependency for test:module
 

--- a/common/web/keyboard-processor/build.sh
+++ b/common/web/keyboard-processor/build.sh
@@ -17,10 +17,6 @@ cd "$THIS_SCRIPT_PATH"
 
 ################################ Main script ################################
 
-# Ensures color var use in `builder_describe`'s argument respects the specified
-# --color/--no-color option.
-builder_check_color "$@"
-
 builder_describe \
   "Compiles the web-oriented utility function module." \
   "@../recorder  test" \

--- a/resources/build/build-utils.md
+++ b/resources/build/build-utils.md
@@ -216,21 +216,6 @@ The following parameters are pre-defined and should not be overridden:
 
 # Builder API functions and variables
 
-
-## `builder_check_color` function
-
-If you wish to provide [formatting variables] in your [`builder_describe`] call, you
-will need to use `builder_check_color` first. This function takes the same
-parameters as [`builder_parse`].
-
-### Usage
-
-```bash
-builder_check_color "$@"
-builder_describe "sample" \
-  "--ci    For use with action $(builder_term test) - emits CI-friendly test reports"
-```
-
 ## `builder_describe` function
 
 Describes a build script, defines available parameters and their meanings. Use
@@ -526,13 +511,13 @@ also print a log message indicating that the action has started, for example:
 
 ## `builder_term` function
 
-Emits the parameters passed to the function, wrapped with `$BUILDER_TERM_START`
-and `$BUILDER_TERM_END`.
+Emits the parameters passed to the function, wrapped with the helper function
+`builder_term`, which wraps the passed string with `$BUILDER_TERM_START` and
+`$BUILDER_TERM_END`, e.g.: `$(builder_term text)`.
 
 ### Usage
 
 ```bash
-builder_check_color "$@"
 builder_describe "sample" \
   "--ci    For use with action $(builder_term test) - emits CI-friendly test reports"
 ```
@@ -588,7 +573,6 @@ Note: it is recommended that you use `$(builder_term text)` instead of
 `${BUILDER_TERM_START}text${BUILDER_TERM_END}`.
 
 [standard builder parameters]: #standard-builder-parameters
-[`builder_check_color`]: #buildercheckcolor-function
 [`builder_describe`]: #builderdescribe-function
 [`builder_display_usage`]: #builderdisplayusage-function
 [`$builder_extra_params`]: #builderextraparams-variable

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -19,7 +19,7 @@ function _builder_init() {
   _builder_findRepoRoot
   _builder_setBuildScriptIdentifiers
 
-  if [[ -n "$TERM" ]] && [[ "$TERM" != "dumb" ]] && [[ "$TERM" != "unknown" ]]; then
+  if [[ -n "$TERM" ]] && [[ "$TERM" != "dumb" ]] && [[ "$TERM" != "unknown" ]] && [ -t 1 ]; then
     builder_use_color true
   else
     builder_use_color false
@@ -673,16 +673,14 @@ _builder_parameter_error() {
 
 }
 
-# Pre-initializes the color setting based on the options specified to a
-# a build.sh script, parsing the command line to do so.  This is only
-# needed if said script wishes to use this script's defined colors while
-# respecting the options provided by the script's caller.
 #
-# Usage:
-#   builder_check_color "$@"
+# Pre-initializes the color setting based on the options specified to a
+# a build.sh script. This is called automatically during init.
+#
 # Parameters
-#   1: $@         all command-line arguments (as with builder_parse)
-builder_check_color() {
+#   1: "$@"         all command-line arguments
+#
+_builder_check_color() {
   # Process command-line arguments
   while [[ $# -gt 0 ]] ; do
     local key="$1"
@@ -1308,3 +1306,4 @@ _builder_has_function_been_called() {
 # Initialize builder once all functions are declared
 #
 _builder_init
+_builder_check_color "$@"

--- a/web/build.sh
+++ b/web/build.sh
@@ -85,8 +85,6 @@ compilecmd="$compiler"
 PREDICTIVE_TEXT_SOURCE="../common/predictive-text/unit_tests/in_browser/resources/models/simple-trie.js"
 PREDICTIVE_TEXT_OUTPUT="src/test/manual/web/prediction-ui/simple-en-trie.js"
 
-builder_check_color "$@"
-
 builder_describe "Builds Keyman Engine for Web (KMW)." \
   "@../common/web/keyman-version build" \
   "@../common/web/input-processor build" \

--- a/web/src/engine/build.sh
+++ b/web/src/engine/build.sh
@@ -81,8 +81,6 @@ PATH="../../../node_modules/.bin:$PATH"
 compiler="npm run tsc --"
 compilecmd="$compiler"
 
-builder_check_color "$@"
-
 builder_describe "Builds engine modules for Keyman Engine for Web (KMW)." \
   "@../../../common/web/keyman-version build:main" \
   "@../../../common/web/input-processor build:main" \

--- a/web/test.sh
+++ b/web/test.sh
@@ -16,8 +16,6 @@ cd "$THIS_SCRIPT_PATH"
 
 ################################ Main script ################################
 
-builder_check_color "$@"
-
 builder_describe "Runs the Keyman Engine for Web unit-testing suites" \
   "@./src/tools/testing/recorder test:engine" \
   "@./src/engine" \


### PR DESCRIPTION
`builder_check_color()` is now an internal function, called automatically, and should never need to be called from a `build.sh` script. All scripts updated accordingly.

@keymanapp-test-bot skip