### PR TITLE
chore(core): Remove obsolete `--target-path` option

### DIFF
--- a/core/build.sh
+++ b/core/build.sh
@@ -74,7 +74,6 @@ Libraries will be built in 'build/<target>/<configuration>/src'.
   "${archtargets[@]}" \
   "--debug,-d                      configuration is 'debug', not 'release'" \
   "--no-tests                      do not configure tests (used by other projects)" \
-  "--target-path=opt_target_path   override for build/ target path" \
   "--test=opt_tests,-t             test[s] to run (space separated)"
 
 builder_parse "$@"
@@ -123,23 +122,13 @@ builder_describe_outputs \
   build:arch                build/arch/$CONFIGURATION/src/libkmnkbp0.a \
   build:wasm                build/wasm/$CONFIGURATION/src/libkmnkbp0.a
 
-# Target path is used by Linux build, e.g. --target-path keyboardprocessor
-# TODO: sort out builder_describe_outputs and TARGET_PATH -- preferably by
-#       having Keyman for Linux build Core normally and then _copy_ the
-#       required files into its target path, and eliminating --target-path
-if builder_has_option --target-path; then
-  TARGET_PATH="$opt_target_path"
-else
-  TARGET_PATH="$KEYMAN_ROOT/core/build"
-fi
-
 # Iterate through all possible targets; note that targets that cannot be built
 # on the current platform have already been excluded through the archtargets
 # settings above
 targets=(wasm x86 x64 mac-x86_64 mac-arm64 arch)
 
 for target in "${targets[@]}"; do
-  MESON_PATH="$TARGET_PATH/$target/$CONFIGURATION"
+  MESON_PATH="$KEYMAN_ROOT/core/build/$target/$CONFIGURATION"
 
   do_clean $target
   do_configure $target
@@ -152,15 +141,15 @@ done
 # After we have built the necessary internal dependencies, then we can go
 # ahead and build a fat library for external consumption
 if builder_start_action configure:mac; then
-  mkdir -p "$TARGET_PATH/mac/$CONFIGURATION"
+  mkdir -p "$KEYMAN_ROOT/core/build/mac/$CONFIGURATION"
   builder_finish_action success configure:mac
 fi
 
 if builder_start_action build:mac; then
   lipo -create \
-    "$TARGET_PATH/mac-x86_64/$CONFIGURATION/src/libkmnkbp0.a" \
-    "$TARGET_PATH/mac-arm64/$CONFIGURATION/src/libkmnkbp0.a" \
-    -output "$TARGET_PATH/mac/$CONFIGURATION/libkmnkbp0.a"
+    "$KEYMAN_ROOT/core/build/mac-x86_64/$CONFIGURATION/src/libkmnkbp0.a" \
+    "$KEYMAN_ROOT/core/build/mac-arm64/$CONFIGURATION/src/libkmnkbp0.a" \
+    -output "$KEYMAN_ROOT/core/build/mac/$CONFIGURATION/libkmnkbp0.a"
   builder_finish_action success build:mac
 fi
 
@@ -169,7 +158,7 @@ if builder_start_action test:mac; then
   # assume that build:mac has run so both architectures will be
   # available
   target=mac-`uname -m`
-  MESON_PATH="$TARGET_PATH/$target/$CONFIGURATION"
+  MESON_PATH="$KEYMAN_ROOT/core/build/$target/$CONFIGURATION"
   meson test -C "$MESON_PATH" "${builder_extra_params[@]}"
   builder_finish_action success test:mac
 fi

--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -12,8 +12,6 @@ keyman-config/make_deb
 tmp/
 dist/
 *~
-# keyboardprocessor build artifacts (Keyman Core desktop)
-keyboardprocessor/
 # IDE config files
 **/.idea/
 upload/

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -32,7 +32,7 @@ sources:
 	./scripts/dist.sh
 
 tmpsources:
-	PKG_CONFIG_PATH="../keyboardprocessor/arch/release/meson-private" ./scripts/dist.sh
+	PKG_CONFIG_PATH="../../core/build/arch/release/meson-private" ./scripts/dist.sh
 
 origdist:
 	./scripts/dist.sh origdist

--- a/linux/ibus-keyman/tests/scripts/run-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/run-tests.sh
@@ -60,7 +60,6 @@ function run_tests() {
 
   COMMON_ARCH_DIR=
   [ -d "${TOP_SRCDIR}"/../../core/build/arch ] && COMMON_ARCH_DIR=${TOP_SRCDIR}/../../core/build/arch
-  [ -d "${TOP_SRCDIR}"/../keyboardprocessor/arch ] && COMMON_ARCH_DIR=${TOP_SRCDIR}/../keyboardprocessor/arch
 
   if [ -d "${COMMON_ARCH_DIR}"/release ]; then
     COMMON_ARCH_DIR=${COMMON_ARCH_DIR}/release

--- a/linux/ibus-keyman/tests/scripts/setup-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/setup-tests.sh
@@ -22,7 +22,6 @@ echo "rm -rf ${TEMP_DATA_DIR}" >> "$PID_FILE"
 
 COMMON_ARCH_DIR=
 [ -d "${TOP_SRCDIR}"/../../core/build/arch ] && COMMON_ARCH_DIR=${TOP_SRCDIR}/../../core/build/arch
-[ -d "${TOP_SRCDIR}"/../keyboardprocessor/arch ] && COMMON_ARCH_DIR=${TOP_SRCDIR}/../keyboardprocessor/arch
 
 if [ -d "${COMMON_ARCH_DIR}"/release ]; then
   COMMON_ARCH_DIR=${COMMON_ARCH_DIR}/release

--- a/linux/scripts/build.sh
+++ b/linux/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Build Keyman for Linux: keyboardprocessor ibus-keyman
+# Build Keyman for Linux: core ibus-keyman
 
 # It must be run from the keyman/linux directory
 
@@ -25,7 +25,7 @@ if [[ "${BUILDONLY}" == "no" ]]; then
 	# While we can't pass extra parameters to the configure action
 	# we need these extra commands
 	cd ../core/build/arch/release
-	echo "reconfiguring keyboardprocessor meson with prefix ${INSTALLDIR}"
+	echo "reconfiguring Keyman Core meson with prefix ${INSTALLDIR}"
 	meson configure -Dprefix="${INSTALLDIR}" && ninja reconfigure
 
 	# We need to build core first before we can configure ibus-keyman!
@@ -37,7 +37,7 @@ if [[ "${BUILDONLY}" == "no" ]]; then
 fi
 
 if [[ "${CONFIGUREONLY}" == "no" ]]; then
-	echo "building keyboardprocessor"
+	echo "building Keyman Core"
 	cd "$BASEDIR"
 	# May 2021: For now, running tests here as well. We could move this elsewhere
 	# in the future if we want to split out the tests, but they run in a couple of seconds

--- a/linux/scripts/build.sh
+++ b/linux/scripts/build.sh
@@ -20,15 +20,17 @@ fi
 
 if [[ "${BUILDONLY}" == "no" ]]; then
 	cd "$BASEDIR"
-	../core/build.sh --no-tests --target-path "$BASEDIR/keyboardprocessor" configure:arch
+	../core/build.sh --no-tests configure:arch
 
-	cd keyboardprocessor/arch/release
+	# While we can't pass extra parameters to the configure action
+	# we need these extra commands
+	cd ../core/build/arch/release
 	echo "reconfiguring keyboardprocessor meson with prefix ${INSTALLDIR}"
 	meson configure -Dprefix="${INSTALLDIR}" && ninja reconfigure
 
 	# We need to build core first before we can configure ibus-keyman!
 	cd "$BASEDIR"
-	../core/build.sh --target-path "$BASEDIR/keyboardprocessor" build:arch
+	../core/build.sh build:arch
 
 	cd "$BASEDIR/ibus-keyman"
 	./build.sh clean configure -- --prefix="${INSTALLDIR}"
@@ -40,7 +42,7 @@ if [[ "${CONFIGUREONLY}" == "no" ]]; then
 	# May 2021: For now, running tests here as well. We could move this elsewhere
 	# in the future if we want to split out the tests, but they run in a couple of seconds
 	# at present.
-	../core/build.sh --target-path "$BASEDIR/keyboardprocessor" build:arch test:arch
+	../core/build.sh build:arch test:arch
 
 	echo "building ibus-keyman"
 	cd "$BASEDIR/ibus-keyman"

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -36,10 +36,10 @@ dpkg-source --tar-ignore=*~ --tar-ignore=.git --tar-ignore=.gitattributes \
     --tar-ignore=common/models --tar-ignore=common/predictive-text \
     --tar-ignore=common/resources --tar-ignore=common/schemas \
     --tar-ignore=common/test --tar-ignore=common/web --tar-ignore=common/windows \
+    --tar-ignore=core/build \
     --tar-ignore=developer --tar-ignore=docs --tar-ignore=ios \
     --tar-ignore=linux/keyman-config/buildtools/build-langtags.py --tar-ignore=__pycache__ \
     --tar-ignore=linux/help --tar-ignore=linux/Jenkinsfile \
-    --tar-ignore=linux/keyboardprocessor \
     --tar-ignore=mac --tar-ignore=node_modules --tar-ignore=oem \
     --tar-ignore=linux/build --tar-ignore=core/build \
     --tar-ignore=resources/devbox --tar-ignore=resources/git-hooks \

--- a/linux/scripts/install.sh
+++ b/linux/scripts/install.sh
@@ -31,7 +31,7 @@ if [ -f "/usr/share/ibus/component/keyman.xml" ] && [ "${SUDOINSTALL}" == "yes" 
 	fi
 fi
 
-cd keyboardprocessor/arch/release
+cd ../core/build/arch/release
 ninja install
 cd "$BASEDIR"
 


### PR DESCRIPTION
Linux package builds no longer require a different target path, so we can remove the `--target-path` parameter.

@keymanapp-test-bot skip