### PR TITLE
fix(android): Ensure Sentry doesn't send email info

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -35,6 +35,7 @@ import android.widget.FrameLayout;
 
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.Sentry;
+import io.sentry.protocol.User;
 
 public class SystemKeyboard extends InputMethodService implements OnKeyboardEventListener {
 
@@ -55,6 +56,14 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     if (DependencyUtil.libraryExists(LibraryType.SENTRY) && !Sentry.isEnabled()) {
       Log.d(TAG, "Initializing Sentry");
       SentryAndroid.init(getApplicationContext(), options -> {
+        options.setSendDefaultPii(false);
+        options.setBeforeSend((event, hint) -> {
+          // Delete user email
+          User user = event.getUser();
+          user.setEmail(null);
+          event.setUser(user);
+          return event;
+        });
         options.setRelease(com.tavultesoft.kmapro.BuildConfig.VERSION_GIT_TAG);
         options.setEnvironment(com.tavultesoft.kmapro.BuildConfig.VERSION_ENVIRONMENT);
       });

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -94,6 +94,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import io.sentry.android.core.SentryAndroid;
+import io.sentry.protocol.User;
 
 public class MainActivity extends BaseActivity implements OnKeyboardEventListener, OnKeyboardDownloadEventListener,
     ActivityCompat.OnRequestPermissionsResultCallback {
@@ -131,6 +132,14 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     checkSendCrashReport();
     if (KMManager.getMaySendCrashReport()) {
       SentryAndroid.init(context, options -> {
+        options.setSendDefaultPii(false);
+        options.setBeforeSend((event, hint) -> {
+          // Delete user email
+          User user = event.getUser();
+          user.setEmail(null);
+          event.setUser(user);
+          return event;
+        });
         options.setRelease(com.tavultesoft.kmapro.BuildConfig.VERSION_GIT_TAG);
         options.setEnvironment(com.tavultesoft.kmapro.BuildConfig.VERSION_ENVIRONMENT);
       });

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -16,6 +16,7 @@ import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 
 import io.sentry.android.core.SentryAndroid;
+import io.sentry.protocol.User;
 
 import com.keyman.engine.*;
 import com.keyman.engine.data.Keyboard;
@@ -40,6 +41,14 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardDownloa
         context = this;
 
         SentryAndroid.init(context, options -> {
+            options.setSendDefaultPii(false);
+            options.setBeforeSend((event, hint) -> {
+              // Delete user email
+              User user = event.getUser();
+              user.setEmail(null);
+              event.setUser(user);
+              return event;
+            });
             options.setRelease(com.firstvoices.keyboards.BuildConfig.VERSION_GIT_TAG);
             options.setEnvironment(com.firstvoices.keyboards.BuildConfig.VERSION_ENVIRONMENT);
         });

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -30,6 +30,7 @@ import com.keyman.engine.util.DependencyUtil;
 import com.keyman.engine.util.DependencyUtil.LibraryType;
 
 import io.sentry.android.core.SentryAndroid;
+import io.sentry.protocol.User;
 import io.sentry.Sentry;
 
 public class SystemKeyboard extends InputMethodService implements OnKeyboardEventListener {
@@ -49,6 +50,14 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
         if (DependencyUtil.libraryExists(LibraryType.SENTRY) && !Sentry.isEnabled()) {
             Log.d(TAG, "Initializing Sentry");
             SentryAndroid.init(getApplicationContext(), options -> {
+                options.setSendDefaultPii(false);
+                options.setBeforeSend((event, hint) -> {
+                  // Delete user email
+                  User user = event.getUser();
+                  user.setEmail(null);
+                  event.setUser(user);
+                  return event;
+                });
                 options.setRelease(com.firstvoices.keyboards.BuildConfig.VERSION_GIT_TAG);
                 options.setEnvironment(com.firstvoices.keyboards.BuildConfig.VERSION_ENVIRONMENT);
             });


### PR DESCRIPTION
This PR ensures Sentry doesn't send email info to comply with data access policy.
* [Default PII](https://docs.sentry.io/platforms/java/guides/spring/data-management/sensitive-data/#personally-identifiable-information-pii) isn't sent
* User email info is scrubbed [before sending event](https://docs.sentry.io/platforms/java/configuration/filtering/#using-platformidentifier-namebefore-send-)

Will 🍒 pick to stable-16.0

## User Testing
Setup - Install the PR build of the corresponding Android apps. We don't see user.email in our Sentry logs. So just confirm apps still function

* **TEST_KEYMAN** - Verifies Keyman app functions
1. Install the PR build of Keyman for Android
2. Launch Keyman
3. From "Get Started", set and enable Keyman as default System keyboard
4. From the Keyman app, type on the keyboard
5. Verify keyboard functions fine
6. Launch a separate app (e.g. Google Chrome) and click in a text area
7. Bring up Keyman as system keybard
8. Type with the Keyman keyboard
9. Verify keyboard functions fine

* **TEST_FIRSTVOICES** - Verifies FirstVoices for Android
1. Install the PR build of FV for Android
2. Launch FirstVoices app
3. Follow the setup instructions to add a keyboard and set as default system keyboard
4. Launch a separate app (e.g. Google Chrome) and click in a text area
5. Bring up FirstVoices keyboard (make sure different from Keyman keyboard)
6. Type with the FV keyboard
7. Verify keyboard functions fine.