### PR TITLE
feat(windows): Use Keyboard Activated event API call to turn off caps lock (if required) 🚏

### DIFF
--- a/core/src/km_kbp_processevent_api.cpp
+++ b/core/src/km_kbp_processevent_api.cpp
@@ -28,7 +28,7 @@ km_kbp_event(
   switch(event) {
     case KM_KBP_EVENT_KEYBOARD_ACTIVATED:
       assert(data == nullptr);
-      if(data == nullptr) {
+      if(data != nullptr) {
         return KM_KBP_STATUS_INVALID_ARGUMENT;
       }
       break;

--- a/core/src/kmx/kmx_processevent.h
+++ b/core/src/kmx/kmx_processevent.h
@@ -99,7 +99,7 @@ public:
 
   KMX_BOOL Load(km_kbp_path_name keyboardName);
   KMX_BOOL ProcessEvent(km_kbp_state *state, KMX_UINT vkey, KMX_DWORD modifiers, KMX_BOOL isKeyDown);  // returns FALSE on error or key not matched
-
+  /// TODO: 5822 public member process external event.
   KMX_Actions *GetActions();
   KMX_Context *GetContext();
   KMX_Options *GetOptions();

--- a/core/src/kmx/kmx_processevent.h
+++ b/core/src/kmx/kmx_processevent.h
@@ -86,7 +86,6 @@ private:
   /* Caps Lock and modifier management */
 
   KMX_BOOL IsCapsLockOn(KMX_DWORD modifiers);
-  void SetCapsLock(KMX_DWORD &modifiers, KMX_BOOL capsLockOn, KMX_BOOL force = FALSE);
   void ResetCapsLock(KMX_DWORD &modifiers, KMX_BOOL isKeyDown);
   KMX_BOOL KeyCapsLockPress(KMX_DWORD &modifiers, KMX_BOOL isKeyDown);
   void KeyShiftPress(KMX_DWORD &modifiers, KMX_BOOL isKeyDown);
@@ -99,7 +98,7 @@ public:
 
   KMX_BOOL Load(km_kbp_path_name keyboardName);
   KMX_BOOL ProcessEvent(km_kbp_state *state, KMX_UINT vkey, KMX_DWORD modifiers, KMX_BOOL isKeyDown);  // returns FALSE on error or key not matched
-  /// TODO: 5822 public member process external event.
+
   KMX_Actions *GetActions();
   KMX_Context *GetContext();
   KMX_Options *GetOptions();
@@ -107,6 +106,8 @@ public:
   KMX_Environment *GetEnvironment();
   KMX_Environment const *GetEnvironment() const;
   INTKEYBOARDINFO const *GetKeyboard() const;
+  /// TODO: 5822 public member process external event.
+  void SetCapsLock(KMX_DWORD &modifiers, KMX_BOOL capsLockOn, KMX_BOOL force = FALSE);
 
   // Utility function
 public:

--- a/core/src/kmx/kmx_processevent.h
+++ b/core/src/kmx/kmx_processevent.h
@@ -106,7 +106,6 @@ public:
   KMX_Environment *GetEnvironment();
   KMX_Environment const *GetEnvironment() const;
   INTKEYBOARDINFO const *GetKeyboard() const;
-  /// TODO: 5822 public member process external event.
   void SetCapsLock(KMX_DWORD &modifiers, KMX_BOOL capsLockOn, KMX_BOOL force = FALSE);
 
   // Utility function

--- a/core/src/kmx/kmx_processor.cpp
+++ b/core/src/kmx/kmx_processor.cpp
@@ -105,23 +105,22 @@ kmx_processor::update_option(
 
 km_kbp_status
 kmx_processor::external_event(
-      km_kbp_state* state,
-      uint32_t event,
-      void* _kmn_unused(data)
-      ) {
+  km_kbp_state* state,
+  uint32_t event,
+  void* _kmn_unused(data)
+) {
 
-  switch (event){
-    case KM_KBP_EVENT_KEYBOARD_ACTIVATED:{
+  switch (event) {
+    case KM_KBP_EVENT_KEYBOARD_ACTIVATED:
       // reset any current actions in the queue as a new keyboard
       // has been activated
       _kmx.GetActions()->ResetQueue();
       state->actions().clear();
-    KMX_DWORD dummy_modifiers = 0;
-    if (_kmx.GetKeyboard()->Keyboard->dwFlags & KF_CAPSALWAYSOFF) {
-      _kmx.SetCapsLock(dummy_modifiers, FALSE, TRUE);
+      if (_kmx.GetKeyboard()->Keyboard->dwFlags & KF_CAPSALWAYSOFF) {
+        KMX_DWORD dummy_modifiers = 0;
+        _kmx.SetCapsLock(dummy_modifiers, FALSE, TRUE);
       }
-    }
-    break;
+      break;
     default:
       return KM_KBP_STATUS_INVALID_ARGUMENT;
   }

--- a/core/src/kmx/kmx_processor.cpp
+++ b/core/src/kmx/kmx_processor.cpp
@@ -107,11 +107,11 @@ km_kbp_status
 kmx_processor::external_event(
       km_kbp_state* state,
       uint32_t event,
-      void* data
+      void* _kmn_unused(data)
       ) {
 
   switch (event){
-    case KM_KBP_EVENT_KEYBOARD_ACTIVATED:
+    case KM_KBP_EVENT_KEYBOARD_ACTIVATED:{
       // reset any current actions in the queue as we have
       // just loaded a new keyboard
       _kmx.GetActions()->ResetQueue();
@@ -125,6 +125,7 @@ kmx_processor::external_event(
        // TODO: #5822    need to use public member to access_kmx
       _kmx.SetCapsLock(dummy_modifiers, FALSE, TRUE);
       }
+    }
     break;
     default:
       return KM_KBP_STATUS_INVALID_ARGUMENT;

--- a/core/src/kmx/kmx_processor.cpp
+++ b/core/src/kmx/kmx_processor.cpp
@@ -112,17 +112,12 @@ kmx_processor::external_event(
 
   switch (event){
     case KM_KBP_EVENT_KEYBOARD_ACTIVATED:{
-      // reset any current actions in the queue as we have
-      // just loaded a new keyboard
+      // reset any current actions in the queue as a new keyboard
+      // has been activated
       _kmx.GetActions()->ResetQueue();
       state->actions().clear();
-      // TODO: #5822
-      // just force it if caps always off is set.
-      // We need to pass the current modifiers in from the
-      // platform if we were to check.
     KMX_DWORD dummy_modifiers = 0;
     if (_kmx.GetKeyboard()->Keyboard->dwFlags & KF_CAPSALWAYSOFF) {
-       // TODO: #5822    need to use public member to access_kmx
       _kmx.SetCapsLock(dummy_modifiers, FALSE, TRUE);
       }
     }

--- a/core/src/kmx/kmx_processor.cpp
+++ b/core/src/kmx/kmx_processor.cpp
@@ -103,6 +103,35 @@ kmx_processor::update_option(
   return option(scope, key, value);
 }
 
+km_kbp_status
+kmx_processor::external_event(
+      km_kbp_state* state,
+      uint32_t event,
+      void* data
+      ) {
+
+  switch (event){
+    case KM_KBP_EVENT_KEYBOARD_ACTIVATED:
+      // reset any current actions in the queue as we have
+      // just loaded a new keyboard
+      _kmx.GetActions()->ResetQueue();
+      state->actions().clear();
+      // TODO: #5822
+      // just force it if caps always off is set.
+      // We need to pass the current modifiers in from the
+      // platform if we were to check.
+    KMX_DWORD dummy_modifiers = 0;
+    if (_kmx.GetKeyboard()->Keyboard->dwFlags & KF_CAPSALWAYSOFF) {
+       // TODO: #5822    need to use public member to access_kmx
+      _kmx.SetCapsLock(dummy_modifiers, FALSE, TRUE);
+      }
+    break;
+    default:
+      return KM_KBP_STATUS_INVALID_ARGUMENT;
+  }
+  return internal_process_queued_actions(state);
+}
+
 bool
 kmx_processor::queue_action(
   km_kbp_state * state,

--- a/core/src/kmx/kmx_processor.hpp
+++ b/core/src/kmx/kmx_processor.hpp
@@ -61,6 +61,13 @@ namespace kbp
       km_kbp_state *state
       ) override;
 
+    km_kbp_status
+    external_event(
+      km_kbp_state* state,
+      uint32_t event,
+      void* data
+      ) override;
+
     bool
     queue_action(
       km_kbp_state * state,

--- a/core/src/kmx/kmx_processor.hpp
+++ b/core/src/kmx/kmx_processor.hpp
@@ -59,14 +59,14 @@ namespace kbp
     km_kbp_status
     process_queued_actions(
       km_kbp_state *state
-      ) override;
+    ) override;
 
     km_kbp_status
     external_event(
       km_kbp_state* state,
       uint32_t event,
       void* data
-      ) override;
+    ) override;
 
     bool
     queue_action(

--- a/core/tests/unit/kmnkbd/action_items.hpp
+++ b/core/tests/unit/kmnkbd/action_items.hpp
@@ -23,6 +23,7 @@ const char *action_item_types[] = {
   "KM_KBP_IT_PERSIST_OPT", // = 5,  // The indicated option needs to be stored.
   "KM_KBP_IT_EMIT_KEYSTROKE", // = 6,  // Emit the current keystroke to the application
   "KM_KBP_IT_INVALIDATE_CONTEXT", // = 7,
+  "KM_KBP_IT_CAPSLOCK",    // = 8,
 };
 
 void print_action_item(const char *title, km_kbp_action_item const & item) {
@@ -50,6 +51,13 @@ void print_action_item(const char *title, km_kbp_action_item const & item) {
       << "           value: " << item.option->value << std::endl
       << "           scope: " << item.option->scope << std::endl;
     break;
+  case KM_KBP_IT_CAPSLOCK:
+    std::cout << "  caps lock:  " <<
+      (item.capsLock == 0 ? "off" :
+      item.capsLock == 1 ? "on" :
+      "invalid value") << " (" <<
+      item.capsLock << ")" << std::endl;
+    break;
   }
 }
 
@@ -68,6 +76,7 @@ bool operator==(
                                                   lhs.backspace.expected_value == rhs.backspace.expected_value; break;
       case KM_KBP_IT_PERSIST_OPT:        result = *lhs.option == *rhs.option; break;
       case KM_KBP_IT_EMIT_KEYSTROKE:     break;
+      case KM_KBP_IT_CAPSLOCK:           result = lhs.capsLock == rhs.capsLock; break;
       case KM_KBP_IT_INVALIDATE_CONTEXT: break;
       default: std::cout << "unexpected type" << std::endl; return false; //
     }

--- a/core/tests/unit/kmnkbd/action_items.hpp
+++ b/core/tests/unit/kmnkbd/action_items.hpp
@@ -23,7 +23,7 @@ const char *action_item_types[] = {
   "KM_KBP_IT_PERSIST_OPT", // = 5,  // The indicated option needs to be stored.
   "KM_KBP_IT_EMIT_KEYSTROKE", // = 6,  // Emit the current keystroke to the application
   "KM_KBP_IT_INVALIDATE_CONTEXT", // = 7,
-  "KM_KBP_IT_CAPSLOCK",    // = 8,
+  "KM_KBP_IT_CAPSLOCK",//     = 8, Enable or disable capsLock
 };
 
 void print_action_item(const char *title, km_kbp_action_item const & item) {

--- a/core/tests/unit/kmx/kmx_external_event.cpp
+++ b/core/tests/unit/kmx/kmx_external_event.cpp
@@ -56,7 +56,7 @@ void test_external_event(const km::kbp::path &source_file){
   // keyboard is a caps always off keyboard
 
   try_status(km_kbp_event(test_state, event, nullptr));
-  // The action to turn capslock off must be in the actions let.
+  // The action to turn capslock off must be in the actions list.
   assert(action_items(test_state, {{KM_KBP_IT_CAPSLOCK, {0,}, {0}}, {KM_KBP_IT_END}}));
 
   km_kbp_state_dispose(test_state);

--- a/core/tests/unit/kmx/kmx_external_event.cpp
+++ b/core/tests/unit/kmx/kmx_external_event.cpp
@@ -1,7 +1,7 @@
 /*
   Copyright:    © 2023 SIL International.
   Description:  Tests for external event processing for the kmx processor
-  Create Date:  15 Nov 2021
+  Create Date:  28 Jul 2023
   Authors:      Ross Cruickshank (RC)
 
 */
@@ -21,7 +21,7 @@
 
 /** This test will test the infrastructure around the external event processing
  *  The functions tested are:
- *  km_kbp_event
+ *  km_kbp_event with the event KM_KBP_EVENT_KEYBOARD_ACTIVATED
  *
  */
 
@@ -41,7 +41,6 @@ void test_external_event(const km::kbp::path &source_file){
 
   km_kbp_keyboard * test_kb = nullptr;
   km_kbp_state * test_state = nullptr;
-  //km_kbp_keyboard_imx * kb_imx_list;
 
   km::kbp::path full_path = source_file;
 
@@ -50,18 +49,14 @@ void test_external_event(const km::kbp::path &source_file){
   // Setup state, environment
   try_status(km_kbp_state_create(test_kb, test_env_opts, &test_state));
 
-  // This is where we can set up external events to test the processing.
+  // Set up external events to test the processing.
   uint32_t event = KM_KBP_EVENT_KEYBOARD_ACTIVATED;
   // For this particular test we want to have the capslock state as on.
   // then after the km_kbp_event the caps lock should be off as the load
   // keyboard is a caps always off keyboard
-  // set caps lock state (probably with key event caps lock key)
-  // check caps lock state
-  //caps_lock_state()
-  //set_caps_lock_on(bool caps_lock_on)
+
   try_status(km_kbp_event(test_state, event, nullptr));
-  // The action to turn capslock of should exist.
-  //assert(action_items(test_state, {{KM_KBP_IT_CAPSLOCK, {0,}, {0}}, {KM_KBP_IT_END}}));
+  // The action to turn capslock off must be in the actions let.
   assert(action_items(test_state, {{KM_KBP_IT_CAPSLOCK, {0,}, {0}}, {KM_KBP_IT_END}}));
 
   km_kbp_state_dispose(test_state);

--- a/core/tests/unit/kmx/kmx_external_event.cpp
+++ b/core/tests/unit/kmx/kmx_external_event.cpp
@@ -1,0 +1,96 @@
+/*
+  Copyright:    © 2023 SIL International.
+  Description:  Tests for external event processing for the kmx processor
+  Create Date:  15 Nov 2021
+  Authors:      Ross Cruickshank (RC)
+
+*/
+
+#include <kmx/kmx_processevent.h>
+
+#include "path.hpp"
+#include "state.hpp"
+#include "../kmnkbd/action_items.hpp"
+#include <test_assert.h>
+#include <test_color.h>
+#include "../emscripten_filesystem.h"
+
+#include <map>
+#include <iostream>
+#include <sstream>
+
+/** This test will test the infrastructure around the external event processing
+ *  The functions tested are:
+ *  km_kbp_event
+ *
+ */
+
+using namespace km::kbp::kmx;
+
+km_kbp_option_item test_env_opts[] =
+{
+  KM_KBP_OPTIONS_END
+};
+
+int error_args() {
+    std::cerr << "kmx: Not enough arguments." << std::endl;
+    return 1;
+}
+
+void test_external_event(const km::kbp::path &source_file){
+
+  km_kbp_keyboard * test_kb = nullptr;
+  km_kbp_state * test_state = nullptr;
+  //km_kbp_keyboard_imx * kb_imx_list;
+
+  km::kbp::path full_path = source_file;
+
+  try_status(km_kbp_keyboard_load(full_path.native().c_str(), &test_kb));
+
+  // Setup state, environment
+  try_status(km_kbp_state_create(test_kb, test_env_opts, &test_state));
+
+  // This is where we can set up external events to test the processing.
+  uint32_t event = KM_KBP_EVENT_KEYBOARD_ACTIVATED;
+  // For this particular test we want to have the capslock state as on.
+  // then after the km_kbp_event the caps lock should be off as the load
+  // keyboard is a caps always off keyboard
+  // set caps lock state (probably with key event caps lock key)
+  // check caps lock state
+  //caps_lock_state()
+  //set_caps_lock_on(bool caps_lock_on)
+  try_status(km_kbp_event(test_state, event, nullptr));
+  // The action to turn capslock of should exist.
+  //assert(action_items(test_state, {{KM_KBP_IT_CAPSLOCK, {0,}, {0}}, {KM_KBP_IT_END}}));
+  assert(action_items(test_state, {{KM_KBP_IT_CAPSLOCK, {0,}, {0}}, {KM_KBP_IT_END}}));
+
+  km_kbp_state_dispose(test_state);
+  km_kbp_keyboard_dispose(test_kb);
+
+}
+
+int main(int argc, char *argv []) {
+  int first_arg = 1;
+
+  if (argc < 2) {
+    return error_args();
+  }
+
+  auto arg_color = std::string(argv[1]) == "--color";
+  if(arg_color) {
+    first_arg++;
+    if(argc < 3) {
+      return error_args();
+    }
+  }
+  console_color::enabled = console_color::isaterminal() || arg_color;
+  km::kbp::kmx::g_debug_ToConsole = TRUE;
+
+#ifdef __EMSCRIPTEN__
+  test_external_event(get_wasm_file_path(argv[first_arg]));
+#else
+  test_external_event(argv[first_arg]);
+#endif
+
+  return 0;
+}

--- a/core/tests/unit/kmx/kmx_external_event.cpp
+++ b/core/tests/unit/kmx/kmx_external_event.cpp
@@ -19,10 +19,10 @@
 #include <iostream>
 #include <sstream>
 
-/** This test will test the infrastructure around the external event processing
- *  The functions tested are:
- *  km_kbp_event with the event KM_KBP_EVENT_KEYBOARD_ACTIVATED
- *
+/** 
+ * This test will test the infrastructure around the external event processing
+ * The functions tested are:
+ * - km_kbp_event with the event KM_KBP_EVENT_KEYBOARD_ACTIVATED
  */
 
 using namespace km::kbp::kmx;
@@ -33,8 +33,8 @@ km_kbp_option_item test_env_opts[] =
 };
 
 int error_args() {
-    std::cerr << "kmx: Not enough arguments." << std::endl;
-    return 1;
+  std::cerr << "kmx: Not enough arguments." << std::endl;
+  return 1;
 }
 
 void test_external_event(const km::kbp::path &source_file){

--- a/core/tests/unit/kmx/meson.build
+++ b/core/tests/unit/kmx/meson.build
@@ -208,3 +208,21 @@ kbd_log = custom_target(test_kbd + '.kmx'.underscorify(),
   command: kmc_cmd + ['build', '--debug', '--no-compiler-version', '@INPUT@', '--out-file', kbd_obj]
 )
   test('imx_list', imx_e,  depends: kbd_log, args: [kbd_obj] )
+
+external_e = executable('ext_event', ['kmx_external_event.cpp', '../emscripten_filesystem.cpp'],
+                cpp_args: defns + warns,
+                include_directories: [inc, libsrc],
+                link_args: links + tests_flags,
+                objects: lib.extract_all_objects(recursive: false))
+
+test_kbd = 'k_033___caps_always_off'
+
+
+kbd_src = common_test_keyboards_baseline + '/' + test_kbd + '.kmn'
+kbd_obj = join_paths(meson.current_build_dir(), test_kbd) + '.kmx'
+kbd_log = custom_target(test_kbd + '.kmx'.underscorify(),
+  output: test_kbd + '.log',
+  input: kbd_src,
+  command: kmc_cmd + ['build', '--debug', '--no-compiler-version', '@INPUT@', '--out-file', kbd_obj]
+)
+  test('ext_event', external_e,  depends: kbd_log, args: [kbd_obj] )

--- a/windows/src/engine/keyman32/kmprocessactions.cpp
+++ b/windows/src/engine/keyman32/kmprocessactions.cpp
@@ -218,7 +218,7 @@ ProcessActionsExternalEvent() {
   if (!_td) {
     return FALSE;
   }
-  // Currently the only Action handled is KM_KBP_IT_CAPSLOCK.
+  // Currently only a subset of actions are handled.
   // Other actions will be added when needed.
   BOOL continueProcessingActions = TRUE;
   for (auto act = km_kbp_state_action_items(_td->lpActiveKeyboard->lpCoreKeyboardState, nullptr); act->type != KM_KBP_IT_END;

--- a/windows/src/engine/keyman32/kmprocessactions.h
+++ b/windows/src/engine/keyman32/kmprocessactions.h
@@ -26,4 +26,15 @@ BOOL ProcessActions(BOOL* emitKeyStroke);
  */
 BOOL ProcessActionsNonUpdatableParse(BOOL* emitKeyStroke);
 
+/**
+ * This function processes the actions queued in the core processor in
+ * the external event case. That is actions not caused by a keystroke but from selecting a
+ * different keyboard for example.
+ * Currently only CAPS Lock and invalidate key stroke are processed.
+ *
+ * @return BOOL  True if actions were successfully processed
+ */
+BOOL ProcessActionsExternalEvent();
+
+
 #endif

--- a/windows/src/engine/keyman32/kmprocessactions.h
+++ b/windows/src/engine/keyman32/kmprocessactions.h
@@ -30,9 +30,9 @@ BOOL ProcessActionsNonUpdatableParse(BOOL* emitKeyStroke);
  * This function processes the actions queued in the core processor in
  * the external event case. That is actions not caused by a keystroke but from selecting a
  * different keyboard for example.
- * Currently only CAPS Lock and invalidate key stroke are processed.
+ * Currently only KM_KBP_IT_CAPSLOCK and KM_KBP_IT_INVALIDATE_CONTEXT are processed.
  *
- * @return BOOL  True if actions were successfully processed
+ * @return BOOL  TRUE if actions were successfully processed
  */
 BOOL ProcessActionsExternalEvent();
 

--- a/windows/src/engine/keyman32/selectkeyboard.cpp
+++ b/windows/src/engine/keyman32/selectkeyboard.cpp
@@ -96,16 +96,18 @@ BOOL SelectKeyboard(DWORD KeymanID)
         SendDebugMessageFormat(hwnd, sdmGlobal, 0, "SelectKeyboard: NewKeymanID: %x", _td->ActiveKeymanID);
 
         if (_td->app) _td->app->ResetContext();
-
-        // TODO: #5822 tell the core with km_kbp_event so it can reset the capslock state
-
-
         SelectApplicationIntegration();   // I4287
         if (_td->app && !_td->app->IsWindowHandled(hwnd)) _td->app->HandleWindow(hwnd);
         _td->state.windowunicode = !_td->app || _td->app->IsUnicode();
 
         ActivateDLLs(_td->lpActiveKeyboard);
 
+        if (KM_KBP_STATUS_OK !=
+            km_kbp_event(_td->lpActiveKeyboard->lpCoreKeyboardState, KM_KBP_EVENT_KEYBOARD_ACTIVATED, nullptr)) {
+          SendDebugMessageFormat(0, sdmGlobal, 0, "km_kbp_event Failed Result: %d ", FALSE);
+        } else {
+          ProcessActionsExternalEvent();
+        }
         return TRUE;
       }
       if (IsFocusedThread())

--- a/windows/src/engine/keyman32/selectkeyboard.cpp
+++ b/windows/src/engine/keyman32/selectkeyboard.cpp
@@ -61,8 +61,8 @@ BOOL SelectKeyboard(DWORD KeymanID)
   PKEYMAN64THREADDATA _td = ThreadGlobals();
   if (!_td) return FALSE;
 
-  SendDebugMessageFormat(hwnd, sdmGlobal, 0, "ENTER SelectKeyboardCore-------------------------------------------");
-  SendDebugMessageFormat(hwnd, sdmGlobal, 0, "ENTER SelectKeyboardCore: Current:(HKL=%x KeymanID=%x %s) New:(ID=%x)", //lpActiveKeyboard=%s ActiveKeymanID: %x sk: %x KeymanID: %d",
+  SendDebugMessageFormat(hwnd, sdmGlobal, 0, "ENTER SelectKeyboard-------------------------------------------");
+  SendDebugMessageFormat(hwnd, sdmGlobal, 0, "ENTER SelectKeyboard: Current:(HKL=%x KeymanID=%x %s) New:(ID=%x)", //lpActiveKeyboard=%s ActiveKeymanID: %x sk: %x KeymanID: %d",
     GetKeyboardLayout(0),
     _td->ActiveKeymanID,
     _td->lpActiveKeyboard == NULL ? "NULL" : _td->lpActiveKeyboard->Name,
@@ -86,18 +86,19 @@ BOOL SelectKeyboard(DWORD KeymanID)
       {
         if (!_td->lpKeyboards[i].lpCoreKeyboard && !LoadlpKeyboard(i))
         {
-          SendDebugMessageFormat(hwnd, sdmGlobal, 0, "SelectKeyboardCore: Unable to load");
+          SendDebugMessageFormat(hwnd, sdmGlobal, 0, "SelectKeyboard: Unable to load");
           return TRUE;
         }
 
         _td->lpActiveKeyboard = &_td->lpKeyboards[i];
         _td->ActiveKeymanID = _td->lpActiveKeyboard->KeymanID;
 
-        SendDebugMessageFormat(hwnd, sdmGlobal, 0, "SelectKeyboardCore: NewKeymanID: %x", _td->ActiveKeymanID);
+        SendDebugMessageFormat(hwnd, sdmGlobal, 0, "SelectKeyboard: NewKeymanID: %x", _td->ActiveKeymanID);
 
         if (_td->app) _td->app->ResetContext();
 
         // TODO: #5822 tell the core with km_kbp_event so it can reset the capslock state
+
 
         SelectApplicationIntegration();   // I4287
         if (_td->app && !_td->app->IsWindowHandled(hwnd)) _td->app->HandleWindow(hwnd);
@@ -109,19 +110,19 @@ BOOL SelectKeyboard(DWORD KeymanID)
       }
       if (IsFocusedThread())
       {
-        SendDebugMessageFormat(hwnd, sdmGlobal, 0, "SelectKeyboardCore: Keyboard Not Found");
+        SendDebugMessageFormat(hwnd, sdmGlobal, 0, "SelectKeyboard: Keyboard Not Found");
       }
     }
   }
 
     __finally
     {
-      SendDebugMessageFormat(hwnd, sdmGlobal, 0, "EXIT SelectKeyboardCore: Current:(HKL=%x KeymanID=%x %s) New:(ID=%x)", //lpActiveKeyboard=%s ActiveKeymanID: %x sk: %x KeymanID: %d",
+      SendDebugMessageFormat(hwnd, sdmGlobal, 0, "EXIT SelectKeyboard: Current:(HKL=%x KeymanID=%x %s) New:(ID=%x)", //lpActiveKeyboard=%s ActiveKeymanID: %x sk: %x KeymanID: %d",
         GetKeyboardLayout(0),
         _td->ActiveKeymanID,
         _td->lpActiveKeyboard == NULL ? "NULL" : _td->lpActiveKeyboard->Name,
         KeymanID);
-      SendDebugMessageFormat(hwnd, sdmGlobal, 0, "EXIT SelectKeyboardCore-------------------------------------------");
+      SendDebugMessageFormat(hwnd, sdmGlobal, 0, "EXIT SelectKeyboard-------------------------------------------");
     }
     return TRUE;
 }


### PR DESCRIPTION
Add external event processing to the kmx processor. 

At this point, the current modifier state has not been passed with the event. It could be passed as the third object with the void* pointer. Currently, the kmx_processor will queue a action to turn caps lock off, if the just loaded keyboard has the  `CapsAlwaysOff` store set, regardless of the current state of the capslock on the platform. 

Fixes: #5822 

# User Testing

For these tests, use a keyboard with the [`caps_always_off.kmp.zip`](https://github.com/keymanapp/keyman/files/8937257/caps_always_off.kmp.zip) store set. We call this keyboard _capsalwaysoff_ below.

Any keyboard with that store set will work; if you don't have one at hand you can use the `caps_always_off.kmp` keyboard. The *caps_always_off.kmp* keyboard will prevent switching caps lock on. As a sanity check to verify that Keyman is actually active, pressing the key `a` will output `ncaps_little_a`, and `Shift+a` will output `ncaps_shift_A`.

**Note:** When testing in a virtual machine, use an on-screen keyboard (in VirtualBox: Input/Keyboard/Soft Keyboard) and observe the caps lock indicator of the on-screen keyboard. Using the hardware keyboard might show side effects with caps lock.


- Install a keyboard that has `CapsAlwaysOff` store set, e.g. `caps_always_off.kmp`.
- Currently active keyboard is a non-Keyman keyboard

- **TEST_CAPSOFF-EXT_EVENT**: switching turns off caps lock
  - turn on caps lock
  - switch to capsalwaysoff keyboard
  Expected result:
  - caps lock indicator turned off


## The following tests are more regression tests to sure existing behaviour still works. 


- **TEST_CAPSOFF-1**: sanity check
  - switch to capsalwaysoff keyboard
  - press and release `a`

  Expected result:
  - output: `ncaps_little_a`

- **TEST_CAPSOFF-2**: caps lock stays off
  - switch to capsalwaysoff keyboard
  - press and release `CapsLock` key
  - press and release `a`

  Expected result:
  - caps lock indicator stays turned off
  - output: `ncaps_little_a`

- **TEST_CAPSOFF-3**: no caps lock while holding capslock key
  - switch to capsalwaysoff keyboard
  - press and hold `CapsLock` key
  - press and release `a`
  - release `CapsLock` key

  Expected result:
  - output: `ncaps_little_a`

- **TEST_CAPSOFF-4**: no caps lock while holding capslock key
  - switch to capsalwaysoff keyboard
  - press and hold `CapsLock` key
  - press and hold `Shift` key
  - press and release `a`
  - release `CapsLock` and `Shift` keys

  Expected result:
  - output: `ncaps_shift_A`

## SHIFT: CapsOnOnly/ShiftFreesCaps

For these tests, use a keyboard with the `CapsOnOnly` and `ShiftFreesCaps` stores set. We call this keyboard _shift_frees_caps_ below.

Any keyboard with these stores set will work; if you don't have one at hand you can use the [`shift_frees_caps.kmp.zip`](https://github.com/keymanapp/keyman/files/8937320/shift_frees_caps.kmp.zip) keyboard.

The _shift_frees_caps.kmp_ keyboard will enable caps lock by pressing the `CapsLock` key, and will turn capslock off by pressing the `Shift` key. The keyboard outputs _pass_ or _fail_ if following the test cases.

**Note:** When testing in a virtual machine, use an on-screen keyboard (in VirtualBox: Input/Keyboard/Soft Keyboard) and observe the caps lock indicator of the on-screen keyboard. Using the hardware keyboard might show side effects with caps lock. **Except** for TEST_CAPSONLY-5 which can only be reliably tested on a hardware keyboard on host OS (not a VM). For windows 10 and windows 11 with a virtual box vm-onscreen keyboard, the following happens. The VM soft keyboard does NOT actually send the Shift Shift Key Stroke through but rather will change the keys pressed for example if an `a` is pressed the soft keyboard itself will change that key to a `A`. This means we can't Test TEST_CAPONLY-5 on a soft keyboard. 

### Prerequisites before each test

- Install a keyboard that has the `CapsOnOnly` and `ShiftFreesCaps` stores set, e.g.
   `shift_frees_caps.kmp`.
- CapsLock is currently off
- Currently active keyboard is _shift_frees_caps_ keyboard

### Test cases

<details>
<summary>click to expand</summary>

- **TEST_CAPSONLY-1**: no caps
  - press and release `1`

  Expected result:
  - output: `pass.`

- **TEST_CAPSONLY-2**: caps
  - press and release `CapsLock`
  - press and release `2`

  Expected result:
  - caps lock indicator turned on
  - output: `pass.`

- **TEST_CAPSONLY-3**: caps doesn't toggle
  - press and release `CapsLock`
  - press and release `CapsLock`
  - press and release `6`

  Expected result:
  - caps lock indicator turned on
  - output: `pass.`

- **TEST_CAPSONLY-4**: shift turns off
  - press and release `CapsLock`
  - press and hold `Shift`
  - press and release `3`
  - release `Shift`

  Expected result:
  - caps lock indicator turned off
  - output: `pass.`

- **TEST_CAPSONLY-5**: shift by itself turns off
  Be aware of limitations when testing this on virtual machines as noted above. 
  - press and release `CapsLock`
  - press and release `Shift`

  Expected result:
  - caps lock indicator turned off
  - (no output)

</details>
