### PR TITLE
fix(developer/compilers): locks esbuild target detection for kmc building

### DIFF
--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -12,10 +12,10 @@
   "scripts": {
     "build": "tsc -b",
     "bundle": "npm run bundle-kmc && npm run bundle-kmlmc && npm run bundle-kmlmi && npm run bundle-kmlmp",
-    "bundle-kmc": "esbuild build/src/kmc.js --bundle --platform=node > build/cjs-src/kmc.cjs",
-    "bundle-kmlmc": "esbuild build/src/kmlmc.js --bundle --platform=node > build/cjs-src/kmlmc.cjs",
-    "bundle-kmlmi": "esbuild build/src/kmlmi.js --bundle --platform=node > build/cjs-src/kmlmi.cjs",
-    "bundle-kmlmp": "esbuild build/src/kmlmp.js --bundle --platform=node > build/cjs-src/kmlmp.cjs",
+    "bundle-kmc": "esbuild build/src/kmc.js --bundle --platform=node --target=es2022 > build/cjs-src/kmc.cjs",
+    "bundle-kmlmc": "esbuild build/src/kmlmc.js --bundle --platform=node --target=es2022 > build/cjs-src/kmlmc.cjs",
+    "bundle-kmlmi": "esbuild build/src/kmlmi.js --bundle --platform=node --target=es2022 > build/cjs-src/kmlmi.cjs",
+    "bundle-kmlmp": "esbuild build/src/kmlmp.js --bundle --platform=node --target=es2022 > build/cjs-src/kmlmp.cjs",
     "test": "cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
Fixes #8433.

It sounds like `esbuild` is looking for the most selective ES-version target, and since `common/web/keyman-version` is set to ES5 in its tsconfig.json, it runs with that... despite the top level products targeting ES2022.  (ES5 will be needed when KMW is modularized due to our back-compat on older Android devices.)  Setting the option above will tell `esbuild` we know better, that the final product is ES2022-compatible - and will bypass the issue.

@keymanapp-test-bot skip