### PR TITLE
fix(developer): restore selection in layout builder even with duplicate ids

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/builder.js
+++ b/developer/src/tike/xml/layoutbuilder/builder.js
@@ -863,10 +863,17 @@ $(function() {
 
   this.rescale = function () {
     builder.saveUndo();
-    var keyId = builder.selectedKey().data('id');
+    const k = builder.selectedKey();
+    const keyId = k.data('id');
+    const keyItems = $('#kbd .key').filter((_index,item) => $(item).data('id') === keyId);
+    const keyItemIndex = keyItems.indexOf(k.length ? k[0] : null);
     builder.prepareLayer();
-    if (keyId !== null)
-      builder.selectKey($('#kbd .key').filter(function (index) { return $(this).data('id') === keyId; }).first());
+    if (keyId !== null && keyItemIndex >= 0) {
+      const newKeyItems = $('#kbd .key').filter((_index,item) => $(item).data('id') === keyId);
+      if(keyItemIndex < newKeyItems.length) {
+        builder.selectKey(newKeyItems[keyItemIndex]);
+      }
+    }
   };
 
   this.translateFlickArrayToObject = function(flicks) {


### PR DESCRIPTION
Fixes #7851.

Note that this fixes the selection pop issue with duplicate ids in some scenarios but not all. For example, the undo stack doesn't have enough detail at this point to be able to track this. This fix addresses the most egregious issue relating to key size adjustment and similar.

# User Testing

* **TEST_KEY_RESIZE:** Open a touch layout, and give two keys on the same layer the same ID (e.g. `K_Q`). Select each key in turn and resize it by dragging on the right hand border. When you resize, the selected key should remain the same -- previously the selection would jump to the first key with the same ID.