### PR TITLE
fix(developer): kmc warnings tidyup 🗜

### DIFF
--- a/common/web/input-processor/tests/cases/languageProcessor.js
+++ b/common/web/input-processor/tests/cases/languageProcessor.js
@@ -11,6 +11,7 @@ import { Mock } from '@keymanapp/keyboard-processor';
 import { LexicalModelCompiler } from '@keymanapp/kmc-model';
 import { fileURLToPath } from 'url';
 import path from 'path';
+import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 
 // Required initialization setup.
 global.keyman = {}; // So that keyboard-based checks against the global `keyman` succeed.
@@ -22,9 +23,11 @@ String.kmwEnableSupplementaryPlane(false);
 // Test the KeyboardProcessor interface.
 describe('LanguageProcessor', function() {
   let worker;
+  const callbacks = new TestCompilerCallbacks();
 
   beforeEach(function() {
     worker = LMWorker.constructInstance();
+    callbacks.clear();
   });
 
   afterEach(function() {
@@ -54,7 +57,7 @@ describe('LanguageProcessor', function() {
   });
 
   describe('.predict', function() {
-    let compiler = new LexicalModelCompiler();
+    let compiler = new LexicalModelCompiler(callbacks);
     const MODEL_ID = 'example.qaa.trivial';
 
     // ES-module mode leaves out `__dirname`, so we rebuild it using other components.

--- a/common/web/types/src/kpj/keyman-developer-project.ts
+++ b/common/web/types/src/kpj/keyman-developer-project.ts
@@ -102,7 +102,7 @@ export class KeymanDeveloperProjectOptions {
   sourcePath: string;
   compilerWarningsAsErrors: boolean = false;
   warnDeprecatedCode: boolean = true;
-  checkFilenameConventions: boolean = true;
+  checkFilenameConventions: boolean = false;  // missing option defaults to False
   projectType: KeymanDeveloperProjectType = KeymanDeveloperProjectType.Keyboard;
   readonly version: KeymanDeveloperProjectVersion;
   constructor(version: KeymanDeveloperProjectVersion) {

--- a/common/web/types/src/kpj/kpj-file-reader.ts
+++ b/common/web/types/src/kpj/kpj-file-reader.ts
@@ -65,7 +65,7 @@ export class KPJFileReader {
     } else {
       result.options.buildPath = (project.Options?.BuildPath || '').replace(/\\/g, '/');
     }
-    result.options.checkFilenameConventions = this.boolFromString(project.Options?.CheckFilenameConventions, true);
+    result.options.checkFilenameConventions = this.boolFromString(project.Options?.CheckFilenameConventions, false);
     result.options.compilerWarningsAsErrors = this.boolFromString(project.Options?.CompilerWarningsAsErrors, false);
     result.options.warnDeprecatedCode = this.boolFromString(project.Options?.WarnDeprecatedCode, true);
     result.options.projectType =

--- a/common/web/types/src/kpj/kpj-file.ts
+++ b/common/web/types/src/kpj/kpj-file.ts
@@ -20,7 +20,7 @@ export interface KPJFileOptions {
   SourcePath?: string;                        // default '' in 1.0, '$PROJECTPATH/source' in 2.0
   CompilerWarningsAsErrors?: string;          // default False
   WarnDeprecatedCode?: string;                // default True
-  CheckFilenameConventions?: string;          // default True
+  CheckFilenameConventions?: string;          // default False
   ProjectType?: 'keyboard' | 'lexicalmodel';  // default 'keyboard'
   Version?: '1.0' | '2.0';                    // default 1.0
 };

--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -370,6 +370,10 @@ export interface CompilerOptions extends CompilerBaseOptions {
    * Emit warnings if deprecated code is encountered
    */
 	warnDeprecatedCode?: boolean;
+  /**
+   * Check filename conventions in packages
+   */
+  checkFilenameConventions?: boolean;
 };
 
 export const defaultCompilerOptions: CompilerOptions = {
@@ -379,6 +383,7 @@ export const defaultCompilerOptions: CompilerOptions = {
   shouldAddCompilerVersion: true,
   compilerWarningsAsErrors: false,
   warnDeprecatedCode: true,
+  checkFilenameConventions: false,
 }
 
 /**

--- a/developer/src/common/include/kmn_compiler_errors.h
+++ b/developer/src/common/include/kmn_compiler_errors.h
@@ -184,7 +184,10 @@
 #define CWARN_ANSIInUnicodeGroup                           0x00002087
 #define CWARN_UnicodeSurrogateUsed                         0x00002088
 #define CWARN_ReservedCharacter                            0x00002089
+// Note: CWARN_Info has an "info" severity; this changed in 17.0. Earlier versions
+// had a special case for CWARN_Info in message output.
 #define CWARN_Info                                         0x0000008A
+#define CINFO_Info                                         CWARN_Info
 #define CWARN_VirtualKeyWithMnemonicLayout                 0x0000208B
 #define CWARN_VirtualCharKeyWithPositionalLayout           0x0000208C
 #define CWARN_StoreAlreadyUsedAsOptionOrCall               0x0000208D

--- a/developer/src/common/include/kmn_compiler_errors.h
+++ b/developer/src/common/include/kmn_compiler_errors.h
@@ -184,7 +184,7 @@
 #define CWARN_ANSIInUnicodeGroup                           0x00002087
 #define CWARN_UnicodeSurrogateUsed                         0x00002088
 #define CWARN_ReservedCharacter                            0x00002089
-#define CWARN_Info                                         0x0000208A
+#define CWARN_Info                                         0x0000008A
 #define CWARN_VirtualKeyWithMnemonicLayout                 0x0000208B
 #define CWARN_VirtualCharKeyWithPositionalLayout           0x0000208C
 #define CWARN_StoreAlreadyUsedAsOptionOrCall               0x0000208D

--- a/developer/src/kmc-kmn/src/compiler/messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/messages.ts
@@ -241,7 +241,10 @@ export class KmnCompilerMessages {
   static WARN_ANSIInUnicodeGroup                              = SevWarn | 0x087;
   static WARN_UnicodeSurrogateUsed                            = SevWarn | 0x088;
   static WARN_ReservedCharacter                               = SevWarn | 0x089;
-  static WARN_Info                                            = SevWarn | 0x08A;
+
+  // Note: INFO_Info is called CWARN_Info in kmn_compiler_errors.h, but should have an "info" severity
+  static INFO_Info                                            = SevInfo | 0x08A;
+
   static WARN_VirtualKeyWithMnemonicLayout                    = SevWarn | 0x08B;
   static WARN_VirtualCharKeyWithPositionalLayout              = SevWarn | 0x08C;
   static WARN_StoreAlreadyUsedAsOptionOrCall                  = SevWarn | 0x08D;

--- a/developer/src/kmc-kmn/src/kmw-compiler/messages.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/messages.ts
@@ -60,7 +60,7 @@ export class KmwCompilerMessages extends KmnCompilerMessages {
   static Warn_TouchLayoutFontShouldBeSameForAllPlatforms = () => m(this.WARN_TouchLayoutFontShouldBeSameForAllPlatforms,
     `The touch layout font should be the same for all platforms.`);
   static Warn_TouchLayoutMissingRequiredKeys = (o:{layerId:string, platformName:string, missingKeys:string}) => m(this.WARN_TouchLayoutMissingRequiredKeys,
-    `Layer "${o.layerId}" on platform "${o.platformName}" is missing the required key(s) '${o.missingKeys}.`);
+    `Layer "${o.layerId}" on platform "${o.platformName}" is missing the required key(s) '${o.missingKeys}'.`);
 
   // Following messages are kmw-compiler only, so use KmwCompiler error namespace
 

--- a/developer/src/kmc-kmn/src/kmw-compiler/validate-layout-file.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/validate-layout-file.ts
@@ -82,7 +82,9 @@ function CheckKey(
 
   for(let key of CRequiredKeys) {
     if(TRequiredKey[key].toLowerCase() == FId.toLowerCase()) {
-      FRequiredKeys.push(key);
+      if(FRequiredKeys.indexOf(key) < 0) {
+        FRequiredKeys.push(key);
+      }
       break;
     }
   }

--- a/developer/src/kmc-model/src/lexical-model-compiler.ts
+++ b/developer/src/kmc-model/src/lexical-model-compiler.ts
@@ -9,9 +9,14 @@ import {decorateWithJoin} from "./join-word-breaker-decorator.js";
 import {decorateWithScriptOverrides} from "./script-overrides-decorator.js";
 import { LexicalModelSource, WordBreakerSpec, SimpleWordBreakerSpec } from "./lexical-model.js";
 import { ModelCompilerError, ModelCompilerMessages } from "./model-compiler-errors.js";
-import { callbacks } from "./compiler-callbacks.js";
+import { callbacks, setCompilerCallbacks } from "./compiler-callbacks.js";
+import { CompilerCallbacks } from "@keymanapp/common-types";
 
 export default class LexicalModelCompiler {
+
+  constructor(callbacks: CompilerCallbacks) {
+    setCompilerCallbacks(callbacks);
+  }
 
   /**
    * Returns the generated code for the model that will ultimately be loaded by

--- a/developer/src/kmc-model/src/main.ts
+++ b/developer/src/kmc-model/src/main.ts
@@ -21,7 +21,7 @@ export function compileModel(filename: string, callbacks: CompilerCallbacks): st
     let modelSource = loadFromFilename(filename, callbacks);
     let containingDirectory = callbacks.path.dirname(filename);
 
-    return (new LexicalModelCompiler)
+    return (new LexicalModelCompiler(callbacks))
       .generateLexicalModelCode('<unknown>', modelSource, containingDirectory);
   } catch(e) {
     callbacks.reportMessage(

--- a/developer/src/kmc-model/test/test-compile-model-with-pseudoclosure.ts
+++ b/developer/src/kmc-model/test/test-compile-model-with-pseudoclosure.ts
@@ -3,11 +3,10 @@ import {assert} from 'chai';
 import 'mocha';
 
 import { makePathToFixture, compileModelSourceCode } from './helpers/index.js';
-import { setCompilerCallbacks } from '../src/compiler-callbacks.js';
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 
 describe('LexicalModelCompiler - pseudoclosure compilation + use', function () {
-  setCompilerCallbacks(new TestCompilerCallbacks());
+  const callbacks = new TestCompilerCallbacks();
 
   const MODEL_ID = 'example.qaa.trivial';
   const PATH = makePathToFixture(MODEL_ID);
@@ -28,7 +27,7 @@ describe('LexicalModelCompiler - pseudoclosure compilation + use', function () {
     };
 
     it('variant 1:  applyCasing prepends symbols, searchTermToKey removes them', function() {
-      let compiler = new LexicalModelCompiler;
+      let compiler = new LexicalModelCompiler(callbacks);
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
         sources: ['wordlist.tsv'],
@@ -82,7 +81,7 @@ describe('LexicalModelCompiler - pseudoclosure compilation + use', function () {
     });
 
     it('variant 2:  applyCasing prepends symbols, searchTermToKey keeps them', function() {
-      let compiler = new LexicalModelCompiler;
+      let compiler = new LexicalModelCompiler(callbacks);
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
         sources: ['wordlist.tsv'],
@@ -126,7 +125,7 @@ describe('LexicalModelCompiler - pseudoclosure compilation + use', function () {
     });
 
     it('variant 3:  applyCasing prepends symbols, default searchTermToKey', function() {
-      let compiler = new LexicalModelCompiler;
+      let compiler = new LexicalModelCompiler(callbacks);
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
         sources: ['wordlist.tsv'],
@@ -166,7 +165,7 @@ describe('LexicalModelCompiler - pseudoclosure compilation + use', function () {
 
   describe('relying on default applyCasing + searchTermToKey', function() {
     it('languageUsesCasing: true', function() {
-      let compiler = new LexicalModelCompiler;
+      let compiler = new LexicalModelCompiler(callbacks);
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
         sources: ['wordlist.tsv'],
@@ -190,7 +189,7 @@ describe('LexicalModelCompiler - pseudoclosure compilation + use', function () {
     });
 
     it('languageUsesCasing: false', function() {
-      let compiler = new LexicalModelCompiler;
+      let compiler = new LexicalModelCompiler(callbacks);
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
         sources: ['wordlist.tsv'],
@@ -215,7 +214,7 @@ describe('LexicalModelCompiler - pseudoclosure compilation + use', function () {
     });
 
     it('languageUsesCasing: undefined', function() {
-      let compiler = new LexicalModelCompiler;
+      let compiler = new LexicalModelCompiler(callbacks);
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
         sources: ['wordlist.tsv']

--- a/developer/src/kmc-model/test/test-compile-trie.ts
+++ b/developer/src/kmc-model/test/test-compile-trie.ts
@@ -5,14 +5,20 @@ import 'mocha';
 import {makePathToFixture, compileModelSourceCode} from './helpers/index.js';
 import { createTrieDataStructure } from '../src/build-trie.js';
 import { ModelCompilerError } from '../src/model-compiler-errors.js';
+import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 
 describe('LexicalModelCompiler', function () {
+  const callbacks = new TestCompilerCallbacks();
+  this.beforeEach(function() {
+    callbacks.clear();
+  });
+
   describe('#generateLexicalModelCode', function () {
     it('should compile a trivial word list', function () {
       const MODEL_ID = 'example.qaa.trivial';
       const PATH = makePathToFixture(MODEL_ID);
 
-      let compiler = new LexicalModelCompiler;
+      let compiler = new LexicalModelCompiler(callbacks);
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
         sources: ['wordlist.tsv']
@@ -35,7 +41,7 @@ describe('LexicalModelCompiler', function () {
       const MODEL_ID = 'example.qaa.utf16le';
       const PATH = makePathToFixture(MODEL_ID);
 
-      let compiler = new LexicalModelCompiler;
+      let compiler = new LexicalModelCompiler(callbacks);
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
         sources: ['wordlist.txt']
@@ -56,7 +62,7 @@ describe('LexicalModelCompiler', function () {
     const MODEL_ID = 'example.qaa.trivial';
     const PATH = makePathToFixture(MODEL_ID);
 
-    let compiler = new LexicalModelCompiler;
+    let compiler = new LexicalModelCompiler(callbacks);
     let code = compiler.generateLexicalModelCode(MODEL_ID, {
       format: 'trie-1.0',
       sources: ['wordlist.tsv'],
@@ -79,7 +85,7 @@ describe('LexicalModelCompiler', function () {
     const MODEL_ID = 'example.qaa.smp';
     const PATH = makePathToFixture(MODEL_ID);
 
-    let compiler = new LexicalModelCompiler;
+    let compiler = new LexicalModelCompiler(callbacks);
     let code = compiler.generateLexicalModelCode(MODEL_ID, {
       format: 'trie-1.0',
       sources: ['wordlist.tsv']
@@ -112,7 +118,7 @@ describe('LexicalModelCompiler', function () {
   it('should include the source code of its search term to key function', function () {
     const MODEL_ID = 'example.qaa.trivial';
     const PATH = makePathToFixture(MODEL_ID);
-    let compiler = new LexicalModelCompiler;
+    let compiler = new LexicalModelCompiler(callbacks);
     let code = compiler.generateLexicalModelCode(MODEL_ID, {
       format: 'trie-1.0',
       sources: ['wordlist.tsv']

--- a/developer/src/kmc-model/test/test-punctuation.ts
+++ b/developer/src/kmc-model/test/test-punctuation.ts
@@ -3,7 +3,6 @@ import {assert} from 'chai';
 import 'mocha';
 
 import { makePathToFixture, compileModelSourceCode } from './helpers/index.js';
-import { setCompilerCallbacks } from '../src/compiler-callbacks.js';
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 
 describe('LexicalModelCompiler', function () {
@@ -12,9 +11,9 @@ describe('LexicalModelCompiler', function () {
     const PATH = makePathToFixture(MODEL_ID);
 
     it('should compile punctuation into the generated code', function () {
-      setCompilerCallbacks(new TestCompilerCallbacks());
+      const callbacks = new TestCompilerCallbacks();
 
-      let compiler = new LexicalModelCompiler;
+      let compiler = new LexicalModelCompiler(callbacks);
       let code = compiler.generateLexicalModelCode(MODEL_ID, {
         format: 'trie-1.0',
         sources: ['wordlist.tsv'],

--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -1,4 +1,4 @@
-import { KmpJsonFile, CompilerCallbacks } from '@keymanapp/common-types';
+import { KmpJsonFile, CompilerCallbacks, CompilerOptions } from '@keymanapp/common-types';
 import { CompilerMessages } from './messages.js';
 import { keymanEngineForWindowsFiles, keymanForWindowsInstallerFiles, keymanForWindowsRedistFiles } from './redist-files.js';
 
@@ -14,11 +14,11 @@ const MODEL_ID_PATTERN_PACKAGE = /^[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_-]*\.[a-z_][a
 
 // "Content files" within the package should adhere to these pattern:
 const CONTENT_FILE_BASENAME_PATTERN = /^[a-z0-9_+.-]+$/i; // base names can be case insensitive
-const CONTENT_FILE_EXTENSION_PATTERN = /^\.[a-z0-9_]+$/;  // extensions should be lower-case
+const CONTENT_FILE_EXTENSION_PATTERN = /^(\.[a-z0-9_-]+)?$/;  // extensions should be lower-case or empty
 
 export class PackageValidation {
 
-  constructor(private callbacks: CompilerCallbacks) {
+  constructor(private callbacks: CompilerCallbacks, private options: CompilerOptions) {
   }
 
   public validate(filename: string, kmpJson: KmpJsonFile.KmpJsonFile) {
@@ -153,8 +153,10 @@ export class PackageValidation {
     const filename = this.callbacks.path.basename(file.name);
     const ext = this.callbacks.path.extname(filename);
     const base = filename.substring(0, filename.length-ext.length);
-    if(!CONTENT_FILE_BASENAME_PATTERN.test(base) || !CONTENT_FILE_EXTENSION_PATTERN.test(ext)) {
-      this.callbacks.reportMessage(CompilerMessages.Warn_FileInPackageDoesNotFollowFilenameConventions({filename}));
+    if(this.options.checkFilenameConventions) {
+      if(!CONTENT_FILE_BASENAME_PATTERN.test(base) || !CONTENT_FILE_EXTENSION_PATTERN.test(ext)) {
+        this.callbacks.reportMessage(CompilerMessages.Warn_FileInPackageDoesNotFollowFilenameConventions({filename}));
+      }
     }
 
     if(!this.checkIfContentFileIsDangerous(file)) {

--- a/developer/src/kmc-package/test/test-messages.ts
+++ b/developer/src/kmc-package/test/test-messages.ts
@@ -5,7 +5,7 @@ import { CompilerMessages } from '../src/compiler/messages.js';
 import { makePathToFixture } from './helpers/index.js';
 import { KmpCompiler } from '../src/compiler/kmp-compiler.js';
 import { PackageValidation } from '../src/compiler/package-validation.js';
-import { CompilerErrorNamespace } from '@keymanapp/common-types';
+import { CompilerErrorNamespace, CompilerOptions } from '@keymanapp/common-types';
 
 const debug = false;
 const callbacks = new TestCompilerCallbacks();
@@ -20,7 +20,7 @@ describe('CompilerMessages', function () {
   // Message tests
   //
 
-  function testForMessage(context: Mocha.Context, fixture: string[], messageId?: number) {
+  function testForMessage(context: Mocha.Context, fixture: string[], messageId?: number, options?: CompilerOptions) {
     context.timeout(10000);
 
     callbacks.clear();
@@ -30,7 +30,7 @@ describe('CompilerMessages', function () {
 
     let kmpJson = kmpCompiler.transformKpsToKmpObject(kpsPath);
     if(kmpJson && callbacks.messages.length == 0) {
-      const validator = new PackageValidation(callbacks);
+      const validator = new PackageValidation(callbacks, options ?? {});
       validator.validate(kpsPath, kmpJson); // we'll ignore return value and rely on the messages
     }
 
@@ -122,8 +122,10 @@ describe('CompilerMessages', function () {
   // WARN_FileInPackageDoesNotFollowFilenameConventions
 
   it('should generate WARN_FileInPackageDoesNotFollowFilenameConventions if content filename has wrong conventions', async function() {
-    testForMessage(this, ['invalid', 'warn_file_in_package_does_not_follow_filename_conventions.kps'], CompilerMessages.WARN_FileInPackageDoesNotFollowFilenameConventions);
-    testForMessage(this, ['invalid', 'warn_file_in_package_does_not_follow_filename_conventions_2.kps'], CompilerMessages.WARN_FileInPackageDoesNotFollowFilenameConventions);
+    testForMessage(this, ['invalid', 'warn_file_in_package_does_not_follow_filename_conventions.kps'],
+      CompilerMessages.WARN_FileInPackageDoesNotFollowFilenameConventions, {checkFilenameConventions: true});
+    testForMessage(this, ['invalid', 'warn_file_in_package_does_not_follow_filename_conventions_2.kps'],
+      CompilerMessages.WARN_FileInPackageDoesNotFollowFilenameConventions, {checkFilenameConventions: true});
   });
 
   // ERROR_PackageNameCannotBeBlank

--- a/developer/src/kmc/src/commands/buildClasses/BuildPackage.ts
+++ b/developer/src/kmc/src/commands/buildClasses/BuildPackage.ts
@@ -26,7 +26,7 @@ export class BuildPackage extends BuildActivity {
     // Validate the package file
     //
 
-    const validation = new PackageValidation(callbacks);
+    const validation = new PackageValidation(callbacks, options);
     if(!validation.validate(infile, kmpJsonData)) {
       return false;
     }

--- a/developer/src/kmc/src/commands/buildClasses/BuildProject.ts
+++ b/developer/src/kmc/src/commands/buildClasses/BuildProject.ts
@@ -71,6 +71,7 @@ class ProjectBuilder {
   async buildTarget(file: KeymanDeveloperProjectFile, activity: BuildActivity): Promise<boolean> {
     const options = {...this.options};
     options.outFile = this.project.resolveOutputFilePath(file, activity.sourceExtension, activity.compiledExtension);
+    options.checkFilenameConventions = this.project.options.checkFilenameConventions ?? this.options.checkFilenameConventions;
     const infile = this.project.resolveInputFilePath(file);
 
     const buildFilename = path.relative(process.cwd(), infile).replace(/\\/g, '/');

--- a/developer/src/kmc/src/kmlmi.ts
+++ b/developer/src/kmc/src/kmlmi.ts
@@ -57,7 +57,7 @@ if(!kmpJsonData) {
 // Validate the package file
 //
 
-const validation = new PackageValidation(callbacks);
+const validation = new PackageValidation(callbacks, {});
 if(!validation.validate(kpsFilename, kmpJsonData)) {
   process.exit(1);
 }

--- a/developer/src/kmc/src/kmlmp.ts
+++ b/developer/src/kmc/src/kmlmp.ts
@@ -48,7 +48,7 @@ if(!kmpJsonData) {
 // Validate the package file
 //
 
-const validation = new PackageValidation(callbacks);
+const validation = new PackageValidation(callbacks, {});
 if(!validation.validate(inputFilename, kmpJsonData)) {
   process.exit(1);
 }

--- a/developer/src/kmc/src/messages/messages.ts
+++ b/developer/src/kmc/src/messages/messages.ts
@@ -44,7 +44,7 @@ export class InfrastructureMessages {
   static ERROR_InvalidProjectFile = SevError | 0x0008;
 
   static Hint_FilenameHasDifferingCase = (o:{reference:string, filename:string}) => m(this.HINT_FilenameHasDifferingCase,
-    `File ${o.filename} differs in case from reference ${o.reference}; this will fail on platforms with case-sensitive filesystems.`);
+    `File on disk '${o.filename}' does not match case of '${o.reference}' in source file; this is an error on platforms with case-sensitive filesystems.`);
   static HINT_FilenameHasDifferingCase = SevHint | 0x0009;
 
   static Error_UnknownFileFormat = (o:{format:string}) => m(this.ERROR_UnknownFileFormat,

--- a/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
@@ -109,6 +109,16 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
   }
 
   reportMessage(event: CompilerEvent): void {
+    if(!event.filename) {
+      event.filename = this.messageFilename;
+    }
+
+    if(this.messageFilename != event.filename) {
+      // Reset max message limit when a new file is being processed
+      this.messageFilename = event.filename;
+      this.messageCount = 0;
+    }
+
     this.messages.push({...event});
 
     if(CompilerError.severity(event.code) < compilerLogLevelToSeverity[this.options.logLevel]) {
@@ -119,12 +129,6 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
     // We don't use this.messages.length because we only want to count visible
     // messages, and there's no point in recalculating the total for every
     // message emitted.
-
-    if(this.messageFilename != event.filename) {
-      // Reset max message limit when a new file is being processed
-      this.messageFilename = event.filename;
-      this.messageCount = 0;
-    }
 
     this.messageCount++;
     if(this.messageCount > MaxMessagesDefault) {
@@ -138,6 +142,7 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
       // that will continue to collect all messages; this only affects the
       // console emission of messages.
       event = InfrastructureMessages.Info_TooManyMessages({count: MaxMessagesDefault});
+      event.filename = this.messageFilename;
     }
 
     const severityColor = severityColors[CompilerError.severity(event.code)] ?? color.reset;

--- a/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
@@ -14,7 +14,7 @@ const color = chalk.default;
 const severityColors: {[value in CompilerErrorSeverity]: chalk.Chalk} = {
   [CompilerErrorSeverity.Info]: color.reset,
   [CompilerErrorSeverity.Hint]: color.blueBright,
-  [CompilerErrorSeverity.Warn]: color.yellowBright,
+  [CompilerErrorSeverity.Warn]: color.hex('FFA500'), // orange
   [CompilerErrorSeverity.Error]: color.redBright,
   [CompilerErrorSeverity.Fatal]: color.redBright,
 };
@@ -74,8 +74,8 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
       const nativeFilename = fs.realpathSync.native(filename);
       if(filename != nativeFilename) {
         this.reportMessage(InfrastructureMessages.Hint_FilenameHasDifferingCase({
-          reference: originalFilename,
-          filename: nativeFilename
+          reference: path.basename(originalFilename),
+          filename: path.basename(nativeFilename)
         }));
       }
     }


### PR DESCRIPTION
* Fixes #9300: respect checkFilenameConventions in kmc
* Fixes #9299: clean up warning KM02093
* Fixes #9298: use relative paths for KM05009
* Fixes #9297: consistently show filename for messages in kmc
* Fixes #9296: reduce KM0208A to info severity

Throws in: warning colour changed to orange to differentiate from line number colour.

Note for #9296: 208A in kmcmplib is the awkwardly-named CWARN_Info. We now have an 'info' severity in kmc, so this tidies that up (we can keep the same flag in kmcmplib for now).

@keymanapp-test-bot skip