### PR TITLE
feat(common): supports specifically-untargeted actions in builder scripts

### DIFF
--- a/resources/build/test/test.sh
+++ b/resources/build/test/test.sh
@@ -18,7 +18,7 @@ cd "$THIS_SCRIPT_PATH"
 builder_describe - clean build
 builder_parse "build"
 if [[ "${_builder_chosen_action_targets[@]}" != "build:project" ]]; then
-  builder_die "  Test: builder_parse, shorthand form 'build' should give us 'build:project"
+  builder_die "  Test: builder_parse, shorthand form 'build' should give us 'build:project'"
 fi
 
 if builder_start_action build; then
@@ -44,7 +44,7 @@ builder_describe_parse_short_test() {
   fi
 }
 
-builder_describe_parse_short_test "clean build test" ":module :tools :app" "build:module build:tools build:app" "build"
+builder_describe_parse_short_test "clean build test" ":module :tools :app" "build:module build:tools build:app build:project" "build"
 builder_describe_parse_short_test "clean build test" ":module :tools :app" "build:app" "build:app"
 builder_describe_parse_short_test "clean build test" ":module :tools :app" "build:app clean:module" "build:app clean:module"
 builder_describe_parse_short_test "clean build test" ":module :tools :app :project" "clean:module clean:tools clean:app clean:project build:app build:project" "clean build:app build:project"
@@ -112,6 +112,23 @@ builder_describe \
   "--power,-p   Use powerful mode" \
   "--zoom,-z    Use zoom mode" \
   "--feature=FOO Enable feature foo"
+
+#----------------------------------------------------------------------
+# Test implicit :project targets
+
+builder_parse_test "clean:app test:engine" "" clean:app test:engine
+
+if builder_has_action test:project; then
+  builder_die "FAIL: test:project should not have matched project-wide test action"
+fi
+
+builder_parse_test "clean:app test:app test:engine test:project" "" clean:app test
+
+if builder_has_action test:project; then
+  echo "PASS: test:project matched"
+else
+  builder_die: "FAIL: test:project missing for untargeted test action"
+fi
 
 #----------------------------------------------------------------------
 # Test --options

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1279,6 +1279,8 @@ _builder_parse_expanded_parameters() {
       for e in "${_builder_targets[@]}"; do
         _builder_chosen_action_targets+=("$action$e")
       done
+      # Also include an action-target pair indicating that the non-targeted action was specified.
+      _builder_chosen_action_targets+=("$action:project")
     elif (( has_target )); then
       # apply the default action to the selected target
 

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1279,8 +1279,11 @@ _builder_parse_expanded_parameters() {
       for e in "${_builder_targets[@]}"; do
         _builder_chosen_action_targets+=("$action$e")
       done
-      # Also include an action-target pair indicating that the non-targeted action was specified.
-      _builder_chosen_action_targets+=("$action:project")
+
+      if ! _builder_item_in_array ":project" "${_builder_targets[@]}"; then
+        # Also include an action-target pair indicating that the non-targeted action was specified.
+        _builder_chosen_action_targets+=("$action:project")
+      fi
     elif (( has_target )); then
       # apply the default action to the selected target
 


### PR DESCRIPTION
I've added one small tweak to `builder_parse`'s parsing procedures.  

With this small tweak in place, we gain the ability to specify build steps that are only performed when an action is requested but **_not_** given a specific target on the command-line.

How this works:  when `builder_parse` enumerates all possible `target` entries for an `action` specified without a target, it now adds one bonus entry:  `action:project`.  The standard check-to-run operations may then check against that as they would any other action-target pair.  In short:

```bash
# Existing behavior
if builder_has_action build; then
  # will trigger from `build`, `build:child`, or `build:target`
fi

# What this PR adds
if builder_has_action build:project; then
  # will only trigger from `build`; it will not trigger for `build:child` or `build:target`
fi
```

As `:project` has been noted to be the implicit target name if no targets are builder-defined, I felt it the natural fit to denote an _**explicitly project-wide, untargeted**_ action.  Accordingly, `:project` should probably now be considered a "reserved keyword" (or whatever term is most appropriate) for targets.  I didn't see an established pattern for this, though, so I haven't set it in place at this time... and a pre-existing test or two have :project targets, so I didn't want to overstep bounds.

For the two cases that motivated development of this proposed feature, see #8830.  The short version:

```bash
# Case 1
# A 100% full clean of any and all build outputs contained within a top-level project.
# Useful if specific components are typically only built via dependency; perhaps for specific tests.
# Particularly useful when numerous child projects exist.
builder_run_action clean:project rm -rf build

# Case 2
# If only a component-specific test is requested, integration test suites - 
# usually performed last in the testing sequence - make it harder to check 
# the test report of greatest interest - the one for the actually-requested target.
builder_run_action test:project do_integration_tests
```

@keymanapp-test-bot skip