### PR TITLE
fix(mac): Improve detection of non-compliant apps

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -319,10 +319,13 @@ NSRange _previousSelRange;
 //MARK: Core-related key processing
 
 - (void)checkTextApiCompliance:(id)client {
-  // if TextApiCompliance object is null or stale,
-  // then create a new one for the current application
+  // if TextApiCompliance object is nil or the app or the context has changed,
+  // then create a new one for the current application and context
+  // the text api compliance may be different from one text field to another
   
-  if ((self.apiCompliance == nil) || (![self.apiCompliance.clientApplicationId isEqualTo:self.clientApplicationId])) {
+  if ((self.apiCompliance == nil) ||
+      (![self.apiCompliance.clientApplicationId isEqualTo:self.clientApplicationId]) ||
+      self.contextChanged) {
     self.apiCompliance = [[TextApiCompliance alloc]initWithClient:client applicationId:self.clientApplicationId];
     [self.appDelegate logDebugMessage:@"KMInputMethodHandler initWithClient checkTextApiCompliance: %@", _apiCompliance];
   } else if (self.apiCompliance.isComplianceUncertain) {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -319,9 +319,9 @@ NSRange _previousSelRange;
 //MARK: Core-related key processing
 
 - (void)checkTextApiCompliance:(id)client {
-  // if TextApiCompliance object is nil or the app or the context has changed,
-  // then create a new one for the current application and context
-  // the text api compliance may be different from one text field to another
+  // If the TextApiCompliance object is nil or the app or the context has changed,
+  // then create a new object for the current application and context.
+  // The text api compliance may vary from one text field to another of the same app.
   
   if ((self.apiCompliance == nil) ||
       (![self.apiCompliance.clientApplicationId isEqualTo:self.clientApplicationId]) ||
@@ -329,7 +329,7 @@ NSRange _previousSelRange;
     self.apiCompliance = [[TextApiCompliance alloc]initWithClient:client applicationId:self.clientApplicationId];
     [self.appDelegate logDebugMessage:@"KMInputMethodHandler initWithClient checkTextApiCompliance: %@", _apiCompliance];
   } else if (self.apiCompliance.isComplianceUncertain) {
-    // if it is valid but compliance is uncertain, then test it
+    // We have a TextApiCompliance object is valid, but compliance is uncertain, so test it
     [self.apiCompliance testCompliance:client];
   }
 }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -329,7 +329,7 @@ NSRange _previousSelRange;
     self.apiCompliance = [[TextApiCompliance alloc]initWithClient:client applicationId:self.clientApplicationId];
     [self.appDelegate logDebugMessage:@"KMInputMethodHandler initWithClient checkTextApiCompliance: %@", _apiCompliance];
   } else if (self.apiCompliance.isComplianceUncertain) {
-    // We have a TextApiCompliance object is valid, but compliance is uncertain, so test it
+    // We have a valid TextApiCompliance object, but compliance is uncertain, so test it
     [self.apiCompliance testCompliance:client];
   }
 }

--- a/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
@@ -174,7 +174,8 @@ return [NSString stringWithFormat:@"complianceUncertain: %d, hasCompliantSelecti
 *  This was formerly called the legacy app list, renamed to improve clarity.
 */
 - (BOOL)containedInHardCodedNoncompliantAppList:(NSString *)clientAppId {
-    BOOL isAppNonCompliant = ([clientAppId isEqual: @"com.github.atom"] ||
+    BOOL isAppNonCompliant = (//[clientAppId isEqual: @"com.github.atom"] ||
+                              // 2023-12-19[sgs] Atom is now automatically detected as non-compliant
                      [clientAppId isEqual: @"com.collabora.libreoffice-free"] ||
                      [clientAppId isEqual: @"org.libreoffice.script"] ||
                      [clientAppId isEqual: @"org.vim.MacVim"] ||


### PR DESCRIPTION
This addresses two cases with non-compliance:
1) apps that report a seemingly valid selection (location and length) but the selection does not change after a character is inserted
2) apps for which the compliance varies when the context changes from one text field to another within the same application (e.g. Safari, switching from the URL field to the content area of Google Docs)

Fixes #10247

@keymanapp-test-bot skip