### PR TITLE
fix(web): sentry sourcemapping round 2 - yesterday's 'fix' unfortunately doesn't upload the maps

### DIFF
--- a/web/ci.sh
+++ b/web/ci.sh
@@ -43,12 +43,12 @@ TIER=`cat ../TIER.md`
 BUILD_NUMBER=`cat ../VERSION.md`
 
 function web_sentry_upload () {
-  echo "Uploading $ARTIFACT_FOLDER to Sentry..."
+  echo "Uploading $1 to Sentry..."
 
   # The "$ARTIFACT_FOLDER" bit is being used as the path to the sourcemaps.
   # --strip-common-prefix does not take an argument, unlike --strip-prefix.  It auto-detects
   # the most common prefix instead.
-  sentry-cli releases files "$VERSION_GIT_TAG" upload-sourcemaps --strip-common-prefix "$ARTIFACT_FOLDER" \
+  sentry-cli releases files "$VERSION_GIT_TAG" upload-sourcemaps --strip-common-prefix "$1" \
     --rewrite --ext js --ext map --ext ts
   echo "Upload successful."
 }

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -43,14 +43,7 @@ TIER=`cat ../TIER.md`
 BUILD_NUMBER=`cat ../VERSION.md`
 
 function web_sentry_upload () {
-  if [ $1 = "webview" ]; then
-    # There is no "publish" version for app/webview; it's "published" inside our mobile apps.
-    ARTIFACT_FOLDER="$KEYMAN_ROOT/web/build/app/webview/release/"
-  elif [ $1 = "browser" ]; then
-    ARTIFACT_FOLDER="$KEYMAN_ROOT/web/build/publish/release/"
-  fi
-
-  echo "Uploading $(builder_term app/$1) ($ARTIFACT_FOLDER) to Sentry..."
+  echo "Uploading $ARTIFACT_FOLDER to Sentry..."
 
   # The "$ARTIFACT_FOLDER" bit is being used as the path to the sourcemaps.
   # --strip-common-prefix does not take an argument, unlike --strip-prefix.  It auto-detects
@@ -71,8 +64,12 @@ if builder_start_action build; then
   # - --ci:       For app/browser, outputs 'release' config filesize profiling logs
   ./build.sh configure clean build --ci
 
-  web_sentry_upload webview
-  web_sentry_upload browser
+  # Upload the sentry-configuration engine used by the mobile apps to sentry
+  web_sentry_upload "$KEYMAN_ROOT/common/web/sentry-manager/build/lib/"
+
+  # And, of course, the main build-products too
+  web_sentry_upload "$KEYMAN_ROOT/web/build/app/webview/release/"
+  web_sentry_upload "$KEYMAN_ROOT/web/build/publish/release/"
 
   builder_finish_action success build
 fi

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -50,11 +50,14 @@ function web_sentry_upload () {
     ARTIFACT_FOLDER="$KEYMAN_ROOT/web/build/publish/release/"
   fi
 
-  pushd "$ARTIFACT_FOLDER"
-  echo "Uploading to Sentry..."
-  sentry-cli releases files "$VERSION_GIT_TAG" upload-sourcemaps --strip-common-prefix "@keymanapp/keyman/" --rewrite --ext js --ext map --ext ts || fail "Sentry upload failed."
+  echo "Uploading $(builder_term app/$1) ($ARTIFACT_FOLDER) to Sentry..."
+
+  # The "$ARTIFACT_FOLDER" bit is being used as the path to the sourcemaps.
+  # --strip-common-prefix does not take an argument, unlike --strip-prefix.  It auto-detects
+  # the most common prefix instead.
+  sentry-cli releases files "$VERSION_GIT_TAG" upload-sourcemaps --strip-common-prefix "$ARTIFACT_FOLDER" \
+    --rewrite --ext js --ext map --ext ts
   echo "Upload successful."
-  popd
 }
 
 if builder_start_action build; then

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -45,7 +45,6 @@ BUILD_NUMBER=`cat ../VERSION.md`
 function web_sentry_upload () {
   echo "Uploading $1 to Sentry..."
 
-  # The "$ARTIFACT_FOLDER" bit is being used as the path to the sourcemaps.
   # --strip-common-prefix does not take an argument, unlike --strip-prefix.  It auto-detects
   # the most common prefix instead.
   sentry-cli releases files "$VERSION_GIT_TAG" upload-sourcemaps --strip-common-prefix "$1" \


### PR DESCRIPTION
Went to double-check that everything was patched up after #9179... and it's a good thing I did.  Long story short, 

> ```
>   > Bundled 0 files for upload
> ```

So... we ran the tool, but it didn't actually upload anything.  🤦  We obviously want to upload a couple of things, hence round 2 here.

That's from the CI build logs:

```
00:59:24 
  Source Map Upload Report
00:59:24 
  Upload successful.
00:59:24 
  /c/BuildAgent/work/99b311828f4ee7c/keyman/web
00:59:24 
  /c/BuildAgent/work/99b311828f4ee7c/keyman/web/build/publish/release /c/BuildAgent/work/99b311828f4ee7c/keyman/web
00:59:24 
  Uploading to Sentry...
00:59:25 
  > Rewriting sources
00:59:25 
  > Adding source map references
00:59:25 
  > Bundled 0 files for upload
00:59:25 
  > Uploaded release files to Sentry
00:59:25 
  > File processing complete
00:59:25 
  > Organization: keyman
00:59:25 
  > Project: keyman-web
00:59:25 
  > Release: release@17.0.134-alpha-test
00:59:25 
  > Dist: None
00:59:25 
  
00:59:25 
  Source Map Upload Report
```

@keymanapp-test-bot skip