### PR TITLE
fix(developer): use keyboard3 tag rather than DTD to identify LDML keyboard xml files 🌱

### DIFF
--- a/developer/src/kmconvert/Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas
@@ -75,7 +75,7 @@ end;
 const
   TemplateXML: string =
     '<?xml version="1.0" encoding="UTF-8"?>'#13#10+
-    '<!DOCTYPE keyboard3 SYSTEM "ldmlKeyboard3.dtd">'#13#10+
+    // We won't inject the DOCTYPE because of pathing challenges, CLDR-15505: '<!DOCTYPE keyboard3 SYSTEM "ldmlKeyboard3.dtd">'#13#10+
     '<keyboard3 />'#13#10;
 
 const

--- a/developer/src/tike/project/Keyman.Developer.System.Project.xmlLdmlProjectFile.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.xmlLdmlProjectFile.pas
@@ -83,7 +83,7 @@ begin
     ss := TStringStream.Create('', TEncoding.UTF8);
     try
       ss.LoadFromFile(Filename);
-      Result := ss.DataString.IndexOf('ldmlKeyboard3.dtd') > 0;
+      Result := ss.DataString.IndexOf('<keyboard3') > 0;
     finally
       ss.Free;
     end;


### PR DESCRIPTION
Fixes #10469.

@keymanapp-test-bot skip