### PR TITLE
fix(core): don't use double newlines in debuglog

### DIFF
--- a/core/src/debuglog.cpp
+++ b/core/src/debuglog.cpp
@@ -358,7 +358,7 @@ int DebugLog_1(const char *file, int line, const char *function, const char *fmt
           "%ld" TAB   //"TickCount" TAB
           "%s:%d" TAB //"SourceFile" TAB
           "%s" TAB    //"Function"
-          "%s" NL,    //"Message"
+          "%s",    //"Message"
 
           GetTickCount(), //"TickCount" TAB
           file, line,     //"SourceFile" TAB


### PR DESCRIPTION
- syslog() will automatically add newlines (per mac and linux manpages)
- there's no reason to add NL *AND* add std::endl
- this fix will cause syslog to have no newline going in, and print only one instead of two newlines on other platforms/environments

Just an annoyance now that I'm using DebugLog a lot.

@keymanapp-test-bot skip