### PR TITLE
fix(developer): kmc should not validate as well as compile keyboard

### DIFF
--- a/developer/src/kmc/src/activities/BuildLdmlKeyboard.ts
+++ b/developer/src/kmc/src/activities/BuildLdmlKeyboard.ts
@@ -55,9 +55,6 @@ function buildLdmlKeyboardToMemory(inputFilename: string, options: BuildActivity
   if (!source) {
     return [null, null, null];
   }
-  if (!k.validate(source)) {
-    return [null, null, null];
-  }
   let kmx = k.compile(source);
   if (!kmx) {
     return [null, null, null];


### PR DESCRIPTION
Fixes #8512.

Note: the compile phase is identical to the validation phase at this point, so no need to run validate prior to compile:

https://github.com/keymanapp/keyman/blob/b34cdb9c8405eb0cb5a3803c16f7ceb4f6f92338/developer/src/kmc-keyboard/src/compiler/compiler.ts#L113-L121

@keymanapp-test-bot skip