### PR TITLE
fix(developer): reduce confusion in Unicode fields in touch layout editor

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/builder.xsl
+++ b/developer/src/tike/xml/layoutbuilder/builder.xsl
@@ -108,7 +108,7 @@
         </div>
 
         <div class='toolbar-item' id='key-cap-unicode-toolbar-item'>
-          <label for='inpKeyCapUnicode'>Unicode:</label>
+          <label for='inpKeyCapUnicode'>Text Unicode:</label>
           <input id='inpKeyCapUnicode' type='text' size='16' />
         </div>
 
@@ -118,7 +118,7 @@
         </div>
 
         <div class='toolbar-item' id='key-hint-unicode-toolbar-item'>
-          <label for='inpKeyHintUnicode'>Unicode:</label>
+          <label for='inpKeyHintUnicode'>Hint Unicode:</label>
           <input id='inpKeyHintUnicode' type='text' size='16' />
         </div>
 
@@ -221,7 +221,7 @@
           <input id='inpSubKeyCap' type='text' size='8' />
         </div>
         <div class='toolbar-item' id='sub-key-cap-unicode-toolbar-item'>
-          <label>Unicode:</label>
+          <label>Text Unicode:</label>
           <input id='inpSubKeyCapUnicode' type='text' size='16' />
         </div>
         <div class='toolbar-item'>


### PR DESCRIPTION
Fixes #9830.

@keymanapp-test-bot skip