### PR TITLE
chore(linux): Allow to run tests without integration tests

### DIFF
--- a/linux/ibus-keyman/build.sh
+++ b/linux/ibus-keyman/build.sh
@@ -19,7 +19,8 @@ builder_describe \
   "test" \
   "install                   install artifacts" \
   "uninstall                 uninstall artifacts" \
-  "@/core:arch"
+  "@/core:arch" \
+  "--no-integration          don't run integration tests"
 
 builder_parse "$@"
 
@@ -59,7 +60,11 @@ fi
 
 if builder_start_action test; then
   cd "$THIS_SCRIPT_PATH/$MESON_PATH"
-  meson test --print-errorlogs $builder_verbose
+  if builder_has_option --no-integration; then
+    meson test --print-errorlogs $builder_verbose keymanutil-tests print-kmpdetails-test print-kmp-test
+  else
+    meson test --print-errorlogs $builder_verbose
+  fi
   builder_finish_action success test
 fi
 


### PR DESCRIPTION
This will allow to run the integration tests on TC separately with lower priority.

@keymanapp-test-bot skip