### PR TITLE
feat(developer): issue hint if package includes keyboard source files

### DIFF
--- a/developer/src/kmc-package/src/compiler/messages.ts
+++ b/developer/src/kmc-package/src/compiler/messages.ts
@@ -2,7 +2,7 @@ import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m
 
 const Namespace = CompilerErrorNamespace.PackageCompiler;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
-// const SevHint = CompilerErrorSeverity.Hint | Namespace;
+const SevHint = CompilerErrorSeverity.Hint | Namespace;
 const SevWarn = CompilerErrorSeverity.Warn | Namespace;
 const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
@@ -115,6 +115,10 @@ export class CompilerMessages {
   static Warn_KeyboardShouldHaveAtLeastOneLanguage = (o:{id:string}) => m(this.WARN_KeyboardShouldHaveAtLeastOneLanguage,
     `The keyboard ${o.id} should have at least one language specified.`);
   static WARN_KeyboardShouldHaveAtLeastOneLanguage = SevWarn | 0x001B;
+
+  static Hint_PackageContainsSourceFile = (o:{filename:string}) => m(this.HINT_PackageContainsSourceFile,
+    `The source file ${o.filename} should not be included in the package; instead include the compiled result.`);
+  static HINT_PackageContainsSourceFile = SevHint | 0x001C;
 
 }
 

--- a/developer/src/kmc-package/test/fixtures/invalid/error_package_must_contain_a_model_or_a_keyboard.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/error_package_must_contain_a_model_or_a_keyboard.kps
@@ -10,12 +10,11 @@
   </Info>
   <Files>
     <File>
-      <!-- error_package_must_contain_a_model_or_a_keyboard. This is a common error:
-           to include a .kmn instead of a .kmx -->
-      <Name>khmer_angkor.kmn</Name>
-      <Description>Keyboard Khmer Angkor</Description>
+      <!-- error_package_must_contain_a_model_or_a_keyboard.  -->
+      <Name>example.txt</Name>
+      <Description>Example text file</Description>
       <CopyLocation>0</CopyLocation>
-      <FileType>.kmn</FileType>
+      <FileType>.txt</FileType>
     </File>
   </Files>
 </Package>

--- a/developer/src/kmc-package/test/fixtures/invalid/example.txt
+++ b/developer/src/kmc-package/test/fixtures/invalid/example.txt
@@ -1,0 +1,1 @@
+This is a sample text file

--- a/developer/src/kmc-package/test/fixtures/invalid/hint_source_file_should_not_be_in_package.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/hint_source_file_should_not_be_in_package.kps
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Info>
+    <Name URL="">SENĆOŦEN (Saanich Dialect) Keyboard</Name>
+    <Copyright URL="">© 2019 National Research Council Canada</Copyright>
+    <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
+    <Version>1.0</Version>
+  </Info>
+  <Files>
+    <File>
+      <Name>basic.kmx</Name>
+      <Description>Keyboard Basic</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+    <!-- hint_source_file_should_not_be_in_package -->
+    <File>
+      <Name>basic.kmn</Name>
+      <Description>Keyboard Source Basic</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmn</FileType>
+    </File>
+  </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>Basic</Name>
+      <ID>basic</ID>
+      <Version>1.0</Version>
+      <Languages>
+        <Language ID="KM">Khmer</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
+</Package>

--- a/developer/src/kmc-package/test/test-messages.ts
+++ b/developer/src/kmc-package/test/test-messages.ts
@@ -182,7 +182,7 @@ describe('CompilerMessages', function () {
 
   // ERROR_PackageMustContainAPackageOrAKeyboard
 
-  it('should generate ERROR_PackageMustContainAModelOrAKeyboard if package contains a .doc file', async function() {
+  it('should generate ERROR_PackageMustContainAModelOrAKeyboard if package contains no keyboard or model', async function() {
     testForMessage(this, ['invalid', 'error_package_must_contain_a_model_or_a_keyboard.kps'],
       CompilerMessages.ERROR_PackageMustContainAModelOrAKeyboard);
   });
@@ -199,6 +199,13 @@ describe('CompilerMessages', function () {
   it('should generate WARN_KeyboardShouldHaveAtLeastOneLanguage if keyboard has zero language tags', async function() {
     testForMessage(this, ['invalid', 'warn_keyboard_should_have_at_least_one_language.kps'],
       CompilerMessages.WARN_KeyboardShouldHaveAtLeastOneLanguage);
+  });
+
+  // HINT_PackageContainsSourceFile
+
+  it('should generate HINT_PackageContainsSourceFile if package contains a source file', async function() {
+    testForMessage(this, ['invalid', 'hint_source_file_should_not_be_in_package.kps'],
+      CompilerMessages.HINT_PackageContainsSourceFile);
   });
 
 });


### PR DESCRIPTION
Fixes #9325.

Also tweaks unit test for error_package_must_contain_a_model_or_a_keyboard as the fixture had a .kmn, triggering the new hint, which was unhelpful in this case.

@keymanapp-test-bot skip