### PR TITLE
chore(developer): cleanup data passing from wasm 🗜

### DIFF
--- a/developer/src/kmc-analyze/src/util/get-osk-from-kmn-file.ts
+++ b/developer/src/kmc-analyze/src/util/get-osk-from-kmn-file.ts
@@ -26,8 +26,8 @@ export async function getOskFromKmnFile(callbacks: CompilerCallbacks, filename: 
     return null;
   }
 
-  if(result.data.kvksFilename) {
-    kvksFilename = callbacks.resolveFilename(filename, result.data.kvksFilename);
+  if(result.extra.kvksFilename) {
+    kvksFilename = callbacks.resolveFilename(filename, result.extra.kvksFilename);
   }
 
   const reader = new KmxFileReader();

--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -22,7 +22,7 @@ export const COMPILETARGETS_JS =    0x02;
 export const COMPILETARGETS__MASK = 0x03;
 
 /**
- * Data in CompilerResultMetadata comes from kmcmplib
+ * Data in CompilerResultExtra comes from kmcmplib
  */
 export interface CompilerResultExtra {
   /**

--- a/developer/src/kmc-kmn/src/kmw-compiler/write-compiled-keyboard.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/write-compiled-keyboard.ts
@@ -1,10 +1,11 @@
-import { KMX, CompilerOptions, CompilerCallbacks, KvkFileReader, VisualKeyboard, KmxFileReader, Osk, KvkFile } from "@keymanapp/common-types";
+import { KMX, CompilerOptions, CompilerCallbacks, KvkFileReader, VisualKeyboard, KmxFileReader, KvkFile } from "@keymanapp/common-types";
 import { ExpandSentinel, incxstr, xstrlen } from "./util.js";
 import { options, nl, FTabStop, setupGlobals, IsKeyboardVersion10OrLater, callbacks, FFix183_LadderLength } from "./compiler-globals.js";
 import { JavaScript_ContextMatch, JavaScript_KeyAsString, JavaScript_Name, JavaScript_OutputString, JavaScript_Rules, JavaScript_Shift, JavaScript_ShiftAsString, JavaScript_Store, zeroPadHex } from './javascript-strings.js';
 import { KmwCompilerMessages } from "./messages.js";
 import { ValidateLayoutFile } from "./validate-layout-file.js";
 import { VisualKeyboardFromFile } from "./visual-keyboard-compiler.js";
+import { CompilerResult } from "src/compiler/compiler.js";
 
 function requote(s: string): string {
   return "'" + s.replaceAll(/(['\\])/, "\\$1") + "'";
@@ -33,7 +34,7 @@ export function RequotedString(s: string, RequoteSingleQuotes: boolean = false):
   return s;
 }
 
-export function WriteCompiledKeyboard(callbacks: CompilerCallbacks, kmnfile: string, keyboardData: Uint8Array, kvkData: Uint8Array, displayMap: Osk.PuaMap, FDebug: boolean = false): string {
+export function WriteCompiledKeyboard(callbacks: CompilerCallbacks, kmnfile: string, keyboardData: Uint8Array, kvkData: Uint8Array, kmxResult: CompilerResult, FDebug: boolean = false): string {
   let opts: CompilerOptions = {
     shouldAddCompilerVersion: false,
     saveDebug: FDebug
@@ -153,7 +154,7 @@ export function WriteCompiledKeyboard(callbacks: CompilerCallbacks, kmnfile: str
   if (sLayoutFilename != '') {  // I3483
     sLayoutFilename = callbacks.resolveFilename(kmnfile, sLayoutFilename);
 
-    let result = ValidateLayoutFile(keyboard, options.saveDebug, sLayoutFilename, sVKDictionary, displayMap);
+    let result = ValidateLayoutFile(keyboard, options.saveDebug, sLayoutFilename, sVKDictionary, kmxResult.displayMap);
     if(!result.result) {
       sLayoutFile = '';
       callbacks.reportMessage(KmwCompilerMessages.Error_TouchLayoutFileInvalid({filename:sLayoutFilename}));

--- a/developer/src/kmc-kmn/test/kmw/test-compiler-manual.ts
+++ b/developer/src/kmc-kmn/test/kmw/test-compiler-manual.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { KmnCompiler } from '../../src/compiler/compiler.js';
-import { WriteCompiledKeyboard } from '../../src/kmw-compiler/write-compiled-keyboard.js';
 import { extractTouchLayout } from './util.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url)).replace(/\\/g, '/');
@@ -25,8 +24,6 @@ if(!await kmnCompiler.init(callbacks)) {
   process.exit(1);
 }
 
-// TODO: this needs rewrite due to circular deps
-
 let result = kmnCompiler.runCompiler(infile, outfile, {
   shouldAddCompilerVersion: false,
   saveDebug: true,  // TODO: we should probably use passed debug flag
@@ -37,7 +34,7 @@ if(!result) {
   process.exit(1);
 }
 
-const js = WriteCompiledKeyboard(callbacks, infile, result.kmx.data, result.kvk.data, null, true);
+const js = new TextDecoder().decode(result.js.data);
 
 callbacks.printMessages();
 

--- a/developer/src/kmc-kmn/test/kmw/test-compiler.ts
+++ b/developer/src/kmc-kmn/test/kmw/test-compiler.ts
@@ -1,7 +1,6 @@
 import 'mocha';
 import { assert } from 'chai';
 // import sinonChai from 'sinon-chai';
-import { WriteCompiledKeyboard } from '../../src/kmw-compiler/write-compiled-keyboard.js';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
@@ -37,7 +36,6 @@ describe('Compiler class', function() {
     const kmnCompiler = new KmnCompiler();
     assert.isTrue(await kmnCompiler.init(callbacks));
 
-    // TODO: runToMemory, add option to kmxCompiler to store debug-data for conversion to .js (e.g. store metadata, group readonly metadata, visual keyboard source filename, etc)
     let result = kmnCompiler.runCompiler(infile, outfile, {
       shouldAddCompilerVersion: false,
       saveDebug: true,  // TODO: we should probably use passed debug flag
@@ -45,7 +43,7 @@ describe('Compiler class', function() {
 
     assert.isNotNull(result);
 
-    const js = WriteCompiledKeyboard(callbacks, infile, result.kmx?.data, result.kvk?.data, null, true);
+    const js = new TextDecoder().decode(result.js.data);
 
     const fjs = fs.readFileSync(fixtureName, 'utf8');
 

--- a/developer/src/kmcmplib/include/kmcmplibapi.h
+++ b/developer/src/kmcmplib/include/kmcmplibapi.h
@@ -34,12 +34,17 @@ struct KMCMP_COMPILER_OPTIONS {
 #define COMPILETARGETS_JS      0x02
 #define COMPILETARGETS__MASK   0x03
 
+struct KMCMP_COMPILER_RESULT_EXTRA {
+  int targets; /// COMPILETARGETS__MASK = COMPILETARGETS_KMX | COMPILETARGETS_JS
+  std::string kmnFilename;
+  std::string kvksFilename;
+  std::string displayMapFilename;
+};
+
 struct KMCMP_COMPILER_RESULT {
   void* kmx;
   size_t kmxSize;
-  int targets; /// COMPILETARGETS__MASK = COMPILETARGETS_KMX | COMPILETARGETS_JS
-  std::string kvksFilename;
-  std::string displayMapFilename;
+  struct KMCMP_COMPILER_RESULT_EXTRA extra;
 };
 
 /**

--- a/developer/src/kmcmplib/src/CompileKeyboardBuffer.cpp
+++ b/developer/src/kmcmplib/src/CompileKeyboardBuffer.cpp
@@ -43,8 +43,8 @@ bool CompileKeyboardBuffer(KMX_BYTE* infile, int sz, PFILE_KEYBOARD fk)
   fk->cxVKDictionary = 0;  // I3438
   fk->dpVKDictionary = NULL;  // I3438
   fk->extra->targets = COMPILETARGETS_KMX;
-  fk->extra->kvksFilename = u"";
-  fk->extra->displayMapFilename = u"";
+  fk->extra->kvksFilename = "";
+  fk->extra->displayMapFilename = "";
 /*	fk->szMessage[0] = 0;
   fk->szLanguageName[0] = 0;*/
   fk->dwBitmapSize = 0;

--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -1026,7 +1026,7 @@ KMX_DWORD ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE 
     {
       // Store extra metadata for callers as we mutate this store during
       // compilation
-      fk->extra->kvksFilename = sp->dpString;
+      fk->extra->kvksFilename = string_from_u16string(sp->dpString);
       // Strip path from the store, leaving bare filename only
       p = sp->dpString;
 
@@ -1140,7 +1140,7 @@ KMX_DWORD ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE 
     // This store is allowed in older versions of Keyman, as it is a
     // compile-time only feature. Implemented only in kmc-kmn, not in
     // the legacy compilers.
-    fk->extra->displayMapFilename = sp->dpString;
+    fk->extra->displayMapFilename = string_from_u16string(sp->dpString);
     break;
 
   default:

--- a/developer/src/kmcmplib/src/CompilerInterfaces.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfaces.cpp
@@ -15,7 +15,7 @@ EXTERN bool kmcmp_CompileKeyboard(
 ) {
 
   FILE_KEYBOARD fk;
-  fk.extra = new FILE_KEYBOARD_EXTRA;
+  fk.extra = new KMCMP_COMPILER_RESULT_EXTRA;
   fk.extra->kmnFilename = pszInfile;
 
   kmcmp::FSaveDebug = options.saveDebug;   // I3681
@@ -103,10 +103,7 @@ EXTERN bool kmcmp_CompileKeyboard(
 
   result.kmx = data;
   result.kmxSize = dataSize;
-  // TODO: can we eliminate this intermediate structure?
-  result.targets = fk.extra->targets;
-  result.kvksFilename = string_from_u16string(fk.extra->kvksFilename); // convert to UTF8
-  result.displayMapFilename = string_from_u16string(fk.extra->displayMapFilename); // convert to UTF8
+  result.extra = *fk.extra;
 
   return TRUE;
 }

--- a/developer/src/kmcmplib/src/CompilerInterfacesWasm.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfacesWasm.cpp
@@ -53,24 +53,12 @@ struct WASM_COMPILER_RESULT {
   // Following are pointer offsets in heap + buffer size
   int kmx;
   int kmxSize;
-  // Following are compiler side-channel data, required for
-  // follow-on transform
-  int targets; /* COMPILETARGETS_KMX | COMPILETARGETS_JS */
-  std::string kvksFilename;
-  std::string displayMapFilename;
-  // TODO: additional data to be passed back
+  KMCMP_COMPILER_RESULT_EXTRA extra;
 };
 
 WASM_COMPILER_RESULT kmcmp_wasm_compile(std::string pszInfile, const KMCMP_COMPILER_OPTIONS options, const WASM_COMPILER_INTERFACE intf) {
-  WASM_COMPILER_RESULT r;
+  WASM_COMPILER_RESULT r = {false};
   KMCMP_COMPILER_RESULT kr;
-
-  r.result = false;
-  r.kmx = 0;
-  r.kmxSize = 0;
-  r.targets = 0;
-  r.kvksFilename = "";
-  r.displayMapFilename = "";
 
   r.result = kmcmp_CompileKeyboard(
     pszInfile.c_str(),
@@ -85,9 +73,7 @@ WASM_COMPILER_RESULT kmcmp_wasm_compile(std::string pszInfile, const KMCMP_COMPI
     // TODO: additional data as required by kmc_kmw
     r.kmx = (int) kr.kmx;
     r.kmxSize = (int) kr.kmxSize;
-    r.kvksFilename = kr.kvksFilename;
-    r.displayMapFilename = kr.displayMapFilename;
-    r.targets = kr.targets;
+    r.extra = kr.extra;
   }
 
   return r;
@@ -114,9 +100,15 @@ EMSCRIPTEN_BINDINGS(compiler_interface) {
     .property("result", &WASM_COMPILER_RESULT::result)
     .property("kmx", &WASM_COMPILER_RESULT::kmx)
     .property("kmxSize", &WASM_COMPILER_RESULT::kmxSize)
-    .property("targets", &WASM_COMPILER_RESULT::targets)
-    .property("kvksFilename", &WASM_COMPILER_RESULT::kvksFilename)
-    .property("displayMapFilename", &WASM_COMPILER_RESULT::displayMapFilename)
+    .property("extra", &WASM_COMPILER_RESULT::extra)
+    ;
+
+  emscripten::class_<KMCMP_COMPILER_RESULT_EXTRA>("CompilerResultExtra")
+    .constructor<>()
+    .property("targets", &KMCMP_COMPILER_RESULT_EXTRA::targets)
+    .property("kmnFilename", &KMCMP_COMPILER_RESULT_EXTRA::kmnFilename)
+    .property("kvksFilename", &KMCMP_COMPILER_RESULT_EXTRA::kvksFilename)
+    .property("displayMapFilename", &KMCMP_COMPILER_RESULT_EXTRA::displayMapFilename)
     ;
 
   emscripten::function("kmcmp_compile", &kmcmp_wasm_compile);

--- a/developer/src/kmcmplib/src/compfile.h
+++ b/developer/src/kmcmplib/src/compfile.h
@@ -21,6 +21,7 @@
 #define _COMPFILE_H
 
 #include "kmcompx.h"
+#include "kmcmplibapi.h"
 #include <kmx_file.h>
 #include <string>
 
@@ -119,18 +120,6 @@ struct FILE_VKDICTIONARY {
 };
 typedef FILE_VKDICTIONARY *PFILE_VKDICTIONARY;
 
-/**
- * Extra metadata for API consumers
- */
-struct FILE_KEYBOARD_EXTRA {
-  int targets;
-  std::string kmnFilename; // utf-8
-  std::u16string kvksFilename;	// utf-16, original TSS_VISUALKEYBOARD value
-  std::u16string displayMapFilename;	// utf-16, original TSS_DISPLAY_MAP value
-};
-
-typedef struct FILE_KEYBOARD_EXTRA* PFILE_KEYBOARD_EXTRA;
-
 struct FILE_KEYBOARD {
   KMX_DWORD KeyboardID;			// deprecated, unused
 
@@ -160,7 +149,7 @@ struct FILE_KEYBOARD {
   KMX_DWORD cxVKDictionary;
   PFILE_VKDICTIONARY dpVKDictionary; // temp - virtual key dictionary
 
-  PFILE_KEYBOARD_EXTRA extra;
+  KMCMP_COMPILER_RESULT_EXTRA* extra;   // extra metadata passed back from the compiler
 };
 
 typedef FILE_KEYBOARD *PFILE_KEYBOARD;


### PR DESCRIPTION
Relates to #8955.

Reorganizes the data structures passed out of kmcmplib via WASM to make it easier to work with the extra metadata and reduce the number of places we have to touch when we add extra metadata fields.

Preparation for supporting the metadata that the kmw compiler requires.

@keymanapp-test-bot skip