### PR TITLE
fix(web): adds null-guard for longpress-key validation

### DIFF
--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -442,7 +442,7 @@ export function longpressContactModel(params: GestureParams, enabledFlicks: bool
     timer: {
       duration: spec.waitLength,
       expectedResult: true,
-      validateItem: (key: KeyElement) => !!key.key.spec.sk
+      validateItem: (key: KeyElement) => !!key?.key.spec.sk
     },
     pathModel: {
       evaluate: (path) => {


### PR DESCRIPTION
Should there not be a selectable key at an active touchpoint (say, due to blank keys), we should prevent `null` errors when checking for triggering longpresses.  In such a case, we'd fail to lookup subkeys on a `null`/`undefined` key.

Assuming we have a valid, non-null object for the key, the rest of the properties should be exist, save perhaps for the final one (`.sk`).  If they don't, that's a separate error and would be worth much more of an investigation.

@keymanapp-test-bot skip