### PR TITLE
feat(web): enhanced flick resetting via path base-coord replacement 🐵

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/cumulativePathStats.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/cumulativePathStats.ts
@@ -240,6 +240,7 @@ export class CumulativePathStats<Type = any> {
     // Re: the block above... obviously, don't replace if there IS no initial sample yet.
     // It'll happen soon enough anyway.
     const originalSample = result.initialSample;
+    result._initialSample = sample;
 
     if(this.sampleCount > 1) {
       // Works fine re: cata-cancellation - `this.baseSample.___` cancels out.
@@ -269,7 +270,7 @@ export class CumulativePathStats<Type = any> {
 
       result.coordArcSum     += coordArcDelta;
     } else {
-      this._lastSample = sample;
+      result._lastSample = sample;
     }
 
     // Do NOT change sampleCount; we're replacing the original.

--- a/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
@@ -76,10 +76,25 @@ export class GesturePath<Type, StateToken = any> extends EventEmitter<EventMap<T
     return this._wasCancelled;
   }
 
+  /**
+   * Builds a new instance with equal stats and with translated initialSample and
+   * lastSample coordinates.  Further accumulation will be based upon the new
+   * coordinate system as well.
+   * @param functor
+   */
   public translateCoordSystem(functor: (sample: InputSample<Type, StateToken>) => InputSample<Type, StateToken>) {
     this._stats = this._stats.translateCoordSystem(functor);
   }
 
+  /**
+   * Builds a new instance with its initial sample replaced and stats updated
+   * to reflect the alternate starting position.
+   *
+   * Note that `rawDistance` adjustments are an approximation, not exact.  To
+   * be precise, for stats representing two more more samples, the distance
+   * between the original and new initial samples is added as a flat amount.
+   * @param sample
+   */
   public replaceInitialSample(sample: InputSample<Type, StateToken>) {
     this._stats = this._stats.replaceInitialSample(sample);
   }

--- a/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
@@ -80,6 +80,10 @@ export class GesturePath<Type, StateToken = any> extends EventEmitter<EventMap<T
     this._stats = this._stats.translateCoordSystem(functor);
   }
 
+  public replaceInitialSample(sample: InputSample<Type, StateToken>) {
+    this._stats = this._stats.replaceInitialSample(sample);
+  }
+
   /**
    * Extends the path with a newly-observed coordinate.
    * @param sample

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
@@ -433,7 +433,7 @@ export class GestureMatcher<Type, StateToken = any> implements PredecessorMatch<
         };
 
         // 2. Replace it within the source's path-stats.
-        simpleSource.path.stats.replaceInitialSample(replacementSample);
+        simpleSource.path.replaceInitialSample(replacementSample);
       }
     }
 

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
@@ -1,8 +1,11 @@
+import { CumulativePathStats } from "../../cumulativePathStats.js";
 import { InputSample } from "../../inputSample.js";
 import { PathModel } from "./pathModel.js";
 
 // pop - a signal to reverse actions taken in response to the most-recent 'push'.  (Generally, for 'modipress' gestures)
 type SimpleStringResult = 'resolve' | 'reject';
+
+export type SampleCoordReplacement<Type> = Pick<InputSample<Type>, 'clientX' | 'clientY'> & Partial<Pick<InputSample<Type>, 't'>>;
 
 export type PointModelResolution = SimpleStringResult;
 
@@ -59,6 +62,26 @@ export interface ContactModel<Type, StateToken = any> {
    * If not specified, 'chop' inheritance will be used as the default.
    */
   pathInheritance?: 'reject' | 'chop' | 'partial' | 'full';
+
+  /**
+   * An optional method that, when specified, may be used to overwrite the model's perceived
+   * initial coordinate for stat-tracking.  Only utilized if there is any pre-existing path
+   * to inherit.
+   *
+   * @param inheritedStats Full stats for any inherited portions of the path.  Note that
+   * `.initialSample` is the coordinate to be replaced.
+   *
+   * @param baseItem       The base item as determined by the `pathInheritance` setting.
+   *
+   * @returns              The input sample to use as the stat-tracking base coordinate.
+   * Non-coordinate properties will be replaced and maintained internally after the call
+   * is complete.
+   *
+   * If `t` is left unspecified, the original coord's timestamp will be maintained.
+   *
+   * If the return value is `null` or `undefined`, the original `.initialSample` will be preserved.
+   */
+  baseCoordReplacer?: (inheritedStats: CumulativePathStats<Type>, baseItem: Type) => SampleCoordReplacement<Type>;
 
   /**
    * Used to either instantly resolve or reject this component of a gesture based on

--- a/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
@@ -1,18 +1,25 @@
 import { InputEngineBase } from "./headless/inputEngineBase.js";
 import { InputSample } from "./headless/inputSample.js";
 import { GestureSource } from "./headless/gestureSource.js";
+import { GestureRecognizerConfiguration } from "./index.js";
+
+export function processSampleClientCoords<Type, StateToken>(config: GestureRecognizerConfiguration<Type>, clientX: number, clientY: number) {
+  const targetRect = config.targetRoot.getBoundingClientRect();
+  return {
+    clientX: clientX,
+    clientY: clientY,
+    targetX: clientX - targetRect.left,
+    targetY: clientY - targetRect.top
+  } as InputSample<Type, StateToken>;
+}
 
 export abstract class InputEventEngine<HoveredItemType, StateToken> extends InputEngineBase<HoveredItemType, StateToken> {
   abstract registerEventHandlers(): void;
   abstract unregisterEventHandlers(): void;
 
   protected buildSampleFor(clientX: number, clientY: number, target: EventTarget, timestamp: number, source: GestureSource<HoveredItemType, StateToken>): InputSample<HoveredItemType, StateToken> {
-    const targetRect = this.config.targetRoot.getBoundingClientRect();
     const sample: InputSample<HoveredItemType, StateToken> = {
-      clientX: clientX,
-      clientY: clientY,
-      targetX: clientX - targetRect.left,
-      targetY: clientY - targetRect.top,
+      ...processSampleClientCoords(this.config, clientX, clientY),
       t: timestamp,
       stateToken: source?.stateToken ?? this.stateToken
     };

--- a/web/src/engine/osk/src/input/gestures/browser/flick.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/flick.ts
@@ -128,7 +128,13 @@ export default class Flick implements GestureHandler {
       const baseSelection = this.computedFlickDistribution[0].keySpec;
 
       if(result.matchedId == 'flick-restart') {
+        // The gesture-engine's already done this, but we need an analogue for it here.
+        source.path.replaceInitialSample(result.sources[0].path.stats.initialSample);
         // Part of the flick-reset process.
+        return;
+      } if(result.matchedId == 'flick-reset-centering') {
+        // Part of the flick-reset process.
+        source = baseSource.constructSubview(true, true);
         return;
       } else if(result.matchedId == 'flick-reset-end') {
         this.emitKey(vkbd, this.baseSpec, source.path.stats);
@@ -149,7 +155,6 @@ export default class Flick implements GestureHandler {
           // Clean up the handlers; we're replacing the subview.
           source.disconnect();
         }
-        source = baseSource.constructSubview(true, true);
         return;
       } else if(result.matchedId == 'flick-mid') {
         if(baseSelection == this.baseSpec) {

--- a/web/src/engine/osk/src/input/gestures/browser/flick.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/flick.ts
@@ -2,7 +2,7 @@ import { type KeyElement } from '../../../keyElement.js';
 import VisualKeyboard from '../../../visualKeyboard.js';
 
 import { ActiveKey, ActiveKeyBase, ActiveSubKey, KeyDistribution, KeyEvent } from '@keymanapp/keyboard-processor';
-import { ConfigChangeClosure, CumulativePathStats, GestureRecognizerConfiguration, GestureSequence, GestureSource, InputSample, PaddedZoneSource, RecognitionZoneSource } from '@keymanapp/gesture-recognizer';
+import { ConfigChangeClosure, CumulativePathStats, GestureRecognizerConfiguration, GestureSequence, GestureSource, GestureSourceSubview, InputSample, RecognitionZoneSource } from '@keymanapp/gesture-recognizer';
 import { GestureHandler } from '../gestureHandler.js';
 import { distributionFromDistanceMaps } from '@keymanapp/input-processor';
 import { GestureParams } from '../specsForLayout.js';
@@ -30,8 +30,9 @@ export function lockedAngleForDir(lockedDir: typeof OrderedFlickDirections[numbe
 export function calcLockedDistance(pathStats: CumulativePathStats<any>, lockedDir: typeof OrderedFlickDirections[number]) {
   const lockedAngle = lockedAngleForDir(lockedDir);
 
-  const deltaX = pathStats.lastSample.targetX - pathStats.initialSample.targetX;
-  const deltaY = pathStats.lastSample.targetY - pathStats.initialSample.targetY;
+  const rootCoord = pathStats.initialSample;
+  const deltaX = pathStats.lastSample.targetX - rootCoord.targetX;
+  const deltaY = pathStats.lastSample.targetY - rootCoord.targetY;
 
   const projY = Math.max(0, -deltaY * Math.cos(lockedAngle));
   const projX = Math.max(0,  deltaX * Math.sin(lockedAngle));
@@ -42,8 +43,7 @@ export function calcLockedDistance(pathStats: CumulativePathStats<any>, lockedDi
 }
 
 export function buildFlickScroller(
-  baseSource: GestureSource<KeyElement>,
-  initialCoord: InputSample<KeyElement>,
+  source: GestureSource<KeyElement>,
   lockedDir: typeof OrderedFlickDirections[number],
   previewHost: GesturePreviewHost,
   gestureParams: GestureParams
@@ -52,7 +52,7 @@ export function buildFlickScroller(
     const lockedAngle = lockedAngleForDir(lockedDir);
 
     const maxProgressDist = gestureParams.flick.triggerDist - gestureParams.flick.dirLockDist;
-    let progressDist =  Math.max(0, calcLockedDistance(baseSource.path.stats, lockedDir) - gestureParams.flick.dirLockDist);
+    let progressDist =  Math.max(0, calcLockedDistance(source.path.stats, lockedDir) - gestureParams.flick.dirLockDist);
 
     // Make progress appear slightly less than it really is; 'near complete' slides thus actually are, so
     // the user doesn't get aggrevated by 'near misses' in that regard.
@@ -115,29 +115,41 @@ export default class Flick implements GestureHandler {
 
     this.baseKeyDistances = vkbd.getSimpleTapCorrectionDistances(sequence.stageReports[0].sources[0].path.stats.initialSample, this.baseSpec)
     const baseSource = sequence.stageReports[0].sources[0].baseSource;
+    let source: GestureSource<KeyElement> = baseSource;
 
     sequence.on('complete', () => {
       previewHost.cancel()
     });
 
     this.sequence.on('stage', (result) => {
-      const pathStats = baseSource.path.stats;
+      const pathStats = source.path.stats;
       this.computedFlickDistribution = this.flickDistribution(pathStats, true);
 
       const baseSelection = this.computedFlickDistribution[0].keySpec;
-      if(result.matchedId == 'flick-reset-end') {
-        this.emitKey(vkbd, this.baseSpec, baseSource.path.stats);
+
+      if(result.matchedId == 'flick-restart') {
+        // Part of the flick-reset process.
+        return;
+      } else if(result.matchedId == 'flick-reset-end') {
+        this.emitKey(vkbd, this.baseSpec, source.path.stats);
         return;
       } else if(result.matchedId == 'flick-reset') {
         // Instant transitions to flick-mid state; entry indicates a lock "reset".
         // Cancel the flick-viz bit.
         if(this.flickScroller) {
-          this.flickScroller(baseSource.currentSample);
+          this.flickScroller(source.currentSample);
           // Clear any previously-set scroller.
-          baseSource.path.off('step', this.flickScroller);
+          source.path.off('step', this.flickScroller);
         }
         this.lockedDir = null;
         this.lockedSelectable = null;
+
+        // Chops off the prior part of the path
+        if(source instanceof GestureSourceSubview) {
+          // Clean up the handlers; we're replacing the subview.
+          source.disconnect();
+        }
+        source = baseSource.constructSubview(true, true);
         return;
       } else if(result.matchedId == 'flick-mid') {
         if(baseSelection == this.baseSpec) {
@@ -153,14 +165,14 @@ export default class Flick implements GestureHandler {
         this.lockedDir = dir;
         this.lockedSelectable = baseSelection;
 
-        const baseCoord = baseSource.path.stats.initialSample;
         if(this.flickScroller) {
           // Clear any previously-set scroller.
-          baseSource.path.off('step', this.flickScroller);
+          source.path.off('step', this.flickScroller);
         }
-        this.flickScroller = buildFlickScroller(baseSource, baseCoord, dir, previewHost, this.gestureParams);
-        this.flickScroller(baseSource.currentSample);
-        baseSource.path.on('step', this.flickScroller);
+
+        this.flickScroller = buildFlickScroller(source, dir, previewHost, this.gestureParams);
+        this.flickScroller(source.currentSample);
+        source.path.on('step', this.flickScroller);
 
         return;
       }

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1244,8 +1244,8 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     paddingZone.updatePadding([-0.333 * this.currentLayer.rowHeight]);
 
     this.gestureParams.longpress.flickDist = 0.25 * this.currentLayer.rowHeight;
-    this.gestureParams.flick.startDist     = 0.1  * this.currentLayer.rowHeight;
-    this.gestureParams.flick.dirLockDist   = 0.25 * this.currentLayer.rowHeight;
+    this.gestureParams.flick.startDist     = 0.15 * this.currentLayer.rowHeight;
+    this.gestureParams.flick.dirLockDist   = 0.35 * this.currentLayer.rowHeight;
     this.gestureParams.flick.triggerDist   = 0.75 * this.currentLayer.rowHeight;
 
     // Needs the refreshed layout info to work correctly.


### PR DESCRIPTION
Rather than requiring a user to remember exactly where their initial touch location was for a flick during resets, this set of changes allow for flicks to 'change' their start location when reset.  A location nearish the center of the base key will always be chosen in a manner that also favors the actual location of the active contact-point when reasonable.

Deliberately _not_ picking the actual center, but an off-center location with a moderate radius of it toward the actual location of a touch, it becomes far easier to swap flick direction intuitively after a reset.

## User Testing

**TEST_FLICK_LOCKING**:  Using the standard "Test unminified KeymanWeb" test page from a mobile device...

1. Select "English...", then "Gesture Prototyping".
2. Tap and hold the `u` key.
3. For the following steps, pay attention to the animated preview.
4. Drag it purely north (straight up) - you should see the `û` key in the preview area (assuming it's not blocked by your finger).
    - If the animation was "jumpy" - if there was a lack of motion at the same time you moved your finger, then a big "jump" to catch up - FAIL this test.
    - If any such "jumps" were directly tied to you moving your finger quickly, do _not_ fail this test. 
5. Return your finger to the original 'u' key; the 'u' key should slide back into place. 
    - Note when the preview's `u` fully recenters:  that indicates a successful "reset".
6. Now drag your finger downward:  you should see a preview for `ü` as you do so.
7. Return your finger to the original 'u' key; the 'u' key should slide back into place. 
8. Now, drag your finger in a up-and-right motion:  you should also see a preview for `ú` as you do so.
    - Again, if the animation felt "jumpy" and not well connected to your input, FAIL this test.
9. While the `ú` is visible and in the center, lift your finger and end the gesture.
10. Verify that a `ú` is output.
11. Repeat steps 2 through 6 for the `a` key; you should see similar previews and text there.  (`â`, `ä`, `á`)

NOTE:  this should replace the corresponding test from Web's regression-test specification if possible.  Consider it an update.