### PR TITLE
chore(common): Report status if no platform needs build

### DIFF
--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -176,11 +176,21 @@ while IFS= read -r line; do
 done <<< "$prfiles"
 
 debug_echo "Build platforms: ${build_platforms[*]}"
-#
-# Start the test builds
-#
 
-echo ". Start test builds"
-triggerTestBuilds "`echo ${build_platforms[@]}`" "$PRNUM"
+if (( ${#build_platforms[@]} > 0)); then
+  #
+  # Start the test builds
+  #
+  echo ". Start test builds"
+  triggerTestBuilds "`echo ${build_platforms[@]}`" "$PRNUM"
+else
+  echo ". No builds to start"
+  curl --silent --write-out '\n' \
+    --request POST \
+    --header "Accept: application/vnd.github+json" \
+    --header "Authorization: token $GITHUB_TOKEN" \
+    --data '{"state":"success","description":"Skipping since no platform builds necessary","context":"Test Build (Keyman)"}' \
+    "https://api.github.com/repos/keymanapp/keyman/statuses/${BUILD_VCS_NUMBER}"
+fi
 
 exit 0


### PR DESCRIPTION
This works around a problem where status.keyman.com keeps a PR in the "Waiting for build" status because no status messages appear in the PR because no files changed that affect any platform (e.g. changes in GHA or [documentation](https://github.com/keymanapp/keyman/pull/8202)) which causes no platform builds to be triggered.

**Edit:** #8209 is no longer an example where this happens because I had to change additional files that triggered a build.

@keymanapp-test-bot skip