### PR TITLE
fix(linux): Checkout before  running apt-install

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -165,11 +165,10 @@ jobs:
     if: github.event.client_payload.isTestBuild == 'false'
 
     steps:
-    - name: Download Artifacts
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+    - name: Checkout
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
       with:
-        name: keyman-signedpkgs
-        path: artifacts
+        ref: '${{ github.event.client_payload.ref }}'
 
     - name: Install dput
       uses: ./.github/actions/apt-install
@@ -179,6 +178,12 @@ jobs:
     - name: Setup .dput.cf
       run: |
         echo "${{vars.ENV_DPUT_CONFIG}}" > ~/.dput.cf
+
+    - name: Download Artifacts
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: keyman-signedpkgs
+        path: artifacts
 
     - name: Upload
       run: |


### PR DESCRIPTION
We need to check out the source code before we can run the apt-install action in the packaging GHA.

@keymanapp-test-bot skip