### PR TITLE
fix(linux): Explicitly initialize GTK

### DIFF
--- a/linux/keyman-config/km-config
+++ b/linux/keyman-config/km-config
@@ -2,6 +2,12 @@
 
 import argparse
 import logging
+import sys
+import gi
+
+gi.require_version('Gtk', '3.0')
+
+from gi.repository import Gtk
 
 from keyman_config import __versionwithtag__, __pkgversion__, add_standard_arguments, initialize_logging, initialize_sentry
 from keyman_config.handle_install import download_and_install_package
@@ -29,6 +35,8 @@ if __name__ == '__main__':
     add_standard_arguments(parser)
 
     args = parser.parse_args()
+
+    Gtk.init(sys.argv[1:])
 
     initialize_logging(args)
     initialize_sentry()


### PR DESCRIPTION
Usually this is done automatically. However, if e.g. no `DISPLAY` variable is set it'll fail. When we explicitly initialize GTK it still fails, but shows a more helpful warning instead of throwing a runtime error.

Fixes #9705.

# User Testing

## Preparations

- The test should be run on any Linux platform with X11:

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

## Tests

**TEST_WARNING**: if `DISPLAY` is not set we should get a warning instead of a runtime error

- in a terminal window, run `unset DISPLAY`
- in the same terminal, start Keyman Configuration by typing `km-config`
- Verify that instead of opening the Keyman Configuration window the terminal displays a warning similar to `Gtk-WARNING **: 16:51:19.867: cannot open display:`. There should be no lines containing the text `RuntimeError`.
