### PR TITLE
refactor(android/engine): Make KMKeyboardJSHandler a normal class 🛋

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -23,7 +23,7 @@ import com.keyman.engine.KMManager.KeyboardType;
 import com.keyman.engine.util.CharSequenceUtil;
 import com.keyman.engine.util.KMLog;
 
-public abstract class KMKeyboardJSHandler {
+public class KMKeyboardJSHandler {
   private Context context;
   private KMKeyboard k = null;
   private static int KM_VIBRATE_DURATION = 100; // milliseconds

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -423,13 +423,11 @@ public final class KMManager {
       didCopyAssets = true;
     }
 
-    if (keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-      initInAppKeyboard(appContext);
-    } else if (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-      initSystemKeyboard(appContext);
-    } else {
+    if (keyboardType == KeyboardType.KEYBOARD_TYPE_UNDEFINED) {
       String msg = "Cannot initialize: Invalid keyboard type";
       KMLog.LogError(TAG, msg);
+    } else {
+      initKeyboard(appContext, keyboardType);
     }
 
     JSONUtils.initialize(new File(getPackagesDir()));
@@ -631,8 +629,8 @@ public final class KMManager {
    return params;
   }
 
-  private static void initInAppKeyboard(Context appContext) {
-    if (InAppKeyboard == null) {
+  private static void initKeyboard(Context appContext, KeyboardType keyboardType) {
+    if (keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP && InAppKeyboard == null) {
       InAppKeyboard = new KMKeyboard(appContext, KeyboardType.KEYBOARD_TYPE_INAPP);
       RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
       InAppKeyboard.setLayoutParams(params);
@@ -640,15 +638,11 @@ public final class KMManager {
       InAppKeyboard.setHorizontalScrollBarEnabled(false);
       InAppKeyboardWebViewClient = new KMKeyboardWebViewClient(appContext, KeyboardType.KEYBOARD_TYPE_INAPP);
       InAppKeyboard.setWebViewClient(InAppKeyboardWebViewClient);
-      InAppKeyboard.addJavascriptInterface(new KMInAppKeyboardJSHandler(appContext, InAppKeyboard), "jsInterface");
+      InAppKeyboard.addJavascriptInterface(new KMKeyboardJSHandler(appContext, InAppKeyboard), "jsInterface");
       InAppKeyboard.loadKeyboard();
 
       setEngineWebViewVersionStatus(appContext, InAppKeyboard);
-    }
-  }
-
-  private static void initSystemKeyboard(Context appContext) {
-    if (SystemKeyboard == null) {
+    } else if (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM && SystemKeyboard == null) {
       SystemKeyboard = new KMKeyboard(appContext, KeyboardType.KEYBOARD_TYPE_SYSTEM);
       RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
       SystemKeyboard.setLayoutParams(params);
@@ -656,7 +650,7 @@ public final class KMManager {
       SystemKeyboard.setHorizontalScrollBarEnabled(false);
       SystemKeyboardWebViewClient = new KMKeyboardWebViewClient(appContext, KeyboardType.KEYBOARD_TYPE_SYSTEM);
       SystemKeyboard.setWebViewClient(SystemKeyboardWebViewClient);
-      SystemKeyboard.addJavascriptInterface(new KMSystemKeyboardJSHandler(appContext, SystemKeyboard), "jsInterface");
+      SystemKeyboard.addJavascriptInterface(new KMKeyboardJSHandler(appContext, SystemKeyboard), "jsInterface");
       SystemKeyboard.loadKeyboard();
 
       setEngineWebViewVersionStatus(appContext, SystemKeyboard);
@@ -2246,18 +2240,6 @@ public final class KMManager {
     } else {
       // clear globeKeyState
       globeKeyState = GlobeKeyState.GLOBE_KEY_STATE_UP;
-    }
-  }
-
-  private static final class KMInAppKeyboardJSHandler extends KMKeyboardJSHandler {
-    KMInAppKeyboardJSHandler(Context context, KMKeyboard k) {
-      super(context, k);
-    }
-  }
-
-  private static final class KMSystemKeyboardJSHandler extends KMKeyboardJSHandler {
-    KMSystemKeyboardJSHandler(Context context, KMKeyboard k) {
-      super(context, k);
     }
   }
 }


### PR DESCRIPTION
Continues KMManager refactor for #7881 

The refactoring of insertText #8438 and dispatchKey #8483 mean KMKeyboardJSHandler can be converted from an abstract to normal class.

Also consolidates initInAppKeyboard with initSystemKeyboard

## User Testing
**Setup** - Install PR build of Keyman for Android to a physical device
Also install xinaliq keyboard which uses rota keys (some of the keys rotate when the same key is pressed multiple times).
Connect an external keyboard (USB or bluetooth)

* **TEST_INAPP** - Verifies InApp keyboard works
1. Launch Keyman for Android
2. Dismiss the "Get Started" menu
3. In the Keyman app, start typing on the touch keyboard with the default sil_euro_latin keyboard
4. Verify:
    * Base keys are output when pressed
    * longpress keys are output when pressed
5. Switch to the xinaliq keyboard
6. Move the cursor and type
7. Verify the rota keys work such as:
    * s, g, h, k
8. In the Keyman app, start typing with the external keyboard
9. Verify the typed keys are output (some of the rota keys will produce different characters)
10. On the external keyboard, press <kbd>TAB</kbd>
11. Verify nothing is output
12. On the external keyboard, press <kbd>ENTER</kbd>
13. Verify a newline is output

* **TEST_SYSTEM** - Verifies system keyboard works
1. Launch Keyman for Android
2. From the "Get Started" menu, enable Keyman as a system keyboard and set as the default system keyboard.
3. Launch the Google Keep app and select the title field
4. With the external keyboard, type
5. Verify the typed keys are output (xinaliq will produce rota keys output)
6. WIth the external keyboard, press <kbd>TAB</kbd>
7. Verify Keep toggles from the title field to the body
8. Continue to type on the external keyboard
9. Verify  typed keys are output
10. From the external keyboard press <kbd>ENTER</kbd>
11. Verify a newline is output

* **TEST_SYSTEM** - 
