### PR TITLE
chore(linux): Cleanup GHA

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -248,24 +248,24 @@ jobs:
 
   set_status:
     name: Set result status on PR builds
-    needs: [sourcepackage, binary_packages, deb_signing, api_verification]
+    needs: [sourcepackage, binary_packages, api_verification]
     runs-on: ubuntu-latest
     if: ${{ always() && github.event.client_payload.isTestBuild == 'true' }}
     steps:
     - name: Set success
-      if: needs.sourcepackage.result == 'success' && needs.binary_packages.result == 'success' && (needs.deb_signing.result == 'success' || needs.deb_signing.result == 'skipped') && needs.api_verification.result == 'success'
+      if: needs.sourcepackage.result == 'success' && needs.binary_packages.result == 'success' && needs.api_verification.result == 'success'
       run: |
         echo "RESULT=success" >> $GITHUB_ENV
         echo "MSG=Package build succeeded" >> $GITHUB_ENV
 
     - name: Set cancelled
-      if: needs.sourcepackage.result == 'cancelled' || needs.binary_packages.result == 'cancelled' || needs.deb_signing.result == 'cancelled' || needs.api_verification.result == 'cancelled'
+      if: needs.sourcepackage.result == 'cancelled' || needs.binary_packages.result == 'cancelled' || needs.api_verification.result == 'cancelled'
       run: |
         echo "RESULT=error" >> $GITHUB_ENV
         echo "MSG=Package build cancelled" >> $GITHUB_ENV
 
     - name: Set failure
-      if: needs.sourcepackage.result == 'failure' || needs.binary_packages.result == 'failure' || needs.deb_signing.result == 'failure' || needs.api_verification.result == 'failure'
+      if: needs.sourcepackage.result == 'failure' || needs.binary_packages.result == 'failure' || needs.api_verification.result == 'failure'
       run: |
         echo "RESULT=failure" >> $GITHUB_ENV
         echo "MSG=Package build failed" >> $GITHUB_ENV


### PR DESCRIPTION
`deb_signing` only runs for release builds, so it doesn't make sense that `set_status` (which only runs for non-release builds) depends on it.

@keymanapp-test-bot skip