### PR TITLE
fix(linux): Fix crash initializing Sentry with Python < 3.10

### DIFF
--- a/linux/keyman-config/keyman_config/sentry_handling.py
+++ b/linux/keyman-config/keyman_config/sentry_handling.py
@@ -143,6 +143,11 @@ class SentryErrorHandling:
                     scope.set_tag('os.version', os_release['VERSION'])
             except OSError as e:
                 logging.debug(f'System does not have os_release file: {e.strerror}')
+            except AttributeError:
+                logging.debug('System does not have platform.freedesktop_os_release() method')
+            except:
+                logging.debug(
+                    'Got exception trying to access platform.freedesktop_os_release()  method or os_release information')
         logging.info("Initialized Sentry error reporting")
 
     def _raven_initialize(self):


### PR DESCRIPTION
Ubuntu 20.04 comes with Python 3.8 which doesn't have `platform.freedesktop_os_release()`. This change catches the exception if this happens, as well as other exceptions we might get so that the initialization of Sentry will succeed.

Fixes #9773.

# User Testing

## Preparations

- The tests should be run on Wasta 20.04 or Ubuntu 20.04.

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

## Tests

**TEST_CAN_START**: Open a terminal window and run `km-config`. Verify that Keyman Configuration starts.