### PR TITLE
chore(common): fix child build error handling

### DIFF
--- a/resources/build/tests/builder.inc.test.sh
+++ b/resources/build/tests/builder.inc.test.sh
@@ -162,6 +162,16 @@ $THIS_SCRIPT_PATH/build-utils-traps.test.sh error-in-function
 $THIS_SCRIPT_PATH/build-utils-traps.test.sh incomplete
 echo "${COLOR_BLUE}## Running dependency tests${COLOR_RESET}"
 $THIS_SCRIPT_PATH/builder-deps.test.sh
+$THIS_SCRIPT_PATH/dependencies/app/build.sh configure build
+
+$THIS_SCRIPT_PATH/dependencies/app/build.sh error && \
+  builder_die "FAIL: error code 0 but should have failed with exit code 22 from child dep" || (
+    result=$?
+    if [[ $result != 22 ]]; then
+      builder_die "FAIL: exit code $result but should have failed with exit code 22 from child dep"
+    fi
+  ) || exit $?
+
 echo "${COLOR_BLUE}## End external tests${COLOR_RESET}"
 echo
 

--- a/resources/build/tests/dependencies/app/build.sh
+++ b/resources/build/tests/dependencies/app/build.sh
@@ -14,8 +14,10 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_describe "app test module" \
   @../library \
+  "@../error error" \
   configure \
-  build
+  build \
+  error
 
 builder_parse "$@"
 
@@ -38,4 +40,10 @@ if builder_start_action build:project; then
   echo " ... doing the 'build' action for 'app'"
   touch out.build
   builder_finish_action success build:project
+fi
+
+if builder_start_action error:project; then
+  echo " ... doing the 'error' action for 'app'; we shouldn't have gotten here"
+  echo " ... because dependencies/error should have failed"
+  exit 99
 fi

--- a/resources/build/tests/dependencies/error/build.sh
+++ b/resources/build/tests/dependencies/error/build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../build-utils.sh"
+# END STANDARD BUILD SCRIPT INCLUDE
+
+cd "$THIS_SCRIPT_PATH"
+
+# Test builder_describe_outputs and dependencies
+
+builder_describe "library test module" \
+  configure \
+  build
+
+builder_parse "$@"
+
+builder_describe_outputs \
+  configure:project out.configure \
+  build:project     out.build
+
+if builder_start_action configure:project; then
+  echo " ... doing the 'configure' action for 'library'"
+  exit 22
+fi
+
+if builder_start_action build:project; then
+  echo " ... doing the 'build' action for 'library'"
+  exit 22
+fi

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1125,7 +1125,7 @@ builder_display_usage() {
   echo "Actions: "
 
   for e in "${_builder_actions[@]}"; do
-    if [[ -v _builder_params[$e] ]]; then
+    if _builder_item_in_glob_array "$e" "${_builder_params[@]}"; then
       description="${_builder_params[$e]}"
     else
       description=$(_builder_get_default_description "$e")
@@ -1137,7 +1137,7 @@ builder_display_usage() {
   echo "Targets: "
 
   for e in "${_builder_targets[@]}"; do
-    if [[ -v _builder_params[$e] ]]; then
+    if _builder_item_in_glob_array "$e" "${_builder_params[@]}"; then
       description="${_builder_params[$e]}"
     else
       description=$(_builder_get_default_description "$e")


### PR DESCRIPTION
Fixes #8322.

This issue was arising due to subshells masking the exit code.

[set -e is not really to be trusted](http://mywiki.wooledge.org/BashFAQ/105).

Also, avoid -v for testing arrays in builder.

@keymanapp-test-bot skip