### PR TITLE
chore(ios): Changes required for XCode 14.3

### DIFF
--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,5 +1,5 @@
 github "marmelroy/Zip"
-github "DaveWoodCom/XCGLogger" ~> 6.1.0
+github "keymanapp/dependency-XCGLogger" "master"
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
-github "getsentry/sentry-cocoa" ~> 6.2.1
+github "getsentry/sentry-cocoa" ~> 8.7.0

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,5 +1,5 @@
-github "DaveWoodCom/XCGLogger" "6.1.0"
 github "ashleymills/Reachability.swift" "v5.1.0"
 github "devicekit/DeviceKit" "5.0.0"
-github "getsentry/sentry-cocoa" "6.2.1"
+github "getsentry/sentry-cocoa" "8.7.0"
+github "keymanapp/dependency-XCGLogger" "57a7b975dbb6fe4fe90cef3d1bc52b8adbd89113"
 github "marmelroy/Zip" "2.1.2"

--- a/ios/engine/KMEI/KeymanEngine/Classes/Errors/SentryManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Errors/SentryManager.swift
@@ -167,7 +167,7 @@ public class SentryManager {
   public static func breadcrumbAndLog(crumb: Sentry.Breadcrumb, logLevel: XCGLogger.Level? = nil) {
     // Guarded in case a library consumer decides against initializing Sentry.
     if _started {
-      SentrySDK.addBreadcrumb(crumb: crumb)
+      SentrySDK.addBreadcrumb(crumb)
     }
 
     let level = logLevel ?? mapLoggingLevel(crumb.level)
@@ -193,7 +193,7 @@ public class SentryManager {
   }
 
   public static func forceError() {
-    SentrySDK.addBreadcrumb(crumb: Sentry.Breadcrumb(level: .info, category: "Deliberate testing error"))
+    SentrySDK.addBreadcrumb(Sentry.Breadcrumb(level: .info, category: "Deliberate testing error"))
     SentrySDK.crash()
   }
 }

--- a/oem/firstvoices/ios/Cartfile
+++ b/oem/firstvoices/ios/Cartfile
@@ -1,4 +1,4 @@
-github "DaveWoodCom/XCGLogger" ~> 6.1.0
+github "keymanapp/dependency-XCGLogger" "head"
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
-github "getsentry/sentry-cocoa" ~> 6.2.1
+github "getsentry/sentry-cocoa" ~> 8.7.0

--- a/oem/firstvoices/ios/Cartfile
+++ b/oem/firstvoices/ios/Cartfile
@@ -1,4 +1,4 @@
-github "keymanapp/dependency-XCGLogger" "head"
+github "keymanapp/dependency-XCGLogger" "master"
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
 github "getsentry/sentry-cocoa" ~> 8.7.0

--- a/oem/firstvoices/ios/Cartfile.resolved
+++ b/oem/firstvoices/ios/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "DaveWoodCom/XCGLogger" "6.1.0"
 github "ashleymills/Reachability.swift" "v5.1.0"
 github "devicekit/DeviceKit" "5.0.0"
-github "getsentry/sentry-cocoa" "6.2.1"
+github "getsentry/sentry-cocoa" "8.7.0"
+github "keymanapp/dependency-XCGLogger" "57a7b975dbb6fe4fe90cef3d1bc52b8adbd89113"


### PR DESCRIPTION
Update Carthage dependencies to versions that will build under XCode 14.3

# User Testing

(adopted from Keyman for iPhone and iPad Acceptance Test Procedures)

---

## Gather Assets for Testing ##
- [ ] We only need to test all these on iPhone 
- [ ] Record device's iOS version
- [ ] Ensure the device is properly configured for testing and is registered with TestFlight. 

At this time, Keyman for iOS does not support external keyboard input.

## Setup Steps ##
1.  Uninstall previous version of Keyman on the device (on a simulator, "Erase All Content and Settings..." under Device menu)
2. Install test build IPA (on a simulator, "iOS Simulator Image")
3. Disable internet connectivity of the device
4. Start Keyman and select **Add a keyboard for your language**
5. Verify error message "Could not reach Keyman server!" or "The Internet connection appears to be offline." is displayed
6. Click OK to dismiss.  Close Keyman app
7. On device, enable internet connectivity
8. Start Keyman
9. On initial **Get Started** menu, select "Enable Keyman as system-wide keyboard" and do any necessary system steps to enable Keyman

---

## SUITE_MENU_FUNCTIONALITY: Menu Functionality Tests, in-app

### Test Cases
- **TEST_GET_STARTED**: Get Started
  - Verify touching **Add a keyboard for your language** pulls up the **keyboard search**
      - This should also be accessible as **Settings** > **Installed Languages** > **`+`**.
  - Verify touching **Enable Keyman as system-wide keyboard** pulls up Keyman's menu within iOS settings.  (11.0+ devices)
      - If older versions of iOS are supported, ensure that the help page for doing it manually is properly linked.
  - Verify touching **More info** brings up an accurate version and the main table-of-contents help page.
      - This should also be accessible as **Info** from the main menu dropdown (on phones) or as the circled-i button (on tablets).
  - Set **Don't show again** to checked, close and re-open Keyman, and verify **Get Started** menu does not appear

- **TEST_ADD_NEW_KEYBOARD**: Add New Keyboard
This menu is accessed via **Get Started** menu or **Settings** menu
  - On the device, enable internet connectivity
  - Verify a new keyboard can be downloaded and selected, say "US Basic"
  - Return to the text input screen and confirm that it operates correctly.
  - Without changing selected language, confirm that it can be cleanly deleted via the Settings menu.
  - Confirm that another keyboard is correctly selected afterward.

- **TEST_ADD_NEW_KEYBOARD_FROM_FILE**:
  - On the device, go to keyman.com on Safari
  - Search for "US Basic"
  - scroll down to keyboard details and tap to download the keyboard package (i.e. `.kmp` file)
  - open Files app and navigate to Download folder to find "basic_kbdus.kmp" and tap on it to start the installation processes
  - Keyman app should be pulled up
  - follow the screen to finish the keyboard installation
  - verity that the keyboard is correctly installed and working as expected

- **TEST_SWITCH_KEYBOARD**
  - press on the globe key
  - the keyboard menu should be shown
  - press on a keyboard to switch to, say "EuroLatin (SIL)"
  - confirm that "EuroLatin (SIL)" is now selected and ready to be used
  - swich back to "US Basic" and confirm it does as expected

- **TEST_SHARE**: Share
  - Type and verify text can be copied and shared to external app

- **TEST_KEYMAN_BROWSER**: Keyman Browser ###
  - On default page, click on text field and set system keyboard to Keyman
  - Verify can type with Keyman as system keyboard
  - Verify that predictive suggestions are properly applied when selected (using `sil_euro_latin` + English)
  - Close and reopen Keyman app

- **TEST_TEXT_SIZE**: Text Size
  - Verify text can be rescaled from Text Size 9 to 72

- **TEST_CLEAR_TEXT**: Clear Text
  - Verify text can be cleared

- **TEST_INFO**: Info
  - Verify that the Keyman iOS version is displayed; record the version
  - Verify that the Info menu options matches that of the **More Info...** option from the **Get Started** menu option.
  - Verify that the Keyman iOS version matches the version string seen at (Home Screen) > [iOS] Settings > Keyman.

- **TEST_SETTINGS**: Settings
  - Installed Languages ... Add Language
  - Select an installed language ... Add (another) Keyboard
    - Should automatically perform a filtered search based upon that language's BCP-47 code, i.e. for "English" it should be seen as shown in the screenshot below.
    <img width="150" src="https://user-images.githubusercontent.com/28331388/163088289-b467eabb-01a6-468e-81f9-2cfad38584bd.png">

  - Select an installed language ... Dictionary
    - Turn on/off 'Enable Predictions' and validate each
    - Turn on/off 'Enable Corrections' and validate each
  - Validate that when both predictions and corrections are off, banner is not visible
  - Add/Remove dictionaries - validate
  - If multiple dictionaries are available, test swapping between them

---

## SUITE_IN_APP_KEYBOARD:

### Test Cases

- **TEST_US_BASIC**: English: `US Basic` in-app
  - Verify that the **US Basic** keyboard can be downloaded through Settings > Installed Languages > English > `+`
    - This should automatically bring up search results for **English** keyboards.
    - When the package-installer launches, English should be the one pre-selected language.
  - Install the package for both English and Tagalog by selecting both of them in the installation processes.
  - Set **English: US Basic** as the active in-app keyboard.
  - Verify that predictive text suggestions appear.
  - Set **Tagalog: US Basic** as the active in-app keyboard.
  - Verify that predictive text suggestions do _not_ appear.
  - Verify that long-press `123` key works, presenting options for a currency layer and a symbol layer.
  - Select the currency layer, then press the `£` key.
  - Verify that the keyboard outputs correctly and returns to the default layer.
  - Go to the symbol layer and press the `©` key.
  - Verify that the keyboard outputs correctly and remains on the symbol layer.
  - Revert to the default layer and ensure basic key inputs work.
  - Long-press `e` on the default layer and select a subkey.
  - Verify that the selected key produces the correct output.
  - From the `Settings > Languages > English > US Basic` menu, follow the "Help link" and ensure it displays appropriate help.
    - (Should work both online and offline)
  - From the `Settings > Languages > English > US Basic` menu, scan the QR code with a phone and test that it links to the current version of that keyboard's public download page on keyman.com.
  - Returning to the app, uninstall the **US Basic** keyboard via Settings for Tagalog.
  - Set **English: US Basic** as the active in-app keyboard.
  - Verify that the keyboard appears correctly and ensure basic key inputs work.
    - This is to ensure that uninstalling for one language doesn't adversely affect installations of the same resource for another language.
  - Uninstall the **US Basic** keyboard via Settings for English.

- **TEST_EUROLATIN**: `English (Eurolatin)` in-app
  - In portrait orientation, verify that the OSK appears and fills the width the bottom of the screen
  - Verify long-press `q` key works
  - Verify long-press `k` key works
      - Verify that any predictive suggestions generated feel 'reasonable' (based upon 'k', the selected subkey, or one of its neighbors)
  - Verify uppercase layer can be selected via `SHIFT`
  - Verify number layer can be selected via `123`
  - Verify long-press `1` key works
  - Verify long-press `0` key works
  - Verify backspace, space, and enter keys work

---

## SUITE_SYSTEM_KEYBOARD:

Test the following after setting Keyman as a system keyboard.

Test Cases
- **TEST_BASIC_USAGE**: ensure that the keyboards functions as expected on all layers. Please test on multiple keyboards, i.e. EuroLatin (SIL), Cameroon QWERTY keyboard and Khmer Angkor.

- **TEST_LONG_PRESS**: ensure that longpress on all applicable layers are working as intended.

- **TEST_GLOBE_KEY**: ensure that a short press on the globe key switch to the next keyboard and a longpress on it open the keyboard menu where you can select a keyboard of your choice