### PR TITLE
refactor(android/engine): Move shouldIgnore booleans to KMKeyboard 🛋

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -72,6 +72,9 @@ final class KMKeyboard extends WebView {
   private String keyboardName;
   private String keyboardVersion;
 
+  private boolean shouldIgnoreTextChange = false;
+  private boolean shouldIgnoreSelectionChange = false;
+
   protected KeyboardType keyboardType = KeyboardType.KEYBOARD_TYPE_UNDEFINED;
   protected ArrayList<String> javascriptAfterLoad = new ArrayList<String>();
 
@@ -147,6 +150,11 @@ final class KMKeyboard extends WebView {
   public void setShouldShowHelpBubble(boolean flag) {
     this._shouldShowHelpBubble = flag;
   }
+
+  protected boolean shouldIgnoreTextChange() { return shouldIgnoreTextChange; }
+  protected void setShouldIgnoreTextChange(boolean ignore) { this.shouldIgnoreTextChange = ignore; }
+  protected boolean shouldIgnoreSelectionChange() { return shouldIgnoreSelectionChange; }
+  protected void setShouldIgnoreSelectionChange(boolean ignore) { this.shouldIgnoreSelectionChange = ignore; }
 
   @SuppressWarnings("deprecation")
   @SuppressLint("SetJavaScriptEnabled")

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -128,11 +128,7 @@ public class KMKeyboardJSHandler {
               ic.endBatchEdit();
               return;
             } else {
-              if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-                KMManager.SystemKeyboardShouldIgnoreSelectionChange = true;
-              } else if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-                KMManager.InAppKeyboardShouldIgnoreSelectionChange = true;
-              }
+              k.setShouldIgnoreSelectionChange(true);
               ic.setSelection(start, start);
               ic.deleteSurroundingText(0, end - start);
             }
@@ -152,8 +148,8 @@ public class KMKeyboardJSHandler {
         // Perform left-deletions
         if (deleteLeft > 0) {
           if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-            KMManager.InAppKeyboardShouldIgnoreTextChange = true;
-            KMManager.InAppKeyboardShouldIgnoreSelectionChange = true;
+            k.setShouldIgnoreTextChange(true);
+            k.setShouldIgnoreSelectionChange(true);
           }
           performLeftDeletions(ic, deleteLeft);
         }
@@ -163,11 +159,7 @@ public class KMKeyboardJSHandler {
           CharSequence chars = ic.getTextAfterCursor(1, 0);
           if (chars != null && chars.length() > 0) {
             char c = chars.charAt(0);
-            if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-              KMManager.SystemKeyboardShouldIgnoreSelectionChange = true;
-            } else if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-              KMManager.InAppKeyboardShouldIgnoreSelectionChange = true;
-            }
+            k.setShouldIgnoreSelectionChange(true);
             if (Character.isHighSurrogate(c)) {
               ic.deleteSurroundingText(0, 2);
             } else {
@@ -177,11 +169,7 @@ public class KMKeyboardJSHandler {
         }
 
         if (s.length() > 0) {
-          if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-            KMManager.SystemKeyboardShouldIgnoreSelectionChange = true;
-          } else if (k.keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-            KMManager.InAppKeyboardShouldIgnoreSelectionChange = true;
-          }
+          k.setShouldIgnoreSelectionChange(true);
           // Commit the string s. Use newCursorPosition 1 so cursor will end up after the string.
           ic.commitText(s, 1);
         }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -175,10 +175,6 @@ public final class KMManager {
 
   private static KMManager.SpacebarText spacebarText = KMManager.SpacebarText.LANGUAGE_KEYBOARD; // must match default given in kmwbase.ts
 
-  protected static boolean InAppKeyboardShouldIgnoreTextChange = false;
-  protected static boolean InAppKeyboardShouldIgnoreSelectionChange = false;
-  protected static boolean SystemKeyboardShouldIgnoreTextChange = false;
-  protected static boolean SystemKeyboardShouldIgnoreSelectionChange = false;
   protected static KMKeyboard InAppKeyboard = null;
   protected static KMKeyboard SystemKeyboard = null;
   protected static KMKeyboardWebViewClient InAppKeyboardWebViewClient = null;
@@ -1329,12 +1325,12 @@ public final class KMManager {
     boolean mayCorrect = prefs.getBoolean(getLanguageCorrectionPreferenceKey(languageID), true);
 
     RelativeLayout.LayoutParams params;
-    if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboardShouldIgnoreTextChange && modelFileExists) {
+    if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreTextChange() && modelFileExists) {
       params = getKeyboardLayoutParams();
       InAppKeyboard.setLayoutParams(params);
       InAppKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
     }
-    if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboardShouldIgnoreTextChange && modelFileExists) {
+    if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreTextChange() && modelFileExists) {
       params = getKeyboardLayoutParams();
       SystemKeyboard.setLayoutParams(params);
       SystemKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
@@ -1942,11 +1938,11 @@ public final class KMManager {
 
   public static void setNumericLayer(KeyboardType kbType) {
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboardShouldIgnoreTextChange) {
+      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreTextChange()) {
         InAppKeyboard.loadJavascript("setNumericLayer()");
       }
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboardShouldIgnoreTextChange) {
+      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreTextChange()) {
         SystemKeyboard.loadJavascript("setNumericLayer()");
       }
     }
@@ -1960,19 +1956,19 @@ public final class KMManager {
     }
 
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboardShouldIgnoreTextChange) {
+      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreTextChange()) {
         InAppKeyboard.loadJavascript(KMString.format("updateKMText('%s')", kmText));
         result = true;
       }
 
-      InAppKeyboardShouldIgnoreTextChange = false;
+      InAppKeyboard.setShouldIgnoreTextChange(false);
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboardShouldIgnoreTextChange) {
+      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreTextChange()) {
         SystemKeyboard.loadJavascript(KMString.format("updateKMText('%s')", kmText));
         result = true;
       }
 
-      SystemKeyboardShouldIgnoreTextChange = false;
+      SystemKeyboard.setShouldIgnoreTextChange(false);
     }
 
     return result;
@@ -1981,14 +1977,14 @@ public final class KMManager {
   public static boolean updateSelectionRange(KeyboardType kbType, int selStart, int selEnd) {
     boolean result = false;
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboardShouldIgnoreSelectionChange) {
+      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreSelectionChange()) {
         InAppKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
         result = true;
       }
 
-      InAppKeyboardShouldIgnoreSelectionChange = false;
+      InAppKeyboard.setShouldIgnoreSelectionChange(false);
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboardShouldIgnoreSelectionChange) {
+      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreSelectionChange()) {
         InputConnection ic = getInputConnection(KeyboardType.KEYBOARD_TYPE_SYSTEM);
         if (ic != null) {
           ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
@@ -2001,7 +1997,7 @@ public final class KMManager {
         result = true;
       }
 
-      SystemKeyboardShouldIgnoreSelectionChange = false;
+      SystemKeyboard.setShouldIgnoreSelectionChange(false);
     }
 
     return result;


### PR DESCRIPTION
More refactoring for #7881 

This consolidates the following 4 static fields from `KMManager` to 2 `KMKeyboard` members.
```
  protected static boolean InAppKeyboardShouldIgnoreTextChange = false;
  protected static boolean InAppKeyboardShouldIgnoreSelectionChange = false;
  protected static boolean SystemKeyboardShouldIgnoreTextChange = false;
  protected static boolean SystemKeyboardShouldIgnoreSelectionChange = false;
```

Becomes
```
  private boolean shouldIgnoreTextChange = false;
  private boolean shouldIgnoreSelectionChange = false;
```
along with the getters/setters.

## User Testing
**Setup** - Install the PR build of Keyman for Android on a device/emulator

* **TEST_IN_APP** - Verifies typing and replacing selected text in INAPP keyboard
1. Launch Keyman for Android
2. Dismiss the "Get Started" menu
3. In the Keyman app, type "The quick brown fox jumped"
4. Move the cursor to the beginning of "brown"
5. Type <kbd>E</kbd>
6. Verify "brown" is now "Ebrown"
7. Select the letters "uic" in "quick"
8. Type <kbd>S</kbd>
9. Verify "quick" is now "qSk"
10. Press <kbd>backspace</kbd>
11. Verify "qSk" is now "qk"
12. Select the letters "ump" in "jumped"
13. Press <kbd>enter</kbd>
14. Verify "jumped" is now "j" followed by new line and "ed"

* **TEST_SYSTEM** - Verifies typing and replacing selected text in SYSTEM keyboard
1. From Keyman for Android, set Keyman as the default system keyboard
2. Dismiss the "Get Started" menu
3. Launch the Contacts app, create a new contact and select a First name field to edit
4. Type "The quick brown fox jumped"
5. Move the cursor to the beginning of "brown"
6. Type <kbd>E</kbd>
7. Verify "brown" is now "Ebrown"
8. Select the letters "uic" in "quick"
9. Type <kbd>S</kbd>
10. Verify "quick" is now "qSk"
11. Press <kbd>backspace</kbd>
12. Verify "qSk" is now "qk"
13. Select the letters "ump" in "jumped"
14. Press <kbd>enter</kbd>
15. Verify "jumped" is now "jed" (The name field is limited to one line). On current "Contacts" app, the selection may now be "Last name".