### PR TITLE
refactor(core): consolidate wasm defs

### DIFF
--- a/core/wasm.build.linux.in
+++ b/core/wasm.build.linux.in
@@ -1,7 +1,4 @@
 [binaries]
-c = ['$EMSCRIPTEN_BASE/emcc.py', '-s', 'WASM=1', '-O2']
-cpp = ['$EMSCRIPTEN_BASE/em++.py', '-s', 'WASM=1','-O2']
+c = ['$EMSCRIPTEN_BASE/emcc.py']
+cpp = ['$EMSCRIPTEN_BASE/em++.py']
 ar = ['$EMSCRIPTEN_BASE/emar.py']
-
-[properties]
-root = '$EMSCRIPTEN_BASE/system'

--- a/core/wasm.build.mac.in
+++ b/core/wasm.build.mac.in
@@ -1,2 +1,4 @@
-[properties]
-root = '$EMSCRIPTEN_BASE/system'
+[binaries]
+c = ['$EMSCRIPTEN_BASE/emcc.py']
+cpp = ['$EMSCRIPTEN_BASE/em++.py']
+ar = ['$EMSCRIPTEN_BASE/emar.py']

--- a/core/wasm.build.win.in
+++ b/core/wasm.build.win.in
@@ -1,7 +1,6 @@
 [binaries]
-c = ['python.exe', '$EMSCRIPTEN_BASE/emcc.py', '-s', '-O2']
-cpp = ['python.exe', '$EMSCRIPTEN_BASE/em++.py', '-s', '-O2']
+c = ['python.exe', '$EMSCRIPTEN_BASE/emcc.py']
+cpp = ['python.exe', '$EMSCRIPTEN_BASE/em++.py']
 ar = ['python.exe', '$EMSCRIPTEN_BASE/emar.py']
 
 [properties]
-root = '$EMSCRIPTEN_BASE/system'

--- a/core/wasm.defs.build
+++ b/core/wasm.defs.build
@@ -1,10 +1,11 @@
 [binaries]
-c = ['emcc.py', '-s', 'WASM=1', '-O2']
-cpp = ['em++.py', '-s', 'WASM=1','-O2']
+c = ['emcc.py']
+cpp = ['em++.py']
 ar = ['emar.py']
 exe_wrapper = 'node'
 
 [properties]
+root = '$EMSCRIPTEN_BASE/system'
 shared_lib_suffix = 'js'
 static_lib_suffix = 'js'
 shared_module_suffix = 'js'


### PR DESCRIPTION
Fixes #8010.

Note that #8398 moves other settings into a shared resources folder, and once that hits master, it would be good to do another round of consolidation to share the wasm defs in resources as well.

@keymanapp-test-bot skip