### PR TITLE
fix(web): re-establishes web srcmap uploading

### DIFF
--- a/web/ci.sh
+++ b/web/ci.sh
@@ -52,7 +52,7 @@ function web_sentry_upload () {
 
   pushd "$ARTIFACT_FOLDER"
   echo "Uploading to Sentry..."
-  npm run sentry-cli -- releases files "$SENTRY_RELEASE_VERSION" upload-sourcemaps --strip-common-prefix "@keymanapp/keyman/" --rewrite --ext js --ext map --ext ts || fail "Sentry upload failed."
+  npm run sentry-cli -- releases files "$VERSION_GIT_TAG" upload-sourcemaps --strip-common-prefix "@keymanapp/keyman/" --rewrite --ext js --ext map --ext ts || fail "Sentry upload failed."
   echo "Upload successful."
   popd
 }

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -52,7 +52,7 @@ function web_sentry_upload () {
 
   pushd "$ARTIFACT_FOLDER"
   echo "Uploading to Sentry..."
-  npm run sentry-cli -- releases files "$VERSION_GIT_TAG" upload-sourcemaps --strip-common-prefix "@keymanapp/keyman/" --rewrite --ext js --ext map --ext ts || fail "Sentry upload failed."
+  sentry-cli releases files "$VERSION_GIT_TAG" upload-sourcemaps --strip-common-prefix "@keymanapp/keyman/" --rewrite --ext js --ext map --ext ts || fail "Sentry upload failed."
   echo "Upload successful."
   popd
 }


### PR DESCRIPTION
Fixes #9176.

So, I'd disabled the Sentry sourcemap-uploads a bit before ES module work took place during 17.0-alpha in #7474.  It's been that way since then for 17.0 alpha, but 16.0 alpha still did proper sourcemap-uploading.

This PR seeks to re-establish that uploading so we can get nice stacktraces in our Sentry reports again.

@keymanapp-test-bot skip