### PR TITLE
fix(android/engine): Add builder output for configure

### DIFF
--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -49,6 +49,7 @@ if builder_is_debug_build; then
 fi
 
 builder_describe_outputs \
+  configure:engine /android/KMEA/app/src/main/assets/keymanandroid.js \
   build:engine     /android/KMEA/app/build/outputs/aar/${CONFIG}/keyman-engine.aar
 
 #### Build

--- a/android/Samples/KMSample1/build.sh
+++ b/android/Samples/KMSample1/build.sh
@@ -29,6 +29,7 @@ builder_describe "Build KMSample1 app for Android." \
   "clean" \
   "configure" \
   "build" \
+  "test" \
   ":app                   KMSample1" \
   "--ci                   Don't start the Gradle daemon. Use for CI"
 
@@ -75,6 +76,10 @@ fi
 if builder_start_action build:app; then
   ./gradlew clean $SAMPLE_FLAGS
 
-
   builder_finish_action success build:app
+fi
+
+if builder_start_action test:app; then
+
+  builder_finish_action success test:app
 fi

--- a/android/Samples/KMSample1/build.sh
+++ b/android/Samples/KMSample1/build.sh
@@ -80,6 +80,6 @@ if builder_start_action build:app; then
 fi
 
 if builder_start_action test:app; then
-
+  # TODO: define tests
   builder_finish_action success test:app
 fi

--- a/android/Samples/KMSample2/build.sh
+++ b/android/Samples/KMSample2/build.sh
@@ -29,6 +29,7 @@ builder_describe "Build KMSample2 app for Android." \
   "clean" \
   "configure" \
   "build" \
+  "test" \
   ":app                   KMSample2" \
   "--ci                   Don't start the Gradle daemon. Use for CI"
 
@@ -75,6 +76,10 @@ fi
 if builder_start_action build:app; then
   ./gradlew clean $SAMPLE_FLAGS
 
-
   builder_finish_action success build:app
+fi
+
+if builder_start_action test:app; then
+
+  builder_finish_action success test:app
 fi

--- a/android/Samples/KMSample2/build.sh
+++ b/android/Samples/KMSample2/build.sh
@@ -80,6 +80,6 @@ if builder_start_action build:app; then
 fi
 
 if builder_start_action test:app; then
-
+  # TODO: define tests
   builder_finish_action success test:app
 fi

--- a/android/Tests/KeyboardHarness/build.sh
+++ b/android/Tests/KeyboardHarness/build.sh
@@ -28,6 +28,7 @@ builder_describe "Build KeyboardHarness test app for Android." \
   "clean" \
   "configure" \
   "build" \
+  "test" \
   ":app                   KeyboardHarness" \
   "--ci                   Don't start the Gradle daemon. Use for CI"
 

--- a/android/Tests/KeyboardHarness/build.sh
+++ b/android/Tests/KeyboardHarness/build.sh
@@ -90,6 +90,6 @@ fi
 
 if builder_start_action test:app; then
   echo "TEST_FLAGS $TEST_FLAGS"
-
+  # TODO: define tests
   builder_finish_action success test:app
 fi


### PR DESCRIPTION
Follow-on to #7407 

@bharanidharanj was getting exceptions loading test builds of "Keyman for Android". Turns out the KMEA builder configure step wasn't consistently triggering, so the engine got built missing the embedded KeymanWeb dependencies.

## User Testing
**Setup** - Install the PR build of Keyman for Android

* **TEST_KEYMAN** - Verifies Keyman app runs fine
1. Launch Keyman for Android
2. Verify OSK appears behind the "Get Started" menu
3. Verify exceptions **do NOT** appear about being unable to copy an asset file
[Screenshot of an exception](https://user-images.githubusercontent.com/19683143/225273142-d7f6221b-c5b2-41e1-9f81-40fa1c31d5b1.png) as reported 
