### PR TITLE
chore(web): disconnects the gesture-oriented touchpath-subsegmentation engine 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/subsegmentation/README.md
+++ b/common/web/gesture-recognizer/src/engine/headless/subsegmentation/README.md
@@ -1,0 +1,14 @@
+## About this subfolder
+
+This folder contains code for an advanced touchpath sub-segmentation engine that would facilitate more complex gestures,
+such as multi-segment flicks and/or swipe-style input.  The decision was made to "ice" it for now in favor of preventing
+further delays for the release of the feature.
+
+To revisit a state when the system was fully connected, the following two commits may provide a useful reference:
+- https://github.com/keymanapp/keyman/tree/0c7ac4ff3caf612674602fefb7ff71350b13964a
+  - The last feature-gestures commit with full subsegmentation integration
+- https://github.com/keymanapp/keyman/tree/5c48cc5b9b127ab42a8055b7d960dbc4d39e4df7
+  - See #7440 - its description details the basic process for creation of a asynchronous FSM for recognizing & constructing gestures based on subsegments produced by the subsegmentation engine.
+  - The permalinked commit itself holds the code that said process would connect with.
+  - This was never fully committed to feature-gestures; #7440 was directly based upon the "last feature-gestures
+    commit..." mentioned above.

--- a/common/web/gesture-recognizer/src/engine/headless/subsegmentation/constructingSegment.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/subsegmentation/constructingSegment.ts
@@ -1,7 +1,7 @@
 import { SegmentClassifier } from "../segmentClassifier.js";
 import { CumulativePathStats } from "../cumulativePathStats.js";
 import { SegmentationSplit, Subsegmentation } from "./pathSegmenter.js";
-import { SegmentImplementation } from "../segment.js";
+import { SegmentImplementation } from "./segment.js";
 import { SubsegmentCompatibilityAnalyzer } from "./subsegmentCompatibilityAnalyzer.js";
 
 /**

--- a/common/web/gesture-recognizer/src/engine/headless/subsegmentation/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/subsegmentation/pathSegmenter.ts
@@ -1,7 +1,7 @@
 import { ConstructingSegment } from "./constructingSegment.js";
 import { CumulativePathStats, PathCoordAxis, sigMinus } from "../cumulativePathStats.js";
 import { InputSample } from "../inputSample.js";
-import { Segment, SegmentImplementation } from "../segment.js";
+import { Segment, SegmentImplementation } from "./segment.js";
 import { SegmentClass, SegmentClassifier, SegmentClassifierConfig } from "../segmentClassifier.js";
 
 // Mostly used here to compare the sum-squared error components of segmented regressions

--- a/common/web/gesture-recognizer/src/engine/headless/subsegmentation/segment.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/subsegmentation/segment.ts
@@ -1,6 +1,6 @@
-import { CumulativePathStats } from "./cumulativePathStats.js";
-import { InputSample } from "./inputSample.js";
-import { type SegmentClass } from "./segmentClassifier.js";
+import { CumulativePathStats } from "../cumulativePathStats.js";
+import { InputSample } from "../inputSample.js";
+import { type SegmentClass } from "../segmentClassifier.js";
 
 export interface JSONSegment {
   type: SegmentClass,

--- a/common/web/gesture-recognizer/src/engine/headless/trackedPath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/trackedPath.ts
@@ -1,6 +1,5 @@
 import EventEmitter from "eventemitter3";
 import { InputSample } from "./inputSample.js";
-import { Segment } from "./segment.js";
 import { CumulativePathStats } from "./cumulativePathStats.js";
 
 /**
@@ -15,7 +14,6 @@ interface EventMap {
   'step': (sample: InputSample) => void,
   'complete': () => void,
   'invalidated': () => void
-  'segmentation': (segment: Segment) => void
 }
 
 /**

--- a/common/web/gesture-recognizer/src/engine/index.ts
+++ b/common/web/gesture-recognizer/src/engine/index.ts
@@ -10,7 +10,7 @@ export { MouseEventEngine } from "./mouseEventEngine.js";
 export { PathSegmenter, Subsegmentation } from "./headless/subsegmentation/pathSegmenter.js";
 export { PaddedZoneSource } from './configuration/paddedZoneSource.js';
 export { RecognitionZoneSource } from './configuration/recognitionZoneSource.js';
-export { Segment } from "./headless/segment.js";
+export { Segment } from "./headless/subsegmentation/segment.js";
 export { SegmentClassifier } from "./headless/segmentClassifier.js";
 export { TouchEventEngine } from "./touchEventEngine.js";
 export { ViewportZoneSource } from './configuration/viewportZoneSource.js';

--- a/common/web/gesture-recognizer/src/test/auto/headless/recordedSegmentations.js
+++ b/common/web/gesture-recognizer/src/test/auto/headless/recordedSegmentations.js
@@ -19,6 +19,25 @@ const SEGMENT_TEST_JSON_FOLDER = path.resolve(`${scriptFolder}/../../resources/j
 
 import { assertSegmentSimilarity } from '../../resources/assertSegmentSimilarity.js';
 
+/**
+ * Since we're disconnecting subsegmentation stuff for the first gestures release, our
+ * previously-recorded subsegmentations aren't retrievable in the same spot as before.
+ *
+ * This manually retrieves them from the originally-recorded version in order to preserve
+ * the unit tests.  Makes a few assumptions, but they're valid for the original recordings.
+ * @param {*} jsonObj
+ */
+function retrieveSubsegmentations(jsonObj) {
+  return jsonObj.inputs[0].touchpoints[0].path.segments;
+}
+
+// ---------------------------------------
+// NOTE:  this suite of tests is for a disconnected subsystem - subsegmentation - designed
+// to handle more complicated gestures than supported in our initial release.  We had to
+// triage it to prevent further delays.
+//
+// The tests themselves should still be functional.
+// ---------------------------------------
 describe("Segmentation - from recorded sequences", function() {
   beforeEach(function() {
     this.fakeClock = sinon.useFakeTimers();
@@ -85,7 +104,7 @@ describe("Segmentation - from recorded sequences", function() {
     await recognitionTestCapturer.recognizedPromise;
 
     // Any post-sequence tests to run.
-    const originalSegments = testObj.originalSegments;
+    const originalSegments = retrieveSubsegmentations(jsonObj);
     const originalSegmentTypeSequence = originalSegments.map((segment) => segment.type);
 
     const reproedSegments = spy.getCalls().map((call) => call.args[0]);
@@ -151,7 +170,7 @@ describe("Segmentation - from recorded sequences", function() {
     await recognitionTestCapturer.recognizedPromise;
 
     // Any post-sequence tests to run.
-    const originalSegments = testObj.originalSegments;
+    const originalSegments = retrieveSubsegmentations(jsonObj);
     const originalSegmentTypeSequence = originalSegments.map((segment) => segment.type);
 
     const reproedSegments = spy.getCalls().map((call) => call.args[0]);
@@ -187,7 +206,7 @@ describe("Segmentation - from recorded sequences", function() {
     await testObj.compositePromise;
 
     // Any post-sequence tests to run.
-    const originalSegments = testObj.originalSegments;
+    const originalSegments = retrieveSubsegmentations(jsonObj);
     const originalSegmentTypeSequence = originalSegments.map((segment) => segment.type);
 
     const reproedSegments = spy.getCalls().map((call) => call.args[0]);
@@ -227,7 +246,7 @@ describe("Segmentation - from recorded sequences", function() {
     await testObj.compositePromise;
 
     // Any post-sequence tests to run.
-    const originalSegments = testObj.originalSegments;
+    const originalSegments = retrieveSubsegmentations(jsonObj);
     const reproedSegments = spy.getCalls().map((call) => call.args[0]);
 
     // Because of the sweeping arc motion, we won't assume a perfect match to the segmentation here.
@@ -281,7 +300,7 @@ describe("Segmentation - from recorded sequences", function() {
     const nulls = reproedSegments.filter((segment) => segment.type === null);
 
     assert.isEmpty(nulls);
-    assert.isEmpty(holds.filter((hold) => hold.duration > 200)); // all motions were very quick.
+    assert.isEmpty(holds.filter((hold) => hold.duration > 300)); // all motions were very quick.
 
     // True (intended) motions were 'e' -> 's' -> 'w' -> 'n', but the motions weren't that precise
     // due to prioritizing speed.

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessRecordingSimulator.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessRecordingSimulator.ts
@@ -21,6 +21,7 @@ export interface RecordingTestConfig {
   endSequence:  () => void;
 }
 
+// Note:  this class is currently only used by subsegmentation unit tests.
 export class HeadlessRecordingSimulator {
   // Designed to test against PathSegmenter and TrackedPath - just implement the config interface appropriately!
   static prepareTest(recordingObj: RecordedCoordSequenceSet, config: RecordingTestConfig): ProcessedSequenceTest {

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessRecordingSimulator.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessRecordingSimulator.ts
@@ -30,7 +30,9 @@ export class HeadlessRecordingSimulator {
     const sourceTrackedPath = recordingObj.inputs[0].touchpoints[0].path;
 
     testObj.originalSamples = sourceTrackedPath.coords;
-    testObj.originalSegments = sourceTrackedPath.segments;
+    const sampleCount = testObj.originalSamples.length;
+    // still exists on original recorded sequences that exist before we removed segmentation.
+    testObj.originalSegments = sourceTrackedPath['segments'];
     const lastSegment = testObj.originalSegments[testObj.originalSegments.length-1];
 
     // Build promises designed to reproduce the events at the correct times.
@@ -40,9 +42,18 @@ export class HeadlessRecordingSimulator {
       }, sample.t - testObj.originalSamples[0].t);
     });
 
+
+    // Originally we did not record the release-timing of the touch, instead using the timing of
+    // the last sample for the last subsegmentation's last sample.  We've disabled that in order
+    // to get out a release in a more timely manner, but we'll still use it first if it's available.
+    //
+    // If not... we use a more current style.  TODO:  resolve 'release timing' aspect of input
+    // sequence recording + playback.
+    const endTime = lastSegment ? lastSegment.lastCoord.t : sourceTrackedPath.coords[sampleCount-1].t;
+
     testObj.endPromise = timedPromise(() => {
       config.endSequence();
-    }, lastSegment.lastCoord.t - testObj.originalSamples[0].t);
+    }, endTime - testObj.originalSamples[0].t);
 
     // Wrap it all together with a nice little bow.
     testObj.compositePromise = Promise.all([testObj.endPromise].concat(testObj.samplePromises)).catch((reason) => {


### PR DESCRIPTION
Given our decision to focus on the basic gestures for now in order to prevent further delays for the feature, this PR cuts off the subsegmentation components of the engine.

I didn't outright delete the classes, but they're relegated within a clearly-marked, README-documented folder.  There was a bit of touchup to maintain the unit tests, but nothing too bad; the trickiest aspect was in regard to something I'd have had to rediscover at some point anyway, even without subsegmentation - it's the added 'TODO' tidbit.

I'll still need to touchup the design of `TrackedPath` and such; I'm sure the way forward is via cumulative stats of incoming input coordinates.  Just... the details of that will require further work, as it's a shift from the prior model.

@keymanapp-test-bot skip