### PR TITLE
fix(windows): use min-width allow to expand

### DIFF
--- a/windows/src/desktop/kmshell/xml/installkeyboard.css
+++ b/windows/src/desktop/kmshell/xml/installkeyboard.css
@@ -76,7 +76,7 @@ div {
   font-weight: bold;
   font-size: 13.3px;
   padding: 2px;
-  width: 76px; background: #cccccc; text-align: center;
+  min-width: 76px; background: #cccccc; text-align: center;
   top: -2px; margin-left: -2px;
   border-left: solid 2px #888888;
   border-right: solid 2px #888888;


### PR DESCRIPTION
Fixes #8077 

Changed `#tabs div` in `installkeyboards.css` from using a fixed width to min-width this allows the tab label to grow to accommodate much longer strings. There is plenty of horizontal real estate, no need to wrap the text.


# User Testing

## TEST_README_TAB

1. Install Keyman from this PR
2. Open Keyman Configuration dialog.
3. Change the UI language into 'Kannada'.
4. Click the 'Download keyboard' button.
5. In Download Keyboard From keyman.com dialog, enter 'Khmer_Angkor' in the Keyboard search bar.
6. Click the 'Khmer Angkor' language from the results.
7. Click 'Khmer Angkor' link.
8. Click Install Keyboard button.
9. Here, I noticed that the Readme label name no longer wraps and the the tab is properly aligned containing the full text.





Expected behavior
Kannada 'Readme' label name should appear inside the label.
