### PR TITLE
fix(web): restores compat with older Android devices 🐵

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -15,6 +15,7 @@
        polyfill.
   -->
   <script src="es6-shim.min.js"></script>
+  <script src="other-polyfills.js"></script>
   <script src="keymanweb-webview.js"></script>
   <script src="sentry.min.js"></script>
   <script src="keyman-sentry.js"></script>

--- a/android/KMEA/app/src/main/assets/other-polyfills.js
+++ b/android/KMEA/app/src/main/assets/other-polyfills.js
@@ -1,0 +1,17 @@
+// Needed by the KMW's gesture engine until Chrome 61.
+var DOMRect = DOMRect || function (x, y, width, height) {
+  this.x = this.left = x;
+  this.y = this.top = y;
+  this.width = width;
+  this.height = height;
+  this.bottom = y + height;
+  this.right = x + width;
+};
+
+// https://stackoverflow.com/questions/53308396/how-to-polyfill-array-prototype-includes-for-ie8
+if(!Array.prototype.includes){
+  //or use Object.defineProperty
+  Array.prototype.includes = function(search){
+   return !!~this.indexOf(search);
+ }
+}

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -281,6 +281,7 @@ public final class KMManager {
   protected static final String KMFilename_KmwGlobeHintCss = "globe-hint.css";
   protected static final String KMFilename_Osk_Ttf_Font = "keymanweb-osk.ttf";
   protected static final String KMFilename_JSPolyfill = "es6-shim.min.js";
+  protected static final String KMFilename_JSPolyfill2 = "other-polyfills.js";
 
   // Deprecated by KeyboardController.KMFilename_Installed_KeyboardsList
   public static final String KMFilename_KeyboardsList = "keyboards_list.dat";
@@ -812,6 +813,7 @@ public final class KMManager {
       // Copy default keyboard font
       copyAsset(context, KMDefault_KeyboardFont, "", true);
       copyAsset(context, KMFilename_JSPolyfill, "", true);
+      copyAsset(context, KMFilename_JSPolyfill2, "", true);
 
       // Keyboard packages directory
       File packagesDir = new File(getPackagesDir());

--- a/common/web/gesture-recognizer/src/engine/configuration/paddedZoneSource.ts
+++ b/common/web/gesture-recognizer/src/engine/configuration/paddedZoneSource.ts
@@ -125,11 +125,11 @@ export class PaddedZoneSource implements RecognitionZoneSource {
   getBoundingClientRect(): DOMRect {
     const rootZone = this.root.getBoundingClientRect();
 
-    return DOMRect.fromRect({
-      x: rootZone.x + this.edgePadding.x,
-      y: rootZone.y + this.edgePadding.y,
-      width:  rootZone.width  - this.edgePadding.w,
-      height: rootZone.height - this.edgePadding.h
-    });
+    return new DOMRect(
+      /*x:*/ rootZone.x + this.edgePadding.x,
+      /*y:*/ rootZone.y + this.edgePadding.y,
+      /*width:*/  rootZone.width  - this.edgePadding.w,
+      /*height:*/ rootZone.height - this.edgePadding.h
+    );
   }
 }

--- a/common/web/gesture-recognizer/src/engine/configuration/viewportZoneSource.ts
+++ b/common/web/gesture-recognizer/src/engine/configuration/viewportZoneSource.ts
@@ -5,11 +5,11 @@ export class ViewportZoneSource implements RecognitionZoneSource {
 
   getBoundingClientRect(): DOMRect {
     // Viewport dimension detection is based on https://stackoverflow.com/a/8876069.
-    return DOMRect.fromRect({
-      y: 0,
-      x: 0,
-      width:  Math.max(document.documentElement.clientWidth  || 0, window.innerWidth || 0),
-      height: Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
-    });
+    return new DOMRect(
+      /*x:*/ 0,
+      /*y:*/ 0,
+      /*width:*/  Math.max(document.documentElement.clientWidth  || 0, window.innerWidth || 0),
+      /*height:*/ Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
+    );
   }
 }

--- a/common/web/lm-worker/build-bundler.js
+++ b/common/web/lm-worker/build-bundler.js
@@ -51,7 +51,9 @@ await esbuild.build(embeddedWorkerBuildOptions);
 const minifiedProfilingOptions = {
   ...embeddedWorkerBuildOptions,
   minify: true,
-  keepNames: false, // Do NOT enable - will break under Android 5.0 / Chrome 35 environments!
+  // Do NOT enable - will break under Android 5.0 / Chrome 35 environments, likely through Chrome 42.
+  // https://caniuse.com/mdn-javascript_builtins_function_name_configurable_true
+  keepNames: false,
   metafile: true,
   write: false // don't actually write the file.
 }

--- a/common/web/lm-worker/build-bundler.js
+++ b/common/web/lm-worker/build-bundler.js
@@ -51,6 +51,7 @@ await esbuild.build(embeddedWorkerBuildOptions);
 const minifiedProfilingOptions = {
   ...embeddedWorkerBuildOptions,
   minify: true,
+  keepNames: false, // Do NOT enable - will break under Android 5.0 / Chrome 35 environments!
   metafile: true,
   write: false // don't actually write the file.
 }

--- a/common/web/lm-worker/build-wrap-and-minify.js
+++ b/common/web/lm-worker/build-wrap-and-minify.js
@@ -34,7 +34,9 @@ if(MINIFY) {
     sourcemap: 'external',
     sourcesContent: DEBUG,
     minify: true,
-    keepNames: false, // Do NOT enable - will break under Android 5.0 / Chrome 35 environments!
+    // Do NOT enable - will break under Android 5.0 / Chrome 35 environments, likely through Chrome 42.
+    // https://caniuse.com/mdn-javascript_builtins_function_name_configurable_true
+    keepNames: false,
     target: 'es5',
     outfile: `build/lib/worker-main.polyfilled.min.js`
   });

--- a/common/web/lm-worker/build-wrap-and-minify.js
+++ b/common/web/lm-worker/build-wrap-and-minify.js
@@ -34,7 +34,7 @@ if(MINIFY) {
     sourcemap: 'external',
     sourcesContent: DEBUG,
     minify: true,
-    keepNames: true,
+    keepNames: false, // Do NOT enable - will break under Android 5.0 / Chrome 35 environments!
     target: 'es5',
     outfile: `build/lib/worker-main.polyfilled.min.js`
   });


### PR DESCRIPTION
Fixes #9443.

Turns out that the `es6-shim` polyfill doesn't actually polyfill quite _everything_ we want:
- `Object.values`, `Object.entries` - requires Chrome 54.  Fortunately, it's also very easy to workaround with minimal code restructuring.
- `Array.includes`:  Chrome 47.
- `DOMRect` with constructor:  [Chrome 61](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect#browser_compatibility).
    - This one in particular surprised me, given `getBoundingClientRect` goes as far back as Chrome 18; the gesture engine has components built on this method in particular.

Also disables `keepNames` in the lm-worker's es-build config, as noted here: https://github.com/keymanapp/keyman/pull/9943#discussion_r1384247462

@keymanapp-test-bot skip