### PR TITLE
refactor(android/engine): Consolidate dispatchKey

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -209,28 +209,30 @@ public abstract class KMKeyboardJSHandler {
     Handler mainLoop = new Handler(Looper.getMainLooper());
     mainLoop.post(new Runnable() {
       public void run() {
-        if (SystemKeyboard == null) {
+        if (k == null) {
           KMLog.LogError(TAG, "dispatchKey failed: SystemKeyboard is null");
           return;
         }
 
-        if (SystemKeyboard.subKeysWindow != null) {
+        if (k.subKeysWindow != null) {
           return;
         }
 
-        InputConnection ic = IMService.getCurrentInputConnection();
+        InputConnection ic = (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) ?
+          KMTextView.activeView.onCreateInputConnection(new EditorInfo()) :
+          KMManager.getInputMethodService().getCurrentInputConnection();
         if (ic == null) {
-          if (isDebugMode()) {
-            Log.w(HANDLER_TAG, "insertText failed: InputConnection is null");
+          if (KMManager.isDebugMode()) {
+            Log.w(TAG, "insertText failed: InputConnection is null");
           }
           return;
         }
 
-        SystemKeyboard.dismissHelpBubble();
-        SystemKeyboard.setShouldShowHelpBubble(false);
+        k.dismissHelpBubble();
+        k.setShouldShowHelpBubble(false);
 
         // Handle tab or enter since KMW didn't process it
-        Log.d(HANDLER_TAG, "dispatchKey called with code: " + code + ", eventModifiers: " + eventModifiers);
+        Log.d(TAG, "dispatchKey called with code: " + code + ", eventModifiers: " + eventModifiers);
         if (code == KMScanCodeMap.scanCodeMap[KMScanCodeMap.KEY_TAB]) {
           KeyEvent event = new KeyEvent(0, 0, 0, KeyEvent.KEYCODE_TAB, 0, eventModifiers, 0, 0, 0);
           ic.sendKeyEvent(event);

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -210,11 +210,19 @@ public abstract class KMKeyboardJSHandler {
     mainLoop.post(new Runnable() {
       public void run() {
         if (k == null) {
-          KMLog.LogError(TAG, "dispatchKey failed: SystemKeyboard is null");
+          KMLog.LogError(TAG, "dispatchKey failed: Keyboard is null");
           return;
         }
 
         if (k.subKeysWindow != null) {
+          return;
+        }
+
+        if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP &&
+            (KMTextView.activeView == null || KMTextView.activeView.getClass() != KMTextView.class)) {
+          if (KMTextView.activeView == null && KMManager.isDebugMode()) {
+            Log.w(TAG, "dispatchKey failed: activeView is null");
+          }
           return;
         }
 
@@ -235,10 +243,20 @@ public abstract class KMKeyboardJSHandler {
         Log.d(TAG, "dispatchKey called with code: " + code + ", eventModifiers: " + eventModifiers);
         if (code == KMScanCodeMap.scanCodeMap[KMScanCodeMap.KEY_TAB]) {
           KeyEvent event = new KeyEvent(0, 0, 0, KeyEvent.KEYCODE_TAB, 0, eventModifiers, 0, 0, 0);
-          ic.sendKeyEvent(event);
+          if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+            KMTextView textView = (KMTextView)KMTextView.activeView;
+            textView.dispatchKeyEvent(event);
+          } else {
+            ic.sendKeyEvent(event);
+          }
         } else if (code == KMScanCodeMap.scanCodeMap[KMScanCodeMap.KEY_ENTER]) {
           KeyEvent event = new KeyEvent(0, 0, 0, KeyEvent.KEYCODE_ENTER, 0, eventModifiers, 0, 0, 0);
-          ic.sendKeyEvent(event);
+          if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+            KMTextView textView = (KMTextView)KMTextView.activeView;
+            textView.dispatchKeyEvent(event);
+          } else {
+            ic.sendKeyEvent(event);
+          }
         }
       }
     });

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2228,41 +2228,8 @@ public final class KMManager {
   }
 
   private static final class KMInAppKeyboardJSHandler extends KMKeyboardJSHandler {
-
     KMInAppKeyboardJSHandler(Context context, KMKeyboard k) {
       super(context, k);
-    }
-    private static final String HANDLER_TAG = "IAK: JS Handler";
-
-    @JavascriptInterface
-    public boolean dispatchKey(final int code, final int eventModifiers) {
-      Handler mainLoop = new Handler(Looper.getMainLooper());
-      mainLoop.post(new Runnable() {
-        public void run() {
-          if (InAppKeyboard == null) {
-            KMLog.LogError(TAG, "dispatchKey failed: InAppKeyboard is null");
-            return;
-          }
-
-          if (InAppKeyboard.subKeysWindow != null || KMTextView.activeView == null || KMTextView.activeView.getClass() != KMTextView.class) {
-            if ((KMTextView.activeView == null) && isDebugMode()) {
-              Log.w(HANDLER_TAG, "dispatchKey failed: activeView is null");
-            }
-            return;
-          }
-
-          // Handle tab or enter since KMW didn't process it
-          KMTextView textView = (KMTextView) KMTextView.activeView;
-          if (code == KMScanCodeMap.scanCodeMap[KMScanCodeMap.KEY_TAB]) {
-            KeyEvent event = new KeyEvent(0, 0, 0, KeyEvent.KEYCODE_TAB, 0, eventModifiers, 0, 0, 0);
-            textView.dispatchKeyEvent(event);
-          } else if (code == KMScanCodeMap.scanCodeMap[KMScanCodeMap.KEY_ENTER]) {
-            KeyEvent event = new KeyEvent(0, 0, 0, KeyEvent.KEYCODE_ENTER, 0, eventModifiers, 0, 0, 0);
-            textView.dispatchKeyEvent(event);
-          }
-        }
-      });
-      return true;
     }
   }
 
@@ -2270,6 +2237,5 @@ public final class KMManager {
     KMSystemKeyboardJSHandler(Context context, KMKeyboard k) {
       super(context, k);
     }
-    private static final String HANDLER_TAG = "SWK: JS Handler";
   }
 }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2271,44 +2271,5 @@ public final class KMManager {
       super(context, k);
     }
     private static final String HANDLER_TAG = "SWK: JS Handler";
-
-    @JavascriptInterface
-    public boolean dispatchKey(final int code, final int eventModifiers) {
-      Handler mainLoop = new Handler(Looper.getMainLooper());
-      mainLoop.post(new Runnable() {
-        public void run() {
-          if (SystemKeyboard == null) {
-            KMLog.LogError(TAG, "dispatchKey failed: SystemKeyboard is null");
-            return;
-          }
-
-          if (SystemKeyboard.subKeysWindow != null) {
-            return;
-          }
-
-          InputConnection ic = IMService.getCurrentInputConnection();
-          if (ic == null) {
-            if (isDebugMode()) {
-              Log.w(HANDLER_TAG, "insertText failed: InputConnection is null");
-            }
-            return;
-          }
-
-          SystemKeyboard.dismissHelpBubble();
-          SystemKeyboard.setShouldShowHelpBubble(false);
-
-          // Handle tab or enter since KMW didn't process it
-          Log.d(HANDLER_TAG, "dispatchKey called with code: " + code + ", eventModifiers: " + eventModifiers);
-          if (code == KMScanCodeMap.scanCodeMap[KMScanCodeMap.KEY_TAB]) {
-            KeyEvent event = new KeyEvent(0, 0, 0, KeyEvent.KEYCODE_TAB, 0, eventModifiers, 0, 0, 0);
-            ic.sendKeyEvent(event);
-          } else if (code == KMScanCodeMap.scanCodeMap[KMScanCodeMap.KEY_ENTER]) {
-            KeyEvent event = new KeyEvent(0, 0, 0, KeyEvent.KEYCODE_ENTER, 0, eventModifiers, 0, 0, 0);
-            ic.sendKeyEvent(event);
-          }
-        }
-      });
-      return true;
-    }
   }
 }


### PR DESCRIPTION
Continues refactor for #7881 

This consolidates `dispatchKey` into `KMKeyboardJSHandler.java`

## User Testing
**Setup** - Install the PR build of Keyman for Android on a physical device. Also pair an external keyboard (USB or bluetooth) to verify dispatchKey functionality. For all the test steps, use the external keyboard for typing and **NOT** the touch keyboard.

* **TEST_INAPP_KEYBOARD** - Verifies dispatchKey with the InApp keyboard
1. Launch Keyman for Android
2. With the external keyboard, type "qwerty"
3. Verify the text is output to the Keyman app
4. With the external keyboard, press the <kbd>ENTER</kbd> key
5. Verify a newline is output in the Keyman app
6. With the external keyboard, press the <kbd>TAB</kbd> key
7. Verify nothing happens (The Keyman app doesn't output tabspace)

* TEST_SYSTEM_KEYBOARD** - Verifies dispatchKey with the System keyboard
1. Launch Keyman for Android
2. From the "Get Started" menu, set Keyman as a system keyboard and enable as the default system keyboard
3. Exit the Keyman app
4. Launch a text application like Google Keep
5. Select the title field
6. With Keyman as the system keyboard, type from the external keyboard "qwerty"
7. Verify the text is output in the title field
8. With the external keyboard, press the <kbd>TAB</kbd> key
9. Verify Google Keep advances from the title to the the body of the app
10. Continue typing on the external keyboard
11. Verify the text is output to the body of the app
12. From the external keyboard, press the <kbd>ENTER</kbd> key
13. Verify a newline is output
