### PR TITLE
change(web): internal-event convention consistency 🧩

### DIFF
--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -37,7 +37,7 @@ export interface ProcessorInitOptions {
 }
 
 interface EventMap {
-  statekeyChange: (stateKeys: typeof KeyboardProcessor.prototype.stateKeys) => void;
+  statekeychange: (stateKeys: typeof KeyboardProcessor.prototype.stateKeys) => void;
 }
 
 export default class KeyboardProcessor extends EventEmitter<EventMap> {
@@ -287,7 +287,7 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
       }
 
       if(stateMutation) {
-        this.emit('statekeyChange', this.stateKeys);
+        this.emit('statekeychange', this.stateKeys);
       }
     }
 

--- a/web/src/app/browser/src/hardwareEventKeyboard.ts
+++ b/web/src/app/browser/src/hardwareEventKeyboard.ts
@@ -389,7 +389,7 @@ export default class HardwareEventKeyboard extends HardKeyboard {
     }
 
     // Is synchronous.
-    this.emit('keyEvent', Levent, (ruleBehavior, error) => {
+    this.emit('keyevent', Levent, (ruleBehavior, error) => {
       resultCapture.LeventMatched = ruleBehavior && !ruleBehavior.triggerKeyDefault;
 
       if(resultCapture.LeventMatched) {
@@ -454,7 +454,7 @@ export default class HardwareEventKeyboard extends HardKeyboard {
     // interpretation as well by _not_ evaluating it during this pass.
     if(!this.swallowKeypress) {
       // is synchronous
-      this.emit('keyEvent', Levent, (result, error) => {
+      this.emit('keyevent', Levent, (result, error) => {
         resultCapture.preventDefaultKeystroke = !!result;
       })
     }

--- a/web/src/app/browser/src/languageMenu.ts
+++ b/web/src/app/browser/src/languageMenu.ts
@@ -43,7 +43,7 @@ export class LanguageMenu {
         if(sX > spaceBar.offsetLeft && sX < spaceBar.offsetLeft+spaceBar.offsetWidth &&
            sY > spaceBar.offsetTop && sY < spaceBar.offsetTop+spaceBar.offsetHeight
         ) {
-          this.keyman.osk.emit('showBuild');
+          this.keyman.osk.emit('showbuild');
         }
       }
     },false);

--- a/web/src/app/browser/src/oskConfiguration.ts
+++ b/web/src/app/browser/src/oskConfiguration.ts
@@ -7,7 +7,7 @@ import { LanguageMenu } from "./languageMenu.js";
 export function setupOskListeners(engine: KeymanEngine, osk: OSKView, contextManager: ContextManager) {
   const focusAssistant = contextManager.focusAssistant;
 
-  osk.on('globeKey', (key, on) => { // K_LOPT
+  osk.on('globekey', (key, on) => { // K_LOPT
     if(on) {
       if(osk.hostDevice.touchable) {
         engine.touchLanguageMenu = new LanguageMenu(engine);
@@ -20,7 +20,7 @@ export function setupOskListeners(engine: KeymanEngine, osk: OSKView, contextMan
     }
   });
 
-  osk.on('hideRequested', (key) => { // K_ROPT
+  osk.on('hiderequested', (key) => { // K_ROPT
     if(osk) {
       osk.startHide(true);
       contextManager.forgetActiveTarget();
@@ -34,12 +34,12 @@ export function setupOskListeners(engine: KeymanEngine, osk: OSKView, contextMan
     }
   });
 
-  osk.on('showBuild', () => {
+  osk.on('showbuild', () => {
     engine.config.alertHost?.alert('KeymanWeb Version ' + KEYMAN_VERSION.VERSION + '<br /><br />'
       +'<span style="font-size:0.8em">Copyright &copy; 2007-2023 SIL International</span>');
   });
 
-  osk.on('dragMove', async (promise) => {
+  osk.on('dragmove', async (promise) => {
     focusAssistant.restoringFocus = true;
 
     await promise;
@@ -50,7 +50,7 @@ export function setupOskListeners(engine: KeymanEngine, osk: OSKView, contextMan
     focusAssistant.setMaintainingFocus(false);
   });
 
-  osk.on('resizeMove', async (promise) => {
+  osk.on('resizemove', async (promise) => {
     focusAssistant.restoringFocus = true;
 
     await promise;
@@ -60,7 +60,7 @@ export function setupOskListeners(engine: KeymanEngine, osk: OSKView, contextMan
     focusAssistant.setMaintainingFocus(false);
   });
 
-  osk.on('pointerInteraction', async (promise) => {
+  osk.on('pointerinteraction', async (promise) => {
    // On event start
    focusAssistant.setMaintainingFocus(true);
 

--- a/web/src/app/webview/src/oskConfiguration.ts
+++ b/web/src/app/webview/src/oskConfiguration.ts
@@ -9,7 +9,7 @@ import { PendingLongpress } from './osk/pendingLongpress.js';
 import type KeymanEngine from "./keymanEngine.js";
 
 export function setupEmbeddedListeners(engine: KeymanEngine, osk: OSKView) {
-  osk.on('globeKey', (key, on) => {
+  osk.on('globekey', (key, on) => {
     if(on) {
       if(typeof engine.showKeyboardList == 'function') { // OSKView event: shouldShowLanguageMenu
         engine.showKeyboardList();                       // Is connected to VisualKeyboard event: globeKey
@@ -29,7 +29,7 @@ export function setupEmbeddedListeners(engine: KeymanEngine, osk: OSKView) {
     }
   });
 
-  osk.on('hideRequested', (key) => {
+  osk.on('hiderequested', (key) => {
     if(osk.vkbd) {
       osk.vkbd.highlightKey(key, false);
     }

--- a/web/src/app/webview/src/passthroughKeyboard.ts
+++ b/web/src/app/webview/src/passthroughKeyboard.ts
@@ -40,7 +40,7 @@ export default class PassthroughKeyboard extends HardKeyboard {
     const promise = new ManagedPromise<Boolean>();
 
     try {
-      this.emit('keyEvent', Lkc, (result, error) => {
+      this.emit('keyevent', Lkc, (result, error) => {
         if(error) {
           promise.reject(error);
         } else {

--- a/web/src/engine/events/src/emitterListenerSpy.ts
+++ b/web/src/engine/events/src/emitterListenerSpy.ts
@@ -9,14 +9,14 @@ interface EventMap<BaseEventMap extends Object> {
    * EventEmitter being spied upon.
    * @param eventName
    */
-  listenerAdded(eventName: EventNames<BaseEventMap>);
+  listeneradded(eventName: EventNames<BaseEventMap>);
 
   /**
    * Indicates that a listener for the named event has been unregistered from the
    * EventEmitter being spied upon.
    * @param eventName
    */
-  listenerRemoved(eventName: EventNames<BaseEventMap>);
+  listenerremoved(eventName: EventNames<BaseEventMap>);
 }
 
 type Emitter<BaseEventMap extends Object> = EventEmitter<BaseEventMap> | LegacyEventEmitter<BaseEventMap>;
@@ -30,19 +30,19 @@ export class EmitterListenerSpy<BaseEventMap extends Object> extends EventEmitte
     super();
 
     if(emitter instanceof EventEmitter) {
-      emitter.on = this.listenerRegistrationSpy('listenerAdded', emitter, emitter.on);
-      emitter.addListener = this.listenerRegistrationSpy('listenerAdded', emitter, emitter.addListener);
-      emitter.off = this.listenerRegistrationSpy('listenerRemoved', emitter, emitter.off);
-      emitter.removeListener = this.listenerRegistrationSpy('listenerRemoved', emitter, emitter.off);
+      emitter.on = this.listenerRegistrationSpy('listeneradded', emitter, emitter.on);
+      emitter.addListener = this.listenerRegistrationSpy('listeneradded', emitter, emitter.addListener);
+      emitter.off = this.listenerRegistrationSpy('listenerremoved', emitter, emitter.off);
+      emitter.removeListener = this.listenerRegistrationSpy('listenerremoved', emitter, emitter.off);
     } else {
       // TS gets really fussy about how the legacy event typing is a bit more
       // restrictive (due to less-restricted event name types in EventEmitter)
       // It's not worth the effort to make this 100% perfect at the moment.
       //
       // @ts-ignore
-      emitter.addEventListener = this.listenerRegistrationSpy('listenerAdded', emitter, emitter.addEventListener);
+      emitter.addEventListener = this.listenerRegistrationSpy('listeneradded', emitter, emitter.addEventListener);
       // @ts-ignore
-      emitter.removeEventListener = this.listenerRegistrationSpy('listenerRemoved', emitter, emitter.removeEventListener);
+      emitter.removeEventListener = this.listenerRegistrationSpy('listenerremoved', emitter, emitter.removeEventListener);
     }
   }
 
@@ -82,7 +82,7 @@ export class EmitterListenerSpy<BaseEventMap extends Object> extends EventEmitte
 
 // const emitter = new LegacyEventEmitter<TestMap>;  // or `new EventEmitter<TestMap>`.
 // const emitterSpy = new EmitterListenerSpy<TestMap>(emitter);
-// emitterSpy.on('listenerAdded', (eventName) => {
+// emitterSpy.on('listeneradded', (eventName) => {
 //   // eventName = 'c'; // will error; there is no event 'c' in the event map.
 //   if(eventName == 'a') {
 //     // stuff

--- a/web/src/engine/events/src/legacyEventEmitter.ts
+++ b/web/src/engine/events/src/legacyEventEmitter.ts
@@ -95,7 +95,7 @@ export class LegacyEventEmitter<EventTypes extends LegacyEventMap> {
     return this._removeEventListener(event, func);
   }
 
-  // Separate, in order to prevent `addEventListener` from sending 'listenerRemoved' events with
+  // Separate, in order to prevent `addEventListener` from sending 'listenerremoved' events with
   // EmitterListenerSpy.
   private _removeEventListener<T extends EventNames<EventTypes>> (
     event: T,

--- a/web/src/engine/main/src/hardKeyboard.ts
+++ b/web/src/engine/main/src/hardKeyboard.ts
@@ -6,7 +6,7 @@ interface EventMap {
   /**
    * Designed to pass key events off to any consuming modules/libraries.
    */
-  'keyEvent': (event: KeyEvent, callback?: (result: RuleBehavior, error?: Error) => void) => void
+  'keyevent': (event: KeyEvent, callback?: (result: RuleBehavior, error?: Error) => void) => void
 }
 
 export default class HardKeyboard extends EventEmitter<EventMap> implements KeyEventSourceInterface { }

--- a/web/src/engine/main/src/keyEventSource.interface.ts
+++ b/web/src/engine/main/src/keyEventSource.interface.ts
@@ -8,7 +8,7 @@ interface EventMap {
   /**
    * Designed to pass key events off to any consuming modules/libraries.
    */
-  'keyEvent': KeyEventHandler;
+  'keyevent': KeyEventHandler;
 }
 
 export default interface KeyEventSourceInterface extends EventEmitter<EventMap> { }

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -117,7 +117,7 @@ export default class KeymanEngine<
     // The OSK does not possess a direct connection to the KeyboardProcessor's state-key
     // management object; this event + handler allow us to keep the OSK's related states
     // in sync.
-    this.core.keyboardProcessor.on('statekeyChange', (stateKeys) => {
+    this.core.keyboardProcessor.on('statekeychange', (stateKeys) => {
       this.osk?.vkbd?.updateStateKeys(stateKeys);
     })
 
@@ -211,7 +211,7 @@ export default class KeymanEngine<
       this.osk?.refreshLayout();
     });
 
-    kbdCache.on('stubAdded', (stub) => {
+    kbdCache.on('stubadded', (stub) => {
       let eventRaiser = () => {
         // The corresponding event is needed in order to update UI modules as new keyboard stubs "come online".
         this.legacyAPIEvents.callEvent('keyboardregistered', {
@@ -236,7 +236,7 @@ export default class KeymanEngine<
       }
     });
 
-    kbdCache.on('keyboardAdded', (keyboard) => {
+    kbdCache.on('keyboardadded', (keyboard) => {
       let eventRaiser = () => {
         // Execute any external (UI) code needed after loading keyboard
         this.legacyAPIEvents.callEvent('keyboardloaded', {
@@ -251,7 +251,7 @@ export default class KeymanEngine<
       }
     });
 
-    this.keyboardRequisitioner.cache.on('keyboardAdded', (keyboard) => {
+    this.keyboardRequisitioner.cache.on('keyboardadded', (keyboard) => {
       this.legacyAPIEvents.callEvent('keyboardloaded', { keyboardName: keyboard.id });
     });
     //
@@ -272,10 +272,10 @@ export default class KeymanEngine<
 
   protected set hardKeyboard(keyboard: HardKeyboard) {
     if(this._hardKeyboard) {
-      this._hardKeyboard.off('keyEvent', this.keyEventListener);
+      this._hardKeyboard.off('keyevent', this.keyEventListener);
     }
     this._hardKeyboard = keyboard;
-    keyboard.on('keyEvent', this.keyEventListener);
+    keyboard.on('keyevent', this.keyEventListener);
   }
 
   public get osk(): OSKView {
@@ -284,13 +284,13 @@ export default class KeymanEngine<
 
   public set osk(value: OSKView) {
     if(this._osk) {
-      this._osk.off('keyEvent', this.keyEventListener);
+      this._osk.off('keyevent', this.keyEventListener);
       this.core.keyboardProcessor.layerStore.handler = this.osk.layerChangeHandler;
     }
     this._osk = value;
     if(value) {
       value.activeKeyboard = this.contextManager.activeKeyboard;
-      value.on('keyEvent', this.keyEventListener);
+      value.on('keyevent', this.keyEventListener);
       this.core.keyboardProcessor.layerStore.handler = value.layerChangeHandler;
     }
   }

--- a/web/src/engine/osk/src/components/resizeBar.ts
+++ b/web/src/engine/osk/src/components/resizeBar.ts
@@ -10,7 +10,7 @@ interface EventMap {
   /**
    * Triggered when the user inputs a special command to show the engine's current version number.
    */
-  showBuild: () => void;
+  showbuild: () => void;
 }
 
 export default class ResizeBar extends EventEmitter<EventMap, ResizeBar> implements OSKViewComponent {
@@ -66,7 +66,7 @@ export default class ResizeBar extends EventEmitter<EventMap, ResizeBar> impleme
 
     // Display build number on shift+double click
     Ltitle.addEventListener('dblclick', (e) => {
-      this.emit('showBuild');
+      this.emit('showbuild');
 
       return false;
     }, false);

--- a/web/src/engine/osk/src/views/floatingOskView.ts
+++ b/web/src/engine/osk/src/views/floatingOskView.ts
@@ -45,7 +45,7 @@ export default class FloatingOSKView extends OSKView {
 
     super(config);
 
-    this.typedActivationModel.on('triggerChange', () => this.setDisplayPositioning());
+    this.typedActivationModel.on('triggerchange', () => this.setDisplayPositioning());
 
     document.body.appendChild(this._Box);
 
@@ -61,7 +61,7 @@ export default class FloatingOSKView extends OSKView {
     this.titleBar.on('unpin', () => this.restorePosition(true));
 
     this.resizeBar = new ResizeBar(this.resizeDragHandler);
-    this.resizeBar.on('showBuild', () => this.emit('showBuild'));
+    this.resizeBar.on('showbuild', () => this.emit('showbuild'));
 
     this.headerView = this.titleBar;
 
@@ -86,8 +86,8 @@ export default class FloatingOSKView extends OSKView {
     const listenerSpyNew = new EmitterListenerSpy(this);
     const listenerSpyOld = new EmitterListenerSpy(this.legacyEvents);
     for(let listenerSpy of [listenerSpyNew, listenerSpyOld]) {
-      listenerSpy.on('listenerAdded', onListenedEvent);
-      listenerSpy.on('listenerRemoved', onListenedEvent);
+      listenerSpy.on('listeneradded', onListenedEvent);
+      listenerSpy.on('listenerremoved', onListenedEvent);
     }
 
     this.loadPersistedLayout();
@@ -149,7 +149,7 @@ export default class FloatingOSKView extends OSKView {
     let isVisible = this._Visible;
 
     let dragPromise = new ManagedPromise<void>();
-    this.emit('dragMove', dragPromise.corePromise);
+    this.emit('dragmove', dragPromise.corePromise);
 
     this.loadPersistedLayout();
     this.userPositioned=false;
@@ -648,7 +648,7 @@ export default class FloatingOSKView extends OSKView {
         }
 
         this.dragPromise = new ManagedPromise<void>();
-        _this.emit('dragMove', this.dragPromise.corePromise);
+        _this.emit('dragmove', this.dragPromise.corePromise);
       }
 
       onDragMove(cumulativeX: number, cumulativeY: number) {
@@ -711,7 +711,7 @@ export default class FloatingOSKView extends OSKView {
         }
 
         this.dragPromise = new ManagedPromise<void>();
-        _this.emit('resizeMove', this.dragPromise.corePromise);
+        _this.emit('resizemove', this.dragPromise.corePromise);
       }
 
       onDragMove(cumulativeX: number, cumulativeY: number) {

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -66,23 +66,23 @@ export interface EventMap {
    * Note:  the following code block was originally used to integrate with the keyboard & input
    * processors, but it requires entanglement with components external to this OSK module.
    */
-  'keyEvent': (event: KeyEvent) => void,
+  'keyevent': (event: KeyEvent) => void,
 
   /**
    * Indicates that the globe key has either been pressed (`on` == `true`)
    * or released (`on` == `false`).
    */
-  globeKey: (e: KeyElement, on: boolean) => void;
+  globekey: (e: KeyElement, on: boolean) => void;
 
   /**
    * A virtual keystroke corresponding to a "hide" command has been received.
    */
-  hideRequested: (key: KeyElement) => void;
+  hiderequested: (key: KeyElement) => void;
 
   /**
    * Signals the special command to display the engine's version + build number.
    */
-  showBuild: () => void;
+  showbuild: () => void;
 
   // While the next two are near-duplicates of the legacy event `resizemove`, these
   // have the advantage of providing a Promise for the end of the ongoing user
@@ -96,14 +96,14 @@ export interface EventMap {
    * Note that position-restoration (unpinning the OSK) is treated as a drag-move
    * event.  It resolves near-instantly.
    */
-  dragMove: (promise: Promise<void>) => void;
+  dragmove: (promise: Promise<void>) => void;
 
   /**
    * Signals that the OSK is being resized via a drag operation (on a resize 'handle').
    *
    * The provided Promise will resolve once the resize operation is complete.
    */
-  resizeMove: (promise: Promise<void>) => void;
+  resizemove: (promise: Promise<void>) => void;
 
   /**
    * Signals that either the mouse or an active touchpoint is interacting with the OSK.
@@ -112,7 +112,7 @@ export interface EventMap {
    * Note that for touch events, more than one touchpoint may coexist, each with its own
    * corresponding call of this event and corresponding `Promise`.
    */
-  pointerInteraction: (promise: Promise<void>) => void;
+  pointerinteraction: (promise: Promise<void>) => void;
 }
 
 export default abstract class OSKView extends EventEmitter<EventMap> implements MinimalCodesInterface {
@@ -277,7 +277,7 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
       }
 
       this.mouseEnterPromise = new ManagedPromise<void>();
-      this.emit('pointerInteraction', this.mouseEnterPromise.corePromise);
+      this.emit('pointerinteraction', this.mouseEnterPromise.corePromise);
     };
 
     this._Box.onmouseleave = this._VKbdMouseLeave = (e) => {
@@ -310,7 +310,7 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
     this._boxBaseTouchStart = (e) => {
       for(let i = 0; i < e.changedTouches.length; i++) {
         let promise = this.touchEventPromiseManager.promiseForTouchpoint(e.changedTouches[i].identifier);
-        this.emit('pointerInteraction', promise.corePromise);
+        this.emit('pointerinteraction', promise.corePromise);
       }
 
       this.touchEventPromiseManager.maintainTouches(e.touches);
@@ -801,11 +801,11 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
       isEmbedded: this.config.isEmbedded
     });
 
-    vkbd.on('keyEvent', (keyEvent) => this.emit('keyEvent', keyEvent));
-    vkbd.on('globeKey', (keyElement, on) => this.emit('globeKey', keyElement, on));
-    vkbd.on('hideRequested', (keyElement) => {
+    vkbd.on('keyevent', (keyEvent) => this.emit('keyevent', keyEvent));
+    vkbd.on('globekey', (keyElement, on) => this.emit('globekey', keyElement, on));
+    vkbd.on('hiderequested', (keyElement) => {
       this.doHide(true);
-      this.emit('hideRequested', keyElement);
+      this.emit('hiderequested', keyElement);
     });
 
     // Set box class - OS and keyboard added for Build 360

--- a/web/src/engine/osk/src/views/twoStateActivator.ts
+++ b/web/src/engine/osk/src/views/twoStateActivator.ts
@@ -1,7 +1,7 @@
 import Activator from './activator.js';
 
 interface TriggerEventMap<Type> {
-  triggerChange: (trigger: Type) => void;
+  triggerchange: (trigger: Type) => void;
 }
 
 export default class TwoStateActivator<Type> extends Activator<TriggerEventMap<Type>> {
@@ -40,7 +40,7 @@ export default class TwoStateActivator<Type> extends Activator<TriggerEventMap<T
 
     this.checkState(oldState);
     if(oldValue != value) {
-      this.emit('triggerChange', value);
+      this.emit('triggerchange', value);
     }
   }
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -88,11 +88,11 @@ interface EventMap {
    * Note:  the following code block was originally used to integrate with the keyboard & input
    * processors, but it requires entanglement with components external to this OSK module.
    */
-  'keyEvent': (event: KeyEvent) => void,
+  'keyevent': (event: KeyEvent) => void,
 
-  'hideRequested': (keyElement: KeyElement) => void,
+  'hiderequested': (keyElement: KeyElement) => void,
 
-  'globeKey': (keyElement: KeyElement, on: boolean) => void
+  'globekey': (keyElement: KeyElement, on: boolean) => void
 }
 
 export default class VisualKeyboard extends EventEmitter<EventMap> implements KeyboardView {
@@ -1861,10 +1861,10 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
 
   optionKey(e: KeyElement, keyName: string, keyDown: boolean) {
     if (keyName.indexOf('K_LOPT') >= 0) {
-      this.emit('globeKey', e, keyDown);
+      this.emit('globekey', e, keyDown);
     } else if (keyName.indexOf('K_ROPT') >= 0) {
       if (keyDown) {
-        this.emit('hideRequested', e);
+        this.emit('hiderequested', e);
       }
     }
   };
@@ -1949,6 +1949,6 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       return true;
     }
 
-    this.emit('keyEvent', keyEvent);
+    this.emit('keyevent', keyEvent);
   }
 }

--- a/web/src/engine/package-cache/src/stubAndKeyboardCache.ts
+++ b/web/src/engine/package-cache/src/stubAndKeyboardCache.ts
@@ -1,6 +1,5 @@
 import { Keyboard, KeyboardLoaderBase as KeyboardLoader } from "@keymanapp/keyboard-processor";
 import EventEmitter from "eventemitter3";
-import { type PathConfiguration } from "keyman/engine/paths";
 
 import KeyboardStub from "./keyboardStub.js";
 
@@ -34,12 +33,12 @@ interface EventMap {
    * to denote the first added stub to facilitate auto-activation of the first
    * keyboard to be registered.
    */
-  stubAdded: (stub: KeyboardStub) => void;
+  stubadded: (stub: KeyboardStub) => void;
 
   /**
    * Indicates that the specified Keyboard has just been added to the cache.
    */
-  keyboardAdded: (keyboard: Keyboard) => void;
+  keyboardadded: (keyboard: Keyboard) => void;
 }
 
 export default class StubAndKeyboardCache extends EventEmitter<EventMap> {
@@ -117,7 +116,7 @@ export default class StubAndKeyboardCache extends EventEmitter<EventMap> {
     const keyboardID = prefixed(keyboard.id);
     this.keyboardTable[keyboardID] = keyboard;
 
-    this.emit('keyboardAdded', keyboard);
+    this.emit('keyboardadded', keyboard);
   }
 
   fetchKeyboardForStub(stub: KeyboardStub) : Promise<Keyboard> {
@@ -182,7 +181,7 @@ export default class StubAndKeyboardCache extends EventEmitter<EventMap> {
     const stubTable = this.stubSetTable[keyboardID] = this.stubSetTable[keyboardID] ?? {};
     stubTable[stub.KLC] = stub;
 
-    this.emit('stubAdded', stub);
+    this.emit('stubadded', stub);
   }
 
   findMatchingStub(stub: KeyboardStub) {

--- a/web/src/test/auto/headless/events/emitterListenerSpy.js
+++ b/web/src/test/auto/headless/events/emitterListenerSpy.js
@@ -15,8 +15,8 @@ describe("EmitterListenerSpy", () => {
     const fakeAddListener = sinon.fake();
     const fakeRemoveListener = sinon.fake();
 
-    emitterSpy.on('listenerAdded', fakeAddListener);
-    emitterSpy.on('listenerRemoved', fakeRemoveListener);
+    emitterSpy.on('listeneradded', fakeAddListener);
+    emitterSpy.on('listenerremoved', fakeRemoveListener);
     emitter.on('event', fakeEventHandler);
 
     assert.isTrue(fakeAddListener.calledOnce);
@@ -35,8 +35,8 @@ describe("EmitterListenerSpy", () => {
     const fakeAddListener = sinon.fake();
     const fakeRemoveListener = sinon.fake();
 
-    emitterSpy.on('listenerAdded', fakeAddListener);
-    emitterSpy.on('listenerRemoved', fakeRemoveListener);
+    emitterSpy.on('listeneradded', fakeAddListener);
+    emitterSpy.on('listenerremoved', fakeRemoveListener);
     emitter.addEventListener('event', fakeEventHandler);
 
     assert.isTrue(fakeAddListener.calledOnce);

--- a/web/src/test/auto/headless/osk/activation.js
+++ b/web/src/test/auto/headless/osk/activation.js
@@ -95,7 +95,7 @@ describe("Activators", () => {
       const activateStub = sinon.fake();
       const triggerStub = sinon.fake();
       activator.on('activate', activateStub);
-      activator.on('triggerChange', triggerStub);
+      activator.on('triggerchange', triggerStub);
 
       activator.activationTrigger = "foo"; // using a string, just 'cause.
 
@@ -154,7 +154,7 @@ describe("Activators", () => {
     it("'triggerchange' event generation", () => {
       const activator = new TwoStateActivator();
       const stub = sinon.fake();
-      activator.on('triggerChange', stub);
+      activator.on('triggerchange', stub);
 
       activator.enabled = false;
 
@@ -219,7 +219,7 @@ describe("Activators", () => {
     it("'activationTrigger' as object", () => {
       const activator = new TwoStateActivator();
       const stub = sinon.fake();
-      activator.on('triggerChange', stub);
+      activator.on('triggerchange', stub);
 
       const object = {a: {b: {c: "def"}, g: "hi"}, jk: ["l"]};
 

--- a/web/src/test/manual/web/osk/scratchspace/commands.js
+++ b/web/src/test/manual/web/osk/scratchspace/commands.js
@@ -97,7 +97,7 @@ function setOSK(mode) {
     keyboard = setKeyboard('us');
   }
   currentOSK.activeKeyboard = keyboard;
-  currentOSK.on('keyEvent', (event) => {
+  currentOSK.on('keyevent', (event) => {
     let eventText = JSON.stringify(event, (key, value) => {
       switch(key) {
         case 'srcKeyboard':

--- a/web/src/tools/testing/recorder/scribe.ts
+++ b/web/src/tools/testing/recorder/scribe.ts
@@ -182,7 +182,7 @@ export class Scribe extends EventEmitter {
   initHooks(recordingElement: HTMLElement) {
     let recorderScribe = this;
 
-    keyman.hardKeyboard.on('keyEvent', (e) => {
+    keyman.hardKeyboard.on('keyevent', (e) => {
       let in_output = outputTargetForElement(recordingElement);
       if(!in_output || keyman.contextManager.activeTarget != in_output) {
         return;
@@ -198,7 +198,7 @@ export class Scribe extends EventEmitter {
       }, 1);
     });
 
-    keyman.osk.on('keyEvent', (e) => {
+    keyman.osk.on('keyevent', (e) => {
       let in_output = outputTargetForElement(recordingElement);
       if(!in_output || keyman.contextManager.activeTarget != in_output) {
         return;


### PR DESCRIPTION
From #8560:

> There are some notable inconsistencies with internal event nomenclature, as noted by [...]

From a review comment on #8591:

> Is this [event name] supposed to be camelCase unlike all the other event names?

So... I somehow wasn't fully aware until now that event names in JS are conventionally set to full lowercase, as are our [pre-existing documented API events](https://help.keyman.com/developer/engine/web/17.0/reference/events/), and I'd gone making a number of camel-cased internal event names.  This PR corrects my mistakes and sets them to their lowercase-convention form.  I'm still not personally super-comfortable with it for certain names, but it's best to follow conventions.

@keymanapp-test-bot skip