### PR TITLE
feat(core): implement reorder  🙀

### DIFF
--- a/core/src/ldml/ldml_transforms.cpp
+++ b/core/src/ldml/ldml_transforms.cpp
@@ -18,12 +18,12 @@ namespace km {
 namespace kbp {
 namespace ldml {
 
-element::element(const USet &u, KMX_DWORD flags)
-    : chr(), uset(u), flags((flags & ~LDML_ELEM_FLAGS_TYPE) | LDML_ELEM_FLAGS_TYPE_USET) {
+element::element(const USet &new_u, KMX_DWORD new_flags)
+    : chr(), uset(new_u), flags((new_flags & ~LDML_ELEM_FLAGS_TYPE) | LDML_ELEM_FLAGS_TYPE_USET) {
 }
 
-element::element(km_kbp_usv ch, KMX_DWORD flags)
-    : chr(ch), uset(), flags((flags & ~LDML_ELEM_FLAGS_TYPE) | LDML_ELEM_FLAGS_TYPE_CHAR) {
+element::element(km_kbp_usv ch, KMX_DWORD new_flags)
+    : chr(ch), uset(), flags((new_flags & ~LDML_ELEM_FLAGS_TYPE) | LDML_ELEM_FLAGS_TYPE_CHAR) {
 }
 
 bool
@@ -158,9 +158,9 @@ element_list::update_sort_key(size_t offset, std::deque<reorder_sort_key> &key) 
   return key;
 }
 
-reorder_entry::reorder_entry(const element_list &elements) : elements(elements), before() {
+reorder_entry::reorder_entry(const element_list &new_elements) : elements(new_elements), before() {
 }
-reorder_entry::reorder_entry(const element_list &elements, const element_list &before) : elements(elements), before(before) {
+reorder_entry::reorder_entry(const element_list &new_elements, const element_list &new_before) : elements(new_elements), before(new_before) {
 }
 
 size_t

--- a/core/src/ldml/ldml_transforms.cpp
+++ b/core/src/ldml/ldml_transforms.cpp
@@ -101,10 +101,8 @@ reorder_sort_key::from(const std::u32string &str) {
   std::deque<reorder_sort_key> keylist;
   auto s   = str.begin();  // str iterator
   size_t c = 0;            // str index
-  for (auto e = str.begin(); e < str.end(); e++) {
+  for (auto e = str.begin(); e < str.end(); e++, s++, c++) {
     keylist.emplace_back(reorder_sort_key{*s, 0, c, 0, c});
-    s++;
-    c++;
   }
   return keylist;
 }
@@ -239,12 +237,11 @@ reorder_group::apply(std::u32string &str) const {
   // recombine into a str
   std::u32string newSuffix;
   size_t q = sort_keys.begin()->quaternary;  //
-  for (auto e = sort_keys.begin(); e < sort_keys.end(); e++) {
+  for (auto e = sort_keys.begin(); e < sort_keys.end(); e++, q++) {
     if (q != e->quaternary) {                // something rearranged in this subrange
       applied = true;
     }
     newSuffix.append(1, e->ch);
-    q++;  // TODO: use this to check if reorder happened.
   }
   if (applied) {
     // DebugLog("Final Sort");

--- a/core/src/ldml/ldml_transforms.cpp
+++ b/core/src/ldml/ldml_transforms.cpp
@@ -16,8 +16,8 @@ namespace km {
 namespace kbp {
 namespace ldml {
 
-
-element::element(const USet &u, KMX_DWORD flags) : str(), uset(u), flags(flags) {
+element::element(const USet &u, KMX_DWORD flags)
+    : str(), uset(u), flags((flags & ~LDML_ELEM_FLAGS_TYPE) | LDML_ELEM_FLAGS_TYPE_USET) {
 }
 
 element::element(const std::u16string &s, KMX_DWORD flags) : str(s), uset(), flags(flags) {
@@ -25,6 +25,19 @@ element::element(const std::u16string &s, KMX_DWORD flags) : str(s), uset(), fla
 
 bool element::is_uset() const {
   return (flags & LDML_ELEM_FLAGS_TYPE) == LDML_ELEM_FLAGS_TYPE_USET;
+}
+
+KMX_DWORD element::get_order() const {
+  return ((flags & LDML_ELEM_FLAGS_ORDER_MASK) >> LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+}
+
+KMX_DWORD element::get_flags() const {
+  return flags;
+}
+
+reorder_entry::reorder_entry(const element_list &elements) : elements(elements), before() {
+}
+reorder_entry::reorder_entry(const element_list &elements, const element_list &before) : elements(elements), before(before) {
 }
 
 transform_entry::transform_entry(const std::u16string &from, const std::u16string &to) : fFrom(from), fTo(to) {

--- a/core/src/ldml/ldml_transforms.cpp
+++ b/core/src/ldml/ldml_transforms.cpp
@@ -45,12 +45,12 @@ element::get_tertiary() const {
 
 bool
 element::is_prebase() const {
-  return flags & LDML_ELEM_FLAGS_PREBASE;
+  return !!(flags & LDML_ELEM_FLAGS_PREBASE);
 }
 
 bool
 element::is_tertiary_base() const {
-  return flags & LDML_ELEM_FLAGS_TERTIARY_BASE;
+  return !!(flags & LDML_ELEM_FLAGS_TERTIARY_BASE);
 }
 
 KMX_DWORD
@@ -96,7 +96,7 @@ reorder_sort_key::compare(const reorder_sort_key &other) const {
 
 bool
 reorder_sort_key::operator<(const reorder_sort_key &other) const {
-  return (compare(other) == -1);
+  return (compare(other) < 0);
 }
 
 std::deque<reorder_sort_key>
@@ -129,7 +129,7 @@ element_list::match_end(const std::u32string &str) const {
   auto s = str.rbegin();
   // e: end to front on elements.
   // we know the # of elements is <= length of string,
-  // so we dont' need to check the string's boundaries
+  // so we don't need to check the string's boundaries
   for (auto e = rbegin(); e < rend(); e++) {
     assert(s < str.rend()); // double check
     if (!e->matches(*s)) {

--- a/core/src/ldml/ldml_transforms.cpp
+++ b/core/src/ldml/ldml_transforms.cpp
@@ -69,28 +69,23 @@ element::matches(km_kbp_usv ch) const {
 
 int
 reorder_sort_key::compare(const reorder_sort_key &other) const {
-  if (primary < other.primary) {
-    return -1;
-  } else if (primary > other.primary) {
-    return 1;
-  } else if (secondary < other.secondary) {
-    return -1;
-  } else if (secondary > other.secondary) {
-    return 1;
-  } else if (tertiary < other.tertiary) {
-    return -1;
-  } else if (tertiary > other.tertiary) {
-    return 1;
-  } else if (quaternary < other.quaternary) {
-    return -1;
-  } else if (quaternary > other.quaternary) {
-    return 1;
-  } else if (ch < other.ch) {  // tiebreak with char value
-    return -1;
-  } else if (ch > other.ch) {
-    return 1;
+  int primaryResult    = (int)primary    - (int)other.primary;
+  int secondaryResult  = (int)secondary  - (int)other.secondary;
+  int tertiaryResult   = (int)tertiary   - (int)other.tertiary;
+  int quaternaryResult = (int)quaternary - (int)other.quaternary;
+
+  if (primaryResult) {
+    return primaryResult;
+  } else if (secondaryResult) {
+    return secondaryResult;
+  } else if (tertiaryResult) {
+    return tertiaryResult;
+  } else if (quaternaryResult) {
+    return quaternaryResult;
   } else {
-    return 0;  // identical
+    assert(quaternaryResult);  // quaternary is a string index, should always be !=
+    int identityResult = (int)ch - (int)other.ch;  // tie breaker
+    return identityResult;
   }
 }
 

--- a/core/src/ldml/ldml_transforms.hpp
+++ b/core/src/ldml/ldml_transforms.hpp
@@ -7,13 +7,12 @@
 
 #pragma once
 
+#include "kmx/kmx_plus.h"
 #include <deque>
 #include <map>
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include "kmx/kmx_plus.h"
-
 
 namespace km {
 namespace kbp {
@@ -23,7 +22,7 @@ using km::kbp::kmx::USet;
 
 /**
  * Type of a group
-*/
+ */
 enum any_group_type {
   transform = LDML_TRAN_GROUP_TYPE_REORDER,
   reorder   = LDML_TRAN_GROUP_TYPE_REORDER,
@@ -31,36 +30,35 @@ enum any_group_type {
 
 /**
  * Corresponds to an 'elem' entry
-*/
+ */
 class element {
-  public:
-    /** from a USet */
-    element(const USet &u, KMX_DWORD flags);
-    /** from a single char */
-    element(km_kbp_usv ch, KMX_DWORD flags);
+public:
+  /** from a USet */
+  element(const USet &u, KMX_DWORD flags);
+  /** from a single char */
+  element(km_kbp_usv ch, KMX_DWORD flags);
 
+  /** @returns true if a USet type */
+  bool is_uset() const;
+  bool is_prebase() const;
+  bool is_tertiary_base() const;
+  signed char get_tertiary() const;
+  signed char get_order() const;
+  /** @returns raw elem flags */
+  KMX_DWORD get_flags() const;
+  /** @returns true if matches this character*/
+  bool matches(km_kbp_usv ch) const;
 
-    /** @returns true if a USet type */
-    bool is_uset() const;
-    bool is_prebase() const;
-    bool is_tertiary_base() const;
-    signed char get_tertiary() const;
-    signed char get_order() const;
-    /** @returns raw elem flags */
-    KMX_DWORD get_flags() const;
-    /** @returns true if matches this character*/
-    bool matches(km_kbp_usv ch) const;
-
-  private:
-    // TODO-LDML: support multi-char strings
-    const km_kbp_usv     chr;
-    const USet           uset;
-    const KMX_DWORD      flags;
+private:
+  // TODO-LDML: support multi-char strings
+  const km_kbp_usv chr;
+  const USet uset;
+  const KMX_DWORD flags;
 };
 
 /**
  * Inner element, representing <transform>
-*/
+ */
 class transform_entry {
 public:
   transform_entry(
@@ -71,12 +69,12 @@ public:
 
   /**
    * @returns length if it's a match
-  */
+   */
   size_t match(const std::u16string &input) const;
 
   /**
    * @returns output string
-  */
+   */
   std::u16string apply(const std::u16string &input, size_t matchLen) const;
 
 private:
@@ -93,91 +91,106 @@ typedef std::deque<std::u16string> string_list;
  * a group of <transform> entries - a <transformGroup>
  */
 class transform_group : public std::deque<transform_entry> {
-  public:
-    transform_group();
+public:
+  transform_group();
 
-    /**
-     * Find the first match in the group
-     * @param input input string to match
-     * @param subMatched on output, the matched length
-     * @returns alias to transform_entry or nullptr
-    */
-    const transform_entry *match(const std::u16string &input, size_t &subMatched) const;
+  /**
+   * Find the first match in the group
+   * @param input input string to match
+   * @param subMatched on output, the matched length
+   * @returns alias to transform_entry or nullptr
+   */
+  const transform_entry *match(const std::u16string &input, size_t &subMatched) const;
 };
 
 /** a single char, categorized according to reorder rules*/
 struct reorder_sort_key {
-    km_kbp_usv ch;           // the single char value
-    signed char primary;     // primary order value
-    size_t secondary;        // index position
-    signed char tertiary;    // tertiary value, defaults to 0
-    size_t quaternary;       // index again
+  km_kbp_usv ch;         // the single char value
+  signed char primary;   // primary order value
+  size_t secondary;      // index position
+  signed char tertiary;  // tertiary value, defaults to 0
+  size_t quaternary;     // index again
 
-    int compare(const reorder_sort_key &other) const;
-    bool operator<(const reorder_sort_key &other) const;
+  /**
+   * Return -1, 0, 1 depending on order
+  */
+  int compare(const reorder_sort_key &other) const;
+  bool operator<(const reorder_sort_key &other) const;
 
-    /** create a 'baseline' sort key */
-    static std::deque<reorder_sort_key> from(const std::u32string &str);
+  /** create a 'baseline' sort key, all 0 primary weights */
+  static std::deque<reorder_sort_key> from(const std::u32string &str);
+
+  /** TODO-LDML: for debugging. */
+  void dump() const;
 };
 
 /**
- * List of elements. Subclassed to provide match.
-*/
+ * List of elements.
+ */
 class element_list : public std::deque<element> {
-  public:
-    /** @returns 0 if no match, or number of chars at end matched */
-    size_t match_end(const std::u32string& str) const;
-    /** now just for testing */
-    std::deque<reorder_sort_key> get_sort_key(const std::u32string& str) const;
+public:
+  /** @returns 0 if no match, or number of chars at end matched */
+  size_t match_end(const std::u32string &str) const;
 
-    std::deque<reorder_sort_key> &
-    update_sort_key(size_t offset, const std::u32string &str, std::deque<reorder_sort_key> &key) const;
+  /**
+   * Update the deque (see reorder_sort_key::from()) with the weights from this element list
+   * starting at the beginning of this element list
+   * @param offset start at this offset in the deque. Still starts at the first element
+   * @param the key deque to update
+   * @returns the key parameter
+  */
+  std::deque<reorder_sort_key> &update_sort_key(size_t offset, std::deque<reorder_sort_key> &key) const;
 };
 
 class reorder_entry {
-  public:
-    reorder_entry(const element_list& elements);
-    reorder_entry(const element_list& elements, const element_list& before);
-    bool apply(std::u32string &str) const;
-    /**
-     * @param str string to match
-     * @param offset start matching at this offset
-     * @return 0 if no match otherwise length matched
-     */
-    size_t match_end(std::u32string &str, size_t offset) const;
+public:
+  /** construct an entry from elements */
+  reorder_entry(const element_list &elements);
+  /** construct an element from elements and before */
+  reorder_entry(const element_list &elements, const element_list &before);
+  /**
+   * Does it match?
+   * @param str string to match
+   * @param offset start matching at this offset
+   * @return 0 if no match otherwise length matched
+   */
+  size_t match_end(std::u32string &str, size_t offset, size_t len) const;
 
-  public:
-    element_list elements;
-    element_list before;
+public:
+  element_list elements;
+  element_list before;
 };
 
+/** a list of entries, such as in a group */
 typedef std::deque<reorder_entry> reorder_list;
 
+/** subtype that's a list of reorders */
 struct reorder_group {
-  public:
-    reorder_list list;
-    bool apply(std::u32string &str) const;
+public:
+  reorder_list list;
+  /** apply this reordering. Return true if changed. */
+  bool apply(std::u32string &str) const;
 };
 
+/** container for either a transform or a reorder group */
 class any_group {
-  public:
-    any_group(const transform_group& g);
-    any_group(const reorder_group& g);
-    any_group_type type; // transform or reorder
-    transform_group transform;
-    reorder_group reorder;
+public:
+  any_group(const transform_group &g);
+  any_group(const reorder_group &g);
+  any_group_type type;  // transform or reorder
+  transform_group transform;
+  reorder_group reorder;
 };
 
 /**
- * A list of groups
-*/
+ * A list of any_groups
+ */
 typedef std::deque<any_group> group_list;
 
 /**
  * This represents an entire <transforms> element
  */
 class transforms {
-
 private:
   group_list transform_groups;
 
@@ -187,11 +200,11 @@ public:
   /**
    * Add a transform group
    */
-  void addGroup(const transform_group& s);
+  void addGroup(const transform_group &s);
   /**
    * Add a reorder group
    */
-  void addGroup(const reorder_group& s);
+  void addGroup(const reorder_group &s);
 
   /**
    * Attempt to match and apply a pattern change.
@@ -205,21 +218,18 @@ public:
   /**
    * For tests
    * @return true if str was altered
-  */
+   */
   bool apply(std::u16string &str);
 
   /**
    * For tests - TODO-LDML only supports reorder
    * @return true if str was altered
-  */
+   */
   bool apply(std::u32string &str);
 
 public:
   static transforms *
-  load(
-    const kmx::kmx_plus &kplus,
-    const kbp::kmx::COMP_KMXPLUS_TRAN *tran,
-    const kbp::kmx::COMP_KMXPLUS_TRAN_Helper &tranHelper);
+  load(const kmx::kmx_plus &kplus, const kbp::kmx::COMP_KMXPLUS_TRAN *tran, const kbp::kmx::COMP_KMXPLUS_TRAN_Helper &tranHelper);
 };
 /**
  * Loader for transform groups (from tran or bksp)

--- a/core/src/ldml/ldml_transforms.hpp
+++ b/core/src/ldml/ldml_transforms.hpp
@@ -38,8 +38,9 @@ class element {
     element(const std::u16string &s, KMX_DWORD flags);
 
     // TODO-LDML: getters that interpret flags
-
     bool is_uset() const;
+    KMX_DWORD get_order() const;
+    KMX_DWORD get_flags() const;
 
   private:
     const std::u16string str;
@@ -98,8 +99,11 @@ typedef std::deque<element> element_list;
 
 class reorder_entry {
   public:
-    element_list before;
+    reorder_entry(const element_list& elements);
+    reorder_entry(const element_list& elements, const element_list& before);
+  public:
     element_list elements;
+    element_list before;
 };
 
 typedef std::deque<reorder_entry> reorder_list;

--- a/core/src/ldml/ldml_transforms.hpp
+++ b/core/src/ldml/ldml_transforms.hpp
@@ -39,7 +39,7 @@ class element {
     /** from a single char */
     element(km_kbp_usv ch, KMX_DWORD flags);
 
-  
+
     /** @returns true if a USet type */
     bool is_uset() const;
     bool is_prebase() const;
@@ -115,6 +115,9 @@ struct reorder_sort_key {
 
     int compare(const reorder_sort_key &other) const;
     bool operator<(const reorder_sort_key &other) const;
+
+    /** create a 'baseline' sort key */
+    static std::deque<reorder_sort_key> from(const std::u32string &str);
 };
 
 /**
@@ -124,7 +127,11 @@ class element_list : public std::deque<element> {
   public:
     /** @returns 0 if no match, or number of chars at end matched */
     size_t match_end(const std::u32string& str) const;
+    /** now just for testing */
     std::deque<reorder_sort_key> get_sort_key(const std::u32string& str) const;
+
+    std::deque<reorder_sort_key> &
+    update_sort_key(size_t offset, const std::u32string &str, std::deque<reorder_sort_key> &key) const;
 };
 
 class reorder_entry {
@@ -132,6 +139,12 @@ class reorder_entry {
     reorder_entry(const element_list& elements);
     reorder_entry(const element_list& elements, const element_list& before);
     bool apply(std::u32string &str) const;
+    /**
+     * @param str string to match
+     * @param offset start matching at this offset
+     * @return 0 if no match otherwise length matched
+     */
+    size_t match_end(std::u32string &str, size_t offset) const;
 
   public:
     element_list elements;

--- a/core/tests/unit/ldml/test_transforms.cpp
+++ b/core/tests/unit/ldml/test_transforms.cpp
@@ -290,6 +290,7 @@ test_reorder_standalone() {
       element_list e2;
       e2.emplace_back(toneMarks, 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
       rg.list.emplace_back(e2);
+
       // <reorder before="\u1A6B" from="\u1A60\u1A45" order="10" />
       element_list e3;
       e3.emplace_back(U'\u1A60', 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
@@ -306,6 +307,7 @@ test_reorder_standalone() {
       e4before.emplace_back(U'\u1A6B', 0);
       e4before.emplace_back(toneMarks, 0);
       rg.list.emplace_back(e4, e4before);
+
       // <reorder before="\u1A6B" from="\u1A60[\u1A75-\u1A79]\u1A45" order="10 55 10" />
       element_list e5;
       e5.emplace_back(U'\u1A60', 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);

--- a/core/tests/unit/ldml/test_transforms.cpp
+++ b/core/tests/unit/ldml/test_transforms.cpp
@@ -1,39 +1,46 @@
-#include <test_assert.h>
+#include "../../../src/ldml/ldml_transforms.hpp"
 #include "kmx/kmx_plus.h"
 #include "kmx/kmx_xstring.h"
-#include "../../../src/ldml/ldml_transforms.hpp"
 #include <iostream>
 #include <string>
+#include <test_assert.h>
 
 // TODO-LDML: normal asserts wern't working, so using some hacks.
-//#include "ldml_test_utils.hpp"
+// #include "ldml_test_utils.hpp"
 // #include <test_assert.h>
-//#include "debuglog.h"
+// #include "debuglog.h"
 
 #ifndef zassert_string_equal
-#define zassert_string_equal(actual, expected) { if (actual != expected) { std::cerr << __FILE__ << ":" << __LINE__ << ": " << "got: " << actual << " expected " << expected << std::endl; return EXIT_FAILURE; }}
+#define zassert_string_equal(actual, expected)                                 \
+  {                                                                            \
+    if (actual != expected) {                                                  \
+      std::cerr << __FILE__ << ":" << __LINE__ << ": "                         \
+                << "got: " << actual << " expected " << expected << std::endl; \
+      return EXIT_FAILURE;                                                     \
+    }                                                                          \
+  }
 #endif
 
 #ifndef zassert_equal
-#define zassert_equal(actual, expected) zassert_string_equal(actual,expected)
+#define zassert_equal(actual, expected) zassert_string_equal(actual, expected)
 #endif
 
 // needed for streaming operators
 #include "utfcodec.hpp"
 
-
 using namespace km::kbp::ldml;
 using namespace km::kbp::kmx;
 
-//using km::kbp::kmx::u16cmp;
+// using km::kbp::kmx::u16cmp;
 
-int test_transforms() {
+int
+test_transforms() {
   std::cout << "== " << __FUNCTION__ << std::endl;
 
   std::cout << __FILE__ << ":" << __LINE__ << " - basic " << std::endl;
   {
     // start with one
-    transform_entry te(std::u16string(u"e^"), std::u16string(u"E")); // keep it simple
+    transform_entry te(std::u16string(u"e^"), std::u16string(u"E"));  // keep it simple
     // OK now make a group do it
     transforms tr;
     transform_group st;
@@ -47,7 +54,7 @@ int test_transforms() {
       std::u16string src(u"barQ^");
       bool res = tr.apply(src);
       zassert_equal(res, false);
-      zassert_string_equal(src, std::u16string(u"barQ^")); // no change
+      zassert_string_equal(src, std::u16string(u"barQ^"));  // no change
     }
 
     {
@@ -139,44 +146,110 @@ int test_transforms() {
   return EXIT_SUCCESS;
 }
 
-int test_reorder_standalone() {
+int
+test_reorder_standalone() {
   std::cout << "== " << __FUNCTION__ << std::endl;
 
   std::cout << __FILE__ << ":" << __LINE__ << " - nod-Lana " << std::endl;
   {
     const std::u16string roasts[] = {
-      // from the spec
-      u"\u1A21\u1A60\u1A45\u1A6B\u1A76", // 'ideal'
-      u"\u1A21\u1A6B\u1A76\u1A60\u1A45", // vowel first
-      u"\u1A21\u1A6B\u1A60\u1A76\u1A45", // vowel first, NFC
-      u"\u1A21\u1A6B\u1A60\u1A45\u1A76", // tone after lower
+        // from the spec
+        u"\u1A21\u1A60\u1A45\u1A6B\u1A76",  // 'ideal'
+        u"\u1A21\u1A6B\u1A76\u1A60\u1A45",  // vowel first
+        u"\u1A21\u1A6B\u1A60\u1A76\u1A45",  // vowel first, NFC
+        u"\u1A21\u1A6B\u1A60\u1A45\u1A76",  // tone after lower
     };
+    /** we expect this is what comes out the other side */
     const std::u16string expect = roasts[0];
-    /*
-          <!-- from the spec: nod-Lana for ᩅᩫ᩶  -->
-      <reorder from="\u1A60" order="127" />
-      <reorder from="\u1A6B" order="42" />
-      <reorder from="[\u1A75-\u1A79]" order="55" />
-      <reorder before="\u1A6B" from="\u1A60\u1A45" order="10" />
-      <reorder before="\u1A6B[\u1A75-\u1A79]" from="\u1A60\u1A45" order="10" />
-      <reorder before="\u1A6B" from="\u1A60[\u1A75-\u1A79]\u1A45" order="10 55 10" />
-    */
-   // now setup the rules
-    const COMP_KMXPLUS_USET_RANGE ranges[] = {
-      // 0
-      {0x1A75, 0x1A79}
-    };
-    const COMP_KMXPLUS_USET_USET usets[] = {
-      {
-        0, 1, 0xFFFFFFFF
-      }
-    };
+    // now setup the rules
+    const COMP_KMXPLUS_USET_RANGE ranges[]      = {// 0
+                                              {0x1A75, 0x1A79}};
+    const COMP_KMXPLUS_USET_USET usets[]        = {{0, 1, 0xFFFFFFFF}};
     const COMP_KMXPLUS_USET_USET &toneMarksUset = usets[0];
     const USet toneMarks(&ranges[toneMarksUset.range], toneMarksUset.count);
     // validate
     assert_equal(toneMarks.contains(0x1A76), true);
     assert_equal(toneMarks.contains(0x1A60), false);
-    // TODO-LDML: build the transforms group.
+
+    // element test
+    {
+      element es(u"a", 123 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      std::cout << "es flags" << std::hex << es.get_flags() << std::dec << std::endl;
+      assert_equal(es.is_uset(), false);
+      assert_equal(es.get_order(), 123);
+      element eu(toneMarks, 43 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      std::cout << "eu flags" << std::hex << eu.get_flags() << std::dec << std::endl;
+      assert_equal(eu.is_uset(), true);
+      std::cout << "order" << eu.get_order() << std::endl;
+      assert_equal(eu.get_order(), 43);
+    }
+
+    transforms tr;
+    {
+      reorder_group rg;
+
+      // <reorder from="\u1A60" order="127" />
+      element_list e0;
+      e0.emplace_back(u"\u1A6B", 127 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      rg.list.emplace_back(e0);
+
+      // <reorder from="\u1A6B" order="42" />
+      element_list e1;
+      e1.emplace_back(u"\u1A6B", 42 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      rg.list.emplace_back(e1);
+
+      // <reorder from="[\u1A75-\u1A79]" order="55" />
+      element_list e2;
+      e2.emplace_back(toneMarks, 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      rg.list.emplace_back(e2);
+      // <reorder before="\u1A6B" from="\u1A60\u1A45" order="10" />
+      element_list e3;
+      e3.emplace_back(u"\u1A60", 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e3.emplace_back(u"\u1A45", 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      element_list e3before;
+      e3before.emplace_back(u"\u1A6B", 0);
+      rg.list.emplace_back(e3, e3before);
+
+      // <reorder before="\u1A6B[\u1A75-\u1A79]" from="\u1A60\u1A45" order="10" />
+      element_list e4;
+      e4.emplace_back(u"\u1A60", 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e4.emplace_back(u"\u1A45", 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      element_list e4before;
+      e4before.emplace_back(u"\u1A6B", 0);
+      e4before.emplace_back(toneMarks, 0);
+      rg.list.emplace_back(e4, e4before);
+      // <reorder before="\u1A6B" from="\u1A60[\u1A75-\u1A79]\u1A45" order="10 55 10" />
+      element_list e5;
+      e5.emplace_back(u"\u1A60", 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e5.emplace_back(toneMarks, 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e5.emplace_back(u"\u1A45", 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      element_list e5before;
+      e5before.emplace_back(u"\u1A6B", 0);
+      rg.list.emplace_back(e5, e5before);
+
+      tr.addGroup(rg);
+    }
+
+    // now actually test it
+    // TODO-LDML: move this into test code perhaps
+    for (int r = 0; r < std::size(roasts); r++) {
+      std::cout << __FILE__ << ":" << __LINE__ << " - trying roast #" << r << std::endl;
+      const auto &roast = roasts[r];
+      // simulate typing this one char at a time;
+      std::u16string text;
+      for (auto ch = roast.begin(); ch < roast.end(); ch++) {
+        // append the string
+        text.append(1, *ch);
+        std::cout << "-: " << text << std::endl;
+        if (!tr.apply(text)) {
+          std::cout << " (did not apply)" << std::endl;
+        }
+      }
+      // now the moment of truth
+      zassert_string_equal(text, expect);
+      std::cout << " matched!" << std::endl;
+      std::cout << std::endl;
+    }
   }
   return EXIT_SUCCESS;
 }

--- a/core/tests/unit/ldml/test_transforms.cpp
+++ b/core/tests/unit/ldml/test_transforms.cpp
@@ -152,50 +152,138 @@ test_reorder_standalone() {
 
   std::cout << __FILE__ << ":" << __LINE__ << " - nod-Lana " << std::endl;
   {
-    const std::u16string roasts[] = {
+    const std::u32string roasts[] = {
         // from the spec
-        u"\u1A21\u1A60\u1A45\u1A6B\u1A76",  // 'ideal'
-        u"\u1A21\u1A6B\u1A76\u1A60\u1A45",  // vowel first
-        u"\u1A21\u1A6B\u1A60\u1A76\u1A45",  // vowel first, NFC
-        u"\u1A21\u1A6B\u1A60\u1A45\u1A76",  // tone after lower
+        U"\u1A21\u1A60\u1A45\u1A6B\u1A76",  // 'ideal'
+        U"\u1A21\u1A6B\u1A76\u1A60\u1A45",  // vowel first
+        U"\u1A21\u1A6B\u1A60\u1A76\u1A45",  // vowel first, NFC
+        U"\u1A21\u1A6B\u1A60\u1A45\u1A76",  // tone after lower
     };
     /** we expect this is what comes out the other side */
-    const std::u16string expect = roasts[0];
+    const std::u32string expect = roasts[0];
     // now setup the rules
     const COMP_KMXPLUS_USET_RANGE ranges[]      = {// 0
                                               {0x1A75, 0x1A79}};
     const COMP_KMXPLUS_USET_USET usets[]        = {{0, 1, 0xFFFFFFFF}};
     const COMP_KMXPLUS_USET_USET &toneMarksUset = usets[0];
     const USet toneMarks(&ranges[toneMarksUset.range], toneMarksUset.count);
-    // validate
+    // validate that the range [1A75, 1A79] matches
     assert_equal(toneMarks.contains(0x1A76), true);
     assert_equal(toneMarks.contains(0x1A60), false);
 
+    std::cout << __FILE__ << ":" << __LINE__ << " - element test " << std::endl;
     // element test
     {
-      element es(u"a", 123 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      element es(U'a', 0xF4500000 | LDML_ELEM_FLAGS_PREBASE | LDML_ELEM_FLAGS_TERTIARY_BASE); // tertiary -12, primary 80
       std::cout << "es flags" << std::hex << es.get_flags() << std::dec << std::endl;
+      // verify element metadata
       assert_equal(es.is_uset(), false);
-      assert_equal(es.get_order(), 123);
-      element eu(toneMarks, 43 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      assert_equal(es.get_order(), 0x50);
+      assert_equal(es.get_tertiary(), -12);
+      assert_equal(es.is_prebase(), true);
+      assert_equal(es.is_tertiary_base(), true);
+      // verify element matching
+      assert_equal(es.matches(U'a'), true);
+      assert_equal(es.matches(U'b'), false);
+
+      element eu(toneMarks, 0x37F40000);
+      // element metadata
       std::cout << "eu flags" << std::hex << eu.get_flags() << std::dec << std::endl;
       assert_equal(eu.is_uset(), true);
-      std::cout << "order" << eu.get_order() << std::endl;
-      assert_equal(eu.get_order(), 43);
-    }
+      std::cout << "order" << (int)eu.get_order() << std::endl;
+      assert_equal(eu.get_order(), -12);
+      assert_equal(eu.get_tertiary(), 55);
+      assert_equal(eu.is_prebase(), false);
+      assert_equal(eu.is_tertiary_base(), false);
+      // element matching
+      assert_equal(eu.matches(U'a'), false);
+      assert_equal(eu.matches(U'\u1A76'), true);
+      assert_equal(eu.matches(U'\u1A75'), true);
 
+      element_list l; // '[tones]a'
+      l.emplace_back(es);
+      l.emplace_back(eu);
+
+      std::cout << __FILE__ << ":" << __LINE__ << " - list test " << std::endl;
+      assert_equal(l.match_end(U"asdfasdf"), 0); // no match
+      assert_equal(l.match_end(U"a"), 0);        // partial substring, fastpath because it's short
+      assert_equal(l.match_end(U"\u1A76"), 0);   // partial substring, fastpath because it's short
+      assert_equal(l.match_end(U"a\u1A76"), 2);  // Match
+      assert_equal(l.match_end(U"a\u1A75"), 2);  // Match
+      assert_equal(l.match_end(U"SomethingSomethingSomethinga\u1A76"), 2);  // Sub-Match
+
+      // generate sort keys
+      std::cout << __FILE__ << ":" << __LINE__ << " - get_sort_key test " << std::endl;
+      auto keylist = l.get_sort_key(U"a\u1A7A");
+      assert_equal(keylist.size(), 2);
+      size_t secondary = 0;
+      for (auto i = keylist.begin(); i < keylist.end(); i++) {
+        std::cout << " U+" << std::hex << i->ch << std::dec << " (" << (int)i->primary << "," << (int)i->secondary
+          << "," << (int)i->tertiary << "," << (int)i->quaternary << ")";
+          assert_equal(i->secondary, secondary);
+          assert_equal(i->quaternary, secondary);
+          secondary++;
+      }
+      std::cout << std::endl;
+
+      // spot check first sortkey
+      assert_equal(keylist.begin()->primary, 80);
+      assert_equal(keylist.begin()->tertiary, -12);
+      assert_equal(keylist.begin()->ch, 0x61);
+
+      // now sort them
+      std::sort(keylist.begin(), keylist.end());
+      for (auto i = keylist.begin(); i < keylist.end(); i++) {
+        std::cout << " U+" << std::hex << i->ch << std::dec << " (" << (int)i->primary << "," << (int)i->secondary
+          << "," << (int)i->tertiary << "," << (int)i->quaternary << ")";
+      }
+      std::cout << std::endl;
+      // spot check first sort key
+      assert_equal(keylist.begin()->primary, -12);
+      assert_equal(keylist.begin()->tertiary, 55);
+      assert_equal(keylist.begin()->ch, 0x1A7A);
+  }
+
+    std::cout << __FILE__ << ":" << __LINE__ << " - key test " << std::endl;
+    {
+      // can we sort an array of reorder sort keys?
+      reorder_sort_key keys0[] = {
+          {U'\u1A21', 0, 0, 0, 0},
+          {U'\u1A6B', 42, 1, 0, 1},
+          {U'\u1A76', 55, 2, 0, 2},
+          {U'\u1A60', 10, 3, 0, 3},
+          {U'\u1A45', 10, 4, 0, 3}};
+      // add it to a list
+      std::deque<reorder_sort_key> keylist;
+      for (size_t i = 0; i < std::size(keys0); i++) {
+        keylist.emplace_back(keys0[i]);
+      }
+      // now sort it
+      std::sort(keylist.begin(), keylist.end());
+      std::u32string sorted;
+      std::cout << " sorted: ";
+      for (auto i = keylist.begin(); i < keylist.end(); i++) {
+        std::cout << " U+" << std::hex << i->ch << std::dec << " (" << (int)i->primary << "," << (int)i->secondary
+          << "," << (int)i->tertiary << "," << (int)i->quaternary << ")";
+        sorted.append(1, i->ch);
+      }
+      std::cout << std::endl;
+      // did the roast come out?
+      zassert_string_equal(sorted, expect);
+    }
+    std::cout << "now prepare the reorder elements" << std::endl;
     transforms tr;
     {
       reorder_group rg;
 
       // <reorder from="\u1A60" order="127" />
       element_list e0;
-      e0.emplace_back(u"\u1A6B", 127 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e0.emplace_back(U'\u1A6B', 127 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
       rg.list.emplace_back(e0);
 
       // <reorder from="\u1A6B" order="42" />
       element_list e1;
-      e1.emplace_back(u"\u1A6B", 42 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e1.emplace_back(U'\u1A6B', 42 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
       rg.list.emplace_back(e1);
 
       // <reorder from="[\u1A75-\u1A79]" order="55" />
@@ -204,39 +292,40 @@ test_reorder_standalone() {
       rg.list.emplace_back(e2);
       // <reorder before="\u1A6B" from="\u1A60\u1A45" order="10" />
       element_list e3;
-      e3.emplace_back(u"\u1A60", 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
-      e3.emplace_back(u"\u1A45", 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e3.emplace_back(U'\u1A60', 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e3.emplace_back(U'\u1A45', 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
       element_list e3before;
-      e3before.emplace_back(u"\u1A6B", 0);
+      e3before.emplace_back(U'\u1A6B', 0);
       rg.list.emplace_back(e3, e3before);
 
       // <reorder before="\u1A6B[\u1A75-\u1A79]" from="\u1A60\u1A45" order="10" />
       element_list e4;
-      e4.emplace_back(u"\u1A60", 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
-      e4.emplace_back(u"\u1A45", 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e4.emplace_back(U'\u1A60', 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e4.emplace_back(U'\u1A45', 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
       element_list e4before;
-      e4before.emplace_back(u"\u1A6B", 0);
+      e4before.emplace_back(U'\u1A6B', 0);
       e4before.emplace_back(toneMarks, 0);
       rg.list.emplace_back(e4, e4before);
       // <reorder before="\u1A6B" from="\u1A60[\u1A75-\u1A79]\u1A45" order="10 55 10" />
       element_list e5;
-      e5.emplace_back(u"\u1A60", 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e5.emplace_back(U'\u1A60', 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
       e5.emplace_back(toneMarks, 55 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
-      e5.emplace_back(u"\u1A45", 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
+      e5.emplace_back(U'\u1A45', 10 << LDML_ELEM_FLAGS_ORDER_BITSHIFT);
       element_list e5before;
-      e5before.emplace_back(u"\u1A6B", 0);
+      e5before.emplace_back(U'\u1A6B', 0);
       rg.list.emplace_back(e5, e5before);
 
       tr.addGroup(rg);
     }
 
     // now actually test it
+    std::cout << __FILE__ << ":" << __LINE__ << " - back to nod-Lana " << std::endl;
     // TODO-LDML: move this into test code perhaps
     for (int r = 0; r < std::size(roasts); r++) {
       std::cout << __FILE__ << ":" << __LINE__ << " - trying roast #" << r << std::endl;
       const auto &roast = roasts[r];
       // simulate typing this one char at a time;
-      std::u16string text;
+      std::u32string text;
       for (auto ch = roast.begin(); ch < roast.end(); ch++) {
         // append the string
         text.append(1, *ch);

--- a/core/tests/unit/ldml/test_transforms.cpp
+++ b/core/tests/unit/ldml/test_transforms.cpp
@@ -255,7 +255,7 @@ test_reorder_standalone() {
           {U'\u1A45', 10, 4, 0, 3}};
       // add it to a list
       std::deque<reorder_sort_key> keylist;
-      for (size_t i = 0; i < std::size(keys0); i++) {
+      for (size_t i = 0; i < sizeof(keys0)/sizeof(keys0[0]); i++) {
         keylist.emplace_back(keys0[i]);
       }
       // now sort it
@@ -321,7 +321,7 @@ test_reorder_standalone() {
     // now actually test it
     std::cout << __FILE__ << ":" << __LINE__ << " - back to nod-Lana " << std::endl;
     // TODO-LDML: move this into test code perhaps
-    for (int r = 0; r < std::size(roasts); r++) {
+    for (size_t r = 0; r < sizeof(roasts)/sizeof(roasts[0]); r++) {
       std::cout << __FILE__ << ":" << __LINE__ << " - trying roast #" << r << std::endl;
       const auto &roast = roasts[r];
       // simulate typing this one char at a time;


### PR DESCRIPTION
for #9120

- this implements the algorithm, only called by unit tests right now

there are some TODOs:
- does not handle runs properly. That is, more than one cluster may be jumbled
- tertiary is not handled yet
- std::u32string call path is only called by unit tests, whereas the std::u16string call path is used by the processing code to pickup other transforms
- does not load reorders from KMX+

@keymanapp-test-bot skip