### PR TITLE
chore(linux): Remove Kinetic from GHA

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -103,7 +103,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [focal, jammy, kinetic, lunar]
+        # Currently not building mantic until ibus version on mantic stabilizied
+        # and we can provide a patched version
+        # dist: [focal, jammy, lunar, mantic]
+        dist: [focal, jammy, lunar]
         arch: [amd64]
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Don't build Ubuntu 22.10 Kinetic with packaging GHA.

Also prepare for Ubuntu 23.10 Mantic - we can't currently build that because they are trying to get ibus 1.5.29-beta to work on so there are often new packages. We wait until that stabilized before we're providing a new patched ibus version at which point we can enable building for mantic.
See also #9398.

@keymanapp-test-bot skip