### PR TITLE
chore(common): Add Crowdin strings for Mon

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values-mnw-rMM/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-mnw-rMM/strings.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- app_name removed in 16.0 beta. Set in build.gradle -->
+  <!-- Context: Menu Action -->
+  <string name="action_share" comment="Menu action to send text content to another app">ပါ်ပရအ်</string>
+  <!-- Context: Menu Action -->
+  <string name="action_web" comment="Menu action to open Keyman browser">ဝေက်ဗရဴသာ</string>
+  <!-- Context: Menu Action -->
+  <string name="action_text_size" comment="Menu action to adjust text size">အဝဲမလိက်</string>
+  <!-- Context: Menu Action -->
+  <string name="action_overflow" comment="Show additional menu items">ဂၠိုၚ်နူဏံ</string>
+  <!-- Context: Menu Action -->
+  <string name="action_clear_text" comment="Menu action to erase text">ပလီုလိက်</string>
+  <!-- Context: Menu Action -->
+  <string name="action_info" comment="Menu action to display Keyman help page">တၚ်နၚ်</string>
+  <!-- Context: Menu Action -->
+  <string name="action_settings" comment="Menu action to open Settings menu">ဒၞါဲပလေဝ်နာနာ</string>
+  <!-- Context: Menu Action -->
+  <string name="action_install_updates" comment="Menu notification that keyboard or dictionary updates available">ပ္တိုန်စုတ်က္ဆံၚ်ဂမၠိုၚ်</string>
+  <!-- Context: Title -->
+  <string name="title_version" comment="Title of Keyman for Android version">ပါယှေန်: %1$s</string>
+  <!-- Context: Text label when old Chrome version installed -->
+  <string name="text_require_chrome_57" comment="Banner text when old version of Chrome is installed">    ကဳမာန် ဒးသုၚ်စောဲ Chrome ပါယှေန် ၅၇ အေန်အိုတ်ဟွံသေၚ်မ္ဂး သၠုၚ်နူဂှ်။</string>
+  <!-- Context: Button label -->
+  <string name="button_update_chrome" comment="Prompt to upgrade Chrome in the Play Store">သၠုၚ်ပ္တိုန်က္ဆံၚ် Chrome</string>
+  <!-- Context: Textfield prompt (&#8230; is the ellipsis character "...") -->
+  <string name="textview_hint" comment="Prompt to start typing">စတက်လိက်ဒၞာဲဏံ&#8230;</string>
+  <!-- Context: Splash screen (version/copyright info currently disabled -->
+  <string name="splash_blank" translatable="false" comment="Blank text while version info on splash page is disabled"></string>
+  <!-- Context: Splash screen (version/copyright info currently disabled -->
+  <!-- Context: Text Size dialog -->
+  <string name="text_size" comment="Current text size (number)">အဝဲမလိက်: %1$d</string>
+  <!-- Context: Text Size dialog -->
+  <string name="ic_text_size_up" comment="Make text bigger">အဝဲမလိက်လ္တူ</string>
+  <!-- Context: Text Size dialog -->
+  <string name="ic_text_size_down" comment="Make text smaller">ဗၞတ်ဗ္ၜတ်မလိက်သၟဝ်</string>
+  <!-- Context: Text Size dialog -->
+  <string name="ic_text_size_slider" comment="Adjust text size">တသောဝ်ဖျေံ အဝဲမလိက်</string>
+  <!-- Context: Clear Text dialog -->
+  <string name="all_text_will_be_cleared" comment="Erase all the text">\nလိက်သီုဖအိုတ်ဂှ် သ္အးထောံရောၚ်\n</string>
+  <!-- Context: Get Started menu -->
+  <string name="get_started" comment="Menu for getting started">စတရဴစိုအ်</string>
+  <!-- Context: Get Started menu -->
+  <string name="add_a_keyboard" comment="Menu item to add a keyboard">စုတ်ကဳဗုဒ်သွက်ဘာသာမၞးညိ</string>
+  <!-- Context: Get Started menu -->
+  <string name="enable_system_keyboard" comment="Menu item to enable Keyman as system keyboard">သ္ပဒတန်ကဳမာန် နကဵု ကဳဗုဒ်အလုံစက်</string>
+  <!-- Context: Get Started menu -->
+  <string name="set_keyman_as_default" comment="Menu item to set Keyman as default system keyboard">ကဳမာန်ဂှ် စွံနဒဒှ်ကဳဗုဒ်ပကတိညိ</string>
+  <!-- Context: Get Started menu -->
+  <string name="more_info" comment="Open the Keyman for Android help page">တၚ်နၚ်ဂမၠိုၚ်</string>
+  <!-- Context: Get Started menu -->
+  <string name="show_get_started" comment="Show the &quot;Get Started&quot; menu on startup">ကာလစပ္တံမ္ဂး ထ္ၜး “%1$s”ညိ</string>
+  <!-- Context: Android Storage Permission -->
+  <string name="request_storage_permission" comment="Request storage permission to access keyboard packages">သွက်ဂွံစုတ်ပက်ကေကဳဗုဒ်ဂမၠိုၚ်ကီု, သွက်ဂွံဗှ်အရာမစွံပ္တန်လဝ်မ္ၚးတအ်မာန်ကီုဂှ် ပံက်ကဵုအခေါၚ် ကဳမာန်ညိ</string>
+  <!-- Context: Android Storage Permission -->
+  <string name="storage_permission_denied" comment="Keyboard package installation may fail since Android storage permission not granted">အခေါၚ်သွက်ဂွံစွံပ္တန်ဂှ် တးပါဲလဝ်ရ။ သွက်ဂွံစုတ်ပက်ကုက်ကဳဗုဒ်လေဝ် လီုအာမာန်ရ။</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="keyman_settings" comment="Settings menu title">ဒၞါဲပလေဝ်နာနာ</string>
+  <!-- Context: Keyman Settings menu -->
+  <plurals name="installed_languages">
+    <item quantity="other">အရေဝ်ဘာသာ (%1$d) စုတ်လဝ် တုဲတုဲဂမၠိုၚ်</item>
+  </plurals>
+  <!-- Context: Keyman Settings menu -->
+  <string name="install_keyboard_or_dictionary" comment="Menu item to install keyboard or dictionary">စုတ် ကဳဗုဒ် ဟွံသေၚ်မ္ဂး အဘိဓာန်</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="change_display_language" comment="Menu action to change interface language">ဘာသာဓမံက်ထ္ၜး</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="adjust_keyboard_height" comment="Menu action to adjust keyboard height">ချိၚ်ဆသမၠုၚ်ကဳဗုဒ်ညိ</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="spacebar_caption" comment="Menu action to set the spacebar caption">က္တိုပ်လိက် Spacebar</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_keyboard" comment="Spacebar caption option - keyboard">ကဳဗုဒ်</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language" comment="Spacebar caption option - language">အရေဝ်ဘာသာ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_language_keyboard" comment="Spacebar caption option - language + keyboard">ဘာသာ + ကဳဗုဒ်</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption -->
+  <string name="spacebar_caption_blank" comment="Spacebar caption option - blank">သၠး</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_keyboard" comment="Spacebar caption hint - keyboard">ပ္ဍဲ spacebar ဂှ် ထ္ၜးယၟုကဳဗုဒ်ညိ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language" comment="Spacebar caption hint - language">ပ္ဍဲ spacebar ဂှ် ထ္ၜးယၟုအရေဝ်ဘာသာညိ</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_language_keyboard" comment="Spacebar caption hint - language + keyboard">ကဳဗုဒ် ကေုာံ အရေဝ်ဘာသာ
+ပ္ဍဲspacebar</string>
+  <!-- Context: Keyman Settings menu / Spacebar caption hint -->
+  <string name="spacebar_caption_hint_blank" comment="Spacebar caption hint - blank">လ္ပဓမံက်ထ္ၜးမလိက်ပ္ဍဲspacebarညိ</string>
+  <!-- Context: Keyman Settings menu / Haptic feedback -->
+  <string name="haptic_feedback" comment="haptic feedback on key press">ပ္ဍဲကာလမတက်လိက် ချဳဒတဝ်ညိ</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_banner" comment="text suggestions banner">ဓမံက်ထ္ၜးbannerလၟိုန်ညိ</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_banner_on" comment="Description when toggle is on">သွက်ဂွံဓမံက်ရုပ်ရဴ</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_banner_off" comment="Description when toggle is off">ကၟာတ်လဝ်မ္ဂး မလိက်ချိၚ်ဆလဝ်တံဂှ် ထ္ၜးအဃောပံက်လဝ်ဟေၚ်</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_send_crash_report" comment="permission for sending crash reports">ကဵုအခေါၚ် ပၠံၚ်လိက်စဳရေၚ်လ္တူ အေန်တာနက်ညိ</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_send_crash_report_on" comment="Description when toggle is on">ယဝ်ပံက်လဝ်မ္ဂး လိက်ဒုၚ်စဳရေၚ်ဂှ်ပၠံၚ်ဏာရောၚ်</string>
+  <!-- Context: Keyman Settings menu -->
+  <string name="show_send_crash_report_off" comment="Description when toggle is off">ယဝ်ကၟာတ်လဝ်မ္ဂး လိက်ဒုၚ်စဳရေၚ်ဂှ် ဟွံပၠံၚ်ရ။.</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="install_from_keyman_dot_com" comment="Install package from Keyman server">စုတ်နူ keyman.com</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="install_from_local_file" comment="Install package file from local device">စုတ်နူ ဝှါၚ် ပ္ဍဲစက်</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="install_from_other_device" comment="Scan QR Code">စုတ်နူစက်တၞဟ်ဟ်</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="add_languages_to_installed_keyboard" comment="Install additional languages from a keyboard package">ဂွံစုတ်ကဳဗုဒ်ဂှ် ထပ်စုတ် အရေဝ်ဘာသာဂမၠိုၚ်</string>
+  <!-- Context: Keyman Settings "Install Keyboard or Dictionary" menu -->
+  <string name="add_language_subtext" comment="Additional information for adding another language">(နူကဵုပက်ကေ ကဳဗုဒ်)</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="title_select_keyboard_package_list" comment="Select a keyboard package to add languages">ရုဲစှ်ကဳဗုဒ်ပက်ကေ</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="title_select_languages_for_package" comment="Select language names from the keyboard package">ရုဲစှ်အရေဝ်ဘာသာ%1$s</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="added_language_to_keyboard" comment="Notification that a language name is added to a keyboard">စုတ်လဝ်ဘာသာနူ %1$s စိုပ် %2$s တုဲရ</string>
+  <!-- Context: Select Package and Select Languages menu -->
+  <string name="all_languages_installed" comment="Text when all languages from a keyboard package have been installed">စုတ်ဘာသာသီုဖအိုတ်တုဲ</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="drag_the_keyboard" comment="First line of adjusting keyboard height">သ္ဂောံချိၚ်သမၠုၚ် ကဳဗုဒ်ဂှ် ဂြဲညိ</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="rotate_the_device" comment="Second line of adjusting keyboard height">ဂွံချိၚ် လံက်သတိက် လံက်ဇမၠိၚ်ဂှ် ဗဂေတ်ကဵုစက်ပိုဲညိ။</string>
+  <!-- Context: Adjust Keyboard Height menu -->
+  <string name="reset_to_defaults" comment="Button to reset to default heights">ကလေၚ်သ္ပနူပကတိ</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="hint_text" comment="Prompt to type in the browser search bar">ဂၠာဲ ဟွံသေၚ် တက် URL</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="title_bookmarks" comment="Title for bookmarks">သမ္တီမုက်လိက်ဂမၠိုၚ်</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="no_bookmarks" comment="Text when bookmark list is empty">မုက်လိက်သမ္တီလဝ်ဂမၠိုၚ်ဟွံမွဲ</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="add_bookmark" comment="Confirmation to add bookmark">စွံ သမ္တီမုက်လိက်</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="hint_title" comment="Page title for saved bookmark">မာတိကာ</string>
+  <!-- Context: Keyman Web Browser -->
+  <string name="hint_url" comment="Page URL for saved bookmark">Url</string>
+  <!-- Context: KMP Package strings -->
+  <string name="title_package_failed_to_install" comment="Error dialog title when package failed to install">ပက်ကေ %1$s ဂှ် ပ္တိုန်စုတ်ဟွံအံၚ်ဇၞး</string>
+  <!-- Context: KMP Package strings -->
+  <string name="downloading_keyboard_package" comment="Confirmation to download keyboard package filename">အဃောဂြဲဖျေံဒၟံၚ် ပက်ကေကဳဗုဒ်\n&amp;%1$s&#8230;</string>
+  <!-- Context: KMP Package strings -->
+  <string name="failed_to_extract" comment="Notification that keyboard package failed to unzip">သှ် ဟွံအံၚ်ဇၞး</string>
+  <!-- Context: KMP Package strings -->
+  <string name="install_keyboard_package" comment="Title to install keyboard package">စုတ်ကဳဗုဒ်</string>
+  <!-- Context: KMP Package strings -->
+  <string name="install_predictive_text_package" comment="Title to install dictionary package">စုတ်အဘိဓာန်</string>
+  <!-- Context: KMP Package strings -->
+  <string name="not_valid_package_file" comment="Notification when invalid package file cannot be installed">%1$s ဂှ် ဝှါၚ်ပက်ကေ ကဳမာန် ဟွံသေၚ်ရ။\n%2$s\"</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_new_touch_keyboards_to_install" comment="Notification when no touch-optimized keyboards can be installed">ပက်ကေ ကဳဗုဒ် ဂှ် ကဳဗုဒ် လုက်စုက် သမၠုၚ်လဝ်ကဆံၚ် ဂမၠိုၚ်ဟွံဂွံစုတ်လဝ်ရ။</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_new_predictive_text_to_install" comment="Notification when no dictionaries can be installed">မလိက်ခယျတၟိ ဟွံစုတ်လဝ်ရ။</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_targets_to_install" comment="Notification when a package doesn't contain keyboards or dictionaries">မလိက်ခယျတၟိ ဟွံစုတ်လဝ်ရ။</string>
+  <!-- Context: KMP Package strings -->
+  <string name="no_associated_languages" comment="Notification when a keyboard package doesn't contain languages">ပ္ဍဲပက်ကေ ကဳဗုဒ်ဏံ ဘာသာ မဆက်စပ်ဂမၠိုၚ် ဟွံပ္တိုန်စုတ်လဝ်ရ</string>
+  <!-- Context: KMP Package strings -->
+  <string name="invalid_metadata" comment="kmp.json metadata file is invalid or missing in package">မဳတာဒေတာ ပ္ဍဲပက်ကေဏံ သုၚ်စောဲ ဟွံဂွံ/ကၠေံမံၚ်ရ။</string>
+  <!-- Context: KMP Package strings -->
+  <string name="minimum_keyboard_version_not_supported" comment="Notification when keyboard has functionality not supported by current Keyman">    ကဳဗုဒ်ဏံ နွံပၟိက်ကု ပါယှေန် ကဳမာန်တၟိ</string>
+  <!-- Context: anywhere -->
+  <string name="unable_to_open_browser" comment="Notification when a browser activity cannot be launched">ပံက် ဝေက်ဗရဴသာဟွံဂွံ</string>
+</resources>

--- a/android/KMEA/app/src/main/java/com/keyman/engine/DisplayLanguages.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/DisplayLanguages.java
@@ -58,6 +58,7 @@ public class DisplayLanguages {
       new DisplayLanguageType("ckl-NG", "Kibaku"),
       new DisplayLanguageType("mfi-NG", "Mandara (Wandala)"),
       new DisplayLanguageType("mrt-NG", "Marghi"),
+      new DisplayLanguageType("mnw-MM", "မန် (Mon)"),
       new DisplayLanguageType("nl-NL", "Nederlands (Dutch)"),
       new DisplayLanguageType("ann", "Obolo"),
       new DisplayLanguageType("pl-PL", "Polski (Polish)"),

--- a/android/KMEA/app/src/main/res/values-mnw-rMM/strings.xml
+++ b/android/KMEA/app/src/main/res/values-mnw-rMM/strings.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Device type  -->
+    <!-- Application name (Keyman Engine for Android) -->
+    <!-- Context: Title for list -->
+    <plurals name="title_keyboards">
+        <item quantity="other">ကဳဗုဒ်</item>
+    </plurals>
+    <!-- Context: Title for list -->
+    <plurals name="title_other_input_methods">
+        <item quantity="other">နဲကဲစုတ်ကဳဗုဒ်တၞဟ်ဟ်</item>
+    </plurals>
+    <!-- Context: Title for list -->
+    <string name="title_add_keyboard" comment="Add a new keyboard">စုတ်ကဳဗုဒ်တၟိ</string>
+    <!-- Context: Title for list -->
+    <string name="title_languages_settings" comment="List of installed languages">ဘာသာစုတ်လဝ်တုဲတုဲဂမၠိုၚ်</string>
+    <!-- Context: Title for list -->
+    <string name="title_language_settings" comment="Keyman Settings for a language">ဒၞါဲပလေဝ်နာနာ %1$s</string>
+    <!-- Context: Button label -->
+    <string name="label_add" comment="Button to add an item">ထပ်စုတ်</string>
+    <!-- Context: Button label -->
+    <string name="label_back" comment="Button to go back">ကလေၚ်</string>
+    <!-- Context: Button label -->
+    <string name="label_cancel" comment="Button to cancel an action">တးပါဲ</string>
+    <!-- Context: Button label -->
+    <string name="label_close" comment="Close a dialog">ကၟာတ်</string>
+    <!-- Context: Button label. Removed in Keyman 15 -->
+    <string name="label_close_keyman" comment="Close the Keyman application">ကၟာတ်ကဳမာန်</string>
+    <!-- Context: Button label -->
+    <string name="label_forward" comment="Button to go forward">ဆက်အာဂတ</string>
+    <!-- Context: Button label -->
+    <string name="label_next_input_method" comment="Switch to next input method (replaces label_close_keyman)">နဲကဲဲကဳဗုဒ်မွဲပၠန်</string>
+    <!-- Context: Button label -->
+    <string name="label_download" comment="Button to confirm downloading an item">ဂြဲဖျေံ</string>
+    <!-- Context: Button label -->
+    <string name="label_install" comment="Confirmation to install a package">စုတ်</string>
+    <!-- Context: Button label -->
+    <string name="label_later" comment="Do an action at a later time">ဂတဏံမှ</string>
+    <!-- Context: Button label -->
+    <string name="label_next" comment="Go to the next screen">မွဲပၠန်</string>
+    <!-- Context: Button label -->
+    <string name="label_ok" comment="Button to acknowledge a dialog">အဵုခေ</string>
+    <!-- Context: Button label -->
+    <string name="label_update" comment="Dialog button to update a resource">ပ္တိုန်က္ဆံၚ်</string>
+    <!-- Context: No internet for updates -->
+    <string name="no_internet_connection" comment="Internet connection missing">ဆက်စၠောံအေန်တာနက်ဟွံဂွံ</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="cannot_connect" comment="Error message when network connection fails">ချိက်စၠောံကဵုသ္ၚိစာတ် Keyman ဟွံဂွံဏီရ!</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="confirm_delete_keyboard" comment="Confirmation to delete a keyboard">မၞးမိက်ဂွံဇိုတ်ပ္တိတ်ထောံ ကောန်ဍေၚ်ဏံဟာ?</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="confirm_download_keyboard" comment="Confirmation to download a keyboard update">မၞးမိက်ဂွံကလောၚ်စုတ်ကေတ်မူလက္ကရဴအိုတ် သွက်ကောန်ဍေၚ်ဏံဟာ?</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="confirm_update" comment="Confirmation to update several resources">မၞးနွံပၟိက်မိက်သ္ဂောံသၠုၚ်ပ္တိုန်မူကု ကောန်ဍေၚ်ဏံကဵုအဘိဓါန်ဂမၠိုၚ်လၟုဟ်ရဟာ?</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="keyboard_updates_channel">သၠုၚ်ကဆံၚ်တမ်ရိုဟ်ဂမၠိုၚ်</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="keyboard_updates_available" comment="Notification when resource updates are available">ကလိဂွံတမ်ရိုဟ်သၠုၚ်ကဆံၚ်ဂမၠိုၚ်မာန်</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="update_available" comment="Currently installed version of a resource with an available update">%1$s (သမၠုၚ်ပ္တိုန်က္ဆံၚ်ဂွံယျ)</string>
+    <!-- Context: Keyboard Updates -->
+    <string name="keyboard_update_message" comment="language name: keyboard name">      ကလိဂွံပ္တိုန်ကဆံၚ် သွက်ကဳဗုဒ် %1$s: %2$s </string>
+    <!-- Context: Keyboard Updates -->
+    <string name="dictionary_update_message">ကလိဂွံပ္တိုန်ကဆံၚ် သွက်အဘိဓာန် %1$s: %2$s </string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="keyboard_version" comment="Label for keyboard version">ပါယှေန်ကဳဗုဒ်</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="help_link" comment="Label for help link">လေက်မရီုဗၚ်</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="uninstall_keyboard" comment="Label for uninstalling keyboard">ပ္တိတ်ကဳဗုဒ်</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="keyboard_picker_new_keyboard" comment="Mark a language name that's newly installed in keyboard list">%1$s [တၟိ]</string>
+    <!-- Context: Keyboard Info and Keyboard Settings -->
+    <string name="keyboard_qr_code" comment="QR Code description">      ဂွံစုတ်ကဳဗုဒ်ဏံ\nပ္ဍဲစက်တၞဟ်ဟ်ဂှ် သဂေန်ကုက်ဏံညိ</string>
+    <!-- Context: Keyboard Help welcome.htm title -->
+    <string name="welcome_package" comment="Title to welcome.htm page (name and version)">ဒုၚ်တၠုၚ်ဏာ %1$s</string>
+    <!-- Context: Keyboard app doesn't include FileProvider library needed to view help file -->
+    <string name="fileprovider_undefined" comment="FileProvider library needed to view help file">     တၚ်နၚ်လိက် FileProvider မိက်ဂွံဗဵု ဝှါၚ်အရီုဗၚ်: %1$s</string>
+    <!-- Context: Fatal keyboard error. Will load default keyboard -->
+    <string name="fatal_keyboard_error" comment="Fatal keyboard error (keyboard ID::packageID for language). Will load default keyboard">    ကဳဗုဒ်ယောၚ်ယာဇၞော်ဇၞော်နကဵု %1$s:%2$s သွက် ဘာသာ %3$s ။ ဂြဲပ္တိုန်မံၚ် ကဳဗုဒ်ပကတိ။</string>
+    <!-- Context: Fatal keyboard error.  -->
+    <string name="fatal_keyboard_error_short" comment="Error in keyboard (keyboard ID::packageID for language).">      တၚ်ယောၚ်ယာ ပ္ဍဲကဳဗုဒ် %1$s:%2$s သွက် ဘာသာ %3$s</string>
+    <!-- Context: Query for associated dictionary -->
+    <string name="query_associated_model" comment="Check if there's an available dictionary to download">စၟဳစၟတ်ဒၟံၚ် အဘိဓာန် မဆက်စပ် သ္ဂောံဂြဲဖျေံ</string>
+    <string name="cannot_query_associated_model" comment="Cannot reach server to check if there's an available dictionary to download">      သ္ဂောံဂြဲဖျေံ အဘိဓာန်မဆက်စပ်တံဂှ် ဆက်စၠောံကု သာပါ ကဳမာန်ဟွံဂွံ</string>
+    <!-- Context: Model Updates -->
+    <string name="confirm_download_model" comment="Confirmation to download a dictionary update">မၞးမိက်ဂွံဂြဲဖျေံမူတၟိသွက်အဘိဓာန်ဏံဟာ?</string>
+    <!-- Context: No associated dictionary found -->
+    <string name="no_associated_model" comment="Confirmation there's no available dictionary to download">တံၚ်ဂြဲလဝ်အဘိဓာန်ဟွံမွဲ</string>
+    <!-- Context: Model Updates -->
+    <string name="catalog_unavailable" comment="Notification that the cloud resource catalog can't be updated">တံရိုဟ်သွက်ဏံဟွံမွဲ</string>
+    <!-- Context: Background download messages-->
+    <string name="catalog_download_start_in_background" comment="Notification that the resource catalog update will begin">ကာတ်တလံက် သၠုၚ်ပ္တိုန်ဒၟံၚ်ကဆံၚ်လက်ကရဴရ</string>
+    <!-- Context: Background download messages-->
+    <string name="catalog_download_is_running_in_background" comment="Notification that the resource catalog update is still downloading">      ဂြဲဖျေံဒၟံၚ်ကာတ်တလံက်ဖိုဟ်၊ မၚ်မွဲလစုတ်တုဲဂ္စါန်မွဲဝါပၠန်ညိ!</string>
+    <!-- Context: Background download messages-->
+    <string name="progress_message_checking_resource_is_running" comment="Progress notification that the check for a resource is still running ">စၟဳစၟတ်သွက်တမ်ရိုဟ်</string>
+    <!-- Context: Background download messages-->
+    <string name="keyboard_download_start_in_background" comment="Notification that a keyboard download has started">ဂြဲ​ဖျေံဒၟံၚ် ကဳဗုဒ် လ္ပါ်လက်ကရဴ</string>
+    <!-- Context: Background download messages-->
+    <string name="keyboard_download_is_running_in_background" comment="Notification that a keyboard download is still running">ကဳဗုဒ်မရုဲလဝ်ဂှ် အဃောဂၠောၚ်ဂြဲ​ဖျေံဒၟံၚ်ရောင်။ မၚ်မွဲချိုန်ခဏတုဲ ဆက်ဂစာန်ပၠန်ညိ!</string>
+    <!-- Context: Background download messages-->
+    <string name="keyboard_download_finished" comment="Notification that a keyboard download has finished">​​​​ဂၠောၚ်ဂြဲဖျေံကဳဗုဒ်အာစိုပ်ဒတုဲ!</string>
+    <!-- Context: Background download messages-->
+    <string name="dictionary_download_start_in_background" comment="Notification that a dictionary download has started">ပွမဂြဲ​ဂၠောၚ်ဖျေံဒၟံၚ် အဘိဓာန်ဂှ် ​ဍေံပ္တံလဝ်ပ္ဍဲလက်ကရဴတေံ</string>
+    <!-- Context: Background download messages-->
+    <string name="dictionary_download_is_running_in_background" comment="Notification that a dictionary download is still running">အဘိဓာန်ရုဲစှ်လဝ်ဂှ် အဃောဂၠောၚ်ဂြဲ​ဖျေံဒၟံၚ်ရောင်။ မၚ်မွဲချိုန်ခဏတုဲ ဆက်ဂစာန်ပၠန်ညိ!</string>
+    <!-- Context: Background download messages-->
+    <string name="dictionary_download_finished" comment="Notification that a dictionary download has finished">​​​​ဂၠောၚ်ဂြဲဖျေံအဘိဓာန်အာစိုပ်ဒတုဲ။</string>
+    <!-- Context: Background download messages -->
+    <string name="download_failed" comment="Notification that a download failed">​တံၚ်ဂြဲဖျေံဟွံအံၚ်ဇၞး</string>
+    <!-- Context: Background download messages -->
+    <string name="failed_to_retrieve_file" comment="Failed to retrieve downloaded file">ဝှာၚ်မဂၠောၚ်ဂြဲ​ဖျေံလဝ်ဂှ် ကလေၚ်​ကေတ်ဟွံဂွံ</string>
+    <!-- Context: General Updates -->
+    <string name="update_check_unavailable" comment="Error message when a Keyman server can't be reached">ဆက်စၠောံကုသာပါဟွံအံၚ်ဇၞး!</string>
+    <!-- Context: General Updates -->
+    <string name="update_check_current" comment="Notification that all resources are up to date">"တံရိုဟ်ဖအိုတ်ဂှ် ဒှ်တၟိရ!"</string>
+    <!-- Context: General Updates -->
+    <string name="update_failed" comment="Notification that a resource update failed">သၠုၚ်ပ္တိုန်ကဆံၚ် တံရိုဟ် မွဲဟွံသေၚ်မွဲ ဟွံအံၚ်ဇၞး!</string>
+    <!-- Context: General Updates -->
+    <string name="update_success" comment="Notification that a resource update successfully updated">သမၠုၚ်ပ္တိုန်ကဆံၚ်တံရိုဟ်အံၚ်ဇၞး!</string>
+    <!-- Context: Model Info -->
+    <string name="model_version" comment="Title for a dictionary version">ပါယှေန်အဘိဓာန်</string>
+    <!-- Context: Model Info -->
+    <string name="uninstall_model" comment="Label to uninstall a dictionary">ပလှ်ပတိတ် အဘိဓာန်</string>
+    <!-- Context: Model Info -->
+    <string name="confirm_delete_model" comment="Confirmation to delete a dictionary">မၞးမိက်ဂွံဇိုတ် အဘိဓာန်ဟာ?</string>
+    <!-- Context: Model Deleted -->
+    <string name="model_deleted" comment="Notification when a dictionary is deleted">ဇိုတ် အဘိဓာန်တုဲ</string>
+    <!-- Context: Language Settings Keyboard install strings -->
+    <string name="keyboard_install_toast" comment="Notification when a keyboard is installed">ကဳဗုဒ် %1$s စုတ်လဝ်တုဲ</string>
+    <!-- Context: Language Settings Keyboard uninstall strings -->
+    <string name="keyboard_deleted_toast" comment="Notification when a keyboard is deleted">ဇိုတ် ကဳဗုဒ်တုဲ</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="enable_corrections" comment="Enable corrections from the suggestion banner">ပံက် ပလေဝ်ဒါန်</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="enable_predictions" comment="Enable predictions from the suggestion banner">ပံက် တၚ်ချိၚ်ခယျဂမၠိုၚ်</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_label">အဘိဓာန်</string>
+    <plurals name="model_count">
+        <item quantity="other">အဘိဓာန်</item>
+    </plurals>
+    <!-- Context: Language Settings menu substring - Check for available dictionary -->
+    <string name="check_available_model" comment="Check for available dictionary">စၟဳစၟတ်အဘိဓာန်နွံဟွံမွဲ</string>
+    <string name="check_model_online" comment="Check for dictionaries online">စၟဳစၟတ်အဘိဓာန်အောန်လာၚ်</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_info_header" comment="Dictionary name">အဘိဓာန်: %1$s</string>
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_picker_header" comment="Dictionaries for a specified language">အဘိဓာန် %1$s ဂမၠိုၚ်</string>
+    <!-- Context: Language Settings menu strings -->
+    <!-- Context: Language Settings menu strings -->
+    <string name="model_install_toast" comment="Notification when a dictionary is installed">စုတ် အဘိဓာန်တုဲ</string>
+    <!-- Context: Language Settings menu strings -->
+    <plurals name="keyboard_count">
+        <item quantity="other">(ကဳဗုဒ် %1$d)</item>
+    </plurals>
+    <!-- Context: "Change Display Language" menu -->
+    <string name="default_locale" comment="Use the device's current locale">အရေဝ်ဘာသာပကတိ</string>
+    <!-- Context: Content descriptions -->
+    <!-- Context: Content descriptions -->
+    <!-- Context: Popup menu labels -->
+    <string name="label_delete" comment="Confirmation to delete an item">ပလီု</string>
+    <!-- Context: Shared preferences name -->
+    <!-- Context: Other strings -->
+    <string name="help_bubble_text">မိက်ဂွံသၠာဲ ကဳဗုဒ်မ္ဂး ဍဵုအဏံညိ</string>
+    <!-- Context: anywhere -->
+    <string name="unable_to_open_browser" comment="Notification when a browser activity cannot be launched">ပံက် ဝေက်ဗရဴသာဟွံဂွံ</string>
+</resources>

--- a/ios/engine/KMEI/KeymanEngine/Classes/mnw.lproj/ResourceInfoView.strings
+++ b/ios/engine/KMEI/KeymanEngine/Classes/mnw.lproj/ResourceInfoView.strings
@@ -1,0 +1,2 @@
+/* Class = "UILabel"; text = "Scan this code to load this keyboard on another device"; ObjectID = "z2O-MT-IoV"; */
+"z2O-MT-IoV.text" = "ဂွံစုတ်ကဳဗုဒ်ဏံ ပ္ဍဲစက်တၞဟ်ဟ်ဂှ် သဂေန် ကုက်ဏံညိ";

--- a/ios/engine/KMEI/KeymanEngine/mnw.lproj/Localizable.strings
+++ b/ios/engine/KMEI/KeymanEngine/mnw.lproj/Localizable.strings
@@ -1,0 +1,257 @@
+/* A descriptive message used for errors when the app is already busy downloading */
+"alert-download-error-busy" = "ဂြဲဖျေံဒၟံၚ်ဖိုဟ်ရ။";
+
+/* A descriptive message used when a download fails */
+"alert-download-error-detail" = "အဃော ပ္တိုန်စုတ်ဒၟံၚ် ဟွံသေၚ်မ္ဂး အဃော ဂြဲဖျေံဒၟံၚ်ဂှ် ယောၚ်ယာအာ။";
+
+/* Title for a "download failed" alert */
+"alert-download-error-title" = "ဂြဲဖျေံဆောတ်ယောၚ်";
+
+/* Title for a general alert about errors */
+"alert-error-title" = "ယောၚ်ယာ";
+
+/* A descriptive message used when no internet connection is detected */
+"alert-no-connection-detail" = "ကေတ်အဆက်ကု သာပါ ကဳမာန် ဟွံဂွံ။ ဂ္စါန်မွဲဝါပၠန်ညိ။";
+
+/* Title for a "no connection" alert */
+"alert-no-connection-title" = "ဆက်စၠောံယောၚ်ယာ";
+
+/* Short text for a 'back' navigational command.  Used to return to the previous screen */
+"command-back" = "ကလေၚ်";
+
+/* Short text for a 'cancel' command.  Used to back out of a menu or install process without making changes */
+"command-cancel" = "တးပါဲ";
+
+/* Short text for a 'done' command.  Used to back out of settings menus after changes have been made */
+"command-done" = "တုဲ";
+
+/* Short text for an 'install' command.  Used to confirm installation of a package. */
+"command-install" = "စုတ်";
+
+/* Short text for a 'next' navigational command.  Used to advance to the next screen */
+"command-next" = "မွဲပၠန်";
+
+/* Short text for an 'OK' command.  Used for some error alerts */
+"command-ok" = "အဵုခေ";
+
+/* Short text for confirmining 'uninstall' commands. */
+"command-uninstall" = "ပလှ်ပ္တိတ်";
+
+/* Text for the command to uninstall a keyboard */
+"command-uninstall-keyboard" = "ပ္တိတ်ကဳဗုဒ်";
+
+/* Confirmation text to display before uninstalling a keyboard */
+"command-uninstall-keyboard-confirm" = "မၞးမိက်ဂွံပလှ်ပ္တိတ်ကဳဗုဒ်ဏံဟာ?";
+
+/* Text for the command to uninstall a lexical model */
+"command-uninstall-lexical-model" = "ပလှ်ပတိတ် အဘိဓာန်";
+
+/* Confirmation text to display before uninstalling a lexical model */
+"command-uninstall-lexical-model-confirm" = "မၞးမိက်ဂွံပတိတ် အဘိဓာန်ဏံဟာ?";
+
+/* Text for error when a keyboard cannot load properly */
+"error-loading-keyboard" = "ဂြဲစုတ်ကဳဗုဒ် အာတ်မိက်ဟွံဂွံ";
+
+/* Text for error when a lexical model cannot load properly */
+"error-loading-lexical-model" = "ဂြဲကေတ် အဘိဓာန် အာတ်မိက်ဟွံဂွံ";
+
+/* Text for error when an installed file is unexpectedly missing */
+"error-missing-file" = "ဝှါၚ်ပၟိက်ဇၞော်ဂၠာဲဟွံဆဵု။";
+
+/* Text for error when an installed file is unexpectedly missing */
+"error-missing-file-critical" = "ဝှါၚ်ပၟိက်ဇၞော်အိုတ် ဟွံဆဵု။ ကလေၚ်ပ္တိုန် အေပ်ဏံ မွဲဝါပၠန်ညိ။";
+
+/* Text for errors in data received from search queries */
+"error-query-decoding" = "သာပါဂှ် ပြဟ်ဟ်ဏံ သွာၚ်စက်ဒှ်မံၚ်အခက်ခုဲညိရ";
+
+/* A descriptive message used when a download fails */
+"error-query-general" = "ဆက်စၠောံကု သာပါယောၚ်အာ";
+
+/* Text for error when a search query is unexpectedly empty */
+"error-query-no-data" = "ဆက်စၠောံကု သာပါဟွံဂွံ";
+
+/* Text for general errors where not much information is known */
+"error-unknown" = "တၚ်ယောၚ်ယာက္တဵုဒှ်";
+
+/* Text for error when updating a resource:  cannot download because no source is available */
+"error-update-no-link" = "တံရိုဟ်ပ္တိုန်ကဆံၚ်သွက်ဏံဟွံမွဲဏီ";
+
+/* Text for error when updating a resource:  Keyman does not know how to update the resource */
+"error-update-not-managed" = "ပ္တိုန်ကဆံၚ်သွက် တံရိုဟ် ဏံဂှ် နူ စက်ကဳမာန်တေံ ထိၚ်ဒဝ်လဝ်ဟွံသေၚ်ရ";
+
+/* Text for the command to open the help page of a keyboard, as shown on resource information views */
+"info-command-help-keyboard" = "အရီုဗၚ် ကဳဗုဒ်";
+
+/* Text for the command to open the help page of a lexical model, as shown on resource information views */
+"info-command-help-lexical-model" = "အရီုဗၚ် အဘိဓာန်";
+
+/* Text label for displaying a keyboard's version, as shown on resource information views */
+"info-label-version-keyboard" = "ပါယှေန်ကဳဗုဒ်";
+
+/* Text label for displaying a lexical model's version, as shown on resource information views */
+"info-label-version-lexical-model" = "ပါယှေန်အဘိဓာန်";
+
+/* Label used for the "package info" / readme tab with the package installation prompt on phones. */
+"installer-label-package-info" = "တၚ်နၚ်ပက်ကေ";
+
+/* Label used for the language-selection tab with the package installation prompt on phones. */
+"installer-label-select-languages" = "ရုဲဘာသာဂမၠိုၚ်";
+
+/* Label used with a package's version, as seen within the package installation prompt.  Example:  "Version: 14.0.0" */
+"installer-label-version" = "ပါယှေန်: %@";
+
+/* Section header for languages supported by a package, as seen within the package installation prompt */
+"installer-section-available-languages" = "ဘာသာကၠိဂွံဂမၠိုၚ်";
+
+/* Text for the help popup for changing keyboards with the globe key */
+"keyboard-help-change" = "မိက်ဂွံသၠာဲ ကဳဗုဒ်မ္ဂး ဍဵုအဏံညိ";
+
+/* Text for the command to exit the Keyman keyboard in favor of other keyboards installed on the system */
+"keyboard-menu-exit" = "ကၟာတ် %@";
+
+/* Error installing a Keyman package - could not allocate a location to install it */
+"kmp-error-file-system" = "ယောၚ်လီုအာ အဃောမတၚ်စုတ် တၚ်နၚ်မံၚ်ပ္ဍဲစက်";
+
+/* Error installing a Keyman package - could not copy package files */
+"kmp-error-file-copying" = "ယောၚ်လီုအာ အဃောမတၚ်စုတ်ဆာဲစၠောံဒၟံၚ် တၚ်နၚ်မံၚ်ပ္ဍဲစက်";
+
+/* Error opening a Keyman package - package is not valid */
+"kmp-error-invalid" = "ပက်ကေဝှါၚ်ယောၚ်။";
+
+/* Error opening a Keyman package - it does not exist / the specified location is wrong */
+"kmp-error-missing" = "ပက်ကေမၞးစုတ်ဂှ် ဟွံမွဲရ။";
+
+/* Error installing a Keyman package - expected resource (keyboard or dictionary) is missing */
+"kmp-error-missing-resource" = "ပ္ဍဲပက်ကေဏံ ကဳဗုဒ်ကဵု အဘိဓာန်အာတ်လဝ်တံဟွံပါရ။";
+
+/* Error installing a Keyman package with a version of Keyman that does not support it */
+"kmp-error-unsupported-keyman-version" = "ပက်ကေဏံ နွံပၟိက်ကုပါယှေန် ကဳမာန်တၟိရ။";
+
+/* Error opening a Keyman package - cannot parse contents */
+"kmp-error-no-metadata" = "ပက်ကေဏံသိုၚ်လဝ်ဟွံချိုတ်ပၠိုတ် - ကပေါတ်ဟွံတီ။";
+
+/* Error opening a Keyman package - package's contents are for desktop platforms only */
+"kmp-error-unsupported" = "ပ္ဍဲပက်ကေဏံ အထံက်ပၚ် သွက်စက်မၞးဟွံပါ။";
+
+/* Error opening a Keyman package - package contains unexpected resource (keyboard or dictionary) type */
+"kmp-error-wrong-type" = "ပက်ကေဏံ ဂကူတမ်ရိုဟ်စၟဳလဝ်ဟွံပါ";
+
+/* Title for the Installed Languages menu */
+"menu-installed-languages-title" = "ဘာသာစုတ်လဝ်တုဲတုဲဂမၠိုၚ်";
+
+/* Section header for lexical models within a language-specific settings menu */
+"menu-langsettings-label-lexical-models" = "အဘိဓာန်ဂမၠိုၚ်";
+
+/* Section header for keyboards within a language-specific settings menu */
+"menu-langsettings-section-keyboards" = "ကဳဗုဒ်ဂမၠိုၚ်";
+
+/* Section header for the settings toggles within a language-specific settings menu */
+"menu-langsettings-section-settings" = "တၚ်ပလေဝ် ဘာသာနာနာ";
+
+/* Title for the language-specific settings menus */
+"menu-langsettings-title" = "ဒၞါဲပလေဝ်နာနာ %@";
+
+/* Label for the toggle that enables corrections that is displayed within a language-specific settings menu */
+"menu-langsettings-toggle-correct" = "ပံက် ပလေဝ်ဒါန်";
+
+/* Label for the toggle that enables predictions that is displayed within a language-specific settings menu */
+"menu-langsettings-toggle-predict" = "ပံက် တၚ်ချိၚ်ခယျဂမၠိုၚ်";
+
+/* Help message for a prompt that appears for confirming a lexical model download:  language (1): lexical model (dictionary) name (2) */
+"menu-lexical-model-install-message" = "မၞးမိက်ဂွံ စုတ်အဘိဓါန်ဟာ?";
+
+/* Title for a prompt that appears for confirming a lexical model download:  language (1): lexical model (dictionary) name (2) */
+"menu-lexical-model-install-title" = "%1$@: %2$@";
+
+/* Text for an info alert indicating that no lexical models are available */
+"menu-lexical-model-none-message" = "အဘိဓာန်ဟွံမွဲ";
+
+/* Title for the lexical model menu, a submenu of the language-specific settings menus */
+"menu-lexical-model-title" = "အဘိဓာန် %@ ဂမၠိုၚ်";
+
+/* Title for the keyboard picker */
+"menu-picker-title" = "ကဳဗုဒ်ဂမၠိုၚ်";
+
+/* Primary text for the Settings menu option to report keyboard crashes */
+"menu-settings-error-report" = "ကဵုအခေါၚ် ပ္တိုန်ထ္ၜးတၚ်ယောၚ်ယာ";
+
+/* Secondary text for the Settings menu option to report keyboard crashes */
+"menu-settings-error-report-description" = "သ္ဒးကဵု \"အခေါၚ်ပေၚ်ၚ်\" မာန်";
+
+/* Primary text for the Settings menu local-file package installation option */
+"menu-settings-install-from-file" = "ပ္တိုန်စုတ်နူ ဝှါၚ်";
+
+/* Secondary text for the Settings menu local-file package installation option */
+"menu-settings-install-from-file-description" = "ဂၠါဲ ဝှါၚ် .kmp ဂမၠိုၚ်";
+
+/* Primary text for the Settings menu option that displays the iOS system menu options for the app's keyboard */
+"menu-settings-system-keyboard-menu" = "တၚ်ပလေဝ်နာနာသွက် ကဳဗုဒ် စက်";
+
+/* Label for the "Show Banner" toggle on the main settings screen */
+"menu-settings-show-banner" = "ထ္ၜးလ္တူဗၠးမုက်";
+
+/* Label for the "Get Started" automatic display toggle seen in the Settings menu */
+"menu-settings-startup-get-started" = "ထ္ၜး \"စတရဴစိုအ်\" ပ္ဍဲကဵုအစ";
+
+/* Title for the main Settings menu */
+"menu-settings-title" = "တၚ်ပလေဝ်နာနာ သွက်ကဳမာန်";
+
+/* Secondary text showing current setting for spacebar caption - blank */
+"menu-settings-spacebar-hint-blank" = "လ္ပဓမံက်ထ္ၜးမလိက်ပ္ဍဲspacebarညိ";
+
+/* Secondary text showing current setting for spacebar caption - keyboard */
+"menu-settings-spacebar-hint-keyboard" = "ပ္ဍဲ spacebar ဂှ် ထ္ၜးယၟုကဳဗုဒ်ညိ";
+
+/* Secondary text showing current setting for spacebar caption - language */
+"menu-settings-spacebar-hint-language" = "ပ္ဍဲ spacebar ဂှ် ထ္ၜးယၟုအရေဝ်ဘာသာညိ";
+
+/* Secondary text showing current setting for spacebar caption - language + keyboard */
+"menu-settings-spacebar-hint-languageKeyboard" = "ထ္ၜးယၟုအရေဝ်ဘာသာ ကေုာံ ကဳဗုဒ် လ္တူ spacebar";
+
+/* Label for the "Spacebar Caption" item on the main settings screen */
+"menu-settings-spacebar-text" = "က္တိုပ်လိက် Spacebar";
+
+/* Title for the "Spacebar Caption" settings screen */
+"menu-settings-spacebar-title" = "က္တိုပ်လိက် Spacebar";
+
+/* Text showing name of spacebar caption - blank */
+"menu-settings-spacebar-item-blank" = "သၠး";
+
+/* Text showing name of spacebar caption - keyboard */
+"menu-settings-spacebar-item-keyboard" = "ကဳဗုဒ်";
+
+/* Text showing name of spacebar caption - language */
+"menu-settings-spacebar-item-language" = "ဘာသာဂမၠိုၚ်";
+
+/* Text showing name of spacebar caption - language + keyboard */
+"menu-settings-spacebar-item-languageKeyboard" = "ဘာသာ ကေုာံ ကဳဗုဒ်";
+
+/* Short text for notification:  download failure for keyboard */
+"notification-download-failure-keyboard" = "ဂြဲဖျေံကဳဗုဒ်ဟွံအံၚ်ဇၞး";
+
+/* Short text for notification:  download failure for lexical model */
+"notification-download-failure-lexical-model" = "ဂြဲဖျေံအဘိဓာန်ဟွံအံၚ်ဇၞး";
+
+/* Short text for notification:  download success for keyboard */
+"notification-download-success-keyboard" = "ဂြဲဖျေံကဳဗုဒ် အံၚ်ဇၞး";
+
+/* Short text for notification:  download success for lexical model */
+"notification-download-success-lexical-model" = "သ္ၚိအၚ်အဘိဓာန်ဂြဲဖျေံအံၚ်ဇၞးအာယျ";
+
+/* Short text for notification:  downloading a keyboard */
+"notification-downloading-keyboard" = "ဂြဲဖျေံဒၟံၚ် ကဳဗုဒ်\U2026";
+
+/* Short text for notification:  downloading a lexical model */
+"notification-downloading-lexical-model" = "ဂြဲဖျေံဒၟံၚ် အဘိဓာန်\U2026";
+
+/* Short text for notification:  an update is available */
+"notification-update-available" = "သၠုၚ်ပ္တိုန်က္ဆံၚ်ဂွံယျ";
+
+/* Short text for notification:  currently updating */
+"notification-update-processing" = "သၠုၚ်ပ္တိုန်ဒၟံၚ်က္ဆံၚ်\U2026";
+
+/* Text indicating success at installing new keyboards or dictionaries */
+"success-install" = "ပ္တိုန်စုတ် အံၚ်ဇၞးယျ။";
+
+/* A title to use in alerts indicating 'success' at whatever task the user requested */
+"success-title" = "အံၚ်ဇၞး";

--- a/ios/engine/KMEI/KeymanEngine/mnw.lproj/Localizable.stringsdict
+++ b/ios/engine/KMEI/KeymanEngine/mnw.lproj/Localizable.stringsdict
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>menu-langsettings-lexical-model-count</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>other</key>
+        <string>%u အဘိဓာန်ဂမၠိုၚ် စုတ်လဝ်တုဲ</string>
+      </dict>
+    </dict>
+    <key>notification-update-failed</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>other</key>
+        <string>%u ပ္တိုန်က္ဆံၚ်ဟွံအံၚ်ဇၞး</string>
+      </dict>
+    </dict>
+    <key>notification-update-success</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>other</key>
+        <string>%u ပ္တိုန်က္ဆံၚ်အံၚ်ဇၞး</string>
+      </dict>
+    </dict>
+    <key>settings-keyboards-installed-count</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>other</key>
+        <string>ကဳဗုဒ် %u စုတ်လဝ်တုဲ</string>
+      </dict>
+    </dict>
+    <key>settings-languages-installed-count</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>other</key>
+        <string>အရေဝ်ဘာသာ %u ဘာသာ စုတ်လဝ်တုဲ</string>
+      </dict>
+    </dict>
+    <key>package-default-found-keyboards</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>other</key>
+        <string>ကဳဗုဒ် %u ဂွံဆဵုကေတ်ပ္ဍဲပက်ကေ:</string>
+      </dict>
+    </dict>
+    <key>package-default-found-lexical-models</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@count@</string>
+      <key>count</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>u</string>
+        <key>other</key>
+        <string>အဘိဓာန် %u ဂွံဆဵုကေတ်ပ္ဍဲပက်ကေ:</string>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/ios/keyman/Keyman/Keyman/mnw.lproj/Localizable.strings
+++ b/ios/keyman/Keyman/Keyman/mnw.lproj/Localizable.strings
@@ -1,0 +1,81 @@
+/* Title for the bookmarks menu within the embedded browser */
+"browser-bookmarks-add-title" = "စွံ သမ္တီမုက်လိက်";
+
+/* Title for the bookmarks menu within the embedded browser */
+"browser-bookmarks-none" = "မုက်လိက်သမ္တီလဝ်ဟွံမွဲ";
+
+/* Title for the bookmarks menu within the embedded browser */
+"browser-bookmarks-title" = "သမ္တီမုက်လိက်";
+
+/* Used to confirm a user's desire to install a package */
+"confirm-install" = "စုတ်";
+
+/* The label for the toggle to stop automatically showing the "Get Started" tutorial popup. */
+"disable-get-started" = "လ္ပထ္ၜးမွဲလန်ပၠန်ညိ";
+
+/* Indicates an error opening a web page requested by a user */
+"error-opening-page" = "ပံက်မုက်လိက်ဟွံဂွံ";
+
+/* Long-form used when installing a font in order to display a language properly. */
+"font-install-description" = "%@ ဂွံထ္ၜးပ္ဍဲကဵု ကပေါတ်စက်စုၚ်ၚ်မာန်ဂှ် ရုဲစှ်ကဵု စုတ် ညိ";
+
+/* The name of the iOS Settings menu option for keyboards */
+"ios-settings-keyboards" = "ကဳဗုဒ်ဂမၠိုၚ်";
+
+/* The name of the iOS Settings menu option for giving the keyboard full access.  (The menu entry
+underneath the app's name within the app-specific keyboard menu.) */
+"ios-settings-allow-full-access" = "ကဵုအခေါၚ်ပေၚ်ၚ်";
+
+/* Short-form used when installing a font in order to display a language properly. */
+"language-for-font" = "မလိက် %@";
+
+/* Used for 'add' options within menus */
+"menu-add" = "စုတ်";
+
+/* Used to indicate a sequence of menu options that a user needs to copy.  May be chained.  Example:  "Keyboards (1) > Enable Keyman (2)" */
+"menu-breadcrumbing" = "%1$@ > %2$@";
+
+/* Used to exit a menu without choosing an option */
+"menu-cancel" = "တးပါဲ";
+
+/* Menu option that erases all previously-typed text. */
+"menu-clear-text" = "ပလီုလိက်";
+
+/* Menu option that displays a list designed to help users start using the app */
+"menu-get-started" = "စတရဴစိုအ်";
+
+/* Menu option that displays help for the app */
+"menu-help" = "တၚ်နၚ်";
+
+/* Menu option that displays the main screen's drop-down menu */
+"menu-more" = "ဂၠိုၚ်နူဏံ";
+
+/* Menu option used to edit keyboard and dictionary settings */
+"menu-settings" = "ဒၞါဲပလေဝ်နာနာ";
+
+/* Menu option that displays the iOS Share menu */
+"menu-share" = "ပါ်ပရအ်";
+
+/* Menu option that displays an embedded web browser. */
+"menu-show-browser" = "ဗရဴသာ";
+
+/* Menu option used to control in-app font size. */
+"menu-text-size" = "အဝဲမလိက်";
+
+/* Used to describe the current font size */
+"text-size-label" = "အဝဲမလိက်: %i";
+
+/* Text to indicate that a user should set a toggle within iOS Settings to 'active'. */
+"toggle-to-enable" = "ပံက် %@";
+
+/* First option on the Get Started tutorial - Add a keyboard for your language */
+"tutorial-add-keyboard" = "စုတ်ကဳဗုဒ်သွက်ဘာသာမၞး";
+
+/* Third option on the Get Started tutorial - Displays app help. */
+"tutorial-show-help" = "တၚ်နၚ်ဂၠိုၚ်နူဏံ";
+
+/* Second option on the Get Started tutorial - Set up Keyman as system-wide keyboard */
+"tutorial-system-keyboard" = "သ္ပဒတန်ကဳမာန် နကဵု ကဳဗုဒ်သၞောတ်စက်";
+
+/* Used to display app version (as in \"Version: 1.0.2\" */
+"version-label" = "ပါယှေန်: %@";

--- a/linux/keyman-config/locale/mnw_MM.po
+++ b/linux/keyman-config/locale/mnw_MM.po
@@ -1,0 +1,332 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: keyman\n"
+"Report-Msgid-Bugs-To: <support@keyman.com>\n"
+"POT-Creation-Date: 2020-08-19 19:17+0200\n"
+"PO-Revision-Date: 2023-09-12 04:15\n"
+"Last-Translator: \n"
+"Language-Team: Mon\n"
+"Language: mnw_MM\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Crowdin-Project: keyman\n"
+"X-Crowdin-Project-ID: 386703\n"
+"X-Crowdin-Language: mnw\n"
+"X-Crowdin-File: /master/linux/keyman-config.pot\n"
+"X-Crowdin-File-ID: 504\n"
+
+#: keyman_config/__init__.py:68
+msgid "Neither sentry-sdk nor raven is available. Not enabling Sentry error reporting."
+msgstr "Sentry-sdk ကီု raven ကီုဟွံမွဲရ။ ဟွံပံက် ဒုၚ်စဳရေၚ် ပရေၚ်ယောၚ်ယာ Sentry ရ။"
+
+#: keyman_config/downloadkeyboard.py:23
+msgid "Download Keyman keyboards"
+msgstr "ဂြဲကေတ် ကဳဗုဒ် ကဳမာန်ဂမၠိုၚ်"
+
+#: keyman_config/downloadkeyboard.py:37 keyman_config/keyboard_details.py:49
+#: keyman_config/keyboard_details.py:340 keyman_config/view_installed.py:205
+msgid "_Close"
+msgstr "_ကၟာတ်"
+
+#: keyman_config/install_kmp.py:99
+msgid "You do not have permissions to install the keyboard files to the shared area /usr/local/share/keyman"
+msgstr "သ္ဂောံစုတ်ကဳဗုဒ် ပ္ဍဲဨရိယျာ /usr/local/share/keyman ဂှ် မၞးအခေါၚ်ဟၟံမွဲ"
+
+#: keyman_config/install_kmp.py:103
+msgid "You do not have permissions to install the documentation to the shared documentation area /usr/local/share/doc/keyman"
+msgstr "သ္ဂောံစုတ်ကဳဗုဒ် ပ္ဍဲဨရိယျာ /usr/local/share/doc/keyman ဂှ် မၞးအခေါၚ်ဟၟံမွဲ"
+
+#: keyman_config/install_kmp.py:107
+msgid "You do not have permissions to install the font files to the shared font area /usr/local/share/fonts"
+msgstr "သ္ဂောံစုတ်ဝှတ် ပ္ဍဲဨရိယျာ /usr/local/share/fonts ဂှ် မၞးအခေါၚ်ဟၟံမွဲ"
+
+#: keyman_config/install_kmp.py:179
+#, python-brace-format
+msgid "install_kmp.py: error: No kmp.json or kmp.inf found in {package}"
+msgstr "install_kmp.py: error: No kmp.json or kmp.inf found in {package}"
+
+#: keyman_config/install_kmp.py:246
+#, python-brace-format
+msgid "install_kmp.py: error: No kmp.json or kmp.inf found in {packageFile}"
+msgstr "install_kmp.py: error: No kmp.json or kmp.inf found in {packageFile}"
+
+#: keyman_config/install_window.py:54
+#, python-brace-format
+msgid "Installing keyboard/package {keyboardid}"
+msgstr "စုတ် ကဳဗုဒ်/ပက်ကေ တုဲ {keyboardid}"
+
+#: keyman_config/install_window.py:72 keyman_config/install_window.py:93
+msgid "Keyboard is installed already"
+msgstr "ကဳဗုဒ် ဂှ် စုတ်လဝ်တုဲတုဲရ"
+
+#: keyman_config/install_window.py:74
+#, python-brace-format
+msgid "The {name} keyboard is already installed at version {version}. Do you want to uninstall then reinstall it?"
+msgstr "ကဳဗုဒ် {name} စုတ်လဝ်တုဲ နကဵု ပါယှေန် {version} ရ။ မၞးမိက်ဂွံပ္တိတ်တုဲ စုတ်တၟိဟာ?"
+
+#: keyman_config/install_window.py:95
+#, python-brace-format
+msgid "The {name} keyboard is already installed with a newer version {installedversion}. Do you want to uninstall it and install the older version {version}?"
+msgstr "ကဳဗုဒ် {name} ဂှ်စုတ်လဝ်တုဲနကဵု ပါယှေန်တၟိ {installedversion} ရ။ မၞးမိက်ဂွံ ပ္တိတ်တုဲ စုတ် ပါယှေန်တြေံ {version} ပၠန်ဟာ?"
+
+#: keyman_config/install_window.py:128
+msgid "Keyboard layouts:   "
+msgstr "သ္ၚိအၚ်ကဳဗုဒ်:   "
+
+#: keyman_config/install_window.py:147
+msgid "Fonts:   "
+msgstr "မလိက်ဖွန်:   "
+
+#: keyman_config/install_window.py:167 keyman_config/keyboard_details.py:96
+msgid "Package version:   "
+msgstr "ပါယှေန်ပက်ကေ:   "
+
+#: keyman_config/install_window.py:179
+msgid "Author:   "
+msgstr "ညးချူဗဒှ်: "
+
+#: keyman_config/install_window.py:197
+msgid "Website:   "
+msgstr "ဝက်သာ်:   "
+
+#: keyman_config/install_window.py:211
+msgid "Copyright:   "
+msgstr "အခေါၚ်အဝဵုပိုၚ်ပြဳ:   "
+
+#: keyman_config/install_window.py:245
+msgid "Details"
+msgstr "တၚ်နၚ်သောဲသောဲဗြောဲဗြောဲ"
+
+#: keyman_config/install_window.py:248
+msgid "README"
+msgstr "ဗှ်အဲညိ"
+
+#: keyman_config/install_window.py:256 keyman_config/view_installed.py:200
+msgid "_Install"
+msgstr "_ပ္တိုန်စုတ်"
+
+#: keyman_config/install_window.py:260
+msgid "_Cancel"
+msgstr "_တးပါဲ"
+
+#: keyman_config/install_window.py:305
+#, python-brace-format
+msgid "Keyboard {name} installed"
+msgstr "ကဳဗုဒ် {name} ဂှ် စုတ်လဝ်တုဲတုဲ"
+
+#: keyman_config/install_window.py:310 keyman_config/install_window.py:315
+#, python-brace-format
+msgid "Keyboard {name} could not be installed."
+msgstr "ကဳဗုဒ် {name} ဂှ်စုတ်ဟွံဂွံ။"
+
+#: keyman_config/install_window.py:311
+msgid "Error Message:"
+msgstr "လိက်တၚ်ဗၠေတ်:"
+
+#: keyman_config/install_window.py:316
+msgid "Warning Message:"
+msgstr "လိက်ကဵုသတိ:"
+
+#: keyman_config/keyboard_details.py:37
+#, python-brace-format
+msgid "{name} keyboard"
+msgstr "ကဳဗုဒ် {name}"
+
+#: keyman_config/keyboard_details.py:53
+msgid "ERROR: Keyboard metadata is damaged.\n"
+"Please \"Uninstall\" and then \"Install\" the keyboard."
+msgstr "တၚ်ယောၚ်ယာ: မဳတာဒေတာ ကဳဗုဒ်လီု။\n"
+"ကလေၚ် ပ္တိတ်တုဲ ပ္တိုန်စုတ်ကဳဗုဒ်တၟိပၠန်ညိ။"
+
+#: keyman_config/keyboard_details.py:74
+msgid "Package name:   "
+msgstr "ယၟု ပက်ကေ:   "
+
+#: keyman_config/keyboard_details.py:85
+msgid "Package id:   "
+msgstr "ID ပက်ကေ:   "
+
+#: keyman_config/keyboard_details.py:108
+msgid "Package description:   "
+msgstr "တၚ်သောၚ် ပက်ကေ:   "
+
+#: keyman_config/keyboard_details.py:121
+msgid "Package author:   "
+msgstr "ညးချူခၞံ ပက်ကေ:   "
+
+#: keyman_config/keyboard_details.py:133
+msgid "Package copyright:   "
+msgstr "တၠမူ ပက်ကေ:   "
+
+#: keyman_config/keyboard_details.py:174
+msgid "Keyboard filename:   "
+msgstr "ယၟုဝှါၚ် ကဳဗုဒ်:   "
+
+#: keyman_config/keyboard_details.py:187
+msgid "Keyboard name:   "
+msgstr "ယၟုကဳဗုဒ်:   "
+
+#: keyman_config/keyboard_details.py:198
+msgid "Keyboard id:   "
+msgstr "Id ကဳဗုဒ်:   "
+
+#: keyman_config/keyboard_details.py:209
+msgid "Keyboard version:   "
+msgstr "ပါယှေန်ကဳဗုဒ်:   "
+
+#: keyman_config/keyboard_details.py:221
+msgid "Keyboard author:   "
+msgstr "ညးချူ ကဳဗုဒ်:   "
+
+#: keyman_config/keyboard_details.py:232
+msgid "Keyboard license:   "
+msgstr "လာၚ်ဇြေန် ကဳဗုဒ်:   "
+
+#: keyman_config/keyboard_details.py:243
+msgid "Keyboard description:   "
+msgstr "တၚ်သောၚ်ကဳဗုဒ် ဍန်န်:   "
+
+#: keyman_config/keyboard_details.py:334
+#, python-brace-format
+msgid "Scan this code to load this keyboard\n"
+"on another device or <a href='{uri}'>share online</a>"
+msgstr "သ္ဂောံစုတ်ကဳဗုဒ်ဏံ\n"
+"ပ္ဍဲစက်တၞဟ်ဟ်ဂှ် သဂေန်ညိ ဟွံသေၚ် <a href='{uri}'>share online</a>"
+
+#: keyman_config/options.py:24
+#, python-brace-format
+msgid "{packageId} Settings"
+msgstr "ဒၞါဲချိၚ်နာနာ {packageId}"
+
+#: keyman_config/view_installed.py:30
+msgid "Keyman Configuration"
+msgstr "ဒၞါဲပလေဝ်သၞောတ်စက် ကဳမာန် နာနာ"
+
+#: keyman_config/view_installed.py:60
+msgid "Choose a kmp file..."
+msgstr "ရုဲစှ် ဝှါၚ် kmp..."
+
+#. i18n: file type in file selection dialog
+#: keyman_config/view_installed.py:65
+msgid "KMP files"
+msgstr "ဝှါၚ် KMP ဂမၠိုၚ်"
+
+#. i18n: column header in table displaying installed keyboards
+#: keyman_config/view_installed.py:141
+msgid "Icon"
+msgstr "ရုပ်"
+
+#. i18n: column header in table displaying installed keyboards
+#: keyman_config/view_installed.py:145
+msgid "Name"
+msgstr "ယၟု"
+
+#. i18n: column header in table displaying installed keyboards
+#: keyman_config/view_installed.py:148
+msgid "Version"
+msgstr "ပါယှေန်"
+
+#: keyman_config/view_installed.py:161
+msgid "_Uninstall"
+msgstr "_ပ္တိတ်"
+
+#: keyman_config/view_installed.py:162 keyman_config/view_installed.py:304
+msgid "Uninstall keyboard"
+msgstr "ပ္တိတ်ကဳဗုဒ်"
+
+#: keyman_config/view_installed.py:167
+msgid "_About"
+msgstr "_ပရော"
+
+#: keyman_config/view_installed.py:168 keyman_config/view_installed.py:306
+msgid "About keyboard"
+msgstr "ပရောကဳဗုဒ်"
+
+#: keyman_config/view_installed.py:173
+msgid "_Help"
+msgstr "_အရီုဗၚ်"
+
+#: keyman_config/view_installed.py:174 keyman_config/view_installed.py:305
+msgid "Help for keyboard"
+msgstr "အရီုဗၚ်သွက် ကဳဗုဒ်"
+
+#: keyman_config/view_installed.py:179
+msgid "_Options"
+msgstr "_တၚ်ရုဲစှ်ဂမၠိုၚ်"
+
+#: keyman_config/view_installed.py:180 keyman_config/view_installed.py:307
+msgid "Settings for keyboard"
+msgstr "တၚ်ချိၚ်သွက် ကဳဗုဒ်"
+
+#: keyman_config/view_installed.py:190
+msgid "_Refresh"
+msgstr "_ကလေၚ်ကေတ်တၟိ"
+
+#: keyman_config/view_installed.py:191
+msgid "Refresh keyboard list"
+msgstr "ကလေၚ်ကေတ် စရၚ် ကဳဗုဒ်တၟိ"
+
+#: keyman_config/view_installed.py:195
+msgid "_Download"
+msgstr "_ဂြဲ"
+
+#: keyman_config/view_installed.py:196
+msgid "Download and install a keyboard from the Keyman website"
+msgstr "ဂြဲကေတ်တုဲ စုတ် ကဳဗုဒ် နူ ဝက်သာ် ကဳမာန်"
+
+#: keyman_config/view_installed.py:201
+msgid "Install a keyboard from a file"
+msgstr "စုတ်ကဳဗုဒ် နူကဵု ဝှါၚ်"
+
+#: keyman_config/view_installed.py:206
+msgid "Close window"
+msgstr "ကၟာတ်ဝေန်ဒဵု"
+
+#: keyman_config/view_installed.py:278
+#, python-brace-format
+msgid "Uninstall keyboard {package}"
+msgstr "ပလှ်ကဳဗုဒ် {package}"
+
+#: keyman_config/view_installed.py:280
+#, python-brace-format
+msgid "Help for keyboard {package}"
+msgstr "အရီုဗၚ်သွက်ကဳဗုဒ် {package}"
+
+#: keyman_config/view_installed.py:282
+#, python-brace-format
+msgid "About keyboard {package}"
+msgstr "ပရောကဳဗုဒ် {package}"
+
+#: keyman_config/view_installed.py:284
+#, python-brace-format
+msgid "Settings for keyboard {package}"
+msgstr "တၚ်ချိၚ်နာနာသွက်ကဳဗုဒ် {package}"
+
+#: keyman_config/view_installed.py:349
+msgid "Uninstall keyboard package?"
+msgstr "ပလှ်ပ္တိတ် သ္ၚိကဳဗုဒ်ဟာ?"
+
+#: keyman_config/view_installed.py:351
+#, python-brace-format
+msgid "Are you sure that you want to uninstall the {keyboard} keyboard and its fonts?"
+msgstr "မၞးပ္တိတ် ကဳဗုဒ် {keyboard} ကေုာံ မလိက် ကောန်ဍောၚ်ဍေံရောၚ်ဂှ် ချိုတ်ပၠိုတ်ဟာ?"
+
+#: keyman_config/welcome.py:22
+#, python-brace-format
+msgid "{name} installed"
+msgstr "{name} စုတ်လဝ်တုဲတုဲ"
+
+#: keyman_config/welcome.py:40
+msgid "Open in _Web browser"
+msgstr "ပံက်ပ္ဍဲ _ဝက်ပ်ဗရဴသာ"
+
+#: keyman_config/welcome.py:42
+msgid "Open in the default web browser to do things like printing"
+msgstr "သ္ဂောံကၠောန်ကမၠောန် ဗီုဆာဲလိက်တံမာန်ဂှ် အာပံက်ကု ဗရဴသာ ပကတိညိ"
+
+#: keyman_config/welcome.py:45
+msgid "_OK"
+msgstr "_အဵုခေ"
+

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/mnw.lproj/KMAboutWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/mnw.lproj/KMAboutWindowController.strings
@@ -1,0 +1,8 @@
+/* button text to close the About window */
+"Kab-Up-fYH.title" = "ကၟာတ်";
+
+/* text of link to the license agreement */
+"hYC-Bx-aoP.title" = "တၚ်တုပ်စိုတ် လာၚ်ဇြေန်";
+
+/* button text to open Configuration window  */
+"vkh-b5-vO7.title" = "ပလေဝ်နာနာ...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/mnw.lproj/preferences.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/mnw.lproj/preferences.strings
@@ -1,0 +1,38 @@
+/* Checkbox text to always show on-screen keyboard */
+"4UX-80-0Vo.title" = "ထ္ၜး ကဳဗုဒ် ဗၠးမုက်လၟိုန်";
+
+/* Checkbox text to enable verbose Console logging */
+"7J6-zy-R20.title" = "သုၚ်စောဲ verbose Console logging";
+
+/* Support button text  */
+"93O-x6-RLF.label" = "အထံက်အပၚ်";
+
+/* Download Keyboard button text */
+"CTw-kf-WNS.title" = "ဂြဲကေတ် ကဳဗုဒ်...";
+
+/* Keyman Configuration window title */
+"F0z-JX-Cv5.title" = "ဗီုပြၚ်သၞောတ်စက် ကဳမာန်";
+
+/* button text to go back to previous page */
+"JOK-JV-n8w.title" = "ကလေၚ်";
+
+/* Keyboards button text */
+"MPN-9N-wWc.label" = "ကဳဗုဒ်ဂမၠိုၚ်";
+
+/* text to explain verbose Console logging option */
+"MrI-GM-7d6.title" = "အခါရ တၚ်ရုဲစှ် verbose logging ဂှ်ပံက်လဝ်မ္ဂး ကဳမာန် တော်ဆ ကမၠောန်သွက်ဂွံကဵု အထံက်အရီုကု ဂၠိုက်ဂၠါဲပြဿနာရ။ ဂွံဆဵု တၚ်တော်ဆလဝ်သွက်ကဳမာန်တံဂှ် သုၚ်စောဲ Console programဏံမာန်ရ။ ပ္ဍဲ Console ဂှ် ဒၞါဲထ္ဍိုဟ်ဒှ် ရုဲစှ်ကဵု ထ္ၜးလိက်တၚ်နၚ် နူကဵု ကမၠောန် ကဳမာန်တံဖအိုတ်ညိ။ တၚ်နၚ်တော်ဆလဝ်တံဂှ် နွံပၟိက်မ္ဂး ဆာဲပ္တိတ်တုဲ ပၠံၚ်ဗ္စိုပ်ကု ဂကောံအထံက်ပၚ် ကဳမာန် မာန်ရ။";
+
+/* button text to move forward to the next page */
+"eXr-8V-h1g.title" = "ဆက်အာဂတ";
+
+/* button text to return to the home help page */
+"fXS-aC-CMH.title" = "မုက်တမ်";
+
+/* Options button text */
+"frd-No-seV.label" = "တၚ်ရုဲစှ်ဂမၠိုၚ်";
+
+/* Installed Keyboard column heading */
+"jex-Nd-Qzg.headerCell.title" = "ကဳဗုဒ်စုတ်လဝ်တုဲတုဲ";
+
+/* Verbose logging tooltip text */
+"uWx-3J-U0D.ibShadowedToolTip" = "ယဝ်ရမၞးဒှ်မံၚ်ခက်ခုဲမွဲမွဲသာကု ကဳဗုဒ်မွဲမွဲ ဒှ်ဒှ် ကဵု ကဳမာန်ဒှ်ဒှ် မ္ဂး ပံက်လဝ်ၝဏံညိ။";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/mnw.lproj/KMInfoWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/mnw.lproj/KMInfoWindowController.strings
@@ -1,0 +1,8 @@
+/* Package Information window title */
+"F0z-JX-Cv5.title" = "တၚ်နၚ် ပက်ကေ";
+
+/* button text to show Details */
+"Fvy-XJ-s38.label" = "တၚ်နၚ်သောဲသောဲဗြောဲဗြောဲ";
+
+/* button text to show Read Me */
+"waA-IW-Qyn.label" = "ဗှ်အဲ";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/mnw.lproj/KMKeyboardHelpWindowController.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/mnw.lproj/KMKeyboardHelpWindowController.strings
@@ -1,0 +1,8 @@
+/* Keyboard Help window title */
+"F0z-JX-Cv5.title" = "အရီုဗၚ် ကဳဗုဒ်";
+
+/* OK button text */
+"Zla-QF-m0K.title" = "အဵုခေ";
+
+/* Print button text */
+"fYY-Uj-y4S.title" = "ဆာဲပ္တိတ်...";

--- a/mac/Keyman4MacIM/Keyman4MacIM/mnw.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/mnw.lproj/Localizable.strings
@@ -1,0 +1,71 @@
+/* Message displayed to confirm delete of the Keyman keyboard selected by the user from the keyboard list  */
+"message-confirm-delete-keyboard" = "မၞးပလီု ကဳဗုဒ် '%@' ဏံရောၚ် ဂှ်ချိုတ်ပၠိုတ်ရဟာ?";
+
+/* Delete keyboard confirmation info indicating that the delete action cannot be undone  */
+"info-cannot-undo-delete-keyboard" = "မၞးကၠောန်ဏာတုဲ ကလေၚ်ကေတ်ဟွံဂွံရောၚ်။";
+
+/* Button text to cancel delete of the specified installed Keyman keyboard  */
+"button-cancel-delete-keyboard" = "တးပါဲ";
+
+/* Button text to confirm delete of the specified installed Keyman keyboard  */
+"button-delete-keyboard" = "ပလီု";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"message-confirm-install-keyboard" = "စုတ် ကဳမာန် ကဳဗုဒ်ဟာ?";
+
+/* Message displayed to confirm installation of a keyboard from the specifed .kmp file double-clicked by the user  */
+"info-install-keyboard-filename" = "မၞးမိက်ဂွံကဵု ကဳမာန် စုတ် ကဳဗုဒ်နူ ဝှါၚ် '%@' ဟာ?";
+
+/* Button text to cancel installation of the double-clicked Keyman file  */
+"button-cancel-install-keyboard" = "တးပါဲ";
+
+/* Button text to confirm installation of the double-clicked Keyman file  */
+"button-install-keyboard" = "စုတ်";
+
+/* Message displayed to inform user that .kmp file could not be read/unzipped  */
+"message-keyboard-file-unreadable" = "ဗှ် ဝှါၚ်ကဳမာန် '%@' ဟွံဂွံ။";
+
+/* Message displayed in Configuration window when keyboard cannot be loaded */
+"message-error-loading-keyboard" = "(ပ္တိုန်စုတ်ကဳဗုဒ်ဆောတ်ယောၚ်)";
+
+/* Message displayed in Configuration window when keyboard metadata cannot be loaded */
+"message-error-unknown-metadata" = "ဟွံတီ";
+
+/* Button text to acknowledge that .kmp file could not be read  */
+"button-keyboard-file-unreadable" = "အဵုခေ";
+
+/* label text to identify Keyman version */
+"version-label-text" = "ပါယှေန်: %@";
+
+/* Status text for keyboard downloading  */
+"message-keyboard-downloading" = "ဂြဲဖျေံဒၟံၚ်...";
+
+/* Status text for keyboard download complete  */
+"message-keyboard-download-complete" = "ဂြဲဖျေံအံၚ်ဇၞး။";
+
+/* Button text to cancel downloading keyboard  */
+"button-cancel-downloading" = "တးပါဲ";
+
+/* Button text keyboard download complete  */
+"button-download-complete" = "တုဲ";
+
+/* keyboards label in the Package Information window */
+"keyboards-label" = "ကဳဗုဒ်ဂမၠိုၚ်:";
+
+/* fonts label in the Package Information window */
+"fonts-label" = "ဖွန်ဂမၠိုၚ်:";
+
+/* package version label in the Package Information window */
+"package-version-label" = "ပါယှေန်ဓုပ်:";
+
+/* author label in the Package Information window */
+"author-label" = "ညးချူဗဒှ်:";
+
+/* website label in the Package Information window */
+"website-label" = "ဝေက်သာ်:";
+
+/* copyright label in the Package Information window */
+"copyright-label" = "တၠမူ:";
+
+/* message displayed to alert user to need grant accessibility permission */
+"privacy-alert-text" = "ဂွံကၠောန်ကမၠောန်ခိုဟ်ဟ်မာန်ှဂှ် ကဳမာန်ဒးသုၚ်စောဲ နဲကဲဆက်စၠောံအကြာစက်ဂမၠိုၚ်ရ။\n\nအာပ္ဍဲ တၚ်ပလေဝ်သၞောတ်စက်၊ ပရေၚ်ဂီုဂၠီု ကေုာံ ပရေၚ်ဂီုဂၠီုပူဂဵု တုဲ ကဵုအခေါၚ်ညိ။\nကလေၚ်ပံက်ကၟာတ်စက်ညိ။";

--- a/mac/Keyman4MacIM/Keyman4MacIM/mnw.lproj/MainMenu.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/mnw.lproj/MainMenu.strings
@@ -1,0 +1,14 @@
+/* Configuration window menu text */
+"P1b-lE-yFw.title" = "ပလေဝ်ပလေတ်နာနာ...";
+
+/* Keyboards menu text */
+"bQa-j9-nHe.title" = "ကဳဗုဒ်ဂမၠိုၚ်";
+
+/* Keyboards menu text */
+"goP-aK-3WB.title" = "ကဳဗုဒ်ဂမၠိုၚ်";
+
+/* About menu text */
+"kb2-ww-RS3.title" = "ပရော";
+
+/* On-Screen Keyboard menu text */
+"s96-JI-YDh.title" = "ကဳဗုဒ်လ္တူဗၠးမုက်";

--- a/windows/src/desktop/kmshell/locale/mnw-MM/strings.xml
+++ b/windows/src/desktop/kmshell/locale/mnw-MM/strings.xml
@@ -1,0 +1,911 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  strings.xml: Contains all localizable strings for Keyman for Windows
+  * Create a user interface translation for Keyman for Windows at https://translate.keyman.com/
+-->
+<resources>
+  <!-- Context: System -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.266.0 -->
+  <string name="S_LocaleAuthors" comment="Name(s) of people who created this translation - i.e. your name">ကဳမာန်</string>
+  <!-- Context: _Font -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SK_UIFontName" comment="The standard font">Segoe UI</string>
+  <!-- Context: _Font -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SK_UIFontSize" comment="The standard font size">၉</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKButtonYes" comment="Yes button in message boxes">&amp;ယွံ</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKButtonNo" comment="No button in message boxes">&amp;ဟအှ်ေ</string>
+  <!-- Context: General Strings -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_OK" comment="Ok button term">အဵုခေ</string>
+  <!-- Context: General Strings -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_Cancel" comment="Cancel button term">တးပါဲ</string>
+  <!-- Context: General Strings -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_Close" comment="Close button term">ကၟာတ်</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKButtonOK" comment="OK button in message boxes">အဵုခေ</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKButtonCancel" comment="Cancel button in message boxes">တးပါဲ</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 16.0.47 -->
+  <string name="SKAddremove" comment="Add or Remove languages button opens a dialog window">စုတ်/ပ္တိတ် ဘာသာတၟိ...</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.330.0 -->
+  <string name="SKBalloonClickToSelectKeyboard" comment="Balloon that shows when Keyman icon is first shown during the tutorial">သ္ဂောံရုဲကောန်ဍေၚ်ဂှ် ခ္ဍံက်လ္တူ ဗီုဏံညိ</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.330.0 -->
+  <string name="SKBalloonOSKClosed" comment="Balloon that shows when OSK is closed">Keyman ဂှ် ကၠောန်မံၚ်ကမၠောန်ဖိုဟ်ဏောၚ်။ ခ္ဍံက်လ္တူ ရုပ် ဏံတုဲ အခိၚ်လဵုဟွံရုဲ ပြံၚ်သၠာဲကေတ် ကောန်ဍေၚ်ဘာသာ မၞးမာန်ရ။</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 14.0.234 -->
+  <string name="SKBalloonKeymanIsRunning" comment="Balloon that shows when user tries to start Keyman but it is already running">Keyman ကၠောန်မံၚ်ကမၠောန်တုဲတုဲရ။ သ္ဂောံသုၚ်စောဲ ကောန်ဍေၚ်ဘာသာမၞးဂှ် ဍဵုလ္တူ ရုပ် Keyman ညိ</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ConfigurationTitle" comment="Configuration dialog title, which includes the product name">ဗီုပြၚ်သၞောတ်စက် Keyman</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.239.0 -->
+  <string name="S_Caption_Help" comment="Configuration dialog link to Help">အရီုဗၚ်</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47.0 -->
+  <string name="S_Caption_Uninstall" comment="Configuration dialog link to Uninstall Keyboard">ပလှ်</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47.0 -->
+  <string name="S_Caption_Enable" comment="Configuration dialog link to Enable Keyboard">ပံက်</string>
+  <!-- Context: Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47.0 -->
+  <string name="S_Caption_Disable" comment="Configuration dialog link to Disable Keyboard">ကၟာတ်</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Keyboards" comment="Keyboard Layouts tab name">သ္ၚိအၚ်ကဳဗုဒ်ဂမၠိုၚ်</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Keyboards_AccessChar" comment="Direct access to the Keyboard Layouts tab using alt+">K</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Options" comment="Options tab name">တၚ်ရုဲစှ်ဂမၠိုၚ်</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Options_AccessChar" comment="Direct access to the Options tab using alt+">O</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkeys" comment="Hotkeys tab name">မဍဵုတၟေၚ်</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkeys_AccessChar" comment="Direct access to the Hotkeys tab using alt+">H</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Support" comment="Support tab name">အထံက်အပၚ်</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Support_AccessChar" comment="Direct access to the Support tab using alt+">S</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.493.0 -->
+  <string name="S_KeepInTouch" comment="Keep in touch tab name">ကေတ်အဆက်ညိ</string>
+  <!-- Context: Configuration Dialog - Tab names -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.492.0 -->
+  <string name="S_KeepInTouch_AccessChar" comment="Direct access to the Keep in Touch tab using alt+">T</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Filename" comment="Keyboard download window, etc. - term for filename">ယၟုဝှါၚ်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Version" comment="Keyboard download window, etc. - term for package version">ပါယှေန်ပက်ကေ:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.442.0 -->
+  <string name="S_Caption_KeyboardVersion" comment="Keyboard download window, etc. - term for keyboard version">ပါယှေန်ကဳဗုဒ်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Author" comment="Keyboard download window, etc. - term for author">မၞိဟ်ချူဗဒှ်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Website" comment="Keyboard download window, etc. - term for website">ဝက်သာ်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Package" comment="Keyboard download window, etc. - term for package">ပက်ကေ:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Fonts" comment="Keyboard download window, etc. - term for fonts">မလိက်ဖွန်ဂမၠိုၚ်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Keyboards" comment="Keyboard download window, etc. - term for keyboard layouts">သ္ၚိအၚ်ကဳဗုဒ်ဂမၠိုၚ်:</string>
+  <!-- Context: Keyboard Install Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Caption_Keyboard" comment="Keyboard install dialog - term for a single keyboard layout">သ္ၚိအၚ်ကဳဗုဒ်:</string>
+  <!-- Context: Keyboard Install Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Caption_KeyboardLanguage" comment="Keyboard install dialog - term for caption for language selector a single keyboard layout">ဘာသာ ကဳဗုဒ်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Encodings" comment="Keyboard download window, etc. - term for encodings (encodings include Unicode, ANSI, Non-Unicode, etc).">အေန်ကုဒ်ဂမၠိုၚ်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_LayoutType" comment="Keyboard download window, etc. - term for keyboard layout type (keyboard layout types include Fixed and Mnemonic)">ဂကူ သ္ၚိအၚ်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_LayoutType_Positional" comment="Keyboard download window, etc. - term for the fixed keyboard layout type">ဗီုပြၚ်ဂမစိုတ် (Positional)</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_LayoutType_Mnemonic" comment="Keyboard download window, etc. - term for the mnemonic keyboard layout type">ခံက်အၚ် သွက် သ္ၚိအၚ် ဝေန်ဒဵု (Mnemonic)</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.420.0 -->
+  <string name="S_Caption_Languages" comment="Text preceding linked language profiles">ဘာသာဂမၠိုၚ်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.420.0 -->
+  <string name="S_Languages_Uninstall" comment="Remove language profile">✕</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.420.0 -->
+  <string name="S_Languages_Install" comment="Add language profile">ထပ်စုတ် ဘာသာ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 16.0.47 -->
+  <string name="S_Languages_Addremove" comment="Title for dialog to add or remove languages for keyboard layout">စုတ်/ပ္တိတ် ဘာသာ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_OnScreenKeyboard" comment="Term for the On Screen Keyboard">ကဳဗုဒ်လ္တူဗၠးမုက်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.306.0 -->
+  <string name="S_OnScreenKeyboard_Custom" comment="(OSK) Custom term">ပၟိက်စိုတ်</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OnScreenKeyboard_Installed" comment="(OSK) Installed term">စုတ်လဝ်တုဲ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OnScreenKeyboard_NotInstalled" comment="(OSK) Not installed term">ဟွံဂွံစုတ်လဝ်ဏီ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.306.0 -->
+  <string name="S_Caption_Documentation" comment="Term for the Documentation">ပရောပရာ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.306.0 -->
+  <string name="S_Documentation_Installed" comment="(Documentation) Installed term">စုတ်တုဲ</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.306.0 -->
+  <string name="S_Documentation_NotInstalled" comment="(Documentation) Not installed term">ဟွံဂွံစုတ်လဝ်</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Message" comment="Keyboard download window, etc. - term for additional messages">လိက်ဂကန်ဖျန်:</string>
+  <!-- Context: Configuration Dialog - Captions -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Caption_Copyright" comment="Keyboard download window, etc. - term for copyright">တၠမူ:</string>
+  <!-- Context: Configuration Dialog - Footer -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Footer_ChangesImmediate" comment="Short-term (14.0) message explaining why Ok and Cancel buttons are no longer present">ပရေၚ်ပြံၚ်သၠာဲ ဒှ်ဒတန် ဓဝါဲဂှ်</string>
+  <!-- Context: Configuration Dialog - Footer -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_InstallKeyboard" comment="Keyboard Layouts - install keyboard button">စုတ်ကဳဗုဒ်...</string>
+  <!-- Context: Configuration Dialog - Footer -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_DownloadKeyboard" comment="Keyboard Layouts - download keyboard button">ဂြဲကေတ် ကဳဗုဒ်...</string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.287.0 -->
+  <string name="S_Menu_Options" comment="KL option button submenu - keyboard options">ဒၞါဲရုဲစှ် ကဳဗုဒ် ဂမၠိုၚ်...</string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Keyboards_NoKeyboardsInstalled" comment="Keyboard Layouts - notice of no keyboard layouts installed">ကဳဗုဒ်လဵုမွဲ မၞးဟွံဂွံစုတ်လဝ်ဏီ။ သ္ဂောံစုတ် သ္ၚိအၚ်ကဳဗုဒ် နူ ဝက်သာ် ကဳမာန်ဂှ် ဍဵုလ္တူ မဍဵု ဂြဲကေတ် ကဳဗုဒ်ညိ။</string>
+  <!-- Parameters: %1$s = keyboard layout name -->
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- Introduced: 7.1.251.0 -->
+  <!-- String Type: PlainText -->
+  <string name="SKUninstallRequireAdmin" comment="Keyboard Layouts - notice of ineligibility to uninstall a keyboard">မၞိဟ်က္ဆံၚ် ထိၚ်ဒဝ်ဟေၚ် ပလှ်ပ္တိတ် ကဳဗုဒ် \'%1$s\' ဏံမာန်ရ။</string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 13.0.40.0 -->
+  <string name="S_Keyboard_Share" comment="Keyboard Layouts - share selected keyboard button">ပါ်ပြအ် ကဳဗုဒ်</string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 13.0.40.0 -->
+  <string name="S_Keyboard_Share_QRCode" comment="Keyboard Layouts - caption explaining QRCode, plus prefix to link to share">ဂွံစုတ်ကဳဗုဒ်ဏံ ပ္ဍဲစက်တၞဟ်ဟ်ဂှ် သဂေန် ကုက်ဏံညိ </string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 13.0.40.0 -->
+  <string name="S_Keyboard_Share_Link" comment="Keyboard Layouts - text for link to share">ပါ်ပြအ်လ္တူ လပှ်ကျာ</string>
+  <!-- Context: Configuration Dialog - Keyboard Layouts tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 13.0.40.0 -->
+  <string name="S_Keyboard_Share_LinkSuffix" comment="Keyboard Layouts - suffix for link to share"></string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="kogGeneral" comment="Options section - General">နာနာ</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="kogStartup" comment="Options section - Startup">စညိ</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="kogOSK" comment="Options section - OSK">ကဳဗုဒ်လ္တူဗၠးမုက်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="kogAdvanced" comment="Options section - Advanced">ဒၞါဲပလေဝ် က္ဆံၚ်သၠုၚ်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koKeyboardHotkeysAreToggle" comment="General options - hotkeys toggle on AND off a keyboard layout">မဍဵုတၟေၚ် ကဳဗုဒ် ပံက် ကဳဗုဒ်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koAltGrCtrlAlt" comment="General options - Ctrl+Alt simulates AltGr on computers without AltGr">ပချဳ AltGr နကဵု Ctrl+Alt</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 9.0.480.0 -->
+  <string name="koDeadkeyConversion" comment="Advanced options - Base keyboard deadkeys are treated as normal keys">စွံ မဍဵုချိုတ်တ် နကဵု မဍဵု အလောတ်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="koShowHints" comment="General options - show/hide hint messages (resets hint messages individually disabled)">ထ္ၜးလိက်စၞောန်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 14.0 -->
+  <string name="koAutomaticallyReportErrors" comment="General options - report errors to Keyman team automatically">ပ္တိုန်ထ္ၜး တၚ်ယောၚ်ယာကဵု keyman.com ကေတ်တ်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 14.0 -->
+  <string name="koAutomaticallyReportUsage" comment="General options - report anonymous usage to Keyman team automatically">ပါ်ပရအ် စရၚ်သုၚ်စောဲ သ္ၚိတ်တ်ကု keyman.com</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koStartWithWindows" comment="Startup options - Start Keyman with Windows start">စကမၠောန် အဃော ဝေန်ဒဵုစ</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koShowStartup" comment="Startup options - show/hide splash screen">ပံက် ဗၠးသပလက်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koShowWelcome" comment="Startup options - show/hide welcome screen">ထ္ၜးမုက်လိက် ဒုၚ်တၠုၚ်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koCheckForUpdates" comment="Startup options - check online weekly for updates">စၟဳစၟတ် keyman.com သွက် သမၠုၚ်က္ဆံၚ် ဇၟာပ်သတ္တဟ</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.236.0 -->
+  <string name="koTestKeymanFunctioning" comment="Startup options - test for conflicting apps when Product starts">စၟဳစၟတ် အပလဳကေယှေန် ပဠပထုဲမာန် အဃောစ ကဳမာန်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.236.0 -->
+  <string name="koReleaseShiftKeysAfterKeyPress" comment="OSK options - Releases shift/ctrl/alt on OSK after key press">ဍဵုကဳတုဲ ဗလး Shift/Ctrl/Alt လ္တူ ကဳဗုဒ်ဗၠးမုက်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="koAutoOpenOSK" comment="OSK options - auto-open OSK">ယဝ်ရ ကဳဗုဒ်ကဳမာန် ရုဲလဝ်မ္ဂး ပံက် ကဳဗုဒ်ဗၠးမုက် လၟိန်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="koAutoSwitchOSKPages" comment="OSK options - when a keyboard is activated, switch to most appropriate page in OSK">ယဝ်ရ ရုဲစှ်လဝ်ကဳဗုဒ်မွဲမွဲမ္ဂး ပံက်ကဵု အရီုဗၚ် မဆက်စပ် ကု ကဳဗုဒ်ဗၠးမုက်</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="koDebugging" comment="Advanced options - turn on debugging (which creates a very large file)">ဂၠိုက်ဂၠာဲပသောၚ်စၟ</string>
+  <!-- Context: Configuration Dialog - Options tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.445.0 -->
+  <string name="S_Button_BaseKeyboard" comment="Options tab - base keyboard button">ကဳဗုဒ် သဇိုၚ်...</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.241.0 -->
+  <string name="S_Hotkey_Language_Prefix" comment="Hotkey - activation term preceding Windows language name. Note: include a space following."></string>
+  <!-- e.g. "Activate [Korean KORDA] Keyboard" -->
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.241.0 -->
+  <string name="S_Hotkey_Language_Suffix" comment="Hotkey - language term following Windows language name. Note: include an initial space."></string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkey_None" comment="Hotkey - text used when no hotkey set">(ကဳတၟေၚ်ဟွံမွဲ)</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkey_TurnKeymanOff" comment="Hotkey - Turn Product Off">ကၟာတ် ပြံၚ်သၠာဲ ကဳမာန်</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkey_OpenKeyboardMenu" comment="Hotkey - Open Keyman system tray menu">ပံက် မဳနူ ကဳဗုဒ်</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkey_ShowOnScreenKeyboard" comment="Hotkey - show keyboard in OSK">ထ္ၜးက္ဆံၚ် ကဳဗုဒ်ဗၠးမုက်</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Hotkey_OpenConfiguration" comment="Hotkey - open Keyman Configuration">ဗီုပြၚ်သၞောတ်စက် ကဳမာန်</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.275.0 -->
+  <string name="S_Hotkey_ShowFontHelper" comment="Hotkey - show font helper in OSK">ထ္ၜးအရီုဗၚ်သွက်မလိက်</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.275.0 -->
+  <string name="S_Hotkey_ShowCharacterMap" comment="Hotkey - show character map in OSK">ထ္ၜးခံက်အၚ် အက္ခရ်</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.275.0 -->
+  <string name="S_Hotkey_OpenTextEditor" comment="Hotkey - open text editor">ပံက် ဒၞါဲပလေဝ်ဒါန်လိက်</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_Hotkey_SwitchLanguage" comment="Hotkey - switch language window">ပံက်စက်ပြံၚ် ဘာသာ</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.274.0 -->
+  <string name="S_Hotkey_Control_Title" comment="Hotkey - Control Title">မဍဵုတၟေၚ်နာနာ</string>
+  <!-- Context: Configuration Dialog - Hotkeys tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.274.0 -->
+  <string name="S_Hotkey_Keyboard_Title" comment="Hotkey - Keyboard Title">သ္ၚိအၚ်ကဳဗုဒ်ဂမၠိုၚ်</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.465.0 -->
+  <string name="S_Support_ContactInstructions_Free" comment="">တၚ်ယောၚ်ယာ တၚ်ဟွံကၠးမးမွဲမွဲဒှ်တိုန်အဃောသုၚ်စောဲ ကဳမာန်မ္ဂး သၟာန်သၟုက်ပ္ဍဲကဵု ဂကောံ ဖဝ်ရာမ် ကဳမာန်ဂွံရ။</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.465.0 -->
+  <string name="S_Button_CommunitySupport" comment="">ပံက်ဖဝ်ရာမ် ကဳမာန်</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 11.0.1500.0 -->
+  <string name="S_Support_CreatedBySIL" comment="Support - SIL statement">SIL International ဖန်ဗဒှ်လဝ်</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Support_Copyright" comment="Support - Product Copyright">တၠမူ © SIL International. အခေါၚ်အဝဵုနွံပေၚ်ၚ်။</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Support_Version" comment="Support - version">ပါယှေန်</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_Support_UsefulLinks" comment="Support - Useful Links heading">လေက် ဒှ်အထံက်အရီုဂမၠိုၚ်</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_OnlineSupport" comment="Support button - links to online support">အရီုဗၚ်လ္တူလပှ်ကျာ</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_CheckForUpdates" comment="Support button - manually checks for product updates">စၟဳစၟတ်တၚ်နၚ်ပ္တိုန်က္ဆံၚ်</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_ProxyConfig" comment="Options button - allows manual adjustment of proxy settings">တၚ်ပလေဝ် ပရံက်ဇြဳ...</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Button_SettingsManager" comment="Options button - access to the Settings Manager">တၚ်ပလေဝ် ကဳမာန်နာနာ...</string>
+  <!-- Context: Configuration Dialog - Support tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_Diagnostics_Diagnostics" comment="Support button submenu - performs a diagnostic report">ဂၠိုၚ်ဂၠါဲပြဿနာ</string>
+  <!-- Context: Download Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_DownloadKeyboard_Title" comment="Download keyboard layout from keyman.com dialog title">ဂြဲကေတ် ကဳဗုဒ်နူ keyman.com</string>
+  <!-- Context: Download Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_DownloadKeyboard_DownloadOnlyCheckbox" comment="Download only option checkbox">ဂြဲဖျေံသၟး လ္ပစုတ်</string>
+  <!-- Parameters: %1$s = Error Message, %2$d Error Code -->
+  <!-- Context: Download Keyboard Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_DownloadKeyboard_DownloadError" comment="Message shown when there is an error downloading the keyboard package">ဂြဲဖျေံကဳဗုဒ်ဟွံဂွံ၊ တၚ်ဗၠေတ် %2$d: %1$s</string>
+  <!-- Context: Download Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 14.0 -->
+  <string name="S_Button_Back" comment="Back button">&lt; ကလေၚ်</string>
+  <!-- Context: Install Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_InstallKeyboard_Title" comment="Install keyboard/package dialog title">စုတ် ကဳဗုဒ်/ပက်ကေ</string>
+  <!-- Context: Install Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_InstallKeyboard_Tab_Details" comment="Install keyboard/package - details">တၚ်နၚ်သောဲသောဲဗြောဲဗြောဲ</string>
+  <!-- Context: Install Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_InstallKeyboard_Tab_Readme" comment="Install keyboard/package - readme">ဗှ်အဲညိ</string>
+  <!-- Context: Install Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_InstallKeyboard_Button_Install" comment="Install keyboard/package - install button">စုတ်</string>
+  <!-- Context: Proxy Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ProxyConfiguration_Title" comment="Proxy configuration dialog title">တၚ်ချိၚ်သာပါပရံက်ဇြဳ</string>
+  <!-- Context: Proxy Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ProxyConfiguration_Server" comment="Proxy dialog - fillable-field server">သာပါ: </string>
+  <!-- Context: Proxy Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ProxyConfiguration_Port" comment="Proxy dialog - fillable-field port">ဖတ်: </string>
+  <!-- Context: Proxy Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ProxyConfiguration_Username" comment="Proxy dialog - fillable-field username">ယၟုမၞိဟ်သုၚ်စောဲ: </string>
+  <!-- Context: Proxy Configuration Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_ProxyConfiguration_Password" comment="Proxy dialog - fillable-field password">မဓလုက်: </string>
+  <!-- Context: Base Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.445.0 -->
+  <string name="S_BaseKeyboard_Title" comment="Base keyboard dialog title">စွံဒတန် ကဳဗုဒ်သဇိုၚ်</string>
+  <!-- Context: Base Keyboard Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.445.0 -->
+  <string name="S_BaseKeyboard_Text" comment="Base keyboard dialog description">ရုဲစှ် သ္ၚိအၚ်ကဳဗုဒ် လက်တေန် မၞးသုၚ်စောဲ ပ္ဍဲဝေန်ဒဵုညိ။ ကဳဗုဒ် ကဳမာန် ချိၚ်ဆဏာကဵု ကဳဗုဒ် အတိုၚ်မၞးဒးစိုတ်ဂှ်ဏောၚ်။</string>
+  <!-- Context: Hotkey Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKChangeHotkeyTitle" comment="Change Hotkey dialog title">ပြံၚ်မဍဵုတၟေၚ်</string>
+  <!-- Parameters: %1$s = Name of keyboard -->
+  <!-- Context: Hotkey Dialog -->
+  <!-- Introduced: 7.0.241.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKSetHotkey_Language" comment="Hotkey dialog - message when setting hotkey for a language">ရုဲစှ်မဍဵုတၟေၚ် ဟွံသေၚ်မ္ဂး ရုဲကေတ် \'ပၟိက်စိုတ်\' တုဲ ဍဵုလဝ် Ctrl,Shift and/ Alt တုဲ တက်စုတ် မဍဵုတၟေၚ်မၞးဒးစိုတ်သွက်ဘာသာ %1$s:</string>
+  <!-- Context: Hotkey Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKSetHotkey_Interface" comment="Hotkey dialog - message displayed when changing a hotkey for a product feature (e.g. show menu or show on screen keyboard)">ရုဲစှ်မဍဵုတၟေၚ် ဟွံသေၚ်မ္ဂး ရုဲကေတ် \'ပၟိက်စိုတ်\' တုဲ ဍဵုလဝ် Ctrl,Shift and/ Alt တုဲ တက်စုတ် မဍဵုတၟေၚ်မၞးဒးစိုတ်:</string>
+  <!-- Parameters: %1$s = Hotkey -->
+  <!-- Context: Hotkey Dialog -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUnsafeHotkey" comment="Hotkey dialog - warning of hotkey conflict with standard keyboard use">မဍဵုတၟေၚ် %1$s ဂှ်ဒှ် ပဠပထုဲကု ကဳဗုဒ်ဓမ္မတာမာန်ရ။ မၞးအောန်အိုတ်သုၚ်စောဲ ကဵု Ctrl ကဵု Alt ညိ။ မိက်ဂွံပြံၚ်လၟုဟ်ဟာ\?</string>
+  <!-- Parameters: %1$s = Hotkey, %2$s = Conflicting keyboard -->
+  <!-- Context: Hotkey Dialog -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKHotkeyConflicts_Keyboard" comment="Hotkey dialog - warning of hotkey conflict with hotkey for another keyboard">မဍဵုတၟေၚ် %1$s ဒှ်ပြသာနာကု မဍဵုတၟေၚ် ရုဲစှ်လဝ်သွက် ကဳဗုဒ် %2$s ရ။ ယဝ်ဆက်အာမ္ဂး မဍဵုတၟေၚ်သွက် ကဳဗုဒ် %2$s ဂှ်သ္အးထောံဏောၚ်။ ဆက်အာဟာ\?</string>
+  <!-- Parameters: %1$s = Hotkey -->
+  <!-- Context: Hotkey Dialog -->
+  <!-- Introduced: 14.0.117 -->
+  <!-- String Type: FormatString -->
+  <string name="SKHotkeyConflicts_Interface" comment="Hotkey dialog - warning of hotkey conflict with hotkey for another interface hotkey">မဍဵုတၟေၚ် %1$s ဒှ်ပြဿနာကု မဍဵုတၟေၚ်တၞဟ်ဟ်ရ။ ယဝ်ဆက်အာမ္ဂး မဍဵုတၟေၚ်တၞဟ်ဟ်ဂှ် သ္အးထောံရောၚ်။ ဆက်အာဟာ\?</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Update_Title" comment="Update dialog title, where Keyman = product name">ကပေါတ်တၟိသွက်ကဳမာန်တံကလိဂွံမာန်ယျ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Update_NewVersionAvailable" comment="Update dialog - updates available text">ပ္တိုန်က္ဆံၚ်သွက်ကဳမာန်ဂွံရ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.255.0 -->
+  <string name="S_Update_NewVersionPrompt" comment="Update dialog - prompt to select updates">ရုဲစှ်တၚ်သမၠုၚ်က္ဆံၚ်မၞးမိက်ဂွံစုတ်ညိ:</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Update_DownloadFrom" comment="Update dialog - download information">မၞးဂြဲကေတ်ပါယှေန်တၟိမာန် နူ :</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Update_Button_InstallNow" comment="Update dialog - install now button">စုတ်လၟုဟ်</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Update_Button_InstallLater" comment="Update dialog - cancel button">တးပါဲ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.255.0 -->
+  <string name="S_Update_OldVersionHead" comment="Update dialog - old version">ပါယှေန်တြေံ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.255.0 -->
+  <string name="S_Update_ComponentHead" comment="Update dialog - update component">ကပေါတ်သမၠုၚ်က္ဆံၚ်တုဲ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.1.255.0 -->
+  <string name="S_Update_SizeHead" comment="Update dialog - update size">အဝဲ</string>
+  <!-- Parameters: %1$s = Current version number -->
+  <!-- Context: Online Update Dialog -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUpdate_KeymanText" comment="Update dialog - name and version of updatable product">ကဳမာန် %1$s</string>
+  <!-- Parameters: %1$s = Package description, %2$s = Current package version number -->
+  <!-- Context: Online Update Dialog -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUpdate_PackageText" comment="Update dialog - name and version of updatable keyboard layout package">ကဳဗုဒ် %1$s %2$s</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKUpdate_UnableToContact" comment="Update dialog - unable to access keyman.com warning">ဆက်စၠောံကု keyman.com ဟွံဂွံ - ကလေၚ်စၟဳစၟတ် အေန်တာနက်တုဲ ဂ္စါန်မွဲဝါပၠန်ညိ။</string>
+  <!-- Parameters: %1$s = Error message -->
+  <!-- Context: Online Update Dialog -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUpdate_UnableToContact_Error" comment="Update dialog - unable to access keyman.com error message">ဆက်စၠောံကု keyman.com ဟွံဂွံ - ကလေၚ်စၟဳစၟတ် အေန်တာနက်တုဲ ဂ္စါန်မွဲဝါပၠန်ညိ။ တၚ်ယောၚ်ယာဂှ် :%1$s</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.288.0 -->
+  <string name="SKUpdate_IconTitle" comment="Update icon - title">တၚ်သမၠုၚ်က္ဆံၚ်သွက်ကီမာန်ကလိဂွံမာန်ရ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.288.0 -->
+  <string name="SKUpdate_IconText" comment="Update icon - text">သ္ဂောံဂြဲကေတ်တုဲ ပ္တိုန်က္ဆံၚ်ဂှ် ဍဵုရုပ်ဏံညိ</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.288.0 -->
+  <string name="SKUpdate_IconMenuText" comment="Update icon - install menu item">ဗဵုကေုာံ &amp;ပ္တိုန် သမၠုၚ်က္ဆံၚ်ကဳမာန်</string>
+  <!-- Context: Online Update Dialog -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.288.0 -->
+  <string name="SKUpdate_IconMenuExit" comment="Update icon - exit menu item">ဗ&amp;ဒေါံ စၟဳစၟတ်သမၠုၚ်က္ဆံၚ်အောန်လာၚ်</string>
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.288.0 -->
+  <string name="S_Splash_Name" comment="Splash major title">ကဳမာန်</string>
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_Splash_Start" comment="Start Keyman button">စ ကဳမာန်</string>
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_Splash_Exit" comment="Exit button">တိတ်</string>
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_Splash_Configuration" comment="Keyman Configuration link">ပလေဝ်ပလေတ်နာနာ</string>
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.341.0 -->
+  <string name="S_Splash_ShowAtStartup" comment="Show at Startup toggle">ထ္ၜးမုက်ဒ္ၚောဝ်တဏအ်ကာလစကၠောန်</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.278.0 -->
+  <string name="S_DisplayIn" comment="'Display In' text label for UI language menu">ဓမံက်ထ္ၜးပ္ဍဲ</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 8.0.278.0 -->
+  <string name="S_MoreUILanguagesMenu" comment="More UI languages online menu item">ကလေၚ်ဂၠာဲဓမံက်ထ္ၜးအရေဝ်ဘာသာတၞဟ်လ္ပာ်အောန်လာဲ...</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 9.0.525.0 -->
+  <string name="S_ContributeUILanguagesMenu" comment="Link to contribute to language UI">ကဵုအရီုကၠာဲဘာသာမဆေၚ်စပ်ကဵုကိစ္စညးလွပ်တၞဟ်...</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKUILanguageName" comment="User interface language name in the UI language">မန်</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKUILanguageNameWithEnglish" comment="UI language name in the UI language with the English name in parentheses  (this message is used when the user gets stuck in a strange UI language)">မန် (Mon)</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKLanguageCode" comment="The language code for the current translation">mnw</string>
+  <!-- Context: _LanguageInfo -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKDefaultLanguageCode" comment="The default language code for this product.  This should be the language that the product is created in. For Keyman this must stay 'en', for all translations.">mnw</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKShortApplicationTitle" comment="Product name">ကဳမာအ်</string>
+  <!-- Context: Hints -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="S_Button_ResetHints" comment="Hint - options tab button to reset hints">သအးထောံဂရိပ်အရေဝ်ဂမၠိုၚ်</string>
+  <!-- Context: Hints -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.244.0 -->
+  <string name="SKHintsReset" comment="Hint - options tab dialog confirming reset of hints">ထိုၚ်လိက်ဂရိပ်အရေဝ်သီုဖအိုတ်ဒးဒုၚ်သအးထောံတုဲ ကဵု ကလေၚ်ဓမံက်ထ္ၜးကဵုမွဲအလန်ပၠန်။</string>
+  <!-- Context: Hints -->
+  <!-- Introduced: 7.0.244.0 -->
+  <!-- String Type: HintTitle -->
+  <!-- DevNote: this is a constructed identifier so won't appear in a search with i18n-check-unused-strings.sh -->
+  <string name="HintTitle_KH_EXITPRODUCT" comment="Hint - dialog title upon attempting to exit product">တိတ်နူကဳမာအ်ချိုတ်ပၠိုတ်ယျဟာ?</string>
+  <!-- Context: Hints -->
+  <!-- Introduced: 7.0.244.0 -->
+  <!-- String Type: Hint -->
+  <!-- DevNote: this is a constructed identifier so won't appear in a search with i18n-check-unused-strings.sh -->
+  <string name="Hint_KH_EXITPRODUCT" comment="Hint - asks for confirmation, explains the difference between de-activating a keyboard layout and closing Product">မိက်ဂွံကၟာတ် ကဳမာန်ဂှ် ချိုတ်ပၠိုန်ဟာ\? ကဳဗုဒ်ကဳမာန်မၞးဂှ် လုပ်အာပ္ဍဲစရၚ် အရေဝ်ဘသာ ဝေန်ဒဵု ရောၚ် ဆ္ဂး ဟွံကေၚ်ပံက်ကၟာတ် ကဳမာန်ဏီမ္ဂး ဟွံကၠောန်ကမၠောန်ရ။</string>
+  <!-- Context: Hints -->
+  <!-- Introduced: 7.0.244.0 -->
+  <!-- String Type: HintTitle -->
+  <!-- DevNote: this is a constructed identifier so won't appear in a search with i18n-check-unused-strings.sh -->
+  <string name="HintTitle_KH_CLOSEOSK" comment="Hint - dialog title upon closing the OSK">ကၟာတ်ကဳဗုဒ်ဗၠးမုက်</string>
+  <!-- Context: Hints -->
+  <!-- Introduced: 7.0.244.0 -->
+  <!-- String Type: Hint -->
+  <!-- DevNote: this is a constructed identifier so won't appear in a search with i18n-check-unused-strings.sh -->
+  <string name="Hint_KH_CLOSEOSK" comment="Hint - explains that Product is still running and informs how to reopen OSK">ကၟာတ် ကဳဗုဒ်ဗၠးမုက်တုဲ။ ကဳမာန်ကၠောန်မံၚ်ကမၠောန်ဖိုဟ်။ မၞးဍဵုလ္တူရုပ်ကဳမာန်တုဲ ရုဲကေတ် ကဳဗုဒ်ဗၠးမုက်မာန်ရ။</string>
+  <!-- Context: Hints -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 10.0.836.0 -->
+  <string name="S_HintDialog_DontShowHintAgain" comment="Hint dialog - caption of checkbox at bottom of dialog">လ္ပထ္ၜးလိက်စၞောန်ပၠန်ညိ</string>
+  <!-- Context: Help Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_HelpTitle" comment="Help - product name help">အရီုဗၚ် ကဳမာန်</string>
+  <!-- Context: Help Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Help_Product" comment="Help - help contents link title">တၚ်အရီုဗၚ်ဂမၠိုၚ်</string>
+  <!-- Context: Help Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Help_Keyboard_Prefix" comment="Help - text preceding keyboard name">အရီုဗၚ်လ္တူ \"</string>
+  <!-- Context: Help Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Help_Keyboard_Suffix" comment="Help - text following keyboard name">\" ကဳဗုဒ်</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_ViewOnScreenKeyboard" comment="Toolbar help - View OSK pop-up text">ဗဵုကဳဗုဒ်လ္တူဗလးမုက်</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_ViewFontHelper" comment="Toolbar help - View Font Helper pop-up text">ဗဵုအရီုဗၚ်မလိက်ဖွန်</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_ViewCharacterMap" comment="Toolbar help - View Character Map pop-up text">ဗဵုခံက်သ္ၚိအၚ်အက္ခရ်</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_OpenConfiguration" comment="Toolbar help - Open Keyman Configuration pop-up text">ပံက်ဒၞါဲပလေဝ်သၞောတ်စက် ကဳမာန် နာနာ</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_OpenHelp" comment="Toolbar help - Open help pop-up text">ပံက်ဒၞါဲအရီုဗၚ်</string>
+  <!-- Context: Toolbar Context Help -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Toolbar_CloseOnScreenKeyboard" comment="Toolbar help - Close OSK pop-up text">ကၟာတ် ကဳဗုဒ်ဗၠးမုက်</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_SwitchKeymanOff" comment="Systray item - Switch Keyman Off [&amp; precedes alt + access-character]">ပြံၚ် ကဳမာန် &amp;ကၟာတ်</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_OnScreenKeyboard" comment="Systray item - OSK [&amp; precedes alt + access-character]">ကဳဗုဒ် &amp;လ္တူဗၠးမုက်</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_FontHelper" comment="Systray item - Font Helper [&amp; precedes alt + access-character]">အရီုဗၚ်မလိက်ဖွန်&amp;</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_CharacterMap" comment="Systray item - Character Map [&amp; precedes alt + access-character]">သ္ၚိအၚ် အက္ခရ် &amp;</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_TextEditor" comment="Systray item - Text Editor [&amp; precedes alt + access-character]">&amp;ပလေဝ်ဒါန်လိက်...</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_Configuration" comment="Systray item - Configuration [&amp; precedes alt + access-character]">တၚ်ပလေဝ်နာနာ &amp;...</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_Help" comment="Systray item - Help [&amp; precedes alt + access-character]">&amp;အရီုဗၚ်...</string>
+  <!-- Context: System Tray Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_Menu_Exit" comment="Systray item - Exit [&amp; precedes alt + access-character]">တိတ်&amp;</string>
+  <!-- Context: On Screen Keyboard Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OSKContext_FadeWhenInactive" comment="OSK right-click menu - fade OSK when mouse is elsewhere">ဟွံချဳဓရာၚ်မ္ဂး အေဲဖျေံလျး</string>
+  <!-- Context: On Screen Keyboard Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OSKContext_ShowToolbar" comment="OSK right-click menu - show/hide OSK toolbar">ထ္ၜးဒၞါဲကပေါတ်</string>
+  <!-- Context: On Screen Keyboard Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OSKContext_SaveAsWebPage" comment="OSK right-click menu - save diagram of active keyboard layout as a web page">ဂွံစွံနကဵု မုက်လိက် ဝေက်...</string>
+  <!-- Context: On Screen Keyboard Menu Items -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="S_OSKContext_Print" comment="OSK right-click menu - print diagram of active keyboard layout">ဆာဲပ္တိတ်...</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKApplicationTitle" comment="Product name used for the title of message boxes and message dialogs">ကဳမာန်</string>
+  <!-- Parameters: %1$s = Version number string -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKSplashVersion" comment="Version number">ပါယှေန် %1$s</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.239.0 -->
+  <string name="SKButtonPrint" comment="Print button in Welcome dialog for keyboards">&amp;ဆာဲပ္တိတ်...</string>
+  <!-- Parameters: %1$s = Package to be uninstalled -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKPackageAlreadyInstalled" comment="Notice during package installation that a package with the same name is already installed.">ပက်ကေ နကဵုယၟု %1$s ဂှ်စုတ်လဝ်တုဲတုဲ။ မိက်ဂွံပ္တိတ်ထောံဍေံတုဲ ကလေၚ်စုတ်တၟိဟာ\?</string>
+  <!-- Parameters: %1$s = Keyboard name -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKKeyboardAlreadyInstalled" comment="Notice during keyboard layout installation that a keyboard layout with the same name is already installed.">ကဳဗုဒ် နကဵု ယၟု %1$s ဂှ်စုတ်လဝ်တုဲတုဲ။ ယဝ်ဆက်အာမ္ဂး ပ္တိတ်ဍေံကၠာတုဲ စုတ်တၟိရောၚ်။ ဆက်အာဟာ\?</string>
+  <!-- Parameters: %1$s = Keyboard name, %2$s = Package name -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKKeyboardPartOfPackage" comment="Notice of need to uninstall an entire package">ကဳဗုဒ် %1$s ဂှ် အပိုၚ်ခြာ နူကဵု ပက်ကေ %2$s ရ။ မၞးဒးပ္တိတ် အတိုၚ်ပက်ကေမွဲရောၚ်။ ဆက်အာဟာ\?</string>
+  <!-- PArameters: %1$s = BCP 47 code -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 14.0.211 -->
+  <!-- String Type: FormatString -->
+  <string name="SKInstallLanguageTransientLimit" comment="Message shown when Keyman is unable to install a Windows language for a keyboard">စုတ် အရေဝ်ဘာသာကဳဗုဒ် ဟွံဂွံ။ ဝေန်ဒဵုစဵုဒၞါလဝ် စုတ်ပၟိက်စိုတ်ဂွံ ၄ ဘာသာဟေၚ် တုဲ မၞးစုတ်လဝ် ပဵုအာနူကဵု ဗ္ၜတ်ဒှ်ဂွံရ။</string>
+  <!-- Parameters: %1$s = Package Name -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKPackageDoesNotIncludeWelcome" comment="Notice of lack of introductory help">ပက်ကေ (ဟွံ) ကဳဗုဒ် %1$s ဟွံမွဲပ္ဍဲကဵု အရီုဗၚ်ဆက်မိတ်ရ။</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKOSNotSupported" comment="Notice of unsupported operating system">စက်မၞးသုၚ်စောဲမံၚ်လၟုဟ်ဏံဟွံထံက်ပၚ်ရ။</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKOnlineHelpFile" comment="File name of the help file - must be .chm format.  The locale folder will be checked first for the file">KeymanDesktop.chm</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKCouldNotFindHelp" comment="Notice of help file not found">ဝှါၚ်အရီုဗၚ်ဂၠါဲဟွံဆဵု။</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKANSIEncoding" comment="Keyboard with an ANSI or Codepage encoding">မုက်လိက်ကုက်</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKUnicodeEncoding" comment="Keyboard with a Unicode encoding">ယူနဳကုဒ်</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKDownloadProgress_Title" comment="Notice of file downloading">ဂြဲဖျေံဒၟံၚ်ဝှါၚ်</string>
+  <!-- Parameters: %1$s = Keyboard name -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUninstallOnScreenKeyboard" comment="Request for confirmation to uninstall OSK for a keyboard layout">မိက်ဂွံပ္တိတ် ကဳဗုဒ်ဗၠးမုက် စုတ်လဝ်သွက်%1$s ဂှ်ချိုတ်ပၠိုတ်ဟာ?</string>
+  <!-- Parameters: %1$s = Keyboard name -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.239.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUninstallKeyboard" comment="Request for confirmation to uninstall keyboard layout">မၞးမိက်ဂွံပ္တိတ် ကဳဗုဒ် %1$s ဂှ်ချိုတ်ပၠိုတ်ဟာ\?</string>
+  <!-- Parameters: %1$s = Package name, %2$s: Fonts list -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.239.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUninstallPackage" comment="Request for confirmation to uninstall a package">မၞးမိက်ဂွံပ္တိတ် ပက်ကေ %1$s ဂှ်ချိုတ်ပၠိုတ်ဟာ\?\n\n%2$s</string>
+  <!-- Parameters: %1$s = Fonts list -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.1.270.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUninstallPackageFonts" comment="Text embedded in SKUninstallPackage when fonts are ready for uninstall.">မလိက်ဝှတ်သၟဝ်တေံဂှ်လေဝ်တိတ်အာဏောၚ်: %1$s ။</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKUnicodeData_Build" comment="Request to build Unicode Character Map database">အက္ခရ်ဂမၠိုၚ်ဂှ် ကၠာဟွံဂိုၚ် သြိုၚ်ခၞံ သုၚ်စောဲဂွံဂှ် နွံပ္ဍဲသ္ၚိအၚ်အက္ခရ်ရ။ မိက်ဂွံသြိုၚ်လၟုဟ်ဟာ?</string>
+  <!-- Parameters: %1$s = Error detail string -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUnicodeData_DatabaseCouldNotBeDeleted" comment="Error deleting Unicode Character Map database">သ္ဂောံကလေၚ် သြိုၚ်ခၞံ အက္ခရ်ဂှ် ပလီု ဒေတာသွက်အက္ခရ်ယူနဳကုဒ် ဟွံဂွံရ။ တၚ်ယောၚ်ယာသောဲသောဲဗြောဲဗြောဲဂမၠိုၚ်ဂှ်: %1$s</string>
+  <!-- Parameters: %1$s = Error details -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUnicodeData_CouldNotCreateDatabase" comment="Error creating Unicode Character Map database">ဒေတာသွက် အက္ခရ်ယူနဳကုဒ် ဂှ် ဖန်ဗဒှ်ဟွံဂွံတုဲ ကၟာတ်ထောံရ။ တၚ်ယောၚ်ယာသောဲသောဲဗြောဲဗြောဲဂမၠိုၚ်ဂှ်: %1$s</string>
+  <!-- Parameters: %1$s = Error message -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.230.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKUnicodeData_DatabaseLoadFailedRebuild" comment="Error loading Unicode Character Map database. Request to rebuild.">ဒေတာသွက်အက္ခရ်ယူနဳကုဒ် ဂြဲပ္တိုန် ဟွံအံၚ်ဇၞး (%1$s)။ ကလေၚ်သြိုၚ်ဍေံလၟုဟ်ဟာ\?</string>
+  <!-- Parameters: %1$s: error message -->
+  <!-- Context: Formatted Messages -->
+  <!-- Introduced: 7.0.241.0 -->
+  <!-- String Type: FormatString -->
+  <string name="SKCannotStartProduct" comment="Error from Keyman failing to start keyman.exe due to an access denied or file not found">ကဳမာန် စကမၠောန်ဟွံဂွံ။ အာစၟဳစၟတ် တၚ်ပလေဝ်နာနာပ္ဍဲ ပရေၚ်ဂီုဂၠီုတေံတုဲ keyman.exe ဂှ်ကဵုအခေါၚ်ကၠာညိ။ ယဝ်တၚ်ယောၚ်ယာ ကလေၚ်ကၠုၚ်ဂှ်: \n\n%1$s\n\n မိက်ဂွံကလေၚ်ဂ္စါန် တုဲ ပံက် ကဳမာန် မွဲဝါလၟုဟ်ဟာ\?</string>
+  <!-- Context: Formatted Messages -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 7.0.230.0 -->
+  <string name="SKDebuggingWarning" comment="Warning upon starting debugging in the Options tab">တၚ်နၚ် သောၚ်သၠးစၟသွက်ကဳမာန်ဂှ် ဂိုၚ်စွံလဝ်ပ္ဍဲ ဝှါၚ်ကော်စ %LOCALAPPDATA% \Keyman\Diag\system#.etl (#ဂှ် မဂၞန်ရ)။ ကၠာဟွံပလီု ဝှါၚ်ဂှ် ကၟာတ်ထောံကဳမာန်ကၠာညိ။\n\n\သတိ: ဝှါၚ်ဏံဇၞော်တိုန်ပြဟ်ဟ်မာန်ရ။ ပံက်ဂၠိုက်ဂၠာဲပသောၚ်စၟဂှ် ဖအိၚ်ဖျေံစက်မၞးမာန်တုဲ အ္စာပလေဝ်စက်တံကဵုကသပ်မှ ပံက်မ္ဂးခိုဟ်ရ။\n\nတၚ်ကဵုသတိပရေၚ်ပူဂဵု: ဝှါၚ်ပသောၚ်စၟဂှ် သမ္တီစုတ် အရာမၞးတက်ဏာတံဖအိုတ်ရောၚ်။ အခိၚ်ပိုဲဂၠိုက်ဂၠာဲပသောၚ်စၟမှ ပံက်ကဵု ဝှါၚ်ပသောၚ်စၟမ္ဂးခိုဟ်ရ။</string>
+  <!-- Context: OSK Font Helper -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_OSK_FontHelper_PleaseWait" comment="OSK Font helper message">အဃောဂၠာဲဒၟံၚ် ဝှတ်မလိက်သွက် ကဳဗုဒ် %1$s ဂှ်မၚ်ညိ</string>
+  <!-- Context: OSK Font Helper -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_OSK_FontHelper_NonUnicode" comment="OSK Font helper non-Unicode keyboard">ကဳဗုဒ် %1$s ဂှ် ကဳဗုဒ်ယူနဳကုဒ် ဟွံသေၚ်။ မလိက်ဝှတ်ဂှ် ဂၠာဲကေတ်တ်ဟွံဂွံ။ စၟဳစၟတ် လိက်ကၞပ် ကဳဗုဒ် သွက်တၚ်နၚ် ဝှတ်။</string>
+  <!-- Context: OSK Font Helper -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_OSK_FontHelper_NoKeyboards" comment="OSK Font helper no keyboards">သ္ၚိအၚ်ကဳဗုဒ် လဵုမွဲဟွံဂွံပ္တိုန်စုတ်လဝ်။</string>
+  <!-- Context: OSK Font Helper -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 8.0.294.0 -->
+  <string name="S_OSK_FontHelper_ChooseKeyboard" comment="OSK Font helper choose keyboard">သ္ဂောံဆဵု မလိက်ကောန်ဍောၚ် မဆေၚ်စပ်တံဂှ် ရုဲကဵု ကဳဗုဒ် ကဳမာန်တံညိ။</string>
+  <!-- Context: Text Editor -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 10.0.836.0 -->
+  <string name="SKTextEditorCaption" comment="Caption of Text Editor">ဒၞါဲပလေဝ်ဒါန်လိက် - ကဳမာန်</string>
+</resources>

--- a/windows/src/desktop/setup/locale/mnw-MM/strings.xml
+++ b/windows/src/desktop/setup/locale/mnw-MM/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="ssLanguageName" comment="User interface language name in the UI language">မန် (Mon)</string>
+  <string name="ssApplicationTitle">ပလေဝ်ပလေတ် $APPNAME $VERSION</string>
+  <string name="ssTitle">စုတ် $APPNAME $VERSION</string>
+  <string name="ssInstallSuccess">$APPNAME $VERSION ဂှ်ပ္တိုန်စုတ်တုဲအာ ဗွဲမအံၚ်ဇၞးရ။</string>
+  <string name="ssCancelQuery">မၞးတးပါဲ ပ္တိုန်စုတ် $APPNAME ဏောၚ်ဂှ် ချိုတ်ပၠိုတ်ဟာ?</string>
+  <string name="ssBootstrapExtractingBundle">သှ်ဒၟံၚ် ကဠာဗါန်ဒဴ...</string>
+  <string name="ssBootstrapCheckingPackages">အဃောစၟဳစၟတ်ဒၟံၚ် ပက်ကေဂမၠိုၚ်...</string>
+  <string name="ssBootstrapCheckingForUpdates">သွက်သ္ဂောံသၠုၚ်က္ဆံၚ်တံဂှ် အဃောစၟဳစၟတ်ဒၟံၚ်လ္တူအွန်လာၚ်...</string>
+  <string name="ssBootstrapCheckingInstalledVersions">အဃောစၟဳစၟတ်ဒၟံၚ် ပါယှေန်စုတ်လဝ်တုဲတုဲ...</string>
+  <string name="ssBootstrapReady">ဒတုဲမံၚ်...</string>
+  <!-- Parameters: %0:s: version, %1:s: ssActionDownload -->
+  <string name="ssActionInstallKeyman">• $APPNAME %0:s %1:s</string>
+  <!-- Parameters: %0:s: package name %1:s: version %2:s: ssActionDownload -->
+  <string name="ssActionInstallPackage">• %0:s %1:s %2:s</string>
+  <!-- Parameters: %0:s: package name %1:s: version %2:s: language %3:s: ssActionDownload -->
+  <string name="ssActionInstallPackageLanguage">• %0:s %1:s for %2:s %3:s</string>
+  <string name="ssActionNothingToInstall">မုသက်ပ္တိုန်စုတ်ဟွံမွဲ။</string>
+  <!-- Parameters: %0:s download size -->
+  <string name="ssActionDownload">(%0:s ဂြဲဖျေံလဝ်တုဲ)</string>
+  <string name="ssActionInstall">တၚ်ပ္တိုန်ဏံ ပ္တိုန်ဏာ:</string>
+  <string name="ssFreeCaption">$APPNAME $VERSION ဂှ် မးး ကေုာံ ဒှ် တံရိုဟ်ပံက်လဝ်မးမးရ</string>
+  <string name="ssLicenseLink">&amp;ဗှ်လာၚ်ဇြေန်</string>
+  <string name="ssInstallOptionsLink">စုတ် &amp;တၚ်ရုဲစှ်ဂမၠိုၚ်</string>
+  <string name="ssMessageBoxTitle">ပ္တိုန် $APPNAME</string>
+  <string name="ssOkButton">အဵုခေ</string>
+  <string name="ssInstallButton">&amp;ပ္တိုန်စုတ်</string>
+  <string name="ssCancelButton">တးပါဲ</string>
+  <string name="ssExitButton">ပ&amp;တိတ်</string>
+  <string name="ssStatusInstalling">စုတ်ဒၟံၚ် $APPNAME</string>
+  <string name="ssStatusRemovingOlderVersions">ပ္တိတ်ဒၟံၚ် ပါယှေန်တြေံဂမၠိုၚ်</string>
+  <string name="ssStatusComplete">စုတ်တုဲအာယျ</string>
+  <string name="ssQueryRestart">ပရေၚ်ပ္တိုန်စုတ် ဂွံအံၚ်ဇၞးမာန်ဂှ် မၞးဒးကလေၚ် ကၟာတ်ပံက် ဝေန်ဒဵုကၠာရောၚ်။ ကလေၚ် ကၟာတ်ပံက်စက်တုဲမ္ဂး ဍေံဆက်စုတ်အာကဵုရောၚ်။ 
+
+
+ကၟာတ်ပံက်စက်လၟုဟ်ဟာ?</string>
+  <string name="ssErrorUnableToAutomaticallyRestart">ဝေန်ဒဵုကလေၚ်ပံက်ကၟာတ်ကေတ်တ်ဟွံဂွံ။ ကၠာဟွံဂွံပံက် $APPNAME ဂှ် မၞးကလေၚ်ပံက်ကၟာတ်ကုစက်ထေက်ရ။</string>
+  <string name="ssMustRestart">သ္ဂောံပတုဲကမၠောန်ဂှ်မၞးဒးပံက်ကၟာတ်ကဵု ဝေန်ဒဵုဟေၚ်။ ပံက်ကၟာတ်တုဲမ္ဂး ကမၠောန်ပ္တိုန်တုဲရ။</string>
+  <string name="ssOldOsVersionInstallKeyboards">ဂွံစုတ် $APPNAME $VERSION ဂှ် ဒးကေတ် ဝေန်ဒဵု ၇ (ဟွံ) လပါ်လ္တူရ။ ဆ္ဂး ကဳမာန်ဒက်တပ် ၇၊ ၈၊ ၉ ဂှ် ဂွံဆဵုညာတ်ကေတ်ရ။ မၞးမိက်ဂွံပ္တိုန်စုတ် ကဳဗုဒ်ပါလုပ်ပ္ဍဲ စက်ပ္တိုန်ဏံ လ္တူ ပါယှေတ် ကဳမာန်ဒက်တပ်ဟာ?</string>
+  <string name="ssOldOsVersionDownload">$APPNAME ပါယှေန်ဏံ ဂှ် ဒးကေတ် ဝေန်ဒဵု ၇ ဟွံသေၚ်တှ်ေ လ္ပါ်လ္တူရ။ ဂြဲကေတ် ကဳမာန်ဒက်တပ် ၈ ဟာ?</string>
+  <string name="ssOptionsTitle">နဲကဲပ္တိုန်ဂွံဂမၠိုၚ်</string>
+  <string name="ssOptionsTitleInstallOptions">ဗီုပြၚ်ပ္တိုန်စုတ်ဂမၠိုၚ်</string>
+  <string name="ssOptionsTitleDefaultKeymanSettings">ပလေဝ်နာနာ $APPNAME ပကတိ</string>
+  <string name="ssOptionsTitleSelectModulesToInstall">မဝ်ဒျူ သွက်ဂွံ စုတ် ဟွံသေၚ် သမၠုၚ်က္ဆံၚ်</string>
+  <string name="ssOptionsTitleAssociatedKeyboardLanguage">ဘာသာ ကဳဗုဒ် မဆက်စပ်</string>
+  <string name="ssOptionsTitleLocation">ပါယှေန်သွက်ဂွံစုတ်</string>
+  <string name="ssOptionsStartWithWindows">စ $APPNAME ပ္ဍဲဝေန်ဒဵုတိုန်</string>
+  <string name="ssOptionsStartAfterInstall">စ $APPNAME အခါရ ပ္တိုန်တုဲဒှ်</string>
+  <string name="ssOptionsCheckForUpdates">စၟဳစၟတ်က္ဆံၚ် လ္တူအောန်လာၚ် နကဵုအခိၚ်အပိုၚ်အခြာ</string>
+  <string name="ssOptionsUpgradeKeyboards">သမၠုၚ်ပ္တိုန်ကဳဗုဒ် ပါယှေန် စုတ်လဝ်တုဲတုဲ နကဵု ပါယှေန် $VERSION</string>
+  <string name="ssOptionsAutomaticallyReportUsage">ပါ်ပရအ် စရၚ်သုၚ်စောဲ သ္ၚိတ်တ်ကု keyman.com</string>
+  <!-- Parameters: %0:s: version of installer (may differ from Keyman version) -->
+  <string name="ssInstallerVersion">စုတ် ပါယှေန်: %0:s</string>
+  <string name="ssOptionsInstallKeyman">စုတ် $APPNAME</string>
+  <string name="ssOptionsUpgradeKeyman">သၠုၚ်ကဆံၚ် $APPNAME</string>
+  <!-- Parameters: %0:s: installed version -->
+  <string name="ssOptionsKeymanAlreadyInstalled">$APPNAME %0:s ဂှ် စုတ်လဝ်တုဲ။</string>
+  <!-- Parameters: %0:s: version, %1:s: size -->
+  <string name="ssOptionsDownloadKeymanVersion">တံၚ်ဂြဲ ပါယှေန် %0:s (%1:s)</string>
+  <!-- Parameters: %0:s: version -->
+  <string name="ssOptionsInstallKeymanVersion">ပါယှေန် %0:s</string>
+  <!-- Parameters: %0:s: package name %1:s -->
+  <string name="ssOptionsInstallPackage">စုတ် %0:s</string>
+  <!-- Parameters: %0:s: package version %1:s package size -->
+  <string name="ssOptionsDownloadPackageVersion">တံၚ်ဂြဲ ပါယှေန် %0:s (%1:s)</string>
+  <!-- Parameters: %0:s: package version -->
+  <string name="ssOptionsInstallPackageVersion">ပါယှေန် %0:s</string>
+  <!-- Parameters: %0:s package name -->
+  <string name="ssOptionsPackageLanguageAssociation">ရုဲကဵု အရေဝ်ဘာသာ သ္ဂောံစၠောံကု ကဳဗုဒ် %0:s ညိ</string>
+  <string name="ssOptionsDefaultLanguage">ဘာသာပကတိ</string>
+  <!-- Parameters: %0:s: filename -->
+  <string name="ssDownloadingTitle">အဃောတံၚ်ဂြဲ %0:s</string>
+  <!-- Parameters: %0:s: filename -->
+  <string name="ssDownloadingText">အဃောတံၚ်ဂြဲ %0:s</string>
+  <string name="ssOffline">စက်ပ္တိုန် $APPNAME ဂွံဂြဲဖျေံတမ်ရိုဟ်ဂှ် ဆက်စၠောံကု keyman.com ဟွံဂွံ။</string>
+  <string name="ssOffline2">ကလေၚ်ရံၚ် မၞးနွံလ္တူအောန်လာၚ်ရဟာ တုဲ ကဵုအခေါၚ်သုၚ်စောဲအေန်တာနက် ကု စက်ပ္တိုန် $APPNAME ပ္ဍဲကဵု တၚ်ချိၚ် ဗ္ဒၚ်ပၟတ်ညိ။</string>
+  <string name="ssOffline3">ဍဵု ဗဒေါံ သွက်ဂွံတိတ်နူ စက်ပ္တိုန်၊ က္လေၚ်ဂ္စါန် သွက်ဂွံ ဂ္စါန်တုဲ ဂြဲဖျေံတမ်ရိုဟ်မွဲတုဲပၠန်၊ ဟွံသေၚ်မ္ဂး ဟွံပဂရု သွက်ဂွံ ဆက်အာ အိုပ်လာၚ်။</string>
+</resources>


### PR DESCRIPTION
This adds crowdin strings for Mon (`mnw-MM` written with Burmese script).
Not available for iOS or macOS.

TODO for @sgschantz 
- [x] See if iOS can add mnw-MM locale
- [x] See if macOS can add mnw-MM locale

## User Testing
Test the Keyman apps can change to UI in Mon

* **TEST_ANDROID** 
1. On an Android device/emulator, load the PR build of Keyman for Android
2. In the Keyman app, go to Settings --> Display language --> မန် (Mon)
3. Exit the menu and wait for the app to refresh
4. Verify the UI is in Mon

![android mon](https://github.com/keymanapp/keyman/assets/7358010/e563e7ff-3540-4636-97b4-a82624c56d4a)


* **TEST_WINDOWS**
1. Install the PR build of Keyman for Windows
2. In Keyman configuration, change the UI to "မန် (Mon)"
3. Verify the UI is in Mon

* **TEST_LINUX**
1.Start Keyman configuration with: LANGUAGE=mnw_MM km-config
2. Verify Keyman UI is in Mon
