### PR TITLE
change(web): prevents auto-cancellation of simple-taps for flicked layouts when touchpoint moves 🐵

### DIFF
--- a/web/src/engine/osk/src/banner/bannerGestureSet.ts
+++ b/web/src/engine/osk/src/banner/bannerGestureSet.ts
@@ -10,7 +10,7 @@ import { BannerSuggestion } from './suggestionBanner.js';
 import { simpleTapModelWithReset } from "../input/gestures/specsForLayout.js";
 
 export const BannerSimpleTap: gestures.specs.GestureModel<BannerSuggestion> = {
-  ...deepCopy(simpleTapModelWithReset()),
+  ...deepCopy(simpleTapModelWithReset(null)),
   resolutionAction: {
     type: 'complete',
     item: 'current'

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -371,7 +371,9 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       mouseEventRoot: document.body,
       // Note: at this point in execution, the value will evaluate to NaN!  Height hasn't been set yet.
       // BUT:  we need to establish the instance now; we can update it later when height _is_ set.
-      maxRoamingBounds: new PaddedZoneSource(this.element, [NaN]),
+      //
+      // Allow keys to be preserved while the contact point is within banner space + a small fudge-factor.
+      maxRoamingBounds: new PaddedZoneSource(this.topContainer, [NaN]),
       // touchEventRoot:  this.element, // is the default
       itemIdentifier: (sample, target) => {
         /* ALWAYS use the findNearestKey function.
@@ -450,17 +452,14 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
         const key = sample.item;
         const oldKey = sourceTrackingMap[source.identifier].key;
 
-        if(key != oldKey) {
+        if(!this.kbdLayout.hasFlicks && key != oldKey) {
           this.highlightKey(oldKey, false);
           this.gesturePreviewHost?.cancel();
           this.gesturePreviewHost = null;
 
-          if(!this.kbdLayout.hasFlicks) {
-            const previewHost = this.highlightKey(key, true);
-            if(previewHost) {
-              this.gesturePreviewHost = previewHost;
-            }
-
+          const previewHost = this.highlightKey(key, true);
+          if(previewHost) {
+            this.gesturePreviewHost = previewHost;
             trackingEntry.previewHost = previewHost;
             sourceTrackingMap[source.identifier].key = key;
           }

--- a/web/src/test/manual/web/prediction-mtnt/index.html
+++ b/web/src/test/manual/web/prediction-mtnt/index.html
@@ -45,6 +45,8 @@
         kmw.addKeyboards('sil_euro_latin@en');
         kmw.addKeyboards({id:'ye_old_ten_key',name:'Classic 10-key',languages:{id:'en',name:'English'},
           filename:('../keyboards/ye_old_ten_key/build/ye_old_ten_key.js')})
+        kmw.addKeyboards({id:'gesture_prototyping',name:'Gesture prototyping',languages:{id:'en',name:'English'},
+          filename:('../keyboards/gesture_prototyping/build/gesture_prototyping.js')})
 
         var pageRef = (window.location.protocol == 'file:')
           ? window.location.href.substr(0, window.location.href.lastIndexOf('/')+1)


### PR DESCRIPTION
Simple taps are no longer auto-cancelled when the touchpoint moves if roaming-touch is disabled; this provides consistency with the handling of keys supporting flicks.

@keymanapp-test-bot skip