### PR TITLE
chore(developer): minor patches to fix compile issues 🗜

### DIFF
--- a/core/src/ldml/ldml_transforms.cpp
+++ b/core/src/ldml/ldml_transforms.cpp
@@ -141,13 +141,14 @@ element_list::load(const kmx::kmx_plus &kplus, kmx::KMXPLUS_ELEM id) {
   assert((elementsLength == 0) || (elements != nullptr));
   for (size_t i = 0; i<elementsLength; i++) {
     auto e = elements[i];
-    auto flags = e.flags;
+    KMX_DWORD flags = e.flags;
     auto type = flags & LDML_ELEM_FLAGS_TYPE;
     if (type == LDML_ELEM_FLAGS_TYPE_CHAR) {
-      emplace_back(e.element, flags); // char
+      km_kbp_usv ch = e.element;
+      emplace_back(ch, flags); // char
     } else if (type == LDML_ELEM_FLAGS_TYPE_USET) {
       auto u = kplus.usetHelper.getUset(e.element);
-      emplace_back(u, e.flags);
+      emplace_back(u, flags);
     } else {
       // not handled
       assert((type != LDML_ELEM_FLAGS_TYPE_USET) && (type != LDML_ELEM_FLAGS_TYPE_CHAR));

--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -8,7 +8,7 @@ import { InfrastructureMessages } from '../messages/messages.js';
 import { CompilerFileCallbacks, CompilerOptions, KeymanFileTypes } from '@keymanapp/common-types';
 import { BaseOptions } from '../util/baseOptions.js';
 import { expandFileLists } from '../util/fileLists.js';
-import { isProject } from 'src/util/projectLoader.js';
+import { isProject } from '../util/projectLoader.js';
 
 
 function commandOptionsToCompilerOptions(options: any): CompilerOptions {


### PR DESCRIPTION
Fixes #9377.

1. ldml_transforms.cpp used emplace_back with char instead of dword values (#9377)
2. import was updated to src/ instead of ../ by vscode in build.ts (no related issue)

@keymanapp-test-bot skip