### PR TITLE
chore(common): clean up `--debug` usage in build scripts

### DIFF
--- a/common/predictive-text/unit_tests/test.sh
+++ b/common/predictive-text/unit_tests/test.sh
@@ -23,8 +23,7 @@ builder_describe "Runs all tests for the language-modeling / predictive-text lay
   ":libraries  Runs unit tests for in-repo libraries used by this module"\
   ":headless   Runs this module's headless user tests" \
   ":browser    Runs this module's browser-based user tests" \
-  "--ci        Uses CI-based test configurations & emits CI-friendly test reports" \
-  "--debug,-d  Activates developer-friendly debug mode for unit tests where applicable"
+  "--ci        Uses CI-based test configurations & emits CI-friendly test reports"
 
 # TODO: consider dependencies? ideally this will be test.inc.sh?
 
@@ -122,12 +121,12 @@ if builder_start_action test:browser; then
     KARMA_CONFIG="CI.conf.js"
     KARMA_INFO_LEVEL="--log-level=debug"
 
-    if builder_has_option --debug; then
+    if builder_is_debug_build; then
       echo "$(builder_term --ci) option set; ignoring $(builder_term --debug) option"
     fi
   else
     KARMA_CONFIG="manual.conf.js"
-    if builder_has_option --debug; then
+    if builder_is_debug_build; then
       KARMA_FLAGS="$KARMA_FLAGS --no-single-run"
       KARMA_CONFIG="manual.conf.js"
       KARMA_INFO_LEVEL="--log-level=debug"

--- a/core/build.sh
+++ b/core/build.sh
@@ -95,7 +95,7 @@ if builder_is_dep_build || builder_has_option --no-tests; then
   builder_remove_dep /developer/src/kmc
 fi
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   CONFIGURATION=debug
 else
   CONFIGURATION=release

--- a/core/build.sh
+++ b/core/build.sh
@@ -72,7 +72,6 @@ Libraries will be built in 'build/<target>/<configuration>/src'.
   "install                         install libraries to current system" \
   "uninstall                       uninstall libraries from current system" \
   "${archtargets[@]}" \
-  "--debug,-d                      configuration is 'debug', not 'release'" \
   "--no-tests                      do not configure tests (used by other projects)" \
   "--target-path=opt_target_path   override for build/ target path" \
   "--test=opt_tests,-t             test[s] to run (space separated)"

--- a/linux/ibus-keyman/build.sh
+++ b/linux/ibus-keyman/build.sh
@@ -18,15 +18,15 @@ builder_describe \
   "build" \
   "test" \
   "install                   install artifacts" \
-  "uninstall                 uninstall artifacts" \
-  "--debug,-d                Debug build"
+  "uninstall                 uninstall artifacts"
+
 # We can't yet depend on core until it moved to the new build.sh syntax
 # (currently it doesn't know some parameters that we're passing)
 #  "@/core configure build"
 
 builder_parse "$@"
 
-if builder_has_option --debug; then
+if builder_is_debug_build; then
   MESON_TARGET=debug
   export CPPFLAGS=-DG_MESSAGES_DEBUG
   export CFLAGS="-O0"

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -32,7 +32,6 @@ builder_describe "Defines and implements the CI build steps for Keyman Engine fo
   "prepare                      Prepare upload artifacts for specified target(s)" \
   ":s.keyman.com                Target:  builds artifacts for s.keyman.com " \
   ":downloads.keyman.com        Target:  builds artifacts for downloads.keyman.com" \
-  "--debug                      Runs this script in local-development mode; reports and tests will be locally logged" \
   "--s.keyman.com=S_KEYMAN_COM  Sets the root location of a checked-out s.keyman.com repo"
 
 builder_parse "$@"
@@ -58,7 +57,7 @@ if builder_start_action test; then
   # For all others, specify only the :libraries target
   FLAGS=
 
-  if ! builder_has_option --debug; then
+  if ! builder_is_debug_build; then
     FLAGS=--ci
   fi
 
@@ -80,7 +79,7 @@ if builder_start_action validate-size; then
   # Performs the web build product size check as reported on Web test PRs.
   FLAGS=
 
-  if ! builder_has_option --debug; then
+  if ! builder_is_debug_build; then
     FLAGS=--write-status
   fi
 
@@ -96,7 +95,7 @@ if builder_start_action prepare:s.keyman.com; then
     builder_die "--s.keyman.com is unset!"
   fi
 
-  if builder_has_option --debug; then
+  if builder_is_debug_build; then
     # First phase: make sure the s.keyman.com repo is locally-available and up to date.
     pushd "$S_KEYMAN_COM"
 

--- a/web/test.sh
+++ b/web/test.sh
@@ -76,7 +76,7 @@ get_default_browser_set ( ) {
 }
 
 if builder_start_action test:engine; then
-  if builder_has_option --ci && builder_has_option --debug; then
+  if builder_has_option --ci && builder_is_debug_build; then
     builder_die "Options --ci and --debug are incompatible."
   fi
 
@@ -104,7 +104,7 @@ if builder_start_action test:engine; then
   # Prepare the flags for the karma command.
   KARMA_FLAGS=
 
-  if builder_has_option --debug; then
+  if builder_is_debug_build; then
     KARMA_FLAGS="$KARMA_FLAGS --no-single-run"
   fi
 


### PR DESCRIPTION
Fixes #8373.

Replaces #8378 (basing on master; android script updates will be added to #7407).

Note that the core functionality requested in #8373 is already in place; this commit just does some cleanup to make this easier to maintain in the future:

* Uses `builder_is_debug_build` function to test for debug build (instead of `builder_has_option --debug`, which would also work but using the other function avoids typo issues with the option name).

* Renames `$_builder_debug` to `$_builder_debug_internal` to reduce naming confusion

* Documents `$builder_debug`, `builder_is_debug_build`, and clarifies usage of `--debug` option.

* Logs command line for dep builds (we could hide this in the future, but it certainly doesn't hurt for now!)

@keymanapp-test-bot skip