### PR TITLE
fix(web): bulk renderer interface for recent-version targeting keyboards

### DIFF
--- a/web/src/tools/testing/bulk_rendering/README.md
+++ b/web/src/tools/testing/bulk_rendering/README.md
@@ -12,8 +12,9 @@ This renderer loads all the cloud keyboards from api.keyman.com and renders each
     - Note that it is preferable to run this on an actual device if possible.
       - If no prompt is given re: screensharing when you click the 'run' button, use Chrome's Developer Tools
         on a desktop or laptop to run this via emulation instead.
-      - If emulating a mobile device, when prompted to screenshare, be sure to share _the Chrome tab_.  The screen capture
-        system will fail to capture the OSK properly otherwise.
+      - If emulating a mobile device, when prompted to screenshare...
+          - Be sure to share _the Chrome tab_.  The screen capture system will fail to capture the OSK properly otherwise.
+          - Also verify that emulation zoom is set to 100%; the system will fail to capture the OSK properly otherwise.
 6. Save the result to a .html file, either before.html or after.html.
 7. When swapping versions, don't forget to rebuild.
 

--- a/web/src/tools/testing/bulk_rendering/index.html
+++ b/web/src/tools/testing/bulk_rendering/index.html
@@ -27,7 +27,7 @@
     <!-- Insert unminified KeymanWeb source scripts -->
     <!--<script src="https://s.keyman.com/kmw/engine/14.0.227/keymanweb.js" type="application/javascript"></script>-->
     <script src="../../../../build/publish/debug/keymanweb.js" type="application/javascript"></script>
-    <script src="../../../../build/tools/testing/bulk_rendering/bulk_render.js" type="application/javascript"></script>
+    <script src="../../../../build/tools/testing/bulk_rendering/lib/bulk_render.js" type="application/javascript"></script>
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>


### PR DESCRIPTION
Some Web-compiled keyboards that target recent versions of Keyman lacked a certain property that the batch-renderer references for its render headers, which cause an exception before those keyboards had a chance to render.

Also, the path to the compiled rendering script was off by a folder.

Finally, I found documentation for a property that allows streamlining of the recording-system startup, so I added it in - and I think it's actually necessary on Chrome at this point for recording the tab making the recording request.  I couldn't find the tab listed without the property being set.

@keymanapp-test-bot skip