### PR TITLE
fix(developer): partial Revert in test and json validator

### DIFF
--- a/developer/src/ext/json-schema-validator/json-validator.cpp
+++ b/developer/src/ext/json-schema-validator/json-validator.cpp
@@ -362,24 +362,24 @@ void json_validator::validate(const json &instance, const json &schema_, const s
 	} combine_logic = none;
 
 	{
-		const auto &attr2 = schema->find("allOf");
-		if (attr2 != schema->end()) {
+		const auto &attr = schema->find("allOf");
+		if (attr != schema->end()) {
 			combine_logic = allOf;
-			combined_schemas = &attr2.value();
+			combined_schemas = &attr.value();
 		}
 	}
 	{
-		const auto &attr2 = schema->find("anyOf");
-		if (attr2 != schema->end()) {
+		const auto &attr = schema->find("anyOf");
+		if (attr != schema->end()) {
 			combine_logic = anyOf;
-			combined_schemas = &attr2.value();
+			combined_schemas = &attr.value();
 		}
 	}
 	{
-		const auto &attr2 = schema->find("oneOf");
-		if (attr2 != schema->end()) {
+		const auto &attr = schema->find("oneOf");
+		if (attr != schema->end()) {
 			combine_logic = oneOf;
-			combined_schemas = &attr2.value();
+			combined_schemas = &attr.value();
 		}
 	}
 

--- a/developer/src/kmcmplib/tests/api-test.cpp
+++ b/developer/src/kmcmplib/tests/api-test.cpp
@@ -54,11 +54,8 @@ void setup() {
 
 void test_kmcmp_CompileKeyboardFile() {
   char kmn_file[L_tmpnam], kmx_file[L_tmpnam];
-  strncpy(kmn_file, "test_kmcmp_CompileKeyboardFile.kmn", L_tmpnam);
-  strncpy(kmx_file, "test_kmcmp_CompileKeyboardFile.kmx", L_tmpnam);
-
-  puts(kmn_file);
-  puts(kmx_file);
+  tmpnam(kmn_file);
+  tmpnam(kmx_file);
 
   // Create an empty file
   FILE *fp = fopen(kmn_file, "w");
@@ -70,13 +67,12 @@ void test_kmcmp_CompileKeyboardFile() {
   assert(error_vec[0] == CERR_CannotReadInfile);
 
   unlink(kmn_file);
-  unlink(kmx_file);
 }
 
 void test_kmcmp_CompileKeyboardFileToBuffer() {
   char kmn_file[L_tmpnam], kmx_file[L_tmpnam];
-  strncpy(kmn_file, "test_kmcmp_CompileKeyboardFileToBuffer.kmn", L_tmpnam);
-  strncpy(kmx_file, "test_kmcmp_CompileKeyboardFileToBuffer.kmx", L_tmpnam);
+  tmpnam(kmn_file);
+  tmpnam(kmx_file);
 
   // Create an empty file
   FILE *fp = fopen(kmn_file, "w");
@@ -90,5 +86,4 @@ void test_kmcmp_CompileKeyboardFileToBuffer() {
   assert(error_vec[0] == CERR_CannotReadInfile);
 
   unlink(kmn_file);
-  unlink(kmx_file);
 }


### PR DESCRIPTION
This partially reverts commit 55405e5cf14cf08c8edffb3d1ab50ee793dc29a1 removing some of the controversial changes

#8688 

@keymanapp-test-bot skip
