### PR TITLE
feat(developer): verify bcp47 tags are valid and minimal in kmc-package

### DIFF
--- a/developer/src/kmc-package/src/compiler/messages.ts
+++ b/developer/src/kmc-package/src/compiler/messages.ts
@@ -51,8 +51,8 @@ export class CompilerMessages {
     `The package contains both lexical models and keyboards, which is not permitted.`);
   static ERROR_PackageCannotContainBothModelsAndKeyboards = SevError | 0x000B;
 
-  static Warn_PackageShouldNotRepeatLanguages = (o:{resourceType: string, id: string, tag: string}) => m(this.WARN_PackageShouldNotRepeatLanguages,
-    `The ${o.resourceType} ${o.id} has a repeated language "${o.tag}".`);
+  static Warn_PackageShouldNotRepeatLanguages = (o:{resourceType: string, id: string, minimalTag: string, firstTag: string, secondTag: string}) => m(this.WARN_PackageShouldNotRepeatLanguages,
+    `Two language tags in ${o.resourceType} ${o.id}, '${o.firstTag}' and '${o.secondTag}', reduce to the same minimal tag '${o.minimalTag}'.`);
   static WARN_PackageShouldNotRepeatLanguages = SevWarn | 0x000C;
 
   static Warn_PackageNameDoesNotFollowLexicalModelConventions = (o:{filename: string}) => m(this.WARN_PackageNameDoesNotFollowLexicalModelConventions,
@@ -86,5 +86,13 @@ export class CompilerMessages {
   static Warn_KeyboardVersionsDoNotMatchPackageVersion = (o: {keyboard:string, keyboardVersion: string, packageVersion: string}) => m(this.WARN_KeyboardVersionsDoNotMatchPackageVersion,
     `Keyboard ${o.keyboard} version ${o.keyboardVersion} does not match package version ${o.packageVersion}.`);
   static WARN_KeyboardVersionsDoNotMatchPackageVersion = SevWarn | 0x0013;
-  }
+
+  static Error_LanguageTagIsNotValid = (o: {resourceType: string, id:string, lang:string, e:any}) => m(this.ERROR_LanguageTagIsNotValid,
+    `Language tag '${o.lang}' in ${o.resourceType} ${o.id} is invalid.`);
+  static ERROR_LanguageTagIsNotValid = SevError | 0x0014;
+
+  static Warn_LanguageTagIsNotMinimal = (o: {resourceType: string, id:string, actual:string, expected:string}) => m(this.WARN_LanguageTagIsNotMinimal,
+    `Language tag '${o.actual}' in ${o.resourceType} ${o.id} is not minimal, and should be '${o.expected}'.`);
+  static WARN_LanguageTagIsNotMinimal = SevWarn | 0x0015;
+}
 

--- a/developer/src/kmc-package/test/fixtures/invalid/error_language_tag_is_not_valid.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/error_language_tag_is_not_valid.kps
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Info>
+    <Name URL="">SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
+    <Copyright URL="">© 2019 National Research Council Canada</Copyright>
+    <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
+    <Version>1.3</Version>
+  </Info>
+  <Files>
+    <File>
+      <Name>khmer_angkor.kmx</Name>
+      <Description>Keyboard Khmer Angkor</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+  </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>Khmer Angkor</Name>
+      <ID>khmer_angkor</ID>
+      <Version>1.3</Version>
+      <Languages>
+        <!-- ERROR_LanguageTagIsNotValid -->
+        <Language ID="en-au-latn">English (Australian script) as spoken in Latin</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
+</Package>

--- a/developer/src/kmc-package/test/fixtures/invalid/warn_language_tag_is_not_minimal.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/warn_language_tag_is_not_minimal.kps
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Info>
+    <Name URL="">SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
+    <Copyright URL="">© 2019 National Research Council Canada</Copyright>
+    <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
+    <Version>1.3</Version>
+  </Info>
+  <Files>
+    <File>
+      <Name>khmer_angkor.kmx</Name>
+      <Description>Keyboard Khmer Angkor</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+  </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>Khmer Angkor</Name>
+      <ID>khmer_angkor</ID>
+      <Version>1.3</Version>
+      <Languages>
+        <!-- WARN_LanguageTagIsNotMinimal -->
+        <Language ID="km-Khmr-KH">Central Khmer (Khmer, Cambodia)</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
+</Package>

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -281,8 +281,19 @@ describe('KmpCompiler', function () {
 
   // WARN_KeyboardVersionsDoNotMatchPackageVersion
 
-  it('should generate ERROR_KeyboardFileNotFound if <Keyboard> version does not match package version', async function() {
+  it('should generate WARN_KeyboardVersionsDoNotMatchPackageVersion if <Keyboard> version does not match package version', async function() {
     testForMessage(this, ['invalid', 'warn_keyboard_versions_do_not_match_package_version.kps'], CompilerMessages.WARN_KeyboardVersionsDoNotMatchPackageVersion);
   });
 
+  // ERROR_LanguageTagIsNotValid
+
+  it('should generate ERROR_LanguageTagIsNotValid if keyboard has an invalid language tag', async function() {
+    testForMessage(this, ['invalid', 'error_language_tag_is_not_valid.kps'], CompilerMessages.ERROR_LanguageTagIsNotValid);
+  });
+
+  // WARN_LanguageTagIsNotMinimal
+
+  it('should generate WARN_LanguageTagIsNotMinimal if keyboard has a non-minimal language tag', async function() {
+    testForMessage(this, ['invalid', 'warn_language_tag_is_not_minimal.kps'], CompilerMessages.WARN_LanguageTagIsNotMinimal);
+  });
 });


### PR DESCRIPTION
Fixes #8774.
Fixes #8775.
Fixes #8776.
Fixes #8777.

Adds checks for bcp47 tag metadata for keyboards and lexical models -- both validity and minimality. Adds `ERROR_LanguageTagIsNotValid` and `WARN_LanguageTagIsNotMinimal` messages and corresponding unit tests.

This was implemented by extending the existing duplicate id check, so renamed that function accordingly.

@keymanapp-test-bot skip