### PR TITLE
fix(developer): keep kmc-kmn messages within namespace

### DIFF
--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -15,8 +15,13 @@ export enum CompilerErrorSeverity {
   Error =         0x300000, // Severe error where we can't continue
   Fatal =         0x400000, // OOM or should-not-happen internal problem
 
-  Severity_Mask = 0xF00000, // includes reserved bits
-  Error_Mask =    0x0FFFFF,
+  // Mask values for mapping compiler errors
+  // TODO: make this a separate enum?
+  Severity_Mask =  0x00F00000,  // includes reserved bits, 16 possible severity levels
+  Error_Mask =     0x000FFFFF,  // error | namespace
+  Namespace_Mask = 0x000FF000,  // 256 possible namespaces
+  BaseError_Mask = 0x00000FFF,  // error code, 2,048 possible error codes per namespace
+  Reserved_Mask  = 0xFF000000,  // do not use these error values at this time
 };
 
 export function compilerErrorSeverityName(code: number): string {

--- a/developer/src/common/web/test-helpers/verifyCompilerMessagesObject.ts
+++ b/developer/src/common/web/test-helpers/verifyCompilerMessagesObject.ts
@@ -8,6 +8,7 @@ import {assert, expect} from 'chai';
 //   * that names are consistent between the message functions and constants
 //   * that constants have unique codes
 //   * that constants have the right error mask for their type
+//   * that constants don't creep outside their namespace
 //
 // This means we don't have to worry about DRYing out the constants, which would
 // probably require us to have a preprocessing step, which has its own
@@ -18,7 +19,7 @@ import {assert, expect} from 'chai';
 
 const toTitleCase = (s: string) => s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
 
-export function verifyCompilerMessagesObject(source: Record<string,any>) {
+export function verifyCompilerMessagesObject(source: Record<string,any>, namespace: number) {
   const keys = Object.keys(source);
 
   const m = source as Record<string,any>;
@@ -58,8 +59,12 @@ export function verifyCompilerMessagesObject(source: Record<string,any>) {
       const mask = compilerErrorSeverityName(m[key]);
       expect(o[1]).to.equal(mask, `Mask value for ${key} does not match`);
 
+      expect(m[key] & CompilerErrorSeverity.Reserved_Mask).to.equal(0, `Constant value ${key} uses a reserved value`);
+
       const code = m[key] & CompilerErrorSeverity.Error_Mask;
       expect(codes).to.not.contain(code, `Constant value ${key} is not unique`);
+      expect(m[key] & CompilerErrorSeverity.Namespace_Mask).to.equal(namespace,
+        `Constant value ${key} is not in the correct namespace (0x${namespace.toString(16)})`);
       codes.push(code);
     }
   }

--- a/developer/src/kmc-kmn/src/compiler/messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/messages.ts
@@ -32,11 +32,12 @@ const LogLevelToSeverity: Record<number,number> = {
 }
 
 export const enum KmnCompilerMessageRanges {
-  RANGE_KMN_COMPILER_MIN    = 0x0001, // from kmn_compiler_errors.h
-  RANGE_KMN_COMPILER_MAX    = 0x07FF, // from kmn_compiler_errors.h
-  RANGE_LEXICAL_MODEL_MIN   = 0x0800, // from kmn_compiler_errors.h, deprecated -- this range will not be used in future versions
-  RANGE_LEXICAL_MODEL_MAX   = 0x08FF, // from kmn_compiler_errors.h, deprecated -- this range will not be used in future versions
-  RANGE_CompilerMessage_Min = 0x1000, // All compiler messages listed here must be >= this value
+  RANGE_KMN_COMPILER_MIN    = 0x001, // from kmn_compiler_errors.h
+  RANGE_KMN_COMPILER_MAX    = 0x7FF, // from kmn_compiler_errors.h
+  RANGE_LEXICAL_MODEL_MIN   = 0x800, // from kmn_compiler_errors.h, deprecated -- this range will not be used in future versions
+  RANGE_LEXICAL_MODEL_MAX   = 0x8FF, // from kmn_compiler_errors.h, deprecated -- this range will not be used in future versions
+  RANGE_CompilerMessage_Min = 0x900, // All compiler messages listed here must be >= this value
+  RANGE_CompilerMessage_Max = 0xFFF, // Highest available error code for kmc-kmn
 }
 
 /*
@@ -46,36 +47,36 @@ export const enum KmnCompilerMessageRanges {
 */
 export class CompilerMessages {
   static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException, `Unexpected exception: ${exc(o.e)}`);
-  static FATAL_UnexpectedException = SevFatal | 0x1000;
+  static FATAL_UnexpectedException = SevFatal | 0x900;
 
   static Fatal_MissingWasmModule = (o:{e?: any}) => m(this.FATAL_MissingWasmModule, `Could not instantiate WASM compiler module or initialization failed: ${exc(o.e)}`);
-  static FATAL_MissingWasmModule = SevFatal | 0x1001;
+  static FATAL_MissingWasmModule = SevFatal | 0x901;
 
   static Fatal_UnableToSetCompilerOptions = () => m(this.FATAL_UnableToSetCompilerOptions, `Unable to set compiler options`);
-  static FATAL_UnableToSetCompilerOptions = SevFatal | 0x1002;
+  static FATAL_UnableToSetCompilerOptions = SevFatal | 0x902;
 
   static Fatal_CallbacksNotSet = () => m(this.FATAL_CallbacksNotSet, `Callbacks were not set with init`);
-  static FATAL_CallbacksNotSet = SevFatal | 0x1003;
+  static FATAL_CallbacksNotSet = SevFatal | 0x903;
 
   static Fatal_UnicodeSetOutOfRange = () => m(this.FATAL_UnicodeSetOutOfRange, `UnicodeSet buffer was too small`);
-  static FATAL_UnicodeSetOutOfRange = SevFatal | 0x1004;
+  static FATAL_UnicodeSetOutOfRange = SevFatal | 0x904;
 
   static Error_UnicodeSetHasStrings = () => m(this.ERROR_UnicodeSetHasStrings, `UnicodeSet contains strings, not allowed`);
-  static ERROR_UnicodeSetHasStrings = SevError | 0x1005;
+  static ERROR_UnicodeSetHasStrings = SevError | 0x905;
 
   static Error_UnicodeSetHasProperties = () => m(this.ERROR_UnicodeSetHasProperties, `UnicodeSet contains properties, not allowed`);
-  static ERROR_UnicodeSetHasProperties = SevError | 0x1006;
+  static ERROR_UnicodeSetHasProperties = SevError | 0x906;
 
   static Error_UnicodeSetSyntaxError = () => m(this.ERROR_UnicodeSetSyntaxError, `UnicodeSet had a Syntax Error while parsing`);
-  static ERROR_UnicodeSetSyntaxError = SevError | 0x1007;
+  static ERROR_UnicodeSetSyntaxError = SevError | 0x907;
 
   static Error_InvalidKvksFile = (o:{filename: string, e: any}) => m(this.ERROR_InvalidKvksFile,
     `Error encountered parsing ${o.filename}: ${o.e}`);
-  static ERROR_InvalidKvksFile = SevError | 0x1008;
+  static ERROR_InvalidKvksFile = SevError | 0x908;
 
   static Warn_InvalidVkeyInKvksFile = (o:{filename: string, invalidVkey: string}) => m(this.WARN_InvalidVkeyInKvksFile,
     `Invalid virtual key ${o.invalidVkey} found in ${o.filename}`);
-  static WARN_InvalidVkeyInKvksFile = SevWarn | 0x1009;
+  static WARN_InvalidVkeyInKvksFile = SevWarn | 0x909;
 };
 
 /**
@@ -92,200 +93,200 @@ export class CompilerMessages {
  * Message text is defined by kmcmplib and passed through a callback.
  */
 export class KmnCompilerMessages {
-  static INFO_None                                            = SevInfo | 0x0000;
-  static INFO_EndOfFile                                       = SevInfo | 0x0001;
+  static INFO_None                                            = SevInfo | 0x000;
+  static INFO_EndOfFile                                       = SevInfo | 0x001;
 
-  static FATAL_BadCallParams                                  = SevFatal | 0x0002;
-  static FATAL_CannotAllocateMemory                           = SevFatal | 0x0004;
-  static FATAL_InfileNotExist                                 = SevFatal | 0x0005;
-  static FATAL_CannotCreateOutfile                            = SevFatal | 0x0006;
-  static FATAL_UnableToWriteFully                             = SevFatal | 0x0007;
-  static FATAL_CannotReadInfile                               = SevFatal | 0x0008;
-  static FATAL_SomewhereIGotItWrong                           = SevFatal | 0x0009;
+  static FATAL_BadCallParams                                  = SevFatal | 0x002;
+  static FATAL_CannotAllocateMemory                           = SevFatal | 0x004;
+  static FATAL_InfileNotExist                                 = SevFatal | 0x005;
+  static FATAL_CannotCreateOutfile                            = SevFatal | 0x006;
+  static FATAL_UnableToWriteFully                             = SevFatal | 0x007;
+  static FATAL_CannotReadInfile                               = SevFatal | 0x008;
+  static FATAL_SomewhereIGotItWrong                           = SevFatal | 0x009;
 
-  static ERROR_InvalidToken                                   = SevError | 0x000A;
-  static ERROR_InvalidBegin                                   = SevError | 0x000B;
-  static ERROR_InvalidName                                    = SevError | 0x000C;
-  static ERROR_InvalidVersion                                 = SevError | 0x000D;
-  static ERROR_InvalidLanguageLine                            = SevError | 0x000E;
-  static ERROR_LayoutButNoLanguage                            = SevError | 0x000F;
-  static ERROR_InvalidLayoutLine                              = SevError | 0x0010;
-  static ERROR_NoVersionLine                                  = SevError | 0x0011;
-  static ERROR_InvalidGroupLine                               = SevError | 0x0012;
-  static ERROR_InvalidStoreLine                               = SevError | 0x0013;
-  static ERROR_InvalidCodeInKeyPartOfRule                     = SevError | 0x0014;
-  static ERROR_InvalidDeadkey                                 = SevError | 0x0015;
-  static ERROR_InvalidValue                                   = SevError | 0x0016;
-  static ERROR_ZeroLengthString                               = SevError | 0x0017;
-  static ERROR_TooManyIndexToKeyRefs                          = SevError | 0x0018;
-  static ERROR_UnterminatedString                             = SevError | 0x0019;
-  static ERROR_StringInVirtualKeySection                      = SevError | 0x001A;
-  static ERROR_AnyInVirtualKeySection                         = SevError | 0x001B;
-  static ERROR_InvalidAny                                     = SevError | 0x001C;
-  static ERROR_StoreDoesNotExist                              = SevError | 0x001D;
-  static ERROR_BeepInVirtualKeySection                        = SevError | 0x001E;
-  static ERROR_IndexInVirtualKeySection                       = SevError | 0x001F;
-  static ERROR_InvalidIndex                                   = SevError | 0x0020;
-  static ERROR_OutsInVirtualKeySection                        = SevError | 0x0021;
-  static ERROR_InvalidOuts                                    = SevError | 0x0022;
-  static ERROR_ContextInVirtualKeySection                     = SevError | 0x0024;
-  static ERROR_InvalidUse                                     = SevError | 0x0025;
-  static ERROR_GroupDoesNotExist                              = SevError | 0x0026;
-  static ERROR_VirtualKeyNotAllowedHere                       = SevError | 0x0027;
-  static ERROR_InvalidSwitch                                  = SevError | 0x0028;
-  static ERROR_NoTokensFound                                  = SevError | 0x0029;
-  static ERROR_InvalidLineContinuation                        = SevError | 0x002A;
-  static ERROR_LineTooLong                                    = SevError | 0x002B;
-  static ERROR_InvalidCopyright                               = SevError | 0x002C;
-  static ERROR_CodeInvalidInThisSection                       = SevError | 0x002D;
-  static ERROR_InvalidMessage                                 = SevError | 0x002E;
-  static ERROR_InvalidLanguageName                            = SevError | 0x002F;
-  static ERROR_InvalidBitmapLine                              = SevError | 0x0030;
-  static ERROR_CannotReadBitmapFile                           = SevError | 0x0031;
-  static ERROR_IndexDoesNotPointToAny                         = SevError | 0x0032;
-  static ERROR_ReservedCharacter                              = SevError | 0x0033;
-  static ERROR_InvalidCharacter                               = SevError | 0x0034;
-  static ERROR_InvalidCall                                    = SevError | 0x0035;
-  static ERROR_CallInVirtualKeySection                        = SevError | 0x0036;
-  static ERROR_CodeInvalidInKeyStore                          = SevError | 0x0037;
-  static ERROR_CannotLoadIncludeFile                          = SevError | 0x0038;
+  static ERROR_InvalidToken                                   = SevError | 0x00A;
+  static ERROR_InvalidBegin                                   = SevError | 0x00B;
+  static ERROR_InvalidName                                    = SevError | 0x00C;
+  static ERROR_InvalidVersion                                 = SevError | 0x00D;
+  static ERROR_InvalidLanguageLine                            = SevError | 0x00E;
+  static ERROR_LayoutButNoLanguage                            = SevError | 0x00F;
+  static ERROR_InvalidLayoutLine                              = SevError | 0x010;
+  static ERROR_NoVersionLine                                  = SevError | 0x011;
+  static ERROR_InvalidGroupLine                               = SevError | 0x012;
+  static ERROR_InvalidStoreLine                               = SevError | 0x013;
+  static ERROR_InvalidCodeInKeyPartOfRule                     = SevError | 0x014;
+  static ERROR_InvalidDeadkey                                 = SevError | 0x015;
+  static ERROR_InvalidValue                                   = SevError | 0x016;
+  static ERROR_ZeroLengthString                               = SevError | 0x017;
+  static ERROR_TooManyIndexToKeyRefs                          = SevError | 0x018;
+  static ERROR_UnterminatedString                             = SevError | 0x019;
+  static ERROR_StringInVirtualKeySection                      = SevError | 0x01A;
+  static ERROR_AnyInVirtualKeySection                         = SevError | 0x01B;
+  static ERROR_InvalidAny                                     = SevError | 0x01C;
+  static ERROR_StoreDoesNotExist                              = SevError | 0x01D;
+  static ERROR_BeepInVirtualKeySection                        = SevError | 0x01E;
+  static ERROR_IndexInVirtualKeySection                       = SevError | 0x01F;
+  static ERROR_InvalidIndex                                   = SevError | 0x020;
+  static ERROR_OutsInVirtualKeySection                        = SevError | 0x021;
+  static ERROR_InvalidOuts                                    = SevError | 0x022;
+  static ERROR_ContextInVirtualKeySection                     = SevError | 0x024;
+  static ERROR_InvalidUse                                     = SevError | 0x025;
+  static ERROR_GroupDoesNotExist                              = SevError | 0x026;
+  static ERROR_VirtualKeyNotAllowedHere                       = SevError | 0x027;
+  static ERROR_InvalidSwitch                                  = SevError | 0x028;
+  static ERROR_NoTokensFound                                  = SevError | 0x029;
+  static ERROR_InvalidLineContinuation                        = SevError | 0x02A;
+  static ERROR_LineTooLong                                    = SevError | 0x02B;
+  static ERROR_InvalidCopyright                               = SevError | 0x02C;
+  static ERROR_CodeInvalidInThisSection                       = SevError | 0x02D;
+  static ERROR_InvalidMessage                                 = SevError | 0x02E;
+  static ERROR_InvalidLanguageName                            = SevError | 0x02F;
+  static ERROR_InvalidBitmapLine                              = SevError | 0x030;
+  static ERROR_CannotReadBitmapFile                           = SevError | 0x031;
+  static ERROR_IndexDoesNotPointToAny                         = SevError | 0x032;
+  static ERROR_ReservedCharacter                              = SevError | 0x033;
+  static ERROR_InvalidCharacter                               = SevError | 0x034;
+  static ERROR_InvalidCall                                    = SevError | 0x035;
+  static ERROR_CallInVirtualKeySection                        = SevError | 0x036;
+  static ERROR_CodeInvalidInKeyStore                          = SevError | 0x037;
+  static ERROR_CannotLoadIncludeFile                          = SevError | 0x038;
 
-  static ERROR_60FeatureOnly_EthnologueCode                   = SevError | 0x0039;
-  static ERROR_60FeatureOnly_MnemonicLayout                   = SevError | 0x003A;
-  static ERROR_60FeatureOnly_OldCharPosMatching               = SevError | 0x003B;
-  static ERROR_60FeatureOnly_NamedCodes                       = SevError | 0x003C;
-  static ERROR_60FeatureOnly_Contextn                         = SevError | 0x003D;
-  static ERROR_501FeatureOnly_Call                            = SevError | 0x003E;
+  static ERROR_60FeatureOnly_EthnologueCode                   = SevError | 0x039;
+  static ERROR_60FeatureOnly_MnemonicLayout                   = SevError | 0x03A;
+  static ERROR_60FeatureOnly_OldCharPosMatching               = SevError | 0x03B;
+  static ERROR_60FeatureOnly_NamedCodes                       = SevError | 0x03C;
+  static ERROR_60FeatureOnly_Contextn                         = SevError | 0x03D;
+  static ERROR_501FeatureOnly_Call                            = SevError | 0x03E;
 
-  static ERROR_InvalidNamedCode                               = SevError | 0x003F;
-  static ERROR_InvalidSystemStore                             = SevError | 0x0040;
+  static ERROR_InvalidNamedCode                               = SevError | 0x03F;
+  static ERROR_InvalidSystemStore                             = SevError | 0x040;
 
-  static ERROR_60FeatureOnly_VirtualCharKey                   = SevError | 0x0044;
+  static ERROR_60FeatureOnly_VirtualCharKey                   = SevError | 0x044;
 
-  static ERROR_VersionAlreadyIncluded                         = SevError | 0x0045;
+  static ERROR_VersionAlreadyIncluded                         = SevError | 0x045;
 
-  static ERROR_70FeatureOnly                                  = SevError | 0x0046;
+  static ERROR_70FeatureOnly                                  = SevError | 0x046;
 
-  static ERROR_80FeatureOnly                                  = SevError | 0x0047;
-  static ERROR_InvalidInVirtualKeySection                     = SevError | 0x0048;
-  static ERROR_InvalidIf                                      = SevError | 0x0049;
-  static ERROR_InvalidReset                                   = SevError | 0x004A;
-  static ERROR_InvalidSet                                     = SevError | 0x004B;
-  static ERROR_InvalidSave                                    = SevError | 0x004C;
+  static ERROR_80FeatureOnly                                  = SevError | 0x047;
+  static ERROR_InvalidInVirtualKeySection                     = SevError | 0x048;
+  static ERROR_InvalidIf                                      = SevError | 0x049;
+  static ERROR_InvalidReset                                   = SevError | 0x04A;
+  static ERROR_InvalidSet                                     = SevError | 0x04B;
+  static ERROR_InvalidSave                                    = SevError | 0x04C;
 
-  static ERROR_InvalidEthnologueCode                          = SevError | 0x004D;
+  static ERROR_InvalidEthnologueCode                          = SevError | 0x04D;
 
-  static FATAL_CannotCreateTempfile                           = SevFatal | 0x004E;
+  static FATAL_CannotCreateTempfile                           = SevFatal | 0x04E;
 
-  static ERROR_90FeatureOnly_IfSystemStores                   = SevError | 0x004F;
-  static ERROR_IfSystemStore_NotFound                         = SevError | 0x0050;
-  static ERROR_90FeatureOnly_SetSystemStores                  = SevError | 0x0051;
-  static ERROR_SetSystemStore_NotFound                        = SevError | 0x0052;
-  static ERROR_90FeatureOnlyVirtualKeyDictionary              = SevError | 0x0053;
+  static ERROR_90FeatureOnly_IfSystemStores                   = SevError | 0x04F;
+  static ERROR_IfSystemStore_NotFound                         = SevError | 0x050;
+  static ERROR_90FeatureOnly_SetSystemStores                  = SevError | 0x051;
+  static ERROR_SetSystemStore_NotFound                        = SevError | 0x052;
+  static ERROR_90FeatureOnlyVirtualKeyDictionary              = SevError | 0x053;
 
-  static ERROR_NotSupportedInKeymanWebContext                 = SevError | 0x0054;
-  static ERROR_NotSupportedInKeymanWebOutput                  = SevError | 0x0055;
-  static ERROR_NotSupportedInKeymanWebStore                   = SevError | 0x0056;
-  static ERROR_VirtualCharacterKeysNotSupportedInKeymanWeb    = SevError | 0x0057;
-  static ERROR_VirtualKeysNotValidForMnemonicLayouts          = SevError | 0x0058;
-  static ERROR_InvalidTouchLayoutFile                         = SevError | 0x0059;
-  static ERROR_TouchLayoutInvalidIdentifier                   = SevError | 0x005A;
-  static ERROR_InvalidKeyCode                                 = SevError | 0x005B;
-  static ERROR_90FeatureOnlyLayoutFile                        = SevError | 0x005C;
-  static ERROR_90FeatureOnlyKeyboardVersion                   = SevError | 0x005D;
-  static ERROR_KeyboardVersionFormatInvalid                   = SevError | 0x005E;
-  static ERROR_ContextExHasInvalidOffset                      = SevError | 0x005F;
-  static ERROR_90FeatureOnlyEmbedCSS                          = SevError | 0x0060;
-  static ERROR_90FeatureOnlyTargets                           = SevError | 0x0061;
-  static ERROR_ContextAndIndexInvalidInMatchNomatch           = SevError | 0x0062;
-  static ERROR_140FeatureOnlyContextAndNotAnyWeb              = SevError | 0x0063;
+  static ERROR_NotSupportedInKeymanWebContext                 = SevError | 0x054;
+  static ERROR_NotSupportedInKeymanWebOutput                  = SevError | 0x055;
+  static ERROR_NotSupportedInKeymanWebStore                   = SevError | 0x056;
+  static ERROR_VirtualCharacterKeysNotSupportedInKeymanWeb    = SevError | 0x057;
+  static ERROR_VirtualKeysNotValidForMnemonicLayouts          = SevError | 0x058;
+  static ERROR_InvalidTouchLayoutFile                         = SevError | 0x059;
+  static ERROR_TouchLayoutInvalidIdentifier                   = SevError | 0x05A;
+  static ERROR_InvalidKeyCode                                 = SevError | 0x05B;
+  static ERROR_90FeatureOnlyLayoutFile                        = SevError | 0x05C;
+  static ERROR_90FeatureOnlyKeyboardVersion                   = SevError | 0x05D;
+  static ERROR_KeyboardVersionFormatInvalid                   = SevError | 0x05E;
+  static ERROR_ContextExHasInvalidOffset                      = SevError | 0x05F;
+  static ERROR_90FeatureOnlyEmbedCSS                          = SevError | 0x060;
+  static ERROR_90FeatureOnlyTargets                           = SevError | 0x061;
+  static ERROR_ContextAndIndexInvalidInMatchNomatch           = SevError | 0x062;
+  static ERROR_140FeatureOnlyContextAndNotAnyWeb              = SevError | 0x063;
 
-  static ERROR_ExpansionMustFollowCharacterOrVKey             = SevError | 0x0064;
-  static ERROR_VKeyExpansionMustBeFollowedByVKey              = SevError | 0x0065;
-  static ERROR_CharacterExpansionMustBeFollowedByCharacter    = SevError | 0x0066;
-  static ERROR_VKeyExpansionMustUseConsistentShift            = SevError | 0x0067;
-  static ERROR_ExpansionMustBePositive                        = SevError | 0x0068;
+  static ERROR_ExpansionMustFollowCharacterOrVKey             = SevError | 0x064;
+  static ERROR_VKeyExpansionMustBeFollowedByVKey              = SevError | 0x065;
+  static ERROR_CharacterExpansionMustBeFollowedByCharacter    = SevError | 0x066;
+  static ERROR_VKeyExpansionMustUseConsistentShift            = SevError | 0x067;
+  static ERROR_ExpansionMustBePositive                        = SevError | 0x068;
 
-  static ERROR_CasedKeysMustContainOnlyVirtualKeys            = SevError | 0x0069;
-  static ERROR_CasedKeysMustNotIncludeShiftStates             = SevError | 0x006A;
-  static ERROR_CasedKeysNotSupportedWithMnemonicLayout        = SevError | 0x006B;
+  static ERROR_CasedKeysMustContainOnlyVirtualKeys            = SevError | 0x069;
+  static ERROR_CasedKeysMustNotIncludeShiftStates             = SevError | 0x06A;
+  static ERROR_CasedKeysNotSupportedWithMnemonicLayout        = SevError | 0x06B;
 
-  static ERROR_CannotUseReadWriteGroupFromReadonlyGroup       = SevError | 0x006C;
-  static ERROR_StatementNotPermittedInReadonlyGroup           = SevError | 0x006D;
-  static ERROR_OutputInReadonlyGroup                          = SevError | 0x006E;
-  static ERROR_NewContextGroupMustBeReadonly                  = SevError | 0x006F;
-  static ERROR_PostKeystrokeGroupMustBeReadonly               = SevError | 0x0070;
+  static ERROR_CannotUseReadWriteGroupFromReadonlyGroup       = SevError | 0x06C;
+  static ERROR_StatementNotPermittedInReadonlyGroup           = SevError | 0x06D;
+  static ERROR_OutputInReadonlyGroup                          = SevError | 0x06E;
+  static ERROR_NewContextGroupMustBeReadonly                  = SevError | 0x06F;
+  static ERROR_PostKeystrokeGroupMustBeReadonly               = SevError | 0x070;
 
-  static ERROR_DuplicateGroup                                 = SevError | 0x0071;
-  static ERROR_DuplicateStore                                 = SevError | 0x0072;
+  static ERROR_DuplicateGroup                                 = SevError | 0x071;
+  static ERROR_DuplicateStore                                 = SevError | 0x072;
 
-  static ERROR_RepeatedBegin                                  = SevError | 0x0073;
+  static ERROR_RepeatedBegin                                  = SevError | 0x073;
 
-  static WARN_TooManyWarnings                                 = SevWarn | 0x0080;
-  static WARN_OldVersion                                      = SevWarn | 0x0081;
-  static WARN_BitmapNotUsed                                   = SevWarn | 0x0082;
-  static WARN_CustomLanguagesNotSupported                     = SevWarn | 0x0083;
-  static WARN_KeyBadLength                                    = SevWarn | 0x0084;
-  static WARN_IndexStoreShort                                 = SevWarn | 0x0085;
-  static WARN_UnicodeInANSIGroup                              = SevWarn | 0x0086;
-  static WARN_ANSIInUnicodeGroup                              = SevWarn | 0x0087;
-  static WARN_UnicodeSurrogateUsed                            = SevWarn | 0x0088;
-  static WARN_ReservedCharacter                               = SevWarn | 0x0089;
-  static WARN_Info                                            = SevWarn | 0x008A;
-  static WARN_VirtualKeyWithMnemonicLayout                    = SevWarn | 0x008B;
-  static WARN_VirtualCharKeyWithPositionalLayout              = SevWarn | 0x008C;
-  static WARN_StoreAlreadyUsedAsOptionOrCall                  = SevWarn | 0x008D;
-  static WARN_StoreAlreadyUsedAsStoreOrCall                   = SevWarn | 0x008E;
-  static WARN_StoreAlreadyUsedAsStoreOrOption                 = SevWarn | 0x008F;
+  static WARN_TooManyWarnings                                 = SevWarn | 0x080;
+  static WARN_OldVersion                                      = SevWarn | 0x081;
+  static WARN_BitmapNotUsed                                   = SevWarn | 0x082;
+  static WARN_CustomLanguagesNotSupported                     = SevWarn | 0x083;
+  static WARN_KeyBadLength                                    = SevWarn | 0x084;
+  static WARN_IndexStoreShort                                 = SevWarn | 0x085;
+  static WARN_UnicodeInANSIGroup                              = SevWarn | 0x086;
+  static WARN_ANSIInUnicodeGroup                              = SevWarn | 0x087;
+  static WARN_UnicodeSurrogateUsed                            = SevWarn | 0x088;
+  static WARN_ReservedCharacter                               = SevWarn | 0x089;
+  static WARN_Info                                            = SevWarn | 0x08A;
+  static WARN_VirtualKeyWithMnemonicLayout                    = SevWarn | 0x08B;
+  static WARN_VirtualCharKeyWithPositionalLayout              = SevWarn | 0x08C;
+  static WARN_StoreAlreadyUsedAsOptionOrCall                  = SevWarn | 0x08D;
+  static WARN_StoreAlreadyUsedAsStoreOrCall                   = SevWarn | 0x08E;
+  static WARN_StoreAlreadyUsedAsStoreOrOption                 = SevWarn | 0x08F;
 
-  static WARN_PunctuationInEthnologueCode                     = SevWarn | 0x0090;
+  static WARN_PunctuationInEthnologueCode                     = SevWarn | 0x090;
 
-  static WARN_TouchLayoutMissingLayer                         = SevWarn | 0x0091;
-  static WARN_TouchLayoutCustomKeyNotDefined                  = SevWarn | 0x0092;
-  static WARN_TouchLayoutMissingRequiredKeys                  = SevWarn | 0x0093;
-  static WARN_HelpFileMissing                                 = SevWarn | 0x0094;
-  static WARN_EmbedJsFileMissing                              = SevWarn | 0x0095;
-  static WARN_TouchLayoutFileMissing                          = SevWarn | 0x0096;
-  static WARN_VisualKeyboardFileMissing                       = SevWarn | 0x0097;
-  static WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb       = SevWarn | 0x0098;
-  static WARN_TouchLayoutUnidentifiedKey                      = SevWarn | 0x0099;
-  static HINT_UnreachableKeyCode                              = SevHint | 0x009A;
+  static WARN_TouchLayoutMissingLayer                         = SevWarn | 0x091;
+  static WARN_TouchLayoutCustomKeyNotDefined                  = SevWarn | 0x092;
+  static WARN_TouchLayoutMissingRequiredKeys                  = SevWarn | 0x093;
+  static WARN_HelpFileMissing                                 = SevWarn | 0x094;
+  static WARN_EmbedJsFileMissing                              = SevWarn | 0x095;
+  static WARN_TouchLayoutFileMissing                          = SevWarn | 0x096;
+  static WARN_VisualKeyboardFileMissing                       = SevWarn | 0x097;
+  static WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb       = SevWarn | 0x098;
+  static WARN_TouchLayoutUnidentifiedKey                      = SevWarn | 0x099;
+  static HINT_UnreachableKeyCode                              = SevHint | 0x09A;
 
-  static WARN_CouldNotCopyJsonFile                            = SevWarn | 0x009B;
-  static WARN_PlatformNotInTargets                            = SevWarn | 0x009C;
+  static WARN_CouldNotCopyJsonFile                            = SevWarn | 0x09B;
+  static WARN_PlatformNotInTargets                            = SevWarn | 0x09C;
 
-  static WARN_HeaderStatementIsDeprecated                     = SevWarn | 0x009D;
-  static WARN_UseNotLastStatementInRule                       = SevWarn | 0x009E;
+  static WARN_HeaderStatementIsDeprecated                     = SevWarn | 0x09D;
+  static WARN_UseNotLastStatementInRule                       = SevWarn | 0x09E;
 
-  static WARN_TouchLayoutFontShouldBeSameForAllPlatforms      = SevWarn | 0x009F;
-  static WARN_InvalidJSONMetadataFile                         = SevWarn | 0x00A0;
-  static WARN_JSONMetadataOSKFontShouldMatchTouchFont         = SevWarn | 0x00A1;
-  static WARN_KVKFileIsInSourceFormat                         = SevWarn | 0x00A2;
+  static WARN_TouchLayoutFontShouldBeSameForAllPlatforms      = SevWarn | 0x09F;
+  static WARN_InvalidJSONMetadataFile                         = SevWarn | 0x0A0;
+  static WARN_JSONMetadataOSKFontShouldMatchTouchFont         = SevWarn | 0x0A1;
+  static WARN_KVKFileIsInSourceFormat                         = SevWarn | 0x0A2;
 
-  static WARN_DontMixChiralAndNonChiralModifiers              = SevWarn | 0x00A3;
-  static WARN_MixingLeftAndRightModifiers                     = SevWarn | 0x00A4;
+  static WARN_DontMixChiralAndNonChiralModifiers              = SevWarn | 0x0A3;
+  static WARN_MixingLeftAndRightModifiers                     = SevWarn | 0x0A4;
 
-  static WARN_LanguageHeadersDeprecatedInKeyman10             = SevWarn | 0x00A5;
+  static WARN_LanguageHeadersDeprecatedInKeyman10             = SevWarn | 0x0A5;
 
-  static HINT_NonUnicodeFile                                  = SevHint | 0x00A6;
+  static HINT_NonUnicodeFile                                  = SevHint | 0x0A6;
 
-  static WARN_TooManyErrorsOrWarnings                         = SevWarn | 0x00A7;
+  static WARN_TooManyErrorsOrWarnings                         = SevWarn | 0x0A7;
 
-  static WARN_HotkeyHasInvalidModifier                        = SevWarn | 0x00A8;
+  static WARN_HotkeyHasInvalidModifier                        = SevWarn | 0x0A8;
 
-  static WARN_TouchLayoutSpecialLabelOnNormalKey              = SevWarn | 0x00A9;
+  static WARN_TouchLayoutSpecialLabelOnNormalKey              = SevWarn | 0x0A9;
 
-  static WARN_OptionStoreNameInvalid                          = SevWarn | 0x00AA;
+  static WARN_OptionStoreNameInvalid                          = SevWarn | 0x0AA;
 
-  static WARN_NulNotFirstStatementInContext                   = SevWarn | 0x00AB;
-  static WARN_IfShouldBeAtStartOfContext                      = SevWarn | 0x00AC;
+  static WARN_NulNotFirstStatementInContext                   = SevWarn | 0x0AB;
+  static WARN_IfShouldBeAtStartOfContext                      = SevWarn | 0x0AC;
 
-  static WARN_KeyShouldIncludeNCaps                           = SevWarn | 0x00AD;
+  static WARN_KeyShouldIncludeNCaps                           = SevWarn | 0x0AD;
 
-  static HINT_UnreachableRule                                 = SevHint | 0x00AE;
+  static HINT_UnreachableRule                                 = SevHint | 0x0AE;
 
-  static FATAL_BufferOverflow                                 = SevFatal | 0x00C0;
-  static FATAL_Break                                          = SevFatal | 0x00C1;
+  static FATAL_BufferOverflow                                 = SevFatal | 0x0C0;
+  static FATAL_Break                                          = SevFatal | 0x0C1;
 };
 
 export function mapErrorFromKmcmplib(line: number, code: number, msg: string): CompilerEvent {

--- a/developer/src/kmc-kmn/test/test-messages.ts
+++ b/developer/src/kmc-kmn/test/test-messages.ts
@@ -5,12 +5,13 @@ import { CompilerMessages } from '../src/compiler/messages.js';
 import { TestCompilerCallbacks, verifyCompilerMessagesObject } from '@keymanapp/developer-test-helpers';
 import { makePathToFixture } from './helpers/index.js';
 import { KmnCompiler } from '../src/main.js';
+import { CompilerErrorNamespace } from '@keymanapp/common-types';
 
 describe('CompilerMessages', function () {
   const callbacks = new TestCompilerCallbacks();
 
   it('should have a valid CompilerMessages object', function() {
-    return verifyCompilerMessagesObject(CompilerMessages);
+    return verifyCompilerMessagesObject(CompilerMessages, CompilerErrorNamespace.KmnCompiler);
   });
 
   //

--- a/developer/src/kmc-ldml/test/test-messages.ts
+++ b/developer/src/kmc-ldml/test/test-messages.ts
@@ -1,9 +1,10 @@
 import 'mocha';
 import { CompilerMessages } from '../src/compiler/messages.js';
 import { verifyCompilerMessagesObject } from '@keymanapp/developer-test-helpers';
+import { CompilerErrorNamespace } from '@keymanapp/common-types';
 
 describe('CompilerMessages', function () {
   it('should have a valid CompilerMessages object', function() {
-    return verifyCompilerMessagesObject(CompilerMessages);
+    return verifyCompilerMessagesObject(CompilerMessages, CompilerErrorNamespace.LdmlKeyboardCompiler);
   });
 });

--- a/developer/src/kmc-model/test/test-messages.ts
+++ b/developer/src/kmc-model/test/test-messages.ts
@@ -1,9 +1,10 @@
 import 'mocha';
 import { ModelCompilerMessages } from '../src/model-compiler-errors.js';
 import { verifyCompilerMessagesObject } from '@keymanapp/developer-test-helpers';
+import { CompilerErrorNamespace } from '@keymanapp/common-types';
 
 describe('ModelCompilerMessages', function () {
   it('should have a valid ModelCompilerMessages object', function() {
-    return verifyCompilerMessagesObject(ModelCompilerMessages);
+    return verifyCompilerMessagesObject(ModelCompilerMessages, CompilerErrorNamespace.ModelCompiler);
   });
 });

--- a/developer/src/kmc-package/test/test-messages.ts
+++ b/developer/src/kmc-package/test/test-messages.ts
@@ -5,13 +5,14 @@ import { CompilerMessages } from '../src/compiler/messages.js';
 import { makePathToFixture } from './helpers/index.js';
 import { KmpCompiler } from '../src/compiler/kmp-compiler.js';
 import { PackageValidation } from '../src/compiler/package-validation.js';
+import { CompilerErrorNamespace } from '@keymanapp/common-types';
 
 const debug = false;
 const callbacks = new TestCompilerCallbacks();
 
 describe('CompilerMessages', function () {
   it('should have a valid CompilerMessages object', function() {
-    return verifyCompilerMessagesObject(CompilerMessages);
+    return verifyCompilerMessagesObject(CompilerMessages, CompilerErrorNamespace.PackageCompiler);
   });
 
 

--- a/developer/src/kmc/test/test-messages.ts
+++ b/developer/src/kmc/test/test-messages.ts
@@ -4,10 +4,11 @@ import { InfrastructureMessages } from '../src/messages/messages.js';
 import { verifyCompilerMessagesObject } from '@keymanapp/developer-test-helpers';
 import { makePathToFixture } from './helpers/index.js';
 import { NodeCompilerCallbacks } from '../src/messages/NodeCompilerCallbacks.js';
+import { CompilerErrorNamespace } from '@keymanapp/common-types';
 
 describe('InfrastructureMessages', function () {
   it('should have a valid InfrastructureMessages object', function() {
-    return verifyCompilerMessagesObject(InfrastructureMessages);
+    return verifyCompilerMessagesObject(InfrastructureMessages, CompilerErrorNamespace.Infrastructure);
   });
 
   //


### PR DESCRIPTION
Fixes #8998.

kmc-kmn messages were broken down into sub-namespaces, but the range overlapped the reserved namespace mask range. Fixed the message values, added a new test to the verifyCompilerMessagesObject function to verify that messages don't creep outside their namespace, and defined new masks (in CompilerErrorSeverity enum... hmm) to help.

I opted to remove the leading `0` in the messages for kmc-kmn as I had to correct a number of them anyway, but not the messages in remaining units at this time (it's not an error, but just slightly misleading as we only have 12 bits, not 16 to play with).

It is safe to reassign these messages as they were only assigned in 17.0 alpha.

@keymanapp-test-bot skip