### PR TITLE
fix(web): use KMW OSK font for "**" special-text in key hints

### DIFF
--- a/web/src/engine/osk/src/input/gestures/browser/multitap.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/multitap.ts
@@ -8,7 +8,6 @@ import { distributionFromDistanceMaps } from '@keymanapp/input-processor';
 import Modipress from './modipress.js';
 import { keySupportsModipress } from '../specsForLayout.js';
 import { GesturePreviewHost } from '../../../keyboard-layout/gesturePreviewHost.js';
-import { renameSpecialKey } from '../../../keyboard-layout/oskKey.js';
 
 /**
  * Represents a potential multitap gesture's implementation within KeymanWeb.

--- a/web/src/engine/osk/src/input/gestures/browser/multitap.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/multitap.ts
@@ -60,10 +60,7 @@ export default class Multitap implements GestureHandler {
     const tapLookahead = (offset) => (this.tapIndex + offset) % this.multitaps.length;
 
     const updatePreview = () => {
-      previewHost?.setMultitapHint(
-        renameSpecialKey(this.multitaps[tapLookahead(0)].text, vkbd),
-        renameSpecialKey(this.multitaps[tapLookahead(1)].text, vkbd)
-      );
+      previewHost?.setMultitapHint(this.multitaps[tapLookahead(0)], this.multitaps[tapLookahead(1)], vkbd);
     }
 
     source.on('complete', () => {

--- a/web/src/engine/osk/src/input/gestures/browser/multitap.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/multitap.ts
@@ -8,6 +8,7 @@ import { distributionFromDistanceMaps } from '@keymanapp/input-processor';
 import Modipress from './modipress.js';
 import { keySupportsModipress } from '../specsForLayout.js';
 import { GesturePreviewHost } from '../../../keyboard-layout/gesturePreviewHost.js';
+import { renameSpecialKey } from '../../../keyboard-layout/oskKey.js';
 
 /**
  * Represents a potential multitap gesture's implementation within KeymanWeb.
@@ -59,7 +60,10 @@ export default class Multitap implements GestureHandler {
     const tapLookahead = (offset) => (this.tapIndex + offset) % this.multitaps.length;
 
     const updatePreview = () => {
-      previewHost?.setMultitapHint(this.multitaps[tapLookahead(0)].text, this.multitaps[tapLookahead(1)].text);
+      previewHost?.setMultitapHint(
+        renameSpecialKey(this.multitaps[tapLookahead(0)].text, vkbd),
+        renameSpecialKey(this.multitaps[tapLookahead(1)].text, vkbd)
+      );
     }
 
     source.on('complete', () => {

--- a/web/src/engine/osk/src/keyboard-layout/gesturePreviewHost.ts
+++ b/web/src/engine/osk/src/keyboard-layout/gesturePreviewHost.ts
@@ -4,6 +4,8 @@ import EventEmitter from "eventemitter3";
 import { KeyElement } from "../keyElement.js";
 import { FlickNameCoordMap, OrderedFlickDirections } from "../input/gestures/browser/flick.js";
 import { PhoneKeyTipOrientation } from "../input/gestures/browser/keytip.js";
+import { default as VisualKeyboard } from "../visualKeyboard.js";
+import { renameSpecialKey } from "./oskKey.js";
 
 /**With edge lengths of 1, to keep flick-text invisible at the start, the
  * hypotenuse for an inter-cardinal path is sqrt(2).  To keep a perfect circle
@@ -130,9 +132,15 @@ export class GesturePreviewHost extends EventEmitter<EventMap> {
     this.onCancel = handler;
   }
 
-  public setMultitapHint(current: string, next: string) {
+  public setMultitapHint(currentSrc: ActiveKeyBase, nextSrc: ActiveKeyBase, vkbd?: VisualKeyboard) {
+    const current = renameSpecialKey(currentSrc.text, vkbd);
+    const next    = renameSpecialKey(nextSrc.text, vkbd);
+
     this.label.textContent = current;
     this.hintLabel.textContent = next;
+
+    this.label.style.fontFamily     = (current != currentSrc.text) ? 'SpecialOSK' : currentSrc.font ?? this.label.style.fontFamily;
+    this.hintLabel.style.fontFamily = (next != nextSrc.text) ? 'SpecialOSK' : nextSrc.font ?? this.hintLabel.style.fontFamily;
 
     this.emit('startFade');
 

--- a/web/src/engine/osk/src/keyboard-layout/oskBaseKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskBaseKey.ts
@@ -1,7 +1,7 @@
 import { ActiveKey, Codes, DeviceSpec } from '@keymanapp/keyboard-processor';
 import { landscapeView } from 'keyman/engine/dom-utils';
 
-import OSKKey from './oskKey.js';
+import OSKKey, { renameSpecialKey } from './oskKey.js';
 import { KeyData, KeyElement, link } from '../keyElement.js';
 import OSKRow from './oskRow.js';
 import VisualKeyboard from '../visualKeyboard.js';
@@ -78,7 +78,7 @@ export default class OSKBaseKey extends OSKKey {
     for(bsn=0; bsn<bsk.length; bsn++) {
       if(bsk[bsn]['sp'] == 1 || bsk[bsn]['sp'] == 2) {
         var oldText=bsk[bsn]['text'];
-        bsk[bsn]['text']=this.renameSpecialKey(oldText, vkbd);
+        bsk[bsn]['text']=renameSpecialKey(oldText, vkbd);
       }
 
       // If a subkey doesn't have a defined layer property, copy it from the base key's layer by default.
@@ -120,7 +120,7 @@ export default class OSKBaseKey extends OSKKey {
     }
 
     // If a subkey array is defined, add an icon
-    const skIcon = this.generateHint();
+    const skIcon = this.generateHint(vkbd);
     btn.appendChild(skIcon);
 
     // Add text to button and button to placeholder div
@@ -134,7 +134,7 @@ export default class OSKBaseKey extends OSKKey {
     return this.square = kDiv;
   }
 
-  public generateHint(): HTMLDivElement {
+  public generateHint(vkbd: VisualKeyboard): HTMLDivElement {
     // If a hint is defined, add an icon
     const skIcon = document.createElement('div');
     // Ensure that we use the keyboard's text font for hints.
@@ -161,7 +161,7 @@ export default class OSKBaseKey extends OSKKey {
 
     // If the base key itself is the source of the hint text, we use `hint` directly.
     // Otherwise, we present the source subkey's key cap as the hint.
-    const text = hintSpec == this.spec ? this.spec.hint : hintSpec.text;
+    const text = renameSpecialKey(hintSpec == this.spec ? this.spec.hint : hintSpec.text, vkbd);
     if(text == '\u2022') {
       // The original, pre-17.0 longpress dot-hint used bold-face styling.
       skIcon.style.fontWeight='bold';

--- a/web/src/engine/osk/src/keyboard-layout/oskBaseKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskBaseKey.ts
@@ -161,11 +161,18 @@ export default class OSKBaseKey extends OSKKey {
 
     // If the base key itself is the source of the hint text, we use `hint` directly.
     // Otherwise, we present the source subkey's key cap as the hint.
-    const text = renameSpecialKey(hintSpec == this.spec ? this.spec.hint : hintSpec.text, vkbd);
+    const baseText = hintSpec == this.spec ? this.spec.hint : hintSpec.text
+    const text = renameSpecialKey(baseText, vkbd);
     if(text == '\u2022') {
       // The original, pre-17.0 longpress dot-hint used bold-face styling.
       skIcon.style.fontWeight='bold';
     }
+
+    if(baseText != text) {
+      // if the text is from a *Special* shorthand, always use our special-key OSK font.
+      skIcon.style.fontFamily = 'SpecialOSK';
+    }
+
     skIcon.textContent = text;
 
     return skIcon;

--- a/web/src/engine/osk/src/keyboard-layout/oskBaseKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskBaseKey.ts
@@ -145,7 +145,7 @@ export default class OSKBaseKey extends OSKKey {
       return skIcon;
     }
 
-    if(hintSpec.font) {
+    if(hintSpec.font && hintSpec.font != 'SpecialOSK') {
       skIcon.style.fontFamily = hintSpec.font;
     } else {
       skIcon.classList.add('kmw-key-text');


### PR DESCRIPTION
The OSK render would always use the key cap font for hint text, but for special text strings which are replaced by symbols from the KMW OSK font (e.g. `*Shift*`) we need to both transform this, and use the correct font.

---

In a picture:

![image](https://github.com/keymanapp/keyman/assets/25213402/85659137-6c2a-4cc0-a1a4-52561a706105)

That hint is from the special-key shortcut `*Symbol*`.  While subkeys were already being adequately styled, I recently realized that _hints_ were not considering such shortcuts.  For the record, Developer doesn't either:

![image](https://github.com/keymanapp/keyman/assets/25213402/e52f559e-54eb-460a-b45f-3a9914c66e07)

While I was at it, I also considered the case where such use might appear in a multitap-gesture preview hint.  This shouldn't happen for most of our defined *Special* cases, but we do support *ZWNJ* and a few other special keycodes in a similar manner, so it's conceivable this could matter for some keyboard yet to be defined.

There are also other "fun" hint combinations that can arise.  As a quick test of such cases...

![image](https://github.com/keymanapp/keyman/assets/25213402/afb0f380-c4a8-48a9-a41c-7f3f3b3ffdcf)

Note the "Shifty" shift-key hint - it's using the standard key-cap fonts, _not_ the special OSK font that the base key-cap uses.  Meanwhile, the numeric key's cap and hint both use the special OSK font.  Finally, the space bar uses the special-key *ZWNJ* for its hint on a non-special key.