### PR TITLE
chore(developer): handle compilerWarningsAsErrors option 🗜

### DIFF
--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -21,7 +21,7 @@ export { LDMLKeyboardXMLSourceFileReader, LDMLKeyboardXMLSourceFileReaderOptions
 export * as Constants from './consts/virtual-key-constants.js';
 
 export { defaultCompilerOptions, CompilerBaseOptions, CompilerCallbacks, CompilerOptions, CompilerSchema, CompilerEvent, CompilerErrorNamespace,
-         CompilerErrorSeverity, CompilerPathCallbacks, CompilerFileSystemCallbacks,
+         CompilerErrorSeverity, CompilerPathCallbacks, CompilerFileSystemCallbacks, CompilerCallbackOptions,
          CompilerError, CompilerMessageSpec, compilerErrorSeverity, CompilerErrorMask, CompilerFileCallbacks, compilerErrorSeverityName,
          compilerExceptionToString, compilerErrorFormatCode,
          compilerLogLevelToSeverity, CompilerLogLevel, compilerEventFormat, ALL_COMPILER_LOG_LEVELS } from './util/compiler-interfaces.js';


### PR DESCRIPTION
Fixes #9100.

The `compilerWarningsAsErrors` option can be passed in as a command-line option or in the project options. Command-line option, if present, takes precedence over the project option. If neither is set, then the value is `false`.

Handling of this is within kmc, rather than individual modules.

TODO:

- [x] add a unit test -- see #9238.

@keymanapp-test-bot skip