### PR TITLE
fix(linux): Fix uninstalling keyboard for multiple languages with ibus

### DIFF
--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -12,7 +12,7 @@ from keyman_config.get_kmp import (InstallLocation, get_keyboard_dir,
 from keyman_config.gnome_keyboards_util import (GnomeKeyboardsUtil,
                                                 get_ibus_keyboard_id,
                                                 is_gnome_shell)
-from keyman_config.ibus_util import (get_ibus_bus, restart_ibus,
+from keyman_config.ibus_util import (IbusUtil, get_ibus_bus, restart_ibus,
                                      uninstall_from_ibus)
 from keyman_config.kmpmetadata import get_metadata
 
@@ -82,14 +82,20 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
 
 def _uninstall_keyboards_from_ibus(keyboards, packageDir):
     bus = get_ibus_bus()
-    if bus or os.environ.get('SUDO_USER'):
-        # install all kmx for first lang not just packageID
-        for kb in keyboards:
-            ibus_keyboard_id = get_ibus_keyboard_id(kb, packageDir)
-            uninstall_from_ibus(bus, ibus_keyboard_id)
-        restart_ibus(bus)
-    else:
-        logging.warning("could not uninstall keyboards from IBus")
+    ibusUtil = IbusUtil()
+    sources = ibusUtil.read_preload_engines()
+    if not sources:
+        return
+
+    # install all kmx for first lang not just packageID
+    for kb in keyboards:
+        match_id = ":%s" % get_ibus_keyboard_id(kb, packageDir, ignore_language=True)
+        toRemove = [id for id in sources if id.endswith(match_id)]
+        for val in toRemove:
+            sources.remove(val)
+
+    ibusUtil.write_preload_engines(bus, sources)
+    restart_ibus(bus)
 
 
 def _uninstall_keyboards_from_gnome(keyboards, packageDir):

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -87,8 +87,9 @@ def _uninstall_keyboards_from_ibus(keyboards, packageDir):
     if not sources:
         return
 
-    # install all kmx for first lang not just packageID
+    # uninstall all specified keyboards for all languages
     for kb in keyboards:
+        # keyboard ids are similar to `km:/path/to/keyman/khmer_angkor/khmer_angkor.kmx`
         match_id = ":%s" % get_ibus_keyboard_id(kb, packageDir, ignore_language=True)
         toRemove = [id for id in sources if id.endswith(match_id)]
         for val in toRemove:

--- a/linux/keyman-config/tests/test_uninstall_kmp.py
+++ b/linux/keyman-config/tests/test_uninstall_kmp.py
@@ -2,10 +2,10 @@
 import unittest
 from unittest.mock import patch
 
-from keyman_config.uninstall_kmp import _uninstall_keyboards_from_gnome
+from keyman_config.uninstall_kmp import _uninstall_keyboards_from_gnome, _uninstall_keyboards_from_ibus
 
 
-class UninstallKmpTests(unittest.TestCase):
+class UninstallKmpGnomeTests(unittest.TestCase):
 
     def setUp(self):
         patcher = patch('keyman_config.uninstall_kmp.GnomeKeyboardsUtil')
@@ -110,3 +110,123 @@ class UninstallKmpTests(unittest.TestCase):
         # Verify
         mockGnomeKeyboardsUtilInstance.write_input_sources.assert_called_once_with(
           [('xkb', 'en')])
+
+
+class UninstallKmpIbusTests(unittest.TestCase):
+
+    def setUp(self):
+        self.mockIbusUtilClass = self._setupMock('keyman_config.uninstall_kmp.IbusUtil')
+        self.mockRestartIbus = self._setupMock('keyman_config.uninstall_kmp.restart_ibus')
+        self.mockGetIbusBus = self._setupMock('keyman_config.uninstall_kmp.get_ibus_bus')
+        self.mockGetIbusBus.return_value = None
+
+    def _setupMock(self, arg0):
+        patcher = patch(arg0)
+        result = patcher.start()
+        self.addCleanup(patcher.stop)
+        return result
+
+    def test_UninstallKeyboardsFromIbus_RemoveOneKeyboardFromEmpty(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = []
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1'}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_not_called()
+
+    def test_UninstallKeyboardsFromIbus_RemoveNonExistingKeyboard(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'fr:fooDir/foo2.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1'}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(None, [
+          'fr:fooDir/foo2.kmx'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveOneKeyboard(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'km:fooDir/foo1.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1'}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveMultipleKeyboards(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'km:fooDir/foo1.kmx', 'fr:fooDir/foo2.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveAllKeyboards(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'km:fooDir/foo1.kmx', 'fr:fooDir/foo2.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1'}, {'id': 'foo2'}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(None, [])
+
+    def test_UninstallKeyboardsFromIbus_RemoveKeyboard_SingleLanguage(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'en:fooDir/foo1.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus([{'id': 'foo1', 'languages': [{'id': 'en'}]}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveKeyboard_MultipleLanguages(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'fr:fooDir/foo1.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus(
+          [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveKeyboard_OneNotMatchingLanguage(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'en:fooDir/foo1.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus(
+          [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng'])
+
+    def test_UninstallKeyboardsFromIbus_RemoveKeyboard_RemovesAllMatching(self):
+        # Setup
+        mockIbusUtilInstance = self.mockIbusUtilClass.return_value
+        mockIbusUtilInstance.read_preload_engines.return_value = [
+          'xkb:us::eng', 'en:fooDir/foo1.kmx', 'fr:fooDir/foo1.kmx', 'km:fooDir/foo2.kmx']
+        # Execute
+        _uninstall_keyboards_from_ibus(
+          [{'id': 'foo1', 'languages': [{'id': 'fr'}]}], 'fooDir')
+        # Verify
+        mockIbusUtilInstance.write_preload_engines.assert_called_once_with(
+          None,
+          ['xkb:us::eng', 'km:fooDir/foo2.kmx'])


### PR DESCRIPTION
After this change uninstalling a keyboard will remove all installed language/keyboard combinations for that particular keyboard. Previously we only uninstalled for the first language listed in the keyboard.

This will be tested as part of #9017.

@keymanapp-test-bot skip