### PR TITLE
chore(developer): make unknown vkey a hint, not error 🙀

### DIFF
--- a/core/tests/unit/ldml/keyboards/k_020_fr-test.xml
+++ b/core/tests/unit/ldml/keyboards/k_020_fr-test.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Note: similar to, but slightly ahead of, fr-t-k0-azerty -->
 <!DOCTYPE keyboardTest SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboardTest.dtd">
 <keyboardTest conformsTo="techpreview">
-    <info keyboard="fr-t-k0-azerty.xml" author="Team Keyboard" name="fr-test" />
+    <info keyboard="k_020_fr.xml" author="Team Keyboard" name="fr-test-updated" />
     <repertoire name="simple-repertoire" chars="[a b c d e \u0022]" type="simple" /> <!-- verify that these outputs are all available from simple keys on any layer, for all form factors -->
     <repertoire name="chars-repertoire" chars="[á é ó]" type="gesture" /> <!-- verify that these outputs are all available from simple or gesture keys on any layer, for touch -->
-    <tests name="key-tests">
+    <tests name="key-tests-updated">
         <test name="key-test">
             <startContext to="abc\u0022..."/>
             <!-- tests by pressing key ids -->

--- a/core/tests/unit/ldml/keyboards/k_020_fr.xml
+++ b/core/tests/unit/ldml/keyboards/k_020_fr.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Note: similar to, but slightly ahead of, fr-t-k0-azerty -->
 <!DOCTYPE keyboard SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard.dtd">
 <keyboard locale="fr-t-k0-azerty" conformsTo="techpreview">
 	<locales>
@@ -7,11 +8,11 @@
 	<!-- 'conformsTo' gives CLDR spec conformance. Distinguishes from prior
 		keyboard formats -->
 	<!-- 'version' element is now optional -->
-	<version number="1.0.0" />
+	<version number="1.0.1" />
 	<info author="Team Keyboard" normalization="NFC" layout="AZERTY" indicator="FR" />
 	<names>
-		<name value="French Test" />
-		<name value="French Test AZERTY" />
+		<name value="French Test Updated" />
+		<name value="French Test AZERTY Updated" />
 	</names>
 
 	<settings fallback="omit" /> <!-- "hide" makes this act like a dead keyTBD -->
@@ -22,15 +23,15 @@
     <vkey from="A" to="Q" />
     <vkey from="Z" to="W" />
     <vkey from="GRAVE" to="QUOTE" /> <!-- TODO-LDML: GRAVE=BKQUOTE in ldml? -->
-    <!-- <vkey from="MINUS" to="LBRACKET" /> --> <!-- TODO-LDML: missing MINUS, LBRKT=LBRACKET in ldml? -->
+    <vkey from="MINUS" to="LBRACKET" /> <!-- TODO-LDML: missing MINUS, LBRKT=LBRACKET in ldml? -->
     <!-- i.e., OEM_3 >>> OEM_7 -->
     <vkey from="LBRACKET" to="RBRACKET" />  <!-- TODO-LDML: RBRKT=RBRACKET in ldml? -->
-    <!-- <vkey from="COLON" to="M" /> --> <!-- TODO-LDML: missing COLON-->
+    <vkey from="COLON" to="M" /> <!-- TODO-LDML: missing COLON-->
     <vkey from="QUOTE" to="GRAVE" /> <!-- TODO-LDML: GRAVE=BKQUOTE in ldml? -->
     <vkey from="M" to="COMMA" />
 		<vkey from="COMMA" to="PERIOD" />
 		<vkey from="PERIOD" to="SLASH" />
-    <!-- <vkey from="SLASH" to="EXCLAMATION" />  --> <!-- TODO-LDML: missing: EXCLAMATION -->
+    <vkey from="SLASH" to="EXCLAMATION" />  <!-- TODO-LDML: missing: EXCLAMATION -->
     <!-- i.e., OEM_2 >>> OEM_8 -->
 	</vkeys>
 

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -10,7 +10,7 @@
 tests_from_cldr = [
   'ja-Latn',
   'pt-k0-abnt2',
-  # 'fr-t-k0-azerty', # vkey issues
+  'fr-t-k0-azerty',
 ]
 
 tests_without_testdata = [
@@ -32,7 +32,7 @@ tests_without_testdata = [
 # These tests have a k_001_tiny-test.xml file as well.
 tests_with_testdata = [
   'k_001_tiny',
-  'fr-t-k0-azerty', # TODO-LDML: move to cldr above (fix vkey)
+  'k_020_fr', # TODO-LDML: move to cldr above (fix vkey)
   'k_200_reorder_nod_Lana',
 ]
 

--- a/developer/src/kmc-ldml/src/compiler/messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/messages.ts
@@ -2,7 +2,7 @@ import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m
 
 const SevInfo = CompilerErrorSeverity.Info | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevHint = CompilerErrorSeverity.Hint | CompilerErrorNamespace.LdmlKeyboardCompiler;
-// const SevWarn = CompilerErrorSeverity.Warn | CompilerErrorNamespace.KeyboardCompiler;
+// const SevWarn = CompilerErrorSeverity.Warn | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevError = CompilerErrorSeverity.Error | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevFatal = CompilerErrorSeverity.Fatal | CompilerErrorNamespace.LdmlKeyboardCompiler;
 
@@ -35,9 +35,9 @@ export class CompilerMessages {
     m(this.HINT_LocaleIsNotMinimalAndClean, `Locale '${o.sourceLocale}' is not minimal or correctly formatted and should be '${o.locale}'`);
   static HINT_LocaleIsNotMinimalAndClean = SevHint | 0x0008;
 
-  static Error_VkeyIsNotValid = (o:{vkey: string}) =>
-    m(this.ERROR_VkeyIsNotValid, `Virtual key '${o.vkey}' is not found in the CLDR VKey Enum table.`);
-  static ERROR_VkeyIsNotValid = SevError | 0x0009;
+  static Hint_VkeyIsNotValid = (o:{vkey: string}) =>
+    m(this.HINT_VkeyIsNotValid, `Virtual key '${o.vkey}' is not found in the CLDR VKey Enum table.`);
+  static HINT_VkeyIsNotValid = SevHint | 0x0009;
 
   static Hint_VkeyIsRedundant = (o:{vkey: string}) =>
     m(this.HINT_VkeyIsRedundant, `Virtual key '${o.vkey}' is mapped to itself, which is redundant.`);

--- a/developer/src/kmc-ldml/src/compiler/visual-keyboard-compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/visual-keyboard-compiler.ts
@@ -44,6 +44,10 @@ export class LdmlKeyboardVisualKeyboardCompiler {
 
         let keydef = source.keyboard.keys?.key?.find(x => x.id == key);
 
+        if (!keydef) {
+          throw Error(`Internal Error: could not find key id="${key}" in layer "${layer.id || '<none>'}", row "${y}"`);
+        }
+
         vk.keys.push({
           flags: VisualKeyboard.VisualKeyboardKeyFlags.kvkkUnicode,
           shift: shift,

--- a/developer/src/kmc-ldml/src/compiler/vkey.ts
+++ b/developer/src/kmc-ldml/src/compiler/vkey.ts
@@ -19,11 +19,13 @@ export class VkeyCompiler extends SectionCompiler {
 
       this.keyboard.vkeys.vkey.forEach(vk => {
         if(LdmlVkeyNames[vk.from] === undefined) {
+          // TODO-LDML: When we do #7135 this may need to change back to an error.
           this.callbacks.reportMessage(CompilerMessages.Hint_VkeyIsNotValid({vkey: vk.from}));
           return;
         }
 
         if(LdmlVkeyNames[vk.to] === undefined) {
+          // TODO-LDML: When we do #7135 this may need to change back to an error.
           this.callbacks.reportMessage(CompilerMessages.Hint_VkeyIsNotValid({vkey: vk.to}));
           return;
         }

--- a/developer/src/kmc-ldml/src/compiler/vkey.ts
+++ b/developer/src/kmc-ldml/src/compiler/vkey.ts
@@ -19,13 +19,13 @@ export class VkeyCompiler extends SectionCompiler {
 
       this.keyboard.vkeys.vkey.forEach(vk => {
         if(LdmlVkeyNames[vk.from] === undefined) {
-          this.callbacks.reportMessage(CompilerMessages.Error_VkeyIsNotValid({vkey: vk.from}));
-          valid = false;
+          this.callbacks.reportMessage(CompilerMessages.Hint_VkeyIsNotValid({vkey: vk.from}));
+          return;
         }
 
         if(LdmlVkeyNames[vk.to] === undefined) {
-          this.callbacks.reportMessage(CompilerMessages.Error_VkeyIsNotValid({vkey: vk.to}));
-          valid = false;
+          this.callbacks.reportMessage(CompilerMessages.Hint_VkeyIsNotValid({vkey: vk.to}));
+          return;
         }
 
         if(vk.from == vk.to) {

--- a/developer/src/kmc-ldml/test/test-vkey.ts
+++ b/developer/src/kmc-ldml/test/test-vkey.ts
@@ -37,19 +37,19 @@ describe('vkey compiler', function () {
     assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Info_MultipleVkeysHaveSameTarget({vkey: 'Q'}));
   });
 
-  it('should error on invalid "from" vkey', async function() {
+  it('should hint on invalid "from" vkey', async function() {
     let vkey = await loadSectionFixture(VkeyCompiler, 'sections/vkey/invalid-from-vkey.xml', compilerTestCallbacks) as Vkey;
-    assert.isNull(vkey);
+    assert.isNotNull(vkey);
     assert.equal(compilerTestCallbacks.messages.length, 2);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_VkeyIsNotValid({vkey: 'q'}));
-    assert.deepEqual(compilerTestCallbacks.messages[1], CompilerMessages.Error_VkeyIsNotValid({vkey: 'HYFEN'}));
+    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Hint_VkeyIsNotValid({vkey: 'q'}));
+    assert.deepEqual(compilerTestCallbacks.messages[1], CompilerMessages.Hint_VkeyIsNotValid({vkey: 'HYFEN'}));
   });
 
-  it('should error on invalid "to" vkey', async function() {
+  it('should hint on invalid "to" vkey', async function() {
     let vkey = await loadSectionFixture(VkeyCompiler, 'sections/vkey/invalid-to-vkey.xml', compilerTestCallbacks) as Vkey;
-    assert.isNull(vkey);
+    assert.isNotNull(vkey);
     assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_VkeyIsNotValid({vkey: 'A-ACUTE'}));
+    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Hint_VkeyIsNotValid({vkey: 'A-ACUTE'}));
   });
 
   it('should error on repeated vkeys', async function() {

--- a/resources/standards-data/ldml-keyboards/techpreview/3.0/fr-t-k0-azerty.xml
+++ b/resources/standards-data/ldml-keyboards/techpreview/3.0/fr-t-k0-azerty.xml
@@ -63,12 +63,9 @@
 		<key id="symbol" switch="symbol" />
 		<key id="base" switch="base" />
 
-		<!--
-			TODO: need discussion
 		<key id="bksp" gap="true" />
 		<key id="extra" gap="true" />
 		<key id="enter" to="\u{000A}" />
-		-->
 
 		<!-- extra keys -->
 		<key id="u-grave" to="ü" />


### PR DESCRIPTION
Note that feat(core): ldml vkey support 🙀 #7135 is future, in the future this may be an Error again.

- also, add an internal error to the visual-keyboard-compiler on missing keys
- also, update fr-t-k0-azerty to fix a missing key (simultaneous fix has been made in CLDR)
- also, reinstate CLDR's fr-t-k0-azerty - now all 'stock' keyboards build in keyman!
- keep the 'internal' azerty as k_020 - it has some additional transform goodies

Fixes: #9236

@keymanapp-test-bot skip