### PR TITLE
chore(linux): Exclude environment.sh from build

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -56,7 +56,9 @@ dpkg-source --tar-ignore=*~ --tar-ignore=.git --tar-ignore=.gitattributes \
     --tar-ignore=linux/builddebs \
     --tar-ignore=linux/ibus-keyman/build \
     --tar-ignore=linux/keyman-system-service/build \
-    --tar-ignore=resources/devbox --tar-ignore=resources/git-hooks \
+    --tar-ignore=resources/devbox \
+    --tar-ignore=resources/environment.sh \
+    --tar-ignore=resources/git-hooks \
     --tar-ignore=resources/scopes \
     --tar-ignore=resources/build/*.lua --tar-ignore=resources/build/jq* \
     --tar-ignore=results \

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -193,6 +193,26 @@ printBuildNumberForTeamCity
 
 findShouldSentryRelease
 
+# Sets the BUILDER_OS environment variable to linux|mac|win
+#
+_builder_get_operating_system() {
+  declare -g BUILDER_OS
+  # Default value, since it's the most general case/configuration to detect.
+  BUILDER_OS=linux
+
+  # Subject to change with future improvements.
+  if [[ $OSTYPE == darwin* ]]; then
+    BUILDER_OS=mac
+  elif [[ $OSTYPE == msys ]]; then
+    BUILDER_OS=win
+  elif [[ $OSTYPE == cygwin ]]; then
+    BUILDER_OS=win
+  fi
+  readonly BUILDER_OS
+}
+
+_builder_get_operating_system
+
 # Intended for use with macOS-based builds, as Xcode build phase "run script"s do not have access to important
 # environment variables.  Doesn't hurt to run it at other times as well.  The output file is .gitignore'd.
 function exportEnvironmentDefinitionScript() {
@@ -227,7 +247,7 @@ function exportEnvironmentDefinitionScript() {
 # someone else to intentionally use, so this check seems reasonable.
 #
 # https://gist.github.com/gdavis/6670468 has a representative copy of a standard Xcode environment variable setup.
-if [[ -z "${XCODE_VERSION_ACTUAL:-}" ]] && [[ -z "${XCODE_PRODUCT_BUILD_VERSION:-}" ]]; then
+if [ "$BUILDER_OS" == "mac" ] && [[ -z "${XCODE_VERSION_ACTUAL:-}" ]] && [[ -z "${XCODE_PRODUCT_BUILD_VERSION:-}" ]]; then
     exportEnvironmentDefinitionScript
 fi
 
@@ -356,26 +376,6 @@ run_xcodebuild() {
   fi
 }
 
-
-# Sets the BUILDER_OS environment variable to linux|mac|win
-#
-_builder_get_operating_system() {
-  declare -g BUILDER_OS
-  # Default value, since it's the most general case/configuration to detect.
-  BUILDER_OS=linux
-
-  # Subject to change with future improvements.
-  if [[ $OSTYPE == darwin* ]]; then
-    BUILDER_OS=mac
-  elif [[ $OSTYPE == msys ]]; then
-    BUILDER_OS=win
-  elif [[ $OSTYPE == cygwin ]]; then
-    BUILDER_OS=win
-  fi
-  readonly BUILDER_OS
-}
-
-_builder_get_operating_system
 
 #
 # We always want to use tools out of node_modules/.bin to guarantee that we get the


### PR DESCRIPTION
`environment.sh` is used only on Mac. This change modifies `build.sh` to generate this file only when building on Mac. It also excludes `environment.sh` from the Linux source tarball.

@keymanapp-test-bot skip