### PR TITLE
fix(windows): qr code id uses keyboard name and not package name

### DIFF
--- a/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
@@ -163,26 +163,29 @@
                   <xsl:with-param name="id">share_<xsl:value-of select="id"/></xsl:with-param>
                   <xsl:with-param name="className">kbd_button</xsl:with-param>
                   <xsl:with-param name="caption"><xsl:value-of select="$locale/string[@name='S_Keyboard_Share']"/></xsl:with-param>
-                  <xsl:with-param name="command">javascript:showKeyboardLink('<xsl:value-of select="../../id" />')</xsl:with-param>
+                  <xsl:with-param name="command">javascript:showKeyboardLink('<xsl:value-of select="id" />')</xsl:with-param>
                 </xsl:call-template>
                 <div class='qrcode'>
-                  <xsl:attribute name='id'>qrcode-<xsl:value-of select="../../id" /></xsl:attribute>
+                  <!-- Use the keyboard id to ensure unique id -->
+                  <xsl:attribute name='id'>qrcode-<xsl:value-of select="id" /></xsl:attribute>
                   <div class='qrcode_back'>
                     <xsl:attribute name="onclick">return hideKeyboardLink('<xsl:value-of select="../../id" />')</xsl:attribute>
                   </div>
                   <div class='qrcode_popup'>
                     <div>
-                      <xsl:attribute name='id'>qrcode-img-<xsl:value-of select="../../id" /></xsl:attribute>
+                      <!-- Use the keyboard id to ensure unique xml id -->
+                      <xsl:attribute name='id'>qrcode-img-<xsl:value-of select="id" /></xsl:attribute>
                     </div>
                     <div class='qrcode_caption'>
                       <xsl:value-of select="$locale/string[@name='S_Keyboard_Share_QRCode']"/>&#160;
                       <a>
+                        <!-- Use the package id for the actual URL link -->
                         <xsl:attribute name="href">keyman:link?url=<xsl:value-of select="/Keyman/keyman-com" />/go/keyboard/<xsl:value-of select="../../id" />/share</xsl:attribute>
                         <xsl:value-of select="$locale/string[@name='S_Keyboard_Share_Link']"/>
                       </a>
                       <xsl:value-of select="$locale/string[@name='S_Keyboard_Share_LinkSuffix']"/>
                     </div>
-                    <script>new QRCode(document.getElementById("qrcode-img-<xsl:value-of select="../../id"/>"), {
+                    <script>new QRCode(document.getElementById("qrcode-img-<xsl:value-of select="id"/>"), {
                         text: '<xsl:value-of select="/Keyman/keyman-com" />/go/keyboard/<xsl:value-of select="../../id"/>/share',
                         width: 256,
                         height: 256

--- a/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_keyboardlist.xsl
@@ -169,7 +169,7 @@
                   <!-- Use the keyboard id to ensure unique id -->
                   <xsl:attribute name='id'>qrcode-<xsl:value-of select="id" /></xsl:attribute>
                   <div class='qrcode_back'>
-                    <xsl:attribute name="onclick">return hideKeyboardLink('<xsl:value-of select="../../id" />')</xsl:attribute>
+                    <xsl:attribute name="onclick">return hideKeyboardLink('<xsl:value-of select="id" />')</xsl:attribute>
                   </div>
                   <div class='qrcode_popup'>
                     <div>


### PR DESCRIPTION
The QR code class and pop-up xml attribute id now uses the keyboard name and not the keyboard package name. However the link if the keyboard is part of a package still uses the package name for the URL.

# USER TESTING

# TEST_QRCODE_PACKAGE

1. Install build linked in this PR
2. Open Keyman Configuration dialog. 
3. Download and install Syriac/Aramaic keyboard.
4. Notice that three keyboards namely Aramaic (Hebrew layout), Syriac (Arabic layout) and Syriac (Phonetic layout) keyboards are available under Syriac/Aramaic name. 
5. Click 'Aramaic (Hebrew layout)'  keyboard in Keyboard Layouts view. 
6. Click 'Share keyboard' button. 

Expected Result: Just one QR Code is shown.

7. Click 'Syriac (Arabic layout)` keyboard in Keyboard Layouts view. 
8. Click 'Share keyboard' button.

Expected Result:
A QR Code now shows. 

# TEST_QRCODE_SINGLE

1. Open Keyman Configuration dialog. 
2. Download and install single keyboard layout such as IPA (SIL)
3. Click 'IPA (SIL)'  keyboard in Keyboard Layouts view. 
4. Click 'Share keyboard' button. 

Expected Result:
A QR Code now shows. 


