### PR TITLE
chore(core): remove vkey output from kmx processor

### DIFF
--- a/core/src/kmx/kmx_actions.cpp
+++ b/core/src/kmx/kmx_actions.cpp
@@ -35,9 +35,6 @@ KMX_BOOL KMX_Actions::QueueAction(int ItemType, KMX_DWORD dwData)
 
   switch(ItemType)
   {
-  case QIT_VKEYDOWN:
-    break;
-
   case QIT_DEADKEY:
     m_context->Add(UC_SENTINEL);
     m_context->Add(CODE_DEADKEY);

--- a/core/src/kmx/kmx_actions.h
+++ b/core/src/kmx/kmx_actions.h
@@ -20,10 +20,10 @@ typedef struct
 } KMX_Action;
 
 // QueueAction ItemTypes
-#define QIT_VKEYDOWN  0
-#define QIT_VKEYUP    1
-#define QIT_VSHIFTDOWN  2
-#define QIT_VSHIFTUP  3
+// QIT_VKEYDOWN    0  Not supported by Core, legacy Windows-only, see #10049
+// QIT_VKEYUP      1  Not supported by Core, legacy Windows-only, see #10049
+// QIT_VSHIFTDOWN  2  Not supported by Core, legacy Windows-only, see #10049
+// QIT_VSHIFTUP    3  Not supported by Core, legacy Windows-only, see #10049
 #define QIT_CHAR    4
 #define QIT_DEADKEY   5
 #define QIT_BELL    6
@@ -34,10 +34,6 @@ typedef struct
 #define QIT_EMIT_KEYSTROKE 11
 
 #define QIT_MAX     11
-
-#define QVK_EXTENDED 0x00010000 // Flag for QIT_VKEYDOWN to indicate an extended key
-#define QVK_KEYMASK  0x0000FFFF
-#define QVK_FLAGMASK 0xFFFF0000
 
 class KMX_Actions
 {

--- a/core/src/kmx/kmx_processevent.cpp
+++ b/core/src/kmx/kmx_processevent.cpp
@@ -434,7 +434,7 @@ int KMX_ProcessEvent::PostString(PKMX_WCHAR str, LPKEYBOARD lpkb, PKMX_WCHAR end
   PKMX_WCHAR p, q, temp;
   LPSTORE s;
   int n1, n2;
-  int i, n, shift;
+  int i, n;
   KMX_BOOL FoundUse = FALSE;
   // TODO: Refactor to use incxstr
   for(p = str; *p && (p < endstr || !endstr); p++)
@@ -443,21 +443,9 @@ int KMX_ProcessEvent::PostString(PKMX_WCHAR str, LPKEYBOARD lpkb, PKMX_WCHAR end
      switch(*(++p))
      {
       case CODE_EXTENDED:       // Start of a virtual key section w/shift codes
-        p++;
-
-        shift = *p; //(*p<<8) | *(p+1);
-        m_actions.QueueAction(QIT_VSHIFTDOWN, shift);
-
-        p++;
-
-        m_actions.QueueAction(QIT_VKEYDOWN, *p);
-        m_actions.QueueAction(QIT_VKEYUP, *p);
-
-        m_actions.QueueAction(QIT_VSHIFTUP, shift);
-
+        p++; // modifier
+        p++; // vkey
         p++; // CODE_EXTENDEDEND
-        ////// CODE_EXTENDEDEND will be incremented by loop
-
         break;
 
       case CODE_DEADKEY:        // A deadkey to be output

--- a/core/src/kmx/kmx_processevent.cpp
+++ b/core/src/kmx/kmx_processevent.cpp
@@ -443,6 +443,7 @@ int KMX_ProcessEvent::PostString(PKMX_WCHAR str, LPKEYBOARD lpkb, PKMX_WCHAR end
      switch(*(++p))
      {
       case CODE_EXTENDED:       // Start of a virtual key section w/shift codes
+        // virtual keys in output are not supported
         p++; // modifier
         p++; // vkey
         p++; // CODE_EXTENDEDEND

--- a/core/src/kmx/kmx_processor.cpp
+++ b/core/src/kmx/kmx_processor.cpp
@@ -205,12 +205,6 @@ kmx_processor::internal_process_queued_actions(km_core_state *state) {
     case QIT_EMIT_KEYSTROKE:
       state->actions().push_emit_keystroke();
       break;
-    case QIT_VKEYDOWN:
-    case QIT_VKEYUP:
-    case QIT_VSHIFTDOWN:
-    case QIT_VSHIFTUP:
-      // TODO: eliminate??
-      break;
     case QIT_CHAR:
       state->context().push_character(a.dwData);
       state->actions().push_character(a.dwData);


### PR DESCRIPTION
Fixes #10049.

vkey output was never supported by Core, so this code effectively was a no-op.

@keymanapp-test-bot skip