### PR TITLE
fix(web): handling of backspaces when left-context is empty

### DIFF
--- a/common/web/keyboard-processor/src/text/keyboardProcessor.ts
+++ b/common/web/keyboard-processor/src/text/keyboardProcessor.ts
@@ -217,12 +217,26 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
   processKeystroke(keyEvent: KeyEvent, outputTarget: OutputTarget): RuleBehavior {
     var matchBehavior: RuleBehavior;
 
+    // Before keyboard rules apply, check if the left-context is empty.
+    const nothingDeletable = outputTarget.getTextBeforeCaret().kmwLength() == 0 && outputTarget.isSelectionEmpty();
+
     // Pass this key code and state to the keyboard program
     if(this.activeKeyboard && keyEvent.Lcode != 0) {
       matchBehavior = this.keyboardInterface.processKeystroke(outputTarget, keyEvent);
     }
 
-    if(!matchBehavior || matchBehavior.triggerKeyDefault) {
+    // Final conditional component - if someone actually makes a keyboard rule that blocks output
+    // of K_BKSP with an empty left-context or does other really weird things... it's on them.
+    //
+    // We don't expect such rules to appear, but trying to override them would likely result in odd
+    // behavior in cases where such rules actually would appear.  (Though, _that_ should be caught
+    // in the keyboard-review process and heavily discouraged, so... yeah.)
+    if(nothingDeletable && keyEvent.Lcode == Codes.keyCodes.K_BKSP && matchBehavior.triggerKeyDefault) {
+      matchBehavior = this.defaultRuleBehavior(keyEvent, outputTarget, false);
+      matchBehavior.triggerKeyDefault = true;
+      // Force a single `deleteLeft`.
+      matchBehavior.transcription.transform.deleteLeft = 1;
+    } else if(!matchBehavior || matchBehavior.triggerKeyDefault) {
       // Restore the virtual key code if a mnemonic keyboard is being used
       // If no vkCode value was stored, maintain the original Lcode value.
       keyEvent.Lcode=keyEvent.vkCode || keyEvent.Lcode;

--- a/common/web/keyboard-processor/tests/node/specialized-backspace.js
+++ b/common/web/keyboard-processor/tests/node/specialized-backspace.js
@@ -1,0 +1,312 @@
+import { assert } from 'chai';
+import fs from 'fs';
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+import { Codes, KeyboardInterface, KeyboardProcessor, KeyEvent, MinimalKeymanGlobal, Mock } from '@keymanapp/keyboard-processor';
+import { NodeKeyboardLoader } from '@keymanapp/keyboard-processor/node-keyboard-loader';
+
+
+const TEST_DEVICE = {
+  formFactor: 'desktop',
+  OS: 'windows',
+  browser: 'native',
+  touchable: false
+}
+
+// Basic scaffolding necessary to use special, locally-defined test keyboards.
+const COMMON_KBD_SCRIPT_PROPS = new (function (){
+  var modCodes = Codes.modifierCodes;
+
+  this.KMINVER="10.0";
+  // this.KV left empty - we aren't doing layout stuff for this test, so it's "fine".
+  // - also this.KV.KLS
+  // - also this.KV.BK
+  this.KH='';
+  this.KM=0;
+  this.KBVER="0.0.1";
+  this.KMBM=modCodes.SHIFT /* 0x0010 */;
+  this.gs=function(t,e) {
+    return this.g_main(t,e);
+  };
+})();
+
+const DUMMIED_KEYS_KEYBOARD_SCRIPT = function keyboard_core () {
+  Object.assign(this, COMMON_KBD_SCRIPT_PROPS);
+
+  this.KI="Keyboard_dummied_keys";
+  this.KN="Dummied Keys";
+  this.g_main=function(t,e) {
+    // All keys match but do nothing.
+    return 1;
+  }
+}
+
+const DOUBLED_BKSP_KEYBOARD_SCRIPT = function keyboard_core () {
+  Object.assign(this, COMMON_KBD_SCRIPT_PROPS);
+
+  this.KI="Keyboard_doubled_backspace";
+  this.KN="Doubled Backspace";
+  this.g_main=function(t,e) {
+    var k=KeymanWeb;
+    // Standard compiled keyboards do not directly use any methods on `t`.
+    if(e.Lcode == Codes.keyCodes.K_BKSP && t.getTextBeforeCaret().kmwLength() >= 2){
+      // If the context has at least two characters, delete two.
+      k.KO(2, t, '')
+      // Our rule matched, so signal that.
+      return 1;
+    } else {
+      // All other keystrokes should result in default behavior.
+      return 0;
+    }
+  }
+}
+
+describe.only('Engine - specialized backspace handling', function() {
+  const ipaPath = require.resolve('@keymanapp/common-test-resources/keyboards/sil_ipa.js');
+  const angkorPath = require.resolve('@keymanapp/common-test-resources/keyboards/khmer_angkor.js');
+
+  let device = {
+    formFactor: 'desktop',
+    OS: 'windows',
+    browser: 'native'
+  }
+
+  let ipaWithHarness;
+  let angkorWithHarness;
+  let dummiedWithHarness;
+  let bksp2xWithHarness;
+
+  before(async () => {
+    // -- START: Standard keyboard unit test loading boilerplate --
+    let harness = new KeyboardInterface({}, MinimalKeymanGlobal);
+    let keyboardLoader = new NodeKeyboardLoader(harness);
+    let keyboard = await keyboardLoader.loadKeyboardFromPath(ipaPath);
+    // --  END:  Standard keyboard unit test loading boilerplate --
+
+    // This part provides extra assurance that the keyboard properly loaded.
+    assert.equal(keyboard.id, "Keyboard_sil_ipa");
+
+    harness.activeKeyboard = keyboard;
+    ipaWithHarness = harness;
+
+    // --------------
+
+    // -- START: Standard keyboard unit test loading boilerplate --
+    harness = new KeyboardInterface({}, MinimalKeymanGlobal);
+    keyboardLoader = new NodeKeyboardLoader(harness);
+    keyboard = await keyboardLoader.loadKeyboardFromPath(angkorPath);
+    // --  END:  Standard keyboard unit test loading boilerplate --
+
+    // This part provides extra assurance that the keyboard properly loaded.
+    assert.equal(keyboard.id, "Keyboard_khmer_angkor");
+
+    harness.activeKeyboard = keyboard;
+    angkorWithHarness = harness;
+
+    // --------------
+
+    harness = new KeyboardInterface(globalThis, MinimalKeymanGlobal);
+    harness.install();
+    // Sets the keyboard as the harness's "loaded" keyboard, but not "active".
+    harness.KR(new DUMMIED_KEYS_KEYBOARD_SCRIPT());
+    harness.activeKeyboard = harness.loadedKeyboard;
+    assert.isOk(harness.activeKeyboard);
+    dummiedWithHarness = harness;
+
+    // --------------
+
+    harness = new KeyboardInterface(globalThis, MinimalKeymanGlobal);
+    harness.install();
+    // Sets the keyboard as the harness's "loaded" keyboard, but not "active".
+    harness.KR(new DOUBLED_BKSP_KEYBOARD_SCRIPT());
+    harness.activeKeyboard = harness.loadedKeyboard;
+    assert.isOk(harness.activeKeyboard);
+    bksp2xWithHarness = harness;
+  });
+
+  it('empty context, positional keyboard', () => {
+    let contextSource = new Mock('');
+    let event = new KeyEvent({
+      Lcode: Codes.keyCodes.K_BKSP,
+      Lmodifiers: 0,
+      Lstates: Codes.modifierCodes.NO_CAPS | Codes.modifierCodes.NO_NUM_LOCK | Codes.modifierCodes.NO_SCROLL_LOCK,
+      LisVirtualKey: true,
+      kName: '',
+      vkCode: Codes.keyCodes.K_BKSP,
+      device: device
+    });
+
+    const processor = new KeyboardProcessor(TEST_DEVICE, {
+      keyboardInterface: angkorWithHarness
+    });
+    const result = processor.processKeystroke(event, contextSource);
+
+    assert.isTrue(result.triggerKeyDefault);
+    assert.equal(contextSource.getTextBeforeCaret(), '');
+    assert.equal(contextSource.getTextAfterCaret(), '');
+    assert.isOk(result?.transcription?.transform);
+
+    const transform = result.transcription.transform;
+    assert.equal(transform.insert, '');
+    assert.equal(transform.deleteLeft, 1);
+    assert.isNotOk(transform.deleteRight);
+  });
+
+  it("empty context, positional keyboard, outputless-key that's not BKSP", () => {
+    let contextSource = new Mock('');
+    let event = new KeyEvent({
+      Lcode: Codes.keyCodes.K_A,
+      Lmodifiers: 0,
+      Lstates: Codes.modifierCodes.NO_CAPS | Codes.modifierCodes.NO_NUM_LOCK | Codes.modifierCodes.NO_SCROLL_LOCK,
+      LisVirtualKey: true,
+      kName: '',
+      vkCode: Codes.keyCodes.K_A,
+      device: device
+    });
+
+    // A specialized test keyboard that handles keys without emitting any content.
+    // We want to ensure error cases without output, on null context, don't act
+    // like backspaces.
+    const processor = new KeyboardProcessor(TEST_DEVICE, {
+      keyboardInterface: dummiedWithHarness
+    });
+    const result = processor.processKeystroke(event, contextSource);
+
+    // Did match a keyboard rule.
+    assert.isFalse(result.triggerKeyDefault);
+    assert.equal(contextSource.getTextBeforeCaret(), '');
+    assert.equal(contextSource.getTextAfterCaret(), '');
+    assert.isOk(result?.transcription?.transform);
+
+    const transform = result.transcription.transform;
+    assert.equal(transform.insert, '');
+    // Does not trigger backspace-like behavior.
+    assert.equal(transform.deleteLeft, 0);
+    assert.isNotOk(transform.deleteRight);
+  });
+
+  it('empty left-context, positional keyboard', () => {
+    let contextSource = new Mock('post-caret text', 0);
+    let event = new KeyEvent({
+      Lcode: Codes.keyCodes.K_BKSP,
+      Lmodifiers: 0,
+      Lstates: Codes.modifierCodes.NO_CAPS | Codes.modifierCodes.NO_NUM_LOCK | Codes.modifierCodes.NO_SCROLL_LOCK,
+      LisVirtualKey: true,
+      kName: '',
+      vkCode: Codes.keyCodes.K_BKSP,
+      device: device
+    });
+
+    const processor = new KeyboardProcessor(TEST_DEVICE, {
+      keyboardInterface: angkorWithHarness
+    });
+    const result = processor.processKeystroke(event, contextSource);
+
+    assert.isTrue(result.triggerKeyDefault);
+    assert.equal(contextSource.getTextBeforeCaret(), '');
+    assert.equal(contextSource.getTextAfterCaret(), 'post-caret text');
+    assert.isOk(result?.transcription?.transform);
+
+    const transform = result.transcription.transform;
+    assert.equal(transform.insert, '');
+    assert.equal(transform.deleteLeft, 1);
+    assert.isNotOk(transform.deleteRight);
+  });
+
+  it('empty context, mnemonic keyboard', () => {
+    let contextSource = new Mock('');
+    let event = new KeyEvent({
+      Lcode: Codes.keyCodes.K_BKSP,
+      Lmodifiers: 0,
+      Lstates: Codes.modifierCodes.NO_CAPS | Codes.modifierCodes.NO_NUM_LOCK | Codes.modifierCodes.NO_SCROLL_LOCK,
+      LisVirtualKey: true,
+      kName: '',
+      vkCode: Codes.keyCodes.K_BKSP,
+      device: device
+    });
+
+    const processor = new KeyboardProcessor(TEST_DEVICE, {
+      keyboardInterface: ipaWithHarness
+    });
+    const result = processor.processKeystroke(event, contextSource);
+
+    assert.isTrue(result.triggerKeyDefault);
+    assert.equal(contextSource.getTextBeforeCaret(), '');
+    assert.equal(contextSource.getTextAfterCaret(), '');
+    assert.isOk(result?.transcription?.transform);
+
+    const transform = result.transcription.transform;
+    assert.equal(transform.insert, '');
+    assert.equal(transform.deleteLeft, 1);
+    assert.isNotOk(transform.deleteRight);
+  });
+
+  it('final empty context, positional keyboard, rule-handled BKSP', () => {
+    let contextSource = new Mock('abc', 2);
+    let event = new KeyEvent({
+      Lcode: Codes.keyCodes.K_BKSP,
+      Lmodifiers: 0,
+      Lstates: Codes.modifierCodes.NO_CAPS | Codes.modifierCodes.NO_NUM_LOCK | Codes.modifierCodes.NO_SCROLL_LOCK,
+      LisVirtualKey: true,
+      kName: '',
+      vkCode: Codes.keyCodes.K_BKSP,
+      device: device
+    });
+
+    // A specialized test keyboard that duplicates backspaces when sufficient
+    // context exists.
+
+    const processor = new KeyboardProcessor(TEST_DEVICE, {
+      keyboardInterface: bksp2xWithHarness
+    });
+    const result = processor.processKeystroke(event, contextSource);
+
+    // Did match a keyboard rule.
+    assert.isFalse(result.triggerKeyDefault);
+    assert.equal(contextSource.getTextBeforeCaret(), '');
+    assert.equal(contextSource.getTextAfterCaret(), 'c');
+    assert.isOk(result?.transcription?.transform);
+
+    const transform = result.transcription.transform;
+    assert.equal(transform.insert, '');
+    // Triggered keyboard's backspace behavior, not special started-as-null behavior.
+    // (Ensure that _ending_ with empty context doesn't overwrite a rule that gets us there.)
+    assert.equal(transform.deleteLeft, 2);
+    assert.isNotOk(transform.deleteRight);
+  });
+
+  // Special case:  BKSP rule-matches with empty left-context.
+  it("empty context, positional keyboard, outputless BKSP rule", () => {
+    let contextSource = new Mock('');
+    let event = new KeyEvent({
+      Lcode: Codes.keyCodes.K_BKSP,
+      Lmodifiers: 0,
+      Lstates: Codes.modifierCodes.NO_CAPS | Codes.modifierCodes.NO_NUM_LOCK | Codes.modifierCodes.NO_SCROLL_LOCK,
+      LisVirtualKey: true,
+      kName: '',
+      vkCode: Codes.keyCodes.K_BKSP,
+      device: device
+    });
+
+    // A specialized test keyboard that handles keys without emitting any content.
+    // We want to ensure error cases without output, on null context, don't act
+    // like backspaces.
+    const processor = new KeyboardProcessor(TEST_DEVICE, {
+      keyboardInterface: dummiedWithHarness
+    });
+    const result = processor.processKeystroke(event, contextSource);
+
+    assert.isFalse(result.triggerKeyDefault);
+    assert.equal(contextSource.getTextBeforeCaret(), '');
+    assert.equal(contextSource.getTextAfterCaret(), '');
+    assert.isOk(result?.transcription?.transform);
+
+    const transform = result.transcription.transform;
+    assert.equal(transform.insert, '');
+    // Does not trigger backspace-like behavior because of the keyboard's rule.
+    assert.equal(transform.deleteLeft, 0);
+    assert.isNotOk(transform.deleteRight);
+  });
+});


### PR DESCRIPTION
Addresses the core aspect of #10204 on the Web side - the fact that backspaces weren't being passed through when Web sees an empty app-context.

This is also enough to heavily mitigate the main issue; a personal test of the test-artifact from this PR was able to delete the _entirety_ of the following text with a single held backspace.  (Keyman system keyboard, Notes app - just to be clear.)

```
Testing testing one two three one two three

Even more random text typed here. Lots and lots and lots of text. Like, way too much text. I want to trigger a context window, and we're going to make certain of it.

And yeah, another one to be safe. Gonna start within this one, so I can fall back on the last one and see if it triggers across THOSE boundaries. That could totally happen, right?
```

Before, it wouldn't even make it to the beginning of the final paragraph.  (Starting from after the context-final `?`, of course.)

I did see the `shift` layer flash in a few times during deletion, so there is still that aspect, at a minimum, to correct.  Upon further examination... it was pretty much always at sentence breaks on my personal device, at which point it _should_ have been showing the `shift` layer anyway!  On my personal device, anyway.

## User Testing

**TEST_LONG_DELETION**:  Using the iOS Keyman app on a real iPhone or iPad, delete a _lot_ of pre-existing text from within a third-party application.

1. Ensure that Keyman is enabled for use as a system keyboard.
2. Open a third party application **and swap to the default iOS system keyboard**.
3. Visit this PR's page on the test device and copy the full text from the code box above.  ("`Testing testing`...")
4. Open the Notes app and create a new note.
5. Paste the text copied from this PR's page as the content of the new note.
6. Use the globe key keyboard-selection menu to **activate Keyman as your system keyboard**.
7. Hold down BKSP until no further deletions occur.
8. If any visible text remains that refuses to be deleted, FAIL this test.

This test can be done on Simulator by using the Messages app instead and selecting one of the sample contacts.  The Notes app is typically not available for Simulator-based iOS devices.  (Notes doesn't come with the risk of butt-texting, though.)