### PR TITLE
chore(linux): Fix lintian warnings

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -191,7 +191,7 @@ Depends:
   libevdev2,
   ${misc:Depends},
   ${shlibs:Depends},
-Description: Keyman system service
+Description: System service for Keyman
  Originally created in 1993 to type Lao on Windows, Keyman is now a free and
  open source keyboarding platform which allows anyone to write a keyboard
  layout for their language. Keyman is available for many platforms, including

--- a/linux/debian/keyman-system-service.manpages
+++ b/linux/debian/keyman-system-service.manpages
@@ -1,0 +1,1 @@
+linux/keyman-system-service/man/keyman-system-service.1

--- a/linux/keyman-config/km-config.bash-completion
+++ b/linux/keyman-config/km-config.bash-completion
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck disable=SC2148
+# No hashbang for bash completion scripts! They are intended to be sourced, not executed.
 
 _km-config_completions()
 {

--- a/linux/keyman-config/km-kvk2ldml.bash-completion
+++ b/linux/keyman-config/km-kvk2ldml.bash-completion
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck disable=SC2148
+# No hashbang for bash completion scripts! They are intended to be sourced, not executed.
 
 _km-kvk2ldml_completions()
 {

--- a/linux/keyman-config/km-package-get.bash-completion
+++ b/linux/keyman-config/km-package-get.bash-completion
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck disable=SC2148
+# No hashbang for bash completion scripts! They are intended to be sourced, not executed.
 
 _km-package-get_completions()
 {

--- a/linux/keyman-config/km-package-install.bash-completion
+++ b/linux/keyman-config/km-package-install.bash-completion
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck disable=SC2148
+# No hashbang for bash completion scripts! They are intended to be sourced, not executed.
 
 _km-package-install_completions()
 {

--- a/linux/keyman-config/km-package-list-installed.bash-completion
+++ b/linux/keyman-config/km-package-list-installed.bash-completion
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck disable=SC2148
+# No hashbang for bash completion scripts! They are intended to be sourced, not executed.
 
 _km-package-list-installed_completions()
 {

--- a/linux/keyman-config/km-package-uninstall.bash-completion
+++ b/linux/keyman-config/km-package-uninstall.bash-completion
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck disable=SC2148
+# No hashbang for bash completion scripts! They are intended to be sourced, not executed.
 
 _km-package-uninstall_completions()
 {

--- a/linux/keyman-system-service/man/keyman-system-service.1
+++ b/linux/keyman-system-service/man/keyman-system-service.1
@@ -1,0 +1,10 @@
+.TH KEYMAN-SYSTEM-SERVICE "1" "May 2023" "keyman-system-service" "User Commands"
+.SH NAME
+keyman-system-service \- System service for Keyman
+.SH DESCRIPTION
+\&keyman\-system\-service
+.TP
+This command should not be run directly. It will be started as a DBUS
+system service by systemd.
+.SH "SEE ALSO"
+.BR ibus-engine-keyman(1)


### PR DESCRIPTION
- add rudimentary man page for keyman-system-service
- remove hashbang for bash completion files
- reword description for keyman-system-service

This fixes these lintian warnings:
- keyman-system-service: description-is-pkg-name Keyman system service
- keyman: bash-completion-with-hashbang /usr/bin/env bash
        [usr/share/bash-completion/completions/km-config:1]
- keyman-system-service: no-manual-page
        [usr/libexec/keyman-system-service]

@keymanapp-test-bot skip