### PR TITLE
chore(developer): loadFile callback error check and optimization

### DIFF
--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -3233,6 +3233,12 @@ KMX_DWORD ImportBitmapFile(PFILE_KEYBOARD fk, PKMX_WCHAR szName, PKMX_DWORD File
     }
   }
 
+  if(*FileSize < 2) {
+    // Zero-byte file is invalid; 2 byte file is too, but we only really care
+    // about the prolog at this point so we don't overrun our buffer
+    return CERR_CannotReadBitmapFile;
+  }
+
   *Buf = new KMX_BYTE[*FileSize];
   if(!loadfileproc(szNameUtf8.c_str(), fk->extra->kmnFilename.c_str(), *Buf, (int*) FileSize, msgprocContext)) {
     delete[] *Buf;

--- a/developer/src/kmcmplib/src/CompilerInterfacesWasm.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfacesWasm.cpp
@@ -33,7 +33,7 @@ bool wasm_LoadFileProc(const char* filename, const char* baseFilename, void* buf
   char* msgProc = static_cast<char*>(context);
   if(buffer == nullptr) {
     *bufferSize = wasm_loadfileproc(filename, baseFilename, 0, 0, msgProc);
-    return *bufferSize != 0;
+    return *bufferSize != -1;
   } else {
     return wasm_loadfileproc(filename, baseFilename, buffer, *bufferSize, msgProc) == 1;
   }


### PR DESCRIPTION
Fixes #8885.

Adds some optimization and error checking to the loadFile callback in kmc-kmn. Also handles case of zero-byte bitmap file so we won't crash on it.

@keymanapp-test-bot skip