### PR TITLE
feat(core): ldml reorder marker processing 🙀 

### DIFF
--- a/core/src/ldml/ldml_markers.cpp
+++ b/core/src/ldml/ldml_markers.cpp
@@ -58,7 +58,7 @@ bool normalize_nfd(std::u16string &str) {
   return normalize(nfd, str, status);
 }
 
-static void add_back_markers(std::u32string &str, const std::u32string &src, marker_map &map, marker_encoding encoding) {
+void add_back_markers(std::u32string &str, const std::u32string &src, marker_map &map, marker_encoding encoding) {
   // need to reconstitute.
   marker_map map2(map);  // make a copy of the map
   // clear the string

--- a/core/src/ldml/ldml_markers.cpp
+++ b/core/src/ldml/ldml_markers.cpp
@@ -61,6 +61,7 @@ bool normalize_nfd(std::u16string &str) {
 void add_back_markers(std::u32string &str, const std::u32string &src, marker_map &map, marker_encoding encoding) {
   if (map.empty()) {
     // quick check, nothing to do if no markers
+    str = src;
     return;
   }
   // need to reconstitute.

--- a/core/src/ldml/ldml_markers.cpp
+++ b/core/src/ldml/ldml_markers.cpp
@@ -59,6 +59,10 @@ bool normalize_nfd(std::u16string &str) {
 }
 
 void add_back_markers(std::u32string &str, const std::u32string &src, marker_map &map, marker_encoding encoding) {
+  if (map.empty()) {
+    // quick check, nothing to do if no markers
+    return;
+  }
   // need to reconstitute.
   marker_map map2(map);  // make a copy of the map
   // clear the string
@@ -110,9 +114,6 @@ bool normalize_nfd_markers_segment(std::u32string &str, marker_map &map, marker_
   std::u32string str_unmarked_nfd = str_unmarked;
   if(!normalize_nfd(str_unmarked_nfd)) {
     return false; // normalize failed.
-  } else if (map.size() == 0) {
-    // no markers. Return the normalized unmarked str
-    str = str_unmarked_nfd;
   } else if (str_unmarked_nfd == str_unmarked) {
     // Normalization produced no change when markers were removed.
     // So, we'll call this a no-op.

--- a/core/src/ldml/ldml_markers.hpp
+++ b/core/src/ldml/ldml_markers.hpp
@@ -93,6 +93,8 @@ void prepend_hex_quad(std::u32string &str, KMX_DWORD marker);
 /** parse 0001...FFFF into a KMX_DWORD. Returns 0 on failure */
 KMX_DWORD parse_hex_quad(const km_core_usv hex_str[]);
 
+/** re-add markers */
+void add_back_markers(std::u32string &str, const std::u32string &src, marker_map &map, marker_encoding encoding);
 
 // bool normalize_nfc_markers(std::u16string &str, marker_encoding encoding) {
 //   marker_map m;

--- a/core/src/ldml/ldml_transforms.cpp
+++ b/core/src/ldml/ldml_transforms.cpp
@@ -331,7 +331,7 @@ reorder_group::apply(std::u32string &str) const {
   /** did we match anything */
   bool some_match = false;
 
-  // markers need to 'pass thorugh' reorders. remove and re-add if needed
+  // markers need to 'pass through' reorders. remove and re-add if needed
   marker_map markers;
   std::u32string out = remove_markers(str, markers, plain_sentinel);
 
@@ -433,13 +433,7 @@ reorder_group::apply(std::u32string &str) const {
     r.dump();
   }
 #endif
-  if (markers.empty()) {
-    // no markers, just copy over to str
-    str = out;
-  } else {
-    // copy and re-add markers
-    add_back_markers(str, out, markers, plain_sentinel);
-  }
+  add_back_markers(str, out, markers, plain_sentinel);
   return true; // updated
 }
 

--- a/core/tests/unit/ldml/keyboards/k_201_reorder_esk-test.xml
+++ b/core/tests/unit/ldml/keyboards/k_201_reorder_esk-test.xml
@@ -21,4 +21,46 @@
       <check result="a\u0332\u0305xz" />
     </test>
   </tests>
+  <tests name="onekey" >
+    <!-- same as above, but a single key-->
+    <test name="1short">
+      <startContext to="" />
+      <keystroke key="test0" />
+      <check result="a\u0305x" />
+      <keystroke key="o"/>
+      <backspace />
+      <!-- no change -->
+      <check result="a\u0305x" />
+    </test>
+    <test name="2longer">
+      <startContext to="" />
+      <keystroke key="test1" />
+      <check result="a\u0332\u0305xz" />
+      <keystroke key="o"/>
+      <backspace />
+      <!-- no change -->
+      <check result="a\u0332\u0305xz" />
+    </test>
+  </tests>
+  <tests name="marker" >
+    <!-- same as above, but a single key with markers -->
+    <test name="1short">
+      <startContext to="" />
+      <keystroke key="markertest0" />
+      <check result="a\u0305x" />
+      <keystroke key="o"/>
+      <backspace />
+      <!-- no change -->
+      <check result="a\u0305x" />
+    </test>
+    <test name="2longer">
+      <startContext to="" />
+      <keystroke key="markertest1" />
+      <check result="a\u0332\u0305xz" />
+      <keystroke key="o"/>
+      <backspace />
+      <!-- no change -->
+      <check result="a\u0332\u0305xz" />
+    </test>
+  </tests>
 </keyboardTest3>

--- a/core/tests/unit/ldml/keyboards/k_201_reorder_esk.xml
+++ b/core/tests/unit/ldml/keyboards/k_201_reorder_esk.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--
-  Test Keyboard from Spec
-  see https://keyman.com/keyboards/sil_boonkit
--->
-
 <!DOCTYPE keyboard3 SYSTEM "../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard3.dtd">
 <keyboard3 locale="en-t-k0-esk" conformsTo="techpreview">
   <info author="srl295" indicator="🙀" layout="qwerty"  name="esk reorder test"/>
@@ -19,6 +14,10 @@
     <key id="overbar" output="${overbar}" />
     <key id="underbar" output="${underbar}" />
     <key id="circumflex" output="${circumflex}" />
+    <key id="test0" output="ax${overbar}" />
+    <key id="markertest0" output="a\m{m4}x\m{marker0}${overbar}" />
+    <key id="test1" output="az${overbar}x${underbar}" />
+    <key id="markertest1" output="a\m{m0}z\m{m1}${overbar}\m{m2}x\m{m3}${underbar}\m{m3}" />
   </keys>
 
   <layers formId="us">
@@ -28,6 +27,12 @@
       <row keys="a" />
       <row keys="z x" />
       <row keys="space" />
+    </layer>
+    <layer modifiers="shift">
+      <row keys="gap test0 test1" />
+    </layer>
+    <layer modifiers="altR shift">
+      <row keys="gap markertest0 markertest1" />
     </layer>
   </layers>
 


### PR DESCRIPTION
- reorders don't interact with markers, but must transit them
- add updated tests
- simplify reorder_group::apply(): the 'common prefix' discussion
was out-of-date as std::mismatch is handled by the ldml_processor
and the core context.
- add_back_markers() promoted to SPI so it can be called from reordering.

Fixes: #10516

@keymanapp-test-bot skip