### PR TITLE
feat(developer): add package validation

### DIFF
--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -8,8 +8,7 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./build/src/kmp-compiler.js",
-    "./kmp-json-file": "./build/src/kmp-json-file.js"
+    ".": "./build/src/main.js"
   },
   "files": [
     "/build/src/"

--- a/developer/src/kmc-package/src/compiler/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/kmp-compiler.ts
@@ -8,7 +8,7 @@ import { KmpJsonFile, KpsFile, KMX, KmxFileReader } from '@keymanapp/common-type
 
 const FILEVERSION_KMP_JSON = '12.0';
 
-export default class KmpCompiler {
+export class KmpCompiler {
 
   constructor(private callbacks: CompilerCallbacks) {
   }

--- a/developer/src/kmc-package/src/compiler/messages.ts
+++ b/developer/src/kmc-package/src/compiler/messages.ts
@@ -47,6 +47,12 @@ export class CompilerMessages {
     `Keyboard file ${o.filename} has no &KeyboardVersion store`);
   static WARN_KeyboardFileHasNoKeyboardVersion = SevWarn | 0x000A;
 
+  static Error_PackageCannotContainBothModelsAndKeyboards = () => m(this.ERROR_PackageCannotContainBothModelsAndKeyboards,
+    `The package contains both lexical models and keyboards, which is not permitted.`);
+  static ERROR_PackageCannotContainBothModelsAndKeyboards = SevError | 0x000B;
 
+  static Warn_PackageShouldNotRepeatLanguages = (o:{resourceType: string, id: string, tag: string}) => m(this.WARN_PackageShouldNotRepeatLanguages,
+    `The ${o.resourceType} ${o.id} has a repeated language "${o.tag}".`);
+  static WARN_PackageShouldNotRepeatLanguages = SevWarn | 0x000C;
 }
 

--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -7,6 +7,9 @@ export class PackageValidation {
   }
 
   public validate(kmpJson: KmpJsonFile.KmpJsonFile) {
+    if(!this.checkKeyboards(kmpJson)) {
+      return false;
+    }
     if(!this.checkLexicalModels(kmpJson)) {
       return false;
     }
@@ -34,6 +37,16 @@ export class PackageValidation {
     if(kmpJson.lexicalModels) {
       for(let model of kmpJson.lexicalModels) {
         this.checkForDuplicatedLanguages('model', model.id, model.languages);
+      }
+    }
+
+    return true;
+  }
+
+  private checkKeyboards(kmpJson: KmpJsonFile.KmpJsonFile): boolean {
+    if(kmpJson.keyboards) {
+      for(let keyboard of kmpJson.keyboards) {
+        this.checkForDuplicatedLanguages('keyboard', keyboard.id, keyboard.languages);
       }
     }
 

--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -1,0 +1,42 @@
+import { KmpJsonFile, CompilerCallbacks } from '@keymanapp/common-types';
+import { CompilerMessages } from './messages.js';
+
+export class PackageValidation {
+
+  constructor(private callbacks: CompilerCallbacks) {
+  }
+
+  public validate(kmpJson: KmpJsonFile.KmpJsonFile) {
+    if(!this.checkLexicalModels(kmpJson)) {
+      return false;
+    }
+    return true;
+  }
+
+  private checkForDuplicatedLanguages(resourceType: 'keyboard'|'model', id: string, languages: KmpJsonFile.KmpJsonFileLanguage[]) {
+    let tags: {[index:string]: boolean} = {};
+    for(let lang of languages) {
+      const langTag = lang.id.toLowerCase();
+      if(tags[langTag]) {
+        this.callbacks.reportMessage(CompilerMessages.Warn_PackageShouldNotRepeatLanguages({resourceType:resourceType, id:id, tag:lang.id}));
+      } else {
+        tags[langTag] = true;
+      }
+    }
+  }
+
+  private checkLexicalModels(kmpJson: KmpJsonFile.KmpJsonFile): boolean {
+    if(kmpJson.lexicalModels?.length > 0 && kmpJson.keyboards?.length > 0) {
+      this.callbacks.reportMessage(CompilerMessages.Error_PackageCannotContainBothModelsAndKeyboards());
+      return false;
+    }
+
+    if(kmpJson.lexicalModels) {
+      for(let model of kmpJson.lexicalModels) {
+        this.checkForDuplicatedLanguages('model', model.id, model.languages);
+      }
+    }
+
+    return true;
+  }
+}

--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -7,6 +7,9 @@ export class PackageValidation {
   }
 
   public validate(kmpJson: KmpJsonFile.KmpJsonFile) {
+    if(!this.checkForModelsAndKeyboardsInSamePackage(kmpJson)) {
+      return false;
+    }
     if(!this.checkKeyboards(kmpJson)) {
       return false;
     }
@@ -28,12 +31,16 @@ export class PackageValidation {
     }
   }
 
-  private checkLexicalModels(kmpJson: KmpJsonFile.KmpJsonFile): boolean {
+  private checkForModelsAndKeyboardsInSamePackage(kmpJson: KmpJsonFile.KmpJsonFile): boolean {
     if(kmpJson.lexicalModels?.length > 0 && kmpJson.keyboards?.length > 0) {
       this.callbacks.reportMessage(CompilerMessages.Error_PackageCannotContainBothModelsAndKeyboards());
       return false;
     }
 
+    return true;
+  }
+
+  private checkLexicalModels(kmpJson: KmpJsonFile.KmpJsonFile): boolean {
     if(kmpJson.lexicalModels) {
       for(let model of kmpJson.lexicalModels) {
         this.checkForDuplicatedLanguages('model', model.id, model.languages);

--- a/developer/src/kmc-package/src/main.ts
+++ b/developer/src/kmc-package/src/main.ts
@@ -1,0 +1,2 @@
+export { KmpCompiler } from "./compiler/kmp-compiler.js";
+export { PackageValidation } from "./compiler/package-validation.js";

--- a/developer/src/kmc-package/test/fixtures/invalid/ERROR_PackageCannotContainBothModelsAndKeyboards.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/ERROR_PackageCannotContainBothModelsAndKeyboards.kps
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Info>
+    <Name URL="">Khmer Angkor</Name>
+    <Copyright URL="">© 2015-2022 SIL International</Copyright>
+    <Author URL="mailto:makara_sok@sil.org">Makara Sok</Author>
+    <Version URL=""></Version>
+    <WebSite URL="https://keyman.com/keyboards/khmer_angkor">https://keyman.com/keyboards/khmer_angkor</WebSite>
+  </Info>
+  <Files>
+    <File>
+      <Name>nokeyboardversion.kmx</Name>
+      <Description>Keyboard Khmer Angkor</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+    <File>
+      <Name>example.qaa.sencoten.model.js</Name>
+      <Description>Lexical model example.qaa.sencoten.model.js</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.model.js</FileType>
+    </File>
+  </Files>
+  <!-- ERROR_PackageCannotContainBothModelsAndKeyboards -->
+  <LexicalModels>
+    <LexicalModel>
+      <Name>SENĆOŦEN dictionary</Name>
+      <ID>example.qaa.sencoten</ID>
+      <Languages>
+        <Language ID="qaa">North Straits Salish</Language>
+        <Language ID="qaa-Latn">SENĆOŦEN</Language>
+      </Languages>
+    </LexicalModel>
+  </LexicalModels>
+  <Keyboards>
+    <Keyboard>
+      <Name>Khmer Angkor</Name>
+      <ID>nokeyboardversion</ID>
+      <Version>1.3</Version>
+      <Languages>
+        <Language ID="km">Central Khmer (Khmer, Cambodia)</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
+</Package>

--- a/developer/src/kmc-package/test/fixtures/invalid/WARN_PackageShouldNotRepeatLanguages.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/WARN_PackageShouldNotRepeatLanguages.kps
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Info>
+    <Name URL="">SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
+    <Copyright URL="">© 2019 National Research Council Canada</Copyright>
+    <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
+    <Version>1.0.3</Version>
+  </Info>
+  <Files>
+    <File>
+      <Name>example.qaa.sencoten.model.js</Name>
+      <Description>Lexical model example.qaa.sencoten.model.js</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.model.js</FileType>
+    </File>
+  </Files>
+  <LexicalModels>
+    <LexicalModel>
+      <Name>SENĆOŦEN dictionary</Name>
+      <ID>example.qaa.sencoten</ID>
+      <Languages>
+        <Language ID="qaa">North Straits Salish</Language>
+        <!-- WARN_PackageShouldNotRepeatLanguages -->
+        <Language ID="QAA">Salish Again</Language>
+        <Language ID="qaa-Latn">SENĆOŦEN</Language>
+      </Languages>
+    </LexicalModel>
+  </LexicalModels>
+</Package>

--- a/developer/src/kmc-package/test/fixtures/invalid/WARN_PackageShouldNotRepeatLanguages.model.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/WARN_PackageShouldNotRepeatLanguages.model.kps
@@ -12,22 +12,22 @@
   </Info>
   <Files>
     <File>
-      <Name>nokeyboardversion.kmx</Name>
-      <Description>Keyboard Khmer Angkor</Description>
+      <Name>example.qaa.sencoten.model.js</Name>
+      <Description>Lexical model example.qaa.sencoten.model.js</Description>
       <CopyLocation>0</CopyLocation>
-      <FileType>.kmx</FileType>
+      <FileType>.model.js</FileType>
     </File>
   </Files>
-  <Keyboards>
-    <Keyboard>
-      <Name>Khmer Angkor</Name>
-      <ID>nokeyboardversion</ID>
-      <Version>1.3</Version>
+  <LexicalModels>
+    <LexicalModel>
+      <Name>SENĆOŦEN dictionary</Name>
+      <ID>example.qaa.sencoten</ID>
       <Languages>
+        <Language ID="qaa">North Straits Salish</Language>
         <!-- WARN_PackageShouldNotRepeatLanguages -->
-        <Language ID="km">Central Khmer (Khmer, Cambodia)</Language>
-        <Language ID="KM">Khmer</Language>
+        <Language ID="QAA">Salish Again</Language>
+        <Language ID="qaa-Latn">SENĆOŦEN</Language>
       </Languages>
-    </Keyboard>
-  </Keyboards>
+    </LexicalModel>
+  </LexicalModels>
 </Package>

--- a/developer/src/kmc-package/test/test-messages.ts
+++ b/developer/src/kmc-package/test/test-messages.ts
@@ -1,6 +1,6 @@
 import 'mocha';
-import { CompilerMessages } from '../src/messages.js';
 import { verifyCompilerMessagesObject } from '@keymanapp/developer-test-helpers';
+import { CompilerMessages } from '../src/compiler/messages.js';
 
 describe('CompilerMessages', function () {
   it('should have a valid CompilerMessages object', function() {

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -225,9 +225,15 @@ describe('KmpCompiler', function () {
     testForMessage(this, ['invalid', 'ERROR_PackageCannotContainBothModelsAndKeyboards.kps'], CompilerMessages.ERROR_PackageCannotContainBothModelsAndKeyboards);
   });
 
-  // WARN_PackageShouldNotRepeatLanguages
+  // WARN_PackageShouldNotRepeatLanguages (models)
 
   it('should generate WARN_PackageShouldNotRepeatLanguages if model has same language repeated', async function() {
+    testForMessage(this, ['invalid', 'WARN_PackageShouldNotRepeatLanguages.model.kps'], CompilerMessages.WARN_PackageShouldNotRepeatLanguages);
+  });
+
+  // WARN_PackageShouldNotRepeatLanguages (keyboards)
+
+  it('should generate WARN_PackageShouldNotRepeatLanguages if keyboard has same language repeated', async function() {
     testForMessage(this, ['invalid', 'WARN_PackageShouldNotRepeatLanguages.kps'], CompilerMessages.WARN_PackageShouldNotRepeatLanguages);
   });
 

--- a/developer/src/kmc/src/commands/build/BuildPackage.ts
+++ b/developer/src/kmc/src/commands/build/BuildPackage.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { BuildActivity, BuildActivityOptions } from './BuildActivity.js';
-import KmpCompiler from '@keymanapp/kmc-package';
 import { CompilerCallbacks } from '@keymanapp/common-types';
+import { KmpCompiler, PackageValidation } from '@keymanapp/kmc-package';
 
 export class BuildPackage extends BuildActivity {
   public get name(): string { return 'Package'; }
@@ -19,6 +19,15 @@ export class BuildPackage extends BuildActivity {
     const kmpCompiler = new KmpCompiler(callbacks);
     const kmpJsonData = kmpCompiler.transformKpsToKmpObject(infile);
     if(!kmpJsonData) {
+      return false;
+    }
+
+    //
+    // Validate the package file
+    //
+
+    const validation = new PackageValidation(callbacks);
+    if(!validation.validate(kmpJsonData)) {
       return false;
     }
 

--- a/developer/src/kmc/src/kmlmi.ts
+++ b/developer/src/kmc/src/kmlmi.ts
@@ -5,8 +5,8 @@
 
 import * as path from 'path';
 import { Command } from 'commander';
-import KmpCompiler from '@keymanapp/kmc-package';
-import { ModelInfoOptions as ModelInfoOptions, writeMergedModelMetadataFile } from '@keymanapp/kmc-model-info';
+import { KmpCompiler, PackageValidation } from '@keymanapp/kmc-package';
+import { ModelInfoOptions, writeMergedModelMetadataFile } from '@keymanapp/kmc-model-info';
 import { SysExits } from './util/sysexits.js';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
 import { NodeCompilerCallbacks } from './messages/NodeCompilerCallbacks.js';
@@ -48,6 +48,15 @@ let jsFilename = program.opts().jsFilename ? program.opts().jsFilename : path.jo
 const callbacks = new NodeCompilerCallbacks();
 let kmpCompiler = new KmpCompiler(callbacks);
 let kmpJsonData = kmpCompiler.transformKpsToKmpObject(kpsFilename);
+
+//
+// Validate the package file
+//
+
+const validation = new PackageValidation(callbacks);
+if(!validation.validate(kmpJsonData)) {
+  process.exit(1);
+}
 
 //
 // Write out the merged .model_info file

--- a/developer/src/kmc/src/kmlmp.ts
+++ b/developer/src/kmc/src/kmlmp.ts
@@ -3,9 +3,11 @@
  * kmlmp - Keyman Lexical Model Package Compiler
  */
 
+// Note: this is a deprecated package and will be removed in Keyman 18.0
+
 import * as fs from 'fs';
 import { Command } from 'commander';
-import KmpCompiler from '@keymanapp/kmc-package';
+import { PackageValidation, KmpCompiler } from '@keymanapp/kmc-package';
 import { SysExits } from './util/sysexits.js';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
 import { NodeCompilerCallbacks } from './messages/NodeCompilerCallbacks.js';
@@ -15,7 +17,7 @@ const program = new Command();
 
 /* Arguments */
 program
-  .description('Compiles Keyman lexical model packages')
+  .description('Compiles Keyman lexical model packages\nDeprecated: use <kmc build> instead; will be removed in v18')
   .version(KEYMAN_VERSION.VERSION_WITH_TAG)
   .arguments('<infile>')
   .action(infile => inputFilename = infile)
@@ -38,6 +40,18 @@ let outputFilename: string = program.opts().outFile ? program.opts().outFile : i
 const callbacks = new NodeCompilerCallbacks();
 let kmpCompiler = new KmpCompiler(callbacks);
 let kmpJsonData = kmpCompiler.transformKpsToKmpObject(inputFilename);
+if(!kmpJsonData) {
+  process.exit(1);
+}
+
+//
+// Validate the package file
+//
+
+const validation = new PackageValidation(callbacks);
+if(!validation.validate(kmpJsonData)) {
+  process.exit(1);
+}
 
 //
 // Build the .kmp package file


### PR DESCRIPTION
Fixes #8730.
Fixes #8731.

Adds a package-validation.ts module, plus adds a call to the validation step in the compilers.

Rearranges the kmc-package files to match other compilers better.

Removes `default` from exports.

And finally, adds ERROR_PackageCannotContainBothModelsAndKeyboards and WARN_PackageShouldNotRepeatLanguages messages, plus tests.

@keymanapp-test-bot skip