### PR TITLE
feat(common): adds warning if described output does not exist

### DIFF
--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -402,6 +402,23 @@ builder_has_action() {
   fi
 }
 
+_builder_dep_output_defined() {
+  if [[ ! -z ${_builder_dep_path[$1]+x} ]]; then
+    return 0
+  else
+    echo "${_builder_dep_path[*]}"
+    return 1
+  fi
+}
+
+_builder_dep_output_exists() {
+  if _builder_dep_output_defined $1 && [[ -e "$KEYMAN_ROOT/${_builder_dep_path[$1]}" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 #
 # Returns `0` if the user has asked to perform action on target on the command
 # line, and then starts the action. Should be paired with
@@ -433,8 +450,7 @@ builder_start_action() {
     # verify whether a target output is present.
     if builder_is_dep_build &&
         ! builder_is_full_dep_build &&
-        [[ ! -z ${_builder_dep_path[$_builder_matched_action]+x} ]] &&
-        [[ -e "$KEYMAN_ROOT/${_builder_dep_path[$_builder_matched_action]}" ]]; then
+        _builder_dep_output_exists $_builder_matched_action; then
       echo "$scope skipping $_builder_matched_action_name, up-to-date"
       return 1
     fi
@@ -1190,9 +1206,15 @@ builder_finish_action() {
   fi
 
   local scope="[$THIS_SCRIPT_IDENTIFIER] "
+  local matched_action="$action$target"
 
-  if [[ "$action$target" == "${_builder_current_action}" ]]; then
+  if [[ "$matched_action" == "${_builder_current_action}" ]]; then
     if [[ $result == success ]]; then
+      # Sanity check:  if there is a described output for this action, does the corresponding
+      # file or directory exist now?
+      if _builder_dep_output_defined $matched_action && ! _builder_dep_output_exists "$matched_action"; then
+        builder_warn "## $scope$action_name's described output does not exist"
+      fi
       echo "${COLOR_GREEN}## $scope$action_name completed successfully${COLOR_RESET}"
     elif [[ $result == failure ]]; then
       echo "${COLOR_RED}## $scope$action_name failed${COLOR_RESET}"

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1212,10 +1212,11 @@ builder_finish_action() {
       # Sanity check:  if there is a described output for this action, does the corresponding
       # file or directory exist now?
       if _builder_dep_output_defined $matched_action && ! _builder_dep_output_exists "$matched_action"; then
-        builder_warn "## $scope$action_name's described output does not exist"
+        builder_warn "## $scope$action_name was successful, but output does not exist"
         builder_warn "## ${scope}Expected output: '${_builder_dep_path[$matched_action]}'."
+      else
+        echo "${COLOR_GREEN}## $scope$action_name completed successfully${COLOR_RESET}"
       fi
-      echo "${COLOR_GREEN}## $scope$action_name completed successfully${COLOR_RESET}"
     elif [[ $result == failure ]]; then
       echo "${COLOR_RED}## $scope$action_name failed${COLOR_RESET}"
     else

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -406,7 +406,6 @@ _builder_dep_output_defined() {
   if [[ ! -z ${_builder_dep_path[$1]+x} ]]; then
     return 0
   else
-    echo "${_builder_dep_path[*]}"
     return 1
   fi
 }
@@ -1214,6 +1213,7 @@ builder_finish_action() {
       # file or directory exist now?
       if _builder_dep_output_defined $matched_action && ! _builder_dep_output_exists "$matched_action"; then
         builder_warn "## $scope$action_name's described output does not exist"
+        builder_warn "## ${scope}Expected output: '${_builder_dep_path[$matched_action]}'."
       fi
       echo "${COLOR_GREEN}## $scope$action_name completed successfully${COLOR_RESET}"
     elif [[ $result == failure ]]; then

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -26,24 +26,6 @@ verify_project() {
   fi
 }
 
-# The list of valid platforms that our build scripts ought expect.
-platforms=("android" "ios" "linux" "lmlayer" "mac" "web" "desktop" "developer")
-
-# Used to validate a specified 'platform' parameter.
-verify_platform() {
-  match=false
-  for proj in ${platforms[@]}
-  do
-    if [ $proj = $1 ]; then
-      match=true
-    fi
-  done
-
-  if [ $match = false ]; then
-    builder_die "Invalid platform specified!"
-  fi
-}
-
 displayInfo() {
     if [ "$QUIET" != true ]; then
         while [[ $# -gt 0 ]] ; do


### PR DESCRIPTION
Example:

![image](https://user-images.githubusercontent.com/25213402/221066703-fca2e0c0-1e30-4261-9694-de47595d90b5.png)

Actual build output: `common/web/keyboard-processor/build/index.js` (no second `s`)

The warning is only omitted when the action "succeeds" _**and**_ the described output is missing.

----

I just opted for the behavior seen above because it is the least intrusive.  Feel free to tweak the behavior as desired - it'd just be a nice check to have, one way or the other.

@keymanapp-test-bot skip