### PR TITLE
fix(web): properly connects picker interface API 🧩

### DIFF
--- a/web/src/app/browser/src/keyboardInterface.ts
+++ b/web/src/app/browser/src/keyboardInterface.ts
@@ -15,10 +15,6 @@ export default class KeyboardInterface extends KeyboardInterfaceBase<ContextMana
     // Nothing else to do here... quite yet.  Things may not stay that way, though.
   }
 
-  public get osk() {
-    return this.engine.osk;
-  }
-
   // *** The following are quite useful for website-integrating KMW, but not needed for the embedded form. ***
 
   /**
@@ -43,12 +39,12 @@ export default class KeyboardInterface extends KeyboardInterfaceBase<ContextMana
 
   //The following entry points are defined but should not normally be used in a keyboard, as OSK display is no longer determined by the keyboard
   hideHelp(): void {
-    const osk = this.osk;
+    const osk = this.engine.osk;
     osk.startHide(true);
   }
 
   showHelp(Px: number, Py: number): void {
-    const osk = this.osk;
+    const osk = this.engine.osk;
 
     if(osk instanceof FloatingOSKView) {
       osk.presentAtPosition(Px,Py);
@@ -58,7 +54,7 @@ export default class KeyboardInterface extends KeyboardInterfaceBase<ContextMana
   }
 
   showPinnedHelp(): void {
-    const osk = this.osk;
+    const osk = this.engine.osk;
 
     if(osk instanceof FloatingOSKView) {
       // An old KMW bug previously auto-unset the affected field when this function was

--- a/web/src/app/browser/src/keyboardInterface.ts
+++ b/web/src/app/browser/src/keyboardInterface.ts
@@ -6,12 +6,6 @@ import ContextManager from './contextManager.js';
 import KeymanEngine from './keymanEngine.js';
 
 export default class KeyboardInterface extends KeyboardInterfaceBase<ContextManager> {
-  // TBD:  allowing it to be set and/or the retrieval mechanism.
-  //       Note that the OSK is constructed notably later, after page load + during full engine init.
-  //       So, the actual instance will not be available at construction-time.
-  private osk: OSKView; // Or some way to retrieve it.
-
-
   constructor(
     _jsGlobal: any,
     engine: KeymanEngine,
@@ -20,6 +14,11 @@ export default class KeyboardInterface extends KeyboardInterfaceBase<ContextMana
 
     // Nothing else to do here... quite yet.  Things may not stay that way, though.
   }
+
+  public get osk() {
+    return this.engine.osk;
+  }
+
   // *** The following are quite useful for website-integrating KMW, but not needed for the embedded form. ***
 
   /**

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -26,6 +26,7 @@ import { UtilApiEndpoint} from './utilApiEndpoint.js';
 import { UIModule } from './uiModuleInterface.js';
 import { HotkeyManager } from './hotkeyManager.js';
 import { BeepHandler } from './beepHandler.js';
+import KeyboardInterface from './keyboardInterface.js';
 
 export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, ContextManager, HardwareEventKeyboard> {
   touchLanguageMenu?: LanguageMenu;
@@ -113,6 +114,7 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
   protected processorConfiguration(): ProcessorInitOptions {
     return {
       ...super.processorConfiguration(),
+      keyboardInterface: this.interface || new KeyboardInterface(window, this),
       // Overrides just this component of the configuration.
       defaultOutputRules: new DefaultBrowserRules(this.contextManager)
     };

--- a/web/src/app/webview/src/keymanEngine.ts
+++ b/web/src/app/webview/src/keymanEngine.ts
@@ -1,5 +1,5 @@
-import { DeviceSpec } from '@keymanapp/keyboard-processor'
-import { KeymanEngine as KeymanEngineBase } from 'keyman/engine/main';
+import { DefaultRules, DeviceSpec } from '@keymanapp/keyboard-processor'
+import { KeymanEngine as KeymanEngineBase, KeyboardInterface } from 'keyman/engine/main';
 import { AnchoredOSKView, ViewConfiguration, StaticActivator } from 'keyman/engine/osk';
 import { getAbsoluteX, getAbsoluteY } from 'keyman/engine/dom-utils';
 import { type KeyboardStub, toPrefixedKeyboardId, toUnprefixedKeyboardId } from 'keyman/engine/package-cache';
@@ -25,7 +25,14 @@ export default class KeymanEngine extends KeymanEngineBase<WebviewConfiguration,
       }
     }
 
-    super(worker, config, new ContextManager(config));
+    super(worker, config, new ContextManager(config), (engine) => {
+      return {
+        // The `engine` parameter cannot be supplied with the constructing instance before calling
+        // `super`, hence the 'fun' rigging to supply it _from_ `super` via this closure.
+        keyboardInterface: new KeyboardInterface(window, engine, config.stubNamespacer),
+        defaultOutputRules: new DefaultRules()
+      };
+    });
 
     this.hardKeyboard = new PassthroughKeyboard(config.hardDevice);
   }

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -84,7 +84,8 @@ export default class KeymanEngine<
     }
 
     return {
-      keyboardInterface: this.interface,
+      keyboardInterface: this.interface ||
+        new KeyboardInterface<ContextManager>(window, this, this.config.stubNamespacer),
       baseLayout: baseLayout,
       defaultOutputRules: new DefaultRules()
     };
@@ -104,8 +105,9 @@ export default class KeymanEngine<
     this.config = config;
     this.contextManager = contextManager;
 
-    this.interface = new KeyboardInterface(window, this, config.stubNamespacer);
-    this.core = new InputProcessor(config.hostDevice, worker, this.processorConfiguration());
+    const processorConfiguration = this.processorConfiguration();
+    this.interface = processorConfiguration.keyboardInterface as KeyboardInterface<ContextManager>;
+    this.core = new InputProcessor(config.hostDevice, worker, processorConfiguration);
 
     this.core.languageProcessor.on('statechange', (state) => {
       // The banner controller cannot directly trigger a layout-refresh at this time,


### PR DESCRIPTION
Wow, totally missed this piece.  The special API functions used by the CJK picker keyboards had been converted, but were fully disconnected from the engine.  I'd also neglected to patch up their connection to the OSK.

I happened to catch this while preparing and double-checking Web's regression test suite in prep for user testing. I realized I hadn't double-checked the functionality in a while, so I took the opportunity to verify everything was working correctly... and as evidenced by this PR... it was not.  

@keymanapp-test-bot skip