### PR TITLE
fix(developer): handle displayMap correctly with 'fill from layout'

### DIFF
--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -280,6 +280,9 @@ export class KmnCompiler implements UnicodeSetParser {
 
       if(result.extra.displayMapFilename) {
         result.displayMap = this.loadDisplayMapping(infile, result.extra.displayMapFilename)
+        if(!result.displayMap) {
+          return null;
+        }
       }
 
       if(result.extra.kvksFilename) {
@@ -406,6 +409,10 @@ export class KmnCompiler implements UnicodeSetParser {
     try {
       // Expected file format: displaymap.schema.json
       const data = this.callbacks.loadFile(displayMapFilename);
+      if(!data) {
+        this.callbacks.reportMessage(CompilerMessages.Error_FileNotFound({filename: displayMapFilename}));
+        return null;
+      }
       const mapping = JSON.parse(new TextDecoder().decode(data));
       return Osk.parseMapping(mapping);
     } catch(e) {

--- a/developer/src/kmc-kmn/src/compiler/messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/messages.ts
@@ -87,6 +87,10 @@ export class CompilerMessages {
   static Error_InvalidKvkFile = (o:{filename: string, e: any}) => m(this.ERROR_InvalidKvkFile,
     `Error encountered loading ${o.filename}: ${o.e ?? 'unknown error'}`); // Note, not fatal, not reporting to Sentry
   static ERROR_InvalidKvkFile = SevError | 0x90B;
+
+  static Error_FileNotFound = (o:{filename: string}) => m(this.ERROR_FileNotFound,
+    `File ${o.filename} was not found`);
+  static ERROR_FileNotFound = SevError | 0x90C;
 };
 
 /**

--- a/developer/src/tike/child/UfrmKeymanWizard.pas
+++ b/developer/src/tike/child/UfrmKeymanWizard.pas
@@ -2944,8 +2944,7 @@ end;
 
 procedure TfrmKeymanWizard.OSKImportKMX(Sender: TObject; var KMXFileName: TTempFile);   // I4181
 var
-  KMNFileName: TTempFile;
-  KMXFileName2: string;
+  KMNFileName: string;
   sw: WideString;
   kbdparser: TKeyboardParser;
   FEncoding: TEncoding;
@@ -2953,7 +2952,7 @@ var
   w: TKmcWrapper;
 begin
   KMXFileName := TTempFileManager.Get('.kmx');   // I4181
-  KMNFileName := TTempFileManager.Get('.kmn');   // I4181
+  KMNFileName := ExtractFilePath(Filename) + '__temp_osk_import_' + ExtractFileName(Filename);
 
   kbdparser := TKeyboardParser.Create;
   try
@@ -2989,18 +2988,16 @@ begin
   with TStringList.Create do  // I3337
   try
     Text := sw;
-    SaveToFile(KMNFileName.Name, FEncoding);   // I4181
+    SaveToFile(KMNFileName, FEncoding);   // I4181
   finally
     Free;
   end;
-
-  KMXFileName2 := KMXFileName.Name;   // I4181
 
   TProject.CompilerMessageFile := ProjectFile;
   frmMessages.Clear;
   w := TKmcWrapper.Create;
   try
-    if not w.Compile(ProjectFile, KMNFileName.Name, KMXFileName2, False) then
+    if not w.Compile(ProjectFile, KMNFileName, KMXFileName.Name, False) then
     begin
       frmMessages.DoShowForm;
       ShowMessage('There were errors compiling the keyboard to convert to the On Screen Keyboard.');
@@ -3008,8 +3005,8 @@ begin
     end;
   finally
     w.Free;
+    DeleteFile(KMNFileName);
   end;
-  FreeAndNil(KMNFileName);   // I4181
   TProject.CompilerMessageFile := nil;
 end;
 


### PR DESCRIPTION
Fixes #9851.

Two fixes:

* errors from loading the displayMap from disk should be handled before passing result to next function
* temp compile of the .kmn for the 'fill from layout' function should be in the same path as the original .kmn, so that referenced files can be located

@keymanapp-test-bot skip

(User test involves setting up a `&displayMap` which is a bit too involved to be feasible right now...  I have tested locally.)