### PR TITLE
fix(developer): non-minimal BCP 47 tags in kps should be a hint 🎺

### DIFF
--- a/developer/src/kmc-package/src/compiler/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/kmp-compiler.ts
@@ -28,6 +28,9 @@ export class KmpCompiler {
 
   public transformKpsToKmpObject(kpsFilename: string): KmpJsonFile.KmpJsonFile {
     const kps = this.loadKpsFile(kpsFilename);
+    if(!kps) {
+      return null;
+    }
     return this.transformKpsFileToKmpObject(kpsFilename, kps);
   }
 

--- a/developer/src/kmc-package/src/compiler/messages.ts
+++ b/developer/src/kmc-package/src/compiler/messages.ts
@@ -88,9 +88,9 @@ export class CompilerMessages {
     `Language tag '${o.lang}' in ${o.resourceType} ${o.id} is invalid.`);
   static ERROR_LanguageTagIsNotValid = SevError | 0x0014;
 
-  static Warn_LanguageTagIsNotMinimal = (o: {resourceType: string, id:string, actual:string, expected:string}) => m(this.WARN_LanguageTagIsNotMinimal,
+  static Hint_LanguageTagIsNotMinimal = (o: {resourceType: string, id:string, actual:string, expected:string}) => m(this.HINT_LanguageTagIsNotMinimal,
     `Language tag '${o.actual}' in ${o.resourceType} ${o.id} is not minimal, and should be '${o.expected}'.`);
-  static WARN_LanguageTagIsNotMinimal = SevWarn | 0x0015;
+  static HINT_LanguageTagIsNotMinimal = SevHint | 0x0015;
 
   static Error_ModelMustHaveAtLeastOneLanguage = (o:{id:string}) => m(this.ERROR_ModelMustHaveAtLeastOneLanguage,
     `The lexical model ${o.id} must have at least one language specified.`);

--- a/developer/src/kmc-package/src/compiler/messages.ts
+++ b/developer/src/kmc-package/src/compiler/messages.ts
@@ -50,9 +50,9 @@ export class CompilerMessages {
     `The package contains both lexical models and keyboards, which is not permitted.`);
   static ERROR_PackageCannotContainBothModelsAndKeyboards = SevError | 0x000B;
 
-  static Warn_PackageShouldNotRepeatLanguages = (o:{resourceType: string, id: string, minimalTag: string, firstTag: string, secondTag: string}) => m(this.WARN_PackageShouldNotRepeatLanguages,
+  static Hint_PackageShouldNotRepeatLanguages = (o:{resourceType: string, id: string, minimalTag: string, firstTag: string, secondTag: string}) => m(this.HINT_PackageShouldNotRepeatLanguages,
     `Two language tags in ${o.resourceType} ${o.id}, '${o.firstTag}' and '${o.secondTag}', reduce to the same minimal tag '${o.minimalTag}'.`);
-  static WARN_PackageShouldNotRepeatLanguages = SevWarn | 0x000C;
+  static HINT_PackageShouldNotRepeatLanguages = SevHint | 0x000C;
 
   static Warn_PackageNameDoesNotFollowLexicalModelConventions = (o:{filename: string}) => m(this.WARN_PackageNameDoesNotFollowLexicalModelConventions,
     `The package file ${o.filename} does not follow the recommended model filename conventions. The name should be all lower case, `+

--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -64,7 +64,7 @@ export class PackageValidation {
       const minimalTag = locale.minimize().toString();
 
       if(minimalTag.toLowerCase() !== lang.id.toLowerCase()) {
-        this.callbacks.reportMessage(CompilerMessages.Warn_LanguageTagIsNotMinimal({resourceType, id, actual: lang.id, expected: minimalTag}));
+        this.callbacks.reportMessage(CompilerMessages.Hint_LanguageTagIsNotMinimal({resourceType, id, actual: lang.id, expected: minimalTag}));
       }
 
       if(minimalTags[minimalTag]) {

--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -68,7 +68,7 @@ export class PackageValidation {
       }
 
       if(minimalTags[minimalTag]) {
-        this.callbacks.reportMessage(CompilerMessages.Warn_PackageShouldNotRepeatLanguages({resourceType, id, minimalTag, firstTag: lang.id, secondTag: minimalTags[minimalTag]}));
+        this.callbacks.reportMessage(CompilerMessages.Hint_PackageShouldNotRepeatLanguages({resourceType, id, minimalTag, firstTag: lang.id, secondTag: minimalTags[minimalTag]}));
       }
       else {
         minimalTags[minimalTag] = lang.id;

--- a/developer/src/kmc-package/test/fixtures/invalid/hint_language_tag_is_not_minimal.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/hint_language_tag_is_not_minimal.kps
@@ -24,7 +24,7 @@
       <ID>basic</ID>
       <Version>1.0</Version>
       <Languages>
-        <!-- WARN_LanguageTagIsNotMinimal -->
+        <!-- HINT_LanguageTagIsNotMinimal -->
         <Language ID="km-Khmr-KH">Central Khmer (Khmer, Cambodia)</Language>
       </Languages>
     </Keyboard>

--- a/developer/src/kmc-package/test/fixtures/invalid/hint_package_should_not_repeat_languages.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/hint_package_should_not_repeat_languages.kps
@@ -24,7 +24,7 @@
       <ID>basic</ID>
       <Version>1.0</Version>
       <Languages>
-        <!-- WARN_PackageShouldNotRepeatLanguages -->
+        <!-- HINT_PackageShouldNotRepeatLanguages -->
         <Language ID="km">Central Khmer (Khmer, Cambodia)</Language>
         <Language ID="KM">Khmer</Language>
       </Languages>

--- a/developer/src/kmc-package/test/fixtures/invalid/keyman.en.hint_package_should_not_repeat_languages.model.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/keyman.en.hint_package_should_not_repeat_languages.model.kps
@@ -24,7 +24,7 @@
       <ID>example.qaa.sencoten</ID>
       <Languages>
         <Language ID="qaa">North Straits Salish</Language>
-        <!-- WARN_PackageShouldNotRepeatLanguages -->
+        <!-- HINT_PackageShouldNotRepeatLanguages -->
         <Language ID="QAA">Salish Again</Language>
         <Language ID="qaa-Latn">SENĆOŦEN</Language>
       </Languages>

--- a/developer/src/kmc-package/test/test-messages.ts
+++ b/developer/src/kmc-package/test/test-messages.ts
@@ -95,16 +95,16 @@ describe('CompilerMessages', function () {
     testForMessage(this, ['invalid', 'error_package_cannot_contain_both_models_and_keyboards.kps'], CompilerMessages.ERROR_PackageCannotContainBothModelsAndKeyboards);
   });
 
-  // WARN_PackageShouldNotRepeatLanguages (models)
+  // HINT_PackageShouldNotRepeatLanguages (models)
 
-  it('should generate WARN_PackageShouldNotRepeatLanguages if model has same language repeated', async function() {
-    testForMessage(this, ['invalid', 'keyman.en.warn_package_should_not_repeat_languages.model.kps'], CompilerMessages.WARN_PackageShouldNotRepeatLanguages);
+  it('should generate HINT_PackageShouldNotRepeatLanguages if model has same language repeated', async function() {
+    testForMessage(this, ['invalid', 'keyman.en.hint_package_should_not_repeat_languages.model.kps'], CompilerMessages.HINT_PackageShouldNotRepeatLanguages);
   });
 
-  // WARN_PackageShouldNotRepeatLanguages (keyboards)
+  // HINT_PackageShouldNotRepeatLanguages (keyboards)
 
-  it('should generate WARN_PackageShouldNotRepeatLanguages if keyboard has same language repeated', async function() {
-    testForMessage(this, ['invalid', 'warn_package_should_not_repeat_languages.kps'], CompilerMessages.WARN_PackageShouldNotRepeatLanguages);
+  it('should generate HINT_PackageShouldNotRepeatLanguages if keyboard has same language repeated', async function() {
+    testForMessage(this, ['invalid', 'hint_package_should_not_repeat_languages.kps'], CompilerMessages.HINT_PackageShouldNotRepeatLanguages);
   });
 
   // WARN_PackageNameDoesNotFollowLexicalModelConventions
@@ -160,10 +160,10 @@ describe('CompilerMessages', function () {
     testForMessage(this, ['invalid', 'error_language_tag_is_not_valid.kps'], CompilerMessages.ERROR_LanguageTagIsNotValid);
   });
 
-  // WARN_LanguageTagIsNotMinimal
+  // HINT_LanguageTagIsNotMinimal
 
-  it('should generate WARN_LanguageTagIsNotMinimal if keyboard has a non-minimal language tag', async function() {
-    testForMessage(this, ['invalid', 'warn_language_tag_is_not_minimal.kps'], CompilerMessages.HINT_LanguageTagIsNotMinimal);
+  it('should generate HINT_LanguageTagIsNotMinimal if keyboard has a non-minimal language tag', async function() {
+    testForMessage(this, ['invalid', 'hint_language_tag_is_not_minimal.kps'], CompilerMessages.HINT_LanguageTagIsNotMinimal);
   });
 
   // ERROR_ModelMustHaveAtLeastOneLanguage

--- a/developer/src/kmc-package/test/test-messages.ts
+++ b/developer/src/kmc-package/test/test-messages.ts
@@ -163,7 +163,7 @@ describe('CompilerMessages', function () {
   // WARN_LanguageTagIsNotMinimal
 
   it('should generate WARN_LanguageTagIsNotMinimal if keyboard has a non-minimal language tag', async function() {
-    testForMessage(this, ['invalid', 'warn_language_tag_is_not_minimal.kps'], CompilerMessages.WARN_LanguageTagIsNotMinimal);
+    testForMessage(this, ['invalid', 'warn_language_tag_is_not_minimal.kps'], CompilerMessages.HINT_LanguageTagIsNotMinimal);
   });
 
   // ERROR_ModelMustHaveAtLeastOneLanguage
@@ -218,7 +218,7 @@ describe('CompilerMessages', function () {
   it('should not generate HINT_JsKeyboardFileHasNoTouchTargets if keyboard has a touch target', async function() {
     testForMessage(this, ['khmer_angkor', 'source', 'khmer_angkor.kps'], null);
   });
-  
+
   // HINT_PackageContainsSourceFile
 
   it('should generate HINT_PackageContainsSourceFile if package contains a source file', async function() {


### PR DESCRIPTION
Fixes #9266.

For historical reasons there are many non-minimal BCP 47 tags in package metadata in the repository (over 2500). Furthermore, earlier versions of kmcomp did not fail the build on package compilation warnings. This means it is better to reduce WARN_LanguageTagIsNotMinimal to HINT_LanguageTagIsNotMinimal, so that we can otherwise respect the 'treat warnings as errors' flag on the keyboard projects.

We may be able to upgrade this to a warning again one day in the future.

TODO:
- [x] we need to treat WARN_PackageShouldNotRepeatLanguages the same way for the same reason

@keymanapp-test-bot skip