### PR TITLE
chore(linux): Disable Mantic builds on Launchpad

### DIFF
--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -33,7 +33,8 @@ else
 fi
 echo "ppa: ${ppa}"
 
-distributions="${DIST:-focal jammy lunar mantic}"
+# distributions="${DIST:-focal jammy lunar mantic}"
+distributions="${DIST:-focal jammy lunar}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
Mantic builds currently fail because there's a newer ibus version in the official Ubuntu repos that overrides our patched ibus version. Ubuntu is trying to get ibus 1.5.29-beta to work so there are often new packages. We wait until that stabilized before we're providing a new patched ibus version at which point we can enable building for Ubuntu 23.10 Mantic.

Closes #9428.

@keymanapp-test-bot skip