### PR TITLE
fix(developer): test-page model loading

### DIFF
--- a/developer/src/server/src/site/test.js
+++ b/developer/src/server/src/site/test.js
@@ -367,7 +367,7 @@ function selectModel(modelId) {
   }
 
   if(model) {
-    keyman.modelCache.register({
+    keyman.addModel({
       id: model.id,
       languages: ['en'],
       path: location.protocol + '//' + location.host + '/data/model/' + model.src

--- a/developer/src/server/src/site/test.js
+++ b/developer/src/server/src/site/test.js
@@ -367,7 +367,7 @@ function selectModel(modelId) {
   }
 
   if(model) {
-    keyman.modelManager.register({
+    keyman.modelCache.register({
       id: model.id,
       languages: ['en'],
       path: location.protocol + '//' + location.host + '/data/model/' + model.src

--- a/web/src/engine/package-cache/src/modelCache.ts
+++ b/web/src/engine/package-cache/src/modelCache.ts
@@ -11,7 +11,7 @@ export default class ModelManager {
     return this.languageModelMap[lgCode];
   }
 
-  // Accessible publicly as keyman.modelManager.register(model: ModelSpec)
+  // Accessible publicly as keyman.modelCache.register(model: ModelSpec)
   register(model: ModelSpec): void {
     // Forcibly lowercase the model ID before proceeding.
     model.id = model.id.toLowerCase();

--- a/web/src/test/manual/web/issue3701/index.html
+++ b/web/src/test/manual/web/issue3701/index.html
@@ -55,7 +55,7 @@
 
       function togglePredictions() {
         let newVal = !keyman.core.languageProcessor.mayPredict;
-        keyman.osk.banner.setOptions({'mayPredict': newVal});
+        keyman.core.languageProcessor.mayPredict = newVal;
 
         let btnPredict = document.getElementById("btnPredict");
         btnPredict.value = (newVal ? "Disable" : "Enable") + " predictions";
@@ -63,7 +63,7 @@
 
       function toggleCorrections() {
         let newVal = !keyman.core.languageProcessor.mayCorrect;
-        keyman.osk.banner.setOptions({'mayCorrect': newVal});
+        keyman.core.languageProcessor.mayCorrect = newVal;
 
         let btnCorrect = document.getElementById("btnCorrect");
         btnCorrect.value = (newVal ? "Disable" : "Enable") + " corrections";

--- a/web/src/test/manual/web/issue3701/index.html
+++ b/web/src/test/manual/web/issue3701/index.html
@@ -54,7 +54,7 @@
       });
 
       function togglePredictions() {
-        let newVal = !keyman.modelManager.mayPredict;
+        let newVal = !keyman.core.languageProcessor.mayPredict;
         keyman.osk.banner.setOptions({'mayPredict': newVal});
 
         let btnPredict = document.getElementById("btnPredict");
@@ -62,7 +62,7 @@
       }
 
       function toggleCorrections() {
-        let newVal = !keyman.modelManager.mayCorrect;
+        let newVal = !keyman.core.languageProcessor.mayCorrect;
         keyman.osk.banner.setOptions({'mayCorrect': newVal});
 
         let btnCorrect = document.getElementById("btnCorrect");

--- a/web/src/test/manual/web/issue9469/index.html
+++ b/web/src/test/manual/web/issue9469/index.html
@@ -55,7 +55,7 @@
 
       function togglePredictions() {
         let newVal = !keyman.core.languageProcessor.mayPredict;
-        keyman.osk.banner.setOptions({'mayPredict': newVal});
+        keyman.core.languageProcessor.mayPredict = newVal;
 
         let btnPredict = document.getElementById("btnPredict");
         btnPredict.value = (newVal ? "Disable" : "Enable") + " predictions";
@@ -63,7 +63,7 @@
 
       function toggleCorrections() {
         let newVal = !keyman.core.languageProcessor.mayCorrect;
-        keyman.osk.banner.setOptions({'mayCorrect': newVal});
+        keyman.core.languageProcessor.mayCorrect = newVal;
 
         let btnCorrect = document.getElementById("btnCorrect");
         btnCorrect.value = (newVal ? "Disable" : "Enable") + " corrections";

--- a/web/src/test/manual/web/issue9469/index.html
+++ b/web/src/test/manual/web/issue9469/index.html
@@ -54,7 +54,7 @@
       });
 
       function togglePredictions() {
-        let newVal = !keyman.modelManager.mayPredict;
+        let newVal = !keyman.core.languageProcessor.mayPredict;
         keyman.osk.banner.setOptions({'mayPredict': newVal});
 
         let btnPredict = document.getElementById("btnPredict");
@@ -62,7 +62,7 @@
       }
 
       function toggleCorrections() {
-        let newVal = !keyman.modelManager.mayCorrect;
+        let newVal = !keyman.core.languageProcessor.mayCorrect;
         keyman.osk.banner.setOptions({'mayCorrect': newVal});
 
         let btnCorrect = document.getElementById("btnCorrect");

--- a/web/src/test/manual/web/prediction-mtnt/index.html
+++ b/web/src/test/manual/web/prediction-mtnt/index.html
@@ -61,7 +61,7 @@
 
       function togglePredictions() {
         let newVal = !keyman.core.languageProcessor.mayPredict;
-        keyman.osk.banner.setOptions({'mayPredict': newVal});
+        keyman.core.languageProcessor.mayPredict = newVal;
 
         let btnPredict = document.getElementById("btnPredict");
         btnPredict.value = (newVal ? "Disable" : "Enable") + " predictions";
@@ -69,7 +69,7 @@
 
       function toggleCorrections() {
         let newVal = !keyman.core.languageProcessor.mayCorrect;
-        keyman.osk.banner.setOptions({'mayCorrect': newVal});
+        keyman.core.languageProcessor.mayCorrect = newVal;
 
         let btnCorrect = document.getElementById("btnCorrect");
         btnCorrect.value = (newVal ? "Disable" : "Enable") + " corrections";

--- a/web/src/test/manual/web/prediction-mtnt/index.html
+++ b/web/src/test/manual/web/prediction-mtnt/index.html
@@ -60,7 +60,7 @@
       });
 
       function togglePredictions() {
-        let newVal = !keyman.modelManager.mayPredict;
+        let newVal = !keyman.core.languageProcessor.mayPredict;
         keyman.osk.banner.setOptions({'mayPredict': newVal});
 
         let btnPredict = document.getElementById("btnPredict");
@@ -68,7 +68,7 @@
       }
 
       function toggleCorrections() {
-        let newVal = !keyman.modelManager.mayCorrect;
+        let newVal = !keyman.core.languageProcessor.mayCorrect;
         keyman.osk.banner.setOptions({'mayCorrect': newVal});
 
         let btnCorrect = document.getElementById("btnCorrect");

--- a/web/src/test/manual/web/prediction-ui/index.html
+++ b/web/src/test/manual/web/prediction-ui/index.html
@@ -58,7 +58,7 @@
       });
 
       function togglePredictions() {
-        let newVal = !keyman.modelManager.mayPredict;
+        let newVal = !keyman.core.languageProcessor.mayPredict;
         keyman.osk.banner.setOptions({'mayPredict': newVal});
 
         let btnPredict = document.getElementById("btnPredict");
@@ -66,7 +66,7 @@
       }
 
       function toggleCorrections() {
-        let newVal = !keyman.modelManager.mayCorrect;
+        let newVal = !keyman.core.languageProcessor.mayCorrect;
         keyman.osk.banner.setOptions({'mayCorrect': newVal});
 
         let btnCorrect = document.getElementById("btnCorrect");

--- a/web/src/test/manual/web/prediction-ui/index.html
+++ b/web/src/test/manual/web/prediction-ui/index.html
@@ -59,7 +59,7 @@
 
       function togglePredictions() {
         let newVal = !keyman.core.languageProcessor.mayPredict;
-        keyman.osk.banner.setOptions({'mayPredict': newVal});
+        keyman.core.languageProcessor.mayPredict = newVal;
 
         let btnPredict = document.getElementById("btnPredict");
         btnPredict.value = (newVal ? "Disable" : "Enable") + " predictions";
@@ -67,7 +67,7 @@
 
       function toggleCorrections() {
         let newVal = !keyman.core.languageProcessor.mayCorrect;
-        keyman.osk.banner.setOptions({'mayCorrect': newVal});
+        keyman.core.languageProcessor.mayCorrect = newVal;
 
         let btnCorrect = document.getElementById("btnCorrect");
         btnCorrect.value = (newVal ? "Disable" : "Enable") + " corrections";


### PR DESCRIPTION
It would appear that ever since KeymanWeb got modularized, the Developer test-page hooks for loading models have been broken.  With #8472, `keyman.modelManager` was reworked into `keyman.modelCache`. 

The prediction and correction toggle properties... weren't even available there in 16.0, so the Web test-page toggles have likely been dead for a little while.  I went ahead and patched them up while I was at it.

## User Testing

TEST_PREDICTIVE_TOGGLES:  Using the "Prediction - robust testing" for **_KeymanWeb_** **on a mobile device**, verify that the toggles have the indicated effect.

1. Click on a text area.
2. Verify that the predictive-text banner is visible.
3. Click on a blank part of the page (to dismiss the OSK)
4. Click the "Disable predictions" button.
5. Click on the original text area (from step 1)
6. Verify that the predictive-text banner is _not_ visible.
7. Click on a blank part of the page (to dismiss the OSK)
8. Click the "Enable predictions" button.
9. Click on the original text area (from step 1)
10. Verify that the predictive-text banner is visible.

TEST_DEV_HOST_MODELS:  Using the **_Developer_** test-host page, verify that lexical models load properly.
- `release/sil/sil_euro_latin` (for keyboard) and `release/nrc/nrc_en_mtnt` (for model) are probably "good enough" to use for this test.  Feel free to use and/or test with others if you prefer.

1. Select a mobile test device configuration.  (e.g: Device > Phone Devices > "iPhone 5S")
2. Verify that selecting a keyboard (e.g: `sil_euro_latin`) and model (e.g: `nrc_en_mtnt`) with matching language codes causes the predictive-text banner to appear.
    - You may need to open both projects, build them, and request to test them via the project "build" tab for them to appear in the test-host page.
4. Check that interactions in the web debugger continue to work as before.