### PR TITLE
chore(ios): minor build-script cleanup

### DIFF
--- a/ios/build.sh
+++ b/ios/build.sh
@@ -24,7 +24,6 @@ builder_describe "Builds Keyman Engine and the Keyman app for use on iOS devices
   ":sample1=Samples/KMSample1   Builds the first KeymanEngine sample app" \
   ":sample2=Samples/KMSample2   Builds the second KeymanEngine sample app" \
   ":fv=../oem/firstvoices/ios   Builds OEM FirstVoices for iOS platforms" \
-  "--debug+                     Avoids codesigning and adds full sourcemaps for the embedded predictive-text engine" \
   "--sim-artifact+              Also outputs a simulator-friendly test artifact corresponding to the build"
 
 builder_parse "$@"

--- a/ios/engine/build.sh
+++ b/ios/engine/build.sh
@@ -22,7 +22,6 @@ builder_describe "Builds Keyman Engine for use on iOS devices - iPhone and iPad.
   "clean" \
   "configure" \
   "build" \
-  "--debug         Avoids codesigning and adds full sourcemaps for the embedded predictive-text engine" \
   "--sim-artifact  Also outputs a simulator-friendly test artifact corresponding to the build"
 
 builder_parse "$@"

--- a/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
+++ b/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
@@ -205,8 +205,8 @@
 		16A9229D20325253003CC98E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Keyman/Info.plist; sourceTree = SOURCE_ROOT; };
 		293EA3E027059C6900545EED /* ha */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ha; path = ha.lproj/Localizable.strings; sourceTree = "<group>"; };
 		294914742738DF7700400732 /* ff-NG */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ff-NG"; path = "ff-NG.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		298566B829802828004ACA95 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		297810FD297FA818007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Localizable.strings; sourceTree = "<group>"; };
+		298566B829802828004ACA95 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		298566C42980C493004ACA95 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		298566D02980D354004ACA95 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		298566DC2980E416004ACA95 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -994,7 +994,7 @@
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
+			shellPath = "/usr/bin/env bash";
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --config ../../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		CE7E13D8240E285800252C00 /* Run Script - set versions */ = {
@@ -1030,7 +1030,7 @@
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
+			shellPath = "/usr/bin/env bash";
 			shellScript = ". \"$KEYMAN_ROOT/resources/build/xcode-utils.sh\"\n\n# Calls resource script to update build products' versioning.\nphaseSetBundleVersions\n";
 			showEnvVarsInLog = 0;
 		};

--- a/ios/keyman/build.sh
+++ b/ios/keyman/build.sh
@@ -20,7 +20,6 @@ builder_describe "Builds Keyman Engine and the Keyman app for use on iOS devices
   "clean" \
   "configure" \
   "build" \
-  "--debug         Avoids codesigning and adds full sourcemaps for the embedded predictive-text engine" \
   "--sim-artifact  Also outputs a simulator-friendly test artifact corresponding to the build"
 
 builder_parse "$@"

--- a/ios/samples/KMSample1/build.sh
+++ b/ios/samples/KMSample1/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"

--- a/ios/samples/KMSample2/build.sh
+++ b/ios/samples/KMSample2/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"

--- a/ios/samples/common.inc.sh
+++ b/ios/samples/common.inc.sh
@@ -40,10 +40,10 @@ function execute_sample_build() {
     CONFIG="Debug"
   fi
 
-  local BUILD_FOLDER="$KEYMAN_ROOT/ios/samples/$TARGET/build"
+  local BUILD_FOLDER="ios/samples/$TARGET/build"
 
   builder_describe_outputs \
-    build  "$BUILD_FOLDER"
+    build  "/$BUILD_FOLDER"
 
   ### START OF THE BUILD ###
 
@@ -51,6 +51,6 @@ function execute_sample_build() {
   KEYMAN_ENGINE_FRAMEWORK_SRC="$KEYMAN_ROOT/ios/build/Build/Products/$CONFIG/KeymanEngine.xcframework"
   KEYMAN_ENGINE_FRAMEWORK_DST=./
 
-  builder_run_action clean     rm -rf "$BUILD_FOLDER"
+  builder_run_action clean     rm -rf "$KEYMAN_ROOT/$BUILD_FOLDER"
   builder_run_action build     do_build
 }


### PR DESCRIPTION
Just a few fixes for odds and ends I ran into with the new script format after it landed.

1.  Looks like I do need to remove the custom `--debug` definition after all; it seems to be incompatible with `builder_is_debug_build` in some scenarios.
    - It wasn't propagating to the `:app` build, which failed on code signing when launched with `ios/build.sh --debug build:app`.
2. Found a few missing `#/usr/bin/env bash` headers, and also a few spots it was missing within the Xcode project setup
3. Fixed the sample-app builds not properly detecting their build outputs upon completion.

@keymanapp-test-bot skip