### PR TITLE
fix(ios): multiple keyboard slide-in animations on app start

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/TextField.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/TextField.swift
@@ -146,10 +146,6 @@ public class TextField: UITextField, KeymanResponder {
       font = UIFont.systemFont(ofSize: fontSize)
     }
 
-    if isFirstResponder {
-      resignFirstResponder()
-      becomeFirstResponder()
-    }
     log.debug("TextField \(self.hashValue) setFont: \(font?.familyName ?? "nil")")
   }
 
@@ -179,7 +175,7 @@ extension KeymanResponder where Self: TextField {
     resignFirstResponder()
     Manager.shared.inputViewController.endEditing(true)
   }
-  
+
   public func summonKeyboard() {
     becomeFirstResponder()
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/TextView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/TextView.swift
@@ -133,11 +133,6 @@ public class TextView: UITextView, KeymanResponder {
       font = UIFont.systemFont(ofSize: fontSize)
     }
 
-    if isFirstResponder {
-      resignFirstResponder()
-      becomeFirstResponder()
-    }
-
     log.debug("TextView: \(self.hashValue) setFont: \(font?.familyName ?? "nil")")
   }
 


### PR DESCRIPTION
Heavily mitigates #9211.

While there will still be a very slight bit of layout-shift that still occurs, this eliminates the multiple slide-in animations for the keyboard that appear at app start.

How it looks now, in Simulator:

![app load](https://github.com/keymanapp/keyman/assets/25213402/15348c14-61f1-4659-a5fc-df18f76b54e3)

Notice the subtle shift in the keys near the end of the GIF - that's the "slight bit of layout shift" I was referring to.

The likely reason for this:

![image](https://github.com/keymanapp/keyman/assets/25213402/a2e927d8-be23-4bde-b888-715aab449292)

Note the timing of `kmwosk.css` in the Network tab; it loads relatively late in the process... as does the OSK font.  Though... symbols from the font are actually showing up _before_ the shift, so I'm not fully confident that this delay is the cause.  Using the same debugger, it appears that the shift actually happens solely within the "Layout & Rendering" section at a time that doesn't overlap with _any_ network events, JavaScript or DOM-event processing.

I am a bit concerned that the code being removed might have a side-effect I'm not anticipating, but this is, by far, the easiest way to smooth out this aspect of app init.

## User Testing

TEST_IOS_APP_START:  Launch the Keyman app on an iOS device and verify that the app appears to start and function normally.
- Do some typing tests.
- Swap the keyboard once or twice, then type some more.
- Go into the settings menu to install a keyboard once, then return to the main screen and type a bit more.
- If anything "seems wrong", please report back on that.