### PR TITLE
fix(linux): Fix exception in km-kvk2ldml

### DIFF
--- a/linux/keyman-config/km-kvk2ldml
+++ b/linux/keyman-config/km-kvk2ldml
@@ -42,14 +42,25 @@ def main():
     if args.print:
         print_kvk(kvkData, args.keys)
 
-    if args.output:
-        outputfile = args.output
-    else:
-        outputfile = name + ".ldml"
+    outputfile = args.output if args.output else f'{name}.ldml'
 
-    with open(outputfile, 'wb') as ldmlfile:
-        ldml = convert_ldml(kvkData)
-        output_ldml(ldmlfile, ldml)
+    dirname = os.path.dirname(outputfile)
+    if not os.path.isdir(dirname):
+        if os.path.exists(dirname):
+            logging.error(f'km-kvk2ldml: error, `{dirname}` exists but is not a directory')
+            sys.exit(3)
+        os.makedirs(dirname)
+
+    try:
+        with open(outputfile, 'wb') as ldmlfile:
+            ldml = convert_ldml(kvkData)
+            output_ldml(ldmlfile, ldml)
+    except PermissionError:
+        logging.error(f'km-kvk2ldml: error, permission denied writing file `{outputfile}`')
+        sys.exit(4)
+    except IsADirectoryError:
+        logging.error(f'km-kvk2ldml: error, cannot create file `{outputfile}` - it is a directory')
+        sys.exit(5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change fixes an exception that occurs if the user specifies an outputfile in a non-existing directory. Also catch several other related exceptions.

Fixes #9522.

@keymanapp-test-bot skip