### PR TITLE
fix(android/samples): Cleanup Sample/Tests apk's

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -13,6 +13,7 @@ sentry.properties
 # User-specific stuff:
 **/.idea/libraries/
 **/.idea/dictionaries
+**/.idea/shelf/
 **/.idea/**/*.xml
 **/*.iml
 

--- a/android/Samples/KMSample1/build.sh
+++ b/android/Samples/KMSample1/build.sh
@@ -36,13 +36,14 @@ builder_describe "Build KMSample1 app for Android." \
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
 
+ARTIFACT="app-release-unsigned.apk"
+
 if builder_is_debug_build; then
   builder_heading "### Debug config ####"
   CONFIG="debug"
   SAMPLE_FLAGS="assembleDebug"
+  ARTIFACT="app-$CONFIG.apk"
 fi
-
-ARTIFACT="app-$CONFIG.apk"
 
 
 builder_describe_outputs \

--- a/android/Samples/KMSample2/build.gradle
+++ b/android/Samples/KMSample2/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/Samples/KMSample2/build.sh
+++ b/android/Samples/KMSample2/build.sh
@@ -36,13 +36,15 @@ builder_describe "Build KMSample2 app for Android." \
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
 
+ARTIFACT="app-release-unsigned.apk"
+
 if builder_is_debug_build; then
   builder_heading "### Debug config ####"
   CONFIG="debug"
   SAMPLE_FLAGS="assembleDebug"
+  ARTIFACT="app-$CONFIG.apk"
 fi
 
-ARTIFACT="app-$CONFIG.apk"
 
 
 builder_describe_outputs \

--- a/android/Tests/KeyboardHarness/build.sh
+++ b/android/Tests/KeyboardHarness/build.sh
@@ -35,14 +35,16 @@ builder_describe "Build KeyboardHarness test app for Android." \
 # parse before describe outputs to check debug flags  
 builder_parse "$@"
 
+ARTIFACT="app-release-unsigned.apk"
+
 if builder_is_debug_build; then
   builder_heading "### Debug config ####"
   CONFIG="debug"
   BUILD_FLAGS="assembleDebug -x lint -x test"
   TEST_FLAGS="-x assembleDebug lintDebug testDebug"
+  ARTIFACT="app-$CONFIG.apk"
 fi
 
-ARTIFACT="app-$CONFIG.apk"
 
 builder_describe_outputs \
   configure    /android/Tests/KeyboardHarness/app/libs/keyman-engine.aar \


### PR DESCRIPTION
I was setting up a new machine and encountered warnings/errors with `/android/build.sh` (no args for Samples/Tests generate unsigned release apk's)

* Default output is app-release-unsigned.apk instead of app-release.apk. KMAPro not affected because that build has custom version/environment in the apk name
* KMSample2 failed to build due to a linting error (updating Gradle plugin fixed it)

@keymanapp-test-bot skip
