### PR TITLE
chore(web): sets kmc-model as dependency of input-processor test action

### DIFF
--- a/common/web/input-processor/build.sh
+++ b/common/web/input-processor/build.sh
@@ -23,20 +23,16 @@ builder_describe "Builds the standalone, headless form of Keyman Engine for Web'
   "@/common/web/keyman-version" \
   "@/common/web/keyboard-processor" \
   "@/common/predictive-text" \
+  "@/developer/src/kmc-model test:module" \
   "clean" \
   "configure" \
   "build" \
   "test" \
-  ":module     A headless, Node-oriented version of the module useful for unit tests" \
-  ":tools      Related tools useful for development and testing of this module" \
   "--ci        Sets $(builder_term test) action to use CI-based test configurations & reporting"
 
 builder_describe_outputs \
   configure          /node_modules \
-  configure:module   /node_modules \
-  configure:tools    /node_modules \
-  build:module       /common/web/input-processor/build/index.js \
-  build:tools        /developer/src/kmc/build/src/kmlmc.js    # TODO: remove this once kmlmc is a dependency
+  build              /common/web/input-processor/build/index.js
 
 builder_parse "$@"
 
@@ -56,27 +52,14 @@ fi
 
 ### BUILD ACTIONS
 
-if builder_start_action build:tools; then
-  # Used by test:module
-  # TODO: convert to a dependency once we have updated kmlmc to use builder script
-  pushd "$KEYMAN_ROOT/developer/src/kmc-model"
-  ./build.sh
-  popd
-  pushd "$KEYMAN_ROOT/developer/src/kmc"
-  ./build.sh
-  popd
-
-  builder_finish_action success build:tools
-fi
-
-if builder_start_action build:module; then
+if builder_start_action build; then
   tsc -b src/tsconfig.json
-  builder_finish_action success build:module
+  builder_finish_action success build
 fi
 
 # TEST ACTIONS
 
-if builder_start_action test:module; then
+if builder_start_action test; then
   FLAGS=
   if builder_has_option --ci; then
     FLAGS="--reporter mocha-teamcity-reporter"
@@ -87,5 +70,5 @@ if builder_start_action test:module; then
 
   mocha --recursive $FLAGS ./tests/cases/
 
-  builder_finish_action success test:module
+  builder_finish_action success test
 fi

--- a/common/web/input-processor/build.sh
+++ b/common/web/input-processor/build.sh
@@ -8,22 +8,20 @@ set -eu
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../resources/build/build-utils.sh"
-. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
 # This script runs from its own folder
-cd "$(dirname "$THIS_SCRIPT")"
+cd "$THIS_SCRIPT_PATH"
 
 ################################ Main script ################################
-
-# TODO: for predictive-text, we only need :headless, perhaps we should be splitting modules?
-# TODO: remove :tools once kmlmc is a dependency for test:module
 
 builder_describe "Builds the standalone, headless form of Keyman Engine for Web's input-processor module" \
   "@/common/web/keyman-version" \
   "@/common/web/keyboard-processor" \
   "@/common/predictive-text" \
-  "@/developer/src/kmc-model test:module" \
+  "@/developer/src/kmc-model test" \
   "clean" \
   "configure" \
   "build" \
@@ -53,7 +51,7 @@ fi
 ### BUILD ACTIONS
 
 if builder_start_action build; then
-  tsc -b src/tsconfig.json
+  tsc --build src/tsconfig.json
   builder_finish_action success build
 fi
 

--- a/web/test.sh
+++ b/web/test.sh
@@ -38,7 +38,7 @@ if builder_start_action test:libraries; then
   # No --reporter option exists yet for the headless modules.
 
   $KEYMAN_ROOT/common/web/keyboard-processor/build.sh test $HEADLESS_FLAGS
-  $KEYMAN_ROOT/common/web/input-processor/build.sh build:tools test $HEADLESS_FLAGS
+  $KEYMAN_ROOT/common/web/input-processor/build.sh test $HEADLESS_FLAGS
 
   builder_finish_action success test:libraries
 fi


### PR DESCRIPTION
Not sure why both `kmc` and `kmc-model` were being built; only the latter is needed.  Also, now that `kmc-model` has a builder-based script, we can directly use builder dependencies to link it in.

@keymanapp-test-bot skip