### PR TITLE
fix(developer): sentry-cli no longer injects into .d.ts 🌱

### DIFF
--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -119,7 +119,6 @@ if builder_start_action bundle; then
     --org keyman \
     --project keyman-developer \
     --release "$VERSION_GIT_TAG"  \
-    --ext js --ext mjs --ext ts --ext map \
     build/ "${SOURCEMAP_PATHS[@]}"
 
   # Manually copy over kmcmplib module


### PR DESCRIPTION
Fixes #10490.

Note that the default is to inject into .js, .mjs, .cjs, so we don't need to override that.

@keymanapp-test-bot skip