### PR TITLE
feat(common): builder.inc.sh inheritable options

### DIFF
--- a/resources/build/build-utils.md
+++ b/resources/build/build-utils.md
@@ -378,7 +378,9 @@ a definition:
 builder_describe "Testing script" clean test+
 ```
 
-**Options** are defined by including a `--` prefix, for example:
+**Options** are defined by including a `--` prefix.
+
+Specification of options: `"--option[,-o][+][=var]   [One line description]"`
 
 ```bash
 builder_describe "Sample script" \
@@ -390,6 +392,12 @@ A shorthand form may optionally be provided by appending `,-x` to the parameter
 definition, where `x` is a one letter shorthand form. Currently, shorthand forms
 may not be combined when invoking the script -- each must be passed separately.
 Ensure that you do not include a space after the comma.
+
+If a `+` is appended (after the optional shorthand form, but before the
+default), then the option will be passed to child scripts. All child scripts
+_must_ accept this option, or they will fail. It is acceptable for the child
+script to declare the option but ignore it. However, the option will _not_ be
+passed to dependencies.
 
 By default, an option will be treated as a boolean. It can be tested with
 [`builder_has_option`]. If you need to pass additional data, then the

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -313,7 +313,17 @@ _builder_execute_child() {
     builder_echo heading "## $action$target starting..."
   fi
 
+  # Build array of specified inheritable options
+  local child_options=()
+  local opt
+  for opt in "${_builder_options_inheritable[@]}"; do
+    if builder_has_option $opt; then
+      child_options+=($opt)
+    fi
+  done
+
   "$script" $action \
+    ${child_options[@]} \
     $builder_verbose \
     $builder_debug \
   && (
@@ -605,16 +615,21 @@ _builder_expand_action_targets() {
 #
 # There are four types of parameters that may be specified:
 #
-# * **Option:** `"--option[,-o][=var]   [One line description]"`
+# * **Option:** `"--option[,-o][+][=var]   [One line description]"`
 #
 #   All options must have a longhand form with two prefix hyphens,
 #   e.g. `--option`. The `,-o` shorthand form is optional. When testing if
 #   the option is set with `builder_has_option`, always use the longhand
 #   form.
 #
-#   if `=var` is specified, then the next parameter will be a variable stored in
+#   If `=var` is specified, then the next parameter will be a variable stored in
 #   `$var` for that option. e.g. `--option=opt` means `$opt` will have the value
 #   `"foo"` when the script is called for `--option foo`.
+#
+#   If `+` is specified, then the option will be passed to child scripts. All
+#   child scripts _must_ accept this option, or they will fail. It is acceptable
+#   for the child script to declare the option but ignore it. However, the option
+#   will _not_ be passed to dependencies.
 #
 # * **Action**: `"action   [One line description]"`
 #
@@ -656,6 +671,7 @@ builder_describe() {
   _builder_targets=()
   _builder_options=()
   _builder_deps=()                    # array of all dependencies for this script
+  _builder_options_inheritable=()     # array of all options that should be passed to child scripts
   _builder_default_action=build
   declare -A -g _builder_params
   declare -A -g _builder_options_short
@@ -714,10 +730,21 @@ builder_describe() {
         value="$(echo "$value" | cut -d= -f 1 -)"
       fi
 
+      local is_inheritable=false
+
+      if [[ $value =~ \+$ ]]; then
+        # final + indicates that option is inheritable
+        is_inheritable=true
+        value="${value:0:-1}"
+      fi
+
       if [[ $value =~ , ]]; then
         local option_long="$(echo "$value" | cut -d, -f 1 -)"
         local option_short="$(echo "$value" | cut -d, -f 2 -)"
         _builder_options+=($option_long)
+        if $is_inheritable; then
+          _builder_options_inheritable+=($option_long)
+        fi
         _builder_options_short[$option_short]="$option_long"
         if [[ ! -z "$option_var" ]]; then
           _builder_options_var[$option_long]="$option_var"
@@ -725,6 +752,9 @@ builder_describe() {
         value="$option_long, $option_short"
       else
         _builder_options+=($value)
+        if $is_inheritable; then
+          _builder_options_inheritable+=($value)
+        fi
         if [[ ! -z "$option_var" ]]; then
           _builder_options_var[$value]="$option_var"
         fi
@@ -733,6 +763,7 @@ builder_describe() {
       if [[ ! -z $option_var ]]; then
         value="$value $option_var"
       fi
+
     else
       # Parameter is an action
       if [[ $value =~ \+$ ]]; then


### PR DESCRIPTION
Appending a `+` to a builder option will automatically pass that option to child scripts.

I wanted to apply #8371 to master branch so #7407 can remain strictly Android changes. (This can replace #8371)

TODO on #7407 - add inheritable options syntax.

@keymanapp-test-bot skip

