### PR TITLE
feat(developer): add 'default' property for longpress keys

### DIFF
--- a/common/schemas/keyman-touch-layout/README.md
+++ b/common/schemas/keyman-touch-layout/README.md
@@ -399,6 +399,13 @@ and `width`.
 : Number. Defines the width of the key. Not currently supported for longpress
   keys. See `key` object for details.
 
+* `default`
+
+: Boolean. Defaults to `false`. If true, this will be the default key when the
+  user longpresses the base key without moving their finger. Only one subkey
+  should be default; if multiple subkeys have the default field set, then
+  behaviour is undefined.
+
 ## `flick` object
 
 A object with a set of properties that define flick keys for given directions.
@@ -444,6 +451,9 @@ output .js file, and transforms any legacy formats (such as "number in a
 string") into the appropriate spec format.
 
 # .keyman-touch-layout version history
+
+## 2023-08-08 2.1 stable
+* Add support for default on longpress (sk) keys. Aligns with Keyman 17.0.
 
 ## 2022-06-30 2.0 stable
 * Add support for flick, multitap, hint, defaultHint. Aligns with Keyman 16.0.

--- a/common/schemas/keyman-touch-layout/keyman-touch-layout.spec.json
+++ b/common/schemas/keyman-touch-layout/keyman-touch-layout.spec.json
@@ -131,7 +131,8 @@
         "width": { "$ref" : "#/definitions/numeric" },
         "fontsize": { "$ref": "#/definitions/fontsize-spec" },
         "font": { "$ref": "#/definitions/font-spec" },
-        "dk": { "type": "string" }
+        "dk": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "required": ["id"],
       "additionalProperties": false

--- a/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file-writer.ts
+++ b/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file-writer.ts
@@ -77,6 +77,7 @@ export class TouchLayoutFileWriter {
       if(Object.hasOwn(key, 'text') && key.text === '') delete key.text;
       if(Object.hasOwn(key, 'id') && <string>key.id === '') delete key.id;
       if(Object.hasOwn(key, 'hint') && (<any>key).hint === '') delete (<any>key).hint;
+      if(Object.hasOwn(key, 'default') && (<any>key).default === false) delete (<any>key).default;
     };
 
     const fixupPlatform = (platform: TouchLayoutPlatform) => {

--- a/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file.ts
+++ b/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file.ts
@@ -73,6 +73,7 @@ export interface TouchLayoutSubKey {
   sp?: TouchLayoutKeySp;
   pad?: TouchLayoutKeyPad;
   width?: TouchLayoutKeyWidth;
+  default?: boolean;  // Only used for longpress currently
 };
 
 export interface TouchLayoutFlick {

--- a/developer/src/tike/oskbuilder/TouchLayout.pas
+++ b/developer/src/tike/oskbuilder/TouchLayout.pas
@@ -96,6 +96,7 @@ type
     FPad: Integer;
     FSp: Integer;
     FText: string;
+    FDefault: boolean;
     function GetSpT: TTouchKeyType;   // I4119
     procedure SetSpT(const Value: TTouchKeyType);   // I4119
   protected
@@ -113,6 +114,7 @@ type
     property NextLayer: string read FNextLayer write FNextLayer;
     property Font: string read FFont write FFont;
     property FontSize: string read FFontSize write FFontSize;
+    property Default: boolean read FDefault write FDefault;
   end;
 
   TTouchLayoutSubKeys = class(TObjectList<TTouchLayoutSubKey>)
@@ -734,6 +736,7 @@ begin
   GetValue('pad', FPad);
   GetValue('sp', FSp);
   GetValue('text', FText);
+  GetValue('default', FDefault);
 end;
 
 procedure TTouchLayoutObject.AddJSONValue(JSON: TJSONObject; const name, value: string);
@@ -760,6 +763,7 @@ begin
   if FPad <> 0 then AddJSONValue(JSON, 'pad', IntToStr(FPad));
   if FSp <> 0 then AddJSONValue(JSON, 'sp', IntToStr(FSp));
   AddJSONValue(JSON, 'text', FText);
+  if FDefault then AddJSONValue(JSON, 'default', FDefault);
 end;
 
 function TTouchLayoutSubKey.GetSpT: TTouchKeyType;   // I4119

--- a/developer/src/tike/oskbuilder/TouchLayoutDefinitions.pas
+++ b/developer/src/tike/oskbuilder/TouchLayoutDefinitions.pas
@@ -36,7 +36,7 @@ type
   TJSONDefArray = array of TJSONDef;
 
 const
-  SkDef: array[0..9] of TJSONDef = (
+  SkDef: array[0..10] of TJSONDef = (
     (Name: 'id'; ClassType: TJSONString; Required: True),
     (Name: 'text'; ClassType: TJSONString),
     (Name: 'sp'; ClassType: TJSONValue),
@@ -46,7 +46,8 @@ const
     (Name: 'layer'; ClassType: TJSONString),
     (Name: 'nextlayer'; ClassType: TJSONString),
     (Name: 'font'; ClassType: TJSONString),
-    (Name: 'fontsize'; ClassType: TJSONString)
+    (Name: 'fontsize'; ClassType: TJSONString),
+    (Name: 'default'; ClassType: TJSONBool)
   );
 
   FlickDef: array[0..7] of TJSONDef = (

--- a/developer/src/tike/xml/layoutbuilder/builder.css
+++ b/developer/src/tike/xml/layoutbuilder/builder.css
@@ -307,6 +307,19 @@ body {
   box-shadow: 0px 0px 20px rgba(100, 100, 255, 0.5);
 }
 
+.key.key-is-default {
+  border-width: 4px;
+}
+
+.key.key-is-default .id {
+  bottom: 1px;
+  right: 1px;
+}
+
+.key.key-is-default .text {
+  margin-top: -3px;
+}
+
 .row {
   clear:left;
   line-height: 1;
@@ -576,6 +589,10 @@ body:not(.text-controls-in-toolbar) input#inpSubKeyCap {
   text-align: center;
   border: solid 1px #c0c0c0;
   display: none;
+}
+
+input#chkSubKeyIsDefault {
+  margin-top: 10px;
 }
 
 .key-size {

--- a/developer/src/tike/xml/layoutbuilder/builder.xsl
+++ b/developer/src/tike/xml/layoutbuilder/builder.xsl
@@ -247,6 +247,10 @@
           <label for='selSubKeyNextLayer'>Next Layer:</label>
           <select id='selSubKeyNextLayer'></select>
         </div>
+        <div class='toolbar-item'>
+          <label for='chkSubKeyIsDefault'>Is default:</label>
+          <input id='chkSubKeyIsDefault' type='checkbox' />
+        </div>
       </div>
 
       <!-- Subkey Controls -->

--- a/developer/src/tike/xml/layoutbuilder/prepare-key.js
+++ b/developer/src/tike/xml/layoutbuilder/prepare-key.js
@@ -138,12 +138,17 @@ $(function() {
           .data('nextlayer', key.nextlayer)
           .data('layer', key.layer)
           .data('direction', key.direction) // used only by flicks
+          .data('default', key.default) // used only by longpress
           .css('width', (100 * 0.7) + 'px')
           .css('font-family', key.font)
           .css('font-size', key.fontsize);
 
         if(builder.specialCharacters[text]) {
           $(nkey).addClass('key-special-text');
+        }
+
+        if(key.default) {
+          $(nkey).addClass('key-is-default');
         }
 
         $('.text', nkey).text(builder.renameSpecialKey(text));

--- a/developer/src/tike/xml/layoutbuilder/subkeys.js
+++ b/developer/src/tike/xml/layoutbuilder/subkeys.js
@@ -41,7 +41,8 @@ $(function() {
           fontsize: $(key).data('fontsize'),
           nextlayer: $(key).data('nextlayer'),
           layer: $(key).data('layer'),
-          direction: $(key).data('direction')
+          direction: $(key).data('direction'),
+          default: $(key).data('default')
         });
       }
       return items;
@@ -72,6 +73,7 @@ $(function() {
     $('#selSubKeyType').val($(key).data('sp') ? $(key).data('sp') : 0);
     $('#selSubKeyNextLayer').val($(key).data('nextlayer'));
     $('#selSubKeyLayerOverride').val($(key).data('layer'));
+    $('#chkSubKeyIsDefault').prop('checked', !!$(key).data('default'));
   }
 
   const subKeyNameChange = builder.wrapChange(function () {
@@ -165,6 +167,20 @@ $(function() {
   });
 
   $('#selSubKeyNextLayer').change(selSubKeyNextLayerChange);
+
+  const chkSubKeyIsDefaultChange = builder.wrapChange(function () {
+    // Remove default property from all subkeys
+    $('#sub-key-groups .key-is-default').removeData('default');
+    $('#sub-key-groups .key-is-default').removeClass('key-is-default');
+    if($(this).prop('checked')) {
+      // Then add it to selected key
+      builder.selectedSubKey().data('default', true);
+      builder.selectedSubKey().addClass('key-is-default');
+    }
+    builder.generateSubKeys();
+  });
+
+  $('#chkSubKeyIsDefault').change(chkSubKeyIsDefaultChange);
 
   const selSubKeyLayerOverrideChange = builder.wrapChange(function () {
     $(this).val() === '' ?
@@ -276,6 +292,7 @@ $(function() {
       $('#subKeyToolbar *').removeAttr('disabled');
       $('#subKeyToolbar #inpSubKeyGestureType').attr('disabled', 'disabled');
       $('#sub-key-cap-unicode-toolbar-item, #sub-key-cap-toolbar-item').css('display', builder.specialCharacters[val] ? 'none' : '');
+      $('#chkSubKeyIsDefault').prop('disabled', $(key).data('type') != 'longpress');
     }
   }
 


### PR DESCRIPTION
Fixes #9430.

Adds a 'default' property to subkeys, only used by longpress-type subkeys:

* Added property to schema and readers/writers
* Added property to touch layout validator
* Added editor for property to layout builder

# User Testing

In Keyman Developer, open the touch layout tab in a keyboard. Select a key and create a set of longpress keys.

* **TEST_DEFAULT_PROPERTY**: Select a subkey, and tick the 'Is Default' property. The border of the subkey should be bolded to indicate that it is default. Go to Code view and verify that the property `"default":true` is correctly set for the subkey.
* **TEST_RESET_DEFAULT**: Select the same subkey, and untick the 'Is Default' property on that key. The subkey should lose its bold border. Go to Code view and verify that the property `"default"` is correctly removed for the subkey.
* **TEST_RESET_ALL**: Tick the 'Is Default' property for one subkey. Then, select another subkey under the same key, and tick the 'Is Default' property on that key. The original 'default' subkey should lose its bold border, and the new subkey should have a bolded border. Go to Code view and verify that the property `"default":true` is correctly set for the new subkey, and removed for the old subkey.