### PR TITLE
fix(android/engine): Fix resetContext calls when selection changes

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -152,6 +152,7 @@ public class KMKeyboardJSHandler {
         // Perform left-deletions
         if (deleteLeft > 0) {
           if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+            KMManager.InAppKeyboardShouldIgnoreTextChange = true;
             KMManager.InAppKeyboardShouldIgnoreSelectionChange = true;
           }
           performLeftDeletions(ic, deleteLeft);

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -130,6 +130,8 @@ public class KMKeyboardJSHandler {
             } else {
               if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
                 KMManager.SystemKeyboardShouldIgnoreSelectionChange = true;
+              } else if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+                KMManager.InAppKeyboardShouldIgnoreSelectionChange = true;
               }
               ic.setSelection(start, start);
               ic.deleteSurroundingText(0, end - start);
@@ -149,6 +151,9 @@ public class KMKeyboardJSHandler {
 
         // Perform left-deletions
         if (deleteLeft > 0) {
+          if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+            KMManager.InAppKeyboardShouldIgnoreSelectionChange = true;
+          }
           performLeftDeletions(ic, deleteLeft);
         }
 
@@ -159,6 +164,8 @@ public class KMKeyboardJSHandler {
             char c = chars.charAt(0);
             if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
               KMManager.SystemKeyboardShouldIgnoreSelectionChange = true;
+            } else if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+              KMManager.InAppKeyboardShouldIgnoreSelectionChange = true;
             }
             if (Character.isHighSurrogate(c)) {
               ic.deleteSurroundingText(0, 2);
@@ -171,6 +178,8 @@ public class KMKeyboardJSHandler {
         if (s.length() > 0) {
           if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
             KMManager.SystemKeyboardShouldIgnoreSelectionChange = true;
+          } else if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
+            KMManager.InAppKeyboardShouldIgnoreSelectionChange = true;
           }
           // Commit the string s. Use newCursorPosition 1 so cursor will end up after the string.
           ic.commitText(s, 1);

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMTextView.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMTextView.java
@@ -167,7 +167,7 @@ public final class KMTextView extends AppCompatEditText {
   protected void onSelectionChanged(int selStart, int selEnd) {
     super.onSelectionChanged(selStart, selEnd);
     if (activeView != null && activeView.equals(this)) {
-      if (KMManager.updateSelectionRange(KMManager.KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd) && !KMManager.InAppKeyboardShouldIgnoreSelectionChange) {
+      if (KMManager.updateSelectionRange(KMManager.KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd)) {
         KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_INAPP);
       }
     }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMTextView.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMTextView.java
@@ -167,7 +167,7 @@ public final class KMTextView extends AppCompatEditText {
   protected void onSelectionChanged(int selStart, int selEnd) {
     super.onSelectionChanged(selStart, selEnd);
     if (activeView != null && activeView.equals(this)) {
-      if (KMManager.updateSelectionRange(KMManager.KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd)) {
+      if (KMManager.updateSelectionRange(KMManager.KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd) && !KMManager.InAppKeyboardShouldIgnoreSelectionChange) {
         KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_INAPP);
       }
     }


### PR DESCRIPTION
Fixes #8556 and continuing refactor in #7881

> The bug was introduced during the consolidation in #8438 where `KMManager.SystemKeyboardShouldIgnoreSelectionChange` gets set, but never `KMManager.InAppKeyboardShouldIgnoreSelectionChange`. This was causing resetContext to trigger on every change.

I also note these are never set to true, but am not addressing on this PR:
* KMManager.InAppKeyboardShouldIgnoreTextChange
* KMManager.SystemKeyboardShouldIgnoreTextChange


## User Testing
*Setup* - Install the PR build of Keyman for Android and also install the Keyman keyboard kbd_basicfr (Basic French) on an Android device/emulator. Set Keyman as the default system keyboard. Note - if pressing the shift layer deletes selected keys, that's already a known issue #7866.

**GROUP_INAPP** - Verifies inapp keyboard. Use Keyman for Android app
**GROUP_SYSTEM** - Verifies system keyboard. Use Contacts app to add a new contact name (not Chrome/Browser because the searchbar interferes with selection)

* **TEST_UNDO_SUGGESTION** - Verifies backspace after a suggestion works
1. With the sil_euro_latin keyboard, type "prob"
2. Select "problem" from the suggestion banner
3. Press <kbd>Backspace</kbd> key 
4. Verify "prob" is now the left suggestion (the context before accepting the suggestion)
5. Select "prob" from the suggestion banner
6. Verify the text changes from "problem" to "prob"

* **TEST_REPLACE_SELECTION_DEADKEYS** - Verifies keyboard replaces selected text and handles deadkeys
1. In Keyman with the sil_euro_latin keyboard, type "the quick brown fox"
2. Select the letters "row" within the word "brown". (keyboard switches to shift layer)
3. Type "H"
4. Verify the text changes from "brown" to "bHn"
5. Select the letters "ick" within the word "quick"
6. Press <kbd>backspace</kbd> key
7. Verify the text changes from "quick" to "qu"
8. Select the letter "o" within the word "fox"
9. Press <kbd>enter</kbd> key
10. If testing INAPP
  a. verify the word changes from "fox" to "f" followed by "x" on the next line
11. If testing SYSTEM
  a. verify the word changes from "fox" to "fx" (Name is limited to one line)
  b. Select the end of the name field
12. Use the Keyman globe key to switch to the kbd_basicfr keyboard
13. Press the green <kbd>^</kbd>
14. Verify nothing is output (it's a deadkey)
15. Press a vowel
16. Verify the vowel with the combined diacritic is output




