### PR TITLE
fix(web): forgot to target es5 when minifying polyfilled worker

### DIFF
--- a/common/web/lm-worker/build-wrap-and-minify.js
+++ b/common/web/lm-worker/build-wrap-and-minify.js
@@ -35,6 +35,7 @@ if(MINIFY) {
     sourcesContent: DEBUG,
     minify: true,
     keepNames: true,
+    target: 'es5',
     outfile: `build/lib/worker-main.polyfilled.min.js`
   });
 }


### PR DESCRIPTION
Fixes #9401.
Fixes #9408.
Fixes Sentry issue: [KEYMAN-WEB-DS](https://keyman.sentry.io/issues/4362964860/?referrer=github_integration).

## User Testing

TEST_ANDROID_5:  Using an Android 5.0 (Lollipop) device with its originally-installed version of Chrome...

1. Install and launch the Keyman app for Android
2. Verify that no errors happen on startup
3. Swap to `sil_euro_latin` for English if it is not already the active keyboard/language combination.
4. Type `app`.
5. Verify that the predictive-text banner is visible and shows reasonable suggestions.

This may be easiest to do through Android Studio emulation.