### PR TITLE
chore(linux): Add `clean` target to `rules` 🍒 🏠

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,9 @@
+keyman (16.0.141-2) UNRELEASED; urgency=medium
+
+  * Fix failure to build source after successful build (Closes #1046776)
+
+ -- Eberhard Beilharz <eb1@sil.org>  Thu, 31 Aug 2023 17:30:34 +0200
+
 keyman (16.0.141-1) unstable; urgency=medium
 
   * Work around mips64el build failure (#1041499)

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -43,6 +43,7 @@ override_dh_auto_build:
 	cd linux/ibus-keyman && make
 	# keyman-config
 	cd linux/keyman-config && \
+		./version.sh && \
 		make man && \
 		sed -i -e "s/^__pkgversion__ = \"[^\"]*\"/__pkgversion__ = \"$(DEB_VERSION)\"/g" keyman_config/version.py && \
 		make compile-po
@@ -77,3 +78,11 @@ override_dh_auto_install:
 
 override_dh_missing:
 	dh_missing --fail-missing
+
+override_dh_auto_clean:
+	cd core && ./build.sh clean
+	cd linux/ibus-keyman && make distclean || true
+	rm -f linux/ibus-keyman/VERSION
+	cd linux/keyman-config && make clean
+	rm -rf .pybuild/
+	dh_auto_clean $@

--- a/linux/keyman-config/Makefile
+++ b/linux/keyman-config/Makefile
@@ -35,8 +35,9 @@ uninstall: clean # run as sudo
 	rm -f /usr/local/bin/km-package-uninstall
 
 clean:
-	-rm -rf dist make_deb build keyman_config/version.py *.egg-info __pycache__ \
-		keyman_config/standards/lang_tags_map.py
+	-rm -rf dist make_deb build *.egg-info keyman_config/version.py
+	-find . \( -name __pycache__ -o -name keyman-config.mo \) -exec rm -rf {} +
+	-[ -z "$(KEYMAN_PKG_BUILD)" ] && rm -rf keyman_config/standards/lang_tags_map.py
 
 devdist: version
 	python3 setup.py egg_info -b.`TZ=UTC git log -1 --pretty=format:%cd --date=format-local:%Y%m%d%H%M` sdist

--- a/linux/keyman-config/version.sh
+++ b/linux/keyman-config/version.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Helper script for 16.0 to generate version.py without redefining
+# version variables that we already have in build-utils.sh
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+cd "$THIS_SCRIPT_PATH"
+
+pushd keyman_config
+sed \
+    -e "s/_VERSION_/${VERSION}/g" \
+    -e "s/_VERSIONWITHTAG_/${VERSION_WITH_TAG}/g" \
+    -e "s/_VERSIONGITTAG_/${VERSION_GIT_TAG}/g" \
+    -e "s/_MAJORVERSION_/${VERSION_MAJOR}/g" \
+    -e "s/_RELEASEVERSION_/${VERSION_RELEASE}/g" \
+    -e "s/_TIER_/${TIER}/g" \
+    -e "s/_ENVIRONMENT_/${VERSION_ENVIRONMENT}/g" \
+    -e "s/_UPLOADSENTRY_/${UPLOAD_SENTRY}/g" \
+    version.py.in > version.py
+popd

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -72,6 +72,7 @@ for proj in ${extra_projects}; do
         --tar-ignore=common/resources --tar-ignore=common/schemas \
         --tar-ignore=common/test --tar-ignore=common/web --tar-ignore=common/windows \
         --tar-ignore=developer --tar-ignore=docs --tar-ignore=ios \
+        --tar-ignore=linux/keyman-config/keyman_config/version.py \
         --tar-ignore=linux/keyman-config/buildtools/build-langtags.py --tar-ignore=__pycache__ \
         --tar-ignore=linux/help --tar-ignore=linux/Jenkinsfile \
         --tar-ignore=linux/keyboardprocessor --tar-ignore=linux/legacy \


### PR DESCRIPTION
This allows to completely cleanup after a package build. We no longer include `version.py` in the source package. Instead this
change adds a `version.sh` script that allows to create `version.py` during a package build where we don't ship `linux/scripts/*` which contains the scripts that usually create that file. This is a workaround for 16.0 - `master` already generates `version.py` in a different way.

Fixes #9518.

Modified :cherries:-pick of #9531.

@keymanapp-test-bot skip