### PR TITLE
fix(web): allows registering precached keyboards

### DIFF
--- a/web/src/engine/package-cache/src/cloud/queryEngine.ts
+++ b/web/src/engine/package-cache/src/cloud/queryEngine.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'eventemitter3';
+import EventEmitter from 'eventemitter3';
 
 import { PathConfiguration } from 'keyman/engine/paths';
 

--- a/web/src/engine/package-cache/src/cloud/queryEngine.ts
+++ b/web/src/engine/package-cache/src/cloud/queryEngine.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'eventemitter3';
+
 import { PathConfiguration } from 'keyman/engine/paths';
 
 import { default as KeyboardStub, ErrorStub, KeyboardAPISpec, mergeAndResolveStubPromises } from '../keyboardStub.js';
@@ -55,7 +57,11 @@ type CloudLanguagesQueryResult = {
 
 export type CloudQueryResult = CloudKeyboardQueryResult | CloudLanguagesQueryResult;
 
-export default class CloudQueryEngine {
+interface EventMap {
+  'unboundregister': (registration: ReturnType<CloudQueryEngine['_registerCore']>) => void
+}
+
+export default class CloudQueryEngine extends EventEmitter<EventMap> {
   private cloudResolutionPromises: Record<number, ManagedPromise<KeyboardStub[] | ManagedPromise<LanguageAPIPropertySpec[]>>> = {};
 
   private _languageListPromise: ManagedPromise<LanguageAPIPropertySpec[]>;
@@ -65,6 +71,8 @@ export default class CloudQueryEngine {
   private pathConfig: PathConfiguration;
 
   constructor(requestEngine: CloudRequesterInterface, pathConfig: PathConfiguration) {
+    super();
+
     this.requestEngine = requestEngine;
     this.pathConfig = pathConfig;
 
@@ -138,10 +146,16 @@ export default class CloudQueryEngine {
       result = new Error(CLOUD_REGISTRATION_ERR + err);
     }
 
-    if(promiseid) {
+    if(!promiseid) {
+      this.emit('unboundregister', result);
+      return;
+    } else {
       const promise: ManagedPromise<KeyboardStub[]> | ManagedPromise<LanguageAPIPropertySpec[]> = this.cloudResolutionPromises[promiseid];
 
-      if(promise) {
+      if(!promise) {
+        this.emit('unboundregister', result);
+        return;
+      } else {
         try {
           if(result instanceof Error) {
             promise.reject(result as Error);

--- a/web/src/engine/package-cache/src/keyboardRequisitioner.ts
+++ b/web/src/engine/package-cache/src/keyboardRequisitioner.ts
@@ -101,13 +101,13 @@ export default class KeyboardRequisitioner {
     // Handles keymanweb.com's precached keyboard array.  There is no associated promise,
     // so there's nothing handling the `register` call's results otherwise.
     this.cloudQueryEngine.on('unboundregister', (registration) => {
-      try {
-        if(Array.isArray(registration)) {
-          registration.forEach((entry) => {
-            this.cache.addStub(entry);
-          });
-        }
-      } finally { }
+      // Internal, undocumented use-case of `keyman.register`:  precached keyboard loading
+      // Other uses may trigger errors, especially if there's a type-structure mismatch.
+      // Those errors should not be handled here; let them surface.
+      if(Array.isArray(registration)) {
+        registration.forEach((entry) => {
+          this.cache.addStub(entry);
+        });
     });
   }
 

--- a/web/src/engine/package-cache/src/keyboardRequisitioner.ts
+++ b/web/src/engine/package-cache/src/keyboardRequisitioner.ts
@@ -108,6 +108,7 @@ export default class KeyboardRequisitioner {
         registration.forEach((entry) => {
           this.cache.addStub(entry);
         });
+      }
     });
   }
 

--- a/web/src/engine/package-cache/src/keyboardRequisitioner.ts
+++ b/web/src/engine/package-cache/src/keyboardRequisitioner.ts
@@ -97,6 +97,18 @@ export default class KeyboardRequisitioner {
     this.pathConfig = pathConfig;
     this.cache = new StubAndKeyboardCache(keyboardLoader);
     this.cloudQueryEngine = new CloudQueryEngine(keyboardRequester, this.pathConfig);
+
+    // Handles keymanweb.com's precached keyboard array.  There is no associated promise,
+    // so there's nothing handling the `register` call's results otherwise.
+    this.cloudQueryEngine.on('unboundregister', (registration) => {
+      try {
+        if(Array.isArray(registration)) {
+          registration.forEach((entry) => {
+            this.cache.addStub(entry);
+          });
+        }
+      } finally { }
+    });
   }
 
   addKeyboardArray(x: (string|RawKeyboardMetadata)[]): Promise<(KeyboardStub | ErrorStub)[]> {


### PR DESCRIPTION
Fixes https://github.com/keymanapp/keymanweb.com/issues/77.

The modularized design for KMW's cloud interactions assumes that there's always a `Promise` for any incoming `keyman.register` calls.  That said, keymanweb.com likes to pre-cache the keyboards query and directly register it in a manner that bypasses cloud queries and the associated Promises.  Since there was no `Promise` bound to the register, KMW had no infrastructure for forwarding the precached stubs.

So, this PR adds in a relatively simple rigging to remedy that issue.

@keymanapp-test-bot skip