### PR TITLE
feat(web): draft design for gesture model definition + processing 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/configuration/gestureRecognizerConfiguration.ts
+++ b/common/web/gesture-recognizer/src/engine/configuration/gestureRecognizerConfiguration.ts
@@ -2,7 +2,7 @@
 // it's just that the ELEMENTS and zone definitions involved shouldn't be shifting
 // after configuration.
 
-import { InputSample } from "../headless/inputSample.js";
+import { BaseItemIdentifier, GestureItemIdentifier } from "./itemIdentifier.js";
 import { RecognitionZoneSource } from "./recognitionZoneSource.js";
 
 // For example, customization of a longpress timer's length need not be readonly.
@@ -80,5 +80,16 @@ export interface GestureRecognizerConfiguration<HoveredItemType> {
    * @param target  The `EventTarget` (`Node` or `Element`) provided by the corresponding input event.
    * @returns
    */
-  readonly itemIdentifier?: (coord: Omit<InputSample<any>, 'item'>, target: EventTarget) => HoveredItemType;
+  readonly itemIdentifier?: BaseItemIdentifier<HoveredItemType>;
+
+  /**
+   * Allows defining specific item identifiers for specific gesture types.
+   *
+   * For example, keyboard flicks lock in a base key as well, specifying a subkey based on the properties
+   * of the gesture's motion.  All this is before they can lock-in.
+   *
+   * Keyboard longpresses, however, can 'lock-in', and they typically present a subkey menu that's best
+   * handled by an alternate configuration instead.  They're a better fit for that model.
+   */
+  readonly gestureItemIdentifiers?: Record<string, GestureItemIdentifier<HoveredItemType>>;
 }

--- a/common/web/gesture-recognizer/src/engine/configuration/itemIdentifier.ts
+++ b/common/web/gesture-recognizer/src/engine/configuration/itemIdentifier.ts
@@ -1,0 +1,5 @@
+import { InputSample } from "../headless/inputSample.js";
+import { CumulativePathStats } from "../index.js";
+
+export type BaseItemIdentifier<Type> = (coord: Omit<InputSample<any>, 'item'>, target: EventTarget) => Type;
+export type GestureItemIdentifier<Type> = (baseItem: Type, currentItem: Type, stats: CumulativePathStats) => Type;

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/index.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/index.ts
@@ -1,0 +1,2 @@
+export * from './inputModel.js';
+export * from './pathModel.js';

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/inputModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/inputModel.ts
@@ -1,0 +1,120 @@
+import { TouchpointModel } from './pointModel.js';
+
+// Leave this as an interface; it's easier for external stuff to specify that way.
+export interface InputModel<ItemType> {  // Only generic b/c TouchpointModel<ItemType>.
+  // Gestures may want to say "build gesture of type `id`" for a followup-gesture.
+  readonly id: string;
+
+  // Higher = better.
+  readonly resolutionPriority: number;
+
+  // If there are multiple unresolved gestures, with no lock-in, the "potential gesture" with the
+  // highest item priority is the authority re: the "current item".
+  readonly itemPriority: number;
+
+  // One or more "touchpath models" - how a touchpath matching this gesture would look, based on its
+  // ordinal position.  (Same order as in the TrackedInput)
+  readonly touchpathModels: TouchpointModel<ItemType>[]; // May be able to drop the generic bit!
+
+  // if this is defined, the gesture can't resolve while the spec'd Promise is active.
+  // Even if `expectedResult` is negative.
+  readonly awaitModel?: {
+    duration: number,
+    expectedResult: boolean
+  }
+
+  // what if the gesture can preserve items from linked predecessors, rather than the predecessor haphazardly forwarding them?
+  // Makes more sense?
+  //
+  // Default if undefined:
+  // - initial:  the ancestor 'initial' (likely, the touchpath's true initial item)
+  //
+  // If multiple paths are inherited, but only a string is set, the specified mode will be used for all paths.
+  // If an array, but more paths exist than have an entry, the last will be used as default.
+  readonly initialItemSource: ('initial' | 'current')[] | 'initial' | 'current';
+
+  readonly pathInheritance?: 'none' | 'reset' | 'full';
+
+  readonly onResolution: {
+    // At least one must be set.
+    nextGesture?: string,
+    item?: 'initial' | 'current' | 'none',
+    terminatePaths: number[]; // the ordinal indices of currently-tracked paths to force-terminate.
+    lockedIn?: boolean; // default - false
+                        // (a possible second tap of a multitap should not be 'locked in', but 'third' on should)
+  }
+
+  // The next item is more speculative than the rest of the defined properties.
+  // May be useful for longpress-resets when the key shifts?
+  readonly onRejection: {
+    // At least one must be set.
+    nextGesture?: {
+      id: string,
+    },
+    item?: 'initial' | 'current' | 'none',
+    terminatePaths: number[]; // the ordinal indices of currently-tracked paths to force-terminate.
+  }
+}
+
+// something to match state of TrackedInput with GestureModel above.
+
+/*
+ * TODO for specific gesture support:
+ *
+ * Upon recognition of a gesture that continues with another, the consumer should be allowed to stack-push
+ * an entirely new GestureRecognizerConfiguration.  In particular, for longpress subkey menu support.
+ * - Note:  might complicate TrackedPath tracking management & the input engines?
+ *   - probably:  have a config 'stack'... and so long as the touch doesn't go outside of the top-most stack's config,
+ *     we'd be fine.
+ * - I'm not 100% on what form this would take for the theoretical spun-off WebView based Android app subkey menu,
+ *   where the subkeys would be displayed in a separate WebView from the one that triggered the subkey menu.  But
+ *   "we can cross that bridge when we come to it".
+ *   - key thing:  we can set _precedent_ for delegating control/completion of the gesture to something else if/as
+ *     desired.
+ *
+ * May also be wise to allow alternating with a Promise (b/c Android embedded mode).
+ * - Perhaps the Promise itself says "i'll take over from here; resume when the gesture resolves".
+ * - Could be a separate instance (Android WebView) or just delegation to an entirely different controller
+ *   (the current Android-app delegation to Java-based gesture handling)
+ */
+
+/****** BRAINSTORMING NOTES (helped me process & develop the interfaces, etc spec'd in this source folder) ******/
+
+  /*
+   * First touches:
+   * - on path-termination, auto-completes
+   * - on sufficient pathing, auto-completes base gesture, makes a second
+   *   - longpress (shortcut) => subkey menu
+   *   - waaaaaait.  "makes a second" - so it can pre-build the model-match for the next stage, maybe?
+   * - after sufficient time + still-matching path, auto-completes
+   *   - longpress => subkey menu
+   *   - must track timeout on the gesture model, since we don't have the subsegmentation model yet
+   *     - which would better facilitate hold length
+   *     - unless we put something related on the _stats_ object... which isn't the best fit
+   *     - may need ability to reset it / reset the longpress-hold (when roaming touch is allowed)
+   * - after sufficient time, auto-cancels
+   *   - flick (?)
+   * - on path-termination, does NOT (fully) auto-complete, though may make secondary gesture
+   *   - multitap => continued-multitap
+   * - may allow 'resets'?
+   *   - roaming touch => longpress-timer restart?
+   */
+
+  /*
+   * Second touches:
+   * - accepts a second; specifies legal paths (caret panning, possibly modifierpress)
+   *   - !!under specific conditions!!         (caret panning:  must start within threshold of #1, near #1)
+   *   - is assimilated by the gesture; no new Input
+   * - rejects a second & auto-cancels         (new touchpoint during a subkey menu)
+   *   - may or may not need new Input - is kind of undefined
+   * - rejects a second while autocompleting   (simple touch)
+   *   - is not assimilated by the gesture, does allow new Input / gesture from the trigger
+   *   - does reject a multitap
+   * - just... ignores a second                (modifierpress?)
+   *
+   * - multitap:  can complete a first, have an empty slot, no second touch
+   *   => continued-multitap:  can accept a (new) first with constraints, no second touch
+   *     - or "that's all"
+   *   => continued-multitap (again)
+   *     - or "that's all"
+   */

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/inputModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/inputModel.ts
@@ -33,7 +33,9 @@ export interface InputModel<ItemType> {  // Only generic b/c TouchpointModel<Ite
   // If an array, but more paths exist than have an entry, the last will be used as default.
   readonly initialItemSource: ('initial' | 'current')[] | 'initial' | 'current';
 
-  readonly pathInheritance?: 'none' | 'reset' | 'full';
+  // 'reject':  multitaps must not have a lingering prior path.  If a simple touch was triggered due to a second touchpoint,
+  // 'reject' will fail the multitouch because the second touchpoint's existence will continue and attempt inheritance
+  readonly pathInheritance?: 'none' | 'reset' | 'full' | 'reject';
 
   readonly onResolution: {
     // At least one must be set.

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/inputModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/inputModel.ts
@@ -1,4 +1,4 @@
-import { TouchpointModel } from './pointModel.js';
+import { PointModel } from './pointModel.js';
 
 // Leave this as an interface; it's easier for external stuff to specify that way.
 export interface InputModel<ItemType> {  // Only generic b/c TouchpointModel<ItemType>.
@@ -14,7 +14,7 @@ export interface InputModel<ItemType> {  // Only generic b/c TouchpointModel<Ite
 
   // One or more "touchpath models" - how a touchpath matching this gesture would look, based on its
   // ordinal position.  (Same order as in the TrackedInput)
-  readonly touchpathModels: TouchpointModel<ItemType>[]; // May be able to drop the generic bit!
+  readonly touchpathModels: PointModel<ItemType>[]; // May be able to drop the generic bit!
 
   // if this is defined, the gesture can't resolve while the spec'd Promise is active.
   // Even if `expectedResult` is negative.

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/pathModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/pathModel.ts
@@ -1,0 +1,43 @@
+import { TrackedPoint } from "../trackedPoint.js";
+import { TrackedPath } from "../trackedPath.js";
+
+// The TrackedPath model only cares about if the path matches... not what that MEANS.
+// THAT is the role of the gesture Model (model.ts).
+export interface PathModel<Type> {
+  /*
+   * NOTE:  in theory, we could JSON-spec this instead.  Worst case:
+   * - resolve if any:
+   *   - condition 1: if all:
+   *     - conditions on path stats
+   *   - condition 2: if all:
+   *     - conditions on path stats
+   *   - etc.
+   * - reject if any:
+   *   - same as above
+   * - if neither has a match:  implied 'continue'
+   * - if both do:  uh... double check that spec, for one.  But also, could
+   *   set/specify which set should take precedence.  Or globally say 'reject'
+   *   before 'resolve'.
+   *
+   * TODO:  probably, that.  (JSON-spec'ing here instead of requiring a func)
+   * But, for a first pass... there's so much JSON-interpretation stuff to pin down
+   * already that this aspect should be triaged 'til later.
+   *
+   * Metaphorically speaking, we should prove the 'forest' design will work before we
+   * commit to fine-tuned landscaping that we may have to trash if proven wrong.
+   */
+
+  /**
+   * Given a TrackedPath, indicates whether or not the path matches this PathModel.
+   *
+   * @param path
+   * @param initialItem
+   */
+  evaluate(path: TrackedPath<any> /*, initialItem: Type*/): 'reject' | 'resolve' | 'continue';
+  // path contains the 'current' item.
+  // but more importantly... I don't think we need to worry about the item at all here.
+  // the 'point' level setting for onItemChange, gesture-specific itemIdentifier based
+  // on recognizerId, and/or itemIdentifier override on longpress-lockin should all
+  // handle anything that we'd need to track the Item here for.
+  // (In which case we can drop the generic aspect!  Yay!)
+}

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/pointModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/pointModel.ts
@@ -18,7 +18,7 @@ export interface PushResult {
 export interface ComplexResolveResult {
   type: 'resolve';
   cancelBaseAwait?: boolean; // default false, but if true, will auto-cancel the top-level model's await (if it exists)
-  set?: 'initial' | 'set' | 'current'
+  set?: 'initial' | 'current'
 }
 
 type WrappedString<Text> = { type: Text };
@@ -38,7 +38,7 @@ type SimpleStringResult = 'resolve' | 'reject' | 'pop';
 export type PointModelResolution =  SimpleStringResult | AwaitResult | PushResult |
                                     ComplexResolveResult | WrappedString<SimpleStringResult>;
 
-export interface TouchpointModel<Type> {
+export interface PointModel<Type> {
   pathModel: PathModel<Type>, // Might be able to fully drop the generic.
   onPathResolve: PointModelResolution,
   itemPriority: number; // If multiple touchpoints are active, determines which point's item 'wins' for

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/pointModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/pointModel.ts
@@ -1,0 +1,74 @@
+import { TrackedPath } from "../trackedPath.js";
+import { PathModel } from "./pathModel.js";
+
+// For multitaps, we may need to actually have this be something passed to initialize (the next stage of)
+// a multitap gesture.
+export interface AwaitResult {
+  type: 'await';
+  duration: number;
+  expectedResult: boolean;
+}
+
+// For modipress, in particular - says what gestures are allowed during the 'push' state.
+export interface PushResult {
+  type: 'push';
+  permittedGestures: string[]; // of ids for allowed types
+}
+
+export interface ComplexResolveResult {
+  type: 'resolve';
+  cancelBaseAwait?: boolean; // default false, but if true, will auto-cancel the top-level model's await (if it exists)
+  set?: 'initial' | 'set' | 'current'
+}
+
+type WrappedString<Text> = { type: Text };
+
+// pop - ends the modipress 'push' state.
+type SimpleStringResult = 'resolve' | 'reject' | 'pop';
+
+// DO NOT WORRY ABOUT CARET PAN HERE (for now).
+// That'll come later... and there ought be a decent way or two forward.
+// - rough idea:  top-level config option:  multipress trumps singlepress, but neither BLOCKS the other.
+//   - on multipress stop:  simply... don't terminate the paths.
+//   - on new incoming press:  trigger "start new gesture" from currently-pressed position
+//     - with trimmed / 'reset' path.
+//     - classic multitouch gestures (pinch, zoom) don't care about any "before" path components.
+//     - they just start tracking from when they activate.
+
+export type PointModelResolution =  SimpleStringResult | AwaitResult | PushResult |
+                                    ComplexResolveResult | WrappedString<SimpleStringResult>;
+
+export interface TouchpointModel<Type> {
+  pathModel: PathModel<Type>, // Might be able to fully drop the generic.
+  onPathResolve: PointModelResolution,
+  itemPriority: number; // If multiple touchpoints are active, determines which point's item 'wins' for
+                        // gesture-state updates and resolution.  Higher = better.
+
+  // For longpresses, in particular.
+  // Reset:  this one should fail (base item change)
+  // - roaming touch behaviors start a new one with new base items; that's the 'reset'.
+  timer?: {
+    duration: number,
+    expectedResult: boolean;
+  }
+
+  // Allows specifying use of one of the configured 'gestureItemIdentifiers'.
+  recognizerId?: string;
+
+  readonly onItemChange: 'reject' | 'resolve'; // may be undefined for 'continue'
+}
+
+/*** Probably safe to eliminate this stuff, but _just_ in case... ***/
+
+// I'm _thinking_ that onItemChange above is sufficient, given BaseItemIdentifier, GestureItemIdentifier, and
+// the prospective ability to stack-push a new GestureRecognizerConfiguration for specific gestures (for subkey menus).
+
+// Just in case I'm wrong, though... what's below was as far as I got when attempting a different direction before I
+// settled on the model referred to in the previous paragraph.
+
+// // I'm not 100% on the parameterizations below / exactly _which_ items should be considered yet.
+// // Or if these actually should exist.
+// //
+// // ... could these be JSON-spec'd in some form?
+// initialItemMatch?: (itemState: Type, path: TrackedPath<Type>) => boolean,
+// currentItemMatch?: (itemState: Type, path: TrackedPath<Type>) => boolean // or (pathInitialItem, pathCurrentItem) => boolean //?

--- a/common/web/gesture-recognizer/src/engine/headless/trackedInput.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/trackedInput.ts
@@ -1,5 +1,6 @@
 import EventEmitter from "eventemitter3";
 import { JSONTrackedPoint, TrackedPoint } from "./trackedPoint.js";
+import * as Gestures from "./gestures/index.js";
 
 /**
  * Documents the expected typing of serialized versions of the `TrackedInput` class.
@@ -31,9 +32,7 @@ interface EventMap {
 export class TrackedInput<HoveredItemType> extends EventEmitter<EventMap> {
   public readonly touchpoints: TrackedPoint<HoveredItemType>[];
 
-  // --- Future design aspects ---
-  // private _gesture: Gesture;
-  // public get gesture() { return this._gesture };
+  private _potentialGestures: Gestures.InputModel<HoveredItemType>[];
 
   private isActive = true;
 
@@ -72,6 +71,10 @@ export class TrackedInput<HoveredItemType> extends EventEmitter<EventMap> {
         point.path.terminate(false);
       }
     }
+  }
+
+  get potentialGestures(): Gestures.InputModel<HoveredItemType>[] {
+    return [].concat(this._potentialGestures);
   }
 
   /**

--- a/common/web/gesture-recognizer/src/engine/headless/trackedPath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/trackedPath.ts
@@ -157,4 +157,12 @@ export class TrackedPath<Type> extends EventEmitter<EventMap<Type>> {
 
     return jsonClone;
   }
+
+  public get firstInput(): InputSample<Type> {
+    return this.coords[0];
+  }
+
+  public get latestInput(): InputSample<Type> {
+    return this.coords[this.coords.length-1];
+  }
 }


### PR DESCRIPTION
🚧 🚧 🚧 🚧 

This PR, in its present form, presents a 'draft design' for a common set of structures that may be used to define specifications for recognition of gestures as mouse & touch input events are received.  There are a few actual code changes included; these seek to further clarify how the draft design would integrate with the existing gesture codebase.

### Defining gestures

Note that the gesture specification typings are almost fully JSON-compatible.  There is one property requesting a defined function (hence "almost fully"), but I believe even that could be replaced with a JSON spec + interpretation of that spec.

By ensuring a common abstraction set, and a corresponding mechanism for interpretation thereof, the goal is to keep overall complexity down.  It's also worth note that the gesture engine needs to be able to support different 'gesture sets':

- Keyboard supports flicks:
    - Should disable longpress up-flicks / use a variant without them
    - Allow flick detection
- Keyboard does not support flicks:
    - Disable flick detection and re-enable longpress up-flicks
- Modifier-longpress ("modifierpress" / "modipress" for short)
    - Does not allow a modifier longpress on the temp-shifted layer
    - Does not allow layer-shift from multitaps (if I recall correctly)
- Longpress confirmed => subkey menu mode
    - Do not allow other gesture types at all

A gesture-specification format that makes it easy to say "enable these gesture types", without having to custom-tailor the gestures based on which other ones are supported, is probably a wise way to go.  The idea:  spec out JSON for all possible gesture types, then tell the engine "these are the gesture types that are currently committed" by their ID.

### On the gesture specification typings

#### PathModel

The responsibility of this class is solely to determine if the touchpoint's path meets certain constraints for the gesture and what to do when those constraint types are met.

Longpress:  
- if the touchpoint moves too far, reject
- unless it's a legal up-flick, in which case resolve early

Flick:
- if the touchpoint doesn't move in a reasonably-straight line, reject 
- if the touchpoint doesn't move far enough, reject 

Simple keypress (second touch):
- resolve immediately (other mechanisms will ensure it's the first touch that reports the keystroke)

Most other cases:  neither 'resolve' nor 'reject'.

#### PointModel

The responsibility of this class:  other conditions not directly related to the coordinate sequence over time, but specific to the touchpoint.

Longpresses:
- resolve after a set amount of time
- combined with `onItemChange`, fails if the base key changes.  (This effectively permits us to restart, attempting a new longpress using the new base key)

Simple keypress (second touch):
- The _first point_ will have a higher priority than the second, thus the first touchpoint is considered the authority regarding which key is triggered by the gesture.

For flicks, the `recognizerId` allows setting a special recognizer that should be useful for flick hints.

#### InputModel

This one is the top-level gesture spec definition, corresponding to the `TrackedInput` level, which is designed for multitouch handling.  It is responsible for handling multitouch scenarios.

Multitap - sets a timer:
- If the timer resolves without being cancelled, reject (too much time has elapsed)
    - This is the purpose of `awaitModel`.
- Also, to _start_ a multitap...
    ```
    // Simple keypress
    onResolution: {
      item: 'current',
      nextGesture: 'multitap',
      lockedIn: false
    }
    ```
    
    In other words, "output the current 'item' / key, and also start a potential (but not confirmed) multitap."
    
    For the `initialItemSource` entry for 'multitap':  `current`
    - Use the previously-current entry as the 'initial' item for this gesture.
    - Combine with `TouchpointModel.onItemChange` set to `reject`, and any touches starting with a different base item will be rejected.  Only the same base item will match and allow a 'multitap' to continue.

If any one PointModel resolves, the gesture then resolves.

#### Other handling

Note that there is some implied segmentation in this model for processing gestures.  In particular, some gestures will 'resolve' into other gestures once there's a clear shift in state:

- longpress resolution => subkey menu
- simple keypress => _possible_ multitap
- _possible_ multitap => multitap

The "segmentation" only occurs once a gesture is recognized, though, and the split is made at the recognition point.

When starting from scratch, the fully-specified set of allowed gestures will be loaded as 'potential' gestures.  As 'potential' gestures' models are rejected, so long as any remain, no new gestures will replace them (unless a rejected one specifies a replacement for itself).  Once one _resolves_, what comes next depends on its spec.

If `lockedIn` is set, only the specified follow-up gesture will be considered as a 'potential'.  No other gestures will be considered.  Otherwise, the standard set will be preloaded _in addition to_ the specified follow-up.

When new 'potential' gestures are initialized, any still-active paths from the previous gesture will be considered for 'migration' to the new gesture.  Each one specifies how it would prefer to view the touchpoint's path.  In some cases, truncation may be desired, while in others, it may be fine to remember the full path that led up to the current 'potential' gesture.
- In particular, consider 'roaming touch' -> longpress.  When 'roaming touch' reaches a new base key, we need to throw out the path leading up to that point - otherwise, we may throw out the gesture due to having moved too far in total.

Again, 🚧 NOTE 🚧:  this PR is currently intended to serve _only_ as a draft design for upcoming gesture work.  Full implementation in one shot is likely to result in an overly-large amount of code to review, so I'm hoping to break it down piecemeal.

@keymanapp-test-bot skip