### PR TITLE
fix(android): Use alert dialog when package is missing touch keyboards

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -117,7 +117,8 @@ public class PackageActivity extends AppCompatActivity implements
     // Sanity check for keyboard packages
     if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
       if (keyboardCount == 0) {
-        showErrorToast(getString(R.string.no_new_touch_keyboards_to_install));
+        showErrorDialog(context, pkgId, getString(R.string.no_new_touch_keyboards_to_install));
+        return;
       } else if (languageCount == 0) {
         showErrorToast(getString(R.string.no_associated_languages));
       }
@@ -340,7 +341,11 @@ public class PackageActivity extends AppCompatActivity implements
           if (dialog != null) {
             dialog.dismiss();
           }
+          // Setting result to 1 so calling activity will finish too
+          setResult(1);
           cleanup();
+          finish();
+          MainActivity.cleanupPackageInstall();
         }
       });
 


### PR DESCRIPTION
Fixes #10132

> When installing a keyboard package that is missing a touch-optimized .js keyboard file, a toast appears indicating that there is an error, but it is truncated and disappears too quickly. It should be a message box because it's an error the user should respond to.

This changes the error message from a Toast notification that disappears to an alert dialog that remains until the User closes it.

## User Testing
**Setup**
1. Install the PR build of Keyman for Android on Android device/emulator.
2. On the device/emulator, download a keyboard package (.kmp) file that's missing a touch-optimized .js keyboard file. An example .kmp file is at https://darcywong00.github.io/examples/invalid/sil_ethiopic.kmp


* **TEST_ALERT_DIALOG** - Verifies alert dialog is displayed when keyboard package is missing a touch-optimized .js keyboard file
1. Launch Keyman for Android and dismiss the "Get Started" menu.
2. From the Keyman settings menu, attempt to install the local keyboard package file (saved in Setup above):
  a. Keyman settings --> Install Keyboard or Dictionary --> Install from local file
  b. In the file browser, navigate to where sil_ethiopic.kmp was saved (typically Downloads --> sil_ethiopic.kmp) and click the .kmp file
3. Verify the keyboard package fails to install with an alert dialog
![alert - no touch keyboard](https://github.com/keymanapp/keyman/assets/7358010/a19fc47e-198d-4038-91a2-efa00fe8090a)

4. Click "Close"
5. Verify the alert dialog is dismissed.