### PR TITLE
fix(web): restores element text-selection auto-scrolling 🧩

### DIFF
--- a/web/src/app/browser/src/context/focusAssistant.ts
+++ b/web/src/app/browser/src/context/focusAssistant.ts
@@ -41,6 +41,18 @@ interface EventMap {
 export class FocusAssistant extends EventEmitter<EventMap> {
   private _maintainingFocus: boolean = false;  // ActivatingKeymanWebUI - Does the OSK have active focus / an active interaction?
 
+  /**
+   * Returns `true` only when the active target has an active `forceScroll` method/state, which deliberately
+   * blurs and then refocuses the same element in order to force a browser-default page scroll to keep the
+   * element and text-caret visible.
+   */
+  readonly isTargetForcingScroll: () => boolean;
+
+  constructor(isTargetForcingScroll: () => boolean) {
+    super();
+    this.isTargetForcingScroll = isTargetForcingScroll;
+  }
+
   /*
    * Long-term idea here: about all of the relevant OSK events that would interact with this have "enter" and
    * "leave" variants - we could take a stack of `Promise`s.  On a `Promise` fulfillment, remove it from the
@@ -108,16 +120,6 @@ export class FocusAssistant extends EventEmitter<EventMap> {
    * super-straightforward, but a refactor should be manageable all the same.
    */
   _IgnoreNextSelChange = 0;
-
-  /**
-   * JH (2023-04-24): Set only by the OutputTarget `forceScroll` method, which deliberately blurs and
-   * then refocuses the same element in order to force a browser-default page scroll to keep the element
-   * visible.
-   *
-   * While it feels like this should be possible to merge with the other class fields in some form... it
-   * doesn't seem as safe to do on first glance.
-   */
-  _IgnoreBlurFocus: boolean = false;
 
   /**
    * Is used as a time-delayed async `restoringFocus` or `maintainingFocus` - could be modeled decently as a Promise.

--- a/web/src/app/browser/src/context/pageIntegrationHandlers.ts
+++ b/web/src/app/browser/src/context/pageIntegrationHandlers.ts
@@ -67,8 +67,10 @@ export class PageIntegrationHandlers {
   }
 
   private suppressFocusCheck: (e: FocusEvent) => boolean = (e) => {
-    if(this.focusAssistant._IgnoreBlurFocus) {
-      // Prevent triggering other blur-handling events (as possible)
+    if(this.focusAssistant.isTargetForcingScroll()) {
+      // Prevent triggering other blur-handling events (as possible) - this blur
+      // is programmatic in order to force a browser scroll-position update.
+      // All focus changes should be prevented at this time.
       e.stopPropagation();
       e.cancelBubble = true;
     }

--- a/web/src/engine/element-wrappers/src/outputTarget.ts
+++ b/web/src/engine/element-wrappers/src/outputTarget.ts
@@ -24,6 +24,16 @@ export default abstract class OutputTarget<EventMap extends EventEmitter.ValidEv
   }
 
   /**
+   * Denotes when the represented element is forcing a text scroll via focus manipulation.
+   * As the intent is not to change the focused element, but just to have the browser update
+   * the scroll location, standard focus handlers (for updating the active context) should
+   * not deactivate the element while this state is active.
+   */
+  isForcingScroll(): boolean {
+    return false;
+  }
+
+  /**
    * A helper method for doInputEvent; creates a simple common event and default dispatching.
    * @param elem
    */


### PR DESCRIPTION
References for the original behavior, intent, and implementation: 
- #2168
- #2514

This corresponds to one of the tracking items on #8560 🧩:

> - Address, then resolve all comments for https://github.com/keymanapp/keyman/pull/8055.
>     - They're loose threads that were unresolvable at the time.

----

TL,DR: forces a scroll on `<input>` element text when the selection expands out of bounds.
- The 'caret' by itself can serve as a selection of width zero and is the most common case.
- Just type a long string; output text should auto-scroll to keep the caret in bounds. 
- Pretty easy to user test, once you know why the code existed in the first place.

Well... the pathway I'd set up previously was looking quite unwieldy, so I reworked it into something more streamlined that still addresses the original, underlying problem.

Obviously, we'll want a formal user test for the behavior as part of the main test batch based on the simple repro mentioned above.

@keymanapp-test-bot skip