### PR TITLE
docs(linux): Update documentation

### DIFF
--- a/docs/linux/packaging.md
+++ b/docs/linux/packaging.md
@@ -238,8 +238,10 @@ You'll have to create the docker image.
 
   ```bash
   cd $KEYMAN_ROOT
-  docker run -v $(pwd):/source -i -t -w /source --platform=linux/amd64 \
-    sillsdev/jammy jammy keyman_*.dsc
+  DIST=jammy
+  docker run -v $(pwd):/source -i -t -w /source --platform=amd64 \
+    --env INPUT_DIST=$DIST --env INPUT_SOURCEPACKAGE=$(ls keyman_*.dsc) \
+    --env INPUT_SOURCE_DIR=. sillsdev/$DIST
   ```
 
   This will create the binary packages in `$KEYMAN_ROOT/artifacts`.

--- a/docs/settings/linux/tasks.json
+++ b/docs/settings/linux/tasks.json
@@ -139,14 +139,32 @@
     },
     {
       "type": "shell",
-      "label": "ibus-keyman: test",
+      "label": "ibus-keyman: unit tests",
       "command": "./build.sh",
-      "args": ["test", "--debug"],
+      "args": [
+        "test",
+        "--debug",
+        "--no-integration"
+      ],
       "options": {
         "cwd": "${workspaceFolder}/linux/ibus-keyman/",
       },
       "group": "build",
-      "detail": "run tests of ibus-keyman"
+      "detail": "run unit tests of ibus-keyman"
+    },
+    {
+      "type": "shell",
+      "label": "ibus-keyman: test (unit+integration)",
+      "command": "./build.sh",
+      "args": [
+        "test",
+        "--debug"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/linux/ibus-keyman/",
+      },
+      "group": "build",
+      "detail": "run unit and integration tests of ibus-keyman"
     },
     {
       "type": "shell",


### PR DESCRIPTION
- fix docker packaging command
- add option to run only unit tests to `tasks.json`

@keymanapp-test-bot skip