### PR TITLE
fix(developer): package editor no longer loses RTL flag for LMs

### DIFF
--- a/common/windows/delphi/packages/PackageInfo.pas
+++ b/common/windows/delphi/packages/PackageInfo.pas
@@ -2213,7 +2213,7 @@ begin
     lexicalModel := TPackageLexicalModel.Create(Package);
     lexicalModel.Name := XmlVarToStr(ALexicalModel.ChildValues[SXML_PackageLexicalModel_Name]);
     lexicalModel.ID := XmlVarToStr(ALexicalModel.ChildValues[SXML_PackageLexicalModel_ID]);
-    lexicalModel.RTL := ANode.ChildNodes.IndexOf(SXML_PackageLexicalModel_RTL) >= 0;
+    lexicalModel.RTL := ALexicalModel.ChildNodes.IndexOf(SXML_PackageLexicalModel_RTL) >= 0;
     lexicalModel.Languages.LoadXML(ALexicalModel);
     Add(lexicalModel);
   end;


### PR DESCRIPTION
Fixes #8595.

# User Testing

* **TEST_RTL_CHECKBOX:** Following the steps below, ensure that the "Is Right-to-left" checkbox for the lexical model always matches the source view value for `RTL`.

1. Create a new lexical model and open the .kps file.
2. Go to the "Lexical Models" section/tab.
3. Check "Is Right-to-left" by clicking on it.
4. Go to the "Source" section/tab and verify that `<RTL>True</RTL>` is present in the lexical models section.
5. Return to "Lexical Models", "Is Right-to-left" should remain checked.
6. Repeat these steps, with the RTL checkbox _off_ and confirm that the Source and Lexical Models tabs match up.