### PR TITLE
chore(developer): upgrade ngrok to v3

### DIFF
--- a/developer/src/server/package.json
+++ b/developer/src/server/package.json
@@ -9,12 +9,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@sentry/node": "^6.16.1",
     "@keymanapp/developer-utils": "*",
+    "@sentry/node": "^6.16.1",
     "chalk": "^4.1.2",
     "express": "^4.17.2",
     "multer": "^1.4.5-lts.1",
-    "ngrok": "^4.2.2",
+    "ngrok": "^5.0.0-beta.2",
     "open": "^8.4.0",
     "ws": "^8.3.0"
   },

--- a/developer/src/server/src/config.ts
+++ b/developer/src/server/src/config.ts
@@ -19,7 +19,6 @@ export class Configuration {
   public readonly useNgrok: boolean;
   public readonly ngrokControlPort: number;
   public readonly ngrokToken: string;
-  public readonly ngrokRegion: string;
   public readonly ngrokVisible: boolean;
 
   public ngrokEndpoint: string = '';
@@ -46,7 +45,6 @@ export class Configuration {
     this.ngrokBinPath = this.appDataPath + 'bin/';
     this.ngrokControlPort = cfg?.ngrokControlPort ?? 8009;
     this.ngrokToken = cfg?.ngrokToken ?? '';
-    this.ngrokRegion = cfg?.ngrokRegion ?? '';
     this.ngrokVisible = cfg?.ngrokVisible ?? false;
   }
 };

--- a/developer/src/server/src/index.ts
+++ b/developer/src/server/src/index.ts
@@ -100,7 +100,6 @@ export async function run() {
     (async function() {
       configuration.ngrokEndpoint = await ngrok.connect({
         proto: 'http',
-        bind_tls: true,
         addr: configuration.port,
         authtoken: configuration.ngrokToken,
         region: configuration.ngrokRegion,

--- a/developer/src/server/src/index.ts
+++ b/developer/src/server/src/index.ts
@@ -102,7 +102,6 @@ export async function run() {
         proto: 'http',
         addr: configuration.port,
         authtoken: configuration.ngrokToken,
-        // region: configuration.ngrokRegion,
         binPath: () => configuration.ngrokBinPath,
         onLogEvent: (msg: string) => {
           if(options.ngrokLog) {

--- a/developer/src/server/src/index.ts
+++ b/developer/src/server/src/index.ts
@@ -102,7 +102,7 @@ export async function run() {
         proto: 'http',
         addr: configuration.port,
         authtoken: configuration.ngrokToken,
-        region: configuration.ngrokRegion,
+        // region: configuration.ngrokRegion,
         binPath: () => configuration.ngrokBinPath,
         onLogEvent: (msg: string) => {
           if(options.ngrokLog) {

--- a/developer/src/tike/dialogs/Keyman.Developer.UI.UfrmServerOptions.dfm
+++ b/developer/src/tike/dialogs/Keyman.Developer.UI.UfrmServerOptions.dfm
@@ -4,7 +4,7 @@ object frmServerOptions: TfrmServerOptions
   BorderIcons = [biSystemMenu]
   BorderStyle = bsDialog
   Caption = 'Keyman Developer Server Options'
-  ClientHeight = 402
+  ClientHeight = 378
   ClientWidth = 433
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
@@ -40,7 +40,7 @@ object frmServerOptions: TfrmServerOptions
   end
   object cmdOK: TButton
     Left = 272
-    Top = 367
+    Top = 346
     Width = 73
     Height = 25
     Caption = 'OK'
@@ -51,7 +51,7 @@ object frmServerOptions: TfrmServerOptions
   end
   object cmdCancel: TButton
     Left = 352
-    Top = 367
+    Top = 346
     Width = 73
     Height = 25
     Cancel = True
@@ -63,7 +63,7 @@ object frmServerOptions: TfrmServerOptions
     Left = 8
     Top = 144
     Width = 417
-    Height = 150
+    Height = 129
     Caption = 'Setup'
     TabOrder = 3
     object lblAuthToken: TLabel
@@ -73,14 +73,6 @@ object frmServerOptions: TfrmServerOptions
       Height = 13
       Caption = '&Authentication token'
       FocusControl = editAuthToken
-    end
-    object lblRegion: TLabel
-      Left = 16
-      Top = 120
-      Width = 33
-      Height = 13
-      Caption = '&Region'
-      FocusControl = cbRegion
     end
     object lblVersion: TLabel
       Left = 183
@@ -111,22 +103,6 @@ object frmServerOptions: TfrmServerOptions
       Height = 21
       TabOrder = 2
     end
-    object cbRegion: TComboBox
-      Left = 122
-      Top = 117
-      Width = 145
-      Height = 21
-      Style = csDropDownList
-      TabOrder = 3
-      Items.Strings = (
-        'us (North America)'
-        'eu (Europe)'
-        'au (Australia)'
-        'ap (Asia/Pacific)'
-        'sa (South Africa)'
-        'jp (Japan)'
-        'in (India)')
-    end
     object cmdDownload: TButton
       Left = 16
       Top = 24
@@ -148,7 +124,7 @@ object frmServerOptions: TfrmServerOptions
   end
   object gbAdvanced: TGroupBox
     Left = 8
-    Top = 300
+    Top = 279
     Width = 417
     Height = 61
     Caption = 'Advanced Options'

--- a/developer/src/tike/dialogs/Keyman.Developer.UI.UfrmServerOptions.pas
+++ b/developer/src/tike/dialogs/Keyman.Developer.UI.UfrmServerOptions.pas
@@ -75,7 +75,7 @@ const
   // to be stable, as they are used in other apps also.
   SUrlNgrokAuthToken = 'https://dashboard.ngrok.com/get-started/your-authtoken';
   SUrlNgrokSignup = 'https://dashboard.ngrok.com/signup';
-  SUrlNgrokDownload = 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-386.zip';
+  SUrlNgrokDownload = 'https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-386.zip';
   SNGrokExe = 'ngrok.exe';
 
 procedure TfrmServerOptions.cmdCreateAccountClick(Sender: TObject);

--- a/developer/src/tike/dialogs/Keyman.Developer.UI.UfrmServerOptions.pas
+++ b/developer/src/tike/dialogs/Keyman.Developer.UI.UfrmServerOptions.pas
@@ -24,8 +24,6 @@ type
     gbSetup: TGroupBox;
     editAuthToken: TEdit;
     lblAuthToken: TLabel;
-    cbRegion: TComboBox;
-    lblRegion: TLabel;
     cmdDownload: TButton;
     gbAdvanced: TGroupBox;
     chkServerShowConsoleWindow: TCheckBox;
@@ -193,14 +191,13 @@ procedure TfrmServerOptions.cmdOKClick(Sender: TObject);
 var
   DefaultPort: Integer;
   KeepAlive, UseNgrok, ngrokKeepVisible: Boolean;
-  ngrokToken, ngrokRegion: string;
+  ngrokToken: string;
   Changed: Boolean;
 begin
   DefaultPort := StrToIntDef(editDefaultPort.Text, 8008);   // I4021
   KeepAlive := chkLeaveServerRunning.Checked;
   UseNgrok := chkUseNgrok.Checked;
   ngrokToken := editAuthToken.Text;
-  ngrokRegion := Copy(cbRegion.Text, 1, 2);
   ngrokKeepVisible := chkServerShowConsoleWindow.Checked;
 
   Changed :=
@@ -208,7 +205,6 @@ begin
     (FKeymanDeveloperOptions.ServerKeepAlive <> KeepAlive) or
     (FKeymanDeveloperOptions.ServerUseNgrok <> UseNgrok) or
     (FKeymanDeveloperOptions.ServerNgrokToken <> ngrokToken) or
-    (FKeymanDeveloperOptions.ServerNgrokRegion <> ngrokRegion) or
     (FKeymanDeveloperOptions.ServerServerShowConsoleWindow <> ngrokKeepVisible);
 
   if Changed then
@@ -217,7 +213,6 @@ begin
     FKeymanDeveloperOptions.ServerKeepAlive := KeepAlive;
     FKeymanDeveloperOptions.ServerUseNgrok := UseNgrok;
     FKeymanDeveloperOptions.ServerNgrokToken := ngrokToken;
-    FKeymanDeveloperOptions.ServerNgrokRegion := ngrokRegion;
     FKeymanDeveloperOptions.ServerServerShowConsoleWindow := ngrokKeepVisible;
     FKeymanDeveloperOptions.Write; // TODO: Cancel button in parent dialog is a problem
     modWebHttpServer.RestartServer;
@@ -226,8 +221,6 @@ begin
 end;
 
 procedure TfrmServerOptions.FormCreate(Sender: TObject);
-var
-  i: Integer;
 begin
   editDefaultPort.Text := IntToStr(FKeymanDeveloperOptions.ServerDefaultPort);   // I4021
   chkUseNgrok.Checked := FKeymanDeveloperOptions.ServerUseNgrok;
@@ -235,14 +228,6 @@ begin
 
   lblVersion.Caption := '';
   editAuthToken.Text := FKeymanDeveloperOptions.ServerNgrokToken;
-
-  cbRegion.ItemIndex := 0;
-  for i := 0 to cbRegion.Items.Count - 1 do
-    if cbRegion.Items[i].StartsWith(FKeymanDeveloperOptions.ServerNgrokRegion) then
-    begin
-      cbRegion.ItemIndex := i;
-      Break;
-    end;
 
   chkServerShowConsoleWindow.Checked := FKeymanDeveloperOptions.ServerServerShowConsoleWindow;
 

--- a/developer/src/tike/main/KeymanDeveloperOptions.pas
+++ b/developer/src/tike/main/KeymanDeveloperOptions.pas
@@ -69,7 +69,6 @@ type
     FServerUseNgrok: Boolean;
     FServerServerShowConsoleWindow: Boolean;
     FServerNgrokToken: string;
-    FServerNgrokRegion: string;
     FServerKeepAlive: Boolean;
     FToolbarVisible: Boolean;
     FStartupProjectPath: string;
@@ -117,7 +116,6 @@ type
     property ServerUseLocalAddresses: Boolean read FServerUseLocalAddresses write FServerUseLocalAddresses;
 
     property ServerNgrokToken: string read FServerNgrokToken write FServerNgrokToken;
-    property ServerNgrokRegion: string read FServerNgrokRegion write FServerNgrokRegion;
     property ServerUseNgrok: Boolean read FServerUseNgrok write FServerUseNgrok;
     property ServerServerShowConsoleWindow: Boolean read FServerServerShowConsoleWindow write FServerServerShowConsoleWindow;
 
@@ -201,7 +199,6 @@ const
   SRegValue_IDEOptServerPort = 'web host port';   // I4021
   SRegValue_IDEOptServerKeepAlive = 'server keep alive';
   SRegValue_IDEOptServerNgrokToken = 'server ngrok token';
-  SRegValue_IDEOptServerNgrokRegion = 'server ngrok region';
   SRegValue_IDEOptServerUseLocalAddresses = 'server use local addresses';
   SRegValue_IDEOptServerUseNgrok = 'server use ngrok';
   SRegValue_IDEOptServerShowConsoleWindow = 'server show console window';
@@ -348,7 +345,6 @@ begin
     FServerUseLocalAddresses := optReadBool(SRegValue_IDEOptServerUseLocalAddresses, True);
 
     FServerNgrokToken := optReadString(SRegValue_IDEOptServerNgrokToken, '');
-    FServerNgrokRegion := optReadString(SRegValue_IDEOptServerNgrokRegion, 'us');
     FServerUseNgrok := optReadBool(SRegValue_IDEOptServerUseNgrok, False);
     FServerServerShowConsoleWindow := optReadBool(SRegValue_IDEOptServerShowConsoleWindow, False);
 
@@ -434,7 +430,6 @@ begin
     optWriteBool(SRegValue_IDEOptServerUseLocalAddresses, FServerUseLocalAddresses);
 
     optWriteString(SRegValue_IDEOptServerNgrokToken, FServerNgrokToken);
-    optWriteString(SRegValue_IDEOptServerNgrokRegion, FServerNgrokRegion);
     optWriteBool(SRegValue_IDEOptServerUseNgrok, FServerUseNgrok);
     optWriteBool(SRegValue_IDEOptServerShowConsoleWindow, FServerServerShowConsoleWindow);
 
@@ -514,7 +509,6 @@ begin
   try
     o.AddPair('port', TJSONNumber.Create(FServerDefaultPort));
     o.AddPair('ngrokToken', FServerNgrokToken);
-    o.AddPair('ngrokRegion', FServerNgrokRegion);
     o.AddPair('useNgrok', TJSONBool.Create(FServerUseNgrok));
     o.AddPair('ngrokVisible', TJSONBool.Create(FServerServerShowConsoleWindow));
     SaveJSONToFile(TKeymanDeveloperPaths.ServerDataPath + TKeymanDeveloperPaths.S_ServerConfigJson, o);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2837,7 +2837,7 @@
         "chalk": "^4.1.2",
         "express": "^4.17.2",
         "multer": "^1.4.5-lts.1",
-        "ngrok": "^4.2.2",
+        "ngrok": "^5.0.0-beta.2",
         "open": "^8.4.0",
         "ws": "^8.3.0"
       },
@@ -9830,30 +9830,26 @@
       }
     },
     "node_modules/ngrok": {
-      "version": "4.3.1",
+      "version": "5.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-5.0.0-beta.2.tgz",
+      "integrity": "sha512-UzsyGiJ4yTTQLCQD11k1DQaMwq2/SsztBg2b34zAqcyjS25qjDpogMKPaCKHwe/APRTHeel3iDXcVctk5CNaCQ==",
       "hasInstallScript": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/node": "^8.10.50",
         "extract-zip": "^2.0.1",
-        "got": "^11.5.1",
+        "got": "^11.8.5",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^7.0.0 || ^8.0.0",
-        "yaml": "^1.10.0"
+        "yaml": "^2.2.2"
       },
       "bin": {
         "ngrok": "bin/ngrok"
       },
       "engines": {
-        "node": ">=10.19.0 <14 || >=14.2"
+        "node": ">=14.2"
       },
       "optionalDependencies": {
         "hpagent": "^0.1.2"
       }
-    },
-    "node_modules/ngrok/node_modules/@types/node": {
-      "version": "8.10.66",
-      "license": "MIT"
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -12205,10 +12201,11 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "license": "ISC",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {


### PR DESCRIPTION
Fixes #10357.

# User Testing

TEST_NGROK_UPGRADE: In Keyman Developer, Tools|Options|Server, Configure Server, click `Download or update ngrok`. Once the download completes, the label to the right of the button should show "ngrok version 3.5.0" or similar (it must be version 3.2 or later to pass).

TEST_NGROK_WORKING: In Keyman Developer, verify that you have enabled ngrok in Keyman Developer Server Options. Open a keyboard, and test it on web. Verify that a URL appears in the list of server web addresses, and that when you select it to Open in browser, the test web site works correctly.

Note: your ngrok entry will look different to this but will be a public website:
![image](https://github.com/keymanapp/keyman/assets/4498365/9fd67779-db34-4c97-8735-2b52ccf31b37)
