### PR TITLE
fix(linux): Fix logging

### DIFF
--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -1,7 +1,7 @@
 import gettext
+import logging
 
 from keyman_config.sentry_handling import SentryErrorHandling
-
 from keyman_config.version import (
   __version__,
   __versionwithtag__,
@@ -36,6 +36,30 @@ def secure_lookup(data, key1, key2=None):
     return None
 
 
+def initialize_logging(args):
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(message)s')
+    elif args.veryverbose:
+        logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s')
+    else:
+        logging.basicConfig(format='%(levelname)s:%(message)s')
+
+
+def initialize_sentry():
+    SentryErrorHandling().initialize_sentry()
+
+
+def add_standard_arguments(parser):
+    if __pkgversion__:
+        versionstring = f"{__versionwithtag__} (package version {__pkgversion__})"
+    else:
+        versionstring = f"{__versionwithtag__}"
+
+    parser.add_argument('--version', action='version', version=f'%(prog)s version {versionstring}')
+    parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
+    parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
+
+
 gettext.bindtextdomain('keyman-config', '/usr/share/locale')
 gettext.textdomain('keyman-config')
 
@@ -53,5 +77,3 @@ KeymanApiUrl = 'https://api.keyman.com'
 
 # There's no staging site for downloads
 KeymanDownloadsUrl = 'https://downloads.keyman.com'
-
-SentryErrorHandling().initialize_sentry()

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -39,7 +39,7 @@ def get_ibus_bus():
     except Exception as e:
         logging.warning("Failed get bus")
         logging.warning(e)
-    logging.warning("could not find connected IBus.Bus")
+    logging.info("could not find connected IBus.Bus")
     return None
 
 
@@ -158,9 +158,8 @@ def bus_has_engine(bus, name):
 def get_current_engine(bus):
     try:
         contextname = bus.current_input_context()
-        ic = IBus.InputContext.get_input_context(contextname, bus.get_connection())
-        engine = ic.get_engine()
-        if engine:
+        inputContext = IBus.InputContext.get_input_context(contextname, bus.get_connection())
+        if engine := inputContext.get_engine():
             return engine.get_name()
     except Exception as e:
         logging.warning("Failed to get current engine")
@@ -170,11 +169,11 @@ def get_current_engine(bus):
 def change_to_keyboard(bus, keyboard_id):
     try:
         contextname = bus.current_input_context()
-        ic = IBus.InputContext.get_input_context(contextname, bus.get_connection())
+        inputContext = IBus.InputContext.get_input_context(contextname, bus.get_connection())
         if bus_has_engine(bus, keyboard_id) <= 0:
-            logging.warning("Could not find engine %s" % keyboard_id)
+            logging.warning(f"Could not find engine {keyboard_id}")
         else:
-            ic.set_engine(keyboard_id)
+            inputContext.set_engine(keyboard_id)
     except Exception as e:
         logging.warning("Failed to change keyboard")
         logging.warning(e)

--- a/linux/keyman-config/keyman_config/sentry_handling.py
+++ b/linux/keyman-config/keyman_config/sentry_handling.py
@@ -5,7 +5,6 @@ import logging
 import os
 import platform
 import sys
-from keyman_config.gsettings import GSettings
 from keyman_config.version import (
   __version__,
   __versionwithtag__,

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import getpass
 import logging
 import os
 from shutil import rmtree
@@ -12,8 +13,7 @@ from keyman_config.get_kmp import (InstallLocation, get_keyboard_dir,
 from keyman_config.gnome_keyboards_util import (GnomeKeyboardsUtil,
                                                 get_ibus_keyboard_id,
                                                 is_gnome_shell)
-from keyman_config.ibus_util import (IbusUtil, get_ibus_bus, restart_ibus,
-                                     uninstall_from_ibus)
+from keyman_config.ibus_util import IbusUtil, get_ibus_bus, restart_ibus
 from keyman_config.kmpmetadata import get_metadata
 
 
@@ -48,10 +48,10 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
     kbdocdir = get_keyman_doc_dir(location, packageID)
     kbfontdir = get_keyman_font_dir(location, packageID)
 
-    where = 'shared' if location == InstallLocation.Shared else 'local'
+    where = 'shared' if location == InstallLocation.Shared else 'user'
     info, system, options, keyboards, files = get_metadata(kbdir)
     if removeLanguages:
-        logging.info(f'Uninstalling {where} keyboard: {packageID}')
+        logging.info(f'Uninstalling {where} keyboard: "{packageID}"')
         if keyboards:
             if is_fcitx_running():
                 _uninstall_keyboards_from_fcitx5()
@@ -60,12 +60,13 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
             else:
                 _uninstall_keyboards_from_ibus(keyboards, kbdir)
         else:
-            logging.warning("could not uninstall keyboards")
+            logging.info(f'Could not uninstall {where} keyboard "{packageID}" from list of keyboards')
     else:
-        logging.info(f'Replacing {where} keyboard: {packageID}')
+        logging.info(f'Replacing {where} keyboard: "{packageID}"')
 
     if not os.path.isdir(kbdir):
-        logging.error('Keyboard directory %s for %s does not exist.', kbdir, packageID)
+        logging.info(f'Keyboard directory {kbdir} for "{packageID}" does not exist.')
+        logging.warning(f'Cannot uninstall non-existing {where} keyboard "{packageID}" for user {getpass.getuser()}')
 
     _uninstall_dir('Keyman keyboards', kbdir)
     _uninstall_dir('documentation', kbdocdir)
@@ -76,7 +77,7 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
         logging.error(msg)
         return msg
 
-    logging.info("Finished uninstalling %s keyboard: %s", where, packageID)
+    logging.info(f'Finished uninstalling {where} keyboard: "{packageID}"')
     return ''
 
 

--- a/linux/keyman-config/km-config
+++ b/linux/keyman-config/km-config
@@ -3,24 +3,18 @@
 import argparse
 import logging
 
-from keyman_config import __versionwithtag__, __pkgversion__
+from keyman_config import __versionwithtag__, __pkgversion__, add_standard_arguments, initialize_logging, initialize_sentry
 from keyman_config.handle_install import download_and_install_package
 from keyman_config.ibus_util import verify_ibus_daemon
+from keyman_config.view_installed import ViewInstalledWindow
 
 
 if __name__ == '__main__':
-    if __pkgversion__:
-        versionstring = "%s (package version %s)" % (__versionwithtag__, __pkgversion__)
-    else:
-        versionstring = "%s" % __versionwithtag__
     parser = argparse.ArgumentParser(description='km-config shows the currently installed ' +
                                      'Keyman keyboard packages and allows you to view ' +
                                      'information about them. It enables you to download new ' +
                                      'keyboard packages from the website or install from ' +
                                      'local files.')
-    parser.add_argument('--version', action='version', version='%(prog)s version ' + versionstring)
-    parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
-    parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
     parser.add_argument('-i', '--install', action='store', help='download and/or install .kmp ' +
                         'package. INSTALL can either be a downloaded .kmp file, a file:// URL ' +
                         'pointing to a .kmp file, or a keyman:// URL, possibly with a ' +
@@ -32,14 +26,12 @@ if __name__ == '__main__':
                         'pointing to a .kmp file, or a keyman:// URL, possibly with a ' +
                         'bcp47=<language> specified (e.g. keyman://download/keyboard/' +
                         'sil_el_ethiopian_latin?bcp47=ssy-latn).')
+    add_standard_arguments(parser)
 
     args = parser.parse_args()
-    if args.verbose:
-        logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(message)s')
-    elif args.veryverbose:
-        logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s')
-    else:
-        logging.basicConfig(format='%(levelname)s:%(message)s')
+
+    initialize_logging(args)
+    initialize_sentry()
 
     logging.info('Keyman version %s %s', __versionwithtag__, __pkgversion__)
 
@@ -50,7 +42,6 @@ if __name__ == '__main__':
     elif args.url:
         download_and_install_package(args.url)
     else:
-        from keyman_config.view_installed import ViewInstalledWindow
         w = ViewInstalledWindow()
         try:
             w.run()

--- a/linux/keyman-config/km-kvk2ldml
+++ b/linux/keyman-config/km-kvk2ldml
@@ -5,7 +5,8 @@ import logging
 import os
 import sys
 
-from keyman_config import __version__
+from keyman_config import add_standard_arguments, initialize_logging, initialize_sentry
+from keyman_config.kvk2ldml import parse_kvk_file, print_kvk, convert_ldml, output_ldml
 
 
 def main():
@@ -16,19 +17,12 @@ def main():
     parser.add_argument('-k', "--keys", help='if printing also print all keys', action="store_true")
     parser.add_argument('kvkfile', help='kvk file')
     parser.add_argument('-o', '--output', metavar='LDMLFILE', help='output LDML file location')
-    parser.add_argument('--version', action='version', version='%(prog)s version ' + __version__)
-    parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
-    parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
+    add_standard_arguments(parser)
 
     args = parser.parse_args()
-    if args.verbose:
-        logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(message)s')
-    elif args.veryverbose:
-        logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s')
-    else:
-        logging.basicConfig(format='%(levelname)s:%(message)s')
 
-    from keyman_config.kvk2ldml import parse_kvk_file, print_kvk, convert_ldml, output_ldml
+    initialize_logging(args)
+    initialize_sentry()
 
     name, ext = os.path.splitext(args.kvkfile)
     # Check if input file extension is kvk

--- a/linux/keyman-config/km-package-get
+++ b/linux/keyman-config/km-package-get
@@ -1,28 +1,22 @@
 #!/usr/bin/python3
 
 import argparse
-import logging
 import os
 
-from keyman_config import __version__
+from keyman_config import add_standard_arguments, initialize_logging, initialize_sentry
+from keyman_config.get_kmp import get_kmp, keyman_cache_dir
 
 
 def main():
     parser = argparse.ArgumentParser(description='Download Keyman keyboard package to ~/.cache/keyman')
     parser.add_argument('id', help='Keyman keyboard id')
-    parser.add_argument('--version', action='version', version='%(prog)s version ' + __version__)
-    parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
-    parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
+    add_standard_arguments(parser)
 
     args = parser.parse_args()
-    if args.verbose:
-        logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(message)s')
-    elif args.veryverbose:
-        logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s')
-    else:
-        logging.basicConfig(format='%(levelname)s:%(message)s')
 
-    from keyman_config.get_kmp import get_kmp, keyman_cache_dir
+    initialize_logging(args)
+    initialize_sentry()
+
     get_kmp(args.id)
     if os.path.exists(os.path.join(keyman_cache_dir(), 'kmpdirlist')):
         os.remove(os.path.join(keyman_cache_dir(), 'kmpdirlist'))

--- a/linux/keyman-config/km-package-install
+++ b/linux/keyman-config/km-package-install
@@ -4,23 +4,22 @@ import argparse
 import datetime
 import logging
 import os
+import requests
+import requests_cache
 import sys
 import time
 from pkg_resources import parse_version
 from zipfile import is_zipfile
 
-from keyman_config import KeymanApiUrl, __version__, secure_lookup
-from keyman_config.install_kmp import extract_kmp
+from keyman_config import KeymanApiUrl, add_standard_arguments, initialize_logging, initialize_sentry, secure_lookup
+from keyman_config.get_kmp import get_keyboard_data, get_kmp, keyman_cache_dir
+from keyman_config.install_kmp import extract_kmp, InstallError, InstallStatus, install_kmp
 from keyman_config.kmpmetadata import get_metadata
+from keyman_config.list_installed_kmp import get_kmp_version_shared, get_kmp_version_user
 from keyman_config.uninstall_kmp import uninstall_kmp
 
 
 def get_languages():
-    import requests
-    import requests_cache
-
-    from keyman_config.get_kmp import keyman_cache_dir
-
     logging.info("Getting language list from search")
     api_url = f"{KeymanApiUrl}/search?q=l:*&platform=linux"
     logging.debug("At URL %s", api_url)
@@ -71,7 +70,6 @@ def write_kmpdirlist(kmpdirfile):
 
 
 def list_keyboards():
-    from keyman_config.get_kmp import keyman_cache_dir
     kmpdirfile = os.path.join(keyman_cache_dir(), 'kmpdirlist')
     if not os.path.exists(kmpdirfile):
         write_kmpdirlist(kmpdirfile)
@@ -83,7 +81,6 @@ def list_keyboards():
 
 
 def _list_languages_for_keyboard_impl(packageId, packageDir):
-    from keyman_config.get_kmp import keyman_cache_dir
     kmpfile = os.path.join(keyman_cache_dir(), packageId)
     if not os.path.exists(kmpfile):
         kmpfile = f'{kmpfile}.kmp'
@@ -119,19 +116,14 @@ def main():
     parser.add_argument('-f', '--file', metavar='KMPFILE', help='Keyman kmp file')
     parser.add_argument('-p', '--package', metavar='PACKAGE', help='Keyman package id')
     parser.add_argument('-l', '--bcp47', metavar='LANGTAG', help='bcp47 language tag')
-    parser.add_argument('--version', action='version', version=f'%(prog)s version {__version__}')
-    parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
-    parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
     parser.add_argument('--force', action='store_true', help='force installation of keyboard even if it is ' +
                         'a downgrade to an older version of the keyboard')
+    add_standard_arguments(parser)
 
     args = parser.parse_args()
-    if args.verbose:
-        logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(message)s')
-    elif args.veryverbose:
-        logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s')
-    else:
-        logging.basicConfig(format='%(levelname)s:%(message)s')
+
+    initialize_logging(args)
+    initialize_sentry()
 
     if args.package and args.file:
         parser.print_usage()
@@ -139,12 +131,6 @@ def main():
           "km-package-install: error: too many arguments: either install a local kmp file or " +
           "specify a keyboard id to download and install.")
         sys.exit(2)
-
-    from keyman_config.get_kmp import (get_keyboard_data, get_kmp,
-                                       keyman_cache_dir)
-    from keyman_config.install_kmp import (InstallError, InstallStatus,
-                                           install_kmp)
-    from keyman_config.list_installed_kmp import get_kmp_version_shared, get_kmp_version_user
 
     if os.path.exists(os.path.join(keyman_cache_dir(), 'kmpdirlist')):
         os.remove(os.path.join(keyman_cache_dir(), 'kmpdirlist'))

--- a/linux/keyman-config/km-package-list-installed
+++ b/linux/keyman-config/km-package-list-installed
@@ -1,9 +1,11 @@
 #!/usr/bin/python3
 
 import argparse
-import logging
 import os
-from keyman_config import __version__
+
+from keyman_config import add_standard_arguments, initialize_logging, initialize_sentry
+from keyman_config.get_kmp import get_keyman_dir, InstallLocation
+from keyman_config.list_installed_kmp import get_installed_kmp
 
 
 def main():
@@ -12,21 +14,14 @@ def main():
     parser.add_argument('-s', "--shared", help='show keyboard packages installed in shared area', action="store_true")
     parser.add_argument('-o', "--os", help='show keyboard packages installed by the OS', action="store_true")
     parser.add_argument('-u', "--user", help='show keyboard packages installed in user area', action="store_true")
-    parser.add_argument('--version', action='version', version=f'%(prog)s version {__version__}')
-    parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
-    parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
+    add_standard_arguments(parser)
 
     args = parser.parse_args()
-    if args.verbose:
-        logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(message)s')
-    elif args.veryverbose:
-        logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s')
-    else:
-        logging.basicConfig(format='%(levelname)s:%(message)s')
+
+    initialize_logging(args)
+    initialize_sentry()
 
     _all = not args.user and not args.shared and not args.os
-    from keyman_config.list_installed_kmp import get_installed_kmp
-    from keyman_config.get_kmp import get_keyman_dir, InstallLocation
     if args.user or _all:
         installed_kmp = get_installed_kmp(InstallLocation.User)
         if args.verbose or args.veryverbose:

--- a/linux/keyman-config/km-package-uninstall
+++ b/linux/keyman-config/km-package-uninstall
@@ -1,28 +1,21 @@
 #!/usr/bin/python3
 
 import argparse
-import logging
 
-from keyman_config import __version__
-
+from keyman_config import add_standard_arguments, initialize_logging, initialize_sentry
+from keyman_config.uninstall_kmp import uninstall_kmp
 
 def main():
     parser = argparse.ArgumentParser(description='Uninstall a Keyman keyboard package.')
     parser.add_argument('id', help='Keyman keyboard id')
     parser.add_argument('-s', '--shared', action='store_true', help='Uninstall from shared area /usr/local')
-    parser.add_argument('--version', action='version', version='%(prog)s version ' + __version__)
-    parser.add_argument('-v', '--verbose', action='store_true', help='verbose logging')
-    parser.add_argument('-vv', '--veryverbose', action='store_true', help='very verbose logging')
+    add_standard_arguments(parser)
 
     args = parser.parse_args()
-    if args.verbose:
-        logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(message)s')
-    elif args.veryverbose:
-        logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s')
-    else:
-        logging.basicConfig(format='%(levelname)s:%(message)s')
 
-    from keyman_config.uninstall_kmp import uninstall_kmp
+    initialize_logging(args)
+    initialize_sentry()
+
     uninstall_kmp(args.id, args.shared)
 
 


### PR DESCRIPTION
We can't initialize Sentry during module initialization because our `initialize_sentry` method logs some status info. Setting the logging level later on is then a no-op, breaking verbose and very-verbose logging.

This change fixes this by putting Sentry initialization into a separate method that gets called after we set the log level.

Also refactor some common code into methods that appear in all our executables.

@keymanapp-test-bot skip