### PR TITLE
change(web): default shift-caps multitap inclusion of default layer in rota 🐵

### DIFF
--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -332,7 +332,7 @@ export class ActiveKeyBase {
        *
        */
       if(!key.sk && !key.multitap && !!layout.layer.find((entry) => entry.id == 'caps')) {
-        key.multitap = [Layouts.dfltShiftMultitap];
+        key.multitap = [Layouts.dfltShiftMultitap, Layouts.dfltShiftRotaDefault];
       }
     }
 

--- a/common/web/keyboard-processor/src/keyboards/defaultLayouts.ts
+++ b/common/web/keyboard-processor/src/keyboards/defaultLayouts.ts
@@ -535,6 +535,15 @@ export class Layouts {
     nextlayer: 'caps'
   }
 
+  static dfltShiftRotaDefault: LayoutSubKey = {
+    // Needs to be something special and unique.  Typing restricts us from
+    // using a reserved key-id prefix, though.
+    id: "T_*_MT_SHIFT_ROTA_TO_DEFAULT",
+    text: '*Shift*',
+    sp: 1,
+    nextlayer: 'default'
+  }
+
   // Defines the default visual layout for a keyboard.
   /* c8 ignore start */
   static dfltLayout: LayoutSpec = {

--- a/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file.ts
+++ b/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file.ts
@@ -49,10 +49,11 @@ export type TouchLayoutKeyId = `${Key_Type}_${Key_Id}`; // pattern = /^[TKUtku]_
  */
 export const PRIVATE_USE_IDS = [
   /**
-   * A private-use identifier used by KeymanWeb for the default multitap-into-caps-layer key
+   * Private-use identifiers used by KeymanWeb for the default multitap-into-caps-layer key
    * for keyboards with a caps layer while not defining multitaps on shift.
    */
-  'T_*_MT_SHIFT_TO_CAPS'
+  'T_*_MT_SHIFT_TO_CAPS',
+  'T_*_MT_SHIFT_ROTA_TO_DEFAULT'
 ] as const;
 
 /* A map of key field names with values matching the `typeof` the corresponding property

--- a/web/src/test/manual/web/keyboards/gesture_prototyping/build/gesture_prototyping.js
+++ b/web/src/test/manual/web/keyboards/gesture_prototyping/build/gesture_prototyping.js
@@ -250,7 +250,14 @@ function Keyboard_gesture_prototyping()
                   {
                     "text": "*ShiftLock*",
                     "id": "T_new_991",
+                    "sp": "1",
                     "nextlayer": "caps"
+                  },
+                  {
+                    "text": "*Shift*",
+                    "id": "T_new_107",
+                    "sp": "1",
+                    "nextlayer": "default"
                   }
                 ]
               },

--- a/web/src/test/manual/web/keyboards/gesture_prototyping/source/gesture_prototyping.keyman-touch-layout
+++ b/web/src/test/manual/web/keyboards/gesture_prototyping/source/gesture_prototyping.keyman-touch-layout
@@ -213,7 +213,14 @@
                   {
                     "text": "*ShiftLock*",
                     "id": "T_new_991",
+                    "sp": "1",
                     "nextlayer": "caps"
+                  },
+                  {
+                    "text": "*Shift*",
+                    "id": "T_new_107",
+                    "sp": "1",
+                    "nextlayer": "default"
                   }
                 ]
               },


### PR DESCRIPTION
As noted in a recent team trial of the current state of gestures, it felt really odd to not have the default layer as part of the layer rotation for the default shift-caps multitap interaction.  This change restores / enables that.

@keymanapp-test-bot skip