### PR TITLE
fix(linux): Prevent exception if neither USER, LOGNAME nor SUDO_USER set 🏠🍒

### DIFF
--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -88,6 +88,10 @@ def verify_ibus_daemon(start):
     elif not user:
         user = os.environ.get('LOGNAME')
 
+    if not user:
+        logging.debug('Neither SUDO_USER, USER nor LOGNAME set. Skipping ibus-daemon check.')
+        return
+
     try:
         ps = subprocess.run(('ps', '--user', user, '-o', 's=', '-o', 'cmd'), stdout=subprocess.PIPE).stdout
         ibus_daemons = re.findall('^[^ZT] ibus-daemon .*--xim.*', ps.decode('utf-8'), re.MULTILINE)


### PR DESCRIPTION
Closes #9542.

(🍒-picked from PR #9543 )

@keymanapp-test-bot skip