### PR TITLE
fix(ios): fixes xcode-triggered debug, run builds

### DIFF
--- a/resources/build/xcode-utils.sh
+++ b/resources/build/xcode-utils.sh
@@ -42,7 +42,11 @@ function phaseSetBundleVersions() {
 
   # For command-line builds, VERSION and VERSION_WITH_TAG) are forwarded through xcodebuild.
   if [ -z "${VERSION:-}" ]; then
-    # We're not a command-line build... so we'll need to retrieve these values ourselves with ./build-utils.sh.
+    # This is likely not a command-line build at the top level; it's been triggered through Xcode.
+    # The $VERSION-loading code is in build-utils.sh, but we need $THIS_SCRIPT to be set
+    # (in similar manner to the "standard build header") in order to avoid script errors therein.
+    THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+
     # Note that this script's process will not have access to TC environment variables, but that's fine for
     # local builds triggered through Xcode's UI, which aren't part of our CI processes.
     . "$KEYMAN_ROOT/resources/build/build-utils.sh"


### PR DESCRIPTION
Looks like we haven't done much development-debugging for the iOS platform in a while.

While trying to diagnose issues with the ES module feature branch (see #8544), I found I was unable to build Keyman within Xcode, which is a prerequisite for launching/testing the app via Simulator and for locally installing on a test device without TestFlight.  It turns out... it was simply because of a missing environment variable definition when certain custom scripts were being triggered by top-level Xcode builds.

As best as I can tell, the git-blame for this likely lies within #7365 and #8344 - the original  `_builder_setBuildScriptIdentifiers` function (in #7365) silently failed when the environment variable was undefined, but the new version it introduced produced warnings.  This, in turn, was converted into an outright _error_ by #8344, which is what was causing my attempts to locally debug via Xcode to fail.

@keymanapp-test-bot skip

Unless we want a dev-oriented user test - to confirm that this allows others to local-debug via Simulator for Xcode.