### PR TITLE
feat(linux): Allow installing keyboards with arbitrary language 🏘️

### DIFF
--- a/linux/keyman-config/keyman_config/custom_keyboards.py
+++ b/linux/keyman-config/keyman_config/custom_keyboards.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+from keyman_config.gsettings import GSettings
+
+
+GSETTINGS_ENGINE_BASE = 'com.keyman.engine'
+GSETTINGS_ADDITIONAL_KEYBOARDS_KEY = 'additional-keyboards'
+
+class CustomKeyboards():
+    def __init__(self):
+        self.gsettings = GSettings(GSETTINGS_ENGINE_BASE)
+
+    def add(self, keyboard):
+        if not keyboard:
+            return
+
+        custom_keyboards = self.gsettings.get(GSETTINGS_ADDITIONAL_KEYBOARDS_KEY)
+        if isinstance(custom_keyboards, type([])):
+            duplicate = False
+            i = 0
+            while i < len(custom_keyboards):
+                kb = custom_keyboards[i]
+                if kb == keyboard:
+                    duplicate = True
+                elif not len(kb.split(':')) > 1:
+                    custom_keyboards.remove(kb)
+                    i -= 1
+                i += 1
+            if duplicate:
+                return
+            custom_keyboards.append(keyboard)
+        else:
+            custom_keyboards = [keyboard]
+        self.gsettings.set('additional-keyboards', custom_keyboards, 'as')
+
+    def remove(self, keyboard_path):
+        if not keyboard_path:
+            return
+
+        custom_keyboards = self.gsettings.get(GSETTINGS_ADDITIONAL_KEYBOARDS_KEY)
+        if isinstance(custom_keyboards, type([])):
+            i = 0
+            while i < len(custom_keyboards):
+                kb = custom_keyboards[i]
+                if kb.endswith(keyboard_path) or not len(kb.split(':')) > 1:
+                    custom_keyboards.remove(kb)
+                else:
+                    i += 1
+        else:
+            custom_keyboards = []
+
+        self.gsettings.set('additional-keyboards', custom_keyboards, 'as')

--- a/linux/keyman-config/keyman_config/gsettings.py
+++ b/linux/keyman-config/keyman_config/gsettings.py
@@ -93,3 +93,4 @@ class GSettings():
         else:
             variant = self._convert_array_to_variant(value, type)
             self.schema.set_value(key, variant)
+            self.schema.sync()

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -11,6 +11,7 @@ from shutil import rmtree
 from keyman_config import _, __version__, secure_lookup
 from keyman_config.canonical_language_code_utils import CanonicalLanguageCodeUtils
 from keyman_config.convertico import checkandsaveico, extractico
+from keyman_config.custom_keyboards import CustomKeyboards
 from keyman_config.dbus_util import get_keyman_config_service
 from keyman_config.fcitx_util import is_fcitx_running, restart_fcitx
 from keyman_config.get_kmp import (InstallLocation, get_keyboard_data,
@@ -19,6 +20,7 @@ from keyman_config.get_kmp import (InstallLocation, get_keyboard_data,
 from keyman_config.gnome_keyboards_util import (GnomeKeyboardsUtil,
                                                 get_ibus_keyboard_id,
                                                 is_gnome_shell)
+from keyman_config.gsettings import GSettings
 from keyman_config.ibus_util import get_ibus_bus, install_to_ibus, restart_ibus
 from keyman_config.kmpmetadata import KMFileTypes, get_metadata
 from keyman_config.kvk2ldml import convert_kvk_to_ldml, output_ldml
@@ -114,38 +116,31 @@ class InstallKmp():
 
         extract_kmp(inputfile, self.packageDir)
 
-        if is_fcitx_running():
-            restart_fcitx()
-        else:
-            restart_ibus()
-
         info, system, options, keyboards, files = get_metadata(self.packageDir)
 
         self._check_version(inputfile, system)
 
-        if keyboards:
-            # sourcery skip: extract-method
-            logging.info("Installing %s", secure_lookup(info, 'name', 'description'))
-            process_keyboard_data(self.packageID, self.packageDir)
-            for kb in keyboards:
-                if kb['id'] != self.packageID:
-                    process_keyboard_data(kb['id'], self.packageDir)
-
-            if files is None:
-                return self.install_keyboards(keyboards, self.packageDir, language)
-
-            self._install_files(keyboards, files)
-
-            return self.install_keyboards(keyboards, self.packageDir, language)
-        else:
+        if not keyboards:
             logging.error("install_kmp.py: error: No kmp.json or kmp.inf found in %s", inputfile)
             logging.info("Contents of %s:", inputfile)
             for o in os.listdir(self.packageDir):
                 logging.info(o)
             rmtree(self.packageDir)
             message = _("No kmp.json or kmp.inf found in {packageFile}").format(
-              packageFile=inputfile)
+                packageFile=inputfile)
             raise InstallError(InstallStatus.Abort, message)
+
+        # sourcery skip: extract-method
+        logging.info("Installing %s", secure_lookup(info, 'name', 'description'))
+        process_keyboard_data(self.packageID, self.packageDir)
+        for kb in keyboards:
+            if kb['id'] != self.packageID:
+                process_keyboard_data(kb['id'], self.packageDir)
+
+        if files is not None:
+            self._install_files(keyboards, files)
+
+        return self._install_keyboards(keyboards, self.packageDir, language)
 
     def _check_version(self, inputfile, system):
         if not system:
@@ -245,10 +240,28 @@ class InstallKmp():
                 return tag
         return None
 
-    def install_keyboards(self, keyboards, packageDir, language=None):
+    def _add_custom_keyboard(self, keyboard, package_dir, requested_language):
+        if not requested_language:
+            return None
+        language = CanonicalLanguageCodeUtils.findBestTag(requested_language, False, False)
+        new_keyboard = get_ibus_keyboard_id(keyboard, package_dir, language)
+        CustomKeyboards().add(new_keyboard)
+        return language
+
+    def _install_keyboards(self, keyboards, packageDir, requested_language=None):
+        language = requested_language
+        # TODO: add other keyboards as well (#9757)
         firstKeyboard = keyboards[0]
-        if secure_lookup(firstKeyboard, 'languages') and len(firstKeyboard['languages']) > 0:
+        if secure_lookup(firstKeyboard, 'languages') and firstKeyboard['languages']:
             language = self._normalize_language(firstKeyboard['languages'], language)
+
+        if not language:
+            language = self._add_custom_keyboard(firstKeyboard, packageDir, requested_language)
+
+        if is_fcitx_running():
+            restart_fcitx()
+        else:
+            restart_ibus()
 
         if is_fcitx_running():
             return self._install_keyboards_to_fcitx()

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -6,6 +6,7 @@ import os
 from shutil import rmtree
 
 from keyman_config import _
+from keyman_config.custom_keyboards import CustomKeyboards
 from keyman_config.dbus_util import get_keyman_config_service
 from keyman_config.fcitx_util import is_fcitx_running
 from keyman_config.get_kmp import (InstallLocation, get_keyboard_dir,
@@ -13,6 +14,7 @@ from keyman_config.get_kmp import (InstallLocation, get_keyboard_dir,
 from keyman_config.gnome_keyboards_util import (GnomeKeyboardsUtil,
                                                 get_ibus_keyboard_id,
                                                 is_gnome_shell)
+from keyman_config.gsettings import GSettings
 from keyman_config.ibus_util import IbusUtil, get_ibus_bus, restart_ibus
 from keyman_config.kmpmetadata import get_metadata
 
@@ -42,7 +44,6 @@ def _uninstall_dir(what, dir):
     else:
         logging.info('No %s directory %s', what, dir)
 
-
 def _uninstall_kmp_common(location, packageID, removeLanguages):
     kbdir = get_keyboard_dir(location, packageID)
     kbdocdir = get_keyman_doc_dir(location, packageID)
@@ -59,8 +60,16 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
                 _uninstall_keyboards_from_gnome(keyboards, kbdir)
             else:
                 _uninstall_keyboards_from_ibus(keyboards, kbdir)
+
+            logging.debug('Removing custom keyboards:')
+            custom_keyboards = CustomKeyboards()
+            for kb in keyboards:
+                kb_path = os.path.join(kbdir, kb["id"] + ".kmx")
+                logging.debug(f'    removing {kb["id"]} ({kb_path})')
+                custom_keyboards.remove(kb_path)
         else:
             logging.info(f'Could not uninstall {where} keyboard "{packageID}" from list of keyboards')
+
     else:
         logging.info(f'Replacing {where} keyboard: "{packageID}"')
 

--- a/linux/keyman-config/tests/test_custom_keyboards.py
+++ b/linux/keyman-config/tests/test_custom_keyboards.py
@@ -1,0 +1,194 @@
+#!/usr/bin/python3
+import unittest
+from unittest.mock import patch
+from keyman_config import __version__
+from keyman_config.custom_keyboards import CustomKeyboards
+
+class AddCustomKeyboardTests(unittest.TestCase):
+    def setUp(self):
+        patcher1 = patch('keyman_config.custom_keyboards.GSettings')
+        self.mockGSettingsClass = patcher1.start()
+        self.addCleanup(patcher1.stop)
+
+    def test_Add_NoParam(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = None
+        # Execute
+        CustomKeyboards().add(None)
+        # Verify
+        mockGSettingsInstance.set.assert_not_called()
+
+    def test_Add_Unset(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = None
+        keyboard = 'mul:fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().add(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with('additional-keyboards', ['mul:fooDir/foo1.kmx'], 'as')
+
+    def test_Add_Invalid(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = 'foo'
+        keyboard = 'mul:fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().add(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with('additional-keyboards', ['mul:fooDir/foo1.kmx'], 'as')
+
+    def test_Add_InvalidArray(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = ['garbage', '', 'und:barDir/bar.kmx']
+        keyboard = 'mul:fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().add(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with(
+            'additional-keyboards', ['und:barDir/bar.kmx', 'mul:fooDir/foo1.kmx'], 'as')
+
+    def test_Add_EmptyArray(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = []
+        keyboard = 'mul:fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().add(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with('additional-keyboards', ['mul:fooDir/foo1.kmx'], 'as')
+
+    def test_Add_EmptyString(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = ['', 'und:barDir/bar.kmx']
+        keyboard = 'mul:fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().add(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with(
+            'additional-keyboards', ['und:barDir/bar.kmx', 'mul:fooDir/foo1.kmx'], 'as')
+
+    def test_Add_PrevVal(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = ['und:barDir/bar.kmx']
+        keyboard = 'mul:fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().add(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with(
+            'additional-keyboards', ['und:barDir/bar.kmx', 'mul:fooDir/foo1.kmx'], 'as')
+
+    def test_Add_Duplicate(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = ['und:barDir/bar.kmx', 'mul:fooDir/foo1.kmx']
+        keyboard = 'mul:fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().add(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_not_called()  # nothing changed, so no need to call
+
+
+class RemoveCustomKeyboardTests(unittest.TestCase):
+    def setUp(self):
+        patcher1 = patch('keyman_config.custom_keyboards.GSettings')
+        self.mockGSettingsClass = patcher1.start()
+        self.addCleanup(patcher1.stop)
+
+    def test_Remove_NoParam(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = None
+        # Execute
+        CustomKeyboards().remove(None)
+        # Verify
+        mockGSettingsInstance.set.assert_not_called()
+
+    def test_Remove_Unset(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = None
+        keyboard = 'fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().remove(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with('additional-keyboards', [], 'as')
+
+    def test_Remove_Invalid(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = 'foo'
+        keyboard = 'fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().remove(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with('additional-keyboards', [], 'as')
+
+    def test_Remove_InvalidArray(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = ['garbage', '', 'und:barDir/bar.kmx']
+        keyboard = 'fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().remove(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with(
+            'additional-keyboards', ['und:barDir/bar.kmx'], 'as')
+
+    def test_Remove_EmptyArray(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = []
+        keyboard = 'fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().remove(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with('additional-keyboards', [], 'as')
+
+    def test_Remove_EmptyString(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = ['', 'und:barDir/bar.kmx']
+        keyboard = 'fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().remove(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with(
+            'additional-keyboards', ['und:barDir/bar.kmx'], 'as')
+
+    def test_Remove_MultipleValues(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = ['und:barDir/bar.kmx', 'mul:fooDir/foo1.kmx']
+        keyboard = 'fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().remove(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with(
+            'additional-keyboards', ['und:barDir/bar.kmx'], 'as')
+
+    def test_Remove_MultipleValuesWithSameKeyboard(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = ['und:barDir/bar.kmx', 'mul:fooDir/foo1.kmx', 'und:fooDir/foo1.kmx']
+        keyboard = 'fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().remove(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with(
+            'additional-keyboards', ['und:barDir/bar.kmx'], 'as')
+
+    def test_Remove_SingleValue(self):
+        # Setup
+        mockGSettingsInstance = self.mockGSettingsClass.return_value
+        mockGSettingsInstance.get.return_value = ['mul:fooDir/foo1.kmx']
+        keyboard = 'fooDir/foo1.kmx'
+        # Execute
+        CustomKeyboards().remove(keyboard)
+        # Verify
+        mockGSettingsInstance.set.assert_called_once_with(
+            'additional-keyboards', [], 'as')

--- a/linux/keyman-config/tests/test_install_kmp.py
+++ b/linux/keyman-config/tests/test_install_kmp.py
@@ -8,7 +8,7 @@ from keyman_config.get_kmp import InstallLocation
 from keyman_config.install_kmp import InstallError, InstallKmp
 
 
-class InstallKmpTests(unittest.TestCase):
+class InstallKmpBase(unittest.TestCase):
 
     def setUp(self):
         patcher1 = patch('keyman_config.install_kmp.install_to_ibus')
@@ -40,7 +40,12 @@ class InstallKmpTests(unittest.TestCase):
         self.mockIsFcitxRunning = patcher9.start()
         self.addCleanup(patcher9.stop)
         self.mockIsFcitxRunning.return_value = False
+        patcher10 = patch('keyman_config.install_kmp.CustomKeyboards')
+        self.mockCustomKeyboardsClass = patcher10.start()
+        self.addCleanup(patcher10.stop)
 
+
+class InstallKeyboardsToIbusTests(InstallKmpBase):
     def test_InstallKeyboardsToIbus_NoIbus(self):
         # Setup
         self.mockGetIbusBus.return_value = None
@@ -122,6 +127,8 @@ class InstallKmpTests(unittest.TestCase):
         self.mockRestartIbus.assert_called_once()
         bus.destroy.assert_called_once()
 
+
+class InstallKeyboardsToGnomeTests(InstallKmpBase):
     def test_InstallKeyboardsToGnome_SingleKbNoLanguages(self):
         # Setup
         mockGnomeKeyboardsUtilInstance = self.mockGnomeKeyboardsUtilClass.return_value
@@ -194,6 +201,8 @@ class InstallKmpTests(unittest.TestCase):
             [('xkb', 'en'), ('ibus', 'de:fooDir/foo1.kmx')])
         self.mockRestartIbus.assert_not_called()
 
+
+class NormalizeLanguageTests(InstallKmpBase):
     def test_normalizeLanguage(self):
         # Setup
         languages = [
@@ -233,6 +242,8 @@ class InstallKmpTests(unittest.TestCase):
         # Verify
         self.assertEqual(result, '')
 
+
+class InstallKmpTests(InstallKmpBase):
     def _createEmptyKmp(self, workdir):
         kmpfile = os.path.join(workdir, 'foo.kmp')
         with open(kmpfile, 'w') as file:
@@ -298,8 +309,12 @@ class InstallKmpTests(unittest.TestCase):
                 kmpfile = self._createEmptyKmp(workdir.name)
                 self._createKmpJson(packagedir.name, testcase['fileVersion'])
 
-                # Execute
-                InstallKmp()._install_kmp(kmpfile, 'km', InstallLocation.User)
+                with patch('keyman_config.install_kmp.process_keyboard_data') as mock:
+                    method = mock.return_value
+                    method.return_value = None
+
+                    # Execute
+                    InstallKmp()._install_kmp(kmpfile, 'km', InstallLocation.User)
 
                 # Verify
                 self.mockInstallToIbus.assert_called_once()
@@ -309,5 +324,58 @@ class InstallKmpTests(unittest.TestCase):
                 packagedir.cleanup()
 
 
-if __name__ == '__main__':
-    unittest.main()
+class InstallKeyboardsTests(InstallKmpBase):
+    def test_InstallKeyboards_NoLang(self):
+        # Setup
+        mockCustomKeyboardsInstance = self.mockCustomKeyboardsClass.return_value
+        mockCustomKeyboardsInstance.get.return_value = None
+        keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
+        # Execute
+        InstallKmp()._install_keyboards(keyboards, 'fooDir', None)
+        # Verify
+        self.mockInstallToIbus.assert_called_once_with(ANY, 'en:fooDir/foo1.kmx')
+        mockCustomKeyboardsInstance.add.assert_not_called()
+
+    def test_InstallKeyboards_LangInKeyboard(self):
+        # Setup
+        keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
+        mockCustomKeyboardsInstance = self.mockCustomKeyboardsClass.return_value
+        mockCustomKeyboardsInstance.get.return_value = None
+        # Execute
+        InstallKmp()._install_keyboards(keyboards, 'fooDir', 'fr')
+        # Verify
+        self.mockInstallToIbus.assert_called_once_with(ANY, 'fr:fooDir/foo1.kmx')
+        mockCustomKeyboardsInstance.add.assert_not_called()
+
+    def test_InstallKeyboards_CustomLang(self):
+        # Setup
+        mockCustomKeyboardsInstance = self.mockCustomKeyboardsClass.return_value
+        mockCustomKeyboardsInstance.get.return_value = None
+        keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}, {'id': 'fr'}]}]
+        # Execute
+        InstallKmp()._install_keyboards(keyboards, 'fooDir', 'mul')
+        # Verify
+        self.mockInstallToIbus.assert_called_once_with(ANY, 'mul:fooDir/foo1.kmx')
+        mockCustomKeyboardsInstance.add.assert_called_once_with('mul:fooDir/foo1.kmx')
+
+
+class AddCustomKeyboardTests(InstallKmpBase):
+    def test_AddCustomKeyboard_NoLang(self):
+        # Setup
+        mockCustomKeyboardsInstance = self.mockCustomKeyboardsClass.return_value
+        keyboard = {'id': 'foo1'}
+        # Execute
+        language = InstallKmp()._add_custom_keyboard(keyboard, 'fooDir', None)
+        # Verify
+        self.assertEqual(language, None)
+        mockCustomKeyboardsInstance.add.assert_not_called()
+
+    def test_AddCustomKeyboard_Add(self):
+        # Setup
+        mockCustomKeyboardsInstance = self.mockCustomKeyboardsClass.return_value
+        keyboard = {'id': 'foo1'}
+        # Execute
+        language = InstallKmp()._add_custom_keyboard(keyboard, 'fooDir', 'mul')
+        # Verify
+        self.assertEqual(language, 'mul')
+        mockCustomKeyboardsInstance.add.assert_called_once_with('mul:fooDir/foo1.kmx')


### PR DESCRIPTION
- during installation add to the list of custom keyboards if necessary
- during uninstallation remove from the list of custom keyboards
- if list of custom keyboards has invalid values, remove those before saving the list

Closes #8598.

# User Testing

## Preparations

- The tests should be run any these Linux platform
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

## Tests

**TEST_CLI_INSTALL**: Installing a keyboard with an arbitrary language will add the keyboard to the keyboards drop down

- In a terminal window, run `km-package-install -p sil_euro_latin -l mul`
- Verify that the keyboard dropdown shows a keyboard similar to "Multiple languages (EuroLatin (SIL)) mul" (the exact wording depends on the Linux platform used for testing)

**TEST_CLI_INSTALL2**: Installing more than one keyboard with an arbitrary language is possible

- In a terminal window, run `km-package-install -p sil_ipa -l en`
- Verify that the keyboard dropdown shows a keyboard similar to "English (IPA (SIL)) en" (the exact wording depends on the Linux platform used for testing)
- Verify that the "Multiple languages (EuroLatin (SIL)) mul" keyboard installed in the previous test still shows

**TEST_KM_CLI_INST**: Installing a keyboard with `km-config` with parameters will add the keyboard to the keyboards drop down

- In a terminal window, run `km-config -i keyman://download/keyboard/sil_euro_latin?bcp47=und`
- In the "Install keyboard/package sil_euro_latin" dialog press the "Install" button
- Verify that the keyboard dropdown shows a keyboard similar to "Undetermined (EuroLatin (SIL)) und" (the exact wording depends on the Linux platform used for testing)

**TEST_KM_INST**: Installing a keyboard with `km-config` is still possible

- Open `km-config`
- Press the "Download keyboard" button and search for "Xinaliq"
- Install the Xinaliq keyboard
- Verify that the keyboard dropdown shows a keyboard similar to "Khinalugh (Xinaliq) kjj"  (the exact wording depends on the Linux platform used for testing)

**TEST_CLI_UNINSTALL**: Uninstalling a keyboard removes custom keyboards for that keyboard

- In a terminal window, run `km-package-uninstall sil_euro_latin`
- Verify that the keyboard dropdown has removed the keyboard entries for "Multiple languages (EuroLatin (SIL)) mul" and "Undetermined (EuroLatin (SIL)) und" 
- Verify that the keyboard dropdown still shows the keyboard similar to "English (IPA (SIL)) en"

**TEST_KM_UNINSTALL**: Uninstalling a keyboard in `km-config` removes custom keyboard for that keyboard

- Open `km-config`
- Select "IPA (SIL)" and press "Uninstall" button
- In the "Uninstall keyboard package?" dialog press the Yes button
- Verify that the keyboard dropdown no longer shows the keyboard similar to "English (IPA (SIL)) en"
