### PR TITLE
feat(developer): kmc build command 🙀

### DIFF
--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -50,7 +50,7 @@ endforeach
 
 foreach kbd : tests_with_testdata
   configure_file(
-    command: kmc_cmd + ['build-test-data', '@INPUT@', '@OUTPUT@'],
+    command: kmc_cmd + ['build-test-data', '@INPUT@', '--out-file', '@OUTPUT@'],
     output: kbd + '-test.json',
     input: kbd + '-test.xml'
   )

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -42,7 +42,7 @@ foreach kbd : tests
   )
 
   configure_file(
-    command: kmc_cmd + ['@INPUT@', '--out-file', '@OUTPUT@'],
+    command: kmc_cmd + ['build', '@INPUT@', '--out-file', '@OUTPUT@'],
     output: kbd + '.kmx',
     input: kbd + '.xml'
   )
@@ -50,7 +50,7 @@ endforeach
 
 foreach kbd : tests_with_testdata
   configure_file(
-    command: kmc_cmd + ['@INPUT@', '--test-data', '@OUTPUT@'],
+    command: kmc_cmd + ['build-test-data', '@INPUT@', '@OUTPUT@'],
     output: kbd + '-test.json',
     input: kbd + '-test.xml'
   )

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@keymanapp/keyman-version": "*",
     "@keymanapp/models-types": "*",
-    "commander": "^3.0.0",
     "typescript": "^4.9.5",
     "xml2js": "^0.4.19"
   },

--- a/developer/src/kmc/README.md
+++ b/developer/src/kmc/README.md
@@ -34,7 +34,7 @@ kmc Usage
 
 To compile an LDML keyboard from its `.xml` source, use `kmc`:
 
-    kmc my-keyboard.xml --outFile my-keyboard.kmx
+    kmc build my-keyboard.xml --outFile my-keyboard.kmx
 
 To see more command line options by using the `--help` option:
 

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -45,8 +45,9 @@ if builder_start_action clean; then
 else
   # We need the schema file at runtime and bundled, so always copy it for all actions except `clean`
   mkdir -p "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json" "$THIS_SCRIPT_PATH/build/src/"
+  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/util/"
+  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json" "$THIS_SCRIPT_PATH/build/src/util/"
+  cp "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json" "$THIS_SCRIPT_PATH/build/src/util/"
 fi
 
 

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -44,7 +44,7 @@ if builder_start_action clean; then
   builder_finish_action success clean
 else
   # We need the schema file at runtime and bundled, so always copy it for all actions except `clean`
-  mkdir -p "$THIS_SCRIPT_PATH/build/src/"
+  mkdir -p "$THIS_SCRIPT_PATH/build/src/util/"
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/util/"
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json" "$THIS_SCRIPT_PATH/build/src/util/"
   cp "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json" "$THIS_SCRIPT_PATH/build/src/util/"

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -44,7 +44,7 @@
     "@keymanapp/kmc-model-info": "*",
     "@keymanapp/kmc-package": "*",
     "@keymanapp/models-types": "*",
-    "commander": "^3.0.0"
+    "commander": "^10.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/developer/src/kmc/src/activities/buildLdmlKeyboard.ts
+++ b/developer/src/kmc/src/activities/buildLdmlKeyboard.ts
@@ -1,0 +1,81 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as kmc from '@keymanapp/kmc-keyboard';
+import { KvkFileWriter, CompilerCallbacks } from '@keymanapp/common-types';
+import { NodeCompilerCallbacks } from '../util/NodeCompilerCallbacks.js';
+
+export function buildLdmlKeyboard(infile: string, options: any) {
+  // TODO-LDML: consider hardware vs touch -- touch-only layout will not have a .kvk
+  // Compile:
+  let [kmx,kvk,kmw] = buildLdmlKeyboardToMemory(infile, options);
+  // Output:
+
+  const fileBaseName = options.outFile ?? infile;
+  const outFileBase = path.basename(fileBaseName, path.extname(fileBaseName));
+  const outFileDir = path.dirname(fileBaseName);
+
+  if(kmx && kvk) {
+    const outFileKmx = path.join(outFileDir, outFileBase + '.kmx');
+    console.log(`Writing compiled keyboard to ${outFileKmx}`);
+    fs.writeFileSync(outFileKmx, kmx);
+
+    const outFileKvk = path.join(outFileDir, outFileBase + '.kvk');
+    console.log(`Writing compiled visual keyboard to ${outFileKvk}`);
+    fs.writeFileSync(outFileKvk, kvk);
+  } else {
+    console.error(`An error occurred compiling ${infile}`);
+    process.exit(1);
+  }
+
+  if(kmw) {
+    const outFileKmw = path.join(outFileDir, outFileBase + '.js');
+    console.log(`Writing compiled js keyboard to ${outFileKmw}`);
+    fs.writeFileSync(outFileKmw, kmw);
+  }
+}
+
+function buildLdmlKeyboardToMemory(inputFilename: string, options: any): [Uint8Array, Uint8Array, Uint8Array] {
+  let compilerOptions: kmc.CompilerOptions = {
+    debug: options.debug ?? false,
+    addCompilerVersion: options.compilerVersion ?? true
+  }
+
+  const c: CompilerCallbacks = new NodeCompilerCallbacks();
+  const k = new kmc.Compiler(c, options);
+  let source = k.load(inputFilename);
+  if (!source) {
+    return [null, null, null];
+  }
+  if (!k.validate(source)) {
+    return [null, null, null];
+  }
+  let kmx = k.compile(source);
+  if (!kmx) {
+    return [null, null, null];
+  }
+
+  // In order for the KMX file to be loaded by non-KMXPlus components, it is helpful
+  // to duplicate some of the metadata
+  kmc.KMXPlusMetadataCompiler.addKmxMetadata(kmx.kmxplus, kmx.keyboard, compilerOptions);
+
+  // Use the builder to generate the binary output file
+  const builder = new kmc.KMXBuilder(kmx, options.debug);
+  const kmx_binary = builder.compile();
+
+  const vkcompiler = new kmc.VisualKeyboardCompiler();
+  const vk = vkcompiler.compile(source);
+  const writer = new KvkFileWriter();
+  const kvk_binary = writer.write(vk);
+
+  // Note: we could have a step of generating source files here
+  // KvksFileWriter()...
+  // const tlcompiler = new kmc.TouchLayoutCompiler();
+  // const tl = tlcompiler.compile(source);
+  // const tlwriter = new TouchLayoutFileWriter();
+  const kmwcompiler = new kmc.KeymanWebCompiler(compilerOptions);
+  const kmw_string = kmwcompiler.compile(inputFilename, source);
+  const encoder = new TextEncoder();
+  const kmw_binary = encoder.encode(kmw_string);
+
+  return [kmx_binary, kvk_binary, kmw_binary];
+}

--- a/developer/src/kmc/src/activities/buildTestData.ts
+++ b/developer/src/kmc/src/activities/buildTestData.ts
@@ -1,0 +1,34 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as kmc from '@keymanapp/kmc-keyboard';
+import { CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
+import { NodeCompilerCallbacks } from '../util/NodeCompilerCallbacks.js';
+
+export function buildTestData(infile: string) {
+  let compilerOptions: kmc.CompilerOptions = {
+    debug: false,
+    addCompilerVersion: false
+  };
+
+  let testData = loadTestData(infile, compilerOptions);
+  if (!testData) {
+    return;
+  }
+
+  const fileBaseName = infile;
+  const outFileBase = path.basename(fileBaseName, path.extname(fileBaseName));
+  const outFileDir = path.dirname(fileBaseName);
+  const outFileJson = path.join(outFileDir, outFileBase + '.json');
+  console.log(`Writing JSON test data to ${outFileJson}`);
+  fs
+  .writeFileSync(outFileJson, JSON.stringify(testData, null, '  '));
+}
+function loadTestData(inputFilename: string, options: kmc.CompilerOptions): LDMLKeyboardTestDataXMLSourceFile {
+  const c: CompilerCallbacks = new NodeCompilerCallbacks();
+  const k = new kmc.Compiler(c, options);
+  let source = k.loadTestData(inputFilename);
+  if (!source) {
+    return null;
+  }
+  return source;
+}

--- a/developer/src/kmc/src/activities/buildTestData.ts
+++ b/developer/src/kmc/src/activities/buildTestData.ts
@@ -4,7 +4,7 @@ import * as kmc from '@keymanapp/kmc-keyboard';
 import { CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
 import { NodeCompilerCallbacks } from '../util/NodeCompilerCallbacks.js';
 
-export function buildTestData(infile: string) {
+export function buildTestData(infile: string, options: any) {
   let compilerOptions: kmc.CompilerOptions = {
     debug: false,
     addCompilerVersion: false
@@ -15,7 +15,7 @@ export function buildTestData(infile: string) {
     return;
   }
 
-  const fileBaseName = infile;
+  const fileBaseName = options.outFile ?? infile;
   const outFileBase = path.basename(fileBaseName, path.extname(fileBaseName));
   const outFileDir = path.dirname(fileBaseName);
   const outFileJson = path.join(outFileDir, outFileBase + '.json');

--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -1,0 +1,53 @@
+import { Command } from 'commander';
+import { buildLdmlKeyboard } from '../activities/buildLdmlKeyboard.js';
+
+export function declareBuild(program: Command) {
+  program
+    .command('build [infile...]')
+    .description('Build a source file into a final file')
+    .option('-d, --debug', 'Include debug information in output')
+    .option('-o, --out-file <filename>', 'where to save the resulting .kmx file')
+    .option('--no-compiler-version', 'Exclude compiler version metadata from output')
+    .action((infiles: string[], options: any) => {
+      if(!infiles.length) {
+        console.debug('Assuming infile == .');
+        build('.', options);
+      }
+      for(let infile of infiles) {
+        build(infile, options);
+      }
+    });
+}
+
+function build(infile: string, options: any) {
+  console.log(`Building ${infile}`);
+
+  if(infile.endsWith('.xml')) {
+    return buildLdmlKeyboard(infile, options);
+  }
+
+/*
+  if(infile.endsWith('.kmn')) {
+    return buildKmnKeyboard(infile, options);
+  }
+
+  if(infile.endsWith('.kps')) {
+    return buildPackage(infile, options);
+  }
+
+  if(infile.endsWith('.model.ts')) {
+    return buildModel(infile, options);
+  }
+
+  if(infile.endsWith('.kpj')) {
+    return buildProject(infile, options);
+  }
+
+  if(fs.statSync(infile).isDirectory()) {
+    return buildProjectFolder(infile, options);
+  }
+*/
+
+  console.error(`Unrecognised input file ${infile}, expecting .xml, .kmn, .kps, .model.ts, .kpj, or project folder`);
+  process.exit(2);
+}

--- a/developer/src/kmc/src/commands/buildTestData.ts
+++ b/developer/src/kmc/src/commands/buildTestData.ts
@@ -7,7 +7,7 @@ export function declareBuildTestData(program: Command) {
   program
     .command('build-test-data <infile>')
     .description('Convert keyboard test .xml to .json')
-    .option('-o, --out-file <filename>', 'where to save the resulting .kmx file')
+    .option('-o, --out-file <filename>', 'where to save the resulting .json file')
     .action(buildTestData);
 }
 

--- a/developer/src/kmc/src/commands/buildTestData.ts
+++ b/developer/src/kmc/src/commands/buildTestData.ts
@@ -1,0 +1,14 @@
+
+
+import { Command } from 'commander';
+import { buildTestData } from '../activities/buildTestData.js';
+
+export function declareBuildTestData(program: Command) {
+  program
+    .command('build-test-data <infile>')
+    .description('Convert keyboard test .xml to .json')
+    .option('-o, --out-file <filename>', 'where to save the resulting .kmx file')
+    .action(buildTestData);
+}
+
+

--- a/developer/src/kmc/src/kmc.ts
+++ b/developer/src/kmc/src/kmc.ts
@@ -3,172 +3,44 @@
  * kmc - Keyman Next Generation Compiler
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
 
 import { Command } from 'commander';
-import * as kmc from '@keymanapp/kmc-keyboard';
 import KEYMAN_VERSION from "@keymanapp/keyman-version/keyman-version.mjs";
-import { KvkFileWriter, CompilerCallbacks, CompilerEvent, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
-
-let inputFilename: string;
+import { declareBuild } from './commands/build.js';
+import { declareBuildTestData } from './commands/buildTestData.js';
 
 const program = new Command();
+
 /* Arguments */
 program
-  .description('Compiles Keyman LDML keyboards')
-  .version(KEYMAN_VERSION.VERSION_WITH_TAG)
-  .arguments('<infile>')
-  .action((infile:any) => inputFilename = infile)
-  .option('-d, --debug', 'Include debug information in output')
-  .option('--no-compiler-version', 'Exclude compiler version metadata from output')
-  .option('-o, --out-file <filename>', 'where to save the resulting .kmx file')
-  .option('-T, --test-data <filename>', 'Convert keyboard test .xml to .json');
+  .description('Keyman Developer Command Line Interface')
+  .version(KEYMAN_VERSION.VERSION_WITH_TAG);
+
+declareBuild(program);
+declareBuildTestData(program);
+
+/*
+program
+  .command('clean');
+
+program
+  .command('copy');
+
+program
+  .command('rename');
+
+program
+  .command('generate');
+
+program
+  .command('import');
+
+program
+  .command('test');
+
+program
+  .command('publish');
+*/
 
 program.parse(process.argv);
 
-// Deal with input arguments:
-if (!inputFilename) {
-  exitDueToUsageError('Must provide a LDML keyboard .xml source file.');
-}
-
-function exitDueToUsageError(message: string): never  {
-  console.error(`${program._name}: ${message}`);
-  console.error();
-  program.outputHelp();
-  return process.exit(64); // TODO: SysExits.EX_USAGE
-}
-
-/**
- * Concrete implementation for CLI use
- */
-class NodeCompilerCallbacks implements CompilerCallbacks {
-  loadFile(baseFilename: string, filename: string | URL): Buffer {
-    // TODO: translate filename based on the baseFilename
-    try {
-      return fs.readFileSync(filename);
-    } catch(e) {
-      if (e.code === 'ENOENT') {
-        return null;
-      } else {
-        throw e;
-      }
-    }
-  }
-  reportMessage(event: CompilerEvent): void {
-    console.log(kmc.CompilerMessages.severityName(event.code) + ' ' + event.code.toString(16) + ': ' + event.message);
-  }
-  loadLdmlKeyboardSchema(): Buffer {
-    let schemaPath = new URL('ldml-keyboard.schema.json', import.meta.url);
-    return fs.readFileSync(schemaPath);
-  }
-  loadLdmlKeyboardTestSchema(): Buffer {
-    let schemaPath = new URL('ldml-keyboardtest.schema.json', import.meta.url);
-    return fs.readFileSync(schemaPath);
-  }
-  loadKvksJsonSchema(): Buffer {
-    let schemaPath = new URL('kvks.schema.json', import.meta.url);
-    return fs.readFileSync(schemaPath);
-  }
-}
-
-function compileKeyboard(inputFilename: string, options: kmc.CompilerOptions): [Uint8Array,Uint8Array,Uint8Array] {
-  const c : CompilerCallbacks = new NodeCompilerCallbacks();
-  const k = new kmc.Compiler(c, options);
-  let source = k.load(inputFilename);
-  if(!source) {
-    return [null, null, null];
-  }
-  if(!k.validate(source)) {
-    return [null, null, null];
-  }
-  let kmx = k.compile(source);
-  if(!kmx) {
-    return [null, null, null];
-  }
-
-  // In order for the KMX file to be loaded by non-KMXPlus components, it is helpful
-  // to duplicate some of the metadata
-  kmc.KMXPlusMetadataCompiler.addKmxMetadata(kmx.kmxplus, kmx.keyboard, options);
-
-  // Use the builder to generate the binary output file
-  const builder = new kmc.KMXBuilder(kmx, options.debug);
-  const kmx_binary = builder.compile();
-
-  const vkcompiler = new kmc.VisualKeyboardCompiler();
-  const vk = vkcompiler.compile(source);
-  const writer = new KvkFileWriter();
-  const kvk_binary = writer.write(vk);
-
-  // Note: we could have a step of generating source files here
-  // KvksFileWriter()...
-  // const tlcompiler = new kmc.TouchLayoutCompiler();
-  // const tl = tlcompiler.compile(source);
-  // const tlwriter = new TouchLayoutFileWriter();
-
-  const kmwcompiler = new kmc.KeymanWebCompiler(options);
-  const kmw_string = kmwcompiler.compile(inputFilename, source);
-  const encoder = new TextEncoder();
-  const kmw_binary = encoder.encode(kmw_string);
-
-  return [kmx_binary, kvk_binary, kmw_binary];
-}
-
-function loadTestData(inputFilename: string, options: kmc.CompilerOptions): LDMLKeyboardTestDataXMLSourceFile {
-   const c : CompilerCallbacks = new NodeCompilerCallbacks();
-   const k = new kmc.Compiler(c, options);
-   let source = k.loadTestData(inputFilename);
-   if(!source) {
-     return null;
-   }
-   return source;
-}
-
-let options: kmc.CompilerOptions = {
-  debug: program.debug ?? false,
-  addCompilerVersion: program.compilerVersion ?? true
-}
-
-if (program.testData) {
-  let testData = loadTestData(inputFilename, options);
-  if (testData) {
-    const fileBaseName = program.testData ?? inputFilename;
-    const outFileBase = path.basename(fileBaseName, path.extname(fileBaseName));
-    const outFileDir = path.dirname(fileBaseName);
-
-    const outFileJson = path.join(outFileDir, outFileBase + '.json');
-    console.log(`Writing JSON test data to ${outFileJson}`);
-    fs.writeFileSync(outFileJson, JSON.stringify(testData, null, '  '));
-  } else {
-    console.error(`An error occurred loading test data ${inputFilename}`);
-    process.exit(1);
-  }
-} else {
-  // TODO-LDML: consider hardware vs touch -- touch-only layout will not have a .kvk
-  // Compile:
-  let [kmx,kvk,kmw] = compileKeyboard(inputFilename, options);
-  // Output:
-
-  const fileBaseName = program.outFile ?? inputFilename;
-  const outFileBase = path.basename(fileBaseName, path.extname(fileBaseName));
-  const outFileDir = path.dirname(fileBaseName);
-
-  if(kmx && kvk) {
-    const outFileKmx = path.join(outFileDir, outFileBase + '.kmx');
-    console.log(`Writing compiled keyboard to ${outFileKmx}`);
-    fs.writeFileSync(outFileKmx, kmx);
-
-    const outFileKvk = path.join(outFileDir, outFileBase + '.kvk');
-    console.log(`Writing compiled visual keyboard to ${outFileKvk}`);
-    fs.writeFileSync(outFileKvk, kvk);
-  } else {
-    console.error(`An error occurred compiling ${inputFilename}`);
-    process.exit(1);
-  }
-
-  if(kmw) {
-    const outFileKmw = path.join(outFileDir, outFileBase + '.js');
-    console.log(`Writing compiled js keyboard to ${outFileKmw}`);
-    fs.writeFileSync(outFileKmw, kmw);
-  }
-}

--- a/developer/src/kmc/src/kmlmc.ts
+++ b/developer/src/kmc/src/kmlmc.ts
@@ -42,14 +42,14 @@ if(!code) {
 }
 
 // Output:
-if (program.outFile) {
-  fs.writeFileSync(program.outFile, code, 'utf8');
+if (program.opts().outFile) {
+  fs.writeFileSync(program.opts().outFile, code, 'utf8');
 } else {
   console.log(code);
 }
 
 function exitDueToUsageError(message: string): never  {
-  console.error(`${program._name}: ${message}`);
+  console.error(`${program.name()}: ${message}`);
   console.error();
   program.outputHelp();
   return process.exit(SysExits.EX_USAGE);

--- a/developer/src/kmc/src/kmlmi.ts
+++ b/developer/src/kmc/src/kmlmi.ts
@@ -35,11 +35,11 @@ if (!inputFilename) {
   exitDueToUsageError('Must provide a lexical model .model_info source file.');
 }
 
-let model_id: string = program.model ? program.model : path.basename(inputFilename).replace(/\.model_info$/, "");
-let outputFilename: string = program.outFile ? program.outFile : path.join(path.dirname(inputFilename), 'build', path.basename(inputFilename));
-let kpsFilename = program.kpsFilename ? program.kpsFilename : path.join(path.dirname(inputFilename), 'source', path.basename(inputFilename).replace(/\.model_info$/, '.model.kps'));
-let kmpFilename = program.kmpFilename ? program.kmpFilename : path.join(path.dirname(inputFilename), 'build', path.basename(inputFilename).replace(/\.model_info$/, '.model.kmp'));
-let jsFilename = program.jsFilename ? program.jsFilename : path.join(path.dirname(inputFilename), 'build', path.basename(inputFilename).replace(/\.model_info$/, '.model.js'));
+let model_id: string = program.opts().model ? program.opts().model : path.basename(inputFilename).replace(/\.model_info$/, "");
+let outputFilename: string = program.opts().outFile ? program.opts().outFile : path.join(path.dirname(inputFilename), 'build', path.basename(inputFilename));
+let kpsFilename = program.opts().kpsFilename ? program.opts().kpsFilename : path.join(path.dirname(inputFilename), 'source', path.basename(inputFilename).replace(/\.model_info$/, '.model.kps'));
+let kmpFilename = program.opts().kmpFilename ? program.opts().kmpFilename : path.join(path.dirname(inputFilename), 'build', path.basename(inputFilename).replace(/\.model_info$/, '.model.kmp'));
+let jsFilename = program.opts().jsFilename ? program.opts().jsFilename : path.join(path.dirname(inputFilename), 'build', path.basename(inputFilename).replace(/\.model_info$/, '.model.js'));
 
 //
 // Load .kps source data
@@ -56,7 +56,7 @@ let kmpJsonData = kmpCompiler.transformKpsToKmpObject(kpsString, kpsFilename);
 let modelInfoOptions: ModelInfoOptions = {
   model_id: model_id,
   kmpJsonData: kmpJsonData,
-  sourcePath: program.source,
+  sourcePath: program.opts().source,
   modelFileName: jsFilename,
   kmpFileName: kmpFilename
 };
@@ -72,7 +72,7 @@ try {
 }
 
 function exitDueToUsageError(message: string): never  {
-  console.error(`${program._name}: ${message}`);
+  console.error(`${program.name()}: ${message}`);
   console.error();
   program.outputHelp();
   return process.exit(SysExits.EX_USAGE);

--- a/developer/src/kmc/src/kmlmp.ts
+++ b/developer/src/kmc/src/kmlmp.ts
@@ -28,7 +28,7 @@ if (!inputFilename) {
   exitDueToUsageError('Must provide a lexical model package source file.');
 }
 
-let outputFilename: string = program.outFile ? program.outFile : inputFilename.replace(/\.kps$/, ".kmp");
+let outputFilename: string = program.opts().outFile ? program.opts().outFile : inputFilename.replace(/\.kps$/, ".kmp");
 
 //
 // Load .kps source data
@@ -51,7 +51,7 @@ promise.then(data => {
 });
 
 function exitDueToUsageError(message: string): never  {
-  console.error(`${program._name}: ${message}`);
+  console.error(`${program.name()}: ${message}`);
   console.error();
   program.outputHelp();
   return process.exit(SysExits.EX_USAGE);

--- a/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as kmc from '@keymanapp/kmc-keyboard';
+import { CompilerCallbacks, CompilerEvent } from '@keymanapp/common-types';
+
+/**
+ * Concrete implementation for CLI use
+ */
+export class NodeCompilerCallbacks implements CompilerCallbacks {
+  loadFile(baseFilename: string, filename: string | URL): Buffer {
+    // TODO: translate filename based on the baseFilename
+    try {
+      return fs.readFileSync(filename);
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+  reportMessage(event: CompilerEvent): void {
+    console.log(kmc.CompilerMessages.severityName(event.code) + ' ' + event.code.toString(16) + ': ' + event.message);
+  }
+  loadLdmlKeyboardSchema(): Buffer {
+    let schemaPath = new URL('ldml-keyboard.schema.json', import.meta.url);
+    return fs.readFileSync(schemaPath);
+  }
+  loadLdmlKeyboardTestSchema(): Buffer {
+    let schemaPath = new URL('ldml-keyboardtest.schema.json', import.meta.url);
+    return fs.readFileSync(schemaPath);
+  }
+  loadKvksJsonSchema(): Buffer {
+    let schemaPath = new URL('kvks.schema.json', import.meta.url);
+    return fs.readFileSync(schemaPath);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -590,7 +590,7 @@
         "@keymanapp/kmc-model-info": "*",
         "@keymanapp/kmc-package": "*",
         "@keymanapp/models-types": "*",
-        "commander": "^3.0.0"
+        "commander": "^10.0.0"
       },
       "bin": {
         "kmc": "build/src/kmc.js",
@@ -1431,6 +1431,14 @@
       "version": "1.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "developer/src/kmc/node_modules/commander": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "developer/src/kmc/node_modules/js-yaml": {
       "version": "4.0.0",


### PR DESCRIPTION
@keymanapp-test-bot skip

Starts the refactor of `kmc` to support the `build` command. In this PR, only supports building LDML keyboards. But infrastructure is in place to add different types of builds.

I have moved `-T` option to `build-test-data` command for now. Not sure exactly how this fits, and even if it should be in kmc at all. But it'll do as a start.

This file layout is intended to help keep options and commands under control and modular:

* commands/ contains all the command-line processing for each command
* activities/ contains all the logic and file processing, wrapping file input/output from the corresponding kmc-* module.

It's going to grow substantially!