### PR TITLE
fix(android/app): Temporarily disable Keyman browser 🍒

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -435,9 +435,10 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
       case R.id.action_share:
         showShareDialog();
         return true;
+      /* Disable Web Browser to investigate Google sign-in
       case R.id.action_web:
         showWebBrowser();
-        return true;
+        return true;*/
       case R.id.action_text_size:
         showTextSizeDialog();
         return true;

--- a/android/KMAPro/kMAPro/src/main/res/menu-land/main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu-land/main.xml
@@ -8,12 +8,13 @@
         app:showAsAction="always"
         android:title="@string/action_share"
         android:icon="@drawable/ic_light_action_share" />
-    
-    <item
+
+  <!-- Disable Web Browser to investigate Google sign-in -->
+  <!--item
         android:id="@+id/action_web"
         app:showAsAction="always"
         android:title="@string/action_web"
-        android:icon="@drawable/ic_light_action_web" />
+        android:icon="@drawable/ic_light_action_web" /> -->
 
     <item
         android:id="@+id/action_text_size"

--- a/android/KMAPro/kMAPro/src/main/res/menu-sw600dp/main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu-sw600dp/main.xml
@@ -8,12 +8,13 @@
         app:showAsAction="always"
         android:title="@string/action_share"
         android:icon="@drawable/ic_light_action_share" />
-    
-    <item
+
+    <!-- Disable Web Browser to investigate Google sign-in -->
+    <!--item
         android:id="@+id/action_web"
         app:showAsAction="always"
         android:title="@string/action_web"
-        android:icon="@drawable/ic_light_action_web" />
+        android:icon="@drawable/ic_light_action_web" /-->
 
     <item
         android:id="@+id/action_text_size"

--- a/android/KMAPro/kMAPro/src/main/res/menu/main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu/main.xml
@@ -8,12 +8,13 @@
         app:showAsAction="always"
         android:title="@string/action_share"
         android:icon="@drawable/ic_light_action_share" />
-    
-    <item
+
+    <!-- Disable Web Browser to investigate Google sign-in -->
+    <!--item
         android:id="@+id/action_web"
         app:showAsAction="always"
         android:title="@string/action_web"
-        android:icon="@drawable/ic_light_action_web" />
+        android:icon="@drawable/ic_light_action_web" /> -->
 
     <!-- Set showAsAction="never" for overflow -->
     <item


### PR DESCRIPTION
🍒 of #8428 to 17.0 alpha

Intermediary step towards #2159 

This PR temporarily disable access to the in-app browser (Keeps the Keyman app account agonistic)

## User Testing
**Setup** 
Install the PR build of Keyman for Android 

* **TEST_BROWSER_DISABLED** - Verifies Keyman browser can't be accessed
1. Launch Keyman for Android in portrait orientation
2. Observe the menu icons and verify the browser icon is not visible
![](https://help.keyman.com/products/android/16.0/android_images/browser-a.png)
3. Rotate the device to landscape orientation
4. Observe the menu icons and verify the browser icon is not visible
