### PR TITLE
fix(mac): fix corrupt installer

### DIFF
--- a/ios/samples/build_common.sh
+++ b/ios/samples/build_common.sh
@@ -129,7 +129,7 @@ if [ $DO_UPDATE = true ]; then
     fi
 
     # Copy resources.
-    cp -Rf "$KEYMAN_ENGINE_FRAMEWORK_SRC" "$KEYMAN_ENGINE_FRAMEWORK_DST"
+    /bin/cp -Rf "$KEYMAN_ENGINE_FRAMEWORK_SRC" "$KEYMAN_ENGINE_FRAMEWORK_DST"
 fi
 
 if [ $CODE_SIGN = true ]; then

--- a/mac/Keyman4MacIM/localdeploy.sh
+++ b/mac/Keyman4MacIM/localdeploy.sh
@@ -42,7 +42,7 @@ if [[ -d "$KM4MIM_INSTALL_PATH" ]]; then
     rm -Rf "$KM4MIM_INSTALL_PATH"
 fi
 echo "Copying $KM4MIM_APP_PATH to $IMLIBRARY_PATH..."
-cp -R "$KM4MIM_APP_PATH" "$IMLIBRARY_PATH"
+/bin/cp -R "$KM4MIM_APP_PATH" "$IMLIBRARY_PATH"
 
 if [[ -d "$KM4MIM_INSTALL_PATH" ]]; then
     exit 0

--- a/mac/Keyman4MacIM/make-km-dmg.sh
+++ b/mac/Keyman4MacIM/make-km-dmg.sh
@@ -174,7 +174,7 @@ displayInfo "Copying files from \"$SOURCE_KM_APP\"..."
 find "$DEST_KM_APP" -mindepth 1 -maxdepth 1
 echo "---------"
 find "$DEST_KM_APP" -mindepth 1 -maxdepth 1 -print0 | xargs -0 rm -rf
-cp -fR "$SOURCE_KM_APP/" "$DEST_KM_APP"
+cp -fR "$SOURCE_KM_APP/"* "$DEST_KM_APP/"
 
 echo "---- Listing info in /Volumes/Keyman/ ----"
 echo "DEST_KM_APP=$DEST_KM_APP"

--- a/mac/Keyman4MacIM/make-km-dmg.sh
+++ b/mac/Keyman4MacIM/make-km-dmg.sh
@@ -174,7 +174,7 @@ displayInfo "Copying files from \"$SOURCE_KM_APP\"..."
 find "$DEST_KM_APP" -mindepth 1 -maxdepth 1
 echo "---------"
 find "$DEST_KM_APP" -mindepth 1 -maxdepth 1 -print0 | xargs -0 rm -rf
-cp -fR "$SOURCE_KM_APP/"* "$DEST_KM_APP/"
+/bin/cp -fR "$SOURCE_KM_APP/" "$DEST_KM_APP"
 
 echo "---- Listing info in /Volumes/Keyman/ ----"
 echo "DEST_KM_APP=$DEST_KM_APP"

--- a/mac/setup/build.sh
+++ b/mac/setup/build.sh
@@ -62,10 +62,10 @@ mkdir -p "$TARGETPATH"
 rm -rf "$TARGETAPP" || true
 
 # Copy new install image to output folder
-cp -R "$SOURCEAPP" "$TARGETPATH/"
+/bin/cp -R "$SOURCEAPP" "$TARGETPATH/"
 
 # Copy Keyman.app into install image
-cp -R "$KEYMANAPP" "$TARGETAPP/Contents/MacOS/Keyman.app"
+/bin/cp -R "$KEYMANAPP" "$TARGETAPP/Contents/MacOS/Keyman.app"
 
 # Copy textinputsource into install image
 cp textinputsource/textinputsource "$TARGETAPP/Contents/MacOS/textinputsource"

--- a/oem/firstvoices/ios/build_common.sh
+++ b/oem/firstvoices/ios/build_common.sh
@@ -154,7 +154,7 @@ if [ $DO_UPDATE = true ]; then
     fi
 
     # Copy resources.
-    cp -Rf "$KEYMAN_ENGINE_FRAMEWORK_SRC" "$KEYMAN_ENGINE_FRAMEWORK_DST"
+    /bin/cp -Rf "$KEYMAN_ENGINE_FRAMEWORK_SRC" "$KEYMAN_ENGINE_FRAMEWORK_DST"
 fi
 
 # First things first - update our dependencies.


### PR DESCRIPTION
Fixes https://github.com/keymanapp/keyman/issues/8533 after build agent maintenance put GNU coreutils cp on path ahead of macOS /bin/cp. This subtly changed the behaviour of the `-R` flag such that it copied the folder into a subfolder rather than copying the contents of the folder into the destination folder:

Original layout:

```
Install Keyman.app/Contents/MacOS/
  applet
  textinputsource
  Keyman.app/
```

Corrupted layout:

```
Install Keyman.app/Install Keyman.app/Contents/MacOS/
  applet
  textinputsource
  Keyman.app/
```

Query: should we be rolling back the path changes so that /bin is first on the path? I am concerned about other subtle changes in behaviour in the macOS and iOS builds. Otherwise it feels like we may need to audit the scripts in /mac, /ios (and possibly /common, /core, /web, /resources) for potential changes.

Annoyed that it took me so long to figure out. Also annoying that macOS fails so subtly when a parent folder has the .app extension in its name (this seems to be a bug in Gatekeeper, really).

# User Testing

* TEST_INSTALLER: Verify that Keyman for Mac installs and runs successfully, on a clean VM. Make sure that you can install and use a keyboard.