### PR TITLE
chore(windows): remove unused globals relating to old keyboard debugging

### DIFF
--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -54,10 +54,6 @@
 
 #include <evntprov.h>
 
-#define GLOBAL_ContextStackSize 80
-#define GLOBAL_MsgStackSize 80
-#define GLOBAL_MaxKeyboards 32
-
 #include "serialkeyeventclient.h"
 #include "SharedBuffers.h"
 
@@ -66,8 +62,6 @@
 class Globals
 {
 public:
-	//static INI *Ini();
-
 	static HHOOK *hhookGetMessage();
 	static HHOOK *hhookCallWndProc();
 
@@ -196,15 +190,8 @@ typedef struct tagKEYMAN64THREADDATA
   LPINTKEYBOARDINFO lpKeyboards;			// keyboard definitions
   LPINTKEYBOARDINFO lpActiveKeyboard;
 
-   // I3616
-  LPMSG msgbuf;						// Message buffer (alloc at runtime)
-
   int nKeyboards;						// nLoadedKeyboards
   int nLanguages;           // I1087 //TODO UNUSED
-
-  LPWORD IndexStack;
-  LPWSTR miniContext;
-  int miniContextIfLen;
 
   KMSTATE state;
 

--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -217,9 +217,6 @@ BOOL Globals_ProcessInitialised()
 
 #pragma data_seg(".SHARDATA")
 
-//static INI     // I3158   // I3524
-//    f_Ini = {0};								// KEYMAN.INI options
-
 static HHOOK
     f_hhookGetMessage = NULL,				// GETMESSAGE hook handle
     f_hhookCallWndProc = NULL;			// CALLWNDPROC hook handle
@@ -294,8 +291,6 @@ DWORD	//static
 	f_ShiftState = 0;
 
 HANDLE f_hLockMutex = 0;
-
-//INI   *Globals::Ini()                 { return &f_Ini;                }  // I3158   // I3524
 
 HHOOK *Globals::hhookGetMessage()     { return &f_hhookGetMessage;    }
 HHOOK *Globals::hhookCallWndProc()    { return &f_hhookCallWndProc;   }
@@ -427,11 +422,6 @@ BOOL Globals::ResetControllers()  // I3092
 
   f_MasterController = NULL;
   f_MaxControllerThreads = 0;
-  /*   I3158   // I3524
-  f_Ini.ContextStackSize = 0;
-  f_Ini.MaxKeyboards = 0;
-  f_Ini.MsgStackSize = 0;
-  */
   f_hhookCallWndProc = NULL;
   f_hhookGetMessage = NULL;
 #ifndef _WIN64

--- a/windows/src/engine/keyman32/keymanengine.h
+++ b/windows/src/engine/keyman32/keymanengine.h
@@ -92,13 +92,6 @@ typedef struct tagINTKEYBOARDINFO
   km_core_keyboard_imx* lpIMXList;
 } INTKEYBOARDINFO, * LPINTKEYBOARDINFO;
 
-typedef struct tagINI
-{
-  int MsgStackSize;
-  int MaxKeyboards;
-  int ContextStackSize;
-} INI;
-
 typedef struct tagKMSTATE
 {
   BOOL NoMatches;


### PR DESCRIPTION
Fixes #10056.

Removes:
* `Globals::miniContext`
* `Globals::miniContextIfLen`
* `Globals::indexStack`
* `Globals::msgbuf`
* `GLOBAL_ContextStackSize`
* `GLOBAL_MsgStackSize`
* `GLOBAL_MaxKeyboards`
* `INI` struct (and commented-out usage of this)

@keymanapp-test-bot skip