### PR TITLE
fix(linux): Fix debian postinst script 🍒

### DIFF
--- a/linux/debian/ibus-keyman.postinst
+++ b/linux/debian/ibus-keyman.postinst
@@ -1,10 +1,13 @@
 #!/bin/sh
 
-set -e
+# Don't call `set -e`. Even if some commands should fail, it's still
+# worth running the rest of the commands.
 
 case "$1" in
 
   configure)
+    # (Re-)Start IBus
+
     # if don't have sudo and ps then don't attempt to restart ibus
     if which sudo > /dev/null && which ps > /dev/null; then
 
@@ -37,20 +40,20 @@ case "$1" in
       fi
 
       # Verify that it's running now
-      if [ ! -z $SUDO_USER ] && id $SUDO_USER > /dev/null 2>/dev/null; then
-        ! ibusdaemon=$(ps --user $SUDO_USER -o s= -o cmd | grep --regexp="^[^ZT] ibus-daemon .*--xim.*")
-        if [ "x$ibusdaemon" = "x" ]; then
+      if [ -n "$SUDO_USER" ] && id "$SUDO_USER" > /dev/null 2>/dev/null; then
+        ibusdaemon=$(ps --user "$SUDO_USER" -o s= -o cmd | grep --regexp="^[^ZT] \(/usr/bin/\)\?ibus-daemon .*--xim.*")
+        if [ "$ibusdaemon" = "" ]; then
           # otherwise try to start it for the user installing the package
-          if [ "x$is_gnome_shell" = "x1" ]; then
-            for session in $(loginctl show-user ${SUDO_USER} -p Sessions --value); do
-              case $(loginctl show-session ${session} -p Type --value) in
-                wayland) sudo -H -u "${SUDO_USER}" -i WAYLAND_DISPLAY=wayland-0 -- ibus-daemon -d -r --xim --panel disable;;
-                x11) sudo -H -u "${SUDO_USER}" -- ibus-daemon -d -r --xim --panel disable;;
+          if [ "$is_gnome_shell" = "1" ]; then
+            for session in $(loginctl show-user "${SUDO_USER}" -p Sessions --value); do
+              case $(loginctl show-session "${session}" -p Type --value) in
+                wayland) sudo -H -u "${SUDO_USER}" -i WAYLAND_DISPLAY=wayland-0 -- /usr/bin/ibus-daemon -d -r --xim --panel disable;;
+                x11) sudo -H -u "${SUDO_USER}" -- /usr/bin/ibus-daemon -d -r --xim --panel disable;;
                 *) ;;
               esac
             done
           else
-            sudo -H -u "${SUDO_USER}" -- ibus-daemon -d -r --xim
+            sudo -H -u "${SUDO_USER}" -- /usr/bin/ibus-daemon -d -r --xim
           fi
         fi
       fi


### PR DESCRIPTION
The ibus-keyman post-installation script could fail, causing the entire installation to fail. This change removes `set -e` so that we try to run the rest of the commands even when one command should fail. Also accounts for ibus-daemon being started with the full path, and start ibus-daemon with fill path as well.

(🍒-picked from PR #8294)

# User Testing

## Preparations

- The tests should be run on these Linux platforms:
  - **GROUP_JAMMY_X11:** Ubuntu 22.04 Jammy with Gnome Shell and X11 ("Ubuntu on Xorg")
  - **GROUP_KINETIC_X11:** Ubuntu 22.10 Kinetic with Gnome Shell and X11 ("Ubuntu on Xorg")
- Download package build artifacts for this PR

## Tests

- **TEST_INSTALL:** Install keyman and onboard

  - in a terminal window, run the following commands in the directory where the packages got extracted (this might show errors):
    ```
    sudo apt update
    sudo dpkg -i \
      {ibus-keyman,libkmnkbp0}*$(lsb_release -s -c)*$(dpkg --print-architecture).deb \
      {keyman,python3-keyman-config}*$(lsb_release -s -c)*all.deb
    sudo apt install -f
    ```
  - run:
    ```
    sudo dpkg -i \
      {ibus-keyman,libkmnkbp0}*$(lsb_release -s -c)*$(dpkg --print-architecture).deb \
      {keyman,python3-keyman-config}*$(lsb_release -s -c)*all.deb
    ```
  - verify that this works without showing any error
  - verify that ibus is running:
    ```
    ps --user "$USER" -o s= -o cmd | grep --regexp="^[^ZT] \(/usr/bin/\)\?ibus-daemon .*--xim.*"
    ``` 
    This should show one line similar to this:
    ```
    S /usr/bin/ibus-daemon -d -r --xim --panel disable
    ```

