### PR TITLE
chore(web): gesture-engine unit test touchup 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/cumulativePathStats.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/cumulativePathStats.ts
@@ -65,6 +65,7 @@ export class CumulativePathStats {
      * @param independentAxis The 'input' axis/dimension.
      */
     constructor(mainStats: CumulativePathStats, dependentAxis: PathCoordAxis, independentAxis: PathCoordAxis) {
+      /* c8 ignore next 3 */
       if(dependentAxis == independentAxis) {
         throw new Error("Two different axes must be specified for the regression object.");
       }
@@ -218,6 +219,7 @@ export class CumulativePathStats {
       this.rawSquaredSums   = {...obj.rawSquaredSums};
     } else if(isAnInputSample(obj)) {
       Object.assign(this, this.extend(obj));
+      /* c8 ignore next 3 */
     } else {
       throw new Error("A constructor for this input pattern has not yet been implemented");
     }
@@ -322,6 +324,7 @@ export class CumulativePathStats {
       return result;
     }
 
+    /* c8 ignore next 3 */
     if(!subsetStats.followingSample || !subsetStats.lastSample) {
       throw 'Invalid argument:  stats missing necessary tracking variable.';
     }
@@ -721,6 +724,7 @@ export class CumulativePathStats {
     return this.coordArcSum;
   }
 
+  /* c8 ignore start */
   /**
    * Provides a JSON.stringify()-friendly object with the properties most useful for
    * debugger-based inspection and/or console-logging statements.
@@ -739,4 +743,5 @@ export class CumulativePathStats {
       speedVariance: this.variance('v')
     }
   }
+  /* c8 ignore end */
 }

--- a/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
@@ -97,6 +97,7 @@ export class GesturePath<Type> extends EventEmitter<EventMap<Type>> {
    * @param sample
    */
   extend(sample: InputSample<Type>) {
+    /* c8 ignore next 3 */
     if(this._isComplete) {
       throw new Error("Invalid state:  this GesturePath has already terminated.");
     }
@@ -113,6 +114,7 @@ export class GesturePath<Type> extends EventEmitter<EventMap<Type>> {
    * @param cancel Whether or not this finalization should trigger cancellation.
    */
   terminate(cancel: boolean = false) {
+    /* c8 ignore next 3 */
     if(this._isComplete) {
       throw new Error("Invalid state:  this GesturePath has already terminated.");
     }
@@ -161,6 +163,11 @@ export class GesturePath<Type> extends EventEmitter<EventMap<Type>> {
     for(let sample of jsonClone.coords) {
       delete sample.clientX;
       delete sample.clientY;
+
+      // No point in serializing an `undefined` 'item' entry.
+      if(sample.item === undefined) {
+        delete sample.item;
+      }
     }
 
     return jsonClone;

--- a/common/web/gesture-recognizer/src/test/auto/headless/pathStats.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/pathStats.ts
@@ -1,10 +1,42 @@
 import { assert } from 'chai';
+import { CumulativePathStats, InputSample } from '@keymanapp/gesture-recognizer';
 
-import { CumulativePathStats } from '@keymanapp/gesture-recognizer';
+import { TouchpathTurtle } from '../../../../build/tools/obj/index.js';
 
 describe("CumulativePathStats", function() {
+  it("Sample count = 0", function() {
+    let stats = new CumulativePathStats();
+
+    assert.equal(stats.duration, 0);
+    assert.equal(stats.angle, undefined);
+    assert.isNaN(stats.angleDeviation);
+    assert.equal(stats.cardinalDirection, undefined);
+    assert.equal(stats.rawDistance, 0);
+    assert.equal(stats.netDistance, 0);
+    assert.isNaN(stats.mean('x'));
+    assert.isNaN(stats.mean('y'));
+  });
+
+  it("Sample count = 1", function() {
+    let stats = new CumulativePathStats();
+    stats = stats.extend({
+      targetX: 4,
+      targetY: 8,
+      t: 40
+    });
+
+    assert.equal(stats.duration, 0);
+    assert.equal(stats.angle, undefined);
+    assert.isNaN(stats.angleDeviation);
+    assert.equal(stats.cardinalDirection, undefined);
+    assert.isNaN(stats.variance('x'));
+    assert.isNaN(stats.variance('y'));
+    assert.equal(stats.mean('x'), 4);
+    assert.equal(stats.mean('y'), 8);
+  });
+
   it("Basic accumulation (perfect correlation)", function() {
-    const samples = [];
+    const samples: InputSample<any>[] = [];
 
     // Exactly 5 points, evenly spaced and linear.
     // So, the arithmetic mean should be very obvious - it's the middle sample.
@@ -40,7 +72,7 @@ describe("CumulativePathStats", function() {
   });
 
   it("Immutability (aside from .followingSample)", function() {
-    const samples = [];
+    const samples: InputSample<any>[] = [];
 
     // Exactly 5 points, evenly spaced and linear.
     // So, the arithmetic mean should be very obvious - it's the middle sample.
@@ -53,8 +85,8 @@ describe("CumulativePathStats", function() {
     }
 
     let stats = new CumulativePathStats();
-    let preStats  = [];
-    let postStats = [];
+    let preStats: CumulativePathStats[]  = [];
+    let postStats: CumulativePathStats[] = [];
 
     for(const sample of samples) {
       const initialValue = stats;
@@ -67,7 +99,8 @@ describe("CumulativePathStats", function() {
     // The one not-immutable part:  `.followingSample`.  It's needed for some of the
     // internal mechanisms - for `.deaccumulate`, in particular.
     for(let obj of postStats) {
-      delete obj.followingSample;
+      // is technically private; we delete it b/c it'd get in the way of the assertion below.
+      delete obj['followingSample'];
     }
 
     // The very first sample has a few more changes because of recording the first (and thus, base) sample.
@@ -79,7 +112,7 @@ describe("CumulativePathStats", function() {
   });
 
   it("Basic regressions (perfect correlation)", function() {
-    const samples = [];
+    const samples: InputSample<any>[] = [];
 
     // Exactly 5 points, evenly spaced and linear.
     // So, the arithmetic mean should be very obvious - it's the middle sample.
@@ -117,7 +150,7 @@ describe("CumulativePathStats", function() {
   });
 
   it("Deaccumulation", function() {
-    const sampleSet1 = [];
+    const sampleSet1: InputSample<any>[] = [];
 
     // Exactly 5 points, evenly spaced and linear.
     // So, the arithmetic mean should be very obvious - it's the middle sample.
@@ -129,7 +162,7 @@ describe("CumulativePathStats", function() {
       });
     }
 
-    let firstHalfStats  = new CumulativePathStats();
+    let firstHalfStats = new CumulativePathStats();
 
     for(const sample of sampleSet1) {
       firstHalfStats = firstHalfStats.extend(sample);
@@ -143,7 +176,7 @@ describe("CumulativePathStats", function() {
 
     firstHalfStats = firstHalfStats.extend(splitPoint);
 
-    const sampleSet2 = [];
+    const sampleSet2: InputSample<any>[] = [];
 
     // Exactly 5 points, evenly spaced and linear.
     // So, the arithmetic mean should be very obvious - it's the middle sample.
@@ -180,11 +213,14 @@ describe("CumulativePathStats", function() {
     assert.equal(deaccumulatedSecondHalfStats.variance('y'), secondHalfStats.variance('y'));
     assert.equal(deaccumulatedSecondHalfStats.variance('t'), secondHalfStats.variance('t'));
 
-    assert.equal(deaccumulatedSecondHalfStats.covariance('xt'), secondHalfStats.covariance('xt'));
-    assert.equal(deaccumulatedSecondHalfStats.covariance('yt'), secondHalfStats.covariance('yt'));
+    assert.equal(deaccumulatedSecondHalfStats.covariance('tx'), secondHalfStats.covariance('tx'));
+    assert.equal(deaccumulatedSecondHalfStats.covariance('ty'), secondHalfStats.covariance('ty'));
     assert.equal(deaccumulatedSecondHalfStats.covariance('xy'), secondHalfStats.covariance('xy'));
 
-    assert.equal(deaccumulatedSecondHalfStats.distance, secondHalfStats.distance);
+    // Floating-point "equality".
+    assert.closeTo(deaccumulatedSecondHalfStats.netDistance, secondHalfStats.netDistance, 1e-8);
+    assert.closeTo(deaccumulatedSecondHalfStats.rawDistance, secondHalfStats.rawDistance, 1e-8);
+
     assert.equal(deaccumulatedSecondHalfStats.duration, secondHalfStats.duration);
     assert.equal(deaccumulatedSecondHalfStats.angle, secondHalfStats.angle);
 
@@ -194,5 +230,65 @@ describe("CumulativePathStats", function() {
     // Angle deviation stuff doesn't currently have the same level of catastrophic cancellation protection
     // as the main statistical properties.  But... even still, we can add a reasonable test.
     assert.isBelow(Math.abs(deaccumulatedSecondHalfStats.angleDeviation - secondHalfStats.angleDeviation), 1e-7);
+  });
+
+  it("Renormalization", () => {
+    let stats = new CumulativePathStats();
+
+    const turtle = new TouchpathTurtle({
+      targetX: 50,
+      targetY: -25,
+      t: 500,
+      item: 'a'
+    });
+
+    turtle.on('sample', (sample) => {
+      stats = stats.extend(sample);
+    });
+
+    function assertMatchingStats(actual: CumulativePathStats, expected: CumulativePathStats) {
+      assert.equal(actual.duration, expected.duration);
+      assert.equal(actual.sampleCount, expected.sampleCount);
+
+      assert.closeTo(actual.angle, expected.angle, 1e-8);
+      assert.closeTo(actual.mean('x'), expected.mean('x'), 1e-8);
+      assert.closeTo(actual.mean('y'), expected.mean('y'), 1e-8);
+      assert.closeTo(actual.mean('t'), expected.mean('t'), 1e-8);
+
+      assert.closeTo(actual.variance('x'), expected.variance('x'), 1e-8);
+      assert.closeTo(actual.variance('y'), expected.variance('y'), 1e-8);
+      assert.closeTo(actual.variance('t'), expected.variance('t'), 1e-8);
+
+      assert.closeTo(actual.rawDistance, expected.rawDistance, 1e-8);
+      assert.closeTo(actual.netDistance, expected.netDistance, 1e-8);
+
+      const actualRegression = actual.fitRegression('x', 'y');
+      const expectedRegression = expected.fitRegression('x', 'y');
+      assert.closeTo(
+        actualRegression.coefficientOfDetermination,
+        expectedRegression.coefficientOfDetermination,
+        1e-8
+      );
+      assert.closeTo(actualRegression.slope, expectedRegression.slope, 1e-8);
+    }
+
+    turtle.move(90, 4, 20, 2);
+    turtle.move(60, 5, 20, 2); // net move:  <4, -3>.
+    turtle.commitPending();
+
+    let renormalizedStats = stats.buildRenormalized();
+    assertMatchingStats(renormalizedStats, stats);
+
+    // Continue to accumulate stats for both.
+    turtle.on('sample', (sample) => {
+      renormalizedStats = renormalizedStats.extend(sample);
+    })
+
+    turtle.move(0, 10, 40, 4);
+    turtle.move(45, 3 * Math.sqrt(2), 40, 4);
+    turtle.commitPending();
+
+    // After the renormalization, there should be no externally-visible distinction between the two stats objects.
+    assertMatchingStats(renormalizedStats, stats);
   });
 });


### PR DESCRIPTION
I just realized that in #9261, while I did rename `TrackedPath` to `GesturePath`, I neglected to update the name of its most directly-related unit test specification accordingly.  While I was at it, I took a look at the code-coverage reports and what they identified as being "not covered" and realized that a few of the blocks would be worth unit testing:

1. Serialization and deserialization of `GesturePath` data.  
    - While this functionality won't be needed in the live, published version once integrated, it plays a significant role in facilitating many of the automated tests.
2. `CumulativePathStats.buildRenormalized` is fairly mathematically-involved yet lacked a proper test.
    - Also, basic zero-sample and single-sample cases, but at least those are super-simple to spec.

Taking a page from #7440, I implemented event-emission for the "turtle" as it emulates a sequence, noting that such a feature facilitates its use for a broader range of potential automated tests.  The model gets a little more complex due to the need to manage the 'hovered item', but only a little - and part of the same change actually makes setup a little less tedious.  I then promptly used its enhancements when writing some of the new tests in this PR.

@keymanapp-test-bot skip