### PR TITLE
fix(developer): enable line breaks in debugger

### DIFF
--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -759,9 +759,15 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
         begin
           Assert(m >= 1);
           Assert(memo.Text[m] <> #$FFFC);
+          // Delete surrogate pairs
           if (m > 1) and
               Uni_IsSurrogate2(memo.Text[m]) and
               Uni_IsSurrogate1(memo.Text[m-1]) then
+            Dec(m, 2)
+          // Delete \r\n line breaks
+          else if (m > 1) and
+              (memo.Text[m] = #$0A) and
+              (memo.Text[m-1] = #$0D) then
             Dec(m, 2)
           else
             Dec(m);
@@ -894,7 +900,8 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
     state: TMemoSelectionState;
   begin
     state := SaveMemoSelectionState;
-    memo.SelText := Text;
+    // Line breaks: replace \n with \r\n so line breaks work
+    memo.SelText := ReplaceStr(Text, #$0D, #$0D#$0A);
     memo.SelStart := memo.SelStart + memo.SelLength;  // I1603
     memo.SelLength := 0;
     RealignMemoSelectionState(state);

--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -900,7 +900,7 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
     state: TMemoSelectionState;
   begin
     state := SaveMemoSelectionState;
-    // Line breaks: replace \n with \r\n so line breaks work
+    // Line breaks: replace \r (0x0D) with \r\n (0x0D 0x0A) so line breaks work
     memo.SelText := ReplaceStr(Text, #$0D, #$0D#$0A);
     memo.SelStart := memo.SelStart + memo.SelLength;  // I1603
     memo.SelLength := 0;


### PR DESCRIPTION
Fixes #9444.

# User Testing

* **TEST_DEBUGGER_ENTER_KEY:** In the Keyman Developer keyboard debugger, type text, then press Enter. Verify that a new line is inserted, and that the debugger character grid shows `000D` and `000A` values.
* **TEST_DEBUGGER_BKSP_KEY:** In the Keyman Developer keyboard debugger, type text, then press Enter. Press Bksp to delete the new line. Verify that both `000D` and `000A` values are deleted with a single press of Bksp.