### PR TITLE
chore(linux): docker: fix Node.js install, make customizable

### DIFF
--- a/common/web/input-processor/README.md
+++ b/common/web/input-processor/README.md
@@ -8,13 +8,7 @@ The Keyboard Processor module is an internal component of KeymanWeb, seen within
 * A local installation of [Node.js](https://nodejs.org/) v8.9+.
 	* Builds will call `npm install` to automatically install further necessary build dependencies.
 
-	* Linux users can run the following to update to LTS version of nodejs
-	
-```
-sudo apt-get install python-software-properties
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-sudo apt-get install nodejs
-```
+	* Linux users can update to LTS version of nodejs by following instructions on the [NodeSource Distributions](https://github.com/nodesource/distributions#table-of-contents) page.
 
 **********************************************************************
 

--- a/common/web/keyboard-processor/README.md
+++ b/common/web/keyboard-processor/README.md
@@ -8,13 +8,7 @@ The Keyboard Processor module is an internal component of KeymanWeb, seen within
 * A local installation of [Node.js](https://nodejs.org/) v8.9+.
 	* Builds will call `npm install` to automatically install further necessary build dependencies.
 
-	* Linux users can run the following to update to LTS version of nodejs
-
-```
-sudo apt-get install python-software-properties
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-sudo apt-get install nodejs
-```
+	* Linux users can update to LTS version of nodejs by following instructions on the [NodeSource Distributions](https://github.com/nodesource/distributions#table-of-contents) page.
 
 **********************************************************************
 

--- a/docs/build/linux-ubuntu.md
+++ b/docs/build/linux-ubuntu.md
@@ -267,3 +267,21 @@ cd linux
 docker pull ubuntu:23.04 # (to make sure you have an up-to-date image)
 docker build . -t keymanapp/keyman-linux-builder:u23.04-node20 --build-arg OS_VERSION=23.04 --build-arg NODE_MAJOR=20
 ````
+
+### Using the builder with VSCode [Dev Containers](https://code.visualstudio.com/docs/devcontainers/tutorial)
+
+1. Save the following as `.devcontainer/devcontainer.json`, updating the `image` to match the Docker image built above.
+
+```json
+// file: .devcontainer/devcontainer.json
+{
+        "name": "Keyman Ubuntu 23.04",
+        "image": "keymanapp/keyman-linux-builder:u23.04-node18"
+}
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+```
+
+2. in VSCode, use the "Dev Containers: Open Folder In Container…" option and choose the Keyman directory.
+
+3. You will be given a window which is running VSCode inside this builder image, regardless of your host OS.

--- a/docs/build/linux-ubuntu.md
+++ b/docs/build/linux-ubuntu.md
@@ -260,7 +260,7 @@ Once the image is built, it may be used to build parts of Keyman.
 
 ### Customizing the builder
 
-You can use Docker [build args](https://docs.docker.com/build/guide/build-args/) to customize the image build. As an example, the following will build an image explicitly with Ubuntu 23.04 and Node.js 21
+You can use Docker [build args](https://docs.docker.com/build/guide/build-args/) to customize the image build. As an example, the following will build an image explicitly with Ubuntu 23.04 and Node.js 20
 
 ```shell
 cd linux

--- a/docs/build/linux-ubuntu.md
+++ b/docs/build/linux-ubuntu.md
@@ -260,7 +260,7 @@ Once the image is built, it may be used to build parts of Keyman.
 
 ### Customizing the builder
 
-You can use Docker [build args](https://docs.docker.com/build/guide/build-args/) to customize the image build. As an example, the following will build an image explicitly with Ubuntu 23.04 and Node.js 20
+You can use Docker [build args](https://docs.docker.com/build/guide/build-args/) to customize the image build. As an example, the following will build an image explicitly with Ubuntu 23.04 and Node.js 20. Check the [Dockerfile](../../linux/Dockerfile) for `ARG` entries.
 
 ```shell
 cd linux

--- a/docs/build/linux-ubuntu.md
+++ b/docs/build/linux-ubuntu.md
@@ -55,12 +55,7 @@ sudo mk-build-deps --install linux/debian/control
 
 Node.js v18 is required for Core builds, Web builds, and Developer command line tool builds and usage.
 
-You can install it with:
-
-```shell
-curl -sL https://deb.nodesource.com/setup_18.x | bash
-apt-get -q -y install nodejs
-```
+Follow the instructions on the [NodeSource Distributions](https://github.com/nodesource/distributions#table-of-contents) page.
 
 #### Emscripten
 

--- a/docs/build/linux-ubuntu.md
+++ b/docs/build/linux-ubuntu.md
@@ -215,7 +215,7 @@ To build the docker image:
 
 ```shell
 cd linux
-docker pull ubuntu:latest
+docker pull ubuntu:latest # (to make sure you have an up-to-date image)
 docker build . -t keymanapp/keyman-linux-builder:latest
 ```
 
@@ -262,3 +262,13 @@ Once the image is built, it may be used to build parts of Keyman.
     keymanapp/keyman-linux-builder:latest \
     android/build.sh --debug
   ```
+
+### Customizing the builder
+
+You can use Docker [build args](https://docs.docker.com/build/guide/build-args/) to customize the image build. As an example, the following will build an image explicitly with Ubuntu 23.04 and Node.js 21
+
+```shell
+cd linux
+docker pull ubuntu:23.04 # (to make sure you have an up-to-date image)
+docker build . -t keymanapp/keyman-linux-builder:u23.04-node20 --build-arg OS_VERSION=23.04 --build-arg NODE_MAJOR=20
+````

--- a/docs/build/old/web-notes.md
+++ b/docs/build/old/web-notes.md
@@ -9,10 +9,4 @@ WARNING: these are old configuration notes. See [index.md](../index.md) for curr
 * A local installation of [Node.js](https://nodejs.org/) v8.9+.
 	* Builds will call `npm install` to automatically install further necessary build dependencies.
 
-	* Linux users can run the following to update to LTS version of nodejs
-
-```
-sudo apt-get install python-software-properties
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-sudo apt-get install nodejs
-```
+	* Linux users can update to LTS version of nodejs by following instructions on the [NodeSource Distributions](https://github.com/nodesource/distributions#table-of-contents) page.

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -3,7 +3,10 @@
 # builder image for a linux build
 # see ../docs/build/linux-ubuntu.md
 
-FROM --platform=amd64 ubuntu:latest
+ARG OS_VERSION=latest
+ARG OS_PLATFORM=amd64
+
+FROM --platform=${OS_PLATFORM} ubuntu:${OS_VERSION}
 LABEL org.opencontainers.image.authors="SIL International."
 LABEL org.opencontainers.image.url="https://github.com/keymanapp/keyman.git"
 LABEL org.opencontainers.image.title="Keyman Linux Build Image"
@@ -33,8 +36,8 @@ RUN (yes | mk-build-deps --install /tmp/control) || true && \
   rm /tmp/control
 
 # Install Node
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash && \
-  apt-get -q -y install nodejs
+ARG NODE_MAJOR=18
+RUN apt-get install -q -y ca-certificates curl gnupg && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_"${NODE_MAJOR}".x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && apt-get update && apt-get install nodejs -y
 
 # Install emscripten
 RUN cd /usr/share && \

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -39,12 +39,13 @@ RUN (yes | mk-build-deps --install /tmp/control) || true && \
 ARG NODE_MAJOR=18
 RUN apt-get install -q -y ca-certificates curl gnupg && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_"${NODE_MAJOR}".x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && apt-get update && apt-get install nodejs -y
 
+ARG EMSCRIPTEN_VERSION=3.1.44
 # Install emscripten
 RUN cd /usr/share && \
   git clone https://github.com/emscripten-core/emsdk.git && \
   cd emsdk && \
-  ./emsdk install 3.1.44 && \
-  ./emsdk activate 3.1.44 && \
+  ./emsdk install ${EMSCRIPTEN_VERSION} && \
+  ./emsdk activate ${EMSCRIPTEN_VERSION} && \
   echo "#!/bin/bash" > /usr/bin/bashwrapper && \
   echo "export EMSCRIPTEN_BASE=/usr/share/emsdk/upstream/emscripten" >> /usr/bin/bashwrapper
 


### PR DESCRIPTION
🐋 
- fix the Node.js install script deprecation 
- fix the user-facing docs to just point people to <https://github.com/nodesource/distributions#ubuntu-versions> for installing.
- also make items configurable such as Ubuntu version and Node version

Fixes: chore(linux): script deprecation warning from nodesource #10024

@keymanapp-test-bot skip