### PR TITLE
chore(linux): Exclude environment.sh from build 🍒 🏠

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -78,7 +78,9 @@ for proj in ${extra_projects}; do
         --tar-ignore=linux/keyboardprocessor --tar-ignore=linux/legacy \
         --tar-ignore=mac --tar-ignore=node_modules --tar-ignore=oem \
         --tar-ignore=linux/build* --tar-ignore=core/build \
-        --tar-ignore=resources/devbox --tar-ignore=resources/git-hooks \
+        --tar-ignore=resources/devbox \
+        --tar-ignore=resources/environment.sh \
+        --tar-ignore=resources/git-hooks \
         --tar-ignore=resources/scopes \
         --tar-ignore=resources/build/*.lua --tar-ignore=resources/build/jq* \
         --tar-ignore=resources/build/vswhere* --tar-ignore=results \


### PR DESCRIPTION
`environment.sh` is used only on Mac. This change modifies `build.sh` to generate this file only when building on Mac. It also excludes `environment.sh` from the Linux source tarball.

(cherry picked from #9553)

@keymanapp-test-bot skip