### PR TITLE
fix(android/engine): Update InApp input connection 🛋

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -158,7 +158,6 @@ public final class KMManager {
   };
 
   protected static InputMethodService IMService;
-  protected static InputConnection inappInputConnection; // Input Connection for InApp Keyboard
 
   private static boolean debugMode = false;
   private static boolean shouldAllowSetKeyboard = true;
@@ -461,16 +460,12 @@ public final class KMManager {
 
   /**
    * Get the input connection based on the keyboard type.
-   * For InApp keyboard, save the connection to inappInputConnection
    * @param {KeyboardType} keyboard
    * @return InputConnection
    */
   protected static InputConnection getInputConnection(KeyboardType keyboard) {
     if (keyboard == KeyboardType.KEYBOARD_TYPE_INAPP) {
-      if (inappInputConnection == null) {
-        inappInputConnection = KMTextView.activeView.onCreateInputConnection(new EditorInfo());
-      }
-      return inappInputConnection;
+      return KMTextView.activeView.onCreateInputConnection(new EditorInfo());
     } else if (keyboard == KeyboardType.KEYBOARD_TYPE_SYSTEM && IMService != null) {
       return IMService.getCurrentInputConnection();
     }


### PR DESCRIPTION
Fixes  #8639 and maybe fixes/addresses #8548 too  (part of #7881 refactoring)

Regression introduced in #8483 

It turns out the Keyman app is recreated when changing the Display Language. So we can't reuse the inappInputConnection handle.

## User Testing
Setup - Install PR build of Keyman for Android

* **TEST_CHANGING_DISPLAY_LANGUAGE** - Verifies inapp keyboard works after changing display language
1. Open Keyman In-App.
2. Type a word (eg., Testing) in the text input screen.
3. We may notice that the typed word appears on the screen.
4. Change the Display Language into Amharic.
6. Revert to Home Screen.
7. Type a word (eg., testing) in the text input screen.
8. Verify typed text appears

* **TEST_SETTING_SYSTEM_KETYBOARD** -  Verifies inapp keyboard works after setting Keyman as system keyboard
1. Install the PR build of Keyman for Android in an Android Mobile / emulator. 
2. Set the sil_eurolatin keyboard as the system wide and default keyboard. 
3. Type some texts in the Keyman In-app. We may able to see the typed text in the text area. 
4. Close the application. 
5. Open Chrome browser. 
6. Click the Search field in the chrome browser. 
7. Verify that the Keyman Keyboard (sil_eurolatin) appears on the screen. 
8. Type some texts using the system keyboard. 
9. Close the browser. 
10. Open Keyman In-App. 
11. Type some text. 
12. Verify typed text appears
 
(edit) Per review comments, adding two tests from #8611 below
* **TEST_UNDO_SUGGESTION** - Verifies backspace after a suggestion works (suggestion reverts to context)
1. Launch Keyman for Android
2. From Keyman settings --> Change the Display Language into Khmer.
3. With the sil_euro_latin keyboard, type "prob"
4. Select "problem" from the suggestion banner
5. Press <kbd>Backspace</kbd> key
6. Verify "prob" is now the left suggestion (the context before accepting the suggestion)
7. Select "prob" from the suggestion banner
8. Verify the text changes from "problem" to "prob"

* **TEST_REPLACE_SELECTION_DEADKEYS** - Verifies keyboard replaces selected text and handles deadkeys
1. Launch Keyman for Android
2. From Keyman Settings --> Install the Basic French (basic_kbdfr) keyboard
3. From Keyman Settings --> Change the Display Language to Hausa.
4. In Keyman with the sil_euro_latin keyboard, type "the quick brown fox"
5. Select the letters "row" within the word "brown". (keyboard switches to shift layer)
6. Type "H"
7. Verify the text changes from "brown" to "bHn"
8. Select the letters "ick" within the word "quick"
9. Press <kbd>backspace</kbd> key
10. Verify the text changes from "quick" to "qu"
11. Select the letter "o" within the word "fox"
12. Press <kbd>enter</kbd> key
13. verify the word changes from "fox" to "f" followed by "x" on the next line
14. Use the Keyman globe key to switch to the basic_kbdfr keyboard
15. Press the green </kbd>^</kbd>
16. Verify nothing is output (it's a deadkey)
17. Press a vowel
18. Verify the vowel with the combined diacritic is output
