### PR TITLE
fix(web): fixes doc-kbd display of default layer when it's not defined first

### DIFF
--- a/web/src/engine/osk/src/keyboard-layout/oskLayerGroup.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskLayerGroup.ts
@@ -47,8 +47,8 @@ export default class OSKLayerGroup {
       const layerObj = new OSKLayer(vkbd, layout, layer);
       this.layers[layer.id] = layerObj;
 
-      // Always make the first layer visible
-      layerObj.element.style.display = (n==0 ? 'block' : 'none');
+      // Always make the 'default' layer visible by default.
+      layerObj.element.style.display = (layer.id == 'default' ? 'block' : 'none');
 
       // Add layer to group
       lDiv.appendChild(layerObj.element);

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1647,6 +1647,8 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     // Add a faint border
     kbd.style.border = '1px solid #ccc';
 
+    kbdObj.updateState(); // double-ensure that the 'default' layer is properly displayed.
+
     // Once the element is inserted into the DOM, refresh the layout so that proper text scaling may apply.
     const detectAndHandleInsertion = () => {
       if(document.contains(kbd)) {


### PR DESCRIPTION
Fixes #9654.

@keymanapp-test-bot skip