### PR TITLE
fix(linux): Fix display of installed keyboard version

### DIFF
--- a/linux/keyman-config/keyman_config/kmpmetadata.py
+++ b/linux/keyman-config/keyman_config/kmpmetadata.py
@@ -51,7 +51,6 @@ def print_info(info):
         print(type(e))    # the exception instance
         print(e.args)     # arguments stored in .args
         print(e)          # __str__ allows args to be printed directly,		pass
-        pass
 
 
 def print_system(system):
@@ -67,7 +66,6 @@ def print_system(system):
         print(type(e))    # the exception instance
         print(e.args)     # arguments stored in .args
         print(e)          # __str__ allows args to be printed directly,		pass
-        pass
 
 
 def print_options(options):
@@ -83,7 +81,6 @@ def print_options(options):
         print(type(e))    # the exception instance
         print(e.args)     # arguments stored in .args
         print(e)          # __str__ allows args to be printed directly,		pass
-        pass
 
 
 def print_keyboards(keyboards):
@@ -107,7 +104,6 @@ def print_keyboards(keyboards):
         print(type(e))    # the exception instance
         print(e.args)     # arguments stored in .args
         print(e)          # __str__ allows args to be printed directly,		pass
-        pass
 
 
 def determine_filetype(kblist, filename):
@@ -148,7 +144,7 @@ def determine_filetype(kblist, filename):
         return KMFileTypes.KM_KMX
     elif ext.lower() == ".kvk":
         return KMFileTypes.KM_OSK
-    elif ext.lower() == ".ttf" or ext.lower() == ".otf":
+    elif ext.lower() in [".ttf", ".otf"]:
         return KMFileTypes.KM_FONT
     elif ext.lower() == ".js":
         if kblist is None:
@@ -156,24 +152,31 @@ def determine_filetype(kblist, filename):
         if name in kblist:
             return KMFileTypes.KM_TOUCH
         else:
-            if name == "keyrenderer":  # currently 2018-09-21 this is the own known non touch js file
-                return KMFileTypes.KM_DOC
-            else:
-                return KMFileTypes.KM_UNKNOWN
-    elif ext.lower() == ".txt" or ext.lower() == ".pdf" or ext.lower() == ".htm" \
-            or ext.lower() == ".html" or ext.lower() == ".doc" or ext.lower() == ".docx" \
-            or ext.lower() == ".css" or ext.lower() == ".chm" or ext.lower() == "" \
-            or ext.lower() == ".md" or ext.lower() == ".odt" or ext.lower() == ".rtf" \
-            or ext.lower() == ".dot" or ext.lower() == ".mht" or ext.lower() == ".woff" \
-            or ext.lower() == ".php":
+            return KMFileTypes.KM_DOC if name == "keyrenderer" else KMFileTypes.KM_UNKNOWN
+    elif ext.lower() in [
+      ".txt",
+      ".pdf",
+      ".htm",
+      ".html",
+      ".doc",
+      ".docx",
+      ".css",
+      ".chm",
+      "",
+      ".md",
+      ".odt",
+      ".rtf",
+      ".dot",
+      ".mht",
+      ".woff",
+      ".php",
+    ]:
         return KMFileTypes.KM_DOC
-    elif ext.lower() == ".inf" or ext.lower() == ".json":
+    elif ext.lower() in [".inf", ".json"]:
         return KMFileTypes.KM_META
-    elif ext.lower() == ".png" or ext.lower() == ".jpeg" \
-            or ext.lower() == ".jpg" or ext.lower() == ".gif" \
-            or ext.lower() == ".bmp":
+    elif ext.lower() in [".png", ".jpeg", ".jpg", ".gif", ".bmp"]:
         return KMFileTypes.KM_IMAGE
-    elif ext.lower() == ".tec" or ext.lower() == ".map":
+    elif ext.lower() in [".tec", ".map"]:
         return KMFileTypes.KM_TECKIT
     elif ext.lower() == ".cct":
         return KMFileTypes.KM_CC
@@ -206,7 +209,6 @@ def print_files(files, extracted_dir):
         print(type(e))    # the exception instance
         print(e.args)     # arguments stored in .args
         print(e)          # __str__ allows args to be printed directly,		pass
-        pass
 
 
 def get_fonts(files):
@@ -275,9 +277,9 @@ def parseinfdata(inffile, verbose=False):
                 if not info:
                     info = {}
                 for item in config.items('Info'):
-                    if item[0] == 'Name' or item[0] == 'name':
+                    if item[0] in ['Name', 'name']:
                         info['name'] = {'description': item[1].split("\"")[1]}
-                    elif item[0] == 'Copyright' or item[0] == 'copyright':
+                    elif item[0] in ['Copyright', 'copyright']:
                         info['copyright'] = {'description': item[1].split("\"")[1]}
                     elif item[0] == 'Version':
                         info['version'] = {'description': item[1].split("\"")[1]}
@@ -292,12 +294,12 @@ def parseinfdata(inffile, verbose=False):
                     info = {}
                 info['version'] = {'description': "1.0"}
                 for item in config.items('PackageInfo'):
-                    if item[0] == 'Name' or item[0] == 'name':
+                    if item[0] in ['Name', 'name']:
                         if item[1].split("\"")[1]:
                             info['name'] = {'description': item[1].split("\"")[1]}
                         else:
                             info['name'] = {'description': item[1].split("\"")[2]}
-                    elif item[0] == 'Copyright' or item[0] == 'copyright':
+                    elif item[0] in ['Copyright', 'copyright']:
                         if item[1].split("\"")[1]:
                             info['copyright'] = {'description': item[1].split("\"")[1]}
                         else:
@@ -329,9 +331,7 @@ def parseinfdata(inffile, verbose=False):
                         options['disableKeepFonts'] = item[1]
                     elif item[0] == 'BothVersionsIncluded':
                         options['bothVersionsIncluded'] = item[1]
-                    elif item[0] == 'ExecuteProgram':
-                        pass
-                    else:
+                    elif item[0] != 'ExecuteProgram':
                         print("Unknown item in Package:", item[0])
                 system['keymanDeveloperVersion'] = ""
             elif "Keyboard" in section:
@@ -391,9 +391,9 @@ def parseinfdata(inffile, verbose=False):
                 if kbfile['type'] == KMFileTypes.KM_KMX:
                     id = os.path.basename(os.path.splitext(kbfile['name'])[0])
                     keyboards = [{
-                        'name': id,
-                        'id': id,
-                        'version': secure_lookup(info, 'version', 'description')
+                      'name': id,
+                      'id': id,
+                      'version': secure_lookup(info, 'version', 'description')
                     }]
 
         kblist = []
@@ -469,22 +469,21 @@ def parsemetadata(jsonfile, verbose=False):
                 data = {"nonexistent": "none"}
 
             for x in data:
-                if x == 'info':
+                if x == 'files':
+                    files = data[x]
+                elif x == 'info':
                     info = data[x]
-                elif x == 'system':
-                    system = data[x]
                 elif x == 'keyboards':
                     keyboards = data[x]
-                elif x == 'files':
-                    files = data[x]
-                elif x == 'options':
-                    options = data[x]
                 elif x == 'nonexistent':
                     nonexistent = data[x]
+                elif x == 'options':
+                    options = data[x]
+                elif x == 'system':
+                    system = data[x]
             kblist = []
             if keyboards:
-                for k in keyboards:
-                    kblist.append(k['id'])
+                kblist.extend(k['id'] for k in keyboards)
             if files:
                 for kbfile in files:
                     kbfile['type'] = determine_filetype(kblist, kbfile['name'])

--- a/linux/keyman-config/keyman_config/list_installed_kmp.py
+++ b/linux/keyman-config/keyman_config/list_installed_kmp.py
@@ -131,7 +131,7 @@ def get_kmp_version(packageID):
 def _get_kmp_version_internal(packageId, location, previousVersion):
     kmp = get_installed_kmp(location)
     if packageId in kmp:
-        version = kmp[packageId]['version']
+        version = kmp[packageId]['kmpversion']
         if previousVersion and previousVersion < version or not previousVersion:
             previousVersion = version
     return previousVersion

--- a/linux/keyman-config/keyman_config/list_installed_kmp.py
+++ b/linux/keyman-config/keyman_config/list_installed_kmp.py
@@ -30,8 +30,8 @@ def get_installed_kmp(area):
                 id (str): Keyboard ID
                 name (str): Keyboard name
                 kmpname (str): Keyboard name in local
-                version (str): Keyboard version
-                kmpversion (str):
+                version (str): available Keyboard version
+                kmpversion (str): installed Keyboard version
                 path (str): base path where keyboard is installed
                 description (str): Keyboard description
     """
@@ -122,30 +122,19 @@ def get_kmp_version(packageID):
         None: if not found
     """
     version = None
-    user_kmp = get_installed_kmp(InstallLocation.User)
-    shared_kmp = get_installed_kmp(InstallLocation.Shared)
-    os_kmp = get_installed_kmp(InstallLocation.OS)
-
-    if packageID in os_kmp:
-        version = os_kmp[packageID]['version']
-
-    if packageID in shared_kmp:
-        shared_version = shared_kmp[packageID]['version']
-        if version:
-            if version < shared_version:
-                version = shared_version
-        else:
-            version = shared_version
-
-    if packageID in user_kmp:
-        user_version = user_kmp[packageID]['version']
-        if version:
-            if version < user_version:
-                version = user_version
-        else:
-            version = user_version
-
+    version = _get_kmp_version_internal(packageID, InstallLocation.OS, version)
+    version = _get_kmp_version_internal(packageID, InstallLocation.Shared, version)
+    version = _get_kmp_version_internal(packageID, InstallLocation.User, version)
     return version
+
+
+def _get_kmp_version_internal(packageId, location, previousVersion):
+    kmp = get_installed_kmp(location)
+    if packageId in kmp:
+        version = kmp[packageId]['version']
+        if previousVersion and previousVersion < version or not previousVersion:
+            previousVersion = version
+    return previousVersion
 
 
 def get_kmp_version_user(packageID):
@@ -159,11 +148,7 @@ def get_kmp_version_user(packageID):
         str: kmp version if kmp ID is installed
         None: if not found
     """
-    user_kmp = get_installed_kmp(InstallLocation.User)
-    if packageID in user_kmp:
-        return user_kmp[packageID]['version']
-    else:
-        return None
+    return _get_kmp_version_internal(packageID, InstallLocation.User, None)
 
 
 def get_kmp_version_shared(packageID):
@@ -177,8 +162,4 @@ def get_kmp_version_shared(packageID):
         str: kmp version if kmp ID is installed
         None: if not found
     """
-    shared_kmp = get_installed_kmp(InstallLocation.Shared)
-    if packageID in shared_kmp:
-        return shared_kmp[packageID]['version']
-    else:
-        return None
+    return _get_kmp_version_internal(packageID, InstallLocation.Shared, None)

--- a/linux/keyman-config/keyman_config/list_installed_kmp.py
+++ b/linux/keyman-config/keyman_config/list_installed_kmp.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from pkg_resources import parse_version
 
 from keyman_config import secure_lookup
 from keyman_config.deprecated_decorator import deprecated
@@ -132,7 +133,7 @@ def _get_kmp_version_internal(packageId, location, previousVersion):
     kmp = get_installed_kmp(location)
     if packageId in kmp:
         version = kmp[packageId]['kmpversion']
-        if previousVersion and previousVersion < version or not previousVersion:
+        if not previousVersion or parse_version(previousVersion) < parse_version(version):
             previousVersion = version
     return previousVersion
 

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -79,6 +79,7 @@ def _uninstall_kmp_common(location, packageID):
     logging.info("Finished uninstalling %s keyboard: %s", where, packageID)
     return ''
 
+
 def _uninstall_keyboards_from_ibus(keyboards, packageDir):
     bus = get_ibus_bus()
     if bus or os.environ.get('SUDO_USER'):
@@ -98,12 +99,12 @@ def _uninstall_keyboards_from_gnome(keyboards, packageDir):
     # uninstall all kmx for all languages
     for kb in keyboards:
         ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir)
-        tuple = ('ibus', ibus_keyboard_id)
-        if tuple in sources:
-            sources.remove(tuple)
+        _tuple = ('ibus', ibus_keyboard_id)
+        if _tuple in sources:
+            sources.remove(_tuple)
 
-        toRemove = []
         match_id = ":%s" % get_ibus_keyboard_id(kb, packageDir, ignore_language=True)
+        toRemove = []
         for (type, id) in sources:
             if type == 'ibus' and id.endswith(match_id):
                 toRemove.append((type, id))

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -312,7 +312,7 @@ class ViewInstalledWindow(ViewInstalledWindowBase):
             store.append([
               icofile,
               kmpdata['name'],
-              kmpdata['version'],
+              kmpdata['kmpversion'],
               kmpdata['packageID'],
               install_area,
               get_install_area_string(install_area),

--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -49,9 +49,9 @@ def _add_model():
       # Keep in sync with Model above
       GdkPixbuf.Pixbuf,  # icon
       str,    # name
-      str,    # version
-      str,    # packageID
-      int,    # enum InstallLocation (KmpArea is GObject version)
+      str,    # installed package version
+      str,    # package ID
+      int,    # enum InstallLocation
       str,    # InstallLocation area
       str,    # Tooltip with InstallLocation path
       str,    # path to welcome file if it exists or None

--- a/linux/keyman-config/km-package-list-installed
+++ b/linux/keyman-config/km-package-list-installed
@@ -12,7 +12,7 @@ def main():
     parser.add_argument('-s', "--shared", help='show keyboard packages installed in shared area', action="store_true")
     parser.add_argument('-o', "--os", help='show keyboard packages installed by the OS', action="store_true")
     parser.add_argument('-u', "--user", help='show keyboard packages installed in user area', action="store_true")
-    parser.add_argument('--version', action='version', version='%(prog)s version ' + __version__)
+    parser.add_argument('--version', action='version', version=f'%(prog)s version {__version__}')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
     parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
 
@@ -24,17 +24,17 @@ def main():
     else:
         logging.basicConfig(format='%(levelname)s:%(message)s')
 
-    all = not args.user and not args.shared and not args.os
+    _all = not args.user and not args.shared and not args.os
     from keyman_config.list_installed_kmp import get_installed_kmp
     from keyman_config.get_kmp import get_keyman_dir, InstallLocation
-    if args.user or all:
+    if args.user or _all:
         installed_kmp = get_installed_kmp(InstallLocation.User)
         if args.verbose or args.veryverbose:
             print("--- Installed user Keyman keyboard packages (%s) ---" % (get_keyman_dir(InstallLocation.User)))
         else:
             print("--- Installed user Keyman keyboard packages ---")
         print_keyboards(installed_kmp, args.long)
-    if args.shared or all:
+    if args.shared or _all:
         installed_kmp = get_installed_kmp(InstallLocation.Shared)
         if args.verbose or args.veryverbose:
             print("--- Installed shared Keyman keyboard packages (%s) ---" %
@@ -42,7 +42,7 @@ def main():
         else:
             print("--- Installed shared Keyman keyboard packages ---")
         print_keyboards(installed_kmp, args.long)
-    if args.os or all:
+    if args.os or _all:
         installed_kmp = get_installed_kmp(InstallLocation.OS)
         if args.verbose or args.veryverbose:
             print("--- Installed OS Keyman keyboard packages (%s) ---" % (get_keyman_dir(InstallLocation.OS)))

--- a/linux/keyman-config/km-package-list-installed
+++ b/linux/keyman-config/km-package-list-installed
@@ -51,12 +51,12 @@ def main():
         print_keyboards(installed_kmp, args.long)
 
 
-def print_keyboards(installed_kmp, verbose):
+def print_keyboards(installed_kmp, detailed):
     for packageID in sorted(installed_kmp):
-        print(installed_kmp[packageID]['name'] + ", version:", installed_kmp[packageID]['version'] + ", id:", packageID)
-        if verbose:
+        print(f"{installed_kmp[packageID]['name']}, version: {installed_kmp[packageID]['kmpversion']}, id: {packageID}")
+        if detailed:
             if installed_kmp[packageID]['version'] != installed_kmp[packageID]['kmpversion']:
-                print("Version mismatch. Installed keyboard package is %s. Website says it is %s."
+                print("New version of keyboard available. Installed keyboard package is %s. Website has %s."
                       % (installed_kmp[packageID]['kmpversion'], installed_kmp[packageID]['version']))
             if installed_kmp[packageID]['name'] != installed_kmp[packageID]['kmpname']:
                 print("Name mismatch. Installed keyboard package is %s. Website says it is %s."


### PR DESCRIPTION
Previously if there was a newer version available on keyman.com we showed that version number instead of the version number of the installed keyboard.

# User Testing

## Preparations

- The tests can be run on any Linux version
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot
- Download EuroLatin (SIL) version 2.0.1: <https://keyman.com/go/package/download/sil_euro_latin?version=2.0.1&tier=stable>
- Open Keyman Configuration
- If you have any EuroLatin (SIL) keyboards installed, uninstall them
- Install the just downloaded keyboard by clicking the "Install keyboard" button and selecting the downloaded file

## Tests

**TEST_VERSION_NO**: Correct version number shows

- Verify that the "Version" column shows version 2.0.1 for the EuroLatin (SIL) keyboard