### PR TITLE
fix(mac): unit tests should expect core context clear after invalidate

### DIFF
--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
@@ -518,9 +518,6 @@ NSString * names[nCombinations];
 
 
 - (void)testEngine_ipaKeyboardAction_DoesNotCrash_Issue1892 {
-//  KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForSilIpaTests];
-//  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@"a" verboseLogging:YES];
-//  NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"=" charactersIgnoringModifiers:@"=" isARepeat:NO keyCode:kVK_ANSI_Equal];
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForIndexOffsetTests];
     KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"z" verboseLogging:YES];
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"a" charactersIgnoringModifiers:@"a" isARepeat:NO keyCode:kVK_ANSI_A];
@@ -533,21 +530,6 @@ NSString * names[nCombinations];
     XCTAssert([action isCharacter], @"Expected CharacterAction");
     XCTAssert([action.content isEqualToString:@"Z"], @"Expected output to be 'Z'.");
 }
-
-/*
-- (void)testLegacyProcessEvent_eventForFWithElNuerKmx_ReturnsCorrectCharacter {
-    KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
-    KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@"" verboseLogging:YES];
-    NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"f" charactersIgnoringModifiers:@"f" isARepeat:NO keyCode:kVK_ANSI_F];
-    NSArray *actions = [engine experimentallyProcessEventForUnitTestingOnly:event usingCore:NO];
-    XCTAssert(actions.count == 1, @"Expected one action");
-    NSDictionary *action = actions[0];
-    NSString *actionType = [[action allKeys] objectAtIndex:0];
-    XCTAssert([actionType isEqualToString:Q_STR], @"Expected Q_STR action");
-    NSString *output = [action objectForKey:actionType];
-    XCTAssert([output isEqualToString:@"ɣ"], @"Expected output to be 'ɣ'.");
-}
-*/
 
 - (void)testCoreProcessEvent_eventForFWithElNuerKmx_ReturnsCorrectCharacter {
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
@@ -572,20 +554,7 @@ NSString * names[nCombinations];
     XCTAssert([context isEqualToString:@""], @"Context should be empty.");
 }
 
-/*
-- (void)testLegacyProcessEvent_eventDeleteWithElNuerKmx_ReturnsEmptyActionListContextUnchanged {
-    KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
-    KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@"ɣ" verboseLogging:YES];
-    NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\b" charactersIgnoringModifiers:@"\b" isARepeat:NO keyCode:kVK_Delete];
-    NSArray *actions = [engine experimentallyProcessEventForUnitTestingOnly:event usingCore:NO];
-    XCTAssert(actions.count == 0, @"Expected no actions");
-    NSString *context = engine.contextBuffer;
-    XCTAssert([context isEqualToString:@"ɣ"], @"Context should be unchanged.");
-}
-*/
-
-
-- (void)testCoreProcessEvent_eventReturnWithElNuerKmx_ContextUnchangedReturnsReturn {
+- (void)testCoreProcessEvent_eventReturnWithElNuerKmx_EmitWithContextEmpty {
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
     KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"ɣ" verboseLogging:YES];
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\n" charactersIgnoringModifiers:@"\n" isARepeat:NO keyCode:kVK_Return];
@@ -594,22 +563,10 @@ NSString * names[nCombinations];
     CoreAction *action = actions[1];
     XCTAssert(action.actionType == EmitKeystrokeAction, @"Expected EmitKeystrokeAction");
     NSString *context = engine.getCoreContext;
-    XCTAssert([context isEqualToString:@"ɣ"], @"Context should be unchanged.");
+    XCTAssert([context isEqualToString:@""], @"Context should be cleared.");
 }
 
-/*
-- (void)testLegacyProcessEvent_eventReturnWithElNuerKmx_ReturnsEmptyActionListContextUnchanged {
-    KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
-    KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@"ɣ" verboseLogging:YES];
-    NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\n" charactersIgnoringModifiers:@"\n" isARepeat:NO keyCode:kVK_Return];
-    NSArray *actions = [engine experimentallyProcessEventForUnitTestingOnly:event usingCore:NO];
-    XCTAssert(actions.count == 0, @"Expected no actions");
-    NSString *context = engine.contextBuffer;
-    XCTAssert([context isEqualToString:@"ɣ"], @"Context should be unchanged.");
-}
-*/
-
-- (void)testCoreProcessEvent_eventTabWithElNuerKmx_ContextUnchangedReturnsTab {
+- (void)testCoreProcessEvent_eventTabWithElNuerKmx_EmitWithContextEmpty {
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
     KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"ɣ" verboseLogging:YES];
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\t" charactersIgnoringModifiers:@"\t" isARepeat:NO keyCode:kVK_Tab];
@@ -618,20 +575,8 @@ NSString * names[nCombinations];
     CoreAction *action = actions[1];
     XCTAssert(action.actionType == EmitKeystrokeAction, @"Expected EmitKeystrokeAction");
     NSString *context = engine.getCoreContext;
-    XCTAssert([context isEqualToString:@"ɣ"], @"Context should be unchanged.");
+    XCTAssert([context isEqualToString:@""], @"Context should be cleared.");
 }
-
-/*
-- (void)testLegacyProcessEvent_eventTabWithElNuerKmx_ReturnsEmptyActionListContextUnchanged {
-    KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
-    KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@"ɣ" verboseLogging:YES];
-    NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\t" charactersIgnoringModifiers:@"\n" isARepeat:NO keyCode:kVK_Tab];
-    NSArray *actions = [engine experimentallyProcessEventForUnitTestingOnly:event usingCore:NO];
-    XCTAssert(actions.count == 0, @"Expected no actions");
-    NSString *context = engine.contextBuffer;
-    XCTAssert([context isEqualToString:@"ɣ"], @"Context should be unchanged.");
-}
-*/
 
 - (void)testCoreProcessEvent_eventSingleQuoteWithElNuerKmx_ReturnsDiacritic {
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
@@ -645,25 +590,5 @@ NSString * names[nCombinations];
     context = engine.getCoreContext;
     XCTAssert([context isEqualToString:@"\u025B\u0308"], @"Context updated with diacritic.");
 }
-
-/*
-- (void)testLegacyProcessEvent_eventSingleQuoteWithElNuerKmx_ReturnsTwoActions {
-    KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
-    NSString *context = @"ɛ";
-    KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:context verboseLogging:YES];
-    NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"'" charactersIgnoringModifiers:@"'" isARepeat:NO keyCode:kVK_ANSI_Quote];
-    NSArray *actions = [engine experimentallyProcessEventForUnitTestingOnly:event usingCore:NO];
-    XCTAssert(actions.count == 2, @"Expected two actions");
-    NSDictionary *action = actions[0];
-    NSString *actionType = [[action allKeys] objectAtIndex:0];
-    XCTAssert([actionType isEqualToString:Q_BACK], @"Expected Q_BACK action");
-    action = actions[1];
-    actionType = [[action allKeys] objectAtIndex:0];
-    NSString *characters = [action objectForKey:actionType];
-    XCTAssert([characters isEqualToString:@"\u025B\u0308"], @"Expected \u025B\u0308");
-    context = engine.contextBuffer;
-    XCTAssert([context isEqualToString:@"\u025B\u0308"], @"Context updated with diacritic.");
-}
-*/
 
 @end


### PR DESCRIPTION
Fix two units that are expecting the context to be unchanged after a tab and enter keys are processed by core. These keys invalidate the context and should cause the core to clear the context.

@keymanapp-test-bot skip
