### PR TITLE
feat(web): logs enhanced debug info for error reports

### DIFF
--- a/common/web/keyboard-processor/src/keyboards/keyboard.ts
+++ b/common/web/keyboard-processor/src/keyboards/keyboard.ts
@@ -331,6 +331,10 @@ export default class Keyboard {
     return kbd && ((kbd['KS'] && kbd['KS'] == 1) || kbd['KN'] == 'Hieroglyphic');
   }
 
+  get version(): string {
+    return this.scriptObject['KBVER'] || '';
+  }
+
   usesDesktopLayoutOnDevice(device: DeviceSpec) {
     if(this.scriptObject['KVKL']) {
       // A custom mobile layout is defined... but are we using it?

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -2,7 +2,7 @@ import { type Keyboard, KeyboardKeymanGlobal, ProcessorInitOptions } from "@keym
 import { DOMKeyboardLoader as KeyboardLoader } from "@keymanapp/keyboard-processor/dom-keyboard-loader";
 import { InputProcessor, PredictionContext } from "@keymanapp/input-processor";
 import { OSKView } from "keyman/engine/osk";
-import { KeyboardRequisitioner, ModelCache, ModelSpec } from "keyman/engine/package-cache";
+import { KeyboardRequisitioner, ModelCache, ModelSpec, toUnprefixedKeyboardId as unprefixed } from "keyman/engine/package-cache";
 
 import { EngineConfiguration, InitOptionSpec } from "./engineConfiguration.js";
 import KeyboardInterface from "./keyboardInterface.js";
@@ -310,12 +310,22 @@ export default class KeymanEngine<
   }
 
   public getDebugInfo(): Record<string, any> {
+    const activeKbd = this.contextManager.activeKeyboard;
+
     const report = {
-      configReport: this.config.debugReport()
-      // oskType / oskReport?
-      // - mode
-      // - dimensions
-      // other possible entries?
+      configReport: this.config.debugReport(),
+      keyboard: {
+        id: unprefixed(activeKbd.metadata.id),
+        langId: activeKbd?.metadata.langId || '',
+        version: activeKbd?.keyboard.version
+      },
+      model: {
+        id: this.core.activeModel?.id || ''
+      },
+      osk: {
+        banner: this.osk?.bannerController.activeType,
+        layer: this.osk?.vkbd?.layerId || ''
+      }
     };
 
     return report;

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -310,20 +310,20 @@ export default class KeymanEngine<
   }
 
   public getDebugInfo(): Record<string, any> {
-    const activeKbd = this.contextManager.activeKeyboard;
+    const activeKbd = this.contextManager?.activeKeyboard;
 
     const report = {
-      configReport: this.config.debugReport(),
+      configReport: this.config?.debugReport(),
       keyboard: {
-        id: unprefixed(activeKbd.metadata.id),
-        langId: activeKbd?.metadata.langId || '',
-        version: activeKbd?.keyboard.version
+        id: unprefixed(activeKbd?.metadata?.id ?? ''),
+        langId: activeKbd?.metadata?.langId || '',
+        version: activeKbd?.keyboard?.version ?? ''
       },
       model: {
-        id: this.core.activeModel?.id || ''
+        id: this.core?.activeModel?.id || ''
       },
       osk: {
-        banner: this.osk?.bannerController.activeType,
+        banner: this.osk?.bannerController?.activeType ?? '',
         layer: this.osk?.vkbd?.layerId || ''
       }
     };


### PR DESCRIPTION
Fixes #8738.

This PR seeks to add additional metadata about the engine-state for logged errors and events:
- the id and version of the active keyboard
- the id of the active model
- the current layer of the OSK

----

Example report with the new enhancements:

![image](https://github.com/keymanapp/keyman/assets/25213402/252c804d-a3bd-4c78-aaf7-70ac94af0c29)

```
{
  "configReport": {
    "hostDevice": {
      "browser": "safari",
      "formFactor": "phone",
      "OS": "ios",
      "touchable": true
    },
    "initialized": true,
    "attachType": "auto",
    "ui": "",
    "keymanEngine": "app/browser"
  },
  "keyboard": {
    "id": "us",
    "langId": "en",
    "version": ""
  },
  "model": {
    "id": "nrc.en.mtnt"
  },
  "osk": {
    "banner": "suggestion",
    "layer": "shift"
  }
}
```

The test-page `us` keyboard actually _doesn't_ have a `KBVER` entry, hence the blank `version` field.

Round 2:  same 'test device', different keyboard

![image](https://github.com/keymanapp/keyman/assets/25213402/88a34426-de70-4781-8fd3-5a2b1685c8e8)

```
{
  "configReport": {
    "hostDevice": {
      "browser": "safari",
      "formFactor": "phone",
      "OS": "ios",
      "touchable": true
    },
    "initialized": true,
    "attachType": "auto",
    "ui": "",
    "keymanEngine": "app/browser"
  },
  "keyboard": {
    "id": "khmer_angkor",
    "langId": "km",
    "version": "1.3"
  },
  "model": {
    "id": ""
  },
  "osk": {
    "banner": "blank",
    "layer": "numeric"
  }
}
```

@keymanapp-test-bot skip