### PR TITLE
fix(developer): lm compiler handle missing line no in errors

### DIFF
--- a/developer/src/common/delphi/lexicalmodels/Keyman.Developer.System.LexicalModelCompile.pas
+++ b/developer/src/common/delphi/lexicalmodels/Keyman.Developer.System.LexicalModelCompile.pas
@@ -61,7 +61,7 @@ begin
       if m.Success then
       begin
         msgFilename := m.Groups[1].Value;
-        msgLine := StrToInt(m.Groups[2].Value);
+        msgLine := StrToIntDef(m.Groups[2].Value, 0);
         msgType := m.Groups[3].Value;
         msgCode := StrToInt('$'+m.Groups[4].Value);
         msgText := m.Groups[5].Value;


### PR DESCRIPTION
Fixes #8443.

Cherry pick of #8444.

The regex for matching error messages has an optional section for the file/line detail (line 54):

https://github.com/keymanapp/keyman/blob/9db4cf23799b4e528d4333db9d7f509d977a0bc4/developer/src/common/delphi/lexicalmodels/Keyman.Developer.System.LexicalModelCompile.pas#L54

The first part of that regex:
```regex
^(?:(.+) \((\d+)\): )?
```

The code that parses the results did not account for this being optional, which would cause a crash if the error message did not include this information.

@keymanapp-test-bot skip