### PR TITLE
fix(developer): kmc-package path reference

### DIFF
--- a/developer/src/kmc/src/commands/build/BuildPackage.ts
+++ b/developer/src/kmc/src/commands/build/BuildPackage.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import { BuildActivity, BuildActivityOptions } from './BuildActivity.js';
 import KmpCompiler from '@keymanapp/kmc-package';
 import { CompilerCallbacks } from '@keymanapp/common-types';
-import { NodeCompilerCallbacks } from 'src/util/NodeCompilerCallbacks.js';
+import { NodeCompilerCallbacks } from '../../util/NodeCompilerCallbacks.js';
 
 export class BuildPackage extends BuildActivity {
   public get name(): string { return 'Package'; }


### PR DESCRIPTION
@keymanapp-test-bot skip

This was breaking core build due to a broken path ref