### PR TITLE
feat(web): adds gesture-engine API properties for integration use 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureSequence.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureSequence.ts
@@ -105,6 +105,32 @@ export class GestureSequence<Type> extends EventEmitter<EventMap<Type>> {
     return this.selector?.baseGestureSetId ?? null;
   }
 
+    /**
+   * Returns an array of IDs for gesture models that are still valid for the `GestureSource`'s
+   * current state.  They will be specified in descending `resolutionPriority` order.
+   */
+    public get potentialModelMatchIds(): string[] {
+      // The new round of model-matching is based on the sources used by the previous round.
+      // This is important; 'sustainTimer' gesture models may rely on a now-terminated source
+      // from that previous round (like with multitaps).
+      const lastStageReport = this.stageReports[this.stageReports.length-1];
+      const trackedSources = lastStageReport.sources;
+
+      const potentialMatches = trackedSources.map((source) => {
+        return this.selector.potentialMatchersForSource(source)
+          .map((matcher) => matcher.model.id)
+      }).reduce((deduplicated, arr) => {
+        for(let entry of arr) {
+          if(deduplicated.indexOf(entry) == -1) {
+            deduplicated.push(entry);
+          }
+        }
+        return deduplicated;
+      }, [] as string[]);;
+
+      return potentialMatches;
+    }
+
   private readonly selectionHandler = (selection: MatcherSelection<Type>) => {
     const matchReport = new GestureStageReport<Type>(selection);
     if(selection.matcher) {

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/matcherSelector.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/matcherSelector.ts
@@ -43,6 +43,16 @@ export class MatcherSelector<Type> extends EventEmitter<EventMap<Type>> {
     this.baseGestureSetId = baseSetId || 'default';
   }
 
+  /**
+   * Returns all active `GestureMatcher`s that are currently active for the specified `GestureSource`.
+   * They will be specified in descending `resolutionPriority` order.
+   * @param source
+   * @returns
+   */
+  public potentialMatchersForSource(source: GestureSource<Type>) {
+    return this.potentialMatchers.filter((matcher) => matcher.allSourceIds.find((id) => id == source.identifier));
+  }
+
   public cascadeTermination() {
     const potentialMatchers = this.potentialMatchers;
     const matchersToCancel = potentialMatchers.filter((matcher) => !matcher.model.sustainWhenNested);

--- a/common/web/gesture-recognizer/src/engine/headless/inputEngineBase.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/inputEngineBase.ts
@@ -56,4 +56,8 @@ export abstract class InputEngineBase<HoveredItemType, StateToken = any> extends
   protected addTouchpoint(touchpoint: GestureSource<HoveredItemType, StateToken>) {
     this._activeTouchpoints.push(touchpoint);
   }
+
+  public get activeSources(): GestureSource<HoveredItemType, StateToken>[] {
+    return [].concat(this._activeTouchpoints);
+  }
 }

--- a/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
@@ -5,13 +5,13 @@ import { MatcherSelector } from "./gestures/matchers/matcherSelector.js";
 import { GestureSequence } from "./gestures/matchers/gestureSequence.js";
 import { GestureModelDefs, getGestureModelSet } from "./gestures/specs/gestureModelDefs.js";
 
-interface EventMap<HoveredItemType> {
+interface EventMap<HoveredItemType, StateToken> {
   /**
    * Indicates that a new potential gesture has begun.
    * @param input
    * @returns
    */
-  'inputstart': (input: GestureSource<HoveredItemType>) => void;
+  'inputstart': (input: GestureSource<HoveredItemType, StateToken>) => void;
 
   'recognizedgesture': (sequence: GestureSequence<HoveredItemType>) => void;
 }
@@ -24,7 +24,7 @@ interface EventMap<HoveredItemType> {
  * Of particular note: when a gesture involves multiple touchpoints - like a multitap - this class
  * is responsible for linking related touchpoints together for the detection of that gesture.
  */
-export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends EventEmitter<EventMap<HoveredItemType>> {
+export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends EventEmitter<EventMap<HoveredItemType, StateToken>> {
   private inputEngines: InputEngineBase<HoveredItemType, StateToken>[];
   private selectorStack: MatcherSelector<HoveredItemType>[] = [new MatcherSelector()];
 

--- a/common/web/gesture-recognizer/src/engine/index.ts
+++ b/common/web/gesture-recognizer/src/engine/index.ts
@@ -6,7 +6,7 @@ export { GestureRecognizerConfiguration } from "./configuration/gestureRecognize
 export { InputEngineBase } from "./headless/inputEngineBase.js";
 export { InputSample } from "./headless/inputSample.js";
 export { SerializedGesturePath, GesturePath } from "./headless/gesturePath.js";
-export { SerializedGestureSource, GestureSource } from "./headless/gestureSource.js";
+export { SerializedGestureSource, GestureSource, buildGestureMatchInspector } from "./headless/gestureSource.js";
 export { MouseEventEngine } from "./mouseEventEngine.js";
 export { PathSegmenter, Subsegmentation } from "./headless/subsegmentation/pathSegmenter.js";
 export { PaddedZoneSource } from './configuration/paddedZoneSource.js';

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/gestureSequence.spec.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/gestureSequence.spec.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import * as PromiseStatusModule from 'promise-status-async';
 import { assertingPromiseStatus as promiseStatus } from '../../../resources/assertingPromiseStatus.js';
 
-import { GestureModelDefs, GestureSource, gestures } from '@keymanapp/gesture-recognizer';
+import { GestureModelDefs, buildGestureMatchInspector, gestures } from '@keymanapp/gesture-recognizer';
 const { matchers } = gestures;
 
 // Huh... gotta do BOTH here?  One for constructor use, the other for generic-parameter use?
@@ -92,6 +92,8 @@ async function sequenceEmulationAndAssertion(emulationEngine: HeadlessInputEngin
   // The workaround: we build Promises for would-be async handlers that can sync; we pass caught errors
   // to them so that they're reported by the automated test.
   emulationEngine.on('pointstart', (source) => {
+    source.setGestureMatchInspector(buildGestureMatchInspector(selector));
+
     try {
       // These parts should be handled by TouchpointCoordinator.  This is a simplified mocked version
       // of what lies there.

--- a/common/web/gesture-recognizer/src/test/resources/simulateMultiSourceInput.ts
+++ b/common/web/gesture-recognizer/src/test/resources/simulateMultiSourceInput.ts
@@ -1,4 +1,4 @@
-import { InputSample, GestureSource, gestures } from '@keymanapp/gesture-recognizer';
+import { InputSample, buildGestureMatchInspector, GestureSource, gestures } from '@keymanapp/gesture-recognizer';
 import { ManagedPromise, timedPromise } from '@keymanapp/web-utils';
 import { GestureSourceSubview } from '../../../build/obj/headless/gestureSource.js';
 
@@ -393,6 +393,10 @@ export function simulateSelectorInput<Type>(
     executor
     // Minor TS inference problem below (b/c arrays aren't necessarily guaranteed a first entry?)
   } = simulateMultiSourceInput(config, input.pathSpecs as any, fakeClock);
+
+  testObjPromise.then((selector) => {
+    sources.forEach((source) => source.setGestureMatchInspector(buildGestureMatchInspector(selector)));
+  });
 
   return {
     sources,

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessInputEngine.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/headlessInputEngine.ts
@@ -32,6 +32,7 @@ export class HeadlessInputEngine<Type = any> extends InputEngineBase<Type> {
     replaySource.update(headSample); // is included before the point is made available.
 
     const startPromise = timedPromise(headSample.t).then(() => {
+      this.addTouchpoint(replaySource);
       this.emit('pointstart', replaySource);
     });
 
@@ -64,6 +65,7 @@ export class HeadlessInputEngine<Type = any> extends InputEngineBase<Type> {
       if(replaySource.isPathComplete) {
         return;
       }
+      this.dropTouchpointWithId(replaySource.rawIdentifier);
       replaySource.terminate(recording.path.wasCancelled);
     });
   }


### PR DESCRIPTION
Adds three new properties:

`TouchpointCoordinator.activeSources` - while `.activeGestures` already exists, reporting active gestures with at least one stage already... there was nothing for cases that do not yet have any stages / matches.  Essentially... `GestureSource`s here correspond well to "roaming touch" inputs, early key highlighting, and key previews - we have a pending input, but it hasn't actually triggered any state changes or key events.

`GestureSource.potentialModelMatchIds` - this allows inspecting the state of `GestureSource`s - like those available on the previous property - to determine what gesture models still have the potential to match for the current stage.  Reading that can be very useful for determining the best hint type for the OSK to display.
- if the key has flicks available and a "flick" gesture is still possible... maybe show a flick hint, even before a flick state is confirmed
- otherwise, key previews and/or key highlighting sound good

`GestureSequence.potentialModelMatchIds` - the same, but on the `GestureSequence` object that results after at least one gesture component has fully resolved.

Even if they (somehow) don't end up getting used directly by Web's OSK, they also carry the benefit of being great, easily-readable properties for debug inspection.  That's a nice benefit by itself.

----

As a side note, I now have a minor question on flick hint interactions with phone form-factor key previews.  Admittedly, the best idea I remember us having for flick hints was to shift the key caps on the key itself, which actually doesn't conflict (directly) with a key preview... but we should probably cancel the preview after a small distance threshold, as the flick hint system starts having effects.  It would be simpler and more granular to block a flick hint outright until that threshold, but it could cause jumpy animation.  (Of course, it'll likely be jumpy either way if a longpress wins if the flick-recognition distance threshold isn't met.)

@keymanapp-test-bot skip