### PR TITLE
chore(developer): manage SourcePath in project upgrade 🦕

### DIFF
--- a/developer/src/tike/project/Keyman.Developer.System.Project.xmlLdmlProjectFile.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.xmlLdmlProjectFile.pas
@@ -145,10 +145,6 @@ begin
 end;
 
 procedure TxmlLdmlProjectFile.GetFileParameters;
-var
-  j: Integer;
-  value: WideString;
-  FVersion: string;   // I4701
 begin
   FHeader_Name := '';
   FKVKFileName := '';

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.xmlLdmlProjectFileUI.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.xmlLdmlProjectFileUI.pas
@@ -21,7 +21,6 @@ type
   TxmlLdmlProjectFileUI = class(TOpenableProjectFileUI)
   private
     function TestKeymanWeb(FSilent: Boolean): Boolean;
-    function DebugKeyboard(FSilent: Boolean): Boolean;
     function InstallKeyboard: Boolean;
     function UninstallKeyboard: Boolean;
     function GetProjectFile: TxmlLdmlProjectFileAction;
@@ -232,15 +231,6 @@ end;
 function TxmlLdmlProjectFileUI.UninstallKeyboard: Boolean;
 begin
   Result := KeymanDeveloperUtils.UninstallKeyboard(ChangeFileExt(ExtractFileName(ProjectFile.FileName), ''));
-end;
-
-function TxmlLdmlProjectFileUI.DebugKeyboard(FSilent: Boolean): Boolean;
-var
-  editor: TfrmLdmlKeyboardEditor;
-begin
-  editor := frmKeymanDeveloper.OpenEditor(ProjectFile.FileName, TfrmLdmlKeyboardEditor) as TfrmLdmlKeyboardEditor;
-//  editor.StartDebugging;
-  Result := True;
 end;
 
 function TxmlLdmlProjectFileUI.TestKeyboardState(FCompiledName: string; FSilent: Boolean): Boolean;


### PR DESCRIPTION
Relates to #9948.

When upgrading a project to v2.0, it is important that all source files are in the same folder. This change makes the upgrade process verify that this is the case and blocks the upgrade if there are source files in multiple folders.

Source files are .kmn, .xml (ldml keyboard), .kps, and .model.ts.

Note: cleanups in other units are removing unused code.

@keymanapp-test-bot skip