### PR TITLE
fix(web): right-flick gesture-preview positioning

### DIFF
--- a/web/src/engine/osk/src/keyboard-layout/gesturePreviewHost.ts
+++ b/web/src/engine/osk/src/keyboard-layout/gesturePreviewHost.ts
@@ -14,6 +14,10 @@ import { renameSpecialKey } from "./oskKey.js";
  */
 const FLICK_OVERFLOW_OFFSET = 1.4142;
 
+// If it's a rounding error off of 0, force it to 0.
+// Values such as -1.32e-18 have been seen when 0 was expected.
+const coerceZeroes = (val: number) => Math.abs(val) < 1e-10 ? 0 : val;
+
 interface EventMap {
   preferredOrientation: (orientation: PhoneKeyTipOrientation) => void;
   startFade: () => void;
@@ -74,8 +78,9 @@ export class GesturePreviewHost extends EventEmitter<EventMap> {
 
         // is in polar coords, origin toward north, clockwise.
         const coords = FlickNameCoordMap.get(dir);
-        const x = -Math.sin(coords[0]); // Put 'e' flick at left
-        const y =  Math.cos(coords[0]); // Put 'n' flick at bottom
+
+        const x = coerceZeroes(-Math.sin(coords[0])); // Put 'e' flick at left
+        const y = coerceZeroes(Math.cos(coords[0])); // Put 'n' flick at bottom
 
         ps.width = '100%';
         ps.textAlign = 'center';
@@ -90,6 +95,7 @@ export class GesturePreviewHost extends EventEmitter<EventMap> {
 
         ps.height = '100%';
         ps.lineHeight = '100%';
+
         if(y < 0) {
           ps.bottom = (-y * FLICK_OVERFLOW_OFFSET * edgeLength) + 'px';
         } else if(y > 0) {
@@ -156,7 +162,7 @@ export class GesturePreviewHost extends EventEmitter<EventMap> {
     scrollStyle.marginLeft = `${edge * x}px`;
     scrollStyle.marginTop =  `${edge * y}px`;
 
-    const preferredOrientation = y < 0 ? 'bottom' : 'top';
+    const preferredOrientation = coerceZeroes(y) < 0 ? 'bottom' : 'top';
     if(this.orientation != preferredOrientation) {
       this.orientation = preferredOrientation;
       this.emit('preferredOrientation', preferredOrientation);


### PR DESCRIPTION
... thought I could get away with not double-checking numerical errors on the trig functions related to flick angles, but alas... nope.  The trig function used to detect north-ish flicks reported a change of y-coordinate for 'e' flicks on the order of -1e-18... which is less than zero, and the negative sign caused this to be interpreted as "northish".

If you put this...

```
Math.cos(Math.PI/2)
```

into a JS terminal, you don't get `0` - you get `6.12e-17`, despite cos(90 degrees) = 0 being a known trig property (with 90 degrees = pi/2 radians).  Add a little numerical approximation error on top of that... and you get the source of the 'e'-flick error.

With this change, 'e' flicks now use the upward-positioned gesture previews as originally intended.

@keymanapp-test-bot skip