### PR TITLE
feat(windows): add text editor to the support makefile

### DIFF
--- a/windows/src/support/Makefile
+++ b/windows/src/support/Makefile
@@ -3,9 +3,9 @@
 #
 
 !ifdef NODELPHI
-TARGETS=etl2log
+TARGETS=etl2log texteditor
 !else
-TARGETS=oskbulkrenderer etl2log
+TARGETS=oskbulkrenderer etl2log texteditor
 !endif
 CLEANS=clean-support
 
@@ -19,6 +19,10 @@ oskbulkrenderer: .virtual
 
 etl2log: .virtual
     cd $(ROOT)\src\support\etl2log
+    $(MAKE) $(TARGET)
+
+texteditor: .virtual
+    cd $(ROOT)\src\support\texteditor
     $(MAKE) $(TARGET)
 
 # ----------------------------------------------------------------------

--- a/windows/src/support/texteditor/Makefile
+++ b/windows/src/support/texteditor/Makefile
@@ -8,9 +8,9 @@ build:
     $(MSBUILD) editor.vcxproj $(MSBUILD_BUILD) /p:Platform=x86
 		$(MSBUILD) editor.vcxproj $(MSBUILD_BUILD) /p:Platform=x64
     $(COPY) $(WIN32_TARGET_PATH)\editor32.exe $(PROGRAM)\support
-    $(COPY) $(WIN32_TARGET_PATH)\editor32.pdb $(PROGRAM)\support
+    $(COPY) $(WIN32_TARGET_PATH)\editor32.pdb $(DEBUGPATH)\support
 		$(COPY) $(X64_TARGET_PATH)\editor64.exe $(PROGRAM)\support
-    $(COPY) $(X64_TARGET_PATH)\editor64.pdb $(PROGRAM)\support
+    $(COPY) $(X64_TARGET_PATH)\editor64.pdb $(DEBUGPATH)\support
 
 clean: def-clean
     $(MSBUILD) $(MSBUILD_CLEAN) editor.sln


### PR DESCRIPTION
- Add text editor to the `windows/src/support/Makefile` 
- Fixed the TextEditor Makefile to copy the debug file to the debug folder.

# User Testing

# TEST_DOWNLOAD_USE_TXT_EDITOR

* Under the `Test Artifacts` heading on this PR click the `Text Editor (32 bit)`
* Expected result: it should download. 
* Under the `Test Artifacts` heading on this PR click the `Text Editor (64 bit)`
* Expected result: it should also download.
* You should be able to run either of these once downloaded.