### PR TITLE
fix(web): Ignore `osk-always-visible` on non-desktop devices

### DIFF
--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -964,8 +964,10 @@ export default abstract class OSKView extends EventEmitter<EventMap> implements 
    * Performs the _actual_ logic and functionality involved in hiding the OSK.
    */
   protected finalizeHide() {
-    if(document.body.className.indexOf('osk-always-visible') >= 0) {
-      return;
+    if (document.body.className.indexOf('osk-always-visible') >= 0) {
+      if (this.hostDevice.formFactor == 'desktop') {
+        return;
+      }
     }
 
     if(this._Box) {


### PR DESCRIPTION
See also #9917 for the Keyman Developer part.

Fixes #9918.

# User Testing

* **TEST_WEB:** Open Keyman Web on a touch device (or in touch device emulation in Chrome); ensure there is a Keyman keyboard active for testing. Touch on the touch OSK to input some text into the test box. Then touch outside the text box to hide the OSK. Then, touch where the OSK _was_ visible. This should _no longer_ cause text to be inserted into the test box.