### PR TITLE
fix(developer): don't use osk-always-visible on touch devices

### DIFF
--- a/developer/src/server/src/site/index.html
+++ b/developer/src/server/src/site/index.html
@@ -21,7 +21,7 @@
     <link href="inc/keyboards.css" type="text/css" rel="stylesheet" /> <!-- This script loads the dynamic keyboard fonts -->
   </head>
 
-  <body class='osk-always-visible'>
+  <body>
 
     <header class='navbar navbar-dark bg-dark text-white'>
       <div class='container-fluid'>

--- a/developer/src/server/src/site/test.js
+++ b/developer/src/server/src/site/test.js
@@ -42,6 +42,10 @@ function enableControls(enable) {
 let keymanInitialized = false;
 enableControls(false);
 
+if(!keyman.util.isTouchDevice()) {
+  document.body.className = 'osk-always-visible';
+}
+
 keyman.init({
   ui:'button',
   resources:'/resource/',


### PR DESCRIPTION
Fixes #9845.

It seems that the logic for `osk-always-visible` is not quite right on touch devices -- the OSK disappears on blur but remains touchable -- so presses in the OSK region emit key events. For Keyman Developer Server, the simple workaround is to only use `<body class="osk-always-visible">` when on desktop devices.

We should review the logic for `osk-always-visible` in KeymanWeb, so that this issue does not arise on touch devices. This patch addresses the issue in Keyman Developer Server, and matches the behaviour we want on touch devices in any case, as we don't really want the OSK visible when blurred, unlike on desktop.

# User Testing

* **TEST_INVISIBLE_OSK_ON_TOUCH_DEVICE:** Open Keyman Developer Server on a touch device (or in touch device emulation in Chrome); ensure there is a Keyman keyboard active for testing. Touch on the touch OSK to input some text into the test box. Then touch outside the text box to hide the OSK. Then, touch where the OSK _was_ visible. This should _no longer_ cause text to be inserted into the test box.