### PR TITLE
chore(linux): Update symbols file with current version 🏥

### DIFF
--- a/linux/debian/libkeymancore.symbols
+++ b/linux/debian/libkeymancore.symbols
@@ -8,7 +8,7 @@ libkeymancore.so.1 libkeymancore #MINVER#
  km_core_context_items_dispose@Base 17.0.195
  km_core_context_length@Base 17.0.195
  km_core_context_set@Base 17.0.195
- km_core_cp_dispose@Base 17.0.244
+ km_core_cp_dispose@Base 17.0.263
  km_core_event@Base 17.0.195
  km_core_get_engine_attrs@Base 17.0.195
  km_core_keyboard_dispose@Base 17.0.195
@@ -22,11 +22,11 @@ libkeymancore.so.1 libkeymancore #MINVER#
  km_core_process_event@Base 17.0.195
  km_core_process_queued_actions@Base 17.0.195
  km_core_state_action_items@Base 17.0.195
- km_core_state_app_context@Base 17.0.245
+ km_core_state_app_context@Base 17.0.263
  km_core_state_clone@Base 17.0.195
  km_core_state_context@Base 17.0.195
  km_core_state_context_clear@Base 17.0.197
- km_core_state_context_debug@Base 17.0.244
+ km_core_state_context_debug@Base 17.0.263
  km_core_state_context_set_if_needed@Base 17.0.197
  km_core_state_create@Base 17.0.195
  km_core_state_debug_get@Base 17.0.195


### PR DESCRIPTION
The new API methods landed in `master` with the merge of the epic branch. This change updates the version numbers to the current version.

Closes #10567.

@keymanapp-test-bot skip