### PR TITLE
feat(developer): use new message infrastructure in kmc-kmn

### DIFF
--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -15,7 +15,7 @@ export { default as LDMLKeyboardXMLSourceFileReader } from './ldml-keyboard/ldml
 
 export * as Constants from './consts/virtual-key-constants.js';
 
-export { CompilerCallbacks, CompilerEvent, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec } from './util/compiler-interfaces.js';
+export { CompilerCallbacks, CompilerEvent, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec, compilerErrorSeverityName } from './util/compiler-interfaces.js';
 export { CommonTypesMessages } from './util/common-events.js';
 
 export * as TouchLayout from './keyman-touch-layout/keyman-touch-layout-file.js';

--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -2,6 +2,7 @@
  * Abstract interface for compiler error and warning messages
  */
 export interface CompilerEvent {
+  line?: number;
   code: number;
   message: string;
 };
@@ -17,6 +18,25 @@ export enum CompilerErrorSeverity {
   Error_Mask =    0x0FFFFF,
 };
 
+export function compilerErrorSeverityName(code: number): string {
+  let severity = code & CompilerErrorSeverity.Severity_Mask;
+  switch(severity) {
+    case CompilerErrorSeverity.Info: return 'INFO';
+    case CompilerErrorSeverity.Hint: return 'HINT';
+    case CompilerErrorSeverity.Warn: return 'WARN';
+    case CompilerErrorSeverity.Error: return 'ERROR';
+    case CompilerErrorSeverity.Fatal: return 'FATAL';
+    /* istanbul ignore next */
+    default: return 'UNKNOWN';
+  }
+}
+
+/**
+ * Defines the error code ranges for various compilers. Once defined, these
+ * ranges must not be changed as external modules may depend on specific error
+ * codes. Individual errors are defined at a compiler level, for example,
+ * kmn-keyboard/src/compiler/messages.ts.
+ */
 export enum CompilerErrorNamespace {
   /**
    * kmc-keyboard errors between 0x0000…0x0FFF
@@ -26,6 +46,23 @@ export enum CompilerErrorNamespace {
    * common/web/types errors between 0x1000…0x1FFF
    */
   CommonTypes = 0x1000,
+  /**
+   * kmc-kmn errors between 0x2000…0x2FFF; these map to
+   * the base codes found in comperr.h, exclusive severity flags
+   */
+  KmnCompiler = 0x2000,
+  /**
+   * kmc-model errors between 0x3000…0x3FFF
+   */
+  ModelCompiler = 0x3000,
+  /**
+   * kmc-package errors between 0x4000…0x4FFF
+   */
+  PackageCompiler = 0x4000,
+  /**
+   * kmc and related infrastructure errors between 0x5000…0x5FFF;
+   */
+  Infrastructure = 0x5000,
 };
 
 /**

--- a/developer/src/kmc-keyboard/package.json
+++ b/developer/src/kmc-keyboard/package.json
@@ -51,6 +51,16 @@
       "source-map-support/register"
     ]
   },
+  "c8": {
+    "all": true,
+    "src": [
+      "src/"
+    ],
+    "exclude-after-remap": true,
+    "exclude": [
+      "test/"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/keymanapp/keyman.git"

--- a/developer/src/kmc-keyboard/src/compiler/messages.ts
+++ b/developer/src/kmc-keyboard/src/compiler/messages.ts
@@ -89,18 +89,5 @@ export class CompilerMessages {
   static Error_MissingFlicks = (o:{flicks: string, id: string}) => m(this.ERROR_MissingFlicks,
     `key id=${o.id} refers to missing flicks=${o.flicks}`);
   static ERROR_MissingFlicks = SevError | 0x0015;
-
-  static severityName(code: number): string {
-    let severity = code & CompilerErrorSeverity.Severity_Mask;
-    switch(severity) {
-      case CompilerErrorSeverity.Info: return 'INFO';
-      case CompilerErrorSeverity.Hint: return 'HINT';
-      case CompilerErrorSeverity.Warn: return 'WARN';
-      case CompilerErrorSeverity.Error: return 'ERROR';
-      case CompilerErrorSeverity.Fatal: return 'FATAL';
-      /* istanbul ignore next */
-      default: return 'UNKNOWN';
-    }
-  }
 }
 

--- a/developer/src/kmc-keyboard/test/test-messages.ts
+++ b/developer/src/kmc-keyboard/test/test-messages.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import {assert, expect} from 'chai';
 import { CompilerMessages } from '../src/compiler/messages.js';
-import { CompilerErrorSeverity } from '@keymanapp/common-types';
+import { CompilerErrorSeverity, compilerErrorSeverityName } from '@keymanapp/common-types';
 
 const toTitleCase = (s: string) => s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
 
@@ -24,11 +24,6 @@ describe('compiler messages', function () {
     const m = CompilerMessages as Record<string,any>;
 
     for(let key of keys) {
-      if(key == 'severityName') {
-        // any helper functions we skip here
-        continue;
-      }
-
       if(typeof m[key] == 'function') {
         const o = /^(Info|Hint|Warning|Error|Fatal)_([A-Za-z0-9_]+)$/.exec(key);
         expect(o).to.be.instanceOf(Array);
@@ -63,7 +58,7 @@ describe('compiler messages', function () {
         const o = /^(INFO|HINT|WARNING|ERROR|FATAL)_([A-Za-z0-9_]+)$/.exec(key);
         expect(o).to.be.instanceOf(Array);
 
-        const mask = CompilerMessages.severityName(m[key]);
+        const mask = compilerErrorSeverityName(m[key]);
         expect(o[1]).to.equal(mask, `Mask value for ${key} does not match`);
 
         const code = m[key] & CompilerErrorSeverity.Error_Mask;

--- a/developer/src/kmc-kmn/package.json
+++ b/developer/src/kmc-kmn/package.json
@@ -51,6 +51,17 @@
       "source-map-support/register"
     ]
   },
+  "c8": {
+    "all": true,
+    "src": [
+      "src/"
+    ],
+    "exclude-after-remap": true,
+    "exclude": [
+      "src/import/",
+      "test/"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/keymanapp/keyman.git"

--- a/developer/src/kmc-kmn/src/compiler/messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/messages.ts
@@ -1,0 +1,65 @@
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec as m } from "@keymanapp/common-types";
+
+const Namespace = CompilerErrorNamespace.KmnCompiler;
+const SevInfo = CompilerErrorSeverity.Info | Namespace;
+const SevHint = CompilerErrorSeverity.Hint | Namespace;
+const SevWarn = CompilerErrorSeverity.Warn | Namespace;
+const SevError = CompilerErrorSeverity.Error | Namespace;
+const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
+
+/**
+ * LogLevel comes from comperr.h, for legacy compiler error messages
+ */
+const enum LogLevel {
+  LEVEL_MASK = 0xF000,
+  CODE_MASK = 0x0FFF,
+  CERR_FATAL = 0x8000,
+  CERR_ERROR = 0x4000,
+  CERR_WARNING = 0x2000,
+  CERR_HINT = 0x1000,
+  CERR_INFO = 0
+};
+
+/**
+ * Translate the legacy compiler error messages to Severity codes
+ */
+const LogLevelToSeverity: Record<number,number> = {
+  [LogLevel.CERR_FATAL]:   SevFatal,
+  [LogLevel.CERR_ERROR]:   SevError,
+  [LogLevel.CERR_WARNING]: SevWarn,
+  [LogLevel.CERR_HINT]:    SevHint,
+  [LogLevel.CERR_INFO]:    SevInfo
+}
+
+/*
+  The messages in this class share the namespace with messages from comperr.h
+  and the below ranges are reserved.
+*/
+export class CompilerMessages {
+  static RANGE_KMN_COMPILER_MIN    = 0x0001; // from comperr.h
+  static RANGE_KMN_COMPILER_MAX    = 0x07FF; // from comperr.h
+  static RANGE_LEXICAL_MODEL_MIN   = 0x0800; // from comperr.h, deprecated -- this range will not be used in future versions
+  static RANGE_LEXICAL_MODEL_MAX   = 0x08FF; // from comperr.h, deprecated -- this range will not be used in future versions
+  static RANGE_CompilerMessage_Min = 0x1000; // All compiler messages listed here must be >= this value
+
+  static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException, `Unexpected exception: ${(o.e ?? 'unknown error').toString()}\n\nCall stack:\n${(o.e instanceof Error ? o.e.stack : (new Error()).stack)}`);
+  static FATAL_UnexpectedException = SevFatal | 0x1000;
+
+  static Fatal_MissingWasmModule = () => m(this.FATAL_MissingWasmModule, `Could not instanatiate WASM compiler module`);
+  static FATAL_MissingWasmModule = SevFatal | 0x1001;
+
+  static Fatal_UnableToSetCompilerOptions = () => m(this.FATAL_UnableToSetCompilerOptions, `Unable to set compiler options`);
+  static FATAL_UnableToSetCompilerOptions = SevFatal | 0x1002;
+
+  static mapErrorFromKmcmplib = (line: number, code: number, msg: string): CompilerEvent => {
+    const severity = LogLevelToSeverity[code & LogLevel.LEVEL_MASK];
+    const baseCode = code & LogLevel.CODE_MASK;
+    const event: CompilerEvent = {
+      line: line,
+      code: severity | CompilerErrorNamespace.KmnCompiler | baseCode,
+      message: msg
+    };
+    return event;
+  };
+}
+

--- a/developer/src/kmc-kmn/test/helpers.ts
+++ b/developer/src/kmc-kmn/test/helpers.ts
@@ -1,0 +1,41 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { CompilerEvent, CompilerCallbacks } from '@keymanapp/common-types';
+
+/**
+ * A CompilerCallbacks implementation for testing
+ */
+export class TestCompilerCallbacks implements CompilerCallbacks {
+  clear() {
+    this.messages = [];
+  }
+  messages: CompilerEvent[] = [];
+  loadFile(baseFilename: string, filename: string | URL): Buffer {
+    // TODO: translate filename based on the baseFilename
+    try {
+      return fs.readFileSync(filename);
+    } catch(e) {
+      if (e.code === 'ENOENT') {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+  reportMessage(event: CompilerEvent): void {
+    // console.log(event.message);
+    this.messages.push(event);
+  }
+  loadLdmlKeyboardSchema(): Buffer {
+    return fs.readFileSync(new URL(path.join('..', '..', 'src', 'ldml-keyboard.schema.json'), import.meta.url));
+  }
+  loadKvksJsonSchema(): Buffer {
+    return fs.readFileSync(new URL(path.join('..', '..', 'src', 'kvks.schema.json'), import.meta.url));
+  }
+  loadKpjJsonSchema(): Buffer {
+    return fs.readFileSync(new URL(path.join('..', '..', 'src', 'kpj.schema.json'), import.meta.url));
+  }
+  loadLdmlKeyboardTestSchema(): Buffer {
+    return fs.readFileSync(new URL(path.join('..', '..', 'src', 'ldml-keyboardtest.schema.json'), import.meta.url));
+  }
+};

--- a/developer/src/kmc-kmn/test/test-compiler.ts
+++ b/developer/src/kmc-kmn/test/test-compiler.ts
@@ -6,6 +6,7 @@ import { Compiler } from '../src/main.js';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
+import { TestCompilerCallbacks } from './helpers.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url)).replace(/\\/g, '/');
 const baselineDir = __dirname + '/../../../../../common/test/keyboards/baseline/';
@@ -29,13 +30,14 @@ describe('Compiler class', function() {
 
   it('should compile a basic keyboard', async function() {
     const compiler = new Compiler();
+    const callbacks = new TestCompilerCallbacks();
     assert(await compiler.init());
 
     const fixtureName = baselineDir + 'k_000___null_keyboard.kmx';
     const infile = baselineDir + 'k_000___null_keyboard.kmn';
     const outfile = __dirname + '/k_000___null_keyboard.kmx';
 
-    assert(compiler.run(infile, outfile, {saveDebug: true, shouldAddCompilerVersion: false}));
+    assert(compiler.run(infile, outfile, callbacks, {saveDebug: true, shouldAddCompilerVersion: false}));
 
     assert(fs.existsSync(outfile));
     const outfileData = fs.readFileSync(outfile);
@@ -48,6 +50,7 @@ describe('Compiler class', function() {
   // the basic keyboard test is slightly simpler to read
   it('should build all baseline fixtures', async function() {
     const compiler = new Compiler();
+    const callbacks = new TestCompilerCallbacks();
     assert(await compiler.init());
 
     const files = fs.readdirSync(baselineDir);
@@ -57,7 +60,7 @@ describe('Compiler class', function() {
         const infile = baselineDir + file.replace(/x$/, 'n');
         const outfile = __dirname + '/' + file;
 
-        assert(compiler.run(infile, outfile, {saveDebug: true, shouldAddCompilerVersion: false}));
+        assert(compiler.run(infile, outfile, callbacks, {saveDebug: true, shouldAddCompilerVersion: false}));
 
         assert(fs.existsSync(outfile));
         const outfileData = fs.readFileSync(outfile);

--- a/developer/src/kmc-kmn/test/tsconfig.json
+++ b/developer/src/kmc-kmn/test/tsconfig.json
@@ -13,7 +13,7 @@
     },
   "include": [
       "**/test-*.ts",
-      "./helpers/index.ts"
+      "./helpers.ts"
   ],
   "references": [
       { "path": "../../../../common/web/keyman-version/tsconfig.esm.json" },

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -54,6 +54,17 @@
       "source-map-support/register"
     ]
   },
+  "c8": {
+    "all": true,
+    "src": [
+      "src/"
+    ],
+    "exclude-after-remap": true,
+    "exclude": [
+      "test/",
+      "tools/"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/keymanapp/keyman.git"

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -62,7 +62,8 @@
     "exclude-after-remap": true,
     "exclude": [
       "test/",
-      "tools/"
+      "tools/",
+      "src/lexical-model.ts"
     ]
   },
   "repository": {

--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -49,6 +49,16 @@
       "source-map-support/register"
     ]
   },
+  "c8": {
+    "all": true,
+    "src": [
+      "src/"
+    ],
+    "exclude-after-remap": true,
+    "exclude": [
+      "test/"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/keymanapp/keyman.git"

--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -56,7 +56,9 @@
     ],
     "exclude-after-remap": true,
     "exclude": [
-      "test/"
+      "test/",
+      "src/kmp-json-file.ts",
+      "src/kps-file.ts"
     ]
   },
   "repository": {

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -69,6 +69,16 @@
       "source-map-support/register"
     ]
   },
+  "c8": {
+    "all": true,
+    "src": [
+      "src/"
+    ],
+    "exclude-after-remap": true,
+    "exclude": [
+      "test/"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/keymanapp/keyman.git"

--- a/developer/src/kmc/src/commands/build/BuildKmnKeyboard.ts
+++ b/developer/src/kmc/src/commands/build/BuildKmnKeyboard.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { BuildActivity, BuildActivityOptions } from './BuildActivity.js';
 import { Compiler } from '@keymanapp/kmc-kmn';
 import { platform } from 'os';
+import { NodeCompilerCallbacks } from '../../util/NodeCompilerCallbacks.js';
 
 export class BuildKmnKeyboard extends BuildActivity {
   public get name(): string { return 'Keyman keyboard'; }
@@ -14,6 +15,8 @@ export class BuildKmnKeyboard extends BuildActivity {
       return false;
     }
 
+    const callbacks = new NodeCompilerCallbacks();
+
     // We need to resolve paths to absolute paths before calling kmc-kmn
     let outfile = this.getOutputFilename(infile, options);
 
@@ -22,7 +25,8 @@ export class BuildKmnKeyboard extends BuildActivity {
 
     // TODO: Currently this only builds .kmn->.kmx, and targeting .js is as-yet unsupported
     // TODO: Support additional options compilerWarningsAsErrors, warnDeprecatedCode
-    return compiler.run(infile, outfile, {
+    return compiler.run(infile, outfile, callbacks,
+    {
       saveDebug: options.debug,
       shouldAddCompilerVersion: options.compilerVersion,
       warnDeprecatedCode: options.warnDeprecatedCode,

--- a/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
-import * as kmc from '@keymanapp/kmc-keyboard';
-import { CompilerCallbacks, CompilerEvent } from '@keymanapp/common-types';
+import { CompilerCallbacks, CompilerEvent, compilerErrorSeverityName } from '@keymanapp/common-types';
 
 /**
  * Concrete implementation for CLI use
@@ -18,9 +17,16 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
       }
     }
   }
+
   reportMessage(event: CompilerEvent): void {
-    console.log(kmc.CompilerMessages.severityName(event.code) + ' ' + event.code.toString(16) + ': ' + event.message);
+    const code = event.code.toString(16);
+    if(event.line) {
+      console.log(`${compilerErrorSeverityName(event.code)} ${code} [${event.line}]: ${event.message}`);
+    } else {
+      console.log(`${compilerErrorSeverityName(event.code)} ${code}: ${event.message}`);
+    }
   }
+
   loadLdmlKeyboardSchema(): Buffer {
     let schemaPath = new URL('ldml-keyboard.schema.json', import.meta.url);
     return fs.readFileSync(schemaPath);


### PR DESCRIPTION
Moves to using the `reportMessage` callback for reporting all errors in kmc-kmn.

This required some patching to common/web/types in order to get the new constants in place and add support for line numbers to `CompilerEvent`, so at the same time I refactored `compilerErrorSeverityName` into the module.

After the refactor, coverage tests were failing because they included the test/ folder, so cleaned that up at the same time.

@keymanapp-test-bot skip