### PR TITLE
chore(web): deduplicates non-distinct osk events 🧩

### DIFF
--- a/web/src/app/browser/src/oskConfiguration.ts
+++ b/web/src/app/browser/src/oskConfiguration.ts
@@ -27,9 +27,9 @@ export function setupOskListeners(engine: KeymanEngine, osk: OSKView, contextMan
     }
   });
 
-  osk.on('onhide', (hiddenByUser) => {
+  osk.addEventListener('hide', (params) => {
     // If hidden by the UI, be sure to restore the focus
-    if(hiddenByUser) {
+    if(params?.HiddenByUser) {
       contextManager.activeTarget?.focus();
     }
   });

--- a/web/src/engine/osk/src/views/anchoredOskView.ts
+++ b/web/src/engine/osk/src/views/anchoredOskView.ts
@@ -241,4 +241,9 @@ export default class AnchoredOSKView extends OSKView {
       Ls.borderTop='1px solid gray';
     }
   }
+
+  public present() {
+    super.present();
+    this.legacyEvents.callEvent('show', {});
+  }
 }

--- a/web/src/engine/osk/src/views/floatingOskView.ts
+++ b/web/src/engine/osk/src/views/floatingOskView.ts
@@ -52,11 +52,9 @@ export default class FloatingOSKView extends OSKView {
     // Add header element to OSK only for desktop browsers
     this.titleBar = new TitleBar(this.titleDragHandler);
     this.titleBar.on('help', () => {
-      this.emit('showHelp');
       this.legacyEvents.callEvent('helpclick', {});
     });
     this.titleBar.on('config', () => {
-      this.emit('showConfig');
       this.legacyEvents.callEvent('configclick', {});
     });
     this.titleBar.on('close', () => this.startHide(true));
@@ -74,12 +72,10 @@ export default class FloatingOSKView extends OSKView {
       if(titleBar && titleBar instanceof TitleBar) {
         switch(eventName) {
           case 'configclick':
-          case 'showConfig':
-            titleBar.configEnabled = this.listenerCount('showConfig') + this.legacyEvents.listenerCount('configclick') > 0;
+            titleBar.configEnabled = this.legacyEvents.listenerCount('configclick') > 0;
             break;
-          case 'showHelp':
           case 'helpclick':
-            titleBar.helpEnabled = this.listenerCount('showHelp') + this.legacyEvents.listenerCount('helpclick') > 0;
+            titleBar.helpEnabled = this.legacyEvents.listenerCount('helpclick') > 0;
             break;
           default:
             return;

--- a/web/src/engine/osk/src/views/inlinedOskView.ts
+++ b/web/src/engine/osk/src/views/inlinedOskView.ts
@@ -116,6 +116,12 @@ export default class InlinedOSKView extends OSKView {
     return; // I3363 (Build 301)
   }
 
+  public present() {
+    super.present();
+
+    this.legacyEvents.callEvent('show', {});
+  }
+
   protected setDisplayPositioning() {
     // no-op; an inlined OSK cannot control its own positioning.
   }

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -84,7 +84,7 @@ export interface EventMap {
    */
   showBuild: () => void;
 
-  // While the next two are near-duplicates of the legacy event `resizeMove`, these
+  // While the next two are near-duplicates of the legacy event `resizemove`, these
   // have the advantage of providing a Promise for the end of the ongoing user
   // interaction.  We need that Promise for focus-management.
 

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -21,7 +21,7 @@ import {
   type SystemStoreMutationHandler
 } from '@keymanapp/keyboard-processor';
 import { createUnselectableElement, getAbsoluteX, getAbsoluteY, StylesheetManager } from 'keyman/engine/dom-utils';
-import { LegacyEventEmitter } from 'keyman/engine/events';
+import { EventListener, EventNames, LegacyEventEmitter } from 'keyman/engine/events';
 
 import Configuration from '../config/viewConfiguration.js';
 import Activator, { StaticActivator } from './activator.js';
@@ -49,7 +49,9 @@ export interface LegacyOSKEventMap {
   'helpclick'(obj: {});
   'resizemove'(obj: {});
   'show'(obj: {});
-  'hide'(obj: {});
+  'hide'(obj: {
+    HiddenByUser: boolean
+  });
 }
 
 /**
@@ -66,10 +68,6 @@ export interface EventMap {
    */
   'keyEvent': (event: KeyEvent) => void,
 
-  onshow(): void;
-
-  onhide(hiddenByUser: boolean): void;
-
   /**
    * Indicates that the globe key has either been pressed (`on` == `true`)
    * or released (`on` == `false`).
@@ -82,23 +80,13 @@ export interface EventMap {
   hideRequested: (key: KeyElement) => void;
 
   /**
-   * This event is raised when the OSK's 'config' button is clicked.
-   * Adding a listener for the event will cause the 'config' button to be displayed for
-   * FloatingOSKView instances.
-   */
-  showConfig: () => void;
-
-  /**
-   * This event is raised when the OSK's 'help' button is clicked.
-   * Adding a listener for the event will cause the 'help' button to be displayed for
-   * FloatingOSKView instances.
-   */
-  showHelp: () => void;
-
-  /**
    * Signals the special command to display the engine's version + build number.
    */
   showBuild: () => void;
+
+  // While the next two are near-duplicates of the legacy event `resizeMove`, these
+  // have the advantage of providing a Promise for the end of the ongoing user
+  // interaction.  We need that Promise for focus-management.
 
   /**
    * Signals that the OSK is being moved by the user via a drag operation.
@@ -116,7 +104,6 @@ export interface EventMap {
    * The provided Promise will resolve once the resize operation is complete.
    */
   resizeMove: (promise: Promise<void>) => void;
-
 
   /**
    * Signals that either the mouse or an active touchpoint is interacting with the OSK.
@@ -918,9 +905,8 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
 
     this.setDisplayPositioning();
 
-    // Do this once all properties are set; that way, consumers can safely poll
-    // for position, size, etc.
-    this.emit('onshow');
+    // Each subclass is responsible for raising the 'show' event on its own, since
+    // certain ones supply extra information in their event param object.
   }
 
   /**
@@ -1241,10 +1227,9 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
    *
    */
   doHide(hiddenByUser: boolean) {
-    this.emit('onhide', hiddenByUser);
-
-    const p={};
-    p['HiddenByUser']=hiddenByUser;
+    const p={
+      HiddenByUser: hiddenByUser
+    };
     this.legacyEvents.callEvent('hide', p);
   }
 
@@ -1256,11 +1241,17 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
    * @return      {boolean}
    * Description  Wrapper function to add and identify OSK-specific event handlers
    */
-  addEventListener<T extends keyof LegacyOSKEventMap>(event: T, fn: (arg: {}) => any): void {
+  addEventListener<T extends keyof LegacyOSKEventMap>(
+    event: T,
+    fn: EventListener<LegacyOSKEventMap, T>
+  ): void {
     this.legacyEvents.addEventListener(event, fn);
   }
 
-  removeEventListener<T extends keyof LegacyOSKEventMap>(event: T, fn: (arg: {}) => any): void {
+  removeEventListener<T extends keyof LegacyOSKEventMap>(
+    event: T,
+    fn: EventListener<LegacyOSKEventMap, T>
+  ): void {
     this.legacyEvents.removeEventListener(event, fn);
   }
 }

--- a/web/src/test/auto/dom/cases/osk/events.js
+++ b/web/src/test/auto/dom/cases/osk/events.js
@@ -59,25 +59,21 @@ describe('OSK events', function () {
     // Setup complete.
 
     // Hide the OSK + check for related event
-    let hideStub = sinon.fake();
     let legacyHideStub = sinon.fake();
-    osk.once('onhide', hideStub);
     osk.legacyEvents.addEventListener('hide', legacyHideStub);
 
     osk.activationModel.enabled = false;
-    assert.isTrue(hideStub.calledOnce);
     assert.isTrue(legacyHideStub.calledOnce);
 
+    // The hide actually occurs on a Promise's completion.
+    // Adding the 'await' makes this clearer during test maintenance.
+    await Promise.resolve();
+
     // Show the OSK + check for related event
-    let showStub = sinon.fake();
-    // let legacyShowStub = sinon.fake();
-    osk.once('onshow', showStub);
-    // osk.once('legacyevent', legacyShowStub);
+    let legacyShowStub = sinon.fake();
+    osk.legacyEvents.addEventListener('show', legacyShowStub);
 
     osk.activationModel.enabled = true;
-    assert.isTrue(showStub.calledOnce);
-    // // Only called (at present) for "Floating" OSK views, given the event's parameterization.
-    // assert.isTrue(legacyShowStub.calledOnce);
-    // assert.equal(legacyShowStub.firstCall.args[0], 'osk.show');
+    assert.isTrue(legacyShowStub.calledOnce);
   });
 });


### PR DESCRIPTION
Follows up on a feature-branch TODO item based on this: https://github.com/keymanapp/keyman/pull/8624#discussion_r1191843605

The problem:

https://github.com/keymanapp/keyman/blob/833f3aed40356eabc7714954c3840d435d80d9ce/web/src/engine/osk/src/views/oskView.ts#L43-L53

has duplicates / near duplicates I made earlier in the process in a "newer" event style:

https://github.com/keymanapp/keyman/blob/833f3aed40356eabc7714954c3840d435d80d9ce/web/src/engine/osk/src/views/oskView.ts#L69-L71

https://github.com/keymanapp/keyman/blob/833f3aed40356eabc7714954c3840d435d80d9ce/web/src/engine/osk/src/views/oskView.ts#L84-L96

https://github.com/keymanapp/keyman/blob/833f3aed40356eabc7714954c3840d435d80d9ce/web/src/engine/osk/src/views/oskView.ts#L103-L118

Nearly pure duplicates:
- onHide
- onShow
- showConfig
- showHelp

The last two listed above - `dragMove` and `resizeMove` - remain after this due to their importance for focus management, but the others were simple enough to delete.  A bit of extra work for that was needed by the `show` event in order for it to  generate for all OSK types, even if it won't include the same information as the `FloatingOSKView`.  This is a mild divergence from 16.0 / `master`, which only fires the event for desktop form-factor layouts.

I made that last decision because `hide` already generated for all types, so `show` only occurring for one felt like a bug, even if it was the true conversion from the original KMW 16.0 codebase.  Note that the duplicated `onShow` event OSK event had been generating for all types.

@keymanapp-test-bot skip