### PR TITLE
fix(developer): three kmc .keyboard_info generation bugs

### DIFF
--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -36,7 +36,7 @@ export { TouchLayoutFileWriter, TouchLayoutFileWriterOptions } from './keyman-to
 
 export * as KPJ from './kpj/kpj-file.js';
 export { KPJFileReader } from './kpj/kpj-file-reader.js';
-export { KeymanDeveloperProject, KeymanDeveloperProjectFile, } from './kpj/keyman-developer-project.js';
+export { KeymanDeveloperProject, KeymanDeveloperProjectFile, KeymanDeveloperProjectType, } from './kpj/keyman-developer-project.js';
 
 export * as KpsFile from './package/kps-file.js';
 export * as KmpJsonFile from './package/kmp-json-file.js';

--- a/developer/src/common/web/utils/src/validate-mit-license.ts
+++ b/developer/src/common/web/utils/src/validate-mit-license.ts
@@ -9,7 +9,7 @@ export function validateMITLicense(license: string) {
   // lexical-models repositories, suggest we don't worry about this
 
   // split input text into paragraphs, trimming whitespace
-  const text = license.split('\n').map(line => line.trim()).join('\n').split(/\n\s*\n/);
+  const text = license.trim().split('\n').map(line => line.trim()).join('\n').split(/\n\s*\n/);
 
   // MIT license, cleanup whitespace
   const clauses = [

--- a/developer/src/kmc-keyboard-info/src/index.ts
+++ b/developer/src/kmc-keyboard-info/src/index.ts
@@ -389,8 +389,8 @@ export class KeyboardInfoCompiler {
       keyboard_info.languages[language] = {};
     }
 
-    const fontSource = kmpJsonData.keyboards.map(e => e.displayFont).concat(...kmpJsonData.keyboards.map(e => e.webDisplayFonts ?? []));
-    const oskFontSource = kmpJsonData.keyboards.map(e => e.oskFont).concat(...kmpJsonData.keyboards.map(e => e.webOskFonts ?? []));
+    const fontSource = [].concat(...kmpJsonData.keyboards.map(e => e.displayFont ? [e.displayFont] : []), ...kmpJsonData.keyboards.map(e => e.webDisplayFonts ?? []));
+    const oskFontSource = [].concat(...kmpJsonData.keyboards.map(e => e.oskFont ? [e.oskFont] : []), ...kmpJsonData.keyboards.map(e => e.webOskFonts ?? []));
 
     for(const bcp47 of Object.keys(keyboard_info.languages)) {
       const language = keyboard_info.languages[bcp47];


### PR DESCRIPTION
Three separate bugs (separate commits):

* handle fv_all keyboard project with no .kmn
* avoid adding null font data to keyboard_info
* ignore whitespace at end of LICENSE.md

Cleanup alongside keymanapp/keyboards#2404.

@keymanapp-test-bot skip