### PR TITLE
fix(mac): move keyboard menu items to main Input Menu from submenu 🔥 🍒 🏠

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/Base.lproj/MainMenu.xib
+++ b/mac/Keyman4MacIM/Keyman4MacIM/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -19,19 +19,16 @@
         </customObject>
         <menu id="Uod-T8-nBO">
             <items>
-                <menuItem title="Keyboards" tag="1" id="bQa-j9-nHe">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <menu key="submenu" title="Keyboards" id="goP-aK-3WB"/>
-                </menuItem>
-                <menuItem title="Configuration..." tag="2" id="P1b-lE-yFw"/>
-                <menuItem title="On-Screen Keyboard" tag="3" id="s96-JI-YDh">
+                <menuItem isSeparatorItem="YES" tag="-4" id="uqs-C7-aK3"/>
+                <menuItem title="Configuration..." tag="-3" id="P1b-lE-yFw"/>
+                <menuItem title="On-Screen Keyboard" tag="-2" id="s96-JI-YDh">
                     <modifierMask key="keyEquivalentModifierMask"/>
                 </menuItem>
-                <menuItem title="About" tag="4" id="kb2-ww-RS3">
+                <menuItem title="About..." tag="-1" id="kb2-ww-RS3" userLabel="About">
                     <modifierMask key="keyEquivalentModifierMask"/>
                 </menuItem>
             </items>
-            <point key="canvasLocation" x="57" y="152"/>
+            <point key="canvasLocation" x="56.5" y="151.5"/>
         </menu>
     </objects>
 </document>

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -364,6 +364,8 @@
         [self saveActiveKeyboards];
     }
     else if (checkBox.state == NSOffState) {
+        if ([self.AppDelegate debugMode])
+            NSLog(@"Disabling active keyboard: %@", kmxFilePath);
         [self.activeKeyboards removeObject:kmxFilePath];
         [self saveActiveKeyboards];
     }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
@@ -183,68 +183,40 @@ NSMutableArray *servers;
     return self.AppDelegate.kmx;
 }
 
-
 - (void)menuAction:(id)sender {
     NSMenuItem *mItem = [sender objectForKey:kIMKCommandMenuItemName];
     NSInteger itag = mItem.tag;
     if ([self.AppDelegate debugMode])
         NSLog(@"Keyman menu clicked - tag: %lu", itag);
-    if (itag == 2) {
-        // Using `showConfigurationWindow` instead of `showPreferences:` because `showPreferences:` is missing in
-        // High Sierra (10.13.1 - 10.13.3). See: https://bugreport.apple.com/web/?problemID=35422518
-        // rrb: where Apple's API is broken (10.13.1-10.13.3) call our workaround, otherwise, call showPreferences
-        u_int16_t systemVersion = [KMOSVersion SystemVersion];
-        if ([KMOSVersion Version_10_13_1] <= systemVersion && systemVersion <= [KMOSVersion Version_10_13_3]) // between 10.13.1 and 10.13.3 inclusive
-        {
-            NSLog(@"Input Menu: calling workaround instead of showPreferences (sys ver %x)", systemVersion);
-            [self.AppDelegate showConfigurationWindow]; // call our workaround
-        }
-        else
-        {
-            NSLog(@"Input Menu: calling Apple's showPreferences (sys ver %x)", systemVersion);
-            [self showPreferences:sender]; // call Apple API
-        }
+    if (itag == CONFIG_MENUITEM_TAG) {
+        [self showConfigurationWindow:sender];
     }
-    else if (itag == 3) {
+    else if (itag == OSK_MENUITEM_TAG) {
         [self.AppDelegate showOSK];
     }
-    else if (itag == 4) {
+    else if (itag == ABOUT_MENUITEM_TAG) {
         [self.AppDelegate showAboutWindow];
     }
-    else if (itag >= 1000) {
-        NSMenuItem *keyboards = [self.AppDelegate.menu itemWithTag:1];
-        NSString *title = keyboards.title;
-        NSLog(@"Input Menu, selected Keyboards menu, itag: %lu, title: %@", itag, title);
-        for (NSMenuItem *item in keyboards.submenu.itemArray) {
-        NSLog(@"menu item, itag: %lu, title: %@", item.tag, item.title);
-            if (item.tag == itag)
-                [item setState:NSOnState];
-            else
-                [item setState:NSOffState];
-        }
-        
-        NSString *path = [self.AppDelegate.activeKeyboards objectAtIndex:itag%1000];
-        KMXFile *kmx = [[KMXFile alloc] initWithFilePath:path];
-        [self.AppDelegate setKmx:kmx];
-        KVKFile *kvk = nil;
-        NSDictionary *kmxInfo = [KMXFile keyboardInfoFromKmxFile:path];
-        NSString *kvkFilename = [kmxInfo objectForKey:kKMVisualKeyboardKey];
-        if (kvkFilename != nil) {
-            NSString *kvkFilePath = [self.AppDelegate kvkFilePathFromFilename:kvkFilename];
-            if (kvkFilePath != nil)
-                kvk = [[KVKFile alloc] initWithFilePath:kvkFilePath];
-        }
-        [self.AppDelegate setKvk:kvk];
-        NSString *keyboardName = [kmxInfo objectForKey:kKMKeyboardNameKey];
-        if ([self.AppDelegate debugMode])
-            NSLog(@"Selected keyboard from menu: %@", keyboardName);
-        [self.AppDelegate setKeyboardName:keyboardName];
-        [self.AppDelegate setKeyboardIcon:[kmxInfo objectForKey:kKMKeyboardIconKey]];
-        [self.AppDelegate setContextBuffer:nil];
-        [self.AppDelegate setSelectedKeyboard:path];
-        [self.AppDelegate loadSavedStores];
-        if (kvk != nil && self.AppDelegate.alwaysShowOSK)
-            [self.AppDelegate showOSK];
+    else if (itag >= KEYMAN_FIRST_KEYBOARD_MENUITEM_TAG) {
+      [self.AppDelegate selectKeyboardFromMenu:itag];
     }
 }
+
+- (void)showConfigurationWindow:(id)sender {
+  // Using `showConfigurationWindow` instead of `showPreferences:` because `showPreferences:` is missing in
+  // High Sierra (10.13.1 - 10.13.3). See: https://bugreport.apple.com/web/?problemID=35422518
+  // rrb: where Apple's API is broken (10.13.1-10.13.3) call our workaround, otherwise, call showPreferences
+  u_int16_t systemVersion = [KMOSVersion SystemVersion];
+  if ([KMOSVersion Version_10_13_1] <= systemVersion && systemVersion <= [KMOSVersion Version_10_13_3]) // between 10.13.1 and 10.13.3 inclusive
+  {
+      NSLog(@"Input Menu: calling workaround instead of showPreferences (sys ver %x)", systemVersion);
+      [self.AppDelegate showConfigurationWindow]; // call our workaround
+  }
+  else
+  {
+      NSLog(@"Input Menu: calling Apple's showPreferences (sys ver %x)", systemVersion);
+      [self showPreferences:sender]; // call Apple API
+  }
+}
+
 @end

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
@@ -213,7 +213,10 @@ NSMutableArray *servers;
     }
     else if (itag >= 1000) {
         NSMenuItem *keyboards = [self.AppDelegate.menu itemWithTag:1];
+        NSString *title = keyboards.title;
+        NSLog(@"Input Menu, selected Keyboards menu, itag: %lu, title: %@", itag, title);
         for (NSMenuItem *item in keyboards.submenu.itemArray) {
+        NSLog(@"menu item, itag: %lu, title: %@", item.tag, item.title);
             if (item.tag == itag)
                 [item setState:NSOnState];
             else

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
@@ -37,6 +37,21 @@ typedef struct {
     NSString *apiKeymanCom;
 } KeymanVersionInfo;
 
+// tags for default menu items, displayed whether keyboards are active or not
+static const int DIVIDER_MENUITEM_TAG = -4;
+static const int CONFIG_MENUITEM_TAG = -3;
+static const int OSK_MENUITEM_TAG = -2;
+static const int ABOUT_MENUITEM_TAG = -1;
+
+// the number of menu items that do not represent active keyboards
+static const int DEFAULT_KEYMAN_MENU_ITEM_COUNT = 4;
+
+// the tag for the first keyboard dynamically added to the menu
+static const int KEYMAN_FIRST_KEYBOARD_MENUITEM_TAG = 0;
+
+// the menu index for the first keyboard dynamically added to the menu
+static const int KEYMAN_FIRST_KEYBOARD_MENUITEM_INDEX = 0;
+
 @interface KMInputMethodAppDelegate : NSObject
 #define USE_ALERT_SHOW_HELP_TO_FORCE_EASTER_EGG_CRASH_FROM_ENGINE 1
 #ifdef USE_ALERT_SHOW_HELP_TO_FORCE_EASTER_EGG_CRASH_FROM_ENGINE
@@ -54,6 +69,7 @@ typedef struct {
 @property (nonatomic, strong) NSMutableArray *kmxFileList;
 @property (nonatomic, strong) NSString *selectedKeyboard;
 @property (nonatomic, strong) NSMutableArray *activeKeyboards;
+@property (assign) int numberOfKeyboardMenuItems;
 @property (nonatomic, strong) NSMutableString *contextBuffer;
 @property (nonatomic, assign) NSEventModifierFlags currentModifierFlags;
 @property (nonatomic, assign) CFMachPortRef lowLevelEventTap;
@@ -87,6 +103,7 @@ typedef struct {
 - (void)showAboutWindow;
 - (void)showOSK;
 - (void)showConfigurationWindow;
+- (void)selectKeyboardFromMenu:(NSInteger)tag;
 - (void)sleepFollowingDeactivationOfServer:(id)lastServer;
 - (void)wakeUpWith:(id)newServer;
 - (void)handleKeyEvent:(NSEvent *)event;

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -699,14 +699,14 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     [userData setObject:_activeKeyboards forKey:kKMActiveKeyboardsKey];
     [userData synchronize];
     [self resetActiveKeyboards];
-    [self setKeyboardsSubMenu];
+    [self updateKeyboardMenuItems];
 }
 
 - (void)clearActiveKeyboards {
     NSUserDefaults *userData = [NSUserDefaults standardUserDefaults];
     [userData setObject:nil forKey:kKMActiveKeyboardsKey];
     [userData synchronize];
-    [self setKeyboardsSubMenu];
+    [self updateKeyboardMenuItems];
 }
 
 - (void)resetActiveKeyboards {
@@ -759,96 +759,174 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 }
 
 - (void)awakeFromNib {
-    [self setKeyboardsSubMenu];
-
-    NSMenuItem *config = [self.menu itemWithTag:2];
-    if (config)
-        [config setAction:@selector(menuAction:)];
-
-    NSMenuItem *osk = [self.menu itemWithTag:3];
-    if (osk)
-        [osk setAction:@selector(menuAction:)];
-
-    NSMenuItem *about = [self.menu itemWithTag:4];
-    if (about)
-        [about setAction:@selector(menuAction:)];
+    [self setDefaultKeymanMenuItems];
+    [self updateKeyboardMenuItems];
 }
 
-- (void)setKeyboardsSubMenu {
-    NSMenuItem *keyboards = [self.menu itemWithTag:1];
-    if (keyboards) {
-        KVKFile *kvk = nil;
-        BOOL didSetKeyboard = NO;
-        NSInteger itag = 1000;
-        NSString *keyboardMenuName = @"";
+- (void)setDefaultKeymanMenuItems {
+  NSMenuItem *config = [self.menu itemWithTag:CONFIG_MENUITEM_TAG];
+  if (config) {
+    [config setAction:@selector(menuAction:)];
+  }
+  
+  NSMenuItem *osk = [self.menu itemWithTag:OSK_MENUITEM_TAG];
+  if (osk) {
+    [osk setAction:@selector(menuAction:)];
+  }
+  
+  NSMenuItem *about = [self.menu itemWithTag:ABOUT_MENUITEM_TAG];
+  if (about) {
+    [about setAction:@selector(menuAction:)];
+  }
+}
+
+- (void)updateKeyboardMenuItems {
+  self.numberOfKeyboardMenuItems = [self calculateNumberOfKeyboardMenuItems];
+  [self removeDynamicKeyboardMenuItems];
+  [self addDynamicKeyboardMenuItems];
+}
+
+- (int)calculateNumberOfKeyboardMenuItems {
+  if (self.activeKeyboards.count == 0) {
+    // if there are no active keyboards, then we will insert one placeholder menu item 'No Active Keyboards'
+    return 1;
+  } else {
+    return (int) self.activeKeyboards.count;
+  }
+}
+
+- (void)removeDynamicKeyboardMenuItems {
+  int numberToRemove = (int) self.menu.numberOfItems - DEFAULT_KEYMAN_MENU_ITEM_COUNT;
+  
+  if (self.debugMode) {
+    NSLog(@"*** removeDynamicKeyboardMenuItems, self.menu.numberOfItems = %ld, number of items to remove = %d", (long)self.menu.numberOfItems, numberToRemove);
+  }
+  
+  if (numberToRemove > 0) {
+    for (int i = 1; i <= numberToRemove; i++) {
+      [self.menu removeItemAtIndex:KEYMAN_FIRST_KEYBOARD_MENUITEM_INDEX];
+    }
+  }
+}
+
+- (void)addDynamicKeyboardMenuItems {
+    BOOL didSetSelectedKeyboard = NO;
+    NSInteger itag = KEYMAN_FIRST_KEYBOARD_MENUITEM_TAG;
+    NSString *keyboardMenuName = @"";
+    int menuItemIndex = KEYMAN_FIRST_KEYBOARD_MENUITEM_INDEX;
+  
+    if (self.debugMode) {
+      NSLog(@"*** populateKeyboardMenuItems, number of active keyboards=%lu", self.activeKeyboards.count);
+    }
+  
+    // loop through the active keyboards list and add them to the menu
+    for (NSString *path in self.activeKeyboards) {
+        NSDictionary *infoDict = [KMXFile keyboardInfoFromKmxFile:path];
+        if (!infoDict) {
+          continue;
+        }
+        keyboardMenuName = [infoDict objectForKey:kKMKeyboardNameKey];
+        NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:keyboardMenuName action:@selector(menuAction:) keyEquivalent:@""];
+        [item setTag:itag++];
+        
+        // if this is the selected keyboard, then configure it as selected
+        if ([path isEqualToString:self.selectedKeyboard]) {
+            [self setSelectedKeyboard:path inMenuItem:item];
+            didSetSelectedKeyboard = YES;
+        }
+        else {
+            [item setState:NSOffState];
+        }
       
-        [keyboards.submenu removeAllItems];
-        for (NSString *path in self.activeKeyboards) {
-            NSDictionary *infoDict = [KMXFile keyboardInfoFromKmxFile:path];
-            if (!infoDict)
-                continue;
-            //NSString *str = [NSString stringWithFormat:@"%@ (%@)", [infoDict objectForKey:kKMKeyboardNameKey], [infoDict objectForKey:kKMKeyboardVersionKey]];
-            NSString *str = [infoDict objectForKey:kKMKeyboardNameKey];
-            // for debugging
-            keyboardMenuName = str;
-            NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:str action:@selector(menuAction:) keyEquivalent:@""];
-            [item setTag:itag++];
-            if ([path isEqualToString:self.selectedKeyboard]) {
-                [item setState:NSOnState];
-                KMXFile *kmx = [[KMXFile alloc] initWithFilePath:path];
-                [self setKmx:kmx];
-                NSDictionary *kmxInfo = [KMXFile keyboardInfoFromKmxFile:path];
-                NSString *kvkFilename = [kmxInfo objectForKey:kKMVisualKeyboardKey];
-                if (kvkFilename != nil) {
-                    NSString *kvkFilePath = [self kvkFilePathFromFilename:kvkFilename];
-                    if (kvkFilePath != nil)
-                        kvk = [[KVKFile alloc] initWithFilePath:kvkFilePath];
-                }
-                [self setKvk:kvk];
-                [self setKeyboardName:[kmxInfo objectForKey:kKMKeyboardNameKey]];
-                [self setKeyboardIcon:[kmxInfo objectForKey:kKMKeyboardIconKey]];
-                [self loadSavedStores];
+        [self.menu insertItem:item atIndex:menuItemIndex++];
+    }
+  
+    if (self.activeKeyboards.count == 0) {
+        [self addKeyboardPlaceholderMenuItem];
+    } else if (!didSetSelectedKeyboard) {
+        [self setDefaultSelectedKeyboard];
+    }
+}
 
-                didSetKeyboard = YES;
-            }
-            else
-                [item setState:NSOffState];
+- (void) setSelectedKeyboard:(NSString*)keyboardName inMenuItem:(NSMenuItem*) menuItem {
+    KVKFile *kvk = nil;
 
-          NSLog(@"*** adding item to keyboards menu, itag=%lu, keyboard=%@", itag, keyboardMenuName);
-
-            [keyboards.submenu addItem:item];
-        }
-
-        if (keyboards.submenu.numberOfItems == 0) {
-            NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@"(None)" action:NULL keyEquivalent:@""];
-            [keyboards.submenu addItem:item];
-            [self setKmx:nil];
-            [self setKvk:nil];
-            [self setKeyboardName:nil];
-            [self setKeyboardIcon:nil];
-            [self setContextBuffer:nil];
-            [self setSelectedKeyboard:nil];
-        }
-        else if (!didSetKeyboard) {
-            [keyboards.submenu itemAtIndex:0].state = NSOnState;
-            NSString *path = [self.activeKeyboards objectAtIndex:0];
-            KMXFile *kmx = [[KMXFile alloc] initWithFilePath:path];
-            [self setKmx:kmx];
-            NSDictionary *kmxInfo = [KMXFile keyboardInfoFromKmxFile:path];
-            NSString *kvkFilename = [kmxInfo objectForKey:kKMVisualKeyboardKey];
-            if (kvkFilename != nil) {
-                NSString *kvkFilePath = [self kvkFilePathFromFilename:kvkFilename];
-                if (kvkFilePath != nil)
-                    kvk = [[KVKFile alloc] initWithFilePath:kvkFilePath];
-            }
-            [self setKvk:kvk];
-            [self setKeyboardName:[kmxInfo objectForKey:kKMKeyboardNameKey]];
-            [self setKeyboardIcon:[kmxInfo objectForKey:kKMKeyboardIconKey]];
-            [self setContextBuffer:nil];
-            [self loadSavedStores];
-            [self setSelectedKeyboard:path];
+    [menuItem setState:NSOnState];
+    KMXFile *kmx = [[KMXFile alloc] initWithFilePath:keyboardName];
+    [self setKmx:kmx];
+    NSDictionary *kmxInfo = [KMXFile keyboardInfoFromKmxFile:keyboardName];
+    NSString *kvkFilename = [kmxInfo objectForKey:kKMVisualKeyboardKey];
+    if (kvkFilename != nil) {
+        NSString *kvkFilePath = [self kvkFilePathFromFilename:kvkFilename];
+        if (kvkFilePath != nil) {
+          kvk = [[KVKFile alloc] initWithFilePath:kvkFilePath];
         }
     }
+    [self setKvk:kvk];
+    [self setKeyboardName:[kmxInfo objectForKey:kKMKeyboardNameKey]];
+    [self setKeyboardIcon:[kmxInfo objectForKey:kKMKeyboardIconKey]];
+    [self loadSavedStores];
+}
+
+// defaults to the whatever keyboard happens to be first in the list
+- (void) setDefaultSelectedKeyboard {
+    NSMenuItem* menuItem = [self.menu itemAtIndex:KEYMAN_FIRST_KEYBOARD_MENUITEM_INDEX];
+    NSString *keyboardName = [self.activeKeyboards objectAtIndex:0];
+    [self setSelectedKeyboard:keyboardName inMenuItem:menuItem];
+    [self setSelectedKeyboard:keyboardName];
+    [self setContextBuffer:nil];
+}
+
+- (void) addKeyboardPlaceholderMenuItem {
+    NSString* placeholder = NSLocalizedString(@"no-keyboard-configured-menu-placeholder", nil);
+    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:placeholder action:NULL keyEquivalent:@""];
+    [self.menu insertItem:item atIndex:KEYMAN_FIRST_KEYBOARD_MENUITEM_INDEX];
+    [self setKmx:nil];
+    [self setKvk:nil];
+    [self setKeyboardName:nil];
+    [self setKeyboardIcon:nil];
+    [self setContextBuffer:nil];
+    [self setSelectedKeyboard:nil];
+}
+
+- (void)selectKeyboardFromMenu:(NSInteger)tag {
+    NSMenuItem *menuItem = [self.menu itemWithTag:tag];
+    NSString *title = menuItem.title;
+    NSLog(@"Input Menu, selected Keyboards menu, itag: %lu, title: %@", tag, title);
+    for (NSMenuItem *item in self.menu.itemArray) {
+        // set the state of the keyboard items in the Keyman menu based on the new selection
+        if (item.tag >= KEYMAN_FIRST_KEYBOARD_MENUITEM_TAG) {
+            if (item.tag == tag) {
+                [item setState:NSOnState];
+            }
+            else {
+                [item setState:NSOffState];
+            }
+        }
+    }
+    
+    NSString *path = [self.activeKeyboards objectAtIndex:tag-KEYMAN_FIRST_KEYBOARD_MENUITEM_TAG];
+    KMXFile *kmx = [[KMXFile alloc] initWithFilePath:path];
+    [self setKmx:kmx];
+    KVKFile *kvk = nil;
+    NSDictionary *kmxInfo = [KMXFile keyboardInfoFromKmxFile:path];
+    NSString *kvkFilename = [kmxInfo objectForKey:kKMVisualKeyboardKey];
+    if (kvkFilename != nil) {
+        NSString *kvkFilePath = [self kvkFilePathFromFilename:kvkFilename];
+        if (kvkFilePath != nil)
+            kvk = [[KVKFile alloc] initWithFilePath:kvkFilePath];
+    }
+    [self setKvk:kvk];
+    NSString *keyboardName = [kmxInfo objectForKey:kKMKeyboardNameKey];
+    if ([self debugMode])
+        NSLog(@"Selected keyboard from menu: %@", keyboardName);
+    [self setKeyboardName:keyboardName];
+    [self setKeyboardIcon:[kmxInfo objectForKey:kKMKeyboardIconKey]];
+    [self setContextBuffer:nil];
+    [self setSelectedKeyboard:path];
+    [self loadSavedStores];
+    if (kvk != nil && self.alwaysShowOSK)
+        [self showOSK];
 }
 
 - (NSArray *)KMXFiles {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -780,6 +780,8 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
         KVKFile *kvk = nil;
         BOOL didSetKeyboard = NO;
         NSInteger itag = 1000;
+        NSString *keyboardMenuName = @"";
+      
         [keyboards.submenu removeAllItems];
         for (NSString *path in self.activeKeyboards) {
             NSDictionary *infoDict = [KMXFile keyboardInfoFromKmxFile:path];
@@ -787,6 +789,8 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
                 continue;
             //NSString *str = [NSString stringWithFormat:@"%@ (%@)", [infoDict objectForKey:kKMKeyboardNameKey], [infoDict objectForKey:kKMKeyboardVersionKey]];
             NSString *str = [infoDict objectForKey:kKMKeyboardNameKey];
+            // for debugging
+            keyboardMenuName = str;
             NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:str action:@selector(menuAction:) keyEquivalent:@""];
             [item setTag:itag++];
             if ([path isEqualToString:self.selectedKeyboard]) {
@@ -809,6 +813,8 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
             }
             else
                 [item setState:NSOffState];
+
+          NSLog(@"*** adding item to keyboards menu, itag=%lu, keyboard=%@", itag, keyboardMenuName);
 
             [keyboards.submenu addItem:item];
         }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -803,7 +803,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
   }
   
   if (numberToRemove > 0) {
-    for (int i = 1; i <= numberToRemove; i++) {
+    for (int i = 0; i < numberToRemove; i++) {
       [self.menu removeItemAtIndex:KEYMAN_FIRST_KEYBOARD_MENUITEM_INDEX];
     }
   }

--- a/mac/Keyman4MacIM/Keyman4MacIM/en.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/en.lproj/Localizable.strings
@@ -71,4 +71,6 @@
 /* message displayed to alert user to need grant accessibility permission */
 "privacy-alert-text" = "To function properly, Keyman requires accessibility features:\n\nGrant access in System Preferences, Security & Privacy.\nRestart your system.";
 
+/* Text of menu item in Input Menu when no Keyboards are configured -- include parentheses  */
+"no-keyboard-configured-menu-placeholder" = "(No Keyboard Configured)";
 


### PR DESCRIPTION
Cherry-pick of #9777 to stable-16.0

Previously, Keyman for Mac supported switching of keyboards using a submenu from the Keyman section of the Input Menu:

![image](https://github.com/keymanapp/keyman/assets/89134789/f6a7dcc5-0ac9-43e1-8fa2-c2d5e50f3b25)

This  change eliminates the submenu and lists the keyboards at the top of the Keyman section of the Input menu:

![image](https://github.com/keymanapp/keyman/assets/89134789/92999056-2e9d-44f0-9a74-f23a5e1fa0c8)

It is helpful to make this change now because the Keyboards submenu is not functioning properly with macOS Sonoma, 14.0 (see #9684).

Fixes #9684

# User Testing

- **TEST_KEYBOARD_SELECTION**:
Run Keyman for Mac and verify that a single keyboard is selected in the Keyman section of the Input Menu. Also, confirm that the selected keyboard is actually the one that is processing keystrokes when typing in a text document.

- **TEST_CHANGING_KEYBOARDS**:
Select a different keyboard from the list in the Keyman section of the Input Menu and verify that:
1) The keyboard that was selected now has the checkmark next to it when you open the Input Menu.
2) The previously selected keyboard does not have a checkmark next to it.
3) When typing in a text document, confirm the selected keyboard is the one that is processing keystrokes.

- **TEST_CONFIGURATION_MENU**:
Select the 'Configuration...' menu item and confirm that it brings up the Configuration window.

- **TEST_SHOW_OSK_MENU**:
Select the 'On-Screen Keyboard' menu item and confirm that it brings up the On-screen Keyboard window.

- **TEST_ABOUT_MENU**:
Select the 'About' menu item and confirm that it brings up the About dialog.

- **TEST_ADD_KEYBOARD**:
Go to the Configuration window and either install a new keyboard or enable one that is already installed by clicking on the checkbox in the leftmost column of the Keyboards pane. Confirm that the newly added keyboard is now listed in the Keyman section of the Input Menu.

- **TEST_REMOVE_SELECTED_KEYBOARD**:
Go to the Configuration window and disable the keyboard that is currently active in Keyman by unchecking the corresponding checkbox in the leftmost column of the Keyboards pane. Confirm that:
1) the removed keyboard is no longer listed in the Keyman section of the Input Menu
2) that some other keyboard is now selected instead
3) that the newly selected keyboard is being used for key processing when typing in a text document

- **TEST_REMOVE_ALL_KEYBOARDS**:
Go to the Configuration window and disable all the keyboards that are currently active in Keyman by unchecking the checkboxes in the leftmost column of the Keyboards pane. Go look at the Input Menu and confirm that the only keyboard listed is a placeholder that says: '(No Keyboard Configured)':

![image](https://github.com/keymanapp/keyman/assets/89134789/0cf5eade-b735-41bc-91cf-632fe5bc916a)

- **TEST_MENU_PERFORMANCE**:
When the Input Menu is opened, confirm that the contents of the menu are fully populated and you do not need to open and close the Input Menu a few times for the Keyman section of the menu to appear.