### PR TITLE
chore(linux): Build with webkitgtk 4.1 instead of 4.0

### DIFF
--- a/docs/linux/keyman-config.md
+++ b/docs/linux/keyman-config.md
@@ -9,7 +9,7 @@ then you will need to:
 
 ```bash
 sudo apt install python3-lxml python3-magic python3-numpy python3-qrcode python3-pil \
-    python3-requests python3-requests-cache python3 python3-gi gir1.2-webkit2-4.0 dconf-cli \
+    python3-requests python3-requests-cache python3 python3-gi gir1.2-webkit2-4.1 dconf-cli \
     python3-setuptools python3-pip python3-dbus ibus libglib2.0-bin liblocale-gettext-perl
 ```
 

--- a/docs/settings/linux/.devcontainer/Dockerfile
+++ b/docs/settings/linux/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         libjson-glib-dev libgtk-3-dev libxml2-utils help2man python3-lxml \
         python3-magic python3-numpy python3-pil python3-pip python3-qrcode \
         python3-requests python3-requests-cache python3 python3-gi dconf-cli \
-        dconf-editor cargo python3-dbus gir1.2-webkit2-4.0 ibus libglib2.0-bin \
+        dconf-editor cargo python3-dbus gir1.2-webkit2-4.1 ibus libglib2.0-bin \
         liblocale-gettext-perl xvfb xserver-xephyr metacity mutter \
     && sudo add-apt-repository --yes ppa:keymanapp/keyman \
     && sudo apt upgrade --yes

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,5 +1,8 @@
 keyman (16.0.144-1) unstable; urgency=medium
 
+  [Jeremy Bicha]
+  * Build with webkitgtk 4.1 instead of 4.0  (closes: #1061396)
+
   [Dandan Zhang]
   * Add support for loong64 (closes: #1057134)
 

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,7 +1,11 @@
-keyman (16.0.144-1) unstable; urgency=medium
+keyman (16.0.144-2) UNRELEASED; urgency=medium
 
   [Jeremy Bicha]
   * Build with webkitgtk 4.1 instead of 4.0  (closes: #1061396)
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 24 Jan 2024 17:38:11 +0100
+
+keyman (16.0.144-1) unstable; urgency=medium
 
   [Dandan Zhang]
   * Add support for loong64 (closes: #1057134)

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -9,7 +9,7 @@ Build-Depends:
  bash-completion,
  debhelper (>= 11),
  dh-python,
- gir1.2-webkit2-4.0,
+ gir1.2-webkit2-4.1 | gir1.2-webkit2-4.0,
  ibus,
  liblocale-gettext-perl,
  perl,
@@ -85,7 +85,7 @@ Section: python
 Architecture: all
 Depends:
  dconf-cli,
- gir1.2-webkit2-4.0,
+ gir1.2-webkit2-4.1 | gir1.2-webkit2-4.0,
  keyman-engine,
  python3-bs4,
  python3-gi,

--- a/linux/keyman-config/keyman_config/downloadkeyboard.py
+++ b/linux/keyman-config/keyman_config/downloadkeyboard.py
@@ -7,7 +7,11 @@ import urllib.parse
 import gi
 
 gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.1')
+try:
+    gi.require_version('WebKit2', '4.1')
+except ValueError:
+    # TODO: Remove once we drop support for Ubuntu 20.04 Focal
+    gi.require_version('WebKit2', '4.0')
 
 from gi.repository import Gtk, WebKit2
 

--- a/linux/keyman-config/keyman_config/downloadkeyboard.py
+++ b/linux/keyman-config/keyman_config/downloadkeyboard.py
@@ -7,7 +7,7 @@ import urllib.parse
 import gi
 
 gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.0')
+gi.require_version('WebKit2', '4.1')
 
 from gi.repository import Gtk, WebKit2
 

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -14,7 +14,11 @@ import webbrowser
 import gi
 
 gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.1')
+try:
+    gi.require_version('WebKit2', '4.1')
+except ValueError:
+    # TODO: Remove once we drop support for Ubuntu 20.04 Focal
+    gi.require_version('WebKit2', '4.0')
 
 from pkg_resources import parse_version
 

--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -14,7 +14,7 @@ import webbrowser
 import gi
 
 gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.0')
+gi.require_version('WebKit2', '4.1')
 
 from pkg_resources import parse_version
 

--- a/linux/keyman-config/keyman_config/keyboard_options_view.py
+++ b/linux/keyman-config/keyman_config/keyboard_options_view.py
@@ -8,7 +8,11 @@ from urllib.parse import parse_qsl, urlencode
 import gi
 
 gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.1')
+try:
+    gi.require_version('WebKit2', '4.1')
+except ValueError:
+    # TODO: Remove once we drop support for Ubuntu 20.04 Focal
+    gi.require_version('WebKit2', '4.0')
 
 from gi.repository import Gtk, WebKit2
 

--- a/linux/keyman-config/keyman_config/keyboard_options_view.py
+++ b/linux/keyman-config/keyman_config/keyboard_options_view.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qsl, urlencode
 import gi
 
 gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.0')
+gi.require_version('WebKit2', '4.1')
 
 from gi.repository import Gtk, WebKit2
 

--- a/linux/keyman-config/keyman_config/welcome.py
+++ b/linux/keyman-config/keyman_config/welcome.py
@@ -7,7 +7,11 @@ import webbrowser
 import gi
 
 gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.1')
+try:
+    gi.require_version('WebKit2', '4.1')
+except ValueError:
+    # TODO: Remove once we drop support for Ubuntu 20.04 Focal
+    gi.require_version('WebKit2', '4.0')
 from gi.repository import Gtk, WebKit2
 
 from keyman_config import _

--- a/linux/keyman-config/keyman_config/welcome.py
+++ b/linux/keyman-config/keyman_config/welcome.py
@@ -7,7 +7,7 @@ import webbrowser
 import gi
 
 gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.0')
+gi.require_version('WebKit2', '4.1')
 from gi.repository import Gtk, WebKit2
 
 from keyman_config import _


### PR DESCRIPTION
webkitgtk 4.1 is the same API as 4.0 except that it uses libsoup3 instead of libsoup 2.4.

Fedora has [stopped](https://fedoraproject.org/wiki/Changes/Remove_webkit2gtk-4.0_API_Version) building the 4.0 API (in preparation for Fedora 40 in a few months). Debian and Ubuntu will also stop building the 4.0 API soon.

webkitgtk 4.1 should exist in currently mainatained distros. It is in Debian 12, Ubuntu 22.04 LTS, etc.