### PR TITLE
chore(developer): add unicode-license.txt for ldml keyboards data

### DIFF
--- a/developer/src/inst/kmdev.wxs
+++ b/developer/src/inst/kmdev.wxs
@@ -203,6 +203,9 @@
         <File Id="LdmlImportReadme" Name="README.md" KeyPath="yes" />
       </Component>
       <Component>
+        <File Id="LdmlImportLicense" Name="unicode-license.txt" Source="..\..\..\resources\standards-data\ldml-keyboards\unicode-license.txt" />
+      </Component>
+      <Component>
         <File Name="keys-Latn-implied.xml" KeyPath="yes" />
       </Component>
       <Component>

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -66,7 +66,8 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action build; then
-  npm run build
+  tsc -b
+  cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/unicode-license.txt" ./build/unicode-license.txt
   builder_finish_action success build
 fi
 

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -51,7 +51,8 @@
     "supports-color": "^9.4.0"
   },
   "files": [
-    "build/src/"
+    "build/src/",
+    "build/unicode-license.txt"
   ],
   "devDependencies": {
     "@sentry/cli": "^2.19.4",

--- a/resources/standards-data/ldml-keyboards/readme.md
+++ b/resources/standards-data/ldml-keyboards/readme.md
@@ -20,3 +20,7 @@ Each directory contains:
     - change /keyboard/keys/key type to "array"
 
 - `imports/` - the importable data files (TODO-LDML)
+
+## License
+
+- [unicode-license.txt](unicode-license.txt) - Unicode license

--- a/resources/standards-data/ldml-keyboards/unicode-license.txt
+++ b/resources/standards-data/ldml-keyboards/unicode-license.txt
@@ -1,0 +1,39 @@
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2024 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.


### PR DESCRIPTION
Fixes #10491.

Called unicode-license.txt in order to disambiguate.

This PR packs the license with kmc, not kmc-ldml for now (even though kmc-ldml is available as a separate npm package). Up for discussion.

@keymanapp-test-bot skip