### PR TITLE
fix(windows): adds an extra row for Change Hotkey text label

### DIFF
--- a/windows/src/desktop/kmshell/main/UfrmChangeHotkey.dfm
+++ b/windows/src/desktop/kmshell/main/UfrmChangeHotkey.dfm
@@ -5,26 +5,26 @@ inherited frmChangeHotkey: TfrmChangeHotkey
   BorderIcons = [biSystemMenu, biHelp]
   BorderStyle = bsDialog
   Caption = 'Change Hotkey'
-  ClientHeight = 217
+  ClientHeight = 237
   ClientWidth = 305
   Font.Name = 'Tahoma'
   Position = poScreenCenter
   ExplicitWidth = 311
-  ExplicitHeight = 246
+  ExplicitHeight = 266
   PixelsPerInch = 96
   TextHeight = 13
   object lblHotkey: TLabel
     Left = 12
     Top = 12
     Width = 281
-    Height = 49
+    Height = 69
     AutoSize = False
     Caption = 'lblHotkey'
     WordWrap = True
   end
   object hkHotkey: THotKey
     Left = 75
-    Top = 152
+    Top = 172
     Width = 155
     Height = 19
     HotKey = 49217
@@ -34,7 +34,7 @@ inherited frmChangeHotkey: TfrmChangeHotkey
   end
   object cmdOK: TButton
     Left = 140
-    Top = 180
+    Top = 200
     Width = 73
     Height = 25
     Caption = 'OK'
@@ -44,7 +44,7 @@ inherited frmChangeHotkey: TfrmChangeHotkey
   end
   object cmdCancel: TButton
     Left = 220
-    Top = 180
+    Top = 200
     Width = 73
     Height = 25
     Cancel = True
@@ -54,7 +54,7 @@ inherited frmChangeHotkey: TfrmChangeHotkey
   end
   object rbAltLeftShift: TRadioButton
     Left = 12
-    Top = 84
+    Top = 104
     Width = 113
     Height = 17
     Caption = 'Left Alt + Shift'
@@ -63,7 +63,7 @@ inherited frmChangeHotkey: TfrmChangeHotkey
   end
   object rbNone: TRadioButton
     Left = 12
-    Top = 61
+    Top = 81
     Width = 113
     Height = 17
     Caption = 'No Hotkey'
@@ -72,7 +72,7 @@ inherited frmChangeHotkey: TfrmChangeHotkey
   end
   object rbCtrlShift: TRadioButton
     Left = 12
-    Top = 107
+    Top = 127
     Width = 113
     Height = 17
     Caption = 'Ctrl + Shift'
@@ -81,7 +81,7 @@ inherited frmChangeHotkey: TfrmChangeHotkey
   end
   object rbCustom: TRadioButton
     Left = 12
-    Top = 129
+    Top = 149
     Width = 113
     Height = 17
     Caption = 'Custom'


### PR DESCRIPTION
Fixes: #9093 

Add an extra row for the change text label to accommodate the German and Kannada translations.
I did try auto-size but wasn't sure how to get the rest of the GUI objects on the form to flow down the page as well. 

# User Testing

* TEST_CHANGE_LBL

With build artifacts with this PR follow the following steps. These have been taken from the original issue #9093

1. Open Keyman Configuration dialog.
2. Download and Install Khmer Angkor keyboard.
3. Change the UI language to Kannada.
4. Click the 'no hotkey' link button in the Keyboard Layouts view.
5. Verify noticed the last line of Kannada text is fully visible.
6. Repeat steps 3-5 selecting Deutsch (German) instead.


