### PR TITLE
chore(developer): show only source path files in project views 🦕

### DIFF
--- a/developer/src/tike/project/Keyman.Developer.System.Project.ProjectSaver.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.ProjectSaver.pas
@@ -83,7 +83,7 @@ procedure TProjectSaver.Execute;   // I4698
 var
   i: Integer;
   doc: IXMLDocument;
-  node, root: IXMLNode;
+  filenode, node, root: IXMLNode;
   defopts: TProjectOptionsRecord;
 begin
   if FProject.IsDefaultProject(pv20) and (FFileName <> '') then
@@ -136,7 +136,24 @@ begin
   begin
     node := root.AddChild('Files');
     for i := 0 to FProject.Files.Count - 1 do
-      FProject.Files[i].Save(node.AddChild('File'));
+    begin
+      filenode := node.AddChild('File');
+
+      // For xsl renderer, we have additional metadata we provide for v2.0
+      // projects, at least until we replace the project view with a tree
+      // structure
+      if (FFileName = '') then
+      begin
+        if FProject.Files[i].IsSourceFile
+          then filenode.AddChild('IsInSourcePath').NodeValue := 'true'
+          else filenode.AddChild('IsInSourcePath').NodeValue := 'false';
+        if FProject.Files[i].IsCompilable
+          then filenode.AddChild('IsCompilable').NodeValue := 'true'
+          else filenode.AddChild('IsCompilable').NodeValue := 'false';
+      end;
+
+      FProject.Files[i].Save(filenode);
+    end;
   end;
 
   if FFileName <> '' then

--- a/developer/src/tike/xml/project/distribution.xsl
+++ b/developer/src/tike/xml/project/distribution.xsl
@@ -78,7 +78,7 @@
         <br />
 
         <div>
-          <xsl:for-each select="/KeymanDeveloperProject/Files/File[FileType!='.kps' and FileType!='.kmn' and FileType!='.xml-ldml-keyboard' and FileType!='.ts' and FileType!='.tsv' and not(ParentFileID)]">
+          <xsl:for-each select="$NonSourceFiles">
             <xsl:variable name="FileState" select="/KeymanDeveloperProject/FileStates/FileState[ID=current()/ID]" />
             <xsl:call-template name="file">
               <xsl:with-param name="file_description"></xsl:with-param>

--- a/developer/src/tike/xml/project/elements.xsl
+++ b/developer/src/tike/xml/project/elements.xsl
@@ -2,6 +2,23 @@
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:k="http://www.tavultesoft.com/xml/70">
 
+<!-- IsInSourcePath and IsCompilable props are injected by ProjectSaver.pas for render time only -->
+<xsl:variable name="ParentFiles" select="/KeymanDeveloperProject/Files/File[not(ParentFileID)]" />
+<xsl:variable name="SourcePathFiles" select="$ParentFiles[
+  IsInSourcePath='true' or
+  /KeymanDeveloperProject/Options/Version != '2.0'
+]" />
+<xsl:variable name="SourceKeyboardFiles" select="$SourcePathFiles[FileType='.kmn' or FileType='.xml-ldml-keyboard']" />
+<xsl:variable name="SourcePackageFiles" select="$SourcePathFiles[FileType='.kps']" />
+<xsl:variable name="SourceModelFiles" select="$SourcePathFiles[FileType='.ts' or FileType='.tsv']" />
+<xsl:variable name="SourceFiles" select="$SourcePathFiles[FileType='.kmn' or FileType='.xml-ldml-keyboard' or FileType='.kps' or FileType='.model.ts']" />
+<xsl:variable name="NonSourceFiles" select="$ParentFiles[
+    IsInSourcePath != 'true' or
+    (FileType != '.kmn' and FileType != '.kps' and FileType != '.xml-ldml-keyboard' and FileType != '.ts' and FileType != '.tsv') or
+    /KeymanDeveloperProject/Options/Version != '2.0'
+  ]" />
+
+
 <xsl:template name="head">
   <head>
     <script src="/app/lib/sentry/bundle.min.js"><xsl:text> </xsl:text></script>

--- a/developer/src/tike/xml/project/keyboards.xsl
+++ b/developer/src/tike/xml/project/keyboards.xsl
@@ -120,7 +120,7 @@
         <br />
 
         <div>
-          <xsl:for-each select="KeymanDeveloperProject/Files/File[(FileType='.kmn' or FileType='.xml-ldml-keyboard') and not(ParentFileID)]">
+          <xsl:for-each select="$SourceKeyboardFiles">
             <xsl:variable name="FileState" select="/KeymanDeveloperProject/FileStates/FileState[ID=current()/ID]" />
             <xsl:call-template name="file">
               <xsl:with-param name="file_description">

--- a/developer/src/tike/xml/project/models.xsl
+++ b/developer/src/tike/xml/project/models.xsl
@@ -108,7 +108,7 @@
         <br />
 
         <div>
-          <xsl:for-each select="KeymanDeveloperProject/Files/File[(FileType='.ts' or FileType='.tsv') and not(ParentFileID)]">
+          <xsl:for-each select="$SourceModelFiles">
             <xsl:variable name="FileState" select="/KeymanDeveloperProject/FileStates/FileState[ID=current()/ID]" />
             <xsl:call-template name="file">
               <xsl:with-param name="file_description">

--- a/developer/src/tike/xml/project/packages.xsl
+++ b/developer/src/tike/xml/project/packages.xsl
@@ -99,7 +99,7 @@
         <br />
 
         <div>
-          <xsl:for-each select="/KeymanDeveloperProject/Files/File[FileType='.kps' and not(ParentFileID)]">
+          <xsl:for-each select="$SourcePackageFiles">
             <xsl:variable name="FileState" select="/KeymanDeveloperProject/FileStates/FileState[ID=current()/ID]" />
             <xsl:call-template name="file">
               <xsl:with-param name="file_description"><xsl:if test="string-length(Details/Name) &gt; 0">(<xsl:value-of select="Details/Name" />)</xsl:if></xsl:with-param>


### PR DESCRIPTION
Relates to #9948.

For v2.0 projects, only show .kmn, .kps, .model.ts, .tsv, and .xml files if they are source files within Options.SourcePath.

@keymanapp-test-bot skip