### PR TITLE
fix(windows): allow QR share box to grow to edge of default configuration parent window

### DIFF
--- a/windows/src/desktop/kmshell/xml/config.css
+++ b/windows/src/desktop/kmshell/xml/config.css
@@ -1136,7 +1136,7 @@ th
   position: fixed;
   display: none;
   width: 256px;
-  height: 324px;
+  height: auto;
   margin: -180px 0 0 -128px;
   left: 50%;
   top: 50%;
@@ -1149,6 +1149,8 @@ th
 
 .qrcode .qrcode_caption {
   display: block;
+  max-height: 130px;
+  overflow-y: auto;
   white-space: normal;
   font-size: 12pt;
   padding: 8px;


### PR DESCRIPTION
Fixes: #9436
Allow QR box to grow if the caption box is bigger than the English text. Limit of 130px is set if extends further than this then add a vertical scroll for the caption.

In testing no language actually causes the scroll bar to be displayed. However, using dummy text to test the overflow shows that it will handle this should the translation ever reach this length.
![image](https://github.com/keymanapp/keyman/assets/58423624/a610a696-0b70-4f00-9835-61f6274cb61a)

Here is just a screen shot to show the vertical scroll when there is a huge amount of extra text which I don't think we will reach but am handling that use case anyway.
![image](https://github.com/keymanapp/keyman/assets/58423624/8e987a8a-1435-4cec-ad33-421c101d98b1)





# User Testing

# TEST_QR_CAPTION

1. Install Keyman for Windows Build artfifact
2. Open Keyman Configuration dialog. 
3. Install a keyboard. (eg., EuroLatin(SIL) 
4. Open the Keyboard Layout View. 
5. Change the UI into Kannada. 
6. Click Share Keyboard button. 
The QR share box should be large enough to fit the text caption below the QR. 
7. Test for Portuguese, Russian, Mandara, Italian, Ukrainian, Deutsch 

