### PR TITLE
fix(linux): Fix uninstallation of shared keyboard

### DIFF
--- a/linux/keyman-config/keyman_config/gsettings.py
+++ b/linux/keyman-config/keyman_config/gsettings.py
@@ -74,10 +74,13 @@ class GSettings():
             else:
                 process = subprocess.run(args, capture_output=True)
                 if process.returncode == 0:
-                    value = eval(process.stdout)
-                else:
-                    value = None
-                    logging.warning('Could not convert to sources')
+                    output = process.stdout
+                    if output.decode('utf-8').startswith('['):
+                        value = eval(output)
+                        return value
+
+                logging.debug('Could not convert to sources')
+                return None
         else:
             variant = self.schema.get_value(key)
             value = self._convert_variant_to_array(variant)


### PR DESCRIPTION
This fixes the uninstallation of shared keyboards if the `additional-keyboards` settings doesn't exist yet.

Closes #9879.

# User Testing

## Preparations

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

- Install the shared hieroglyphic keyboard: `sudo km-package-install -s -p hieroglyphic`

## Tests

**TEST_WORKS**:

- Uninstall the shared keyboard: `sudo km-package-uninstall -s hieroglyphic`
- verify that there are no errors or warnings shown in the terminal