### PR TITLE
chore(common): `set -eu` in build-utils.sh

### DIFF
--- a/common/predictive-text/unit_tests/test.sh
+++ b/common/predictive-text/unit_tests/test.sh
@@ -58,7 +58,7 @@ if builder_start_action test:libraries; then
 
   pushd "$KEYMAN_ROOT/common/models/templates"
   echo
-  echo "### Running $builder_term common/models/templates) tests"
+  echo "### Running $(builder_term common/models/templates) tests"
   if builder_has_option --ci; then
     npm run test -- -reporter mocha-teamcity-reporter
   else

--- a/common/predictive-text/unit_tests/test.sh
+++ b/common/predictive-text/unit_tests/test.sh
@@ -68,7 +68,7 @@ if builder_start_action test:libraries; then
 
   pushd "$KEYMAN_ROOT/common/models/types"
   echo
-  echo "### Running $builder_term common/models/types) tests"
+  echo "### Running $(builder_term common/models/types) tests"
   # Is not mocha-based; it's TSC-based instead, as we're just ensuring that the .d.ts
   # file is a proper TS declaration file.
   npm run test
@@ -100,7 +100,7 @@ if [[ $VERSION_ENVIRONMENT == test ]] && builder_has_action test :browser; then
   if builder_pull_get_details; then
     if ! ([[ $builder_pull_title =~ \(web\) ]] || builder_pull_has_label test-browserstack); then
 
-      echo "Auto-skipping $builder_term test:browser) for unrelated CI test build"
+      echo "Auto-skipping $(builder_term test:browser) for unrelated CI test build"
       exit 0
     fi
   fi

--- a/ios/tools/prepRelease.sh
+++ b/ios/tools/prepRelease.sh
@@ -70,17 +70,17 @@ KEYMAN_SAMPLES="samples"
 
 echo "engine dest: $KMEI_DST"
 
-echo "Zipping ${UNI_FRAMEWORK} => ${UPLOAD_DIR}/${KMEI_DST}..."
+echo "Zipping ${FRAMEWORK} => ${UPLOAD_DIR}/${KMEI_DST}..."
 cd "${KMEI_FRAMEWORK_BASE}"
-zip -qrX ${KMEI_DST} ${FRAMEWORK}
-cd $WORK_DIR
+zip -qrX "${KMEI_DST}" ${FRAMEWORK}
+cd "$WORK_DIR"
 
 echo "Copying Keyman Engine samples into ${UPLOAD_DIR}/${KMEI_DST_NAME}..."
 cp -rf "${KEYMAN_SAMPLES}" "${UPLOAD_DIR}/samples"
 cd "${UPLOAD_DIR}"
 zip -qr "${KMEI_DST_NAME}" "samples"
 rm -rf "samples"
-cd $WORK_DIR
+cd "$WORK_DIR"
 
 #
 # Keyman app

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -17,7 +17,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 BASEDIR=$(pwd)
 
-if [ "$1" == "origdist" ]; then
+if [[ ! -z ${1+x} ]] && [ "$1" == "origdist" ]; then
     create_origdist=1
     shift
 fi

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -61,7 +61,7 @@ echo "3.0 (quilt)" > debian/source/format
 cd "$BASEDIR"
 
 # create orig.tar.gz
-if [ -n "$create_origdist" ]; then
+if [ ! -z "${create_origdist+x}" ]; then
     cd dist
     pkgvers="keyman-$VERSION"
     tar xfz keyman-"${VERSION}".tar.gz

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -132,6 +132,7 @@ QUIET=false
 NOTARIZE=false
 SKIP_BUILD=false
 UPLOAD_SENTRY=false
+QUIET_FLAG=
 
 # Import local environment variables for build
 if [[ -f $(dirname "$THIS_SCRIPT")/localenv.sh ]]; then
@@ -259,6 +260,7 @@ displayInfo "" \
     "BUILD_ACTIONS: $BUILD_ACTIONS" \
     "TEST_ACTION: $TEST_ACTION" \
     "UPLOAD_SENTRY: $UPLOAD_SENTRY" \
+    "QUIET_FLAG: $QUIET_FLAG" \
     ""
 
 ### Validate notarization environment variables ###

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -273,11 +273,11 @@ if $LOCALDEPLOY && ! $NOTARIZE ; then
 fi
 
 if $PREPRELEASE || $NOTARIZE ; then
-  if [ ! $DO_CODESIGN ] || [ -z "${CERTIFICATE_ID}" ]; then
+  if [ ! $DO_CODESIGN ] || [ -z "${CERTIFICATE_ID+x}" ]; then
     builder_die "Code signing must be configured for deployment. See build.sh -help for details."
   fi
 
-  if [ -z "${APPSTORECONNECT_PROVIDER}" ] || [ -z "${APPSTORECONNECT_USERNAME}" ] || [ -z "${APPSTORECONNECT_PASSWORD}" ]; then
+  if [ -z "${APPSTORECONNECT_PROVIDER+x}" ] || [ -z "${APPSTORECONNECT_USERNAME+x}" ] || [ -z "${APPSTORECONNECT_PASSWORD+x}" ]; then
     builder_die "Appstoreconnect Apple ID credentials must be configured in environment. See build.sh -help for details."
   fi
 fi
@@ -388,7 +388,7 @@ if $DO_KEYMANIM ; then
         ENTITLEMENTS_FILE=Keyman.entitlements
     fi
 
-    if [ -z "$DEVELOPMENT_TEAM" ]; then
+    if [ -z "${DEVELOPMENT_TEAM+x}" ]; then
         DEVELOPMENT_TEAM=3YE4W86L3G
     fi
 
@@ -432,7 +432,7 @@ fi
 
 if $PREPRELEASE || $NOTARIZE; then
   builder_heading "Notarizing app"
-  if [ "${CODESIGNING_SUPPRESSION}" != "" ] && [ -z "${CERTIFICATE_ID}" ]; then
+  if [ "${CODESIGNING_SUPPRESSION}" != "" ] && [ -z "${CERTIFICATE_ID+x}" ]; then
     builder_die "Notarization and signed executable is required for deployment, even locally. Specify CERTIFICATE_ID environment variable for custom certificate."
   else
     TARGET_PATH="$KM4MIM_BASE_PATH/build/$CONFIG"
@@ -443,7 +443,7 @@ if $PREPRELEASE || $NOTARIZE; then
     # Note: get-task-allow entitlement must be *off* in our release build (to do this, don't include base entitlements in project build settings)
 
     # We may need to re-run the code signing if a custom certificate has been passed in
-    if [ ! -z "${CERTIFICATE_ID}" ]; then
+    if [ ! -z "${CERTIFICATE_ID+x}" ]; then
       builder_heading "Signing with custom certificate (CERTIFICATE_ID environment variable)."
       codesign --force --options runtime --entitlements Keyman4MacIM/Keyman.entitlements --deep --sign "${CERTIFICATE_ID}" "$TARGET_APP_PATH"
     fi

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -30,7 +30,7 @@
 #
 
 # Exit on command failure and when using unset variables:
-# TODO #8693: set -eu
+set -eu
 
 #
 # Prevents 'clear' on exit of mingw64 bash shell


### PR DESCRIPTION
Fixes #8693.

Enforces `-e` (abort script on error) and `-u` (error on unset variable use) on all scripts that source build-utils.sh. This may result in some downstream build failures which we'll need to address before merge to master.

@keymanapp-test-bot skip