### PR TITLE
chore(linux): Revert "Run and ignore autopkgtests on s390x"

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,9 @@
+keyman (16.0.139-4) unstable; urgency=medium
+
+  * debian/tests: Revert previous change and ignore s390x from autopkgtests
+
+ -- Eberhard Beilharz <eb1@sil.org>  Fri, 24 Mar 2023 16:05:07 +0100
+
 keyman (16.0.139-3) unstable; urgency=medium
 
   * debian/tests: Run autopkgtests on s390x but immediately return

--- a/linux/debian/tests/control
+++ b/linux/debian/tests/control
@@ -2,4 +2,4 @@ Tests: test-build
 Depends: @,
  build-essential,
  pkg-config,
-Architecture: any
+Architecture: amd64 arm64 armel armhf i386 mips64el mipsel ppc64el riscv64

--- a/linux/debian/tests/test-build
+++ b/linux/debian/tests/test-build
@@ -9,14 +9,6 @@ WORKDIR=$(mktemp -d)
 trap "rm -rf $WORKDIR" 0 INT QUIT ABRT PIPE TERM
 cd "$WORKDIR"
 
-if [ "$(dpkg --print-architecture)" == "s390x" ]; then
-  # libkmnkbp doesn't support big endian architectures
-  # (https://github.com/keymanapp/keyman/issues/5111), so it isn't
-  # build on s390x and we can't run the tests. Simply ignore.
-  echo "Not supported on s390x: OK"
-  exit 0
-fi
-
 # Test all include files are available
 cat <<EOF > keymantest.c
 #include <keyman/keyboardprocessor.h>


### PR DESCRIPTION
This basically reverts commit 2f716b3e517ecc4ad4c3a86479533d37fc55a4bc (#8491 .

@keymanapp-test-bot skip