### PR TITLE
feat(developer): kmc .kpj support 🙀

### DIFF
--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -42,6 +42,8 @@ export interface CompilerCallbacks {
   loadLdmlKeyboardTestSchema(): Buffer;
   reportMessage(event: CompilerEvent): void;
   loadKvksJsonSchema(): Buffer;
+  loadKpjJsonSchema(): Buffer;
+  forceDirectories(dir: string): void;
 };
 
 /**

--- a/developer/src/kmc-keyboard/build.sh
+++ b/developer/src/kmc-keyboard/build.sh
@@ -51,6 +51,7 @@ copy_schemas() {
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/"
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json" "$THIS_SCRIPT_PATH/build/src/"
   cp "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json" "$THIS_SCRIPT_PATH/build/src/"
+  cp "$KEYMAN_ROOT/common/schemas/kpj/kpj.schema.json" "$THIS_SCRIPT_PATH/build/src/"
 }
 
 #-------------------------------------------------------------------------------------------------------------------

--- a/developer/src/kmc-keyboard/test/helpers/index.ts
+++ b/developer/src/kmc-keyboard/test/helpers/index.ts
@@ -55,11 +55,17 @@ class TestCompilerCallbacks implements CompilerCallbacks {
     // console.log(event.message);
     this.messages.push(event);
   }
+  forceDirectories(dir: string): void {
+    fs.mkdirSync(dir, {recursive:true});
+  }
   loadLdmlKeyboardSchema(): Buffer {
     return fs.readFileSync(new URL(path.join('..', '..', 'src', 'ldml-keyboard.schema.json'), import.meta.url));
   }
   loadKvksJsonSchema(): Buffer {
     return fs.readFileSync(new URL(path.join('..', '..', 'src', 'kvks.schema.json'), import.meta.url));
+  }
+  loadKpjJsonSchema(): Buffer {
+    return fs.readFileSync(new URL(path.join('..', '..', 'src', 'kpj.schema.json'), import.meta.url));
   }
   loadLdmlKeyboardTestSchema(): Buffer {
     return fs.readFileSync(new URL(path.join('..', '..', 'src', 'ldml-keyboardtest.schema.json'), import.meta.url));

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -48,6 +48,7 @@ else
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/util/"
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json" "$THIS_SCRIPT_PATH/build/src/util/"
   cp "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json" "$THIS_SCRIPT_PATH/build/src/util/"
+  cp "$KEYMAN_ROOT/common/schemas/kpj/kpj.schema.json" "$THIS_SCRIPT_PATH/build/src/util/"
 fi
 
 

--- a/developer/src/kmc/src/activities/buildKmnKeyboard.ts
+++ b/developer/src/kmc/src/activities/buildKmnKeyboard.ts
@@ -4,7 +4,10 @@ import { BuildCommandOptions } from '../commands/build.js';
 import { getDeveloperBinPath } from '../util/getDeveloperBinPath.js';
 
 export async function buildKmnKeyboard(infile: string, options: BuildCommandOptions): Promise<boolean> {
-  // We'll call out to kmcomp.exe to build a .kmn keyboard into a .kmx
+  // We'll call out to kmcomp.exe to build a .kmn keyboard into a .kmx Note:
+  // kmcomp.exe will also build a .js if it is required, and may not actually
+  // generate a .kmx if the output target defined in the .kmn is mobile/web
+  // only. kmcomp.exe will also build the .kvk file.
   const binRoot = getDeveloperBinPath();
   if(binRoot == null) {
     console.error('Could not locate Keyman Developer bin path');
@@ -15,12 +18,24 @@ export async function buildKmnKeyboard(infile: string, options: BuildCommandOpti
   if(options.debug) {
     args.push('-d');
   }
-  args.push(infile);
-  if(options.outFile) {
-    args.push(options.outFile);
-  }
+
+  args.push(path.win32.normalize(infile));
+
+  // .* target file name option allows us to specify .kmx output file and the
+  // .js output file will also be generated as required, in the same way as when
+  // we build a project. Note: this is a stop gap as we work to deprecate
+  // kmcomp.exe and replace it with kmcmp (cross-platform .kmx compiler in C++)
+  // + kmc-kmw (KMX->KMW transpiler in TypeScript) + kmc-kvk (KVK compiler in
+  // TypeScript).
+  let outfile = (options.outFile ?? infile).replace(/\\/g, '/');
+  // For now, we normalize to posix, and then renormalize to win32 for launching
+  // kmcomp, until we have a cross-platform alternative to use
+  outfile = path.win32.normalize(options.outFile).replace(/\.km.$/i, '.*');
+  args.push(outfile);
 
   const kmcomp = path.join(binRoot, 'kmcomp.exe');
+
+  // We won't attempt to make this call cross-platform, yet.
   let child = spawnSync(kmcomp, args, {
     encoding: 'utf8'
   });

--- a/developer/src/kmc/src/activities/buildProject.ts
+++ b/developer/src/kmc/src/activities/buildProject.ts
@@ -1,0 +1,132 @@
+import { CompilerCallbacks, KeymanDeveloperProject, KPJFileReader } from '@keymanapp/common-types';
+import { NodeCompilerCallbacks } from '../util/NodeCompilerCallbacks.js';
+import { KeymanDeveloperProjectFile } from '../../../../../common/web/types/src/kpj/keyman-developer-project.js';
+import { BuildCommandOptions } from '../commands/build.js';
+import { buildKmnKeyboard } from './buildKmnKeyboard.js';
+import * as path from 'path';
+import { buildLdmlKeyboard } from './buildLdmlKeyboard.js';
+import { buildModel } from './buildModel.js';
+import { buildPackage } from './buildPackage.js';
+
+export async function buildProject(infile: string, options: BuildCommandOptions): Promise<boolean> {
+  let builder = new ProjectBuilder(infile, options);
+  return builder.run();
+}
+
+class ProjectBuilder {
+  callbacks: CompilerCallbacks = new NodeCompilerCallbacks();
+  infile: string;
+  options: BuildCommandOptions;
+  project: KeymanDeveloperProject;
+
+  constructor(infile: string, options: BuildCommandOptions) {
+    this.infile = path.resolve(infile);
+    this.options = options;
+  }
+
+  async run(): Promise<boolean> {
+    if(this.options.outFile) {
+      // TODO: callbacks.reportMessage
+      console.error('--out-file should not be specified for project builds');
+      return false;
+    }
+
+    this.project = this.loadProject();
+    if(!this.project) {
+      return false;
+    }
+
+    // Build all Keyman keyboards in the project
+    if(!await this.buildProjectTargets(buildKmnKeyboard, '.kmn', '.kmx')) {
+      return false;
+    }
+
+    // Build all LDML keyboards in the project
+    if(!await this.buildProjectTargets(buildLdmlKeyboard, '.xml', '.kmx')) {
+      return false;
+    }
+
+    // Build all models in the project
+    if(!await this.buildProjectTargets(buildModel, '.model.ts', '.model.js')) {
+      return false;
+    }
+
+    // Build all packages in the project
+    if(!await this.buildProjectTargets(buildPackage, '.kps', '.kmp')) {
+      return false;
+    }
+
+    return true;
+  }
+
+  loadProject(): KeymanDeveloperProject {
+    // TODO: callbacks.reportMessage on exceptions
+    // TODO: version 2.0 projects are folder-based and scan source/ folder for valid
+    // files. .kpj need not exist, but if it does, is used just for options.
+    const kpjData = this.callbacks.loadFile(null, this.infile);
+    const reader = new KPJFileReader();
+    const kpj = reader.read(kpjData);
+    const schema = this.callbacks.loadKpjJsonSchema();
+    try {
+      reader.validate(kpj, schema);
+    } catch(e) {
+      // TODO: callbacks.reportMessage
+      console.error(e);
+      return null;
+    }
+    const project = reader.transform(kpj);
+    return project;
+  }
+
+  async buildProjectTargets(
+    buildTarget: (infile: string, options: BuildCommandOptions) => Promise<boolean>,
+    fileType: '.xml'|'.kmn'|'.model.ts'|'.kps',
+    outputFileType: '.kmx'|'.model.js'|'.kmp'
+  ): Promise<boolean> {
+    let result = true;
+    for(let file of this.project.files) {
+      if(file.fileType.toLowerCase() == fileType) {
+        result = await this.buildTarget(file, buildTarget, fileType, outputFileType) && result;
+      }
+    }
+    return result;
+  }
+
+  async buildTarget(
+    file: KeymanDeveloperProjectFile,
+    buildTarget: (infile: string, options: BuildCommandOptions) => Promise<boolean>,
+    fileType: '.xml'|'.kmn'|'.model.ts'|'.kps',
+    outputFileType: '.kmx'|'.model.js'|'.kmp'
+  ): Promise<boolean> {
+    const options = {...this.options};
+    options.outFile = this.resolveOutputFilePath(file, fileType, outputFileType);
+    const infile = this.resolveInputFilePath(file);
+    // TODO: callbacks.reportMessage, improve logging and make consistent
+    console.log(`Building ${infile}\n  Output ${options.outFile}`);
+    this.callbacks.forceDirectories(path.dirname(options.outFile));
+    let result = await buildTarget(infile, options);
+    if(result) {
+      console.log(`${path.basename(infile )} built successfully.`);
+    } else {
+      console.log(`${path.basename(infile)} failed to build.`);
+    }
+    return result;
+  }
+
+  resolveInputFilePath(file: KeymanDeveloperProjectFile): string {
+    let p = path.dirname(this.infile);
+    return path.normalize(path.join(p, file.filePath));
+  }
+
+  resolveOutputFilePath(file: KeymanDeveloperProjectFile, sourceExt: string, targetExt: string): string {
+    // Matches Delphi TProject.GetTargetFileName
+    let p = this.project.options.buildPath || '$SOURCEPATH';
+
+    // Replace placeholders in the target path
+    // TODO: do we need to support $VERSION?
+    p = p.replace('$SOURCEPATH', path.dirname(this.resolveInputFilePath(file)));
+    p = p.replace('$PROJECTPATH', path.dirname(this.infile));
+    let f = file.filename.replace(new RegExp(`\\${sourceExt}$`, 'i'), targetExt);
+    return path.normalize(path.join(p, f));
+  }
+}

--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -3,6 +3,7 @@ import { buildPackage } from '../activities/buildPackage.js';
 import { buildKmnKeyboard } from '../activities/buildKmnKeyboard.js';
 import { buildLdmlKeyboard } from '../activities/buildLdmlKeyboard.js';
 import { buildModel } from '../activities/buildModel.js';
+import { buildProject } from '../activities/buildProject.js';
 
 export interface BuildCommandOptions {
   debug?: boolean;
@@ -48,11 +49,11 @@ async function build(infile: string, options: BuildCommandOptions): Promise<bool
   if(infile.endsWith('.model.ts')) {
     return buildModel(infile, options);
   }
-/*
+
   if(infile.endsWith('.kpj')) {
     return buildProject(infile, options);
   }
-
+/*
   if(fs.statSync(infile).isDirectory()) {
     return buildProjectFolder(infile, options);
   }

--- a/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
@@ -33,4 +33,11 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
     let schemaPath = new URL('kvks.schema.json', import.meta.url);
     return fs.readFileSync(schemaPath);
   }
+  loadKpjJsonSchema(): Buffer {
+    let schemaPath = new URL('kpj.schema.json', import.meta.url);
+    return fs.readFileSync(schemaPath);
+  }
+  forceDirectories(dir: string): void {
+    fs.mkdirSync(dir, {recursive:true});
+  }
 }


### PR DESCRIPTION
Adds support for building .kpj projects. Required minor tweak to kmcomp to allow it to build both .kmx and .js from .kmn command line. Currently, calls kmcomp.exe to build .kmn files, until we support a cross-platform kmc-kmn C++ project.

@keymanapp-test-bot skip