### PR TITLE
feat(developer): ldml: err/hint on illegal/pua chars 🙀 

### DIFF
--- a/common/web/types/src/kmx/kmx-plus.ts
+++ b/common/web/types/src/kmx/kmx-plus.ts
@@ -146,7 +146,11 @@ export interface StrsOptions {
 };
 
 export class Strs extends Section {
-  strings: StrsItem[] = [ new StrsItem('') ]; // C7043: The null string is always requierd
+  /** the in-memory string table */
+  strings: StrsItem[] = [ new StrsItem('') ]; // C7043: The null string is always required
+
+  /** for validating */
+  allProcessedStrings = new Set<string>();
   /**
    * Allocate a StrsItem given the string, unescaping if necessary.
    * @param s escaped string
@@ -157,6 +161,11 @@ export class Strs extends Section {
   allocString(s?: string, opts?: StrsOptions, sections?: DependencySections): StrsItem {
     // Run the string processing pipeline
     s = Strs.processString(s, opts, sections);
+
+    // add to the set, for testing
+    if (s) {
+      this.allProcessedStrings.add(s);
+    }
 
     // if it's a single char, don't push it into the strs table
     if (opts?.singleOk && isOneChar(s)) {

--- a/common/web/types/src/util/util.ts
+++ b/common/web/types/src/util/util.ts
@@ -103,7 +103,14 @@ toOneChar(value: string) : number {
 }
 
 export function describeCodepoint(ch : number) : string {
-  const s = isValidUnicode(ch) ? String.fromCodePoint(ch) : "INVALID";
+  let s;
+  if (isPUA(ch)) {
+    s = "PUA";
+  } else if (isValidUnicode(ch)) {
+    s = String.fromCodePoint(ch);
+  } else {
+    s = "INVALID";
+  }
   return `"${s}" (U+${Number(ch).toString(16)})`;
 }
 
@@ -214,7 +221,6 @@ function getProblem(ch : number) : BadStringType {
     return null;
   }
 }
-
 export class BadStringAnalyzer {
   /** add a string for analysis */
   public add(s : string) {

--- a/common/web/types/test/util/test-unescape.ts
+++ b/common/web/types/test/util/test-unescape.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import {assert} from 'chai';
-import {unescapeString, UnescapeError, isOneChar, toOneChar, unescapeOneQuadString} from '../../src/util/util.js';
+import {unescapeString, UnescapeError, isOneChar, toOneChar, unescapeOneQuadString, BadStringAnalyzer, isValidUnicode, describeCodepoint, isPUA, BadStringType} from '../../src/util/util.js';
 
 describe('test UTF32 functions()', function() {
   it('should properly categorize strings', () => {
@@ -66,5 +66,148 @@ describe('test unescapeOneQuadString()', () => {
   it('should fail when it needs to fail', () => {
     assert.throws(() => unescapeOneQuadString(null), null);
     assert.throws(() => unescapeOneQuadString('\uFFFFFFFFFFFF'));
+  });
+});
+
+function titleize(o : any) {
+  const s = JSON.stringify(o);
+  if (!s) {
+    return `''`;
+  } else if (s.length < 10) {
+    return s;
+  } else {
+    return s.substring(0,10)+'…';
+  }
+}
+
+describe('test bad char functions', () => {
+  it('should match test_kmx_xstring.cpp', () => {
+    function Uni_IsValid(start: number, end?: number) {
+      return [ start, end ];
+    }
+    function assert_equal(range: number[], expect : boolean) {
+      const [start, end] = range;
+      if (end) {
+        assert.equal(isValidUnicode(start, end), expect, `for ${describeCodepoint(start)}-${describeCodepoint(end)}}`);
+      } else {
+        // if branch just for the message
+        assert.equal(isValidUnicode(start), expect, `for ${describeCodepoint(start)}`);
+      }
+    }
+    // following lines are from test_kmx_xstring.cpp
+    assert_equal(Uni_IsValid(0x0000), true);
+    assert_equal(Uni_IsValid(0x0127), true);
+    assert_equal(Uni_IsValid('🙀'.codePointAt(0)), true);
+    assert_equal(Uni_IsValid(0xDECAFBAD), false); // out of range
+    assert_equal(Uni_IsValid(0x566D4128), false);
+    assert_equal(Uni_IsValid(0xFFFF), false); // nonchar
+    assert_equal(Uni_IsValid(0xFFFE), false); // nonchar
+    assert_equal(Uni_IsValid(0x10FFFF), false); // nonchar
+    assert_equal(Uni_IsValid(0x10FFFE), false); // nonchar
+    assert_equal(Uni_IsValid(0x01FFFF), false); // nonchar
+    assert_equal(Uni_IsValid(0x01FFFE), false); // nonchar
+    assert_equal(Uni_IsValid(0x02FFFF), false); // nonchar
+    assert_equal(Uni_IsValid(0x02FFFE), false); // nonchar
+    assert_equal(Uni_IsValid(0xFDD1), false); // nonchar
+    assert_equal(Uni_IsValid(0xD800), false); // orphaned surrogate
+    assert_equal(Uni_IsValid(0xFDD0), false); // nonchar
+    assert_equal(Uni_IsValid(0x100000, 0x10FFFD), true);
+    assert_equal(Uni_IsValid(0x10, 0x20), true);
+    assert_equal(Uni_IsValid(0x100000, 0x10FFFD), true);
+    assert_equal(Uni_IsValid(0x0000, 0xD7FF), true);
+    assert_equal(Uni_IsValid(0xD800, 0xDFFF), false); // orphaned surrogate
+    assert_equal(Uni_IsValid(0xE000, 0xFDCF), true);
+    assert_equal(Uni_IsValid(0xFDD0, 0xFDEF), false);
+    assert_equal(Uni_IsValid(0xFDF0, 0xFDFF), true);
+    assert_equal(Uni_IsValid(0xFDF0, 0xFFFD), true);
+    assert_equal(Uni_IsValid(0, 0x10FFFF), false);         // ends with nonchar
+    assert_equal(Uni_IsValid(0, 0x10FFFD), false);         // contains lots o' nonchars
+    assert_equal(Uni_IsValid(0x20, 0x10), false);          // swapped
+    assert_equal(Uni_IsValid(0xFDEF, 0xFDF0), false);      // just outside range
+    assert_equal(Uni_IsValid(0x0000, 0x010000), false);    // crosses noncharacter plane boundary and other stuff
+    assert_equal(Uni_IsValid(0x010000, 0x020000), false);  // crosses noncharacter plane boundary
+    assert_equal(Uni_IsValid(0x0000, 0xFFFF), false);      // crosses other BMP prohibited and plane boundary
+    assert_equal(Uni_IsValid(0x0000, 0xFFFD), false);      // crosses other BMP prohibited
+    assert_equal(Uni_IsValid(0x0000, 0xE000), false);      // crosses surrogate space
+    assert_equal(Uni_IsValid(0x0000, 0x20FFFF), false);      // out of bounds
+    assert_equal(Uni_IsValid(0x10FFFD, 0x20FFFF), false);      // out of bounds
+  });
+  it('should detect non-PUA', () => {
+    const strs = "abcd" +
+    ([
+      0xF900,
+      0xFFFFF,
+    ].map(ch => String.fromCodePoint(ch)).join(''));
+    for (const s of strs) {
+      const ch = s.codePointAt(0);
+      assert.isFalse(isPUA(ch), describeCodepoint(ch));
+    }
+  });
+  it('should detect PUA', () => {
+    const strs = "\uE010" +
+      ([
+        0xE000,0xE001,0xE002,
+        0xF000,
+        0xF800,
+        0xF8FF,
+
+        0x0F0000,
+        0x0FFFFD,
+
+        0x100000,
+        0x10FFFD
+      ].map(ch => String.fromCodePoint(ch)).join(''));
+    for (const s of strs) {
+      const ch = s.codePointAt(0);
+      assert.isTrue(isPUA(ch), describeCodepoint(ch));
+    }
+  });
+});
+
+describe('test BadStringAnalyzer', () => {
+  describe('should return nothing for all valid strings', () => {
+    const cases = [
+      [],
+      ['a',],
+      ['a', 'b',]
+    ];
+    for (const strs of cases) {
+      const title = titleize(strs);
+      it(`should analyze ${title}`, () => {
+        const bsa = new BadStringAnalyzer();
+        for (const s of strs) {
+          bsa.add(s);
+        }
+        const m = bsa.analyze();
+        assert.isNull(m, `${title}`);
+      });
+    }
+  });
+  describe('should return nothing for all valid strings', () => {
+    it('should handle a case with some odd strs in it', () => {
+      const strs = "But you can call me “\uE010\uFDD0\uFFFE\uD800”, for short." +
+      ([
+        0xF800,
+        0x05FFFF,
+        0x102222,
+        0x04FFFE,
+      ].map(ch => String.fromCodePoint(ch)).join(''));
+
+      const bsa = new BadStringAnalyzer();
+      for (const s of strs) {
+        bsa.add(s);
+      }
+      const m = bsa.analyze();
+      assert.isNotNull(m);
+      assert.containsAllKeys(m, [BadStringType.pua, BadStringType.illegal]);
+      assert.sameDeepMembers(Array.from(m.get(BadStringType.pua).values()), [
+        0xE010,0xF800, 0x102222,
+      ], `pua analysis`);
+      assert.sameDeepMembers(Array.from(m.get(BadStringType.illegal).values()), [
+        0xFDD0,0xD800,0xFFFE,
+        0x05FFFF,
+        0x04FFFE,
+      ], `illegal analysis`);
+    });
   });
 });

--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -147,8 +147,8 @@ export class LdmlKeyboardCompiler {
    * @param     source
    * @returns   true if the file validates
    */
-  public validate(source: LDMLKeyboardXMLSourceFile): boolean {
-    return !!this.compile(source);
+  public async validate(source: LDMLKeyboardXMLSourceFile): Promise<boolean> {
+    return !!(await this.compile(source, true));
   }
 
   /**
@@ -157,7 +157,7 @@ export class LdmlKeyboardCompiler {
    * @param   source  in-memory representation of LDML keyboard xml file
    * @returns         KMXPlusFile intermediate file
    */
-  public async compile(source: LDMLKeyboardXMLSourceFile): Promise<KMXPlus.KMXPlusFile> {
+  public async compile(source: LDMLKeyboardXMLSourceFile, postValidate?: boolean): Promise<KMXPlus.KMXPlusFile> {
     const sections = this.buildSections(source);
     let passed = true;
 
@@ -208,9 +208,11 @@ export class LdmlKeyboardCompiler {
     }
 
     // give all sections a chance to postValidate
-    for(let section of sections) {
-      if(!section.postValidate(kmx.kmxplus[section.id])) {
-        passed = false;
+    if (postValidate) {
+      for(let section of sections) {
+        if(!section.postValidate(kmx.kmxplus[section.id])) {
+          passed = false;
+        }
       }
     }
 

--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -207,6 +207,13 @@ export class LdmlKeyboardCompiler {
       kmx.kmxplus[section.id] = sect as any;
     }
 
+    // give all sections a chance to postValidate
+    for(let section of sections) {
+      if(!section.postValidate(kmx.kmxplus[section.id])) {
+        passed = false;
+      }
+    }
+
     return passed ? kmx : null;
   }
 }

--- a/developer/src/kmc-ldml/src/compiler/empty-compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/empty-compiler.ts
@@ -1,7 +1,8 @@
 import { SectionIdent, constants } from '@keymanapp/ldml-keyboard-constants';
 import { SectionCompiler } from "./section-compiler.js";
-import { LDMLKeyboard, KMXPlus, CompilerCallbacks } from "@keymanapp/common-types";
+import { LDMLKeyboard, KMXPlus, CompilerCallbacks, util, MarkerParser } from "@keymanapp/common-types";
 import { VarsCompiler } from './vars.js';
+import { CompilerMessages } from './messages.js';
 
 /**
  * Compiler for typrs that don't actually consume input XML
@@ -27,6 +28,45 @@ export class StrsCompiler extends EmptyCompiler {
   }
   public compile(sections: KMXPlus.DependencySections): KMXPlus.Section {
     return new KMXPlus.Strs();
+  }
+  public postValidate(section?: KMXPlus.Section): boolean {
+    const strs = <KMXPlus.Strs>section;
+
+    if (strs) {
+      const badStringAnalyzer = new util.BadStringAnalyzer();
+      const CONTAINS_MARKER_REGEX = new RegExp(MarkerParser.ANY_MARKER_MATCH);
+      for (let s of strs.allProcessedStrings.values()) {
+        // skip marker strings
+        if (CONTAINS_MARKER_REGEX.test(s)) {
+          // it had a marker, take out all marker strings, as the sentinel is illegal
+          // need a new regex to match
+          const REPLACE_MARKER_REGEX = new RegExp(MarkerParser.ANY_MARKER_MATCH, 'g');
+          s = s.replaceAll(REPLACE_MARKER_REGEX, ''); // remove markers.
+        }
+        badStringAnalyzer.add(s);
+      }
+      const m = badStringAnalyzer.analyze();
+      if (m?.size > 0) {
+        const puas = m.get(util.BadStringType.pua);
+        const unassigneds = m.get(util.BadStringType.unassigned);
+        const illegals = m.get(util.BadStringType.illegal);
+        if (puas) {
+          const [count, lowestCh] = [puas.size, Array.from(puas.values()).sort((a, b) => a - b)[0]];
+          this.callbacks.reportMessage(CompilerMessages.Hint_PUACharacters({ count, lowestCh }))
+        }
+        if (unassigneds) {
+          const [count, lowestCh] = [unassigneds.size, Array.from(unassigneds.values()).sort((a, b) => a - b)[0]];
+          this.callbacks.reportMessage(CompilerMessages.Warn_UnassignedCharacters({ count, lowestCh }))
+        }
+        if (illegals) {
+          // do this last, because we will return false.
+          const [count, lowestCh] = [illegals.size, Array.from(illegals.values()).sort((a, b) => a - b)[0]];
+          this.callbacks.reportMessage(CompilerMessages.Error_IllegalCharacters({ count, lowestCh }))
+          return false;
+        }
+      }
+    }
+    return true;
   }
 }
 

--- a/developer/src/kmc-ldml/src/compiler/messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/messages.ts
@@ -1,5 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
-
+import { util, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
 // const SevInfo = CompilerErrorSeverity.Info | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevHint = CompilerErrorSeverity.Hint | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevWarn = CompilerErrorSeverity.Warn | CompilerErrorNamespace.LdmlKeyboardCompiler;
@@ -146,6 +145,18 @@ export class CompilerMessages {
   static Error_DisplayNeedsToOrId = (o:{output?: string, keyId?: string}) =>
   m(this.ERROR_DisplayNeedsToOrId, `display ${CompilerMessages.outputOrKeyId(o)} needs output= or keyId=, but not both`);
   static ERROR_DisplayNeedsToOrId = SevError | 0x0022;
+
+  static Hint_PUACharacters = (o: { count: number, lowestCh: number }) =>
+  m(this.HINT_PUACharacters, `File contained ${o.count} PUA character(s), including ${util.describeCodepoint(o.lowestCh)}`);
+  static HINT_PUACharacters = SevHint | 0x0023;
+
+  static Warn_UnassignedCharacters = (o: { count: number, lowestCh: number }) =>
+  m(this.WARN_UnassignedCharacters, `File contained ${o.count} unassigned character(s), including ${util.describeCodepoint(o.lowestCh)}`);
+  static WARN_UnassignedCharacters = SevWarn | 0x0024;
+
+  static Error_IllegalCharacters = (o: { count: number, lowestCh: number }) =>
+  m(this.ERROR_IllegalCharacters, `File contained ${o.count} illegal character(s), including ${util.describeCodepoint(o.lowestCh)}`);
+  static ERROR_IllegalCharacters = SevError | 0x0025;
 }
 
 

--- a/developer/src/kmc-ldml/src/compiler/section-compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/section-compiler.ts
@@ -31,7 +31,8 @@ export abstract class SectionCompiler {
   public abstract compile(sections: KMXPlus.DependencySections): KMXPlus.Section;
 
   /**
-   * This is called after all other compile phases have completed, and provides an
+   * This is called after all other compile phases have completed,
+   * when being called by validate(), and provides an
    * opportunity for late error reporting, for example for invalid strings.
    * @param section the compiled section, if any.
    * @returns false if validate fails

--- a/developer/src/kmc-ldml/src/compiler/section-compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/section-compiler.ts
@@ -1,8 +1,9 @@
 import { LDMLKeyboard, KMXPlus, CompilerCallbacks } from "@keymanapp/common-types";
 import { SectionIdent, constants } from '@keymanapp/ldml-keyboard-constants';
 
-/* istanbul ignore next */
-export class SectionCompiler {
+/** newable interface to SectionCompiler c'tor */
+export type SectionCompilerNew = new (source: LDMLKeyboard.LDMLKeyboardXMLSourceFile, callbacks: CompilerCallbacks) => SectionCompiler;
+export abstract class SectionCompiler {
   protected readonly keyboard3: LDMLKeyboard.LKKeyboard;
   protected readonly callbacks: CompilerCallbacks;
 
@@ -11,16 +12,31 @@ export class SectionCompiler {
     this.callbacks = callbacks;
   }
 
-  /* c8 ignore next 11 */
-  public get id(): SectionIdent {
-    throw Error(`Internal Error: id() not implemented`);
-  }
+  public abstract get id(): SectionIdent;
 
-  public compile(sections: KMXPlus.DependencySections): KMXPlus.Section {
-    throw Error(`Internal Error: compile() not implemented`);
-  }
-
+  /**
+   * This is called before compile.
+   * @returns false if this compiler failed to validate.
+   */
   public validate(): boolean {
+    return true;
+  }
+
+  /**
+   * Perform the compilation for this section, returning the correct Section subclass
+   * object.
+   *
+   * @param sections any declared dependency sections per dependencies()
+   */
+  public abstract compile(sections: KMXPlus.DependencySections): KMXPlus.Section;
+
+  /**
+   * This is called after all other compile phases have completed, and provides an
+   * opportunity for late error reporting, for example for invalid strings.
+   * @param section the compiled section, if any.
+   * @returns false if validate fails
+   */
+  public postValidate(section?: KMXPlus.Section): boolean {
     return true;
   }
 

--- a/developer/src/kmc-ldml/src/compiler/tran.ts
+++ b/developer/src/kmc-ldml/src/compiler/tran.ts
@@ -19,7 +19,7 @@ import { MarkerTracker, MarkerUse } from "./marker-tracker.js";
 
 type TransformCompilerType = 'simple' | 'backspace';
 
-export class TransformCompiler<T extends TransformCompilerType, TranBase extends Tran> extends SectionCompiler {
+export abstract class TransformCompiler<T extends TransformCompilerType, TranBase extends Tran> extends SectionCompiler {
 
   static validateMarkers(keyboard: LDMLKeyboard.LKKeyboard, mt : MarkerTracker): boolean {
     keyboard?.transforms?.forEach(transforms =>

--- a/developer/src/kmc-ldml/test/fixtures/sections/strs/hint-pua.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/strs/hint-pua.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+@@keys: [K_Q][K_W][K_Q]
+@@expected: \u0127\u1790\u17B6\u0127
+-->
+<!DOCTYPE keyboard3 SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard3.dtd">
+<keyboard3 locale="mt" conformsTo="techpreview">
+  <version number="1.0.0" />
+
+  <info author="srl295" indicator="🙀" layout="qwerty"  name="TestKbd"/>
+
+  <displays>
+    <!-- values chosen to reuse strings -->
+    <display output="a" display="^" />
+    <display keyId="\u{E020}" display="^e" />
+    <displayOptions baseCharacter="e" />
+  </displays>
+  <keys>
+    <!-- Note: implied keys here: 'a' and 'e' -->
+    <key id="hmaqtugha" output="hhh" longPressKeyIds="a e" />
+  </keys>
+
+  <layers formId="us" minDeviceWidth="123">
+    <layer id="zz">
+      <row keys="hmaqtugha" />
+    </layer>
+  </layers>
+
+  <variables>
+    <string id="a" value="\m{a}"/>
+    <string id="vst" value="pua:\u{E010}"/>
+    <set id="vse" value="a b"/>
+    <unicodeSet id="vus" value="[abc]"/>
+  </variables>
+
+  <transforms type="simple">
+    <transformGroup>
+      <transform from="^a" to="q" />
+      <transform from="a" to="\m{a}" />
+    </transformGroup>
+    <transformGroup>
+      <!-- delete that marker -->
+      <transform from="\m{a}\u{E020}" />
+    </transformGroup>
+
+    <transformGroup>
+      <!-- Northern Thai example from spec -->
+      <reorder before="\u{1A6B}" from="\u{1A60}[\u1A75-\u1A79]\u{1A45}" order="10 55 10" />
+    </transformGroup>
+  </transforms>
+
+  <transforms type="backspace">
+    <transformGroup>
+      <transform from="^e" />
+    </transformGroup>
+  </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/fixtures/sections/strs/invalid-illegal.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/strs/invalid-illegal.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+@@keys: [K_Q][K_W][K_Q]
+@@expected: \u0127\u1790\u17B6\u0127
+-->
+<!DOCTYPE keyboard3 SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard3.dtd">
+<keyboard3 locale="mt" conformsTo="techpreview">
+  <version number="1.0.0" />
+
+  <info author="srl295" indicator="🙀" layout="qwerty"  name="TestKbd"/>
+
+  <displays>
+    <!-- values chosen to reuse strings -->
+    <display output="a" display="^" />
+    <display keyId="e" display="^e" />
+    <displayOptions baseCharacter="e" />
+  </displays>
+  <keys>
+    <!-- Note: implied keys here: 'a' and 'e' -->
+    <key id="hmaqtugha" output="h\u{FDD0}" longPressKeyIds="a e" />
+    <key id="that" output="&#xFFFF;" /> <!-- illegal NCR (single char)-->
+  </keys>
+
+  <layers formId="us" minDeviceWidth="123">
+    <layer id="&#xFFFE;">
+      <row keys="hmaqtugha that" />
+    </layer>
+  </layers>
+
+  <variables>
+    <string id="a" value="\m{a}"/>
+    <string id="vst" value="abc pua:\u{E010}"/>
+    <set id="vse" value="a b \u{04FFFE} \u{5FFFF}"/>
+    <unicodeSet id="vus" value="[abc]"/>
+  </variables>
+
+  <transforms type="simple">
+    <transformGroup>
+      <transform from="^a" to="\u{FDD0}" />
+      <transform from="a" to="\m{a}\u{E020}" /> <!-- another PUA, with a marker -->
+    </transformGroup>
+    <transformGroup>
+      <!-- delete that marker -->
+      <transform from="\m{a}" />
+    </transformGroup>
+
+    <transformGroup>
+      <!-- Northern Thai example from spec -->
+      <reorder before="\u{1A6B}" from="\u{1A60}[\u1A75-\u1A79]\u{1A45}" order="10 55 10" />
+    </transformGroup>
+  </transforms>
+
+  <transforms type="backspace">
+    <transformGroup>
+      <transform from="^e" />
+    </transformGroup>
+  </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-unassigned.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-unassigned.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+@@keys: [K_Q][K_W][K_Q]
+@@expected: \u0127\u1790\u17B6\u0127
+-->
+<!DOCTYPE keyboard3 SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard3.dtd">
+<keyboard3 locale="mt" conformsTo="techpreview">
+  <version number="1.0.0" />
+
+  <info author="srl295" indicator="🙀" layout="qwerty"  name="TestKbd"/>
+
+  <displays>
+    <!-- values chosen to reuse strings -->
+    <display output="a" display="^" />
+    <display keyId="\u{E020}" display="^e" />
+    <displayOptions baseCharacter="e" />
+  </displays>
+  <keys>
+    <!-- unassigned char (as of this writing) -->
+    <key id="hmaqtugha" output="\u{CFFFD}" longPressKeyIds="a e" />
+  </keys>
+
+  <layers formId="us" minDeviceWidth="123">
+    <layer id="zz">
+      <row keys="hmaqtugha" />
+    </layer>
+  </layers>
+
+  <variables>
+    <string id="a" value="\m{a}"/>
+    <string id="vst" value="pua:\u{E010}"/>
+    <set id="vse" value="a b"/>
+    <unicodeSet id="vus" value="[abc]"/>
+  </variables>
+
+  <transforms type="simple">
+    <transformGroup>
+      <transform from="^a" to="q" />
+      <transform from="a" to="\m{a}" />
+    </transformGroup>
+    <transformGroup>
+      <!-- delete that marker -->
+      <transform from="\m{a}\u{E020}" />
+    </transformGroup>
+
+    <transformGroup>
+      <!-- Northern Thai example from spec -->
+      <reorder before="\u{1A6B}" from="\u{1A60}[\u1A75-\u1A79]\u{1A45}" order="10 55 10" />
+    </transformGroup>
+  </transforms>
+
+  <transforms type="backspace">
+    <transformGroup>
+      <transform from="^e" />
+    </transformGroup>
+  </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/test-compiler-e2e.ts
+++ b/developer/src/kmc-ldml/test/test-compiler-e2e.ts
@@ -4,11 +4,13 @@ import hextobin from '@keymanapp/hextobin';
 import { KMXBuilder } from '@keymanapp/common-types';
 import {checkMessages, compileKeyboard, compilerTestCallbacks, compilerTestOptions, makePathToFixture} from './helpers/index.js';
 import { LdmlKeyboardCompiler } from '../src/compiler/compiler.js';
+import { CompilerMessages } from '../src/compiler/messages.js';
 
 describe('compiler-tests', function() {
   this.slow(500); // 0.5 sec -- json schema validation takes a while
 
   it('should-build-fixtures', async function() {
+    compilerTestCallbacks.messages = [];
     // Let's build basic.xml
     // It should match basic.kmx (built from basic.txt)
 
@@ -32,33 +34,87 @@ describe('compiler-tests', function() {
   });
 
   it('should handle non existent files', () => {
+    compilerTestCallbacks.messages = [];
     const filename = 'DOES_NOT_EXIST.xml';
     const k = new LdmlKeyboardCompiler(compilerTestCallbacks, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false });
     const source = k.load(filename);
     assert.notOk(source, `Trying to load(${filename})`);
   });
   it('should handle unparseable files', () => {
+    compilerTestCallbacks.messages = [];
     const filename = makePathToFixture('basic-kvk.txt'); // not an .xml file
     const k = new LdmlKeyboardCompiler(compilerTestCallbacks, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false });
     const source = k.load(filename);
     assert.notOk(source, `Trying to load(${filename})`);
   });
   it('should handle not-valid files', () => {
+    compilerTestCallbacks.messages = [];
     const filename = makePathToFixture('test-fr.xml'); // not a keyboard .xml file
     const k = new LdmlKeyboardCompiler(compilerTestCallbacks, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false });
     const source = k.load(filename);
     assert.notOk(source, `Trying to load(${filename})`);
   });
   it('should handle non existent test files', () => {
+    compilerTestCallbacks.messages = [];
     const filename = 'DOES_NOT_EXIST.xml';
     const k = new LdmlKeyboardCompiler(compilerTestCallbacks, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false });
     const source = k.loadTestData(filename);
     assert.notOk(source, `Trying to loadTestData(${filename})`);
   });
   it('should handle unparseable test files', () => {
+    compilerTestCallbacks.messages = [];
     const filename = makePathToFixture('basic-kvk.txt'); // not an .xml file
     const k = new LdmlKeyboardCompiler(compilerTestCallbacks, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false });
     const source = k.load(filename);
     assert.notOk(source, `Trying to loadTestData(${filename})`);
+  });
+  it('should fail on illegal chars', async function() {
+    compilerTestCallbacks.messages = [];
+    const inputFilename = makePathToFixture('sections/strs/invalid-illegal.xml');
+    const kmx = await compileKeyboard(inputFilename, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false },
+      [
+        // validation messages
+        CompilerMessages.Error_IllegalCharacters({ count: 5, lowestCh: 0xFDD0 }),
+        CompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
+      ],
+      true, // validation should fail
+      [
+        // compiler messages (not reached, we've already failed)
+      ]);
+    assert.isNull(kmx); // should fail post-validate
+  });
+  it('should hint on pua chars', async function() {
+    compilerTestCallbacks.messages = [];
+    const inputFilename = makePathToFixture('sections/strs/hint-pua.xml');
+    // Compile the keyboard
+    const kmx = await compileKeyboard(inputFilename, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false },
+      [
+        // validation messages
+        CompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
+      ],
+      false, // validation should pass
+      [
+        // same messages
+        CompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
+      ]);
+    assert.isNotNull(kmx);
+  });
+  it.skip('should warn on unassigned chars', async function() {
+    // unassigned not implemented yet
+    compilerTestCallbacks.messages = [];
+    const inputFilename = makePathToFixture('sections/strs/warn-unassigned.xml');
+    const kmx = await compileKeyboard(inputFilename, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false },
+      [
+        // validation messages
+        CompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
+        CompilerMessages.Warn_UnassignedCharacters({ count: 1, lowestCh: 0x0CFFFD }),
+      ],
+      false, // validation should pass
+      [
+        // same messages
+        CompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
+        CompilerMessages.Warn_UnassignedCharacters({ count: 1, lowestCh: 0x0CFFFD }),
+      ]);
+    assert.isNotNull(kmx);
   });
 });

--- a/developer/src/kmc-ldml/test/test-keymanweb-compiler.ts
+++ b/developer/src/kmc-ldml/test/test-keymanweb-compiler.ts
@@ -22,7 +22,7 @@ describe('LdmlKeyboardKeymanWebCompiler', function() {
     assert.isNotNull(source, 'k.load should not have returned null');
 
     // Sanity check ... this is also checked in other tests
-    const valid = k.validate(source);
+    const valid = await k.validate(source);
     checkMessages();
     assert.isTrue(valid, 'k.validate should not have failed');
 

--- a/developer/src/kmc-ldml/test/test-visual-keyboard-compiler-e2e.ts
+++ b/developer/src/kmc-ldml/test/test-visual-keyboard-compiler-e2e.ts
@@ -15,7 +15,7 @@ describe('visual-keyboard-compiler', function() {
     const binaryFilename = makePathToFixture('basic-kvk.txt');
 
     // Compile the visual keyboard
-    const vk = compileVisualKeyboard(inputFilename, {...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false});
+    const vk = await compileVisualKeyboard(inputFilename, {...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false});
     assert.isNotNull(vk);
 
     // Use the builder to generate the binary output file


### PR DESCRIPTION
- error if illegal unicode chars are used, hint if PUA is used

- also fix an issue where kmc validate() wasn't async
- also, add scaffolding where there's a post

Note, _unassigned_ chars not implemented yet. Might vector to ICU for that? (Could include the Unicode version when it reports.) 

For: #9446

@keymanapp-test-bot skip