### PR TITLE
feat(developer): New Project - Description field and tweaks 🦕

### DIFF
--- a/developer/src/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
@@ -28,6 +28,7 @@ type
     FCopyright: string;
     FTargets: TKeymanTargets;
     FFullCopyright: string;
+    FDescription: string;
     function LoadKLIDDetails: Boolean;
     function ImportKeyboard(const DestinationFilename, DestinationKVKSFilename: string): Boolean;
     function GenerateIcon(const IconFilename: string): Boolean;
@@ -46,6 +47,7 @@ type
     function GetProjectFilename: string;
     procedure SetTargets(const Value: TKeymanTargets);
     procedure SetFullCopyright(const Value: string);
+    procedure SetDescription(const Value: string);
  public
     function Execute: Boolean; overload;
 
@@ -62,6 +64,7 @@ type
     property Version: string read FVersion write SetVersion;
     property BCP47Tags: string read FBCP47Tags write SetBCP47Tags;
     property Author: string read FAuthor write SetAuthor;
+    property Description: string read FDescription write SetDescription;
     property Targets: TKeymanTargets read FTargets write SetTargets;
 
     property ProjectFilename: string read GetProjectFilename;
@@ -151,6 +154,11 @@ begin
   FCopyright := Value;
 end;
 
+procedure TImportWindowsKeyboard.SetDescription(const Value: string);
+begin
+  FDescription := Value;
+end;
+
 procedure TImportWindowsKeyboard.SetDestinationPath(const Value: string);
 begin
   FDestinationPath := IncludeTrailingPathDelimiter(Value);
@@ -219,6 +227,7 @@ begin
     FTemplate.Copyright := FCopyright;
     FTemplate.FullCopyright := FFullCopyright;
     FTemplate.Author := FAuthor;
+    FTemplate.Description := FDescription;
     FTemplate.Version := FVersion;
     FTemplate.IncludeIcon := True;
 

--- a/developer/src/kmconvert/Keyman.Developer.System.KMConvertParameters.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.KMConvertParameters.pas
@@ -26,6 +26,7 @@ type
     FModelIdLanguage: string;
     FModelIdUniq: string;
     FEmitUsage: Boolean;
+    FDescription: string;
 
     function CheckParam(name, value: string): Boolean;
     function SetKLID(const value: string): Boolean;
@@ -44,6 +45,7 @@ type
     function IsValidModelComponent(const component, value: string): Boolean;
     function ValidateBCP47Tag(const component, tag: string): Boolean;
     procedure OutputText(const msg: string = '');
+    function SetDescription(const value: string): Boolean;
   public
     type TOutputTextProc = reference to procedure(msg: string);
     var OnOutputText: TOutputTextProc;
@@ -62,6 +64,7 @@ type
     property Version: string read FVersion;
     property BCP47Tags: string read FBCP47Tags;
     property Author: string read FAuthor;
+    property Description: string read FDescription;
     property Targets: TKeymanTargets read FTargets;
     property Mode: TKMConvertMode read FMode;
     property NoLogo: Boolean read FNoLogo;
@@ -90,8 +93,8 @@ begin
   FEmitUsage := False;
 
   FDestination := '.';
-  FCopyright := 'Copyright (C)';
-  FFullCopyright := 'Copyright (C) '+FormatDateTime('yyyy', Now);
+  FCopyright := 'Copyright '+Char($00A9 {copyright});
+  FFullCopyright := 'Copyright '+Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now);
   FVersion := '1.0';
   FTargets := [ktAny];
 
@@ -161,6 +164,7 @@ begin
   OutputText('                         (in `import-windows` mode, can be a format string)');
   OutputText('  -o <destination>       The target folder to write the project into, defaults to "."');
   OutputText('  -author <data>         Name of author of the keyboard/model, no default');
+  OutputText('  -description <data>    Short plain-text description of the keyboard/model, no default');
   OutputText('  -name <data>           Name of the keyboard/model, e.g. "My First Keyboard", "%s Basic" ');
   OutputText('                         (format strings are only valid in `import-windows` mode)');
   OutputText('  -copyright <data>      Copyright string for the keyboard/model, defaults to "Copyright (C)"');
@@ -189,6 +193,7 @@ begin
   else if name = '-version' then Result := SetVersion(value)
   else if name = '-languages' then Result := SetBCP47Tags(value)
   else if name = '-author' then Result := SetAuthor(value)
+  else if name = '-description' then Result := SetDescription(value)
   else if name = '-targets' then Result := SetTargets(value)
   else if name = '-id-author' then Result := SetModelIdAuthor(value)
   else if name = '-id-language' then Result := SetModelIdLanguage(value)
@@ -311,6 +316,12 @@ end;
 function TKMConvertParameters.SetAuthor(const value: string): Boolean;
 begin
   FAuthor := Value;
+  Result := True;
+end;
+
+function TKMConvertParameters.SetDescription(const value: string): Boolean;
+begin
+  FDescription := Value;
   Result := True;
 end;
 

--- a/developer/src/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
@@ -233,6 +233,7 @@ begin
     kps.Info.Desc[PackageInfo_Name] := Name;
     kps.Info.Desc[PackageInfo_Copyright] := Copyright;
     kps.Info.Desc[PackageInfo_Author] := Author;
+    kps.Info.Desc[PackageInfo_Description] := Description;
     kps.KPSOptions.FollowKeyboardVersion := True;
     kps.FileName := GetPackageFilename;
 

--- a/developer/src/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
@@ -50,6 +50,7 @@ begin
     iwk.DestinationPath := FParameters.Destination;
     iwk.KeyboardIDTemplate := FParameters.KeyboardID;
     iwk.NameTemplate := FParameters.Name;
+    iwk.Description := FParameters.Description;
     iwk.Copyright := FParameters.Copyright;
     iwk.FullCopyright := FParameters.FullCopyright;
     iwk.Version := FParameters.Version;

--- a/developer/src/kmconvert/Keyman.Developer.System.ModelProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.ModelProjectTemplate.pas
@@ -161,6 +161,7 @@ begin
     kps.Info.Desc[PackageInfo_Copyright] := Copyright;
     kps.Info.Desc[PackageInfo_Author] := Author;
     kps.Info.Desc[PackageInfo_Version] := Version;
+    kps.Info.Desc[PackageInfo_Description] := Description;
     kps.FileName := GetPackageFilename;
 
     // Add model.js

--- a/developer/src/kmconvert/Keyman.Developer.System.ProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.ProjectTemplate.pas
@@ -25,6 +25,7 @@ type
     FProjectType: TKeymanProjectType;
     FTargets: TKeymanTargets;
     FFullCopyright: string;
+    FDescription: string;
 
   protected
     const
@@ -61,6 +62,7 @@ type
     property Targets: TKeymanTargets read FTargets;
 
     property Name: string read FName write FName;
+    property Description: string read FDescription write FDescription;
     property Copyright: string read FCopyright write FCopyright;
     property FullCopyright: string read FFullCopyright write FFullCopyright;
     property Author: string read FAuthor write FAuthor;
@@ -235,10 +237,12 @@ begin
   end;
 
   s := ReplaceStr(s, '$NAME', FName);
+  s := ReplaceStr(s, '$ID', FId);
   s := ReplaceStr(s, '$VERSION', FVersion);
   s := ReplaceStr(s, '$COPYRIGHT', FCopyright);
   s := ReplaceStr(s, '$FULLCOPYRIGHT', FFullCopyright);
   s := ReplaceStr(s, '$AUTHOR', FAuthor);
+  s := ReplaceStr(s, '$DESCRIPTION', FDescription);
   s := ReplaceStr(s, '$DATE', FormatDateTime('yyyy-mm-dd', Now));
   if Pos('$LANGUAGES_KEYBOARD_INFO', s) > 0 then
     s := ReplaceStr(s, '$LANGUAGES_KEYBOARD_INFO', GetLanguageTagListForKeyboardInfo);

--- a/developer/src/kmconvert/data/basic-keyboard/README.md
+++ b/developer/src/kmconvert/data/basic-keyboard/README.md
@@ -1,14 +1,13 @@
 $NAME keyboard
 ==============
 
-Version $VERSION
-
 Description
 -----------
-$NAME generated from template
+$DESCRIPTION
 
 Links
 -----
+Keyboard Homepage: https://keyman.com/keyboards/$ID
 
 Copyright
 ---------

--- a/developer/src/kmconvert/data/basic-keyboard/source/readme.htm
+++ b/developer/src/kmconvert/data/basic-keyboard/source/readme.htm
@@ -15,7 +15,7 @@
 <h1>$NAME</h1>
 
 <p>
-    $NAME $VERSION generated from template.
+  $DESCRIPTION
 </p>
 
 <p>$COPYRIGHT</p>

--- a/developer/src/kmconvert/data/basic-keyboard/source/welcome.htm
+++ b/developer/src/kmconvert/data/basic-keyboard/source/welcome.htm
@@ -15,7 +15,7 @@
 <h1>Start Using $NAME</h1>
 
 <p>
-    $NAME $VERSION generated from template.
+  $DESCRIPTION
 </p>
 
 <h1>Keyboard Layout</h1>

--- a/developer/src/kmconvert/data/wordlist-lexical-model/README.md
+++ b/developer/src/kmconvert/data/wordlist-lexical-model/README.md
@@ -1,11 +1,9 @@
 $NAME lexical model
 ===================
 
-Version $VERSION
-
 Description
 -----------
-$NAME generated from template
+$DESCRIPTION
 
 Links
 -----

--- a/developer/src/kmconvert/data/wordlist-lexical-model/model.model_info
+++ b/developer/src/kmconvert/data/wordlist-lexical-model/model.model_info
@@ -3,5 +3,5 @@
     "languages": [
         $LANGUAGES_KEYBOARD_INFO
     ],
-	  "description": "$NAME generated from template"
+	  "description": "$DESCRIPTION"
 }

--- a/developer/src/kmconvert/data/wordlist-lexical-model/source/model.ts
+++ b/developer/src/kmconvert/data/wordlist-lexical-model/source/model.ts
@@ -1,6 +1,6 @@
 /*
-  $NAME $VERSION generated from template.
-  
+  $NAME $VERSION
+
   This is a minimal lexical model source that uses a tab delimited wordlist.
   See documentation online at https://help.keyman.com/developer/ for
   additional parameters.

--- a/developer/src/kmconvert/data/wordlist-lexical-model/source/readme.htm
+++ b/developer/src/kmconvert/data/wordlist-lexical-model/source/readme.htm
@@ -15,7 +15,7 @@
 <h1>$NAME</h1>
 
 <p>
-    $NAME $VERSION generated from template.
+  $DESCRIPTION
 </p>
 
 <p>$COPYRIGHT</p>

--- a/developer/src/kmconvert/data/wordlist-lexical-model/source/welcome.htm
+++ b/developer/src/kmconvert/data/wordlist-lexical-model/source/welcome.htm
@@ -15,7 +15,7 @@
 <h1>Start Using $NAME</h1>
 
 <p>
-    $NAME $VERSION generated from template.
+  $DESCRIPTION
 </p>
 
 <h1>Wordlist Model Documentation</h1>

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.dfm
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.dfm
@@ -2,19 +2,18 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   BorderIcons = [biSystemMenu]
   BorderStyle = bsDialog
   Caption = 'New Wordlist Lexical Model Project'
-  ClientHeight = 510
-  ClientWidth = 412
+  ClientHeight = 402
+  ClientWidth = 756
   OldCreateOrder = True
   Position = poScreenCenter
   OnDestroy = FormDestroy
-  ExplicitTop = -8
-  ExplicitWidth = 418
-  ExplicitHeight = 539
+  ExplicitWidth = 762
+  ExplicitHeight = 431
   PixelsPerInch = 96
   TextHeight = 13
   object lblFileName: TLabel
     Left = 8
-    Top = 423
+    Top = 311
     Width = 46
     Height = 13
     Caption = 'Model &ID:'
@@ -22,7 +21,7 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object lblPath: TLabel
     Left = 8
-    Top = 287
+    Top = 149
     Width = 26
     Height = 13
     Caption = '&Path:'
@@ -30,7 +29,7 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object lblAuthorID: TLabel
     Left = 8
-    Top = 342
+    Top = 230
     Width = 51
     Height = 13
     Caption = 'Aut&hor ID:'
@@ -61,8 +60,8 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
     FocusControl = editAuthor
   end
   object lblLanguages: TLabel
-    Left = 9
-    Top = 146
+    Left = 348
+    Top = 114
     Width = 52
     Height = 13
     Caption = '&Languages'
@@ -70,14 +69,14 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object lblBCP47: TLabel
     Left = 8
-    Top = 369
+    Top = 257
     Width = 90
     Height = 13
     Caption = '&Primary Language:'
   end
   object lblUniq: TLabel
     Left = 8
-    Top = 396
+    Top = 284
     Width = 67
     Height = 13
     Caption = 'Uni&que Name:'
@@ -93,13 +92,13 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object Bevel1: TBevel
     Left = 8
-    Top = 317
-    Width = 397
-    Height = 2
+    Top = 205
+    Width = 317
+    Height = 4
   end
   object lblProjectFilename: TLabel
     Left = 8
-    Top = 450
+    Top = 338
     Width = 77
     Height = 13
     Caption = 'Project &filename'
@@ -113,40 +112,48 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
     Caption = 'Fu&ll copyright:'
     FocusControl = editFullCopyright
   end
+  object Label2: TLabel
+    Left = 347
+    Top = 10
+    Width = 53
+    Height = 13
+    Caption = '&Description'
+    FocusControl = memoDescription
+  end
   object editModelID: TEdit
     Left = 120
-    Top = 420
+    Top = 308
     Width = 205
     Height = 21
     TabStop = False
     ParentColor = True
     ReadOnly = True
-    TabOrder = 14
+    TabOrder = 15
     OnChange = editModelIDChange
   end
   object cmdBrowse: TButton
-    Left = 332
-    Top = 284
+    Left = 120
+    Top = 173
     Width = 73
     Height = 21
     Caption = '&Browse...'
-    TabOrder = 10
+    TabOrder = 6
     OnClick = cmdBrowseClick
   end
   object editPath: TEdit
     Left = 120
-    Top = 284
+    Top = 146
     Width = 205
     Height = 21
-    TabOrder = 9
+    TabOrder = 5
     OnChange = editPathChange
   end
   object editAuthorID: TEdit
     Left = 120
-    Top = 339
+    Top = 227
     Width = 205
     Height = 21
-    TabOrder = 11
+    TabOrder = 12
     OnChange = editModelIDComponentChange
   end
   object editCopyright: TEdit
@@ -175,28 +182,28 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
     OnChange = editAuthorChange
   end
   object cmdOK: TButton
-    Left = 252
-    Top = 479
+    Left = 302
+    Top = 367
     Width = 73
     Height = 25
     Caption = 'OK'
     Default = True
-    TabOrder = 16
+    TabOrder = 17
     OnClick = cmdOKClick
   end
   object cmdCancel: TButton
-    Left = 331
-    Top = 479
+    Left = 381
+    Top = 367
     Width = 73
     Height = 25
     Cancel = True
     Caption = 'Cancel'
     ModalResult = 2
-    TabOrder = 17
+    TabOrder = 18
   end
   object gridLanguages: TStringGrid
-    Left = 8
-    Top = 167
+    Left = 347
+    Top = 135
     Width = 317
     Height = 102
     ColCount = 2
@@ -204,7 +211,7 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
     FixedCols = 0
     RowCount = 9
     Options = [goFixedVertLine, goFixedHorzLine, goVertLine, goHorzLine, goColSizing, goRowSelect]
-    TabOrder = 5
+    TabOrder = 8
     OnClick = gridLanguagesClick
     OnDblClick = gridLanguagesDblClick
     ColWidths = (
@@ -212,47 +219,47 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
       64)
   end
   object cmdAddLanguage: TButton
-    Left = 332
-    Top = 167
+    Left = 671
+    Top = 135
     Width = 73
     Height = 25
     Caption = '&Add...'
-    TabOrder = 6
+    TabOrder = 9
     OnClick = cmdAddLanguageClick
   end
   object cmdEditLanguage: TButton
-    Left = 332
-    Top = 198
+    Left = 671
+    Top = 166
     Width = 73
     Height = 25
     Caption = '&Edit...'
-    TabOrder = 7
+    TabOrder = 10
     OnClick = cmdEditLanguageClick
   end
   object cmdRemoveLanguage: TButton
-    Left = 332
-    Top = 229
+    Left = 671
+    Top = 197
     Width = 73
     Height = 25
     Caption = '&Remove'
-    TabOrder = 8
+    TabOrder = 11
     OnClick = cmdRemoveLanguageClick
   end
   object editUniq: TEdit
     Left = 120
-    Top = 393
+    Top = 281
     Width = 205
     Height = 21
-    TabOrder = 13
+    TabOrder = 14
     OnChange = editModelIDComponentChange
   end
   object cbBCP47: TComboBox
     Left = 120
-    Top = 366
+    Top = 254
     Width = 205
     Height = 21
     Style = csDropDownList
-    TabOrder = 12
+    TabOrder = 13
     OnClick = editModelIDComponentChange
   end
   object editModelName: TEdit
@@ -265,13 +272,13 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
   end
   object editProjectFilename: TEdit
     Left = 120
-    Top = 447
+    Top = 335
     Width = 284
     Height = 21
     TabStop = False
     ParentColor = True
     ReadOnly = True
-    TabOrder = 15
+    TabOrder = 16
   end
   object editFullCopyright: TEdit
     Left = 120
@@ -280,5 +287,13 @@ inherited frmNewModelProjectParameters: TfrmNewModelProjectParameters
     Height = 21
     TabOrder = 3
     OnChange = editFullCopyrightChange
+  end
+  object memoDescription: TMemo
+    Left = 347
+    Top = 31
+    Width = 398
+    Height = 79
+    TabOrder = 7
+    OnChange = memoDescriptionChange
   end
 end

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.pas
@@ -58,6 +58,8 @@ type
     editProjectFilename: TEdit;
     Label1: TLabel;
     editFullCopyright: TEdit;
+    Label2: TLabel;
+    memoDescription: TMemo;
     procedure cmdOKClick(Sender: TObject);
     procedure editModelIDComponentChange(Sender: TObject);
     procedure FormCreate(Sender: TObject);
@@ -75,6 +77,7 @@ type
     procedure cmdBrowseClick(Sender: TObject);
     procedure editModelNameChange(Sender: TObject);
     procedure editFullCopyrightChange(Sender: TObject);
+    procedure memoDescriptionChange(Sender: TObject);
   private
     pack: TKPSFile;
     FSetup: Integer;
@@ -100,6 +103,7 @@ type
     procedure UpdateModelIDFromComponents;
     procedure UpdateProjectFilename;
     function GetFullCopyright: string;
+    function GetDescription: string;
   protected
     function GetHelpTopic: string; override;
     property AuthorID: string read GetAuthorID;
@@ -110,6 +114,7 @@ type
     property FullCopyright: string read GetFullCopyright;
     property Version: string read GetVersion;
     property Author: string read GetAuthor;
+    property Description: string read GetDescription;
     property ModelName: string read GetModelName;
     property BCP47Tags: string read GetBCP47Tags;
     property BasePath: string read GetBasePath;
@@ -153,6 +158,7 @@ begin
       pt.Name := f.ModelName;
       pt.Copyright := f.Copyright;
       pt.FullCopyright := f.FullCopyright;
+      pt.Description := f.Description;
       pt.Author := f.Author;
       pt.Version := f.Version;
       pt.BCP47Tags := f.BCP47Tags;
@@ -352,6 +358,7 @@ var
 begin
   e :=
     not Author.IsEmpty and
+    not Description.IsEmpty and
     not ModelName.IsEmpty and
     not AuthorID.IsEmpty and
     not PrimaryBCP47.IsEmpty and
@@ -388,6 +395,11 @@ end;
 function TfrmNewModelProjectParameters.GetCopyright: string;
 begin
   Result := Trim(editCopyright.Text);
+end;
+
+function TfrmNewModelProjectParameters.GetDescription: string;
+begin
+  Result := memoDescription.Text;
 end;
 
 function TfrmNewModelProjectParameters.GetFullCopyright: string;
@@ -474,8 +486,8 @@ end;
 procedure TfrmNewModelProjectParameters.UpdateAuthorIDFromAuthor;
 begin
   editAuthorID.Text := TLexicalModelUtils.CleanLexicalModelIDComponent(Author);
-  editCopyright.Text := Char($00A9 {copyright})+' '+Author;
-  editFullCopyright.Text := Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now)+' '+Author;
+  editCopyright.Text := 'Copyright ' + Char($00A9 {copyright})+' '+Author;
+  editFullCopyright.Text := 'Copyright ' + Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now)+' '+Author;
 end;
 
 procedure TfrmNewModelProjectParameters.UpdateUniqFromModelName;
@@ -554,6 +566,11 @@ begin
   finally
     Dec(FSetup);
   end;
+end;
+
+procedure TfrmNewModelProjectParameters.memoDescriptionChange(Sender: TObject);
+begin
+  EnableControls;
 end;
 
 procedure TfrmNewModelProjectParameters.BCP47_Fill;

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.dfm
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.dfm
@@ -2,17 +2,17 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   BorderIcons = [biSystemMenu]
   BorderStyle = bsDialog
   Caption = 'New Basic Keyboard Project'
-  ClientHeight = 330
+  ClientHeight = 444
   ClientWidth = 625
   Position = poScreenCenter
   OnDestroy = FormDestroy
   ExplicitWidth = 631
-  ExplicitHeight = 359
+  ExplicitHeight = 473
   PixelsPerInch = 96
   TextHeight = 13
   object lblFileName: TLabel
     Left = 12
-    Top = 275
+    Top = 390
     Width = 64
     Height = 13
     Caption = '&Keyboard ID:'
@@ -20,7 +20,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblPath: TLabel
     Left = 12
-    Top = 248
+    Top = 363
     Width = 26
     Height = 13
     Caption = '&Path:'
@@ -36,7 +36,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblCoypright: TLabel
     Left = 12
-    Top = 65
+    Top = 180
     Width = 51
     Height = 13
     Caption = '&Copyright:'
@@ -44,7 +44,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblVersion: TLabel
     Left = 12
-    Top = 118
+    Top = 233
     Width = 39
     Height = 13
     Caption = '&Version:'
@@ -52,7 +52,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblAuthor: TLabel
     Left = 12
-    Top = 38
+    Top = 153
     Width = 37
     Height = 13
     Caption = 'A&uthor:'
@@ -60,7 +60,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblTargets: TLabel
     Left = 12
-    Top = 145
+    Top = 260
     Width = 41
     Height = 13
     Caption = '&Targets:'
@@ -68,7 +68,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblKeyboardLanguages: TLabel
     Left = 339
-    Top = 11
+    Top = 152
     Width = 52
     Height = 13
     Caption = '&Languages'
@@ -76,7 +76,7 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object lblProjectFilename: TLabel
     Left = 12
-    Top = 302
+    Top = 417
     Width = 77
     Height = 13
     Caption = 'Project &filename'
@@ -84,35 +84,43 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object Label1: TLabel
     Left = 12
-    Top = 91
+    Top = 206
     Width = 68
     Height = 13
     Caption = 'Fu&ll copyright:'
     FocusControl = editFullCopyright
   end
+  object Label2: TLabel
+    Left = 12
+    Top = 38
+    Width = 53
+    Height = 13
+    Caption = '&Description'
+    FocusControl = memoDescription
+  end
   object editKeyboardID: TEdit
     Left = 120
-    Top = 272
+    Top = 387
     Width = 205
     Height = 21
-    TabOrder = 12
+    TabOrder = 13
     OnChange = editKeyboardIDChange
   end
   object cmdBrowse: TButton
     Left = 340
-    Top = 245
+    Top = 360
     Width = 73
     Height = 21
     Caption = '&Browse...'
-    TabOrder = 11
+    TabOrder = 12
     OnClick = cmdBrowseClick
   end
   object editPath: TEdit
     Left = 120
-    Top = 245
+    Top = 360
     Width = 205
     Height = 21
-    TabOrder = 10
+    TabOrder = 11
     OnChange = editPathChange
   end
   object editKeyboardName: TEdit
@@ -125,70 +133,70 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object editCopyright: TEdit
     Left = 120
-    Top = 62
+    Top = 176
     Width = 205
     Height = 21
-    TabOrder = 2
-    Text = #169
+    TabOrder = 3
+    Text = 'Copyright '#169
     OnChange = editCopyrightChange
   end
   object editVersion: TEdit
     Left = 120
-    Top = 115
+    Top = 230
     Width = 205
     Height = 21
-    TabOrder = 4
+    TabOrder = 5
     Text = '1.0'
     OnChange = editVersionChange
   end
   object editAuthor: TEdit
     Left = 120
-    Top = 35
+    Top = 150
     Width = 205
     Height = 21
-    TabOrder = 1
+    TabOrder = 2
     OnChange = editAuthorChange
   end
   object cmdOK: TButton
     Left = 463
-    Top = 297
+    Top = 412
     Width = 73
     Height = 25
     Caption = 'OK'
     Default = True
-    TabOrder = 14
+    TabOrder = 15
     OnClick = cmdOKClick
   end
   object cmdCancel: TButton
     Left = 542
-    Top = 297
+    Top = 412
     Width = 73
     Height = 25
     Cancel = True
     Caption = 'Cancel'
     ModalResult = 2
-    TabOrder = 15
+    TabOrder = 16
   end
   object clbTargets: TCheckListBox
     Left = 120
-    Top = 142
+    Top = 257
     Width = 205
     Height = 97
     OnClickCheck = clbTargetsClickCheck
     ItemHeight = 13
-    TabOrder = 5
+    TabOrder = 6
   end
   object gridKeyboardLanguages: TStringGrid
     Left = 339
-    Top = 32
+    Top = 173
     Width = 278
-    Height = 153
+    Height = 120
     ColCount = 2
     DefaultRowHeight = 16
     FixedCols = 0
     RowCount = 9
     Options = [goFixedVertLine, goFixedHorzLine, goVertLine, goHorzLine, goColSizing, goRowSelect]
-    TabOrder = 6
+    TabOrder = 7
     OnClick = gridKeyboardLanguagesClick
     OnDblClick = gridKeyboardLanguagesDblClick
     ColWidths = (
@@ -197,49 +205,57 @@ inherited frmNewProjectParameters: TfrmNewProjectParameters
   end
   object cmdKeyboardAddLanguage: TButton
     Left = 340
-    Top = 191
+    Top = 299
     Width = 73
     Height = 25
     Caption = '&Add...'
-    TabOrder = 7
+    TabOrder = 8
     OnClick = cmdKeyboardAddLanguageClick
   end
   object cmdKeyboardEditLanguage: TButton
     Left = 419
-    Top = 191
+    Top = 299
     Width = 73
     Height = 25
     Caption = 'Ed&it...'
-    TabOrder = 8
+    TabOrder = 9
     OnClick = cmdKeyboardEditLanguageClick
   end
   object cmdKeyboardRemoveLanguage: TButton
     Left = 498
-    Top = 191
+    Top = 299
     Width = 72
     Height = 25
     Caption = '&Remove'
-    TabOrder = 9
+    TabOrder = 10
     OnClick = cmdKeyboardRemoveLanguageClick
   end
   object editProjectFilename: TEdit
     Left = 120
-    Top = 299
+    Top = 414
     Width = 293
     Height = 21
     TabStop = False
     ParentColor = True
     ReadOnly = True
-    TabOrder = 13
+    TabOrder = 14
     OnChange = editKeyboardIDChange
   end
   object editFullCopyright: TEdit
     Left = 120
-    Top = 88
+    Top = 203
     Width = 205
     Height = 21
-    TabOrder = 3
-    Text = #169' YYYY'
+    TabOrder = 4
+    Text = 'Copyright '#169' YYYY'
     OnChange = editFullCopyrightChange
+  end
+  object memoDescription: TMemo
+    Left = 120
+    Top = 35
+    Width = 497
+    Height = 109
+    TabOrder = 1
+    OnChange = memoDescriptionChange
   end
 end

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
@@ -51,6 +51,8 @@ type
     editProjectFilename: TEdit;
     Label1: TLabel;
     editFullCopyright: TEdit;
+    Label2: TLabel;
+    memoDescription: TMemo;
     procedure cmdOKClick(Sender: TObject);
     procedure editKeyboardNameChange(Sender: TObject);
     procedure FormCreate(Sender: TObject);
@@ -68,6 +70,7 @@ type
     procedure editKeyboardIDChange(Sender: TObject);
     procedure cmdBrowseClick(Sender: TObject);
     procedure editFullCopyrightChange(Sender: TObject);
+    procedure memoDescriptionChange(Sender: TObject);
   private
     dlgBrowse: TBrowse4Folder;
     pack: TKPSFile; // Used temporarily for storing language list
@@ -90,6 +93,7 @@ type
     procedure SetKeyboardName(const Value: string);
     procedure UpdateProjectFilename;
     function GetFullCopyright: string;
+    function GetDescription: string;
   protected
     function GetHelpTopic: string; override;
   public
@@ -100,6 +104,8 @@ type
     property Targets: TKeymanTargets read GetTargets;
     property BCP47Tags: string read GetBCP47Tags write SetBCP47Tags;
     property BasePath: string read GetBasePath;
+
+    property Description: string read GetDescription;
 
     property KeyboardName: string read GetKeyboardName write SetKeyboardName;
     property KeyboardID: string read GetKeyboardID write SetKeyboardID;
@@ -132,6 +138,7 @@ uses
 // 6. author
 // 7. version
 // 8. bcp47 tags
+// 9. description
 
 {$R *.dfm}
 
@@ -153,6 +160,7 @@ begin
       pt.FullCopyright := f.FullCopyright;
       pt.Author := f.Author;
       pt.Version := f.Version;
+      pt.Description := f.Description;
       pt.BCP47Tags := f.BCP47Tags;
       pt.IncludeIcon := True;
 
@@ -185,7 +193,7 @@ var
 begin
   inherited;
   editPath.Text := FKeymanDeveloperOptions.DefaultProjectPath;
-  editFullCopyright.Text := Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now)+' ';
+  editFullCopyright.Text := 'Copyright '+Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now)+' ';
 
   dlgBrowse := TBrowse4Folder.Create(Self);
   dlgBrowse.InitialDir := editPath.Text;
@@ -307,9 +315,9 @@ procedure TfrmNewProjectParameters.editAuthorChange(Sender: TObject);
 begin
   EnableControls;
   if not editCopyright.Modified then
-    editCopyright.Text := Char($00A9 {copyright})+' '+Author;
+    editCopyright.Text := 'Copyright '+Char($00A9 {copyright})+' '+Author;
   if not editFullCopyright.Modified then
-    editFullCopyright.Text := Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now)+' '+Author;
+    editFullCopyright.Text := 'Copyright '+Char($00A9 {copyright})+' '+FormatDateTime('yyyy', Now)+' '+Author;
 end;
 
 procedure TfrmNewProjectParameters.editCopyrightChange(Sender: TObject);
@@ -353,7 +361,8 @@ begin
   e := (Trim(editKeyboardName.Text) <> '') and
     (Trim(editPath.Text) <> '') and
     TKeyboardUtils.IsValidKeyboardID(Trim(editKeyboardID.Text), True) and
-    (GetTargets <> []);
+    (GetTargets <> []) and
+    (Trim(memoDescription.Text) <> '');
 
   cmdOK.Enabled := e;
 
@@ -378,6 +387,11 @@ end;
 function TfrmNewProjectParameters.GetCopyright: string;
 begin
   Result := Trim(editCopyright.Text);
+end;
+
+function TfrmNewProjectParameters.GetDescription: string;
+begin
+  Result := Trim(memoDescription.Text);
 end;
 
 function TfrmNewProjectParameters.GetFullCopyright: string;
@@ -561,6 +575,11 @@ begin
   finally
     Dec(FSetup);
   end;
+end;
+
+procedure TfrmNewProjectParameters.memoDescriptionChange(Sender: TObject);
+begin
+  EnableControls;
 end;
 
 procedure TfrmNewProjectParameters.UpdateProjectFilename;


### PR DESCRIPTION
Fixes #9869.

Adds a 'Description' field, tweaks Copyright strings, and tweaks default content for documentation to the New Project wizards and kmconvert.

# User Testing

**TEST_NEW_KEYBOARD_PROJECT:** Create a new keyboard project, and verify that the Description field is visible in the resulting README.md, readme.htm, welcome.htm, and in the Description field of the package. Check also that the Copyright string starts with the word 'Copyright'.

**TEST_NEW_MODEL_PROJECT:** Create a new lexical model project, and verify that the Description field is visible in the resulting README.md, readme.htm, welcome.htm, and in the Description field of the package. Check also that the Copyright string starts with the word 'Copyright'.