### PR TITLE
feat(developer): show an INFO message when warnings have failed a build

### DIFF
--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -129,6 +129,9 @@ async function build(filename: string, parentCallbacks: NodeCompilerCallbacks, o
         : InfrastructureMessages.Info_FileBuiltSuccessfully({filename:buildFilename})
       );
     } else {
+      if(!callbacks.hasFailureMessage(false)) { // false == check only for error+fatal messages
+        callbacks.reportMessage(InfrastructureMessages.Info_WarningsHaveFailedBuild());
+      }
       callbacks.reportMessage(builder instanceof BuildProject
         ? InfrastructureMessages.Info_ProjectNotBuiltSuccessfully({filename:buildFilename})
         : InfrastructureMessages.Info_FileNotBuiltSuccessfully({filename:buildFilename})

--- a/developer/src/kmc/src/messages/infrastructureMessages.ts
+++ b/developer/src/kmc/src/messages/infrastructureMessages.ts
@@ -71,5 +71,9 @@ export class InfrastructureMessages {
   static Error_NotAProjectFile = (o:{filename:string}) => m(this.ERROR_NotAProjectFile,
     `File ${o.filename} must have a .kpj extension to be treated as a project.`);
   static ERROR_NotAProjectFile = SevError | 0x000F;
+
+  static Info_WarningsHaveFailedBuild = () => m(this.INFO_WarningsHaveFailedBuild,
+    `The build failed because option "treat warnings as errors" is enabled and there are one or more warnings.`);
+  static INFO_WarningsHaveFailedBuild = SevInfo | 0x0010;
 }
 

--- a/developer/src/kmc/test/test-infrastructureMessages.ts
+++ b/developer/src/kmc/test/test-infrastructureMessages.ts
@@ -6,6 +6,7 @@ import { makePathToFixture } from './helpers/index.js';
 import { NodeCompilerCallbacks } from '../src/util/NodeCompilerCallbacks.js';
 import { CompilerErrorNamespace } from '@keymanapp/common-types';
 import { unitTestEndpoints } from '../src/commands/build.js';
+import { KmnCompilerMessages } from '@keymanapp/kmc-kmn';
 
 describe('InfrastructureMessages', function () {
   it('should have a valid InfrastructureMessages object', function() {
@@ -64,5 +65,23 @@ describe('InfrastructureMessages', function () {
     ncb.loadFile(makePathToFixture('invalid-keyboards', 'Hint_Filename_Has_Differing_Case.kmn'));
     assert.isTrue(ncb.hasMessage(InfrastructureMessages.HINT_FilenameHasDifferingCase),
       `HINT_FilenameHasDifferingCase not generated, instead got: `+JSON.stringify(ncb.messages,null,2));
+  });
+
+  // INFO_WarningsHaveFailedBuild
+
+  it('should generate INFO_WarningsHaveFailedBuild if only warnings failed the build', async function() {
+    // NOTE: we can probably re-use this format for most other message tests in the future
+    const ncb = new NodeCompilerCallbacks({logLevel: 'silent'});
+    const filename = makePathToFixture('compiler-warnings-as-errors', 'keyboard.kmn');
+    const expectedMessages = [
+      InfrastructureMessages.INFO_BuildingFile,
+      KmnCompilerMessages.WARN_HeaderStatementIsDeprecated,
+      InfrastructureMessages.INFO_WarningsHaveFailedBuild,
+      InfrastructureMessages.INFO_FileNotBuiltSuccessfully
+    ];
+    await unitTestEndpoints.build(filename, ncb, {compilerWarningsAsErrors: true});
+    assert.deepEqual(ncb.messages.map(m => m.code), expectedMessages,
+      `actual callbacks.messages:\n${JSON.stringify(ncb.messages,null,2)}\n\n`+
+      `did not match expected:\n${JSON.stringify(expectedMessages,null,2)}\n\n`);
   });
 });


### PR DESCRIPTION
Fixes #9610.

If a build fails when "treat warnings as errors" is on, but there are only warnings and no error messages, it can be confusing for the developer. Adds the following `INFO_WarningsHaveFailedBuild` message:

`The build failed because option "treat warnings as errors" is enabled and there are one or more warnings.`

Unit test also added to verify behaviour.

@keymanapp-test-bot skip