### PR TITLE
fix(linux): Fix version comparison

### DIFF
--- a/linux/ibus-keyman/src/keymanutil.c
+++ b/linux/ibus-keyman/src/keymanutil.c
@@ -212,6 +212,30 @@ get_engine_for_language(
   return engine_desc;
 }
 
+int
+keyman_compare_version(const gchar *version1str, const gchar *version2str) {
+  size_t len1 = strlen(version1str);
+  size_t len2 = strlen(version2str);
+  for (size_t i = 0, j = 0; i < len1 || j < len2; i++, j++) {
+      int version1 = 0, version2 = 0;
+
+      while (i < len1 && version1str[i] != '.') {
+        version1 = version1 * 10 + (version1str[i] - '0');
+        i++;
+      }
+      while (j < len2 && version2str[j] != '.') {
+        version2 = version2 * 10 + (version2str[j] - '0');
+        j++;
+      }
+
+      if (version1 < version2)
+        return -1;
+      if (version1 > version2)
+        return +1;
+    }
+  return 0;
+}
+
 gboolean
 keyman_list_contains_keyboard(
   GList *engines_list,
@@ -225,8 +249,7 @@ keyman_list_contains_keyboard(
     // If we already have an engine for this keyboard (in a different area), we
     // don't want to add it again since we wouldn't add anything new
     // if it's the same version
-    // TODO: fix version comparison (#9593)
-    if (g_strcmp0(kmx_file, keyboard->kmx_file) == 0 && g_strcmp0(version, keyboard->version) >= 0) {
+    if (g_strcmp0(kmx_file, keyboard->kmx_file) == 0 && keyman_compare_version(version, keyboard->version) >= 0) {
       g_debug("keyboard %s already exists at version %s which is newer or same as %s", kmx_file, version, keyboard->version);
       return TRUE;
     }

--- a/linux/ibus-keyman/src/keymanutil.c
+++ b/linux/ibus-keyman/src/keymanutil.c
@@ -212,27 +212,41 @@ get_engine_for_language(
   return engine_desc;
 }
 
-int
-keyman_compare_version(const gchar *version1str, const gchar *version2str) {
-  size_t len1 = strlen(version1str);
-  size_t len2 = strlen(version2str);
-  for (size_t i = 0, j = 0; i < len1 || j < len2; i++, j++) {
-      int version1 = 0, version2 = 0;
+int _get_version(const gchar **pver) {
+  g_assert(pver);
+  const gchar *ver = *pver;
+  int version      = 0;
 
-      while (i < len1 && version1str[i] != '.') {
-        version1 = version1 * 10 + (version1str[i] - '0');
-        i++;
-      }
-      while (j < len2 && version2str[j] != '.') {
-        version2 = version2 * 10 + (version2str[j] - '0');
-        j++;
-      }
-
-      if (version1 < version2)
-        return -1;
-      if (version1 > version2)
-        return +1;
+  while (*ver && *ver != '.') {
+    if (*ver >= '0' && *ver <= '9') {
+      version = version * 10 + (*ver - '0');
+      ver++;
+    } else {
+      // stop comparison on first non-digit
+      while (*ver)
+        ver++;
     }
+  }
+  *pver = ver;
+  return version;
+}
+
+int
+keyman_compare_version(const gchar *ver1, const gchar *ver2) {
+  for (; *ver1 || *ver2; ) {
+    int version1 = _get_version(&ver1);
+    int version2 = _get_version(&ver2);
+
+    if (version1 < version2)
+      return -1;
+    if (version1 > version2)
+      return +1;
+
+    if (*ver1)
+      ver1++;
+    if (*ver2)
+      ver2++;
+  }
   return 0;
 }
 

--- a/linux/ibus-keyman/src/keymanutil_internal.h
+++ b/linux/ibus-keyman/src/keymanutil_internal.h
@@ -42,6 +42,7 @@ void keyman_set_custom_keyboards(gchar ** keyboards);
 GHashTable * keyman_get_custom_keyboard_dictionary();
 void keyman_add_keyboard(gpointer data, gpointer user_data);
 void keyman_add_keyboards_from_dir(gpointer data, gpointer user_data);
+int keyman_compare_version(const gchar *version1, const gchar *version2);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(IBusEngineDesc, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(IBusComponent, g_object_unref)

--- a/linux/ibus-keyman/src/test/keymanutil_tests.c
+++ b/linux/ibus-keyman/src/test/keymanutil_tests.c
@@ -1033,6 +1033,41 @@ test_keyman_add_keyboards_from_dir__one_language_plus_two_different_custom() {
   g_assert_cmpstr(ibus_engine_desc_get_name(desc), ==, expected_name);
 }
 
+void
+test_keyman_compare_version_equal() {
+  g_assert_cmpint(keyman_compare_version("1.0", "1.0"), ==, 0);
+}
+
+void
+test_keyman_compare_version_equal_with_patch() {
+  g_assert_cmpint(keyman_compare_version("1.0", "1.0.0"), ==, 0);
+}
+
+void
+test_keyman_compare_version_less() {
+  g_assert_cmpint(keyman_compare_version("1.0", "1.1"), <, 0);
+}
+
+void
+test_keyman_compare_version_minor_less_with_patch() {
+  g_assert_cmpint(keyman_compare_version("1.0.1", "1.1"), <, 0);
+}
+
+void
+test_keyman_compare_version_patch_less() {
+  g_assert_cmpint(keyman_compare_version("1.0", "1.0.1"), <, 0);
+}
+
+void
+test_keyman_compare_version_less_twodigit() {
+  g_assert_cmpint(keyman_compare_version("99.9", "100"), <, 0);
+}
+
+void
+test_keyman_compare_version_greater() {
+  g_assert_cmpint(keyman_compare_version("1.10", "1.9"), >, 0);
+}
+
 //----------------------------------------------------------------------------------------------
 void
 print_usage() {
@@ -1110,10 +1145,9 @@ int main(int argc, char* argv[]) {
   g_test_add_func(
       "/keymanutil/keyman_add_keyboard/prev_engine_adding_newer_version",
       test_keyman_add_keyboard__prev_engine_adding_newer_version);
-  // #9593
-  // g_test_add_func(
-  //     "/keymanutil/keyman_add_keyboard/prev_engine_adding_newer_version_versioncompare",
-  //     test_keyman_add_keyboard__prev_engine_adding_newer_version_9593);
+  g_test_add_func(
+      "/keymanutil/keyman_add_keyboard/prev_engine_adding_newer_version_versioncompare",
+      test_keyman_add_keyboard__prev_engine_adding_newer_version_9593);
   g_test_add_func(
       "/keymanutil/keyman_add_keyboard/prev_engine_adding_older_version",
       test_keyman_add_keyboard__prev_engine_adding_older_version);
@@ -1125,6 +1159,14 @@ int main(int argc, char* argv[]) {
   g_test_add_func(
       "/keymanutil/keyman_add_keyboards_from_dir/one_language_plus_two_different_custom",
       test_keyman_add_keyboards_from_dir__one_language_plus_two_different_custom);
+
+  g_test_add_func("/keymanutil/keyman_compare_version/1.0==1.0", test_keyman_compare_version_equal);
+  g_test_add_func("/keymanutil/keyman_compare_version/1.0==1.0.0", test_keyman_compare_version_equal_with_patch);
+  g_test_add_func("/keymanutil/keyman_compare_version/1.0<1.1", test_keyman_compare_version_less);
+  g_test_add_func("/keymanutil/keyman_compare_version/1.0.1<1.1", test_keyman_compare_version_minor_less_with_patch);
+  g_test_add_func("/keymanutil/keyman_compare_version/1.0<1.0.1", test_keyman_compare_version_patch_less);
+  g_test_add_func("/keymanutil/keyman_compare_version/99.9<100",test_keyman_compare_version_less_twodigit);
+  g_test_add_func("/keymanutil/keyman_compare_version/1.10>1.9", test_keyman_compare_version_greater);
 
   // Run tests
   int retVal = g_test_run();

--- a/linux/ibus-keyman/src/test/keymanutil_tests.c
+++ b/linux/ibus-keyman/src/test/keymanutil_tests.c
@@ -1044,6 +1044,16 @@ test_keyman_compare_version_equal_with_patch() {
 }
 
 void
+test_keyman_compare_version_equal_nondigit() {
+  g_assert_cmpint(keyman_compare_version("1.1", "1.1-beta2"), ==, 0);
+}
+
+void
+test_keyman_compare_version_equal_doubledot() {
+  g_assert_cmpint(keyman_compare_version("1..2", "1.0.2"), ==, 0);
+}
+
+void
 test_keyman_compare_version_less() {
   g_assert_cmpint(keyman_compare_version("1.0", "1.1"), <, 0);
 }
@@ -1162,6 +1172,8 @@ int main(int argc, char* argv[]) {
 
   g_test_add_func("/keymanutil/keyman_compare_version/1.0==1.0", test_keyman_compare_version_equal);
   g_test_add_func("/keymanutil/keyman_compare_version/1.0==1.0.0", test_keyman_compare_version_equal_with_patch);
+  g_test_add_func("/keymanutil/keyman_compare_version/1.1==1.1-beta", test_keyman_compare_version_equal_nondigit);
+  g_test_add_func("/keymanutil/keyman_compare_version/1..2==1.0.2", test_keyman_compare_version_equal_doubledot);
   g_test_add_func("/keymanutil/keyman_compare_version/1.0<1.1", test_keyman_compare_version_less);
   g_test_add_func("/keymanutil/keyman_compare_version/1.0.1<1.1", test_keyman_compare_version_minor_less_with_patch);
   g_test_add_func("/keymanutil/keyman_compare_version/1.0<1.0.1", test_keyman_compare_version_patch_less);


### PR DESCRIPTION
Implement proper comparison of versions so that 1.10 is newer than 1.9.

Fixes #9593.

@keymanapp-test-bot skip