### PR TITLE
refactor(android/engine): Move currentBanner to KMKeyboard

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -76,6 +76,21 @@ final class KMKeyboard extends WebView {
   protected ArrayList<String> javascriptAfterLoad = new ArrayList<String>();
 
   private static String currentKeyboard = null;
+
+  /**
+   * Banner state value: "blank" - no banner available.
+   */
+  protected static final String KM_BANNER_STATE_BLANK = "blank";
+  /**
+   * Banner state value: "suggestion" - dictionary suggestions are shown.
+   */
+  protected static final String KM_BANNER_STATE_SUGGESTION = "suggestion";
+
+  /**
+   * Current banner state.
+   */
+  protected static String currentBanner = KM_BANNER_STATE_BLANK;
+
   private static String txtFont = "";
   private static String oskFont = null;
   private static String keyboardRoot = "";
@@ -400,6 +415,12 @@ final class KMKeyboard extends WebView {
   public static String currentKeyboard() {
     return currentKeyboard;
   }
+
+  public static void setCurrentBanner(String banner) {
+    currentBanner = banner;
+  }
+
+  public static String currentBanner() { return currentBanner; }
 
   /**
    * Return the full path to the display text font. Usually used for creating a Typeface font

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
@@ -245,8 +245,8 @@ public final class KMKeyboardWebViewClient extends WebViewClient {
       if (KMManager.currentLexicalModel != null) {
         modelPredictionPref = prefs.getBoolean(KMManager.getLanguagePredictionPreferenceKey(KMManager.currentLexicalModel.get(KMManager.KMKey_LanguageID)), true);
       }
-      KMManager.currentBanner = (isModelActive && modelPredictionPref) ?
-        KMManager.KM_BANNER_STATE_SUGGESTION : KMManager.KM_BANNER_STATE_BLANK;
+      kmKeyboard.setCurrentBanner((isModelActive && modelPredictionPref) ?
+        KMKeyboard.KM_BANNER_STATE_SUGGESTION : KMKeyboard.KM_BANNER_STATE_BLANK);
       RelativeLayout.LayoutParams params = KMManager.getKeyboardLayoutParams();
       kmKeyboard.setLayoutParams(params);
     } else if (url.indexOf("suggestPopup") >= 0) {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -190,22 +190,6 @@ public final class KMManager {
   public final static String predictionPrefSuffix = ".mayPredict";
   public final static String correctionPrefSuffix = ".mayCorrect";
 
-  /**
-   * Banner state value: "blank" - no banner available.
-   */
-  protected static final String KM_BANNER_STATE_BLANK = "blank";
-  /**
-   * Banner state value: "suggestion" - dictionary suggestions are shown.
-   */
-  protected static final String KM_BANNER_STATE_SUGGESTION = "suggestion";
-
-  //TODO: should be part of kmkeyboard
-  /**
-   * Current banner state.
-   */
-  protected static String currentBanner = KM_BANNER_STATE_BLANK;
-
-
   // Special override for when the keyboard may have haptic feedback when typing.
   // haptic feedback disabled for hardware keystrokes
   private static boolean mayHaveHapticFeedback = false;
@@ -1852,7 +1836,9 @@ public final class KMManager {
 
   public static int getBannerHeight(Context context) {
     int bannerHeight = 0;
-    if (currentBanner.equals(KM_BANNER_STATE_SUGGESTION)) {
+    if (InAppKeyboard != null && InAppKeyboard.currentBanner().equals(KMKeyboard.KM_BANNER_STATE_SUGGESTION)) {
+      bannerHeight = (int) context.getResources().getDimension(R.dimen.banner_height);
+    } else if (SystemKeyboard != null && SystemKeyboard.currentBanner().equals(KMKeyboard.KM_BANNER_STATE_SUGGESTION)) {
       bannerHeight = (int) context.getResources().getDimension(R.dimen.banner_height);
     }
     return bannerHeight;
@@ -2168,9 +2154,14 @@ public final class KMManager {
 
   private static void toggleSuggestionBanner(String languageID, boolean inappKeyboardChanged, boolean systemKeyboardChanged) {
     //reset banner state if new language has no lexical model
-    if (currentBanner.equals(KMManager.KM_BANNER_STATE_SUGGESTION)
+    if (InAppKeyboard != null && InAppKeyboard.currentBanner().equals(KMKeyboard.KM_BANNER_STATE_SUGGESTION)
       && getAssociatedLexicalModel(languageID)==null) {
-      currentBanner = KMManager.KM_BANNER_STATE_BLANK;
+      InAppKeyboard.setCurrentBanner(KMKeyboard.KM_BANNER_STATE_BLANK);
+    }
+
+    if (SystemKeyboard != null && SystemKeyboard.currentBanner().equals(KMKeyboard.KM_BANNER_STATE_SUGGESTION)
+      && getAssociatedLexicalModel(languageID)==null) {
+      SystemKeyboard.setCurrentBanner(KMKeyboard.KM_BANNER_STATE_BLANK);
     }
 
     if(inappKeyboardChanged) {


### PR DESCRIPTION
This addresses a TODO of moving KMManager.currentBanner to KMKeyboard.

## User Testing
**Setup** - Install the PR build of Keyman for Android on an Android emulator/device. From Keyman, also install a keyboard that doesn't have a dictionary (e.g. basic_kbdfr).

* **TEST_INAPP_ADJUST_KEYBOARD_HEIGHT** - Verifies keyboard height can be adjusted
1. Launch Keyman for Android
2. From Keyman Settings --> Adjust the keyboard height to the max
3. Return to Keyman
4. Verify the keyboard height is now the adjusted keyboard height. (Note, keyboard height doesn't include the suggestion banner height)

* **TEST_INAPP_BANNER_TOGGLES** - Verifies banner toggles for INAPP keyboard
1. Launch Keyman for Android
2. Select sil_euro_latin keyboard
3. Verify suggestion banner appears
4. With the globe button, switch to basic_kbdfr
5. Verify the suggestion banner disappears
6. With the globe button, switch to sil_euro_latin
7. Verify suggestion banner reappears
8. From Keyman Settings --> Installed Languages --> English --> Disable predictions
9. Return to Keyman
10. Verify suggesiton banner disappears
11. From Keyman Settings --> Reenable predictions for English

* **TEST_SYSTEM_BANNER_TOGGLES** - Verify banner toggles for SYSTEM keyboard
1. Launch Keyman for Android
2. Set and enable Keyman as the default system keyboard
3. Launch a separate app (e.g. Google Chrome) and select a text area to type in
4. Select sil_euro_latin Keyman keyboard
5. Verify suggestion banner appears
6. With the globe button, switch to basic_kbdfr
7. Verify the suggestion banner disappears
8. With the globe button, switch to sil_euro_latin
9. Verify suggestion banner reappears
10. From Keyman Settings --> Installed Languages --> English --> Disable predictions
11. Return to Chrome and select a text area to type in
12. Verify suggesiton banner disappears
13. From Keyman Settings --> Reenable predictions for English
