### PR TITLE
fix(common): set variables need to serialize elementstring 🙀

### DIFF
--- a/common/web/types/src/kmx/kmx-plus-builder/build-vars.ts
+++ b/common/web/types/src/kmx/kmx-plus-builder/build-vars.ts
@@ -2,13 +2,14 @@ import { constants } from "@keymanapp/ldml-keyboard-constants";
 import { KMXPlusData } from "../kmx-plus.js";
 import { build_strs_index, BUILDER_STRS } from "./build-strs.js";
 import { BUILDER_SECTION } from "./builder-section.js";
+import { build_elem_index, BUILDER_ELEM } from "./build-elem.js";
 
 
 interface BUILDER_VARS_ITEM {
   type: number;
   id: number; // str
   value: number; // str
-  elem?: number; // elem, TODO-LDML
+  elem?: number; // elem
 };
 
 export interface BUILDER_VARS extends BUILDER_SECTION {
@@ -20,7 +21,7 @@ export interface BUILDER_VARS extends BUILDER_SECTION {
 /**
 * Builder for the 'vars' section
 */
-export function build_vars(kmxplus: KMXPlusData, sect_strs: BUILDER_STRS /*, sect_elem: BUILDER_ELEM*/) : BUILDER_VARS {
+export function build_vars(kmxplus: KMXPlusData, sect_strs: BUILDER_STRS, sect_elem: BUILDER_ELEM) : BUILDER_VARS {
   if(!kmxplus.vars) {
     return null;
   }
@@ -34,6 +35,7 @@ export function build_vars(kmxplus: KMXPlusData, sect_strs: BUILDER_STRS /*, sec
     type: constants.vars_entry_type_set,
     id: build_strs_index(sect_strs, v.id),
     value: build_strs_index(sect_strs, v.value),
+    elem: build_elem_index(sect_elem, v.items),
   });
   const uniSetVars = kmxplus.vars.unicodeSets.map(v => <BUILDER_VARS_ITEM>{
     type: constants.vars_entry_type_unicodeSet,

--- a/common/web/types/src/kmx/kmx-plus-builder/kmx-plus-builder.ts
+++ b/common/web/types/src/kmx/kmx-plus-builder/kmx-plus-builder.ts
@@ -99,7 +99,7 @@ export default class KMXPlusBuilder {
     this.sect.name = build_name(this.file.kmxplus, this.sect.strs);
     this.sect.tran = build_tran(this.file.kmxplus.tran, this.sect.strs, this.sect.elem);
     this.sect.uset = build_uset(this.file.kmxplus, this.sect.strs);
-    this.sect.vars = build_vars(this.file.kmxplus, this.sect.strs);
+    this.sect.vars = build_vars(this.file.kmxplus, this.sect.strs, this.sect.elem);
     this.sect.vkey = build_vkey(this.file.kmxplus);
 
     // Finalize the sect (index) section

--- a/developer/src/kmc-ldml/test/fixtures/basic.txt
+++ b/developer/src/kmc-ldml/test/fixtures/basic.txt
@@ -528,7 +528,7 @@ block(vars)                         # struct COMP_KMXPLUS_VARS {
   01 00 00 00                       #   KMX_DWORD type = set
   index(strNull,strVse,2)           #   KMXPLUS_STR id  'vse'
   index(strNull,strSet,2)           #   KMXPLUS_STR value 'a b c'
-  00 00 00 00                       #   KMXPLUS_ELEM elem TODO-LDML should be set
+  01 00 00 00                       #   KMXPLUS_ELEM elem 'a b c' see 'elemSet'
 
   # var 1
   00 00 00 00                       #   KMX_DWORD type = string


### PR DESCRIPTION
- populate the 'elem' field of set variables
- this will be needed for mapFrom/mapTo

For: #7375

@keymanapp-test-bot skip

found during a recent TODO sweep