### PR TITLE
fix(web): unit test for null-null keyboard switch event from #10245

### DIFF
--- a/web/src/test/auto/dom/cases/browser/contextManager.js
+++ b/web/src/test/auto/dom/cases/browser/contextManager.js
@@ -531,9 +531,9 @@ describe('app/browser:  ContextManager', function () {
         // Even though it's to effectively the same keyboard, we reload it (in case its stub
         // has been replaced)
         assert.isTrue(beforekeyboardchange.calledOnce);
-        assert.isTrue(keyboardchange.calledOnce);
+        // Changing from null-to-null should be a non change; see keyman/keymanweb#96.
+        assert.isFalse(keyboardchange.calledOnce);
         assert.isTrue(keyboardasyncload.notCalled);
-        assert.equal(keyboardchange.firstCall.args[0], null);
       });
 
       it('activate: without .activeTarget, null -> null (touch)', async () => {


### PR DESCRIPTION
Glad I double-checked the final build check status & investigated.

There was a unit test that expected the wrong behavior.  Behavior was corrected in #10245, but not the test... which means test failures will occur without this test-fix.

@keymanapp-test-bot skip