### PR TITLE
fix(web): input-processor unit test - constructor missing a parameter 🧩

### DIFF
--- a/common/web/input-processor/tests/cases/inputProcessor.js
+++ b/common/web/input-processor/tests/cases/inputProcessor.js
@@ -7,6 +7,8 @@ const require = createRequire(import.meta.url);
 import InputProcessor from '#./text/inputProcessor.js';
 import { KeyboardInterface, MinimalKeymanGlobal, Mock } from '@keymanapp/keyboard-processor';
 import { NodeKeyboardLoader } from '@keymanapp/keyboard-processor/node-keyboard-loader';
+
+import { Worker } from '@keymanapp/lexical-model-layer/node';
 import * as utils from '@keymanapp/web-utils';
 
 // Required initialization setup.
@@ -31,7 +33,9 @@ describe('InputProcessor', function() {
     });
 
     it('has expected default values after initialization', function () {
-      let core = new InputProcessor(device);
+      // Can construct without the second parameter; if so, the final assertion - .mayPredict
+      // will be invalidated.  (No worker, no ability to predict.)
+      let core = new InputProcessor(device, Worker.constructInstance());
 
       assert.isOk(core.keyboardProcessor);
       assert.isDefined(core.keyboardProcessor.contextDevice);


### PR DESCRIPTION
 I'm not sure exactly when and where the issue arose - probably from some of the rebases that happened before many of the PRs went up - but one input-processor unit test is falling over due to a missing parameter.  

The predictive-text worker is now provided during initialization, rather than initialized by the `InputProcessor` class.  It can also simply be `null`... but that has a side effect causing the final assertion of one unit test to fail.  (No worker, no ability to predict - but the assertion, as previously set, expects enabled predictions.)

@keymanapp-test-bot skip