### PR TITLE
fix(web): syncs timestamps of active contact points, paths 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
@@ -86,7 +86,7 @@ export class PathMatcher<Type> {
       return this.finalize(false, 'path');
     }
 
-    if(model.itemChangeAction && source.currentHoveredItem != source.initialHoveredItem) {
+    if(model.itemChangeAction && source.currentSample.item != source.initialSample.item) {
       const result = model.itemChangeAction == 'resolve';
 
       return this.finalize(result, 'item');

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
@@ -37,7 +37,7 @@ export interface ContactModel<Type> {
    * For example, a longpress component should likely reject on change of base item,
    * allowing a new longpress (with a fresh timer) to start with the new base item.
    */
-  readonly itemChangeAction?: 'reject' | 'resolve'; // may be undefined for 'continue'
+  readonly itemChangeAction?: 'reject' | 'resolve' | undefined; // may be undefined for 'continue'
 
   /**
    * Is needed to define whether or not the contact-point should be ignored by this gesture type.

--- a/common/web/gesture-recognizer/src/engine/headless/simpleGestureSource.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/simpleGestureSource.ts
@@ -7,7 +7,6 @@ import { SerializedGesturePath, GesturePath } from "./gesturePath.js";
 export type SerializedSimpleGestureSource<HoveredItemType = any> = {
   isFromTouch: boolean;
   path: SerializedGesturePath<HoveredItemType>;
-  initialHoveredItem: HoveredItemType
   // identifier is not included b/c it's only needed during live processing.
 }
 
@@ -84,19 +83,17 @@ export class SimpleGestureSource<HoveredItemType> {
   }
 
   /**
-   * The identifying metadata returned by the configuration's specified `itemIdentifier` for
-   * the target of the first `Event` that corresponded to this `SimpleGestureSource`.
+   * The initial path sample (coordinate) under consideration for this `SimpleGestureSource`.
    */
-  public get initialHoveredItem(): HoveredItemType {
-    return this.path.coords[0].item;
+  public get initialSample(): InputSample<HoveredItemType> {
+    return this.path.coords[0];
   }
 
   /**
-   * The identifying metadata returned by the configuration's specified `itemIdentifier` for
-   * the target of the latest `Event` that corresponded to this `SimpleGestureSource`.
+   * The most recent path sample (coordinate) under consideration for this `SimpleGestureSource`.
    */
-  public get currentHoveredItem(): HoveredItemType {
-    return this.path.coords[this.path.coords.length-1].item;
+  public get currentSample(): InputSample<HoveredItemType> {
+    return this.path.coords[this.path.coords.length-1];
   }
 
   /**
@@ -115,7 +112,6 @@ export class SimpleGestureSource<HoveredItemType> {
   toJSON(): SerializedSimpleGestureSource {
     let jsonClone: SerializedSimpleGestureSource = {
       isFromTouch: this.isFromTouch,
-      initialHoveredItem: this.initialHoveredItem,
       path: this.path.toJSON()
     }
 

--- a/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
@@ -15,14 +15,14 @@ export abstract class InputEventEngine<HoveredItemType> extends InputEngineBase<
   abstract registerEventHandlers(): void;
   abstract unregisterEventHandlers(): void;
 
-  protected buildSampleFor(clientX: number, clientY: number, target: EventTarget): InputSample<HoveredItemType> {
+  protected buildSampleFor(clientX: number, clientY: number, target: EventTarget, timestamp: number): InputSample<HoveredItemType> {
     const targetRect = this.config.targetRoot.getBoundingClientRect();
     const sample: InputSample<HoveredItemType> = {
       clientX: clientX,
       clientY: clientY,
       targetX: clientX - targetRect.left,
       targetY: clientY - targetRect.top,
-      t: performance.now()
+      t: timestamp
     };
 
     const hoveredItem = this.config.itemIdentifier(sample, target);
@@ -76,7 +76,7 @@ export abstract class InputEventEngine<HoveredItemType> extends InputEngineBase<
     }
 
     const lastEntry = touchpoint.path.coords[touchpoint.path.coords.length-1];
-    const sample = this.buildSampleFor(lastEntry.clientX, lastEntry.clientY, target);
+    const sample = this.buildSampleFor(lastEntry.clientX, lastEntry.clientY, target, lastEntry.t);
 
     /* While an 'end' event immediately follows a 'move' if it occurred simultaneously,
      * this is decidedly _not_ the case if the touchpoint was held for a while without

--- a/common/web/gesture-recognizer/src/engine/mouseEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/mouseEventEngine.ts
@@ -89,7 +89,7 @@ export class MouseEventEngine<HoveredItemType> extends InputEventEngine<HoveredI
   }
 
   private buildSampleFromEvent(event: MouseEvent) {
-    return this.buildSampleFor(event.clientX, event.clientY, event.target);
+    return this.buildSampleFor(event.clientX, event.clientY, event.target, performance.now());
   }
 
   onMouseStart(event: MouseEvent) {


### PR DESCRIPTION
Pretty much what the title says - these changes ensure:
- updates from the same touch event have perfectly-matching timestamps
- all active touchpaths are always updated, not just those that changed...
- ... so that `ComplexGestureSource` instances can verify that all component paths have been updated for a multitouch gesture before processing gesture-related updates.  (Running gesture-update logic & calcs while only half-updated could pose problems.)

The latter point was the main motivator, even if it's not needed at the immediate moment.  That said, it's a problem that's been on my mind, repeatedly, for a while - so this helps me reclaim headspace and move on to the other things that need doing.  (Fortunately, it was pretty easy to isolate.)

@keymanapp-test-bot skip