### PR TITLE
chore: consolidate script helper functions

### DIFF
--- a/android/KMAPro/build-play-store-notes.sh
+++ b/android/KMAPro/build-play-store-notes.sh
@@ -35,7 +35,7 @@ DEFAULT_RELEASE_NOTE="* Additional bug fixes and improvements"
 FILTERED_LINES=$( grep '^\s*\*.*$' "$KEYMAN_ROOT/android/help/about/whatsnew.md" || [[ $? == 1 ]] ) # Continue if grep has no matches
 if [ -z "$FILTERED_LINES" ]; then
   FILTERED_LINES="$DEFAULT_RELEASE_NOTE"
-  warn "Warning: whatsnew.md empty so using default release note: '$FILTERED_LINES'"
+  builder_warn "Warning: whatsnew.md empty so using default release note: '$FILTERED_LINES'"
 fi
 
 IFS=$'\n'      # Change IFS to new line
@@ -48,8 +48,8 @@ do
     echo "$line" >> $PLAY_RELEASE_NOTES
   else
     # 450 chars reached
-    warn "Warning: Play Store release notes approaching 500 character limit"
+    builder_warn "Warning: Play Store release notes approaching 500 character limit"
     echo "$DEFAULT_RELEASE_NOTE" >> $PLAY_RELEASE_NOTES
     break
-  fi  
+  fi
 done

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -47,10 +47,6 @@ KMA_ROOT="$KEYMAN_ROOT/android"
 KMW_ROOT="$KEYMAN_ROOT/web"
 KMEA_ASSETS="$KMA_ROOT/KMEA/app/src/main/assets"
 
-warn ( ) {
-    echo "$*"
-}
-
 die ( ) {
     echo
     echo "$*"

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -47,13 +47,6 @@ KMA_ROOT="$KEYMAN_ROOT/android"
 KMW_ROOT="$KEYMAN_ROOT/web"
 KMEA_ASSETS="$KMA_ROOT/KMEA/app/src/main/assets"
 
-die ( ) {
-    echo
-    echo "$*"
-    echo
-    exit 1
-}
-
 # Default is building KMW and copying artifacts
 DO_BUILD=true
 DO_COPY=true
@@ -131,7 +124,7 @@ if [ "$DO_BUILD" = true ]; then
     "$KMW_ROOT/build.sh" $KMWFLAGS
 
     if [ $? -ne 0 ]; then
-        die "ERROR: keymanweb build failed. Exiting"
+        builder_die "ERROR: keymanweb build failed. Exiting"
     fi
 fi
 if [ "$DO_COPY" = true ]; then
@@ -149,7 +142,7 @@ if [ "$DO_COPY" = true ]; then
     cp $KEYMAN_ROOT/node_modules/es6-shim/es6-shim.min.js $KMEA_ASSETS/es6-shim.min.js
 
     if [ $? -ne 0 ]; then
-        die "ERROR: copying artifacts failed"
+        builder_die "ERROR: copying artifacts failed"
     fi
 fi
 
@@ -177,13 +170,13 @@ fi
 echo "BUILD_FLAGS $BUILD_FLAGS"
 ./gradlew $DAEMON_FLAG clean $BUILD_FLAGS
 if [ $? -ne 0 ]; then
-    die "ERROR: Build of KMEA failed"
+    builder_die "ERROR: Build of KMEA failed"
 fi
 if [ "$DO_TEST" = true ]; then
     echo "TEST_FLAGS $TEST_FLAGS"
     ./gradlew $DAEMON_FLAG $TEST_FLAGS
     if [ $? -ne 0 ]; then
-        die "ERROR: KMEA test cases failed"
+        builder_die "ERROR: KMEA test cases failed"
     fi
 fi
 

--- a/android/build.sh
+++ b/android/build.sh
@@ -59,7 +59,7 @@ cd "$KEYMAN_ROOT/android/KMEA"
 ./build.sh "$@"
 
 if [ $? -ne 0 ]; then
-    die "ERROR: KMEA/build.sh failed"
+    builder_die "ERROR: KMEA/build.sh failed"
 fi
 
 # Building Keyman for Android
@@ -68,7 +68,7 @@ cd "$KEYMAN_ROOT/android/KMAPro"
 ./build.sh "$@"
 
 if [ $? -ne 0 ]; then
-    die "ERROR: KMAPro/build.sh failed"
+    builder_die "ERROR: KMAPro/build.sh failed"
 fi
 
 cd "$KEYMAN_ROOT/android"
@@ -80,6 +80,6 @@ if [ ! -z "$RELEASE_OEM" ]; then
   ./build.sh -download-keyboards -lib-nobuild "$@"
 
   if [ $? -ne 0 ]; then
-    die "ERROR: oem/firstvoices/android/build.sh failed"
+    builder_die "ERROR: oem/firstvoices/android/build.sh failed"
   fi
 fi

--- a/common/models/types/build.sh
+++ b/common/models/types/build.sh
@@ -82,14 +82,14 @@ fi
 
 # Check if Node.JS/npm is installed.
 type npm >/dev/null ||\
-    fail "Build environment setup error detected!  Please ensure Node.js is installed!"
+    builder_die "Build environment setup error detected!  Please ensure Node.js is installed!"
 
 if (( install_dependencies )) ; then
-  npm install || fail "Could not download dependencies."
+  npm install || builder_die "Could not download dependencies."
 fi
 
 if (( run_tests )); then
-  npm test || fail "Tests failed"
+  npm test || builder_die "Tests failed"
 fi
 
 if (( should_publish )); then
@@ -106,5 +106,5 @@ if (( should_publish )); then
   #
   # See `npm help publish` for more details.
   echo "Publishing $DRY_RUN npm package with tag $npm_dist_tag"
-  npm publish $DRY_RUN --access public --tag $npm_dist_tag || fail "Could not publish $npm_dist_tag release."
+  npm publish $DRY_RUN --access public --tag $npm_dist_tag || builder_die "Could not publish $npm_dist_tag release."
 fi

--- a/common/predictive-text/testing/one-stage-embedded-webworker/build.sh
+++ b/common/predictive-text/testing/one-stage-embedded-webworker/build.sh
@@ -23,14 +23,14 @@ echo "Node.js + dependencies check"
 npm install --no-optional
 
 if [ $? -ne 0 ]; then
-  fail "Build environment setup error detected!  Please ensure Node.js is installed!"
+  builder_die "Build environment setup error detected!  Please ensure Node.js is installed!"
 fi
 
 # A nice, extensible method for -clean operations.  Add to this as necessary.
 clean ( ) {
   rm -rf "./*.js"
   if [ $? -ne 0 ]; then
-    fail "Failed to erase the prior build."
+    builder_die "Failed to erase the prior build."
   fi
 }
 
@@ -48,7 +48,7 @@ done
 npm run tsc -- -p $SOURCE/tsconfig.json
 
 if [ $? -ne 0 ]; then
-  fail "Compilation failed."
+  builder_die "Compilation failed."
 fi
 
 echo "Typescript compilation successful."

--- a/common/predictive-text/testing/two-stage-embedded-webworker/build.sh
+++ b/common/predictive-text/testing/two-stage-embedded-webworker/build.sh
@@ -26,14 +26,14 @@ echo "Node.js + dependencies check"
 npm install --no-optional
 
 if [ $? -ne 0 ]; then
-  fail "Build environment setup error detected!  Please ensure Node.js is installed!"
+  builder_die "Build environment setup error detected!  Please ensure Node.js is installed!"
 fi
 
 # A nice, extensible method for -clean operations.  Add to this as necessary.
 clean ( ) {
   rm -rf "./*.js"
   if [ $? -ne 0 ]; then
-    fail "Failed to erase the prior build."
+    builder_die "Failed to erase the prior build."
   fi
 }
 
@@ -50,7 +50,7 @@ done
 
 npm run tsc -- -p $SOURCE/worker/tsconfig.json
 if [ $? -ne 0 ]; then
-  fail "Worker compilation failed."
+  builder_die "Worker compilation failed."
 fi
 
 rm $EMBEDDED_WORKER &> /dev/null
@@ -62,7 +62,7 @@ echo "}" >> $EMBEDDED_WORKER
 
 npm run tsc -- -p $SOURCE/tsconfig.json
 if [ $? -ne 0 ]; then
-  fail "Final compilation failed."
+  builder_die "Final compilation failed."
 fi
 
 echo "Typescript compilation successful."

--- a/common/test/keyboards/build.sh
+++ b/common/test/keyboards/build.sh
@@ -191,14 +191,14 @@ for TARGET in "${TARGETS[@]}"; do
   if $CLEAN; then
     if ! $QUIET; then
       echo
-      echo_heading "Cleaning target $TARGET"
+      builder_heading "Cleaning target $TARGET"
       echo
     fi
     clean "$TARGET"
   else
     if ! $QUIET; then
       echo
-      echo_heading "Building target $TARGET"
+      builder_heading "Building target $TARGET"
       echo
     fi
     build "$TARGET"

--- a/common/web/keyboard-processor/build.sh
+++ b/common/web/keyboard-processor/build.sh
@@ -52,7 +52,7 @@ fi
 if builder_start_action test; then
   npm run tsc -- --build "$THIS_SCRIPT_PATH/src/tsconfig.bundled.json"
 
-  echo_heading "Running Keyboard Processor test suite"
+  builder_heading "Running Keyboard Processor test suite"
 
   FLAGS=
   if builder_has_option --ci; then

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -113,7 +113,7 @@ if builder_start_action build; then
   fi
 
   # Build worker with tsc first
-  npm run build -- $builder_verbose || fail "Could not build worker."
+  npm run build -- $builder_verbose || builder_die "Could not build worker."
 
   # Wrap the worker code and create embedded index.js. Must be run after the
   # worker is built
@@ -127,6 +127,6 @@ if builder_start_action build; then
 fi
 
 if builder_start_action test; then
-  npm test || fail "Tests failed"
+  npm test || builder_die "Tests failed"
   builder_finish_action success test
 fi

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -51,25 +51,25 @@ wrap-worker-code ( ) {
   # but also adds a lot more code the worker doesn't need to use.
   # Recommended by MDN while keeping the worker lean and efficient.
   # Needed for Android / Chromium browser pre-41.
-  cat "../../../node_modules/string.prototype.codepointat/codepointat.js" || die
+  cat "../../../node_modules/string.prototype.codepointat/codepointat.js" || builder_die
 
   # These two are straight from MDN - I didn't find any NPM ones that don't
   # use the node `require` statement for the second.  They're also relatively
   # short and simple, which is good.
-  cat "src/polyfills/array.fill.js" || die # Needed for Android / Chromium browser pre-45.
-  cat "src/polyfills/array.findIndex.js" || die # Needed for Android / Chromium browser pre-45.
-  cat "src/polyfills/array.from.js" || die # Needed for Android / Chromium browser pre-45.
-  cat "src/polyfills/array.includes.js" || die # Needed for Android / Chromium browser pre-47.
+  cat "src/polyfills/array.fill.js" || builder_die # Needed for Android / Chromium browser pre-45.
+  cat "src/polyfills/array.findIndex.js" || builder_die # Needed for Android / Chromium browser pre-45.
+  cat "src/polyfills/array.from.js" || builder_die # Needed for Android / Chromium browser pre-45.
+  cat "src/polyfills/array.includes.js" || builder_die # Needed for Android / Chromium browser pre-47.
 
   # For Object.values, for iteration over object-based associate arrays.
-  cat "src/polyfills/object.values.js" || die # Needed for Android / Chromium browser pre-54.
+  cat "src/polyfills/object.values.js" || builder_die # Needed for Android / Chromium browser pre-54.
 
   # Needed to support Symbol.iterator, as used by the correction algorithm.
-  cat "src/polyfills/symbol-es6.min.js" || die # Needed for Android / Chromium browser pre-43.
+  cat "src/polyfills/symbol-es6.min.js" || builder_die # Needed for Android / Chromium browser pre-43.
 
   echo ""
 
-  cat "${js}" || die
+  cat "${js}" || builder_die
   printf "\n}\n"
   echo "// --END:LMLlayerWorkerCode"
 }
@@ -120,8 +120,8 @@ if builder_start_action build; then
   echo "Wrapping worker in function LMLayerWorkerCode ${WORKER_OUTPUT_FILENAME}"
   # Note: We use intermediate.js for unit tests in predictive-text
   cp "${WORKER_OUTPUT_FILENAME}" "${WORKER_OUTPUT}/intermediate.js"
-  wrap-worker-code LMLayerWorkerCode "${WORKER_OUTPUT}/intermediate.js" > "${WORKER_OUTPUT_FILENAME}" || die
-  cp "${WORKER_OUTPUT_FILENAME}" "${WORKER_TEST_BUNDLE_TARGET_FILENAME}" || die
+  wrap-worker-code LMLayerWorkerCode "${WORKER_OUTPUT}/intermediate.js" > "${WORKER_OUTPUT_FILENAME}" || builder_die
+  cp "${WORKER_OUTPUT_FILENAME}" "${WORKER_TEST_BUNDLE_TARGET_FILENAME}" || builder_die
 
   builder_finish_action success build
 fi

--- a/common/web/sentry-manager/src/build.sh
+++ b/common/web/sentry-manager/src/build.sh
@@ -44,10 +44,10 @@ done
 if [ $FETCH_DEPS = true ]; then
     verify_npm_setup
     # We need to build keyman-version with a script for now
-    "$KEYMAN_ROOT/common/web/keyman-version/build.sh" || fail "Could not build keyman-version"
+    "$KEYMAN_ROOT/common/web/keyman-version/build.sh" || builder_die "Could not build keyman-version"
 fi
 
 npm run tsc -- --build "$THIS_SCRIPT_PATH/tsconfig.json"
 if [ $? -ne 0 ]; then
-    fail "Compilation of package for Sentry integration with KeymanWeb failed."
+    builder_die "Compilation of package for Sentry integration with KeymanWeb failed."
 fi

--- a/common/windows/cef-checkout.sh
+++ b/common/windows/cef-checkout.sh
@@ -47,7 +47,7 @@ if [ ! -f ./libcef.dll ]; then
     rm "$zip"
   done
 
-  [ -f ./libcef.dll ] || die "File libcef.dll could not be found. Path $KEYMAN_CEF4DELPHI_ROOT may not be valid."
+  [ -f ./libcef.dll ] || builder_die "File libcef.dll could not be found. Path $KEYMAN_CEF4DELPHI_ROOT may not be valid."
 fi
 
 popd > /dev/null

--- a/core/build.sh
+++ b/core/build.sh
@@ -124,7 +124,7 @@ while [[ $# -gt 0 ]] ; do
       break
       ;;
     *)
-      fail "Invalid parameters. Use --help for help"
+      builder_die "Invalid parameters. Use --help for help"
   esac
   shift
 done
@@ -259,13 +259,13 @@ locate_emscripten() {
   if [[ -z ${EMSCRIPTEN_BASE+x} ]]; then
     if [[ -z ${EMCC+x} ]]; then
       local EMCC=`which emcc`
-      [[ -z $EMCC ]] && fail "locate_emscripten: Could not locate emscripten (emcc) on the path or with \$EMCC or \$EMSCRIPTEN_BASE"
+      [[ -z $EMCC ]] && builder_die "locate_emscripten: Could not locate emscripten (emcc) on the path or with \$EMCC or \$EMSCRIPTEN_BASE"
     fi
-    [[ -x $EMCC ]] || fail "locate_emscripten: Variable EMCC ($EMCC) does not point to a valid executable emcc"
+    [[ -x $EMCC ]] || builder_die "locate_emscripten: Variable EMCC ($EMCC) does not point to a valid executable emcc"
     EMSCRIPTEN_BASE="$(dirname "$EMCC")"
   fi
 
-  [[ -x ${EMSCRIPTEN_BASE}/emcc ]] || fail "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) does not point to emcc's folder"
+  [[ -x ${EMSCRIPTEN_BASE}/emcc ]] || builder_die "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) does not point to emcc's folder"
 }
 
 build_meson_cross_file_for_wasm() {

--- a/core/build.sh
+++ b/core/build.sh
@@ -179,14 +179,14 @@ build_windows() {
 
   if $BUILD_CPP; then
     if $TESTS_CPP; then
-      echo_heading "======= Building and Testing C++ library for Windows (x86, x64) ======="
+      builder_heading "======= Building and Testing C++ library for Windows (x86, x64) ======="
       cmd //C build.bat all $MESON_TARGET build tests
     else
-      echo_heading "======= Building C++ library for Windows (x86, x64) ======="
+      builder_heading "======= Building C++ library for Windows (x86, x64) ======="
       cmd //C build.bat all $MESON_TARGET build
     fi
   elif $TESTS_CPP; then
-    echo_heading "======= Testing C++ library for Windows (x86, x64) ======="
+    builder_heading "======= Testing C++ library for Windows (x86, x64) ======="
     cmd //C build.bat all $MESON_TARGET tests
   fi
 }
@@ -205,35 +205,35 @@ build_standard() {
 
   # Build meson targets
   if $CONFIGURE; then
-    echo_heading "======= Configuring C++ library for $BUILD_PLATFORM ======="
+    builder_heading "======= Configuring C++ library for $BUILD_PLATFORM ======="
     pushd "$THIS_SCRIPT_PATH" > /dev/null
     meson setup "$MESON_PATH" --werror --buildtype $MESON_TARGET $STANDARD_MESON_ARGS $ADDITIONAL_ARGS
     popd > /dev/null
   fi
 
   if $BUILD_CPP; then
-    echo_heading "======= Building C++ library for $BUILD_PLATFORM ======="
+    builder_heading "======= Building C++ library for $BUILD_PLATFORM ======="
     pushd "$MESON_PATH" > /dev/null
     ninja
     popd > /dev/null
   fi
 
   if $TESTS_CPP; then
-    echo_heading "======= Testing C++ library for $BUILD_PLATFORM ======="
+    builder_heading "======= Testing C++ library for $BUILD_PLATFORM ======="
     pushd "$MESON_PATH" > /dev/null
     meson test --print-errorlogs
     popd > /dev/null
   fi
 
   if $INSTALL_CPP; then
-    echo_heading "======= Installing C++ libraries for $BUILD_PLATFORM ======="
+    builder_heading "======= Installing C++ libraries for $BUILD_PLATFORM ======="
     pushd "$MESON_PATH" > /dev/null
     ninja install
     popd > /dev/null
   fi
 
   if $UNINSTALL_CPP; then
-    echo_heading "======= Uninstalling C++ libraries for $BUILD_PLATFORM ======="
+    builder_heading "======= Uninstalling C++ libraries for $BUILD_PLATFORM ======="
     pushd "$MESON_PATH" > /dev/null
     ninja uninstall
     popd > /dev/null

--- a/developer/src/kmlmc/build.sh
+++ b/developer/src/kmlmc/build.sh
@@ -20,7 +20,7 @@ LEXICAL_MODELS_TYPES="$KEYMAN_ROOT/common/models/types"
 
 # Build the main script.
 build () {
-  npm run build || fail "Could not build top-level JavaScript file."
+  npm run build || builder_die "Could not build top-level JavaScript file."
 }
 
 display_usage ( ) {
@@ -90,19 +90,19 @@ fi
 
 # Check if Node.JS/npm is installed.
 type npm >/dev/null ||\
-    fail "Build environment setup error detected!  Please ensure Node.js is installed!"
+    builder_die "Build environment setup error detected!  Please ensure Node.js is installed!"
 
 if (( install_dependencies )) ; then
   verify_npm_setup
   # We need to build keyman-version and lm-worker with a script for now
-  "$KEYMAN_ROOT/common/web/keyman-version/build.sh" || fail "Could not build keyman-version"
+  "$KEYMAN_ROOT/common/web/keyman-version/build.sh" || builder_die "Could not build keyman-version"
 fi
 
-build || fail "Compilation failed."
+build || builder_die "Compilation failed."
 echo "Typescript compilation successful."
 
 if (( run_tests )); then
-  npm test || fail "Tests failed"
+  npm test || builder_die "Tests failed"
 fi
 
 if (( should_publish )); then
@@ -119,7 +119,7 @@ if (( should_publish )); then
   #
   # See `npm help publish` for more details.
   echo "Publishing $DRY_RUN npm package with tag $npm_dist_tag"
-  npm publish $DRY_RUN --access public --tag $npm_dist_tag || fail "Could not publish $npm_dist_tag release."
+  npm publish $DRY_RUN --access public --tag $npm_dist_tag || builder_die "Could not publish $npm_dist_tag release."
 
   # For now, kmlmc will have responsibility for publishing keyman-version. In
   # the future, we should probably have a top-level npm publish script that

--- a/developer/src/server/build-addins.inc.sh
+++ b/developer/src/server/build-addins.inc.sh
@@ -57,10 +57,10 @@ build_addins() {
   #
 
   if (( NODEX64 )); then
-    [[ $(isFileX64 "$TRAYICON_TARGET") == 1 ]] || die "$TRAYICON_TARGET should be 64-bit"
-    [[ $(isFileX64 "$HIDECONSOLE_TARGET") == 1 ]] || die "$HIDECONSOLE_TARGET should be 64-bit"
+    [[ $(isFileX64 "$TRAYICON_TARGET") == 1 ]] || builder_die "$TRAYICON_TARGET should be 64-bit"
+    [[ $(isFileX64 "$HIDECONSOLE_TARGET") == 1 ]] || builder_die "$HIDECONSOLE_TARGET should be 64-bit"
   else
-    [[ $(isFileX64 "$TRAYICON_TARGET") == 0 ]] || die "$TRAYICON_TARGET should not be 64-bit"
-    [[ $(isFileX64 "$HIDECONSOLE_TARGET") == 0 ]] || die "$HIDECONSOLE_TARGET should not be 64-bit"
+    [[ $(isFileX64 "$TRAYICON_TARGET") == 0 ]] || builder_die "$TRAYICON_TARGET should not be 64-bit"
+    [[ $(isFileX64 "$HIDECONSOLE_TARGET") == 0 ]] || builder_die "$HIDECONSOLE_TARGET should not be 64-bit"
   fi
 }

--- a/developer/src/server/build.sh
+++ b/developer/src/server/build.sh
@@ -20,7 +20,7 @@ pushd "$(dirname "$THIS_SCRIPT")"
 
 # Build the main script.
 build () {
-  npm run build || fail "Could not build top-level JavaScript file."
+  npm run build || builder_die "Could not build top-level JavaScript file."
 }
 
 display_usage ( ) {
@@ -93,7 +93,7 @@ done
 
 # Check if Node.JS/npm is installed.
 type npm >/dev/null ||\
-    fail "Build environment setup error detected!  Please ensure Node.js is installed!"
+    builder_die "Build environment setup error detected!  Please ensure Node.js is installed!"
 
 if (( install_dependencies )) ; then
   verify_npm_setup
@@ -148,7 +148,7 @@ fi
 # Build the project
 # ----------------------------------------
 
-npm run build || fail "Compilation failed."
+npm run build || builder_die "Compilation failed."
 echo "Typescript compilation successful."
 
 # ----------------------------------------
@@ -156,7 +156,7 @@ echo "Typescript compilation successful."
 # ----------------------------------------
 
 if (( run_tests )); then
-  npm test || fail "Tests failed"
+  npm test || builder_die "Tests failed"
 fi
 
 # ----------------------------------------

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -200,7 +200,7 @@ update_bundle ( ) {
     fi
 
     if [ $DO_KMP_DOWNLOADS = true ]; then
-      echo_heading "Downloading up-to-date packages for default resources"
+      builder_heading "Downloading up-to-date packages for default resources"
 
       downloadKeyboardPackage "$DEFAULT_KBD_ID" "$base_dir/$BUNDLE_PATH/$DEFAULT_KBD_ID.kmp"
       downloadModelPackage "$DEFAULT_LM_ID" "$base_dir/$BUNDLE_PATH/$DEFAULT_LM_ID.model.kmp"

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -172,7 +172,7 @@ update_bundle ( ) {
 
         "$KEYMAN_ROOT/web/build.sh" $KMWFLAGS
         if [ $? -ne 0 ]; then
-            fail "ERROR:  KeymanWeb's build.sh failed."
+            builder_die "ERROR:  KeymanWeb's build.sh failed."
         fi
 
         #Copy over the relevant resources!  It's easiest to do if we navigate to the resulting folder.
@@ -218,11 +218,11 @@ if [ $DO_CARTHAGE = true ]; then
   echo
   echo "Load dependencies with Carthage"
 
-  carthage checkout || fail "Carthage dependency loading failed"
+  carthage checkout || builder_die "Carthage dependency loading failed"
 
   # --no-use-binaries: due to https://github.com/Carthage/Carthage/issues/3134,
   # which affects the sentry-cocoa dependency.
-  carthage build --use-xcframeworks --no-use-binaries --platform iOS || fail "Carthage dependency loading failed"
+  carthage build --use-xcframeworks --no-use-binaries --platform iOS || builder_die "Carthage dependency loading failed"
 fi
 
 echo

--- a/ios/kmbuild.sh
+++ b/ios/kmbuild.sh
@@ -193,10 +193,10 @@ update_bundle ( ) {
     # Our default resources are part of the bundle, so let's check on them.
     if [ ! -f "$base_dir/$BUNDLE_PATH/$DEFAULT_KBD_ID.kmp" ]; then
       DO_KMP_DOWNLOADS=true
-      warn "OVERRIDE:  Performing -download-resources run, as the keyboard package is missing!"
+      builder_warn "OVERRIDE:  Performing -download-resources run, as the keyboard package is missing!"
     elif [ ! -f "$base_dir/$BUNDLE_PATH/$DEFAULT_LM_ID.model.kmp" ]; then
       DO_KMP_DOWNLOADS=true
-      warn "OVERRIDE:  Performing -download-resources run, as the lexical model package is missing!"
+      builder_warn "OVERRIDE:  Performing -download-resources run, as the lexical model package is missing!"
     fi
 
     if [ $DO_KMP_DOWNLOADS = true ]; then

--- a/linux/scripts/jenkins.sh
+++ b/linux/scripts/jenkins.sh
@@ -62,24 +62,24 @@ checkAndInstallRequirements()
 checkAndInstallRequirements
 
 # clean up prev deb builds
-echo_heading "cleaning previous builds of $1"
+builder_heading "cleaning previous builds of $1"
 
 rm -rf builddebs
 rm -rf "$sourcedir/${1}"_*.{dsc,build,buildinfo,changes,tar.?z,log}
 rm -rf "$sourcedir/../${1}"_*.{dsc,build,buildinfo,changes,tar.?z,log}
 
-echo_heading "Make source package for $fullsourcename"
-echo_heading "reconfigure"
+builder_heading "Make source package for $fullsourcename"
+builder_heading "reconfigure"
 TIER="$tier" ./scripts/reconf.sh $sourcename
 
-echo_heading "Make origdist"
+builder_heading "Make origdist"
 ./scripts/dist.sh origdist $sourcename
-echo_heading "Make deb source"
+builder_heading "Make deb source"
 ./scripts/deb.sh sourcepackage "$proj"
 
 #sign source package
 for file in builddebs/*.dsc; do
-	echo_heading "Signing source package $file"
+	builder_heading "Signing source package $file"
 	debsign -k"$2" "$file"
 done
 

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -73,7 +73,7 @@ if ! git diff --quiet; then
     builder_die "You have changed files in your git working directory. Exiting."
 fi
 
-echo_heading "Fetching latest changes"
+builder_heading "Fetching latest changes"
 git fetch -p origin
 stable_branch=$(git branch -r | grep origin/stable- | sort | tail -1)
 stable_branch=${stable_branch##* }
@@ -88,16 +88,16 @@ else
 fi
 
 cd "$KEYMAN_ROOT/linux"
-echo_heading "Building source package"
+builder_heading "Building source package"
 DIST=unstable DEBREVISION=$REVISION scripts/debian.sh
 cd debianpackage/
-echo_heading "Signing source package"
+builder_heading "Signing source package"
 debsign -k"$DEBKEYID" --re-sign ./*.changes
-echo_heading "Uploading packages to mentors.debian.net"
+builder_heading "Uploading packages to mentors.debian.net"
 $NOOP dput mentors ./*.changes
 cd ..
 
-echo_heading "Updating changelog"
+builder_heading "Updating changelog"
 # base changelog branch on remote stable branch
 git checkout -B chore/linux/changelog "$stable_branch"
 cp debianpackage/keyman-*/debian/changelog debian/
@@ -119,7 +119,7 @@ if [ -n "$PUSH" ]; then
     $NOOP git push --force-with-lease origin chore/linux/cherry-pick/changelog
 fi
 
-echo_heading "Finishing"
+builder_heading "Finishing"
 if $ISBETA; then
     git checkout beta
 else

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -47,7 +47,7 @@ while (( $# )); do
             if [ ! $# -eq 0 ]; then
                 DEBKEYID=$1
             else
-                fail "Error: The -k argument is missing a value. Exiting."
+                builder_die "Error: The -k argument is missing a value. Exiting."
             fi;;
         -n) NOOP=: ;;
         --help) usage ; exit 0 ;;
@@ -57,11 +57,11 @@ while (( $# )); do
             if [ ! $# -eq 0 ]; then
                 REVISION=$1
             else
-                fail "Error: The --debian-revision argument is missing a value. Exiting."
+                builder_die "Error: The --debian-revision argument is missing a value. Exiting."
             fi;;
-        *) fail "Error: Unexpected argument \"$1\". Exiting." ;;
+        *) builder_die "Error: Unexpected argument \"$1\". Exiting." ;;
     esac
-    shift || fail "Error: The last argument is missing a value. Exiting."
+    shift || builder_die "Error: The last argument is missing a value. Exiting."
 done
 
 if [ -z "$DEBKEYID" ]; then
@@ -70,7 +70,7 @@ if [ -z "$DEBKEYID" ]; then
 fi
 
 if ! git diff --quiet; then
-    fail "You have changed files in your git working directory. Exiting."
+    builder_die "You have changed files in your git working directory. Exiting."
 fi
 
 echo_heading "Fetching latest changes"

--- a/mac/Keyman4MacIM/make-km-dmg.sh
+++ b/mac/Keyman4MacIM/make-km-dmg.sh
@@ -143,7 +143,7 @@ fi
 WORKING_COPY_OF_IMAGE="$OUTPUT_DIR/Keyman-temp-$VERSION.dmg"
 displayInfo "Copying \"$TEMPLATE_IMAGE\" to \"$WORKING_COPY_OF_IMAGE\"..."
 if [[ -e "$WORKING_COPY_OF_IMAGE" && "$VERBOSITY" != "-quiet" ]] ; then
-    warn "Overwriting: $WORKING_COPY_OF_IMAGE"
+    builder_warn "Overwriting: $WORKING_COPY_OF_IMAGE"
 fi
 cp -f "$TEMPLATE_IMAGE" "$WORKING_COPY_OF_IMAGE"
 
@@ -210,7 +210,7 @@ DMG_FILE_PATH="$DEST_DIR/keyman-$VERSION.dmg"
 displayInfo "Converting/compressing image to create \"$DMG_FILE_PATH\""
 if [[ -e "$DMG_FILE_PATH" ]] ; then
     if [[ "$VERBOSITY" != "-quiet" ]] ; then
-        warn "Overwriting: $DMG_FILE_PATH"
+        builder_warn "Overwriting: $DMG_FILE_PATH"
     fi
     rm -rf "$DMG_FILE_PATH"
 fi

--- a/mac/Keyman4MacIM/make-km-dmg.sh
+++ b/mac/Keyman4MacIM/make-km-dmg.sh
@@ -64,7 +64,7 @@ while [[ $# -gt 0 ]] ; do
     case $key in
         -sourceApp)
             if [[ "$2" == "" || "$2" =~ ^\- ]]; then
-                fail "Missing source directory on command line."
+                builder_die "Missing source directory on command line."
             else
                 SOURCE_KM_APP=="$2"
                 shift # past argument
@@ -72,9 +72,9 @@ while [[ $# -gt 0 ]] ; do
             ;;
         -template)
             if [[ "$2" == "" || "$2" =~ ^\- ]]; then
-                fail "Missing template image on command line."
+                builder_die "Missing template image on command line."
             elif ! [[ "$2" =~ \.dmg$ ]]; then
-                fail "Template image must be a .dmg!"
+                builder_die "Template image must be a .dmg!"
             else
                 TEMPLATE_IMAGE="$2"
                 shift # past argument
@@ -82,7 +82,7 @@ while [[ $# -gt 0 ]] ; do
             ;;
         -destDir)
             if [[ "$2" == "" || "$2" =~ ^\- ]]; then
-                fail "Missing destination directory on command line."
+                builder_die "Missing destination directory on command line."
             else
                 DEST_DIR="$2"
                 ADD_VERSION_TO_DEST_DIR=false
@@ -103,7 +103,7 @@ while [[ $# -gt 0 ]] ; do
             display_usage
             ;;
         -*)
-          fail "Unknown option $1. Run with --help for help."
+          builder_die "Unknown option $1. Run with --help for help."
           ;;
     esac
     shift # past argument
@@ -111,21 +111,21 @@ done
 
 # Step 0 - check parameter and initial file state
 if [ "$VERSION" = "" ]; then
-  fail "Required -version parameter not specified!"
+  builder_die "Required -version parameter not specified!"
 fi
 
 if [[ ! -d "$SOURCE_KM_APP" ]]; then
-	fail "$SOURCE_KM_APP does not exist!"
+	builder_die "$SOURCE_KM_APP does not exist!"
 fi
 
 if [[ ! -f "$TEMPLATE_IMAGE" ]]; then
-	fail "$TEMPLATE_IMAGE does not exist!"
+	builder_die "$TEMPLATE_IMAGE does not exist!"
 fi
 
 if [[ ! -e "$OUTPUT_DIR" ]]; then
 	mkdir "$OUTPUT_DIR"
 elif [[ ! -d "$OUTPUT_DIR" ]]; then
-	fail "Output dir exists but is not a directory: $2"
+	builder_die "Output dir exists but is not a directory: $2"
 fi
 
 if $ADD_VERSION_TO_DEST_DIR ; then
@@ -134,7 +134,7 @@ fi
 if [[ ! -e "$DEST_DIR" ]]; then
 	mkdir -p "$DEST_DIR"
 elif [[ ! -d "$DEST_DIR" ]]; then
-	fail "Destination dir exists but is not a directory: $2"
+	builder_die "Destination dir exists but is not a directory: $2"
 fi
 
 # TODO: Check that no Keyman volume is already mounted.
@@ -150,16 +150,16 @@ cp -f "$TEMPLATE_IMAGE" "$WORKING_COPY_OF_IMAGE"
 # Step 2 - Mount (copy of) template image - writeable
 displayInfo "Attaching \"$WORKING_COPY_OF_IMAGE\"" "Mounting as \"$STAGING_DIR\"..."
 if [[ -e "$STAGING_DIR" ]]; then
-    fail "Mount folder $STAGING_DIR is already present. Unmount it first."
+    builder_die "Mount folder $STAGING_DIR is already present. Unmount it first."
 fi
 hdiutil attach "$WORKING_COPY_OF_IMAGE" -readwrite -mountpoint "$STAGING_DIR" $VERBOSITY
 if  ! [[ $? == 0 && -d "$STAGING_DIR" ]] ; then
-    fail "Image could not be mounted at: \"$STAGING_DIR\""
+    builder_die "Image could not be mounted at: \"$STAGING_DIR\""
 fi
 DEST_KM_APP="$STAGING_DIR/$KM_APP_NAME"
 if  ! [[ -d "$DEST_KM_APP" ]] ; then
     hdiutil detach $STAGING_DIR $VERBOSITY
-    fail "Expected mounted image to contain Keyman app, but \"$DEST_KM_APP\" does not exist."
+    builder_die "Expected mounted image to contain Keyman app, but \"$DEST_KM_APP\" does not exist."
 fi
 
 echo "---- Listing info in /Volumes/Keyman/ ----"
@@ -202,7 +202,7 @@ while (( DETACH_SUCCESS < 10 )); do
 done
 
 if (( DETACH_SUCCESS < 999 )); then
-    fail "Unable to unmount \"$STAGING_DIR\". Aborting build."
+    builder_die "Unable to unmount \"$STAGING_DIR\". Aborting build."
 fi
 
 # Step 5 - Convert image to a compressed readonly DMG image
@@ -216,7 +216,7 @@ if [[ -e "$DMG_FILE_PATH" ]] ; then
 fi
 hdiutil convert "$WORKING_COPY_OF_IMAGE" -format UDZO -o "$DMG_FILE_PATH" $VERBOSITY
 if ! [[ $? == 0 && -f "$DMG_FILE_PATH" ]]; then
-    fail "make-km-dmg failed to create \"$DMG_FILE_PATH\"."
+    builder_die "make-km-dmg failed to create \"$DMG_FILE_PATH\"."
 fi
 
 # Step 6 - Clean up

--- a/mac/Keyman4MacIM/write-download_info.sh
+++ b/mac/Keyman4MacIM/write-download_info.sh
@@ -85,7 +85,7 @@ DMG_FILE_SIZE=$(stat -f"%z" "$DMG_FILEPATH")
 DMG_MD5=$(md5 -q "$DMG_FILEPATH")
 
 if [[ -f "$DOWNLOAD_INFO_FILEPATH" ]]; then
-  warn "Overwriting $DOWNLOAD_INFO_FILEPATH"
+  builder_warn "Overwriting $DOWNLOAD_INFO_FILEPATH"
 fi
 
 echo { > "$DOWNLOAD_INFO_FILEPATH"

--- a/mac/Keyman4MacIM/write-download_info.sh
+++ b/mac/Keyman4MacIM/write-download_info.sh
@@ -49,7 +49,7 @@ while [[ $# -gt 0 ]] ; do
     case $key in
         -destDir)
             if [[ "$2" == "" || "$2" =~ ^\- ]]; then
-                fail "Missing destination directory on command line."
+                builder_die "Missing destination directory on command line."
             else
                 DEST_DIR="$2"
                 ADD_VERSION_TO_DEST_DIR=false
@@ -60,7 +60,7 @@ while [[ $# -gt 0 ]] ; do
             display_usage
             ;;
         -*)
-          fail "Unknown option $1. Run with --help for help."
+          builder_die "Unknown option $1. Run with --help for help."
           ;;
     esac
     shift # past argument
@@ -72,14 +72,14 @@ fi
 if [[ ! -e $DEST_DIR ]]; then
 	mkdir -p $DEST_DIR
 elif [[ ! -d $DEST_DIR ]]; then
-	fail "Destination dir exists but is not a directory: $2"
+	builder_die "Destination dir exists but is not a directory: $2"
 fi
 
 DMG_FILENAME="keyman-$VERSION.dmg"
 DMG_FILEPATH="$DEST_DIR/$DMG_FILENAME"
 DOWNLOAD_INFO_FILEPATH="${DMG_FILEPATH}.download_info"
 if [[ ! -f "$DMG_FILEPATH" ]]; then
-  fail "Cannot compute file size or MD5 for non-existent DMG file: $DMG_FILEPATH"
+  builder_die "Cannot compute file size or MD5 for non-existent DMG file: $DMG_FILEPATH"
 fi
 DMG_FILE_SIZE=$(stat -f"%z" "$DMG_FILEPATH")
 DMG_MD5=$(md5 -q "$DMG_FILEPATH")

--- a/mac/bashHelperFunctions.sh
+++ b/mac/bashHelperFunctions.sh
@@ -19,8 +19,6 @@ fail() {
     exit 1
 }
 
-warn() { echo "${WARNING_YELLOW}$*${NORMAL}"; }
-
 displayInfo() {
     if [ "$QUIET" != true ]; then
         while [[ $# -gt 0 ]] ; do

--- a/mac/bashHelperFunctions.sh
+++ b/mac/bashHelperFunctions.sh
@@ -10,15 +10,6 @@ if ! [[ "$TERM" == "" || "$TERM" == "dumb" ]]; then
     NORMAL=$(tput sgr0)
 fi
 
-fail() {
-    FAILURE_MSG="$1"
-    if [[ "$FAILURE_MSG" == "" ]]; then
-        FAILURE_MSG="Unknown failure"
-    fi
-    echo "${ERROR_RED}$FAILURE_MSG${NORMAL}"
-    exit 1
-}
-
 displayInfo() {
     if [ "$QUIET" != true ]; then
         while [[ $# -gt 0 ]] ; do
@@ -30,13 +21,13 @@ displayInfo() {
 
 assertFileExists() {
     if ! [ -f $1 ]; then
-        fail "Build failed:  missing $1"
+        builder_die "Build failed:  missing $1"
     fi
 }
 
 assertValidVersionNbr()
 {
     if [[ "$1" == "" || ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        fail "Specified version not valid: '$1'. Version should be in the form Major.Minor.BuildCounter"
+        builder_die "Specified version not valid: '$1'. Version should be in the form Major.Minor.BuildCounter"
     fi
 }

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -171,7 +171,7 @@ while [[ $# -gt 0 ]] ; do
             ;;
         -config)
             if [[ "$2" == "" || "$2" =~ ^\- ]]; then
-                warn "Missing config name on command line. Using 'Debug' as default..."
+                builder_warn "Missing config name on command line. Using 'Debug' as default..."
             else
                 if $PREPRELEASE && [[ "$2" != "Release" ]]; then
                     echo "Deployment option 'preprelease' supersedes $2 configuration."
@@ -268,8 +268,8 @@ displayInfo "" \
 if $LOCALDEPLOY && ! $NOTARIZE ; then
     if [ "$(spctl --status)" == "assessments enabled" ]; then
       echo
-      warn "WARNING: Notarization is disabled but SecAssessment security policy is still active. Keyman will not run correctly."
-      warn "         Disable SecAssessment with 'sudo spctl --master-disable' (or do notarized builds)"
+      builder_warn "WARNING: Notarization is disabled but SecAssessment security policy is still active. Keyman will not run correctly."
+      builder_warn "         Disable SecAssessment with 'sudo spctl --master-disable' (or do notarized builds)"
       fail "Re-run with '-deploy local' or disable SecAssessment."
     fi
 fi

--- a/mac/setup/build.sh
+++ b/mac/setup/build.sh
@@ -89,7 +89,7 @@ echo_heading "Zipping Install Keyman.app for notarization to $TARGET_ZIP_PATH"
 
 echo_heading "Uploading Install Keyman.zip to Apple for notarization"
 
-xcrun altool --notarize-app --primary-bundle-id "com.Keyman.install.zip" --asc-provider "$APPSTORECONNECT_PROVIDER" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --file "$TARGET_ZIP_PATH" --output-format xml > $ALTOOL_LOG_PATH || fail "altool failed"
+xcrun altool --notarize-app --primary-bundle-id "com.Keyman.install.zip" --asc-provider "$APPSTORECONNECT_PROVIDER" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --file "$TARGET_ZIP_PATH" --output-format xml > $ALTOOL_LOG_PATH || builder_die "altool failed"
 cat "$ALTOOL_LOG_PATH"
 
 ALTOOL_UUID=$(/usr/libexec/PlistBuddy -c "Print notarization-upload:RequestUUID" "$ALTOOL_LOG_PATH")
@@ -100,7 +100,7 @@ do
     # We'll sleep 30 seconds before checking status, to give the altool server time to process the archive
     echo "Waiting 30 seconds for status"
     sleep 30
-    xcrun altool --notarization-info "$ALTOOL_UUID" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --output-format xml > "$ALTOOL_LOG_PATH" || fail "altool failed"
+    xcrun altool --notarization-info "$ALTOOL_UUID" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --output-format xml > "$ALTOOL_LOG_PATH" || builder_die "altool failed"
     ALTOOL_STATUS=$(/usr/libexec/PlistBuddy -c "Print notarization-info:Status" "$ALTOOL_LOG_PATH")
     if [ "$ALTOOL_STATUS" == "success" ]; then
     ALTOOL_FINISHED=1
@@ -109,7 +109,7 @@ do
     cat "$ALTOOL_LOG_PATH"
     ALTOOL_LOG_URL=$(/usr/libexec/PlistBuddy -c "Print notarization-info:LogFileURL" "$ALTOOL_LOG_PATH")
     curl "$ALTOOL_LOG_URL"
-    fail "Notarization failed with $ALTOOL_STATUS; check log at $ALTOOL_LOG_PATH"
+    builder_die "Notarization failed with $ALTOOL_STATUS; check log at $ALTOOL_LOG_PATH"
     fi
 done
 
@@ -119,7 +119,7 @@ ALTOOL_LOG_URL=$(/usr/libexec/PlistBuddy -c "Print notarization-info:LogFileURL"
 curl "$ALTOOL_LOG_URL"
 echo
 echo_heading "Attempting to staple notarization to Install Keyman.app"
-xcrun stapler staple "$TARGET_APP_PATH" || fail "stapler failed"
+xcrun stapler staple "$TARGET_APP_PATH" || builder_die "stapler failed"
 
 # Done.
 # Now, we can add "Install Keyman.app" to the .dmg for distribution!

--- a/mac/setup/build.sh
+++ b/mac/setup/build.sh
@@ -83,11 +83,11 @@ TARGET_ZIP_PATH="$TARGETPATH/Install Keyman.zip"
 TARGET_APP_PATH="$TARGETAPP"
 ALTOOL_LOG_PATH="$TARGETPATH/altool.log"
 
-echo_heading "Zipping Install Keyman.app for notarization to $TARGET_ZIP_PATH"
+builder_heading "Zipping Install Keyman.app for notarization to $TARGET_ZIP_PATH"
 
 /usr/bin/ditto -c -k --keepParent "$TARGET_APP_PATH" "$TARGET_ZIP_PATH"
 
-echo_heading "Uploading Install Keyman.zip to Apple for notarization"
+builder_heading "Uploading Install Keyman.zip to Apple for notarization"
 
 xcrun altool --notarize-app --primary-bundle-id "com.Keyman.install.zip" --asc-provider "$APPSTORECONNECT_PROVIDER" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --file "$TARGET_ZIP_PATH" --output-format xml > $ALTOOL_LOG_PATH || builder_die "altool failed"
 cat "$ALTOOL_LOG_PATH"
@@ -113,12 +113,12 @@ do
     fi
 done
 
-echo_heading "Notarization completed successfully. Review logs below for any warnings."
+builder_heading "Notarization completed successfully. Review logs below for any warnings."
 cat "$ALTOOL_LOG_PATH"
 ALTOOL_LOG_URL=$(/usr/libexec/PlistBuddy -c "Print notarization-info:LogFileURL" "$ALTOOL_LOG_PATH")
 curl "$ALTOOL_LOG_URL"
 echo
-echo_heading "Attempting to staple notarization to Install Keyman.app"
+builder_heading "Attempting to staple notarization to Install Keyman.app"
 xcrun stapler staple "$TARGET_APP_PATH" || builder_die "stapler failed"
 
 # Done.

--- a/oem/firstvoices/common/build_keyboards.sh
+++ b/oem/firstvoices/common/build_keyboards.sh
@@ -29,11 +29,6 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 # the same parent folder as this repo, with the default name 'keyboards'
 KEYBOARDS_ROOT="$KEYMAN_ROOT/../keyboards"
 
-function die {
-  echo "FATAL: $1"
-  exit 99
-}
-
 function display_usage {
   echo "Usage: build_keyboards.sh [-download-keyboards] [-copy-keyboards] [-clean-keyboards] [-debug] [-h|-?]"
   echo "Builds all keyboards used by the app and copies them into the"
@@ -77,7 +72,7 @@ done
 
 # Check that $KEYBOARDS_TARGET is valid
 if [[ -z "$KEYBOARDS_TARGET" ]]; then
-  die "KEYBOARDS_TARGET cannot be empty"
+  builder_die "KEYBOARDS_TARGET cannot be empty"
 fi
 
 # Clean existing Keyboards folder
@@ -113,7 +108,7 @@ if [ $DO_BUILD = true ] || [ $DO_COPY = true ]; then
     while IFS=, read -r shortname id name region old_keyboard; do
       if [ $DO_BUILD = true ]; then
         echo "Building $id ($name)" # $shortname/$id -> $name"
-        WINEDEBUG=fixme-nls,fixme-thread "./build.sh" release/$shortname/$id || die "Unable to build keyboard $shortname/$id"
+        WINEDEBUG=fixme-nls,fixme-thread "./build.sh" release/$shortname/$id || builder_die "Unable to build keyboard $shortname/$id"
       fi
       if [ $DO_COPY = true ]; then
         echo "Copying $id ($name) to $KEYBOARDS_TARGET"
@@ -121,7 +116,6 @@ if [ $DO_BUILD = true ] || [ $DO_COPY = true ]; then
         unzip -o release/$shortname/$id/build/$id.kmp $id.js kmp.json -d "$SCRIPT_ROOT/$KEYBOARDS_TARGET/$id/"
         cp release/$shortname/$id/build/$id.keyboard_info "$SCRIPT_ROOT/$KEYBOARDS_TARGET/$id.keyboard_info"
       fi
-#        die "done"
     done
   } < "$SCRIPT_ROOT/../keyboards.csv"
 

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -163,11 +163,11 @@ if [ $DO_CARTHAGE = true ]; then
   echo
   echo "Load dependencies with Carthage"
 
-  carthage checkout || fail "Carthage dependency loading failed"
+  carthage checkout || builder_die "Carthage dependency loading failed"
 
   # --no-use-binaries: due to https://github.com/Carthage/Carthage/issues/3134,
   # which affects the sentry-cocoa dependency.
-  carthage build --use-xcframeworks --no-use-binaries --platform iOS || fail "Carthage dependency loading failed"
+  carthage build --use-xcframeworks --no-use-binaries --platform iOS || builder_die "Carthage dependency loading failed"
 fi
 
 #

--- a/resources/build/build-download-resources.sh
+++ b/resources/build/build-download-resources.sh
@@ -21,7 +21,7 @@ SHLVL=0
 function downloadKeyboardPackage() {
   # Check that $KEYBOARDS_TARGET is valid
   if [ "$#" -ne 2 ]; then
-      die "downloadKeyboardPackage requires KEYBOARD_PACKAGE_ID and KEYBOARDS_TARGET to be set"
+      builder_die "downloadKeyboardPackage requires KEYBOARD_PACKAGE_ID and KEYBOARDS_TARGET to be set"
   fi
   # Default Keyboard
   local ID="$1"
@@ -33,14 +33,14 @@ function downloadKeyboardPackage() {
   echo "Downloading ${ID}.kmp from downloads.keyman.com"
   local URL_DOWNLOAD_FILE=`curl -s "$URL_API_KEYBOARD_VERSION/${ID}" | "$JQ" -r .kmp`
   curl -f -s "$URL_DOWNLOAD_FILE" -o "$KEYBOARDS_TARGET" || {
-      die "Downloading $KEYBOARDS_TARGET failed with error $?"
+      builder_die "Downloading $KEYBOARDS_TARGET failed with error $?"
   }
 }
 
 function downloadModelPackage() {
   # Check that $MODELS_TARGET is valid
   if [ "$#" -ne 2 ]; then
-    die "downloadModelPackage requires MODEL_PACKAGE_ID and MODELS_TARGET to be set"
+    builder_die "downloadModelPackage requires MODEL_PACKAGE_ID and MODELS_TARGET to be set"
   fi
   # Default Model
   local ID="$1"
@@ -52,6 +52,6 @@ function downloadModelPackage() {
   echo "Downloading ${ID}.model.kmp from downloads.keyman.com"
   local URL_DOWNLOAD_FILE=`curl -s "$URL_API_MODEL_VERSION/${ID}" | "$JQ" -r .kmp`
   curl -f -s "$URL_DOWNLOAD_FILE" -o "$MODELS_TARGET" || {
-      die "Downloading $MODELS_TARGET failed with error $?"
+      builder_die "Downloading $MODELS_TARGET failed with error $?"
   }
 }

--- a/resources/build/build-utils-ci.test.sh
+++ b/resources/build/build-utils-ci.test.sh
@@ -20,7 +20,7 @@ echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBE
 if ! builder_pull_get_details; then
   echo "PASS: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER is not set"
 else
-  fail "FAIL: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER is not set"
+  builder_die "FAIL: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER is not set"
 fi
 
 
@@ -29,14 +29,14 @@ TEAMCITY_PR_NUMBER=master
 if ! builder_pull_get_details; then
   echo "PASS: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER=master"
 else
-  fail "FAIL: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER=master"
+  builder_die "FAIL: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER=master"
 fi
 
 
 echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=$TEAMCITY_PR_NUMBER${COLOR_RESET}"
 TEAMCITY_PR_NUMBER=7248
 if ! builder_pull_get_details; then
-  fail "FAIL: builder_pull_get_details was unable to read and parse PR details for #$TEAMCITY_PR_NUMBER from GitHub"
+  builder_die "FAIL: builder_pull_get_details was unable to read and parse PR details for #$TEAMCITY_PR_NUMBER from GitHub"
 fi
 
 # print metadata from PR
@@ -49,7 +49,7 @@ echo "PASS: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=$TEAMCITY_PR_NUMB
 
 echo "${COLOR_BLUE}## Testing: builder_pull_has_label epic-ldml${COLOR_RESET}"
 if ! builder_pull_has_label epic-ldml; then
-  fail "FAIL: builder_pull_has_label epic-ldml"
+  builder_die "FAIL: builder_pull_has_label epic-ldml"
 fi
 
 echo "PASS: builder_pull_has_label epic-ldml"

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -331,7 +331,7 @@ run_xcodebuild() {
 
   printXCodeBuildScriptLogs
   if [ $ret_code != 0 ]; then
-    fail "Build failed! Error: [$ret_code] when executing command: 'xcodebuild $cmnd'"
+    builder_die "Build failed! Error: [$ret_code] when executing command: 'xcodebuild $cmnd'"
   fi
 }
 

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -34,11 +34,6 @@
 #
 SHLVL=0
 
-function die() {
-  # TODO: consolidate this with fail() from shellHelperFunctions.sh
-  builder_die "$*"
-}
-
 function findKeymanRoot() {
     # See https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself
     # None of the answers are 100% correct for cross-platform

--- a/resources/build/history/history-utils.sh
+++ b/resources/build/history/history-utils.sh
@@ -192,7 +192,7 @@ get_version_notes() {
   process_history_loop "${history_file}" get_version_helper "$vn_version" "$vn_tier" "$vn_product"
 
   if [ $version_found = false ]; then
-    fail "Could not find changelog information for $vn_product version $vn_version $vn_tier."
+    builder_die "Could not find changelog information for $vn_product version $vn_version $vn_tier."
   fi
 }
 

--- a/resources/build/report-history.sh
+++ b/resources/build/report-history.sh
@@ -73,17 +73,17 @@ while [[ $# -gt 0 ]] ; do
       shift
       ;;
     *)
-      fail "Invalid parameters. Use --help for help"
+      builder_die "Invalid parameters. Use --help for help"
   esac
   shift
 done
 
 if [ -z "$GITHUB_TOKEN" ]; then
-  fail "Github token must be specified"
+  builder_die "Github token must be specified"
 fi
 
 if [ ! "$BASE" == "master" ] && [ ! "$BASE" == "beta" ] && [[ ! $BASE =~ stable-.+ ]]; then
-  fail "Invalid base branch $BASE"
+  builder_die "Invalid base branch $BASE"
 fi
 
 if [ ! -f "$KEYMAN_ROOT/resources/build/version/lib/index.js" ]; then

--- a/resources/build/tests/builder-deps.test.sh
+++ b/resources/build/tests/builder-deps.test.sh
@@ -36,7 +36,7 @@ function test_dep_should_build() {
   local dep="$2"
 
   if ! _builder_should_build_dep "$at" "resources/build/tests/$dep"; then
-    fail "FAIL: expecting to build dependency $dep for $at"
+    builder_die "FAIL: expecting to build dependency $dep for $at"
   else
     echo "PASS: will build dependency $dep for $at"
   fi
@@ -47,7 +47,7 @@ function test_dep_should_not_build() {
   local dep="$2"
 
   if _builder_should_build_dep "$at" "resources/build/tests/$dep"; then
-    fail "FAIL: not expecting to build dependency $dep for $at"
+    builder_die "FAIL: not expecting to build dependency $dep for $at"
   else
     echo "PASS: will not build dependency $dep for $at"
   fi
@@ -102,5 +102,5 @@ if [[ "${_builder_chosen_action_targets[@]}" == "test:project test:bar build:pro
   echo "PASS: 'build' actions automatically added"
 else
   echo "All targets: ${_builder_chosen_action_targets[@]}"
-  fail "FAIL: 'build' actions not automatically added, or unexpected action:targets added"
+  builder_die "FAIL: 'build' actions not automatically added, or unexpected action:targets added"
 fi

--- a/resources/build/tests/builder.inc.test.sh
+++ b/resources/build/tests/builder.inc.test.sh
@@ -15,14 +15,14 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 builder_describe - clean build
 builder_parse "build"
 if [[ "${_builder_chosen_action_targets[@]}" != "build:project" ]]; then
-  fail "  Test: builder_parse, shorthand form 'build' should give us 'build:project"
+  builder_die "  Test: builder_parse, shorthand form 'build' should give us 'build:project"
 fi
 
 if builder_start_action build; then
   echo "building project"
   builder_finish_action success build
 else
-  fail "FAIL: should have matched action build for :project"
+  builder_die "FAIL: should have matched action build for :project"
 fi
 
 # Longhand builder_describe, builder_parse
@@ -33,10 +33,10 @@ builder_describe_parse_short_test() {
   local expected="$3"
   local parameters="$4"
   echo "Testing: builder_describe, parse \"$actions\" \"$targets\" $parameters"
-  builder_describe "-" $actions $targets || fail "builder_describe died under curious circumstances"
-  builder_parse $parameters || fail "builder_parse died under curious circumstances"
+  builder_describe "-" $actions $targets || builder_die "builder_describe died under curious circumstances"
+  builder_parse $parameters || builder_die "builder_parse died under curious circumstances"
   if [[ "$expected" != "${_builder_chosen_action_targets[@]}" ]]; then
-    fail "  Test: builder_describe, parse \"$actions\" \"$targets\" $parameters != \"$expected\""
+    builder_die "  Test: builder_describe, parse \"$actions\" \"$targets\" $parameters != \"$expected\""
   fi
 }
 
@@ -50,7 +50,7 @@ builder_describe_parse_short_test "clean build test" ":module :tools :app :proje
 builder_describe "-" clean build test 'default+' :module :tools :app
 
 if [[ $_builder_default_action != "default" ]]; then
-  fail "FAIL: default action should have been 'default'"
+  builder_die "FAIL: default action should have been 'default'"
 fi
 
 # Shorthand form where we don't have a :target (default is ":project")
@@ -58,25 +58,25 @@ if builder_start_action build; then
   echo "building project"
   builder_finish_action success build
 else
-  fail "FAIL: should have matched action build for :project"
+  builder_die "FAIL: should have matched action build for :project"
 fi
 
 if builder_start_action clean:app; then
   echo "Cleaning <clean:app>"
   builder_finish_action success clean:app
 else
-  fail "FAIL: should have matched action clean for :app"
+  builder_die "FAIL: should have matched action clean for :app"
 fi
 
 if builder_start_action build:app; then
   echo "Building app"
   builder_finish_action success build:app
 else
-  fail "FAIL: should have matched action build for :app"
+  builder_die "FAIL: should have matched action build for :app"
 fi
 
 if builder_start_action build:module; then
-  fail "FAIL: should not have matched action build for :module"
+  builder_die "FAIL: should not have matched action build for :module"
 fi
 
 # "clean build test" ":app :engine" "--help"
@@ -88,12 +88,12 @@ builder_parse_test() {
   shift
   local parameters="$@"
   echo "${COLOR_BLUE}## Testing: builder_parse $parameters${COLOR_RESET}"
-  builder_parse $parameters || fail "builder_parse died under curious circumstances"
+  builder_parse $parameters || builder_die "builder_parse died under curious circumstances"
   if [[ "$expected" != "${_builder_chosen_action_targets[@]}" ]]; then
-    fail "  Test: builder_parse $parameters action:target != \"$expected\""
+    builder_die "  Test: builder_parse $parameters action:target != \"$expected\""
   fi
   if [[ "$expected_options" != "${_builder_chosen_options[@]}" ]]; then
-    fail "  Test: builder_parse $parameters, options != \"$expected\""
+    builder_die "  Test: builder_parse $parameters, options != \"$expected\""
   fi
 }
 
@@ -115,7 +115,7 @@ builder_parse_test "clean:app test:engine" "--power" clean:app test:engine --pow
 if builder_has_option --power; then
   echo "PASS: --power option found"
 else
-  fail "FAIL: --power option not found"
+  builder_die "FAIL: --power option not found"
 fi
 
 builder_parse_test "clean:app test:engine" "--zoom" clean:app test:engine -z
@@ -123,7 +123,7 @@ builder_parse_test "clean:app test:engine" "--zoom" clean:app test:engine -z
 if builder_has_option --zoom; then
   echo "PASS: --zoom option found"
 else
-  fail "FAIL: --zoom option not found"
+  builder_die "FAIL: --zoom option not found"
 fi
 
 # Test --feature <foo>
@@ -135,21 +135,21 @@ if builder_has_option --feature; then
   if [[ $FOO == xyzzy ]]; then
     echo "PASS: --feature option variable \$FOO has expected value 'xyzzy'"
   else
-    fail "FAIL: --feature option variable \$FOO had value '$FOO' but should have had 'xyzzy'"
+    builder_die "FAIL: --feature option variable \$FOO had value '$FOO' but should have had 'xyzzy'"
   fi
 else
-  echo "FAIL: --feature option not found"
+  builder_die "FAIL: --feature option not found"
 fi
 
 builder_parse -- one two "three four five"
 if [[ ${builder_extra_params[0]} != "one" ]]; then
-  fail "FAIL: -- extra parameter 'one' not found"
+  builder_die "FAIL: -- extra parameter 'one' not found"
 fi
 if [[ ${builder_extra_params[1]} != "two" ]]; then
-  fail "FAIL: -- extra parameter 'two' not found"
+  builder_die "FAIL: -- extra parameter 'two' not found"
 fi
 if [[ ${builder_extra_params[2]} != "three four five" ]]; then
-  fail "FAIL: -- extra parameter 'three four five' not found"
+  builder_die "FAIL: -- extra parameter 'three four five' not found"
 fi
 
 # Run tests based in separate scripts to facilitate their operation

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -132,6 +132,11 @@ function builder_warn() {
   echo "${COLOR_YELLOW}$*${COLOR_RESET}"
 }
 
+function builder_heading() {
+  echo -e "${HEADING_SETMARK}${COLOR_BLUE}$*${COLOR_RESET}"
+}
+
+
 ####################################################################################
 #
 # builder_ functions for standard build script parameter and process management

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -119,7 +119,11 @@ function builder_term() {
 
 function builder_die() {
   echo
-  echo "${COLOR_RED}$*${COLOR_RESET}"
+  if [[ $# -eq 0 ]]; then
+    echo "${COLOR_RED}Unspecified error, aborting script${COLOR_RESET}"
+  else
+    echo "${COLOR_RED}$*${COLOR_RESET}"
+  fi
   echo
   exit 1
 }

--- a/resources/devbox/iis-https/setup-iis-https.sh
+++ b/resources/devbox/iis-https/setup-iis-https.sh
@@ -20,7 +20,7 @@ if [[ $BUILDER_OS != win ]]; then
   fail "This script can only be run on Windows to setup IIS."
 fi
 
-warn "Warning: this script requires Administrator permissions to install certificates."
+builder_warn "Warning: this script requires Administrator permissions to install certificates."
 
 # Generate CA key
 echo_heading2 "Generating CA key"
@@ -106,4 +106,4 @@ echo "   curl.cainfo = \"C:\\tools\\php74\\cacert.pem\""
 echo "4. Finally, you may need to restart IIS for changes to take effect."
 
 echo_heading2 "Complete"
-warn "Please check logs above for errors and manual steps"
+builder_warn "Please check logs above for errors and manual steps"

--- a/resources/devbox/iis-https/setup-iis-https.sh
+++ b/resources/devbox/iis-https/setup-iis-https.sh
@@ -17,7 +17,7 @@ echo_heading2() {
 }
 
 if [[ $BUILDER_OS != win ]]; then
-  fail "This script can only be run on Windows to setup IIS."
+  builder_die "This script can only be run on Windows to setup IIS."
 fi
 
 builder_warn "Warning: this script requires Administrator permissions to install certificates."

--- a/resources/devbox/iis-https/setup-iis-https.sh
+++ b/resources/devbox/iis-https/setup-iis-https.sh
@@ -13,7 +13,7 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 
 echo_heading2() {
   echo ""
-  echo_heading "$*"
+  builder_heading "$*"
 }
 
 if [[ $BUILDER_OS != win ]]; then

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -52,10 +52,6 @@ log_error() {
   echo "${COLOR_RED}$THIS_SCRIPT_NAME: $*${COLOR_RESET}" >&2
 }
 
-log_warning() {
-  echo "${COLOR_YELLOW}$THIS_SCRIPT_NAME: $*${COLOR_RESET}" >&2
-}
-
 displayInfo() {
     if [ "$QUIET" != true ]; then
         while [[ $# -gt 0 ]] ; do

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -69,8 +69,6 @@ fail() {
     exit 1
 }
 
-warn() { echo "${COLOR_YELLOW}$*${COLOR_RESET}"; }
-
 displayInfo() {
     if [ "$QUIET" != true ]; then
         while [[ $# -gt 0 ]] ; do
@@ -175,7 +173,7 @@ write_download_info() {
   MD5_HASH=$(md5 -q "${BASE_PATH}/${BASE_FILE}")
 
   if [[ -f "$DOWNLOAD_INFO_FILEPATH" ]]; then
-    warn "Overwriting $DOWNLOAD_INFO_FILEPATH"
+    builder_warn "Overwriting $DOWNLOAD_INFO_FILEPATH"
   fi
 
   echo { > "$DOWNLOAD_INFO_FILEPATH"

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -44,14 +44,6 @@ verify_platform() {
   fi
 }
 
-# Note: COLOR_ and HEADING_ variables are defined in build-utils.sh
-# which is already required for scripts so these should be safe.
-# (part of TODO: consolidate these two scripts)
-
-log_error() {
-  echo "${COLOR_RED}$THIS_SCRIPT_NAME: $*${COLOR_RESET}" >&2
-}
-
 displayInfo() {
     if [ "$QUIET" != true ]; then
         while [[ $# -gt 0 ]] ; do

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -3,7 +3,7 @@
 # Allows for a quick macOS check for those scripts requiring a macOS environment.
 verify_on_mac() {
   if [[ "${OSTYPE}" != "darwin"* ]]; then
-    fail "This build script will only run in a Mac environment."
+    builder_die "This build script will only run in a Mac environment."
     exit 1
   fi
 }
@@ -22,7 +22,7 @@ verify_project() {
   done
 
   if [ $match = false ]; then
-    fail "Invalid project specified!"
+    builder_die "Invalid project specified!"
   fi
 }
 
@@ -40,7 +40,7 @@ verify_platform() {
   done
 
   if [ $match = false ]; then
-    fail "Invalid platform specified!"
+    builder_die "Invalid platform specified!"
   fi
 }
 
@@ -60,15 +60,6 @@ log_warning() {
   echo "${COLOR_YELLOW}$THIS_SCRIPT_NAME: $*${COLOR_RESET}" >&2
 }
 
-fail() {
-    FAILURE_MSG="$1"
-    if [[ "$FAILURE_MSG" == "" ]]; then
-        FAILURE_MSG="Unknown failure"
-    fi
-    echo "${COLOR_RED}$FAILURE_MSG${COLOR_RESET}"
-    exit 1
-}
-
 displayInfo() {
     if [ "$QUIET" != true ]; then
         while [[ $# -gt 0 ]] ; do
@@ -80,27 +71,27 @@ displayInfo() {
 
 assertFileExists() {
     if ! [ -f $1 ]; then
-        fail "Build failed:  missing $1"
+        builder_die "Build failed:  missing $1"
     fi
 }
 
 assertDirExists() {
     if ! [ -d $1 ]; then
-        fail "Build failed:  missing $1"
+        builder_die "Build failed:  missing $1"
     fi
 }
 
 assertValidVersionNbr()
 {
     if [[ "$1" == "" || ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        fail "Specified version not valid: '$1'. Version should be in the form Major.Minor.BuildCounter"
+        builder_die "Specified version not valid: '$1'. Version should be in the form Major.Minor.BuildCounter"
     fi
 }
 
 assertValidPRVersionNbr()
 {
     if [[ "$1" == "" || ! "$1" =~ ^[0-9]+\.[0-9]+\.pull\.[0-9]+$ ]]; then
-        fail "Specified version not valid: '$1'. Version should be in the form Major.Minor.pull.BuildCounter"
+        builder_die "Specified version not valid: '$1'. Version should be in the form Major.Minor.pull.BuildCounter"
     fi
 }
 
@@ -155,16 +146,16 @@ write_download_info() {
   KM_BLD_COUNTER="$((${KM_VERSION##*.}))"
 
   if [ "$KM_VERSION" = "" ]; then
-    fail "Required -version parameter not specified!"
+    builder_die "Required -version parameter not specified!"
   fi
 
   if [ "$KM_TIER" = "" ]; then
-    fail "Required -tier parameter not specified!"
+    builder_die "Required -tier parameter not specified!"
   fi
 
   DOWNLOAD_INFO_FILEPATH="${BASE_PATH}/${BASE_FILE}.download_info"
   if [[ ! -f "${BASE_PATH}/${BASE_FILE}" ]]; then
-    fail "Cannot compute file size or MD5 for non-existent DMG file: ${BASE_PATH}/${BASE_FILE}"
+    builder_die "Cannot compute file size or MD5 for non-existent DMG file: ${BASE_PATH}/${BASE_FILE}"
   fi
 
   FILE_EXTENSION="${BASE_FILE##*.}"
@@ -240,7 +231,7 @@ verify_npm_setup() {
 
   # Check if Node.JS/npm is installed.
   type npm >/dev/null ||\
-    fail "Build environment setup error detected!  Please ensure Node.js is installed!"
+    builder_die "Build environment setup error detected!  Please ensure Node.js is installed!"
 
   pushd "$KEYMAN_ROOT" > /dev/null
   npm ci

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -48,10 +48,6 @@ verify_platform() {
 # which is already required for scripts so these should be safe.
 # (part of TODO: consolidate these two scripts)
 
-echo_heading() {
-  echo -e "${HEADING_SETMARK}${COLOR_BLUE}$*${COLOR_RESET}"
-}
-
 log_error() {
   echo "${COLOR_RED}$THIS_SCRIPT_NAME: $*${COLOR_RESET}" >&2
 }

--- a/web/build.sh
+++ b/web/build.sh
@@ -350,7 +350,7 @@ copy_outputs ( ) {
 # ```
 compile ( ) {
   if [ $# -lt 1 ]; then
-    fail "Scripting error: insufficient argument count!"
+    builder_die "Scripting error: insufficient argument count!"
   fi
 
   local COMPILE_TARGET=$1
@@ -377,7 +377,7 @@ compile ( ) {
 # ```
 finalize ( ) {
   if [ $# -lt 2 ]; then
-    fail "Scripting error: insufficient argument count!"
+    builder_die "Scripting error: insufficient argument count!"
   fi
 
   local COMPILE_TARGET=$1
@@ -508,7 +508,7 @@ if builder_start_action build:embed; then
   #     pushd $EMBED_OUTPUTs
   #   fi
   #   echo "Uploading to Sentry..."
-  #   npm run sentry-cli -- releases files "$SENTRY_RELEASE_VERSION" upload-sourcemaps --strip-common-prefix $ARTIFACT_FOLDER --rewrite --ext js --ext map --ext ts || fail "Sentry upload failed."
+  #   npm run sentry-cli -- releases files "$SENTRY_RELEASE_VERSION" upload-sourcemaps --strip-common-prefix $ARTIFACT_FOLDER --rewrite --ext js --ext map --ext ts || builder_die "Sentry upload failed."
   #   echo "Upload successful."
   #   popd
   # fi
@@ -572,7 +572,7 @@ fi
 # if [ $UPLOAD_WEB_SENTRY = true ]; then
 #     pushd $WEB_OUTPUT
 #     echo "Uploading to Sentry..."
-#     npm run sentry-cli -- releases files "$SENTRY_RELEASE_VERSION" upload-sourcemaps --strip-common-prefix release/web/ --rewrite --ext js --ext map --ext ts || fail "Sentry upload failed."
+#     npm run sentry-cli -- releases files "$SENTRY_RELEASE_VERSION" upload-sourcemaps --strip-common-prefix release/web/ --rewrite --ext js --ext map --ext ts || builder_die "Sentry upload failed."
 #     echo "Upload successful."
 #     popd
 # fi

--- a/web/src/engine/build.sh
+++ b/web/src/engine/build.sh
@@ -120,7 +120,7 @@ builder_parse "$@"
 # ```
 compile ( ) {
   if [ $# -lt 1 ]; then
-    fail "Scripting error: insufficient argument count!"
+    builder_die "Scripting error: insufficient argument count!"
   fi
 
   local COMPILE_TARGET=$1

--- a/web/src/tools/building/check-build-size.sh
+++ b/web/src/tools/building/check-build-size.sh
@@ -154,7 +154,7 @@ if $WRITE_STATUS; then
     # If we have a GITHUB_TOKEN env var set, either via environment in TeamCity,
     # or via command line parameter, then we can attempt to report a GitHub status
     # check
-    die "Error: GITHUB_TOKEN variable is not set."
+    builder_die "Error: GITHUB_TOKEN variable is not set."
   fi
 
   if [ ! -z ${BUILD_VCS_NUMBER+x} ]; then
@@ -166,7 +166,7 @@ if $WRITE_STATUS; then
     # command line
     write_github_status_check "check/web/file-size" "$RESULT_STATE" "$RESULT_MESSAGE" "" $TARGET_SHA
   else
-    die "Error: could not find SHA to report against."
+    builder_die "Error: could not find SHA to report against."
   fi
 fi
 

--- a/web/test.sh
+++ b/web/test.sh
@@ -81,7 +81,7 @@ if builder_start_action test:engine; then
   fi
 
   if [[ DO_BROWSER_TEST_SUITE == false ]]; then
-    log_warning "Skipping action test:engine - this CI build does not appear to be for a Web PR."
+    builder_warn "Skipping action test:engine - this CI build does not appear to be for a Web PR."
     builder_finish_action success test:engine
     exit 0
   fi

--- a/windows/src/desktop/locale/crowdin-control.sh
+++ b/windows/src/desktop/locale/crowdin-control.sh
@@ -17,7 +17,7 @@ THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BA
 
 LOCALE_DIR="$KEYMAN_ROOT/windows/src/desktop/locale/"
 XSLT="$KEYMAN_ROOT/windows/bin/buildtools/xslt.exe"
-[ -f "$XSLT" ] || die "ERROR: Unable to find xslt.exe; build Keyman buildtools first."
+[ -f "$XSLT" ] || builder_die "ERROR: Unable to find xslt.exe; build Keyman buildtools first."
 
 SOURCE_LOCALE_XML="$KEYMAN_ROOT/windows/src/desktop/kmshell/xml/locale.xml"
 TARGET_STRINGS_XML="$LOCALE_DIR/strings.xml"
@@ -50,7 +50,7 @@ do_upload() {
 ##
 do_download() {
   # crowdin.bat download
-  die "Not yet implemented"
+  builder_die "Not yet implemented"
 }
 
 # Parse args
@@ -71,14 +71,14 @@ while [[ $# -gt 0 ]] ; do
       display_usage
       ;;
     *)
-      die "Invalid parameters specified. $0 --help for help."
+      builder_die "Invalid parameters specified. $0 --help for help."
       ;;
   esac
   shift # past argument
 done
 
 if [ -z $ACTION ]; then
-  die "No parameters specified. $0 --help for help.";
+  builder_die "No parameters specified. $0 --help for help.";
 fi
 
 if [ $ACTION = upload ]; then


### PR DESCRIPTION
@keymanapp-test-bot skip

Refactors the following helper functions in shellHelperFunctions.sh:

* `log_error` --> remove, unused
* `log_warning` --> `builder_warn`
* `echo_heading` --> `builder_heading`
* `fail` --> `builder_die`
* `die` --> `builder_die`
* `warn` --> `builder_warn`

It may be easier to review this PR commit-by-commit.