### PR TITLE
fix(ios): missing backslash in build script

### DIFF
--- a/oem/firstvoices/ios/build.sh
+++ b/oem/firstvoices/ios/build.sh
@@ -113,8 +113,8 @@ function do_build() {
             -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
             -exportOptionsPlist exportAppStore.plist \
-            -exportPath "$BUILD_PATH/${CONFIG}-iphoneos"
-             -allowProvisioningUpdates \
+            -exportPath "$BUILD_PATH/${CONFIG}-iphoneos" \
+            -allowProvisioningUpdates \
             VERSION=$VERSION \
             VERSION_WITH_TAG=$VERSION_WITH_TAG
   else


### PR DESCRIPTION
Fixes #9764.

Fixes regression introduced in #9092 (b65a80f6f9d735b57015f9bc6e974ac57c25aaf4).

@keymanapp-test-bot skip