### PR TITLE
chore(mac): move from altool to notarytool

### DIFF
--- a/mac/build.sh
+++ b/mac/build.sh
@@ -460,6 +460,7 @@ if $PREPRELEASE || $NOTARIZE; then
         --apple-id "$APPSTORECONNECT_USERNAME" \
         --team-id "$DEVELOPMENT_TEAM" \
         --password "$APPSTORECONNECT_PASSWORD" \
+        --output-format json \
         --wait \
         "$TARGET_ZIP_PATH" > "$NOTARYTOOL_LOG_PATH"
 

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -440,7 +440,7 @@ if $PREPRELEASE || $NOTARIZE; then
     TARGET_PATH="$KM4MIM_BASE_PATH/build/$CONFIG"
     TARGET_APP_PATH="$TARGET_PATH/$PRODUCT_NAME.app"
     TARGET_ZIP_PATH="$TARGET_PATH/$PRODUCT_NAME.zip"
-    ALTOOL_LOG_PATH="$TARGET_PATH/altool.log"
+    NOTARYTOOL_LOG_PATH="$TARGET_PATH/notarytool.log"
 
     # Note: get-task-allow entitlement must be *off* in our release build (to do this, don't include base entitlements in project build settings)
 
@@ -456,48 +456,24 @@ if $PREPRELEASE || $NOTARIZE; then
 
     builder_heading "Uploading Keyman.zip to Apple for notarization"
 
-    xcrun altool --notarize-app --primary-bundle-id "com.Keyman.im.zip" --asc-provider "$APPSTORECONNECT_PROVIDER" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --file "$TARGET_ZIP_PATH" --output-format xml > $ALTOOL_LOG_PATH || (
-      ALTOOL_CODE=$?
-      cat "$ALTOOL_LOG_PATH"
-      builder_die "altool failed with code $ALTOOL_CODE"
-    )
-    cat "$ALTOOL_LOG_PATH"
+    xcrun notarytool submit \
+        --apple-id "$APPSTORECONNECT_USERNAME" \
+        --team-id "$DEVELOPMENT_TEAM" \
+        --password "$APPSTORECONNECT_PASSWORD" \
+        --wait \
+        "$TARGET_ZIP_PATH" > "$NOTARYTOOL_LOG_PATH"
 
-    ALTOOL_UUID=$(/usr/libexec/PlistBuddy -c "Print notarization-upload:RequestUUID" "$ALTOOL_LOG_PATH")
-    ALTOOL_FINISHED=0
-
-    while [ $ALTOOL_FINISHED -eq 0 ]
-    do
-      # We'll sleep 30 seconds before checking status, to give the altool server time to process the archive
-      echo "Waiting 30 seconds for status"
-      sleep 30
-      xcrun altool --notarization-info "$ALTOOL_UUID" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --output-format xml > "$ALTOOL_LOG_PATH" || (
-        ALTOOL_CODE=$?
-        ALTOOL_PRODUCT_ERROR=$(/usr/libexec/PlistBuddy -c "Print product-errors:0:code" "$ALTOOL_LOG_PATH")
-        if [ "$ALTOOL_PRODUCT_ERROR" == 1519 ]; then
-            # Could not find the RequestUUID; this is a temporary error sometimes returned by Apple.
-            # We'll just keep retrying.
-            continue;
-        fi
-        cat "$ALTOOL_LOG_PATH"
-        builder_die "altool failed with code $ALTOOL_CODE"
-      )
-      ALTOOL_STATUS=$(/usr/libexec/PlistBuddy -c "Print notarization-info:Status" "$ALTOOL_LOG_PATH")
-      if [ "$ALTOOL_STATUS" == "success" ]; then
-        ALTOOL_FINISHED=1
-      elif [ "$ALTOOL_STATUS" != "in progress" ]; then
-        # Probably failing with 'invalid'
-        cat "$ALTOOL_LOG_PATH"
-        ALTOOL_LOG_URL=$(/usr/libexec/PlistBuddy -c "Print notarization-info:LogFileURL" "$ALTOOL_LOG_PATH")
-        curl "$ALTOOL_LOG_URL"
-        builder_die "Notarization failed with $ALTOOL_STATUS; check log at $ALTOOL_LOG_PATH"
-      fi
-    done
+    cat "$NOTARYTOOL_LOG_PATH"
+    NOTARYTOOL_SUBMISSION_ID=`cat "$NOTARYTOOL_LOG_PATH"`
 
     builder_heading "Notarization completed successfully. Review logs below for any warnings."
-    cat "$ALTOOL_LOG_PATH"
-    ALTOOL_LOG_URL=$(/usr/libexec/PlistBuddy -c "Print notarization-info:LogFileURL" "$ALTOOL_LOG_PATH")
-    curl "$ALTOOL_LOG_URL"
+
+    xcrun notarytool log \
+        --apple-id "$APPSTORECONNECT_USERNAME" \
+        --team-id "$DEVELOPMENT_TEAM" \
+        --password "$APPSTORECONNECT_PASSWORD" \
+        "$NOTARYTOOL_SUBMISSION_ID"
+
     echo
     builder_heading "Attempting to staple notarization to Keyman.app"
     xcrun stapler staple "$TARGET_APP_PATH" || builder_die "stapler failed"

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -463,9 +463,15 @@ if $PREPRELEASE || $NOTARIZE; then
         --output-format json \
         --wait \
         "$TARGET_ZIP_PATH" > "$NOTARYTOOL_LOG_PATH"
+    # notarytool output: {"status":"Accepted","id":"ca62bba0-6c49-43c2-90d8-83a8ef306e0f","message":"Processing complete"}
 
     cat "$NOTARYTOOL_LOG_PATH"
-    NOTARYTOOL_SUBMISSION_ID=`cat "$NOTARYTOOL_LOG_PATH"`
+    NOTARYTOOL_STATUS=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .status`
+    NOTARYTOOL_SUBMISSION_ID=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .id`
+    if [[ "$NOTARYTOOL_STATUS" != Accepted ]]; then
+        # We won't assume notarytool returns an error code if status != Accepted
+        builder_die "Notarization failed with $NOTARYTOOL_STATUS"
+    fi
 
     builder_heading "Notarization completed successfully. Review logs below for any warnings."
 

--- a/mac/mac-utils.inc.sh
+++ b/mac/mac-utils.inc.sh
@@ -1,0 +1,38 @@
+
+if [ -z "${DEVELOPMENT_TEAM+x}" ]; then
+    DEVELOPMENT_TEAM=3YE4W86L3G
+fi
+
+function mac_notarize() {
+  local TARGET_PATH="$1"
+  local TARGET_FILE="$2"
+
+  local NOTARYTOOL_LOG_PATH="$TARGET_PATH/notarytool.log"
+
+  xcrun notarytool submit \
+      --apple-id "$APPSTORECONNECT_USERNAME" \
+      --team-id "$DEVELOPMENT_TEAM" \
+      --password "$APPSTORECONNECT_PASSWORD" \
+      --output-format json \
+      --wait \
+      "$TARGET_FILE" > "$NOTARYTOOL_LOG_PATH"
+  # notarytool output: {"status":"Accepted","id":"ca62bba0-6c49-43c2-90d8-83a8ef306e0f","message":"Processing complete"}
+
+  cat "$NOTARYTOOL_LOG_PATH"
+  local NOTARYTOOL_STATUS=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .status`
+  local NOTARYTOOL_SUBMISSION_ID=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .id`
+  if [[ "$NOTARYTOOL_STATUS" != Accepted ]]; then
+      # We won't assume notarytool returns an error code if status != Accepted
+      builder_die "Notarization failed with $NOTARYTOOL_STATUS"
+  fi
+
+  builder_heading "Notarization completed successfully. Review logs below for any warnings."
+
+  xcrun notarytool log \
+        --apple-id "$APPSTORECONNECT_USERNAME" \
+        --team-id "$DEVELOPMENT_TEAM" \
+        --password "$APPSTORECONNECT_PASSWORD" \
+        "$NOTARYTOOL_SUBMISSION_ID"
+
+  rm -f "$NOTARYTOOL_LOG_PATH"
+}

--- a/mac/setup/build.sh
+++ b/mac/setup/build.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-
-set -e
-set -u
-
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
@@ -11,6 +7,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 # Include our resource functions; they're pretty useful!
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/mac/mac-utils.inc.sh"
 
 # Please note that this build script (understandably) assumes that it is running on Mac OS X.
 verify_on_mac
@@ -81,40 +78,14 @@ codesign --force --options runtime --deep --sign "${CERTIFICATE_ID}" "$TARGETAPP
 
 TARGET_ZIP_PATH="$TARGETPATH/Install Keyman.zip"
 TARGET_APP_PATH="$TARGETAPP"
-NOTARYTOOL_LOG_PATH="$TARGETPATH/notarytool.log"
 
 builder_heading "Zipping Install Keyman.app for notarization to $TARGET_ZIP_PATH"
 
 /usr/bin/ditto -c -k --keepParent "$TARGET_APP_PATH" "$TARGET_ZIP_PATH"
 
 builder_heading "Uploading Install Keyman.zip to Apple for notarization"
+mac_notarize "$TARGETPATH" "$TARGET_ZIP_PATH"
 
-xcrun notarytool submit \
-    --apple-id "$APPSTORECONNECT_USERNAME" \
-    --team-id "$DEVELOPMENT_TEAM" \
-    --password "$APPSTORECONNECT_PASSWORD" \
-    --output-format json \
-    --wait \
-    "$TARGET_ZIP_PATH" > "$NOTARYTOOL_LOG_PATH"
-# notarytool output: {"status":"Accepted","id":"ca62bba0-6c49-43c2-90d8-83a8ef306e0f","message":"Processing complete"}
-
-cat "$NOTARYTOOL_LOG_PATH"
-NOTARYTOOL_STATUS=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .status`
-NOTARYTOOL_SUBMISSION_ID=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .id`
-if [[ "$NOTARYTOOL_STATUS" != Accepted ]]; then
-    # We won't assume notarytool returns an error code if status != Accepted
-    builder_die "Notarization failed with $NOTARYTOOL_STATUS"
-fi
-
-builder_heading "Notarization completed successfully. Review logs below for any warnings."
-
-xcrun notarytool log \
-      --apple-id "$APPSTORECONNECT_USERNAME" \
-      --team-id "$DEVELOPMENT_TEAM" \
-      --password "$APPSTORECONNECT_PASSWORD" \
-      "$NOTARYTOOL_SUBMISSION_ID"
-
-echo
 builder_heading "Attempting to staple notarization to Install Keyman.app"
 xcrun stapler staple "$TARGET_APP_PATH" || builder_die "stapler failed"
 

--- a/mac/setup/build.sh
+++ b/mac/setup/build.sh
@@ -81,7 +81,7 @@ codesign --force --options runtime --deep --sign "${CERTIFICATE_ID}" "$TARGETAPP
 
 TARGET_ZIP_PATH="$TARGETPATH/Install Keyman.zip"
 TARGET_APP_PATH="$TARGETAPP"
-ALTOOL_LOG_PATH="$TARGETPATH/altool.log"
+NOTARYTOOL_LOG_PATH="$TARGETPATH/notarytool.log"
 
 builder_heading "Zipping Install Keyman.app for notarization to $TARGET_ZIP_PATH"
 
@@ -89,34 +89,31 @@ builder_heading "Zipping Install Keyman.app for notarization to $TARGET_ZIP_PATH
 
 builder_heading "Uploading Install Keyman.zip to Apple for notarization"
 
-xcrun altool --notarize-app --primary-bundle-id "com.Keyman.install.zip" --asc-provider "$APPSTORECONNECT_PROVIDER" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --file "$TARGET_ZIP_PATH" --output-format xml > $ALTOOL_LOG_PATH || builder_die "altool failed"
-cat "$ALTOOL_LOG_PATH"
+xcrun notarytool submit \
+    --apple-id "$APPSTORECONNECT_USERNAME" \
+    --team-id "$DEVELOPMENT_TEAM" \
+    --password "$APPSTORECONNECT_PASSWORD" \
+    --output-format json \
+    --wait \
+    "$TARGET_ZIP_PATH" > "$NOTARYTOOL_LOG_PATH"
+# notarytool output: {"status":"Accepted","id":"ca62bba0-6c49-43c2-90d8-83a8ef306e0f","message":"Processing complete"}
 
-ALTOOL_UUID=$(/usr/libexec/PlistBuddy -c "Print notarization-upload:RequestUUID" "$ALTOOL_LOG_PATH")
-ALTOOL_FINISHED=0
-
-while [ $ALTOOL_FINISHED -eq 0 ]
-do
-    # We'll sleep 30 seconds before checking status, to give the altool server time to process the archive
-    echo "Waiting 30 seconds for status"
-    sleep 30
-    xcrun altool --notarization-info "$ALTOOL_UUID" --username "$APPSTORECONNECT_USERNAME" --password @env:APPSTORECONNECT_PASSWORD --output-format xml > "$ALTOOL_LOG_PATH" || builder_die "altool failed"
-    ALTOOL_STATUS=$(/usr/libexec/PlistBuddy -c "Print notarization-info:Status" "$ALTOOL_LOG_PATH")
-    if [ "$ALTOOL_STATUS" == "success" ]; then
-    ALTOOL_FINISHED=1
-    elif [ "$ALTOOL_STATUS" != "in progress" ]; then
-    # Probably failing with 'invalid'
-    cat "$ALTOOL_LOG_PATH"
-    ALTOOL_LOG_URL=$(/usr/libexec/PlistBuddy -c "Print notarization-info:LogFileURL" "$ALTOOL_LOG_PATH")
-    curl "$ALTOOL_LOG_URL"
-    builder_die "Notarization failed with $ALTOOL_STATUS; check log at $ALTOOL_LOG_PATH"
-    fi
-done
+cat "$NOTARYTOOL_LOG_PATH"
+NOTARYTOOL_STATUS=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .status`
+NOTARYTOOL_SUBMISSION_ID=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .id`
+if [[ "$NOTARYTOOL_STATUS" != Accepted ]]; then
+    # We won't assume notarytool returns an error code if status != Accepted
+    builder_die "Notarization failed with $NOTARYTOOL_STATUS"
+fi
 
 builder_heading "Notarization completed successfully. Review logs below for any warnings."
-cat "$ALTOOL_LOG_PATH"
-ALTOOL_LOG_URL=$(/usr/libexec/PlistBuddy -c "Print notarization-info:LogFileURL" "$ALTOOL_LOG_PATH")
-curl "$ALTOOL_LOG_URL"
+
+xcrun notarytool log \
+      --apple-id "$APPSTORECONNECT_USERNAME" \
+      --team-id "$DEVELOPMENT_TEAM" \
+      --password "$APPSTORECONNECT_PASSWORD" \
+      "$NOTARYTOOL_SUBMISSION_ID"
+
 echo
 builder_heading "Attempting to staple notarization to Install Keyman.app"
 xcrun stapler staple "$TARGET_APP_PATH" || builder_die "stapler failed"


### PR DESCRIPTION
Fixes #6881.

References for the transition to `notarytool`:
* https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool?changes=_3_3
* https://keith.github.io/xcode-man-pages/notarytool.1.html

@keymanapp-test-bot skip