### PR TITLE
chore(developer): ignore Esc key when compiling

### DIFF
--- a/developer/src/kmcmpdll/Compiler.cpp
+++ b/developer/src/kmcmpdll/Compiler.cpp
@@ -521,7 +521,7 @@ BOOL CompileKeyboardHandle(HANDLE hInfile, PFILE_KEYBOARD fk)
   // must preprocess for group and store names -> this isn't really necessary, but never mind!
   while ((msg = ReadLine(hInfile, str, TRUE)) == CERR_None)
   {
-    if (GetAsyncKeyState(VK_ESCAPE) < 0) SetError(CERR_Break);
+    //if (GetAsyncKeyState(VK_ESCAPE) < 0) SetError(CERR_Break);
     p = str;
     switch (LineTokenType(&p))
     {
@@ -555,7 +555,7 @@ BOOL CompileKeyboardHandle(HANDLE hInfile, PFILE_KEYBOARD fk)
   /* ReadLine will automatically skip over $Keyman lines, and parse wrapped lines */
   while ((msg = ReadLine(hInfile, str, FALSE)) == CERR_None)
   {
-    if (GetAsyncKeyState(VK_ESCAPE) < 0) SetError(CERR_Break);
+    //if (GetAsyncKeyState(VK_ESCAPE) < 0) SetError(CERR_Break);
     msg = ParseLine(fk, str);
     if (msg != CERR_None) SetError(msg);
   }

--- a/developer/src/kmcmpdll/Compiler.cpp
+++ b/developer/src/kmcmpdll/Compiler.cpp
@@ -521,7 +521,6 @@ BOOL CompileKeyboardHandle(HANDLE hInfile, PFILE_KEYBOARD fk)
   // must preprocess for group and store names -> this isn't really necessary, but never mind!
   while ((msg = ReadLine(hInfile, str, TRUE)) == CERR_None)
   {
-    //if (GetAsyncKeyState(VK_ESCAPE) < 0) SetError(CERR_Break);
     p = str;
     switch (LineTokenType(&p))
     {
@@ -555,7 +554,6 @@ BOOL CompileKeyboardHandle(HANDLE hInfile, PFILE_KEYBOARD fk)
   /* ReadLine will automatically skip over $Keyman lines, and parse wrapped lines */
   while ((msg = ReadLine(hInfile, str, FALSE)) == CERR_None)
   {
-    //if (GetAsyncKeyState(VK_ESCAPE) < 0) SetError(CERR_Break);
     msg = ParseLine(fk, str);
     if (msg != CERR_None) SetError(msg);
   }


### PR DESCRIPTION
Long ago, ESC was a useful way to stop the compiler. These days, it's so fast that it's hard to break it that way anyway. It's also watching in the background, so that's bad... because if you have keyboard compiles happening in the background and hit Esc at the wrong time, you cancel the build. So... delete it!

@keymanapp-test-bot skip