### PR TITLE
chore(linux): Upgrade artifacts to v4

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -101,7 +101,7 @@ jobs:
         echo "- $(find . -name keyman_\*.dsc)" >> $GITHUB_STEP_SUMMARY
 
     - name: Store source package
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
       with:
         name: keyman-srcpkg
         path: |
@@ -121,8 +121,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
       with:
+        name: keyman-srcpkg
         path: artifacts
 
     - name: Build
@@ -143,9 +144,9 @@ jobs:
         echo '```' >> $GITHUB_STEP_SUMMARY
 
     - name: Store binary packages
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
       with:
-        name: keyman-binarypkgs
+        name: keyman-binarypkgs-${{ matrix.dist }}${{ matrix.arch }}
         path: |
           artifacts/*
           !artifacts/keyman-srcpkg/
@@ -160,13 +161,12 @@ jobs:
 
     steps:
       - name: Sign packages
-        uses: sillsdev/gha-deb-signing@c85704766bdf6056e03ea2b2e761c33ed0acc187 # v0.5
+        uses: sillsdev/gha-deb-signing@a38dbde6bc9afabede5e07609105acc83c760ad4 # v0.6
         with:
-          src-pkg-path: "artifacts/keyman-srcpkg"
           src-pkg-name: "keyman_${{ needs.sourcepackage.outputs.VERSION }}-1_source.changes"
-          bin-pkg-path: "artifacts/keyman-binarypkgs"
           bin-pkg-name: "keyman_${{ needs.sourcepackage.outputs.VERSION }}-1${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}+"
-          artifacts-name: "keyman-signedpkgs"
+          artifacts-prefix: "keyman-"
+          artifacts-result-name: "keyman-signedpkgs"
           gpg-signing-key: "${{ secrets.GPG_SIGNING_KEY }}"
           debsign-keyid: "${{ secrets.DEBSIGN_KEYID }}"
 
@@ -199,7 +199,7 @@ jobs:
         echo "::endgroup::"
 
     - name: Download Artifacts
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
       with:
         name: keyman-signedpkgs
 
@@ -264,15 +264,16 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         ref: '${{ github.event.client_payload.buildSha }}'
         fetch-depth: 0
 
     - name: Download Artifacts
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
       with:
         path: artifacts
+        merge-multiple: true
 
     - name: Install devscripts
       uses: ./.github/actions/apt-install
@@ -285,13 +286,13 @@ jobs:
         PKG_NAME=libkeymancore
         ./scripts/deb-packaging.sh \
           --gha \
-          --bin-pkg "${GITHUB_WORKSPACE}/artifacts/keyman-binarypkgs/${PKG_NAME}_${{ needs.sourcepackage.outputs.VERSION }}-1${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}+jammy1_amd64.deb" \
+          --bin-pkg "${GITHUB_WORKSPACE}/artifacts/${PKG_NAME}_${{ needs.sourcepackage.outputs.VERSION }}-1${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}+jammy1_amd64.deb" \
           --git-sha "${{ github.event.client_payload.buildSha }}" \
           --git-base "${{ github.event.client_payload.baseRef }}" \
           verify 2>> $GITHUB_STEP_SUMMARY
 
     - name: Archive .symbols file
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
       with:
         name: libkeymancore.symbols
         path: linux/debian/tmp/DEBIAN/symbols


### PR DESCRIPTION
- Upgrade upload-artifact to v4.3.0
- Upgrade download-artifact to v4.1.1
- Upgrade checkout to v4.1.1
- Upgrade gha-deb-signing to v0.6

Closes #10385.

@keymanapp-test-bot skip