### PR TITLE
change(web): multitap previews now 'look ahead' by an extra rota step 🐵

### DIFF
--- a/web/src/engine/osk/src/input/gestures/browser/multitap.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/multitap.ts
@@ -59,7 +59,7 @@ export default class Multitap implements GestureHandler {
     const tapLookahead = (offset) => (this.tapIndex + offset) % this.multitaps.length;
 
     const updatePreview = () => {
-      previewHost?.setMultitapHint(this.multitaps[tapLookahead(0)].text, this.multitaps[tapLookahead(1)].text);
+      previewHost?.setMultitapHint(this.multitaps[tapLookahead(1)].text, this.multitaps[tapLookahead(2)].text);
     }
 
     source.on('complete', () => {


### PR DESCRIPTION
Compare against #10103; this PR simply performs a minor tweak that causes the preview keycaps and hints to "look ahead" by an extra rota step.  The net effect:  once multitap-mode activates, the currently displayed preview keycap is now the _next_ key to be typed, not the one that was _just_ typed.

I currently think #10102 is more ideal, but it'd be good to test and get feedback from others.  There's also a shot that this version is better on tablets, where the preview text is directly on an actual key... meaning that the key would visibly update to the "correct" spot during the finger-lift leading up to its use.

So, to facilitate a comparison version that's demoable, this PR exists.