### PR TITLE
chore: clean up a few minor discrepancies in builder.inc.sh

### DIFF
--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -29,6 +29,11 @@
 # Note: keep changes to version, tier and tag determination in sync with mkver (windows/src/buildutils/mkver)
 #
 
+# Note: set -eu and SHLVL are deliberately set both here and in builder.inc.sh,
+#       because we want them set as early as possible, and because
+#       builder.inc.sh is shared to other repos, this keeps the usage consistent
+#       there as well.
+
 # Exit on command failure and when using unset variables:
 set -eu
 

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -21,6 +21,14 @@
 #   builder.inc.sh directly, or, just in the Keyman repo, via build-utils.sh.
 #
 
+# Exit on command failure and when using unset variables:
+set -eu
+
+#
+# Prevents 'clear' on exit of mingw64 bash shell
+#
+SHLVL=0
+
 # _builder_init is called internally at the bottom of this file after we have
 # all function declarations in place.
 function _builder_init() {
@@ -659,14 +667,14 @@ builder_trim() {
 # `/` is expected to be relative to repo root, not filesystem root. Otherwise,
 # it's relative to current script path, not current working directory. The
 # returned path will not have a prefix `/`, and will be relative to
-# `$KEYMAN_ROOT`. Assumes realpath is installed (brew coreutils on macOS).
+# `$REPO_ROOT`. Assumes realpath is installed (brew coreutils on macOS).
 #
 _builder_expand_relative_path() {
   local path="$1"
   if [[ "$path" =~ ^/ ]]; then
     echo "${path:1}"
   else
-    realpath --canonicalize-missing --relative-to="$KEYMAN_ROOT" "$THIS_SCRIPT_PATH/$path"
+    realpath --canonicalize-missing --relative-to="$REPO_ROOT" "$THIS_SCRIPT_PATH/$path"
   fi
 }
 
@@ -1076,7 +1084,7 @@ _builder_add_chosen_action_target_dependencies() {
         # If there is a defined output for this dependency
         if [[ ! -z ${_builder_dep_path[$dep_output]+x} ]]; then
           # If the output for the dependency is missing, or we have --force-deps
-          if [[ ! -e "$KEYMAN_ROOT/${_builder_dep_path[$dep_output]}" ]] || builder_is_full_dep_build; then
+          if [[ ! -e "$REPO_ROOT/${_builder_dep_path[$dep_output]}" ]] || builder_is_full_dep_build; then
             # Add the dependency to the chosen action:target list
             if ! _builder_item_in_array "$dep_output" "${_builder_chosen_action_targets[@]}"; then
               _builder_chosen_action_targets+=($dep_output)
@@ -1591,7 +1599,7 @@ _builder_dep_output_defined() {
 }
 
 _builder_dep_output_exists() {
-  if _builder_dep_output_defined $1 && [[ -e "$KEYMAN_ROOT/${_builder_dep_path[$1]}" ]]; then
+  if _builder_dep_output_defined $1 && [[ -e "$REPO_ROOT/${_builder_dep_path[$1]}" ]]; then
     return 0
   else
     return 1
@@ -1670,7 +1678,7 @@ _builder_do_build_deps() {
     fi
 
     builder_set_module_has_been_built "$dep"
-    "$KEYMAN_ROOT/$dep/build.sh" "configure$dep_target" "build$dep_target" \
+    "$REPO_ROOT/$dep/build.sh" "configure$dep_target" "build$dep_target" \
       $builder_verbose \
       $builder_debug \
       $_builder_build_deps \


### PR DESCRIPTION
- Some uses of `KEYMAN_ROOT` (not cross-repo compatible)
- `set -eu` and `SHLVL` now set there as well

Other Updates:
* https://github.com/keymanapp/shared-sites/pull/3
* https://github.com/keymanapp/keyboards/pull/2393 (https://github.com/keymanapp/keyboards/pull/2393/commits/3e1368dd649631ab1b4e91d5c41b286ef949e669)
* https://github.com/keymanapp/lexical-models/pull/226 (https://github.com/keymanapp/lexical-models/pull/226/commits/28c7506b83074d5b6ff287647265eba5b19d01b8)

@keymanapp-test-bot skip