### PR TITLE
fix(ios): long-held backspace handling

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -315,9 +315,6 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     let updater = { (_ before: String, _ after: String) -> Void in
       let contextWindowText = "\(before)\(after)"
 
-      // On the KMW app/webview side, `location` is SMP-aware.
-      // .utf16:  treats SMPs as two char.  (Tested with U+1D5BA)
-      // Without .utf16 - treats SMPs as one char.
       let range = NSRange(location: before.unicodeScalars.count, length: 0)
 
       self.setContextState(text: contextWindowText, range: range)
@@ -602,6 +599,13 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     keymanWeb.setSentryState(enabled: enabled)
   }
 
+  /**
+   * Facilitates context synchronization with the KMW-app/webview side.
+   *
+   * The range's components should be SMP-aware, as the embedded engine
+   * will be expecting SMP-aware measurements.  Swift's `.unicodeScalars`
+   * property on `String`s lines up best with this.
+   */
   func setContextState(text: String?, range: NSRange) {
     // Check for any LTR or RTL marks at the context's start; if they exist, we should
     // offset the selection range.

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -341,7 +341,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
        * there's no guarantee (yet) that the times will be the same.
        * But something refresh-rate related is a fairly reasonable assumption.
        */
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.033) { //0.033) {  // contrast:  held backspace - every 0.1.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.033) { // 33 msec; contrast: held backspace - every 100 msec.
 
         // Does NOT update after half a second if there's no context manipulation.
         let preCaretAsyncContext = self.textDocumentProxy.documentContextBeforeInput ?? ""

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -342,7 +342,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
        * there's no guarantee (yet) that the times will be the same.
        * But something refresh-rate related is a fairly reasonable assumption.
        */
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.33) { //0.033) {  // contrast:  held backspace - every 0.1.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.033) { //0.033) {  // contrast:  held backspace - every 0.1.
 
         // Does NOT update after half a second if there's no context manipulation.
         let preCaretAsyncContext = self.textDocumentProxy.documentContextBeforeInput ?? ""

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -327,19 +327,23 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     updater(preCaretContext, postCaretContext)
 
     if preCaretContext == "" {
-      // 33ms seemed sufficient.  Can we go lower? (~30 Hz rate)
-      // Success with 20ms. (50 Hz rate)
-      // 1ms is not sufficient, nor is 10ms.   :(
-      // Note:  these notes were taken via Simulator, not on a physical device;
-      // there's no guarantee (yet) that the times will be the same.
-      // But something refresh-rate related is a fairly reasonable assumption.
+      /* The `textDocumentProxy` abstraction is documented (in passing) as involving
+       * inter-process communication.  It is thus asynchronous.  Despite all attempts to prod
+       * it, the context window is only ever updated if an attempt to make an actual *edit*
+       * outside of the context window occurs.  The first such edit will NOT have
+       * available synchronous data... but a bit of an async wait will usually succeed in
+       * getting the update.
+       *
+       * 33ms seemed sufficient.  Can we go lower? (~30 Hz rate)
+       * Success with 20ms. (50 Hz rate)
+       * 1ms is not sufficient, nor is 10ms.   :(
+       *
+       * Note:  these notes were taken via Simulator, not on a physical device;
+       * there's no guarantee (yet) that the times will be the same.
+       * But something refresh-rate related is a fairly reasonable assumption.
+       */
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.33) { //0.033) {  // contrast:  held backspace - every 0.1.
 
-        // if currentPostContext != postCaretContext {
-        //   // We probably reached the TRUE beginning of context, meaning the initial
-        //   // relocate by -1 failed.  So, we need to undo the +1 that DID succeed.
-        //   self.textDocumentProxy.adjustTextPosition(byCharacterOffset: -1)
-        // }
         // Does NOT update after half a second if there's no context manipulation.
         let preCaretAsyncContext = self.textDocumentProxy.documentContextBeforeInput ?? ""
         let postCaretAsyncContext = self.textDocumentProxy.documentContextAfterInput ?? ""

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -144,7 +144,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   var isSystemKeyboard: Bool {
     return _isSystemKeyboard;
   }
-  
+
   // Constraints dependent upon the device's current rotation state.
   // For now, should be mostly upon keymanWeb.view.heightAnchor.
   var portraitConstraint: NSLayoutConstraint?
@@ -170,14 +170,14 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   var expandedHeight: CGFloat {
     return keymanWeb.keyboardHeight + activeTopBarHeight
   }
-  
+
   public convenience init() {
     // iOS will call this constructor to initialize the system keyboard app extension.
     // It's safe and there will only ever be one active instance of this class within process scope.
     // See https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionOverview.html
     self.init(forSystem: true)
   }
-  
+
   public convenience init(forSystem: Bool) {
     // In-app uses of the keyboard should call this constructor for simplicity, setting `forSystem`=`false`.
     self.init(nibName: nil, bundle: nil)
@@ -189,7 +189,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     _isSystemKeyboard = true
     keymanWeb = KeymanWebViewController(storage: Storage.active)
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    
+
     addChild(keymanWeb)
   }
 
@@ -202,7 +202,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
 
     super.updateViewConstraints()
   }
-  
+
   open override func loadView() {
     let baseView = CustomInputView(frame: CGRect.zero, innerVC: keymanWeb, inputViewStyle: .keyboard)
     baseView.backgroundColor = Colors.keyboardBackground
@@ -294,18 +294,61 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       self.swallowBackspaceTextChange = false
       return
     }
-    
+
     let contextBeforeInput = textDocumentProxy.documentContextBeforeInput ?? ""
     let selection = textDocumentProxy.selectedText ?? ""
     let contextAfterInput = textDocumentProxy.documentContextAfterInput ?? ""
     let context = "\(contextBeforeInput)\(selection)\(contextAfterInput)"
-    let bLength = contextBeforeInput.utf16.count
-    let sLength = selection.utf16.count
+    let bLength = contextBeforeInput.count
+    let sLength = selection.count
     setContextState(text: context, range: NSMakeRange(bLength, sLength))
     // Within the app, this is triggered after every keyboard input.
     // We should NOT call .resetContext() here for this reason.
   }
-  
+
+  // Pre-condition:  no text is selected.  As this is currently only called by `insertText`
+  // below, this condition is met.
+  func sendContextUpdate() {
+    let preCaretContext = textDocumentProxy.documentContextBeforeInput ?? ""
+    let postCaretContext = textDocumentProxy.documentContextAfterInput ?? ""
+
+    let updater = { (_ before: String, _ after: String) -> Void in
+      let contextWindowText = "\(before)\(after)"
+
+      // On the KMW app/webview side, `location` is SMP-aware.
+      // .utf16:  treats SMPs as two char.  (Tested with U+1D5BA)
+      // Without .utf16 - treats SMPs as one char.
+      let range = NSRange(location: before.count, length: 0)
+
+      os_log("setContextState(text: `%@`, range initializer location: %d, range.location: %d", log: KeymanEngineLogger.engine, type: .debug, contextWindowText, before.count, range.location)
+      self.setContextState(text: contextWindowText, range: range)
+    }
+
+    updater(preCaretContext, postCaretContext)
+
+    if preCaretContext == "" {
+      // 33ms seemed sufficient.  Can we go lower? (~30 Hz rate)
+      // Success with 20ms. (50 Hz rate)
+      // 1ms is not sufficient, nor is 10ms.   :(
+      // Note:  these notes were taken via Simulator, not on a physical device;
+      // there's no guarantee (yet) that the times will be the same.
+      // But something refresh-rate related is a fairly reasonable assumption.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.33) { //0.033) {  // contrast:  held backspace - every 0.1.
+
+        // if currentPostContext != postCaretContext {
+        //   // We probably reached the TRUE beginning of context, meaning the initial
+        //   // relocate by -1 failed.  So, we need to undo the +1 that DID succeed.
+        //   self.textDocumentProxy.adjustTextPosition(byCharacterOffset: -1)
+        // }
+        // Does NOT update after half a second if there's no context manipulation.
+        let preCaretAsyncContext = self.textDocumentProxy.documentContextBeforeInput ?? ""
+        let postCaretAsyncContext = self.textDocumentProxy.documentContextAfterInput ?? ""
+
+        updater(preCaretAsyncContext, postCaretAsyncContext)
+      }
+    }
+  }
+
   func insertText(_ keymanWeb: KeymanWebViewController, numCharsToDelete: Int, newText: String) {
     if keymanWeb.isSubKeysMenuVisible {
       return
@@ -318,9 +361,9 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       isInputClickSoundEnabled = false
       perform(#selector(self.enableInputClickSound), with: nil, afterDelay: 0.1)
     }
-    
+
     var hasDeletedSelection = false
-    
+
     if let selected = textDocumentProxy.selectedText {
       if selected.count > 0 {
         textDocumentProxy.deleteBackward()
@@ -331,14 +374,16 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     if numCharsToDelete <= 0 || hasDeletedSelection {
       textDocumentProxy.insertText(newText)
 
+      sendContextUpdate()
       return
     }
 
     if numCharsToDelete > 0 && textDocumentProxy.documentContextBeforeInput == nil {
       textDocumentProxy.deleteBackward()
+      sendContextUpdate()
       return
     }
-    
+
     for _ in 0..<numCharsToDelete {
       let oldContext = textDocumentProxy.documentContextBeforeInput ?? ""
       textDocumentProxy.deleteBackward()
@@ -378,6 +423,8 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     if !newText.isEmpty {
       textDocumentProxy.insertText(newText)
     }
+
+    sendContextUpdate()
   }
 
   func menuKeyUp(_ keymanWeb: KeymanWebViewController) {
@@ -411,7 +458,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   func updateShowBannerSetting() {
     keymanWeb.updateShowBannerSetting()
   }
-  
+
   func updateSpacebarText() {
     keymanWeb.updateSpacebarText()
   }
@@ -452,7 +499,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     // If 'isSystemKeyboard' is true, always show the top bar.
     return isTopBarActive ? CGFloat(InputViewController.topBarHeight) : 0
   }
-  
+
   public var kmwHeight: CGFloat {
     return keymanWeb.keyboardHeight
   }
@@ -468,12 +515,12 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     self.updateViewConstraints()
     fixLayout()
   }
-  
+
   func fixLayout() {
     view.setNeedsLayout()
     view.layoutIfNeeded()
   }
-  
+
   open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
 
@@ -507,7 +554,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       keymanWeb.shouldReload = false
     }
   }
-  
+
   func setKeyboard(_ kb: InstallableKeyboard) throws {
     try keymanWeb.setKeyboard(kb)
   }
@@ -519,19 +566,19 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   internal var shouldReload: Bool {
     return keymanWeb.shouldReload
   }
-    
+
   func registerLexicalModel(_ lm: InstallableLexicalModel) throws {
     try keymanWeb.registerLexicalModel(lm)
   }
-  
+
   func deregisterLexicalModel(_ lm: InstallableLexicalModel) {
     keymanWeb.deregisterLexicalModel(lm)
   }
-  
+
   func showHelpBubble() {
     keymanWeb.showHelpBubble()
   }
-  
+
   func showHelpBubble(afterDelay delay: TimeInterval) {
     keymanWeb.showHelpBubble(afterDelay: delay)
   }
@@ -543,7 +590,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     os_log("%{public}s", log: KeymanEngineLogger.ui, type: .info, message)
     SentryManager.breadcrumb(message)
   }
-  
+
   func resetContext() {
     keymanWeb.resetContext()
   }
@@ -551,33 +598,33 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   internal func setSentryState(enabled: Bool) {
     keymanWeb.setSentryState(enabled: enabled)
   }
- 
+
   func setContextState(text: String?, range: NSRange) {
     // Check for any LTR or RTL marks at the context's start; if they exist, we should
     // offset the selection range.
     let characterOrderingChecks = [ "\u{200e}" /*LTR*/, "\u{202e}" /*RTL 1*/, "\u{200f}" /*RTL 2*/ ]
     var offsetPrefix = false;
-    
+
     let context = text ?? ""
-    
+
     for codepoint in characterOrderingChecks {
       if(context.hasPrefix(codepoint)) {
         offsetPrefix = true;
         break;
       }
     }
-    
+
     var selRange = range;
     if(offsetPrefix) { // If we have a character ordering mark, offset range location to hide it.
       selRange = NSRange(location: selRange.location - 1, length: selRange.length)
     }
-    
+
     keymanWeb.setText(context)
     if range.location != NSNotFound {
       keymanWeb.setCursorRange(selRange)
     }
   }
-  
+
   func resetKeyboardState() {
     keymanWeb.resetKeyboardState()
   }
@@ -585,11 +632,11 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   func endEditing(_ force: Bool) {
     keymanWeb.view.endEditing(force)
   }
-  
+
   func dismissKeyboardMenu() {
     keymanWeb.dismissKeyboardMenu()
   }
-  
+
   open func setBannerImage(to path: String) {
     keymanWeb.setBannerImage(to: path)
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -299,8 +299,8 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     let selection = textDocumentProxy.selectedText ?? ""
     let contextAfterInput = textDocumentProxy.documentContextAfterInput ?? ""
     let context = "\(contextBeforeInput)\(selection)\(contextAfterInput)"
-    let bLength = contextBeforeInput.count
-    let sLength = selection.count
+    let bLength = contextBeforeInput.unicodeScalars.count
+    let sLength = selection.unicodeScalars.count
     setContextState(text: context, range: NSMakeRange(bLength, sLength))
     // Within the app, this is triggered after every keyboard input.
     // We should NOT call .resetContext() here for this reason.
@@ -318,9 +318,8 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       // On the KMW app/webview side, `location` is SMP-aware.
       // .utf16:  treats SMPs as two char.  (Tested with U+1D5BA)
       // Without .utf16 - treats SMPs as one char.
-      let range = NSRange(location: before.count, length: 0)
+      let range = NSRange(location: before.unicodeScalars.count, length: 0)
 
-      os_log("setContextState(text: `%@`, range initializer location: %d, range.location: %d", log: KeymanEngineLogger.engine, type: .debug, contextWindowText, before.count, range.location)
       self.setContextState(text: contextWindowText, range: range)
     }
 

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -36,7 +36,11 @@ class ContextHost extends Mock {
   // changing the context's text.
   setText(text: string): void {
     this.text = text;
-    this.setSelection(this.text._kmwLength());
+    // Regardless of keyboard, we should check the SMP-aware length of the string.
+    // Our host app will not know whether or not the keyboard uses SMP chars,
+    // and we want a consistent interface for context synchronization between
+    // host app + app/webview KMW.
+    this.setSelection(this.text.kmwLength());
   }
 }
 


### PR DESCRIPTION
Fixes #10204.  Continues from #10584.

While this isn't a 100% perfect fix, it should present a marked improvement in the iOS Keyman app's handling of large-scale text deletion.  That said, there's no reasonably simple way to reach 100% perfection with the interfaces Apple gives us due to the internal mechanisms at play and the limited API.

Known remaining issues:
- When deleting large amounts of text...
    - ... within a large paragraph, on rare occasions the keyboard may change layer as if the context were empty, even when it isn't.  
    - ... on rare occasions, a backspace may not properly delete a character (for keyboards with scripts in the Unicode SMP range).
    - Similarly, keyboard rules with special backspace handling may occasionally not trigger if large amounts of text was deleted between the last directly user-set caret position and its current position.
        - Such "last positions" also include "position after pasting text", as long as the text-insertion point has only been manipulated by typing since then.

In either case, correct behavior will resume either on the following backspace or the backspace after that (the latter is more likely when "mashing" the backspace key than when not).

Sadly, any alternative solution I could find... required quite finicky manipulation of the caret and context.  The resulting "feel" was off - the manipulation had results that could easily feel unexpected and/or glitchy due to related timing issues - and those issues would cause such solutions to be more fragile than desired.

## User Testing

**TEST_LONG_DELETION_BMP**:  Using the iOS Keyman app on a real iPhone or iPad, delete a _lot_ of pre-existing text from within a third-party application.

1. Ensure that Keyman is enabled for use as a system keyboard.
2. Open a third party application **and swap to the default iOS system keyboard**.
3. Copy the following text (to be pasted on the device, in a later step):
    ```
    Testing testing one two three one two three

    Even more random text typed here. Lots and lots and lots of text. Like, way too much text. I want to trigger a context window, and we're going to make certain of it.

    And yeah, another one to be safe. Gonna start within this one, so I can fall back on the last one and see if it triggers across THOSE boundaries. That could totally happen, right?
    ```
4. Open the Notes app and create a new note.
5. Paste the text copied from step 3 as the content of the new note.
6. While still in the Notes app, use the globe key keyboard-selection menu to **activate Keyman as your system keyboard**.
7. Hold down BKSP until no further deletions occur.
8. If any visible text remains that refuses to be deleted, FAIL this test.

**TEST_LONG_DELETION_SMP**:  Using the iOS Keyman app on a real iPhone or iPad, delete a _lot_ of pre-existing text from within a third-party application.

1. Ensure that Keyman is enabled for use as a system keyboard.
2. Open a third party application **and swap to the default iOS system keyboard**.
3. Copy the following text (to be pasted on the device, in a later step):
    ```
    𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖

    𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖

    𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖 𝕒𝕓𝕔𝕕𝕖
    ```
    - For future reference, `𝕒` = `U+1D552`.  ("Mathematical double-struck small A")  Similar for the other "letters".
4. Open the Notes app and create a new note.
5. Paste the text copied from step 3 as the content of the new note.
6. While still in the Notes app, use the globe key keyboard-selection menu to **activate Keyman as your system keyboard**.
7. Hold down BKSP until no further deletions occur.
    - If the first BKSP does not act as expected, FAIL this test.
    - If a random symbol appears after _many_ deletions but is deleted shortly thereafter, _ignore_ the random symbol and continue the test.  (This is a known limitation.)
8. If any visible text remains that refuses to be deleted, FAIL this test.

Additional test resource:

The following QR code will open this PR's GitHub page on a mobile device:

![pr qr code](https://github.com/keymanapp/keyman/assets/25213402/365eac3b-167e-472c-b271-548d4639593f)

I figured this might make visiting this page on the test device, to copy each test's text blocks, less complicated.