### PR TITLE
chore(android/engine): Cleanup old SDK calls

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -150,21 +150,10 @@ final class KMKeyboard extends WebView {
 
     getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
     getSettings().setSupportZoom(false);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      getSettings().setUseWideViewPort(true);
-      getSettings().setLoadWithOverviewMode(true);
-      setWebContentsDebuggingEnabled(true);
-    }
 
-    if (keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1)
-      setLayerType(View.LAYER_TYPE_SOFTWARE, null); // Disable hardware acceleration for API < 17, Keyman keyboard is slower without HWA but it causes some display issues.
-    // (Tested on Samsung Galaxy Nexus running Android 4.1.2)
-
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
-      // These were deprecated in API 18
-      getSettings().setRenderPriority(WebSettings.RenderPriority.HIGH);
-      getSettings().setPluginState(WebSettings.PluginState.ON_DEMAND);
-    }
+    getSettings().setUseWideViewPort(true);
+    getSettings().setLoadWithOverviewMode(true);
+    setWebContentsDebuggingEnabled(true);
 
     setWebChromeClient(new WebChromeClient() {
       public boolean onConsoleMessage(ConsoleMessage cm) {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1655,7 +1655,7 @@ public final class KMManager {
       if (IMService != null) {
         IMService.switchToPreviousInputMethod();
       }
-    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+    } else {
       // This method is added in API level 16 and deprecated in API level 28
       // Reference: https://developer.android.com/reference/android/view/inputmethod/InputMethodManager#switchToLastInputMethod(android.os.IBinder)
       InputMethodManager imm = (InputMethodManager) appContext.getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -1668,7 +1668,7 @@ public final class KMManager {
       if (IMService != null) {
         IMService.switchToNextInputMethod(false);
       }
-    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+    } else {
       // This method is added in API level 16 and deprecated in API level 28
       // Reference: https://developer.android.com/reference/android/view/inputmethod/InputMethodManager.html#switchToNextInputMethod(android.os.IBinder,%20boolean)
       InputMethodManager imm = (InputMethodManager) appContext.getSystemService(Context.INPUT_METHOD_SERVICE);


### PR DESCRIPTION
Split out the following from #8608

> 1. Since our minimum SDK is 21 (Lollipop 5.0), this cleans up some of the logic checking for SDK version (always greater than KITKAT and never less than JELLY_BEAN_MR1)

@keymanapp-test-bot skip
