### PR TITLE
feat(developer): convert markdown description to html 🎺

### DIFF
--- a/developer/src/kmc-keyboard-info/package.json
+++ b/developer/src/kmc-keyboard-info/package.json
@@ -28,7 +28,7 @@
     "@keymanapp/kmc-package": "*"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.7",
+    "@types/chai": "^4.3.5",
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.4.1",
     "c8": "^7.12.0",

--- a/developer/src/kmc-keyboard-info/src/index.ts
+++ b/developer/src/kmc-keyboard-info/src/index.ts
@@ -152,7 +152,7 @@ export class KeyboardInfoCompiler {
     // description
 
     if(sources.kmpJsonData.info.description?.description) {
-      keyboard_info.description = markDownToHTML(sources.kmpJsonData.info.description?.description);
+      keyboard_info.description = sources.kmpJsonData.info.description?.description.trim();
     }
 
     // extract the language identifiers from the language metadata arrays for
@@ -438,10 +438,5 @@ export class KeyboardInfoCompiler {
       );
     }
   }
-
 }
 
-function markDownToHTML(markdown: string): string {
-  // TODO
-  return markdown;
-}

--- a/developer/src/kmc-keyboard-info/test/fixtures/khmer_angkor/build/khmer_angkor.keyboard_info
+++ b/developer/src/kmc-keyboard-info/test/fixtures/khmer_angkor/build/khmer_angkor.keyboard_info
@@ -23,7 +23,7 @@
       "languageName": "Khmer"
     }
   },
-  "description": "Khmer Unicode keyboard layout based on the NiDA keyboard layout. Automatically corrects many common keying errors.",
+  "description": "<p>Khmer Unicode keyboard layout based on the NiDA keyboard layout. Automatically corrects many common keying errors.</p>",
   "related": {
     "khmer10": {
       "deprecates": true

--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "@keymanapp/common-types": "*",
-    "jszip": "^3.7.0"
+    "jszip": "^3.7.0",
+    "marked": "^7.0.0"
   },
   "devDependencies": {
     "@keymanapp/developer-test-helpers": "*",

--- a/developer/src/kmc-package/src/compiler/markdown.ts
+++ b/developer/src/kmc-package/src/compiler/markdown.ts
@@ -1,0 +1,50 @@
+/**
+ * Markdown transform for our `description` field. Tweaked to disable all inline
+ * HTML, because we want descriptions to be short and sweet, and don't need any
+ * of the more complex formatting that inline HTML affords.
+ */
+
+//
+// Note: using marked 7.0.0.
+// https://github.com/markedjs/marked/issues/2926
+//
+// Version 7.0.1 introduced a TypeScript 5.0+ feature `export type *` which causes:
+//
+//   ../../../node_modules/marked/lib/marked.d.ts:722:5 - error TS1383: Only named exports may use 'export type'.
+//   722     export type * from "MarkedOptions";
+//           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// https://github.com/markedjs/marked/compare/v7.0.0...v7.0.1#diff-32d87a2bc59f429470ccf7afc8ae8818914d4d45c3f7c5b1767c6a0a240b55c9R449-R451
+//
+// When we move to TS 5.0, we can upgrade marked.
+//
+import { Marked } from 'marked';
+
+/*
+  Markdown rendering: we don't want to use the global object, because this
+  pollutes the settings for all modules. So we construct our own instance,
+  so that we can strip all inline HTML; we don't need any
+*/
+
+const renderer = {
+  html(_html:string, _block:boolean) {
+    // we don't allow inline HTML
+    return '';
+  }
+}
+const markedStripHtml = new Marked({renderer});
+const marked = new Marked();
+
+/**
+ *
+ * @param markdown
+ * @param allowHTML
+ * @returns
+ */
+export function markdownToHTML(markdown: string, allowHTML: boolean): string {
+  // <string>: .parse can return a Promise if async=true. We don't pass ths
+  // option, and this sync usage isn't separated out in the types for
+  // Marked.prototype.parse, so <string> avoids tsc complaints here.
+  const html = <string> (allowHTML ? marked : markedStripHtml).parse(markdown.trim());
+  return html;
+}

--- a/developer/src/kmc-package/test/fixtures/kmp_2.0/kmp.json
+++ b/developer/src/kmc-package/test/fixtures/kmp_2.0/kmp.json
@@ -26,7 +26,7 @@
       "url": "https://keyman.com/keyboards/khmer_angkor"
     },
     "description": {
-      "description": "# Khmer Angkor\r\n\r\nKhmer Unicode keyboard layout based on the NiDA keyboard layout. Automatically corrects many common keying errors, including:\r\n\r\n* Using wrong vowel combination\r\n* Typing clusters out of order\r\n* Typing wrong mark for consonant shifters\r\n* And more!"
+      "description": "<h1>Khmer Angkor</h1>\n<p>Khmer Unicode keyboard layout based on the NiDA keyboard layout. Automatically corrects many common keying errors, including:</p>\n<ul>\n<li>Using wrong vowel combination</li>\n<li>Typing clusters out of order</li>\n<li>Typing wrong mark for consonant shifters</li>\n<li>And more!</li>\n</ul>"
     }
   },
   "files": [

--- a/developer/src/kmc-package/test/test-markdown.ts
+++ b/developer/src/kmc-package/test/test-markdown.ts
@@ -1,0 +1,20 @@
+import { assert } from 'chai';
+import 'mocha';
+import { markdownToHTML } from '../src/compiler/markdown.js';
+
+describe('markdownToHTML', function () {
+  it('should convert markdown into HTML', function() {
+    const html = markdownToHTML('# heading\n\n**bold** and _beautiful_', true);
+    assert.equal(html, `<h1>heading</h1>\n<p><strong>bold</strong> and <em>beautiful</em></p>\n`);
+  });
+
+  it('should strip inline html if asked to do so', function() {
+    const html = markdownToHTML(`# heading\n\n<script>alert('gotcha')</script>\n\n**bold** and _beautiful_`, false);
+    assert.equal(html, `<h1>heading</h1>\n<p><strong>bold</strong> and <em>beautiful</em></p>\n`);
+  });
+
+  it('should keep inline html if asked to do so', function() {
+    const html = markdownToHTML(`# heading\n\n<script>alert('gotcha')</script>\n\n**bold** and _beautiful_`, true);
+    assert.equal(html, `<h1>heading</h1>\n<script>alert('gotcha')</script>\n\n<p><strong>bold</strong> and <em>beautiful</em></p>\n`);
+  });
+});

--- a/developer/src/kmc/src/commands/buildClasses/BuildKeyboardInfo.ts
+++ b/developer/src/kmc/src/commands/buildClasses/BuildKeyboardInfo.ts
@@ -8,7 +8,6 @@ import { KmpCompiler } from '@keymanapp/kmc-package';
 import { calculateSourcePath } from '../../util/calculateSourcePath.js';
 
 const HelpRoot = 'https://help.keyman.com/keyboard/';
-const LICENSE_FILENAME = 'LICENSE.md';
 
 export class BuildKeyboardInfo extends BuildActivity {
   public get name(): string { return 'Keyboard metadata'; }
@@ -39,8 +38,6 @@ export class BuildKeyboardInfo extends BuildActivity {
       return false;
     }
 
-    const license = project.files.find(file => file.filename == LICENSE_FILENAME);
-
     const keyboard = findProjectFile(callbacks, project, KeymanFileTypes.Source.KeymanKeyboard);
     const kps = findProjectFile(callbacks, project, KeymanFileTypes.Source.Package);
     if(!keyboard || !kps)  {
@@ -57,15 +54,14 @@ export class BuildKeyboardInfo extends BuildActivity {
     const keyboardFileNameJs = project.resolveOutputFilePath(keyboard, KeymanFileTypes.Source.KeymanKeyboard, KeymanFileTypes.Binary.WebKeyboard);
     const keyboard_id = callbacks.path.basename(metadata.filename, KeymanFileTypes.Source.KeyboardInfo);
     const compiler = new KeyboardInfoCompiler(callbacks);
-    const data = compiler.writeMergedKeyboardInfoFile(project.resolveInputFilePath(metadata), {
+    const data = compiler.writeMergedKeyboardInfoFile({
       keyboard_id,
       kmpFilename:  project.resolveOutputFilePath(kps, KeymanFileTypes.Source.Package, KeymanFileTypes.Binary.Package),
       kmpJsonData,
       kpsFilename: project.resolveInputFilePath(kps),
       helpLink: HelpRoot + keyboard_id,
       keyboardFilenameJs: fs.existsSync(keyboardFileNameJs) ? keyboardFileNameJs : undefined,
-      sourcePath: calculateSourcePath(infile),
-      licenseFilename: license ? project.resolveInputFilePath(license) : undefined
+      sourcePath: calculateSourcePath(infile)
     });
 
     if(data == null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -997,10 +997,11 @@
       "name": "@keymanapp/kmc-keyboard-info",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/common-types": "*"
+        "@keymanapp/common-types": "*",
+        "@keymanapp/kmc-package": "*"
       },
       "devDependencies": {
-        "@types/chai": "^4.1.7",
+        "@types/chai": "^4.3.5",
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.4.1",
         "c8": "^7.12.0",
@@ -2138,7 +2139,8 @@
       "license": "MIT",
       "dependencies": {
         "@keymanapp/common-types": "*",
-        "jszip": "^3.7.0"
+        "jszip": "^3.7.0",
+        "marked": "^7.0.0"
       },
       "devDependencies": {
         "@keymanapp/developer-test-helpers": "*",
@@ -7392,8 +7394,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -8510,6 +8513,17 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/marked": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-7.0.0.tgz",
+      "integrity": "sha512-7Gv1Ry8tqR352ElQOQfxdGpIh8kNZh/yYjNCxAQCN1DDbY4bCTG3qDCSkZWlRElSseeEILDxkY/G9w7cgziBNw==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/mdurl": {
@@ -9756,8 +9770,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "license": "MIT",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "engines": {
         "node": ">=6"
       }
@@ -11290,14 +11305,15 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.5.0",
-      "license": "MIT",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {


### PR DESCRIPTION
Next part of kmc work, converts the Markdown description field in the .kps into HTML during the .kmp build. This also filters through to the .keyboard_info file.

@keymanapp-test-bot skip