### PR TITLE
chore(web): web build streamlining

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -97,9 +97,10 @@ builder_run_child_actions build:app/ui
 # Needs both app/browser and app/ui.
 builder_run_child_actions build:samples
 
-builder_run_child_actions build:test-pages
-
 builder_run_child_actions build:tools
+
+# Some test pages refer to KMW tools.
+builder_run_child_actions build:test-pages
 
 builder_run_child_actions test
 

--- a/web/src/tools/build.sh
+++ b/web/src/tools/build.sh
@@ -31,42 +31,12 @@ builder_describe "Builds the Keyman Engine for Web's development & unit-testing 
 
 builder_parse "$@"
 
-### CLEAN ACTIONS
+builder_run_child_actions clean
 
-if builder_start_action clean:bulk_rendering; then
-  testing/bulk_rendering/build.sh clean
-
-  builder_finish_action success clean:bulk_rendering
+# Some of the web/src/test section uses this script as a dependency.  We can skip
+# the configure sections in such a case.
+if ! builder_is_dep_build && ! builder_is_child_build; then
+  builder_run_child_actions configure
 fi
 
-if builder_start_action clean:recorder; then
-  testing/recorder/build.sh clean
-
-  builder_finish_action success clean:recorder
-fi
-
-if builder_start_action clean:sourcemap-root; then
-  building/sourcemap-root/build.sh clean
-
-  builder_finish_action success clean:sourcemap-root
-fi
-
-### BUILD ACTIONS
-
-if builder_start_action build:bulk_rendering; then
-  testing/bulk_rendering/build.sh
-
-  builder_finish_action success build:bulk_rendering
-fi
-
-if builder_start_action build:recorder; then
-  testing/recorder/build.sh
-
-  builder_finish_action success build:recorder
-fi
-
-if builder_start_action build:sourcemap-root; then
-  building/sourcemap-root/build.sh
-
-  builder_finish_action success build:sourcemap-root
-fi
+builder_run_child_actions build


### PR DESCRIPTION
Fixes #9670.  ~~Addresses #9670.  While it does fix~~ It fixes the _biggest_ concern from the issue, though there are a few other nits that this doesn't outright address.

(As per comments received on this PR, I've updated this to "fix" the issue.)

1. The `android-harness` build.sh is still called directly; it's not on a child-project path related to the build product that triggers it.  That said... it's only called one time.

2. The build scripts for the tools do still get called twice, although they at least don't "lose the environment" now.

```
[web/src/tools] child build, parameters: <build --builder-child --deps>
[web/src/tools/testing/bulk_rendering] child build, parameters: <build --builder-child --deps>
[web/src/tools/testing/bulk_rendering] ## build starting...
[web/src/tools/testing/bulk_rendering] ## build completed successfully
[web/src/tools/testing/recorder] child build, parameters: <build --builder-child --deps>
[web/src/tools/testing/recorder] ## build starting...
[common/web/recorder] dependency build, started by web/src/tools/testing/recorder
[common/web/recorder] build.sh parameters: <configure build --deps --builder-dep-parent web/src/tools/testing/recorder>
[common/web/recorder] skipping configure, up-to-date
[common/web/recorder] skipping build, up-to-date
[web/src/tools/testing/recorder] ## build completed successfully
[web/src/tools/building/sourcemap-root] child build, parameters: <build --builder-child --deps>
[web/src/tools/building/sourcemap-root] ## build starting...
[common/tools/sourcemap-path-remapper] dependency build, started by web/src/tools/building/sourcemap-root
[common/tools/sourcemap-path-remapper] build.sh parameters: <configure build --deps --builder-dep-parent web/src/tools/building/sourcemap-root>
[common/tools/sourcemap-path-remapper] skipping configure, up-to-date
[common/tools/sourcemap-path-remapper] skipping build, up-to-date
[web/src/tools/building/sourcemap-root] ## build completed successfully
```
Followed immediately by:

```
[web/src/test/manual] child build, parameters: <build --builder-child --deps>
[web/src/test/manual] ## build starting...
[common/web/sentry-manager] dependency build, started by web/src/test/manual
[common/web/sentry-manager] build.sh parameters: <configure build --deps --builder-dep-parent web/src/test/manual>
[common/web/sentry-manager] skipping configure, up-to-date
[common/web/sentry-manager] skipping build, up-to-date
[web/src/tools] dependency build, started by web/src/test/manual
[web/src/tools] build.sh parameters: <configure build --deps --builder-dep-parent web/src/test/manual>
[web/src/tools/testing/bulk_rendering] child build, parameters: <build --builder-child --deps>
[web/src/tools/testing/bulk_rendering] ## build starting...
[web/src/tools/testing/bulk_rendering] ## build completed successfully
[web/src/tools/testing/recorder] child build, parameters: <build --builder-child --deps>
[web/src/tools/testing/recorder] ## build starting...
[web/src/tools/testing/recorder] ## build completed successfully
[web/src/tools/building/sourcemap-root] child build, parameters: <build --builder-child --deps>
[web/src/tools/building/sourcemap-root] ## build starting...
[web/src/tools/building/sourcemap-root] ## build completed successfully
[web/src/test/manual] ## build completed successfully
```

Compare the later entries in both sections; they're nigh-identical.

First set of calls:  as a child script, from the top-level build.sh.

Second set:  as a _dependency_, from `web/src/test/manual`, which does not include `web/src/tools` as a viable child-project folder.

@keymanapp-test-bot skip