### PR TITLE
fix(developer): improve .kmx output consistency for cross-platform 🚑

### DIFF
--- a/developer/src/common/delphi/compiler/compile.pas
+++ b/developer/src/common/delphi/compiler/compile.pas
@@ -64,7 +64,7 @@ type
 
   FILE_KEY = record
     Key: WCHAR;            // WCHAR -- actually a WORD
-    packing: WORD;
+    LineStoreIndex: WORD;
     Line: DWORD;
     ShiftFlags: DWORD;
     dpOutput: PWideChar;		// from start of key structure

--- a/developer/src/kmcmpdll/Compiler.cpp
+++ b/developer/src/kmcmpdll/Compiler.cpp
@@ -990,10 +990,23 @@ int cmpkeys(const void *key, const void *elem)
     {
       if (akey->Line < aelem->Line) return -1;
       if (akey->Line > aelem->Line) return 1;
-      return 0;
+      if(akey->Key == aelem->Key) {
+        if(akey->ShiftFlags == aelem->ShiftFlags) {
+          return akey->LineStoreIndex - aelem->LineStoreIndex;
+        }
+        return akey->ShiftFlags - aelem->ShiftFlags;
+      }
+      return akey->Key - aelem->Key;
     }
     if (l1 < l2) return 1;
     if (l1 > l2) return -1;
+    if(akey->Key == aelem->Key) {
+      if(akey->ShiftFlags == aelem->ShiftFlags) {
+        return akey->LineStoreIndex - aelem->LineStoreIndex;
+      }
+      return akey->ShiftFlags - aelem->ShiftFlags;
+    }
+    return akey->Key - aelem->Key;
   }
   return(char_key - char_elem); // akey->Key - aelem->Key);
 }
@@ -1776,6 +1789,7 @@ CheckOutputIsReadonly(const PFILE_KEYBOARD fk, const PWSTR output) {  // I4867
     wcscpy_s(kp->dpContext, wcslen(pklIn) + 1, pklIn);  // I3481
 
     kp->Line = currentLine;
+    kp->LineStoreIndex = 0;
 
     // Finished if we are not using keys
 
@@ -1917,6 +1931,7 @@ DWORD ExpandKp(PFILE_KEYBOARD fk, PFILE_KEY kpp, DWORD storeIndex)
       k->ShiftFlags = 0;
     }
     k->Line = kpp->Line;
+    k->LineStoreIndex = (WORD)n;
     ExpandKp_ReplaceIndex(fk, k, keyIndex, n);
   }
 
@@ -3363,6 +3378,7 @@ DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, HANDLE hOutfile)
     offset += gp->cxKeyArray * sizeof(COMP_KEY);
     for (j = 0; j < gp->cxKeyArray; j++, kp++, fkp++)
     {
+      kp->_reserved = 0;
       kp->Key = fkp->Key;
       if (FSaveDebug) kp->Line = fkp->Line; else kp->Line = 0;
       kp->ShiftFlags = fkp->ShiftFlags;

--- a/developer/src/kmcmpdll/compfile.h
+++ b/developer/src/kmcmpdll/compfile.h
@@ -86,6 +86,7 @@ typedef FILE_STORE *PFILE_STORE;
 
 struct FILE_KEY {
 	WCHAR   Key;            // WCHAR for consistency; only a byte used however
+	WORD    LineStoreIndex;
 	DWORD   Line;
 	DWORD   ShiftFlags;
 	PWSTR  dpOutput;		// from start of key structure

--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -99,7 +99,6 @@
 #include "UnreachableRules.h"
 #include "CheckForDuplicates.h"
 #include "kmx_u16.h"
-#include "filesystem.h"
 #include <CompMsg.h>
 
 /* These macros are adapted from winnt.h and legacy use only */

--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -984,10 +984,23 @@ int kmcmp::cmpkeys(const void *key, const void *elem)
     {
       if (akey->Line < aelem->Line) return -1;
       if (akey->Line > aelem->Line) return 1;
-      return 0;
+      if(akey->Key == aelem->Key) {
+        if(akey->ShiftFlags == aelem->ShiftFlags) {
+          return akey->LineStoreIndex - aelem->LineStoreIndex;
+        }
+        return akey->ShiftFlags - aelem->ShiftFlags;
+      }
+      return akey->Key - aelem->Key;
     }
     if (l1 < l2) return 1;
     if (l1 > l2) return -1;
+    if(akey->Key == aelem->Key) {
+      if(akey->ShiftFlags == aelem->ShiftFlags) {
+        return akey->LineStoreIndex - aelem->LineStoreIndex;
+      }
+      return akey->ShiftFlags - aelem->ShiftFlags;
+    }
+    return akey->Key - aelem->Key;
   }
   return(char_key - char_elem); // akey->Key - aelem->Key);
 }
@@ -1753,7 +1766,7 @@ KMX_DWORD ProcessKeyLineImpl(PFILE_KEYBOARD fk, PKMX_WCHAR str, KMX_BOOL IsUnico
   u16ncpy(kp->dpContext, pklIn, u16len(pklIn) + 1);  // I3481
 
   kp->Line = kmcmp::currentLine;
-    kp->Line = kmcmp::currentLine;
+  kp->LineStoreIndex = 0;
 
   // Finished if we are not using keys
 
@@ -1887,6 +1900,7 @@ KMX_DWORD ExpandKp(PFILE_KEYBOARD fk, PFILE_KEY kpp, KMX_DWORD storeIndex)
       k->ShiftFlags = 0;
     }
     k->Line = kpp->Line;
+    k->LineStoreIndex = n;
     ExpandKp_ReplaceIndex(fk, k, keyIndex, n);
   }
 
@@ -3339,6 +3353,7 @@ KMX_DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, FILE* fp_out)
     offset += gp->cxKeyArray * sizeof(COMP_KEY);
     for (j = 0; j < gp->cxKeyArray; j++, kp++, fkp++)
     {
+      kp->_reserved = 0;
       kp->Key = fkp->Key;
       if (kmcmp::FSaveDebug) kp->Line = fkp->Line; else kp->Line = 0;
       kp->ShiftFlags = fkp->ShiftFlags;

--- a/developer/src/kmcmplib/src/compfile.h
+++ b/developer/src/kmcmplib/src/compfile.h
@@ -88,6 +88,7 @@ typedef FILE_STORE * PFILE_STORE;
 
 struct FILE_KEY {
 	KMX_WCHAR   Key;            // WCHAR for consistency; only a byte used however
+	KMX_WORD    LineStoreIndex;
 	KMX_DWORD   Line;
 	KMX_DWORD   ShiftFlags;
 	PKMX_WCHAR  dpOutput;		// from start of key structure


### PR DESCRIPTION
This fixes two issues:

1. `COMP_KEY` structure had padding that was not always zeroed out. Made this explicit.

2. Rule sorting could be inconsistent when re-sorting rules that use `+ any() > ...`, which are expanded at compile time into multiple rules, and which ended up with identical sort keys due to lack of precision. This relates to #8381 but only adds differentiation for the otherwise ambiguous rule sort keys, and does not fix that issue, which requires further investigation.

@keymanapp-test-bot skip