### PR TITLE
chore(developer): require project file to exist 🦕

### DIFF
--- a/developer/src/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
@@ -201,20 +201,13 @@ var
 begin
   kpj := TProject.Create(ptKeyboard, GetProjectFilename);
   try
+    kpj.Options.Version := pv20;
     kpj.Options.BuildPath := '$PROJECTPATH\' + SFolder_Build;
+    kpj.Options.SourcePath := '$PROJECTPATH\' + SFolder_Source;
     kpj.Options.WarnDeprecatedCode := True;
     kpj.Options.CompilerWarningsAsErrors := True;
     kpj.Options.CheckFilenameConventions := True;
-
-    // Add keyboard and package to project
-    kpj.Files.Add(TkmnProjectFile.Create(kpj, GetKeyboardFilename, nil));
-    kpj.Files.Add(TkpsProjectFile.Create(kpj, GetPackageFilename, nil));
-
-    // Add metadata files to project
-    kpj.Files.Add(TOpenableProjectFile.Create(kpj, BasePath + ID + '\' + SFile_HistoryMD, nil));
-    kpj.Files.Add(TOpenableProjectFile.Create(kpj, BasePath + ID + '\' + SFile_LicenseMD, nil));
-    kpj.Files.Add(TOpenableProjectFile.Create(kpj, BasePath + ID + '\' + SFile_ReadmeMD, nil));
-
+    kpj.Options.SkipMetadataFiles := False;
     kpj.Save;
   finally
     kpj.Free;

--- a/developer/src/tike/actions/dmActionsMain.dfm
+++ b/developer/src/tike/actions/dmActionsMain.dfm
@@ -32,17 +32,6 @@ object modActionsMain: TmodActionsMain
       OnExecute = actViewCharacterIdentifierExecute
       OnUpdate = actViewCharacterIdentifierUpdate
     end
-    object actProjectOpenFolder: TBrowseForFolder
-      Category = 'Project'
-      Caption = 'Open Project Folder...'
-      DialogCaption = 'Open Project Folder'
-      BrowseOptions = []
-      BrowseOptionsEx = []
-      Hint = 'Open Project Folder|Opens an existing project folder'
-      ShortCut = 24655
-      UseFileDialog = True
-      OnAccept = actProjectOpenFolderAccept
-    end
     object actFileOpen: TFileOpen
       Category = 'File'
       Caption = '&Open...'
@@ -259,6 +248,7 @@ object modActionsMain: TmodActionsMain
       Dialog.Options = [ofHideReadOnly, ofPathMustExist, ofFileMustExist, ofEnableSizing]
       Hint = 'Open Project|Opens an existing project'
       ImageIndex = 28
+      ShortCut = 24655
       OnAccept = actProjectOpenAccept
     end
     object actProjectAddCurrentEditorFile: TAction

--- a/developer/src/tike/actions/dmActionsMain.pas
+++ b/developer/src/tike/actions/dmActionsMain.pas
@@ -138,7 +138,6 @@ type
     actToolsWebConfigure: TAction;
     actToolsWebStartServer: TAction;
     actToolsWebStopServer: TAction;
-    actProjectOpenFolder: TBrowseForFolder;
     procedure actFileNewExecute(Sender: TObject);
     procedure DataModuleCreate(Sender: TObject);
     procedure actFileOpenAccept(Sender: TObject);
@@ -238,7 +237,6 @@ type
     procedure actToolsWebStartServerUpdate(Sender: TObject);
     procedure actToolsWebStopServerExecute(Sender: TObject);
     procedure actToolsWebStopServerUpdate(Sender: TObject);
-    procedure actProjectOpenFolderAccept(Sender: TObject);
   private
     function CheckFilenameConventions(FileName: string): Boolean;
     function SaveAndCloseAllFiles: Boolean;
@@ -593,17 +591,10 @@ begin
   OpenProject(actProjectOpen.Dialog.FileName);
 end;
 
-procedure TmodActionsMain.actProjectOpenFolderAccept(Sender: TObject);
-begin
-  if not frmKeymanDeveloper.BeforeOpenProject then
-    Exit;
-  OpenProject(actProjectOpenFolder.Folder);
-end;
-
 procedure TmodActionsMain.OpenProject(FileName: WideString);
 begin
   FileName := ExpandUNCFileName(FileName);
-  if (FileName <> '') and not FileExists(FileName) and not DirectoryExists(FileName) then
+  if (FileName <> '') and not FileExists(FileName) then
   begin
     ShowMessage('The project '+FileName+' does not exist.');
     Exit;

--- a/developer/src/tike/main/UfrmMain.dfm
+++ b/developer/src/tike/main/UfrmMain.dfm
@@ -2935,9 +2935,6 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
       object OpenProject1: TMenuItem
         Action = modActionsMain.actProjectOpen
       end
-      object OpenProjectFolder1: TMenuItem
-        Action = modActionsMain.actProjectOpenFolder
-      end
       object CloseProject1: TMenuItem
         Action = modActionsMain.actProjectClose
       end

--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -314,7 +314,6 @@ type
     Stopserver1: TMenuItem;
     ToolButton13: TToolButton;
     ToolButton16: TToolButton;
-    OpenProjectFolder1: TMenuItem;
     procedure FormCreate(Sender: TObject);
     procedure FormShow(Sender: TObject);
     procedure mnuFileClick(Sender: TObject);

--- a/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFile.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFile.pas
@@ -845,9 +845,6 @@ begin
         then Result := LoadFromXML(FileName)
         else Result := ImportFromIni(FileName);
     end
-    else if DirectoryExists(ExtractFilePath(FileName)) then
-      // This will fall back to a 2.0 folder load
-      Result := LoadFromXML(FileName)
     else
     begin
       Result := False;

--- a/developer/src/tike/project/Keyman.Developer.System.Project.ProjectLoader.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.ProjectLoader.pas
@@ -48,7 +48,6 @@ type
     FFileName: string;
     FProject: TProject;
     procedure LoadUser;
-    procedure LoadDefaultProjectFromFolder;
     procedure LoadProjectFromFile;   // I4698
   public
     constructor Create(AProject: TProject; AFileName: string);
@@ -80,20 +79,8 @@ end;
 
 procedure TProjectLoader.Execute;   // I4698
 begin
-  if FileExists(FFileName) or (FFileName = '')
-    then LoadProjectFromFile
-    else LoadDefaultProjectFromFolder;
+  LoadProjectFromFile;
 end;
-
-procedure TProjectLoader.LoadDefaultProjectFromFolder;
-begin
-  FProject.Options.Assign(DefaultProjectOptions[pv20]);
-  if not FProject.PopulateFiles then
-    // TODO: This seems somewhat arbitrary and troublesome. Better to load the
-    //       folder and give warnings about file layout
-    raise EProjectLoader.Create('Not a Keyman Developer project folder');
-end;
-
 
 procedure TProjectLoader.LoadProjectFromFile;
 var

--- a/developer/src/tike/project/Keyman.Developer.System.Project.ProjectSaver.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.ProjectSaver.pas
@@ -86,13 +86,6 @@ var
   filenode, node, root: IXMLNode;
   defopts: TProjectOptionsRecord;
 begin
-  if FProject.IsDefaultProject(pv20) and (FFileName <> '') then
-  begin
-    if FileExists(FFileName) then
-      System.SysUtils.DeleteFile(FFileName);
-    Exit;
-  end;
-
   defopts := DefaultProjectOptions[FProject.Options.Version];
 
   doc := NewXMLDocument();

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProject.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProject.pas
@@ -349,8 +349,6 @@ begin
     modActionsMain.actProjectNew.Execute
   else if Command = 'openproject' then
     modActionsMain.actProjectOpen.Execute
-  else if Command = 'openprojectfolder' then
-    modActionsMain.actProjectOpenFolder.Execute
   else if Command = 'editfile' then // MRU
   begin
     if SelectedMRUFileName <> '' then

--- a/developer/src/tike/xml/project/globalwelcome.xsl
+++ b/developer/src/tike/xml/project/globalwelcome.xsl
@@ -57,10 +57,6 @@
                 <xsl:with-param name="caption">Open Existing Project...</xsl:with-param>
                 <xsl:with-param name="command">keyman:openproject</xsl:with-param>
               </xsl:call-template>
-              <xsl:call-template name="button">
-                <xsl:with-param name="caption">Open Existing Project Folder...</xsl:with-param>
-                <xsl:with-param name="command">keyman:openprojectfolder</xsl:with-param>
-              </xsl:call-template>
             </div>
           </div>
 


### PR DESCRIPTION
Reverts some of the version 2.0 project functionality, as there are a number of challenges around populating files for folders that don't have project definitions, particularly if user attempts to load a folder that is not a project folder after all but happens, e.g. to have a source folder in it.

Also: generate version 2.0 keyboard project

@keymanapp-test-bot skip