### PR TITLE
fix(ios): fv: add Zip framework to address crash on startup

### DIFF
--- a/oem/firstvoices/ios/Cartfile
+++ b/oem/firstvoices/ios/Cartfile
@@ -1,3 +1,4 @@
+github "marmelroy/Zip"
 github "keymanapp/dependency-XCGLogger" "master"
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"

--- a/oem/firstvoices/ios/Cartfile.resolved
+++ b/oem/firstvoices/ios/Cartfile.resolved
@@ -1,4 +1,5 @@
 github "ashleymills/Reachability.swift" "v5.1.0"
-github "devicekit/DeviceKit" "5.0.0"
-github "getsentry/sentry-cocoa" "8.7.0"
+github "devicekit/DeviceKit" "5.1.0"
+github "getsentry/sentry-cocoa" "8.14.2"
 github "keymanapp/dependency-XCGLogger" "57a7b975dbb6fe4fe90cef3d1bc52b8adbd89113"
+github "marmelroy/Zip" "2.1.2"

--- a/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
+++ b/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
@@ -650,9 +650,11 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FirstVoices/FirstVoices.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = D7TR486TEH;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = D7TR486TEH;
 				INFOPLIST_FILE = FirstVoices/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
 				KEYMAN_ROOT = "$(SRCROOT)/../../..";
@@ -666,6 +668,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices Keyboards Development";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = FirstVoices_Keyboards;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;

--- a/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
+++ b/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
@@ -14,8 +14,9 @@
 		2990208E278FF402004F18CF /* KeyboardTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2990208D278FF402004F18CF /* KeyboardTableController.swift */; };
 		2990209127901DD7004F18CF /* KeyboardDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2990209027901DD7004F18CF /* KeyboardDetailCell.swift */; };
 		2993F6E62791621D009E1352 /* KeyboardDetailController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2993F6E52791621D009E1352 /* KeyboardDetailController.swift */; };
-		29946C182AF8EFC5007EA0E3 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29946C172AF8EFC5007EA0E3 /* Zip.xcframework */; };
 		29946C192AF8F017007EA0E3 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29946C172AF8EFC5007EA0E3 /* Zip.xcframework */; };
+		29946C1A2AF9E087007EA0E3 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29946C172AF8EFC5007EA0E3 /* Zip.xcframework */; };
+		29946C1B2AF9E087007EA0E3 /* Zip.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 29946C172AF8EFC5007EA0E3 /* Zip.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		37C183B922932AD2009F9EFD /* FVKeyboardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C183B822932AD2009F9EFD /* FVKeyboardList.swift */; };
 		37C183BD2293321C009F9EFD /* Instructions in Resources */ = {isa = PBXBuildFile; fileRef = 37C183BC2293321C009F9EFD /* Instructions */; };
 		37EA1F23228A1F57003E710C /* FVInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EA1F22228A1F57003E710C /* FVInputViewController.swift */; };
@@ -80,6 +81,7 @@
 				CEBD34232654D76B00EB2EA8 /* Sentry.xcframework in Embed Frameworks */,
 				CEBD34262654D76C00EB2EA8 /* XCGLogger.xcframework in Embed Frameworks */,
 				CEBD34032654D41200EB2EA8 /* KeymanEngine.xcframework in Embed Frameworks */,
+				29946C1B2AF9E087007EA0E3 /* Zip.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -154,13 +156,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				29946C182AF8EFC5007EA0E3 /* Zip.xcframework in Frameworks */,
 				CEBD341D2654D76800EB2EA8 /* ObjcExceptionBridging.xcframework in Frameworks */,
 				CEBD341F2654D76900EB2EA8 /* Reachability.xcframework in Frameworks */,
 				CEBD34222654D76B00EB2EA8 /* Sentry.xcframework in Frameworks */,
 				CEBD341A2654D76600EB2EA8 /* DeviceKit.xcframework in Frameworks */,
 				CEBD34022654D41200EB2EA8 /* KeymanEngine.xcframework in Frameworks */,
 				CEBD34252654D76C00EB2EA8 /* XCGLogger.xcframework in Frameworks */,
+				29946C1A2AF9E087007EA0E3 /* Zip.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
+++ b/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		2990208E278FF402004F18CF /* KeyboardTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2990208D278FF402004F18CF /* KeyboardTableController.swift */; };
 		2990209127901DD7004F18CF /* KeyboardDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2990209027901DD7004F18CF /* KeyboardDetailCell.swift */; };
 		2993F6E62791621D009E1352 /* KeyboardDetailController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2993F6E52791621D009E1352 /* KeyboardDetailController.swift */; };
+		29946C182AF8EFC5007EA0E3 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29946C172AF8EFC5007EA0E3 /* Zip.xcframework */; };
+		29946C192AF8F017007EA0E3 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29946C172AF8EFC5007EA0E3 /* Zip.xcframework */; };
 		37C183B922932AD2009F9EFD /* FVKeyboardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C183B822932AD2009F9EFD /* FVKeyboardList.swift */; };
 		37C183BD2293321C009F9EFD /* Instructions in Resources */ = {isa = PBXBuildFile; fileRef = 37C183BC2293321C009F9EFD /* Instructions */; };
 		37EA1F23228A1F57003E710C /* FVInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EA1F22228A1F57003E710C /* FVInputViewController.swift */; };
@@ -103,6 +105,7 @@
 		2990208D278FF402004F18CF /* KeyboardTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardTableController.swift; sourceTree = "<group>"; };
 		2990209027901DD7004F18CF /* KeyboardDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDetailCell.swift; sourceTree = "<group>"; };
 		2993F6E52791621D009E1352 /* KeyboardDetailController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDetailController.swift; sourceTree = "<group>"; };
+		29946C172AF8EFC5007EA0E3 /* Zip.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Zip.xcframework; path = Carthage/Build/Zip.xcframework; sourceTree = "<group>"; };
 		37C183B822932AD2009F9EFD /* FVKeyboardList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FVKeyboardList.swift; sourceTree = "<group>"; };
 		37C183BC2293321C009F9EFD /* Instructions */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Instructions; path = FirstVoices/Instructions; sourceTree = "<group>"; };
 		37EA1F22228A1F57003E710C /* FVInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FVInputViewController.swift; sourceTree = "<group>"; };
@@ -151,6 +154,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				29946C182AF8EFC5007EA0E3 /* Zip.xcframework in Frameworks */,
 				CEBD341D2654D76800EB2EA8 /* ObjcExceptionBridging.xcframework in Frameworks */,
 				CEBD341F2654D76900EB2EA8 /* Reachability.xcframework in Frameworks */,
 				CEBD34222654D76B00EB2EA8 /* Sentry.xcframework in Frameworks */,
@@ -164,6 +168,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				29946C192AF8F017007EA0E3 /* Zip.xcframework in Frameworks */,
 				CEDB327F265C9C58000A2009 /* DeviceKit.xcframework in Frameworks */,
 				CEDB3280265C9C58000A2009 /* ObjcExceptionBridging.xcframework in Frameworks */,
 				CEDB3281265C9C58000A2009 /* Reachability.xcframework in Frameworks */,
@@ -284,6 +289,7 @@
 		98C9A9FB1BFC19ED009E9A4F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				29946C172AF8EFC5007EA0E3 /* Zip.xcframework */,
 				CEBD34082654D5AA00EB2EA8 /* ObjcExceptionBridging.xcframework */,
 				CEBD340C2654D5AB00EB2EA8 /* Reachability.xcframework */,
 				CEBD34092654D5AA00EB2EA8 /* Sentry.xcframework */,
@@ -650,11 +656,9 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FirstVoices/FirstVoices.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = D7TR486TEH;
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = D7TR486TEH;
 				INFOPLIST_FILE = FirstVoices/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
 				KEYMAN_ROOT = "$(SRCROOT)/../../..";
@@ -668,7 +672,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "FirstVoices Keyboards Development";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = FirstVoices_Keyboards;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;

--- a/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
+++ b/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		2990208E278FF402004F18CF /* KeyboardTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2990208D278FF402004F18CF /* KeyboardTableController.swift */; };
 		2990209127901DD7004F18CF /* KeyboardDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2990209027901DD7004F18CF /* KeyboardDetailCell.swift */; };
 		2993F6E62791621D009E1352 /* KeyboardDetailController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2993F6E52791621D009E1352 /* KeyboardDetailController.swift */; };
-		29946C192AF8F017007EA0E3 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29946C172AF8EFC5007EA0E3 /* Zip.xcframework */; };
 		29946C1A2AF9E087007EA0E3 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29946C172AF8EFC5007EA0E3 /* Zip.xcframework */; };
 		29946C1B2AF9E087007EA0E3 /* Zip.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 29946C172AF8EFC5007EA0E3 /* Zip.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		37C183B922932AD2009F9EFD /* FVKeyboardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C183B822932AD2009F9EFD /* FVKeyboardList.swift */; };
@@ -170,7 +169,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				29946C192AF8F017007EA0E3 /* Zip.xcframework in Frameworks */,
 				CEDB327F265C9C58000A2009 /* DeviceKit.xcframework in Frameworks */,
 				CEDB3280265C9C58000A2009 /* ObjcExceptionBridging.xcframework in Frameworks */,
 				CEDB3281265C9C58000A2009 /* Reachability.xcframework in Frameworks */,


### PR DESCRIPTION
Adding back Zip framework that was removed during upgrade to Xcode 14.2

**Not ready to review or test** -- in draft to try testing release build on CI server.

Fixes #9819  

@keymanapp-test-bot skip