### PR TITLE
feat(web): gesture modeling + isolated matching 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
@@ -6,10 +6,6 @@ import { GestureModel, GestureResolution, GestureResolutionSpec, RejectionDefaul
 import { ManagedPromise, TimeoutPromise } from "@keymanapp/web-utils";
 import { FulfillmentCause, PathMatcher } from "./pathMatcher.js";
 
-//
-// TODO:  Next up - let's unit-test this bad boy!
-//
-
 export interface MatchResult<Type> {
   matched: boolean,
   action: GestureResolution<Type>
@@ -65,12 +61,9 @@ export class GestureMatcher<Type> {
 
     this.pathMatchers = [];
 
-    let sourceTouchpoints: SimpleGestureSource<Type>[];
-    if(source) {
-      sourceTouchpoints = source.touchpoints;
-    } else {
-      sourceTouchpoints = predecessor.pathMatchers.map((matcher) => matcher.source);
-    }
+    const sourceTouchpoints: SimpleGestureSource<Type>[] = source
+      ? source.touchpoints
+      : predecessor.pathMatchers.map((matcher) => matcher.source);
 
     let offset = 0;
     for(let touchpointIndex = 0; touchpointIndex < sourceTouchpoints.length; touchpointIndex++) {
@@ -131,7 +124,7 @@ export class GestureMatcher<Type> {
         // Some gesture types may wish to restart with a new base item if they fail due to
         // it changing during its lifetime or due to characteristics of the contact-point's
         // path.
-        if(this.model.rejectionActions && this.model.rejectionActions[cause]) {
+        if(this.model.rejectionActions?.[cause]) {
           action = this.model.rejectionActions[cause];
           action.item = 'none';
         }

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
@@ -1,0 +1,293 @@
+import { ComplexGestureSource } from "../../complexGestureSource.js";
+import { SimpleGestureSource, SimpleGestureSourceSubview } from "../../simpleGestureSource.js";
+
+import { GestureModel, GestureResolution, GestureResolutionSpec, RejectionDefault, ResolutionItemSpec } from "../specs/gestureModel.js";
+
+import { ManagedPromise, TimeoutPromise } from "@keymanapp/web-utils";
+import { FulfillmentCause, PathMatcher } from "./pathMatcher.js";
+
+//
+// TODO:  Next up - let's unit-test this bad boy!
+//
+
+export interface MatchResult<Type> {
+  matched: boolean,
+  action: GestureResolution<Type>
+}
+
+export interface MatchResultSpec {
+  matched: boolean,
+  action: GestureResolutionSpec
+}
+
+export class GestureMatcher<Type> {
+  private sustainTimerPromise?: TimeoutPromise;
+  public readonly model: GestureModel<Type>;
+
+  public readonly pathMatchers: PathMatcher<Type>[];
+  private predecessor?: GestureMatcher<Type>;
+
+  private readonly publishedPromise: ManagedPromise<MatchResult<Type>>; // unsure on the actual typing at the moment.
+  private _result: MatchResult<Type>;
+
+  private baseSource: ComplexGestureSource<Type>;
+
+  public get promise() {
+    return this.publishedPromise.corePromise;
+  }
+
+  constructor(model: GestureModel<Type>, sourceObj: ComplexGestureSource<Type> | GestureMatcher<Type>) {
+    /* c8 ignore next 5 */
+    if(!model || !sourceObj) {
+      throw new Error("Construction of GestureMatcher requires a gesture-model spec and a source for related contact points.");
+    } else if(!model.sustainTimer && sourceObj instanceof ComplexGestureSource && sourceObj.touchpoints.length == 0) {
+      throw new Error("If the provided gesture-model spec lacks a sustain timer, there must be an active contact point.");
+    }
+
+    // We condition on ComplexGestureSource since some unit tests mock the other type without
+    // instantiating the actual type.
+    const predecessor = sourceObj instanceof ComplexGestureSource<Type> ? null : sourceObj;
+    const source = predecessor ? null : (sourceObj as ComplexGestureSource<Type>);
+
+    this.baseSource = predecessor?.baseSource || source;
+
+    this.predecessor = predecessor;
+    this.publishedPromise = new ManagedPromise();
+
+    this.model = model;
+    if(model.sustainTimer) {
+      this.sustainTimerPromise = new TimeoutPromise(model.sustainTimer.duration);
+      this.sustainTimerPromise.then((elapsed) => {
+        const shouldResolve = model.sustainTimer.expectedResult == elapsed;
+        this.finalize(shouldResolve, 'timer');
+      });
+    }
+
+    this.pathMatchers = [];
+
+    let sourceTouchpoints: SimpleGestureSource<Type>[];
+    if(source) {
+      sourceTouchpoints = source.touchpoints;
+    } else {
+      sourceTouchpoints = predecessor.pathMatchers.map((matcher) => matcher.source);
+    }
+
+    let offset = 0;
+    for(let touchpointIndex = 0; touchpointIndex < sourceTouchpoints.length; touchpointIndex++) {
+      const srcContact = sourceTouchpoints[touchpointIndex];
+
+      // If a touchpoint's path is already complete, ignore it when modeling a new gesture.
+      if(srcContact.path.isComplete) {
+        offset++;
+        continue;
+      }
+
+      if(srcContact instanceof SimpleGestureSourceSubview) {
+        srcContact.disconnect();  // prevent further updates from mangling tracked path info.
+      }
+      let i = touchpointIndex - offset;
+
+      const contactSpec = model.contacts[i];
+      /* c8 ignore next 3 */
+      if(!contactSpec) {
+        throw new Error(`No contact model for inherited path: gesture "${model.id}', entry ${i}`);
+      }
+      const inheritancePattern = contactSpec?.model.pathInheritance ?? 'chop';
+
+      let preserveBaseItem: boolean = false;
+
+      let contact: SimpleGestureSource<Type>;
+      switch(inheritancePattern) {
+        case 'reject':
+          this.finalize(false, 'path');
+          return;
+        case 'full':
+          contact = srcContact.constructSubview(false, true);
+          this.addContactInternal(contact);
+          continue;
+        case 'partial':
+          preserveBaseItem = true;
+          // Intentional fall-through
+        case 'chop':
+          contact = srcContact.constructSubview(true, preserveBaseItem);
+          this.addContactInternal(contact);
+          break;
+      }
+    }
+  }
+
+  private finalize(matched: boolean, cause: FulfillmentCause) {
+    if(this.publishedPromise.isFulfilled) {
+      return this._result;
+    }
+
+    try {
+      // Determine the correct action-spec that should result from the finalization.
+      let action: GestureResolutionSpec | (RejectionDefault & ResolutionItemSpec);
+      if(matched) {
+        // Easy peasy - resolutions only need & have the one defined action type.
+        action = this.model.resolutionAction;
+      } else {
+        // Some gesture types may wish to restart with a new base item if they fail due to
+        // it changing during its lifetime or due to characteristics of the contact-point's
+        // path.
+        if(this.model.rejectionActions && this.model.rejectionActions[cause]) {
+          action = this.model.rejectionActions[cause];
+          action.item = 'none';
+        }
+
+        // Rejection for other reasons, or if no special action is defined for item rejection:
+        action = action || {
+          type: 'none',
+          item: 'none'
+        };
+      }
+
+      for(let i = 0; i < this.pathMatchers.length; i++) {
+        const matcher = this.pathMatchers[i];
+        const contactSpec = this.model.contacts[i];
+
+        // If the path already terminated, no need to evaluate further for this contact point.
+        if(matcher.source.isPathComplete) {
+          continue;
+        }
+
+        if(matched && contactSpec.endOnResolve) {
+          matcher.source.terminate(false);
+        } else if(!matched && contactSpec.endOnReject) {
+          // Ending due to gesture-rejection effectively means to cancel the path,
+          // so signal exactly that.
+          matcher.source.terminate(true);
+        }
+      }
+
+      // Determine the item source for the item to be reported for this gesture, if any.
+      let resolutionItem: Type;
+      const itemSource = action.item ?? 'current';
+      switch(itemSource) {
+        case 'none':
+          resolutionItem = null;
+          break;
+        case 'base':
+          resolutionItem = this.comparisonStandard.baseItem;
+          break;
+        case 'current':
+          resolutionItem = this.comparisonStandard.currentSample.item;
+          break;
+      }
+
+      // Do actual resolution now that we can convert the spec into a proper resolution object.
+      let resolveObj: MatchResult<Type> = {
+        matched: matched,
+        action: {
+          ...action,
+          item: resolutionItem
+        }
+      };
+
+      this.publishedPromise.resolve(resolveObj);
+
+      this._result = resolveObj;
+      return resolveObj;
+      /* c8 ignore next 3 */
+    } catch(err) {
+      this.publishedPromise.reject(err);
+    }
+  }
+
+  /**
+   * Determines the active path-matcher best suited to serve as the "primary" path for the gesture.
+   *
+   * This is needed for the following logic roles:
+   * - If accepting a new contact point, `allowsInitialState` needs an existing path's sample for
+   *   comparison.
+   * - When resolving, the "primary" path determines what item (if any) is generated for the gesture.
+   *
+   * If no matcher is active, but the currently-evaluating gesture has a direct ancestor, the best
+   * matcher from the predecessor may be used instead.
+   */
+  private get comparisonStandard(): SimpleGestureSource<Type> {
+    let bestMatcher: PathMatcher<Type>;
+    let highestPriority = Number.MIN_VALUE;
+    for(let matcher of this.pathMatchers) {
+      if(matcher.model.itemPriority > highestPriority) {
+        highestPriority = matcher.model.itemPriority;
+        bestMatcher = matcher;
+      }
+    }
+
+    // Example case:  multitap, with the current stage of the chain having zero active touchpaths...
+    // but a previous 'link' having had a valid touchpath.
+    //
+    // Here, the best answer is to use the 'comparisonPath' from the prior link; it'll contain
+    // the path-samples we'd intuitively expect to use for comparison, after all.
+    if(!bestMatcher && this.predecessor) {
+      return this.predecessor.comparisonStandard;
+    }
+
+    return bestMatcher.source;
+  }
+
+  mayAddContact(): boolean {
+    return this.pathMatchers.length < this.model.contacts.length;
+  }
+
+  // for new incoming SimpleGestureSource
+  addContact(simpleSource: SimpleGestureSource<Type>) {
+    const existingContacts = this.pathMatchers.length;
+    /* c8 ignore next 3 */
+    if(!this.mayAddContact()) {
+      throw new Error(`The specified gesture model does not support more than ${existingContacts} contact points.`);
+    }
+
+    // The number of already-active contacts tracked for this gesture
+    const contactSpec = this.model.contacts[existingContacts];
+
+    let baseItem: Type = null;
+    if(existingContacts) {
+      // just use the highest-priority item source's base item and call it a day.
+      baseItem = this.comparisonStandard.baseItem;
+    } else if(this.predecessor && this.model.sustainTimer) {
+      const baseItemMode = this.model.sustainTimer.baseItem ?? 'result';
+
+      switch(baseItemMode) {
+        case 'none':
+          baseItem = null;
+          break;
+        case 'base':
+          baseItem = this.predecessor.comparisonStandard.baseItem;
+          break;
+        case 'result':
+          baseItem = this.predecessor._result.action.item;
+          break;
+      }
+    }
+
+    if(contactSpec.model.allowsInitialState) {
+      const initialStateCheck = contactSpec.model.allowsInitialState(simpleSource.currentSample, this.comparisonStandard.currentSample, baseItem);
+
+      if(!initialStateCheck) {
+        this.finalize(false, 'path');
+      }
+    }
+
+    this.addContactInternal(simpleSource.constructSubview(false, true));
+  }
+
+  private addContactInternal(simpleSource: SimpleGestureSource<Type>) {
+    const existingContacts = this.pathMatchers.length;
+
+    // The number of already-active contacts tracked for this gesture
+    const contactSpec = this.model.contacts[existingContacts];
+    const contactModel = new PathMatcher(contactSpec.model, simpleSource);
+    contactModel.promise.then((resolution) => {
+      this.finalize(resolution.type == 'resolve', resolution.cause);
+    });
+
+    this.pathMatchers.push(contactModel);
+  }
+
+  update() {
+    this.pathMatchers.forEach((matcher) => matcher.update());
+  }
+}

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/index.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/index.ts
@@ -1,1 +1,2 @@
+export { GestureMatcher } from './gestureMatcher.js';
 export { PathMatcher } from './pathMatcher.js';

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
@@ -30,6 +30,23 @@ export interface ContactModel<Type> {
   // Allows specifying use of one of the configured 'gestureItemIdentifiers'.
   recognizerId?: string;
 
+  // This field is primarly used at the `GestureMatcher` level, rather than the
+  // `PathMatcher` level.
+  /**
+   * When a parent gesture 'chains' into a gesture with this contact model,
+   * the path may be "inherited" in one of four ways:
+   *
+   * - 'reject' - a still-active path is not allowed
+   * - 'chop'   - a still-active path is merely 'trimmed' at the current point in
+   *              the path.  The current location's 'item' will become the base item.
+   * - 'partial' - like 'chop', except it preserves the original base item.
+   * - 'full'   - preserves the entire path and keeps the original base item.
+   *
+   * Note that for gestures reachable by _optional_ chaining, only the first two modes
+   * are properly supported.  Exclusive chaining may safely use all four.
+   */
+  pathInheritance?: 'reject' | 'chop' | 'partial' | 'full';
+
   /**
    * Used to either instantly resolve or reject this component of a gesture based on
    * a change in 'currently hovered item' for the path.
@@ -42,8 +59,9 @@ export interface ContactModel<Type> {
   /**
    * Is needed to define whether or not the contact-point should be ignored by this gesture type.
    * If undefined, defaults to () => true.
-   * Param 2 only matters for slot 2+ of a multitouch gesture spec; it will receive the latest sample
-   * from already-linked.
+   * Param 2 only matters for slots of multitouch gesture spec added after initialization of
+   * the gesture's corresponding matcher; it will receive the latest sample from the highest-priority
+   * active path (or predecessor gesture, if no path is active due to a 'sustain' state)
    */
-  readonly allowsInitialState?: (incomingSample: InputSample<Type>, priorityMultitouchSample?: InputSample<Type>) => boolean;
+  readonly allowsInitialState?: (incomingSample: InputSample<Type>, comparisonSample?: InputSample<Type>, baseItem?: Type) => boolean;
 }

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/gestureModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/gestureModel.ts
@@ -1,0 +1,97 @@
+import { FulfillmentCause } from "../matchers/pathMatcher.js";
+import { ContactModel } from "./contactModel.js";
+
+// So doc-comments can be inherited together.
+export interface ResolutionItemSpec {
+  item?: 'base' | 'current' | 'none',
+}
+
+export interface ResolutionItem<Type> {
+  item: Type
+}
+
+export interface ResolutionPush {
+  type: 'push',
+  allowedGestures: string[]
+}
+
+export interface ResolutionChain {
+  type: 'chain',
+  next: string
+}
+
+// is not "locked-in"
+export interface OptionalChain {
+  type: 'optional-chain', // With spec-shift: 'reset'?
+  allowNext: string
+}
+
+export interface ResolutionComplete {
+  type: 'complete'
+}
+
+export interface RejectionDefault {
+  type: 'none'
+}
+
+
+// If there is a 'gesture stack' associated with the gesture chain, it's auto-popped
+// upon completion of the chain.  So, either this resolution type or a final,
+// non-chainable rejection will 'pop' to undo any existing prior 'push' resolutions
+// in the chain.  As such, there is no need for a {type: 'pop'} variant.
+
+type ResolutionStruct = ResolutionPush | ResolutionChain | OptionalChain | ResolutionComplete;
+
+export type GestureResolutionSpec   = ResolutionStruct & ResolutionItemSpec;
+export type GestureResolution<Type> = (ResolutionStruct | RejectionDefault) & ResolutionItem<Type>;
+
+export interface GestureModel<Type> {
+  // Gestures may want to say "build gesture of type `id`" for a followup-gesture.
+  readonly id: string;
+
+  // This field is primarly used at the `GestureMatcher` level, rather than the
+  // `PathMatcher` level.
+  //
+  // Higher = better.  Only takes effect if multiple gesture types could resolve on the same
+  // ComplexGestureSource for the same update.
+  readonly resolutionPriority: number;
+
+  // This field is primarly used at the `GestureMatcher` level, rather than the
+  // `PathMatcher` level.
+  //
+  // If there are multiple unresolved gestures, with no lock-in, the "potential gesture" with the
+  // highest item priority is the authority re: the "current item".
+  readonly itemPriority: number;
+
+  // One or more "touchpath models" - how a touchpath matching this gesture would look, based on its
+  // ordinal position.  (Same order as in the TrackedInput)
+  readonly contacts: {
+    model: ContactModel<Type>,
+    endOnResolve?: boolean,
+    endOnReject?: boolean
+  }[];
+
+  // if this is defined, the gesture can't resolve while the spec'd Promise is active.
+  // Even if `expectedResult` is negative.
+  readonly sustainTimer?: {
+    duration: number,
+    expectedResult: boolean,
+
+    // Determines which base item from an ancestor should be used for any initial-state checks for
+    // paths that come in during the sustain.
+    baseItem?: 'base' | 'result' | 'none'
+  }
+
+  readonly resolutionAction: GestureResolutionSpec;
+
+  readonly rejectionActions?: Partial<Record<FulfillmentCause, Omit<OptionalChain, 'item'>>>;
+  // If there is a 'gesture stack' associated with the gesture chain, it's auto-popped
+  // upon completion of the chain.  Optional-chaining can sustain the chain while the
+  // potential child gesture is still a possibility.
+
+  // TODO:  allow function for correlating multitouch paths (like for caret-pannning)
+  // But that's something we'll likely defer past 17.0.
+  // Probably:  takes both paths' stat-objects.  (Fortunately, the stats object holds
+  // 'start' and 'end' sample references - so we don't need to add them as additional
+  // parameters.)
+}

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/index.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/index.ts
@@ -1,2 +1,3 @@
 export * from './contactModel.js';
+export * from './gestureModel.js';
 export * from './pathModel.js';

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/gestureMatcher.spec.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/gestureMatcher.spec.ts
@@ -1,0 +1,485 @@
+import { assert } from 'chai'
+import sinon from 'sinon';
+
+import * as PromiseStatusModule from 'promise-status-async';
+const promiseStatus       = PromiseStatusModule.promiseStatus;
+const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
+
+import { ComplexGestureSource, InputSample, SimpleGestureSource, gestures } from '@keymanapp/gesture-recognizer';
+
+// import { HeadlessInputEngine, TouchpathTurtle } from '../../../../../build/tools/obj/index.js'; //'#tools';
+import { TouchpathTurtle } from '#tools';
+import { ManagedPromise, timedPromise } from '@keymanapp/web-utils';
+
+import {
+  MultitapModel,
+  SimpleTapModel
+} from './isolatedGestureSpecs.js';
+import { GestureMatcher } from '../../../../../build/obj/headless/gestures/matchers/gestureMatcher.js';
+
+interface SimSpecSequence<Type> {
+  type: 'sequence',
+  samples: InputSample<Type>[],
+  terminate: boolean
+}
+
+interface SimSpecTimer<Type> {
+  type: 'timer',
+  lastSample: InputSample<Type>
+}
+
+interface MockedPredecessor<Type> {
+  comparisonStandard: {
+    sample: InputSample<Type>,
+    baseItem: Type
+  },
+  pathMatchers: GestureMatcher<Type>[],
+  _result: {
+    action: {
+      item: Type
+    }
+  }
+}
+
+function mockedPredecessor<Type>(
+  lastSample: InputSample<Type>,
+  baseItem?: Type
+): MockedPredecessor<Type> {
+  return {
+    comparisonStandard: {
+      sample: lastSample,
+      baseItem: baseItem ?? lastSample.item
+    },
+    pathMatchers: [],
+    _result: {
+      action: {
+        item: baseItem ?? lastSample.item
+      }
+    }
+  };
+}
+
+function simulateComplexGestureSource<Type>(
+  sequences: (SimSpecTimer<Type> | SimSpecSequence<Type>)[],
+  fakeClock: sinon.SinonFakeTimers,
+  modelSpec: gestures.specs.GestureModel<Type>
+  ): {
+    source: ComplexGestureSource<Type>,
+    modelMatcherPromise: Promise<gestures.matchers.GestureMatcher<Type>>,
+    executor: () => Promise<void>
+  } {
+
+  if(sequences.length == 0) {
+    return;
+  }
+
+  const firstEntry = sequences[0];
+  const startTimestamp = firstEntry.type == 'timer' ? firstEntry.lastSample.t : firstEntry.samples[0].t;
+  // Expectation (that should probably be an assertion) - the first entry in the input should hold the
+  // earliest timestamp.
+
+  let allPromises: Promise<void>[] = [];
+
+  let source: ComplexGestureSource<Type>;
+  let contacts: SimpleGestureSource<Type>[] = [];
+  let modelMatcher: gestures.matchers.GestureMatcher<Type>;
+  let modelMatcherPromise = new ManagedPromise<gestures.matchers.GestureMatcher<Type>>();
+
+  // Build Promises for these first; that way, new contacts are connected before any new samples
+  // for already-existing touchpaths are observed, facilitating synchronization of coordinate
+  // sample updates.
+  //
+  // We do accept the _first_ coordinate for a sample, as this is necessary for accepting
+  // new contact points for some gesture types (such as multitap).  Previously-existing touchpaths
+  // will gain their corresponding update in a Promise created later, thus coming second.
+  // (If it came first, that update would be desynced with the initial sample for the new path.)
+  for(let i = 0; i < sequences.length; i++) {
+    const simpleSource = new SimpleGestureSource<Type>(i, true);
+    contacts.push(simpleSource);
+    let entry = sequences[i];
+
+    if(i == 0) {
+      source = new ComplexGestureSource(simpleSource);
+      timedPromise(0).then(() => {
+        let predecessor: GestureMatcher<Type>;
+        if(entry.type == 'timer') {
+          // We're simulating a previously-completed contact point's path..
+          // Preserve the supposed 'last sample' from that previous contact point.
+          simpleSource.update(entry.lastSample);
+          simpleSource.terminate(false);
+
+          predecessor = mockedPredecessor(entry.lastSample) as any as GestureMatcher<Type>;
+        }
+
+        // The final parameter mocks a previous match attempt for the same ComplexGestureSource.
+        modelMatcher = new gestures.matchers.GestureMatcher<Type>(modelSpec, predecessor || source);
+        modelMatcherPromise.resolve(modelMatcher);
+      });
+    } else {
+      if(entry.type != 'sequence') {
+        throw new Error("Only the first entry for complex gesture input simulation may be a timer.");
+      } else {
+        timedPromise(entry.samples[0].t - startTimestamp).then(() => {
+          // Acceptance of new contact points requires an existing sample.
+          simpleSource.update((entry as SimSpecSequence<Type>).samples[0]);
+          source.addTouchpoint(simpleSource);
+          modelMatcher.addContact(simpleSource);
+        });
+      }
+    }
+  }
+
+  // Now that touchpath-creation Promises are registered first, we can start adding in the updates for
+  // already-existing sequences.  Any gesture-management updates based on path will check for timestamp
+  // synchronization across all constituent paths / tracked contact points.  (Having the 'new contacts'
+  // registered first is necessary for including them in the synchronization check.)
+  for(let i = 0; i < sequences.length; i++) {
+    const sequenceSpec = sequences[i];
+    if(sequenceSpec.type != 'sequence') {
+      continue;
+    }
+
+    const simpleSource = contacts[i];
+
+    const sequence = sequenceSpec.samples;
+    const sequencePromises = sequence.map((sample) => {
+      return timedPromise(sample.t - startTimestamp).then(async () => {
+        // We already committed the sample early, to facilitate new contact-point acceptance,
+        // so we skip re-adding it here.  We DO allow all other update functionality to
+        // proceed as normal, though.
+        if(simpleSource.path.coords[0] != sample && !simpleSource.isPathComplete) {
+          simpleSource.update(sample);
+        }
+
+        // Includes the synchronization check.
+        modelMatcher.update();
+
+        // All path updates for synchronization have Promises predating this one.
+        // This ensures those are all processed before we move on to default handling of the path
+        // for cases that don't otherwise look at path termination.
+        await Promise.resolve();
+
+        if((sequenceSpec.terminate ?? true) && sample == sequence[sequence.length-1]) {
+          if(!simpleSource.isPathComplete) {
+            simpleSource.terminate(false);
+            modelMatcher.update();
+          }
+        }
+      });
+    });
+
+    allPromises = allPromises.concat(sequencePromises);
+  }
+
+  const executor = async () => {
+    // Runs until the last already-scheduled timer.  We haven't actually built the
+    // GestureMatcher instance yet - only for the actual path observations.
+    // Thus, it's possible for the simulation to end before a 'sustain timer' elapses.
+    await fakeClock.runToLastAsync();
+    // In case of unexpected errors during sample or cancel simulation.
+    await Promise.all(allPromises);
+  }
+
+  return {
+    source: source,
+    modelMatcherPromise: modelMatcherPromise.corePromise,
+    executor: executor
+  }
+}
+
+describe.only("GestureMatcher", function() {
+  // // File paths need to be from the package's / module's root folder
+  // let testJSONtext = fs.readFileSync('src/test/resources/json/canaryRecording.json');
+
+  beforeEach(function() {
+    this.fakeClock = sinon.useFakeTimers();
+  })
+
+  afterEach(function() {
+    this.fakeClock.restore();
+  })
+
+  describe("Simple tap", function() {
+    it("resolve: single path, touch release", async function() {
+      const turtle = new TouchpathTurtle({
+        targetX: 0,
+        targetY: 0,
+        t: 0,
+        item: 'a'
+      });
+
+      turtle.wait(100, 5);
+      turtle.commitPending();
+
+      const {
+        source,
+        modelMatcherPromise,
+        executor
+      } = simulateComplexGestureSource([{type: 'sequence', samples: turtle.path, terminate: true}], this.fakeClock, SimpleTapModel);
+
+      await executor();
+      const modelMatcher = await modelMatcherPromise;
+
+      assert.equal(await promiseStatus(modelMatcher.promise), PromiseStatuses.PROMISE_RESOLVED);
+      assert.deepEqual(await modelMatcher.promise, {matched: true, action: { type: 'optional-chain', item: 'a', allowNext: 'multitap'}});
+      assert.isTrue(source.touchpoints[0].path.isComplete);
+    });
+
+    it("resolve: second contact-point", async function() {
+      const turtle1 = new TouchpathTurtle({
+        targetX: 0,
+        targetY: 0,
+        t: 0,
+        item: 'a'
+      });
+
+      turtle1.wait(100, 5);
+      turtle1.commitPending();
+
+      const turtle2 = new TouchpathTurtle({
+        targetX: 50,
+        targetY: 0,
+        t: 100,
+        item: 'b'
+      });
+      turtle2.commitPending();
+
+      const {
+        source,
+        modelMatcherPromise,
+        executor
+      } = simulateComplexGestureSource([{
+        type: 'sequence', samples: turtle1.path, terminate: false,
+      }, {
+        type: 'sequence', samples: turtle2.path, terminate: false
+      }], this.fakeClock, SimpleTapModel);
+
+      await executor();
+      const modelMatcher = await modelMatcherPromise;
+
+      assert.equal(await promiseStatus(modelMatcher.promise), PromiseStatuses.PROMISE_RESOLVED);
+
+      assert.deepEqual(await modelMatcher.promise, {matched: true, action: { type: 'optional-chain', item: 'a', allowNext: 'multitap'}});
+      assert.isTrue(source.touchpoints[0].path.isComplete);
+      assert.isFalse(source.touchpoints[1].path.isComplete);
+    });
+  });
+
+  describe("Multitap", function() {
+    it("reject: pre-existing path", async function() {
+      const turtle = new TouchpathTurtle({
+        targetX: 0,
+        targetY: 0,
+        t: 0,
+        item: 'a'
+      });
+      turtle.commitPending();
+
+      const {
+        source,
+        modelMatcherPromise,
+        executor
+      } = simulateComplexGestureSource([{type: 'sequence', samples: turtle.path, terminate: false}], this.fakeClock, MultitapModel);
+
+      await executor();
+      const modelMatcher = await modelMatcherPromise;
+
+      assert.equal(await promiseStatus(modelMatcher.promise), PromiseStatuses.PROMISE_RESOLVED);
+      assert.deepEqual(await modelMatcher.promise, {matched: false, action: { type: 'none', item: null }});
+      assert.isFalse(source.touchpoints[0].path.isComplete);
+    });
+
+    it("resolve: touch after 100ms, release after 300ms", async function() {
+      const turtle = new TouchpathTurtle({
+        targetX: 0,
+        targetY: 0,
+        t: 200,
+        item: 'a'
+      });
+      turtle.wait(200, 10);
+      turtle.commitPending();
+
+      const {
+        source,
+        modelMatcherPromise,
+        executor
+      } = simulateComplexGestureSource([
+        {
+          type: 'timer',
+          lastSample: {
+            targetX: 0,
+            targetY: 0,
+            t: 100,
+            item: 'a'
+          }
+        },
+        {
+          type: 'sequence', samples: turtle.path, terminate: true
+        }
+      ], this.fakeClock, MultitapModel);
+
+      await executor();
+      const modelMatcher = await modelMatcherPromise;
+
+      assert.equal(await promiseStatus(modelMatcher.promise), PromiseStatuses.PROMISE_RESOLVED);
+      assert.deepEqual(await modelMatcher.promise, {matched: true, action: { type: 'chain', item: 'a', next: 'multitap' }});
+      // touchpoints[0] - a pre-completed path.
+      assert.isTrue(source.touchpoints[1].path.isComplete);
+    });
+
+    it("reject: touch after 600ms (threshold = 500ms)", async function() {
+      const {
+        source,
+        modelMatcherPromise,
+        executor
+      } = simulateComplexGestureSource([
+        {
+          type: 'timer',
+          lastSample: {
+
+            targetX: 0,
+            targetY: 0,
+            t: 100,
+            item: 'a'
+          }
+        },
+        {
+          type: 'sequence', samples: [{
+            targetX: 0,
+            targetY: 0,
+            t: 700,
+            item: 'a'
+          }], terminate: false
+        }
+      ], this.fakeClock, MultitapModel);
+
+      await executor();
+      const modelMatcher = await modelMatcherPromise;
+
+      assert.equal(await promiseStatus(modelMatcher.promise), PromiseStatuses.PROMISE_RESOLVED);
+      assert.deepEqual(await modelMatcher.promise, {matched: false, action: { type: 'none', item: null }});
+      assert.isFalse(source.touchpoints[1].path.isComplete);
+    });
+
+    it("pending: touchstart within sustain timer, but no touchend", async function() {
+      const {
+        source,
+        modelMatcherPromise,
+        executor
+      } = simulateComplexGestureSource([
+        {
+          type: 'timer',
+          lastSample: {
+            targetX: 0,
+            targetY: 0,
+            t: 100,
+            item: 'a'
+          }
+        },
+        {
+          type: 'sequence', samples: [{
+            targetX: 0,
+            targetY: 0,
+            t: 200,
+            item: 'a'  // is 'failing' with the same item!?
+          }], terminate: false
+        }
+      ], this.fakeClock, MultitapModel);
+
+      await executor();
+      const modelMatcher = await modelMatcherPromise;
+
+      assert.equal(await promiseStatus(modelMatcher.promise), PromiseStatuses.PROMISE_PENDING);
+      assert.isFalse(source.touchpoints[1].path.isComplete);
+
+      // Yet to be determined:  if the touchpoint is held until after the sustain timer passes,
+      // should we reject the multitap?  A valid 'touchstart' will have occurred, but not the
+      // 'touchend'.
+    });
+
+    it("reject: different base item", async function() {
+      const {
+        source,
+        modelMatcherPromise,
+        executor
+      } = simulateComplexGestureSource([
+        {
+          type: 'timer',
+          lastSample: {
+            targetX: 0,
+            targetY: 0,
+            t: 100,
+            item: 'a'
+          }
+        },
+        {
+          type: 'sequence', samples: [{
+            targetX: 0,
+            targetY: 0,
+            t: 200,
+            item: 'b'  // is 'failing' with the same item!?
+          }], terminate: false
+        }
+      ], this.fakeClock, MultitapModel);
+
+      await executor();
+      const modelMatcher = await modelMatcherPromise;
+
+      assert.equal(await promiseStatus(modelMatcher.promise), PromiseStatuses.PROMISE_RESOLVED);
+      assert.deepEqual(await modelMatcher.promise, {matched: false, action: { type: 'none', item: null }});
+      assert.isFalse(source.touchpoints[1].path.isComplete);
+    });
+
+    it("resolve: second contact-point", async function() {
+      const turtle1 = new TouchpathTurtle({
+        targetX: 0,
+        targetY: 0,
+        t: 100,
+        item: 'a'
+      });
+
+      turtle1.wait(100, 5);
+      turtle1.commitPending();
+
+      const turtle2 = new TouchpathTurtle({
+        targetX: 50,
+        targetY: 0,
+        t: 200,
+        item: 'b'
+      });
+      turtle2.commitPending();
+
+      const {
+        source,
+        modelMatcherPromise,
+        executor
+      } = simulateComplexGestureSource([
+        {
+          type: 'timer',
+          lastSample: {
+            targetX: 0,
+            targetY: 0,
+            t: 0,
+            item: 'a'
+          }
+        }, {
+          type: 'sequence', samples: turtle1.path, terminate: false,
+        }, {
+          type: 'sequence', samples: turtle2.path, terminate: false
+        }
+      ], this.fakeClock, MultitapModel);
+
+      await executor();
+      const modelMatcher = await modelMatcherPromise;
+
+      assert.equal(await promiseStatus(modelMatcher.promise), PromiseStatuses.PROMISE_RESOLVED);
+
+      assert.deepEqual(await modelMatcher.promise, {matched: true, action: { type: 'chain', item: 'a', next: 'multitap'}});
+      assert.isTrue(source.touchpoints[1].path.isComplete);
+
+      // Design note:  as this one is _not_ complete, when gesture chaining tries to do a followup multitap match,
+      // it will fail.  Same mechanism as the "Pre-existing route" test.
+      assert.isFalse(source.touchpoints[2].path.isComplete);
+    });
+  });
+});

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/gestureMatcher.spec.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/gestureMatcher.spec.ts
@@ -2,8 +2,8 @@ import { assert } from 'chai'
 import sinon from 'sinon';
 
 import * as PromiseStatusModule from 'promise-status-async';
-const promiseStatus       = PromiseStatusModule.promiseStatus;
 const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
+import { assertingPromiseStatus as promiseStatus } from '../../../resources/assertingPromiseStatus.js';
 
 import { ComplexGestureSource, InputSample, SimpleGestureSource, gestures } from '@keymanapp/gesture-recognizer';
 

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedGestureSpecs.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedGestureSpecs.ts
@@ -1,0 +1,56 @@
+import { gestures } from '@keymanapp/gesture-recognizer';
+import * as specs from './isolatedPathSpecs.js';
+import specTypeDefs = gestures.specs;
+
+type GestureModel = specTypeDefs.GestureModel<string>;
+
+export const SimpleTapModel: GestureModel = {
+  id: 'simple-tap',
+  resolutionPriority: 0,
+  itemPriority: 0,
+  contacts: [
+    {
+      model: {
+        ...specs.SimpleTapModel,
+        itemPriority: 1
+      },
+      endOnResolve: true
+    }, {
+      model: specs.InstantResolutionModel
+    }
+  ],
+  resolutionAction: {
+    type: 'optional-chain',
+    allowNext: 'multitap'
+  }
+}
+
+export const MultitapModel: GestureModel = {
+  id: 'multitap',
+  resolutionPriority: 1,
+  itemPriority: 1,
+  contacts: [
+    {
+      model: {
+        ...specs.SimpleTapModel,
+        itemPriority: 1,
+        pathInheritance: 'reject',
+        allowsInitialState(incomingSample, comparisonSample, baseItem) {
+          return incomingSample.item == baseItem;
+        },
+      },
+      endOnResolve: true
+    }, {
+      model: specs.InstantResolutionModel
+    }
+  ],
+  sustainTimer: {
+    duration: 500,
+    expectedResult: false,
+    baseItem: 'base'
+  },
+  resolutionAction: {
+    type: 'chain',
+    next: 'multitap'
+  }
+}

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedGestureSpecs.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedGestureSpecs.ts
@@ -4,25 +4,36 @@ import specTypeDefs = gestures.specs;
 
 type GestureModel = specTypeDefs.GestureModel<string>;
 
-export const SimpleTapModel: GestureModel = {
-  id: 'simple-tap',
+export const LongpressModel: GestureModel = {
+  id: 'longpress',
   resolutionPriority: 0,
   itemPriority: 0,
   contacts: [
     {
       model: {
-        ...specs.SimpleTapModel,
-        pathInheritance: 'chop',
-        itemPriority: 1
+        ...specs.MainLongpressSourceModel,
+        itemPriority: 1,
+        pathInheritance: 'chop'
       },
-      endOnResolve: true
+      endOnResolve: false
     }, {
-      model: specs.InstantResolutionModel
+      model: specs.InstantRejectionModel
     }
   ],
   resolutionAction: {
-    type: 'optional-chain',
-    allowNext: 'multitap'
+    type: 'chain',
+    next: 'subkeyselect',
+    item: 'none'
+  },
+  rejectionActions: {
+    item: {
+      type: 'optional-chain',
+      allowNext: 'longpress'
+    },
+    path: {
+      type: 'optional-chain',
+      allowNext: 'longpress'
+    }
   }
 }
 
@@ -56,35 +67,24 @@ export const MultitapModel: GestureModel = {
   }
 }
 
-export const LongpressModel: GestureModel = {
-  id: 'longpress',
+export const SimpleTapModel: GestureModel = {
+  id: 'simple-tap',
   resolutionPriority: 0,
   itemPriority: 0,
   contacts: [
     {
       model: {
-        ...specs.MainLongpressSourceModel,
-        itemPriority: 1,
-        pathInheritance: 'chop'
+        ...specs.SimpleTapModel,
+        pathInheritance: 'chop',
+        itemPriority: 1
       },
-      endOnResolve: false
+      endOnResolve: true
     }, {
-      model: specs.InstantRejectionModel
+      model: specs.InstantResolutionModel
     }
   ],
   resolutionAction: {
-    type: 'chain',
-    next: 'subkeyselect',
-    item: 'none'
-  },
-  rejectionActions: {
-    item: {
-      type: 'optional-chain',
-      allowNext: 'longpress'
-    },
-    path: {
-      type: 'optional-chain',
-      allowNext: 'longpress'
-    }
+    type: 'optional-chain',
+    allowNext: 'multitap'
   }
 }

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedGestureSpecs.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedGestureSpecs.ts
@@ -88,3 +88,31 @@ export const SimpleTapModel: GestureModel = {
     allowNext: 'multitap'
   }
 }
+
+export const SubkeySelectModel: GestureModel = {
+  id: 'subkey-select',
+  resolutionPriority: 0,
+  itemPriority: 0,
+  contacts: [
+    {
+      model: {
+        ...specs.SubkeySelectModel,
+        pathInheritance: 'full',
+        itemPriority: 1
+      },
+      endOnResolve: true,
+      endOnReject: true
+    }, {
+      // A second touch while selecting a subkey will trigger instant cancellation
+      // of subkey mode.  (With this setting in place, anyway.)
+      //
+      // Might not be ideal for actual production... but it does have benefits for
+      // unit testing the gesture-matching engine.
+      model: specs.InstantRejectionModel
+    }
+  ],
+  resolutionAction: {
+    type: 'complete',
+    item: 'current'
+  }
+}

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedGestureSpecs.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedGestureSpecs.ts
@@ -12,6 +12,7 @@ export const SimpleTapModel: GestureModel = {
     {
       model: {
         ...specs.SimpleTapModel,
+        pathInheritance: 'chop',
         itemPriority: 1
       },
       endOnResolve: true
@@ -52,5 +53,38 @@ export const MultitapModel: GestureModel = {
   resolutionAction: {
     type: 'chain',
     next: 'multitap'
+  }
+}
+
+export const LongpressModel: GestureModel = {
+  id: 'longpress',
+  resolutionPriority: 0,
+  itemPriority: 0,
+  contacts: [
+    {
+      model: {
+        ...specs.MainLongpressSourceModel,
+        itemPriority: 1,
+        pathInheritance: 'chop'
+      },
+      endOnResolve: false
+    }, {
+      model: specs.InstantRejectionModel
+    }
+  ],
+  resolutionAction: {
+    type: 'chain',
+    next: 'subkeyselect',
+    item: 'none'
+  },
+  rejectionActions: {
+    item: {
+      type: 'optional-chain',
+      allowNext: 'longpress'
+    },
+    path: {
+      type: 'optional-chain',
+      allowNext: 'longpress'
+    }
   }
 }

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedPathSpecs.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedPathSpecs.ts
@@ -1,7 +1,7 @@
 import { gestures } from '@keymanapp/gesture-recognizer';
-import specs = gestures.specs;
+import specTypeDefs = gestures.specs;
 
-type ContactModel = specs.ContactModel<string>;
+type ContactModel = specTypeDefs.ContactModel<string>;
 
 export const InstantRejectionModel: ContactModel = {
   itemPriority: 0,

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedPathSpecs.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedPathSpecs.ts
@@ -19,6 +19,7 @@ export const InstantResolutionModel: ContactModel = {
   }
 }
 
+export const LongpressDistanceThreshold = 10;
 export const MainLongpressSourceModel: ContactModel = {
   itemChangeAction: 'reject',
   itemPriority: 0,
@@ -30,7 +31,7 @@ export const MainLongpressSourceModel: ContactModel = {
   pathModel: {
     evaluate: (path) => {
       const stats = path.stats;
-      if(stats.rawDistance > 10) {
+      if(stats.rawDistance > LongpressDistanceThreshold) {
         return 'reject';
       }
 
@@ -41,6 +42,7 @@ export const MainLongpressSourceModel: ContactModel = {
   }
 };
 
+export const LongpressFlickDistanceThreshold = 6;
 export const MainLongpressSourceModelWithShortcut: ContactModel = {
   ...MainLongpressSourceModel,
   pathModel: {
@@ -48,7 +50,7 @@ export const MainLongpressSourceModelWithShortcut: ContactModel = {
       const stats = path.stats;
 
       // Adds up-flick support!
-      if(stats.rawDistance > 5 && stats.cardinalDirection == 'n') {
+      if(stats.rawDistance > LongpressFlickDistanceThreshold && stats.cardinalDirection == 'n') {
         return 'resolve';
       }
 

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedPathSpecs.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedPathSpecs.ts
@@ -94,3 +94,15 @@ export const SimpleTapModel: ContactModel = {
     }
   }
 }
+
+export const SubkeySelectModel: ContactModel = {
+  itemPriority: 0,
+  pathResolutionAction: 'resolve',
+  pathModel: {
+    evaluate: (path) => {
+      if(path.isComplete && !path.wasCancelled) {
+        return 'resolve';
+      }
+    }
+  }
+}

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/pathMatcher.spec.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/pathMatcher.spec.ts
@@ -2,8 +2,8 @@ import { assert } from 'chai'
 import sinon from 'sinon';
 
 import * as PromiseStatusModule from 'promise-status-async';
-const promiseStatus       = PromiseStatusModule.promiseStatus;
 const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
+import { assertingPromiseStatus as promiseStatus } from '../../../resources/assertingPromiseStatus.js';
 
 import { InputSample, SimpleGestureSource, gestures } from '@keymanapp/gesture-recognizer';
 import { timedPromise } from '@keymanapp/web-utils';

--- a/common/web/gesture-recognizer/src/test/resources/assertingPromiseStatus.ts
+++ b/common/web/gesture-recognizer/src/test/resources/assertingPromiseStatus.ts
@@ -1,0 +1,19 @@
+import * as PromiseStatusModule from 'promise-status-async';
+
+/**
+ * A custom variant of the promise-status function; this one asserts that rejections should
+ * be reported as test errors.  If a rejection occurs, it will ensure that it is reported
+ * on the main thread / error output.
+ * @param promise
+ * @returns
+ */
+export async function assertingPromiseStatus(promise: Promise<any>) {
+  const status = await PromiseStatusModule.promiseStatus(promise);
+  if(status == PromiseStatusModule.PROMISE_REJECTED) {
+    // Synchronize on the spot - this will cause the calling test to throw and report
+    // the reported rejection cause / error.  This is far more informative in error logs
+    // than "oh, the promise was rejected" - with no indication as to _why_.
+    await promise;
+  }
+  return status;
+}


### PR DESCRIPTION
This PR seeks to allow definition of different types of gestures via a relatively simple specification pattern.  This pattern, in turn, is interpreted by an algorithm capable of matching any legal configuration of the spec.  This yields a generalized gesture matcher.

This PR's features incorporate many aspects of the prospective design seen in #9252.  Some changes occurred as I started actually implementing related logic.

Assumptions:
- A separate layer will handle detection of when a new contact point belongs to the gesture being matched vs when it should remain separate.
- A separate layer (likely the same as the prior point) will manage multiple instances of this class - one per possible gesture - to facilitate gesture _selection_.
    - General idea:  first one to be 'resolved' wins; any 'rejected' ones are simply eliminated from consideration.
    - Once one is 'resolved', the others are cancelled - and then a new round begins.
    - If all are rejected... well, none of them matched.  Purge tracked data and prepare for another round of inputs.

Note that this relies on the path-match snapshot component added in #9339.  (I did some rebasing to clean up the timeline and changesets leading up to this point, and it was far simpler to isolate that component for review by placing it earlier in the commit history.)  In particular, multitaps need to know about the previous gesture-match snapshot leading up to the current match attempt - that snapshot provides the source of truth regarding the expected base key.

@keymanapp-test-bot skip