### PR TITLE
chore(linux): Re-enable building for Ubuntu 23.10 Mantic

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -105,10 +105,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Currently not building mantic until ibus version on mantic stabilizied
-        # and we can provide a patched version
-        # dist: [focal, jammy, lunar, mantic]
-        dist: [focal, jammy, lunar]
+        dist: [focal, jammy, lunar, mantic]
         arch: [amd64]
 
     runs-on: ubuntu-latest

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -33,8 +33,7 @@ else
 fi
 echo "ppa: ${ppa}"
 
-# distributions="${DIST:-focal jammy lunar mantic}"
-distributions="${DIST:-focal jammy lunar}"
+distributions="${DIST:-focal jammy lunar mantic}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
Now that we have updated ibus packages in place we can re-enable building for Mantic.

Fixes #9520 and #9398.

@keymanapp-test-bot skip