### PR TITLE
fix(android/app): InfoActivity pass external links to browser

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
@@ -7,7 +7,9 @@ package com.tavultesoft.kmapro;
 import com.keyman.engine.BaseActivity;
 
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Bitmap;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
 import android.webkit.WebChromeClient;
@@ -87,9 +89,20 @@ public class InfoActivity extends BaseActivity {
 
       @Override
       public boolean shouldOverrideUrlLoading(WebView view, String url) {
-        if (url != null && !url.toLowerCase().equals("about:blank")) {
+        String lowerURL = url.toLowerCase();
+        if (lowerURL.equals("about:blank")) {
+          return true; // never load a blank page, e.g. when the component initializes
+        }
+
+        Uri uri = Uri.parse(url);
+
+        // All links that aren't internal Keyman help links open in user's browser
+        if (!url.contains(htmlPath)) {
+          Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+          startActivity(intent);
+        } else {
           view.loadUrl(url);
-         }
+        }
 
         return true;
       }


### PR DESCRIPTION
Fixes #9862 

Most of the in-app help content in InfoActivity is stored within the app.
Following a pattern of in-app keyboard seaches which sends external links to the user's browser.

## User Testing
* **Setup** - Install the PR build of Keyman for Android on a Android device/emulator

* **TEST_INFO_LINKS** - Verifies Info Activity launches external links in separate browser
1. Open Keyman app 
2. Click the "More info" option from the Get Started dialog to launch in-app help.
3. Click the "Version History" dialog.
4. Click the "help.keyman.com/version-history" link in the Version History page.
5. Verify help.keyman.com/version-history is launched in the device's browser (separate from Keyman app)
6. Scroll down to the bottom of the Keyman Help page.
7. Click the "Facebook" link under "Keep in touch" topic.
8. Verify the browser handles the "Facebook" link. (The state of Facebook profile in the device's browser is separate from this PR)
