### PR TITLE
fix(web): touch-layout fontsize property use ⛲

### DIFF
--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1232,17 +1232,15 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       paddedHeight = this.computedAdjustedOskHeight(this.height);
     }
 
-    let b = this.layerGroup.element as HTMLElement;
     let gs = this.kbdDiv.style;
-    let bs = b.style;
     if (this.usesFixedHeightScaling && this.height) {
       // Sets the layer group to the correct height.
       gs.height = gs.maxHeight = this.height + 'px';
     }
 
-    // The font-scaling applied on the layer group.
-    gs.fontSize = this.fontSize.styleString;
-    bs.fontSize = ParsedLengthStyle.forScalar(fs).styleString;
+    // The font-scaling applied by default for this instance on its root element.
+    // Layer-group font-scaling is applied separately.
+    gs.fontSize = this.fontSize.scaledBy(fs).styleString;
 
     // Step 1:  have the necessary conditions been met?
     const fixedSize = this.width && this.height;


### PR DESCRIPTION
Fixes #10444 for standard use cases.  To reach "all use cases" will take a bit more work.

## User Testing

TEST_BALOCHI_PHONETIC:  Using the Keyman app on an iPhone - preferably on an iPhone SE (emulated or real) - verify that key caps are sufficiently large.

1. Install the  `balochi_phonetic` keyboard.
2. Load the `balochi_phonetic` keyboard.
3. Verify that multiple keys have key caps spanning nearly the entire width of their respective keys.
    - Good keys to inspect:
        - 'g': `گ`
        - 'k': `ک`
        - 'e': `ے`
        - 't': `ت`

Example of the keyboard properly rendered:

![image](https://github.com/keymanapp/keyman/assets/25213402/969853ad-8bce-49aa-96e2-b7676c0e0075)

How it looks on the current `master`, for comparison:

![image](https://github.com/keymanapp/keyman/assets/25213402/b609c859-d1f9-4093-9bcd-f705216b9304)

It may be wise to run the test a second time, with the latest `alpha` build, for comparison.

(This keyboard's touch-layout requests a font-size boost of +40%.)