### PR TITLE
chore(windows): disable wix compression for debug builds

### DIFF
--- a/common/windows/delphi/Defines.mak
+++ b/common/windows/delphi/Defines.mak
@@ -187,7 +187,12 @@ WIXLIGHTLINT= -sice:ICE82 -sice:ICE80
 # for debug builds, we turn off compression because it is so hideously slow
 WIXLIGHTCOMPRESSION=-dcl:none
 !ELSE
+!IF "$(VERSION_ENVIRONMENT)" == "test"
+# for test builds, we also turn off compression
+WIXLIGHTCOMPRESSION=-dcl:none
+!ELSE
 WIXLIGHTCOMPRESSION=
+!ENDIF
 !ENDIF
 
 WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo $(WIXLIGHTLINT) $(WIXLIGHTCOMPRESSION)

--- a/common/windows/delphi/Defines.mak
+++ b/common/windows/delphi/Defines.mak
@@ -187,7 +187,7 @@ WIXLIGHTLINT= -sice:ICE82 -sice:ICE80
 # for debug builds, we turn off compression because it is so hideously slow
 WIXLIGHTCOMPRESSION=-dcl:none
 !ELSE
-!IF "$(VERSION_ENVIRONMENT)" == "test"
+!IFDEF TEAMCITY_PR_NUMBER
 # for test builds, we also turn off compression
 WIXLIGHTCOMPRESSION=-dcl:none
 !ELSE

--- a/common/windows/delphi/Defines.mak
+++ b/common/windows/delphi/Defines.mak
@@ -191,7 +191,7 @@ WIXLIGHTCOMPRESSION=-dcl:none
 # for test builds, we also turn off compression
 WIXLIGHTCOMPRESSION=-dcl:none
 !ELSE
-WIXLIGHTCOMPRESSION=
+WIXLIGHTCOMPRESSION=-dcl:high
 !ENDIF
 !ENDIF
 

--- a/common/windows/delphi/Defines.mak
+++ b/common/windows/delphi/Defines.mak
@@ -22,9 +22,13 @@ COMMON_BIN=$(KEYMAN_ROOT)\windows\bin
 # INCLUDE=$(ROOT)\src\global\inc;$(INCLUDE)
 
 !IFDEF DEBUG
+GO_FAST=1
 MAKEFLAG_DEBUG="DEBUG=$(DEBUG)"
 DELPHI_MSBUILD_FLAG_DEBUG="/p:Config=Debug"
 !ELSE
+!IFDEF TEAMCITY_PR_NUMBER
+GO_FAST=1
+!ENDIF
 DELPHI_MSBUILD_FLAG_DEBUG="/p:Config=Release"
 !ENDIF
 
@@ -164,7 +168,11 @@ MSBUILD_CLEAN=/t:Clean /p:Configuration=Release
 COPY=copy
 ISXBUILD=C:\PROGRA~1\INSTALLSHIELD\Express\System\IsExpCmdBld
 WZZIPPATH="C:\program files\7-zip\7z.exe"
-WZZIP=$(WZZIPPATH) a
+!IFDEF GO_FAST
+WZZIP=$(WZZIPPATH) a -mx1
+!ELSE
+WZZIP=$(WZZIPPATH) a -mx9
+!ENDIF
 WZUNZIP=$(WZZIPPATH) e
 
 # we are using cmd /c because tds2dbg is failing on direct execution
@@ -183,16 +191,12 @@ WIXLIGHTLINT=
 WIXLIGHTLINT= -sice:ICE82 -sice:ICE80
 !ENDIF
 
-!IFDEF DEBUG
+!IFDEF GO_FAST
 # for debug builds, we turn off compression because it is so hideously slow
-WIXLIGHTCOMPRESSION=-dcl:none
-!ELSE
-!IFDEF TEAMCITY_PR_NUMBER
 # for test builds, we also turn off compression
 WIXLIGHTCOMPRESSION=-dcl:none
 !ELSE
 WIXLIGHTCOMPRESSION=-dcl:high
-!ENDIF
 !ENDIF
 
 WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo $(WIXLIGHTLINT) $(WIXLIGHTCOMPRESSION)

--- a/common/windows/delphi/Defines.mak
+++ b/common/windows/delphi/Defines.mak
@@ -177,9 +177,21 @@ WIXPATH="c:\program files (x86)\WiX Toolset v3.11\bin"
 WIXCANDLE=$(WIXPATH)\candle.exe -wx -nologo
 
 !IFDEF LINT
-WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo
+WIXLIGHTLINT=
 !ELSE
 # we suppress ICE82 because it reports spurious errors with merge module keymanengine to do with duplicate sequence numbers.  Safely ignored.
+WIXLIGHTLINT= -sice:ICE82 -sice:ICE80
+!ENDIF
+
+!IFDEF DEBUG
+# for debug builds, we turn off compression because it is so hideously slow
+WIXLIGHTCOMPRESSION=-dcl:none
+!ELSE
+WIXLIGHTCOMPRESSION=
+!ENDIF
+
+WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo $(WIXLIGHTLINT) $(WIXLIGHTCOMPRESSION)
+!ELSE
 WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo -sice:ICE82 -sice:ICE80
 !ENDIF
 

--- a/common/windows/delphi/Defines.mak
+++ b/common/windows/delphi/Defines.mak
@@ -191,9 +191,6 @@ WIXLIGHTCOMPRESSION=
 !ENDIF
 
 WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo $(WIXLIGHTLINT) $(WIXLIGHTCOMPRESSION)
-!ELSE
-WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo -sice:ICE82 -sice:ICE80
-!ENDIF
 
 WIXLIT=$(WIXPATH)\lit.exe -wx -nologo
 WIXHEAT=$(WIXPATH)\heat.exe

--- a/developer/src/inst/kmdev.wxs
+++ b/developer/src/inst/kmdev.wxs
@@ -297,7 +297,7 @@
       <ComponentGroupRef Id="Server" />
     </Feature>
 
-    <Media Id="1" EmbedCab="yes" CompressionLevel="high" Cabinet="Data1.cab" VolumeLabel="DISK1" />
+    <Media Id="1" EmbedCab="yes" Cabinet="Data1.cab" VolumeLabel="DISK1" />
 
     <UIRef Id="WixUI_FeatureTree"/>
 

--- a/oem/firstvoices/windows/src/inst/firstvoices.wxs
+++ b/oem/firstvoices/windows/src/inst/firstvoices.wxs
@@ -9,7 +9,7 @@
     <!-- ALLOW Upgrade from 8.0 -->
 <!-- TODO: find 8.0 upgrade id from existing installer; are there any 7.0 installs?
     <Upgrade Id="E756C3BC-A261-427f-91BE-37955544A126">
-      <UpgradeVersion OnlyDetect="no" Minimum="8.0.300.0" IncludeMinimum="yes" 
+      <UpgradeVersion OnlyDetect="no" Minimum="8.0.300.0" IncludeMinimum="yes"
                       Maximum="9.0.0.0" IncludeMaximum="no" MigrateFeatures="yes" Property="OLDERFOUND80" />
     </Upgrade>
 -->
@@ -17,16 +17,16 @@
     <!-- ALLOW Upgrade from 9.0 -->
 <!-- TODO: find 9.0 upgrade id from existing installer
     <Upgrade Id="593EA657-7DF2-4799-B90E-B9E95A8E66D3">
-      <UpgradeVersion OnlyDetect="no" Minimum="9.0.454.0" IncludeMinimum="yes" 
+      <UpgradeVersion OnlyDetect="no" Minimum="9.0.454.0" IncludeMinimum="yes"
                       Maximum="10.0.0.0" IncludeMaximum="no" MigrateFeatures="yes" Property="VERSION9FOUND" />
     </Upgrade>
 -->
-    
+
     <!-- PREVENT or ALLOW Upgrade from 11.0 or later versions -->
     <Upgrade Id="f212edf7-0bef-43bb-8fc2-2625ae7bbfca">
-      <UpgradeVersion OnlyDetect="no" Minimum="11.0.0.0" IncludeMinimum="yes" 
+      <UpgradeVersion OnlyDetect="no" Minimum="11.0.0.0" IncludeMinimum="yes"
                       Maximum="$(var.VERSION)" IncludeMaximum="no" MigrateFeatures="yes" Property="VERSION11FOUND" />
-      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VERSION)" IncludeMinimum="yes" 
+      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VERSION)" IncludeMinimum="yes"
                       Maximum="$(var.VERSION)" IncludeMaximum="yes" Property="CURRENTVERSIONFOUND" />
       <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VERSION)" IncludeMinimum="no" Property="NEWERFOUND" />
     </Upgrade>
@@ -34,13 +34,13 @@
     <Property Id='OLDINSTALLDIR'>
       <RegistrySearch Id='oldinstalldir_search' Key='Software\$(var.OEMNAME)\$(var.PRODUCTNAME)' Root='HKLM' Name='root path' Type='raw' />
     </Property>
-    
+
     <Property Id='OnlineProductID' Value='30' />
-    
+
     <Directory Id="TARGETDIR" Name="SourceDir" DiskId="1">
 
       <Merge Id="keymanengine" Language='1033' SourceFile='$(var.ROOT)\src\engine\inst\keymanengine.msm' />
-      
+
       <Directory Id="ProgramFilesFolder" Name=".">
         <Directory Id="KEYMANROOT" Name="$(var.OEMNAME)">
           <Directory Id="KEYMAN" Name="$(var.PRODUCTNAME)">
@@ -52,20 +52,20 @@
                   <Shortcut Id="startmenuKeyman" Advertise="yes" Directory="ProgramMenuDir" Name="$(var.PRODUCTNAME)" WorkingDirectory='INSTALLDIR' Icon="appicon.ico" IconIndex="0" />
                   <Shortcut Id="startmenuKeymanConfiguration" Advertise="yes" Directory="ProgramMenuDir" Arguments="-c" Name="$(var.PRODUCTNAME) Configuration" WorkingDirectory='INSTALLDIR' Icon="KMSHELL.ico" IconIndex="0" />
                 </File>
-                
+
                 <RemoveFile Id="CachedInstallDirFiles" Property="CachedInstallDir" On="uninstall" Name="*" />
                 <RemoveFolder Id="CachedInstallDir" Property="CachedInstallDir" On="uninstall" />
                 <RemoveFolder Id="CachedInstallDirParent" Property="CachedInstallDirParent" On="uninstall" />
               </Component>
-              
+
               <Component>
                 <File Name="menu.txt" Source="..\branding\menu.txt" KeyPath="yes" />
               </Component>
-              
+
               <Component>
                 <File Name="messages.txt" Source="$(var.ROOT)\src\desktop\branding\messages.txt" KeyPath="yes" />
               </Component>
-              
+
               <Component>
                 <File Name="menutitle.png" Source="..\branding\menutitle.png" KeyPath="yes" />
               </Component>
@@ -73,19 +73,19 @@
               <Component>
                 <File Id="trayicon.ico" Name="trayicon.ico" Source="..\branding\trayicon.ico" KeyPath="yes" />
               </Component>
-                            
+
               <Component>
                 <File Id="KeymanDesktop.chm" Name="KeymanDesktop.chm" KeyPath="yes" />
               </Component>
-              
+
               <Component>
                 <File Id="appicon.ico" Name="appicon.ico" Source="..\branding\appicon.ico" KeyPath="yes" />
               </Component>
-              
+
               <Component>
                 <File Id="cfgicon.ico" Name="cfgicon.ico" Source="..\branding\cfgicon.ico" KeyPath="yes" />
               </Component>
-              
+
               <Component Id="Reg_RootPath" Guid="*">
                 <RegistryValue KeyPath="yes" Root="HKLM" Key="SOFTWARE\$(var.OEMNAME)\$(var.PRODUCTNAME)" Name="root path" Type="string" Value="[INSTALLDIR]" />
                 <RegistryValue Root="HKLM" Key="SOFTWARE\$(var.OEMNAME)\$(var.PRODUCTNAME)" Name="version" Type="string" Value="$(var.VERSION)" />
@@ -98,7 +98,7 @@
                   <RegistryValue KeyPath="yes" Name="oem product path" Type="multiString" Value="[INSTALLDIR]" Action="append" />
                 </RegistryKey>
               </Component>
-              
+
               <Component Id="removeCU" Guid="*">
                 <RegistryValue KeyPath="yes" Root="HKCU" Key="Software\$(var.OEMNAME)\$(var.PRODUCTNAME)" Name="Install" Type="string" Value="1" />
                 <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKCU" Key="Software\$(var.OEMNAME)\$(var.PRODUCTNAME)" />
@@ -111,7 +111,7 @@
           </Directory>
         </Directory>
       </Directory>
-      
+
       <Directory Id="ProgramMenuFolder" Name="Programs">
         <Directory Id="ProgramMenuDir" Name="$(var.OEMNAME)" />
       </Directory>
@@ -130,7 +130,7 @@
       <ComponentRef Id="appicon.ico" />
       <ComponentRef Id="cfgicon.ico" />
       <ComponentRef Id="menutitle.png" />
-      
+
       <ComponentRef Id="Reg_RootPath" />
       <ComponentRef Id="Reg_OemProductPath" />
       <ComponentRef Id="removeCU" />
@@ -138,9 +138,9 @@
 
       <MergeRef Id='keymanengine' />
     </Feature>
-    
+
     <!-- Actions -->
-    
+
     <CustomAction Id="RollbackPostInstallCU" Execute="rollback" Impersonate="yes" ExeCommand='-rcu' BinaryKey='insthelp.exe' />
     <CustomAction Id="RollbackPostInstallLM" Execute="rollback" Impersonate="no" ExeCommand='-rlm' BinaryKey='insthelp.exe' />
     <CustomAction Id="PreUninstallUser" Execute="deferred" Impersonate="yes" ExeCommand='-uu' BinaryKey="insthelp.exe" />
@@ -174,7 +174,7 @@
       <Custom Action='SaveARPInstallLocation' After='InstallValidate'><![CDATA[Not Installed Or REINSTALL]]></Custom>
     </InstallExecuteSequence>
 
-    <Media Id="1" CompressionLevel="high" EmbedCab="yes" Cabinet="Data1.cab" VolumeLabel="DISK1" />
+    <Media Id="1" EmbedCab="yes" Cabinet="Data1.cab" VolumeLabel="DISK1" />
 
     <Property Id="ALLUSERS">1</Property>
 

--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -210,7 +210,7 @@ WIXLIGHTLINT= -sice:ICE82 -sice:ICE80
 # for debug builds, we turn off compression because it is so hideously slow
 WIXLIGHTCOMPRESSION=-dcl:none
 !ELSE
-!IF "$(VERSION_ENVIRONMENT)" == "test"
+!IFDEF TEAMCITY_PR_NUMBER
 # for test builds, we also turn off compression
 WIXLIGHTCOMPRESSION=-dcl:none
 !ELSE

--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -210,7 +210,12 @@ WIXLIGHTLINT= -sice:ICE82 -sice:ICE80
 # for debug builds, we turn off compression because it is so hideously slow
 WIXLIGHTCOMPRESSION=-dcl:none
 !ELSE
+!IF "$(VERSION_ENVIRONMENT)" == "test"
+# for test builds, we also turn off compression
+WIXLIGHTCOMPRESSION=-dcl:none
+!ELSE
 WIXLIGHTCOMPRESSION=
+!ENDIF
 !ENDIF
 
 WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo $(WIXLIGHTLINT) $(WIXLIGHTCOMPRESSION)

--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -214,7 +214,7 @@ WIXLIGHTCOMPRESSION=-dcl:none
 # for test builds, we also turn off compression
 WIXLIGHTCOMPRESSION=-dcl:none
 !ELSE
-WIXLIGHTCOMPRESSION=
+WIXLIGHTCOMPRESSION=-dcl:high
 !ENDIF
 !ENDIF
 

--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -32,11 +32,16 @@ INSTALLPATH_KEYMANDEVELOPER=%ProgramFiles(X86)%\Keyman\Keyman Developer
 INSTALLPATH_KEYMANENGINE=%CommonProgramFiles(X86)%\Keyman\Keyman Engine
 
 !IFDEF DEBUG
+GO_FAST=1
 MAKEFLAG_DEBUG="DEBUG=$(DEBUG)"
 DELPHI_MSBUILD_FLAG_DEBUG="/p:Config=Debug"
 !ELSE
+!IFDEF TEAMCITY_PR_NUMBER
+GO_FAST=1
+!ENDIF
 DELPHI_MSBUILD_FLAG_DEBUG="/p:Config=Release"
 !ENDIF
+
 
 !IFDEF USERDEFINES
 MAKEFLAG_USERDEFINES="USERDEFINES=$(USERDEFINES)"
@@ -184,7 +189,12 @@ MSBUILD_CLEAN=/t:Clean /p:Configuration=Release
 COPY=copy
 ISXBUILD=C:\PROGRA~1\INSTALLSHIELD\Express\System\IsExpCmdBld
 WZZIPPATH="C:\program files\7-zip\7z.exe"
-WZZIP=$(WZZIPPATH) a
+
+!IFDEF GO_FAST
+WZZIP=$(WZZIPPATH) a -mx1
+!ELSE
+WZZIP=$(WZZIPPATH) a -mx9
+!ENDIF
 WZUNZIP=$(WZZIPPATH) e
 
 # TDSPACK=error! $(ROOT)\src\buildtools\tdspack\tdspack -e
@@ -206,16 +216,12 @@ WIXLIGHTLINT=
 WIXLIGHTLINT= -sice:ICE82 -sice:ICE80
 !ENDIF
 
-!IFDEF DEBUG
+!IFDEF GO_FAST
 # for debug builds, we turn off compression because it is so hideously slow
-WIXLIGHTCOMPRESSION=-dcl:none
-!ELSE
-!IFDEF TEAMCITY_PR_NUMBER
 # for test builds, we also turn off compression
 WIXLIGHTCOMPRESSION=-dcl:none
 !ELSE
 WIXLIGHTCOMPRESSION=-dcl:high
-!ENDIF
 !ENDIF
 
 WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo $(WIXLIGHTLINT) $(WIXLIGHTCOMPRESSION)

--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -214,10 +214,6 @@ WIXLIGHTCOMPRESSION=
 !ENDIF
 
 WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo $(WIXLIGHTLINT) $(WIXLIGHTCOMPRESSION)
-!ELSE
-WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo -sice:ICE82 -sice:ICE80
-!ENDIF
-
 WIXLIT=$(WIXPATH)\lit.exe -wx -nologo
 WIXHEAT=$(WIXPATH)\heat.exe
 

--- a/windows/src/Defines.mak
+++ b/windows/src/Defines.mak
@@ -200,9 +200,21 @@ WIXPATH="c:\program files (x86)\WiX Toolset v3.11\bin"
 WIXCANDLE=$(WIXPATH)\candle.exe -wx -nologo
 
 !IFDEF LINT
-WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo
+WIXLIGHTLINT=
 !ELSE
 # we suppress ICE82 because it reports spurious errors with merge module keymanengine to do with duplicate sequence numbers.  Safely ignored.
+WIXLIGHTLINT= -sice:ICE82 -sice:ICE80
+!ENDIF
+
+!IFDEF DEBUG
+# for debug builds, we turn off compression because it is so hideously slow
+WIXLIGHTCOMPRESSION=-dcl:none
+!ELSE
+WIXLIGHTCOMPRESSION=
+!ENDIF
+
+WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo $(WIXLIGHTLINT) $(WIXLIGHTCOMPRESSION)
+!ELSE
 WIXLIGHT=$(WIXPATH)\light.exe -wx -nologo -sice:ICE82 -sice:ICE80
 !ENDIF
 

--- a/windows/src/desktop/inst/keymandesktop.wxs
+++ b/windows/src/desktop/inst/keymandesktop.wxs
@@ -298,7 +298,7 @@
       <Custom Action='SaveARPInstallLocation' After='InstallValidate'><![CDATA[Not Installed Or REINSTALL]]></Custom>
     </InstallExecuteSequence>
 
-    <Media Id="1" CompressionLevel="high" EmbedCab="yes" Cabinet="Data1.cab" VolumeLabel="DISK1" />
+    <Media Id="1" EmbedCab="yes" Cabinet="Data1.cab" VolumeLabel="DISK1" />
 
     <Property Id="ALLUSERS">1</Property>
 


### PR DESCRIPTION
Disables compression for .msi build and .exe installer for debug and PR test builds for Windows and Developer.

Single-test comparison of build times and resulting total file sizes for Developer and Windows on the agents:

 Build | Before | After
-------|--------|-------
Windows time | 13-18 minutes | 10 minutes
Windows size | 240mb | 485mb
Developer time | 28-35 minutes | 21 minutes
Developer size | 304mb | 597mb

@keymanapp-test-bot skip