### PR TITLE
chore(common): TS updates to non-sync'd packages, feature-esmodule merge conflict prevention

### DIFF
--- a/common/web/keyman-version/package.json
+++ b/common/web/keyman-version/package.json
@@ -3,8 +3,10 @@
   "description": "Keyman global version data",
   "main": "./build/index.js",
   "exports": {
-    ".": "./build/index.js",
-    "./keyman-version.mjs": "./build/keyman-version.mjs"
+    ".": {
+      "import": "./build/keyman-version.mjs",
+      "require": "./build/index.js"
+    }
   },
   "scripts": {
     "build": "echo 'Building @keymanapp/keyman-version' && tsc -b",

--- a/common/web/types/package.json
+++ b/common/web/types/package.json
@@ -42,7 +42,7 @@
     "hexy": "^0.3.4",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "4.6.3"
+    "typescript": "^4.9.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file-reader.ts
+++ b/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file-reader.ts
@@ -1,4 +1,5 @@
-import Ajv from "ajv";
+import { default as AjvModule } from 'ajv';
+const Ajv = AjvModule.default; // The actual expected Ajv type.
 import { TouchLayoutFile } from "./keyman-touch-layout-file.js";
 
 export class TouchLayoutFileReader {

--- a/common/web/types/src/kpj/kpj-file-reader.ts
+++ b/common/web/types/src/kpj/kpj-file-reader.ts
@@ -1,6 +1,7 @@
 import * as xml2js from 'xml2js';
 import { KPJFile, KPJFileProject } from './kpj-file.js';
-import Ajv from 'ajv';
+import { default as AjvModule } from 'ajv';
+const Ajv = AjvModule.default; // The actual expected Ajv type.
 import { boxXmlArray } from '../util/util.js';
 import { KeymanDeveloperProject, KeymanDeveloperProjectFile10, KeymanDeveloperProjectType } from './keyman-developer-project.js';
 

--- a/common/web/types/src/kvk/kvks-file-reader.ts
+++ b/common/web/types/src/kvk/kvks-file-reader.ts
@@ -1,6 +1,7 @@
 import * as xml2js from 'xml2js';
 import KVKSourceFile from './kvks-file.js';
-import Ajv from 'ajv';
+import { default as AjvModule } from 'ajv';
+const Ajv = AjvModule.default; // The actual expected Ajv type.
 import { boxXmlArray } from '../util/util.js';
 import { VisualKeyboard, VisualKeyboardHeaderFlags, VisualKeyboardKey, VisualKeyboardKeyFlags, VisualKeyboardLegalShiftStates, VisualKeyboardShiftState } from './visual-keyboard.js';
 import { USVirtualKeyCodes } from '../consts/virtual-key-constants.js';

--- a/common/web/types/src/kvk/visual-keyboard.ts
+++ b/common/web/types/src/kvk/visual-keyboard.ts
@@ -4,14 +4,14 @@
 // Corresponds to .kvk / .kvks file data
 //
 
-import { BUILDER_KVK_SHIFT_STATE, BUILDER_KVK_HEADER_FLAGS, BUILDER_KVK_KEY_FLAGS } from "./kvk-file";
+import { BUILDER_KVK_SHIFT_STATE, BUILDER_KVK_HEADER_FLAGS, BUILDER_KVK_KEY_FLAGS } from "./kvk-file.js";
 
 export class VisualKeyboard {
   header: VisualKeyboardHeader = {flags: 0, ansiFont:{}, unicodeFont:{}, underlyingLayout: undefined};
   keys: VisualKeyboardKey[] = [];
 };
 
-export { BUILDER_KVK_HEADER_FLAGS as VisualKeyboardHeaderFlags } from "./kvk-file";
+export { BUILDER_KVK_HEADER_FLAGS as VisualKeyboardHeaderFlags } from "./kvk-file.js";
 
 export class VisualKeyboardHeader {
   version?: number;                      // 0x0600

--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -1,6 +1,7 @@
 import * as xml2js from 'xml2js';
 import { LDMLKeyboardXMLSourceFile, LKImport } from './ldml-keyboard-xml.js';
-import Ajv from 'ajv';
+import { default as AjvModule } from 'ajv';
+const Ajv = AjvModule.default; // The actual expected Ajv type.
 import { boxXmlArray } from '../util/util.js';
 import { CompilerCallbacks } from '../util/compiler-interfaces.js';
 import { constants } from '@keymanapp/ldml-keyboard-constants';

--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -10,7 +10,7 @@ export { default as KvksFileReader } from './kvk/kvks-file-reader.js';
 export { default as KvkFileWriter } from './kvk/kvk-file-writer.js';
 
 export * as LDMLKeyboard from './ldml-keyboard/ldml-keyboard-xml.js';
-export { LDMLKeyboardTestDataXMLSourceFile } from './ldml-keyboard/ldml-keyboard-testdata-xml';
+export { LDMLKeyboardTestDataXMLSourceFile } from './ldml-keyboard/ldml-keyboard-testdata-xml.js';
 export { default as LDMLKeyboardXMLSourceFileReader } from './ldml-keyboard/ldml-keyboard-xml-reader.js';
 
 export * as Constants from './consts/virtual-key-constants.js';

--- a/common/web/types/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
+++ b/common/web/types/test/ldml-keyboard/test-ldml-keyboard-xml-reader.ts
@@ -1,4 +1,4 @@
-import { LKKey } from './../../src/ldml-keyboard/ldml-keyboard-xml';
+import { LKKey } from './../../src/ldml-keyboard/ldml-keyboard-xml.js';
 import 'mocha';
 import {assert} from 'chai';
 import { CommonTypesMessages } from '../../src/util/common-events.js';

--- a/developer/src/kmc-keyboard/package.json
+++ b/developer/src/kmc-keyboard/package.json
@@ -39,7 +39,7 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "4.6.3"
+    "typescript": "^4.9.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-keyboard/src/compiler/metadata-compiler.ts
+++ b/developer/src/kmc-keyboard/src/compiler/metadata-compiler.ts
@@ -1,6 +1,6 @@
 import { KMX, KMXPlus } from '@keymanapp/common-types';
 import CompilerOptions from "./compiler-options.js";
-import KEYMAN_VERSION from "@keymanapp/keyman-version/keyman-version.mjs";
+import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 import KMXPlusData = KMXPlus.KMXPlusData;
 import KMXFile = KMX.KMXFile;

--- a/developer/src/kmc-keyboard/test/test-metadata-compiler.ts
+++ b/developer/src/kmc-keyboard/test/test-metadata-compiler.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import { assert } from 'chai';
 import { checkMessages, compileKeyboard, makePathToFixture } from './helpers/index.js';
 import { KMX } from '@keymanapp/common-types';
-import KEYMAN_VERSION from '@keymanapp/keyman-version/keyman-version.mjs';
+import KEYMAN_VERSION from '@keymanapp/keyman-version';
 
 import KMXFile = KMX.KMXFile;
 

--- a/developer/src/kmc-model-info/package.json
+++ b/developer/src/kmc-model-info/package.json
@@ -41,7 +41,7 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-model-info/src/model-info-compiler.ts
+++ b/developer/src/kmc-model-info/src/model-info-compiler.ts
@@ -9,7 +9,8 @@
 import * as fs from "fs";
 import * as path from "path";
 import { minKeymanVersion } from "./min-keyman-version.js";
-// import KmpJsonFile from "@keymanapp/kmc-package/kmp-json-file";
+import { ModelInfoFile } from "./model-info-file.js";
+import { type KmpJsonFile } from "@keymanapp/kmc-package";
 
 export class ModelInfoOptions {
   /** The identifier for the model */

--- a/developer/src/kmc-model-info/src/model-info-file.ts
+++ b/developer/src/kmc-model-info/src/model-info-file.ts
@@ -1,4 +1,4 @@
-interface ModelInfoFile {
+export interface ModelInfoFile {
   id?: string;
   name?: string;
   authorName?: string;
@@ -21,12 +21,12 @@ interface ModelInfoFile {
   related?: ModelInfoFileRelated[];
 }
 
-interface ModelInfoFileLink {
+export interface ModelInfoFileLink {
   name: string;
   url: string;
 }
 
-interface ModelInfoFileRelated {
+export interface ModelInfoFileRelated {
   deprecates?: string;
   deprecatedBy?: string;
   note?: string;

--- a/developer/src/kmc-model/src/model-definitions.ts
+++ b/developer/src/kmc-model/src/model-definitions.ts
@@ -3,7 +3,7 @@ import { defaultApplyCasing,
          defaultSearchTermToKey
        } from "./model-defaults.js";
 
-import KEYMAN_VERSION from "@keymanapp/keyman-version/keyman-version.mjs";
+import KEYMAN_VERSION from "@keymanapp/keyman-version";
 import { LexicalModelSource, WordformToKeySpec } from "./lexical-model.js";
 
 /**

--- a/developer/src/kmc-model/src/script-overrides-decorator.ts
+++ b/developer/src/kmc-model/src/script-overrides-decorator.ts
@@ -1,4 +1,4 @@
-import { OverrideScriptDefaults } from "./lexical-model";
+import { OverrideScriptDefaults } from "./lexical-model.js";
 
 export function decorateWithScriptOverrides(breaker: WordBreakingFunction, option: OverrideScriptDefaults) {
   if (option !== 'break-words-at-spaces') {

--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -38,7 +38,7 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-package/src/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/kmp-compiler.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as xml2js from 'xml2js';
 import JSZip from 'jszip';
-import KEYMAN_VERSION from "@keymanapp/keyman-version/keyman-version.mjs";
+import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 const FILEVERSION_KMP_JSON = '12.0';
 

--- a/developer/src/kmc-package/src/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/kmp-compiler.ts
@@ -1,11 +1,13 @@
-/// <reference path="kps-file.ts" />
-/// <reference path="kmp-json-file.ts" />
-
 import * as fs from 'fs';
 import * as path from 'path';
 import * as xml2js from 'xml2js';
 import JSZip from 'jszip';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
+
+import type { KpsFile, KpsFileContentFile, KpsFileInfo, KpsFileKeyboard, KpsFileLanguage, KpsFileLexicalModel, KpsFileOptions, KpsPackage } from './kps-file.js';
+import type { KmpJsonFile, KmpJsonFileInfo, KmpJsonFileLanguage, KmpJsonFileOptions } from './kmp-json-file.js';
+
+export { type KmpJsonFile } from './kmp-json-file.js';
 
 const FILEVERSION_KMP_JSON = '12.0';
 

--- a/developer/src/kmc-package/src/kmp-json-file.ts
+++ b/developer/src/kmc-package/src/kmp-json-file.ts
@@ -1,4 +1,4 @@
-interface KmpJsonFile {
+export interface KmpJsonFile {
   system: KmpJsonFileSystem;
   options: KmpJsonFileOptions;
   info?: KmpJsonFileInfo;
@@ -9,12 +9,12 @@ interface KmpJsonFile {
   strings?: string[];
 }
 
-interface KmpJsonFileSystem {
+export interface KmpJsonFileSystem {
   keymanDeveloperVersion: string;
   fileVersion: string;
 }
 
-interface KmpJsonFileOptions {
+export interface KmpJsonFileOptions {
   readmeFile?: string;
   graphicFile?: string;
   executeProgram?: string;
@@ -22,7 +22,7 @@ interface KmpJsonFileOptions {
   msiOptions?: string;
 }
 
-interface KmpJsonFileInfo {
+export interface KmpJsonFileInfo {
   website?: KmpJsonFileInfoItem;
   version?: KmpJsonFileInfoItem;
   name?: KmpJsonFileInfoItem;
@@ -30,29 +30,29 @@ interface KmpJsonFileInfo {
   author?: KmpJsonFileInfoItem;
 }
 
-interface KmpJsonFileInfoItem {
+export interface KmpJsonFileInfoItem {
   description: string;
   url?: string;
 }
 
-interface KmpJsonFileContentFile {
+export interface KmpJsonFileContentFile {
   name: string;
   description: string;
   copyLocation?: number;
 }
 
-interface KmpJsonFileLexicalModel {
+export interface KmpJsonFileLexicalModel {
   name: string;
   id: string;
   languages: KmpJsonFileLanguage[];
 }
 
-interface KmpJsonFileLanguage {
+export interface KmpJsonFileLanguage {
   name: string;
   id: string;
 }
 
-interface KmpJsonFileKeyboard {
+export interface KmpJsonFileKeyboard {
   name: string;
   id: string;
   version: string;
@@ -62,13 +62,13 @@ interface KmpJsonFileKeyboard {
   languages?: KmpJsonFileLanguage[];
 }
 
-interface KmpJsonFileStartMenu {
+export interface KmpJsonFileStartMenu {
   folder?: string;
   addUninstallEntry?: boolean;
   items?: KmpJsonFileStartMenuItem[];
 }
 
-interface KmpJsonFileStartMenuItem {
+export interface KmpJsonFileStartMenuItem {
   name: string;
   filename: string;
   arguments?: string;

--- a/developer/src/kmc-package/src/kps-file.ts
+++ b/developer/src/kmc-package/src/kps-file.ts
@@ -13,14 +13,14 @@
 // * Strings element is not yet checked to be correct
 //
 
-interface KpsPackage {
+export interface KpsPackage {
   /**
    * <Package> -- the root element.
    */
   package: KpsFile;
 }
 
-interface KpsFile {
+export interface KpsFile {
   system: KpsFileSystem;
   options: KpsFileOptions;
   info?: KpsFileInfo;
@@ -31,12 +31,12 @@ interface KpsFile {
   strings?: KpsFileStrings;
 }
 
-interface KpsFileSystem {
+export interface KpsFileSystem {
   keymanDeveloperVersion: string;
   fileVersion: string;
 }
 
-interface KpsFileOptions {
+export interface KpsFileOptions {
   followKeyboardVersion?: string;
   readMeFile?: string;
   graphicFile?: string;
@@ -45,7 +45,7 @@ interface KpsFileOptions {
   msiOptions?: string;
 }
 
-interface KpsFileInfo {
+export interface KpsFileInfo {
   name?: KpsFileInfoItem;
   copyright?: KpsFileInfoItem;
   author?: KpsFileInfoItem;
@@ -53,42 +53,42 @@ interface KpsFileInfo {
   version?: KpsFileInfoItem;
 }
 
-interface KpsFileInfoItem {
+export interface KpsFileInfoItem {
   _: string;
   $: { URL: string };
 }
 
-interface KpsFileContentFiles {
+export interface KpsFileContentFiles {
   file: KpsFileContentFile[] | KpsFileContentFile;
 }
 
-interface KpsFileContentFile {
+export interface KpsFileContentFile {
   name: string;
   description: string;
   copyLocation: string;
   fileType: string;
 }
 
-interface KpsFileLexicalModel {
+export interface KpsFileLexicalModel {
   name: string;
   iD: string;
   languages: KpsFileLanguages;
 }
 
-interface KpsFileLexicalModels {
+export interface KpsFileLexicalModels {
   lexicalModel: KpsFileLexicalModel[] | KpsFileLexicalModel;
 }
 
-interface KpsFileLanguages {
+export interface KpsFileLanguages {
   language: KpsFileLanguage[] | KpsFileLanguage;
 }
 
-interface KpsFileLanguage {
+export interface KpsFileLanguage {
   _: string;
   $: { ID: string }
 }
 
-interface KpsFileKeyboard {
+export interface KpsFileKeyboard {
   name: string;
   iD: string;
   version: string;
@@ -98,17 +98,17 @@ interface KpsFileKeyboard {
   languages?: KpsFileLanguages;
 }
 
-interface KpsFileKeyboards {
+export interface KpsFileKeyboards {
   keyboard: KpsFileKeyboard[] | KpsFileKeyboard;
 }
 
-interface KpsFileStartMenu {
+export interface KpsFileStartMenu {
   folder?: string;
   addUninstallEntry?: string;
   items?: KpsFileStartMenuItems;
 }
 
-interface KpsFileStartMenuItem {
+export interface KpsFileStartMenuItem {
   name: string;
   filename: string;
   arguments?: string;
@@ -116,11 +116,11 @@ interface KpsFileStartMenuItem {
   location?: string;
 }
 
-interface KpsFileStartMenuItems {
+export interface KpsFileStartMenuItems {
   item: KpsFileStartMenuItem[] | KpsFileStartMenuItem;
 }
 
-interface KpsFileStrings {
+export interface KpsFileStrings {
   //TODO: validate this structure
   string: string[] | string;
 }

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -6,6 +6,7 @@ import KmpCompiler from '../src/kmp-compiler.js';
 import {makePathToFixture} from './helpers/index.js';
 import JSZip from 'jszip';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
+import { type KmpJsonFile } from '../src/kmp-json-file.js';
 
 describe('KmpCompiler', function () {
   const MODELS : string[] = [

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -5,7 +5,7 @@ import {assert} from 'chai';
 import KmpCompiler from '../src/kmp-compiler.js';
 import {makePathToFixture} from './helpers/index.js';
 import JSZip from 'jszip';
-import KEYMAN_VERSION from "@keymanapp/keyman-version/keyman-version.mjs";
+import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 describe('KmpCompiler', function () {
   const MODELS : string[] = [

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -57,7 +57,7 @@
     "esbuild": "^0.15.8",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc/src/kmc.ts
+++ b/developer/src/kmc/src/kmc.ts
@@ -5,7 +5,7 @@
 
 
 import { Command } from 'commander';
-import KEYMAN_VERSION from "@keymanapp/keyman-version/keyman-version.mjs";
+import KEYMAN_VERSION from "@keymanapp/keyman-version";
 import { declareBuild } from './commands/build.js';
 import { declareBuildTestData } from './commands/buildTestData.js';
 

--- a/developer/src/kmc/src/kmlmc.ts
+++ b/developer/src/kmc/src/kmlmc.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import { Command } from 'commander';
 import { compileModel } from '@keymanapp/kmc-model';
 import { SysExits } from './util/sysexits';
-import KEYMAN_VERSION from "@keymanapp/keyman-version/keyman-version.mjs";
+import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 let inputFilename: string;
 const program = new Command();

--- a/developer/src/kmc/src/kmlmc.ts
+++ b/developer/src/kmc/src/kmlmc.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs';
 import { Command } from 'commander';
 import { compileModel } from '@keymanapp/kmc-model';
-import { SysExits } from './util/sysexits';
+import { SysExits } from './util/sysexits.js';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 let inputFilename: string;

--- a/developer/src/kmc/src/kmlmi.ts
+++ b/developer/src/kmc/src/kmlmi.ts
@@ -9,7 +9,7 @@ import { Command } from 'commander';
 import KmpCompiler from '@keymanapp/kmc-package';
 import { ModelInfoOptions as ModelInfoOptions, writeMergedModelMetadataFile } from '@keymanapp/kmc-model-info';
 import { SysExits } from './util/sysexits';
-import KEYMAN_VERSION from "@keymanapp/keyman-version/keyman-version.mjs";
+import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 let inputFilename: string;
 const program = new Command();

--- a/developer/src/kmc/src/kmlmi.ts
+++ b/developer/src/kmc/src/kmlmi.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { Command } from 'commander';
 import KmpCompiler from '@keymanapp/kmc-package';
 import { ModelInfoOptions as ModelInfoOptions, writeMergedModelMetadataFile } from '@keymanapp/kmc-model-info';
-import { SysExits } from './util/sysexits';
+import { SysExits } from './util/sysexits.js';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 let inputFilename: string;

--- a/developer/src/kmc/src/kmlmp.ts
+++ b/developer/src/kmc/src/kmlmp.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs';
 import { Command } from 'commander';
 import KmpCompiler from '@keymanapp/kmc-package';
-import { SysExits } from './util/sysexits';
+import { SysExits } from './util/sysexits.js';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 let inputFilename: string;

--- a/developer/src/kmc/src/kmlmp.ts
+++ b/developer/src/kmc/src/kmlmp.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import { Command } from 'commander';
 import KmpCompiler from '@keymanapp/kmc-package';
 import { SysExits } from './util/sysexits';
-import KEYMAN_VERSION from "@keymanapp/keyman-version/keyman-version.mjs";
+import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 let inputFilename: string;
 const program = new Command();

--- a/package-lock.json
+++ b/package-lock.json
@@ -330,7 +330,7 @@
         "hexy": "^0.3.4",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "4.6.3"
+        "typescript": "^4.9.5"
       }
     },
     "common/web/types/node_modules/@types/mocha": {
@@ -547,19 +547,6 @@
         "node": ">=0.3.1"
       }
     },
-    "common/web/types/node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "common/web/utils": {
       "name": "@keymanapp/web-utils",
       "license": "MIT",
@@ -609,7 +596,7 @@
         "esbuild": "^0.15.8",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.5.4"
+        "typescript": "^4.9.5"
       }
     },
     "developer/src/kmc-keyboard": {
@@ -633,7 +620,7 @@
         "chalk": "^2.4.2",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "4.6.3"
+        "typescript": "^4.9.5"
       }
     },
     "developer/src/kmc-keyboard/node_modules/@types/mocha": {
@@ -850,26 +837,12 @@
         "node": ">=0.3.1"
       }
     },
-    "developer/src/kmc-keyboard/node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "developer/src/kmc-model": {
       "name": "@keymanapp/kmc-model",
       "license": "MIT",
       "dependencies": {
         "@keymanapp/keyman-version": "*",
         "@keymanapp/models-types": "*",
-        "commander": "^3.0.0",
         "typescript": "^4.9.5",
         "xml2js": "^0.4.19"
       },
@@ -906,7 +879,7 @@
         "chalk": "^2.4.2",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.5.4"
+        "typescript": "^4.9.5"
       }
     },
     "developer/src/kmc-model-info/node_modules/@types/mocha": {
@@ -1186,7 +1159,7 @@
         "chalk": "^2.4.2",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.5.4"
+        "typescript": "^4.9.5"
       }
     },
     "developer/src/kmc-package/node_modules/@types/mocha": {
@@ -3142,10 +3115,6 @@
       "bin": {
         "color-support": "bin.js"
       }
-    },
-    "node_modules/commander": {
-      "version": "3.0.2",
-      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",

--- a/tsconfig.esm-base.json
+++ b/tsconfig.esm-base.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "module": "ES2022",
     "target": "es2022",
-    "moduleResolution": "Node",
+    "moduleResolution": "Node16",
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "alwaysStrict": true,


### PR DESCRIPTION
Note: supersedes #8427.

Also note:  assumes that #8419 won't conflict and will resolve failing tests under `common/web/types`.  (These are not currently run by CI, so go unnoticed by our checks at the moment anyway.)

Fixes #8420.

Accomplishes the following goals:
- A few new modules from `feature-ldml` had their TS version updated.
    - Some were set to use precisely TS `4.6.3` for some reason, not `^4.6.3`... and certainly not `^4.9.5` like the rest of our TS-reliant modules. 
    - Some were set to `^4.5.4`, but this didn't really affect the package-lock.json - especially not like the rigid `4.6.3` did.
- Establishes export mapping for `common/web/keyman-version`, making the differentiated namespace vs module build product setup invisible when importing the package.
    - Yay, cleaner import paths!
- Resolves breakages that resulted from changing to `Node16` module resolution, which was necessary for the prior point.
   - This involved explicitly `export`ing certain type definitions and explicitly `import`ing them in some of the `kmc` modules.

The export-mapping scenario is the most notable aspect for preventing the upcoming merge conflict, as it facilitates the masking of any changes to the underlying build outputs - whether on `master` or on `feature-` branches.  As `feature-esmodule-web-engine` already uses the export-map feature, having it in place will make the merge conflict with master (#8418, currently) far easier to resolve.

@keymanapp-test-bot skip