### PR TITLE
feat(web): multitap key-previews 🐵

### DIFF
--- a/web/src/engine/osk/src/input/gestures/browser/keytip.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/keytip.ts
@@ -214,6 +214,12 @@ export default class KeyTip implements KeyTipInterface {
         this.preview = this.previewHost.element;
         this.tip.replaceChild(this.preview, oldHost);
         previewHost.setCancellationHandler(() => this.show(null, false, null));
+        previewHost.on('startFade', () => {
+          this.element.classList.remove('kmw-preview-fade');
+          // Note:  a reflow is needed to reset the transition animation.
+          this.element.offsetWidth;
+          this.element.classList.add('kmw-preview-fade');
+        });
       }
     } else { // Hide the key preview
       this.element.style.display = 'none';
@@ -222,6 +228,7 @@ export default class KeyTip implements KeyTipInterface {
       const oldPreview = this.preview;
       this.preview = document.createElement('div');
       this.tip.replaceChild(this.preview, oldPreview);
+      this.element.classList.remove('kmw-preview-fade');
 
       this.orientation = DEFAULT_TIP_ORIENTATION;
     }

--- a/web/src/engine/osk/src/input/gestures/browser/multitap.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/multitap.ts
@@ -56,6 +56,12 @@ export default class Multitap implements GestureHandler {
 
     this.originalLayer = vkbd.layerId;
 
+    const tapLookahead = (offset) => (this.tapIndex + offset) % this.multitaps.length;
+
+    const updatePreview = () => {
+      previewHost?.setMultitapHint(this.multitaps[tapLookahead(0)].text, this.multitaps[tapLookahead(1)].text);
+    }
+
     source.on('complete', () => {
       this.modipress?.cancel();
       this.clear();
@@ -90,11 +96,9 @@ export default class Multitap implements GestureHandler {
       }
 
       // For rota-style behavior
-      this.tapIndex = (this.tapIndex + 1) % this.multitaps.length;
+      this.tapIndex = tapLookahead(1);
       const selection = this.multitaps[this.tapIndex];
-      const nextSel = (this.tapIndex == this.multitaps.length - 1) ? this.multitaps[0] : this.multitaps[this.tapIndex+1];
-
-      previewHost?.setMultitapHint(selection.text, nextSel.text);
+      updatePreview();
 
       const keyEvent = vkbd.keyEventFromSpec(selection);
       keyEvent.baseTranscriptionToken = this.baseContextToken;
@@ -139,7 +143,7 @@ export default class Multitap implements GestureHandler {
 
     // For this specific instance, we'll go ahead and directly maintain the preview;
     // a touch just ended, and all other updates occur on the start of a new touch.
-    previewHost?.setMultitapHint(this.multitaps[0].text, this.multitaps[1].text);
+    updatePreview();
 
     /* In theory, setting up a specialized recognizer config limited to the base key's surface area
      * would be pretty ideal - it'd provide automatic cancellation if anywhere else were touched.

--- a/web/src/engine/osk/src/input/gestures/browser/tabletPreview.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/tabletPreview.ts
@@ -96,6 +96,12 @@ export class TabletKeyTip implements KeyTipInterface {
         this.preview = this.previewHost.element;
         this.element.replaceChild(this.preview, oldHost);
         previewHost.setCancellationHandler(() => this.show(null, false, null));
+        previewHost.on('startFade', () => {
+          this.element.classList.remove('kmw-preview-fade');
+          // Note:  a reflow is needed to reset the transition animation.
+          this.element.offsetWidth;
+          this.element.classList.add('kmw-preview-fade');
+        });
       }
     } else { // Hide the key preview
       this.element.style.display = 'none';
@@ -105,6 +111,7 @@ export class TabletKeyTip implements KeyTipInterface {
       const oldPreview = this.preview;
       this.preview = document.createElement('div');
       this.element.replaceChild(this.preview, oldPreview);
+      this.element.classList.remove('kmw-preview-fade');
     }
 
     // Save the key preview state

--- a/web/src/engine/osk/src/keyboard-layout/gesturePreviewHost.ts
+++ b/web/src/engine/osk/src/keyboard-layout/gesturePreviewHost.ts
@@ -1,4 +1,4 @@
-import { ActiveKey } from "@keymanapp/keyboard-processor";
+import { ActiveKey, ActiveKeyBase } from "@keymanapp/keyboard-processor";
 import EventEmitter from "eventemitter3";
 
 import { KeyElement } from "../keyElement.js";
@@ -135,6 +135,13 @@ export class GesturePreviewHost extends EventEmitter<EventMap> {
 
   public setCancellationHandler(handler: () => void) {
     this.onCancel = handler;
+  }
+
+  public setMultitapHint(current: string, next: string) {
+    this.label.textContent = current;
+    this.hintLabel.textContent = next;
+
+    this.clearFlick();
   }
 
   public scrollFlickPreview(x: number, y: number) {

--- a/web/src/engine/osk/src/keyboard-layout/gesturePreviewHost.ts
+++ b/web/src/engine/osk/src/keyboard-layout/gesturePreviewHost.ts
@@ -14,6 +14,7 @@ const FLICK_OVERFLOW_OFFSET = 1.4142;
 
 interface EventMap {
   preferredOrientation: (orientation: PhoneKeyTipOrientation) => void;
+  startFade: () => void;
 }
 
 export class GesturePreviewHost extends EventEmitter<EventMap> {
@@ -140,6 +141,8 @@ export class GesturePreviewHost extends EventEmitter<EventMap> {
   public setMultitapHint(current: string, next: string) {
     this.label.textContent = current;
     this.hintLabel.textContent = next;
+
+    this.emit('startFade');
 
     this.clearFlick();
   }

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -636,7 +636,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
           trackingEntry.previewHost = null;
 
           gestureSequence.on('complete', () => {
-            existingPreviewHost.cancel();
+            existingPreviewHost?.cancel();
             this.gesturePreviewHost = null;
           })
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -429,6 +429,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
 
       const endHighlighting = () => {
         // The base call will occur before our "is this a multitap?" check otherwise.
+        // That check will unset the field so that it's unaffected by this check.
         timedPromise(0).then(() => {
           const previewHost = trackingEntry.previewHost;
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -428,17 +428,22 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       }
 
       const endHighlighting = () => {
-        trackingEntry.previewHost?.cancel();
-        // If we ever allow concurrent previews, check if it exists and matches
-        // a VisualKeyboard-tracked entry; if so, clear that too.
-        if(previewHost) {
-          this.gesturePreviewHost = null;
-          trackingEntry.previewHost = null;
-        }
-        if(trackingEntry.key) {
-          this.highlightKey(trackingEntry.key, false);
-          trackingEntry.key = null;
-        }
+        // The base call will occur before our "is this a multitap?" check otherwise.
+        timedPromise(0).then(() => {
+          const previewHost = trackingEntry.previewHost;
+
+          // If we ever allow concurrent previews, check if it exists and matches
+          // a VisualKeyboard-tracked entry; if so, clear that too.
+          if(previewHost) {
+            previewHost.cancel();
+            this.gesturePreviewHost = null;
+            trackingEntry.previewHost = null;
+          }
+          if(trackingEntry.key) {
+            this.highlightKey(trackingEntry.key, false);
+            trackingEntry.key = null;
+          }
+        })
       }
 
       // Fix:  if flicks enabled, no roaming.
@@ -510,6 +515,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
           existingPreviewHost.clearFlick();
         }
 
+        let trackingEntry: typeof sourceTrackingMap[string];
         // Disable roaming-touch highlighting (and current highlighting) for all
         // touchpoints included in a gesture, even newly-included ones as they occur.
         for(let id of gestureStage.allSourceIds) {
@@ -522,7 +528,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
             trackingEntry.source.path.off('step', trackingEntry.roamingHighlightHandler);
           }
 
-          const trackingEntry = sourceTrackingMap[id];
+          trackingEntry = sourceTrackingMap[id];
 
           if(trackingEntry) {
             clearRoaming(trackingEntry);
@@ -625,12 +631,16 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
           // baseItem is sometimes null during a keyboard-swap... for app/browser touch-based language menus.
           // not ideal, but it is what it is; just let it pass by for now.
         } else if(baseItem?.key.spec.multitap && (gestureStage.matchedId == 'initial-tap' || gestureStage.matchedId == 'multitap' || gestureStage.matchedId == 'modipress-start')) {
-          // For now, but worth changing later!
-          // Idea:  if the preview weren't hosted by the key, but instead had a key-lookalike overlay.
-          // Then it would float above any layer, even after layer swaps.
-          existingPreviewHost?.cancel();
-          // Likewise - mere construction is enough.
-          handlers = [new Multitap(gestureSequence, this, baseItem, keyResult.contextToken)];
+          // Detach the lifetime of the preview from the current touch.
+          trackingEntry.previewHost = null;
+
+          gestureSequence.on('complete', () => {
+            existingPreviewHost.cancel();
+            this.gesturePreviewHost = null;
+          })
+
+          // Past that, mere construction of the class for delegation is enough.
+          handlers = [new Multitap(gestureSequence, this, baseItem, keyResult.contextToken, existingPreviewHost)];
         } else if(gestureStage.matchedId.indexOf('flick') > -1) {
           handlers = [new Flick(
             gestureSequence,

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -349,9 +349,19 @@ body div.kmw-key-shift-on span.kmw-key-text {font-family:SpecialOSK !important;f
   z-index: 10002;
 }
 
+#kmw-keytip.kmw-preview-fade {
+  opacity: 0;
+  transition: 0.15s cubic-bezier(.42,0,.58,1) all 0.35s;
+}
+
 .kmw-keypreview {
   z-index: 10002;
   position: absolute;
+}
+
+.kmw-keypreview.kmw-preview-fade {
+  opacity: 0;
+  transition: 0.15s cubic-bezier(.42,0,.58,1) all 0.35s;
 }
 
 #kmw-gesture-preview {


### PR DESCRIPTION
In order to provide better feedback to users, this implements a special key-preview pattern for use during active multitaps:

<details open><summary><strong>Phones</strong> (animated gif dropdown)</summary>

![multitap-apple](https://github.com/keymanapp/keyman/assets/25213402/a1304085-6be5-4de7-a156-cdcd16ec7143)

</details>

<details><summary><strong>Tablets</strong> (animated gif dropdown)</summary>

![multitapple-tablet](https://github.com/keymanapp/keyman/assets/25213402/28992c17-27dd-4c25-b5cd-4531c2f5fffe)

</details>

The key-preview is now kept alive during the multitap process.  Once a user's finger is lifted from a base key that supports multitaps, a "key hint" appears on the top-right for the next key in-line.  Upon receiving each new, incoming tap, the newly-activated key becomes the preview's "key cap", with the key next in rotation appearing as the next "hint".

Thanks to #10102, this works even when multitapping across layers...

<details open><summary>Layer-crossing previews</summary>

![mt-layer-crossing-previews](https://github.com/keymanapp/keyman/assets/25213402/d3711b56-0367-4adb-9998-6af88759ce0e)

Note how the key-hints in the background swap as the key continues to be tapped.  The fact that the shift-key doesn't illuminate/highlight is a keyboard-design bug on my part.

</details>

@keymanapp-test-bot skip

I wanted to have user tests here... but I've been at a loss for how to spec related tests well.  It played out well in the team demo, so I figure that's a decent enough "user test" to count.