### PR TITLE
chore(linux): disable node-based core tests when testing during packaging

### DIFF
--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -50,7 +50,7 @@ override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	# keymankeyboardprocessor
 	cd core && \
-	  ./build.sh test:arch
+	  ./build.sh --no-tests test:arch
 	# ibus-keyman
 	cd linux/ibus-keyman && \
 		./build.sh test


### PR DESCRIPTION
@keymanapp-test-bot skip