### PR TITLE
fix(linux): Remove tags from package description

### DIFF
--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+import re
 import tempfile
 from os import path
 
@@ -13,7 +14,7 @@ import qrcode.constants
 
 gi.require_version('Gtk', '3.0')
 
-from gi.repository import Gtk
+from gi.repository import GLib, Gtk
 
 from keyman_config import KeymanComUrl, _, secure_lookup
 from keyman_config.accelerators import init_accel
@@ -165,7 +166,7 @@ class KeyboardDetailsView(Gtk.Dialog):
         label = self._add_label(text, prevlabel)
         contentLabel = Gtk.Label()
         if content:
-            contentLabel.set_text(content)
+            contentLabel.set_text(re.sub(r'( )?</?[^>]*>', ' ', content))
         contentLabel.set_halign(Gtk.Align.START)
         contentLabel.set_selectable(True)
         contentLabel.set_line_wrap(True)


### PR DESCRIPTION
This is a temporary workaround - see discussion on #8057. While this is not the perfect solution it should improve things in most cases.

Fixes #4769.

Before this change:
![image](https://github.com/keymanapp/keyman/assets/181336/af704e43-e575-4429-a528-ff96ca1a5109)

With this change:
![image](https://github.com/keymanapp/keyman/assets/181336/659242a1-b176-4511-be30-5f71fc13022e)

# User Testing

## Preparations

- The tests can be run on any Linux platform.
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot
- Install "Khmer Angkor" keyboard

## Tests

**TEST_NOTAG**: 

- Open Keyman Configuration and select "Khmer Angkor" keyboard
- click About button
- verify that the package description field doesn't show tags