### PR TITLE
fix(web): fixes toolbar refocus timing after a keyboard change

### DIFF
--- a/web/src/app/ui/kmwuitoolbar.ts
+++ b/web/src/app/ui/kmwuitoolbar.ts
@@ -824,10 +824,12 @@ if(!keyman?.ui?.name) {
         this.selectedLanguage = kbd.LanguageCode;
 
         // Return focus to input area and activate the selected keyboard
-        this.setLastFocus(); //*****this seems out of sequence???
         this.addKeyboardToList(lang, kbd);
         if(updateKeyman) {
-          keymanweb.setActiveKeyboard(kbd.InternalName, kbd.LanguageCode);
+          keymanweb.setActiveKeyboard(kbd.InternalName, kbd.LanguageCode).then(() => {
+            // Restore focus _after_ the keyboard finishes loading.
+            this.setLastFocus();
+          });
         }
         this.listedKeyboards[this.findListedKeyboard(lang)].buttonNode.className = 'kmw_button_selected';
 


### PR DESCRIPTION
Fixes #9617.

This PR ensures upon selecting a keyboard, both of the following expectations are met:
- if a text area or input field was active immediately before interacting with the toolbar, it regains focus
- ... and the OSK is redisplayed if it was previously enabled.

It appears that some of the focus-rework that occurred during modularization may have caused a previously-noted concern in Toolbar code to be a little more merited than before.  Simply changing the timing of when the annotated function is called - to be firmly _after_ the keyboard-activation process has completed - appears to be enough to fix the issue.

## User Testing

TEST_REPRO:  Verify that the originally-reported repro no longer triggers the error.

- Using the "Desktop UI module testing" test page, select "Toolbar UI" for testing.
- Type 'abc' in one of the two text areas for input.
- Click on the toolbar's "Languages" section.
- Click on the map's Asia region.
- Find "Kannada" in the language menu that displays beneath the map and click it.
- Verify that, after a brief wait, the text area with 'abc' in it is selected and that an OSK for a Kannada keyboard is displayed.
- Click on the toolbar's keyboard menu - the rightmost menu item, to the right of the "Kannada" menu item that has an icon.
    - It will likely be displaying "Kannada Basic".
- Select "ISIS (Kannada)"
- Verify that, after a brief wait, the text area with 'abc' in it is selected and that the OSK for "ISIS-Kannada" is displayed.