### PR TITLE
refactor(common): bundle schemas into web/types 🗜

### DIFF
--- a/common/web/types/.gitignore
+++ b/common/web/types/.gitignore
@@ -1,0 +1,1 @@
+src/schemas/

--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -49,6 +49,8 @@ function copy_schemas() {
     "$KEYMAN_ROOT/common/schemas/kpj/kpj.schema.json"
     "$KEYMAN_ROOT/common/schemas/kpj-9.0/kpj-9.0.schema.json"
     "$KEYMAN_ROOT/common/schemas/displaymap/displaymap.schema.json"
+    "$KEYMAN_ROOT/common/schemas/keyman-touch-layout/keyman-touch-layout.spec.json"
+    "$KEYMAN_ROOT/common/schemas/keyman-touch-layout/keyman-touch-layout.clean.spec.json"
   )
 
   rm -rf "$THIS_SCRIPT_PATH/src/schemas"

--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -40,8 +40,6 @@ fi
 
 function copy_schemas() {
   # We need the schema files at runtime and bundled, so always copy it for all actions except `clean`
-
-  # We need the schema file at runtime and bundled, so always copy it for all actions except `clean`
   local schemas=(
     "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json"
     "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json"

--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -40,14 +40,20 @@ fi
 
 function copy_schemas() {
   # We need the schema files at runtime and bundled, so always copy it for all actions except `clean`
-  mkdir -p "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/common/schemas/kpj/kpj.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/common/schemas/kpj-9.0/kpj-9.0.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/common/schemas/keyman-touch-layout/keyman-touch-layout.clean.spec.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/common/schemas/displaymap/displaymap.schema.json" "$THIS_SCRIPT_PATH/build/src/"
+
+  # We need the schema file at runtime and bundled, so always copy it for all actions except `clean`
+  local schemas=(
+    "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json"
+    "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json"
+    "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json"
+    "$KEYMAN_ROOT/common/schemas/kpj/kpj.schema.json"
+    "$KEYMAN_ROOT/common/schemas/kpj-9.0/kpj-9.0.schema.json"
+    "$KEYMAN_ROOT/common/schemas/displaymap/displaymap.schema.json"
+  )
+
+  rm -rf "$THIS_SCRIPT_PATH/src/schemas"
+  mkdir -p "$THIS_SCRIPT_PATH/src/schemas"
+  cp "${schemas[@]}" "$THIS_SCRIPT_PATH/src/schemas/"
   # Store CLDR imports
   # load all versions that have a cldr_info.json
   for CLDR_INFO_PATH in "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/"*/cldr_info.json

--- a/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file-reader.ts
+++ b/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file-reader.ts
@@ -1,6 +1,7 @@
 import { default as AjvModule } from 'ajv';
 const Ajv = AjvModule.default; // The actual expected Ajv type.
 import { TouchLayoutFile } from "./keyman-touch-layout-file.js";
+import Schemas from '../../src/schemas.js';
 
 export class TouchLayoutFileReader {
   public read(source: Uint8Array): TouchLayoutFile {
@@ -67,11 +68,9 @@ export class TouchLayoutFileReader {
     return result;
   }
 
-  // TODO: still using Buffer not Uint8Array here
-  public validate(source: TouchLayoutFile, schemaBuffer: Buffer): void {
-    const schema = JSON.parse(schemaBuffer.toString('utf8'));
+  public validate(source: TouchLayoutFile): void {
     const ajv = new Ajv();
-    if(!ajv.validate(schema, source))
+    if(!ajv.validate(Schemas.touchLayoutClean, source))
     /* c8 ignore next 3 */
     {
       throw new Error(ajv.errorsText());

--- a/common/web/types/src/kpj/kpj-file-reader.ts
+++ b/common/web/types/src/kpj/kpj-file-reader.ts
@@ -5,6 +5,7 @@ const Ajv = AjvModule.default; // The actual expected Ajv type.
 import { boxXmlArray } from '../util/util.js';
 import { KeymanDeveloperProject, KeymanDeveloperProjectFile10, KeymanDeveloperProjectType } from './keyman-developer-project.js';
 import { CompilerCallbacks } from '../util/compiler-interfaces.js';
+import Schemas from '../schemas.js';
 
 export class KPJFileReader {
   constructor(private callbacks: CompilerCallbacks) {
@@ -33,13 +34,11 @@ export class KPJFileReader {
     return data as KPJFile;
   }
 
-  public validate(source: KPJFile, schemaBuffer: Uint8Array, legacySchemaBuffer: Uint8Array): void {
-    const schema = JSON.parse(new TextDecoder().decode(schemaBuffer));
+  public validate(source: KPJFile): void {
     const ajv = new Ajv();
-    if(!ajv.validate(schema, source)) {
+    if(!ajv.validate(Schemas.kpj, source)) {
       const ajvLegacy = new Ajv();
-      const legacySchema = JSON.parse(new TextDecoder().decode(legacySchemaBuffer));
-      if(!ajvLegacy.validate(legacySchema, source)) {
+      if(!ajvLegacy.validate(Schemas.kpj90, source)) {
         // If the legacy schema also does not validate, then we will only report
         // the errors against the modern schema
         throw new Error(ajv.errorsText());

--- a/common/web/types/src/kvk/kvks-file-reader.ts
+++ b/common/web/types/src/kvk/kvks-file-reader.ts
@@ -6,6 +6,8 @@ import { boxXmlArray } from '../util/util.js';
 import { DEFAULT_KVK_FONT, VisualKeyboard, VisualKeyboardHeaderFlags, VisualKeyboardKey, VisualKeyboardKeyFlags, VisualKeyboardLegalShiftStates, VisualKeyboardShiftState } from './visual-keyboard.js';
 import { USVirtualKeyCodes } from '../consts/virtual-key-constants.js';
 import { BUILDER_KVK_HEADER_VERSION, KVK_HEADER_IDENTIFIER_BYTES } from './kvk-file.js';
+import Schemas from '../schemas.js';
+
 
 export default class KVKSFileReader {
   public read(file: Uint8Array): KVKSourceFile {
@@ -82,10 +84,9 @@ export default class KVKSFileReader {
     }
   }
 
-  public validate(source: KVKSourceFile, schemaBuffer: Uint8Array): void {
-    const schema = JSON.parse(new TextDecoder().decode(schemaBuffer));
+  public validate(source: KVKSourceFile): void {
     const ajv = new Ajv();
-    if(!ajv.validate(schema, source)) {
+    if(!ajv.validate(Schemas.kvks, source)) {
       throw new Error(ajv.errorsText());
     }
   }

--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -7,6 +7,7 @@ import { CompilerCallbacks } from '../util/compiler-interfaces.js';
 import { constants } from '@keymanapp/ldml-keyboard-constants';
 import { CommonTypesMessages } from '../util/common-events.js';
 import { LDMLKeyboardTestDataXMLSourceFile, LKTTest, LKTTests } from './ldml-keyboard-testdata-xml.js';
+import Schemas from '../schemas.js';
 
 interface NameAndProps  {
   '$'?: any; // content
@@ -205,10 +206,9 @@ export class LDMLKeyboardXMLSourceFileReader {
   /**
    * @returns true if valid, false if invalid
    */
-  public validate(source: LDMLKeyboardXMLSourceFile | LDMLKeyboardTestDataXMLSourceFile, schemaSource: Uint8Array): boolean {
-    const schema = JSON.parse(new TextDecoder().decode(schemaSource));
+  public validate(source: LDMLKeyboardXMLSourceFile | LDMLKeyboardTestDataXMLSourceFile): boolean {
     const ajv = new Ajv();
-    if(!ajv.validate(schema, source)) {
+    if(!ajv.validate(Schemas.ldmlKeyboard, source)) {
       for (let err of ajv.errors) {
         this.callbacks.reportMessage(CommonTypesMessages.Error_SchemaValidationError({
           instancePath: err.instancePath,

--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -20,7 +20,7 @@ export { LDMLKeyboardXMLSourceFileReader, LDMLKeyboardXMLSourceFileReaderOptions
 
 export * as Constants from './consts/virtual-key-constants.js';
 
-export { defaultCompilerOptions, CompilerBaseOptions, CompilerCallbacks, CompilerOptions, CompilerSchema, CompilerEvent, CompilerErrorNamespace,
+export { defaultCompilerOptions, CompilerBaseOptions, CompilerCallbacks, CompilerOptions, CompilerEvent, CompilerErrorNamespace,
          CompilerErrorSeverity, CompilerPathCallbacks, CompilerFileSystemCallbacks, CompilerCallbackOptions,
          CompilerError, CompilerMessageSpec, compilerErrorSeverity, CompilerErrorMask, CompilerFileCallbacks, compilerErrorSeverityName,
          compilerExceptionToString, compilerErrorFormatCode,
@@ -43,3 +43,5 @@ export * as util from './util/util.js';
 export * as KeymanFileTypes from './util/file-types.js';
 
 export * as Osk from './osk/osk.js';
+
+export * as Schemas from './schemas.js';

--- a/common/web/types/src/osk/osk.ts
+++ b/common/web/types/src/osk/osk.ts
@@ -1,6 +1,7 @@
 import { TouchLayoutFile, TouchLayoutFlick, TouchLayoutKey, TouchLayoutPlatform, TouchLayoutSubKey } from "src/keyman-touch-layout/keyman-touch-layout-file.js";
 import { VisualKeyboard } from "../kvk/visual-keyboard.js";
 import { default as AjvModule } from 'ajv';
+import Schemas from "../schemas.js";
 const Ajv = AjvModule.default; // The actual expected Ajv type.
 
 export interface StringRefUsage {
@@ -22,11 +23,9 @@ export interface StringResult {
 
 export type PuaMap = {[index:string]: string};
 
-export function parseMapping(mapping: any, schemaData: Uint8Array) {
-
-  const schema = JSON.parse(new TextDecoder().decode(schemaData));
+export function parseMapping(mapping: any) {
   const ajv = new Ajv();
-  if(!ajv.validate(schema, <any>mapping))
+  if(!ajv.validate(Schemas.displayMap, <any>mapping))
   /* c8 ignore next 3 */
   {
     throw new Error(ajv.errorsText());

--- a/common/web/types/src/schemas.ts
+++ b/common/web/types/src/schemas.ts
@@ -11,8 +11,10 @@ import ldmlKeyboard from './schemas/ldml-keyboard.schema.json' assert { type: 'j
 import ldmlKeyboardTest from './schemas/ldml-keyboardtest.schema.json' assert { type: 'json' };
 // @ts-expect-error(2821) import assertions
 import displayMap from './schemas/displaymap.schema.json' assert { type: 'json' };
-
-// 'keyman-touch-layout.clean'; TODO this has the wrong name pattern, .spec.json instead of .schema.json
+// @ts-expect-error(2821) import assertions
+import touchLayoutClean from './schemas/keyman-touch-layout.clean.spec.json' assert { type: 'json' };
+// @ts-expect-error(2821) import assertions
+import touchLayout from './schemas/keyman-touch-layout.spec.json' assert { type: 'json' };
 
 const Schemas = {
   kpj,
@@ -21,6 +23,8 @@ const Schemas = {
   ldmlKeyboard,
   ldmlKeyboardTest,
   displayMap,
+  touchLayoutClean,
+  touchLayout,
 };
 
 export default Schemas;

--- a/common/web/types/src/schemas.ts
+++ b/common/web/types/src/schemas.ts
@@ -1,0 +1,26 @@
+
+// @ts-expect-error(2821) import assertions
+import kpj from './schemas/kpj.schema.json' assert { type: 'json' };
+// @ts-expect-error(2821) import assertions
+import kpj90 from './schemas/kpj-9.0.schema.json' assert { type: 'json' };
+// @ts-expect-error(2821) import assertions
+import kvks from './schemas/kvks.schema.json' assert { type: 'json' };
+// @ts-expect-error(2821) import assertions
+import ldmlKeyboard from './schemas/ldml-keyboard.schema.json' assert { type: 'json' };
+// @ts-expect-error(2821) import assertions
+import ldmlKeyboardTest from './schemas/ldml-keyboardtest.schema.json' assert { type: 'json' };
+// @ts-expect-error(2821) import assertions
+import displayMap from './schemas/displaymap.schema.json' assert { type: 'json' };
+
+// 'keyman-touch-layout.clean'; TODO this has the wrong name pattern, .spec.json instead of .schema.json
+
+const Schemas = {
+  kpj,
+  kpj90,
+  kvks,
+  ldmlKeyboard,
+  ldmlKeyboardTest,
+  displayMap,
+};
+
+export default Schemas;

--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -195,15 +195,6 @@ export enum CompilerErrorNamespace {
   KmwCompiler = 0x7000,
 };
 
-export type CompilerSchema =
-  'ldml-keyboard' |
-  'ldml-keyboardtest' |
-  'kvks' |
-  'kpj' |
-  'kpj-9.0' |
-  'displaymap';
-  // | 'keyman-touch-layout.clean'; TODO this has the wrong name pattern, .spec.json instead of .schema.json
-
 /**
  * A mapping for common path operations, maps to Node path module. This only
  * defines the functions we are actually using, so that we can port more easily
@@ -261,7 +252,6 @@ export interface CompilerCallbacks {
    */
   resolveFilename(baseFilename: string, filename: string): string;
 
-  loadSchema(schema: CompilerSchema): Uint8Array;
   reportMessage(event: CompilerEvent): void;
 
   debug(msg: string): void;
@@ -322,10 +312,6 @@ export class CompilerFileCallbacks implements CompilerCallbacks {
 
   resolveFilename(baseFilename: string, filename: string): string {
     return this.parent.resolveFilename(baseFilename, filename);
-  }
-
-  loadSchema(schema: CompilerSchema): Uint8Array {
-    return this.parent.loadSchema(schema);
   }
 
   reportMessage(event: CompilerEvent): void {

--- a/common/web/types/test/helpers/TestCompilerCallbacks.ts
+++ b/common/web/types/test/helpers/TestCompilerCallbacks.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { loadFile, loadSchema, resolveFilename } from '../helpers/index.js';
-import { CompilerCallbacks, CompilerError, CompilerEvent, CompilerFileSystemCallbacks, CompilerPathCallbacks, CompilerSchema } from '../../src/util/compiler-interfaces.js';
+import { loadFile, resolveFilename } from '../helpers/index.js';
+import { CompilerCallbacks, CompilerError, CompilerEvent, CompilerFileSystemCallbacks, CompilerPathCallbacks } from '../../src/util/compiler-interfaces.js';
 
 // This is related to developer/src/common/web/test-helpers/index.ts but has a slightly different API surface
 // as this runs at a lower level than the compiler.
@@ -9,20 +9,6 @@ import { CompilerCallbacks, CompilerError, CompilerEvent, CompilerFileSystemCall
  * A CompilerCallbacks implementation for testing
  */
 export class TestCompilerCallbacks implements CompilerCallbacks {
-  loadSchema(schema: CompilerSchema): Buffer {
-    switch (schema) {
-      case 'kpj':
-      case 'kpj-9.0':
-      case 'kvks':
-      case 'displaymap':
-        // listing all unimplemented schemas rather than using 'default'
-        throw new Error(`loadSchema(${schema}) not implemented.`); // not needed for this test
-      case 'ldml-keyboard':
-        return loadSchema(schema);
-      case 'ldml-keyboardtest':
-        return loadSchema(schema);
-    }
-  }
   clear() {
     this.messages = [];
   }

--- a/common/web/types/test/helpers/index.ts
+++ b/common/web/types/test/helpers/index.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
-import { CompilerSchema } from "../../src/util/compiler-interfaces.js";
 
 /**
  * Builds a path to the fixture with the given path components.
@@ -21,10 +20,6 @@ export function loadKeymanTouchLayoutCleanJsonSchema(): Buffer {
 
 export function loadFile(filename: string | URL): Buffer {
   return fs.readFileSync(filename);
-}
-
-export function loadSchema(schema: CompilerSchema): Buffer {
-  return fs.readFileSync(new URL(path.join('..', '..', 'src', schema + '.schema.json'), import.meta.url));
 }
 
 export function resolveFilename(baseFilename: string, filename: string) {

--- a/common/web/types/test/helpers/index.ts
+++ b/common/web/types/test/helpers/index.ts
@@ -13,11 +13,6 @@ export function makePathToFixture(...components: string[]): string {
   return fileURLToPath(new URL(path.join('..', '..', '..', 'test', 'fixtures', ...components), import.meta.url));
 }
 
-export function loadKeymanTouchLayoutCleanJsonSchema(): Buffer {
-  // TODO: this has the Wrong Name Pattern!
-  return fs.readFileSync(new URL(path.join('..', '..', 'src', 'keyman-touch-layout.clean.spec.json'), import.meta.url));
-}
-
 export function loadFile(filename: string | URL): Buffer {
   return fs.readFileSync(filename);
 }

--- a/common/web/types/test/helpers/reader-callback-test.ts
+++ b/common/web/types/test/helpers/reader-callback-test.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import {assert} from 'chai';
-import { loadFile, makePathToFixture, loadSchema } from '../helpers/index.js';
+import { loadFile, makePathToFixture } from '../helpers/index.js';
 import { LDMLKeyboardXMLSourceFileReader, LDMLKeyboardXMLSourceFileReaderOptions } from '../../src/ldml-keyboard/ldml-keyboard-xml-reader.js';
 import { CompilerEvent } from '../../src/util/compiler-interfaces.js';
 import { LDMLKeyboardXMLSourceFile } from '../../src/ldml-keyboard/ldml-keyboard-xml.js';
@@ -94,9 +94,9 @@ export function testReaderCases(cases : CompilationCase[]) {
       }
       // special case for an expected exception
       if (testcase.throws) {
-        assert.throws(() => reader.validate(source, loadSchema('ldml-keyboard')), testcase.throws);
+        assert.throws(() => reader.validate(source), testcase.throws);
       } else {
-        assert.doesNotThrow(() => reader.validate(source, loadSchema('ldml-keyboard')), `validating ${testcase.subpath}`);
+        assert.doesNotThrow(() => reader.validate(source), `validating ${testcase.subpath}`);
         // if we expected errors or warnings, show them
         if (testcase.errors) {
           assert.includeDeepMembers(callbacks.messages, testcase.errors, 'expected errors to be included');

--- a/common/web/types/test/keyman-touch-layout/test-keyman-touch-layout-file-reader.ts
+++ b/common/web/types/test/keyman-touch-layout/test-keyman-touch-layout-file-reader.ts
@@ -1,17 +1,16 @@
 import * as fs from 'fs';
 import 'mocha';
 import { assert } from 'chai';
-import { loadKeymanTouchLayoutCleanJsonSchema, makePathToFixture } from '../helpers/index.js';
+import { makePathToFixture } from '../helpers/index.js';
 import { TouchLayoutFileReader } from "../../src/keyman-touch-layout/keyman-touch-layout-file-reader.js";
 
 describe('TouchLayoutFileReader', function () {
   it('should read a valid file', function() {
     const path = makePathToFixture('keyman-touch-layout', 'khmer_angkor.keyman-touch-layout');
-    const schema = loadKeymanTouchLayoutCleanJsonSchema();
     const input = fs.readFileSync(path);
     const reader = new TouchLayoutFileReader();
     const layout = reader.read(input);
-    reader.validate(layout, schema);
+    reader.validate(layout);
 
     // We don't really need to validate the JSON parser. We'll do a handful of
     // tests for object integrity and a couple of object members inside the file
@@ -36,11 +35,10 @@ describe('TouchLayoutFileReader', function () {
 
   it('should fixup numeric types in a valid legacy file', function() {
     const path = makePathToFixture('keyman-touch-layout', 'legacy.keyman-touch-layout');
-    const schema = loadKeymanTouchLayoutCleanJsonSchema();
     const input = fs.readFileSync(path);
     const reader = new TouchLayoutFileReader();
     const layout = reader.read(input);
-    reader.validate(layout, schema);
+    reader.validate(layout);
 
     // row.id can be a string in legacy files
     assert.strictEqual(layout.tablet.layer[0].row[0].id, 1);
@@ -58,11 +56,10 @@ describe('TouchLayoutFileReader', function () {
 
   it('should fixup remove empty arrays in a valid legacy file', function() {
     const path = makePathToFixture('keyman-touch-layout', 'legacy.keyman-touch-layout');
-    const schema = loadKeymanTouchLayoutCleanJsonSchema();
     const input = fs.readFileSync(path);
     const reader = new TouchLayoutFileReader();
     const layout = reader.read(input);
-    reader.validate(layout, schema);
+    reader.validate(layout);
 
     // sk was defined as [] in legacy.keyman-touch-layout but we want to treat
     // it as not present

--- a/common/web/types/test/kpj/test-kpj-file-reader.ts
+++ b/common/web/types/test/kpj/test-kpj-file-reader.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import 'mocha';
 import {assert} from 'chai';
-import { loadSchema, makePathToFixture } from '../helpers/index.js';
+import { makePathToFixture } from '../helpers/index.js';
 import { KPJFileReader } from "../../src/kpj/kpj-file-reader.js";
 import { KeymanDeveloperProjectFile10, KeymanDeveloperProjectType } from '../../src/kpj/keyman-developer-project.js';
 import { TestCompilerCallbacks } from '../helpers/TestCompilerCallbacks.js';
@@ -16,7 +16,7 @@ describe('kpj-file-reader', function () {
     const reader = new KPJFileReader(callbacks);
     const kpj = reader.read(input);
     assert.doesNotThrow(() => {
-      reader.validate(kpj, loadSchema('kpj'), loadSchema('kpj-9.0'));
+      reader.validate(kpj); //loadSchema('kpj'), loadSchema('kpj-9.0'));
     });
     assert.equal(kpj.KeymanDeveloperProject.Options.BuildPath, '$PROJECTPATH\\build');
     assert.equal(kpj.KeymanDeveloperProject.Options.CheckFilenameConventions, 'False');

--- a/common/web/types/test/kpj/test-kpj-file-reader.ts
+++ b/common/web/types/test/kpj/test-kpj-file-reader.ts
@@ -16,7 +16,7 @@ describe('kpj-file-reader', function () {
     const reader = new KPJFileReader(callbacks);
     const kpj = reader.read(input);
     assert.doesNotThrow(() => {
-      reader.validate(kpj); //loadSchema('kpj'), loadSchema('kpj-9.0'));
+      reader.validate(kpj);
     });
     assert.equal(kpj.KeymanDeveloperProject.Options.BuildPath, '$PROJECTPATH\\build');
     assert.equal(kpj.KeymanDeveloperProject.Options.CheckFilenameConventions, 'False');

--- a/common/web/types/test/kvk/test-kvk-round-trip.ts
+++ b/common/web/types/test/kvk/test-kvk-round-trip.ts
@@ -4,7 +4,7 @@ import {assert} from 'chai';
 import Hexy from 'hexy';
 import gitDiff from 'git-diff';
 const { hexy } = Hexy;
-import { loadSchema, makePathToFixture } from '../helpers/index.js';
+import { makePathToFixture } from '../helpers/index.js';
 import KvksFileReader from "../../src/kvk/kvks-file-reader.js";
 import KvkFileReader from "../../src/kvk/kvk-file-reader.js";
 import KvkFileWriter from "../../src/kvk/kvk-file-writer.js";
@@ -51,7 +51,7 @@ describe('kvks-file-reader', function () {
     const reader = new KvksFileReader();
     const kvks = reader.read(input);
     assert.doesNotThrow(() => {
-      reader.validate(kvks, loadSchema('kvks'));
+      reader.validate(kvks);
     });
     const invalidVkeys: string[] = [];
     const vk = reader.transform(kvks, invalidVkeys);
@@ -74,7 +74,7 @@ describe('kvks-file-reader', function () {
       // Now, re-read kvk from the kvks
       const kvks = kvksReader.read(Buffer.from(kvksOut));
       assert.doesNotThrow(() => {
-        kvksReader.validate(kvks, loadSchema('kvks'));
+        kvksReader.validate(kvks);
       });
       const invalidVkeys: string[] = [];
       const vk2 = kvksReader.transform(kvks, invalidVkeys);

--- a/common/web/types/test/kvk/test-kvks-file.ts
+++ b/common/web/types/test/kvk/test-kvks-file.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import 'mocha';
-import { loadSchema, makePathToFixture } from '../helpers/index.js';
+import { makePathToFixture } from '../helpers/index.js';
 import KvksFileReader from "../../src/kvk/kvks-file-reader.js";
 import KvksFileWriter from "../../src/kvk/kvks-file-writer.js";
 import { verify_khmer_angkor, verify_balochi_inpage } from './test-kvk-utils.js';
@@ -14,7 +14,7 @@ describe('kvks-file-reader', function() {
     const reader = new KvksFileReader();
     const kvks = reader.read(input);
     assert.doesNotThrow(() => {
-      reader.validate(kvks, loadSchema('kvks'));
+      reader.validate(kvks);
     });
     const invalidVkeys: string[] = [];
     const vk = reader.transform(kvks, invalidVkeys);

--- a/common/web/types/tsconfig.json
+++ b/common/web/types/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "build/src/",
     "rootDir": "src/",
     "baseUrl": ".",
-    "allowSyntheticDefaultImports": true // for ajv
+    "allowSyntheticDefaultImports": true, // for ajv
+    "resolveJsonModule": true,
   },
   "include": [
     "src/**/*.ts"

--- a/developer/src/common/web/test-helpers/index.ts
+++ b/developer/src/common/web/test-helpers/index.ts
@@ -1,11 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { CompilerEvent, CompilerCallbacks, CompilerSchema, CompilerPathCallbacks, CompilerFileSystemCallbacks, CompilerError } from '@keymanapp/common-types';
+import { CompilerEvent, CompilerCallbacks, CompilerPathCallbacks, CompilerFileSystemCallbacks, CompilerError } from '@keymanapp/common-types';
 export { verifyCompilerMessagesObject } from './verifyCompilerMessagesObject.js';
-
-// TODO: schemas are only used by kmc-ldml for now, so this works at this
-// time, but it's a little fragile if we need them elsewhere in the future
-const SCHEMA_BASE = '../../../../kmc-ldml/build/src/';
 
 /**
  * A CompilerCallbacks implementation for testing
@@ -71,10 +67,6 @@ export class TestCompilerCallbacks implements CompilerCallbacks {
   reportMessage(event: CompilerEvent): void {
     // console.log(event.message);
     this.messages.push(event);
-  }
-
-  loadSchema(schema: CompilerSchema): Uint8Array {
-    return fs.readFileSync(new URL(SCHEMA_BASE + schema + '.schema.json', import.meta.url));
   }
 
   debug(msg: string) {

--- a/developer/src/kmc-analyze/src/osk-rewrite-pua/index.ts
+++ b/developer/src/kmc-analyze/src/osk-rewrite-pua/index.ts
@@ -18,7 +18,7 @@ export class AnalyzeOskRewritePua {
   //
 
   public async analyze(file: string, mapping: Osk.StringResult[]): Promise<boolean> {
-    let map: Osk.PuaMap = Osk.parseMapping(mapping, this.callbacks.loadSchema('displaymap'));
+    let map: Osk.PuaMap = Osk.parseMapping(mapping);
 
     switch(KeymanFileTypes.sourceTypeFromFilename(file)) {
       case KeymanFileTypes.Source.VisualKeyboard:

--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -364,7 +364,7 @@ export class KmnCompiler implements UnicodeSetParser {
       let kvks = null;
       try {
         kvks = reader.read(this.callbacks.loadFile(kvksFilename));
-        reader.validate(kvks, this.callbacks.loadSchema('kvks'));
+        reader.validate(kvks);
       } catch(e) {
         this.callbacks.reportMessage(CompilerMessages.Error_InvalidKvksFile({filename, e}));
         return null;
@@ -399,9 +399,8 @@ export class KmnCompiler implements UnicodeSetParser {
     try {
       // Expected file format: displaymap.schema.json
       const data = this.callbacks.loadFile(displayMapFilename);
-      const schema = this.callbacks.loadSchema('displaymap');
       const mapping = JSON.parse(new TextDecoder().decode(data));
-      return Osk.parseMapping(mapping, schema);
+      return Osk.parseMapping(mapping);
     } catch(e) {
       this.callbacks.reportMessage(CompilerMessages.Error_InvalidDisplayMapFile({filename: displayMapFilename, e}));
       return null;

--- a/developer/src/kmc-ldml/build.sh
+++ b/developer/src/kmc-ldml/build.sh
@@ -42,29 +42,9 @@ if builder_start_action clean; then
   builder_finish_action success clean
 fi
 
-SCHEMAS_COPIED=false
-
-copy_schemas() {
-  # TODO: why do we need a copy of the schemas here? kmc already has a copy of
-  #       them; are they used only by tests, in which case, can't we use them in
-  #       their source location?
-  if $SCHEMAS_COPIED; then
-    return 0
-  fi
-  SCHEMAS_COPIED=true
-  # We need the schema file at runtime and bundled, so always copy it for all actions except `clean`
-  mkdir -p "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/common/schemas/kpj/kpj.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-  cp "$KEYMAN_ROOT/common/schemas/kpj-9.0/kpj-9.0.schema.json" "$THIS_SCRIPT_PATH/build/src/"
-}
-
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action configure; then
-  copy_schemas
   verify_npm_setup
   builder_finish_action success configure
 fi
@@ -72,7 +52,6 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action build; then
-  copy_schemas
   npm run build
   builder_finish_action success build
 fi
@@ -80,8 +59,6 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action build-fixtures; then
-  copy_schemas
-
   # Build basic.kmx and emit its checksum
   mkdir -p ./build/test/fixtures
   node ../kmc build ./test/fixtures/basic.xml --no-compiler-version --debug --out-file ./build/test/fixtures/basic-xml.kmx
@@ -97,7 +74,6 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action test; then
-  copy_schemas
   npm test
   builder_finish_action success test
 fi
@@ -105,12 +81,10 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action publish; then
-  copy_schemas
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
   builder_publish_to_npm
   builder_finish_action success publish
 elif builder_start_action pack; then
-  copy_schemas
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
   builder_publish_to_pack
   builder_finish_action success pack

--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -100,7 +100,7 @@ export class LdmlKeyboardCompiler {
     }
     try {
       // validate the object tree against the .xsd schema
-      if (!reader.validate(source, this.callbacks.loadSchema('ldml-keyboard'))) {
+      if (!reader.validate(source)) {
         return null;
       }
     } catch(e) {
@@ -133,7 +133,7 @@ export class LdmlKeyboardCompiler {
       // TODO-LDML: The unboxed data doesn't match the schema anymore. Skipping validation, for now.
 
       // try {
-      //   if (!reader.validate(source, this.callbacks.loadSchema('ldml-keyboard-test'))) {
+      //   if (!reader.validate(source)) {
       //     return null;
       //   }
       // } catch(e) {

--- a/developer/src/kmc-ldml/test/helpers/index.ts
+++ b/developer/src/kmc-ldml/test/helpers/index.ts
@@ -61,7 +61,7 @@ export async function loadSectionFixture(compilerClass: typeof SectionCompiler, 
   const source = reader.load(data);
   assert.isNotNull(source, `Failed to load XML from ${inputFilename}`);
 
-  if (!reader.validate(source, callbacks.loadSchema('ldml-keyboard'))) {
+  if (!reader.validate(source)) {
     return null; // mimic kmc behavior - bail if validate fails
   }
 

--- a/developer/src/kmc-ldml/test/test-compiler-e2e.ts
+++ b/developer/src/kmc-ldml/test/test-compiler-e2e.ts
@@ -4,7 +4,6 @@ import x_hextobin from '@keymanapp/hextobin';
 import { KMXBuilder } from '@keymanapp/common-types';
 import {checkMessages, compileKeyboard, compilerTestCallbacks, compilerTestOptions, makePathToFixture} from './helpers/index.js';
 import { LdmlKeyboardCompiler } from '../src/compiler/compiler.js';
-import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 
 const hextobin = (x_hextobin as any).default;
 
@@ -49,15 +48,6 @@ describe('compiler-tests', function() {
   it('should handle not-valid files', () => {
     const filename = makePathToFixture('test-fr.xml'); // not a keyboard .xml file
     const k = new LdmlKeyboardCompiler(compilerTestCallbacks, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false });
-    const source = k.load(filename);
-    assert.notOk(source, `Trying to load(${filename})`);
-  });
-  it('should throw on broken schema', () => {
-    const filename = makePathToFixture('basic.xml');
-    const callbacks = new TestCompilerCallbacks();
-    // simulate broken schema
-    callbacks.loadSchema = () => new Uint8Array();
-    const k = new LdmlKeyboardCompiler(callbacks, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false });
     const source = k.load(filename);
     assert.notOk(source, `Trying to load(${filename})`);
   });

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -54,28 +54,9 @@ if builder_start_action clean; then
   builder_finish_action success clean
 fi
 
-function copy_schemas() {
-  # We need the schema file at runtime and bundled, so always copy it for all actions except `clean`
-  local schemas=(
-    "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboard.schema.json"
-    "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/techpreview/ldml-keyboardtest.schema.json"
-    "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json"
-    "$KEYMAN_ROOT/common/schemas/kpj/kpj.schema.json"
-    "$KEYMAN_ROOT/common/schemas/kpj-9.0/kpj-9.0.schema.json"
-    "$KEYMAN_ROOT/common/schemas/displaymap/displaymap.schema.json"
-  )
-
-  mkdir -p "$THIS_SCRIPT_PATH/build/src/util/"
-  cp "${schemas[@]}" "$THIS_SCRIPT_PATH/build/src/util/"
-
-  mkdir -p "$THIS_SCRIPT_PATH/build/dist/"
-  cp "${schemas[@]}" "$THIS_SCRIPT_PATH/build/dist/"
-}
-
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action configure; then
-  copy_schemas
   verify_npm_setup
   builder_finish_action success configure
 fi
@@ -83,7 +64,6 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action build; then
-  copy_schemas
   npm run build
   builder_finish_action success build
 fi
@@ -91,7 +71,6 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action test; then
-  copy_schemas
   eslint .
   tsc --build test/
   mocha
@@ -103,7 +82,6 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action bundle; then
-
   if ! builder_has_option --build-path; then
     builder_finish_action "Parameter --build-path is required" bundle
     exit 64
@@ -113,8 +91,7 @@ if builder_start_action bundle; then
   mkdir -p build/dist
   node build-bundler.js
 
-  # Manually copy over kmcmplib module and schemas
-  copy_schemas
+  # Manually copy over kmcmplib module
   cp ../kmc-kmn/build/src/import/kmcmplib/wasm-host.wasm build/dist/
 
   cp build/dist/* "$BUILD_PATH"

--- a/developer/src/kmc/src/commands/buildClasses/BuildProject.ts
+++ b/developer/src/kmc/src/commands/buildClasses/BuildProject.ts
@@ -88,10 +88,8 @@ class ProjectBuilder {
     const kpjData = this.callbacks.loadFile(this.infile);
     const reader = new KPJFileReader(this.callbacks);
     const kpj = reader.read(kpjData);
-    const schema = this.callbacks.loadSchema('kpj');
-    const legacySchema = this.callbacks.loadSchema('kpj-9.0');
     try {
-      reader.validate(kpj, schema, legacySchema);
+      reader.validate(kpj);
     } catch(e) {
       this.callbacks.reportMessage(InfrastructureMessages.Error_InvalidProjectFile({message: (e??'').toString()}));
       return null;

--- a/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { CompilerCallbacks, CompilerSchema, CompilerEvent,
+import { CompilerCallbacks, CompilerEvent,
          CompilerPathCallbacks, CompilerFileSystemCallbacks,
          compilerLogLevelToSeverity, CompilerErrorSeverity,
          CompilerError,
@@ -171,11 +171,6 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
     if(this.options.logLevel == 'debug') {
       console.debug(msg);
     }
-  }
-
-  loadSchema(schema: CompilerSchema): Uint8Array {
-    let schemaPath = new URL('./' + schema + '.schema.json', import.meta.url);
-    return fs.readFileSync(schemaPath);
   }
 
   fileExists(filename: string) {


### PR DESCRIPTION
Fixes #9253.

Removes the `loadSchema` function and instead resolves schema with import statements. Next commit will do the same work for Developer modules.

Note that this uses "import assertions" which are still experimental, but implemented in Node 17+, and are being renamed to "import attributes". Use of the `@ts-expect-error` hint will help cleanup and checking when we upgrade TS.

@keymanapp-test-bot skip