### PR TITLE
fix(linux): Display error message for corrupt .kmp file🍒

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -283,8 +283,11 @@ class InstallKmp():
 
 
 def extract_kmp(kmpfile, directory):
-    with zipfile.ZipFile(kmpfile, "r") as zip_ref:
-        zip_ref.extractall(directory)
+    try:
+        with zipfile.ZipFile(kmpfile, "r") as zip_ref:
+            zip_ref.extractall(directory)
+    except zipfile.BadZipFile as e:
+        raise InstallError(InstallStatus.Abort, e)
 
 
 def process_keyboard_data(keyboardID, packageDir) -> None:

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -49,6 +49,7 @@ class InstallKmpWindow(Gtk.Dialog):
 
     def __init__(self, kmpfile, online=False, viewkmp=None, language=None):
         logging.debug("InstallKmpWindow: kmpfile: %s", kmpfile)
+        self.is_error = False
         self.kmpfile = kmpfile
         self.online = online
         self.viewwindow = viewkmp
@@ -68,7 +69,13 @@ class InstallKmpWindow(Gtk.Dialog):
         mainhbox = Gtk.Box()
 
         with tempfile.TemporaryDirectory() as tmpdirname:
-            extract_kmp(kmpfile, tmpdirname)
+            try:
+                extract_kmp(kmpfile, tmpdirname)
+            except InstallError as e:
+                self._handle_install_error(e, kmpfile)
+                self.is_error = True
+                return
+
             info, system, options, keyboards, files = get_metadata(tmpdirname)
             if not keyboards:
                 # Likely not a keyboard .kmp file
@@ -358,26 +365,29 @@ class InstallKmpWindow(Gtk.Dialog):
                 dialog.run()
                 dialog.destroy()
         except InstallError as e:
-            if e.status == InstallStatus.Abort:
-                message = _("Keyboard {name} could not be installed.").format(name=self.kbname) \
-                  + "\n\n" + _("Error Message:") + "\n %s" % (e.message)
-                logging.error(message)
-                message_type = Gtk.MessageType.ERROR
-            else:
-                message = _("Keyboard {name} could not be installed.").format(name=self.kbname) \
-                  + "\n\n" + _("Warning Message:") + "\n %s" % (e.message)
-                logging.warning(message)
-                message_type = Gtk.MessageType.WARNING
-            dialog = Gtk.MessageDialog(
-                self, 0, message_type,
-                Gtk.ButtonsType.OK, message)
-            dialog.run()
-            dialog.destroy()
+            self._handle_install_error(e, self.kbname)
         self.close()
 
     def on_cancel_clicked(self, button):
         logging.info("Cancel install keyboard")
         self.response(Gtk.ResponseType.CANCEL)
+
+    def _handle_install_error(self, e, kbname):
+        if e.status == InstallStatus.Abort:
+            message = _("Keyboard {name} could not be installed.").format(name=kbname) \
+                + "\n\n" + _("Error Message:") + "\n %s" % (e.message)
+            logging.error(message)
+            message_type = Gtk.MessageType.ERROR
+        else:
+            message = _("Keyboard {name} could not be installed.").format(name=kbname) \
+                + "\n\n" + _("Warning Message:") + "\n %s" % (e.message)
+            logging.warning(message)
+            message_type = Gtk.MessageType.WARNING
+        dialog = Gtk.MessageDialog(
+            self, 0, message_type,
+            Gtk.ButtonsType.OK, message)
+        dialog.run()
+        dialog.destroy()
 
 
 def main(argv):

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -81,6 +81,8 @@ class ViewInstalledWindowBase(Gtk.Window):
 
     def install_file(self, kmpfile, language=None):
         installDlg = InstallKmpWindow(kmpfile, viewkmp=self, language=language)
+        if installDlg.is_error:
+            return Gtk.ResponseType.CANCEL
         result = installDlg.run()
         installDlg.destroy()
         return result


### PR DESCRIPTION
If the user tries to install a corrupt .kmp file we now display an error message instead of just logging to the console and Sentry.

Fixes #8478.

(🍒-picked from PR #8479)

# User Testing

## Preparations

- The test can be run on any Linux platform.
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Create an empty .kmp file by opening a terminal window and running: `touch /tmp/corrupt.kmp`

- Reboot

## Tests

**TEST_MSG**: 
- open km-config
- click "Install" button
- select `/tmp/corrupt.kmp` file
- verify that a message box with an error is shown