### PR TITLE
change(android): smoother keyboard initialization ✨

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -31,6 +31,10 @@ function init() {
   keyman.getOskHeight = getOskHeight;
   keyman.getOskWidth = getOskWidth;
   keyman.beepKeyboard = beepKeyboard;
+
+  // Readies the keyboard stub for instant loading during the init process.
+  KeymanWeb.registerStub(JSON.parse(jsInterface.initialKeyboard()));
+
   keyman.init({
     'embeddingApp':device,
     'fonts':'packages/',

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -243,10 +243,8 @@ final class KMKeyboard extends WebView {
         }
 
         // Send console errors to Sentry in case they're missed by KMW sentryManager
-        // (Ignoring spurious message "No keyboard stubs exist = ...")
-        // TODO: Fix base error rather than trying to ignore it "No keyboard stubs exist"
 
-        if ((cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) && (!cm.message().startsWith("No keyboard stubs exist"))) {
+        if (cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) {
           // Make Toast notification of error and send log about falling back to default keyboard (ignore language ID)
           // Sanitize sourceId info
           String NAVIGATION_PATTERN = "^(.*)?(keyboard\\.html#[^-]+)-.*$";

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -1,6 +1,7 @@
 package com.keyman.engine;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -20,6 +21,7 @@ import android.webkit.JavascriptInterface;
 import static android.content.Context.VIBRATOR_SERVICE;
 
 import com.keyman.engine.KMManager.KeyboardType;
+import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.util.CharSequenceUtil;
 import com.keyman.engine.util.KMLog;
 
@@ -60,6 +62,21 @@ public class KMKeyboardJSHandler {
     DisplayMetrics dms = context.getResources().getDisplayMetrics();
     int kbWidth = (int) (dms.widthPixels / dms.density);
     return kbWidth;
+  }
+
+  @JavascriptInterface
+  public String initialKeyboard() {
+    // Note:  KMManager.getCurrentKeyboard() (and similar) will throw errors until the host-page is first fully
+    // loaded and has set a keyboard.  To allow the host-page to have earlier access, we instead get the stored
+    // keyboard index directly.
+    SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+    int index = prefs.getInt(KMManager.KMKey_UserKeyboardIndex, 0);
+    if (index < 0) {
+      index = 0;
+    }
+
+    Keyboard kbd = KMManager.getKeyboardInfo(this.context, index);
+    return kbd.toStub(context);
   }
 
   // This annotation is required in Jelly Bean and later:

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -747,12 +747,10 @@ public final class KMManager {
     // KMKeyboard
     if (InAppKeyboard != null) {
       RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
-      InAppKeyboard.setLayoutParams(params);
       InAppKeyboard.onConfigurationChanged(newConfig);
     }
     if (SystemKeyboard != null) {
       RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
-      SystemKeyboard.setLayoutParams(params);
       SystemKeyboard.onConfigurationChanged(newConfig);
     }
   }

--- a/web/src/engine/main/src/keyboardInterface.ts
+++ b/web/src/engine/main/src/keyboardInterface.ts
@@ -88,15 +88,21 @@ export default class KeyboardInterface<ContextManagerType extends ContextManager
     //
     // The mobile apps typically have fully-preconfigured paths, but Developer's
     // test-host page does not.
-    const pathConfig = this.engine.config.paths;
-    const stub = new KeyboardStub(Pstub, pathConfig.keyboards, pathConfig.fonts);
-    if(this.engine.keyboardRequisitioner?.cache.findMatchingStub(stub)) {
-      return 1;
-    }
+
+    const buildStub = () => {
+      const pathConfig = this.engine.config.paths;
+      return new KeyboardStub(Pstub, pathConfig.keyboards, pathConfig.fonts);
+    };
 
     if(!this.engine.config.deferForInitialization.hasFinalized) {
-      this.engine.config.deferForInitialization.then(() => this.engine.keyboardRequisitioner.cache.addStub(stub));
+      // pathConfig is not ready until KMW initializes, which prevents proper stub-building.
+      this.engine.config.deferForInitialization.then(() => this.engine.keyboardRequisitioner.cache.addStub(buildStub()));
     } else {
+      const stub = buildStub();
+
+      if(this.engine.keyboardRequisitioner?.cache.findMatchingStub(stub)) {
+        return 1;
+      }
       this.engine.keyboardRequisitioner.cache.addStub(stub);
     }
 


### PR DESCRIPTION
Continuing from #10017, this PR adds a few more tweaks to further smooth certain aspects of keyboard use.

One thing I happened upon [while investigating the keyboard-load process](https://github.com/keymanapp/keyman/issues/8868#issuecomment-1813941552):

> Sixth:
>
> (System keyboard) is active; the actual desired keyboard hasn't shown yet.

That tidbit above surfaces as a keyboard-initialization flash whenever the host-page is loaded - be it the first time or a reset.  It's what happens when Web loads on touch without an available keyboard stub... corresponding to an old warning about how "no keyboard stubs exist".  It seems that the flash has become slower / more prominent recently... possibly due to side effects from the Web modularization work?

One way to resolve that issue:  make sure that a valid keyboard stub _is_ available before the embedded version of KMW initializes.  In essence, "get it right the first time."  It turns out there were a few complications to resolve on the way, but they're nothing a little elbow grease can't resolve.

----

So, for many of those complications... the best way forward involved replicating a lot of the keyboard-stub building code for use within the `Keyboard` class, unbound from the standard `setKeyboard` methods.  This is obviously a bit WET to do, but unavoidable due to entangling side-effects in the originals. The new methods are better modularized; I'd advise refactoring the old methods to rely on the new methods at some point.

## User Testing

SIMPLE_LOAD_TEST:  

1. Install the Keyman app test build from this PR.
2. Open Keyman App. 
3. If any errors are reported during the loading process, FAIL this test.
4. If you see a flash of some _other_ keyboard that is swapped out before app loading completes, FAIL this test.
    - If it occurs, you might see "(System keyboard)" on the "temporary" keyboard's space bar.
    - That "temp" keyboard may have five rows instead of four, which would also likely be noticeable.