### PR TITLE
chore(windows): remove `wm_keymandebug` messages and functions

### DIFF
--- a/windows/src/engine/keyman32/appint/aiTIP.h
+++ b/windows/src/engine/keyman32/appint/aiTIP.h
@@ -35,29 +35,10 @@
 // This can be customised with HKLM\Software\Keyman\Keyman Engine\zap virtual key code
 #define _VK_PREFIX_DEFAULT    0x0E
 
-struct AIDEBUGKEYINFO
-{
-	UINT VirtualKey;
-	DWORD shiftFlags;
-	WCHAR Character, DeadKeyCharacter;
-	BOOL IsUp;
-};
-
 class AITIP : public AIWin2000Unicode
 {
 private:
-	int WM_KEYMANDEBUG_CANDEBUG,
-		WM_KEYMANDEBUG_GETUNICODESTATUS,
-		WM_KEYMANDEBUG_GETCONTEXT,
-		WM_KEYMANDEBUG_ACTION,
-		WM_KEYMANDEBUG_RULEMATCH;
-
-	BOOL FIsDebugControlWindow;
-	HWND GetDebugControlWindow();
-	void Debug_FillContextBuffer();
   void MergeContextWithCache(PWSTR buf, AppContext *context);   // I4262
-
-	static BOOL IsDebugControlWindow(HWND hwnd);
 
 private:
   BOOL useLegacy;
@@ -68,8 +49,6 @@ private:
 public:
 	AITIP();
 	~AITIP();
-
-  BOOL DebugControlled();
 
   /**
    * Copy the member context
@@ -85,13 +64,9 @@ public:
    */
   void RestoreContextOnly(AppContext *savedContext);
 
-	virtual BOOL QueueAction(int ItemType, DWORD dwData);
-
 	/* Information functions */
 
 	virtual BOOL CanHandleWindow(HWND ahwnd);
-	virtual BOOL IsWindowHandled(HWND ahwnd);
-	virtual BOOL HandleWindow(HWND ahwnd);
 	virtual BOOL IsUnicode();
 
 	/* Context functions */

--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -263,12 +263,10 @@ typedef struct tagKEYMAN64THREADDATA
 
 extern UINT
   wm_keyman,						// user message - ignore msg
-  wm_kmdebug,						//  " "  "  "   - debugging
   wm_keyman_control,				// messages to main Keyman window - replaces WM_USER+*
   wm_keyman_control_internal,       // messages to all windows to notify of changes to Keyman   // I4412
   wm_keymankeydown,
   wm_keymankeyup,
-  wm_keymandebug,
   wm_keyman_grabwindowproc,
   wm_keyman_refresh,
   wm_kmgetactivekeymanid,

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -72,7 +72,6 @@
 UINT
   //TODO: consolidate these messages -- they are probably not all required now
   wm_keyman = 0,						// user message - ignore msg   // I3594
-	wm_kmdebug = 0,						//  " "  "  "   - debugging
 
 	wm_keymankeydown = 0,
 	wm_keymankeyup = 0,

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -266,11 +266,6 @@ LRESULT _kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
 		SendDebugMessageFormat(0, sdmInternat, 0, "GetMessage: wm_keymanshift %x %x", mp->wParam, mp->lParam);
     SelectApplicationIntegration();
 		if(!_td->app->IsWindowHandled(mp->hwnd)) _td->app->HandleWindow(mp->hwnd);
-		if(_td->app->DebugControlled())
-		{
-			if(mp->wParam == 1) *Globals::ShiftState() = (DWORD) mp->lParam;
-			else *Globals::ShiftState() = 0;
-		}
 		return CallNextHookEx(Globals::get_hhookGetMessage(), nCode, wParam, lParam);
 	}
 

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -138,16 +138,7 @@ BOOL ProcessHook()
   if(!_td) return FALSE;
 
   fOutputKeystroke = FALSE;  // TODO: 5442 no longer needs to be global once we use core processor
-  //
-  // If we are running in the debugger, don't do a second run through
-  //
 
-  if(_td->app->DebugControlled() && !_td->TIPFUpdateable) {   // I4287
-    if(_td->state.vkey == VK_ESCAPE || (_td->state.vkey >= VK_PRIOR && _td->state.vkey <= VK_DOWN) || (_td->state.vkey == VK_DELETE)) return FALSE;   // I4033   // I4826   // I4845
-    else return TRUE;
-  }
-
-	//app->NoSetShift = FALSE;
   _td->app->ReadContext();
 
 	if(_td->state.msg.message == wm_keymankeydown) {   // I4827
@@ -214,17 +205,6 @@ BOOL ProcessHook()
       //
       fOutputKeystroke = FALSE;
     }
-  }
-
-  if (fOutputKeystroke && _td->app->DebugControlled()) {
-		// The debug memo does not receive default key events because
-		// we capture them all here. So we synthesize the key event for
-		// the debugger.
-    _td->app->QueueAction(QIT_VSHIFTDOWN, Globals::get_ShiftState());
-    _td->app->QueueAction(QIT_VKEYDOWN, _td->state.vkey);
-    _td->app->QueueAction(QIT_VKEYUP, _td->state.vkey);
-    _td->app->QueueAction(QIT_VSHIFTUP, Globals::get_ShiftState());
-    fOutputKeystroke = FALSE;
   }
 
 	if(*Globals::hwndIM() == 0 || *Globals::hwndIMAlways())


### PR DESCRIPTION
Fixes #10050.

Removes the following unused identifiers:
* `::wm_kmdebug`
* `::wm_keymandebug`
* `AppInt::DebugControlled()`
* `AITIP::WM_KEYMANDEBUG_CANDEBUG`
* `AITIP::WM_KEYMANDEBUG_GETUNICODESTATUS`
* `AITIP::WM_KEYMANDEBUG_GETCONTEXT`
* `AITIP::WM_KEYMANDEBUG_ACTION`
* `AITIP::WM_KEYMANDEBUG_RULEMATCH`
* `AITIP::DebugControlled()`
* `AITIP::IsDebugControlWindow()`
* `AITIP::GetDebugControlWindow()`
* `AITIP::Debug_FillContextBuffer()`
* `AIDEBUGINFO struct`
* `::FillStoreOffsets()`
* `AIDEBUGKEYINFO struct`

Removes overloads which are now no-ops:
* `AITIP::HandleWindow()`
* `AITIP::IsWindowHandled()`
* `AITIP::QueueAction()`

@keymanapp-test-bot skip