### PR TITLE
chore(common): remove prepublish step from package.json

### DIFF
--- a/common/web/types/package.json
+++ b/common/web/types/package.json
@@ -18,8 +18,7 @@
     "build": "tsc -b",
     "build:schema": "ajv compile",
     "lint": "eslint .",
-    "test": "npm run lint && cd test && tsc -b && cd .. && c8 --skip-full --reporter=lcov --reporter=text mocha",
-    "prepublishOnly": "npm run build"
+    "test": "npm run lint && cd test && tsc -b && cd .. && c8 --skip-full --reporter=lcov --reporter=text mocha"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",
   "license": "MIT",

--- a/developer/src/kmc-keyboard-info/package.json
+++ b/developer/src/kmc-keyboard-info/package.json
@@ -16,8 +16,7 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "eslint .",
-    "test": "npm run lint",
-    "prepublishOnly": "npm run build"
+    "test": "npm run lint"
   },
   "license": "MIT",
   "bugs": {

--- a/developer/src/kmc-kmn/package.json
+++ b/developer/src/kmc-kmn/package.json
@@ -18,8 +18,7 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "eslint .",
-    "test": "npm run lint && cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
-    "prepublishOnly": "npm run build"
+    "test": "npm run lint && cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",
   "license": "MIT",

--- a/developer/src/kmc-ldml/package.json
+++ b/developer/src/kmc-ldml/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "eslint .",
-    "test": "npm run lint && cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
-    "prepublishOnly": "npm run build"
+    "test": "npm run lint && cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",
   "license": "MIT",

--- a/developer/src/kmc-model-info/package.json
+++ b/developer/src/kmc-model-info/package.json
@@ -18,8 +18,7 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "eslint .",
-    "test": "npm run lint",
-    "prepublishOnly": "npm run build"
+    "test": "npm run lint"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",
   "contributors": [

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -18,8 +18,7 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "eslint .",
-    "test": "npm run lint && cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
-    "prepublishOnly": "npm run build"
+    "test": "npm run lint && cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",
   "contributors": [

--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -17,8 +17,7 @@
     "build": "tsc -b",
     "lint": "eslint .",
     "test": "npm run lint && cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha",
-    "coverage": "npm test",
-    "prepublishOnly": "npm run build"
+    "coverage": "npm test"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",
   "contributors": [

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -15,8 +15,7 @@
     "bundle-kmc": "esbuild build/src/kmc.js --bundle --platform=node --target=es2022 > build/cjs-src/kmc.cjs",
     "bundle-kmlmc": "esbuild build/src/kmlmc.js --bundle --platform=node --target=es2022 > build/cjs-src/kmlmc.cjs",
     "bundle-kmlmp": "esbuild build/src/kmlmp.js --bundle --platform=node --target=es2022 > build/cjs-src/kmlmp.cjs",
-    "test": "eslint . && cd test && tsc -b && cd .. && mocha",
-    "prepublishOnly": "npm run build"
+    "test": "eslint . && cd test && tsc -b && cd .. && mocha"
   },
   "type": "module",
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",


### PR DESCRIPTION
Given we've just run a build, this (a) seems unnecessary, and (b) seems to go wrong in some circumstances anyway, e.g. https://build.palaso.org/buildConfiguration/Keyman_Developer_Release/421326?buildTab=log&focusLine=19936&linesState=18839&logView=flowAware:

```
07:01:29   > @keymanapp/kmc@17.0.205-alpha prepublishOnly
07:01:29   > npm run build
07:01:29
07:01:31
07:01:31   > @keymanapp/kmc@17.0.205-alpha build
07:01:31   > tsc -b
07:01:31
07:01:35   ../../../common/web/types/build/src/kmx/kmx.d.ts(1,1): error TS1036: Statements are not allowed in ambient contexts.
07:01:35   ../../../common/web/types/build/src/kmx/kmx.d.ts(1,2): error TS1345: An expression of type 'void' cannot be tested for truthiness.
...
```

@keymanapp-test-bot skip