### PR TITLE
fix(linux): Add scrollbar to About dialog

### DIFF
--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -63,6 +63,9 @@ class KeyboardDetailsView(Gtk.Dialog):
                 logging.warning('Exception %s reading %s %s', type(e), jsonfile, e.args)
 
         self.grid = Gtk.Grid()
+
+        scrolledWindow = Gtk.ScrolledWindow()
+        scrolledWindow.add(self.grid)
         # self.grid.set_column_homogeneous(True)
 
         # kbdatapath = path.join("/usr/local/share/keyman", self.kmp["id"], self.kmp["id"] + ".json")
@@ -97,8 +100,9 @@ class KeyboardDetailsView(Gtk.Dialog):
 
         self.add_button(_("_Close"), Gtk.ResponseType.CLOSE)
 
-        self.get_content_area().pack_start(self.grid, True, True, 12)
+        self.get_content_area().pack_start(scrolledWindow, True, True, 12)
         self.resize(800, 450)
+        scrolledWindow.set_vadjustment(None)
         self.show_all()
 
     def _add_info_for_all_keyboards(self, keyboards, prevlabel) -> Gtk.Widget:


### PR DESCRIPTION
Fixes #9005.

# User Testing

## Preparations

- The test can be run on any Linux platform
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot
- Download and install Syriac/Aramaic keyboard

## Tests

**TEST_SCROLLBAR**:

- Open Keyman Configuration and select Syriac/Aramaic keyboard
- Click About button
- verify that a scrollbar is available (if necessary) so that the entire content is accessible