### PR TITLE
feat(developer): ldml emit test data from kmc, integrate into core 🙀

### DIFF
--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -39,6 +39,7 @@ else
   # We need the schema file at runtime and bundled, so always copy it for all actions except `clean`
   mkdir -p "$THIS_SCRIPT_PATH/build/src/"
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/"
+  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json" "$THIS_SCRIPT_PATH/build/src/"
   cp "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json" "$THIS_SCRIPT_PATH/build/src/"
   cp "$KEYMAN_ROOT/common/schemas/keyman-touch-layout/keyman-touch-layout.clean.spec.json" "$THIS_SCRIPT_PATH/build/src/"
   # Store CLDR imports

--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -10,6 +10,7 @@ export { default as KvksFileReader } from './kvk/kvks-file-reader.js';
 export { default as KvkFileWriter } from './kvk/kvk-file-writer.js';
 
 export * as LDMLKeyboard from './ldml-keyboard/ldml-keyboard-xml.js';
+export { LDMLKeyboardTestDataXMLSourceFile } from './ldml-keyboard/ldml-keyboard-testdata-xml';
 export { default as LDMLKeyboardXMLSourceFileReader } from './ldml-keyboard/ldml-keyboard-xml-reader.js';
 
 export * as Constants from './consts/virtual-key-constants.js';

--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -39,6 +39,7 @@ export interface CompilerCallbacks {
    */
   loadFile(baseFilename: string, filename: string | URL): Buffer;
   loadLdmlKeyboardSchema(): Buffer;
+  loadLdmlKeyboardTestSchema(): Buffer;
   reportMessage(event: CompilerEvent): void;
   loadKvksJsonSchema(): Buffer;
 };

--- a/common/web/types/test/helpers/reader-callback-test.ts
+++ b/common/web/types/test/helpers/reader-callback-test.ts
@@ -8,11 +8,13 @@ import { LDMLKeyboardTestDataXMLSourceFile } from '../ldml-keyboard/ldml-keyboar
 
 // TODO-LDML: this is largely a port from developer/src/kmc-keyboard/test/helpers/index.ts
 
-
 /**
  * A CompilerCallbacks implementation for testing
  */
 class TestCompilerCallbacks implements CompilerCallbacks {
+  loadLdmlKeyboardTestSchema(): Buffer {
+    return loadLdmlKeyboardTestDataSchema();
+  }
   loadLdmlKeyboardSchema(): Buffer {
     return loadLdmlKeyboardSchema();
   }

--- a/core/tests/unit/ldml/keyboards/k_001_tiny-test.xml
+++ b/core/tests/unit/ldml/keyboards/k_001_tiny-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboardTest SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboardTest.dtd">
+<keyboardTest conformsTo="techpreview">
+  <info keyboard="k_001_tiny.xml" author="srl295" name="k_001_tiny" />
+  <repertoire chars="[ħ ថា]" name="our little language" />
+  <tests name="tiny-tests">
+    <test name="tiny-test">
+      <startContext to=""/> <!-- empty start context -->
+      <keystroke key="hmaqtugha"/>
+      <keystroke key="that"/>
+      <keystroke key="hmaqtugha"/>
+      <check result="ħថាħ"/>
+    </test>
+  </tests>
+</keyboardTest>

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -4,10 +4,16 @@
 # Authors:      Marc Durdin
 #
 
+
+# These tests have a k_001_tiny-test.xml file as well.
+
+tests_with_testdata = [
+  'k_001_tiny',
+]
+
 tests = [
 # disabling 000 until we have updates to core or to the keyboard so that it passes
 #  'k_000_null_keyboard',
-  'k_001_tiny',
   'k_002_tinyu32',
   'k_003_transform',
   'k_004_tinyshift',
@@ -17,6 +23,8 @@ tests = [
   'k_101_keytest',
   'k_102_keytest',
 ]
+
+tests += tests_with_testdata
 
 # Setup kmc
 
@@ -36,5 +44,13 @@ foreach kbd : tests
     command: kmc_cmd + ['@INPUT@', '--out-file', '@OUTPUT@'],
     output: kbd + '.kmx',
     input: kbd + '.xml'
+  )
+endforeach
+
+foreach kbd : tests_with_testdata
+  configure_file(
+    command: kmc_cmd + ['@INPUT@', '--test-data', '@OUTPUT@'],
+    output: kbd + '-test.json',
+    input: kbd + '-test.xml'
   )
 endforeach

--- a/developer/src/kmc-keyboard/build.sh
+++ b/developer/src/kmc-keyboard/build.sh
@@ -41,6 +41,7 @@ else
   # We need the schema file at runtime and bundled, so always copy it for all actions except `clean`
   mkdir -p "$THIS_SCRIPT_PATH/build/src/"
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/"
+  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json" "$THIS_SCRIPT_PATH/build/src/"
   cp "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json" "$THIS_SCRIPT_PATH/build/src/"
 fi
 

--- a/developer/src/kmc-keyboard/src/compiler/compiler.ts
+++ b/developer/src/kmc-keyboard/src/compiler/compiler.ts
@@ -1,4 +1,4 @@
-import { LDMLKeyboardXMLSourceFileReader, LDMLKeyboard, KMXPlus, CompilerCallbacks } from '@keymanapp/common-types';
+import { LDMLKeyboardXMLSourceFileReader, LDMLKeyboard, KMXPlus, CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
 import CompilerOptions from './compiler-options.js';
 import { CompilerMessages } from './messages.js';
 import { BkspCompiler, FinlCompiler, TranCompiler } from './tran.js';
@@ -78,6 +78,39 @@ export default class Compiler {
 
     return source;
   }
+
+  /**
+   * Loads a LDML Keyboard test data xml file and compiles into in-memory xml
+   * structures.
+   * @param filename  input filename, will use callback to load from disk
+   * @returns the source file, or null if invalid
+   */
+    public loadTestData(filename: string): LDMLKeyboardTestDataXMLSourceFile | null {
+      const reader = new LDMLKeyboardXMLSourceFileReader(this.callbacks);
+      const data = this.callbacks.loadFile(filename, filename);
+      if(!data) {
+        this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to read XML file'}));
+        return null;
+      }
+      const source = reader.loadTestData(data);
+      if(!source) {
+        this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to load XML file'}));
+        return null;
+      }
+      // TODO-LDML: The unboxed data doesn't match the schema anymore. Skipping validation, for now.
+
+      // try {
+      //   if (!reader.validate(source, this.callbacks.loadLdmlKeyboardTestSchema())) {
+      //     return null;
+      //   }
+      // } catch(e) {
+      //   this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: e.toString()}));
+      //   return null;
+      // }
+
+      return source;
+    }
+
 
   /**
    * Validates that the LDML keyboard source file and lints. Actually just

--- a/developer/src/kmc-keyboard/test/fixtures/test-fr.json
+++ b/developer/src/kmc-keyboard/test/fixtures/test-fr.json
@@ -1,0 +1,77 @@
+{
+  "keyboardTest": {
+    "conformsTo": "techpreview",
+    "info": {
+      "keyboard": "fr-t-k0-azerty.xml",
+      "author": "Team Keyboard",
+      "name": "fr-test"
+    },
+    "repertoire": [
+      {
+        "name": "simple-repertoire",
+        "chars": "[a b c d e \\u{22}]",
+        "type": "simple"
+      },
+      {
+        "name": "chars-repertoire",
+        "chars": "[á é ó]",
+        "type": "gesture"
+      }
+    ],
+    "tests": [
+      {
+        "name": "key-tests",
+        "test": [
+          {
+            "name": "key-test",
+            "startContext": {
+              "to": "abc\\u0022..."
+            },
+            "actions": [
+              {
+                "keystroke": {
+                  "key": "s"
+                }
+              },
+              {
+                "check": {
+                  "result": "abc\\u0022...s"
+                }
+              },
+              {
+                "keystroke": {
+                  "key": "t"
+                }
+              },
+              {
+                "check": {
+                  "result": "abc\\u0022...st"
+                }
+              },
+              {
+                "keystroke": {
+                  "key": "u"
+                }
+              },
+              {
+                "check": {
+                  "result": "abc\\u0022...stu"
+                }
+              },
+              {
+                "emit": {
+                  "to": "v"
+                }
+              },
+              {
+                "check": {
+                  "result": "abc\\u0022...stuv"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/developer/src/kmc-keyboard/test/fixtures/test-fr.xml
+++ b/developer/src/kmc-keyboard/test/fixtures/test-fr.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboardTest SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboardTest.dtd">
+<keyboardTest conformsTo="techpreview">
+    <info keyboard="fr-t-k0-azerty.xml" author="Team Keyboard" name="fr-test" />
+    <repertoire name="simple-repertoire" chars="[a b c d e \u{22}]" type="simple" /> <!-- verify that these outputs are all available from simple keys on any layer, for all form factors -->
+    <repertoire name="chars-repertoire" chars="[á é ó]" type="gesture" /> <!-- verify that these outputs are all available from simple or gesture keys on any layer, for touch -->
+    <tests name="key-tests">
+        <test name="key-test">
+            <startContext to="abc\u0022..."/>
+            <!-- tests by pressing key ids -->
+            <keystroke key="s"/>
+            <check result="abc\u0022...s" />
+            <keystroke key="t"/>
+            <check result="abc\u0022...st" />
+            <keystroke key="u"/>
+            <check result="abc\u0022...stu" />
+            <!-- tests by specifying 'to' output char -->
+            <emit to="v"/>
+            <check result="abc\u0022...stuv" />
+        </test>
+    </tests>
+</keyboardTest>

--- a/developer/src/kmc-keyboard/test/helpers/index.ts
+++ b/developer/src/kmc-keyboard/test/helpers/index.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { fileURLToPath } from 'url';
 import { SectionCompiler } from '../../src/compiler/section-compiler.js';
-import { KMXPlus, LDMLKeyboardXMLSourceFileReader, VisualKeyboard, CompilerEvent, CompilerCallbacks } from '@keymanapp/common-types';
+import { KMXPlus, LDMLKeyboardXMLSourceFileReader, VisualKeyboard, CompilerEvent, CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
 import Compiler from '../../src/compiler/compiler.js';
 import { assert } from 'chai';
 import KMXPlusMetadataCompiler from '../../src/compiler/metadata-compiler.js';
@@ -61,6 +61,9 @@ class TestCompilerCallbacks implements CompilerCallbacks {
   loadKvksJsonSchema(): Buffer {
     return fs.readFileSync(new URL(path.join('..', '..', 'src', 'kvks.schema.json'), import.meta.url));
   }
+  loadLdmlKeyboardTestSchema(): Buffer {
+    return fs.readFileSync(new URL(path.join('..', '..', 'src', 'ldml-keyboardtest.schema.json'), import.meta.url));
+  }
 };
 
 export const compilerTestCallbacks = new TestCompilerCallbacks();
@@ -104,6 +107,12 @@ export function loadSectionFixture(compilerClass: typeof SectionCompiler, filena
   globalSections.list = new List(globalSections.strs);
 
   return compiler.compile(globalSections);
+}
+
+export function loadTestdata(inputFilename: string, options: CompilerOptions) : LDMLKeyboardTestDataXMLSourceFile {
+  const k = new Compiler(compilerTestCallbacks, options);
+  const source = k.loadTestData(inputFilename);
+  return source;
 }
 
 export function compileKeyboard(inputFilename: string, options: CompilerOptions): KMXPlusFile {

--- a/developer/src/kmc-keyboard/test/test-testdata-e2e.ts
+++ b/developer/src/kmc-keyboard/test/test-testdata-e2e.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'fs';
+import 'mocha';
+import {assert} from 'chai';
+import {loadTestdata, makePathToFixture} from './helpers/index.js';
+
+describe('testdata-tests', function() {
+  this.slow(500); // 0.5 sec -- json schema validation takes a while
+
+  it('should-build-testdata-fixtures', async function() {
+    // Let's build test-fr.json
+    // It should match test-fr.json (built from test-fr.xml)
+
+    const inputFilename = makePathToFixture('test-fr.xml');
+    const jsonFilename = makePathToFixture('test-fr.json');
+
+    // Compile the keyboard
+    const testData = loadTestdata(inputFilename, {debug: true, addCompilerVersion: false});
+    assert.isNotNull(testData);
+
+    const jsonData = JSON.parse(readFileSync(jsonFilename, 'utf-8'));
+
+    assert.deepEqual(testData, jsonData);
+  });
+});

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -46,6 +46,7 @@ else
   # We need the schema file at runtime and bundled, so always copy it for all actions except `clean`
   mkdir -p "$THIS_SCRIPT_PATH/build/src/"
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/"
+  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json" "$THIS_SCRIPT_PATH/build/src/"
 fi
 
 


### PR DESCRIPTION
- developer: add a `-T` option that reads/emits test json instead of kmx
- core: add a mechanism for generating .json test data for xml source files that have them - not used yet.

for #7535 

@keymanapp-test-bot skip