### PR TITLE
refactor(mac): remove unused context calls 🌱

### DIFF
--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.h
@@ -1,9 +1,9 @@
 /**
  * Keyman is copyright (C) SIL International. MIT License.
- * 
+ *
  * CoreWrapper.h
  * Keyman
- * 
+ *
  * Created by Shawn Schantz on 2022-12-12.
  */
 
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
                 withKeyDown:(BOOL)isKeyDown;
 -(void)setContextIfNeeded:(NSString*)context;
 -(void)setContext:(NSString*)context;
--(NSString*)context;
+-(NSString*)contextDebug;
 -(void)clearCoreContext;
 -(void)dealloc;
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
@@ -310,7 +310,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   return action;
 }
 
--(NSString *)getContextAsStringUsingCore {
+/*-(NSString *)getContextAsStringUsingCore {
   km_core_context * context =  km_core_state_context(self.coreState);
 
   km_core_context_item * contextItemsArray = nil;
@@ -341,7 +341,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
 
   [self.coreHelper logDebugMessage:@"CoreWrapper getContextAsStringUsingCore = %@", immutableString];
   return immutableString;
-}
+}*/
 
 -(void)clearContextUsingCore {
   km_core_state_context_clear(self.coreState);
@@ -374,9 +374,9 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
 }
 
 
--(NSString*)context {
+/*-(NSString*)context {
   return [self getContextAsStringUsingCore];
-}
+}*/
 
 //TODO: create and save as static
 +(BOOL)setupCoreEnvironment:(km_core_option_item *) coreOptionArray {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
@@ -310,39 +310,6 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   return action;
 }
 
-/*-(NSString *)getContextAsStringUsingCore {
-  km_core_context * context =  km_core_state_context(self.coreState);
-
-  km_core_context_item * contextItemsArray = nil;
-  size_t contextLength = km_core_context_length(context);
-
-  NSMutableString *contextString = [[NSMutableString alloc]init];
-
-  if (contextLength==0) {
-    [self.coreHelper logDebugMessage:@"CoreWrapper getContextAsStringUsingCore, context is empty."];
-  } else {
-    km_core_status result = km_core_context_get(context, &contextItemsArray);
-    if (result==KM_CORE_STATUS_OK) {
-      for (int i = 0; i < contextLength; i++) {
-        km_core_context_item contextItem = contextItemsArray[i];
-        if (contextItem.type == KM_CORE_CT_CHAR) {
-          NSString *unicodeString = [self.coreHelper utf32ValueToString:contextItem.character];
-          [contextString appendString:unicodeString];
-        }
-      }
-    }
-  }
-  NSString *immutableString = [NSString stringWithString:contextString];
-
-  // dispose of context items array
-  if (contextItemsArray) {
-    km_core_context_items_dispose(contextItemsArray);
-  }
-
-  [self.coreHelper logDebugMessage:@"CoreWrapper getContextAsStringUsingCore = %@", immutableString];
-  return immutableString;
-}*/
-
 -(void)clearContextUsingCore {
   km_core_state_context_clear(self.coreState);
   [self.coreHelper logDebugMessage:@"km_core_state_context_clear called"];
@@ -373,10 +340,14 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   }
 }
 
+-(NSString*)contextDebug {
+  km_core_cp * context = km_core_state_context_debug(self.coreState, KM_CORE_DEBUG_CONTEXT_CACHED);
+  NSString *debugString = [self.coreHelper createNSStringFromUnicharString:context];
+  km_core_cp_dispose(context);
 
-/*-(NSString*)context {
-  return [self getContextAsStringUsingCore];
-}*/
+  [self.coreHelper logDebugMessage:@"CoreWrapper contextDebug = %@", debugString];
+  return debugString;
+}
 
 //TODO: create and save as static
 +(BOOL)setupCoreEnvironment:(km_core_option_item *) coreOptionArray {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.h
@@ -21,7 +21,7 @@
 @property (assign, nonatomic) BOOL debugMode;
 
 - (id)initWithKMX:(KMXFile *)kmx context:(NSString *)ctxBuf verboseLogging:(BOOL)enableDebugLogging;
-- (NSString *)getCoreContext;
+- (NSString *)getCoreContextDebug;
 - (void)clearCoreContext;
 - (void)setCoreContextIfNeeded:(NSString *)context;
 - (void)setCoreContext:(NSString *)context;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -36,7 +36,7 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
         self.debugMode = enableDebugLogging;
         _kmx = kmx;
         _coreHelper = [[CoreHelper alloc] initWithDebugMode:enableDebugLogging];
-      
+
       if (kmx) {
         [self loadCoreWrapperFromKmxFile:self.kmx.filePath];
         [self.coreWrapper setContext:contextString];
@@ -71,7 +71,7 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
     if (self.coreHelper) {
         self.coreHelper.debugMode = useVerboseLogging;
     }
-  
+
     if (useVerboseLogging) {
         NSLog(@"KMEngine - Turning verbose logging on");
         // In Keyman Engine if "debugMode" is turned on (explicitly) with "English plus Spanish" as the current keyboard and you type "Sentrycrash#KME",
@@ -89,8 +89,8 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
         NSLog(@"KMEngine - Turning verbose logging off");
 }
 
-- (NSString *)getCoreContext {
-  return self.coreWrapper.context;
+- (NSString *)getCoreContextDebug {
+  return self.coreWrapper.contextDebug;
 }
 
 - (void)clearCoreContext {

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreWrapperTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreWrapperTests.m
@@ -1,11 +1,11 @@
 /**
  * Keyman is copyright (C) SIL International. MIT License.
- * 
+ *
  * CoreWrapperTest.m
  * CoreWrapperTests
- * 
+ *
  * Created by Shawn Schantz on 2023-02-17.
- * 
+ *
  * Description...
  */
 
@@ -29,7 +29,7 @@ CoreWrapper *mockWrapper;
   NSString *khmerKeyboardPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"khmer_angkor.kmx"];
 
   NSLog(@"mockKmxFilePath  = %@\n", mockKmxFilePath);
-  
+
   mockWrapper = [[CoreWrapper alloc] initWithHelper: [CoreTestStaticHelperMethods helper] kmxFilePath:mockKmxFilePath];
 }
 
@@ -57,7 +57,7 @@ CoreWrapper *mockWrapper;
 - (void)testprocessEvent_lowercaseA_returnsExpectedCharacterForKmx {
   NSString *kmxPath = [CoreTestStaticHelperMethods getKmxFilePathTestMacEngine];
   CoreWrapper *core = [[CoreWrapper alloc] initWithHelper: [CoreTestStaticHelperMethods helper] kmxFilePath:kmxPath];
-  
+
   // expecting character with 'Ç'
   CoreKeyOutput *coreOutput = [core processMacVirtualKey:MVK_A withModifiers:0 withKeyDown:YES];
   XCTAssert([coreOutput.textToInsert isEqualToString:@"\u00C7"], @"Expected capital C cedille (U+00C7)");
@@ -67,8 +67,8 @@ CoreWrapper *mockWrapper;
   NSString *kmxPath = [CoreTestStaticHelperMethods getKmxFilePathTestMacEngine];
   CoreWrapper *core = [[CoreWrapper alloc] initWithHelper: [CoreTestStaticHelperMethods helper] kmxFilePath:kmxPath];
   [core setContext:@"🤔?👍🏻✅"];
-  NSString *finalContext = core.context;
-  XCTAssert([finalContext isEqualToString:@"🤔?👍🏻✅"], @"Expected '🤔?👍🏻✅' in context buffer");
+  NSString *finalContext = core.contextDebug;
+  XCTAssert([finalContext isEqualToString:@"|🤔?👍🏻✅| (len:5) [ U+1f914 U+003f U+1f44d U+1f3fb U+2705 ]"], @"Expected '🤔?👍🏻✅' in context buffer");
 }
 
 @end

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreWrapperTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreWrapperTests.m
@@ -68,7 +68,7 @@ CoreWrapper *mockWrapper;
   CoreWrapper *core = [[CoreWrapper alloc] initWithHelper: [CoreTestStaticHelperMethods helper] kmxFilePath:kmxPath];
   [core setContext:@"🤔?👍🏻✅"];
   NSString *finalContext = core.contextDebug;
-  XCTAssert([finalContext isEqualToString:@"|🤔?👍🏻✅| (len:5) [ U+1f914 U+003f U+1f44d U+1f3fb U+2705 ]"], @"Expected '🤔?👍🏻✅' in context buffer");
+  XCTAssert([finalContext isEqualToString:@"|🤔?👍🏻✅| (len: 5) [ U+1f914 U+003f U+1f44d U+1f3fb U+2705 ]"], @"Expected '🤔?👍🏻✅' in context buffer");
 }
 
 @end

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreWrapperTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreWrapperTests.m
@@ -68,6 +68,8 @@ CoreWrapper *mockWrapper;
   CoreWrapper *core = [[CoreWrapper alloc] initWithHelper: [CoreTestStaticHelperMethods helper] kmxFilePath:kmxPath];
   [core setContext:@"🤔?👍🏻✅"];
   NSString *finalContext = core.contextDebug;
+  // Note: relying on km_core_state_context_debug output format is just barely
+  // acceptable for a unit test
   XCTAssert([finalContext isEqualToString:@"|🤔?👍🏻✅| (len: 5) [ U+1f914 U+003f U+1f44d U+1f3fb U+2705 ]"], @"Expected '🤔?👍🏻✅' in context buffer");
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
@@ -563,6 +563,8 @@ NSString * names[nCombinations];
     XCTAssert(output.codePointsToDeleteBeforeInsert == 1, @"Expected output to delete one code point");
     XCTAssert(!output.hasTextToInsert, @"expected to insert nothing");
     NSString *context = engine.getCoreContextDebug;
+    // Note: relying on km_core_state_context_debug output format is just barely
+    // acceptable for a unit test
     XCTAssert([context isEqualToString:@"|| (len: 0) [ ]"], @"Context should be empty.");
 }
 
@@ -573,6 +575,8 @@ NSString * names[nCombinations];
     CoreKeyOutput *output = [engine processEvent:event];
     XCTAssert(output.emitKeystroke, @"Expected emitKeystroke==YES");
     NSString *context = engine.getCoreContextDebug;
+    // Note: relying on km_core_state_context_debug output format is just barely
+    // acceptable for a unit test
     XCTAssert([context isEqualToString:@"|| (len: 0) [ ]"], @"Context should be cleared.");
 }
 
@@ -583,6 +587,8 @@ NSString * names[nCombinations];
     CoreKeyOutput *output = [engine processEvent:event];
     XCTAssert(output.emitKeystroke, @"Expected emitKeystroke==YES");
     NSString *context = engine.getCoreContextDebug;
+    // Note: relying on km_core_state_context_debug output format is just barely
+    // acceptable for a unit test
     XCTAssert([context isEqualToString:@"|| (len: 0) [ ]"], @"Context should be cleared.");
 }
 
@@ -594,6 +600,8 @@ NSString * names[nCombinations];
     CoreKeyOutput *output = [engine processEvent:event];
     XCTAssert(output.hasTextToInsert, @"returns text to insert");
     context = engine.getCoreContextDebug;
+    // Note: relying on km_core_state_context_debug output format is just barely
+    // acceptable for a unit test
     XCTAssert([context isEqualToString:@"|\u025B\u0308| (len: 2) [ U+025b U+0308 ]"], @"Context updated with diacritic.");
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
@@ -43,7 +43,7 @@ NSString * names[nCombinations];
     XCTAssert(engine != nil, @"Expected non-nil engine");
     // Note: relying on km_core_state_context_debug output format is just barely
     // acceptable for a unit test
-    XCTAssert([engine.getCoreContextDebug isEqualToString:@"|| (len: 0) [ ]", @"Expected empty context buffer"]);
+    XCTAssert([engine.getCoreContextDebug isEqualToString:@"|| (len: 0) [ ]"], @"Expected empty context buffer");
 }
 
 - (void)testinitWithKMX_ValidKmxNonEmptyContext_InitializedWithContext {

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
@@ -43,7 +43,7 @@ NSString * names[nCombinations];
     XCTAssert(engine != nil, @"Expected non-nil engine");
     // Note: relying on km_core_state_context_debug output format is just barely
     // acceptable for a unit test
-    XCTAssert(engine.getCoreContextDebug isEqualToString:@"|| (len: 0) [ ]", @"Expected empty context buffer");
+    XCTAssert([engine.getCoreContextDebug isEqualToString:@"|| (len: 0) [ ]", @"Expected empty context buffer"]);
 }
 
 - (void)testinitWithKMX_ValidKmxNonEmptyContext_InitializedWithContext {

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
@@ -41,21 +41,27 @@ NSString * names[nCombinations];
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
     KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
     XCTAssert(engine != nil, @"Expected non-nil engine");
-    XCTAssert(engine.getCoreContext.length == 0, @"Expected empty context buffer");
+    // Note: relying on km_core_state_context_debug output format is just barely
+    // acceptable for a unit test
+    XCTAssert(engine.getCoreContextDebug isEqualToString:@"|| (len: 0) [ ]", @"Expected empty context buffer");
 }
 
 - (void)testinitWithKMX_ValidKmxNonEmptyContext_InitializedWithContext {
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
     KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"abc" verboseLogging:YES];
     XCTAssert(engine != nil, @"Expected non-nil engine");
-    XCTAssert([engine.getCoreContext isEqualToString:@"abc"], @"Expected 'abc' in context buffer");
+    // Note: relying on km_core_state_context_debug output format is just barely
+    // acceptable for a unit test
+    XCTAssert([engine.getCoreContextDebug isEqualToString:@"|abc| (len: 3) [ U+0061 U+0062 U+0063 ]"], @"Expected 'abc' in context buffer");
 }
 
 - (void)testsetCoreContextIfNeeded_NonEmptyContext_InitialContextUpdated {
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
     KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"a" verboseLogging:YES];
     [engine setCoreContextIfNeeded:@"xyz"];
-    XCTAssert([engine.getCoreContext isEqualToString:@"xyz"], @"Expected 'xyz' in context buffer");
+    // Note: relying on km_core_state_context_debug output format is just barely
+    // acceptable for a unit test
+    XCTAssert([engine.getCoreContextDebug isEqualToString:@"|xyz| (len: 3) [ U+0078 U+0079 U+007a ]"], @"Expected 'xyz' in context buffer");
 }
 
 // TODO: re-enable this one after the core API km_core_state_context_set_if_needed is fixed
@@ -64,7 +70,9 @@ NSString * names[nCombinations];
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
     KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
     [engine setCoreContextIfNeeded:@"xyz"];
-    XCTAssert([engine.getCoreContext isEqualToString:@"xyz"], @"Expected 'xyz' in context buffer");
+    // Note: relying on km_core_state_context_debug output format is just barely
+    // acceptable for a unit test
+    XCTAssert([engine.getCoreContextDebug isEqualToString:@"|xyz| (len: 3) [ U+0078 U+0079 U+007a ]"], @"Expected 'xyz' in context buffer");
 }
  */
 
@@ -278,7 +286,7 @@ NSString * names[nCombinations];
         NSString * characters = charactersIgnoringModifiers;
         if (modifiers[i] & (LEFT_ALT_FLAG | RIGHT_ALT_FLAG))
             characters = [characters stringByAppendingString:@"\u030A"];
-        
+
         NSLog(@"Test case: %lu", (NSUInteger)modifiers[i]);
         // NOTE: 'a' happens to be keyCode 0 (see initVirtualKeyMapping in CoreHelper)
         NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:modifiers[i] timestamp:0 windowNumber:0 context:nil characters:characters charactersIgnoringModifiers:charactersIgnoringModifiers isARepeat:NO keyCode:0];
@@ -335,10 +343,10 @@ NSString * names[nCombinations];
 - (void)testprocessEvent_eventForSWithModifiers_ReturnsCharacterActionWithExpectedCharacterBasedOnKmx {
     int i = 0;
     [KMEngineTests fillInNamesAndModifiersForAllChiralCombinations];
-    
+
     KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
     KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
-    
+
     for (i = 0; i < nCombinations; i++) {
         [engine clearCoreContext];
         NSString *charactersIgnoringModifiers = (modifiers[i] & (LEFT_SHIFT_FLAG | RIGHT_SHIFT_FLAG)) ? @"S" : @"s";
@@ -349,7 +357,7 @@ NSString * names[nCombinations];
             else
                 characters = @"ß";
         }
-        
+
         NSLog(@"Test case: %lu", (NSUInteger)modifiers[i]);
         // NOTE: 's' happens to be keyCode 1 (see initVirtualKeyMapping in CoreHelper)
         NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:modifiers[i] timestamp:0 windowNumber:0 context:nil characters:characters charactersIgnoringModifiers:charactersIgnoringModifiers isARepeat:NO keyCode:1];
@@ -554,8 +562,8 @@ NSString * names[nCombinations];
     NSLog(@"output: %@", output);
     XCTAssert(output.codePointsToDeleteBeforeInsert == 1, @"Expected output to delete one code point");
     XCTAssert(!output.hasTextToInsert, @"expected to insert nothing");
-    NSString *context = engine.getCoreContext;
-    XCTAssert([context isEqualToString:@""], @"Context should be empty.");
+    NSString *context = engine.getCoreContextDebug;
+    XCTAssert([context isEqualToString:@"|| (len: 0) [ ]"], @"Context should be empty.");
 }
 
 - (void)testCoreProcessEvent_eventReturnWithElNuerKmx_EmitWithContextEmpty {
@@ -564,8 +572,8 @@ NSString * names[nCombinations];
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\n" charactersIgnoringModifiers:@"\n" isARepeat:NO keyCode:kVK_Return];
     CoreKeyOutput *output = [engine processEvent:event];
     XCTAssert(output.emitKeystroke, @"Expected emitKeystroke==YES");
-    NSString *context = engine.getCoreContext;
-    XCTAssert([context isEqualToString:@""], @"Context should be cleared.");
+    NSString *context = engine.getCoreContextDebug;
+    XCTAssert([context isEqualToString:@"|| (len: 0) [ ]"], @"Context should be cleared.");
 }
 
 - (void)testCoreProcessEvent_eventTabWithElNuerKmx_EmitWithContextEmpty {
@@ -574,8 +582,8 @@ NSString * names[nCombinations];
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\t" charactersIgnoringModifiers:@"\t" isARepeat:NO keyCode:kVK_Tab];
     CoreKeyOutput *output = [engine processEvent:event];
     XCTAssert(output.emitKeystroke, @"Expected emitKeystroke==YES");
-    NSString *context = engine.getCoreContext;
-    XCTAssert([context isEqualToString:@""], @"Context should be cleared.");
+    NSString *context = engine.getCoreContextDebug;
+    XCTAssert([context isEqualToString:@"|| (len: 0) [ ]"], @"Context should be cleared.");
 }
 
 - (void)testCoreProcessEvent_eventSingleQuoteWithElNuerKmx_ReturnsDiacritic {
@@ -585,8 +593,8 @@ NSString * names[nCombinations];
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"'" charactersIgnoringModifiers:@"'" isARepeat:NO keyCode:kVK_ANSI_Quote];
     CoreKeyOutput *output = [engine processEvent:event];
     XCTAssert(output.hasTextToInsert, @"returns text to insert");
-    context = engine.getCoreContext;
-    XCTAssert([context isEqualToString:@"\u025B\u0308"], @"Context updated with diacritic.");
+    context = engine.getCoreContextDebug;
+    XCTAssert([context isEqualToString:@"|\u025B\u0308| (len: 2) [ U+025b U+0308 ]"], @"Context updated with diacritic.");
 }
 
 @end


### PR DESCRIPTION
Relates to #10365.

Ensures that the only uses of the Core context are for unit tests. Renames accordingly to clarify usage.

@keymanapp-test-bot skip