### PR TITLE
chore(developer): fixup signcode paths for server

### DIFF
--- a/developer/src/server/Makefile
+++ b/developer/src/server/Makefile
@@ -14,10 +14,10 @@ clean: .virtual
     -del tsconfig.tsbuildinfo
 
 signcode:
-    $(SIGNCODE) /d "Keyman Developer" $(DEVELOPER_PROGRAM)\server\dist\win32\console\node-hide-console-window.node
-    $(SIGNCODE) /d "Keyman Developer" $(DEVELOPER_PROGRAM)\server\dist\win32\console\node-hide-console-window.x64.node
-    $(SIGNCODE) /d "Keyman Developer" $(DEVELOPER_PROGRAM)\server\dist\win32\trayicon\addon.node
-    $(SIGNCODE) /d "Keyman Developer" $(DEVELOPER_PROGRAM)\server\dist\win32\trayicon\addon.x64.node
+    $(SIGNCODE) /d "Keyman Developer" $(DEVELOPER_PROGRAM)\server\build\src\win32\console\node-hide-console-window.node
+    $(SIGNCODE) /d "Keyman Developer" $(DEVELOPER_PROGRAM)\server\build\src\win32\console\node-hide-console-window.x64.node
+    $(SIGNCODE) /d "Keyman Developer" $(DEVELOPER_PROGRAM)\server\build\src\win32\trayicon\addon.node
+    $(SIGNCODE) /d "Keyman Developer" $(DEVELOPER_PROGRAM)\server\build\src\win32\trayicon\addon.x64.node
 
 wrap-symbols:
     @rem nothing to do


### PR DESCRIPTION
Fixes broken developer (master).

Two conflicting merges meant that paths diverged:
* #9695 
* #9673

This fixes that.

@keymanapp-test-bot skip