### PR TITLE
fix(linux): Fix path to artifacts when uploading to llso

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -241,15 +241,12 @@ jobs:
         esac
 
         echo -e "::group::${COLOR_GREEN}Upload source package"
-        cd keyman-srcpkg
-
         dput_retry -U llso:ubuntu/jammy${destination} *_source.changes
         echo "::endgroup::"
 
         echo -e "::group::${COLOR_GREEN}Uploading binary packages"
-        cd ../keyman-binarypkgs
         pattern="keyman_${{ needs.sourcepackage.outputs.VERSION }}.+\+(.*)[0-9]_[^.]+.changes"
-        for f in *.changes; do
+        for f in *_amd64.changes; do
           if [[ $f =~ $pattern ]]; then
             dist=${BASH_REMATCH[1]}
             dput_retry -U llso:ubuntu/${dist}${destination} $f


### PR DESCRIPTION
With the new download-artifact version when using `merge-multiple:true` all artifacts end up in the same directory. This change adjusts for that.

Another follow-up of #10577.

Fixes #10613.

@keymanapp-test-bot skip