### PR TITLE
fix(android/app): Cleanup AndroidManifest handling of *.kmp

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -103,6 +103,9 @@
         <data
           android:mimeType="application/octet-stream"
           android:scheme="content" />
+        <data
+          android:mimeType="application/x-keyman-package"
+          android:scheme="content" />
       </intent-filter>
 
       <!--
@@ -121,19 +124,7 @@
 
         <data android:scheme="file" />
         <data android:host="*" />
-
-        <!--
-                     Work around Android's ugly primitive PatternMatcher
-                     implementation that can't cope with finding a . early in
-                     the path unless it's explicitly matched.
-                -->
-        <data android:pathPattern=".*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\..*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.kmp" />
+        <data android:pathPattern="/.*\\.kmp" />
       </intent-filter>
 
       <!--
@@ -154,19 +145,7 @@
         <data android:scheme="file" />
         <data android:host="*" />
         <data android:mimeType="*/*" />
-
-        <!--
-                     Work around Android's ugly primitive PatternMatcher
-                     implementation that can't cope with finding a . early in
-                     the path unless it's explicitly matched.
-                -->
-        <data android:pathPattern=".*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\..*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.kmp" />
-        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.kmp" />
+        <data android:pathPattern="/.*\\.kmp" />
       </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
@@ -177,11 +156,11 @@
         <!-- http:// and  https:// protocols -->
         <data
           android:host="*"
-          android:pathPattern=".*\\.kmp"
+          android:pathPattern="/.*\\.kmp"
           android:scheme="http" />
         <data
           android:host="*"
-          android:pathPattern=".*\\.kmp"
+          android:pathPattern="/.*\\.kmp"
           android:scheme="https" />
       </intent-filter>
 


### PR DESCRIPTION
Fixes #10095 
This PR cleans up the AndroidManifest.xml file for associating .kmp files with Keyman.

The Play Store was flagging an error:
> <data> tag failed
Add a "/" to the beginning of the android:path attribute in the <data> tag. The attribute might also be android:pathPrefix or android:pathPattern.

Additional AndroidManifest.xml cleanup
* Remove the ugly Android pattern matcher
* Add mimeType x-keyman-package which matches the mimeType from `curl -I  https://downloads.keyman.com/keyboards/fv_all/12.6/fv_all.kmp`


Things to address on separate PR's:
* Samsung devices with MyFiles explorer (#10133)
* Granular media permissions on Android 13.0+ (Reference https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions)


## User Testing
Verifies that kmp files can be downloaded and installed with Keyman for Android

**Setup** - On an Android device/emulator, install the PR build of Keyman for Android. Note the limitations above. Do not use the following:
* Samsung device
* device/emulator of Android 13.0+ (SDK 33+)

* **TEST_KEYMAN_SEARCH** - Verifies kmp files install from Keyman search
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. In Keyman settings, Install a keyboard from keyman.com (e.g. khmer_angkor)
3. Verify khmer_angkor.kmp is downloaded and installed

* **TEST_DOWNLOADS** - Verifies kmp files can be installed from Chrome Downloads
1. Launch Chrome
2. From Chrome, download sil_cameroon_qwerty from https://downloads.keyman.com/keyboards/sil_cameroon_qwerty/6.1.0/sil_cameroon_qwerty.kmp
3. When sil_cameroon_qwerty.kmp is done downloading, go to Chrome --> Downloads
4. From the Downloads app, select sil_cameroon_qwerty.kmp
5. Verify keyboard install wizard appears (you may be prompted to first choose Keyman to handle kmp)
6. Complete the keyboard installation
7. Verify sil_cameroon_qwerty is installed.