### PR TITLE
fix(web): Don't throw errors after detach

### DIFF
--- a/web/src/app/browser/src/hardwareEventKeyboard.ts
+++ b/web/src/app/browser/src/hardwareEventKeyboard.ts
@@ -267,7 +267,7 @@ export default class HardwareEventKeyboard extends HardKeyboard {
       }
     });
 
-    page.off('disabled', (Pelem) => {
+    page.on('disabled', (Pelem) => {
       const target = outputTargetForElement(Pelem);
 
       if(!(target instanceof DesignIFrame)) {

--- a/web/src/app/browser/src/hardwareEventKeyboard.ts
+++ b/web/src/app/browser/src/hardwareEventKeyboard.ts
@@ -335,7 +335,7 @@ export default class HardwareEventKeyboard extends HardKeyboard {
   _KeyUp: (e: KeyboardEvent) => boolean = (e) => {
     const target = eventOutputTarget(e);
     var Levent = preprocessKeyboardEvent(e, this.processor, this.hardDevice);
-    if(Levent == null) {
+    if(Levent == null || target == null) {
       return true;
     }
 

--- a/web/src/engine/attachment/src/outputTargetForElement.ts
+++ b/web/src/engine/attachment/src/outputTargetForElement.ts
@@ -40,11 +40,7 @@ export function outputTargetForElement(Ltarg: HTMLElement) {
     }
   }
 
-  if (Ltarg._kmwAttachment == null) {
-    return null;
-  }
-
   // Step 2:  With the most likely host element determined, obtain the corresponding OutputTarget
   // instance.
-  return Ltarg._kmwAttachment.interface;
+  return Ltarg._kmwAttachment?.interface;
 }

--- a/web/src/engine/attachment/src/outputTargetForElement.ts
+++ b/web/src/engine/attachment/src/outputTargetForElement.ts
@@ -40,6 +40,10 @@ export function outputTargetForElement(Ltarg: HTMLElement) {
     }
   }
 
+  if (Ltarg._kmwAttachment == null) {
+    return null;
+  }
+
   // Step 2:  With the most likely host element determined, obtain the corresponding OutputTarget
   // instance.
   return Ltarg._kmwAttachment.interface;


### PR DESCRIPTION
Fixes #10031.

# User Testing

## Preparations

**TEST_FIXED**: follow the repro instructions in #10031 to test if this is fixed. You can use the ["KeymanWeb Sample Page - Tests the new Attachment/Enablement API functionality"](https://build.palaso.org/repository/download/Keymanweb_TestPullRequests/426988:id/src/test/manual/web/attachment-api/index.html?mode=auto) (in manual mode) instead of the code listed in #10031.