### PR TITLE
change(web): prep for enhanced flick-resets - alters the contact-path evaluation signature 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
@@ -31,7 +31,18 @@ export class PathMatcher<Type, StateToken = any> {
   // `source` will continue to receive edits and may even change the instance
   // underlying the `path` field.
   public readonly source: GestureSource<Type>;
-  private readonly basePathStats: CumulativePathStats<Type>;
+
+  /**
+   * Holds the stats for the inherited portion of the path.
+   */
+  private readonly inheritedStats: CumulativePathStats<Type>;
+
+  /**
+   * Holds the path's stats at the time of the last `update()` call, as needed
+   * by PathModel's `evaluate` function.
+   */
+  // In regard to KeymanWeb, this exists to enhance flick-resetting behaviors.
+  private lastStats: CumulativePathStats<Type>;
 
   private readonly publishedPromise: ManagedPromise<PathMatchResult>
   private _result: PathMatchResult;
@@ -49,7 +60,8 @@ export class PathMatcher<Type, StateToken = any> {
     this.model = model;
     this.publishedPromise = new ManagedPromise<PathMatchResult>();
     this.source = source;
-    this.basePathStats = basePathStats;
+    this.inheritedStats = basePathStats;
+    this.lastStats = null;
 
     if(model.timer) {
       const offset = model.timer.inheritElapsed ? Math.min(source.path.stats.duration, model.timer.duration) : 0;
@@ -132,7 +144,8 @@ export class PathMatcher<Type, StateToken = any> {
       return this.finalize(result, 'item');
     } else {
       // Note:  is current path, not 'full path'.
-      const result = model.pathModel.evaluate(source.path, this.basePathStats) || 'continue';
+      const result = model.pathModel.evaluate(source.path, this.lastStats, source.baseItem, this.inheritedStats) || 'continue';
+      this.lastStats = source.path.stats;
 
       if(result != 'continue') {
         return this.finalize(result == 'resolve', 'path');

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/pathModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/pathModel.ts
@@ -12,8 +12,18 @@ export interface PathModel<Type = any> {
    *
    * @param path The current gesture's path, based on the path-inheritance setting of
    * its `ContactModel`.
-   * @param basePathStats The stats for the path of the gesture's previous 'stage', if
-   * one existed.
+   * @param priorStats The current path's stats at the time of the previous path-evaluate
+   * call.  Will be null on _each_ path model's first `evaluate` call.
+   * @param baseItem The base 'item' for the path's source.  May match an item not
+   * held by any path coordinate if 'partial' path inheritance has occurred at some
+   * point in the source's history.
+   * @param inheritedStats The stats for the portion of the path 'inherited' from
+   * prior stages.  May be null.
    */
-  evaluate(path: GesturePath<Type>, basePathStats: CumulativePathStats<Type>): 'reject' | 'resolve' | undefined;
+  evaluate(
+    path: GesturePath<Type>,
+    priorStats: CumulativePathStats<Type>,
+    baseItem: Type,
+    inheritedStats: CumulativePathStats<Type>
+  ): 'reject' | 'resolve' | undefined;
 }

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedPathSpecs.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedPathSpecs.ts
@@ -46,7 +46,7 @@ export const LongpressFlickDistanceThreshold = 6;
 export const MainLongpressSourceModelWithShortcut: ContactModel = {
   ...MainLongpressSourceModel,
   pathModel: {
-    evaluate: (path, baseStats) => {
+    evaluate: (path, priorStats, baseItem, baseStats) => {
       const stats = path.stats;
 
       // Adds up-flick support!
@@ -54,7 +54,7 @@ export const MainLongpressSourceModelWithShortcut: ContactModel = {
         return 'resolve';
       }
 
-      return MainLongpressSourceModel.pathModel.evaluate(path, baseStats);
+      return MainLongpressSourceModel.pathModel.evaluate(path, priorStats, baseItem, baseStats);
     }
   }
 }
@@ -121,7 +121,7 @@ export const FlickEndThreshold = 20;
 export const FlickEndContactModel: ContactModel = {
   itemPriority: 1,
   pathModel: {
-    evaluate: (path, baseStats) => {
+    evaluate: (path, priorStats, baseItem, baseStats) => {
       if(!baseStats) {
         throw Error("Missing data for the previous flick stage");
       }

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -375,7 +375,7 @@ export function flickEndContactModel(params: GestureParams): ContactModel {
   return {
     itemPriority: 1,
     pathModel: {
-      evaluate: (path, baseStats) => {
+      evaluate: (path, dummy, dummy2, baseStats) => {
         if(path.isComplete) {
           // The Flick handler class will sort out the mess once the path is complete.
           // Note:  if we wanted auto-triggering once the threshold distance were met,


### PR DESCRIPTION
@keymanapp-test-bot skip