### PR TITLE
chore(docs): update docs due to Mac Ventura

### DIFF
--- a/docs/build/macos.md
+++ b/docs/build/macos.md
@@ -65,6 +65,13 @@ These dependencies are also listed below if you'd prefer to install manually.
   sudo ln -s /opt/homebrew/bin/greadlink /usr/local/bin/greadlink
   ```
 
+  On Ventura, you will need to adjust your PATH so that coreutils’ `realpath` takes precedence over the BSD one:
+
+  ```shell
+  # Credit: brew info coreutils
+  PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+  ```
+
 * Web: node.js, emscripten, openjdk 8
 
   ```shell


### PR DESCRIPTION
Symptom:

```
$ cd core ; ./build.sh build:arch
realpath: illegal option -- -
usage: realpath [-q] [path ...]
```

By the way, if this was done everywhere, we could use `readlink` instead of `greadlink` in the scripts.  I note that it says 'M1 only' but it might be Ventura only?

@keymanapp-test-bot skip