### PR TITLE
refactor(core): use `km_core_state_context_clear` where possible

### DIFF
--- a/developer/src/tike/main/Keyman.System.KeymanCore.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCore.pas
@@ -282,6 +282,10 @@ function km_core_state_to_json(
   space: pinteger
 ): km_core_status; cdecl; external keymancore delayed;
 
+function km_core_state_context_clear(
+  state: pkm_core_state
+): km_core_status; cdecl; external keymancore delayed;
+
 type
   km_core_attr = record
     max_context: Integer;   // Maximum context size supported by processor.

--- a/developer/src/tike/main/Keyman.System.VisualKeyboardImportKMX.pas
+++ b/developer/src/tike/main/Keyman.System.VisualKeyboardImportKMX.pas
@@ -106,10 +106,8 @@ procedure TVisualKeyboardImportKMX.ImportKey(vk: TVKKey);
 var
   data: string;
   i: Integer;
-  context: pkm_core_context;
 begin
-  context := km_core_state_context(FCore.State);
-  km_core_context_clear(context);
+  km_core_state_context_clear(FCore.State);
   if km_core_process_event(FCore.State, vk.vkey, vk.kmshift, 1, KM_CORE_EVENT_FLAG_DEFAULT) = KM_CORE_STATUS_OK then
   begin
     FEvents.Clear;

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -996,7 +996,7 @@ ibus_keyman_engine_focus_out (IBusEngine *engine)
     IBusKeymanEngine *keyman = (IBusKeymanEngine *) engine;
 
     g_message("%s", __FUNCTION__);
-    km_core_context_clear(km_core_state_context(keyman->state));
+    km_core_state_context_clear(keyman->state);
     parent_class->focus_out (engine);
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
@@ -1,11 +1,11 @@
 /**
  * Keyman is copyright (C) SIL International. MIT License.
- * 
+ *
  * CoreWrapper.m
  * Keyman
- * 
+ *
  * Created by Shawn Schantz on 2022-12-12.
- * 
+ *
  * A class to wrap an instance of a Keyman Core keyboard (a km_core_keyboard
  * object) and its associated objects. A new CoreWrapper is created whenever
  * Keyman for Mac switches to a new keyboard. The CoreWrapper allows Keyman
@@ -32,7 +32,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   self = [super init];
   if (self) {
     _coreHelper = helper;
-    
+
     // if the kmxFilePath has been provided, then load the keyboard now
     if (path != nil) {
       [self changeKeyboardWithKmxFilePath: path];
@@ -79,7 +79,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
 -(void)loadKeyboardUsingCore:(NSString*) path {
   km_core_path_name keyboardPath = [path UTF8String];
   km_core_status result = km_core_keyboard_load(keyboardPath, &_coreKeyboard);
-  
+
   if (result != KM_CORE_STATUS_OK) {
     NSString *message = [NSString stringWithFormat:@"Unexpected Keyman Core result: %u", result];
     [NSException raise:@"LoadKeyboardException" format:@"%@", message];
@@ -103,7 +103,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
 
 -(void)createKeyboardStateUsingCore {
   km_core_status result = KM_CORE_STATUS_OK;
-  
+
   // TODO: create once
   // create option list
   km_core_option_item coreEnvironment[CORE_ENVIRONMENT_ARRAY_LENGTH] = {0};
@@ -123,7 +123,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
 
 -(CoreKeyOutput*)processEvent:(nonnull NSEvent *)event {
   NSEventModifierFlags modifiers = event.modifierFlags;
-  
+
   // process key down events only
   if (event.type != NSEventTypeKeyDown) {
       return nil;
@@ -132,7 +132,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   if (modifiers & NSEventModifierFlagCommand) {
       return nil;
   }
-  
+
   return [self processMacVirtualKey:event.keyCode
                       withModifiers:modifiers withKeyDown:YES];
 }
@@ -229,7 +229,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   size_t actionCount = 0;
   km_core_action_item const * actionList =
       km_core_state_action_items(self.coreState, &actionCount);
-  
+
   NSMutableArray *eventArray = [NSMutableArray arrayWithCapacity:actionCount];
 
   for (int i = 0; i < actionCount; i++) {
@@ -237,7 +237,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
     CoreAction *coreAction = [self createCoreActionForActionStruct:&action];
     [eventArray insertObject:coreAction atIndex:i];
   }
-  
+
   return eventArray;
 }
 
@@ -266,7 +266,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
       }
       case KM_CORE_IT_BACK: {
         km_core_backspace_item backspace = actionStruct->backspace;
-        
+
         if (backspace.expected_type == KM_CORE_BT_CHAR) {
           NSString *charString = [self.coreHelper utf32ValueToString:backspace.expected_value];
           [self.coreHelper logDebugMessage:@"createCoreActionForActionStruct charString = %@", charString];
@@ -285,9 +285,9 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
         km_core_option_item const * option = actionStruct->option;
         NSString *keyString = [self.coreHelper createNSStringFromUnicharString:option->key];
         NSString *valueString = [self.coreHelper createNSStringFromUnicharString:option->value];
-        
+
         [self.coreHelper logDebugMessage:@"***createCoreActionForActionStruct converted Persist Options, key = %@, value = %@, scope = %d", keyString, valueString, option->scope];
-        
+
         action = [[CoreAction alloc] initPersistOptionAction:keyString value:valueString scope:option->scope];
         break;
       }
@@ -312,10 +312,10 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
 
 -(NSString *)getContextAsStringUsingCore {
   km_core_context * context =  km_core_state_context(self.coreState);
-  
+
   km_core_context_item * contextItemsArray = nil;
   size_t contextLength = km_core_context_length(context);
-  
+
   NSMutableString *contextString = [[NSMutableString alloc]init];
 
   if (contextLength==0) {
@@ -333,7 +333,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
     }
   }
   NSString *immutableString = [NSString stringWithString:contextString];
-  
+
   // dispose of context items array
   if (contextItemsArray) {
     km_core_context_items_dispose(contextItemsArray);
@@ -344,9 +344,8 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
 }
 
 -(void)clearContextUsingCore {
-  km_core_context * coreContext =  km_core_state_context(self.coreState);
-  km_core_context_clear(coreContext);
-  [self.coreHelper logDebugMessage:@"km_core_context_clear called"];
+  km_core_state_context_clear(self.coreState);
+  [self.coreHelper logDebugMessage:@"km_core_state_context_clear called"];
 }
 
 -(void)setContextIfNeeded:(NSString*)context {
@@ -361,11 +360,11 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   } else {
     char const *coreString = [context cStringUsingEncoding:NSUTF8StringEncoding];
     km_core_context_item *contextItemArray;
-    
+
     // create array of context items
     km_core_status result = km_core_context_items_from_utf8(coreString, &contextItemArray);
     [self.coreHelper logDebugMessage:@"km_core_context_items_from_utf8, result=%i", result];
-    
+
     // set the context in core using the array
     km_core_context * coreContext =  km_core_state_context(self.coreState);
     km_core_context_set(coreContext, contextItemArray);
@@ -400,24 +399,24 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   coreOptionArray[4].scope = KM_CORE_OPT_ENVIRONMENT;
   coreOptionArray[4].key = KM_CORE_KMX_ENV_PLATFORM;
   coreOptionArray[4].value = u"mac macos macosx hardware desktop native";   // const char16_t*, encoded as UTF-16
-  
+
   coreOptionArray[5] = (km_core_option_item) {0};
-  
+
   return TRUE;
 }
 
 -(BOOL)setOptionsForCore: (NSString *) key value:(NSString *) value {
   [self.coreHelper logDebugMessage:@"setOptionsForCore, key = %@, value = %@", key, value];
-  
+
   // array of length 2, second item is terminating null struct
   km_core_option_item option[2] = {0};
   option[0].key = [self.coreHelper createUnicharStringFromNSString: key];
   option[0].value = [self.coreHelper createUnicharStringFromNSString: value];
   option[0].scope = KM_CORE_OPT_KEYBOARD;
-  
+
   km_core_status result = km_core_state_options_update(self.coreState, &option[0]);
   [self.coreHelper logDebugMessage:@"setOptionsForCore, km_core_state_options_update result = %d", result];
-  
+
   return (result==KM_CORE_STATUS_OK);
 }
 


### PR DESCRIPTION
Relates to #10365.

Use `km_core_state_context_clear()` instead of `km_core_context_clear()` as part of eliminating use of `km_core_state_context()`.

@keymanapp-test-bot skip