### PR TITLE
chore(web): builds that output to web/build/publish should also clean it

### DIFF
--- a/web/src/app/browser/build.sh
+++ b/web/src/app/browser/build.sh
@@ -41,6 +41,11 @@ builder_describe_outputs \
 
 #### Build action definitions ####
 
+do_clean() {
+  rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
+  rm -rf "$KEYMAN_ROOT/web/build/publish"
+}
+
 compile_and_copy() {
   local COMPILE_FLAGS=
   if builder_has_option --ci; then
@@ -61,7 +66,7 @@ compile_and_copy() {
 }
 
 builder_run_action configure verify_npm_setup
-builder_run_action clean rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
+builder_run_action clean do_clean
 builder_run_action build compile_and_copy
 
 # No headless tests for this child project.  Currently, DOM-based unit &

--- a/web/src/app/ui/build.sh
+++ b/web/src/app/ui/build.sh
@@ -40,6 +40,11 @@ builder_describe_outputs \
 
 #### Build action definitions ####
 
+do_clean() {
+  rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
+  rm -rf "$KEYMAN_ROOT/web/build/publish"
+}
+
 compile_and_copy() {
   compile $SUBPROJECT_NAME
 
@@ -51,7 +56,7 @@ compile_and_copy() {
 }
 
 builder_run_action configure verify_npm_setup
-builder_run_action clean rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
+builder_run_action clean do_clean
 builder_run_action build compile_and_copy
 
 # No headless tests for this child project.  Currently, DOM-based unit &


### PR DESCRIPTION
@darcywong00 had a fun error come up as a result of an oversight in Web's build scripts - while two of the `app/` projects output to a `publish` folder to prepare for releases, their `clean` steps did not actually delete any previously-existing entries.  

The error he was getting... resulted from running a post-processing command on an outdated build product that wasn't deleted due to said oversight.  (The build configurations were slightly different when they were built, and the post-processing step couldn't handle the difference.)  It definitely wasn't an intuitive scenario to infer, so it's best we fix the oversight so that it doesn't cause similar issues later down the line.

@keymanapp-test-bot skip
