### PR TITLE
fix(common): builder: skip dependency build for clean action

### DIFF
--- a/resources/build/tests/builder-deps.test.sh
+++ b/resources/build/tests/builder-deps.test.sh
@@ -18,6 +18,7 @@ builder_describe \
   "@./dep4 *:project" \
   "@./dep5 build:bar test:*" \
   "@./dep6 build:bar test" \
+  clean \
   configure \
   build \
   test \
@@ -94,6 +95,19 @@ test_dep_should_build test:project dep6
 test_dep_should_not_build configure:bar dep6
 test_dep_should_build build:bar dep6
 test_dep_should_build test:bar dep6
+
+test_dep_should_not_build clean:project dep1
+test_dep_should_not_build clean:bar dep1
+test_dep_should_not_build clean:project dep2
+test_dep_should_not_build clean:bar dep2
+test_dep_should_not_build clean:project dep3
+test_dep_should_not_build clean:bar dep3
+test_dep_should_not_build clean:project dep4
+test_dep_should_not_build clean:bar dep4
+test_dep_should_not_build clean:project dep5
+test_dep_should_not_build clean:bar dep5
+test_dep_should_not_build clean:project dep6
+test_dep_should_not_build clean:bar dep6
 
 # Test if 'build' actions are added because their output
 # is missing

--- a/resources/build/tests/builder.inc.test.sh
+++ b/resources/build/tests/builder.inc.test.sh
@@ -175,9 +175,13 @@ $THIS_SCRIPT_PATH/dependencies/app/build.sh error && \
 echo "${COLOR_BLUE}## End external tests${COLOR_RESET}"
 echo
 
-# Finally, run with --help so we can see what it looks like
-# Note:  calls `exit`, so no further tests may be defined.
+(
+  # Finally, run with --help so we can see what it looks like; note:
+  # builder_parse calls `exit 0` on a --help run, so running in a subshell
+  echo "${COLOR_BLUE}## Testing --help${COLOR_RESET}"
+  builder_parse --no-color --help
+) || builder_die "FAIL: builder-parse returned failure code $? unexpectedly"
 
-echo "${COLOR_BLUE}## Testing --help${COLOR_RESET}"
-
-builder_parse --no-color --help
+echo "${COLOR_GREEN}======================================================${COLOR_RESET}"
+echo "${COLOR_GREEN}All tests passed successfully${COLOR_RESET}"
+echo "${COLOR_GREEN}======================================================${COLOR_RESET}"

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1240,6 +1240,12 @@ _builder_should_build_dep() {
   local action_target="$1"
   local dep="$2"
   local related_actions=(${_builder_dep_related_actions[$dep]})
+
+  if [[ $action_target =~ ^clean ]]; then
+    # don't attempt to build dependencies for a 'clean' action
+    return 1
+  fi
+
   # echo "bdra: ${_builder_dep_related_actions[@]}"
   # echo "target: $action_target"
   # echo "dep: $2"


### PR DESCRIPTION
We should not attempt to build dependencies when running `clean`. Note: if your `clean` action requires dependencies, then something is very, very wrong and you should fix that!

This should resolve the failed Keyman Developer build on master.

@keymanapp-test-bot skip