### PR TITLE
fix(web): touchpath recordings always sample end of path, even when stationary 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
@@ -90,8 +90,26 @@ export abstract class InputEventEngine<HoveredItemType> extends EventEmitter<Eve
   }
 
   protected onInputEnd(identifier: number) {
-    // We do not add extend the path here because any 'end' event immediately
-    // follows a 'move' if it occurred simultaneously.
+    const touchpoint = this.getTouchpointWithId(identifier);
+    if(!touchpoint) {
+      return;
+    }
+
+    const lastEntry = touchpoint.path.coords[touchpoint.path.coords.length-1];
+    const sample = this.buildSampleFor(lastEntry.clientX, lastEntry.clientY);
+
+    /* While an 'end' event immediately follows a 'move' if it occurred simultaneously,
+     * this is decidedly _not_ the case if the touchpoint was held for a while without
+     * moving, even at the point of its release.
+     *
+     * We'll never need to worry about the touchpoint moving here, and thus we don't
+     * need to worry about `currentHoveredItem` changing.  We're only concerned with
+     * recording the _timing_ of the touchpoint's release.
+     */
+    if(sample.t != lastEntry.t) {
+      touchpoint.update(sample, touchpoint.currentHoveredItem);
+    }
+
     this.getTouchpointWithId(identifier)?.path.terminate(false);
   }
 }

--- a/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
@@ -89,14 +89,14 @@ export abstract class InputEventEngine<HoveredItemType> extends EventEmitter<Eve
     touchpoint.path.terminate(true);
   }
 
-  protected onInputEnd(identifier: number) {
+  protected onInputEnd(identifier: number, target: EventTarget) {
     const touchpoint = this.getTouchpointWithId(identifier);
     if(!touchpoint) {
       return;
     }
 
     const lastEntry = touchpoint.path.coords[touchpoint.path.coords.length-1];
-    const sample = this.buildSampleFor(lastEntry.clientX, lastEntry.clientY);
+    const sample = this.buildSampleFor(lastEntry.clientX, lastEntry.clientY, target);
 
     /* While an 'end' event immediately follows a 'move' if it occurred simultaneously,
      * this is decidedly _not_ the case if the touchpoint was held for a while without
@@ -107,7 +107,7 @@ export abstract class InputEventEngine<HoveredItemType> extends EventEmitter<Eve
      * recording the _timing_ of the touchpoint's release.
      */
     if(sample.t != lastEntry.t) {
-      touchpoint.update(sample, touchpoint.currentHoveredItem);
+      touchpoint.update(sample);
     }
 
     this.getTouchpointWithId(identifier)?.path.terminate(false);

--- a/common/web/gesture-recognizer/src/engine/mouseEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/mouseEventEngine.ts
@@ -145,6 +145,6 @@ export class MouseEventEngine<HoveredItemType> extends InputEventEngine<HoveredI
       this.hasActiveClick = false;
     }
 
-    this.onInputEnd(this.activeIdentifier);
+    this.onInputEnd(this.activeIdentifier, event.target);
   }
 }

--- a/common/web/gesture-recognizer/src/engine/touchEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/touchEventEngine.ts
@@ -146,7 +146,7 @@ export class TouchEventEngine<HoveredItemType> extends InputEventEngine<HoveredI
         propagationActive = false;
       }
 
-      this.onInputEnd(touch.identifier);
+      this.onInputEnd(touch.identifier, event.target);
     }
   }
 }

--- a/common/web/gesture-recognizer/src/test/resources/json/segmentation/flick_ne_se.json
+++ b/common/web/gesture-recognizer/src/test/resources/json/segmentation/flick_ne_se.json
@@ -225,6 +225,11 @@
                 "targetX": 141,
                 "targetY": 128,
                 "t": 7272
+              },
+              {
+                "targetX": 141,
+                "targetY": 128,
+                "t": 7470
               }
             ],
             "segments": [

--- a/common/web/gesture-recognizer/src/test/resources/json/segmentation/nonstationary_hold.json
+++ b/common/web/gesture-recognizer/src/test/resources/json/segmentation/nonstationary_hold.json
@@ -20,6 +20,11 @@
                 "targetX": 80,
                 "targetY": 88,
                 "t": 21786349
+              },
+              {
+                "targetX": 80,
+                "targetY": 88,
+                "t": 21786555
               }
             ],
             "segments": [

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessRecordingSimulator.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessRecordingSimulator.ts
@@ -34,7 +34,6 @@ export class HeadlessRecordingSimulator {
     const sampleCount = testObj.originalSamples.length;
     // still exists on original recorded sequences that exist before we removed segmentation.
     testObj.originalSegments = sourceTrackedPath['segments'];
-    const lastSegment = testObj.originalSegments[testObj.originalSegments.length-1];
 
     // Build promises designed to reproduce the events at the correct times.
     testObj.samplePromises = testObj.originalSamples.map((sample) => {
@@ -43,14 +42,7 @@ export class HeadlessRecordingSimulator {
       }, sample.t - testObj.originalSamples[0].t);
     });
 
-
-    // Originally we did not record the release-timing of the touch, instead using the timing of
-    // the last sample for the last subsegmentation's last sample.  We've disabled that in order
-    // to get out a release in a more timely manner, but we'll still use it first if it's available.
-    //
-    // If not... we use a more current style.  TODO:  resolve 'release timing' aspect of input
-    // sequence recording + playback.
-    const endTime = lastSegment ? lastSegment.lastCoord.t : sourceTrackedPath.coords[sampleCount-1].t;
+    const endTime = sourceTrackedPath.coords[sampleCount-1].t;
 
     testObj.endPromise = timedPromise(() => {
       config.endSequence();


### PR DESCRIPTION
On reviewing the old code and when disabling subsegmentation in #9067, I noticed some issues regarding end-of-sequence modeling for automated tests.  By making sure there is always a sample at the _time_ of the touchpath's end, we can avoid the problem.

If the touchpath was in motion at the time, a sample already exists - this was the common case for the existing test sequences.  If it was being held, though... there wasn't a matching sample.  It was easy enough to add "in post," though, and it's easy enough to detect at the time of recording for future test sequences, too.

@keymanapp-test-bot skip 