### PR TITLE
chore(linux): Add `clean` target to `rules`

### DIFF
--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -73,3 +73,11 @@ override_dh_auto_install:
 
 override_dh_missing:
 	dh_missing --fail-missing
+
+override_dh_auto_clean:
+	core/build.sh clean
+	linux/ibus-keyman/build.sh clean
+	linux/keyman-system-service/build.sh clean
+	linux/keyman-config/build.sh clean
+	rm -rf .pybuild/
+	dh_auto_clean $@

--- a/linux/keyman-config/build.sh
+++ b/linux/keyman-config/build.sh
@@ -26,8 +26,17 @@ builder_describe_outputs \
   build "/linux/keyman-config/keyman_config/standards/lang_tags_map.py"
 
 clean_action() {
-  rm -rf dist make_deb build keyman_config/version.py ./*.egg-info __pycache__ \
-    keyman_config/standards/lang_tags_map.py
+  rm -rf dist make_deb build ./*.egg-info keyman_config/version.py
+  find . \( -name __pycache__ -o -name keyman-config.mo \) -exec rm -rf {} +
+  rm -rf ../help/reference/km-*.md
+
+  # Don't delete this file during a package build because they are
+  # part of the source package. We can't generate it during a package
+  # build because we need to get data from the network which isn't
+  # available for package builds.
+  if [ -z "${KEYMAN_PKG_BUILD-}" ]; then
+    rm -rf keyman_config/standards/lang_tags_map.py
+  fi
 }
 
 execute_with_temp_schema() {

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -48,6 +48,7 @@ dpkg-source --tar-ignore=*~ --tar-ignore=.git --tar-ignore=.gitattributes \
     \
     --tar-ignore=core/build \
     --tar-ignore=developer --tar-ignore=docs --tar-ignore=ios \
+    --tar-ignore=linux/keyman-config/keyman_config/version.py \
     --tar-ignore=linux/keyman-config/buildtools/build-langtags.py --tar-ignore=__pycache__ \
     --tar-ignore=linux/help \
     --tar-ignore=mac --tar-ignore=node_modules --tar-ignore=oem \


### PR DESCRIPTION
This allows to completely cleanup after a package build. Also fixes `keyman-config/build.sh` to do a better job with clean.

Fixes #9518.

@keymanapp-test-bot skip