### PR TITLE
feat(developer): introduce WelcomeFile property to packages 🎺

### DIFF
--- a/common/schemas/kps/kps.xsd
+++ b/common/schemas/kps/kps.xsd
@@ -32,6 +32,7 @@
             <xs:element minOccurs="0" maxOccurs="1" name="ReadMeFile" type="xs:string" />
             <xs:element minOccurs="0" maxOccurs="1" name="GraphicFile" type="xs:string" />
             <xs:element minOccurs="0" maxOccurs="1" name="LicenseFile" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" name="WelcomeFile" type="xs:string" />
             <xs:element minOccurs="0" maxOccurs="1" name="MSIFileName" type="xs:string" />
             <xs:element minOccurs="0" maxOccurs="1" name="MSIOptions" type="xs:string" />
             <xs:element minOccurs="0" maxOccurs="1" name="FollowKeyboardVersion" type="km-empty" />

--- a/common/web/types/src/package/kmp-json-file.ts
+++ b/common/web/types/src/package/kmp-json-file.ts
@@ -18,6 +18,7 @@ export interface KmpJsonFileOptions {
   readmeFile?: string;
   graphicFile?: string;
   licenseFile?: string;
+  welcomeFile?: string;
   executeProgram?: string;
   msiFilename?: string;
   msiOptions?: string;

--- a/common/web/types/src/package/kps-file.ts
+++ b/common/web/types/src/package/kps-file.ts
@@ -42,6 +42,7 @@ export interface KpsFileOptions {
   readMeFile?: string;
   graphicFile?: string;
   licenseFile?: string;
+  welcomeFile?: string;
   executeProgram?: string;
   msiFileName?: string;
   msiOptions?: string;

--- a/developer/src/kmc-package/src/compiler/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/kmp-compiler.ts
@@ -16,6 +16,11 @@ import { markdownToHTML } from './markdown.js';
 const KMP_JSON_FILENAME = 'kmp.json';
 const KMP_INF_FILENAME = 'kmp.inf';
 
+// welcome.htm: this is a legacy filename, as of 17.0 the welcome
+// (documentation) filename can be any file, but we will fallback to detecting
+// this filename for existing keyboard packages.
+const WELCOME_HTM_FILENAME = 'welcome.htm';
+
 export class KmpCompiler {
 
   constructor(private callbacks: CompilerCallbacks) {
@@ -84,6 +89,7 @@ export class KmpCompiler {
       kmp.options.msiOptions = kps.options.msiOptions || undefined;
       kmp.options.readmeFile = kps.options.readMeFile || undefined;
       kmp.options.licenseFile = kps.options.licenseFile || undefined;
+      kmp.options.welcomeFile = kps.options.welcomeFile || undefined;
     }
 
     //
@@ -373,6 +379,8 @@ export class KmpCompiler {
       return null;
     }
 
+    // TODO #9477: transform .md to .htm
+
     // Remove path data from file references in options
 
     if(data.options.graphicFile) {
@@ -384,6 +392,16 @@ export class KmpCompiler {
     if(data.options.licenseFile) {
       data.options.licenseFile = this.callbacks.path.basename(data.options.licenseFile);
     }
+    if(data.options.welcomeFile) {
+      data.options.welcomeFile = this.callbacks.path.basename(data.options.welcomeFile);
+    } else if(data.files.find(file => file.name == WELCOME_HTM_FILENAME)) {
+      // We will, for improved backward-compatibility with existing packages, add a
+      // reference to the file welcome.htm is it is present in the package. This allows
+      // newer tools to avoid knowing about welcome.htm, if we assume that they work with
+      // packages compiled with kmc-package (17.0+) and not kmcomp (5.x-16.x).
+      data.options.welcomeFile = WELCOME_HTM_FILENAME;
+    }
+
     if(data.options.msiFilename) {
       data.options.msiFilename = this.callbacks.path.basename(data.options.msiFilename);
     }

--- a/developer/src/kmc-package/test/fixtures/khmer_angkor/ref/kmp.json
+++ b/developer/src/kmc-package/test/fixtures/khmer_angkor/ref/kmp.json
@@ -5,7 +5,8 @@
   },
   "options": {
     "readmeFile": "readme.htm",
-    "graphicFile": "splash.gif"
+    "graphicFile": "splash.gif",
+    "welcomeFile": "welcome.htm"
   },
   "info": {
     "name": {

--- a/developer/src/kmc-package/test/fixtures/khmer_angkor/source/khmer_angkor.kps
+++ b/developer/src/kmc-package/test/fixtures/khmer_angkor/source/khmer_angkor.kps
@@ -8,6 +8,7 @@
     <ExecuteProgram></ExecuteProgram>
     <ReadMeFile>readme.htm</ReadMeFile>
     <GraphicFile>splash.gif</GraphicFile>
+    <WelcomeFile>welcome.htm</WelcomeFile>
     <MSIFileName></MSIFileName>
     <MSIOptions></MSIOptions>
     <FollowKeyboardVersion/>

--- a/developer/src/tike/child/UfrmPackageEditor.dfm
+++ b/developer/src/tike/child/UfrmPackageEditor.dfm
@@ -184,7 +184,7 @@ inherited frmPackageEditor: TfrmPackageEditor
     Top = 0
     Width = 965
     Height = 622
-    ActivePage = pageKeyboards
+    ActivePage = pageDetails
     Align = alClient
     Images = modActionsMain.ilEditorPages
     MultiLine = True
@@ -236,7 +236,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 546
           Height = 32
           AutoSize = False
-          Caption =
+          Caption = 
             'A typical package will need keyboards, fonts, and documentation.' +
             ' You shouldn'#39't typically add source files. Also, don'#39't add any s' +
             'tandard Keyman files (such as keyman.exe) here.'
@@ -839,7 +839,7 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object lblReadme: TLabel
           Left = 15
-          Top = 120
+          Top = 148
           Width = 63
           Height = 13
           Caption = '&Readme file:'
@@ -853,35 +853,35 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object lblStep2c: TLabel
           Left = 15
-          Top = 173
+          Top = 202
           Width = 41
           Height = 13
           Caption = 'Version:'
         end
         object lblStep2d: TLabel
           Left = 15
-          Top = 221
+          Top = 254
           Width = 54
           Height = 13
           Caption = 'Copyright:'
         end
         object lblStep2e: TLabel
           Left = 15
-          Top = 253
+          Top = 282
           Width = 39
           Height = 13
           Caption = 'Author:'
         end
         object lblStep2f: TLabel
-          Left = 15
-          Top = 277
+          Left = 295
+          Top = 282
           Width = 77
           Height = 13
           Caption = 'E-mail address:'
         end
         object lblStep2g: TLabel
           Left = 15
-          Top = 301
+          Top = 309
           Width = 49
           Height = 13
           Caption = 'Web Site:'
@@ -927,7 +927,7 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object lblVersionHint: TLabel
           Left = 622
-          Top = 175
+          Top = 204
           Width = 46
           Height = 13
           Anchors = [akTop, akRight]
@@ -959,20 +959,28 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object lblLicenseFile: TLabel
           Left = 15
-          Top = 147
+          Top = 175
           Width = 59
           Height = 13
           Caption = '&License file:'
           FocusControl = cbLicense
         end
+        object lblWelcomeFile: TLabel
+          Left = 14
+          Top = 118
+          Width = 69
+          Height = 13
+          Caption = '&Welcome file:'
+          FocusControl = cbWelcomeFile
+        end
         object cbReadMe: TComboBox
           Left = 114
-          Top = 115
+          Top = 143
           Width = 499
           Height = 21
           Style = csDropDownList
           Anchors = [akLeft, akTop, akRight]
-          TabOrder = 1
+          TabOrder = 2
           OnClick = cbReadMeClick
         end
         object editInfoName: TEdit
@@ -986,58 +994,57 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object editInfoVersion: TEdit
           Left = 114
-          Top = 170
+          Top = 199
           Width = 499
           Height = 21
           Anchors = [akLeft, akTop, akRight]
-          TabOrder = 3
+          TabOrder = 4
           OnChange = editInfoVersionChange
         end
         object editInfoCopyright: TEdit
           Left = 114
-          Top = 218
+          Top = 251
           Width = 499
           Height = 21
           Anchors = [akLeft, akTop, akRight]
-          TabOrder = 5
+          TabOrder = 6
           Text = #169
           OnChange = editInfoCopyrightChange
         end
         object editInfoAuthor: TEdit
           Left = 114
-          Top = 250
-          Width = 499
+          Top = 279
+          Width = 175
           Height = 21
-          Anchors = [akLeft, akTop, akRight]
-          TabOrder = 7
+          TabOrder = 8
           OnChange = editInfoAuthorChange
         end
         object editInfoEmail: TEdit
-          Left = 114
-          Top = 274
-          Width = 499
+          Left = 377
+          Top = 279
+          Width = 236
           Height = 21
           Anchors = [akLeft, akTop, akRight]
-          TabOrder = 8
+          TabOrder = 9
           OnChange = editInfoEmailChange
         end
         object editInfoWebSite: TEdit
           Left = 114
-          Top = 298
+          Top = 306
           Width = 499
           Height = 21
           Anchors = [akLeft, akTop, akRight]
-          TabOrder = 9
+          TabOrder = 10
           OnChange = editInfoWebSiteChange
         end
         object cmdInsertCopyright: TButton
           Left = 620
-          Top = 218
+          Top = 251
           Width = 49
           Height = 21
           Anchors = [akTop, akRight]
           Caption = '&Insert '#169
-          TabOrder = 6
+          TabOrder = 7
           OnClick = cmdInsertCopyrightClick
         end
         object cbKMPImageFile: TComboBox
@@ -1047,7 +1054,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 21
           Style = csDropDownList
           Anchors = [akLeft, akTop, akRight]
-          TabOrder = 10
+          TabOrder = 11
           OnClick = cbKMPImageFileClick
         end
         object panKMPImageSample: TPanel
@@ -1057,7 +1064,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 251
           Anchors = [akTop, akRight]
           BevelOuter = bvLowered
-          TabOrder = 11
+          TabOrder = 12
           object imgKMPSample: TImage
             Left = 1
             Top = 0
@@ -1067,11 +1074,11 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object chkFollowKeyboardVersion: TCheckBox
           Left = 114
-          Top = 196
+          Top = 225
           Width = 237
           Height = 17
           Caption = 'Package version follows keyboard version'
-          TabOrder = 4
+          TabOrder = 5
           OnClick = chkFollowKeyboardVersionClick
         end
         object memoInfoDescription: TMemo
@@ -1079,7 +1086,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Top = 394
           Width = 499
           Height = 97
-          TabOrder = 12
+          TabOrder = 13
           OnChange = memoInfoDescriptionChange
         end
         object gridRelatedPackages: TStringGrid
@@ -1092,7 +1099,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           FixedCols = 0
           RowCount = 9
           Options = [goFixedVertLine, goFixedHorzLine, goVertLine, goHorzLine, goColSizing, goRowSelect]
-          TabOrder = 13
+          TabOrder = 14
           OnDblClick = gridRelatedPackagesDblClick
           ColWidths = (
             78
@@ -1104,7 +1111,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 73
           Height = 25
           Caption = '&Add...'
-          TabOrder = 14
+          TabOrder = 15
           OnClick = cmdAddRelatedPackageClick
         end
         object cmdEditRelatedPackage: TButton
@@ -1113,7 +1120,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 73
           Height = 25
           Caption = 'Ed&it...'
-          TabOrder = 15
+          TabOrder = 16
           OnClick = cmdEditRelatedPackageClick
         end
         object cmdRemoveRelatedPackage: TButton
@@ -1122,18 +1129,28 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 72
           Height = 25
           Caption = '&Remove'
-          TabOrder = 16
+          TabOrder = 17
           OnClick = cmdRemoveRelatedPackageClick
         end
         object cbLicense: TComboBox
           Left = 114
-          Top = 143
+          Top = 171
           Width = 499
           Height = 21
           Style = csDropDownList
           Anchors = [akLeft, akTop, akRight]
-          TabOrder = 2
+          TabOrder = 3
           OnClick = cbLicenseClick
+        end
+        object cbWelcomeFile: TComboBox
+          Left = 114
+          Top = 115
+          Width = 499
+          Height = 21
+          Style = csDropDownList
+          Anchors = [akLeft, akTop, akRight]
+          TabOrder = 1
+          OnClick = cbWelcomeFileClick
         end
       end
     end
@@ -1325,7 +1342,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Top = 48
           Width = 551
           Height = 13
-          Caption =
+          Caption = 
             'Compiling the package takes all the files you have selected and ' +
             'compresses them into a single package file.'
         end

--- a/developer/src/tike/child/UfrmPackageEditor.pas
+++ b/developer/src/tike/child/UfrmPackageEditor.pas
@@ -217,6 +217,8 @@ type
     lblWebDisplayFonts: TLabel;
     lblLicenseFile: TLabel;
     cbLicense: TComboBox;
+    lblWelcomeFile: TLabel;
+    cbWelcomeFile: TComboBox;
     procedure cmdCloseClick(Sender: TObject);
     procedure cmdAddFileClick(Sender: TObject);
     procedure cmdRemoveFileClick(Sender: TObject);
@@ -293,6 +295,7 @@ type
     procedure cmdKeyboardWebOSKFontsClick(Sender: TObject);
     procedure cmdKeyboardWebDisplayFontsClick(Sender: TObject);
     procedure cbLicenseClick(Sender: TObject);
+    procedure cbWelcomeFileClick(Sender: TObject);
   private
     pack: TKPSFile;
     FSetup: Integer;
@@ -308,6 +311,7 @@ type
     procedure EnableDetailsTabControls;
     procedure EnableCompileTabControls;
     function DoAction(action: TProjectFileAction): Boolean;
+    procedure UpdateWelcomeFile;
     procedure UpdateReadme;
     procedure UpdateImageFiles;
     procedure GetStartMenuEntries(var AName, AProg, AParams: WideString);
@@ -448,6 +452,7 @@ begin
     gridRelatedPackages.Cells[1, 0] := 'Relationship';
 
     UpdateStartMenuPrograms;
+    UpdateWelcomeFile;
     UpdateReadme;
     UpdateLicense;
     UpdateImageFiles;
@@ -768,6 +773,7 @@ begin
   pack.Files.Add(f);
   lbFiles.ItemIndex := lbFiles.Items.AddObject(ExtractFileName(FileName), f);
   lbFilesClick(lbFiles);
+  UpdateWelcomeFile;
   UpdateReadme;
   UpdateLicense;
   UpdateImageFiles;
@@ -814,6 +820,7 @@ begin
     lbFiles.Items.Delete(lbFiles.ItemIndex);
     if lbFiles.Items.Count > 0 then lbFiles.ItemIndex := 0;
     lbFilesClick(lbFiles);
+    UpdateWelcomeFile;
     UpdateReadme;
     UpdateLicense;
     UpdateImageFiles;
@@ -941,6 +948,15 @@ end;
 {-------------------------------------------------------------------------------
  - Options page                                                                -
  -------------------------------------------------------------------------------}
+
+procedure TfrmPackageEditor.cbWelcomeFileClick(Sender: TObject);
+begin
+  if FSetup > 0 then Exit;
+  if cbWelcomeFile.ItemIndex <= 0
+    then pack.Options.WelcomeFile := nil
+    else pack.Options.WelcomeFile := cbWelcomeFile.Items.Objects[cbWelcomeFile.ItemIndex] as TPackageContentFile;
+  Modified := True;
+end;
 
 procedure TfrmPackageEditor.cbReadMeClick(Sender: TObject);
 begin
@@ -1258,6 +1274,11 @@ begin
   cbStartMenuProgram.Items.Insert(3, '(About Product)');
 end;
 
+procedure TfrmPackageEditor.UpdateWelcomeFile;
+begin
+  FillFileList(cbWelcomeFile, pack.Options.WelcomeFile);
+end;
+
 procedure TfrmPackageEditor.UpdateReadme;
 begin
   FillFileList(cbReadme, pack.Options.ReadmeFile);
@@ -1297,6 +1318,7 @@ begin
       lbFiles.Items.AddObject(ExtractFileName(pack.Files[i].FileName), pack.Files[i]);
 
     UpdateOutPath;
+    UpdateWelcomeFile;
     UpdateReadme;
     UpdateLicense;
     UpdateImageFiles;


### PR DESCRIPTION
Fixes #9478.

This adds a property WelcomeFile to .kps and kmp.json, which allows us to move away from the hardcoded welcome.htm filename in the future, and makes transform from Markdown (#9477) a simpler operation, and just generally starts the cleanup of the messiness of hard-coded filenames.

The package compiler will fallback to injecting welcome.htm into this property if (a) welcome.htm is present, and (b) the property does not already have a value. This doesn't buy us much because we still need to support welcome.htm for existing legacy packages, but does mean that our .kmp package metadata will be more consistent for packages compiled with 17.0+ compilers.

# User Testing

**Note:** Keyman itself on all platforms still only supports the welcome.htm filename at this time, so do not expect documentation with arbitrary filenames to be visible in the client apps.

TEST_WELCOME_FILE: In the package editor in Keyman Developer, select a welcome.htm file in the new Documentation file field. Compile the package and verify that there are no errors. Add and remove the reference to the documentation file and verify that the field behaves as you would expect.