### PR TITLE
fix(web): Fix attachment-api tests

### DIFF
--- a/web/src/test/manual/web/attachment-api/utilities.js
+++ b/web/src/test/manual/web/attachment-api/utilities.js
@@ -1,6 +1,7 @@
 // Page-global variable definitions.
 {
 var inputCounter = 0;
+var kmw = keyman;
 }
 
 function generateDiagnosticDiv(elem) {


### PR DESCRIPTION
This PR fixes an error thrown on the test page because it can't find `kmw`.

@keymanapp-test-bot skip