### PR TITLE
chore(android): Update QRGen version for Java 11

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -161,7 +161,7 @@ dependencies {
     // Add dependency for generating QR Codes
     // (Even though it's embedded in KMEA, because we're manually copying keyman-engine.aar,
     // we "lose" it in the dependency management)
-    implementation ('com.github.kenglxn.QRGen:android:2.7.0') {
+    implementation ('com.github.kenglxn.QRGen:android:3.0.1') {
         transitive = true
     }
 }

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -78,8 +78,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.8.1'
 
     // Generate QR Codes
-    // 3.0.1 requires Java 11
-    implementation ('com.github.kenglxn.QRGen:android:2.7.0') {
+    implementation ('com.github.kenglxn.QRGen:android:3.0.1') {
         transitive = true
     }
 }

--- a/android/README.md
+++ b/android/README.md
@@ -138,7 +138,7 @@ dependencies {
     implementation 'androidx.preference:preference:1.2.0'
 
     // Include this if you want to have QR Codes displayed on Keyboard Info
-    implementation ('com.github.kenglxn.QRGen:android:2.7.0') {
+    implementation ('com.github.kenglxn.QRGen:android:3.0.1') {
         transitive = true
     }
 }


### PR DESCRIPTION
Follow-on to #8543 where the Android projects were updated to Java 11.

We can now update the QRGen dependency to 3.0.1 which was built with Java 11.

## User Testing
**Setup** - Install the PR build of Keyman for Android

* **TEST_QR_CODE** - Verifies QR code is generated for keyboard info
1. Launch Keyman for Android
2. Dismiss the "Get Started" menu
3. Long-press on the globe key to bring up the Keyboard Picker menu
4. On the Keyboard picker menu, click the "i" on sil_euro_latin to display the keyboard info
5. Verify a QR code is displayed at the bottom of the EuroLatin (SIL) keyboard info page.
