### PR TITLE
fix(web): fixes up Web's InlinedOSK manual test page

### DIFF
--- a/web/src/test/manual/web/inline-osk/index.html
+++ b/web/src/test/manual/web/inline-osk/index.html
@@ -42,7 +42,7 @@
           {'browser': 'chrome', 'formFactor': 'desktop', OS: 'windows', touchable: false} :  // Or whatever target config you want.
           {'browser': 'chrome', 'formFactor': 'phone', OS: 'ios', touchable: true};
         if(newOSK) document.getElementById('KeymanWebControl').removeChild(newOSK.element);
-        newOSK = new com.keyman.osk.InlinedOSKView(targetDevice, keyman.util.device.coreSpec);
+        newOSK = new keyman.views.InlinedOSKView(keyman, keyman.config.hostDevice);
         newOSK.setSize('300px', '150px');  // Or pick whatever size you want, however you want it.
         document.getElementById('KeymanWebControl').appendChild(newOSK.element);
         keyman.osk = newOSK;

--- a/web/src/test/manual/web/inline-osk/index.html
+++ b/web/src/test/manual/web/inline-osk/index.html
@@ -42,11 +42,10 @@
           {'browser': 'chrome', 'formFactor': 'desktop', OS: 'windows', touchable: false} :  // Or whatever target config you want.
           {'browser': 'chrome', 'formFactor': 'phone', OS: 'ios', touchable: true};
         if(newOSK) document.getElementById('KeymanWebControl').removeChild(newOSK.element);
-        newOSK = new keyman.views.InlinedOSKView(keyman, keyman.config.hostDevice);
+        newOSK = new keyman.views.InlinedOSKView(keyman, { device: targetDevice });
         newOSK.setSize('300px', '150px');  // Or pick whatever size you want, however you want it.
         document.getElementById('KeymanWebControl').appendChild(newOSK.element);
         keyman.osk = newOSK;
-        newOSK.activeKeyboard = keyman.core.activeKeyboard;
         document.getElementById('ta1').focus();
       }
 


### PR DESCRIPTION
Looks like I somehow missed fixing this manual test page fully during the ES-module work, but at least it's just a simple fix that's required.

@keymanapp-test-bot skip