### PR TITLE
fix(android/engine): Fix OSK widths

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     android:hardwareAccelerated="true"
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"
+    android:resizeableActivity="false"
     android:usesCleartextTraffic="true"
     android:theme="@style/AppTheme"
     android:supportsRtl="true">
@@ -71,7 +72,6 @@
       android:exported="true"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
       android:label="@string/app_name"
-      android:resizeableActivity="false"
       android:launchMode="singleTask">
 
       <!-- See http://stackoverflow.com/questions/1733195/android-intent-filter-for-a-particular-file-extension/2062112#2062112 -->

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -60,6 +60,7 @@
       android:name=".SplashScreenActivity"
       android:exported="true"
       android:label="@string/app_name"
+      android:resizeableActivity="false"
       android:theme="@style/AppTheme.BrandedLaunch">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
@@ -72,6 +73,7 @@
       android:exported="true"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
       android:label="@string/app_name"
+      android:resizeableActivity="false"
       android:launchMode="singleTask">
 
       <!-- See http://stackoverflow.com/questions/1733195/android-intent-filter-for-a-particular-file-extension/2062112#2062112 -->

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
@@ -107,7 +107,7 @@ public class AdjustKeyboardHeightActivity extends BaseActivity {
             break;
           case MotionEvent.ACTION_UP:
             // Save the currentHeight when the user releases
-            int orientation = KMManager.getOrientation(context);;
+            int orientation = KMManager.getOrientation(context);
             String keyboardHeightKey = (orientation == Configuration.ORIENTATION_LANDSCAPE) ?
               KMManager.KMKey_KeyboardHeightLandscape : KMManager.KMKey_KeyboardHeightPortrait;
             editor.putInt(keyboardHeightKey, currentHeight);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
@@ -8,12 +8,9 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
-import android.view.Display;
 import android.view.MotionEvent;
-import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -110,9 +107,8 @@ public class AdjustKeyboardHeightActivity extends BaseActivity {
             break;
           case MotionEvent.ACTION_UP:
             // Save the currentHeight when the user releases
-            Display display = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
-            int rotation = display.getRotation();
-            String keyboardHeightKey = (rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270) ?
+            int orientation = KMManager.getOrientation(context);;
+            String keyboardHeightKey = (orientation == Configuration.ORIENTATION_LANDSCAPE) ?
               KMManager.KMKey_KeyboardHeightLandscape : KMManager.KMKey_KeyboardHeightPortrait;
             editor.putInt(keyboardHeightKey, currentHeight);
             editor.commit();

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -267,9 +267,11 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
 
     // onConfigurationChanged() only triggers when device is rotated while app is in foreground
     // This handles when device is rotated while app is in background
+    // using KMManager.getOrientation() since getConfiguration().orientation is unreliable #10241
     Configuration newConfig = this.getResources().getConfiguration();
-    if (newConfig != null && newConfig.orientation != lastOrientation) {
-      lastOrientation = newConfig.orientation;
+    int newOrientation = KMManager.getOrientation(context);
+    if (newOrientation != lastOrientation) {
+      lastOrientation = newOrientation;
       KMManager.onConfigurationChanged(newConfig);
     }
     resizeTextView(textView.isKeyboardVisible());

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -268,10 +268,10 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     // onConfigurationChanged() only triggers when device is rotated while app is in foreground
     // This handles when device is rotated while app is in background
     // using KMManager.getOrientation() since getConfiguration().orientation is unreliable #10241
-    Configuration newConfig = this.getResources().getConfiguration();
     int newOrientation = KMManager.getOrientation(context);
     if (newOrientation != lastOrientation) {
       lastOrientation = newOrientation;
+      Configuration newConfig = this.getResources().getConfiguration();
       KMManager.onConfigurationChanged(newConfig);
     }
     resizeTextView(textView.isKeyboardVisible());

--- a/android/KMEA/app/src/main/AndroidManifest.xml
+++ b/android/KMEA/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.INTERNET" tools:node="remove" />
 
     <application
+        android:resizeableActivity="false"
         android:theme="@style/AppTheme" >
 
         <!-- Have application handle initializing Sentry -->

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -186,7 +186,6 @@ final class KMKeyboard extends WebView {
     clearCache(true);
     getSettings().setJavaScriptEnabled(true);
     getSettings().setAllowFileAccess(true);
-    getSettings().setSupportMultipleWindows(false);
 
     // Normally, this would be true to prevent the WebView from accessing the network.
     // But this needs to false for sending embedded KMW crash reports to Sentry (keymanapp/keyman#3825)

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -186,6 +186,7 @@ final class KMKeyboard extends WebView {
     clearCache(true);
     getSettings().setJavaScriptEnabled(true);
     getSettings().setAllowFileAccess(true);
+    getSettings().setSupportMultipleWindows(false);
 
     // Normally, this would be true to prevent the WebView from accessing the network.
     // But this needs to false for sending embedded KMW crash reports to Sentry (keymanapp/keyman#3825)

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1998,6 +1998,17 @@ public final class KMManager {
     KMKeyboard.removeOnKeyboardEventListener(listener);
   }
 
+  public static int getOrientation(Context context) {
+    Display display = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+    int rotation = display.getRotation();
+    if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180) {
+      return Configuration.ORIENTATION_PORTRAIT;
+    } else if (rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270) {
+      return Configuration.ORIENTATION_LANDSCAPE;
+    }
+    return Configuration.ORIENTATION_UNDEFINED;
+  }
+
   public static int getBannerHeight(Context context) {
     int bannerHeight = 0;
     if (InAppKeyboard != null && InAppKeyboard.getBanner() != BannerType.BLANK) {
@@ -2012,11 +2023,10 @@ public final class KMManager {
     int defaultHeight = (int) context.getResources().getDimension(R.dimen.keyboard_height);
     SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
 
-    Display display = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
-    int rotation = display.getRotation();
-    if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180) {
+    int orientation = getOrientation(context);
+    if (orientation == Configuration.ORIENTATION_PORTRAIT) {
       return prefs.getInt(KMManager.KMKey_KeyboardHeightPortrait, defaultHeight);
-    } else if (rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270) {
+    } else if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
       return prefs.getInt(KMManager.KMKey_KeyboardHeightLandscape, defaultHeight);
     }
 


### PR DESCRIPTION
Follows #10373 and fixes #10241

This applies two things to fix OSK width to be full screen
* Disables multi-window mode for the entire Keyman app
* Refactors detection of device orientation so MainActivity.onResume() has the correct dimensions for the OSK

## User Testing

**Setup** - Install the PR build of Keyman for Android on an Android 12.0 device /emulator (SDK 31)

* **TEST_OSK** - Verifies OSK is full width after using keyboard picker
1. Launch Keyman for Android in landscape
2. Type some letters on the input text screen. 
3. Longpress the globe key to open the Keyboard picker menu. 
4. Click the default keyboard. 
5. Verify the app shows the OSK full-width.