### PR TITLE
feat(windows): Remove UI com online-update check 📲 💽

### DIFF
--- a/windows/src/desktop/kmshell/kmshell.dpr
+++ b/windows/src/desktop/kmshell/kmshell.dpr
@@ -179,7 +179,7 @@ uses
   Keyman.System.AndroidStringToKeymanLocaleString in '..\..\..\..\common\windows\delphi\general\Keyman.System.AndroidStringToKeymanLocaleString.pas',
   UpdateXMLRenderer in 'render\UpdateXMLRenderer.pas',
   Keyman.System.UpdateCheckStorage in 'main\Keyman.System.UpdateCheckStorage.pas',
-  RemoteUpdateCheck in 'main\RemoteUpdateCheck.pas';
+  Keyman.System.RemoteUpdateCheck in 'main\Keyman.System.RemoteUpdateCheck.pas';
 
 {$R VERSION.RES}
 {$R manifest.res}

--- a/windows/src/desktop/kmshell/kmshell.dpr
+++ b/windows/src/desktop/kmshell/kmshell.dpr
@@ -178,7 +178,8 @@ uses
   Keyman.Configuration.System.HttpServer.App.Locale in 'web\Keyman.Configuration.System.HttpServer.App.Locale.pas',
   Keyman.System.AndroidStringToKeymanLocaleString in '..\..\..\..\common\windows\delphi\general\Keyman.System.AndroidStringToKeymanLocaleString.pas',
   UpdateXMLRenderer in 'render\UpdateXMLRenderer.pas',
-  Keyman.System.UpdateCheckStorage in 'main\Keyman.System.UpdateCheckStorage.pas';
+  Keyman.System.UpdateCheckStorage in 'main\Keyman.System.UpdateCheckStorage.pas',
+  RemoteUpdateCheck in 'main\RemoteUpdateCheck.pas';
 
 {$R VERSION.RES}
 {$R manifest.res}
@@ -200,7 +201,7 @@ begin
         Application.Initialize;
         Application.Title := 'Keyman Configuration';
         Application.CreateForm(TmodWebHttpServer, modWebHttpServer);
-        try
+  try
           Run;
         finally
           FreeAndNil(modWebHttpServer);

--- a/windows/src/desktop/kmshell/kmshell.dproj
+++ b/windows/src/desktop/kmshell/kmshell.dproj
@@ -355,7 +355,7 @@
         <DCCReference Include="..\..\..\..\common\windows\delphi\general\Keyman.System.AndroidStringToKeymanLocaleString.pas"/>
         <DCCReference Include="render\UpdateXMLRenderer.pas"/>
         <DCCReference Include="main\Keyman.System.UpdateCheckStorage.pas"/>
-        <DCCReference Include="main\RemoteUpdateCheck.pas"/>
+        <DCCReference Include="main\Keyman.System.RemoteUpdateCheck.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
@@ -417,12 +417,6 @@
                 <Platform value="Win64">False</Platform>
             </Platforms>
             <Deployment Version="3">
-                <DeployFile LocalName="bin\Win32\Debug\kmshell.rsm" Configuration="Debug" Class="DebugSymbols">
-                    <Platform Name="Win32">
-                        <RemoteName>kmshell.rsm</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
                 <DeployFile LocalName="bin\Win32\Debug\kmshell.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>kmshell.exe</RemoteName>
@@ -432,6 +426,12 @@
                 <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
                     <Platform Name="Win32">
                         <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="bin\Win32\Debug\kmshell.rsm" Configuration="Debug" Class="DebugSymbols">
+                    <Platform Name="Win32">
+                        <RemoteName>kmshell.rsm</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>

--- a/windows/src/desktop/kmshell/kmshell.dproj
+++ b/windows/src/desktop/kmshell/kmshell.dproj
@@ -355,6 +355,7 @@
         <DCCReference Include="..\..\..\..\common\windows\delphi\general\Keyman.System.AndroidStringToKeymanLocaleString.pas"/>
         <DCCReference Include="render\UpdateXMLRenderer.pas"/>
         <DCCReference Include="main\Keyman.System.UpdateCheckStorage.pas"/>
+        <DCCReference Include="main\RemoteUpdateCheck.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
@@ -416,21 +417,21 @@
                 <Platform value="Win64">False</Platform>
             </Platforms>
             <Deployment Version="3">
-                <DeployFile LocalName="kmshell.rsm" Configuration="Debug" Class="DebugSymbols">
+                <DeployFile LocalName="bin\Win32\Debug\kmshell.rsm" Configuration="Debug" Class="DebugSymbols">
                     <Platform Name="Win32">
                         <RemoteName>kmshell.rsm</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="bin\Win32\Debug\kmshell.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>kmshell.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
                 <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
                     <Platform Name="Win32">
                         <RemoteDir>.\</RemoteDir>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="kmshell.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>kmshell.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>

--- a/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
@@ -15,21 +15,18 @@
   Notes:
   History:
 *)
-unit RemoteUpdateCheck;  // I3306
+unit Keyman.System.RemoteUpdateCheck;  // I3306
 
 interface
 
 uses
   System.Classes,
   System.SysUtils,
-  System.UITypes,
-  System.IOUtils,
-  Vcl.Forms,
+  //System.UITypes,
+  //System.IOUtils,
   KeymanPaths,
-
   httpuploader,
   Keyman.System.UpdateCheckResponse,
-  UfrmDownloadProgress,
   OnlineUpdateCheck;
 
 type
@@ -78,8 +75,7 @@ implementation
 
 uses
   System.WideStrUtils,
-  Vcl.Dialogs,
-  Winapi.ShellApi,
+  //Winapi.ShellApi,
   Winapi.Windows,
   Winapi.WinINet,
 
@@ -92,15 +88,13 @@ uses
   ErrorControlledRegistry,
   RegistryKeys,
   Upload_Settings,
-  utildir,
-  utilexecute,
-  OnlineUpdateCheckMessages,
-  UfrmOnlineUpdateIcon,
-  UfrmOnlineUpdateNewVersion,
-  utilkmshell,
-  utilsystem,
-  utiluac,
-  versioninfo;
+  //utildir,
+  //utilexecute,
+  OnlineUpdateCheckMessages;
+  //utilkmshell,
+ // utilsystem,
+  //utiluac,
+  //versioninfo;
 
 { TRemoteUpdateCheck }
 
@@ -358,10 +352,12 @@ begin
             TUpdateCheckStorage.SaveUpdateCacheData(ucr);
             Result := FParams.Result;
           end
+          // TODO: #10038
+          // Integerate into state machine. in the download state
+          // the process can call LoadUpdateCacheData if needed to get the
+          // response result.
           else if (Length(FParams.Packages) > 0) or (FParams.Keyman.DownloadURL <> '') then
           begin
-            // TODO: Integrate in to the Background update state machine.
-            // for now just go straight to DownloadUpdates
             downloadResult := DownloadUpdates;
             if DownloadResult then
             begin

--- a/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
@@ -125,24 +125,26 @@ end;
 procedure TRemoteUpdateCheck.DoDownloadUpdates(SavePath: string; Params: TUpdateCheckResponse; var Result: Boolean);
 var
   i, downloadCount: Integer;
+  http: THttpUploader;
+  fs: TFileStream;
 
     function DownloadFile(const url, savepath: string): Boolean;
     begin
-      with THttpUploader.Create(nil) do
+      http := THttpUploader.Create(nil);
       try
-        Proxy.Server := GetProxySettings.Server;
-        Proxy.Port := GetProxySettings.Port;
-        Proxy.Username := GetProxySettings.Username;
-        Proxy.Password := GetProxySettings.Password;
-        Request.Agent := API_UserAgent;
+        http.Proxy.Server := GetProxySettings.Server;
+        http.Proxy.Port := GetProxySettings.Port;
+        http.Proxy.Username := GetProxySettings.Username;
+        http.Proxy.Password := GetProxySettings.Password;
+        http.Request.Agent := API_UserAgent;
 
-        Request.SetURL(url);
-        Upload;
-        if Response.StatusCode = 200 then
+        http.Request.SetURL(url);
+        http.Upload;
+        if http.Response.StatusCode = 200 then
         begin
           fs := TFileStream.Create(savepath, fmCreate);
           try
-            fs.Write(Response.PMessageBody^, Response.MessageBodyLength);
+            fs.Write(http.Response.PMessageBody^, http.Response.MessageBodyLength);
           finally
             fs.Free;
           end;
@@ -153,7 +155,7 @@ var
           Result := False;
           Exit;
       finally
-        Free;
+        http.Free;
       end;
     end;
 
@@ -235,6 +237,8 @@ var
   ucr: TUpdateCheckResponse;
   pkg: IKeymanPackage;
   downloadResult: boolean;
+  registry: TRegistryErrorControlled;
+  http: THttpUploader;
 begin
   {FProxyHost := '';
   FProxyPort := 0;}
@@ -248,16 +252,16 @@ begin
 
   { Verify that it has been at least 7 days since last update check }
   try
-    with TRegistryErrorControlled.Create do  // I2890
+    registry := TRegistryErrorControlled.Create;  // I2890
     try
-      if OpenKeyReadOnly(SRegKey_KeymanDesktop_CU) then
+      if registry.OpenKeyReadOnly(SRegKey_KeymanDesktop_CU) then
       begin
-        if ValueExists(SRegValue_CheckForUpdates) and not ReadBool(SRegValue_CheckForUpdates) and not FForce then
+        if registry.ValueExists(SRegValue_CheckForUpdates) and not registry.ReadBool(SRegValue_CheckForUpdates) and not FForce then
         begin
           Result := wucNoUpdates;
           Exit;
         end;
-        if ValueExists(SRegValue_LastUpdateCheckTime) and (Now - ReadDateTime(SRegValue_LastUpdateCheckTime) < 7) and not FForce then
+        if registry.ValueExists(SRegValue_LastUpdateCheckTime) and (Now - registry.ReadDateTime(SRegValue_LastUpdateCheckTime) < 7) and not FForce then
         begin
           Result := wucNoUpdates;
           // TODO: This exit is just to remove the time check for testing.
@@ -271,7 +275,7 @@ begin
         end;}
       end;
     finally
-      Free;
+      registry.Free;
     end;
   except
     { we will not run the check if an error occurs reading the settings }
@@ -286,13 +290,13 @@ begin
   Result := wucNoUpdates;
 
   try
-    with THTTPUploader.Create(nil) do
+    http := THTTPUploader.Create(nil);
     try
-      Fields.Add('version', ansistring(CKeymanVersionInfo.Version));
-      Fields.Add('tier', ansistring(CKeymanVersionInfo.Tier));
+      http.Fields.Add('version', ansistring(CKeymanVersionInfo.Version));
+      http.Fields.Add('tier', ansistring(CKeymanVersionInfo.Tier));
       if FForce
-        then Fields.Add('manual', '1')
-        else Fields.Add('manual', '0');
+        then http.Fields.Add('manual', '1')
+        else http.Fields.Add('manual', '0');
 
       for i := 0 to kmcom.Packages.Count - 1 do
       begin
@@ -301,24 +305,24 @@ begin
         // Due to limitations in PHP parsing of query string parameters names with
         // space or period, we need to split the parameters up. The legacy pattern
         // is still supported on the server side. Relates to #4886.
-        Fields.Add(AnsiString('packageid_'+IntToStr(i)), AnsiString(pkg.ID));
-        Fields.Add(AnsiString('packageversion_'+IntToStr(i)), AnsiString(pkg.Version));
+        http.Fields.Add(AnsiString('packageid_'+IntToStr(i)), AnsiString(pkg.ID));
+        http.Fields.Add(AnsiString('packageversion_'+IntToStr(i)), AnsiString(pkg.Version));
         pkg := nil;
       end;
 
-      Proxy.Server := GetProxySettings.Server;
-      Proxy.Port := GetProxySettings.Port;
-      Proxy.Username := GetProxySettings.Username;
-      Proxy.Password := GetProxySettings.Password;
+      http.Proxy.Server := GetProxySettings.Server;
+      http.Proxy.Port := GetProxySettings.Port;
+      http.Proxy.Username := GetProxySettings.Username;
+      http.Proxy.Password := GetProxySettings.Password;
 
-      Request.HostName := API_Server;
-      Request.Protocol := API_Protocol;
-      Request.UrlPath := API_Path_UpdateCheck_Windows;
+      http.Request.HostName := API_Server;
+      http.Request.Protocol := API_Protocol;
+      http.Request.UrlPath := API_Path_UpdateCheck_Windows;
       //OnStatus :=
-      Upload;
-      if Response.StatusCode = 200 then
+      http.Upload;
+      if http.Response.StatusCode = 200 then
       begin
-        if ucr.Parse(Response.MessageBodyAsString, 'bundle', CKeymanVersionInfo.Version) then
+        if ucr.Parse(http.Response.MessageBodyAsString, 'bundle', CKeymanVersionInfo.Version) then
         begin
           //ResponseToParams(ucr);
 
@@ -348,9 +352,9 @@ begin
         end;
       end
       else
-        raise ERemoteUpdateCheck.Create('Error '+IntToStr(Response.StatusCode));
+        raise ERemoteUpdateCheck.Create('Error '+IntToStr(http.Response.StatusCode));
     finally
-      Free;
+      http.Free;
     end;
   except
     on E:EHTTPUploader do
@@ -367,12 +371,12 @@ begin
     end;
   end;
 
-  with TRegistryErrorControlled.Create do  // I2890
+  registry := TRegistryErrorControlled.Create;  // I2890
   try
-    if OpenKey(SRegKey_KeymanDesktop_CU, True) then
-      WriteDateTime(SRegValue_LastUpdateCheckTime, Now);
+    if registry.OpenKey(SRegKey_KeymanDesktop_CU, True) then
+      registry.WriteDateTime(SRegValue_LastUpdateCheckTime, Now);
   finally
-    Free;
+    registry.Free;
   end;
 end;
 

--- a/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
@@ -1,20 +1,9 @@
-(*
-  Name:             WebUpdateCheck
-  Copyright:        Copyright (C) SIL International.
-  Documentation:
-  Description:
-  Create Date:      5 Dec 2023
-
-  Modified Date:
-  Authors:          rcruickshank
-  Related Files:
-  Dependencies:
-
-  Bugs:
-  Todo:
-  Notes:
-  History:
-*)
+{
+  * Keyman is copyright (C) SIL International. MIT License.
+  *
+  * Keyman.System.RemoteUpdateCheck: Checks for keyboard package and Keyman
+                                     for Windows updates.
+}
 unit Keyman.System.RemoteUpdateCheck;  // I3306
 
 interface
@@ -195,7 +184,7 @@ begin
     // Keyman Installer
     if not DownloadFile(Params.InstallURL, SavePath + Params.FileName) then  // I2742
     begin
-      // TODO record fail? and log  // Download failed but user wants to install other files
+      // TODO: #10210record fail? and log  // Download failed but user wants to install other files
     end
     else
     begin
@@ -264,7 +253,7 @@ begin
         if registry.ValueExists(SRegValue_LastUpdateCheckTime) and (Now - registry.ReadDateTime(SRegValue_LastUpdateCheckTime) < 7) and not FForce then
         begin
           Result := wucNoUpdates;
-          // TODO: This exit is just to remove the time check for testing.
+          // TODO: #10210 This exit is just to remove the time check for testing.
           //Exit;
         end;
 
@@ -328,11 +317,10 @@ begin
 
           if FCheckOnly then
           begin
-            // TODO: Refactor this
             TUpdateCheckStorage.SaveUpdateCacheData(ucr);
             Result := FRemoteResult;
           end
-          // TODO: #10038
+          // TODO: ##10210
           // Integerate into state machine. in the download state
           // the process can call LoadUpdateCacheData if needed to get the
           // response result.

--- a/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
@@ -140,11 +140,11 @@ var
         Upload;
         if Response.StatusCode = 200 then
         begin
-          with TFileStream.Create(savepath, fmCreate) do
+          fs := TFileStream.Create(savepath, fmCreate);
           try
-            Write(Response.PMessageBody^, Response.MessageBodyLength);
+            fs.Write(Response.PMessageBody^, Response.MessageBodyLength);
           finally
-            Free;
+            fs.Free;
           end;
           Result := True;
         end
@@ -167,11 +167,11 @@ begin
 
     // Keyboard Packages
     for i := 0 to High(Params.Packages) do
-      begin
-        Inc(FDownload.TotalDownloads);
-        Inc(FDownload.TotalSize, Params.Packages[i].DownloadSize);
-        Params.Packages[i].SavePath := SavePath + Params.Packages[i].FileName;
-      end;
+    begin
+      Inc(FDownload.TotalDownloads);
+      Inc(FDownload.TotalSize, Params.Packages[i].DownloadSize);
+      Params.Packages[i].SavePath := SavePath + Params.Packages[i].FileName;
+    end;
 
     // Add the Keyman installer
     Inc(FDownload.TotalDownloads);
@@ -190,7 +190,7 @@ begin
         FDownload.StartPosition := FDownload.StartPosition + Params.Packages[i].DownloadSize;
       end;
 
-    // Keyamn Installer
+    // Keyman Installer
     if not DownloadFile(Params.InstallURL, SavePath + Params.FileName) then  // I2742
     begin
       // TODO record fail? and log  // Download failed but user wants to install other files
@@ -201,8 +201,8 @@ begin
     end;
 
     // There needs to be at least one file successfully downloaded to return
-    // TRUE that files where downloaded
-    if downloadCount > 0  then
+    // True that files were downloaded
+    if downloadCount > 0 then
       Result := True;
   except
     on E:EHTTPUploader do

--- a/windows/src/desktop/kmshell/main/RemoteUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/RemoteUpdateCheck.pas
@@ -1,0 +1,460 @@
+(*
+  Name:             WebUpdateCheck
+  Copyright:        Copyright (C) SIL International.
+  Documentation:
+  Description:
+  Create Date:      5 Dec 2023
+
+  Modified Date:
+  Authors:          rcruickshank
+  Related Files:
+  Dependencies:
+
+  Bugs:
+  Todo:
+  Notes:
+  History:
+*)
+unit RemoteUpdateCheck;  // I3306
+
+interface
+
+uses
+  System.Classes,
+  System.SysUtils,
+  System.UITypes,
+  System.IOUtils,
+  Vcl.Forms,
+  KeymanPaths,
+
+  httpuploader,
+  Keyman.System.UpdateCheckResponse,
+  UfrmDownloadProgress,
+  OnlineUpdateCheck;
+
+type
+  ERemoteUpdateCheck = class(Exception);
+
+  TRemoteUpdateCheckResult = (wucUnknown, wucSuccess, wucNoUpdates, wucFailure, wucOffline);
+
+  TRemoteUpdateCheckParams = record
+    Keyman: TOnlineUpdateCheckParamsKeyman;
+    Packages: array of TOnlineUpdateCheckParamsPackage;
+    Result: TRemoteUpdateCheckResult;
+  end;
+
+  TRemoteUpdateCheckDownloadParams = record
+    TotalSize: Integer;
+    TotalDownloads: Integer;
+    StartPosition: Integer;
+  end;
+
+  TRemoteUpdateCheck = class
+  private
+    FForce: Boolean;
+    FParams: TRemoteUpdateCheckParams;
+
+    FErrorMessage: string;
+
+    FShowErrors: Boolean;
+    FDownload: TRemoteUpdateCheckDownloadParams;
+    FCheckOnly: Boolean;
+
+    function DownloadUpdates: Boolean;
+    procedure DoDownloadUpdates(SavePath: string; var Result: Boolean);
+    function DoRun: TRemoteUpdateCheckResult;
+  public
+    function ResponseToParams(const ucr: TUpdateCheckResponse): TRemoteUpdateCheckParams;
+
+    constructor Create(AForce : Boolean; ACheckOnly: Boolean = False);
+    destructor Destroy; override;
+    function Run: TRemoteUpdateCheckResult;
+    property ShowErrors: Boolean read FShowErrors write FShowErrors;
+  end;
+
+procedure LogMessage(LogMessage: string);
+
+implementation
+
+uses
+  System.WideStrUtils,
+  Vcl.Dialogs,
+  Winapi.ShellApi,
+  Winapi.Windows,
+  Winapi.WinINet,
+
+  GlobalProxySettings,
+  KLog,
+  keymanapi_TLB,
+  KeymanVersion,
+  Keyman.System.UpdateCheckStorage,
+  kmint,
+  ErrorControlledRegistry,
+  RegistryKeys,
+  Upload_Settings,
+  utildir,
+  utilexecute,
+  OnlineUpdateCheckMessages,
+  UfrmOnlineUpdateIcon,
+  UfrmOnlineUpdateNewVersion,
+  utilkmshell,
+  utilsystem,
+  utiluac,
+  versioninfo;
+
+{ TRemoteUpdateCheck }
+
+constructor TRemoteUpdateCheck.Create(AForce, ACheckOnly: Boolean);
+begin
+  inherited Create;
+
+  FShowErrors := True;
+  FParams.Result := wucUnknown;
+
+  FForce := AForce;
+  FCheckOnly := ACheckOnly;
+
+  KL.Log('TRemoteUpdateCheck.Create');
+end;
+
+destructor TRemoteUpdateCheck.Destroy;
+begin
+  if (FErrorMessage <> '') and FShowErrors then
+    LogMessage(FErrorMessage);
+
+  KL.Log('TRemoteUpdateCheck.Destroy: FErrorMessage = '+FErrorMessage);
+  KL.Log('TRemoteUpdateCheck.Destroy: FParams.Result = '+IntToStr(Ord(FParams.Result)));
+
+  inherited Destroy;
+end;
+
+function TRemoteUpdateCheck.Run: TRemoteUpdateCheckResult;
+begin
+  Result := DoRun;
+
+  if Result in [ wucSuccess] then
+  begin
+    kmcom.Keyboards.Refresh;
+    kmcom.Keyboards.Apply;
+    kmcom.Packages.Refresh;
+  end;
+
+  FParams.Result := Result;
+end;
+
+
+procedure TRemoteUpdateCheck.DoDownloadUpdates(SavePath: string; var Result: Boolean);
+var
+  i, downloadCount: Integer;
+
+    function DownloadFile(const url, savepath: string): Boolean;
+    begin
+      Result := False;
+      with THttpUploader.Create(nil) do
+      try
+        Proxy.Server := GetProxySettings.Server;
+        Proxy.Port := GetProxySettings.Port;
+        Proxy.Username := GetProxySettings.Username;
+        Proxy.Password := GetProxySettings.Password;
+        Request.Agent := API_UserAgent;
+
+        Request.SetURL(url);
+        Upload;
+        if Response.StatusCode = 200 then
+        begin
+          with TFileStream.Create(savepath, fmCreate) do
+          try
+            Write(Response.PMessageBody^, Response.MessageBodyLength);
+          finally
+            Free;
+          end;
+          Result := True;
+        end
+        else // I2742
+          // If it fails we set to false but will try the other files
+          Result := False;
+          Exit;
+      finally
+        Free;
+      end;
+    end;
+
+
+begin
+  Result := False;
+  try
+    FDownload.TotalSize := 0;
+    FDownload.TotalDownloads := 0;
+    downloadCount := 0;
+
+    for i := 0 to High(FParams.Packages) do
+      if FParams.Packages[i].Install then
+      begin
+        Inc(FDownload.TotalDownloads);
+        Inc(FDownload.TotalSize, FParams.Packages[i].DownloadSize);
+
+        FParams.Packages[i].SavePath := SavePath + FParams.Packages[i].FileName;
+      end;
+
+    if FParams.Keyman.Install then
+    begin
+      Inc(FDownload.TotalDownloads);
+      Inc(FDownload.TotalSize, FParams.Keyman.DownloadSize);
+      FParams.Keyman.SavePath := SavePath + FParams.Keyman.FileName;
+    end;
+
+    FDownload.StartPosition := 0;
+    for i := 0 to High(FParams.Packages) do
+      if FParams.Packages[i].Install then
+      begin
+        if not DownloadFile(FParams.Packages[i].DownloadURL, FParams.Packages[i].SavePath) then // I2742
+        begin
+          FParams.Packages[i].Install := False; // Download failed but install other files
+        end
+        else
+          Inc(downloadCount);
+        FDownload.StartPosition := FDownload.StartPosition + FParams.Packages[i].DownloadSize;
+      end;
+
+    if FParams.Keyman.Install then
+      if not DownloadFile(FParams.Keyman.DownloadURL, FParams.Keyman.SavePath) then  // I2742
+      begin
+        FParams.Keyman.Install := False;  // Download failed but user wants to install other files
+      end;
+
+    // There needs to be at least one file successfully downloaded to return
+    // TRUE that files where downloaded
+    if downloadCount > 0  then
+      Result := True;
+  except
+    on E:EHTTPUploader do
+    begin
+      if (E.ErrorCode = 12007) or (E.ErrorCode = 12029)
+        then LogMessage(S_OnlineUpdate_UnableToContact)
+        else LogMessage(WideFormat(S_OnlineUpdate_UnableToContact_Error, [E.Message]));
+      Result := False;
+    end;
+  end;
+end;
+
+function TRemoteUpdateCheck.DownloadUpdates: Boolean;
+var
+  i: Integer;
+  DownloadBackGroundSavePath : String;
+  DownloadResult : Boolean;
+begin
+  DownloadBackGroundSavePath := IncludeTrailingPathDelimiter(TKeymanPaths.KeymanUpdateCachePath);
+  { For now lets download all the updates. Set all as true }
+
+  if FParams.Keyman.DownloadURL <> '' then
+    FParams.Keyman.Install := True;
+
+  for i := 0 to High(FParams.Packages) do
+    FParams.Packages[i].Install := True;
+
+  DoDownloadUpdates(DownloadBackGroundSavePath, DownloadResult);
+  KL.Log('TRemoteUpdateCheck.DownloadUpdatesBackground: DownloadResult = '+IntToStr(Ord(DownloadResult)));
+  Result := DownloadResult;
+
+end;
+
+function TRemoteUpdateCheck.DoRun: TRemoteUpdateCheckResult;
+var
+  flags: DWord;
+  i: Integer;
+  ucr: TUpdateCheckResponse;
+  pkg: IKeymanPackage;
+  downloadResult: boolean;
+begin
+  {FProxyHost := '';
+  FProxyPort := 0;}
+
+  { Check if user is currently online }
+  if not InternetGetConnectedState(@flags, 0) then
+  begin
+    Result := wucOffline;
+    Exit;
+  end;
+
+  { Verify that it has been at least 7 days since last update check }
+  try
+    with TRegistryErrorControlled.Create do  // I2890
+    try
+      if OpenKeyReadOnly(SRegKey_KeymanDesktop_CU) then
+      begin
+        if ValueExists(SRegValue_CheckForUpdates) and not ReadBool(SRegValue_CheckForUpdates) and not FForce then
+        begin
+          Result := wucNoUpdates;
+          Exit;
+        end;
+        if ValueExists(SRegValue_LastUpdateCheckTime) and (Now - ReadDateTime(SRegValue_LastUpdateCheckTime) < 7) and not FForce then
+        begin
+          Result := wucNoUpdates;
+          // TODO: This exit is just to remove the time check for testing.
+          //Exit;
+        end;
+
+        {if ValueExists(SRegValue_UpdateCheck_UseProxy) and ReadBool(SRegValue_UpdateCheck_UseProxy) then
+        begin
+          FProxyHost := ReadString(SRegValue_UpdateCheck_ProxyHost);
+          FProxyPort := StrToIntDef(ReadString(SRegValue_UpdateCheck_ProxyPort), 80);
+        end;}
+      end;
+    finally
+      Free;
+    end;
+  except
+    { we will not run the check if an error occurs reading the settings }
+    on E:Exception do
+    begin
+      Result := wucFailure;
+      FErrorMessage := E.Message;
+      Exit;
+    end;
+  end;
+
+  Result := wucNoUpdates;
+
+  try
+    with THTTPUploader.Create(nil) do
+    try
+      Fields.Add('version', ansistring(CKeymanVersionInfo.Version));
+      Fields.Add('tier', ansistring(CKeymanVersionInfo.Tier));
+      if FForce
+        then Fields.Add('manual', '1')
+        else Fields.Add('manual', '0');
+
+      for i := 0 to kmcom.Packages.Count - 1 do
+      begin
+        pkg := kmcom.Packages[i];
+
+        // Due to limitations in PHP parsing of query string parameters names with
+        // space or period, we need to split the parameters up. The legacy pattern
+        // is still supported on the server side. Relates to #4886.
+        Fields.Add(AnsiString('packageid_'+IntToStr(i)), AnsiString(pkg.ID));
+        Fields.Add(AnsiString('packageversion_'+IntToStr(i)), AnsiString(pkg.Version));
+        pkg := nil;
+      end;
+
+      Proxy.Server := GetProxySettings.Server;
+      Proxy.Port := GetProxySettings.Port;
+      Proxy.Username := GetProxySettings.Username;
+      Proxy.Password := GetProxySettings.Password;
+
+      Request.HostName := API_Server;
+      Request.Protocol := API_Protocol;
+      Request.UrlPath := API_Path_UpdateCheck_Windows;
+      //OnStatus :=
+      Upload;
+      if Response.StatusCode = 200 then
+      begin
+        if ucr.Parse(Response.MessageBodyAsString, 'bundle', CKeymanVersionInfo.Version) then
+        begin
+          ResponseToParams(ucr);
+
+          if FCheckOnly then
+          begin
+            // TODO: Refactor this
+            TUpdateCheckStorage.SaveUpdateCacheData(ucr);
+            Result := FParams.Result;
+          end
+          else if (Length(FParams.Packages) > 0) or (FParams.Keyman.DownloadURL <> '') then
+          begin
+            // TODO: Integrate in to the Background update state machine.
+            // for now just go straight to DownloadUpdates
+            downloadResult := DownloadUpdates;
+            if DownloadResult then
+            begin
+              Result := wucSuccess;
+            end;
+          end;
+        end
+        else
+        begin
+          FErrorMessage := ucr.ErrorMessage;
+          Result := wucFailure;
+        end;
+      end
+      else
+        raise ERemoteUpdateCheck.Create('Error '+IntToStr(Response.StatusCode));
+    finally
+      Free;
+    end;
+  except
+    on E:EHTTPUploader do
+    begin
+      if (E.ErrorCode = 12007) or (E.ErrorCode = 12029)
+        then FErrorMessage := S_OnlineUpdate_UnableToContact
+        else FErrorMessage := WideFormat(S_OnlineUpdate_UnableToContact_Error, [E.Message]);
+      Result := wucFailure;
+    end;
+    on E:Exception do
+    begin
+      FErrorMessage := E.Message;
+      Result := wucFailure;
+    end;
+  end;
+
+  with TRegistryErrorControlled.Create do  // I2890
+  try
+    if OpenKey(SRegKey_KeymanDesktop_CU, True) then
+      WriteDateTime(SRegValue_LastUpdateCheckTime, Now);
+  finally
+    Free;
+  end;
+end;
+
+function TRemoteUpdateCheck.ResponseToParams(const ucr: TUpdateCheckResponse): TRemoteUpdateCheckParams;
+var
+  i, j, n: Integer;
+  pkg: IKeymanPackage;
+begin
+  SetLength(FParams.Packages,0);
+  for i := Low(ucr.Packages) to High(ucr.Packages) do
+  begin
+    n := kmcom.Packages.IndexOf(ucr.Packages[i].ID);
+    if n >= 0 then
+    begin
+      pkg := kmcom.Packages[n];
+      j := Length(FParams.Packages);
+      SetLength(FParams.Packages, j+1);
+      FParams.Packages[j].NewID := ucr.Packages[i].NewID;
+      FParams.Packages[j].ID := ucr.Packages[i].ID;
+      FParams.Packages[j].Description := ucr.Packages[i].Name;
+      FParams.Packages[j].OldVersion := pkg.Version;
+      FParams.Packages[j].NewVersion := ucr.Packages[i].NewVersion;
+      FParams.Packages[j].DownloadSize := ucr.Packages[i].DownloadSize;
+      FParams.Packages[j].DownloadURL := ucr.Packages[i].DownloadURL;
+      FParams.Packages[j].FileName := ucr.Packages[i].FileName;
+      pkg := nil;
+    end
+    else
+      FErrorMessage := 'Unable to find package '+ucr.Packages[i].ID;
+  end;
+
+  case ucr.Status of
+    ucrsNoUpdate:
+      begin
+        FErrorMessage := ucr.ErrorMessage;
+      end;
+    ucrsUpdateReady:
+      begin
+        FParams.Keyman.OldVersion := ucr.CurrentVersion;
+        FParams.Keyman.NewVersion := ucr.NewVersion;
+        FParams.Keyman.DownloadURL := ucr.InstallURL;
+        FParams.Keyman.DownloadSize := ucr.InstallSize;
+        FParams.Keyman.FileName := ucr.FileName;
+      end;
+  end;
+
+  Result := FParams;
+end;
+
+ // temp wrapper for converting showmessage to logs don't know where
+ // if nt using klog
+ procedure LogMessage(LogMessage: string);
+ begin
+   KL.Log(LogMessage);
+ end;
+
+end.

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -82,6 +82,7 @@ type
                     fmMigrate, fmSplash, fmStart,
                     fmUpgradeKeyboards, fmOnlineUpdateCheck,// I2548
                     fmOnlineUpdateAdmin, fmTextEditor,
+                    fmBackgroundUpdateCheck,
                     fmFirstRun, // I2562
                     fmKeyboardWelcome,  // I2569
                     fmKeyboardPrint,  // I2329
@@ -120,6 +121,7 @@ uses
   KMShellHints,
   KeymanMutex,
   OnlineUpdateCheck,
+  RemoteUpdateCheck,
   RegistryKeys,
   UfrmBaseKeyboard,
   UfrmKeymanBase,
@@ -249,6 +251,7 @@ begin
       else if s = '-h'   then FMode := fmHelp
       else if s = '-t'   then FMode := fmTextEditor
       else if s = '-ouc' then FMode := fmOnlineUpdateCheck
+      else if s = '-buc' then FMode := fmBackgroundUpdateCheck
       else if s = '-basekeyboard' then FMode := fmBaseKeyboard   // I4169
       else if s = '-nowelcome'   then FNoWelcome := True
       else if s = '-kw' then FMode := fmKeyboardWelcome  // I2569
@@ -427,6 +430,19 @@ begin
     ShowMessage(MsgFromId(SKOSNotSupported));
     Exit;
   end;
+  // TODO: #10038  Will add this as part of the background update state machine
+  // for now just verifing the download happens via -buc switch.
+  with TRemoteUpdateCheck.Create(False, False) do
+    try
+      if (FMode = fmBackgroundUpdateCheck) then
+      begin
+        Run;
+        Exit;
+      end
+    finally
+      Free;
+    end;
+
 
   if not FSilent or (FMode = fmUpgradeMnemonicLayout) then   // I4553
   begin

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -384,6 +384,7 @@ var
   kdl: IKeymanDefaultLanguage;
   FIcon: string;
   FMutex: TKeymanMutex;  // I2720
+  RemoteUpdateCheck: TRemoteUpdateCheck;
     function FirstKeyboardFileName: WideString;
     begin
       if KeyboardFileNames.Count = 0
@@ -432,15 +433,15 @@ begin
   end;
   // TODO: #10038  Will add this as part of the background update state machine
   // for now just verifing the download happens via -buc switch.
-  with TRemoteUpdateCheck.Create(False, False) do
+  RemoteUpdateCheck := TRemoteUpdateCheck.Create(False, False);
     try
       if (FMode = fmBackgroundUpdateCheck) then
       begin
-        Run;
+        RemoteUpdateCheck.Run;
         Exit;
       end
     finally
-      Free;
+      RemoteUpdateCheck.Free;
     end;
 
 

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -121,7 +121,7 @@ uses
   KMShellHints,
   KeymanMutex,
   OnlineUpdateCheck,
-  RemoteUpdateCheck,
+  Keyman.System.RemoteUpdateCheck,
   RegistryKeys,
   UfrmBaseKeyboard,
   UfrmKeymanBase,

--- a/windows/src/desktop/kmshell/render/UpdateXMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/UpdateXMLRenderer.pas
@@ -30,7 +30,6 @@ uses
   Keyman.System.UpdateCheckStorage,
   MessageIdentifierConsts,
   MessageIdentifiers,
-  OnlineUpdateCheck,
   utilxml;
 
 { TUpdateXMLRenderer }
@@ -39,48 +38,51 @@ function TUpdateXMLRenderer.XMLData: WideString;
 var
   xml: string;
   ucr: TUpdateCheckResponse;
-  ouc: TOnlineUpdateCheck;
-  params: TOnlineUpdateCheckParams;
-  i: Integer;
+  i, n : Integer;
+  pkg: IKeymanPackage;
 begin
   xml := '';
 
   if TUpdateCheckStorage.LoadUpdateCacheData(ucr) then
   begin
-    ouc := TOnlineUpdateCheck.Create(nil, False, True);
-    params := ouc.ResponseToParams(ucr);
-
-    if (Params.Keyman.DownloadURL <> '') then
+    if (ucr.InstallURL <> '') then
     begin
       xml := xml +
         '<Update>'+
           '<index>0</index>'+
           IfThen(not kmcom.SystemInfo.IsAdministrator, '<RequiresAdmin />')+
           '<Keyman>'+
-            '<Text>'+xmlencode(TLocaleStrings.MsgFromIdFormat(kmcom, SKUpdate_KeymanText, [Params.Keyman.NewVersion]))+'</Text>'+
-            '<NewVersion>'+xmlencode(Params.Keyman.NewVersion)+'</NewVersion>'+
-            '<OldVersion>'+xmlencode(Params.Keyman.OldVersion)+'</OldVersion>'+
-            '<DownloadSize>'+xmlencode(Format('%d', [Params.Keyman.DownloadSize div 1024]))+'KB</DownloadSize>'+
-            '<DownloadURL>'+xmlencode(Params.Keyman.DownloadURL)+'</DownloadURL>'+
+            '<Text>'+xmlencode(TLocaleStrings.MsgFromIdFormat(kmcom, SKUpdate_KeymanText, [ucr.NewVersion]))+'</Text>'+
+            '<NewVersion>'+xmlencode(ucr.NewVersion)+'</NewVersion>'+
+            '<OldVersion>'+xmlencode(ucr.CurrentVersion)+'</OldVersion>'+
+            '<DownloadSize>'+xmlencode(Format('%d', [ucr.InstallSize div 1024]))+'KB</DownloadSize>'+
+            '<DownloadURL>'+xmlencode(ucr.InstallURL)+'</DownloadURL>'+
           '</Keyman>'+
         '</Update>';
     end;
 
-    for i := 0 to High(Params.Packages) do
+    for i := 0 to High(ucr.Packages) do
     begin
-      xml := xml +
-        '<Update>'+
-          '<index>'+IntToStr(i+1)+'</index>'+
-          IfThen(not kmcom.SystemInfo.IsAdministrator, '<RequiresAdmin />')+
-          '<Package>'+
-            '<Text>'+xmlencode(TLocaleStrings.MsgFromIdFormat(kmcom, SKUpdate_PackageText,
-              [Params.Packages[i].Description, Params.Packages[i].NewVersion]))+'</Text>'+
-            '<NewVersion>'+xmlencode(Params.Packages[i].NewVersion)+'</NewVersion>'+
-            '<OldVersion>'+xmlencode(Params.Packages[i].OldVersion)+'</OldVersion>'+
-            '<DownloadSize>'+xmlencode(Format('%d', [Params.Packages[i].DownloadSize div 1024]))+'KB</DownloadSize>'+
-            '<DownloadURL>'+xmlencode(Params.Packages[i].DownloadURL)+'</DownloadURL>'+
-          '</Package>'+
-        '</Update>';
+      n := kmcom.Packages.IndexOf(ucr.Packages[i].ID);
+      if n >= 0 then
+      pkg := kmcom.Packages[n];
+      begin
+        xml := xml +
+          '<Update>'+
+            '<index>'+IntToStr(i+1)+'</index>'+
+            IfThen(not kmcom.SystemInfo.IsAdministrator, '<RequiresAdmin />')+
+            '<Package>'+
+              '<Text>'+xmlencode(TLocaleStrings.MsgFromIdFormat(kmcom, SKUpdate_PackageText,
+                [ucr.Packages[i].Name, ucr.Packages[i].NewVersion]))+'</Text>'+
+              '<NewVersion>'+xmlencode(ucr.Packages[i].NewVersion)+'</NewVersion>'+
+              '<OldVersion>'+xmlencode(pkg.version)+'</OldVersion>'+
+              '<DownloadSize>'+xmlencode(Format('%d', [ucr.Packages[i].DownloadSize div 1024]))+'KB</DownloadSize>'+
+              '<DownloadURL>'+xmlencode(ucr.Packages[i].DownloadURL)+'</DownloadURL>'+
+            '</Package>'+
+          '</Update>';
+        pkg := nil;
+      end;
+      // else Package not found, skip
     end;
   end;
 


### PR DESCRIPTION
This is just first step in #10038 
Fixes:   #10119

I discovered

- [x] - Remove all UI calls from it and use callbacks
           Not going to use call backs at all at this stage.
- [x] -  Keep parsing separate
            For now I have this testing with `kmshell.exe -buc` I will have this separated more in the next PR
- [x] -  Consider merging TOnlineUpdateCheckParams and TUpdateCheckResponse
            This I think can be done I just have a question around `old version` it seems that we don't want to use the old version in the Response. Probably because it is just the "previous" version. Where as the version currently installed could be even older. We could make the Fparams of type `TUpdateCheckResponse`  as the only other piece of data we would lose is a`TRemoteUpdateCheckResult` which I will not be using.

- [x] -  Figure out how SPackageUpgradeFilename is used for upgrading packages and how it fits into the new check/download, with later install model
     This was just flat file for recording the file names of the packages in the temporary data location in the case when the elevated call was required.  We now have all the information we need in the `cache.json`

@keymanapp-test-bot skip
