### PR TITLE
chore(linux): Use correct format specifier for `g_utf8_strlen`

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -237,7 +237,7 @@ get_context_debug(IBusEngine *engine) {
 static gchar *
 debug_utf8_with_codepoints(const gchar *utf8) {
   GString *output = g_string_new("");
-  g_string_append_printf(output, "|%s| len:%zu) [", utf8, g_utf8_strlen(utf8, -1));
+  g_string_append_printf(output, "|%s| len:%ld) [", utf8, g_utf8_strlen(utf8, -1));
   gunichar2 *utf16 = g_utf8_to_utf16(utf8, -1, NULL, NULL, NULL);
   for (int i = 0; utf16[i] != '\0'; i++) {
     g_string_append_printf(output, "U+%04x ", utf16[i]);


### PR DESCRIPTION
The package build on armhf failed because of the wrong format specifier which expects a `size_t` instead of `glong` that `g_utf8_strlen` returns.

@keymanapp-test-bot skip