### PR TITLE
chore(linux): Add support for `--no-integration` flag to build files

### DIFF
--- a/linux/build.sh
+++ b/linux/build.sh
@@ -22,7 +22,8 @@ builder_describe \
   "build" \
   "test" \
   "install                   install artifacts" \
-  "uninstall                 uninstall artifacts"
+  "uninstall                 uninstall artifacts" \
+  "--no-integration+         don't run integration tests"
 
 builder_parse "$@"
 

--- a/linux/keyman-config/build.sh
+++ b/linux/keyman-config/build.sh
@@ -16,6 +16,7 @@ builder_describe \
   "test" \
   "install                   install artifacts" \
   "uninstall                 uninstall artifacts" \
+  "--no-integration          don't run integration tests"
 
 builder_parse "$@"
 

--- a/linux/keyman-system-service/build.sh
+++ b/linux/keyman-system-service/build.sh
@@ -16,7 +16,8 @@ builder_describe \
   "build" \
   "test" \
   "install                   install artifacts" \
-  "uninstall                 uninstall artifacts"
+  "uninstall                 uninstall artifacts" \
+  "--no-integration          don't run integration tests"
 
 builder_parse "$@"
 


### PR DESCRIPTION
This allows to use the `linux/build.sh` file to specify the `--no-integration` flag which makes it easier to specify jobs on CI because CI then doesn't need to know all subprojects.

@keymanapp-test-bot skip