### PR TITLE
chore(linux): Add code coverage index page

### DIFF
--- a/docs/linux/README.md
+++ b/docs/linux/README.md
@@ -87,6 +87,21 @@ scripts/run-tests
 The `run-tests` script accepts different arguments which can be seen with
 `scripts/run-tests --help`.
 
+### Code Coverage Report
+
+All three projects (ibus-keyman, keyman-config, and keyman-system-service)
+can produce code coverage reports.
+
+Run `./build.sh --debug --coverage --report test` to create the report.
+
+**Note:** You might have to run `./build.sh clean` first.
+
+There's also an index page (`linux/CodecoverageReports.html`) that links to all
+three reports. You can run
+`linux/build.sh --debug --coverage --report --no-integration test`
+to create the coverage reports for all three Linux projects and open the
+index page in the browser.
+
 ## Running Keyman for Linux
 
 ### Setting up Ibus

--- a/docs/linux/README.md
+++ b/docs/linux/README.md
@@ -98,7 +98,7 @@ Run `./build.sh --debug --coverage --report test` to create the report.
 
 There's also an index page (`linux/CodecoverageReports.html`) that links to all
 three reports. You can run
-`linux/build.sh --debug --coverage --report --no-integration test`
+`linux/build.sh --debug --coverage --report --open --no-integration test`
 to create the coverage reports for all three Linux projects and open the
 index page in the browser.
 

--- a/linux/CodeCoverageReports.html
+++ b/linux/CodeCoverageReports.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+  <title>Keyman for Linux Code Coverage</title>
+  <style type="text/css">
+    body, html {width: 100%; height: 100%; margin-left: 0; padding-left: 0;}
+    .row-container {display: flex; width: 100%; height: 100%; flex-direction: column; overflow: hidden;}
+    .second-row { flex-grow: 1; border: none; margin: 0; padding: 0; border: none; }
+    .tablink { background-color: #555; color: white; float: left; border: none; border-right: 1px solid black; outline: none; cursor: pointer; padding: 14px 16px; font-size: 17px; width: 33.3%; }
+    .tablink:hover { background-color: #777; }
+  </style>
+</head>
+  <body>
+  <div class="row-container">
+    <div class="first-row">
+      <h1>Keyman for Linux Code Coverage Reports</h1>
+      <button class="tablink" onclick="openPage(this, 'build/x86_64/debug/meson-logs/coveragereport/index.html')" id="defaultOpen">ibus-keyman</button>
+      <button class="tablink" onclick="openPage(this, 'keyman-config/build/coveragereport/index.html')">keyman-config</button>
+      <button class="tablink" onclick="openPage(this, 'keyman-system-service/build/x86_64/debug/meson-logs/coveragereport/index.html')">keyman-system-service</button>
+    </div>
+    <iframe id="iframe_a" class="second-row"></iframe>
+  </div>
+
+  <script>
+    function openPage(elmnt, filename) {
+      document.getElementById('iframe_a').src = filename;
+      tablinks = document.getElementsByClassName("tablink");
+      for (i = 0; i < tablinks.length; i++) {
+        tablinks[i].style.backgroundColor = "";
+      }
+      elmnt.style.backgroundColor = "#777";
+    }
+
+    document.getElementById("defaultOpen").click();
+  </script>
+
+  </body>
+</html>

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,5 +1,3 @@
 # Keyman for Linux
 
 See [/docs/linux/README.md](../docs/linux/README.md) for documentation.
-
-.

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -24,15 +24,16 @@ builder_describe \
   "install                   install artifacts" \
   "uninstall                 uninstall artifacts" \
   "--no-integration+         don't run integration tests" \
+  "--coverage+               capture test coverage" \
   "--report+                 create coverage report" \
-  "--coverage+               capture test coverage"
+  "--open                    open the coverage reports in the browser"
 
 builder_parse "$@"
 
 builder_run_child_actions clean configure build test install uninstall
 
 test_action() {
-  if builder_has_option --report; then
+  if builder_has_option --open; then
     builder_echo "Opening coverage reports in browser..."
     xdg-open "file://${THIS_SCRIPT_PATH}/CodeCoverageReports.html"
   fi

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -30,3 +30,12 @@ builder_describe \
 builder_parse "$@"
 
 builder_run_child_actions clean configure build test install uninstall
+
+test_action() {
+  if builder_has_option --report; then
+    builder_echo "Opening coverage reports in browser..."
+    xdg-open "file://${THIS_SCRIPT_PATH}/CodeCoverageReports.html"
+  fi
+}
+
+builder_run_action test test_action

--- a/linux/keyman-system-service/build.sh
+++ b/linux/keyman-system-service/build.sh
@@ -50,14 +50,14 @@ builder_run_action clean rm -rf "$THIS_SCRIPT_PATH/build/"
 # shellcheck disable=SC2086
 builder_run_action configure meson setup "$MESON_PATH" --werror --buildtype $MESON_TARGET ${MESON_COVERAGE} "${builder_extra_params[@]}"
 
+cd "$MESON_PATH" || true
+
 if builder_start_action build; then
-  cd "$MESON_PATH"
   ninja
   builder_finish_action success build
 fi
 
 if builder_start_action test; then
-  cd "$MESON_PATH"
   meson test --print-errorlogs $builder_verbose
   if builder_has_option --coverage; then
     # Note: requires lcov > 1.16 to properly work (see https://github.com/mesonbuild/meson/issues/6747)
@@ -67,13 +67,11 @@ if builder_start_action test; then
 fi
 
 if builder_start_action install; then
-  cd "$MESON_PATH"
   ninja install
   builder_finish_action success install
 fi
 
 if builder_start_action uninstall; then
-  cd "$MESON_PATH"
   ninja uninstall
   builder_finish_action success uninstall
 fi


### PR DESCRIPTION
This change adds an index page that can show the reports for the child projects.

Also fix a path problem in the `keyman-system-service/build.sh` script.

@keymanapp-test-bot skip