### PR TITLE
chore(web): test/test-resource cleanup & generic typing on stats object 🐵

### DIFF
--- a/common/web/gesture-recognizer/package.json
+++ b/common/web/gesture-recognizer/package.json
@@ -26,6 +26,9 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
   },
+  "imports": {
+    "#tools": "./build/tools/obj/index.js"
+  },
   "scripts": {
     "build": "gosh ./build.sh",
     "test": "gosh ./test.sh"

--- a/common/web/gesture-recognizer/src/engine/headless/cumulativePathStats.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/cumulativePathStats.ts
@@ -45,7 +45,7 @@ export function sigMinus(operand1: number, operand2: number) {
  *
  * Instances of this class are immutable.
  */
-export class CumulativePathStats {
+export class CumulativePathStats<Type = any> {
   /**
    * Provides linear-regression statistics & fitting values based on the underlying `CumulativePathStats`
    * object used to generate it.  All operations are O(1).
@@ -204,8 +204,8 @@ export class CumulativePathStats {
 
   constructor();
   constructor(sample: InputSample<any>);
-  constructor(instance: CumulativePathStats);
-  constructor(obj?: InputSample<any> | CumulativePathStats) {
+  constructor(instance: CumulativePathStats<Type>);
+  constructor(obj?: InputSample<any> | CumulativePathStats<Type>) {
     if(!obj) {
       return;
     }
@@ -232,7 +232,7 @@ export class CumulativePathStats {
    * @returns A new, separate instance for the cumulative properties up to the
    *          newly-sampled point.
    */
-  public extend(sample: InputSample<any>): CumulativePathStats {
+  public extend(sample: InputSample<any>): CumulativePathStats<Type> {
     if(!this._initialSample) {
       this._initialSample = sample;
       this.baseSample = sample;
@@ -301,7 +301,7 @@ export class CumulativePathStats {
    *                    from this instance's current accumulation.
    * @returns
    */
-  public deaccumulate(subsetStats?: CumulativePathStats): CumulativePathStats {
+  public deaccumulate(subsetStats?: CumulativePathStats<Type>): CumulativePathStats<Type> {
     // Possible addition:  use `this.buildRenormalized` on the returned version
     // if catastrophic cancellation effects (random, small floating point errors)
     // are not sufficiently mitigated & handled by the measures currently in place.
@@ -509,7 +509,7 @@ export class CumulativePathStats {
    * errors than the old instance whenever they do occur.
    * @returns
    */
-  public buildRenormalized(): CumulativePathStats {
+  public buildRenormalized(): CumulativePathStats<Type> {
     // Other (internal) notes:  the internal mapping of the new instance will not
     // match that of the old instance.  This should not affect the practical
     // results of any mapping to and from the external coordinate space, however.

--- a/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
@@ -48,7 +48,7 @@ export class GesturePath<Type> extends EventEmitter<EventMap<Type>> {
   private _isComplete: boolean = false;
   private _wasCancelled?: boolean;
 
-  private _stats: CumulativePathStats;
+  private _stats: CumulativePathStats<Type>;
 
   public get stats() {
     // Is (practically) immutable, so it's safe to expose the instance directly.
@@ -75,7 +75,7 @@ export class GesturePath<Type> extends EventEmitter<EventMap<Type>> {
     instance._isComplete = true;
     instance._wasCancelled = jsonObj.wasCancelled;
 
-    let stats = instance.samples.reduce((stats: CumulativePathStats, sample) => stats.extend(sample), new CumulativePathStats());
+    let stats = instance.samples.reduce((stats: CumulativePathStats<Type>, sample) => stats.extend(sample), new CumulativePathStats<Type>());
     instance._stats = stats;
 
     return instance;

--- a/common/web/gesture-recognizer/src/test/auto/headless/gesturePath.js
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gesturePath.js
@@ -6,7 +6,7 @@ import fs from 'fs';
 
 import { GesturePath } from '@keymanapp/gesture-recognizer';
 import { timedPromise } from '@keymanapp/web-utils';
-import { TouchpathTurtle } from '../../../../build/tools/obj/index.js';
+import { TouchpathTurtle } from '#tools';
 
 // Ensures that the resources are resolved relative to this script, not to the cwd when the test
 // runner was launched.

--- a/common/web/gesture-recognizer/src/test/auto/headless/pathStats.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/pathStats.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import { CumulativePathStats, InputSample } from '@keymanapp/gesture-recognizer';
 
-import { TouchpathTurtle } from '../../../../build/tools/obj/index.js';
+import { TouchpathTurtle } from '#tools';
 
 describe("CumulativePathStats", function() {
   it("Sample count = 0", function() {

--- a/common/web/gesture-recognizer/src/test/auto/headless/recordedSegmentations.js
+++ b/common/web/gesture-recognizer/src/test/auto/headless/recordedSegmentations.js
@@ -10,7 +10,7 @@ const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
 
 import { PathSegmenter } from '@keymanapp/gesture-recognizer';
 
-import { HeadlessInputEngine } from '../../../../build/tools/obj/index.js';
+import { HeadlessInputEngine } from '#tools';
 
 // Ensures that the resources are resolved relative to this script, not to the cwd when the test
 // runner was launched.

--- a/common/web/gesture-recognizer/src/test/auto/tsconfig.json
+++ b/common/web/gesture-recognizer/src/test/auto/tsconfig.json
@@ -4,7 +4,6 @@
  * editing - even if the tests themselves actually work.
  */
 {
-  // Enabling the following line re-breaks it for some reason?
   "extends": "../../../../tsconfig.kmw-main-base.json",
   "compilerOptions": {
     "moduleResolution": "Node16",

--- a/common/web/gesture-recognizer/src/test/auto/tsconfig.json
+++ b/common/web/gesture-recognizer/src/test/auto/tsconfig.json
@@ -1,0 +1,12 @@
+/*
+ * VS Code Intellisense needs this helper in order to properly use subpath imports in the
+ * test specs found under the `headless` subfolder.  Otherwise, it'll report errors while
+ * editing - even if the tests themselves actually work.
+ */
+{
+  // Enabling the following line re-breaks it for some reason?
+  // "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "Node16",
+  }
+}

--- a/common/web/gesture-recognizer/src/test/auto/tsconfig.json
+++ b/common/web/gesture-recognizer/src/test/auto/tsconfig.json
@@ -5,7 +5,7 @@
  */
 {
   // Enabling the following line re-breaks it for some reason?
-  // "extends": "../../../tsconfig.json",
+  "extends": "../../../../tsconfig.kmw-main-base.json",
   "compilerOptions": {
     "moduleResolution": "Node16",
   }

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/touchpathTurtle.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/touchpathTurtle.ts
@@ -76,6 +76,7 @@ export class TouchpathTurtle<HoveredItemType> extends EventEmitter<EventMap<Hove
       this.emit('sample', pending);
     }
     this.pendingSample = null;
+    return pending;
   }
 
   protected trackSample(sample: InputSample<HoveredItemType>) {
@@ -102,23 +103,20 @@ export class TouchpathTurtle<HoveredItemType> extends EventEmitter<EventMap<Hove
      */
   }
 
-  wait(totalTime: number, repeatInterval: number) {
-    if(repeatInterval < 0 || totalTime < 0) {
+  wait(totalTime: number, sampleCount: number) {
+    if(sampleCount <= 0 || totalTime < 0) {
       throw new Error("Invalid parameter value:  may not be negative!");
     }
 
     const startSample = this.location;
+    const timeDelta = totalTime / sampleCount;
 
     // Base sample always exists in advance.
-    for(let timeDelta = 0; timeDelta < totalTime; timeDelta += repeatInterval) {
+    for(let i = 1; i <= sampleCount; i++) {
       let sample = {...startSample};
-      sample.t += timeDelta;
+      sample.t += timeDelta * i;
       this.trackSample(sample);
     }
-
-    let currentSample = {...startSample};
-    currentSample.t += totalTime;
-    this.trackSample(currentSample);
   }
 
   move(angleInDegrees: number, distance: number, time: number, sampleCount: number) {

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/touchpathTurtle.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/touchpathTurtle.ts
@@ -105,7 +105,7 @@ export class TouchpathTurtle<HoveredItemType> extends EventEmitter<EventMap<Hove
 
   wait(totalTime: number, sampleCount: number) {
     if(sampleCount <= 0 || totalTime < 0) {
-      throw new Error("Invalid parameter value:  may not be negative!");
+      throw new Error("Invalid parameter value: totalTime may not be negative and sampleCount must be > 0!");
     }
 
     const startSample = this.location;


### PR DESCRIPTION
This PR largely serves to present a few significant changes first made in #9320 in isolation.  This grouping has a remarkably small line-change count, but there are enough altered details here as it is.

1. The "unit test resources" subproject was being included in headless tests via a nasty, long import path with lots of `../` entries.  I remembered the whole "subpath imports" thing I discovered during ES module (🧩) work and decided to re-use that here.

    Turns out to be a bit trickier when developing TS-based unit tests in VS code - it wanted to ignore the import paths for some reason, but only when editing in the IDE.  It's not optimal, but I did find a sufficient workaround, so... yeah.  It's enough to proceed.  

    (That random, ultra-light src/test/auto/tsconfig.json is the workaround.) 

2. I altered the TouchpathTurtle's `move` method a few PRs ago, but failed to update the `wait` function to use similar sampling semantics.  I've corrected that now; the number of samples to make is specified, rather than the time interval between samples.  (Helps prevent an occasional duplicate final-sample problem.)

3.  I'd avoided putting a generic type on `CumulativePathStats` a while back since the item typing doesn't really matter for any of the stats it tracks.  Well... it looks like the item aspect may still be useful to retrieve from it for consumers outside the class, so I added light typing for it... but only to the parts that matter.  

    It's allowed to default to `any`, minimizing impact for uses that still don't care about the hovered-item entries associated with gesture processing.

@keymanapp-test-bot skip