### PR TITLE
chore(web): normalizes sourcemap paths for cleaner Sentry reports

### DIFF
--- a/common/web/sentry-manager/build-bundler.js
+++ b/common/web/sentry-manager/build-bundler.js
@@ -17,5 +17,6 @@ await esbuild.build({
   },
   outfile: 'build/lib/index.js',
   target: "es5",
-  tsconfig: './src/tsconfig.json'
+  tsconfig: './src/tsconfig.json',
+  sourceRoot: '@keymanapp/keyman/common/web/sentry-manager/build/lib/'
 });

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -65,6 +65,10 @@ if builder_start_action build; then
   ./build.sh configure clean build --ci
 
   # Upload the sentry-configuration engine used by the mobile apps to sentry
+  # Also, clean 'em first.
+  for sourcemap in "$KEYMAN_ROOT/common/web/sentry-manager/build/lib/"*.map; do
+    node "$KEYMAN_ROOT/web/build/tools/building/sourcemap-root/index.js" null "$sourcemap" --clean
+  done
   web_sentry_upload "$KEYMAN_ROOT/common/web/sentry-manager/build/lib/"
 
   # And, of course, the main build-products too

--- a/web/common.inc.sh
+++ b/web/common.inc.sh
@@ -42,7 +42,7 @@ function _copy_dir_if_exists() {
 }
 
 # Copies top-level build artifacts into common 'debug' and 'release' config folders
-# for use in publishing.
+# for use in publishing and does a normalization pass on the sourcemaps.
 function prepare() {
   local CHILD_BUILD_ROOT="$KEYMAN_ROOT/web/build/app"
   local PUBLISH_BUILD_ROOT="$KEYMAN_ROOT/web/build/publish"
@@ -58,6 +58,15 @@ function prepare() {
 
   _copy_dir_if_exists "$CHILD_BUILD_ROOT/ui/debug"    "$PUBLISH_BUILD_ROOT/debug"
   _copy_dir_if_exists "$CHILD_BUILD_ROOT/ui/release"  "$PUBLISH_BUILD_ROOT/release"
+
+  # Normalize paths in the sourcemaps
+  for sourcemap in "$PUBLISH_BUILD_ROOT/debug/"*.map; do
+    node "$KEYMAN_ROOT/web/build/tools/building/sourcemap-root/index.js" null "$sourcemap" --clean
+  done
+
+  for sourcemap in "$PUBLISH_BUILD_ROOT/release/"*.map; do
+    node "$KEYMAN_ROOT/web/build/tools/building/sourcemap-root/index.js" null "$sourcemap" --clean
+  done
 }
 
 # Runs all headless tests corresponding to the specified target.

--- a/web/src/app/browser/build.sh
+++ b/web/src/app/browser/build.sh
@@ -18,6 +18,7 @@ cd "$THIS_SCRIPT_PATH"
 builder_describe "Builds the Keyman Engine for Web's website-integrating version for use in non-puppeted browsers." \
   "@/web/src/engine/attachment build" \
   "@/web/src/engine/main build" \
+  "@/web/src/tools/building/sourcemap-root" \
   "clean" \
   "configure" \
   "build" \

--- a/web/src/app/ui/build.sh
+++ b/web/src/app/ui/build.sh
@@ -17,6 +17,7 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_describe "Builds the Keyman Engine for Web's desktop form-factor keyboard selection modules." \
   "@/web/src/app/browser build" \
+  "@/web/src/tools/building/sourcemap-root" \
   "clean" \
   "configure" \
   "build" \

--- a/web/src/app/webview/build.sh
+++ b/web/src/app/webview/build.sh
@@ -17,6 +17,7 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_describe "Builds the Keyman Engine for Web's puppetable version designed for use within WebViews." \
   "@/web/src/engine/main build" \
+  "@/web/src/tools/building/sourcemap-root" \
   "clean" \
   "configure" \
   "build" \
@@ -44,6 +45,15 @@ compile_and_copy() {
 
   mkdir -p "$KEYMAN_ROOT/web/build/app/resources/osk"
   cp -R "$KEYMAN_ROOT/web/src/resources/osk/." "$KEYMAN_ROOT/web/build/app/resources/osk/"
+
+  # Clean the sourcemaps of .. and . components
+  for sourcemap in "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME/debug/"*.map; do
+    node "$KEYMAN_ROOT/web/build/tools/building/sourcemap-root/index.js" null "$sourcemap" --clean
+  done
+
+  for sourcemap in "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME/release/"*.map; do
+    node "$KEYMAN_ROOT/web/build/tools/building/sourcemap-root/index.js" null "$sourcemap" --clean
+  done
 
   # For dependent test pages.
   "$KEYMAN_ROOT/web/src/test/manual/embed/android-harness/build.sh"

--- a/web/src/tools/building/sourcemap-root/index.ts
+++ b/web/src/tools/building/sourcemap-root/index.ts
@@ -75,16 +75,9 @@ for(let procArgIndex = 4; procArgIndex < process.argv.length; procArgIndex++) {
 let srcMap = SourcemapRemapper.fromFile(destFile);
 
 if(shouldClean) {
-  // First pass:  remove any closure prepended ../../../ pathing.
-  srcMap.remapPaths([
-    { from: "../../../", to: "" }
-  ]);
-
-  // Second pass:  fix up any mangled source paths
-  srcMap.remapPaths([
-    { from: "common/web/input-processor/build/keyman/", to: "" },
-    { from: "common/web/keyboard-processor/build/keyman/", to: "" }
-  ]);
+  // Keeps "@keymanapp/keyman" as sourceRoot, but prepends all `sources` entries with
+  // the remainder / suffix of sourceRoot and normalizes the paths.
+  srcMap.normalizeWithSourceRoot('@keymanapp/keyman/'.length);
 }
 
 if(sourceRoot) {


### PR DESCRIPTION
As noted in #9199, from 
https://keyman.sentry.io/share/issue/3f6a18ac8a3d403c9636709278172b25/ ...

![image](https://github.com/keymanapp/keyman/assets/25213402/775b3e0e-a359-468d-9f82-c5f4aebf7a6c)

The sourcemap `sources` entries are not normalized by Sentry when prepending the `sourceRoot`.  We still get linkage to the original repo source without it, but a little elbow grease and pre-normalization can make the stack-trace paths simpler to read.

@keymanapp-test-bot skip