### PR TITLE
chore(common): use mac /usr/bin/stat rather than homebrew version

### DIFF
--- a/mac/Keyman4MacIM/write-download_info.sh
+++ b/mac/Keyman4MacIM/write-download_info.sh
@@ -81,7 +81,7 @@ DOWNLOAD_INFO_FILEPATH="${DMG_FILEPATH}.download_info"
 if [[ ! -f "$DMG_FILEPATH" ]]; then
   builder_die "Cannot compute file size or MD5 for non-existent DMG file: $DMG_FILEPATH"
 fi
-DMG_FILE_SIZE=$(stat -f"%z" "$DMG_FILEPATH")
+DMG_FILE_SIZE=$(/usr/bin/stat -f"%z" "$DMG_FILEPATH")
 DMG_MD5=$(md5 -q "$DMG_FILEPATH")
 
 if [[ -f "$DOWNLOAD_INFO_FILEPATH" ]]; then

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -126,7 +126,7 @@ write_download_info() {
 
   FILE_EXTENSION="${BASE_FILE##*.}"
 
-  FILE_SIZE=$(stat -f"%z" "${BASE_PATH}/${BASE_FILE}")
+  FILE_SIZE=$(/usr/bin/stat -f"%z" "${BASE_PATH}/${BASE_FILE}")
   MD5_HASH=$(md5 -q "${BASE_PATH}/${BASE_FILE}")
 
   if [[ -f "$DOWNLOAD_INFO_FILEPATH" ]]; then


### PR DESCRIPTION
@keymanapp-test-bot skip

I am not 100% sure that this changed due to the macOS upgrade, but stat was now finding the coreutils version rather than the macOS version.

Later, we should probably standardize on the coreutils version so we can use it on all platforms.
