### PR TITLE
refactor(linux): Use `km_core_actions` struct instead of queue 🌱

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -60,8 +60,12 @@ typedef struct _IBusKeymanEngineClass IBusKeymanEngineClass;
 #define MAX_QUEUE_SIZE 100
 
 typedef struct _commit_queue_item {
+  // char_buffer and emitting_keystroke as well as more than one queue
+  // item are only used if ibus supports prefilter but the client
+  // doesn't support surrounding text (non-compliant app)
   gchar *char_buffer;
   gboolean emitting_keystroke;
+
   guint keyval;
   guint keycode;
   guint state;
@@ -85,7 +89,6 @@ struct _IBusKeymanEngine {
 
   commit_queue_item commit_queue[MAX_QUEUE_SIZE];
   commit_queue_item *commit_item;
-  guint             consecutive_backspaces;
 };
 
 struct _IBusKeymanEngineClass {
@@ -436,7 +439,6 @@ ibus_keyman_engine_constructor(
     keyman->lctrl_pressed = FALSE;
     keyman->ralt_pressed = FALSE;
     keyman->rctrl_pressed = FALSE;
-    keyman->consecutive_backspaces = 0;
     initialize_queue(keyman, 0, MAX_QUEUE_SIZE);
     keyman->commit_item    = &keyman->commit_queue[0];
     gchar **split_name     = g_strsplit(engine_name, ":", 2);
@@ -477,7 +479,7 @@ ibus_keyman_engine_constructor(
     status = km_core_keyboard_load(abs_kmx_path, &(keyman->keyboard));
 
     if (status != KM_CORE_STATUS_OK) {
-      g_warning("%s: problem creating km_core_keyboard. Status is %u.", __FUNCTION__, status);
+      g_warning("%s: problem loading km_core_keyboard %s. Status is %u.", __FUNCTION__, abs_kmx_path, status);
       ibus_keyman_engine_destroy(keyman);
       return NULL;
     }
@@ -558,160 +560,113 @@ static void commit_string(IBusKeymanEngine *keyman, const gchar *string)
     g_object_unref (text);
 }
 
-static void forward_backspace(IBusKeymanEngine *keyman, unsigned int state)
-{
-    g_message("DAR: %s: forward_backspace %d no keysym state %d", __FUNCTION__, KEYMAN_BACKSPACE, state);
-    ibus_engine_forward_key_event((IBusEngine *)keyman, KEYMAN_BACKSPACE_KEYSYM, KEYMAN_BACKSPACE, state);
-}
-
+//
 static gboolean
-process_unicode_char_action(
-  IBusKeymanEngine *keyman,
-  const km_core_action_item *action_item
-) {
-  g_assert(g_unichar_type(action_item->character) != G_UNICODE_SURROGATE);
-  gchar *utf8   = (gchar *)g_new0(gchar, 12);
-  gint numbytes = g_unichar_to_utf8(action_item->character, utf8);
-  if (numbytes > 12) {
-    g_error("%s: g_unichar_to_utf8 overflowing buffer", __FUNCTION__);
-    g_free(utf8);
-  } else {
-    g_message("%s: unichar:U+%04x, bytes:%d, string:%s", __FUNCTION__, action_item->character, numbytes, utf8);
-    if (keyman->commit_item->char_buffer == NULL) {
-      g_message("%s: setting buffer to converted unichar", __FUNCTION__);
-      keyman->commit_item->char_buffer = utf8;
-    } else {
-      g_message("%s: appending converted unichar to CHAR buffer", __FUNCTION__);
-      gchar *new_buffer = g_strjoin("", keyman->commit_item->char_buffer, utf8, NULL);
-      g_free(keyman->commit_item->char_buffer);
-      g_free(utf8);
-      keyman->commit_item->char_buffer = new_buffer;
-    }
-    g_message("%s: CHAR buffer is now %s", __FUNCTION__, keyman->commit_item->char_buffer);
-  }
-  return TRUE;
+is_core_options_end(km_core_option_item *option) {
+  g_assert(option);
+  return option->key == NULL && option->value == NULL && option->scope == 0;
 }
 
-static gboolean process_alert_action() {
+static void
+process_output_action(IBusEngine *engine, km_core_usv* output_utf32) {
+  if (output_utf32 == NULL || output_utf32[0] == '\0') {
+    return;
+  }
+
+  IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
+  gchar *output_utf8 = g_ucs4_to_utf8(output_utf32, -1, NULL, NULL, NULL);
+  if (client_supports_prefilter(engine) && !client_supports_surrounding_text(engine)) {
+    // non-compliant app with patched ibus
+    g_message("%s: Adding to commit queue: %s", __FUNCTION__, output_utf8);
+    g_assert(keyman->commit_item->char_buffer == NULL);
+    keyman->commit_item->char_buffer = output_utf8;
+  } else {
+    // compliant app or unpatched ibus
+    g_message("%s: Outputing %s", __FUNCTION__, output_utf8);
+    commit_string(keyman, output_utf8);
+    g_free(output_utf8);
+  }
+}
+
+static void process_alert_action(km_core_bool alert) {
+  if (!alert) {
+    return;
+  }
   GdkDisplay *display = gdk_display_open(NULL);
   if (display != NULL) {
     gdk_display_beep(display);
     gdk_display_close(display);
   }
-  return TRUE;
-}
-
-static gboolean
-process_backspace_action(
-  IBusEngine *engine,
-  const km_core_action_item *action_items,
-  int i,
-  size_t num_action_items
-) {
-  IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
-  if (action_items[i].backspace.expected_type == KM_CORE_IT_MARKER) {
-    g_message("%s: skipping marker type", __FUNCTION__);
-  } else if (keyman->commit_item->char_buffer != NULL) {
-    g_message("%s: removing one utf8 char from CHAR buffer", __FUNCTION__);
-    glong end_pos = g_utf8_strlen(keyman->commit_item->char_buffer, -1);
-    gchar *new_buffer;
-    if (end_pos == 1) {
-      new_buffer = NULL;
-      g_message("%s: resetting CHAR buffer to NULL", __FUNCTION__);
-    } else {
-      new_buffer = g_utf8_substring(keyman->commit_item->char_buffer, 0, end_pos - 1);
-      g_message("%s: changing CHAR buffer to :%s:", __FUNCTION__, new_buffer);
-    }
-    if (g_strcmp0(keyman->commit_item->char_buffer, new_buffer) == 0) {
-      g_message("%s: oops, CHAR buffer hasn't changed", __FUNCTION__);
-    }
-    g_free(keyman->commit_item->char_buffer);
-    keyman->commit_item->char_buffer = new_buffer;
-  } else {
-    g_message(
-        "DAR: %s - client_capabilities=%x, %x", __FUNCTION__, engine->client_capabilities, IBUS_CAP_SURROUNDING_TEXT);
-
-    if (client_supports_surrounding_text(engine)) {
-      keyman->consecutive_backspaces++;
-      g_message("%s: compliant app: increment consecutive backspaces to %d", __FUNCTION__, keyman->consecutive_backspaces);
-    } else {
-      g_message("%s: non-compliant app: forwarding backspace", __FUNCTION__);
-      forward_backspace(keyman, 0);
-    }
-  }
-  return TRUE;
-}
-
-static gboolean
-finish_backspace_action(
-  IBusEngine *engine
-) {
-  IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
-  if (keyman->consecutive_backspaces <= 0)
-    return TRUE;
-
-  g_assert(client_supports_surrounding_text(engine));
-  g_message("%s: deleting surrounding text %d char", __FUNCTION__, keyman->consecutive_backspaces);
-  ibus_engine_delete_surrounding_text(engine, -keyman->consecutive_backspaces, keyman->consecutive_backspaces);
-  keyman->consecutive_backspaces = 0;
-  return TRUE;
-}
-
-static gboolean
-process_persist_action(
-  IBusKeymanEngine *keyman,
-  const km_core_action_item *action_item
-) {
-  // Save keyboard option
-  if (!action_item->option)
-    return TRUE;
-
-  // Allocate for 1 option plus 1 pad struct of 0's
-  km_core_option_item *keyboard_opts = g_new0(km_core_option_item, 2);
-  memmove(&(keyboard_opts[0]), action_item->option, sizeof(km_core_option_item));
-  km_core_status event_status = km_core_state_options_update(keyman->state, keyboard_opts);
-  if (event_status != KM_CORE_STATUS_OK) {
-    g_warning("%s: problem saving option for km_core_keyboard", __FUNCTION__);
-  }
-  g_free(keyboard_opts);
-
-  // Put the keyboard option into DConf
-  if (action_item->option->key != NULL && action_item->option->value != NULL) {
-    g_message("%s: Saving keyboard option to DConf", __FUNCTION__);
-    // Load the current keyboard options from DConf
-    keyman_put_options_todconf(
-        keyman->kb_name, keyman->kb_name, (gchar *)action_item->option->key, (gchar *)action_item->option->value);
-  }
-  return TRUE;
-}
-
-static gboolean
-process_emit_keystroke_action(IBusKeymanEngine *keyman) {
-  IBusEngine *engine = (IBusEngine *)keyman;
-  if ((!client_supports_prefilter(engine) || client_supports_surrounding_text(engine)) &&
-      keyman->commit_item->char_buffer != NULL) {
-    commit_string(keyman, keyman->commit_item->char_buffer);
-    g_free(keyman->commit_item->char_buffer);
-    keyman->commit_item->char_buffer = NULL;
-  }
-  keyman->commit_item->emitting_keystroke = TRUE;
-  return TRUE;
-}
-
-static gboolean
-process_capslock_action(
-  IBusKeymanEngine *keyman,
-  const km_core_action_item *action_item
-) {
-  g_message("%s: %s caps-lock", __FUNCTION__, action_item->capsLock ? "Enable" : "Disable");
-
-  set_capslock_indicator(action_item->capsLock);
-  return TRUE;
 }
 
 static void
-commit_text(IBusKeymanEngine *keyman) {
+process_backspace_action(IBusEngine *engine, unsigned int code_points_to_delete) {
+  if (code_points_to_delete < 1) {
+    return;
+  }
+
+  if (client_supports_surrounding_text(engine)) {
+    g_message("%s: compliant app: deleting surrounding text %d codepoints", __FUNCTION__, code_points_to_delete);
+    ibus_engine_delete_surrounding_text(engine, -code_points_to_delete, code_points_to_delete);
+  } else {
+    g_message("%s: non-compliant app: forwarding %d backspaces", __FUNCTION__, code_points_to_delete);
+    while (code_points_to_delete > 0) {
+      ibus_engine_forward_key_event(engine, KEYMAN_BACKSPACE_KEYSYM, KEYMAN_BACKSPACE, 0);
+      code_points_to_delete--;
+    }
+  }
+}
+
+static void
+process_persist_action(IBusEngine *engine, km_core_option_item *persist_options) {
+  if (persist_options == NULL) {
+    return;
+  }
+
+  IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
+  for (km_core_option_item *option = persist_options; !is_core_options_end(option); option++) {
+    // Put the keyboard option into DConf
+    if (option->key != NULL && option->value != NULL) {
+      g_message("%s: Saving keyboard option to DConf", __FUNCTION__);
+      // Load the current keyboard options from DConf
+      keyman_put_options_todconf(keyman->kb_name, keyman->kb_name, (gchar *)option->key, (gchar *)option->value);
+    }
+  }
+}
+
+static void
+process_emit_keystroke_action(IBusEngine *engine, km_core_bool emit_keystroke) {
+  if (!emit_keystroke) {
+    return;
+  }
+  IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
+  if (!client_supports_prefilter(engine) || client_supports_surrounding_text(engine)) {
+    // compliant app or unpatched ibus version
+    ibus_engine_forward_key_event(engine, keyman->commit_item->keyval,
+      keyman->commit_item->keycode, keyman->commit_item->state);
+    return;
+  }
+  // non-compliant app
+  keyman->commit_item->emitting_keystroke = TRUE;
+}
+
+static void
+process_capslock_action(km_core_caps_state caps_state) {
+  if (caps_state == KM_CORE_CAPS_UNCHANGED) {
+    return;
+  }
+  g_message("%s: %s caps-lock", __FUNCTION__, caps_state == KM_CORE_CAPS_ON ? "Enable" : "Disable");
+
+  set_capslock_indicator(caps_state);
+}
+
+static void
+commit_current_queue_item(IBusKeymanEngine *keyman) {
+  // only called for non-compliant apps with patched ibus
   g_assert(keyman != NULL);
+  g_assert(client_supports_prefilter((IBusEngine *)keyman));
+  g_assert(!client_supports_surrounding_text((IBusEngine *)keyman));
+
   if (keyman->commit_item <= keyman->commit_queue)
     return;
 
@@ -729,10 +684,11 @@ commit_text(IBusKeymanEngine *keyman) {
 }
 
 static gboolean
-process_end_action(IBusKeymanEngine *keyman) {
-  g_assert(keyman != NULL);
-  IBusEngine *engine = (IBusEngine *)keyman;
+finish_process_actions(IBusEngine *engine) {
+  g_assert(engine != NULL);
+  IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
   if (client_supports_prefilter(engine) && !client_supports_surrounding_text(engine)) {
+    // non-compliant app with patched ibus
     guint state = keyman->commit_item->state;
     keyman->commit_item++;
     if (keyman->commit_item > &keyman->commit_queue[MAX_QUEUE_SIZE-1]) {
@@ -745,25 +701,18 @@ process_end_action(IBusKeymanEngine *keyman) {
     // generated will be processed before the character we're adding. We need to send a
     // valid keyval/keycode combination so that it doesn't get swallowed by GTK but which
     // isn't very likely used in real keyboards. F24 seems to work for that.
-    ibus_engine_forward_key_event((IBusEngine*)keyman,
+    ibus_engine_forward_key_event(engine,
       KEYMAN_NOCHAR_KEYSYM,
       KEYMAN_F24_KEYCODE_OUTPUT_SENTINEL,
       (state & IBUS_RELEASE_MASK)
         ? IBUS_PREFILTER_MASK | IBUS_RELEASE_MASK
         : IBUS_PREFILTER_MASK);
   } else {
-    if (keyman->commit_item->char_buffer != NULL) {
-      commit_string(keyman, keyman->commit_item->char_buffer);
-      g_free(keyman->commit_item->char_buffer);
-      keyman->commit_item->char_buffer = NULL;
-    }
-    if (keyman->commit_item->emitting_keystroke) {
-      keyman->commit_item->emitting_keystroke = FALSE;
-      // We have an old ibus version without prefilter support, or a client that does support
-      // surrounding text. In either case we return FALSE because we emitted a keystroke
-      // so that the processing of the event will continue.
-      return FALSE;
-    }
+    // compliant app, or unpatched ibus
+    // If we have an old ibus version without prefilter support, or a client that does support
+    // surrounding text we already did everything that needs to be done including forwarding
+    // a keystroke. So we can return TRUE to stop processing of this event.
+      return TRUE;
   }
 
   // If we have a new ibus version that supports prefilter and a client that doesn't support
@@ -778,65 +727,16 @@ process_end_action(IBusKeymanEngine *keyman) {
 static gboolean
 process_actions(
   IBusEngine *engine,
-  const km_core_action_item *action_items,
-  size_t num_action_items
+  km_core_actions const *actions
 ) {
-  IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
-  for (int i = 0; i < num_action_items; i++) {
-    gboolean continue_with_next_action = TRUE;
-    if (action_items[i].type != KM_CORE_IT_BACK && keyman->consecutive_backspaces > 0) {
-      finish_backspace_action(engine);
-    }
-    switch (action_items[i].type) {
-    case KM_CORE_IT_CHAR:
-      g_message("CHAR action %d/%d", i + 1, (int)num_action_items);
-      continue_with_next_action = process_unicode_char_action(keyman, &action_items[i]);
-      g_assert(continue_with_next_action == TRUE);
-      break;
-    case KM_CORE_IT_MARKER:
-      g_message("MARKER action %d/%d", i + 1, (int)num_action_items);
-      break;
-    case KM_CORE_IT_ALERT:
-      g_message("ALERT action %d/%d", i + 1, (int)num_action_items);
-      continue_with_next_action = process_alert_action();
-      g_assert(continue_with_next_action == TRUE);
-      break;
-    case KM_CORE_IT_BACK:
-      g_message("BACK action %d/%d", i + 1, (int)num_action_items);
-      continue_with_next_action = process_backspace_action(engine, action_items, i, num_action_items);
-      g_assert(continue_with_next_action == TRUE);
-      break;
-    case KM_CORE_IT_PERSIST_OPT:
-      g_message("PERSIST_OPT action %d/%d", i + 1, (int)num_action_items);
-      continue_with_next_action = process_persist_action(keyman, &action_items[i]);
-      g_assert(continue_with_next_action == TRUE);
-      break;
-    case KM_CORE_IT_EMIT_KEYSTROKE:
-      g_message("EMIT_KEYSTROKE action %d/%d", i + 1, (int)num_action_items);
-      continue_with_next_action = process_emit_keystroke_action(keyman);
-      g_assert(continue_with_next_action == TRUE);
-      break;
-    case KM_CORE_IT_INVALIDATE_CONTEXT:
-      g_message("INVALIDATE_CONTEXT action %d/%d", i + 1, (int)num_action_items);
-      // no-op when context is maintained in core
-      continue_with_next_action = TRUE;
-      break;
-    case KM_CORE_IT_CAPSLOCK:
-      g_message("CAPSLOCK action %d/%d", i + 1, (int)num_action_items);
-      continue_with_next_action = process_capslock_action(keyman, &action_items[i]);
-      g_assert(continue_with_next_action == TRUE);
-      break;
-    case KM_CORE_IT_END:
-      g_message("END action %d/%d", i + 1, (int)num_action_items);
-      continue_with_next_action = process_end_action(keyman);
-      break;
-    default:
-      g_warning("%s: Unknown action %d/%d(%d)", __FUNCTION__, i + 1, (int)num_action_items, action_items[i].type);
-    }
-    if (!continue_with_next_action)
-      return FALSE;
-  }
-  return TRUE;
+  process_backspace_action(engine, actions->code_points_to_delete);
+  process_output_action(engine, actions->output);
+  process_persist_action(engine, actions->persist_options);
+  process_alert_action(actions->do_alert);
+  process_emit_keystroke_action(engine, actions->emit_keystroke);
+  process_capslock_action(actions->new_caps_lock_state);
+
+  return finish_process_actions(engine);
 }
 
 static gboolean
@@ -862,7 +762,7 @@ ibus_keyman_engine_process_key_event(
   // correct output order of backspace and text.
   if (client_supports_prefilter(engine) && !client_supports_surrounding_text(engine) &&
       keycode == KEYMAN_F24_KEYCODE_OUTPUT_SENTINEL && (state & IBUS_PREFILTER_MASK)) {
-    commit_text(keyman);
+    commit_current_queue_item(keyman);
     return TRUE;
   }
 
@@ -929,17 +829,16 @@ ibus_keyman_engine_process_key_event(
   km_core_process_event(keyman->state, keycode_to_vk[keycode], km_mod_state, isKeyDown, KM_CORE_EVENT_FLAG_DEFAULT);
   g_message("%s: after process key event : %s", __FUNCTION__, debug_context1 = get_context_debug(engine));
 
-  // km_core_state_action_items to get action items
-  size_t num_action_items;
   g_free(keyman->commit_item->char_buffer);
   keyman->commit_item->char_buffer = NULL;
-  const km_core_action_item *action_items = km_core_state_action_items(keyman->state, &num_action_items);
+  const km_core_actions *core_actions = km_core_state_get_actions(keyman->state);
 
-  if (!process_actions(engine, action_items, num_action_items) &&
+  if (!process_actions(engine, core_actions) &&
       (!client_supports_prefilter(engine) || client_supports_surrounding_text(engine))) {
     // If we have an old ibus version without prefilter support, or a client that supports
     // surrounding text, and we forwarded a key event we want to return FALSE so that the
     // processing of the event continues.
+    km_core_actions_dispose(core_actions);
     return FALSE;
   }
 


### PR DESCRIPTION
Implements #10353.

# User Testing

## Preparations

- The tests can be be run on any Linux platforms (running with X11). Note that Firefox and Chromium have to be installed from .deb, the snap version won't work because it's missing the ibus patch.

- Install Anki
  - Download [Qt5 version of Anki](https://apps.ankiweb.net/#linux)
  - Run the following commands
    ```bash
    sudo apt update
    sudo apt install zstd
    tar xaf Downloads/anki-2.*-linux-qt5.tar.zst
    cd anki-2.*-linux-qt5
    sudo ./install.sh
    sudo apt install libxcb-xinerama0
    ```
  - When testing in Anki, select e.g. "Tools"/"Study Deck"

- Install patched ibus by running these commands:
  ```
  sudo add-apt-repository ppa:keymanapp/keyman-alpha
  sudo apt upgrade
  ```
  - afterwards running `dpkg -l ibus` should show a version number with `sil` in the version string, e.g. `1.5.28-3sil2~jammy`
 
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

- Install the following keyboards in Keyman:
  * [IPA (SIL)](https://keyman.com/keyboards/sil_ipa)
  * [Korean KORDA Jamo (SIL)](https://keyman.com/keyboards/sil_korda_jamo)
  * [Khmer Angkor](https://keyman.com/keyboards/khmer_angkor)
  * [Vedic Sanskrit Devanagari Phonetic (ITRANS)](https://keyman.com/keyboards/itrans_devanagari_sanskrit_vedic)

## SUITE_WRITER: LibreOffice Writer

Open LibreOffice Writer.

### Tests

- **TEST_WRITER_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_WRITER_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_WRITER_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री". (If the result looks wrong, select all text and change the font to "Siddhanta")
- **TEST_WRITER_KM:** Switch to "Khmer Angkor" keyboard. Select "Khmer Mondulkiri" font. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_WRITER_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.

## SUITE_GEDIT: gedit

Open gedit.

### Tests

- **TEST_GEDIT_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_GEDIT_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_GEDIT_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री".
- **TEST_GEDIT_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_GEDIT_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.

## SUITE_FIREFOX: Firefox

Open https://keyman.com/keyboards in Firefox.

**NOTE:** If the output looks wrong, copy the text from the browser and paste it into gedit and verify that it there.

### Tests

- **TEST_FIREFOX_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_FIREFOX_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_FIREFOX_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री".
- **TEST_FIREFOX_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".

**NOTE:** Backspace with Firefox won't work correctly because of #9971).

## SUITE_CHROMIUM: Chrome/Chromium

Open https://keyman.com/keyboards in Chrome/Chromium browser.

**NOTE:** If the output looks wrong, copy the text from the browser and paste it into gedit and verify that it there.

### Tests

- **TEST_CHROMIUM_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_CHROMIUM_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_CHROMIUM_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री".
- **TEST_CHROMIUM_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_CHROMIUM_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.

## SUITE_TERMINAL: gnome-terminal

Open Terminal.

### Tests

- **TEST_TERMINAL_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".

**NOTE:** the other tests for gnome-terminal won't work because of #10481 

## SUITE_ANKI: Anki

Open Anki.

### Tests

- **TEST_ANKI_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_ANKI_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_ANKI_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री" (If the result looks wrong, copy/paste it in text editor and verify there).
- **TEST_ANKI_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_ANKI_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.

## SUITE_SEARCHBAR: Searchbar in gnome-shell

Press Windows key to open searchbar.

### Tests

- **TEST_SEARCHBAR_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_SEARCHBAR_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_SEARCHBAR_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री".
- **TEST_SEARCHBAR_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_SEARCHBAR_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.
