### PR TITLE
fix(web): Fix null error with legacy keyboards

### DIFF
--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -282,9 +282,7 @@ export class ActiveKey implements LayoutKey {
 
       // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
       if(!keyboard.definesPositionalOrMnemonic) {
-        // Not the best pattern, but currently safe - we don't look up any properties of any of the
-        // arguments in this use case, and the object's scope is extremely limited.
-        Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(keyboard.constructNullKeyEvent(null, null));
+        Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(Lkc);
         Lkc.LisVirtualKey=false;
       }
     }

--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -284,11 +284,7 @@ export class ActiveKey implements LayoutKey {
       if(!keyboard.definesPositionalOrMnemonic) {
         // Not the best pattern, but currently safe - we don't look up any properties of any of the
         // arguments in this use case, and the object's scope is extremely limited.
-        Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(keyboard.constructKeyEvent(null, null, {
-          K_CAPS: false,
-          K_NUMLOCK: false,
-          K_SCROLL: false
-        }));
+        Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(keyboard.constructNullKeyEvent(null, null));
         Lkc.LisVirtualKey=false;
       }
     }

--- a/common/web/keyboard-processor/src/keyboards/keyboard.ts
+++ b/common/web/keyboard-processor/src/keyboards/keyboard.ts
@@ -502,7 +502,7 @@ export default class Keyboard {
     // Set the flags for the state keys - for desktop devices. For touch
     // devices, the only state key in use currently is Caps Lock, which is set
     // when the 'caps' layer is active in ActiveKey::constructBaseKeyEvent.
-    if(!Lkc.device?.touchable) {
+    if(!Lkc.device.touchable) {
       /*
        * For desktop-style keyboards, start from a blank slate.  They have a 'default'
        * (implicit 'NO_CAPS') layer but not a 'caps' layer.  With caps set, it just

--- a/common/web/keyboard-processor/src/keyboards/keyboard.ts
+++ b/common/web/keyboard-processor/src/keyboards/keyboard.ts
@@ -502,7 +502,7 @@ export default class Keyboard {
     // Set the flags for the state keys - for desktop devices. For touch
     // devices, the only state key in use currently is Caps Lock, which is set
     // when the 'caps' layer is active in ActiveKey::constructBaseKeyEvent.
-    if(!Lkc.device.touchable) {
+    if(!Lkc.device?.touchable) {
       /*
        * For desktop-style keyboards, start from a blank slate.  They have a 'default'
        * (implicit 'NO_CAPS') layer but not a 'caps' layer.  With caps set, it just


### PR DESCRIPTION
Fixes #10099.

# User Testing

**TEST_FIXED**: 

- Open the [Unminified Source test page](https://build.palaso.org/repository/download/Keymanweb_TestPullRequests/428137:id/src/test/manual/web/unminified.html)
- Load the Armenian keyboard by typing "armenian" in the "Add a keyboard by keyboard name" field and pressing the "Add" button
- click in the "Type here" field and switch to the Armenian keyboard
- Verify that the Armenian OSK is shown, but no error