### PR TITLE
feat(developer): use CompilerEvent for messages in all of kmc

### DIFF
--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -18,7 +18,7 @@ export { default as LDMLKeyboardXMLSourceFileReader } from './ldml-keyboard/ldml
 
 export * as Constants from './consts/virtual-key-constants.js';
 
-export { CompilerCallbacks, CompilerEvent, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec, compilerErrorSeverityName } from './util/compiler-interfaces.js';
+export { CompilerCallbacks, CompilerSchema, CompilerEvent, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec, compilerErrorSeverityName } from './util/compiler-interfaces.js';
 export { CommonTypesMessages } from './util/common-events.js';
 
 export * as TouchLayout from './keyman-touch-layout/keyman-touch-layout-file.js';

--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -66,6 +66,13 @@ export enum CompilerErrorNamespace {
   Infrastructure = 0x5000,
 };
 
+export type CompilerSchema =
+  'ldml-keyboard' |
+  'ldml-keyboardtest' |
+  'kvks' |
+  'kpj';
+  // | 'keyman-touch-layout.clean'; TODO this has the wrong name pattern, .spec.json instead of .schema.json
+
 /**
  * Abstract interface for callbacks, to abstract out file i/o
  */
@@ -76,11 +83,9 @@ export interface CompilerCallbacks {
    * @param filename
    */
   loadFile(baseFilename: string, filename: string | URL): Buffer;
-  loadLdmlKeyboardSchema(): Buffer;
-  loadLdmlKeyboardTestSchema(): Buffer;
+  loadSchema(schema: CompilerSchema): Buffer;
   reportMessage(event: CompilerEvent): void;
-  loadKvksJsonSchema(): Buffer;
-  loadKpjJsonSchema(): Buffer;
+  debug(msg: string): void;
 };
 
 /**

--- a/common/web/types/test/helpers/index.ts
+++ b/common/web/types/test/helpers/index.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
+import { CompilerSchema } from "../../src/util/compiler-interfaces.js";
 
 /**
  * Builds a path to the fixture with the given path components.
@@ -13,11 +14,8 @@ export function makePathToFixture(...components: string[]): string {
   return fileURLToPath(new URL(path.join('..', '..', '..', 'test', 'fixtures', ...components), import.meta.url));
 }
 
-export function loadKvksJsonSchema(): Buffer {
-  return fs.readFileSync(new URL(path.join('..', '..', 'src', 'kvks.schema.json'), import.meta.url));
-}
-
 export function loadKeymanTouchLayoutCleanJsonSchema(): Buffer {
+  // TODO: this has the Wrong Name Pattern!
   return fs.readFileSync(new URL(path.join('..', '..', 'src', 'keyman-touch-layout.clean.spec.json'), import.meta.url));
 }
 
@@ -26,14 +24,6 @@ export function loadFile(baseFilename: string, filename: string | URL): Buffer {
   return fs.readFileSync(filename);
 }
 
-export function loadLdmlKeyboardSchema(): Buffer {
-  return fs.readFileSync(new URL(path.join('..', '..', 'src', 'ldml-keyboard.schema.json'), import.meta.url));
-}
-
-export function loadLdmlKeyboardTestDataSchema(): Buffer {
-  return fs.readFileSync(new URL(path.join('..', '..', 'src', 'ldml-keyboardtest.schema.json'), import.meta.url));
-}
-
-export function loadKpjJsonSchema(): Buffer {
-  return fs.readFileSync(new URL(path.join('..', '..', 'src', 'kpj.schema.json'), import.meta.url));
+export function loadSchema(schema: CompilerSchema): Buffer {
+  return fs.readFileSync(new URL(path.join('..', '..', 'src', schema + '.schema.json'), import.meta.url));
 }

--- a/common/web/types/test/helpers/reader-callback-test.ts
+++ b/common/web/types/test/helpers/reader-callback-test.ts
@@ -1,8 +1,8 @@
 import 'mocha';
 import {assert} from 'chai';
-import {loadLdmlKeyboardSchema, loadFile, makePathToFixture, loadLdmlKeyboardTestDataSchema} from '../helpers/index.js';
+import { loadFile, makePathToFixture, loadSchema } from '../helpers/index.js';
 import LDMLKeyboardXMLSourceFileReader from '../../src/ldml-keyboard/ldml-keyboard-xml-reader.js';
-import { CompilerCallbacks, CompilerEvent } from '../../src/util/compiler-interfaces.js';
+import { CompilerCallbacks, CompilerEvent, CompilerSchema } from '../../src/util/compiler-interfaces.js';
 import { LDMLKeyboardXMLSourceFile } from '../../src/ldml-keyboard/ldml-keyboard-xml.js';
 import { LDMLKeyboardTestDataXMLSourceFile } from '../ldml-keyboard/ldml-keyboard-testdata-xml.js';
 
@@ -13,20 +13,23 @@ import { LDMLKeyboardTestDataXMLSourceFile } from '../ldml-keyboard/ldml-keyboar
  * A CompilerCallbacks implementation for testing
  */
 class TestCompilerCallbacks implements CompilerCallbacks {
-  loadKpjJsonSchema(): Buffer {
-    throw new Error('loadKpjJsonSchema not implemented.'); // not needed for this test
-  }
-  loadLdmlKeyboardTestSchema(): Buffer {
-    return loadLdmlKeyboardTestDataSchema();
-  }
-  loadLdmlKeyboardSchema(): Buffer {
-    return loadLdmlKeyboardSchema();
-  }
-  loadKvksJsonSchema(): Buffer {
-    throw new Error('loadKvksJsonSchema not implemented.');
+  loadSchema(schema: CompilerSchema): Buffer {
+    switch(schema) {
+      case 'kpj':
+        throw new Error('loadKpjJsonSchema not implemented.'); // not needed for this test
+      case 'kvks':
+        throw new Error('loadKvksJsonSchema not implemented.');
+      case 'ldml-keyboard':
+        return loadSchema(schema);
+      case 'ldml-keyboardtest':
+        return loadSchema(schema);
+    }
   }
   clear() {
     this.messages = [];
+  }
+  debug(msg: string): void {
+    console.debug(msg);
   }
   messages: CompilerEvent[] = [];
   loadFile(baseFilename: string, filename: string | URL): Buffer {
@@ -128,9 +131,9 @@ export function testReaderCases(cases : CompilationCase[]) {
       }
       // special case for an expected exception
       if (testcase.throws) {
-        assert.throws(() => reader.validate(source, loadLdmlKeyboardSchema()), testcase.throws);
+        assert.throws(() => reader.validate(source, loadSchema('ldml-keyboard')), testcase.throws);
       } else {
-        assert.doesNotThrow(() => reader.validate(source, loadLdmlKeyboardSchema()), `validating ${testcase.subpath}`);
+        assert.doesNotThrow(() => reader.validate(source, loadSchema('ldml-keyboard')), `validating ${testcase.subpath}`);
         // if we expected errors or warnings, show them
         if (testcase.errors) {
           assert.includeDeepMembers(callbacks.messages, testcase.errors, 'expected errors to be included');

--- a/common/web/types/test/kpj/test-kpj-file-reader.ts
+++ b/common/web/types/test/kpj/test-kpj-file-reader.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import 'mocha';
 import {assert} from 'chai';
-import { loadKpjJsonSchema, makePathToFixture } from '../helpers/index.js';
+import { loadSchema, makePathToFixture } from '../helpers/index.js';
 import { KPJFileReader } from "../../src/kpj/kpj-file-reader.js";
 import { KeymanDeveloperProjectFile10, KeymanDeveloperProjectType } from '../../src/kpj/keyman-developer-project.js';
 
@@ -14,7 +14,7 @@ describe('kpj-file-reader', function () {
     const kpj = reader.read(input);
     console.dir(kpj);
     assert.doesNotThrow(() => {
-      reader.validate(kpj, loadKpjJsonSchema());
+      reader.validate(kpj, loadSchema('kpj'));
     });
     assert.equal(kpj.KeymanDeveloperProject.Options.BuildPath, '$PROJECTPATH\\build');
     assert.equal(kpj.KeymanDeveloperProject.Options.CheckFilenameConventions, 'False');

--- a/common/web/types/test/kvk/test-kvk-round-trip.ts
+++ b/common/web/types/test/kvk/test-kvk-round-trip.ts
@@ -4,7 +4,7 @@ import {assert} from 'chai';
 import Hexy from 'hexy';
 import gitDiff from 'git-diff';
 const { hexy } = Hexy;
-import { loadKvksJsonSchema, makePathToFixture } from '../helpers/index.js';
+import { loadSchema, makePathToFixture } from '../helpers/index.js';
 import KvksFileReader, { KVKSParseError } from "../../src/kvk/kvks-file-reader.js";
 import KvkFileReader from "../../src/kvk/kvk-file-reader.js";
 import KvkFileWriter from "../../src/kvk/kvk-file-writer.js";
@@ -51,7 +51,7 @@ describe('kvks-file-reader', function () {
     const reader = new KvksFileReader();
     const kvks = reader.read(input);
     assert.doesNotThrow(() => {
-      reader.validate(kvks, loadKvksJsonSchema());
+      reader.validate(kvks, loadSchema('kvks'));
     });
     const errors: KVKSParseError[] = [];
     const vk = reader.transform(kvks, errors);
@@ -74,7 +74,7 @@ describe('kvks-file-reader', function () {
       // Now, re-read kvk from the kvks
       const kvks = kvksReader.read(Buffer.from(kvksOut));
       assert.doesNotThrow(() => {
-        kvksReader.validate(kvks, loadKvksJsonSchema());
+        kvksReader.validate(kvks, loadSchema('kvks'));
       });
       const errors: KVKSParseError[] = [];
       const vk2 = kvksReader.transform(kvks, errors);

--- a/common/web/types/test/kvk/test-kvks-file.ts
+++ b/common/web/types/test/kvk/test-kvks-file.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import 'mocha';
-import { loadKvksJsonSchema, makePathToFixture } from '../helpers/index.js';
+import { loadSchema, makePathToFixture } from '../helpers/index.js';
 import KvksFileReader, { KVKSParseError } from "../../src/kvk/kvks-file-reader.js";
 import KvksFileWriter from "../../src/kvk/kvks-file-writer.js";
 import { verify_khmer_angkor } from './test-kvk-utils.js';
@@ -14,7 +14,7 @@ describe('kvks-file-reader', function() {
     const reader = new KvksFileReader();
     const kvks = reader.read(input);
     assert.doesNotThrow(() => {
-      reader.validate(kvks, loadKvksJsonSchema());
+      reader.validate(kvks, loadSchema('kvks'));
     });
     const errors: KVKSParseError[] = [];
     const vk = reader.transform(kvks, errors);

--- a/developer/src/common/web/test-helpers/index.ts
+++ b/developer/src/common/web/test-helpers/index.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { CompilerEvent, CompilerCallbacks } from '@keymanapp/common-types';
+import { CompilerEvent, CompilerCallbacks, CompilerSchema } from '@keymanapp/common-types';
 
 // TODO: schemas are only used by kmc-keyboard for now, so this works at this
 // time, but it's a little fragile if we need them elsewhere in the future
@@ -9,10 +9,20 @@ const SCHEMA_BASE = '../../../../kmc-keyboard/build/src/';
  * A CompilerCallbacks implementation for testing
  */
 export class TestCompilerCallbacks implements CompilerCallbacks {
+  /* TestCompilerCallbacks */
+
+  messages: CompilerEvent[] = [];
+
   clear() {
     this.messages = [];
   }
-  messages: CompilerEvent[] = [];
+
+  hasMessage(code: number): boolean {
+    return this.messages.find((item) => item.code == code) === undefined ? false : true;
+  }
+
+  /* CompilerCallbacks */
+
   loadFile(baseFilename: string, filename: string | URL): Buffer {
     // TODO: translate filename based on the baseFilename
     try {
@@ -25,23 +35,16 @@ export class TestCompilerCallbacks implements CompilerCallbacks {
       }
     }
   }
-  hasMessage(code: number): boolean {
-    return this.messages.find((item) => item.code == code) === undefined ? false : true;
-  }
   reportMessage(event: CompilerEvent): void {
     // console.log(event.message);
     this.messages.push(event);
   }
-  loadLdmlKeyboardSchema(): Buffer {
-    return fs.readFileSync(new URL(SCHEMA_BASE + 'ldml-keyboard.schema.json', import.meta.url));
+
+  loadSchema(schema: CompilerSchema): Buffer {
+    return fs.readFileSync(new URL(SCHEMA_BASE + schema + '.schema.json', import.meta.url));
   }
-  loadKvksJsonSchema(): Buffer {
-    return fs.readFileSync(new URL(SCHEMA_BASE + 'kvks.schema.json', import.meta.url));
-  }
-  loadKpjJsonSchema(): Buffer {
-    return fs.readFileSync(new URL(SCHEMA_BASE + 'kpj.schema.json', import.meta.url));
-  }
-  loadLdmlKeyboardTestSchema(): Buffer {
-    return fs.readFileSync(new URL(SCHEMA_BASE + 'ldml-keyboardtest.schema.json', import.meta.url));
+
+  debug(msg: string) {
+    console.debug(msg);
   }
 };

--- a/developer/src/kmc-keyboard/src/compiler/compiler.ts
+++ b/developer/src/kmc-keyboard/src/compiler/compiler.ts
@@ -66,7 +66,7 @@ export default class Compiler {
       return null;
     }
     try {
-      if (!reader.validate(source, this.callbacks.loadLdmlKeyboardSchema())) {
+      if (!reader.validate(source, this.callbacks.loadSchema('ldml-keyboard'))) {
         return null;
       }
     } catch(e) {
@@ -98,7 +98,7 @@ export default class Compiler {
       // TODO-LDML: The unboxed data doesn't match the schema anymore. Skipping validation, for now.
 
       // try {
-      //   if (!reader.validate(source, this.callbacks.loadLdmlKeyboardTestSchema())) {
+      //   if (!reader.validate(source, this.callbacks.loadSchema('ldml-keyboard-test'))) {
       //     return null;
       //   }
       // } catch(e) {

--- a/developer/src/kmc-keyboard/test/helpers/index.ts
+++ b/developer/src/kmc-keyboard/test/helpers/index.ts
@@ -54,7 +54,7 @@ export function loadSectionFixture(compilerClass: typeof SectionCompiler, filena
   const source = reader.load(data);
   assert.isNotNull(source);
 
-  if (!reader.validate(source, callbacks.loadLdmlKeyboardSchema())) {
+  if (!reader.validate(source, callbacks.loadSchema('ldml-keyboard'))) {
     return null; // mimic kmc behavior - bail if validate fails
   }
 

--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -3,8 +3,8 @@ import { Command } from 'commander';
 import { BuildActivityOptions } from './build/BuildActivity.js';
 import { buildActivities } from './build/buildActivities.js';
 import { BuildProject } from './build/BuildProject.js';
-import { NodeCompilerCallbacks } from 'src/messages/NodeCompilerCallbacks.js';
-import { InfrastructureMessages } from 'src/messages/messages.js';
+import { NodeCompilerCallbacks } from '../messages/NodeCompilerCallbacks.js';
+import { InfrastructureMessages } from '../messages/messages.js';
 
 export function declareBuild(program: Command) {
   program

--- a/developer/src/kmc/src/commands/build/BuildActivity.ts
+++ b/developer/src/kmc/src/commands/build/BuildActivity.ts
@@ -1,3 +1,4 @@
+import { CompilerCallbacks } from "@keymanapp/common-types";
 import { escapeRegExp } from "../../util/escapeRegExp.js";
 
 export interface BuildActivityOptions {
@@ -13,7 +14,7 @@ export abstract class BuildActivity {
   public abstract get sourceExtension(): string;
   public abstract get compiledExtension(): string;
   public abstract get description(): string;
-  public abstract build(infile: string, options: BuildActivityOptions): Promise<boolean>;
+  public abstract build(infile: string, callbacks: CompilerCallbacks, options: BuildActivityOptions): Promise<boolean>;
   protected getOutputFilename(infile: string, options: BuildActivityOptions): string {
     return options.outFile ?
       options.outFile :

--- a/developer/src/kmc/src/commands/build/BuildKmnKeyboard.ts
+++ b/developer/src/kmc/src/commands/build/BuildKmnKeyboard.ts
@@ -2,20 +2,18 @@ import * as path from 'path';
 import { BuildActivity, BuildActivityOptions } from './BuildActivity.js';
 import { Compiler } from '@keymanapp/kmc-kmn';
 import { platform } from 'os';
-import { NodeCompilerCallbacks } from '../../util/NodeCompilerCallbacks.js';
+import { CompilerCallbacks } from '@keymanapp/common-types';
 
 export class BuildKmnKeyboard extends BuildActivity {
   public get name(): string { return 'Keyman keyboard'; }
   public get sourceExtension(): string { return '.kmn'; }
   public get compiledExtension(): string { return '.kmx'; }
   public get description(): string { return 'Build a Keyman keyboard'; }
-  public async build(infile: string, options: BuildActivityOptions): Promise<boolean> {
+  public async build(infile: string, callbacks: CompilerCallbacks, options: BuildActivityOptions): Promise<boolean> {
     let compiler = new Compiler();
     if(!await compiler.init()) {
       return false;
     }
-
-    const callbacks = new NodeCompilerCallbacks();
 
     // We need to resolve paths to absolute paths before calling kmc-kmn
     let outfile = this.getOutputFilename(infile, options);

--- a/developer/src/kmc/src/commands/build/BuildLdmlKeyboard.ts
+++ b/developer/src/kmc/src/commands/build/BuildLdmlKeyboard.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as kmc from '@keymanapp/kmc-keyboard';
 import { KvkFileWriter, CompilerCallbacks } from '@keymanapp/common-types';
-import { NodeCompilerCallbacks } from '../../util/NodeCompilerCallbacks.js';
 import { BuildActivity, BuildActivityOptions } from './BuildActivity.js';
 
 export class BuildLdmlKeyboard extends BuildActivity {
@@ -10,10 +9,10 @@ export class BuildLdmlKeyboard extends BuildActivity {
   public get sourceExtension(): string { return '.xml'; }
   public get compiledExtension(): string { return '.kmx'; }
   public get description(): string { return 'Build a LDML keyboard'; }
-  public async build(infile: string, options: BuildActivityOptions): Promise<boolean> {
+  public async build(infile: string, callbacks: CompilerCallbacks, options: BuildActivityOptions): Promise<boolean> {
     // TODO-LDML: consider hardware vs touch -- touch-only layout will not have a .kvk
     // Compile:
-    let [kmx,kvk,kmw] = buildLdmlKeyboardToMemory(infile, options);
+    let [kmx,kvk,kmw] = buildLdmlKeyboardToMemory(infile, callbacks, options);
     // Output:
 
     const fileBaseName = options.outFile ?? infile;
@@ -43,7 +42,7 @@ export class BuildLdmlKeyboard extends BuildActivity {
   }
 }
 
-function buildLdmlKeyboardToMemory(inputFilename: string, options: BuildActivityOptions): [Uint8Array, Uint8Array, Uint8Array] {
+function buildLdmlKeyboardToMemory(inputFilename: string, callbacks: CompilerCallbacks, options: BuildActivityOptions): [Uint8Array, Uint8Array, Uint8Array] {
   let compilerOptions: kmc.CompilerOptions = {
     debug: options.debug ?? false,
     addCompilerVersion: options.compilerVersion ?? true,
@@ -51,8 +50,7 @@ function buildLdmlKeyboardToMemory(inputFilename: string, options: BuildActivity
     // TODO: treatWarningsAsErrors: options.treatWarningsAsErrors,
   }
 
-  const c: CompilerCallbacks = new NodeCompilerCallbacks();
-  const k = new kmc.Compiler(c, options);
+  const k = new kmc.Compiler(callbacks, options);
   let source = k.load(inputFilename);
   if (!source) {
     return [null, null, null];

--- a/developer/src/kmc/src/commands/build/BuildModel.ts
+++ b/developer/src/kmc/src/commands/build/BuildModel.ts
@@ -1,18 +1,16 @@
 import * as fs from 'fs';
 import { BuildActivity, BuildActivityOptions } from './BuildActivity.js';
 import { compileModel } from '@keymanapp/kmc-model';
-import { NodeCompilerCallbacks } from '../../util/NodeCompilerCallbacks.js';
+import { CompilerCallbacks } from '@keymanapp/common-types';
 
 export class BuildModel extends BuildActivity {
   public get name(): string { return 'Lexical model'; }
   public get sourceExtension(): string { return '.model.ts'; }
   public get compiledExtension(): string { return '.model.js'; }
   public get description(): string { return 'Build a lexical model'; }
-  public async build(infile: string, options: BuildActivityOptions): Promise<boolean> {
+  public async build(infile: string, callbacks: CompilerCallbacks, options: BuildActivityOptions): Promise<boolean> {
     let outputFilename: string = this.getOutputFilename(infile, options);
     let code = null;
-
-    const callbacks = new NodeCompilerCallbacks();
 
     // Compile:
     try {

--- a/developer/src/kmc/src/commands/build/BuildPackage.ts
+++ b/developer/src/kmc/src/commands/build/BuildPackage.ts
@@ -2,15 +2,13 @@ import * as fs from 'fs';
 import { BuildActivity, BuildActivityOptions } from './BuildActivity.js';
 import KmpCompiler from '@keymanapp/kmc-package';
 import { CompilerCallbacks } from '@keymanapp/common-types';
-import { NodeCompilerCallbacks } from '../../util/NodeCompilerCallbacks.js';
 
 export class BuildPackage extends BuildActivity {
   public get name(): string { return 'Package'; }
   public get sourceExtension(): string { return '.kps'; }
   public get compiledExtension(): string { return '.kmp'; }
   public get description(): string  { return 'Build a Keyman package'; }
-  public async build(infile: string, options: BuildActivityOptions): Promise<boolean> {
-    const c: CompilerCallbacks = new NodeCompilerCallbacks();
+  public async build(infile: string, callbacks: CompilerCallbacks, options: BuildActivityOptions): Promise<boolean> {
 
     const outfile = this.getOutputFilename(infile, options);
 
@@ -19,7 +17,7 @@ export class BuildPackage extends BuildActivity {
     //
 
     const kpsString: string = fs.readFileSync(infile, 'utf8');
-    const kmpCompiler = new KmpCompiler(c);
+    const kmpCompiler = new KmpCompiler(callbacks);
     const kmpJsonData = kmpCompiler.transformKpsToKmpObject(kpsString, infile);
     if(!kmpJsonData) {
       return false;

--- a/developer/src/kmc/src/commands/build/BuildProject.ts
+++ b/developer/src/kmc/src/commands/build/BuildProject.ts
@@ -4,7 +4,7 @@ import { CompilerCallbacks, KeymanDeveloperProject, KPJFileReader } from '@keyma
 import { KeymanDeveloperProjectFile } from '../../../../../../common/web/types/src/kpj/keyman-developer-project.js';
 import { BuildActivity, BuildActivityOptions } from './BuildActivity.js';
 import { buildActivities } from './buildActivities.js';
-import { InfrastructureMessages } from 'src/messages/messages.js';
+import { InfrastructureMessages } from '../../messages/messages.js';
 
 const PROJECT_EXTENSION = '.kpj';
 

--- a/developer/src/kmc/src/commands/build/BuildProject.ts
+++ b/developer/src/kmc/src/commands/build/BuildProject.ts
@@ -94,8 +94,7 @@ class ProjectBuilder {
     try {
       reader.validate(kpj, schema);
     } catch(e) {
-      // TODO: callbacks.reportMessage
-      console.error(e);
+      this.callbacks.reportMessage(InfrastructureMessages.Error_InvalidProjectFile({message: (e??'').toString()}));
       return null;
     }
     const project = reader.transform(this.infile, kpj);
@@ -116,16 +115,15 @@ class ProjectBuilder {
     const options = {...this.options};
     options.outFile = this.project.resolveOutputFilePath(this.infile, file, activity.sourceExtension, activity.compiledExtension);
     const infile = this.project.resolveInputFilePath(this.infile, file);
-    // TODO: callbacks.reportMessage, improve logging and make consistent
-    console.log(`Building ${infile}\n  Output ${options.outFile}`);
+    this.callbacks.reportMessage(InfrastructureMessages.Info_BuildingFile({filename: infile}));
 
     fs.mkdirSync(path.dirname(options.outFile), {recursive:true});
 
     let result = await activity.build(infile, this.callbacks, options);
     if(result) {
-      console.log(`${path.basename(infile )} built successfully.`);
+      this.callbacks.reportMessage(InfrastructureMessages.Info_FileBuiltSuccessfully({filename: path.basename(infile)}));
     } else {
-      console.log(`${path.basename(infile)} failed to build.`);
+      this.callbacks.reportMessage(InfrastructureMessages.Info_FileNotBuiltSuccessfully({filename: path.basename(infile)}));
     }
     return result;
   }

--- a/developer/src/kmc/src/commands/buildTestData/index.ts
+++ b/developer/src/kmc/src/commands/buildTestData/index.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as kmc from '@keymanapp/kmc-keyboard';
 import { CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
-import { NodeCompilerCallbacks } from '../../util/NodeCompilerCallbacks.js';
+import { NodeCompilerCallbacks } from '../../messages/NodeCompilerCallbacks.js';
 
 export interface BuildTestDataOptions {
   outFile?: string;

--- a/developer/src/kmc/src/kmlmc.ts
+++ b/developer/src/kmc/src/kmlmc.ts
@@ -8,7 +8,7 @@ import { Command } from 'commander';
 import { compileModel } from '@keymanapp/kmc-model';
 import { SysExits } from './util/sysexits.js';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
-import { NodeCompilerCallbacks } from './util/NodeCompilerCallbacks.js';
+import { NodeCompilerCallbacks } from './messages/NodeCompilerCallbacks.js';
 
 let inputFilename: string;
 const program = new Command();

--- a/developer/src/kmc/src/kmlmi.ts
+++ b/developer/src/kmc/src/kmlmi.ts
@@ -10,7 +10,7 @@ import KmpCompiler from '@keymanapp/kmc-package';
 import { ModelInfoOptions as ModelInfoOptions, writeMergedModelMetadataFile } from '@keymanapp/kmc-model-info';
 import { SysExits } from './util/sysexits.js';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
-import { NodeCompilerCallbacks } from './util/NodeCompilerCallbacks.js';
+import { NodeCompilerCallbacks } from './messages/NodeCompilerCallbacks.js';
 
 let inputFilename: string;
 const program = new Command();

--- a/developer/src/kmc/src/kmlmp.ts
+++ b/developer/src/kmc/src/kmlmp.ts
@@ -8,7 +8,7 @@ import { Command } from 'commander';
 import KmpCompiler from '@keymanapp/kmc-package';
 import { SysExits } from './util/sysexits.js';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
-import { NodeCompilerCallbacks } from './util/NodeCompilerCallbacks.js';
+import { NodeCompilerCallbacks } from './messages/NodeCompilerCallbacks.js';
 
 let inputFilename: string;
 const program = new Command();

--- a/developer/src/kmc/src/messages/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/messages/NodeCompilerCallbacks.ts
@@ -32,7 +32,7 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
   }
 
   loadSchema(schema: CompilerSchema) {
-    let schemaPath = new URL(schema + '.schema.json', import.meta.url);
+    let schemaPath = new URL('../util/' + schema + '.schema.json', import.meta.url);
     return fs.readFileSync(schemaPath);
   }
 }

--- a/developer/src/kmc/src/messages/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/messages/NodeCompilerCallbacks.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { CompilerCallbacks, CompilerEvent, compilerErrorSeverityName } from '@keymanapp/common-types';
+import { CompilerCallbacks, CompilerSchema, CompilerEvent, compilerErrorSeverityName } from '@keymanapp/common-types';
 
 /**
  * Concrete implementation for CLI use
@@ -27,20 +27,12 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
     }
   }
 
-  loadLdmlKeyboardSchema(): Buffer {
-    let schemaPath = new URL('ldml-keyboard.schema.json', import.meta.url);
-    return fs.readFileSync(schemaPath);
+  debug(msg: string) {
+    console.debug(msg);
   }
-  loadLdmlKeyboardTestSchema(): Buffer {
-    let schemaPath = new URL('ldml-keyboardtest.schema.json', import.meta.url);
-    return fs.readFileSync(schemaPath);
-  }
-  loadKvksJsonSchema(): Buffer {
-    let schemaPath = new URL('kvks.schema.json', import.meta.url);
-    return fs.readFileSync(schemaPath);
-  }
-  loadKpjJsonSchema(): Buffer {
-    let schemaPath = new URL('kpj.schema.json', import.meta.url);
+
+  loadSchema(schema: CompilerSchema) {
+    let schemaPath = new URL(schema + '.schema.json', import.meta.url);
     return fs.readFileSync(schemaPath);
   }
 }

--- a/developer/src/kmc/src/messages/messages.ts
+++ b/developer/src/kmc/src/messages/messages.ts
@@ -35,5 +35,9 @@ export class InfrastructureMessages {
   static Info_FileNotBuiltSuccessfully = (o:{filename:string}) => m(this.INFO_FileNotBuiltSuccessfully,
     `${o.filename} failed to build.`);
   static INFO_FileNotBuiltSuccessfully = SevInfo | 0x0007;
+
+  static Error_InvalidProjectFile = (o:{message:string}) => m(this.ERROR_InvalidProjectFile,
+    `Project file is not valid: ${o.message}`);
+  static ERROR_InvalidProjectFile = SevError | 0x0008;
 }
 

--- a/developer/src/kmc/src/messages/messages.ts
+++ b/developer/src/kmc/src/messages/messages.ts
@@ -1,0 +1,39 @@
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
+
+const Namespace = CompilerErrorNamespace.Infrastructure;
+const SevInfo = CompilerErrorSeverity.Info | Namespace;
+// const SevHint = CompilerErrorSeverity.Hint | Namespace;
+// const SevWarn = CompilerErrorSeverity.Warn | Namespace;
+const SevError = CompilerErrorSeverity.Error | Namespace;
+const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
+
+export class InfrastructureMessages {
+  static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException,
+    `Unexpected exception: ${(o.e ?? 'unknown error').toString()}\n\nCall stack:\n${(o.e instanceof Error ? o.e.stack : (new Error()).stack)}`);
+  static FATAL_UnexpectedException = SevFatal | 0x0001;
+
+  static Info_BuildingFile = (o:{filename:string}) => m(this.INFO_BuildingFile,
+    `Building ${o.filename}`);
+  static INFO_BuildingFile = SevInfo | 0x0002;
+
+  static Error_FileDoesNotExist = (o:{filename:string}) => m(this.ERROR_FileDoesNotExist,
+    `File ${o.filename} does not exist`);
+  static ERROR_FileDoesNotExist = SevError | 0x0003;
+
+  static Error_FileTypeNotRecognized = (o:{filename: string, extensions: string}) => m(this.ERROR_FileTypeNotRecognized,
+    `Unrecognised input file ${o.filename}, expecting ${o.extensions}, or project folder`);
+  static ERROR_FileTypeNotRecognized = SevError | 0x0004;
+
+  static Error_OutFileNotValidForProjects = () => m(this.ERROR_OutFileNotValidForProjects,
+    `--out-file should not be specified for project builds`);
+  static ERROR_OutFileNotValidForProjects = SevError | 0x0005;
+
+  static Info_FileBuiltSuccessfully = (o:{filename:string}) => m(this.INFO_FileBuiltSuccessfully,
+    `${o.filename} built successfully.`);
+  static INFO_FileBuiltSuccessfully = SevInfo | 0x0006;
+
+  static Info_FileNotBuiltSuccessfully = (o:{filename:string}) => m(this.INFO_FileNotBuiltSuccessfully,
+    `${o.filename} failed to build.`);
+  static INFO_FileNotBuiltSuccessfully = SevInfo | 0x0007;
+}
+


### PR DESCRIPTION
Cleans up majority of remaining kmc-* modules to use CompilerEvent messages instead of console.log and friends, adding InfrastructureMessages class for kmc CLI messages.

Consolidates schema loading functions into a single `loadSchema` function in the CompilerCallbacks interface and implementations.

Moves responsibility for instantiating NodeCompilerCallbacks out of each individual BuildActivity and into higher level modules.

Fixes return value for failing builds.

@keymanapp-test-bot skip