### PR TITLE
chore(linux): Fix installation build step on TC

### DIFF
--- a/linux/keyman-config/Makefile
+++ b/linux/keyman-config/Makefile
@@ -6,7 +6,14 @@ default: clean version man langtags
 langtags:
 	cd buildtools && python3 ./build-langtags.py
 
-install: # run as sudo
+install:
+	if [ -n "${SUDO_USER}" ]; then \
+		make install-sudo; \
+	else \
+		make install-temp; \
+	fi
+
+install-sudo:  # run as sudo
 	pip3 install qrcode sentry-sdk
 	# eventually change this to: pip3 install .
 	python3 setup.py install


### PR DESCRIPTION
When building on TC we install into a temporary directory. This broke with the recent introduction of build.sh because that now calls `make install` whereas previously we explicitly called `make install-temp` on TC. Instead of adding a `install-temp` action to `build.sh` we now check in the Makefile if sudo is set.

@keymanapp-test-bot skip