### PR TITLE
chore(android): Update targetSDKVersion to 33 🏠

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -10,8 +10,7 @@ ext.rootPath = '../../'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -7,8 +7,7 @@ ext.rootPath = '../../'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 21

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
       </intent>
     </queries>
 
+    <!-- https://developer.android.com/develop/ui/views/notifications/notification-permission#declare -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <!-- Ensure these permissions aren't added by dependencies unless calling app intentionally adds them -->

--- a/android/README.md
+++ b/android/README.md
@@ -110,8 +110,7 @@ Keyman Engine for Android library (**keyman-engine.aar**) is now ready to be imp
 4. Check that the `android{}` object, includes the following:
 ```gradle
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -4,8 +4,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -4,8 +4,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -7,7 +7,7 @@ ext.rootPath = '../../../'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -8,8 +8,7 @@ ext.rootPath = '../../../../android'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Fixes #9493 for stable-16.0

Google Play Store is requiring Android apps to target API 33 by August 31, 2023.
This 🍒 -picks portions from #7897.

## User Testing
Setup - Install the PR builds of Keyman for Android and FirstVoices for Android on an Android device/emulator

* **TEST_KEYMAN** - Verifies the Keyman app functions
1. Launch Keyman
2. Complete the "Getting Started" steps of installing a Keyman keyboard and setting Keyman as a default system keyboard
3. Verifiy the installed Keyboard functions
4. Launch a separate app (e.g. Google Chrome) and select a text area to type in
5. With Keyman as the system keyboard, verify the keyboard functions.

* **TEST_FV** - Verifies the FirstVoices Android app functions
1. Launch FirstVoices for Android
2. Complete the menu items of selecting an FV keyboard to install and setting FirstVoices as the default system keyboard
3. Launch a separate app (e.g. Google Chrome) and select a text area to type in
5. With FirstVoices as the system keyboard (make sure not the Keyman keyboard from before), verify the FirstVoices keyboard functions.
 