### PR TITLE
chore(developer): add test for `checkFilenameConventions == false` or unset

### DIFF
--- a/developer/src/kmc-package/test/fixtures/invalid/my_file.PDF
+++ b/developer/src/kmc-package/test/fixtures/invalid/my_file.PDF
@@ -1,0 +1,1 @@
+(Note: not a PDF file, just included as a sample file)

--- a/developer/src/kmc-package/test/test-messages.ts
+++ b/developer/src/kmc-package/test/test-messages.ts
@@ -128,6 +128,13 @@ describe('CompilerMessages', function () {
       CompilerMessages.WARN_FileInPackageDoesNotFollowFilenameConventions, {checkFilenameConventions: true});
   });
 
+  // Test the inverse -- no warning generated if checkFilenameConventions is false
+
+  it('should not generate WARN_FileInPackageDoesNotFollowFilenameConventions if content filename has wrong conventions but checkFilenameConventions is false', async function() {
+    testForMessage(this, ['invalid', 'warn_file_in_package_does_not_follow_filename_conventions.kps'], null, {checkFilenameConventions: false});
+    testForMessage(this, ['invalid', 'warn_file_in_package_does_not_follow_filename_conventions_2.kps'], null, {checkFilenameConventions: false});
+  });
+
   // ERROR_PackageNameCannotBeBlank
 
   it('should generate ERROR_PackageNameCannotBeBlank if package info has empty name', async function() {


### PR DESCRIPTION
Fixes #9317.

@keymanapp-test-bot skip