### PR TITLE
fix(web): heterogenous longpress roaming 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
@@ -75,7 +75,17 @@ export class PathMatcher<Type, StateToken = any> {
             t: timestamp
           });
         }
-        this.finalize(result == model.timer.expectedResult, 'timer');
+
+        if(result != model.timer.expectedResult) {
+          this.finalize(false, 'timer');
+        }
+
+        // Check for validation as needed.
+        if(!model.timer.validateItem) {
+          this.finalize(true, 'timer');
+        } else {
+          this.finalize(model.timer.validateItem(this.source.path.stats.lastSample.item, this.baseItem), 'timer');
+        }
       });
     }
   }

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
@@ -38,7 +38,17 @@ export interface ContactModel<Type, StateToken = any> {
      * If `true`, the timer will use the inherited `path.stats.duration` stat as an
      * offset that has already elapsed, counting it against the timer.
      */
-    inheritElapsed?: boolean
+    inheritElapsed?: boolean,
+    /**
+     * An optional timer-spec function parameter.  If specified and other conditions are met,
+     * this function will validate the model on the basis of the associated 'items'.
+     * @param currentItem
+     * @param baseItem
+     * @returns
+     * - `true` if the model is valid for the associated items, resulting in a model match
+     * - `false` if the model is invalid, leading to model rejection
+     */
+    validateItem?: (currentItem: Type, baseItem: Type) => boolean
   }
 
   // This field is primarly used at the `GestureMatcher` level, rather than the

--- a/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
@@ -57,6 +57,7 @@ export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends Even
     replaceModelWith: (model: GestureModel<HoveredItemType, StateToken>) => void
   ) => {
     const sourceIds = selection.matcher.allSourceIds;
+    console.log(selection.matcher.model.id);
 
     // If there's an active gesture that uses a source noted in the selection, it's the responsibility
     // of an existing GestureSequence to handle this one.  The handler should bypass it for this round.

--- a/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/touchpointCoordinator.ts
@@ -57,7 +57,6 @@ export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends Even
     replaceModelWith: (model: GestureModel<HoveredItemType, StateToken>) => void
   ) => {
     const sourceIds = selection.matcher.allSourceIds;
-    console.log(selection.matcher.model.id);
 
     // If there's an active gesture that uses a source noted in the selection, it's the responsibility
     // of an existing GestureSequence to handle this one.  The handler should bypass it for this round.


### PR DESCRIPTION
Fixes #10170.
Fixes #10171.

Longpress validation now occurs when the longpress would trigger, rather than on the initial key-down.  If the timer elapses on a key that doesn't support longpresses and roaming mode is disabled, the gesture-engine will enter a state that restores longpress processing when the base key changes - including a restart of the longpress timer.

## User Testing

TEST_ROAM_FROM_SUBKEYLESS:  Using the "Predictive Text: Robust Testing" KeymanWeb test page...

1. Select the "SIL EuroLatin" keyboard (under English).
2. Swap to the numeric layer.
3. Press and hold the `&` key for at least a second.
4. Move your finger over the `%` key and hold.
5. Verify that after a moment, a subkey menu appears with these options: `‰`, `‱`
    
    In case of bad GitHub rendering: 
    ![image](https://github.com/keymanapp/keyman/assets/25213402/561e8336-1336-419c-ba9e-49debcf716cf)

TEST_ROAM_TO_SUBKEYLESS:  Using the "Predictive Text: Robust Testing" KeymanWeb test page...

1. Select the "SIL EuroLatin" keyboard (under English).
2. Swap to the numeric layer.
3. Press and hold the `%` key, then quickly move to the `&` key for at least a second.
4. Return your finger to the `%` key and hold.
5. Verify that after a moment, a subkey menu appears with these options: `‰`, `‱`

TEST_BIG_ROAM:  Using the "Predictive Text: Robust Testing" KeymanWeb test page...

1. Select the "SIL EuroLatin" keyboard (under English).
2. Swap to the numeric layer.
3. Press and hold the `1` key, then quickly move to the `$` key for at least a second.
4. Move your finger toward the right across the entire second row of keys, landing on the `/` key.
6. Verify that after a moment, a subkey menu appears for the `/` key with this option: `\`