### PR TITLE
feat(developer): New Project opens in new process 🦕

### DIFF
--- a/developer/src/tike/actions/dmActionsMain.pas
+++ b/developer/src/tike/actions/dmActionsMain.pas
@@ -241,10 +241,7 @@ type
     procedure actWindowNewExecute(Sender: TObject);
   private
     function CheckFilenameConventions(FileName: string): Boolean;
-    function SaveAndCloseAllFiles: Boolean;
     procedure CloseProject;
-  public
-    procedure OpenProject(FileName: WideString);
   end;
 
 var
@@ -589,42 +586,13 @@ begin
   frmKeymanDeveloper.OpenProject(actProjectOpen.Dialog.FileName);
 end;
 
-procedure TmodActionsMain.OpenProject(FileName: WideString);
-begin
-  FileName := ExpandUNCFileName(FileName);
-  if (FileName <> '') and not FileExists(FileName) then
-  begin
-    ShowMessage('The project '+FileName+' does not exist.');
-    Exit;
-  end;
 
-  if IsGlobalProjectUIReady then
-  begin
-    if not SaveAndCloseAllFiles then Exit;
-    FreeGlobalProjectUI;
-  end;
-  try
-    LoadGlobalProjectUI(ptUnknown, FileName);   // I4687
-  except
-    on E:EProjectLoader do
-    begin
-      // Message will be displayed by LoadGlobalProjectUI
-      FreeGlobalProjectUI;
-      frmKeymanDeveloper.ShowProject;
-      frmKeymanDeveloper.UpdateCaption;
-      Exit;
-    end;
-  end;
-  frmKeymanDeveloper.ProjectMRU.Add(FGlobalProject.FileName);
-  frmKeymanDeveloper.ShowProject;
-  frmKeymanDeveloper.UpdateCaption;
-end;
 
 procedure TmodActionsMain.CloseProject;
 begin
   if IsGlobalProjectUIReady then
   begin
-    if not SaveAndCloseAllFiles then Exit;
+    if not frmKeymanDeveloper.SaveAndCloseAllFiles then Exit;
     FreeGlobalProjectUI;
   end;
   frmKeymanDeveloper.ShowProject;
@@ -1069,33 +1037,6 @@ begin
     'HTML files (*.htm, *.html)|*.htm?|'+
     'XML files (*.xml)|*.xml|'+
     'All files (*.*)|*.*';
-end;
-
-function TmodActionsMain.SaveAndCloseAllFiles: Boolean;
-var
-  i: Integer;
-begin
-  FGlobalProject.Save;
-  for i := 0 to frmKeymanDeveloper.ChildWindows.Count - 1 do
-  begin
-    if frmKeymanDeveloper.ChildWindows[i] is TfrmProject then
-      Continue;
-
-    if not frmKeymanDeveloper.ChildWindows[i].CloseQuery then
-      Exit(False);
-  end;
-
-  for i := 0 to frmKeymanDeveloper.ChildWindows.Count - 1 do
-  begin
-    if frmKeymanDeveloper.ChildWindows[i] is TfrmProject then
-      Continue;
-
-    frmKeymanDeveloper.ChildWindows[i].Visible := False;
-    frmKeymanDeveloper.ChildWindows[i].Parent := nil;
-    frmKeymanDeveloper.ChildWindows[i].Release;
-  end;
-
-  Result := True;
 end;
 
 end.

--- a/developer/src/tike/main/Keyman.Developer.UI.ImportWindowsKeyboardDialogManager.pas
+++ b/developer/src/tike/main/Keyman.Developer.UI.ImportWindowsKeyboardDialogManager.pas
@@ -16,7 +16,7 @@ uses
 
   Keyman.Developer.System.ImportWindowsKeyboard,
   Keyman.Developer.UI.Project.UfrmNewProjectParameters,
-  dmActionsMain,
+  UfrmMain,
   UfrmSelectSystemKeyboard;
 
 function ShowImportWindowsKeyboard(Owner: TComponent): Boolean;
@@ -83,7 +83,7 @@ begin
     f.Free;
   end;
 
-  modActionsMain.OpenProject(ProjectFilename);
+  frmKeymanDeveloper.OpenProject(ProjectFilename);
   Result := True;
 end;
 

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.pas
@@ -131,14 +131,14 @@ uses
   Keyman.System.LexicalModelUtils,
   BCP47Tag,
   utilstr,
-  dmActionsMain,
   KeymanDeveloperOptions,
   Keyman.Developer.System.HelpTopics,
   Keyman.Developer.System.Project.Project,
   Keyman.Developer.System.Project.ProjectFile,
   Keyman.Developer.System.ModelProjectTemplate,
   Keyman.Developer.System.ProjectTemplate,
-  Keyman.Developer.UI.UfrmSelectBCP47Language;
+  Keyman.Developer.UI.UfrmSelectBCP47Language,
+  UfrmMain;
 
 {$R *.dfm}
 
@@ -173,7 +173,7 @@ begin
         end;
       end;
 
-      modActionsMain.OpenProject(pt.ProjectFilename);
+      frmKeymanDeveloper.OpenProject(pt.ProjectFilename);
       Result := True;
 
     finally

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
@@ -120,7 +120,6 @@ uses
   Keyman.System.LanguageCodeUtils,
   BCP47Tag,
   utilstr,
-  dmActionsMain,
   KeymanDeveloperOptions,
   Keyman.Developer.System.HelpTopics,
   Keyman.Developer.System.Project.Project,
@@ -128,7 +127,8 @@ uses
   Keyman.Developer.System.KeyboardProjectTemplate,
   Keyman.Developer.System.ProjectTemplate,
   Keyman.Developer.UI.UfrmSelectBCP47Language,
-  Keyman.System.KeyboardUtils;
+  Keyman.System.KeyboardUtils,
+  UfrmMain;
 
 // 1. project filename
 // 2. location
@@ -174,7 +174,7 @@ begin
         end;
       end;
 
-      modActionsMain.OpenProject(pt.ProjectFilename);
+      frmKeymanDeveloper.OpenProject(pt.ProjectFilename);
       Result := True;
 
     finally

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProject.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProject.pas
@@ -359,7 +359,7 @@ begin
   else if Command = 'editfile' then // MRU
   begin
     if SelectedMRUFileName <> '' then
-      modActionsMain.OpenProject(SelectedMRUFileName);
+      frmKeymanDeveloper.OpenProject(SelectedMRUFileName);
   end
   else if Command = 'removefrommru' then
   begin


### PR DESCRIPTION
Fixes #10138.

If the current instance of Keyman Developer already has a project open, then the New Project dialog will now open the new project in a new instance of Keyman Developer.

Note: this also moves a couple of functions out of dmActionsMain and into UfrmMain, as their functionality belongs more closely there. The `TmodActionsMain.OpenProject` function has been renamed to `TfrmMain.OpenProjectInCurrentProcess` to clarify its usage and context.

# User Testing

* **TEST_NEW_PROJECT:** Open Keyman Developer, and open a project. Create a new project, and verify that the new project opens in a new instance of Keyman Developer.

* **TEST_NEW_PROJECT_NO_PROJECT_OPEN:** Open Keyman Developer, and make sure no project is open (Project|Close Project). Create a new project, and verify that the project opens in the current instance of Keyman Developer.