### PR TITLE
fix(linux): Fix vertical alignment of labels in About dialog

### DIFF
--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -148,6 +148,7 @@ class KeyboardDetailsView(Gtk.Dialog):
         label = Gtk.Label()
         label.set_text(text)
         label.set_halign(Gtk.Align.END)
+        label.set_valign(Gtk.Align.START)
         if prevlabel:
             self.grid.attach_next_to(label, prevlabel, Gtk.PositionType.BOTTOM, 1, 1)
         else:


### PR DESCRIPTION
Before this change:

![image](https://github.com/keymanapp/keyman/assets/181336/210185bb-8cf6-4e25-b681-6aa71c2d72af)

With this change:

![image](https://github.com/keymanapp/keyman/assets/181336/77b05523-269b-4743-b17d-c60f3cf10edd)

@keymanapp-test-bot skip
