### PR TITLE
chore(core): Ignore C++ symbols

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -294,7 +294,7 @@ jobs:
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: libkeymancore.symbols
-        path: linux/debian/libkeymancore.symbols
+        path: linux/debian/tmp/DEBIAN/symbols
       if: always()
 
   set_status:

--- a/linux/debian/libkeymancore.symbols
+++ b/linux/debian/libkeymancore.symbols
@@ -1,6 +1,7 @@
 libkeymancore.so.1 libkeymancore #MINVER#
 * Build-Depends-Package: libkeymancore-dev
 
+ (c++|optional)"typeinfo name for std::codecvt_utf8_utf16<char16_t, 1114111ul, (std::codecvt_mode)0>@Base" 17.0.244
  km_core_actions_dispose@Base 17.0.197
  km_core_context_append@Base 17.0.195
  km_core_context_clear@Base 17.0.195

--- a/linux/scripts/deb-packaging.sh
+++ b/linux/scripts/deb-packaging.sh
@@ -82,8 +82,8 @@ check_api_not_changed() {
   # shellcheck disable=SC2064
   trap "rm -rf \"${tmpDir}\"" ERR
   dpkg -x "${BIN_PKG}" "${tmpDir}"
-  cd debian
-  dpkg-gensymbols -v"${VERSION}" -p"${PKG_NAME}" -e"${tmpDir}"/usr/lib/x86_64-linux-gnu/"${LIB_NAME}".so* -O"${PKG_NAME}.symbols" -c4
+  mkdir -p debian/tmp/DEBIAN
+  dpkg-gensymbols -v"${VERSION}" -p"${PKG_NAME}" -e"${tmpDir}"/usr/lib/x86_64-linux-gnu/"${LIB_NAME}".so* -c4
   output_ok "${LIB_NAME} API didn't change"
   cd "${REPO_ROOT}/linux"
   rm -rf "${tmpDir}"


### PR DESCRIPTION
We have a C API, but (internal) C++ template instantiations are visible and so get flagged by `dpkg-gensymbols`. This change ignores the one use of C++ by marking it optional. This is listed as a usage scenario in the dpkg-gensymbols man page.

Note this requires a change how we call dpkg-gensymbols: if the `-O` parameter is specified, the file is not treated as being a template file (see man deb-src-symbols) and so the tags are not interpreted. Additionally the file gets overwritten with the non-tag version. So this change removes the `-O` parameter, and changes the archiving of the generated file.

@keymanapp-test-bot skip