### PR TITLE
fix(web): app/webview control flow for initial layer

### DIFF
--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -151,7 +151,6 @@ export default class KeymanEngine<
         this.osk.startHide(false);
       }
 
-      console.log(`this.osk == ${this.osk}`);
       if(this.osk) {
         this.osk.setNeedsLayout();
         this.osk.activeKeyboard = kbd;

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -151,11 +151,17 @@ export default class KeymanEngine<
         this.osk.startHide(false);
       }
 
+      console.log(`this.osk == ${this.osk}`);
       if(this.osk) {
         this.osk.setNeedsLayout();
         this.osk.activeKeyboard = kbd;
         this.osk.present();
       }
+
+      // Needed to ensure the correct layer is displayed.
+      // Needs to be after the OSK has loaded for the keyboard in case the default
+      // layer should be something other than "default" for the current context.
+      this.core.resetContext(this.contextManager.activeTarget);
     });
 
     this.contextManager.on('keyboardasyncload', (metadata) => {


### PR DESCRIPTION
Fixes #8947.

We weren't seeing this on iOS because of a iOS-side `resetContext` call that occurred after the keyboard loads; this only occurs after dismissing the "Get Started" menu within the Android app.

## User Testing

**TEST_ANDROID_GET_STARTED_INIT**:  Using Keyman for Android as a fresh installation, verify that `sil_euro_latin` displays properly at all relevant points of initialization.

1. Remove any previous installation of Keyman.
2. Open Keyman In-App.
3. The Get Started dialog should automatically open.
4. Verify that the keyboard, if visible, is on the `shift` layer and any suggestions have a capital first letter.
5. Dismiss the Get Started dialog. 
6. Verify that the keyboard is (still) on the `shift` layer and any suggestions have a capital first letter.