### PR TITLE
fix(windows): serve images for readme files in Keyboard Install

### DIFF
--- a/windows/src/desktop/kmshell/web/Keyman.Configuration.System.HttpServer.App.pas
+++ b/windows/src/desktop/kmshell/web/Keyman.Configuration.System.HttpServer.App.pas
@@ -60,6 +60,7 @@ implementation
 
 uses
   System.Contnrs,
+  System.RegularExpressions,
   System.StrUtils,
   System.SysUtils,
 
@@ -282,9 +283,21 @@ var
   tag: Integer;
   u: IInterface;
   PageTag: string;
+  regex: TRegEx;
+  matches: TMatch;
 begin
   Result := False;
   PageTag := RequestInfo.Params.Values['tag'];
+  if PageTag = '' then
+  begin
+    // TIdUri does not have a parameter parser, and while there are other
+    // classes we could use, a regex is adequate for this task
+    regex := TRegEx.Create('tag=(\d+)');
+    matches := regex.Match(RequestInfo.Referer);
+    if matches.Success then
+      PageTag := matches.Groups[1].Value;
+  end;
+
   tag := StrToIntDef(PageTag, -1);
   if tag >= 0 then
   begin


### PR DESCRIPTION
Fixes #10308.

When a file is requested without a tag parameter, we need to look to the referer to find out what the tag is, so we can associate it with the correct readme file.

# User Testing

TEST_INSTALL_README: Try and install the package in readme_images_10308.zip from #10308. Verify that the flag image shows in the Readme tab.