### PR TITLE
chore(core): ldml shuffle some deck chairs 🌱

### DIFF
--- a/core/src/ldml/ldml_processor.hpp
+++ b/core/src/ldml/ldml_processor.hpp
@@ -24,18 +24,15 @@ namespace core {
 
 #define KM_CORE_LMDL_PROCESSOR_VERSION u"1.0"
 
-  class ldml_processor : public abstract_processor {
-  private:
-    bool _valid;
-    std::unique_ptr<ldml::transforms> transforms, bksp_transforms;
-    ldml::vkeys keys;
+class ldml_event_state;
+
+/** our actual processor */
+class ldml_processor : public abstract_processor {
   public:
     ldml_processor(
       path const & kb_path,
       const std::vector<uint8_t> & data
     );
-
-//    ~ldml_processor() override;
 
     static bool is_kmxplus_file(
       path const & kb_path,
@@ -90,56 +87,104 @@ namespace core {
     }
 
   private:
-     /** emit text to context and actions */
-     static void emit_text(km_core_state *state, const std::u16string &str);
-     /** emit text to context and actions */
-     static void emit_text(km_core_state *state, const std::u32string &str);
-     /** emit char to context and actions */
-     static void emit_text(km_core_state *state, km_core_usv ch);
-     /** emit a marker */
-     static void emit_marker(km_core_state *state, KMX_DWORD marker);
-     /** emit a pass-through and invalidate */
-     static void emit_invalidate_passthrough_keystroke(km_core_state *state, km_core_virtual_key vk, uint16_t modifier_state);
+    /** process a key-up */
+    void process_key_up(ldml_event_state &ldml_state) const;
 
-     /**
-      * Delete text from the state, by:
-      *  1. calling actions().push_backspace() to push the appropriate backspaces
-      *  2. popping the same items from the context items
-      *  3. mutating 'str' by removing the same number of items.
-      * This function handles marker strings correctly.
-      * @param str string with text to remove, from the end
-      * @param length number of chars from the end of str to drop
-      */
-     static void remove_text(km_core_state *state, std::u32string &str, size_t length);
+    /** process a key-down (if it wasn't handled exceptionally) */
+    void process_key_down(ldml_event_state &ldml_state) const;
 
-     /** process a key-up */
-     void process_key_up(km_core_state *state, km_core_virtual_key vk, uint16_t modifier_state) const;
+    /** process a typed key */
+    void process_key_string(ldml_event_state &ldml_state, const std::u16string &key_str) const;
 
-     /** process a key-down (if it wasn't handled exceptionally) */
-     void process_key_down(km_core_state *state, km_core_virtual_key vk, uint16_t modifier_state) const;
+    /** process a backspace */
+    void process_backspace(ldml_event_state &ldml_state) const;
 
-     /** process a typed key */
-     void process_key_string(km_core_state *state, const std::u16string &key_str) const;
+    /**
+     * common function for outputting a string with transforms/normalization applied.
+     * @param str string to output (such as from a key), or empty
+     * @param with_transforms transforms to use or nullptr
+     * @returns length of matched input context
+     */
+    size_t process_output(ldml_event_state &ldml_state, const std::u32string &str, ldml::transforms *with_transforms) const;
 
-     /** process a backspace */
-     void process_backspace(km_core_state *state) const;
+  private:
+    bool _valid;
+    std::unique_ptr<ldml::transforms> transforms, bksp_transforms;
+    ldml::vkeys keys;
+};
 
-     /**
-      * common function for outputting a string with transforms/normalization applied.
-      * @param str string to output (such as from a key), or empty
-      * @param with_transforms transforms to use or nullptr
-      * @returns length of matched input context
-      */
-     size_t process_output(km_core_state *state, const std::u32string &str, ldml::transforms *with_transforms) const;
 
-     /**
-      * add the string+marker portion of the context to the beginning of str.
-      * Stop when a non-string and non-marker is hit.
-      * Convert markers into the UC_SENTINEL format.
-      * @return the number of context items consumed
-      */
-     static size_t context_to_string(km_core_state *state, std::u32string &str, bool include_markers = true);
+/** class holding state as we process an event. mirrors process_event args. */
+class ldml_event_state {
+public:
+  ldml_event_state(
+      km_core_state *state,
+      km_core_virtual_key vk,
+      uint16_t modifier_state,
+      uint8_t is_key_down,
+      uint16_t event_flags);
+  /** done with this, copy it into core state */
+  void commit();
+  /** clear this object out */
+  void clear();
 
-  };
+  // getters
+  inline km_core_virtual_key get_vk() const;
+  inline uint16_t get_modifier_state() const;
+
+  // actions
+
+  /** emit text to context and actions */
+  void emit_text(const std::u16string &str);
+  /** emit text to context and actions */
+  void emit_text(const std::u32string &str);
+  /** emit char to context and actions */
+  void emit_text(km_core_usv ch);
+  /** emit a marker */
+  void emit_marker(KMX_DWORD marker);
+  /** emit a pass-through and invalidate */
+  void emit_invalidate_passthrough_keystroke();
+  /** emit a backspace (for a user-initiated deletion) */
+  void emit_backspace();
+
+  /**
+   * Delete text from the state, by:
+   *  1. calling actions().push_backspace() to push the appropriate backspaces
+   *  2. popping the same items from the context items
+   *  3. mutating 'str' by removing the same number of items.
+   * This function handles marker strings correctly.
+   * @param str string with text to remove, from the end
+   * @param length number of chars from the end of str to drop
+   */
+   void remove_text(std::u32string &str, size_t length);
+
+   /**
+    * add the string+marker portion of the context to the beginning of str.
+    * Stop when a non-string and non-marker is hit.
+    * Convert markers into the UC_SENTINEL format.
+    * @return the number of context items consumed
+    */
+   size_t context_to_string(std::u32string &str, bool include_markers = true);
+
+ private:
+   km_core_virtual_key vk;
+   uint16_t modifier_state;
+   uint8_t is_key_down;
+   uint16_t event_flags;
+   km_core_state *state;
+};
+
+
+// implementation
+km_core_virtual_key
+ldml_event_state::get_vk() const {
+  return vk;
+}
+
+uint16_t
+ldml_event_state::get_modifier_state() const {
+  return modifier_state;
+}
+
 } // namespace core
 } // namespace km


### PR DESCRIPTION
- move the emit_ and context functions into an ldml_event_state object

@keymanapp-test-bot skip

For: #10410 

Note: rebased to make non-changes more clear.