### PR TITLE
fix(windows): use right instead of left alignment for popup buttons

### DIFF
--- a/windows/src/desktop/kmshell/xml/config.css
+++ b/windows/src/desktop/kmshell/xml/config.css
@@ -1199,8 +1199,8 @@ th
 .list_languages_add {
   padding-top: 10px;
   position: fixed;
-  top: 45%;
-  left: 49%;
+  top: 223px; /* Have to use fixed position can't use flex or grid inside a fixed child */
+  right: 281px;
 }
 
 .modify .keyboard_language {


### PR DESCRIPTION
Fixes: #8525 
The fixed layout of the popup means we need to use a specified starting point for the child div that contains the `add language` and `close` button. However, it needs to be right justified instead of left justified to allow for the variable-sized buttons. The buttons will be longer based on the locale text chosen.


# User Testing

# TEST_BUTTONS_ALIGN

1. Install Windows build from this PR
2. Open Keyman Configuration dialog.
3. Install any Keyboard. (eg., Khmer Angkor)
4. Change the UI language into Deutsch (German).
5. In the Keyboard Layouts tab, Click Add/remove language button.
6. Verify that the `Add Language` and `Close` Button now align inside the pop-up box.

7. Change the UI to other Languages and verify steps 5-6. for those languages.

