### PR TITLE
fix(android): Fix OSK rotation issues

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -71,6 +71,7 @@
       android:exported="true"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
       android:label="@string/app_name"
+      android:resizeableActivity="false"
       android:launchMode="singleTask">
 
       <!-- See http://stackoverflow.com/questions/1733195/android-intent-filter-for-a-particular-file-extension/2062112#2062112 -->

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
@@ -8,9 +8,12 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
+import android.view.Display;
 import android.view.MotionEvent;
+import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -107,8 +110,9 @@ public class AdjustKeyboardHeightActivity extends BaseActivity {
             break;
           case MotionEvent.ACTION_UP:
             // Save the currentHeight when the user releases
-            int orientation = context.getResources().getConfiguration().orientation;
-            String keyboardHeightKey = (orientation == Configuration.ORIENTATION_LANDSCAPE) ?
+            Display display = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+            int rotation = display.getRotation();
+            String keyboardHeightKey = (rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270) ?
               KMManager.KMKey_KeyboardHeightLandscape : KMManager.KMKey_KeyboardHeightPortrait;
             editor.putInt(keyboardHeightKey, currentHeight);
             editor.commit();

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -34,8 +34,11 @@ import android.os.IBinder;
 import android.text.InputType;
 import android.util.Log;
 import android.view.View;
+import android.view.Display;
+import android.view.Surface;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
@@ -2016,10 +2019,12 @@ public final class KMManager {
   public static int getKeyboardHeight(Context context) {
     int defaultHeight = (int) context.getResources().getDimension(R.dimen.keyboard_height);
     SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-    int orientation = context.getResources().getConfiguration().orientation;
-    if (orientation == Configuration.ORIENTATION_PORTRAIT) {
+
+    Display display = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+    int rotation = display.getRotation();
+    if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180) {
       return prefs.getInt(KMManager.KMKey_KeyboardHeightPortrait, defaultHeight);
-    } else if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+    } else if (rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270) {
       return prefs.getInt(KMManager.KMKey_KeyboardHeightLandscape, defaultHeight);
     }
 


### PR DESCRIPTION
Fixes #10241 
Fixes #9978 
Fixes #9191 

There were multiple bugs related to OSK not filling the full width or not appearing after rotating the device orientation.

The main two fixes on this PR:
* Disable multi-window (where modern Android devices try to split the screen so dimensions are "half"
* The existing device orientation code would sporadically report PORTRAIT when the device was LANDSCAPE. Changing to getRotation() seems to have more consistent behavior.


## User Testing
**Setup** - Install the PR build of Keyman for Android on the device/emulator. Some tests specify a specific Android SDK level

* **TEST_LANDSCAPE_KEYBOARD_PICKER** - Verifies menu to adjust keyboard height works
1. Install the PR build of Keyman for Android on an Android device/emulator
2. with the device in Landscape mode, Launch Keyman and dismiss the Get Started menu
3. In the Keyman app, type some letter using the OSK
4. Longpress the globe key to display the keyboard picker menu
5. Select the same keyboard from the picker menu
6. Verify OSK is still full width

* **TEST_OSK_ROTATION_ANDROID_12**
1. Install the PR build of Keyman for Android on an Android device/emulator Android 12 (SDK 32) 
2. Open Keyman In-App.
3. Open the Settings menu.
4. Open Adjust keyboard height menu.
5. Set the height to the maximum size.
6. Revert to Keyman Home screen.
7. Change the Orientation from Portrait to Landscape.
8. Verify OSK displays and is full width.
 
* **TEST_OSK_ROTATION_ANDROID_13**
1. Install the PR build of Keyman for Android on an Android device/emulator Android 13 (SDK 33) 
2. Open Keyman In-App.
3. Open the Settings menu.
4. Open Adjust keyboard height menu.
5. Set the height to the maximum size.
6. Revert to Keyman Home screen.
7. Change the Orientation from Portrait to Landscape.
8. Verify OSK displays and is full width.