### PR TITLE
feat(core): ldml marker normalization fix 🙀

### DIFF
--- a/core/tests/unit/ldml/keyboards/k_008_transform_norm-test.xml
+++ b/core/tests/unit/ldml/keyboards/k_008_transform_norm-test.xml
@@ -305,5 +305,41 @@
       <check result="YES9d"/>
     </test>
   </tests>
-
+  <!-- separate tests for NFC-->
+  <tests name="regex-tests-9e">
+    <test name="regex-test-9e-0">
+      <keystroke key="9" />
+      <keystroke key="e" />
+      <keystroke key="e" />
+      <keystroke key="u-0300" />
+      <keystroke key="stampy" />
+      <keystroke key="e" />
+      <keystroke key="u-0300" /> <!-- out of order -->
+      <keystroke key="u-0320" />
+      <keystroke key="lgtm" />
+      <check result="YES9e" />
+    </test>
+    <test name="regex-test-9e-0">
+      <keystroke key="9" />
+      <keystroke key="e" />
+      <keystroke key="e" />
+      <keystroke key="u-0300" />
+      <keystroke key="stampy" />
+      <keystroke key="e" />
+      <keystroke key="u-0320" />
+      <keystroke key="u-0300" /> <!-- in order -->
+      <keystroke key="lgtm" />
+      <check result="YES9e" />
+    </test>
+  </tests>
+  <tests name="regex-tests-9f">
+    <test name="regex-test-9f-0">
+      <keystroke key="9" />
+      <keystroke key="f" />
+      <keystroke key="e" />
+      <keystroke key="stampy" />
+      <keystroke key="u-0344" />
+      <check result="YES9f" />
+    </test>
+  </tests>
 </keyboardTest3>

--- a/core/tests/unit/ldml/keyboards/k_008_transform_norm.xml
+++ b/core/tests/unit/ldml/keyboards/k_008_transform_norm.xml
@@ -13,6 +13,7 @@ https://github.com/unicode-org/cldr/blob/keyboard-preview/docs/ldml/tr35-keyboar
     <key id="u-0320" output="\u{0320}" /> <!-- ◌̠ -->
     <key id="u-0300" output="\u{0300}" /> <!-- ◌̀ -->
     <key id="u-00e8" output="\u{00e8}" /> <!-- è -->
+    <key id="u-0344" output="\u{0344}" /> <!-- discouraged greek dialytika tonos -->
     <key id="nfd" output="e\u{0320}\u{0300}" />
     <key id="nfc" output="\u{00E8}\u{0320}" />
     <key id="not-nfd" output="e\u{0300}\u{0320}" />
@@ -29,7 +30,7 @@ https://github.com/unicode-org/cldr/blob/keyboard-preview/docs/ldml/tr35-keyboar
       <row keys="space" />
     </layer>
     <layer modifiers="shift" id="shift">
-      <row keys="u-0300 u-00e8 nfd nfc not-nfd stampy lgtm" />
+      <row keys="u-0300 u-00e8 nfd nfc not-nfd stampy lgtm u-0344" />
     </layer>
   </layers>
 
@@ -84,6 +85,9 @@ https://github.com/unicode-org/cldr/blob/keyboard-preview/docs/ldml/tr35-keyboar
       <transform from="9c" to="9ce\u{0300}\m{stampy}\u{0320}\m{lgtm}" /> <!-- marker, denormalized -->
       <transform from="9d" to="9de\u{0320}\m{stampy}\u{0300}\m{lgtm}" /> <!--  marker, NFD -->
 
+      <transform from="9e\u{00E8}\m{stampy}\u{00E8}\u{0320}\m{lgtm}" to="YES9e" /> <!-- NFC in rules-->
+
+      <transform from="9fe\m{stampy}\u{0344}" to="YES9f" />
     </transformGroup>
     <transformGroup>
       <transform from="9ce\m{stampy}[\u{0320}][\u{0300}]\m{lgtm}" to="YES9c" />

--- a/core/tests/unit/ldml/test_transforms.cpp
+++ b/core/tests/unit/ldml/test_transforms.cpp
@@ -954,7 +954,80 @@ test_normalize() {
       std::cout << "dst: " << Debug_UnicodeString(dst_nfd) << std::endl;
       std::cout << "exp: " << Debug_UnicodeString(expect_nfd) << std::endl;
     }
+      zassert_string_equal(dst_nfd, expect_nfd);
+  }
+  {
+    marker_map map;
+    std::cout << __FILE__ << ":" << __LINE__ << " - marker-before-NFC " << std::endl;
+    // KA \m O -> KA \m E AA
+    const std::u32string src        = U"\u0995\uFFFF\u0008\u0001\u09CB";
+    const std::u32string expect_rem = U"\u0995\u09CB";
+    const std::u32string expect_nfd = U"\u0995\uFFFF\u0008\u0001\u09C7\u09BE";
+    auto dst_rem                    = remove_markers(src, &map);
+    marker_map expm({{0x09C7, 0x1L}});
+    zassert_string_equal(dst_rem, expect_rem);
+    std::u32string dst_nfd = src;
+    assert(normalize_nfd_markers(dst_nfd));
+    if (dst_nfd != expect_nfd) {
+      std::cout << "dst: " << Debug_UnicodeString(dst_nfd) << std::endl;
+      std::cout << "exp: " << Debug_UnicodeString(expect_nfd) << std::endl;
+    }
     zassert_string_equal(dst_nfd, expect_nfd);
+    assert_marker_map_equal(map, expm);
+  }
+  {
+    marker_map map;
+    std::cout << __FILE__ << ":" << __LINE__ << " - marker-before-NFC " << std::endl;
+    const std::u32string src        = U"\u0995\u09BE\uFFFF\u0008\u0001\u09C7";
+    const std::u32string expect_rem = U"\u0995\u09BE\u09C7";
+    const std::u32string expect_nfd = src; // does not get reordered
+    auto dst_rem                    = remove_markers(src, &map);
+    marker_map expm({{0x09C7, 0x1L}});
+    zassert_string_equal(dst_rem, expect_rem);
+    std::u32string dst_nfd = src;
+    assert(normalize_nfd_markers(dst_nfd));
+    if (dst_nfd != expect_nfd) {
+      std::cout << "dst: " << Debug_UnicodeString(dst_nfd) << std::endl;
+      std::cout << "exp: " << Debug_UnicodeString(expect_nfd) << std::endl;
+    }
+    zassert_string_equal(dst_nfd, expect_nfd);
+    assert_marker_map_equal(map, expm);
+  }
+  {
+    marker_map map;
+    std::cout << __FILE__ << ":" << __LINE__ << " - marker-before-NFC " << std::endl;
+    const std::u32string src        = U"\u0995\u09BE\uFFFF\u0008\u0001\u09C7";
+    const std::u32string expect_rem = U"\u0995\u09BE\u09C7";
+    const std::u32string expect_nfd = src; // does not get reordered
+    auto dst_rem                    = remove_markers(src, &map);
+    marker_map expm({{0x09C7, 0x1L}});
+    zassert_string_equal(dst_rem, expect_rem);
+    std::u32string dst_nfd = src;
+    assert(normalize_nfd_markers(dst_nfd));
+    if (dst_nfd != expect_nfd) {
+      std::cout << "dst: " << Debug_UnicodeString(dst_nfd) << std::endl;
+      std::cout << "exp: " << Debug_UnicodeString(expect_nfd) << std::endl;
+    }
+    zassert_string_equal(dst_nfd, expect_nfd);
+    assert_marker_map_equal(map, expm);
+  }
+  {
+    marker_map map;
+    std::cout << __FILE__ << ":" << __LINE__ << " - marker-before-greek " << std::endl;
+    const std::u32string src        = U"\u03B5\uFFFF\u0008\u0001\u0344";
+    const std::u32string expect_rem = U"\u03B5\u0344";
+    const std::u32string expect_nfd = U"\u03B5\uFFFF\u0008\u0001\u0308\u0301";
+    auto dst_rem                    = remove_markers(src, &map);
+    marker_map expm({{0x0308, 0x1L}});
+    zassert_string_equal(dst_rem, expect_rem);
+    std::u32string dst_nfd = src;
+    assert(normalize_nfd_markers(dst_nfd));
+    if (dst_nfd != expect_nfd) {
+      std::cout << "dst: " << Debug_UnicodeString(dst_nfd) << std::endl;
+      std::cout << "exp: " << Debug_UnicodeString(expect_nfd) << std::endl;
+    }
+    zassert_string_equal(dst_nfd, expect_nfd);
+    assert_marker_map_equal(map, expm);
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
- decomp the 'glued' char before storing in map
- [x] will port this to .ts in a followup PR

For: #10516

@keymanapp-test-bot skip