### PR TITLE
fix(ios): banner image management

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -81,6 +81,14 @@ function showBanner(flag) {
 
 function setBannerImage(path) {
     bannerImgPath = path;
+
+    var bc = keyman && keyman.osk && keyman.osk.bannerController;
+    if(!bc) {
+      return;
+    }
+
+    // If an inactive banner is set, update its image.
+    bc.inactiveBanner = bc.inactiveBanner ? new bc.ImageBanner(bannerImgPath) : null;
 }
 
 function setBannerHeight(h) {


### PR DESCRIPTION
Fixes #9990.

If an "image banner" is set in place before its image is ready, setting the image will refresh the image banner with the newly-available image.

It appears that either during ES module (🧩) or gesture (🐵) work, the order of the two internal image-banner related methods changed.  This update should allow things to work and update properly regardless of method ordering.

# User Testing

TEST_SYSTEM_IMAGE_BANNER:  Using the Keyman for iPhone and iPad app, verify that the image banner works as intended when enabled.

1. Test Setup
    1. Using the `Settings` menu, enable the "Show Banner" toggle.
    2. Using "Settings" > "Installed Languages" > "+", serach for and install the `sil_ipa` keyboard.
    3. Ensure that Keyman is enabled as a system keyboard.
        - Use "System Keyboard Settings" if needed to enable this.
2. The actual test
    1. Exit the Keyman app and open Safari.
    2. Swap system keyboard to Keyman.
    3. If `sil_ipa` is not the initial active keyboard:
        1. Swap to `sil_ipa`.
        2. Swap system keyboard to the default iOS keyboard.
        3. Repeat step 2 - swap system keyboard back to Keyman.
    4. Verify that an image banner appears above the keyboard - it should have the Keyman logo and include text saying "Keyman".
    5. Rotate the device from portrait to landscape.
    6. Verify that the logo and text are not flattened or stretched - the aspect ratio should appear the same.
    7. Verify that the image banner is at least as wide as the keyboard.
    8. Verify that the tri-color bar on the banner's top contains all three primary colors from the logo.  (The darker shades)
    9. Rotate the device from landscape to portrait.
    10. Verify that the logo and text are not flattened or stretched - the aspect ratio should appear the same.
    11. Verify that the image banner is at least as wide as the keyboard.
    12. Verify that the tri-color bar on the banner's top contains all three primary colors from the logo.  (The darker shades)