### PR TITLE
chore(developer): ensure kmcmplib messages are all UTF-8

### DIFF
--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/cerr_duplicate_group.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/cerr_duplicate_group.kmn
@@ -1,0 +1,30 @@
+c Description: Verifies that kmcmplib picks up on duplicated groups with Unicode names,
+c and that the Unicode names are correctly reported in error messages in UTF-8
+
+store(&NAME) 'cerr_duplicate_group'
+store(&VERSION) '9.0'
+
+begin unicode > use(ខ្មែរ)
+
+group(ខ្មែរ) using keys
+
+store(c_key)           [K_K] [K_X] [SHIFT K_K] [SHIFT K_X] [K_G] \
+                       [K_C] [K_Q] [SHIFT K_C] [SHIFT K_Q] [SHIFT K_J] \
+                       [K_D] [K_Z] [SHIFT K_D] [SHIFT K_Z] [SHIFT K_N] \
+                       [K_T] [K_F] [SHIFT K_T] [SHIFT K_F] [K_N] \
+                       [K_B] [K_P] [SHIFT K_B] [SHIFT K_P] [K_M] \
+                       [K_Y] [K_R] [K_L] [K_V] [K_S] [K_H] [SHIFT K_L] [SHIFT K_G] \
+                       [RALT K_K] [RALT K_B]
+store(c_out)           U+1780 U+1781 U+1782 U+1783 U+1784 \
+    	   	   	       U+1785 U+1786 U+1787 U+1788 U+1789 \
+    	   	   	       U+178A U+178B U+178C U+178D U+178E \
+    	   	   	       U+178F U+1790 U+1791 U+1792 U+1793 \
+    	   	   	       U+1794 U+1795 U+1796 U+1797 U+1798 \
+    	   	   	       U+1799 U+179A U+179B U+179C U+179F U+17A0 U+17A1 U+17A2 \
+    	   	   	       U+179D U+179E c deprecated, but they are used in minority languages
+
++ any(c_key) > index(c_out, 1)
+
+group(ខ្មែរ) using keys
+
++ 'a' > 'oops two groups!'

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/cerr_duplicate_store.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/cerr_duplicate_store.kmn
@@ -1,0 +1,13 @@
+c Description: Verifies that kmcmplib picks up on duplicated stores with Unicode names,
+c and that the Unicode names are correctly reported in error messages in UTF-8
+
+store(&NAME) 'cerr_duplicate_store'
+store(&VERSION) '9.0'
+
+begin unicode > use(ខ្មែរ)
+
+group(ខ្មែរ) using keys
+
+store(ខ្មែរ) 'abc'
+store(ខ្មែរ) 'def'
+

--- a/developer/src/kmc-kmn/test/test-messages.ts
+++ b/developer/src/kmc-kmn/test/test-messages.ts
@@ -52,4 +52,18 @@ describe('CompilerMessages', function () {
     await testForMessage(this, ['invalid-keyboards', 'warn_invalid_vkey_in_kvks_file.kmn'], CompilerMessages.WARN_InvalidVkeyInKvksFile);
   });
 
+  // CERR_DuplicateGroup
+
+  it('should generate CERR_DuplicateGroup if the kmn contains two groups with the same name', async function() {
+    await testForMessage(this, ['invalid-keyboards', 'cerr_duplicate_group.kmn'], 0x302071); //TODO: consolidate messages from kmcmplib, CompilerMessages.CERR_DuplicateGroup
+    assert.equal(callbacks.messages[0].message, "A group with this name has already been defined. Group 'ខ្មែរ' declared on line 9");
+  });
+
+  // CERR_DuplicateStore
+
+  it('should generate CERR_DuplicateStore if the kmn contains two stores with the same name', async function() {
+    await testForMessage(this, ['invalid-keyboards', 'cerr_duplicate_store.kmn'], 0x302072); //TODO: consolidate messages from kmcmplib, CompilerMessages.CERR_DuplicateStore
+    assert.equal(callbacks.messages[0].message, "A store with this name has already been defined. Store 'ខ្មែរ' declared on line 11");
+  });
+
 });

--- a/developer/src/kmcmplib/include/kmcmplibapi.h
+++ b/developer/src/kmcmplib/include/kmcmplibapi.h
@@ -35,7 +35,9 @@ struct KMCMP_COMPILER_RESULT {
   std::string kvksFilename;
 };
 
-// TODO: parameters in UTF-8 #8887
+/**
+ * @param szText UTF-8 string
+*/
 typedef int (*kmcmp_CompilerMessageProc)(int line, uint32_t dwMsgCode, const char* szText, void* context);
 
 // parameters in UTF-8
@@ -50,7 +52,9 @@ typedef int (*kmcmp_CompilerMessageProc)(int line, uint32_t dwMsgCode, const cha
 // }
 typedef bool (*kmcmp_LoadFileProc)(const char* loadFilename, const char* baseFilename, void* buffer, int* bufferSize, void* context);
 
-// Parameters in UTF-8
+/**
+ * @param pszInfile  UTF-8 path to file.kmn
+ */
 EXTERN bool kmcmp_CompileKeyboard(
   const char* pszInfile,
   const KMCMP_COMPILER_OPTIONS& options,

--- a/developer/src/kmcmplib/src/CheckForDuplicates.cpp
+++ b/developer/src/kmcmplib/src/CheckForDuplicates.cpp
@@ -18,8 +18,7 @@ KMX_DWORD CheckForDuplicateGroup(PFILE_KEYBOARD fk, PFILE_GROUP gp) noexcept {
       continue;
     }
     if (u16icmp(gp0->szName, gp->szName) == 0) {
-      u16sprintf(ErrExtraW, 256, L" Group '%ls' declared on line %d", u16fmt(gp0->szName).c_str(), gp0->Line);
-      strcpy(ErrExtraLIB, string_from_u16string(ErrExtraW).c_str());
+      snprintf(ErrExtraLIB, ERR_EXTRA_LIB_LEN, " Group '%s' declared on line %d", string_from_u16string(gp->szName).c_str(), gp0->Line);
       return CERR_DuplicateGroup;
     }
   }
@@ -39,8 +38,7 @@ KMX_DWORD CheckForDuplicateStore(PFILE_KEYBOARD fk, PFILE_STORE sp) noexcept {
       continue;
     }
     if (u16icmp(sp0->szName, sp->szName) == 0) {
-      u16sprintf(ErrExtraW,256, L" Store '%ls' declared on line %d", u16fmt(sp0->szName).c_str(), sp0->line);
-      strcpy(ErrExtraLIB, string_from_u16string(ErrExtraW).c_str());
+      snprintf(ErrExtraLIB, ERR_EXTRA_LIB_LEN, " Store '%s' declared on line %d", string_from_u16string(sp0->szName).c_str(), sp0->line);
       return CERR_DuplicateStore;
     }
   }

--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -111,8 +111,7 @@
 
 using namespace kmcmp;
 
-  char ErrExtraLIB[ERR_EXTRA_LIB_LEN];
-  KMX_WCHAR ErrExtraW[ERR_EXTRA_W_LEN];
+  char ErrExtraLIB[ERR_EXTRA_LIB_LEN]; // utf-8
   KMX_BOOL AWarnDeprecatedCode_GLOBAL_LIB;
 
 namespace kmcmp{

--- a/developer/src/kmcmplib/src/UnreachableRules.cpp
+++ b/developer/src/kmcmplib/src/UnreachableRules.cpp
@@ -41,8 +41,7 @@ KMX_DWORD VerifyUnreachableRules(PFILE_GROUP gp) {
       if (kp->Line != k1.Line && reportedLines.count(kp->Line) == 0) {
         reportedLines.insert(kp->Line);
         kmcmp::currentLine = kp->Line;
-        u16sprintf(ErrExtraW, ERR_EXTRA_W_LEN, L" Overridden by rule on line %d", k1.Line);
-        strcpy(ErrExtraLIB, string_from_u16string(ErrExtraW).c_str());
+        snprintf(ErrExtraLIB, ERR_EXTRA_LIB_LEN, " Overridden by rule on line %d", k1.Line);
         AddWarning(CHINT_UnreachableRule);
       }
     }

--- a/developer/src/kmcmplib/src/kmcmplib.h
+++ b/developer/src/kmcmplib/src/kmcmplib.h
@@ -28,9 +28,7 @@ extern void* msgprocContext;
 
 extern KMX_BOOL AWarnDeprecatedCode_GLOBAL_LIB;
 #define ERR_EXTRA_LIB_LEN 256
-#define ERR_EXTRA_W_LEN 256
 extern char ErrExtraLIB[ERR_EXTRA_LIB_LEN];
-extern KMX_WCHAR ErrExtraW[ERR_EXTRA_W_LEN];
 KMX_BOOL AddCompileError(KMX_DWORD msg);
 
 /// Use AddWarningBool for functions that return bool or KMX_BOOL


### PR DESCRIPTION
Fixes #8887.

@keymanapp-test-bot skip