### PR TITLE
docs(linux): Explicitly specify emscripten version

### DIFF
--- a/docs/build/linux-ubuntu.md
+++ b/docs/build/linux-ubuntu.md
@@ -69,8 +69,8 @@ You'll also have to install `emscripten` (version 3.1.44 is known to work):
 ```shell
 git clone https://github.com/emscripten-core/emsdk.git
 cd emsdk
-./emsdk install latest
-./emsdk activate latest
+./emsdk install 3.1.44
+./emsdk activate 3.1.44
 export EMSCRIPTEN_BASE=$(pwd)/upstream/emscripten
 ```
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -40,8 +40,8 @@ RUN curl -sL https://deb.nodesource.com/setup_18.x | bash && \
 RUN cd /usr/share && \
   git clone https://github.com/emscripten-core/emsdk.git && \
   cd emsdk && \
-  ./emsdk install latest && \
-  ./emsdk activate latest && \
+  ./emsdk install 3.1.44 && \
+  ./emsdk activate 3.1.44 && \
   echo "#!/bin/bash" > /usr/bin/bashwrapper && \
   echo "export EMSCRIPTEN_BASE=/usr/share/emsdk/upstream/emscripten" >> /usr/bin/bashwrapper
 


### PR DESCRIPTION
emscripten 3.1.44 works, but 3.1.45 fails, so this change modifies the documentation to explicitly request `3.1.44` instead of `latest`.

@keymanapp-test-bot skip