### PR TITLE
chore(linux): Add unit tests for dconf_util.py

### DIFF
--- a/linux/keyman-config/keyman_config/dconf_util.py
+++ b/linux/keyman-config/keyman_config/dconf_util.py
@@ -15,7 +15,7 @@ def get_child_schema(info):
     if not path.endswith('/'):
         path += '/'
     path += info['packageID'] + '/' + info['keyboardID'] + '/'
-    return Gio.Settings(GSETTINGS_BASE + '.child', path)
+    return Gio.Settings(f'{GSETTINGS_BASE}.child', path)
 
 
 def get_option(info):
@@ -51,11 +51,8 @@ def set_option(info, options):
             key and values to store
     """
     if "packageID" in info and "keyboardID" in info and options:
-        # Convert dictionary of options into a list of comma-separated option strings
-        list_options = []
-        for key, value in options.items():
-            list_options.append(key + "=" + value)
-
+        # Convert dictionary of options into a list of option strings
+        list_options = [f"{key}={value}" for key, value in options.items()]
         child_schema = get_child_schema(info)
         child_schema.set_strv("options", list_options)
 

--- a/linux/keyman-config/run-tests.sh
+++ b/linux/keyman-config/run-tests.sh
@@ -4,6 +4,10 @@ PYTHONPATH=.:$PYTHONPATH
 XDG_CONFIG_HOME=$(mktemp --directory)
 export XDG_CONFIG_HOME
 
+if [ -f /usr/libexec/ibus-memconf ]; then
+  export GSETTINGS_BACKEND=keyfile
+fi
+
 if [ -n "$TEAMCITY_VERSION" ]; then
     if ! pip3 list --format=columns | grep -q teamcity-messages; then
         pip3 install teamcity-messages

--- a/linux/keyman-config/tests/test_dconf_util.py
+++ b/linux/keyman-config/tests/test_dconf_util.py
@@ -13,21 +13,26 @@ class TestKeymanOptions(unittest.TestCase):
         # Reset the GSettings to its original state
         self.settings.reset("options")
 
+    def test_get_option_no_info(self):
+        # Test getting options with invalid info
+        options = get_option({})
+        self.assertEqual(options, {})
+
     def test_get_option_invalid_info(self):
         # Test getting options with invalid info
-        info = {"packageID": "invalid", "keyboardID": "invalid"}
+        info = {"packageID": "", "keyboardID": ""}
         options = get_option(info)
         self.assertEqual(options, {})
 
     def test_get_option_valid_info(self):
         # Test getting options with valid info
-        info = {"packageID": "sil_cipher_music", "keyboardID": "sil_cipher_music"}
+        info = {"packageID": "foo", "keyboardID": "bar"}
         options = get_option(info)
         self.assertIsInstance(options, dict)
 
     def test_set_option(self):
         # Test setting options
-        info = {"packageID": "sil_cipher_music", "keyboardID": "sil_cipher_music"}
+        info = {"packageID": "foo", "keyboardID": "bar"}
         options = {"set_nfc": "1"}
         set_option(info, options)
         retrieved_options = get_option(info)

--- a/linux/keyman-config/tests/test_dconf_util.py
+++ b/linux/keyman-config/tests/test_dconf_util.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+import unittest
+from gi.repository import Gio
+
+from keyman_config.dconf_util import get_option, set_option, GSETTINGS_BASE
+
+
+class TestKeymanOptions(unittest.TestCase):
+    def setUp(self):
+        self.settings = Gio.Settings.new(GSETTINGS_BASE)
+
+    def tearDown(self):
+        # Reset the GSettings to its original state
+        self.settings.reset("options")
+
+    def test_get_option_invalid_info(self):
+        # Test getting options with invalid info
+        info = {"packageID": "invalid", "keyboardID": "invalid"}
+        options = get_option(info)
+        self.assertEqual(options, {})
+
+    def test_get_option_valid_info(self):
+        # Test getting options with valid info
+        info = {"packageID": "sil_cipher_music", "keyboardID": "sil_cipher_music"}
+        options = get_option(info)
+        self.assertIsInstance(options, dict)
+
+    def test_set_option(self):
+        # Test setting options
+        info = {"packageID": "sil_cipher_music", "keyboardID": "sil_cipher_music"}
+        options = {"set_nfc": "1"}
+        set_option(info, options)
+        retrieved_options = get_option(info)
+        self.assertEqual(retrieved_options, options)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Tests were generated by ChatGPT (although it didn't get it quite right - was missing the parameter in `self.settings.reset`). It basically converted the test code from `__main__` into tests.

@keymanapp-test-bot skip