### PR TITLE
chore(linux): Fix running tests with Wayland

### DIFF
--- a/linux/ibus-keyman/tests/meson.build
+++ b/linux/ibus-keyman/tests/meson.build
@@ -57,22 +57,16 @@ teardown_tests = find_program('teardown-tests.sh', dirs: [meson.current_source_d
 run_test = find_program('run-single-test.sh', dirs: [meson.current_source_dir() / 'scripts'])
 find_tests = find_program('find-tests.sh', dirs: [meson.current_source_dir() / 'scripts'])
 
+# Mutter 40.x added the --headless option wich we need in order to be able to run the Wayland tests
+mutter = find_program('mutter', required: false, version: '>=40')
+can_build_wayland = mutter.found()
+
 test(
   'setup-x11',
   setup_tests,
   args: ['--x11', env_file, pid_file],
   env: test_env,
   priority: -10,
-  is_parallel: false,
-  protocol: 'exitcode'
-)
-
-test(
-  'setup-wayland',
-  setup_tests,
-  args: ['--wayland', env_file, pid_file],
-  env: test_env,
-  priority: -20,
   is_parallel: false,
   protocol: 'exitcode'
 )
@@ -86,14 +80,26 @@ test(
   protocol: 'exitcode'
 )
 
-test(
-  'teardown-wayland',
-  teardown_tests,
-  args: [pid_file],
-  priority: -29,
-  is_parallel: false,
-  protocol: 'exitcode'
-)
+if can_build_wayland
+  test(
+    'setup-wayland',
+    setup_tests,
+    args: ['--wayland', env_file, pid_file],
+    env: test_env,
+    priority: -20,
+    is_parallel: false,
+    protocol: 'exitcode'
+  )
+
+  test(
+    'teardown-wayland',
+    teardown_tests,
+    args: [pid_file],
+    priority: -29,
+    is_parallel: false,
+    protocol: 'exitcode'
+  )
+endif
 
 kmxtest_files = run_command(
   find_tests,
@@ -130,26 +136,28 @@ foreach kmx: kmxtest_files
     timeout: 120,
     protocol: 'tap',
   )
-  test(
-    'Wayland-' + testname + '__surrounding-text',
-    run_test,
-    args: [ '--wayland', '--surrounding-text', test_args],
-    env: test_env,
-    depends: [test_exe],
-    priority: -21,
-    is_parallel: false,
-    timeout: 120,
-    protocol: 'tap',
-  )
-  test(
-    'Wayland-' + testname + '__no-surrounding-text',
-    run_test,
-    args: [ '--wayland', '--no-surrounding-text', test_args],
-    env: test_env,
-    depends: [test_exe],
-    priority: -22,
-    is_parallel: false,
-    timeout: 120,
-    protocol: 'tap',
-  )
+  if can_build_wayland
+    test(
+      'Wayland-' + testname + '__surrounding-text',
+      run_test,
+      args: [ '--wayland', '--surrounding-text', test_args],
+      env: test_env,
+      depends: [test_exe],
+      priority: -21,
+      is_parallel: false,
+      timeout: 120,
+      protocol: 'tap',
+    )
+    test(
+      'Wayland-' + testname + '__no-surrounding-text',
+      run_test,
+      args: [ '--wayland', '--no-surrounding-text', test_args],
+      env: test_env,
+      depends: [test_exe],
+      priority: -22,
+      is_parallel: false,
+      timeout: 120,
+      protocol: 'tap',
+    )
+  endif
 endforeach

--- a/linux/ibus-keyman/tests/scripts/run-single-test.sh
+++ b/linux/ibus-keyman/tests/scripts/run-single-test.sh
@@ -9,8 +9,8 @@ if [ -v KEYMAN_PKG_BUILD ]; then
   # ibus requires to find /var/lib/dbus/machine-id or /etc/machine-id, otherwise it fails with:
   # "Bail out! IBUS-FATAL-WARNING: Unable to load /var/lib/dbus/machine-id: Failed to open file
   # “/var/lib/dbus/machine-id”: No such file or directory"
-  echo "1..1"
-  echo "ok 1 - Integration tests # SKIP on package build"
+  echo "TAP version 14"
+  echo "1..0  # SKIP on package build"
   exit 0
 fi
 
@@ -38,10 +38,13 @@ function help() {
 }
 
 function run_tests() {
-  echo "# NOTE: When the tests fail check /tmp/ibus-engine-keyman.log and /tmp/ibus-daemon.log!"
-  echo ""
+  # Output these lines to stderr - the first line on stdout has to be the TAP version number
+  # which running ${TESTFILE} outputs
+  echo "# NOTE: When the tests fail check /tmp/ibus-engine-keyman.log and /tmp/ibus-daemon.log!" >&2
+  echo "" >&2
 
-  echo "# Starting tests..."
+  echo "# Starting tests..." >&2
+
   # Note: -k and --tap are consumed by the GLib testing framework
   # shellcheck disable=SC2086
   "${G_TEST_BUILDDIR:-.}"/ibus-keyman-tests ${ARG_K-} ${ARG_TAP-} \

--- a/linux/ibus-keyman/tests/scripts/run-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/run-tests.sh
@@ -18,8 +18,7 @@ if [ -v KEYMAN_PKG_BUILD ]; then
   # ibus requires to find /var/lib/dbus/machine-id or /etc/machine-id, otherwise it fails with:
   # "Bail out! IBUS-FATAL-WARNING: Unable to load /var/lib/dbus/machine-id: Failed to open file
   # “/var/lib/dbus/machine-id”: No such file or directory"
-  echo "1..1"
-  echo "ok 1 - Integration tests # SKIP on package build"
+  echo "1..0 # SKIP on package build"
   exit 0
 fi
 

--- a/linux/ibus-keyman/tests/scripts/setup-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/setup-tests.sh
@@ -3,4 +3,10 @@ set -eu
 
 . "$(dirname "$0")/test-helper.inc.sh"
 
+if [ -v KEYMAN_PKG_BUILD ]; then
+  # Skip setup during package builds - can't run headless and we won't
+  # run the other tests anyway
+  exit 0
+fi
+
 setup "$1" "$2" "$3"

--- a/linux/ibus-keyman/tests/scripts/setup-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/setup-tests.sh
@@ -3,10 +3,6 @@ set -eu
 
 . "$(dirname "$0")/test-helper.inc.sh"
 
-if [ -v KEYMAN_PKG_BUILD ]; then
-  # Skip setup during package builds - can't run headless and we won't
-  # run the other tests anyway
-  exit 0
-fi
+exit_on_package_build
 
 setup "$1" "$2" "$3"

--- a/linux/ibus-keyman/tests/scripts/teardown-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/teardown-tests.sh
@@ -3,4 +3,10 @@ set -eu
 
 . "$(dirname "$0")/test-helper.inc.sh"
 
+if [ -v KEYMAN_PKG_BUILD ]; then
+  # Skip setup during package builds - can't run headless and we won't
+  # run the other tests anyway
+  exit 0
+fi
+
 cleanup "$1"

--- a/linux/ibus-keyman/tests/scripts/teardown-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/teardown-tests.sh
@@ -3,10 +3,6 @@ set -eu
 
 . "$(dirname "$0")/test-helper.inc.sh"
 
-if [ -v KEYMAN_PKG_BUILD ]; then
-  # Skip setup during package builds - can't run headless and we won't
-  # run the other tests anyway
-  exit 0
-fi
+exit_on_package_build
 
 cleanup "$1"

--- a/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
+++ b/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
@@ -155,7 +155,7 @@ function _setup_display_server() {
   PID_FILE=$2
   DISPLAY_SERVER=$3
 
-  if [ "$DISPLAY_SERVER" == "wayland" ]; then
+  if [ "$DISPLAY_SERVER" == "--wayland" ]; then
     if ! can_run_wayland; then
       # support for --headless got added in mutter 40.x
       echo "ERROR: mutter doesn't support running headless. Can't run Wayland tests."

--- a/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
+++ b/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
@@ -283,3 +283,11 @@ function cleanup() {
     echo "# Finished shutdown of processes."
   fi
 }
+
+function exit_on_package_build() {
+  if [ -v KEYMAN_PKG_BUILD ]; then
+    # Skip setup during package builds - can't run headless and we won't
+    # run the other tests anyway
+    exit 0
+  fi
+}


### PR DESCRIPTION
Because we passed in a wrong parameter (`--wayland`) but checked for just `wayland` we never run the tests with Wayland. This change rectifies this.

@keymanapp-test-bot skip