### PR TITLE
chore(web): build script cleanup 🐵

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -31,7 +31,6 @@ builder_describe "Builds engine modules for Keyman Engine for Web (KMW)." \
   ":engine/dom-utils         A common subset of function used for DOM calculations, layout, etc" \
   ":engine/events            Specialized classes utilized to support KMW API events" \
   ":engine/element-wrappers  Subset used to integrate with website elements" \
-  ":engine/gestures          The gesture-recognition engine used by KMW's OSK" \
   ":engine/main              Builds all common code used by KMW's app/-level targets" \
   ":engine/osk               Builds the Web OSK module" \
   ":engine/package-cache     Subset used to collate keyboards and request them from the cloud" \
@@ -115,27 +114,6 @@ if builder_start_action test; then
   ./test.sh $TEST_OPTS
 
   builder_finish_action success test
-fi
-
-### Temporary tie-in for pre-modularization version of the gesture-recognizer
-
-if builder_start_action build:engine/gestures; then
-  # Definition of global compile constants
-
-  GESTURE_RECOGNIZER_BUILD="$KEYMAN_ROOT/common/web/gesture-recognizer/build/lib/."
-  GESTURE_RECOGNIZER_TARGET="$KEYMAN_ROOT/web/build/engine/gesture-recognizer/lib/"
-
-  # Copy gesture-recognizer build artifacts into web-space for CI testing
-  # Note:  make sure this doesn't break once KeymanWeb actually uses the module!
-  if ! [ -d $GESTURE_RECOGNIZER_TARGET ]; then
-      mkdir -p $GESTURE_RECOGNIZER_TARGET
-  fi
-  cp -a $GESTURE_RECOGNIZER_BUILD $GESTURE_RECOGNIZER_TARGET
-
-  # Which could then have a parallel script for `prediction-mtnt` that downloads + extracts
-  # the current MTNT model.
-
-  builder_finish_action success build:engine/gestures;
 fi
 
 coverage_action() {

--- a/web/src/test/manual/build.sh
+++ b/web/src/test/manual/build.sh
@@ -55,9 +55,7 @@ function do_copy() {
   GESTURE_RECOGNIZER_BUILD="$KEYMAN_ROOT/common/web/gesture-recognizer/build/lib/."
   GESTURE_RECOGNIZER_TARGET="$KEYMAN_ROOT/web/build/engine/gesture-recognizer/lib/"
 
-  if ! [ -d $GESTURE_RECOGNIZER_TARGET ]; then
-      mkdir -p $GESTURE_RECOGNIZER_TARGET
-  fi
+  mkdir -p "$GESTURE_RECOGNIZER_TARGET"
   cp -a $GESTURE_RECOGNIZER_BUILD $GESTURE_RECOGNIZER_TARGET
 }
 

--- a/web/src/test/manual/build.sh
+++ b/web/src/test/manual/build.sh
@@ -56,7 +56,7 @@ function do_copy() {
   GESTURE_RECOGNIZER_TARGET="$KEYMAN_ROOT/web/build/engine/gesture-recognizer/lib/"
 
   mkdir -p "$GESTURE_RECOGNIZER_TARGET"
-  cp -a $GESTURE_RECOGNIZER_BUILD $GESTURE_RECOGNIZER_TARGET
+  cp -a "$GESTURE_RECOGNIZER_BUILD" "$GESTURE_RECOGNIZER_TARGET"
 }
 
 builder_run_action clean rm -rf "$KEYMAN_ROOT/$DEST"

--- a/web/src/test/manual/build.sh
+++ b/web/src/test/manual/build.sh
@@ -51,6 +51,14 @@ function do_copy() {
   cp "$SENTRY_MANAGER_MAP"  "$KEYMAN_ROOT/$DEST/sentry-manager.js.map"
   cp "$SENTRY_SRC"          "$KEYMAN_ROOT/$DEST/sentry-bundle.min.js"
   cp "$SENTRY_MAP"          "$KEYMAN_ROOT/$DEST/sentry-bundle.min.js.map"
+
+  GESTURE_RECOGNIZER_BUILD="$KEYMAN_ROOT/common/web/gesture-recognizer/build/lib/."
+  GESTURE_RECOGNIZER_TARGET="$KEYMAN_ROOT/web/build/engine/gesture-recognizer/lib/"
+
+  if ! [ -d $GESTURE_RECOGNIZER_TARGET ]; then
+      mkdir -p $GESTURE_RECOGNIZER_TARGET
+  fi
+  cp -a $GESTURE_RECOGNIZER_BUILD $GESTURE_RECOGNIZER_TARGET
 }
 
 builder_run_action clean rm -rf "$KEYMAN_ROOT/$DEST"

--- a/web/src/test/manual/web/gesture-recognizer/hostConfiguration.mjs
+++ b/web/src/test/manual/web/gesture-recognizer/hostConfiguration.mjs
@@ -66,7 +66,7 @@ window.addEventListener('load', function() {
     paddedSafeBounds: document.getElementById('padded-safe-zone')
   };
 
-  recognizer = new GestureRecognizer(recognizerConfig);
+  recognizer = new GestureRecognizer({gestures: [], sets: []}, recognizerConfig);
 
   let recordingArr = [];
   let logElement = document.getElementById('event-log');


### PR DESCRIPTION
Noticed upon a review of a recent merge of master into the feature-branch - web's  build.sh had "temp" code to ensure the gesture engine was built when it wasn't connected.  It is connected now, via our build-script dependency system, so we no longer need that "temp" code.

@keymanapp-test-bot skip