### PR TITLE
fix(android/engine): Re-enable KMManager tests

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -29,6 +29,7 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Color;
@@ -223,8 +224,11 @@ final class KMKeyboard extends WebView {
 
     getSettings().setUseWideViewPort(true);
     getSettings().setLoadWithOverviewMode(true);
-    setWebContentsDebuggingEnabled(true);
-
+    if (0 != (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {
+      // Enable debugging of WebView via adb. Not used during unit tests
+      // Refer: https://developer.chrome.com/docs/devtools/remote-debugging/webviews/#configure_webviews_for_debugging
+      setWebContentsDebuggingEnabled(true);
+    }
     setWebChromeClient(new WebChromeClient() {
       public boolean onConsoleMessage(ConsoleMessage cm) {
         String msg = KMString.format("KMW JS Log: Line %d, %s:%s", cm.lineNumber(), cm.sourceId(), cm.message());

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -624,8 +624,11 @@ public final class KMManager {
       return;
     }
 
-    RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
-    keyboard.setLayoutParams(params);
+    if (!isTestMode()) {
+      // Keyboard layout not needed in unit tests. #5125
+      RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
+      keyboard.setLayoutParams(params);
+    }
     keyboard.setVerticalScrollBarEnabled(false);
     keyboard.setHorizontalScrollBarEnabled(false);
     keyboard.setWebViewClient(webViewClient);

--- a/android/KMEA/app/src/test/java/com/keyman/engine/KMManagerTest.java
+++ b/android/KMEA/app/src/test/java/com/keyman/engine/KMManagerTest.java
@@ -29,13 +29,14 @@ public class KMManagerTest {
   private static final String OLD_KEYBOARDS_LIST = "old_keyboards_list.dat";
   ArrayList<HashMap<String, String>> dat_list;
 
-  @Before
-  public void loadOldKeyboardsList() throws FileNotFoundException {
+  // For some keyboard list tests, load an existing keyboard list.
+  // Can't use @Before because context is null before running tests.
+  public void loadOldKeyboardsList() {
     KMManager.initialize(ApplicationProvider.getApplicationContext(), KMManager.KeyboardType.KEYBOARD_TYPE_INAPP);
 
     File keyboards_dat = new File(TEST_RESOURCE_ROOT, OLD_KEYBOARDS_LIST);
     if (keyboards_dat == null || !keyboards_dat.exists()) {
-      throw new FileNotFoundException();
+      Assert.fail(TAG + ": keyboards list not found");
     }
     try {
       ObjectInputStream inputStream = new ObjectInputStream(new FileInputStream(keyboards_dat));
@@ -46,7 +47,6 @@ public class KMManagerTest {
     }
   }
 
-  @Ignore("Investigate ResourcesNotFoundException")
   @Test
   public void test_getTier() {
     String versionName = "14.0.248-alpha";
@@ -109,9 +109,9 @@ public class KMManagerTest {
   /*
   * This test is manually run to edit/regenerate the old keyboards list
   */
-  @Ignore
   @Test
   public void create_newKeyboardsList() {
+    loadOldKeyboardsList();
     dat_list = new ArrayList<HashMap<String, String>>();
 
     HashMap<String, String> usInfo = new HashMap<String, String>();
@@ -181,9 +181,9 @@ public class KMManagerTest {
     }
   }
 
-  @Ignore("Investigate ResourcesNotFoundException")
   @Test
   public void test_updateOldKeyboardsList() {
+    loadOldKeyboardsList();
     Assert.assertNotNull(dat_list);
 
     // Verify old keyboards list contains deprecated keyboards


### PR DESCRIPTION
Addresses some of #5125 by re-enabling the disabled KMManager tests.

I still haven't seen how Robolectric accesses resource values from the merged AndroidManifest.xml file, so the other tests remain TODO's.

## User Testing

**Setup** - Install the PR build of Keyman for Android on an Android emualtor/device

* **TEST_KEYMAN** - Verifies Keyman still functions
1. Launch Keyman for Android in portrait orientation and dismiss the Get Started" menu
2. Verify the in-app OSK is displayed with the default sil_euro_latin keyboard


