### PR TITLE
fix(developer): projects 2.0 internal path enumeration 🦕

### DIFF
--- a/common/windows/delphi/general/utildir.pas
+++ b/common/windows/delphi/general/utildir.pas
@@ -45,13 +45,19 @@ function KGetTempPath: string;
 
 function GetLongFileName(const fname: string): string;
 
+function DosSlashes(const filename: string): string;
+
 implementation
 
 uses
+  System.StrUtils,
   System.SysUtils,
   Winapi.Windows;
 
-
+function DosSlashes(const filename: string): string;
+begin
+  Result := ReplaceStr(filename, '/', '\');
+end;
 
 function DirectoryEmpty(dir: WideString): Boolean;
 var

--- a/developer/src/tike/project/Keyman.Developer.System.Project.ProjectLoader.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.ProjectLoader.pas
@@ -66,6 +66,7 @@ uses
   Keyman.Developer.System.Project.ProjectFiles,
   Keyman.Developer.System.Project.ProjectFileType,
 
+  utildir,
   utilfiletypes;
 
 { TProjectLoader }
@@ -131,10 +132,10 @@ begin
     FProject.Options.Assign(DefaultProjectOptions[FProject.Options.Version]);
 
     if not VarIsNull(node.ChildValues['BuildPath']) then
-      FProject.Options.BuildPath := VarToStr(node.ChildValues['BuildPath']);
+      FProject.Options.BuildPath := DosSlashes(VarToStr(node.ChildValues['BuildPath']));
 
     if not VarIsNull(node.ChildValues['SourcePath']) then
-      FProject.Options.SourcePath := VarToStr(node.ChildValues['SourcePath']);
+      FProject.Options.SourcePath := DosSlashes(VarToStr(node.ChildValues['SourcePath']));
 
     if not VarIsNull(node.ChildValues['CompilerWarningsAsErrors']) then
       FProject.Options.CompilerWarningsAsErrors := node.ChildValues['CompilerWarningsAsErrors'];

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProjectSettings20.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProjectSettings20.pas
@@ -1,22 +1,22 @@
 (*
   Name:             Keyman.Developer.UI.Project.UfrmProjectSettings
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      4 May 2015
 
   Modified Date:    24 Aug 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          04 May 2015 - mcdurdin - I4688 - V9.0 - Add build path to project settings
                     24 Aug 2015 - mcdurdin - I4865 - Add treat hints and warnings as errors into project
                     24 Aug 2015 - mcdurdin - I4866 - Add warn on deprecated features to project and compile
-                    
+
 *)
 unit Keyman.Developer.UI.Project.UfrmProjectSettings20;   // I4688
 
@@ -54,12 +54,13 @@ implementation
 {$R *.dfm}
 
 uses
-  Keyman.Developer.System.Project.Project;
+  Keyman.Developer.System.Project.Project,
+  utildir;
 
 procedure TfrmProjectSettings20.cmdOKClick(Sender: TObject);
 begin
-  FGlobalProject.Options.BuildPath := Trim(editOutputPath.Text);
-  FGlobalProject.Options.SourcePath := Trim(editSourcePath.Text);
+  FGlobalProject.Options.BuildPath := Trim(DosSlashes(editOutputPath.Text));
+  FGlobalProject.Options.SourcePath := Trim(DosSlashes(editSourcePath.Text));
   FGlobalProject.Options.SkipMetadataFiles := not chkBuildMetadataFiles.Checked;
   FGlobalProject.Options.CompilerWarningsAsErrors := chkCompilerWarningsAsErrors.Checked;   // I4865
   FGlobalProject.Options.WarnDeprecatedCode := chkWarnDeprecatedCode.Checked;   // I4866

--- a/developer/src/tike/xml/project/distribution.xsl
+++ b/developer/src/tike/xml/project/distribution.xsl
@@ -83,6 +83,7 @@
             <xsl:call-template name="file">
               <xsl:with-param name="file_description"></xsl:with-param>
               <xsl:with-param name="file_has_details">false</xsl:with-param>
+              <xsl:with-param name="file_relative_path">true</xsl:with-param>
             </xsl:call-template>
           </xsl:for-each>
         </div>

--- a/developer/src/tike/xml/project/elements.xsl
+++ b/developer/src/tike/xml/project/elements.xsl
@@ -76,6 +76,7 @@
     <xsl:param name="file_description" />
     <xsl:param name="file_has_details" />
     <xsl:param name="file_has_no_options" />
+    <xsl:param name="file_relative_path" />
 
     <span tabindex="1" class="file" onmousedown="javascript:this.focus();">
       <xsl:attribute name="id">file<xsl:value-of select="ID"/></xsl:attribute>
@@ -103,7 +104,10 @@
       <div class="filename">
         <a tabindex="-1">
           <xsl:attribute name="href">keyman:editfile?id=<xsl:value-of select="ID"/></xsl:attribute>
-          <xsl:value-of select="Filename" />
+          <xsl:choose>
+            <xsl:when test="$file_relative_path = 'true'"><xsl:value-of select="Filepath" /></xsl:when>
+            <xsl:otherwise><xsl:value-of select="Filename" /></xsl:otherwise>
+          </xsl:choose>
         </a>
       </div>
       <div class="filedescription"><xsl:value-of select="$file_description"/></div>


### PR DESCRIPTION
Relates to #9948.

Restricts enumeration of files for the project to the project folder and the SourcePath folder. This prevents problems where a project may be in a folder with many subfolders which would take a long time to enumerate, and avoids confusion where there are source-type files in other folders.

At the same time, sorts out forward slash vs backslash in paths. While forward slash works in many scenarios, there are several filename manipulation functions, such as ExpandFileName, which would build valid but non-optimal paths when forward slashes were encountered, which cascaded into files appearing to be different and presentation issues.

For the Project view, the Distribution tab now shows file relative paths, which helps with organization. Have opted _not_ to show the relative paths in the other tabs, because that information is visible when the file details are expanded, and because those files should always be in SourcePath anyway.

@keymanapp-test-bot skip