### PR TITLE
chore(developer): move cassert ref to filesystem.cpp

### DIFF
--- a/developer/src/kmcmplib/src/filesystem.cpp
+++ b/developer/src/kmcmplib/src/filesystem.cpp
@@ -1,4 +1,10 @@
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#include <emscripten/bind.h>
+#endif
+
+#include <cassert>
 #include <algorithm>
 #include <iostream>
 #include "filesystem.h"

--- a/developer/src/kmcmplib/src/filesystem.h
+++ b/developer/src/kmcmplib/src/filesystem.h
@@ -1,14 +1,6 @@
 #pragma once
 
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#include <emscripten/bind.h>
-#endif
-
 #include <stdio.h>
-#include <cassert>
-#include <iostream>
-
 #include "kmx_u16.h"
 
 // Opens files on windows and non-windows platforms. Datatypes for Filename and mode must be the same.


### PR DESCRIPTION
Fixes #8530.

@keymanapp-test-bot skip