### PR TITLE
chore(developer): fixup deps for kmc modules

### DIFF
--- a/developer/build.sh
+++ b/developer/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Build Keyman Developer components
+#
+# TODO: convert existing Makefiles/ into build.sh scripts; for now,
+# this only builds kmc and kmcmplib
+
+#set -x
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
+################################ Main script ################################
+
+builder_describe \
+  "Build Keyman Developer
+
+  **NOTE:** this only builds kmc and kmcmplib for now (TODO on other modules)" \
+  \
+  clean \
+  configure \
+  build \
+  test \
+  ":kmcmplib=src/kmcmplib                   Compiler - .kmn compiler" \
+  ":kmc-keyboard=src/kmc-keyboard           Compiler - LDML Keyboard Module" \
+  ":kmc-kmn=src/kmc-kmn                     Compiler - .kmn wrapper Keyboard Module" \
+  ":kmc-model=src/kmc-model                 Compiler - Lexical Model Module" \
+  ":kmc-model-info=src/kmc-model-info       Compiler - .model_info Module" \
+  ":kmc-package=src/kmc-package             Compiler - Package Module" \
+  ":kmc=src/kmc                             Compiler - Command Line Interface"
+
+builder_parse "$@"
+
+builder_run_child_actions clean configure build test

--- a/developer/src/common/web/test-helpers/build.sh
+++ b/developer/src/common/web/test-helpers/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Compiles developer test helpers
+#
+
+# Exit on command failure and when using unset variables:
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+cd "$THIS_SCRIPT_PATH"
+
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
+builder_describe "Build Keyman Developer test helpers" \
+  "@/common/web/types" \
+  "clean" \
+  "configure" \
+  "build"
+
+builder_describe_outputs \
+  configure     /node_modules \
+  build         /developer/src/common/web/test-helpers/build/index.js
+
+builder_parse "$@"
+
+#-------------------------------------------------------------------------------------------------------------------
+
+if builder_start_action clean; then
+  rm -rf ./build/
+  builder_finish_action success clean
+fi
+
+#-------------------------------------------------------------------------------------------------------------------
+
+if builder_start_action configure; then
+  verify_npm_setup
+  builder_finish_action success configure
+fi
+
+#-------------------------------------------------------------------------------------------------------------------
+
+if builder_start_action build; then
+  tsc --build
+  builder_finish_action success build
+fi

--- a/developer/src/kmc-keyboard/build.sh
+++ b/developer/src/kmc-keyboard/build.sh
@@ -19,6 +19,7 @@ cd "$THIS_SCRIPT_PATH"
 builder_describe "Build Keyman kmc Keyboard Compiler module" \
   "@/common/web/keyman-version" \
   "@/common/web/types" \
+  "@/developer/src/common/web/test-helpers" \
   "configure" \
   "build" \
   "clean" \

--- a/developer/src/kmc-kmn/build.sh
+++ b/developer/src/kmc-kmn/build.sh
@@ -19,6 +19,7 @@ cd "$THIS_SCRIPT_PATH"
 builder_describe "Build Keyman Developer Compiler Module for .kmn to .kmx" \
   "@/common/web/keyman-version" \
   "@/common/web/types" \
+  "@/developer/src/common/web/test-helpers" \
   "@/developer/src/kmcmplib:wasm" \
   "configure" \
   "build" \

--- a/developer/src/kmc-model/build.sh
+++ b/developer/src/kmc-model/build.sh
@@ -20,6 +20,7 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_describe "Build Keyman kmc Lexical Model Compiler module" \
   "@/common/web/keyman-version" \
+  "@/developer/src/common/web/test-helpers" \
   "configure" \
   "build" \
   "clean" \

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -47,7 +47,8 @@
     "chalk": "^2.4.2",
     "esbuild": "^0.15.7",
     "mocha": "^10.0.0",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "@keymanapp/developer-test-helpers": "*"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-model/test/tsconfig.json
+++ b/developer/src/kmc-model/test/tsconfig.json
@@ -9,6 +9,9 @@
       "moduleResolution": "node16",
       "allowSyntheticDefaultImports": true,
       "baseUrl": ".",
+      "paths": {
+        "@keymanapp/developer-test-helpers": ["../../common/web/test-helpers/index"],
+      },
   },
   "include": [
       "**/test-*.ts",
@@ -18,5 +21,6 @@
   ],
   "references": [
       { "path": "../" },
+      { "path": "../../common/web/test-helpers/" },
     ]
 }

--- a/developer/src/kmc-package/build.sh
+++ b/developer/src/kmc-package/build.sh
@@ -18,6 +18,7 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_describe "Build Keyman kmc Package Compiler module" \
   "@/common/web/keyman-version" \
+  "@/developer/src/common/web/test-helpers" \
   "configure" \
   "build" \
   "clean" \

--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -41,7 +41,8 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "@keymanapp/developer-test-helpers": "*"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-package/test/tsconfig.json
+++ b/developer/src/kmc-package/test/tsconfig.json
@@ -7,6 +7,9 @@
       "outDir": "../build/test",
       "baseUrl": ".",
       "allowSyntheticDefaultImports": true, // for jszip
+      "paths": {
+        "@keymanapp/developer-test-helpers": ["../../common/web/test-helpers/index"],
+      },
     },
   "include": [
       "**/test-*.ts",
@@ -15,5 +18,6 @@
   "references": [
       { "path": "../" },
       { "path": "../../../../common/web/keyman-version/tsconfig.esm.json" },
+      { "path": "../../common/web/test-helpers/" },
     ]
 }


### PR DESCRIPTION
@keymanapp-test-bot skip

Note: also adds rudimentary top-level developer build script, just for building kmc + friends. Its primary use right now is to run `developer/build.sh test` as that will run tests on all modules (building happens through child dep relationships for kmc anyway)