### PR TITLE
chore(linux): Prevent building on s390x

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,10 @@
+keyman (16.0.139-2) unstable; urgency=medium
+
+  * Don't build on s390x because Keyman doesn't work on big-endian architectures
+   (upstream bug https://github.com/keymanapp/keyman/issues/5111)
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 20 Mar 2023 19:54:44 +0100
+
 keyman (16.0.139-1) unstable; urgency=medium
 
   * New upstream release.

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -105,7 +105,7 @@ Description: Keyman for Linux configuration
  information about Keyman keyboard packages.
 
 Package: libkmnkbp-dev
-Architecture: any
+Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el riscv64
 Section: libdevel
 Depends:
  libkmnkbp0-0 (= ${binary:Version}),
@@ -129,7 +129,7 @@ Description: Development files for Keyman keyboard processing library
  This package contains development headers and libraries.
 
 Package: libkmnkbp0-0
-Architecture: any
+Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el riscv64
 Section: libs
 Pre-Depends:
  ${misc:Pre-Depends},
@@ -155,7 +155,7 @@ Description: Keyman keyboard processing library
  and applies rules from compiled Keyman keyboard files.
 
 Package: ibus-keyman
-Architecture: any
+Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el riscv64
 Depends:
  ibus (>= 1.3.7),
  sudo,


### PR DESCRIPTION
This reverts commit 07ae306fd41e1c7d0e4274020e3656ac2c7afed8 which got merged in PR #6500 after a [discussion on the Debian mailing list](https://lists.debian.org/debian-input-method/2022/03/msg00095.html).

However, Keyman currently doesn't work on s390x architecture because we don't support big-endian (#5111). This shows in test failures during package build (cf [build log](https://buildd.debian.org/status/fetch.php?pkg=keyman&arch=s390x&ver=16.0.138-4&stamp=1676139609&raw=0)).

@keymanapp-test-bot skip