### PR TITLE
fix(linux): packaging on Ubuntu and Debian servers should give message instead of warning because we don't have patched ibus there

### DIFF
--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -33,7 +33,8 @@ override_dh_auto_configure:
 	linux/keyman-system-service/build.sh configure -- \
 		--wrap-mode=nodownload --prefix=/usr --sysconfdir=/etc --localstatedir=/var
 	linux/ibus-keyman/build.sh configure -- \
-		--wrap-mode=nodownload --prefix=/usr --sysconfdir=/etc --localstatedir=/var
+		--wrap-mode=nodownload --prefix=/usr --sysconfdir=/etc --localstatedir=/var \
+		 -Dkeyman_deb_pkg_build=true
 	linux/keyman-config/build.sh configure
 
 override_dh_auto_build:

--- a/linux/ibus-keyman/meson.build
+++ b/linux/ibus-keyman/meson.build
@@ -1,10 +1,6 @@
 project('ibus-keyman', 'c', 'cpp',
         version: run_command('cat', '../../VERSION.md', check: true).stdout().strip(),
         license: 'GPL-2+',
-        # default_options : ['buildtype=release',
-        #                    'cpp_std=c++14',
-        #                    'b_vscrt=static_from_buildtype',
-        #                    'warning_level=2'],
         meson_version: '>=0.53.0')
 cc = meson.get_compiler('c')
 conf = configuration_data()
@@ -22,6 +18,10 @@ keymancore_lib = cc.find_library(
   'keymancore', # meson will prefix 'lib'
   dirs: [ core_dir / 'build/arch' / get_option('buildtype') / 'src' ]
 )
+
+if get_option('keyman_deb_pkg_build')
+  add_global_arguments('-DKEYMAN_PKG_BUILD', language: ['cpp', 'c'])
+endif
 
 env = find_program('env')
 

--- a/linux/ibus-keyman/meson_options.txt
+++ b/linux/ibus-keyman/meson_options.txt
@@ -1,0 +1,1 @@
+option('keyman_deb_pkg_build', type: 'boolean', value: false, description: 'Building .deb package?')

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -40,7 +40,15 @@
 
 // Fallback for older ibus versions that don't define IBUS_PREFILTER_MASK
 #ifndef IBUS_HAS_PREFILTER
+#ifdef KEYMAN_PKG_BUILD
+// When building packages on Ubuntu and Debian servers we probably don't have
+// a patched ibus available and additionally treat warnings as errors, but
+// still want to build packages.
+#pragma message "Compiling against ibus version that does not include prefilter mask patch\n(https://github.com/ibus/ibus/pull/2440). Output ordering guarantees will be disabled."
+#else
 #warning Compiling against ibus version that does not include prefilter mask patch (https://github.com/ibus/ibus/pull/2440). Output ordering guarantees will be disabled.
+#endif
+
 #define IBUS_PREFILTER_MASK (1 << 23)
 #endif
 

--- a/linux/ibus-keyman/tests/ibusimcontext.c
+++ b/linux/ibus-keyman/tests/ibusimcontext.c
@@ -31,7 +31,15 @@
 #include <config.h>
 
 #ifndef IBUS_HAS_PREFILTER
+#ifdef KEYMAN_PKG_BUILD
+// When building packages on Ubuntu and Debian servers we probably don't have
+// a patched ibus available and additionally treat warnings as errors, but
+// still want to build packages.
+#pragma message "Compiling against ibus version that does not include prefilter mask patch\n(https://github.com/ibus/ibus/pull/2440). Output ordering guarantees will be disabled."
+#else
 #warning Compiling against ibus version that does not include prefilter mask patch (https://github.com/ibus/ibus/pull/2440). Output ordering guarantees will be disabled.
+#endif
+
 #define IBUS_PREFILTER_MASK (1 << 23)
 #endif
 


### PR DESCRIPTION
When building packages warnings are treated as errors. When building on Ubuntu and Debian servers we don't have a patched ibus version but still want to build the packages. So this change outputs a message instead of a warning when building packages.

@keymanapp-test-bot skip