### PR TITLE
fix(mac): `$CONFIG` not `$CONFIGURATION` in build path

### DIFF
--- a/mac/build.sh
+++ b/mac/build.sh
@@ -413,7 +413,7 @@ if $DO_KEYMANIM ; then
 
         if which sentry-cli >/dev/null; then
             cd "$KM4MIM_BASE_PATH"
-            sentry-cli upload-dif "build/${CONFIGURATION}"
+            sentry-cli upload-dif "build/$CONFIG"
         else
             builder_die "Error: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"
         fi


### PR DESCRIPTION
Fixes an error in mac/build.sh, arising from work in #8698. Kinda proves that the `-u` flag was worth setting globally!

This error broke release 17.0.101-alpha and 17.0.102-alpha.

@keymanapp-test-bot skip