### PR TITLE
fix(developer): support readonly groups in kmc-kmn/kmw-compiler 🗜

### DIFF
--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -33,6 +33,11 @@ export interface CompilerResultExtraStore {
   name: string;      // when debug=false, the .kmx will not have store names
 };
 
+export interface CompilerResultExtraGroup {
+  isReadOnly: boolean;
+  name: string;
+};
+
 export const COMPILETARGETS_KMX =   0x01;
 export const COMPILETARGETS_JS =    0x02;
 export const COMPILETARGETS__MASK = 0x03;
@@ -47,7 +52,8 @@ export interface CompilerResultExtra {
   targets: number;
   kvksFilename?: string;
   displayMapFilename?: string;
-  stores?: CompilerResultExtraStore[];
+  stores: CompilerResultExtraStore[];
+  groups: CompilerResultExtraGroup[];
 };
 
 //
@@ -191,12 +197,16 @@ export class KmnCompiler implements UnicodeSetParser {
         targets: wasm_result.extra.targets,
         displayMapFilename: wasm_result.extra.displayMapFilename,
         kvksFilename: wasm_result.extra.kvksFilename,
-        stores: []
+        stores: [],
+        groups: [],
       },
       displayMap: null
     };
     for(let store of wasm_result.extra.stores) {
       result.extra.stores.push({storeType: store.storeType, name: store.name});
+    }
+    for(let group of wasm_result.extra.groups) {
+      result.extra.groups.push({isReadOnly: group.isReadOnly, name: group.name});
     }
 
     return result;

--- a/developer/src/kmc-kmn/src/kmw-compiler/compiler-globals.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/compiler-globals.ts
@@ -1,8 +1,10 @@
 import { KMX, CompilerCallbacks, CompilerOptions } from "@keymanapp/common-types";
+import { CompilerResult } from "../compiler/compiler.js";
 
 export let FTabStop: string;
 export let nl: string;
 export let FCompilerWarningsAsErrors = false;
+export let kmxResult: CompilerResult;
 export let fk: KMX.KEYBOARD;
 export let FMnemonic: boolean;
 export let options: CompilerOptions;
@@ -12,11 +14,20 @@ export let FUnreachableKeys: KMX.KEY[];
 export let FCallFunctions: string[];
 export let FFix183_LadderLength: number;
 
-export function setupGlobals(_callbacks: CompilerCallbacks, _options: CompilerOptions, _tab: string, _nl: string, _keyboard: KMX.KEYBOARD, _kmnfile: string) {
+export function setupGlobals(
+  _callbacks: CompilerCallbacks,
+  _options: CompilerOptions,
+  _tab: string,
+  _nl: string,
+  _kmxResult: CompilerResult,
+  _keyboard: KMX.KEYBOARD,
+  _kmnfile: string
+) {
   callbacks = _callbacks;
   options = _options;
   FTabStop = _tab;
   nl = _nl;
+  kmxResult = _kmxResult;
   fk = _keyboard;
   kmnfile = _kmnfile;
   FUnreachableKeys = [];

--- a/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
@@ -1,7 +1,7 @@
 import { TSentinelRecord, GetSuppChar, ExpandSentinel, incxstr, xstrlen, xstrlen_printing } from "./util.js";
 import { KMX } from "@keymanapp/common-types";
 
-import { callbacks, FCallFunctions, FFix183_LadderLength, FMnemonic, FTabStop, FUnreachableKeys, IsKeyboardVersion10OrLater, IsKeyboardVersion14OrLater, nl, options } from "./compiler-globals.js";
+import { callbacks, FCallFunctions, FFix183_LadderLength, FMnemonic, FTabStop, FUnreachableKeys, IsKeyboardVersion10OrLater, IsKeyboardVersion14OrLater, kmxResult, nl, options } from "./compiler-globals.js";
 import { KmwCompilerMessages } from "./messages.js";
 import { FormatModifierAsBitflags, RuleIsExcludedByPlatform } from "./write-compiled-keyboard.js";
 import { KMXCodeNames, SValidIdentifierCharSet, UnreachableKeyCodes, USEnglishShift, USEnglishUnshift, USEnglishValues } from "./constants.js";
@@ -620,8 +620,8 @@ begin*/
 }
 
 function isGroupReadOnly(fk: KMX.KEYBOARD, fgp: KMX.GROUP) {
-  // TODO: export group + store metadata in debug store, use that
-  return false;
+  const index = fk.groups.indexOf(fgp);
+  return kmxResult.extra.groups[index].isReadOnly;
 }
 
 function CallFunctionName(s: string): string {

--- a/developer/src/kmc-kmn/src/kmw-compiler/write-compiled-keyboard.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/write-compiled-keyboard.ts
@@ -49,7 +49,7 @@ export function WriteCompiledKeyboard(
   const reader = new KmxFileReader();
   const keyboard: KMX.KEYBOARD = reader.read(keyboardData);
 
-  setupGlobals(callbacks, opts, FDebug?'  ':'', FDebug?'\r\n':'', keyboard, kmnfile);
+  setupGlobals(callbacks, opts, FDebug?'  ':'', FDebug?'\r\n':'', kmxResult, keyboard, kmnfile);
 
   // let fgp: GROUP;
 
@@ -376,7 +376,10 @@ export function WriteCompiledKeyboard(
       else {
         result +=
           `${FTabStop+FTabStop}if(!m) {${nl}`+
-          `${FTabStop+FTabStop+FTabStop}${JavaScript_OutputString(keyboard, FTabStop + FTabStop + FTabStop, null, fgp.dpNoMatch, fgp)}${nl}`+
+          `${FTabStop+FTabStop}${JavaScript_OutputString(keyboard, FTabStop + FTabStop + FTabStop, null, fgp.dpNoMatch, fgp)}${nl}`+
+          // TODO: add FTabStop to line above, once we have 100% identical match
+          //       to legacy compiler, but because legacy compiler missed this
+          //       tabstop we'll leave it out here for now
           `${FTabStop+FTabStop}}${nl}`;
       }
     }

--- a/developer/src/kmc-kmn/test/fixtures/kmw/.gitignore
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/.gitignore
@@ -1,7 +1,4 @@
 # Files generated during unit tests that do not need to be committed but are
 # kept around for comparison if needed
-khmer_angkor.js.strip.js
-khmer_angkor.kmx
-khmer_angkor.kvk
-khmer_angkor.test.js
-khmer_angkor.test.js.strip.js
+*.test.js
+*.strip.js

--- a/developer/src/kmc-kmn/test/fixtures/kmw/test_readonly_groups.js
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/test_readonly_groups.js
@@ -1,0 +1,825 @@
+if(typeof keyman === 'undefined') {
+  console.log('Keyboard requires KeymanWeb 10.0 or later');
+  if(typeof tavultesoft !== 'undefined') tavultesoft.keymanweb.util.alert("This keyboard requires KeymanWeb 10.0 or later");
+} else {
+KeymanWeb.KR(new Keyboard_test_readonly_groups());
+}
+function Keyboard_test_readonly_groups()
+{
+  var modCodes = keyman.osk.modifierCodes;
+  var keyCodes = keyman.osk.keyCodes;
+
+  this._v=(typeof keyman!="undefined"&&typeof keyman.version=="string")?parseInt(keyman.version,10):9;
+  this.KI="Keyboard_test_readonly_groups";
+  this.KN="test_readonly_groups";
+  this.KMINVER="10.0";
+  this.KV=null;
+  this.KDU=0;
+  this.KH='';
+  this.KM=0;
+  this.KBVER="1.0";
+  this.KMBM=modCodes.SHIFT | modCodes.CAPS | modCodes.NO_CAPS /* 0x0310 */;
+  this.s_key_6=['','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','','',''];
+  this.s_out_7="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  this.s_caps_8="ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  this.s_digit_9="0123456789";
+  this.s_sentencePunctuation_13=".?!";
+  this.s19="";
+  this.s20="numeric";
+  this.s21="caps";
+  this.s22="";
+  this.s23="shift";
+  this.s24="shift";
+  this.s25="shift";
+  this.s26="default";
+  this.KVS=[];
+  this.gs=function(t,e) {
+    return this.g_main_3(t,e);
+  };
+  this.gn=function(t,e) {
+    return this.g_NewContext_0(t,e);
+  };
+  this.gpk=function(t,e) {
+    return this.g_PostKeystroke_1(t,e);
+  };
+  this.gs=function(t,e) {
+    return this.g_main_3(t,e);
+  };
+  this.g_NewContext_0=function(t,e) {
+    var k=KeymanWeb,r=1,m=0;
+    if(!m) {
+    
+      r=this.g_detectStartOfSentence_2(t,e);
+      m=2;
+    }
+    return r;
+  };
+  this.g_PostKeystroke_1=function(t,e) {
+    var k=KeymanWeb,r=1,m=0;
+      if(k.KFCM(1,t,[{t:'a',a:this.s_digit_9}])&&k.KIFS(42,this.s19,t)&&k.KIFS(33,this.s20,t)){
+        m=1;   // Line 35
+      }
+      else if(k.KIFS(33,this.s21,t)){
+        m=1;   // Line 38
+      }
+      else if(k.KIFS(42,this.s22,t)){
+        m=1;   // Line 42
+        r=this.g_detectStartOfSentence_2(t,e);
+        m=2;
+      }
+    return r;
+  };
+  this.g_detectStartOfSentence_2=function(t,e) {
+    var k=KeymanWeb,r=1,m=0;
+      if(k.KFCM(3,t,[{t:'a',a:this.s_sentencePunctuation_13},' ',' '])){
+        m=1;   // Line 58
+        k.KSETS(33,this.s25,t);
+      }
+      else if(k.KFCM(2,t,[{t:'a',a:this.s_sentencePunctuation_13},' '])){
+        m=1;   // Line 57
+        k.KSETS(33,this.s24,t);
+      }
+      else if(k.KFCM(1,t,[{t:'n'}])){
+        m=1;   // Line 53
+        k.KSETS(33,this.s23,t);
+      }
+    if(!m) {
+    
+      k.KSETS(33,this.s26,t);
+    }
+    return r;
+  };
+  this.g_main_3=function(t,e) {
+    var k=KeymanWeb,r=0,m=0;
+    if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_A /* 0x41 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"A");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_A /* 0x41 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"A");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_B /* 0x42 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"B");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_B /* 0x42 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"B");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_C /* 0x43 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"C");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_C /* 0x43 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"C");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_D /* 0x44 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"D");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_D /* 0x44 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"D");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_E /* 0x45 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"E");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_E /* 0x45 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"E");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_F /* 0x46 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"F");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_F /* 0x46 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"F");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_G /* 0x47 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"G");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_G /* 0x47 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"G");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_H /* 0x48 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"H");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_H /* 0x48 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"H");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_I /* 0x49 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"I");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_I /* 0x49 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"I");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_J /* 0x4A */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"J");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_J /* 0x4A */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"J");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_K /* 0x4B */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"K");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_K /* 0x4B */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"K");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_L /* 0x4C */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"L");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_L /* 0x4C */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"L");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_M /* 0x4D */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"M");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_M /* 0x4D */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"M");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_N /* 0x4E */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"N");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_N /* 0x4E */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"N");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_O /* 0x4F */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"O");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_O /* 0x4F */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"O");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_P /* 0x50 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"P");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_P /* 0x50 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"P");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_Q /* 0x51 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"Q");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_Q /* 0x51 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"Q");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_R /* 0x52 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"R");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_R /* 0x52 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"R");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_S /* 0x53 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"S");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_S /* 0x53 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"S");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_T /* 0x54 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"T");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_T /* 0x54 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"T");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_U /* 0x55 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"U");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_U /* 0x55 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"U");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_V /* 0x56 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"V");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_V /* 0x56 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"V");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_W /* 0x57 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"W");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_W /* 0x57 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"W");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_X /* 0x58 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"X");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_X /* 0x58 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"X");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_Y /* 0x59 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"Y");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_Y /* 0x59 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"Y");
+      }
+    }
+    else if(k.KKM(e, modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4100 */, keyCodes.K_Z /* 0x5A */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"Z");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4210 */, keyCodes.K_Z /* 0x5A */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"Z");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_A /* 0x41 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"a");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_A /* 0x41 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"a");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_B /* 0x42 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"b");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_B /* 0x42 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"b");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_C /* 0x43 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"c");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_C /* 0x43 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"c");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_D /* 0x44 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"d");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_D /* 0x44 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"d");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_E /* 0x45 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"e");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_E /* 0x45 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"e");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_F /* 0x46 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"f");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_F /* 0x46 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"f");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_G /* 0x47 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"g");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_G /* 0x47 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"g");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_H /* 0x48 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"h");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_H /* 0x48 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"h");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_I /* 0x49 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"i");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_I /* 0x49 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"i");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_J /* 0x4A */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"j");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_J /* 0x4A */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"j");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_K /* 0x4B */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"k");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_K /* 0x4B */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"k");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_L /* 0x4C */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"l");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_L /* 0x4C */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"l");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_M /* 0x4D */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"m");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_M /* 0x4D */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"m");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_N /* 0x4E */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"n");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_N /* 0x4E */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"n");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_O /* 0x4F */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"o");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_O /* 0x4F */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"o");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_P /* 0x50 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"p");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_P /* 0x50 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"p");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_Q /* 0x51 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"q");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_Q /* 0x51 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"q");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_R /* 0x52 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"r");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_R /* 0x52 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"r");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_S /* 0x53 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"s");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_S /* 0x53 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"s");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_T /* 0x54 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"t");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_T /* 0x54 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"t");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_U /* 0x55 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"u");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_U /* 0x55 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"u");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_V /* 0x56 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"v");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_V /* 0x56 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"v");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_W /* 0x57 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"w");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_W /* 0x57 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"w");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_X /* 0x58 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"x");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_X /* 0x58 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"x");
+      }
+    }
+      if(m) {}
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_Y /* 0x59 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"y");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_Y /* 0x59 */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"y");
+      }
+    }
+    else if(k.KKM(e, modCodes.SHIFT | modCodes.CAPS | modCodes.VIRTUAL_KEY /* 0x4110 */, keyCodes.K_Z /* 0x5A */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"z");
+      }
+    }
+    else if(k.KKM(e, modCodes.NO_CAPS | modCodes.VIRTUAL_KEY /* 0x4200 */, keyCodes.K_Z /* 0x5A */)) {
+      if(1){
+        r=m=1;   // Line 67
+        k.KDC(0,t);
+        k.KO(-1,t,"z");
+      }
+    }
+    return r;
+  };
+}

--- a/developer/src/kmc-kmn/test/fixtures/kmw/test_readonly_groups.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/test_readonly_groups.kmn
@@ -1,0 +1,68 @@
+c Tests that readonly groups are correctly compiled
+c Uses https://help.keyman.com/developer/language/guide/casing-support
+
+c Sample English keyboard with start-of-sentence detection
+store(&VERSION) '10.0'
+store(&NAME) 'test_readonly_groups'
+store(&TARGETS) 'any'
+
+c Note three entry points, rather than the traditional single entry point
+
+begin Unicode > use(main)
+begin NewContext > use(NewContext)
+begin PostKeystroke > use(PostKeystroke)
+
+c This tells Keyman which keys should have casing behavior applied
+store(&CasedKeys) [K_A] .. [K_Z]
+
+c We'll define some useful stores here
+store(key) [K_A] .. [K_Z] [SHIFT K_A] .. [SHIFT K_Z]
+store(out) 'a' .. 'z'     'A' .. 'Z'
+
+store(caps) 'A'..'Z'
+store(digit) '0'..'9'
+
+group(NewContext) readonly
+    c Any time we get a new context, by mouse click, tap,
+    c cursor movement, new document, etc, we'll try and
+    c determine the best layer to use
+    nomatch > use(detectStartOfSentence)
+
+group(PostKeystroke) readonly
+    c We get here after every keystroke and model action is processed
+
+    c Okay, let's stay on the numeric layer if we are there already
+    if(&newLayer = "") if(&layer = 'numeric') any(digit) > context
+
+    c Don't swap off the caps lock layer automatically
+    if(&layer = 'caps') > context
+
+    c no other changes, so detect sentence or layer change, as long
+    c as the user hasn't attempted to change layer themselves.
+    if(&newLayer = "") > use(detectStartOfSentence)
+
+group(detectStartOfSentence) readonly
+    c We have a shared group for the start of sentence detection now
+    c which will set the current layer according to the current context.
+
+    c Some common end-of-sentence punctuation
+    store(sentencePunctuation) '.?!'
+
+    c If we are at the start of a text field, we're at the 'start of a
+    c sentence', so we'll move to the Shift layer
+    nul > layer('shift')
+
+    c Otherwise, we'll move to the Shift layer only if we see end of a
+    c sentence followed by one or two spaces.
+    any(sentencePunctuation) ' ' > layer('shift')
+    any(sentencePunctuation) '  ' > layer('shift')
+
+    c And because we haven't see any of these situations above, we'll
+    c move to the default layer. Note that this effectively drops us
+    c back to the default layer after every keystroke that isn't blocked
+    c by the `PostKeystroke` or early `detectStartOfSentence` rules.
+    nomatch > layer('default')
+
+group(main) using keys
+    + any(key) > index(out, 1)
+

--- a/developer/src/kmc-kmn/test/kmw/test-kmw-compiler.ts
+++ b/developer/src/kmc-kmn/test/kmw/test-kmw-compiler.ts
@@ -57,6 +57,10 @@ describe('KeymanWeb Compiler', function() {
     //
     run_test_keyboard(kmnCompiler, 'test_keychars');
   });
+
+  it('should handle readonly groups', async function() {
+    run_test_keyboard(kmnCompiler, 'test_readonly_groups');
+  });
 });
 
 
@@ -78,15 +82,16 @@ function run_test_keyboard(kmnCompiler: KmnCompiler, id: string): { result: Comp
   };
   value.actual = parseWebTestResult(value.actualCode);
   value.expected = parseWebTestResult(value.expectedCode);
-  assert.deepEqual(value.actual.js, value.expected.js);
-  assert.deepEqual(JSON.parse(value.actual.touchLayout), JSON.parse(value.expected.touchLayout));
 
   if(debug) {
     // This is mostly to allow us to verify that parseWebTestResult is doing what we want
-    fs.writeFileSync(filenames.binary + '.strip.js', value.actual.js);
-    fs.writeFileSync(filenames.fixture + '.strip.js', value.expected.js);
+    // fs.writeFileSync(filenames.binary + '.strip.js', value.actual.js);
+    // fs.writeFileSync(filenames.fixture + '.strip.js', value.expected.js);
     fs.writeFileSync(filenames.binary, value.actualCode);
   }
+
+  assert.deepEqual(value.actual.js, value.expected.js);
+  assert.deepEqual(JSON.parse(value.actual.touchLayout), JSON.parse(value.expected.touchLayout));
 
   return value;
 }

--- a/developer/src/kmcmplib/include/kmcmplibapi.h
+++ b/developer/src/kmcmplib/include/kmcmplibapi.h
@@ -47,6 +47,11 @@ struct KMCMP_COMPILER_RESULT_EXTRA_STORE {
   std::string name; // when debug=false, the .kmx will not have store names
 };
 
+struct KMCMP_COMPILER_RESULT_EXTRA_GROUP {
+  bool isReadOnly;
+  std::string name;
+};
+
 #define COMPILETARGETS_KMX     0x01
 #define COMPILETARGETS_JS      0x02
 #define COMPILETARGETS__MASK   0x03
@@ -57,6 +62,7 @@ struct KMCMP_COMPILER_RESULT_EXTRA {
   std::string kvksFilename;
   std::string displayMapFilename;
   std::vector<KMCMP_COMPILER_RESULT_EXTRA_STORE> stores;
+  std::vector<KMCMP_COMPILER_RESULT_EXTRA_GROUP> groups;
 };
 
 struct KMCMP_COMPILER_RESULT {

--- a/developer/src/kmcmplib/src/CompileKeyboardBuffer.cpp
+++ b/developer/src/kmcmplib/src/CompileKeyboardBuffer.cpp
@@ -50,6 +50,7 @@ bool CompileKeyboardBuffer(KMX_BYTE* infile, int sz, PFILE_KEYBOARD fk)
   fk->extra->kvksFilename = "";
   fk->extra->displayMapFilename = "";
   fk->extra->stores.clear();
+  fk->extra->groups.clear();
 /*	fk->szMessage[0] = 0;
   fk->szLanguageName[0] = 0;*/
   fk->dwBitmapSize = 0;
@@ -183,6 +184,14 @@ namespace kmcmp {
         (store->fIsCall ? STORETYPE_CALL : 0);
       extraStore.name = string_from_u16string(store->szName);
       fk->extra->stores.push_back(extraStore);
+    }
+
+    PFILE_GROUP group = fk->dpGroupArray;
+    for(int i = 0; i < fk->cxGroupArray; i++, group++) {
+      KMCMP_COMPILER_RESULT_EXTRA_GROUP extraGroup;
+      extraGroup.isReadOnly = group->fReadOnly;
+      extraGroup.name = string_from_u16string(group->szName);
+      fk->extra->groups.push_back(extraGroup);
     }
   }
 }

--- a/developer/src/kmcmplib/src/CompilerInterfacesWasm.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfacesWasm.cpp
@@ -142,11 +142,17 @@ EMSCRIPTEN_BINDINGS(compiler_interface) {
     .property("kvksFilename", &KMCMP_COMPILER_RESULT_EXTRA::kvksFilename)
     .property("displayMapFilename", &KMCMP_COMPILER_RESULT_EXTRA::displayMapFilename)
     .property("stores", &KMCMP_COMPILER_RESULT_EXTRA::stores)
+    .property("groups", &KMCMP_COMPILER_RESULT_EXTRA::groups)
     ;
 
   emscripten::value_object<KMCMP_COMPILER_RESULT_EXTRA_STORE>("CompilerResultExtraStore")
     .field("storeType", &KMCMP_COMPILER_RESULT_EXTRA_STORE::storeType)
     .field("name", &KMCMP_COMPILER_RESULT_EXTRA_STORE::name)
+    ;
+
+  emscripten::value_object<KMCMP_COMPILER_RESULT_EXTRA_GROUP>("CompilerResultExtraGroup")
+    .field("isReadOnly", &KMCMP_COMPILER_RESULT_EXTRA_GROUP::isReadOnly)
+    .field("name", &KMCMP_COMPILER_RESULT_EXTRA_GROUP::name)
     ;
 
   emscripten::function("kmcmp_compile", &kmcmp_wasm_compile);


### PR DESCRIPTION
Adds support for readonly groups and corresponding unit test. Again required more metadata from kmcmplib; this metadata is now fairly straightforward to patch in without side-effects, which is encouraging.

@keymanapp-test-bot skip