### PR TITLE
fix(common): don't crash on illegal unicodesets 🙀

### DIFF
--- a/common/web/types/src/kmx/kmx-plus.ts
+++ b/common/web/types/src/kmx/kmx-plus.ts
@@ -320,12 +320,10 @@ export class VarsItem extends Section {
 export class UnicodeSetItem extends VarsItem {
   constructor(id: string, value: string, sections: DependencySections, usetparser: UnicodeSetParser) {
     super(id, value, sections);
-    // TODO-LDML: err on max buffer size
     const needRanges = sections.usetparser.sizeUnicodeSet(value);
-    this.unicodeSet = sections.usetparser.parseUnicodeSet(value, needRanges);
-
-    // _unicodeSet may be null, indicating this is invalid.
-    // A message will have been set in that case.
+    if (needRanges >= 0) {
+      this.unicodeSet = sections.usetparser.parseUnicodeSet(value, needRanges);
+    } // otherwise: error (was recorded via callback)
   }
   unicodeSet?: UnicodeSet;
   valid() : boolean {


### PR DESCRIPTION
- UnicodeSetItem was ignoring the error value from sizeUnicodeSet() and calling parseUnicodeSet with an invalid size
- it *is* an error, but should be handled properly.
- an error is already recorded in the callback


This may be to better typechecking in wasm-host.js than we had before?

```
     TypeError: Passing a number "-2" from JS side to C/C++ side to an argument of type "unsigned int", which is outside the valid range [0, 4294967295]!
      at checkAssertions (file:///Users/srl295/src/keymanapp/keyman/developer/src/kmc-kmn/src/import/kmcmplib/wasm-host.js:2861:17)
      at Object.toWireType (file:///Users/srl295/src/keymanapp/keyman/developer/src/kmc-kmn/src/import/kmcmplib/wasm-host.js:2867:11)
      at Object.kmcmp_parseUnicodeSet (eval at newFunc (file:///Users/srl295/src/keymanapp/keyman/developer/src/kmc-kmn/src/import/kmcmplib/wasm-host.js:2419:27), <anonymous>:9:26)
      at KmnCompiler.parseUnicodeSet (file:///Users/srl295/src/keymanapp/keyman/developer/src/kmc-kmn/src/compiler/compiler.ts:439:23)
      at new UnicodeSetItem (file:///Users/srl295/src/keymanapp/keyman/common/web/types/src/kmx/kmx-plus.ts:325:43)
      at VarsCompiler.addUnicodeSet (file:///Users/srl295/src/keymanapp/keyman/developer/src/kmc-ldml/src/compiler/vars.ts:247:29)
      at file:///Users/srl295/src/keymanapp/keyman/developer/src/kmc-ldml/src/compiler/vars.ts:211:12
      at Array.forEach (<anonymous>)
      at VarsCompiler.compile (file:///Users/srl295/src/keymanapp/keyman/developer/src/kmc-ldml/src/compiler/vars.ts:210:28)
      at loadSectionFixture (file:///Users/srl295/src/keymanapp/keyman/developer/src/kmc-ldml/test/helpers/index.ts:86:19)
      at Context.<anonymous> (file:///Users/srl295/src/keymanapp/keyman/developer/src/kmc-ldml/test/helpers/index.ts:210:21)
```

For: #7377

@keymanapp-test-bot skip
