### PR TITLE
feat(common/web): sandboxed keyboard loading

### DIFF
--- a/common/web/keyboard-processor/src/keyboards/loaders/domKeyboardLoader.ts
+++ b/common/web/keyboard-processor/src/keyboards/loaders/domKeyboardLoader.ts
@@ -2,16 +2,18 @@
 
 ///<reference lib="dom" />
 
+import { default as DOMKeyboardSandbox } from './domKeyboardSandbox.js';
 import { Keyboard, KeyboardHarness, KeyboardLoaderBase, MinimalKeymanGlobal } from '@keymanapp/keyboard-processor';
 
 import { ManagedPromise } from '@keymanapp/web-utils';
 
 export class DOMKeyboardLoader extends KeyboardLoaderBase {
   public readonly element: HTMLIFrameElement;
+  private sandboxHost?: DOMKeyboardSandbox;
 
   constructor()
-  constructor(harness: KeyboardHarness);
-  constructor(harness?: KeyboardHarness) {
+  constructor(harness: KeyboardHarness, sandboxHost?: DOMKeyboardSandbox);
+  constructor(harness?: KeyboardHarness, sandboxHost?: DOMKeyboardSandbox) {
     if(harness && harness._jsGlobal != window) {
       // Copy the String typing over; preserve string extensions!
       harness._jsGlobal['String'] = window['String'];
@@ -22,12 +24,16 @@ export class DOMKeyboardLoader extends KeyboardLoaderBase {
     } else {
       super(harness);
     }
+
+    // sandboxHost?.detachFromDOM();
+    this.sandboxHost = sandboxHost;
   }
 
   protected loadKeyboardInternal(uri: string): Promise<Keyboard> {
     const promise = new ManagedPromise<Keyboard>();
 
     try {
+      // this.sandboxHost?.attachToDOM();
       const document = this.harness._jsGlobal.document;
       const script = document.createElement('script');
       document.head.appendChild(script);
@@ -41,6 +47,7 @@ export class DOMKeyboardLoader extends KeyboardLoaderBase {
       }
 
       promise.finally(() => {
+        // this.sandboxHost?.detachFromDOM();
         // It is safe to remove the script once it has been run (https://stackoverflow.com/a/37393041)
         script.remove();
       });
@@ -54,3 +61,5 @@ export class DOMKeyboardLoader extends KeyboardLoaderBase {
     return promise.corePromise;
   }
 }
+
+export { default as DOMKeyboardSandbox } from './domKeyboardSandbox.js';

--- a/common/web/keyboard-processor/src/keyboards/loaders/domKeyboardSandbox.ts
+++ b/common/web/keyboard-processor/src/keyboards/loaders/domKeyboardSandbox.ts
@@ -1,0 +1,49 @@
+// Enables DOM types, but just for this one module.
+///<reference lib="dom" />
+
+import { ManagedPromise } from "@keymanapp/web-utils";
+
+export default class DOMKeyboardSandbox {
+  public readonly sandboxHost: HTMLIFrameElement;
+  public get sandbox(): Window {
+    return this.sandboxHost.contentWindow;
+  }
+
+  private constructor() {
+    const host = this.sandboxHost = document.createElement('iframe');
+    host.style.display = 'none';
+    host.style.width = '0px';
+    host.style.height = '0px';
+    host.tabIndex = -1;
+    host.title = "Sandboxed keyboard loader";
+    host.hidden = true;
+  }
+
+  public static buildSandbox(): Promise<DOMKeyboardSandbox> {
+    // Promise:  because the iframe's document isn't instantly ready.
+    const promise = new ManagedPromise<DOMKeyboardSandbox>();
+    const instance = new DOMKeyboardSandbox();
+
+    instance.sandboxHost.onload = () => { promise.resolve(instance) };
+    instance.sandboxHost.onerror = () => { promise.reject() };
+
+    // Need to insert the sandbox into the DOM before it can load or error!
+    instance.attachToDOM();
+
+    return promise.corePromise;
+  }
+
+  public attachToDOM() {
+    if(!this.sandboxHost.parentElement) {
+      window.document.body.appendChild(this.sandboxHost);
+    }
+  }
+
+  // KNOWN LIMITATION:  must "throw away" after detaching from the DOM.
+  //                    Attempting to reattach + load more keyboards will fail to load those "more keyboards".
+  public detachFromDOM() {
+    if(this.sandboxHost.parentElement) {
+      this.sandboxHost.remove();
+    }
+  }
+}

--- a/common/web/keyboard-processor/src/keyboards/loaders/tsconfig.dom.json
+++ b/common/web/keyboard-processor/src/keyboards/loaders/tsconfig.dom.json
@@ -21,5 +21,5 @@
   "references": [
     { "path": "../../../tsconfig.common.json" }
   ],
-  "include": ["dom-keyboard-loader.ts", "domKeyboardLoader.ts"],
+  "include": ["dom-keyboard-loader.ts", "domKeyboardLoader.ts", "domKeyboardSandbox.ts"],
 }

--- a/common/web/keyboard-processor/tests/dom/cases/domKeyboardLoader.js
+++ b/common/web/keyboard-processor/tests/dom/cases/domKeyboardLoader.js
@@ -53,4 +53,47 @@ describe('Keyboard loading in DOM', function() {
     assert.isOk(window.KeymanWeb);
     assert.isOk(window.keyman);
   });
+
+  // Note:  tests already pass, but we don't wish to "turn the feature on" and maintain it at this time.
+  it.skip('`<iframe>` sandbox, disabled rule processing', async () => {
+    let sandboxedGlobal = await DOMKeyboardSandbox.buildSandbox();
+    let keyboardLoader = new DOMKeyboardLoader(new KeyboardHarness(sandboxedGlobal.sandbox, MinimalKeymanGlobal), sandboxedGlobal);
+    let keyboard = await keyboardLoader.loadKeyboardFromPath('/resources/keyboards/khmer_angkor.js');
+
+    assert.isOk(keyboard);
+    assert.equal(keyboard.id, 'Keyboard_khmer_angkor');
+    assert.isTrue(keyboard.isChiral);
+    assert.isFalse(keyboard.isCJK);
+    assert.isNotOk(window.KeymanWeb);
+    assert.isNotOk(window.keyman);
+  });
+
+  // Note:  tests already pass, but we don't wish to "turn the feature on" and maintain it at this time.
+  it.skip('`<iframe>` sandbox, enabled rule processing', async () => {
+    const sandboxedGlobal = await DOMKeyboardSandbox.buildSandbox();
+    const harness = new KeyboardInterface(sandboxedGlobal.sandbox, MinimalKeymanGlobal);
+    const keyboardLoader = new DOMKeyboardLoader(harness, sandboxedGlobal);
+    const keyboard = await keyboardLoader.loadKeyboardFromPath('/resources/keyboards/khmer_angkor.js');
+    assert.isNotOk(window.KeymanWeb);
+
+    assert.isOk(keyboard);
+    assert.equal(keyboard.id, 'Keyboard_khmer_angkor');
+    assert.isTrue(keyboard.isChiral);
+    assert.isFalse(keyboard.isCJK);
+    assert.isNotOk(window.KeymanWeb);
+    assert.isNotOk(window.keyman);
+
+    // TODO:  verify actual rule processing.
+    const nullKeyEvent = keyboard.constructNullKeyEvent(device);
+    const mock = new Mock();
+    const result = harness.processKeystroke(mock, nullKeyEvent);
+
+    assert.isOk(result);
+    assert.isNotOk(window.KeymanWeb);
+    assert.isNotOk(window.keyman);
+  });
+
+  // Obviously, not yet implemented; this aspect is not adequately tested and is a part of
+  // why the potential feature's on pause.
+  it.skip('`<iframe>` sandbox, loading from remote URL', () => {});
 });


### PR DESCRIPTION
**Note**:  the call was made during development of #8267 to not pursue this avenue further at this time due to the added complexity of proper test coverage and possible complications with `<iframe>` use - after all, our current focus is first on proper ES-module conversion, then on completion of new gesture features.

What this PR _does_ do, in its present state:  it demonstrates a pathway to load Keyman keyboards, which rely on reserving variable names in the global object, without actually needing to pollute the true global object for the active webpage.  This is done via use of "sandboxing" with invisible `<iframe>` elements.

_Just_ in case this turns up in random Google searches:  note that this is not designed as a 'security'-oriented sandbox; it would very likely fail in that regard.  Our goal here is simply to avoid variable name collisions with variables that a website author may create that would otherwise conflict with names Keyman Engine for Web wishes to use.

So, the fancy experiment:

### `DOMKeyboardSandbox`

_**NOTE**: while seemingly functional as is, this component is not thoroughly vetted... which is why this PR is in draft._

Up until now, the Keyman Engine for Web has always relied on loading keyboards against the main Window (`window`) global into specific variable names, effectively "reserving" them in the global space.  This is something that may or may not be acceptable to some site developers.  The process of modularizing KMW already gives us much to leverage for eliminating some of our "reserved" names... (farewell, `com`, `com.keyman`!) but there may be a way to eliminate _**all**_ of them - by sandboxing keyboard loads within an invisible `<iframe>`.

The key details of this approach?  Each `<iframe>`' comes complete with its own internal window and internal document; as such, the window of an iframe can act as a "sandboxed global" for any keyboards loaded within it, allowing us to reference the same names without polluting the _true_ global.

This has been proof-of-concept tested for files locally hosted (on `localhost` and via Karma.js), though not for remote files (as via `s.keyman.com`).  The first two ".skip"-ped tests within the `domKeyboardLoader.js` unit-test file will currently _pass_ if not skipped.