### PR TITLE
fix(developer): layout builder - maintain presentation during undo

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/builder.js
+++ b/developer/src/tike/xml/layoutbuilder/builder.js
@@ -40,14 +40,16 @@ $(function() {
     builder.selectSubKey(subKey);
   }
 
-  $('#selPlatformPresentation').change(function () {
+  builder.selPlatformPresentationChange = function () {
     let lastSelection = builder.saveSelection();
     builder.selectKey(null, false);
     builder.selectSubKey(null);
     builder.prepareLayer();
     builder.restoreSelection(lastSelection);
     builder.saveState();
-  });
+  }
+
+  $('#selPlatformPresentation').change(builder.selPlatformPresentationChange);
 
   builder.removeAllSubKeys = function() {
     $('#sub-key-groups .key').remove();

--- a/developer/src/tike/xml/layoutbuilder/undo.js
+++ b/developer/src/tike/xml/layoutbuilder/undo.js
@@ -25,6 +25,8 @@ $(function() {
   this.loadUndo = function (s) {
     KVKL = JSON.parse(s.KVKL);
 
+    const lastPresentation = $('#selPlatformPresentation').val();
+
     builder.preparePlatforms();
     builder.enableUndoControls();
 
@@ -34,6 +36,15 @@ $(function() {
     builder.selectLayer();
     builder.selectKey($('#kbd .key').filter(function (index) { return $(this).data('id') === s.key; }).first());
     if (s.subkey) builder.selectSubKey($('#sub-key-groups .key').filter(function (index) { return $(this).data('id') === s.subkey; }).first());
+
+    // If we are on the same platform, restore the user's current presentation,
+    // which has been reset by the earlier `preparePlatforms()` call. We can't
+    // manage this across platforms because the presentation values are unique
+    // per platform
+    if($(`#selPlatformPresentation option[value="${lastPresentation}"]`).length) {
+      $('#selPlatformPresentation').val(lastPresentation);
+      builder.selPlatformPresentationChange();
+    }
   }
 
   this.saveUndo = function (saveToRedo) {


### PR DESCRIPTION
Fixes #7852.

When undo is run in the layout builder, it is better to keep the user's selected presentation if possible. (The selected presentation is not stored in the undo stack, but is a view property affected by the currently selected platform.)

# User Testing

* **TEST_UNDO:** In the Touch Layout tab of the keyboard editor, in View Controls, select 'iPad (Portait)' or 'iPhone (Portait)'. Make a change to the layout, and then press Ctrl+Z to undo (or use the Undo toolbar button). The view should remain as a portait view, and not switch back to landscape.