### PR TITLE
chore(linux): Don't fail on parallel builds

### DIFF
--- a/linux/scripts/package-build.inc.sh
+++ b/linux/scripts/package-build.inc.sh
@@ -49,6 +49,14 @@ function downloadSource() {
     sha256sum -c --ignore-missing SHA256SUMS |grep "${proj}"
 }
 
+function wait_for_apt_deb {
+    # from https://gist.github.com/hrpatel/117419dcc3a75e46f79a9f1dce99ef52
+    while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock &>/dev/null 2>&1; do
+       echo "Waiting for apt/dpkg lock to release, sleeping 10s"
+       sleep 10
+    done
+}
+
 function checkAndInstallRequirements()
 {
 	local TOINSTALL=""
@@ -63,12 +71,12 @@ function checkAndInstallRequirements()
 	export DEBIAN_FRONTEND=noninteractive
 
 	if [ -n "$TOINSTALL" ]; then
-		sudo apt-get update
+		wait_for_apt_deb && sudo apt-get update
 		# shellcheck disable=SC2086
-		sudo apt-get -qy install $TOINSTALL
+		wait_for_apt_deb && sudo apt-get -qy install $TOINSTALL
 	fi
 
 	sudo mk-build-deps debian/control
-	sudo apt-get -qy --allow-downgrades install ./keyman-build-deps_*.deb
+	wait_for_apt_deb && sudo apt-get -qy --allow-downgrades install ./keyman-build-deps_*.deb
 	sudo rm -f keyman-buid-deps_*
 }


### PR DESCRIPTION
If another package build runs on the same build agent at the same time and installs dependencies at the same time, previously the build failed because apt/dpkg was already running. This change checks for the existence of the apt/dpkg lock file and waits until the other process is finished before starting the installation of dependencies.

@keymanapp-test-bot skip