### PR TITLE
fix(windows): open pdf in an external browser

### DIFF
--- a/common/windows/delphi/chromium/Keyman.UI.UframeCEFHost.pas
+++ b/common/windows/delphi/chromium/Keyman.UI.UframeCEFHost.pas
@@ -437,6 +437,11 @@ begin
     URL.StartsWith('http://127.0.0.1/');
 end;
 
+function IsPDFURL(URL: string): Boolean;
+begin
+  Result := LowerCase(URL).EndsWith('.pdf');
+end;
+
 procedure TframeCEFHost.Handle_CEF_BEFOREBROWSE(var message: TMessage);
 var
   params: TStringList;
@@ -464,7 +469,7 @@ begin
       FOnBeforeBrowse(Self, url, isPopup, wasHandled);
     end;
 
-    if FShouldOpenRemoteUrlsInBrowser and not IsLocalURL(URL) then
+    if FShouldOpenRemoteUrlsInBrowser and (not IsLocalURL(URL) or IsPDFURL(URL)) then
     begin
       {$MESSAGE HINT 'Refactor how remote URLs are handled'}
       // TODO: refactor links
@@ -534,7 +539,7 @@ begin
   else
   begin
     // Use OnBeforeBrowse for other URLs
-    if not Handled and FShouldOpenRemoteUrlsInBrowser and not IsLocalURL(URL) then
+    if not Handled and FShouldOpenRemoteUrlsInBrowser and (not IsLocalURL(URL) or IsPDFURL(URL)) then
       Handled := True;
 
     params := TStringList.Create;


### PR DESCRIPTION
Fixes: #9044 
Fixes: #9018

When opening a local pdf with the CEF module it causes prompt to install an extension. This change opens the local pdf in a browser in the same way the external pdf and webpages are loaded.


# User Testing

## TEST_PDF_LINKS

1. Install Keyman build artifact with this PR
2. Open Keyman Configuration dialog. 
3. Download and Install Khmer Angkor keyboard. 
4. Open Khmer Angkor keyboard in Keyboard Layouts view. 
5. Click the Help button. 
6. Click the blue link `here` under the `Keyboard Documentations` heading. 
Expected Result the pdf should now open in a web browser window.

This should be the same behaviour(open in browser window) as clicking the `Khmer Scripty by Unicode Standard` right at the bottom of the Khmer Ankor help. 