### PR TITLE
feat(developer): add 'Use Legacy Compiler' option to TIKE 🚑

### DIFF
--- a/common/windows/delphi/general/RegistryKeys.pas
+++ b/common/windows/delphi/general/RegistryKeys.pas
@@ -393,6 +393,8 @@ const
   SRegValue_IDEOptAutoSaveBeforeCompiling = 'auto save before compiling'; // CU
   SRegValue_IDEOptOSKAutoSaveBeforeImporting = 'osk auto save before importing'; // CU
 
+  SRegValue_IDEOptUseLegacyCompiler = 'use legacy compiler'; // CU
+
   // Note: keeping 'web host port' reg value name to ensure settings maintained
   //       from version 14.0 and earlier of Keyman Developer. Other values are
   //       new with Keyman Developer 15.0

--- a/developer/src/tike/dialogs/UfrmOptions.dfm
+++ b/developer/src/tike/dialogs/UfrmOptions.dfm
@@ -30,7 +30,7 @@ inherited frmOptions: TfrmOptions
         Width = 125
         Height = 25
         Caption = '&Proxy Settings...'
-        TabOrder = 4
+        TabOrder = 5
         OnClick = cmdProxySettingsClick
       end
       object gbExternalEditor: TGroupBox
@@ -39,7 +39,7 @@ inherited frmOptions: TfrmOptions
         Width = 401
         Height = 45
         Caption = '&External Editor Path'
-        TabOrder = 1
+        TabOrder = 2
         object editExternalEditorPath: TEdit
           Left = 8
           Top = 16
@@ -62,7 +62,7 @@ inherited frmOptions: TfrmOptions
         Width = 125
         Height = 25
         Caption = 'S&MTP Settings...'
-        TabOrder = 3
+        TabOrder = 6
         OnClick = cmdSMTPSettingsClick
       end
       object chkOpenKeyboardFilesInSourceView: TCheckBox
@@ -71,7 +71,7 @@ inherited frmOptions: TfrmOptions
         Width = 221
         Height = 17
         Caption = 'Open &keyboard files in source view'
-        TabOrder = 0
+        TabOrder = 1
       end
       object cmdResetToolWindows: TButton
         Left = 8
@@ -79,7 +79,7 @@ inherited frmOptions: TfrmOptions
         Width = 125
         Height = 25
         Caption = '&Reset tool windows'
-        TabOrder = 2
+        TabOrder = 4
         OnClick = cmdResetToolWindowsClick
       end
       object chkAllowMultipleInstances: TCheckBox
@@ -88,7 +88,7 @@ inherited frmOptions: TfrmOptions
         Width = 289
         Height = 17
         Caption = '&Allow multiple instances of Keyman Developer'
-        TabOrder = 5
+        TabOrder = 0
       end
       object gbDefaultProjectPath: TGroupBox
         Left = 8
@@ -96,7 +96,7 @@ inherited frmOptions: TfrmOptions
         Width = 401
         Height = 45
         Caption = '&Default Project Folder'
-        TabOrder = 6
+        TabOrder = 3
         object editDefaultProjectPath: TEdit
           Left = 8
           Top = 16
@@ -136,14 +136,14 @@ inherited frmOptions: TfrmOptions
         Width = 401
         Height = 73
         Caption = 'Privacy'
-        TabOrder = 9
+        TabOrder = 10
         object chkReportUsage: TCheckBox
           Left = 8
           Top = 44
           Width = 311
           Height = 17
           Caption = '&Share anonymous usage statistics with keyman.com'
-          TabOrder = 0
+          TabOrder = 1
         end
         object chkReportErrors: TCheckBox
           Left = 8
@@ -151,8 +151,16 @@ inherited frmOptions: TfrmOptions
           Width = 311
           Height = 17
           Caption = 'Automatically report &errors to keyman.com'
-          TabOrder = 1
+          TabOrder = 0
         end
+      end
+      object chkUseLegacyCompiler: TCheckBox
+        Left = 152
+        Top = 244
+        Width = 250
+        Height = 17
+        Caption = 'Use legacy .kmn compiler (removing in 18.0)'
+        TabOrder = 9
       end
     end
     object tabEditor: TTabSheet

--- a/developer/src/tike/dialogs/UfrmOptions.pas
+++ b/developer/src/tike/dialogs/UfrmOptions.pas
@@ -105,6 +105,7 @@ type
     gbServer: TGroupBox;
     chkListLocalURLs: TCheckBox;
     cmdConfigureServer: TButton;
+    chkUseLegacyCompiler: TCheckBox;
     procedure FormCreate(Sender: TObject);
     procedure cmdOKClick(Sender: TObject);
     procedure cmdDefaultFontClick(Sender: TObject);
@@ -193,6 +194,8 @@ begin
     chkDebuggerAutoResetBeforeCompiling.Checked := DebuggerAutoResetBeforeCompiling;
     chkAutoSaveBeforeCompiling.Checked :=          AutoSaveBeforeCompiling;
     chkOSKAutoSaveBeforeImporting.Checked :=       OSKAutoSaveBeforeImporting;
+
+    chkUseLegacyCompiler.Checked := UseLegacyCompiler;
 
     chkCharMapAutoLookup.Checked := CharMapAutoLookup;
     chkCharMapDisableDatabaseLookups.Checked := CharMapDisableDatabaseLookups;
@@ -294,6 +297,8 @@ begin
     DebuggerAutoResetBeforeCompiling := chkDebuggerAutoResetBeforeCompiling.Checked;
     AutoSaveBeforeCompiling          := chkAutoSaveBeforeCompiling.Checked;
     OSKAutoSaveBeforeImporting       := chkOSKAutoSaveBeforeImporting.Checked;
+
+    UseLegacyCompiler := chkUseLegacyCompiler.Checked;
 
     ServerUseLocalAddresses := chkListLocalURLs.Checked;
 

--- a/developer/src/tike/main/KeymanDeveloperOptions.pas
+++ b/developer/src/tike/main/KeymanDeveloperOptions.pas
@@ -70,6 +70,7 @@ type
     FServerNgrokToken: string;
     FServerNgrokRegion: string;
     FServerKeepAlive: Boolean;
+    FUseLegacyCompiler: Boolean;
     procedure CloseRegistry;
     procedure OpenRegistry;
     function regReadString(const nm, def: string): string;
@@ -103,6 +104,8 @@ type
     property DebuggerAutoResetBeforeCompiling: Boolean read FDebuggerAutoResetBeforeCompiling write FDebuggerAutoResetBeforeCompiling;
     property AutoSaveBeforeCompiling: Boolean read FAutoSaveBeforeCompiling write FAutoSaveBeforeCompiling;
     property OSKAutoSaveBeforeImporting: Boolean read FOSKAutoSaveBeforeImporting write FOSKAutoSaveBeforeImporting;
+
+    property UseLegacyCompiler: Boolean read FUseLegacyCompiler write FUseLegacyCompiler;
 
     property ReportErrors: Boolean read FReportErrors write FReportErrors;
     property ReportUsage: Boolean read FReportUsage write FReportUsage;
@@ -215,6 +218,8 @@ begin
     FAutoSaveBeforeCompiling := regReadBool(SRegValue_IDEOptAutoSaveBeforeCompiling, False);
     FOSKAutoSaveBeforeImporting := regReadBool(SRegValue_IDEOptOSKAutoSaveBeforeImporting, False);
 
+    FUseLegacyCompiler := regReadBool(SRegValue_IDEOptUseLegacyCompiler, False);
+
     FServerDefaultPort := regReadInt(SRegValue_IDEOptServerPort, 8008);
     FServerKeepAlive := regReadBool(SRegValue_IDEOptServerKeepAlive, False);
     FServerUseLocalAddresses := regReadBool(SRegValue_IDEOptServerUseLocalAddresses, True);
@@ -276,6 +281,7 @@ begin
     regWriteBool(SRegValue_IDEOptAutoSaveBeforeCompiling, FAutoSaveBeforeCompiling);
     regWriteBool(SRegValue_IDEOptOSKAutoSaveBeforeImporting, FOSKAutoSaveBeforeImporting);
 
+    regWriteBool(SRegValue_IDEOptUseLegacyCompiler, FUseLegacyCompiler);
 
     regWriteInt(SRegValue_IDEOptServerPort, FServerDefaultPort);
     regWriteBool(SRegValue_IDEOptServerKeepAlive, FServerKeepAlive);

--- a/developer/src/tike/project/Keyman.Developer.System.Project.kmnProjectFileAction.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.kmnProjectFileAction.pas
@@ -19,6 +19,8 @@ type
   public
     function CompileKeyboard: Boolean;
     function Clean: Boolean;
+    function DoSetCompilerOptions(addVersion,
+      useLegacyCompiler: Boolean): Boolean;
   end;
 
 implementation
@@ -104,6 +106,22 @@ begin
       Log(plsWarning, Format(TKeyboardUtils.SKeyboardNameDoesNotFollowConventions_Message, [ExtractFileName(KVKFileName)]), CERR_WARNING, 0);
     end;
   end;
+end;
+
+function TkmnProjectFileAction.DoSetCompilerOptions(addVersion: Boolean; useLegacyCompiler: Boolean): Boolean;
+var
+  options: COMPILER_OPTIONS;
+begin
+  TProject.CompilerMessageFile := Self;
+  options.dwSize := sizeof(COMPILER_OPTIONS);
+  options.ShouldAddCompilerVersion := addVersion;
+  options.UseKmcmpLib := not useLegacyCompiler;
+  if not SetCompilerOptions(@options, ProjectCompilerMessage) then
+  begin
+    Log(plsFatal, 'Unable to set compiler options', CERR_FATAL, 0);
+    Exit(False);
+  end;
+  Result := True;
 end;
 
 function TkmnProjectFileAction.CompileKeyboard: Boolean;

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
@@ -130,7 +130,11 @@ begin
   if not FSilent then
     frmMessages.DoShowForm;
 
-  Result := ProjectFile.CompileKeyboard;
+  Result :=
+    // Note: we do not surface the ability to exclude version information from
+    // the TIKE compiler; this must be done from kmcomp.exe.
+    ProjectFile.DoSetCompilerOptions(True, FKeymanDeveloperOptions.UseLegacyCompiler) and
+    ProjectFile.CompileKeyboard;
 
   if Result and
       TServerDebugAPI.Running and


### PR DESCRIPTION
# User Testing

**TEST_LEGACY_COMPILE:** In Keyman Developer Tools/Options, check the option 'Use legacy compiler'. Load a keyboard project, compile it, and verify that the message 'NOTE: Using legacy compiler' shows up in the compiler output log.

**TEST_MODERN_COMPILE:** In Keyman Developer Tools/Options, uncheck the option 'Use legacy compiler'. Load a keyboard project, compile it, and verify that the message 'NOTE: Using legacy compiler' does _not_ show up in the compiler output log.