### PR TITLE
fix(common): preserve const enums in tsc build 🌱

### DIFF
--- a/common/web/types/tsconfig.json
+++ b/common/web/types/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src/",
     "baseUrl": ".",
     "allowSyntheticDefaultImports": true,
+    "preserveConstEnums": true,
   },
   "include": [
     "src/**/*.ts",

--- a/developer/src/kmc-kmn/tsconfig.json
+++ b/developer/src/kmc-kmn/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src/",
     "baseUrl": ".",
     "allowJs": true,
+    "preserveConstEnums": true,
     "paths": {
       "@keymanapp/common-types": ["../../../common/web/types/src/main"],
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,6 @@
     "strictFunctionTypes": true,
     "noUnusedLocals": true,
     "allowJs": true,
-    "preserveConstEnums": true,
 
     "rootDir": ".",
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     "strictFunctionTypes": true,
     "noUnusedLocals": true,
     "allowJs": true,
+    "preserveConstEnums": true,
 
     "rootDir": ".",
 


### PR DESCRIPTION
Fixes #10486.

Note: we are not enabling this globally, because KeymanWeb can break on some of its modules. Something for us to consider for the future.

I audited usage of const enum elsewhere and found it only in common/web/types and developer/src/kmc-kmn.

@keymanapp-test-bot skip