### PR TITLE
fix(web): documentation-keyboard font size, font scaling ⛲

### DIFF
--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -679,7 +679,7 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
     return VisualKeyboard.buildDocumentationKeyboard(
       PKbd,
       Pstub,
-      this.config.paths.fonts,
+      this.config.paths,
       argFormFactor,
       argLayerId,
       targetHeight

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -647,7 +647,7 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
    *  @param  {string}          PInternalName   internal name of keyboard, with or without Keyboard_ prefix
    *  @param  {number}          Pstatic         static keyboard flag  (unselectable elements)
    *  @param  {string=}         argFormFactor   layout form factor, defaulting to 'desktop'
-   *  @param  {(string|number)=}  argLayerId    name or index of layer to show, defaulting to 'default'
+   *  @param  {(string)=}  argLayerId    name or index of layer to show, defaulting to 'default'
    *  @return {Object}                          DIV object with filled keyboard layer content
    *
    * See https://help.keyman.com/developer/engine/web/current-version/reference/osk/BuildVisualKeyboard
@@ -656,7 +656,7 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
     PInternalName: string,
     Pstatic: number,
     argFormFactor?: DeviceSpec.FormFactor,
-    argLayerId?: string|number
+    argLayerId?: string
   ): HTMLElement {
     let PKbd: Keyboard = null;
 

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -198,7 +198,7 @@ export default abstract class OSKView
   private mouseEnterPromise?: ManagedPromise<void>;
   private touchEventPromiseManager = new TouchEventPromiseMap();
 
-  private static readonly STYLESHEET_FILES = ['kmwosk.css', 'globe-hint.css'];
+  static readonly STYLESHEET_FILES = ['kmwosk.css', 'globe-hint.css'];
 
   constructor(configuration: Configuration) {
     super();

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1401,10 +1401,12 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
    * Create copy of the OSK that can be used for embedding in documentation or help
    * The currently active keyboard will be returned if PInternalName is null
    *
-   *  @param  {Object}            PKbd            the keyboard object to be displayed
-   *  @param  {string=}           argFormFactor   layout form factor, defaulting to 'desktop'
-   *  @param  {(string|number)=}  argLayerId      name or index of layer to show, defaulting to 'default'
-   *  @param  {number}            height          Target height for the rendered keyboard
+   *  @param  {Keyboard}           PKbd            the keyboard object to be displayed
+   *  @param  {KeyboardProperties} kbdProperties   the metadata stub for the keyboard
+   *  @param  {Object}             pathConfig      an OSK path-configuration instance
+   *  @param  {string=}            argFormFactor   layout form factor, defaulting to 'desktop'
+   *  @param  {(string|number)=}   argLayerId      name or index of layer to show, defaulting to 'default'
+   *  @param  {number}             height          Target height for the rendered keyboard
    *                                              (currently required for legacy reasons)
    *  @return {Object}                            DIV object with filled keyboard layer content
    */
@@ -1413,7 +1415,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     kbdProperties: KeyboardProperties,
     pathConfig: OSKResourcePathConfiguration,
     argFormFactor: DeviceSpec.FormFactor,
-    argLayerId,
+    argLayerId: string,
     height: number
   ): HTMLElement { // I777
     if (!PKbd) {

--- a/web/src/test/manual/web/build-visual-keyboard/index.html
+++ b/web/src/test/manual/web/build-visual-keyboard/index.html
@@ -52,17 +52,19 @@
       };
 
       let shadowfy = function(container) {
-        const docBase = container.children[0];
-        container.removeChild(docBase);
-
         const shadow = container.attachShadow({ mode: "open" });
-        shadow.appendChild(docBase);
+        const docBase = container.children[0];
 
-        const baseOSKStyle = document.createElement('link');
-        baseOSKStyle.href = "../../../../../build/app/resources/osk/kmwosk.css";
-        baseOSKStyle.rel="stylesheet";
-        baseOSKStyle.type="text/css";
-        shadow.appendChild(baseOSKStyle);
+        while(docBase.children.length > 1) {
+          const sheet = docBase.children[1];
+          docBase.removeChild(docBase.children[1]);
+          shadow.appendChild(sheet);
+        }
+
+        // Do this one last - that way, all relevant sheets are in place when the
+        // layout-refresh is triggered.
+        container.removeChild(docBase);
+        shadow.appendChild(docBase);
       }
 
       let documentKeyboard = async function(kbdid, langid, formFactor, layer) {


### PR DESCRIPTION
Fixes #10444.  (Covers remaining cases.)

As the keyboard-documentation element structure removes the layer group from the main element of a `VisualKeyboard`, font-size handling requires specialized logic to ensure all relevant bits land in the correct location.

This PR admittedly also includes some specialized handling for one of the documentation-keyboard Web test pages, looking forward to #4881:
- There had been a regression here from 16.0 related to the notes about @font-face within Shadow DOM, causing the fonts to not display properly on the test page.
- Stylesheet management is now better-structured for transition to Shadow DOM hosting.
- Before, if kmwosk.css wasn't properly available within the Shadow DOM setup at the time that the layout-refresh was called, it was possible for taller characters to be overly shrunk due to the lack of proper positioning and structure that resulted.

I used breakpoints to verify that the final layout-refresh used to build documentation keyboards now occurs after all related fonts are properly loaded, with _all_ relevant styles fully in-place and loaded.

@keymanapp-test-bot skip