### PR TITLE
chore(developer): cleanup compiler messages in kmc 🗜

### DIFF
--- a/common/web/keyman-version/package.json
+++ b/common/web/keyman-version/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "type": "module",
   "devDependencies": {
-    "@types/node": "^18.7.13",
+    "@types/node": "^20.4.1",
     "typescript": "^4.9.5"
   }
 }

--- a/common/web/types/package.json
+++ b/common/web/types/package.json
@@ -36,7 +36,7 @@
     "@types/chai": "^4.1.7",
     "@types/git-diff": "^2.0.3",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10.14.6",
+    "@types/node": "^20.4.1",
     "@types/semver": "^7.3.12",
     "@types/xml2js": "^0.4.5",
     "c8": "^7.12.0",
@@ -60,7 +60,9 @@
   },
   "c8": {
     "all": true,
-    "src": ["src/"],
+    "src": [
+      "src/"
+    ],
     "exclude-after-remap": true,
     "exclude": [
       "src/kmx/kmx-plus-builder/",

--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -22,7 +22,7 @@ export * as Constants from './consts/virtual-key-constants.js';
 
 export { defaultCompilerOptions, CompilerBaseOptions, CompilerCallbacks, CompilerOptions, CompilerSchema, CompilerEvent, CompilerErrorNamespace,
          CompilerErrorSeverity, CompilerPathCallbacks, CompilerFileSystemCallbacks,
-         CompilerMessageSpec, compilerErrorSeverity, compilerErrorSeverityName,
+         CompilerError, CompilerMessageSpec, compilerErrorSeverity, CompilerErrorMask, CompilerFileCallbacks, compilerErrorSeverityName,
          compilerExceptionToString, compilerErrorFormatCode,
          compilerLogLevelToSeverity, CompilerLogLevel, compilerEventFormat, ALL_COMPILER_LOG_LEVELS } from './util/compiler-interfaces.js';
 export { CommonTypesMessages } from './util/common-events.js';

--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -14,57 +14,141 @@ export enum CompilerErrorSeverity {
   Warn =          0x200000, // Warning: Not great, but we can keep going.
   Error =         0x300000, // Severe error where we can't continue
   Fatal =         0x400000, // OOM or should-not-happen internal problem
-
-  // Mask values for mapping compiler errors
-  // TODO: make this a separate enum?
-  Severity_Mask =  0x00F00000,  // includes reserved bits, 16 possible severity levels
-  Error_Mask =     0x000FFFFF,  // error | namespace
-  Namespace_Mask = 0x000FF000,  // 256 possible namespaces
-  BaseError_Mask = 0x00000FFF,  // error code, 2,048 possible error codes per namespace
-  Reserved_Mask  = 0xFF000000,  // do not use these error values at this time
 };
 
-export function compilerErrorSeverity(code: number): number {
-  return code & CompilerErrorSeverity.Severity_Mask;
+/**
+ * Mask values for mapping compiler errors
+ */
+export enum CompilerErrorMask {
+  Severity =  0x00F00000,  // includes reserved bits, 16 possible severity levels
+  Error =     0x000FFFFF,  // error | namespace
+  Namespace = 0x000FF000,  // 256 possible namespaces
+  BaseError = 0x00000FFF,  // error code, 2,048 possible error codes per namespace
+  Reserved  = 0xFF000000,  // do not use these error values at this time
+};
+
+const errorSeverityName = {
+  [CompilerErrorSeverity.Info]: 'info',
+  [CompilerErrorSeverity.Hint]: 'hint',
+  [CompilerErrorSeverity.Warn]: 'warn',
+  [CompilerErrorSeverity.Error]: 'error',
+  [CompilerErrorSeverity.Fatal]: 'fatal',
+};
+
+export class CompilerError {
+  static severity(code: number): CompilerErrorSeverity {
+    return code & CompilerErrorMask.Severity;
+  }
+  static error(code: number): number {
+    return code & CompilerErrorMask.Error;
+  }
+  static baseError(code: number): number {
+    return code & CompilerErrorMask.BaseError;
+  }
+  static formatSeverity(code: number): string {
+    return errorSeverityName[CompilerError.severity(code)] ?? 'UNKNOWN';
+  }
+  /**
+   * Format an error code number. The error code number does not include
+   * the severity mask, as this is reported in text form separately; see
+   * `severityName`.
+   * @example
+   *
+   * The following call returns `KM03004`
+   * ```
+   *   formatCode(CompilerMessage.ERROR_InvalidDisplayMapFile)
+   * ```
+   */
+  static formatCode(code: number): string {
+    return 'KM' + CompilerError.error(code).toString(16).toUpperCase().padStart(5, '0');
+  }
+
+  /**
+   * Formats an event filename for an error report,
+   * stripping off path component
+   * @param filename
+   * @returns
+   */
+  static formatFilename(filename: string): string {
+    if(!filename) {
+      return '';
+    }
+
+    let x = filename.lastIndexOf('/');
+    if(x < 0) {
+      x = filename.lastIndexOf('\\');
+    }
+    return x >= 0 ? filename.substring(x+1) : filename;
+  }
+
+  /**
+   * Formats an event line for an error report
+   * @param line
+   * @returns
+   */
+  static formatLine(line: number): string {
+    return line ? line.toString() : '';
+  }
+
+  /**
+   * Formats an event message for an error report
+   * @param message
+   * @returns
+   */
+  static formatMessage(message: string): string {
+    return message ?? '';
+  }
+
+  /**
+   * Formats a compiler message, without coloring; an ANSI color version is
+   * implemented in NodeCompilerCallbacks.
+   * @param event event or array of events
+   */
+  static formatEvent(event : CompilerEvent | CompilerEvent[]): string {
+    if (!event) {
+      return "";
+    }
+    if (Array.isArray(event)) {
+      return event.map(item => CompilerError.formatEvent(item)).join('\n') + '\n';
+    }
+
+    return (
+      event.filename
+      ? CompilerError.formatFilename(event.filename) +
+        (event.line ? ':' + CompilerError.formatLine(event.line) : '') + ' - '
+      : ''
+    ) +
+    CompilerError.formatSeverity(event.code) + ' ' +
+    CompilerError.formatCode(event.code) + ': ' +
+    CompilerError.formatMessage(event.message);
+  }
+
+  /**
+   * @param e Error-like
+   */
+  static exceptionToString(e?: any) : string {
+    return `${(e ?? 'unknown error').toString()}\n\nCall stack:\n${(e instanceof Error ? e.stack : (new Error()).stack)}`;
+  }
+};
+
+/** @deprecated use `CompilerError.severity` instead */
+export function compilerErrorSeverity(code: number): CompilerErrorSeverity {
+  return CompilerError.severity(code);
 }
 
+/** @deprecated use `CompilerError.formatSeverity` instead */
 export function compilerErrorSeverityName(code: number): string {
-  switch(compilerErrorSeverity(code)) {
-    case CompilerErrorSeverity.Info: return 'INFO';
-    case CompilerErrorSeverity.Hint: return 'HINT';
-    case CompilerErrorSeverity.Warn: return 'WARN';
-    case CompilerErrorSeverity.Error: return 'ERROR';
-    case CompilerErrorSeverity.Fatal: return 'FATAL';
-    /* istanbul ignore next */
-    default: return 'UNKNOWN';
-  }
+  return CompilerError.formatSeverity(code);
 }
 
-/**
- * Format the error code number
- * example: "FATAL:0x03004"
- */
+/** @deprecated use `CompilerError.formatCode` instead */
 export function compilerErrorFormatCode(code: number): string {
-  const severity = code & CompilerErrorSeverity.Severity_Mask;
-  const severityName = compilerErrorSeverityName(severity);
-  const errorCode = code & CompilerErrorSeverity.Error_Mask;
-  const errorCodeString = Number(errorCode).toString(16).padStart(5,'0');
-  return `${severityName}:0x${errorCodeString}`;
+  return CompilerError.formatCode(code);
 }
 
-/**
- * @param e event or array of events
- * @returns string
- */
+/** @deprecated use `CompilerError.formatEvent` instead */
 export function compilerEventFormat(e : CompilerEvent | CompilerEvent[]) : string {
-  if (!e) {
-    return "";
-  }
-  if (Array.isArray(e)) {
-    return e.map(item => compilerEventFormat(item)).join('\n');
-  }
-  const {code, message} = e;
-  return `${compilerErrorFormatCode(code)}: “${message}”`;
+  return CompilerError.formatEvent(e);
 }
 
 /**
@@ -173,8 +257,45 @@ export interface CompilerCallbacks {
 
   loadSchema(schema: CompilerSchema): Uint8Array;
   reportMessage(event: CompilerEvent): void;
+
   debug(msg: string): void;
 };
+
+/**
+ * Wrapper class for CompilerCallbacks for a given input file
+ */
+export class CompilerFileCallbacks implements CompilerCallbacks {
+  constructor(private filename: string, private parent: CompilerCallbacks) {
+  }
+
+  loadFile(filename: string): Uint8Array {
+    return this.parent.loadFile(filename);
+  }
+
+  get path(): CompilerPathCallbacks {
+    return this.parent.path;
+  }
+
+  get fs(): CompilerFileSystemCallbacks {
+    return this.parent.fs;
+  }
+
+  resolveFilename(baseFilename: string, filename: string): string {
+    return this.parent.resolveFilename(baseFilename, filename);
+  }
+
+  loadSchema(schema: CompilerSchema): Uint8Array {
+    return this.parent.loadSchema(schema);
+  }
+
+  reportMessage(event: CompilerEvent): void {
+    this.parent.reportMessage({filename: this.filename, ...event});
+  }
+
+  debug(msg: string): void {
+    return this.parent.debug(msg);
+  }
+}
 
 /**
  * Abstract interface for compiler options
@@ -229,10 +350,10 @@ export const defaultCompilerOptions: CompilerOptions = {
 export const CompilerMessageSpec = (code: number, message: string) : CompilerEvent => { return { code, message } };
 
 /**
- * @param e Error-like
+ * @deprecated use `CompilerError.exceptionToString` instead
  */
 export function compilerExceptionToString(e?: any) : string {
-  return `${(e ?? 'unknown error').toString()}\n\nCall stack:\n${(e instanceof Error ? e.stack : (new Error()).stack)}`;
+  return CompilerError.exceptionToString(e);
 }
 
 /**
@@ -252,7 +373,7 @@ type CompilerLogLevelTuple = typeof ALL_COMPILER_LOG_LEVELS;
 export type CompilerLogLevel = CompilerLogLevelTuple[number];
 
 export const compilerLogLevelToSeverity: {[index in CompilerLogLevel]: number} = {
-  'silent': CompilerErrorSeverity.Severity_Mask,  // effectively excludes all reporting
+  'silent': CompilerErrorMask.Severity,  // effectively excludes all reporting
   'error': CompilerErrorSeverity.Error,
   'warn': CompilerErrorSeverity.Warn,
   'hint': CompilerErrorSeverity.Hint,

--- a/common/web/types/test/helpers/TestCompilerCallbacks.ts
+++ b/common/web/types/test/helpers/TestCompilerCallbacks.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { loadFile, loadSchema, resolveFilename } from '../helpers/index.js';
-import { CompilerCallbacks, CompilerEvent, CompilerFileSystemCallbacks, CompilerPathCallbacks, CompilerSchema } from '../../src/util/compiler-interfaces.js';
+import { CompilerCallbacks, CompilerError, CompilerEvent, CompilerFileSystemCallbacks, CompilerPathCallbacks, CompilerSchema } from '../../src/util/compiler-interfaces.js';
 
 // This is related to developer/src/common/web/test-helpers/index.ts but has a slightly different API surface
 // as this runs at a lower level than the compiler.
@@ -28,6 +28,10 @@ export class TestCompilerCallbacks implements CompilerCallbacks {
   }
   debug(msg: string): void {
     console.debug(msg);
+  }
+
+  printMessages() {
+    process.stdout.write(CompilerError.formatEvent(this.messages));
   }
 
   messages: CompilerEvent[] = [];

--- a/developer/src/common/web/test-helpers/index.ts
+++ b/developer/src/common/web/test-helpers/index.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { CompilerEvent, CompilerCallbacks, CompilerSchema, CompilerPathCallbacks, CompilerFileSystemCallbacks, compilerErrorSeverityName } from '@keymanapp/common-types';
+import { CompilerEvent, CompilerCallbacks, CompilerSchema, CompilerPathCallbacks, CompilerFileSystemCallbacks, CompilerError } from '@keymanapp/common-types';
 export { verifyCompilerMessagesObject } from './verifyCompilerMessagesObject.js';
 
 // TODO: schemas are only used by kmc-ldml for now, so this works at this
@@ -20,14 +20,7 @@ export class TestCompilerCallbacks implements CompilerCallbacks {
   }
 
   printMessages() {
-    this.messages.forEach(event => {
-      const code = event.code.toString(16);
-      if(event.line) {
-        console.log(`${compilerErrorSeverityName(event.code)} ${code} [${event.line}]: ${event.message}`);
-      } else {
-        console.log(`${compilerErrorSeverityName(event.code)} ${code}: ${event.message}`);
-      }
-    });
+    process.stdout.write(CompilerError.formatEvent(this.messages));
   }
 
   hasMessage(code: number): boolean {

--- a/developer/src/common/web/test-helpers/package.json
+++ b/developer/src/common/web/test-helpers/package.json
@@ -9,11 +9,11 @@
     "/build/"
   ],
   "devDependencies": {
-    "@types/node": "^10.14.6",
+    "@types/node": "^20.4.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.9.5"
   },
-"scripts": {
+  "scripts": {
     "build": "tsc -b"
   },
   "license": "MIT",

--- a/developer/src/common/web/test-helpers/verifyCompilerMessagesObject.ts
+++ b/developer/src/common/web/test-helpers/verifyCompilerMessagesObject.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorSeverity, compilerErrorSeverityName } from '@keymanapp/common-types';
+import { CompilerError, CompilerErrorMask } from '@keymanapp/common-types';
 import {assert, expect} from 'chai';
 
 //
@@ -56,14 +56,14 @@ export function verifyCompilerMessagesObject(source: Record<string,any>, namespa
       const o = /^(INFO|HINT|WARN|ERROR|FATAL)_([A-Za-z0-9_]+)$/.exec(key);
       expect(o).to.be.instanceOf(Array);
 
-      const mask = compilerErrorSeverityName(m[key]);
+      const mask = CompilerError.formatSeverity(m[key]).toUpperCase();
       expect(o[1]).to.equal(mask, `Mask value for ${key} does not match`);
 
-      expect(m[key] & CompilerErrorSeverity.Reserved_Mask).to.equal(0, `Constant value ${key} uses a reserved value`);
+      expect(m[key] & CompilerErrorMask.Reserved).to.equal(0, `Constant value ${key} uses a reserved value`);
 
-      const code = m[key] & CompilerErrorSeverity.Error_Mask;
+      const code = m[key] & CompilerErrorMask.Error;
       expect(codes).to.not.contain(code, `Constant value ${key} is not unique`);
-      expect(m[key] & CompilerErrorSeverity.Namespace_Mask).to.equal(namespace,
+      expect(m[key] & CompilerErrorMask.Namespace).to.equal(namespace,
         `Constant value ${key} is not in the correct namespace (0x${namespace.toString(16)})`);
       codes.push(code);
     }

--- a/developer/src/kmc-analyze/package.json
+++ b/developer/src/kmc-analyze/package.json
@@ -26,9 +26,10 @@
     "commander": "^10.0.0"
   },
   "devDependencies": {
+    "@keymanapp/resources-gosh": "*",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10.14.6",
+    "@types/node": "^20.4.1",
     "@types/xml2js": "^0.4.5",
     "c8": "^7.12.0",
     "chai": "^4.3.4",
@@ -36,8 +37,7 @@
     "esbuild": "^0.15.8",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5",
-    "@keymanapp/resources-gosh": "*"
+    "typescript": "^4.9.5"
   },
   "repository": {
     "type": "git",

--- a/developer/src/kmc-kmn/package.json
+++ b/developer/src/kmc-kmn/package.json
@@ -31,9 +31,10 @@
     "@keymanapp/kmc-kmn": "*"
   },
   "devDependencies": {
+    "@keymanapp/developer-test-helpers": "*",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10.14.6",
+    "@types/node": "^20.4.1",
     "@types/semver": "^7.3.12",
     "@types/sinon": "^10.0.13",
     "@types/sinon-chai": "^3.2.9",
@@ -45,8 +46,7 @@
     "sinon": "^15.0.2",
     "sinon-chai": "^3.7.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5",
-    "@keymanapp/developer-test-helpers": "*"
+    "typescript": "^4.9.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-ldml/package.json
+++ b/developer/src/kmc-ldml/package.json
@@ -26,8 +26,8 @@
     "url": "https://github.com/keymanapp/keyman/issues"
   },
   "dependencies": {
-    "@keymanapp/kmc-kmn": "*",
     "@keymanapp/keyman-version": "*",
+    "@keymanapp/kmc-kmn": "*",
     "@keymanapp/ldml-keyboard-constants": "*",
     "ajv": "^8.11.0",
     "restructure": "git+https://github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
@@ -35,9 +35,10 @@
     "xml2js": "git+https://github.com/keymanapp/dependency-node-xml2js#535fe732dc408d697e0f847c944cc45f0baf0829"
   },
   "devDependencies": {
+    "@keymanapp/developer-test-helpers": "*",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10.14.6",
+    "@types/node": "^20.4.1",
     "@types/semver": "^7.3.12",
     "@types/xml2js": "^0.4.5",
     "c8": "^7.12.0",
@@ -45,8 +46,7 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5",
-    "@keymanapp/developer-test-helpers": "*"
+    "typescript": "^4.9.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-model-info/package.json
+++ b/developer/src/kmc-model-info/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10.14.6",
+    "@types/node": "^20.4.1",
     "@types/xml2js": "^0.4.5",
     "c8": "^7.12.0",
     "chai": "^4.3.4",

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -31,24 +31,24 @@
     "url": "https://github.com/keymanapp/keyman/issues"
   },
   "dependencies": {
+    "@keymanapp/common-types": "*",
     "@keymanapp/keyman-version": "*",
     "@keymanapp/models-types": "*",
-    "@keymanapp/common-types": "*",
     "typescript": "^4.9.5",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {
+    "@keymanapp/developer-test-helpers": "*",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10.14.6",
+    "@types/node": "^20.4.1",
     "@types/xml2js": "^0.4.5",
     "c8": "^7.12.0",
     "chai": "^4.3.4",
     "chalk": "^2.4.2",
     "esbuild": "^0.15.7",
     "mocha": "^10.0.0",
-    "ts-node": "^10.9.1",
-    "@keymanapp/developer-test-helpers": "*"
+    "ts-node": "^10.9.1"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -30,20 +30,20 @@
     "url": "https://github.com/keymanapp/keyman/issues"
   },
   "dependencies": {
-    "jszip": "^3.7.0",
-    "@keymanapp/common-types": "*"
+    "@keymanapp/common-types": "*",
+    "jszip": "^3.7.0"
   },
   "devDependencies": {
+    "@keymanapp/developer-test-helpers": "*",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10.14.6",
+    "@types/node": "^20.4.1",
     "c8": "^7.12.0",
     "chai": "^4.3.4",
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5",
-    "@keymanapp/developer-test-helpers": "*"
+    "typescript": "^4.9.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-package/test/test-kmp-inf-writer.ts
+++ b/developer/src/kmc-package/test/test-kmp-inf-writer.ts
@@ -11,7 +11,7 @@ import { transcodeToCP1252 } from '../src/compiler/cp1252.js';
 
 describe('KmpInfWriter', function () {
   it(`should transform kmp.json to kmp.inf`, function () {
-    const data: KmpJsonFile.KmpJsonFile = JSON.parse(fs.readFileSync(makePathToFixture('kmp.inf', 'kmp.json'), 'UTF-8'));
+    const data: KmpJsonFile.KmpJsonFile = JSON.parse(fs.readFileSync(makePathToFixture('kmp.inf', 'kmp.json'), 'utf-8'));
     const writer = new KmpInfWriter(data);
     const fixtureKmpInf = fs.readFileSync(makePathToFixture('kmp.inf', 'kmp.inf'));
     const value = writer.write();

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -37,8 +37,8 @@
     "kmlmi": "build/src/kmlmi.js"
   },
   "dependencies": {
-    "@keymanapp/keyman-version": "*",
     "@keymanapp/common-types": "*",
+    "@keymanapp/keyman-version": "*",
     "@keymanapp/kmc-analyze": "*",
     "@keymanapp/kmc-kmn": "*",
     "@keymanapp/kmc-ldml": "*",
@@ -46,7 +46,9 @@
     "@keymanapp/kmc-model-info": "*",
     "@keymanapp/kmc-package": "*",
     "@keymanapp/models-types": "*",
-    "commander": "^10.0.0"
+    "chalk": "^2.4.2",
+    "commander": "^10.0.0",
+    "supports-color": "^9.4.0"
   },
   "files": [
     "build/src/"
@@ -54,11 +56,10 @@
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10.14.6",
+    "@types/node": "^20.4.1",
     "@types/xml2js": "^0.4.5",
     "c8": "^7.12.0",
     "chai": "^4.3.4",
-    "chalk": "^2.4.2",
     "esbuild": "^0.15.8",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",

--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -87,9 +87,15 @@ async function build(filename: string, parentCallbacks: NodeCompilerCallbacks, o
     let result = await builder.build(filename, callbacks, options);
     const firstFailureMessage = parentCallbacks.messages.find(m => failureCodes.includes(m.code & CompilerErrorMask.Severity));
     if(result && firstFailureMessage == undefined) {
-      callbacks.reportMessage(InfrastructureMessages.Info_FileBuiltSuccessfully({filename}));
+      callbacks.reportMessage(builder instanceof BuildProject
+        ? InfrastructureMessages.Info_ProjectBuiltSuccessfully({filename})
+        : InfrastructureMessages.Info_FileBuiltSuccessfully({filename})
+      );
     } else {
-      callbacks.reportMessage(InfrastructureMessages.Info_FileNotBuiltSuccessfully({filename}));
+      callbacks.reportMessage(builder instanceof BuildProject
+        ? InfrastructureMessages.Info_ProjectNotBuiltSuccessfully({filename})
+        : InfrastructureMessages.Info_FileNotBuiltSuccessfully({filename})
+      );
     }
 
     return result;

--- a/developer/src/kmc/src/messages/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/messages/NodeCompilerCallbacks.ts
@@ -1,19 +1,23 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { CompilerCallbacks, CompilerSchema, CompilerEvent, compilerErrorSeverity,
-         compilerErrorSeverityName, CompilerPathCallbacks, CompilerFileSystemCallbacks,
-         CompilerLogLevel, compilerLogLevelToSeverity } from '@keymanapp/common-types';
+import { CompilerCallbacks, CompilerSchema, CompilerEvent,
+         CompilerPathCallbacks, CompilerFileSystemCallbacks,
+         CompilerLogLevel, compilerLogLevelToSeverity, CompilerErrorSeverity,
+         CompilerError } from '@keymanapp/common-types';
 import { InfrastructureMessages } from './messages.js';
-
+import chalk from 'chalk';
+import supportsColor from 'supports-color';
 /**
  * Concrete implementation for CLI use
  */
 
-// TODO: Make a common class for all the CompilerCallbacks implementations
+const color = chalk.default;
 
+export  enum CompilerLogColor { default, no, force };
 
 export interface CompilerCallbackOptions {
   logLevel?: CompilerLogLevel;
+  color?: CompilerLogColor;
 }
 
 export class NodeCompilerCallbacks implements CompilerCallbacks {
@@ -72,19 +76,69 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
   }
 
   reportMessage(event: CompilerEvent): void {
-    this.messages.push(event);
+    this.messages.push({...event});
 
-    if(compilerErrorSeverity(event.code) < compilerLogLevelToSeverity[this.options.logLevel]) {
+    if(CompilerError.severity(event.code) < compilerLogLevelToSeverity[this.options.logLevel]) {
       // collect messages but don't print to console
       return;
     }
 
-    const code = event.code.toString(16);
-    if(event.line) {
-      console.log(`${compilerErrorSeverityName(event.code)} ${code} [${event.line}]: ${event.message}`);
-    } else {
-      console.log(`${compilerErrorSeverityName(event.code)} ${code}: ${event.message}`);
+    switch(this.options.color) {
+    case CompilerLogColor.default:
+      color.enabled = supportsColor.stdout ? supportsColor.stdout.hasBasic : false;
+      break;
+    case CompilerLogColor.no:
+      color.enabled = false;
+      break;
+    case CompilerLogColor.force:
+      color.enabled = true;
+      break;
     }
+
+    const colors: {[value in CompilerErrorSeverity]: chalk.Chalk} = {
+      [CompilerErrorSeverity.Info]: color.reset,
+      [CompilerErrorSeverity.Hint]: color.blueBright,
+      [CompilerErrorSeverity.Warn]: color.yellowBright,
+      [CompilerErrorSeverity.Error]: color.redBright,
+      [CompilerErrorSeverity.Fatal]: color.redBright,
+    };
+
+    const severityColor = colors[CompilerError.severity(event.code)] ?? color.reset;
+    const lineColor = this.messageSpecialColor(event) ?? color.reset;
+    process.stdout.write(
+      (
+        event.filename
+        ? color.cyan(CompilerError.formatFilename(event.filename)) +
+          (event.line ? ':' + color.yellowBright(CompilerError.formatLine(event.line)) : '') + ' - '
+        : ''
+      ) +
+      severityColor(CompilerError.formatSeverity(event.code)) + ' ' +
+      color.grey(CompilerError.formatCode(event.code)) + ': ' +
+      lineColor(CompilerError.formatMessage(event.message)) + '\n'
+    );
+
+    if(event.code == InfrastructureMessages.INFO_FileBuiltSuccessfully && (event.filename.endsWith('.kpj') || path.extname(event.filename) == '')) {
+      // Special case: we'll add a blank line after project builds
+      process.stdout.write('\n');
+    }
+
+  }
+
+  /**
+   * We treat a few certain infrastructure messages with special colours
+   * @param event
+   * @returns
+   */
+  messageSpecialColor(event: CompilerEvent) {
+    switch(event.code) {
+      case InfrastructureMessages.INFO_BuildingFile:
+        return color.whiteBright;
+      case InfrastructureMessages.INFO_FileNotBuiltSuccessfully:
+        return color.red;
+      case InfrastructureMessages.INFO_FileBuiltSuccessfully:
+        return color.green;
+    }
+    return null;
   }
 
   debug(msg: string) {

--- a/developer/src/kmc/src/messages/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/messages/NodeCompilerCallbacks.ts
@@ -104,7 +104,7 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
     };
 
     const severityColor = colors[CompilerError.severity(event.code)] ?? color.reset;
-    const lineColor = this.messageSpecialColor(event) ?? color.reset;
+    const messageColor = this.messageSpecialColor(event) ?? color.reset;
     process.stdout.write(
       (
         event.filename
@@ -114,10 +114,10 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
       ) +
       severityColor(CompilerError.formatSeverity(event.code)) + ' ' +
       color.grey(CompilerError.formatCode(event.code)) + ': ' +
-      lineColor(CompilerError.formatMessage(event.message)) + '\n'
+      messageColor(CompilerError.formatMessage(event.message)) + '\n'
     );
 
-    if(event.code == InfrastructureMessages.INFO_FileBuiltSuccessfully && (event.filename.endsWith('.kpj') || path.extname(event.filename) == '')) {
+    if(event.code == InfrastructureMessages.INFO_ProjectBuiltSuccessfully) {
       // Special case: we'll add a blank line after project builds
       process.stdout.write('\n');
     }
@@ -134,8 +134,10 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
       case InfrastructureMessages.INFO_BuildingFile:
         return color.whiteBright;
       case InfrastructureMessages.INFO_FileNotBuiltSuccessfully:
+      case InfrastructureMessages.INFO_ProjectNotBuiltSuccessfully:
         return color.red;
       case InfrastructureMessages.INFO_FileBuiltSuccessfully:
+      case InfrastructureMessages.INFO_ProjectBuiltSuccessfully:
         return color.green;
     }
     return null;

--- a/developer/src/kmc/src/messages/messages.ts
+++ b/developer/src/kmc/src/messages/messages.ts
@@ -12,8 +12,9 @@ export class InfrastructureMessages {
     `Unexpected exception: ${(o.e ?? 'unknown error').toString()}\n\nCall stack:\n${(o.e instanceof Error ? o.e.stack : (new Error()).stack)}`);
   static FATAL_UnexpectedException = SevFatal | 0x0001;
 
-  static Info_BuildingFile = (o:{filename:string}) => m(this.INFO_BuildingFile,
-    `Building ${o.filename}`);
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static Info_BuildingFile = (o:{filename:string}) => ({filename:o.filename, ...m(this.INFO_BuildingFile,
+    `Building ${o.filename}`)});
   static INFO_BuildingFile = SevInfo | 0x0002;
 
   static Error_FileDoesNotExist = (o:{filename:string}) => m(this.ERROR_FileDoesNotExist,
@@ -28,12 +29,14 @@ export class InfrastructureMessages {
     `--out-file should not be specified for project builds`);
   static ERROR_OutFileNotValidForProjects = SevError | 0x0005;
 
-  static Info_FileBuiltSuccessfully = (o:{filename:string}) => m(this.INFO_FileBuiltSuccessfully,
-    `${o.filename} built successfully.`);
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static Info_FileBuiltSuccessfully = (o:{filename:string}) => ({filename:o.filename, ...m(this.INFO_FileBuiltSuccessfully,
+    `${o.filename} built successfully.`)});
   static INFO_FileBuiltSuccessfully = SevInfo | 0x0006;
 
-  static Info_FileNotBuiltSuccessfully = (o:{filename:string}) => m(this.INFO_FileNotBuiltSuccessfully,
-    `${o.filename} failed to build.`);
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static Info_FileNotBuiltSuccessfully = (o:{filename:string}) => ({filename:o.filename, ...m(this.INFO_FileNotBuiltSuccessfully,
+    `${o.filename} failed to build.`)});
   static INFO_FileNotBuiltSuccessfully = SevInfo | 0x0007;
 
   static Error_InvalidProjectFile = (o:{message:string}) => m(this.ERROR_InvalidProjectFile,

--- a/developer/src/kmc/src/messages/messages.ts
+++ b/developer/src/kmc/src/messages/messages.ts
@@ -50,5 +50,16 @@ export class InfrastructureMessages {
   static Error_UnknownFileFormat = (o:{format:string}) => m(this.ERROR_UnknownFileFormat,
     `Unknown file format ${o.format}; only Markdown (.md), JSON (.json), and Text (.txt) are supported.`);
   static ERROR_UnknownFileFormat = SevError | 0x000A;
+
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static Info_ProjectBuiltSuccessfully = (o:{filename:string}) => ({filename:o.filename, ...m(this.INFO_ProjectBuiltSuccessfully,
+    `Project ${o.filename} built successfully.`)});
+  static INFO_ProjectBuiltSuccessfully = SevInfo | 0x000B;
+
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static Info_ProjectNotBuiltSuccessfully = (o:{filename:string}) => ({filename:o.filename, ...m(this.INFO_ProjectNotBuiltSuccessfully,
+    `Project ${o.filename} failed to build.`)});
+  static INFO_ProjectNotBuiltSuccessfully = SevInfo | 0x000C;
+
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -266,14 +266,15 @@
       "name": "@keymanapp/keyman-version",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^18.7.13",
+        "@types/node": "^20.4.1",
         "typescript": "^4.9.5"
       }
     },
     "common/web/keyman-version/node_modules/@types/node": {
-      "version": "18.11.15",
-      "dev": true,
-      "license": "MIT"
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true
     },
     "common/web/lm-message-types": {
       "name": "@keymanapp/lm-message-types",
@@ -378,7 +379,7 @@
         "@types/chai": "^4.1.7",
         "@types/git-diff": "^2.0.3",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.14.6",
+        "@types/node": "^20.4.1",
         "@types/semver": "^7.3.12",
         "@types/xml2js": "^0.4.5",
         "c8": "^7.12.0",
@@ -397,9 +398,10 @@
       "license": "MIT"
     },
     "common/web/types/node_modules/@types/node": {
-      "version": "10.17.60",
-      "dev": true,
-      "license": "MIT"
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true
     },
     "common/web/types/node_modules/ajv": {
       "version": "8.11.2",
@@ -641,15 +643,15 @@
         "@keymanapp/common-types": "*"
       },
       "devDependencies": {
-        "@types/node": "^10.14.6",
+        "@types/node": "^20.4.1",
         "ts-node": "^9.1.1",
         "typescript": "^4.9.5"
       }
     },
     "developer/src/common/web/test-helpers/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
       "dev": true
     },
     "developer/src/common/web/test-helpers/node_modules/diff": {
@@ -700,7 +702,9 @@
         "@keymanapp/kmc-model-info": "*",
         "@keymanapp/kmc-package": "*",
         "@keymanapp/models-types": "*",
-        "commander": "^10.0.0"
+        "chalk": "^2.4.2",
+        "commander": "^10.0.0",
+        "supports-color": "^9.4.0"
       },
       "bin": {
         "kmc": "build/src/kmc.js",
@@ -711,11 +715,10 @@
       "devDependencies": {
         "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.14.6",
+        "@types/node": "^20.4.1",
         "@types/xml2js": "^0.4.5",
         "c8": "^7.12.0",
         "chai": "^4.3.4",
-        "chalk": "^2.4.2",
         "esbuild": "^0.15.8",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
@@ -734,7 +737,7 @@
         "@keymanapp/resources-gosh": "*",
         "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.14.6",
+        "@types/node": "^20.4.1",
         "@types/xml2js": "^0.4.5",
         "c8": "^7.12.0",
         "chai": "^4.3.4",
@@ -752,9 +755,9 @@
       "dev": true
     },
     "developer/src/kmc-analyze/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
       "dev": true
     },
     "developer/src/kmc-analyze/node_modules/ansi-styles": {
@@ -993,7 +996,7 @@
         "@keymanapp/developer-test-helpers": "*",
         "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.14.6",
+        "@types/node": "^20.4.1",
         "@types/semver": "^7.3.12",
         "@types/sinon": "^10.0.13",
         "@types/sinon-chai": "^3.2.9",
@@ -1044,9 +1047,9 @@
       "dev": true
     },
     "developer/src/kmc-kmn/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
       "dev": true
     },
     "developer/src/kmc-kmn/node_modules/ansi-styles": {
@@ -1339,7 +1342,7 @@
         "@keymanapp/developer-test-helpers": "*",
         "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.14.6",
+        "@types/node": "^20.4.1",
         "@types/semver": "^7.3.12",
         "@types/xml2js": "^0.4.5",
         "c8": "^7.12.0",
@@ -1357,9 +1360,9 @@
       "dev": true
     },
     "developer/src/kmc-ldml/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
       "dev": true
     },
     "developer/src/kmc-ldml/node_modules/ajv": {
@@ -1600,7 +1603,7 @@
         "@keymanapp/developer-test-helpers": "*",
         "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.14.6",
+        "@types/node": "^20.4.1",
         "@types/xml2js": "^0.4.5",
         "c8": "^7.12.0",
         "chai": "^4.3.4",
@@ -1620,7 +1623,7 @@
       "devDependencies": {
         "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.14.6",
+        "@types/node": "^20.4.1",
         "@types/xml2js": "^0.4.5",
         "c8": "^7.12.0",
         "chai": "^4.3.4",
@@ -1636,9 +1639,10 @@
       "license": "MIT"
     },
     "developer/src/kmc-model-info/node_modules/@types/node": {
-      "version": "10.17.60",
-      "dev": true,
-      "license": "MIT"
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true
     },
     "developer/src/kmc-model-info/node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -1832,9 +1836,10 @@
       "license": "MIT"
     },
     "developer/src/kmc-model/node_modules/@types/node": {
-      "version": "10.17.60",
-      "dev": true,
-      "license": "MIT"
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true
     },
     "developer/src/kmc-model/node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -1903,7 +1908,7 @@
         "@keymanapp/developer-test-helpers": "*",
         "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.14.6",
+        "@types/node": "^20.4.1",
         "c8": "^7.12.0",
         "chai": "^4.3.4",
         "chalk": "^2.4.2",
@@ -1918,9 +1923,10 @@
       "license": "MIT"
     },
     "developer/src/kmc-package/node_modules/@types/node": {
-      "version": "10.17.60",
-      "dev": true,
-      "license": "MIT"
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true
     },
     "developer/src/kmc-package/node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -2114,13 +2120,13 @@
       "license": "MIT"
     },
     "developer/src/kmc/node_modules/@types/node": {
-      "version": "10.17.60",
-      "dev": true,
-      "license": "MIT"
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true
     },
     "developer/src/kmc/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -2131,8 +2137,8 @@
     },
     "developer/src/kmc/node_modules/chalk": {
       "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2142,9 +2148,27 @@
         "node": ">=4"
       }
     },
+    "developer/src/kmc/node_modules/chalk/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "developer/src/kmc/node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "developer/src/kmc/node_modules/color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -2152,7 +2176,6 @@
     },
     "developer/src/kmc/node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "developer/src/kmc/node_modules/js-yaml": {
@@ -2220,6 +2243,15 @@
         "url": "https://opencollective.com/mochajs"
       }
     },
+    "developer/src/kmc/node_modules/mocha/node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "developer/src/kmc/node_modules/mocha/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "dev": true,
@@ -2251,22 +2283,14 @@
       "license": "MIT"
     },
     "developer/src/kmc/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "engines": {
+        "node": ">=12"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "developer/src/kmc/node_modules/supports-color/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "developer/src/kmc/node_modules/ts-node": {
@@ -5513,7 +5537,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"


### PR DESCRIPTION
Fixes #8795.
Fixes #9230.
Relates to #9090.

Cleans up and makes consistent compiler messages in kmc, and related unit tests.

Adds support for colorized messages.

Standardizes on `KMxxxxx` for the error code format, which should make them reasonably searchable long-term.

After installing chalk for ansi coloring in kmc, @types/node needed to be brought in sync with the Typescript version, per the suggestion of checking against `npm dist-tags @types/node`,found in a discussion at https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64262#discussioncomment-4905069

Additional tidying up includes:
* Deprecating a set of functions in compiler-interfaces, bringing them together under a new CompilerError class. Separating CompilerErrorSeverity and CompilerErrorMask enums.
* Making CompilerError.formatEvent (formerly compilerEventFormat) print messages in the same format as NodeCompilerCallbacks (sans coloring).
* Adding a wrapper class for CompilerCallbacks that manages the filename reporting, used currently exclusively by kmc itself.

![image](https://github.com/keymanapp/keyman/assets/4498365/86e13727-d69f-4794-9d06-1923e3ef7f06)


@keymanapp-test-bot skip