### PR TITLE
fix(common/models): lm-worker context resets didn't properly manage context cache

### DIFF
--- a/common/web/lm-worker/src/main/correction/context-tracker.ts
+++ b/common/web/lm-worker/src/main/correction/context-tracker.ts
@@ -579,4 +579,10 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
     this.enqueue(state);
     return state;
   }
+
+  clearCache() {
+    while(this.count > 0) {
+      this.dequeue();
+    }
+  }
 }

--- a/common/web/lm-worker/src/main/correction/context-tracker.ts
+++ b/common/web/lm-worker/src/main/correction/context-tracker.ts
@@ -470,7 +470,7 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
     return state;
   }
 
-  static modelContextState(tokenizedContext: USVString[],
+  private static modelContextState(tokenizedContext: USVString[],
                             transformDistribution: Distribution<Transform>,
                             lexicalModel: LexicalModel): TrackedContextState {
     let baseTokens = tokenizedContext.map(function(entry) {

--- a/common/web/lm-worker/src/main/correction/context-tracker.ts
+++ b/common/web/lm-worker/src/main/correction/context-tracker.ts
@@ -532,17 +532,20 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
     if(tokenizedContext.left.length > 0) {
       for(let i = this.count - 1; i >= 0; i--) {
         const priorMatchState = this.item(i);
-        if(transformDistribution && transformDistribution.length > 0) {
+        const priorTaggedContext = priorMatchState.taggedContext;
+        if(priorTaggedContext && transformDistribution && transformDistribution.length > 0) {
           // Using the potential `matchState` + the incoming transform, do the results line up for
           // our observed context?  If not, skip it.
           //
           // Necessary to properly handle multitaps, as there are context rewinds that the
           // predictive-text engine is not otherwise warned about.
-          const doublecheckContext = applyTransform(transformDistribution[0].sample, priorMatchState.taggedContext);
+          //
+          // `priorTaggedContext` must not be `null`!
+          const doublecheckContext = applyTransform(transformDistribution[0].sample, priorTaggedContext);
           if(doublecheckContext.left != context.left) {
             continue;
           }
-        } else if(priorMatchState.taggedContext?.left != context.left) {
+        } else if(priorTaggedContext?.left != context.left) {
           continue;
         }
 
@@ -553,6 +556,7 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
           // in the history.  However, if it's the most current already, there's no need
           // to refresh it.
           if(this.newest != resultState && this.newest != priorMatchState) {
+            // Already has a taggedContext.
             this.enqueue(priorMatchState);
           }
 

--- a/common/web/lm-worker/src/main/model-compositor.ts
+++ b/common/web/lm-worker/src/main/model-compositor.ts
@@ -741,11 +741,8 @@ export default class ModelCompositor {
     // Designed for use when the caret has been directly moved and/or the context sourced from a different control
     // than before.
     if(this.contextTracker) {
-      let tokenizedContext = models.tokenize(this.lexicalModel.wordbreaker || wordBreakers.default, context);
-      let contextState = correction.ContextTracker.modelContextState(tokenizedContext.left, null, this.lexicalModel);
-
-      contextState.taggedContext = context;
-      this.contextTracker.enqueue(contextState);
+      this.contextTracker.clearCache();
+      this.contextTracker.analyzeState(this.lexicalModel, context, null);
     }
   }
 

--- a/common/web/lm-worker/src/main/model-compositor.ts
+++ b/common/web/lm-worker/src/main/model-compositor.ts
@@ -743,6 +743,8 @@ export default class ModelCompositor {
     if(this.contextTracker) {
       let tokenizedContext = models.tokenize(this.lexicalModel.wordbreaker || wordBreakers.default, context);
       let contextState = correction.ContextTracker.modelContextState(tokenizedContext.left, null, this.lexicalModel);
+
+      contextState.taggedContext = context;
       this.contextTracker.enqueue(contextState);
     }
   }


### PR DESCRIPTION
Fixes #10136.

The first commit, in particular, is the actual fix.  Examining the changeset of #9855, I had made no changes whatsoever to `model-compositor.ts`'s `resetContext` method... despite now tagging all context states with their context when built - a clear oversight.  It did not tag the context on a context reset, which is what gave rise to the `null` cases for the Sentry events.

While fixing this, I noticed that the `ContextManager` isn't actually _reset_ on a `resetContext` call.  I decided to fix that while I was at it, which results in better centralization of the related code.  That sort of state management was otherwise encapsulated within `ContextTracker`, and this change removes that "otherwise" caveat.

@keymanapp-test-bot skip