### PR TITLE
fix(developer): improve 'does not exist' error message

### DIFF
--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -27,6 +27,12 @@ export function declareBuild(program: Command) {
 async function build(infile: string, options: BuildActivityOptions): Promise<boolean> {
   console.log(`Building ${infile}`);
 
+  if(!fs.existsSync(infile)) {
+    // TODO: consolidate errors
+    console.error(`File ${infile} does not exist`);
+    process.exit(2);
+  }
+
   // If infile is a directory, then we treat that as a project and build it
   if(fs.statSync(infile).isDirectory()) {
     return (new BuildProject()).build(infile, options);
@@ -41,6 +47,7 @@ async function build(infile: string, options: BuildActivityOptions): Promise<boo
     extensions += build.sourceExtension + ', ';
   }
 
+  // TODO: consolidate errors
   console.error(`Unrecognised input file ${infile}, expecting ${extensions}or project folder`);
   process.exit(2);
 }


### PR DESCRIPTION
Fixes #8508.

Now shows:

```
$ node . build does-not-exist.xml
Building does-not-exist.xml
File does-not-exist.xml does not exist
```

(Note, full error message cleanup and consolidation is a separate issue, part of #5283)

@keymanapp-test-bot skip