### PR TITLE
fix(developer): use KeymanWeb.Codes for 17.0+

### DIFF
--- a/developer/src/kmc-kmn/src/kmw-compiler/compiler-globals.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/compiler-globals.ts
@@ -46,3 +46,7 @@ export function IsKeyboardVersion14OrLater(): boolean {
 export function IsKeyboardVersion15OrLater(): boolean {
   return fk.fileVersion >= KMX.KMXFile.VERSION_150;
 }
+
+export function IsKeyboardVersion17OrLater(): boolean {
+  return fk.fileVersion >= KMX.KMXFile.VERSION_170;
+}

--- a/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler.ts
@@ -1,6 +1,6 @@
 import { KMX, CompilerOptions, CompilerCallbacks, KvkFileReader, VisualKeyboard, KmxFileReader, KvkFile } from "@keymanapp/common-types";
 import { ExpandSentinel, incxstr, xstrlen } from "./util.js";
-import { options, nl, FTabStop, setupGlobals, IsKeyboardVersion10OrLater, callbacks, FFix183_LadderLength, FCallFunctions, fk } from "./compiler-globals.js";
+import { options, nl, FTabStop, setupGlobals, IsKeyboardVersion10OrLater, callbacks, FFix183_LadderLength, FCallFunctions, fk, IsKeyboardVersion17OrLater } from "./compiler-globals.js";
 import { JavaScript_ContextMatch, JavaScript_KeyAsString, JavaScript_Name, JavaScript_OutputString, JavaScript_Rules, JavaScript_Shift, JavaScript_ShiftAsString, JavaScript_Store, zeroPadHex } from './javascript-strings.js';
 import { KmwCompilerMessages } from "./messages.js";
 import { ValidateLayoutFile } from "./validate-layout-file.js";
@@ -435,8 +435,13 @@ function GetKeyboardModifierBitmask(keyboard: KMX.KEYBOARD, fMnemonic: boolean):
 function JavaScript_SetupDebug() {
   if(IsKeyboardVersion10OrLater()) {
     if(options.saveDebug) {
-      return 'var modCodes = keyman.osk.modifierCodes;'+nl+
-             FTabStop+'var keyCodes = keyman.osk.keyCodes;'+nl;
+      if(IsKeyboardVersion17OrLater()) {
+        return 'var modCodes = KeymanWeb.Codes.modifierCodes;'+nl+
+              FTabStop+'var keyCodes = KeymanWeb.Codes.keyCodes;'+nl;
+      } else {
+        return 'var modCodes = keyman.osk.modifierCodes;'+nl+
+              FTabStop+'var keyCodes = keyman.osk.keyCodes;'+nl;
+      }
     }
   }
   return '';


### PR DESCRIPTION
Fixes #8147.

Keyboards debug-compiled for web 17.0+ will use `KeymanWeb.Codes.` instead of `keyman.osk.`.

# User Testing

* **TEST_DEBUGGER:** Create a new keyboard in Developer, and set its `store(&VERSION)` line to '17.0'. Compile the keyboard, and test it in the web debugger. Verify that the keyboard loads in Keyman Developer Server in the browser and that there are no Javascript errors (you will need to look at the Javascript console to be certain)