### PR TITLE
chore(common): clean up `--debug` usage in build scripts

### DIFF
--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -38,7 +38,7 @@ builder_describe "Builds Keyman for Android app." \
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   builder_heading "### Debug config ####"
   CONFIG="debug"
   BUILD_FLAGS="assembleDebug -x lint -x test"

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -40,7 +40,7 @@ builder_describe "Builds Keyman Engine for Android." \
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   builder_heading "### Debug config ####"
   CONFIG="debug"
   BUILD_FLAGS="assembleDebug -x lint -x test"

--- a/android/Samples/KMSample1/build.sh
+++ b/android/Samples/KMSample1/build.sh
@@ -30,12 +30,12 @@ builder_describe "Build KMSample1 app for Android." \
   "configure" \
   "build" \
   ":app                   KMSample1" \
-  "--ci                   Don't start the Gradle daemon. Use for CI" 
+  "--ci                   Don't start the Gradle daemon. Use for CI"
 
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   builder_heading "### Debug config ####"
   CONFIG="debug"
   SAMPLE_FLAGS="assembleDebug"

--- a/android/Samples/KMSample2/build.sh
+++ b/android/Samples/KMSample2/build.sh
@@ -30,12 +30,12 @@ builder_describe "Build KMSample2 app for Android." \
   "configure" \
   "build" \
   ":app                   KMSample2" \
-  "--ci                   Don't start the Gradle daemon. Use for CI" 
+  "--ci                   Don't start the Gradle daemon. Use for CI"
 
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   builder_heading "### Debug config ####"
   CONFIG="debug"
   SAMPLE_FLAGS="assembleDebug"

--- a/android/Tests/KeyboardHarness/build.sh
+++ b/android/Tests/KeyboardHarness/build.sh
@@ -29,12 +29,12 @@ builder_describe "Build KeyboardHarness test app for Android." \
   "configure" \
   "build" \
   ":app                   KeyboardHarness" \
-  "--ci                   Don't start the Gradle daemon. Use for CI" 
+  "--ci                   Don't start the Gradle daemon. Use for CI"
 
-# parse before describe outputs to check debug flags  
+# parse before describe outputs to check debug flags
 builder_parse "$@"
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   builder_heading "### Debug config ####"
   CONFIG="debug"
   BUILD_FLAGS="assembleDebug -x lint -x test"

--- a/android/build.sh
+++ b/android/build.sh
@@ -44,9 +44,8 @@ if builder_has_option --ci; then
   CI_FLAG=--ci
 fi
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   CONFIG=debug
-  DEBUG_FLAG=--debug
 fi
 
 builder_run_child_actions clean configure build test publish
@@ -55,7 +54,7 @@ if builder_has_option --upload-sentry; then
   SENTRY_FLAG="--upload-sentry"
 fi
 
-# TODO: 
+# TODO:
 # builder_declare_inheritable_parameters \
 #  "--ci                                     Don't start the Gradle daemon. Use for CI" \
 #  "--upload-sentry                          Uploads debug symbols, etc, to Sentry"

--- a/core/build.sh
+++ b/core/build.sh
@@ -66,7 +66,6 @@ Libraries will be built in 'build/<target>/<configuration>/src'.
   "install         install libraries to current system" \
   "uninstall       uninstall libraries from current system" \
   "${archtargets[@]}" \
-  "--debug,-d                      configuration is 'debug', not 'release'" \
   "--no-tests      do not configure tests (used by other projects)" \
   "--target-path=opt_target_path   override for build/ target path" \
   "--test=opt_tests,-t             test[s] to run (space separated)"
@@ -89,7 +88,7 @@ if builder_is_dep_build || builder_has_option --no-tests; then
   builder_remove_dep /developer/src/kmc
 fi
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   CONFIGURATION=debug
 else
   CONFIGURATION=release

--- a/linux/ibus-keyman/build.sh
+++ b/linux/ibus-keyman/build.sh
@@ -18,15 +18,15 @@ builder_describe \
   "build" \
   "test" \
   "install                   install artifacts" \
-  "uninstall                 uninstall artifacts" \
-  "--debug,-d                Debug build"
+  "uninstall                 uninstall artifacts"
+
 # We can't yet depend on core until it moved to the new build.sh syntax
 # (currently it doesn't know some parameters that we're passing)
 #  "@/core configure build"
 
 builder_parse "$@"
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   MESON_TARGET=debug
   export CPPFLAGS=-DG_MESSAGES_DEBUG
   export CFLAGS="-O0"

--- a/oem/firstvoices/android/build.sh
+++ b/oem/firstvoices/android/build.sh
@@ -38,12 +38,12 @@ builder_describe "Builds FirstVoices for Android app." \
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   builder_heading "### Debug config ####"
   CONFIG="debug"
   BUILD_FLAGS="assembleDebug -x lint -x test"
   TEST_FLAGS="-x assembleDebug lintDebug testDebug"
-fi  
+fi
 
 ARTIFACT="firstvoices-$VERSION.apk"
 

--- a/resources/build/build-utils.md
+++ b/resources/build/build-utils.md
@@ -151,15 +151,18 @@ a user or called by another script:
 
 * **options**: these are possible additional options that can be passed to the
   script to modify the behavior of the script. All options should be prefixed
-  with `--`, such as `--debug`, and a shorthand single letter form may also be
-  optionally provided, such as `-d`.
+  with `--`, such as `--option`, and a shorthand single letter form may also be
+  optionally provided, such as `-o`.
 
   Note that when we call scripts from other scripts, particularly in CI, we
   should always use the longhand form; the shorthand form is for convenience on
   the command line only.
 
-  Be judicious in use of options; a common one will be `--debug` to do a debug
-  build, but overuse of options will make scripts hard to use.
+  Be judicious in use of options; overuse of options will make scripts hard to
+  use.
+
+  **Note:** `--debug` (or `-d`) is a standard option and should not be declared
+  again. See [`builder_is_debug_build`] for more details on the `--debug` flag.
 
   Options can be used to provide additional data, by including `=<varname>` in
   their definition. Otherwise, they are treated as a boolean.
@@ -245,8 +248,24 @@ The following parameters are pre-defined and should not be overridden:
 * `--color`: forces on ANSI color output for the script
 * `--no-color`: forces off ANSI color output for the script
 * `--verbose`, `-v`: verbose mode, sets the [`$builder_verbose`] variable
+* `--debug`, `-d`: debug build; see [`builder_is_debug_build`] for more detail
 
 # Builder API functions and variables
+
+## `$builder_debug` variable
+
+This standard variable will be set to `"--debug"`, if the `--debug` or `-d`
+parameter is passed on the command line, and otherwise will be set to `""`.
+
+### Usage
+
+For example, can be used to pass `--debug` to another app:
+
+```bash
+npm test -- $builder_debug
+```
+
+--------------------------------------------------------------------------------
 
 ## `builder_describe` function
 
@@ -341,7 +360,7 @@ builder_describe "Testing script" clean test+
 
 ```bash
 builder_describe "Sample script" \
-  --debug,-d \
+  --option,-o \
   "--out-path,-o=OUT_PATH    Specify output path"
 ```
 
@@ -359,8 +378,9 @@ to test for the presence of the parameter before attempting to use the variable.
 **Note:** although the definition uses `=` to define the variable, when invoking
 script, the value should be passed in as a separate parameter.
 
-There is one option with a predefined description: `--debug`. When including
-this, you should use `--debug,-d` to enable the shorthand form.
+There is one standard option: `--debug`. You should not include `--debug` in the
+`builder_describe` call, as it is always available. See
+[`builder_is_debug_build`] for more details.
 
 Note that you should not include any of the [standard builder parameters] here.
 
@@ -517,6 +537,29 @@ if builder_has_option --path; then
   echo "The output path is $OUT_PATH"
 fi
 ```
+
+--------------------------------------------------------------------------------
+
+## `builder_is_debug_build` function
+
+Returns `true` (aka 0) if the `--debug` standard option was passed in. This
+should be used instead of `builder_has_option --debug`.
+
+### Usage
+
+```bash
+if builder_is_debug_build; then
+  ... # e.g. CONFIG=debug
+fi
+```
+
+### Description
+
+The `--debug` standard option is currently handled differently to other options.
+It should never be declared in `builder_describe`, because it is always
+available anyway.
+
+`--debug` is automatically passed to child scripts and dependency scripts.
 
 --------------------------------------------------------------------------------
 
@@ -691,3 +734,4 @@ Note: it is recommended that you use `$(builder_term text)` instead of
 [`$builder_verbose`]: #builderverbose-variable
 [formatting variables]: #formatting-variables
 [`builder_run_child_actions`]: #builderrunchildactions-function
+[`builder_is_debug_build`]: #builderisdebugbuild-function


### PR DESCRIPTION
Fixes #8373.

Note that the core functionality requested in #8373 is already in place; this commit just does some cleanup to make this easier to maintain in the future:

* Uses `builder_is_debug_build` function to test for debug build (instead of `builder_has_option --debug`, which would also work but using the other function avoids typo issues with the option name).

* Renames `$_builder_debug` to `$_builder_debug_internal` to reduce naming confusion

* Documents `$builder_debug`, `builder_is_debug_build`, and clarifies usage of `--debug` option.

* Logs command line for dep builds (we could hide this in the future, but it certainly doesn't hurt for now!)

@keymanapp-test-bot skip