### PR TITLE
refactor(developer): move file write out of WriteCompiledKeyboard and CompileKeyboard merge

### DIFF
--- a/developer/src/kmc-kmn/build.sh
+++ b/developer/src/kmc-kmn/build.sh
@@ -51,11 +51,15 @@ fi
 
 #-------------------------------------------------------------------------------------------------------------------
 
-if builder_start_action build; then
+function copy_deps() {
   mkdir -p build/src/import/kmcmplib
   mkdir -p src/import/kmcmplib
   cp ../kmcmplib/build/wasm/$BUILDER_CONFIGURATION/src/wasm-host.js ./src/import/kmcmplib/wasm-host.js
   cp ../kmcmplib/build/wasm/$BUILDER_CONFIGURATION/src/wasm-host.wasm ./build/src/import/kmcmplib/wasm-host.wasm
+}
+
+if builder_start_action build; then
+  copy_deps
   tsc --build
   builder_finish_action success build
 fi
@@ -63,6 +67,7 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action test; then
+  copy_deps
   tsc --build test/
   npm run lint
   c8 --reporter=lcov --reporter=text mocha "${builder_extra_params[@]}"

--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -2888,7 +2888,7 @@ KMX_BOOL kmcmp::CheckStoreUsage(PFILE_KEYBOARD fk, int storeIndex, KMX_BOOL fIsS
   return TRUE;
 }
 
-KMX_DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, FILE* fp_out)
+KMX_DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, KMX_BYTE**data, size_t& dataSize)
 {
   PFILE_GROUP fgp;
   PFILE_STORE fsp;
@@ -2902,6 +2902,9 @@ KMX_DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, FILE* fp_out)
   size_t offset;
   size_t size;
   KMX_DWORD i, j;
+
+  *data = nullptr;
+  dataSize = 0;
 
   // Calculate how much memory to allocate
 
@@ -3056,15 +3059,8 @@ KMX_DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, FILE* fp_out)
 
   SetChecksum(buf, &ck->dwCheckSum, (KMX_DWORD)size);
 
-  KMX_DWORD dwBytesWritten = 0;
-  dwBytesWritten = (KMX_DWORD)fwrite(buf,1, (KMX_DWORD)size ,  fp_out);
-
-  if (dwBytesWritten != size) {
-    delete[] buf;
-    return CERR_UnableToWriteFully;
-  }
-
-  delete[] buf;
+  *data = buf;
+  dataSize = size;
 
   return CERR_None;
 }

--- a/developer/src/kmcmplib/src/CompilerInterfaces.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfaces.cpp
@@ -144,9 +144,16 @@ EXTERN bool kmcmp_CompileKeyboardFile(char* pszInfile,
   bool result = CompileKeyboardHandle(fp_in, &fk);
   if(result) {
     KMX_DWORD msg;
-    if ((msg = WriteCompiledKeyboard(&fk, fp_out)) != CERR_None) {
+    KMX_BYTE* data = nullptr;
+    size_t dataSize = 0;
+    if ((msg = WriteCompiledKeyboard(&fk, &data, dataSize)) != CERR_None) {
       result = FALSE;
       AddCompileError(msg);
+    } else {
+      if(fwrite(data, 1, dataSize, fp_out) != dataSize) {
+        AddCompileError(CERR_UnableToWriteFully);
+      }
+      delete[] data;
     }
   } else {
     AddCompileError(CERR_InvalidValue);

--- a/developer/src/kmcmplib/src/CompilerInterfaces.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfaces.cpp
@@ -165,33 +165,27 @@ EXTERN bool kmcmp_CompileKeyboardFile(char* pszInfile,
   }
 
   FILE_KEYBOARD fk;
-  bool result = CompileKeyboard(pszInfile, &fk, ASaveDebug, ACompilerWarningsAsErrors, AWarnDeprecatedCode,
-    pMsgproc, AmsgprocContext, CKF_KEYMAN);
-  if(!result) {
-    return false;
+  if(!CompileKeyboard(pszInfile, &fk, ASaveDebug, ACompilerWarningsAsErrors, AWarnDeprecatedCode,
+      pMsgproc, AmsgprocContext, CKF_KEYMAN)) {
+    // any errors will have been reported directly by CompileKeyboard
+    return FALSE;
   }
 
   FILE* fp_out = Open_File(pszOutfile, "wb");
-
   if (fp_out == NULL) {
     SetError(CERR_CannotCreateOutfile);
   }
 
-  if(result) {
-    KMX_DWORD msg;
-    KMX_BYTE* data = nullptr;
-    size_t dataSize = 0;
-    if ((msg = WriteCompiledKeyboard(&fk, &data, dataSize)) != CERR_None) {
-      result = FALSE;
-      AddCompileError(msg);
-    } else {
-      if(fwrite(data, 1, dataSize, fp_out) != dataSize) {
-        AddCompileError(CERR_UnableToWriteFully);
-      }
-      delete[] data;
-    }
+  KMX_DWORD msg;
+  KMX_BYTE* data = nullptr;
+  size_t dataSize = 0;
+  if ((msg = WriteCompiledKeyboard(&fk, &data, dataSize)) != CERR_None) {
+    AddCompileError(msg);
   } else {
-    AddCompileError(CERR_InvalidValue);
+    if(fwrite(data, 1, dataSize, fp_out) != dataSize) {
+      AddCompileError(CERR_UnableToWriteFully);
+    }
+    delete[] data;
   }
 
   fclose(fp_out);
@@ -201,7 +195,7 @@ EXTERN bool kmcmp_CompileKeyboardFile(char* pszInfile,
     return FALSE;
   }
 
-  return result;
+  return TRUE;
 }
 
 bool CompileKeyboardHandle(FILE* fp_in, PFILE_KEYBOARD fk)

--- a/developer/src/kmcmplib/src/kmcmplib.h
+++ b/developer/src/kmcmplib/src/kmcmplib.h
@@ -41,7 +41,7 @@ KMX_BOOL AddCompileError(KMX_DWORD msg);
 PKMX_WCHAR strtowstr(PKMX_STR in);
 PFILE_STORE FindSystemStore(PFILE_KEYBOARD fk, KMX_DWORD dwSystemID);
 FILE* UTF16TempFromUTF8(FILE* fp_in , KMX_BOOL hasPreamble);
-KMX_DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, FILE* fp_out);
+KMX_DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, KMX_BYTE**data, size_t& dataSize);
 KMX_DWORD AddStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, KMX_WCHAR const * str, KMX_DWORD *dwStoreID= NULL);
 KMX_DWORD ReadLine(FILE* fp_in , PKMX_WCHAR wstr, KMX_BOOL PreProcess);
 KMX_DWORD ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str);


### PR DESCRIPTION
Relates to #8493.

Stage one of the kmcmplib filesystem refactoring, as we move to writing to buffers and allowing caller to write to disk. Moves responsibility for writing data out of WriteCompiledKeyboard and into kmcmp_CompileKeyboardFile. This means that there are now no file writes in Compiler.cpp, except for the temp UTF16fromUTF8 (which I will also change to a in-memory buffer "real soon now").

Note that responsibility for writing in kmcmp_CompileKeyboardFile is very much temporary as we'll move it out of the library altogether in a subsequent commit.

@keymanapp-test-bot skip