### PR TITLE
fix(ios): fv: replace Zip framework to prevent crash on startup 🍒 

### DIFF
--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,5 +1,5 @@
 github "weichsel/ZIPFoundation" ~> 0.9
-github "DaveWoodCom/XCGLogger" ~> 6.1.0
+github "keymanapp/dependency-XCGLogger" "master"
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
 github "getsentry/sentry-cocoa" ~> 8.7.0

--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,5 +1,5 @@
-github "marmelroy/Zip"
-github "keymanapp/dependency-XCGLogger" "master"
+github "weichsel/ZIPFoundation" ~> 0.9
+github "DaveWoodCom/XCGLogger" ~> 6.1.0
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
 github "getsentry/sentry-cocoa" ~> 8.7.0

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,5 +1,4 @@
 github "ashleymills/Reachability.swift" "v5.1.0"
-github "devicekit/DeviceKit" "5.0.0"
-github "getsentry/sentry-cocoa" "8.7.0"
-github "keymanapp/dependency-XCGLogger" "57a7b975dbb6fe4fe90cef3d1bc52b8adbd89113"
-github "marmelroy/Zip" "2.1.2"
+github "devicekit/DeviceKit" "5.1.0"
+github "getsentry/sentry-cocoa" "6.2.1"
+github "weichsel/ZIPFoundation" "0.9.17"

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,4 +1,5 @@
 github "ashleymills/Reachability.swift" "v5.1.0"
 github "devicekit/DeviceKit" "5.1.0"
-github "getsentry/sentry-cocoa" "6.2.1"
+github "getsentry/sentry-cocoa" "8.15.2"
+github "keymanapp/dependency-XCGLogger" "57a7b975dbb6fe4fe90cef3d1bc52b8adbd89113"
 github "weichsel/ZIPFoundation" "0.9.17"

--- a/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
+++ b/ios/engine/KMEI/KeymanEngine.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		1645D5952036C6FF0076C51B /* KeymanPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1645D5942036C6FF0076C51B /* KeymanPackage.swift */; };
 		1645D5972036C9F80076C51B /* KMPKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1645D5962036C9F80076C51B /* KMPKeyboard.swift */; };
 		165EB3A12098993900040A69 /* KeyboardError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165EB3A02098993900040A69 /* KeyboardError.swift */; };
+		296EF2C72AFA26C700E3E384 /* ZIPFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296EF2C62AFA26C700E3E384 /* ZIPFoundation.xcframework */; };
 		377D10DE26846B8900467431 /* SpacebarTextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377D10DD26846B8900467431 /* SpacebarTextViewController.swift */; };
 		6CD5DFAA150F6DC8007A5DDE /* icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6CD5DFA8150F6DC8007A5DDE /* icon.png */; };
 		6CD5DFAB150F6DC8007A5DDE /* icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6CD5DFA9150F6DC8007A5DDE /* icon@2x.png */; };
@@ -121,7 +122,6 @@
 		CE5C8BE324B5B3BA00FAFB7F /* Queries+LexicalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5C8BE224B5B3BA00FAFB7F /* Queries+LexicalModel.swift */; };
 		CE5C8BE524B5BD1C00FAFB7F /* QueryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5C8BE424B5BD1C00FAFB7F /* QueryModelTests.swift */; };
 		CE5EDDC526522EAA001733AC /* XCGLogger.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5EDDC026522EA9001733AC /* XCGLogger.xcframework */; };
-		CE5EDDC626522EAA001733AC /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5EDDC126522EA9001733AC /* Zip.xcframework */; };
 		CE5EDDC726522EAA001733AC /* Sentry.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5EDDC226522EAA001733AC /* Sentry.xcframework */; };
 		CE5EDDC826522EAA001733AC /* Reachability.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5EDDC326522EAA001733AC /* Reachability.xcframework */; };
 		CE5EDDC926522EAA001733AC /* ObjcExceptionBridging.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5EDDC426522EAA001733AC /* ObjcExceptionBridging.xcframework */; };
@@ -308,6 +308,7 @@
 		2949146F2738DA6700400732 /* ff-NG */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ff-NG"; path = "ff-NG.lproj/ResourceInfoView.strings"; sourceTree = "<group>"; };
 		294914702738DD7400400732 /* ff-NG */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ff-NG"; path = "ff-NG.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		294914712738DD9700400732 /* ff-NG */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "ff-NG"; path = "ff-NG.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
+		296EF2C62AFA26C700E3E384 /* ZIPFoundation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ZIPFoundation.xcframework; path = ../../Carthage/Build/ZIPFoundation.xcframework; sourceTree = "<group>"; };
 		297810FE297FAEDF007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/ResourceInfoView.strings; sourceTree = "<group>"; };
 		297810FF297FAEF8007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		29781100297FAF06007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = kn; path = kn.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -436,7 +437,6 @@
 		CE5C8BE424B5BD1C00FAFB7F /* QueryModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryModelTests.swift; sourceTree = "<group>"; };
 		CE5EDDBB26522EA3001733AC /* DeviceKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DeviceKit.xcframework; path = ../../Carthage/Build/DeviceKit.xcframework; sourceTree = "<group>"; };
 		CE5EDDC026522EA9001733AC /* XCGLogger.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = XCGLogger.xcframework; path = ../../Carthage/Build/XCGLogger.xcframework; sourceTree = "<group>"; };
-		CE5EDDC126522EA9001733AC /* Zip.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Zip.xcframework; path = ../../Carthage/Build/Zip.xcframework; sourceTree = "<group>"; };
 		CE5EDDC226522EAA001733AC /* Sentry.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Sentry.xcframework; path = ../../Carthage/Build/Sentry.xcframework; sourceTree = "<group>"; };
 		CE5EDDC326522EAA001733AC /* Reachability.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Reachability.xcframework; path = ../../Carthage/Build/Reachability.xcframework; sourceTree = "<group>"; };
 		CE5EDDC426522EAA001733AC /* ObjcExceptionBridging.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ObjcExceptionBridging.xcframework; path = ../../Carthage/Build/ObjcExceptionBridging.xcframework; sourceTree = "<group>"; };
@@ -560,8 +560,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				296EF2C72AFA26C700E3E384 /* ZIPFoundation.xcframework in Frameworks */,
 				CE5EDDC526522EAA001733AC /* XCGLogger.xcframework in Frameworks */,
-				CE5EDDC626522EAA001733AC /* Zip.xcframework in Frameworks */,
 				CE5EDDD52652372A001733AC /* DeviceKit.xcframework in Frameworks */,
 				CE5EDDC726522EAA001733AC /* Sentry.xcframework in Frameworks */,
 				CE5EDDC826522EAA001733AC /* Reachability.xcframework in Frameworks */,
@@ -949,11 +949,11 @@
 		F243888114BBD43000A3E055 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				296EF2C62AFA26C700E3E384 /* ZIPFoundation.xcframework */,
 				CE5EDDC426522EAA001733AC /* ObjcExceptionBridging.xcframework */,
 				CE5EDDC326522EAA001733AC /* Reachability.xcframework */,
 				CE5EDDC226522EAA001733AC /* Sentry.xcframework */,
 				CE5EDDC026522EA9001733AC /* XCGLogger.xcframework */,
-				CE5EDDC126522EA9001733AC /* Zip.xcframework */,
 				CE5EDDBB26522EA3001733AC /* DeviceKit.xcframework */,
 				9A079DE52231A69D00581263 /* Foundation.framework */,
 			);

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -455,10 +455,17 @@ public class KeymanPackage {
   }
   
   static public func clearDirectory(destination: URL) throws {
-    let fileArray = try FileManager.default.contentsOfDirectory(atPath: destination.path)
-    try fileArray.forEach { file in
-        let fileUrl = destination.appendingPathComponent(file)
-      try FileManager.default.removeItem(atPath: fileUrl.path)
+    // First check to see if directory exists. If not, then do nothing.
+    var isDirectory: ObjCBool = false
+    if(FileManager.default.fileExists(atPath: destination.path, isDirectory: &isDirectory)){
+      if (isDirectory.boolValue) {
+        // it exists and is actually a directory, so remove every file it contains
+        let fileArray = try FileManager.default.contentsOfDirectory(atPath: destination.path)
+        try fileArray.forEach { file in
+            let fileUrl = destination.appendingPathComponent(file)
+          try FileManager.default.removeItem(atPath: fileUrl.path)
+        }
+      }
     }
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -453,6 +453,14 @@ public class KeymanPackage {
       complete(nil)
     }
   }
+  
+  static public func clearDirectory(destination: URL) throws {
+    let fileArray = try FileManager.default.contentsOfDirectory(atPath: destination.path)
+    try fileArray.forEach { file in
+        let fileUrl = destination.appendingPathComponent(file)
+      try FileManager.default.removeItem(atPath: fileUrl.path)
+    }
+  }
 
   static public func extract(fileUrl: URL, destination: URL) throws -> KeymanPackage? {
     try unzipFile(fileUrl: fileUrl, destination: destination)

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -462,7 +462,7 @@ public class KeymanPackage {
         // it exists and is actually a directory, so remove every file it contains
         let fileArray = try FileManager.default.contentsOfDirectory(atPath: destination.path)
         try fileArray.forEach { file in
-            let fileUrl = destination.appendingPathComponent(file)
+          let fileUrl = destination.appendingPathComponent(file)
           try FileManager.default.removeItem(atPath: fileUrl.path)
         }
       }

--- a/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/KeymanPackage.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import Zip
+import ZIPFoundation
 
 // KMPErrors may be passed to UIAlertControllers, so they need localization.
 public enum KMPError : String, Error {
@@ -443,14 +443,14 @@ public class KeymanPackage {
   
   @available(*, deprecated, message: "Use of the completion block is unnecessary; this method now returns synchronously.")
   static public func extract(fileUrl: URL, destination: URL, complete: @escaping (KeymanPackage?) -> Void) throws {
-    try unzipFile(fileUrl: fileUrl, destination: destination) {
-      do {
-        let package = try KeymanPackage.parse(destination)
-        complete(package)
-      } catch {
-        SentryManager.captureAndLog(error, sentryLevel: .info)
-        complete(nil)
-      }
+    let fileManager = FileManager()
+    do {
+      try fileManager.unzipItem(at: fileUrl, to: destination)
+      let package = try KeymanPackage.parse(destination)
+      complete(package)
+    } catch {
+      SentryManager.captureAndLog(error, sentryLevel: .info)
+      complete(nil)
     }
   }
 
@@ -460,7 +460,8 @@ public class KeymanPackage {
   }
 
   static public func unzipFile(fileUrl: URL, destination: URL, complete: @escaping () -> Void = {}) throws {
-    try Zip.unzipFile(fileUrl, destination: destination, overwrite: true, password: nil)
+    let fileManager = FileManager()
+    try fileManager.unzipItem(at: fileUrl, to: destination)
     complete()
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/ResourceFileManager.swift
@@ -183,6 +183,9 @@ public class ResourceFileManager {
     var extractionFolder = cacheDirectory
     extractionFolder.appendPathComponent("temp/\(archiveUrl.lastPathComponent)")
 
+    // first clear extraction folder to avoid creating duplicates
+    try KeymanPackage.clearDirectory(destination: extractionFolder)
+    
     do {
       if let package = try KeymanPackage.extract(fileUrl: archiveUrl, destination: extractionFolder) {
         return package

--- a/ios/engine/KMEI/KeymanEngineTests/KeymanPackageTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/KeymanPackageTests.swift
@@ -58,6 +58,18 @@ class KeymanPackageTests: XCTestCase {
     }
   }
 
+  func testKeyboardPackage_clearNonexistentDirectory_doesNothing() throws {
+    let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+    let destinationDirectory = cacheDirectory.appendingPathComponent("doesnotexist")
+
+    do {
+      // clear directory
+      try KeymanPackage.clearDirectory(destination: destinationDirectory)
+      } catch {
+        XCTFail("error clearing the nonexistent directory \(error)")
+      }
+  }
+
   func testKeyboardPackage_clearEmptyDirectory_throwsNoError() throws {
     let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
     let destinationDirectory = cacheDirectory.appendingPathComponent("destination")

--- a/ios/engine/KMEI/KeymanEngineTests/KeymanPackageTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/KeymanPackageTests.swift
@@ -29,14 +29,13 @@ class KeymanPackageTests: XCTestCase {
     }
   }
 
-  func testKeyboardPackageExtraction() throws {
+  func testKeyboardPackage_extractWithoutKmpExtension_succeeds() throws {
     let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-    let khmerPackageZip = cacheDirectory.appendingPathComponent("khmer_angkor.kmp.zip")
+    let khmerPackageZip = cacheDirectory.appendingPathComponent("khmer_angkor.kmp")
     try ResourceFileManager.shared.copyWithOverwrite(from: TestUtils.Keyboards.khmerAngkorKMP, to: khmerPackageZip)
 
     let destinationFolderURL = cacheDirectory.appendingPathComponent("khmer_angkor")
 
-    // Requires that the source file is already .zip, not .kmp.  It's a ZipUtils limitation.
     do {
       if let kmp = try KeymanPackage.extract(fileUrl: khmerPackageZip, destination: destinationFolderURL) {
         // Run assertions on the package's kmp.info.
@@ -65,9 +64,9 @@ class KeymanPackageTests: XCTestCase {
     do {
       // clear directory
       try KeymanPackage.clearDirectory(destination: destinationDirectory)
-      } catch {
-        XCTFail("error clearing the nonexistent directory \(error)")
-      }
+    } catch {
+      XCTFail("error clearing the nonexistent directory \(error)")
+    }
   }
 
   func testKeyboardPackage_clearEmptyDirectory_throwsNoError() throws {
@@ -84,12 +83,12 @@ class KeymanPackageTests: XCTestCase {
 
       // clear directory
       try KeymanPackage.clearDirectory(destination: destinationDirectory)
-      } catch {
-        XCTFail("error clearing the empty directory \(error)")
-      }
+    } catch {
+      XCTFail("error clearing the empty directory \(error)")
+    }
     
     let fileArray = try FileManager.default.contentsOfDirectory(atPath: destinationDirectory.path)
-    XCTAssert(fileArray.count == 0, "directory still contains /(fileArray.count) items")
+    XCTAssert(fileArray.count == 0, "directory still contains \(fileArray.count) items")
   }
 
   func testKeyboardPackage_clearNonEmptyDirectory_directoryIsEmpty() throws {
@@ -111,22 +110,21 @@ class KeymanPackageTests: XCTestCase {
 
       // clear directory
       try KeymanPackage.clearDirectory(destination: destinationDirectory)
-      } catch {
-        XCTFail("error clearing the empty directory \(error)")
-      }
+    } catch {
+      XCTFail("error clearing the empty directory \(error)")
+    }
     
     let fileArray = try FileManager.default.contentsOfDirectory(atPath: destinationDirectory.path)
-    XCTAssert(fileArray.count == 0, "directory still contains /(fileArray.count) items")
+    XCTAssert(fileArray.count == 0, "directory still contains \(fileArray.count) items")
   }
 
   func testKeyboardPackage_extractTwice_noDuplicateFileError() throws {
     let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-    let khmerPackageZip = cacheDirectory.appendingPathComponent("khmer_angkor.kmp.zip")
+    let khmerPackageZip = cacheDirectory.appendingPathComponent("khmer_angkor.kmp")
     try ResourceFileManager.shared.copyWithOverwrite(from: TestUtils.Keyboards.khmerAngkorKMP, to: khmerPackageZip)
 
     let destinationFolderURL = cacheDirectory.appendingPathComponent("khmer_angkor")
 
-    // Requires that the source file is already .zip, not .kmp.  It's a ZipUtils limitation.
     do {
       if let kmp = try KeymanPackage.extract(fileUrl: khmerPackageZip, destination: destinationFolderURL) {
         log.info("*** first unzip of \(kmp.id)")
@@ -135,15 +133,15 @@ class KeymanPackageTests: XCTestCase {
           try KeymanPackage.clearDirectory(destination: destinationFolderURL)
           
           if let secondKmp = try KeymanPackage.extract(fileUrl: khmerPackageZip, destination: destinationFolderURL) {
-              log.info("*** second unzip of \(secondKmp.id)")
-            } else {
-              XCTAssert(false, "*** second unzip failed")
-            }
-          } catch {
-            XCTFail("unzip 2 failure with error \(error)")
+            log.info("*** second unzip of \(secondKmp.id)")
+          } else {
+            XCTAssert(false, "*** second unzip failed")
           }
-       } else {
-          XCTAssert(false, "*** first unzip failed")
+        } catch {
+          XCTFail("unzip 2 failure with error \(error)")
+        }
+      } else {
+        XCTAssert(false, "*** first unzip failed")
       }
     } catch {
       XCTFail("unzip 1 failure with error \(error)")
@@ -152,12 +150,11 @@ class KeymanPackageTests: XCTestCase {
 
   func testLexicalModelPackageExtraction() throws {
     let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-    let mtntZip = cacheDirectory.appendingPathComponent("nrc.en.mtnt.kmp.zip")
+    let mtntZip = cacheDirectory.appendingPathComponent("nrc.en.mtnt.kmp")
     try ResourceFileManager.shared.copyWithOverwrite(from: TestUtils.LexicalModels.mtntKMP, to: mtntZip)
 
     let destinationFolderURL = cacheDirectory.appendingPathComponent("nrc.en.mtnt.model")
 
-    // Requires that the source file is already .zip, not .kmp.  It's a ZipUtils limitation.
     do {
       if let kmp = try KeymanPackage.extract(fileUrl: mtntZip, destination: destinationFolderURL) {
         // Run assertions on the package's kmp.info.

--- a/ios/engine/KMEI/KeymanEngineTests/KeymanPackageTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/KeymanPackageTests.swift
@@ -58,6 +58,86 @@ class KeymanPackageTests: XCTestCase {
     }
   }
 
+  func testKeyboardPackage_clearEmptyDirectory_throwsNoError() throws {
+    let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+    let destinationDirectory = cacheDirectory.appendingPathComponent("destination")
+
+    do {
+      // create directory
+      try FileManager.default.createDirectory(
+        atPath: destinationDirectory.path,
+        withIntermediateDirectories: false,
+        attributes: nil
+      )
+
+      // clear directory
+      try KeymanPackage.clearDirectory(destination: destinationDirectory)
+      } catch {
+        XCTFail("error clearing the empty directory \(error)")
+      }
+    
+    let fileArray = try FileManager.default.contentsOfDirectory(atPath: destinationDirectory.path)
+    XCTAssert(fileArray.count == 0, "directory still contains /(fileArray.count) items")
+  }
+
+  func testKeyboardPackage_clearNonEmptyDirectory_directoryIsEmpty() throws {
+    let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+    let destinationDirectory = cacheDirectory.appendingPathComponent("destination")
+
+    do {
+      // create directory
+      try FileManager.default.createDirectory(
+        atPath: destinationDirectory.path,
+        withIntermediateDirectories: false,
+        attributes: nil
+      )
+
+      // add some files
+      FileManager.default.createFile(atPath: destinationDirectory.appendingPathComponent("fileone").path, contents: nil)
+      FileManager.default.createFile(atPath: destinationDirectory.appendingPathComponent("filetwo").path, contents: nil)
+      FileManager.default.createFile(atPath: destinationDirectory.appendingPathComponent("filethree").path, contents: nil)
+
+      // clear directory
+      try KeymanPackage.clearDirectory(destination: destinationDirectory)
+      } catch {
+        XCTFail("error clearing the empty directory \(error)")
+      }
+    
+    let fileArray = try FileManager.default.contentsOfDirectory(atPath: destinationDirectory.path)
+    XCTAssert(fileArray.count == 0, "directory still contains /(fileArray.count) items")
+  }
+
+  func testKeyboardPackage_extractTwice_noDuplicateFileError() throws {
+    let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+    let khmerPackageZip = cacheDirectory.appendingPathComponent("khmer_angkor.kmp.zip")
+    try ResourceFileManager.shared.copyWithOverwrite(from: TestUtils.Keyboards.khmerAngkorKMP, to: khmerPackageZip)
+
+    let destinationFolderURL = cacheDirectory.appendingPathComponent("khmer_angkor")
+
+    // Requires that the source file is already .zip, not .kmp.  It's a ZipUtils limitation.
+    do {
+      if let kmp = try KeymanPackage.extract(fileUrl: khmerPackageZip, destination: destinationFolderURL) {
+        log.info("*** first unzip of \(kmp.id)")
+        do {
+          // clear directory before second extract
+          try KeymanPackage.clearDirectory(destination: destinationFolderURL)
+          
+          if let secondKmp = try KeymanPackage.extract(fileUrl: khmerPackageZip, destination: destinationFolderURL) {
+              log.info("*** second unzip of \(secondKmp.id)")
+            } else {
+              XCTAssert(false, "*** second unzip failed")
+            }
+          } catch {
+            XCTFail("unzip 2 failure with error \(error)")
+          }
+       } else {
+          XCTAssert(false, "*** first unzip failed")
+      }
+    } catch {
+      XCTFail("unzip 1 failure with error \(error)")
+    }
+  }
+
   func testLexicalModelPackageExtraction() throws {
     let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
     let mtntZip = cacheDirectory.appendingPathComponent("nrc.en.mtnt.kmp.zip")

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceUpdateTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceUpdateTests.swift
@@ -57,10 +57,12 @@ class ResourceUpdateTests: XCTestCase {
 
     wait(for: [queryExpectation], timeout: 5)
 
+    /*
     // Uses the XCTest 'attachment' system to retrieve the desired file.
     self.add(try TestUtils.EngineStateBundler.createBundle(withName: "khmer_angkor update base"))
 
     log.info("Bundle archived and attached to test's report.")
+     */
   }
 
   func testCacheCurrent() {

--- a/ios/engine/KMEI/KeymanEngineTests/ResourceUpdateTests.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/ResourceUpdateTests.swift
@@ -57,12 +57,10 @@ class ResourceUpdateTests: XCTestCase {
 
     wait(for: [queryExpectation], timeout: 5)
 
-    /*
     // Uses the XCTest 'attachment' system to retrieve the desired file.
     self.add(try TestUtils.EngineStateBundler.createBundle(withName: "khmer_angkor update base"))
 
     log.info("Bundle archived and attached to test's report.")
-     */
   }
 
   func testCacheCurrent() {

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/EngineStateBundler.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/EngineStateBundler.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 import XCTest
-import Zip
+import ZIPFoundation
+
 @testable import KeymanEngine
 
 extension TestUtils {
@@ -28,6 +29,7 @@ extension TestUtils {
       return FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0].appendingPathComponent("Preferences")
     }
 
+    /*
     static func createBundle(withName name: String) throws -> XCTAttachment {
       let tempDirectory = FileManager.default.temporaryDirectory
       let bundleConstructionURL = tempDirectory.appendingPathComponent("\(name).bundle")
@@ -64,12 +66,20 @@ extension TestUtils {
         try FileManager.default.moveItem(at: pListPath.appendingPathComponent(testEngineFilename), to: pListPath.appendingPathComponent(appGroupFilename))
       }
 
-      let attachmentFile = try Zip.quickZipFiles([bundleConstructionURL], fileName: "bundleArchive")
-      log.info("Archive source: \(bundleConstructionURL)")
-      let attachment = XCTAttachment(contentsOfFile: attachmentFile)
-      attachment.lifetime = .keepAlways
-
-      return attachment
+      let archiveURL = bundleConstructionURL.appendingPathComponent("bundleArchive.zip")
+      do {
+        let attachmentFile = try Archive(url: archiveURL, accessMode: .create)
+        log.info("archiveURL: \(archiveURL)")
+        let attachment = XCTAttachment(contentsOfFile: archiveURL)
+        attachment.lifetime = .keepAlways
+        return attachment
+      }
+      catch let error {
+        print (error.localizedDescription)
+        return XCTAttachment(string: error.localizedDescription)
+      }
     }
+     
+     */
   }
 }

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/EngineStateBundler.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/EngineStateBundler.swift
@@ -72,12 +72,10 @@ extension TestUtils {
         let attachment = XCTAttachment(contentsOfFile: archiveURL)
         attachment.lifetime = .keepAlways
         return attachment
-      }
-      catch let error {
+      } catch let error {
         print (error.localizedDescription)
         return XCTAttachment(string: error.localizedDescription)
       }
-    }
-     
+    }     
   }
 }

--- a/ios/engine/KMEI/KeymanEngineTests/TestUtils/EngineStateBundler.swift
+++ b/ios/engine/KMEI/KeymanEngineTests/TestUtils/EngineStateBundler.swift
@@ -29,7 +29,6 @@ extension TestUtils {
       return FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0].appendingPathComponent("Preferences")
     }
 
-    /*
     static func createBundle(withName name: String) throws -> XCTAttachment {
       let tempDirectory = FileManager.default.temporaryDirectory
       let bundleConstructionURL = tempDirectory.appendingPathComponent("\(name).bundle")
@@ -68,7 +67,7 @@ extension TestUtils {
 
       let archiveURL = bundleConstructionURL.appendingPathComponent("bundleArchive.zip")
       do {
-        let attachmentFile = try Archive(url: archiveURL, accessMode: .create)
+        _ = try Archive(url: archiveURL, accessMode: .create)
         log.info("archiveURL: \(archiveURL)")
         let attachment = XCTAttachment(contentsOfFile: archiveURL)
         attachment.lifetime = .keepAlways
@@ -80,6 +79,5 @@ extension TestUtils {
       }
     }
      
-     */
   }
 }

--- a/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
+++ b/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		162E2C9F2092D36800F40769 /* UIDevice+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162E2C9E2092D36800F40769 /* UIDevice+Extensions.swift */; };
 		165EB39A2097165B00040A69 /* UIColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165EB3992097165B00040A69 /* UIColor+Extensions.swift */; };
 		165EB39C2097181D00040A69 /* KMView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165EB39B2097181D00040A69 /* KMView.swift */; };
+		296EF2C42AFA267500E3E384 /* ZIPFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296EF2C32AFA267500E3E384 /* ZIPFoundation.xcframework */; };
+		296EF2C52AFA267500E3E384 /* ZIPFoundation.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 296EF2C32AFA267500E3E384 /* ZIPFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		981AFA8F19EF44DE006706BF /* 724-info@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 9815725518E4F0930014DF0C /* 724-info@2x.png */; };
 		981AFA9619EF44DE006706BF /* MainViewController_iPhone.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98ABADCE176935E500B62590 /* MainViewController_iPhone.xib */; };
 		981AFA9819EF44DE006706BF /* 724-info.png in Resources */ = {isa = PBXBuildFile; fileRef = 9815725418E4F0930014DF0C /* 724-info.png */; };
@@ -155,8 +157,6 @@
 		CEBD34422654FEB400EB2EA8 /* Sentry.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD34382654FEB400EB2EA8 /* Sentry.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CEBD34432654FEB400EB2EA8 /* XCGLogger.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD34392654FEB400EB2EA8 /* XCGLogger.xcframework */; };
 		CEBD34442654FEB400EB2EA8 /* XCGLogger.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD34392654FEB400EB2EA8 /* XCGLogger.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		CEBD34452654FEB400EB2EA8 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD343A2654FEB400EB2EA8 /* Zip.xcframework */; };
-		CEBD34462654FEB400EB2EA8 /* Zip.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD343A2654FEB400EB2EA8 /* Zip.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CEF4E55623E95B7B0065B9C7 /* ImageBanner.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEF4E55523E95B7B0065B9C7 /* ImageBanner.xib */; };
 		CEF4E55723E95B7B0065B9C7 /* ImageBanner.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEF4E55523E95B7B0065B9C7 /* ImageBanner.xib */; };
 		CEF4E55923E967140065B9C7 /* ImageBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF4E55823E967140065B9C7 /* ImageBannerViewController.swift */; };
@@ -183,11 +183,11 @@
 			files = (
 				CEBD34402654FEB400EB2EA8 /* Reachability.xcframework in Embed Frameworks */,
 				CEBD343E2654FEB400EB2EA8 /* ObjcExceptionBridging.xcframework in Embed Frameworks */,
+				296EF2C52AFA267500E3E384 /* ZIPFoundation.xcframework in Embed Frameworks */,
 				CEBD343C2654FEB400EB2EA8 /* DeviceKit.xcframework in Embed Frameworks */,
 				CEBD34422654FEB400EB2EA8 /* Sentry.xcframework in Embed Frameworks */,
 				CEBD34442654FEB400EB2EA8 /* XCGLogger.xcframework in Embed Frameworks */,
 				CE80AD34257F2B4B008D2150 /* KeymanEngine.framework in Embed Frameworks */,
-				CEBD34462654FEB400EB2EA8 /* Zip.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -205,6 +205,7 @@
 		16A9229D20325253003CC98E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Keyman/Info.plist; sourceTree = SOURCE_ROOT; };
 		293EA3E027059C6900545EED /* ha */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ha; path = ha.lproj/Localizable.strings; sourceTree = "<group>"; };
 		294914742738DF7700400732 /* ff-NG */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ff-NG"; path = "ff-NG.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		296EF2C32AFA267500E3E384 /* ZIPFoundation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ZIPFoundation.xcframework; path = ../../Carthage/Build/ZIPFoundation.xcframework; sourceTree = "<group>"; };
 		297810FD297FA818007C886D /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		298566B829802828004ACA95 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		298566C42980C493004ACA95 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -344,7 +345,6 @@
 		CEBD34372654FEB400EB2EA8 /* Reachability.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Reachability.xcframework; path = ../../Carthage/Build/Reachability.xcframework; sourceTree = "<absolute>"; };
 		CEBD34382654FEB400EB2EA8 /* Sentry.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Sentry.xcframework; path = ../../Carthage/Build/Sentry.xcframework; sourceTree = "<absolute>"; };
 		CEBD34392654FEB400EB2EA8 /* XCGLogger.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = XCGLogger.xcframework; path = ../../Carthage/Build/XCGLogger.xcframework; sourceTree = "<absolute>"; };
-		CEBD343A2654FEB400EB2EA8 /* Zip.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Zip.xcframework; path = ../../Carthage/Build/Zip.xcframework; sourceTree = "<absolute>"; };
 		CEBD3458265511B700EB2EA8 /* am */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = am; path = am.lproj/Localizable.strings; sourceTree = "<group>"; };
 		CEEC468226F2F7BA009A5B7D /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		CEEF81B92673019600EE6A07 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -359,11 +359,11 @@
 			files = (
 				CEBD343F2654FEB400EB2EA8 /* Reachability.xcframework in Frameworks */,
 				CEBD343D2654FEB400EB2EA8 /* ObjcExceptionBridging.xcframework in Frameworks */,
+				296EF2C42AFA267500E3E384 /* ZIPFoundation.xcframework in Frameworks */,
 				CEBD343B2654FEB400EB2EA8 /* DeviceKit.xcframework in Frameworks */,
 				CEBD34412654FEB400EB2EA8 /* Sentry.xcframework in Frameworks */,
 				CEBD34432654FEB400EB2EA8 /* XCGLogger.xcframework in Frameworks */,
 				CE80AD33257F2B4A008D2150 /* KeymanEngine.framework in Frameworks */,
-				CEBD34452654FEB400EB2EA8 /* Zip.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -544,12 +544,12 @@
 		98ABADB2176935E400B62590 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				296EF2C32AFA267500E3E384 /* ZIPFoundation.xcframework */,
 				CEBD34352654FEB400EB2EA8 /* DeviceKit.xcframework */,
 				CEBD34362654FEB400EB2EA8 /* ObjcExceptionBridging.xcframework */,
 				CEBD34372654FEB400EB2EA8 /* Reachability.xcframework */,
 				CEBD34382654FEB400EB2EA8 /* Sentry.xcframework */,
 				CEBD34392654FEB400EB2EA8 /* XCGLogger.xcframework */,
-				CEBD343A2654FEB400EB2EA8 /* Zip.xcframework */,
 				CE80AD32257F2B4A008D2150 /* KeymanEngine.framework */,
 			);
 			name = Frameworks;

--- a/ios/keymanios.xcworkspace/xcshareddata/xcschemes/Keyman.xcscheme
+++ b/ios/keymanios.xcworkspace/xcshareddata/xcschemes/Keyman.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/ios/samples/KMSample1/KMSample1.xcodeproj/project.pbxproj
+++ b/ios/samples/KMSample1/KMSample1.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		290FB45B2AFB234900249D58 /* ZIPFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 290FB45A2AFB234800249D58 /* ZIPFoundation.xcframework */; };
+		290FB45C2AFB234900249D58 /* ZIPFoundation.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 290FB45A2AFB234800249D58 /* ZIPFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		98ABFCEC1AD39165005534F0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98ABFCEA1AD39165005534F0 /* Main.storyboard */; };
 		98ABFCEE1AD39165005534F0 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98ABFCED1AD39165005534F0 /* Images.xcassets */; };
 		98ABFCF11AD39165005534F0 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98ABFCEF1AD39165005534F0 /* LaunchScreen.xib */; };
@@ -24,8 +26,6 @@
 		CEBD33CD2654CB1500EB2EA8 /* Sentry.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33BE2654CA5900EB2EA8 /* Sentry.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CEBD33CE2654CB1600EB2EA8 /* XCGLogger.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33BD2654CA5900EB2EA8 /* XCGLogger.xcframework */; };
 		CEBD33CF2654CB1700EB2EA8 /* XCGLogger.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33BD2654CA5900EB2EA8 /* XCGLogger.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		CEBD33D02654CB1900EB2EA8 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33BB2654CA5900EB2EA8 /* Zip.xcframework */; };
-		CEBD33D12654CB1900EB2EA8 /* Zip.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33BB2654CA5900EB2EA8 /* Zip.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CED2AC85260AFADC00A408D2 /* ekwtamil99uni.kmp in Resources */ = {isa = PBXBuildFile; fileRef = CED2AC84260AFADC00A408D2 /* ekwtamil99uni.kmp */; };
 /* End PBXBuildFile section */
 
@@ -38,11 +38,11 @@
 			files = (
 				CEBD33CB2654CB1300EB2EA8 /* Reachability.xcframework in Embed Frameworks */,
 				CEBD33C92654CB1100EB2EA8 /* ObjcExceptionBridging.xcframework in Embed Frameworks */,
+				290FB45C2AFB234900249D58 /* ZIPFoundation.xcframework in Embed Frameworks */,
 				CEBD33C72654CB0F00EB2EA8 /* DeviceKit.xcframework in Embed Frameworks */,
 				CEBD33CD2654CB1500EB2EA8 /* Sentry.xcframework in Embed Frameworks */,
 				CEBD33CF2654CB1700EB2EA8 /* XCGLogger.xcframework in Embed Frameworks */,
 				CEBD337E26549EC100EB2EA8 /* KeymanEngine.xcframework in Embed Frameworks */,
-				CEBD33D12654CB1900EB2EA8 /* Zip.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -50,6 +50,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		290FB45A2AFB234800249D58 /* ZIPFoundation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ZIPFoundation.xcframework; path = ../../Carthage/Build/ZIPFoundation.xcframework; sourceTree = "<group>"; };
 		98ABFCDD1AD39165005534F0 /* KMSample1.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KMSample1.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		98ABFCE11AD39165005534F0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		98ABFCEB1AD39165005534F0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -59,7 +60,6 @@
 		C0324B831F87172900AF3785 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		CEBD337C26549EC100EB2EA8 /* KeymanEngine.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = KeymanEngine.xcframework; sourceTree = "<group>"; };
 		CEBD33B92654CA4B00EB2EA8 /* DeviceKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DeviceKit.xcframework; path = ../../Carthage/Build/DeviceKit.xcframework; sourceTree = "<group>"; };
-		CEBD33BB2654CA5900EB2EA8 /* Zip.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Zip.xcframework; path = ../../Carthage/Build/Zip.xcframework; sourceTree = "<group>"; };
 		CEBD33BC2654CA5900EB2EA8 /* ObjcExceptionBridging.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ObjcExceptionBridging.xcframework; path = ../../Carthage/Build/ObjcExceptionBridging.xcframework; sourceTree = "<group>"; };
 		CEBD33BD2654CA5900EB2EA8 /* XCGLogger.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = XCGLogger.xcframework; path = ../../Carthage/Build/XCGLogger.xcframework; sourceTree = "<group>"; };
 		CEBD33BE2654CA5900EB2EA8 /* Sentry.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Sentry.xcframework; path = ../../Carthage/Build/Sentry.xcframework; sourceTree = "<group>"; };
@@ -74,11 +74,11 @@
 			files = (
 				CEBD33C82654CB1000EB2EA8 /* ObjcExceptionBridging.xcframework in Frameworks */,
 				CEBD33CA2654CB1300EB2EA8 /* Reachability.xcframework in Frameworks */,
+				290FB45B2AFB234900249D58 /* ZIPFoundation.xcframework in Frameworks */,
 				CEBD33CC2654CB1400EB2EA8 /* Sentry.xcframework in Frameworks */,
 				CEBD33C62654CB0E00EB2EA8 /* DeviceKit.xcframework in Frameworks */,
 				CEBD337D26549EC100EB2EA8 /* KeymanEngine.xcframework in Frameworks */,
 				CEBD33CE2654CB1600EB2EA8 /* XCGLogger.xcframework in Frameworks */,
-				CEBD33D02654CB1900EB2EA8 /* Zip.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -127,11 +127,11 @@
 		98ABFD171AD391B0005534F0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				290FB45A2AFB234800249D58 /* ZIPFoundation.xcframework */,
 				CEBD33BC2654CA5900EB2EA8 /* ObjcExceptionBridging.xcframework */,
 				CEBD33BF2654CA5900EB2EA8 /* Reachability.xcframework */,
 				CEBD33BE2654CA5900EB2EA8 /* Sentry.xcframework */,
 				CEBD33BD2654CA5900EB2EA8 /* XCGLogger.xcframework */,
-				CEBD33BB2654CA5900EB2EA8 /* Zip.xcframework */,
 				CEBD33B92654CA4B00EB2EA8 /* DeviceKit.xcframework */,
 				CEBD337C26549EC100EB2EA8 /* KeymanEngine.xcframework */,
 			);

--- a/ios/samples/KMSample2/KMSample2.xcodeproj/project.pbxproj
+++ b/ios/samples/KMSample2/KMSample2.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		290FB45E2AFB270D00249D58 /* ZIPFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 290FB45D2AFB270D00249D58 /* ZIPFoundation.xcframework */; };
+		290FB45F2AFB270D00249D58 /* ZIPFoundation.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 290FB45D2AFB270D00249D58 /* ZIPFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		290FB4602AFB271C00249D58 /* ZIPFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 290FB45D2AFB270D00249D58 /* ZIPFoundation.xcframework */; };
 		98ABFD461AD3A047005534F0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98ABFD441AD3A047005534F0 /* Main.storyboard */; };
 		98ABFD481AD3A047005534F0 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98ABFD471AD3A047005534F0 /* Images.xcassets */; };
 		98ABFD4B1AD3A047005534F0 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98ABFD491AD3A047005534F0 /* LaunchScreen.xib */; };
@@ -18,8 +21,6 @@
 		CEBD33D42654CB6A00EB2EA8 /* KeymanEngine.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33D22654CB6A00EB2EA8 /* KeymanEngine.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CEBD33D82654CB7800EB2EA8 /* DeviceKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33D72654CB7800EB2EA8 /* DeviceKit.xcframework */; };
 		CEBD33D92654CB7800EB2EA8 /* DeviceKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33D72654CB7800EB2EA8 /* DeviceKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		CEBD33E02654CB8700EB2EA8 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33DB2654CB8700EB2EA8 /* Zip.xcframework */; };
-		CEBD33E12654CB8700EB2EA8 /* Zip.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33DB2654CB8700EB2EA8 /* Zip.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CEBD33E22654CB8700EB2EA8 /* Reachability.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33DC2654CB8700EB2EA8 /* Reachability.xcframework */; };
 		CEBD33E32654CB8700EB2EA8 /* Reachability.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33DC2654CB8700EB2EA8 /* Reachability.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CEBD33E42654CB8800EB2EA8 /* ObjcExceptionBridging.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33DD2654CB8700EB2EA8 /* ObjcExceptionBridging.xcframework */; };
@@ -38,7 +39,6 @@
 		CEDB327B265C9B33000A2009 /* Reachability.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33DC2654CB8700EB2EA8 /* Reachability.xcframework */; };
 		CEDB327C265C9B33000A2009 /* Sentry.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33DE2654CB8700EB2EA8 /* Sentry.xcframework */; };
 		CEDB327D265C9B33000A2009 /* XCGLogger.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33DF2654CB8700EB2EA8 /* XCGLogger.xcframework */; };
-		CEDB327E265C9B33000A2009 /* Zip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBD33DB2654CB8700EB2EA8 /* Zip.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,9 +71,9 @@
 			files = (
 				CEBD33E32654CB8700EB2EA8 /* Reachability.xcframework in Embed Frameworks */,
 				CEBD33E52654CB8800EB2EA8 /* ObjcExceptionBridging.xcframework in Embed Frameworks */,
+				290FB45F2AFB270D00249D58 /* ZIPFoundation.xcframework in Embed Frameworks */,
 				CEBD33E72654CB8800EB2EA8 /* Sentry.xcframework in Embed Frameworks */,
 				CEBD33D92654CB7800EB2EA8 /* DeviceKit.xcframework in Embed Frameworks */,
-				CEBD33E12654CB8700EB2EA8 /* Zip.xcframework in Embed Frameworks */,
 				CEBD33D42654CB6A00EB2EA8 /* KeymanEngine.xcframework in Embed Frameworks */,
 				CEBD33E92654CB8800EB2EA8 /* XCGLogger.xcframework in Embed Frameworks */,
 			);
@@ -94,6 +94,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		290FB45D2AFB270D00249D58 /* ZIPFoundation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ZIPFoundation.xcframework; path = ../../Carthage/Build/ZIPFoundation.xcframework; sourceTree = "<group>"; };
 		98ABFD371AD3A047005534F0 /* KMSample2.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KMSample2.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		98ABFD3B1AD3A047005534F0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		98ABFD451AD3A047005534F0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -108,7 +109,6 @@
 		C045148C1F85E33300D88416 /* KeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
 		CEBD33D22654CB6A00EB2EA8 /* KeymanEngine.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = KeymanEngine.xcframework; sourceTree = "<group>"; };
 		CEBD33D72654CB7800EB2EA8 /* DeviceKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DeviceKit.xcframework; path = ../../Carthage/Build/DeviceKit.xcframework; sourceTree = "<group>"; };
-		CEBD33DB2654CB8700EB2EA8 /* Zip.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Zip.xcframework; path = ../../Carthage/Build/Zip.xcframework; sourceTree = "<group>"; };
 		CEBD33DC2654CB8700EB2EA8 /* Reachability.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Reachability.xcframework; path = ../../Carthage/Build/Reachability.xcframework; sourceTree = "<group>"; };
 		CEBD33DD2654CB8700EB2EA8 /* ObjcExceptionBridging.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ObjcExceptionBridging.xcframework; path = ../../Carthage/Build/ObjcExceptionBridging.xcframework; sourceTree = "<group>"; };
 		CEBD33DE2654CB8700EB2EA8 /* Sentry.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Sentry.xcframework; path = ../../Carthage/Build/Sentry.xcframework; sourceTree = "<group>"; };
@@ -125,9 +125,9 @@
 			files = (
 				CEBD33E22654CB8700EB2EA8 /* Reachability.xcframework in Frameworks */,
 				CEBD33E42654CB8800EB2EA8 /* ObjcExceptionBridging.xcframework in Frameworks */,
+				290FB45E2AFB270D00249D58 /* ZIPFoundation.xcframework in Frameworks */,
 				CEBD33E62654CB8800EB2EA8 /* Sentry.xcframework in Frameworks */,
 				CEBD33D82654CB7800EB2EA8 /* DeviceKit.xcframework in Frameworks */,
-				CEBD33E02654CB8700EB2EA8 /* Zip.xcframework in Frameworks */,
 				CEBD33E82654CB8800EB2EA8 /* XCGLogger.xcframework in Frameworks */,
 				CEBD33D32654CB6A00EB2EA8 /* KeymanEngine.xcframework in Frameworks */,
 			);
@@ -139,9 +139,9 @@
 			files = (
 				CEDB327A265C9B33000A2009 /* ObjcExceptionBridging.xcframework in Frameworks */,
 				CEDB327B265C9B33000A2009 /* Reachability.xcframework in Frameworks */,
+				290FB4602AFB271C00249D58 /* ZIPFoundation.xcframework in Frameworks */,
 				CEDB327C265C9B33000A2009 /* Sentry.xcframework in Frameworks */,
 				CEDB327D265C9B33000A2009 /* XCGLogger.xcframework in Frameworks */,
-				CEDB327E265C9B33000A2009 /* Zip.xcframework in Frameworks */,
 				CEDB3279265C9B15000A2009 /* DeviceKit.xcframework in Frameworks */,
 				CEDB3276265C953A000A2009 /* KeymanEngine.xcframework in Frameworks */,
 			);
@@ -195,11 +195,11 @@
 		98ABFD601AD3A087005534F0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				290FB45D2AFB270D00249D58 /* ZIPFoundation.xcframework */,
 				CEBD33DD2654CB8700EB2EA8 /* ObjcExceptionBridging.xcframework */,
 				CEBD33DC2654CB8700EB2EA8 /* Reachability.xcframework */,
 				CEBD33DE2654CB8700EB2EA8 /* Sentry.xcframework */,
 				CEBD33DF2654CB8700EB2EA8 /* XCGLogger.xcframework */,
-				CEBD33DB2654CB8700EB2EA8 /* Zip.xcframework */,
 				CEBD33D72654CB7800EB2EA8 /* DeviceKit.xcframework */,
 				CEBD33D22654CB6A00EB2EA8 /* KeymanEngine.xcframework */,
 			);

--- a/oem/firstvoices/ios/Cartfile
+++ b/oem/firstvoices/ios/Cartfile
@@ -1,5 +1,5 @@
 github "weichsel/ZIPFoundation" ~> 0.9
-github "DaveWoodCom/XCGLogger" ~> 6.1.0
+github "keymanapp/dependency-XCGLogger" "master"
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
 github "getsentry/sentry-cocoa" ~> 8.7.0

--- a/oem/firstvoices/ios/Cartfile
+++ b/oem/firstvoices/ios/Cartfile
@@ -1,4 +1,5 @@
-github "keymanapp/dependency-XCGLogger" "master"
+github "weichsel/ZIPFoundation" ~> 0.9
+github "DaveWoodCom/XCGLogger" ~> 6.1.0
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
 github "getsentry/sentry-cocoa" ~> 8.7.0

--- a/oem/firstvoices/ios/Cartfile.resolved
+++ b/oem/firstvoices/ios/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "ashleymills/Reachability.swift" "v5.1.0"
-github "devicekit/DeviceKit" "5.0.0"
-github "getsentry/sentry-cocoa" "8.7.0"
-github "keymanapp/dependency-XCGLogger" "57a7b975dbb6fe4fe90cef3d1bc52b8adbd89113"
+github "devicekit/DeviceKit" "5.1.0"
+github "getsentry/sentry-cocoa" "6.2.1"
+github "weichsel/ZIPFoundation" "0.9.17"

--- a/oem/firstvoices/ios/Cartfile.resolved
+++ b/oem/firstvoices/ios/Cartfile.resolved
@@ -1,4 +1,5 @@
 github "ashleymills/Reachability.swift" "v5.1.0"
 github "devicekit/DeviceKit" "5.1.0"
-github "getsentry/sentry-cocoa" "6.2.1"
+github "getsentry/sentry-cocoa" "8.15.2"
+github "keymanapp/dependency-XCGLogger" "57a7b975dbb6fe4fe90cef3d1bc52b8adbd89113"
 github "weichsel/ZIPFoundation" "0.9.17"

--- a/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
+++ b/oem/firstvoices/ios/FirstVoices.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		290FB4632AFB358F00249D58 /* ZIPFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 290FB4622AFB358E00249D58 /* ZIPFoundation.xcframework */; };
+		290FB4642AFB358F00249D58 /* ZIPFoundation.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 290FB4622AFB358E00249D58 /* ZIPFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		290FB4652AFB359A00249D58 /* ZIPFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 290FB4622AFB358E00249D58 /* ZIPFoundation.xcframework */; };
 		294D40E9279FE62600DB37F6 /* KeyboardRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294D40E8279FE62600DB37F6 /* KeyboardRepository.swift */; };
 		294D40EC27A110BC00DB37F6 /* KeyboardSettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294D40EB27A110BC00DB37F6 /* KeyboardSettingsRepository.swift */; };
 		29694DC227A27EC300EA6C18 /* LexicalModelRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29694DC127A27EC300EA6C18 /* LexicalModelRepository.swift */; };
@@ -74,6 +77,7 @@
 			files = (
 				CEBD34202654D76900EB2EA8 /* Reachability.xcframework in Embed Frameworks */,
 				CEBD341E2654D76800EB2EA8 /* ObjcExceptionBridging.xcframework in Embed Frameworks */,
+				290FB4642AFB358F00249D58 /* ZIPFoundation.xcframework in Embed Frameworks */,
 				CEBD341B2654D76600EB2EA8 /* DeviceKit.xcframework in Embed Frameworks */,
 				CEBD34232654D76B00EB2EA8 /* Sentry.xcframework in Embed Frameworks */,
 				CEBD34262654D76C00EB2EA8 /* XCGLogger.xcframework in Embed Frameworks */,
@@ -96,6 +100,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		290FB4622AFB358E00249D58 /* ZIPFoundation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ZIPFoundation.xcframework; path = Carthage/Build/ZIPFoundation.xcframework; sourceTree = "<group>"; };
 		294D40E8279FE62600DB37F6 /* KeyboardRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardRepository.swift; sourceTree = "<group>"; };
 		294D40EB27A110BC00DB37F6 /* KeyboardSettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSettingsRepository.swift; sourceTree = "<group>"; };
 		29694DC127A27EC300EA6C18 /* LexicalModelRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexicalModelRepository.swift; sourceTree = "<group>"; };
@@ -153,6 +158,7 @@
 			files = (
 				CEBD341D2654D76800EB2EA8 /* ObjcExceptionBridging.xcframework in Frameworks */,
 				CEBD341F2654D76900EB2EA8 /* Reachability.xcframework in Frameworks */,
+				290FB4632AFB358F00249D58 /* ZIPFoundation.xcframework in Frameworks */,
 				CEBD34222654D76B00EB2EA8 /* Sentry.xcframework in Frameworks */,
 				CEBD341A2654D76600EB2EA8 /* DeviceKit.xcframework in Frameworks */,
 				CEBD34022654D41200EB2EA8 /* KeymanEngine.xcframework in Frameworks */,
@@ -166,6 +172,7 @@
 			files = (
 				CEDB327F265C9C58000A2009 /* DeviceKit.xcframework in Frameworks */,
 				CEDB3280265C9C58000A2009 /* ObjcExceptionBridging.xcframework in Frameworks */,
+				290FB4652AFB359A00249D58 /* ZIPFoundation.xcframework in Frameworks */,
 				CEDB3281265C9C58000A2009 /* Reachability.xcframework in Frameworks */,
 				CEDB3282265C9C58000A2009 /* Sentry.xcframework in Frameworks */,
 				CEDB3283265C9C58000A2009 /* XCGLogger.xcframework in Frameworks */,
@@ -284,6 +291,7 @@
 		98C9A9FB1BFC19ED009E9A4F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				290FB4622AFB358E00249D58 /* ZIPFoundation.xcframework */,
 				CEBD34082654D5AA00EB2EA8 /* ObjcExceptionBridging.xcframework */,
 				CEBD340C2654D5AB00EB2EA8 /* Reachability.xcframework */,
 				CEBD34092654D5AA00EB2EA8 /* Sentry.xcframework */,


### PR DESCRIPTION
Replacing marmelroy/Zip framework with weichsel/ZIPFoundation due to problems with using the [Zip framework and Carthage](https://github.com/marmelroy/Zip/issues/70). Attempts to use Zip framework were unsuccessful in #9942 

Fixes #8861
(#9819 is specific to Stable 16.0, so that is directly fixed by #9958)

@keymanapp-test-bot skip

🍒 from #9958 