### PR TITLE
fix(common): don't use URL in common/web/types

### DIFF
--- a/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/common/web/types/src/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -21,8 +21,8 @@ export class LDMLKeyboardXMLSourceFileReader {
   constructor(private options: LDMLKeyboardXMLSourceFileReaderOptions, private callbacks : CompilerCallbacks) {
   }
 
-  static get defaultImportsURL() {
-    return new URL(`../import/`, import.meta.url);
+  static get defaultImportsURL(): [string,string] {
+    return ['../import/', import.meta.url];
   }
 
   readImportFile(version: string, subpath: string): Uint8Array {

--- a/common/web/types/test/helpers/reader-callback-test.ts
+++ b/common/web/types/test/helpers/reader-callback-test.ts
@@ -9,7 +9,7 @@ import { TestCompilerCallbacks } from './TestCompilerCallbacks.js';
 import { fileURLToPath } from 'url';
 
 const readerOptions: LDMLKeyboardXMLSourceFileReaderOptions = {
-  importsPath: fileURLToPath(LDMLKeyboardXMLSourceFileReader.defaultImportsURL)
+  importsPath: fileURLToPath(new URL(...LDMLKeyboardXMLSourceFileReader.defaultImportsURL))
 };
 
 export interface CompilationCase {

--- a/developer/src/kmc-ldml/test/helpers/index.ts
+++ b/developer/src/kmc-ldml/test/helpers/index.ts
@@ -37,7 +37,7 @@ export const compilerTestCallbacks = new TestCompilerCallbacks();
 
 export const compilerTestOptions: LdmlCompilerOptions = {
   readerOptions: {
-    importsPath: fileURLToPath(LDMLKeyboardXMLSourceFileReader.defaultImportsURL)
+    importsPath: fileURLToPath(new URL(...LDMLKeyboardXMLSourceFileReader.defaultImportsURL))
   }
 };
 

--- a/developer/src/kmc/src/commands/buildClasses/BuildLdmlKeyboard.ts
+++ b/developer/src/kmc/src/commands/buildClasses/BuildLdmlKeyboard.ts
@@ -48,7 +48,7 @@ async function buildLdmlKeyboardToMemory(inputFilename: string, callbacks: Compi
     ...defaultCompilerOptions,
     ...options,
     readerOptions: {
-      importsPath: fileURLToPath(LDMLKeyboardXMLSourceFileReader.defaultImportsURL)
+      importsPath: fileURLToPath(new URL(...LDMLKeyboardXMLSourceFileReader.defaultImportsURL))
     }
   };
 

--- a/developer/src/kmc/src/commands/buildTestData/index.ts
+++ b/developer/src/kmc/src/commands/buildTestData/index.ts
@@ -14,7 +14,7 @@ export function buildTestData(infile: string, _options: any, commander: any) {
     saveDebug: false,
     shouldAddCompilerVersion: false,
     readerOptions: {
-      importsPath: fileURLToPath(LDMLKeyboardXMLSourceFileReader.defaultImportsURL)
+      importsPath: fileURLToPath(new URL(...LDMLKeyboardXMLSourceFileReader.defaultImportsURL))
     }
   };
 


### PR DESCRIPTION
Fixes #9788.

@jahorton you should be able to cherry-pick this and then remove the following from ldml-keyboard-xml-reader.ts on #9664:

```
// Enables DOM types, but just for this one module.
///<reference lib="dom" />
```

@keymanapp-test-bot skip