### PR TITLE
fix(core): memory management of options in action struct

### DIFF
--- a/core/src/action.cpp
+++ b/core/src/action.cpp
@@ -95,13 +95,15 @@ km_core_actions * km::core::action_item_list_to_actions_object(
         output.push_back({KM_CORE_CT_MARKER,{0},{action_items->marker}});
         break;
       case KM_CORE_IT_PERSIST_OPT:
+      {
         // TODO: lowpri: replace existing item if already present in options vector?
-        options.push_back(km::core::option(
-          static_cast<km_core_option_scope>(action_items->option->scope),
+        km::core::option opt(static_cast<km_core_option_scope>(action_items->option->scope),
           action_items->option->key,
           action_items->option->value
-        ));
+        );
+        options.push_back(opt.release()); // hand over memory management of the option item to the action struct
         break;
+      }
       default:
         assert(false);
     }

--- a/core/src/option.cpp
+++ b/core/src/option.cpp
@@ -43,6 +43,14 @@ option::option(km_core_option_scope s, char16_t const *k, char16_t const *v)
   }
 }
 
+km_core_option_item
+option::release() {
+  km_core_option_item opt = *this;
+  key = nullptr;
+  value = nullptr;
+  return opt;
+}
+
 // TODO: Relocate this and fix it
 json & km::core::operator << (json &j, abstract_processor const &)
 {

--- a/core/src/option.hpp
+++ b/core/src/option.hpp
@@ -34,9 +34,14 @@ namespace core
     option & operator=(option const & rhs);
     option & operator=(option && rhs);
 
+    /**
+     * Returns contents of this object as a C struct, releasing memory
+     * management of key and value, and invalidates this object.
+     */
+    km_core_option_item release();
+
     bool empty() const;
   };
-
 
   inline
   option::option(km_core_option_scope s,

--- a/core/tests/unit/kmnkbd/action_api.cpp
+++ b/core/tests/unit/kmnkbd/action_api.cpp
@@ -374,6 +374,7 @@ int main(int argc, char *argv []) {
   test_alert();
   test_emit_keystroke();
   test_invalidate_context();
+  test_persist_opt();
 
   // context -- todo move to another file
   test_context_set_if_needed();


### PR DESCRIPTION
Fixes #10067.

Management of memory for persisted options was wrong in the action struct, as the members key and value would be freed immediately after being added to the temporary vector (because the vector was of the struct rather than of the class).

Given the struct is a C struct, we need the memory management to be explicit, so we now release() each option into the vector as we create it, which means that its member values will not be freed when the option is then immediately deleted. (This allows us to use the initial copy of the members of option that option() constructor does.)

Added the release() function as that was a relatively clear way of indicating that the contents of the structure are now owned by the caller, following the pattern from std::unique_ptr.

Finally, the unit test for persisted options was in the action_api.cpp test module, but it was never called, so this was not being tested. Now it is.

@keymanapp-test-bot skip