### PR TITLE
fix(web): default subkey forwarding 🐵

### DIFF
--- a/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
@@ -59,6 +59,7 @@ export default class SubkeyPopup implements GestureHandler {
       this.clear();
     });
 
+    // When subkey-selection is fully triggered, emit the selected key.
     source.on('stage', () => {
       const key = this.currentSelection;
       if(key) {

--- a/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
@@ -61,10 +61,12 @@ export default class SubkeyPopup implements GestureHandler {
 
     source.on('stage', () => {
       const key = this.currentSelection;
-      const keyEvent = vkbd.keyEventFromSpec(key.key.spec);
-      keyEvent.keyDistribution = this.currentStageKeyDistribution();
+      if(key) {
+        const keyEvent = vkbd.keyEventFromSpec(key.key.spec);
+        keyEvent.keyDistribution = this.currentStageKeyDistribution();
 
-      vkbd.raiseKeyEvent(keyEvent, key);
+        vkbd.raiseKeyEvent(keyEvent, key);
+      }
     });
 
     // From here, we want to make decisions based on only the subkey-menu portion of the gesture path.

--- a/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
@@ -22,7 +22,7 @@ import { GestureParams } from '../specsForLayout.js';
  * displayed, selection of the subkey is inherently asynchronous.
  */
 export default class SubkeyPopup implements GestureHandler {
-  readonly directlyEmitsKeys = false;
+  readonly directlyEmitsKeys = true;
 
   public readonly element: HTMLDivElement;
   public readonly shim: HTMLDivElement;
@@ -57,6 +57,14 @@ export default class SubkeyPopup implements GestureHandler {
     source.on('complete', () => {
       this.currentSelection?.key.highlight(false);
       this.clear();
+    });
+
+    source.on('stage', () => {
+      const key = this.currentSelection;
+      const keyEvent = vkbd.keyEventFromSpec(key.key.spec);
+      keyEvent.keyDistribution = this.currentStageKeyDistribution();
+
+      vkbd.raiseKeyEvent(keyEvent, key);
     });
 
     // From here, we want to make decisions based on only the subkey-menu portion of the gesture path.

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -550,7 +550,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
 
         let keyResult: KeyRuleEffects = null;
 
-        // Multitaps and flicks do special key-mapping stuff internally and produce + raise
+        // Longpresses, multitaps and flicks do special key-mapping stuff internally and produce + raise
         // their key events directly.
         if(gestureKey && !(handlers && handlers[0].directlyEmitsKeys)) {
           let correctionKeyDistribution: KeyDistribution;


### PR DESCRIPTION
I'd forgotten that default subkey selection logic is not available on the gesture-engine level, so KMW longpress handling has to override the gesture's selected-key output when a default subkey should be selected. 

Technically, we _could_ make it override only when the "select default" mode is on; that wouldn't actually be that difficult.  But... it's not really necessary to toggle the `directlyEmitsKey` property, and not doing so results in somewhat simpler code.

## User Testing

TEST_SPECIAL_DEFAULT:  if a subkey exists with an explicitly-marked 'default' subkey, it should be auto-selected when the subkey menu is first displayed.

1. On a mobile device (or when emulating one in a desktop browser), visit the testing page marked "Tests handling of new default-subkey feature (#9430)."
2. Longpress the `d` key.
3. When the subkey menu is displayed, verify that the fifth subkey - "default" - is selected.  The text may be cropped.
    
    ![image](https://github.com/keymanapp/keyman/assets/25213402/154efce1-e84f-403a-b4fa-3876d4907833)

4. _Without moving the touchpoint/finger_, release the touchpoint / lift your finger.  This should output the text `default`.
    - Note:  if significant movement occurs, the text will not be output.  (A small "fudge factor" is allowed before this occurs.)

TEST_MATCHING_ID_DEFAULT:  if a subkey exists with an ID perfectly matching its base key, it should be auto-selected in the absence of a specified subkey.

1. On a mobile device (or when emulating one in a desktop browser), visit the testing page marked "Tests handling of new default-subkey feature (#9430)."
2. Longpress the `a` key.
3. When the subkey menu is displayed, verify that the third subkey - "a" - is selected.

4. _Without moving the touchpoint/finger_, release the touchpoint / lift your finger.  This should output the text `a`.

TEST_NONDEFAULT_SELECTION: the user should still be able to select a subkey that's not the default, of course.

1. On a mobile device (or when emulating one in a desktop browser), visit the testing page marked "Tests handling of new default-subkey feature (#9430)."
2. Longpress the `d` key.
3. Select the third `d` subkey: `đ` and release.
4. Verify that `đ` is output.

TEST_IOS_SPECIAL_DEFAULT: the same as the first test above, but this time within the iOS app.

1. Using Safari, download and then install the `default-subkey` keyboard package: [default_subkey.kmp](https://jahorton.github.io/default_subkey.kmp)
    - I'm hosting this under my GitHub pages; it's the same link that can be found here: https://jahorton.github.io/
2. Within the iOS app, longpress the `d` key.
6. When the subkey menu is displayed, verify that the fifth subkey - "default" - is selected.  The text may be cropped.
    
    ![image](https://github.com/keymanapp/keyman/assets/25213402/154efce1-e84f-403a-b4fa-3876d4907833)

7. _Without moving the touchpoint/finger_, release the touchpoint / lift your finger.  This should output the text `default`.
    - Note:  if significant movement occurs, the text will not be output.  (A small "fudge factor" is allowed before this occurs.)