### PR TITLE
refactor(developer): remove node dependencies from kmc-model-info 🗜

### DIFF
--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -220,7 +220,6 @@ export interface CompilerFileSystemCallbacks {
   readFileSync(path: string, options: { encoding: string; flag?: string; } | string): string;
   readFileSync(path: string, options?: { encoding?: string | null; flag?: string; } | string | null): string | Uint8Array;
   writeFileSync(path: string, data: Uint8Array): void;
-  // statSync(path: string):
 
   existsSync(name: string): boolean;
 }

--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -220,6 +220,7 @@ export interface CompilerFileSystemCallbacks {
   readFileSync(path: string, options: { encoding: string; flag?: string; } | string): string;
   readFileSync(path: string, options?: { encoding?: string | null; flag?: string; } | string | null): string | Uint8Array;
   writeFileSync(path: string, data: Uint8Array): void;
+  // statSync(path: string):
 
   existsSync(name: string): boolean;
 }
@@ -237,10 +238,14 @@ export interface CompilerCallbacks {
   /**
    * Attempt to load a file. Return falsy if not found.
    * TODO: never return falsy, just throw if not found?
-   * @param baseFilename
    * @param filename
    */
   loadFile(filename: string): Uint8Array;
+
+  /**
+   * Get file size, returns undefined if not found
+   */
+  fileSize(filename: string): number;
 
   get path(): CompilerPathCallbacks;
   get fs(): CompilerFileSystemCallbacks;
@@ -300,6 +305,10 @@ export class CompilerFileCallbacks implements CompilerCallbacks {
 
   loadFile(filename: string): Uint8Array {
     return this.parent.loadFile(filename);
+  }
+
+  fileSize(filename: string): number {
+    return this.parent.fileSize(filename);
   }
 
   get path(): CompilerPathCallbacks {

--- a/common/web/types/test/helpers/TestCompilerCallbacks.ts
+++ b/common/web/types/test/helpers/TestCompilerCallbacks.ts
@@ -47,6 +47,10 @@ export class TestCompilerCallbacks implements CompilerCallbacks {
     }
   }
 
+  fileSize(filename: string): number {
+    return fs.statSync(filename).size;
+  }
+
   reportMessage(event: CompilerEvent): void {
     // console.log(event.message);
     this.messages.push(event);

--- a/developer/src/common/web/test-helpers/index.ts
+++ b/developer/src/common/web/test-helpers/index.ts
@@ -37,6 +37,10 @@ export class TestCompilerCallbacks implements CompilerCallbacks {
     }
   }
 
+  fileSize(filename: string): number {
+    return fs.statSync(filename)?.size;
+  }
+
   get path(): CompilerPathCallbacks {
     return path;
   }

--- a/developer/src/kmc-model-info/.eslintrc.cjs
+++ b/developer/src/kmc-model-info/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
   overrides: [
     {
       files: "src/**/*.ts",
-      // extends: ["../../../common/web/eslint/eslintNoNodeImports.js"],
+      extends: ["../../../common/web/eslint/eslintNoNodeImports.js"],
     }
   ],
   rules: {

--- a/developer/src/kmc-model-info/test/test-model-info-compiler.ts
+++ b/developer/src/kmc-model-info/test/test-model-info-compiler.ts
@@ -23,15 +23,16 @@ describe('model-info-compiler', function () {
     const kmpJsonData = kmpCompiler.transformKpsToKmpObject(kpsFileName);
     const modelFileName = makePathToFixture('sil.cmo.bw', 'build', 'sil.cmo.bw.model.js');
 
-    writeMergedModelMetadataFile(path, path+'.out', {
+    const data = writeMergedModelMetadataFile(path, callbacks, {
       kmpFileName,
       kmpJsonData,
       model_id: 'sil.cmo.bw',
       modelFileName,
       sourcePath: 'release/sil/sil.cmo.bw'
     });
+    assert.isNotNull(data);
 
-    const actual = JSON.parse(fs.readFileSync(path+'.out', 'utf-8'));
+    const actual = JSON.parse(new TextDecoder().decode(data));
     let expected = JSON.parse(fs.readFileSync(buildModelInfoFilename, 'utf-8'));
 
     // `lastModifiedDate` is dependent on time of run (not worth mocking)

--- a/developer/src/kmc/src/commands/buildClasses/BuildModelInfo.ts
+++ b/developer/src/kmc/src/commands/buildClasses/BuildModelInfo.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { BuildActivity } from './BuildActivity.js';
 import { CompilerCallbacks, CompilerOptions, KeymanFileTypes } from '@keymanapp/common-types';
 import { writeMergedModelMetadataFile } from '@keymanapp/kmc-model-info';
@@ -57,9 +58,9 @@ export class BuildModelInfo extends BuildActivity {
       throw new Error('Invalid .kps file');
     }
 
-    writeMergedModelMetadataFile(
+    const data = writeMergedModelMetadataFile(
       project.resolveInputFilePath(metadata),
-      project.resolveOutputFilePath(metadata, KeymanFileTypes.Source.ModelInfo, KeymanFileTypes.Binary.ModelInfo),
+      callbacks,
       {
         model_id: callbacks.path.basename(metadata.filename, KeymanFileTypes.Source.ModelInfo),
         kmpJsonData,
@@ -69,8 +70,15 @@ export class BuildModelInfo extends BuildActivity {
       }
     );
 
-    // Output:
-    // TODO fs.writeFileSync(options.outFile, code, 'utf8');
+    if(data == null) {
+      // TODO error would have been emitted by writeMergedModelMetadataFile
+      return false;
+    }
+
+    fs.writeFileSync(
+      project.resolveOutputFilePath(metadata, KeymanFileTypes.Source.ModelInfo, KeymanFileTypes.Binary.ModelInfo),
+      data
+    );
 
     return true;
   }

--- a/developer/src/kmc/src/kmlmi.ts
+++ b/developer/src/kmc/src/kmlmi.ts
@@ -3,6 +3,7 @@
  * kmlmi - Keyman Lexical Model model_info Compiler
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 import { Command } from 'commander';
 import { KmpCompiler, PackageValidation } from '@keymanapp/kmc-package';
@@ -74,10 +75,11 @@ let modelInfoOptions: ModelInfoOptions = {
 };
 
 try {
-  writeMergedModelMetadataFile(
+  const data = writeMergedModelMetadataFile(
     inputFilename,
-    outputFilename,
+    callbacks,
     modelInfoOptions);
+  fs.writeFileSync(outputFilename, data);
 } catch(e) {
   console.error(e);
   process.exit(SysExits.EX_DATAERR);

--- a/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
@@ -96,6 +96,10 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
     }
   }
 
+  fileSize(filename: string): number {
+    return fs.statSync(filename)?.size;
+  }
+
   get path(): CompilerPathCallbacks {
     return path;
   }


### PR DESCRIPTION
Fixes #9286.

Refactors the use of path and fs into the standard kmc callbacks pattern and adds `callbacks.fileSize()`, which is needed for populating the metadata file.

Turns on eslint test for node dependencies for kmc-model-info.

@keymanapp-test-bot skip