### PR TITLE
fix(android/engine): Add RECEIVER_EXPORTED flag for broadcast receiver

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Log;
 
 import com.keyman.engine.util.KMLog;
@@ -59,7 +60,15 @@ public class CloudDownloadMgr{
     if(isInitialized)
       return;
     try {
-      aContext.registerReceiver(completeListener, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+      // Runtime-registered boradcasts receivers must specify export behavior to indicate whether
+      // or not the receiver should be exported to all other apps on the device
+      // https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        aContext.registerReceiver(completeListener, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+          Context.RECEIVER_EXPORTED);
+      } else {
+        aContext.registerReceiver(completeListener, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+      }
     } catch (IllegalStateException e) {
       String message = "initialize error: ";
       KMLog.LogException(TAG, message, e);


### PR DESCRIPTION
Fixes [Sentry crash](https://keyman.sentry.io/issues/4892768528/?environment=local&project=5983520&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=0) and follows #10393 which updates the Android targetSDKVersion to 34.

Per Android Developer guide about apps targeting Android 14
https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported

> Apps and services that target Android 14 and use [context-registered receivers](https://developer.android.com/guide/components/broadcasts#context-registered-receivers) are required to specify a flag to indicate whether or not the receiver should be exported to all other apps on the device: either RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED

## User Testing
**Setup** - Install the PR build of Keyman for Android on Android 14.0 (SDK 34) device / emulator

* **TEST_KEYMAN** - Verifies Keyman startup
1. Launch Keyman for Android and verify app doesn't crash
2. Dismiss the "Get Started" menu
3. From Keyman settings, install a Keyman keyboard from keyman.com
4. Verify Keyman keyboard installs (Disregard OSK rotation issues as those are tracked on a separate PR)




