### PR TITLE
fix(common): consolidate npm publishing

### DIFF
--- a/common/models/types/.build-builder
+++ b/common/models/types/.build-builder
@@ -1,0 +1,1 @@
+The presence of this file tells CI to use the new builder_ style parameters for build.sh.

--- a/common/models/types/build.sh
+++ b/common/models/types/build.sh
@@ -10,101 +10,63 @@ set -eu
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../resources/build/build-utils.sh"
-. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-EX_USAGE=64
+cd "$THIS_SCRIPT_PATH"
+
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 
 
-display_usage ( ) {
-  echo "Usage: $0 [-test] [-publish-to-npm]"
-  echo "       $0 -help"
-  echo
-  echo "  -help               displays this screen and exits"
-  echo "  -test               runs tests"
-  echo "  -publish-to-npm     publishes the current version to the npm package index"
-  echo "  -dry-run            do test, etc, but don't actually publish"
-}
+builder_describe "Build Keyman kmc Package Compiler module" \
+  "@/common/web/keyman-version" \
+  "clean" \
+  "configure" \
+  "build" \
+  "test" \
+  "pack" \
+  "publish                   publish to npm" \
+  "--dry-run,-n              don't actually publish, just dry run"
+builder_describe_outputs \
+  configure     /node_modules \
+  build         /common/models/types/build/common/models/types/tsconfig.tsbuildinfo
+builder_parse "$@"
 
-################################ Main script ################################
+#-------------------------------------------------------------------------------------------------------------------
 
-run_tests=0
-install_dependencies=1
-should_publish=0
-npm_dist_tag=
-should_dry_run=0
-
-# Process command-line arguments
-while [[ $# -gt 0 ]] ; do
-  key="$1"
-  case $key in
-    -help|-h)
-      display_usage
-      exit
-      ;;
-    -dry-run)
-      should_dry_run=1
-      ;;
-    -test)
-      run_tests=1
-      install_dependencies=0
-      ;;
-    -version)
-      echo "Warning: -version is now ignored"
-      ;;
-    -tier)
-      echo "Warning: -tier is now ignored"
-      ;;
-    -publish-to-npm)
-      should_publish=1
-      ;;
-    *)
-      echo "$0: invalid option: $key"
-      display_usage
-      exit $EX_USAGE
-  esac
-  shift # past the processed argument
-done
-
-# Dry run settings
-if (( should_dry_run )); then
-  DRY_RUN=--dry-run
-else
-  DRY_RUN=
+if builder_start_action clean; then
+  rm -rf ./build/
+  builder_finish_action success clean
 fi
 
-# Check that we're doing any task at all!
-if (( !run_tests )) && (( !should_publish )); then
-  echo "$0: Must do at least one of: -test, -publish-npm" >&2
-  display_usage
-  exit $EX_USAGE
+#-------------------------------------------------------------------------------------------------------------------
+
+if builder_start_action configure; then
+  verify_npm_setup
+  builder_finish_action success configure
 fi
 
-# Check if Node.JS/npm is installed.
-type npm >/dev/null ||\
-    builder_die "Build environment setup error detected!  Please ensure Node.js is installed!"
+#-------------------------------------------------------------------------------------------------------------------
 
-if (( install_dependencies )) ; then
-  npm install || builder_die "Could not download dependencies."
+if builder_start_action build; then
+  tsc --build
+  builder_finish_action success build
 fi
 
-if (( run_tests )); then
-  npm test || builder_die "Tests failed"
+#-------------------------------------------------------------------------------------------------------------------
+
+if builder_start_action test; then
+  npm test
+  builder_finish_action success test
 fi
 
-if (( should_publish )); then
-  if [[ $TIER == stable ]]; then
-    npm_dist_tag=latest
-  else
-    npm_dist_tag=$TIER
-  fi
+#-------------------------------------------------------------------------------------------------------------------
 
-  set_npm_version
-
-  # Note: In either case, npm publish MUST be given --access public to publish
-  # a package in the @keymanapp scope on the public npm package index.
-  #
-  # See `npm help publish` for more details.
-  echo "Publishing $DRY_RUN npm package with tag $npm_dist_tag"
-  npm publish $DRY_RUN --access public --tag $npm_dist_tag || builder_die "Could not publish $npm_dist_tag release."
+if builder_start_action publish; then
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_npm
+  builder_finish_action success publish
+elif builder_start_action pack; then
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_pack
+  builder_finish_action success pack
 fi

--- a/common/web/keyman-version/build.sh
+++ b/common/web/keyman-version/build.sh
@@ -23,6 +23,7 @@ builder_describe "Build the include script for current Keyman version" \
   configure \
   clean \
   build \
+  pack \
   publish \
   test \
   --dry-run
@@ -97,4 +98,8 @@ if builder_start_action publish; then
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
   builder_publish_to_npm
   builder_finish_action success publish
+elif builder_start_action pack; then
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_pack
+  builder_finish_action success pack
 fi

--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -22,6 +22,7 @@ builder_describe "Build Keyman common file types module" \
   "build" \
   "clean" \
   "test" \
+  "pack" \
   "publish                   publish to npm" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
@@ -83,4 +84,8 @@ if builder_start_action publish; then
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
   builder_publish_to_npm
   builder_finish_action success publish
+elif builder_start_action pack; then
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_pack
+  builder_finish_action success pack
 fi

--- a/developer/src/kmc-keyboard/build.sh
+++ b/developer/src/kmc-keyboard/build.sh
@@ -24,6 +24,7 @@ builder_describe "Build Keyman kmc Keyboard Compiler module" \
   "clean" \
   "test" \
   "build-fixtures            builds test fixtures for manual examination" \
+  "pack" \
   "publish                   publish to npm" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
@@ -102,4 +103,9 @@ if builder_start_action publish; then
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
   builder_publish_to_npm
   builder_finish_action success publish
+elif builder_start_action pack; then
+  copy_schemas
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_pack
+  builder_finish_action success pack
 fi

--- a/developer/src/kmc-kmn/build.sh
+++ b/developer/src/kmc-kmn/build.sh
@@ -24,6 +24,7 @@ builder_describe "Build Keyman Developer Compiler Module for .kmn to .kmx" \
   "build" \
   "clean" \
   "test" \
+  "pack" \
   "publish                   publish to npm" \
   "--dry-run,-n              don't actually publish, just dry run"
 
@@ -72,4 +73,8 @@ if builder_start_action publish; then
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
   builder_publish_to_npm
   builder_finish_action success publish
+elif builder_start_action pack; then
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_pack
+  builder_finish_action success pack
 fi

--- a/developer/src/kmc-model-info/build.sh
+++ b/developer/src/kmc-model-info/build.sh
@@ -22,6 +22,7 @@ builder_describe "Build Keyman kmc Lexical Model model-info Compiler module" \
   "build" \
   "clean" \
   "test" \
+  "pack" \
   "publish                   publish to npm" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
@@ -64,4 +65,8 @@ if builder_start_action publish; then
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
   builder_publish_to_npm
   builder_finish_action success publish
+elif builder_start_action pack; then
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_pack
+  builder_finish_action success pack
 fi

--- a/developer/src/kmc-model/build.sh
+++ b/developer/src/kmc-model/build.sh
@@ -24,6 +24,7 @@ builder_describe "Build Keyman kmc Lexical Model Compiler module" \
   "build" \
   "clean" \
   "test" \
+  "pack" \
   "publish                   publish to npm" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
@@ -70,4 +71,8 @@ if builder_start_action publish; then
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
   builder_publish_to_npm
   builder_finish_action success publish
+elif builder_start_action pack; then
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_pack
+  builder_finish_action success pack
 fi

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -34,8 +34,6 @@
     "xml2js": "^0.4.19"
   },
   "devDependencies": {
-    "@keymanapp/models-templates": "*",
-    "@keymanapp/models-wordbreakers": "*",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.14.6",

--- a/developer/src/kmc-package/build.sh
+++ b/developer/src/kmc-package/build.sh
@@ -22,6 +22,7 @@ builder_describe "Build Keyman kmc Package Compiler module" \
   "build" \
   "clean" \
   "test" \
+  "pack" \
   "publish                   publish to npm" \
   "--dry-run,-n              don't actually publish, just dry run"
 builder_describe_outputs \
@@ -63,4 +64,8 @@ if builder_start_action publish; then
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
   builder_publish_to_npm
   builder_finish_action success publish
+elif builder_start_action pack; then
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_pack
+  builder_finish_action success pack
 fi

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -30,6 +30,7 @@ builder_describe "Build Keyman Keyboard Compiler kmc" \
   "clean                     cleans build/ folder" \
   "bundle                    creates a bundled version of kmc" \
   "test                      run automated tests for kmc" \
+  "pack                      create an npm package" \
   "publish                   publish to npm" \
   "--build-path=BUILD_PATH   build directory for bundle" \
   "--dry-run,-n              don't actually publish, just dry run"
@@ -98,6 +99,17 @@ fi
 
 #-------------------------------------------------------------------------------------------------------------------
 
+readonly PACKAGES=(
+  common/web/keyman-version
+  common/web/types
+  common/models/types
+  developer/src/kmc-keyboard
+  developer/src/kmc-kmn
+  developer/src/kmc-model
+  developer/src/kmc-model-info
+  developer/src/kmc-package
+)
+
 if builder_start_action publish; then
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
@@ -105,16 +117,20 @@ if builder_start_action publish; then
   # common-types, as well as all the other dependent modules. In the future, we
   # should probably have a top-level npm publish script that publishes all
   # modules for a given release version From: #7595
-  "$KEYMAN_ROOT/common/web/keyman-version/build.sh" publish $DRY_RUN
-  "$KEYMAN_ROOT/common/web/types/build.sh" publish $DRY_RUN
-  "$KEYMAN_ROOT/developer/src/kmc-keyboard/build.sh" publish $DRY_RUN
-  "$KEYMAN_ROOT/developer/src/kmc-kmn/build.sh" publish $DRY_RUN
-  "$KEYMAN_ROOT/developer/src/kmc-model/build.sh" publish $DRY_RUN
-  "$KEYMAN_ROOT/developer/src/kmc-model-info/build.sh" publish $DRY_RUN
-  "$KEYMAN_ROOT/developer/src/kmc-package/build.sh" publish $DRY_RUN
+  for package in "${PACKAGES[@]}"; do
+    "$KEYMAN_ROOT/$package/build.sh" publish $DRY_RUN
+  done
 
   # Finally, publish kmc
   builder_publish_to_npm
-
   builder_finish_action success publish
+elif builder_start_action pack; then
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+
+  for package in "${PACKAGES[@]}"; do
+    "$KEYMAN_ROOT/$package/build.sh" pack $DRY_RUN
+  done
+
+  builder_publish_to_pack
+  builder_finish_action success pack
 fi

--- a/docs/npm-packages.md
+++ b/docs/npm-packages.md
@@ -10,16 +10,23 @@ Packages are **never** published from a developer's machine.
 
 ## List of current published npm packages
 
-* `@keymanapp/models-types` -- located at `common/models/types`
+* `@keymanapp/common-types` -- located at `common/web/types`
+* `@keymanapp/keyman-version` -- located at `common/web/keyman-version`
 * `@keymanapp/kmc` -- located at `developer/src/kmc`
 * `@keymanapp/kmc-keyboard` -- located at `developer/src/kmc-keyboard`
+* `@keymanapp/kmc-kmn` -- located at `developer/src/kmc-kmn`
 * `@keymanapp/kmc-model` -- located at `developer/src/kmc-model`
 * `@keymanapp/kmc-model-info` -- located at `developer/src/kmc-model-info`
 * `@keymanapp/kmc-package` -- located at `developer/src/kmc-package`
+* `@keymanapp/models-types` -- located at `common/models/types`
 
 ### Deprecated npm packages
 
+* `@keymanapp/developer-lexical-model-compiler` -- replaced by `@keymanapp/kmc`
 * `@keymanapp/lexical-model-compiler` -- replaced by `@keymanapp/kmc`
+* `@keymanapp/lexical-model-types` -- replaced by `@keymanapp/models-types`
+* `@keymanapp/lmlayer-cli` -- replaced by `@keymanapp/kmc`
+* `@keymanapp/models-wordbreakers` -- published accidentally
 
 ## For CI developers
 
@@ -89,13 +96,12 @@ For every release of **Keyman Developer**, the CI publishes a release of
 `@keymanapp/kmc`. The version number is locked with the particular version of
 Keyman Developer.
 
-### `set_npm_version`
+### `builder_publish_to_npm`
 
-This helper function sets the version in the `package.json` for the given
-package, according to the VERSION_WITH_TAG variable.
+This helper function updates version numbers and does the publish step for the
+package.json in the working directory, using the VERSION_WITH_TAG variable.
 
 ```bash
-. $KEYMAN_ROOT/resources/shellHelperFunctions.sh
-
-set_npm_version
+  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+  builder_publish_to_npm
 ```

--- a/resources/build/build-utils-ci.inc.sh
+++ b/resources/build/build-utils-ci.inc.sh
@@ -71,12 +71,25 @@ function builder_pull_has_label() {
 # field will be added to it, and @keymanapp dependency versions will also be
 # modified. This change should not be committed to the repository.
 #
+# builder_publish_to_pack and builder_publish_to_npm are similar:
+#  * builder_publish_to_npm publishes to the public registry
+#  * builder_publish_to_pack creates a local tarball which can be used to test
+#
 # Usage:
 # ```bash
 #   builder_publish_to_npm
 # ```
 #
 function builder_publish_to_npm() {
+  _builder_publish_npm_package publish
+}
+
+function builder_publish_to_pack() {
+  _builder_publish_npm_package pack
+}
+
+function _builder_publish_npm_package() {
+  local action=$1
   local dist_tag=$TIER dry_run=
 
   if [[ $TIER == stable ]]; then
@@ -104,8 +117,15 @@ function builder_publish_to_npm() {
   # package in the @keymanapp scope on the public npm package index.
   #
   # See `npm help publish` for more details.
-  echo "Publishing $dry_run npm package $THIS_SCRIPT_IDENTIFIER with tag $dist_tag"
-  npm publish $dry_run --access public --tag $dist_tag
+  if [[ $action == pack ]]; then
+    # We can use --publish-to-pack to locally test a package
+    # before publishing to the package registry
+    echo "Packing $dry_run npm package $THIS_SCRIPT_IDENTIFIER with tag $dist_tag"
+    npm pack $dry_run --access public --tag $dist_tag
+  else # $action == publish
+    echo "Publishing $dry_run npm package $THIS_SCRIPT_IDENTIFIER with tag $dist_tag"
+    npm publish $dry_run --access public --tag $dist_tag
+  fi
 }
 
 # Updates all @keymanapp/* [*]dependencies in package.json to the current


### PR DESCRIPTION
Fixes #8586.
Fixes #7310.

Four fixes all centred around npm publish:
* Sets dependency versions when publishing npm packages
* All npm publish actions in the repository are now run as part of the Developer release build, hosted at present by kmc, until we setup a higher-level build script to do it.
* Adds a 'pack' action which mirrors 'publish' for all npm packages.
* Removes unnecessary dev dependencies of models-templates and models-wordbreakers from kmc-model.

The Web Release build CI step has been updated to check for presence of .build-builder for models-types.

@keymanapp-test-bot skip