### PR TITLE
fix(web): special key highlighting when pressed

### DIFF
--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1126,13 +1126,12 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     // even if for a different contact point.
     on = modalVizActive ? false : on;
 
+    key.key.highlight(on);
     if(!on) {
-      key.key.highlight(on);
       return null;
     }
 
     if (usePreview) {
-      key.key.highlight(on);
       if(this.gesturePreviewHost) {
         return null; // do not override lingering previews for still-active gestures.
       } else {


### PR DESCRIPTION
Fixes #10280.

While we don't show key previews for 'special' keys, we should still show highlighting when they're pressed.

## User Testing

TEST_ENTER_HIGHLIGHT_DESKTOP: Using the "Test Inline OSK" test page for KeymanWeb, verify that the ENTER key receives highlighting when pressed.

1. Click on the first text area (with placeholder text "Type here").
2. Hit the ENTER key once.
3. Verify that the key was highlighted when pressed and is no longer highlighted once released.

TEST_ENTER_HIGHLIGHT_IOS: Using the "Test Inline OSK" test page for KeymanWeb, verify that the ENTER key receives highlighting when pressed.

1. At the bottom of the page, click the button labeled "setOSK(ios)".  The OSK should change to that of a touch keyboard.
    - Note:  the keyboard's globe key may not function.  This is fine.
    - The key caps may not be ideally sized.  Even if so, that detail is irrelevant to this test.
2. Click on the first text area (with placeholder text "Type here").
3. Hit the ENTER key once.
4. Verify that the key was highlighted when pressed and is no longer highlighted once released.

TEST_DEHIGHLIGHT_FALLBACK: Using the "Test Inline OSK" test page for KeymanWeb, on a Windows computer, verify that the ENTER key receives highlighting when pressed.

1. At the bottom of the page, click the button labeled "setOSK(ios)".  The OSK should change to that of a touch keyboard.
    - Note:  the keyboard's globe key may not function.  This is fine.
    - The key caps may not be ideally sized.  Even if so, that detail is irrelevant to this test.
2. Click on the first text area (with placeholder text "Type here").
3. Press and hold the ENTER key.
4. On your physical keyboard, press the Windows key to summon the system Start menu.
5. Dismiss the start menu and click on the title bar or address bar of your browser's window.
    - The ENTER key should still be highlighted; this is intentional for this test.
    - Do not click within the test page itself yet; this will likely clear the highlighting prematurely.
    - If not highlighted, repeat steps 3 to 5 until it remains highlighted.
6. With the ENTER key still highlighted, press the 'h' key.
7. Verify that the ENTER key is no longer highlighted.
8. Release the 'h' key, then verify that the 'h' key is no longer highlighted.