### PR TITLE
fix(android): no suggestions available when swapping pred-text target language ✨

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -149,7 +149,9 @@ function onStateChange(change) {
   keyman.refreshOskLayout();
 
   fragmentToggle = (fragmentToggle + 1) % 100;
-  window.location.hash = 'refreshBannerHeight-'+fragmentToggle;
+  if(change != 'configured') {
+    window.location.hash = 'refreshBannerHeight-'+fragmentToggle;
+  }
 }
 
 // Query KMW if a given keyboard uses chiral modifiers.

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -102,7 +102,7 @@ function setBannerHeight(h) {
 
     if (keyman.osk) {
       keyman.osk.bannerView.activeBannerHeight = bannerHeight;
-    }  
+    }
   }
 
   // Refresh KMW's OSK
@@ -149,9 +149,7 @@ function onStateChange(change) {
   keyman.refreshOskLayout();
 
   fragmentToggle = (fragmentToggle + 1) % 100;
-  if(change != 'configured') { // doesn't change the display; only initiates suggestions.
-    window.location.hash = 'refreshBannerHeight-'+fragmentToggle+'+change='+change;
-  }
+  window.location.hash = 'refreshBannerHeight-'+fragmentToggle;
 }
 
 // Query KMW if a given keyboard uses chiral modifiers.

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
@@ -164,16 +164,13 @@ public final class KMKeyboardWebViewClient extends WebViewClient {
       // for the rest of the lifetime of this keyboard instance.
       kmKeyboard.setShouldShowHelpBubble(false);
     } else if (url.indexOf("refreshBannerHeight") >= 0) {
-      int start = url.indexOf("change=") + 7;
-      String change = url.substring(start);
-      boolean isModelActive = change.equals("active");
       // appContext instead of context?
       SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
       boolean modelPredictionPref = false;
       if (KMManager.currentLexicalModel != null) {
         modelPredictionPref = prefs.getBoolean(KMManager.getLanguagePredictionPreferenceKey(KMManager.currentLexicalModel.get(KMManager.KMKey_LanguageID)), true);
       }
-      KMManager.setBannerOptions(isModelActive && modelPredictionPref);
+      KMManager.setBannerOptions(modelPredictionPref);
       RelativeLayout.LayoutParams params = KMManager.getKeyboardLayoutParams();
       kmKeyboard.setLayoutParams(params);
     } else if (url.indexOf("suggestPopup") >= 0) {

--- a/common/web/input-processor/src/text/prediction/languageProcessor.ts
+++ b/common/web/input-processor/src/text/prediction/languageProcessor.ts
@@ -127,8 +127,10 @@ export default class LanguageProcessor extends EventEmitter<LanguageProcessorEve
 
     return this.lmEngine.loadModel(source, specType).then((config: Configuration) => {
       this.configuration = config;
-      this._state = 'configured';
-      this.emit('statechange', 'configured');
+      if(this.mayPredict) {
+        this._state = 'configured';
+        this.emit('statechange', 'configured');
+      }
     }).catch((error) => {
       // Does this provide enough logging information?
       let message: string;


### PR DESCRIPTION
Addresses the issue documented here: https://github.com/keymanapp/keyman/pull/10017#issuecomment-1823764995

The net effect of that issue is that suggestions would appear to be disabled upon swapping to a language with an different 'dictionary' from the most recently-used one.

The full documentation of the underlying cause can be found in that linked comment, but the essence of it is that the banner can't display any suggestions because it's _constantly being deactivated and reactivated_.  This is also generally considered "not good" for performance and device batteries.

## User Testing

TEST_PICKER_SELECTION_ANDROID:  Ensure suggestions are properly displayed after swapping keyboards with different language models.

1. Install the Android Keyman app test build from this PR.
2. Open Keyman App.
3. Install **Khmer Angkor** and Tamil Keyboards using Settings / Install Keyboard or Dictionary / Install from keyman.com option.
    - The break & bug - occurs when swapping models.
4. Verify all the Keyboards are installed under Installed languages menu. 
5. Return to main page. 
6. Verify that the default keyboard English -EuroLatin(SIL) is displayed on the page.
7. Short-press the globe key and observe the keyboard change.  There should be minimal adjustment while the keyboard loads.
8. Now, long press the globe key, Click Khmer or Tamil Keyboard and observe the keyboard change.  It should change as smoothly as it did after the globe-key short-press (step 7).
    - If suggestions for the suggestion banner do not appear after a second, type a single key.  If no suggestions appear even then, FAIL the test.

TEST_PICKER_SELECTION_IOS:  Ensure suggestions are properly displayed after swapping keyboards with different language models.

1. Install the iOS Keyman app test build from this PR.
2. Open Keyman App.
3. Install **Khmer Angkor** and Tamil Keyboards using Settings / Install Keyboard or Dictionary / Install from keyman.com option.
    - The break & bug - occurs when swapping models.
4. Verify all the Keyboards are installed under Installed languages menu. 
5. Return to main page. 
6. Verify that the default keyboard English -EuroLatin(SIL) is displayed on the page.
7. Short-press the globe key and observe the keyboard change.  There should be minimal adjustment while the keyboard loads.
8. Now, long press the globe key, Click Khmer or Tamil Keyboard and observe the keyboard change.  It should change as smoothly as it did after the globe-key short-press (step 7).
    - If suggestions for the suggestion banner do not appear after a second, type a single key.  If no suggestions appear even then, FAIL the test.