### PR TITLE
chore(linux): Rename `kbp_state_get_intermediate_context` to `km_core…` 〽️

### DIFF
--- a/core/include/keyman/keyman_core_api.h
+++ b/core/include/keyman/keyman_core_api.h
@@ -936,7 +936,7 @@ km_core_state_context(km_core_state *state);
 
 /*
 ```
-### `kbp_state_get_intermediate_context`
+### `km_core_state_get_intermediate_context`
 ##### Description:
 Get access to the state object's keyboard processor's intermediate context. This context
 is used during an IMX callback, part way through processing a keystroke.
@@ -950,7 +950,7 @@ to `km_core_context_items_dispose`.
 */
 KMN_API
 km_core_status
-kbp_state_get_intermediate_context(km_core_state *state, km_core_context_item ** context_items);
+km_core_state_get_intermediate_context(km_core_state *state, km_core_context_item ** context_items);
 
 /*
 ```

--- a/core/src/km_core_state_api.cpp
+++ b/core/src/km_core_state_api.cpp
@@ -69,7 +69,7 @@ km_core_context *km_core_state_context(km_core_state *state)
   return static_cast<km_core_context *>(&state->context());
 }
 
-km_core_status kbp_state_get_intermediate_context(
+km_core_status km_core_state_get_intermediate_context(
   km_core_state *state,
   km_core_context_item ** context_items
 ) {

--- a/core/tests/unit/kmx/kmx_imx.cpp
+++ b/core/tests/unit/kmx/kmx_imx.cpp
@@ -74,7 +74,7 @@ uint8_t test_imx_callback(km_core_state *state, uint32_t imx_id, void *callback_
 
   // Test get intermediate context
   km_core_context_item *entry_context = nullptr;
-  kbp_state_get_intermediate_context(state, &entry_context);
+  km_core_state_get_intermediate_context(state, &entry_context);
 
   size_t n = 0;
   try_status(km_core_context_items_to_utf16(entry_context, nullptr, &n))
@@ -142,7 +142,7 @@ uint8_t test_imx_callback(km_core_state *state, uint32_t imx_id, void *callback_
   }
   // Test Exit Context
   km_core_context_item *exit_context = nullptr;
-  kbp_state_get_intermediate_context(state, &exit_context);
+  km_core_state_get_intermediate_context(state, &exit_context);
 
   n = 0;
   try_status(km_core_context_items_to_utf16(exit_context, nullptr, &n))

--- a/linux/debian/libkmnkbp0-0.symbols
+++ b/linux/debian/libkmnkbp0-0.symbols
@@ -1,7 +1,7 @@
 libkmnkbp0.so.0 libkmnkbp0-0 #MINVER#
 * Build-Depends-Package: libkmnkbp-dev
 
- kbp_state_get_intermediate_context@Base 15.0
+ km_core_state_get_intermediate_context@Base 17.0.193
  km_core_context_append@Base 15.0
  km_core_context_clear@Base 15.0
  km_core_context_get@Base 15.0

--- a/windows/src/engine/keyman32/calldll.cpp
+++ b/windows/src/engine/keyman32/calldll.cpp
@@ -165,7 +165,7 @@ LogContext(km_core_state *lpCoreKeyboardState, uint8_t context_type) {
     log_str_title = int_context;
     break;
   case CONTEXT_INT:
-    error_status = (km_core_status_codes)kbp_state_get_intermediate_context(lpCoreKeyboardState, &citems);
+    error_status = (km_core_status_codes)km_core_state_get_intermediate_context(lpCoreKeyboardState, &citems);
     log_str_title = core_context;
     break;
   default:
@@ -318,7 +318,7 @@ extern "C" BOOL _declspec(dllexport) WINAPI KMSetOutput(PWSTR buf, DWORD backlen
   // correctly. To do this need to check the context as we process the
   // backspaces.
   km_core_context_item *citems = nullptr;
-  if (KM_CORE_STATUS_OK != kbp_state_get_intermediate_context(_td->lpActiveKeyboard->lpCoreKeyboardState, &citems)) {
+  if (KM_CORE_STATUS_OK != km_core_state_get_intermediate_context(_td->lpActiveKeyboard->lpCoreKeyboardState, &citems)) {
     delete[] actionItems;
     return FALSE;
   }
@@ -428,7 +428,7 @@ extern "C" BOOL _declspec(dllexport) WINAPI KMGetContext(PWSTR buf, DWORD len)
   }
 
   km_core_context_item *citems = nullptr;
-  if (KM_CORE_STATUS_OK != kbp_state_get_intermediate_context(_td->lpActiveKeyboard->lpCoreKeyboardState, &citems)) {
+  if (KM_CORE_STATUS_OK != km_core_state_get_intermediate_context(_td->lpActiveKeyboard->lpCoreKeyboardState, &citems)) {
       return FALSE;
   }
 


### PR DESCRIPTION
A previous rename missed this.

@keymanapp-test-bot skip