### PR TITLE
refactor(android/engine): Move toggleSuggestionBanner to KMKeyboard 🛋

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -422,23 +422,15 @@ final class KMKeyboard extends WebView {
 
   public static String currentBanner() { return currentBanner; }
 
-  private static void toggleSuggestionBanner(String languageID, boolean inappKeyboardChanged, boolean systemKeyboardChanged) {
+  protected void toggleSuggestionBanner(HashMap<String, String> associatedLexicalModel, boolean keyboardChanged) {
     //reset banner state if new language has no lexical model
-    if (InAppKeyboard != null && InAppKeyboard.currentBanner().equals(KMKeyboard.KM_BANNER_STATE_SUGGESTION)
-      && getAssociatedLexicalModel(languageID)==null) {
-      InAppKeyboard.setCurrentBanner(KMKeyboard.KM_BANNER_STATE_BLANK);
+    if (currentBanner != null && currentBanner.equals(KM_BANNER_STATE_SUGGESTION)
+        && associatedLexicalModel == null) {
+      setCurrentBanner(KMKeyboard.KM_BANNER_STATE_BLANK);
     }
 
-    if (SystemKeyboard != null && SystemKeyboard.currentBanner().equals(KMKeyboard.KM_BANNER_STATE_SUGGESTION)
-      && getAssociatedLexicalModel(languageID)==null) {
-      SystemKeyboard.setCurrentBanner(KMKeyboard.KM_BANNER_STATE_BLANK);
-    }
-
-    if(inappKeyboardChanged) {
-      InAppKeyboard.setLayoutParams(getKeyboardLayoutParams());
-    }
-    if(systemKeyboardChanged) {
-      SystemKeyboard.setLayoutParams(getKeyboardLayoutParams());
+    if(keyboardChanged) {
+      setLayoutParams(KMManager.getKeyboardLayoutParams());
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -422,6 +422,26 @@ final class KMKeyboard extends WebView {
 
   public static String currentBanner() { return currentBanner; }
 
+  private static void toggleSuggestionBanner(String languageID, boolean inappKeyboardChanged, boolean systemKeyboardChanged) {
+    //reset banner state if new language has no lexical model
+    if (InAppKeyboard != null && InAppKeyboard.currentBanner().equals(KMKeyboard.KM_BANNER_STATE_SUGGESTION)
+      && getAssociatedLexicalModel(languageID)==null) {
+      InAppKeyboard.setCurrentBanner(KMKeyboard.KM_BANNER_STATE_BLANK);
+    }
+
+    if (SystemKeyboard != null && SystemKeyboard.currentBanner().equals(KMKeyboard.KM_BANNER_STATE_SUGGESTION)
+      && getAssociatedLexicalModel(languageID)==null) {
+      SystemKeyboard.setCurrentBanner(KMKeyboard.KM_BANNER_STATE_BLANK);
+    }
+
+    if(inappKeyboardChanged) {
+      InAppKeyboard.setLayoutParams(getKeyboardLayoutParams());
+    }
+    if(systemKeyboardChanged) {
+      SystemKeyboard.setLayoutParams(getKeyboardLayoutParams());
+    }
+  }
+
   /**
    * Return the full path to the display text font. Usually used for creating a Typeface font
    * @return String

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1511,19 +1511,25 @@ public final class KMManager {
   public static boolean setKeyboard(Keyboard keyboardInfo) {
     boolean result1 = false;
     boolean result2 = false;
+    HashMap<String, String> associatedLexicalModel = null;
+    String languageID = null;
+
+    if (keyboardInfo != null) {
+      languageID = keyboardInfo.getLanguageID();
+      associatedLexicalModel = getAssociatedLexicalModel(languageID);
+    }
 
     if (InAppKeyboard != null && InAppKeyboardWebViewClient.getKeyboardLoaded() && keyboardInfo != null) {
       result1 = InAppKeyboard.setKeyboard(keyboardInfo);
+      InAppKeyboard.toggleSuggestionBanner(associatedLexicalModel, result1);
     }
 
-    if (SystemKeyboard != null && SystemKeyboardWebViewClient.getKeyboardLoaded() && keyboardInfo != null)
+    if (SystemKeyboard != null && SystemKeyboardWebViewClient.getKeyboardLoaded() && keyboardInfo != null) {
       result2 = SystemKeyboard.setKeyboard(keyboardInfo);
-
-    if (keyboardInfo != null) {
-      String languageID = keyboardInfo.getLanguageID();
-      toggleSuggestionBanner(languageID, result1, result2);
-      registerAssociatedLexicalModel(languageID);
+      SystemKeyboard.toggleSuggestionBanner(associatedLexicalModel, result2);
     }
+
+    registerAssociatedLexicalModel(languageID);
 
     return (result1 || result2);
   }
@@ -1537,21 +1543,21 @@ public final class KMManager {
    * @return the success result
    */
   public static boolean prepareKeyboardSwitch(String packageID, String keyboardID, String languageID, String keyboardName) {
-
-
     boolean result1 = false;
     boolean result2 = false;
 
+    HashMap<String, String> associatedLexicalModel = getAssociatedLexicalModel(languageID);
     if (InAppKeyboard != null && InAppKeyboardWebViewClient.getKeyboardLoaded())
     {
       result1 = InAppKeyboard.prepareKeyboardSwitch(packageID, keyboardID, languageID,keyboardName);
+      InAppKeyboard.toggleSuggestionBanner(associatedLexicalModel, result1);
     }
     if (SystemKeyboard != null && SystemKeyboardWebViewClient.getKeyboardLoaded())
     {
       result2 = SystemKeyboard.prepareKeyboardSwitch(packageID, keyboardID, languageID,keyboardName);
+      SystemKeyboard.toggleSuggestionBanner(associatedLexicalModel, result2);
     }
 
-    toggleSuggestionBanner(languageID, result1, result2);
     registerAssociatedLexicalModel(languageID);
 
     return (result1 || result2);

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2152,26 +2152,6 @@ public final class KMManager {
     globeKeyState = state;
   }
 
-  private static void toggleSuggestionBanner(String languageID, boolean inappKeyboardChanged, boolean systemKeyboardChanged) {
-    //reset banner state if new language has no lexical model
-    if (InAppKeyboard != null && InAppKeyboard.currentBanner().equals(KMKeyboard.KM_BANNER_STATE_SUGGESTION)
-      && getAssociatedLexicalModel(languageID)==null) {
-      InAppKeyboard.setCurrentBanner(KMKeyboard.KM_BANNER_STATE_BLANK);
-    }
-
-    if (SystemKeyboard != null && SystemKeyboard.currentBanner().equals(KMKeyboard.KM_BANNER_STATE_SUGGESTION)
-      && getAssociatedLexicalModel(languageID)==null) {
-      SystemKeyboard.setCurrentBanner(KMKeyboard.KM_BANNER_STATE_BLANK);
-    }
-
-    if(inappKeyboardChanged) {
-      InAppKeyboard.setLayoutParams(getKeyboardLayoutParams());
-    }
-    if(systemKeyboardChanged) {
-      SystemKeyboard.setLayoutParams(getKeyboardLayoutParams());
-    }
-  }
-
   /**
    * Return if the lock screen is locked (prevents keyboard picker menu from being displayed)
    * @return boolean


### PR DESCRIPTION
More refactoring for #7881 

This moves KMManager.toggleSuggestionBanner to KMKeyboard.

## User Testing
Tests copied from #8671

**Setup** - Install the PR build of Keyman for Android on a device/emulator. From Keyman, also install a keyboard that doesn't have a dictionary (e.g. basic_kbdfr).

* **TEST_INAPP_BANNER_TOGGLES** - Verifies banner toggles for INAPP keyboard
1. Launch Keyman for Android
2. Select sil_euro_latin keyboard
3. Verify suggestion banner appears
4. With the globe button, switch to basic_kbdfr
5. Verify the suggestion banner disappears
6. With the globe button, switch to sil_euro_latin
7. Verify suggestion banner reappears
8. From Keyman Settings --> Installed Languages --> English --> Disable predictions
9. Return to Keyman
10. Verify suggestion banner disappears
11. From Keyman Settings --> Reenable predictions for English

* **TEST_SYSTEM_BANNER_TOGGLES** - Verify banner toggles for SYSTEM keyboard
1. Launch Keyman for Android
2. Set and enable Keyman as the default system keyboard
3. Launch a separate app (e.g. Google Chrome) and select a text area to type in
4. Select sil_euro_latin Keyman keyboard
5. Verify suggestion banner appears
6. With the globe button, switch to basic_kbdfr
7. Verify the suggestion banner disappears
8. With the globe button, switch to sil_euro_latin
9. Verify suggestion banner reappears
10. From Keyman Settings --> Installed Languages --> English --> Disable predictions
11. Return to Chrome and select a text area to type in
12. Verify suggestion banner disappears
13. From Keyman Settings --> Reenable predictions for English
