### PR TITLE
refactor(developer): remove node deps from kmc-model 🗜

### DIFF
--- a/developer/src/kmc-model/.eslintrc.cjs
+++ b/developer/src/kmc-model/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
   overrides: [
     {
       files: "src/**/*.ts",
-      // extends: ["../../../common/web/eslint/eslintNoNodeImports.js"],
+      extends: ["../../../common/web/eslint/eslintNoNodeImports.js"],
     },
   ],
   rules: {

--- a/developer/src/kmc-model/src/lexical-model-compiler.ts
+++ b/developer/src/kmc-model/src/lexical-model-compiler.ts
@@ -2,17 +2,14 @@
   lexical-model-compiler.ts: base file for lexical model compiler.
 */
 
-/// <reference path="./lexical-model.ts" />
-
 import * as ts from "typescript";
-import * as fs from "fs";
-import * as path from "path";
 import { createTrieDataStructure } from "./build-trie.js";
 import { ModelDefinitions } from "./model-definitions.js";
 import {decorateWithJoin} from "./join-word-breaker-decorator.js";
 import {decorateWithScriptOverrides} from "./script-overrides-decorator.js";
 import { LexicalModelSource, WordBreakerSpec, SimpleWordBreakerSpec } from "./lexical-model.js";
 import { ModelCompilerError, ModelCompilerMessages } from "./model-compiler-errors.js";
+import { callbacks } from "./compiler-callbacks.js";
 
 export default class LexicalModelCompiler {
 
@@ -38,7 +35,7 @@ export default class LexicalModelCompiler {
     switch(modelSource.format) {
       case "custom-1.0":
         let sources: string[] = modelSource.sources.map(function(source) {
-          return fs.readFileSync(path.join(sourcePath, source), 'utf8');
+          return new TextDecoder().decode(callbacks.loadFile(callbacks.path.join(sourcePath, source)));
         });
         func += this.transpileSources(sources).join('\n');
         func += `LMLayerWorker.loadModel(new ${modelSource.rootClass}());\n`;
@@ -49,7 +46,7 @@ export default class LexicalModelCompiler {
         // Convert all relative path names to paths relative to the enclosing
         // directory. This way, we'll read the files relative to the model.ts
         // file, rather than the current working directory.
-        let filenames = modelSource.sources.map(filename => path.join(sourcePath, filename));
+        let filenames = modelSource.sources.map(filename => callbacks.path.join(sourcePath, filename));
 
         let definitions = new ModelDefinitions(modelSource);
 

--- a/developer/src/kmc-model/src/main.ts
+++ b/developer/src/kmc-model/src/main.ts
@@ -1,6 +1,4 @@
 import { CompilerCallbacks } from '@keymanapp/common-types';
-import * as fs from 'fs';
-import * as path from 'path';
 import ts from 'typescript';
 import { setCompilerCallbacks } from './compiler-callbacks.js';
 
@@ -21,7 +19,7 @@ export function compileModel(filename: string, callbacks: CompilerCallbacks): st
 
   try {
     let modelSource = loadFromFilename(filename, callbacks);
-    let containingDirectory = path.dirname(filename);
+    let containingDirectory = callbacks.path.dirname(filename);
 
     return (new LexicalModelCompiler)
       .generateLexicalModelCode('<unknown>', modelSource, containingDirectory);
@@ -52,7 +50,7 @@ interface ES2015Module {
 export function loadFromFilename(filename: string, callbacks: CompilerCallbacks): LexicalModelSource {
   setCompilerCallbacks(callbacks);
 
-  let sourceCode = fs.readFileSync(filename, 'utf8');
+  let sourceCode = new TextDecoder().decode(callbacks.loadFile(filename));
   // Compile the module to JavaScript code.
   // NOTE: transpile module does a very simple TS to JS compilation.
   // It DOES NOT check for types!

--- a/developer/src/kmc-model/test/test-compile-model-with-pseudoclosure.ts
+++ b/developer/src/kmc-model/test/test-compile-model-with-pseudoclosure.ts
@@ -3,8 +3,12 @@ import {assert} from 'chai';
 import 'mocha';
 
 import { makePathToFixture, compileModelSourceCode } from './helpers/index.js';
+import { setCompilerCallbacks } from '../src/compiler-callbacks.js';
+import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 
 describe('LexicalModelCompiler - pseudoclosure compilation + use', function () {
+  setCompilerCallbacks(new TestCompilerCallbacks());
+
   const MODEL_ID = 'example.qaa.trivial';
   const PATH = makePathToFixture(MODEL_ID);
 

--- a/developer/src/kmc-model/test/test-compile-model.ts
+++ b/developer/src/kmc-model/test/test-compile-model.ts
@@ -24,10 +24,8 @@ describe('compileModel', function () {
 
     it(`should compile ${modelID}`, function () {
       let code = compileModel(modelPath, callbacks);
-      let r: unknown;
-      assert.doesNotThrow(() => {
-        r = compileModelSourceCode(code);
-      });
+      callbacks.printMessages();
+      let r = compileModelSourceCode(code);
       let compilation = r as CompilationResult;
 
       assert.isFalse(compilation.hasSyntaxError, 'model code had syntax error');

--- a/developer/src/kmc-model/test/test-punctuation.ts
+++ b/developer/src/kmc-model/test/test-punctuation.ts
@@ -3,6 +3,8 @@ import {assert} from 'chai';
 import 'mocha';
 
 import { makePathToFixture, compileModelSourceCode } from './helpers/index.js';
+import { setCompilerCallbacks } from '../src/compiler-callbacks.js';
+import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 
 describe('LexicalModelCompiler', function () {
   describe('specifying punctuation', function () {
@@ -10,6 +12,8 @@ describe('LexicalModelCompiler', function () {
     const PATH = makePathToFixture(MODEL_ID);
 
     it('should compile punctuation into the generated code', function () {
+      setCompilerCallbacks(new TestCompilerCallbacks());
+
       let compiler = new LexicalModelCompiler;
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',


### PR DESCRIPTION
Fixes #9288.

Tweaks a couple of unit tests to ensure callbacks are available, and stops masking exceptions in one test with `doesNotThrow`... if it's gonna throw then the test is gonna go bang anyway.

@keymanapp-test-bot skip