### PR TITLE
fix(linux): Fix debian postinst script

### DIFF
--- a/linux/debian/ibus-keyman.postinst
+++ b/linux/debian/ibus-keyman.postinst
@@ -1,10 +1,13 @@
 #!/bin/sh
 
-set -e
+# Don't call `set -e`. Even if some commands should fail, it's still
+# worth running the rest of the commands.
 
 case "$1" in
 
   configure)
+    # (Re-)Start IBus
+
     # if don't have sudo and ps then don't attempt to restart ibus
     if which sudo > /dev/null && which ps > /dev/null; then
 
@@ -38,19 +41,19 @@ case "$1" in
 
       # Verify that it's running now
       if [ -n "$SUDO_USER" ] && id "$SUDO_USER" > /dev/null 2>/dev/null; then
-        ibusdaemon=$(ps --user "$SUDO_USER" -o s= -o cmd | grep --regexp="^[^ZT] ibus-daemon .*--xim.*")
+        ibusdaemon=$(ps --user "$SUDO_USER" -o s= -o cmd | grep --regexp="^[^ZT] \(/usr/bin/\)\?ibus-daemon .*--xim.*")
         if [ "$ibusdaemon" = "" ]; then
           # otherwise try to start it for the user installing the package
           if [ "$is_gnome_shell" = "1" ]; then
             for session in $(loginctl show-user "${SUDO_USER}" -p Sessions --value); do
               case $(loginctl show-session "${session}" -p Type --value) in
-                wayland) sudo -H -u "${SUDO_USER}" -i WAYLAND_DISPLAY=wayland-0 -- ibus-daemon -d -r --xim --panel disable;;
-                x11) sudo -H -u "${SUDO_USER}" -- ibus-daemon -d -r --xim --panel disable;;
+                wayland) sudo -H -u "${SUDO_USER}" -i WAYLAND_DISPLAY=wayland-0 -- /usr/bin/ibus-daemon -d -r --xim --panel disable;;
+                x11) sudo -H -u "${SUDO_USER}" -- /usr/bin/ibus-daemon -d -r --xim --panel disable;;
                 *) ;;
               esac
             done
           else
-            sudo -H -u "${SUDO_USER}" -- ibus-daemon -d -r --xim
+            sudo -H -u "${SUDO_USER}" -- /usr/bin/ibus-daemon -d -r --xim
           fi
         fi
       fi


### PR DESCRIPTION
The ibus-keyman post-installation script failed, causing the entire installation to fail. This change removes `set -e` so that we try to run the rest of the commands even when one command should fail. Also accounts for ibus-daemon being started with the full path, and start ibus-daemon with fill path as well.

@keymanapp-test-bot skip