### PR TITLE
chore(linux): Improve Sentry reports

### DIFF
--- a/linux/keyman-config/keyman_config/sentry_handling.py
+++ b/linux/keyman-config/keyman_config/sentry_handling.py
@@ -134,6 +134,15 @@ class SentryErrorHandling:
             scope.set_tag("platform", platform.platform())
             scope.set_tag("system", platform.system())
             scope.set_tag("tier", __tier__)
+            scope.set_tag("device", platform.node())
+            try:
+                os_release = platform.freedesktop_os_release()
+                scope.set_tag('os', os_release['PRETTY_NAME'])
+                scope.set_tag('os.name', os_release['NAME'])
+                if 'VERSION' in os_release:
+                    scope.set_tag('os.version', os_release['VERSION'])
+            except OSError as e:
+                logging.debug(f'System does not have os_release file: {e.strerror}')
         logging.info("Initialized Sentry error reporting")
 
     def _raven_initialize(self):

--- a/linux/keyman-config/keyman_config/sentry_handling.py
+++ b/linux/keyman-config/keyman_config/sentry_handling.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 import getpass
+import hashlib
 import importlib
 import logging
 import os
@@ -124,7 +125,9 @@ class SentryErrorHandling:
           integrations=[sentry_logging],
           before_send=self._before_send
         )
-        set_user({'id': hash(getpass.getuser())})
+        hash = hashlib.md5()
+        hash.update(getpass.getuser().encode())
+        set_user({'id': hash.hexdigest()})
         with configure_scope() as scope:
             scope.set_tag("app", os.path.basename(sys.argv[0]))
             scope.set_tag("pkgversion", __pkgversion__)


### PR DESCRIPTION
- fix the calculation of the user hash so that the same user now always gets the same hash value. Previously we got a different value after restarting the app because the Python `hash` function calculates the hash based on the memory location.
- add additional details to Sentry events so that the "All Events" tab on keyman.sentry.io will show helpful values in the "device" and "os" columns instead of emptry strings.

@keymanapp-test-bot skip