### PR TITLE
fix(android/engine): Fix various OSK bugs due to refactor 🛋

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
@@ -27,14 +27,14 @@ import java.util.HashMap;
 public final class KMKeyboardWebViewClient extends WebViewClient {
   public static final String TAG = "KMKeyboardWebViewClient";
 
-  public static Context context;
-  private static KeyboardType keyboardType;
-  private static boolean keyboardLoaded;
+  public Context context;
+  private KeyboardType keyboardType;
+  private boolean keyboardLoaded;
 
   KMKeyboardWebViewClient(Context context, KeyboardType keyboardType) {
-    KMKeyboardWebViewClient.context = context;
-    KMKeyboardWebViewClient.keyboardType = keyboardType;
-    KMKeyboardWebViewClient.keyboardLoaded = false;
+    this.context = context;
+    this.keyboardType = keyboardType;
+    this.keyboardLoaded = false;
 
     if (keyboardType != KeyboardType.KEYBOARD_TYPE_INAPP && keyboardType != KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       KMLog.LogError(TAG, String.format("Cannot initialize: Invalid keyboard type: %s", keyboardType.toString()));
@@ -42,7 +42,7 @@ public final class KMKeyboardWebViewClient extends WebViewClient {
   }
 
   public void setContext(Context context) {
-    KMKeyboardWebViewClient.context = context;
+    this.context = context;
   }
 
   public boolean getKeyboardLoaded() {
@@ -50,7 +50,7 @@ public final class KMKeyboardWebViewClient extends WebViewClient {
   }
 
   public void setKeyboardLoaded(boolean keyboardLoaded) {
-    KMKeyboardWebViewClient.keyboardLoaded = keyboardLoaded;
+    this.keyboardLoaded = keyboardLoaded;
   }
 
   @Override
@@ -74,7 +74,7 @@ public final class KMKeyboardWebViewClient extends WebViewClient {
     KMManager.currentLexicalModel = null;
 
     if (url.startsWith("file")) { // TODO: is this test necessary?
-      KMKeyboardWebViewClient.keyboardLoaded = true;
+      this.keyboardLoaded = true;
 
       SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
       int index = prefs.getInt(KMManager.KMKey_UserKeyboardIndex, 0);


### PR DESCRIPTION
Fixes #8305 and fixes #8337 which were regressions introduced in the #7993 refactoring

During my refactoring of KMKeyboardWebViewClient.java, I haphazardly left all the members `static`, which meant there were collisions when both InApp and System keyboards updated themselves.


## User Testing
Setup - Install the PR build of Keyman for Android

* **TEST_GLOBE_KEY_WORKS_AFTER_SYSTEM_KEYBOARD** - Verifies #8337 is fixed
1. Install the PR build of Keyman for Android
2. Open Keyman In-App
3. Click the Globe key
4. May notice that the Keyboard picker menu opens on the screen
5. Open Settings menu
6. Enable Keyman as the "System-wide keyboard" and "Default keyboard"
7. Revert to OSK
8. Click the globe key
9. Dismiss keyboard picker and verify keyboard area is **not** blank

* **TEST_PREDICTIVE_TEXT_BANNER_DISAPPEARS_AFTER_UNINSTALL** - Verifies #8305 is fixed
1. Install the PR build of Keyman for Android
2. Open Keyman In-App
3. Open Settings menu
4. Enable the tick against 'Enable Keyman as system-wide keyboard' check box.
5. Enable the tick against 'Set Keyman as default keyboard' check box.
6. Click Installed languages option.
7. Click English option to go to English Settings menu.
8. Disable both predictions and corrections.
9. Click the Dictionary(MTNT) option.
10. Uninstall English dictionary (MTNT).
11. Switch to main keyboard view.
12. Verify the predictive text banner **no longer** appears
