### PR TITLE
feat(linux): Add column for installation location

### DIFF
--- a/linux/keyman-config/build.sh
+++ b/linux/keyman-config/build.sh
@@ -34,14 +34,14 @@ build_man_pages() {
   TEMP_DATA_DIR=$(mktemp -d)
   SCHEMA_DIR=$TEMP_DATA_DIR/glib-2.0/schemas
   export XDG_DATA_DIRS=$TEMP_DATA_DIR:${XDG_DATA_DIRS-}
-  export GSETTINGS_SCHEMA_DIR=${SCHEMA_DIR}
+  export GSETTINGS_SCHEMA_DIR="${SCHEMA_DIR}"
   mkdir -p "$SCHEMA_DIR"
   cp ./com.keyman.gschema.xml "$SCHEMA_DIR"/
   glib-compile-schemas "$SCHEMA_DIR"
   ./build-help.sh --man --no-reconf
   export XDG_DATA_DIRS=${XDG_DATA_DIRS#*:}
   unset GSETTINGS_SCHEMA_DIR
-  rm -rf $TEMP_DATA_DIR
+  rm -rf "$TEMP_DATA_DIR"
 }
 
 build_action() {

--- a/linux/keyman-config/keyman_config/get_kmp.py
+++ b/linux/keyman-config/keyman_config/get_kmp.py
@@ -9,6 +9,7 @@ import requests
 import requests_cache
 from gi.repository import GObject
 
+from keyman_config import _
 from keyman_config import KeymanApiUrl, KeymanDownloadsUrl
 from keyman_config.deprecated_decorator import deprecated
 
@@ -18,6 +19,16 @@ class InstallLocation(GObject.GEnum):
     Shared = 2
     User = 3
     Unknown = 99
+
+
+def get_install_area_string(area):
+    if area == InstallLocation.OS:
+        return _('System')
+    elif area == InstallLocation.Shared:
+        return _('Shared')
+    elif area == InstallLocation.User:
+        return _('User')
+    return _('Unknown')
 
 
 def get_package_download_data(packageID, weekCache=False):

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -166,6 +166,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             str,    # version
             str,    # packageID
             int,    # enum InstallLocation (KmpArea is GObject version)
+            str,    # InstallLocation path
             str,    # path to welcome file if it exists or None
             str)    # path to options file if it exists or None
 
@@ -183,6 +184,9 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         self.tree.append_column(column)
         # i18n: column header in table displaying installed keyboards
         column = Gtk.TreeViewColumn(_("Version"), renderer, text=2)
+        self.tree.append_column(column)
+        # i18n: column header in table displaying installed keyboards
+        column = Gtk.TreeViewColumn(_("Location"), renderer, text=5)
         self.tree.append_column(column)
 
         select = self.tree.get_selection()
@@ -282,6 +286,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
                 kmpdata['version'],
                 kmpdata['packageID'],
                 install_area,
+                get_keyman_dir(install_area).replace(os.path.expanduser('~'), '~'),
                 welcome_file,
                 options_file])
 


### PR DESCRIPTION
Closes #8631.

## km-config with new Location column

![image](https://github.com/keymanapp/keyman/assets/181336/da7818ed-8a50-4b4f-ba84-8b5af00c1808)

## Previous version

![image](https://user-images.githubusercontent.com/181336/211070080-cbc1d9b4-538c-4511-930f-a868ad2a752e.png)

# User Testing

## Preparations

- The tests can be run on any Linux version

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot
- Install EuroLatin (SIL) keyboard for German into the user area: 
  ```
  km-package-install --package sil_euro_latin --bcp47 de
  ```
- Install EuroLatin (SIL) keyboard for French into the shared area: 
  ```
  sudo km-package-install --shared --package sil_euro_latin --bcp47 fr
  ```
- Verify that both German and French show up in the keyboard dropdown in the top bar. Otherwise reboot.

## Tests

**TEST_LOCATION_COLUMN**: New column exists and shows expected values

- open Keyman Configuration
- verify that EuroLatin (SIL) shows up twice. In the Location column one of these rows should have the value `~/.local/share/keyman`, the other `/usr/local/share/keyman`
