### PR TITLE
chore(common): remove url module ref from common/web/types

### DIFF
--- a/common/web/types/src/kvk/kvks-file-writer.ts
+++ b/common/web/types/src/kvk/kvks-file-writer.ts
@@ -96,7 +96,6 @@ export default class KVKSFileWriter {
       l.key.push(k);
     }
 
-    // console.dir(kvks, {depth:8});
     let result = builder.buildObject(kvks);
     return result; //Uint8Array.from(result);
   }

--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -25,7 +25,7 @@ export class LDMLKeyboardXMLSourceFileReader {
   }
 
   readImportFile(version: string, subpath: string): Uint8Array {
-    const importPath = this.callbacks.resolveFilename(this.options.importsPath, `../import/${version}/${subpath}`);
+    const importPath = this.callbacks.resolveFilename(this.options.importsPath, `${version}/${subpath}`);
     return this.callbacks.loadFile(importPath);
   }
 

--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -7,7 +7,6 @@ import { CompilerCallbacks } from '../util/compiler-interfaces.js';
 import { constants } from '@keymanapp/ldml-keyboard-constants';
 import { CommonTypesMessages } from '../util/common-events.js';
 import { LDMLKeyboardTestDataXMLSourceFile, LKTTest, LKTTests } from './ldml-keyboard-testdata-xml.js';
-import { fileURLToPath } from 'url';
 
 interface NameAndProps  {
   '$'?: any; // content
@@ -15,16 +14,18 @@ interface NameAndProps  {
   '$$'?: any; // children
 };
 
-export default class LDMLKeyboardXMLSourceFileReader {
-  callbacks: CompilerCallbacks;
+export class LDMLKeyboardXMLSourceFileReaderOptions {
+  importsPath: string;
+};
 
-  constructor(callbacks : CompilerCallbacks) {
-    this.callbacks = callbacks;
+export const LDMLKeyboardXMLDefaultImportsURL = new URL(`../import/`, import.meta.url);
+
+export class LDMLKeyboardXMLSourceFileReader {
+  constructor(private options: LDMLKeyboardXMLSourceFileReaderOptions, private callbacks : CompilerCallbacks) {
   }
 
   readImportFile(version: string, subpath: string): Uint8Array {
-    // TODO-LDML: use this.callbacks.resolveFilename to get the actual path
-    let importPath = fileURLToPath(new URL(`../import/${version}/${subpath}`, import.meta.url));
+    const importPath = this.callbacks.resolveFilename(this.options.importsPath, `../import/${version}/${subpath}`);
     return this.callbacks.loadFile(importPath);
   }
 

--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -18,10 +18,12 @@ export class LDMLKeyboardXMLSourceFileReaderOptions {
   importsPath: string;
 };
 
-export const LDMLKeyboardXMLDefaultImportsURL = new URL(`../import/`, import.meta.url);
-
 export class LDMLKeyboardXMLSourceFileReader {
   constructor(private options: LDMLKeyboardXMLSourceFileReaderOptions, private callbacks : CompilerCallbacks) {
+  }
+
+  static get defaultImportsURL() {
+    return new URL(`../import/`, import.meta.url);
   }
 
   readImportFile(version: string, subpath: string): Uint8Array {

--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -14,7 +14,7 @@ export * as KvksFile from './kvk/kvk-file.js';
 
 export * as LDMLKeyboard from './ldml-keyboard/ldml-keyboard-xml.js';
 export { LDMLKeyboardTestDataXMLSourceFile } from './ldml-keyboard/ldml-keyboard-testdata-xml.js';
-export { default as LDMLKeyboardXMLSourceFileReader } from './ldml-keyboard/ldml-keyboard-xml-reader.js';
+export { LDMLKeyboardXMLSourceFileReader, LDMLKeyboardXMLSourceFileReaderOptions, LDMLKeyboardXMLDefaultImportsURL } from './ldml-keyboard/ldml-keyboard-xml-reader.js';
 
 export * as Constants from './consts/virtual-key-constants.js';
 

--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -14,7 +14,7 @@ export * as KvksFile from './kvk/kvk-file.js';
 
 export * as LDMLKeyboard from './ldml-keyboard/ldml-keyboard-xml.js';
 export { LDMLKeyboardTestDataXMLSourceFile } from './ldml-keyboard/ldml-keyboard-testdata-xml.js';
-export { LDMLKeyboardXMLSourceFileReader, LDMLKeyboardXMLSourceFileReaderOptions, LDMLKeyboardXMLDefaultImportsURL } from './ldml-keyboard/ldml-keyboard-xml-reader.js';
+export { LDMLKeyboardXMLSourceFileReader, LDMLKeyboardXMLSourceFileReaderOptions } from './ldml-keyboard/ldml-keyboard-xml-reader.js';
 
 export * as Constants from './consts/virtual-key-constants.js';
 

--- a/common/web/types/test/helpers/index.ts
+++ b/common/web/types/test/helpers/index.ts
@@ -28,7 +28,10 @@ export function loadSchema(schema: CompilerSchema): Buffer {
 }
 
 export function resolveFilename(baseFilename: string, filename: string) {
-  const basePath = path.dirname(baseFilename);
+  const basePath =
+    baseFilename.endsWith('/') || baseFilename.endsWith('\\') ?
+    baseFilename :
+    path.dirname(baseFilename);
   // Transform separators to platform separators -- we are agnostic
   // in our use here but path prefers files may use
   // either / or \, although older kps files were always \.

--- a/common/web/types/test/helpers/reader-callback-test.ts
+++ b/common/web/types/test/helpers/reader-callback-test.ts
@@ -1,11 +1,16 @@
 import 'mocha';
 import {assert} from 'chai';
 import { loadFile, makePathToFixture, loadSchema } from '../helpers/index.js';
-import LDMLKeyboardXMLSourceFileReader from '../../src/ldml-keyboard/ldml-keyboard-xml-reader.js';
+import { LDMLKeyboardXMLDefaultImportsURL, LDMLKeyboardXMLSourceFileReader, LDMLKeyboardXMLSourceFileReaderOptions } from '../../src/ldml-keyboard/ldml-keyboard-xml-reader.js';
 import { CompilerEvent } from '../../src/util/compiler-interfaces.js';
 import { LDMLKeyboardXMLSourceFile } from '../../src/ldml-keyboard/ldml-keyboard-xml.js';
 import { LDMLKeyboardTestDataXMLSourceFile } from '../ldml-keyboard/ldml-keyboard-testdata-xml.js';
 import { TestCompilerCallbacks } from './TestCompilerCallbacks.js';
+import { fileURLToPath } from 'url';
+
+const readerOptions: LDMLKeyboardXMLSourceFileReaderOptions = {
+  importsPath: fileURLToPath(LDMLKeyboardXMLDefaultImportsURL)
+};
 
 export interface CompilationCase {
   /**
@@ -71,7 +76,7 @@ export interface TestDataCase {
 export function testReaderCases(cases : CompilationCase[]) {
   // we need our own callbacks rather than using the global so messages don't get mixed
   const callbacks = new TestCompilerCallbacks();
-  const reader = new LDMLKeyboardXMLSourceFileReader(callbacks);
+  const reader = new LDMLKeyboardXMLSourceFileReader(readerOptions, callbacks);
   for (let testcase of cases) {
     const expectFailure = testcase.throws || !!(testcase.errors); // if true, we expect this to fail
     const testHeading = expectFailure ? `should fail to load: ${testcase.subpath}`:
@@ -79,6 +84,7 @@ export function testReaderCases(cases : CompilationCase[]) {
     it(testHeading, function () {
       callbacks.clear();
 
+      debugger;
       const data = loadFile(makePathToFixture(testcase.subpath));
       assert.ok(data, `reading ${testcase.subpath}`);
       const source = reader.load(data);
@@ -122,7 +128,7 @@ export function testReaderCases(cases : CompilationCase[]) {
 export function testTestdataReaderCases(cases : TestDataCase[]) {
   // we need our own callbacks rather than using the global so messages don't get mixed
   const callbacks = new TestCompilerCallbacks();
-  const reader = new LDMLKeyboardXMLSourceFileReader(callbacks);
+  const reader = new LDMLKeyboardXMLSourceFileReader(readerOptions, callbacks);
   for (let testcase of cases) {
     const expectFailure = testcase.throws || !!(testcase.errors); // if true, we expect this to fail
     const testHeading = expectFailure ? `should fail to load: ${testcase.subpath}`:

--- a/common/web/types/test/helpers/reader-callback-test.ts
+++ b/common/web/types/test/helpers/reader-callback-test.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import {assert} from 'chai';
 import { loadFile, makePathToFixture, loadSchema } from '../helpers/index.js';
-import { LDMLKeyboardXMLDefaultImportsURL, LDMLKeyboardXMLSourceFileReader, LDMLKeyboardXMLSourceFileReaderOptions } from '../../src/ldml-keyboard/ldml-keyboard-xml-reader.js';
+import { LDMLKeyboardXMLSourceFileReader, LDMLKeyboardXMLSourceFileReaderOptions } from '../../src/ldml-keyboard/ldml-keyboard-xml-reader.js';
 import { CompilerEvent } from '../../src/util/compiler-interfaces.js';
 import { LDMLKeyboardXMLSourceFile } from '../../src/ldml-keyboard/ldml-keyboard-xml.js';
 import { LDMLKeyboardTestDataXMLSourceFile } from '../ldml-keyboard/ldml-keyboard-testdata-xml.js';
@@ -9,7 +9,7 @@ import { TestCompilerCallbacks } from './TestCompilerCallbacks.js';
 import { fileURLToPath } from 'url';
 
 const readerOptions: LDMLKeyboardXMLSourceFileReaderOptions = {
-  importsPath: fileURLToPath(LDMLKeyboardXMLDefaultImportsURL)
+  importsPath: fileURLToPath(LDMLKeyboardXMLSourceFileReader.defaultImportsURL)
 };
 
 export interface CompilationCase {

--- a/common/web/types/test/helpers/reader-callback-test.ts
+++ b/common/web/types/test/helpers/reader-callback-test.ts
@@ -84,7 +84,6 @@ export function testReaderCases(cases : CompilationCase[]) {
     it(testHeading, function () {
       callbacks.clear();
 
-      debugger;
       const data = loadFile(makePathToFixture(testcase.subpath));
       assert.ok(data, `reading ${testcase.subpath}`);
       const source = reader.load(data);

--- a/common/web/types/test/kpj/test-kpj-file-reader.ts
+++ b/common/web/types/test/kpj/test-kpj-file-reader.ts
@@ -15,7 +15,6 @@ describe('kpj-file-reader', function () {
     const input = fs.readFileSync(path);
     const reader = new KPJFileReader(callbacks);
     const kpj = reader.read(input);
-    console.dir(kpj);
     assert.doesNotThrow(() => {
       reader.validate(kpj, loadSchema('kpj'));
     });
@@ -79,7 +78,6 @@ describe('kpj-file-reader', function () {
     assert.lengthOf(project.files, 2);
 
     let f: KeymanDeveloperProjectFile10 = <KeymanDeveloperProjectFile10>project.files[0];
-    console.dir(f);
     assert.equal(f.id, 'id_f347675c33d2e6b1c705c787fad4941a');
     assert.equal(f.filename, 'khmer_angkor.kmn');
     assert.equal(f.filePath, 'source/khmer_angkor.kmn');

--- a/developer/src/common/web/test-helpers/index.ts
+++ b/developer/src/common/web/test-helpers/index.ts
@@ -57,7 +57,10 @@ export class TestCompilerCallbacks implements CompilerCallbacks {
   }
 
   resolveFilename(baseFilename: string, filename: string): string {
-    const basePath = path.dirname(baseFilename);
+    const basePath =
+      baseFilename.endsWith('/') || baseFilename.endsWith('\\') ?
+      baseFilename :
+      path.dirname(baseFilename);
     // Transform separators to platform separators -- we are agnostic
     // in our use here but path prefers files may use
     // either / or \, although older kps files were always \.

--- a/developer/src/kmc-ldml/src/compiler/compiler-options.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler-options.ts
@@ -1,4 +1,4 @@
-
+import { LDMLKeyboardXMLSourceFileReaderOptions } from "@keymanapp/common-types";
 
 export interface CompilerOptions {
   /**
@@ -10,4 +10,9 @@ export interface CompilerOptions {
    * Add metadata about the compiler version to .kmx file when compiling
    */
   addCompilerVersion?: boolean;
+
+  /**
+   * Paths and other options required for reading .xml files
+   */
+  readerOptions: LDMLKeyboardXMLSourceFileReaderOptions;
 };

--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -30,7 +30,7 @@ const SECTION_COMPILERS = [
 
 export class LdmlKeyboardCompiler {
   private readonly callbacks: CompilerCallbacks;
-  private readonly options: CompilerOptions; // not currently used
+  private readonly options: CompilerOptions;
 
   constructor (callbacks: CompilerCallbacks, options: CompilerOptions) {
     this.options = {

--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -30,16 +30,14 @@ const SECTION_COMPILERS = [
 
 export class LdmlKeyboardCompiler {
   private readonly callbacks: CompilerCallbacks;
-  // private readonly options: CompilerOptions; // not currently used
+  private readonly options: CompilerOptions; // not currently used
 
-  constructor (callbacks: CompilerCallbacks, _options?: CompilerOptions) {
-    /*
+  constructor (callbacks: CompilerCallbacks, options: CompilerOptions) {
     this.options = {
       debug: false,
       addCompilerVersion: true,
       ...options
     };
-    */
     this.callbacks = callbacks;
   }
 
@@ -54,7 +52,7 @@ export class LdmlKeyboardCompiler {
    * @returns the source file, or null if invalid
    */
   public load(filename: string): LDMLKeyboardXMLSourceFile | null {
-    const reader = new LDMLKeyboardXMLSourceFileReader(this.callbacks);
+    const reader = new LDMLKeyboardXMLSourceFileReader(this.options.readerOptions, this.callbacks);
     const data = this.callbacks.loadFile(filename);
     if(!data) {
       this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to read XML file'}));
@@ -84,7 +82,7 @@ export class LdmlKeyboardCompiler {
    * @returns the source file, or null if invalid
    */
     public loadTestData(filename: string): LDMLKeyboardTestDataXMLSourceFile | null {
-      const reader = new LDMLKeyboardXMLSourceFileReader(this.callbacks);
+      const reader = new LDMLKeyboardXMLSourceFileReader(this.options.readerOptions, this.callbacks);
       const data = this.callbacks.loadFile(filename);
       if(!data) {
         this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to read XML file'}));

--- a/developer/src/kmc-ldml/test/helpers/index.ts
+++ b/developer/src/kmc-ldml/test/helpers/index.ts
@@ -5,7 +5,7 @@ import 'mocha';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { SectionCompiler } from '../../src/compiler/section-compiler.js';
-import { KMXPlus, LDMLKeyboardXMLSourceFileReader, VisualKeyboard, CompilerEvent, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
+import { KMXPlus, LDMLKeyboardXMLSourceFileReader, VisualKeyboard, CompilerEvent, LDMLKeyboardTestDataXMLSourceFile, LDMLKeyboardXMLDefaultImportsURL } from '@keymanapp/common-types';
 import { LdmlKeyboardCompiler } from '../../src/compiler/compiler.js';
 import { assert } from 'chai';
 import { KMXPlusMetadataCompiler } from '../../src/compiler/metadata-compiler.js';
@@ -33,6 +33,12 @@ export function makePathToFixture(...components: string[]): string {
 
 export const compilerTestCallbacks = new TestCompilerCallbacks();
 
+export const compilerTestOptions: CompilerOptions = {
+  readerOptions: {
+    importsPath: fileURLToPath(LDMLKeyboardXMLDefaultImportsURL)
+  }
+};
+
 beforeEach(function() {
   compilerTestCallbacks.clear();
 });
@@ -43,14 +49,13 @@ afterEach(function() {
   }
 });
 
-
 export function loadSectionFixture(compilerClass: typeof SectionCompiler, filename: string, callbacks: TestCompilerCallbacks): Section {
   callbacks.messages = [];
   const inputFilename = makePathToFixture(filename);
   const data = callbacks.loadFile(inputFilename);
   assert.isNotNull(data);
 
-  const reader = new LDMLKeyboardXMLSourceFileReader(callbacks);
+  const reader = new LDMLKeyboardXMLSourceFileReader(compilerTestOptions.readerOptions, callbacks);
   const source = reader.load(data);
   assert.isNotNull(source);
 

--- a/developer/src/kmc-ldml/test/helpers/index.ts
+++ b/developer/src/kmc-ldml/test/helpers/index.ts
@@ -5,7 +5,7 @@ import 'mocha';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { SectionCompiler } from '../../src/compiler/section-compiler.js';
-import { KMXPlus, LDMLKeyboardXMLSourceFileReader, VisualKeyboard, CompilerEvent, LDMLKeyboardTestDataXMLSourceFile, LDMLKeyboardXMLDefaultImportsURL } from '@keymanapp/common-types';
+import { KMXPlus, LDMLKeyboardXMLSourceFileReader, VisualKeyboard, CompilerEvent, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
 import { LdmlKeyboardCompiler } from '../../src/compiler/compiler.js';
 import { assert } from 'chai';
 import { KMXPlusMetadataCompiler } from '../../src/compiler/metadata-compiler.js';
@@ -35,7 +35,7 @@ export const compilerTestCallbacks = new TestCompilerCallbacks();
 
 export const compilerTestOptions: CompilerOptions = {
   readerOptions: {
-    importsPath: fileURLToPath(LDMLKeyboardXMLDefaultImportsURL)
+    importsPath: fileURLToPath(LDMLKeyboardXMLSourceFileReader.defaultImportsURL)
   }
 };
 

--- a/developer/src/kmc-ldml/test/test-compiler-e2e.ts
+++ b/developer/src/kmc-ldml/test/test-compiler-e2e.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import {assert} from 'chai';
 import x_hextobin from '@keymanapp/hextobin';
 import { KMXBuilder } from '@keymanapp/common-types';
-import {checkMessages, compileKeyboard, makePathToFixture} from './helpers/index.js';
+import {checkMessages, compileKeyboard, compilerTestOptions, makePathToFixture} from './helpers/index.js';
 
 const hextobin = (x_hextobin as any).default;
 
@@ -17,7 +17,7 @@ describe('compiler-tests', function() {
     const binaryFilename = makePathToFixture('basic.txt');
 
     // Compile the keyboard
-    const kmx = compileKeyboard(inputFilename, {debug: true, addCompilerVersion: false});
+    const kmx = compileKeyboard(inputFilename, {...compilerTestOptions, debug: true, addCompilerVersion: false});
     assert.isNotNull(kmx);
 
     // Use the builder to generate the binary output file

--- a/developer/src/kmc-ldml/test/test-keymanweb-compiler.ts
+++ b/developer/src/kmc-ldml/test/test-keymanweb-compiler.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { assert } from 'chai';
-import { checkMessages, compilerTestCallbacks, makePathToFixture } from './helpers/index.js';
+import { checkMessages, compilerTestCallbacks, compilerTestOptions, makePathToFixture } from './helpers/index.js';
 import { LdmlKeyboardKeymanWebCompiler } from '../src/compiler/keymanweb-compiler.js';
 import { LdmlKeyboardCompiler } from '../src/compiler/compiler.js';
 import * as fs from 'fs';
@@ -16,7 +16,7 @@ describe('LdmlKeyboardKeymanWebCompiler', function() {
 
     // Load input data; we'll use the LDML keyboard compiler loader to save us
     // effort here
-    const k = new LdmlKeyboardCompiler(compilerTestCallbacks, {debug: true, addCompilerVersion: false});
+    const k = new LdmlKeyboardCompiler(compilerTestCallbacks, {...compilerTestOptions, debug: true, addCompilerVersion: false});
     const source = k.load(inputFilename);
     checkMessages();
     assert.isNotNull(source, 'k.load should not have returned null');
@@ -27,7 +27,7 @@ describe('LdmlKeyboardKeymanWebCompiler', function() {
     assert.isTrue(valid, 'k.validate should not have failed');
 
     // Actual test: compile to javascript
-    const jsCompiler = new LdmlKeyboardKeymanWebCompiler(compilerTestCallbacks, {debug: true});
+    const jsCompiler = new LdmlKeyboardKeymanWebCompiler(compilerTestCallbacks, {...compilerTestOptions, debug: true});
     const output = jsCompiler.compile('basic.xml', source);
     assert.isNotNull(output);
 
@@ -36,7 +36,7 @@ describe('LdmlKeyboardKeymanWebCompiler', function() {
     assert.strictEqual(output, outputFixture);
 
     // Second test: compile to javascript without debug formatting
-    const jsCompilerNoDebug = new LdmlKeyboardKeymanWebCompiler(compilerTestCallbacks, {debug: false});
+    const jsCompilerNoDebug = new LdmlKeyboardKeymanWebCompiler(compilerTestCallbacks, {...compilerTestOptions, debug: false});
     const outputNoDebug = jsCompilerNoDebug.compile('basic.xml', source);
     assert.isNotNull(outputNoDebug);
 

--- a/developer/src/kmc-ldml/test/test-metadata-compiler.ts
+++ b/developer/src/kmc-ldml/test/test-metadata-compiler.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { assert } from 'chai';
-import { checkMessages, compileKeyboard, makePathToFixture } from './helpers/index.js';
+import { checkMessages, compileKeyboard, compilerTestOptions, makePathToFixture } from './helpers/index.js';
 import { KMX } from '@keymanapp/common-types';
 import KEYMAN_VERSION from '@keymanapp/keyman-version';
 
@@ -13,7 +13,7 @@ describe('kmx metadata compiler', function () {
     const inputFilename = makePathToFixture('basic.xml');
 
     // Compile the keyboard
-    const kmx = compileKeyboard(inputFilename, {debug:true, addCompilerVersion:true});
+    const kmx = compileKeyboard(inputFilename, {...compilerTestOptions, debug:true, addCompilerVersion:true});
     checkMessages();
     assert.isNotNull(kmx);
 
@@ -48,7 +48,7 @@ describe('kmx metadata compiler', function () {
     const inputFilename = makePathToFixture('basic.xml');
 
     // Compile the keyboard
-    const kmx = compileKeyboard(inputFilename, {debug:true, addCompilerVersion:false});
+    const kmx = compileKeyboard(inputFilename, {...compilerTestOptions, debug:true, addCompilerVersion:false});
     checkMessages();
     assert.isNotNull(kmx);
 

--- a/developer/src/kmc-ldml/test/test-testdata-e2e.ts
+++ b/developer/src/kmc-ldml/test/test-testdata-e2e.ts
@@ -14,7 +14,7 @@ describe('testdata-tests', function() {
     const jsonFilename = makePathToFixture('test-fr.json');
 
     // Compile the keyboard
-    const testData = loadTestdata(inputFilename, compilerTestOptions);
+    const testData = loadTestdata(inputFilename, {...compilerTestOptions, debug: true, addCompilerVersion: false});
     assert.isNotNull(testData);
 
     const jsonData = JSON.parse(readFileSync(jsonFilename, 'utf-8'));

--- a/developer/src/kmc-ldml/test/test-testdata-e2e.ts
+++ b/developer/src/kmc-ldml/test/test-testdata-e2e.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import 'mocha';
 import {assert} from 'chai';
-import {loadTestdata, makePathToFixture} from './helpers/index.js';
+import {compilerTestOptions, loadTestdata, makePathToFixture} from './helpers/index.js';
 
 describe('testdata-tests', function() {
   this.slow(500); // 0.5 sec -- json schema validation takes a while
@@ -14,7 +14,7 @@ describe('testdata-tests', function() {
     const jsonFilename = makePathToFixture('test-fr.json');
 
     // Compile the keyboard
-    const testData = loadTestdata(inputFilename, {debug: true, addCompilerVersion: false});
+    const testData = loadTestdata(inputFilename, compilerTestOptions);
     assert.isNotNull(testData);
 
     const jsonData = JSON.parse(readFileSync(jsonFilename, 'utf-8'));

--- a/developer/src/kmc-ldml/test/test-visual-keyboard-compiler-e2e.ts
+++ b/developer/src/kmc-ldml/test/test-visual-keyboard-compiler-e2e.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import {assert} from 'chai';
 import x_hextobin from '@keymanapp/hextobin';
 import { KvkFileWriter } from '@keymanapp/common-types';
-import {checkMessages,  compileVisualKeyboard, makePathToFixture} from './helpers/index.js';
+import {checkMessages,  compilerTestOptions,  compileVisualKeyboard, makePathToFixture} from './helpers/index.js';
 
 const hextobin = (x_hextobin as any).default;
 
@@ -17,7 +17,7 @@ describe('visual-keyboard-compiler', function() {
     const binaryFilename = makePathToFixture('basic-kvk.txt');
 
     // Compile the visual keyboard
-    const vk = compileVisualKeyboard(inputFilename, {debug: true, addCompilerVersion: false});
+    const vk = compileVisualKeyboard(inputFilename, {...compilerTestOptions, debug: true, addCompilerVersion: false});
     assert.isNotNull(vk);
 
     // Use the builder to generate the binary output file

--- a/developer/src/kmc/src/commands/build/BuildLdmlKeyboard.ts
+++ b/developer/src/kmc/src/commands/build/BuildLdmlKeyboard.ts
@@ -1,8 +1,9 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as kmcLdml from '@keymanapp/kmc-ldml';
-import { KvkFileWriter, CompilerCallbacks } from '@keymanapp/common-types';
+import { KvkFileWriter, CompilerCallbacks, LDMLKeyboardXMLDefaultImportsURL } from '@keymanapp/common-types';
 import { BuildActivity, BuildActivityOptions } from './BuildActivity.js';
+import { fileURLToPath } from 'url';
 
 export class BuildLdmlKeyboard extends BuildActivity {
   public get name(): string { return 'LDML keyboard'; }
@@ -46,11 +47,14 @@ function buildLdmlKeyboardToMemory(inputFilename: string, callbacks: CompilerCal
   let compilerOptions: kmcLdml.CompilerOptions = {
     debug: options.debug ?? false,
     addCompilerVersion: options.compilerVersion ?? true,
+    readerOptions: {
+      importsPath: fileURLToPath(LDMLKeyboardXMLDefaultImportsURL)
+    }
     // TODO: warnDeprecatedCode: options.warnDeprecatedCode,
     // TODO: treatWarningsAsErrors: options.treatWarningsAsErrors,
   }
 
-  const k = new kmcLdml.LdmlKeyboardCompiler(callbacks, options);
+  const k = new kmcLdml.LdmlKeyboardCompiler(callbacks, compilerOptions);
   let source = k.load(inputFilename);
   if (!source) {
     return [null, null, null];

--- a/developer/src/kmc/src/commands/build/BuildLdmlKeyboard.ts
+++ b/developer/src/kmc/src/commands/build/BuildLdmlKeyboard.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as kmcLdml from '@keymanapp/kmc-ldml';
-import { KvkFileWriter, CompilerCallbacks, LDMLKeyboardXMLDefaultImportsURL } from '@keymanapp/common-types';
+import { KvkFileWriter, CompilerCallbacks, LDMLKeyboardXMLSourceFileReader } from '@keymanapp/common-types';
 import { BuildActivity, BuildActivityOptions } from './BuildActivity.js';
 import { fileURLToPath } from 'url';
 
@@ -48,7 +48,7 @@ function buildLdmlKeyboardToMemory(inputFilename: string, callbacks: CompilerCal
     debug: options.debug ?? false,
     addCompilerVersion: options.compilerVersion ?? true,
     readerOptions: {
-      importsPath: fileURLToPath(LDMLKeyboardXMLDefaultImportsURL)
+      importsPath: fileURLToPath(LDMLKeyboardXMLSourceFileReader.defaultImportsURL)
     }
     // TODO: warnDeprecatedCode: options.warnDeprecatedCode,
     // TODO: treatWarningsAsErrors: options.treatWarningsAsErrors,

--- a/developer/src/kmc/src/commands/buildTestData/index.ts
+++ b/developer/src/kmc/src/commands/buildTestData/index.ts
@@ -1,8 +1,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as kmc from '@keymanapp/kmc-ldml';
-import { CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
+import { CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile, LDMLKeyboardXMLDefaultImportsURL } from '@keymanapp/common-types';
 import { NodeCompilerCallbacks } from '../../messages/NodeCompilerCallbacks.js';
+import { fileURLToPath } from 'url';
 
 export interface BuildTestDataOptions {
   outFile?: string;
@@ -11,7 +12,10 @@ export interface BuildTestDataOptions {
 export function buildTestData(infile: string, options: BuildTestDataOptions) {
   let compilerOptions: kmc.CompilerOptions = {
     debug: false,
-    addCompilerVersion: false
+    addCompilerVersion: false,
+    readerOptions: {
+      importsPath: fileURLToPath(LDMLKeyboardXMLDefaultImportsURL)
+    }
   };
 
   let testData = loadTestData(infile, compilerOptions);

--- a/developer/src/kmc/src/commands/buildTestData/index.ts
+++ b/developer/src/kmc/src/commands/buildTestData/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as kmc from '@keymanapp/kmc-ldml';
-import { CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile, LDMLKeyboardXMLDefaultImportsURL } from '@keymanapp/common-types';
+import { CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile, LDMLKeyboardXMLSourceFileReader } from '@keymanapp/common-types';
 import { NodeCompilerCallbacks } from '../../messages/NodeCompilerCallbacks.js';
 import { fileURLToPath } from 'url';
 
@@ -14,7 +14,7 @@ export function buildTestData(infile: string, options: BuildTestDataOptions) {
     debug: false,
     addCompilerVersion: false,
     readerOptions: {
-      importsPath: fileURLToPath(LDMLKeyboardXMLDefaultImportsURL)
+      importsPath: fileURLToPath(LDMLKeyboardXMLSourceFileReader.defaultImportsURL)
     }
   };
 

--- a/developer/src/kmc/src/messages/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/messages/NodeCompilerCallbacks.ts
@@ -93,7 +93,10 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
   }
 
   resolveFilename(baseFilename: string, filename: string) {
-    const basePath = path.dirname(baseFilename);
+    const basePath =
+      baseFilename.endsWith('/') || baseFilename.endsWith('\\') ?
+      baseFilename :
+      path.dirname(baseFilename);
     // Transform separators to platform separators -- we are agnostic
     // in our use here but path prefers files may use
     // either / or \, although older kps files were always \.


### PR DESCRIPTION
The url module is a node module. We need to move responsibility for resolving the path of the LDML XML <import> statements out of common/web/types, and into the ultimate consumer, so it's now surfaced as an option, along with a helper constant that reports the import.meta.url-relative base path of the standard imports that are compiled into common/web/types.

This hopefully means we can use this module in both browser and node contexts without trouble.

@keymanapp-test-bot skip