### PR TITLE
chore(linux): Check and restart background processes

### DIFF
--- a/linux/ibus-keyman/src/test/meson.build
+++ b/linux/ibus-keyman/src/test/meson.build
@@ -19,7 +19,8 @@ test_include_dirs = [
 ]
 
 env_file = '/tmp/env-src-test.txt'
-pid_file = '/tmp/ibus-keyman-src-test-pids'
+cleanup_file = '/tmp/ibus-keyman-src-test-pids'
+pid_file = '/tmp/ibus-keyman-src-test-pids.pids'
 
 setup_src_test_tests = find_program('setup-tests.sh', dirs: [meson.current_source_dir()])
 teardown_tests = find_program('teardown-tests.sh', dirs: [meson.current_source_dir() / '../../tests/scripts'])
@@ -64,7 +65,7 @@ bcp47_util_tests = executable(
 test(
   'setup-src-test',
   setup_src_test_tests,
-  args: ['--x11', env_file, pid_file],
+  args: ['--x11', env_file, cleanup_file, pid_file],
   env: test_env,
   priority: -1,
   is_parallel: false,
@@ -74,7 +75,7 @@ test(
 test(
   'teardown-src-test',
   teardown_tests,
-  args: [pid_file],
+  args: [cleanup_file],
   priority: -9,
   is_parallel: false,
   protocol: 'exitcode'

--- a/linux/ibus-keyman/src/test/setup-tests.sh
+++ b/linux/ibus-keyman/src/test/setup-tests.sh
@@ -3,4 +3,4 @@ set -eu
 
 . "$(dirname "$0")/../../tests/scripts/test-helper.inc.sh"
 
-setup_display_server_only "$1" "$2" "$3"
+setup_display_server_only "$1" "$2" "$3" "$4"

--- a/linux/ibus-keyman/tests/meson.build
+++ b/linux/ibus-keyman/tests/meson.build
@@ -50,7 +50,8 @@ stop_test_server = executable(
 )
 
 env_file = '/tmp/env.txt'
-pid_file = '/tmp/ibus-keyman-test-pids'
+cleanup_file = '/tmp/ibus-keyman-test-pids'
+pid_file = '/tmp/ibus-keyman-test-pids.pids'
 
 setup_tests = find_program('setup-tests.sh', dirs: [meson.current_source_dir() / 'scripts'])
 teardown_tests = find_program('teardown-tests.sh', dirs: [meson.current_source_dir() / 'scripts'])
@@ -64,7 +65,7 @@ can_build_wayland = mutter.found()
 test(
   'setup-x11',
   setup_tests,
-  args: ['--x11', env_file, pid_file],
+  args: ['--x11', env_file, cleanup_file, pid_file],
   env: test_env,
   priority: -10,
   is_parallel: false,
@@ -74,7 +75,7 @@ test(
 test(
   'teardown-x11',
   teardown_tests,
-  args: [pid_file],
+  args: [cleanup_file],
   priority: -19,
   is_parallel: false,
   protocol: 'exitcode'
@@ -84,7 +85,7 @@ if can_build_wayland
   test(
     'setup-wayland',
     setup_tests,
-    args: ['--wayland', env_file, pid_file],
+    args: ['--wayland', env_file, cleanup_file, pid_file],
     env: test_env,
     priority: -20,
     is_parallel: false,
@@ -94,7 +95,7 @@ if can_build_wayland
   test(
     'teardown-wayland',
     teardown_tests,
-    args: [pid_file],
+    args: [cleanup_file],
     priority: -29,
     is_parallel: false,
     protocol: 'exitcode'
@@ -113,7 +114,7 @@ foreach kmx: kmxtest_files
     continue
   endif
   testname = filename[1].split('.kmx')[0]
-  test_args = [ '--tap', '-k', '--env', env_file, '--', filename]
+  test_args = [ '--tap', '-k', '--env', env_file, '--cleanup', cleanup_file, '--check', pid_file, '--', filename]
   test(
     'X11-' + testname + '__surrounding-text',
     run_test,

--- a/linux/ibus-keyman/tests/scripts/run-single-test.sh
+++ b/linux/ibus-keyman/tests/scripts/run-single-test.sh
@@ -21,7 +21,7 @@ fi
 
 function help() {
   echo "Usage:"
-  echo "  $0 [--env <envfile>] [-k] [--tap] [--surrounding-text] [--no-surrounding-text] [--wayland|--x11] [--] TEST"
+  echo "  $0 [--env <envfile>] [-k] [--tap] [--surrounding-text] [--no-surrounding-text] [--wayland|--x11] [--check <pidfile> --cleanup <file>] [--] TEST"
   echo
   echo "Arguments:"
   echo "  --help, -h, -?          Display this help"

--- a/linux/ibus-keyman/tests/scripts/run-single-test.sh
+++ b/linux/ibus-keyman/tests/scripts/run-single-test.sh
@@ -34,6 +34,8 @@ function help() {
   echo "  --wayland               run tests with Wayland"
   echo "  --x11                   run tests with X11"
   echo "  --env <envfile>         Name of the file containing environment variables to use"
+  echo "  --check <pidfile>       Name of the file containing pids to check are running"
+  echo "  --cleanup <file>        Name of the file containing cleanup of processes"
   exit 0
 }
 
@@ -65,11 +67,21 @@ while (( $# )); do
     --verbose|-v) ARG_VERBOSE=--verbose;;
     --debug) ARG_DEBUG=--debug-log;;
     --env) shift ; ARG_ENV=$1 ;;
+    --check) shift; ARG_PIDS=$1 ;;
+    --cleanup) shift; ARG_CLEANUP=$1 ;;
     --) shift ; TESTFILE=$1; break ;;
     *) echo "Error: Unexpected argument \"$1\". Exiting." ; exit 4 ;;
   esac
   shift || (echo "Error: The last argument is missing a value. Exiting."; false) || exit 5
 done
+
+# shellcheck disable=SC2236
+if [ -n "${ARG_PIDS:-}" ] && [ ! -n "${ARG_CLEANUP:-}" ]; then
+  echo "Error: '--check' also requires '--cleanup'. Exiting."
+  exit 6
+fi
+
+check_processes_running "$ARG_DISPLAY_SERVER" "$ARG_ENV" "$ARG_CLEANUP" "$ARG_PIDS" >&2
 
 # shellcheck source=/dev/null
 . "$ARG_ENV"

--- a/linux/ibus-keyman/tests/scripts/setup-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/setup-tests.sh
@@ -5,4 +5,4 @@ set -eu
 
 exit_on_package_build
 
-setup "$1" "$2" "$3"
+setup "$1" "$2" "$3" "$4"

--- a/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
+++ b/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
@@ -94,9 +94,10 @@ function _link_test_keyboards() {
 }
 
 function _setup_init() {
-  local ENV_FILE PID_FILE
+  local ENV_FILE CLEANUP_FILE PID_FILE
   ENV_FILE=$1
-  PID_FILE=$2
+  CLEANUP_FILE=$2
+  PID_FILE=$3
 
   if [ -z "${TOP_SRCDIR:-}" ]; then
     TOP_SRCDIR=${G_TEST_SRCDIR:-$(realpath "$(dirname "$0")/..")}/..
@@ -107,14 +108,15 @@ function _setup_init() {
 
   echo > "$ENV_FILE"
 
-  if [ -f "$PID_FILE" ]; then
+  if [ -f "$CLEANUP_FILE" ]; then
     # kill previous instances
-    "$(dirname "$0")"/teardown-tests.sh "$PID_FILE" || true
+    "$(dirname "$0")"/teardown-tests.sh "$CLEANUP_FILE" || true
   fi
 
+  echo > "$CLEANUP_FILE"
   echo > "$PID_FILE"
   TEMP_DATA_DIR=$(mktemp --directory)
-  echo "rm -rf ${TEMP_DATA_DIR} || true" >> "$PID_FILE"
+  echo "rm -rf ${TEMP_DATA_DIR} || true" >> "$CLEANUP_FILE"
 
   COMMON_ARCH_DIR=
   [ -d "${TOP_SRCDIR}"/../../core/build/arch ] && COMMON_ARCH_DIR=${TOP_SRCDIR}/../../core/build/arch
@@ -133,27 +135,28 @@ function _setup_init() {
 }
 
 function _setup_test_dbus_server() {
-  local ENV_FILE PID_FILE
+  local ENV_FILE CLEANUP_FILE
   ENV_FILE=$1
-  PID_FILE=$2
+  CLEANUP_FILE=$2
 
   # Start test dbus server. This will create `/tmp/km-test-server.env`.
   "${TOP_BINDIR}/tests/km-dbus-test-server" &> /dev/null &
   sleep 1
 
   cat /tmp/km-test-server.env >> "$ENV_FILE"
-  cat /tmp/km-test-server.env >> "$PID_FILE"
-  echo "${TOP_BINDIR}/tests/stop-test-server" >> "$PID_FILE"
+  cat /tmp/km-test-server.env >> "$CLEANUP_FILE"
+  echo "${TOP_BINDIR}/tests/stop-test-server" >> "$CLEANUP_FILE"
 
   source /tmp/km-test-server.env
   echo "# DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
 }
 
 function _setup_display_server() {
-  local DISPLAY_SERVER ENV_FILE PID_FILE
+  local DISPLAY_SERVER ENV_FILE CLEANUP_FILE PID_FILE PID
   ENV_FILE=$1
-  PID_FILE=$2
-  DISPLAY_SERVER=$3
+  CLEANUP_FILE=$2
+  PID_FILE=$3
+  DISPLAY_SERVER=$4
 
   if [ "$DISPLAY_SERVER" == "--wayland" ]; then
     if ! can_run_wayland; then
@@ -166,7 +169,9 @@ function _setup_display_server() {
     TMPFILE=$(mktemp)
     # mutter-Message: 18:56:15.422: Using Wayland display name 'wayland-1'
     mutter --wayland --headless --no-x11 --virtual-monitor 1024x768 &> "$TMPFILE" &
-    echo "kill -9 $! || true" >> "$PID_FILE"
+    PID=$!
+    echo "kill -9 ${PID} || true" >> "$CLEANUP_FILE"
+    echo "${PID}" >> "${PID_FILE}"
     sleep 1s
     export WAYLAND_DISPLAY
     WAYLAND_DISPLAY=$(grep "Using Wayland display" "$TMPFILE" | cut -d"'" -f2)
@@ -176,15 +181,21 @@ function _setup_display_server() {
     echo "Running on X11:"
     echo "Starting Xvfb..."
     Xvfb -screen 0 1024x768x24 :33 &> /dev/null &
-    echo "kill -9 $! || true" >> "$PID_FILE"
+    PID=$!
+    echo "kill -9 ${PID} || true" >> "$CLEANUP_FILE"
+    echo "${PID}" >> "${PID_FILE}"
     sleep 1
     echo "Starting Xephyr..."
     DISPLAY=:33 Xephyr :32 -screen 1024x768 &> /dev/null &
-    echo "kill -9 $! || true" >> "$PID_FILE"
+    PID=$!
+    echo "kill -9 ${PID} || true" >> "$CLEANUP_FILE"
+    echo "${PID}" >> "${PID_FILE}"
     sleep 1
     echo "Starting metacity"
     metacity --display=:32 &> /dev/null &
-    echo "kill -9 $! || true" >> "$PID_FILE"
+    PID=$!
+    echo "kill -9 ${PID} || true" >> "$CLEANUP_FILE"
+    echo "${PID}" >> "${PID_FILE}"
 
     export DISPLAY=:32
     echo "export DISPLAY=\"$DISPLAY\"" >> "$ENV_FILE"
@@ -192,9 +203,9 @@ function _setup_display_server() {
 }
 
 function _setup_schema_and_gsettings() {
-  local ENV_FILE PID_FILE
+  local ENV_FILE CLEANUP_FILE
   ENV_FILE=$1
-  PID_FILE=$2
+  CLEANUP_FILE=$2
 
   # Install schema to temporary directory. This removes the build dependency on the keyman package.
   SCHEMA_DIR=$TEMP_DATA_DIR/glib-2.0/schemas
@@ -219,13 +230,17 @@ function _setup_schema_and_gsettings() {
 }
 
 function _setup_ibus() {
-  local ENV_FILE PID_FILE
+  local ENV_FILE CLEANUP_FILE PID_FILE PID
   ENV_FILE=$1
-  PID_FILE=$2
+  CLEANUP_FILE=$2
+  PID_FILE=$3
 
+  echo "Starting ibus-daemon..."
   #shellcheck disable=SC2086
   ibus-daemon ${ARG_VERBOSE-} --daemonize --panel=disable --address=unix:abstract="${TEMP_DATA_DIR}/test-ibus" ${IBUS_CONFIG-} &> /tmp/ibus-daemon.log
-  echo "kill -9 $! || true" >> "$PID_FILE"
+  PID=$(pgrep -f "${TEMP_DATA_DIR}/test-ibus")
+  echo "kill -9 ${PID} || true" >> "$CLEANUP_FILE"
+  echo "${PID}" >> "${PID_FILE}"
   sleep 1s
 
   IBUS_ADDRESS=$(ibus address)
@@ -233,19 +248,23 @@ function _setup_ibus() {
 
   echo "export IBUS_ADDRESS=\"$IBUS_ADDRESS\"" >> "$ENV_FILE"
 
+  echo "Starting ibus-engine-keyman..."
   #shellcheck disable=SC2086
   "${TOP_BINDIR}/src/ibus-engine-keyman" --testing ${ARG_VERBOSE-} &> /tmp/ibus-engine-keyman.log &
-  echo "kill -9 $! || true" >> "$PID_FILE"
+  PID=$!
+  echo "kill -9 ${PID} || true" >> "$CLEANUP_FILE"
+  echo "${PID}" >> "${PID_FILE}"
   sleep 1s
-
 }
+
 function setup() {
-  local DISPLAY_SERVER ENV_FILE PID_FILE TESTBASEDIR TESTDIR
+  local DISPLAY_SERVER ENV_FILE CLEANUP_FILE PID_FILE TESTBASEDIR TESTDIR
   DISPLAY_SERVER=$1
   ENV_FILE=$2
-  PID_FILE=$3
+  CLEANUP_FILE=$3
+  PID_FILE=$4
 
-  _setup_init "${ENV_FILE}" "${PID_FILE}"
+  _setup_init "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}"
 
   TESTBASEDIR=${XDG_DATA_HOME:-$HOME/.local/share}/keyman
   TESTDIR=${TESTBASEDIR}/test_kmx
@@ -254,32 +273,33 @@ function setup() {
 
   _generate_kmpjson "$TESTDIR"
 
-  _setup_test_dbus_server "${ENV_FILE}" "${PID_FILE}"
-  _setup_display_server "${ENV_FILE}" "${PID_FILE}" "${DISPLAY_SERVER}"
-  _setup_schema_and_gsettings "${ENV_FILE}" "${PID_FILE}"
-  _setup_ibus "${ENV_FILE}" "${PID_FILE}"
+  _setup_test_dbus_server "${ENV_FILE}" "${CLEANUP_FILE}"
+  _setup_display_server "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}" "${DISPLAY_SERVER}"
+  _setup_schema_and_gsettings "${ENV_FILE}" "${CLEANUP_FILE}"
+  _setup_ibus "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}"
 }
 
 function setup_display_server_only() {
-  local DISPLAY_SERVER ENV_FILE PID_FILE TESTBASEDIR TESTDIR
+  local DISPLAY_SERVER ENV_FILE CLEANUP_FILE PID_FILE TESTBASEDIR TESTDIR
   DISPLAY_SERVER=$1
   ENV_FILE=$2
-  PID_FILE=$3
+  CLEANUP_FILE=$3
+  PID_FILE=$4
 
-  _setup_init "${ENV_FILE}" "${PID_FILE}"
-  _setup_display_server "${ENV_FILE}" "${PID_FILE}" "${DISPLAY_SERVER}"
-  _setup_schema_and_gsettings "${ENV_FILE}" "${PID_FILE}"
+  _setup_init "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}"
+  _setup_display_server "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}" "${DISPLAY_SERVER}"
+  _setup_schema_and_gsettings "${ENV_FILE}" "${CLEANUP_FILE}"
 }
 
 function cleanup() {
-  local PID_FILE
-  PID_FILE=$1
+  local CLEANUP_FILE
+  CLEANUP_FILE=$1
 
-  if [ -f "$PID_FILE" ]; then
+  if [ -f "$CLEANUP_FILE" ]; then
     echo
     echo "# Shutting down processes..."
-    bash "$PID_FILE" # > /dev/null 2>&1
-    rm "$PID_FILE"
+    bash "$CLEANUP_FILE" # > /dev/null 2>&1
+    rm "$CLEANUP_FILE"
     echo "# Finished shutdown of processes."
   fi
 }
@@ -289,5 +309,30 @@ function exit_on_package_build() {
     # Skip setup during package builds - can't run headless and we won't
     # run the other tests anyway
     exit 0
+  fi
+}
+
+function check_processes_running() {
+  local DISPLAY_SERVER ENV_FILE CLEANUP_FILE PID_FILE PID MISSING
+  DISPLAY_SERVER=$1
+  ENV_FILE=$2
+  CLEANUP_FILE=$3
+  PID_FILE=$4
+  MISSING=false
+
+  while read -r PID; do
+    if [ -z "$PID" ]; then
+      continue
+    elif ! ps --no-headers --pid="$PID" > /dev/null; then
+      MISSING=true
+      break
+    fi
+  done < "${PID_FILE}"
+
+  if $MISSING; then
+    echo "# Some background processes no longer running. Restarting..."
+    echo "Some background processes no longer running. Restarting..." > /tmp/debug.output
+    cleanup "${CLEANUP_FILE}" > /dev/null 2>&1
+    setup "${DISPLAY_SERVER}" "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}" > /dev/null 2>&1
   fi
 }

--- a/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
+++ b/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
@@ -203,9 +203,8 @@ function _setup_display_server() {
 }
 
 function _setup_schema_and_gsettings() {
-  local ENV_FILE CLEANUP_FILE
+  local ENV_FILE
   ENV_FILE=$1
-  CLEANUP_FILE=$2
 
   # Install schema to temporary directory. This removes the build dependency on the keyman package.
   SCHEMA_DIR=$TEMP_DATA_DIR/glib-2.0/schemas
@@ -275,7 +274,7 @@ function setup() {
 
   _setup_test_dbus_server "${ENV_FILE}" "${CLEANUP_FILE}"
   _setup_display_server "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}" "${DISPLAY_SERVER}"
-  _setup_schema_and_gsettings "${ENV_FILE}" "${CLEANUP_FILE}"
+  _setup_schema_and_gsettings "${ENV_FILE}"
   _setup_ibus "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}"
 }
 
@@ -288,7 +287,7 @@ function setup_display_server_only() {
 
   _setup_init "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}"
   _setup_display_server "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}" "${DISPLAY_SERVER}"
-  _setup_schema_and_gsettings "${ENV_FILE}" "${CLEANUP_FILE}"
+  _setup_schema_and_gsettings "${ENV_FILE}"
 }
 
 function cleanup() {


### PR DESCRIPTION
Before we run a test we now check that ibus and the other processes we need are still running. If not we run test setup again.

This will likely fix #9570.

@keymanapp-test-bot skip