### PR TITLE
chore: workaround npm/cli#3466 when bundling internal deps

### DIFF
--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -133,6 +133,10 @@ fi
 if builder_start_action publish; then
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
+  # To ensure that we cache the top-level package.json, we must call this before
+  # the global publish
+  builder_publish_cleanup
+
   # For now, kmc will have responsibility for publishing keyman-version and
   # common-types, as well as all the other dependent modules. In the future, we
   # should probably have a top-level npm publish script that publishes all
@@ -143,14 +147,20 @@ if builder_start_action publish; then
 
   # Finally, publish kmc
   builder_publish_to_npm
+  builder_publish_cleanup
   builder_finish_action success publish
 elif builder_start_action pack; then
   . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+
+  # To ensure that we cache the top-level package.json, we must call this before
+  # the global pack
+  builder_publish_cleanup
 
   for package in "${PACKAGES[@]}"; do
     "$KEYMAN_ROOT/$package/build.sh" pack $DRY_RUN
   done
 
   builder_publish_to_pack
+  builder_publish_cleanup
   builder_finish_action success pack
 fi


### PR DESCRIPTION
Works around npm/cli#3466 when bundling internal dependencies using the bundleDependencies package.json property.

This change works in tandem with the npm pack/publish process -- when we run `developer/src/kmc/build.sh publish` (or `pack`), we end up with `npm version` stomping on all our package.json files, so the repo is dirty after this. We need a copy of the top-level package.json before this stomping happens, in order to get a simple map of the location of each of our internal dependencies, from the `dependencies` property (it would be possible to figure this out with a lot more parsing of our package.json files, but this is simpler).

This means, in future, we should avoid publishing our internal dependencies such as those under common/ to npm, as they serve no practical purpose there.

I will cherry-pick this commit onto my epic-package-metadata branch in order to move it forward, but felt like this belonged separately.

Note: there are not packages making use of this functionality in this branch; see #9535 for this in use in kmc-keyboard-info, kmc-model-info.

@keymanapp-test-bot skip