### PR TITLE
chore(developer): `--enable-source-maps` parameter for kmc wrapper

### DIFF
--- a/developer/src/inst/node/kmc.cmd
+++ b/developer/src/inst/node/kmc.cmd
@@ -1,4 +1,12 @@
-@rem This script avoids path dependencies for node for distribution
-@rem with Keyman Developer. When used on platforms other than Windows,
-@rem node can be used directly with the compiler (`npm link` will setup).
-@"%~dp0\node.js\node.exe" "%~dp0\kmc\kmc.mjs" %*
+@echo off
+rem This script avoids path dependencies for node for distribution
+rem with Keyman Developer. When used on platforms other than Windows,
+rem node can be used directly with the compiler (`npm link` will setup).
+if "%1" == "--enable-source-maps" (
+  set ESM=--enable-source-maps
+  shift
+) else (
+  set ESM=
+)
+"%~dp0\node.js\node.exe" %ESM% "%~dp0\kmc\kmc.mjs" %1 %2 %3 %4 %5 %6 %7 %8 %9
+exit /b %errorlevel%


### PR DESCRIPTION
Fixes #10487.

In Keyman Developer's wrapper of kmc, we now accept `--enable-source-maps` as the first parameter to pass on to node. We do not enable source maps by default because they have a performance penalty.

@keymanapp-test-bot skip