### PR TITLE
chore(developer): use consistent line endings \r\n

### DIFF
--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -3389,12 +3389,20 @@ KMX_DWORD ReadLine(FILE* fp_in , PKMX_WCHAR wstr, KMX_BOOL PreProcess)
 
   if (cur == fsize)
 
-  // S: Is replacing "\r\n" with "\n" here sufficient or do we need changes at other places as well when we skip "\r"?
+  // \r\n is still added here even though Linux doesn`t use \r.
+  // This is to ensure to still have a working windows-only-version
   u16ncat(str, u"\r\n", _countof(str));  // I3481     // Always a "\r\n" to the EOF, avoids funny bugs
-  // u16ncat(str, u"\n", _countof(str));  // I3481
 
   if (len == 0) return CERR_EndOfFile;
 
+  // neccessary to add this block for using on non-windows platforms (removes all \r for platforms that use \n instead of \r\n)
+  for (p = str, n = 0; n < len; n++, p++) {
+    if (*p == L'\r')
+      *p = L' ';
+  }
+
+  // \r is still left in this block even though Linux doesn`t use \r.
+  // This is to ensure to still have a working windows-only-version
   for (p = str, n = 0; n < len; n++, p++)
   {
     if (currentQuotes != 0)

--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -3413,7 +3413,7 @@ KMX_DWORD ReadLine(FILE* fp_in , PKMX_WCHAR wstr, KMX_BOOL PreProcess)
       *p = L' ';
       continue;
     }
-    if((*p == L'\\') || (*p == L'/')) {
+    if((*p == L'\\')) {
       LineCarry = TRUE;
       *p = L' ';
       continue;


### PR DESCRIPTION
fixes: #8355
In kmcompdll we use \r\n as line ending which works for windows. We need to ensure that this works on Linux as well ( as there is no \r) 

see https://github.com/keymanapp/keyman/pull/6980#discussion_r975516282 cross-platform kmx compiler 🚑 https://github.com/keymanapp/keyman/pull/6980, [#7330](https://github.com/keymanapp/keyman/pull/7330)
@keymanapp-test-bot skip