### PR TITLE
chore: cleanup some of shellHelperFunctions.sh

### DIFF
--- a/common/predictive-text/unit_tests/test.sh
+++ b/common/predictive-text/unit_tests/test.sh
@@ -104,9 +104,9 @@ if [[ $VERSION_ENVIRONMENT == test ]] && builder_has_action test :browser; then
 fi
 
 get_browser_set_for_OS ( ) {
-  if [ $os_id = "mac" ]; then
+  if [[ $BUILDER_OS == mac ]]; then
     BROWSERS="--browsers Firefox,Chrome,Safari"
-  elif [ $os_id = "win" ]; then
+  elif [[ $BUILDER_OS == win ]]; then
     BROWSERS="--browsers Chrome"
   else
     BROWSERS="--browsers Firefox,Chrome"
@@ -139,7 +139,6 @@ if builder_start_action test:browser; then
   fi
 
   if [[ KARMA_CONFIG == "manual.conf.js" ]]; then
-    get_builder_OS  # return:  os_id="linux"|"mac"|"win"
     get_browser_set_for_OS
   else
     BROWSERS=

--- a/common/test/resources/test_kill_browserstack.sh
+++ b/common/test/resources/test_kill_browserstack.sh
@@ -9,12 +9,10 @@ set -eu
 # adjust relative paths as necessary
 THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
 . "$(dirname "$THIS_SCRIPT")/../../../resources/build/build-utils.sh"
-. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-get_builder_OS
 
-if [ ${os_id} == 'win' ]; then
+if [[ $BUILDER_OS == win ]]; then
   # BrowserStackLocal may not exist, so always pass
   taskkill //f //im BrowserStackLocal.exe || true
 fi

--- a/core/build.sh
+++ b/core/build.sh
@@ -37,8 +37,6 @@ display_usage() {
   exit 0
 }
 
-get_builder_OS
-
 MESON_TARGET=release
 HAS_TARGET=false
 CLEAN=false
@@ -271,12 +269,12 @@ locate_emscripten() {
 }
 
 build_meson_cross_file_for_wasm() {
-  if [ $os_id == win ]; then
+  if [[ $BUILDER_OS == win ]]; then
     local R=$(cygpath -w $(echo $EMSCRIPTEN_BASE) | sed 's_\\_\\\\_g')
   else
     local R=$(echo $EMSCRIPTEN_BASE | sed 's_/_\\/_g')
   fi
-  sed -e "s/\$EMSCRIPTEN_BASE/$R/g" wasm.build.$os_id.in > wasm.build
+  sed -e "s/\$EMSCRIPTEN_BASE/$R/g" wasm.build.$BUILDER_OS.in > wasm.build
 }
 
 ###
@@ -286,14 +284,14 @@ if $CLEAN; then
 fi
 
 if [[ $PLATFORM == native ]]; then
-  case $os_id in
-    "linux")
-      build_standard $os_id arch
+  case $BUILDER_OS in
+    linux)
+      build_standard linux arch
       ;;
-    "mac")
-      build_standard $os_id arch
+    mac)
+      build_standard mac arch
       ;;
-    "win")
+    win)
       build_windows
       ;;
   esac

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -15,6 +15,7 @@
 #   VERSION_ENVIRONMENT: One of: local, test, alpha, beta, stable
 #   UPLOAD_SENTRY:    true - if VERSION_ENVIRONMENT is one of alpha, beta, stable
 #                     false - if local, test.  Indicates if debug artifacts should be uploaded to Sentry
+#   BUILDER_OS:       win|mac|linux -- current build environment
 #
 # On macOS, this script requires coreutils (`brew install coreutils`)
 #
@@ -338,3 +339,24 @@ run_xcodebuild() {
     fail "Build failed! Error: [$ret_code] when executing command: 'xcodebuild $cmnd'"
   fi
 }
+
+#
+# Sets the BUILDER_OS environment variable to linux|mac|win
+#
+_builder_get_operating_system() {
+  declare -g BUILDER_OS
+  # Default value, since it's the most general case/configuration to detect.
+  BUILDER_OS=linux
+
+  # Subject to change with future improvements.
+  if [[ $OSTYPE == darwin* ]]; then
+    BUILDER_OS=mac
+  elif [[ $OSTYPE == msys ]]; then
+    BUILDER_OS=win
+  elif [[ $OSTYPE == cygwin ]]; then
+    BUILDER_OS=win
+  fi
+  readonly BUILDER_OS
+}
+
+_builder_get_operating_system

--- a/resources/devbox/iis-https/setup-iis-https.sh
+++ b/resources/devbox/iis-https/setup-iis-https.sh
@@ -16,9 +16,7 @@ echo_heading2() {
   echo_heading "$*"
 }
 
-get_builder_OS
-
-if [ $os_id != win ]; then
+if [[ $BUILDER_OS != win ]]; then
   fail "This script can only be run on Windows to setup IIS."
 fi
 

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-_shf_base_dir=$(dirname "$BASH_SOURCE")/..
-
 # Designed to determine which set of browsers should be available for local testing,
 # based upon the current system OS.
 get_builder_OS ( ) {
@@ -59,20 +57,6 @@ verify_platform() {
 
   if [ $match = false ]; then
     fail "Invalid platform specified!"
-  fi
-}
-
-# Gets the folder containing each platform's history.md file, which is also the base folder for most of the platforms.
-# Sets $platform_folder accordingly.
-get_platform_folder() {
-  verify_platform $1
-
-  if [[ $1 = "desktop" || $1 = "developer" ]]; then
-    platform_folder="$_shf_base_dir/windows/src/$1"
-  elif [[ $1 = "lmlayer" ]]; then
-    platform_folder="common/predictive-text"
-  else
-    platform_folder="$_shf_base_dir/$1"
   fi
 }
 

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -1,21 +1,5 @@
 #!/usr/bin/env bash
 
-# Designed to determine which set of browsers should be available for local testing,
-# based upon the current system OS.
-get_builder_OS ( ) {
-  # Default value, since it's the most general case/configuration to detect.
-  os_id="linux"
-
-  # Subject to change with future improvements.
-  if [[ "${OSTYPE}" = "darwin"* ]]; then
-    os_id="mac"
-  elif [[ "${OSTYPE}" = "msys" ]]; then
-    os_id="win"
-  elif [[ "${OSTYPE}" = "cygwin" ]]; then
-    os_id="win"
-  fi
-}
-
 # Allows for a quick macOS check for those scripts requiring a macOS environment.
 verify_on_mac() {
   if [[ "${OSTYPE}" != "darwin"* ]]; then

--- a/web/test.sh
+++ b/web/test.sh
@@ -66,21 +66,9 @@ if [[ $VERSION_ENVIRONMENT == test ]]; then
 fi
 
 get_default_browser_set ( ) {
-  # Default value, since it's the most general case/configuration to detect.
-  local os_id="linux"
-
-  # Subject to change with future improvements.
-  if [[ "${OSTYPE}" = "darwin"* ]]; then
-    os_id="mac"
-  elif [[ "${OSTYPE}" = "msys" ]]; then
-    os_id="win"
-  elif [[ "${OSTYPE}" = "cygwin" ]]; then
-    os_id="win"
-  fi
-
-  if [ $os_id = "mac" ]; then
+  if [[ $BUILDER_OS == mac ]]; then
       BROWSERS="--browsers Firefox,Chrome,Safari"
-  elif [ $os_id = "win" ]; then
+  elif [[ $BUILDER_OS == win ]]; then
       BROWSERS="--browsers Firefox,Chrome,Edge"
   else
       BROWSERS="--browsers Firefox,Chrome"


### PR DESCRIPTION
Continues consolidation of various 'helper' functions:
* Removes unused function `get_platform_folder`
* Renames `os_id` to `BUILDER_OS`

@keymanapp-test-bot skip