### PR TITLE
chore(linux): Improve detecting presence of test files

### DIFF
--- a/linux/ibus-keyman/tests/scripts/setup-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/setup-tests.sh
@@ -33,8 +33,8 @@ else
   exit 2
 fi
 
-if [ ! -d "$TESTDIR" ] || ! [[ $(find "${TESTDIR}/" -name \*.kmx 2>/dev/null | wc -l) -gt 0 ]]; then
-  if [[ $(find "${COMMON_ARCH_DIR}/tests/unit/kmx/" -name \*.kmx 2>/dev/null | wc -l) -gt 0 ]]; then
+if [ ! -d "$TESTDIR" ] || ! [[ $(find "${TESTDIR}/" -name k_\*.kmx 2>/dev/null | wc -l) -gt 0 ]]; then
+  if [[ $(find "${COMMON_ARCH_DIR}/tests/unit/kmx/" -name k_\*.kmx 2>/dev/null | wc -l) -gt 0 ]]; then
     mkdir -p "$(realpath --canonicalize-missing "$TESTDIR"/..)"
     ln -sf "$(realpath "${COMMON_ARCH_DIR}"/tests/unit/kmx)" "$TESTDIR"
   else


### PR DESCRIPTION
With recent work the location where we generate the test files changed, but the test setup script didn't completely work.

@keymanapp-test-bot skip