### PR TITLE
fix(developer): kmc-kmn would abort build on warnings

### DIFF
--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -60,9 +60,10 @@ export class Compiler {
 
     options = {...baseOptions, ...options};
 
-    (globalThis as any).msgproc = function(line: number, code: number, msg: string) {
+    (globalThis as any).msgproc = function(line: number, code: number, msg: string): number {
       // TODO: link into the kmc error reporting infrastructure
-      console.log(`[${line}] ${code}: ${msg}`);
+      console.log(`[${line}] ${code.toString(16)}: ${msg}`);
+      return 1; // 1 == continue build
     }
 
     // TODO: use callbacks for file access -- so kmc-kmn is entirely fs agnostic
@@ -83,7 +84,8 @@ export class Compiler {
         outfile,
         options.saveDebug ? 1 : 0,
         options.compilerWarningsAsErrors ? 1 : 0,
-        options.warnDeprecatedCode ? 1 : 0, 'msgproc');
+        options.warnDeprecatedCode ? 1 : 0,
+        'msgproc');
     } catch(e) {
       // TODO: use sentry
       console.error(e);

--- a/developer/src/kmcmplib/src/CompilerInterfaces.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfaces.cpp
@@ -30,7 +30,7 @@ EXTERN bool kmcmp_SetCompilerOptions(KMCMP_COMPILER_OPTIONS* options) {
   WASM interface for compiler message callback
 */
 EM_JS(int, wasm_msgproc, (int line, int msgcode, char* text, char* context), {
-  const proc = globalThis[context];
+  const proc = globalThis[UTF8ToString(context)];
   if(!proc || typeof proc != 'function') {
     console.log(`[${line}: ${msgcode}: ${UTF8ToString(text)}]`);
     return 0;


### PR DESCRIPTION
Fixes #8615.

The msgproc was never being located as we were missing the UTF8ToString wrapper for the context.

This also ensures error message codes are emitted in hexadecimal, and that the return value from the msgproc callback is 1, meaning 'continue build'.

@keymanapp-test-bot skip