### PR TITLE
fix(android/app): Resize OSK when resuming app from background

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -109,6 +109,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   private final int minTextSize = 16;
   private final int maxTextSize = 72;
   private int textSize = minTextSize;
+  private int lastOrientation = Configuration.ORIENTATION_UNDEFINED;
   private static final String defaultKeyboardInstalled = "DefaultKeyboardInstalled";
   private static final String defaultDictionaryInstalled = "DefaultDictionaryInstalled";
   private static final String userTextKey = "UserText";
@@ -262,6 +263,14 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     super.onResume();
     KMManager.onResume();
     KMManager.hideSystemKeyboard();
+
+    // onConfigurationChanged() only triggers when device is rotated while app is in foreground
+    // This handles when device is rotated while app is in background
+    Configuration newConfig = this.getResources().getConfiguration();
+    if (newConfig != null && newConfig.orientation != lastOrientation) {
+      lastOrientation = newConfig.orientation;
+      KMManager.onConfigurationChanged(newConfig);
+    }
     resizeTextView(textView.isKeyboardVisible());
 
     KMManager.addKeyboardEventListener(this);
@@ -349,6 +358,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     getSupportActionBar().setBackgroundDrawable(getActionBarDrawable(this));
     resizeTextView(textView.isKeyboardVisible());
     invalidateOptionsMenu();
+    lastOrientation = newConfig.orientation;
   }
 
   @SuppressLint("RestrictedApi")


### PR DESCRIPTION
Fixes #8550 
When Keyman app is in the foreground and the device is rotated, `onConfigurationChanged()` triggers which handles resizing the OSK.
If Keyman is in the background while the device is rotated, resuming the app does not trigger `onConfigurationChanged()`.
This only affects the in-app keyboard. Note, on old Android devices (e.g. Android 5.0 / SDK 21), the app is recreated so the OSK always appears fine.

This PR adds a check to `onResume()` to handle resizing the OSK if needed.

## User Testing
**Setup** - Install the PR build of Keyman for Android on a recent Android device/emulator (Anything newer than Android Oreo will do). Note, some Android devices use an "orientation" button on the navigation bar to trigger orientation changes. Press the button as necessary when rotating between portrait / landscape.

* **TEST_PORTRAIT_TO_LANDSCAPE** - Verifies OSK is resized going from portrait to landscape orientation
1. With the device in portrait orientation, launch Keyman for Android
2. From the navigation bar, press the back button twice to dismiss "Get Started" menu and dismiss Keyman
3. While Keyman is in the background rotate the device from portrait to landscape orientation.
4. From the launcher, launch Keyman for Android
5. When Keyman resumes, verify the OSK refreshes to fill the landscape orientation.

* **TEST_LANDSCAPE_TO_PORTRAIT** - Verifies OSK is resized going from landscape to portrait orientation
1. With the device in landscape orientation, launch Keyman for Android
2. From the navigation bar, press the back button twice to dismiss "Get Started" menu and dismiss Keyman
3. While Keyman is in the background rotate the device from landscape to portrait orientation.
4. From the launcher, launch Keyman for Android
5. When Keyman resumes, verify the OSK refreshes to fill the portrait orientation.
