### PR TITLE
fix(ios): use safe area to position Keyman menu correctly

### DIFF
--- a/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
@@ -940,16 +940,26 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     wasKeyboardVisible = textView.isFirstResponder
     textView.dismissKeyboard()
 
-    let w: CGFloat = 160
-    let h: CGFloat = 44
-    let x: CGFloat = navBarWidth() - w
-    let y: CGFloat = AppDelegate.statusBarHeight() + navBarHeight()
-
-    let dropDownList = DropDownListView(listItems: dropdownItems, itemSize: CGSize(width: w, height: h),
-                                        position: CGPoint(x: x, y: y))
+    let menuRect: CGRect = self.calculateDropDownMenuRect()
+    let dropDownList = DropDownListView(listItems: dropdownItems, itemSize: menuRect.size, position: menuRect.origin)
     dropDownList.tag = dropDownListTag
 
     navigationController?.view?.addSubview(dropDownList)
+  }
+
+  /**
+   * Calculates coordinates of Keyman app dropdown menu
+   * takes into account safearea so that menu does display over iPhone notch when
+   * rotated to landscape (issue #8168)
+   */
+  private func calculateDropDownMenuRect() -> CGRect {
+    let rightInset: CGFloat? = self.view.window?.safeAreaInsets.right
+    let width: CGFloat = 160
+    let height: CGFloat = 44
+    let x: CGFloat = navBarWidth() - width - (rightInset ?? 0)
+    let y: CGFloat = AppDelegate.statusBarHeight() + navBarHeight()
+    let menuRect = CGRect(x: x, y: y, width: width, height: height)
+    return menuRect
   }
 
   private func dismissDropDownMenu() -> Bool {


### PR DESCRIPTION
The drop down menu in Keyman should be positioned so that it is not obstructed by the notch that appeared beginning with the iPhone X or the dynamic island that appeared beginning with the iPhone 14 Pro.

Fixes #8168 

# User Testing

**TEST_DROP_DOWN_MENU_PORTRAIT**: 

- Install the attached version of Keyman on an iPhone 14 Pro simulator
- Click on the Keyman dropdown menu represented by three dots on the menu bar
- Verify that the menu is completely visible when it drops down

**TEST_DROP_DOWN_MENU_LANDSCAPE**: 

- Click on the Keyman dropdown menu represented by three dots on the menu bar
- Rotate the phone to the landscape orientation with the notch/dynamic island on the right side
- Verify that the menu is completely visible when it drops down
