### PR TITLE
docs(linux): Update man page and remove do-nothing option

### DIFF
--- a/linux/ibus-keyman/man/ibus-engine-keyman.1
+++ b/linux/ibus-keyman/man/ibus-engine-keyman.1
@@ -1,28 +1,25 @@
-.TH IBUS-ENGINE-KEYMAN "1" "September 2018" "ibus-engine-keyman" "User Commands"
+.TH IBUS-ENGINE-KEYMAN "1" "September 2023" "ibus-engine-keyman" "User Commands"
 .SH NAME
 ibus-engine-keyman \- multiple language input engine based on ibus
 .SH DESCRIPTION
-\&ibus\-engine\-keyman [options] [engines]
+\&ibus\-engine\-keyman [options]
 .TP
 this command should run from ibus, don't run it directly.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 show this message.
 .TP
-\fB\-d\fR, \fB\-\-daemonize\fR
-daemonize ibus engine
+\fB\-x\fR, \fB\-\-xml\fR
+generate XML listing all keyboards. This is used by ibus.
 .TP
-\fB\-l\fR, \fB\-\-list\fR
-list all Keyman input methods
+\fB\-i\fR, \fB\-\-ibus\fR
+Component is executed by ibus
 .TP
-\fB\-a\fR, \fB\-\-all\fR
-enable all Keyman input methods
+\fB\-\-testing\fR
+Component is executed by integration tests.
 .SS "example:"
 .IP
-\&./ibus\-engine\-keyman zh:py ja:trycode
+\&./ibus\-engine\-keyman --ibus
 
-\&./ibus\-engine\-keyman zh:py,pinyin hi:inscript
-
-\&./ibus\-engine\-keyman \fB\-a\fR
 .SH "SEE ALSO"
 .BR ibus(1)

--- a/linux/ibus-keyman/src/main.c
+++ b/linux/ibus-keyman/src/main.c
@@ -35,18 +35,17 @@ static IBusFactory *factory = NULL;
 /* options */
 static gboolean xml = FALSE;
 static gboolean ibus = FALSE;
-static gboolean verbose = FALSE;
 gboolean testing = FALSE;
 
 static const GOptionEntry entries[] =
 {
     { "xml", 'x', 0, G_OPTION_ARG_NONE, &xml, "generate xml for engines", NULL },
     { "ibus", 'i', 0, G_OPTION_ARG_NONE, &ibus, "component is executed by ibus", NULL },
-    { "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose, "verbose", NULL },
     { "testing", 0, 0, G_OPTION_ARG_NONE, &testing, "component is executed by integration testing", NULL},
     { NULL },
 };
 
+// Add an environment variable to see debug messages: export G_MESSAGES_DEBUG=all
 
 static void
 ibus_disconnected_cb (IBusBus  *bus,


### PR DESCRIPTION
`ibus-engine-keyman` accepted a `--verbose` and `-v` command line option which didn't do anything. Instead this change adds a comment explaining how to get more verbose output.

This change also updates the man page to reflect the actual options.

@keymanapp-test-bot skip