### PR TITLE
fix(linux): Reword error if uninstalling non-existent keyboard

### DIFF
--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -39,7 +39,7 @@ def get_ibus_bus():
     except Exception as e:
         logging.warning("Failed get bus")
         logging.warning(e)
-    logging.warning("could not find connected IBus.Bus")
+    logging.info("could not find connected IBus.Bus")
     return None
 
 

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -158,9 +158,8 @@ def bus_has_engine(bus, name):
 def get_current_engine(bus):
     try:
         contextname = bus.current_input_context()
-        ic = IBus.InputContext.get_input_context(contextname, bus.get_connection())
-        engine = ic.get_engine()
-        if engine:
+        inputContext = IBus.InputContext.get_input_context(contextname, bus.get_connection())
+        if engine := inputContext.get_engine():
             return engine.get_name()
     except Exception as e:
         logging.warning("Failed to get current engine")
@@ -170,11 +169,11 @@ def get_current_engine(bus):
 def change_to_keyboard(bus, keyboard_id):
     try:
         contextname = bus.current_input_context()
-        ic = IBus.InputContext.get_input_context(contextname, bus.get_connection())
+        inputContext = IBus.InputContext.get_input_context(contextname, bus.get_connection())
         if bus_has_engine(bus, keyboard_id) <= 0:
-            logging.warning("Could not find engine %s" % keyboard_id)
+            logging.warning(f"Could not find engine {keyboard_id}")
         else:
-            ic.set_engine(keyboard_id)
+            inputContext.set_engine(keyboard_id)
     except Exception as e:
         logging.warning("Failed to change keyboard")
         logging.warning(e)

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import getpass
 import logging
 import os
 from shutil import rmtree
@@ -47,7 +48,7 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
     kbdocdir = get_keyman_doc_dir(location, packageID)
     kbfontdir = get_keyman_font_dir(location, packageID)
 
-    where = 'shared' if location == InstallLocation.Shared else 'local'
+    where = 'shared' if location == InstallLocation.Shared else 'user'
     info, system, options, keyboards, files = get_metadata(kbdir)
     if removeLanguages:
         logging.info(f'Uninstalling {where} keyboard: "{packageID}"')
@@ -65,7 +66,7 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
 
     if not os.path.isdir(kbdir):
         logging.info(f'Keyboard directory {kbdir} for "{packageID}" does not exist.')
-        logging.warning(f'Cannot uninstall non-existing {where} keyboard "{packageID}"')
+        logging.warning(f'Cannot uninstall non-existing {where} keyboard "{packageID}" for user {getpass.getuser()}')
 
     _uninstall_dir('Keyman keyboards', kbdir)
     _uninstall_dir('documentation', kbdocdir)

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -12,8 +12,7 @@ from keyman_config.get_kmp import (InstallLocation, get_keyboard_dir,
 from keyman_config.gnome_keyboards_util import (GnomeKeyboardsUtil,
                                                 get_ibus_keyboard_id,
                                                 is_gnome_shell)
-from keyman_config.ibus_util import (IbusUtil, get_ibus_bus, restart_ibus,
-                                     uninstall_from_ibus)
+from keyman_config.ibus_util import IbusUtil, get_ibus_bus, restart_ibus
 from keyman_config.kmpmetadata import get_metadata
 
 
@@ -51,7 +50,7 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
     where = 'shared' if location == InstallLocation.Shared else 'local'
     info, system, options, keyboards, files = get_metadata(kbdir)
     if removeLanguages:
-        logging.info(f'Uninstalling {where} keyboard: {packageID}')
+        logging.info(f'Uninstalling {where} keyboard: "{packageID}"')
         if keyboards:
             if is_fcitx_running():
                 _uninstall_keyboards_from_fcitx5()
@@ -60,12 +59,13 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
             else:
                 _uninstall_keyboards_from_ibus(keyboards, kbdir)
         else:
-            logging.warning("could not uninstall keyboards")
+            logging.info(f'Could not uninstall {where} keyboard "{packageID}" from list of keyboards')
     else:
-        logging.info(f'Replacing {where} keyboard: {packageID}')
+        logging.info(f'Replacing {where} keyboard: "{packageID}"')
 
     if not os.path.isdir(kbdir):
-        logging.error('Keyboard directory %s for %s does not exist.', kbdir, packageID)
+        logging.info(f'Keyboard directory {kbdir} for "{packageID}" does not exist.')
+        logging.warning(f'Cannot uninstall non-existing {where} keyboard "{packageID}"')
 
     _uninstall_dir('Keyman keyboards', kbdir)
     _uninstall_dir('documentation', kbdocdir)
@@ -76,7 +76,7 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
         logging.error(msg)
         return msg
 
-    logging.info("Finished uninstalling %s keyboard: %s", where, packageID)
+    logging.info(f'Finished uninstalling {where} keyboard: "{packageID}"')
     return ''
 
 


### PR DESCRIPTION
This change reworks the output we show if the user tries to uninstall a non-existing keyboard. This could be trying to uninstall a shared keyboard when a user keyboard exists and vice versa. This change rewords the message to include the area (shared/user), so hopefully this makes it a bit clearer. We also now output this as a warning instead of an error.

Completely suppressing the message as suggested in #9213 doesn't seem to be the right way as that would lead to the user blaming uninstall to not work when the real reason are wrong parameters.

Closes #9213.

## Screenshot of the new warning
![image](https://github.com/keymanapp/keyman/assets/181336/41c3dc64-d89b-49e5-a52c-c8095e8fadba)

# User Testing

## Preparations

- The tests can be run on any Linux platform
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot

## Tests

**TEST_MULTIPLE_UNINSTALL**: 

- Open Terminal window
- Install Swedish EuroLatin(SIL) keyboard using`km-package-install -p sil_euro_latin -l sv` command
- Uninstall keyboard using `km-package-uninstall sil_euro_latin` command
- Run the same uninstall command again: `km-package-uninstall sil_euro_latin`
- Verify that no error is shown (Note that it will show a warning though, see discussion in the description at the top of this PR)
