### PR TITLE
refactor(android/engine): Consolidate updateSelection 🛋

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1978,6 +1978,13 @@ public final class KMManager {
     boolean result = false;
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreSelectionChange()) {
+        InputConnection ic = getInputConnection(KeyboardType.KEYBOARD_TYPE_INAPP);
+        if (ic != null) {
+          ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
+          if (icText != null) {
+            updateText(kbType, icText.text.toString());
+          }
+        }
         InAppKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
         result = true;
       }
@@ -1992,7 +1999,6 @@ public final class KMManager {
             updateText(kbType, icText.text.toString());
           }
         }
-
         SystemKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
         result = true;
       }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1950,25 +1950,11 @@ public final class KMManager {
 
   public static boolean updateText(KeyboardType kbType, String text) {
     boolean result = false;
-    String kmText = "";
-    if (text != null) {
-      kmText = text.toString().replace("\\", "\\u005C").replace("'", "\\u0027").replace("\n", "\\n");
-    }
 
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
-      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreTextChange()) {
-        InAppKeyboard.loadJavascript(KMString.format("updateKMText('%s')", kmText));
-        result = true;
-      }
-
-      InAppKeyboard.setShouldIgnoreTextChange(false);
+      return InAppKeyboard.updateText(text);
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-      if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreTextChange()) {
-        SystemKeyboard.loadJavascript(KMString.format("updateKMText('%s')", kmText));
-        result = true;
-      }
-
-      SystemKeyboard.setShouldIgnoreTextChange(false);
+      return SystemKeyboard.updateText(text);
     }
 
     return result;
@@ -1978,29 +1964,13 @@ public final class KMManager {
     boolean result = false;
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreSelectionChange()) {
-        InputConnection ic = getInputConnection(KeyboardType.KEYBOARD_TYPE_INAPP);
-        if (ic != null) {
-          ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
-          if (icText != null) {
-            updateText(kbType, icText.text.toString());
-          }
-        }
-        InAppKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
-        result = true;
+        result = InAppKeyboard.updateSelectionRange(selStart, selEnd);
       }
 
       InAppKeyboard.setShouldIgnoreSelectionChange(false);
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreSelectionChange()) {
-        InputConnection ic = getInputConnection(KeyboardType.KEYBOARD_TYPE_SYSTEM);
-        if (ic != null) {
-          ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
-          if (icText != null) {
-            updateText(kbType, icText.text.toString());
-          }
-        }
-        SystemKeyboard.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
-        result = true;
+        result = SystemKeyboard.updateSelectionRange(selStart, selEnd);
       }
 
       SystemKeyboard.setShouldIgnoreSelectionChange(false);


### PR DESCRIPTION
More refactoring for #7881 
> updateSelectionRange - the if (ic!=null) branch - is there a reason that can't run for the in-app keyboard too?

1. updateSelectionRange() consolidated to update text with inputConnection.
2. Then refactor updateSelectionRange from KMManager to KMKeyboard

## User Testing
**Setup** - Install the PR build of Keyman for Android on device/emulator.
From Keyman, also install basic_kbdfr keyboard (Basic French keyboard uses deadkeys on vowels)

* **TEST_REPLACE_SELECTION_DEADKEYS_INAPP** - Verifies INAPP keyboard replaces selected text and handles deadkeys
1. Launch Keyman for Android
2. In Keyman with the sil_euro_latin keyboard, type "the quick brown fox"
3. Select the letters "row" within the word "brown". (keyboard switches to shift layer)
4. Type "H"
5. Verify the text changes from "brown" to "bHn"
6. Select the letters "ick" within the word "quick"
7. Press backspace key
8. Verify the text changes from "quick" to "qu"
9. Select the letter "o" within the word "fox"
10. Press enter key
11. Verify the word changes from "fox" to "f" followed by "x" on the next line
12. Use the Keyman globe key to switch to the basic_kbdfr keyboard
13. Press the green <kbd>^</kbd>
14. Verify nothing is output (it's a deadkey)
15. Press a vowel
16. Verify the vowel with a hat is output.


* **TEST_REPLACE_SELECTION_DEADKEYS_SYSTEM** - Verifies system keyboard replaces selected text and handles deadkeys
1. From Keyman Settings, set Keyman as the default system keyboard
2. Launch the Contacts app and edit a new entry's Last name.
3. With the Keyman sil_euro_latin keyboard, type "the quick brown fox"
4. Select the letters "row" within the word "brown". (keyboard switches to shift layer)
5. Type "H"
6. Verify the text changes from "brown" to "bHn"
7.Select the letters "ick" within the word "quick"
8. Press backspace key
9. Verify the text changes from "quick" to "qu"
10. Select the letter "o" within the word "fox"
11. Press enter key
12. Verify the word changes from "fox" to "fx". Instead of a newline, the next field is selected.
13. Use the Keyman globe key to switch to the basic_kbdfr keyboard
14. Press the green <kbd>^</kbd>
15. Verify nothing is output (it's a deadkey)
16. Press a vowel
17. Verify the vowel with the combined diacritic is output
