### PR TITLE
fix(web): accidental suggestion-banner retoggle when disabling predictions

### DIFF
--- a/common/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -423,7 +423,9 @@ export default class LanguageProcessor extends EventEmitter<LanguageProcessorEve
         this._state = state;
         this.emit('statechange', state);
 
-        if(this.isConfigured) {
+        // Only signal `'configured'` for a previously-loaded model if we're turning
+        // things back on; don't send it if deactivated!
+        if(flag && this.isConfigured) {
           this._state = 'configured';
           this.emit('statechange', 'configured');
         }


### PR DESCRIPTION
While @darcywong00 was working on the Android app keyboard banner, we discovered that when predictions are turned off, but a model is already loaded, the internal model-management code would still send the `configured` event (from model loading) when turning predictions off.  This should not happen, as that signaled the predictive-text banner to reappear.

## User Testing

TEST_EUROLATIN_PREDICTIONS_OFF:  Using the Keyman for Android app...

1. Set the keyboard to English - EuroLatin (SIL).
2. Using the app menu, navigate to Settings > Installed Languages > English.
3. Toggle "Enable predictions" off.
4. Leave the app menu.
5. Verify that neither a banner or blank space for a banner is shown.

TEST_KEYBOARD_SWAP:  Using the Keyman for Android app...

1.  Download the IPA (SIL) keyboard and install it.
2. Within the Settings menu, navigate to Settings > Installed Languages > English.
3. Toggle "Enable predictions" on.
4. Return to the app's main screen.
5. Verify that no predictive-text banner (nor corresponding blank space) is active.
6. Swap to English - EuroLatin (SIL).
7. Verify that the predictive-text banner appears, with suggestions visible.
8. Swap to the IPA keyboard again.
9. Verify that no predictive-text banner (nor corresponding blank space) is active.