### PR TITLE
chore(linux): Update packaging GHA 〽️

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -242,8 +242,13 @@ jobs:
     - name: Verify API
       run: |
         cd linux
+        if [ -f debian/libkeymancore.symbols ]; then
+          PKG_NAME=libkeymancore
+        else
+          PKG_NAME=libkmnkbp0-0
+        fi
         SRC_PKG="${GITHUB_WORKSPACE}/artifacts/keyman-srcpkg/keyman_${{ needs.sourcepackage.outputs.VERSION }}-1.debian.tar.xz" \
-        BIN_PKG="${GITHUB_WORKSPACE}/artifacts/keyman-binarypkgs/libkmnkbp0-0_${{ needs.sourcepackage.outputs.VERSION }}-1${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}+jammy1_amd64.deb" \
+        BIN_PKG="${GITHUB_WORKSPACE}/artifacts/keyman-binarypkgs/${PKG_NAME}_${{ needs.sourcepackage.outputs.VERSION }}-1${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}+jammy1_amd64.deb" \
         PKG_VERSION="${{ needs.sourcepackage.outputs.VERSION }}" \
         ./scripts/deb-packaging.sh --gha verify 2>> $GITHUB_STEP_SUMMARY
 
@@ -252,6 +257,13 @@ jobs:
       with:
         name: libkmnkbp0-0.symbols
         path: linux/debian/libkmnkbp0-0.symbols
+      if: always()
+
+    - name: Archive .symbols file
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: libkeymancore.symbols
+        path: linux/debian/libkeymancore.symbols
       if: always()
 
   set_status:

--- a/linux/scripts/deb-packaging.sh
+++ b/linux/scripts/deb-packaging.sh
@@ -57,14 +57,21 @@ fi
 
 if builder_start_action verify; then
   tar xf "${SRC_PKG}"
-  if [ ! -f debian/libkmnkbp0-0.symbols ]; then
-    echo ":warning: Missing libkmnkbp0-0.symbols file" >&2
+  if [ ! -f debian/libkmnkbp0-0.symbols ] && [ ! -f debian/libkeymancore.symbols ]; then
+    echo ":warning: Missing libkmnkbp0-0.symbols/libkeymancore.symbols file" >&2
   else
+    if [ -f debian/libeymancore.symbols ]; then
+        PKG_NAME=libkeymancore
+        LIB_NAME=libkeymancore
+    else
+        PKG_NAME=libkmnkbp0-0
+        LIB_NAME=libkmnkbp0
+    fi
     tmpDir=$(mktemp -d)
     dpkg -x "${BIN_PKG}" "$tmpDir"
     cd debian
-    dpkg-gensymbols -v"${PKG_VERSION}" -plibkmnkbp0-0 -e"${tmpDir}"/usr/lib/x86_64-linux-gnu/libkmnkbp0.so* -Olibkmnkbp0-0.symbols -c4
-    echo ":heavy_check_mark: libkmnkbp0-0 API didn't change" >&2
+    dpkg-gensymbols -v"${PKG_VERSION}" -p${PKG_NAME} -e"${tmpDir}"/usr/lib/x86_64-linux-gnu/${LIB_NAME}.so* -O${PKG_NAME}.symbols -c4
+    echo ":heavy_check_mark: ${LIB_NAME} API didn't change" >&2
   fi
   builder_finish_action success verify
   exit 0


### PR DESCRIPTION
This enhances the packaging GHA to be able to verify the renamed core library. Since the GHA packaging build always uses the action definition from `master` this change has to land before we can successfully build the PR that does the actual renaming of the core library and Debian package. Later we can remove the references to `libkmnkbp0-0` again.

Part of #9733.

@keymanapp-test-bot skip