### PR TITLE
chore(android/app): Cleanup build-play-store-notes script

### DIFF
--- a/android/KMAPro/build-play-store-notes.inc.sh
+++ b/android/KMAPro/build-play-store-notes.inc.sh
@@ -2,12 +2,11 @@
 
 # Assumption: parent script that sources this already has START STANDARD BUILD SCRIPT INCLUDE
 
-# This script runs from its own folder
-cd "$THIS_SCRIPT_PATH"
-
 ################################ Main script ################################
 
 function generateReleaseNotes() {
+  pushd "$KEYMAN_ROOT/android/KMAPro/"
+
   #
   # Copy release notes for Gradle Play Publisher to upload
   # Reference: https://github.com/Triple-T/gradle-play-publisher#uploading-release-notes
@@ -31,7 +30,9 @@ function generateReleaseNotes() {
     builder_warn "Warning: whatsnew.md empty so using default release note: '$FILTERED_LINES'"
   fi
 
-  IFS=$'\n'      # Change IFS to new line
+  # Change IFS to new line
+  local old_IFS="${IFS}"
+  IFS=$'\n'      
   for line in $FILTERED_LINES
   do
     local CHARS_IN_RELEASE_NOTES=$( wc -m < $PLAY_RELEASE_NOTES )
@@ -46,4 +47,8 @@ function generateReleaseNotes() {
       break
     fi
   done
+
+  # Restore IFS
+  IFS=${old_IFS}
+  popd
 }

--- a/android/KMAPro/build-play-store-notes.inc.sh
+++ b/android/KMAPro/build-play-store-notes.inc.sh
@@ -35,20 +35,20 @@ function generateReleaseNotes() {
   IFS=$'\n'      
   for line in $FILTERED_LINES
   do
-    local CHARS_IN_RELEASE_NOTES=$( wc -m < $PLAY_RELEASE_NOTES )
+    local CHARS_IN_RELEASE_NOTES=$( wc -m < "$PLAY_RELEASE_NOTES" )
     local CHARS_IN_CURRENT_LINE=$( wc -m <<< $line )
     if (( CHARS_IN_RELEASE_NOTES + CHARS_IN_CURRENT_LINE + 1 < 450 )); then
       # Copy line to Play Store release notes
-      echo "$line" >> $PLAY_RELEASE_NOTES
+      echo "$line" >> "$PLAY_RELEASE_NOTES"
     else
       # 450 chars reached
       builder_warn "Warning: Play Store release notes approaching 500 character limit"
-      echo "$DEFAULT_RELEASE_NOTE" >> $PLAY_RELEASE_NOTES
+      echo "$DEFAULT_RELEASE_NOTE" >> "$PLAY_RELEASE_NOTES"
       break
     fi
   done
 
   # Restore IFS
-  IFS=${old_IFS}
+  IFS="${old_IFS}"
   popd
 }

--- a/android/KMAPro/build-play-store-notes.sh
+++ b/android/KMAPro/build-play-store-notes.sh
@@ -1,55 +1,49 @@
-# Set sensible script defaults:
-# set -e: Terminate script if a command returns an error
-set -e
-# set -u: Terminate script if an unset variable is used
-set -u
+#!/usr/bin/env bash
 
-## START STANDARD BUILD SCRIPT INCLUDE
-# adjust relative paths as necessary
-THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
-## END STANDARD BUILD SCRIPT INCLUDE
+# Assumption: parent script that sources this already has START STANDARD BUILD SCRIPT INCLUDE
 
-QUIET=0
+# This script runs from its own folder
+cd "$THIS_SCRIPT_PATH"
 
-. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+################################ Main script ################################
 
-THIS_DIR="$(dirname "$THIS_SCRIPT")"
-
-#
-# Copy release notes for Gradle Play Publisher to upload
-# Reference: https://github.com/Triple-T/gradle-play-publisher#uploading-release-notes
-#
-PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/$TIER.txt"
-if [ $TIER = "stable" ]; then
-  PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/default.txt"
-fi
-echo "Generating Play Store release notes to $PLAY_RELEASE_NOTES"
-echo "" > "$PLAY_RELEASE_NOTES"
-
-# Copy whatsnew.md to release notes 1 line at a time,
-# filtering for lines that start with "*".
-# Pad release notes if whatsnew.md doesn't have any line items
-# Play Store release notes have a limit of 500 characters
-DEFAULT_RELEASE_NOTE="* Additional bug fixes and improvements"
-FILTERED_LINES=$( grep '^\s*\*.*$' "$KEYMAN_ROOT/android/help/about/whatsnew.md" || [[ $? == 1 ]] ) # Continue if grep has no matches
-if [ -z "$FILTERED_LINES" ]; then
-  FILTERED_LINES="$DEFAULT_RELEASE_NOTE"
-  builder_warn "Warning: whatsnew.md empty so using default release note: '$FILTERED_LINES'"
-fi
-
-IFS=$'\n'      # Change IFS to new line
-for line in $FILTERED_LINES
-do
-  CHARS_IN_RELEASE_NOTES=$( wc -m < $PLAY_RELEASE_NOTES )
-  CHARS_IN_CURRENT_LINE=$( wc -m <<< $line )
-  if (( CHARS_IN_RELEASE_NOTES + CHARS_IN_CURRENT_LINE + 1 < 450 )); then
-    # Copy line to Play Store release notes
-    echo "$line" >> $PLAY_RELEASE_NOTES
-  else
-    # 450 chars reached
-    builder_warn "Warning: Play Store release notes approaching 500 character limit"
-    echo "$DEFAULT_RELEASE_NOTE" >> $PLAY_RELEASE_NOTES
-    break
+function generateReleaseNotes() {
+  #
+  # Copy release notes for Gradle Play Publisher to upload
+  # Reference: https://github.com/Triple-T/gradle-play-publisher#uploading-release-notes
+  #
+  local PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/$TIER.txt"
+  if [ $TIER = "stable" ]; then
+    PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/default.txt"
   fi
-done
+  builder_heading "Generating Play Store release notes to $PLAY_RELEASE_NOTES"
+  # write to file
+  echo "" > "$PLAY_RELEASE_NOTES"
+
+  # Copy whatsnew.md to release notes 1 line at a time,
+  # filtering for lines that start with "*".
+  # Pad release notes if whatsnew.md doesn't have any line items
+  # Play Store release notes have a limit of 500 characters
+  local DEFAULT_RELEASE_NOTE="* Additional bug fixes and improvements"
+  local FILTERED_LINES=$( grep '^\s*\*.*$' "$KEYMAN_ROOT/android/help/about/whatsnew.md" || [[ $? == 1 ]] ) # Continue if grep has no matches
+  if [ -z "$FILTERED_LINES" ]; then
+    FILTERED_LINES="$DEFAULT_RELEASE_NOTE"
+    builder_warn "Warning: whatsnew.md empty so using default release note: '$FILTERED_LINES'"
+  fi
+
+  IFS=$'\n'      # Change IFS to new line
+  for line in $FILTERED_LINES
+  do
+    local CHARS_IN_RELEASE_NOTES=$( wc -m < $PLAY_RELEASE_NOTES )
+    local CHARS_IN_CURRENT_LINE=$( wc -m <<< $line )
+    if (( CHARS_IN_RELEASE_NOTES + CHARS_IN_CURRENT_LINE + 1 < 450 )); then
+      # Copy line to Play Store release notes
+      echo "$line" >> $PLAY_RELEASE_NOTES
+    else
+      # 450 chars reached
+      builder_warn "Warning: Play Store release notes approaching 500 character limit"
+      echo "$DEFAULT_RELEASE_NOTE" >> $PLAY_RELEASE_NOTES
+      break
+    fi
+  done
+}

--- a/android/build-publish.sh
+++ b/android/build-publish.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # CI script to publish specified app APKs to the Play Store.
 # The APKs should already have been built from a separate script
 
@@ -11,7 +10,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-. "$KEYMAN_ROOT/android/KMAPro/build-play-store-notes.sh"
+. "$KEYMAN_ROOT/android/KMAPro/build-play-store-notes.inc.sh"
 
 echo Publishing APKs to Play Store
 
@@ -74,9 +73,9 @@ echo "BUILD_FLAGS $BUILD_FLAGS"
 
 # Publish Keyman for Android
 if [ "$DO_KMAPRO" = true ]; then
-  cd "$KEYMAN_ROOT/android/KMAPro/"
   # Copy Release Notes
   generateReleaseNotes
+  exit
   ./gradlew $DAEMON_FLAG $BUILD_FLAGS
 fi
 

--- a/android/build-publish.sh
+++ b/android/build-publish.sh
@@ -75,7 +75,6 @@ echo "BUILD_FLAGS $BUILD_FLAGS"
 if [ "$DO_KMAPRO" = true ]; then
   # Copy Release Notes
   generateReleaseNotes
-  exit
   ./gradlew $DAEMON_FLAG $BUILD_FLAGS
 fi
 

--- a/android/build-publish.sh
+++ b/android/build-publish.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # CI script to publish specified app APKs to the Play Store.
 # The APKs should already have been built from a separate script
 

--- a/android/build-publish.sh
+++ b/android/build-publish.sh
@@ -2,11 +2,6 @@
 # CI script to publish specified app APKs to the Play Store.
 # The APKs should already have been built from a separate script
 
-# Set sensible script defaults:
-# set -e: Terminate script if a command returns an error
-set -e
-# set -u: Terminate script if an unset variable is used
-set -u
 # set -x: Debugging use, print each statement
 # set -x
 
@@ -15,6 +10,8 @@ set -u
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
+
+. "$KEYMAN_ROOT/android/KMAPro/build-play-store-notes.sh"
 
 echo Publishing APKs to Play Store
 
@@ -79,8 +76,7 @@ echo "BUILD_FLAGS $BUILD_FLAGS"
 if [ "$DO_KMAPRO" = true ]; then
   cd "$KEYMAN_ROOT/android/KMAPro/"
   # Copy Release Notes
-  ./build-play-store-notes.sh
-
+  generateReleaseNotes
   ./gradlew $DAEMON_FLAG $BUILD_FLAGS
 fi
 


### PR DESCRIPTION
Some minor cleanup to the script that generates Play Store release notes.
This mainly encapsulates build-play-store-notes.sh into a function `generateReleaseNotes()`

A lot of preamble is already handled by the parent script sourcing build-utils.sh

@keymanapp-test-bot skip