### PR TITLE
fix(web): app/webview sourcemap inlining

### DIFF
--- a/web/src/tools/building/sourcemap-root/index.ts
+++ b/web/src/tools/building/sourcemap-root/index.ts
@@ -99,7 +99,7 @@ if(sourceRoot) {
 srcMap.toFile(mapFile);
 
 if(shouldInline) {
-  const mapToInline = SourcemapRemapper.fromFile(mapFile).sourceRoot;
+  const mapToInline = SourcemapRemapper.fromFile(mapFile).sourceMap;
   const inlineableComment = convertSourceMap.fromObject(mapToInline).toComment();
 
   fs.appendFileSync(scriptFile, `\n${inlineableComment}`);


### PR DESCRIPTION
When inlining a sourcemap, it's important to inline the _map_, not just one narrow field of it.

Not sure how I missed the error back when making and merging #10413, which introduced the inlining code, but at least this should fix it moving forward.

@keymanapp-test-bot skip