### PR TITLE
fix: path for ESM increment-version, and exit code

### DIFF
--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -93,9 +93,9 @@ npm ci
 echo "increment-version.sh: running resources/build/version"
 pushd "$KEYMAN_ROOT"
 ABORT=0
-node resources/build/version/lib/index.js history version -t "$GITHUB_TOKEN" -b "$base" $HISTORY_FORCE || ABORT=$?
+node resources/build/version/build/src/index.js history version -t "$GITHUB_TOKEN" -b "$base" $HISTORY_FORCE || ABORT=$?
 
-if [[ $ABORT = 1 ]]; then
+if [[ $ABORT = 50 ]]; then
   if [[ $FORCE = 0 ]]; then
     echo "Skipping version increment from $VERSION: no recently merged pull requests were found"
     if [ ! -z "${TEAMCITY_VERSION-}" ]; then
@@ -107,7 +107,7 @@ if [[ $ABORT = 1 ]]; then
     echo "Force specified; building even though no changes were detected"
   fi
 elif [[ $ABORT != 0 ]]; then
-  echo "Failed to complete version history check"
+  echo "Failed to complete version history check (node version/lib/index.js failed with error $ABORT)"
   exit $ABORT
 fi
 popd > /dev/null

--- a/resources/build/version/src/index.ts
+++ b/resources/build/version/src/index.ts
@@ -123,7 +123,7 @@ const main = async (): Promise<void> => {
     process.exit(0); // Tell shell that we have updated files
   }
 
-  process.exit(1); // Tell shell that we haven't updated files
+  process.exit(50); // Tell shell that we haven't updated files
 };
 
 
@@ -132,5 +132,5 @@ main().then(
 )
 .catch((error: Error): void => {
   console.error(`An unexpected error occurred: ${error.message}, ${error.stack ?? 'no stack trace'}.`);
-  process.exit(2);
+  process.exit(1);
 });


### PR DESCRIPTION
* Fixes the path for the increment-version module
* Uses exit code 50 instead of 1 to indicate 'success, but no change', so that low-value error exit codes as used by node.js don't indavertently continue the build

Was causing the alpha build trigger to fail, e.g. https://build.palaso.org/buildConfiguration/Keyman_TriggerReleaseBuildsMaster/413596?buildTab=log&focusLine=259&logView=flowAware&linesState=217:

```log
09:13:28   increment-version.sh: running resources/build/version
09:13:28   /c/BuildAgent/work/99b311828f4ee7c/keyman /c/BuildAgent/work/99b311828f4ee7c/keyman /c/BuildAgent/work/99b311828f4ee7c/keyman
09:13:28   node:internal/modules/cjs/loader:1078
09:13:28     throw err;
09:13:28     ^
09:13:28   
09:13:28   Error: Cannot find module 'C:\BuildAgent\work\99b311828f4ee7c\keyman\resources\build\version\lib\index.js'
09:13:28       at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
09:13:28       at Module._load (node:internal/modules/cjs/loader:920:27)
09:13:28       at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
09:13:28       at node:internal/main/run_main_module:23:47 {
09:13:28     code: 'MODULE_NOT_FOUND',
09:13:28     requireStack: []
09:13:28   }
09:13:28   
09:13:28   Node.js v18.16.0
09:13:28   Skipping version increment from 17.0.187: no recently merged pull requests were found
```

@keymanapp-test-bot skip