### PR TITLE
chore(linux): Improve deb-packaging GHA

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -165,15 +165,13 @@ jobs:
     if: github.event.client_payload.isTestBuild == 'false'
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
-      with:
-        ref: '${{ github.event.client_payload.ref }}'
-
     - name: Install dput
-      uses: ./.github/actions/apt-install
-      with:
-        packages: dput
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        export DEBIAN_PRIORITY=critical
+        export DEBCONF_NOWARNINGS=yes
+        sudo apt-get update
+        sudo apt-get install -q -y dput
 
     - name: Setup .dput.cf
       run: |


### PR DESCRIPTION
This change eliminates the need to checkout the Keyman source repo on the self-hosted runner. The checkout previously timed out, and the only reason we need it was the `apt-install` action. So now we directly call `apt install` instead of using the action.

@keymanapp-test-bot skip