### PR TITLE
fix(developer): prevent opening .kpj in multiple processes 🦕

### DIFF
--- a/developer/src/tike/actions/dmActionsMain.pas
+++ b/developer/src/tike/actions/dmActionsMain.pas
@@ -576,6 +576,7 @@ end;
 
 procedure TmodActionsMain.actProjectNewExecute(Sender: TObject);
 begin
+  // TODO: new process
   if not frmKeymanDeveloper.BeforeOpenProject then
     Exit;
   ShowNewProjectForm(frmKeymanDeveloper);
@@ -583,9 +584,7 @@ end;
 
 procedure TmodActionsMain.actProjectOpenAccept(Sender: TObject);
 begin
-  if not frmKeymanDeveloper.BeforeOpenProject then
-    Exit;
-  OpenProject(actProjectOpen.Dialog.FileName);
+  frmKeymanDeveloper.OpenProject(actProjectOpen.Dialog.FileName);
 end;
 
 procedure TmodActionsMain.OpenProject(FileName: WideString);

--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -444,6 +444,7 @@ type
     procedure RefreshOptions;
 
     function OpenEditor(FFileName: string; frmClass: TfrmTikeEditorClass): TfrmTikeEditor;
+    procedure OpenProject(const filename: string);
     function OpenFile(FFileName: string; FCloseNewFile: Boolean): TfrmTikeChild;
     procedure OpenFilesInProject(FFileNames: TArray<string>);
 
@@ -1563,11 +1564,22 @@ begin
 end;
 
 procedure TfrmKeymanDeveloper.mnuProjectRecentFileClick(Sender: TObject);
+var
+  filename: string;
 begin
-  with Sender as TMenuItem do
+  filename := (Sender as TMenuItem).Hint;
+  OpenProject(filename);
+end;
+
+procedure TfrmKeymanDeveloper.OpenProject(const filename: string);
+begin
+  if IsGlobalProjectUIReady then
   begin
-    if BeforeOpenProject then
-      modActionsMain.OpenProject(Hint);
+    OpenFilesInProject([filename]);
+  end
+  else if BeforeOpenProject then
+  begin
+    modActionsMain.OpenProject(filename);
   end;
 end;
 

--- a/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFiles.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFiles.pas
@@ -70,5 +70,7 @@ initialization
   RegisterProjectFileType('.html', TOpenableProjectFile);  // I1769
   RegisterProjectFileType('.xml', TOpenableProjectFile);   // I1769
   RegisterProjectFileType('.js', TOpenableProjectFile);
+  RegisterProjectFileType('.kpj', TOpenableProjectFile);
+  RegisterProjectFileType('.user', TOpenableProjectFile);
 end.
 

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.ProjectFilesUI.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.ProjectFilesUI.pas
@@ -146,8 +146,11 @@ end;
 procedure TOpenableProjectFileUI.OpenFile;
 begin
   FMDIChild := frmKeymanDeveloper.OpenFile(ProjectFile.FileName, False);
-  FMDIChild.OnCloseFile := CloseFile;
-  FMDIChild.ProjectFile := ProjectFile;
+  if Assigned(FMDIChild) then
+  begin
+    FMDIChild.OnCloseFile := CloseFile;
+    FMDIChild.ProjectFile := ProjectFile;
+  end;
 end;
 
 function TOpenableProjectFileUI.WindowOpen: Boolean;


### PR DESCRIPTION
Fixes #10003.

Multiple small fixes required here:
* Add .kpj as an editable file type
* Ensure that when OpenFile returns nil (which it always will for a .kpj), that we don't crash
* Ensure that projects open in a new process rather than replacing the current project session

Adds a TODO for New Project -- this should be opened in a new process if we already have a project open in the current process. Will push this into a separate PR (see #10138).

@keymanapp-test-bot skip