### PR TITLE
fix(developer): kmc should not compile twice 🙀

### DIFF
--- a/developer/src/kmc-keyboard/src/compiler/compiler.ts
+++ b/developer/src/kmc-keyboard/src/compiler/compiler.ts
@@ -113,6 +113,8 @@ export default class Compiler {
   /**
    * Validates that the LDML keyboard source file and lints. Actually just
    * compiles the keyboard and returns `true` if everything is good...
+   * No need to call this before calling compile, use this only for
+   * validating without compiling.
    * @param     source
    * @returns   true if the file validates
    */

--- a/developer/src/kmc/src/activities/buildLdmlKeyboard.ts
+++ b/developer/src/kmc/src/activities/buildLdmlKeyboard.ts
@@ -49,9 +49,7 @@ function buildLdmlKeyboardToMemory(inputFilename: string, options: BuildCommandO
   if (!source) {
     return [null, null, null];
   }
-  if (!k.validate(source)) {
-    return [null, null, null];
-  }
+  // 'compile' will perform validation as well.
   let kmx = k.compile(source);
   if (!kmx) {
     return [null, null, null];


### PR DESCRIPTION
- don’t call validate() before compiler()

Fixes: #8512

@keymanapp-test-bot skip