### PR TITLE
chore(linux): Remove dependency on `sudo`

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -158,7 +158,6 @@ Package: ibus-keyman
 Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el riscv64
 Depends:
  ibus (>= 1.3.7),
- sudo,
  libkmnkbp0-0 (= ${binary:Version}),
  ${misc:Depends},
  ${shlibs:Depends},


### PR DESCRIPTION
Fixes #8468.

# User Testing

**TEST_SMOKE**: Install this PR, then run a quick smoke test: install a keyboard, verify it's working, remove it. Doesn't matter on which Ubuntu version this is tested.