### PR TITLE
fix(linux): Remove warning after pressing Close button

### DIFF
--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -41,7 +41,7 @@ class ViewInstalledWindowBase(Gtk.Window):
 
     def on_close_clicked(self, button):
         logging.debug("Close application clicked")
-        Gtk.main_quit()
+        self.close()
 
     def on_refresh_clicked(self, button):
         logging.debug("Refresh application clicked")


### PR DESCRIPTION
Fixes #8454.

# User Testing

## Preparations

- Can be run on any Linux platform
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot

## Tests

**TEST_NO_WARNING**: When closing the dialog, no error or warning shows
  - Start km-config from the command line.
  - In the Keyman Configuration dialog, click the Close button which appears at the bottom right of the dialog.
  - Verify that no warning or error message appears in the terminal window.
