### PR TITLE
fix(developer): touch layout font test should be lower case 🗜

### DIFF
--- a/developer/src/kmc-kmn/src/kmw-compiler/validate-layout-file.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/validate-layout-file.ts
@@ -223,9 +223,9 @@ export function ValidateLayoutFile(fk: KMX.KEYBOARD, FDebug: boolean, sLayoutFil
     // Test that the font matches on all platforms   // I4872
 
     if(FTouchLayoutFont == '') {
-      FTouchLayoutFont = platform.font ?? '';
+      FTouchLayoutFont = platform.font?.toLowerCase() ?? '';
     }
-    else if(platform.font?.toLowerCase() ?? '' != FTouchLayoutFont) {
+    else if((platform.font?.toLowerCase() ?? '') != FTouchLayoutFont) {
       callbacks.reportMessage(KmwCompilerMessages.Warn_TouchLayoutFontShouldBeSameForAllPlatforms());
       // TODO: why support multiple font values if it has to be the same across all platforms?!
     }


### PR DESCRIPTION
Fixes #9110.

Also, `!=` has higher precedence than `??`.

This returns a boolean result:

```
(platform.font?.toLowerCase() ?? '') != FTouchLayoutFont
```

But `!=` has higher precedence than `??` so this returns the font name:

```
platform.font?.toLowerCase() ?? '' != FTouchLayoutFont
```

@keymanapp-test-bot skip