### PR TITLE
docs(linux): Update sample settings

### DIFF
--- a/docs/settings/linux/extensions.json
+++ b/docs/settings/linux/extensions.json
@@ -10,5 +10,6 @@
     "maelvalais.autoconf",
     "webfreak.debug",
     "dawidd6.debian-vscode",
+    "ms-python.autopep8",
   ]
 }

--- a/docs/settings/linux/settings.json
+++ b/docs/settings/linux/settings.json
@@ -10,10 +10,11 @@
   "python.testing.unittestEnabled": true,
   "python.testing.pytestEnabled": false,
   "python.testing.nosetestsEnabled": false,
-  "python.linting.enabled": true,
-  // We use flake8 for Python linting - install with `pip3 install flake8`
-  "python.linting.flake8Enabled": true,
   "python.pythonPath": "/usr/bin/python3",
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.autopep8",
+    "editor.formatOnType": true
+  },
   "files.associations": {
     "*.tcc": "cpp",
     "keyman_core_api.h": "c",


### PR DESCRIPTION
The previous settings are now deprecated, so this change replaces them.

@keymanapp-test-bot skip