### PR TITLE
feat(web): basic gesture model validation 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
@@ -6,6 +6,12 @@ type SimpleStringResult = 'resolve' | 'reject';
 
 export type PointModelResolution = SimpleStringResult;
 
+/**
+ * Represents the full criteria necessary to match one active contact point
+ * against its owning `GestureModel`.  Path-matching aspects are delegated
+ * to `.pathModel`, but other aspects of matching are checked against the
+ * other fields of this type.
+ */
 export interface ContactModel<Type, StateToken = any> {
   pathModel: PathModel<Type>,
   pathResolutionAction: PointModelResolution,
@@ -49,6 +55,8 @@ export interface ContactModel<Type, StateToken = any> {
    *
    * Note that for gestures reachable by _optional_ chaining, only the first two modes
    * are properly supported.  Exclusive chaining may safely use all four.
+   *
+   * If not specified, 'chop' inheritance will be used as the default.
    */
   pathInheritance?: 'reject' | 'chop' | 'partial' | 'full';
 

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/gestureModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/gestureModel.ts
@@ -83,6 +83,15 @@ type ResolutionStruct = ResolutionChain | ResolutionComplete;
 export type GestureResolutionSpec   = ResolutionStruct & ResolutionItemSpec;
 export type GestureResolution<Type> = (ResolutionStruct | RejectionDefault | RejectionReplace) & ResolutionItem<Type>;
 
+/**
+ * Represents the criteria necessary to fulfill one stage of an ongoing gesture;
+ * essentially, one 'state' on a time-based finite-state-machine representing
+ * a full gesture (as processed by `GestureSequence`).
+ *
+ * For example, a longpress interaction on a keyboard may consist of two stages:
+ * 1. The actual "hold and wait" that longpress is known for.
+ * 2. Selection of a key from the menu that appears afterward.
+ */
 export interface GestureModel<Type, StateToken = any> {
   // Gestures may want to say "build gesture of type `id`" for a followup-gesture.
   readonly id: string;

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/gestureModelDefs.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/gestureModelDefs.ts
@@ -1,10 +1,26 @@
 import * as gestures from "../index.js";
 
-// Prototype spec for the main gesture & gesture-set definitions.
-// A work in-progress.  Should probably land somewhere within headless/gestures/specs/.
-// ... with the following two functions, as well.
 export interface GestureModelDefs<Type, StateToken = any> {
+  /**
+   * The full set of gesture models to be utilized by the gesture-recognition engine.
+   */
   gestures: gestures.specs.GestureModel<Type, StateToken>[],
+
+  /**
+   * Sets _of sets_ of gesture models accessible as initial gesture stages while
+   * within various states of the gesture-engine.
+   *
+   * `'default'` must be specified, as it is the default state.
+   *
+   * A 'chain'-type model resolution has the option to specify a `selectionMode` property;
+   * the value set there will activate a different gesture-recognition mode _for new
+   * gestures_ corresponding to the sets specified here.
+   *
+   * These sets may be defined to either restrict the range of options for new incoming
+   * gestures or to restrict them.  Specifying an empty set will disable all incoming
+   * gestures while the alternate state is active, allowing one gesture to block any
+   * further gestures from starting until it is completed.
+   */
   sets: {
     default: string[],
   } & Record<string, string[]>;

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/index.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/index.ts
@@ -1,4 +1,6 @@
 export * from './contactModel.js';
 export * from './gestureModel.js';
 export * from './gestureModelDefs.js';
+// Do NOT export from modelDefValidator here.  That's top-level only,
+// making it far easier to tree-shake.
 export * from './pathModel.js';

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/modelDefValidator.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/modelDefValidator.ts
@@ -1,0 +1,126 @@
+import { GestureResolutionSpec, RejectionReplace } from "./gestureModel.js";
+import { GestureModelDefs } from "./gestureModelDefs.js";
+
+interface ModelDefError {
+  error: string,
+  instances: string[]
+}
+
+/**
+ * Validates that all gesture ids and gesture-set ids that are defined are utilized and vice-versa.
+ *
+ * Note that this function is not currently able to validate the represented behaviors; it only
+ * validates internal self-references.
+ * @param definitions
+ * @returns
+ */
+export function validateModelDefs(definitions: GestureModelDefs<any, any>): ModelDefError[] | null {
+  const errors: ModelDefError[] = [];
+  const {gestures, sets} = definitions;
+
+  const definedGestureIds = gestures.map((entry) => entry.id);
+  const definedSetIds: string[] = Object.keys(sets);
+
+  const sortedGestureIds = [].concat(definedGestureIds).sort();
+  const idError: ModelDefError = {
+    error: "Duplicated model IDs",
+    instances: []
+  };
+
+  for(let i=0; i < sortedGestureIds.length - 1; i++) {
+    if(sortedGestureIds[i] == sortedGestureIds[i+1]) {
+      idError.instances.push(`duplicated model id: ${sortedGestureIds[i]}`);
+    }
+  }
+
+  if(idError.instances.length) {
+    errors.push(idError);
+  }
+
+  const referencedGestureIds = new Set<string>();
+  const unreferencedGestureIds = new Set<string>(sortedGestureIds);
+  const missingGestureIds = new Map<string, ModelDefError>();
+
+  const referencedSetIds = new Set<string>();
+  const unreferencedSetIds = new Set<string>(definedSetIds);
+  const missingSetIds = new Map<string, ModelDefError>();
+
+  function observeGestureId(id: string, src: string) {
+    if(unreferencedGestureIds.has(id)) {
+      referencedGestureIds.add(id);
+      unreferencedGestureIds.delete(id);
+    } else if(!referencedGestureIds.has(id)) {
+      let err = missingGestureIds.get(id);
+      if(!err) {
+        err = {
+          error: `Gesture model ${id} does not exist`,
+          instances: []
+        };
+        errors.push(err);
+      }
+      err.instances.push(src);
+      missingGestureIds.set(id, err);
+    }
+  }
+
+  function observeSetId(id: string, src: string) {
+    if(unreferencedSetIds.has(id)) {
+      referencedSetIds.add(id);
+      unreferencedSetIds.delete(id);
+    } else if(!referencedSetIds.has(id)) {
+      let err = missingSetIds.get(id);
+      if(!err) {
+        err = {
+          error: `Gesture set ${id} does not exist`,
+          instances: []
+        };
+        errors.push(err);
+      }
+      err.instances.push(src);
+      missingSetIds.set(id, err);
+    }
+  }
+
+  // There is an implicit reference to the 'default' set.
+  observeSetId('default', "Definition Set");
+
+  function processAction(action: GestureResolutionSpec | RejectionReplace, src: string) {
+    if(action.type == 'chain') {
+      observeGestureId(action.next, src);
+      if(action.selectionMode) {
+        observeSetId(action.selectionMode, src);
+      }
+    } else if(action.type == 'replace') {
+      observeGestureId(action.replace, src);
+    }
+  }
+
+  gestures.forEach((entry) => {
+    processAction(entry.resolutionAction, `model: ${entry.id}`);
+
+    Object.keys(entry.rejectionActions ?? {}).forEach((key) => {
+      processAction(entry.rejectionActions[key], `model: ${entry.id}`);
+    });
+  });
+
+  Object.keys(sets).forEach((key) => {
+    const set = sets[key];
+    set.forEach((entry) => observeGestureId(entry, `set: ${key}`));
+  });
+
+  unreferencedGestureIds.forEach((entry) => {
+    errors.push({
+      error: `Gesture model ${entry} is not referenced`,
+      instances: ["Definition Set"]
+    });
+  });
+
+  unreferencedSetIds.forEach((entry) => {
+    errors.push({
+      error: `Gesture set ${entry} is not referenced`,
+      instances: ["Definition Set"]
+    });
+  });
+
+  return errors.length > 0 ? errors : null;
+}

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/pathModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/pathModel.ts
@@ -1,12 +1,12 @@
 import { CumulativePathStats } from "../../cumulativePathStats.js";
 import { GesturePath } from "../../gesturePath.js";
 
-// The TrackedPath model only cares about if the path matches... not what that MEANS.
-// THAT is the role of the gesture Model (model.ts).
+// The GesturePath model only cares about if the path matches... not what that MEANS.
+// THAT is the role of the GestureModel (gestureModel.ts).
 
 export interface PathModel<Type = any> {
   /**
-   * Given a TrackedPath, indicates whether or not the path matches this PathModel.
+   * Given a GesturePath, indicates whether or not the path matches this PathModel.
    *
    * May return null or undefined to signal 'continue'.
    *

--- a/common/web/gesture-recognizer/src/engine/index.ts
+++ b/common/web/gesture-recognizer/src/engine/index.ts
@@ -1,3 +1,5 @@
+import { validateModelDefs } from './headless/gestures/specs/modelDefValidator.js';
+
 export { ConstructingSegment } from './headless/subsegmentation/constructingSegment.js';
 export { CumulativePathStats } from './headless/cumulativePathStats.js';
 export { GestureModelDefs } from './headless/gestures/specs/gestureModelDefs.js';
@@ -19,5 +21,6 @@ export { TouchpointCoordinator } from "./headless/touchpointCoordinator.js";
 export { ViewportZoneSource } from './configuration/viewportZoneSource.js';
 
 export * as gestures from './headless/gestures/index.js';
+export { validateModelDefs } from './headless/gestures/specs/modelDefValidator.js';
 
 // TODO:  export other odds & ends.

--- a/web/src/engine/osk/build.sh
+++ b/web/src/engine/osk/build.sh
@@ -37,7 +37,14 @@ builder_parse "$@"
 
 #### Build action definitions ####
 
+do_build() {
+  compile $SUBPROJECT_NAME
+
+  echo "Validating gesture model and set references"
+  node validate-gesture-specs.js
+}
+
 builder_run_action configure verify_npm_setup
 builder_run_action clean rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
-builder_run_action build compile $SUBPROJECT_NAME
+builder_run_action build do_build
 builder_run_action test test-headless osk

--- a/web/src/engine/osk/src/index.ts
+++ b/web/src/engine/osk/src/index.ts
@@ -21,6 +21,8 @@ export { default as SimpleActivator } from './views/simpleActivator.js';
 export { default as TwoStateActivator } from './views/twoStateActivator.js';
 export { ParsedLengthStyle } from './lengthStyle.js';
 
+export { gestureSetForLayout, DEFAULT_GESTURE_PARAMS } from './input/gestures/specsForLayout.js'
+
 // PredictionContext is exported from input-processor, not the OSK.
 
 // More things will likely need to be added.

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -11,9 +11,9 @@ import {
 import ButtonClasses = TouchLayout.TouchLayoutKeySp;
 
 import {
+  ActiveLayout,
   deepCopy
 } from '@keymanapp/keyboard-processor';
-import OSKLayerGroup from '../../keyboard-layout/oskLayerGroup.js';
 
 import { type KeyElement } from '../../keyElement.js';
 
@@ -133,6 +133,16 @@ export function keySupportsModipress(key: KeyElement) {
   }
 }
 
+interface LayoutGestureSupportFlags {
+  hasFlicks: boolean,
+  hasMultitaps: boolean,
+  hasLongpresses: boolean
+}
+
+// Simple compile-time validation that OSKLayerGroup's spec object provides the fields expected above.
+let dummy: ActiveLayout;
+let dummy2: LayoutGestureSupportFlags = dummy;
+
 /**
  * Defines the set of gestures appropriate for use with the specified Keyman keyboard.
  * @param layerGroup  The active keyboard's layer group
@@ -141,9 +151,7 @@ export function keySupportsModipress(key: KeyElement) {
  *                    immediate effect during gesture processing.
  * @returns
  */
-export function gestureSetForLayout(layerGroup: OSKLayerGroup, params: GestureParams): GestureModelDefs<KeyElement, string> {
-  const layout = layerGroup.spec;
-
+export function gestureSetForLayout(flags: LayoutGestureSupportFlags, params: GestureParams): GestureModelDefs<KeyElement, string> {
   // To be used among the `allowsInitialState` contact-model specifications as needed.
   const gestureKeyFilter = (key: KeyElement, gestureId: string) => {
     if(!key) {
@@ -160,7 +168,7 @@ export function gestureSetForLayout(layerGroup: OSKLayerGroup, params: GesturePa
         return !!keySpec.sk;
       case 'multitap-start':
       case 'modipress-multitap-start':
-        if(layout.hasMultitaps) {
+        if(flags.hasMultitaps) {
           return !!keySpec.multitap;
         } else {
           return false;
@@ -173,9 +181,9 @@ export function gestureSetForLayout(layerGroup: OSKLayerGroup, params: GesturePa
     }
   };
 
-  const _initialTapModel: GestureModel<KeyElement> = deepCopy(layout.hasFlicks ? initialTapModel(params) : initialTapModelWithReset(params));
-  const _simpleTapModel: GestureModel<KeyElement> = deepCopy(layout.hasFlicks ? simpleTapModel() : simpleTapModelWithReset());
-  const longpressModel: GestureModel<KeyElement> = deepCopy(longpressModelWithShortcut(params, true, !layout.hasFlicks));
+  const _initialTapModel: GestureModel<KeyElement> = deepCopy(flags.hasFlicks ? initialTapModel(params) : initialTapModelWithReset(params));
+  const _simpleTapModel: GestureModel<KeyElement> = deepCopy(flags.hasFlicks ? simpleTapModel() : simpleTapModelWithReset());
+  const longpressModel: GestureModel<KeyElement> = deepCopy(longpressModelWithShortcut(params, true, !flags.hasFlicks));
 
   // #region Functions for implementing and/or extending path initial-state checks
   function withKeySpecFiltering(model: GestureModel<KeyElement>, contactIndices: number | number[]) {
@@ -228,7 +236,7 @@ export function gestureSetForLayout(layerGroup: OSKLayerGroup, params: GesturePa
     longpressModel.id, _initialTapModel.id, _modipressStartModel.id, specialStartModel.id
   ];
 
-  if(layout.hasFlicks) {
+  if(flags.hasFlicks) {
     gestureModels.push(withKeySpecFiltering(flickStartModel(params), 0));
     gestureModels.push(flickMidModel(params));
     gestureModels.push(flickResetModel(params));

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -394,7 +394,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       return !flickSpec || !(flickSpec.n || flickSpec.nw || flickSpec.ne);
     };
 
-    const recognizer = new GestureRecognizer(gestureSetForLayout(this.layerGroup, this.gestureParams), config);
+    const recognizer = new GestureRecognizer(gestureSetForLayout(this.kbdLayout, this.gestureParams), config);
     recognizer.stateToken = this.layerId;
 
     const sourceTrackingMap: Record<string, {

--- a/web/src/engine/osk/validate-gesture-specs.js
+++ b/web/src/engine/osk/validate-gesture-specs.js
@@ -1,0 +1,52 @@
+import { validateModelDefs } from '@keymanapp/gesture-recognizer';
+import { gestureSetForLayout, DEFAULT_GESTURE_PARAMS } from 'keyman/engine/osk';
+
+const flicklessSet = gestureSetForLayout(
+  {
+    hasFlicks: false, hasMultitaps: false, hasLongpresses: false
+  },
+  DEFAULT_GESTURE_PARAMS
+);
+
+const flicklessErrors = validateModelDefs(flicklessSet);
+
+const flickedSet = gestureSetForLayout(
+  {
+    hasFlicks: true, hasMultitaps: false, hasLongpresses: false
+  },
+  DEFAULT_GESTURE_PARAMS
+);
+
+const flickedErrors = validateModelDefs(flickedSet);
+
+if(!flicklessErrors && !flickedErrors) {
+  // Success!
+  process.exit(0);
+}
+
+function printErrors(errors) {
+  errors.forEach((error) => {
+    console.error(error.error);
+    error.instances.forEach((subentry) => {
+      console.error(`- ${subentry}`);
+    });
+  });
+}
+
+if(flicklessErrors) {
+  console.error("With flicks disabled: ");
+  console.error();
+  printErrors(flicklessErrors);
+}
+
+if(flickedErrors) {
+  if(flicklessErrors) {
+    console.error();
+  }
+
+  console.error("With flicks enabled: ");
+  console.error();
+  printErrors(flickedErrors);
+}
+
+process.exit(1);


### PR DESCRIPTION
To help prevent accidental breakage during future maintenance of the new gesture engine, I decided to write up a small validator for the gesture-definition ids.  There were a couple of times during development where I messed up the IDs and had to discover that; fortunately, a simple targeted tool is well-able to help prevent future recurrences of such an issue.

This PR also updates some of the lower-level gesture-engine documentation within its first commit.

The validation function will tree-shake out during builds of the main artifacts, so it won't affect Web's file-size.

In the case of a validation issue, here's how it looks during a build of the OSK...

```
[web/src/engine/events] dependency build, started by web/src/engine/osk
[web/src/engine/events] build.sh parameters: <configure build --deps --builder-dep-parent web/src/engine/osk>
[web/src/engine/events] skipping configure, up-to-date
[web/src/engine/events] skipping build, up-to-date
Validating gesture model and set references
With flicks disabled: 

Gesture model subkey-select does not exist
- model: longpress
- model: longpress-roam
Gesture model subkeyselect is not referenced
- Definition Set

With flicks enabled:

Gesture model subkey-select does not exist
- model: longpress
Gesture model subkeyselect is not referenced
- Definition Set
[web/src/engine/osk] ## build failed
```

@keymanapp-test-bot skip