### PR TITLE
fix(web): U_ key id -> text for all subkeys; is now preprocessed

### DIFF
--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -331,6 +331,10 @@ export class ActiveKeyBase {
       }
     }
 
+    if(!key.text && typeof key.id == 'string') {
+      key.text = ActiveKey.unicodeIDToText(key.id);
+    }
+
     // Ensure subkeys are also properly extended.
     if(key.sk) {
       analysisFlagObj.hasLongpresses = true;

--- a/web/src/engine/osk/src/keyboard-layout/oskKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskKey.ts
@@ -300,12 +300,8 @@ export default abstract class OSKKey {
     // Add OSK key labels
     let keyText = null;
     if(spec['text'] == null || spec['text'] == '') {
-      if(typeof spec['id'] == 'string') {
-        // If the ID's Unicode-based, just use that code.
-        keyText = ActiveKey.unicodeIDToText(spec['id']);
-      }
-
-      keyText = keyText || DEFAULT_BLANK;
+      // U_ codes are handled during keyboard pre-processing.
+      keyText = DEFAULT_BLANK;
     } else {
       keyText=spec['text'];
 


### PR DESCRIPTION
During the addition of gesture features, I failed to handle `U_` key ID processing for key text associated with previews of the new gesture types.  This change will address that.

Relates to #10383 - and is likely a reasonable resolution to that issue, given that the behavior already existed in Web for longpress subkeys.  (See sil_euro_latin numeric layer `%` subkeys - those have no defined key-cap text.)

It also handles this in the keyboard-layout preprocessing stage, ensuring that it's universally applied for all OSK keys and subkeys before touch-keyboard construction even begins.  (This helps ensure DRY-ness.)

@keymanapp-test-bot skip