### PR TITLE
docs(windows): link to wiki architecture faq page

### DIFF
--- a/windows/src/engine/README.md
+++ b/windows/src/engine/README.md
@@ -1,6 +1,7 @@
 # Keyman Engine for Windows
 
 There are a number of build artifacts that make up the Keyman Engine. This is a brief description of each artifact's purpose.
+For FAQs on the architecture see the [Keyman Wiki](https://github.com/keymanapp/keyman/wiki/Keyman-Windows-FAQs).
 
 ## inst - keymanengine.msm
 


### PR DESCRIPTION
This links to FAQ page on the Windows architecture. A developer reading the summary architecture Readme.MD is most likely to find a FAQ page on these components useful. 

@keymanapp-test-bot skip