### PR TITLE
fix(ios): cherrypicks FV ios build script fix 🐵

### DIFF
--- a/oem/firstvoices/ios/build.sh
+++ b/oem/firstvoices/ios/build.sh
@@ -113,8 +113,8 @@ function do_build() {
             -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
             -exportOptionsPlist exportAppStore.plist \
-            -exportPath "$BUILD_PATH/${CONFIG}-iphoneos"
-             -allowProvisioningUpdates \
+            -exportPath "$BUILD_PATH/${CONFIG}-iphoneos" \
+            -allowProvisioningUpdates \
             VERSION=$VERSION \
             VERSION_WITH_TAG=$VERSION_WITH_TAG
   else


### PR DESCRIPTION
Fixes the falling-over iOS build checks in this feature branch's PRs.

I could have done a full merge against master... but this was so narrow and specific that it was easy to extract, and it'll be much simpler and clearer to actually review as a result.  So yeah.

@keymanapp-test-bot skip