### PR TITLE
chore(linux): Properly treat test builds with packaging GHA

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -18,6 +18,8 @@ jobs:
       VERSION: ${{ steps.version_step.outputs.VERSION }}
       PRERELEASE_TAG: ${{ steps.prerelease_tag.outputs.PRERELEASE_TAG }}
       GIT_SHA: ${{ steps.set_status.outputs.GIT_SHA }}
+      GHA_TEST_BUILD: ${{ github.event.client_payload.isTestBuild }}
+      GHA_BRANCH: ${{ github.event.client_payload.branch }}
     steps:
     - name: Checkout
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0


### PR DESCRIPTION
Previously GHA builds always used the "local" environment. This change now detects test builds as well as release builds and properly sets the environment.

@keymanapp-test-bot skip