### PR TITLE
fix(web): app/webview did not clear deadkeys on context-reset

### DIFF
--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -570,6 +570,9 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
 
   resetContext(target?: OutputTarget) {
     this.layerId = 'default';
+
+    // Make sure all deadkeys for the context get cleared properly.
+    target?.resetContext();
     this.keyboardInterface.resetContextCache();
 
     // May be null if it's a keyboard swap.

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -202,6 +202,8 @@ export default class KeymanEngine<
 
     this.contextManager.configure({
       resetContext: (target) => {
+        // Could reset the target's deadkeys here, but it's really more of a 'core' task.
+        // So we delegate that to keyboard-processor.
         this.core.resetContext(target);
       },
       predictionContext: new PredictionContext(this.core.languageProcessor, this.core.keyboardProcessor),


### PR DESCRIPTION
Discovered during user-test development for #9973:  our mobile app context-reset commands were not erasing deadkeys from the context.  This likely was a missed "loose thread" that arose from ES-modularization work.

@keymanapp-test-bot skip

User test TEST_APP_10_KEY_DIACRITICS  from #9973 covers this sufficiently; this change has been 🍒-picked for `master` from that `feature-gestures` PR.