### PR TITLE
fix(developer): kmc exit needs to wait for Sentry

### DIFF
--- a/developer/src/common/web/utils/src/KeymanSentry.ts
+++ b/developer/src/common/web/utils/src/KeymanSentry.ts
@@ -12,7 +12,7 @@ let isInit = false;
 
 export class KeymanSentry {
 
-  static async isEnabled() {
+  static isEnabled() {
     if(process.argv.includes('--no-error-reporting')) {
       return false;
     }

--- a/developer/src/kmc/src/commands/analyze.ts
+++ b/developer/src/kmc/src/commands/analyze.ts
@@ -7,6 +7,7 @@ import { CompilerCallbacks, CompilerLogLevel } from '@keymanapp/common-types';
 import { AnalyzeOskCharacterUse, AnalyzeOskRewritePua } from '@keymanapp/kmc-analyze';
 import { BaseOptions } from '../util/baseOptions.js';
 import { runOnFiles } from '../util/projectRunner.js';
+import { exitProcess } from '../util/sysexits.js';
 
 interface AnalysisActivityOptions /* not inheriting from CompilerBaseOptions */ {
   /**
@@ -45,7 +46,7 @@ function declareOskCharUse(command: Command) {
 
       if(!await analyze(analyzeOskCharUse, filenames, options)) {
         // Once a file fails to build, we bail on subsequent builds
-        process.exit(1);
+        await exitProcess(1);
       }
     });
 
@@ -65,7 +66,7 @@ function declareOskRewrite(command: Command) {
 
       if(!await analyze(analyzeOskRewritePua, filenames, options)) {
         // Once a file fails to build, we bail on subsequent builds
-        process.exit(1);
+        await exitProcess(1);
       }
     });
 }

--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -12,6 +12,7 @@ import { isProject } from '../util/projectLoader.js';
 import { buildTestData } from './buildTestData/index.js';
 import { buildWindowsPackageInstaller } from './buildWindowsPackageInstaller/index.js';
 import { commandOptionsToCompilerOptions } from '../util/extendedCompilerOptions.js';
+import { exitProcess } from '../util/sysexits.js';
 
 export function declareBuild(program: Command) {
   // TODO: localization?
@@ -79,7 +80,7 @@ async function buildFile(filenames: string[], _options: any, commander: any)  {
   const commanderOptions/*:{TODO?} CommandLineCompilerOptions*/ = commander.optsWithGlobals();
   const options = initialize(commanderOptions);
   if(!options) {
-    process.exit(1);
+    await exitProcess(1);
   }
 
   const callbacks = new NodeCompilerCallbacks(options);
@@ -93,17 +94,17 @@ async function buildFile(filenames: string[], _options: any, commander: any)  {
   if(filenames.length > 1 && commanderOptions.outFile) {
     // -o can only be specified with a single input file
     callbacks.reportMessage(InfrastructureMessages.Error_OutFileCanOnlyBeSpecifiedWithSingleInfile());
-    process.exit(1);
+    await exitProcess(1);
   }
 
   if(!expandFileLists(filenames, callbacks)) {
-    process.exit(1);
+    await exitProcess(1);
   }
 
   for(let filename of filenames) {
     if(!await build(filename, commanderOptions.outFile, callbacks, options)) {
       // Once a file fails to build, we bail on subsequent builds
-      process.exit(1);
+      await exitProcess(1);
     }
   }
 }

--- a/developer/src/kmc/src/commands/buildWindowsPackageInstaller/index.ts
+++ b/developer/src/kmc/src/commands/buildWindowsPackageInstaller/index.ts
@@ -4,6 +4,7 @@ import { CompilerCallbacks, defaultCompilerOptions } from '@keymanapp/common-typ
 import { NodeCompilerCallbacks } from '../../util/NodeCompilerCallbacks.js';
 import { WindowsPackageInstallerCompiler, WindowsPackageInstallerSources } from '@keymanapp/kmc-package';
 import { CommandLineBaseOptions } from 'src/util/baseOptions.js';
+import { exitProcess } from '../../util/sysexits.js';
 
 interface WindowsPackageInstallerCommandLineOptions extends CommandLineBaseOptions {
   msi: string;
@@ -38,7 +39,7 @@ export async function buildWindowsPackageInstaller(infile: string, _options: any
   const callbacks: CompilerCallbacks = new NodeCompilerCallbacks({...defaultCompilerOptions, ...options});
   const compiler = new WindowsPackageInstallerCompiler();
   if(!await compiler.init(callbacks, {...options, sources})) {
-    process.exit(1);
+    await exitProcess(1);
   }
 
   const fileBaseName = outfile ?? infile;
@@ -49,10 +50,10 @@ export async function buildWindowsPackageInstaller(infile: string, _options: any
   const result = await compiler.run(infile, outFileExe);
   if(!result) {
     // errors will have been reported already
-    process.exit(1);
+    await exitProcess(1);
   }
 
   if(!await compiler.write(result.artifacts)) {
-    process.exit(1);
+    await exitProcess(1);
   }
 }

--- a/developer/src/kmc/src/kmc.ts
+++ b/developer/src/kmc/src/kmc.ts
@@ -9,9 +9,12 @@ import { declareAnalyze } from './commands/analyze.js';
 import { KeymanSentry, loadOptions } from '@keymanapp/developer-utils';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
 import { TestKeymanSentry } from './util/TestKeymanSentry.js';
+import { exitProcess } from './util/sysexits.js';
 
 await TestKeymanSentry.runTestIfCLRequested();
-KeymanSentry.init();
+if(KeymanSentry.isEnabled()) {
+  KeymanSentry.init();
+}
 try {
   await run();
 } catch(e) {
@@ -20,7 +23,7 @@ try {
 
 // Ensure any messages reported to Sentry have had time to be uploaded before we
 // exit. In most cases, this will be a no-op so should not affect performance.
-await KeymanSentry.close();
+await exitProcess(0);
 
 async function run() {
   await loadOptions();
@@ -41,10 +44,6 @@ async function run() {
     // in launch
     .addOption(new Option('--no-error-reporting', 'Disable error reporting to keyman.com (overriding user settings)'))
     .addOption(new Option('--error-reporting', 'Enable error reporting to keyman.com (overriding user settings)'));
-
-  if(await KeymanSentry.isEnabled()) {
-    KeymanSentry.init();
-  }
 
   declareBuild(program);
   declareAnalyze(program);

--- a/developer/src/kmc/src/util/sysexits.ts
+++ b/developer/src/kmc/src/util/sysexits.ts
@@ -1,3 +1,5 @@
+import { KeymanSentry } from "@keymanapp/developer-utils";
+
 /**
  * Exit codes defined in <sysexits.h>:
  * https://www.freebsd.org/cgi/man.cgi?query=sysexits&apropos=0&sektion=0&manpath=FreeBSD+4.3-RELEASE&format=html
@@ -6,3 +8,8 @@ export const enum SysExits {
   EX_USAGE = 64,
   EX_DATAERR = 65,
 };
+
+export async function exitProcess(exitCode?: number): Promise<never> {
+  await KeymanSentry.close();
+  process.exit(exitCode);
+}


### PR DESCRIPTION
Fixes #10488:

1. Use a consistent `exitProcess()` function so that we always wait for Sentry to do its thing.
2. Make `KeymanSentry.isEnabled()` non-async because it is synchronous.
3. Remove duplicate initialization of `KeymanSentry` in kmc.ts.

@keymanapp-test-bot skip