### PR TITLE
fix(android/engine): Use fallback keyboard if keyboard index undefined

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -70,12 +70,11 @@ public class KMKeyboardJSHandler {
     // loaded and has set a keyboard.  To allow the host-page to have earlier access, we instead get the stored
     // keyboard index directly.
     SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-    int index = prefs.getInt(KMManager.KMKey_UserKeyboardIndex, 0);
-    if (index < 0) {
-      index = 0;
+    Keyboard kbd = Keyboard.getDefaultKeyboard(context);
+    int index = prefs.getInt(KMManager.KMKey_UserKeyboardIndex, -1);
+    if (index >= 0) {
+      kbd = KMManager.getKeyboardInfo(this.context, index);
     }
-
-    Keyboard kbd = KMManager.getKeyboardInfo(this.context, index);
     return kbd.toStub(context);
   }
 

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -62,6 +62,29 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
         KMManager.setKeyboardPickerFont(Typeface.createFromAsset(getAssets(), "fonts/NotoSansCanadianAboriginal.ttf"));
         KMManager.initialize(getApplicationContext(), KeyboardType.KEYBOARD_TYPE_SYSTEM);
 
+        /**
+         * We need to set the default (fallback) keyboard to sil_euro_latin inside the fv_all package
+         * rather than the normal default of sil_euro_latin inside the sil_euro_latin package.
+         * Fallback keyboard needed in case the user never selects a FV keyboard to add
+         * as a system keyboard.
+         */
+        String version = KMManager.getLatestKeyboardFileVersion(
+          this, FVShared.FVDefault_PackageID, KMManager.KMDefault_KeyboardID);
+        KMManager.setDefaultKeyboard(
+          new Keyboard(
+            FVShared.FVDefault_PackageID,
+            KMManager.KMDefault_KeyboardID,
+            KMManager.KMDefault_KeyboardName,
+            KMManager.KMDefault_LanguageID,
+            KMManager.KMDefault_LanguageName,
+            version,
+            null, // will use help.keyman.com link because context required to determine local welcome.htm path,
+            "",
+            false,
+            KMManager.KMDefault_KeyboardFont,
+            KMManager.KMDefault_KeyboardFont)
+        );
+
         interpreter = new KMHardwareKeyboardInterpreter(getApplicationContext(), KeyboardType.KEYBOARD_TYPE_SYSTEM);
         KMManager.setInputMethodService(this); // for HW interface
 


### PR DESCRIPTION
Fixes #10297 and follows #10022

This fixes a bug in KMKeyboardJSHandler.initialKeyboard() in the scenario where an FV keyboard hasn't been setup, and the user attempts to use FV as a system keyboard.

https://github.com/keymanapp/keyman/blob/6cfe170789fc9b06e8a4579d2ab6b156bdcf4d02/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java#L68-L80

When an FV keyboard hasn't been setup, the user preference `KMKey_UserKeyboardIndex` is undefined, so index falls back to 0.

## User Testing
**Setup** - Install the PR build of FV for Android on an Android device/emulator

* **TEST_0_KEYBOARDS** - Verifies FV doesn't generate Toast errors when using uninitialized FV system keyboard
1. Close the FV app if it is running
2. From the Android system settings --> Languages & input --> Enable FV as a system keyboard
3. Launch a separate app (e.g. Google Chrome) and click on a text field
4. Use the device keyboard picker to switch to FV system keyboard
5. Verify the FV keyboard appears with a fallback sil_euro_latin keyboard
6. Verify no Toast notifications appear about a keyboard error

* **TEST_SETUP** - Verifies FV can set up and use system keyboard
1. Launch the FV app
2. Use the FV setup menu to select and enable a keyboard, and enable FV as a system keyboard
3. Launch a separate app (e.g. Google Chrome) and click on a text field
4. Use the device keyboard picker to switch to FV system keyboard
5. Verify the FV keyboard appears with the keyboard installed during FV setup
