### PR TITLE
chore(linux): Replace Lunar with Noble

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [focal, jammy, lunar, mantic]
+        dist: [focal, jammy, mantic, noble]
         arch: [amd64]
 
     runs-on: ubuntu-latest

--- a/linux/.pbuilderrc
+++ b/linux/.pbuilderrc
@@ -14,7 +14,7 @@ DEBIAN_SUITES=($UNSTABLE_CODENAME $TESTING_CODENAME $STABLE_CODENAME $STABLE_BAC
     "experimental" "unstable" "testing" "stable")
 
 # List of Ubuntu suites. Update these when needed.
-UBUNTU_SUITES=("mantic" "lunar" "jammy" "focal")
+UBUNTU_SUITES=("noble" "mantic" "jammy" "focal")
 
 # Mirrors to use. Update these to your preferred mirror.
 DEBIAN_MIRROR="deb.debian.org"

--- a/linux/scripts/cow.sh
+++ b/linux/scripts/cow.sh
@@ -3,7 +3,7 @@
 # If needed set cowbuilder up for building Keyman Debian packages
 # Then cowbuilder update
 
-distributions='focal jammy lunar mantic'
+distributions='focal jammy mantic noble'
 
 if ! dpkg-query -l cowbuilder; then
     echo "installing pbuilder and cowbuilder"

--- a/linux/scripts/deb.sh
+++ b/linux/scripts/deb.sh
@@ -11,7 +11,7 @@
 
 set -e
 
-all_distributions="focal jammy lunar mantic"
+all_distributions="focal jammy mantic noble"
 distributions=""
 echo "all_distributions: ${all_distributions}"
 

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -33,7 +33,7 @@ else
 fi
 echo "ppa: ${ppa}"
 
-distributions="${DIST:-focal jammy lunar mantic}"
+distributions="${DIST:-focal jammy mantic noble}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
This change removes Ubuntu 23.04 Lunar and adds support for Ubuntu 24.04 Noble.

@keymanapp-test-bot skip