### PR TITLE
fix(core): set_if_needed updates an empty cached context

### DIFF
--- a/core/src/km_core_state_api.cpp
+++ b/core/src/km_core_state_api.cpp
@@ -262,6 +262,10 @@ void km_core_state_imx_deregister_callback(km_core_state *state)
 }
 
 bool is_context_valid(km_core_cp const * context, km_core_cp const * cached_context) {
+  if (context == nullptr || cached_context == nullptr || *cached_context == NULL) {
+      // If the cached_context is "empty" then it needs updating
+      return false;
+  }
   km_core_cp const* context_p = context;
   while(*context_p) {
     context_p++;

--- a/core/src/km_core_state_api.cpp
+++ b/core/src/km_core_state_api.cpp
@@ -263,8 +263,8 @@ void km_core_state_imx_deregister_callback(km_core_state *state)
 
 bool is_context_valid(km_core_cp const * context, km_core_cp const * cached_context) {
   if (context == nullptr || cached_context == nullptr || *cached_context == NULL) {
-      // If the cached_context is "empty" then it needs updating
-      return false;
+    // If the cached_context is "empty" then it needs updating
+    return false;
   }
   km_core_cp const* context_p = context;
   while(*context_p) {

--- a/core/tests/unit/kmnkbd/action_api.cpp
+++ b/core/tests/unit/kmnkbd/action_api.cpp
@@ -258,6 +258,27 @@ void test_context_set_if_needed_different_context() {
   teardown();
 }
 
+void test_context_set_if_needed_cached_context_cleared() {
+  km_core_cp const *application_context = u"This is a test";
+  km_core_cp const *cached_context =      u"";
+  setup("k_000___null_keyboard.kmx", cached_context);
+  km_core_state_context_clear(test_state);
+  assert(km_core_state_context_set_if_needed(test_state, application_context) == KM_CORE_CONTEXT_STATUS_UPDATED);
+  assert(!is_identical_context(cached_context));
+  assert(is_identical_context(application_context));
+  teardown();
+}
+
+void test_context_set_if_needed_application_context_empty() {
+  km_core_cp const *application_context = u"";
+  km_core_cp const *cached_context =      u"This is a test";
+  setup("k_000___null_keyboard.kmx", cached_context);
+  assert(km_core_state_context_set_if_needed(test_state, application_context) == KM_CORE_CONTEXT_STATUS_UPDATED);
+  assert(!is_identical_context(cached_context));
+  assert(is_identical_context(application_context));
+  teardown();
+}
+
 void test_context_set_if_needed_app_context_is_longer() {
   km_core_cp const *application_context = u"Longer This is a test";
   km_core_cp const *cached_context =             u"This is a test";
@@ -319,6 +340,8 @@ void test_context_set_if_needed_cached_context_has_markers() {
 void test_context_set_if_needed() {
   test_context_set_if_needed_identical_context();
   test_context_set_if_needed_different_context();
+  test_context_set_if_needed_cached_context_cleared();
+  test_context_set_if_needed_application_context_empty();
   test_context_set_if_needed_app_context_is_longer();
   test_context_set_if_needed_app_context_is_shorter();
   test_context_set_if_needed_cached_context_has_markers();


### PR DESCRIPTION
In the case where the cached context had been cleared the km_core_state_context_set_if_needed call would just compare the null terminations of both strings and not set the cached context to the application context.

I first thought I could just change the decrement of the pointers to occur before the iteration not after e.g.

``` 

for(; context_p > context && cached_context_p > cached_context; --context_p, --cached_context_p) {
    if(*context_p != *cached_context_p) {
      // The cached context doesn't match the application context, so it is
      // invalid
      return false;
    }
  }
```
  
This skips the comparing the null, however it will still also drop out and return true. It is just quicker to bail if the cached context is an "empty" string. 
I also considered renaming is_context_valid to is_context_update_needed.

@keymanapp-test-bot skip