### PR TITLE
feat(web): state token tracking, association with gestures 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/configuration/gestureRecognizerConfiguration.ts
+++ b/common/web/gesture-recognizer/src/engine/configuration/gestureRecognizerConfiguration.ts
@@ -9,7 +9,7 @@ import { PaddedZoneSource } from "./paddedZoneSource.js";
 import { RecognitionZoneSource } from "./recognitionZoneSource.js";
 
 // For example, customization of a longpress timer's length need not be readonly.
-export interface GestureRecognizerConfiguration<HoveredItemType> {
+export interface GestureRecognizerConfiguration<HoveredItemType, StateToken = any> {
   /**
    * Specifies the element that mouse input listeners should be attached to.  If
    * not specified, `eventRoot` will be set equal to `targetRoot`.
@@ -80,17 +80,23 @@ export interface GestureRecognizerConfiguration<HoveredItemType> {
    * For applications in the DOM, simply returning `target` itself may be sufficient.
    * @param coord   The current touchpath coordinate; its .targetX and .targetY values should be
    *                interpreted as offsets from `targetRoot`.
+   *
+   *                Its `stateToken` will match the most recently set value for its corresponding
+   *                `GestureSource` if continuing one; otherwise, it'll use the one currently set
+   *                at the gesture-engine level.
    * @param target  The `EventTarget` (`Node` or `Element`) provided by the corresponding input event.
    * @returns
    */
-  readonly itemIdentifier?: (coord: Omit<InputSample<any>, 'item'>, target: EventTarget) => HoveredItemType;
+  readonly itemIdentifier?: (coord: Omit<InputSample<any, StateToken>, 'item'>, target: EventTarget) => HoveredItemType;
 }
 
-export function preprocessRecognizerConfig<HoveredItemType>(
-  config: GestureRecognizerConfiguration<HoveredItemType>
-): Nonoptional<GestureRecognizerConfiguration<HoveredItemType>> {
+export function preprocessRecognizerConfig<HoveredItemType, StateToken = any>(
+  config: GestureRecognizerConfiguration<HoveredItemType, StateToken>
+): Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>> {
   // Allows configuration pre-processing during this method.
-  let processingConfig: Mutable<Nonoptional<GestureRecognizerConfiguration<HoveredItemType>>> = {...config} as Nonoptional<GestureRecognizerConfiguration<HoveredItemType>>;
+  let processingConfig: Mutable<Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>> = {...config} as
+    Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>;
+
   processingConfig.mouseEventRoot = processingConfig.mouseEventRoot ?? processingConfig.targetRoot;
   processingConfig.touchEventRoot = processingConfig.touchEventRoot ?? processingConfig.targetRoot;
 

--- a/common/web/gesture-recognizer/src/engine/gestureRecognizer.ts
+++ b/common/web/gesture-recognizer/src/engine/gestureRecognizer.ts
@@ -5,13 +5,13 @@ import { TouchEventEngine } from "./touchEventEngine.js";
 import { TouchpointCoordinator } from "./headless/touchpointCoordinator.js";
 import { EMPTY_GESTURE_DEFS, GestureModelDefs } from "./headless/gestures/specs/index.js";
 
-export class GestureRecognizer<HoveredItemType> extends TouchpointCoordinator<HoveredItemType> {
-  public readonly config: Nonoptional<GestureRecognizerConfiguration<HoveredItemType>>;
+export class GestureRecognizer<HoveredItemType, StateToken = any> extends TouchpointCoordinator<HoveredItemType, StateToken> {
+  public readonly config: Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>;
 
   private readonly mouseEngine: MouseEventEngine<HoveredItemType>;
   private readonly touchEngine: TouchEventEngine<HoveredItemType>;
 
-  public constructor(gestureModelDefinitions: GestureModelDefs<HoveredItemType>, config: GestureRecognizerConfiguration<HoveredItemType>) {
+  public constructor(gestureModelDefinitions: GestureModelDefs<HoveredItemType>, config: GestureRecognizerConfiguration<HoveredItemType, StateToken>) {
     const preprocessedConfig = preprocessRecognizerConfig(config);
 
     // Possibly just a stop-gap measure... but this provides an empty gesture-spec set definition

--- a/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
@@ -1,12 +1,13 @@
 import EventEmitter from "eventemitter3";
 import { InputSample } from "./inputSample.js";
 import { CumulativePathStats } from "./cumulativePathStats.js";
+import { Mutable } from "../mutable.js";
 
 /**
  * Documents the expected typing of serialized versions of the `GesturePath` class.
  */
 export type SerializedGesturePath<Type, StateToken> = {
-  coords: InputSample<Type, StateToken>[]; // ensures type match with public class property.
+  coords: Mutable<InputSample<Type, StateToken>>[]; // ensures type match with public class property.
   wasCancelled?: boolean;
 }
 

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
@@ -27,9 +27,6 @@ export interface ContactModel<Type> {
     expectedResult: boolean;
   }
 
-  // Allows specifying use of one of the configured 'gestureItemIdentifiers'.
-  recognizerId?: string;
-
   // This field is primarly used at the `GestureMatcher` level, rather than the
   // `PathMatcher` level.
   /**

--- a/common/web/gesture-recognizer/src/engine/headless/inputEngineBase.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/inputEngineBase.ts
@@ -1,12 +1,12 @@
 import EventEmitter from "eventemitter3";
 import { GestureSource } from "./gestureSource.js";
 
-interface EventMap<HoveredItemType> {
+interface EventMap<HoveredItemType, StateToken> {
   /**
    * Indicates that a new, ongoing touchpoint or mouse interaction has begun.
    * @param input The instance that tracks all future updates over the lifetime of the touchpoint / mouse interaction.
    */
-  'pointstart': (input: GestureSource<HoveredItemType>) => void;
+  'pointstart': (input: GestureSource<HoveredItemType, StateToken>) => void;
 
   // // idea for line below: to help multitouch gestures keep touchpaths in sync, rather than updated separately
   // 'eventcomplete': () => void;
@@ -17,8 +17,10 @@ interface EventMap<HoveredItemType> {
  * gesture recognition as it is either generated (in the DOM) or replayed during automated tests
  * (headlessly).
  */
-export abstract class InputEngineBase<HoveredItemType> extends EventEmitter<EventMap<HoveredItemType>> {
+export abstract class InputEngineBase<HoveredItemType, StateToken = any> extends EventEmitter<EventMap<HoveredItemType, StateToken>> {
   private _activeTouchpoints: GestureSource<HoveredItemType>[] = [];
+
+  public stateToken: StateToken;
 
   /**
    * @param identifier The identifier number corresponding to the input sequence.
@@ -43,11 +45,15 @@ export abstract class InputEngineBase<HoveredItemType> extends EventEmitter<Even
     return this.getTouchpointWithId(identifier).currentRecognizerConfig;
   }
 
+  protected getStateTokenForId(identifier: number) {
+    return this.getTouchpointWithId(identifier).stateToken ?? null;
+  }
+
   public dropTouchpointWithId(identifier: number) {
     this._activeTouchpoints = this._activeTouchpoints.filter((point) => point.rawIdentifier != identifier);
   }
 
-  protected addTouchpoint(touchpoint: GestureSource<HoveredItemType>) {
+  protected addTouchpoint(touchpoint: GestureSource<HoveredItemType, StateToken>) {
     this._activeTouchpoints.push(touchpoint);
   }
 }

--- a/common/web/gesture-recognizer/src/engine/headless/inputSample.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/inputSample.ts
@@ -2,7 +2,7 @@
  * We want these to be readily and safely converted to and from
  * JSON (for unit test use and development)
  */
-export interface InputSample<Type> {
+export interface InputSample<Type, StateToken = any> {
   /**
    * Represents the x-coordinate of the input sample
    * in 'client' / viewport coordinates.
@@ -37,10 +37,16 @@ export interface InputSample<Type> {
    * The UI/UX 'item' underneath the touchpoint for this sample.
    */
   item?: Type;
+
+  /**
+   * A token identifying the state of the consuming system associated
+   * with this sample's `GestureSource`, if any such association exists.
+   */
+  stateToken?: StateToken
 }
 
-export type InputSampleSequence<Type> = InputSample<Type>[];
+export type InputSampleSequence<Type, StateToken> = InputSample<Type, StateToken>[];
 
-export function isAnInputSample<Type>(obj: any): obj is InputSample<Type> {
+export function isAnInputSample<Type, StateToken>(obj: any): obj is InputSample<Type, StateToken> {
   return 'targetX' in obj && 'targetY' in obj && 't' in obj;
 }

--- a/common/web/gesture-recognizer/src/engine/headless/inputSample.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/inputSample.ts
@@ -7,31 +7,34 @@ export interface InputSample<Type, StateToken = any> {
    * Represents the x-coordinate of the input sample
    * in 'client' / viewport coordinates.
    */
-  clientX?: number;
+  readonly clientX?: number;
 
   /**
    * Represents the x-coordinate of the input sample in
    * coordinates relative to the recognizer's `targetRoot`.
    */
-  targetX: number;
+  readonly targetX: number;
 
   /**
    * Represents the y-coordinate of the input sample
    * in 'client' / viewport coordinates.
    */
-  clientY?: number;
+  readonly clientY?: number;
 
   /**
    * Represents the y-coordinate of the input sample in
    * coordinates relative to the recognizer's `targetRoot`.
    */
-  targetY: number;
+  readonly targetY: number;
 
   /**
    * Represents the timestamp at which the input was observed
    * (in ms)
    */
-  t: number;
+  readonly t: number;
+
+  // The following two are intentionally _not_ readonly; `stateToken`, in particular,
+  // may need modification by specific gesture-model implementations.
 
   /**
    * The UI/UX 'item' underneath the touchpoint for this sample.

--- a/common/web/gesture-recognizer/src/engine/headless/subsegmentation/pathSegmenter.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/subsegmentation/pathSegmenter.ts
@@ -686,8 +686,7 @@ export class PathSegmenter {
       cumulativeStats = new CumulativePathStats();
     }
 
-    sample = {... sample};
-    sample.t += timeDelta;
+    sample = {... sample, t: sample.t + timeDelta};
     const extendedStats = cumulativeStats.extend(sample);
     this.steppedCumulativeStats.push(extendedStats);
 

--- a/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
@@ -5,13 +5,13 @@ import { MatcherSelector } from "./gestures/matchers/matcherSelector.js";
 import { GestureSequence } from "./gestures/matchers/gestureSequence.js";
 import { GestureModelDefs, getGestureModelSet } from "./gestures/specs/gestureModelDefs.js";
 
-interface EventMap<HoveredItemType> {
+interface EventMap<HoveredItemType, StateToken> {
   /**
    * Indicates that a new potential gesture has begun.
    * @param input
    * @returns
    */
-  'inputstart': (input: GestureSource<HoveredItemType>) => void;
+  'inputstart': (input: GestureSource<HoveredItemType, StateToken>) => void;
 
   'recognizedgesture': (sequence: GestureSequence<HoveredItemType>) => void;
 }
@@ -24,7 +24,7 @@ interface EventMap<HoveredItemType> {
  * Of particular note: when a gesture involves multiple touchpoints - like a multitap - this class
  * is responsible for linking related touchpoints together for the detection of that gesture.
  */
-export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends EventEmitter<EventMap<HoveredItemType>> {
+export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends EventEmitter<EventMap<HoveredItemType, StateToken>> {
   private inputEngines: InputEngineBase<HoveredItemType, StateToken>[];
   private selectorStack: MatcherSelector<HoveredItemType>[] = [new MatcherSelector()];
 

--- a/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
@@ -134,6 +134,7 @@ export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends Even
 
   public set stateToken(token: StateToken) {
     this._stateToken = token;
+    this.inputEngines.forEach((engine) => engine.stateToken = token);
   }
 
   private addSimpleSourceHooks(touchpoint: GestureSource<HoveredItemType>) {

--- a/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
@@ -34,6 +34,7 @@ export abstract class InputEventEngine<HoveredItemType, StateToken> extends Inpu
 
   protected onInputStart(identifier: number, sample: InputSample<HoveredItemType, StateToken>, target: EventTarget, isFromTouch: boolean) {
     const touchpoint = new GestureSource<HoveredItemType>(identifier, this.config, isFromTouch);
+    touchpoint.stateToken = this.stateToken;
     touchpoint.update(sample);
 
     this.addTouchpoint(touchpoint);

--- a/common/web/gesture-recognizer/src/engine/touchEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/touchEventEngine.ts
@@ -4,14 +4,14 @@ import { InputSample } from "./headless/inputSample.js";
 import { Nonoptional } from "./nonoptional.js";
 import { ZoneBoundaryChecker } from "./configuration/zoneBoundaryChecker.js";
 
-export class TouchEventEngine<HoveredItemType> extends InputEventEngine<HoveredItemType> {
+export class TouchEventEngine<HoveredItemType, StateToken = any> extends InputEventEngine<HoveredItemType, StateToken> {
   private readonly _touchStart: typeof TouchEventEngine.prototype.onTouchStart;
   private readonly _touchMove:  typeof TouchEventEngine.prototype.onTouchMove;
   private readonly _touchEnd:   typeof TouchEventEngine.prototype.onTouchEnd;
 
   private safeBoundMaskMap: {[id: number]: number} = {};
 
-  public constructor(config: Nonoptional<GestureRecognizerConfiguration<HoveredItemType>>) {
+  public constructor(config: Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>) {
     super(config);
 
     // We use this approach, rather than .bind, because _this_ version allows hook
@@ -24,15 +24,6 @@ export class TouchEventEngine<HoveredItemType> extends InputEventEngine<HoveredI
   private get eventRoot(): HTMLElement {
     return this.config.touchEventRoot;
   }
-
-  // public static forVisualKeyboard(vkbd: VisualKeyboard) {
-  //   let config: GestureRecognizerConfiguration = {
-  //     targetRoot: vkbd.element,
-  //     eventRoot: vkbd.element,
-  //   };
-
-  //   return new TouchEventEngine(config);
-  // }
 
   // public static forPredictiveBanner(banner: SuggestionBanner, handlerRoot: SuggestionManager) {
   //   const config: GestureRecognizerConfiguration = {
@@ -79,7 +70,9 @@ export class TouchEventEngine<HoveredItemType> extends InputEventEngine<HoveredI
   }
 
   private buildSampleFromTouch(touch: Touch, timestamp: number) {
-    return this.buildSampleFor(touch.clientX, touch.clientY, touch.target, timestamp);
+    // WILL be null for newly-starting `GestureSource`s / contact points.
+    const source = this.getTouchpointWithId(touch.identifier);
+    return this.buildSampleFor(touch.clientX, touch.clientY, touch.target, timestamp, source?.stateToken ?? this.stateToken);
   }
 
   onTouchStart(event: TouchEvent) {


### PR DESCRIPTION
This PR aims to facilitate a resolution to #7173.  It is not a fix at this time, as integration with the OSK will be required for that.

The main addition here:  typing for a "state token", as well as a few related fields.  The idea:  the KMW OSK will be able to set the current "layer ID" as a "state token" on each gesture when the corresponding touchpoint first begins (and thus, the `GestureSource` is first instantiated.  Even if the layer changes before the gesture completes, that data will be accessible and can be used to look up the correct key from the gesture's original starting layer.

Note that this will be useful for more than just #7173 - it will also be useful for multitaps that include layer-switching keys.

In case a gesture's "active layer" ever _should_ be swapped after it begins, the field on the `GestureSource` is public and mutable; any new updates for the `GestureSource` will use the new value.  Older samples will still remember the old, pre-change layer.

For predictive-text:  the banner doesn't have layers, but it _does_ have state:  the `Transcription` id of the input that triggered the suggestions being displayed.  (Its type is `number`, rather than `string` as used by the OSK's layer id.)  We have noted a couple of scenarios where multitouch interactions with the banner have issues, and this could help prevent similar issues to #7173 from occurring for the banner.

----

Finally, this PR also adds `readonly` to the stats-oriented properties of `InputSample`.  Due to the need for stats-tracking in order to support geometrical analyses of gesture paths, it is unwise to allow those properties to be mutable after the fact.  However, there _are_ cases in which the new `stateToken` _should_ be mutable.  I figured that adding `readonly` where applicable would make this distinction much clearer in the type definitions.

`item` could _probably_ be `readonly`, but I'm not 100% sure that it should be, while I'm 100% sure that there's no reason it _needs_ to be `readonly` at this time.  I figured I'd leave it mutable for now.

@keymanapp-test-bot skip