### PR TITLE
chore(developer): only run keyboards-repo tests for a full-test

### DIFF
--- a/developer/src/kmcmplib/build.sh
+++ b/developer/src/kmcmplib/build.sh
@@ -52,6 +52,7 @@ Libraries will be built in 'build/<target>/<configuration>/src'.
   "build" \
   "test" \
   "${archtargets[@]}" \
+  "--full-test                     also run expensive tests that rely on keyboards repo" \
   "--test=opt_tests,-t             test[s] to run (space separated)"
 
 builder_parse "$@"
@@ -81,7 +82,9 @@ do_action() {
   done
 }
 
-locate_keyboards_repo
+if builder_has_option --full-test; then
+  locate_keyboards_repo
+fi
 
 # Note, we have a 'global' clean and also a per-arch clean
 if builder_start_action clean; then
@@ -102,11 +105,13 @@ if builder_start_action configure; then
   # We have to checkout the keyboards repo in a 'configure' action because
   # otherwise meson will not get the right list of keyboard source files,
   # even though we only use it in the 'test' action
-  checkout_keyboards
+  if builder_has_option --full-test; then
+    checkout_keyboards
+  fi
+
   builder_finish_action success configure
 fi
 
 do_action configure
-
 do_action build
 do_action test

--- a/developer/src/kmcmplib/commands.inc.sh
+++ b/developer/src/kmcmplib/commands.inc.sh
@@ -74,7 +74,10 @@ do_test() {
 
   # Works on a local clone of keyboards repository, to avoid clobbering
   # user's existing keyboards repo, if present
-  checkout_keyboards
+
+  if builder_has_option --full-test; then
+    checkout_keyboards
+  fi
 
   if [[ $target =~ ^(x86|x64)$ ]]; then
     cmd //C build.bat $target $BUILDER_CONFIGURATION test "${builder_extra_params[@]}"

--- a/developer/src/kmcmplib/meson_options.txt
+++ b/developer/src/kmcmplib/meson_options.txt
@@ -1,0 +1,1 @@
+option('full_test', type: 'boolean', value: false)

--- a/developer/src/kmcmplib/tests/README.md
+++ b/developer/src/kmcmplib/tests/README.md
@@ -1,5 +1,8 @@
 # Unit tests for kmcmplib
 
+**Note:** the keyboards repository tests only run if --full-test is passed to
+build.sh.
+
 kmcmplib tests include building all keyboards in the keyboards repository and
 comparing against a 'known good' legacy compiler set. This is trickier than it
 sounds because the legacy compiler only runs under Windows/WINE and we don't

--- a/developer/src/kmcmplib/tests/meson.build
+++ b/developer/src/kmcmplib/tests/meson.build
@@ -74,30 +74,36 @@ foreach kbd : tests
   test(kbd, kmcompxtest, args: [kbd_src, kbd_obj, join_paths(input_path, kbd) + '.kmx'])
 endforeach
 
-# Test fixtures that come from keyboards repo
+# Test fixtures that come from keyboards repo -- but only for a "full" test,
+# which typically we run on CI no more than once a day, because it's expensive.
 
-keyboards_root = meson.current_source_dir() / 'keyboards'
+if get_option('full_test')
 
-if build_machine.system() == 'windows'
-  test_source = run_command('run-shell.bat', 'get-test-source.sh', keyboards_root, capture: true, check: true)
-else
-  test_source = run_command('get-test-source.sh', keyboards_root, capture: true, check: true)
+  keyboards_root = meson.current_source_dir() / 'keyboards'
+
+  if build_machine.system() == 'windows'
+    test_source = run_command('run-shell.bat', 'get-test-source.sh', keyboards_root, capture: true, check: true)
+  else
+    test_source = run_command('get-test-source.sh', keyboards_root, capture: true, check: true)
+  endif
+
+  tests = test_source.stdout().strip().split('\n')
+
+  foreach kbd : tests
+    test_basename = fs.replace_suffix(fs.name(kbd), '')
+
+    # kbd is going to be an absolute path
+    kbd_obj = output_path / test_basename + '.kmx'
+    reference_kmx = meson.current_source_dir() / 'fixtures' / test_basename + '.kmx'
+
+    if fs.is_file(reference_kmx)
+      test(test_basename, kmcompxtest, args: [kbd, kbd_obj, reference_kmx])
+    endif
+  endforeach
+
 endif
 
-tests = test_source.stdout().strip().split('\n')
-
-foreach kbd : tests
-  test_basename = fs.replace_suffix(fs.name(kbd), '')
-
-  # kbd is going to be an absolute path
-  kbd_obj = output_path / test_basename + '.kmx'
-  reference_kmx = meson.current_source_dir() / 'fixtures' / test_basename + '.kmx'
-
-  if fs.is_file(reference_kmx)
-    test(test_basename, kmcompxtest, args: [kbd, kbd_obj, reference_kmx])
-  endif
-endforeach
-
+# Test the API endpoints
 
 apitest = executable('api-test', 'api-test.cpp',
     cpp_args: defns,


### PR DESCRIPTION
If kmcmplib build includes the --full-test flag, then configure and run tests that include pulling in the keyboards repo; otherwise skip all of that.

This will require CI changes to run full tests, relating to #8361.

@keymanapp-test-bot skip