### PR TITLE
chore(web): esbuild configuration cleanup 🧩

### DIFF
--- a/common/models/templates/build.sh
+++ b/common/models/templates/build.sh
@@ -19,7 +19,7 @@ cd "$(dirname "$THIS_SCRIPT")"
 
 builder_describe "Builds the predictive-text model template implementation module" \
   "@/common/web/keyman-version" \
-  "@/common/web/tslib" \
+  "@/common/web/es-bundling" \
   "@/common/models/wordbreakers" \
   "clean" \
   "configure" \

--- a/common/predictive-text/build-bundler.js
+++ b/common/predictive-text/build-bundler.js
@@ -1,18 +1,10 @@
 import esbuild from 'esbuild';
+import { esmConfiguration } from '../web/es-bundling/build/index.mjs';
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  format: "esm",
-  sourcemap: true,
-  target: "es5",
-  external: ['fs', 'vm'],
-  // nodePaths: ['../../node_modules'],
+  ...esmConfiguration,
   entryPoints: {
     'index': 'build/obj/web/index.js',
   },
-  outdir: 'build/lib/web',
-  outExtension: { '.js': '.mjs' }
+  outdir: 'build/lib/web' // We want to preserve the subdirectory for this one.
 });

--- a/common/predictive-text/build.sh
+++ b/common/predictive-text/build.sh
@@ -26,7 +26,7 @@ cd "$(dirname "$THIS_SCRIPT")"
 
 builder_describe "Builds the lm-layer module" \
   "@/common/web/keyman-version" \
-  "@/common/web/tslib" \
+  "@/common/web/es-bundling" \
   "@/common/web/lm-worker" \
   "clean" \
   "configure" \

--- a/common/web/es-bundling/README.md
+++ b/common/web/es-bundling/README.md
@@ -1,0 +1,6 @@
+This subproject provides definitions for the common configuration settings used for bundling
+web/ and common/web projects via `esbuild`.  This includes:
+
+- Standard settings for bundling to IIFE and ESM module formats
+- An `esbuild` plugin that facilitate tree-shaking of classes downcompiled to ES5 by TypeScript
+- Two `esbuild` plugins that facilitate tree-shaking of unused `tslib` helper functions

--- a/common/web/es-bundling/build.sh
+++ b/common/web/es-bundling/build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Compile KeymanWeb's 'keyboard-processor' module, one of the components of Web's 'core' module.
+#
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
+# This script runs from its own folder
+cd "$THIS_SCRIPT_PATH"
+
+################################ Main script ################################
+
+builder_describe "Builds KMW's esbuild-oriented common configuration & tooling" \
+  "@/common/web/tslib" \
+  "clean" \
+  "configure" \
+  "build"
+
+builder_describe_outputs \
+  configure          /node_modules \
+  build              /common/web/es-bundling/build/index.mjs
+
+builder_parse "$@"
+
+builder_run_action configure  verify_npm_setup
+builder_run_action clean      rm -rf build/
+builder_run_action build      tsc -b tsconfig.json

--- a/common/web/es-bundling/build.sh
+++ b/common/web/es-bundling/build.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-#
-# Compile KeymanWeb's 'keyboard-processor' module, one of the components of Web's 'core' module.
-#
-set -eu
 
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary

--- a/common/web/es-bundling/src/classTreeshaker.mts
+++ b/common/web/es-bundling/src/classTreeshaker.mts
@@ -1,0 +1,23 @@
+import type * as esbuild from 'esbuild';
+import * as fs from 'fs';
+
+/**
+ * Refer to https://github.com/microsoft/TypeScript/issues/13721#issuecomment-307259227 -
+ * the `@class` emit comment-annotation is designed to facilitate tree-shaking for ES5-targeted
+ * down-level emits.  `esbuild` doesn't look for it by default... but we can override that with
+ * this plugin.
+ */
+export const pluginForDowncompiledClassTreeshaking: esbuild.Plugin = {
+  name: '@class -> __PURE__',
+  setup(build) {
+    build.onLoad({filter: /\.js$/ }, async (args) => {
+      let source = await fs.promises.readFile(args.path, 'utf8');
+      return {
+        // Marks any classes compiled by TS (as per the /** @class */ annotation)
+        // as __PURE__ in order to facilitate tree-shaking.
+        contents: source.replace('/** @class */', '/* @__PURE__ */ /** @class */'),
+        loader: 'js'
+      }
+    });
+  }
+}

--- a/common/web/es-bundling/src/configuration.mts
+++ b/common/web/es-bundling/src/configuration.mts
@@ -14,30 +14,37 @@ export const esmConfiguration: esbuild.BuildOptions = {
   target: "es5"
 };
 
-export function objToLibRoot(entryPath: string) {
+export function objRoot(entryPath: string) {
   const OBJ_REGEX = /^(.+)\/obj\//;
   const match = entryPath.match(OBJ_REGEX);
 
-  return `${match[1]}/lib/`;
+  return `${match[1]}`;
 }
 
 /**
- * Given the KMW build output convention of raw TS output in build/obj or a subdirectory thereof,
- * with bundled output in build/lib directly, this produces the standard input-to-bundled-output
- * mapping for `esbuild`'s configuration settings.
+ * Given the KMW build output convention of raw TS output within a subfolder of `build` named `obj`,
+ * this configures esbuild to use the specified entry points for bundling and to have their output
+ * bundle locations rooted within a specified sibling folder to their "source" `obj` subfolder.
+ *
+ * Examples:
+ * 1. 'lib', 'build/obj/index.js' => 'build/lib/index.js'
+ * 2. 'debug', 'build/app/ui/obj/kmwuitoggle.js' => 'build/app/browser/debug/kmwuitoggle.js'
  *
  * @param path
+ * @configFolder
  * @returns
  */
-export function bundleObjEntryPointsAsLib(...path: string[]): esbuild.BuildOptions {
+export function bundleObjEntryPoints(configFolder: 'lib' | 'debug' | 'release', ...path: string[]): esbuild.BuildOptions {
   if(!path.length) {
     throw new Error("Must specify at least one entry point.");
   }
 
-  let mappedRoot = objToLibRoot(path[0]);
-  if(path.map((entry) => objToLibRoot(entry)).find((mappedEntry) => mappedEntry != mappedRoot)) {
+  let mappedRoot = objRoot(path[0]);
+  if(path.map((entry) => objRoot(entry)).find((mappedEntry) => mappedEntry != mappedRoot)) {
     throw new Error("The specified entry points map to different roots, therefore mapping is not 'standard'.");
   }
+
+  mappedRoot = `${mappedRoot}/${configFolder}/`
 
   return {
     entryPoints: path,

--- a/common/web/es-bundling/src/configuration.mts
+++ b/common/web/es-bundling/src/configuration.mts
@@ -1,0 +1,46 @@
+import type * as esbuild from 'esbuild';
+import { pluginForDowncompiledClassTreeshaking } from './classTreeshaker.mjs';
+
+export const esmConfiguration: esbuild.BuildOptions = {
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
+  bundle: true,
+  outExtension: { '.js': '.mjs'},
+  plugins: [ pluginForDowncompiledClassTreeshaking ],
+  sourcemap: true,
+  sourcesContent: true,
+  format: "esm",
+  target: "es5"
+};
+
+export function objToLibRoot(entryPath: string) {
+  const OBJ_REGEX = /^(.+)\/obj\//;
+  const match = entryPath.match(OBJ_REGEX);
+
+  return `${match[1]}/lib/`;
+}
+
+/**
+ * Given the KMW build output convention of raw TS output in build/obj or a subdirectory thereof,
+ * with bundled output in build/lib directly, this produces the standard input-to-bundled-output
+ * mapping for `esbuild`'s configuration settings.
+ *
+ * @param path
+ * @returns
+ */
+export function bundleObjEntryPointsAsLib(...path: string[]): esbuild.BuildOptions {
+  if(!path.length) {
+    throw new Error("Must specify at least one entry point.");
+  }
+
+  let mappedRoot = objToLibRoot(path[0]);
+  if(path.map((entry) => objToLibRoot(entry)).find((mappedEntry) => mappedEntry != mappedRoot)) {
+    throw new Error("The specified entry points map to different roots, therefore mapping is not 'standard'.");
+  }
+
+  return {
+    entryPoints: path,
+    outdir: mappedRoot
+  };
+}

--- a/common/web/es-bundling/src/configuration.mts
+++ b/common/web/es-bundling/src/configuration.mts
@@ -6,12 +6,19 @@ export const esmConfiguration: esbuild.BuildOptions = {
     'tslib': '@keymanapp/tslib'
   },
   bundle: true,
+  format: "esm",
   outExtension: { '.js': '.mjs'},
   plugins: [ pluginForDowncompiledClassTreeshaking ],
   sourcemap: true,
   sourcesContent: true,
-  format: "esm",
   target: "es5"
+};
+
+export const iifeConfiguration: esbuild.BuildOptions = {
+  ...esmConfiguration,
+  format: 'iife',
+  outExtension: { '.js': '.js'},
+  treeShaking: true
 };
 
 export function objRoot(entryPath: string) {

--- a/common/web/es-bundling/src/index.mts
+++ b/common/web/es-bundling/src/index.mts
@@ -1,2 +1,3 @@
 export * from './classTreeshaker.mjs';
 export * from './configuration.mjs';
+export * from './tslibTreeshaking.mjs';

--- a/common/web/es-bundling/src/index.mts
+++ b/common/web/es-bundling/src/index.mts
@@ -1,0 +1,2 @@
+export * from './classTreeshaker.mjs';
+export * from './configuration.mjs';

--- a/common/web/es-bundling/src/tslibTreeshaking.mts
+++ b/common/web/es-bundling/src/tslibTreeshaking.mts
@@ -40,8 +40,9 @@ export async function determineNeededDowncompileHelpers(config: esbuild.BuildOpt
 
   const detectedHelpers: string[] = [];
 
+  const pluginName = 'es-bundling:  tslib helper use detection'
   let tslibHelperDetectionPlugin = {
-    name: 'tslib helper use detection',
+    name: pluginName,
     setup(build: esbuild.PluginBuild) {
       build.onLoad({filter: /\.js$/}, async (args) => {
         let source = await fs.promises.readFile(args.path, 'utf8');
@@ -54,7 +55,7 @@ export async function determineNeededDowncompileHelpers(config: esbuild.BuildOpt
 
           if(!results) {
             return buildMessage(
-              'tslib helper use detection',
+              pluginName,
               "tslib's definition pattern has shifted dramatically!  tslib helper-definition detector maintenance is needed.",
               indexToSourceLocation('', 0, 0, args.path)
             );
@@ -68,7 +69,7 @@ export async function determineNeededDowncompileHelpers(config: esbuild.BuildOpt
               let index = source.indexOf(result);
 
               warnings.push(buildMessage(
-                'tslib helper use detection',
+                pluginName,
                 'Probable `tslib` helper `' + capture + '` has not been validated for tree-shaking potential',
                 indexToSourceLocation(source, index, result.length, args.path)
               ));

--- a/common/web/es-bundling/tsconfig.json
+++ b/common/web/es-bundling/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.esm-base.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "build/",
+    "tsBuildInfoFile": "build/tsconfig.tsbuildinfo",
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*.mts"]
+}

--- a/common/web/input-processor/build-bundler.js
+++ b/common/web/input-processor/build-bundler.js
@@ -1,14 +1,8 @@
 import esbuild from 'esbuild';
+import { esmConfiguration, bundleObjEntryPointsAsLib } from '../es-bundling/build/index.mjs';
 
 // Bundled ES module version
-esbuild.buildSync({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  target: "es5",
-  entryPoints: ['build/obj/index.js'],
-  outfile: "build/lib/index.mjs"
+await esbuild.build({
+  ...esmConfiguration,
+  ...bundleObjEntryPointsAsLib('build/obj/index.js')
 });

--- a/common/web/input-processor/build-bundler.js
+++ b/common/web/input-processor/build-bundler.js
@@ -1,8 +1,8 @@
 import esbuild from 'esbuild';
-import { esmConfiguration, bundleObjEntryPointsAsLib } from '../es-bundling/build/index.mjs';
+import { esmConfiguration, bundleObjEntryPoints } from '../es-bundling/build/index.mjs';
 
 // Bundled ES module version
 await esbuild.build({
   ...esmConfiguration,
-  ...bundleObjEntryPointsAsLib('build/obj/index.js')
+  ...bundleObjEntryPoints('lib', 'build/obj/index.js')
 });

--- a/common/web/keyboard-processor/build-bundler.js
+++ b/common/web/keyboard-processor/build-bundler.js
@@ -1,11 +1,11 @@
 import esbuild from 'esbuild';
-import { esmConfiguration, bundleObjEntryPointsAsLib } from '../es-bundling/build/index.mjs';
+import { esmConfiguration, bundleObjEntryPoints } from '../es-bundling/build/index.mjs';
 import * as fs from 'fs';
 
 // Bundled ES module version
 await esbuild.build({
   ...esmConfiguration,
-  ...bundleObjEntryPointsAsLib('build/obj/index.js', 'build/obj/keyboards/loaders/dom-keyboard-loader.js')
+  ...bundleObjEntryPoints('lib', 'build/obj/index.js', 'build/obj/keyboards/loaders/dom-keyboard-loader.js')
 });
 
 // Sadly, esbuild aims to preserve the relative path between entry points... we want it directly
@@ -19,6 +19,6 @@ fs.rmSync('build/lib/keyboards', { recursive: true, force: true });
 // The node-based keyboard loader needs an extra parameter due to Node-built-in imports:
 await esbuild.build({
   ...esmConfiguration,
-  ...bundleObjEntryPointsAsLib('build/obj/keyboards/loaders/node-keyboard-loader.js'),
+  ...bundleObjEntryPoints('lib', 'build/obj/keyboards/loaders/node-keyboard-loader.js'),
   platform: "node"
 });

--- a/common/web/keyboard-processor/build-bundler.js
+++ b/common/web/keyboard-processor/build-bundler.js
@@ -1,33 +1,24 @@
 import esbuild from 'esbuild';
-
-/** @type {esbuild.BuildOptions} */
-const commonConfig = {
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  target: "es5"
-};
+import { esmConfiguration, bundleObjEntryPointsAsLib } from '../es-bundling/build/index.mjs';
+import * as fs from 'fs';
 
 // Bundled ES module version
-esbuild.buildSync({
-  entryPoints: ['build/obj/index.js'],
-  outfile: "build/lib/index.mjs",
-  ...commonConfig
+await esbuild.build({
+  ...esmConfiguration,
+  ...bundleObjEntryPointsAsLib('build/obj/index.js', 'build/obj/keyboards/loaders/dom-keyboard-loader.js')
 });
 
-esbuild.buildSync({
-  entryPoints: ['build/obj/keyboards/loaders/dom-keyboard-loader.js'],
-  outfile: 'build/lib/dom-keyboard-loader.mjs',
-  ...commonConfig
-});
+// Sadly, esbuild aims to preserve the relative path between entry points... we want it directly
+// in /build/lib, not in a buried subfolder.  (This matters most for explicitly DOM libs like this
+// one, since we can't do import path resolution in DOM tests like we can for headless tests.)
+//
+// Alternatively, we can just build it separately like the node-oriented one.
+fs.renameSync('build/lib/keyboards/loaders/dom-keyboard-loader.mjs', 'build/lib/dom-keyboard-loader.mjs');
+fs.rmSync('build/lib/keyboards', { recursive: true, force: true });
 
 // The node-based keyboard loader needs an extra parameter due to Node-built-in imports:
-esbuild.buildSync({
-  entryPoints: ['build/obj/keyboards/loaders/node-keyboard-loader.js'],
-  outfile: 'build/lib/node-keyboard-loader.mjs',
-  platform: "node",
-  ...commonConfig
+await esbuild.build({
+  ...esmConfiguration,
+  ...bundleObjEntryPointsAsLib('build/obj/keyboards/loaders/node-keyboard-loader.js'),
+  platform: "node"
 });

--- a/common/web/keyboard-processor/build.sh
+++ b/common/web/keyboard-processor/build.sh
@@ -22,7 +22,6 @@ builder_describe \
   "@/common/web/recorder  test" \
   "@/common/web/keyman-version" \
   "@/common/web/es-bundling" \
-  "@/common/web/es-bundling" \
   "@/common/web/utils" \
   configure \
   clean \

--- a/common/web/keyboard-processor/build.sh
+++ b/common/web/keyboard-processor/build.sh
@@ -21,7 +21,8 @@ builder_describe \
   "Compiles the web-oriented utility function module." \
   "@/common/web/recorder  test" \
   "@/common/web/keyman-version" \
-  "@/common/web/tslib" \
+  "@/common/web/es-bundling" \
+  "@/common/web/es-bundling" \
   "@/common/web/utils" \
   configure \
   clean \

--- a/common/web/lm-worker/build-bundler.js
+++ b/common/web/lm-worker/build-bundler.js
@@ -6,7 +6,7 @@
  */
 
 import esbuild from 'esbuild';
-import { bundleObjEntryPointsAsLib, esmConfiguration, prepareTslibTreeshaking } from '../es-bundling/build/index.mjs';
+import { bundleObjEntryPoints, esmConfiguration, prepareTslibTreeshaking } from '../es-bundling/build/index.mjs';
 
 import fs from 'fs';
 
@@ -36,7 +36,7 @@ const embeddedWorkerBuildOptions = await prepareTslibTreeshaking({
   // configs change their default, we should not minify for THIS build; we'll
   // have a separate minify pass later, after concatenating our polyfills.
   minify: false,
-  ...bundleObjEntryPointsAsLib('build/obj/index.js', 'build/obj/worker-main.js')
+  ...bundleObjEntryPoints('lib', 'build/obj/index.js', 'build/obj/worker-main.js')
 });
 
 // Direct-use version

--- a/common/web/lm-worker/build-bundler.js
+++ b/common/web/lm-worker/build-bundler.js
@@ -32,11 +32,12 @@ if(process.argv.length > 2) {
 
 const embeddedWorkerBuildOptions = await prepareTslibTreeshaking({
   ...esmConfiguration,
+  ...bundleObjEntryPoints('lib', 'build/obj/index.js', 'build/obj/worker-main.js'),
   // To be explicit, in comparison to the other build below.  Even if our other
   // configs change their default, we should not minify for THIS build; we'll
   // have a separate minify pass later, after concatenating our polyfills.
-  minify: false,
-  ...bundleObjEntryPoints('lib', 'build/obj/index.js', 'build/obj/worker-main.js')
+  minify: false
+  // No treeshaking at the moment (in case it treeshakes out certain model templates!)
 });
 
 // Direct-use version

--- a/common/web/lm-worker/build-wrap-and-minify.js
+++ b/common/web/lm-worker/build-wrap-and-minify.js
@@ -33,7 +33,7 @@ if(MINIFY) {
     entryPoints: [`build/lib/worker-main.polyfilled.js`],
     sourcemap: 'external',
     sourcesContent: DEBUG,
-    minify: MINIFY,
+    minify: true,
     keepNames: true,
     outfile: `build/lib/worker-main.polyfilled.min.js`
   });

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -29,7 +29,6 @@ builder_describe \
   "Compiles the Language Modeling Layer for common use in predictive text and autocorrective applications." \
   "@/common/web/keyman-version" \
   "@/common/web/es-bundling" \
-  "@/common/web/es-bundling" \
   "@/common/models/wordbreakers" \
   "@/common/models/templates" \
   configure clean build test --ci

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -28,7 +28,8 @@ WORKER_OUTPUT_FILENAME=build/lib/worker-main.js
 builder_describe \
   "Compiles the Language Modeling Layer for common use in predictive text and autocorrective applications." \
   "@/common/web/keyman-version" \
-  "@/common/web/tslib" \
+  "@/common/web/es-bundling" \
+  "@/common/web/es-bundling" \
   "@/common/models/wordbreakers" \
   "@/common/models/templates" \
   configure clean build test --ci

--- a/common/web/utils/build.sh
+++ b/common/web/utils/build.sh
@@ -19,7 +19,7 @@ cd "$THIS_SCRIPT_PATH"
 builder_describe \
   "Compiles the web-oriented utility function module." \
   "@/common/web/keyman-version" \
-  "@/common/web/tslib" \
+  "@/common/web/es-bundling" \
   clean configure build test \
   "--ci    For use with action ${BUILDER_TERM_START}test${BUILDER_TERM_END} - emits CI-friendly test reports"
 

--- a/web/src/app/browser/build-bundler.js
+++ b/web/src/app/browser/build-bundler.js
@@ -7,7 +7,7 @@
 
 import esbuild from 'esbuild';
 import fs from 'fs';
-import { determineNeededDowncompileHelpers, buildTslibTreeshaker } from '@keymanapp/tslib/esbuild-tools';
+import { bundleObjEntryPointsAsLib, esmConfiguration, prepareTslibTreeshaking } from '../../../../common/web/es-bundling/build/index.mjs';
 
 let EMIT_FILESIZE_PROFILE = false;
 
@@ -72,9 +72,7 @@ const commonConfig = {
   tsconfig: './tsconfig.json'
 };
 
-// Prepare the needed setup for `tslib` treeshaking.
-const unusedHelpers = await determineNeededDowncompileHelpers(commonConfig, /worker-main\.wrapped(?:\.min)?\.js/);
-commonConfig.plugins = [buildTslibTreeshaker(unusedHelpers), ...commonConfig.plugins];
+await prepareTslibTreeshaking(commonConfig, /worker-main\.wrapped(?:\.min)?\.js/);
 
 // And now... do the actual builds.
 await esbuild.build(commonConfig);

--- a/web/src/app/browser/build-bundler.js
+++ b/web/src/app/browser/build-bundler.js
@@ -7,7 +7,7 @@
 
 import esbuild from 'esbuild';
 import fs from 'fs';
-import { bundleObjEntryPointsAsLib, esmConfiguration, prepareTslibTreeshaking } from '../../../../common/web/es-bundling/build/index.mjs';
+import { bundleObjEntryPoints, esmConfiguration, prepareTslibTreeshaking } from '../../../../common/web/es-bundling/build/index.mjs';
 
 let EMIT_FILESIZE_PROFILE = false;
 

--- a/web/src/app/ui/build-bundler.js
+++ b/web/src/app/ui/build-bundler.js
@@ -6,67 +6,26 @@
  */
 
 import esbuild from 'esbuild';
+import { bundleObjEntryPoints, iifeConfiguration } from '../../../../common/web/es-bundling/build/index.mjs';
 
-import fs from 'fs';
+const moduleNames = ['kmwuibutton', 'kmwuifloat', 'kmwuitoggle', 'kmwuitoolbar'];
+const modules = moduleNames.map((name) => `../../../build/app/ui/obj/${name}.js`);
 
-/*
- * Refer to https://github.com/microsoft/TypeScript/issues/13721#issuecomment-307259227 -
- * the `@class` emit comment-annotation is designed to facilitate tree-shaking for ES5-targeted
- * down-level emits.  `esbuild` doesn't look for it by default... but we can override that with
- * this plugin.
- */
-let es5ClassAnnotationAsPurePlugin = {
-  name: '@class -> __PURE__',
-  setup(build) {
-    build.onLoad({filter: /\.js$/ }, async (args) => {
-      let source = await fs.promises.readFile(args.path, 'utf8');
-      return {
-        // Marks any classes compiled by TS (as per the /** @class */ annotation)
-        // as __PURE__ in order to facilitate tree-shaking.
-        contents: source.replace('/** @class */', '/* @__PURE__ */ /** @class */'),
-        loader: 'js'
-      }
-    });
-  }
-}
+await esbuild.build({
+  ...iifeConfiguration,
+  ...bundleObjEntryPoints('debug', ...modules),
+  // `esbuild`'s sourcemap output puts relative paths to the original sources from the
+  // directory of the build output.  The following keeps repo structure intact and
+  // puts our code under a common 'namespace' of sorts.
+  sourceRoot: '@keymanapp/keyman/web/build/app/ui/debug/',
+});
 
-const modules = ['kmwuibutton', 'kmwuifloat', 'kmwuitoggle', 'kmwuitoolbar'];
-
-for(let module of modules) {
-  await esbuild.build({
-    bundle: true,
-    sourcemap: true,
-    format: "iife",
-    nodePaths: ['../../../../node_modules'],
-    entryPoints: {
-      'index': `../../../build/app/ui/obj/${module}.js`,
-    },
-    outfile: `../../../build/app/ui/debug/${module}.js`,
-    plugins: [ es5ClassAnnotationAsPurePlugin ],
-    // `esbuild`'s sourcemap output puts relative paths to the original sources from the
-    // directory of the build output.  The following keeps repo structure intact and
-    // puts our code under a common 'namespace' of sorts.
-    sourceRoot: '@keymanapp/keyman/web/build/app/ui/debug/',
-    target: "es5",
-    treeShaking: true,
-    tsconfig: './tsconfig.json'
-  });
-
-  await esbuild.build({
-    bundle: true,
-    sourcemap: true,
-    minifyWhitespace: true,
-    minifySyntax: true,
-    minifyIdentifiers: false,
-    format: "iife",
-    nodePaths: ['../../../../node_modules'],
-    entryPoints: {
-      'index': `../../../build/app/ui/obj/${module}.js`,
-    },
-    outfile: `../../../build/app/ui/release/${module}.js`,
-    plugins: [ es5ClassAnnotationAsPurePlugin ],
-    target: "es5",
-    treeShaking: true,
-    tsconfig: './tsconfig.json'
-  });
-}
+await esbuild.build({
+  ...iifeConfiguration,
+  ...bundleObjEntryPoints('release', ...modules),
+  minify: true,
+  // `esbuild`'s sourcemap output puts relative paths to the original sources from the
+  // directory of the build output.  The following keeps repo structure intact and
+  // puts our code under a common 'namespace' of sorts.
+  sourceRoot: '@keymanapp/keyman/web/build/app/ui/debug/',
+});

--- a/web/src/app/webview/build-bundler.js
+++ b/web/src/app/webview/build-bundler.js
@@ -6,7 +6,7 @@
  */
 
 import esbuild from 'esbuild';
-import { iifeConfiguration } from '../../../../common/web/es-bundling/build/index.mjs';
+import { iifeConfiguration, prepareTslibTreeshaking  } from '../../../../common/web/es-bundling/build/index.mjs';
 
 const commonConfig = {
   ...iifeConfiguration,

--- a/web/src/app/webview/build-bundler.js
+++ b/web/src/app/webview/build-bundler.js
@@ -6,75 +6,33 @@
  */
 
 import esbuild from 'esbuild';
+import { iifeConfiguration } from '../../../../common/web/es-bundling/build/index.mjs';
 
-import fs from 'fs';
-
-/*
- * Refer to https://github.com/microsoft/TypeScript/issues/13721#issuecomment-307259227 -
- * the `@class` emit comment-annotation is designed to facilitate tree-shaking for ES5-targeted
- * down-level emits.  `esbuild` doesn't look for it by default... but we can override that with
- * this plugin.
- */
-let es5ClassAnnotationAsPurePlugin = {
-  name: '@class -> __PURE__',
-  setup(build) {
-    build.onLoad({filter: /\.js$/ }, async (args) => {
-      let source = await fs.promises.readFile(args.path, 'utf8');
-      return {
-        // Marks any classes compiled by TS (as per the /** @class */ annotation)
-        // as __PURE__ in order to facilitate tree-shaking.
-        contents: source.replace('/** @class */', '/* @__PURE__ */ /** @class */'),
-        loader: 'js'
-      }
-    });
-  }
-}
-
-await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "iife",
-  nodePaths: ['../../../../node_modules'],
+const commonConfig = {
+  ...iifeConfiguration,
   entryPoints: {
     'index': '../../../build/app/webview/obj/debug-main.js',
   },
   outfile: '../../../build/app/webview/debug/keymanweb-webview.js',
-  plugins: [ es5ClassAnnotationAsPurePlugin ],
   // `esbuild`'s sourcemap output puts relative paths to the original sources from the
   // directory of the build output.  The following keeps repo structure intact and
   // puts our code under a common 'namespace' of sorts.
-  sourceRoot: '@keymanapp/keyman/web/build/app/webview/debug/',
-  target: "es5",
-  treeShaking: true,
-  tsconfig: './tsconfig.json'
-});
+  sourceRoot: '@keymanapp/keyman/web/build/app/webview/debug/'
+};
 
-// TODO: add tslib treeshaking.
+await prepareTslibTreeshaking(commonConfig, /worker-main\.wrapped(?:\.min)?\.js/);
+
+await esbuild.build(commonConfig);
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  minifyWhitespace: true,
-  minifySyntax: true,
-  minifyIdentifiers: false,
-  format: "iife",
-  nodePaths: ['../../../../node_modules'],
+  ...commonConfig,
   entryPoints: {
     'index': '../../../build/app/webview/obj/release-main.js',
   },
+  minify: true,
   outfile: '../../../build/app/webview/release/keymanweb-webview.js',
-  plugins: [ es5ClassAnnotationAsPurePlugin ],
   // `esbuild`'s sourcemap output puts relative paths to the original sources from the
   // directory of the build output.  The following keeps repo structure intact and
   // puts our code under a common 'namespace' of sorts.
-  sourceRoot: '@keymanapp/keyman/web/build/app/webview/debug/',
-  target: "es5",
-  treeShaking: true,
-  tsconfig: './tsconfig.json'
+  sourceRoot: '@keymanapp/keyman/web/build/app/webview/debug/'
 });

--- a/web/src/app/webview/build-bundler.js
+++ b/web/src/app/webview/build-bundler.js
@@ -52,6 +52,8 @@ await esbuild.build({
   tsconfig: './tsconfig.json'
 });
 
+// TODO: add tslib treeshaking.
+
 await esbuild.build({
   alias: {
     'tslib': '@keymanapp/tslib'

--- a/web/src/engine/attachment/build-bundler.js
+++ b/web/src/engine/attachment/build-bundler.js
@@ -6,22 +6,9 @@
  */
 
 import esbuild from 'esbuild';
-
+import { esmConfiguration, bundleObjEntryPoints } from '../../../../common/web/es-bundling/build/index.mjs';
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  nodePaths: ['../../../../node_modules'],
-  entryPoints: {
-    'index': '../../../build/engine/attachment/obj/index.js',
-  },
-  external: ['fs', 'vm'],
-  outdir: '../../../build/engine/attachment/lib/',
-  outExtension: { '.js': '.mjs' },
-  tsconfig: './tsconfig.json',
-  target: "es5"
+  ...esmConfiguration,
+  ...bundleObjEntryPoints('lib', '../../../build/engine/attachment/obj/index.js')
 });

--- a/web/src/engine/device-detect/build-bundler.js
+++ b/web/src/engine/device-detect/build-bundler.js
@@ -6,21 +6,9 @@
  */
 
 import esbuild from 'esbuild';
-
+import { esmConfiguration, bundleObjEntryPoints } from '../../../../common/web/es-bundling/build/index.mjs';
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  nodePaths: ['../../../../node_modules', '../../../build/engine/device-detect/obj'],
-  entryPoints: {
-    'index': '../../../build/engine/device-detect/obj/index.js',
-  },
-  external: ['fs', 'vm'],
-  outfile: '../../../build/engine/device-detect/lib/index.mjs',
-  tsconfig: './tsconfig.json',
-  target: "es5"
+  ...esmConfiguration,
+  ...bundleObjEntryPoints('lib', '../../../build/engine/device-detect/obj/index.js')
 });

--- a/web/src/engine/element-wrappers/build-bundler.js
+++ b/web/src/engine/element-wrappers/build-bundler.js
@@ -6,22 +6,9 @@
  */
 
 import esbuild from 'esbuild';
-
+import { esmConfiguration, bundleObjEntryPoints } from '../../../../common/web/es-bundling/build/index.mjs';
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  nodePaths: ['../../../../node_modules'],
-  entryPoints: {
-    'index': '../../../build/engine/element-wrappers/obj/index.js',
-  },
-  external: ['fs', 'vm'],
-  outdir: '../../../build/engine/element-wrappers/lib/',
-  outExtension: { '.js': '.mjs' },
-  tsconfig: './tsconfig.json',
-  target: "es5"
+  ...esmConfiguration,
+  ...bundleObjEntryPoints('lib', '../../../build/engine/element-wrappers/obj/index.js')
 });

--- a/web/src/engine/events/build-bundler.js
+++ b/web/src/engine/events/build-bundler.js
@@ -6,22 +6,9 @@
  */
 
 import esbuild from 'esbuild';
-
+import { esmConfiguration, bundleObjEntryPoints } from '../../../../common/web/es-bundling/build/index.mjs';
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  nodePaths: ['../../../../node_modules'],
-  entryPoints: {
-    'index': '../../../build/engine/events/obj/index.js',
-  },
-  external: ['fs', 'vm'],
-  outdir: '../../../build/engine/events/lib/',
-  outExtension: { '.js': '.mjs' },
-  tsconfig: './tsconfig.json',
-  target: "es5"
+  ...esmConfiguration,
+  ...bundleObjEntryPoints('lib', '../../../build/engine/events/obj/index.js')
 });

--- a/web/src/engine/main/build-bundler.js
+++ b/web/src/engine/main/build-bundler.js
@@ -6,22 +6,9 @@
  */
 
 import esbuild from 'esbuild';
-
+import { esmConfiguration, bundleObjEntryPoints } from '../../../../common/web/es-bundling/build/index.mjs';
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  nodePaths: ['../../../../node_modules'],
-  entryPoints: {
-    'index': '../../../build/engine/main/obj/index.js',
-  },
-  external: ['fs', 'vm'],
-  outdir: '../../../build/engine/main/lib/',
-  outExtension: { '.js': '.mjs' },
-  tsconfig: './tsconfig.json',
-  target: "es5"
+  ...esmConfiguration,
+  ...bundleObjEntryPoints('lib', '../../../build/engine/main/obj/index.js')
 });

--- a/web/src/engine/osk/build-bundler.js
+++ b/web/src/engine/osk/build-bundler.js
@@ -1,19 +1,7 @@
 import esbuild from 'esbuild';
+import { esmConfiguration, bundleObjEntryPoints } from '../../../../common/web/es-bundling/build/index.mjs';
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  nodePaths: ['../../../../node_modules'],
-  entryPoints: {
-    'index': '../../../build/engine/osk/obj/index.js',
-  },
-  external: ['fs', 'vm'],
-  outdir: '../../../build/engine/osk/lib/',
-  outExtension: { '.js': '.mjs' },
-  tsconfig: './tsconfig.json',
-  target: "es5"
+  ...esmConfiguration,
+  ...bundleObjEntryPoints('lib', '../../../build/engine/osk/obj/index.js')
 });

--- a/web/src/engine/package-cache/build-bundler.js
+++ b/web/src/engine/package-cache/build-bundler.js
@@ -1,53 +1,24 @@
 import esbuild from 'esbuild';
+import { esmConfiguration, bundleObjEntryPoints } from '../../../../common/web/es-bundling/build/index.mjs';
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  nodePaths: ['../../../../node_modules'],
-  entryPoints: {
-    'index': '../../../build/engine/package-cache/obj/index.js',
-  },
-  outdir: '../../../build/engine/package-cache/lib/',
-  outExtension: { '.js': '.mjs' },
-  tsconfig: './tsconfig.json',
-  target: "es5"
+  ...esmConfiguration,
+  ...bundleObjEntryPoints('lib', '../../../build/engine/package-cache/obj/index.js')
 });
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  nodePaths: ['../../../../node_modules'],
+  ...esmConfiguration,
   entryPoints: {
     'dom-cloud-requester': '../../../build/engine/package-cache/obj/domCloudRequester.js',
   },
   outdir: '../../../build/engine/package-cache/lib/',
-  outExtension: { '.js': '.mjs' },
-  tsconfig: './tsconfig.json',
-  target: "es5"
 });
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  nodePaths: ['../../../../node_modules'],
+  ...esmConfiguration,
   entryPoints: {
     'node-cloud-requester': '../../../build/engine/package-cache/obj/nodeCloudRequester.js',
   },
   outdir: '../../../build/engine/package-cache/lib/',
-  outExtension: { '.js': '.mjs' },
-  platform: 'node',
-  tsconfig: './tsconfig.json',
-  target: "es5"
+  platform: 'node'
 });

--- a/web/src/engine/package-cache/build.sh
+++ b/web/src/engine/package-cache/build.sh
@@ -16,7 +16,7 @@ cd "$THIS_SCRIPT_PATH"
 # ################################ Main script ################################
 
 builder_describe "Builds Keyman Engine modules for keyboard cloud-querying & caching + model caching." \
-  "@/common/web/tslib" \
+  "@/common/web/es-bundling" \
   "@/common/web/input-processor build" \
   "@/web/src/engine/paths" \
   "clean" \

--- a/web/src/engine/paths/build-bundler.js
+++ b/web/src/engine/paths/build-bundler.js
@@ -6,22 +6,9 @@
  */
 
 import esbuild from 'esbuild';
-
+import { esmConfiguration, bundleObjEntryPoints } from '../../../../common/web/es-bundling/build/index.mjs';
 
 await esbuild.build({
-  alias: {
-    'tslib': '@keymanapp/tslib'
-  },
-  bundle: true,
-  sourcemap: true,
-  format: "esm",
-  nodePaths: ['../../../../node_modules'],
-  entryPoints: {
-    'index': '../../../build/engine/paths/obj/index.js',
-  },
-  external: ['fs', 'vm'],
-  outdir: '../../../build/engine/paths/lib/',
-  outExtension: { '.js': '.mjs' },
-  tsconfig: './tsconfig.json',
-  target: "es5"
+  ...esmConfiguration,
+  ...bundleObjEntryPoints('lib', '../../../build/engine/paths/obj/index.js')
 });

--- a/web/src/engine/paths/build.sh
+++ b/web/src/engine/paths/build.sh
@@ -16,7 +16,7 @@ cd "$THIS_SCRIPT_PATH"
 # ################################ Main script ################################
 
 builder_describe "Builds configuration subclasses used by the Keyman Engine for Web (KMW)." \
-  "@/common/web/tslib" \
+  "@/common/web/es-bundling" \
   "@/web/src/engine/osk build" \
   "clean" \
   "configure" \


### PR DESCRIPTION
This PR centralizes the main configuration properties among all the esbuild-oriented scripts introduced on the feature-esmodule-web-engine (🧩) feature branch.  There's also some cleanup of unnecessary settings.

I thought about making a package.json and such for the centralized config & utility definitions, but figured we could do without yet another one for now.  (I noticed that `common/web/es-lint` does similarly.)  It would make the import pathing simpler if we did add one, though.

@keymanapp-test-bot skip