### PR TITLE
feat(developer): show .xml LDML keyboards in project 🦕

### DIFF
--- a/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFile.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFile.pas
@@ -629,7 +629,10 @@ begin
   node.AddChild('Filename').NodeValue := ExtractFileName(FFileName);
   node.AddChild('Filepath').NodeValue := ExtractRelativePath(FProject.FileName, FFileName);
   node.AddChild('FileVersion').NodeValue := FFileVersion;   // I4701
-  node.AddChild('FileType').NodeValue := ExtractFileExt(FFileName);;
+
+  // Note: FileType is only ever written in Delphi code; it is used by xsl
+  // transforms for rendering
+  node.AddChild('FileType').NodeValue := ExtractFileExt(FFileName);
   if Assigned(FParent) then
     node.AddChild('ParentFileID').NodeValue := FParent.ID;
 end;

--- a/developer/src/tike/project/Keyman.Developer.System.Project.xmlLdmlProjectFile.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.xmlLdmlProjectFile.pas
@@ -91,6 +91,13 @@ end;
 procedure TxmlLdmlProjectFile.Save(node: IXMLNode);   // I4698
 begin
   inherited Save(node);   // I4698
+
+  // We override the FileType set by TProjectFile so that we
+  // can distinguish .xml keyboard files in the project view
+  // from other arbitrary .xml files that may be in the project
+  // FileType is _only_ used by the project view xsl files
+  node.ChildValues['FileType'] := '.xml-ldml-keyboard';
+
   node := node.AddChild('Details');
   if FHeader_Name <> '' then node.AddChild('Name').NodeValue := FHeader_Name;
 end;

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProject.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProject.pas
@@ -109,6 +109,7 @@ uses
   Keyman.Developer.System.Project.kmnProjectFile,
   Keyman.Developer.System.Project.kpsProjectFile,
   Keyman.Developer.System.Project.modelTsProjectFile,
+  Keyman.Developer.System.Project.xmlLdmlProjectFile,
   Keyman.Developer.System.Project.Project,
   Keyman.Developer.UI.Project.ProjectUI,
   Keyman.Developer.UI.Project.ProjectFileUI,
@@ -470,6 +471,8 @@ begin
     pf := SelectedProjectFile;
     if Assigned(pf) and (pf is TkmnProjectFile) then
       OpenContainingFolder((pf as TkmnProjectFile).TargetFileName)
+    else if Assigned(pf) and (pf is TxmlLdmlProjectFile) then
+      OpenContainingFolder((pf as TxmlLdmlProjectFile).TargetFileName)
     else if Assigned(pf) and (pf is TkpsProjectFile) then
       OpenContainingFolder((pf as TkpsProjectFile).TargetFileName)
     else if Assigned(pf) and (pf is TmodelTsProjectFile) then
@@ -514,7 +517,8 @@ begin
     ClearMessages;
     for i := 0 to FGlobalProject.Files.Count - 1 do
     begin
-      if FGlobalProject.Files[i] is TkmnProjectFile then
+      if (FGlobalProject.Files[i] is TkmnProjectFile) or
+          (FGlobalProject.Files[i] is TxmlLdmlProjectFile) then
         (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaCompile, False);   // I4687
     end;
   end
@@ -523,7 +527,8 @@ begin
     ClearMessages;
     for i := 0 to FGlobalProject.Files.Count - 1 do
     begin
-      if FGlobalProject.Files[i] is TkmnProjectFile then
+      if (FGlobalProject.Files[i] is TkmnProjectFile) or
+          (FGlobalProject.Files[i] is TxmlLdmlProjectFile) then
         (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaClean, False);
     end;
   end

--- a/developer/src/tike/xml/project/distribution.xsl
+++ b/developer/src/tike/xml/project/distribution.xsl
@@ -62,14 +62,14 @@
           <xsl:with-param name="caption">Build all</xsl:with-param>
           <xsl:with-param name="command">keyman:compileall</xsl:with-param>
           <xsl:with-param name="enabled">
-            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn' or FileType='.ts' or FileType='.tsv') and not (ParentFileID)])">false</xsl:if>
+            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn' or FileType='.xml-ldml-keyboard' or FileType='.ts' or FileType='.tsv') and not (ParentFileID)])">false</xsl:if>
           </xsl:with-param>
         </xsl:call-template>
         <xsl:call-template name="button">
           <xsl:with-param name="caption">Clean all</xsl:with-param>
           <xsl:with-param name="command">keyman:cleanall</xsl:with-param>
           <xsl:with-param name="enabled">
-            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn' or FileType='.ts' or FileType='.tsv') and not (ParentFileID)])">false</xsl:if>
+            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn' or FileType='.xml-ldml-keyboard' or FileType='.ts' or FileType='.tsv') and not (ParentFileID)])">false</xsl:if>
           </xsl:with-param>
           <xsl:with-param name="width">auto</xsl:with-param>
         </xsl:call-template>
@@ -78,7 +78,7 @@
         <br />
 
         <div>
-          <xsl:for-each select="/KeymanDeveloperProject/Files/File[FileType!='.kps' and FileType!='.kmn' and FileType!='.ts' and FileType!='.tsv' and not(ParentFileID)]">
+          <xsl:for-each select="/KeymanDeveloperProject/Files/File[FileType!='.kps' and FileType!='.kmn' and FileType!='.xml-ldml-keyboard' and FileType!='.ts' and FileType!='.tsv' and not(ParentFileID)]">
             <xsl:variable name="FileState" select="/KeymanDeveloperProject/FileStates/FileState[ID=current()/ID]" />
             <xsl:call-template name="file">
               <xsl:with-param name="file_description"></xsl:with-param>
@@ -90,7 +90,7 @@
     </div>
   </xsl:template>
 
-  <xsl:template mode="options_menu" match="/KeymanDeveloperProject/Files/File[FileType!='.kps' and FileType!='.kmn' and FileType!='.ts' and FileType!='.tsv']" >
+  <xsl:template mode="options_menu" match="/KeymanDeveloperProject/Files/File[FileType!='.kps' and FileType!='.kmn' and FileType!='.xml-ldml-keyboard' and FileType!='.ts' and FileType!='.tsv']" >
     <div class="menu">
       <xsl:attribute name="id">menu_options_<xsl:value-of select="ID"/></xsl:attribute>
       <xsl:call-template name="menuitem">

--- a/developer/src/tike/xml/project/keyboards.xsl
+++ b/developer/src/tike/xml/project/keyboards.xsl
@@ -88,14 +88,14 @@
           <xsl:with-param name="caption">Build all</xsl:with-param>
           <xsl:with-param name="command">keyman:compileall</xsl:with-param>
           <xsl:with-param name="enabled">
-            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn') and not (ParentFileID)])">false</xsl:if>
+            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn' or FileType='.xml-ldml-keyboard') and not (ParentFileID)])">false</xsl:if>
           </xsl:with-param>
         </xsl:call-template>
         <xsl:call-template name="button">
           <xsl:with-param name="caption">Clean all</xsl:with-param>
           <xsl:with-param name="command">keyman:cleanall</xsl:with-param>
           <xsl:with-param name="enabled">
-            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn') and not (ParentFileID)])">false</xsl:if>
+            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn' or FileType='.xml-ldml-keyboard') and not (ParentFileID)])">false</xsl:if>
           </xsl:with-param>
           <xsl:with-param name="width">auto</xsl:with-param>
         </xsl:call-template>
@@ -104,7 +104,7 @@
           <xsl:with-param name="caption">Build keyboards</xsl:with-param>
           <xsl:with-param name="command">keyman:keyboard_compileall</xsl:with-param>
           <xsl:with-param name="enabled">
-            <xsl:if test="not(KeymanDeveloperProject/Files/File[FileType='.kmn' and not (ParentFileID)])">false</xsl:if>
+            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kmn' or FileType='.xml-ldml-keyboard') and not (ParentFileID)])">false</xsl:if>
           </xsl:with-param>
           <xsl:with-param name="width">auto</xsl:with-param>
         </xsl:call-template>
@@ -112,7 +112,7 @@
           <xsl:with-param name="caption">Clean keyboards</xsl:with-param>
           <xsl:with-param name="command">keyman:keyboard_cleanall</xsl:with-param>
           <xsl:with-param name="enabled">
-            <xsl:if test="not(KeymanDeveloperProject/Files/File[FileType='.kmn' and not (ParentFileID)])">false</xsl:if>
+            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kmn' or FileType='.xml-ldml-keyboard') and not (ParentFileID)])">false</xsl:if>
           </xsl:with-param>
           <xsl:with-param name="width">auto</xsl:with-param>
         </xsl:call-template>
@@ -120,7 +120,7 @@
         <br />
 
         <div>
-          <xsl:for-each select="KeymanDeveloperProject/Files/File[FileType='.kmn' and not(ParentFileID)]">
+          <xsl:for-each select="KeymanDeveloperProject/Files/File[(FileType='.kmn' or FileType='.xml-ldml-keyboard') and not(ParentFileID)]">
             <xsl:variable name="FileState" select="/KeymanDeveloperProject/FileStates/FileState[ID=current()/ID]" />
             <xsl:call-template name="file">
               <xsl:with-param name="file_description">
@@ -138,7 +138,7 @@
     </div>
   </xsl:template>
 
-  <xsl:template mode="options_menu" match="/KeymanDeveloperProject/Files/File[FileType='.kmn']" >
+  <xsl:template mode="options_menu" match="/KeymanDeveloperProject/Files/File[FileType='.kmn' or FileType='.xml-ldml-keyboard']" >
     <div class="menu">
       <xsl:attribute name="id">menu_options_<xsl:value-of select="ID"/></xsl:attribute>
       <xsl:call-template name="menuitem">
@@ -186,7 +186,7 @@
     </div>
   </xsl:template>
 
-  <xsl:template mode="filedetails" match="/KeymanDeveloperProject/Files/File[FileType='.kmn']">
+  <xsl:template mode="filedetails" match="/KeymanDeveloperProject/Files/File[FileType='.kmn' or FileType='.xml-ldml-keyboard']">
     <xsl:variable name="FileState" select="/KeymanDeveloperProject/FileStates/FileState[ID=current()/ID]" />
     <table class="filedetailtext">
       <xsl:if test="$FileState/FullPath">

--- a/developer/src/tike/xml/project/packages.xsl
+++ b/developer/src/tike/xml/project/packages.xsl
@@ -67,14 +67,14 @@
           <xsl:with-param name="caption">Build all</xsl:with-param>
           <xsl:with-param name="command">keyman:compileall</xsl:with-param>
           <xsl:with-param name="enabled">
-            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn') and not (ParentFileID)])">false</xsl:if>
+            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn' or FileType='.xml-ldml-keyboard') and not (ParentFileID)])">false</xsl:if>
           </xsl:with-param>
         </xsl:call-template>
         <xsl:call-template name="button">
           <xsl:with-param name="caption">Clean all</xsl:with-param>
           <xsl:with-param name="command">keyman:cleanall</xsl:with-param>
           <xsl:with-param name="enabled">
-            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn') and not (ParentFileID)])">false</xsl:if>
+            <xsl:if test="not(KeymanDeveloperProject/Files/File[(FileType='.kps' or FileType='.kmn' or FileType='.xml-ldml-keyboard') and not (ParentFileID)])">false</xsl:if>
           </xsl:with-param>
           <xsl:with-param name="width">auto</xsl:with-param>
         </xsl:call-template>

--- a/developer/src/tike/xml/project/welcome.xsl
+++ b/developer/src/tike/xml/project/welcome.xsl
@@ -80,7 +80,7 @@
         <xsl:with-param name="caption">Open</xsl:with-param>
         <xsl:with-param name="command">keyman:openfile?id=<xsl:value-of select="ID" /></xsl:with-param>
       </xsl:call-template>
-      <xsl:if test="FileType='.kmn' or FileType='.kps' or FileType='.kpp'">
+      <xsl:if test="FileType='.kmn' or FileType='.kps' or FileType='.xml-ldml-keyboard'">
         <xsl:call-template name="menuitem">
           <xsl:with-param name="caption">View Source</xsl:with-param>
           <xsl:with-param name="command">keyman:viewfilesource?id=<xsl:value-of select="ID" /></xsl:with-param>


### PR DESCRIPTION
Relates to #9948.

Identifies .xml keyboards when building file list, then shows those appropriately in the keyboard list. Also enables grouped actions such as keyboard_compileall for those keyboards.

XML keyboards listed in the Keyboards tab:
![image](https://github.com/keymanapp/keyman/assets/4498365/59bca42e-6dab-4fc5-9da0-73f221b34e6d)

Note how the empty.xml is correctly identified as _not_ a XML LDML keyboard file:
![image](https://github.com/keymanapp/keyman/assets/4498365/67f98d18-efae-45f0-b6ce-2cb055c6ce58)


@keymanapp-test-bot skip