### PR TITLE
refactor(web): Link to `index.html` in test pages

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -20,9 +20,9 @@
   </head>
   <body>
   <h1>KeymanWeb Repo Index</h1>
-  <h2><a href="./src/samples/">View Keymanweb use samples.</a></h2>
-  <h2><a href="./src/test/manual/embed/">View manual test pages for embedded-mode Keymanweb.</a></h2>
-  <h2><a href="./src/test/manual/web/">View Keymanweb website-oriented manual test pages.</a></h2>
-  <h2><a href="./src/tools/testing/">Use Keymanweb development tools.</a></h2>
+  <h2><a href="./src/samples/index.html">View Keymanweb use samples.</a></h2>
+  <h2><a href="./src/test/manual/embed/index.html">View manual test pages for embedded-mode Keymanweb.</a></h2>
+  <h2><a href="./src/test/manual/web/index.html">View Keymanweb website-oriented manual test pages.</a></h2>
+  <h2><a href="./src/tools/testing/index.html">Use Keymanweb development tools.</a></h2>
   </body>
 </html>

--- a/web/src/samples/index.html
+++ b/web/src/samples/index.html
@@ -20,9 +20,11 @@
   </head>
   <body>
   <h1>KeymanWeb Samples</h1>
-  <h2><a href="./simplest/">Example 1 - Toggle UI, all resources in same folder as page</a></h2>
-  <h2><a href="./subfolder_toggle/">Example 2 - Toggle UI, all resources in a common subfolder</a></h2>
-  <h2><a href="./subfolder_toolbar/">Example 3 - Toolbar UI, all resources in a common subfolder</a></h2>
-  <h2><a href="./complex/root/pages/">Example 4 - a more complex file-organization setup</a></h2>
+  <h2><a href="./simplest/index.html">Example 1 - Toggle UI, all resources in same folder as page</a></h2>
+  <h2><a href="./subfolder_toggle/index.html">Example 2 - Toggle UI, all resources in a common subfolder</a></h2>
+  <h2><a href="./subfolder_toolbar/index.html">Example 3 - Toolbar UI, all resources in a common subfolder</a></h2>
+  <h2><a href="./complex/root/pages/index.html">Example 4 - a more complex file-organization setup</a></h2>
+  <hr>
+  <p><a href="../../index.html">Return to main index</a></p>
   </body>
 </html>

--- a/web/src/test/manual/embed/index.html
+++ b/web/src/test/manual/embed/index.html
@@ -19,8 +19,9 @@
     </style>
   </head>
   <body>
-  <h1>KeymanWeb 15 Testing - for embedded contexts</h1>
-  <h2><a href="./android-harness/">Android test harness</a></h2>
-  <p><a href="../../../../index.html">Return to main index.</a>
+  <h1>KeymanWeb Testing - for embedded contexts</h1>
+  <h2><a href="./android-harness/index.html">Android test harness</a></h2>
+  <hr>
+  <p><a href="../../../../index.html">Return to main index</a>
   </body>
 </html>

--- a/web/src/test/manual/web/index.html
+++ b/web/src/test/manual/web/index.html
@@ -22,52 +22,53 @@
   <h1>KeymanWeb 17 Testing</h1>
   <h2><a href="./unminified.html">Test unminified Keymanweb</a></h2>
   <h2><a href="./unminified - manual.html">Test unminified Keymanweb in manual-attachment mode.</a></h2>
-  <h2><a href="./keyboard-errors/">Tests keyboard error-handling functionality</a></h2>
-  <h2><a href="./attachment-api/?mode=auto">Tests the new Attachment/Enablement API functionality</a><h2>
-  <h2><a href="./chirality/">Chirality testing/bootstrapping</a><h2>
-  <h2><a href="./options-with-save/">Tests option/variable store functionality</a></h2>
-  <h2><a href="./empty-row/">Tests OSK handling of empty rows</a></h2>
-  <h2><a href="./platform/">Platform testing</a></h2>
-  <h2><a href="./prediction-ui/">Prediction UI testing</a></h2>
-  <h2><a href="./prediction-mtnt/">Prediction - robust testing</a></h2>
-  <h2><a href="./promise-api/">Promise API testing</a></h2>
-  <h2><a href="./desktop-ui/">Desktop UI module testing</a></h2>
-  <h2><a href="./build-visual-keyboard/">Tests keyboard documentation rendering.</a></h2>
-  <h2><a href="./sentry-integration/">Tests Sentry error-reporting functionality</a></h2>
-  <h2><a href="./osk-movement/">Test page for osk setRect() and restorePosition() interaction</a></h2>
-  <h2><a href="./ckeditor/">Integration with CKEditor</a></h2>
-  <h2><a href="./osk-event-buttons/">Tests toggling & use of desktop OSK config & help buttons</a></h2>
+  <h2><a href="./keyboard-errors/index.html">Tests keyboard error-handling functionality</a></h2>
+  <h2><a href="./attachment-api/index.html?mode=auto">Tests the new Attachment/Enablement API functionality</a><h2>
+  <h2><a href="./chirality/index.html">Chirality testing/bootstrapping</a><h2>
+  <h2><a href="./options-with-save/index.html">Tests option/variable store functionality</a></h2>
+  <h2><a href="./empty-row/index.html">Tests OSK handling of empty rows</a></h2>
+  <h2><a href="./platform/index.html">Platform testing</a></h2>
+  <h2><a href="./prediction-ui/index.html">Prediction UI testing</a></h2>
+  <h2><a href="./prediction-mtnt/index.html">Prediction - robust testing</a></h2>
+  <h2><a href="./promise-api/index.html">Promise API testing</a></h2>
+  <h2><a href="./desktop-ui/index.html">Desktop UI module testing</a></h2>
+  <h2><a href="./build-visual-keyboard/index.html">Tests keyboard documentation rendering.</a></h2>
+  <h2><a href="./sentry-integration/index.html">Tests Sentry error-reporting functionality</a></h2>
+  <h2><a href="./osk-movement/index.html">Test page for osk setRect() and restorePosition() interaction</a></h2>
+  <h2><a href="./ckeditor/index.html">Integration with CKEditor</a></h2>
+  <h2><a href="./osk-event-buttons/index.html">Tests toggling & use of desktop OSK config & help buttons</a></h2>
   <h1>Auto-attachment mode tests</h1>
-  <h2><a href="./issue29/">Test desktop MutationObserver functionality</a></h2>
-  <h2><a href="./issue62/">Light test for touch-based MutationObserver functionality</a></h2>
-  <h2><a href="./issue63/">Test/stress-test touch-based MutationObserver functionality</a></h2>
+  <h2><a href="./issue29/index.html">Test desktop MutationObserver functionality</a></h2>
+  <h2><a href="./issue62/index.html">Light test for touch-based MutationObserver functionality</a></h2>
+  <h2><a href="./issue63/index.html">Test/stress-test touch-based MutationObserver functionality</a></h2>
   <h1>Issue Testing</h1>
-  <h2><a href="./issue005/">'Test case' for proper implementation of the removeKeyboards API function.</a></h2>
-  <h2><a href="./issue53/">Tests layering transitions for keyboards with variable layer sizes.</a></h2>
-  <h2><a href="./issue103/">Tests keyboard loading with repeated requests</a></h2>
-  <h2><a href="./issue115/">Long-press on numeric and symbolic layer testing</a></h2>
-  <h2><a href="./issue116/">Next-layer processing testing</a></h2>
-  <h2><a href="./issue160/">Uxxxx code testing</a></h2>
+  <h2><a href="./issue005/index.html">'Test case' for proper implementation of the removeKeyboards API function.</a></h2>
+  <h2><a href="./issue53/index.html">Tests layering transitions for keyboards with variable layer sizes.</a></h2>
+  <h2><a href="./issue103/index.html">Tests keyboard loading with repeated requests</a></h2>
+  <h2><a href="./issue115/index.html">Long-press on numeric and symbolic layer testing</a></h2>
+  <h2><a href="./issue116/index.html">Next-layer processing testing</a></h2>
+  <h2><a href="./issue160/index.html">Uxxxx code testing</a></h2>
   <h2><a href="./issue266/index.html">Test KMW beep</a></h2>
-  <h2><a href="./issue271/">Test page for interactions between setActiveKeyboard and the toolbar UI.</a></h2>
+  <h2><a href="./issue271/index.html">Test page for interactions between setActiveKeyboard and the toolbar UI.</a></h2>
   <h2><a href="./issue1332/index.html">Test keyboard loading with upper case TTF font</a></h2>
-  <h2><a href="./basic-iframe">Test page for IFrame connectivity and class prototype management.</a></h2>
-  <h2><a href="./mnemonic">Test page for mnemonic basic support on US English.</a></h2>
-  <h2><a href="./rotation-events">Test page for evaluating issues with mobile device rotation events.</a></h2>
-  <h2><a href="./issue382/">Test page for automatic key-cap scaling.</a></h2>
-  <h2><a href="./issue3701/">Test page for fat-finger interaction with beep feedback</a></h2>
-  <h2><a href="./issue917-context-and-notany/">Test page for context() and notany() interaction</a></h2>
-  <h2><a href="./spacebar-text/">Test SpacebarText APIs (#949)</a></h2>
-  <h2><a href="./inline-osk/">Test inline OSK (#5665)</a></h2>
-  <h2><a href="./issue2924/">Test variable stores and predictive text (#2924)</a></h2>
-  <h2><a href="./caps-lock-layer-3620/">Test Caps Lock Layer (#3620)</a></h2>
-  <h2><a href="./start-of-sentence-3621/">Test Start of Sentence (#3621)</a></h2>
-  <h2><a href="./start-of-sentence-3621/">Test start of sentence keyboard rules (#5963)</a></h2>
-  <h2><a href="./issue6005/">Tests predictive text & other handling of rule matching when the final rule group does not match (#6005)</a></h2>
-  <h2><a href="./default-subkey/">Tests handling of new default-subkey feature (#9430)</a></h2>
-  <h2><a href="./issue9469/">Test special characters rendering with keymanweb-osk.ttf (#9469)</a></h2>
+  <h2><a href="./basic-iframe/index.html">Test page for IFrame connectivity and class prototype management</a></h2>
+  <h2><a href="./mnemonic/index.html">Test page for mnemonic basic support on US English</a></h2>
+  <h2><a href="./rotation-events/index.html">Test page for evaluating issues with mobile device rotation events</a></h2>
+  <h2><a href="./issue382/index.html">Test page for automatic key-cap scaling</a></h2>
+  <h2><a href="./issue3701/index.html">Test page for fat-finger interaction with beep feedback</a></h2>
+  <h2><a href="./issue917-context-and-notany/index.html">Test page for context() and notany() interaction</a></h2>
+  <h2><a href="./spacebar-text/index.html">Test SpacebarText APIs (#949)</a></h2>
+  <h2><a href="./inline-osk/index.html">Test inline OSK (#5665)</a></h2>
+  <h2><a href="./issue2924/index.html">Test variable stores and predictive text (#2924)</a></h2>
+  <h2><a href="./caps-lock-layer-3620/index.html">Test Caps Lock Layer (#3620)</a></h2>
+  <h2><a href="./start-of-sentence-3621/index.html">Test Start of Sentence (#3621)</a></h2>
+  <h2><a href="./start-of-sentence-3621/index.html">Test start of sentence keyboard rules (#5963)</a></h2>
+  <h2><a href="./issue6005/index.html">Tests predictive text & other handling of rule matching when the final rule group does not match (#6005)</a></h2>
+  <h2><a href="./default-subkey/index.html">Tests handling of new default-subkey feature (#9430)</a></h2>
+  <h2><a href="./issue9469/index.html">Test special characters rendering with keymanweb-osk.ttf (#9469)</a></h2>
   <h1>Other</h1>
-  <h2><a href="./regression-tests/">Keystroke processing regression test engine.</a></h2>
-  <p><a href="../../../../index.html">Return to main index.</a>
+  <h2><a href="./regression-tests/index.html">Keystroke processing regression test engine.</a></h2>
+  <hr>
+  <p><a href="../../../../index.html">Return to main index</a>
   </body>
 </html>

--- a/web/src/tools/testing/index.html
+++ b/web/src/tools/testing/index.html
@@ -20,9 +20,9 @@
   </head>
   <body>
     <h1>KeymanWeb Resources and Tools</h1>
-  <h2><a href="./bulk_rendering/">Bulk OSK renderer</a></h2>
-  <h2><a href="./recorder/">Test-sequence recorder</a></h2>
+  <h2><a href="./bulk_rendering/index.html">Bulk OSK renderer</a></h2>
+  <h2><a href="./recorder/index.html">Test-sequence recorder</a></h2>
   <hr>
-  <p><a href="../../../index.html">Return to main index.</a>
+  <p><a href="../../../index.html">Return to main index</a>
   </body>
 </html>


### PR DESCRIPTION
This change adds `index.html` to all links that point to test index pages. This will show the index page instead of the directory listing when opening locally, identical to the behavior on TC.

@keymanapp-test-bot skip