### PR TITLE
fix(linux): Fix environment for Debian packages

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -16,10 +16,8 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       VERSION: ${{ steps.version_step.outputs.VERSION }}
-      PRERELEASE_TAG: ${{ steps.prerelease_tag.outputs.PRERELEASE_TAG }}
       GIT_SHA: ${{ steps.set_status.outputs.GIT_SHA }}
-      GHA_TEST_BUILD: ${{ github.event.client_payload.isTestBuild }}
-      GHA_BRANCH: ${{ github.event.client_payload.branch }}
+      PRERELEASE_TAG: ${{ steps.prerelease_tag.outputs.PRERELEASE_TAG }}
     steps:
     - name: Checkout
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
@@ -53,10 +51,14 @@ jobs:
         ./scripts/deb-packaging.sh --gha dependencies
 
     - name: Build source package
+      id: build_source_package
       run: |
-        TIER=$(cat TIER.md)
-        export TIER
+        export TIER=$(cat TIER.md)
+        export GHA_TEST_BUILD="${{ github.event.client_payload.isTestBuild }}"
+        export GHA_BRANCH="${{ github.event.client_payload.branch }}"
         echo "TIER=$TIER" >> $GITHUB_ENV
+        echo "GHA_TEST_BUILD=${GHA_TEST_BUILD}" >> $GITHUB_ENV
+        echo "GHA_BRANCH=${GHA_BRANCH}" >> $GITHUB_ENV
         cd linux
         ./scripts/deb-packaging.sh --gha source
 

--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -38,3 +38,7 @@ help/reference/
 
 # Debian watch file - we generate it from watch.in
 watch
+# Debian quilt metadata
+.pc/
+# Debian patch files will be re-generated
+debian/patches/

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -26,6 +26,7 @@ Build-Depends:
  python3-requests,
  python3-requests-cache,
  python3-setuptools,
+ quilt,
  meson (>= 0.53),
  ninja-build,
  libevdev-dev,

--- a/linux/scripts/reconf.sh
+++ b/linux/scripts/reconf.sh
@@ -25,6 +25,12 @@ cd "$BASEDIR/keyman-config"
 ./build.sh clean
 
 cd "$BASEDIR/keyman-config/keyman_config"
+export QUILT_PATCHES="${BASEDIR}/debian/patches"
+export QUILT_REFRESH_ARGS="-p ab --no-timestamps --no-index"
+quilt push -a || true
+quilt new version_py.diff
+quilt add "version.py"
+
 sed \
     -e "s/_VERSION_/${VERSION}/g" \
     -e "s/_VERSIONWITHTAG_/${VERSION_WITH_TAG}/g" \
@@ -35,5 +41,7 @@ sed \
     -e "s/_ENVIRONMENT_/${VERSION_ENVIRONMENT}/g" \
     -e "s/_UPLOADSENTRY_/${UPLOAD_SENTRY}/g" \
     version.py.in > version.py
+quilt refresh
+quilt pop -a
 cd ../buildtools && python3 ./build-langtags.py
 cd "$BASEDIR"


### PR DESCRIPTION
When didn't set the correct environment when building Debian packages with GitHub actions. The version information wasn't included in the source file but instead was generated at binary package build time, at which time not all necessary environment variables were available. This change will create a patch file on-the-fly which gets included in the source package that contains the correct information.

Fixes #9878.

@keymanapp-test-bot skip

