### PR TITLE
feat(web): alternate artifact - es6-bundled Web 🐵

### DIFF
--- a/common/models/templates/package.json
+++ b/common/models/templates/package.json
@@ -19,7 +19,10 @@
   "main": "./build/obj/index.js",
   "types": "./build/obj/index.d.ts",
   "exports": {
-    ".": "./build/obj/index.js",
+    ".": {
+      "es6-bundling": "./src/index.ts",
+      "default": "./build/obj/index.js"
+    },
     "./lib": {
       "types": "./build/lib/index.d.ts"
     },

--- a/common/models/wordbreakers/package.json
+++ b/common/models/wordbreakers/package.json
@@ -17,7 +17,10 @@
   "main": "build/obj/index.js",
   "types": "build/obj/index.d.ts",
   "exports": {
-    ".": "./build/obj/index.js",
+    ".": {
+      "es6-bundling": "./src/index.ts",
+      "default": "./build/obj/index.js"
+    },
     "./lib": {
       "types": "./build/lib/index.d.ts"
     },

--- a/common/predictive-text/package.json
+++ b/common/predictive-text/package.json
@@ -4,6 +4,7 @@
   "main": "build/obj/node/index.js",
   "exports": {
     ".": {
+      "es6-bundling": "./src/web/index.ts",
       "node": {
         "types": "./build/obj/node/index.d.ts",
         "import": "./build/obj/index.js"
@@ -14,7 +15,10 @@
       }
     },
     "./node": "./build/obj/node/index.js",
-    "./web": "./build/obj/web/index.js",
+    "./web": {
+      "es6-bundling": "./src/web/index.ts",
+      "default": "./build/obj/web/index.js"
+    },
     "./build/obj/node/index.js": "./build/obj/node/index.js",
     "./build/obj/web/index.js": "./build/obj/web/index.js"
   },

--- a/common/web/gesture-recognizer/package.json
+++ b/common/web/gesture-recognizer/package.json
@@ -37,6 +37,11 @@
     "eventemitter3": "^4.0.0"
   },
   "main": "./build/obj/index.js",
+  "exports": {
+    "es6-bundling": "./src/engine/index.ts",
+    "default": "./build/obj/index.js"
+  },
   "types": "./build/obj/index.d.ts",
-  "type": "module"
+  "type": "module",
+  "sideEffects": false
 }

--- a/common/web/input-processor/package.json
+++ b/common/web/input-processor/package.json
@@ -41,7 +41,10 @@
   "main": "./build/obj/index.js",
   "types": "./build/obj/index.d.ts",
   "exports": {
-    ".": "./build/obj/index.js",
+    ".": {
+      "es6-bundling": "./src/index.ts",
+      "default": "./build/obj/index.js"
+    },
     "./lib": {
       "types": "./build/lib/index.d.ts",
       "import": "./build/lib/index.mjs"

--- a/common/web/keyboard-processor/package.json
+++ b/common/web/keyboard-processor/package.json
@@ -47,12 +47,17 @@
   "main": "./build/obj/index.js",
   "types": "./build/obj/index.d.ts",
   "exports": {
-    ".": "./build/obj/index.js",
+    ".": {
+      "es6-bundling": "./src/index.ts",
+      "default": "./build/obj/index.js"
+    },
     "./node-keyboard-loader": {
+      "es6-bundling": "./src/keyboards/loaders/node-keyboard-loader.ts",
       "types": "./build/obj/keyboards/loaders/node-keyboard-loader.d.ts",
       "import": "./build/obj/keyboards/loaders/node-keyboard-loader.js"
     },
     "./dom-keyboard-loader": {
+      "es6-bundling": "./src/keyboards/loaders/dom-keyboard-loader.ts",
       "types": "./build/obj/keyboards/loaders/dom-keyboard-loader.d.ts",
       "import": "./build/obj/keyboards/loaders/dom-keyboard-loader.js"
     },

--- a/common/web/keyman-version/package.json
+++ b/common/web/keyman-version/package.json
@@ -2,7 +2,10 @@
   "name": "@keymanapp/keyman-version",
   "description": "Keyman global version data",
   "exports": {
-    ".": "./build/version.inc.js"
+    ".": {
+      "es6-bundling": "./version.inc.ts",
+      "default": "./build/version.inc.js"
+    }
   },
   "files": [
     "/build/"

--- a/common/web/lm-worker/temp-bundler.js
+++ b/common/web/lm-worker/temp-bundler.js
@@ -1,0 +1,48 @@
+import { pluginForDowncompiledClassTreeshaking, prepareTslibTreeshaking } from '../es-bundling/build/index.mjs';
+import esbuild from 'esbuild';
+import fs from 'fs';
+
+const esmConfiguration = {
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
+  bundle: true,
+  minify: true,
+  format: "iife",
+  // minifyWhitespace: true,
+  // minifySyntax: true,
+  // // minifyIdentifiers: true,
+  plugins: [ pluginForDowncompiledClassTreeshaking ],
+  sourcemap: true,
+  sourcesContent: true,
+  target: "es6",
+  outExtension: { '.js': '.js'},
+  treeShaking: true,
+  conditions: ['es6-bundling']
+};
+
+const localConfig = {
+  ...esmConfiguration,
+  entryPoints: {
+    'index': './src/main/index.ts',
+  },
+  outfile: './build/lib/temp/index.js',
+  // `esbuild`'s sourcemap output puts relative paths to the original sources from the
+  // directory of the build output.  The following keeps repo structure intact and
+  // puts our code under a common 'namespace' of sorts.
+  sourceRoot: '@keymanapp/keyman/common/web/lm-worker/src/main',
+  tsconfig: 'tsconfig.json',
+  // temp
+  metafile: true
+}
+
+await prepareTslibTreeshaking(localConfig);
+
+let result = await esbuild.build(localConfig);
+
+let filesizeProfile = await esbuild.analyzeMetafile(result.metafile, { verbose: true });
+
+fs.writeFileSync('./build/lib/temp/filesize-profile.log', `
+// Minified Worker filesize profile, before polyfilling
+${filesizeProfile}
+`);

--- a/common/web/types/package.json
+++ b/common/web/types/package.json
@@ -9,7 +9,10 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./build/src/main.js"
+    ".": {
+      "es6-bundling": "./src/main.ts",
+      "default": "./build/src/main.js"
+    }
   },
   "files": [
     "/build/src/"
@@ -79,5 +82,6 @@
       "src/schemas/*",
       "test/"
     ]
-  }
+  },
+  "sideEffects": false
 }

--- a/common/web/utils/package.json
+++ b/common/web/utils/package.json
@@ -4,6 +4,7 @@
   "main": "./build/obj/index.js",
   "exports": {
     ".": {
+      "es6-bundling": "./src/index.ts",
       "types": "./build/obj/index.d.ts",
       "import": "./build/obj/index.js"
     }

--- a/web/package.json
+++ b/web/package.json
@@ -3,51 +3,63 @@
   "description": "Facilitates text input in any language.",
   "exports": {
     "./app/browser": {
+      "es6-bundling": "./src/app/browser/src/test-index.ts",
       "types": "./build/app/browser/obj/test-index.d.js",
       "import": "./build/app/browser/obj/test-index.js"
     },
     "./engine/attachment": {
+      "es6-bundling": "./src/engine/attachment/src/index.ts",
       "types": "./build/engine/attachment/obj/index.d.ts",
       "import": "./build/engine/attachment/obj/index.js"
     },
     "./engine/paths": {
+      "es6-bundling": "./src/engine/paths/src/index.ts",
       "types": "./build/engine/paths/obj/index.d.ts",
       "import": "./build/engine/paths/obj/index.js"
     },
     "./engine/device-detect": {
+      "es6-bundling": "./src/engine/device-detect/src/index.ts",
       "types": "./build/engine/device-detect/obj/index.d.ts",
       "import": "./build/engine/device-detect/obj/index.js"
     },
     "./engine/dom-utils": {
+      "es6-bundling": "./src/engine/dom-utils/src/index.ts",
       "types": "./build/engine/dom-utils/obj/index.d.ts",
       "import": "./build/engine/dom-utils/obj/index.js"
     },
     "./engine/element-wrappers": {
+      "es6-bundling": "./src/engine/element-wrappers/src/index.ts",
       "types": "./build/engine/element-wrappers/obj/index.d.ts",
       "import": "./build/engine/element-wrappers/obj/index.js"
     },
     "./engine/events": {
+      "es6-bundling": "./src/engine/events/src/index.ts",
       "types": "./build/engine/events/obj/index.d.ts",
       "import": "./build/engine/events/obj/index.js"
     },
     "./engine/package-cache": {
+      "es6-bundling": "./src/engine/package-cache/src/index.ts",
       "types": "./build/engine/package-cache/obj/index.d.ts",
       "import": "./build/engine/package-cache/obj/index.js",
       "require": "./build/engine/package-cache/obj/index.js"
     },
     "./engine/package-cache/dom-requester": {
+      "es6-bundling": "./src/engine/package-cache/src/domCloudRequester.ts",
       "types": "./build/engine/package-cache/obj/domCloudRequester.d.ts",
       "import": "./build/engine/package-cache/obj/domCloudRequester.js"
     },
     "./engine/package-cache/node-requester": {
+      "es6-bundling": "./src/engine/package-cache/src/nodeCloudRequester.ts",
       "types": "./build/engine/package-cache/obj/nodeCloudRequester.d.ts",
       "import": "./build/engine/package-cache/obj/nodeCloudRequester.js"
     },
     "./engine/main": {
+      "es6-bundling": "./src/engine/main/src/index.ts",
       "types": "./build/engine/main/obj/index.d.ts",
       "import": "./build/engine/main/obj/index.js"
     },
     "./engine/osk": {
+      "es6-bundling": "./src/engine/osk/src/index.ts",
       "types": "./build/engine/osk/obj/index.d.ts",
       "import": "./build/engine/osk/obj/index.js"
     }

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -20,7 +20,7 @@ import { PageIntegrationHandlers } from './context/pageIntegrationHandlers.js';
 import { LanguageMenu } from './languageMenu.js';
 import { setupOskListeners } from './oskConfiguration.js';
 import { whenDocumentReady } from './utils/documentReady.js';
-import { outputTargetForElement } from '../../../../build/engine/attachment/obj/outputTargetForElement.js';
+import { outputTargetForElement } from 'keyman/engine/attachment';
 
 import { UtilApiEndpoint} from './utilApiEndpoint.js';
 import { UIModule } from './uiModuleInterface.js';

--- a/web/src/app/browser/temp-bundler.js
+++ b/web/src/app/browser/temp-bundler.js
@@ -1,0 +1,49 @@
+import { pluginForDowncompiledClassTreeshaking, prepareTslibTreeshaking } from '../../../../common/web/es-bundling/build/index.mjs';
+import esbuild from 'esbuild';
+import fs from 'fs';
+
+const esmConfiguration = {
+  alias: {
+    'tslib': '@keymanapp/tslib'
+  },
+  bundle: true,
+  minify: true,
+  format: "iife",
+  // minifyWhitespace: true,
+  // minifySyntax: true,
+  // // minifyIdentifiers: true,
+  plugins: [ pluginForDowncompiledClassTreeshaking ],
+  sourcemap: true,
+  sourcesContent: true,
+  target: "es6",
+  outExtension: { '.js': '.js'},
+  treeShaking: true,
+  conditions: ['es6-bundling'],
+  external: ['timers', 'buffer', 'events']
+};
+
+const localConfig = {
+  ...esmConfiguration,
+  entryPoints: {
+    'index': './src/release-main.ts',
+  },
+  outfile: '../../../build/app/browser/temp/keymanweb.js',
+  // `esbuild`'s sourcemap output puts relative paths to the original sources from the
+  // directory of the build output.  The following keeps repo structure intact and
+  // puts our code under a common 'namespace' of sorts.
+  sourceRoot: '@keymanapp/keyman/web/src/app/browser/src',
+  tsconfig: 'tsconfig.json',
+  // temp
+  metafile: true
+}
+
+await prepareTslibTreeshaking(localConfig);
+
+let result = await esbuild.build(localConfig);
+
+let filesizeProfile = await esbuild.analyzeMetafile(result.metafile, { verbose: true });
+
+fs.writeFileSync('../../../build/app/browser/temp/filesize-profile.log', `
+// Minified Keyman Engine for Web ('app/browser' target), filesize profile
+${filesizeProfile}
+`);


### PR DESCRIPTION
ES6-oriented bundling within this PR is very much "in draft" - the necessary code is in temp-scripts and not properly connected to our actual build infrastructure.

Note:  do _not_ block a merge of the feature-branch on account of this PR.  We will want to optimize to the post-merge state, though, hence why this PR's based as it is.


### First commit results

_**New**_
```
  ../../../build/app/browser/temp/keymanweb.js ──────────────────────────────────────── 411.5kb ─ 100.0%
```

Contrast with the feature-branch's current size:  

_Old_
>  ❌ Oh dear! keymanweb.js is 71,830 bytes (17%) larger than 17.0.229, now 485,221 bytes


### Second commit results

_**New**_
```
  build/lib/temp/index.js ─────────────────────────── 65.6kb ─ 100.0%
```

Contrast with the feature-branch's current lm-worker size:

_Old_
```
   build/lib/worker-main.mjs ─────────────────────────── 77.3kb ─ 100.0%
```

Also keep in mind:  for a top-level es6 target, we should be able to wholesale drop the polyfills that bloats it to this size in main Web:

_Old_
```
   ../../../../common/web/lm-worker/build/lib/worker-main.wrapped.min.js ───────────────── 91.6kb ─ 19.3%
```

Of note:  again, so far these scripts are not connected to the full Web toolchain.  They do give us useful information on how many bytes we can expect to 'save', though.  I also am not yet building the wrapped version of the es6-bundled worker.

Also of note:  these changes do not affect the standard Web build.  That said, I haven't yet run any tests or unit tests on either the old es5-oriented artifact or the new, potential es6 artifacts.

Also of note:  
- 16.0.144's minified KeymanWeb weighs in at 384 KB.
- 411.5 KB - (91.6 - 65.6 = 26 KB) = 385.5 KB.
    - As in, we'll likely end up with minimal growth in comparison to 16.0 stable, let alone 17.0-alpha `master`!