### PR TITLE
fix(core): build: support -t parameter correctly

### DIFF
--- a/core/build.sh
+++ b/core/build.sh
@@ -73,7 +73,7 @@ Libraries will be built in 'build/<target>/<configuration>/src'.
   "uninstall                       uninstall libraries from current system" \
   "${archtargets[@]}" \
   "--no-tests                      do not configure tests (used by other projects)" \
-  "--test=opt_tests,-t             test[s] to run (space separated)"
+  "--test,-t=opt_tests             test[s] to run (space separated)"
 
 builder_parse "$@"
 
@@ -165,6 +165,11 @@ fi
 
 # -------------------------------------------------------------------------------
 
+testparams="${builder_extra_params[@]}"
+if builder_has_option --test; then
+  testparams="$opt_tests $testparams"
+fi
+
 do_action test
 
 if builder_start_action test:mac; then
@@ -173,7 +178,7 @@ if builder_start_action test:mac; then
   # available
   target=mac-`uname -m`
   MESON_PATH="$KEYMAN_ROOT/core/build/$target/$BUILDER_CONFIGURATION"
-  meson test -C "$MESON_PATH" "${builder_extra_params[@]}"
+  meson test -C "$MESON_PATH" $testparams
   builder_finish_action success test:mac
 fi
 

--- a/core/commands.inc.sh
+++ b/core/commands.inc.sh
@@ -89,9 +89,9 @@ do_test() {
   local target=$1
   builder_start_action test:$target || return 0
   if [[ $target =~ ^(x86|x64)$ ]]; then
-    cmd //C build.bat $target $BUILDER_CONFIGURATION test "${builder_extra_params[@]}"
+    cmd //C build.bat $target $BUILDER_CONFIGURATION test $testparams
   else
-    meson test -C "$MESON_PATH" "${builder_extra_params[@]}"
+    meson test -C "$MESON_PATH" $testparams
   fi
   builder_finish_action success test:$target
 }


### PR DESCRIPTION
Fixes #9816.

Now allows any of the following. Quote marks are significant for multiple tests with `-t`:

```bash
core/build.sh test:wasm --no-deps -- state-api debug-api
core/build.sh test:wasm --no-deps -- "state-api debug-api"
core/build.sh test:wasm --no-deps -t "state-api debug-api"
core/build.sh test:wasm --no-deps --test "state-api debug-api"
```

The `-t` / `--test` option takes a single string parameter which is passed on to `meson test`, whereas the `--` "end of parameters" marker allows arbitrary remaining parameters to be passed on to `meson test`.

@keymanapp-test-bot skip