### PR TITLE
fix(mac): write persisted options returned from Core

### DIFF
--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj/xcshareddata/xcschemes/KeymanEngine4Mac.xcscheme
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj/xcshareddata/xcschemes/KeymanEngine4Mac.xcscheme
@@ -48,9 +48,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "KMEngineTests/testArmenianMnemonic_triggerPersistOptions_ReturnsOptions">
-               </Test>
-               <Test
                   Identifier = "KMEngineTests/testCheckPlatform_Browsers_ReturnsNo">
                </Test>
                <Test

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
@@ -191,28 +191,18 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
 }
 
 -(NSDictionary*)convertOptionsArray:(km_core_option_item*)options {
-  NSDictionary* optionsDictionary = nil;
-  unichar const * optionsKey = options->key;
-  unichar const * optionsValue = options->value;
-  if ((optionsKey != nil) && (optionsValue != nil)) {
-    optionsDictionary = [[NSDictionary alloc] init];
-    NSString *key = [self.coreHelper createNSStringFromUnicharString:optionsKey];
-    NSString *value = [self.coreHelper createNSStringFromUnicharString:optionsValue];
-    [optionsDictionary insertValue:value inPropertyWithKey:key];
-  }
-/*
+  NSMutableDictionary* optionsDictionary = nil;
   if (options) {
-    optionsDictionary = [[NSDictionary alloc] init];
+    optionsDictionary = [[NSMutableDictionary alloc] init];
     for (; options->key != 0; ++options) {
       unichar const * optionsKey = options->key;
       unichar const * valueKey = options->value;
 
       NSString *key = [self.coreHelper createNSStringFromUnicharString:optionsKey];
       NSString *value = [self.coreHelper createNSStringFromUnicharString:valueKey];
-      [optionsDictionary insertValue:value inPropertyWithKey:key];
+      [optionsDictionary setObject:value forKey:key];
     }
   }
- */
   return optionsDictionary;
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
@@ -542,13 +542,15 @@ NSString * names[nCombinations];
     XCTAssert(!output.emitKeystroke, @"expected to emit nothing");
 }
 
-// TODO: enable after resolving issue getting options from Keyman Core
 - (void)testArmenianMnemonic_triggerPersistOptions_ReturnsOptions {
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForArmenianMnemonicTests];
     KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"√" verboseLogging:YES];
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"w" charactersIgnoringModifiers:@"w" isARepeat:NO keyCode:kVK_ANSI_W];
     CoreKeyOutput *output = [engine processEvent:event];
-    XCTAssert(!output.hasCodePointsToDelete, @"expected to delete nothing");
+    NSString *key = @"option_ligature_ew";
+    NSDictionary *options = output.optionsToPersist;
+    NSString *value = options[key];
+    XCTAssertEqualObjects(value, @"1", @"expected 'option_ligature_ew' with value of '1'");
 }
 
 - (void)testCoreProcessEvent_backspaceElNuerEmptyContext_PassesThrough {


### PR DESCRIPTION
Consume the persisted options action returned from Keyman Core and persist it to the User Defaults for Keyman. 

Fixes #10273

# User Testing

**TEST_ARMENIAN_OPTION_CHANGE**: 

- Open the Stickies app on the Mac and create a new note
- Switch to the Armenian Mnemonic keyboard 
- Type <kbd>e</kbd><kbd>w</kbd>
- Confirm that this produces the output: եւ
- Type option-v, w (this toggles a setting within Keyman for this specific keyboard)
- Type <kbd>e</kbd><kbd>w</kbd>
- Confirm that this same input as earlier now produces the output: և

**TEST_ARMENIAN_OPTION_PERSISTED**: 

- Restart the computer after the above test is completed
- Open the Stickies app on the Mac and create a new note
- Switch to the Armenian Mnemonic keyboard 
- Type <kbd>e</kbd><kbd>w</kbd>
- Confirm that this produces the output: և
- This shows the option from the previous Keyman session was persisted and loaded correctly back to Core