### PR TITLE
chore(developer): cleanup API interfaces and types for kmcmplib

### DIFF
--- a/developer/src/kmcmplib/include/kmcmplibapi.h
+++ b/developer/src/kmcmplib/include/kmcmplibapi.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <fstream>
+
+typedef struct _KMCMP_COMPILER_OPTIONS {
+  uint32_t dwSize;
+  bool ShouldAddCompilerVersion;
+} KMCMP_COMPILER_OPTIONS;
+
+extern "C" bool kmcmp_SetCompilerOptions(
+  KMCMP_COMPILER_OPTIONS* options
+);
+
+typedef int (*kmcmp_CompilerMessageProc)(int line, uint32_t dwMsgCode, char* szText, void* context);
+
+extern "C" uint32_t kmcmp_CompileKeyboardFile(
+  char* pszInfile,
+  char* pszOutfile,
+  bool ASaveDebug,
+  bool ACompilerWarningsAsErrors,
+	bool AWarnDeprecatedCode,
+  kmcmp_CompilerMessageProc pMsgproc,
+  void* AmsgprocContext
+);
+
+extern "C" uint32_t kmcmp_CompileKeyboardFileToBuffer(
+  char* pszInfile,
+  void* pfkBuffer,
+  bool ACompilerWarningsAsErrors,
+  bool AWarnDeprecatedCode,
+  kmcmp_CompilerMessageProc pMsgproc,
+  void* AmsgprocContext,
+  int Target
+);
+
+typedef bool (*kmcmp_ValidateJsonMessageProc)(int64_t offset, const char* szText, void* context);
+
+extern "C" bool kmcmp_ValidateJsonFile(
+  std::fstream& f,
+  std::fstream& fd,
+  kmcmp_ValidateJsonMessageProc MessageProc,
+  void* context
+);

--- a/developer/src/kmcmplib/include/kmcompx.h
+++ b/developer/src/kmcmplib/include/kmcompx.h
@@ -1,19 +1,7 @@
 #pragma once
-#include <stdint.h>
 #include <km_types.h>
 
-typedef int         KMX_INT;
 typedef wchar_t     KMX_WCHART;
 typedef KMX_DWORD * PKMX_DWORD;
 typedef char *      PKMX_STR;
 typedef KMX_WCHAR*  PKMX_WCHAR ;
-
-// TODO: Windows-specific
-#ifndef CALLBACK
-#define CALLBACK 
-#endif
-
-typedef int (CALLBACK *CompilerMessageProc)(int line, KMX_DWORD dwMsgCode, PKMX_STR  szText);
-extern "C" KMX_BOOL __declspec(dllexport) kmcmp_CompileKeyboardFile(PKMX_STR pszInfile,
-    PKMX_STR pszOutfile, KMX_BOOL ASaveDebug, KMX_BOOL ACompilerWarningsAsErrors,
-	KMX_BOOL AWarnDeprecatedCode, CompilerMessageProc pMsgProc) ;  // I4865   // I4866

--- a/developer/src/kmcmplib/src/CasedKeys.cpp
+++ b/developer/src/kmcmplib/src/CasedKeys.cpp
@@ -131,7 +131,7 @@ KMX_DWORD ExpandCapsRule(PFILE_GROUP gp, PFILE_KEY kpp, PFILE_STORE sp) {
   if (!k) return CERR_CannotAllocateMemory;
   memcpy(k, gp->dpKeyArray, gp->cxKeyArray * sizeof(FILE_KEY));
 
-  kpp = &k[(KMX_INT)(kpp - gp->dpKeyArray)];
+  kpp = &k[(int)(kpp - gp->dpKeyArray)];
 
   delete gp->dpKeyArray;
   gp->dpKeyArray = k;

--- a/developer/src/kmcmplib/src/json-validation.cpp
+++ b/developer/src/kmcmplib/src/json-validation.cpp
@@ -2,13 +2,12 @@
 #include <json-schema.hpp>
 #include <fstream>
 
+#include <kmcmplibapi.h>
 #include "kmcompx.h"
 
 using nlohmann::json;
 using nlohmann::json_uri;
 using nlohmann::json_schema_draft4::json_validator;
-
-typedef bool (*kmcmp_ValidateJsonMessageProc)(int64_t offset, const char* szText, void* context);
 
 static void loader(const json_uri &uri, json &schema)
 {

--- a/developer/src/kmcmplib/src/virtualcharkeys.h
+++ b/developer/src/kmcmplib/src/virtualcharkeys.h
@@ -1,9 +1,7 @@
 #ifndef _VIRTUALCHARKEYS_H
 #define _VIRTUALCHARKEYS_H
 
-//#include <windows.h>
-
 extern BOOL VKeyMayBeVCKey[256];
 
 #endif
-	
+

--- a/developer/src/kmcmplib/tests/kmcompxtest.cpp
+++ b/developer/src/kmcmplib/tests/kmcompxtest.cpp
@@ -4,18 +4,17 @@
  * Tiny frame console app to compile a .kmx from a .kmn
  */
 
-#include <windows.h>
 #include <stdio.h>
-#include "kmcompx.h"
 #include <iostream>
 #include <vector>
 #include <string>
 #include <sstream>
+#include <kmcmplibapi.h>
 using namespace std;
 
 vector < int > error_vec;
 
-int WINAPI msgproc(int line, KMX_DWORD dwMsgCode, char* szText)
+int msgproc(int line, uint32_t dwMsgCode, char* szText, void* context)
 {
   error_vec.push_back(dwMsgCode);
   printf("line %d  error %x  %s\n", line, (unsigned int)dwMsgCode, szText);
@@ -24,8 +23,8 @@ int WINAPI msgproc(int line, KMX_DWORD dwMsgCode, char* szText)
 
 int main(int argc, char *argv[])
 {
-  PKMX_STR kmn_file = argv[1];
-  PKMX_STR kmx_file = argv[2];
+  char* kmn_file = argv[1];
+  char* kmx_file = argv[2];
 
 	if(argc < 3) {
 		puts("Usage: kmcompxtest source.kmn compiled.kmx");
@@ -46,7 +45,7 @@ int main(int argc, char *argv[])
   char  first5[6] = "CERR_";
   char* pfirst5 = first5;
 
-  if (kmcmp_CompileKeyboardFile(kmn_file, kmx_file, FALSE, FALSE, TRUE, msgproc)) {
+  if (kmcmp_CompileKeyboardFile(kmn_file, kmx_file, false, false, true, msgproc, nullptr)) {
     char* testname = strrchr( (char*) kmn_file, '\\') + 1;
     if (strncmp(testname, pfirst5, 5) == 0) return 1;  // exit code 1: CERR_ in Name + no Error found
 


### PR DESCRIPTION
Introduces kmcmplibapi.h which declares all external functions and types for kmcmplib, and updates kmcmplib and kmcmpdll to use these declarations consistently.

Note that kmcmp_CompileKeyboardToBuffer declares a void* instead of PFILE_KEYBOARD, because this is a large and complex type defined in both kmcmpdll and kmcmplib. In the future, when kmcmpdll existing legacy compiler is removed, we can make the kmcmplib type more public.

@keymanapp-test-bot skip