### PR TITLE
chore(common): cancel earlier builds when new test builds triggered

### DIFF
--- a/resources/build/ci/cancel-builds/cancel-test-builds.mjs
+++ b/resources/build/ci/cancel-builds/cancel-test-builds.mjs
@@ -65,16 +65,26 @@ async function cancelRunningBuild(id, buildTypeId) {
   }
 }
 
-const data = await getQueuedBuilds();
-for(const build of data.build) {
-  if(allTestBuildConfigurations.includes(build.buildTypeId) && build.branchName == branchName) {
-    await cancelQueuedBuild(build.id, build.buildTypeId);
+try {
+  const queuedBuilds = await getQueuedBuilds();
+  if(queuedBuilds) {
+    for(const build of queuedBuilds.build) {
+      if(allTestBuildConfigurations.includes(build.buildTypeId) && build.branchName == branchName) {
+        await cancelQueuedBuild(build.id, build.buildTypeId);
+      }
+    }
   }
-}
 
-const runningBuilds = await getRunningBuilds();
-for(const build of runningBuilds.build) {
-  if(allTestBuildConfigurations.includes(build.buildTypeId) && build.branchName == branchName) {
-    await cancelRunningBuild(build.id, build.buildTypeId);
+  const runningBuilds = await getRunningBuilds();
+  if(runningBuilds) {
+    for(const build of runningBuilds.build) {
+      if(allTestBuildConfigurations.includes(build.buildTypeId) && build.branchName == branchName) {
+        await cancelRunningBuild(build.id, build.buildTypeId);
+      }
+    }
   }
+} catch(e) {
+  // we don't want to fail a trigger because of a hiccup in this script
+  console.trace(e);
+  process.exit(0);
 }

--- a/resources/build/ci/cancel-builds/cancel-test-builds.mjs
+++ b/resources/build/ci/cancel-builds/cancel-test-builds.mjs
@@ -1,0 +1,80 @@
+import { testBuildConfigurations } from './trigger_definitions.mjs';
+
+if(process.argv.length != 4) {
+  console.error('Invalid parameters!');
+  console.error('Usage: node cancel-test-builds.mjs PR|branch TEAMCITY_TOKEN');
+  console.error('  PR number should be a pull request number, without preceding #');
+  console.error('  branch can be one of master, beta or stable-x.y, where x.y is a stable release');
+  process.exit(1);
+}
+
+const allTestBuildConfigurations = Object.keys(testBuildConfigurations).flatMap(item => testBuildConfigurations[item]);
+const branchName = process.argv[2];
+const authorizationHeader = "Bearer "+process.argv[3];
+
+console.log(`Cancelling all queued and running test builds for ${branchName}`);
+
+async function getTeamCity(api) {
+  const response = await fetch('https://build.palaso.org/app/rest/'+api, {
+    headers: {
+      "Authorization": authorizationHeader,
+      "Accept": "application/json"
+    }
+  });
+  if(!response.ok) {
+    return null;
+  }
+  return await response.json();
+}
+
+async function postTeamCity(api, body) {
+  const response = await fetch('https://build.palaso.org/app/rest/'+api, {
+    method: 'POST',
+    headers: {
+      "Authorization": authorizationHeader,
+      "Content-Type": "application/json",
+    },
+    body: body
+  });
+  if(!response.ok) {
+    console.warn(`API ${api} failed with HTTP/${response.status}: ${response.statusText}`);
+    return null;
+  }
+  return true;
+}
+
+async function getQueuedBuilds() {
+  return await getTeamCity('buildQueue?locator=count:200');
+}
+
+async function cancelQueuedBuild(id, buildTypeId) {
+  console.log(`Cancelling queued build ${id} on ${branchName} for ${buildTypeId}`);
+  if(await postTeamCity('buildQueue/id:'+id, `{ "buildCancelRequest": { "comment": "Cancelling build due to new commits on branch.", "readdIntoQueue": "false" } }`)) {
+    console.log('  Build successfully cancelled.');
+  }
+}
+
+async function getRunningBuilds() {
+  return await getTeamCity('builds?locator=running:true,count:200');
+}
+
+async function cancelRunningBuild(id, buildTypeId) {
+  console.log(`Cancelling running build ${id} on ${branchName} for ${buildTypeId}`);
+  if(await postTeamCity('builds/id:'+id, `{ "buildCancelRequest": { "comment": "Cancelling build due to new commits on branch.", "readdIntoQueue": "false" } }`)) {
+    console.log('  Build successfully cancelled.');
+  }
+}
+
+const data = await getQueuedBuilds();
+for(const build of data.build) {
+  if(allTestBuildConfigurations.includes(build.buildTypeId) && build.branchName == branchName) {
+    await cancelQueuedBuild(build.id, build.buildTypeId);
+  }
+}
+
+const runningBuilds = await getRunningBuilds();
+for(const build of runningBuilds.build) {
+  if(allTestBuildConfigurations.includes(build.buildTypeId) && build.branchName == branchName) {
+    await cancelRunningBuild(build.id, build.buildTypeId);
+  }
+}

--- a/resources/build/ci/cancel-builds/trigger_definitions.mjs
+++ b/resources/build/ci/cancel-builds/trigger_definitions.mjs
@@ -1,0 +1,15 @@
+// Maps to trigger-definitions.inc.sh and must be kept in sync
+export const testBuildConfigurations = {
+  'android': ['KeymanAndroid_TestPullRequests', 'KeymanAndroid_TestSamplesAndTestProjects'],
+  'ios': ['Keyman_iOS_TestPullRequests', 'Keyman_iOS_TestSamplesAndTestProjects'],
+  'linux': ['KeymanLinux_TestPullRequests', 'Keyman_Linux_Test_Integration', 'Keyman_Common_KPAPI_TestPullRequests_Linux', 'deb-pr-packaging_GitHub'],
+  'mac': ['Keyman_KeymanMac_PullRequests', 'Keyman_Common_KPAPI_TestPullRequests_macOS'],
+  'windows': ['KeymanDesktop_TestPullRequests', 'KeymanDesktop_TestPrRenderOnScreenKeyboards', 'Keyman_Common_KPAPI_TestPullRequests_Windows'],
+  'web': ['Keymanweb_TestPullRequests', 'Keyman_Common_LMLayer_TestPullRequests', 'Keyman_Common_KPAPI_TestPullRequests_WASM'],
+  'developer': ['Keyman_Developer_Test'],
+
+  'common_web': ['Keyman_Test_Common_Web'],
+  'common_windows': ['Keyman_Test_Common_Windows'],
+  'common_mac': ['Keyman_Test_Common_Mac'],
+  'common_linux': ['Keyman_Test_Common_Linux'],
+};

--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -49,6 +49,9 @@ function triggerTestBuilds() {
   local branch="$2"
   local force="${3:-false}"
 
+  # Cancel any already running builds for this branch
+  node "$THIS_SCRIPT_PATH/ci/cancel-builds/cancel-test-builds.mjs" "$branch" "$TEAMCITY_TOKEN"
+
   for platform in "${platforms[@]}"; do
     echo "# $platform: checking for changes"
     eval test_builds='(${'bc_test_$platform'[@]})'

--- a/resources/build/trigger-definitions.inc.sh
+++ b/resources/build/trigger-definitions.inc.sh
@@ -2,6 +2,9 @@
 #
 # This file maps specific paths to build triggers
 #
+# Maps to ci/cancel-builds/trigger-definitions.mjs and must be kept in sync
+#
+
 
 available_platforms=(android common_web common_windows common_mac common_linux ios linux mac web windows developer)
 


### PR DESCRIPTION
Fixes #10590.

Cancels existing running or queued test builds on TeamCity when a new build is started for the same 'branch' (aka branch or PR).

Does not touch release builds or other projects -- only touches recognized test build configurations.

I'm not sure why this isn't a standard parameter for TeamCity builds, but cannot find anything about it anywhere.

@keymanapp-test-bot skip