### PR TITLE
fix(android/app) Disable in-app Browser 🏠

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -434,9 +434,10 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
       case R.id.action_share:
         showShareDialog();
         return true;
+      /* Disable Web Browser to investigate Google sign-in
       case R.id.action_web:
         showWebBrowser();
-        return true;
+        return true;*/
       case R.id.action_text_size:
         showTextSizeDialog();
         return true;

--- a/android/KMAPro/kMAPro/src/main/res/menu-land/main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu-land/main.xml
@@ -8,12 +8,13 @@
         app:showAsAction="always"
         android:title="@string/action_share"
         android:icon="@drawable/ic_light_action_share" />
-    
-    <item
+
+  <!-- Disable Web Browser to investigate Google sign-in -->
+  <!--item
         android:id="@+id/action_web"
         app:showAsAction="always"
         android:title="@string/action_web"
-        android:icon="@drawable/ic_light_action_web" />
+        android:icon="@drawable/ic_light_action_web" /> -->
 
     <item
         android:id="@+id/action_text_size"

--- a/android/KMAPro/kMAPro/src/main/res/menu-sw600dp/main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu-sw600dp/main.xml
@@ -8,12 +8,13 @@
         app:showAsAction="always"
         android:title="@string/action_share"
         android:icon="@drawable/ic_light_action_share" />
-    
-    <item
+
+    <!-- Disable Web Browser to investigate Google sign-in -->
+    <!--item
         android:id="@+id/action_web"
         app:showAsAction="always"
         android:title="@string/action_web"
-        android:icon="@drawable/ic_light_action_web" />
+        android:icon="@drawable/ic_light_action_web" /-->
 
     <item
         android:id="@+id/action_text_size"

--- a/android/KMAPro/kMAPro/src/main/res/menu/main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/menu/main.xml
@@ -8,12 +8,13 @@
         app:showAsAction="always"
         android:title="@string/action_share"
         android:icon="@drawable/ic_light_action_share" />
-    
-    <item
+
+    <!-- Disable Web Browser to investigate Google sign-in -->
+    <!--item
         android:id="@+id/action_web"
         app:showAsAction="always"
         android:title="@string/action_web"
-        android:icon="@drawable/ic_light_action_web" />
+        android:icon="@drawable/ic_light_action_web" /> -->
 
     <!-- Set showAsAction="never" for overflow -->
     <item

--- a/android/help/about/whatsnew.md
+++ b/android/help/about/whatsnew.md
@@ -3,7 +3,4 @@ title: What's New
 ---
 Here are some of the new features and major bug fixes we have added to Keyman 16.0 for Android:
 
-* Dismiss long-press keys on multi-touch (#7388, #7472)
-* Don't show "Get Started" after setting Keyman as default system keyboard (#7587)
-* Add option for haptic feedback (#6626)
-* Add localization for Dutch
+* Disable in-app browser to comply with Play Store Data-safety policy (#10077)


### PR DESCRIPTION
@ermshiperete noticed 16.0 updates on the Play Store haven't happened since Jan 2023.

Re-implements #8428 to disable access to the the in-app browser (Keeps the Keyman app account agnostic)
At the time, we  held off on merging #8428 into 16.0 (it's merged in 17.0)

## User Testing
**Setup** 
Install the PR build of Keyman for Android 

* **TEST_BROWSER_DISABLED** - Verifies Keyman browser can't be accessed
1. Launch Keyman for Android in portrait orientation
2. Observe the menu icons and verify the browser icon is not visible
![](https://help.keyman.com/products/android/16.0/android_images/browser-a.png)
3. Rotate the device to landscape orientation
4. Observe the menu icons and verify the browser icon is not visible

