### PR TITLE
fix(android/app): Pathing for publish script

### DIFF
--- a/android/build-publish.sh
+++ b/android/build-publish.sh
@@ -76,6 +76,7 @@ echo "BUILD_FLAGS $BUILD_FLAGS"
 if [ "$DO_KMAPRO" = true ]; then
   # Copy Release Notes
   generateReleaseNotes
+  cd "$KEYMAN_ROOT/android/KMAPro/"
   ./gradlew $DAEMON_FLAG $BUILD_FLAGS
 fi
 


### PR DESCRIPTION
Fixes #8844 and follow-on to #8749

During the review, we changed the build-play-store-notes.inc.sh script to pushd and popd to preserve the directory.
https://github.com/keymanapp/keyman/pull/8749#discussion_r1190635885

It turns out the popd takes the shell to `$KEYMAN_ROOT/android/` when it needs to be in `$KEYMAN_ROOT/android/KMAPro/` for the ./gradlew call.

The stable-16.0 script for comparison
https://github.com/keymanapp/keyman/blob/fc582339f90a8c9e0c116b4aaea8a9f11bd979c3/android/build-publish.sh#L75-L82
#8844 

@keymanapp-test-bot skip
