### PR TITLE
fix(developer): handle xml errors in package compiler

### DIFF
--- a/developer/src/kmc-package/src/compiler/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/kmp-compiler.ts
@@ -29,6 +29,7 @@ export class KmpCompiler {
   public transformKpsToKmpObject(kpsFilename: string): KmpJsonFile.KmpJsonFile {
     const kps = this.loadKpsFile(kpsFilename);
     if(!kps) {
+      // errors will already have been reported by loadKpsFile
       return null;
     }
     return this.transformKpsFileToKmpObject(kpsFilename, kps);
@@ -48,10 +49,18 @@ export class KmpCompiler {
         let parser = new xml2js.Parser({
           explicitArray: false
         });
-        // TODO: add unit test for xml errors parsing .kps file
-        parser.parseString(data, (e: unknown, r: unknown) => { if(e) throw e; a = r as KpsFile.KpsPackage });
+
+        try {
+          parser.parseString(data, (e: unknown, r: unknown) => { if(e) throw e; a = r as KpsFile.KpsPackage });
+        } catch(e) {
+          this.callbacks.reportMessage(CompilerMessages.Error_InvalidPackageFile({e}));
+        }
         return a;
     })();
+
+    if(!kpsPackage) {
+      return null;
+    }
 
     const kps: KpsFile.KpsFile = kpsPackage.Package;
     return kps;

--- a/developer/src/kmc-package/src/compiler/messages.ts
+++ b/developer/src/kmc-package/src/compiler/messages.ts
@@ -123,5 +123,9 @@ export class CompilerMessages {
   static Hint_PackageContainsSourceFile = (o:{filename:string}) => m(this.HINT_PackageContainsSourceFile,
     `The source file ${o.filename} should not be included in the package; instead include the compiled result.`);
   static HINT_PackageContainsSourceFile = SevHint | 0x001D;
+
+  static Error_InvalidPackageFile = (o:{e:any}) => m(this.ERROR_InvalidPackageFile,
+    `Package source file is invalid: ${(o.e ?? 'unknown error').toString()}`);
+  static ERROR_InvalidPackageFile = SevError | 0x001E;
 }
 

--- a/developer/src/kmc-package/src/compiler/windows-package-installer-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/windows-package-installer-compiler.ts
@@ -39,6 +39,10 @@ export class WindowsPackageInstallerCompiler {
 
   public async compile(kpsFilename: string, sources: WindowsPackageInstallerSources): Promise<Uint8Array> {
     const kps = this.kmpCompiler.loadKpsFile(kpsFilename);
+    if(!kps) {
+      // errors will already have been reported by loadKpsFile
+      return null;
+    }
 
     // Check existence of required files
     for(const filename of [sources.licenseFilename, sources.msiFilename, sources.setupExeFilename]) {

--- a/developer/src/kmc-package/test/fixtures/invalid/error_invalid_package_file.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/error_invalid_package_file.kps
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Info>
+    <Name URL="">SENĆOŦEN (Saanich Dialect) Keyboard</Name>
+    <!-- error_invalid_package_file -->
+    <Copyright URL="">© 2019 National Research Council Canada & this test</Copyright>
+    <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
+    <Version>1.0</Version>
+  </Info>
+  <Files>
+    <File>
+      <Name>basic.kmx</Name>
+      <Description>Keyboard Basic</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+  </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>Basic</Name>
+      <ID>basic</ID>
+      <Version>1.0</Version>
+      <Languages>
+        <Language ID="KM">Khmer</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
+</Package>

--- a/developer/src/kmc-package/test/test-messages.ts
+++ b/developer/src/kmc-package/test/test-messages.ts
@@ -226,4 +226,11 @@ describe('CompilerMessages', function () {
       CompilerMessages.HINT_PackageContainsSourceFile);
   });
 
+  // ERROR_InvalidPackageFile
+
+  it('should generate ERROR_InvalidPackageFile if package source file contains invalid XML', async function() {
+    testForMessage(this, ['invalid', 'error_invalid_package_file.kps'],
+      CompilerMessages.ERROR_InvalidPackageFile);
+  });
+
 });


### PR DESCRIPTION
Fixes #9797.

@keymanapp-test-bot skip