### PR TITLE
fix(developer): ensure `delete` uses array semantics where appropriate 🗜

### DIFF
--- a/developer/src/kmcmplib/src/CasedKeys.cpp
+++ b/developer/src/kmcmplib/src/CasedKeys.cpp
@@ -133,7 +133,7 @@ KMX_DWORD ExpandCapsRule(PFILE_GROUP gp, PFILE_KEY kpp, PFILE_STORE sp) {
 
   kpp = &k[(int)(kpp - gp->dpKeyArray)];
 
-  delete gp->dpKeyArray;
+  delete[] gp->dpKeyArray;
   gp->dpKeyArray = k;
   gp->cxKeyArray++;
 

--- a/developer/src/kmcmplib/src/CompileKeyboardBuffer.cpp
+++ b/developer/src/kmcmplib/src/CompileKeyboardBuffer.cpp
@@ -150,7 +150,7 @@ bool CompileKeyboardBuffer(KMX_BYTE* infile, int sz, PFILE_KEYBOARD fk)
     return FALSE;
   }
 
-  delete str;
+  delete[] str;
 
   if (!kmcmp::CheckKeyboardFinalVersion(fk)) {
     return FALSE;

--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -615,7 +615,7 @@ KMX_DWORD ProcessGroupLine(PFILE_KEYBOARD fk, PKMX_WCHAR p)
   if (fk->dpGroupArray)
   {
     memcpy(gp, fk->dpGroupArray, sizeof(FILE_GROUP) * fk->cxGroupArray);
-    delete fk->dpGroupArray;
+    delete[] fk->dpGroupArray;
   }
 
   fk->dpGroupArray = gp;
@@ -738,7 +738,7 @@ KMX_DWORD ProcessStoreLine(PFILE_KEYBOARD fk, PKMX_WCHAR p)
   if (fk->dpStoreArray)
   {
     memcpy(sp, fk->dpStoreArray, sizeof(FILE_STORE) * fk->cxStoreArray);
-    delete fk->dpStoreArray;
+    delete[] fk->dpStoreArray;
   }
 
   fk->dpStoreArray = sp;
@@ -799,7 +799,7 @@ KMX_DWORD AddStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, const KMX_WCHAR * str,
   if (fk->dpStoreArray)
   {
     memcpy(sp, fk->dpStoreArray, sizeof(FILE_STORE) * fk->cxStoreArray);
-    delete fk->dpStoreArray;
+    delete[] fk->dpStoreArray;
   }
 
   fk->dpStoreArray = sp;
@@ -1468,7 +1468,7 @@ KMX_DWORD ProcessKeyLineImpl(PFILE_KEYBOARD fk, PKMX_WCHAR str, KMX_BOOL IsUnico
   if (gp->dpKeyArray)
   {
     memcpy(kp, gp->dpKeyArray, gp->cxKeyArray * sizeof(FILE_KEY));
-    delete gp->dpKeyArray;
+    delete[] gp->dpKeyArray;
   }
 
   gp->dpKeyArray = kp;
@@ -1587,7 +1587,7 @@ KMX_DWORD ExpandKp(PFILE_KEYBOARD fk, PFILE_KEY kpp, KMX_DWORD storeIndex)
 
   kpp = &k[(int)(kpp - gp->dpKeyArray)];
 
-  delete gp->dpKeyArray;
+  delete[] gp->dpKeyArray;
   gp->dpKeyArray = k;
   gp->cxKeyArray += nchrs - 1;
 
@@ -1621,8 +1621,8 @@ KMX_DWORD ExpandKp(PFILE_KEYBOARD fk, PFILE_KEY kpp, KMX_DWORD storeIndex)
     ExpandKp_ReplaceIndex(fk, k, keyIndex, n);
   }
 
-  delete dpContext;
-  delete dpOutput;
+  delete[] dpContext;
+  delete[] dpOutput;
 
   return CERR_None;
 }
@@ -3390,7 +3390,7 @@ int GetVKCode(PFILE_KEYBOARD fk, PKMX_WCHAR p)
   {
     PFILE_VKDICTIONARY pvk = new FILE_VKDICTIONARY[fk->cxVKDictionary + 10];
     memcpy(pvk, fk->dpVKDictionary, fk->cxVKDictionary * sizeof(FILE_VKDICTIONARY));
-    delete fk->dpVKDictionary;
+    delete[] fk->dpVKDictionary;
     fk->dpVKDictionary = pvk;
   }
   u16ncpy(fk->dpVKDictionary[fk->cxVKDictionary].szName, p, _countof(fk->dpVKDictionary[fk->cxVKDictionary].szName) );  // I3481

--- a/developer/src/kmcmplib/src/NamedCodeConstants.cpp
+++ b/developer/src/kmcmplib/src/NamedCodeConstants.cpp
@@ -51,8 +51,8 @@ NamedCodeConstants::NamedCodeConstants()
 
 NamedCodeConstants::~NamedCodeConstants()
 {
-  if(entries) delete entries;
-  if(entries_file) delete entries_file;
+  if(entries) delete[] entries;
+  if(entries_file) delete[] entries_file;
 }
 
 void NamedCodeConstants::AddCode(int n, const KMX_WCHAR *p, KMX_DWORD storeIndex)
@@ -63,7 +63,7 @@ void NamedCodeConstants::AddCode(int n, const KMX_WCHAR *p, KMX_DWORD storeIndex
     if(nEntries_file > 0)
     {
       memcpy(bn, entries_file, sizeof(NCCENTRY) * nEntries_file);
-      delete entries_file;
+      delete[] entries_file;
     }
     entries_file = bn;
   }
@@ -87,7 +87,7 @@ void NamedCodeConstants::AddCode_IncludedCodes(int n, const KMX_WCHAR *p)
     if(nEntries > 0)
     {
       memcpy(bn, entries, sizeof(NCCENTRY) * nEntries);
-      delete entries;
+      delete[] entries;
     }
     entries = bn;
   }


### PR DESCRIPTION
The kmcmplib compiler source used `delete` instead of `delete[]` in a number of locations where the corresponding allocation was an array.

This doesn't appear to matter on arrays of primitives on most platforms that we are targeting, but it _is_ undefined behaviour so we should correct it.

https://stackoverflow.com/a/2425749/1836776

@keymanapp-test-bot skip