### PR TITLE
fix(web): forgot to ensure that the design-iframe also fully loads 🧩

### DIFF
--- a/web/src/test/auto/dom/cases/attachment/pageContextAttachment.js
+++ b/web/src/test/auto/dom/cases/attachment/pageContextAttachment.js
@@ -268,6 +268,7 @@ describe('KMW element-attachment logic', function () {
 
         // Note:  iframes require additional time to resolve.
         await promiseForIframeLoad(document.getElementById('iframe'));
+        await promiseForIframeLoad(document.getElementById('design-iframe'));
 
         // Give the design-mode iframe a bit of time to set itself up properly.
         // Note: it is thus important that whatever sends the `install` command has also
@@ -495,6 +496,7 @@ describe('KMW element-attachment logic', function () {
 
         // Note:  iframes require additional time to resolve.
         await promiseForIframeLoad(document.getElementById('iframe'));
+        await promiseForIframeLoad(document.getElementById('design-iframe'));
 
         // Our mutation observers delay slightly here to ensure that any doc-internal handlers
         // have a chance to resolve before we attach.  Currently: 10ms.
@@ -639,6 +641,7 @@ describe('KMW element-attachment logic', function () {
 
       // Note:  iframes require additional time to resolve.
       await promiseForIframeLoad(document.getElementById('iframe'));
+      await promiseForIframeLoad(document.getElementById('design-iframe'));
 
       await timedPromise(20); // for the design-iframe to set itself into design-mode.
 

--- a/web/src/test/auto/dom/cases/browser/contextManager.js
+++ b/web/src/test/auto/dom/cases/browser/contextManager.js
@@ -149,6 +149,7 @@ describe('app/browser:  ContextManager', function () {
 
     // Note:  iframes require additional time to resolve.
     await promiseForIframeLoad(document.getElementById('iframe'));
+    await promiseForIframeLoad(document.getElementById('design-iframe'));
 
     // Give the design-mode iframe a bit of time to set itself up properly.
     // Note: it is thus important that whatever sends the `install` command has also


### PR DESCRIPTION
Fixes the DOM-oriented unit test issues noted in this comment: https://github.com/keymanapp/keyman/pull/8891#issuecomment-1577871611

So... it was a pretty simple problem- I'd just neglected to ensure that _both_ iframes completed loading before proceeding.

@keymanapp-test-bot skip