### PR TITLE
feat(developer): warn on usage of virtual keys in rule output

### DIFF
--- a/developer/src/common/include/kmn_compiler_errors.h
+++ b/developer/src/common/include/kmn_compiler_errors.h
@@ -240,6 +240,8 @@
 
 #define CHINT_UnreachableRule                              0x000010AE
 
+#define CWARN_VirtualKeyInOutput                           0x000020AF
+
 #define CERR_BufferOverflow                                0x000080C0
 #define CERR_Break                                         0x000080C1
 

--- a/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
@@ -302,6 +302,8 @@ export class KmnCompilerMessages {
 
   static HINT_UnreachableRule                                 = SevHint | 0x0AE;
 
+  static WARN_VirtualKeyInOutput                              = SevWarn | 0x0AF;
+
   static FATAL_BufferOverflow                                 = SevFatal | 0x0C0;
   static FATAL_Break                                          = SevFatal | 0x0C1;
 };

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/warn_virtual_key_in_output.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/warn_virtual_key_in_output.kmn
@@ -1,0 +1,9 @@
+store(&NAME) 'WARN_VirtualKeyInOutput'
+store(&VERSION) '9.0'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+c WARN_VirtualKeyInOutput
++ 'a' > [K_BKQUOTE]

--- a/developer/src/kmc-kmn/test/test-messages.ts
+++ b/developer/src/kmc-kmn/test/test-messages.ts
@@ -87,4 +87,11 @@ describe('CompilerMessages', function () {
     assert.equal(callbacks.messages[0].message, "Statement 'return' is not currently supported in output for web and touch targets");
   });
 
+  // WARN_VirtualKeyInOutput
+
+  it('should generate WARN_VirtualKeyInOutput if a virtual key is found in the output part of a rule', async function() {
+    await testForMessage(this, ['invalid-keyboards', 'warn_virtual_key_in_output.kmn'], KmnCompilerMessages.WARN_VirtualKeyInOutput);
+    assert.equal(callbacks.messages[0].message, "Virtual keys are not supported in output");
+  });
+
 });

--- a/developer/src/kmcmplib/src/CompMsg.cpp
+++ b/developer/src/kmcmplib/src/CompMsg.cpp
@@ -143,6 +143,7 @@ const struct CompilerError CompilerErrors[] = {
     { CWARN_NulNotFirstStatementInContext                , "nul must be the first statement in the context"},
     { CWARN_IfShouldBeAtStartOfContext                   , "if, platform and baselayout should be at start of context (after nul, if present)"},
     { CWARN_KeyShouldIncludeNCaps                        , "Other rules which reference this key include CAPS or NCAPS modifiers, so this rule must include NCAPS modifier to avoid inconsistent matches"},
+    { CWARN_VirtualKeyInOutput                           , "Virtual keys are not supported in output"},
 
     { 0, nullptr }
   };


### PR DESCRIPTION
Fixes #10059.

Use of the unsupported and undocumented virtual key output, that doesn't work in recent Keyman versions, at all, now results in a build warning.

Only a warning, because it did kinda work in old versions of Keyman.

Sample output:

```
$ ./build.sh --compiler /c/Projects/keyman/app/developer/src/kmc/build/src/kmc.js build -k release/g/gandhari/
...
gandhari.kmn:118 - warn KM020AF: Virtual keys are not supported in output
...
```

@keymanapp-test-bot skip