### PR TITLE
fix(web): cancels active gestures on globe-key use

### DIFF
--- a/common/web/gesture-recognizer/src/engine/gestureRecognizer.ts
+++ b/common/web/gesture-recognizer/src/engine/gestureRecognizer.ts
@@ -33,6 +33,11 @@ export class GestureRecognizer<HoveredItemType, StateToken = any> extends Touchp
   }
 
   public destroy() {
+    // When shutting down the gesture engine, we should go ahead and clear out all related
+    // gesture-source tracking.
+    this.activeGestures.forEach((sequence) => sequence.cancel());
+    this.activeSources.forEach((source) => source.terminate(true));
+
     this.mouseEngine.unregisterEventHandlers();
     this.touchEngine.unregisterEventHandlers();
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -920,7 +920,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
 
     // Prevent NaN breakages.
     if (!width || !height) {
-      return null;
+      return new Map();
     }
 
     let kbdAspectRatio = width / height;

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -612,8 +612,23 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
             // Merely constructing the instance is enough; it'll link into the sequence's events and
             // handle everything that remains for the backspace from here.
             handlers = [new HeldRepeater(gestureSequence, () => this.modelKeyClick(gestureKey, coord))];
-          } else if(gestureKey.key.spec.baseKeyID == "K_LOPT") {
+          } else if(gestureKey.key.spec.baseKeyID == "K_LOPT") { // globe key
             gestureSequence.on('complete', () => this.emit('globekey', gestureKey, false));
+
+            for(const identifier of Object.keys(sourceTrackingMap)) {
+              if(identifier == coordSource.identifier) {
+                // No need to cancel the current gesture; let the globe-key gesture complete.
+                continue;
+              }
+
+              // Any _other_ gesture, though - yeah, that should cancel out.
+              // Might be a _bit_ funky if there's an active modipress, but only momentarily.
+              const entry = sourceTrackingMap[identifier];
+
+              // Trigger cancellation of all other pending gestures - they're not valid after a keyboard-swap.
+              entry.source.terminate(true);
+            }
+
           }
         } else if(gestureStage.matchedId.indexOf('longpress') > -1) {
           existingPreviewHost?.cancel();


### PR DESCRIPTION
Fixes the underlying problem that motivated #10346.

This is intended to act as a patch-PR for #10346, contributing to a more complete, comprehensive solution.

## User Testing

Just realized the base branch had a user test.  The least we could do it run that one here, too.

**Setup**
1. Install the PR build of Keyman for Android on an Android device (needs to be a physical device in order to rapidly type longpress keys and globe key switches
2. From Keyman for Android, install a second Keyman keyboard (e.g. khmer_angkor). This way, the pressing the globe key switches between Keyman keyboards

* **TEST_TYPING_AND_SWITCHING_KEYBOARDS** - Verifies error not shown when changing the keyboard during typing
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. In the Keyman app with both hands, rapidly type longpress keys and globe key switches
3. Verify text is output in the Keyman app
4. Verify keyboard errors do not appear