### PR TITLE
fix(linux): Display error message for corrupt .kmp file

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -281,8 +281,11 @@ class InstallKmp():
 
 
 def extract_kmp(kmpfile, directory):
-    with zipfile.ZipFile(kmpfile, "r") as zip_ref:
-        zip_ref.extractall(directory)
+    try:
+        with zipfile.ZipFile(kmpfile, "r") as zip_ref:
+            zip_ref.extractall(directory)
+    except zipfile.BadZipFile as e:
+        raise InstallError(InstallStatus.Abort, e)
 
 
 def process_keyboard_data(keyboardID, packageDir) -> None:

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -82,6 +82,8 @@ class ViewInstalledWindowBase(Gtk.Window):
 
     def install_file(self, kmpfile, language=None):
         installDlg = InstallKmpWindow(kmpfile, viewkmp=self, language=language)
+        if installDlg.is_error:
+            return Gtk.ResponseType.CANCEL
         result = installDlg.run()
         installDlg.destroy()
         return result


### PR DESCRIPTION
If the user tries to install a corrupt .kmp file we now display an error message instead of just logging to the console and Sentry.

Fixes #8478.

# User Testing

## Preparations

- The test can be run on any Linux platform.
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Create an empty .kmp file by opening a terminal window and running: `touch /tmp/corrupt.kmp`

- Reboot

## Tests

**TEST_MSG**: 
- open km-config
- click "Install" button
- select `/tmp/corrupt.kmp` file
- verify that a message box with an error is shown