### PR TITLE
feat(common/web): mocks may now model selected text 🧩

### DIFF
--- a/common/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/web/keyboard-processor/src/text/outputTarget.ts
@@ -290,6 +290,11 @@ export default abstract class OutputTarget {
   abstract getTextBeforeCaret(): string;
 
   /**
+   * Gets the element's-currently selected text.
+   */
+  abstract getSelectedText(): string;
+
+  /**
    * Relative to the caret (and/or active selection), gets the element's text after the caret,
    * excluding any actively selected text that would be immediately replaced upon text entry.
    */
@@ -350,43 +355,50 @@ export default abstract class OutputTarget {
 // this needs to be in the same file as OutputTarget now.
 export class Mock extends OutputTarget {
   text: string;
-  caretIndex: number;
 
-  constructor(text?: string, caretPos?: number) {
+  selStart: number;
+  selEnd: number;
+  selForward: boolean = true;
+
+  constructor(text?: string, caretPos?: number);
+  constructor(text?: string, selStart?: number, selEnd?: number);
+  constructor(text?: string, selStart?: number, selEnd?: number) {
     super();
 
     this.text = text ? text : "";
     var defaultLength = this.text._kmwLength();
+
     // Ensures that `caretPos == 0` is handled correctly.
-    this.caretIndex = typeof caretPos == "number" ? caretPos : defaultLength;
+    this.selStart = typeof selStart == "number" ? selStart : defaultLength;
+
+    // If no selection-end is set, selection length is implied to be 0.
+    this.selEnd = typeof selEnd == "number" ? selEnd : this.selStart;
+
+    this.selForward = this.selEnd >= this.selStart;
   }
 
   // Clones the state of an existing EditableElement, creating a Mock version of its state.
-  static from(outputTarget: OutputTarget, readonly: boolean) {
+  static from(outputTarget: OutputTarget, readonly?: boolean) {
     let clone: Mock;
 
     if(outputTarget instanceof Mock) {
       // Avoids the need to run expensive kmwstring.ts / `_kmwLength()`
       // calculations when deep-copying Mock instances.
       let priorMock = outputTarget as Mock;
-      clone = new Mock(priorMock.text, priorMock.caretIndex);
+      clone = new Mock(priorMock.text, priorMock.selStart, priorMock.selEnd);
     } else {
-      // If we're 'cloning' a different OutputTarget type, we don't have a
-      // guaranteed way to more efficiently get these values; these are the
-      // best methods specified by the abstraction.
+      let text = outputTarget.getText();
+      let beforeText = outputTarget.getTextBeforeCaret();
+      let afterText = outputTarget.getTextAfterCaret();
+      let selectionStart = beforeText._kmwLength();
+      let selectionEnd = text._kmwLength() - afterText._kmwLength();
 
+      // for NewContext and PostOutput, we want the caret at the selection's end.
+      // Refer to https://github.com/keymanapp/keyman/pull/6249.
       if(readonly) {
-        // for NewContext and PostOutput, we want the whole text
-        let text = outputTarget.getText();
-        let afterText = outputTarget.getTextAfterCaret();
-        let caretIndex = text._kmwLength() - afterText._kmwLength();
-        clone = new Mock(text, caretIndex);
+        clone = new Mock(text, selectionEnd);
       } else {
-        // We choose to ignore (rather, pre-emptively remove) any actively-selected text,
-        // as since it's always removed instantly during any text mutation operations.
-        let preText = outputTarget.getTextBeforeCaret();
-        let caretIndex = preText._kmwLength();
-        clone = new Mock(preText + outputTarget.getTextAfterCaret(), caretIndex);
+        clone = new Mock(text, selectionStart, selectionEnd);
       }
     }
 
@@ -397,7 +409,9 @@ export class Mock extends OutputTarget {
   }
 
   clearSelection(): void {
-    return;
+    this.text = this.getTextBeforeCaret() + this.getTextAfterCaret();
+    this.selEnd = this.selStart;
+    this.selForward = true;
   }
 
   invalidateSelection(): void {
@@ -405,8 +419,7 @@ export class Mock extends OutputTarget {
   }
 
   isSelectionEmpty(): boolean {
-    // TODO: consider if we need to maintain selection information in Mocks
-    return true;
+    return this.selStart == this.selEnd;
   }
 
   hasSelection(): boolean {
@@ -414,22 +427,24 @@ export class Mock extends OutputTarget {
   }
 
   getDeadkeyCaret(): number {
-    return this.caretIndex;
+    return this.selStart;
   }
 
-  setDeadkeyCaret(index: number) {
-    if(index < 0 || index > this.text._kmwLength()) {
-      throw new Error("Provided caret index is out of range.");
-    }
-    this.caretIndex = index;
+  setSelection(start: number, end?: number) {
+    this.selStart = start;
+    this.selEnd = typeof end == 'number' ? end : start;
   }
 
   getTextBeforeCaret(): string {
-    return this.text.kmwSubstr(0, this.caretIndex);
+    return this.text.kmwSubstr(0, this.selStart);
+  }
+
+  getSelectedText(): string {
+    return this.text.kmwSubstr(this.selStart, this.selEnd - this.selStart);
   }
 
   getTextAfterCaret(): string {
-    return this.text.kmwSubstr(this.caretIndex);
+    return this.text.kmwSubstr(this.selEnd);
   }
 
   getText(): string {
@@ -438,19 +453,21 @@ export class Mock extends OutputTarget {
 
   deleteCharsBeforeCaret(dn: number): void {
     if(dn >= 0) {
-      if(dn > this.caretIndex) {
-        dn = this.caretIndex;
+      if(dn > this.selStart) {
+        dn = this.selStart;
       }
       this.adjustDeadkeys(-dn);
-      this.text = this.text.kmwSubstr(0, this.caretIndex - dn) + this.getTextAfterCaret();
-      this.caretIndex -= dn;
+      this.text = this.text.kmwSubstr(0, this.selStart - dn) + this.getTextAfterCaret();
+      this.selStart -= dn;
+      this.selEnd -= dn;
     }
   }
 
   insertTextBeforeCaret(s: string): void {
     this.adjustDeadkeys(s._kmwLength());
     this.text = this.getTextBeforeCaret() + s + this.getTextAfterCaret();
-    this.caretIndex += s.kmwLength();
+    this.selStart += s.kmwLength();
+    this.selEnd += s.kmwLength();
   }
 
   handleNewlineAtCaret(): void {

--- a/common/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/web/keyboard-processor/src/text/outputTarget.ts
@@ -393,13 +393,10 @@ export class Mock extends OutputTarget {
       let selectionStart = beforeText._kmwLength();
       let selectionEnd = text._kmwLength() - afterText._kmwLength();
 
-      // for NewContext and PostOutput, we want the caret at the selection's end.
-      // Refer to https://github.com/keymanapp/keyman/pull/6249.
-      if(readonly) {
-        clone = new Mock(text, selectionEnd);
-      } else {
-        clone = new Mock(text, selectionStart, selectionEnd);
-      }
+      // readonly group or not, the returned Mock remains the same.
+      // New-context events should act as if the caret were at the earlier-in-context
+      // side of the selection, same as standard keyboard rules.
+      clone = new Mock(text, selectionStart, selectionEnd);
     }
 
     // Also duplicate deadkey state!  (Needed for fat-finger ops.)

--- a/common/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/web/keyboard-processor/src/text/outputTarget.ts
@@ -430,6 +430,13 @@ export class Mock extends OutputTarget {
   setSelection(start: number, end?: number) {
     this.selStart = start;
     this.selEnd = typeof end == 'number' ? end : start;
+
+    this.selForward = end >= start;
+    if(!this.selForward) {
+      let temp = this.selStart;
+      this.selStart = this.selEnd;
+      this.selEnd = temp;
+    }
   }
 
   getTextBeforeCaret(): string {
@@ -454,7 +461,7 @@ export class Mock extends OutputTarget {
         dn = this.selStart;
       }
       this.adjustDeadkeys(-dn);
-      this.text = this.text.kmwSubstr(0, this.selStart - dn) + this.getTextAfterCaret();
+      this.text = this.text.kmwSubstr(0, this.selStart - dn) + this.text.kmwSubstr(this.selStart);
       this.selStart -= dn;
       this.selEnd -= dn;
     }
@@ -462,7 +469,7 @@ export class Mock extends OutputTarget {
 
   insertTextBeforeCaret(s: string): void {
     this.adjustDeadkeys(s._kmwLength());
-    this.text = this.getTextBeforeCaret() + s + this.getTextAfterCaret();
+    this.text = this.getTextBeforeCaret() + s + this.text.kmwSubstr(this.selStart);
     this.selStart += s.kmwLength();
     this.selEnd += s.kmwLength();
   }

--- a/common/web/keyboard-processor/tests/node/mocks.js
+++ b/common/web/keyboard-processor/tests/node/mocks.js
@@ -1,0 +1,92 @@
+import { assert } from 'chai';
+import { Mock } from '@keymanapp/keyboard-processor';
+
+describe('Mocks', function() {
+  describe('app|les', () => {
+    const testMock = new Mock('apples', 3);
+
+    it('Cloning with .from()', () => {
+      assert.deepEqual(Mock.from(testMock), testMock);
+      assert.notStrictEqual(Mock.from(testMock), testMock);
+    });
+
+    it('getText', () => {
+      assert.equal(testMock.getText(), 'apples');
+    });
+
+    it('getTextBeforeCaret', () => {
+      assert.equal(testMock.getTextBeforeCaret(), 'app');
+    });
+
+    it('getTextAfterCaret', () => {
+      assert.equal(testMock.getTextAfterCaret(), 'les');
+    });
+
+    it('getSelectedText', () => {
+      assert.equal(testMock.getSelectedText(), '');
+    });
+
+    it('isSelectionEmpty', () => {
+      assert.isTrue(testMock.isSelectionEmpty());
+    });
+
+    it('clearSelection', () => {
+      let editMock = Mock.from(testMock);
+      editMock.clearSelection();
+
+      assert.equal(editMock.getText(), testMock.getTextBeforeCaret() + testMock.getTextAfterCaret());
+      assert.equal(editMock.getTextBeforeCaret(), testMock.getTextBeforeCaret());
+      assert.equal(editMock.getTextAfterCaret(), testMock.getTextAfterCaret());
+      assert.isTrue(editMock.isSelectionEmpty());
+
+      let postClear = Mock.from(editMock);
+      editMock.clearSelection(); // on same object; make sure its internal selection stuff updates correctly!
+      assert.notStrictEqual(postClear, editMock);
+      assert.deepEqual(postClear, editMock);
+    });
+  });
+
+  describe('app|les and ba|nanas', () => {  // selection = 'les and ba'
+    const testMock = new Mock('apples and bananas', 3, 13);
+
+    it('Cloning with from()', () => {
+      assert.deepEqual(Mock.from(testMock), testMock);
+      assert.notStrictEqual(Mock.from(testMock), testMock);
+    });
+
+    it('getText', () => {
+      assert.equal(testMock.getText(), 'apples and bananas');
+    });
+
+    it('getTextBeforeCaret', () => {
+      assert.equal(testMock.getTextBeforeCaret(), 'app');
+    });
+
+    it('getTextAfterCaret', () => {
+      assert.equal(testMock.getTextAfterCaret(), 'nanas');
+    });
+
+    it('getSelectedText', () => {
+      assert.equal(testMock.getSelectedText(), 'les and ba');
+    });
+
+    it('isSelectionEmpty', () => {
+      assert.isFalse(testMock.isSelectionEmpty());
+    });
+
+    it('clearSelection', () => {
+      let editMock = Mock.from(testMock);
+      editMock.clearSelection();
+
+      assert.equal(editMock.getText(), testMock.getTextBeforeCaret() + testMock.getTextAfterCaret());
+      assert.equal(editMock.getTextBeforeCaret(), testMock.getTextBeforeCaret());
+      assert.equal(editMock.getTextAfterCaret(), testMock.getTextAfterCaret());
+      assert.isTrue(editMock.isSelectionEmpty());
+
+      let postClear = Mock.from(editMock);
+      editMock.clearSelection(); // on same object; make sure its internal selection stuff updates correctly!
+      assert.notStrictEqual(postClear, editMock);
+      assert.deepEqual(postClear, editMock);
+    });
+  });
+});

--- a/common/web/keyboard-processor/tests/node/transcriptions.js
+++ b/common/web/keyboard-processor/tests/node/transcriptions.js
@@ -66,7 +66,7 @@ describe("Transcriptions and Transforms", function() {
     it("handles operations with moderately long text", function() {
       var target = new Mock("The quick brown cat jumped onto the lazy dog.", 19);
       var original = Mock.from(target);
-      target.setDeadkeyCaret(30); // 19 + 11:  moves it to after "onto".
+      target.setSelection(30); // 19 + 11:  moves it to after "onto".
       target.deleteCharsBeforeCaret(14); // delete:  "cat jumped onto"
       target.insertTextBeforeCaret("fox jumped over");
 
@@ -111,7 +111,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
     it("handles deletions around the caret without text insertion", function() {
       var target = new Mock("apple", 2);
       var original = Mock.from(target);
-      target.setDeadkeyCaret(3);
+      target.setSelection(3);
       target.deleteCharsBeforeCaret(2); // "ale"
 
       /* It's not exactly black box, but presently we don't NEED the keyEvent object for the method to work.
@@ -129,7 +129,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
         String.kmwEnableSupplementaryPlane(true);
         var target = new Mock(smpApple, 2);
         var original = Mock.from(target);
-        target.setDeadkeyCaret(3);
+        target.setSelection(3);
         target.deleteCharsBeforeCaret(2); // "ale"
 
         /* It's not exactly black box, but presently we don't NEED the keyEvent object for the method to work.
@@ -150,7 +150,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
       // could eventually run in 'headless' mode.
       var target = new Mock("apple", 2);
       var original = Mock.from(target);
-      target.setDeadkeyCaret(3);
+      target.setSelection(3);
       target.deleteCharsBeforeCaret(2);
       target.insertTextBeforeCaret("PP"); // "aPPle"
 
@@ -167,7 +167,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
 
       var target = new Mock("apple", 2);
       var original = Mock.from(target);
-      target.setDeadkeyCaret(4);
+      target.setSelection(4);
       target.deleteCharsBeforeCaret(3);
       target.insertTextBeforeCaret("P"); // "aPe"
 
@@ -184,7 +184,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
 
       var target = new Mock("apple", 2);
       var original = Mock.from(target);
-      target.setDeadkeyCaret(4);
+      target.setSelection(4);
       target.deleteCharsBeforeCaret(3);
       target.insertTextBeforeCaret("aaaaaaaaaaaaaa"); // "aaaaaaaaaaaaaaae"
 
@@ -201,7 +201,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
 
       var target = new Mock("apple", 2);
       var original = Mock.from(target);
-      target.setDeadkeyCaret(5);
+      target.setSelection(5);
       target.deleteCharsBeforeCaret(4);
       target.insertTextBeforeCaret("les"); // "ales" - since we've appended a letter at the very end, the whole right-hand is indeed an insertion.
 
@@ -225,7 +225,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
         var target = new Mock(smpApple, 2);
         let smpLE = u(0x1d5c5)+u(0x1d5be);
         var original = Mock.from(target);
-        target.setDeadkeyCaret(3);
+        target.setSelection(3);
         target.deleteCharsBeforeCaret(2);
         target.insertTextBeforeCaret(smpLE); // "alele"
 
@@ -245,7 +245,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
         var target = new Mock(smpApple, 2);
         let smpB = u(0x1d5bb);
         var original = Mock.from(target);
-        target.setDeadkeyCaret(4);
+        target.setSelection(4);
         target.deleteCharsBeforeCaret(3);
         target.insertTextBeforeCaret(smpB); // "aPe"
 
@@ -262,7 +262,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
 
         var target = new Mock(smpApple, 2);
         var original = Mock.from(target);
-        target.setDeadkeyCaret(4);
+        target.setSelection(4);
         target.deleteCharsBeforeCaret(3);
         target.insertTextBeforeCaret("aaaaaaaaaaaaaa"); // "aaaaaaaaaaaaaaae"
 
@@ -280,7 +280,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
         var target = new Mock(smpApple, 2);
         let smpLES = u(0x1d5c5)+u(0x1d5be)+u(0x1d5cb);
         var original = Mock.from(target);
-        target.setDeadkeyCaret(5);
+        target.setSelection(5);
         target.deleteCharsBeforeCaret(4);
         target.insertTextBeforeCaret(smpLES); // "ales" - since we've appended a letter at the very end, the whole right-hand is indeed an insertion.
 
@@ -308,11 +308,11 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
       var target = new Mock("apple");
       var original = Mock.from(target);
 
-      target.setDeadkeyCaret(4);
+      target.setSelection(4);
       target.insertDeadkeyBeforeCaret(0);
-      target.setDeadkeyCaret(1);
+      target.setSelection(1);
       target.insertDeadkeyBeforeCaret(1);
-      target.setDeadkeyCaret(2);
+      target.setSelection(2);
       target.insertDeadkeyBeforeCaret(2); // 'a' dk(1) 'p' dk(2) | 'p' 'l' dk(0) 'e'
 
       var original = Mock.from(target);
@@ -320,7 +320,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
       target.hasDeadkeyMatch(0, 2);
       target.deadkeys().deleteMatched();
 
-      target.setDeadkeyCaret(3);
+      target.setSelection(3);
       target.deleteCharsBeforeCaret(2);
       target.insertTextBeforeCaret("b");
       target.insertDeadkeyBeforeCaret(3); // In effect: 'a' dk(1) 'b' dk(3) | 'l' dk(0) 'e'

--- a/web/src/engine/element-wrappers/src/contentEditable.ts
+++ b/web/src/engine/element-wrappers/src/contentEditable.ts
@@ -20,7 +20,7 @@ class SelectionRange {
   }
 }
 
-export default class ContentEditable extends OutputTarget<{}> {
+export default class ContentEditable extends OutputTarget {
   root: HTMLElement;
 
   constructor(ele: HTMLElement) {

--- a/web/src/engine/element-wrappers/src/contentEditable.ts
+++ b/web/src/engine/element-wrappers/src/contentEditable.ts
@@ -20,7 +20,7 @@ class SelectionRange {
   }
 }
 
-export default class ContentEditable extends OutputTarget {
+export default class ContentEditable extends OutputTarget<{}> {
   root: HTMLElement;
 
   constructor(ele: HTMLElement) {
@@ -118,6 +118,12 @@ export default class ContentEditable extends OutputTarget {
     }
 
     return caret.node.textContent.substr(0, caret.offset);
+  }
+
+  getSelectedText(): string {
+    // TODO:  figure out the proper implementation.
+    // KMW 16 and before behavior may be maintained by just returning the empty string.
+    return '';
   }
 
   getTextAfterCaret(): string {

--- a/web/src/engine/element-wrappers/src/designIFrame.ts
+++ b/web/src/engine/element-wrappers/src/designIFrame.ts
@@ -31,7 +31,7 @@ class StyleCommand {
   }
 }
 
-export default class DesignIFrame extends OutputTarget<{}> {
+export default class DesignIFrame extends OutputTarget {
   root: HTMLIFrameElement;
   doc: Document;
   docRoot: HTMLElement;

--- a/web/src/engine/element-wrappers/src/designIFrame.ts
+++ b/web/src/engine/element-wrappers/src/designIFrame.ts
@@ -31,7 +31,7 @@ class StyleCommand {
   }
 }
 
-export default class DesignIFrame extends OutputTarget {
+export default class DesignIFrame extends OutputTarget<{}> {
   root: HTMLIFrameElement;
   doc: Document;
   docRoot: HTMLElement;
@@ -140,6 +140,12 @@ export default class DesignIFrame extends OutputTarget {
     }
 
     return caret.node.textContent.substr(0, caret.offset);
+  }
+
+  getSelectedText(): string {
+    // TODO:  figure out the proper implementation.
+    // KMW 16 and before behavior may be maintained by just returning the empty string.
+    return '';
   }
 
   getTextAfterCaret(): string {

--- a/web/src/engine/element-wrappers/src/input.ts
+++ b/web/src/engine/element-wrappers/src/input.ts
@@ -1,6 +1,6 @@
-import OutputTarget, { BaseEventMap } from './outputTarget.js';
+import OutputTarget from './outputTarget.js';
 
-interface EventMap extends BaseEventMap {
+interface EventMap {
   /**
    * Used to facilitate a pre-modularization utility method we wish to maintain:
    ```
@@ -158,6 +158,11 @@ export default class Input extends OutputTarget<EventMap> {
   getTextBeforeCaret(): string {
     this.getCaret();
     return this.getText()._kmwSubstring(0, this.processedSelectionStart);
+  }
+
+  getSelectedText(): string {
+    this.getCaret();
+    return this.getText()._kmwSubstring(this.processedSelectionStart, this.processedSelectionEnd - this.processedSelectionStart);
   }
 
   setTextBeforeCaret(text: string) {

--- a/web/src/engine/element-wrappers/src/input.ts
+++ b/web/src/engine/element-wrappers/src/input.ts
@@ -1,6 +1,6 @@
-import OutputTarget from './outputTarget.js';
+import OutputTarget, { BaseEventMap } from './outputTarget.js';
 
-interface EventMap {
+interface EventMap extends BaseEventMap {
   /**
    * Used to facilitate a pre-modularization utility method we wish to maintain:
    ```
@@ -162,7 +162,7 @@ export default class Input extends OutputTarget<EventMap> {
 
   getSelectedText(): string {
     this.getCaret();
-    return this.getText()._kmwSubstring(this.processedSelectionStart, this.processedSelectionEnd - this.processedSelectionStart);
+    return this.getText()._kmwSubstring(this.processedSelectionStart, this.processedSelectionEnd);
   }
 
   setTextBeforeCaret(text: string) {

--- a/web/src/engine/element-wrappers/src/textarea.ts
+++ b/web/src/engine/element-wrappers/src/textarea.ts
@@ -1,6 +1,6 @@
-import OutputTarget, { BaseEventMap } from './outputTarget.js';
+import OutputTarget from './outputTarget.js';
 
-interface EventMap extends BaseEventMap {
+interface EventMap {
   /**
    * Used to facilitate a pre-modularization utility method we wish to maintain:
    ```
@@ -171,6 +171,11 @@ export default class TextArea extends OutputTarget<EventMap> {
   getTextAfterCaret(): string {
     this.getCaret();
     return this.getText()._kmwSubstring(this.processedSelectionEnd);
+  }
+
+  getSelectedText(): string {
+    this.getCaret();
+    return this.getText()._kmwSubstring(this.processedSelectionStart, this.processedSelectionEnd - this.processedSelectionStart);
   }
 
   getText(): string {

--- a/web/src/engine/element-wrappers/src/textarea.ts
+++ b/web/src/engine/element-wrappers/src/textarea.ts
@@ -1,6 +1,6 @@
-import OutputTarget from './outputTarget.js';
+import OutputTarget, { BaseEventMap } from './outputTarget.js';
 
-interface EventMap {
+interface EventMap extends BaseEventMap {
   /**
    * Used to facilitate a pre-modularization utility method we wish to maintain:
    ```
@@ -175,7 +175,7 @@ export default class TextArea extends OutputTarget<EventMap> {
 
   getSelectedText(): string {
     this.getCaret();
-    return this.getText()._kmwSubstring(this.processedSelectionStart, this.processedSelectionEnd - this.processedSelectionStart);
+    return this.getText()._kmwSubstring(this.processedSelectionStart, this.processedSelectionEnd);
   }
 
   getText(): string {

--- a/web/src/test/auto/dom/cases/element-wrappers/target_mocks.js
+++ b/web/src/test/auto/dom/cases/element-wrappers/target_mocks.js
@@ -3,7 +3,7 @@ let assert = chai.assert;
 import { extendString, Mock } from '/@keymanapp/keyboard-processor/build/lib/index.mjs';
 import { Input } from '/@keymanapp/keyman/build/engine/element-wrappers/lib/index.mjs';
 
-import { toSupplementaryPairString, DynamicElements } from '../test_utils.js';
+import { toSupplementaryPairString, DynamicElements } from '../../test_utils.js';
 
 extendString();
 
@@ -113,7 +113,9 @@ describe('OutputTarget Mocking', function() {
         var mock = Mock.from(base);
         // The selection should appear to be automatically deleted, as any text mutation
         // by KMW would automatically erase the text anyway.
-        assert.equal(mock.getText(), MockTests.Apple.mixed.substr(0, 5));
+        assert.equal(mock.getTextBeforeCaret(), MockTests.Apple.mixed.substr(0, 5));
+        assert.equal(mock.getText(), MockTests.Apple.mixed);
+        assert.equal(mock.getSelectedText(), MockTests.Apple.mixed.substring(5));
         assert.deepEqual(mock.deadkeys(), base.deadkeys());
       });
     });

--- a/web/src/test/auto/integrated/cases/element_interfaces.js
+++ b/web/src/test/auto/integrated/cases/element_interfaces.js
@@ -323,7 +323,7 @@ if(typeof InterfaceTests == 'undefined') {
     }
     //#endregion
 
-    //#region Defines helpers related to HTMLInputElement / Input test setup.
+    //#region Defines helpers related to Mock test setup.
     InterfaceTests.Mock = {};
 
     InterfaceTests.Mock.setupElement = function() {
@@ -338,7 +338,7 @@ if(typeof InterfaceTests == 'undefined') {
     // Implemented for completeness and generality with other tests.
     InterfaceTests.Mock.setCaret = function(pair, index) {
       var text = pair.wrapper.getText();
-      pair.wrapper.caretIndex = text._kmwCodeUnitToCodePoint(index);
+      pair.wrapper.selStart = pair.wrapper.selEnd = text._kmwCodeUnitToCodePoint(index);
     }
 
     // Implemented for completeness and generality with other tests.
@@ -411,6 +411,36 @@ if(typeof InterfaceTests == 'undefined') {
       testObj.setSelectionRange(pair, 10, 6);
       assert.equal(pair.wrapper.getCaret(), 3, "Failed to caret's initial position for backward-selections within an SMP string");
       String.kmwEnableSupplementaryPlane(false);
+    }
+
+    InterfaceTests.Tests.getSelectedText = function(testObj) {
+      var Apple = InterfaceTests.Strings.Apple;
+      var pair = testObj.setupElement();
+
+      String.kmwEnableSupplementaryPlane(false);
+      testObj.resetWithText(pair, Apple.normal);
+      testObj.setSelectionRange(pair, 3, 5);
+      assert.equal(pair.wrapper.getSelectedText(), '45', "Failed to properly retrieve selected text");
+      pair.wrapper.invalidateSelection();
+
+      String.kmwEnableSupplementaryPlane(false);
+      testObj.resetWithText(pair, Apple.normal);
+      testObj.setSelectionRange(pair, 5, 3);
+      assert.equal(pair.wrapper.getSelectedText(), '45', "Failed to properly retrieve reverse-direction selected text");
+      pair.wrapper.invalidateSelection();
+
+      String.kmwEnableSupplementaryPlane(false);
+      testObj.resetWithText(pair, Apple.normal);
+      testObj.setSelectionRange(pair, 3, 3);
+      assert.equal(pair.wrapper.getSelectedText(), '', "No text was selected, but some was returned");
+      pair.wrapper.invalidateSelection();
+
+      String.kmwEnableSupplementaryPlane(true);
+      testObj.resetWithText(pair, Apple.smp);
+      testObj.setSelectionRange(pair, 6, 10);
+      assert.equal(pair.wrapper.getSelectedText(), Apple.smp.substring(6, 10), "Failed to properly retrieve selected SMP text");
+      String.kmwEnableSupplementaryPlane(false);
+      pair.wrapper.invalidateSelection();
     }
 
     // Corresponds to a helper method for certain classes.
@@ -1000,6 +1030,10 @@ describe('Element Input/Output Interfacing', function() {
         });
       });
 
+      it('getSelectedText', function() {
+        InterfaceTests.Tests.getSelectedText(InterfaceTests.Input);
+      });
+
       describe('getTextAfterCaret', function() {
         it('correctly returns text (no active selection)', function() {
           InterfaceTests.Tests.getTextAfterCaretNoSelection(InterfaceTests.Input);
@@ -1094,6 +1128,10 @@ describe('Element Input/Output Interfacing', function() {
         });
       });
 
+      it('getSelectedText', function() {
+        InterfaceTests.Tests.getSelectedText(InterfaceTests.Input);
+      });
+
       describe('getTextAfterCaret', function() {
         it('correctly returns text (no active selection)', function() {
           InterfaceTests.Tests.getTextAfterCaretNoSelection(InterfaceTests.TextArea);
@@ -1180,6 +1218,10 @@ describe('Element Input/Output Interfacing', function() {
         it('correctly returns text (with active selection)', function() {
           InterfaceTests.Tests.getTextBeforeCaretWithSelection(InterfaceTests.ContentEditable);
         });
+      });
+
+      it.skip('getSelectedText', function() { // Not yet properly supported.
+        InterfaceTests.Tests.getSelectedText(InterfaceTests.Input);
       });
 
       describe('getTextAfterCaret', function() {
@@ -1283,6 +1325,10 @@ describe('Element Input/Output Interfacing', function() {
         it('correctly returns text (with active selection)', function() {
           InterfaceTests.Tests.getTextBeforeCaretWithSelection(InterfaceTests.DesignIFrame);
         });
+      });
+
+      it.skip('getSelectedText', function() { // Not yet properly supported.
+        InterfaceTests.Tests.getSelectedText(InterfaceTests.Input);
       });
 
       describe('getTextAfterCaret', function() {

--- a/web/src/test/auto/integrated/cases/element_interfaces.js
+++ b/web/src/test/auto/integrated/cases/element_interfaces.js
@@ -332,18 +332,23 @@ if(typeof InterfaceTests == 'undefined') {
 
     InterfaceTests.Mock.resetWithText = function(pair, string) {
       pair.wrapper.text = string;
-      pair.wrapper.caretIndex = 0;
+      pair.wrapper.selStart = 0;
+      pair.wrapper.selEnd = 0;
     }
 
     // Implemented for completeness and generality with other tests.
     InterfaceTests.Mock.setCaret = function(pair, index) {
-      var text = pair.wrapper.getText();
-      pair.wrapper.selStart = pair.wrapper.selEnd = text._kmwCodeUnitToCodePoint(index);
+      InterfaceTests.Mock.setSelectionRange(pair, index, index);
     }
 
     // Implemented for completeness and generality with other tests.
     InterfaceTests.Mock.getCaret = function(pair) {
       return pair.wrapper.getDeadkeyCaret();
+    }
+
+    InterfaceTests.Mock.setSelectionRange = function(pair, start, end) {
+      let convert = (index) => pair.wrapper.text.kmwCodeUnitToCodePoint(index);
+      pair.wrapper.setSelection(convert(start), convert(end));
     }
 
     InterfaceTests.Mock.setText = function(pair, text) {
@@ -1379,36 +1384,26 @@ describe('Element Input/Output Interfacing', function() {
     // Unique to the Mock type - element interface cloning tests.  Is element state properly copied?
     // As those require a very different setup, they're in the target_mocks.js test case file instead.
 
-    describe('Text Retrieval', function(){
-      describe('getText', function() {
-        it('correctly returns text (no active selection)', function() {
-          InterfaceTests.Tests.getTextNoSelection(InterfaceTests.Mock);
-        });
-      });
-
-      describe('getTextBeforeCaret', function() {
-        it('correctly returns text (no active selection)', function() {
-          InterfaceTests.Tests.getTextBeforeCaretNoSelection(InterfaceTests.Mock);
-        });
-      });
-
-      describe('getTextAfterCaret', function() {
-        it('correctly returns text (no active selection)', function() {
-          InterfaceTests.Tests.getTextAfterCaretNoSelection(InterfaceTests.Mock);
-        });
-      });
-    });
+    // Basic text-retrieval unit tests are now done headlessly in @keymanapp/keyboard-processor.
 
     describe('Text Mutation', function() {
       describe('deleteCharsBeforeCaret', function() {
         it("correctly deletes characters from 'context' (no active selection)", function() {
           InterfaceTests.Tests.deleteCharsBeforeCaretNoSelection(InterfaceTests.Mock);
         });
+
+        it("correctly deletes characters from 'context' (with active selection)", function() {
+          InterfaceTests.Tests.deleteCharsBeforeCaretWithSelection(InterfaceTests.Mock);
+        });
       });
 
       describe('insertTextBeforeCaret', function() {
         it("correctly replaces the element's 'context' (no active selection)", function() {
           InterfaceTests.Tests.insertTextBeforeCaretNoSelection(InterfaceTests.Mock);
+        });
+
+        it("correctly replaces the element's 'context' (with active selection)", function() {
+          InterfaceTests.Tests.insertTextBeforeCaretWithSelection(InterfaceTests.Mock);
         });
       });
 

--- a/web/src/test/auto/integrated/manual.conf.cjs
+++ b/web/src/test/auto/integrated/manual.conf.cjs
@@ -9,7 +9,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Firefox', 'Chrome', 'Edge'], // Can be specified at run-time instead!
+    browsers: ['Firefox', 'Chrome'], // Can be specified at run-time instead!
 	  // Future note for us:  https://www.npmjs.com/package/karma-browserstack-launcher
 
     // Concurrency level


### PR DESCRIPTION
While `app/webview` shouldn't need a webpage element to serve as an intermediary for context management, there is the little issue that the best-suited `OutputTarget` type to use - `Mocks` - has not supported text selection up until now.

So, the obvious path forward:  resolve that issue and have `Mocks` support text-selection - including the ability to clone selected text when constructing them from other `OutputTarget` types.

Note:  this may be of use when resolving #7865 and #7866, though it should not be necessary - especially in regard to 16.0-stable.  Either way, it's work on this PR that led to the recent analyses I wrote for those two issues.

@keymanapp-test-bot skip