### PR TITLE
chore(linux): Add support for loong64 architecture 🏠

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,10 @@
+keyman (16.0.143-1.1) UNRELEASED; urgency=medium
+
+  [Dandan Zhang]
+  * Add support for loong64 (closes: #1057134)
+
+ -- Eberhard Beilharz <eb1@sil.org>  Thu, 30 Nov 2023 17:52:16 +0100
+
 keyman (16.0.143-1) unstable; urgency=medium
 
   * Fix failure to build source after successful build (Closes #1046776)

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -105,7 +105,7 @@ Description: Keyman for Linux configuration
  information about Keyman keyboard packages.
 
 Package: libkmnkbp-dev
-Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el riscv64
+Architecture: amd64 arm64 armel armhf i386 loong64 mipsel mips64el ppc64el riscv64
 Section: libdevel
 Depends:
  libkmnkbp0-0 (= ${binary:Version}),
@@ -129,7 +129,7 @@ Description: Development files for Keyman keyboard processing library
  This package contains development headers and libraries.
 
 Package: libkmnkbp0-0
-Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el riscv64
+Architecture: amd64 arm64 armel armhf i386 loong64 mipsel mips64el ppc64el riscv64
 Section: libs
 Pre-Depends:
  ${misc:Pre-Depends},
@@ -155,7 +155,7 @@ Description: Keyman keyboard processing library
  and applies rules from compiled Keyman keyboard files.
 
 Package: ibus-keyman
-Architecture: amd64 arm64 armel armhf i386 mipsel mips64el ppc64el riscv64
+Architecture: amd64 arm64 armel armhf i386 loong64 mipsel mips64el ppc64el riscv64
 Depends:
  ibus (>= 1.3.7),
  sudo,

--- a/linux/debian/tests/control
+++ b/linux/debian/tests/control
@@ -2,4 +2,4 @@ Tests: test-build
 Depends: @,
  build-essential,
  pkg-config,
-Architecture: amd64 arm64 armel armhf i386 mips64el mipsel ppc64el riscv64
+Architecture: amd64 arm64 armel armhf i386 loong64 mips64el mipsel ppc64el riscv64


### PR DESCRIPTION
Closes Debian bug [#1057134](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1057134).

@keymanapp-test-bot skip