### PR TITLE
refactor(mac): remove legacy Core context API calls 🌱

### DIFF
--- a/mac/Keyman4MacIM/KeymanTests/TestAppDelegate.m
+++ b/mac/Keyman4MacIM/KeymanTests/TestAppDelegate.m
@@ -18,7 +18,7 @@
     if (_kme == nil) {
       _kme = [[KMEngine alloc] initWithKMX:nil context:self.contextBuffer verboseLogging:self.debugMode];
     }
-    
+
     return _kme;
 }
 
@@ -31,7 +31,7 @@
     if (_contextBuffer == nil) {
         _contextBuffer = [[NSMutableString alloc] initWithString:@""];
     }
-    
+
     return _contextBuffer;
 }
 
@@ -39,7 +39,7 @@
     _contextBuffer = [contextBuffer mutableCopy];
     if (_contextBuffer.length)
         [_contextBuffer replaceOccurrencesOfString:@"\0" withString:[NSString nullChar] options:0 range:NSMakeRange(0, 1)];
-    [self.kme setCoreContext:self.contextBuffer];
+    [self.kme setCoreContextIfNeeded:self.contextBuffer];
 }
 
 - (BOOL)debugMode {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.h
@@ -28,7 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
               withModifiers:(NSEventModifierFlags)modifierState
                 withKeyDown:(BOOL)isKeyDown;
 -(void)setContextIfNeeded:(NSString*)context;
--(void)setContext:(NSString*)context;
 -(NSString*)contextDebug;
 -(void)clearCoreContext;
 -(void)dealloc;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
@@ -321,25 +321,6 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   [self.coreHelper logDebugMessage:@"CoreWrapper setContextIfNeeded, context=%@, km_core_state_context_set_if_needed result=%i", context, result];
 }
 
--(void)setContext:(NSString*)context {
-  if (context.length == 0) {
-    [self clearContextUsingCore];
-  } else {
-    char const *coreString = [context cStringUsingEncoding:NSUTF8StringEncoding];
-    km_core_context_item *contextItemArray;
-
-    // create array of context items
-    km_core_status result = km_core_context_items_from_utf8(coreString, &contextItemArray);
-    [self.coreHelper logDebugMessage:@"km_core_context_items_from_utf8, result=%i", result];
-
-    // set the context in core using the array
-    km_core_context * coreContext =  km_core_state_context(self.coreState);
-    km_core_context_set(coreContext, contextItemArray);
-    // dispose
-    km_core_context_items_dispose(contextItemArray);
-  }
-}
-
 -(NSString*)contextDebug {
   km_core_cp * context = km_core_state_context_debug(self.coreState, KM_CORE_DEBUG_CONTEXT_CACHED);
   NSString *debugString = [self.coreHelper createNSStringFromUnicharString:context];

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.h
@@ -24,7 +24,6 @@
 - (NSString *)getCoreContextDebug;
 - (void)clearCoreContext;
 - (void)setCoreContextIfNeeded:(NSString *)context;
-- (void)setCoreContext:(NSString *)context;
 
 - (void)setCoreOptions:(NSString *)key withValue:(NSString *)value;
 - (CoreKeyOutput *)processEvent:(NSEvent *)event;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -39,7 +39,7 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
 
       if (kmx) {
         [self loadCoreWrapperFromKmxFile:self.kmx.filePath];
-        [self.coreWrapper setContext:contextString];
+        [self.coreWrapper setContextIfNeeded:contextString];
       }
     }
 
@@ -99,10 +99,6 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
 
 - (void)setCoreContextIfNeeded:(NSString *)context {
   [self.coreWrapper setContextIfNeeded:context];
-}
-
-- (void)setCoreContext:(NSString *)context {
-  [self.coreWrapper setContext:context];
 }
 
 - (void)setCoreOptions:(NSString *)key withValue:(NSString *)value {

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreWrapperTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreWrapperTests.m
@@ -66,7 +66,7 @@ CoreWrapper *mockWrapper;
 - (void)testgetContextAsString_ContextContainsEmojis_ReturnsSameContext  {
   NSString *kmxPath = [CoreTestStaticHelperMethods getKmxFilePathTestMacEngine];
   CoreWrapper *core = [[CoreWrapper alloc] initWithHelper: [CoreTestStaticHelperMethods helper] kmxFilePath:kmxPath];
-  [core setContext:@"🤔?👍🏻✅"];
+  [core setContextIfNeeded:@"🤔?👍🏻✅"];
   NSString *finalContext = core.contextDebug;
   // Note: relying on km_core_state_context_debug output format is just barely
   // acceptable for a unit test


### PR DESCRIPTION
Relates to #9999.

@keymanapp-test-bot skip