### PR TITLE
chore(linux): Run and ignore autopkgtests on s390x

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,7 +1,13 @@
+keyman (16.0.139-3) unstable; urgency=medium
+
+  * debian/tests: Run autopkgtests on s390x but immediately return
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 22 Mar 2023 19:25:02 +0100
+
 keyman (16.0.139-2) unstable; urgency=medium
 
   * Don't build on s390x because Keyman doesn't work on big-endian architectures
-   (upstream bug https://github.com/keymanapp/keyman/issues/5111)
+    (upstream bug https://github.com/keymanapp/keyman/issues/5111)
 
  -- Eberhard Beilharz <eb1@sil.org>  Mon, 20 Mar 2023 19:54:44 +0100
 

--- a/linux/debian/tests/control
+++ b/linux/debian/tests/control
@@ -2,4 +2,4 @@ Tests: test-build
 Depends: @,
  build-essential,
  pkg-config,
-Architecture: amd64 arm64 armel armhf i386 mips64el mipsel ppc64el riscv64
+Architecture: any

--- a/linux/debian/tests/test-build
+++ b/linux/debian/tests/test-build
@@ -9,6 +9,14 @@ WORKDIR=$(mktemp -d)
 trap "rm -rf $WORKDIR" 0 INT QUIT ABRT PIPE TERM
 cd "$WORKDIR"
 
+if [ "$(dpkg --print-architecture)" == "s390x" ]; then
+  # libkmnkbp doesn't support big endian architectures
+  # (https://github.com/keymanapp/keyman/issues/5111), so it isn't
+  # build on s390x and we can't run the tests. Simply ignore.
+  echo "Not supported on s390x: OK"
+  exit 0
+fi
+
 # Test all include files are available
 cat <<EOF > keymantest.c
 #include <keyman/keyboardprocessor.h>


### PR DESCRIPTION
This change allows the autopkgtests to run on s390x architecture but immediately exits the test with a successful return code.

@keymanapp-test-bot skip