### PR TITLE
fix(web): `--no-minify`, not `--skip-minify`

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -176,7 +176,7 @@ copy_resources ( ) {
   # thus doesn't need to publish sources or resources.
   local CONFIGS=(debug)
 
-  if ! builder_has_option --skip-minify; then
+  if ! builder_has_option --no-minify; then
     CONFIGS+=(release)
   fi
 
@@ -224,7 +224,7 @@ copy_sources ( ) {
   # thus doesn't need to publish sources or resources.
   CONFIGS=(debug)
 
-  if ! builder_has_option --skip-minify; then
+  if ! builder_has_option --no-minify; then
     CONFIGS+=(release)
   fi
 


### PR DESCRIPTION
@keymanapp-test-bot skip

Fixes #8255. (Doesn't attempt to address the idea of `--debug` vs `--no-minify`, which I think we need to consider more carefully.)