### PR TITLE
docs(common): Fix documentation for `builder_describe_internal_dependency`

### DIFF
--- a/resources/build/build-utils.md
+++ b/resources/build/build-utils.md
@@ -510,8 +510,8 @@ builder_describe_internal_dependency action:target depaction:deptarget ...
 
 ```bash
 builder_describe_internal_dependency \
-  mac:build mac-x86_64:build \
-  mac:build mac-arm64:build
+  build:mac build:mac-x86_64 \
+  build:mac build:mac-arm64
 ```
 
 **Note:** actions and targets must be fully specified, and this _must_ be called

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1143,8 +1143,8 @@ _builder_define_default_internal_dep() {
 #   2: depaction:deptarget   The dependency action and target
 # Example:
 #   builder_describe_internal_dependency \
-#     mac:build mac-x86_64:build \
-#     mac:build mac-arm64:build
+#     build:mac build:mac-x86_64 \
+#     build:mac build:mac-arm64
 #
 # Note: actions and targets must be fully specified, and this _must_
 # be called before either builder_describe_outputs or builder_parse in


### PR DESCRIPTION
Fixes #9581.

@keymanapp-test-bot skip