### PR TITLE
fix(web): OSK resource-loading promise's font-wait ⛲

### DIFF
--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -29,6 +29,10 @@ export class StylesheetManager {
   }
 
   linkStylesheet(sheet: HTMLStyleElement) {
+    if(!(sheet instanceof HTMLLinkElement) && !sheet.innerHTML) {
+      return;
+    }
+
     this.linkedSheets.push(sheet);
     this.linkNode.appendChild(sheet);
   }
@@ -51,6 +55,7 @@ export class StylesheetManager {
       } else {
         const promise = new ManagedPromise<void>();
         sheetElem.addEventListener('load', () => promise.resolve());
+        sheetElem.addEventListener('error', () => promise.reject());
         promises.push(promise.corePromise);
       }
     }
@@ -174,12 +179,10 @@ export class StylesheetManager {
      * For now, we're using this solely to detect when the font has been succesfully loaded.
      */
     const fontFace = new FontFace(fd.family, source);
-    const loadPromise = fontFace.load();
-    this.fontPromises.push(loadPromise);
 
     const clearPromise = () => this.fontPromises = this.fontPromises.filter((entry) => entry != loadPromise);
-    loadPromise.then(clearPromise);
-    loadPromise.catch(clearPromise);
+    const loadPromise = fontFace.load().then(clearPromise).catch(clearPromise);
+    this.fontPromises.push(loadPromise);
 
     this.linkStylesheet(sheet);
 

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -88,7 +88,7 @@ export class StylesheetManager {
     const fontKey = fd.family;
     let source: string;
 
-    let i, ttf='', woff='', eot='', svg='', fList=[];
+    let i, ttf='', woff='', fList=[];
 
     // TODO: 22 Aug 2014: check that font path passed from cloud is actually used!
 
@@ -118,8 +118,6 @@ export class StylesheetManager {
       if(fList[i].toLowerCase().indexOf('.otf') > 0) ttf=fList[i];
       if(fList[i].toLowerCase().indexOf('.ttf') > 0) ttf=fList[i];
       if(fList[i].toLowerCase().indexOf('.woff') > 0) woff=fList[i];
-      if(fList[i].toLowerCase().indexOf('.eot') > 0) eot=fList[i];
-      if(fList[i].toLowerCase().indexOf('.svg') > 0) svg=fList[i];
     }
 
     // Font path qualified to support page-relative fonts (build 347)
@@ -129,14 +127,6 @@ export class StylesheetManager {
 
     if(woff != '' && (woff.indexOf('/') < 0)) {
       woff = fontPathRoot+woff;
-    }
-
-    if(eot != '' && (eot.indexOf('/') < 0)) {
-      eot = fontPathRoot+eot;
-    }
-
-    if(svg != '' && (svg.indexOf('/') < 0)) {
-      svg = fontPathRoot+svg;
     }
 
     // Build the font-face definition according to the browser being used
@@ -155,16 +145,10 @@ export class StylesheetManager {
         source = "url('"+ttf+"') format('truetype')";
       }
     } else {
-      var s0 = [];
-
       if(os == DeviceSpec.OperatingSystem.Android) {
         // Android 4.2 and 4.3 have bugs in their rendering for some scripts
         // with embedded ttf or woff.  svg mostly works so is a better initial
         // choice on the Android browser.
-        if(svg != '') {
-          source = "url('"+svg+"') format('svg')";
-        }
-
         if(woff != '') {
           source = "url('"+woff+"') format('woff')";
         }
@@ -179,10 +163,6 @@ export class StylesheetManager {
 
         if(ttf != '') {
           source = "url('"+ttf+"') format('truetype')";
-        }
-
-        if(svg != '') {
-          source = "url('"+svg+"') format('svg')";
         }
       }
     }

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -145,25 +145,12 @@ export class StylesheetManager {
         source = "url('"+ttf+"') format('truetype')";
       }
     } else {
-      if(os == DeviceSpec.OperatingSystem.Android) {
-        // Android 4.2 and 4.3 have bugs in their rendering for some scripts
-        // with embedded ttf or woff.  svg mostly works so is a better initial
-        // choice on the Android browser.
-        if(woff != '') {
-          source = "url('"+woff+"') format('woff')";
-        }
+      if(woff != '') {
+        source = "url('"+woff+"') format('woff')";
+      }
 
-        if(ttf != '') {
-          source = "url('"+ttf+"') format('truetype')";
-        }
-      } else {
-        if(woff != '') {
-          source = "url('"+woff+"') format('woff')";
-        }
-
-        if(ttf != '') {
-          source = "url('"+ttf+"') format('truetype')";
-        }
+      if(ttf != '') {
+        source = "url('"+ttf+"') format('truetype')";
       }
     }
 

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -142,15 +142,15 @@ export class StylesheetManager {
         if(this.doCacheBusting) {
           ttf = this.cacheBust(ttf);
         }
-        source = "url('"+ttf+"') format('truetype')";
+        source = "url('"+encodeURI(ttf)+"') format('truetype')";
       }
     } else {
       if(woff != '') {
-        source = "url('"+woff+"') format('woff')";
+        source = "url('"+encodeURI(woff)+"') format('woff')";
       }
 
       if(ttf != '') {
-        source = "url('"+ttf+"') format('truetype')";
+        source = "url('"+encodeURI(ttf)+"') format('truetype')";
       }
     }
 
@@ -176,7 +176,10 @@ export class StylesheetManager {
     const fontFace = new FontFace(fd.family, source);
     const loadPromise = fontFace.load();
     this.fontPromises.push(loadPromise);
-    loadPromise.then(() => this.fontPromises = this.fontPromises.filter((entry) => entry != loadPromise));
+
+    const clearPromise = () => this.fontPromises = this.fontPromises.filter((entry) => entry != loadPromise);
+    loadPromise.then(clearPromise);
+    loadPromise.catch(clearPromise);
 
     this.linkStylesheet(sheet);
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1358,8 +1358,10 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     if (activeKeyboard != null && typeof (activeKeyboard.oskStyling) == 'string')  // KMEW-129
       customStyle = customStyle + activeKeyboard.oskStyling;
 
-    this.styleSheet = createStyleSheet(customStyle); //Build 360
-    this.styleSheetManager.linkStylesheet(this.styleSheet);
+    if(customStyle) {
+      this.styleSheet = createStyleSheet(customStyle); //Build 360
+      this.styleSheetManager.linkStylesheet(this.styleSheet);
+    }
 
     // Once any related fonts are loaded, we can re-adjust key-cap scaling.
     this.styleSheetManager.allLoadedPromise().then(() => this.refreshLayout());

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1359,11 +1359,10 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       customStyle = customStyle + activeKeyboard.oskStyling;
 
     this.styleSheet = createStyleSheet(customStyle); //Build 360
-    this.styleSheet.addEventListener('load', () => {
-      // Once any related fonts are loaded, we can re-adjust key-cap scaling.
-      this.refreshLayout();
-    })
     this.styleSheetManager.linkStylesheet(this.styleSheet);
+
+    // Once any related fonts are loaded, we can re-adjust key-cap scaling.
+    this.styleSheetManager.allLoadedPromise().then(() => this.refreshLayout());
   }
 
   /**


### PR DESCRIPTION
Enhances the `Promise` setup used to await OSK resource loading to also properly wait for a keyboard's fonts to load.

Rather than use techniques from KMW's past, I've instead utilized a (comparatively) newer Web feature:  [`FontFace`](https://developer.mozilla.org/en-US/docs/Web/API/FontFace).  It's newer than when the setup we _previously_ used was first written, but it's supported on all browser versions KMW currently supports and provides a _much_ cleaner way to achieve the same goals - it even directly provides a Promise for font-loading completion!

This changeset includes a tweak to ensure that there's always a layout-refresh once the keyboard's fonts load; what's small in one font can be large in another, after all.  

This admittedly corresponds better to the original design/logic behind similar handling in KMW 15.0 and before than what it's replacing from 16.0.

----

For comparison, in versions of KeymanWeb up to and including 15.0, when a keyboard's stylesheets were added, we'd wait for font loads like this:

https://github.com/keymanapp/keyman/blob/2dcc11448ee6e715fcfbbbaf6701a29f449e5817/web/source/osk/visualKeyboard.ts#L1365-L1368

That method's comments & signature:

https://github.com/keymanapp/keyman/blob/2dcc11448ee6e715fcfbbbaf6701a29f449e5817/web/source/osk/visualKeyboard.ts#L1725-L1731

We dropped this technique when we dropped the use of touch-alias elements.

@keymanapp-test-bot skip

See #10534; the best user test I could come up with is implemented therein.