### PR TITLE
feat(web): release-configuration filesize profiling 🧩

### DIFF
--- a/common/web/lm-worker/build-bundler.js
+++ b/common/web/lm-worker/build-bundler.js
@@ -109,6 +109,9 @@ const embeddedWorkerBuildOptions = {
 // Direct-use version
 await esbuild.build(embeddedWorkerBuildOptions);
 
+// ------------------------
+
+// Now to generate a filesize profile for the minified version of the worker.
 // We want a specialized bundle build here instead; no output, but minified like
 // the actual release worker.
 const minifiedProfilingOptions = {

--- a/common/web/lm-worker/build-bundler.js
+++ b/common/web/lm-worker/build-bundler.js
@@ -7,6 +7,48 @@
 
 import esbuild from 'esbuild';
 import { spawn } from 'child_process';
+import fs from 'fs';
+
+/*
+ * Refer to https://github.com/microsoft/TypeScript/issues/13721#issuecomment-307259227 -
+ * the `@class` emit comment-annotation is designed to facilitate tree-shaking for ES5-targeted
+ * down-level emits.  `esbuild` doesn't look for it by default... but we can override that with
+ * this plugin.
+ */
+let es5ClassAnnotationAsPurePlugin = {
+  name: '@class -> __PURE__',
+  setup(build) {
+    build.onLoad({filter: /\.js$/ }, async (args) => {
+      let source = await fs.promises.readFile(args.path, 'utf8');
+      return {
+        // Marks any classes compiled by TS (as per the /** @class */ annotation)
+        // as __PURE__ in order to facilitate tree-shaking.
+        contents: source.replace('/** @class */', '/* @__PURE__ */ /** @class */'),
+        loader: 'js'
+      }
+    });
+  }
+}
+
+let EMIT_FILESIZE_PROFILE = false;
+
+if(process.argv.length > 2) {
+  for(let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+
+    switch(arg) {
+      case '':
+        break;
+      case '--ci':
+        EMIT_FILESIZE_PROFILE=true
+        break;
+      // May add other options if desired in the future.
+      default:
+        console.error("Invalid command-line option set for script; only --ci is permitted.");
+        process.exit(1);
+    }
+  }
+}
 
 await esbuild.build({
   bundle: true,
@@ -28,12 +70,13 @@ await esbuild.build({
   },
   outdir: 'build/lib',
   outExtension: { '.js': '.mjs' },
+  plugins: [ es5ClassAnnotationAsPurePlugin ],
   tsconfig: 'tsconfig.json',
-  target: "es5"
+  target: "es5",
 });
 
 // Bundled CommonJS (classic Node) module version
-esbuild.buildSync({
+await esbuild.build({
   bundle: true,
   sourcemap: true,
   format: "cjs",
@@ -44,12 +87,12 @@ esbuild.buildSync({
   },
   outdir: 'build/lib',
   outExtension: { '.js': '.cjs' },
+  plugins: [ es5ClassAnnotationAsPurePlugin ],
   tsconfig: 'tsconfig.json',
   target: "es5"
 });
 
-// Direct-use version
-esbuild.buildSync({
+const embeddedWorkerBuildOptions = {
   bundle: true,
   sourcemap: true,
   format: "iife",
@@ -58,6 +101,27 @@ esbuild.buildSync({
     'worker-main': 'build/obj/worker-main.js'
   },
   outdir: 'build/lib',
+  plugins: [ es5ClassAnnotationAsPurePlugin ],
   tsconfig: 'tsconfig.json',
   target: "es5"
-});
+}
+
+// Direct-use version
+await esbuild.build(embeddedWorkerBuildOptions);
+
+if(EMIT_FILESIZE_PROFILE) {
+  // We want a specialized bundle build here instead; no output, but minified like
+  // the actual worker.
+  const minifiedProfilingOptions = {
+    ...embeddedWorkerBuildOptions,
+    minify: true,
+    metafile: true,
+    write: false // don't actually write the file.
+  }
+
+  let result = await esbuild.build(minifiedProfilingOptions);
+
+  console.log("Minified, pre-polyfill worker filesize profile:");
+  // Profiles the sourcecode!
+  console.log(await esbuild.analyzeMetafile(result.metafile, { verbose: true }));
+}

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -28,6 +28,8 @@ WORKER_OUTPUT_FILENAME=build/lib/worker-main.js
 builder_describe \
   "Compiles the Language Modeling Layer for common use in predictive text and autocorrective applications." \
   "@/common/web/keyman-version" \
+  "@/common/models/wordbreakers" \
+  "@/common/models/templates" \
   "@/common/tools/sourcemap-path-remapper" \
   configure clean build test --ci
 

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -56,9 +56,13 @@ if builder_start_action build; then
   # Build worker with tsc first
   tsc -b $builder_verbose || builder_die "Could not build worker."
 
+  EXT_FLAGS=
+  if builder_has_option --ci; then
+    EXT_FLAGS=--ci
+  fi
 
   echo "Bundling worker modules"
-  node build-bundler.js
+  node build-bundler.js "$EXT_FLAGS"
 
   # Declaration bundling.
   npm run tsc -- --emitDeclarationOnly --outFile ./build/lib/index.d.ts

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -49,7 +49,9 @@ if builder_start_action build; then
   # - clean:      make extra-sure that no prior build products exist.
   #               - also useful when validating this script on a local dev machine!
   # - build:      then do the ACTUAL build.
-  ./build.sh configure clean build
+  # one option:
+  # - --ci:       For app/browser, outputs 'release' config filesize profiling logs
+  ./build.sh configure clean build --ci
 
   builder_finish_action success build
 fi

--- a/web/common.inc.sh
+++ b/web/common.inc.sh
@@ -20,11 +20,12 @@ compile ( ) {
   fi
 
   local COMPILE_TARGET="$1"
+  local BUNDLE_FLAG="${2:-}"
 
   tsc -b "${KEYMAN_ROOT}/web/src/$COMPILE_TARGET" -v
 
   if [ -f "./build-bundler.js" ]; then
-    node "./build-bundler.js"
+    node "./build-bundler.js" "$BUNDLE_FLAG"
 
     # So... tsc does declaration-bundling on its own pretty well, at least for local development.
     tsc --emitDeclarationOnly --outFile "${KEYMAN_ROOT}/web/build/$COMPILE_TARGET/lib/index.d.ts" -p "${KEYMAN_ROOT}/web/src/$COMPILE_TARGET"

--- a/web/src/app/browser/build-bundler.js
+++ b/web/src/app/browser/build-bundler.js
@@ -82,12 +82,17 @@ let result = await esbuild.build({
   treeShaking: true,
   tsconfig: './tsconfig.json',
   // Enables source-file output size profiling!
-  metafile: EMIT_FILESIZE_PROFILE
+  metafile: true
 });
 
+let filesizeProfile = await esbuild.analyzeMetafile(result.metafile, { verbose: true });
+fs.writeFileSync('../../../build/app/browser/filesize-profile.log', `
+// Minified Keyman Engine for Web ('app/browser' target), filesize profile
+${filesizeProfile}
+`);
 if(EMIT_FILESIZE_PROFILE) {
   // Profiles the sourcecode!
-  console.log(await esbuild.analyzeMetafile(result.metafile, { verbose: true }));
+  console.log(filesizeProfile);
 }
 
 await esbuild.build({

--- a/web/src/app/browser/build.sh
+++ b/web/src/app/browser/build.sh
@@ -52,6 +52,11 @@ compile_and_copy() {
 
   # Update the build/publish copy of our build artifacts
   prepare
+
+  local PROFILE_DEST="$KEYMAN_ROOT/web/build/profiling/"
+  mkdir -p "$PROFILE_DEST"
+  cp "$KEYMAN_ROOT/web/build/app/browser/filesize-profile.log"      "$PROFILE_DEST/web-engine-filesize.log"
+  cp "$KEYMAN_ROOT/common/web/lm-worker/build/filesize-profile.log" "$PROFILE_DEST/lm-worker-filesize.log"
 }
 
 builder_run_action configure verify_npm_setup

--- a/web/src/app/browser/build.sh
+++ b/web/src/app/browser/build.sh
@@ -41,7 +41,11 @@ builder_describe_outputs \
 #### Build action definitions ####
 
 compile_and_copy() {
-  compile $SUBPROJECT_NAME
+  local COMPILE_FLAGS=
+  if builder_has_option --ci; then
+    COMPILE_FLAGS=--ci
+  fi
+  compile $SUBPROJECT_NAME $COMPILE_FLAGS
 
   mkdir -p "$KEYMAN_ROOT/web/build/app/resources/osk"
   cp -R "$KEYMAN_ROOT/web/src/resources/osk/." "$KEYMAN_ROOT/web/build/app/resources/osk/"


### PR DESCRIPTION
When chasing down some other bug, I happened upon a very neat `esbuild` feature that can provide us with very useful information in regard to our "check/web/file-size" build check:  the ability to generate a "metafile" and use it to determine how much final, minified data each source file contributes to the final build product!

The main caveat:  this does not directly include the polyfills that we prepend to the compiled worker, as those are prepended outside of esbuild.  `esbuild` does not consider sourcemapping when making the profile, so we can't run the profiling operations meaningfully on the result of the concatenation.  That said, the difference between the reported lm-worker filesize from the worker build vs what the final Web engine build states can easily be inferred to represent the sum total contribution of the polyfills.

This PR adds and enables said feature, producing two filesize profiles for Web builds at `$KEYMAN_ROOT/web/build/profiling`.  (This is outside of the sibling folder `$KEYMAN_ROOT/web/build/publish` - the folder used for s.keyman.com and downloads.keyman.com publishing steps.)

Ideally, at some point we should be able to have that folder linked by the test-bot for easy inspection.  For now... it's at least easily available as a CI build artifact.

We can then use the generated information to further pursue solutions and mitigations in the spirit of #3796.

@keymanapp-test-bot skip