### PR TITLE
fix(common): builder parse multi-param order

### DIFF
--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -273,6 +273,7 @@ _builder_expand_shorthand() {
   shift
   local count=0
   local result=
+  local string=
   for e; do
     if [[ $e == $item ]]; then
       # Exact match trumps substring matches
@@ -282,11 +283,10 @@ _builder_expand_shorthand() {
     if [[ $e == "$item"* ]]; then
       count=$((count+1))
       if [[ $count == 2 ]]; then
-        printf "$result"
-        printf ", $e"
+        string="$result, $e"
         result=$item
       elif [[ $count -gt 2 ]]; then
-        printf ", $e"
+        string="$string, $e"
       else
         result=$e
       fi
@@ -296,7 +296,7 @@ _builder_expand_shorthand() {
   if [[ $count -lt 2 ]]; then
     echo $result
   else
-    echo
+    echo $string
   fi
   return $count
 }


### PR DESCRIPTION
If a build script specified, e.g. :kmc-keyboard, :kmc-package, :kmc as three targets, in that order, then passing :kmc as a parameter would fail, because :kmc-keyboard, :kmc-package would be emitted to the match result before finding :kmc.

@keymanapp-test-bot skip