### PR TITLE
fix(developer): Project upgrade messages now show in Messages panel 🦕

### DIFF
--- a/developer/src/tike/main/UfrmMessages.pas
+++ b/developer/src/tike/main/UfrmMessages.pas
@@ -182,6 +182,12 @@ begin
   mi := FMessageItems[line] as TMessageItem;
   FFilename := mi.FileName;
 
+  if FFileName = FGlobalProject.FileName then
+  begin
+    frmKeymanDeveloper.ShowProject;
+    Exit;
+  end;
+
   frm := frmKeymanDeveloper.FindEditorByFileName(FFileName);
   if not Assigned(frm) then
   begin

--- a/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFile.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFile.pas
@@ -984,17 +984,6 @@ begin
   end;
 end;
 
-{
-function IsLMDLKeyboardFile(filename: string): Boolean;
-  if EndsText('.xml', filename) then
-  begin
-    Result := Pos('ldmlKeyboard3.dtd', ReadUtf8FileText(ff)) > 0;
-  end
-  else
-    Result := False;
-end;
-}
-
 function TProject.CanUpgrade: Boolean;
 var
   i: Integer;
@@ -1015,12 +1004,12 @@ begin
   if Options.BuildPath.Contains('$SOURCEPATH') then
   begin
     Result := False;
-    FUpgradeMessages.Add('The BuildPath option contains "$SOURCEPATH"');
+    FUpgradeMessages.Add('The BuildPath project setting contains the "$SOURCEPATH" tag, which is no longer supported');
   end;
   if Options.BuildPath.Contains('$VERSION') then
   begin
     Result := False;
-    FUpgradeMessages.Add('The BuildPath option contains "$VERSION"');
+    FUpgradeMessages.Add('The BuildPath project setting contains the "$VERSION" tag, which is no longer supported');
   end;
 
   for i := 0 to Files.Count - 1 do
@@ -1037,7 +1026,7 @@ begin
       Continue;
     end;
 
-    FUpgradeMessages.Add('File '+Files[i].FileName+' is outside the project folder');
+    FUpgradeMessages.Add('File '+Files[i].FileName+' is outside the project folder. All primary source files must be in the same folder as the project file, or in a subfolder.');
     Result := False;
   end;
 end;

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UpgradeProject.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UpgradeProject.pas
@@ -13,13 +13,18 @@ function TryUpgradeProject(Project: TProject): TUpgradeResult;
 implementation
 
 uses
+  System.Classes,
   System.UITypes,
   Vcl.Controls,
   Vcl.Dialogs,
 
+  UfrmMessages,
+  Keyman.Developer.System.Project.ProjectLog,
   KeymanDeveloperOptions;
 
 function TryUpgradeProject(Project: TProject): TUpgradeResult;
+var
+  msg: string;
 begin
   Result := urNoAction;
 
@@ -29,22 +34,32 @@ begin
     Exit;
   end;
 
-{  if not FKeymanDeveloperOptions.PromptForProjectUpgrade then
+{ TODO:
+ if not FKeymanDeveloperOptions.PromptForProjectUpgrade then
   begin
     // User wishes to stick with v1.0 projects
     Exit;
-  end;}
+  end;
+}
+
+  frmMessages.Clear;
 
   if not Project.CanUpgrade then
   begin
     // Project has restrictions, such as files in wrong folders, so
     // we cannot upgrade. Show a message for the user
-    ShowMessage('The current project cannot be upgraded to v2.0. The following errors were encountered:'#13#10+
-      Project.UpgradeMessages.Text);
+    for msg in Project.UpgradeMessages do
+    begin
+      Project.Log(plsError, Project.FileName, msg, 0, 0);
+    end;
+    MessageDlg('Some issues must be addressed before the current project can '+
+      'be upgraded to Keyman Developer 17 format.  '+
+      'Details of the issues are listed in the Messages panel.', mtError, [mbOk], 0);
     Exit;
   end;
 
-  case MessageDlg('The current project can be upgraded to Keyman Developer 17.0 format. Do you wish to upgrade it (recommended)?'#13#10#13#10+
+  case MessageDlg('The current project can be upgraded to Keyman Developer 17.0 format.  '+
+      'Do you wish to upgrade it (recommended)?'#13#10#13#10+
       'Note: upgraded projects will not be readable by older versions of Keyman Developer.',
       mtConfirmation, mbYesNoCancel, 0) of
     mrNo: Exit;


### PR DESCRIPTION
Relates to #9948.

Having the project upgrade messages in the Messages panel means that users can refer to them as they clean up their projects to bring them into the v17 format.

https://github.com/keymanapp/keyman/assets/4498365/2ad0f39f-00c3-4eba-bb61-67a3bb5dfc02

(Note near the end of the video: the lingering messages in the messages window are now cleared.)

# User Testing

**TEST_UPGRADE:** Try to upgrade a project to v17 format -- choose a project that has files from various locations, and observe the messages presented during upgrade. Remove the files that are not in the right folder, and then run the upgrade again. The upgrade should succeed and the Upgrade warning message should disappear.