### PR TITLE
fix(linux): Fix syntax for skipping upload in packaging GHA

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -162,7 +162,7 @@ jobs:
     needs: deb_signing
     runs-on: self-hosted
     environment: "deploy (linux)"
-    if: ${{ ! github.event.client_payload.isTestBuild }}
+    if: github.event.client_payload.isTestBuild == 'false'
 
     steps:
     - name: Download Artifacts


### PR DESCRIPTION
Getting closer.

Follow-on to #8223, #8225, #8228, #8230

@keymanapp-test-bot skip