### PR TITLE
chore(web): reconnection of KMW's context-focus event hooks 🧩

### DIFF
--- a/web/src/app/browser/src/context/focusAssistant.ts
+++ b/web/src/app/browser/src/context/focusAssistant.ts
@@ -92,6 +92,16 @@ export class FocusAssistant {
    */
   _IgnoreBlurFocus: boolean = false;
 
+  /**
+   * Is used as a time-delayed async `restoringFocus` or `maintainingFocus` - could be modeled decently as a Promise.
+   * Probably more the latter, as it's a touch-OSK interaction like the other `maintainingFocus` cases.
+   */
+  focusing: boolean;
+  /**
+   * Manages the time-delay aspect of `focusing` state.
+   */
+  focusTimer: number;
+
   constructor() {
   }
 
@@ -114,5 +124,13 @@ export class FocusAssistant {
    */
   setMaintainingFocus(state: boolean) {
     this.maintainingFocus = state ? true : false;
+  }
+
+  setFocusTimer(): void {
+    this.focusing=true;
+
+    this.focusTimer = window.setTimeout(function() {
+      this.focusing=false;
+    }.bind(this), 50)
   }
 }

--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -17,42 +17,6 @@ interface KeyboardCookie {
 }
 
 /**
- * Given a DOM event related to an KMW-attached element, this function determines
- * the corresponding OutputTarget.
- * @param e
- * @returns
- */
-function eventOutputTarget(e: Event) {
-  // Step 1:  given the event target...
-  let Ltarg: HTMLElement = e?.target as HTMLElement;
-  if (Ltarg == null) {
-    return null;
-  }
-  // ... determine the element expected to hold the KMW attachment object based on
-  // its typing, properties, etc.
-
-  // if(Ltarg['body']) {
-  //   Ltarg = Ltarg['body']; // Occurs in Firefox for design-mode iframes.
-  // }
-
-  if (Ltarg.nodeType == 3) { // defeat Safari bug
-    Ltarg = Ltarg.parentNode as HTMLElement;
-  }
-
-  // Verify that the element does correspond to a remappable input field
-  if(nestedInstanceOf(Ltarg, "HTMLInputElement")) {
-    const et=(Ltarg as HTMLInputElement).type.toLowerCase();
-    if(!(et == 'text' || et == 'search')) {
-      return null;
-    }
-  }
-
-  // Step 2:  With the most likely host element determined, obtain the corresponding OutputTarget
-  // instance.
-  return Ltarg._kmwAttachment.interface;
-}
-
-/**
  * Set target element text direction (LTR or RTL), but only if the element is empty
  *
  * If the element base directionality is changed after it contains content, unless all the text
@@ -450,8 +414,6 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
       activeControl: previousTarget?.getElement()
     });
 
-    // this.doControlFocused(LfocusTarg, this.keyman.domManager.lastActiveElement);
-
     return true;
   }
 
@@ -478,8 +440,8 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
     }
 
     // Step 1: determine the corresponding OutputTarget instance.
-    let Ltarg = eventOutputTarget(e);
-    if (Ltarg == null) {
+    let target = eventOutputTarget(e);
+    if (target == null) {
       return true;
     }
 
@@ -493,8 +455,9 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
 
     // Step 3: Now that we've handled all prior-element maintenance, update the active and 'last-active element'.
     // (The "context target" state fields)
+    const previousTarget = this.activeTarget;
     this.currentTarget = null; // I3363 (Build 301)
-    this.mostRecentTarget = Ltarg;
+    this.mostRecentTarget = target;
 
     // Step 4: any and all related events
     /* If the KeymanWeb UI is active as a user changes controls, all UI-based effects
@@ -506,12 +469,20 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
     let activeKeyboard = this.activeKeyboard;
     const maintainingFocus = this.focusAssistant.maintainingFocus;
     if(!maintainingFocus && activeKeyboard) {
-      activeKeyboard.keyboard.notify(0, Ltarg, 0);  // I2187
+      activeKeyboard.keyboard.notify(0, target, 0);  // I2187
+    }
+    if(previousTarget && !this.activeTarget) {
+      this.emit('targetchange', null);
     }
 
-    // TODO:  these related events.
-    // this.doControlBlurred(Ltarg, e, maintainingFocus);
-    // this.doChangeEvent(Ltarg);
+    this.apiEvents.callEvent('controlblurred', {
+      target: target.getElement(),
+      event: e,
+      isActivating: maintainingFocus
+    });
+
+    // Is not an "API event"; it models a native browser event instead.
+    this.doChangeEvent(target);
     this.resetContext();
     return true;
   }

--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -81,8 +81,6 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
 
     this.engineConfig.deferForInitialization.then(() => {
       const device = this.engineConfig.hostDevice;
-      const eventTracker = this.domEventTracker;
-
       const noPropagation = (event: Event) => event.stopPropagation()
 
       // For any elements being attached, or being enabled after having been disabled...
@@ -137,12 +135,6 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
           this.domEventTracker.detachDOMEvent(elem,'focus', this._ControlFocus);
           this.domEventTracker.detachDOMEvent(elem,'blur', this._ControlBlur);
           this.domEventTracker.detachDOMEvent(elem,'click', this._Click);
-
-          // This block:  has to do with maintaining focus (and consequences)
-          var lastElem = this.mostRecentTarget.getElement();
-          if(lastElem == elem) {
-            this.forgetActiveTarget(); // should already auto-hide the OSK while at it via event.
-          }
         } else {
           // For design-mode iframes:
 
@@ -157,6 +149,12 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
             this.domEventTracker.detachDOMEvent(Lelem.body,'focus', this._ControlFocus);
             this.domEventTracker.detachDOMEvent(Lelem.body,'blur', this._ControlBlur);
           }
+        }
+
+        // This block:  has to do with maintaining focus (and consequences)
+        var lastElem = this.mostRecentTarget.getElement();
+        if(lastElem == elem) {
+          this.forgetActiveTarget(); // should already auto-hide the OSK while at it via event.
         }
       });
 

--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -121,7 +121,8 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
 
       // For any elements being detached, disabled, or deliberately not being attached (b/c nonKMWTouchHandler)...
       this.page.on('disabled', (elem) => {
-        if(!(elem._kmwAttachment.interface instanceof DesignIFrame)) {
+        // Note:  we may not actually be attached at this point.
+        if(!(nestedInstanceOf(elem, "HTMLIFrameElement"))) {
           // For anything attached but (design-mode) iframes...
 
           // This block:  has to do with maintaining focus.
@@ -152,8 +153,8 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
         }
 
         // This block:  has to do with maintaining focus (and consequences)
-        var lastElem = this.mostRecentTarget.getElement();
-        if(lastElem == elem) {
+        var lastElem = this.mostRecentTarget?.getElement();
+        if(lastElem && lastElem == elem) {
           this.forgetActiveTarget(); // should already auto-hide the OSK while at it via event.
         }
       });

--- a/web/src/engine/attachment/src/pageContextAttachment.ts
+++ b/web/src/engine/attachment/src/pageContextAttachment.ts
@@ -28,22 +28,6 @@ interface EventMap {
   /***
    * For anything attached but (design-mode) iframes...
     ```
-    // This block:  has to do with maintaining focus.
-    if(touchable) {
-      // Remove any handlers for "NonKMWTouch" elements, since we're enabling it here.
-      Pelem.removeEventListener('touchstart', this.nonKMWTouchHandler);
-
-      // Prevent base-page touch handlers from causing a defocus when interacting
-      // with attached input elements.
-      Pelem.addEventListener('touchmove', (event) => event.stopPropagation(), false);
-      Pelem.addEventListener('touchend', (event) => event.stopPropagation(), false);
-    }
-
-    // This block:  has to do with maintaining focus.
-    this.keyman.util.attachDOMEvent(Pelem,'focus', this.getHandlers(Pelem)._ControlFocus);
-    this.keyman.util.attachDOMEvent(Pelem,'blur', this.getHandlers(Pelem)._ControlBlur);
-    this.keyman.util.attachDOMEvent(Pelem,'click', this.getHandlers(Pelem)._Click);
-
     // This block:  has to do with keystroke processing.
     // These need to be on the actual input element, as otherwise the keyboard will disappear on touch.
     Pelem.onkeypress = this.getHandlers(Pelem)._KeyPress;
@@ -53,17 +37,6 @@ interface EventMap {
    *
    * For design-mode iframes:
     ```
-    // This block:  has to do with maintaining focus.
-    var Lelem=Pelem.contentWindow.document;  // where Pelem = obj, the provided element.
-    // I2404 - Attach to IFRAMEs child objects, only editable IFRAMEs here
-    if(this.device.browser == 'firefox') {
-      util.attachDOMEvent(Lelem,'focus', this.getHandlers(Pelem)._ControlFocus);
-      util.attachDOMEvent(Lelem,'blur', this.getHandlers(Pelem)._ControlBlur);
-    } else { // Chrome, Safari
-      util.attachDOMEvent(Lelem.body,'focus', this.getHandlers(Pelem)._ControlFocus);
-      util.attachDOMEvent(Lelem.body,'blur', this.getHandlers(Pelem)._ControlBlur);
-    }
-
     // This block:  has to do with keystroke processing.
     util.attachDOMEvent(Lelem.body,'keydown', this.getHandlers(Pelem)._KeyDown);
     util.attachDOMEvent(Lelem.body,'keypress', this.getHandlers(Pelem)._KeyPress);
@@ -75,52 +48,14 @@ interface EventMap {
   /***
    * For anything attached but (design-mode) iframes...
     ```
-    // This block:  has to do with maintaining focus.
-    if(touchable) {
-      this.keyman.util.attachDOMEvent(x, 'touchstart', this.nonKMWTouchHandler, false);
-
-      // does not detach the touch-handlers added in 'enabled'?
-    }
-
-    // This block:  has to do with maintaining focus.
-    this.keyman.util.detachDOMEvent(Pelem,'focus', this.getHandlers(Pelem)._ControlFocus);
-    this.keyman.util.detachDOMEvent(Pelem,'blur', this.getHandlers(Pelem)._ControlBlur);
-    this.keyman.util.detachDOMEvent(Pelem,'click', this.getHandlers(Pelem)._Click);
-
     // This block:  has to do with keystroke processing.
     Pelem.onkeypress = null;
     Pelem.onkeydown = null;
     Pelem.onkeyup = null;
     ```
-
-   * also (for anything but iframes)...
-
-    ```
-    // This block:  has to do with maintaining focus (and consequences)
-    var lastElem = this.lastActiveElement;
-    if(lastElem == Pelem) {
-      if(this.activeElement == lastElem) {
-        this.activeElement = null;
-      }
-      this.lastActiveElement = null;
-      this.keyman.osk.startHide(false);
-    }
-    ```
    *
    * For design-mode iframes:
     ```
-    // This block:  has to do with maintaining focus.
-    var Lelem=Pelem.contentWindow.document;
-    // Mozilla      // I2404 - Attach to  IFRAMEs child objects, only editable IFRAMEs here
-    if(util.device.browser == 'firefox') {
-      // Firefox won't handle these events on Lelem.body - only directly on Lelem (the doc) instead.
-      util.detachDOMEvent(Lelem,'focus', this.getHandlers(Pelem)._ControlFocus);
-      util.detachDOMEvent(Lelem,'blur', this.getHandlers(Pelem)._ControlBlur);
-    } else { // Chrome, Safari
-      util.detachDOMEvent(Lelem.body,'focus', this.getHandlers(Pelem)._ControlFocus);
-      util.detachDOMEvent(Lelem.body,'blur', this.getHandlers(Pelem)._ControlBlur);
-    }
-
     // This block:  has to do with keystroke processing.
     util.detachDOMEvent(Lelem.body,'keydown', this.getHandlers(Pelem)._KeyDown);
     util.detachDOMEvent(Lelem.body,'keypress', this.getHandlers(Pelem)._KeyPress);

--- a/web/src/engine/namespaced-main/dom/domEventHandlers.ts
+++ b/web/src/engine/namespaced-main/dom/domEventHandlers.ts
@@ -84,18 +84,6 @@ namespace com.keyman.dom {
       return PreProcessor.keyDown(e);
     }.bind(this);
 
-    _Click: (e: MouseEvent) => boolean = function(this: DOMEventHandlers, e: MouseEvent): boolean {
-      let target = e.target as HTMLElement;
-      if(target && target['base']) {
-        target = target['base'];
-      }
-
-      //console.log('processNewContextEvent called from click');
-      com.keyman.singleton.core.processNewContextEvent(dom.Utils.getOutputTarget(target));
-
-      return true;
-    }.bind(this);
-
     /**
      * Function     _KeyPress
      * Scope        Private

--- a/web/src/engine/namespaced-main/dom/domEventHandlers.ts
+++ b/web/src/engine/namespaced-main/dom/domEventHandlers.ts
@@ -10,29 +10,14 @@ namespace com.keyman.dom {
 
   export class CommonDOMStates {
     _DisableInput: boolean = false;         // Should input be disabled?
-    _IgnoreNextSelChange: number = 0;       // when a visual keyboard key is mouse-down, ignore the next sel change because this stuffs up our history
-    _IgnoreBlurFocus: boolean = false;      // Used to temporarily ignore focus changes
     _Selection = null;
     _SelectionControl: any = null;   // Type behavior is as with activeElement and the like.
-
-    _activeElement: HTMLElement;
-    _lastActiveElement: HTMLElement;
-
-    focusing: boolean;
-    focusTimer: number;
 
     changed: boolean;         // Tracks if the element has been edited since gaining focus.
     swallowKeypress: boolean; // Notes if a keypress should be swallowed; used when handing mnemonics.
 
     /* ----------------------- Static event-related methods ------------------------ */
 
-    setFocusTimer(): void {
-      this.focusing=true;
-
-      this.focusTimer = window.setTimeout(function() {
-        this.focusing=false;
-      }.bind(this), 50)
-    }
   }
 
   /**

--- a/web/src/engine/namespaced-main/dom/domManager.ts
+++ b/web/src/engine/namespaced-main/dom/domManager.ts
@@ -159,22 +159,6 @@ namespace com.keyman.dom {
       this._BeepObjects = [];
     }
 
-    /**** The block below is referenced by modular code seen in `attachmentEngine.ts`. */
-
-    /**
-     * Function     nonKMWTouchHandler
-     * Scope        Private
-     * Description  A handler for KMW-touch-disabled elements when operating on touch devices.
-     */
-    nonKMWTouchHandler = function(x) {
-      DOMEventHandlers.states.focusing=false;
-      clearTimeout(DOMEventHandlers.states.focusTimer);
-      this.keyman.osk.hideNow();
-    }.bind(this);
-
-
-    /**** The block above is referenced by modular code seen in `attachmentEngine.ts`. */
-
     /* ------------- Page and document-level management events ------------------ */
 
     _WindowLoad: (e: Event) => void = function(e: Event) {


### PR DESCRIPTION
Now that all the prerequisites are in order, it's now possible connect all the pieces from #8801, #8802, #8803, and #8804.  With this, the context-management components of Keyman Engine for Web should now be fully modularized.

In case the design behind those PRs wasn't fully clear before, hopefully this PR makes things clearer.

----

Unfortunately, with the current state of the `app/browser` target... it is not practical to establish unit tests to validate this _at this point_.  `ContextManager` is still fairly entangled with a couple of other Web components:

1. A reference to the active engine configuration object, including the engine-initialization Promise.
2. A reference to a "stub and keyboard" cache (and an associated keyboard loader, for async keyboard-activation ops)

Both are pretty possible to mock during unit tests, fortunately.  However, the former is part of the `app/browser` build target - as is `ContextManager` itself.  And there are still a few build errors to resolve before it can build.  Rather than spinning off _yet another_ new child project... we're not too far off from resolving the build errors, so we'll revisit this detail after a few PRs.  See #8818.

@keymanapp-test-bot skip