### PR TITLE
fix(web): banner suggestion resizing after device rotation

### DIFF
--- a/web/src/engine/osk/src/banner/banner.ts
+++ b/web/src/engine/osk/src/banner/banner.ts
@@ -112,5 +112,7 @@ export abstract class Banner {
    */
   public configureForKeyboard(keyboard: Keyboard, keyboardProperties: KeyboardProperties) { }
 
+  public readonly refreshLayout?: () => void;
+
   abstract get type();
 }

--- a/web/src/engine/osk/src/banner/bannerView.ts
+++ b/web/src/engine/osk/src/banner/bannerView.ts
@@ -142,5 +142,6 @@ export class BannerView implements OSKViewComponent {
   }
 
   public refreshLayout() {
+    this.currentBanner.refreshLayout?.();
   }
 }

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -704,25 +704,32 @@ export class SuggestionBanner extends Banner {
       minWidth: 0,
     }
 
-    let totalWidth = 0;
-    let displayCount = 0;
-
-    let collapsedOptions: BannerSuggestion[] = [];
-
     for (let i=0; i<SuggestionBanner.SUGGESTION_LIMIT; i++) {
       const d = this.options[i];
 
       if(suggestions.length > i) {
         const suggestion = suggestions[i];
         d.update(suggestion, optionFormat);
-        if(d.collapsedWidth < d.expandedWidth) {
-          collapsedOptions.push(d);
-        }
-
-        totalWidth += d.collapsedWidth;
-        displayCount++;
       } else {
         d.update(null, optionFormat);
+      }
+    }
+
+    this.refreshLayout();
+  }
+
+  readonly refreshLayout = () => {
+    let collapsedOptions: BannerSuggestion[] = [];
+    let totalWidth = 0;
+
+    let displayCount = Math.min(this.currentSuggestions.length, 8);
+    for(let i=0; i < displayCount; i++) {
+      const opt = this.options[i];
+      opt.minWidth = 0; // remove any previously-applied padding
+      totalWidth += opt.collapsedWidth;
+
+      if(opt.collapsedWidth < opt.expandedWidth) {
+        collapsedOptions.push(opt);
       }
     }
 

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -724,6 +724,10 @@ export class SuggestionBanner extends Banner {
 
     let displayCount = Math.min(this.currentSuggestions.length, 8);
     for(let i=0; i < displayCount; i++) {
+      // Note:  options is an array of pre-built suggestion-hosting elements, with
+      // fixed SUGGESTIONS_LIMIT length - not a length that dynamically changes to
+      // match the number of suggestions available.  Those without a suggestion
+      // are hidden, but preserved.
       const opt = this.options[i];
       opt.minWidth = 0; // remove any previously-applied padding
       totalWidth += opt.collapsedWidth;

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -627,6 +627,7 @@ export default abstract class OSKView
     if(!pending) {
       this.headerView?.refreshLayout();
       this.bannerView.width = this.computedWidth;
+      this.bannerView.refreshLayout();
       this.footerView?.refreshLayout();
     }
 
@@ -652,10 +653,6 @@ export default abstract class OSKView
       bs.width  = 'auto';
       bs.height = 'auto';
       bs.maxWidth = bs.maxHeight = '';
-    }
-
-    if(!pending) {
-      this.bannerView.refreshLayout();
     }
   }
 

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -626,7 +626,6 @@ export default abstract class OSKView
 
     if(!pending) {
       this.headerView?.refreshLayout();
-      this.bannerView.refreshLayout();
       this.bannerView.width = this.computedWidth;
       this.footerView?.refreshLayout();
     }
@@ -653,6 +652,10 @@ export default abstract class OSKView
       bs.width  = 'auto';
       bs.height = 'auto';
       bs.maxWidth = bs.maxHeight = '';
+    }
+
+    if(!pending) {
+      this.bannerView.refreshLayout();
     }
   }
 


### PR DESCRIPTION
Fixes #10477.

The predictive banner's suggestions are now automatically resized when rotating device orientation.  It's more complex than it was before #7934, when basic width-% styling was sufficient.   Fortunately, the fancy-banner layout logic was relatively easy to separate from the suggestion-update logic for use in layout refreshes.

## User Testing

TEST_BANNER_ROTATION:

1. Open Keyman In-App.
2. Verify that the predictive texts appear from left to right, filling the width of the suggestion banner.
3. Change the Mobile Orientation from Portrait to Landscape. 
4. Verify that suggestions extend to the full width of the suggestion banner with comparatively even padding/width for each (with more on longer words).