### PR TITLE
chore(common): build script performance improvements

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -62,7 +62,7 @@ jobs:
       shell: bash
       run: |
         THIS_SCRIPT="$GITHUB_WORKSPACE/.github/workflows/deb-packaging.yml"
-        . "resources/build/build-utils.sh"
+        . "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Set prerelease tag as output parameter

--- a/common/predictive-text/build.sh
+++ b/common/predictive-text/build.sh
@@ -28,8 +28,8 @@ cd "$(dirname "$THIS_SCRIPT")"
 #  "@../models/wordbreakers"
 
 builder_describe "Builds the lm-layer module" \
-  "@../web/keyman-version" \
-  "@../web/lm-worker" \
+  "@/common/web/keyman-version" \
+  "@/common/web/lm-worker" \
   "clean" \
   "configure" \
   "build" \
@@ -42,8 +42,8 @@ builder_describe_outputs \
   configure           /node_modules \
   configure:headless  /node_modules \
   configure:browser   /node_modules \
-  build:headless      build/headless.js \
-  build:browser       build/index.js
+  build:headless      /common/predictive-text/build/headless.js \
+  build:browser       /common/predictive-text/build/index.js
 
 builder_parse "$@"
 

--- a/common/web/input-processor/build.sh
+++ b/common/web/input-processor/build.sh
@@ -20,9 +20,9 @@ cd "$(dirname "$THIS_SCRIPT")"
 # TODO: remove :tools once kmlmc is a dependency for test:module
 
 builder_describe "Builds the standalone, headless form of Keyman Engine for Web's input-processor module" \
-  "@../keyman-version" \
-  "@../keyboard-processor" \
-  "@../../predictive-text" \
+  "@/common/web/keyman-version" \
+  "@/common/web/keyboard-processor" \
+  "@/common/predictive-text" \
   "clean" \
   "configure" \
   "build" \
@@ -35,7 +35,7 @@ builder_describe_outputs \
   configure          /node_modules \
   configure:module   /node_modules \
   configure:tools    /node_modules \
-  build:module       build/index.js \
+  build:module       /common/web/input-processor/build/index.js \
   build:tools        /developer/src/kmc/build/src/kmlmc.js    # TODO: remove this once kmlmc is a dependency
 
 builder_parse "$@"
@@ -70,7 +70,7 @@ if builder_start_action build:tools; then
 fi
 
 if builder_start_action build:module; then
-  npm run tsc -- -b src/tsconfig.json
+  tsc -b src/tsconfig.json
   builder_finish_action success build:module
 fi
 
@@ -83,9 +83,9 @@ if builder_start_action test:module; then
   fi
 
   # Build the leaf-style, bundled version of input-processor for use in testing.
-  npm run tsc -- -b src/tsconfig.bundled.json
+  tsc -b src/tsconfig.bundled.json
 
-  npm run mocha -- --recursive $FLAGS ./tests/cases/
+  mocha --recursive $FLAGS ./tests/cases/
 
   builder_finish_action success test:module
 fi

--- a/common/web/keyboard-processor/build.sh
+++ b/common/web/keyboard-processor/build.sh
@@ -19,9 +19,9 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_describe \
   "Compiles the web-oriented utility function module." \
-  "@../recorder  test" \
-  "@../keyman-version" \
-  "@../utils" \
+  "@/common/web/recorder  test" \
+  "@/common/web/keyman-version" \
+  "@/common/web/utils" \
   configure \
   clean \
   build \
@@ -30,7 +30,7 @@ builder_describe \
 
 builder_describe_outputs \
   configure     /node_modules \
-  build         build/index.js
+  build         /common/web/keyboard-processor/build/index.js
 
 builder_parse "$@"
 
@@ -45,12 +45,12 @@ if builder_start_action clean; then
 fi
 
 if builder_start_action build; then
-  npm run tsc -- --build "$THIS_SCRIPT_PATH/src/tsconfig.json"
+  tsc --build "$THIS_SCRIPT_PATH/src/tsconfig.json"
   builder_finish_action success build
 fi
 
 if builder_start_action test; then
-  npm run tsc -- --build "$THIS_SCRIPT_PATH/src/tsconfig.bundled.json"
+  tsc --build "$THIS_SCRIPT_PATH/src/tsconfig.bundled.json"
 
   builder_heading "Running Keyboard Processor test suite"
 
@@ -60,7 +60,7 @@ if builder_start_action test; then
     FLAGS="$FLAGS --reporter mocha-teamcity-reporter"
   fi
 
-  npm run mocha -- --recursive $FLAGS ./tests/cases/
+  mocha --recursive $FLAGS ./tests/cases/
 
   builder_finish_action success test
 fi

--- a/common/web/keyman-version/build.sh
+++ b/common/web/keyman-version/build.sh
@@ -28,7 +28,7 @@ builder_describe "Build the include script for current Keyman version" \
 
 builder_describe_outputs \
   configure "/node_modules" \
-  build     "build/keyman-version.mjs"
+  build     "/common/web/keyman-version/build/keyman-version.mjs"
 
 builder_parse "$@"
 
@@ -85,7 +85,8 @@ if builder_start_action build; then
   if builder_is_dep_build; then
     builder_echo "skipping tsc -b; will be completed by $builder_dep_parent"
   else
-    npm run build -- $builder_verbose
+    echo 'Building @keymanapp/keyman-version'
+    tsc -b $builder_verbose
   fi
 
   builder_finish_action success build

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -78,12 +78,12 @@ wrap-worker-code ( ) {
 
 builder_describe \
   "Compiles the Language Modeling Layer for common use in predictive text and autocorrective applications." \
-  "@../keyman-version" \
+  "@/common/web/keyman-version" \
   configure clean build test
 
 builder_describe_outputs \
   configure     /node_modules \
-  build         build/index.js
+  build         /common/web/lm-worker/build/index.js
 
 builder_parse "$@"
 
@@ -113,7 +113,7 @@ if builder_start_action build; then
   fi
 
   # Build worker with tsc first
-  npm run build -- $builder_verbose || builder_die "Could not build worker."
+  tsb -b $builder_verbose || builder_die "Could not build worker."
 
   # Wrap the worker code and create embedded index.js. Must be run after the
   # worker is built

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -113,7 +113,7 @@ if builder_start_action build; then
   fi
 
   # Build worker with tsc first
-  tsb -b $builder_verbose || builder_die "Could not build worker."
+  tsc -b $builder_verbose || builder_die "Could not build worker."
 
   # Wrap the worker code and create embedded index.js. Must be run after the
   # worker is built

--- a/common/web/recorder/build.sh
+++ b/common/web/recorder/build.sh
@@ -19,7 +19,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 builder_describe \
   "Compiles the web-oriented utility function module." \
-  "@../keyman-version" \
+  "@/common/web/keyman-version" \
   configure \
   clean \
   build \
@@ -30,8 +30,8 @@ builder_describe_outputs \
   configure          "/node_modules" \
   configure:module   "/node_modules" \
   configure:proctor  "/node_modules" \
-  build:module    "build/index.js" \
-  build:proctor   "build/nodeProctor/index.js"
+  build:module    "/common/web/recorder/build/index.js" \
+  build:proctor   "/common/web/recorder/build/nodeProctor/index.js"
 
 builder_parse "$@"
 
@@ -41,21 +41,21 @@ if builder_start_action configure; then
 fi
 
 if builder_start_action clean:module; then
-  npm run tsc -- -b --clean "$THIS_SCRIPT_PATH/src/tsconfig.json"
+  tsc -b --clean "$THIS_SCRIPT_PATH/src/tsconfig.json"
   builder_finish_action success clean:module
 fi
 
 if builder_start_action clean:proctor; then
-  npm run tsc -- -b --clean "$THIS_SCRIPT_PATH/src/nodeProctor.tsconfig.json"
+  tsc -b --clean "$THIS_SCRIPT_PATH/src/nodeProctor.tsconfig.json"
   builder_finish_action success clean:proctor
 fi
 
 if builder_start_action build:module; then
-  npm run tsc -- --build "$THIS_SCRIPT_PATH/src/tsconfig.json"
+  tsc --build "$THIS_SCRIPT_PATH/src/tsconfig.json"
   builder_finish_action success build:module
 fi
 
 if builder_start_action build:proctor; then
-  npm run tsc -- --build "$THIS_SCRIPT_PATH/src/nodeProctor.tsconfig.json"
+  tsc --build "$THIS_SCRIPT_PATH/src/nodeProctor.tsconfig.json"
   builder_finish_action success build:proctor
 fi

--- a/common/web/sentry-manager/src/build.sh
+++ b/common/web/sentry-manager/src/build.sh
@@ -47,7 +47,7 @@ if [ $FETCH_DEPS = true ]; then
     "$KEYMAN_ROOT/common/web/keyman-version/build.sh" || builder_die "Could not build keyman-version"
 fi
 
-npm run tsc -- --build "$THIS_SCRIPT_PATH/tsconfig.json"
+tsc --build "$THIS_SCRIPT_PATH/tsconfig.json"
 if [ $? -ne 0 ]; then
     builder_die "Compilation of package for Sentry integration with KeymanWeb failed."
 fi

--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -17,7 +17,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 cd "$THIS_SCRIPT_PATH"
 
 builder_describe "Build Keyman common file types module" \
-  "@../keyman-version" \
+  "@/common/web/keyman-version" \
   "configure" \
   "build" \
   "clean" \
@@ -26,7 +26,7 @@ builder_describe "Build Keyman common file types module" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
   configure   /node_modules \
-  build       build/src/main.js
+  build       /common/web/types/build/src/main.js
 
 builder_parse "$@"
 

--- a/common/web/utils/build.sh
+++ b/common/web/utils/build.sh
@@ -18,12 +18,12 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_describe \
   "Compiles the web-oriented utility function module." \
-  "@../keyman-version" \
+  "@/common/web/keyman-version" \
   configure clean build
 
 builder_describe_outputs \
   configure "/node_modules" \
-  build     "build/index.js"
+  build     "/common/web/utils/build/index.js"
 
 builder_parse "$@"
 
@@ -42,7 +42,7 @@ if builder_start_action build; then
   if builder_is_dep_build; then
     builder_echo "skipping tsc -b; will be completed by $builder_dep_parent"
   else
-    npm run tsc -- --build "$THIS_SCRIPT_PATH/tsconfig.json"
+    tsc --build "$THIS_SCRIPT_PATH/tsconfig.json"
   fi
   builder_finish_action success build
 fi

--- a/core/build.sh
+++ b/core/build.sh
@@ -106,20 +106,20 @@ builder_describe_internal_dependency \
   build:mac build:mac-arm64
 
 builder_describe_outputs \
-  configure:x86             build/x86/$CONFIGURATION/build.ninja \
-  configure:x64             build/x64/$CONFIGURATION/build.ninja \
-  configure:mac             build/mac/$CONFIGURATION/ \
-  configure:mac-x86_64      build/mac-x86_64/$CONFIGURATION/build.ninja \
-  configure:mac-arm64       build/mac-arm64/$CONFIGURATION/build.ninja \
-  configure:arch            build/arch/$CONFIGURATION/build.ninja \
-  configure:wasm            build/wasm/$CONFIGURATION/build.ninja \
-  build:x86                 build/x86/$CONFIGURATION/src/libkmnkbp0.a \
-  build:x64                 build/x64/$CONFIGURATION/src/libkmnkbp0.a \
-  build:mac                 build/mac/$CONFIGURATION/libkmnkbp0.a \
-  build:mac-x86_64          build/mac-x86_64/$CONFIGURATION/src/libkmnkbp0.a \
-  build:mac-arm64           build/mac-arm64/$CONFIGURATION/src/libkmnkbp0.a \
-  build:arch                build/arch/$CONFIGURATION/src/libkmnkbp0.a \
-  build:wasm                build/wasm/$CONFIGURATION/src/libkmnkbp0.a
+  configure:x86             /core/build/x86/$CONFIGURATION/build.ninja \
+  configure:x64             /core/build/x64/$CONFIGURATION/build.ninja \
+  configure:mac             /core/build/mac/$CONFIGURATION/ \
+  configure:mac-x86_64      /core/build/mac-x86_64/$CONFIGURATION/build.ninja \
+  configure:mac-arm64       /core/build/mac-arm64/$CONFIGURATION/build.ninja \
+  configure:arch            /core/build/arch/$CONFIGURATION/build.ninja \
+  configure:wasm            /core/build/wasm/$CONFIGURATION/build.ninja \
+  build:x86                 /core/build/x86/$CONFIGURATION/src/libkmnkbp0.a \
+  build:x64                 /core/build/x64/$CONFIGURATION/src/libkmnkbp0.a \
+  build:mac                 /core/build/mac/$CONFIGURATION/libkmnkbp0.a \
+  build:mac-x86_64          /core/build/mac-x86_64/$CONFIGURATION/src/libkmnkbp0.a \
+  build:mac-arm64           /core/build/mac-arm64/$CONFIGURATION/src/libkmnkbp0.a \
+  build:arch                /core/build/arch/$CONFIGURATION/src/libkmnkbp0.a \
+  build:wasm                /core/build/wasm/$CONFIGURATION/src/libkmnkbp0.a
 
 # Iterate through all possible targets; note that targets that cannot be built
 # on the current platform have already been excluded through the archtargets

--- a/core/commands.inc.sh
+++ b/core/commands.inc.sh
@@ -168,7 +168,6 @@ cleanup_visual_studio_path() {
       _new_path="$_new_path:$p"
     fi
   done
-  echo
   PATH="${_new_path:1}"
   unset VSINSTALLDIR
 }

--- a/developer/src/kmc-keyboard/build.sh
+++ b/developer/src/kmc-keyboard/build.sh
@@ -28,7 +28,7 @@ builder_describe "Build Keyman kmc Keyboard Compiler module" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
   configure     /node_modules \
-  build         build/src/main.js
+  build         /developer/src/kmc-keyboard/build/src/main.js
 
 builder_parse "$@"
 

--- a/developer/src/kmc-model-info/build.sh
+++ b/developer/src/kmc-model-info/build.sh
@@ -17,7 +17,7 @@ cd "$THIS_SCRIPT_PATH"
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 
 builder_describe "Build Keyman kmc Lexical Model model-info Compiler module" \
-  "@../kmc-package" \
+  "@/developer/src/kmc-package" \
   "configure" \
   "build" \
   "clean" \
@@ -26,7 +26,7 @@ builder_describe "Build Keyman kmc Lexical Model model-info Compiler module" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
   configure     /node_modules \
-  build         build/src/model-info-compiler.js
+  build         /developer/src/kmc-model-info/build/src/model-info-compiler.js
 
 builder_parse "$@"
 

--- a/developer/src/kmc-model/build.sh
+++ b/developer/src/kmc-model/build.sh
@@ -28,7 +28,7 @@ builder_describe "Build Keyman kmc Lexical Model Compiler module" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
   configure     /node_modules \
-  build         build/src/main.js
+  build         /developer/src/kmc-model/build/src/main.js
 
 builder_parse "$@"
 

--- a/developer/src/kmc-package/build.sh
+++ b/developer/src/kmc-package/build.sh
@@ -26,7 +26,7 @@ builder_describe "Build Keyman kmc Package Compiler module" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
   configure     /node_modules \
-  build         build/src/kmp-compiler.js
+  build         /developer/src/kmc-package/build/src/kmp-compiler.js
 builder_parse "$@"
 
 #-------------------------------------------------------------------------------------------------------------------

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -19,10 +19,10 @@ cd "$THIS_SCRIPT_PATH"
 builder_describe "Build Keyman Keyboard Compiler kmc" \
   "@/common/web/keyman-version" \
   "@/common/web/types" \
-  "@../kmc-keyboard" \
-  "@../kmc-model" \
-  "@../kmc-model-info" \
-  "@../kmc-package" \
+  "@/developer/src/kmc-keyboard" \
+  "@/developer/src/kmc-model" \
+  "@/developer/src/kmc-model-info" \
+  "@/developer/src/kmc-package" \
   "configure                 runs 'npm ci' on root folder" \
   "build                     (default) builds kmc to build/" \
   "clean                     cleans build/ folder" \
@@ -33,7 +33,7 @@ builder_describe "Build Keyman Keyboard Compiler kmc" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
   configure     /node_modules \
-  build         build/src/kmc.js
+  build         /developer/src/kmc/build/src/kmc.js
 
 builder_parse "$@"
 

--- a/resources/build/build-utils-ci.test.sh
+++ b/resources/build/build-utils-ci.test.sh
@@ -8,7 +8,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
@@ -16,42 +16,42 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 # Tests
 
-echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBER not set${COLOR_RESET}"
+builder_echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBER not set${COLOR_RESET}"
 if ! builder_pull_get_details; then
-  echo "PASS: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER is not set"
+  builder_echo "PASS: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER is not set"
 else
   builder_die "FAIL: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER is not set"
 fi
 
 
-echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=master${COLOR_RESET}"
+builder_echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=master${COLOR_RESET}"
 TEAMCITY_PR_NUMBER=master
 if ! builder_pull_get_details; then
-  echo "PASS: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER=master"
+  builder_echo "PASS: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER=master"
 else
   builder_die "FAIL: builder_pull_get_details should get no details if \$TEAMCITY_PR_NUMBER=master"
 fi
 
 
-echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=$TEAMCITY_PR_NUMBER${COLOR_RESET}"
+builder_echo "${COLOR_BLUE}## Testing: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=$TEAMCITY_PR_NUMBER${COLOR_RESET}"
 TEAMCITY_PR_NUMBER=7248
 if ! builder_pull_get_details; then
   builder_die "FAIL: builder_pull_get_details was unable to read and parse PR details for #$TEAMCITY_PR_NUMBER from GitHub"
 fi
 
 # print metadata from PR
-echo "  pull number: $builder_pull_number"
-echo "  title:       $builder_pull_title"
-echo "  labels:      ${builder_pull_labels[*]}"
+builder_echo "  pull number: $builder_pull_number"
+builder_echo "  title:       $builder_pull_title"
+builder_echo "  labels:      ${builder_pull_labels[*]}"
 
-echo "PASS: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=$TEAMCITY_PR_NUMBER"
+builder_echo "PASS: builder_pull_get_details with \$TEAMCITY_PR_NUMBER=$TEAMCITY_PR_NUMBER"
 
 
-echo "${COLOR_BLUE}## Testing: builder_pull_has_label epic-ldml${COLOR_RESET}"
+builder_echo "${COLOR_BLUE}## Testing: builder_pull_has_label epic-ldml${COLOR_RESET}"
 if ! builder_pull_has_label epic-ldml; then
   builder_die "FAIL: builder_pull_has_label epic-ldml"
 fi
 
-echo "PASS: builder_pull_has_label epic-ldml"
+builder_echo "PASS: builder_pull_has_label epic-ldml"
 
-echo "All tests passed."
+builder_echo "All tests passed."

--- a/resources/build/build-utils.md
+++ b/resources/build/build-utils.md
@@ -113,6 +113,15 @@ following line here:
 cd "$THIS_SCRIPT_PATH"
 ```
 
+## Standard environment
+
+`build-utils.sh` will prepend `$KEYMAN_ROOT/node_modules/.bin` to the `PATH`
+variable to ensure that we run the correct versions of node-based commands, so
+there is no need to hard-code path references or add script wrappers to
+package.json (`npm run <script>`).
+
+Other environment variables and paths will probably be added over time.
+
 ## Split
 
 The comment line splitting the prologue from the body of the script is optional,

--- a/resources/build/build-utils.md
+++ b/resources/build/build-utils.md
@@ -116,7 +116,7 @@ cd "$THIS_SCRIPT_PATH"
 ## Standard environment
 
 `build-utils.sh` will prepend `$KEYMAN_ROOT/node_modules/.bin` to the `PATH`
-variable to ensure that we run the correct versions of node-based commands, so
+variable to ensure that we run the correct versions of npm package commands, so
 there is no need to hard-code path references or add script wrappers to
 package.json (`npm run <script>`).
 

--- a/resources/build/build-utils.md
+++ b/resources/build/build-utils.md
@@ -828,6 +828,22 @@ builder_describe "sample" \
 
 --------------------------------------------------------------------------------
 
+## `builder_trim` function
+
+Trims leading and following whitespace from the input parameters.
+
+### Usage
+
+```bash
+  my_string="$(builder_trim "$my_string")"
+```
+
+### Parameters
+
+* `my_string`    An input string
+
+--------------------------------------------------------------------------------
+
 ## `builder_use_color` function
 
 This will normally be managed internally by build-utils, but can be manually

--- a/resources/build/build-utils.md
+++ b/resources/build/build-utils.md
@@ -86,9 +86,14 @@ This somewhat unwieldy incantation handles all our build environments.
 The intent is to get a good solid consistent path for the script so that we can
 safely include the build script, no matter what `pwd` is when the script is run.
 
+
 The only modification permissible in this block is the
 `<relative-path-to-repo-root>` text which will be a series of `../` paths taking
 us to the repository root from the location of the script itself.
+
+It is essential to make the include relative to the repo root, even for scripts
+under the resources/ folder.  Doing this gives us significant performance
+benefits.
 
 Inclusion of other scripts should be kept outside this standard build script
 include section, as we may programatically update (a.ka. global

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -45,7 +45,7 @@ function findKeymanRoot() {
 
 function findVersion() {
     local VERSION_MD="$KEYMAN_ROOT/VERSION.md"
-    VERSION=$(trim $(<"$VERSION_MD"))
+    VERSION=$(builder_trim $(<"$VERSION_MD"))
     [[ "$VERSION" =~ ^([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)$ ]] && {
         VERSION_MAJOR="${BASH_REMATCH[1]}"
         VERSION_MINOR="${BASH_REMATCH[2]}"
@@ -118,18 +118,9 @@ function findVersion() {
     export VERSION_GIT_TAG
 }
 
-function trim() {
-  local var="$*"
-  # remove leading whitespace characters
-  var="${var#"${var%%[![:space:]]*}"}"
-  # remove trailing whitespace characters
-  var="${var%"${var##*[![:space:]]}"}"
-  printf '%s' "$var"
-}
-
 function findTier() {
   local TIER_MD="$KEYMAN_ROOT/TIER.md"
-  TIER=$(trim $(<"$TIER_MD"))
+  TIER=$(builder_trim $(<"$TIER_MD"))
   [[ "$TIER" =~ ^(alpha|beta|stable)$ ]] || {
       echo "Invalid TIER.md file: expected alpha, beta or stable."
       exit 1;
@@ -180,11 +171,13 @@ function findShouldSentryRelease() {
 }
 
 findKeymanRoot
-findTier
-findVersion
 
 # Source builder_script
 . "$KEYMAN_ROOT/resources/builder.inc.sh"
+
+findTier
+findVersion
+
 # printVersionUtilsDebug
 printBuildNumberForTeamCity
 

--- a/resources/build/help-keyman-com.sh
+++ b/resources/build/help-keyman-com.sh
@@ -11,7 +11,7 @@ set -u
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 #

--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -19,7 +19,7 @@ set -u
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "${THIS_SCRIPT%/*}/trigger-definitions.inc.sh"

--- a/resources/build/report-history.sh
+++ b/resources/build/report-history.sh
@@ -9,7 +9,7 @@ set -u
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"

--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -31,7 +31,7 @@ function debug_echo() {
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "${THIS_SCRIPT%/*}/trigger-definitions.inc.sh"

--- a/resources/build/tests/build-utils-traps.test.sh
+++ b/resources/build/tests/build-utils-traps.test.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"

--- a/resources/build/tests/builder-deps.test.sh
+++ b/resources/build/tests/builder-deps.test.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"

--- a/resources/build/tests/builder.inc.test.sh
+++ b/resources/build/tests/builder.inc.test.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
@@ -87,7 +87,7 @@ builder_parse_test() {
   shift
   shift
   local parameters="$@"
-  echo "${COLOR_BLUE}## Testing: builder_parse $parameters${COLOR_RESET}"
+  echo -e "${COLOR_BLUE}## Testing: builder_parse $parameters${COLOR_RESET}"
   builder_parse $parameters || builder_die "builder_parse died under curious circumstances"
   if [[ "$expected" != "${_builder_chosen_action_targets[@]}" ]]; then
     builder_die "  Test: builder_parse $parameters action:target != \"$expected\""
@@ -128,7 +128,7 @@ fi
 
 # Test --feature <foo>
 
-echo "${COLOR_BLUE}## Testing: builder_parse --feature xyzzy${COLOR_RESET}"
+echo -e "${COLOR_BLUE}## Testing: builder_parse --feature xyzzy${COLOR_RESET}"
 builder_parse --feature xyzzy
 
 if builder_has_option --feature; then
@@ -156,24 +156,24 @@ fi
 
 # Due to the nature of the build-utils-traps tests, only one may be
 # specified at a time; each ends with an `exit`.
-echo "${COLOR_BLUE}## Running trap tests${COLOR_RESET}"
+echo -e "${COLOR_BLUE}## Running trap tests${COLOR_RESET}"
 $THIS_SCRIPT_PATH/build-utils-traps.test.sh error
 $THIS_SCRIPT_PATH/build-utils-traps.test.sh error-in-function
 $THIS_SCRIPT_PATH/build-utils-traps.test.sh incomplete
-echo "${COLOR_BLUE}## Running dependency tests${COLOR_RESET}"
+echo -e "${COLOR_BLUE}## Running dependency tests${COLOR_RESET}"
 $THIS_SCRIPT_PATH/builder-deps.test.sh
 $THIS_SCRIPT_PATH/dependencies/test.sh
 
-echo "${COLOR_BLUE}## End external tests${COLOR_RESET}"
+echo -e "${COLOR_BLUE}## End external tests${COLOR_RESET}"
 echo
 
 (
   # Finally, run with --help so we can see what it looks like; note:
   # builder_parse calls `exit 0` on a --help run, so running in a subshell
-  echo "${COLOR_BLUE}## Testing --help${COLOR_RESET}"
+  echo -e "${COLOR_BLUE}## Testing --help${COLOR_RESET}"
   builder_parse --no-color --help
 ) || builder_die "FAIL: builder-parse returned failure code $? unexpectedly"
 
-echo "${COLOR_GREEN}======================================================${COLOR_RESET}"
-echo "${COLOR_GREEN}All tests passed successfully${COLOR_RESET}"
-echo "${COLOR_GREEN}======================================================${COLOR_RESET}"
+echo -e "${COLOR_GREEN}======================================================${COLOR_RESET}"
+echo -e "${COLOR_GREEN}All tests passed successfully${COLOR_RESET}"
+echo -e "${COLOR_GREEN}======================================================${COLOR_RESET}"

--- a/resources/build/tests/dependencies/basic/app/build.sh
+++ b/resources/build/tests/dependencies/basic/app/build.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/dependencies/basic/library/build.sh
+++ b/resources/build/tests/dependencies/basic/library/build.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/dependencies/error/app/build.sh
+++ b/resources/build/tests/dependencies/error/app/build.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/dependencies/error/error/build.sh
+++ b/resources/build/tests/dependencies/error/error/build.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/dependencies/targets/app/build.sh
+++ b/resources/build/tests/dependencies/targets/app/build.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/dependencies/targets/library/build.sh
+++ b/resources/build/tests/dependencies/targets/library/build.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/dependencies/test.sh
+++ b/resources/build/tests/dependencies/test.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/trap-test-builds.sh
+++ b/resources/build/tests/trap-test-builds.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 builder_describe \

--- a/resources/build/tests/trees/build.sh
+++ b/resources/build/tests/trees/build.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/trees/child1/build.sh
+++ b/resources/build/tests/trees/child1/build.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/trees/child2/build.sh
+++ b/resources/build/tests/trees/child2/build.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/trees/child3_renamed/src/build.sh
+++ b/resources/build/tests/trees/child3_renamed/src/build.sh
@@ -5,7 +5,7 @@ set -eu
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../../../build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../../../resources/build/build-utils.sh"
 # END STANDARD BUILD SCRIPT INCLUDE
 
 cd "$THIS_SCRIPT_PATH"

--- a/resources/build/tests/verify-colors.test.sh
+++ b/resources/build/tests/verify-colors.test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../resources/build/build-utils.sh"
+# END STANDARD BUILD SCRIPT INCLUDE
+
+builder_use_color true
+builder_echo "${COLOR_RED}COLOR_RED${COLOR_RESET}"
+builder_echo "${COLOR_GREEN}COLOR_GREEN${COLOR_RESET}"
+builder_echo "${COLOR_YELLOW}COLOR_YELLOW${COLOR_RESET}"
+builder_echo "${COLOR_BLUE}COLOR_BLUE${COLOR_RESET}"
+builder_echo "${COLOR_PURPLE}COLOR_PURPLE${COLOR_RESET}"
+builder_echo "${COLOR_TEAL}COLOR_TEAL${COLOR_RESET}"
+builder_echo "${COLOR_WHITE}COLOR_WHITE${COLOR_RESET}"
+builder_echo "${COLOR_BRIGHT_WHITE}COLOR_BRIGHT_WHITE${COLOR_RESET}"
+builder_echo "${COLOR_GREY}COLOR_GREY${COLOR_RESET}"
+builder_echo "${COLOR_RESET}COLOR_RESET${COLOR_RESET}"
+builder_echo "${BUILDER_BOLD}BUILDER_BOLD${COLOR_RESET}"
+builder_echo "${HEADING_SETMARK}HEADING_SETMARK${COLOR_RESET}"

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -579,7 +579,20 @@ builder_has_option() {
   return 1
 }
 
-_builder_trim() {
+#
+# Trims leading and following whitespace from the input parameters
+#
+# ### Usage
+#
+# ```bash
+#   my_string="$(builder_trim "$my_string")"
+# ```
+#
+# ### Parameters
+#
+# * `my_string`    An input string
+#
+builder_trim() {
   local var="$*"
   # remove leading whitespace characters
   var="${var#"${var%%[![:space:]]*}"}"
@@ -744,7 +757,7 @@ builder_describe() {
     if [[ $key =~ [[:space:]] ]]; then
       IFS=" " read -r -a sub <<< "$key"
       value="${sub[0]}"
-      description="$(_builder_trim "${sub[@]:1}")"
+      description="$(builder_trim "${sub[@]:1}")"
     fi
 
     if [[ $value =~ ^: ]]; then

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -889,11 +889,11 @@ function builder_describe_outputs() {
   _builder_record_function_call builder_describe_outputs
 
   while [[ $# -gt 0 ]]; do
-    local key="$1" path="$2" action target
+    local key="$1" path="$2" action= target=
     path="`_builder_expand_relative_path "$path"`"
 
     if [[ $key =~ : ]]; then
-      IFS=":" read -r -a action target <<< "$key"
+      IFS=":" read -r action target <<< "$key"
       target=":$target"
     else
       # Add dependency expected output file for all targets, as well as a

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -27,11 +27,9 @@ function _builder_init() {
 }
 
 function _builder_findRepoRoot() {
-    # See https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself
-    # None of the answers are 100% correct for cross-platform
-    # On macOS, requires coreutils (`brew install coreutils`)
-    local SCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
-    REPO_ROOT="${SCRIPT%/*/*}"
+    # We don't need readlink here because our standard script prolog does a
+    # readlink -f already so we will have already escaped from any symlinks
+    REPO_ROOT="${BASH_SOURCE[0]%/*/*}"
     readonly REPO_ROOT
 }
 
@@ -77,20 +75,20 @@ function _builder_setBuildScriptIdentifiers() {
 #  1: use_color       true or false
 builder_use_color() {
   if $1; then
-    COLOR_RED=$(tput setaf 1)
-    COLOR_GREEN=$(tput setaf 2)
-    COLOR_YELLOW=$(tput setaf 3)
-    COLOR_BLUE=$(tput setaf 4)
-    COLOR_PURPLE=$(tput setaf 5)
-    COLOR_TEAL=$(tput setaf 6)
-    COLOR_WHITE=$(tput setaf 252)
-    COLOR_BRIGHT_WHITE=$(tput setaf 255)
-    COLOR_GREY=$(tput setaf 8)
-    COLOR_RESET=$(tput sgr0)
+    # Using esc codes instead of tput for performance
+    COLOR_RED='\x1b[31m'                # $(tput setaf 1)
+    COLOR_GREEN='\x1b[32m'              # $(tput setaf 2)
+    COLOR_YELLOW='\x1b[33m'             # $(tput setaf 3)
+    COLOR_BLUE='\x1b[34m'               # $(tput setaf 4)
+    COLOR_PURPLE='\x1b[35m'             # $(tput setaf 5)
+    COLOR_TEAL='\x1b[36m'               # $(tput setaf 6)
+    COLOR_WHITE='\x1b[38;5;252m'        # $(tput setaf 252)
+    COLOR_BRIGHT_WHITE='\x1b[38;5;255m' # $(tput setaf 255)
+    COLOR_GREY='\x1b[90m'               # $(tput setaf 8)
+    COLOR_RESET='\x1b(B\x1b[m'          # $(tput sgr0)
     # e.g. VSCode https://code.visualstudio.com/updates/v1_69#_setmark-sequence-support
-    BUILDER_BOLD=$(tput bold)
+    BUILDER_BOLD='\x1b[1m'              # $(tput bold)
     HEADING_SETMARK='\x1b]1337;SetMark\x07'
-
     # Used by `builder_display_usage` when marking special terms (actions, targets, options)
     # in the plain-text description area.
     BUILDER_TERM_START="$COLOR_BLUE"
@@ -619,8 +617,8 @@ _builder_expand_relative_path() {
 _builder_expand_action_target() {
   local input="$1" target= action=
   if [[ "$input" =~ : ]]; then
-    action=$(echo "$input" | cut -d: -f 1 -)
-    target=$(echo "$input" | cut -d: -f 2 -)
+    IFS=":" read -r action target <<< "$value"
+    target=":$target"
   else
     action=$input
   fi
@@ -738,13 +736,16 @@ builder_describe() {
   declare -A -g _builder_target_paths         # array of target child project paths
   declare -A -g _builder_dep_targets          # array of :targets given for a specific dependency (comma separated if more than one)
   shift
+  local sub=()
   # describe each target, action, and option possibility
   while [[ $# -gt 0 ]]; do
     local key="$1"
-    local value="$(echo "$key" | cut -d" " -f 1 -)"
+    local value="$key"
     local description=
     if [[ $key =~ [[:space:]] ]]; then
-      description="$(_builder_trim "$(echo "$key" | cut -d" " -f 2- -)")"
+      IFS=" " read -r -a sub <<< "$key"
+      value="${sub[0]}"
+      description="$(_builder_trim "${sub[@]:1}")"
     fi
 
     if [[ $value =~ ^: ]]; then
@@ -752,8 +753,9 @@ builder_describe() {
       local target_path=
       if [[ $value =~ = ]]; then
         # The target has a custom child project path
-        target_path="$(echo "$value" | cut -d= -f 2 -)"
-        value="$(echo "$value" | cut -d= -f 1 -)"
+        IFS="=" read -r -a sub <<< "$value"
+        target_path="${sub[@]:1}"
+        value="${sub[0]}"
         if [[ ! -d "$THIS_SCRIPT_PATH/$target_path" ]]; then
           builder_die "Target path '$target_path' for $value does not exist."
         fi
@@ -773,8 +775,9 @@ builder_describe() {
       local dependency="${value:1}"
       local dependency_target= # all targets
       if [[ $dependency =~ : ]]; then
-        dependency_target=":$(echo "$dependency" | cut -d: -f 2 -)"
-        dependency="$(echo "$dependency" | cut -d: -f 1 -)"
+        IFS=":" read -r -a sub <<< "$dependency"
+        dependency_target=":${sub[@]:1}"
+        dependency="${sub[0]}"
       fi
 
       dependency="`_builder_expand_relative_path "$dependency"`"
@@ -789,8 +792,9 @@ builder_describe() {
       # Look for a shorthand version of the option
       local option_var=
       if [[ $value =~ = ]]; then
-        option_var="$(echo "$value" | cut -d= -f 2 -)"
-        value="$(echo "$value" | cut -d= -f 1 -)"
+        IFS="=" read -r -a sub <<< "$value"
+        option_var="${sub[@]:1}"
+        value="${sub[0]}"
       fi
 
       local is_inheritable=false
@@ -802,8 +806,9 @@ builder_describe() {
       fi
 
       if [[ $value =~ , ]]; then
-        local option_long="$(echo "$value" | cut -d, -f 1 -)"
-        local option_short="$(echo "$value" | cut -d, -f 2 -)"
+        IFS="," read -r -a sub <<< "$value"
+        local option_long="${sub[0]}"
+        local option_short="${sub[@]:1}"
         _builder_options+=($option_long)
         if $is_inheritable; then
           _builder_options_inheritable+=($option_long)
@@ -888,8 +893,8 @@ function builder_describe_outputs() {
     path="`_builder_expand_relative_path "$path"`"
 
     if [[ $key =~ : ]]; then
-      action="$(echo "$key" | cut -d: -f 1 -)"
-      target=":$(echo "$key" | cut -d: -f 2 -)"
+      IFS=":" read -r -a action target <<< "$key"
+      target=":$target"
     else
       # Add dependency expected output file for all targets, as well as a
       # wildcard target match

--- a/resources/devbox/iis-https/setup-iis-https.sh
+++ b/resources/devbox/iis-https/setup-iis-https.sh
@@ -6,7 +6,7 @@ set -u
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../build/build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"

--- a/resources/standards-data/ldml-keyboards/techpreview/fetch-latest-cldr-techpreview.sh
+++ b/resources/standards-data/ldml-keyboards/techpreview/fetch-latest-cldr-techpreview.sh
@@ -16,7 +16,7 @@ fi
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../../build/build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../../../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/jq.inc.sh"

--- a/resources/stats/stats.sh
+++ b/resources/stats/stats.sh
@@ -6,7 +6,7 @@ set -u
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../build/build-utils.sh"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"

--- a/web/build.sh
+++ b/web/build.sh
@@ -3,7 +3,6 @@
 # Compiles the Keyman Engine for Web and its various end-products
 #
 
-# set -x
 set -eu
 
 ## START STANDARD BUILD SCRIPT INCLUDE
@@ -23,15 +22,16 @@ cd "$THIS_SCRIPT_PATH"
 
 # Ensures that we rely first upon the local npm-based install of Typescript.
 # (Facilitates automated setup for build agents.)
+# TODO: this should be removeable given set_keyman_standard_build_path does this in build-utils.sh (and relative paths are dodgy in $PATH!)
 PATH="../node_modules/.bin:$PATH"
 
 PREDICTIVE_TEXT_SOURCE="../common/predictive-text/unit_tests/in_browser/resources/models/simple-trie.js"
 PREDICTIVE_TEXT_OUTPUT="src/test/manual/web/prediction-ui/simple-en-trie.js"
 
 builder_describe "Builds Keyman Engine for Web (KMW)." \
-  "@../common/web/keyman-version build" \
-  "@../common/web/input-processor build" \
-  "@src/tools/building/sourcemap-root build" \
+  "@/common/web/keyman-version build" \
+  "@/common/web/input-processor build" \
+  "@/web/src/tools/building/sourcemap-root build" \
   "clean" \
   "configure" \
   "build" \
@@ -49,19 +49,19 @@ builder_describe "Builds Keyman Engine for Web (KMW)." \
 # "upload-symbols   Uploads build product to Sentry for error report symbolification.  Only defined for $(builder_term build:embed) and $(builder_term build:web)" \
 
 builder_describe_outputs \
-  configure         ../node_modules \
-  configure:embed   ../node_modules \
-  configure:engine  ../node_modules \
-  configure:web     ../node_modules \
-  configure:ui      ../node_modules \
-  configure:samples ../node_modules \
-  configure:tools   ../node_modules \
-  build:embed       build/app/embed/release/keyman.js \
-  build:engine      build/engine/main/obj/keymanweb.js \
-  build:web         build/app/web/release/keymanweb.js \
-  build:ui          build/app/ui/release/kmwuibutton.js \
-  build:samples     $PREDICTIVE_TEXT_OUTPUT \
-  build:tools       build/tools/building/sourcemap-root/index.js
+  configure         /node_modules \
+  configure:embed   /node_modules \
+  configure:engine  /node_modules \
+  configure:web     /node_modules \
+  configure:ui      /node_modules \
+  configure:samples /node_modules \
+  configure:tools   /node_modules \
+  build:embed       /web/build/app/embed/release/keyman.js \
+  build:engine      /web/build/engine/main/obj/keymanweb.js \
+  build:web         /web/build/app/web/release/keymanweb.js \
+  build:ui          /web/build/app/ui/release/kmwuibutton.js \
+  build:samples     /web/$PREDICTIVE_TEXT_OUTPUT \
+  build:tools       /web/build/tools/building/sourcemap-root/index.js
 
 builder_parse "$@"
 
@@ -293,7 +293,7 @@ copy_outputs ( ) {
 # ```
 compile ( ) {
   local COMPILE_TARGET=$1
-  npm run tsc -- -b src/$COMPILE_TARGET -v || builder_die "Build command tsc -- -b src/$COMPILE_TARGET -v failed with exit code $?"
+  tsc -b src/$COMPILE_TARGET -v || builder_die "Build command tsc -b src/$COMPILE_TARGET -v failed with exit code $?"
   echo $COMPILE_TARGET TypeScript compiled under build/$COMPILE_TARGET/obj
 }
 

--- a/web/src/engine/build.sh
+++ b/web/src/engine/build.sh
@@ -72,18 +72,22 @@ output_path ( ) {
   fi
 }
 
+# TODO: eliminate $SOURCE variable
 SOURCE="src"
 
 # Ensures that we rely first upon the local npm-based install of Typescript.
 # (Facilitates automated setup for build agents.)
+# TODO: this should be removeable given set_keyman_standard_build_path does this in build-utils.sh (and relative paths are dodgy in $PATH!)
 PATH="../../../node_modules/.bin:$PATH"
 
+# TODO: call tsc directly -- but currently it runs from wrong folder if called directly
+# TODO: eliminate $compiler and $compilecmd variables
 compiler="npm run tsc --"
 compilecmd="$compiler"
 
 builder_describe "Builds engine modules for Keyman Engine for Web (KMW)." \
-  "@../../../common/web/keyman-version build:main" \
-  "@../../../common/web/input-processor build:main" \
+  "@/common/web/keyman-version build:main" \
+  "@/common/web/input-processor build:main" \
   "clean" \
   "configure" \
   "build" \
@@ -95,13 +99,14 @@ builder_describe "Builds engine modules for Keyman Engine for Web (KMW)." \
 # "upload-symbols   Uploads build product to Sentry for error report symbolification.  Only defined for $DOC_BUILD_EMBED_WEB" \
 
 builder_describe_outputs \
-  configure                  ../../../node_modules \
-  configure:device-detect    ../../../node_modules \
-  configure:element-wrappers ../../../node_modules \
-  configure:main             ../../../node_modules \
+  configure                  /node_modules \
+  configure:device-detect    /node_modules \
+  configure:element-wrappers /node_modules \
+  configure:main             /node_modules \
   build:device-detect        $(output_path $DEVICEDETECT $OUTPUT_DIR)/index.js \
   build:element-wrappers     $(output_path $ELEMENTWRAPPERS $OUTPUT_DIR)/index.js \
   build:main                 $(output_path $MAIN $OUTPUT_DIR)/keymanweb.js
+# TODO: eliminate outpath_path function and related variables and just use the plain filenames
 
 builder_parse "$@"
 

--- a/web/src/tools/build.sh
+++ b/web/src/tools/build.sh
@@ -18,8 +18,8 @@ cd "$THIS_SCRIPT_PATH"
 ################################ Main script ################################
 
 builder_describe "Builds the Keyman Engine for Web's development & unit-testing tools" \
-  "@../../../common/web/keyman-version" \
-  "@../../../common/web/keyboard-processor" \
+  "@/common/web/keyman-version" \
+  "@/common/web/keyboard-processor" \
   "clean" \
   "build" \
   ":bulk_rendering     Builds the bulk-rendering tool used to validate changes to OSK display code" \

--- a/web/src/tools/building/sourcemap-root/build.sh
+++ b/web/src/tools/building/sourcemap-root/build.sh
@@ -18,14 +18,14 @@ cd "$THIS_SCRIPT_PATH"
 ################################ Main script ################################
 
 builder_describe "Builds the sourcemap-sanitizing script used for Keyman Engine for Web builds" \
-  "@../../../../../common/tools/sourcemap-path-remapper" \
+  "@/common/tools/sourcemap-path-remapper" \
   "clean" \
   "configure" \
   "build" \
 
 builder_describe_outputs \
   configure                   /node_modules \
-  build                       ../../../../build/tools/sourcemap-root/index.js
+  build                       /web/build/tools/sourcemap-root/index.js
 
 builder_parse "$@"
 
@@ -42,7 +42,7 @@ if builder_start_action clean; then
 fi
 
 if builder_start_action build; then
-  npm run tsc -- -b "$THIS_SCRIPT_PATH/tsconfig.json"
+  tsc -b "$THIS_SCRIPT_PATH/tsconfig.json"
 
   # Necessary until the Web project is converted over to ES modules.
   # Node defaults to CommonJS format otherwise.

--- a/web/src/tools/testing/bulk_rendering/build.sh
+++ b/web/src/tools/testing/bulk_rendering/build.sh
@@ -27,7 +27,7 @@ builder_describe \
 
 builder_describe_outputs \
   configure  /node_modules \
-  build      ../../../../build/tools/testing/bulk_rendering/bulk_render.js
+  build      /web/build/tools/testing/bulk_rendering/bulk_render.js
 
 builder_parse "$@"
 

--- a/web/src/tools/testing/recorder/build.sh
+++ b/web/src/tools/testing/recorder/build.sh
@@ -18,16 +18,16 @@ cd "$THIS_SCRIPT_PATH"
 ################################ Main script ################################
 
 builder_describe "Builds the Keyman Engine for Web's test-sequence recording tool" \
-  "@../../../../../common/web/keyman-version" \
-  "@../../../../../common/web/keyboard-processor" \
-  "@../../../../../common/web/recorder" \
+  "@/common/web/keyman-version" \
+  "@/common/web/keyboard-processor" \
+  "@/common/web/recorder" \
   "clean" \
   "configure" \
   "build"
 
 builder_describe_outputs \
   configure  /node_modules \
-  build      ../../../../build/tools/testing/recorder/index.js
+  build      /web/build/tools/testing/recorder/index.js
 
 builder_parse "$@"
 
@@ -48,7 +48,7 @@ fi
 ### BUILD ACTIONS
 
 if builder_start_action build; then
-  npm run tsc -- -b $THIS_SCRIPT_PATH/tsconfig.json
+  tsc -b $THIS_SCRIPT_PATH/tsconfig.json
 
   builder_finish_action success build
 fi


### PR DESCRIPTION
Improves build script performance by:
* using built-ins wherever possible (e.g. string splitting)
* eliminating redundant code
* using absolute (to $KEYMAN_ROOT) rather than relative paths to avoid realpath
* removing unnecessary `npm run` calls

## Example statistics

```
BEFORE                         | AFTER
-------------------------------|----------------------
time ./core/build.sh --help    
real    0m2.116s               | real    0m0.874s
user    0m0.578s               | user    0m0.198s
sys     0m0.984s               | sys     0m0.289s

time ./web/build.sh --help     
real    0m3.523s               | real    0m0.757s
user    0m1.166s               | user    0m0.320s
sys     0m2.273s               | sys     0m0.455s

time ./web/build.sh -d         
real    1m34.750s              | real    0m59.974s
user    0m9.721s               | user    0m6.284s
sys     0m19.652s              | sys     0m13.202s
```

@keymanapp-test-bot skip