### PR TITLE
fix(web): Add null check for changing the keyboard during typing

### DIFF
--- a/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
@@ -288,7 +288,8 @@ export default class SubkeyPopup implements GestureHandler {
     const _Box = vkbd.topContainer;
     let rowElement = (e.key as OSKBaseKey).row.element;
     let ss=subKeys.style;
-    var x = e.offsetLeft + (<HTMLElement>e.offsetParent).offsetLeft + 0.5*(e.offsetWidth-subKeys.offsetWidth);
+    let parentOffsetLeft = e.offsetParent ? (<HTMLElement>e.offsetParent).offsetLeft : 0;
+    var x = e.offsetLeft + parentOffsetLeft + 0.5*(e.offsetWidth-subKeys.offsetWidth);
     var xMax = vkbd.width - subKeys.offsetWidth;
 
     if(x > xMax) {


### PR DESCRIPTION
Fixes #10286 

When rapidly typing with longpress keys and switching keyboards, a null exception would get thrown on `(<HTMLElement>e.offsetParent).offsetLeft`.

This adds a check to use an offset of 0 if e.offsetParent is null.

## User Testing
**Setup**
1. Install the PR build of Keyman for Android on an Android device (needs to be a physical device in order to rapidly type longpress keys and globe key switches
2. From Keyman for Android, install a second Keyman keyboard (e.g. khmer_angkor). This way, the pressing the globe key switches between Keyman keyboards

* **TEST_TYPING_AND_SWITCHING_KEYBOARDS** - Verifies error not shown when changing the keyboard during typing
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. In the Keyman app with both hands, rapidly type longpress keys and globe key switches
3. Verify text is output in the Keyman app
4. Verify keyboard errors do not appear
