### PR TITLE
feat(linux): Allow to install keyboard for multiple languages

### DIFF
--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -154,7 +154,7 @@ class InstallKmpWindow(Gtk.Dialog):
         try:
             if response == Gtk.ResponseType.YES:
                 logging.debug("QUESTION dialog closed by clicking YES button")
-                uninstall_kmp(keyboardid)
+                uninstall_kmp(keyboardid, False, False)
                 return True
             elif response == Gtk.ResponseType.NO:
                 logging.debug("QUESTION dialog closed by clicking NO button")

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -132,25 +132,17 @@ class InstallKmpWindow(Gtk.Dialog):
     def _uninstall_prev_version_if_necessary(self, keyboardid, viewkmp, installed_kmp_ver, info):
         if not installed_kmp_ver or not secure_lookup(info, 'version', 'description'):
             return True
-        if secure_lookup(info, 'version', 'description') == installed_kmp_ver:
-            response = self._show_version_message_dlg(
-              viewkmp,
-              # i18n: The words in braces (e.g. `{name}`) are placeholders. Don't translate them!
-              _("The {name} keyboard is already installed at version {version}. "
-                "Do you want to uninstall then reinstall it?").format(
-                  name=self.kbname, version=installed_kmp_ver))
-        else:
-            logging.info("package version %s", secure_lookup(info, 'version', 'description'))
-            logging.info("installed kmp version %s", installed_kmp_ver)
-            if parse_version(secure_lookup(info, 'version', 'description')) > parse_version(installed_kmp_ver):
-                return True
-            response = self._show_version_message_dlg(
-              viewkmp,
-              # i18n: The words in braces (e.g. `{name}`) are placeholders. Don't translate them!
-              _("The {name} keyboard is already installed with a newer version {installedversion}. "
-                "Do you want to uninstall it and install the older version {version}?")
-              .format(name=self.kbname, installedversion=installed_kmp_ver,
-                      version=secure_lookup(info, 'version', 'description')))
+        logging.info("package version %s", secure_lookup(info, 'version', 'description'))
+        logging.info("installed kmp version %s", installed_kmp_ver)
+        if parse_version(secure_lookup(info, 'version', 'description')) >= parse_version(installed_kmp_ver):
+            return True
+        response = self._show_version_message_dlg(
+          viewkmp,
+          # i18n: The words in braces (e.g. `{name}`) are placeholders. Don't translate them!
+          _("The {name} keyboard is already installed with a newer version {installedversion}. "
+            "Do you want to uninstall it and install the older version {version}?")
+          .format(name=self.kbname, installedversion=installed_kmp_ver,
+                  version=secure_lookup(info, 'version', 'description')))
         try:
             if response == Gtk.ResponseType.YES:
                 logging.debug("QUESTION dialog closed by clicking YES button")

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -49,12 +49,9 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
     kbfontdir = get_keyman_font_dir(location, packageID)
 
     where = 'shared' if location == InstallLocation.Shared else 'local'
-    if removeLanguages:
-        logging.info(f'Uninstalling {where} keyboard: {packageID}')
-    else:
-        logging.info(f'Replacing {where} keyboard: {packageID}')
     info, system, options, keyboards, files = get_metadata(kbdir)
     if removeLanguages:
+        logging.info(f'Uninstalling {where} keyboard: {packageID}')
         if keyboards:
             if is_fcitx_running():
                 _uninstall_keyboards_from_fcitx5()
@@ -64,6 +61,8 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
                 _uninstall_keyboards_from_ibus(keyboards, kbdir)
         else:
             logging.warning("could not uninstall keyboards")
+    else:
+        logging.info(f'Replacing {where} keyboard: {packageID}')
 
     if not os.path.isdir(kbdir):
         logging.error('Keyboard directory %s for %s does not exist.', kbdir, packageID)
@@ -126,8 +125,8 @@ def uninstall_kmp(packageID, sharedarea=False, removeLanguages=True):
 
     Args:
         packageID (str): Keyboard package ID
-        sharedarea (str): whether to uninstall from shared /usr/local or ~/.local
-        removeLanguages (str): if True also uninstall the languages associated with
+        sharedarea (boolean): whether to uninstall from shared /usr/local or ~/.local
+        removeLanguages (boolean): if True also uninstall the languages associated with
             the keyboard, otherwise only remove keyboard (i.e. in preparation for
             replacing the keyboard with a newer version)
     """

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -22,7 +22,7 @@ def get_languages():
     from keyman_config.get_kmp import keyman_cache_dir
 
     logging.info("Getting language list from search")
-    api_url = KeymanApiUrl + "/search?q=l:*&platform=linux"
+    api_url = f"{KeymanApiUrl}/search?q=l:*&platform=linux"
     logging.debug("At URL %s", api_url)
     cache_dir = keyman_cache_dir()
     current_dir = os.getcwd()
@@ -37,10 +37,7 @@ def get_languages():
         logging.debug("Time: {0} / Used Cache: {1}".format(now, response.from_cache))
         os.chdir(current_dir)
         requests_cache.uninstall_cache()
-        if response.status_code == 200:
-            return response.json()
-        else:
-            return None
+        return response.json() if response.status_code == 200 else None
     except Exception:
         return None
 
@@ -66,9 +63,8 @@ def get_keyboard_list():
 def write_kmpdirlist(kmpdirfile):
     try:
         with open(kmpdirfile, 'wt') as kmpdirlist:
-            keyboards = get_keyboard_list()
-            if keyboards:
-                for kb in get_keyboard_list():
+            if keyboards := get_keyboard_list():
+                for kb in keyboards:
                     print(kb, file=kmpdirlist)
     except Exception as e:
         logging.warning('Exception %s writing %s %s', type(e), kmpdirfile, e.args)
@@ -90,7 +86,7 @@ def _list_languages_for_keyboard_impl(packageId, packageDir):
     from keyman_config.get_kmp import keyman_cache_dir
     kmpfile = os.path.join(keyman_cache_dir(), packageId)
     if not os.path.exists(kmpfile):
-        kmpfile = kmpfile + '.kmp'
+        kmpfile = f'{kmpfile}.kmp'
         if not os.path.exists(kmpfile):
             return ''
     extract_kmp(kmpfile, packageDir)
@@ -123,7 +119,7 @@ def main():
     parser.add_argument('-f', '--file', metavar='KMPFILE', help='Keyman kmp file')
     parser.add_argument('-p', '--package', metavar='PACKAGE', help='Keyman package id')
     parser.add_argument('-l', '--bcp47', metavar='LANGTAG', help='bcp47 language tag')
-    parser.add_argument('--version', action='version', version='%(prog)s version ' + __version__)
+    parser.add_argument('--version', action='version', version=f'%(prog)s version {__version__}')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
     parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
     parser.add_argument('--force', action='store_true', help='force installation of keyboard even if it is ' +
@@ -175,15 +171,17 @@ def main():
             logging.error("km-package-install: Keyman kmp file %s not found.", args.file)
             logging.error("km-package-install -f <kmpfile>")
             sys.exit(2)
-        try_install_kmp(args.file, "file " + args.file, args.bcp47, args.shared)
+        try_install_kmp(args.file, f"file {args.file}", args.bcp47, args.shared)
     elif args.package:
         if args.shared:
             if get_kmp_version_user(args.package):
-                print(f"km-package-install: Warning: Keyboard {args.package} is also installed for the current user.")
+                logging.warning(f'km-package-install: Warning: Keyboard {args.package} is ' +
+                                'also installed for the current user.')
             installed_kmp_ver = get_kmp_version_shared(args.package)
         else:
             if get_kmp_version_shared(args.package):
-                print(f"km-package-install: Warning: Keyboard {args.package} is already installed in the shared area.")
+                logging.warning(f'km-package-install: Warning: Keyboard {args.package} is ' +
+                                'already installed in the shared area.')
             installed_kmp_ver = get_kmp_version_user(args.package)
         kbdata = get_keyboard_data(args.package)
         if not kbdata:
@@ -206,7 +204,7 @@ def main():
 
         kmpfile = get_kmp(args.package)
         if kmpfile:
-            try_install_kmp(kmpfile, "keyboard package " + args.package, args.bcp47, args.shared)
+            try_install_kmp(kmpfile, f"keyboard package {args.package}", args.bcp47, args.shared)
         else:
             logging.error("km-package-install: error: Could not download keyboard package %s", args.package)
             sys.exit(2)

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -126,6 +126,8 @@ def main():
     parser.add_argument('--version', action='version', version='%(prog)s version ' + __version__)
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
     parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
+    parser.add_argument('--force', action='store_true', help='force installation of keyboard even if it is ' +
+                        'a downgrade to an older version of the keyboard')
 
     args = parser.parse_args()
     if args.verbose:
@@ -177,31 +179,30 @@ def main():
     elif args.package:
         if args.shared:
             if get_kmp_version_user(args.package):
-                print("km-package-install: Warning: Keyboard %s is also installed for the current user."
-                      % args.package)
-            installed_kmp_v = get_kmp_version_shared(args.package)
+                print(f"km-package-install: Warning: Keyboard {args.package} is also installed for the current user.")
+            installed_kmp_ver = get_kmp_version_shared(args.package)
         else:
             if get_kmp_version_shared(args.package):
-                print("km-package-install: Warning: Keyboard %s is already installed in the shared area."
-                      % args.package)
-            installed_kmp_v = get_kmp_version_user(args.package)
+                print(f"km-package-install: Warning: Keyboard {args.package} is already installed in the shared area.")
+            installed_kmp_ver = get_kmp_version_user(args.package)
         kbdata = get_keyboard_data(args.package)
         if not kbdata:
             logging.error("km-package-install: error: Could not download keyboard data for %s", args.package)
             sys.exit(3)
-        kbdata_v = secure_lookup(kbdata, 'version')
-        if installed_kmp_v and kbdata_v:
-            kbdata_version = parse_version(kbdata_v)
-            installed_kmp_ver = parse_version(installed_kmp_v)
-            if kbdata_version == installed_kmp_ver:
-                print("km-package-install: Version %s of the %s keyboard package is already installed."
-                      % (installed_kmp_ver, args.package))
-                sys.exit(1)
-            elif kbdata_version > installed_kmp_ver:
-                print("km-package-install: A newer version of %s keyboard package is available. Uninstalling old "
-                      "version %s then downloading and installing new version %s."
-                      % (args.package, installed_kmp_ver, kbdata_version))
-                uninstall_kmp(args.package, args.shared)
+        kbdata_version = secure_lookup(kbdata, 'version')
+        if installed_kmp_ver and kbdata_version:
+            if parse_version(installed_kmp_ver) > parse_version(kbdata_version):
+                if args.force:
+                    logging.warning(f'km-package-install: warning: The {args.package} keyboard ' +
+                                    f'is already installed with a newer version {installed_kmp_ver}. ' +
+                                    f'Downgrading to version {kbdata_version}.')
+                else:
+                    logging.error(f'km-package-install: error: The {args.package} keyboard is ' +
+                                  f'already installed with a newer version {installed_kmp_ver}. ' +
+                                  f'Not installing version {kbdata_version}. Use `--force` to downgrade.')
+                    sys.exit(1)
+        if args.force:
+            uninstall_kmp(args.package, args.shared, False)
 
         kmpfile = get_kmp(args.package)
         if kmpfile:

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -183,21 +183,21 @@ def main():
                 logging.warning(f'km-package-install: Warning: Keyboard {args.package} is ' +
                                 'already installed in the shared area.')
             installed_kmp_ver = get_kmp_version_user(args.package)
-        kbdata = get_keyboard_data(args.package)
-        if not kbdata:
+        pkgdata = get_keyboard_data(args.package)
+        if not pkgdata:
             logging.error("km-package-install: error: Could not download keyboard data for %s", args.package)
             sys.exit(3)
-        kbdata_version = secure_lookup(kbdata, 'version')
-        if installed_kmp_ver and kbdata_version:
-            if parse_version(installed_kmp_ver) > parse_version(kbdata_version):
+        pkg_version = secure_lookup(pkgdata, 'version')
+        if installed_kmp_ver and pkg_version:
+            if parse_version(installed_kmp_ver) > parse_version(pkg_version):
                 if args.force:
                     logging.warning(f'km-package-install: warning: The {args.package} keyboard ' +
                                     f'is already installed with a newer version {installed_kmp_ver}. ' +
-                                    f'Downgrading to version {kbdata_version}.')
+                                    f'Downgrading to version {pkg_version}.')
                 else:
                     logging.error(f'km-package-install: error: The {args.package} keyboard is ' +
                                   f'already installed with a newer version {installed_kmp_ver}. ' +
-                                  f'Not installing version {kbdata_version}. Use `--force` to downgrade.')
+                                  f'Not installing version {pkg_version}. Use `--force` to downgrade.')
                     sys.exit(1)
         if args.force:
             uninstall_kmp(args.package, args.shared, False)

--- a/linux/keyman-config/km-package-install.bash-completion
+++ b/linux/keyman-config/km-package-install.bash-completion
@@ -7,7 +7,7 @@ _km-package-install_completions()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="-h --help -v --verbose -vv --veryverbose --version -p --package -f --file -s --shared -l --bcp47"
+    opts="-h --help -v --verbose -vv --veryverbose --version -p --package -f --file -s --shared -l --bcp47 --force"
 
     cache=${XDG_CACHE_HOME:-~/.cache}/keyman/kmpdirlist
 

--- a/linux/keyman-config/tests/test_uninstall_kmp.py
+++ b/linux/keyman-config/tests/test_uninstall_kmp.py
@@ -2,10 +2,10 @@
 import unittest
 from unittest.mock import patch
 
-from keyman_config.uninstall_kmp import _uninstall_keyboards_from_gnome
+from keyman_config.uninstall_kmp import _uninstall_keyboards_from_gnome, _uninstall_keyboards_from_ibus
 
 
-class UninstallKmpTests(unittest.TestCase):
+class UninstallKmpGnomeTests(unittest.TestCase):
 
     def setUp(self):
         patcher = patch('keyman_config.uninstall_kmp.GnomeKeyboardsUtil')
@@ -110,3 +110,123 @@ class UninstallKmpTests(unittest.TestCase):
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
           [('xkb', 'en')])
+
+
+class UninstallKmpIbusTests(unittest.TestCase):
+
+    def setUp(self):
+        self.mockIbusUtilClass = self._setupMock('keyman_config.uninstall_kmp.IbusUtil')
+        self.mockRestartIbus = self._setupMock('keyman_config.uninstall_kmp.restart_ibus')
+        self.mockGetIbusBus = self._setupMock('keyman_config.uninstall_kmp.get_ibus_bus')
+        self.mockGetIbusBus.return_value = None
+
+    def _setupMock(self, arg0):
+        patcher = patch(arg0)
+        result = patcher.start()
+        self.addCleanup(patcher.stop)
+        return result
+
+    def test_UninstallKeyboardsFromIbus_RemoveOneKeyboardFromEmpty(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = []
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1'}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_not_called()
+
+    def test_UninstallKeyboardsFromIbus_RemoveNonExistingKeyboard(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'fr:fooDir/foo2.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1'}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(None, [
+          'fr:fooDir/foo2.kmx'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveOneKeyboard(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'km:fooDir/foo1.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1'}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveMultipleKeyboards(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'km:fooDir/foo1.kmx', 'fr:fooDir/foo2.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveAllKeyboards(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'km:fooDir/foo1.kmx', 'fr:fooDir/foo2.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(None, [])
+
+    def test_UninstallKeyboardsFromIbus_RemoveKeyboard_SingleLanguage(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'en:fooDir/foo1.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1', 'languages': [{'id': 'en'}]}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveKeyboard_MultipleLanguages(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'fr:fooDir/foo1.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus(
+          [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveKeyboard_OneNotMatchingLanguage(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'en:fooDir/foo1.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus(
+          [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveKeyboard_RemovesAllMatching(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'en:fooDir/foo1.kmx', 'fr:fooDir/foo1.kmx', 'km:fooDir/foo2.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus(
+          [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng', 'km:fooDir/foo2.kmx'])


### PR DESCRIPTION
This change makes it possible to install the same keyboard again for a different language. It won't be visible in the GUI if the keyboard is installed for more than language, but it will show up for the installed languages in the keyboard dropdown.

We no longer ask the user if he tries to install a keyboard that is already installed with the same version. The only time we ask is for downgrades.
    
A similar change is implemented in `km-package-install` where we changed the logic to match `install_window.py`. We now silently install the new version unless it's a downgrade in which case we output a error message and exit. This change also introduces the
`--force` parameter which allows to install the downgrade. For upgrades or re-installing the same version it will cause an
uninstall of the current version first.

Closes #8619.

# User Testing

## Preparations

- The tests should be run on these Linux platforms:
  - **GROUP_JAMMY_X11**: Ubuntu 22.04 Jammy with Gnome Shell and X11
  - **GROUP_LUNAR_WAYLAND**: Ubuntu 23.04 Lunar with Gnome Shell and Wayland
  - **GROUP_WASTA**: Wasta 20.04 with Cinnamon
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot
- Install EuroLatin (SIL) keyboard for Spanish

## Tests

**TEST_INSTALL_UI**: Install same keyboard for different language

- Open Keyman Configuration
- Press Download button
- Search for French and install EuroLatin (SIL) keyboard for French
- Verify that EuroLatin (SIL) shows up once in Keyman Configuration
- Verify that the keyboards dropdown shows both Spanish as well as French with the EuroLatin (SIL) keyboard

**TEST_INSTALL_CLI**: Install the same keyboard for a different language from the command line

(continuing from previous test)
- Open a terminal window
- Run the following command to install EuroLatin (SIL) keyboard for Italian:
  ```
  km-package-install -p sil_euro_latin -l it
  ```
- Verify that the keyboards dropdown now shows Italian in addition to Spanish and French with the EuroLatin (SIL) keyboard

**TEST_INSTALL_SHARED_CLI**: Install the same keyboard for a different language in the shared area

(continuing from previous test)
- Open a terminal window
- Run the following command to install EuroLatin (SIL) keyboard for Swedish into the shared area:
  ```
  sudo km-package-install -p sil_euro_latin -l sv --shared
  ```
- Verify that the keyboards dropdown now shows Spanish, French, Italian and Swedish with the EuroLatin (SIL) keyboard
- Open Keyman Configuration
- Verify that EuroLatin (SIL) is listed twice, once in the User are as well as in the Shared area
- Close Keyman Configuration

**TEST_INSTALL_SHARED_CLI2**: Install the same keyboard again for a different language in the shared area

(continuing from previous test)
- In the terminal window run the following command to install EuroLatin (SIL) keyboard for Swiss German into the shared area:
  ```
  sudo km-package-install -p sil_euro_latin -l gsw --shared
  ```
- Verify that the keyboards dropdown now shows Spanish, French, Italian, Swedish and Swiss German with the EuroLatin (SIL) keyboard

**TEST_UNINSTALL_UI**: Uninstall the keyboard removes it for all languages

(continuing from previous test)
- Open Keyman Configuration
- Uninstall EuroLatin (SIL) keyboard (from the user area)
- Verify that EuroLatin (SIL) only shows up in the shared area in Keyman Configuration
- Verify that the keyboards dropdown no longer shows Spanish, French and Italian with the EuroLatin (SIL) keyboard but still shows Swedish and Swiss German

**TEST_UNINSTALL_CLI**: Uninstall the keyboard from the shared area

(continuing from previous test)
- In the terminal window run the following command to install EuroLatin (SIL) keyboard for German into the user area:
  ```
  km-package-install -p sil_euro_latin -l de
  ```
- Verify that the keyboards dropdown now shows German with the EuroLatin (SIL) keyboard in addition to Swiss German and Swedish
- In the terminal run:
  ```
  sudo km-package-uninstall --shared sil_euro_latin
  ```
- Verify that the keyboards dropdown only shows German with the EuroLatin (SIL) keyboard. Swiss German and Swedish no longer show.
