### PR TITLE
fix(android/app): Fix OSK width when rotating

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -345,6 +345,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   @Override
   public void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
+    KMManager.onConfigurationChanged(newConfig);
     getSupportActionBar().setBackgroundDrawable(getActionBarDrawable(this));
     resizeTextView(textView.isKeyboardVisible());
     invalidateOptionsMenu();


### PR DESCRIPTION
Fixes #8229

This issue was quite puzzling. Only on newer Android SDKs, the in-app keyboard width failed to refresh when rotating the device from portrait to landscape. System Keyboard wasn't affected so I compared `MainActivity.onConfigurationChanged` and `SystemKeyboard.onConfigurationChanged`.

I add this line, and OSK rotation works. I take revert, and the issue is reprod. afaict, the issue **not** appear on stable-16.0.

## User Testing
Setup - Use Android emulator/device with SDK >= 31

* **TEST_OSK_ROTATION** - Verifies OSK refreshes width on rotation
1. Install the PR build of Keyman for Android in portrait orientation
2. Observe the in-app keyboard fills the device width
3. Rotate the device to landscape (you may need to toggle the Android setting to auto-rotate)
4. Observe the in-app keyboard rotate to landscape 
5. Verify in-app keyboard fills the device width.




