### PR TITLE
fix(web): default multitap logic for shift-layer shift multitaps

### DIFF
--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -859,7 +859,7 @@ export class ActiveLayout implements LayoutFormFactor{
       const shiftShift   = shiftLayer ?.getKey('K_SHIFT');
 
       // If BOTH default & shift layer SHIFT keys lack multitaps & longpresses, proceed.
-      if(shiftShift && // doesn't make much sense if there's no shift layer or SHIFT on it
+      if(defaultShift && shiftShift && // doesn't make much sense if there's no shift layer or SHIFT on either
         !defaultShift.multitap && !shiftShift.multitap &&
         !defaultShift.sk       && !shiftShift.sk
       ) {

--- a/common/web/keyboard-processor/src/keyboards/defaultLayouts.ts
+++ b/common/web/keyboard-processor/src/keyboards/defaultLayouts.ts
@@ -526,7 +526,7 @@ export class Layouts {
     return KLS;
   }
 
-  static dfltShiftMultitap: LayoutSubKey = {
+  static dfltShiftToCaps: LayoutSubKey = {
     // Needs to be something special and unique.  Typing restricts us from
     // using a reserved key-id prefix, though.
     id: "T_*_MT_SHIFT_TO_CAPS",
@@ -535,13 +535,20 @@ export class Layouts {
     nextlayer: 'caps'
   }
 
-  static dfltShiftRotaDefault: LayoutSubKey = {
+  static dfltShiftToDefault: LayoutSubKey = {
     // Needs to be something special and unique.  Typing restricts us from
     // using a reserved key-id prefix, though.
-    id: "T_*_MT_SHIFT_ROTA_TO_DEFAULT",
+    id: "T_*_MT_SHIFT_TO_DEFAULT",
     text: '*Shift*',
     sp: 1,
     nextlayer: 'default'
+  }
+
+  static dfltShiftToShift: LayoutSubKey = {
+    id: "T_*_MT_SHIFT_TO_SHIFT",
+    text: '*Shift*',
+    sp: 1,
+    nextlayer: 'shift'
   }
 
   // Defines the default visual layout for a keyboard.

--- a/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file.ts
+++ b/common/web/types/src/keyman-touch-layout/keyman-touch-layout-file.ts
@@ -52,8 +52,9 @@ export const PRIVATE_USE_IDS = [
    * Private-use identifiers used by KeymanWeb for the default multitap-into-caps-layer key
    * for keyboards with a caps layer while not defining multitaps on shift.
    */
+  'T_*_MT_SHIFT_TO_SHIFT',
   'T_*_MT_SHIFT_TO_CAPS',
-  'T_*_MT_SHIFT_ROTA_TO_DEFAULT'
+  'T_*_MT_SHIFT_TO_DEFAULT'
 ] as const;
 
 /* A map of key field names with values matching the `typeof` the corresponding property


### PR DESCRIPTION
Fixes #10272.

When on the shift layer, our default 'caps' layer multitap logic should act as follows:
1. First tap:  default layer
2. Second tap:  caps layer
3. Third tap: return to shift layer
4. Return to step 1 - default layer.  (Things rotate from here.)

In 16.0, steps 1 and 2 (at a minimum) were in place... and I missed this fact when migrating the default multitap logic to the new gesture engine.  This PR fixes the regression.  (Rota behavior - steps 3+ - wasn't expected or implemented at the time, though.)

**NOTE**: The fact that _both_ the `default` and `shift` layer SHIFT keys get multitaps when relying on Keyman multitap defaults suggests to me that we should condition on both SHIFT keys, not just one of them - and so I moved the logic to a location that can check against the properties of both.  It is possible that this point should be debated a bit, though.

## User Testing

TEST_MULTITAP_FROM_SHIFT:  Using the Keyman for Android app and the "EuroLatin (SIL)" keyboard, verify that this fixes the issue.

1. If not already on the keyboard's `shift` layer, activate the `shift` layer.  Wait 1 second before proceeding.
2. Double-tap the SHIFT key.
3. Verify that the `caps` layer is active - there should be a small underline beneath the SHIFT key's up-arrow.
4. Type `CAPS`, verifying that the layer does not change while typing.

TEST_SHIFT_ROTA:  Using the Keyman for Android app and the "EuroLatin (SIL)" keyboard...

1. If not already on the keyboard's `shift` layer, activate the `shift` layer.  Wait 1 second before proceeding.
2. Triple-tap the SHIFT key.
3. Verify that the `shift` layer is once again active.
4. Type `Caps` - after the `C`, the layer should return to `default` automatically.


TEST_MULTITAP_FROM_DEFAULT:  Using the Keyman for Android app and the "EuroLatin (SIL)" keyboard...

1. If not already on the keyboard's `default` layer, activate the `default` layer.  Wait 1 second before proceeding.
2. Double-tap the SHIFT key.
3. Verify that the `caps` layer is active - there should be a small underline beneath the SHIFT key's up-arrow.
4. Type `CAPS`, verifying that the layer does not change while typing.

TEST_DEFAULT_ROTA:  Using the Keyman for Android app and the "EuroLatin (SIL)" keyboard...

1. If not already on the keyboard's `default` layer, activate the `default` layer.  Wait 1 second before proceeding.
2. Triple-tap the SHIFT key.
3. Verify that the `default` layer is once again active.
4. Type `caps`, verifying that the layer does not change while typing.