### PR TITLE
chore(common): remove deprecated fields from keyboard_info 🎺

### DIFF
--- a/common/schemas/keyboard_info/README.md
+++ b/common/schemas/keyboard_info/README.md
@@ -1,17 +1,18 @@
 # keyboard_info
 
-* **keyboard_info.source.json**
-* **keyboard_info.distribution.json**
+* **keyboard_info.schema.json**
 
 Documentation at https://help.keyman.com/developer/cloud/keyboard_info
 
 * Primary version:
-  * https://github.com/keymanapp/api.keyman.com/tree/master/schemas/keyboard_info.source
-  * https://github.com/keymanapp/api.keyman.com/tree/master/schemas/keyboard_info.distribution
+  * https://github.com/keymanapp/api.keyman.com/tree/master/schemas/keyboard_info
 * Synchronized copies at:
   * https://github.com/keymanapp/keyman/tree/master/common/schemas/keyboard_info
 
 # .keyboard_info version history
+
+## 2023-08-11 2.0 stable
+* Removed legacyId, documentationFilename, documentationFileSize. Source vs distribution keyboard_info distinction is removed.
 
 ## 2019-09-06 1.0.6 stable
 * No changes (see api.keyman.com#36 and api.keyman.com#59. Reverted in 2020-06-10.).

--- a/common/schemas/keyboard_info/keyboard_info.distribution.json
+++ b/common/schemas/keyboard_info/keyboard_info.distribution.json
@@ -1,8 +1,0 @@
-{ 
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "allOf": [
-    { "$ref": "/keyboard_info.source.json#/definitions/KeyboardInfo" },
-    { "required": [ "id", "name", "license", "languages", "lastModifiedDate", "platformSupport" ] }
-  ]
-}

--- a/common/schemas/keyboard_info/keyboard_info.schema.json
+++ b/common/schemas/keyboard_info/keyboard_info.schema.json
@@ -17,13 +17,10 @@
           { "$ref": "#/definitions/KeyboardLanguageInfo" }
         ]},
         "lastModifiedDate": { "type": "string", "format": "date-time" },
-        "links": { "type": "array", "items": { "$ref": "#/definitions/KeyboardLinkInfo" } },
         "packageFilename": { "type": "string", "pattern": "\\.km[xp]$" },
         "packageFileSize": { "type": "number" },
         "jsFilename": { "type": "string", "pattern": "\\.js$" },
         "jsFileSize": { "type": "number" },
-        "documentationFilename": { "type": "string", "pattern": "\\.(rtf|html?|pdf|txt)$" },
-        "documentationFileSize": { "type": "number" },
         "isRTL": { "type": "boolean" },
         "encodings": { "type": "array", "items": { "type": "string", "enum": ["ansi", "unicode"] }, "additionalItems": false },
         "packageIncludes": { "type": "array", "items": { "type": "string", "enum": ["welcome", "documentation", "fonts", "visualKeyboard"] }, "additionalItems": false },
@@ -31,7 +28,6 @@
         "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.\\d$" },
         "helpLink": { "type": "string", "pattern": "^https://help\\.keyman\\.com/keyboard/" },
         "platformSupport": { "$ref": "#/definitions/KeyboardPlatformInfo" },
-        "legacyId": { "type": "number" },
         "sourcePath": { "type": "string", "pattern": "^(release|legacy|experimental)/.+/.+$" },
         "related": { "type": "object", "patternProperties": {
           ".": { "$ref": "#/definitions/KeyboardRelatedInfo" }
@@ -40,9 +36,7 @@
         },
         "deprecated": { "type": "boolean" }
       },
-      "required": [
-        "license", "languages"
-      ]
+      "required": [ "id", "name", "license", "languages", "lastModifiedDate", "platformSupport" ]
     },
 
     "KeyboardLanguageInfo": {
@@ -140,16 +134,6 @@
       "additionalProperties": false
     },
 
-    "KeyboardLinkInfo": {
-      "type": "object",
-      "properties": {
-        "name": { "type": "string" },
-        "url": { "type": "string" }
-      },
-      "required": ["name", "url"],
-      "additionalProperties": false
-    },
-
     "KeyboardPlatformInfo": {
       "type": "object",
       "patternProperties": {
@@ -163,8 +147,7 @@
       "type": "object",
       "properties": {
         "deprecates": { "type": "boolean" },
-        "deprecatedBy": { "type": "boolean" },
-        "note": { "type": "string" }
+        "deprecatedBy": { "type": "boolean" }
       },
       "required": [],
       "additionalProperties": false

--- a/developer/src/inst/download.in.mak
+++ b/developer/src/inst/download.in.mak
@@ -119,7 +119,7 @@ make-kmcomp-install-zip: copy-schemas
         kmconvert.exe \
         sentry.dll sentry.x64.dll \
         kmdecomp.exe \
-        keyboard_info.source.json keyboard_info.distribution.json \
+        keyboard_info.schema.json \
         keyman-touch-layout.spec.json keyman-touch-layout.clean.spec.json \
         xml\layoutbuilder\*.keyman-touch-layout \
         projects\* \
@@ -130,8 +130,7 @@ make-kmcomp-install-zip: copy-schemas
 # ldml-keyboard.schema.json ldml-keyboardtest.schema.json \
 
 copy-schemas:
-    copy $(KEYMAN_ROOT)\common\schemas\keyboard_info\keyboard_info.source.json $(DEVELOPER_ROOT)\bin
-    copy $(KEYMAN_ROOT)\common\schemas\keyboard_info\keyboard_info.distribution.json $(DEVELOPER_ROOT)\bin
+    copy $(KEYMAN_ROOT)\common\schemas\keyboard_info\keyboard_info.schema.json $(DEVELOPER_ROOT)\bin
     copy $(KEYMAN_ROOT)\common\schemas\keyman-touch-layout\keyman-touch-layout.spec.json $(DEVELOPER_ROOT)\bin
     copy $(KEYMAN_ROOT)\common\schemas\keyman-touch-layout\keyman-touch-layout.clean.spec.json $(DEVELOPER_ROOT)\bin
     copy $(KEYMAN_ROOT)\common\schemas\displaymap\displaymap.schema.json $(DEVELOPER_ROOT)\bin

--- a/developer/src/inst/kmdev.wxs
+++ b/developer/src/inst/kmdev.wxs
@@ -184,11 +184,7 @@
       </Component>
 
       <Component>
-        <File Name="keyboard_info.distribution.json" Source="..\..\..\common\schemas\keyboard_info\" KeyPath="yes" />
-      </Component>
-
-      <Component>
-        <File Name="keyboard_info.source.json" Source="..\..\..\common\schemas\keyboard_info\" KeyPath="yes" />
+        <File Name="keyboard_info.schema.json" Source="..\..\..\common\schemas\keyboard_info\" KeyPath="yes" />
       </Component>
 
       <!-- Data Files -->

--- a/developer/src/kmc-keyboard-info/src/index.ts
+++ b/developer/src/kmc-keyboard-info/src/index.ts
@@ -126,10 +126,9 @@ export class KeyboardInfoCompiler {
     }[] = this.loadKmxFiles(sources.kpsFileName, sources.kmpJsonData);
 
     //
-    // Build merged .keyboard_info file
-    // https://api.keyman.com/schemas/keyboard_info.source.json and
-    // https://api.keyman.com/schemas/keyboard_info.distribution.json
-    // https://help.keyman.com/developer/cloud/keyboard_info/1.0
+    // Build .keyboard_info file
+    // https://api.keyman.com/schemas/keyboard_info.schema.json
+    // https://help.keyman.com/developer/cloud/keyboard_info/2.0
     //
 
     keyboard_info.isRTL = keyboard_info.isRTL ?? !!jsFile?.match(/this\.KRTL=1/);

--- a/developer/src/kmc-keyboard-info/src/keyboard-info-file.ts
+++ b/developer/src/kmc-keyboard-info/src/keyboard-info-file.ts
@@ -12,13 +12,10 @@ export interface KeyboardInfoFile {
   license?: "freeware" | "shareware" | "commercial" | "mit" | "other";
   languages?: string[] | {[bcp47: string]: KeyboardInfoFileLanguage};
   lastModifiedDate?: string;
-  links?: KeyboardInfoFileLink[];
   packageFilename?: string;
   packageFileSize?: number;
   jsFilename?: string;
   jsFileSize?: number;
-  documentationFilename?: string;
-  documentationFileSize?: number;
   isRTL?: boolean;
   encodings: KeyboardInfoFileEncodings[];
   packageIncludes?: KeyboardInfoFileIncludes[];
@@ -26,21 +23,14 @@ export interface KeyboardInfoFile {
   minKeymanVersion?: string;
   helpLink?: string;
   platformSupport?: {[id in KeyboardInfoFilePlatform]?: KeyboardInfoFilePlatformSupport};
-  legacyId?: number;
   sourcePath?: string;
   related?: {[id: string]: KeyboardInfoFileRelated};
   deprecated?: boolean;
 }
 
-export interface KeyboardInfoFileLink {
-  name: string;
-  url: string;
-}
-
 export interface KeyboardInfoFileRelated {
-  deprecates?: string;
-  deprecatedBy?: string;
-  note?: string;
+  deprecates?: boolean;
+  deprecatedBy?: boolean;
 }
 
 export interface KeyboardInfoFileLanguage {

--- a/developer/src/test/auto/keyboard-info/test-invalid-language-code.keyboard_info
+++ b/developer/src/test/auto/keyboard-info/test-invalid-language-code.keyboard_info
@@ -1,6 +1,17 @@
 {
+    "id": "test",
+    "name": "test",
     "license": "mit",
     "languages": [
         "foooooooo=amh"
-    ]
+    ],
+    "platformSupport": {
+        "windows": "full",
+        "macos": "full",
+        "desktopWeb": "full",
+        "mobileWeb": "full",
+        "ios": "full",
+        "android": "full"
+    },
+    "lastModifiedDate": "2017-09-06"
 }

--- a/developer/src/test/auto/keyboard-info/test-non-canonical-language-code.keyboard_info
+++ b/developer/src/test/auto/keyboard-info/test-non-canonical-language-code.keyboard_info
@@ -1,6 +1,17 @@
 {
+    "id": "test",
+    "name": "test",
     "license": "mit",
     "languages": [
         "amh"
-    ]
+    ],
+    "platformSupport": {
+        "windows": "full",
+        "macos": "full",
+        "desktopWeb": "full",
+        "mobileWeb": "full",
+        "ios": "full",
+        "android": "full"
+    },
+    "lastModifiedDate": "2017-09-06"
 }

--- a/developer/src/test/auto/keyboard-info/test-valid.keyboard_info
+++ b/developer/src/test/auto/keyboard-info/test-valid.keyboard_info
@@ -1,4 +1,5 @@
 {
+    "id": "test-valid",
     "name": "Balochi Phonetic",
     "jsFilename": "balochi_phonetic-1.1.js",
     "packageFilename": "balochi_phonetic.kmp",

--- a/developer/src/test/auto/keyboard-info/test.bat
+++ b/developer/src/test/auto/keyboard-info/test.bat
@@ -3,6 +3,9 @@ rem We use test.bat so we can test errorlevels
 setlocal
 set ESC=
 
+rem This is temporary until source keyboard_info files go away
+copy "%KEYMAN_ROOT%\common\schemas\keyboard_info\keyboard_info.schema.json" "%KEYMAN_ROOT%\common\schemas\keyboard_info\keyboard_info.source.json"
+
 if "%1"=="-h" goto usage
 if "%1"=="--help" goto usage
 if "%1"=="-?" goto usage
@@ -34,7 +37,7 @@ goto :eof
 
 :should-pass
 echo %BLUE%TEST: %1 %WHITE%
-"%compiler%" -s -vs -schema-path "%KEYMAN_ROOT%\common\schemas\keyboard_info" "%2"
+"%compiler%" -vs -schema-path "%KEYMAN_ROOT%\common\schemas\keyboard_info" "%2"
 if %ERRORLEVEL% EQU 0 (
   echo %GREEN%TEST PASSED%WHITE%
   exit /b 0

--- a/developer/src/tike/compile/MergeKeyboardInfo.pas
+++ b/developer/src/tike/compile/MergeKeyboardInfo.pas
@@ -19,7 +19,6 @@
   # packageFileSize -- get from the size of the file
   # jsFilename -- from $keyboard_info_jsFilename
   # jsFileSize -- get from the size of the file
-  # documentationFileSize -- get from the size of the file
   # isRTL -- from .js, KRTL\s*=\s*1
   # encodings -- from .kmx (existence of .js implies unicode)
   # packageIncludes -- from kmp.inf?
@@ -727,7 +726,7 @@ begin
 end;
 
 //
-// packageFileSize, jsFileSize, documentationFileSize, all from the actual files
+// packageFileSize, jsFileSize, all from the actual files
 //
 procedure TMergeKeyboardInfo.CheckOrAddFileSizes;
   procedure DoFileSize(prefix: string);
@@ -756,7 +755,6 @@ procedure TMergeKeyboardInfo.CheckOrAddFileSizes;
 begin
   DoFileSize('js');
   DoFileSize('package');
-  DoFileSize('documentation');
 end;
 
 //

--- a/developer/src/tike/compile/ValidateKeyboardInfo.pas
+++ b/developer/src/tike/compile/ValidateKeyboardInfo.pas
@@ -1,5 +1,7 @@
 unit ValidateKeyboardInfo;
 
+// TODO: this unit is deprecated
+
 interface
 
 uses


### PR DESCRIPTION
This is the first PR in a chain that addresses #9351.

Removes the following fields:
* legacyId
* documentationFilename
* documentationFileSize
* links
* related[].note

None of these fields are needed any longer; see #9351 for steps to remove data.

Eliminates difference between keyboard_info source and distribution, renaming to keyboard_info.schema.json, and updating the required members of the json accordingly.

This has corresponding PRs against keyman.com, api.keyman.com, help.keyman.com, and keyboards repositories:

- [ ] keymanapp/api.keyman.com#204
- [ ] keymanapp/keyman.com#382
- [ ] keymanapp/help.keyman.com#798
- [x] keymanapp/keyboards#2336
- [x] keymanapp/keyboards#2337

@keymanapp-test-bot skip