### PR TITLE
chore(core): Create both dynamic and static libs on Linux

### DIFF
--- a/core/commands.inc.sh
+++ b/core/commands.inc.sh
@@ -20,17 +20,11 @@ do_configure() {
   local target=$1
   builder_start_action configure:$target || return 0
 
-  local STANDARD_MESON_ARGS="$MESON_OPTION_keyman_core_tests"
+  local STANDARD_MESON_ARGS="$MESON_OPTION_keyman_core_tests --default-library both"
   local MESON_CROSS_FILE=
 
   if [[ -f "$THIS_SCRIPT_PATH/cross-$target.build" ]]; then
     MESON_CROSS_FILE="--cross-file cross-$target.build"
-  fi
-
-  if [[ $target =~ ^mac ]]; then
-    # On mac, build both dynamic and static libraries; win does the same in build.bat
-    # In the future, we may do this on Linux as well
-    STANDARD_MESON_ARGS="$STANDARD_MESON_ARGS --default-library both"
   fi
 
   builder_heading "======= Configuring $target ======="

--- a/core/src/meson.build
+++ b/core/src/meson.build
@@ -124,22 +124,6 @@ lib = library('kmnkbp0',
   pic: true,
   install: true)
 
-if host_machine.system() == 'linux'
-  # on Linux we need the static lib for ibus-keyman tests
-  static_library('kmnkbp0-static',
-    api_files,
-    core_files,
-    kmx_files,
-    mock_files,
-    version_res,
-    cpp_args: defns + warns + flags,
-    link_args: links,
-    include_directories: inc,
-    pic: true,
-    install: false
-  )
-endif
-
 headerdirs = [ '.', 'keyman' ] # subdirectories of ${prefix}/include to add to header path
 
 kmnkbp = declare_dependency(link_with: lib, include_directories: inc)

--- a/linux/debian/libkmnkbp-dev.install
+++ b/linux/debian/libkmnkbp-dev.install
@@ -1,3 +1,4 @@
 usr/include/keyman/*
+usr/lib/*/lib*.a
 usr/lib/*/lib*.so
 usr/lib/*/pkgconfig


### PR DESCRIPTION
This change creates both dynamic and static libs on Linux. 

@keymanapp-test-bot skip