### PR TITLE
refactor(web): cookie serialization + deserialization 🧩

### DIFF
--- a/web/src/engine/dom-utils/src/cookieSerializer.ts
+++ b/web/src/engine/dom-utils/src/cookieSerializer.ts
@@ -1,0 +1,91 @@
+type DecodedCookieFieldValue = string | number | boolean;
+
+type FilteredRecordEncoder = (value: DecodedCookieFieldValue, key: string) => string;
+type FilteredRecordDecoder = (value: string, key: string) => DecodedCookieFieldValue;
+const no_change = (val: string) => val as string;
+
+export default class CookieSerializer<Type extends Record<keyof Type, DecodedCookieFieldValue>> {
+  readonly name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  load(decoder?: FilteredRecordEncoder): Type {
+    return this.loadCookie(this.name, decoder || no_change) as Type;
+  }
+
+  save(cookie: Type, encoder?: FilteredRecordEncoder) {
+    this.saveCookie(this.name, cookie, encoder || no_change);
+  }
+
+  /**
+   * Document cookie parsing for use by kernel, OSK, UI etc.
+   *
+   * @return      {Object}                  array of names and strings
+   */
+  private _loadRawCookies(): Record<string, string> {
+    let v: Record<string, string> = {};
+    if(typeof(document.cookie) != 'undefined' && document.cookie != '') {
+      let c = document.cookie.split(/;\s*/);
+      for(let i = 0; i < c.length; i++) {
+        let d = c[i].split('=');
+        if(d.length == 2) {
+          v[d[0]] = d[1];
+        }
+      }
+    }
+
+    return v;
+  }
+
+  /**
+   * Document cookie parsing for use by kernel, OSK, UI etc.
+   *
+   * @param       {string}        cookieName        cookie name
+   * @return      {Object}                  array of variables and values
+   */
+  private loadCookie(cookieName: string, decoder: FilteredRecordDecoder): Record<string, DecodedCookieFieldValue> {
+    let cookie: Record<string, DecodedCookieFieldValue> = {};
+    let allCookies = this._loadRawCookies();
+    const encodedCookie = allCookies[cookieName];
+
+    if(encodedCookie) {
+      let rawDecode = decodeURIComponent(encodedCookie).split(';');
+      for(let i=0; i<rawDecode.length; i++) {
+        // Prevent accidental empty-key entries caused by cookie-final ';'.
+        if(i == rawDecode.length - 1 && !rawDecode[i]) {
+          break;
+        }
+
+        let record = rawDecode[i].split('=');
+        if(record.length > 1) {
+          const [key, value] = record;
+          // key, value
+          cookie[key] = decoder(value, key);
+        } else {
+          // key, <implied 'true', as boolean flag>
+          cookie[record[0]] = '';
+        }
+      }
+    }
+    return cookie;
+  }
+
+  /**
+   * Standard cookie saving for use by kernel, OSK, UI etc.
+   *
+   * @param       {string}      cookieName            name of cookie
+   * @param       {Object}      cookieValueMap            object with array of named arguments and values
+   */
+  private saveCookie(cookieName: string, cookieValueMap: Record<string, DecodedCookieFieldValue>, encoder: FilteredRecordEncoder) {
+    let serialization='';
+    for(let key in cookieValueMap) {
+      serialization += key + '=' + encoder(cookieValueMap[key], key) + ";";
+    }
+
+    let d = new Date(new Date().valueOf() + 1000 * 60 * 60 * 24 * 30).toUTCString();
+    let cookieConfig = ' path=/; expires=' + d;  //Fri, 31 Dec 2099 23:59:59 GMT;';
+    document.cookie = `${cookieName}=${encodeURIComponent(serialization)}; ${cookieConfig}`;
+  }
+}

--- a/web/src/engine/dom-utils/src/cookieSerializer.ts
+++ b/web/src/engine/dom-utils/src/cookieSerializer.ts
@@ -11,7 +11,7 @@ export default class CookieSerializer<Type extends Record<keyof Type, DecodedCoo
     this.name = name;
   }
 
-  load(decoder?: FilteredRecordEncoder): Type {
+  load(decoder?: FilteredRecordDecoder): Type {
     return this.loadCookie(this.name, decoder || no_change) as Type;
   }
 

--- a/web/src/engine/dom-utils/src/index.ts
+++ b/web/src/engine/dom-utils/src/index.ts
@@ -2,3 +2,4 @@ export { getAbsoluteX, getAbsoluteY } from './getAbsolute.js';
 export { default as createUnselectableElement } from './createUnselectableElement.js';
 export { createStyleSheet, StylesheetManager } from './stylesheets.js';
 export { default as landscapeView } from './landscapeView.js';
+export { default as CookieSerializer } from './cookieSerializer.js';

--- a/web/src/engine/osk/src/index.ts
+++ b/web/src/engine/osk/src/index.ts
@@ -4,6 +4,8 @@ export { default as FloatingOSKView } from './views/floatingOskView.js';
 export { default as AnchoredOSKView } from './views/anchoredOskView.js';
 export { default as InlinedOSKView } from './views/inlinedOskView.js';
 export { BannerController } from './banner/bannerView.js';
+// Is referenced by at least one desktop UI module.
+export { FloatingOSKCookie as FloatingOSKViewCookie } from './views/floatingOskCookie.js';
 export { default as VisualKeyboard } from './visualKeyboard.js';
 export type { default as ViewConfiguration } from './config/viewConfiguration.js';
 

--- a/web/src/engine/osk/src/index.ts
+++ b/web/src/engine/osk/src/index.ts
@@ -1,7 +1,6 @@
 export { Codes, DeviceSpec, Keyboard, KeyboardProperties, SpacebarText } from '@keymanapp/keyboard-processor';
 
 export { default as FloatingOSKView } from './views/floatingOskView.js';
-export { default as FloatingOSKViewCookie } from './views/floatingOskCookie.js';
 export { default as AnchoredOSKView } from './views/anchoredOskView.js';
 export { default as InlinedOSKView } from './views/inlinedOskView.js';
 export { BannerController } from './banner/bannerView.js';

--- a/web/src/engine/osk/src/views/floatingOskCookie.ts
+++ b/web/src/engine/osk/src/views/floatingOskCookie.ts
@@ -1,13 +1,42 @@
 import { CookieSerializer } from 'keyman/engine/dom-utils';
 
 export interface FloatingOSKCookie {
-  visible: '0' | '1';
-  userSet: '0' | '1';
-  left: string;
-  top: string;
-  width?: string;
-  height?: string;
+  /**
+   * Notes whether or not the OSK was hidden at the end of the previous session.
+   */
+  visible: 0 | 1;
 
+  /**
+   * Notes whether or not the OSK was pinned (located by the user) at the end
+   * of the previous session.
+   */
+  userSet: 0 | 1;
+
+  /**
+   * Denotes the left-position of the OSK at the end of the previous session if pinned.
+   * Defaults to -1 if the value was undefined.
+   */
+  left: number;
+
+  /**
+   * Denotes the left-position of the OSK at the end of the previous session if pinned.
+   * Defaults to -1 if the value was undefined.
+   */
+  top: number;
+
+  /**
+   * The previously-set OSK width.
+   */
+  width?: number;
+
+  /**
+   * The previously-set OSK height.
+   */
+  height?: number;
+
+  /**
+   * The version of KeymanWeb active when this cookie was generated.
+   */
   _version: string;
 }
 
@@ -16,22 +45,25 @@ export class FloatingOSKCookieSerializer extends CookieSerializer<Required<Float
     super('KeymanWeb_OnScreenKeyboard');
   }
 
+  loadWithDefaults(defaults: Required<FloatingOSKCookie>) {
+    return {...defaults, ...this.load()};
+  }
+
   load() {
     const cookie = super.load((value, key) => {
       switch(key) {
-        case 'visible':
-        case 'userSet':
-          return Number.parseInt(value, 10);
-        default:
+        case 'version':
           return value;
+        default:
+          return Number.parseInt(value, 10);
       }
     });
 
-    if(!cookie['width']) {
-      delete cookie['width'];  // in case of a '' entry.
+    if(!cookie.width) {
+      delete cookie.width;  // in case of a '' entry.
     }
-    if(!cookie['height']) {
-      delete cookie['height']; // in case of a '' entry.
+    if(!cookie.height) {
+      delete cookie.height; // in case of a '' entry.
     }
 
     return cookie;

--- a/web/src/engine/osk/src/views/floatingOskCookie.ts
+++ b/web/src/engine/osk/src/views/floatingOskCookie.ts
@@ -1,4 +1,6 @@
-export default interface FloatingOSKCookie {
+import { CookieSerializer } from 'keyman/engine/dom-utils';
+
+export interface FloatingOSKCookie {
   visible: '0' | '1';
   userSet: '0' | '1';
   left: string;
@@ -7,4 +9,35 @@ export default interface FloatingOSKCookie {
   height?: string;
 
   _version: string;
+}
+
+export class FloatingOSKCookieSerializer extends CookieSerializer<Required<FloatingOSKCookie>> {
+  constructor() {
+    super('KeymanWeb_OnScreenKeyboard');
+  }
+
+  load() {
+    const cookie = super.load((value, key) => {
+      switch(key) {
+        case 'visible':
+        case 'userSet':
+          return Number.parseInt(value, 10);
+        default:
+          return value;
+      }
+    });
+
+    if(!cookie['width']) {
+      delete cookie['width'];  // in case of a '' entry.
+    }
+    if(!cookie['height']) {
+      delete cookie['height']; // in case of a '' entry.
+    }
+
+    return cookie;
+  }
+
+  save(cookie: Required<FloatingOSKCookie>) {
+    super.save(cookie);
+  }
 }

--- a/web/src/engine/osk/src/views/floatingOskView.ts
+++ b/web/src/engine/osk/src/views/floatingOskView.ts
@@ -172,16 +172,16 @@ export default class FloatingOSKView extends OSKView {
     var p = this.getPos();
 
     const c: FloatingOSKCookie = {
-      visible: this.displayIfActive ? '1' : '0',
-      userSet: this.userPositioned ? '1' : '0',
-      left: '' + p.left,
-      top: '' + p.top,
+      visible: this.displayIfActive ? 1 : 0,
+      userSet: this.userPositioned ?  1 : 0,
+      left: p.left,
+      top:  p.top,
       _version: Version.CURRENT.toString()
     }
 
     if(this.vkbd) {
-      c.width = '' + this.width.val;
-      c.height = '' + this.height.val;
+      c.width =  this.width.val;
+      c.height = this.height.val;
     }
 
     this.layoutSerializer.save(c as Required<FloatingOSKCookie>);
@@ -193,28 +193,26 @@ export default class FloatingOSKView extends OSKView {
    *  @return {boolean}
    */
   loadCookie(): void {
-    function parseIntWithDefault(str: string, fallback: number) {
-      let val = Number.parseInt(str, 10);
-      return isNaN(val) ? fallback: val;
-    }
+    let c = this.layoutSerializer.loadWithDefaults({
+      visible: 1,
+      userSet: 0,
+      left: -1,
+      top: -1,
+      _version: undefined,
+      width:  0.3*screen.width,
+      height: 0.15*screen.height
+    });
 
-    let c = this.layoutSerializer.load();
-
-    this.activationModel.enabled = parseIntWithDefault(c.visible, 1) == 1;
-    this.userPositioned = parseIntWithDefault(c.userSet, 0) == 1;
-    this.x = parseIntWithDefault(c.left,-1);
-    this.y = parseIntWithDefault(c.top,-1);
-    let cookieVersionString = c._version;
+    this.activationModel.enabled = c.visible == 1;
+    this.userPositioned = c.userSet == 1;
+    this.x = c.left;
+    this.y = c.top;
+    const cookieVersionString = c._version;
 
     // Restore OSK size - font size now fixed in relation to OSK height, unless overridden (in em) by keyboard
-    let dfltWidth=0.3*screen.width;
-    let dfltHeight=0.15*screen.height;
-
-    let newWidth  = parseInt(c.width, 10);
-    let newHeight = parseInt(c.height, 10);
-    let isNewCookie = isNaN(newHeight);
-    newWidth  = isNaN(newWidth)  ? dfltWidth  : newWidth;
-    newHeight = isNaN(newHeight) ? dfltHeight : newHeight;
+    const isNewCookie = cookieVersionString === undefined;
+    let newWidth  = c.width;
+    let newHeight = c.height;
 
     // Limit the OSK dimensions to reasonable values
     if(newWidth < 0.2*screen.width) {

--- a/web/src/engine/osk/src/views/floatingOskView.ts
+++ b/web/src/engine/osk/src/views/floatingOskView.ts
@@ -66,7 +66,7 @@ export default class FloatingOSKView extends OSKView {
 
     this.headerView = this.titleBar;
 
-    this.loadCookie();
+    this.loadPersistedLayout();
   }
 
   private get typedActivationModel(): TwoStateActivator<HTMLElement> {
@@ -110,7 +110,7 @@ export default class FloatingOSKView extends OSKView {
       this.footerView = null;
     }
 
-    this.loadCookie();
+    this.loadPersistedLayout();
     this.setNeedsLayout();
   }
 
@@ -127,13 +127,13 @@ export default class FloatingOSKView extends OSKView {
     let dragPromise = new ManagedPromise<void>();
     this.emit('dragMove', dragPromise.corePromise);
 
-    this.loadCookie();
+    this.loadPersistedLayout();
     this.userPositioned=false;
     if(!keepDefaultPosition) {
       delete this.dfltX;
       delete this.dfltY;
     }
-    this.saveCookie();
+    this.savePersistedLayout();
 
     if(isVisible) {
       this.present();
@@ -168,7 +168,7 @@ export default class FloatingOSKView extends OSKView {
   /**
    * Save size, position, font size and visibility of OSK
    */
-  saveCookie() {
+  private savePersistedLayout() {
     var p = this.getPos();
 
     const c: FloatingOSKCookie = {
@@ -192,7 +192,7 @@ export default class FloatingOSKView extends OSKView {
    *
    *  @return {boolean}
    */
-  loadCookie(): void {
+  private loadPersistedLayout(): void {
     let c = this.layoutSerializer.loadWithDefaults({
       visible: 1,
       userSet: 0,
@@ -406,7 +406,7 @@ export default class FloatingOSKView extends OSKView {
       this.movementEnabled = !this.noDrag;
     }
     // Save the user-defined OSK size
-    this.saveCookie();
+    this.savePersistedLayout();
   }
 
   /**
@@ -539,7 +539,7 @@ export default class FloatingOSKView extends OSKView {
     super.startHide(hiddenByUser);
 
     if(hiddenByUser) {
-      this.saveCookie();  // Save current OSK state, size and position (desktop only)
+      this.savePersistedLayout();  // Save current OSK state, size and position (desktop only)
     }
   }
 
@@ -549,7 +549,7 @@ export default class FloatingOSKView extends OSKView {
     } else {
       super['show']();
     }
-    this.saveCookie();
+    this.savePersistedLayout();
   }
 
   /**
@@ -651,7 +651,7 @@ export default class FloatingOSKView extends OSKView {
         this.dragPromise.then(() => {
           _this.userPositioned = true;
           _this.doResizeMove();
-          _this.saveCookie();
+          _this.savePersistedLayout();
         });
         this.dragPromise = null;
       }
@@ -729,7 +729,7 @@ export default class FloatingOSKView extends OSKView {
         // Remainder should be done after anything else pending on the Promise.
         this.dragPromise.then(() => {
           _this.doResizeMove();
-          _this.saveCookie();
+          _this.savePersistedLayout();
         });
         this.dragPromise = null;
       }

--- a/web/src/test/auto/dom/cases/dom-utils/cookies.js
+++ b/web/src/test/auto/dom/cases/dom-utils/cookies.js
@@ -1,0 +1,102 @@
+import Device from '/@keymanapp/keyman/build/engine/device-detect/lib/index.mjs';
+import { default as CookieSerializer } from '/@keymanapp/keyman/build/engine/dom-utils/obj/cookieSerializer.js';
+
+let assert = chai.assert;
+
+const device = new Device();
+device.detect();
+
+const RESET="max-age=0";
+
+describe('CookieSerializer', function () {
+  describe('SimpleTestCookie', () => {
+    const COOKIE_ID = "SimpleTestCookie";
+
+    beforeEach(() => {
+      // Purge the cookie!
+      document.cookie = `${COOKIE_ID}=foobar; ${RESET}`;
+
+      const cookieLoader = new CookieSerializer(COOKIE_ID);
+      assert.deepEqual(cookieLoader.load(), {});
+    });
+
+    it('serializes & reloads when all values are strings', () => {
+      const cookieWriter = new CookieSerializer(COOKIE_ID);
+      const obj = {
+        foo: 'bar',
+        widget: 'sprog',
+        fruity: 'tooty',
+        flagProp: ''
+      }
+      cookieWriter.save(obj);
+
+      const cookieReader = new CookieSerializer(COOKIE_ID);
+      const reloadedObj = cookieReader.load();
+
+      assert.deepEqual(reloadedObj, obj);
+      assert.notStrictEqual(reloadedObj, obj);
+    });
+
+    it('serializes all values to strings', () => {
+      const cookieWriter = new CookieSerializer(COOKIE_ID);
+      const obj = {
+        foo: 'bar',
+        two: 2,
+        true: true
+      }
+      const expectedObj = {
+        foo: 'bar',
+        two: `${2}`,
+        true: `${true}`
+      }
+      cookieWriter.save(obj);
+
+      const cookieReader = new CookieSerializer(COOKIE_ID);
+      const reloadedObj = cookieReader.load();
+
+      assert.deepEqual(reloadedObj, expectedObj);
+      assert.notStrictEqual(reloadedObj, expectedObj);
+    });
+
+    it('accepts custom deserialization', () => {
+      const cookieWriter = new CookieSerializer(COOKIE_ID);
+      const obj = {
+        foo: 'bar',
+        two: 2,
+        true: true
+      }
+      cookieWriter.save(obj);
+
+      const cookieReader = new CookieSerializer(COOKIE_ID);
+      const reloadedObj = cookieReader.load((value, key) => {
+        switch(key) {
+          case 'two':
+            return Number.parseInt(value, 10);
+          case 'true':
+            return value === 'true';
+          default:
+            return value;
+        }
+      });
+
+      assert.deepEqual(reloadedObj, obj);
+      assert.notStrictEqual(reloadedObj, obj);
+    });
+
+    it('works with encodeURIComponent + decodeURIComponent', () => {
+      const cookieWriter = new CookieSerializer(COOKIE_ID);
+      const obj = {
+        foo:     'bar',
+        symbols: ':;+&?@ =\n', // Stuff that'll royally wreck cookies if not encoded.
+        star:    '⭐' // Sure, why not test with an emoji?
+      }
+      cookieWriter.save(obj, encodeURIComponent);
+
+      const cookieReader = new CookieSerializer(COOKIE_ID);
+      const reloadedObj = cookieReader.load(decodeURIComponent);
+
+      assert.deepEqual(reloadedObj, obj);
+      assert.notStrictEqual(reloadedObj, obj);
+    });
+  });
+});


### PR DESCRIPTION
Modularizes Web's longstanding `loadCookie` and `saveCookie` utility functions as a serialization object with far better type-checking capabilities + Intellisense compatibility. 

Passing a compatible `interface` definition into the type parameter of the new `CookieSerializer` class allows it to type check inputs and provide automatic type-casting convenience on its loaded outputs.  The class's internal logic is also more thoroughly type-specified as well.  Furthermore, noting that some of our cookies need encoding of some kind - be it into strings or into `encodeURIComponent` forms of strings - it can also apply the necessary transforms during save and load operations.

The main motivations here:
- it'll be far, far easier to encapsulate any persistent-storage boilerplate code and logic
- the parent-class's defining module has literally no dependencies outside of the standard DOM - there's not even a single import in its source file.

Types of cookies currently used by the Keyman Engine for Web and its UI modules:
1. The desktop form-factor "floating" OSK persists positioning and sizing data across sessions.
    - This PR only addresses this one case, as it's the only one that's in a fully-modularized component.
2. Keyboards with variable stores may persist their values across sessions (via `VariableStoreCookieSerializer`)
    - This will very likely be addressed by the next PR in line.
3. The most recently-active keyboard's ID + language code pairing is persisted across settings, with KMW attempting to re-enable it if possible during page init on follow-up sessions.
4. The toggle UI module references cookies 1 and 3 above.
5. The toolbar UI module references cookie 3 above and creates its _own_ cookie the persists the most-recently examined region on the toolbar, making that the default region for future visits.

Note:  also includes removal of code that was modularized as components of #8056's `dom-utils` child package.  As we're already removing code from the same source file and relocating it to the same destination package, it's the second-best place to do that cleanup.  (The "first best" place would have been in #8056, of course, but that ship has sailed.)

@keymanapp-test-bot skip