### PR TITLE
fix(developer): `GetDelimitedString` was using wrong `strchr` 🗜

### DIFF
--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -1642,7 +1642,7 @@ PKMX_WCHAR GetDelimitedString(PKMX_WCHAR *p, KMX_WCHAR const * Delimiters, KMX_W
 
   q++;
 
-  r = xstrchr(q, &dClose);			        // Find closing delimiter
+  r = (PKMX_WCHAR) u16chr(q, dClose);			        // Find closing delimiter
   if (!r) return NULL;
 
   if (Flags & GDS_CUTLEAD)
@@ -1655,7 +1655,7 @@ PKMX_WCHAR GetDelimitedString(PKMX_WCHAR *p, KMX_WCHAR const * Delimiters, KMX_W
       r--;							// Cut off following spaces
       while (iswspace(*r) && r > q) r--;
       r++;
-      *r = 0; r = xstrchr((r + 1), &dClose);
+      *r = 0; r = (PKMX_WCHAR) u16chr((r + 1), dClose);
     }
   else *r = 0;
 

--- a/developer/src/kmcmplib/src/xstring.cpp
+++ b/developer/src/kmcmplib/src/xstring.cpp
@@ -59,7 +59,7 @@ PKMX_WCHAR decxstr(PKMX_WCHAR p, PKMX_WCHAR pStart)
   if(*p == UC_SENTINEL_EXTENDEDEND) {
     int n = 0;
     while (p > pStart && *p != UC_SENTINEL && n < 10) {
-      p--; 
+      p--;
       n++;
     }
 
@@ -110,14 +110,6 @@ int xstrpos(PKMX_WCHAR p1, PKMX_WCHAR p)
   int i;
   for(i = 0; p < p1; p = incxstr(p), i++);
   return i;
-}
-
-PKMX_WCHAR xstrchr(PKMX_WCHAR buf, PKMX_WCHAR chr)
-{
-  for(PKMX_WCHAR q = incxstr(buf); *buf; buf = q, q = incxstr(buf))
-    if(!u16ncmp(buf, chr, (intptr_t)(q-buf)))
-      return buf;
-  return NULL;
 }
 
 const int CODE__SIZE[] = {

--- a/developer/src/kmcmplib/src/xstring.h
+++ b/developer/src/kmcmplib/src/xstring.h
@@ -9,7 +9,6 @@ KMX_UCHAR* decxstr(KMX_UCHAR* p, KMX_UCHAR* pStart);
 int xstrlen(KMX_UCHAR* p);
 int xstrlen_ignoreifopt(KMX_UCHAR* p);
 int xstrpos(KMX_UCHAR* p1, KMX_UCHAR* p);
-KMX_UCHAR* xstrchr(KMX_UCHAR* buf, KMX_UCHAR* chr);
 int xchrcmp(KMX_UCHAR* ch1, KMX_UCHAR* ch2);
 
 #endif // XSTRING_H


### PR DESCRIPTION
Picked this up while running `-fsanitize=address` for trying to track down another bug.

This fixes a buffer overrun (normally invisible) in kmcmplib, where `xstrchr` was being called, which takes a string as its second parameter, but being passed a single character. This was incorrect behaviour for two reasons:

1. Passing a single character doesn't have null termination (big bug!)
2. We were not wanting xstring semantics on the token being parsed here

Replaced with `u16chr`, which does do what we want. Note the casting because `u16chr` only has a `const` version of its input/output at present.

Removed `xstrchr` because it is not used anywhere else in kmcmplib.

@keymanapp-test-bot skip