### PR TITLE
feat(developer): provide line number for some kmw compiler messages

### DIFF
--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -298,6 +298,12 @@ export class KmnCompiler implements UnicodeSetParser {
 
       if(wasm_result.extra.targets & COMPILETARGETS_JS) {
         wasm_options.target = 1; // CKF_KEYMANWEB TODO use COMPILETARGETS_JS
+
+        // We always want debug data in the intermediate .kmx, so that error
+        // messages from KMW compiler can give line numbers in .kmn. This
+        // should have no impact on the final .js if options.debug is false
+        wasm_options.saveDebug = true;
+
         wasm_result = Module.kmcmp_compile(infile, wasm_options, wasm_interface);
         if(!wasm_result.result) {
           return null;

--- a/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
@@ -233,7 +233,7 @@ export function JavaScript_Rules(keyboard: KMX.KEYBOARD, fMnemonic: boolean, fgp
 export function JavaScript_Shift(fkp: KMX.KEY, FMnemonic: boolean): number {
   if (FMnemonic) {
     if (fkp.ShiftFlags & KMX.KMXFile.VIRTUALCHARKEY) {
-      callbacks.reportMessage(KmwCompilerMessages.Error_VirtualCharacterKeysNotSupportedInKeymanWeb());
+      callbacks.reportMessage(KmwCompilerMessages.Error_VirtualCharacterKeysNotSupportedInKeymanWeb({line:fkp.Line}));
       return 0;
     }
 
@@ -241,7 +241,7 @@ export function JavaScript_Shift(fkp: KMX.KEY, FMnemonic: boolean): number {
       // We prohibit K_ keys for mnemonic layouts. We don't block T_ and U_ keys.
       // TODO: this doesn't resolve the issue of, e.g. SHIFT+K_SPACE
       // https://github.com/keymanapp/keyman/issues/265
-      callbacks.reportMessage(KmwCompilerMessages.Error_VirtualKeysNotValidForMnemonicLayouts());
+      callbacks.reportMessage(KmwCompilerMessages.Error_VirtualKeysNotValidForMnemonicLayouts({line:fkp.Line}));
       return 0;
     }
   }
@@ -254,13 +254,13 @@ export function JavaScript_Shift(fkp: KMX.KEY, FMnemonic: boolean): number {
 
     // Non-chiral support only and no support for state keys
     if (fkp.ShiftFlags & (KMX.KMXFile.LCTRLFLAG | KMX.KMXFile.RCTRLFLAG | KMX.KMXFile.LALTFLAG | KMX.KMXFile.RALTFLAG)) {   // I4118
-      callbacks.reportMessage(KmwCompilerMessages.Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb({flags: 'LALT, RALT, LCTRL, RCTRL'}));
+      callbacks.reportMessage(KmwCompilerMessages.Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb({line:fkp.Line, flags: 'LALT, RALT, LCTRL, RCTRL'}));
     }
 
     if (fkp.ShiftFlags & (
       KMX.KMXFile.CAPITALFLAG | KMX.KMXFile.NOTCAPITALFLAG | KMX.KMXFile.NUMLOCKFLAG | KMX.KMXFile.NOTNUMLOCKFLAG |
       KMX.KMXFile.SCROLLFLAG | KMX.KMXFile.NOTSCROLLFLAG)) {   // I4118
-      callbacks.reportMessage(KmwCompilerMessages.Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb({flags: 'CAPS and NCAPS'}));
+      callbacks.reportMessage(KmwCompilerMessages.Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb({line:fkp.Line, flags: 'CAPS and NCAPS'}));
     }
 
     return KMX.KMXFile.ISVIRTUALKEY | (fkp.ShiftFlags & (KMX.KMXFile.K_SHIFTFLAG | KMX.KMXFile.K_CTRLFLAG | KMX.KMXFile.K_ALTFLAG));
@@ -378,7 +378,7 @@ export function JavaScript_Key(fkp: KMX.KEY, FMnemonic: boolean): number {
 
   if (Result == 0 || Result >= TKeymanWebTouchStandardKey.K_LOPT) {   // I4141
     if(!FUnreachableKeys.includes(fkp)) {
-      callbacks.reportMessage(KmwCompilerMessages.Hint_UnreachableKeyCode({key: FormatKeyForErrorMessage(fkp,FMnemonic)}));
+      callbacks.reportMessage(KmwCompilerMessages.Hint_UnreachableKeyCode({line:fkp.Line, key: FormatKeyForErrorMessage(fkp,FMnemonic)}));
       FUnreachableKeys.push(fkp);
     }
   }
@@ -667,7 +667,7 @@ export function JavaScript_OutputString(fk: KMX.KEYBOARD, FTabStops: string, fkp
         // #917: Minimum version required is 14.0: the KCXO function was only added for 14.0
         // Note that this is checked in compiler.cpp as well, so this error can probably never occur
         if(!IsKeyboardVersion14OrLater()) {
-          callbacks.reportMessage(KmwCompilerMessages.Error_NotAnyRequiresVersion14());
+          callbacks.reportMessage(KmwCompilerMessages.Error_NotAnyRequiresVersion14({line:fkp.Line}));
         }
         Result += nlt + `k.KCXO(${len},t,${AdjustIndex(fkp.dpContext, xstrlen(fkp.dpContext))},${AdjustIndex(fkp.dpContext, ContextIndex)+1});`;
         break;

--- a/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
@@ -490,7 +490,7 @@ function JavaScript_CompositeContextValue(fk: KMX.KEYBOARD, fkp: KMX.KEY, pwsz: 
           `this.s${JavaScript_Name(rec.Any.StoreIndex, rec.Any.Store.dpName)})`;
         break;
       default:
-        callbacks.reportMessage(KmwCompilerMessages.Error_NotSupportedInKeymanWebContext({code: GetCodeName(rec.Code)}));
+        callbacks.reportMessage(KmwCompilerMessages.Error_NotSupportedInKeymanWebContext({line: fkp.Line, code: GetCodeName(rec.Code)}));
         Result += '/*.*/ 0 ';
       }
     }
@@ -579,7 +579,7 @@ function JavaScript_FullContextValue(fk: KMX.KEYBOARD, fkp: KMX.KEY, pwsz: strin
           `o:${rec.Index.Index}}`;   // I4611
         break;
       default:
-        callbacks.reportMessage(KmwCompilerMessages.Error_NotSupportedInKeymanWebContext({code: GetCodeName(rec.Code)}));
+        callbacks.reportMessage(KmwCompilerMessages.Error_NotSupportedInKeymanWebContext({line: fkp.Line, code: GetCodeName(rec.Code)}));
         Result += '/*.*/ 0 ';
       }
     }
@@ -677,7 +677,7 @@ export function JavaScript_OutputString(fk: KMX.KEYBOARD, FTabStops: string, fkp
           // These have no output for a context emit
           break;
       default:
-        callbacks.reportMessage(KmwCompilerMessages.Error_NotSupportedInKeymanWebContext({code: GetCodeName(recContext.Code)}));
+        callbacks.reportMessage(KmwCompilerMessages.Error_NotSupportedInKeymanWebContext({line: fkp.Line, code: GetCodeName(recContext.Code)}));
         Result += nlt + '/*.*/ ';   // I4611
       }
     }
@@ -885,7 +885,7 @@ export function JavaScript_OutputString(fk: KMX.KEYBOARD, FTabStops: string, fkp
         len = -1;
         break;
       default:
-        callbacks.reportMessage(KmwCompilerMessages.Error_NotSupportedInKeymanWebOutput({code: GetCodeName(rec.Code)}));
+        callbacks.reportMessage(KmwCompilerMessages.Error_NotSupportedInKeymanWebOutput({line: fkp.Line, code: GetCodeName(rec.Code)}));
         Result += '';
       }
     }

--- a/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
@@ -36,17 +36,17 @@ export class KmwCompilerMessages extends KmnCompilerMessages {
   static Warn_OptionStoreNameInvalid = (o:{name:string}) => m(this.WARN_OptionStoreNameInvalid,
     `The option store ${o.name} should be named with characters in the range A-Z, a-z, 0-9 and _ only.`);
 
-  static Error_VirtualCharacterKeysNotSupportedInKeymanWeb = () => m(this.ERROR_VirtualCharacterKeysNotSupportedInKeymanWeb,
-    `Virtual character keys not currently supported in KeymanWeb`);
+  static Error_VirtualCharacterKeysNotSupportedInKeymanWeb = (o:{line:number}) => m(this.ERROR_VirtualCharacterKeysNotSupportedInKeymanWeb,
+    `Virtual character keys not currently supported in KeymanWeb`, o);
 
-  static Error_VirtualKeysNotValidForMnemonicLayouts = () => m(this.ERROR_VirtualKeysNotValidForMnemonicLayouts,
-    `Virtual keys are not valid for mnemonic layouts`);
+  static Error_VirtualKeysNotValidForMnemonicLayouts = (o:{line:number}) => m(this.ERROR_VirtualKeysNotValidForMnemonicLayouts,
+    `Virtual keys are not valid for mnemonic layouts`, o);
 
-  static Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb = (o:{flags:string}) => m(this.WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb,
-    `Extended shift flags ${o.flags} are not supported in KeymanWeb`);
+  static Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb = (o:{line:number,flags:string}) => m(this.WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb,
+    `Extended shift flags ${o.flags} are not supported in KeymanWeb`, o);
 
-  static Hint_UnreachableKeyCode = (o:{key:string}) => m(this.HINT_UnreachableKeyCode,
-    `The rule will never be matched for key ${o.key} because its key code is never fired.`);
+  static Hint_UnreachableKeyCode = (o:{line:number,key:string}) => m(this.HINT_UnreachableKeyCode,
+    `The rule will never be matched for key ${o.key} because its key code is never fired.`, o);
 
   static Error_NotSupportedInKeymanWebStore = (o:{code:string,store:string}) => m(this.ERROR_NotSupportedInKeymanWebStore,
     `'${o.code}' is not currently supported in store '${o.store}' when used by any or index for web and touch targets`);
@@ -57,11 +57,11 @@ export class KmwCompilerMessages extends KmnCompilerMessages {
   static Error_NotSupportedInKeymanWebOutput = (o:{line:number, code:string}) => m(this.ERROR_NotSupportedInKeymanWebOutput,
     `Statement '${o.code}' is not currently supported in output for web and touch targets`, o);
 
-  static Warn_HelpFileMissing = (o:{filename: string, e:any}) => m(this.WARN_HelpFileMissing,
-    `File ${o.filename} could not be loaded: ${(o.e??'').toString()}`);
+  static Warn_HelpFileMissing = (o:{line:number, helpFilename:string, e:any}) => m(this.WARN_HelpFileMissing,
+    `File ${o.helpFilename} could not be loaded: ${(o.e??'').toString()}`,o);
 
-  static Warn_EmbedJsFileMissing = (o:{filename: string, e:any}) => m(this.WARN_EmbedJsFileMissing,
-    `File ${o.filename} could not be loaded: ${(o.e??'').toString()}`);
+  static Warn_EmbedJsFileMissing = (o:{line:number, jsFilename: string, e:any}) => m(this.WARN_EmbedJsFileMissing,
+    `File ${o.jsFilename} could not be loaded: ${(o.e??'').toString()}`, o);
 
   static Warn_TouchLayoutMissingLayer = (o:{keyId:string, platformName:string, layerId:string, nextLayer:string}) => m(this.WARN_TouchLayoutMissingLayer,
     `Key "${o.keyId}" on platform "${o.platformName}", layer "${o.layerId}", references a missing layer "${o.nextLayer}"`);
@@ -91,8 +91,8 @@ export class KmwCompilerMessages extends KmnCompilerMessages {
 
   // Following messages are kmw-compiler only, so use KmwCompiler error namespace
 
-  static Error_NotAnyRequiresVersion14 = () => m(this.ERROR_NotAnyRequiresVersion14,
-    `Statement notany in context() match requires version 14.0+ of KeymanWeb`);
+  static Error_NotAnyRequiresVersion14 = (o:{line: number}) => m(this.ERROR_NotAnyRequiresVersion14,
+    `Statement notany in context() match requires version 14.0+ of KeymanWeb`, o);
   static ERROR_NotAnyRequiresVersion14 = SevError | 0x0001;
 
   static Error_TouchLayoutIdentifierRequires15 = (o:{keyId:string, platformName:string, layerId:string}) => m(this.ERROR_TouchLayoutIdentifierRequires15,

--- a/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
@@ -1,5 +1,6 @@
 import { KmnCompilerMessages } from "../compiler/kmn-compiler-messages.js";
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec } from "@keymanapp/common-types";
+import { kmnfile } from "./compiler-globals.js";
 
 const Namespace = CompilerErrorNamespace.KmwCompiler;
 // const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -7,6 +8,12 @@ const Namespace = CompilerErrorNamespace.KmwCompiler;
 // const SevWarn = CompilerErrorSeverity.Warn | Namespace;
 const SevError = CompilerErrorSeverity.Error | Namespace;
 // const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
+
+const m = (code: number, message: string, o?: {e?: any, filename?: string, line?: number}) : CompilerEvent => ({
+  ...CompilerMessageSpec(code, message, o?.e),
+  filename: o?.filename ?? kmnfile,
+  line: o?.line,
+});
 
 export class KmwCompilerMessages extends KmnCompilerMessages {
   // Note: for legacy reasons, KMWCompilerMessages extends from
@@ -19,44 +26,66 @@ export class KmwCompilerMessages extends KmnCompilerMessages {
 
   static Error_InvalidBegin = () => m(this.ERROR_InvalidBegin,
     `A "begin unicode" statement is required to compile a KeymanWeb keyboard`);
+
   static Error_InvalidTouchLayoutFile = (o:{filename:string}) => m(this.ERROR_InvalidTouchLayoutFile,
     `Touch layout file ${o.filename} is not valid`);
+
   static Warn_DontMixChiralAndNonChiralModifiers = () => m(this.WARN_DontMixChiralAndNonChiralModifiers,
     `This keyboard contains Ctrl,Alt and LCtrl,LAlt,RCtrl,RAlt sets of modifiers. Use only one or the other set for web target.`);
+
   static Warn_OptionStoreNameInvalid = (o:{name:string}) => m(this.WARN_OptionStoreNameInvalid,
     `The option store ${o.name} should be named with characters in the range A-Z, a-z, 0-9 and _ only.`);
+
   static Error_VirtualCharacterKeysNotSupportedInKeymanWeb = () => m(this.ERROR_VirtualCharacterKeysNotSupportedInKeymanWeb,
     `Virtual character keys not currently supported in KeymanWeb`);
+
   static Error_VirtualKeysNotValidForMnemonicLayouts = () => m(this.ERROR_VirtualKeysNotValidForMnemonicLayouts,
     `Virtual keys are not valid for mnemonic layouts`);
+
   static Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb = (o:{flags:string}) => m(this.WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb,
     `Extended shift flags ${o.flags} are not supported in KeymanWeb`);
+
   static Hint_UnreachableKeyCode = (o:{key:string}) => m(this.HINT_UnreachableKeyCode,
     `The rule will never be matched for key ${o.key} because its key code is never fired.`);
+
   static Error_NotSupportedInKeymanWebStore = (o:{code:string,store:string}) => m(this.ERROR_NotSupportedInKeymanWebStore,
-    `${o.code} is not currently supported in store '${o.store}' when used by any or index`);
-  static Error_NotSupportedInKeymanWebContext = (o:{code:String}) => m(this.ERROR_NotSupportedInKeymanWebContext,
-    `Statement ${o.code} is not currently supported in context`);
-  static Error_NotSupportedInKeymanWebOutput = (o:{code:string}) => m(this.ERROR_NotSupportedInKeymanWebOutput,
-    `Statement ${o.code} is not currently supported in output`);
+    `'${o.code}' is not currently supported in store '${o.store}' when used by any or index for web and touch targets`);
+
+  static Error_NotSupportedInKeymanWebContext = (o:{line:number, code:String}) => m(this.ERROR_NotSupportedInKeymanWebContext,
+    `Statement '${o.code}' is not currently supported in context for web and touch targets`, o);
+
+  static Error_NotSupportedInKeymanWebOutput = (o:{line:number, code:string}) => m(this.ERROR_NotSupportedInKeymanWebOutput,
+    `Statement '${o.code}' is not currently supported in output for web and touch targets`, o);
+
   static Warn_HelpFileMissing = (o:{filename: string, e:any}) => m(this.WARN_HelpFileMissing,
     `File ${o.filename} could not be loaded: ${(o.e??'').toString()}`);
+
   static Warn_EmbedJsFileMissing = (o:{filename: string, e:any}) => m(this.WARN_EmbedJsFileMissing,
     `File ${o.filename} could not be loaded: ${(o.e??'').toString()}`);
+
   static Warn_TouchLayoutMissingLayer = (o:{keyId:string, platformName:string, layerId:string, nextLayer:string}) => m(this.WARN_TouchLayoutMissingLayer,
     `Key "${o.keyId}" on platform "${o.platformName}", layer "${o.layerId}", references a missing layer "${o.nextLayer}"`);
+
   static Warn_TouchLayoutUnidentifiedKey = (o:{layerId:string}) => m(this.WARN_TouchLayoutUnidentifiedKey,
     `A key on layer "${o.layerId}" has no identifier.`);
+
   static Error_TouchLayoutInvalidIdentifier = (o:{keyId:string, platformName: string, layerId:string}) => m(this.ERROR_TouchLayoutInvalidIdentifier,
     `Key "${o.keyId}" on "${o.platformName}", layer "${o.layerId}" has an invalid identifier.`);
+
   static Warn_TouchLayoutCustomKeyNotDefined = (o:{keyId:string, platformName:string, layerId:string}) => m(this.WARN_TouchLayoutCustomKeyNotDefined,
     `Key "${o.keyId}" on platform "${o.platformName}", layer "${o.layerId}", is a custom key but has no corresponding rule in the source.`);
-  static Warn_TouchLayoutSpecialLabelOnNormalKey = (o:{keyId:string, platformName:string, layerId:string, label:string}) => m(this.WARN_TouchLayoutSpecialLabelOnNormalKey,
-    `Key "${o.keyId}" on platform "${o.platformName}", layer "${o.layerId}" does not have the key type "Special" or "Special (active)" but has the label "${o.label}". This feature is only supported in Keyman 14 or later`);
+
+  static Warn_TouchLayoutSpecialLabelOnNormalKey = (o:{keyId:string, platformName:string, layerId:string, label:string}) =>
+    m(this.WARN_TouchLayoutSpecialLabelOnNormalKey,
+    `Key "${o.keyId}" on platform "${o.platformName}", layer "${o.layerId}" does not have `+
+    `the key type "Special" or "Special (active)" but has the label "${o.label}". This feature is only supported in Keyman 14 or later`);
+
   static Error_InvalidKeyCode = (o:{keyId: string}) => m(this.ERROR_InvalidKeyCode,
     `Invalid key identifier "${o.keyId}"`);
+
   static Warn_TouchLayoutFontShouldBeSameForAllPlatforms = () => m(this.WARN_TouchLayoutFontShouldBeSameForAllPlatforms,
     `The touch layout font should be the same for all platforms.`);
+
   static Warn_TouchLayoutMissingRequiredKeys = (o:{layerId:string, platformName:string, missingKeys:string}) => m(this.WARN_TouchLayoutMissingRequiredKeys,
     `Layer "${o.layerId}" on platform "${o.platformName}" is missing the required key(s) '${o.missingKeys}'.`);
 

--- a/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler.ts
@@ -53,6 +53,12 @@ export function WriteCompiledKeyboard(
 
   setupGlobals(callbacks, opts, FDebug?'  ':'', FDebug?'\r\n':'', kmxResult, keyboard, kmnfile);
 
+  const isStoreType = (index:number, type: number) => !!(kmxResult.extra.stores[index].storeType & type);
+  const isDebugStore = (index: number) => isStoreType(index, STORETYPE_DEBUG);
+  const isReservedStore = (index: number) => isStoreType(index, STORETYPE_RESERVED);
+  const isOptionStore = (index: number) => isStoreType(index, STORETYPE_OPTION);
+  const getStoreLine = (index: number) => kmxResult.extra.stores[index].line;
+
   let vMnemonic: number = 0;
   let sRTL: string = "", sHelp: string = "''", sHelpFile: string = "",
       sEmbedJSFilename: string = "", sEmbedCSSFilename: string = "";
@@ -63,6 +69,7 @@ export function WriteCompiledKeyboard(
   let sModifierBitmask: string;
   let FOptionStores: string;
   let FKeyboardVersion = "1.0";
+  let sHelpFileStoreIndex, sEmbedJSStoreIndex, sEmbedCSSStoreIndex;
 
   let result = "";
 	// Locate the name of the keyboard
@@ -76,6 +83,7 @@ export function WriteCompiledKeyboard(
     }
     else if (fsp.dpName == 'HelpFile' || fsp.dwSystemID == KMX.KMXFile.TSS_KMW_HELPFILE) {
       sHelpFile = fsp.dpString;
+      sHelpFileStoreIndex = i;
     }
     else if (fsp.dpName == 'Help' || fsp.dwSystemID == KMX.KMXFile.TSS_KMW_HELPTEXT) {
       sHelp = '"'+RequotedString(fsp.dpString)+'"';
@@ -85,9 +93,11 @@ export function WriteCompiledKeyboard(
     }
     else if (fsp.dpName == 'EmbedJS' || fsp.dwSystemID == KMX.KMXFile.TSS_KMW_EMBEDJS) {
       sEmbedJSFilename = fsp.dpString;
+      sEmbedJSStoreIndex = i;
     }
     else if (fsp.dpName == 'EmbedCSS' || fsp.dwSystemID == KMX.KMXFile.TSS_KMW_EMBEDCSS) {   // I4368
       sEmbedCSSFilename = fsp.dpString;
+      sEmbedCSSStoreIndex = i;
     }
     else if (fsp.dpName == 'RTL' || fsp.dwSystemID == KMX.KMXFile.TSS_KMW_RTL) {
       sRTL = fsp.dpString == '1' ? FTabStop+'this.KRTL=1;'+nl : '';   // I3681
@@ -121,7 +131,7 @@ export function WriteCompiledKeyboard(
       sHelp = html.replace(/\r/g, '').replace(/\n/g, ' ');
       sHelp = requote(sHelp);
     } catch(e) {
-      callbacks.reportMessage(KmwCompilerMessages.Warn_HelpFileMissing({filename: sHelpFile, e}));
+      callbacks.reportMessage(KmwCompilerMessages.Warn_HelpFileMissing({line: getStoreLine(sHelpFileStoreIndex), helpFilename: sHelpFile, e}));
       sHelp = '';
     }
   }
@@ -133,7 +143,7 @@ export function WriteCompiledKeyboard(
       const data = callbacks.loadFile(sEmbedJSFilename);
       sEmbedJS = new TextDecoder().decode(data);
     } catch(e) {
-      callbacks.reportMessage(KmwCompilerMessages.Warn_EmbedJsFileMissing({filename: sEmbedJSFilename, e}));
+      callbacks.reportMessage(KmwCompilerMessages.Warn_EmbedJsFileMissing({line: getStoreLine(sEmbedJSStoreIndex), jsFilename: sEmbedJSFilename, e}));
       sEmbedJS = '';
     }
   }
@@ -147,7 +157,7 @@ export function WriteCompiledKeyboard(
       if(sEmbedCSS != '' && !sEmbedCSS.endsWith('\r\n')) sEmbedCSS += '\r\n';  // match CompileKeymanWeb.pas
     } catch(e) {
       // TODO(lowpri): rename error constant to Warn_EmbedFileMissing
-      callbacks.reportMessage(KmwCompilerMessages.Warn_EmbedJsFileMissing({filename: sEmbedCSSFilename, e}));
+      callbacks.reportMessage(KmwCompilerMessages.Warn_EmbedJsFileMissing({line: getStoreLine(sEmbedCSSStoreIndex), jsFilename: sEmbedCSSFilename, e}));
       sEmbedCSS = '';
     }
   }
@@ -221,12 +231,6 @@ export function WriteCompiledKeyboard(
   if (sEmbedCSS != '') {   // I4368
     result += `${FTabStop}this.KCSS="${RequotedString(sEmbedCSS)}";${nl}`;
   }
-
-  const isStoreType = (index:number, type: number) => !!(kmxResult.extra.stores[index].storeType & type);
-  const isDebugStore = (index: number) => isStoreType(index, STORETYPE_DEBUG);
-  const isReservedStore = (index: number) => isStoreType(index, STORETYPE_RESERVED);
-  const isOptionStore = (index: number) => isStoreType(index, STORETYPE_OPTION);
-  const getStoreLine = (index: number) => kmxResult.extra.stores[index].line;
 
 	// Write the stores out
   FOptionStores = '';

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_not_supported_in_keyman_web_output.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_not_supported_in_keyman_web_output.kmn
@@ -1,0 +1,11 @@
+c Tests ERROR_NotSupportedInKeymanWebOutput for `return`
+
+store(&NAME) 'ERROR_NotSupportedInKeymanWebOutput'
+store(&VERSION) '9.0'
+store(&TARGETS) 'web'
+
+begin unicode > use(main)
+
+group(main) using keys
+
++ 'a' > return

--- a/developer/src/kmc-kmn/test/test-messages.ts
+++ b/developer/src/kmc-kmn/test/test-messages.ts
@@ -84,7 +84,7 @@ describe('CompilerMessages', function () {
 
   it('should generate ERROR_NotSupportedInKeymanWebOutput if a rule has `return` in the output', async function() {
     await testForMessage(this, ['invalid-keyboards', 'error_not_supported_in_keyman_web_output.kmn'], KmnCompilerMessages.ERROR_NotSupportedInKeymanWebOutput);
-    assert.equal(callbacks.messages[0].message, "Statement \"return\" is not currently supported in output");
+    assert.equal(callbacks.messages[0].message, "Statement 'return' is not currently supported in output for web and touch targets");
   });
 
 });

--- a/developer/src/kmc-kmn/test/test-messages.ts
+++ b/developer/src/kmc-kmn/test/test-messages.ts
@@ -80,4 +80,11 @@ describe('CompilerMessages', function () {
     assert.equal(callbacks.messages[0].message, "A key on layer \"default\" has no identifier.");
   });
 
+  // ERROR_NotSupportedInKeymanWebOutput
+
+  it('should generate ERROR_NotSupportedInKeymanWebOutput if a rule has `return` in the output', async function() {
+    await testForMessage(this, ['invalid-keyboards', 'error_not_supported_in_keyman_web_output.kmn'], KmnCompilerMessages.ERROR_NotSupportedInKeymanWebOutput);
+    assert.equal(callbacks.messages[0].message, "Statement \"return\" is not currently supported in output");
+  });
+
 });


### PR DESCRIPTION
Fixes #9931.

Provide additional line and file context for some KeymanWeb compiler messages. This change requires debug data in the intermediate kmx data provided to the kmw compiler, which should have no impact on the final .js if `options.debug==false`.

The following messages have had line number context added:
* `Error_NotSupportedInKeymanWebContext`
* `Error_NotSupportedInKeymanWebOutput`
* `Error_VirtualCharacterKeysNotSupportedInKeymanWeb`
* `Error_VirtualKeysNotValidForMnemonicLayouts`
* `Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb`
* `Hint_UnreachableKeyCode`
* `Warn_HelpFileMissing`
* `Warn_EmbedJsFileMissing`
* `Error_NotAnyRequiresVersion14`

Line number metadata is not easily accessible where the following messages are generated, so these are a potential future improvement:
* `Warn_OptionStoreNameInvalid`
* `Error_NotSupportedInKeymanWebStore`

A unit test has been added for `Error_NotSupportedInKeymanWebOutput`, but not for the other messages.

Potential future improvements to unit tests:
* Tests for the other messages listed here
* Tests for line number correctness

@keymanapp-test-bot skip