### PR TITLE
chore(common): cleanup build.inc.sh echo

### DIFF
--- a/common/web/keyman-version/build.sh
+++ b/common/web/keyman-version/build.sh
@@ -83,7 +83,7 @@ if builder_start_action build; then
 
   # Note: in a dependency build, we'll expect keyman-version to be built by tsc -b
   if builder_is_dep_build; then
-    echo "[$THIS_SCRIPT_IDENTIFIER] skipping tsc -b; will be completed by $builder_dep_parent"
+    builder_echo "skipping tsc -b; will be completed by $builder_dep_parent"
   else
     npm run build -- $builder_verbose
   fi

--- a/common/web/utils/build.sh
+++ b/common/web/utils/build.sh
@@ -40,7 +40,7 @@ fi
 if builder_start_action build; then
   # Note: in a dependency build, we'll expect utils to be built by tsc -b
   if builder_is_dep_build; then
-    echo "[$THIS_SCRIPT_IDENTIFIER] skipping tsc -b; will be completed by $builder_dep_parent"
+    builder_echo "skipping tsc -b; will be completed by $builder_dep_parent"
   else
     npm run tsc -- --build "$THIS_SCRIPT_PATH/tsconfig.json"
   fi

--- a/resources/build/build-utils.md
+++ b/resources/build/build-utils.md
@@ -452,6 +452,91 @@ builder_display_usage
 
 --------------------------------------------------------------------------------
 
+## `builder_echo` function
+
+Wraps the `echo` command with color and a script identifier prefix.
+
+### Usage
+
+```bash
+builder_echo [mode] message
+```
+
+### Parameters
+
+Note: if only a single parameter passed, it will be the **message** parameter, and
+mode will be `white`.
+
+* **mode**: one of the following modes:
+  * `success`: A message indicating success, represented with green text
+  * `heading`: A heading, represented with blue text
+  * `warning`: A warning message, represented with yellow text
+  * `error`: An error message, represented with red text (consider [`builder_die`])
+  * `debug`: A debug string, represented with teal text (consider [`builder_echo_debug`])
+  
+  Or color identifiers:
+  * `white`: Normal white text, the default if **mode** is omitted
+  * `grey`: Darker grey text
+  * `green`: Equivalent to `success`
+  * `blue`: Equivalent to `heading`
+  * `yellow`: Equivalent to `warning`
+  * `red`: Equivalent to `error`
+  * `purple`: Purple text, generally reserved by Builder for `setmark` section 
+    headings
+  * `brightwhite`: Bright white text, generally reserved by Builder for
+    delineating current script messages
+  * `teal`: Teal text, equivalent to `debug`, generally reserved for debugging
+    messages
+
+  The following modes are used mostly by Builder internally:
+  * `setmark`: A marker for a section heading, represented with purple text
+
+* **message**: a string (surround with quote marks)
+
+### Description
+
+The `builder_echo` command will emit a string, with the current script
+identifier  at the start, optionally with color formatting (as long as the terminal 
+supports color).
+
+```bash
+builder_echo "this went well"
+builder_echo error "this didn't go so well"
+```
+
+```
+[this/script/identifier] this went well
+[this/script/identifier] this didn't go so well
+```
+
+(Red text cannot be represented here!)
+
+The current script identifier will be grey for dependency builds and bright
+white for top-level builds and child builds.
+
+--------------------------------------------------------------------------------
+
+## `builder_echo_debug` function
+
+Wraps the `builder_echo` command with debug mode and a `[DEBUG]` prefix.
+
+### Usage
+
+```bash
+builder_echo_debug message
+```
+
+### Parameters
+
+* **message**: The message to emit to the console
+
+### Description
+
+This function is used internally within Builder, but can also be used by
+any builder scripts as required.
+
+--------------------------------------------------------------------------------
+
 ## `$builder_extra_params` variable
 
 If a build script needs to be able to pass arbitrary additional parameters onto
@@ -724,6 +809,8 @@ resolve either to empty string (for `$COLOR_*`), or equivalent plain-text forms
 * `$HEADING_SETMARK`: Add a setmark, e.g. with VSCode
   <https://code.visualstudio.com/updates/v1_69#_setmark-sequence-support>
 
+Note: it is often cleaner to use [`builder_echo`] than to use these variables directly.
+
 Note: it is recommended that you use `$(builder_term text)` instead of
 `${BUILDER_TERM_START}text${BUILDER_TERM_END}`.
 
@@ -740,3 +827,6 @@ Note: it is recommended that you use `$(builder_term text)` instead of
 [`$builder_verbose`]: #builderverbose-variable
 [formatting variables]: #formatting-variables
 [`builder_run_child_actions`]: #builderrunchildactions-function
+[`builder_echo`]: #builderecho-function
+[`builder_die`]: #builderdie-function
+[`builder_echo_debug`]: #builderechodebug-function

--- a/resources/build/build-utils.md
+++ b/resources/build/build-utils.md
@@ -244,10 +244,12 @@ All build scripts have a set of automatic internal dependencies:
 * `build` depends on `configure`
 * `test`, `install`, and `publish` depend on `build`
 
-These dependencies will be added to the list of targets for the build if you
-have described outputs for them, and the outputs do not exist. The build order
-is determined by the order in which `builder_start_action` is called in the
-script for each action.
+Internal dependencies will be added to the list of targets for the build if you
+have described outputs for them, and the outputs do not exist, and the
+dependency is required for one of the targets specified on the command line.
+
+The build order of dependencies is determined by the order in which
+`builder_start_action` is called in the script for each action.
 
 You can also define your own internal dependencies with
 `builder_describe_internal_dependency`. This allows you to define dependencies

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -59,7 +59,7 @@ function _builder_setBuildScriptIdentifiers() {
     THIS_SCRIPT_IDENTIFIER=${THIS_SCRIPT_PATH#"$REPO_ROOT/"}
     readonly THIS_SCRIPT_IDENTIFIER
   else
-    echo "Warning: THIS_SCRIPT not defined; builder.inc.sh has not been sourced with standard script include."
+    builder_die "THIS_SCRIPT not defined; builder.inc.sh has not been sourced with standard script include."
   fi
 }
 
@@ -83,10 +83,12 @@ builder_use_color() {
     COLOR_BLUE=$(tput setaf 4)
     COLOR_PURPLE=$(tput setaf 5)
     COLOR_TEAL=$(tput setaf 6)
-    COLOR_WHITE=$(tput setaf 7)
+    COLOR_WHITE=$(tput setaf 252)
+    COLOR_BRIGHT_WHITE=$(tput setaf 255)
     COLOR_GREY=$(tput setaf 8)
     COLOR_RESET=$(tput sgr0)
     # e.g. VSCode https://code.visualstudio.com/updates/v1_69#_setmark-sequence-support
+    BUILDER_BOLD=$(tput bold)
     HEADING_SETMARK='\x1b]1337;SetMark\x07'
 
     # Used by `builder_display_usage` when marking special terms (actions, targets, options)
@@ -101,8 +103,10 @@ builder_use_color() {
     COLOR_PURPLE=
     COLOR_TEAL=
     COLOR_WHITE=
+    COLOR_BRIGHT_WHITE=
     COLOR_GREY=
     COLOR_RESET=
+    BUILDER_BOLD=
     HEADING_SETMARK=
     BUILDER_TERM_START="<"
     BUILDER_TERM_END=">"
@@ -120,20 +124,20 @@ function builder_term() {
 function builder_die() {
   echo
   if [[ $# -eq 0 ]]; then
-    echo "${COLOR_RED}Unspecified error, aborting script${COLOR_RESET}"
+    builder_echo error "Unspecified error, aborting script"
   else
-    echo "${COLOR_RED}$*${COLOR_RESET}"
+    builder_echo error "$*"
   fi
   echo
   exit 1
 }
 
 function builder_warn() {
-  echo "${COLOR_YELLOW}$*${COLOR_RESET}"
+  builder_echo warning "$*"
 }
 
 function builder_heading() {
-  echo -e "${HEADING_SETMARK}${COLOR_BLUE}$*${COLOR_RESET}"
+  builder_echo heading "$*"
 }
 
 
@@ -143,17 +147,42 @@ function builder_heading() {
 #
 ####################################################################################
 
+
+builder_echo() {
+  local color=white message= mark=
+  if [[ $# -gt 1 ]]; then
+    color="$1"
+    message="$2"
+  else
+    message="$1"
+  fi
+
+  case $color in
+    white) color="$COLOR_WHITE" ;;
+    grey) color="$COLOR_GREY" ;;
+    green|success) color="$COLOR_GREEN" ;;
+    blue|heading) color="$COLOR_BLUE" ;;
+    yellow|warning) color="$COLOR_YELLOW" ;;
+    red|error) color="$COLOR_RED" ;;
+    teal) color="$COLOR_TEAL" ;;
+    setmark) mark="$HEADING_SETMARK" color="$COLOR_PURPLE" ;;
+  esac
+
+  if builder_is_dep_build; then
+    echo -e "$mark$COLOR_GREY[$THIS_SCRIPT_IDENTIFIER]$COLOR_RESET $color$message$COLOR_RESET"
+  else
+    echo -e "$mark$BUILDER_BOLD$COLOR_BRIGHT_WHITE[$THIS_SCRIPT_IDENTIFIER]$COLOR_RESET $color$message$COLOR_RESET"
+  fi
+}
+
+builder_echo_debug() {
+  builder_echo teal "[DEBUG] $*"
+}
+
 #
 # builder_ names are reserved.
 # _builder_ names are internal use and subject to change
 #
-if [ -z ${_builder_debug+x} ]; then
-  _builder_debug=false
-fi
-
-if $_builder_debug; then
-  echo "[DEBUG] Command line: $0 $@"
-fi
 
 #
 # builder_extra_params: string containing all parameters after '--'
@@ -208,8 +237,7 @@ _builder_item_is_target() {
 
 function _builder_warn_if_incomplete() {
   if [ -n "${_builder_current_action}" ]; then
-    local scope="[$THIS_SCRIPT_IDENTIFIER] "
-    echo "${COLOR_YELLOW}## ${scope}Warning - $_builder_current_action never reported success or failure${COLOR_RESET}"
+    builder_echo warning "$_builder_current_action never reported success or failure"
     # exit 1  # If we wanted this scenario to result in a forced build-script fail.
   fi
 
@@ -260,7 +288,7 @@ _builder_failure_trap() {
 _builder_cleanup_deps() {
   if ! builder_is_dep_build && [[ ! -z ${_builder_deps_built+x} ]]; then
     if $_builder_debug; then
-      echo "[DEBUG] Dependencies that were built:"
+      builder_echo_debug "Dependencies that were built:"
       cat "$_builder_deps_built"
     fi
     rm -f "$_builder_deps_built"
@@ -272,11 +300,10 @@ _builder_execute_child() {
   local action=$1
   local target=$2
 
-  local scope="[$THIS_SCRIPT_IDENTIFIER] "
   local script="$THIS_SCRIPT_PATH/${_builder_target_paths[$target]}/build.sh"
 
   if $_builder_debug; then
-    echo "${COLOR_BLUE}## $scope$action$target starting...${COLOR_RESET}"
+    builder_echo heading "## $action$target starting..."
   fi
 
   "$script" $action \
@@ -284,11 +311,11 @@ _builder_execute_child() {
     $builder_debug \
   && (
     if $_builder_debug; then
-      echo "${COLOR_GREEN}## $scope$action$target completed successfully${COLOR_RESET}"
+      builder_echo success "## $action$target completed successfully"
     fi
   ) || (
     result=$?
-    echo "${COLOR_RED}## $scope$action$target failed with exit code $result${COLOR_RESET}"
+    builder_echo error "## $action$target failed with exit code $result"
     exit $result
   ) || exit $? # Required due to above subshell masking exit
 }
@@ -441,8 +468,6 @@ _builder_dep_output_exists() {
 # ```
 #
 builder_start_action() {
-  local scope="[$THIS_SCRIPT_IDENTIFIER] "
-
   if builder_has_action $1; then
     # In a dependency quick build (the default), determine whether we actually
     # need to run this step. Uses data passed to builder_describe_outputs to
@@ -450,11 +475,11 @@ builder_start_action() {
     if builder_is_dep_build &&
         ! builder_is_full_dep_build &&
         _builder_dep_output_exists $_builder_matched_action; then
-      echo "$scope skipping $_builder_matched_action_name, up-to-date"
+      builder_echo "skipping $_builder_matched_action_name, up-to-date"
       return 1
     fi
 
-    echo "${COLOR_BLUE}## $scope$_builder_matched_action_name starting...${COLOR_RESET}"
+    builder_echo blue "## $_builder_matched_action_name starting..."
     if [ -n "${_builder_current_action}" ]; then
       _builder_warn_if_incomplete
     fi
@@ -808,11 +833,10 @@ _builder_parameter_error() {
   local program="$1"
   local type="$2"
   local param="$3"
-  echo "$COLOR_RED$program: invalid $type: $param$COLOR_RESET"
+  builder_echo red "$program: invalid $type: $param"
   echo
   builder_display_usage
   exit 64
-
 }
 
 #
@@ -873,12 +897,12 @@ _builder_add_chosen_action_target_dependencies() {
 
   if [[ ${#new_actions[@]} -gt 0 ]]; then
     if builder_is_full_dep_build; then
-      echo "Automatically running all dependency actions due to --force-deps:"
+      builder_echo "Automatically running all dependency actions due to --force-deps:"
     else
-      echo "Automatically running following required actions with missing outputs:"
+      builder_echo "Automatically running following required actions with missing outputs:"
     fi
     for e in "${new_actions[@]}"; do
-      echo "* $e"
+      builder_echo "* $e"
     done
   fi
 }
@@ -1085,28 +1109,27 @@ builder_parse() {
   fi
 
   if $_builder_debug; then
-    echo "[$THIS_SCRIPT_IDENTIFIER] [DEBUG] Selected actions and targets:"
+    builder_echo_debug "Selected actions and targets:"
     for e in "${_builder_chosen_action_targets[@]}"; do
-      echo "[$THIS_SCRIPT_IDENTIFIER] * $e"
+      builder_echo_debug "* $e"
     done
-    echo
-    echo "[$THIS_SCRIPT_IDENTIFIER] [DEBUG] Selected options:"
+    builder_echo_debug
+    builder_echo_debug "Selected options:"
     for e in "${_builder_chosen_options[@]}"; do
-      echo "[$THIS_SCRIPT_IDENTIFIER] * $e"
+      builder_echo_debug "* $e"
     done
   fi
 
   if builder_is_dep_build; then
-    echo -e "${HEADING_SETMARK}${COLOR_PURPLE}[$THIS_SCRIPT_IDENTIFIER] dependency build, started by $builder_dep_parent${COLOR_RESET}"
+    builder_echo setmark "dependency build, started by $builder_dep_parent"
     if [[ -z ${_builder_deps_built+x} ]]; then
-      echo "FATAL ERROR: Expected --builder-deps-built parameter"
-      exit 1
+      builder_die "FATAL ERROR: Expected --builder-deps-built parameter"
     fi
   else
     # This is a top-level invocation, not a dependency build, so we want to
     # track which dependencies have been built, so they don't get built multiple
     # times.
-    echo -e "${HEADING_SETMARK}${COLOR_PURPLE}[$THIS_SCRIPT_IDENTIFIER] build.sh launched with: <${_builder_params[@]}>${COLOR_RESET}"
+    builder_echo setmark "build.sh parameters: '${_builder_params[@]}'"
     _builder_deps_built=`mktemp`
   fi
 
@@ -1238,7 +1261,6 @@ builder_finish_action() {
     action_name="$action$target"
   fi
 
-  local scope="[$THIS_SCRIPT_IDENTIFIER] "
   local matched_action="$action$target"
 
   if [[ "$matched_action" == "${_builder_current_action}" ]]; then
@@ -1246,21 +1268,21 @@ builder_finish_action() {
       # Sanity check:  if there is a described output for this action, does the corresponding
       # file or directory exist now?
       if _builder_dep_output_defined $matched_action && ! _builder_dep_output_exists "$matched_action"; then
-        builder_warn "## $scope$action_name was successful, but output does not exist"
-        builder_warn "## ${scope}Expected output: '${_builder_dep_path[$matched_action]}'."
+        builder_echo warning "Expected output: '${_builder_dep_path[$matched_action]}'."
+        builder_echo warning "## $action_name completed successfully, but output does not exist"
       else
-        echo "${COLOR_GREEN}## $scope$action_name completed successfully${COLOR_RESET}"
+        builder_echo success "## $action_name completed successfully"
       fi
     elif [[ $result == failure ]]; then
-      echo "${COLOR_RED}## $scope$action_name failed${COLOR_RESET}"
+      builder_echo error "## $action_name failed"
     else
-      echo "${COLOR_RED}## $scope$action_name failed with message: $result${COLOR_RESET}"
+      builder_echo error "## $action_name failed with message: $result"
     fi
 
     # Remove $action$target from the array; it is no longer a current action
     _builder_current_action=
   else
-    echo "${COLOR_YELLOW}## Warning: reporting result of $action_name but the action was never started!${COLOR_RESET}"
+    builder_echo warning "reporting result of $action_name but the action was never started!"
   fi
 }
 
@@ -1277,10 +1299,6 @@ _builder_should_build_dep() {
     return 1
   fi
 
-  # echo "bdra: ${_builder_dep_related_actions[@]}"
-  # echo "target: $action_target"
-  # echo "dep: $2"
-  # echo "ra: ${related_actions[@]}"
   if ! _builder_item_in_glob_array "$action_target" "${related_actions[@]}"; then
     return 1
   fi
@@ -1323,7 +1341,7 @@ _builder_do_build_deps() {
     # Don't attempt to build dependencies that don't match the current
     # action:target (wildcards supported for matches here)
     if ! _builder_should_build_dep "$action_target" "$dep"; then
-      echo "[$THIS_SCRIPT_IDENTIFIER] Skipping dependency $dep for $_builder_matched_action_name"
+      builder_echo "Skipping dependency $dep for $_builder_matched_action_name"
       continue
     fi
 
@@ -1341,11 +1359,11 @@ _builder_do_build_deps() {
       --builder-deps-built "$_builder_deps_built" \
       --builder-dep-parent "$THIS_SCRIPT_IDENTIFIER" && (
       if $_builder_debug; then
-        echo "${COLOR_GREEN}## [$THIS_SCRIPT_IDENTIFIER] Dependency $dep for $_builder_matched_action_name successfully${COLOR_RESET}"
+        builder_echo success "## Dependency $dep for $_builder_matched_action_name successfully"
       fi
     ) || (
       result=$?
-      echo "${COLOR_RED}## [$THIS_SCRIPT_IDENTIFIER] Dependency failed with exit code $result${COLOR_RESET}"
+      builder_echo error "## Dependency failed with exit code $result"
       exit $result
     ) || exit $? # Required due to above subshell masking exit
   done
@@ -1525,3 +1543,11 @@ _builder_has_function_been_called() {
 #
 _builder_init
 _builder_check_color "$@"
+
+if [ -z ${_builder_debug+x} ]; then
+  _builder_debug=false
+fi
+
+if $_builder_debug; then
+  builder_echo_debug "Command line: $0 $@"
+fi

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -165,7 +165,9 @@ builder_echo() {
       blue|heading) color="$COLOR_BLUE" ;;
       yellow|warning) color="$COLOR_YELLOW" ;;
       red|error) color="$COLOR_RED" ;;
-      teal) color="$COLOR_TEAL" ;;
+      purple) color="$COLOR_PURPLE" ;;
+      brightwhite) color="$COLOR_BRIGHTWHITE" ;;
+      teal|debug) color="$COLOR_TEAL" ;;
       setmark) mark="$HEADING_SETMARK" color="$COLOR_PURPLE" ;;
     esac
 
@@ -181,7 +183,7 @@ builder_echo() {
 }
 
 builder_echo_debug() {
-  builder_echo teal "[DEBUG] $*"
+  builder_echo debug "[DEBUG] $*"
 }
 
 #

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -157,21 +157,26 @@ builder_echo() {
     message="$1"
   fi
 
-  case $color in
-    white) color="$COLOR_WHITE" ;;
-    grey) color="$COLOR_GREY" ;;
-    green|success) color="$COLOR_GREEN" ;;
-    blue|heading) color="$COLOR_BLUE" ;;
-    yellow|warning) color="$COLOR_YELLOW" ;;
-    red|error) color="$COLOR_RED" ;;
-    teal) color="$COLOR_TEAL" ;;
-    setmark) mark="$HEADING_SETMARK" color="$COLOR_PURPLE" ;;
-  esac
+  if [[ ! -z ${COLOR_RED+x} ]]; then
+    case $color in
+      white) color="$COLOR_WHITE" ;;
+      grey) color="$COLOR_GREY" ;;
+      green|success) color="$COLOR_GREEN" ;;
+      blue|heading) color="$COLOR_BLUE" ;;
+      yellow|warning) color="$COLOR_YELLOW" ;;
+      red|error) color="$COLOR_RED" ;;
+      teal) color="$COLOR_TEAL" ;;
+      setmark) mark="$HEADING_SETMARK" color="$COLOR_PURPLE" ;;
+    esac
 
-  if builder_is_dep_build; then
-    echo -e "$mark$COLOR_GREY[$THIS_SCRIPT_IDENTIFIER]$COLOR_RESET $color$message$COLOR_RESET"
+    if builder_is_dep_build; then
+      echo -e "$mark$COLOR_GREY[$THIS_SCRIPT_IDENTIFIER]$COLOR_RESET $color$message$COLOR_RESET"
+    else
+      echo -e "$mark$BUILDER_BOLD$COLOR_BRIGHT_WHITE[$THIS_SCRIPT_IDENTIFIER]$COLOR_RESET $color$message$COLOR_RESET"
+    fi
   else
-    echo -e "$mark$BUILDER_BOLD$COLOR_BRIGHT_WHITE[$THIS_SCRIPT_IDENTIFIER]$COLOR_RESET $color$message$COLOR_RESET"
+    # Cope with the case of pre-init message and just emit plain text
+    echo -e "$message"
   fi
 }
 


### PR DESCRIPTION
Makes the output of log messages from builder scripts more consistent, and uses color more effectively to highlight specific parts of lines.

Note: updates documentation for builder_describe_internal_dependency from parent PR #8342.

Sample:
![image](https://user-images.githubusercontent.com/4498365/222077668-89921041-f171-46e8-90ea-c529dcd7a58e.png)

* Highlights top-most script with bright-white+bold identifier
* Dependencies have grey identifiers
* Blue for headings
* Purple for dependency/parameter info
* Yellow for warnings
* Red for errors

@keymanapp-test-bot skip