### PR TITLE
chore(linux): Add code coverage reports for keyman-config and keyman-system-service

### DIFF
--- a/docs/settings/linux/tasks.json
+++ b/docs/settings/linux/tasks.json
@@ -282,6 +282,7 @@
       "command": "${workspaceFolder}/linux/keyman-system-service/build.sh",
       "args": [
         "--debug",
+        "--coverage",
         "configure"
       ],
       "options": {
@@ -299,13 +300,30 @@
       "command": "${workspaceFolder}/linux/keyman-system-service/build.sh",
       "args": [
         "--debug",
-        "test:arch"
+        "test"
       ],
       "problemMatcher": [
         "$gcc"
       ],
       "group": "test",
       "detail": "run tests for keyman-system-service"
+    },
+    {
+      "type": "shell",
+      "label": "keyman-system-service: report",
+      "command": "${workspaceFolder}/linux/keyman-system-service/build.sh",
+      "args": [
+        "test",
+        "--report",
+        "--debug",
+        "--coverage",
+        "--no-integration",
+      ],
+      "problemMatcher": [
+        "$gcc"
+      ],
+      "group": "test",
+      "detail": "run tests and create unit test coverage report"
     },
   ]
 }

--- a/docs/settings/linux/tasks.json
+++ b/docs/settings/linux/tasks.json
@@ -197,6 +197,23 @@
     },
     {
       "type": "shell",
+      "label": "keyman-config: report",
+      "command": "${workspaceFolder}/linux/keyman-config/build.sh",
+      "args": [
+        "test",
+        "--report",
+        "--debug",
+        "--coverage",
+        "--no-integration"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/linux/keyman-config",
+      },
+      "group": "test",
+      "detail": "run tests and create unit test coverage report"
+    },
+    {
+      "type": "shell",
       "label": "keyman-system-service: clean",
       "command": "${workspaceFolder}/linux/keyman-system-service/build.sh",
       "args": [

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -23,7 +23,9 @@ builder_describe \
   "test" \
   "install                   install artifacts" \
   "uninstall                 uninstall artifacts" \
-  "--no-integration+         don't run integration tests"
+  "--no-integration+         don't run integration tests" \
+  "--report+                 create coverage report" \
+  "--coverage+               capture test coverage"
 
 builder_parse "$@"
 

--- a/linux/keyman-config/build.sh
+++ b/linux/keyman-config/build.sh
@@ -16,7 +16,9 @@ builder_describe \
   "test" \
   "install                   install artifacts" \
   "uninstall                 uninstall artifacts" \
-  "--no-integration          don't run integration tests"
+  "--no-integration          don't run integration tests" \
+  "--report                  create coverage report" \
+  "--coverage                capture test coverage"
 
 builder_parse "$@"
 
@@ -87,7 +89,19 @@ build_action() {
 }
 
 test_action() {
-  execute_with_temp_schema ./run-tests.sh
+  local options
+
+  if builder_has_option --coverage; then
+    options="--coverage"
+  else
+    options=""
+  fi
+  execute_with_temp_schema ./run-tests.sh "${options}"
+
+  if builder_has_option --report; then
+    builder_echo "Creating coverage report"
+    python3 -m coverage html --directory="$THIS_SCRIPT_PATH/build/coveragereport/" --data-file=build/.coverage
+  fi
 }
 
 install_action() {

--- a/linux/keyman-config/run-tests.sh
+++ b/linux/keyman-config/run-tests.sh
@@ -8,13 +8,18 @@ if [ -f /usr/libexec/ibus-memconf ]; then
   export GSETTINGS_BACKEND=keyfile
 fi
 
+if [ "$1" == "--coverage" ]; then
+  coverage="-m coverage run --source=. --data-file=build/.coverage"
+fi
+
 if [ -n "$TEAMCITY_VERSION" ]; then
-    if ! pip3 list --format=columns | grep -q teamcity-messages; then
-        pip3 install teamcity-messages
-    fi
-    python3 -m teamcity.unittestpy discover -s tests -p test_*.py
+  if ! pip3 list --format=columns | grep -q teamcity-messages; then
+      pip3 install teamcity-messages
+  fi
+  python3 -m teamcity.unittestpy discover -s tests -p test_*.py
 else
-    python3 -m unittest discover -v -s tests -p test_*.py
+  # shellcheck disable=SC2086
+  python3 ${coverage:-} -m unittest discover -v -s tests -p test_*.py
 fi
 
 rm -rf "$XDG_CONFIG_HOME"


### PR DESCRIPTION
This adds the options to create code coverage reports to `build.sh` for keyman-config and keyman-system-service.

@keymanapp-test-bot skip