### PR TITLE
chore(developer): remove obsolete 'Allow Multiple Instances' and 'Use Legacy Compiler' options

### DIFF
--- a/common/windows/delphi/general/RegistryKeys.pas
+++ b/common/windows/delphi/general/RegistryKeys.pas
@@ -103,8 +103,7 @@ const
 
   SRegValue_Engine_OEMProductPath = 'oem product path';
 
-//  SRegValue_UnknownLayoutID         = 'unknown layout id';                          // LM
-    SRegValue_Legacy_Default_UnknownLayoutID = '000005FE';   // I4220
+  SRegValue_Legacy_Default_UnknownLayoutID = '000005FE';   // I4220
 
   SRegValue_KeymanDebug             = 'debug';                                      // CU
 
@@ -112,10 +111,7 @@ const
 
   SRegValue_ShowStartup             = 'show startup';                        // CU
   SRegValue_ShowWelcome             = 'show welcome';                        // CU
-  //SRegValue_NoCheckAssociations     = 'no check associations';                      // CU
   SRegValue_UseAdvancedInstall      = 'use advanced install';                       // CU
-
-//TOUCH    SRegValue_UseTouchLayout          = 'use touch layout';                           // CU, default false
 
   SRegValue_AltGrCtrlAlt                = 'simulate altgr';                         // CU
   SRegValue_KeyboardHotKeysAreToggle    = 'hotkeys are toggles';                    // CU
@@ -170,9 +166,6 @@ const
 
   SRegValue_DeadkeyConversionMode       = 'deadkey conversion mode';                // CU   // I4552
   SRegValue_UnderlyingLayout            = 'underlying layout';                      // CU
-
-//  SRegKey_AppInitDLLs                   = 'Software\Microsoft\Windows NT\CurrentVersion\Windows';  // LM
-//  SRegValue_AppInitDLLs                 = 'AppInit_DLLs';                                          // LM
 
   SRegKey_KeyboardLayoutToggle          = 'keyboard layout\toggle';                 // CU  // I2522
   SRegValue_Toggle_Hotkey               = 'Hotkey';
@@ -272,10 +265,6 @@ const
   SRegValue_CPIUP_CachedLanguageName = 'CachedLanguageName';
   SRegValue_CPIUP_InputMethodOverride = 'InputMethodOverride';
 
-  { User profile keys }
-
-  //SRegKey_NTProfileList = 'Software\Microsoft\Windows NT\CurrentVersion\ProfileList';
-
   { Font keys }
 
   SRegKey_FontList_LM   = 'Software\Microsoft\Windows\CurrentVersion\Fonts';           // LM
@@ -318,13 +307,6 @@ const
   SRegKey_IDETestFonts_CU        = SRegKey_IDE_CU                 + '\TestFonts';           // CU
   SRegKey_IDEVisualKeyboard_CU   = SRegKey_IDE_CU                 + '\VisualKeyboard';      // CU
   SRegKey_IDEToolbars_CU         = SRegKey_IDE_CU                 + '\Toolbars';            // CU
-//  SRegKey_KCT                 = SRegKey_KeymanDeveloper_CU     + '\KCT';               // LM CU
-//  SRegKey_KCTFiles            = SRegKey_KCT_CU                 + '\Files';             // CU
-
-//  SRegKey_IDEOnline          = SRegKey_IDE_CU                + '\Online';              // CU
-//  SRegKey_IDE_BrandingPackTest = SRegKey_IDE_CU              + '\Branding Pack\Test';  // CU   // I4873
-
-//  SRegKey_CRM                = SRegKey_KeymanDeveloper    + '\CRM';                 // CU
 
   SRegValue_CheckForUpdates   = 'check for updates'; // CU
   SRegValue_LastUpdateCheckTime = 'last update check time'; // CU
@@ -335,8 +317,6 @@ const
 
   SRegValue_KeepInTouchShown = 'keep in touch shown'; // CU. bool   // I4658
 
-  //SRegValue_OnlineUsername    = 'online username';
-  //SRegValue_OnlinePassword    = 'online password';
   SRegValue_OnlineLogin = 'online login';
 
   { SRegKey_CRM values }
@@ -349,7 +329,6 @@ const
 
   { SRegKey_KeymanDeveloper values }
 
-  //SRegValue_ShowStartup             = 'show startup';                           // CU -- see Keyman option of same name
   SRegValue_Evaluation              = 'evaluation';                                 // CU
   SRegValue_ActiveProject           = 'active project';                             // CU
 
@@ -364,7 +343,6 @@ const
 
   SRegValue_IDEMRU                 = 'MRU';                                        // CU
   SRegValue_CharMapSize             = 'char map size';                              // CU
-//SRegValue_IDERegressionTestPath  = 'regression test path';                       // CU
 
   { SRegKey_IDEVisualKeyboard values }
 
@@ -393,8 +371,6 @@ const
   SRegValue_IDEOptAutoSaveBeforeCompiling = 'auto save before compiling'; // CU
   SRegValue_IDEOptOSKAutoSaveBeforeImporting = 'osk auto save before importing'; // CU
 
-  SRegValue_IDEOptUseLegacyCompiler = 'use legacy compiler'; // CU
-
   // Note: keeping 'web host port' reg value name to ensure settings maintained
   //       from version 14.0 and earlier of Keyman Developer. Other values are
   //       new with Keyman Developer 15.0
@@ -409,8 +385,6 @@ const
   SRegValue_IDEOptCharMapDisableDatabaseLookups = 'char map disable database lookups';  // CU
   SRegValue_IDEOptCharMapAutoLookup             = 'char map auto lookup';               // CU
 
-  SRegValue_IDEOptMultipleInstances = 'multiple instances';                         // CU
-
   SRegValue_IDEOptOpenKeyboardFilesInSourceView = 'open keyboard files in source view';  // CU   // I4751
 
   SRegValue_IDEDisplayTheme = 'display theme';   // I4796
@@ -424,10 +398,6 @@ const
   CRegValue_IDEOpt_WebLadderLength_Default = 100;
 
   SRegValue_IDEOpt_DefaultProjectPath = 'default project path';
-
-  { SRegKey_KCT values }
-
-//  SRegValue_KCTTemplatePath = 'template path';                                      // LM
 
 {-------------------------------------------------------------------------------
  - Shared keys and values                                                      -

--- a/common/windows/delphi/general/UserMessages.pas
+++ b/common/windows/delphi/general/UserMessages.pas
@@ -42,10 +42,6 @@ const
   WM_USER_CheckFonts = WM_USER + 115;
 
 const
-  // KeymanDeveloperUtils
-  WM_USER_LOADREGFILES = WM_USER+120;
-  //WM_USER_FORMSHOWN = WM_USER+100;
-
   WC_COMMAND = 0;
   WC_HELP = 1;
   WC_OPENURL = 2;

--- a/developer/src/tike/dialogs/UfrmOptions.dfm
+++ b/developer/src/tike/dialogs/UfrmOptions.dfm
@@ -25,21 +25,21 @@ inherited frmOptions: TfrmOptions
       Caption = 'General'
       ImageIndex = 2
       object cmdProxySettings: TButton
-        Left = 8
-        Top = 209
+        Left = 7
+        Top = 185
         Width = 125
         Height = 25
         Caption = '&Proxy Settings...'
-        TabOrder = 5
+        TabOrder = 4
         OnClick = cmdProxySettingsClick
       end
       object gbExternalEditor: TGroupBox
-        Left = 8
-        Top = 71
+        Left = 7
+        Top = 47
         Width = 401
         Height = 45
         Caption = '&External Editor Path'
-        TabOrder = 2
+        TabOrder = 1
         object editExternalEditorPath: TEdit
           Left = 8
           Top = 16
@@ -57,46 +57,38 @@ inherited frmOptions: TfrmOptions
         end
       end
       object cmdSMTPSettings: TButton
-        Left = 8
-        Top = 240
+        Left = 7
+        Top = 216
         Width = 125
         Height = 25
         Caption = 'S&MTP Settings...'
-        TabOrder = 6
+        TabOrder = 5
         OnClick = cmdSMTPSettingsClick
       end
       object chkOpenKeyboardFilesInSourceView: TCheckBox
-        Left = 8
-        Top = 36
+        Left = 7
+        Top = 12
         Width = 221
         Height = 17
         Caption = 'Open &keyboard files in source view'
-        TabOrder = 1
+        TabOrder = 0
       end
       object cmdResetToolWindows: TButton
-        Left = 8
-        Top = 178
+        Left = 7
+        Top = 154
         Width = 125
         Height = 25
         Caption = '&Reset tool windows'
-        TabOrder = 4
+        TabOrder = 3
         OnClick = cmdResetToolWindowsClick
       end
-      object chkAllowMultipleInstances: TCheckBox
-        Left = 8
-        Top = 12
-        Width = 289
-        Height = 17
-        Caption = '&Allow multiple instances of Keyman Developer'
-        TabOrder = 0
-      end
       object gbDefaultProjectPath: TGroupBox
-        Left = 8
-        Top = 122
+        Left = 7
+        Top = 98
         Width = 401
         Height = 45
         Caption = '&Default Project Folder'
-        TabOrder = 3
+        TabOrder = 2
         object editDefaultProjectPath: TEdit
           Left = 8
           Top = 16
@@ -115,28 +107,28 @@ inherited frmOptions: TfrmOptions
         end
       end
       object chkAutoSaveBeforeCompiling: TCheckBox
-        Left = 152
-        Top = 182
+        Left = 151
+        Top = 158
         Width = 218
         Height = 17
         Caption = '&Automatically save before compiling'
-        TabOrder = 7
+        TabOrder = 6
       end
       object chkOSKAutoSaveBeforeImporting: TCheckBox
-        Left = 152
-        Top = 205
+        Left = 151
+        Top = 181
         Width = 218
         Height = 17
         Caption = '&Automatically save before importing OSK'
-        TabOrder = 8
+        TabOrder = 7
       end
       object gbPrivacy: TGroupBox
-        Left = 8
-        Top = 280
+        Left = 7
+        Top = 256
         Width = 401
         Height = 73
         Caption = 'Privacy'
-        TabOrder = 10
+        TabOrder = 8
         object chkReportUsage: TCheckBox
           Left = 8
           Top = 44
@@ -153,14 +145,6 @@ inherited frmOptions: TfrmOptions
           Caption = 'Automatically report &errors to keyman.com'
           TabOrder = 0
         end
-      end
-      object chkUseLegacyCompiler: TCheckBox
-        Left = 152
-        Top = 244
-        Width = 250
-        Height = 17
-        Caption = 'Use legacy .kmn compiler (removing in 18.0)'
-        TabOrder = 9
       end
     end
     object tabEditor: TTabSheet

--- a/developer/src/tike/dialogs/UfrmOptions.pas
+++ b/developer/src/tike/dialogs/UfrmOptions.pas
@@ -90,7 +90,6 @@ type
     cbEditorTheme: TComboBox;
     lblEditorCustomTheme: TLabel;
     lblEditorTheme: TLabel;
-    chkAllowMultipleInstances: TCheckBox;
     gbDefaultProjectPath: TGroupBox;
     editDefaultProjectPath: TEdit;
     cmdBrowseDefaultProjectPath: TButton;
@@ -105,7 +104,6 @@ type
     gbServer: TGroupBox;
     chkListLocalURLs: TCheckBox;
     cmdConfigureServer: TButton;
-    chkUseLegacyCompiler: TCheckBox;
     procedure FormCreate(Sender: TObject);
     procedure cmdOKClick(Sender: TObject);
     procedure cmdDefaultFontClick(Sender: TObject);
@@ -195,12 +193,8 @@ begin
     chkAutoSaveBeforeCompiling.Checked :=          AutoSaveBeforeCompiling;
     chkOSKAutoSaveBeforeImporting.Checked :=       OSKAutoSaveBeforeImporting;
 
-    chkUseLegacyCompiler.Checked := UseLegacyCompiler;
-
     chkCharMapAutoLookup.Checked := CharMapAutoLookup;
     chkCharMapDisableDatabaseLookups.Checked := CharMapDisableDatabaseLookups;
-
-    chkAllowMultipleInstances.Checked := AllowMultipleInstances;
 
     chkOpenKeyboardFilesInSourceView.Checked := OpenKeyboardFilesInSourceView;   // I4751
 
@@ -298,14 +292,10 @@ begin
     AutoSaveBeforeCompiling          := chkAutoSaveBeforeCompiling.Checked;
     OSKAutoSaveBeforeImporting       := chkOSKAutoSaveBeforeImporting.Checked;
 
-    UseLegacyCompiler := chkUseLegacyCompiler.Checked;
-
     ServerUseLocalAddresses := chkListLocalURLs.Checked;
 
     CharMapAutoLookup := chkCharMapAutoLookup.Checked;
     CharMapDisableDatabaseLookups := chkCharMapDisableDatabaseLookups.Checked;
-
-    AllowMultipleInstances := chkAllowMultipleInstances.Checked;
 
     OpenKeyboardFilesInSourceView := chkOpenKeyboardFilesInSourceView.Checked;   // I4751
 

--- a/developer/src/tike/main/KeymanDeveloperOptions.pas
+++ b/developer/src/tike/main/KeymanDeveloperOptions.pas
@@ -49,7 +49,6 @@ type
     FCharMapAutoLookup: Boolean;
     FCharMapDisableDatabaseLookups: Boolean;
     FDebuggerAutoRecompileWithDebugInfo: Boolean;
-    FAllowMultipleInstances: Boolean;
     FExternalEditorPath: WideString;
     FServerDefaultPort: Integer;   // I4021
     FSMTPServer: string;   // I4506
@@ -70,7 +69,6 @@ type
     FServerNgrokToken: string;
     FServerNgrokRegion: string;
     FServerKeepAlive: Boolean;
-    FUseLegacyCompiler: Boolean;
     procedure CloseRegistry;
     procedure OpenRegistry;
     function regReadString(const nm, def: string): string;
@@ -105,8 +103,6 @@ type
     property AutoSaveBeforeCompiling: Boolean read FAutoSaveBeforeCompiling write FAutoSaveBeforeCompiling;
     property OSKAutoSaveBeforeImporting: Boolean read FOSKAutoSaveBeforeImporting write FOSKAutoSaveBeforeImporting;
 
-    property UseLegacyCompiler: Boolean read FUseLegacyCompiler write FUseLegacyCompiler;
-
     property ReportErrors: Boolean read FReportErrors write FReportErrors;
     property ReportUsage: Boolean read FReportUsage write FReportUsage;
 
@@ -118,8 +114,6 @@ type
     property ServerNgrokRegion: string read FServerNgrokRegion write FServerNgrokRegion;
     property ServerUseNgrok: Boolean read FServerUseNgrok write FServerUseNgrok;
     property ServerServerShowConsoleWindow: Boolean read FServerServerShowConsoleWindow write FServerServerShowConsoleWindow;
-
-    property AllowMultipleInstances: Boolean read FAllowMultipleInstances write FAllowMultipleInstances;
 
     property OpenKeyboardFilesInSourceView: Boolean read FOpenKeyboardFilesInSourceView write FOpenKeyboardFilesInSourceView;   // I4751
     property DefaultProjectPath: string read FDefaultProjectPath write FDefaultProjectPath;
@@ -218,8 +212,6 @@ begin
     FAutoSaveBeforeCompiling := regReadBool(SRegValue_IDEOptAutoSaveBeforeCompiling, False);
     FOSKAutoSaveBeforeImporting := regReadBool(SRegValue_IDEOptOSKAutoSaveBeforeImporting, False);
 
-    FUseLegacyCompiler := regReadBool(SRegValue_IDEOptUseLegacyCompiler, False);
-
     FServerDefaultPort := regReadInt(SRegValue_IDEOptServerPort, 8008);
     FServerKeepAlive := regReadBool(SRegValue_IDEOptServerKeepAlive, False);
     FServerUseLocalAddresses := regReadBool(SRegValue_IDEOptServerUseLocalAddresses, True);
@@ -231,8 +223,6 @@ begin
 
     FCharMapDisableDatabaseLookups := regReadBool(SRegValue_IDEOptCharMapDisableDatabaseLookups, False);
     FCharMapAutoLookup             := regReadBool(SRegValue_IDEOptCharMapAutoLookup,             True);
-
-    FAllowMultipleInstances := regReadBool(SRegValue_IDEOptMultipleInstances, False);
 
     FOpenKeyboardFilesInSourceView  := regReadBool(SRegValue_IDEOptOpenKeyboardFilesInSourceView,  False);   // I4751
 
@@ -281,8 +271,6 @@ begin
     regWriteBool(SRegValue_IDEOptAutoSaveBeforeCompiling, FAutoSaveBeforeCompiling);
     regWriteBool(SRegValue_IDEOptOSKAutoSaveBeforeImporting, FOSKAutoSaveBeforeImporting);
 
-    regWriteBool(SRegValue_IDEOptUseLegacyCompiler, FUseLegacyCompiler);
-
     regWriteInt(SRegValue_IDEOptServerPort, FServerDefaultPort);
     regWriteBool(SRegValue_IDEOptServerKeepAlive, FServerKeepAlive);
     regWriteBool(SRegValue_IDEOptServerUseLocalAddresses, FServerUseLocalAddresses);
@@ -295,8 +283,6 @@ begin
 
     regWriteBool(SRegValue_IDEOptCharMapDisableDatabaseLookups, FCharMapDisableDatabaseLookups);
     regWriteBool(SRegValue_IDEOptCharMapAutoLookup,             FCharMapAutoLookup);
-
-    regWriteBool(SRegValue_IDEOptMultipleInstances,             FAllowMultipleInstances);
 
     regWriteBool(SRegValue_IDEOptOpenKeyboardFilesInSourceView,  FOpenKeyboardFilesInSourceView);   // I4751
 

--- a/developer/src/tike/main/KeymanDeveloperUtils.pas
+++ b/developer/src/tike/main/KeymanDeveloperUtils.pas
@@ -62,7 +62,6 @@ const
   MAX_REG_FONT_ENTRIES = 16;
 
 function GetFolderPath(csidl: Integer): string;
-function TikeActive: Boolean;
 function CreateLink(const ObjPath, LinkPath, Desc: string): Boolean;
 procedure SetFontFromString(f: TFont; s: string);
 function FontAsString(f: TFont): string;
@@ -94,9 +93,6 @@ uses
      KeymanVersion, VisualKeyboard, Controls;
 
 function GetKMShellPath(var ps: string): Boolean; forward;  // I3655
-
-var
-  hMutex: THandle;
 
 type
 { IPersist interface }
@@ -190,54 +186,6 @@ begin
             mm.Free(idl);
         end;
     end;
-end;
-
-function TikeActive: Boolean;
-var
-  handle: THandle;
-  i: Integer;
-  FMultiInstance: Boolean;
-begin
-  with TRegistryErrorControlled.Create do  // I2890
-  try
-    if OpenKeyReadOnly(SRegKey_IDEOptions_CU) and ValueExists(SRegValue_IDEOptMultipleInstances)
-      then FMultiInstance := ReadString(SRegValue_IDEOptMultipleInstances) = '1'
-      else FMultiInstance := False;
-  finally
-    Free;
-  end;
-
-  if FMultiInstance then
-  begin
-    Result := False;
-    Exit;
-  end;
-
-  hMutex := CreateMutex(nil, True, 'Tavultesoft Integrated Keyboard Editor Mutex');
-  if GetLastError = ERROR_ALREADY_EXISTS then
-  begin
-    handle := FindWindow('TfrmKeymanDeveloper', nil);   // I4264
-    if (handle <> 0) then
-    begin
-      with TRegistryErrorControlled.Create do  // I2890
-      try
-        RootKey := HKEY_CURRENT_USER;
-        if not OpenKey(SRegKey_IDEFiles_CU, True) then  // I2890
-          RaiseLastRegistryError;
-        for i := 1 to ParamCount do
-        begin
-          WriteString(IntToStr(i), ExpandFileNameClean(IncludeTrailingPathDelimiter(GetCurrentDir), ParamStr(i)));   // I4749   // I4749
-        end;
-      finally
-        Free;
-      end;
-      PostMessage(handle, WM_USER_LOADREGFILES, 0, 0);
-      SetForegroundWindow(handle);
-    end;
-    Result := True;
-  end
-  else
-    Result := False;
 end;
 
 function FontAsString(f: TFont): string;

--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -327,7 +327,6 @@ type
 
     //procedure ChildWindowsChange(Sender: TObject);
     procedure WMUserFormShown(var Message: TMessage); message WM_USER_FORMSHOWN;
-    procedure WMUserLoadRegFiles(var Message: TMessage); message WM_USER_LOADREGFILES;
     procedure WMUserInputLangChange(var Message: TMessage); message WM_USER_INPUTLANGCHANGE;
 
     procedure UpdateFileMRU;
@@ -759,31 +758,6 @@ var
 begin
   for i := 0 to FChildWindows.Count - 1 do
     PostMessage(FChildWindows[i].Handle, WM_USER_INPUTLANGCHANGE, Message.wParam, Message.LParam);
-end;
-
-procedure TfrmKeymanDeveloper.WMUserLoadRegFiles(var Message: TMessage);
-var
-  i: Integer;
-  s: TStringList;
-  t: string;
-begin
-  s := TStringList.Create;
-  with TRegistryErrorControlled.Create do  // I2890
-  try
-    RootKey := HKEY_CURRENT_USER;
-    if not OpenKey(SRegKey_IDEFiles_CU, True) then  // I2890
-      RaiseLastRegistryError;
-
-    GetValueNames(s);
-    for i := 0 to s.Count - 1 do
-    begin
-      t := ReadString(s[i]);
-      DeleteValue(s[i]);
-      OpenFile(t, False);
-    end;
-  finally
-    Free;
-  end;
 end;
 
 const

--- a/developer/src/tike/tike.dpr
+++ b/developer/src/tike/tike.dpr
@@ -311,9 +311,8 @@ begin
           Application.MainFormOnTaskBar := True;
           Application.Initialize;
           Application.Title := 'Keyman Developer';
-          if TikeActive then Exit;
           Application.CreateForm(TmodWebHttpServer, modWebHttpServer);
-  try
+          try
             Application.CreateForm(TfrmKeymanDeveloper, frmKeymanDeveloper);
             Application.Run;
           finally


### PR DESCRIPTION
Fixes #9925.

Allow Multiple Instances is now always true.
Use Legacy Compiler did nothing (there is no legacy compiler!).

@keymanapp-test-bot skip