### PR TITLE
chore(developer): add `--color` switch to kmc 🗜

### DIFF
--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -311,6 +311,10 @@ export interface CompilerBaseOptions {
    * Optional output file for activities that generate output
    */
   outFile?: string;
+  /**
+   * Colorize log output, default is detected from console
+   */
+  color?: boolean;
 }
 
 export interface CompilerOptions extends CompilerBaseOptions {

--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import { Command } from 'commander';
 import { buildActivities } from './buildClasses/buildActivities.js';
 import { BuildProject } from './buildClasses/BuildProject.js';
-import { CompilerLogColor, NodeCompilerCallbacks } from '../messages/NodeCompilerCallbacks.js';
+import { NodeCompilerCallbacks } from '../messages/NodeCompilerCallbacks.js';
 import { InfrastructureMessages } from '../messages/messages.js';
 import { CompilerErrorSeverity, CompilerErrorMask, CompilerFileCallbacks, CompilerOptions, KeymanFileTypes } from '@keymanapp/common-types';
 import { BaseOptions } from '../util/baseOptions.js';
@@ -16,6 +16,7 @@ function commandOptionsToCompilerOptions(options: any): CompilerOptions {
     // CompilerBaseOptions
     outFile: options.outFile,
     logLevel: options.logLevel,
+    color: options.color,
     // CompilerOptions
     shouldAddCompilerVersion: options.compilerVersion,
     saveDebug: options.debug,
@@ -30,12 +31,14 @@ export function declareBuild(program: Command) {
     .description('Build a source file into a final file')
   )
     .option('-d, --debug', 'Include debug information in output')
-    .option('--no-compiler-version', 'Exclude compiler version metadata from output')
     .option('-w, --compiler-warnings-as-errors', 'Causes warnings to fail the build')
+    .option('--no-compiler-version', 'Exclude compiler version metadata from output')
     .option('--no-warn-deprecated-code', 'Turn off warnings for deprecated code styles')
+    .option('--color', 'Force colorization for log messages')
+    .option('--no-color', 'No colorization for log messages; if both omitted, detects from console')
     .action(async (filenames: string[], options: any) => {
       options = commandOptionsToCompilerOptions(options);
-      const callbacks = new NodeCompilerCallbacks({color:CompilerLogColor.default, ...options});
+      const callbacks = new NodeCompilerCallbacks(options);
 
       if(!filenames.length) {
         // If there are no filenames provided, then we are building the current


### PR DESCRIPTION
Fixes #9233.

Adds `--color` and `--no-color` switches to kmc command line, with default being determined by console mode.

Also ensures color initialization happens just once in NodeCompilerCallbacks and moves constants to top of file.

# User Testing

Let's try and see if we can do some tests!

### Setup

1. Install Keyman Developer first.
2. For these tests, locate a keyboard project (.kpj) file and start a console.
3. Use `cd` to move to the folder of the .kpj project, called below `your.kpj`.

**TEST_DEFAULT_COLOR_MODE:** In the console, type `kmc build your.kpj` (replace `your.kpj` with your own project name). The project should build, with colored log text.
**TEST_COLOR_MODE:** In the console, type `kmc build --color your.kpj` (replace `your.kpj` with your own project name). The project should build, with colored log text.
**TEST_NO_COLOR_MODE:** In the console, type `kmc build --no-color your.kpj` (replace `your.kpj` with your own project name). The project should build, but without colored log text.