### PR TITLE
chore(developer): verify that package has at least a model or keyboard

### DIFF
--- a/developer/src/kmc-package/src/compiler/messages.ts
+++ b/developer/src/kmc-package/src/compiler/messages.ts
@@ -109,6 +109,6 @@ export class CompilerMessages {
 
   static Error_PackageMustContainAModelOrAKeyboard = () => m(this.ERROR_PackageMustContainAModelOrAKeyboard,
     `Package must contain a lexical model or a keyboard.`);
-  static ERROR_PackageMustContainAPackageOrAKeyboard = SevError | 0x0019;
+  static ERROR_PackageMustContainAModelOrAKeyboard = SevError | 0x0019;
 }
 

--- a/developer/src/kmc-package/src/compiler/messages.ts
+++ b/developer/src/kmc-package/src/compiler/messages.ts
@@ -106,5 +106,9 @@ export class CompilerMessages {
   static Warn_DocFileDangerous = (o:{filename:string}) => m(this.WARN_DocFileDangerous,
     `Microsoft Word .doc or .docx files ('${o.filename}') are not portable. You should instead use HTML or PDF format.`);
   static WARN_DocFileDangerous = SevWarn | 0x0018;
+
+  static Error_PackageMustContainAPackageOrAKeyboard = () => m(this.ERROR_PackageMustContainAPackageOrAKeyboard,
+    `Package must contain a lexical model or a keyboard.`);
+  static ERROR_PackageMustContainAPackageOrAKeyboard = SevError | 0x0019;
 }
 

--- a/developer/src/kmc-package/src/compiler/messages.ts
+++ b/developer/src/kmc-package/src/compiler/messages.ts
@@ -107,7 +107,7 @@ export class CompilerMessages {
     `Microsoft Word .doc or .docx files ('${o.filename}') are not portable. You should instead use HTML or PDF format.`);
   static WARN_DocFileDangerous = SevWarn | 0x0018;
 
-  static Error_PackageMustContainAPackageOrAKeyboard = () => m(this.ERROR_PackageMustContainAPackageOrAKeyboard,
+  static Error_PackageMustContainAModelOrAKeyboard = () => m(this.ERROR_PackageMustContainAModelOrAKeyboard,
     `Package must contain a lexical model or a keyboard.`);
   static ERROR_PackageMustContainAPackageOrAKeyboard = SevError | 0x0019;
 }

--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -86,7 +86,7 @@ export class PackageValidation {
       // Note: we require at least 1 keyboard or model in the package. This may
       // change in the future if we start to use packages to distribute, e.g.
       // localizations or themes.
-      this.callbacks.reportMessage(CompilerMessages.Error_PackageMustContainAPackageOrAKeyboard());
+      this.callbacks.reportMessage(CompilerMessages.Error_PackageMustContainAModelOrAKeyboard());
       return false;
     }
 

--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -82,6 +82,16 @@ export class PackageValidation {
       return false;
     }
 
+    if(!kmpJson.lexicalModels?.length && !kmpJson.keyboards?.length) {
+      // Note: we require at least 1 keyboard or model in the package. This may
+      // change in the future if we start to use packages to distribute, e.g.
+      // localizations or themes.
+      this.callbacks.reportMessage(CompilerMessages.Error_PackageMustContainAPackageOrAKeyboard());
+      return false;
+    }
+
+
+
     return true;
   }
 

--- a/developer/src/kmc-package/src/compiler/package-version-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-version-validation.ts
@@ -55,7 +55,7 @@ export class PackageVersionValidation {
         this.callbacks.reportMessage(CompilerMessages.Warn_KeyboardVersionsDoNotMatchPackageVersion({
           keyboard: kmp.keyboards[0].id,
           keyboardVersion: kmp.keyboards[0].version,
-          packageVersion: kmp.info.version.description
+          packageVersion: kmp.info.version?.description
         }));
       }
     }

--- a/developer/src/kmc-package/test/fixtures/binary_kvk_file/source/binary_kvk_file.kps
+++ b/developer/src/kmc-package/test/fixtures/binary_kvk_file/source/binary_kvk_file.kps
@@ -17,6 +17,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Binary KVK File</Name>
+    <Version>1.3</Version>
   </Info>
   <Files>
     <File>
@@ -25,5 +26,21 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
+    <File>
+      <Name>../../invalid/khmer_angkor.kmx</Name>
+      <Description>Keyboard Khmer Angkor</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
   </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>Khmer Angkor</Name>
+      <ID>khmer_angkor</ID>
+      <Version>1.3</Version>
+      <Languages>
+        <Language ID="KM">Khmer</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
 </Package>

--- a/developer/src/kmc-package/test/fixtures/invalid/error_package_must_contain_a_model_or_a_keyboard.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/error_package_must_contain_a_model_or_a_keyboard.kps
@@ -5,12 +5,12 @@
     <FileVersion>7.0</FileVersion>
   </System>
   <Info>
-    <Name URL="">error_package_must_contain_a_package_or_a_keyboard</Name>
+    <Name URL="">error_package_must_contain_a_model_or_a_keyboard</Name>
     <Version>1.3</Version>
   </Info>
   <Files>
     <File>
-      <!-- error_package_must_contain_a_package_or_a_keyboard. This is a common error:
+      <!-- error_package_must_contain_a_model_or_a_keyboard. This is a common error:
            to include a .kmn instead of a .kmx -->
       <Name>khmer_angkor.kmn</Name>
       <Description>Keyboard Khmer Angkor</Description>

--- a/developer/src/kmc-package/test/fixtures/invalid/error_package_must_contain_a_package_or_a_keyboard.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/error_package_must_contain_a_package_or_a_keyboard.kps
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Info>
+    <Name URL="">error_package_must_contain_a_package_or_a_keyboard</Name>
+    <Version>1.3</Version>
+  </Info>
+  <Files>
+    <File>
+      <!-- error_package_must_contain_a_package_or_a_keyboard. This is a common error:
+           to include a .kmn instead of a .kmx -->
+      <Name>khmer_angkor.kmn</Name>
+      <Description>Keyboard Khmer Angkor</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmn</FileType>
+    </File>
+  </Files>
+</Package>

--- a/developer/src/kmc-package/test/fixtures/xml_kvk_file/source/xml_kvk_file.kps
+++ b/developer/src/kmc-package/test/fixtures/xml_kvk_file/source/xml_kvk_file.kps
@@ -17,6 +17,7 @@
   </StartMenu>
   <Info>
     <Name URL="">XML KVK File</Name>
+    <Version>1.3</Version>
   </Info>
   <Files>
     <File>
@@ -25,5 +26,21 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.kvk</FileType>
     </File>
+    <File>
+      <Name>../../invalid/khmer_angkor.kmx</Name>
+      <Description>Keyboard Khmer Angkor</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
   </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>Khmer Angkor</Name>
+      <ID>khmer_angkor</ID>
+      <Version>1.3</Version>
+      <Languages>
+        <Language ID="KM">Khmer</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
 </Package>

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -317,4 +317,11 @@ describe('KmpCompiler', function () {
     testForMessage(this, ['invalid', 'warn_doc_file_dangerous.kps'],
       CompilerMessages.WARN_DocFileDangerous);
   });
+
+  // ERROR_PackageMustContainAPackageOrAKeyboard
+
+  it('should generate ERROR_PackageMustContainAPackageOrAKeyboard if package contains a .doc file', async function() {
+    testForMessage(this, ['invalid', 'error_package_must_contain_a_package_or_a_keyboard.kps'],
+      CompilerMessages.ERROR_PackageMustContainAPackageOrAKeyboard);
+  });
 });

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -320,8 +320,8 @@ describe('KmpCompiler', function () {
 
   // ERROR_PackageMustContainAPackageOrAKeyboard
 
-  it('should generate ERROR_PackageMustContainAPackageOrAKeyboard if package contains a .doc file', async function() {
-    testForMessage(this, ['invalid', 'error_package_must_contain_a_package_or_a_keyboard.kps'],
-      CompilerMessages.ERROR_PackageMustContainAPackageOrAKeyboard);
+  it('should generate ERROR_PackageMustContainAModelOrAKeyboard if package contains a .doc file', async function() {
+    testForMessage(this, ['invalid', 'error_package_must_contain_a_model_or_a_keyboard.kps'],
+      CompilerMessages.ERROR_PackageMustContainAModelOrAKeyboard);
   });
 });


### PR DESCRIPTION
Fixes #8791.

Adds `ERROR_PackageMustContainAPackageOrAKeyboard` and corresponding unit tests. A couple of unit tests tweaked as their fixtures were no longer valid!

@keymanapp-test-bot skip