### PR TITLE
chore(linux): Exclude autopkg tests on s390x

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,10 @@
+keyman (16.0.138-4) unstable; urgency=medium
+
+  * Team upload
+  * debian/tests/control: Don't run autopkgtest on s390x
+
+ -- Gunnar Hjalmarsson <gunnarhj@ubuntu.com>  Sat, 11 Feb 2023 18:39:13 +0100
+
 keyman (16.0.138-3) unstable; urgency=medium
 
   * debian/tests/test-build: Fix autopkgtests

--- a/linux/debian/tests/control
+++ b/linux/debian/tests/control
@@ -2,3 +2,4 @@ Tests: test-build
 Depends: @,
  build-essential,
  pkg-config,
+Architecture: amd64 arm64 armel armhf i386 mips64el mipsel ppc64el riscv64


### PR DESCRIPTION
We don't build the binaries on s390x so it doesn't make sense trying to run the autopkg tests on s390x. This change imports the changes made on Debian in pkg version 16.0.138-4.

Co-authored-by: Gunnar Hjalmarsson <gunnarhj@ubuntu.com>

@keymanapp-test-bot skip