### PR TITLE
chore(developer): verify file types of content files in package

### DIFF
--- a/developer/src/kmc-package/src/compiler/messages.ts
+++ b/developer/src/kmc-package/src/compiler/messages.ts
@@ -98,5 +98,13 @@ export class CompilerMessages {
   static Error_MustHaveAtLeastOneLanguage = (o:{resourceType:string, id:string}) => m(this.ERROR_MustHaveAtLeastOneLanguage,
     `The ${o.resourceType} ${o.id} must have at least one language specified.`);
   static ERROR_MustHaveAtLeastOneLanguage = SevError | 0x0016;
+
+  static Warn_RedistFileShouldNotBeInPackage = (o:{filename:string}) => m(this.WARN_RedistFileShouldNotBeInPackage,
+    `The Keyman system file '${o.filename}' should not be compiled into the package.`);
+  static WARN_RedistFileShouldNotBeInPackage = SevWarn | 0x0017;
+
+  static Warn_DocFileDangerous = (o:{filename:string}) => m(this.WARN_DocFileDangerous,
+    `Microsoft Word .doc or .docx files ('${o.filename}') are not portable. You should instead use HTML or PDF format.`);
+  static WARN_DocFileDangerous = SevWarn | 0x0018;
 }
 

--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -1,5 +1,6 @@
 import { KmpJsonFile, CompilerCallbacks } from '@keymanapp/common-types';
 import { CompilerMessages } from './messages.js';
+import { keymanEngineForWindowsFiles, keymanForWindowsInstallerFiles, keymanForWindowsRedistFiles } from './redist-files.js';
 
 // const SLexicalModelExtension = '.model.js';
 
@@ -142,6 +143,23 @@ export class PackageValidation {
       this.callbacks.reportMessage(CompilerMessages.Warn_FileInPackageDoesNotFollowFilenameConventions({filename}));
     }
 
+    if(!this.checkIfContentFileIsDangerous(file)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private checkIfContentFileIsDangerous(file: KmpJsonFile.KmpJsonFileContentFile): boolean {
+    let filename = this.callbacks.path.basename(file.name).toLowerCase();
+    if(keymanForWindowsInstallerFiles.includes(filename) ||
+        keymanForWindowsRedistFiles.includes(filename) ||
+        keymanEngineForWindowsFiles.includes(filename)) {
+      this.callbacks.reportMessage(CompilerMessages.Warn_RedistFileShouldNotBeInPackage({filename}));
+    }
+    if(filename.match(/\.doc(x?)$/)) {
+      this.callbacks.reportMessage(CompilerMessages.Warn_DocFileDangerous({filename}));
+    }
     return true;
   }
 

--- a/developer/src/kmc-package/src/compiler/redist-files.ts
+++ b/developer/src/kmc-package/src/compiler/redist-files.ts
@@ -1,0 +1,64 @@
+
+/**
+ * This is a set of known redistributable files for Keyman for Windows that
+ * should not be included in packages. It is not critical that this list matches
+ * the current deployment; it is just for warning against accidental inclusion
+ * of these files by package authors. Some redistributable files have been
+ * intentionally excluded because they could legitimately be a different file
+ * with the same name.
+ *
+ * This matches behaviour from the legacy package compiler; we may want to
+ * reconsider how this is done in the future.
+ *
+ * These lists have been constructed from 17.0.109 alpha build. Filenames
+ * intentionally in lower case.
+ */
+
+export const
+  keymanForWindowsInstallerFiles: string[] = [
+    'keymandesktop.msi',
+    'keymanengine.msm'
+  ];
+
+
+export const
+  keymanEngineForWindowsFiles: string[] = [
+    'base.xslt',
+    'crashpad_handler.exe',
+    'keyman-debug-etw.man',
+    'keyman.exe',
+    'keyman32.dll',
+    'keyman64.dll',
+    'keymanmc.dll',
+    'keymanx64.exe',
+    'kmcomapi.dll',
+    'kmcomapi.x64.dll',
+    'kmrefresh.x64.exe',
+    'kmrefresh.x86.exe',
+    'kmtip.dll',
+    'kmtip64.dll',
+    'mcompile.exe',
+    'sentry.dll',
+    'sentry.x64.dll',
+    'si_browsers.xslt',
+    'si_fonts.xslt',
+    'si_hookdlls.xslt',
+    'si_keyman.xslt',
+    'si_language.xslt',
+    'si_office.xslt',
+    'si_overview.xslt',
+    'si_processes.xslt',
+    'si_processes_x64.xslt',
+    'si_startup.xslt',
+    'tsysinfo.exe',
+  ];
+
+export const
+  keymanForWindowsRedistFiles: string[] = [
+    'desktop_resources.dll',
+    'keymandesktop.chm',
+    'kmbrowserhost.exe',
+    'kmconfig.exe',
+    'kmshell.exe',
+    'unicodedata.mdb',
+  ];

--- a/developer/src/kmc-package/test/fixtures/invalid/warn_doc_file_dangerous.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/warn_doc_file_dangerous.kps
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Info>
+    <Name URL="">SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
+    <Copyright URL="">© 2019 National Research Council Canada</Copyright>
+    <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
+    <Version>1.3</Version>
+  </Info>
+  <Files>
+    <File>
+      <Name>khmer_angkor.kmx</Name>
+      <Description>Keyboard Khmer Angkor</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+    <!-- warn_doc_file_dangerous -->
+    <File>
+      <Name>khmer_angkor.docx</Name>
+      <Description>Documentation</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.docx</FileType>
+    </File>
+  </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>Khmer Angkor</Name>
+      <ID>khmer_angkor</ID>
+      <Version>1.3</Version>
+      <Languages>
+        <Language ID="KM">Khmer</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
+</Package>

--- a/developer/src/kmc-package/test/fixtures/invalid/warn_redist_file_should_not_be_in_package.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/warn_redist_file_should_not_be_in_package.kps
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Info>
+    <Name URL="">SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
+    <Copyright URL="">© 2019 National Research Council Canada</Copyright>
+    <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
+    <Version>1.3</Version>
+  </Info>
+  <Files>
+    <File>
+      <Name>khmer_angkor.kmx</Name>
+      <Description>Keyboard Khmer Angkor</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+    <!-- warn_redist_file_should_not_be_in_package -->
+    <File>
+      <Name>keyman.exe</Name>
+      <Description>Keyman Program</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.exe</FileType>
+    </File>
+  </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>Khmer Angkor</Name>
+      <ID>khmer_angkor</ID>
+      <Version>1.3</Version>
+      <Languages>
+        <Language ID="KM">Khmer</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
+</Package>

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -303,4 +303,18 @@ describe('KmpCompiler', function () {
     testForMessage(this, ['invalid', 'keyman.en.error_must_have_at_least_one_language.model.kps'],
       CompilerMessages.ERROR_MustHaveAtLeastOneLanguage);
   });
+
+  // WARN_RedistFileShouldNotBeInPackage
+
+  it('should generate WARN_RedistFileShouldNotBeInPackage if package contains a redist file', async function() {
+    testForMessage(this, ['invalid', 'warn_redist_file_should_not_be_in_package.kps'],
+      CompilerMessages.WARN_RedistFileShouldNotBeInPackage);
+  });
+
+  // WARN_DocFileDangerous
+
+  it('should generate WARN_DocFileDangerous if package contains a .doc file', async function() {
+    testForMessage(this, ['invalid', 'warn_doc_file_dangerous.kps'],
+      CompilerMessages.WARN_DocFileDangerous);
+  });
 });


### PR DESCRIPTION
Fixes #8789.
Fixes #8790.

This is a transfer of the functionality in the legacy package compiler; we could go much further in verifying file types and excluding certain files, but that's a big design session. For now, just refreshed to include the set of Keyman for Windows and Keyman Engine for Windows files which are most likely to be accidentally included.

Adds WARN_RedistFileShouldNotBeInPackage and WARN_DocFileDangerous and corresponding unit tests and constant declarations.

@keymanapp-test-bot skip