### PR TITLE
refactor(core): move context helpers to a new module 🌱

### DIFF
--- a/core/src/context.hpp
+++ b/core/src/context.hpp
@@ -39,6 +39,11 @@ void context::push_marker(uint32_t marker) {
   emplace_back(km_core_context_item { KM_CORE_CT_MARKER, {0,}, {marker} });
 }
 
+// Context helper functions
+
+km_core_cp* get_context_as_string(km_core_context *context);
+km_core_status set_context_from_string(km_core_context *context, km_core_cp const *new_context);
+
 } // namespace core
 } // namespace km
 

--- a/core/src/context_helpers.cpp
+++ b/core/src/context_helpers.cpp
@@ -16,6 +16,11 @@ using namespace km::core;
  * Retrieves the context as a km_core_cp string, dropping markers
  */
 km_core_cp* km::core::get_context_as_string(km_core_context *context) {
+  assert(context != nullptr);
+  if(context == nullptr) {
+    return nullptr;
+  }
+
   size_t buf_size = 0;
   km_core_context_item* context_items = nullptr;
 
@@ -44,6 +49,12 @@ km_core_cp* km::core::get_context_as_string(km_core_context *context) {
  * Updates the context from the new_context km_core_cp string
  */
 km_core_status km::core::set_context_from_string(km_core_context *context, km_core_cp const *new_context) {
+  assert(context != nullptr);
+  assert(new_context != nullptr);
+  if(context == nullptr || new_context == nullptr) {
+    return KM_CORE_STATUS_INVALID_ARGUMENT;
+  }
+
   km_core_context_item* new_context_items = nullptr;
 
   km_core_status status = km_core_context_items_from_utf16(new_context, &new_context_items);

--- a/core/src/context_helpers.cpp
+++ b/core/src/context_helpers.cpp
@@ -1,0 +1,58 @@
+/*
+  Copyright:    © 2018-2024 SIL International.
+  Description:  Helper functions for context data type conversions
+  Create Date:  18 Jan 2024
+  Authors:      Marc Durdin
+  History:      18 Jan 2024 - MCD - Refactor from km_core_state_context_set_if_needed.cpp
+*/
+#include <cassert>
+
+#include "keyman_core.h"
+#include "context.hpp"
+
+using namespace km::core;
+
+/**
+ * Retrieves the context as a km_core_cp string, dropping markers
+ */
+km_core_cp* km::core::get_context_as_string(km_core_context *context) {
+  size_t buf_size = 0;
+  km_core_context_item* context_items = nullptr;
+
+  if(km_core_context_get(context, &context_items) != KM_CORE_STATUS_OK) {
+    return nullptr;
+  }
+
+  if(km_core_context_items_to_utf16(context_items, nullptr, &buf_size) != KM_CORE_STATUS_OK) {
+    km_core_context_items_dispose(context_items);
+    return nullptr;
+  }
+
+  km_core_cp *app_context_string = new km_core_cp[buf_size];
+
+  km_core_status status = km_core_context_items_to_utf16(context_items, app_context_string, &buf_size);
+  km_core_context_items_dispose(context_items);
+
+  if(status != KM_CORE_STATUS_OK) {
+    return nullptr;
+  }
+
+  return app_context_string;
+}
+
+/**
+ * Updates the context from the new_context km_core_cp string
+ */
+km_core_status km::core::set_context_from_string(km_core_context *context, km_core_cp const *new_context) {
+  km_core_context_item* new_context_items = nullptr;
+
+  km_core_status status = km_core_context_items_from_utf16(new_context, &new_context_items);
+  if (status != KM_CORE_STATUS_OK) {
+    return status;
+  }
+
+  km_core_context_set(context, new_context_items);
+  km_core_context_items_dispose(new_context_items);
+
+  return KM_CORE_STATUS_OK;
+}

--- a/core/src/km_core_state_context_set_if_needed.cpp
+++ b/core/src/km_core_state_context_set_if_needed.cpp
@@ -30,8 +30,6 @@ using namespace km::core;
 
 bool should_normalize(km_core_state *state);
 bool is_context_valid(km_core_cp const * context, km_core_cp const * cached_context);
-km_core_cp* get_context_as_string(km_core_context *context);
-km_core_status set_context_from_string(km_core_context *context, km_core_cp const *new_context);
 bool do_normalize_nfd(km_core_cp const * src, std::u16string &dst);
 km_core_context_status do_fail(km_core_context *app_context, km_core_context *cached_context, const char* error);
 
@@ -137,51 +135,6 @@ bool is_context_valid(km_core_cp const * new_app_context, km_core_cp const * app
   // It's acceptable for the application context to be longer than the cached
   // context, so if we match the whole cached context, we can safely return true
   return true;
-}
-
-/**
- * Retrieves the context as a km_core_cp string, dropping markers
- */
-km_core_cp* get_context_as_string(km_core_context *context) {
-  size_t buf_size = 0;
-  km_core_context_item* context_items = nullptr;
-
-  if(km_core_context_get(context, &context_items) != KM_CORE_STATUS_OK) {
-    return nullptr;
-  }
-
-  if(km_core_context_items_to_utf16(context_items, nullptr, &buf_size) != KM_CORE_STATUS_OK) {
-    km_core_context_items_dispose(context_items);
-    return nullptr;
-  }
-
-  km_core_cp *app_context_string = new km_core_cp[buf_size];
-
-  km_core_status status = km_core_context_items_to_utf16(context_items, app_context_string, &buf_size);
-  km_core_context_items_dispose(context_items);
-
-  if(status != KM_CORE_STATUS_OK) {
-    return nullptr;
-  }
-
-  return app_context_string;
-}
-
-/**
- * Updates the context from the new_context km_core_cp string
- */
-km_core_status set_context_from_string(km_core_context *context, km_core_cp const *new_context) {
-  km_core_context_item* new_context_items = nullptr;
-
-  km_core_status status = km_core_context_items_from_utf16(new_context, &new_context_items);
-  if (status != KM_CORE_STATUS_OK) {
-    return status;
-  }
-
-  km_core_context_set(context, new_context_items);
-  km_core_context_items_dispose(new_context_items);
-
-  return KM_CORE_STATUS_OK;
 }
 
 /**

--- a/core/src/meson.build
+++ b/core/src/meson.build
@@ -44,6 +44,7 @@ endif
 kmx_files = files(
   'actions_normalize.cpp',
   'action.cpp',
+  'context_helpers.cpp',
   'option.cpp',
   'keyboard.cpp',
   'state.cpp',

--- a/core/tests/unit/kmnkbd/test_actions_normalize.cpp
+++ b/core/tests/unit/kmnkbd/test_actions_normalize.cpp
@@ -10,14 +10,10 @@
 
 #include "path.hpp"
 #include "action.hpp"
+#include "context.hpp"
 
 #include <test_assert.h>
 #include "../emscripten_filesystem.h"
-
-// TODO: These helpers are in km_core_state_context_set_if_needed.cpp and
-// should be refactored into a helper module
-km_core_status set_context_from_string(km_core_context *context, km_core_cp const *new_context);
-km_core_cp* get_context_as_string(km_core_context *context);
 
 km_core_option_item test_env_opts[] =
 {


### PR DESCRIPTION
Fixes #10423.

@keymanapp-test-bot skip