### PR TITLE
fix(web): silences low-priority warning that shows up in iOS kbd init

### DIFF
--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -582,6 +582,11 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
 
     if(!hasDimensions) {
       // If dimensions haven't been set yet, we have no basis for layout calculations.
+      // We do not emit a warning here; if we did, at the time of writing this, we'd
+      // consistently get Sentry events from the Keyman mobile apps.
+      //
+      // See #9206 & https://github.com/keymanapp/keyman/pull/9206#issuecomment-1627917615
+      // for context and history.
       return;
     }
 

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -596,12 +596,12 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
       const parent = this._Box.parentElement as HTMLElement;
       this._computedWidth  = this.width.val  * (this.width.absolute  ? 1 : parent.offsetWidth);
       this._computedHeight = this.height.val * (this.height.absolute ? 1 : parent.offsetHeight);
-    } else if(!hasDimensions) {
-      // Cannot perform layout operations!
-      console.warn("Unable to properly perform layout - size specifications have not yet been set.");
+    } else if(hasDimensions) {
+      console.warn("Unable to properly perform layout - specification uses a relative spec, thus relies upon insertion into the DOM for layout.");
       return;
     } else {
-      console.warn("Unable to properly perform layout - specification uses a relative spec, thus relies upon insertion into the DOM for layout.");
+      // We may hit this point during certain control flows while establishing the OSK;
+      // it has been observed to happen during the Keyman for iOS keyboard init with some regularity.
       return;
     }
 

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -579,7 +579,13 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
 
     // Step 1:  have the necessary conditions been met?
     const hasDimensions = this.width && this.height;
-    const fixedSize = hasDimensions && this.width.absolute && this.height.absolute;
+
+    if(!hasDimensions) {
+      // If dimensions haven't been set yet, we have no basis for layout calculations.
+      return;
+    }
+
+    const fixedSize = this.width.absolute && this.height.absolute;
     const computedStyle = getComputedStyle(this._Box);
     const isInDOM = computedStyle.height != '' && computedStyle.height != 'auto';
 
@@ -587,7 +593,7 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
     if(fixedSize) {
       this._computedWidth  = this.width.val;
       this._computedHeight = this.height.val;
-    } else if(isInDOM && hasDimensions) {
+    } else if(isInDOM) {
       // Note:  %-based auto-detect for dimensions currently has some issues; the stylesheets load
       // asynchronously, causing the format to be VERY off before the stylesheets fully load.
       //
@@ -596,12 +602,8 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
       const parent = this._Box.parentElement as HTMLElement;
       this._computedWidth  = this.width.val  * (this.width.absolute  ? 1 : parent.offsetWidth);
       this._computedHeight = this.height.val * (this.height.absolute ? 1 : parent.offsetHeight);
-    } else if(hasDimensions) {
-      console.warn("Unable to properly perform layout - specification uses a relative spec, thus relies upon insertion into the DOM for layout.");
-      return;
     } else {
-      // We may hit this point during certain control flows while establishing the OSK;
-      // it has been observed to happen during the Keyman for iOS keyboard init with some regularity.
+      console.warn("Unable to properly perform layout - specification uses a relative spec, thus relies upon insertion into the DOM for layout.");
       return;
     }
 


### PR DESCRIPTION
The warning being silenced here is on a pathway being called by some aspect of the iOS-app's keyboard management, so we're getting a number of Sentry warnings about it.  There are a few loose calls to `setOskHeight`, and it's not clear which is responsible.

In retrospect... the case for this warning is 'standard enough' - if the OSK-consumer hasn't spec'd size, they should at least try to handle that first, even without a warning.

@keymanapp-test-bot skip