### PR TITLE
refactor(web): inactive banner management 🎏

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -24,6 +24,7 @@ if(_debug) {
 var oskHeight = 0;
 var oskWidth = 0;
 var bannerHeight = 0;
+var bannerImgPath = '';
 
 var sentryManager = new KeymanSentryManager({
     hostPlatform: "ios"
@@ -73,14 +74,13 @@ function verifyLoaded() {
 
 function showBanner(flag) {
     console.log("Setting banner display for dictionaryless keyboards to " + flag);
-    keyman.osk.bannerController.setOptions({'alwaysShow': flag});
+
+    var bc = keyman.osk.bannerController;
+    bc.inactiveBanner = flag ? new bc.ImageBanner(bannerImgPath) : null;
 }
 
 function setBannerImage(path) {
-    var kmw=window['keyman'];
-    if(kmw.osk) {
-        kmw.osk.bannerController.setOptions({"imagePath": path});
-    }
+    bannerImgPath = path;
 }
 
 function setBannerHeight(h) {

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -323,7 +323,7 @@ export default class KeymanEngine<
         id: this.core?.activeModel?.id || ''
       },
       osk: {
-        banner: this.osk?.bannerController?.activeType ?? '',
+        banner: this.osk?.banner?.banner.type ?? '',
         layer: this.osk?.vkbd?.layerId || ''
       }
     };

--- a/web/src/engine/osk/src/banner/banner.ts
+++ b/web/src/engine/osk/src/banner/banner.ts
@@ -89,6 +89,8 @@ export abstract class Banner {
    * @param keyboardProperties
    */
   public configureForKeyboard(keyboard: Keyboard, keyboardProperties: KeyboardProperties) { }
+
+  abstract get type();
 }
 
 /**
@@ -100,4 +102,6 @@ export class BlankBanner extends Banner {
   constructor() {
     super(0);
   }
+
+  readonly type = 'blank';
 }

--- a/web/src/engine/osk/src/banner/bannerController.ts
+++ b/web/src/engine/osk/src/banner/bannerController.ts
@@ -2,7 +2,7 @@ import { DeviceSpec } from '@keymanapp/web-utils';
 import type { PredictionContext, StateChangeEnum } from '@keymanapp/input-processor';
 import { ImageBanner } from './imageBanner.js';
 import { SuggestionBanner } from './suggestionBanner.js';
-import { BannerView, BannerOptions, BannerType } from './bannerView.js';
+import { BannerView } from './bannerView.js';
 import { Banner } from './banner.js';
 import { BlankBanner } from './blankBanner.js';
 import { HTMLBanner } from './htmlBanner.js';
@@ -36,15 +36,22 @@ export class BannerController {
     this.inactiveBanner = new BlankBanner();
   }
 
+  /**
+   * Specifies the `Banner` instance to use when predictive-text is _not_ available to the user.
+   *
+   * Defaults to a hidden, "blank" `Banner` if not otherwise specified.  Changes to its value
+   * when predictive-text is not active will result in banner hot-swapping.
+   *
+   * The assigned instance will persist until directly changed through a new assignment,
+   * regardless of any keyboard swaps and/or activations of the suggestion banner that may
+   * occur in the meantime.
+   */
   public get inactiveBanner() {
     return this._inactiveBanner;
   }
 
   public set inactiveBanner(banner: Banner) {
-    if(!banner) {
-      banner = new BlankBanner();
-    }
-    this._inactiveBanner = banner;
+    this._inactiveBanner = banner ?? new BlankBanner();
 
     if(!(this.container.banner instanceof SuggestionBanner)) {
       this.container.banner = banner;

--- a/web/src/engine/osk/src/banner/bannerController.ts
+++ b/web/src/engine/osk/src/banner/bannerController.ts
@@ -54,7 +54,7 @@ export class BannerController {
     this._inactiveBanner = banner ?? new BlankBanner();
 
     if(!(this.container.banner instanceof SuggestionBanner)) {
-      this.container.banner = banner;
+      this.container.banner = this._inactiveBanner;
     }
   }
 

--- a/web/src/engine/osk/src/banner/bannerView.ts
+++ b/web/src/engine/osk/src/banner/bannerView.ts
@@ -20,7 +20,7 @@ export interface BannerOptions {
   imagePath?: string;
 }
 
-export type BannerType = "blank" | "image" | "suggestion";
+export type BannerType = "blank" | "image" | "suggestion" | "html";
 
 interface BannerViewEventMap {
   'bannerchange': () => void;
@@ -62,6 +62,10 @@ interface BannerViewEventMap {
  */
 export default class BannerView implements OSKViewComponent {
   private bannerContainer: HTMLDivElement;
+
+  /**
+   * The currently active banner.
+   */
   private activeBanner: Banner;
   private _activeBannerHeight: number = Banner.DEFAULT_HEIGHT;
 
@@ -165,20 +169,18 @@ export default class BannerView implements OSKViewComponent {
 }
 
 export class BannerController {
-  private _activeType: BannerType;
-  private _options: BannerOptions = {};
   private container: BannerView;
-  private alwaysShow: boolean;
-  private imagePath?: string = "";
 
   private predictionContext?: PredictionContext;
 
   private readonly hostDevice: DeviceSpec;
 
-  public static readonly DEFAULT_OPTIONS: BannerOptions = {
-    alwaysShow: false,
-    imagePath: ""
-  }
+  private _inactiveBanner: Banner;
+
+  /**
+   * Builds a banner for use when predictions are not active, supporting a single image.
+   */
+  public readonly ImageBanner = ImageBanner;
 
   constructor(bannerView: BannerView, hostDevice: DeviceSpec, predictionContext?: PredictionContext) {
     // Step 1 - establish the container element.  Must come before this.setOptions.
@@ -186,108 +188,46 @@ export class BannerController {
     this.container = bannerView;
     this.predictionContext = predictionContext;
 
-    // Initialize with the default options - any 'manually set' options come post-construction.
-    // This will also automatically set the default banner in place.
-    this.setOptions(BannerController.DEFAULT_OPTIONS);
+    this.inactiveBanner = new BlankBanner();
   }
 
-  /**
-   * This function corresponds to `keyman.osk.banner.getOptions`.
-   *
-   * Gets the current control settings in use by `BannerManager`.
-   */
-  public getOptions(): BannerOptions {
-    let retObj = {};
+  public get inactiveBanner() {
+    return this._inactiveBanner;
+  }
 
-    for(let key in this._options) {
-      retObj[key] = this._options[key];
+  public set inactiveBanner(banner: Banner) {
+    if(!banner) {
+      banner = new BlankBanner();
     }
+    this._inactiveBanner = banner;
 
-    return retObj;
-  }
-
-  /**
-   * This function corresponds to `keyman.osk.banner.setOptions`.
-   *
-   * Sets options used to tweak the automatic `Banner`
-   * control logic used by `BannerManager`.
-   * @param optionSpec An object specifying one or more of the following options:
-   * * `persistentBanner` (boolean) When `true`, ensures that a `Banner`
-   *   is always displayed, even when no predictive model exists
-   *   for the active language.
-   *
-   *   Default: `false`
-   * * `imagePath` (URL string) Specifies the file path to use for an
-   *   `ImageBanner` when `persistentBanner` is `true` and no predictive model exists.
-   *
-   *   Default: `''`.
-   * * `enablePredictions` (boolean) Turns KMW predictions
-   *   on (when `true`) and off (when `false`).
-   *
-   *   Default:  `true`.
-   */
-  public setOptions(optionSpec: BannerOptions) {
-    for(let key in optionSpec) {
-      switch(key) {
-        // Each defined option may require specialized handling.
-        case 'alwaysShow':
-          // Determines the banner type to activate.
-          this.alwaysShow = optionSpec[key];
-          break;
-        case 'imagePath':
-          // Determines the image file to use for ImageBanners.
-          this.imagePath = optionSpec[key];
-          break;
-        default:
-          // Invalid option specified!
-      }
-      this._options[key] = optionSpec[key];
-
-      // If no banner instance exists yet, go with a safe, blank initialization.
-      if(!this.container.banner) {
-        this.selectBanner('inactive');
-      }
+    if(!(this.container.banner instanceof SuggestionBanner)) {
+      this.container.banner = banner;
     }
   }
 
   /**
-   * Sets the active `Banner` to the specified type, regardless of
-   * existing management logic settings.
+   * Sets the active `Banner` to match the specified state for predictive text.
    *
-   * @param type `'blank' | 'image' | 'suggestion'` - A plain-text string
-   *        representing the type of `Banner` to set active.
-   * @param height - Optional banner height in pixels.
+   * @param on   Whether prediction is active (`true`) or disabled (`false`).
    */
-  public setBanner(type: BannerType) {
-    var banner: Banner;
+  public activateBanner(on: boolean) {
+    let banner: Banner;
 
-    let oldBanner = this.container.banner;
+    const oldBanner = this.container.banner;
     if(oldBanner instanceof SuggestionBanner) {
       this.predictionContext.off('update', oldBanner.onSuggestionUpdate);
     }
 
-    switch(type) {
-      case 'blank':
-        banner = new BlankBanner();
-        break;
-      case 'image':
-        banner = new ImageBanner(this.imagePath, this.container.activeBannerHeight);
-        break;
-      case 'suggestion':
-        let suggestBanner = banner = new SuggestionBanner(this.hostDevice, this.container.activeBannerHeight);
-        suggestBanner.predictionContext = this.predictionContext;
-        suggestBanner.events.on('apply', (selection) => this.predictionContext.accept(selection.suggestion));
+    if(!on) {
+      this.container.banner = this.inactiveBanner;
+    } else {
+      let suggestBanner = banner = new SuggestionBanner(this.hostDevice, this.container.activeBannerHeight);
+      suggestBanner.predictionContext = this.predictionContext;
+      suggestBanner.events.on('apply', (selection) => this.predictionContext.accept(selection.suggestion));
 
-        this.predictionContext.on('update', suggestBanner.onSuggestionUpdate);
-        break;
-      default:
-        throw new Error("Invalid type specified for the banner!");
-    }
-
-    this._activeType = type;
-
-    if(banner) {
-      this.container.banner = banner;
+      this.predictionContext.on('update', suggestBanner.onSuggestionUpdate);
+      this.container.banner = suggestBanner;
     }
   }
 
@@ -298,18 +238,6 @@ export class BannerController {
    */
   selectBanner(state: StateChangeEnum) {
     // Only display a SuggestionBanner when LanguageProcessor states it is active.
-    if(state == 'active' || state == 'configured') {
-      this.setBanner('suggestion');
-    } else if(state == 'inactive') {
-      if(this.alwaysShow) {
-        this.setBanner('image');
-      } else {
-        this.setBanner('blank');
-      }
-    }
-  }
-
-  public get activeType(): BannerType {
-    return this._activeType;
+    this.activateBanner(state == 'active' || state == 'configured');
   }
 }

--- a/web/src/engine/osk/src/banner/bannerView.ts
+++ b/web/src/engine/osk/src/banner/bannerView.ts
@@ -63,7 +63,7 @@ export class BannerView implements OSKViewComponent {
   /**
    * The currently active banner.
    */
-  private activeBanner: Banner;
+  private currentBanner: Banner;
   private _activeBannerHeight: number = Banner.DEFAULT_HEIGHT;
 
   public readonly events = new EventEmitter<BannerViewEventMap>();
@@ -94,32 +94,31 @@ export class BannerView implements OSKViewComponent {
    * Applies any stylesheets needed by specific `Banner` instances.
    */
   public appendStyles() {
-    if(this.activeBanner) {
-      this.activeBanner.appendStyleSheet();
+    if(this.currentBanner) {
+      this.currentBanner.appendStyleSheet();
     }
   }
 
   public get banner(): Banner {
-    return this.activeBanner;
+    return this.currentBanner;
   }
 
   /**
-   * Sets the active `Banner` to the specified type, regardless of
-   * existing management logic settings.
-   *
-   * @param banner The `Banner` instance to set as active.
+   * The `Banner` actively being displayed to the user in the OSK's current state,
+   * whether a `SuggestionBanner` (with predictive-text active) or a different
+   * type for use when the predictive-text engine is inactive.
    */
   public set banner(banner: Banner) {
-    if(this.activeBanner) {
-      if(banner == this.activeBanner) {
+    if(this.currentBanner) {
+      if(banner == this.currentBanner) {
         return;
       } else {
-        let prevBanner = this.activeBanner;
-        this.activeBanner = banner;
+        let prevBanner = this.currentBanner;
+        this.currentBanner = banner;
         this.bannerContainer.replaceChild(banner.getDiv(), prevBanner.getDiv());
       }
     } else {
-      this.activeBanner = banner;
+      this.currentBanner = banner;
       if(banner) {
         this.bannerContainer.appendChild(banner.getDiv());
       }
@@ -136,8 +135,8 @@ export class BannerView implements OSKViewComponent {
    * Gets the height (in pixels) of the active `Banner` instance.
    */
   public get height(): number {
-    if(this.activeBanner) {
-      return this.activeBanner.height;
+    if(this.currentBanner) {
+      return this.currentBanner.height;
     } else {
       return 0;
     }
@@ -153,8 +152,8 @@ export class BannerView implements OSKViewComponent {
   public set activeBannerHeight(h: number) {
     this._activeBannerHeight = h;
 
-    if (this.activeBanner && !(this.activeBanner instanceof BlankBanner)) {
-      this.activeBanner.height = h;
+    if (this.currentBanner && !(this.currentBanner instanceof BlankBanner)) {
+      this.currentBanner.height = h;
     }
   }
 

--- a/web/src/engine/osk/src/banner/bannerView.ts
+++ b/web/src/engine/osk/src/banner/bannerView.ts
@@ -9,6 +9,7 @@ import { ImageBanner } from './imageBanner.js';
 import OSKViewComponent from '../components/oskViewComponent.interface.js';
 import { ParsedLengthStyle } from '../lengthStyle.js';
 import { SuggestionBanner } from './suggestionBanner.js';
+import { HTMLBanner } from './htmlBanner.js';
 
 /**
  * This object is used to specify options by both `BannerManager.getOptions`
@@ -181,6 +182,12 @@ export class BannerController {
    * Builds a banner for use when predictions are not active, supporting a single image.
    */
   public readonly ImageBanner = ImageBanner;
+
+  /**
+   * Builds a banner for use when predictions are not active, supporting a more generalized
+   * content pattern than ImageBanner via `innerHTML` specifications.
+   */
+  public readonly HTMLBanner = HTMLBanner;
 
   constructor(bannerView: BannerView, hostDevice: DeviceSpec, predictionContext?: PredictionContext) {
     // Step 1 - establish the container element.  Must come before this.setOptions.

--- a/web/src/engine/osk/src/banner/htmlBanner.ts
+++ b/web/src/engine/osk/src/banner/htmlBanner.ts
@@ -1,0 +1,32 @@
+import { Banner } from "./banner.js";
+
+export class HTMLBanner extends Banner {
+  readonly container: ShadowRoot | HTMLElement;
+  readonly type = 'html';
+
+  constructor(contents?: string) {
+    super();
+
+    const bannerHost = this.getDiv();
+
+    // Ensure any HTML styling applied for the banner contents only apply to the contents,
+    // and not the banner's `position: 'relative'` hosting element.
+    const div = document.createElement('div');
+    div.style.userSelect = 'none';
+    div.style.height = '100%';
+    div.style.width = '100%';
+    bannerHost.appendChild(div);
+
+    // If possible, quarantine styling and JS for the banner contents within Shadow DOM.
+    this.container = (div.attachShadow) ? div.attachShadow({mode: 'closed'}) : div;
+    this.container.innerHTML = contents;
+  }
+
+  get innerHTML() {
+    return this.container.innerHTML;
+  }
+
+  set innerHTML(raw: string) {
+    this.container.innerHTML = raw;
+  }
+}

--- a/web/src/engine/osk/src/banner/imageBanner.ts
+++ b/web/src/engine/osk/src/banner/imageBanner.ts
@@ -8,6 +8,7 @@ import { Banner } from "./banner.js";
  */
 export class ImageBanner extends Banner {
   private img: HTMLElement;
+  readonly type;
 
   constructor(imagePath: string, height?: number) {
     if (imagePath.length > 0) {
@@ -19,6 +20,8 @@ export class ImageBanner extends Banner {
       super(0);
     }
 
+    this.type = 'image';
+
     if(imagePath.indexOf('base64') >=0) {
       console.log("Loading img from base64 data");
     } else {
@@ -27,7 +30,6 @@ export class ImageBanner extends Banner {
     this.img = document.createElement('img');
     this.img.setAttribute('src', imagePath);
     let ds = this.img.style;
-    ds.width = '100%';
     ds.height = '100%';
     this.getDiv().appendChild(this.img);
     console.log("Image loaded.");

--- a/web/src/engine/osk/src/banner/imageBanner.ts
+++ b/web/src/engine/osk/src/banner/imageBanner.ts
@@ -30,6 +30,12 @@ export class ImageBanner extends Banner {
     this.img = document.createElement('img');
     this.img.setAttribute('src', imagePath);
     let ds = this.img.style;
+
+    // We may want to eliminate the width-spec in the future, once we're sure of
+    // no unintended side-effects for iOS's use of this banner.
+    //
+    // Maybe if/when we also add a style="background-color: #xxx" option.
+    ds.width = '100%';
     ds.height = '100%';
     this.getDiv().appendChild(this.img);
     console.log("Image loaded.");

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -142,6 +142,8 @@ export class SuggestionBanner extends Banner {
 
   private manager: SuggestionInputManager;
 
+  readonly type = 'suggestion';
+
   private _predictionContext: PredictionContext;
 
   static readonly TOUCHED_CLASS: string = 'kmw-suggest-touched';


### PR DESCRIPTION
Accomplishes two goals:

1. Adds support for a new `HTMLBanner` type, which allows specifying banner contents to be injected via `innerHTML` property.  For devices that support it, this will take place within an attached "shadow" for the banner in order to facilitate styling isolation.
2. Given the new banner type, I dropped the old 'select type of banner' approach in favor of 'set a Banner for use when inactive' approach.
    - This allows direct calls to banner constructors, and thus to use of constructor parameters instead of messy, semi-dissociated "banner options".  Thus, it becomes clear that only data for the requested 'inactive banner' type needs to be specified.

To set the new banner type in motion...

Once KeymanWeb has initialized, make a call like this:

```javascript
keyman.osk.bannerController.inactiveBanner = new keyman.osk.bannerController.HTMLBanner(`
<img style="display:inline-block; height: 100%" src="../../../../../build/publish/debug/ui/button/kmw_button.gif"></div>
<div style="display:inline-block; color: white; text-align: center">Hello World</div>
`)
```

(I used that in the Developer console of the "Predictive Text: robust testing" test page.)

Results:

![image](https://github.com/keymanapp/keyman/assets/25213402/4c7fafce-f901-4c1b-b50d-1b9a3ee34c39)

The same banner will be continuously reused for the lifetime of the page unless replaced with a different assignment to `keyman.osk.bannerController.inactiveBanner`.  (Except when predictive-text is active, of course.)


## User Testing

TEST_IOS_ALWAYS_SHOW: Using the iOS-based Keyman app, verify that the image banner still works as expected.

1. Install the iOS test artifact through TestFlight.
2. Follow the "Get Started" instructions fully.
    - Be sure to install a keyboard without an associated predictive-text model... such as the IPA keyboard.
    - Search: IPA
    - Shows up as IPA (SIL) in the keyboard search.
3. In the Settings menu, toggle "Show Banner" on - the toggle should gain a green background.
4. Exit the Keyman app and open Safari.
5. Go to google.com.
6. Click within the main search field.  When the system keyboard shows up, swap keyboards to reach the Keyman system keyboard.
7. Swap to the default "EuroLatin (SIL)" keyboard if it is not already active.
8. Swap to the keyboard without an associated predictive-text model.
9. Verify that the image banner is displayed.

Note that step 7, then 8 is necessary due to #9990.  That bug is not addressed by this PR; I just happened to discover it when writing this user test.