### PR TITLE
chore(linux): Fix GHA triggering

### DIFF
--- a/resources/build/trigger-builds.inc.sh
+++ b/resources/build/trigger-builds.inc.sh
@@ -79,7 +79,7 @@ function triggerGitHubActionsBuild() {
     GIT_HEAD_SHA="${GIT_BUILD_SHA}"
     GIT_EVENT_TYPE="${GITHUB_ACTION}: release@${VERSION_WITH_TAG}"
   elif [[ $GIT_BRANCH != stable-* ]] && [[ $GIT_BRANCH =~ [0-9]+ ]]; then
-    GIT_BUILD_SHA="$(git rev-parse "refs/pull/${GIT_BRANCH}/merge")"
+    GIT_BUILD_SHA="$(git rev-parse "refs/pull/${GIT_BRANCH}/head")"
     GIT_HEAD_SHA="$(git rev-parse "refs/pull/${GIT_BRANCH}/head")"
     GIT_EVENT_TYPE="${GITHUB_ACTION}: PR #${GIT_BRANCH}"
     GIT_BRANCH="PR-${GIT_BRANCH}"


### PR DESCRIPTION
When we build a PR on TC we use `pull/ID/head` for the build, not `pull/ID/merge`, i.e. the tip of the feature branch and not a merge with the base branch. This means that during the build `pull/ID/merge` is unknown. This change modifies the trigger to use `pull/ID/head` for GHA builds as well.

It's still a mystery why `pull/ID/merge` was known to builds in most cases but failed for some PRs.

@keymanapp-test-bot skip