### PR TITLE
feat(developer): add warning options to kmc

### DIFF
--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -11,6 +11,8 @@ export function declareBuild(program: Command) {
     .option('-d, --debug', 'Include debug information in output')
     .option('-o, --out-file <filename>', 'Override the default path and filename for the output file')
     .option('--no-compiler-version', 'Exclude compiler version metadata from output')
+    .option('-w, --compiler-warnings-as-errors', 'Causes warnings to fail the build')
+    .option('--no-warn-deprecated-code', 'Turn off warnings for deprecated code styles')
     .action((infiles: string[], options: any) => {
       let p = [];
       if(!infiles.length) {

--- a/developer/src/kmc/src/commands/build/BuildActivity.ts
+++ b/developer/src/kmc/src/commands/build/BuildActivity.ts
@@ -4,6 +4,8 @@ export interface BuildActivityOptions {
   debug?: boolean;
   outFile?: string;
   compilerVersion?: boolean;
+  warnDeprecatedCode?: boolean;
+  compilerWarningsAsErrors?: boolean;
 };
 
 export abstract class BuildActivity {

--- a/developer/src/kmc/src/commands/build/BuildKmnKeyboard.ts
+++ b/developer/src/kmc/src/commands/build/BuildKmnKeyboard.ts
@@ -25,6 +25,8 @@ export class BuildKmnKeyboard extends BuildActivity {
     return compiler.run(infile, outfile, {
       saveDebug: options.debug,
       shouldAddCompilerVersion: options.compilerVersion,
+      warnDeprecatedCode: options.warnDeprecatedCode,
+      compilerWarningsAsErrors: options.compilerWarningsAsErrors,
     });
   }
 }

--- a/developer/src/kmc/src/commands/build/BuildLdmlKeyboard.ts
+++ b/developer/src/kmc/src/commands/build/BuildLdmlKeyboard.ts
@@ -46,7 +46,9 @@ export class BuildLdmlKeyboard extends BuildActivity {
 function buildLdmlKeyboardToMemory(inputFilename: string, options: BuildActivityOptions): [Uint8Array, Uint8Array, Uint8Array] {
   let compilerOptions: kmc.CompilerOptions = {
     debug: options.debug ?? false,
-    addCompilerVersion: options.compilerVersion ?? true
+    addCompilerVersion: options.compilerVersion ?? true,
+    // TODO: warnDeprecatedCode: options.warnDeprecatedCode,
+    // TODO: treatWarningsAsErrors: options.treatWarningsAsErrors,
   }
 
   const c: CompilerCallbacks = new NodeCompilerCallbacks();


### PR DESCRIPTION
Adds --compiler-warnings-as-errors and --no-warn-deprecated-code options to kmc command line and interfaces.

Note that most compilers do not yet honour these options, only kmc-kmn.

Both of these should be handled in error filtering and reporting rather than at the compiler level, so management of these may be factored out of kmcmplib and into kmc later (although this goal may be blocked by kmcmpdll's need to also use them).

@keymanapp-test-bot skip