### PR TITLE
feat(web): gesture path snapshots 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/complexGestureSource.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/complexGestureSource.ts
@@ -53,13 +53,13 @@ export class ComplexGestureSource<HoveredItemType> extends EventEmitter<EventMap
   }
 
   private _attachPointHooks(touchpoint: SimpleGestureSource<HoveredItemType>) {
-    touchpoint.fullPath.on('complete', () => {
+    touchpoint.path.on('complete', () => {
       this.isActive = false;
       this.emit('end');
       this.removeAllListeners();
     });
 
-    touchpoint.fullPath.on('invalidated', () => {
+    touchpoint.path.on('invalidated', () => {
       this.isActive = false;
       this.emit('cancel');
       this.removeAllListeners();

--- a/common/web/gesture-recognizer/src/engine/headless/complexGestureSource.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/complexGestureSource.ts
@@ -53,13 +53,13 @@ export class ComplexGestureSource<HoveredItemType> extends EventEmitter<EventMap
   }
 
   private _attachPointHooks(touchpoint: SimpleGestureSource<HoveredItemType>) {
-    touchpoint.path.on('complete', () => {
+    touchpoint.fullPath.on('complete', () => {
       this.isActive = false;
       this.emit('end');
       this.removeAllListeners();
     });
 
-    touchpoint.path.on('invalidated', () => {
+    touchpoint.fullPath.on('invalidated', () => {
       this.isActive = false;
       this.emit('cancel');
       this.removeAllListeners();
@@ -74,7 +74,7 @@ export class ComplexGestureSource<HoveredItemType> extends EventEmitter<EventMap
   cancel() {
     if(this.isActive) {
       for(let point of this.touchpoints) {
-        point.path.terminate(true);
+        point.terminate(true);
       }
     }
   }
@@ -82,7 +82,7 @@ export class ComplexGestureSource<HoveredItemType> extends EventEmitter<EventMap
   end() {
     if(this.isActive) {
       for(let point of this.touchpoints) {
-        point.path.terminate(false);
+        point.terminate(false);
       }
     }
   }

--- a/common/web/gesture-recognizer/src/engine/headless/cumulativePathStats.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/cumulativePathStats.ts
@@ -45,7 +45,7 @@ export function sigMinus(operand1: number, operand2: number) {
  *
  * Instances of this class are immutable.
  */
-export class CumulativePathStats {
+export class CumulativePathStats<Type = any> {
   /**
    * Provides linear-regression statistics & fitting values based on the underlying `CumulativePathStats`
    * object used to generate it.  All operations are O(1).
@@ -204,8 +204,8 @@ export class CumulativePathStats {
 
   constructor();
   constructor(sample: InputSample<any>);
-  constructor(instance: CumulativePathStats);
-  constructor(obj?: InputSample<any> | CumulativePathStats) {
+  constructor(instance: CumulativePathStats<Type>);
+  constructor(obj?: InputSample<any> | CumulativePathStats<Type>) {
     if(!obj) {
       return;
     }
@@ -232,7 +232,7 @@ export class CumulativePathStats {
    * @returns A new, separate instance for the cumulative properties up to the
    *          newly-sampled point.
    */
-  public extend(sample: InputSample<any>): CumulativePathStats {
+  public extend(sample: InputSample<any>): CumulativePathStats<Type> {
     if(!this._initialSample) {
       this._initialSample = sample;
       this.baseSample = sample;
@@ -301,7 +301,7 @@ export class CumulativePathStats {
    *                    from this instance's current accumulation.
    * @returns
    */
-  public deaccumulate(subsetStats?: CumulativePathStats): CumulativePathStats {
+  public deaccumulate(subsetStats?: CumulativePathStats<Type>): CumulativePathStats<Type> {
     // Possible addition:  use `this.buildRenormalized` on the returned version
     // if catastrophic cancellation effects (random, small floating point errors)
     // are not sufficiently mitigated & handled by the measures currently in place.
@@ -509,7 +509,7 @@ export class CumulativePathStats {
    * errors than the old instance whenever they do occur.
    * @returns
    */
-  public buildRenormalized(): CumulativePathStats {
+  public buildRenormalized(): CumulativePathStats<Type> {
     // Other (internal) notes:  the internal mapping of the new instance will not
     // match that of the old instance.  This should not affect the practical
     // results of any mapping to and from the external coordinate space, however.

--- a/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
@@ -64,6 +64,16 @@ export class GesturePath<Type> extends EventEmitter<EventMap<Type>> {
     this._stats = new CumulativePathStats();
   }
 
+  public clone(): GesturePath<Type> {
+    const instance = new GesturePath<Type>();
+    instance.samples = [].concat(this.samples);
+    instance._isComplete = this._isComplete;
+    instance._wasCancelled = this._wasCancelled;
+    instance._stats = new CumulativePathStats<Type>(this._stats);
+
+    return instance;
+  }
+
   /**
    * Deserializes a GesturePath instance from its corresponding JSON.parse() object.
    * @param jsonObj

--- a/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
@@ -48,7 +48,7 @@ export class GesturePath<Type> extends EventEmitter<EventMap<Type>> {
   private _isComplete: boolean = false;
   private _wasCancelled?: boolean;
 
-  private _stats: CumulativePathStats;
+  private _stats: CumulativePathStats<Type>;
 
   public get stats() {
     // Is (practically) immutable, so it's safe to expose the instance directly.
@@ -75,7 +75,7 @@ export class GesturePath<Type> extends EventEmitter<EventMap<Type>> {
     instance._isComplete = true;
     instance._wasCancelled = jsonObj.wasCancelled;
 
-    let stats = instance.samples.reduce((stats: CumulativePathStats, sample) => stats.extend(sample), new CumulativePathStats());
+    let stats = instance.samples.reduce((stats: CumulativePathStats<Type>, sample) => stats.extend(sample), new CumulativePathStats<Type>());
     instance._stats = stats;
 
     return instance;

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
@@ -1,8 +1,9 @@
+import { CumulativePathStats } from "../../cumulativePathStats.js";
 import { SimpleGestureSource } from "../../simpleGestureSource.js";
-import { ContactModel, PointModelResolution } from "../specs/contactModel.js";
+import { ContactModel } from "../specs/contactModel.js";
 import { ManagedPromise, TimeoutPromise } from "@keymanapp/web-utils";
 
-type FulfillmentCause = 'path' | 'timer' | 'item';
+export type FulfillmentCause = 'path' | 'timer' | 'item';
 
 export interface PathMatchResolution {
   type: 'resolve',
@@ -23,10 +24,18 @@ type PathUpdateResult = PathMatchResult | PathNotFulfilled;
 
 export class PathMatcher<Type> {
   private timerPromise?: TimeoutPromise;
-  private model: ContactModel<Type>;
-  private source: SimpleGestureSource<Type>;
+  public readonly model: ContactModel<Type>;
+
+  // During execution, source.path is fine... but once this matcher's role is done,
+  // `source` will continue to receive edits and may even change the instance
+  // underlying the `path` field.
+  public readonly source: SimpleGestureSource<Type>;
+
+  private _finalStats: CumulativePathStats<Type>;
+  private _baseItem: Type;
 
   private readonly publishedPromise: ManagedPromise<PathMatchResult>
+  private _result: PathMatchResult;
 
   public get promise() {
     return this.publishedPromise.corePromise;
@@ -56,9 +65,9 @@ export class PathMatcher<Type> {
     }
   }
 
-  private finalize(result: boolean, cause: FulfillmentCause) {
+  private finalize(result: boolean, cause: FulfillmentCause): PathMatchResult {
     if(this.publishedPromise.isFulfilled) {
-      return;
+      return this._result;
     }
 
     const model = this.model;
@@ -74,8 +83,46 @@ export class PathMatcher<Type> {
         cause: cause
       };
     }
-    this.publishedPromise.resolve(retVal);
+    this.publishedPromise.resolve(retVal)
+    this._result = retVal;
+
+    /*
+     * Lock in the current instance of path, before further processing on the SimpleGestureSource
+     * performs any 'chop'-style operations.
+     *
+     * No need to deep copy; the only mutable part is the "followingSample" field, which relates to
+     * any path continuation by later stages of the ongoing gesture path.  That's fine, as it's
+     * not the part we actually need to preserve in a fixed state.
+     *
+     * While we _could_, in theory, preserve the overall path... we don't need the samples -
+     * just the stats will do.
+     */
+    this._finalStats = this.source.path.stats;
+    this._baseItem = this.source.baseItem;
+
     return retVal;
+  }
+
+  get finalStats() {
+    // Note:  contains `initialSample` and `lastSample`, the endpoints of the path segment that was matched.
+    // The latter can be used to find the matcher's final `currentItem` value if/as desired.
+    return this._finalStats;
+  }
+
+  get baseItem() {
+    if(this.publishedPromise.isFulfilled) {
+      return this._baseItem;
+    } else {
+      return this.source.baseItem;
+    }
+  }
+
+  get lastItem() {
+    if(this.publishedPromise.isFulfilled) {
+      return this.finalStats.lastSample.item;
+    } else {
+      return this.source.currentSample.item;
+    }
   }
 
   update(): PathUpdateResult {
@@ -86,7 +133,7 @@ export class PathMatcher<Type> {
       return this.finalize(false, 'path');
     }
 
-    if(model.itemChangeAction && source.currentSample.item != source.initialSample.item) {
+    if(model.itemChangeAction && source.currentSample.item != source.baseItem) {
       const result = model.itemChangeAction == 'resolve';
 
       return this.finalize(result, 'item');
@@ -99,10 +146,7 @@ export class PathMatcher<Type> {
       } else if(source.path.isComplete) {
         // If the PathModel said to 'continue' but the path is done, we default
         // to rejecting the model; there will be no more changes, after all.
-        return {
-          type: 'reject',
-          cause: 'path'
-        };
+        return this.finalize(false, 'path');
       }
 
       return {

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
@@ -31,9 +31,6 @@ export class PathMatcher<Type> {
   // underlying the `path` field.
   public readonly source: SimpleGestureSource<Type>;
 
-  private _finalStats: CumulativePathStats<Type>;
-  private _baseItem: Type;
-
   private readonly publishedPromise: ManagedPromise<PathMatchResult>
   private _result: PathMatchResult;
 
@@ -86,43 +83,19 @@ export class PathMatcher<Type> {
     this.publishedPromise.resolve(retVal)
     this._result = retVal;
 
-    /*
-     * Lock in the current instance of path, before further processing on the SimpleGestureSource
-     * performs any 'chop'-style operations.
-     *
-     * No need to deep copy; the only mutable part is the "followingSample" field, which relates to
-     * any path continuation by later stages of the ongoing gesture path.  That's fine, as it's
-     * not the part we actually need to preserve in a fixed state.
-     *
-     * While we _could_, in theory, preserve the overall path... we don't need the samples -
-     * just the stats will do.
-     */
-    this._finalStats = this.source.path.stats;
-    this._baseItem = this.source.baseItem;
-
     return retVal;
   }
 
-  get finalStats() {
-    // Note:  contains `initialSample` and `lastSample`, the endpoints of the path segment that was matched.
-    // The latter can be used to find the matcher's final `currentItem` value if/as desired.
-    return this._finalStats;
+  get stats() {
+    return this.source.path.stats;
   }
 
   get baseItem() {
-    if(this.publishedPromise.isFulfilled) {
-      return this._baseItem;
-    } else {
-      return this.source.baseItem;
-    }
+    return this.source.baseItem;
   }
 
   get lastItem() {
-    if(this.publishedPromise.isFulfilled) {
-      return this.finalStats.lastSample.item;
-    } else {
-      return this.source.currentSample.item;
-    }
+    return this.source.currentSample.item;
   }
 
   update(): PathUpdateResult {

--- a/common/web/gesture-recognizer/src/engine/headless/simpleGestureSource.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/simpleGestureSource.ts
@@ -100,14 +100,35 @@ export class SimpleGestureSource<HoveredItemType> {
     return this.path.coords[this.path.coords.length-1];
   }
 
+  /**
+   * Creates a 'subview' of the current SimpleGestureSource.  It will be updated as the underlying
+   * source continues to receive updates until disconnected.
+   *
+   * @param startAtEnd If `true`, the 'subview' will appear to start at the most recently-observed
+   * path coordinate.  If `false`, it will have full knowledge of the current path.
+   * @param preserveBaseItem If `true`, the 'subview' will denote its base item as the same
+   * as its source.  If `false`, the base item for the 'subview' will be set to the `item` entry
+   * from the most recently-observed path coordinate.
+   * @returns
+   */
   public constructSubview(startAtEnd: boolean, preserveBaseItem: boolean) {
     return new SimpleGestureSourceSubview(this, startAtEnd, preserveBaseItem);
   }
 
+  /**
+   * Terminates all tracking for the modeled contact point.  Passing `true` as a parameter will
+   * treat the touchpath as if it were cancelled; `false` and `undefined` will treat it as if
+   * the touchpath has completed its standard lifecycle.
+   * @param cancel
+   */
   public terminate(cancel?: boolean) {
     this.path.terminate(cancel);
   }
 
+  /**
+   * Denotes if the contact point's path either was cancelled or completed its standard
+   * lifecycle.
+   */
   public get isPathComplete(): boolean {
     return this.path.isComplete;
   }
@@ -198,6 +219,10 @@ export class SimpleGestureSourceSubview<HoveredItemType> extends SimpleGestureSo
     return this._baseSource;
   }
 
+  /**
+   * This disconnects this subview from receiving further updates from the the underlying
+   * source without causing it to be cancelled or treated as completed.
+   */
   public disconnect() {
     if(this.subviewDisconnector) {
       this.subviewDisconnector();
@@ -206,9 +231,10 @@ export class SimpleGestureSourceSubview<HoveredItemType> extends SimpleGestureSo
   }
 
   /**
-   * Will also terminate the baseSource.  If the decision has been made to actively
-   * terminate the path by a gesture matcher, this is what is actually desired, even
-   * if called on a 'subview' of it.
+   * Like `disconnect`, but this will also terminate the baseSource and prevent further
+   * updates for the true, original `SimpleGestureSource` instance.  If the gesture-model
+   * and gesture-matching algorithm has determined this should be called, full path-update
+   * termination is correct, even if called against a subview into the instance.
    */
   public terminate(cancel?: boolean) {
     this.baseSource.terminate(cancel);

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/pathMatcher.spec.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/pathMatcher.spec.ts
@@ -32,11 +32,11 @@ async function simulateSequence(
   const startSample = samples[0];
   const samplePromises = samples.map((sample) => {
     return timedPromise(sample.t - startSample.t).then(async () => {
-      emulatedContactPoint.path.extend(sample);
+      emulatedContactPoint.update(sample);
       modelMatcher.update();
 
       if((options?.terminate ?? true) && sample == samples[samples.length-1]) {
-        emulatedContactPoint.path.terminate(false);
+        emulatedContactPoint.terminate(false);
         modelMatcher.update();
       }
     });
@@ -198,7 +198,7 @@ describe("PathMatcher", function() {
       const cancelPromise = timedPromise(250).then(async () => {
         assert.equal(await promiseStatus(modelMatcher.promise), PromiseStatuses.PROMISE_PENDING);
 
-        emulatedContactPoint.path.terminate(true);
+        emulatedContactPoint.terminate(true);
         modelMatcher.update();
 
         // As there's a minor level of indirection in the internal promises, we need the following
@@ -472,7 +472,7 @@ describe("PathMatcher", function() {
       const cancelPromise = timedPromise(250).then(async () => {
         assert.equal(await promiseStatus(modelMatcher.promise), PromiseStatuses.PROMISE_PENDING);
 
-        emulatedContactPoint.path.terminate(true);
+        emulatedContactPoint.terminate(true);
         modelMatcher.update();
 
         // As there's a minor level of indirection in the internal promises, we need the following

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessInputEngine.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessInputEngine.ts
@@ -42,13 +42,13 @@ export class HeadlessInputEngine<Type = any> extends InputEngineBase<Type> {
     const endTime = originalSamples[sampleCount-1].t;
 
     const endPromise = timedPromise(endTime).then(() => {
-      replayPoint.path.terminate(recordedPoint.path.wasCancelled);
+      replayPoint.terminate(recordedPoint.path.wasCancelled);
     });
 
     // Wrap it all together with a nice little bow.
     const compositePromise = Promise.all([endPromise].concat(samplePromises)).catch((reason) => {
       // Because we use a `setInterval` internally, we need cleanup if things go wrong.
-      replayPoint.path.terminate(true);
+      replayPoint.terminate(true);
       throw reason;
     });
 


### PR DESCRIPTION
Continuing from point 3 of #9338, this PR allows the matching algorithm to (effectively) segment the touch-contact paths corresponding to gestures as the paths and/or gestures change state.

1.  During gesture-matching and gesture-selection work, the need to allow "resetting" a path - to observe only the new portions - became quite evident.  Some potential gesture specifications may want this reset while others do not... so the best way forward appears to be providing "subviews" into the path.  

2. These "subviews" will be updated when their base "source" receives updates until "disconnected" at a later time.  This is done via event-handlers attached to the original, base "source" that the "subview" aliases.

3.  When a ContactModel is fully matched, a snapshot of the path segment corresponding to the match is made and the "subview" is "disconnected".  This facilitates conversion of the corresponding "matcher" into something of a "match history frame" / snapshot that may be referred to by later stages of the gesture / ongoing touchpath.

@keymanapp-test-bot skip