### PR TITLE
feat(developer): add CompilerMessages support to kmc-package

### DIFF
--- a/developer/src/kmc-package/src/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/kmp-compiler.ts
@@ -6,12 +6,17 @@ import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 import type { KpsFile, KpsFileContentFile, KpsFileInfo, KpsFileKeyboard, KpsFileLanguage, KpsFileLexicalModel, KpsFileOptions, KpsPackage } from './kps-file.js';
 import type { KmpJsonFile, KmpJsonFileInfo, KmpJsonFileLanguage, KmpJsonFileOptions } from './kmp-json-file.js';
+import { CompilerCallbacks } from 'common/web/types/build/src/main.js';
+import { CompilerMessages } from './messages.js';
 
 export { type KmpJsonFile } from './kmp-json-file.js';
 
 const FILEVERSION_KMP_JSON = '12.0';
 
 export default class KmpCompiler {
+
+  constructor(private callbacks: CompilerCallbacks) {
+  }
 
   public transformKpsToKmpObject(kpsString: string, kpsPath: string): KmpJsonFile {
 
@@ -234,7 +239,7 @@ export default class KmpCompiler {
       data.files = [];
     }
 
-    data.files.forEach(function(value) {
+    data.files.forEach((value) => {
       // Get the path of the file
       let filename = value.name;
 
@@ -246,7 +251,7 @@ export default class KmpCompiler {
       if(path.isAbsolute(value.name)) {
         // absolute paths are not very cross-platform compatible -- we are going to have trouble
         // with path separators and roots
-        // TODO: emit a warning
+        this.callbacks.reportMessage(CompilerMessages.Warn_AbsolutePath({filename: value.name}));
       } else {
         // Transform separators to platform separators -- kps files may use
         // either / or \, although older kps files were always \.

--- a/developer/src/kmc-package/src/messages.ts
+++ b/developer/src/kmc-package/src/messages.ts
@@ -1,0 +1,17 @@
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
+
+const Namespace = CompilerErrorNamespace.PackageCompiler;
+// const SevInfo = CompilerErrorSeverity.Info | Namespace;
+// const SevHint = CompilerErrorSeverity.Hint | Namespace;
+const SevWarn = CompilerErrorSeverity.Warn | Namespace;
+// const SevError = CompilerErrorSeverity.Error | Namespace;
+const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
+
+export class CompilerMessages {
+  static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException, `Unexpected exception: ${(o.e ?? 'unknown error').toString()}\n\nCall stack:\n${(o.e instanceof Error ? o.e.stack : (new Error()).stack)}`);
+  static FATAL_UnexpectedException = SevFatal | 0x0001;
+
+  static Warn_AbsolutePath = (o:{filename: string}) => m(this.WARN_AbsolutePath, `File ${o.filename} has an absolute path, which is not portable`);
+  static WARN_AbsolutePath = SevWarn | 0x0002;
+}
+

--- a/developer/src/kmc-package/src/messages.ts
+++ b/developer/src/kmc-package/src/messages.ts
@@ -4,7 +4,7 @@ const Namespace = CompilerErrorNamespace.PackageCompiler;
 // const SevInfo = CompilerErrorSeverity.Info | Namespace;
 // const SevHint = CompilerErrorSeverity.Hint | Namespace;
 const SevWarn = CompilerErrorSeverity.Warn | Namespace;
-// const SevError = CompilerErrorSeverity.Error | Namespace;
+const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
 export class CompilerMessages {
@@ -13,5 +13,11 @@ export class CompilerMessages {
 
   static Warn_AbsolutePath = (o:{filename: string}) => m(this.WARN_AbsolutePath, `File ${o.filename} has an absolute path, which is not portable`);
   static WARN_AbsolutePath = SevWarn | 0x0002;
+
+  static Error_FileDoesNotExist = (o:{filename: string}) => m(this.ERROR_FileDoesNotExist, `File ${o.filename} does not exist.`);
+  static ERROR_FileDoesNotExist = SevError | 0x0003;
+
+  static Error_FileCouldNotBeRead = (o:{filename: string; e: any}) => m(this.ERROR_FileCouldNotBeRead, `File ${o.filename} could not be read: ${(o.e ?? 'unknown error').toString()}.`);
+  static ERROR_FileCouldNotBeRead = SevError | 0x0004;
 }
 

--- a/developer/src/kmc-package/test/fixtures/absolute_path/source/absolute_path.kps
+++ b/developer/src/kmc-package/test/fixtures/absolute_path/source/absolute_path.kps
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Options>
+    <ExecuteProgram></ExecuteProgram>
+    <ReadMeFile></ReadMeFile>
+    <GraphicFile></GraphicFile>
+    <MSIFileName></MSIFileName>
+    <MSIOptions></MSIOptions>
+    <FollowKeyboardVersion/>
+  </Options>
+  <StartMenu>
+    <Folder></Folder>
+    <Items/>
+  </StartMenu>
+  <Info>
+    <Name URL="">Absolute Path</Name>
+  </Info>
+  <Files>
+    <File>
+      <Name>\build\absolute_path.kmx</Name>
+      <Description>File absolute_path.kmx</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+  </Files>
+</Package>

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -139,14 +139,11 @@ describe('KmpCompiler', function () {
       kmpJson = kmpCompiler.transformKpsToKmpObject(source, kpsPath);
     });
 
-    assert.doesNotThrow(async () => {
-      //assert.isNull( TODO: this should fail to build because of missing files. but that will come
-        await kmpCompiler.buildKmpFile(kpsPath, kmpJson)
-      //);
-    });
+    await assert.isNull(kmpCompiler.buildKmpFile(kpsPath, kmpJson));
 
-    assert.lengthOf(callbacks.messages, 1);
+    assert.lengthOf(callbacks.messages, 2);
     assert.deepEqual(callbacks.messages[0].code, CompilerMessages.WARN_AbsolutePath);
+    assert.deepEqual(callbacks.messages[1].code, CompilerMessages.ERROR_FileDoesNotExist); //TODO: this should be a file-missing-error
   });
 
 });

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -7,6 +7,8 @@ import {makePathToFixture} from './helpers/index.js';
 import JSZip from 'jszip';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
 import { type KmpJsonFile } from '../src/kmp-json-file.js';
+import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
+
 
 describe('KmpCompiler', function () {
   const MODELS : string[] = [
@@ -14,7 +16,8 @@ describe('KmpCompiler', function () {
     'withfolders.qaa.sencoten',
   ];
 
-  let kmpCompiler = new KmpCompiler();
+  const callbacks = new TestCompilerCallbacks();
+  let kmpCompiler = new KmpCompiler(callbacks);
 
   for (let modelID of MODELS) {
     const kpsPath = modelID.includes('withfolders') ?
@@ -78,11 +81,13 @@ describe('KmpCompiler', function () {
   }
 
   it('should generates a valid .kmp (zip) file', async function() {
+    this.timeout(10000); // building a zip file can sometimes be slow
+
     // const kmpPath = makePathToFixture('khmer_angkor', 'build', 'khmer_angkor.kmp');
     const kpsPath = makePathToFixture('khmer_angkor', 'source', 'khmer_angkor.kps');
     const kmpJsonRefPath = makePathToFixture('khmer_angkor', 'ref', 'kmp.json');
 
-    const kmpCompiler = new KmpCompiler();
+    const kmpCompiler = new KmpCompiler(callbacks);
     const source = fs.readFileSync(kpsPath, 'utf-8');
     const kmpJsonFixture: KmpJsonFile = JSON.parse(fs.readFileSync(kmpJsonRefPath, 'utf-8'));
 

--- a/developer/src/kmc/src/kmlmi.ts
+++ b/developer/src/kmc/src/kmlmi.ts
@@ -10,6 +10,7 @@ import KmpCompiler from '@keymanapp/kmc-package';
 import { ModelInfoOptions as ModelInfoOptions, writeMergedModelMetadataFile } from '@keymanapp/kmc-model-info';
 import { SysExits } from './util/sysexits.js';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
+import { NodeCompilerCallbacks } from './util/NodeCompilerCallbacks.js';
 
 let inputFilename: string;
 const program = new Command();
@@ -45,8 +46,9 @@ let jsFilename = program.opts().jsFilename ? program.opts().jsFilename : path.jo
 // Load .kps source data
 //
 
+const callbacks = new NodeCompilerCallbacks();
 let kpsString: string = fs.readFileSync(kpsFilename, 'utf8');
-let kmpCompiler = new KmpCompiler();
+let kmpCompiler = new KmpCompiler(callbacks);
 let kmpJsonData = kmpCompiler.transformKpsToKmpObject(kpsString, kpsFilename);
 
 //

--- a/developer/src/kmc/src/kmlmp.ts
+++ b/developer/src/kmc/src/kmlmp.ts
@@ -8,6 +8,7 @@ import { Command } from 'commander';
 import KmpCompiler from '@keymanapp/kmc-package';
 import { SysExits } from './util/sysexits.js';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
+import { NodeCompilerCallbacks } from './util/NodeCompilerCallbacks.js';
 
 let inputFilename: string;
 const program = new Command();
@@ -34,8 +35,9 @@ let outputFilename: string = program.opts().outFile ? program.opts().outFile : i
 // Load .kps source data
 //
 
+const callbacks = new NodeCompilerCallbacks();
 let kpsString: string = fs.readFileSync(inputFilename, 'utf8');
-let kmpCompiler = new KmpCompiler();
+let kmpCompiler = new KmpCompiler(callbacks);
 let kmpJsonData = kmpCompiler.transformKpsToKmpObject(kpsString, inputFilename);
 
 //


### PR DESCRIPTION
Relates to #8150.

Adds basic infrastructure for CompilerMessages events, along with file-existence check and absolute path warnings. Additional warnings,
errors, and hints to come.

@keymanapp-test-bot skip