### PR TITLE
chore(developer): cleanup kmc-keyboard-info interface 🎺

### DIFF
--- a/developer/src/kmc-keyboard-info/test/test-keyboard-info-compiler.ts
+++ b/developer/src/kmc-keyboard-info/test/test-keyboard-info-compiler.ts
@@ -4,7 +4,6 @@ import 'mocha';
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { makePathToFixture } from './helpers/index.js';
 import { KeyboardInfoCompiler } from '../src/index.js';
-import { KmpCompiler } from '@keymanapp/kmc-package';
 
 const callbacks = new TestCompilerCallbacks();
 
@@ -19,18 +18,12 @@ describe('keyboard-info-compiler', function () {
     const kmpFilename = makePathToFixture('khmer_angkor', 'build', 'khmer_angkor.kmp');
     const buildKeyboardInfoFilename = makePathToFixture('khmer_angkor', 'build', 'khmer_angkor.keyboard_info');
 
-    const kmpCompiler = new KmpCompiler(callbacks);
-    const kmpJsonData = kmpCompiler.transformKpsToKmpObject(kpsFilename);
-
     const compiler = new KeyboardInfoCompiler(callbacks);
     const data = compiler.writeMergedKeyboardInfoFile({
       kmpFilename,
-      kmpJsonData,
-      keyboard_id: 'khmer_angkor',
       sourcePath: 'release/k/khmer_angkor',
       kpsFilename,
-      helpLink: 'https://help.keyman.com/keyboard/khmer_angkor',
-      keyboardFilenameJs: jsFilename,
+      jsFilename: jsFilename,
     });
     if(data == null) {
       callbacks.printMessages();

--- a/developer/src/kmc/src/commands/buildClasses/BuildKeyboardInfo.ts
+++ b/developer/src/kmc/src/commands/buildClasses/BuildKeyboardInfo.ts
@@ -4,10 +4,7 @@ import { CompilerCallbacks, CompilerOptions, KeymanDeveloperProject, KeymanFileT
 import { KeyboardInfoCompiler } from '@keymanapp/kmc-keyboard-info';
 import { loadProject } from '../../util/projectLoader.js';
 import { InfrastructureMessages } from '../../messages/infrastructureMessages.js';
-import { KmpCompiler } from '@keymanapp/kmc-package';
 import { calculateSourcePath } from '../../util/calculateSourcePath.js';
-
-const HelpRoot = 'https://help.keyman.com/keyboard/';
 
 export class BuildKeyboardInfo extends BuildActivity {
   public get name(): string { return 'Keyboard metadata'; }
@@ -44,23 +41,14 @@ export class BuildKeyboardInfo extends BuildActivity {
       return false;
     }
 
-    let kmpCompiler = new KmpCompiler(callbacks);
-    let kmpJsonData = kmpCompiler.transformKpsToKmpObject(project.resolveInputFilePath(kps));
-    if(!kmpJsonData) {
-      // Errors will have been emitted by KmpCompiler
-      return false;
-    }
 
-    const keyboardFileNameJs = project.resolveOutputFilePath(keyboard, KeymanFileTypes.Source.KeymanKeyboard, KeymanFileTypes.Binary.WebKeyboard);
-    const keyboard_id = callbacks.path.basename(metadata.filename, KeymanFileTypes.Source.KeyboardInfo);
+    const jsFilename = project.resolveOutputFilePath(keyboard, KeymanFileTypes.Source.KeymanKeyboard, KeymanFileTypes.Binary.WebKeyboard);
+
     const compiler = new KeyboardInfoCompiler(callbacks);
     const data = compiler.writeMergedKeyboardInfoFile({
-      keyboard_id,
       kmpFilename:  project.resolveOutputFilePath(kps, KeymanFileTypes.Source.Package, KeymanFileTypes.Binary.Package),
-      kmpJsonData,
       kpsFilename: project.resolveInputFilePath(kps),
-      helpLink: HelpRoot + keyboard_id,
-      keyboardFilenameJs: fs.existsSync(keyboardFileNameJs) ? keyboardFileNameJs : undefined,
+      jsFilename: fs.existsSync(jsFilename) ? jsFilename : undefined,
       sourcePath: calculateSourcePath(infile)
     });
 


### PR DESCRIPTION
Relates to #9351.

Moves responsibility for loading .kps into kmc-keyboard-info, away from the caller, and removes other fields with kmc-keyboard-info can calculate by itself.

Have not moved project parsing into kmc-keyboard-info, because that's a bigger job, as currently that is mostly happening within kmc itself. A project for a future version I think.

@keymanapp-test-bot skip