### PR TITLE
change(android): flishy flashy mitigation, round 1 ✨ 

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1332,12 +1332,14 @@ public final class KMManager {
     RelativeLayout.LayoutParams params;
     if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreTextChange() && modelFileExists) {
       params = getKeyboardLayoutParams();
-      InAppKeyboard.setLayoutParams(params);
+
+      // Do NOT re-layout here; it'll be triggered once the banner loads.
       InAppKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect), false);
     }
     if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreTextChange() && modelFileExists) {
       params = getKeyboardLayoutParams();
-      SystemKeyboard.setLayoutParams(params);
+
+      // Do NOT re-layout here; it'll be triggered once the banner loads.
       SystemKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect), false);
     }
     return true;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1333,12 +1333,12 @@ public final class KMManager {
     if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreTextChange() && modelFileExists) {
       params = getKeyboardLayoutParams();
       InAppKeyboard.setLayoutParams(params);
-      InAppKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
+      InAppKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect), false);
     }
     if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreTextChange() && modelFileExists) {
       params = getKeyboardLayoutParams();
       SystemKeyboard.setLayoutParams(params);
-      SystemKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect));
+      SystemKeyboard.loadJavascript(KMString.format("enableSuggestions(%s, %s, %s)", model, mayPredict, mayCorrect), false);
     }
     return true;
   }
@@ -1351,11 +1351,11 @@ public final class KMManager {
 
     String url = KMString.format("deregisterModel('%s')", modelID);
     if (InAppKeyboard != null) {
-      InAppKeyboard.loadJavascript(url);
+      InAppKeyboard.loadJavascript(url, false);
     }
 
     if (SystemKeyboard != null) {
-      SystemKeyboard.loadJavascript(url);
+      SystemKeyboard.loadJavascript(url, false);
     }
     return true;
   }
@@ -1373,11 +1373,11 @@ public final class KMManager {
     public static boolean setBannerOptions(boolean mayPredict) {
     String url = KMString.format("setBannerOptions(%s)", mayPredict);
     if (InAppKeyboard != null) {
-      InAppKeyboard.loadJavascript(url);
+      InAppKeyboard.loadJavascript(url, false);
     }
 
     if (SystemKeyboard != null) {
-      SystemKeyboard.loadJavascript(url);
+      SystemKeyboard.loadJavascript(url, false);
     }
     return true;
   }
@@ -1868,12 +1868,12 @@ public final class KMManager {
 
   public static void applyKeyboardHeight(Context context, int height) {
     if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP)) {
-      InAppKeyboard.loadJavascript(KMString.format("setOskHeight('%s')", height));
+      InAppKeyboard.loadJavascript(KMString.format("setOskHeight('%s')", height), false);
       RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
       InAppKeyboard.setLayoutParams(params);
     }
     if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM)) {
-      SystemKeyboard.loadJavascript(KMString.format("setOskHeight('%s')", height));
+      SystemKeyboard.loadJavascript(KMString.format("setOskHeight('%s')", height), false);
       RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
       SystemKeyboard.setLayoutParams(params);
     }
@@ -1944,11 +1944,11 @@ public final class KMManager {
   public static void setNumericLayer(KeyboardType kbType) {
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreTextChange()) {
-        InAppKeyboard.loadJavascript("setNumericLayer()");
+        InAppKeyboard.loadJavascript("setNumericLayer()", false);
       }
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreTextChange()) {
-        SystemKeyboard.loadJavascript("setNumericLayer()");
+        SystemKeyboard.loadJavascript("setNumericLayer()", false);
       }
     }
   }
@@ -1987,11 +1987,11 @@ public final class KMManager {
   public static void resetContext(KeyboardType kbType) {
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP)) {
-        InAppKeyboard.loadJavascript("resetContext()");
+        InAppKeyboard.loadJavascript("resetContext()", true);
       }
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM)) {
-        SystemKeyboard.loadJavascript("resetContext()");
+        SystemKeyboard.loadJavascript("resetContext()", true);
       }
     }
   }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KeyboardPickerActivity.java
@@ -123,7 +123,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
     listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
       @Override
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        switchKeyboard(position,dismissOnSelect && ! KMManager.isTestMode());
+        switchKeyboard(position);
         if (dismissOnSelect)
           finish();
       }
@@ -264,18 +264,6 @@ public final class KeyboardPickerActivity extends BaseActivity {
   }
 
   @Override
-  protected void onPause() {
-    super.onPause();
-
-    if (KMManager.InAppKeyboard != null) {
-      KMManager.InAppKeyboard.loadKeyboard();
-    }
-    if (KMManager.SystemKeyboard != null) {
-      KMManager.SystemKeyboard.loadKeyboard();
-    }
-  }
-
-  @Override
   public boolean onSupportNavigateUp() {
     onBackPressed();
     return true;
@@ -335,7 +323,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
    * @param position the keyboard index in list
    * @param aPrepareOnly prepare switch, it is executed on keyboard reload
    */
-  private static void switchKeyboard(int position, boolean aPrepareOnly) {
+  private static void switchKeyboard(int position) {
     setSelection(position);
     int size = KeyboardController.getInstance().get().size();
     int listPosition = (position >= size) ? size-1 : position;
@@ -344,10 +332,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
     String kbId = kbInfo.getKeyboardID();
     String langId = kbInfo.getLanguageID();
     String kbName = kbInfo.getKeyboardName();
-    if(aPrepareOnly)
-      KMManager.prepareKeyboardSwitch(pkgId, kbId, langId, kbName);
-    else
-      KMManager.setKeyboard(kbInfo);
+    KMManager.setKeyboard(kbInfo);
   }
 
   protected static boolean addKeyboard(Context context, Keyboard keyboardInfo) {
@@ -449,7 +434,7 @@ public final class KeyboardPickerActivity extends BaseActivity {
         adapter.notifyDataSetChanged();
       }
       if (position == curKbPos) {
-        switchKeyboard(0,false);
+        switchKeyboard(0);
       } else if(listView != null) { // A bit of a hack, since LanguageSettingsActivity calls this method too.
         curKbPos = KeyboardController.getInstance().getKeyboardIndex(KMKeyboard.currentKeyboard());
         setSelection(curKbPos);


### PR DESCRIPTION
Fixes #8868.
Fixes #8007.
Significantly mitigates #8534.

---

Commit 1 has the fix for #8868 and #8007.   As it turns out, the keyboard picker was full-resetting the keyboard page in two scenarios:
- When drilling down into the keyboard's help
- When returning from the picker.

That full-reset is a holdover from 14.0 work, back when we moved keyboard updates out of the picker in #1842.  At the time, the full-reset was triggered... if an update occurred.  It appears I had been overcautious and left the code in... and as the conditional "no longer made sense", it has always triggered since in this scenario.

Disabling just that full-reset instantly halves the amount of re-layout operations that must happen.

---

As noted by https://github.com/keymanapp/keyman/pull/9696/files/68f2661e1f118cfc105c2ef131d7f4c1477e90f9#r1395117451, our internal JS queue for page load waits was queuing individual entries... and executing them one by one with a small asynchronous wait (1ms) between _each_ queued entry.  Fun fact:  upon investigating how the queue looked... I saw queues of up to **14** pending calls.  

Now, all pending calls are concatenated (with intervening `;`s) when the queue is ready to fire.  To be safe, I added an option that allows a call to request an async wait after it... but in practice, it seems that such waits are not optimal, even in the places I'd anticipated they might be useful.  This should "tighten up" the timing among related things and ensure that Web-side relayout operations happen as synchronously as possible.

---

Finally, there was a very easy-to-remove redundant re-layout call when enabling prediction text.  The third commit removes that.

## User Testing

TEST_PICKER_HELP:  Attempt to repro #8868.

1. Install the Keyman app test build from this PR.
2. Open Keyman App. 
3. Download and install Khmer Angkor keyboard. 
4. Long press the globe key to open the Keyboard picker menu. 
5. Click the Info (i) icon against the Central Khmer (Khmer, Cambodia..) label name. 
6. Verify that **absolutely no flicker** occurs for the keyboard in the process.

TEST_PICKER_SELECTION:  Attempt to repro #8007.

1. Install the Keyman app test build from this PR.
2. Open Keyman App.
3. Install Khmer Angkor and Tamil Keyboards using Settings / Install Keyboard or Dictionary / Install from keyman.com option.
4. Verify all the Keyboards are installed under Installed languages menu. 
5. Return to main page. 
6. Verify that the default keyboard English -EuroLatin(SIL) is displayed on the page.
7. Short-press the globe key and observe the keyboard change.  There should be minimal adjustment while the keyboard loads.
8. Now, long press the globe key, Click Khmer or Tamil Keyboard and observe the keyboard change.  It should change as smoothly as it did after the globe-key short-press (step 7).