### PR TITLE
fix(developer): resilience in loading Server config and cache files

### DIFF
--- a/developer/src/server/src/config.ts
+++ b/developer/src/server/src/config.ts
@@ -1,4 +1,5 @@
-import * as fs from 'fs';
+import { mkdirSync } from 'fs';
+import { loadJsonFile } from './load-json-file.js';
 
 export class Configuration {
   public readonly appDataPath: string;
@@ -34,13 +35,9 @@ export class Configuration {
     this.pidFilename = this.appDataPath + 'pid.json';
     this.configFilename = this.appDataPath + 'config.json';
 
-    fs.mkdirSync(this.cachePath, { recursive: true});
+    mkdirSync(this.cachePath, { recursive: true});
 
-    let cfg = null;
-    if(fs.existsSync(this.configFilename)) {
-      const data = fs.readFileSync(this.configFilename, 'utf-8');
-      cfg = JSON.parse(data);
-    }
+    const cfg = loadJsonFile(this.configFilename);
 
     this.port = cfg?.port ?? 8008;
 

--- a/developer/src/server/src/data.ts
+++ b/developer/src/server/src/data.ts
@@ -1,5 +1,6 @@
-import * as fs from 'fs';
+import { writeFileSync } from 'fs';
 import { configuration } from './config.js';
+import { loadJsonFile } from './load-json-file.js';
 
 export interface DebugObject {
   id: string;
@@ -96,7 +97,7 @@ export class SiteData {
   }
 
   private loadState() {
-    const state = fs.existsSync(configuration.cacheStateFilename) ? JSON.parse(fs.readFileSync(configuration.cacheStateFilename, 'utf-8')) : null;
+    const state = loadJsonFile(configuration.cacheStateFilename);
     this.loadDebugObject(DebugKeyboard, state?.keyboards, this.keyboards);
     this.loadDebugObject(DebugModel, state?.models, this.models);
     this.loadDebugObject(DebugFont, state?.fonts, this.fonts);
@@ -105,7 +106,7 @@ export class SiteData {
   }
 
   public saveState() {
-    fs.writeFileSync(configuration.cacheStateFilename, JSON.stringify(this, null, 2), 'utf-8');
+    writeFileSync(configuration.cacheStateFilename, JSON.stringify(this, null, 2), 'utf-8');
   }
 };
 

--- a/developer/src/server/src/load-json-file.ts
+++ b/developer/src/server/src/load-json-file.ts
@@ -1,0 +1,14 @@
+import { KeymanSentry } from '@keymanapp/developer-utils';
+import { readFileSync, existsSync } from 'fs';
+
+export function loadJsonFile(filename: string): any {
+  try {
+    return existsSync(filename) ?
+      JSON.parse(readFileSync(filename, 'utf-8')) :
+      null;
+  } catch(e: any) {
+    console.error(`Error loading ${filename}: ${(e ?? '').toString()}`);
+    KeymanSentry.reportException(e);
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes #9848.

Root cause of #9848 is unknown, because the cache state file was filled with nul bytes. It is unclear how that could have happened, but seems likely to be external interference.

The cascade was that Server failed to start because it would crash when attempting to load the cache state file. So this fix resolves that by handling invalid file exceptions.

@keymanapp-test-bot skip