### PR TITLE
chore(developer): only build source files 🦕

### DIFF
--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProject.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProject.pas
@@ -288,6 +288,8 @@ begin
   ClearMessages;
   for i := 0 to FGlobalProject.Files.Count - 1 do
   begin
+    if not FGlobalProject.Files[i].IsSourceFile then
+      Continue;
     if FGlobalProject.Files[i].IsCompilable and
       not (FGlobalProject.Files[i] is TkpsProjectFile) then
     begin
@@ -296,6 +298,8 @@ begin
   end;
   for i := 0 to FGlobalProject.Files.Count - 1 do
   begin
+    if not FGlobalProject.Files[i].IsSourceFile then
+      Continue;
     if FGlobalProject.Files[i] is TkpsProjectFile then
       if not (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaCompile, False) then Exit;   // I4687
   end;
@@ -509,6 +513,8 @@ begin
     ClearMessages;
     for i := 0 to FGlobalProject.Files.Count - 1 do
     begin
+      if not FGlobalProject.Files[i].IsSourceFile then
+        Continue;
       (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaClean, False);   // I4687
     end;
   end
@@ -517,6 +523,9 @@ begin
     ClearMessages;
     for i := 0 to FGlobalProject.Files.Count - 1 do
     begin
+      if not FGlobalProject.Files[i].IsSourceFile then
+        Continue;
+
       if (FGlobalProject.Files[i] is TkmnProjectFile) or
           (FGlobalProject.Files[i] is TxmlLdmlProjectFile) then
         (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaCompile, False);   // I4687
@@ -527,6 +536,8 @@ begin
     ClearMessages;
     for i := 0 to FGlobalProject.Files.Count - 1 do
     begin
+      if not FGlobalProject.Files[i].IsSourceFile then
+        Continue;
       if (FGlobalProject.Files[i] is TkmnProjectFile) or
           (FGlobalProject.Files[i] is TxmlLdmlProjectFile) then
         (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaClean, False);
@@ -537,6 +548,8 @@ begin
     ClearMessages;
     for i := 0 to FGlobalProject.Files.Count - 1 do
     begin
+      if not FGlobalProject.Files[i].IsSourceFile then
+        Continue;
       if FGlobalProject.Files[i] is TmodelTsProjectFile then
         (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaCompile, False);   // I4687
     end;
@@ -546,6 +559,8 @@ begin
     ClearMessages;
     for i := 0 to FGlobalProject.Files.Count - 1 do
     begin
+      if not FGlobalProject.Files[i].IsSourceFile then
+        Continue;
       if FGlobalProject.Files[i] is TmodelTsProjectFile then
         (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaClean, False);
     end;
@@ -556,6 +571,8 @@ begin
     ClearMessages;
     for i := 0 to FGlobalProject.Files.Count - 1 do
     begin
+      if not FGlobalProject.Files[i].IsSourceFile then
+        Continue;
       if FGlobalProject.Files[i] is TkpsProjectFile then
         (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaCompile, False);
     end;
@@ -565,6 +582,8 @@ begin
     ClearMessages;
     for i := 0 to FGlobalProject.Files.Count - 1 do
     begin
+      if not FGlobalProject.Files[i].IsSourceFile then
+        Continue;
       if FGlobalProject.Files[i] is TkpsProjectFile then
         (FGlobalProject.Files[i].UI as TProjectFileUI).DoAction(pfaClean, False);
     end;


### PR DESCRIPTION
For batch builds (e.g. project/compile all) of v2.0 projects, we only want to build files that are listed in the project's $SOURCEPATH, so that the project can contain extra folders with source file types that won't break a project-level build.

Any source file types in extra folders can still be built one-by-one, which is helpful for investigation and test for keyboard authors, but will not be built if project build is selected.

This commit also formalizes the source/ SourcePath for upgraded projects which contain a source/ folder. If the project to be upgraded does not contain the source/ folder, then no SourcePath is assigned, and any source file in any folder will be built.

@keymanapp-test-bot skip