### PR TITLE
chore(linux): Remove obsolete dist from uploading to launchpad

### DIFF
--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -40,7 +40,7 @@ echo "ppa: ${ppa}"
 if [ "${DIST}" != "" ]; then
     distributions="${DIST}"
 else
-    distributions="bionic focal jammy kinetic"
+    distributions="bionic focal jammy"
 fi
 
 if [ "${PACKAGEVERSION}" != "" ]; then


### PR DESCRIPTION
Ubuntu 22.10 Kinetic is no longer supported, so this change omits it from uploading to Launchpad.

@keymanapp-test-bot skip