### PR TITLE
fix(web): Increase size of spacebar text

### DIFF
--- a/web/src/engine/osk/src/keyboard-layout/oskKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskKey.ts
@@ -208,6 +208,7 @@ export default abstract class OSKKey {
   /**
    * Calculate the font size required for a key cap, scaling to fit longer text
    * @param vkbd
+   * @param text
    * @param style     specification for the desired base font size
    * @param override  if true, don't use the font spec from the button, just use the passed in spec
    * @returns         font size as a style string
@@ -239,14 +240,15 @@ export default abstract class OSKKey {
     const MAX_X_PROPORTION = 0.90;
     const MAX_Y_PROPORTION = 0.90;
     const X_PADDING = 2;
-    const Y_PADDING = 2;
 
     var fontHeight: number, keyHeight: number;
     if(metrics.fontBoundingBoxAscent) {
       fontHeight = metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent;
     }
 
-    let textHeight = fontHeight ? fontHeight + Y_PADDING : 0;
+    // Don't add extra padding to height - multiplying with MAX_Y_PROPORTION already gives
+    // padding
+    let textHeight = fontHeight ? fontHeight : 0;
     if(style.height && style.height.indexOf('px') != -1) {
       keyHeight = Number.parseFloat(style.height.substring(0, style.height.indexOf('px')));
     }

--- a/web/src/engine/osk/src/keyboard-layout/oskKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskKey.ts
@@ -248,7 +248,7 @@ export default abstract class OSKKey {
 
     // Don't add extra padding to height - multiplying with MAX_Y_PROPORTION already gives
     // padding
-    let textHeight = fontHeight ? fontHeight : 0;
+    let textHeight = fontHeight ?? 0;
     if(style.height && style.height.indexOf('px') != -1) {
       keyHeight = Number.parseFloat(style.height.substring(0, style.height.indexOf('px')));
     }

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -526,7 +526,7 @@ div.android div.kmw-keytip-cap {
 .kmw-wait-graphic{width:100%;min-height:19px;background:url('ajax-loader.gif') no-repeat;background-position:center top;}
 .kmw-alert-text{margin:10px;white-space:default;font-family:Arial,sans-serif;}
 
-.kmw-spacebar-caption{font:0.6em Arial !important;color:rgba(0,0,0,0.25);}
+.kmw-spacebar-caption{font:1em Arial !important;color:rgba(0,0,0,0.25);}
 
 /* Probably best to make this its own CSS that can be optionally included? */
 @media (prefers-color-scheme: dark) {

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -526,6 +526,7 @@ div.android div.kmw-keytip-cap {
 .kmw-wait-graphic{width:100%;min-height:19px;background:url('ajax-loader.gif') no-repeat;background-position:center top;}
 .kmw-alert-text{margin:10px;white-space:default;font-family:Arial,sans-serif;}
 
+/* Note: font size gets overwritten in source code! */
 .kmw-spacebar-caption{font:1em Arial !important;color:rgba(0,0,0,0.25);}
 
 /* Probably best to make this its own CSS that can be optionally included? */


### PR DESCRIPTION
Fixes #7940.

The caption on the spacebar used to be 60% (0.6em). This change increases it to 100%.

One reason for the sometimes small text on the spacebar described in #7940 besides the too small font size on `kmw-spacebar-caption` was that the calculation of the ideal font size added double padding: it added two pixels of
padding to the height, but also multiplied the height value by 0.9 which effectively added more padding. This change removes the 2 pixel padding from the calculation.

Note that it is still possible for the text on the spacebar to become unreasonably small if the keyboard/language name is too long. However, that is outside of the scope of this PR.

![Screenshot from 2023-11-07 19-26-53](https://github.com/keymanapp/keyman/assets/181336/aae0c748-c8f5-4e03-881d-7bedbec408fa)

# User Testing

**TEST_EMULATOR**: 

- Go to the "Prediction - robust testing" test page in Chrome.
- Launch developer mode and set it to emulate an iPhone SE.
- Set the emulation scale to better match the relative size to a physical handheld iPhone SE.
- verify that the keyboard name on the spacebar has a reasonable size

**TEST_HARDWARE**:

- Install Keyman on an Android or iPhone device
- Open the Keyman app and install a Keyman keyboard
- verify that the keyboard name on the spacebar has a reasonable size

**TEST_WEB**:

- Go to the "Prediction - robust testing" test page in Chrome.
- verify that the keyboard name on the spacebar has a reasonable size
