### PR TITLE
change(web): gestures polish pass

### DIFF
--- a/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
@@ -4,7 +4,7 @@ import OSKBaseKey from '../../../keyboard-layout/oskBaseKey.js';
 import VisualKeyboard from '../../../visualKeyboard.js';
 
 import { DeviceSpec, KeyEvent, ActiveSubKey, KeyDistribution, ActiveKeyBase } from '@keymanapp/keyboard-processor';
-import { ConfigChangeClosure, GestureRecognizerConfiguration, GestureSequence, PaddedZoneSource } from '@keymanapp/gesture-recognizer';
+import { ConfigChangeClosure, GestureRecognizerConfiguration, GestureSequence, PaddedZoneSource, RecognitionZoneSource } from '@keymanapp/gesture-recognizer';
 import { GestureHandler } from '../gestureHandler.js';
 import { CorrectionLayout, CorrectionLayoutEntry, distributionFromDistanceMaps, keyTouchDistances } from '@keymanapp/input-processor';
 import { GestureParams } from '../specsForLayout.js';
@@ -181,23 +181,22 @@ export default class SubkeyPopup implements GestureHandler {
       -bottomDistance < basePadding ? -bottomDistance : basePadding
     ]);
 
-    const topContainer = vkbd.topContainer;
-    const topContainerBounding = topContainer.getBoundingClientRect();
-    // Uses the top boundary from `roamBounding` unless the OSK's main element has a more
-    // permissive top boundary.
-    const topPadding = Math.min(baseBounding.top + basePadding * topScalar - topContainerBounding.top, 0);
-    const sustainBounding = new PaddedZoneSource(topContainer, [topPadding * topScalar, 0, 0]);
+    const sustainBounding: RecognitionZoneSource = {
+      getBoundingClientRect() {
+        // We don't want to actually use Number.NEGATIVE_INFINITY or Number.POSITIVE_INFINITY
+        // because that produces a DOMRect with a few NaN fields, and we don't want _that_.
 
-    let safeBounds = vkbd.gestureEngine.config.safeBounds;
-    if(vkbd.isEmbedded) {
-      safeBounds = new PaddedZoneSource(safeBounds, [topPadding * topScalar, 0, 0]);
+        // Way larger than any screen resolution should ever be.
+        const base = Number.MAX_SAFE_INTEGER;
+        return new DOMRect(-base, -base, 2*base, 2*base);
+      },
     }
 
     return {
       targetRoot: this.element,
       inputStartBounds: vkbd.element,
       maxRoamingBounds: sustainBounding,
-      safeBounds: safeBounds, // if embedded, ensure top boundary extends outside the WebView!
+      safeBounds: sustainBounding, // if embedded, ensure top boundary extends outside the WebView!
       itemIdentifier: (coord, target) => {
         const roamingRect = roamBounding.getBoundingClientRect();
 

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -458,11 +458,6 @@ export const SubkeySelectContactModel: ContactModel = {
 // func at the top.
 type GestureModel<Type> = specs.GestureModel<Type>;
 
-// TODO:  customization of the gesture models depending upon properties of the keyboard.
-// - has flicks?  no longpress shortcut, also no longpress reset(?)
-// - modipress:  keyboard-specific modifier keys - which may require inspection of a
-//   key's properties.
-
 export const SpecialKeyStartModel: GestureModel<KeyElement> = {
   id: 'special-key-start',
   resolutionPriority: 0,

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -435,6 +435,8 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
         }
       }
 
+      // Fix:  if flicks enabled, no roaming.
+
       // Note:  GestureSource does not currently auto-terminate if there are no
       // remaining matchable gestures.  Though, we shouldn't facilitate roaming
       // anyway if we've turned it off.
@@ -447,13 +449,15 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
           this.highlightKey(oldKey, false);
           this.gesturePreviewHost?.cancel();
 
-          const previewHost = this.highlightKey(key, true);
-          if(previewHost) {
-            this.gesturePreviewHost = previewHost;
-          }
+          if(!this.kbdLayout.hasFlicks) {
+            const previewHost = this.highlightKey(key, true);
+            if(previewHost) {
+              this.gesturePreviewHost = previewHost;
+            }
 
-          trackingEntry.previewHost = previewHost;
-          sourceTrackingMap[source.identifier].key = key;
+            trackingEntry.previewHost = previewHost;
+            sourceTrackingMap[source.identifier].key = key;
+          }
         }
       }
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -132,8 +132,8 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
   /**
    * Tweakable gesture parameters referenced by supported gestures and the gesture engine.
    */
-  readonly gestureParams: GestureParams = {
-    ...DEFAULT_GESTURE_PARAMS
+  readonly gestureParams: GestureParams<KeyElement> = {
+    ...DEFAULT_GESTURE_PARAMS,
   };
 
   // Legacy alias, maintaining a reference for code built against older
@@ -387,6 +387,11 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
 
         return this.layerGroup.findNearestKey(sample);
       }
+    };
+
+    this.gestureParams.longpress.permitsFlick = (key) => {
+      const flickSpec = key?.key.spec.flick;
+      return !flickSpec || !(flickSpec.n || flickSpec.nw || flickSpec.ne);
     };
 
     const recognizer = new GestureRecognizer(gestureSetForLayout(this.layerGroup, this.gestureParams), config);

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -274,6 +274,19 @@
 .kmw-key-popup-icon{position:absolute;display:block;visibility:visible;right:4%;top:1%;/*width:8px;height:8px;*/
       font-size:0.5em;color:#aaa; line-height:initial}
 
+/* For certain form-factors, #aaa blends in with the special-key background-color _way_ too well. */
+/* e.g: .phone.ios .kmw-key.kmw-key-special {background-color:#b2b9c5;} */
+.kmw-key-special .kmw-key-popup-icon {
+  color: #ddd;
+}
+
+@media (prefers-color-scheme: dark) {
+  /* But not in dark mode. */
+  .kmw-key-special .kmw-key-popup-icon {
+    color: #aaa;
+  }
+}
+
 /*.phone .kmw-key-popup-icon{right:6%;top:-2px;width:8px;height:8px;text-align:right;}
 .desktop .kmw-key-popup-icon{right:4%;top:0;width:8px;height:8px;} */
 


### PR DESCRIPTION
This PR accomplishes three things:

1. Longpresses and flicks no longer auto-cancel, except possibly when the path wanders into OS-managed areas (like the system banner or footer on iOS)
2. The longpress up-flick will be enabled for all longpress keys except for those with defined north-ish flicks - one in the nw, n, or ne directions.  Thus, the shortcut can work even with flick-enabled keyboards.
3. Key hint text was nigh-invisible on iOS light-mode special keys; this has been fixed.

TODO: user test definitions