### PR TITLE
chore(common): Update crowdin GHA to trigger daily

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -2,8 +2,8 @@ name: Upload translation sources to Crowdin translate.keyman.com
 
 on:
   schedule:
-    # At 06:00 every two weeks
-    - cron: '0 6 1,15 * *'
+    # At 06:00 every day. https://crontab.cronhub.io/
+    - cron: '0 6 * * *'
 
 jobs:
   upload-sources-to-crowdin:


### PR DESCRIPTION
For the upcoming Keyman team planning meeting, there was an action to change the Crowdin GHA to trigger from fortnightly to daily.

@keymanapp-test-bot skip
