### PR TITLE
chore(android): Move namespace to Gradle files

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -11,6 +11,7 @@ apply from: "$rootPath/version.gradle"
 
 android {
     compileSdkVersion 33
+    namespace="com.tavultesoft.kmapro"
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="com.tavultesoft.kmapro">
+  xmlns:tools="http://schemas.android.com/tools">
 
   <!-- Keyman Engine removes INTERNET permission, so add it back -->
   <uses-permission android:name="android.permission.INTERNET" tools:node="replace" />

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -8,6 +8,7 @@ apply from: "$rootPath/version.gradle"
 
 android {
     compileSdkVersion 33
+    namespace "com.keyman.engine"
 
     defaultConfig {
         minSdkVersion 21

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="com.keyman.engine" >
+  xmlns:tools="http://schemas.android.com/tools">
     <!-- Query other IME's for keyboard picker menu -->
     <queries>
       <intent>

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 android {
     compileSdkVersion 33
+    namespace="com.keyman.kmsample1"
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/android/Samples/KMSample1/app/src/main/AndroidManifest.xml
+++ b/android/Samples/KMSample1/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.keyman.kmsample1" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 android {
     compileSdkVersion 33
+    namespace="com.keyman.kmsample2"
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/android/Samples/KMSample2/app/src/main/AndroidManifest.xml
+++ b/android/Samples/KMSample2/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.keyman.kmsample2" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -7,6 +7,7 @@ apply from: "$rootPath/version.gradle"
 
 android {
     compileSdkVersion 33
+    namespace="com.keyman.android.tests.keyboardHarness"
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/android/Tests/KeyboardHarness/app/src/main/AndroidManifest.xml
+++ b/android/Tests/KeyboardHarness/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.keyman.android.tests.keyboardHarness" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/android/Tests/keycode/app/build.gradle
+++ b/android/Tests/keycode/app/build.gradle
@@ -5,6 +5,8 @@ apply from: "$rootPath/version.gradle"
 
 android {
     compileSdkVersion 33
+    namespace="com.keyman.android.tests.keycode"
+
     defaultConfig {
         applicationId "com.keyman.android.tests.keycode"
         minSdkVersion 21

--- a/android/Tests/keycode/app/src/main/AndroidManifest.xml
+++ b/android/Tests/keycode/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.keyman.android.tests.keycode">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -9,6 +9,7 @@ apply from: "$rootPath/version.gradle"
 
 android {
     compileSdkVersion 33
+    namespace="com.firstvoices.keyboards"
 
     defaultConfig {
         applicationId "com.firstvoices.keyboards"

--- a/oem/firstvoices/android/app/src/main/AndroidManifest.xml
+++ b/oem/firstvoices/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.firstvoices.keyboards" >
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Keyman Engine removes INTERNET permission, so add it back for crash reporting and get dictionaries -->
     <uses-permission android:name="android.permission.INTERNET" tools:node="replace" />


### PR DESCRIPTION
Addresses a small part of #5272.

Gradle warns that declaring package names in AndroidManifest.xml files are deprecated.
They should now be declared as namespaces in the build.gradle files.

@keymanapp-test-bot skip
