### PR TITLE
Feature(windows): mcompile - use static tables for Windows keyboard data 🐘 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,9 @@ lcov.info
 /windows/src/engine/mcompilex/*.txt
 /windows/src/engine/mcompilex/*.vcxproj*
 /windows/src/engine/mcompiletest
+
+#can I exclude these from git??
+/developer/src/kmcmplib/resources/meson.build
+/linux/common/core/desktop/meson.build
+/linux/common/core/desktop/wasm.defs.build
+

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,14 @@ lcov.info
 /keyman*.buildinfo
 /keyman*.changes
 /keyman*.tar.?z
+
+#sabine
+*.kmx
+*.kvk
+*.bak
+/developer/src/test/auto/kmcomp/*.txt
+/developer/src/kmcmplib/tests
+/developer/src/kmcmplib/tests/*.txt
+/windows/src/engine/mcompilex/*.txt
+/windows/src/engine/mcompilex/*.vcxproj*
+/windows/src/engine/mcompiletest

--- a/.gitignore
+++ b/.gitignore
@@ -202,7 +202,7 @@ lcov.info
 /windows/src/engine/mcompilex/*.vcxproj*
 /windows/src/engine/mcompiletest
 
-#can I exclude these from git??
+#Sabine: can I exclude these from git??
 /developer/src/kmcmplib/resources/meson.build
 /linux/common/core/desktop/meson.build
 /linux/common/core/desktop/wasm.defs.build

--- a/windows/src/engine/mcompile/mcompile.cpp
+++ b/windows/src/engine/mcompile/mcompile.cpp
@@ -139,7 +139,7 @@ int run(int argc, wchar_t * argv[])
   //DeleteReallocatedPointers(kmxfile); :TODO
   delete kmxfile;
 
-	return 0;
+       return 0;
 }
 
 
@@ -466,11 +466,11 @@ BOOL DoConvert(LPKEYBOARD kbd, LPWSTR kbid, BOOL bDeadkeyConversion) {   // I455
 }
 
 void LogError(PWSTR fmt, ...) {
-	WCHAR fmtbuf[256];
+       WCHAR fmtbuf[256];
 
-	va_list vars;
-	va_start(vars, fmt);
-	_vsnwprintf_s(fmtbuf, _countof(fmtbuf), _TRUNCATE, fmt, vars);  // I2248   // I3547
-	fmtbuf[255] = 0;
+       va_list vars;
+       va_start(vars, fmt);
+       _vsnwprintf_s(fmtbuf, _countof(fmtbuf), _TRUNCATE, fmt, vars);  // I2248   // I3547
+       fmtbuf[255] = 0;
   _putws(fmtbuf);
 }

--- a/windows/src/engine/mcompilex/Makefile
+++ b/windows/src/engine/mcompilex/Makefile
@@ -1,0 +1,32 @@
+#
+# Mcompile Makefile
+#
+
+!include ..\..\Defines.mak
+
+build: manifest.res version.res dirs
+    $(MSBUILD) mcompile.sln $(MSBUILD_BUILD)
+    $(COPY) $(WIN32_TARGET_PATH)\mcompile.exe $(PROGRAM)\engine
+    $(COPY) $(WIN32_TARGET_PATH)\mcompile.pdb $(DEBUGPATH)\engine
+
+clean: def-clean
+    $(MSBUILD) $(MSBUILD_CLEAN) mcompile.sln
+    -rd /s/q debug
+    -rd /s/q release
+    -rd /s/q ipch
+
+signcode:
+    $(SIGNCODE) /d "Keyman Engine Mnemonic Keyboard Recompiler" $(PROGRAM)\engine\mcompile.exe
+
+wrap-symbols:
+    $(SYMSTORE) $(PROGRAM)\engine\mcompile.exe /t keyman-engine-windows
+    $(SYMSTORE) $(DEBUGPATH)\engine\mcompile.pdb /t keyman-engine-windows
+
+install:
+    $(COPY) $(PROGRAM)\engine\mcompile.exe "$(INSTALLPATH_KEYMANENGINE)"
+
+test-manifest:
+# test that linked manifest exists and correct
+    $(MT) -nologo -inputresource:$(PROGRAM)\engine\mcompile.exe -validate_manifest
+
+!include ..\..\Target.mak

--- a/windows/src/engine/mcompilex/manifest.in
+++ b/windows/src/engine/mcompilex/manifest.in
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+	<assemblyIdentity type="win32" name="com.keyman.windows.engine.mcompile" version="$VersionWin" processorArchitecture="x86"/>
+	<description>Keyman Engine x64 Mnemonic Layout Recompiler</description>
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+		<security>
+			<requestedPrivileges>
+				<requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
+	<!-- Switch on various compatibility values -->
+	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+		<application>
+			<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/><!-- Windows Vista and Windows Server 2008 -->
+			<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/><!-- Windows 7 and Windows Server 2008 R2 -->
+			<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/><!-- Windows 8 and Windows Server 2012 -->
+			<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/><!-- Windows 8.1 and Windows Server 2012 R2 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/><!-- Windows 10 -->
+		</application>
+	</compatibility>
+</assembly>

--- a/windows/src/engine/mcompilex/manifest.rc
+++ b/windows/src/engine/mcompilex/manifest.rc
@@ -1,0 +1,1 @@
+1	24	manifest.xml

--- a/windows/src/engine/mcompilex/mc_import_rules.cpp
+++ b/windows/src/engine/mcompilex/mc_import_rules.cpp
@@ -1,0 +1,783 @@
+/*
+  Name:             mc_import_rules
+  Copyright:        Copyright (C) SIL International.
+  Documentation:    
+  Description:      
+  Create Date:      3 Aug 2014
+
+  Modified Date:    6 Feb 2015
+  Authors:          mcdurdin
+  Related Files:    
+  Dependencies:     
+
+  Bugs:             
+  Todo:             
+  Notes:            
+  History:          03 Aug 2014 - mcdurdin - I4327 - V9.0 - Mnemonic layout compiler follow-up
+                    03 Aug 2014 - mcdurdin - I4353 - V9.0 - mnemonic layout recompiler mixes up deadkey rules
+                    31 Dec 2014 - mcdurdin - I4550 - V9.0 - logical flaw in mnemonic layout recompiler means that AltGr base keys are never processed
+                    06 Feb 2015 - mcdurdin - I4552 - V9.0 - Add mnemonic recompile option to ignore deadkeys
+*/
+
+#include "pch.h"
+#include <vector>
+#include <string>
+
+enum ShiftState {
+    Base = 0,                    // 0
+    Shft = 1,                    // 1
+    Ctrl = 2,                    // 2
+    ShftCtrl = Shft | Ctrl,          // 3
+    Menu = 4,                    // 4 -- NOT USED
+    ShftMenu = Shft | Menu,          // 5 -- NOT USED
+    MenuCtrl = Menu | Ctrl,          // 6
+    ShftMenuCtrl = Shft | Menu | Ctrl,   // 7
+    Xxxx = 8,                    // 8
+    ShftXxxx = Shft | Xxxx,          // 9
+};
+
+const int ShiftStateMap[] = {
+  ISVIRTUALKEY,
+  ISVIRTUALKEY | K_SHIFTFLAG,
+  ISVIRTUALKEY | K_CTRLFLAG,
+  ISVIRTUALKEY | K_SHIFTFLAG | K_CTRLFLAG,
+  0,
+  0,
+  ISVIRTUALKEY | RALTFLAG,
+  ISVIRTUALKEY | RALTFLAG | K_SHIFTFLAG,
+  0,
+  0};
+    
+class DeadKey {
+private:
+  WCHAR m_deadchar;
+  std::vector<WCHAR> m_rgbasechar;
+  std::vector<WCHAR> m_rgcombchar;
+
+public:
+  DeadKey(WCHAR deadCharacter) {
+    this->m_deadchar = deadCharacter;
+  }
+
+  WCHAR DeadCharacter() {
+    return this->m_deadchar;
+  }
+
+  void AddDeadKeyRow(WCHAR baseCharacter, WCHAR combinedCharacter) {
+    this->m_rgbasechar.push_back(baseCharacter);
+    this->m_rgcombchar.push_back(combinedCharacter);
+  }
+
+  int Count() {
+    return this->m_rgbasechar.size();
+  }
+
+  WCHAR GetBaseCharacter(int index) {
+    return this->m_rgbasechar[index];
+  }
+
+  WCHAR GetCombinedCharacter(int index) {
+    return this->m_rgcombchar[index];
+  }
+
+  bool ContainsBaseCharacter(WCHAR baseCharacter) {
+    std::vector<WCHAR>::iterator it;
+    for(it=this->m_rgbasechar.begin(); it<m_rgbasechar.end(); it++) {
+      if(*it == baseCharacter) {
+        return true;
+      }
+    }
+    return false;
+  }
+};
+
+
+int DeadKeyMap(int index, std::vector<DeadKey *> *deadkeys, int deadkeyBase, std::vector<DeadkeyMapping> *deadkeyMappings) {   // I4327   // I4353
+  for(size_t i = 0; i < deadkeyMappings->size(); i++) {
+    if((*deadkeyMappings)[i].deadkey == index) {
+      return (*deadkeyMappings)[i].dkid;
+    }
+  }
+
+  for(size_t i = 0; i < deadkeys->size(); i++) {
+    if((*deadkeys)[i]->DeadCharacter() == index) {
+      return deadkeyBase + i;
+    }
+  }
+  return 0xFFFF;
+}
+
+class VirtualKey {
+private:
+  HKL m_hkl;
+  UINT m_vk;
+  UINT m_sc;
+  bool m_rgfDeadKey[10][2];
+  std::wstring m_rgss[10][2];
+
+public:
+  VirtualKey(HKL hkl, UINT virtualKey) {
+    this->m_sc = MapVirtualKeyEx(virtualKey, 0, hkl);
+    this->m_hkl = hkl;
+    this->m_vk = virtualKey;
+    memset(this->m_rgfDeadKey,0,sizeof(this->m_rgfDeadKey));
+  }
+
+  VirtualKey(UINT scanCode, HKL hkl) {
+    this->m_vk = MapVirtualKeyEx(scanCode, 1, hkl);
+    this->m_hkl = hkl;
+    this->m_sc = scanCode;
+  }
+
+  UINT VK() {
+    return this->m_vk;
+  }
+
+  UINT SC() {
+    return this->m_sc;
+  }
+  
+  std::wstring GetShiftState(ShiftState shiftState, bool capsLock) {
+    return this->m_rgss[(UINT)shiftState][(capsLock ? 1 : 0)];
+  }
+  
+  void SetShiftState(ShiftState shiftState, std::wstring value, bool isDeadKey, bool capsLock) {
+    this->m_rgfDeadKey[(UINT)shiftState][(capsLock ? 1 : 0)] = isDeadKey;
+    this->m_rgss[(UINT)shiftState][(capsLock ? 1 : 0)] = value;
+  }
+
+  bool IsSGCAPS() {
+    std::wstring stBase = this->GetShiftState(Base, false);
+    std::wstring stShift = this->GetShiftState(Shft, false);
+    std::wstring stCaps = this->GetShiftState(Base, true);
+    std::wstring stShiftCaps = this->GetShiftState(Shft, true);
+    return (
+        ((stCaps.size() > 0) &&
+        (stBase.compare(stCaps) != 0) &&
+        (stShift.compare(stCaps) != 0)) ||
+        ((stShiftCaps.size() > 0) &&
+        (stBase.compare(stShiftCaps) != 0) &&
+        (stShift.compare(stShiftCaps) != 0)));
+  }
+
+  bool IsCapsEqualToShift() {
+    std::wstring stBase = this->GetShiftState(Base, false);
+    std::wstring stShift = this->GetShiftState(Shft, false);
+    std::wstring stCaps = this->GetShiftState(Base, true);
+    return (
+        (stBase.size() > 0) &&
+        (stShift.size() > 0) &&
+        (stBase.compare(stShift) != 0) &&
+        (stShift.compare(stCaps) == 0));
+  }
+
+  bool IsAltGrCapsEqualToAltGrShift() {
+    std::wstring stBase = this->GetShiftState(MenuCtrl, false);
+    std::wstring stShift = this->GetShiftState(ShftMenuCtrl, false);
+    std::wstring stCaps = this->GetShiftState(MenuCtrl, true);
+    return (
+        (stBase.size() > 0) &&
+        (stShift.size() > 0) &&
+        (stBase.compare(stShift) != 0) &&
+        (stShift.compare(stCaps) == 0));
+  }
+
+  bool IsXxxxGrCapsEqualToXxxxShift() {
+    std::wstring stBase = this->GetShiftState(Xxxx, false);
+    std::wstring stShift = this->GetShiftState(ShftXxxx, false);
+    std::wstring stCaps = this->GetShiftState(Xxxx, true);
+    return (
+        (stBase.size() > 0) &&
+        (stShift.size() > 0) &&
+        (stBase.compare(stShift) != 0) &&
+        (stShift.compare(stCaps) == 0));
+  }
+
+  bool IsEmpty() {
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j <= 1; j++) {
+        if (this->GetShiftState((ShiftState)i, (j == 1)).size() > 0) {
+          return (false);
+        }
+      }
+    }
+    return true;
+  }
+    
+  bool IsKeymanUsedKey() {
+    return (this->m_vk >= 0x20 && this->m_vk <= 0x5F) || (this->m_vk >= 0x88);
+  }
+
+  UINT GetShiftStateValue(int capslock, int caps, ShiftState ss) {
+    return 
+      ShiftStateMap[(int)ss] |
+      (capslock ? (caps ? CAPITALFLAG : NOTCAPITALFLAG) : 0);
+  }
+
+  int GetKeyCount(int MaxShiftState) {
+    int nkeys = 0;
+
+    // Get the CAPSLOCK value
+    int capslock =
+        (this->IsCapsEqualToShift() ? 1 : 0) |
+        (this->IsSGCAPS() ? 2 : 0) |
+        (this->IsAltGrCapsEqualToAltGrShift() ? 4 : 0) |
+        (this->IsXxxxGrCapsEqualToXxxxShift() ? 8 : 0);
+
+    for (int ss = 0; ss <= MaxShiftState; ss++) {
+      if (ss == Menu || ss == ShftMenu) {
+        // Alt and Shift+Alt don't work, so skip them
+        continue;
+      }
+      for (int caps = 0; caps <= 1; caps++) {
+        std::wstring st = this->GetShiftState((ShiftState) ss, (caps == 1));
+
+        if (st.size() == 0) {
+          // No character assigned here
+        } else if (this->m_rgfDeadKey[(int)ss][caps]) {
+          // It's a dead key, append an @ sign.
+          nkeys++;
+        } else {
+          bool isvalid = true;
+          for (size_t ich = 0; ich < st.size(); ich++) {
+            if(st[ich] < 0x20 || st[ich] == 0x7F) { isvalid=false; break; }
+          }
+            
+          if(isvalid) {
+            nkeys++;
+          }
+        }
+      }
+    }
+    return nkeys;
+  }
+
+  bool LayoutRow(int MaxShiftState, LPKEY key, std::vector<DeadKey*> *deadkeys, int deadkeyBase, BOOL bDeadkeyConversion) {   // I4552
+    // Get the CAPSLOCK value
+    int capslock =
+        (this->IsCapsEqualToShift() ? 1 : 0) |
+        (this->IsSGCAPS() ? 2 : 0) |
+        (this->IsAltGrCapsEqualToAltGrShift() ? 4 : 0) |
+        (this->IsXxxxGrCapsEqualToXxxxShift() ? 8 : 0);
+
+    for (int ss = 0; ss <= MaxShiftState; ss++) {
+      if (ss == Menu || ss == ShftMenu) {
+        // Alt and Shift+Alt don't work, so skip them
+        continue;
+      }
+      for (int caps = 0; caps <= 1; caps++) {
+        std::wstring st = this->GetShiftState((ShiftState) ss, (caps == 1));
+        PWSTR p;
+
+        if (st.size() == 0) {
+          // No character assigned here
+        } else if (this->m_rgfDeadKey[(int)ss][caps]) {
+          // It's a dead key, append an @ sign.
+          key->dpContext = new WCHAR[1]; 
+          *key->dpContext = 0;
+          key->ShiftFlags = this->GetShiftStateValue(capslock, caps, (ShiftState) ss);
+          key->Key = VKUnderlyingLayoutToVKUS(this->VK());
+          key->Line = 0;
+
+          if(bDeadkeyConversion) {   // I4552
+            p = key->dpOutput = new WCHAR[2];
+            *p++ = st[0];
+            *p = 0;
+          } else {
+            p = key->dpOutput = new WCHAR[4];
+            *p++ = UC_SENTINEL;
+            *p++ = CODE_DEADKEY;
+            *p++ = DeadKeyMap(st[0], deadkeys, deadkeyBase, &FDeadkeys);   // I4353
+            *p = 0;
+          }
+          key++;
+        } else {
+          bool isvalid = true;
+          for (size_t ich = 0; ich < st.size(); ich++) {
+            if(st[ich] < 0x20 || st[ich] == 0x7F) { isvalid=false; break; }
+          }
+            
+          if(isvalid) {
+            key->Key = VKUnderlyingLayoutToVKUS(this->VK());
+            key->Line = 0;
+            key->ShiftFlags = this->GetShiftStateValue(capslock, caps, (ShiftState) ss);
+            key->dpContext = new WCHAR; *key->dpContext = 0;
+            p = key->dpOutput = new WCHAR[st.size() + 1];
+            for(size_t ich = 0; ich < st.size(); ich++) *p++ = st[ich];
+            *p = 0;
+            key++;
+          }
+        }
+      }
+    }
+    return true;
+  }
+};
+
+class Loader {
+private:
+  BYTE lpKeyStateNull[256];
+  UINT m_XxxxVk;
+
+public:
+  Loader() {
+    m_XxxxVk = 0;
+    memset(lpKeyStateNull, 0, sizeof(lpKeyStateNull));
+  }
+
+  UINT Get_XxxxVk() {
+    return m_XxxxVk;
+  }
+
+  void Set_XxxxVk(UINT value) {
+    m_XxxxVk = value;
+  }
+
+  ShiftState MaxShiftState() {
+    return (Get_XxxxVk() == 0 ? ShftMenuCtrl : ShftXxxx);
+  }
+
+  void FillKeyState(BYTE *lpKeyState, ShiftState ss, bool fCapsLock) {
+    lpKeyState[VK_SHIFT] = (((ss & Shft) != 0) ? 0x80 : 0x00);
+    lpKeyState[VK_CONTROL] = (((ss & Ctrl) != 0) ? 0x80 : 0x00);
+    lpKeyState[VK_MENU] = (((ss & Menu) != 0) ? 0x80 : 0x00);
+    if (Get_XxxxVk() != 0) {
+      // The Xxxx key has been assigned, so let's include it
+      lpKeyState[Get_XxxxVk()] = (((ss & Xxxx) != 0) ? 0x80 : 0x00);
+    }
+    lpKeyState[VK_CAPITAL] = (fCapsLock ? 0x01 : 0x00);
+  }
+
+  bool IsControlChar(wchar_t ch) {
+    return (ch < 0x0020) || (ch >= 0x007F && ch <= 0x009F);
+  }
+
+  DeadKey *ProcessDeadKey(
+      UINT iKeyDead,              // The index into the VirtualKey of the dead key
+      ShiftState shiftStateDead,  // The shiftstate that contains the dead key
+      BYTE *lpKeyStateDead,       // The key state for the dead key
+      std::vector<VirtualKey*> rgKey,          // Our array of dead keys
+      bool fCapsLock,             // Was the caps lock key pressed?
+      HKL hkl) {                  // The keyboard layout
+
+    BYTE lpKeyState[256];
+    DeadKey *deadKey = new DeadKey(rgKey[iKeyDead]->GetShiftState(shiftStateDead, fCapsLock)[0]);
+
+    for (UINT iKey = 0; iKey < rgKey.size(); iKey++) {
+      if (rgKey[iKey] != NULL) {
+        WCHAR sbBuffer[16];
+
+        for (ShiftState ss = Base; ss <= MaxShiftState(); ss = (ShiftState)((int)ss+1)) {
+          int rc = 0;
+          if (ss == Menu || ss == ShftMenu) {
+            // Alt and Shift+Alt don't work, so skip them
+            continue;
+          }
+
+          for (int caps = 0; caps <= 1; caps++) {
+            // First the dead key
+            while (rc >= 0) {
+              // We know that this is a dead key coming up, otherwise
+              // this function would never have been called. If we do
+              // *not* get a dead key then that means the state is 
+              // messed up so we run again and again to clear it up.
+              // Risk is technically an infinite loop but per Hiroyama
+              // that should be impossible here.
+              rc = ToUnicodeEx(rgKey[iKeyDead]->VK(), rgKey[iKeyDead]->SC(), lpKeyStateDead, sbBuffer, _countof(sbBuffer), 0, hkl);
+            }
+
+            // Now fill the key state for the potential base character
+            FillKeyState(lpKeyState, ss, (caps != 0));
+
+            rc = ToUnicodeEx(rgKey[iKey]->VK(), rgKey[iKey]->SC(), lpKeyState, sbBuffer, _countof(sbBuffer), 0, hkl);
+            if (rc == 1) {
+              // That was indeed a base character for our dead key.
+              // And we now have a composite character. Let's run
+              // through one more time to get the actual base 
+              // character that made it all possible?
+              WCHAR combchar = sbBuffer[0];
+              rc = ToUnicodeEx(rgKey[iKey]->VK(), rgKey[iKey]->SC(), lpKeyState, sbBuffer, _countof(sbBuffer), 0, hkl);
+
+              WCHAR basechar = sbBuffer[0];
+
+              if (deadKey->DeadCharacter() == combchar) {
+                // Since the combined character is the same as the dead key,
+                // we must clear out the keyboard buffer.
+                ClearKeyboardBuffer(VK_DECIMAL, rgKey[VK_DECIMAL]->SC(), hkl);
+              }
+
+              if ((((ss == Ctrl) || (ss == ShftCtrl)) &&
+                  (IsControlChar(basechar))) ||
+                  (basechar == combchar)) {
+                // ToUnicodeEx has an internal knowledge about those 
+                // VK_A ~ VK_Z keys to produce the control characters, 
+                // when the conversion rule is not provided in keyboard 
+                // layout files
+
+                // Additionally, dead key state is lost for some of these
+                // character combinations, for unknown reasons.
+
+                // Therefore, if the base character and combining are equal,
+                // and its a CTRL or CTRL+SHIFT state, and a control character
+                // is returned, then we do not add this "dead key" (which
+                // is not really a dead key).
+                continue;
+              }
+
+              if (!deadKey->ContainsBaseCharacter(basechar)) {
+                deadKey->AddDeadKeyRow(basechar, combchar);
+              }
+            } else if (rc > 1) {
+              // Not a valid dead key combination, sorry! We just ignore it.
+            } else if (rc < 0) {
+              // It's another dead key, so we ignore it (other than to flush it from the state)
+              ClearKeyboardBuffer(VK_DECIMAL, rgKey[VK_DECIMAL]->SC(), hkl);
+            }
+          }
+        }
+      }
+    }
+    return deadKey;
+  }
+
+  void ClearKeyboardBuffer(UINT vk, UINT sc, HKL hkl) {
+    WCHAR sb[16];
+    int rc = 0;
+    do {
+      rc = ::ToUnicodeEx(vk, sc, lpKeyStateNull, sb, _countof(sb), 0, hkl);
+    } while(rc != 1 && rc != 0);
+  }
+};
+
+int GetMaxDeadkeyIndex(WCHAR *p) {
+  int n = 0;
+  while(p && *p) {
+    if(*p == UC_SENTINEL && *(p+1) == CODE_DEADKEY)
+      n = max(n, *(p+2));
+    p = incxstr(p);
+  }
+  return n;
+}
+
+bool ImportRules(WCHAR *kbid, LPKEYBOARD kp, std::vector<DeadkeyMapping> *FDeadkeys, BOOL bDeadkeyConversion) {   // I4353   // I4552
+  Loader loader;
+
+  WCHAR inputHKL[12];
+  wsprintf(inputHKL, L"%08.8x", (unsigned int) wcstol(kbid, NULL, 16));
+
+  int cKeyboards = GetKeyboardLayoutList(0, NULL);
+  HKL *rghkl = new HKL[cKeyboards];
+  GetKeyboardLayoutList(cKeyboards, rghkl);            
+  HKL hkl = LoadKeyboardLayout(inputHKL, KLF_NOTELLSHELL);
+  if(hkl == NULL) {
+      puts("Sorry, that keyboard does not seem to be valid.");
+      delete[] rghkl;
+      return false;
+  }
+            
+  BYTE lpKeyState[256];// = new KeysEx[256];
+  std::vector<VirtualKey*> rgKey; //= new VirtualKey[256];
+  std::vector<DeadKey*> alDead;
+
+  rgKey.resize(256);
+
+  // Scroll through the Scan Code (SC) values and get the valid Virtual Key (VK)
+  // values in it. Then, store the SC in each valid VK so it can act as both a 
+  // flag that the VK is valid, and it can store the SC value.
+  for(UINT sc = 0x01; sc <= 0x7f; sc++) {
+    VirtualKey *key = new VirtualKey(sc, hkl);
+    if(key->VK() != 0) {
+      rgKey[key->VK()] = key;
+    } else {
+      delete key;
+    }
+  }
+
+  // add the special keys that do not get added from the code above
+  for(UINT ke = VK_NUMPAD0; ke <= VK_NUMPAD9; ke++) {
+      rgKey[ke] = new VirtualKey(hkl, ke);
+  }
+  rgKey[VK_DIVIDE] = new VirtualKey(hkl, VK_DIVIDE);
+  rgKey[VK_CANCEL] = new VirtualKey(hkl, VK_CANCEL);
+  rgKey[VK_DECIMAL] = new VirtualKey(hkl, VK_DECIMAL);
+
+  // See if there is a special shift state added
+  for(UINT vk = 0; vk <= VK_OEM_CLEAR; vk++) {
+      UINT sc = MapVirtualKeyEx(vk, 0, hkl);
+      UINT vkL = MapVirtualKeyEx(sc, 1, hkl);
+      UINT vkR = MapVirtualKeyEx(sc, 3, hkl);
+      if((vkL != vkR) && 
+          (vk != vkL)) {
+          switch(vk) {
+              case VK_LCONTROL:
+              case VK_RCONTROL:
+              case VK_LSHIFT:
+              case VK_RSHIFT:
+              case VK_LMENU:
+              case VK_RMENU:
+                  break;
+
+              default:
+                  loader.Set_XxxxVk(vk);
+                  break;
+          }
+      }
+  }
+
+  for(UINT iKey = 0; iKey < rgKey.size(); iKey++) {
+      if(rgKey[iKey] != NULL) {
+          WCHAR sbBuffer[256];     // Scratchpad we use many places
+
+          for(ShiftState ss = Base; ss <= loader.MaxShiftState(); ss = (ShiftState)((int)ss + 1)) {
+              if(ss == Menu || ss == ShftMenu) {
+                  // Alt and Shift+Alt don't work, so skip them
+                  continue;
+              }
+
+              for(int caps = 0; caps <= 1; caps++) {
+                  loader.ClearKeyboardBuffer(VK_DECIMAL, rgKey[VK_DECIMAL]->SC(), hkl);
+                  ////FillKeyState(lpKeyState, ss, (caps != 0)); //http://blogs.msdn.com/michkap/archive/2006/04/18/578557.aspx
+                  loader.FillKeyState(lpKeyState, ss, (caps == 0));
+                  //sbBuffer = new StringBuilder(10);
+                  int rc = ToUnicodeEx(rgKey[iKey]->VK(), rgKey[iKey]->SC(), lpKeyState, sbBuffer, _countof(sbBuffer), 0, hkl);
+                  if(rc > 0) {
+                      if(*sbBuffer == 0) {
+                          // Someone defined NULL on the keyboard; let's coddle them
+                          ////rgKey[iKey].SetShiftState(ss, "\u0000", false, (caps != 0));
+                          rgKey[iKey]->SetShiftState(ss, L"", false, (caps == 0));
+                      }
+                      else {
+                          if((rc == 1) &&
+                              (ss == Ctrl || ss == ShftCtrl) &&
+                              (rgKey[iKey]->VK() == ((UINT)sbBuffer[0] + 0x40))) {
+                              // ToUnicodeEx has an internal knowledge about those 
+                              // VK_A ~ VK_Z keys to produce the control characters, 
+                              // when the conversion rule is not provided in keyboard 
+                              // layout files
+                              continue;
+                          }
+                          sbBuffer[rc] = 0;
+                          //rgKey[iKey].SetShiftState(ss, sbBuffer.ToString().Substring(0, rc), false, (caps != 0));
+                          rgKey[iKey]->SetShiftState(ss, sbBuffer, false, (caps == 0));
+
+                      }
+                  }
+                  else if(rc < 0) {
+                      //rgKey[iKey].SetShiftState(ss, sbBuffer.ToString().Substring(0, 1), true, (caps != 0));
+                      sbBuffer[2] = 0;
+                      rgKey[iKey]->SetShiftState(ss, sbBuffer, true, (caps == 0));
+
+                      // It's a dead key; let's flush out whats stored in the keyboard state.
+                      loader.ClearKeyboardBuffer(VK_DECIMAL, rgKey[VK_DECIMAL]->SC(), hkl);
+                      DeadKey *dk = NULL;
+                      for(UINT iDead = 0; iDead < alDead.size(); iDead++) {
+                          dk = alDead[iDead];
+                          if(dk->DeadCharacter() == rgKey[iKey]->GetShiftState(ss, caps == 0)[0]) {
+                              break;
+                          }
+                          dk = NULL;
+                      }
+                      if(dk == NULL) {
+                        alDead.push_back(loader.ProcessDeadKey(iKey, ss, lpKeyState, rgKey, caps == 0, hkl));
+                      }
+                  }
+              }
+          }
+      }
+  }
+
+  for(int i = 0; i < cKeyboards; i++) {
+    if(hkl == rghkl[i]) {
+      hkl = NULL;
+      break;
+    }
+  }
+
+  if(hkl != NULL) {
+    UnloadKeyboardLayout(hkl);
+  }
+
+  delete[] rghkl;
+
+  //-------------------------------------------------------------
+  // Now that we've collected the key data, we need to
+  // translate it to kmx and append to the existing keyboard
+  //-------------------------------------------------------------
+    
+  int nDeadkey = 0;
+
+  LPGROUP gp = new GROUP[kp->cxGroupArray+2];  // leave space for old
+  memcpy(gp, kp->dpGroupArray, sizeof(GROUP) * kp->cxGroupArray);
+
+  //
+  // Find the current highest deadkey index
+  //
+
+  kp->dpGroupArray = gp;
+  for(UINT i = 0; i < kp->cxGroupArray; i++, gp++) {
+    /*if(gp->fUsingKeys && gp->dpNoMatch == NULL) {   // I4550
+      WCHAR *p = gp->dpNoMatch = new WCHAR[4];
+      *p++ = UC_SENTINEL;
+      *p++ = CODE_USE;
+      *p++ = (WCHAR)(kp->cxGroupArray + 1);
+      *p = 0;
+    }*/
+    LPKEY kkp = gp->dpKeyArray;
+    for(UINT j = 0; j < gp->cxKeyArray; j++, kkp++) {
+      nDeadkey = max(nDeadkey, GetMaxDeadkeyIndex(kkp->dpContext));
+      nDeadkey = max(nDeadkey, GetMaxDeadkeyIndex(kkp->dpOutput));
+    }
+  }
+  kp->cxGroupArray++;
+  gp = &kp->dpGroupArray[kp->cxGroupArray-1];
+
+  UINT nKeys = 0;
+  for (UINT iKey = 0; iKey < rgKey.size(); iKey++) {
+    if ((rgKey[iKey] != NULL) && rgKey[iKey]->IsKeymanUsedKey() && (!rgKey[iKey]->IsEmpty())) {
+      nKeys+= rgKey[iKey]->GetKeyCount(loader.MaxShiftState());
+    }
+  }
+
+  nDeadkey++; // ensure a 1-based index above the max deadkey value already in the keyboard
+
+  gp->fUsingKeys = TRUE;
+  gp->dpMatch = NULL;
+  gp->dpName = NULL;
+  gp->dpNoMatch = NULL;
+  gp->cxKeyArray = nKeys;
+  gp->dpKeyArray = new KEY[gp->cxKeyArray];
+  nKeys = 0;
+
+  //
+  // Fill in the new rules
+  //
+
+  for (UINT iKey = 0; iKey < rgKey.size(); iKey++) {
+    if ((rgKey[iKey] != NULL) && rgKey[iKey]->IsKeymanUsedKey() && (!rgKey[iKey]->IsEmpty())) {
+      // for each item, 
+      if(rgKey[iKey]->LayoutRow(loader.MaxShiftState(), &gp->dpKeyArray[nKeys], &alDead, nDeadkey, bDeadkeyConversion)) {   // I4552
+        nKeys+=rgKey[iKey]->GetKeyCount(loader.MaxShiftState());
+      }
+    }
+  }
+
+  gp->cxKeyArray = nKeys;
+
+  //
+  // Add nomatch control to each terminating 'using keys' group   // I4550
+  //
+  LPGROUP gp2 = kp->dpGroupArray;
+  for(UINT i = 0; i < kp->cxGroupArray - 1; i++, gp2++) {
+    if(gp2->fUsingKeys && gp2->dpNoMatch == NULL) {
+      WCHAR *p = gp2->dpNoMatch = new WCHAR[4];
+      *p++ = UC_SENTINEL;
+      *p++ = CODE_USE;
+      *p++ = (WCHAR)(kp->cxGroupArray);
+      *p = 0;
+
+      //
+      // I4550 - Each place we have a nomatch > use(baselayout) (this last group), we need to add all 
+      // the AltGr and ShiftAltGr combinations as rules to allow them to be matched as well.  Yes, this
+      // loop is not very efficient but it's not worthy of optimisation.
+      //
+      UINT j;
+      LPKEY kkp;
+      for(j = 0, kkp = gp->dpKeyArray; j < gp->cxKeyArray; j++, kkp++) {
+        if((kkp->ShiftFlags & (K_CTRLFLAG|K_ALTFLAG|LCTRLFLAG|LALTFLAG|RCTRLFLAG|RALTFLAG)) != 0) {
+          gp2->cxKeyArray++;
+          LPKEY kkp2 = new KEY[gp2->cxKeyArray];
+          memcpy(kkp2, gp2->dpKeyArray, sizeof(KEY)*(gp2->cxKeyArray-1));
+          gp2->dpKeyArray = kkp2;
+          kkp2 = &kkp2[gp2->cxKeyArray-1];
+          kkp2->dpContext = new WCHAR; *kkp2->dpContext = 0;
+          kkp2->Key = kkp->Key;
+          kkp2->ShiftFlags = kkp->ShiftFlags;
+          kkp2->Line = 0;
+          WCHAR *p = kkp2->dpOutput = new WCHAR[4];
+          *p++ = UC_SENTINEL;
+          *p++ = CODE_USE;
+          *p++ = (WCHAR)(kp->cxGroupArray);
+          *p = 0;
+        }
+      }
+    }
+  }
+
+  //
+  // If we have deadkeys, then add a new group to translate the deadkeys per the deadkey tables
+  // We only do this if not in deadkey conversion mode
+  //
+
+  if (alDead.size() > 0 && !bDeadkeyConversion) {   // I4552
+    kp->cxGroupArray++;
+
+    WCHAR *p = gp->dpMatch = new WCHAR[4];
+    *p++ = UC_SENTINEL;
+    *p++ = CODE_USE;
+    *p++ = (WCHAR) kp->cxGroupArray;
+    *p = 0;
+
+    gp++;
+
+    gp->fUsingKeys = FALSE;
+    gp->dpMatch = NULL;
+    gp->dpName = NULL;
+    gp->dpNoMatch = NULL;
+    gp->cxKeyArray = alDead.size();
+    LPKEY kkp = gp->dpKeyArray = new KEY[alDead.size()];
+
+    LPSTORE sp = new STORE[kp->cxStoreArray + alDead.size() * 2];
+    memcpy(sp, kp->dpStoreArray, sizeof(STORE) * kp->cxStoreArray);
+
+    kp->dpStoreArray = sp;
+
+    sp = &sp[kp->cxStoreArray];
+    int nStoreBase = kp->cxStoreArray;
+    kp->cxStoreArray += alDead.size() * 2;
+
+    for(UINT i = 0; i < alDead.size(); i++) {
+      DeadKey *dk = alDead[i];
+
+      sp->dpName = NULL;
+      sp->dwSystemID = 0;
+      sp->dpString = new WCHAR[dk->Count() + 1];
+      for(int j = 0; j < dk->Count(); j++) 
+        sp->dpString[j] = dk->GetBaseCharacter(j);
+      sp->dpString[dk->Count()] = 0;
+      sp++;
+
+      sp->dpName = NULL;
+      sp->dwSystemID = 0;
+      sp->dpString = new WCHAR[dk->Count() + 1];
+      for(int j = 0; j < dk->Count(); j++) 
+        sp->dpString[j] = dk->GetCombinedCharacter(j);
+      sp->dpString[dk->Count()] = 0;
+      sp++;
+
+      kkp->Line = 0;
+      kkp->ShiftFlags = 0;
+      kkp->Key = 0;
+      WCHAR *p = kkp->dpContext = new WCHAR[8];
+      *p++ = UC_SENTINEL;
+      *p++ = CODE_DEADKEY;
+      *p++ = DeadKeyMap(dk->DeadCharacter(), &alDead, nDeadkey, FDeadkeys);   // I4353
+      //*p++ = nDeadkey+i;
+      *p++ = UC_SENTINEL;
+      *p++ = CODE_ANY;
+      *p++ = nStoreBase + i*2 + 1;
+      *p = 0;
+
+      p = kkp->dpOutput = new WCHAR[5];
+      *p++ = UC_SENTINEL;
+      *p++ = CODE_INDEX;
+      *p++ = nStoreBase + i*2 + 2;
+      *p++ = 2;
+      *p = 0;
+
+      kkp++;
+    }
+  }
+
+  return true;
+}
+

--- a/windows/src/engine/mcompilex/mc_kmxfile.cpp
+++ b/windows/src/engine/mcompilex/mc_kmxfile.cpp
@@ -1,0 +1,143 @@
+#include "pch.h"
+
+
+static BOOL LoadKeyboardFile(LPSTR fileName, LPKEYBOARD *lpKeyboard);
+BOOL VerifyKeyboard(LPBYTE filebase, DWORD sz);
+
+LPKEYBOARD FixupKeyboard(PBYTE bufp, PBYTE base, DWORD dwFileSize);
+
+void Err(wchar_t *s) {
+	LogError(L"LoadKeyboard: %s, last error = %d\n", s, GetLastError());
+}
+
+BOOL LoadKeyboard(LPWSTR fileName, LPKEYBOARD *lpKeyboard) {
+	DWORD sz;
+	LPBYTE buf;
+	HANDLE hFile;
+	LPKEYBOARD kbp;
+  PBYTE filebase;
+
+	if(!fileName || !lpKeyboard) {
+		Err(L"Bad Filename");
+		return FALSE;
+	}
+
+	hFile = CreateFile(fileName, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
+	if(hFile == INVALID_HANDLE_VALUE) {
+		Err(L"Could not open file");
+		return FALSE;
+	}
+
+	sz = GetFileSize(hFile, NULL);
+
+	buf = new BYTE[sz];
+
+	if(!buf) {
+		Err(L"Not allocmem");
+		CloseHandle(hFile);
+		return FALSE;
+	}
+
+  filebase = buf;
+
+	if(!ReadFile(hFile, filebase, sz, &sz, NULL)) {
+    Err(L"errReadFile");
+    CloseHandle(hFile);
+    delete[] buf;
+    return FALSE;
+  }
+	CloseHandle(hFile);
+
+	if(!VerifyKeyboard(filebase, sz)) {
+    Err(L"errVerifyKeyboard");
+    delete[] buf;
+    return FALSE;
+  }
+
+	kbp = FixupKeyboard(buf, filebase, sz);
+  if(!kbp) {
+    Err(L"errFixupKeyboard");
+    delete[] buf;
+    return FALSE;
+  }
+
+	if(kbp->dwIdentifier != FILEID_COMPILED) {
+    Err(L"errNotFileID");
+    delete[] buf;
+    return FALSE;
+  }
+
+	*lpKeyboard = kbp;
+	return TRUE;
+}
+
+PWCHAR StringOffset(PBYTE base, DWORD offset) {
+  if(offset == 0) return NULL;
+  return (PWCHAR)(base + offset);
+}
+
+LPKEYBOARD FixupKeyboard(PBYTE bufp, PBYTE base, DWORD dwFileSize) {
+  UNREFERENCED_PARAMETER(dwFileSize);
+
+  DWORD i, j;
+  PCOMP_KEYBOARD ckbp = (PCOMP_KEYBOARD) base;
+  PCOMP_GROUP cgp;
+  PCOMP_STORE csp;
+  PCOMP_KEY ckp;
+  LPKEYBOARD kbp = (LPKEYBOARD) bufp;
+  LPSTORE sp;
+  LPGROUP gp;
+  LPKEY kp;
+
+	kbp->dpStoreArray = (LPSTORE) (base + ckbp->dpStoreArray);
+	kbp->dpGroupArray = (LPGROUP) (base + ckbp->dpGroupArray);
+
+	for(sp = kbp->dpStoreArray, csp = (PCOMP_STORE) sp, i = 0; i < kbp->cxStoreArray; i++, sp++, csp++)	{
+    sp->dpName = StringOffset(base, csp->dpName);
+		sp->dpString = StringOffset(base, csp->dpString);
+	}
+
+	for(gp = kbp->dpGroupArray, cgp = (PCOMP_GROUP) gp, i = 0; i < kbp->cxGroupArray; i++, gp++, cgp++)	{
+    gp->dpName = StringOffset(base, cgp->dpName);
+		gp->dpKeyArray = (LPKEY) (base + cgp->dpKeyArray);
+		if(cgp->dpMatch != NULL) gp->dpMatch = (PWSTR) (base + cgp->dpMatch);
+		if(cgp->dpNoMatch != NULL) gp->dpNoMatch = (PWSTR) (base + cgp->dpNoMatch);
+
+		for(kp = gp->dpKeyArray, ckp = (PCOMP_KEY) kp, j = 0; j < gp->cxKeyArray; j++, kp++, ckp++) {
+			kp->dpOutput = (PWSTR) (base + ckp->dpOutput);
+			kp->dpContext = (PWSTR) (base + ckp->dpContext);
+		}
+	}
+
+  return kbp;
+}
+
+BOOL VerifyKeyboard(LPBYTE filebase, DWORD sz) {
+  DWORD i;
+  PCOMP_KEYBOARD ckbp = (PCOMP_KEYBOARD) filebase;
+  PCOMP_STORE csp;
+
+	/* Check file version */
+
+	if(ckbp->dwFileVersion < VERSION_MIN ||
+	   ckbp->dwFileVersion > VERSION_MAX) {
+		/* Old or new version -- identify the desired program version */
+			for(csp = (PCOMP_STORE)(filebase + ckbp->dpStoreArray), i = 0; i < ckbp->cxStoreArray; i++, csp++) {
+				if(csp->dwSystemID == TSS_COMPILEDVERSION) {
+					wchar_t buf2[256];
+          if(csp->dpString == 0) {
+  					wsprintf(buf2, L"errWrongFileVersion:NULL");
+          } else {
+					  wsprintf(buf2, L"errWrongFileVersion:%10.10ls", StringOffset(filebase, csp->dpString));
+          }
+					Err(buf2);
+					return FALSE;
+				}
+		}
+		Err(L"errWrongFileVersion");
+		return FALSE;
+	}
+
+
+  return TRUE;
+}

--- a/windows/src/engine/mcompilex/mc_kmxfile.h
+++ b/windows/src/engine/mcompilex/mc_kmxfile.h
@@ -1,0 +1,66 @@
+#include <Windows.h>
+
+#ifndef _KMXFILE_H
+#define _KMXFILE_H
+
+typedef struct tagSTORE {
+	DWORD dwSystemID;
+	PWSTR dpName;
+	PWSTR dpString;
+} STORE, *LPSTORE;
+
+typedef struct tagKEY {
+	WCHAR Key;
+	DWORD Line;
+	DWORD ShiftFlags;
+	PWSTR dpOutput;
+	PWSTR dpContext;
+} KEY, *LPKEY;
+
+
+typedef struct tagGROUP {
+	PWSTR dpName;
+	LPKEY dpKeyArray;		// [LPKEY] address of first item in key array
+	PWSTR dpMatch;
+	PWSTR dpNoMatch;
+	DWORD cxKeyArray;		// in array entries
+	BOOL  fUsingKeys;		// group(xx) [using keys] <-- specified or not
+} GROUP, *LPGROUP;
+
+
+typedef struct tagKEYBOARD {
+	DWORD dwIdentifier;		// Keyman compiled keyboard id
+
+	DWORD dwFileVersion;	// Version of the file - Keyman 4.0 is 0x0400
+
+	DWORD dwCheckSum;		// As stored in keyboard. DEPRECATED as of 16.0
+	DWORD xxkbdlayout;    	// as stored in HKEY_LOCAL_MACHINE//system//currentcontrolset//control//keyboard layouts
+	DWORD IsRegistered;		// layout id, from same registry key
+	DWORD version;			// keyboard version
+
+	DWORD cxStoreArray;		// in array entries
+	DWORD cxGroupArray;		// in array entries
+
+	LPSTORE dpStoreArray;	// [LPSTORE] address of first item in store array, from start of file
+	LPGROUP dpGroupArray;	// [LPGROUP] address of first item in group array, from start of file
+
+	DWORD StartGroup[2];	// index of starting groups [2 of them]
+							// Ansi=0, Unicode=1
+
+	DWORD dwFlags;			// Flags for the keyboard file
+
+	DWORD dwHotKey;			// standard windows hotkey (hiword=shift/ctrl/alt stuff, loword=vkey)
+
+	//PWSTR dpName;			// offset of name
+	//PWSTR dpLanguageName;	// offset of language name;
+	//PWSTR dpCopyright;		// offset of copyright
+	//PWSTR dpMessage;		// offset of message in Keyboard About box
+
+	DWORD dpBitmapOffset;	// 0038 offset of the bitmaps in the file
+	DWORD dwBitmapSize;		// 003C size in bytes of the bitmaps
+	//HBITMAP	hBitmap;		// handle to the bitmap in the file;
+} KEYBOARD, *LPKEYBOARD;
+
+BOOL LoadKeyboard(LPWSTR fileName, LPKEYBOARD *lpKeyboard);
+
+#endif

--- a/windows/src/engine/mcompilex/mc_savekeyboard.cpp
+++ b/windows/src/engine/mcompilex/mc_savekeyboard.cpp
@@ -1,0 +1,218 @@
+
+#include "pch.h"
+
+// These four errors are copied from comperr.h, because WriteCompiledKeyboard is
+// a clone of the compiler's equivalent function. However, the functions
+// diverge, as mc_savekeyboard.cpp's version is copying from an existing
+// compiled keyboard. The error codes have been kept consistent with those in
+// comperr.h.
+#define CERR_None                                          0x00000000
+#define CERR_CannotAllocateMemory                          0x00008004
+#define CERR_UnableToWriteFully                            0x00008007
+#define CERR_SomewhereIGotItWrong                          0x00008009
+
+DWORD WriteCompiledKeyboard(LPKEYBOARD fk, HANDLE hOutfile, BOOL FSaveDebug);
+
+BOOL SaveKeyboard(LPKEYBOARD kbd, PWSTR filename) {
+  HANDLE hOutfile = CreateFile(filename, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 0, NULL);
+  if (hOutfile == INVALID_HANDLE_VALUE) {
+    LogError(L"Failed to create output file (%d)", GetLastError());
+    return FALSE;
+  }
+
+  DWORD err = WriteCompiledKeyboard(kbd, hOutfile, FALSE);
+
+  CloseHandle(hOutfile);
+
+  if (err != CERR_None) {
+    LogError(L"Failed to write compiled keyboard with error %d", err);
+    DeleteFile(filename);
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+DWORD WriteCompiledKeyboard(LPKEYBOARD fk, HANDLE hOutfile, BOOL FSaveDebug)
+{
+  LPGROUP fgp;
+  LPSTORE fsp;
+  LPKEY fkp;
+
+  PCOMP_KEYBOARD ck;
+  PCOMP_GROUP gp;
+  PCOMP_STORE sp;
+  PCOMP_KEY kp;
+  PBYTE buf;
+  DWORD size, offset;
+  DWORD i, j;
+
+  // Calculate how much memory to allocate
+
+  size = sizeof(COMP_KEYBOARD) +
+    fk->cxGroupArray * sizeof(COMP_GROUP) +
+    fk->cxStoreArray * sizeof(COMP_STORE) +
+    /*wcslen(fk->szName)*2 + 2 +
+    wcslen(fk->szCopyright)*2 + 2 +
+    wcslen(fk->szLanguageName)*2 + 2 +
+    wcslen(fk->szMessage)*2 + 2 +*/
+    fk->dwBitmapSize;
+
+  for (i = 0, fgp = fk->dpGroupArray; i < fk->cxGroupArray; i++, fgp++) {
+    if (fgp->dpName)
+      size += wcslen(fgp->dpName) * 2 + 2;
+    size += fgp->cxKeyArray * sizeof(COMP_KEY);
+    for (j = 0, fkp = fgp->dpKeyArray; j < fgp->cxKeyArray; j++, fkp++) {
+      size += wcslen(fkp->dpOutput) * 2 + 2;
+      size += wcslen(fkp->dpContext) * 2 + 2;
+    }
+
+    if (fgp->dpMatch) size += wcslen(fgp->dpMatch) * 2 + 2;
+    if (fgp->dpNoMatch) size += wcslen(fgp->dpNoMatch) * 2 + 2;
+  }
+
+  for (i = 0; i < fk->cxStoreArray; i++)
+  {
+    size += wcslen(fk->dpStoreArray[i].dpString) * 2 + 2;
+    if (fk->dpStoreArray[i].dpName)
+      size += wcslen(fk->dpStoreArray[i].dpName) * 2 + 2;
+  }
+
+  buf = new BYTE[size];
+  if (!buf) return CERR_CannotAllocateMemory;
+  memset(buf, 0, size);
+
+  ck = (PCOMP_KEYBOARD)buf;
+
+  ck->dwIdentifier = FILEID_COMPILED;
+
+  ck->dwFileVersion = fk->dwFileVersion;
+  ck->dwCheckSum = 0; // No checksum in 16.0, see #7276
+  ck->KeyboardID = fk->xxkbdlayout;
+  ck->IsRegistered = fk->IsRegistered;
+  ck->cxStoreArray = fk->cxStoreArray;
+  ck->cxGroupArray = fk->cxGroupArray;
+  ck->StartGroup[0] = fk->StartGroup[0];
+  ck->StartGroup[1] = fk->StartGroup[1];
+  ck->dwHotKey = fk->dwHotKey;
+
+  ck->dwFlags = fk->dwFlags;
+
+  offset = sizeof(COMP_KEYBOARD);
+
+  /*ck->dpLanguageName = offset;
+  wcscpy((PWSTR)(buf + offset), fk->szLanguageName);
+  offset += wcslen(fk->szLanguageName)*2 + 2;
+
+  ck->dpName = offset;
+  wcscpy((PWSTR)(buf + offset), fk->szName);
+  offset += wcslen(fk->szName)*2 + 2;
+
+  ck->dpCopyright = offset;
+  wcscpy((PWSTR)(buf + offset), fk->szCopyright);
+  offset += wcslen(fk->szCopyright)*2 + 2;
+
+  ck->dpMessage = offset;
+  wcscpy((PWSTR)(buf + offset), fk->szMessage);
+  offset += wcslen(fk->szMessage)*2 + 2;*/
+
+  ck->dpStoreArray = offset;
+  sp = (PCOMP_STORE)(buf + offset);
+  fsp = fk->dpStoreArray;
+  offset += sizeof(COMP_STORE) * ck->cxStoreArray;
+  for (i = 0; i < ck->cxStoreArray; i++, sp++, fsp++) {
+    sp->dwSystemID = fsp->dwSystemID;
+    sp->dpString = offset;
+    wcscpy_s((PWSTR)(buf + offset), (size - offset) / sizeof(WCHAR), fsp->dpString);  // I3481   // I3641
+    offset += wcslen(fsp->dpString) * 2 + 2;
+
+    if (!fsp->dpName) {
+      sp->dpName = 0;
+    }
+    else {
+      sp->dpName = offset;
+      wcscpy_s((PWSTR)(buf + offset), (size - offset) / sizeof(WCHAR), fsp->dpName);  // I3481   // I3641
+      offset += wcslen(fsp->dpName) * 2 + 2;
+    }
+  }
+
+  ck->dpGroupArray = offset;
+  gp = (PCOMP_GROUP)(buf + offset);
+  fgp = fk->dpGroupArray;
+
+  offset += sizeof(COMP_GROUP) * ck->cxGroupArray;
+
+  for (i = 0; i < ck->cxGroupArray; i++, gp++, fgp++) {
+    gp->cxKeyArray = fgp->cxKeyArray;
+    gp->fUsingKeys = fgp->fUsingKeys;
+
+    gp->dpMatch = gp->dpNoMatch = 0;
+
+    if (fgp->dpMatch) {
+      gp->dpMatch = offset;
+      wcscpy_s((PWSTR)(buf + offset), (size - offset) / sizeof(WCHAR), fgp->dpMatch);  // I3481   // I3641
+      offset += wcslen(fgp->dpMatch) * 2 + 2;
+    }
+    if (fgp->dpNoMatch) {
+      gp->dpNoMatch = offset;
+      wcscpy_s((PWSTR)(buf + offset), (size - offset) / sizeof(WCHAR), fgp->dpNoMatch);  // I3481   // I3641
+      offset += wcslen(fgp->dpNoMatch) * 2 + 2;
+    }
+
+    if (fgp->dpName) {
+      gp->dpName = offset;
+      wcscpy_s((PWSTR)(buf + offset), (size - offset) / sizeof(WCHAR), fgp->dpName);  // I3481   // I3641
+      offset += wcslen(fgp->dpName) * 2 + 2;
+    }
+    else {
+      gp->dpName = 0;
+    }
+
+    gp->dpKeyArray = offset;
+    kp = (PCOMP_KEY)(buf + offset);
+    fkp = fgp->dpKeyArray;
+    offset += gp->cxKeyArray * sizeof(COMP_KEY);
+    for (j = 0; j < gp->cxKeyArray; j++, kp++, fkp++) {
+      kp->Key = fkp->Key;
+      kp->Line = fkp->Line;
+      kp->ShiftFlags = fkp->ShiftFlags;
+      kp->dpOutput = offset;
+      wcscpy_s((PWSTR)(buf + offset), (size - offset) / sizeof(WCHAR), fkp->dpOutput);  // I3481   // I3641
+      offset += wcslen(fkp->dpOutput) * 2 + 2;
+
+
+      kp->dpContext = offset;
+      wcscpy_s((PWSTR)(buf + offset), (size - offset) / sizeof(WCHAR), fkp->dpContext);  // I3481   // I3641
+      offset += wcslen(fkp->dpContext) * 2 + 2;
+    }
+  }
+
+  if (fk->dwBitmapSize > 0) {
+    ck->dwBitmapSize = fk->dwBitmapSize;
+    ck->dpBitmapOffset = offset;
+    memcpy(buf + offset, ((PBYTE)fk) + fk->dpBitmapOffset, fk->dwBitmapSize);
+    offset += fk->dwBitmapSize;
+  }
+  else {
+    ck->dwBitmapSize = 0;
+    ck->dpBitmapOffset = 0;
+  }
+
+  if (offset != size)
+  {
+    delete[] buf;
+    return CERR_SomewhereIGotItWrong;
+  }
+
+  WriteFile(hOutfile, buf, size, &offset, NULL);
+
+  if (offset != size)
+  {
+    delete[] buf;
+    return CERR_UnableToWriteFully;
+  }
+
+  delete[] buf;
+
+  return CERR_None;
+}

--- a/windows/src/engine/mcompilex/mc_syskbd.cpp
+++ b/windows/src/engine/mcompilex/mc_syskbd.cpp
@@ -1,0 +1,62 @@
+#include "pch.h"
+
+BOOL IsWow64();
+
+BOOL LoadNewLibrary_NT_x64(PWSTR filename);
+WCHAR CharFromVK_NT_x64(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey);
+WORD VKUSToVKUnderlyingLayout_NT_x64(WORD VKey);
+WORD VKUnderlyingLayoutToVKUS_NT_x64(WORD VKey);
+int GetDeadkeys_NT_x64(WORD DeadKey, WORD *OutputPairs);  // returns array of [USVK, ch] pairs
+
+BOOL LoadNewLibrary_NT(PWSTR filename);
+WCHAR CharFromVK_NT(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey);
+WORD VKUSToVKUnderlyingLayout_NT(WORD VKey);
+WORD VKUnderlyingLayoutToVKUS_NT(WORD VKey);
+int GetDeadkeys_NT(WORD DeadKey, WORD *OutputPairs);  // returns array of [USVK, ch] pairs
+
+BOOL LoadNewLibrary(PWSTR filename) {
+  if(IsWow64()) {
+    return LoadNewLibrary_NT_x64(filename);
+  } else {
+    return LoadNewLibrary_NT(filename);
+  }
+}
+
+WCHAR CharFromVK(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey) {
+  if(IsWow64()) {
+    return CharFromVK_NT_x64(VKey, ShiftFlags, PDeadKey);
+  } else {
+    return CharFromVK_NT(VKey, ShiftFlags, PDeadKey);
+  }
+}
+
+int GetDeadkeys(WORD DeadKey, WORD *OutputPairs) {
+  if(IsWow64()) {
+    return GetDeadkeys_NT_x64(DeadKey, OutputPairs);
+  } else {
+    return GetDeadkeys_NT(DeadKey, OutputPairs);
+  }
+}
+
+WORD VKUSToVKUnderlyingLayout(WORD VKey) {
+  if(IsWow64()) {
+    return VKUSToVKUnderlyingLayout_NT_x64(VKey);
+  } else {
+    return VKUSToVKUnderlyingLayout_NT(VKey);
+  }
+}
+
+WORD VKUnderlyingLayoutToVKUS(WORD VKey) {
+  if(IsWow64()) {
+    return VKUnderlyingLayoutToVKUS_NT_x64(VKey);
+  } else {
+    return VKUnderlyingLayoutToVKUS_NT(VKey);
+  }
+}
+
+BOOL IsNumberPadKey(WORD VKey) {
+	return 
+      (VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL || 
+	    VKey == VK_DIVIDE /* NPSLASH */ || VKey == VK_MULTIPLY /* NPSTAR */ || VKey == VK_SUBTRACT /* NPMINUS */ ||
+	    VKey == VK_ADD /* NPPLUS */ || VKey == 5 /* NPENTER faked */;
+}

--- a/windows/src/engine/mcompilex/mc_syskbd.h
+++ b/windows/src/engine/mcompilex/mc_syskbd.h
@@ -1,0 +1,30 @@
+
+#ifndef _SYSKBD_H
+#define _SYSKBD_H
+
+#define VK_COLON	0xBA
+#define VK_EQUAL	0xBB
+#define VK_COMMA	0xBC
+#define VK_HYPHEN	0xBD
+#define VK_PERIOD	0xBE
+#define	VK_SLASH	0xBF
+#define VK_ACCENT	0xC0
+#define VK_LBRKT	0xDB
+#define VK_BKSLASH	0xDC
+#define VK_RBRKT	0xDD
+#define VK_QUOTE	0xDE
+#define VK_xDF		0xDF
+
+BOOL LoadNewLibrary(PWSTR filename);
+WCHAR CharFromVK(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey);
+WORD VKUSToVKUnderlyingLayout(WORD VKey);
+WORD VKUnderlyingLayoutToVKUS(WORD VKey);
+int GetDeadkeys(WORD DeadKey, WORD *OutputPairs);  // returns array of [USVK, ch] pairs
+
+BOOL IsNumberPadKey(WORD VKey);
+
+extern const UINT USVirtualKeyToScanCode[256];
+extern const UINT ScanCodeToUSVirtualKey[128];
+extern const int VKContextReset[256];
+
+#endif

--- a/windows/src/engine/mcompilex/mc_syskbdnt32.cpp
+++ b/windows/src/engine/mcompilex/mc_syskbdnt32.cpp
@@ -1,0 +1,257 @@
+/*
+  Name:             syskbdnt32
+  Copyright:        Copyright (C) SIL International.
+  Documentation:
+  Description:
+  Create Date:      10 Sep 2008
+
+  Modified Date:    4 May 2010
+  Authors:          mcdurdin
+  Related Files:
+  Dependencies:
+
+  Bugs:
+  Todo:
+  Notes:
+  History:          10 Sep 2008 - mcdurdin - I1635 - Initial version
+                    11 Mar 2009 - mcdurdin - I1894 - Fix threading bugs introduced in I1888
+                    30 Nov 2009 - mcdurdin - I934 - Prep for x64 - change UINT to WORD for vkeys
+                    12 Mar 2010 - mcdurdin - I934 - x64 - Complete
+                    12 Mar 2010 - mcdurdin - I2229 - Remove hints and warnings
+                    04 May 2010 - mcdurdin - I2351 - Robustness - verify _td return value
+*/
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Use Windows NT/2000 keyboard DLLs for mapping virtual keys to characters
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "pch.h"
+#include "../../engine/keyman32/kbd.h"	/* DDK kbdlayout */
+
+
+typedef PKBDTABLES (WINAPI *PKBDLAYERDESCRIPTORFUNC)(VOID);
+
+static HMODULE hKbdLibrary = NULL;
+static PKBDTABLES KbdTables = NULL;
+
+BOOL LoadNewLibrary_NT(PWSTR filename) {
+  if(hKbdLibrary) FreeLibrary(hKbdLibrary);
+
+	hKbdLibrary = LoadLibrary(filename);
+	if(!hKbdLibrary) {
+	  LogError(L"LoadNewLibrary: Exit -- could not load library");
+		return FALSE;
+	}
+
+  PKBDLAYERDESCRIPTORFUNC KbdLayerDescriptorFunc = (PKBDLAYERDESCRIPTORFUNC) GetProcAddress(hKbdLibrary, "KbdLayerDescriptor");
+	if(KbdLayerDescriptorFunc)
+	{
+		KbdTables = (*KbdLayerDescriptorFunc)();
+		if(KbdTables) {
+			return TRUE;
+    }
+	}
+
+	FreeLibrary(hKbdLibrary);
+
+	hKbdLibrary = NULL;
+	KbdTables = NULL;
+
+  LogError(L"LoadNewLibrary: Exit -- failed to find function");
+	return FALSE;
+}
+
+WCHAR CharFromVK_NT(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey) {
+	PVK_TO_WCHARS1 pv;
+	PVK_TO_WCHAR_TABLE pvt;
+	int i;
+
+	/* MCD 02/12/2002: Fix bug with number pad keys when numlock is on */
+
+  if(IsNumberPadKey(VKey)) {
+    return 0;
+  }
+
+	/* Get the appropriate table column for shift state */
+
+	int shift = -1, shiftidx = 0, capslockbit = 0;
+
+	for(PVK_TO_BIT pvtb = KbdTables->pCharModifiers->pVkToBit; pvtb->Vk; pvtb++) {
+		switch(pvtb->Vk) {
+		case VK_MENU:
+			if(ShiftFlags & (LALTFLAG|RALTFLAG)) shiftidx |= pvtb->ModBits; break;
+		case VK_SHIFT:
+			if(ShiftFlags & CAPITALFLAG) capslockbit = pvtb->ModBits;
+			if(ShiftFlags & (K_SHIFTFLAG)) shiftidx |= pvtb->ModBits; break;
+		case VK_CONTROL:
+			if(ShiftFlags & (LCTRLFLAG|RCTRLFLAG)) shiftidx |= pvtb->ModBits; break;
+		}
+  }
+
+	/* If the shift modifier is unused, don't produce a character */
+
+	if(shiftidx > KbdTables->pCharModifiers->wMaxModBits ||
+			KbdTables->pCharModifiers->ModNumber[shiftidx] == 0xF) {
+		return 0;
+	}
+
+	shift = KbdTables->pCharModifiers->ModNumber[shiftidx];
+
+	/* Get the appropriate virtual key */
+
+	for(i = 0, pvt = KbdTables->pVkToWcharTable; pvt->pVkToWchars; i++, pvt++) {
+		for(pv = pvt->pVkToWchars; pv->VirtualKey;) {
+			if(pv->VirtualKey == VKey) {
+				if(shift >= pvt->nModifications) {
+					return 0;
+        }
+
+				/* Check for Caps Lock */
+				if(ShiftFlags & CAPITALFLAG) {
+					if(pv->Attributes & CAPLOK) {
+						/* Invert the state of the SHIFT key */
+						shift = KbdTables->pCharModifiers->ModNumber[shiftidx ^ capslockbit];
+          } else if(pv->Attributes & SGCAPS) {
+						pv++; /* Next keystroke has the appropriate capitalised character */
+          }
+				}
+
+				/* Found the keystroke combination, return the appropriate character (if existing) */
+				switch(pv->wch[shift]) {
+				case WCH_DEAD:
+					pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
+          *PDeadKey = pv->wch[shift];
+					return 0xFFFF; /* Don't queue as WM_KEYDOWN -- don't output either */
+				case WCH_NONE:
+					return 0x0000; /* Not a valid key, queue as WM_KEYDOWN */
+				}
+
+				return (pv->wch[shift] > 31 && pv->wch[shift] != 127) ? pv->wch[shift] : 0; /* Don't generate 'special chars'; I911 - fix ctrl+bksp */
+			}
+			pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
+		}
+	}
+
+	return 0;
+}
+
+
+WORD ModificationToShift_NT(int mod) {
+  WORD ShiftFlags = 0;
+
+  int shiftidx = -1;
+  for(int i = 0; i <= KbdTables->pCharModifiers->wMaxModBits; i++) {
+    if(KbdTables->pCharModifiers->ModNumber[i] == mod) {
+      shiftidx = i;
+      break;
+    }
+  }
+
+  if(shiftidx == -1) return 0xFFFF;
+
+	for(PVK_TO_BIT pvtb = KbdTables->pCharModifiers->pVkToBit; pvtb->Vk; pvtb++) {
+    if(shiftidx & pvtb->ModBits) {
+      switch(pvtb->Vk) {
+        case VK_MENU: ShiftFlags |= RALTFLAG; break;
+        case VK_SHIFT: ShiftFlags |= K_SHIFTFLAG; break;
+        case VK_CONTROL: ShiftFlags |= LCTRLFLAG; break;
+      }
+    }
+  }
+
+  return ShiftFlags;
+}
+
+WORD CharToUSVK_NT(WORD ch, WORD *shift)
+{
+	PVK_TO_WCHARS1 pv;
+	PVK_TO_WCHAR_TABLE pvt;
+	int i, j;
+
+	/* Find the appropriate keyboard tables */
+
+	if(!KbdTables) return 0;				/* Could not load keyboard DLL */
+
+	/* Map the character back to the virtual key */
+
+	for(i = 0, pvt = KbdTables->pVkToWcharTable; pvt->pVkToWchars; i++, pvt++)
+		for(pv = pvt->pVkToWchars; pv->VirtualKey;)
+		{
+			for(j = 0; j < pvt->nModifications; j++)
+				if(pv->wch[j] == ch)
+				{
+					/* Return the new virtual key */
+          *shift = ModificationToShift_NT(j);
+          if(*shift == 0xFFFF) return 0;
+          return pv->VirtualKey;
+				}
+			pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
+		}
+
+	/* Remapping not found */
+	return 0;
+}
+
+
+int GetDeadkeys_NT(WORD DeadKey, WORD *OutputPairs) {
+  WORD *p = OutputPairs, shift;
+	for(int i = 0; KbdTables->pDeadKey[i].dwBoth; i++) {
+		if(HIWORD(KbdTables->pDeadKey[i].dwBoth) == DeadKey) {
+			WORD vk = CharToUSVK_NT(LOWORD(KbdTables->pDeadKey[i].dwBoth), &shift);
+      if(vk != 0) {
+        *p++ = vk;
+        *p++ = shift;
+        *p++ = KbdTables->pDeadKey[i].wchComposed;
+      } else {
+        LogError(L"Warning: complex deadkey not supported.");
+      }
+		}
+	}
+  *p = 0;
+  return (INT_PTR)(p-OutputPairs);
+}
+
+WORD VKUSToVKUnderlyingLayout_NT(WORD VKey) {
+
+	/* Num lock test -- MCD: 02/12/2002 Fix num lock not working bug */
+
+	if((VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL) return VKey;
+
+	/* Find the appropriate keyboard tables */
+
+	if(!KbdTables)				/* Could not load keyboard DLL */
+		return VKey;
+
+  if(VKey > 255) return VKey;
+
+	UINT scan = USVirtualKeyToScanCode[VKey];
+	if(scan == 0 || scan >= KbdTables->bMaxVSCtoVK) return VKey;
+	return KbdTables->pusVSCtoVK[scan];
+}
+
+WORD VKUnderlyingLayoutToVKUS_NT(WORD VKey) {
+
+	/* Num lock test -- MCD: 02/12/2002 Fix num lock not working bug */
+
+	if((VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL) return VKey;
+
+	/* Find the appropriate keyboard tables */
+
+	if(!KbdTables)				/* Could not load keyboard DLL */
+		return VKey;
+
+  UINT scan;
+  for(scan = 1; scan <= KbdTables->bMaxVSCtoVK; scan++) {
+    if(KbdTables->pusVSCtoVK[scan] == VKey) {
+      break;
+    }
+  }
+  if(scan > KbdTables->bMaxVSCtoVK || scan > 127) {
+    // no translation.
+    return VKey;
+  }
+
+  return ScanCodeToUSVirtualKey[scan];
+}

--- a/windows/src/engine/mcompilex/mc_syskbdnt64.cpp
+++ b/windows/src/engine/mcompilex/mc_syskbdnt64.cpp
@@ -1,0 +1,367 @@
+/*
+  Name:             syskbdnt64
+  Copyright:        Copyright (C) SIL International.
+  Documentation:
+  Description:
+  Create Date:      10 Sep 2008
+
+  Modified Date:    4 May 2010
+  Authors:          mcdurdin
+  Related Files:
+  Dependencies:
+
+  Bugs:
+  Todo:
+  Notes:
+  History:          10 Sep 2008 - mcdurdin - I1635 - Initial version
+                    11 Mar 2009 - mcdurdin - I1894 - Fix threading bugs introduced in I1888
+                    30 Nov 2009 - mcdurdin - I934 - Prep for x64 - change UINT to WORD for vkeys
+                    12 Mar 2010 - mcdurdin - I934 - x64 - Complete
+                    12 Mar 2010 - mcdurdin - I2229 - Remove hints and warnings
+                    04 May 2010 - mcdurdin - I2351 - Robustness - verify _td return value
+*/
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Use Windows NT/2000 keyboard DLLs for mapping virtual keys to characters
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "pch.h"
+#include "../../engine/keyman32/kbd.h"	/* DDK kbdlayout */
+
+typedef struct {
+    PVK_TO_BIT pVkToBit;     // Virtual Keys -> Mod bits
+    DWORD     filler;
+    WORD       wMaxModBits;  // max Modification bit combination value
+    BYTE       ModNumber[1];  // Mod bits -> Modification Number
+} MODIFIERS_x64, *PMODIFIERS_x64;
+
+typedef struct _VK_TO_WCHAR_TABLE_x64 {
+    PVK_TO_WCHARS1 pVkToWchars;
+    DWORD filler;
+    BYTE           nModifications;
+    BYTE           cbSize;
+    BYTE filler2[2];
+    DWORD filler3;
+} VK_TO_WCHAR_TABLE_x64, *PVK_TO_WCHAR_TABLE_x64;
+
+/***************************************************************************\
+* VSC_VK     - Associate a Virtual Scancode with a Virtual Key
+*  Vsc - Virtual Scancode
+*  Vk  - Virtual Key | flags
+* Used by VKFromVSC() for scancodes prefixed 0xE0 or 0xE1
+\***************************************************************************/
+typedef struct _VSC_VK_x64 {
+    BYTE Vsc;
+    USHORT Vk;
+} VSC_VK_x64, *PVSC_VK_x64;
+
+/***************************************************************************\
+* VK_VSC     - Associate a Virtual Key with a Virtual Scancode
+*  Vk  - Virtual Key
+*  Vsc - Virtual Scancode
+* Used by MapVirtualKey for Virtual Keys not appearing in ausVK[]
+\***************************************************************************/
+typedef struct _VK_VSC_x64 {
+    BYTE Vk;
+    BYTE Vsc;
+} VK_VSC_x64, *PVK_VSC_x64;
+
+
+typedef struct tagKdbLayer_x64
+{
+    /*
+     * Modifier keys
+     */
+    PMODIFIERS_x64 pCharModifiers;
+    DWORD filler1;
+
+    /*
+     * Characters
+     */
+    VK_TO_WCHAR_TABLE_x64 *pVkToWcharTable;  // ptr to tbl of ptrs to tbl
+    DWORD filler2;
+
+    /*
+     * Diacritics
+     */
+    PDEADKEY pDeadKey;
+    DWORD filler3;
+
+    /*
+     * Names of Keys
+     */
+    VSC_LPWSTR *pKeyNames;
+    DWORD filler4;
+    VSC_LPWSTR *pKeyNamesExt;
+    DWORD filler5;
+    LPWSTR     *pKeyNamesDead;
+    DWORD filler6;
+
+    /*
+     * Scan codes to Virtual Keys
+     */
+    USHORT *pusVSCtoVK;
+    DWORD filler7;
+    BYTE    bMaxVSCtoVK;
+    DWORD filler8;
+    PVSC_VK_x64 pVSCtoVK_E0;  // Scancode has E0 prefix
+    DWORD filler9;
+    PVSC_VK_x64 pVSCtoVK_E1;  // Scancode has E1 prefix
+    DWORD fillerA;
+
+    /*
+     * Locale-specific special processing
+     */
+    DWORD fLocaleFlags;
+    DWORD fillerB;
+} KBDTABLES_x64, *PKBDTABLES_x64;
+
+
+typedef PKBDTABLES_x64 (WINAPI *PKBDLAYERDESCRIPTORFUNC)(VOID);
+
+static HMODULE hKbdLibrary_x64 = NULL;
+static PKBDTABLES_x64 KbdTables_x64 = NULL;
+
+BOOL LoadNewLibrary_NT_x64(PWSTR filename) {
+  if(hKbdLibrary_x64) FreeLibrary(hKbdLibrary_x64);
+
+	hKbdLibrary_x64 = LoadLibrary(filename);
+	if(!hKbdLibrary_x64) {
+	  LogError(L"LoadNewLibrary_x64: Exit -- could not load library");
+		return FALSE;
+	}
+
+  PKBDLAYERDESCRIPTORFUNC KbdLayerDescriptorFunc = (PKBDLAYERDESCRIPTORFUNC) GetProcAddress(hKbdLibrary_x64, "KbdLayerDescriptor");
+	if(KbdLayerDescriptorFunc)
+	{
+		KbdTables_x64 = (*KbdLayerDescriptorFunc)();
+		if(KbdTables_x64) {
+			return TRUE;
+    }
+	}
+
+	FreeLibrary(hKbdLibrary_x64);
+
+	hKbdLibrary_x64 = NULL;
+	KbdTables_x64 = NULL;
+
+  LogError(L"LoadNewLibrary_x64: Exit -- failed to find function");
+	return FALSE;
+}
+
+WCHAR CharFromVK_NT_x64(WORD VKey, UINT ShiftFlags, WCHAR *PDeadKey) {
+	PVK_TO_WCHARS1 pv;
+	PVK_TO_WCHAR_TABLE_x64 pvt;
+	int i;
+
+	/* MCD 02/12/2002: Fix bug with number pad keys when numlock is on */
+
+  if(IsNumberPadKey(VKey)) {
+    return 0;
+  }
+
+	/* Get the appropriate table column for shift state */
+
+	int shift = -1, shiftidx = 0, capslockbit = 0;
+
+	for(PVK_TO_BIT pvtb = KbdTables_x64->pCharModifiers->pVkToBit; pvtb->Vk; pvtb++) {
+		switch(pvtb->Vk) {
+		case VK_MENU:
+			if(ShiftFlags & (LALTFLAG|RALTFLAG)) shiftidx |= pvtb->ModBits; break;
+		case VK_SHIFT:
+			if(ShiftFlags & CAPITALFLAG) capslockbit = pvtb->ModBits;
+			if(ShiftFlags & (K_SHIFTFLAG)) shiftidx |= pvtb->ModBits; break;
+		case VK_CONTROL:
+			if(ShiftFlags & (LCTRLFLAG|RCTRLFLAG)) shiftidx |= pvtb->ModBits; break;
+		}
+  }
+
+	/* If the shift modifier is unused, don't produce a character */
+
+	if(shiftidx > KbdTables_x64->pCharModifiers->wMaxModBits ||
+			KbdTables_x64->pCharModifiers->ModNumber[shiftidx] == 0xF) {
+		return 0;
+	}
+
+	shift = KbdTables_x64->pCharModifiers->ModNumber[shiftidx];
+
+	/* Get the appropriate virtual key */
+
+	for(i = 0, pvt = KbdTables_x64->pVkToWcharTable; pvt->pVkToWchars; i++, pvt++) {
+		for(pv = pvt->pVkToWchars; pv->VirtualKey;) {
+			if(pv->VirtualKey == VKey) {
+				if(shift >= pvt->nModifications) {
+					return 0;
+        }
+
+				/* Check for Caps Lock */
+				if(ShiftFlags & CAPITALFLAG) {
+					if(pv->Attributes & CAPLOK) {
+						/* Invert the state of the SHIFT key */
+						shift = KbdTables_x64->pCharModifiers->ModNumber[shiftidx ^ capslockbit];
+          } else if(pv->Attributes & SGCAPS) {
+						pv++; /* Next keystroke has the appropriate capitalised character */
+          }
+				}
+
+				/* Found the keystroke combination, return the appropriate character (if existing) */
+				switch(pv->wch[shift]) {
+				case WCH_DEAD:
+					pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
+          *PDeadKey = pv->wch[shift];
+					return 0xFFFF; /* Don't queue as WM_KEYDOWN -- don't output either */
+				case WCH_NONE:
+					return 0x0000; /* Not a valid key, queue as WM_KEYDOWN */
+				}
+
+				return (pv->wch[shift] > 31 && pv->wch[shift] != 127) ? pv->wch[shift] : 0; /* Don't generate 'special chars'; I911 - fix ctrl+bksp */
+			}
+			pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
+		}
+	}
+
+	return 0;
+}
+
+
+WORD ModificationToShift_NT_x64(int mod) {
+  WORD ShiftFlags = 0;
+
+  int shiftidx = -1;
+  for(int i = 0; i <= KbdTables_x64->pCharModifiers->wMaxModBits; i++) {
+    if(KbdTables_x64->pCharModifiers->ModNumber[i] == mod) {
+      shiftidx = i;
+      break;
+    }
+  }
+
+  if(shiftidx == -1) return 0xFFFF;
+
+	for(PVK_TO_BIT pvtb = KbdTables_x64->pCharModifiers->pVkToBit; pvtb->Vk; pvtb++) {
+    if(shiftidx & pvtb->ModBits) {
+      switch(pvtb->Vk) {
+        case VK_MENU: ShiftFlags |= RALTFLAG; break;
+        case VK_SHIFT: ShiftFlags |= K_SHIFTFLAG; break;
+        case VK_CONTROL: ShiftFlags |= LCTRLFLAG; break;
+      }
+    }
+  }
+
+  return ShiftFlags;
+}
+
+WORD CharToUSVK_NT_x64(WORD ch, WORD *shift)
+{
+	PVK_TO_WCHARS1 pv;
+	PVK_TO_WCHAR_TABLE_x64 pvt;
+	int i, j;
+
+	/* Find the appropriate keyboard tables */
+
+	if(!KbdTables_x64) return 0;				/* Could not load keyboard DLL */
+
+	/* Map the character back to the virtual key */
+
+	for(i = 0, pvt = KbdTables_x64->pVkToWcharTable; pvt->pVkToWchars; i++, pvt++)
+		for(pv = pvt->pVkToWchars; pv->VirtualKey;)
+		{
+			for(j = 0; j < pvt->nModifications; j++)
+				if(pv->wch[j] == ch)
+				{
+					/* Return the new virtual key */
+          *shift = ModificationToShift_NT_x64(j);
+          if(*shift == 0xFFFF) return 0;
+          return pv->VirtualKey;
+				}
+			pv = (PVK_TO_WCHARS1) ((BYTE *)pv + pvt->cbSize);
+		}
+
+	/* Remapping not found */
+	return 0;
+}
+
+
+int GetDeadkeys_NT_x64(WORD DeadKey, WORD *OutputPairs) {
+  WORD *p = OutputPairs, shift;
+	for(int i = 0; KbdTables_x64->pDeadKey[i].dwBoth; i++) {
+		if(HIWORD(KbdTables_x64->pDeadKey[i].dwBoth) == DeadKey) {
+			WORD vk = CharToUSVK_NT_x64(LOWORD(KbdTables_x64->pDeadKey[i].dwBoth), &shift);
+      if(vk != 0) {
+        *p++ = vk;
+        *p++ = shift;
+        *p++ = KbdTables_x64->pDeadKey[i].wchComposed;
+      } else {
+        LogError(L"Warning: complex deadkey not supported.");
+      }
+		}
+	}
+  *p = 0;
+  return (INT_PTR)(p-OutputPairs);
+}
+
+WORD VKUSToVKUnderlyingLayout_NT_x64(WORD VKey) {
+
+	/* Num lock test -- MCD: 02/12/2002 Fix num lock not working bug */
+
+	if((VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL) return VKey;
+
+	/* Find the appropriate keyboard tables */
+
+	if(!KbdTables_x64)				/* Could not load keyboard DLL */
+		return VKey;
+
+  if(VKey > 255) return VKey;
+
+	UINT scan = USVirtualKeyToScanCode[VKey];
+	if(scan == 0 || scan >= KbdTables_x64->bMaxVSCtoVK) return VKey;
+	return KbdTables_x64->pusVSCtoVK[scan];
+}
+
+WORD VKUnderlyingLayoutToVKUS_NT_x64(WORD VKey) {
+
+	/* Num lock test -- MCD: 02/12/2002 Fix num lock not working bug */
+
+	if((VKey >= VK_NUMPAD0 && VKey <= VK_NUMPAD9) || VKey == VK_DECIMAL) return VKey;
+
+	/* Find the appropriate keyboard tables */
+
+	if(!KbdTables_x64)				/* Could not load keyboard DLL */
+		return VKey;
+
+  UINT scan;
+  for(scan = 1; scan <= KbdTables_x64->bMaxVSCtoVK; scan++) {
+    if(KbdTables_x64->pusVSCtoVK[scan] == VKey) {
+      break;
+    }
+  }
+  if(scan > KbdTables_x64->bMaxVSCtoVK || scan > 127) {
+    // no translation.
+    return VKey;
+  }
+
+  return ScanCodeToUSVirtualKey[scan];
+}
+
+
+typedef BOOL (WINAPI *LPFN_ISWOW64PROCESS) (HANDLE, PBOOL);
+
+LPFN_ISWOW64PROCESS
+fnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(GetModuleHandle(L"kernel32"),"IsWow64Process");
+BOOL fStored = FALSE;
+BOOL bIsWow64 = FALSE;
+
+BOOL IsWow64() {
+  if(fStored) return bIsWow64;
+  bIsWow64 = FALSE;
+
+  if(NULL != fnIsWow64Process) {
+    if(!fnIsWow64Process(GetCurrentProcess(),&bIsWow64)){
+      // handle error
+      return FALSE;
+    }
+  }
+  fStored = TRUE;
+  return bIsWow64;
+}

--- a/windows/src/engine/mcompilex/mc_unicode.cpp
+++ b/windows/src/engine/mcompilex/mc_unicode.cpp
@@ -1,0 +1,304 @@
+#include "pch.h"
+
+const WCHAR cp1252[256] = {
+  /*0x00*/  0x0000,  //Null
+  /*0x01*/  0x0001,  //Start Of Heading
+  /*0x02*/  0x0002,  //Start Of Text
+  /*0x03*/  0x0003,  //End Of Text
+  /*0x04*/  0x0004,  //End Of Transmission
+  /*0x05*/  0x0005,  //Enquiry
+  /*0x06*/  0x0006,  //Acknowledge
+  /*0x07*/  0x0007,  //Bell
+  /*0x08*/  0x0008,  //Backspace
+  /*0x09*/  0x0009,  //Horizontal Tabulation
+  /*0x0a*/  0x000a,  //Line Feed
+  /*0x0b*/  0x000b,  //Vertical Tabulation
+  /*0x0c*/  0x000c,  //Form Feed
+  /*0x0d*/  0x000d,  //Carriage Return
+  /*0x0e*/  0x000e,  //Shift Out
+  /*0x0f*/  0x000f,  //Shift In
+  /*0x10*/  0x0010,  //Data Link Escape
+  /*0x11*/  0x0011,  //Device Control One
+  /*0x12*/  0x0012,  //Device Control Two
+  /*0x13*/  0x0013,  //Device Control Three
+  /*0x14*/  0x0014,  //Device Control Four
+  /*0x15*/  0x0015,  //Negative Acknowledge
+  /*0x16*/  0x0016,  //Synchronous Idle
+  /*0x17*/  0x0017,  //End Of Transmission Block
+  /*0x18*/  0x0018,  //Cancel
+  /*0x19*/  0x0019,  //End Of Medium
+  /*0x1a*/  0x001a,  //Substitute
+  /*0x1b*/  0x001b,  //Escape
+  /*0x1c*/  0x001c,  //File Separator
+  /*0x1d*/  0x001d,  //Group Separator
+  /*0x1e*/  0x001e,  //Record Separator
+  /*0x1f*/  0x001f,  //Unit Separator
+  /*0x20*/  0x0020,  //Space
+  /*0x21*/  0x0021,  //Exclamation Mark
+  /*0x22*/  0x0022,  //Quotation Mark
+  /*0x23*/  0x0023,  //Number Sign
+  /*0x24*/  0x0024,  //Dollar Sign
+  /*0x25*/  0x0025,  //Percent Sign
+  /*0x26*/  0x0026,  //Ampersand
+  /*0x27*/  0x0027,  //Apostrophe
+  /*0x28*/  0x0028,  //Left Parenthesis
+  /*0x29*/  0x0029,  //Right Parenthesis
+  /*0x2a*/  0x002a,  //Asterisk
+  /*0x2b*/  0x002b,  //Plus Sign
+  /*0x2c*/  0x002c,  //Comma
+  /*0x2d*/  0x002d,  //Hyphen-Minus
+  /*0x2e*/  0x002e,  //Full Stop
+  /*0x2f*/  0x002f,  //Solidus
+  /*0x30*/  0x0030,  //Digit Zero
+  /*0x31*/  0x0031,  //Digit One
+  /*0x32*/  0x0032,  //Digit Two
+  /*0x33*/  0x0033,  //Digit Three
+  /*0x34*/  0x0034,  //Digit Four
+  /*0x35*/  0x0035,  //Digit Five
+  /*0x36*/  0x0036,  //Digit Six
+  /*0x37*/  0x0037,  //Digit Seven
+  /*0x38*/  0x0038,  //Digit Eight
+  /*0x39*/  0x0039,  //Digit Nine
+  /*0x3a*/  0x003a,  //Colon
+  /*0x3b*/  0x003b,  //Semicolon
+  /*0x3c*/  0x003c,  //Less-Than Sign
+  /*0x3d*/  0x003d,  //Equals Sign
+  /*0x3e*/  0x003e,  //Greater-Than Sign
+  /*0x3f*/  0x003f,  //Question Mark
+  /*0x40*/  0x0040,  //Commercial At
+  /*0x41*/  0x0041,  //Latin Capital Letter A
+  /*0x42*/  0x0042,  //Latin Capital Letter B
+  /*0x43*/  0x0043,  //Latin Capital Letter C
+  /*0x44*/  0x0044,  //Latin Capital Letter D
+  /*0x45*/  0x0045,  //Latin Capital Letter E
+  /*0x46*/  0x0046,  //Latin Capital Letter F
+  /*0x47*/  0x0047,  //Latin Capital Letter G
+  /*0x48*/  0x0048,  //Latin Capital Letter H
+  /*0x49*/  0x0049,  //Latin Capital Letter I
+  /*0x4a*/  0x004a,  //Latin Capital Letter J
+  /*0x4b*/  0x004b,  //Latin Capital Letter K
+  /*0x4c*/  0x004c,  //Latin Capital Letter L
+  /*0x4d*/  0x004d,  //Latin Capital Letter M
+  /*0x4e*/  0x004e,  //Latin Capital Letter N
+  /*0x4f*/  0x004f,  //Latin Capital Letter O
+  /*0x50*/  0x0050,  //Latin Capital Letter P
+  /*0x51*/  0x0051,  //Latin Capital Letter Q
+  /*0x52*/  0x0052,  //Latin Capital Letter R
+  /*0x53*/  0x0053,  //Latin Capital Letter S
+  /*0x54*/  0x0054,  //Latin Capital Letter T
+  /*0x55*/  0x0055,  //Latin Capital Letter U
+  /*0x56*/  0x0056,  //Latin Capital Letter V
+  /*0x57*/  0x0057,  //Latin Capital Letter W
+  /*0x58*/  0x0058,  //Latin Capital Letter X
+  /*0x59*/  0x0059,  //Latin Capital Letter Y
+  /*0x5a*/  0x005a,  //Latin Capital Letter Z
+  /*0x5b*/  0x005b,  //Left Square Bracket
+  /*0x5c*/  0x005c,  //Reverse Solidus
+  /*0x5d*/  0x005d,  //Right Square Bracket
+  /*0x5e*/  0x005e,  //Circumflex Accent
+  /*0x5f*/  0x005f,  //Low Line
+  /*0x60*/  0x0060,  //Grave Accent
+  /*0x61*/  0x0061,  //Latin Small Letter A
+  /*0x62*/  0x0062,  //Latin Small Letter B
+  /*0x63*/  0x0063,  //Latin Small Letter C
+  /*0x64*/  0x0064,  //Latin Small Letter D
+  /*0x65*/  0x0065,  //Latin Small Letter E
+  /*0x66*/  0x0066,  //Latin Small Letter F
+  /*0x67*/  0x0067,  //Latin Small Letter G
+  /*0x68*/  0x0068,  //Latin Small Letter H
+  /*0x69*/  0x0069,  //Latin Small Letter I
+  /*0x6a*/  0x006a,  //Latin Small Letter J
+  /*0x6b*/  0x006b,  //Latin Small Letter K
+  /*0x6c*/  0x006c,  //Latin Small Letter L
+  /*0x6d*/  0x006d,  //Latin Small Letter M
+  /*0x6e*/  0x006e,  //Latin Small Letter N
+  /*0x6f*/  0x006f,  //Latin Small Letter O
+  /*0x70*/  0x0070,  //Latin Small Letter P
+  /*0x71*/  0x0071,  //Latin Small Letter Q
+  /*0x72*/  0x0072,  //Latin Small Letter R
+  /*0x73*/  0x0073,  //Latin Small Letter S
+  /*0x74*/  0x0074,  //Latin Small Letter T
+  /*0x75*/  0x0075,  //Latin Small Letter U
+  /*0x76*/  0x0076,  //Latin Small Letter V
+  /*0x77*/  0x0077,  //Latin Small Letter W
+  /*0x78*/  0x0078,  //Latin Small Letter X
+  /*0x79*/  0x0079,  //Latin Small Letter Y
+  /*0x7a*/  0x007a,  //Latin Small Letter Z
+  /*0x7b*/  0x007b,  //Left Curly Bracket
+  /*0x7c*/  0x007c,  //Vertical Line
+  /*0x7d*/  0x007d,  //Right Curly Bracket
+  /*0x7e*/  0x007e,  //Tilde
+  /*0x7f*/  0x007f,  //Delete
+  /*0x80*/  0x20ac,  //Euro Sign
+  /*0x81*/  0x0081,
+  /*0x82*/  0x201a,  //Single Low-9 Quotation Mark
+  /*0x83*/  0x0192,  //Latin Small Letter F With Hook
+  /*0x84*/  0x201e,  //Double Low-9 Quotation Mark
+  /*0x85*/  0x2026,  //Horizontal Ellipsis
+  /*0x86*/  0x2020,  //Dagger
+  /*0x87*/  0x2021,  //Double Dagger
+  /*0x88*/  0x02c6,  //Modifier Letter Circumflex Accent
+  /*0x89*/  0x2030,  //Per Mille Sign
+  /*0x8a*/  0x0160,  //Latin Capital Letter S With Caron
+  /*0x8b*/  0x2039,  //Single Left-Pointing Angle Quotation Mark
+  /*0x8c*/  0x0152,  //Latin Capital Ligature Oe
+  /*0x8d*/  0x008d,
+  /*0x8e*/  0x017d,  //Latin Capital Letter Z With Caron
+  /*0x8f*/  0x008f,
+  /*0x90*/  0x0090,
+  /*0x91*/  0x2018,  //Left Single Quotation Mark
+  /*0x92*/  0x2019,  //Right Single Quotation Mark
+  /*0x93*/  0x201c,  //Left Double Quotation Mark
+  /*0x94*/  0x201d,  //Right Double Quotation Mark
+  /*0x95*/  0x2022,  //Bullet
+  /*0x96*/  0x2013,  //En Dash
+  /*0x97*/  0x2014,  //Em Dash
+  /*0x98*/  0x02dc,  //Small Tilde
+  /*0x99*/  0x2122,  //Trade Mark Sign
+  /*0x9a*/  0x0161,  //Latin Small Letter S With Caron
+  /*0x9b*/  0x203a,  //Single Right-Pointing Angle Quotation Mark
+  /*0x9c*/  0x0153,  //Latin Small Ligature Oe
+  /*0x9d*/  0x009d,
+  /*0x9e*/  0x017e,  //Latin Small Letter Z With Caron
+  /*0x9f*/  0x0178,  //Latin Capital Letter Y With Diaeresis
+  /*0xa0*/  0x00a0,  //No-Break Space
+  /*0xa1*/  0x00a1,  //Inverted Exclamation Mark
+  /*0xa2*/  0x00a2,  //Cent Sign
+  /*0xa3*/  0x00a3,  //Pound Sign
+  /*0xa4*/  0x00a4,  //Currency Sign
+  /*0xa5*/  0x00a5,  //Yen Sign
+  /*0xa6*/  0x00a6,  //Broken Bar
+  /*0xa7*/  0x00a7,  //Section Sign
+  /*0xa8*/  0x00a8,  //Diaeresis
+  /*0xa9*/  0x00a9,  //Copyright Sign
+  /*0xaa*/  0x00aa,  //Feminine Ordinal Indicator
+  /*0xab*/  0x00ab,  //Left-Pointing Double Angle Quotation Mark
+  /*0xac*/  0x00ac,  //Not Sign
+  /*0xad*/  0x00ad,  //Soft Hyphen
+  /*0xae*/  0x00ae,  //Registered Sign
+  /*0xaf*/  0x00af,  //Macron
+  /*0xb0*/  0x00b0,  //Degree Sign
+  /*0xb1*/  0x00b1,  //Plus-Minus Sign
+  /*0xb2*/  0x00b2,  //Superscript Two
+  /*0xb3*/  0x00b3,  //Superscript Three
+  /*0xb4*/  0x00b4,  //Acute Accent
+  /*0xb5*/  0x00b5,  //Micro Sign
+  /*0xb6*/  0x00b6,  //Pilcrow Sign
+  /*0xb7*/  0x00b7,  //Middle Dot
+  /*0xb8*/  0x00b8,  //Cedilla
+  /*0xb9*/  0x00b9,  //Superscript One
+  /*0xba*/  0x00ba,  //Masculine Ordinal Indicator
+  /*0xbb*/  0x00bb,  //Right-Pointing Double Angle Quotation Mark
+  /*0xbc*/  0x00bc,  //Vulgar Fraction One Quarter
+  /*0xbd*/  0x00bd,  //Vulgar Fraction One Half
+  /*0xbe*/  0x00be,  //Vulgar Fraction Three Quarters
+  /*0xbf*/  0x00bf,  //Inverted Question Mark
+  /*0xc0*/  0x00c0,  //Latin Capital Letter A With Grave
+  /*0xc1*/  0x00c1,  //Latin Capital Letter A With Acute
+  /*0xc2*/  0x00c2,  //Latin Capital Letter A With Circumflex
+  /*0xc3*/  0x00c3,  //Latin Capital Letter A With Tilde
+  /*0xc4*/  0x00c4,  //Latin Capital Letter A With Diaeresis
+  /*0xc5*/  0x00c5,  //Latin Capital Letter A With Ring Above
+  /*0xc6*/  0x00c6,  //Latin Capital Ligature Ae
+  /*0xc7*/  0x00c7,  //Latin Capital Letter C With Cedilla
+  /*0xc8*/  0x00c8,  //Latin Capital Letter E With Grave
+  /*0xc9*/  0x00c9,  //Latin Capital Letter E With Acute
+  /*0xca*/  0x00ca,  //Latin Capital Letter E With Circumflex
+  /*0xcb*/  0x00cb,  //Latin Capital Letter E With Diaeresis
+  /*0xcc*/  0x00cc,  //Latin Capital Letter I With Grave
+  /*0xcd*/  0x00cd,  //Latin Capital Letter I With Acute
+  /*0xce*/  0x00ce,  //Latin Capital Letter I With Circumflex
+  /*0xcf*/  0x00cf,  //Latin Capital Letter I With Diaeresis
+  /*0xd0*/  0x00d0,  //Latin Capital Letter Eth
+  /*0xd1*/  0x00d1,  //Latin Capital Letter N With Tilde
+  /*0xd2*/  0x00d2,  //Latin Capital Letter O With Grave
+  /*0xd3*/  0x00d3,  //Latin Capital Letter O With Acute
+  /*0xd4*/  0x00d4,  //Latin Capital Letter O With Circumflex
+  /*0xd5*/  0x00d5,  //Latin Capital Letter O With Tilde
+  /*0xd6*/  0x00d6,  //Latin Capital Letter O With Diaeresis
+  /*0xd7*/  0x00d7,  //Multiplication Sign
+  /*0xd8*/  0x00d8,  //Latin Capital Letter O With Stroke
+  /*0xd9*/  0x00d9,  //Latin Capital Letter U With Grave
+  /*0xda*/  0x00da,  //Latin Capital Letter U With Acute
+  /*0xdb*/  0x00db,  //Latin Capital Letter U With Circumflex
+  /*0xdc*/  0x00dc,  //Latin Capital Letter U With Diaeresis
+  /*0xdd*/  0x00dd,  //Latin Capital Letter Y With Acute
+  /*0xde*/  0x00de,  //Latin Capital Letter Thorn
+  /*0xdf*/  0x00df,  //Latin Small Letter Sharp S
+  /*0xe0*/  0x00e0,  //Latin Small Letter A With Grave
+  /*0xe1*/  0x00e1,  //Latin Small Letter A With Acute
+  /*0xe2*/  0x00e2,  //Latin Small Letter A With Circumflex
+  /*0xe3*/  0x00e3,  //Latin Small Letter A With Tilde
+  /*0xe4*/  0x00e4,  //Latin Small Letter A With Diaeresis
+  /*0xe5*/  0x00e5,  //Latin Small Letter A With Ring Above
+  /*0xe6*/  0x00e6,  //Latin Small Ligature Ae
+  /*0xe7*/  0x00e7,  //Latin Small Letter C With Cedilla
+  /*0xe8*/  0x00e8,  //Latin Small Letter E With Grave
+  /*0xe9*/  0x00e9,  //Latin Small Letter E With Acute
+  /*0xea*/  0x00ea,  //Latin Small Letter E With Circumflex
+  /*0xeb*/  0x00eb,  //Latin Small Letter E With Diaeresis
+  /*0xec*/  0x00ec,  //Latin Small Letter I With Grave
+  /*0xed*/  0x00ed,  //Latin Small Letter I With Acute
+  /*0xee*/  0x00ee,  //Latin Small Letter I With Circumflex
+  /*0xef*/  0x00ef,  //Latin Small Letter I With Diaeresis
+  /*0xf0*/  0x00f0,  //Latin Small Letter Eth
+  /*0xf1*/  0x00f1,  //Latin Small Letter N With Tilde
+  /*0xf2*/  0x00f2,  //Latin Small Letter O With Grave
+  /*0xf3*/  0x00f3,  //Latin Small Letter O With Acute
+  /*0xf4*/  0x00f4,  //Latin Small Letter O With Circumflex
+  /*0xf5*/  0x00f5,  //Latin Small Letter O With Tilde
+  /*0xf6*/  0x00f6,  //Latin Small Letter O With Diaeresis
+  /*0xf7*/  0x00f7,  //Division Sign
+  /*0xf8*/  0x00f8,  //Latin Small Letter O With Stroke
+  /*0xf9*/  0x00f9,  //Latin Small Letter U With Grave
+  /*0xfa*/  0x00fa,  //Latin Small Letter U With Acute
+  /*0xfb*/  0x00fb,  //Latin Small Letter U With Circumflex
+  /*0xfc*/  0x00fc,  //Latin Small Letter U With Diaeresis
+  /*0xfd*/  0x00fd,  //Latin Small Letter Y With Acute
+  /*0xfe*/  0x00fe,  //Latin Small Letter Thorn
+  /*0xff*/  0x00ff };//Latin Small Letter Y With Diaeresis
+
+void InplaceUnicode(PWSTR p) {
+  while(p && *p) {
+    if(*p != UC_SENTINEL) {
+      if(*p <= 0xFF) {
+        *p = cp1252[*p];
+      }
+    }
+
+    p = incxstr(p);
+  }
+}
+
+BOOL ConvertKeyboardToUnicode(LPKEYBOARD kbd) {
+  LPGROUP gp;
+  LPSTORE sp;
+  LPKEY kp;
+  DWORD i, j;
+
+  if(kbd->StartGroup[BEGIN_UNICODE] < kbd->cxGroupArray) {
+    // Keyboard is already Unicode
+    return TRUE;
+  }
+
+  for(sp = kbd->dpStoreArray, i = 0; i < kbd->cxStoreArray; i++, sp++) {
+    InplaceUnicode(sp->dpName);
+    InplaceUnicode(sp->dpString);
+  }
+
+  for(gp = kbd->dpGroupArray, i = 0; i < kbd->cxGroupArray; i++, gp++) {
+    for(kp = gp->dpKeyArray, j = 0; j < gp->cxKeyArray; j++, kp++) {
+      InplaceUnicode(kp->dpContext);
+      InplaceUnicode(kp->dpOutput);
+    }
+
+    InplaceUnicode(gp->dpName);
+    InplaceUnicode(gp->dpMatch);
+    InplaceUnicode(gp->dpNoMatch);
+  }
+
+  kbd->StartGroup[BEGIN_UNICODE] = kbd->StartGroup[BEGIN_ANSI];
+  kbd->StartGroup[BEGIN_ANSI] = 0xFFFFFFFF;
+
+  return TRUE;
+}

--- a/windows/src/engine/mcompilex/mcompile.h
+++ b/windows/src/engine/mcompilex/mcompile.h
@@ -1,0 +1,30 @@
+/*
+  Name:             mcompile
+  Copyright:        Copyright (C) 2003-2017 SIL International.
+  Documentation:    
+  Description:      
+  Create Date:      3 Aug 2014
+
+  Modified Date:    3 Aug 2014
+  Authors:          mcdurdin
+  Related Files:    
+  Dependencies:     
+
+  Bugs:             
+  Todo:             
+  Notes:            
+  History:          03 Aug 2014 - mcdurdin - I4353 - V9.0 - mnemonic layout recompiler mixes up deadkey rules
+                    
+*/
+#include <vector>
+
+void LogError(PWSTR message, ...);
+
+
+struct DeadkeyMapping {   // I4353
+  WCHAR deadkey, dkid;
+  UINT shift;
+  WORD vk;
+};
+
+extern std::vector<DeadkeyMapping> FDeadkeys;   // I4353

--- a/windows/src/engine/mcompilex/mcompile.rc
+++ b/windows/src/engine/mcompilex/mcompile.rc
@@ -1,0 +1,2 @@
+#include "version.rc"
+#include "manifest.rc"

--- a/windows/src/engine/mcompilex/mcompile.sln
+++ b/windows/src/engine/mcompilex/mcompile.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mcompile", "mcompile.vcxproj", "{5C22DDDA-CEAD-45F1-96B0-1473111156AA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5C22DDDA-CEAD-45F1-96B0-1473111156AA}.Debug|Win32.ActiveCfg = Debug|Win32
+		{5C22DDDA-CEAD-45F1-96B0-1473111156AA}.Debug|Win32.Build.0 = Debug|Win32
+		{5C22DDDA-CEAD-45F1-96B0-1473111156AA}.Release|Win32.ActiveCfg = Release|Win32
+		{5C22DDDA-CEAD-45F1-96B0-1473111156AA}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/windows/src/engine/mcompilex/mcompilex.cpp
+++ b/windows/src/engine/mcompilex/mcompilex.cpp
@@ -1,0 +1,629 @@
+/*
+  Name:             mcompile
+  Copyright:        Copyright (C) SIL International.
+  Documentation:
+  Description:
+  Create Date:      24 Apr 2014
+
+  Modified Date:    8 Apr 2015
+  Authors:          mcdurdin
+  Related Files:
+  Dependencies:
+
+  Bugs:
+  Todo:
+  Notes:
+  History:          24 Apr 2014 - mcdurdin - I4174 - V9 - mcompile logs should be stored in diag folder
+                    16 Jun 2014 - mcdurdin - I4273 - V9.0 - Convert keyboards to Unicode before installing
+                    23 Jun 2014 - mcdurdin - I4279 - V9.0 - mcompile fails to start when converting keyboard to Unicode
+                    03 Aug 2014 - mcdurdin - I4353 - V9.0 - mnemonic layout recompiler mixes up deadkey rules
+                    03 Aug 2014 - mcdurdin - I4327 - V9.0 - Mnemonic layout compiler follow-up
+                    31 Dec 2014 - mcdurdin - I4549 - V9.0 - Mnemonic layout recompiler does not translate Lctrl Ralt for deadkeys correctly
+                    06 Feb 2015 - mcdurdin - I4552 - V9.0 - Add mnemonic recompile option to ignore deadkeys
+                    08 Apr 2015 - mcdurdin - I4651 - V9.0 - Mnemonic layout recompiler maps AltGr+VK_BKSLASH rather than VK_OEM_102
+*/
+//
+// m-to-p.cpp : Defines the entry point for the console application.
+//
+// Note: this program deliberately leaks memory as it has a very short life cycle and managing the memory allocations
+// for the subcomponents of the compiled keyboard is an unnecessary optimisation. Just so you know.
+//
+
+#include "pch.h"
+#include <vector>
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <varargs.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <codecvt>
+typedef std::basic_ofstream<char16_t> u16ofstream;
+
+typedef wchar_t* PWSTR;
+
+
+BOOL WriteTxtFile(wchar_t* indll, PWSTR kbid, wchar_t* TxtFile);
+BOOL DoConvertTxT(LPKEYBOARD kbd, PWSTR kbid, BOOL bDeadkeyConversion);
+BOOL DoConvert(LPKEYBOARD kbd, PWSTR kbid, BOOL bDeadkeyConversion);
+BOOL SaveKeyboard(LPKEYBOARD kbd, PWSTR filename);
+bool ImportRules(WCHAR* kbid, LPKEYBOARD kp, std::vector<DeadkeyMapping>* FDeadkeys, BOOL bDeadkeyConversion);   // I4353   // I4327
+BOOL ConvertKeyboardToUnicode(LPKEYBOARD kbd);   // I4273
+int run(int argc, wchar_t* argv[]);
+
+std::vector<DeadkeyMapping> FDeadkeys;   // I4353
+
+#define KEYMAN_SENTRY_LOGGER_DESKTOP_ENGINE_MCOMPILE KEYMAN_SENTRY_LOGGER_DESKTOP_ENGINE ".mcompile"
+
+int wmain(int argc, wchar_t* argv[])
+{
+  return keyman_sentry_wmain(false, KEYMAN_SENTRY_LOGGER_DESKTOP_ENGINE_MCOMPILE, argc, argv, run);
+}
+
+int run(int argc, wchar_t* argv[])
+{
+  if (argc < 3 || (argc < 5 && wcscmp(argv[1], L"-u") != 0) || (argc < 4 && wcscmp(argv[1], L"-e") != 0)) {   // I4273
+    printf(
+      "Usage: mcompile -u infile.kmx outfile.kmx\n"
+      "       mcompile -e kbdfile.dll kbid outfile.txt\n"
+      "       mcompile [-d] infile.kmx kbdfile.dll kbid outfile.kmx\n"
+      "  With -u parameter, converts keyboard from ANSI to Unicode\n"
+      "  With -e parameter, converts kbdfile.dll to textfile\n"
+      "  Otherwise, mcompile converts a Keyman mnemonic layout to a\n"
+      "  positional one based on the Windows keyboard\n"
+      "  layout file given by kbdfile.dll\n\n"
+      "  kbid should be a hexadecimal number e.g. 409 for US English\n"
+      "  -d   convert deadkeys to plain keys\n");   // I4552
+
+    return 1;
+  }
+
+  int bDeadkeyConversion = wcscmp(argv[1], L"-d") == 0;   // I4552
+  int n = (bDeadkeyConversion ? 2 : 1);
+
+  wchar_t* infile = argv[n], * indll = argv[n + 1], * kbid = argv[n + 2], * outfile = argv[n + 3];
+
+  if (wcscmp(argv[1], L"-u") == 0) {   // I4273
+    wchar_t* infile = argv[2], * outfile = argv[3];
+
+    LPKEYBOARD kmxfile;
+
+    if (!LoadKeyboard(infile, &kmxfile)) {
+      LogError(L"Failed to load keyboard (%d)", GetLastError());
+      return 3;
+    }
+
+    if (ConvertKeyboardToUnicode(kmxfile)) {
+      SaveKeyboard(kmxfile, outfile);
+    }
+
+    //DeleteReallocatedPointers(kmxfile); :TODO
+    delete[] kmxfile;
+
+    return 0;   // I4279
+  }
+
+  wprintf(L"mcompile%ls \"%ls\" \"%ls\" \"%ls\" \"%ls\"\n", bDeadkeyConversion ? L" -d" : L"", infile, indll, kbid, outfile);   // I4174
+
+  if (wcscmp(argv[1], L"-e") == 0) {
+    if (WriteTxtFile(indll, kbid, outfile))
+      wprintf(L"\n********************************************************\n******* Txt-file has been written successfully *********\n********************************************************\n");   // I4174
+    return 0;
+  }
+  // 1. Load the keyman keyboard file
+
+  // 2. For each key on the system layout, determine its output character and perform a
+  //    1-1 replacement on the keyman keyboard of that character with the base VK + shift
+  //    state.  This fixup will transform the char to a vk, which will avoid any issues
+  //    with the key.
+  //
+  //  --> deadkeys we will attack after the POC
+  //
+  //  For each deadkey, we need to determine its possible outputs.  Then we generate a VK
+  //  rule for that deadkey, e.g. [K_LBRKT] > dk(c101)
+  //
+  //  Next, update each rule that references the output from that deadkey to add an extra
+  //  context deadkey at the end of the context match, e.g. 'a' dk(c101) + [K_SPACE] > 'b'.
+  //  This will require a memory layout change for the .kmx file, plus fixups on the
+  //  context+output index offsets
+  //
+  //  --> virtual character keys
+  //
+  //  [CTRL ' '] : we look at the character, and replace it in the same way, but merely
+  //  switch the shift state from the VIRTUALCHARKEY to VIRTUALKEY, without changing any
+  //  other properties of the key.
+  //
+
+  // 3. Write the new keyman keyboard file
+
+  if (!LoadNewLibrary(indll)) {
+    LogError(L"Failed to load keyboard DLL (%d)", GetLastError());
+    return 2;
+  }
+
+  LPKEYBOARD kmxfile;
+
+  if (!LoadKeyboard(infile, &kmxfile)) {
+    LogError(L"Failed to load keyboard (%d)", GetLastError());
+    return 3;
+  }
+  /*
+  if (DoConvert(kmxfile, kbid, bDeadkeyConversion)) {   // I4552 
+    SaveKeyboard(kmxfile, outfile);
+  }
+  */
+
+ 
+  if (DoConvertTxT(kmxfile, kbid, bDeadkeyConversion)) {   // I4552
+    SaveKeyboard(kmxfile, outfile);
+  }/**/
+  //DeleteReallocatedPointers(kmxfile); :TODO
+  delete kmxfile;
+
+  return 0;
+}
+
+
+//
+// Map of all US English virtual key codes that we can translate
+//
+const WORD VKMap[] = {
+  'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
+  '0','1','2','3','4','5','6','7','8','9',
+  VK_SPACE,
+  VK_ACCENT, VK_HYPHEN, VK_EQUAL,
+  VK_LBRKT, VK_RBRKT, VK_BKSLASH,
+  VK_COLON, VK_QUOTE,
+  VK_COMMA, VK_PERIOD, VK_SLASH,
+  VK_xDF, VK_OEM_102,
+  0
+};
+
+
+//
+// Map of all shift states that we will work with
+//
+const UINT VKShiftState[] = { 0, K_SHIFTFLAG, LCTRLFLAG | RALTFLAG, K_SHIFTFLAG | LCTRLFLAG | RALTFLAG, 0xFFFF };
+
+//
+// TranslateKey
+//
+// For each key rule on the keyboard, remap its key to the
+// correct shift state and key.  Adjust the LCTRL+RALT -> RALT if necessary
+//
+void TranslateKey(LPKEY key, WORD vk, UINT shift, WCHAR ch) {
+
+  // The weird LCTRL+RALT is Windows' way of mapping the AltGr key.
+  // We store that as just RALT, and use the option "Simulate RAlt with Ctrl+Alt"
+  // to provide an alternate..
+  if ((shift & (LCTRLFLAG | RALTFLAG)) == (LCTRLFLAG | RALTFLAG))
+    shift &= ~LCTRLFLAG;
+
+  if (key->ShiftFlags == 0 && key->Key == ch) {
+    // Key is a mnemonic key with no shift state defined.
+    // Remap the key according to the character on the key cap.
+    //LogError(L"Converted mnemonic rule on line %d, + '%c' TO + [%x K_%d]", key->Line, key->Key, shift, vk);
+    key->ShiftFlags = ISVIRTUALKEY | shift;
+    key->Key = vk;
+  }
+  else if (key->ShiftFlags & VIRTUALCHARKEY && key->Key == ch) {
+    // Key is a virtual character key with a hard-coded shift state.
+    // Do not remap the shift state, just move the key.
+    // This will not result in 100% wonderful mappings as there could
+    // be overlap, depending on how keys are arranged on the target layout.
+    // But that is up to the designer.
+    //LogError(L"Converted mnemonic virtual char key rule on line %d, + [%x '%c'] TO + [%x K_%d]", key->Line, key->ShiftFlags, key->Key, key->ShiftFlags & ~VIRTUALCHARKEY, vk);
+    key->ShiftFlags &= ~VIRTUALCHARKEY;
+    key->Key = vk;
+  }
+}
+
+void TranslateGroup(LPGROUP group, WORD vk, UINT shift, WCHAR ch) {
+  for (unsigned int i = 0; i < group->cxKeyArray; i++) {
+    TranslateKey(&group->dpKeyArray[i], vk, shift, ch);
+  }
+}
+
+void TranslateKeyboard(LPKEYBOARD kbd, WORD vk, UINT shift, WCHAR ch) {
+  for (unsigned int i = 0; i < kbd->cxGroupArray; i++) {
+    if (kbd->dpGroupArray[i].fUsingKeys) {
+      TranslateGroup(&kbd->dpGroupArray[i], vk, shift, ch);
+    }
+  }
+}
+
+void ReportUnconvertedKeyRule(LPKEY key) {
+  if (key->ShiftFlags == 0) {
+    LogError(L"Did not find a match for mnemonic rule on line %d, + '%c' > ...", key->Line, key->Key);
+  }
+  else if (key->ShiftFlags & VIRTUALCHARKEY) {
+    LogError(L"Did not find a match for mnemonic virtual character key rule on line %d, + [%x '%c'] > ...", key->Line, key->ShiftFlags, key->Key);
+  }
+}
+
+void ReportUnconvertedGroupRules(LPGROUP group) {
+  for (unsigned int i = 0; i < group->cxKeyArray; i++) {
+    ReportUnconvertedKeyRule(&group->dpKeyArray[i]);
+  }
+}
+
+void ReportUnconvertedKeyboardRules(LPKEYBOARD kbd) {
+  for (unsigned int i = 0; i < kbd->cxGroupArray; i++) {
+    if (kbd->dpGroupArray[i].fUsingKeys) {
+      ReportUnconvertedGroupRules(&kbd->dpGroupArray[i]);
+    }
+  }
+}
+
+void TranslateDeadkeyKey(LPKEY key, WCHAR deadkey, WORD vk, UINT shift, WORD ch) {
+  if ((key->ShiftFlags == 0 || key->ShiftFlags & VIRTUALCHARKEY) && key->Key == ch) {
+
+    // The weird LCTRL+RALT is Windows' way of mapping the AltGr key.
+    // We store that as just RALT, and use the option "Simulate RAlt with Ctrl+Alt"
+    // to provide an alternate..
+    if ((shift & (LCTRLFLAG | RALTFLAG)) == (LCTRLFLAG | RALTFLAG))   // I4327
+      shift &= ~LCTRLFLAG;
+
+    if (key->ShiftFlags == 0) {
+      //LogError("Converted mnemonic rule on line %d, + '%c' TO dk(%d) + [%x K_%d]", key->Line, key->Key, deadkey, shift, vk);
+      key->ShiftFlags = ISVIRTUALKEY | shift;
+    }
+    else {
+      //LogError("Converted mnemonic virtual char key rule on line %d, + [%x '%c'] TO dk(%d) + [%x K_%d]", key->Line, key->ShiftFlags, key->Key, deadkey, key->ShiftFlags & ~VIRTUALCHARKEY, vk);
+      key->ShiftFlags &= ~VIRTUALCHARKEY;
+    }
+
+    int len = wcslen(key->dpContext);
+    PWSTR context = new WCHAR[len + 4];
+    memcpy(context, key->dpContext, len * sizeof(WCHAR));
+    context[len] = UC_SENTINEL;
+    context[len + 1] = CODE_DEADKEY;
+    context[len + 2] = deadkey;
+    context[len + 3] = 0;
+    key->dpContext = context;
+    key->Key = vk;
+  }
+}
+
+void TranslateDeadkeyGroup(LPGROUP group, WCHAR deadkey, WORD vk, UINT shift, WORD ch) {
+  for (unsigned int i = 0; i < group->cxKeyArray; i++) {
+    TranslateDeadkeyKey(&group->dpKeyArray[i], deadkey, vk, shift, ch);
+  }
+}
+
+void TranslateDeadkeyKeyboard(LPKEYBOARD kbd, WCHAR deadkey, WORD vk, UINT shift, WORD ch) {
+  for (unsigned int i = 0; i < kbd->cxGroupArray; i++) {
+    if (kbd->dpGroupArray[i].fUsingKeys) {
+      TranslateDeadkeyGroup(&kbd->dpGroupArray[i], deadkey, vk, shift, ch);
+    }
+  }
+}
+
+void AddDeadkeyRule(LPKEYBOARD kbd, WCHAR deadkey, WORD vk, UINT shift) {
+  // The weird LCTRL+RALT is Windows' way of mapping the AltGr key.
+  // We store that as just RALT, and use the option "Simulate RAlt with Ctrl+Alt"
+  // to provide an alternate..
+  if ((shift & (LCTRLFLAG | RALTFLAG)) == (LCTRLFLAG | RALTFLAG))   // I4549
+    shift &= ~LCTRLFLAG;
+
+  // If the first group is not a matching-keys group, then we need to add into
+  // each subgroup, otherwise just the match group
+  for (unsigned int i = 0; i < kbd->cxGroupArray; i++) {
+    if (kbd->dpGroupArray[i].fUsingKeys) {
+      LPKEY keys = new KEY[kbd->dpGroupArray[i].cxKeyArray + 1];
+      memcpy(keys + 1, kbd->dpGroupArray[i].dpKeyArray, kbd->dpGroupArray[i].cxKeyArray * sizeof(KEY));
+      keys[0].dpContext = new WCHAR[1];
+      keys[0].dpContext[0] = 0;
+      keys[0].dpOutput = new WCHAR[4]; // UC_SENTINEL, CODE_DEADKEY, deadkey_value, 0
+      keys[0].dpOutput[0] = UC_SENTINEL;
+      keys[0].dpOutput[1] = CODE_DEADKEY;
+      keys[0].dpOutput[2] = deadkey; // TODO: translate to unique index
+      keys[0].dpOutput[3] = 0;
+      keys[0].Key = vk;
+      keys[0].Line = 0;
+      keys[0].ShiftFlags = shift | ISVIRTUALKEY;
+      kbd->dpGroupArray[i].dpKeyArray = keys;
+      kbd->dpGroupArray[i].cxKeyArray++;
+      //LogError("Add deadkey rule:  + [%d K_%d] > dk(%d)", shift, vk, deadkey);
+      if (i == kbd->StartGroup[1]) break;  // If this is the initial group, that's all we need to do.
+    }
+  }
+}
+
+WCHAR ScanXStringForMaxDeadkeyID(LPWSTR str) {
+  WCHAR dkid = 0;
+  while (str && *str) {
+    if (*str == UC_SENTINEL) {
+      switch (*(str + 1)) {
+      case CODE_DEADKEY:
+        dkid = max(dkid, *(str + 2));
+      }
+    }
+    str = incxstr(str);
+  }
+  return dkid;
+}
+
+struct dkidmap {
+  WCHAR src_deadkey, dst_deadkey;
+};
+
+WCHAR GetUniqueDeadkeyID(LPKEYBOARD kbd, WCHAR deadkey) {
+  LPGROUP gp;
+  LPKEY kp;
+  LPSTORE sp;
+  UINT i, j;
+  WCHAR dkid = 0;
+  static WCHAR s_next_dkid = 0;
+  static dkidmap* s_dkids = NULL;
+  static int s_ndkids = 0;
+
+  if (!kbd) {
+    if (s_dkids) {
+      delete s_dkids;
+    }
+    s_dkids = NULL;
+    s_ndkids = 0;
+    s_next_dkid = 0;
+    return 0;
+  }
+
+  for (int i = 0; i < s_ndkids; i++) {
+    if (s_dkids[i].src_deadkey == deadkey) {
+      return s_dkids[i].dst_deadkey;
+    }
+  }
+
+  if (s_next_dkid != 0) {
+    s_dkids = (dkidmap*)realloc(s_dkids, sizeof(dkidmap) * (s_ndkids + 1));
+    s_dkids[s_ndkids].src_deadkey = deadkey;
+    return s_dkids[s_ndkids++].dst_deadkey = ++s_next_dkid;
+  }
+
+  for (i = 0, gp = kbd->dpGroupArray; i < kbd->cxGroupArray; i++, gp++) {
+    for (j = 0, kp = gp->dpKeyArray; j < gp->cxKeyArray; j++, kp++) {
+      dkid = max(dkid, ScanXStringForMaxDeadkeyID(kp->dpContext));
+      dkid = max(dkid, ScanXStringForMaxDeadkeyID(kp->dpOutput));
+    }
+    dkid = max(dkid, ScanXStringForMaxDeadkeyID(gp->dpMatch));
+    dkid = max(dkid, ScanXStringForMaxDeadkeyID(gp->dpNoMatch));
+  }
+
+  for (i = 0, sp = kbd->dpStoreArray; i < kbd->cxStoreArray; i++, sp++) {
+    dkid = max(dkid, ScanXStringForMaxDeadkeyID(sp->dpString));
+  }
+
+  s_dkids = (dkidmap*)realloc(s_dkids, sizeof(dkidmap) * (s_ndkids + 1));
+  s_dkids[s_ndkids].src_deadkey = deadkey;
+  return s_dkids[s_ndkids++].dst_deadkey = s_next_dkid = ++dkid;
+}
+
+
+void ConvertDeadkey(LPKEYBOARD kbd, WORD vk, UINT shift, WCHAR deadkey) {
+  WORD deadkeys[512], * pdk;
+
+  // Lookup the deadkey table for the deadkey in the physical keyboard
+  // Then for each character, go through and map it through
+
+  WCHAR dkid = GetUniqueDeadkeyID(kbd, deadkey);
+
+  // Add the deadkey to the mapping table for use in the import rules phase
+  DeadkeyMapping deadkeyMapping = { deadkey, dkid, shift, vk };   // I4353
+  FDeadkeys.push_back(deadkeyMapping); //dkid, vk, shift);   // I4353
+
+  AddDeadkeyRule(kbd, dkid, vk, shift);
+
+  GetDeadkeys(deadkey, pdk = deadkeys);  // returns array of [usvk, ch_out] pairs
+  while (*pdk) {
+    // Look up the ch
+    UINT vkUnderlying = VKUnderlyingLayoutToVKUS(*pdk);
+    TranslateDeadkeyKeyboard(kbd, dkid, vkUnderlying, *(pdk + 1), *(pdk + 2));
+    pdk += 3;
+  }
+}
+
+BOOL SetKeyboardToPositional(LPKEYBOARD kbd) {
+  LPSTORE sp;
+  UINT i;
+  for (i = 0, sp = kbd->dpStoreArray; i < kbd->cxStoreArray; i++, sp++) {
+    if (sp->dwSystemID == TSS_MNEMONIC) {
+      if (!sp->dpString) {
+        LogError(L"Invalid &mnemoniclayout system store");
+        return FALSE;
+      }
+      if (wcscmp(sp->dpString, L"1") != 0) {
+        LogError(L"Keyboard is not a mnemonic layout keyboard");
+        return FALSE;
+      }
+      *sp->dpString = '0';
+      return TRUE;
+    }
+  }
+
+  LogError(L"Keyboard is not a mnemonic layout keyboard");
+  return FALSE;
+}
+
+
+BOOL WriteTxtFile(wchar_t* indll, PWSTR kbid, wchar_t* TxtFileName) {   // I4552
+  // Go through each of the shift states - base, shift, ctrl+alt, ctrl+alt+shift, [caps vs ncaps?] and print characters for vkUnderlying, ch, VKMap[i]
+
+  if (!LoadNewLibrary(indll)) {
+    LogError(L"Failed to load keyboard DLL (%d)", GetLastError());
+    return 2;}
+
+  WCHAR DeadKey;
+  std::ofstream TxTFile(TxtFileName);
+  std::cout << "\n\n";
+
+  for (int j = 0; VKShiftState[j] != 0xFFFF; j++) {   // I4651
+    // Go through each possible key on the keyboard
+    TxTFile << "\n";
+    for (int i = 0; VKMap[i]; i++) {   // I4651
+
+      UINT vkUnderlying = VKUSToVKUnderlyingLayout(VKMap[i]);
+      WCHAR ch = CharFromVK(vkUnderlying, VKShiftState[j], &DeadKey);
+
+      //print to txt-file+console
+      TxTFile << VKMap[i] << "\t" << ch;
+      (VKMap[i] == vkUnderlying) ? TxTFile << "\n" : TxTFile << "  *** \n";
+      /*
+      std::cout << "i: " << i << "\tVKMap[" << i << "] =\t" << VKMap[i] << "(" << (char)VKMap[i] << ")\t..scan.. " << " vkUnderlying: " << vkUnderlying << "(" << (char)vkUnderlying << ")\tVKShiftState: " << VKShiftState[j] << "   ch: " << (int)ch << "\t(" << (char)ch << ")";
+      (VKMap[i] == vkUnderlying) ? std::cout << "\n" : std::cout << "  *** \n";*/
+    }
+  }
+
+  TxTFile.close();
+
+  FILE* fp1 = _wfopen(TxtFileName, L"rt");
+  fseek(fp1, 0, SEEK_END);
+  auto sz1 = ftell(fp1);
+  fclose(fp1);
+  return (sz1 > 0);
+}
+
+BOOL DoConvertTxT(LPKEYBOARD kbd, LPWSTR kbid, BOOL bDeadkeyConversion) {   // I4552
+  WCHAR DeadKey;
+
+  if (!SetKeyboardToPositional(kbd)) return FALSE;
+
+  // Go through each of the shift states - base, shift, ctrl+alt, ctrl+alt+shift, [caps vs ncaps?]
+  // Currently, we go in this order so the 102nd key works. But this is not ideal for keyboards without 102nd key:   // I4651
+  // it catches only the first key that matches a given rule, but multiple keys may match that rule. This is particularly
+  // evident for the 102nd key on UK, for example, where \ can be generated with VK_OEM_102 or AltGr+VK_QUOTE.
+  // For now, we get the least shifted version, which is hopefully adequate.
+
+  std::fstream newfile;
+  newfile.open("C:/MCOMPILE____/Dll_as_Text_small.txt", std::fstream::in); //open a file to perform read operation using file object
+
+  if (newfile.is_open()) {
+    std::string tp;
+    std::string first;
+    std::string second;
+    int firstint;
+    int secondint;
+
+    while (getline(newfile, tp)) { //read data from file txt and put it into string.tp
+      std::cout << tp << " ....>>... "; //print the data of the string
+      first = tp.substr(0, tp.find("\t")); //find name and nuber using this number
+      second = tp.substr(tp.find("\t") + 1);
+      firstint = atoi(first.c_str());
+      secondint = atoi(second.c_str());
+      WCHAR TT = secondint;
+
+      WCHAR ch = secondint;
+      std::cout << secondint << "....>.. "<< ch <<"\n"; //print the ch that will be processed further
+      /*
+      if (bDeadkeyConversion) {   // I4552
+        if (ch == 0xFFFF) {
+          ch = DeadKey;
+        }
+      }
+      */
+      switch (ch) {
+      case 0x0000: break;
+        //case 0xFFFF: ConvertDeadkey(kbd, ch, 0, DeadKey); break;
+      default:     TranslateKeyboard(kbd, ch, 0, ch);
+      }
+      //std::cout << "first: " << first << " second: " << second <<"cch1_"<< cch1<<"\n";
+      int zzz = 999;
+    }
+    newfile.close(); //close the file object.
+  }
+
+
+
+
+  for (int j = 0; VKShiftState[j] != 0xFFFF; j++) {   // I4651
+    // Go through each possible key on the keyboard
+    for (int i = 0; VKMap[i]; i++) {   // I4651
+      /*
+      UINT vkUnderlying = VKUSToVKUnderlyingLayout(VKMap[i]);
+      WCHAR ch = CharFromVK(vkUnderlying, VKShiftState[j], &DeadKey);
+
+      //LogError("--- VK_%d -> VK_%d [%c] dk=%d", VKMap[i], vkUnderlying, ch == 0 ? 32 : ch, DeadKey);
+
+
+
+      if (bDeadkeyConversion) {   // I4552
+        if (ch == 0xFFFF) {
+          ch = DeadKey;
+        }
+      }
+
+      switch (ch) {
+      case 0x0000: break;
+      case 0xFFFF: ConvertDeadkey(kbd, VKMap[i], VKShiftState[j], DeadKey); break;
+      default:     TranslateKeyboard(kbd, VKMap[i], VKShiftState[j], ch);
+      }
+      */
+      //
+    }
+  }
+
+  ReportUnconvertedKeyboardRules(kbd);
+
+  if (!ImportRules(kbid, kbd, &FDeadkeys, bDeadkeyConversion)) {   // I4353   // I4552
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+
+
+BOOL DoConvert(LPKEYBOARD kbd, LPWSTR kbid, BOOL bDeadkeyConversion) {   // I4552
+  WCHAR DeadKey;
+
+  if (!SetKeyboardToPositional(kbd)) return FALSE;
+
+  // Go through each of the shift states - base, shift, ctrl+alt, ctrl+alt+shift, [caps vs ncaps?]
+  // Currently, we go in this order so the 102nd key works. But this is not ideal for keyboards without 102nd key:   // I4651
+  // it catches only the first key that matches a given rule, but multiple keys may match that rule. This is particularly
+  // evident for the 102nd key on UK, for example, where \ can be generated with VK_OEM_102 or AltGr+VK_QUOTE.
+  // For now, we get the least shifted version, which is hopefully adequate.
+
+  for (int j = 0; VKShiftState[j] != 0xFFFF; j++) {   // I4651
+    // Go through each possible key on the keyboard
+    for (int i = 0; VKMap[i]; i++) {   // I4651
+      UINT vkUnderlying = VKUSToVKUnderlyingLayout(VKMap[i]);
+
+      WCHAR ch = CharFromVK(vkUnderlying, VKShiftState[j], &DeadKey);
+
+      //LogError("--- VK_%d -> VK_%d [%c] dk=%d", VKMap[i], vkUnderlying, ch == 0 ? 32 : ch, DeadKey);
+
+      if (bDeadkeyConversion) {   // I4552
+        if (ch == 0xFFFF) {
+          ch = DeadKey;
+        }
+      }
+
+      switch (ch) {
+      case 0x0000: break;
+      case 0xFFFF: ConvertDeadkey(kbd, VKMap[i], VKShiftState[j], DeadKey); break;
+      default:     TranslateKeyboard(kbd, VKMap[i], VKShiftState[j], ch);
+      }
+
+      //
+    }
+  }
+
+  ReportUnconvertedKeyboardRules(kbd);
+
+  if (!ImportRules(kbid, kbd, &FDeadkeys, bDeadkeyConversion)) {   // I4353   // I4552
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+void LogError(PWSTR fmt, ...) {
+  WCHAR fmtbuf[256];
+
+  va_list vars;
+  va_start(vars, fmt);
+  _vsnwprintf_s(fmtbuf, _countof(fmtbuf), _TRUNCATE, fmt, vars);  // I2248   // I3547
+  fmtbuf[255] = 0;
+  _putws(fmtbuf);
+}

--- a/windows/src/engine/mcompilex/pch.cpp
+++ b/windows/src/engine/mcompilex/pch.cpp
@@ -1,0 +1,8 @@
+// pch.cpp : source file that includes just the standard includes
+// m-to-p.pch will be the pre-compiled header
+// pch.obj will contain the pre-compiled type information
+
+#include "pch.h"
+
+// TODO: reference any additional headers you need in PC.H
+// and not in this file

--- a/windows/src/engine/mcompilex/pch.h
+++ b/windows/src/engine/mcompilex/pch.h
@@ -1,0 +1,17 @@
+// pch.h : include file for standard system include files,
+// or project specific include files that are used frequently, but
+// are changed infrequently
+//
+
+#pragma once
+
+#include "targetver.h"
+
+#include <Windows.h>
+#include "mcompile.h"
+#include "mc_kmxfile.h"
+#include "mc_syskbd.h"
+#include "../../../../common/windows/cpp/include/crc32.h"
+#include "../../../../common/windows/cpp/include/legacy_kmx_file.h"
+#include "../../../../common/windows/cpp/include/xstring.h"
+#include "../../../../common/windows/cpp/include/keymansentry.h"

--- a/windows/src/engine/mcompilex/targetver.h
+++ b/windows/src/engine/mcompilex/targetver.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>

--- a/windows/src/engine/mcompilex/version.rc
+++ b/windows/src/engine/mcompilex/version.rc
@@ -1,0 +1,32 @@
+#include "../../../../common/windows/cpp/include/keymanversion.h"
+
+1 VERSIONINFO
+  FILEVERSION		KV_FILEVERSION
+  PRODUCTVERSION	KV_PRODUCTVERSION
+  FILEFLAGSMASK		0x3fL
+  FILEFLAGS		0x0L
+  FILEOS		0x4L
+  FILETYPE		0x2L
+  FILESUBTYPE		0x0L
+  BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+      BLOCK "0C0904E4"
+      BEGIN
+        VALUE "CompanyName", KV_COMPANY_NAME
+        VALUE "FileDescription", "Keyman Engine Mnemonic Keyboard Recompiler\0"
+        VALUE "FileVersion", KV_VERSION_STRING
+        VALUE "InternalName", "MCOMPILE\0"
+        VALUE "LegalCopyright", KV_LEGAL_COPYRIGHT
+        VALUE "LegalTrademarks", KV_LEGAL_TRADEMARKS
+        VALUE "OriginalFilename", "MCOMPILE.EXE\0"
+        VALUE "ProductName", "Keyman Engine\0"
+        VALUE "ProductVersion", KV_VERSION_STRING
+        VALUE "Comments", "\0"
+      END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+      VALUE "Translation", 0xc09, 1252
+    END
+  END


### PR DESCRIPTION
fixes #7068

This is a proposal to decouple the Windows system keyboard data from the kbdxx.dll file so that we can use mcompile on other platforms as well. The idea would be to have a program to query the set of Windows kbdxx DLLs that we are interested in, and write each Windows keyboard's data to a datafile. Then mcompile would load this datafile rather than the Windows DLL when running the mcompile process.

@keymanapp-test-bot skip 