### PR TITLE
chore(oem/fv/android): Update Gradle to 7.4

### DIFF
--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'io.sentry.android.gradle'
-    id 'com.github.triplet.play' version '3.7.0-agp4.2' apply false
+    id 'com.github.triplet.play' version '3.8.1' apply false
 }
 
 ext.rootPath = '../../../../android'
@@ -121,7 +121,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
     implementation 'com.google.android.material:material:1.6.0'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation 'io.sentry:sentry-android:6.9.0'
+    implementation 'io.sentry:sentry-android:6.9.2'
     implementation 'androidx.preference:preference:1.2.0'
 }
 

--- a/oem/firstvoices/android/build.gradle
+++ b/oem/firstvoices/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.0'
         classpath 'io.sentry:sentry-android-gradle-plugin:2.1.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
When the Android projects got updated to Java 11 in #8543, the build.gradle files for FV Android inadventertently were missed.

This updates the Gradle plugin to match Keyman for Android 
com.android.tools.build:gradle:7.4.0

along with some other dependencies.

(Updating Gradle plugin to 8.0 will wait for the 18.0 development cycle)

@keymanapp-test-bot skip
