### PR TITLE
chore(web): refines KMW build output organization 🧩

### DIFF
--- a/web/ci.sh
+++ b/web/ci.sh
@@ -118,9 +118,9 @@ if builder_start_action prepare:s.keyman.com; then
   echo "FOLDER: $BASE_PUBLISH_FOLDER"
   mkdir -p "$BASE_PUBLISH_FOLDER/resources"
 
-  cp -Rf build/app/browser/release/* "$BASE_PUBLISH_FOLDER"
-  cp -Rf build/app/resources/* "$BASE_PUBLISH_FOLDER/resources"
-  cp -Rf build/app/ui/release/* "$BASE_PUBLISH_FOLDER"
+  # s.keyman.com - release-config only.  It's notably smaller, thus far more favorable
+  # for dynamic linking.
+  cp -Rf build/publish/release/* "$BASE_PUBLISH_FOLDER"
 
   # Third phase: tweak the sourcemaps
   # We can use an alt-mode of Web's sourcemap-root tool for this.
@@ -164,20 +164,9 @@ if builder_start_action prepare:downloads.keyman.com; then
     fi
   fi
 
-  pushd build/app/browser/release
+  pushd build/publish
+  # Zip both the 'debug' and 'release' configurations together.
   "${COMPRESS_CMD}" $COMPRESS_ADD ../../../../$ZIP *
-  cd ..
-  "${COMPRESS_CMD}" $COMPRESS_ADD ../../../$ZIP debug
-  popd
-
-  pushd build/app/resources
-  "${COMPRESS_CMD}" $COMPRESS_ADD ../../../$ZIP *
-  popd
-
-  pushd build/app/ui/release
-  "${COMPRESS_CMD}" $COMPRESS_ADD ../../../../$ZIP *
-  cd ..
-  "${COMPRESS_CMD}" $COMPRESS_ADD ../../../$ZIP debug
   popd
 
   # --- Second action artifact - the 'static' folder (hosted user testing on downloads.keyman.com) ---

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -116,7 +116,7 @@ if builder_start_action prepare:s.keyman.com; then
   # The main build products are expected to reside at the root of this folder.
   BASE_PUBLISH_FOLDER="$S_KEYMAN_COM/kmw/engine/$VERSION"
   echo "FOLDER: $BASE_PUBLISH_FOLDER"
-  mkdir -p "$BASE_PUBLISH_FOLDER/resources"
+  mkdir -p "$BASE_PUBLISH_FOLDER"
 
   # s.keyman.com - release-config only.  It's notably smaller, thus far more favorable
   # for distribution via cloud service.

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -119,7 +119,7 @@ if builder_start_action prepare:s.keyman.com; then
   mkdir -p "$BASE_PUBLISH_FOLDER/resources"
 
   # s.keyman.com - release-config only.  It's notably smaller, thus far more favorable
-  # for dynamic linking.
+  # for distribution via cloud service.
   cp -Rf build/publish/release/* "$BASE_PUBLISH_FOLDER"
 
   # Third phase: tweak the sourcemaps

--- a/web/common.inc.sh
+++ b/web/common.inc.sh
@@ -23,13 +23,40 @@ compile ( ) {
 
   tsc -b "${KEYMAN_ROOT}/web/src/$COMPILE_TARGET" -v
 
-  # COMPILE_TARGET entries are all prefixed with `engine`, so remove that.
   if [ -f "./build-bundler.js" ]; then
     node "./build-bundler.js"
 
     # So... tsc does declaration-bundling on its own pretty well, at least for local development.
     tsc --emitDeclarationOnly --outFile "${KEYMAN_ROOT}/web/build/$COMPILE_TARGET/lib/index.d.ts" -p "${KEYMAN_ROOT}/web/src/$COMPILE_TARGET"
   fi
+}
+
+_copy_dir_if_exists ( ) {
+  local SRC=$1
+  local DST=$2
+
+  if [ -d "$SRC" ]; then
+    cp -rf "$SRC/." "$DST"
+  fi
+}
+
+# Copies top-level build artifacts into common 'debug' and 'release' config folders
+# for use in publishing.
+prepare ( ) {
+  local CHILD_BUILD_ROOT="$KEYMAN_ROOT/web/build/app"
+  local PUBLISH_BUILD_ROOT="$KEYMAN_ROOT/web/build/publish"
+
+  mkdir -p "$PUBLISH_BUILD_ROOT/debug"
+  mkdir -p "$PUBLISH_BUILD_ROOT/release"
+
+  _copy_dir_if_exists "$CHILD_BUILD_ROOT/browser/debug"    "$PUBLISH_BUILD_ROOT/debug"
+  _copy_dir_if_exists "$CHILD_BUILD_ROOT/browser/release"  "$PUBLISH_BUILD_ROOT/release"
+
+  _copy_dir_if_exists "$CHILD_BUILD_ROOT/resources"  "$PUBLISH_BUILD_ROOT/debug"
+  _copy_dir_if_exists "$CHILD_BUILD_ROOT/resources"  "$PUBLISH_BUILD_ROOT/release"
+
+  _copy_dir_if_exists "$CHILD_BUILD_ROOT/ui/debug"    "$PUBLISH_BUILD_ROOT/debug"
+  _copy_dir_if_exists "$CHILD_BUILD_ROOT/ui/release"  "$PUBLISH_BUILD_ROOT/release"
 }
 
 # Runs all headless tests corresponding to the specified target.

--- a/web/src/app/browser/build.sh
+++ b/web/src/app/browser/build.sh
@@ -45,6 +45,9 @@ compile_and_copy() {
 
   mkdir -p "$KEYMAN_ROOT/web/build/app/resources/osk"
   cp -R "$KEYMAN_ROOT/web/src/resources/osk/." "$KEYMAN_ROOT/web/build/app/resources/osk/"
+
+  # Update the build/publish copy of our build artifacts
+  prepare
 }
 
 builder_run_action configure verify_npm_setup

--- a/web/src/app/ui/build.sh
+++ b/web/src/app/ui/build.sh
@@ -44,6 +44,9 @@ compile_and_copy() {
 
   mkdir -p "$KEYMAN_ROOT/web/build/app/resources/ui"
   cp -R "$KEYMAN_ROOT/web/src/resources/ui/." "$KEYMAN_ROOT/web/build/app/resources/ui/"
+
+  # Update the build/publish copy of our build artifacts
+  prepare
 }
 
 builder_run_action configure verify_npm_setup

--- a/web/src/tools/building/sourcemap-root/build.sh
+++ b/web/src/tools/building/sourcemap-root/build.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 #
 # Compile KeymanWeb's dev & test tool modules
-#
-set -eu
 
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
@@ -25,7 +23,7 @@ builder_describe "Builds the sourcemap-sanitizing script used for Keyman Engine 
 
 builder_describe_outputs \
   configure                   /node_modules \
-  build                       /web/build/tools/sourcemap-root/index.js
+  build                       /web/build/tools/building/sourcemap-root/index.js
 
 builder_parse "$@"
 


### PR DESCRIPTION
Per recent discussion, this PR simply arranges a nice, tidy folder for use with publishing Web builds - `$KEYMAN_ROOT/web/build/publish`.  Underneath that are `debug` and `release` folders, corresponding to the two different build configurations.  

This pattern is a bit different from 16.0 releases, where 'release' was the base folder and 'debug' was a subfolder called 'unminified'.

Now:
- debug
    - compiled scripts, resource folders
- release
    - compiled scripts, resource folders

Then:
- compiled scripts, resource folders
- unminified
    - compiled scripts, resource folders

s.keyman.com tends to only use the 'release' config, while downloads provide both.

@keymanapp-test-bot skip