### PR TITLE
fix(common): support multichar escapes in element sets 🙀

### DIFF
--- a/common/web/types/test/ldml-keyboard/test-pattern-parser.ts
+++ b/common/web/types/test/ldml-keyboard/test-pattern-parser.ts
@@ -149,16 +149,38 @@ describe('Test of Pattern Parsers', () => {
           str: `\\u1A60[\\u1A75-\\u1A79]\\u1A45ħ`,
           expect: [{
             segment: '\\u1A60',
-            type: ElementType.escaped
+            type: ElementType.escaped,
           },{
             segment: '[\\u1A75-\\u1A79]',
-            type: ElementType.uset
+            type: ElementType.uset,
           },{
             segment: '\\u1A45',
-            type: ElementType.escaped
+            type: ElementType.escaped,
           },{
             segment: 'ħ',
-            type: ElementType.codepoint
+            type: ElementType.codepoint,
+          }],
+        },
+        {
+          str: `\\u{22}\\u{0127}`,
+          expect: [{
+            segment: `\\u{22}`,
+            type: ElementType.escaped,
+          },
+          {
+            segment: `\\u{0127}`,
+            type: ElementType.escaped,
+          }],
+        },
+        {
+          str: `\\u{22 0127}`,
+          expect: [{
+            segment: `\\u{22}`,
+            type: ElementType.escaped,
+          },
+          {
+            segment: `\\u{127}`, // resegmented with minimal hex
+            type: ElementType.escaped,
           }],
         },
       ].forEach(({str, expect}) => it(`Segment: ${str}`, () => {

--- a/developer/src/kmc-ldml/test/fixtures/sections/ordr/multi-escape.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/ordr/multi-escape.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="nod-Lana" conformsTo="techpreview">
+  <names>
+    <name value="nod-Lana Test2" />
+  </names>
+
+  <keys />
+
+  <transforms type="simple">
+    <transformGroup>
+      <reorder from="\u{1A60 1A45}" order="10" />
+    </transformGroup>
+  </transforms>
+</keyboard>

--- a/developer/src/kmc-ldml/test/test-tran.ts
+++ b/developer/src/kmc-ldml/test/test-tran.ts
@@ -154,6 +154,23 @@ describe('tran', function () {
 
       }
     },
+    {
+      // test escapes with spaces
+      subpath: 'sections/ordr/multi-escape.xml',
+      callback(sect) {
+        const tran = <Tran> sect;
+        assert.equal(tran.groups?.length, 1);
+        assert.equal(tran.groups[0].type, constants.tran_group_type_reorder);
+        const { reorders } = tran.groups[0];
+        assert.lengthOf(reorders, 1);
+        assert.lengthOf(reorders[0].elements, 2);
+        assert.equal(reorders[0].elements[0].value.char, 0x1A60);
+        assert.equal(reorders[0].elements[1].value.char, 0x1A45);
+        assert.equal(reorders[0].before.length, 0);
+        assert.equal(reorders[0].elements[0].order, 10);
+        assert.equal(reorders[0].elements[1].order, 10);
+      }
+    },
     // bksp non-test
     {
       subpath: 'sections/bksp/minimal.xml',


### PR DESCRIPTION
- \u{22 0127} acts like \u{22}\u{0127}

for: #7377

@keymanapp-test-bot skip