### PR TITLE
fix(windows): fix the ellipsis for longer text on buttons

### DIFF
--- a/windows/src/desktop/kmshell/xml/splash.css
+++ b/windows/src/desktop/kmshell/xml/splash.css
@@ -156,6 +156,9 @@ a.button {
 #config .btn {
   width: 180px;
   text-overflow: ellipsis;
+  overflow: hidden;
+  display: inline-block;
+  white-space: nowrap;
 }
 
 #config {
@@ -167,6 +170,10 @@ a.button {
 
 #exit .btn-small {
   width: 90px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  display: inline-block;
+  white-space: nowrap;
 }
 
 #tasks div#showAtStartupBox { margin-top: 6px; margin-left: 0; }


### PR DESCRIPTION
Fixes #9481 
The buttons already had a property to display ellipsis when the text was too big for the buttons. However the other properties such as white-space nowrap needed to be added to work in all cases. This change adds those properties and also extends the ellipsis overflow to the exit button.

Note it was noticed that "Keyman" had been localized when it shouldn't have been a separate issue has been created. #9635

Here is the result for Kannada  
![image](https://github.com/keymanapp/keyman/assets/58423624/61e20510-fe2c-42d9-a2c9-6d7237e05155)

The exit button for Wahu
![image](https://github.com/keymanapp/keyman/assets/58423624/07752340-7d11-4551-be8b-4993620fb0f4)

 And a bonus Marghi
![image](https://github.com/keymanapp/keyman/assets/58423624/e021e95f-ba88-4ec0-9852-638e57ca4a70)


# User Testing

# TEST_TEXT_OVERUN

1. Install Keyman 17.0.161-alpha build. 
3. Open Keyman Configuration dialog. 
4. Change the UI into Kannada. 
5. Exit Configuration 
6. Go to the Splash Screen

Observe now that the extra-long text is truncated with ellipses  "..."
Repeat for Wahu and Marghi
