### PR TITLE
feat(developer): support build of .kmn from kmc 🙀

### DIFF
--- a/developer/src/kmc/src/activities/buildKmnKeyboard.ts
+++ b/developer/src/kmc/src/activities/buildKmnKeyboard.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+import { BuildCommandOptions } from '../commands/build.js';
+import { getDeveloperBinPath } from '../util/getDeveloperBinPath.js';
+
+export function buildKmnKeyboard(infile: string, options: BuildCommandOptions) {
+  // We'll call out to kmcomp.exe to build a .kmn keyboard into a .kmx
+  const binRoot = getDeveloperBinPath();
+  if(binRoot == null) {
+    console.error('Could not locate Keyman Developer bin path');
+    return false;
+  }
+
+  let args = ['-nologo'];
+  if(options.debug) {
+    args.push('-d');
+  }
+  args.push(infile);
+  if(options.outFile) {
+    args.push(options.outFile);
+  }
+
+  const kmcomp = path.join(binRoot, 'kmcomp.exe');
+  let child = spawnSync(kmcomp, args, {
+    encoding: 'utf8'
+  });
+
+  if(child.error) {
+    console.error(child.error);
+    return false;
+  }
+
+  console.log(child.stdout);
+  if(child.stderr) {
+    console.error(child.stderr);
+  }
+
+  return child.status === 0;
+}

--- a/developer/src/kmc/src/activities/buildLdmlKeyboard.ts
+++ b/developer/src/kmc/src/activities/buildLdmlKeyboard.ts
@@ -3,8 +3,9 @@ import * as fs from 'fs';
 import * as kmc from '@keymanapp/kmc-keyboard';
 import { KvkFileWriter, CompilerCallbacks } from '@keymanapp/common-types';
 import { NodeCompilerCallbacks } from '../util/NodeCompilerCallbacks.js';
+import { BuildCommandOptions } from '../commands/build.js';
 
-export function buildLdmlKeyboard(infile: string, options: any) {
+export function buildLdmlKeyboard(infile: string, options: BuildCommandOptions) {
   // TODO-LDML: consider hardware vs touch -- touch-only layout will not have a .kvk
   // Compile:
   let [kmx,kvk,kmw] = buildLdmlKeyboardToMemory(infile, options);
@@ -34,7 +35,7 @@ export function buildLdmlKeyboard(infile: string, options: any) {
   }
 }
 
-function buildLdmlKeyboardToMemory(inputFilename: string, options: any): [Uint8Array, Uint8Array, Uint8Array] {
+function buildLdmlKeyboardToMemory(inputFilename: string, options: BuildCommandOptions): [Uint8Array, Uint8Array, Uint8Array] {
   let compilerOptions: kmc.CompilerOptions = {
     debug: options.debug ?? false,
     addCompilerVersion: options.compilerVersion ?? true

--- a/developer/src/kmc/src/activities/buildTestData.ts
+++ b/developer/src/kmc/src/activities/buildTestData.ts
@@ -3,8 +3,9 @@ import * as path from 'path';
 import * as kmc from '@keymanapp/kmc-keyboard';
 import { CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
 import { NodeCompilerCallbacks } from '../util/NodeCompilerCallbacks.js';
+import { BuildCommandOptions } from '../commands/build.js';
 
-export function buildTestData(infile: string, options: any) {
+export function buildTestData(infile: string, options: BuildCommandOptions) {
   let compilerOptions: kmc.CompilerOptions = {
     debug: false,
     addCompilerVersion: false

--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -1,5 +1,12 @@
 import { Command } from 'commander';
+import { buildKmnKeyboard } from '../activities/buildKmnKeyboard.js';
 import { buildLdmlKeyboard } from '../activities/buildLdmlKeyboard.js';
+
+export interface BuildCommandOptions {
+  debug?: boolean;
+  outFile?: string;
+  compilerVersion?: boolean;
+};
 
 export function declareBuild(program: Command) {
   program
@@ -19,18 +26,19 @@ export function declareBuild(program: Command) {
     });
 }
 
-function build(infile: string, options: any) {
+function build(infile: string, options: BuildCommandOptions) {
   console.log(`Building ${infile}`);
 
   if(infile.endsWith('.xml')) {
     return buildLdmlKeyboard(infile, options);
   }
 
-/*
+
   if(infile.endsWith('.kmn')) {
     return buildKmnKeyboard(infile, options);
   }
 
+  /*
   if(infile.endsWith('.kps')) {
     return buildPackage(infile, options);
   }

--- a/developer/src/kmc/src/util/getDeveloperBinPath.ts
+++ b/developer/src/kmc/src/util/getDeveloperBinPath.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath } from 'url';
+import * as path from 'path';
+import * as fs from 'fs';
+
+/**
+ * Locates the Keyman Developer bin folder, checking first if this is running
+ * from the source repository (using the presence of the KEYMAN_ROOT environment
+ * variable), and if not, checking for the presence of kmcomp.exe in each
+ * parent folder recursively until we reach the root of the filesystem.
+ * @returns string | null
+ */
+export function getDeveloperBinPath(): string {
+  // if running in source repo, then we always look in developer/bin/
+  const keymanRoot = process.env['KEYMAN_ROOT'];
+  if (keymanRoot) {
+    // https://stackoverflow.com/a/45242825/1836776 (imperfect due to
+    // possibility of '..foo', but good enough)
+    const rel = path.relative(keymanRoot, import.meta.url);
+    if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) {
+      return path.join(keymanRoot, 'developer', 'bin');
+    }
+  }
+
+  // Otherwise, we will look in parent folders until we find kmcomp.exe
+  // TODO: once we eliminate kmcomp.exe, we'll need to do this some other way?
+  let p = fileURLToPath(import.meta.url);
+  const root = path.parse(p).root.toLowerCase(); // lower-case for drive letter on Windows
+  p = path.dirname(p);
+  do {
+    if (fs.existsSync(path.join(p, 'kmcomp.exe'))) {
+      return p;
+    }
+    p = path.dirname(p);
+  } while (p.toLowerCase() != root);
+
+  // kmcomp.exe was not found on the path
+  return null;
+}


### PR DESCRIPTION
Uses existing kmcomp.exe to build .kmn files. Requires kmc to be in a subfolder of the Keyman Developer binary folder.

@keymanapp-test-bot skip