### PR TITLE
chore(web): connects gesture-recognizer tests for Web CI testing 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/test/auto/browser/CI.conf.cjs
+++ b/common/web/gesture-recognizer/src/test/auto/browser/CI.conf.cjs
@@ -1,4 +1,4 @@
 var BASE_CONFIG = require("./base.conf.cjs");
-var ci_config_adapter = require("../../../../../../../common/test/resources/karma-browserstack-config.js");
+var ci_config_adapter = require("../../../../../../../common/test/resources/karma-browserstack-config.cjs");
 
 module.exports = ci_config_adapter(BASE_CONFIG, "partial");

--- a/common/web/gesture-recognizer/src/test/auto/browser/cases/recordedCoordSequences.js
+++ b/common/web/gesture-recognizer/src/test/auto/browser/cases/recordedCoordSequences.js
@@ -6,6 +6,11 @@ import {
   InputSequenceSimulator
 } from '../../../../../build/tools/lib/index.mjs';
 
+function isOnAndroid() {
+  const agent=navigator.userAgent;
+  return agent.indexOf('Android' >= 0);
+}
+
 describe("Layer one - DOM -> InputSequence", function() {
   this.timeout(testconfig.timeouts.standard);
 
@@ -39,6 +44,23 @@ describe("Layer one - DOM -> InputSequence", function() {
       let resultPromise;
 
       let playbackEngine = new InputSequenceSimulator(this.controller);
+
+      // **********************************
+      // Android-Chrome sequence simulation does not allow fractional values in MouseEvent clientX/clientY...
+      // and it's impossible to coerce elements to have proper pixel alignment, it seems.  Fractional
+      // values are fine for touch events `Touch` objects, though.
+      //
+      // So, the best way forward for doing automated testing on Android devices... is to note if we're
+      // Android and coerce test sequences to all run in 'touch' mode if so.
+      // **********************************
+      if(isOnAndroid()) {
+        for(let input of testObj.inputs) {
+          for(let touchpoint of input.touchpoints) {
+            touchpoint.isFromTouch = true;
+          }
+        }
+      }
+
       resultPromise = playbackEngine.replayAsync(testObj);
 
       // replayAsync sets up timeouts against the `clock` object.
@@ -61,7 +83,24 @@ describe("Layer one - DOM -> InputSequence", function() {
         let cleanOriginalSet = testObj.inputs.map(seqCleaner);
         let cleanResultSet   = result .inputs.map(seqCleaner);
 
-        expect(cleanResultSet).to.deep.equal(cleanOriginalSet);
+        expect(cleanOriginalSet.length).to.equal(cleanResultSet.length, "Unexpected difference in number of touch contact points");
+
+        for(let i=0; i < cleanOriginalSet.length; i++) {
+          let resultContactPath = cleanResultSet[i];
+          let originalContactPath = cleanOriginalSet[i];
+
+          for(let j=0; j < Math.max(resultContactPath.length, originalContactPath.length); j++) {
+            const sampleResult = resultContactPath[j];
+            const sampleOriginal = originalContactPath[j];
+
+            assert.isOk(sampleResult, `An expected sample was missing during simulation - failed at path entry ${j}`);
+            assert.isOk(sampleOriginal, `An extra sample was generated during simulation - failed at path entry ${j}`);
+
+            // During test runs against a real Android device, we tend to get almost, but not-quite, integer targetX and targetY values.
+            expect(sampleResult.targetX).to.be.closeTo(sampleOriginal.targetX, 1e-4, `Mismatch in x-coord at path entry ${j}`);
+            expect(sampleResult.targetY).to.be.closeTo(sampleOriginal.targetY, 1e-4, `Mismatch in y-coord at path entry ${j}`);
+          }
+        }
 
         // Now to compare just the timestamp elements.  We'll tolerate a difference of up to 1.
         // Note:  if using the `replaySync` function instead, disable this section!

--- a/common/web/gesture-recognizer/src/test/auto/browser/cases/recordedCoordSequences.js
+++ b/common/web/gesture-recognizer/src/test/auto/browser/cases/recordedCoordSequences.js
@@ -48,7 +48,7 @@ describe("Layer one - DOM -> InputSequence", function() {
       // **********************************
       // Android-Chrome sequence simulation does not allow fractional values in MouseEvent clientX/clientY...
       // and it's impossible to coerce elements to have proper pixel alignment, it seems.  Fractional
-      // values are fine for touch events `Touch` objects, though.
+      // values are fine for touch events' `Touch` objects, though.
       //
       // So, the best way forward for doing automated testing on Android devices... is to note if we're
       // Android and coerce test sequences to all run in 'touch' mode if so.

--- a/common/web/gesture-recognizer/src/test/resources/json/receiver/embeddedBorderCancel.json
+++ b/common/web/gesture-recognizer/src/test/resources/json/receiver/embeddedBorderCancel.json
@@ -143,12 +143,12 @@
               },
               {
                 "targetX": 118,
-                "targetY": 4,
+                "targetY": 5,
                 "t": 111325
               },
               {
                 "targetX": 118,
-                "targetY": 2,
+                "targetY": 3,
                 "t": 111343
               }
             ],

--- a/common/web/utils/src/test/timeoutPromise.js
+++ b/common/web/utils/src/test/timeoutPromise.js
@@ -14,6 +14,7 @@ describe("TimeoutPromise", () => {
     assert.isTrue(await promise.corePromise);
 
     const end = Date.now();
+    // https://github.com/nodejs/node/issues/26578 - setTimeout() may resolve 1ms early than requested.
     assert.isAtLeast(end-start, INTERVAL);
   });
 
@@ -59,7 +60,8 @@ describe("TimeoutPromise", () => {
 
     const end = Date.now();
     assert.isAtMost(end-start, INTERVAL-1);  // completes early
-    assert.isAtLeast(end-start, INTERVAL/2); // but not TOO early
+    // https://github.com/nodejs/node/issues/26578 - setTimeout() may resolve 1ms early than requested.
+    assert.isAtLeast(end-start, INTERVAL/2-1); // but not TOO early
   });
 
   it('late dual fulfillment does not change first result', async () => {
@@ -69,6 +71,7 @@ describe("TimeoutPromise", () => {
     assert.isTrue(await promise.corePromise);
 
     const end = Date.now();
+    // https://github.com/nodejs/node/issues/26578 - setTimeout() may resolve 1ms early than requested.
     assert.isAtLeast(end-start, INTERVAL);
 
     promise.resolve(false);

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -87,8 +87,9 @@ if builder_start_action test; then
 
   # No --reporter option exists yet for the headless modules.
 
-  $KEYMAN_ROOT/common/web/keyboard-processor/build.sh test $OPTIONS
-  $KEYMAN_ROOT/common/web/input-processor/build.sh test $OPTIONS
+  "$KEYMAN_ROOT/common/web/keyboard-processor/build.sh" test $OPTIONS
+  "$KEYMAN_ROOT/common/web/input-processor/build.sh" test $OPTIONS
+  "$KEYMAN_ROOT/common/web/gesture-recognizer/test.sh" $OPTIONS
 
   ./build.sh test $OPTIONS
 


### PR DESCRIPTION
Up until now, the gesture-recognizer's automated tests haven't actually been run by our CI.  This PR seeks to fix that... along with a few issues that were causing certain test configurations to fail.

While this was originally included as part of #9267, it appears best to have it implemented as its own PR due to "fun" complications, mostly surrounding testing on real Android devices via BrowserStack.  In particular...

https://github.com/keymanapp/keyman/blob/30c23760ae010bfcd59210ed9a533b9ef8746ae9/common/web/gesture-recognizer/src/test/auto/browser/cases/recordedCoordSequences.js#L48-L55

I spent pretty much all of yesterday afternoon trying every angle I could think of to work around the issue described there that _didn't_ involve coercing the "mouse-based" sequences to use "touch-based" simulation.  Absolutely nothing worked.  Some details from the investigation:
- While the main 'test fixture' itself _is_ pixel-aligned, the "host-fixture" element within it was _not_ aligned on the BrowserStack test device.  I'm not sure why this was the case, as the issue does not repro locally under Chrome remote-device emulation.
- Any attempt to offset the 'test fixture' to pixel-align the "host-fixture" element failed - `getClientBoundingRect()`'s returned `DOMRect` reported absolutely no change in position when adding subpixel offsets to try correcting the issue.

Rather than throw even more time at the problem, the simple solution that allows us to move on for now is to simply force the sequences to use touch-events when on the affected test config.

@keymanapp-test-bot skip