### PR TITLE
fix(android/app): Another attempt at fixing OSK rotation

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -345,6 +345,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   @Override
   public void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
+    KMManager.onConfigurationChanged(newConfig);
     getSupportActionBar().setBackgroundDrawable(getActionBarDrawable(this));
     resizeTextView(textView.isKeyboardVisible());
     invalidateOptionsMenu();


### PR DESCRIPTION
Fixes #8229 and re-implements #8291

I believe the concerns from #8306 are actually fixed by #8349 which fixed a few issues about interactions between InApp and System keyboard.

## User Testing
Setup - Install the PR build of Keyman for Android

* **TEST_OSK_ROTATION** - Verifies OSK correctly rotates #8229
1. Install the PR build of Keyman for Android on portrait orientation
2. Open the Keyman app
3. Change the mobile view into landscape.
4. Verify the OSK readjusts to fill the entire width

* **TEST_INSTALL_SECOND_LANGUAGE** - Verifies #8306 is still fixed
1. Install the PR build of Keyman for Android
2. Open Keyman In-App.
3. Open Settings menu.
5. Enable Keyman as system-wide keyboard.
6. Enable 'Set Keyman as default keyboard'.
6 Add 'Khmer Angkor' Keyboard using 'Install Keyboard or Dictionary' option.
7. Verify after keyboard and dictionary installed, the keyboard OSK **is not blank**

