### PR TITLE
fix(developer): cleanly handle filling a new osk file from layout

### DIFF
--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -364,6 +364,12 @@ export class KmnCompiler implements KeymanCompiler, UnicodeSetParser {
   private runKvkCompiler(kvksFilename: string, kmnFilename: string, kmxFilename: string, displayMap?: Osk.PuaMap) {
     // The compiler detected a .kvks file, which needs to be captured
     kvksFilename = this.callbacks.resolveFilename(kmnFilename, kvksFilename);
+    const data = this.callbacks.loadFile(kvksFilename);
+    if(!data) {
+      this.callbacks.reportMessage(CompilerMessages.Error_FileNotFound({filename: kvksFilename}));
+      return null;
+    }
+
     const filename = this.callbacks.path.basename(kvksFilename);
     let basename = null;
     let vk: VisualKeyboard.VisualKeyboard = null;
@@ -373,7 +379,7 @@ export class KmnCompiler implements KeymanCompiler, UnicodeSetParser {
       basename = this.callbacks.path.basename(kvksFilename, KeymanFileTypes.Binary.VisualKeyboard);
       const reader = new KvkFileReader();
       try {
-        vk = reader.read(this.callbacks.loadFile(kvksFilename));
+        vk = reader.read(data);
       } catch(e) {
         this.callbacks.reportMessage(CompilerMessages.Error_InvalidKvkFile({filename, e}));
         return null;
@@ -383,7 +389,7 @@ export class KmnCompiler implements KeymanCompiler, UnicodeSetParser {
       const reader = new KvksFileReader();
       let kvks = null;
       try {
-        kvks = reader.read(this.callbacks.loadFile(kvksFilename));
+        kvks = reader.read(data);
         reader.validate(kvks);
       } catch(e) {
         this.callbacks.reportMessage(CompilerMessages.Error_InvalidKvksFile({filename, e}));

--- a/developer/src/tike/child/UfrmKeymanWizard.pas
+++ b/developer/src/tike/child/UfrmKeymanWizard.pas
@@ -2963,6 +2963,7 @@ begin
     kbdparser.AddRequiredLines;
     kbdparser.SetSystemStoreValue(ssTargets, 'windows native');
     kbdparser.SetSystemStoreValue(ssVersion, SKeymanVersion90);
+    kbdparser.DeleteSystemStore(ssVisualKeyboard);
     kbdparser.DeleteSystemStore(ssBitmap);
 
     FIncludeCodes := kbdparser.GetSystemStoreValue(ssIncludeCodes);   // I4979


### PR DESCRIPTION
Fixes #10315.

When filling from layout, if the .kvks file did not exist, an obscure error was generated:

    Error: 2908 Error encountered parsing eo_plus.kvks: TypeError: Cannot read properties of null (reading 'byteLength')

Fixed this by checking for file existence before attempting to process, which then reports a more understandable error of 'file not found'.

Then, needed to tweak the caller in Keyman Developer IDE to remove the reference to the .kvks file before attempting to build (chicken-and-egg).

@keymanapp-test-bot skip