### PR TITLE
chore(developer): refactor so KmnCompiler only created once within kmc 🙀

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/messages.ts
@@ -94,10 +94,6 @@ export class CompilerMessages {
       `duplicate variables: id=${o.ids}`);
   static ERROR_DuplicateVariable = SevError | 0x0016;
 
-  static Fatal_SectionInitFailed = (o:{sect: string}) =>
-  m(this.FATAL_SectionInitFailed, `The compiler for '${o.sect}' failed to initialize.`);
-  static FATAL_SectionInitFailed = SevFatal | 0x0017;
-
   // Not hit due to XML parsing
   static Error_InvalidTransformsType = (o:{types: string[]}) =>
   m(this.ERROR_InvalidTransformsType, `Invalid transforms types: '${o.types?.join(',')}'`);

--- a/developer/src/kmc-ldml/src/compiler/section-compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/section-compiler.ts
@@ -3,15 +3,6 @@ import { SectionIdent, constants } from '@keymanapp/ldml-keyboard-constants';
 
 /* istanbul ignore next */
 export class SectionCompiler {
-  /**
-   * Opportunity for async initialization.
-   * @returns true when OK. On false, causes a message to happen.
-   */
-  public async init() : Promise<boolean> {
-    // nothing to do here
-    return true;
-  }
-
   protected readonly keyboard: LDMLKeyboard.LKKeyboard;
   protected readonly callbacks: CompilerCallbacks;
 

--- a/developer/src/kmc-ldml/src/compiler/tran.ts
+++ b/developer/src/kmc-ldml/src/compiler/tran.ts
@@ -1,5 +1,5 @@
 import { constants, SectionIdent } from "@keymanapp/ldml-keyboard-constants";
-import { KMXPlus, LDMLKeyboard, CompilerCallbacks, VariableParser, UnicodeSetParser } from '@keymanapp/common-types';
+import { KMXPlus, LDMLKeyboard, CompilerCallbacks, VariableParser } from '@keymanapp/common-types';
 import { SectionCompiler } from "./section-compiler.js";
 
 import Bksp = KMXPlus.Bksp;
@@ -15,7 +15,6 @@ import LKTransform = LDMLKeyboard.LKTransform;
 import LKTransforms = LDMLKeyboard.LKTransforms;
 import { verifyValidAndUnique } from "../util/util.js";
 import { CompilerMessages } from "./messages.js";
-import { KmnCompiler } from "@keymanapp/kmc-kmn";
 
 type TransformCompilerType = 'simple' | 'backspace';
 
@@ -25,18 +24,6 @@ class TransformCompiler<T extends TransformCompilerType, TranBase extends Tran> 
 
   constructor(source: LDMLKeyboardXMLSourceFile, callbacks: CompilerCallbacks) {
     super(source, callbacks);
-  }
-
-  // TODO-LDML: dup with 'vars'
-  usetparser : UnicodeSetParser = null;
-
-  public async init() : Promise<boolean> {
-    const compiler = new KmnCompiler();
-    const ok = await compiler.init(this.callbacks);
-    if (ok) {
-      this.usetparser = compiler;
-    }
-    return ok;
   }
 
   public validate(): boolean {
@@ -162,9 +149,6 @@ class TransformCompiler<T extends TransformCompilerType, TranBase extends Tran> 
   }
 
   public compile(sections: DependencySections): TranBase {
-    if (!sections.usetparser) {
-      sections.usetparser = this.usetparser;
-    }
     for(let t of this.keyboard.transforms) {
       if(t.type == this.type) {
         // compile only the transforms of the correct type

--- a/developer/src/kmc-ldml/src/compiler/vars.ts
+++ b/developer/src/kmc-ldml/src/compiler/vars.ts
@@ -1,7 +1,6 @@
 import { SectionIdent, constants } from "@keymanapp/ldml-keyboard-constants";
 import { KMXPlus, LDMLKeyboard, CompilerCallbacks } from '@keymanapp/common-types';
-import { UnicodeSetParser, VariableParser } from '@keymanapp/common-types';
-import { KmnCompiler } from  '@keymanapp/kmc-kmn';
+import { VariableParser } from '@keymanapp/common-types';
 import { SectionCompiler } from "./section-compiler.js";
 import Vars = KMXPlus.Vars;
 import StringVarItem = KMXPlus.StringVarItem;
@@ -22,18 +21,6 @@ export class VarsCompiler extends SectionCompiler {
     ]);
     defaults.delete(this.id);
     return defaults;
-  }
-
-  // TODO-LDML: dup with 'vars'
-  usetparser : UnicodeSetParser = null;
-
-  public async init() : Promise<boolean> {
-    const compiler = new KmnCompiler();
-    const ok = await compiler.init(this.callbacks);
-    if (ok) {
-      this.usetparser = compiler;
-    }
-    return ok;
   }
 
   constructor(source: LDMLKeyboardXMLSourceFile, callbacks: CompilerCallbacks) {
@@ -147,9 +134,6 @@ export class VarsCompiler extends SectionCompiler {
   }
 
   public compile(sections: DependencySections): Vars {
-    if (!sections.usetparser) {
-      sections.usetparser = this.usetparser;
-    }
     const result =  new Vars();
 
     const variables = this.keyboard?.variables;
@@ -195,7 +179,7 @@ export class VarsCompiler extends SectionCompiler {
     let { value } = e;
     value = result.substituteStrings(value, sections);
     value = result.substituteUnicodeSets(value, sections);
-    result.unicodeSets.push(new UnicodeSetItem(id, value, sections, this.usetparser));
+    result.unicodeSets.push(new UnicodeSetItem(id, value, sections, sections.usetparser));
   }
   // routines for using/substituting variables have been moved to the Vars class and its
   // properties


### PR DESCRIPTION
- remove async SectionCompiler.init()  and all callers
- the usetparser lives on the DependencySections, initialized by kmc-ldml (and by the test harnesses)

for: #7377

@keymanapp-test-bot skip