### PR TITLE
feat(web): adds highlighting to BKSP while held

### DIFF
--- a/web/src/engine/osk/src/input/gestures/heldRepeater.ts
+++ b/web/src/engine/osk/src/input/gestures/heldRepeater.ts
@@ -18,13 +18,23 @@ export class HeldRepeater implements GestureHandler {
 
   constructor(source: GestureSequence<KeyElement, string>, closureToRepeat: () => void) {
     this.source = source;
-    this.repeatClosure = closureToRepeat;
+
+    const baseKey = source.stageReports[0].item;
+    baseKey.key.highlight(true);
+
+    this.repeatClosure = () => {
+      closureToRepeat();
+      // The repeat-closure may cancel key highlighting.  This restores it afterward.
+      baseKey.key.highlight(true);
+    }
+
 
     this.timerHandle = window.setTimeout(this.deleteRepeater, HeldRepeater.INITIAL_DELAY);
 
     this.source.on('complete', () => {
       window.clearTimeout(this.timerHandle);
       this.timerHandle = undefined;
+      baseKey.key.highlight(false);
     });
   }
 


### PR DESCRIPTION
Fixes #10263.

The backspace key will now receive special-key highlighting when held, regardless of the duration and number of triggered BKSP repetitions while held.

## User Testing

TEST_SIMPLE_BACKSPACE:  Using the Keyman for Android app artifact from this PR, verify that a simple backspace-tap acts as expected.

1. Using the "EuroLatin (SIL)" keyboard...
2. Type `text`.
3. Tap the BKSP key once.
    - Verify that the BKSP key was highlighted when your finger was on it.
    - Verify that the BKSP key is no longer highlighted after the tap.

TEST_HELD_BACKSPACE:  Using the Keyman for Android app artifact from this PR, verify that a simple backspace-tap acts as expected.

1. Using the "EuroLatin (SIL)" keyboard...
2. Type `text`.
3. Press and hold the BKSP key - do not release it at this time.
4. Verify that the BKSP key is highlighted.
5. Verify that all text is deleted over time.
6. Release the BKSP key.
7. Verify that the BKSP key is no longer highlighted.