### PR TITLE
fix(web): maintenance of focus when changing keyboard via Toolbar UI

### DIFF
--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -212,8 +212,8 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
 
     if(target == originalTarget) {
       // A focus state may have .currentTarget as null at this stage; if the func
-      // is being called with a non-null parameter, we want this SET.
-      if(target) {
+      // is being called with a non-null parameter, we want this SET. #9404
+      if(originalTarget) {
         this.currentTarget = originalTarget;
       }
 

--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -211,6 +211,12 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
     const originalTarget = this.activeTarget; // may differ, depending on focus state.
 
     if(target == originalTarget) {
+      // A focus state may have .currentTarget as null at this stage; if the func
+      // is being called with a non-null parameter, we want this SET.
+      if(target) {
+        this.currentTarget = originalTarget;
+      }
+
       /**
        * If it's already active, we should cancel early.
        *


### PR DESCRIPTION
Fixes https://github.com/keymanapp/keyman/issues/9404.

It turns out that the issue was due to a small mishandling of state management when in a focus-maintenance state.

## User Testing

TEST_TOOLBAR_KEYBOARD_SWAP:  Using the "Desktop UI module testing" test-page link on a desktop form-factor device...
1. Set the page to use the Toolbar UI.
2. Ensure that any KMW keyboard is active and type a couple of keys.
3. Use the toolbar UI to swap to the Khmer language, then select Khmer Angkor from the keyboard-selection dropdown.
4. With no further mouse interaction anywhere on the page, type the `k` key, then the `a` key.  Verify that Khmer characters are output.