### PR TITLE
fix(developer): make sourcePath calculation for kmc-keyboard-info more lenient

### DIFF
--- a/developer/src/kmc/src/util/calculateSourcePath.ts
+++ b/developer/src/kmc/src/util/calculateSourcePath.ts
@@ -9,9 +9,9 @@
  */
 export function calculateSourcePath(projectFilename: string): string {
   projectFilename = projectFilename.replace(/\\/g, '/');
-  const result = /([^\/]+)\/([^\/]+)\/([^\/]+)\/([^\/]+)\.kpj$/.exec(projectFilename);
+  const result = /(release|legacy|experimental)\/([^\/]+)\/([^\/]+)\/([^\/]+)\.kpj$/.exec(projectFilename);
   if (!result) {
-    throw new Error(`Invalid path ${projectFilename}`);
+    return undefined;
   }
   return `${result[1]}/${result[2]}/${result[3]}`;
 }


### PR DESCRIPTION
Fixes #10542.

The `sourcePath` attribute should only be added to a .keyboard_info file if the file is actually in an expected folder matching a pattern like `(release|legacy|experimental)/k/keyboard`.

If the path does not match that pattern, then we just omit the field in the emitted .keyboard_info or .model_info file.

@keymanapp-test-bot skip