### PR TITLE
chore(web): Add option to create test coverage report file

### DIFF
--- a/web/.c8rc.json
+++ b/web/.c8rc.json
@@ -1,0 +1,13 @@
+{
+  "all": true,
+  "check-coverage": false,
+  "clean": true,
+  "exclude-after-remap": true,
+  "extension": [".ts", ".js"],
+  "reporter": ["text", "text-summary"],
+  "reports-dir": "build/coverage",
+  "src": [
+    "**/src/",
+    "../common/**/src"
+  ]
+}

--- a/web/build.sh
+++ b/web/build.sh
@@ -21,6 +21,7 @@ builder_describe "Builds engine modules for Keyman Engine for Web (KMW)." \
   "configure" \
   "build" \
   "test" \
+  "coverage                  Create an HTML page with code coverage" \
   ":app/browser              The form of Keyman Engine for Web for use on websites" \
   ":app/webview              A puppetable version of KMW designed for use in a host app's WebView" \
   ":app/ui                   Builds KMW's desktop form-factor keyboard-selection UI modules" \
@@ -113,3 +114,15 @@ if builder_start_action test; then
 
   builder_finish_action success test
 fi
+
+coverage_action() {
+  builder_echo "Creating coverage report..."
+  pushd .. > /dev/null
+  mkdir -p web/build/coverage/tmp
+  find . -type f -name coverage-\*.json -print0 | xargs -0 cp -t web/build/coverage/tmp
+  c8 report --config web/.c8rc.json ---reporter html --clean=false --reports-dir=web/build/coverage
+  rm -rf web/build/coverage/tmp
+  popd > /dev/null || return
+}
+
+builder_run_action coverage coverage_action


### PR DESCRIPTION
This adds a `coverage` parameter to `web/build.sh` that will create a coverage report in HTML format in `web/build/coverage/index.html`.

@keymanapp-test-bot skip