### PR TITLE
fix(windows): testhost improve error message

### DIFF
--- a/windows/src/engine/testhost/testhost.cpp
+++ b/windows/src/engine/testhost/testhost.cpp
@@ -26,6 +26,7 @@ INT_PTR CALLBACK    About(HWND, UINT, WPARAM, LPARAM);
 void SizeEditWindow();
 void StartKeyman();
 void StopKeyman();
+void Fail(PCWSTR message);
 
   int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                      _In_opt_ HINSTANCE hPrevInstance,
@@ -298,7 +299,9 @@ Fail(PCWSTR message) {
   std::vector<wchar_t> err(bufferLength);
   std::wstring buf;
   DWORD dwError = GetLastError();
-  if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, dwError, 0, err.data(), bufferLength, nullptr) != 0) {
+  if (dwError == ERROR_SUCCESS) {
+    buf = std::wstring(message); // Don't append "The operation completed successfully."
+  } else if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, dwError, 0, err.data(), bufferLength, nullptr) != 0) {
     std::wstring errb(err.data());
     buf = std::wstring(message) + L":" + err.data() + L"[" + std::to_wstring(dwError) + L"]";
   } else {

--- a/windows/src/engine/testhost/testhost.cpp
+++ b/windows/src/engine/testhost/testhost.cpp
@@ -300,7 +300,7 @@ Fail(PCWSTR message) {
   std::wstring buf;
   DWORD dwError = GetLastError();
   if (dwError == ERROR_SUCCESS) {
-    buf = std::wstring(message); // Don't append "The operation completed successfully."
+    buf = std::wstring(message) + L": no error code was returned"; // Don't append "The operation completed successfully."
   } else if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, dwError, 0, err.data(), bufferLength, nullptr) != 0) {
     std::wstring errb(err.data());
     buf = std::wstring(message) + L":" + err.data() + L"[" + std::to_wstring(dwError) + L"]";


### PR DESCRIPTION
if dwError is 0, don't try to format it
avoid "Error starting Keyman: The operation completed successfully.  [0]"

@keymanapp-test-bot skip