### PR TITLE
fix(web): fixes Web build zip artifact construction

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -34,6 +34,7 @@ builder_describe "Builds engine modules for Keyman Engine for Web (KMW)." \
   ":engine/package-cache     Subset used to collate keyboards and request them from the cloud" \
   ":engine/paths             Subset used to configure KMW" \
   ":samples                  Builds all needed resources for the KMW sample-page set" \
+  ":tools                    Builds engine-related development resources" \
   ":test-pages=src/test/manual   Builds resources needed for the KMW manual testing pages" \
   "--ci+                     Set to utilize CI-based test configurations & reporting."
 
@@ -97,6 +98,8 @@ builder_run_child_actions build:app/ui
 builder_run_child_actions build:samples
 
 builder_run_child_actions build:test-pages
+
+builder_run_child_actions build:tools
 
 builder_run_child_actions test
 

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -138,7 +138,7 @@ fi
 # Note:  for now, this command is used to prepare the artifacts used by the download site, but
 #        NOT to actually UPLOAD them via rsync or to produce related .download_info files.
 if builder_start_action prepare:downloads.keyman.com; then
-  UPLOAD_PATH="build/upload/$VERSION"
+  UPLOAD_PATH="$KEYMAN_ROOT/web/build/upload/$VERSION"
 
   # --- First action artifact - the KMW zip file ---
   ZIP="$UPLOAD_PATH/keymanweb-$VERSION.zip"
@@ -168,7 +168,7 @@ if builder_start_action prepare:downloads.keyman.com; then
 
   pushd build/publish
   # Zip both the 'debug' and 'release' configurations together.
-  "${COMPRESS_CMD}" $COMPRESS_ADD ../../../../$ZIP *
+  "${COMPRESS_CMD}" $COMPRESS_ADD $ZIP *
   popd
 
   # --- Second action artifact - the 'static' folder (hosted user testing on downloads.keyman.com) ---

--- a/web/src/test/manual/build.sh
+++ b/web/src/test/manual/build.sh
@@ -15,6 +15,7 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_describe "Builds the Keyman Engine for Web's sample page setups." \
   "@/common/web/sentry-manager build" \
+  "@/web/src/tools/testing/recorder build" \
   "configure           Does nothing for this project" \
   "clean" \
   "build" \

--- a/web/src/test/manual/build.sh
+++ b/web/src/test/manual/build.sh
@@ -15,7 +15,7 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_describe "Builds the Keyman Engine for Web's sample page setups." \
   "@/common/web/sentry-manager build" \
-  "@/web/src/tools/testing/recorder build" \
+  "@/web/src/tools build" \
   "configure           Does nothing for this project" \
   "clean" \
   "build" \

--- a/web/src/test/manual/build.sh
+++ b/web/src/test/manual/build.sh
@@ -15,6 +15,8 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_describe "Builds the Keyman Engine for Web's sample page setups." \
   "@/common/web/sentry-manager build" \
+  "@/web/src/app/browser build" \
+  "@/web/src/app/ui build" \
   "@/web/src/tools build" \
   "configure           Does nothing for this project" \
   "clean" \

--- a/web/src/tools/build.sh
+++ b/web/src/tools/build.sh
@@ -20,11 +20,14 @@ cd "$THIS_SCRIPT_PATH"
 builder_describe "Builds the Keyman Engine for Web's development & unit-testing tools" \
   "@/common/web/keyman-version" \
   "@/common/web/keyboard-processor" \
+  "configure" \
   "clean" \
   "build" \
-  ":bulk_rendering     Builds the bulk-rendering tool used to validate changes to OSK display code" \
-  ":recorder           Builds the KMW recorder tool used for development of unit-test resources" \
-  ":sourcemap-root     Builds the sourcemap-cleaning tool used during minification of app/ builds"
+  "test" \
+  "--ci         Does nothing for this script" \
+  ":bulk_rendering=testing/bulk_rendering   Builds the bulk-rendering tool used to validate changes to OSK display code" \
+  ":recorder=testing/recorder               Builds the KMW recorder tool used for development of unit-test resources" \
+  ":sourcemap-root=building/sourcemap-root  Builds the sourcemap-cleaning tool used during minification of app/ builds"
 
 builder_parse "$@"
 


### PR DESCRIPTION
The [nightly build](https://build.palaso.org/buildConfiguration/Keymanweb_Build/391731?buildTab=log&focusLine=2582&linesState=2558&logView=flowAware) after merging #8560 fell over:

```
01:10:20 
  Creating archive: ../../../../build/upload/17.0.130/keymanweb-17.0.130.zip
01:10:20 

01:10:20 
  Items to compress: 74
01:10:20 
  
01:10:20 

01:10:20 
  Files read from disk: 58
01:10:20 
  Archive size: 2043198 bytes (1996 KiB)
01:10:20 
  Everything is Ok
01:10:20 
  /c/BuildAgent/work/fb3cd69e22dde528/keyman/web
01:10:20 
 
01:10:20 
  Building `static/` folder for long-term hosting of testing resources...
01:10:22 
  [web] ## prepare:downloads.keyman.com completed successfully
01:10:22 
  Resolve-Path : Cannot find path
01:10:22 
  'C:\BuildAgent\work\fb3cd69e22dde528\keyman\web\build\upload\17.0.130\keymanweb-17.0.130.zip' because it does not
01:10:22 
  exist.
```

While fixing it, I figured... why use relative pathing to construct the zip when we can easily construct an absolute one based on script-environment variables we already construct?

I also happened to notice that Web's `tools` section wasn't actually being built by the top level due to lacking an action, so this also remedies that issue.  That section is also needed by the `test` section.

@keymanapp-test-bot skip