### PR TITLE
feat(core): add `deleted_context` to `km_core_actions` struct 🌱

### DIFF
--- a/core/include/keyman/keyman_core_api.h
+++ b/core/include/keyman/keyman_core_api.h
@@ -242,6 +242,12 @@ typedef struct {
 
   // -1=unchanged, 0=off, 1=on
   km_core_caps_state new_caps_lock_state;
+
+  // reference copy of actual UTF32 codepoints deleted from rhs of context
+  // exactly code_points_to_delete in length (plus null terminator). Used to
+  // determine encoding conversion differences when deleting; only set when
+  // using km_core_state_get_actions, otherwise nullptr.
+  const km_core_usv* deleted_context;
 } km_core_actions;
 
 /*

--- a/core/include/keyman/keyman_core_api.h
+++ b/core/include/keyman/keyman_core_api.h
@@ -243,10 +243,10 @@ typedef struct {
   // -1=unchanged, 0=off, 1=on
   km_core_caps_state new_caps_lock_state;
 
-  // reference copy of actual UTF32 codepoints deleted from rhs of context
-  // exactly code_points_to_delete in length (plus null terminator). Used to
-  // determine encoding conversion differences when deleting; only set when
-  // using km_core_state_get_actions, otherwise nullptr.
+  // reference copy of actual UTF32 codepoints deleted from end of context
+  // (closest to caret) exactly code_points_to_delete in length (plus null
+  // terminator). Used to determine encoding conversion differences when
+  // deleting; only set when using km_core_state_get_actions, otherwise nullptr.
   const km_core_usv* deleted_context;
 } km_core_actions;
 

--- a/core/src/action.cpp
+++ b/core/src/action.cpp
@@ -36,6 +36,10 @@ km_core_actions * km::core::action_item_list_to_actions_object(
   actions->emit_keystroke = KM_CORE_FALSE;
   actions->new_caps_lock_state = KM_CORE_CAPS_UNCHANGED;
 
+  // deleted_context data will be set in km_core_state_get_actions
+  // because it needs access to the state's app context
+  actions->deleted_context = nullptr;
+
   // Clear output pointers, will be set later once we have sizes
   actions->output = nullptr;
   actions->persist_options = nullptr;

--- a/core/src/km_core_action_api.cpp
+++ b/core/src/km_core_action_api.cpp
@@ -20,6 +20,8 @@
 
 using namespace km::core;
 
+km_core_usv const *get_deleted_context(context const &app_context, unsigned int code_points_to_delete);
+
 km_core_actions const * km_core_state_get_actions(
   km_core_state const *state
 ) {
@@ -35,6 +37,16 @@ km_core_actions const * km_core_state_get_actions(
 
   km_core_actions * result = action_item_list_to_actions_object(action_items);
 
+  // We keep a copy of the app context before normalization, as the
+  // code_points_to_delete value can be updated by normalization, but by the
+  // time we get it back from actions_normalize or
+  // actions_update_app_context_nfu,  app_context has already been updated to
+  // remove the necessary codepoints
+  context* app_context = km_core_state_app_context(state);
+  context app_context_for_deletion;
+  std::copy(app_context->begin(), app_context->end(), std::back_inserter(app_context_for_deletion));
+
+
   if(state->processor().supports_normalization()) {
     // Normalize to NFC for those keyboard processors that support it
     if(!actions_normalize(km_core_state_context(state), km_core_state_app_context(state), result)) {
@@ -48,6 +60,9 @@ km_core_actions const * km_core_state_get_actions(
       return nullptr;
     }
   }
+
+  result->deleted_context = get_deleted_context(app_context_for_deletion, result->code_points_to_delete);
+
   return result;
 }
 
@@ -60,6 +75,10 @@ km_core_status km_core_actions_dispose(
 
   if(actions->output) {
     delete[] actions->output;
+  }
+
+  if(actions->deleted_context) {
+    delete[] actions->deleted_context;
   }
 
   if(actions->persist_options) {
@@ -75,4 +94,15 @@ km_core_status km_core_actions_dispose(
   return KM_CORE_STATUS_OK;
 }
 
+km_core_usv const *get_deleted_context(context const &app_context, unsigned int code_points_to_delete) {
+  auto p = app_context.end();
+  for(size_t i = code_points_to_delete; i > 0; i--, p--);
 
+  auto deleted_context = new km_core_usv[code_points_to_delete + 1];
+  for(size_t i = 0; i < code_points_to_delete; i++) {
+    deleted_context[i] = p->character;
+    p++;
+  }
+  deleted_context[code_points_to_delete] = 0;
+  return deleted_context;
+}

--- a/core/tests/unit/kmnkbd/action_api.cpp
+++ b/core/tests/unit/kmnkbd/action_api.cpp
@@ -46,6 +46,7 @@ void test_two_backspaces() {
   assert(actions->do_alert == false);
   assert(actions->emit_keystroke == false);
   assert(actions->new_caps_lock_state == -1);
+  assert(actions->deleted_context == nullptr);
 
   try_status(km_core_actions_dispose(actions));
 }
@@ -76,6 +77,7 @@ void test_marker_text_interleaved() {
   assert(actions->do_alert == false);
   assert(actions->emit_keystroke == false);
   assert(actions->new_caps_lock_state == -1);
+  assert(actions->deleted_context == nullptr);
 
   try_status(km_core_actions_dispose(actions));
 }
@@ -99,6 +101,7 @@ void test_alert() {
   assert(actions->do_alert == KM_CORE_TRUE);
   assert(actions->emit_keystroke == KM_CORE_FALSE);
   assert(actions->new_caps_lock_state == KM_CORE_CAPS_UNCHANGED);
+  assert(actions->deleted_context == nullptr);
 
   try_status(km_core_actions_dispose(actions));
 }
@@ -122,6 +125,7 @@ void test_emit_keystroke() {
   assert(actions->do_alert == KM_CORE_FALSE);
   assert(actions->emit_keystroke == KM_CORE_TRUE);
   assert(actions->new_caps_lock_state == KM_CORE_CAPS_UNCHANGED);
+  assert(actions->deleted_context == nullptr);
 
   try_status(km_core_actions_dispose(actions));
 }
@@ -146,6 +150,7 @@ void test_invalidate_context() {
   assert(actions->do_alert == KM_CORE_FALSE);
   assert(actions->emit_keystroke == KM_CORE_FALSE);
   assert(actions->new_caps_lock_state == KM_CORE_CAPS_UNCHANGED);
+  assert(actions->deleted_context == nullptr);
 
   try_status(km_core_actions_dispose(actions));
 }
@@ -185,6 +190,7 @@ void test_persist_opt() {
   assert(actions->do_alert == KM_CORE_FALSE);
   assert(actions->emit_keystroke == KM_CORE_FALSE);
   assert(actions->new_caps_lock_state == KM_CORE_CAPS_UNCHANGED);
+  assert(actions->deleted_context == nullptr);
 
   try_status(km_core_actions_dispose(actions));
 }
@@ -227,6 +233,7 @@ int main(int argc, char *argv []) {
   std::cout << "&km_core_actions.do_alert: " << ((intptr_t)(&act.do_alert)-(intptr_t)(&act)) << std::endl;
   std::cout << "&km_core_actions.emit_keystroke: " << ((intptr_t)(&act.emit_keystroke)-(intptr_t)(&act)) << std::endl;
   std::cout << "&km_core_actions.new_caps_lock_state: " << ((intptr_t)(&act.new_caps_lock_state)-(intptr_t)(&act)) << std::endl;
+  std::cout << "&km_core_actions.deleted_context: " << ((intptr_t)(&act.deleted_context)-(intptr_t)(&act)) << std::endl;
 
   // actions
   test_two_backspaces();

--- a/core/tests/unit/kmnkbd/action_set_api.cpp
+++ b/core/tests/unit/kmnkbd/action_set_api.cpp
@@ -125,7 +125,8 @@ void test_two_backspaces() {
     test_env_opts, // km_core_option_item* persist_options;
     KM_CORE_FALSE, // km_core_bool do_alert;
     KM_CORE_FALSE, // km_core_bool emit_keystroke;
-    KM_CORE_CAPS_UNCHANGED // new_caps_lock_state;
+    KM_CORE_CAPS_UNCHANGED, // new_caps_lock_state;
+    nullptr // km_core_usv* deleted_context;
   };
 
   run_test(action_items, actions);
@@ -144,7 +145,8 @@ void test_character() {
     test_env_opts, // km_core_option_item* persist_options;
     KM_CORE_FALSE, // km_core_bool do_alert;
     KM_CORE_FALSE, // km_core_bool emit_keystroke;
-    KM_CORE_CAPS_UNCHANGED // new_caps_lock_state;
+    KM_CORE_CAPS_UNCHANGED, // new_caps_lock_state;
+    nullptr // km_core_usv* deleted_context;
   };
 
   run_test(action_items, actions);
@@ -165,7 +167,8 @@ void test_alert() {
     test_env_opts, // km_core_option_item* persist_options;
     KM_CORE_TRUE, // km_core_bool do_alert;
     KM_CORE_FALSE, // km_core_bool emit_keystroke;
-    KM_CORE_CAPS_UNCHANGED // new_caps_lock_state;
+    KM_CORE_CAPS_UNCHANGED, // new_caps_lock_state;
+    nullptr // km_core_usv* deleted_context;
   };
 
   run_test(action_items, actions);
@@ -186,7 +189,8 @@ void test_emit_keystroke() {
     test_env_opts, // km_core_option_item* persist_options;
     KM_CORE_FALSE, // km_core_bool do_alert;
     KM_CORE_TRUE, // km_core_bool emit_keystroke;
-    KM_CORE_CAPS_UNCHANGED // new_caps_lock_state;
+    KM_CORE_CAPS_UNCHANGED, // new_caps_lock_state;
+    nullptr // km_core_usv* deleted_context;
   };
 
   run_test(action_items, actions);
@@ -208,7 +212,8 @@ void test_invalidate_context() {
     test_env_opts, // km_core_option_item* persist_options;
     KM_CORE_FALSE, // km_core_bool do_alert;
     KM_CORE_FALSE, // km_core_bool emit_keystroke;
-    KM_CORE_CAPS_UNCHANGED // new_caps_lock_state;
+    KM_CORE_CAPS_UNCHANGED, // new_caps_lock_state;
+    nullptr // km_core_usv* deleted_context;
   };
 
   run_test(action_items, actions);
@@ -243,7 +248,8 @@ void test_persist_opt() {
     options, // km_core_option_item* persist_options;
     KM_CORE_FALSE, // km_core_bool do_alert;
     KM_CORE_FALSE, // km_core_bool emit_keystroke;
-    KM_CORE_CAPS_UNCHANGED // new_caps_lock_state;
+    KM_CORE_CAPS_UNCHANGED, // new_caps_lock_state;
+    nullptr // km_core_usv* deleted_context;
   };
 
   run_test(action_items, actions);
@@ -266,7 +272,8 @@ void test_caps_lock() {
     test_env_opts, // km_core_option_item* persist_options;
     KM_CORE_FALSE, // km_core_bool do_alert;
     KM_CORE_FALSE, // km_core_bool emit_keystroke;
-    KM_CORE_CAPS_ON // new_caps_lock_state;
+    KM_CORE_CAPS_ON, // new_caps_lock_state;
+    nullptr // km_core_usv* deleted_context;
   };
 
   run_test(action_items, actions);

--- a/core/tests/unit/kmnkbd/meson.build
+++ b/core/tests/unit/kmnkbd/meson.build
@@ -27,6 +27,7 @@ tests = [
   ['kmx_xstring', 'test_kmx_xstring.cpp'],
   ['kmx_context', 'test_kmx_context.cpp'],
   ['test_actions_normalize', 'test_actions_normalize.cpp'],
+  ['test_actions_get_api', 'test_actions_get_api.cpp'],
 ]
 
 test_path = join_paths(meson.current_build_dir(), '..', 'kmx')

--- a/developer/src/tike/main/Keyman.System.KeymanCore.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCore.pas
@@ -199,10 +199,11 @@ type
     // -1=unchanged, 0=off, 1=on
     new_caps_lock_state: km_core_caps_state;
 
-    // reference copy of actual UTF32 codepoints deleted from rhs of context
-    // exactly code_points_to_delete in length (plus null terminator). Used to
-    // determine encoding conversion differences when deleting; only set when
-    // using km_core_state_actions_get, otherwise nullptr.
+    // reference copy of actual UTF32 codepoints deleted from end of context
+    // (closest to caret) exactly code_points_to_delete in length (plus null
+    // terminator). Used to determine encoding conversion differences when
+    // deleting; only set when using km_core_state_actions_get, otherwise
+    // nullptr.
     deleted_context: pkm_core_usv;
   end;
   pkm_core_actions = ^km_core_actions;

--- a/developer/src/tike/main/Keyman.System.KeymanCore.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCore.pas
@@ -181,23 +181,29 @@ type
   );
 
   km_core_actions = record
-  code_points_to_delete: uint32; // number of codepoints (not codeunits!) to delete from app context.
+    // number of codepoints (not codeunits!) to delete from app context.
+    code_points_to_delete: uint32;
 
-  // null-term string of characters to insert into document
-  output: pkm_core_usv;
+    // null-term string of characters to insert into document
+    output: pkm_core_usv;
 
-  // list of options to persist, terminated with KM_CORE_OPTIONS_END
-  persist_options: pkm_core_option_item;
+    // list of options to persist, terminated with KM_CORE_OPTIONS_END
+    persist_options: pkm_core_option_item;
 
-  // issue a beep, 0 = no, 1 = yes
-  do_alert: km_core_bool;
+    // issue a beep, 0 = no, 1 = yes
+    do_alert: km_core_bool;
 
-  // emit the (unmodified) input keystroke to the application, 0 = no, 1 = yes
-  emit_keystroke: km_core_bool;
+    // emit the (unmodified) input keystroke to the application, 0 = no, 1 = yes
+    emit_keystroke: km_core_bool;
 
-  // -1=unchanged, 0=off, 1=on
-  new_caps_lock_state: km_core_caps_state;
+    // -1=unchanged, 0=off, 1=on
+    new_caps_lock_state: km_core_caps_state;
 
+    // reference copy of actual UTF32 codepoints deleted from rhs of context
+    // exactly code_points_to_delete in length (plus null terminator). Used to
+    // determine encoding conversion differences when deleting; only set when
+    // using km_core_state_actions_get, otherwise nullptr.
+    deleted_context: pkm_core_usv;
   end;
   pkm_core_actions = ^km_core_actions;
 
@@ -669,13 +675,14 @@ begin
 {$IFDEF WIN64}
   {$ERROR Struct size not yet verified for 64-bit}
 {$ENDIF}
-  assert(sizeof(km_core_actions) = 24);
+  assert(sizeof(km_core_actions) = 28);
   // &km_core_actions.code_points_to_delete: 0
   assert(Uint32(@act.output) - Uint32(@act) = 4);
   assert(Uint32(@act.persist_options) - Uint32(@act) = 8);
   assert(Uint32(@act.do_alert) - Uint32(@act) = 12);
   assert(Uint32(@act.emit_keystroke) - Uint32(@act) = 16);
   assert(Uint32(@act.new_caps_lock_state) - Uint32(@act) = 20);
+  assert(Uint32(@act.deleted_context) - Uint32(@act) = 24);
 end;
 
 initialization


### PR DESCRIPTION
Fixes #10530.

Adds the `deleted_context` member to the `km_core_actions` struct, and associated unit tests. Simplifies integration by providing the consumer with all the data they need in order to execute the transform, specifically around number of delete operations required, without needing to query the target application context again. The number of delete operations will vary according to application compliance and selected encoding; for example a UTF-16 string may require 2 delete-backs for surrogate pairs in the text buffer for a compliant app, whereas there will be a single delete-back key event for a non-compliant app.

The `deleted_context` member should also be used for debug assertions.

@keymanapp-test-bot skip