### PR TITLE
chore(developer): check for nodejs deps in kmc-kmn

### DIFF
--- a/developer/src/kmc-kmn/.eslintrc.cjs
+++ b/developer/src/kmc-kmn/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
   overrides: [
     {
       files:"src/**/*.ts",
-      // extends: ["../../../common/web/eslint/eslintNoNodeImports.js"],
+      extends: ["../../../common/web/eslint/eslintNoNodeImports.js"],
     }
   ],
   rules: {

--- a/developer/src/kmc-model-info/build.sh
+++ b/developer/src/kmc-model-info/build.sh
@@ -50,7 +50,8 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action test; then
-  #npm test - no tests as yet
+  npm test
+  # TODO: no unit tests yet, later add: `&& cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha`
   builder_finish_action success test
 fi
 

--- a/developer/src/kmc-model-info/package.json
+++ b/developer/src/kmc-model-info/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "eslint .",
-    "test": "npm run lint && cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
+    "test": "npm run lint",
     "prepublishOnly": "npm run build"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",

--- a/developer/src/kmc/.eslintrc.cjs
+++ b/developer/src/kmc/.eslintrc.cjs
@@ -1,5 +1,4 @@
 module.exports = {
-  //   extends: ["../../../common/web/eslint/eslintNoNodeImports.js"],
   parserOptions: {
     project: ["./tsconfig.json", "./test/tsconfig.json"],
   },


### PR DESCRIPTION
Enables eslint checks for eslintNoNodeImports for kmc-kmn. Also enables linting for kmc-model-info, but does not enable eslintNoNodeImports on it at this time.

Relates to #8959.

@keymanapp-test-bot skip