### PR TITLE
chore(developer): replace cwrap wasm bindings

### DIFF
--- a/developer/src/kmcmplib/include/kmcmplibapi.h
+++ b/developer/src/kmcmplib/include/kmcmplibapi.h
@@ -62,7 +62,7 @@ EXTERN bool kmcmp_ValidateJsonFile(
 );
 
 /**
- * kmcmp_ParseUnicodeSet is successful if it returns >= USET_OK
+ * kmcmp_parseUnicodeSet is successful if it returns >= USET_OK
  */
 static const int KMCMP_USET_OK = 0;
 
@@ -84,23 +84,18 @@ static const int KMCMP_ERROR_UNSUPPORTED_PROPERTY = -3;
 static const int KMCMP_FATAL_OUT_OF_RANGE = -4;
 
 /**
- * Function pointer to kmcmp_ParseUnicodeSet
- */
-typedef int (*kmcmp_ParseUnicodeSetProc)(const char* szText, uint32_t* output, uint32_t outputLength);
-
-/**
  * Parse a UnicodeSet into 32-bit ranges.
  * For example, "[]" will return 0 (KMCMP_USET_OK) as a zero-length set.
  * "[" will return KMCMP_ERROR_SYNTAX_ERR,
  * and "[x A-C]" will return 2 and [0x41, 0x43, 0x78, 0x78]
- * @param szText input txt, null terminated, in UTF-8 format
+ * @param text input txt, null terminated, in UTF-8 format
  * @param outputBuffer output buffer, owned by caller: Pairs of ranges in order
  * @param outputBufferSize length of output buffer. Needs to be twice the number of expected ranges
  * @return If >= KMCMP_USET_OK, number of ranges, otherwise one of the negative error values.
  */
-EXTERN int kmcmp_ParseUnicodeSet(
-  const char* szText,
-  uint32_t* outputBuffer,
+EXTERN int kmcmp_parseUnicodeSet(
+  const std::string text,
+  uintptr_t outputBuffer_,
   uint32_t outputBufferSize
 );
 

--- a/developer/src/kmcmplib/src/CompilerInterfaces.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfaces.cpp
@@ -46,39 +46,6 @@ int wasm_CompilerMessageProc(int line, uint32_t dwMsgCode, char* szText, void* c
   return wasm_msgproc(line, dwMsgCode, szText, msgProc);
 }
 
-//DEPRECATED
-EXTERN bool kmcmp_Wasm_SetCompilerOptions(int ShouldAddCompilerVersion) {
-  KMCMP_COMPILER_OPTIONS options;
-  options.dwSize = sizeof(KMCMP_COMPILER_OPTIONS);
-  options.ShouldAddCompilerVersion = ShouldAddCompilerVersion;
-  return kmcmp_SetCompilerOptions(&options);
-}
-
-//DEPRECATED
-EXTERN bool kmcmp_Wasm_CompileKeyboardFile(char* pszInfile,
-  char* pszOutfile, int ASaveDebug, int ACompilerWarningsAsErrors,
-	int AWarnDeprecatedCode, char* msgProc
-) {
-  return kmcmp_CompileKeyboardFile(
-    pszInfile,
-    pszOutfile,
-    ASaveDebug,
-    ACompilerWarningsAsErrors,
-    AWarnDeprecatedCode,
-    wasm_CompilerMessageProc,
-    msgProc
-  );
-}
-
-EXTERN int kmcmp_Wasm_ParseUnicodeSet(char* pat,
-  uint32_t* buf, int length
-) {
-  return kmcmp_ParseUnicodeSet(
-    pat, buf, length
-  );
-}
-
-
 struct COMPILER_INTERFACE {
   bool saveDebug;
   bool compilerWarningsAsErrors;
@@ -162,6 +129,7 @@ EMSCRIPTEN_BINDINGS(compiler_interface) {
     ;
 
   emscripten::function("kmcmp_compile", &kmcmp_compile);
+  emscripten::function("kmcmp_parseUnicodeSet", &kmcmp_parseUnicodeSet);
 }
 
 #endif

--- a/developer/src/kmcmplib/src/meson.build
+++ b/developer/src/kmcmplib/src/meson.build
@@ -24,7 +24,7 @@ endif
 name_suffix = []
 
 if cpp_compiler.get_id() == 'emscripten'
-  links += ['-lnodefs.js', '-sMODULARIZE', '-sEXPORT_ES6', '--whole-archive', '--bind', '-sEXPORTED_RUNTIME_METHODS=[\'cwrap\', \'UTF8ToString\']']
+  links += ['-lnodefs.js', '-sMODULARIZE', '-sEXPORT_ES6', '--whole-archive', '--bind', '-sEXPORTED_RUNTIME_METHODS=[\'UTF8ToString\']']
   # tests are building as ES6 so we need to declare the file extension
   # note that meson currently struggles with the sanitycheckc_cross.exe
   # program, because it has a hard coded extension (.exe) which is not

--- a/developer/src/kmcmplib/src/uset-api.cpp
+++ b/developer/src/kmcmplib/src/uset-api.cpp
@@ -4,16 +4,13 @@
 #include "unicode/uniset.h"
 #include "unicode/unistr.h"
 
-EXTERN int kmcmp_ParseUnicodeSet(
-  const char* szText,
-  uint32_t* outputBuffer,
+EXTERN int kmcmp_parseUnicodeSet(
+  const std::string text,
+  uintptr_t outputBuffer_,
   uint32_t outputBufferSize
 ) {
-  if (szText == nullptr) {
-    // null string coming in
-    return KMCMP_ERROR_SYNTAX_ERR;
-  }
-  const icu::UnicodeString str = icu::UnicodeString::fromUTF8(szText);
+  uint32_t* outputBuffer = reinterpret_cast<uint32_t*>(outputBuffer_);
+  const icu::UnicodeString str = icu::UnicodeString::fromUTF8(text.c_str());
   if (str.isBogus() || str.isEmpty()) {
     // empty string
     return KMCMP_ERROR_SYNTAX_ERR;

--- a/developer/src/kmcmplib/tests/uset-api-test.cpp
+++ b/developer/src/kmcmplib/tests/uset-api-test.cpp
@@ -19,30 +19,32 @@
 #include "../src/compfile.h"
 #include <test_assert.h>
 
-void test_kmcmp_ParseUnicodeSetProc();
+void test_kmcmp_parseUnicodeSet();
 
 // std::vector<int> error_vec;
 
 int main(int argc, char *argv[]) {
-  test_kmcmp_ParseUnicodeSetProc();
+  test_kmcmp_parseUnicodeSet();
 
   return 0;
 }
 
 
-void test_kmcmp_ParseUnicodeSetProc() {
+void test_kmcmp_parseUnicodeSet() {
   {
     // null test
     const auto bufsiz = 128;
     uint32_t buf[bufsiz];
-    int rc = kmcmp_ParseUnicodeSet(u8"[]", buf, bufsiz);
+    uintptr_t buf_ = reinterpret_cast<uintptr_t>(buf);
+    int rc = kmcmp_parseUnicodeSet(u8"[]", buf_, bufsiz);
     assert(rc == KMCMP_USET_OK);
   }
   {
     // basic test
     const auto bufsiz = 128;
     uint32_t buf[bufsiz];
-    int rc = kmcmp_ParseUnicodeSet(u8"[x A-C]", buf, bufsiz);
+    uintptr_t buf_ = reinterpret_cast<uintptr_t>(buf);
+    int rc = kmcmp_parseUnicodeSet(u8"[x A-C]", buf_, bufsiz);
     assert(rc == 2);
     assert(buf[0] == 0x41);
     assert(buf[1] == 0x43);
@@ -53,7 +55,8 @@ void test_kmcmp_ParseUnicodeSetProc() {
     // bigger test
     const auto bufsiz = 128;
     uint32_t buf[bufsiz];
-    int rc = kmcmp_ParseUnicodeSet(u8"[[🙀A-C]-[CB]]", buf, bufsiz);
+    uintptr_t buf_ = reinterpret_cast<uintptr_t>(buf);
+    int rc = kmcmp_parseUnicodeSet(u8"[[🙀A-C]-[CB]]", buf_, bufsiz);
     assert(rc == 2);
     assert(buf[0] == 0x41);
     assert(buf[1] == 0x41);
@@ -64,35 +67,40 @@ void test_kmcmp_ParseUnicodeSetProc() {
     // overflow test
     const auto bufsiz = 1;
     uint32_t buf[bufsiz];
-    int rc = kmcmp_ParseUnicodeSet(u8"[x A-C]", buf, bufsiz);
+    uintptr_t buf_ = reinterpret_cast<uintptr_t>(buf);
+    int rc = kmcmp_parseUnicodeSet(u8"[x A-C]", buf_, bufsiz);
     assert(rc == KMCMP_FATAL_OUT_OF_RANGE);
   }
   {
     // err test
     const auto bufsiz = 128;
     uint32_t buf[bufsiz];
-    int rc = kmcmp_ParseUnicodeSet(u8"[:Adlm:]", buf, bufsiz);
+    uintptr_t buf_ = reinterpret_cast<uintptr_t>(buf);
+    int rc = kmcmp_parseUnicodeSet(u8"[:Adlm:]", buf_, bufsiz);
     assert(rc == KMCMP_ERROR_UNSUPPORTED_PROPERTY);
   }
   {
     // err test
     const auto bufsiz = 128;
     uint32_t buf[bufsiz];
-    int rc = kmcmp_ParseUnicodeSet(u8"[[\\p{Mn}]&[A-Z]]", buf, bufsiz);
+    uintptr_t buf_ = reinterpret_cast<uintptr_t>(buf);
+    int rc = kmcmp_parseUnicodeSet(u8"[[\\p{Mn}]&[A-Z]]", buf_, bufsiz);
     assert(rc == KMCMP_ERROR_UNSUPPORTED_PROPERTY);
   }
   {
     // err test
     const auto bufsiz = 128;
     uint32_t buf[bufsiz];
-    int rc = kmcmp_ParseUnicodeSet(u8"[abc{def}]", buf, bufsiz);
+    uintptr_t buf_ = reinterpret_cast<uintptr_t>(buf);
+    int rc = kmcmp_parseUnicodeSet(u8"[abc{def}]", buf_, bufsiz);
     assert(rc == KMCMP_ERROR_HAS_STRINGS);
   }
   {
     // err test
     const auto bufsiz = 128;
     uint32_t buf[bufsiz];
-    int rc = kmcmp_ParseUnicodeSet(u8"[[]", buf, bufsiz);
+    uintptr_t buf_ = reinterpret_cast<uintptr_t>(buf);
+    int rc = kmcmp_parseUnicodeSet(u8"[[]", buf_, bufsiz);
     assert(rc == KMCMP_ERROR_SYNTAX_ERR);
   }
 }


### PR DESCRIPTION
Relates to #8493.

This moves the remainder of the WASM interfaces in kmcmplib to using emscripten bind. It is a little bit of a step backwards at present for parseUnicodeSet, because I've changed the output buffer type to an int for the purposes of simplifying the binding just now. But that can be improved later, and at least we are consistent with the binding methods.

Next step is to move the filesystem access out of kmcmplib, which requires a significant refactoring of the kmcmpdll connection to the library. Ideally, it will move to using the kmcmp_compile endpoint, and remove the overlapping kmcmp_CompileKeyboard and kmcmp_CompileKeyboardToBuffer functions.

@keymanapp-test-bot skip