### PR TITLE
chore(linux): Output results of API verification on stderr

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -234,7 +234,7 @@ jobs:
         SRC_PKG="${GITHUB_WORKSPACE}/artifacts/keyman-srcpkg/keyman_${{ needs.sourcepackage.outputs.VERSION }}-1.debian.tar.xz" \
         BIN_PKG="${GITHUB_WORKSPACE}/artifacts/keyman-binarypkgs/libkmnkbp0-0_${{ needs.sourcepackage.outputs.VERSION }}-1${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}+jammy1_amd64.deb" \
         PKG_VERSION="${{ needs.sourcepackage.outputs.VERSION }}" \
-        ./scripts/deb-packaging.sh --gha verify >> $GITHUB_STEP_SUMMARY
+        ./scripts/deb-packaging.sh --gha verify 2>> $GITHUB_STEP_SUMMARY
 
     - name: Archive .symbols file
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/linux/scripts/deb-packaging.sh
+++ b/linux/scripts/deb-packaging.sh
@@ -58,13 +58,15 @@ fi
 if builder_start_action verify; then
   tar xf "${SRC_PKG}"
   if [ ! -f debian/libkmnkbp0-0.symbols ]; then
-    echo ":warning: Missing libkmnkbp0-0.symbols file"
+    # shellcheck disable=SC2210 # File redirection
+    echo ":warning: Missing libkmnkbp0-0.symbols file" >2
   else
     tmpDir=$(mktemp -d)
     dpkg -x "${BIN_PKG}" "$tmpDir"
     cd debian
     dpkg-gensymbols -v"${PKG_VERSION}" -plibkmnkbp0-0 -e"${tmpDir}"/usr/lib/x86_64-linux-gnu/libkmnkbp0.so* -Olibkmnkbp0-0.symbols -c4
-    echo ":heavy_check_mark: libkmnkbp0-0 API didn't change"
+    # shellcheck disable=SC2210 # File redirection
+    echo ":heavy_check_mark: libkmnkbp0-0 API didn't change" >2
   fi
   builder_finish_action success verify
   exit 0


### PR DESCRIPTION
This reduces the noise on the GHA summary page.

@keymanapp-test-bot skip