### PR TITLE
chore(android/app): Address some pre-launch accessibility report warnings

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/layout/text_size_controller.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/text_size_controller.xml
@@ -21,6 +21,7 @@
         android:id="@+id/seekBar"
         android:layout_width="180dp"
         android:layout_height="wrap_content"
+        android:contentDescription="@string/ic_text_size_slider"
         android:layout_gravity="center" />
 
     <ImageButton

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -57,6 +57,9 @@
   <!-- Context: Text Size dialog -->
   <string name="ic_text_size_down" comment="Make text smaller">Text size down</string>
 
+  <!-- Context: Text Size dialog -->
+  <string name="ic_text_size_slider" comment="Adjust text size">Text size slider</string>
+
 
   <!-- Context: Clear Text dialog -->
   <string name="all_text_will_be_cleared" comment="Erase all the text">\nAll text will be cleared\n</string>

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -251,7 +251,7 @@
     <string name="default_locale" comment="Use the device's current locale">Default Locale</string>
 
     <!-- Context: Content descriptions -->
-    <string name="image_button" translatable="false">Image Button</string>
+    <string name="image_button" translatable="false">Image</string>
 
     <!-- Context: Content descriptions -->
     <string name="image_view" translatable="false">Image View</string>


### PR DESCRIPTION
The Play Store [pre-launch accessibility report](https://play.google.com/console/u/0/developers/6504570275588761950/app/4972763830494387739/pre-launch-report/details?artifactId=4859822136528824508&tab=accessibility) flagged some accessibility warnings (involving screen readers):
* Text Size menu - The slider may not have a label readable by screen readers.
* Languages List menu - The string "Button" in the image button content description is redundant because screen readers will also say "Button".

There's still ~34 warnings about increasing the sizes of some touch icons - TODO as low-priority in future

@keymanapp-test-bot skip

