### PR TITLE
chore(developer): enable eslint for kmc-kmw 🗜

### DIFF
--- a/developer/src/kmc-kmw/.eslintrc.cjs
+++ b/developer/src/kmc-kmw/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  parserOptions: {
+    project: ["./tsconfig.json", "./test/tsconfig.json"],
+  },
+  ignorePatterns: ["test/fixtures/**/*"],
+  overrides: [
+    {
+      files:"src/**/*.ts",
+      extends: ["../../../common/web/eslint/eslintNoNodeImports.js"],
+    }
+  ],
+  rules: {
+    "prefer-const": "off", // TODO: enable this once infrastructure is in place and cleanup the problem cases
+  },
+};

--- a/developer/src/kmc-kmw/build.sh
+++ b/developer/src/kmc-kmw/build.sh
@@ -39,13 +39,17 @@ function copy_schema() {
 
 function do_build() {
   copy_schema
-  npm run build
+  tsc --build
 }
 
 function do_test() {
-  # TODO: add c8 for coverage
   copy_schema
-  npm test
+  eslint .
+  cd test
+  tsc --build
+  cd ..
+  # TODO: add c8 for coverage
+  mocha
 }
 
 function do_publish() {

--- a/developer/src/kmc-kmw/package.json
+++ b/developer/src/kmc-kmw/package.json
@@ -12,9 +12,8 @@
     ".": "./build/src/main.js"
   },
   "scripts": {
-    "build": "tsc -b",
-    "tsc": "tsc",
-    "test": "cd test && tsc -b && cd .. && mocha",
+    "build": "gosh ./build.sh build",
+    "test": "gosh ./build.sh test",
     "prepublishOnly": "npm run build"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",
@@ -41,7 +40,8 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "@keymanapp/resources-gosh": "*"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",


### PR DESCRIPTION
Relates to #8959.

Also makes build.sh responsible for build rather than package.json.

@keymanapp-test-bot skip