### PR TITLE
fix(web): Fix null error with legacy keyboards 🍒 🏠

### DIFF
--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -264,9 +264,7 @@ namespace com.keyman.keyboards {
 
         // Support version 1.0 KeymanWeb keyboards that do not define positional vs mnemonic
         if(!keyboard.definesPositionalOrMnemonic) {
-          // Not the best pattern, but currently safe - we don't look up any properties of any of the
-          // arguments in this use case, and the object's scope is extremely limited.
-          Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(this.constructKeyEvent(null, null));
+          Lkc.Lcode = KeyMapping._USKeyCodeToCharCode(Lkc);
           Lkc.LisVirtualKey=false;
         }
       }


### PR DESCRIPTION
Fixes #10099.

(🍒-picked from PR #10141)

# User Testing

**TEST_FIXED**: 

- Open the [Unminified Source test page](https://build.palaso.org/repository/download/Keymanweb_TestPullRequests/428624:id/testing/unminified.html)
- Load the Armenian keyboard by typing "armenian" in the "Add a keyboard by keyboard name" field and pressing the "Add" button
- click in the "Type here" field and switch to the Armenian keyboard
- Verify that the Armenian OSK is shown, but no error