### PR TITLE
chore(common): add common test build configurations

### DIFF
--- a/common/linux/build.sh
+++ b/common/linux/build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Compiles and tests the common Linux modules
+#
+
+# Exit on command failure and when using unset variables:
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+#
+# TODO: when we have linux-specific tests, add them here
+#       as child modules
+#
+
+builder_describe "Keyman common Linux modules" \
+  clean \
+  configure \
+  build \
+  test
+
+builder_parse "$@"
+
+#-------------------------------------------------------------------------------------------------------------------
+
+builder_run_child_actions clean configure build test

--- a/common/mac/build.sh
+++ b/common/mac/build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Compiles and tests the common mac modules
+#
+
+# Exit on command failure and when using unset variables:
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+#
+# TODO: when we have mac-specific tests, add them here
+#       as child modules
+#
+
+builder_describe "Keyman common mac modules" \
+  clean \
+  configure \
+  build \
+  test
+
+builder_parse "$@"
+
+#-------------------------------------------------------------------------------------------------------------------
+
+builder_run_child_actions clean configure build test

--- a/common/web/build.sh
+++ b/common/web/build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Compiles and tests the common web modules
+#
+
+# Exit on command failure and when using unset variables:
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+#
+# TODO: future modules may include
+#   :lm-message-types \
+#   :sentry-manager \
+#
+
+builder_describe "Keyman common web modules" \
+  :keyman-version \
+  :types \
+  :utils \
+  clean \
+  configure \
+  build \
+  test
+
+builder_parse "$@"
+
+#-------------------------------------------------------------------------------------------------------------------
+
+builder_run_child_actions clean configure build test

--- a/common/web/keyman-version/build.sh
+++ b/common/web/keyman-version/build.sh
@@ -24,6 +24,7 @@ builder_describe "Build the include script for current Keyman version" \
   clean \
   build \
   publish \
+  test \
   --dry-run
 
 builder_describe_outputs \

--- a/common/web/utils/build.sh
+++ b/common/web/utils/build.sh
@@ -19,7 +19,7 @@ cd "$THIS_SCRIPT_PATH"
 builder_describe \
   "Compiles the web-oriented utility function module." \
   "@/common/web/keyman-version" \
-  configure clean build
+  clean configure build test
 
 builder_describe_outputs \
   configure "/node_modules" \

--- a/common/windows/build.sh
+++ b/common/windows/build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Compiles and tests the common Windows modules
+#
+
+# Exit on command failure and when using unset variables:
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+#
+# TODO: when we have windows-specific tests, add them here
+#       as child modules
+#
+
+builder_describe "Keyman common Windows modules" \
+  clean \
+  configure \
+  build \
+  test
+
+builder_parse "$@"
+
+#-------------------------------------------------------------------------------------------------------------------
+
+builder_run_child_actions clean configure build test

--- a/resources/build/trigger-definitions.inc.sh
+++ b/resources/build/trigger-definitions.inc.sh
@@ -3,7 +3,7 @@
 # This file maps specific paths to build triggers
 #
 
-available_platforms=(android ios linux mac web windows developer)
+available_platforms=(android common_web common_windows common_mac common_linux ios linux mac web windows developer)
 
 # the base folder for each pattern does not need to be included, nor oem folders
 # e.g. android='common/models|common/predictive-text'
@@ -16,6 +16,11 @@ watch_mac='core'
 watch_web='common/models|common/predictive-text|common/web|core'
 watch_windows='common|core|web'
 watch_developer='common|core|web'
+
+watch_common_web='common/web'
+watch_common_windows='common/windows'
+watch_common_mac='common/mac'
+watch_common_linux='common/linux'
 
 #
 # Available build configurations and VCS identifiers; identifiers are somewhat inconsistent due
@@ -41,6 +46,12 @@ bc_test_mac=(Keyman_KeymanMac_PullRequests Keyman_Common_KPAPI_TestPullRequests_
 bc_test_windows=(KeymanDesktop_TestPullRequests KeymanDesktop_TestPrRenderOnScreenKeyboards Keyman_Common_KPAPI_TestPullRequests_Windows)
 bc_test_web=(Keymanweb_TestPullRequests Keyman_Common_LMLayer_TestPullRequests Keyman_Common_KPAPI_TestPullRequests_WASM)
 bc_test_developer=(Keyman_Developer_Test)
+
+bc_test_common_web=(Keyman_Test_Common_Web)
+bc_test_common_windows=(Keyman_Test_Common_Windows)
+bc_test_common_mac=(Keyman_Test_Common_Mac)
+bc_test_common_linux=(Keyman_Test_Common_Linux)
+
 # Keymanweb_TestPullRequestRegressions : currently this is timing out so disabled until we have
 #                                        time to investigate further
 

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -424,7 +424,8 @@ _builder_run_child_action() {
         # We have to re-test the action because the user may not
         # have specified all targets in their invocation
         if builder_has_action $action$target; then
-          if [ -f "$THIS_SCRIPT_PATH/${_builder_target_paths[$target]}/build.sh" ]; then
+          if [[ ! -z ${_builder_target_paths[$target]+x} ]] &&
+            [[ -f "$THIS_SCRIPT_PATH/${_builder_target_paths[$target]}/build.sh" ]]; then
             _builder_execute_child $action $target
           fi
         fi

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# Note: these two lines can be uncommented for debugging and profiling build
+# scripts:
+#
+#   set -x
+#   PS4='+ $EPOCHREALTIME $0 $LINENO   '
+#
+
 #
 # This script contains utilities for builder_script calls
 #
@@ -1325,7 +1333,6 @@ _builder_parse_expanded_parameters() {
     # track which dependencies have been built, so they don't get built multiple
     # times.
     # TODO: consider printing expanded builder parameters instead of shorthand
-    echo "${_params[@]}"
     builder_echo setmark "build.sh parameters: <${_params[@]}>"
     if [[ ${#builder_extra_params[@]} -gt 0 ]]; then
       builder_echo grey "build.sh extra parameters: <${builder_extra_params[@]}>"


### PR DESCRIPTION
@keymanapp-test-bot skip

Note 4 new build configs:
![image](https://user-images.githubusercontent.com/4498365/224925417-54958101-e31b-4159-a690-122c10aceb78.png)

These run corresponding `common/___/build.sh configure build test`. For now, mac, linux and Windows have no tests. But this provides hooks for them.

Web has a couple of tests.