### PR TITLE
fix(developer): Project MRU now saves correctly

### DIFF
--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -362,6 +362,8 @@ type
     function OpenModelEditor(FFileName: string): TfrmTikeEditor;
     procedure DoCloseCleanup;
 
+    procedure RefreshProjectMRU;
+
   protected
     procedure WndProc(var Message: TMessage); override;
     procedure CreateWnd; override;
@@ -512,10 +514,11 @@ begin
   modActionsMain := TmodActionsMain.Create(Self);
   modActionsModelEditor := TmodActionsModelEditor.Create(Self);
 
+  FChildWindows := TChildWindowList.Create;
+
   FProjectMRU := TMRUList.Create('Project');
   FProjectMRU.OnChange := ProjectMRUChange;
-
-  FChildWindows := TChildWindowList.Create;
+  FProjectMRU.Load;
 
   ShowDebug(False);
 
@@ -863,6 +866,9 @@ var
   i: Integer;
 begin
   FWndProcInit := False;
+
+  RefreshProjectMRU;
+
   for i := 0 to FChildWindows.Count - 1 do
     if FChildWindows[i] is TfrmTikeEditor then
       with FChildWindows[i] as TfrmTikeEditor do
@@ -1548,6 +1554,11 @@ begin
   finally
     Screen.Cursor := crDefault;
   end;
+end;
+
+procedure TfrmKeymanDeveloper.RefreshProjectMRU;
+begin
+  FProjectMRU.Load;
 end;
 
 function TfrmKeymanDeveloper.ProjectForm: TfrmProject;

--- a/developer/src/tike/main/mrulist.pas
+++ b/developer/src/tike/main/mrulist.pas
@@ -30,24 +30,26 @@ uses
 
 type
   TMRUList = class
-    FMRU: TStrings;
   private
-    FMRUName: WideString;
+    FMRU: TStrings;
+    FMRUName: string;
     FOnChange: TNotifyEvent;
-    function GetFile(Index: Integer): WideString;
+    function GetFile(Index: Integer): string;
     function GetFileCount: Integer;
     procedure Change;
+    procedure Save;
   public
-    constructor Create(AMRUName: WideString);
+    constructor Create(AMRUName: string);
     destructor Destroy; override;
-    procedure Delete(FileName: WideString);
-    procedure Add(FileName: WideString);
-    procedure Append(FileName: WideString);
-    procedure Open(FileName: WideString);
+    procedure Load;
+    procedure Delete(FileName: string);
+    procedure Add(FileName: string);
+    procedure Append(FileName: string);
+    procedure Open(FileName: string);
     procedure SaveListToXML(FileName: string);
     property FileCount: Integer read GetFileCount;
-    property Files[Index: Integer]: WideString read GetFile;
-    function EllipsisFile(Index: Integer): WideString;
+    property Files[Index: Integer]: string read GetFile;
+    function EllipsisFile(Index: Integer): string;
     property OnChange: TNotifyEvent read FOnChange write FOnChange;
   end;
 
@@ -65,7 +67,82 @@ uses
 
 { TMRUList }
 
-procedure TMRUList.Add(FileName: WideString);
+procedure TMRUList.Change;
+begin
+  Save;
+  if Assigned(FOnChange) then
+    FOnChange(Self);
+end;
+
+constructor TMRUList.Create(AMRUName: string);
+begin
+  inherited Create;
+  FMRUName := AMRUName;
+  FMRU := TStringList.Create;
+end;
+
+procedure TMRUList.Load;
+var
+  s: TStringList;
+  i: Integer;
+  name: string;
+  reg: TRegistryErrorControlled;
+  FNewMRU: TStringList;
+begin
+  if FMRUName = '' then
+    Exit;
+
+  FNewMRU := TStringList.Create;
+  try
+    reg := TRegistryErrorControlled.Create;
+    try
+      if reg.OpenKey(SRegKey_IDEFiles_CU, True) and
+        reg.OpenKey(FMRUName, True) then
+      begin
+        s := TStringList.Create;
+        try
+          reg.GetValueNames(s);
+          s.Sort;
+          for i := 0 to s.Count - 1 do
+          begin
+            name := reg.ReadString(s[i]);
+            if FileExists(name) and (FNewMRU.IndexOf(name) < 0) then
+              FNewMRU.Add(name);
+          end;
+        finally
+          s.Free;
+        end;
+      end;
+    finally
+      reg.Free;
+    end;
+
+    if FNewMRU.Text = FMRU.Text then
+    begin
+      // No changes to MRU
+      Exit;
+    end;
+
+    FMRU.Text := FNewMRU.Text;
+  finally
+    FNewMRU.Free;
+  end;
+
+  if FMRU.Count > 9 then
+  begin
+    while FMRU.Count > 9 do
+      FMRU.Delete(9);
+    Change;
+  end
+  else if Assigned(FOnChange) then
+  begin
+    // Don't use 'Change' here because we just loaded, and don't need to 'Save'
+    // as well as notify
+    FOnChange(Self);
+  end;
+end;
+
+procedure TMRUList.Add(FileName: string);
 var
   n: Integer;
 begin
@@ -83,7 +160,7 @@ begin
   Change;
 end;
 
-procedure TMRUList.Append(FileName: WideString);
+procedure TMRUList.Append(FileName: string);
 var
   n: Integer;
 begin
@@ -103,48 +180,7 @@ begin
   end;
 end;
 
-procedure TMRUList.Change;
-begin
-  if Assigned(FOnChange) then
-    FOnChange(Self);
-end;
-
-constructor TMRUList.Create(AMRUName: WideString);
-var
-  s: TStringList;
-  i: Integer;
-begin
-  inherited Create;
-  FMRUName := AMRUName;
-  FMRU := TStringList.Create;
-  if FMRUName <> '' then
-  begin
-    with TRegistryErrorControlled.Create do  // I2890
-    try
-      if OpenKeyReadOnly(SRegKey_IDEFiles_CU) then
-        if OpenKeyReadOnly(FMRUName) then
-        begin
-          s := TStringList.Create;
-          try
-            GetValueNames(s);
-            s.Sort;
-            for i := 0 to s.Count - 1 do
-            begin
-              if FileExists(s[i]) then
-                FMRU.Add(ReadString(s[i]))
-            end;
-          finally
-            s.Free;
-          end;
-        end;
-    finally
-      Free;
-    end;
-    while FMRU.Count > 9 do FMRU.Delete(9);
-  end;
-end;
-
-procedure TMRUList.Delete(FileName: WideString);
+procedure TMRUList.Delete(FileName: string);
 var
   n: Integer;
 begin
@@ -156,48 +192,7 @@ begin
   end;
 end;
 
-destructor TMRUList.Destroy;
-var
-  i: Integer;
-begin
-  if FMRUName <> '' then
-    with TRegistryErrorControlled.Create do  // I2890
-    try
-      if OpenKey(SRegKey_IDEFiles_CU, True) then
-      begin
-        if KeyExists(FMRUName) then DeleteKey(FMRUName);
-        if OpenKey(FMRUName, True) then
-          for i := 0 to FMRU.Count - 1 do
-            WriteString('File'+IntToStr(i), FMRU[i]);
-      end;
-    finally
-      Free;
-    end;
-  FMRU.Free;
-  inherited Destroy;
-end;
-
-function TMRUList.EllipsisFile(Index: Integer): WideString;
-begin
-  Result := Files[Index];
-
-  if PathCompactPath(0, PWideChar(Result), GetSystemMetrics(SM_CXSCREEN) div 3) then   // I4697
-    Result := string(PChar(Result))  // This removes the terminating nul
-  else
-    Result := ExtractFileName(Files[Index]);
-end;
-
-function TMRUList.GetFile(Index: Integer): WideString;
-begin
-  Result := FMRU[Index];
-end;
-
-function TMRUList.GetFileCount: Integer;
-begin
-  Result := FMRU.Count;
-end;
-
-procedure TMRUList.Open(FileName: WideString);
+procedure TMRUList.Open(FileName: string);
 var
   n: Integer;
 begin
@@ -207,6 +202,52 @@ begin
     FMRU.Move(n, 0);
     Change;
   end;
+end;
+
+procedure TMRUList.Save;
+var
+  i: Integer;
+begin
+  if FMRUName = '' then Exit;
+
+  with TRegistryErrorControlled.Create do  // I2890
+  try
+    if OpenKey(SRegKey_IDEFiles_CU, True) then
+    begin
+      if KeyExists(FMRUName) then DeleteKey(FMRUName);
+      if OpenKey(FMRUName, True) then
+        for i := 0 to FMRU.Count - 1 do
+          WriteString('File'+IntToStr(i), FMRU[i]);
+    end;
+  finally
+    Free;
+  end;
+end;
+
+destructor TMRUList.Destroy;
+begin
+  FMRU.Free;
+  inherited Destroy;
+end;
+
+function TMRUList.EllipsisFile(Index: Integer): string;
+begin
+  Result := Files[Index];
+
+  if PathCompactPath(0, PWideChar(Result), GetSystemMetrics(SM_CXSCREEN) div 3) then   // I4697
+    Result := string(PChar(Result))  // This removes the terminating nul
+  else
+    Result := ExtractFileName(Files[Index]);
+end;
+
+function TMRUList.GetFile(Index: Integer): string;
+begin
+  Result := FMRU[Index];
+end;
+
+function TMRUList.GetFileCount: Integer;
+begin
+  Result := FMRU.Count;
 end;
 
 procedure TMRUList.SaveListToXML(FileName: string);


### PR DESCRIPTION
Fixes #9899.

Several problems resolved here:
* project mru did not refresh the welcome screen on first load, so the welcome screen was often showing projects that were no longer relevant
* content saved to registry did not match expectations on load, so mru never worked between sessions (always flushed on reload)
* synchronization between simultaneous sessions of TIKE did not work, because the list was only saved when Keyman Developer exited -- meaning the last exited instance of TIKE would overwrite the MRU from earlier sessions, losing the projects opened in those sessions.

Minor tidyup:
* WideString -> string -- legacy cleanup from when Delphi was non-Unicode.
* Reordered functions to group more clearly.

Note: the issue was not that there was both registry and xml content; the source of truth is the registry for Project MRU, and project_mru.xml is copied from that for the welcome screen. So instead of taking the fix recommended in #9899, have addressed this by fixing the above points in the registry code.

# User Testing

* **TEST_WELCOME:** Open Keyman Developer, load a project. Select Project/Close Project. The project name should appear in the list in the Welcome screen. Close Keyman Developer, restart it. The project name should _still_ appear in the list in the Welcome screen, and if you click it, the project should open.

* **TEST_MULTI_SESSION:** Open three instances of Keyman Developer, and open projects in two of the instances. In the third instance, close the project (Project/Close Project). Open various projects in the first two instances. As you switch projects in the other two instances, the list of projects in the third instance should show this (you will need to focus to the third instance in order to see the list refresh).