### PR TITLE
fix(common/models): predictive-text sourcemapping linkage

### DIFF
--- a/common/web/lm-worker/build-polyfill-concatenator.js
+++ b/common/web/lm-worker/build-polyfill-concatenator.js
@@ -134,7 +134,7 @@ console.log();
 let sourceRoot = "/@keymanapp/keyman";
 console.log(`Setting sourceRoot: ${sourceRoot}`)
 remappingState.sourceRoot = sourceRoot;
-fullWorkerConcatenation.sourcemapJSON = remappingState.sourcemap;
+fullWorkerConcatenation.sourcemapJSON = remappingState.sourceMap;
 
 // End "cleaning the sourcemaps"
 

--- a/common/web/lm-worker/build-polyfill-concatenator.js
+++ b/common/web/lm-worker/build-polyfill-concatenator.js
@@ -134,7 +134,7 @@ console.log();
 let sourceRoot = "/@keymanapp/keyman";
 console.log(`Setting sourceRoot: ${sourceRoot}`)
 remappingState.sourceRoot = sourceRoot;
-fullWorkerConcatenation.sourcemapJSON = remappingState.sourceMap;
+fullWorkerConcatenation.sourcemapJSON = remappingState.sourcemap;
 
 // End "cleaning the sourcemaps"
 

--- a/common/web/lm-worker/build-wrap-and-minify.js
+++ b/common/web/lm-worker/build-wrap-and-minify.js
@@ -37,9 +37,9 @@ if(MINIFY) {
     keepNames: true,
     outfile: `build/lib/worker-main.polyfilled.min.js`
   });
-
-  sourcemapJSON = convertSourcemap.fromJSON(fs.readFileSync(`build/lib/worker-main.polyfilled${MINIFY ? '.min' : ''}.js.map`)).toObject();
 }
+
+sourcemapJSON = convertSourcemap.fromJSON(fs.readFileSync(`build/lib/worker-main.polyfilled${MINIFY ? '.min' : ''}.js.map`)).toObject();
 
 const workerConcatenation = {
   script: fs.readFileSync(`build/lib/worker-main.polyfilled${MINIFY ? '.min' : ''}.js`),


### PR DESCRIPTION
The sourcemap data wasn't being passed along properly for 'debug' config builds, as it was only being stored for minify builds... which would throw it out.

@keymanapp-test-bot skip