### PR TITLE
change(web): common downcompile helpers 🧩

### DIFF
--- a/common/predictive-text/build-bundler.js
+++ b/common/predictive-text/build-bundler.js
@@ -9,6 +9,9 @@ import esbuild from 'esbuild';
 import { spawn } from 'child_process';
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",

--- a/common/predictive-text/build.sh
+++ b/common/predictive-text/build.sh
@@ -26,6 +26,7 @@ cd "$(dirname "$THIS_SCRIPT")"
 
 builder_describe "Builds the lm-layer module" \
   "@/common/web/keyman-version" \
+  "@/common/web/tslib" \
   "@/common/web/lm-worker" \
   "clean" \
   "configure" \

--- a/common/predictive-text/src/node/tsconfig.json
+++ b/common/predictive-text/src/node/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "module": "es6",
     "moduleResolution": "Node16",
+    "importHelpers": true,
     "inlineSources": true,
     "sourceMap": true,
     "sourceRoot": "keyman",

--- a/common/predictive-text/src/tsconfig.json
+++ b/common/predictive-text/src/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "module": "es6",
     "moduleResolution": "Node16",
+    "importHelpers": true,
     "inlineSources": true,
     "sourceMap": true,
     "sourceRoot": "keyman",

--- a/common/predictive-text/src/web/tsconfig.json
+++ b/common/predictive-text/src/web/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "module": "es6",
     "moduleResolution": "Node16",
+    "importHelpers": true,
     "inlineSources": true,
     "sourceMap": true,
     "sourceRoot": "keyman",

--- a/common/predictive-text/tsconfig.all.json
+++ b/common/predictive-text/tsconfig.all.json
@@ -10,6 +10,7 @@
     "declaration": true,
     "module": "es6",
     "moduleResolution": "Node16",
+    "importHelpers": true,
     "inlineSources": true,
     "sourceMap": true,
     "sourceRoot": "keyman",

--- a/common/web/input-processor/build-bundler.js
+++ b/common/web/input-processor/build-bundler.js
@@ -11,6 +11,9 @@ import { spawn } from 'child_process';
 // Bundled ES module version
 esbuild.buildSync({
   entryPoints: ['build/obj/index.js'],
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   external: ['fs', 'vm'],
@@ -29,6 +32,9 @@ esbuild.buildSync({
 // Bundled CommonJS (classic Node) module version
 esbuild.buildSync({
   entryPoints: ['build/obj/index.js'],
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   external: ['fs', 'vm'],

--- a/common/web/input-processor/tsconfig.json
+++ b/common/web/input-processor/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "es6",
     "moduleResolution": "Node16",
     "declaration": true,
+    "importHelpers": true,
     "inlineSources": true,
     "sourceMap": true,
     "sourceRoot": "keyman/",

--- a/common/web/keyboard-processor/build-bundler.js
+++ b/common/web/keyboard-processor/build-bundler.js
@@ -10,6 +10,9 @@ import { spawn } from 'child_process';
 
 /** @type {esbuild.BuildOptions} */
 const commonConfig = {
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",
@@ -23,6 +26,9 @@ const commonConfig = {
 
 // Bundled ES module version
 esbuild.buildSync({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   entryPoints: ['build/obj/index.js'],
   outfile: "build/lib/index.mjs",
   format: "esm",
@@ -31,6 +37,9 @@ esbuild.buildSync({
 
 // Bundled CommonJS (classic Node) module version
 esbuild.buildSync({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   entryPoints: ['build/obj/index.js'],
   outfile: 'build/lib/index.cjs',
   bundle: true,
@@ -42,6 +51,9 @@ esbuild.buildSync({
 
 
 esbuild.buildSync({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   entryPoints: ['build/obj/keyboards/loaders/dom-keyboard-loader.js'],
   outfile: 'build/lib/dom-keyboard-loader.mjs',
   format: "esm",
@@ -50,6 +62,9 @@ esbuild.buildSync({
 
 // The node-based keyboard loader needs an extra parameter due to Node-built-in imports:
 esbuild.buildSync({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   entryPoints: ['build/obj/keyboards/loaders/node-keyboard-loader.js'],
   outfile: 'build/lib/node-keyboard-loader.mjs',
   format: "esm",

--- a/common/web/keyboard-processor/build.sh
+++ b/common/web/keyboard-processor/build.sh
@@ -21,6 +21,7 @@ builder_describe \
   "Compiles the web-oriented utility function module." \
   "@/common/web/recorder  test" \
   "@/common/web/keyman-version" \
+  "@/common/web/tslib" \
   "@/common/web/utils" \
   configure \
   clean \

--- a/common/web/keyboard-processor/src/keyboards/loaders/tsconfig.dom.json
+++ b/common/web/keyboard-processor/src/keyboards/loaders/tsconfig.dom.json
@@ -6,6 +6,7 @@
     "module": "es6",
     "moduleResolution": "Node16",
     "declaration": true,
+    "importHelpers": true,
     "inlineSources": true,
     "sourceMap": true,
     "sourceRoot": "keyman/",

--- a/common/web/keyboard-processor/tsconfig.common.json
+++ b/common/web/keyboard-processor/tsconfig.common.json
@@ -6,6 +6,7 @@
     "module": "es6",
     "moduleResolution": "Node16",
     "declaration": true,
+    "importHelpers": true,
     "inlineSources": true,
     "sourceMap": true,
     "sourceRoot": "keyman/",

--- a/common/web/keyboard-processor/tsconfig.json
+++ b/common/web/keyboard-processor/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "es6",
     "moduleResolution": "Node16",
     "declaration": true,
+    "importHelpers": true,
     "inlineSources": true,
     "sourceMap": true,
     "sourceRoot": "keyman/",

--- a/common/web/tslib/README.md
+++ b/common/web/tslib/README.md
@@ -1,0 +1,15 @@
+The default import setup for the `tslib` package is unfortunately incompatible with `esbuild` when in ES5 mode.  But...
+with a little elbow grease, we can fix that with _this_ package by importing its ES5-compatible file and exporting it
+as _this_ package's default export for use in anything looking to `"importHelpers"`.
+
+To utilize this with `esbuild` while enabling the `"importHelpers"` compilation option in your tsconfig.json, you'll want
+to set the following in your `esbuild` config:
+
+```javascript
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
+```
+
+Note that esbuild 0.15.16 is the minimum required version to utilize the 'alias' feature necessary to replace `tslib` for
+`tsc`-generated `import { /* */ } from 'tslib'` statements that result from enabling `"importHelpers"` in a tsconfig.

--- a/common/web/tslib/build.sh
+++ b/common/web/tslib/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Compiles common TS-based utility functions for use among Keyman's codebase
+
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
+cd "$THIS_SCRIPT_PATH"
+
+################################ Main script ################################
+
+builder_describe \
+  "A ES5 + esbuild compatibility wrapper for the 'tslib' package." \
+  clean configure build
+
+builder_describe_outputs \
+  configure "/node_modules" \
+  build     "/common/web/tslib/build/index.js"
+
+builder_parse "$@"
+
+builder_run_action configure verify_npm_setup
+builder_run_action clean rm -rf build/
+builder_run_action build tsc --build "$THIS_SCRIPT_PATH/tsconfig.json"

--- a/common/web/tslib/build.sh
+++ b/common/web/tslib/build.sh
@@ -24,4 +24,4 @@ builder_parse "$@"
 
 builder_run_action configure verify_npm_setup
 builder_run_action clean rm -rf build/
-builder_run_action build tsc --build "$THIS_SCRIPT_PATH/tsconfig.json"
+builder_run_action build tsc --build

--- a/common/web/tslib/build.sh
+++ b/common/web/tslib/build.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-#
-# Compiles common TS-based utility functions for use among Keyman's codebase
-
-set -eu
 
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary

--- a/common/web/tslib/package.json
+++ b/common/web/tslib/package.json
@@ -3,13 +3,16 @@
   "description": "An ES5 + esbuild-compatible wrapper for the 'tslib' library",
   "main": "./build/index.js",
   "scripts": {
-    "build": "gosh ./build.sh",
-    "clean": "tsc -b --clean",
-    "tsc": "tsc"
+    "build": "gosh ./build.sh build",
+    "clean": "gosh ./build.sh clean"
   },
   "dependencies": {
     "tslib": "^2.5.2",
     "typescript": "^4.9.5"
+  },
+  "devDependencies": {
+    "@keymanapp/resources-gosh": "*",
+    "esbuild": "^0.15.16"
   },
   "type": "module"
 }

--- a/common/web/tslib/package.json
+++ b/common/web/tslib/package.json
@@ -7,16 +7,6 @@
     "clean": "tsc -b --clean",
     "tsc": "tsc"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
-  },
-  "author": "SIL International",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/keymanapp/keyman/issues"
-  },
-  "homepage": "https://github.com/keymanapp/keyman#readme",
   "dependencies": {
     "tslib": "^2.5.2",
     "typescript": "^4.9.5"

--- a/common/web/tslib/package.json
+++ b/common/web/tslib/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@keymanapp/tslib",
+  "description": "An ES5 + esbuild-compatible wrapper for the 'tslib' library",
+  "main": "./build/index.js",
+  "scripts": {
+    "build": "gosh ./build.sh",
+    "clean": "tsc -b --clean",
+    "tsc": "tsc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/keymanapp/keyman.git"
+  },
+  "author": "SIL International",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/keymanapp/keyman/issues"
+  },
+  "homepage": "https://github.com/keymanapp/keyman#readme",
+  "dependencies": {
+    "tslib": "^2.5.2",
+    "typescript": "^4.9.5"
+  },
+  "type": "module"
+}

--- a/common/web/tslib/src/index.ts
+++ b/common/web/tslib/src/index.ts
@@ -1,0 +1,3 @@
+export * from '../../../../node_modules/tslib/tslib.js';
+
+export * as tslib from '../../../../node_modules/tslib/tslib.js';

--- a/common/web/tslib/tsconfig.json
+++ b/common/web/tslib/tsconfig.json
@@ -3,26 +3,19 @@
   "compilerOptions": {
     "allowJs": true,
     "module": "es6",
-    "moduleResolution": "Node16",
-    "importHelpers": true,
+    "moduleResolution": "Node",
     "inlineSources": true,
     "sourceMap": true,
     "declaration": true,
     "target": "es5",
-    "tsBuildInfoFile": "./build/obj/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "./build/tsconfig.tsbuildinfo",
     "types": ["node"],
     "lib": ["es6"],
-    "baseUrl": "./",
-    "outDir": "./build/obj/",
+    "baseUrl": "./src",
+    "outDir": "./build/",
     "rootDir": "./src"
   },
-  "references": [
-    { "path": "../keyman-version"}
-  ],
   "include": [
-    "src/*.ts"
-  ],
-  "exclude": [
-    "src/test/**/*.js"
+    "./src/index.ts"
   ]
 }

--- a/common/web/utils/build-bundler.js
+++ b/common/web/utils/build-bundler.js
@@ -8,6 +8,9 @@ import { spawn } from 'child_process';
 // Bundles to a compact ESModule
 esbuild.buildSync({
   entryPoints: ['build/obj/index.js'],
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   //minify: true,    // No need to minify a module.
@@ -24,6 +27,9 @@ esbuild.buildSync({
 // Bundles to a compact CommonJS (classic Node) module
 esbuild.buildSync({
   entryPoints: ['build/obj/index.js'],
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   //minify: true,    // No need to minify a module.

--- a/common/web/utils/build.sh
+++ b/common/web/utils/build.sh
@@ -19,6 +19,7 @@ cd "$THIS_SCRIPT_PATH"
 builder_describe \
   "Compiles the web-oriented utility function module." \
   "@/common/web/keyman-version" \
+  "@/common/web/tslib" \
   clean configure build test \
   "--ci    For use with action ${BUILDER_TERM_START}test${BUILDER_TERM_END} - emits CI-friendly test reports"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,15 +35,16 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "chai": "^4.3.4",
+        "esbuild": "^0.15.16",
         "eslint": "^8.39.0",
         "eslint-config-standard-with-typescript": "^34.0.1",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-promise": "^6.1.1",
-        "esbuild": "^0.15.15",
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
         "ts-node": "^10.9.1",
+        "tslib": "^2.5.2",
         "typescript": "^4.9.5"
       }
     },
@@ -345,6 +346,14 @@
         "@sentry/browser": "^5.27.4"
       },
       "devDependencies": {
+        "typescript": "^4.9.5"
+      }
+    },
+    "common/web/tslib": {
+      "name": "@keymanapp/tslib",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.5.2",
         "typescript": "^4.9.5"
       }
     },
@@ -2176,6 +2185,38 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+      "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+      "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2247,38 +2288,6 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.15.tgz",
-      "integrity": "sha512-JJjZjJi2eBL01QJuWjfCdZxcIgot+VoK6Fq7eKF9w4YHm9hwl7nhBR1o2Wnt/WcANk5l9SkpvrldW1PLuXxcbw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.15.tgz",
-      "integrity": "sha512-lhz6UNPMDXUhtXSulw8XlFAtSYO26WmHQnCi2Lg2p+/TMiJKNLtZCYUxV4wG6rZMzXmr8InGpNwk+DLT2Hm0PA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@gar/promisify": {
@@ -2448,6 +2457,10 @@
     },
     "node_modules/@keymanapp/sourcemap-path-remapper": {
       "resolved": "common/tools/sourcemap-path-remapper",
+      "link": true
+    },
+    "node_modules/@keymanapp/tslib": {
+      "resolved": "common/web/tslib",
       "link": true
     },
     "node_modules/@keymanapp/web-sentry-manager": {
@@ -2697,6 +2710,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/@sentry/cli": {
       "version": "2.2.0",
       "dev": true,
@@ -2731,6 +2749,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/@sentry/hub": {
       "version": "5.30.0",
       "license": "BSD-3-Clause",
@@ -2743,6 +2766,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/hub/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/@sentry/minimal": {
       "version": "5.30.0",
       "license": "BSD-3-Clause",
@@ -2754,6 +2782,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@sentry/minimal/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
       "version": "6.19.6",
@@ -2828,6 +2861,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/node/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/@sentry/types": {
       "version": "5.30.0",
       "license": "BSD-3-Clause",
@@ -2845,6 +2883,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -4840,9 +4883,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.15.tgz",
-      "integrity": "sha512-TEw/lwK4Zzld9x3FedV6jy8onOUHqcEX3ADFk4k+gzPUwrxn8nWV62tH0udo8jOtjFodlEfc4ypsqX3e+WWO6w==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+      "integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -4852,34 +4895,34 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.15.15",
-        "@esbuild/linux-loong64": "0.15.15",
-        "esbuild-android-64": "0.15.15",
-        "esbuild-android-arm64": "0.15.15",
-        "esbuild-darwin-64": "0.15.15",
-        "esbuild-darwin-arm64": "0.15.15",
-        "esbuild-freebsd-64": "0.15.15",
-        "esbuild-freebsd-arm64": "0.15.15",
-        "esbuild-linux-32": "0.15.15",
-        "esbuild-linux-64": "0.15.15",
-        "esbuild-linux-arm": "0.15.15",
-        "esbuild-linux-arm64": "0.15.15",
-        "esbuild-linux-mips64le": "0.15.15",
-        "esbuild-linux-ppc64le": "0.15.15",
-        "esbuild-linux-riscv64": "0.15.15",
-        "esbuild-linux-s390x": "0.15.15",
-        "esbuild-netbsd-64": "0.15.15",
-        "esbuild-openbsd-64": "0.15.15",
-        "esbuild-sunos-64": "0.15.15",
-        "esbuild-windows-32": "0.15.15",
-        "esbuild-windows-64": "0.15.15",
-        "esbuild-windows-arm64": "0.15.15"
+        "@esbuild/android-arm": "0.15.18",
+        "@esbuild/linux-loong64": "0.15.18",
+        "esbuild-android-64": "0.15.18",
+        "esbuild-android-arm64": "0.15.18",
+        "esbuild-darwin-64": "0.15.18",
+        "esbuild-darwin-arm64": "0.15.18",
+        "esbuild-freebsd-64": "0.15.18",
+        "esbuild-freebsd-arm64": "0.15.18",
+        "esbuild-linux-32": "0.15.18",
+        "esbuild-linux-64": "0.15.18",
+        "esbuild-linux-arm": "0.15.18",
+        "esbuild-linux-arm64": "0.15.18",
+        "esbuild-linux-mips64le": "0.15.18",
+        "esbuild-linux-ppc64le": "0.15.18",
+        "esbuild-linux-riscv64": "0.15.18",
+        "esbuild-linux-s390x": "0.15.18",
+        "esbuild-netbsd-64": "0.15.18",
+        "esbuild-openbsd-64": "0.15.18",
+        "esbuild-sunos-64": "0.15.18",
+        "esbuild-windows-32": "0.15.18",
+        "esbuild-windows-64": "0.15.18",
+        "esbuild-windows-arm64": "0.15.18"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.15.tgz",
-      "integrity": "sha512-F+WjjQxO+JQOva3tJWNdVjouFMLK6R6i5gjDvgUthLYJnIZJsp1HlF523k73hELY20WPyEO8xcz7aaYBVkeg5Q==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+      "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
       "cpu": [
         "x64"
       ],
@@ -4893,9 +4936,9 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.15.tgz",
-      "integrity": "sha512-attlyhD6Y22jNyQ0fIIQ7mnPvDWKw7k6FKnsXlBvQE6s3z6s6cuEHcSgoirquQc7TmZgVCK5fD/2uxmRN+ZpcQ==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+      "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
       "cpu": [
         "arm64"
       ],
@@ -4909,9 +4952,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.15.tgz",
-      "integrity": "sha512-ohZtF8W1SHJ4JWldsPVdk8st0r9ExbAOSrBOh5L+Mq47i696GVwv1ab/KlmbUoikSTNoXEhDzVpxUR/WIO19FQ==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+      "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
       "cpu": [
         "x64"
       ],
@@ -4925,9 +4968,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.15.tgz",
-      "integrity": "sha512-P8jOZ5zshCNIuGn+9KehKs/cq5uIniC+BeCykvdVhx/rBXSxmtj3CUIKZz4sDCuESMbitK54drf/2QX9QHG5Ag==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+      "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
       "cpu": [
         "arm64"
       ],
@@ -4941,9 +4984,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.15.tgz",
-      "integrity": "sha512-KkTg+AmDXz1IvA9S1gt8dE24C8Thx0X5oM0KGF322DuP+P3evwTL9YyusHAWNsh4qLsR80nvBr/EIYs29VSwuA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+      "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
       "cpu": [
         "x64"
       ],
@@ -4957,9 +5000,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.15.tgz",
-      "integrity": "sha512-FUcML0DRsuyqCMfAC+HoeAqvWxMeq0qXvclZZ/lt2kLU6XBnDA5uKTLUd379WYEyVD4KKFctqWd9tTuk8C/96g==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+      "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
       "cpu": [
         "arm64"
       ],
@@ -4973,9 +5016,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.15.tgz",
-      "integrity": "sha512-q28Qn5pZgHNqug02aTkzw5sW9OklSo96b5nm17Mq0pDXrdTBcQ+M6Q9A1B+dalFeynunwh/pvfrNucjzwDXj+Q==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+      "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
       "cpu": [
         "ia32"
       ],
@@ -4989,9 +5032,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.15.tgz",
-      "integrity": "sha512-217KPmWMirkf8liO+fj2qrPwbIbhNTGNVtvqI1TnOWJgcMjUWvd677Gq3fTzXEjilkx2yWypVnTswM2KbXgoAg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+      "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
       "cpu": [
         "x64"
       ],
@@ -5005,9 +5048,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.15.tgz",
-      "integrity": "sha512-RYVW9o2yN8yM7SB1yaWr378CwrjvGCyGybX3SdzPHpikUHkME2AP55Ma20uNwkNyY2eSYFX9D55kDrfQmQBR4w==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+      "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
       "cpu": [
         "arm"
       ],
@@ -5021,9 +5064,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.15.tgz",
-      "integrity": "sha512-/ltmNFs0FivZkYsTzAsXIfLQX38lFnwJTWCJts0IbCqWZQe+jjj0vYBNbI0kmXLb3y5NljiM5USVAO1NVkdh2g==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+      "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
       "cpu": [
         "arm64"
       ],
@@ -5037,9 +5080,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.15.tgz",
-      "integrity": "sha512-PksEPb321/28GFFxtvL33yVPfnMZihxkEv5zME2zapXGp7fA1X2jYeiTUK+9tJ/EGgcNWuwvtawPxJG7Mmn86A==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+      "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
       "cpu": [
         "mips64el"
       ],
@@ -5053,9 +5096,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.15.tgz",
-      "integrity": "sha512-ek8gJBEIhcpGI327eAZigBOHl58QqrJrYYIZBWQCnH3UnXoeWMrMZLeeZL8BI2XMBhP+sQ6ERctD5X+ajL/AIA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+      "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
       "cpu": [
         "ppc64"
       ],
@@ -5069,9 +5112,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.15.tgz",
-      "integrity": "sha512-H5ilTZb33/GnUBrZMNJtBk7/OXzDHDXjIzoLXHSutwwsLxSNaLxzAaMoDGDd/keZoS+GDBqNVxdCkpuiRW4OSw==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+      "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
       "cpu": [
         "riscv64"
       ],
@@ -5085,9 +5128,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.15.tgz",
-      "integrity": "sha512-jKaLUg78mua3rrtrkpv4Or2dNTJU7bgHN4bEjT4OX4GR7nLBSA9dfJezQouTxMmIW7opwEC5/iR9mpC18utnxQ==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+      "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
       "cpu": [
         "s390x"
       ],
@@ -5101,9 +5144,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.15.tgz",
-      "integrity": "sha512-aOvmF/UkjFuW6F36HbIlImJTTx45KUCHJndtKo+KdP8Dhq3mgLRKW9+6Ircpm8bX/RcS3zZMMmaBLkvGY06Gvw==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+      "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
       "cpu": [
         "x64"
       ],
@@ -5117,9 +5160,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.15.tgz",
-      "integrity": "sha512-HFFX+WYedx1w2yJ1VyR1Dfo8zyYGQZf1cA69bLdrHzu9svj6KH6ZLK0k3A1/LFPhcEY9idSOhsB2UyU0tHPxgQ==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+      "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
       "cpu": [
         "x64"
       ],
@@ -5133,9 +5176,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.15.tgz",
-      "integrity": "sha512-jOPBudffG4HN8yJXcK9rib/ZTFoTA5pvIKbRrt3IKAGMq1EpBi4xoVoSRrq/0d4OgZLaQbmkHp8RO9eZIn5atA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+      "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
       "cpu": [
         "x64"
       ],
@@ -5149,9 +5192,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.15.tgz",
-      "integrity": "sha512-MDkJ3QkjnCetKF0fKxCyYNBnOq6dmidcwstBVeMtXSgGYTy8XSwBeIE4+HuKiSsG6I/mXEb++px3IGSmTN0XiA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+      "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
       "cpu": [
         "ia32"
       ],
@@ -5165,9 +5208,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.15.tgz",
-      "integrity": "sha512-xaAUIB2qllE888SsMU3j9nrqyLbkqqkpQyWVkfwSil6BBPgcPk3zOFitTTncEKCLTQy3XV9RuH7PDj3aJDljWA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+      "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
       "cpu": [
         "x64"
       ],
@@ -5181,9 +5224,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.15.tgz",
-      "integrity": "sha512-ttuoCYCIJAFx4UUKKWYnFdrVpoXa3+3WWkXVI6s09U+YjhnyM5h96ewTq/WgQj9LFSIlABQvadHSOQyAVjW5xQ==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+      "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
       "cpu": [
         "arm64"
       ],
@@ -6473,11 +6516,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/google-closure-compiler-java": {
-      "version": "20200224.0.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -6806,20 +6844,6 @@
       "version": "2.0.4",
       "license": "ISC"
     },
-    "node_modules/internal-slot": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/inline-source-map": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
@@ -6836,6 +6860,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/interpret": {
@@ -7639,16 +7677,16 @@
       "version": "4.4.2",
       "license": "MIT"
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
     "node_modules/lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A==",
+      "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "node_modules/lodash.set": {
@@ -10191,8 +10229,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -10208,6 +10247,12 @@
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -10993,7 +11038,6 @@
         "@keymanapp/web-sentry-manager": "*",
         "@sentry/cli": "2.2.0",
         "chai": "^4.3.4",
-        "google-closure-compiler-java": "^20200224.0.0",
         "karma": "^6.4.1",
         "karma-browserstack-launcher": "^1.6.0",
         "karma-chai": "^0.1.0",
@@ -11011,6 +11055,7 @@
         "mocha": "^10.0.0",
         "modernizr": "^3.11.7",
         "ts-node": "^10.9.1",
+        "tslib": "^2.5.2",
         "typescript": "^4.9.5"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11029,6 +11029,7 @@
         "@keymanapp/lexical-model-layer": "*",
         "@keymanapp/models-types": "*",
         "@keymanapp/recorder-core": "*",
+        "@keymanapp/tslib": "*",
         "@keymanapp/web-utils": "*",
         "@types/node": "^11.9.4",
         "eventemitter3": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -351,10 +351,13 @@
     },
     "common/web/tslib": {
       "name": "@keymanapp/tslib",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.5.2",
         "typescript": "^4.9.5"
+      },
+      "devDependencies": {
+        "@keymanapp/resources-gosh": "*",
+        "esbuild": "^0.15.16"
       }
     },
     "common/web/types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11031,7 +11031,8 @@
         "@keymanapp/recorder-core": "*",
         "@keymanapp/web-utils": "*",
         "@types/node": "^11.9.4",
-        "eventemitter3": "^4.0.0"
+        "eventemitter3": "^4.0.0",
+        "tslib": "^2.5.2"
       },
       "devDependencies": {
         "@keymanapp/resources-gosh": "*",
@@ -11055,7 +11056,6 @@
         "mocha": "^10.0.0",
         "modernizr": "^3.11.7",
         "ts-node": "^10.9.1",
-        "tslib": "^2.5.2",
         "typescript": "^4.9.5"
       }
     }

--- a/package.json
+++ b/package.json
@@ -2,18 +2,19 @@
   "name": "root",
   "private": true,
   "devDependencies": {
-    "chai": "^4.3.4",
-    "esbuild": "^0.15.15",
-    "mocha": "^10.0.0",
-    "mocha-teamcity-reporter": "^4.0.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^4.9.5",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
+    "chai": "^4.3.4",
+    "esbuild": "^0.15.16",
     "eslint": "^8.39.0",
     "eslint-config-standard-with-typescript": "^34.0.1",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^15.7.0",
-    "eslint-plugin-promise": "^6.1.1"
+    "eslint-plugin-promise": "^6.1.1",
+    "mocha": "^10.0.0",
+    "mocha-teamcity-reporter": "^4.0.0",
+    "ts-node": "^10.9.1",
+    "tslib": "^2.5.2",
+    "typescript": "^4.9.5"
   },
   "scripts": {},
   "workspaces": [
@@ -37,10 +38,10 @@
     "web"
   ],
   "dependencies": {
+    "@keymanapp/common-types": "file:common/web/types",
+    "@keymanapp/developer-test-helpers": "file:developer/src/common/web/test-helpers",
     "@keymanapp/hextobin": "file:common/tools/hextobin",
     "@keymanapp/keyman-version": "file:common/web/keyman-version",
-    "@keymanapp/common-types": "file:common/web/types",
-    "@keymanapp/ldml-keyboard-constants": "file:core/include/ldml",
-    "@keymanapp/developer-test-helpers": "file:developer/src/common/web/test-helpers"
+    "@keymanapp/ldml-keyboard-constants": "file:core/include/ldml"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -106,6 +106,7 @@
     "@keymanapp/lexical-model-layer": "*",
     "@keymanapp/models-types": "*",
     "@keymanapp/recorder-core": "*",
+    "@keymanapp/tslib": "*",
     "@keymanapp/web-utils": "*",
     "@types/node": "^11.9.4",
     "eventemitter3": "^4.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -108,7 +108,8 @@
     "@keymanapp/recorder-core": "*",
     "@keymanapp/web-utils": "*",
     "@types/node": "^11.9.4",
-    "eventemitter3": "^4.0.0"
+    "eventemitter3": "^4.0.0",
+    "tslib": "^2.5.2"
   },
   "type": "module"
 }

--- a/web/src/app/browser/build-bundler.js
+++ b/web/src/app/browser/build-bundler.js
@@ -98,9 +98,6 @@ if(EMIT_FILESIZE_PROFILE) {
 
 await esbuild.build({
   ...commonConfig,
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
   format: "esm",
   entryPoints: {
     'index': '../../../build/app/browser/obj/test-index.js',

--- a/web/src/app/browser/build-bundler.js
+++ b/web/src/app/browser/build-bundler.js
@@ -63,7 +63,6 @@ const commonConfig = {
   },
   outfile: '../../../build/app/browser/debug/keymanweb.js',
   plugins: [ es5ClassAnnotationAsPurePlugin ],
-  pure: ['__asyncDelegator'],
   target: "es5",
   treeShaking: true,
   tsconfig: './tsconfig.json'

--- a/web/src/app/browser/build-bundler.js
+++ b/web/src/app/browser/build-bundler.js
@@ -50,7 +50,10 @@ let es5ClassAnnotationAsPurePlugin = {
   }
 }
 
-await esbuild.build({
+const commonConfig = {
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "iife",
@@ -60,14 +63,16 @@ await esbuild.build({
   },
   outfile: '../../../build/app/browser/debug/keymanweb.js',
   plugins: [ es5ClassAnnotationAsPurePlugin ],
+  pure: ['__asyncDelegator'],
   target: "es5",
   treeShaking: true,
   tsconfig: './tsconfig.json'
-});
+};
+
+await esbuild.build(commonConfig);
 
 let result = await esbuild.build({
-  bundle: true,
-  sourcemap: true,
+  ...commonConfig,
   minifyWhitespace: true,
   minifySyntax: true,
   minifyIdentifiers: true,
@@ -77,10 +82,6 @@ let result = await esbuild.build({
     'index': '../../../build/app/browser/obj/release-main.js',
   },
   outfile: '../../../build/app/browser/release/keymanweb.js',
-  plugins: [ es5ClassAnnotationAsPurePlugin ],
-  target: "es5",
-  treeShaking: true,
-  tsconfig: './tsconfig.json',
   // Enables source-file output size profiling!
   metafile: true
 });
@@ -96,17 +97,14 @@ if(EMIT_FILESIZE_PROFILE) {
 }
 
 await esbuild.build({
-  bundle: true,
-  sourcemap: true,
-  minify: false,
+  ...commonConfig,
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   format: "esm",
-  nodePaths: ['../../../../node_modules'],
   entryPoints: {
     'index': '../../../build/app/browser/obj/test-index.js',
   },
   outfile: '../../../build/app/browser/lib/index.mjs',
-  plugins: [ es5ClassAnnotationAsPurePlugin ],
-  target: "es5",
-  treeShaking: true,
   tsconfig: './tsconfig.json'
 });

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -295,9 +295,9 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
       } else {
         let x: (string|KeyboardStub)[] = [];
         if (Array.isArray(args[0])) {
-          x.push(...args[0]);
+          x = x.concat(args[0]);
         } else if (Array.isArray(args)) {
-          x.push(...args);
+          x = x.concat(args);
         }
         return this.keyboardRequisitioner.addKeyboardArray(x);
       }

--- a/web/src/app/browser/tsconfig.json
+++ b/web/src/app/browser/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "allowJs": false,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",

--- a/web/src/app/webview/build-bundler.js
+++ b/web/src/app/webview/build-bundler.js
@@ -31,6 +31,9 @@ let es5ClassAnnotationAsPurePlugin = {
 }
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "iife",
@@ -46,6 +49,9 @@ await esbuild.build({
 });
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   minifyWhitespace: true,

--- a/web/src/app/webview/tsconfig.json
+++ b/web/src/app/webview/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "allowJs": false,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",

--- a/web/src/engine/attachment/build-bundler.js
+++ b/web/src/engine/attachment/build-bundler.js
@@ -9,6 +9,9 @@ import esbuild from 'esbuild';
 import { spawn } from 'child_process';
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",

--- a/web/src/engine/attachment/src/pageContextAttachment.ts
+++ b/web/src/engine/attachment/src/pageContextAttachment.ts
@@ -103,7 +103,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
       (flattenedInputList, pageInputList) => flattenedInputList.concat(pageInputList), []
     );
 
-    return [...this._inputList, ...embeddedInputs];
+    return [].concat(this._inputList).concat(embeddedInputs);
   }
 
   // Useful for `moveToNext` operations:  order matters.

--- a/web/src/engine/attachment/tsconfig.json
+++ b/web/src/engine/attachment/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "allowJs": true,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",

--- a/web/src/engine/device-detect/build-bundler.js
+++ b/web/src/engine/device-detect/build-bundler.js
@@ -9,6 +9,9 @@ import esbuild from 'esbuild';
 import { spawn } from 'child_process';
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",

--- a/web/src/engine/device-detect/tsconfig.json
+++ b/web/src/engine/device-detect/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "allowJs": false,
     "declaration": true,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",

--- a/web/src/engine/dom-utils/tsconfig.json
+++ b/web/src/engine/dom-utils/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "allowJs": true,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",

--- a/web/src/engine/element-wrappers/build-bundler.js
+++ b/web/src/engine/element-wrappers/build-bundler.js
@@ -9,6 +9,9 @@ import esbuild from 'esbuild';
 import { spawn } from 'child_process';
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",

--- a/web/src/engine/element-wrappers/tsconfig.json
+++ b/web/src/engine/element-wrappers/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "allowJs": true,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",

--- a/web/src/engine/events/build-bundler.js
+++ b/web/src/engine/events/build-bundler.js
@@ -9,6 +9,9 @@ import esbuild from 'esbuild';
 import { spawn } from 'child_process';
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",

--- a/web/src/engine/events/tsconfig.json
+++ b/web/src/engine/events/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "allowJs": true,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",

--- a/web/src/engine/main/build-bundler.js
+++ b/web/src/engine/main/build-bundler.js
@@ -9,6 +9,9 @@ import esbuild from 'esbuild';
 import { spawn } from 'child_process';
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",

--- a/web/src/engine/main/tsconfig.json
+++ b/web/src/engine/main/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "allowJs": true,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",

--- a/web/src/engine/osk/build-bundler.js
+++ b/web/src/engine/osk/build-bundler.js
@@ -1,6 +1,9 @@
 import esbuild from 'esbuild';
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",

--- a/web/src/engine/osk/tsconfig.json
+++ b/web/src/engine/osk/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "allowJs": true,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",

--- a/web/src/engine/package-cache/build-bundler.js
+++ b/web/src/engine/package-cache/build-bundler.js
@@ -1,6 +1,9 @@
 import esbuild from 'esbuild';
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",
@@ -15,6 +18,9 @@ await esbuild.build({
 });
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",
@@ -29,6 +35,9 @@ await esbuild.build({
 });
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",

--- a/web/src/engine/package-cache/build.sh
+++ b/web/src/engine/package-cache/build.sh
@@ -16,6 +16,7 @@ cd "$THIS_SCRIPT_PATH"
 # ################################ Main script ################################
 
 builder_describe "Builds Keyman Engine modules for keyboard cloud-querying & caching + model caching." \
+  "@/common/web/tslib" \
   "@/common/web/input-processor build" \
   "@/web/src/engine/paths" \
   "clean" \

--- a/web/src/engine/package-cache/src/keyboardRequisitioner.ts
+++ b/web/src/engine/package-cache/src/keyboardRequisitioner.ts
@@ -214,7 +214,7 @@ export default class KeyboardRequisitioner {
         }
       }
 
-      return [...errorStubs, ...completeStubs];
+      return [].concat(errorStubs).concat(completeStubs);
     });
   }
 

--- a/web/src/engine/package-cache/tsconfig.json
+++ b/web/src/engine/package-cache/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "allowJs": true,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",

--- a/web/src/engine/paths/build-bundler.js
+++ b/web/src/engine/paths/build-bundler.js
@@ -9,6 +9,9 @@ import esbuild from 'esbuild';
 import { spawn } from 'child_process';
 
 await esbuild.build({
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
   bundle: true,
   sourcemap: true,
   format: "esm",

--- a/web/src/engine/paths/build.sh
+++ b/web/src/engine/paths/build.sh
@@ -16,6 +16,7 @@ cd "$THIS_SCRIPT_PATH"
 # ################################ Main script ################################
 
 builder_describe "Builds configuration subclasses used by the Keyman Engine for Web (KMW)." \
+  "@/common/web/tslib" \
   "@/web/src/engine/osk build" \
   "clean" \
   "configure" \

--- a/web/src/engine/paths/tsconfig.json
+++ b/web/src/engine/paths/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "allowJs": false,
+    "importHelpers": true,
     "inlineSources": true,
     "allowSyntheticDefaultImports": true,
     "module": "es6",


### PR DESCRIPTION
Inspection of the results of our `esbuild`-bundled products indicates that it's pretty cautious with ES5 code... enough so that without a little help, this can result in somewhat significant filesize bloat for us.

By default, TS directly emits down-compilation "helper" functions - essentially, polyfill helpers for ES6+ features - into ES5-targeting compilations.  This was "fine" when everything was namespace-based - after all, we had `<reference path="..."/>` links that essentially compiled _all_ of the relevant code, at once, into a single file.  One destination file, one set of "downcompile helpers".

With a little extrapolation, note that _now_, with modularized code, we instead have over a hundred individual module files.  These, in turn, get bundled together for the final build.  The problem... is that TS will, by default, directly emit those "downcompile helpers" into each and every one of those "over a hundred" module files that needs it.  Only the ones that are needed by each specific file, granted, but it _definitely_ adds up.  The one that made me aware of this:  the `__extends` helper (for class inheritance) gets duplicated at least 30 times - which represents several kilobytes of bloat by itself.

Enter the [TS compilation option:  "importHelpers"](https://www.typescriptlang.org/tsconfig#importHelpers).  The short of it:  the developers of TypeScript also publish the library `tslib` - a centralized package of modules defining the same helpers.  Using it tells `tsc` to instead insert any needed `import { ... } from 'tslib';` statements into our compiled modules - with a single, centralized definition.  This prevents "downcompile helper" duplication, allowing us to save on filesize.

This does mean:

- adding 'tslib' as a dependency
- ensuring that it can be properly used and imported by `esbuild` 
    - ... which took significant effort on my part to resolve.
    - This is why `/common/web/tslib` is added - it's the workaround that worked.  Long story short... another problem arose due to `es5` being "allowed", but not exactly first-class "supported", by `esbuild`.
    - At least `esbuild` also provides the `alias` feature, which was necessary to fully implement the workaround.
    - Of course, with the workaround being a package... well, we've got to ensure that build dependencies are appropriately set.

Unfortunately, tree-shaking doesn't appear to be possible for `esbuild` + `tslib` with the setup I could get working... at least not built-in.  As a result, I believe it's better to leave `tslib` out of the worker at present; it doesn't have nearly as much "downcompile helper" duplication as the rest of Web's codebase, so it may not win us anything there.

That said, after further experimentation, I believe I've figured out how to use `esbuild` plugins to handle `tslib` treeshaking ourselves; this would save more KB and allow use of `tslib` within the lm-worker.  But that'll be a separate PR - #8964.

The last notable change pattern - I'm getting a spurious error for downcompilations involving "array spreading":  `[...array]` scenarios.  Fortunately, our uses appear safe to convert to `[].concat(array)`-style code, which poses no such issue.

@keymanapp-test-bot skip