### PR TITLE
fix(linux): Fix disabling of buttons

### DIFF
--- a/linux/keyman-config/keyman_config/handle_install.py
+++ b/linux/keyman-config/keyman_config/handle_install.py
@@ -22,9 +22,9 @@ def download_and_install_package(url):
     bcp47 = _extract_bcp47(parsedUrl.query)
 
     if parsedUrl.scheme == 'keyman':
-        logging.info("downloading " + url)
+        logging.info(f"downloading {url}")
         if not url.startswith('keyman://download/keyboard/'):
-            logging.error("Don't know what to do with URL " + url)
+            logging.error(f"Don't know what to do with URL {url}")
             return
 
         packageId = parsedUrl.path[len('/keyboard/'):]
@@ -33,22 +33,22 @@ def download_and_install_package(url):
             return
 
         downloadFile = os.path.join(get_download_folder(), packageId)
-        downloadUrl = KeymanComUrl + '/go/package/download/' + packageId + '?platform=linux&tier=' + __tier__
+        downloadUrl = f'{KeymanComUrl}/go/package/download/{packageId}?platform=linux&tier={__tier__}'
         packageFile = download_kmp_file(downloadUrl, downloadFile)
         if packageFile is None:
             return
-    elif parsedUrl.scheme == '' or parsedUrl.scheme == 'file':
+    elif parsedUrl.scheme in ['', 'file']:
         packageFile = parsedUrl.path
     else:
-        logging.error("Invalid URL: " + url)
+        logging.error(f"Invalid URL: {url}")
         return
 
     if not is_zipfile(packageFile):
-        logging.error("Not a valid KMP package: " + url)
+        logging.error(f"Not a valid KMP package: {url}")
         return
 
     if packageFile and not _install_package(packageFile, bcp47):
-        logging.error("Can't find file " + url)
+        logging.error(f"Can't find file {url}")
 
 
 def _extract_bcp47(query):

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -64,11 +64,10 @@ class InstallKmp():
             # Check for write access of keyman dir to be able to create subdir
             if not os.access(keyman_dir, os.X_OK | os.W_OK):
                 raise InstallError(InstallStatus.Abort, error_message)
-        else:
-            # Check for write access of basedir and create keyman subdir if we can
-            if not os.access(basedir, os.X_OK | os.W_OK):
-                raise InstallError(InstallStatus.Abort, error_message)
+        elif os.access(basedir, os.X_OK | os.W_OK):
             os.mkdir(keyman_dir)
+        else:
+            raise InstallError(InstallStatus.Abort, error_message)
 
     def _extract_package_id(self, inputfile):
         packageID, ext = os.path.splitext(os.path.basename(inputfile))
@@ -122,18 +121,10 @@ class InstallKmp():
 
         info, system, options, keyboards, files = get_metadata(self.packageDir)
 
-        if system:
-            fileVersion = secure_lookup(system, 'fileVersion')
-            if not fileVersion:
-                fileVersion = '7.0'
-            if parse_version(fileVersion) > parse_version(__version__):
-                logging.error("install_kmp.py: error: %s requires a newer version of Keyman (%s)",
-                              inputfile, fileVersion)
-                rmtree(self.packageDir)
-                message = _("{packageFile} requires Keyman {keymanVersion} or higher").format(
-                  packageFile=inputfile, keymanVersion=fileVersion)
-                raise InstallError(InstallStatus.Abort, message)
+        self._check_version(inputfile, system)
+
         if keyboards:
+            # sourcery skip: extract-method
             logging.info("Installing %s", secure_lookup(info, 'name', 'description'))
             process_keyboard_data(self.packageID, self.packageDir)
             for kb in keyboards:
@@ -143,47 +134,7 @@ class InstallKmp():
             if files is None:
                 return self.install_keyboards(keyboards, self.packageDir, language)
 
-            for f in files:
-                fpath = os.path.join(self.packageDir, f['name'])
-                ftype = f['type']
-
-                if ftype == KMFileTypes.KM_DOC or ftype == KMFileTypes.KM_IMAGE:
-                    # Special handling of doc and images to hard link them into doc dir
-                    logging.info("Installing %s as documentation", f['name'])
-                    if self._safeMakeDirs(self.kmpdocdir):
-                        kmpdocpath = os.path.join(self.kmpdocdir, f['name'])
-                        self._safeLinkFile(fpath, kmpdocpath)
-                elif ftype == KMFileTypes.KM_FONT:
-                    # Special handling of font to hard link it into font dir
-                    logging.info("Installing %s as font", f['name'])
-                    if self._safeMakeDirs(self.kmpfontdir):
-                        fontpath = os.path.join(self.kmpfontdir, f['name'])
-                        self._safeLinkFile(fpath, fontpath)
-                elif ftype == KMFileTypes.KM_OSK:
-                    # Special handling to convert kvk into LDML
-                    logging.info("Converting %s to LDML and installing both as as keyman file",
-                                 f['name'])
-                    ldml = convert_kvk_to_ldml(fpath)
-                    name, ext = os.path.splitext(f['name'])
-                    ldmlfile = os.path.join(self.packageDir, name + ".ldml")
-                    output_ldml(ldmlfile, ldml)
-                elif ftype == KMFileTypes.KM_ICON:
-                    # Special handling of icon to convert to PNG
-                    logging.info("Converting %s to PNG and installing both as keyman files",
-                                 f['name'])
-                    checkandsaveico(fpath)
-                elif ftype == KMFileTypes.KM_SOURCE:
-                    # TODO for the moment just leave it for ibus-keyman to ignore if it doesn't load
-                    pass
-                elif ftype == KMFileTypes.KM_KMX:
-                    # Sanitize keyboard filename if not lower case
-                    kmx_id, ext = os.path.splitext(os.path.basename(f['name']))
-                    for kb in keyboards:
-                        if kmx_id.lower() == kb['id'] and kmx_id != kb['id']:
-                            os.rename(os.path.join(self.packageDir, f['name']),
-                                      os.path.join(self.packageDir, kb['id'] + '.kmx'))
-                            fpath = os.path.join(self.packageDir, kb['id'] + '.kmx')
-                    extractico(fpath)
+            self._install_files(keyboards, files)
 
             return self.install_keyboards(keyboards, self.packageDir, language)
         else:
@@ -195,6 +146,64 @@ class InstallKmp():
             message = _("No kmp.json or kmp.inf found in {packageFile}").format(
               packageFile=inputfile)
             raise InstallError(InstallStatus.Abort, message)
+
+    def _check_version(self, inputfile, system):
+        if not system:
+            return
+
+        fileVersion = secure_lookup(system, 'fileVersion')
+        if not fileVersion:
+            fileVersion = '7.0'
+        if parse_version(fileVersion) > parse_version(__version__):
+            logging.error("install_kmp.py: error: %s requires a newer version of Keyman (%s)",
+                          inputfile, fileVersion)
+            rmtree(self.packageDir)
+            message = _("{packageFile} requires Keyman {keymanVersion} or higher").format(
+              packageFile=inputfile, keymanVersion=fileVersion)
+            raise InstallError(InstallStatus.Abort, message)
+
+    def _install_files(self, keyboards, files):
+        for f in files:
+            fpath = os.path.join(self.packageDir, f['name'])
+            ftype = f['type']
+
+            if ftype in [KMFileTypes.KM_DOC, KMFileTypes.KM_IMAGE]:
+                # Special handling of doc and images to hard link them into doc dir
+                logging.info("Installing %s as documentation", f['name'])
+                if self._safeMakeDirs(self.kmpdocdir):
+                    kmpdocpath = os.path.join(self.kmpdocdir, f['name'])
+                    self._safeLinkFile(fpath, kmpdocpath)
+            elif ftype == KMFileTypes.KM_FONT:
+                # Special handling of font to hard link it into font dir
+                logging.info("Installing %s as font", f['name'])
+                if self._safeMakeDirs(self.kmpfontdir):
+                    fontpath = os.path.join(self.kmpfontdir, f['name'])
+                    self._safeLinkFile(fpath, fontpath)
+            elif ftype == KMFileTypes.KM_OSK:
+                # Special handling to convert kvk into LDML
+                logging.info("Converting %s to LDML and installing both as as keyman file",
+                             f['name'])
+                ldml = convert_kvk_to_ldml(fpath)
+                name, ext = os.path.splitext(f['name'])
+                ldmlfile = os.path.join(self.packageDir, f"{name}.ldml")
+                output_ldml(ldmlfile, ldml)
+            elif ftype == KMFileTypes.KM_ICON:
+                # Special handling of icon to convert to PNG
+                logging.info("Converting %s to PNG and installing both as keyman files",
+                             f['name'])
+                checkandsaveico(fpath)
+            elif ftype == KMFileTypes.KM_SOURCE:
+                # TODO for the moment just leave it for ibus-keyman to ignore if it doesn't load
+                pass
+            elif ftype == KMFileTypes.KM_KMX:
+                # Sanitize keyboard filename if not lower case
+                kmx_id, ext = os.path.splitext(os.path.basename(f['name']))
+                for kb in keyboards:
+                    if kmx_id.lower() == kb['id'] and kmx_id != kb['id']:
+                        os.rename(os.path.join(self.packageDir, f['name']),
+                                  os.path.join(self.packageDir, kb['id'] + '.kmx'))
+                        fpath = os.path.join(self.packageDir, kb['id'] + '.kmx')
+                extractico(fpath)
 
     def _safeMakeDirs(self, dir):
         if not os.path.isdir(dir):
@@ -231,9 +240,9 @@ class InstallKmp():
 
         language = CanonicalLanguageCodeUtils.findBestTag(language, False, True)
         for supportedLanguage in supportedLanguages:
-            id = CanonicalLanguageCodeUtils.findBestTag(supportedLanguage['id'], False, True)
-            if id == language:
-                return id
+            tag = CanonicalLanguageCodeUtils.findBestTag(supportedLanguage['id'], False, True)
+            if tag == language:
+                return tag
         return None
 
     def install_keyboards(self, keyboards, packageDir, language=None):
@@ -249,6 +258,7 @@ class InstallKmp():
             return self._install_keyboards_to_ibus(keyboards, packageDir, language)
 
     def _install_keyboards_to_ibus(self, keyboards, packageDir, language=None):
+        # sourcery skip: split-or-ifs
         bus = get_ibus_bus()
         if bus or os.environ.get('SUDO_USER'):
             # install all kmx for first lang not just packageID
@@ -285,29 +295,25 @@ def extract_kmp(kmpfile, directory):
         with zipfile.ZipFile(kmpfile, "r") as zip_ref:
             zip_ref.extractall(directory)
     except zipfile.BadZipFile as e:
-        raise InstallError(InstallStatus.Abort, e)
+        raise InstallError(InstallStatus.Abort, e) from e
 
 
 def process_keyboard_data(keyboardID, packageDir) -> None:
-    kbdata = get_keyboard_data(keyboardID)
-    if kbdata:
-        if not os.path.isdir(packageDir) and os.access(os.path.join(packageDir, os.pardir), os.X_OK | os.W_OK):
-            try:
-                os.makedirs(packageDir)
-            except Exception as e:
-                logging.warning('Exception %s creating %s %s', type(e), packageDir, e.args)
+    if not (kbdata := get_keyboard_data(keyboardID)):
+        return
+    if not os.path.isdir(packageDir) and os.access(os.path.join(packageDir, os.pardir), os.X_OK | os.W_OK):
+        try:
+            os.makedirs(packageDir)
+        except Exception as e:
+            logging.warning('Exception %s creating %s %s', type(e), packageDir, e.args)
 
-        if os.access(packageDir, os.X_OK | os.W_OK):
-            try:
-                with open(os.path.join(packageDir, keyboardID + '.json'), 'w') as outfile:
-                    json.dump(kbdata, outfile)
-                    logging.info("Installing api data file %s.json as keyman file", keyboardID)
-            except Exception as e:
-                logging.warning('Exception %s writing %s/%s.json %s', type(e), packageDir, keyboardID, e.args)
-    # else:
-    # 	message = "install_kmp.py: error: cannot download keyboard data so not installing."
-    # 	rmtree(kbdir)
-    # 	raise InstallError(InstallStatus.Abort, message)
+    if os.access(packageDir, os.X_OK | os.W_OK):
+        try:
+            with open(os.path.join(packageDir, f'{keyboardID}.json'), 'w') as outfile:
+                json.dump(kbdata, outfile)
+                logging.info("Installing api data file %s.json as keyman file", keyboardID)
+        except Exception as e:
+            logging.warning('Exception %s writing %s/%s.json %s', type(e), packageDir, keyboardID, e.args)
 
 
 def install_kmp(inputfile, sharedarea=False, language=None):

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -78,7 +78,7 @@ class InstallKmpWindow(Gtk.Dialog):
             info, system, options, keyboards, files = get_metadata(tmpdirname)
             if not keyboards:
                 # Likely not a keyboard .kmp file
-                logging.info("%s is not a Keyman keyboard package" % kmpfile)
+                logging.info(f"{kmpfile} is not a Keyman keyboard package")
                 dialog = Gtk.MessageDialog(viewkmp, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, _(
                   "The file '{kmpfile}' is not a Keyman keyboard package!").format(kmpfile=kmpfile))
                 dialog.run()
@@ -98,8 +98,8 @@ class InstallKmpWindow(Gtk.Dialog):
                       Gtk.ButtonsType.YES_NO, _("Keyboard is installed already"))
                     dialog.format_secondary_text(
                       _("The {name} keyboard is already installed at version {version}. "
-                        "Do you want to uninstall then reinstall it?")
-                        .format(name=self.kbname, version=installed_kmp_ver))
+                        "Do you want to uninstall then reinstall it?").format(
+                          name=self.kbname, version=installed_kmp_ver))
                     response = dialog.run()
                     dialog.destroy()
                     if response == Gtk.ResponseType.YES:
@@ -132,10 +132,8 @@ class InstallKmpWindow(Gtk.Dialog):
                                 logging.debug("QUESTION dialog closed by clicking NO button")
                                 self.checkcontinue = False
                                 return
-                    except:  # noqa: E722
+                    except Exception:  # noqa: E722
                         logging.warning("Exception uninstalling an old kmp, continuing")
-                        pass
-
             image = Gtk.Image()
             if secure_lookup(options, 'graphicFile'):
                 image.set_from_file(os.path.join(tmpdirname, options['graphicFile']))
@@ -168,8 +166,7 @@ class InstallKmpWindow(Gtk.Dialog):
             label.set_selectable(True)
             grid.attach_next_to(label, label1, Gtk.PositionType.RIGHT, 1, 1)
 
-            fonts = get_fonts(files)
-            if fonts:
+            if fonts := get_fonts(files):
                 label2 = Gtk.Label()
                 # Fonts are optional
                 label2.set_text(_("Fonts:   "))
@@ -198,15 +195,13 @@ class InstallKmpWindow(Gtk.Dialog):
             grid.attach_next_to(label3, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
             prevlabel = label3
             label = Gtk.Label()
-            description = secure_lookup(info, 'version', 'description')
-            if description:
+            if description := secure_lookup(info, 'version', 'description'):
                 label.set_text(description)
             label.set_halign(Gtk.Align.START)
             label.set_selectable(True)
             grid.attach_next_to(label, label3, Gtk.PositionType.RIGHT, 1, 1)
 
-            author = secure_lookup(info, 'author')
-            if author:
+            if author := secure_lookup(info, 'author'):
                 author = author
                 label4 = Gtk.Label()
                 label4.set_text(_("Author:   "))
@@ -216,8 +211,7 @@ class InstallKmpWindow(Gtk.Dialog):
                 label = Gtk.Label()
                 if secure_lookup(author, 'url') and secure_lookup(author, 'description'):
                     label.set_markup(
-                      "<a href=\"" + author['url'] + "\" title=\"" +
-                      author['url'] + "\">" + author['description'] + "</a>")
+                      f"<a href=\"{author['url']}\" title=\"{author['url']}\">{author['description']}</a>")
                 elif secure_lookup(author, 'description'):
                     label.set_text(author['description'])
                 label.set_halign(Gtk.Align.START)
@@ -232,8 +226,9 @@ class InstallKmpWindow(Gtk.Dialog):
                 grid.attach_next_to(label5, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
                 prevlabel = label5
                 label = Gtk.Label()
-                website_description = secure_lookup(info, 'website', 'description')
-                if website_description:
+                if website_description := secure_lookup(
+                    info, 'website', 'description'
+                ):
                     label.set_markup(
                       "<a href=\"" + website_description + "\">" + website_description + "</a>")
                 label.set_halign(Gtk.Align.START)
@@ -246,8 +241,9 @@ class InstallKmpWindow(Gtk.Dialog):
                 label6.set_halign(Gtk.Align.END)
                 grid.attach_next_to(label6, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
                 label = Gtk.Label()
-                copyright_description = secure_lookup(info, 'copyright', 'description')
-                if copyright_description:
+                if copyright_description := secure_lookup(
+                    info, 'copyright', 'description'
+                ):
                     label.set_text(copyright_description)
                 label.set_halign(Gtk.Align.START)
                 label.set_selectable(True)
@@ -257,8 +253,7 @@ class InstallKmpWindow(Gtk.Dialog):
             webview = WebKit2.WebView()
             webview.connect("decide-policy", self.doc_policy)
 
-            readmeFile = secure_lookup(options, 'readmeFile')
-            if readmeFile:
+            if readmeFile := secure_lookup(options, 'readmeFile'):
                 self.readme = readmeFile
             else:
                 self.readme = "noreadme"
@@ -280,11 +275,11 @@ class InstallKmpWindow(Gtk.Dialog):
                         self.notebook.set_tab_pos(Gtk.PositionType.BOTTOM)
                         mainhbox.pack_start(self.notebook, True, True, 0)
                         self.notebook.append_page(
-                            self.page1,
-                            Gtk.Label(_('Details')))
+                          self.page1,
+                          Gtk.Label(_('Details')))
                         self.notebook.append_page(
-                            self.page2,
-                            Gtk.Label(_('README')))
+                          self.page2,
+                          Gtk.Label(_('README')))
                 except UnicodeDecodeError:
                     readme_added = False
             else:
@@ -311,9 +306,7 @@ class InstallKmpWindow(Gtk.Dialog):
         self.show_all()
 
     def run(self):
-        if self.checkcontinue:
-            return Gtk.Dialog.run(self)
-        return Gtk.ResponseType.CANCEL
+        return Gtk.Dialog.run(self) if self.checkcontinue else Gtk.ResponseType.CANCEL
 
     def doc_policy(self, web_view, decision, decision_type):
         logging.info("Checking policy")
@@ -333,8 +326,7 @@ class InstallKmpWindow(Gtk.Dialog):
     def on_install_clicked(self, button):
         logging.info("Installing keyboard")
         try:
-            result = install_kmp(self.kmpfile, language=self.language)
-            if result:
+            if result := install_kmp(self.kmpfile, language=self.language):
                 # If install_kmp returns a string, it is an instruction for the end user,
                 # because for fcitx they will need to take extra steps to complete
                 # installation themselves.
@@ -389,23 +381,23 @@ class InstallKmpWindow(Gtk.Dialog):
         dialog.destroy()
 
 
+def _log_error(arg):
+    logging.error(arg)
+    logging.error("install_window.py <kmpfile>")
+    sys.exit(2)
+
+
 def main(argv):
-    if len(sys.argv) != 2:
+    if len(argv) != 2:
         logging.error("install_window.py <kmpfile>")
         sys.exit(2)
 
-    name, ext = os.path.splitext(sys.argv[1])
+    _, ext = os.path.splitext(argv[1])
     if ext != ".kmp":
-        logging.error("install_window.py Input file", sys.argv[1], "is not a kmp file.")
-        logging.error("install_window.py <kmpfile>")
-        sys.exit(2)
-
-    if not os.path.isfile(sys.argv[1]):
-        logging.error("install_window.py Keyman kmp file", sys.argv[1], "not found.")
-        logging.error("install_window.py <kmpfile>")
-        sys.exit(2)
-
-    w = InstallKmpWindow(sys.argv[1])
+        _log_error(f'install_window.py Input file {argv[1]} is not a kmp file.')
+    if not os.path.isfile(argv[1]):
+        _log_error(f'install_window.py Keyman kmp file {argv[1]} not found.')
+    w = InstallKmpWindow(argv[1])
     w.run()
     w.destroy()
 

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -257,10 +257,10 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         return vbox
 
     def addlistitems(self, installed_kmp, store, install_area):
+        bmppng = ".bmp.png"  # Icon file extension
+
         for kmp in sorted(installed_kmp):
             kmpdata = installed_kmp[kmp]
-            bmppng = ".bmp.png"  # Icon file extension
-
             path = get_keyboard_dir(install_area, kmpdata['packageID'])
 
             welcome_file = os.path.join(path, "welcome.htm")
@@ -280,7 +280,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
                 icofile = GdkPixbuf.Pixbuf.new_from_file_at_size(icofile_name, 16, 16)
             except GError:
                 _, value, _ = sys.exc_info()
-                logging.info("Error reading icon file %s: %s" % (icofile_name, value.message))
+                logging.info(f"Error reading icon file {icofile_name}: {value.message}")
                 icofile = None
 
             store.append([
@@ -320,6 +320,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
     def on_tree_selection_changed(self, selection):
         model, treeiter = selection.get_selected()
         if treeiter is not None:
+            # sourcery skip: extract-method
             self.uninstall_button.set_tooltip_text(
                 _("Uninstall keyboard {package}").format(package=model[treeiter][1]))
             self.help_button.set_tooltip_text(
@@ -363,7 +364,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             welcome_file = model[treeiter][5]
             if welcome_file and os.path.isfile(welcome_file):
                 uri_path = pathlib.Path(welcome_file).as_uri()
-                logging.info("opening " + uri_path)
+                logging.info(f"opening {uri_path}")
                 w = WelcomeView(self, uri_path, model[treeiter][3])
                 w.run()
                 w.destroy()
@@ -376,8 +377,9 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             logging.info("Open options.htm for %s if available", model[treeiter][1])
             options_file = model[treeiter][6]
             if options_file and os.path.isfile(options_file):
+                # sourcery skip: extract-method
                 uri_path = pathlib.Path(options_file).as_uri()
-                logging.info("opening " + uri_path)
+                logging.info(f"opening {uri_path}")
                 # TODO: Determine keyboardID
                 info = {"optionurl": uri_path, "packageID": model[treeiter][3], "keyboardID": model[treeiter][3]}
                 w = OptionsView(info)
@@ -389,7 +391,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
     def on_uninstall_clicked(self, button):
         model, treeiter = self.tree.get_selection().get_selected()
         if treeiter is not None:
-            logging.info("Uninstall keyboard " + model[treeiter][3] + "?")
+            logging.info(f"Uninstall keyboard {model[treeiter][3]}?")
             dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.QUESTION, Gtk.ButtonsType.YES_NO,
                                        _("Uninstall keyboard package?"))
             msg = _("Are you sure that you want to uninstall the {keyboard} keyboard?").format(
@@ -398,8 +400,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             kmpjson = os.path.join(kbdir, "kmp.json")
             if os.path.isfile(kmpjson):
                 info, system, options, keyboards, files = parsemetadata(kmpjson, False)
-                fonts = get_fonts(files)
-                if fonts:
+                if fonts := get_fonts(files):
                     # Fonts are optional
                     fontlist = ""
                     for font in fonts:
@@ -416,10 +417,10 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             response = dialog.run()
             dialog.destroy()
             if response == Gtk.ResponseType.YES:
-                logging.info("Uninstalling keyboard" + model[treeiter][1])
+                logging.info(f"Uninstalling keyboard{model[treeiter][1]}")
                 # can only uninstall with the gui from user area
                 msg = uninstall_kmp(model[treeiter][3])
-                if not msg == '':
+                if msg != '':
                     md = Gtk.MessageDialog(self, 0, Gtk.MessageType.ERROR,
                             Gtk.ButtonsType.OK, _("Uninstalling keyboard failed.\n\nError message: ") + msg)
                     md.run()
@@ -427,16 +428,18 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
                 logging.info("need to restart window after uninstalling a keyboard")
                 self.restart()
             elif response == Gtk.ResponseType.NO:
-                logging.info("Not uninstalling keyboard " + model[treeiter][1])
+                logging.info(f"Not uninstalling keyboard {model[treeiter][1]}")
 
     def on_about_clicked(self, button):
         model, treeiter = self.tree.get_selection().get_selected()
         if treeiter is not None and model[treeiter] is not None:
-            logging.info("Show keyboard details of " + model[treeiter][1])
+            logging.info(f"Show keyboard details of {model[treeiter][1]}")
             areapath = get_keyman_dir(model[treeiter][4])
             kmp = {
-                "name": model[treeiter][1], "version": model[treeiter][2],
-                "packageID": model[treeiter][3], "areapath": areapath
+              "name": model[treeiter][1],
+              "version": model[treeiter][2],
+              "packageID": model[treeiter][3],
+              "areapath": areapath
             }
             w = KeyboardDetailsView(self, kmp)
             w.run()

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+from enum import IntEnum
 import logging
 import os
 import pathlib
@@ -28,6 +29,33 @@ from keyman_config.options import OptionsView
 from keyman_config.sentry_handling import SentryErrorHandling
 from keyman_config.uninstall_kmp import uninstall_kmp
 from keyman_config.welcome import WelcomeView
+
+
+class Model(IntEnum):
+    # Keep in sync with _add_model() below
+    ICON = 0
+    NAME = 1
+    VERSION = 2
+    PACKAGEID = 3
+    LOCATION = 4
+    AREA = 5
+    INSTALLPATH = 6
+    WELCOMEFILE = 7
+    OPTIONSFILE = 8
+
+
+def _add_model():
+    return Gtk.ListStore(
+      # Keep in sync with Model above
+      GdkPixbuf.Pixbuf,  # icon
+      str,    # name
+      str,    # version
+      str,    # packageID
+      int,    # enum InstallLocation (KmpArea is GObject version)
+      str,    # InstallLocation area
+      str,    # Tooltip with InstallLocation path
+      str,    # path to welcome file if it exists or None
+      str)    # path to options file if it exists or None
 
 
 class ViewInstalledWindowBase(Gtk.Window):
@@ -107,6 +135,12 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
 
         self.sentry = SentryErrorHandling()
 
+        outmostVBox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        outmostVBox.pack_start(self._add_stack_sidebar(), True, True, 0)
+        outmostVBox.pack_end(self._add_app_buttons(), False, True, 12)
+        self.add(outmostVBox)
+
+    def _add_stack_sidebar(self):
         outerHbox = Gtk.HBox()
         sidebar = Gtk.StackSidebar()
         stack = Gtk.Stack()
@@ -118,12 +152,11 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         stack.set_vexpand(True)
         sidebar.set_stack(stack)
 
-        stack.add_titled(self.add_keyboard_layouts_widget(), "KeyboardLayouts", _("Keyboard Layouts"))
-        stack.add_titled(self.add_options_widget(), "Options", _("Options"))
+        stack.add_titled(self._add_keyboard_layouts_widget(), "KeyboardLayouts", _("Keyboard Layouts"))
+        stack.add_titled(self._add_options_widget(), "Options", _("Options"))
+        return outerHbox
 
-        outmostVBox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        outmostVBox.pack_start(outerHbox, True, True, 0)
-
+    def _add_app_buttons(self):
         bbox_bottom = Gtk.ButtonBox(spacing=12, orientation=Gtk.Orientation.HORIZONTAL)
         bbox_bottom.set_layout(Gtk.ButtonBoxStyle.START)
 
@@ -151,25 +184,15 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
 
         bbox_hbox = Gtk.HBox(spacing=12)
         bbox_hbox.pack_start(bbox_bottom, True, True, 12)
-        outmostVBox.pack_end(bbox_hbox, False, True, 12)
-        self.add(outmostVBox)
+        return bbox_hbox
 
-    def add_keyboard_layouts_widget(self):
+    def _add_keyboard_layouts_widget(self):
         hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
         scrolledWindow = Gtk.ScrolledWindow()
         hbox.pack_start(scrolledWindow, True, True, 0)
 
-        self.store = Gtk.ListStore(
-            GdkPixbuf.Pixbuf,  # icon
-            str,    # name
-            str,    # version
-            str,    # packageID
-            int,    # enum InstallLocation (KmpArea is GObject version)
-            str,    # InstallLocation area
-            str,    # Tooltip with InstallLocation path
-            str,    # path to welcome file if it exists or None
-            str)    # path to options file if it exists or None
+        self.store = _add_model()
 
         self.refresh_installed_kmp()
 
@@ -177,26 +200,31 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
 
         renderer = Gtk.CellRendererPixbuf()
         # i18n: column header in table displaying installed keyboards
-        column = Gtk.TreeViewColumn(_("Icon"), renderer, pixbuf=0)
+        column = Gtk.TreeViewColumn(_("Icon"), renderer, pixbuf=Model.ICON)
         self.tree.append_column(column)
         renderer = Gtk.CellRendererText()
         # i18n: column header in table displaying installed keyboards
-        column = Gtk.TreeViewColumn(_("Name"), renderer, text=1)
+        column = Gtk.TreeViewColumn(_("Name"), renderer, text=Model.NAME)
         self.tree.append_column(column)
         # i18n: column header in table displaying installed keyboards
-        column = Gtk.TreeViewColumn(_("Version"), renderer, text=2)
+        column = Gtk.TreeViewColumn(_("Version"), renderer, text=Model.VERSION)
         self.tree.append_column(column)
         # i18n: column header in table displaying installed keyboards
-        column = Gtk.TreeViewColumn(_("Area"), renderer, text=5)
+        column = Gtk.TreeViewColumn(_("Area"), renderer, text=Model.AREA)
         self.tree.append_column(column)
 
-        self.tree.set_tooltip_column(column=6)
+        self.tree.set_tooltip_column(column=Model.INSTALLPATH)
 
         select = self.tree.get_selection()
         select.connect("changed", self.on_tree_selection_changed)
 
         scrolledWindow.add(self.tree)
 
+        hbox.pack_start(self._add_keyboard_buttons(), False, False, 12)
+
+        return hbox
+
+    def _add_keyboard_buttons(self):
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
 
         bbox_top = Gtk.ButtonBox(spacing=12, orientation=Gtk.Orientation.VERTICAL)
@@ -227,11 +255,9 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
         bbox_top.add(self.options_button)
 
         vbox.pack_start(bbox_top, False, False, 12)
-        hbox.pack_start(vbox, False, False, 12)
+        return vbox
 
-        return hbox
-
-    def add_options_widget(self):
+    def _add_options_widget(self):
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         label = Gtk.Label(_("General"))
         label.set_padding(5, 5)
@@ -256,7 +282,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
 
         return vbox
 
-    def addlistitems(self, installed_kmp, store, install_area):
+    def _addlistitems(self, installed_kmp, store, install_area):
         bmppng = ".bmp.png"  # Icon file extension
 
         for kmp in sorted(installed_kmp):
@@ -284,15 +310,15 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
                 icofile = None
 
             store.append([
-                icofile,
-                kmpdata['name'],
-                kmpdata['version'],
-                kmpdata['packageID'],
-                install_area,
-                get_install_area_string(install_area),
-                path.replace(os.path.expanduser('~'), '~'),
-                welcome_file,
-                options_file])
+              icofile,
+              kmpdata['name'],
+              kmpdata['version'],
+              kmpdata['packageID'],
+              install_area,
+              get_install_area_string(install_area),
+              path.replace(os.path.expanduser('~'), '~'),
+              welcome_file,
+              options_file])
 
     def refresh_installed_kmp(self):
         logging.debug("Refreshing listview")
@@ -303,47 +329,47 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             kmpdata = user_kmp[kmp]
             if kmpdata["has_kbjson"] is False:
                 self.incomplete_kmp.append(kmpdata)
-        self.addlistitems(user_kmp, self.store, InstallLocation.User)
+        self._addlistitems(user_kmp, self.store, InstallLocation.User)
         shared_kmp = get_installed_kmp(InstallLocation.Shared)
         for kmp in sorted(shared_kmp):
             kmpdata = shared_kmp[kmp]
             if kmpdata["has_kbjson"] is False:
                 self.incomplete_kmp.append(kmpdata)
-        self.addlistitems(shared_kmp, self.store, InstallLocation.Shared)
+        self._addlistitems(shared_kmp, self.store, InstallLocation.Shared)
         os_kmp = get_installed_kmp(InstallLocation.OS)
         for kmp in sorted(os_kmp):
             kmpdata = os_kmp[kmp]
             if kmpdata["has_kbjson"] is False:
                 self.incomplete_kmp.append(kmpdata)
-        self.addlistitems(os_kmp, self.store, InstallLocation.OS)
+        self._addlistitems(os_kmp, self.store, InstallLocation.OS)
 
     def on_tree_selection_changed(self, selection):
         model, treeiter = selection.get_selected()
         if treeiter is not None:
             # sourcery skip: extract-method
             self.uninstall_button.set_tooltip_text(
-                _("Uninstall keyboard {package}").format(package=model[treeiter][1]))
+                _("Uninstall keyboard {package}").format(package=model[treeiter][Model.NAME]))
             self.help_button.set_tooltip_text(
-                _("Help for keyboard {package}").format(package=model[treeiter][1]))
+                _("Help for keyboard {package}").format(package=model[treeiter][Model.NAME]))
             self.about_button.set_tooltip_text(
-                _("About keyboard {package}").format(package=model[treeiter][1]))
+                _("About keyboard {package}").format(package=model[treeiter][Model.NAME]))
             self.options_button.set_tooltip_text(
-                _("Settings for keyboard {package}").format(package=model[treeiter][1]))
-            logging.debug("You selected %s version %s", model[treeiter][1], model[treeiter][2])
+                _("Settings for keyboard {package}").format(package=model[treeiter][Model.NAME]))
+            logging.debug("You selected %s version %s", model[treeiter][Model.NAME], model[treeiter][Model.VERSION])
             self.about_button.set_sensitive(True)
-            if model[treeiter][4] == InstallLocation.User:
-                logging.debug("Enabling uninstall button for %s in %s", model[treeiter][3], model[treeiter][4])
+            if model[treeiter][Model.LOCATION] == InstallLocation.User:
+                logging.debug("Enabling uninstall button for %s in %s", model[treeiter][Model.PACKAGEID], model[treeiter][Model.LOCATION])
                 self.uninstall_button.set_sensitive(True)
             else:
                 self.uninstall_button.set_sensitive(False)
-                logging.debug("Disabling uninstall button for %s in %s", model[treeiter][3], model[treeiter][4])
+                logging.debug("Disabling uninstall button for %s in %s", model[treeiter][Model.PACKAGEID], model[treeiter][Model.LOCATION])
             # welcome file if it exists
-            if model[treeiter][5]:
+            if model[treeiter][Model.WELCOMEFILE]:
                 self.help_button.set_sensitive(True)
             else:
                 self.help_button.set_sensitive(False)
             # options file if it exists
-            if model[treeiter][6]:
+            if model[treeiter][Model.OPTIONSFILE]:
                 self.options_button.set_sensitive(True)
             else:
                 self.options_button.set_sensitive(False)
@@ -360,12 +386,12 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
     def on_help_clicked(self, button):
         model, treeiter = self.tree.get_selection().get_selected()
         if treeiter is not None:
-            logging.info("Open welcome.htm for %s if available", model[treeiter][1])
-            welcome_file = model[treeiter][5]
+            logging.info("Open welcome.htm for %s if available", model[treeiter][Model.NAME])
+            welcome_file = model[treeiter][Model.WELCOMEFILE]
             if welcome_file and os.path.isfile(welcome_file):
                 uri_path = pathlib.Path(welcome_file).as_uri()
                 logging.info(f"opening {uri_path}")
-                w = WelcomeView(self, uri_path, model[treeiter][3])
+                w = WelcomeView(self, uri_path, model[treeiter][Model.PACKAGEID])
                 w.run()
                 w.destroy()
             else:
@@ -374,14 +400,14 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
     def on_options_clicked(self, button):
         model, treeiter = self.tree.get_selection().get_selected()
         if treeiter is not None:
-            logging.info("Open options.htm for %s if available", model[treeiter][1])
-            options_file = model[treeiter][6]
+            logging.info("Open options.htm for %s if available", model[treeiter][Model.NAME])
+            options_file = model[treeiter][Model.OPTIONSFILE]
             if options_file and os.path.isfile(options_file):
                 # sourcery skip: extract-method
                 uri_path = pathlib.Path(options_file).as_uri()
                 logging.info(f"opening {uri_path}")
                 # TODO: Determine keyboardID
-                info = {"optionurl": uri_path, "packageID": model[treeiter][3], "keyboardID": model[treeiter][3]}
+                info = {"optionurl": uri_path, "packageID": model[treeiter][Model.PACKAGEID], "keyboardID": model[treeiter][Model.PACKAGEID]}
                 w = OptionsView(info)
                 w.resize(800, 600)
                 w.show_all()
@@ -391,12 +417,12 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
     def on_uninstall_clicked(self, button):
         model, treeiter = self.tree.get_selection().get_selected()
         if treeiter is not None:
-            logging.info(f"Uninstall keyboard {model[treeiter][3]}?")
+            logging.info(f"Uninstall keyboard {model[treeiter][Model.PACKAGEID]}?")
             dialog = Gtk.MessageDialog(self, 0, Gtk.MessageType.QUESTION, Gtk.ButtonsType.YES_NO,
                                        _("Uninstall keyboard package?"))
             msg = _("Are you sure that you want to uninstall the {keyboard} keyboard?").format(
-              keyboard=model[treeiter][1])
-            kbdir = get_keyboard_dir(InstallLocation.User, model[treeiter][3])
+              keyboard=model[treeiter][Model.NAME])
+            kbdir = get_keyboard_dir(InstallLocation.User, model[treeiter][Model.PACKAGEID])
             kmpjson = os.path.join(kbdir, "kmp.json")
             if os.path.isfile(kmpjson):
                 info, system, options, keyboards, files = parsemetadata(kmpjson, False)
@@ -417,9 +443,9 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             response = dialog.run()
             dialog.destroy()
             if response == Gtk.ResponseType.YES:
-                logging.info(f"Uninstalling keyboard{model[treeiter][1]}")
+                logging.info(f"Uninstalling keyboard{model[treeiter][Model.NAME]}")
                 # can only uninstall with the gui from user area
-                msg = uninstall_kmp(model[treeiter][3])
+                msg = uninstall_kmp(model[treeiter][Model.PACKAGEID])
                 if msg != '':
                     md = Gtk.MessageDialog(self, 0, Gtk.MessageType.ERROR,
                             Gtk.ButtonsType.OK, _("Uninstalling keyboard failed.\n\nError message: ") + msg)
@@ -428,17 +454,17 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
                 logging.info("need to restart window after uninstalling a keyboard")
                 self.restart()
             elif response == Gtk.ResponseType.NO:
-                logging.info(f"Not uninstalling keyboard {model[treeiter][1]}")
+                logging.info(f"Not uninstalling keyboard {model[treeiter][Model.NAME]}")
 
     def on_about_clicked(self, button):
         model, treeiter = self.tree.get_selection().get_selected()
         if treeiter is not None and model[treeiter] is not None:
-            logging.info(f"Show keyboard details of {model[treeiter][1]}")
-            areapath = get_keyman_dir(model[treeiter][4])
+            logging.info(f"Show keyboard details of {model[treeiter][Model.NAME]}")
+            areapath = get_keyman_dir(model[treeiter][Model.LOCATION])
             kmp = {
-              "name": model[treeiter][1],
-              "version": model[treeiter][2],
-              "packageID": model[treeiter][3],
+              "name": model[treeiter][Model.NAME],
+              "version": model[treeiter][Model.VERSION],
+              "packageID": model[treeiter][Model.PACKAGEID],
               "areapath": areapath
             }
             w = KeyboardDetailsView(self, kmp)


### PR DESCRIPTION
When we recently added the new column and changed the model we didn't adjust all the existing references for the model fields.
This change fixes this and also extract some additional methods.

# User Testing

## Preparations

- The tests can be run on any Linux version
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot
- Install Amharic keyboard to shared area:
  ```
  sudo km-package-install --shared --package gff_amharic
  ```
- Install Khmer Angkor keyboard to user area:
  ```
  km-package-install --package khmer_angkor
  ```
- Install EuroLatin (SIL) keyboard for French to user area:
  ```
  km-package-install --package sil_euro_latin  --bcp47 fr
  ```
- Start Keyman Configuration

## Tests

**TEST_UNINST_DISABLED**: Uninstall button disabled for keyboards in Shared area

- In Keyman Configuration select Amharic
- Verify that "Uninstall" and "Options" buttons are grayed out, "About" and "Help" are enabled

**TEST_OPT_ENABLED**: Options button is enabled for keyboards that have options

- In Keyman Configuration select EuroLatin (SIL)
- Verify that all buttons ("Options" "Uninstall", "About", and "Help") are enabled

**TEST_OPT_DISABLED**: Options button is disabled for keyboards that don't have options

- In Keyman Configuration select Khmer Angkor
- Verify that "Options" button is grayed out, "Uninstall", "About", and "Help" are enabled
