### PR TITLE
refactor(core): remove unused context APIs

### DIFF
--- a/core/include/keyman/keyman_core_api_context.h
+++ b/core/include/keyman/keyman_core_api_context.h
@@ -1,14 +1,7 @@
 /*
  * Keyman is copyright (C) SIL International. MIT License.
  *
- * Keyman Keyboard Processor API - Debugger Interfaces
- *
- * The debugger interfaces are still very dependent on .kmx
- * objects.
- *
- * Note: this file is subject to change; the debugger
- *       interfaces are not stable across versions.
- *
+ * Keyman Keyboard Processor API - Context Interfaces
  */
 
 #pragma once
@@ -17,12 +10,6 @@
 #include <stdlib.h>
 #include <keyman/keyman_core_api_bits.h>
 #include <keyman/keyman_core_api_vkeys.h>
-
-// Currently, the Core unit tests use private context APIs defined in
-// keyman_core_api_context.h, which are unused by other consumers. We are
-// hoping to remove these entirely in the future, so we restrict access
-// by default with this macro. Keyman Core internally uses these functions
-// #define _KM_CORE_ACCESS_PRIVATE_CONTEXT_API
 
 #if defined(__cplusplus)
 extern "C"
@@ -96,7 +83,7 @@ km_core_state_get_intermediate_context(km_core_state *state, km_core_context_ite
 ### `km_core_context_items_dispose`
 ##### Description:
 Free the allocated memory belonging to a `km_core_context_item` array previously
-returned by `km_core_context_items_from_utf16` or `km_core_context_get`
+returned by `km_core_context_items_from_utf16` or `context_get`
 ##### Parameters:
 - __context_items__: A pointer to the start of the `km_core_context_item` array
     to be disposed of.
@@ -131,181 +118,6 @@ km_core_state_app_context(km_core_state const *state);
 
 /*
 ```
-### `km_core_context_items_from_utf16`
-##### Description:
-Convert a UTF16 encoded Unicode string into an array of `km_core_context_item`
-structures. Allocates memory as needed.
-##### Return status:
-- `KM_CORE_STATUS_OK`: On success.
-- `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are null.
-- `KM_CORE_STATUS_NO_MEM`: In the event not enough memory can be allocated for the
-  output buffer.
-- `KM_CORE_STATUS_INVALID_UTF`: In the event the UTF16 string cannot be decoded
-  because it contains unpaired surrogate codeunits.
-##### Parameters:
-- __text__: a pointer to a null terminated array of utf16 encoded data.
-- __out_ptr__: a pointer to the result variable:
-    A pointer to the start of the `km_core_context_item` array containing the
-    representation of the input string.
-    Terminated with a type of `KM_CORE_CT_END`. Must be disposed of with
-    `km_core_context_items_dispose`.
-
-```c
-*/
-
-#ifdef _KM_CORE_ACCESS_PRIVATE_CONTEXT_API
-
-KMN_API
-km_core_status
-km_core_context_items_from_utf16(km_core_cp const *text,
-                                km_core_context_item **out_ptr);
-
-#endif
-
-/*
-```
-### `km_core_context_items_from_utf8`
-##### Description:
-Convert an UTF8 encoded Unicode string into an array of `km_core_context_item`
-structures. Allocates memory as needed.
-##### Status:
-- `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are null.
-- `KM_CORE_STATUS_NO_MEM`: In the event it cannot allocate enough memory for the
-  output buffer.
-- `KM_CORE_STATUS_INVALID_UTF`: In the event the UTF8 string cannot be
-decoded.
-##### Parameters:
-- __text__: a pointer to a null terminated array of utf8 encoded data.
-- __out_ptr__: a pointer to the result variable:
-    A pointer to the  start of the `km_core_context_item` array containing the
-    representation of the input string.
-    Terminated with a type of `KM_CORE_CT_END`.
-
-```c
-*/
-
-#ifdef _KM_CORE_ACCESS_PRIVATE_CONTEXT_API
-
-KMN_API
-km_core_status
-km_core_context_items_from_utf8(char const *text,
-                                km_core_context_item **out_ptr);
-
-#endif
-
-/*
-```
-### `km_core_context_items_to_utf16`
-##### Description:
-Convert a context item array into a UTF-16 encoded string placing it into
-the supplied buffer of specified size, and return the number of code units
-actually used in the conversion. If null is passed as the buffer the
-number of codeunits required is returned. Any markers in the context will
-not be included in the output buffer.
-##### Return status:
-- `KM_CORE_STATUS_OK`: On success.
-- `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are null.
-- `KM_CORE_STATUS_INSUFFICENT_BUFFER`: If the buffer is not large enough.
-  `buf_size` will contain the space required. The contents of the buffer are
-  undefined.
-##### Parameters:
-- __context_items__: A pointer to the start of an array `km_core_context_item`.
-    Must be terminated with a type of `KM_CORE_CT_END`.
-- __buf__: A pointer to the buffer to place the UTF-16 string into.
-    May be null to request size calculation.
-- __buf_size__: a pointer to the result variable:
-    The size of the supplied buffer in codeunits if `buf` is given.
-    On return will be the size required if `buf` is null.
-
-```c
-*/
-
-#ifdef _KM_CORE_ACCESS_PRIVATE_CONTEXT_API
-
-KMN_API
-km_core_status
-km_core_context_items_to_utf16(km_core_context_item const *item,
-                              km_core_cp *buf,
-                              size_t *buf_size);
-
-#endif
-
-/*
-```
-### `km_core_context_items_to_utf8`
-##### Description:
-Convert a context item array into a UTF-8 encoded string placing it into
-the supplied buffer of specified size, and return the number of code units
-actually used in the conversion. If null is passed as the buffer the
-number of codeunits required is returned. Any markers in the context will
-not be included in the output buffer.
-##### Return status:
-- `KM_CORE_STATUS_OK`: On success.
-- `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are null.
-- `KM_CORE_STATUS_INSUFFICENT_BUFFER`: If the buffer is not large enough.
-  `buf_size` will contain the space required. The contents of the buffer are
-  undefined.
-##### Parameters:
-- __context_items__: A pointer to the start of an array `km_core_context_item`.
-    Must be terminated with a type of `KM_CORE_CT_END`.
-- __buf__: A pointer to the buffer to place the UTF-8 string into.
-    May be null to request size calculation.
-- __buf_size__: a pointer to the result variable:
-    The size of the supplied buffer in codeunits if `buf` is given.
-    On return will be the size required if `buf` is null.
-
-```c
-*/
-
-#ifdef _KM_CORE_ACCESS_PRIVATE_CONTEXT_API
-
-KMN_API
-km_core_status
-km_core_context_items_to_utf8(km_core_context_item const *item,
-                              char *buf,
-                              size_t *buf_size);
-
-#endif
-
-/*
-```
-### `km_core_context_items_to_utf32`
-##### Description:
-Convert a context item array into a UTF-32 encoded string placing it into
-the supplied buffer of specified size, and return the number of codepoints
-actually used in the conversion. If null is passed as the buffer the
-number of codepoints required is returned. Any markers in the context will
-not be included in the output buffer.
-##### Return status:
-- `KM_CORE_STATUS_OK`: On success.
-- `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are null.
-- `KM_CORE_STATUS_INSUFFICENT_BUFFER`: If the buffer is not large enough.
-  `buf_size` will contain the space required. The contents of the buffer are
-  undefined.
-##### Parameters:
-- __context_items__: A pointer to the start of an array `km_core_context_item`.
-    Must be terminated with a type of `KM_CORE_CT_END`.
-- __buf__: A pointer to the buffer to place the UTF-32 string into.
-    May be null to request size calculation.
-- __buf_size__: a pointer to the result variable:
-    The size of the supplied buffer in codepoints if `buf` is given.
-    On return will be the size required if `buf` is null.
-
-```c
-*/
-
-#ifdef _KM_CORE_ACCESS_PRIVATE_CONTEXT_API
-
-KMN_API
-km_core_status
-km_core_context_items_to_utf32(km_core_context_item const *item,
-                              km_core_usv *buf,
-                              size_t *buf_size);
-
-#endif
-
-/*
-```
 ### `km_core_context_set`
 ##### Description:
 Replace the contents of the current context with a new sequence of
@@ -330,36 +142,6 @@ km_core_context_set(km_core_context *context,
 
 /*
 ```
-### `km_core_context_get`
-##### Description:
-Copies all items in the context into a new array and returns the new array.
-This must be disposed of by caller using `km_core_context_items_dispose`.
-##### Return status:
-- `KM_CORE_STATUS_OK`: On success.
-- `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are null.
-- `KM_CORE_STATUS_NO_MEM`: In the event not enough memory can be allocated for the
-  output buffer.
-##### Parameters:
-- __context_items__: A pointer to the start of an array `km_core_context_item`.
-- __out__: a pointer to the result variable:
-    A pointer to the start of the `km_core_context_item` array containing a
-    copy of the context. Terminated with a type of `KM_CORE_CT_END`. Must be
-    disposed of with `km_core_context_items_dispose`.
-
-```c
-*/
-
-#ifdef _KM_CORE_ACCESS_PRIVATE_CONTEXT_API
-
-KMN_API
-km_core_status
-km_core_context_get(km_core_context const *context_items,
-                   km_core_context_item **out);
-
-#endif
-
-/*
-```
 ### `km_core_context_clear`
 ##### Description:
 Removes all context_items from the internal array. If `context` is
@@ -372,88 +154,6 @@ null, has no effect.
 KMN_API
 void
 km_core_context_clear(km_core_context *);
-
-/*
-```
-### `km_core_context_length`
-##### Description:
-Return the number of items in the context.
-##### Return:
-The number of items in the context, and will return 0 if passed a null `context`
-pointer.
-##### Parameters:
-- __context__: A pointer to an opaque context object
-
-```c
-*/
-
-#ifdef _KM_CORE_ACCESS_PRIVATE_CONTEXT_API
-
-KMN_API
-size_t
-km_core_context_length(km_core_context *);
-
-#endif
-
-/*
-```
-### `km_core_context_append`
-##### Description:
-Add more items to the end (insertion point) of the context. If these exceed the
-maximum context length the same number of items will be dropped from the
-beginning of the context.
-##### Return status:
-- `KM_CORE_STATUS_OK`: On success.
-- `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are null.
-- `KM_CORE_STATUS_NO_MEM`: In the event not enough memory can be allocated to
-  grow the context buffer internally.
-##### Parameters:
-- __context__: A pointer to an opaque context object.
-- __context_items__: A pointer to the start of the `KM_CORE_CT_END` terminated
-    array of `km_core_context_item` to append.
-
-```c
-*/
-
-#ifdef _KM_CORE_ACCESS_PRIVATE_CONTEXT_API
-
-KMN_API
-km_core_status
-km_core_context_append(km_core_context *context,
-                      km_core_context_item const *context_items);
-
-#endif
-
-/*
-```
-### `km_core_context_shrink`
-##### Description:
-Remove a specified number of items from the end of the context, optionally
-add up to the same number of the supplied items to the front of the context.
-##### Return status:
-- `KM_CORE_STATUS_OK`: On success.
-- `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are null.
-- `KM_CORE_STATUS_NO_MEM`: in the event it cannot allocated enough memory to grow
-  the context internally.
-##### Parameters:
-- __context__: A pointer to an opaque context object.
-- __num__: The number of items to remove from the end of context.
-- __context_items__: Pointer to the start of the `KM_CORE_CT_END` terminated
-    array of `km_core_context_item` to add to the front. Up to `num` items will
-    be prepended. This may be null if not required.
-
-```c
-*/
-
-#ifdef _KM_CORE_ACCESS_PRIVATE_CONTEXT_API
-
-KMN_API
-km_core_status
-km_core_context_shrink(km_core_context *context,
-                      size_t num,
-                      km_core_context_item const *prefix);
-
-#endif
 
 /*
 ```

--- a/core/meson.build
+++ b/core/meson.build
@@ -29,9 +29,6 @@ python = py.find_installation()
 # For now, we use KM_CORE_LIBRARY to inject the km::core::kmx namespace
 defns += ['-DKM_CORE_LIBRARY']
 
-# See keyman_core_api_context.h
-defns += ['-D_KM_CORE_ACCESS_PRIVATE_CONTEXT_API']
-
 # #define DEBUG when we are on a debug build
 if get_option('buildtype') == 'debug'
   add_global_arguments('-DDEBUG', language : 'cpp')

--- a/core/src/action.cpp
+++ b/core/src/action.cpp
@@ -115,13 +115,13 @@ km_core_actions * km::core::action_item_list_to_actions_object(
 
   size_t buf_size;
 
-  if((status = km_core_context_items_to_utf32(output.data(), nullptr, &buf_size)) != KM_CORE_STATUS_OK) {
+  if((status = context_items_to_utf32(output.data(), nullptr, &buf_size)) != KM_CORE_STATUS_OK) {
     return nullptr;
   }
 
   std::unique_ptr<km_core_usv[]> output_usv(new km_core_usv[buf_size]);
 
-  if((status = km_core_context_items_to_utf32(output.data(), output_usv.get(), &buf_size)) != KM_CORE_STATUS_OK) {
+  if((status = context_items_to_utf32(output.data(), output_usv.get(), &buf_size)) != KM_CORE_STATUS_OK) {
     return nullptr;
   }
 

--- a/core/src/actions_normalize.cpp
+++ b/core/src/actions_normalize.cpp
@@ -203,8 +203,8 @@ bool km::core::actions_normalize(
   app_context_string.append(output_nfc);
   km_core_context_item *app_context_items = nullptr;
   km_core_status status = KM_CORE_STATUS_OK;
-  if((status = km_core_context_items_from_utf16(app_context_string.getTerminatedBuffer(), &app_context_items)) != KM_CORE_STATUS_OK) {
-    DebugLog("km_core_context_items_from_utf16 failed with %x", status);
+  if((status = context_items_from_utf16(app_context_string.getTerminatedBuffer(), &app_context_items)) != KM_CORE_STATUS_OK) {
+    DebugLog("context_items_from_utf16 failed with %x", status);
     delete [] new_output;
     return false;
   }
@@ -236,19 +236,19 @@ icu::UnicodeString context_items_to_unicode_string(km_core_context const *contex
 
   km_core_context_item *items = nullptr;
   km_core_status status;
-  if((status = km_core_context_get(context, &items)) != KM_CORE_STATUS_OK) {
+  if((status = context_get(context, &items)) != KM_CORE_STATUS_OK) {
     DebugLog("Failed to retrieve context with %s", status);
     return nullString;
   }
   size_t buf_size = 0;
-  if((status = km_core_context_items_to_utf32(items, nullptr, &buf_size)) != KM_CORE_STATUS_OK) {
+  if((status = context_items_to_utf32(items, nullptr, &buf_size)) != KM_CORE_STATUS_OK) {
     DebugLog("Failed to retrieve context size with %s", status);
     km_core_context_items_dispose(items);
     return nullString;
   }
 
   km_core_usv *buf = new km_core_usv[buf_size];
-  if((status = km_core_context_items_to_utf32(items, buf, &buf_size)) != KM_CORE_STATUS_OK) {
+  if((status = context_items_to_utf32(items, buf, &buf_size)) != KM_CORE_STATUS_OK) {
     DebugLog("Failed to retrieve context with %s", status);
     km_core_context_items_dispose(items);
     delete [] buf;
@@ -303,8 +303,8 @@ bool km::core::actions_update_app_context(
   km_core_status status = KM_CORE_STATUS_OK;
   km_core_context_item *items = nullptr;
 
-  if((status = km_core_context_get(cached_context, &items)) != KM_CORE_STATUS_OK) {
-    DebugLog("km_core_context_get failed with %d", status);
+  if((status = context_get(cached_context, &items)) != KM_CORE_STATUS_OK) {
+    DebugLog("context_get failed with %d", status);
     return false;
   }
 

--- a/core/src/context.hpp
+++ b/core/src/context.hpp
@@ -54,3 +54,196 @@ json & operator << (json &, km_core_context_item const &);
 struct km_core_context : public km::core::context
 {
 };
+
+// The following functions were public APIs in previous versions of Keyman Core.
+// However, with the move of context caching responsibility to Core with 17.0,
+// they have been moved to internal
+
+/**
+ * Convert a UTF16 encoded Unicode string into an array of `km_core_context_item`
+ * structures. Allocates memory as needed.
+ *
+ * @return km_core_status
+ *         * `KM_CORE_STATUS_OK`: On success.
+ *         * `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are
+ *           null.
+ *         * `KM_CORE_STATUS_NO_MEM`: In the event not enough memory can be
+ *           allocated for the output buffer.
+ *         * `KM_CORE_STATUS_INVALID_UTF`: In the event the UTF16 string cannot
+ *           be decoded because it contains unpaired surrogate codeunits.
+ *
+ * @param text    a pointer to a null terminated array of utf16 encoded data.
+ * @param out_ptr a pointer to the result variable: A pointer to the start of
+ *                the `km_core_context_item` array containing the representation
+ *                of the input string. Terminated with a type of
+ *                `KM_CORE_CT_END`. Must be disposed of with
+ *                `km_core_context_items_dispose`.
+ */
+km_core_status
+context_items_from_utf16(km_core_cp const *text,
+                                km_core_context_item **out_ptr);
+
+/**
+ * Convert a context item array into a UTF-16 encoded string placing it into the
+ * supplied buffer of specified size, and return the number of code units
+ * actually used in the conversion. If null is passed as the buffer the number
+ * of codeunits required is returned. Any markers in the context will not be
+ * included in the output buffer.
+ *
+ * @return km_core_status
+ *         * `KM_CORE_STATUS_OK`: On success.
+ *         * `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are
+ *           null.
+ *         * `KM_CORE_STATUS_INSUFFICENT_BUFFER`: If the buffer is not large
+ *           enough. `buf_size` will contain the space required. The contents
+ *           of the buffer are undefined.
+ *
+ * @param context_items A pointer to the start of an array
+ *                      `km_core_context_item`. Must be terminated with a type
+ *                      of `KM_CORE_CT_END`.
+ * @param buf           A pointer to the buffer to place the UTF-16 string into.
+ *                      May be null to request size calculation.
+ * @param buf_size      A pointer to the result variable: The size of the
+ *                      supplied buffer in codeunits if `buf` is given. On
+ *                      return will be the size required if `buf` is null.
+ */
+km_core_status
+context_items_to_utf16(km_core_context_item const *item,
+                              km_core_cp *buf,
+                              size_t *buf_size);
+
+/**
+ * Convert a context item array into a UTF-8 encoded string placing it into the
+ * supplied buffer of specified size, and return the number of code units
+ * actually used in the conversion. If null is passed as the buffer the number
+ * of codeunits required is returned. Any markers in the context will not be
+ * included in the output buffer.
+ *
+ * @return km_core_status
+ *         * `KM_CORE_STATUS_OK`: On success.
+ *         * `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are
+ *           null.
+ *         * `KM_CORE_STATUS_INSUFFICENT_BUFFER`: If the buffer is not large
+ *           enough. `buf_size` will contain the space required. The contents
+ *           of the buffer are undefined.
+ *
+ * @param context_items A pointer to the start of an array
+ *                      `km_core_context_item`. Must be terminated with a type
+ *                      of `KM_CORE_CT_END`.
+ * @param buf           A pointer to the buffer to place the UTF-8 string into.
+ *                      May be null to request size calculation.
+ * @param buf_size      A pointer to the result variable: The size of the
+ *                      supplied buffer in codeunits if `buf` is given. On
+ *                      return will be the size required if `buf` is null.
+ */
+km_core_status
+context_items_to_utf8(km_core_context_item const *item,
+                              char *buf,
+                              size_t *buf_size);
+
+/**
+ * Convert a context item array into a UTF-32 encoded string placing it into
+ * the supplied buffer of specified size, and return the number of codepoints
+ * actually used in the conversion. If null is passed as the buffer the
+ * number of codepoints required is returned. Any markers in the context will
+ * not be included in the output buffer.
+ *
+ * @return km_core_status
+ *         * `KM_CORE_STATUS_OK`: On success.
+ *         * `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are
+ *           null.
+ *         * `KM_CORE_STATUS_INSUFFICENT_BUFFER`: If the buffer is not large
+ *           enough. `buf_size` will contain the space required. The contents
+ *           of the buffer are undefined.
+ *
+ * @param context_items A pointer to the start of an array
+ *                      `km_core_context_item`. Must be terminated with a type
+ *                      of `KM_CORE_CT_END`.
+ * @param buf           A pointer to the buffer to place the UTF-32 string into.
+ *                      May be null to request size calculation.
+ * @param buf_size      A pointer to the result variable: The size of the
+ *                      supplied buffer in codepoints if `buf` is given. On
+ *                      return will be the size required if `buf` is null.
+ */
+km_core_status
+context_items_to_utf32(km_core_context_item const *item,
+                              km_core_usv *buf,
+                              size_t *buf_size);
+/**
+ *
+ * Copies all items in the context into a new array and returns the new array.
+ * This must be disposed of by caller using `km_core_context_items_dispose`.
+ *
+ * @return km_core_status
+ *         * `KM_CORE_STATUS_OK`: On success.
+ *         * `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are
+ *           null.
+ *         * `KM_CORE_STATUS_NO_MEM`: In the event not enough memory can be
+ *           allocated for the output buffer.
+ *
+ * @param context_items A pointer to the start of an array
+ *                      `km_core_context_item`.
+ *
+ * @param out           A pointer to the result variable: A pointer to the start
+ *                      of the `km_core_context_item` array containing a copy of
+ *                      the context. Terminated with a type of `KM_CORE_CT_END`.
+ *                      Must be disposed of with
+ *                      `km_core_context_items_dispose`.
+ */
+km_core_status
+context_get(km_core_context const *context_items,
+                   km_core_context_item **out);
+
+/**
+ * Return the number of items in the context.
+ *
+ * @return size_t The number of items in the context, and will return 0 if
+ *                passed a null `context` pointer.
+ * @param context A pointer to an opaque context object
+*/
+size_t
+context_length(km_core_context *);
+
+/**
+ * Add more items to the end (insertion point) of the context. If these exceed
+ * the maximum context length the same number of items will be dropped from the
+ * beginning of the context.
+ *
+ * @return km_core_status
+ *         * `KM_CORE_STATUS_OK`: On success.
+ *         * `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are
+ *           null.
+ *         * `KM_CORE_STATUS_NO_MEM`: In the event not enough memory can be
+ *           allocated to grow the context buffer internally.
+ *
+ * @param context       A pointer to an opaque context object.
+ * @param context_items A pointer to the start of the `KM_CORE_CT_END`
+ *                      terminated array of `km_core_context_item` to append.
+ */
+km_core_status
+context_append(km_core_context *context,
+                      km_core_context_item const *context_items);
+
+/**
+ * Remove a specified number of items from the end of the context, optionally
+ * add up to the same number of the supplied items to the front of the context.
+ *
+ * @return km_core_status
+ *         * `KM_CORE_STATUS_OK`: On success.
+ *         * `KM_CORE_STATUS_INVALID_ARGUMENT`: If non-optional parameters are
+ *           null.
+ *         * `KM_CORE_STATUS_NO_MEM`: in the event it cannot allocated enough
+ *           memory to grow the context internally.
+ *
+ * @param context       A pointer to an opaque context object.
+ * @param num           The number of items to remove from the end of context.
+ * @param context_items Pointer to the start of the `KM_CORE_CT_END` terminated
+ *                      array of `km_core_context_item` to add to the front. Up
+ *                      to `num` items will be prepended. This may be null if
+ *                      not required.
+ */
+KMN_API
+km_core_status
+context_shrink(km_core_context *context,
+                      size_t num,
+                      km_core_context_item const *prefix);

--- a/core/src/context_helpers.cpp
+++ b/core/src/context_helpers.cpp
@@ -24,18 +24,18 @@ km_core_cp* km::core::get_context_as_string(km_core_context *context) {
   size_t buf_size = 0;
   km_core_context_item* context_items = nullptr;
 
-  if(km_core_context_get(context, &context_items) != KM_CORE_STATUS_OK) {
+  if(context_get(context, &context_items) != KM_CORE_STATUS_OK) {
     return nullptr;
   }
 
-  if(km_core_context_items_to_utf16(context_items, nullptr, &buf_size) != KM_CORE_STATUS_OK) {
+  if(context_items_to_utf16(context_items, nullptr, &buf_size) != KM_CORE_STATUS_OK) {
     km_core_context_items_dispose(context_items);
     return nullptr;
   }
 
   km_core_cp *app_context_string = new km_core_cp[buf_size];
 
-  km_core_status status = km_core_context_items_to_utf16(context_items, app_context_string, &buf_size);
+  km_core_status status = context_items_to_utf16(context_items, app_context_string, &buf_size);
   km_core_context_items_dispose(context_items);
 
   if(status != KM_CORE_STATUS_OK) {
@@ -57,7 +57,7 @@ km_core_status km::core::set_context_from_string(km_core_context *context, km_co
 
   km_core_context_item* new_context_items = nullptr;
 
-  km_core_status status = km_core_context_items_from_utf16(new_context, &new_context_items);
+  km_core_status status = context_items_from_utf16(new_context, &new_context_items);
   if (status != KM_CORE_STATUS_OK) {
     return status;
   }

--- a/core/src/km_core_context_api.cpp
+++ b/core/src/km_core_context_api.cpp
@@ -108,22 +108,14 @@ namespace {
 }
 
 km_core_status
-km_core_context_items_from_utf16(km_core_cp const *text,
+context_items_from_utf16(km_core_cp const *text,
                                 km_core_context_item **out_ptr)
 {
   return _context_items_from<utf16>(reinterpret_cast<utf16::codeunit_t const *>(text), out_ptr);
 }
 
 
-km_core_status
-km_core_context_items_from_utf8(char const *text,
-                                km_core_context_item **out_ptr)
-{
-  return _context_items_from<utf8>(reinterpret_cast<utf8::codeunit_t const *>(text), out_ptr);
-}
-
-
-km_core_status km_core_context_items_to_utf8(km_core_context_item const *ci,
+km_core_status context_items_to_utf8(km_core_context_item const *ci,
                                             char *buf, size_t * sz_ptr)
 {
   return _context_items_to<utf8>(ci,
@@ -132,7 +124,7 @@ km_core_status km_core_context_items_to_utf8(km_core_context_item const *ci,
 }
 
 
-km_core_status km_core_context_items_to_utf16(km_core_context_item const *ci,
+km_core_status context_items_to_utf16(km_core_context_item const *ci,
                                             km_core_cp *buf, size_t * sz_ptr)
 {
   return _context_items_to<utf16>(ci,
@@ -140,7 +132,7 @@ km_core_status km_core_context_items_to_utf16(km_core_context_item const *ci,
             sz_ptr);
 }
 
-km_core_status km_core_context_items_to_utf32(km_core_context_item const *ci,
+km_core_status context_items_to_utf32(km_core_context_item const *ci,
                                             km_core_usv *buf, size_t * sz_ptr)
 {
   return _context_items_to<utf32>(ci,
@@ -157,11 +149,11 @@ void km_core_context_items_dispose(km_core_context_item *ci)
 km_core_status km_core_context_set(km_core_context *ctxt, km_core_context_item const *ci)
 {
     km_core_context_clear(ctxt);
-    return km_core_context_append(ctxt, ci);
+    return context_append(ctxt, ci);
 }
 
 
-km_core_status km_core_context_get(km_core_context const *ctxt,
+km_core_status context_get(km_core_context const *ctxt,
                                  km_core_context_item **out_ptr)
 {
   assert(ctxt); assert(out_ptr);
@@ -192,14 +184,14 @@ void km_core_context_clear(km_core_context *ctxt)
 }
 
 
-size_t km_core_context_length(km_core_context *ctxt)
+size_t context_length(km_core_context *ctxt)
 {
   assert(ctxt);
   return ctxt ? ctxt->size() : 0;
 }
 
 
-km_core_status km_core_context_append(km_core_context *ctxt,
+km_core_status context_append(km_core_context *ctxt,
                                     km_core_context_item const *ci)
 {
   assert(ctxt); assert(ci);
@@ -219,7 +211,7 @@ km_core_status km_core_context_append(km_core_context *ctxt,
 }
 
 
-km_core_status km_core_context_shrink(km_core_context *ctxt, size_t num,
+km_core_status context_shrink(km_core_context *ctxt, size_t num,
                            km_core_context_item const * ci)
 {
   assert(ctxt);

--- a/core/src/km_core_state_api.cpp
+++ b/core/src/km_core_state_api.cpp
@@ -310,11 +310,11 @@ km_core_cp * km_core_state_context_debug(
       return _new_error_string(u"<error retrieving intermediate context>");
     }
   } else if(context_type == KM_CORE_DEBUG_CONTEXT_CACHED) {
-    if(km_core_context_get(km_core_state_context(state), &context_items) != KM_CORE_STATUS_OK) {
+    if(context_get(km_core_state_context(state), &context_items) != KM_CORE_STATUS_OK) {
       return _new_error_string(u"<error retrieving cached context>");
     }
   } else if(context_type == KM_CORE_DEBUG_CONTEXT_APP) {
-    if(km_core_context_get(km_core_state_app_context(state), &context_items) != KM_CORE_STATUS_OK) {
+    if(context_get(km_core_state_app_context(state), &context_items) != KM_CORE_STATUS_OK) {
       return _new_error_string(u"<error retrieving app context>");
     }
   } else {
@@ -322,13 +322,13 @@ km_core_cp * km_core_state_context_debug(
   }
 
   size_t buf_size;
-  if(km_core_context_items_to_utf8(context_items, nullptr, &buf_size) != KM_CORE_STATUS_OK) {
+  if(context_items_to_utf8(context_items, nullptr, &buf_size) != KM_CORE_STATUS_OK) {
     km_core_context_items_dispose(context_items);
     return _new_error_string(u"<could not retrieve context buffer size>");
   }
 
   std::vector<char> context_buffer(buf_size);
-  if(km_core_context_items_to_utf8(context_items, &context_buffer[0], &buf_size) != KM_CORE_STATUS_OK) {
+  if(context_items_to_utf8(context_items, &context_buffer[0], &buf_size) != KM_CORE_STATUS_OK) {
     km_core_context_items_dispose(context_items);
     return _new_error_string(u"<could not retrieve context buffer>");
   }

--- a/core/tests/unit/kmnkbd/action_set_api.cpp
+++ b/core/tests/unit/kmnkbd/action_set_api.cpp
@@ -59,7 +59,7 @@ void setup(const char *keyboard, const km_core_cp* context) {
   km::core::path path = km::core::path::join(arg_path, keyboard);
   try_status(km_core_keyboard_load(path.native().c_str(), &test_kb));
   try_status(km_core_state_create(test_kb, test_env_opts, &test_state));
-  try_status(km_core_context_items_from_utf16(context, &citems));
+  try_status(context_items_from_utf16(context, &citems));
   try_status(km_core_context_set(km_core_state_context(test_state), citems));
   try_status(km_core_context_set(km_core_state_app_context(test_state), citems));
 }

--- a/core/tests/unit/kmnkbd/context_api.cpp
+++ b/core/tests/unit/kmnkbd/context_api.cpp
@@ -44,42 +44,29 @@ namespace
 
 int main(int, char * [])
 {
-  km_core_context_item *ctxt1, *ctxt2, *ctxt3, *ctxt4;
+  km_core_context_item *ctxt1, *ctxt2;
   // Test UTF16 to context_item conversion.
-  try_status(km_core_context_items_from_utf16(initial_bmp_context.data(), &ctxt1));
-  try_status(km_core_context_items_from_utf16(initial_smp_context.data(), &ctxt2));
-  try_status(km_core_context_items_from_utf8(initial_u8_bmp_context.data(), &ctxt3));
-  try_status(km_core_context_items_from_utf8(initial_u8_smp_context.data(), &ctxt4));
+  try_status(context_items_from_utf16(initial_bmp_context.data(), &ctxt1));
+  try_status(context_items_from_utf16(initial_smp_context.data(), &ctxt2));
 
   // Check context_item to UTF16 conversion, roundtrip test.
   char16_t ctxt_buffer[512] ={0,};
-  char     ctxt_u8_buffer[512] ={0,};
   // First call measure space 2nd call do conversion.
   size_t ctxt_size = sizeof ctxt_buffer/sizeof(km_core_cp);
-  try_status(km_core_context_items_to_utf16(ctxt1, nullptr, &ctxt_size));
+  try_status(context_items_to_utf16(ctxt1, nullptr, &ctxt_size));
   if (ctxt_size > sizeof ctxt_buffer/sizeof(km_core_cp))  return __LINE__;
-  try_status(km_core_context_items_to_utf16(ctxt1, ctxt_buffer, &ctxt_size));
+  try_status(context_items_to_utf16(ctxt1, ctxt_buffer, &ctxt_size));
   if (initial_bmp_context != ctxt_buffer) return __LINE__;
-  // repeat for utf-8 versions.
-  try_status(km_core_context_items_to_utf8(ctxt3, nullptr, &ctxt_size));
-  if (ctxt_size > sizeof ctxt_u8_buffer/sizeof(char))  return __LINE__;
-  try_status(km_core_context_items_to_utf8(ctxt3, ctxt_u8_buffer, &ctxt_size));
-  if (initial_u8_bmp_context != ctxt_u8_buffer) return __LINE__;
 
   // Test roundtripping SMP characters in surrogate pairs.
   ctxt_size=sizeof ctxt_buffer/sizeof(km_core_cp);
-  try_status(km_core_context_items_to_utf16(ctxt2, ctxt_buffer, &ctxt_size));
+  try_status(context_items_to_utf16(ctxt2, ctxt_buffer, &ctxt_size));
   if (initial_smp_context != ctxt_buffer) return __LINE__;
   // Test buffer overrun protection.
   ctxt_size=4; // This includes space for the null terminator
-  if (km_core_context_items_to_utf16(ctxt2, ctxt_buffer, &ctxt_size)
+  if (context_items_to_utf16(ctxt2, ctxt_buffer, &ctxt_size)
         != KM_CORE_STATUS_INSUFFICENT_BUFFER
       || ctxt_size != 4)
-    return __LINE__;
-  ctxt_size=8; // This includes space for the null terminator
-  if (km_core_context_items_to_utf8(ctxt4, ctxt_u8_buffer, &ctxt_size)
-        != KM_CORE_STATUS_INSUFFICENT_BUFFER
-      || ctxt_size != 6)
     return __LINE__;
 
   // Create a mock context object and set the items
@@ -92,37 +79,37 @@ int main(int, char * [])
   km_core_context_items_dispose(ctxt2);
 
   // Test lengths, these are Unicode Scalar Values, not utf16 codeunits.
-  if(km_core_context_length(&mock_ctxt1) != bmp_ctxt_size) return __LINE__;
-  if(km_core_context_length(&mock_ctxt2) != smp_ctxt_size) return __LINE__;
+  if(context_length(&mock_ctxt1) != bmp_ctxt_size) return __LINE__;
+  if(context_length(&mock_ctxt2) != smp_ctxt_size) return __LINE__;
 
   // retrieve bmp context and check it's okay.
   km_core_context_item *tmp_ctxt;
-  try_status(km_core_context_get(&mock_ctxt1, &tmp_ctxt));
+  try_status(context_get(&mock_ctxt1, &tmp_ctxt));
   ctxt_size=sizeof ctxt_buffer/sizeof(km_core_cp);
-  try_status(km_core_context_items_to_utf16(tmp_ctxt, ctxt_buffer, &ctxt_size));
+  try_status(context_items_to_utf16(tmp_ctxt, ctxt_buffer, &ctxt_size));
   km_core_context_items_dispose(tmp_ctxt);
   if (initial_bmp_context != ctxt_buffer) return __LINE__;
 
   // retrieve smp context and check it's okay.
-  try_status(km_core_context_get(&mock_ctxt2, &tmp_ctxt));
+  try_status(context_get(&mock_ctxt2, &tmp_ctxt));
   ctxt_size=sizeof ctxt_buffer/sizeof(km_core_cp);
-  try_status(km_core_context_items_to_utf16(tmp_ctxt, ctxt_buffer, &ctxt_size));
+  try_status(context_items_to_utf16(tmp_ctxt, ctxt_buffer, &ctxt_size));
   km_core_context_items_dispose(tmp_ctxt);
   if (initial_smp_context != ctxt_buffer) return __LINE__;
 
   // Call km_core_context_clear
   km_core_context_clear(&mock_ctxt2);
-  if(km_core_context_length(&mock_ctxt2) != 0) return __LINE__;
+  if(context_length(&mock_ctxt2) != 0) return __LINE__;
 
   // Mutation tests
-  try_status(km_core_context_shrink(&mock_ctxt1, 42, nullptr));
+  try_status(context_shrink(&mock_ctxt1, 42, nullptr));
 
   // Append a character, a marker and & a string.
-  try_status(km_core_context_items_from_utf16(u" ", &ctxt1));
-  try_status(km_core_context_items_from_utf16(u"World!", &ctxt2));
-  try_status(km_core_context_append(&mock_ctxt1, ctxt1));
-  try_status(km_core_context_append(&mock_ctxt1, test_marker_ctxt));
-  try_status(km_core_context_append(&mock_ctxt1, ctxt2));
+  try_status(context_items_from_utf16(u" ", &ctxt1));
+  try_status(context_items_from_utf16(u"World!", &ctxt2));
+  try_status(context_append(&mock_ctxt1, ctxt1));
+  try_status(context_append(&mock_ctxt1, test_marker_ctxt));
+  try_status(context_append(&mock_ctxt1, ctxt2));
 
   // Delete the items lists
   km_core_context_items_dispose(ctxt1);
@@ -130,19 +117,19 @@ int main(int, char * [])
 
   // Check it matches. The marker will be elided during the conversion.
   ctxt_size=sizeof ctxt_buffer/sizeof(km_core_cp);
-  try_status(km_core_context_get(&mock_ctxt1, &tmp_ctxt));
-  try_status(km_core_context_items_to_utf16(tmp_ctxt, ctxt_buffer, &ctxt_size));
+  try_status(context_get(&mock_ctxt1, &tmp_ctxt));
+  try_status(context_items_to_utf16(tmp_ctxt, ctxt_buffer, &ctxt_size));
   if (std::u16string(u"Hello World!") != ctxt_buffer) return __LINE__;
   km_core_context_items_dispose(tmp_ctxt);
 
   // Test shrink and prepend, delete more than we provide to prepend.
-  try_status(km_core_context_items_from_utf16(u"Bye, ", &ctxt1));
+  try_status(context_items_from_utf16(u"Bye, ", &ctxt1));
   // We delete 7 characters plus 1 marker hence 8 and not 7 as expected if you
   //  go by the test string above.
-  try_status(km_core_context_shrink(&mock_ctxt1, 8, ctxt1));
+  try_status(context_shrink(&mock_ctxt1, 8, ctxt1));
   ctxt_size=sizeof ctxt_buffer/sizeof(km_core_cp);
-  try_status(km_core_context_get(&mock_ctxt1, &tmp_ctxt));
-  try_status(km_core_context_items_to_utf16(tmp_ctxt, ctxt_buffer, &ctxt_size));
+  try_status(context_get(&mock_ctxt1, &tmp_ctxt));
+  try_status(context_items_to_utf16(tmp_ctxt, ctxt_buffer, &ctxt_size));
   if (std::u16string(u"Bye, Hello") != ctxt_buffer) return __LINE__;
 
   // dispose the items lists

--- a/core/tests/unit/kmnkbd/debug_api.cpp
+++ b/core/tests/unit/kmnkbd/debug_api.cpp
@@ -57,7 +57,7 @@ void setup(const char *keyboard) {
 
   try_status(km_core_keyboard_load(path.native().c_str(), &test_kb));
   try_status(km_core_state_create(test_kb, test_env_opts, &test_state));
-  try_status(km_core_context_items_from_utf16(u"Hello 😁", &citems));
+  try_status(context_items_from_utf16(u"Hello 😁", &citems));
 
   // Pre-test sanity: ensure debugging is disabled
   assert(km_core_state_debug_get(test_state) == 0);

--- a/core/tests/unit/kmnkbd/state_api.cpp
+++ b/core/tests/unit/kmnkbd/state_api.cpp
@@ -130,12 +130,12 @@ int main(int argc, char * argv[])
 
   // Lets add data and do some basic checks of options and km_core_context
   km_core_context_item *citems = nullptr;
-  try_status(km_core_context_items_from_utf16(u"Hello 😁", &citems));
+  try_status(context_items_from_utf16(u"Hello 😁", &citems));
   try_status(km_core_context_set(km_core_state_context(test_state), citems));
   km_core_context_items_dispose(citems);
-  if(km_core_context_length(km_core_state_context(test_state)) != 7)
+  if(context_length(km_core_state_context(test_state)) != 7)
     return __LINE__;
-  if(km_core_context_length(km_core_state_context(test_clone)) != 0)
+  if(context_length(km_core_state_context(test_clone)) != 0)
     return __LINE__;
 
   // Overwrite some data.

--- a/core/tests/unit/kmnkbd/state_context_api.cpp
+++ b/core/tests/unit/kmnkbd/state_context_api.cpp
@@ -1,8 +1,9 @@
 // Tests for the state_context_* API methods
 
-#include <keyman/keyman_core_api.h>
+#include "keyman_core.h"
 #include <string>
 
+#include "context.hpp"
 #include "path.hpp"
 
 #include "../emscripten_filesystem.h"
@@ -42,7 +43,7 @@ setup(const char *keyboard, const km_core_cp *context) {
   km::core::path path = km::core::path::join(arg_path, keyboard);
   try_status(km_core_keyboard_load(path.native().c_str(), &test_kb));
   try_status(km_core_state_create(test_kb, test_env_opts, &test_state));
-  try_status(km_core_context_items_from_utf16(context, &citems));
+  try_status(context_items_from_utf16(context, &citems));
   try_status(km_core_context_set(km_core_state_context(test_state), citems));
   try_status(km_core_context_set(km_core_state_app_context(test_state), citems));
 }
@@ -50,10 +51,10 @@ setup(const char *keyboard, const km_core_cp *context) {
 bool
 is_identical_context(km_core_cp const *cached_context) {
   size_t buf_size;
-  try_status(km_core_context_get(km_core_state_context(test_state), &citems));
-  try_status(km_core_context_items_to_utf16(citems, nullptr, &buf_size));
+  try_status(context_get(km_core_state_context(test_state), &citems));
+  try_status(context_items_to_utf16(citems, nullptr, &buf_size));
   km_core_cp *new_cached_context = new km_core_cp[buf_size];
-  try_status(km_core_context_items_to_utf16(citems, new_cached_context, &buf_size));
+  try_status(context_items_to_utf16(citems, new_cached_context, &buf_size));
   bool result = std::u16string(cached_context) == new_cached_context;
   delete[] new_cached_context;
   return result;
@@ -144,7 +145,7 @@ test_context_set_if_needed_cached_context_has_markers() {
 
   km_core_context_item *citems_new;
 
-  try_status(km_core_context_get(km_core_state_context(test_state), &citems_new));
+  try_status(context_get(km_core_state_context(test_state), &citems_new));
 
   for (int i = 0; citems[i].type || citems_new[i].type; i++) {
     assert(citems_new[i].type == citems[i].type);

--- a/core/tests/unit/kmx/kmx.cpp
+++ b/core/tests/unit/kmx/kmx.cpp
@@ -207,7 +207,7 @@ run_test(const km::core::path &source, const km::core::path &compiled) {
 
   // Setup context
   km_core_context_item *citems = nullptr;
-  try_status(km_core_context_items_from_utf16(context.c_str(), &citems));
+  try_status(context_items_from_utf16(context.c_str(), &citems));
   try_status(km_core_context_set(km_core_state_context(test_state), citems));
 
   // Make a copy of the setup context for the test
@@ -244,10 +244,10 @@ run_test(const km::core::path &source, const km::core::path &compiled) {
     // Compare context and text store at each step
     // should be identical unless an action has caused the context to be invalidated
     size_t n = 0;
-    try_status(km_core_context_get(km_core_state_context(test_state), &citems));
-    try_status(km_core_context_items_to_utf16(citems, nullptr, &n));
+    try_status(context_get(km_core_state_context(test_state), &citems));
+    try_status(context_items_to_utf16(citems, nullptr, &n));
     km_core_cp *core_context_str = new km_core_cp[n];
-    try_status(km_core_context_items_to_utf16(citems, core_context_str, &n));
+    try_status(context_items_to_utf16(citems, core_context_str, &n));
 
     // Verify that both our local test_context and the core's test_state.context have
     // not diverged
@@ -271,10 +271,10 @@ run_test(const km::core::path &source, const km::core::path &compiled) {
 
   // Compare final output - retrieve internal context
   size_t n = 0;
-  try_status(km_core_context_get(km_core_state_context(test_state), &citems));
-  try_status(km_core_context_items_to_utf16(citems, nullptr, &n));
+  try_status(context_get(km_core_state_context(test_state), &citems));
+  try_status(context_items_to_utf16(citems, nullptr, &n));
   km_core_cp *core_context_str = new km_core_cp[n];
-  try_status(km_core_context_items_to_utf16(citems, core_context_str, &n));
+  try_status(context_items_to_utf16(citems, core_context_str, &n));
 
   // Verify that both our local test_context and the core's test_state.context have
   // not diverged

--- a/core/tests/unit/kmx/kmx_imx.cpp
+++ b/core/tests/unit/kmx/kmx_imx.cpp
@@ -77,9 +77,9 @@ uint8_t test_imx_callback(km_core_state *state, uint32_t imx_id, void *callback_
   km_core_state_get_intermediate_context(state, &entry_context);
 
   size_t n = 0;
-  try_status(km_core_context_items_to_utf16(entry_context, nullptr, &n))
+  try_status(context_items_to_utf16(entry_context, nullptr, &n))
   km_core_cp *buf = new km_core_cp[n];
-  try_status(km_core_context_items_to_utf16(entry_context, buf, &n));
+  try_status(context_items_to_utf16(entry_context, buf, &n));
 
   std::cout << "imx entry context   : "  << " [" << buf << "]" << std::endl;
   km_core_context_items_dispose(entry_context);
@@ -145,9 +145,9 @@ uint8_t test_imx_callback(km_core_state *state, uint32_t imx_id, void *callback_
   km_core_state_get_intermediate_context(state, &exit_context);
 
   n = 0;
-  try_status(km_core_context_items_to_utf16(exit_context, nullptr, &n))
+  try_status(context_items_to_utf16(exit_context, nullptr, &n))
   km_core_cp *tmp_buf = new km_core_cp[n];
-  try_status(km_core_context_items_to_utf16(exit_context, tmp_buf, &n));
+  try_status(context_items_to_utf16(exit_context, tmp_buf, &n));
 
   std::cout << "imx exit context   : "  << " [" << tmp_buf << "]" << std::endl;
   km_core_context_items_dispose(exit_context);

--- a/core/tests/unit/ldml/ldml.cpp
+++ b/core/tests/unit/ldml/ldml.cpp
@@ -156,7 +156,7 @@ apply_action(
       // the context from the context string.
       km_core_context_item* new_context_items = nullptr;
       // We replace the cached context with the current application context
-      km_core_status status = km_core_context_items_from_utf16(text_store.c_str(), &new_context_items);
+      km_core_status status = context_items_from_utf16(text_store.c_str(), &new_context_items);
       assert(status == KM_CORE_STATUS_OK);
       copy_context_items_to_vector(new_context_items, context);
       // also update the test context
@@ -188,10 +188,10 @@ verify_context(std::u16string& text_store, km_core_state* &test_state, std::vect
       // Compare context and text store at each step - should be identical
     size_t n = 0;
     km_core_context_item* citems = nullptr;
-    try_status(km_core_context_get(km_core_state_context(test_state), &citems));
-    try_status(km_core_context_items_to_utf16(citems, nullptr, &n));
+    try_status(context_get(km_core_state_context(test_state), &citems));
+    try_status(context_items_to_utf16(citems, nullptr, &n));
     km_core_cp *buf = new km_core_cp[n];
-    try_status(km_core_context_items_to_utf16(citems, buf, &n));
+    try_status(context_items_to_utf16(citems, buf, &n));
     std::cout << "context   : " << string_to_hex(buf) << " [" << buf << "]" << std::endl;
     std::cout << "testcontext ";
     std::cout.fill('0');
@@ -247,7 +247,7 @@ run_test(const km::core::path &source, const km::core::path &compiled, km::tests
 
   km_core_context_item *citems = nullptr;
   // setup test_context
-  try_status(km_core_context_items_from_utf16(test_source.get_context().c_str(), &citems));
+  try_status(context_items_from_utf16(test_source.get_context().c_str(), &citems));
   try_status(km_core_context_set(km_core_state_context(test_state), citems));
 
   // Make a copy of the setup context for the test
@@ -301,8 +301,8 @@ run_test(const km::core::path &source, const km::core::path &compiled, km::tests
       text_store.append(action.string);  // TODO-LDML: not going through keyboard
       // Now, update context?
       km_core_context_item *nitems = nullptr;
-      try_status(km_core_context_items_from_utf16(action.string.c_str(), &nitems));
-      try_status(km_core_context_append(km_core_state_context(test_state), nitems));
+      try_status(context_items_from_utf16(action.string.c_str(), &nitems));
+      try_status(context_append(km_core_state_context(test_state), nitems));
       // update the test_context also.
       for (km_core_context_item *ci = nitems; ci->type != KM_CORE_CT_END; ci++) {
         test_context.emplace_back(*ci);

--- a/core/tests/unit/ldml/test_context_normalization.cpp
+++ b/core/tests/unit/ldml/test_context_normalization.cpp
@@ -63,13 +63,13 @@ bool is_identical_context(km_core_cp const *cached_context, km_core_debug_contex
   debug_context(context_type);
 
   if(context_type == KM_CORE_DEBUG_CONTEXT_APP) {
-    try_status(km_core_context_get(km_core_state_app_context(test_state), &citems));
+    try_status(context_get(km_core_state_app_context(test_state), &citems));
   } else {
-    try_status(km_core_context_get(km_core_state_context(test_state), &citems));
+    try_status(context_get(km_core_state_context(test_state), &citems));
   }
-  try_status(km_core_context_items_to_utf16(citems, nullptr, &buf_size));
+  try_status(context_items_to_utf16(citems, nullptr, &buf_size));
   km_core_cp* new_cached_context = new km_core_cp[buf_size];
-  try_status(km_core_context_items_to_utf16(citems, new_cached_context, &buf_size));
+  try_status(context_items_to_utf16(citems, new_cached_context, &buf_size));
 
   km_core_context_items_dispose(citems);
 

--- a/developer/src/tike/main/Keyman.System.KeymanCore.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCore.pas
@@ -81,28 +81,6 @@ const
 const
   keymancore = 'keymancore-1.dll';
 
-function km_core_context_items_from_utf16(
-  const text: pkm_core_cp;
-  var out_ptr: pkm_core_context_item
-): km_core_status; cdecl; external keymancore delayed;
-
-function km_core_context_items_from_utf8(
-  const text: PAnsiChar;
-  var out_ptr: pkm_core_context_item
-): km_core_status; cdecl; external keymancore delayed;
-
-function km_core_context_items_to_utf16(
-  const item: pkm_core_context_item;
-  buf: pkm_core_cp;
-  var buf_size: integer
-): km_core_status; cdecl; external keymancore delayed;
-
-function km_core_context_items_to_utf8(
-  const item: pkm_core_context_item;
-  buf: pansichar;
-  var buf_size: integer
-): km_core_status; cdecl; external keymancore delayed;
-
 procedure km_core_context_items_dispose(
   const context_items: km_core_context_item
 ); cdecl; external keymancore delayed;
@@ -112,26 +90,9 @@ function km_core_context_set(
   context_items: pkm_core_context_item
 ): km_core_status; cdecl; external keymancore delayed;
 
-function km_core_context_get(
-  context: pkm_core_context;
-  var context_items: pkm_core_context_item
-): km_core_status; cdecl; external keymancore delayed;
-
 procedure km_core_context_clear(
   context: pkm_core_context
 ); cdecl; external keymancore delayed;
-
-function km_core_context_append(
-  context: pkm_core_context;
-  context_items: pkm_core_context_item
-): km_core_status; cdecl; external keymancore delayed;
-
-function km_core_context_shrink(
-  context: pkm_core_context;
-  num: Integer;
-  prefix: pkm_core_context_item
-): km_core_status; cdecl; external keymancore delayed;
-
 
 
 type


### PR DESCRIPTION
Fixes #10431.

The `km_core_` prefix has been removed from internal-only functions, and these function declarations moved to context.hpp.

The functions have not been moved from km_core_context_api.cpp at this stage.

Rewrote the function documentation in Javadoc style comments for the internal use functions.

@keymanapp-test-bot skip