### PR TITLE
chore(developer): check for *p != NULL and test for p > pStart

### DIFF
--- a/developer/src/kmcmplib/src/xstring.cpp
+++ b/developer/src/kmcmplib/src/xstring.cpp
@@ -25,7 +25,7 @@ PKMX_WCHAR incxstr(PKMX_WCHAR p) {
   // UC_SENTINEL(FFFF) with UC_SENTINEL_EXTENDEDEND(0x10) == variable length
   if (*(p + 1) == CODE_EXTENDED) {
     p += 2;
-    while (*p && *p != UC_SENTINEL_EXTENDEDEND)
+    while (*p && *p != NULL && *p != UC_SENTINEL_EXTENDEDEND)
       p++;
 
     if (*p == 0)        return p;
@@ -58,10 +58,10 @@ PKMX_WCHAR decxstr(PKMX_WCHAR p, PKMX_WCHAR pStart)
   p--;
   if(*p == UC_SENTINEL_EXTENDEDEND) {
     int n = 0;
-    while (p >= pStart && *p != UC_SENTINEL && n < 10) {
+    while (p > pStart && *p != UC_SENTINEL && n < 10) {
       p--; n++; }
 
-    if(p < pStart) {
+    if(p <= pStart) {
       // May be a malformed virtual key
       return pStart;
     }

--- a/developer/src/kmcmplib/src/xstring.cpp
+++ b/developer/src/kmcmplib/src/xstring.cpp
@@ -59,7 +59,9 @@ PKMX_WCHAR decxstr(PKMX_WCHAR p, PKMX_WCHAR pStart)
   if(*p == UC_SENTINEL_EXTENDEDEND) {
     int n = 0;
     while (p > pStart && *p != UC_SENTINEL && n < 10) {
-      p--; n++; }
+      p--; 
+      n++;
+    }
 
     if(p <= pStart) {
       // May be a malformed virtual key

--- a/developer/src/kmcmplib/src/xstring.cpp
+++ b/developer/src/kmcmplib/src/xstring.cpp
@@ -25,7 +25,7 @@ PKMX_WCHAR incxstr(PKMX_WCHAR p) {
   // UC_SENTINEL(FFFF) with UC_SENTINEL_EXTENDEDEND(0x10) == variable length
   if (*(p + 1) == CODE_EXTENDED) {
     p += 2;
-    while (*p && *p != NULL && *p != UC_SENTINEL_EXTENDEDEND)
+    while (*p && *p != UC_SENTINEL_EXTENDEDEND)
       p++;
 
     if (*p == 0)        return p;

--- a/developer/src/kmcmplib/src/xstring.cpp
+++ b/developer/src/kmcmplib/src/xstring.cpp
@@ -63,10 +63,6 @@ PKMX_WCHAR decxstr(PKMX_WCHAR p, PKMX_WCHAR pStart)
       n++;
     }
 
-    if(p <= pStart) {
-      // May be a malformed virtual key
-      return pStart;
-    }
     return p;
   }
 


### PR DESCRIPTION
fixes: #8082

In developer/src/kmcmplib/src/xstring.cpp (l. 24) 
```
// UC_SENTINEL(FFFF) with UC_SENTINEL_EXTENDEDEND(0x10) == variable length
  if (*(p + 1) == CODE_EXTENDED) {
    p += 2;
    while (*p && *p != UC_SENTINEL_EXTENDEDEND)
```
We probably should check for *p != NULL as well in case we have invalid data.
and from line 57 :
 ```
 p--;
  if(*p == UC_SENTINEL_EXTENDEDEND) {
    int n = 0;
    while (p >= pStart && *p != UC_SENTINEL && n < 10) {
```
It would be better to test for `p > pStart` and change the line after the block below to `if(p <= pStart)`. That way we wouldn't have to decrement the pointer to an unallocated memory location which some machines don't like.

see comment [#6980 (comment)](https://github.com/keymanapp/keyman/pull/6980#discussion_r1068199232) and [#6980 (comment)](https://github.com/keymanapp/keyman/pull/6980#discussion_r1068211588) in feat(developer): cross-platform kmx compiler 🚑 [#6980](https://github.com/keymanapp/keyman/pull/6980), [#7330](https://github.com/keymanapp/keyman/pull/7330)
@keymanapp-test-bot skip
