### PR TITLE
chore(mac): force detach of disk image during build after 5 failures

### DIFF
--- a/mac/Keyman4MacIM/make-km-dmg.sh
+++ b/mac/Keyman4MacIM/make-km-dmg.sh
@@ -190,11 +190,17 @@ displayInfo "Detaching \"$WORKING_COPY_OF_IMAGE\""
 # because macOS may still be working in the folder in the
 # background
 DETACH_SUCCESS=0
+DETACH_FORCE=
 while (( DETACH_SUCCESS < 10 )); do
-    hdiutil detach $STAGING_DIR $VERBOSITY
-    if  [[ $? != 0 || -d "$STAGING_DIR" ]] ; then
+    DETACH_RESULT=0
+    hdiutil detach $STAGING_DIR $VERBOSITY $DETACH_FORCE || DETACH_RESULT=$?
+    if  [[ $DETACH_RESULT != 0 || -d "$STAGING_DIR" ]] ; then
         (( DETACH_SUCCESS++ ))
         echo "Failed to unmount: \"$STAGING_DIR\" on attempt #$DETACH_SUCCESS. Waiting 5 seconds to try again."
+        if (( DETACH_SUCCESS > 5 )); then
+            echo "  Note: Detach failed first five times, so now attempting with '-force'"
+            DETACH_FORCE=-force
+        fi
         sleep 5
     else
         DETACH_SUCCESS=999


### PR DESCRIPTION
Fixes #10200.

This is a two-part fix. First, with our normal `set -e` build environment, the existing loop never ran more than once, so the 5 second delay pattern we used to use in the dim dark past was no longer being applied. It is likely that in most cases, this will address the failure to detach.

The second part is to escalate our detach with a `-force` parameter, after 5 failed polite attempts. This is new and is addressing the suggestion in #10200, so we'll have to see if it has any impact on build stability.

@keymanapp-test-bot skip