### PR TITLE
fix(web): prevent invalid longpress shortcut triggers

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/pathMatcher.ts
@@ -93,11 +93,7 @@ export class PathMatcher<Type, StateToken = any> {
         }
 
         // Check for validation as needed.
-        if(!model.timer.validateItem) {
-          this.finalize(true, 'timer');
-        } else {
-          this.finalize(model.timer.validateItem(this.source.path.stats.lastSample.item, this.baseItem), 'timer');
-        }
+        this.finalize(true, 'timer');
       });
     }
   }
@@ -108,6 +104,14 @@ export class PathMatcher<Type, StateToken = any> {
     }
 
     const model = this.model;
+
+    // Check for validation as needed.
+    if(model.validateItem && result) {
+      // If we're finalizing on a positive note but there's an item-validation check, we need
+      // to obey the results of that check.
+      result = model.validateItem(this.source.path.stats.lastSample.item, this.baseItem);
+    }
+
     let retVal: PathMatchResult;
     if(result) {
       retVal = {

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/contactModel.ts
@@ -24,6 +24,18 @@ export interface ContactModel<Type, StateToken = any> {
   itemPriority: number;
 
   /**
+   * An optional function parameter.  If specified and other conditions are met,
+   * this function will validate the model on the basis of the associated 'items' when
+   * a model match is being finalized.
+   * @param currentItem
+   * @param baseItem
+   * @returns
+   * - `true` if the model is valid for the associated items, resulting in a model match
+   * - `false` if the model is invalid, leading to model rejection
+   */
+  validateItem?: (currentItem: Type, baseItem: Type) => boolean
+
+  /**
    * Used for resolving or rejecting this component of a gesture based on a time threshold
    * for the touch contact point's lifetime.
    *
@@ -41,17 +53,7 @@ export interface ContactModel<Type, StateToken = any> {
      * If `true`, the timer will use the inherited `path.stats.duration` stat as an
      * offset that has already elapsed, counting it against the timer.
      */
-    inheritElapsed?: boolean,
-    /**
-     * An optional timer-spec function parameter.  If specified and other conditions are met,
-     * this function will validate the model on the basis of the associated 'items'.
-     * @param currentItem
-     * @param baseItem
-     * @returns
-     * - `true` if the model is valid for the associated items, resulting in a model match
-     * - `false` if the model is invalid, leading to model rejection
-     */
-    validateItem?: (currentItem: Type, baseItem: Type) => boolean
+    inheritElapsed?: boolean
   }
 
   // This field is primarly used at the `GestureMatcher` level, rather than the

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -441,9 +441,9 @@ export function longpressContactModel(params: GestureParams, enabledFlicks: bool
     pathResolutionAction: 'resolve',
     timer: {
       duration: spec.waitLength,
-      expectedResult: true,
-      validateItem: (key: KeyElement) => !!key?.key.spec.sk
+      expectedResult: true
     },
+    validateItem: (key: KeyElement) => !!key?.key.spec.sk,
     pathModel: {
       evaluate: (path) => {
         const stats = path.stats;


### PR DESCRIPTION
Fixes #10640.

When I put together #10172, I rightly considered how the changes would be affected for standard longpress timeouts... but wrongly forgot to apply the same sort of filtering whenever the longpress up-flick shortcut is executed.  

By making the item-validator a full-on path-model property, rather than a path-model timer-only property, we can validate all finalizations, rather than only timer-based ones.  The same filtering should apply for both cases, after all, so it makes sense as a configurable parameter on its new level.

## User Testing

**TEST_SIMPLE_KEY_UP_FLICK**:
1. Load up the standard "Test unminified Keymanweb" test page while on (or emulating) a mobile device.  (Chrome emulation is fine.)
2. Using the default keyboard ("English")...
3. Press any non-special key.  (For example, the `k` key.)
4. Drag up while keeping the key pressed.
5. FAIL the test if the key-preview disappears almost immediately without moving to a different key.
6. FAIL the test if any stuck-highlighting effects occur after lifting your finger.

There was a temporary extra test here at one point - see https://github.com/keymanapp/keyman/pull/10641#issuecomment-1935882421 - which was used to gauge how related #10640 is to #10592 and whether or not the latter would also be fixed by this PR.  Alas, this PR's changes are insufficient for the latter.