### PR TITLE
feat(developer): Add Window menu 🦕

### DIFF
--- a/developer/src/tike/actions/dmActionsMain.dfm
+++ b/developer/src/tike/actions/dmActionsMain.dfm
@@ -493,6 +493,11 @@ object modActionsMain: TmodActionsMain
       OnExecute = actToolsWebStopServerExecute
       OnUpdate = actToolsWebStopServerUpdate
     end
+    object actWindowNew: TAction
+      Category = 'Window'
+      Caption = '&New window'
+      OnExecute = actWindowNewExecute
+    end
   end
   object ActionManager1: TActionManager
     ActionBars = <

--- a/developer/src/tike/actions/dmActionsMain.pas
+++ b/developer/src/tike/actions/dmActionsMain.pas
@@ -138,6 +138,7 @@ type
     actToolsWebConfigure: TAction;
     actToolsWebStartServer: TAction;
     actToolsWebStopServer: TAction;
+    actWindowNew: TAction;
     procedure actFileNewExecute(Sender: TObject);
     procedure DataModuleCreate(Sender: TObject);
     procedure actFileOpenAccept(Sender: TObject);
@@ -237,6 +238,7 @@ type
     procedure actToolsWebStartServerUpdate(Sender: TObject);
     procedure actToolsWebStopServerExecute(Sender: TObject);
     procedure actToolsWebStopServerUpdate(Sender: TObject);
+    procedure actWindowNewExecute(Sender: TObject);
   private
     function CheckFilenameConventions(FileName: string): Boolean;
     function SaveAndCloseAllFiles: Boolean;
@@ -1008,6 +1010,11 @@ end;
 procedure TmodActionsMain.actWindowCloseUpdate(Sender: TObject);
 begin
   actWindowClose.Enabled := Assigned(frmKeymanDeveloper.ActiveChild);
+end;
+
+procedure TmodActionsMain.actWindowNewExecute(Sender: TObject);
+begin
+  frmKeymanDeveloper.OpenNewWindow;
 end;
 
 procedure TmodActionsMain.actWindowNextExecute(Sender: TObject);

--- a/developer/src/tike/main/Keyman.Developer.System.LaunchProjects.pas
+++ b/developer/src/tike/main/Keyman.Developer.System.LaunchProjects.pas
@@ -35,6 +35,7 @@ type
     procedure GroupFilenamesIntoProjects(const Filenames: TStringList);
     function LaunchAll(AProcesses: TTikeProcessList): Boolean;
     function Find(const ProjectFilename: string): TLaunchProject;
+    class function LaunchNewEmptyInstance: Boolean;
     property ReserveStartupProject: Boolean read FReserveStartupProject;
     property StartupProject: TLaunchProject read GetStartupProject;
   end;
@@ -178,6 +179,14 @@ begin
       end;
     end;
   end;
+end;
+
+class function TLaunchProjects.LaunchNewEmptyInstance: Boolean;
+var
+  cmdline: string;
+begin
+  cmdline := '"'+ParamStr(0)+'" --sub-process *';
+  Result := TUtilExecute.Execute(cmdline, GetCurrentDir, SW_SHOWNORMAL);
 end;
 
 end.

--- a/developer/src/tike/main/Keyman.Developer.System.TikeCommandLine.pas
+++ b/developer/src/tike/main/Keyman.Developer.System.TikeCommandLine.pas
@@ -129,6 +129,14 @@ begin
 
   // TODO(lowpri): Consider error handling
 
+  if ParamStr(2) = '*' then
+  begin
+    // Asked to open a new empty project, via Window|New
+    FStartupProjectPath := '';
+    SetLength(FStartupFilenames, 0);
+    Exit(True);
+  end;
+
   FStartupProjectPath := ParamStr(2);
   SetLength(FStartupFilenames, ParamCount - 2);
   for i := 3 to ParamCount do

--- a/developer/src/tike/main/Keyman.Developer.System.TikeMultiProcess.pas
+++ b/developer/src/tike/main/Keyman.Developer.System.TikeMultiProcess.pas
@@ -14,7 +14,7 @@ type
     ProjectFilename: string;
     SourcePath: string;
     IsProjectOpen: Boolean;
-    IsTemporaryProject: Boolean;
+    function IsTemporaryProject: Boolean;
     function OwnsProject(const filename: string): Boolean;
     function OpenFile(const filename: string): Boolean;
     function FocusProcess: Boolean;
@@ -95,7 +95,6 @@ begin
     begin
       tp := TTikeProcess.Create;
       tp.IsProjectOpen := False;
-      tp.IsTemporaryProject := False;
       tp.ProjectFilename := '';
       tp.SourcePath := '';
       tp.WindowHandle := p.Handle;
@@ -119,7 +118,6 @@ begin
       tp := TTikeProcess.Create;
       tp.IsProjectOpen := True;
       tp.ProjectFilename := jo.Values[JSON_Filename].Value;
-      tp.IsTemporaryProject := tp.ProjectFilename = '';
       tp.SourcePath := jo.Values[JSON_SourcePath].Value;
       tp.WindowHandle := p.Handle;
       tp.ThreadID := p.ThreadId;
@@ -172,6 +170,11 @@ begin
     Result := 'Temporary Project'
   else
     Result := ProjectFilename;
+end;
+
+function TTikeProcess.IsTemporaryProject: Boolean;
+begin
+  Result := IsProjectOpen and (ProjectFilename = '');
 end;
 
 function TTikeProcess.OpenFile(const filename: string): Boolean;

--- a/developer/src/tike/main/UfrmMain.dfm
+++ b/developer/src/tike/main/UfrmMain.dfm
@@ -3140,6 +3140,16 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
         end
       end
     end
+    object mnuWindow: TMenuItem
+      Caption = '&Window'
+      OnClick = mnuWindowClick
+      object Newwindow1: TMenuItem
+        Action = modActionsMain.actWindowNew
+      end
+      object N12: TMenuItem
+        Caption = '-'
+      end
+    end
     object Help1: TMenuItem
       Caption = '&Help'
       object Contents1: TMenuItem

--- a/developer/src/tike/main/mrulist.pas
+++ b/developer/src/tike/main/mrulist.pas
@@ -53,6 +53,8 @@ type
     property OnChange: TNotifyEvent read FOnChange write FOnChange;
   end;
 
+function EllipsisFile(filename: string): string;
+
 implementation
 
 uses
@@ -231,15 +233,20 @@ begin
 end;
 
 function TMRUList.EllipsisFile(Index: Integer): string;
+begin
+  Result := mrulist.EllipsisFile(Files[Index]);
+end;
+
+function EllipsisFile(filename: string): string;
 var
   buffer: array[0..MAX_PATH] of char;
 begin
-  StrPCopy(buffer, Files[Index]);
+  StrPCopy(buffer, filename);
 
   if PathCompactPath(0, buffer, GetSystemMetrics(SM_CXSCREEN) div 3) then   // I4697
     Result := buffer  // This removes the terminating nul
   else
-    Result := ExtractFileName(Files[Index]);
+    Result := ExtractFileName(filename);
 end;
 
 function TMRUList.GetFile(Index: Integer): string;


### PR DESCRIPTION
Fixes #10149.

Adds a Window menu so user can easily switch between Keyman Developer processes or open a new instance.

![image](https://github.com/keymanapp/keyman/assets/4498365/e5c7d8db-f369-4918-80cf-505b801c7a5a)

# User Testing

* **TEST_NEW_WINDOW:** Open Keyman Developer. Use Window|New Window to open a new instance of Keyman Developer, which should open with no project open.
* **TEST_WINDOW_MENU:** Open several instances of Keyman Developer and open projects in each instance. Verify that the windows shown in the Window menu match up with the open projects.