### PR TITLE
fix(developer): new file support for project 2.0

### DIFF
--- a/developer/src/tike/actions/dmActionsMain.pas
+++ b/developer/src/tike/actions/dmActionsMain.pas
@@ -299,31 +299,38 @@ uses
 procedure TmodActionsMain.actFileNewExecute(Sender: TObject);
 var
   FEditor: TfrmTikeEditor;
+  frmNew: TfrmNew;
 begin
-  with TfrmNew.Create(frmKeymanDeveloper) do
+  frmNew := TfrmNew.Create(frmKeymanDeveloper);
   try
-    if ShowModal = mrOk then
+    frmNew.CanAddToProject := FGlobalProject.Options.Version = pv10;
+    if frmNew.ShowModal = mrOk then
     begin
-      case FileType of
-        ftKeymanSource:    FEditor := TfrmKeymanWizard.Create(frmKeymanDeveloper);
-        ftPackageSource:   FEditor := TfrmPackageEditor.Create(frmKeymanDeveloper);
-        ftBitmap:          FEditor := TfrmBitmapEditor.Create(frmKeymanDeveloper);
-        ftVisualKeyboard:  FEditor := TfrmOSKEditor.Create(frmKeymanDeveloper);
-        ftTextFile:        begin FEditor := TfrmEditor.Create(frmKeymanDeveloper); (FEditor as TfrmEditor).EditorFormat := efText; end;
-        ftXMLFile:         begin FEditor := TfrmEditor.Create(frmKeymanDeveloper); (FEditor as TfrmEditor).EditorFormat := efXML; end;
-        ftHTMLFile:        begin FEditor := TfrmEditor.Create(frmKeymanDeveloper); (FEditor as TfrmEditor).EditorFormat := efHTML; end;
-      else
-        FEditor := TfrmEditor.Create(frmKeymanDeveloper);
-      end;
-      if FileName <> '' then
+      if SameFileName(ExtractFilePath(FGlobalProject.FileName), ExtractFilePath(frmNew.FileName)) or
+        SameFileName(FGlobalProject.ResolveProjectPath(FGlobalProject.Options.SourcePath), ExtractFilePath(frmNew.FileName)) then
       begin
-        if AddToProject then
-          FEditor.ProjectFile := CreateProjectFile(FGlobalProject, FileName, nil);
-        FEditor.OpenFile(FileName);
+        // File belongs to the project
+        case frmNew.FileType of
+          ftKeymanSource:    FEditor := TfrmKeymanWizard.Create(frmKeymanDeveloper);
+          ftPackageSource:   FEditor := TfrmPackageEditor.Create(frmKeymanDeveloper);
+          ftBitmap:          FEditor := TfrmBitmapEditor.Create(frmKeymanDeveloper);
+          ftVisualKeyboard:  FEditor := TfrmOSKEditor.Create(frmKeymanDeveloper);
+          ftTextFile:        begin FEditor := TfrmEditor.Create(frmKeymanDeveloper); (FEditor as TfrmEditor).EditorFormat := efText; end;
+          ftXMLFile:         begin FEditor := TfrmEditor.Create(frmKeymanDeveloper); (FEditor as TfrmEditor).EditorFormat := efXML; end;
+          ftHTMLFile:        begin FEditor := TfrmEditor.Create(frmKeymanDeveloper); (FEditor as TfrmEditor).EditorFormat := efHTML; end;
+        else
+          FEditor := TfrmEditor.Create(frmKeymanDeveloper);
+        end;
+        FEditor.ProjectFile := CreateProjectFile(FGlobalProject, frmNew.FileName, nil);
+        FEditor.OpenFile(frmNew.FileName);
+      end
+      else
+      begin
+        frmKeymanDeveloper.OpenFilesInProject([frmNew.FileName]);
       end;
     end;
   finally
-    Free;
+    frmNew.Free;
   end;
 end;
 

--- a/developer/src/tike/dialogs/UfrmNew.pas
+++ b/developer/src/tike/dialogs/UfrmNew.pas
@@ -65,6 +65,7 @@ type
       Selected: Boolean);
   private
     FRootPath: string;
+    FCanAddToProject: Boolean;
     function GetFileType: TKMFileType;
     procedure GetIcon(s: string; index: Integer);   // I4821
     procedure UpdateFileName;
@@ -74,12 +75,14 @@ type
     function GetDefaultExt: string;
     function CheckFilenameConventions: Boolean;
     function FileIsAppropriateForProject: Boolean;
+    procedure SetCanAddToProject(const Value: Boolean);
   protected
     function GetHelpTopic: string; override;
   public
     property FileType: TKMFileType read GetFileType;
     property AddToProject: Boolean read GetAddToProject;
     property FileName: string read GetFileName;
+    property CanAddToProject: Boolean read FCanAddToProject write SetCanAddToProject;
   end;
 
 implementation
@@ -204,6 +207,7 @@ procedure TfrmNew.EnableControls;
 var
   e: Boolean;
 begin
+  chkAddToProject.Visible := FCanAddToProject;
   e := Assigned(lvItems.Selected);
   editFileName.Enabled := e;
   cmdBrowse.Enabled := e;
@@ -217,7 +221,7 @@ var
   i: Integer;
 begin
   inherited;
-  FRootPath := ExtractFilePath(FGlobalProject.FileName);
+  FRootPath := FGlobalProject.ResolveSourcePath;
 
   lvItems.Selected := lvItems.Items[0];
   lvItems.ItemFocused := lvItems.Items[0];
@@ -319,6 +323,14 @@ end;
 procedure TfrmNew.mnuShowIconsClick(Sender: TObject);
 begin
   lvItems.ViewStyle := vsIcon;
+end;
+
+procedure TfrmNew.SetCanAddToProject(const Value: Boolean);
+begin
+  FCanAddToProject := Value;
+  if not Value then
+    chkAddToProject.Checked := False;
+  EnableControls;
 end;
 
 procedure TfrmNew.UpdateFileName;

--- a/developer/src/tike/dialogs/UfrmNewFileDetails.pas
+++ b/developer/src/tike/dialogs/UfrmNewFileDetails.pas
@@ -51,16 +51,19 @@ type
   private
     FFileType: TKMFileType;
     FDefaultExt: string;
+    FCanChangePath: Boolean;
     procedure SetFileType(const Value: TKMFileType);
     procedure EnableControls;
     function GetFileName: string;
     procedure SetBaseFileName(Value: string);
+    procedure SetCanChangePath(const Value: Boolean);
   protected
     function GetHelpTopic: string; override;
   public
     property FileName: string read GetFileName;
     property FileType: TKMFileType read FFileType write SetFileType;
     property BaseFileName: string write SetBaseFileName;
+    property CanChangePath: Boolean write SetCanChangePath;
   end;
 
 implementation
@@ -111,6 +114,12 @@ begin
   editFileName.Text := '';   // I4798
 end;
 
+procedure TfrmNewFileDetails.SetCanChangePath(const Value: Boolean);
+begin
+  FCanChangePath := Value;
+  EnableControls;
+end;
+
 procedure TfrmNewFileDetails.SetFileType(const Value: TKMFileType);
 begin
   FFileType := Value;
@@ -126,6 +135,10 @@ end;
 
 procedure TfrmNewFileDetails.EnableControls;
 begin
+  editFilePath.ReadOnly := not FCanChangePath;
+  editFilePath.ParentColor := editFilePath.ReadOnly;
+  if not editFilePath.ParentColor then editFilePath.Color := clWindow;
+
   cmdOK.Enabled := Trim(ChangeFileExt(ExtractFileName(editFileName.Text), '')) <> '';
 end;
 

--- a/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFile.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFile.pas
@@ -185,7 +185,6 @@ type
     procedure MRUChange(Sender: TObject);
     procedure UpdateFileParameters;
     function GetUserFileName: string;
-    function ResolveProjectPath(APath: string): string;
     procedure PopulateFolder(const path: string);
     function GetTargetFilename10(ATargetFile, ASourceFile,
       AVersion: string): string;
@@ -208,6 +207,9 @@ type
     function Render: WideString;
 
     function IsDefaultProject(Version: TProjectVersion): Boolean;
+
+    function ResolveProjectPath(APath: string): string;
+    function ResolveSourcePath: string;
 
     function Load: Boolean; virtual;   // I4694
     function Save: Boolean; virtual;   // I4694
@@ -1231,6 +1233,13 @@ end;
 function TProject.ResolveProjectPath(APath: string): string;
 begin
   Result := IncludeTrailingPathDelimiter(ReplaceText(APath, '$PROJECTPATH', ExtractFileDir(ExpandFileName(FFileName))));
+end;
+
+function TProject.ResolveSourcePath: string;
+begin
+  if FOptions.Version = pv10
+    then Result := ExtractFilePath(FFileName)
+    else Result := ResolveProjectPath(FOptions.SourcePath);
 end;
 
 function TProject.GetTargetFilename10(ATargetFile, ASourceFile, AVersion: string): string;   // I4688

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProject.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmProject.pas
@@ -407,6 +407,7 @@ var
   FFileType: TKMFileType;
   FDefaultExtension: string;
   i: Integer;
+  frmNewFileDetails: TfrmNewFileDetails;
 begin
   pf := nil;
 
@@ -414,18 +415,19 @@ begin
   if Command = 'fileaddnew' then
   begin
     { create a new file, add it to the project }
-    Assert(FGlobalProject.Options.Version = pv10);
-    with TfrmNewFileDetails.Create(Self) do
-    try
-      BaseFileName := FGlobalProject.FileName;
-      FileType := FileTypeFromParamType;
 
-      if ShowModal = mrOk then
+    frmNewFileDetails := TfrmNewFileDetails.Create(Self);
+    try
+      frmNewFileDetails.BaseFileName := FGlobalProject.ResolveSourcePath;
+      frmNewFileDetails.FileType := FileTypeFromParamType;
+      frmNewFileDetails.CanChangePath := FGlobalProject.Options.Version = pv10;
+
+      if frmNewFileDetails.ShowModal = mrOk then
       begin
-        pf := CreateProjectFile(FGlobalProject, FileName, nil);
+        pf := CreateProjectFile(FGlobalProject, frmNewFileDetails.FileName, nil);
       end;
     finally
-      Free;
+      frmNewFileDetails.Free;
     end;
     if Assigned(pf) then (pf.UI as TProjectFileUI).NewFile;   // I4687
   end


### PR DESCRIPTION
Fixes #10276.

Adding new files to a v2.0 project was unsupported. This requires a little bit of a logic change to the two new File New dialogs:

1. The New File Details dialog does not allow changing from the SourcePath of the project.
2. The New File dialog does allow changing to any path. If you select a path outside the project path, it will open in a new window.

# User Testing

* **TEST_NEW_FILE_10:** Open an existing v1.0 project file, click File|New, and create a new file (any type). Verify that it creates correctly.

* **TEST_NEW_FILE_DETAILS_10:** Open an existing v1.0 project file, click `New Keyboard...`` in the Project tab, Keyboards view, and create a new keyboard file. Verify that it creates correctly.

* **TEST_NEW_FILE_20:** Create a v2.0 project file, click File|New, and create a new file (any type). Verify that it creates correctly and that it is placed into the project SourcePath folder.

* **TEST_NEW_FILE_20_ELSEWHERE:** Create a v2.0 project file, click File|New, and create a new file (any type). Change the Path field to another folder (e.g. a temporary folder). Verify that the file is created correctly and is opened in a new instance of Keyman Developer.

* **TEST_NEW_FILE_DETAILS_20:** Create a v2.0 project file, click `New Keyboard...`` in the Project tab, Keyboards view, and create a new keyboard file. Verify that it creates correctly and that it is placed into the project SourcePath folder.