### PR TITLE
refactor(developer): move keyman-targets.ts to common/web/types 🗜

### DIFF
--- a/common/web/types/src/kmx/keyman-targets.ts
+++ b/common/web/types/src/kmx/keyman-targets.ts
@@ -51,3 +51,12 @@ export const
     [KeymanTarget.mobile]: 'Mobile devices', [KeymanTarget.desktop]: 'Desktop devices',
       [KeymanTarget.tablet]: 'Tablet devices'
   };
+
+
+  export function keymanTargetsFromString(targets: string, options?: {expandAny?: boolean}): KeymanTarget[] {
+    let result = <KeymanTarget[]>targets.split(/ +/);
+    if(options?.expandAny && result.includes(KeymanTarget.any)) {
+      result = AllKeymanTargets;
+    }
+    return result;
+  }

--- a/common/web/types/src/kmx/keyman-targets.ts
+++ b/common/web/types/src/kmx/keyman-targets.ts
@@ -53,10 +53,28 @@ export const
   };
 
 
-  export function keymanTargetsFromString(targets: string, options?: {expandAny?: boolean}): KeymanTarget[] {
-    let result = <KeymanTarget[]>targets.split(/ +/);
-    if(options?.expandAny && result.includes(KeymanTarget.any)) {
-      result = AllKeymanTargets;
+  export function keymanTargetsFromString(targets: string, options?: {expandTargets?: boolean}): KeymanTarget[] {
+    let result = new Set<KeymanTarget>(<KeymanTarget[]>targets.split(/ +/));
+    if(options?.expandTargets) {
+      if(result.has(KeymanTarget.any)) {
+        return AllKeymanTargets;
+      }
+      if(result.has(KeymanTarget.mobile)) {
+        result.delete(KeymanTarget.mobile);
+        result.add(KeymanTarget.androidphone);
+        result.add(KeymanTarget.iphone);
+      }
+      if(result.has(KeymanTarget.tablet)) {
+        result.delete(KeymanTarget.tablet);
+        result.add(KeymanTarget.androidtablet);
+        result.add(KeymanTarget.ipad);
+      }
+      if(result.has(KeymanTarget.desktop)) {
+        result.delete(KeymanTarget.desktop);
+        result.add(KeymanTarget.linux);
+        result.add(KeymanTarget.macosx);
+        result.add(KeymanTarget.windows);
+      }
     }
-    return result;
+    return [...result];
   }

--- a/common/web/types/src/kmx/kmx-file-reader.ts
+++ b/common/web/types/src/kmx/kmx-file-reader.ts
@@ -41,6 +41,9 @@ export class KmxFileReader {
       case KMXFile.TSS_KEYBOARDVERSION:
         result.keyboardVersion = store.dpString;
         break;
+      case KMXFile.TSS_TARGETS:
+        result.targets = store.dpString;
+        break;
       case KMXFile.TSS_BEGIN_NEWCONTEXT:
         if(!this.isValidCodeUse(store.dpString, result)) {
           throw new KmxFileReaderError(`Invalid TSS_BEGIN_NEWCONTEXT system store`);

--- a/common/web/types/src/kmx/kmx.ts
+++ b/common/web/types/src/kmx/kmx.ts
@@ -27,9 +27,9 @@ export class KEYBOARD {
   // Following values are extracted from stores[] but are
   // informative only
 
-  keyboardVersion?: string;  // version (TSS_KEYBOARDVERSION)
+  keyboardVersion?: string;   // version (TSS_KEYBOARDVERSION)
   isMnemonic: boolean;        // TSS_MNEMONICLAYOUT store
-
+  targets: string;            // TSS_TARGETS store ('desktop' if missing)
 };
 
 export class STORE {

--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -2,6 +2,7 @@ export * as KMX from './kmx/kmx.js';
 export * as KMXPlus from './kmx/kmx-plus.js';
 export { default as KMXBuilder } from './kmx/kmx-builder.js';
 export { KmxFileReader, KmxFileReaderError } from './kmx/kmx-file-reader.js';
+export * as KeymanTargets from './kmx/keyman-targets.js';
 
 export * as VisualKeyboard from './kvk/visual-keyboard.js';
 export { default as KMXPlusBuilder}  from './kmx/kmx-plus-builder/kmx-plus-builder.js';

--- a/common/web/types/test/kmx/test-keyman-targets.ts
+++ b/common/web/types/test/kmx/test-keyman-targets.ts
@@ -1,0 +1,13 @@
+import 'mocha';
+import { assert } from 'chai';
+import { AllKeymanTargets, KeymanTarget, keymanTargetsFromString } from "../../src/kmx/keyman-targets.js";
+
+describe('keyman-targets', function () {
+  it('should parse a string of targets', function() {
+    assert.deepEqual(keymanTargetsFromString('any', {expandAny: false}), [KeymanTarget.any]);
+    assert.deepEqual(keymanTargetsFromString('any', {expandAny: true}), AllKeymanTargets);
+    assert.deepEqual(keymanTargetsFromString('windows linux'), [KeymanTarget.windows, KeymanTarget.linux]);
+    assert.deepEqual(keymanTargetsFromString('windows    macosx'), [KeymanTarget.windows, KeymanTarget.macosx]);
+    assert.deepEqual(keymanTargetsFromString('windows macosx any', {expandAny: true}), AllKeymanTargets);
+  });
+});

--- a/common/web/types/test/kmx/test-keyman-targets.ts
+++ b/common/web/types/test/kmx/test-keyman-targets.ts
@@ -4,10 +4,14 @@ import { AllKeymanTargets, KeymanTarget, keymanTargetsFromString } from "../../s
 
 describe('keyman-targets', function () {
   it('should parse a string of targets', function() {
-    assert.deepEqual(keymanTargetsFromString('any', {expandAny: false}), [KeymanTarget.any]);
-    assert.deepEqual(keymanTargetsFromString('any', {expandAny: true}), AllKeymanTargets);
+    assert.deepEqual(keymanTargetsFromString('any', {expandTargets: false}), [KeymanTarget.any]);
+    assert.deepEqual(keymanTargetsFromString('any', {expandTargets: true}), AllKeymanTargets);
     assert.deepEqual(keymanTargetsFromString('windows linux'), [KeymanTarget.windows, KeymanTarget.linux]);
     assert.deepEqual(keymanTargetsFromString('windows    macosx'), [KeymanTarget.windows, KeymanTarget.macosx]);
-    assert.deepEqual(keymanTargetsFromString('windows macosx any', {expandAny: true}), AllKeymanTargets);
+    assert.deepEqual(keymanTargetsFromString('windows macosx any', {expandTargets: true}), AllKeymanTargets);
+    assert.deepEqual(keymanTargetsFromString('desktop mobile', {expandTargets: true}),
+      [KeymanTarget.androidphone, KeymanTarget.iphone, KeymanTarget.linux, KeymanTarget.macosx, KeymanTarget.windows]);
+    assert.deepEqual(keymanTargetsFromString('tablet windows', {expandTargets: true}),
+      [KeymanTarget.windows, KeymanTarget.androidtablet, KeymanTarget.ipad]);
   });
 });

--- a/developer/src/kmc-package/src/compiler/package-keyboard-target-validator.ts
+++ b/developer/src/kmc-package/src/compiler/package-keyboard-target-validator.ts
@@ -29,7 +29,7 @@ export class PackageKeyboardTargetValidator {
 
     // If at least one target is a touch target, we need to check that the
     // package also includes the .js
-    const targets = KeymanTargets.keymanTargetsFromString(targetsText, {expandAny: true});
+    const targets = KeymanTargets.keymanTargetsFromString(targetsText, {expandTargets: true});
     if(targets.some(target => KeymanTargets.TouchKeymanTargets.includes(target))) {
       if(!kmp.files.find(file => this.callbacks.path.basename(file.name, '.js') == keyboard.id)) {
         // .js version of the keyboard is not found, warn

--- a/developer/src/kmc-package/src/compiler/package-keyboard-target-validator.ts
+++ b/developer/src/kmc-package/src/compiler/package-keyboard-target-validator.ts
@@ -29,8 +29,8 @@ export class PackageKeyboardTargetValidator {
 
     // If at least one target is a touch target, we need to check that the
     // package also includes the .js
-    const targets = <KeymanTargets.KeymanTarget[]>targetsText.split(' ');
-    if(targets.some(target => ['any', ...KeymanTargets.TouchKeymanTargets].includes(target))) {
+    const targets = KeymanTargets.keymanTargetsFromString(targetsText, {expandAny: true});
+    if(targets.some(target => KeymanTargets.TouchKeymanTargets.includes(target))) {
       if(!kmp.files.find(file => this.callbacks.path.basename(file.name, '.js') == keyboard.id)) {
         // .js version of the keyboard is not found, warn
         this.callbacks.reportMessage(CompilerMessages.Warn_JsKeyboardFileIsMissing({id: keyboard.id}));

--- a/developer/src/kmc-package/src/compiler/package-keyboard-target-validator.ts
+++ b/developer/src/kmc-package/src/compiler/package-keyboard-target-validator.ts
@@ -1,5 +1,4 @@
-import { CompilerCallbacks, KmpJsonFile } from "@keymanapp/common-types";
-import { KeymanTarget, TouchKeymanTargets } from "./keyman-targets.js";
+import { KeymanTargets, CompilerCallbacks, KmpJsonFile } from "@keymanapp/common-types";
 import { CompilerMessages } from "./messages.js";
 import { KeyboardMetadataCollection } from "./package-metadata-collector.js";
 
@@ -30,8 +29,8 @@ export class PackageKeyboardTargetValidator {
 
     // If at least one target is a touch target, we need to check that the
     // package also includes the .js
-    const targets = <KeymanTarget[]>targetsText.split(' ');
-    if(targets.some(target => ['any', ...TouchKeymanTargets].includes(target))) {
+    const targets = <KeymanTargets.KeymanTarget[]>targetsText.split(' ');
+    if(targets.some(target => ['any', ...KeymanTargets.TouchKeymanTargets].includes(target))) {
       if(!kmp.files.find(file => this.callbacks.path.basename(file.name, '.js') == keyboard.id)) {
         // .js version of the keyboard is not found, warn
         this.callbacks.reportMessage(CompilerMessages.Warn_JsKeyboardFileIsMissing({id: keyboard.id}));


### PR DESCRIPTION
Also adds unit test. Prep for use in kmc-keyboard-info.

@keymanapp-test-bot skip