### PR TITLE
chore(linux): Update docker builds

### DIFF
--- a/docs/build/linux-ubuntu.md
+++ b/docs/build/linux-ubuntu.md
@@ -92,10 +92,8 @@ docker run -it --rm -v $(pwd)/..:/home/build -v $(pwd)/build/linux:/home/build/c
 
 ```shell
 # build 'linux' installation in docker
-# runs as root!
-# note: run 'git clean -fdx linux' afterwards to cleanup
 cd keymanapp/keyman
-docker run -it --rm -v $(pwd):/home/build/src/keyman -u root -w /home/build/src/keyman keymanapp/keyman-linux-builder:latest bash -c "linux/build.sh --debug build install"
+docker run -it --rm -v $(pwd):/home/build/src/keyman -w /home/build/src/keyman keymanapp/keyman-linux-builder:latest bash -c "DESTDIR=. linux/build.sh --debug build install"
 ```
 
 ## Keyman for Android

--- a/docs/build/linux-ubuntu.md
+++ b/docs/build/linux-ubuntu.md
@@ -71,7 +71,7 @@ The Docker builder allows you to perform a linux build from anywhere Docker is s
 To build the docker image:
 
 ```shell
-cd ../../linux
+cd linux
 docker pull ubuntu:latest
 docker build . -t keymanapp/keyman-linux-builder:latest
 ```
@@ -85,7 +85,7 @@ Once the image is built, it may be used to build parts of Keyman.
 cd ../core
 # keep linux build artifacts separate
 mkdir -p build/linux
-docker run -it --rm -v $(pwd)/..:/home/build -v $(pwd)/build/linux:/home/build/core/build keyman-linux-builder:latest bash -c 'cd core; bash build.sh -d'
+docker run -it --rm -v $(pwd)/..:/home/build -v $(pwd)/build/linux:/home/build/core/build keymanapp/keyman-linux-builder:latest bash -c 'core/build.sh --debug'
 ```
 
 - linux
@@ -95,7 +95,7 @@ docker run -it --rm -v $(pwd)/..:/home/build -v $(pwd)/build/linux:/home/build/c
 # runs as root!
 # note: run 'git clean -fdx linux' afterwards to cleanup
 cd keymanapp/keyman
-docker run -it --rm -v $(pwd):/home/build/src/keyman -u root -w /home/build/src/keyman keymanapp/keyman-linux-builder:latest bash -c "cd linux && make reconf && make fullbuild && make install"
+docker run -it --rm -v $(pwd):/home/build/src/keyman -u root -w /home/build/src/keyman keymanapp/keyman-linux-builder:latest bash -c "linux/build.sh --debug build install"
 ```
 
 ## Keyman for Android

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -14,13 +14,20 @@ ENV HOME /home/build
 VOLUME /home/build
 WORKDIR /home/build
 ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_PRIORITY critical
+ENV DEBCONF_NOWARNINGS yes
+
 # Update to the latest
-RUN apt-get -q -y update && apt-get -q -y upgrade
-RUN apt-get -q -y install devscripts equivs meson python3 python3-setuptools
+RUN apt-get -q -y update &&  \
+  apt-get -q -y install devscripts equivs meson python3 python3-setuptools software-properties-common && \
+  add-apt-repository ppa:keymanapp/keyman && \
+  add-apt-repository ppa:keymanapp/keyman-alpha && \
+  apt-get -q -y upgrade
+
 ADD debian/control /tmp/control
 # Answer 'yes' to install questions
 RUN (yes | mk-build-deps --install /tmp/control) || true
-# now, switch to build user
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
 RUN apt-get -q -y install nodejs
+# now, switch to build user
 USER build


### PR DESCRIPTION
- add keyman ppa and update to patched ibus
- install nodejs 18
- update documentation

Note that there are still missing dependencies for building Core according to the documentation. See #8913.

@keymanapp-test-bot skip