### PR TITLE
change(web): tracking for 'initial' and 'current' UI item per touchpoint 🐵

### DIFF
--- a/common/web/gesture-recognizer/build.sh
+++ b/common/web/gesture-recognizer/build.sh
@@ -24,8 +24,7 @@ builder_describe "Builds the gesture-recognition model for Web-based on-screen k
   "--ci    sets the --ci option for child scripts (i.e, the $(builder_term test) action)"
 
 builder_describe_outputs \
-  configure:module /node_modules \
-  configure:tools  /node_modules \
+  configure        /node_modules \
   build:module     /common/web/gesture-recognizer/build/lib/index.mjs \
   build:tools      /common/web/gesture-recognizer/build/tools/lib/index.mjs
 

--- a/common/web/gesture-recognizer/src/engine/configuration/gestureRecognizerConfiguration.ts
+++ b/common/web/gesture-recognizer/src/engine/configuration/gestureRecognizerConfiguration.ts
@@ -80,5 +80,5 @@ export interface GestureRecognizerConfiguration<HoveredItemType> {
    * @param target  The `EventTarget` (`Node` or `Element`) provided by the corresponding input event.
    * @returns
    */
-  readonly itemIdentifier?: (coord: InputSample, target: EventTarget) => HoveredItemType;
+  readonly itemIdentifier?: (coord: Omit<InputSample<any>, 'item'>, target: EventTarget) => HoveredItemType;
 }

--- a/common/web/gesture-recognizer/src/engine/configuration/gestureRecognizerConfiguration.ts
+++ b/common/web/gesture-recognizer/src/engine/configuration/gestureRecognizerConfiguration.ts
@@ -2,10 +2,11 @@
 // it's just that the ELEMENTS and zone definitions involved shouldn't be shifting
 // after configuration.
 
+import { InputSample } from "../headless/inputSample.js";
 import { RecognitionZoneSource } from "./recognitionZoneSource.js";
 
 // For example, customization of a longpress timer's length need not be readonly.
-export interface GestureRecognizerConfiguration {
+export interface GestureRecognizerConfiguration<HoveredItemType> {
   /**
    * Specifies the element that mouse input listeners should be attached to.  If
    * not specified, `eventRoot` will be set equal to `targetRoot`.
@@ -67,4 +68,17 @@ export interface GestureRecognizerConfiguration {
    * set here.
    */
   readonly paddedSafeBounds?: RecognitionZoneSource;
+
+  /**
+   * Allows the gesture-recognizer client to specify the most relevant, identifying UI "item"
+   * (as perceived by users / relevant for gesture discrimination) underneath the touchpoint's
+   * current location based when processing input events.
+   *
+   * For applications in the DOM, simply returning `target` itself may be sufficient.
+   * @param coord   The current touchpath coordinate; its .targetX and .targetY values should be
+   *                interpreted as offsets from `targetRoot`.
+   * @param target  The `EventTarget` (`Node` or `Element`) provided by the corresponding input event.
+   * @returns
+   */
+  readonly itemIdentifier?: (coord: InputSample, target: EventTarget) => HoveredItemType;
 }

--- a/common/web/gesture-recognizer/src/engine/configuration/zoneBoundaryChecker.ts
+++ b/common/web/gesture-recognizer/src/engine/configuration/zoneBoundaryChecker.ts
@@ -21,7 +21,7 @@ export class ZoneBoundaryChecker {
    * @param zone          An object defining a 'recognition zone' of the gesture engine.
    * @param ignoreBitmask A bitmask indicating select boundaries to ignore for the check.
    */
-  static getCoordZoneBitmask(coord: InputSample, zone: RecognitionZoneSource): number {
+  static getCoordZoneBitmask(coord: InputSample<any>, zone: RecognitionZoneSource): number {
     const bounds = zone.getBoundingClientRect();
 
     let bitmask = 0;
@@ -37,7 +37,7 @@ export class ZoneBoundaryChecker {
    * Confirms whether or not the input coordinate lies within the accepted coordinate bounds
    * for a gesture input sequence's first coordinate.
    */
-  static inputStartOutOfBoundsCheck(coord: InputSample, config: Nonoptional<GestureRecognizerConfiguration<any>>): boolean {
+  static inputStartOutOfBoundsCheck(coord: InputSample<any>, config: Nonoptional<GestureRecognizerConfiguration<any>>): boolean {
     return !!this.getCoordZoneBitmask(coord, config.inputStartBounds); // true if out of bounds.
   }
 
@@ -48,11 +48,11 @@ export class ZoneBoundaryChecker {
    * This value should be provided as the third argument to `inputMoveCancellationCheck` for
    * updated input coordinates for the current input sequence.
    */
-  static inputStartSafeBoundProximityCheck(coord: InputSample, config: Nonoptional<GestureRecognizerConfiguration<any>>): number {
+  static inputStartSafeBoundProximityCheck(coord: InputSample<any>, config: Nonoptional<GestureRecognizerConfiguration<any>>): number {
     return this.getCoordZoneBitmask(coord, config.paddedSafeBounds);
   }
 
-  static inputMoveCancellationCheck(coord: InputSample,
+  static inputMoveCancellationCheck(coord: InputSample<any>,
                                     config: Nonoptional<GestureRecognizerConfiguration<any>>,
                                     ignoredSafeBoundFlags?: number): boolean {
     ignoredSafeBoundFlags = ignoredSafeBoundFlags || 0;

--- a/common/web/gesture-recognizer/src/engine/configuration/zoneBoundaryChecker.ts
+++ b/common/web/gesture-recognizer/src/engine/configuration/zoneBoundaryChecker.ts
@@ -37,7 +37,7 @@ export class ZoneBoundaryChecker {
    * Confirms whether or not the input coordinate lies within the accepted coordinate bounds
    * for a gesture input sequence's first coordinate.
    */
-  static inputStartOutOfBoundsCheck(coord: InputSample, config: Nonoptional<GestureRecognizerConfiguration>): boolean {
+  static inputStartOutOfBoundsCheck(coord: InputSample, config: Nonoptional<GestureRecognizerConfiguration<any>>): boolean {
     return !!this.getCoordZoneBitmask(coord, config.inputStartBounds); // true if out of bounds.
   }
 
@@ -48,12 +48,12 @@ export class ZoneBoundaryChecker {
    * This value should be provided as the third argument to `inputMoveCancellationCheck` for
    * updated input coordinates for the current input sequence.
    */
-  static inputStartSafeBoundProximityCheck(coord: InputSample, config: Nonoptional<GestureRecognizerConfiguration>): number {
+  static inputStartSafeBoundProximityCheck(coord: InputSample, config: Nonoptional<GestureRecognizerConfiguration<any>>): number {
     return this.getCoordZoneBitmask(coord, config.paddedSafeBounds);
   }
 
   static inputMoveCancellationCheck(coord: InputSample,
-                                    config: Nonoptional<GestureRecognizerConfiguration>,
+                                    config: Nonoptional<GestureRecognizerConfiguration<any>>,
                                     ignoredSafeBoundFlags?: number): boolean {
     ignoredSafeBoundFlags = ignoredSafeBoundFlags || 0;
 

--- a/common/web/gesture-recognizer/src/engine/headless/cumulativePathStats.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/cumulativePathStats.ts
@@ -189,22 +189,22 @@ export class CumulativePathStats {
    *
    * Refer to https://en.wikipedia.org/wiki/Catastrophic_cancellation.
    */
-  private baseSample?: InputSample;
+  private baseSample?: InputSample<any>;
 
   /**
    * The initial sample included by this instance's computed stats.  Needed for
    * the 'directness' properties.
    */
-  private _initialSample?: InputSample;
+  private _initialSample?: InputSample<any>;
 
-  private _lastSample?: InputSample;
-  private followingSample?: InputSample;
+  private _lastSample?: InputSample<any>;
+  private followingSample?: InputSample<any>;
   private _sampleCount = 0;
 
   constructor();
-  constructor(sample: InputSample);
+  constructor(sample: InputSample<any>);
   constructor(instance: CumulativePathStats);
-  constructor(obj?: InputSample | CumulativePathStats) {
+  constructor(obj?: InputSample<any> | CumulativePathStats) {
     if(!obj) {
       return;
     }
@@ -230,7 +230,7 @@ export class CumulativePathStats {
    * @returns A new, separate instance for the cumulative properties up to the
    *          newly-sampled point.
    */
-  public extend(sample: InputSample): CumulativePathStats {
+  public extend(sample: InputSample<any>): CumulativePathStats {
     if(!this._initialSample) {
       this._initialSample = sample;
       this.baseSample = sample;
@@ -512,7 +512,7 @@ export class CumulativePathStats {
     // results of any mapping to and from the external coordinate space, however.
     let result = new CumulativePathStats(this);
 
-    let newBase: InputSample = {
+    let newBase: InputSample<any> = {
       targetX: this.mappedMean('x') + this.baseSample.targetX,
       targetY: this.mappedMean('y') + this.baseSample.targetY,
       t:       this.mappedMean('t') + this.baseSample.t

--- a/common/web/gesture-recognizer/src/engine/headless/inputSample.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/inputSample.ts
@@ -2,7 +2,7 @@
  * We want these to be readily and safely converted to and from
  * JSON (for unit test use and development)
  */
-export interface InputSample {
+export interface InputSample<Type> {
   /**
    * Represents the x-coordinate of the input sample
    * in 'client' / viewport coordinates.
@@ -32,10 +32,15 @@ export interface InputSample {
    * (in ms)
    */
   t: number;
+
+  /**
+   * The UI/UX 'item' underneath the touchpoint for this sample.
+   */
+  item?: Type;
 }
 
-export type InputSampleSequence = InputSample[];
+export type InputSampleSequence<Type> = InputSample<Type>[];
 
-export function isAnInputSample(obj: any): obj is InputSample {
+export function isAnInputSample<Type>(obj: any): obj is InputSample<Type> {
   return 'targetX' in obj && 'targetY' in obj && 't' in obj;
 }

--- a/common/web/gesture-recognizer/src/engine/headless/subsegmentation/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/subsegmentation/pathSegmenter.ts
@@ -593,7 +593,7 @@ export class PathSegmenter {
    * should neither further inputs be received nor termination of the touchpoint be indicated.
    * @param sample
    */
-  public add(sample: InputSample) {
+  public add(sample: InputSample<any>) {
     // If this is the first received input sample, generate & publish a "start" segment.
     // As ConstructingSegment is designed to work with -sequences- of samples, it's less
     // useful here... and unnecessary, as we already have all the info we need.
@@ -678,7 +678,7 @@ export class PathSegmenter {
    * @param sample
    * @param timeDelta
    */
-  private observe(sample: InputSample, timeDelta: number) {
+  private observe(sample: InputSample<any>, timeDelta: number) {
     let cumulativeStats: CumulativePathStats;
     if(this.steppedCumulativeStats.length) {
       cumulativeStats = this.steppedCumulativeStats[this.steppedCumulativeStats.length-1];

--- a/common/web/gesture-recognizer/src/engine/headless/subsegmentation/segment.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/subsegmentation/segment.ts
@@ -10,8 +10,8 @@ export interface JSONSegment {
   peakSpeed: number
   angle: number,
   cardinalDirection: string,
-  initialCoord: InputSample,
-  lastCoord: InputSample
+  initialCoord: InputSample<any>,
+  lastCoord: InputSample<any>
 }
 
 /**
@@ -127,7 +127,7 @@ export class Segment {
   /**
    * The starting point of this touchpath segment.
    */
-  get initialCoord(): InputSample {
+  get initialCoord(): InputSample<any> {
     if(this._stats instanceof CumulativePathStats) {
       return this._stats.initialSample;
     } else {
@@ -138,7 +138,7 @@ export class Segment {
   /**
    * The ending point of this touchpath segment.
    */
-  get lastCoord(): InputSample {
+  get lastCoord(): InputSample<any> {
     if(this._stats instanceof CumulativePathStats) {
       return this._stats.lastSample;
     } else {
@@ -232,7 +232,7 @@ export class Segment {
    * @returns
    */
   public toJSON(): JSONSegment {
-    const cleanSample: (sample: InputSample) => InputSample = (sample) => {
+    const cleanSample: (sample: InputSample<any>) => InputSample<any> = (sample) => {
       const clone = {... sample};
       delete clone.clientX;
       delete clone.clientY;

--- a/common/web/gesture-recognizer/src/engine/headless/trackedPath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/trackedPath.ts
@@ -53,24 +53,27 @@ export class TrackedPath extends EventEmitter<EventMap> {
   /**
    * Initializes an empty path intended for tracking a newly-activated touchpoint.
    */
-  constructor();
+  constructor() {
+    super();
+
+    this.stats = new CumulativePathStats();
+  }
+
   /**
    * Deserializes a TrackedPath instance from its corresponding JSON.parse() object.
    * @param jsonObj
    */
-  constructor(jsonObj: JSONTrackedPath)
-  constructor(jsonObj?: JSONTrackedPath) {
-    super();
+  static deserialize(jsonObj: JSONTrackedPath): TrackedPath {
+    const instance = new TrackedPath();
 
-    if(jsonObj) {
-      this.samples = [].concat(jsonObj.coords.map((obj) => ({...obj} as InputSample)));
-      // If we're reconstructing this from a JSON.parse, it's a previously-recorded,
-      // completed path.
-      this._isComplete = true;
-      this.wasCancelled = jsonObj.wasCancelled;
-    }
+    instance.samples = [].concat(jsonObj.coords.map((obj) => ({...obj} as InputSample)));
+    instance._isComplete = true;
+    instance.wasCancelled = jsonObj.wasCancelled;
 
-    this.stats = new CumulativePathStats();
+    let stats = instance.samples.reduce((stats: CumulativePathStats, sample) => stats.extend(sample), new CumulativePathStats());
+    instance.stats = stats;
+
+    return instance;
   }
 
   /**

--- a/common/web/gesture-recognizer/src/engine/headless/trackedPoint.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/trackedPoint.ts
@@ -76,10 +76,19 @@ export class TrackedPoint<HoveredItemType> {
   }
 
   /**
-   * The event target for the first `Event` corresponding to this `TrackedPoint`.
+   * The identifying metadata returned by the configuration's specified `itemIdentifier` for
+   * the target of the first `Event` that corresponded to this `TrackedPoint`.
    */
   public get initialHoveredItem(): HoveredItemType {
     return this._initialHoveredItem;
+  }
+
+  /**
+   * The identifying metadata returned by the configuration's specified `itemIdentifier` for
+   * the target of the latest `Event` that corresponded to this `TrackedPoint`.
+   */
+  public get currentHoveredItem(): HoveredItemType {
+    return this._currentHoveredItem;
   }
 
   /**

--- a/common/web/gesture-recognizer/src/engine/index.ts
+++ b/common/web/gesture-recognizer/src/engine/index.ts
@@ -5,7 +5,7 @@ export { GestureRecognizerConfiguration } from "./configuration/gestureRecognize
 export { InputSample } from "./headless/inputSample.js";
 export { JSONTrackedInput, TrackedInput } from "./trackedInput.js";
 export { JSONTrackedPath, TrackedPath } from "./headless/trackedPath.js";
-export { JSONTrackedPoint, TrackedPoint } from "./trackedPoint.js";
+export { JSONTrackedPoint, TrackedPoint } from "./headless/trackedPoint.js";
 export { MouseEventEngine } from "./mouseEventEngine.js";
 export { PathSegmenter, Subsegmentation } from "./headless/subsegmentation/pathSegmenter.js";
 export { PaddedZoneSource } from './configuration/paddedZoneSource.js';

--- a/common/web/gesture-recognizer/src/engine/mouseEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/mouseEventEngine.ts
@@ -4,7 +4,7 @@ import { InputSample } from "./headless/inputSample.js";
 import { Nonoptional } from "./nonoptional.js";
 import { ZoneBoundaryChecker } from "./configuration/zoneBoundaryChecker.js";
 
-export class MouseEventEngine extends InputEventEngine {
+export class MouseEventEngine<HoveredItemType> extends InputEventEngine<HoveredItemType> {
   private readonly _mouseStart: typeof MouseEventEngine.prototype.onMouseStart;
   private readonly _mouseMove:  typeof MouseEventEngine.prototype.onMouseMove;
   private readonly _mouseEnd:   typeof MouseEventEngine.prototype.onMouseEnd;
@@ -14,7 +14,7 @@ export class MouseEventEngine extends InputEventEngine {
 
   private static IDENTIFIER_SEED: number;
 
-  public constructor(config: Nonoptional<GestureRecognizerConfiguration>) {
+  public constructor(config: Nonoptional<GestureRecognizerConfiguration<HoveredItemType>>) {
     super(config);
 
     // We use this approach, rather than .bind, because _this_ version allows hook
@@ -122,7 +122,7 @@ export class MouseEventEngine extends InputEventEngine {
     if(!event.buttons) {
       if(this.hasActiveClick) {
         this.hasActiveClick = false;
-        this.onInputMoveCancel(this.activeIdentifier, sample);
+        this.onInputMoveCancel(this.activeIdentifier, sample, event.target);
       }
       return;
     }
@@ -130,9 +130,9 @@ export class MouseEventEngine extends InputEventEngine {
     this.preventPropagation(event);
 
     if(!ZoneBoundaryChecker.inputMoveCancellationCheck(sample, this.config, this.disabledSafeBounds)) {
-      this.onInputMove(this.activeIdentifier, sample);
+      this.onInputMove(this.activeIdentifier, sample, event.target);
     } else {
-      this.onInputMoveCancel(this.activeIdentifier, sample);
+      this.onInputMoveCancel(this.activeIdentifier, sample, event.target);
     }
   }
 

--- a/common/web/gesture-recognizer/src/engine/mouseEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/mouseEventEngine.ts
@@ -88,8 +88,8 @@ export class MouseEventEngine<HoveredItemType> extends InputEventEngine<HoveredI
     }
   }
 
-  private buildSampleFromEvent(event: MouseEvent): InputSample {
-    return this.buildSampleFor(event.clientX, event.clientY);
+  private buildSampleFromEvent(event: MouseEvent) {
+    return this.buildSampleFor(event.clientX, event.clientY, event.target);
   }
 
   onMouseStart(event: MouseEvent) {

--- a/common/web/gesture-recognizer/src/engine/touchEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/touchEventEngine.ts
@@ -4,14 +4,14 @@ import { InputSample } from "./headless/inputSample.js";
 import { Nonoptional } from "./nonoptional.js";
 import { ZoneBoundaryChecker } from "./configuration/zoneBoundaryChecker.js";
 
-export class TouchEventEngine extends InputEventEngine {
+export class TouchEventEngine<HoveredItemType> extends InputEventEngine<HoveredItemType> {
   private readonly _touchStart: typeof TouchEventEngine.prototype.onTouchStart;
   private readonly _touchMove:  typeof TouchEventEngine.prototype.onTouchMove;
   private readonly _touchEnd:   typeof TouchEventEngine.prototype.onTouchEnd;
 
   private safeBoundMaskMap: {[id: number]: number} = {};
 
-  public constructor(config: Nonoptional<GestureRecognizerConfiguration>) {
+  public constructor(config: Nonoptional<GestureRecognizerConfiguration<HoveredItemType>>) {
     super(config);
 
     // We use this approach, rather than .bind, because _this_ version allows hook
@@ -125,9 +125,9 @@ export class TouchEventEngine extends InputEventEngine {
       const sample = this.buildSampleFromTouch(touch);
 
       if(!ZoneBoundaryChecker.inputMoveCancellationCheck(sample, this.config, this.safeBoundMaskMap[touch.identifier])) {
-        this.onInputMove(touch.identifier, sample);
+        this.onInputMove(touch.identifier, sample, touch.target);
       } else {
-        this.onInputMoveCancel(touch.identifier, sample);
+        this.onInputMoveCancel(touch.identifier, sample, touch.target);
       }
     }
   }

--- a/common/web/gesture-recognizer/src/engine/touchEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/touchEventEngine.ts
@@ -78,8 +78,8 @@ export class TouchEventEngine<HoveredItemType> extends InputEventEngine<HoveredI
     delete this.safeBoundMaskMap[identifier];
   }
 
-  private buildSampleFromTouch(touch: Touch): InputSample {
-    return this.buildSampleFor(touch.clientX, touch.clientY);
+  private buildSampleFromTouch(touch: Touch) {
+    return this.buildSampleFor(touch.clientX, touch.clientY, touch.target);
   }
 
   onTouchStart(event: TouchEvent) {

--- a/common/web/gesture-recognizer/src/engine/trackedInput.ts
+++ b/common/web/gesture-recognizer/src/engine/trackedInput.ts
@@ -1,5 +1,5 @@
 import EventEmitter from "eventemitter3";
-import { JSONTrackedPoint, TrackedPoint } from "./trackedPoint.js";
+import { JSONTrackedPoint, TrackedPoint } from "./headless/trackedPoint.js";
 
 /**
  * Documents the expected typing of serialized versions of the `TrackedInput` class.
@@ -28,8 +28,8 @@ interface EventMap {
  * `'end'`:     all gesture recognition for this input is to be resolved.
  *   - Provides no parameters.
  */
-export class TrackedInput extends EventEmitter<EventMap> {
-  public readonly touchpoints: TrackedPoint[];
+export class TrackedInput<HoveredItemType> extends EventEmitter<EventMap> {
+  public readonly touchpoints: TrackedPoint<HoveredItemType>[];
 
   // --- Future design aspects ---
   // private _gesture: Gesture;
@@ -37,14 +37,14 @@ export class TrackedInput extends EventEmitter<EventMap> {
 
   private isActive = true;
 
-  constructor(basePoint: TrackedPoint) {
+  constructor(basePoint: TrackedPoint<HoveredItemType>) {
     super();
 
     this.touchpoints = [ basePoint ];
     this._attachPointHooks(basePoint);
   }
 
-  private _attachPointHooks(touchpoint: TrackedPoint) {
+  private _attachPointHooks(touchpoint: TrackedPoint<HoveredItemType>) {
     touchpoint.path.on('complete', () => {
       this.isActive = false;
       this.emit('end');

--- a/common/web/gesture-recognizer/src/engine/trackedPoint.ts
+++ b/common/web/gesture-recognizer/src/engine/trackedPoint.ts
@@ -29,6 +29,8 @@ export class TrackedPoint {
 
   private _path: TrackedPath;
 
+  private static _jsonIdSeed: -1;
+
   /**
    * Tracks the coordinates and timestamps of each update for the lifetime of this `TrackedPoint`.
    */
@@ -44,42 +46,26 @@ export class TrackedPoint {
    */
   constructor(identifier: number,
               initialTarget: EventTarget,
-              isFromTouch: boolean);
+              isFromTouch: boolean) {
+    this.rawIdentifier = identifier;
+    this._initialTarget = initialTarget;
+    this.isFromTouch = isFromTouch;
+    this._path = new TrackedPath();
+  }
+
   /**
    * Deserializes a TrackedPoint instance from its serialized-JSON form.
+   * @param jsonObj  The JSON representation to deserialize.
    * @param identifier The unique identifier to assign to this instance.
-   * @param parsedObj  The JSON representation to deserialize.
    */
-  constructor(identifier: number,
-    parsedObj: JSONTrackedPoint);
-  constructor(identifier: number,
-              obj: EventTarget | JSONTrackedPoint,
-              isFromTouch?: boolean) {
-    this.rawIdentifier = identifier;
-    if(obj instanceof EventTarget) {
-      this._initialTarget = obj;
-      this.isFromTouch = isFromTouch;
-      this._path = new TrackedPath();
-    } else {
-      // // TEMP:  conversion of old format.
-      // if(obj['sequence']) {
-      //   obj = obj['sequence'];
-      // }
-      // @ts-ignore
-      this.isFromTouch = obj.isFromTouch;
+  public static deserialize(jsonObj: JSONTrackedPoint, identifier: number) {
+    const id = identifier !== undefined ? identifier : this._jsonIdSeed++;
+    const isFromTouch = jsonObj.isFromTouch;
+    const path = TrackedPath.deserialize(jsonObj.path);
 
-      // TEMP:  conversion of old format
-      // @ts-ignore
-      let path = obj.path;
-      // if(obj['samples']) {
-      //   // @ts-ignore
-      //   path = {
-      //     coords: obj['samples']
-      //   };
-      // }
-
-      this._path = new TrackedPath(path);
-    }
+    const instance = new TrackedPoint(id, null, isFromTouch);
+    instance._path = path;
+    return instance;
   }
 
   /**

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessRecordingSimulator.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessRecordingSimulator.ts
@@ -5,27 +5,27 @@ import {
 import { RecordedCoordSequenceSet } from './inputRecording.js';
 import { timedPromise } from './timedPromise.js';
 
-export class ProcessedSequenceTest {
+export class ProcessedSequenceTest<Type> {
   samplePromises: Promise<void>[];
 
   endPromise: Promise<void>;
   compositePromise: Promise<any>; // nasty-complex return type.
 
-  originalSamples: InputSample[];
+  originalSamples: InputSample<Type>[];
   originalSegments: Segment[];
 }
 
 // Designed to faciliate testing against both PathSegmenter and TrackedPath.
-export interface RecordingTestConfig {
-  replaySample: (sample: InputSample) => void;
+export interface RecordingTestConfig<Type> {
+  replaySample: (sample: InputSample<Type>) => void;
   endSequence:  () => void;
 }
 
 // Note:  this class is currently only used by subsegmentation unit tests.
 export class HeadlessRecordingSimulator {
   // Designed to test against PathSegmenter and TrackedPath - just implement the config interface appropriately!
-  static prepareTest(recordingObj: RecordedCoordSequenceSet, config: RecordingTestConfig): ProcessedSequenceTest {
-    const testObj = new ProcessedSequenceTest();
+  static prepareTest<Type>(recordingObj: RecordedCoordSequenceSet, config: RecordingTestConfig<Type>): ProcessedSequenceTest<Type> {
+    const testObj = new ProcessedSequenceTest<Type>();
 
     // Next:  drill down to the relevant part(s).
     const sourceTrackedPath = recordingObj.inputs[0].touchpoints[0].path;

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/hostFixtureLayoutController.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/hostFixtureLayoutController.ts
@@ -1,13 +1,13 @@
 import EventEmitter from 'eventemitter3';
-import { GestureRecognizer } from '@keymanapp/gesture-recognizer';
+import { GestureRecognizer, GestureRecognizerConfiguration } from '@keymanapp/gesture-recognizer';
 
 import { FixtureLayoutConfiguration } from './fixtureLayoutConfiguration.js';
 
 export class HostFixtureLayoutController extends EventEmitter {
   public static readonly CONFIG_CHANGED_EVENT = "configchanged";
 
-  private _recognizer: GestureRecognizer;
-  private _loadPromise: Promise<GestureRecognizer>;
+  private _recognizer: GestureRecognizer<any>;
+  private _loadPromise: Promise<GestureRecognizer<any>>;
 
   private _hostFixture: HTMLElement;
   private _layoutConfig: FixtureLayoutConfiguration;
@@ -40,7 +40,7 @@ export class HostFixtureLayoutController extends EventEmitter {
   }
 
   // The primary host-layout configuration.
-  protected buildBaseFixtureConfig = function() {
+  protected buildBaseFixtureConfig: () => GestureRecognizerConfiguration<string> = function() {
     // Written as a function in case the class is initialized before the window is loaded.
     return {
       mouseEventRoot: document.body,
@@ -53,12 +53,12 @@ export class HostFixtureLayoutController extends EventEmitter {
 
   private _setup: () => boolean = function(this: HostFixtureLayoutController) {
     let config = this.buildBaseFixtureConfig();
-    this._recognizer = new GestureRecognizer(config);
+    this._recognizer = new GestureRecognizer<any>(config);
     this._hostFixture = document.getElementById('host-fixture');
   }.bind(this);
 
-  public connect(): Promise<GestureRecognizer> {
-    this._loadPromise = new Promise<GestureRecognizer>((resolve, reject) => {
+  public connect(): Promise<GestureRecognizer<any>> {
+    this._loadPromise = new Promise<GestureRecognizer<any>>((resolve, reject) => {
       let pageLoadHandler = () => {
         try {
           this._setup();

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/inputSequenceSimulator.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/inputSequenceSimulator.ts
@@ -194,7 +194,7 @@ export class InputSequenceSimulator {
 
       for(let index=0; index < inputs.length; index++) {
         // TODO:  does not iterate over all touchpoints.  Not that we can have more than one at present...
-        const touchpoint = new TrackedPoint(index, inputs[index].touchpoints[0]);
+        const touchpoint = TrackedPoint.deserialize(inputs[index].touchpoints[0], index);
         const indexInSequence = sequenceProgress[index];
 
         if(indexInSequence == Number.MAX_VALUE) {
@@ -207,7 +207,7 @@ export class InputSequenceSimulator {
         }
       }
 
-      const touchpoint = new TrackedPoint(selectedSequence, inputs[selectedSequence].touchpoints[0]);
+      const touchpoint = TrackedPoint.deserialize(inputs[selectedSequence].touchpoints[0], selectedSequence);
       const indexInSequence = sequenceProgress[selectedSequence];
       let state: string = "move";
 

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/inputSequenceSimulator.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/inputSequenceSimulator.ts
@@ -13,14 +13,14 @@ import { SequenceRecorder } from "./sequenceRecorder.js";
  * This class is designed to 'replay' a recorded InputSequence's DOM events to ensure
  * that the recognizer's DOM layer is working correctly.
  */
-export class InputSequenceSimulator {
+export class InputSequenceSimulator<HoveredItemType> {
   private controller: HostFixtureLayoutController;
 
   constructor(controller: HostFixtureLayoutController) {
     this.controller = controller;
   }
 
-  getSampleClientPos(sample: JSONObject<InputSample>): {clientX: number, clientY: number} {
+  getSampleClientPos(sample: JSONObject<InputSample<HoveredItemType>>): {clientX: number, clientY: number} {
     let targetRoot = this.controller.recognizer.config.targetRoot;
     let targetRect = targetRoot.getBoundingClientRect();
 
@@ -68,7 +68,7 @@ export class InputSequenceSimulator {
     return event;
   }
 
-  replayTouchSample(sample: JSONObject<InputSample>,
+  replayTouchSample(sample: JSONObject<InputSample<HoveredItemType>>,
                     state: string,
                     identifier: number,
                     otherTouches: Touch[],
@@ -124,7 +124,7 @@ export class InputSequenceSimulator {
     return touch;
   }
 
-  replayMouseSample(sample: JSONObject<InputSample>, state: string, targetElement?: HTMLElement) {
+  replayMouseSample(sample: JSONObject<InputSample<HoveredItemType>>, state: string, targetElement?: HTMLElement) {
     let config = this.controller.recognizer.config;
 
     let event: MouseEvent;
@@ -165,7 +165,7 @@ export class InputSequenceSimulator {
    * @returns The final sample to be simulated.
    */
   private replayCore(sequenceTestSpec: RecordedCoordSequenceSet,
-    replayExecutor: (func: () => void, sample?: InputSample) => void): InputSample {
+    replayExecutor: (func: () => void, sample?: InputSample<HoveredItemType>) => void): InputSample<HoveredItemType> {
     let inputs = sequenceTestSpec.inputs;
     const config = sequenceTestSpec.config;
 
@@ -223,7 +223,7 @@ export class InputSequenceSimulator {
         state = "start";
       }
 
-      const sample = touchpoint.path.coords[indexInSequence];
+      const sample = touchpoint.path.coords[indexInSequence] as InputSample<HoveredItemType>;
       if(touchpoint.isFromTouch) {
         let otherTouches = [].concat(sequenceTouches);
         otherTouches.splice(selectedSequence, 1);

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/sequenceRecorder.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/sequenceRecorder.ts
@@ -7,11 +7,11 @@ import { RecordedCoordSequenceSet } from "./inputRecording.js";
  *  verification itself.
  */
 
-type WrappedInputSequence = TrackedInput;
+type WrappedInputSequence = TrackedInput<any>;
 
 export class SequenceRecorder {
   controller: HostFixtureLayoutController;
-  records:  {[identifier: string]: TrackedInput} = {};
+  records:  {[identifier: string]: TrackedInput<any>} = {};
 
   /**
    * Tracks the order in which each sequence was first detected.

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/touchpathTurtle.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/touchpathTurtle.ts
@@ -8,15 +8,15 @@ import {
  * Designed to facilitate creation of 'synthetic' touchpath sample sequences for use
  * in unit tests.
  */
-export class TouchpathTurtle {
-  private readonly startSample: InputSample;
-  private currentSample: InputSample;
+export class TouchpathTurtle<HoveredItemType> {
+  private readonly startSample: InputSample<HoveredItemType>;
+  private currentSample: InputSample<HoveredItemType>;
   private currentStats: CumulativePathStats;
   private currentChop:  CumulativePathStats = null;
 
   private _pathSegments: Subsegmentation[] = [];
 
-  constructor(obj: InputSample | TouchpathTurtle) {
+  constructor(obj: InputSample<HoveredItemType> | TouchpathTurtle<HoveredItemType>) {
     if(!(obj instanceof TouchpathTurtle)) {
       this.startSample = obj;
       this.currentSample = obj;
@@ -43,7 +43,7 @@ export class TouchpathTurtle {
     return this._pathSegments;
   }
 
-  get location(): InputSample {
+  get location(): InputSample<HoveredItemType> {
     return this.currentSample;
   }
 


### PR DESCRIPTION
For many of the gestures we're looking to add, it will be important to know properties of the key...
- underneath the touchpoint at the start
  - longpress:  the base key
  - flicks:  the base key
  - multitap: the original key
- underneath it at a given point in time / the end (once complete)
  - longpress (before subkey menu): if not the same key as the original, cancel it
  - longpress (with subkey menu):  the selected subkey
  - multitap:  if it's not the same key as the original, it can't be part of a multitap with the original.

The changes of this PR seek to enhance support for these needs in a couple of ways:
1.  Each `TrackedPoint` (corresponding to a single touchpoint in an ongoing gesture) now facilitates tracking the 'items' initially and currently underneath it - "hovered items".
    - `initial` - the item 'hovered over' when the touchpoint first activated
    - `current` - the item 'hovered over' by the touchpoint's current position.
    - Hence... `HoveredItemType` for the generic parameter.
2. Right, so about these "hovered items":  this PR adds a bit of abstraction for interaction between the gesture-recognition engine and its client.
    - The gesture engine knows the relevant input coordinates and `EventTarget` currently held underneath the touchpoint.
    - The client knows how to reinterpret those values to lookup the context that's important for user interaction & gesture management.
    - Conceptually, the common case is to represent "the UX item originally / currently 'hovered over' by the touchpoint."
        - Noting the "UX" part of that, it need not be a DOM element; it can be what said element _represents_ (to the user) instead.
3. Part in thanks to the prior point, `TrackedPoint` is now fully headless-compatible.

For point 2 above, one fairly complex aspect of Web's OSK touch handling has long been to find the "nearest" key to the active touchpoint's coordinates:

https://github.com/keymanapp/keyman/blob/93a9a203fb3699669b8c1ae5643702ced8f81b64/web/src/engine/osk/src/visualKeyboard.ts#L1052-L1122

As should be easy to see... that is not exactly a simple, straightforward function.  It's also quite heavily tailored to standard OSK layouts.  Notably, the predictive-text banner has its own similar function as well for finding the best candidate "suggestion" element.  For longpresses, subkeys have their own handling as well.

These differentiated handlers _do_ all share a common, underlying purpose, at least.  What matters for OSK interaction... is to find the `KeyElement`... in order to be able to look up the properties of the underlying key; this generalizes to the other scenarios as well.  (The predictive suggestion, the selected subkey, etc.)  We can even bypass the _element_ and directly return the truly important details - the key spec / the suggestion / the subkey spec.

----

I'd also like to note the wisdom in planning for headlessly testing gesture recognition (from pre-recorded / synthetic touchpath sequences) if possible - this also motivated the abstraction.  Toward that end, such tests would need the code to accept "items" that are _not_ DOM-backed.

For headless testing that's not connected to the OSK, my current thinking is that simple string-based tokens (say "K_A", "K_B", etc) should be unique enough and sufficiently detailed for gesture testing.  This approach would be simple to use and understand at a glance in automated test specs.

@keymanapp-test-bot skip