### PR TITLE
feat(core): load reorder from kmx+, test case 🙀

### DIFF
--- a/core/src/ldml/ldml_transforms.cpp
+++ b/core/src/ldml/ldml_transforms.cpp
@@ -548,13 +548,18 @@ transforms::load(
 
         bool load_ok = elements.load(kplus, reorder->elements) && before.load(kplus, reorder->before);
         assert(load_ok);
-
-        newGroup.list.emplace_back(elements, before);
+        if (load_ok) {
+          newGroup.list.emplace_back(elements, before);
+        } else {
+          return nullptr;
+        }
       }
       transforms->addGroup(newGroup);
     } else {
       // internal error - some other type - should have been caught by validation
       DebugLog("ERROR: some other type");
+      assert(false);
+      return nullptr;
     }
   }
   return transforms;

--- a/core/src/ldml/ldml_transforms.cpp
+++ b/core/src/ldml/ldml_transforms.cpp
@@ -546,8 +546,8 @@ transforms::load(
         element_list elements;
         element_list before;
 
-        assert(elements.load(kplus, reorder->elements));
-        assert(before.load(kplus, reorder->before));
+        bool load_ok = elements.load(kplus, reorder->elements) && before.load(kplus, reorder->before);
+        assert(load_ok);
 
         newGroup.list.emplace_back(elements, before);
       }

--- a/core/src/ldml/ldml_transforms.cpp
+++ b/core/src/ldml/ldml_transforms.cpp
@@ -141,6 +141,29 @@ element_list::match_end(const std::u32string &str) const {
   return size();  // match size = element size
 }
 
+bool
+element_list::load(const kmx::kmx_plus &kplus, kmx::KMXPLUS_ELEM id) {
+  KMX_DWORD elementsLength;
+  auto elements = kplus.elem->getElementList(id, elementsLength);
+  assert((elementsLength == 0) || (elements != nullptr));
+  for (size_t i = 0; i<elementsLength; i++) {
+    auto e = elements[i];
+    auto flags = e.flags;
+    auto type = flags & LDML_ELEM_FLAGS_TYPE;
+    if (type == LDML_ELEM_FLAGS_TYPE_CHAR) {
+      emplace_back(e.element, flags); // char
+    } else if (type == LDML_ELEM_FLAGS_TYPE_USET) {
+      auto u = kplus.usetHelper.getUset(e.element);
+      emplace_back(u, e.flags);
+    } else {
+      // not handled
+      assert((type != LDML_ELEM_FLAGS_TYPE_USET) && (type != LDML_ELEM_FLAGS_TYPE_CHAR));
+      return false;
+    }
+  }
+  return true;
+}
+
 std::deque<reorder_sort_key> &
 element_list::update_sort_key(size_t offset, std::deque<reorder_sort_key> &key) const {
   size_t c = 0;
@@ -514,8 +537,21 @@ transforms::load(
       }
       transforms->addGroup(newGroup);
     } else if (group->type == LDML_TRAN_GROUP_TYPE_REORDER) {
-      // TODO-LDML: reorder
-      DebugLog("Skipping reorder (for now) TODO-LDML");
+      reorder_group newGroup;
+
+      // fetch each reorder in the group
+      for (KMX_DWORD itemNumber = 0; itemNumber < group->count; itemNumber++) {
+        const kmx::COMP_KMXPLUS_TRAN_REORDER *reorder = tranHelper.getReorder(group->index + itemNumber);
+
+        element_list elements;
+        element_list before;
+
+        assert(elements.load(kplus, reorder->elements));
+        assert(before.load(kplus, reorder->before));
+
+        newGroup.list.emplace_back(elements, before);
+      }
+      transforms->addGroup(newGroup);
     } else {
       // internal error - some other type - should have been caught by validation
       DebugLog("ERROR: some other type");

--- a/core/src/ldml/ldml_transforms.hpp
+++ b/core/src/ldml/ldml_transforms.hpp
@@ -140,6 +140,10 @@ public:
    * @returns the key parameter
   */
   std::deque<reorder_sort_key> &update_sort_key(size_t offset, std::deque<reorder_sort_key> &key) const;
+
+  /** construct from KMX+ elem id*/
+  bool
+  load(const kmx::kmx_plus& kplus, kmx::KMXPLUS_ELEM id);
 };
 
 class reorder_entry {

--- a/core/tests/unit/ldml/keyboards/k_200_reorder_nod_Lana-test.xml
+++ b/core/tests/unit/ldml/keyboards/k_200_reorder_nod_Lana-test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboardTest SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboardTest.dtd">
+<keyboardTest conformsTo="techpreview">
+  <info keyboard="k_200_reorder_nod_Lana.xml" author="Team Keyboard" name="nod-Lana" />
+  <tests name="reorder-tests">
+    <test name="roast0-orig">
+      <startContext to="" />
+      <keystroke key="kha" />
+      <keystroke key="sakot" />
+      <keystroke key="wa" />
+      <keystroke key="o" />
+      <keystroke key="t2" />
+      <check result="\u1A21\u1A60\u1A45\u1A6B\u1A76" />
+    </test>
+    <!-- <test name="roast1-upper-first">
+      <startContext to="" />
+      <keystroke key="kha" />
+      <keystroke key="o" />
+      <keystroke key="t2" />
+      <keystroke key="sakot" />
+      <keystroke key="wa" />
+      <check result="\u1A21\u1A60\u1A45\u1A6B\u1A76" />
+    </test>
+    <test name="roast2-upper-first-nfc">
+      <startContext to="" />
+      <keystroke key="kha" />
+      <keystroke key="o" />
+      <keystroke key="sakot" />
+      <keystroke key="t2" />
+      <keystroke key="wa" />
+      <check result="\u1A21\u1A60\u1A45\u1A6B\u1A76" />
+    </test>
+    <test name="roast3-tone-after-lower">
+      <startContext to="" />
+      <keystroke key="kha" />
+      <keystroke key="o" />
+      <keystroke key="sakot" />
+      <keystroke key="wa" />
+      <keystroke key="t2" />
+      <check result="\u1A21\u1A60\u1A45\u1A6B\u1A76" />
+    </test> -->
+  </tests>
+</keyboardTest>

--- a/core/tests/unit/ldml/keyboards/k_200_reorder_nod_Lana.xml
+++ b/core/tests/unit/ldml/keyboards/k_200_reorder_nod_Lana.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Test Keyboard from Spec
+  see https://keyman.com/keyboards/sil_boonkit
+-->
+
+<!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
+<keyboard locale="nod" conformsTo="techpreview">
+  <info author="srl295" indicator="🙀" layout="qwerty" normalization="NFC" />
+  <names>
+    <name value="nod-Lana Test" />
+  </names>
+
+  <keys>
+    <key id="kha" to="\u{1A21}" />
+    <key id="sakot" to="\u{1A60}" />
+    <key id="wa" to="\u{1A45}" />
+    <key id="o" to="\u{1A6B}" />
+    <key id="t2" to="\u{1A76}" />
+  </keys>
+
+  <layers form="us">
+    <layer modifier="none" id="base">
+      <row keys="gap" />
+      <row keys="gap wa gap gap t2 gap gap gap o gap" />
+      <row keys="gap sakot gap gap gap gap gap kha gap" />
+      <row keys="gap gap gap gap gap gap gap" />
+      <row keys="space" />
+    </layer>
+  </layers>
+
+
+  <transforms type="simple">
+    <transformGroup>
+      <!-- from the spec: nod-Lana for ᩅᩫ᩶  -->
+      <reorder from="\u1A60" order="127" />
+      <reorder from="\u1A6B" order="42" />
+      <reorder from="[\u1A75-\u1A79]" order="55" />
+      <reorder before="\u1A6B" from="\u1A60\u1A45" order="10" />
+      <reorder before="\u1A6B[\u1A75-\u1A79]" from="\u1A60\u1A45" order="10" />
+      <reorder before="\u1A6B" from="\u1A60[\u1A75-\u1A79]\u1A45" order="10 55 10" />
+    </transformGroup>
+  </transforms>
+</keyboard>

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -26,12 +26,14 @@ tests_without_testdata = [
   'k_100_keytest',
   'k_101_keytest',
   'k_102_keytest',
+
 ]
 
 # These tests have a k_001_tiny-test.xml file as well.
 tests_with_testdata = [
   'k_001_tiny',
   'fr-t-k0-azerty', # TODO-LDML: move to cldr above (fix vkey)
+  'k_200_reorder_nod_Lana',
 ]
 
 tests =  tests_without_testdata


### PR DESCRIPTION
- load reorder groups and their usets from KMX+
- add a test case matching the nod-Lana spec entry
(the interesting cases commented out for now)

For: #7375

@keymanapp-test-bot skip

~[I somehow picked up #9259 so will need to rebase once that merges]~ fixed it…