### PR TITLE
feat(web): gesture processing - path memory-use optimization 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/configuration/gestureRecognizerConfiguration.ts
+++ b/common/web/gesture-recognizer/src/engine/configuration/gestureRecognizerConfiguration.ts
@@ -91,6 +91,13 @@ export interface GestureRecognizerConfiguration<HoveredItemType, StateToken = an
    * @returns
    */
   readonly itemIdentifier?: ItemIdentifier<HoveredItemType, StateToken>;
+
+  /**
+   * When `true`, the engine will persistently record all coordinates visited by each `GestureSource`
+   * during its lifetime.  This is useful for debugging and for generating input recordings for
+   * use in automated testing.
+   */
+  readonly recordingMode?: boolean;
 }
 
 export function preprocessRecognizerConfig<HoveredItemType, StateToken = any>(
@@ -108,6 +115,7 @@ export function preprocessRecognizerConfig<HoveredItemType, StateToken = any>(
   processingConfig.safeBounds       = processingConfig.safeBounds       ?? new PaddedZoneSource([2]);
 
   processingConfig.itemIdentifier   = processingConfig.itemIdentifier   ?? (() => null);
+  processingConfig.recordingMode = !!processingConfig.recordingMode;
 
   if(!config.paddedSafeBounds) {
     let paddingArray = config.safeBoundPadding;

--- a/common/web/gesture-recognizer/src/engine/headless/gestureDebugPath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestureDebugPath.ts
@@ -94,7 +94,7 @@ export class GestureDebugPath<Type, StateToken = any> extends GesturePath<Type, 
   public translateCoordSystem(functor: (sample: InputSample<Type, StateToken>) => InputSample<Type, StateToken>) {
     super.translateCoordSystem(functor);
 
-    for(let i=0; i < this.coords.length; i++) {
+    for(let i=0; i < this.samples.length; i++) {
       this.samples[i] = functor(this.samples[i]);
     }
   }

--- a/common/web/gesture-recognizer/src/engine/headless/gestureDebugPath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestureDebugPath.ts
@@ -1,0 +1,140 @@
+import { InputSample } from "./inputSample.js";
+import { CumulativePathStats } from "./cumulativePathStats.js";
+import { Mutable } from "../mutable.js";
+import { GesturePath } from "./gesturePath.js";
+
+/**
+ * Documents the expected typing of serialized versions of the `GesturePath` class.
+ */
+export type SerializedGesturePath<Type, StateToken> = {
+  coords: Mutable<InputSample<Type, StateToken>>[]; // ensures type match with public class property.
+  wasCancelled?: boolean;
+}
+
+interface EventMap<Type, StateToken> {
+  'step': (sample: InputSample<Type, StateToken>) => void,
+  'complete': () => void,
+  'invalidated': () => void
+}
+
+/**
+ * Models the path over time through coordinate space taken by a touchpoint during
+ * its active lifetime.
+ *
+ *  _Supported events_:
+ *
+ * `'step'`: a new Event has been observed for this touchpoint, extending the path.
+ * - Parameters:
+ *   - `sample: InputSample` - the coordinate & timestamp of the new observation.
+ *
+ * `'complete'`: the touchpoint is no longer active; a touch-end has been observed.
+ *   - Provides no parameters.
+ *   - Will be the last event raised by its instance, after any final 'segmentation'
+ *     events.
+ *   - Still precedes resolution Promise fulfillment on the `Segment` provided by
+ *     the most recently-preceding 'segmentation' event.
+ *     - And possibly recognition Promise fulfillment.
+ *
+ * `'invalidated'`: the touchpoint is no longer active; the path has crossed
+ * gesture-recognition boundaries and is no longer considered valid.
+ *   - Provides no parameters.
+ *   - Will precede the final 'segmentation' event for the 'end' segment
+ *   - Will precede resolution Promise fulfillment on the `Segment` provided by
+ *     the most recently-preceding 'segmentation' event.
+ *     - And possibly recognition Promise fulfillment.
+ */
+export class GestureDebugPath<Type, StateToken = any> extends GesturePath<Type, StateToken> {
+  private samples: InputSample<Type, StateToken>[] = [];
+
+  public clone(): GestureDebugPath<Type, StateToken> {
+    const instance = new GestureDebugPath<Type, StateToken>();
+    instance.samples = [].concat(this.samples);
+
+    instance._isComplete = this._isComplete;
+    instance._wasCancelled = this._wasCancelled;
+    instance._stats = new CumulativePathStats<Type>(this._stats);
+
+    return instance;
+  }
+
+  /**
+   * Deserializes a GesturePath instance from its corresponding JSON.parse() object.
+   * @param jsonObj
+   */
+  static deserialize<Type, StateToken>(jsonObj: SerializedGesturePath<Type, StateToken>): GestureDebugPath<Type, StateToken> {
+    const instance = new GestureDebugPath<Type, StateToken>();
+
+    instance.samples = [].concat(jsonObj.coords.map((obj) => ({...obj} as InputSample<Type, StateToken>)));
+    instance._isComplete = true;
+    instance._wasCancelled = jsonObj.wasCancelled;
+
+    let stats = instance.samples.reduce((stats: CumulativePathStats<Type>, sample) => stats.extend(sample), new CumulativePathStats<Type>());
+    instance._stats = stats;
+
+    return instance;
+  }
+
+  /**
+   * Extends the path with a newly-observed coordinate.
+   * @param sample
+   */
+  extend(sample: InputSample<Type, StateToken>) {
+    /* c8 ignore next 3 */
+    if(this.isComplete) {
+      throw new Error("Invalid state:  this GesturePath has already terminated.");
+    }
+
+    // The tracked path should emit InputSample events before Segment events and
+    // resolution of Segment Promises.
+    this.samples.push(sample);
+    super.extend(sample);
+  }
+
+
+  public translateCoordSystem(functor: (sample: InputSample<Type, StateToken>) => InputSample<Type, StateToken>) {
+    super.translateCoordSystem(functor);
+
+    for(let i=0; i < this.coords.length; i++) {
+      this.samples[i] = functor(this.samples[i]);
+    }
+  }
+
+  /**
+   * Returns all coordinate + timestamp pairings observed for the corresponding
+   * touchpoint's path over its lifetime thus far.
+   */
+  public get coords(): readonly InputSample<Type, StateToken>[] {
+    return this.samples;
+  }
+
+  /**
+   * Creates a serialization-friendly version of this instance for use by
+   * `JSON.stringify`.
+   */
+  toJSON() {
+    let jsonClone: SerializedGesturePath<Type, StateToken> = {
+      // Replicate array and its entries, but with certain fields of each entry missing.
+      // No .clientX, no .clientY.
+      coords: [].concat(this.samples.map((obj) => ({
+        targetX: obj.targetX,
+        targetY: obj.targetY,
+        t:       obj.t,
+        item:    obj.item
+      }))),
+      wasCancelled: this.wasCancelled
+    }
+
+    // Removes components of each sample that we don't want serialized.
+    for(let sample of jsonClone.coords) {
+      delete sample.clientX;
+      delete sample.clientY;
+
+      // No point in serializing an `undefined` 'item' entry.
+      if(sample.item === undefined) {
+        delete sample.item;
+      }
+    }
+
+    return jsonClone;
+  }
+}

--- a/common/web/gesture-recognizer/src/engine/headless/gestureDebugSource.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestureDebugSource.ts
@@ -1,0 +1,99 @@
+import { InputSample } from "./inputSample.js";
+import { GestureRecognizerConfiguration, preprocessRecognizerConfig } from "../configuration/gestureRecognizerConfiguration.js";
+import { Nonoptional } from "../nonoptional.js";
+import { MatcherSelector } from "./gestures/matchers/matcherSelector.js";
+import { SerializedGesturePath, GestureDebugPath } from "./gestureDebugPath.js";
+import { GestureSource } from "./gestureSource.js";
+
+/**
+ * Documents the expected typing of serialized versions of the `GestureSource` class.
+ */
+export type SerializedGestureSource<HoveredItemType = any, StateToken = any> = {
+  isFromTouch: boolean;
+  path: SerializedGesturePath<HoveredItemType, StateToken>;
+  // identifier is not included b/c it's only needed during live processing.
+}
+
+/**
+ * Represents all metadata needed internally for tracking a single "touch contact point" / "touchpoint"
+ * involved in a potential / recognized gesture as tracked over time.
+ *
+ * Each instance corresponds to one unique contact point as recognized by `Touch.identifier` or to
+ * one 'cursor-point' as represented by mouse-based motion.
+ *
+ * Refer to https://developer.mozilla.org/en-US/docs/Web/API/Touch and
+ * https://developer.mozilla.org/en-US/docs/Web/API/Navigator/maxTouchPoints re "touch contact point".
+ *
+ * May be one-to-many with recognized gestures:  a keyboard longpress interaction generally only has one
+ * contact point but will have multiple realized gestures / components:
+ * - longpress:  Enough time has elapsed
+ * - subkey:  Subkey from the longpress subkey menu has been selected.
+ *
+ * Thus, it is a "gesture source".  This is the level needed to model a single contact point, while some
+ * gestures expect multiple, hence "simple".
+ *
+ */
+export class GestureDebugSource<HoveredItemType, StateToken=any> extends GestureSource<HoveredItemType, StateToken, GestureDebugPath<HoveredItemType, StateToken>> {
+  // Assertion:  must always contain an index 0 - the base recognizer config.
+  protected recognizerConfigStack: Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>[];
+
+  private static _jsonIdSeed: -1;
+
+  /**
+   * Usable by the gesture-recognizer library's consumer to track a token identifying specific states
+   * of the consuming system if desired.
+   */
+  public stateToken: StateToken = null;
+
+  /**
+   * Constructs a new GestureDebugSource instance for tracking updates to an active input point over time.
+   * @param identifier     The system identifier for the input point's events.
+   * @param initialHoveredItem  The initiating event's original target element
+   * @param isFromTouch    `true` if sourced from a `TouchEvent`; `false` otherwise.
+   */
+  constructor(
+    identifier: number,
+    recognizerConfig: Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>
+      | Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>[],
+    isFromTouch: boolean
+  ) {
+    super(identifier, recognizerConfig, isFromTouch, GestureDebugPath);
+  }
+
+  protected initPath(): GestureDebugPath<HoveredItemType, StateToken> {
+    return new GestureDebugPath();
+  }
+
+  /**
+   * Deserializes a GestureSource instance from its serialized-JSON form.
+   * @param jsonObj  The JSON representation to deserialize.
+   * @param identifier The unique identifier to assign to this instance.
+   */
+  public static deserialize(jsonObj: SerializedGestureSource, identifier: number) {
+    const id = identifier !== undefined ? identifier : this._jsonIdSeed++;
+    const isFromTouch = jsonObj.isFromTouch;
+    const path = GestureDebugPath.deserialize(jsonObj.path);
+
+    const instance = new GestureDebugSource(id, null, isFromTouch);
+    instance._path = path;
+    return instance;
+  }
+
+  /**
+   * Creates a serialization-friendly version of this instance for use by
+   * `JSON.stringify`.
+   */
+  /* c8 ignore start */
+  toJSON(): SerializedGestureSource {
+    const path = this.path as GestureDebugPath<HoveredItemType, StateToken>;
+    let jsonClone: SerializedGestureSource = {
+      isFromTouch: this.isFromTouch,
+      path: path.toJSON()
+    };
+
+    return jsonClone;
+    /* c8 ignore stop */
+    /* c8 ignore next 2 */
+    // esbuild or tsc seems to mangle the 'ignore stop' if put outside the ending brace.
+  }
+}

--- a/common/web/gesture-recognizer/src/engine/headless/gestureSource.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestureSource.ts
@@ -151,7 +151,7 @@ export class GestureSource<HoveredItemType, StateToken=any> {
    * The most recent path sample (coordinate) under consideration for this `GestureSource`.
    */
   public get currentSample(): InputSample<HoveredItemType, StateToken> {
-    return this.path.coords[this.path.coords.length-1];
+    return this.path.stats.lastSample;
   }
 
   /**
@@ -273,7 +273,7 @@ export class GestureSourceSubview<HoveredItemType, StateToken = any> extends Ges
     stateTokenOverride?: StateToken
   ) {
     let start = 0;
-    let length = source.path.coords.length;
+    let length = source.path.stats.sampleCount;
     if(source instanceof GestureSourceSubview) {
       start = source._baseStartIndex;
     }

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
@@ -4,8 +4,6 @@ import { GestureModel, GestureResolution, GestureResolutionSpec, RejectionDefaul
 
 import { ManagedPromise, TimeoutPromise } from "@keymanapp/web-utils";
 import { FulfillmentCause, PathMatcher } from "./pathMatcher.js";
-import { ItemIdentifier } from "../../../configuration/gestureRecognizerConfiguration.js";
-import { GesturePath } from "../../gesturePath.js";
 import { CumulativePathStats } from "../../cumulativePathStats.js";
 
 /**

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
@@ -126,7 +126,7 @@ export class PathMatcher<Type, StateToken = any> {
 
     // For certain unit-test setups, we may have a zero-length path when this is called during test init.
     // It's best to have that path-coord-length check in place, just in case.
-    if(model.itemChangeAction && source.path.coords.length > 0 && source.currentSample.item != source.baseItem) {
+    if(model.itemChangeAction && source.path.stats.sampleCount > 0 && source.currentSample.item != source.baseItem) {
       const result = model.itemChangeAction == 'resolve';
 
       return this.finalize(result, 'item');

--- a/common/web/gesture-recognizer/src/engine/headless/inputEngineBase.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/inputEngineBase.ts
@@ -2,6 +2,7 @@ import EventEmitter from "eventemitter3";
 
 import { GestureRecognizerConfiguration } from "../configuration/gestureRecognizerConfiguration.js";
 import { Nonoptional } from "../nonoptional.js";
+import { GestureDebugSource } from "./gestureDebugSource.js";
 import { GestureSource } from "./gestureSource.js";
 
 interface EventMap<HoveredItemType, StateToken> {
@@ -31,10 +32,12 @@ export abstract class InputEngineBase<HoveredItemType, StateToken = any> extends
   public stateToken: StateToken;
 
   protected readonly config: Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>;
+  private sourceConstructor: typeof GestureSource<HoveredItemType, StateToken, any>;
 
   public constructor(config: Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>) {
     super();
     this.config = config;
+    this.sourceConstructor = (config?.recordingMode ?? true) ? GestureDebugSource : GestureSource;
   }
 
   createTouchpoint(identifier: number, isFromTouch: boolean) {
@@ -44,7 +47,8 @@ export abstract class InputEngineBase<HoveredItemType, StateToken = any> extends
 
     this.identifierMap[identifier] = unique_id;
 
-    const source = new GestureSource<HoveredItemType, StateToken>(unique_id, this.config, isFromTouch);
+    // If debug mode is enabled, will enable persistent coordinate tracking.  Is off by default.
+    const source = new this.sourceConstructor(unique_id, this.config, isFromTouch);
     source.stateToken = this.stateToken;
 
     // Do not add here; it needs special managing for unit tests.

--- a/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
@@ -7,6 +7,7 @@ import { GestureModelDefs, getGestureModel, getGestureModelSet } from "./gesture
 import { GestureModel } from "./gestures/specs/gestureModel.js";
 import { timedPromise } from "@keymanapp/web-utils";
 import { InputSample } from "./inputSample.js";
+import { GestureDebugPath } from "./gestureDebugPath.js";
 
 interface EventMap<HoveredItemType, StateToken> {
   /**
@@ -198,7 +199,9 @@ export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends Even
          *
          * Current actual use-case:  deferred modipress due to ongoing flick, auto-completed by new incoming touch.
          */
-        touchpoint.path.coords.forEach(correctSample);
+        if(touchpoint.path instanceof GestureDebugPath) {
+          touchpoint.path.coords.forEach(correctSample);
+        }
 
         // Don't forget to also correct the `stateToken` and `baseItem`!
         touchpoint.stateToken = this.stateToken;

--- a/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
@@ -202,7 +202,7 @@ export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends Even
 
         // Don't forget to also correct the `stateToken` and `baseItem`!
         touchpoint.stateToken = this.stateToken;
-        touchpoint.baseItem = touchpoint.path.coords[0].item;
+        touchpoint.baseItem = touchpoint.path.stats.initialSample.item;
 
         // Also, in case a contact model's path-eval references data via stats...
         correctSample(touchpoint.path.stats.initialSample);

--- a/common/web/gesture-recognizer/src/engine/index.ts
+++ b/common/web/gesture-recognizer/src/engine/index.ts
@@ -6,7 +6,8 @@ export { GestureRecognizer } from "./gestureRecognizer.js";
 export { GestureRecognizerConfiguration } from "./configuration/gestureRecognizerConfiguration.js";
 export { InputEngineBase } from "./headless/inputEngineBase.js";
 export { InputSample } from "./headless/inputSample.js";
-export { SerializedGesturePath, GesturePath } from "./headless/gesturePath.js";
+export { GesturePath } from "./headless/gesturePath.js";
+export { GestureDebugPath } from "./headless/gestureDebugPath.js"
 export { ConfigChangeClosure, GestureStageReport, GestureSequence } from "./headless/gestures/matchers/gestureSequence.js";
 export { SerializedGestureSource, GestureSource, buildGestureMatchInspector } from "./headless/gestureSource.js";
 export { MouseEventEngine } from "./mouseEventEngine.js";

--- a/common/web/gesture-recognizer/src/engine/index.ts
+++ b/common/web/gesture-recognizer/src/engine/index.ts
@@ -9,7 +9,8 @@ export { InputSample } from "./headless/inputSample.js";
 export { GesturePath } from "./headless/gesturePath.js";
 export { GestureDebugPath } from "./headless/gestureDebugPath.js"
 export { ConfigChangeClosure, GestureStageReport, GestureSequence } from "./headless/gestures/matchers/gestureSequence.js";
-export { SerializedGestureSource, GestureSource, buildGestureMatchInspector } from "./headless/gestureSource.js";
+export { GestureSource, GestureSourceSubview, buildGestureMatchInspector } from "./headless/gestureSource.js";
+export { SerializedGestureSource, GestureDebugSource } from "./headless/gestureDebugSource.js";
 export { MouseEventEngine } from "./mouseEventEngine.js";
 export { PaddedZoneSource } from './configuration/paddedZoneSource.js';
 export { RecognitionZoneSource } from './configuration/recognitionZoneSource.js';

--- a/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
@@ -68,7 +68,7 @@ export abstract class InputEventEngine<HoveredItemType, StateToken> extends Inpu
       return;
     }
 
-    const lastEntry = touchpoint.path.coords[touchpoint.path.coords.length-1];
+    const lastEntry = touchpoint.path.stats.lastSample;
     const sample = this.buildSampleFor(lastEntry.clientX, lastEntry.clientY, target, lastEntry.t, touchpoint);
 
     /* While an 'end' event immediately follows a 'move' if it occurred simultaneously,

--- a/common/web/gesture-recognizer/src/test/auto/headless/gesturePath.js
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gesturePath.js
@@ -4,7 +4,7 @@ import path from 'path';
 import url from 'url';
 import fs from 'fs';
 
-import { GesturePath } from '@keymanapp/gesture-recognizer';
+import { GestureDebugPath } from '@keymanapp/gesture-recognizer';
 import { timedPromise } from '@keymanapp/web-utils';
 import { TouchpathTurtle } from '#tools';
 
@@ -27,7 +27,7 @@ describe("GesturePath", function() {
         delete rawPathObject.segments;
       }
 
-      let reconstructedPath = GesturePath.deserialize(rawPathObject);
+      let reconstructedPath = GestureDebugPath.deserialize(rawPathObject);
       assert.isFalse(reconstructedPath.wasCancelled);
 
       assert.sameDeepOrderedMembers(reconstructedPath.coords, rawPathObject.coords);
@@ -43,7 +43,7 @@ describe("GesturePath", function() {
         t: 0
       };
 
-      let path = new GesturePath();
+      let path = new GestureDebugPath();
       let turtle = new TouchpathTurtle(initialSample);
       turtle.on('sample', (sample) => path.extend(sample));
 
@@ -103,7 +103,7 @@ describe("GesturePath", function() {
       const spyEventComplete    = sinon.fake();
       const spyEventInvalidated = sinon.fake();
 
-      const touchpath = new GesturePath();
+      const touchpath = new GestureDebugPath();
       touchpath.on('step', spyEventStep);
       touchpath.on('complete', spyEventComplete);
       touchpath.on('invalidated', spyEventInvalidated);
@@ -136,7 +136,7 @@ describe("GesturePath", function() {
       const spyEventComplete    = sinon.fake();
       const spyEventInvalidated = sinon.fake();
 
-      const touchpath = new GesturePath();
+      const touchpath = new GestureDebugPath();
       touchpath.on('step', spyEventStep);
       touchpath.on('complete', spyEventComplete);
       touchpath.on('invalidated', spyEventInvalidated);
@@ -168,7 +168,7 @@ describe("GesturePath", function() {
       const spyEventComplete     = sinon.fake();
       const spyEventInvalidated  = sinon.fake();
 
-      const touchpath = new GesturePath();
+      const touchpath = new GestureDebugPath();
       touchpath.on('step', spyEventStep);
       touchpath.on('complete', spyEventComplete);
       touchpath.on('invalidated', spyEventInvalidated);
@@ -190,7 +190,7 @@ describe("GesturePath", function() {
       const spyEventComplete     = sinon.fake();
       const spyEventInvalidated  = sinon.fake();
 
-      const touchpath = new GesturePath();
+      const touchpath = new GestureDebugPath();
       touchpath.on('step', spyEventStep);
       touchpath.on('complete', spyEventComplete);
       touchpath.on('invalidated', spyEventInvalidated);
@@ -218,12 +218,12 @@ describe("GesturePath", function() {
       this.fakeClock.restore();
     })
 
-    it("path.segments + path.coords - no extra samples", async function() {
+    it("path.coords - no extra samples", async function() {
       const spyEventStep         = sinon.fake();
       const spyEventComplete     = sinon.fake();
       const spyEventInvalidated  = sinon.fake();
 
-      const touchpath = new GesturePath();
+      const touchpath = new GestureDebugPath();
       touchpath.on('step', spyEventStep);
       touchpath.on('complete', spyEventComplete);
       touchpath.on('invalidated', spyEventInvalidated);

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestureSource.spec.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestureSource.spec.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai'
-import { GestureRecognizerConfiguration, GestureSource, InputSample } from '@keymanapp/gesture-recognizer';
+import { GestureDebugSource, GestureRecognizerConfiguration, GestureSource, InputSample } from '@keymanapp/gesture-recognizer';
 
 const helloSample: InputSample<string> = {
   targetX: 1,
@@ -71,7 +71,7 @@ const mockedShiftedConfig = {
 describe("GestureSource", function() {
   describe("Subviews", function() {
     it("construction:  preserve current path & base item", () => {
-      let source = new GestureSource<string>(0, null, true);
+      let source = new GestureDebugSource<string>(0, null, true);
       for(let i=0; i < simpleSampleSequence.length; i++) {
         source.update(simpleSampleSequence[i]);
       }
@@ -83,7 +83,7 @@ describe("GestureSource", function() {
     });
 
     it("construction:  preserve only most recent sample & base item", () => {
-      let source = new GestureSource<string>(0, null, true);
+      let source = new GestureDebugSource<string>(0, null, true);
       for(let i=0; i < simpleSampleSequence.length; i++) {
         source.update(simpleSampleSequence[i]);
       }
@@ -97,7 +97,7 @@ describe("GestureSource", function() {
     });
 
     it("construction:  preserve only most recent sample", () => {
-      let source = new GestureSource<string>(0, null, true);
+      let source = new GestureDebugSource<string>(0, null, true);
       for(let i=0; i < simpleSampleSequence.length; i++) {
         source.update(simpleSampleSequence[i]);
       }
@@ -111,7 +111,7 @@ describe("GestureSource", function() {
     });
 
     it("construction:  preserve current path & base item, with translation", () => {
-      let source = new GestureSource<string>(0, mockedInitialConfig as any, true);
+      let source = new GestureDebugSource<string>(0, mockedInitialConfig as any, true);
       for(let i=0; i < simpleSampleSequence.length; i++) {
         source.update(simpleSampleSequence[i]);
       }
@@ -137,7 +137,7 @@ describe("GestureSource", function() {
     });
 
     it("properly propagate updates", () => {
-      let source = new GestureSource<string>(0, null, true);
+      let source = new GestureDebugSource<string>(0, null, true);
       let subview = source.constructSubview(false, true);
 
       assert.equal(subview.path.coords.length, 0);
@@ -148,7 +148,7 @@ describe("GestureSource", function() {
     });
 
     it("may be disconnected from further updates", () => {
-      let source = new GestureSource<string>(0, null, true);
+      let source = new GestureDebugSource<string>(0, null, true);
       let subview = source.constructSubview(false, true);
 
       source.update(helloSample);
@@ -165,7 +165,7 @@ describe("GestureSource", function() {
     });
 
     it('is updated if constructed from "current" intermediate subview', () => {
-      let source = new GestureSource<string>(0, null, true);
+      let source = new GestureDebugSource<string>(0, null, true);
       let baseSubview = source.constructSubview(false, true);
 
       source.update(helloSample);
@@ -186,7 +186,7 @@ describe("GestureSource", function() {
     });
 
     it("propagate path termination (complete)",  () => {
-      let source = new GestureSource<string>(0, null, true);
+      let source = new GestureDebugSource<string>(0, null, true);
       let subview = source.constructSubview(true, true);
       let subview2 = source.constructSubview(true, true);
 
@@ -204,7 +204,7 @@ describe("GestureSource", function() {
     });
 
     it("acts read-only - does not allow direct mutations", () => {
-      let source = new GestureSource<string>(0, mockedInitialConfig as any, true);
+      let source = new GestureDebugSource<string>(0, mockedInitialConfig as any, true);
       let subview = source.constructSubview(false, true);
       source.update(helloSample);
       source.pushRecognizerConfig(mockedShiftedConfig as any);

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/gestureMatcher.spec.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/gestureMatcher.spec.ts
@@ -5,7 +5,7 @@ import * as PromiseStatusModule from 'promise-status-async';
 const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
 import { assertingPromiseStatus as promiseStatus } from '../../../resources/assertingPromiseStatus.js';
 
-import { InputSample, GestureSource, gestures } from '@keymanapp/gesture-recognizer';
+import { InputSample, GestureSource, gestures, GestureDebugPath } from '@keymanapp/gesture-recognizer';
 
 import { TouchpathTurtle } from '#tools';
 import { ManagedPromise, timedPromise } from '@keymanapp/web-utils';
@@ -105,7 +105,7 @@ describe("GestureMatcher", function() {
 
 
       // Because 'chopped'.
-      assert.equal(secondMatcher.sources[0].path.coords.length, 1);
+      assert.equal(secondMatcher.sources[0].path.stats.sampleCount, 1);
       assert.deepEqual(sources[0].currentSample, waitCompletionSample);
       // because we 'chopped' the path, we use the current sample's item as the new base.
       assert.equal(secondMatcher.sources[0].baseItem, 'b');
@@ -173,7 +173,7 @@ describe("GestureMatcher", function() {
 
 
       // 'partial' path inheritance still drops the pre-existing path components...
-      assert.equal(secondMatcher.sources[0].path.coords.length, 1);
+      assert.equal(secondMatcher.sources[0].path.stats.sampleCount, 1);
       assert.deepEqual(sources[0].currentSample, waitCompletionSample);
       // ... but preserves the original base item.
       assert.equal(sources[0].baseItem, 'a');
@@ -283,8 +283,13 @@ describe("GestureMatcher", function() {
 
 
       // 'full' path inheritance maintains all pre-existing path components...
-      assert.equal(secondMatcher.sources[0].path.coords.length, sources[0].path.coords.length);
-      assert.deepEqual(secondMatcher.sources[0].path.coords, sources[0].path.coords)
+      assert.equal(secondMatcher.sources[0].path.stats.sampleCount, sources[0].path.stats.sampleCount);
+
+      assert.deepEqual(
+        (secondMatcher.sources[0].path as GestureDebugPath<string>).coords,
+        (sources[0].path as GestureDebugPath<string>).coords
+      );
+
       assert.deepEqual(sources[0].currentSample, waitCompletionSample);
       // ... and also preserves the original base item.
       assert.equal(sources[0].baseItem, 'a');

--- a/common/web/gesture-recognizer/src/test/resources/simulateMultiSourceInput.ts
+++ b/common/web/gesture-recognizer/src/test/resources/simulateMultiSourceInput.ts
@@ -276,7 +276,7 @@ function simulateMultiSourceInput<OutputType, Type>(
         // We already committed the sample early, to facilitate new contact-point acceptance,
         // so we skip re-adding it here.  We DO allow all other update functionality to
         // proceed as normal, though.
-        if(simpleSource.path.coords[0] != sample && !simpleSource.isPathComplete) {
+        if(simpleSource.path.stats.initialSample != sample && !simpleSource.isPathComplete) {
           simpleSource.update(sample);
         }
 

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/hostFixtureLayoutController.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/hostFixtureLayoutController.ts
@@ -47,7 +47,8 @@ export class HostFixtureLayoutController extends EventEmitter {
       targetRoot: document.getElementById('target-root'),
       maxRoamingBounds: document.getElementById('roaming-bounds'),
       safeBounds: document.getElementById('safe-zone'),
-      paddedSafeBounds: document.getElementById('padded-safe-zone')
+      paddedSafeBounds: document.getElementById('padded-safe-zone'),
+      recordingMode: true
     };
   };
 

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/inputSequenceSimulator.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/inputSequenceSimulator.ts
@@ -1,4 +1,6 @@
 import {
+  GestureDebugPath,
+  GestureDebugSource,
   GestureSource,
   type InputSample
 } from "@keymanapp/gesture-recognizer";
@@ -187,7 +189,7 @@ export class InputSequenceSimulator<HoveredItemType> {
 
     this.controller.layoutConfiguration = new FixtureLayoutConfiguration(config);
 
-    const touchpoints = inputs.map((input, index) => GestureSource.deserialize(input, index));
+    const touchpoints = inputs.map((input, index) => GestureDebugSource.deserialize(input, index));
 
     /**
      * For each corresponding recorded sequence, notes the index of the sequence's
@@ -211,27 +213,29 @@ export class InputSequenceSimulator<HoveredItemType> {
       let selectedSequences = [-1];
 
       for(let index=0; index < inputs.length; index++) {
-        const touchpoint = GestureSource.deserialize(inputs[index], index);
+        const touchpoint = GestureDebugSource.deserialize(inputs[index], index);
+        const path = touchpoint.path as GestureDebugPath<any>;
         const indexInSequence = sequenceProgress[index];
 
         if(indexInSequence == Number.MAX_VALUE) {
           continue;
         }
 
-        if(touchpoint.path.coords[indexInSequence].t < minTimestamp) {
-          minTimestamp = touchpoint.path.coords[indexInSequence].t;
+        if(path.coords[indexInSequence].t < minTimestamp) {
+          minTimestamp = path.coords[indexInSequence].t;
           selectedSequences = [index];
-        } else if (touchpoint.path.coords[indexInSequence].t == minTimestamp) {
+        } else if (path.coords[indexInSequence].t == minTimestamp) {
           selectedSequences.push(index);
         }
       }
 
       const preprocessing = selectedSequences.map((inputIndex) => {
         const touchpoint = touchpoints[inputIndex];
+        const path = touchpoint.path as GestureDebugPath<any>;
         const indexInSequence = sequenceProgress[inputIndex];
 
         let appendEndEvent = false;
-        if(indexInSequence + 1 >= touchpoint.path.coords.length) {
+        if(indexInSequence + 1 >= path.coords.length) {
           sequenceProgress[inputIndex] = Number.MAX_VALUE;
           appendEndEvent = true;
         } else {
@@ -244,7 +248,7 @@ export class InputSequenceSimulator<HoveredItemType> {
           state = "start";
         }
 
-        const sample = touchpoint.path.coords[indexInSequence] as InputSample<HoveredItemType>;
+        const sample = path.coords[indexInSequence] as InputSample<HoveredItemType>;
 
         return {
           sample: sample,

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/src/sequenceRecorder.ts
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/src/sequenceRecorder.ts
@@ -1,4 +1,4 @@
-import { GestureSource } from "@keymanapp/gesture-recognizer";
+import { GestureDebugSource, GestureSource } from "@keymanapp/gesture-recognizer";
 import { HostFixtureLayoutController } from "./hostFixtureLayoutController.js";
 import { RecordedCoordSequenceSet } from "./inputRecording.js";
 
@@ -7,11 +7,11 @@ import { RecordedCoordSequenceSet } from "./inputRecording.js";
  *  verification itself.
  */
 
-type WrappedInputSequence = GestureSource<any>;
+type WrappedInputSequence = GestureDebugSource<any>;
 
 export class SequenceRecorder {
   controller: HostFixtureLayoutController;
-  records:  {[identifier: string]: GestureSource<any>} = {};
+  records:  {[identifier: string]: GestureDebugSource<any>} = {};
 
   /**
    * Tracks the order in which each sequence was first detected.

--- a/web/src/engine/osk/src/input/gestures/browser/flick.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/flick.ts
@@ -153,7 +153,7 @@ export default class Flick implements GestureHandler {
         this.lockedDir = dir;
         this.lockedSelectable = baseSelection;
 
-        const baseCoord = baseSource.path.coords[0];
+        const baseCoord = baseSource.path.stats.initialSample;
         if(this.flickScroller) {
           // Clear any previously-set scroller.
           baseSource.path.off('step', this.flickScroller);


### PR DESCRIPTION
The default mode for the gesture engine will no longer persistently store all coordinates visited by each touchpoint.  All relevant data is accumulated within the `CumulativePathStats` object and can be obtained from there.  This change thus should reduce runtime memory overhead, particularly for long-lived continuous gestures.  (Intermediate coordinates may now be garbage-collected quite rapidly, even while their touchpoint lives on.)

Accordingly, a new configuration flag has been added: `recordingMode`.  This flag reactivates persistent coordinate storing, which is useful for some of the existing automated tests and for, well, "recording" input sequences.  It might also be of use when debugging gesture-related issues.

I'd always intended for this change to occur at _some_ point... I'd just always "put off" finding the time to handle the few related loose ends.  The biggest "loose end" was the handling of source "subview" generation as it relates to path inheritance when transitioning between gesture-model states.  The other loose ends are all handled within the first commit.

@keymanapp-test-bot skip