### PR TITLE
chore(mac): move from altool to notarytool 🍒 🏠

### DIFF
--- a/mac/build.sh
+++ b/mac/build.sh
@@ -448,7 +448,7 @@ if $PREPRELEASE || $NOTARIZE; then
 
     /usr/bin/ditto -c -k --keepParent "$TARGET_APP_PATH" "$TARGET_ZIP_PATH"
 
-    builder_heading "Uploading Keyman.zip to Apple for notarization"
+    echo_heading "Uploading Keyman.zip to Apple for notarization"
     mac_notarize "$TARGET_PATH" "$TARGET_ZIP_PATH"
 
     echo

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -462,9 +462,15 @@ if $PREPRELEASE || $NOTARIZE; then
         --output-format json \
         --wait \
         "$TARGET_ZIP_PATH" > "$NOTARYTOOL_LOG_PATH"
+    # notarytool output: {"status":"Accepted","id":"ca62bba0-6c49-43c2-90d8-83a8ef306e0f","message":"Processing complete"}
 
     cat "$NOTARYTOOL_LOG_PATH"
-    NOTARYTOOL_SUBMISSION_ID=`cat "$NOTARYTOOL_LOG_PATH"`
+    NOTARYTOOL_STATUS=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .status`
+    NOTARYTOOL_SUBMISSION_ID=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .id`
+    if [[ "$NOTARYTOOL_STATUS" != Accepted ]]; then
+        # We won't assume notarytool returns an error code if status != Accepted
+        builder_die "Notarization failed with $NOTARYTOOL_STATUS"
+    fi
 
     builder_heading "Notarization completed successfully. Review logs below for any warnings."
 

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -459,6 +459,7 @@ if $PREPRELEASE || $NOTARIZE; then
         --apple-id "$APPSTORECONNECT_USERNAME" \
         --team-id "$DEVELOPMENT_TEAM" \
         --password "$APPSTORECONNECT_PASSWORD" \
+        --output-format json \
         --wait \
         "$TARGET_ZIP_PATH" > "$NOTARYTOOL_LOG_PATH"
 

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-
-set -e
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}")"
@@ -11,6 +9,8 @@ KEYMAN_MAC_BASE_PATH="$KEYMAN_ROOT/mac"
 
 # Include our resource functions; they're pretty useful!
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/resources/build/build-help.inc.sh"
+. "$KEYMAN_ROOT/mac/mac-utils.inc.sh"
 
 # This script runs from its own folder
 cd "$(dirname "$THIS_SCRIPT")"
@@ -389,10 +389,6 @@ if $DO_KEYMANIM ; then
         ENTITLEMENTS_FILE=Keyman.entitlements
     fi
 
-    if [ -z "$DEVELOPMENT_TEAM" ]; then
-        DEVELOPMENT_TEAM=3YE4W86L3G
-    fi
-
     # We need to re-sign the app after updating the plist file
     if $DO_CODESIGN ; then
         execCodeSign --force --sign $CERTIFICATE_ID --timestamp --verbose --preserve-metadata=identifier,entitlements "$KM4MIM_BASE_PATH/build/$CONFIG/Keyman.app/Contents/Frameworks/Sentry.framework"
@@ -439,7 +435,6 @@ if $PREPRELEASE || $NOTARIZE; then
     TARGET_PATH="$KM4MIM_BASE_PATH/build/$CONFIG"
     TARGET_APP_PATH="$TARGET_PATH/$PRODUCT_NAME.app"
     TARGET_ZIP_PATH="$TARGET_PATH/$PRODUCT_NAME.zip"
-    NOTARYTOOL_LOG_PATH="$TARGET_PATH/notarytool.log"
 
     # Note: get-task-allow entitlement must be *off* in our release build (to do this, don't include base entitlements in project build settings)
 
@@ -453,32 +448,8 @@ if $PREPRELEASE || $NOTARIZE; then
 
     /usr/bin/ditto -c -k --keepParent "$TARGET_APP_PATH" "$TARGET_ZIP_PATH"
 
-    echo_heading "Uploading Keyman.zip to Apple for notarization"
-
-    xcrun notarytool submit \
-        --apple-id "$APPSTORECONNECT_USERNAME" \
-        --team-id "$DEVELOPMENT_TEAM" \
-        --password "$APPSTORECONNECT_PASSWORD" \
-        --output-format json \
-        --wait \
-        "$TARGET_ZIP_PATH" > "$NOTARYTOOL_LOG_PATH"
-    # notarytool output: {"status":"Accepted","id":"ca62bba0-6c49-43c2-90d8-83a8ef306e0f","message":"Processing complete"}
-
-    cat "$NOTARYTOOL_LOG_PATH"
-    NOTARYTOOL_STATUS=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .status`
-    NOTARYTOOL_SUBMISSION_ID=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .id`
-    if [[ "$NOTARYTOOL_STATUS" != Accepted ]]; then
-        # We won't assume notarytool returns an error code if status != Accepted
-        builder_die "Notarization failed with $NOTARYTOOL_STATUS"
-    fi
-
-    builder_heading "Notarization completed successfully. Review logs below for any warnings."
-
-    xcrun notarytool log \
-        --apple-id "$APPSTORECONNECT_USERNAME" \
-        --team-id "$DEVELOPMENT_TEAM" \
-        --password "$APPSTORECONNECT_PASSWORD" \
-        "$NOTARYTOOL_SUBMISSION_ID"
+    builder_heading "Uploading Keyman.zip to Apple for notarization"
+    mac_notarize "$TARGET_PATH" "$TARGET_ZIP_PATH"
 
     echo
     echo_heading "Attempting to staple notarization to Keyman.app"

--- a/mac/mac-utils.inc.sh
+++ b/mac/mac-utils.inc.sh
@@ -26,7 +26,7 @@ function mac_notarize() {
       builder_die "Notarization failed with $NOTARYTOOL_STATUS"
   fi
 
-  builder_heading "Notarization completed successfully. Review logs below for any warnings."
+  echo_heading "Notarization completed successfully. Review logs below for any warnings."
 
   xcrun notarytool log \
         --apple-id "$APPSTORECONNECT_USERNAME" \

--- a/mac/mac-utils.inc.sh
+++ b/mac/mac-utils.inc.sh
@@ -1,0 +1,38 @@
+
+if [ -z "${DEVELOPMENT_TEAM+x}" ]; then
+    DEVELOPMENT_TEAM=3YE4W86L3G
+fi
+
+function mac_notarize() {
+  local TARGET_PATH="$1"
+  local TARGET_FILE="$2"
+
+  local NOTARYTOOL_LOG_PATH="$TARGET_PATH/notarytool.log"
+
+  xcrun notarytool submit \
+      --apple-id "$APPSTORECONNECT_USERNAME" \
+      --team-id "$DEVELOPMENT_TEAM" \
+      --password "$APPSTORECONNECT_PASSWORD" \
+      --output-format json \
+      --wait \
+      "$TARGET_FILE" > "$NOTARYTOOL_LOG_PATH"
+  # notarytool output: {"status":"Accepted","id":"ca62bba0-6c49-43c2-90d8-83a8ef306e0f","message":"Processing complete"}
+
+  cat "$NOTARYTOOL_LOG_PATH"
+  local NOTARYTOOL_STATUS=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .status`
+  local NOTARYTOOL_SUBMISSION_ID=`cat "$NOTARYTOOL_LOG_PATH" | jq -r .id`
+  if [[ "$NOTARYTOOL_STATUS" != Accepted ]]; then
+      # We won't assume notarytool returns an error code if status != Accepted
+      builder_die "Notarization failed with $NOTARYTOOL_STATUS"
+  fi
+
+  builder_heading "Notarization completed successfully. Review logs below for any warnings."
+
+  xcrun notarytool log \
+        --apple-id "$APPSTORECONNECT_USERNAME" \
+        --team-id "$DEVELOPMENT_TEAM" \
+        --password "$APPSTORECONNECT_PASSWORD" \
+        "$NOTARYTOOL_SUBMISSION_ID"
+
+  rm -f "$NOTARYTOOL_LOG_PATH"
+}

--- a/mac/setup/build.sh
+++ b/mac/setup/build.sh
@@ -83,10 +83,10 @@ echo_heading "Zipping Install Keyman.app for notarization to $TARGET_ZIP_PATH"
 
 /usr/bin/ditto -c -k --keepParent "$TARGET_APP_PATH" "$TARGET_ZIP_PATH"
 
-builder_heading "Uploading Install Keyman.zip to Apple for notarization"
+echo_heading "Uploading Install Keyman.zip to Apple for notarization"
 mac_notarize "$TARGETPATH" "$TARGET_ZIP_PATH"
 
-builder_heading "Attempting to staple notarization to Install Keyman.app"
+echo_heading "Attempting to staple notarization to Install Keyman.app"
 xcrun stapler staple "$TARGET_APP_PATH" || builder_die "stapler failed"
 
 # Done.


### PR DESCRIPTION
Fixes #6881.
Cherry-pick of #9010. Fixed up 17.0-isms in scripts.

Change has been applied to stable-16.0 in order to meet Apple deadline of 1 Nov for shutdown of altool.

References for the transition to notarytool:

https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool?changes=_3_3
https://keith.github.io/xcode-man-pages/notarytool.1.html
@keymanapp-test-bot skip