### PR TITLE
chore(web): removes unused banner events

### DIFF
--- a/web/src/engine/osk/src/banner/bannerController.ts
+++ b/web/src/engine/osk/src/banner/bannerController.ts
@@ -81,7 +81,6 @@ export class BannerController {
     } else {
       let suggestBanner = banner = new SuggestionBanner(this.hostDevice, this.container.activeBannerHeight);
       suggestBanner.predictionContext = this.predictionContext;
-      suggestBanner.events.on('apply', (selection) => this.predictionContext.accept(selection.suggestion));
 
       // Registers for prediction-engine events & handles its needed connections.
       this.container.banner = suggestBanner;

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -384,8 +384,6 @@ export class SuggestionBanner extends Banner {
 
   public readonly type = "suggestion";
 
-  public readonly events: EventEmitter<SuggestionInputEventMap>;
-
   private currentSuggestions: Suggestion[] = [];
 
   private options : BannerSuggestion[] = [];
@@ -417,8 +415,6 @@ export class SuggestionBanner extends Banner {
     this.container.className = BANNER_SCROLLER_CLASS;
     this.getDiv().appendChild(this.container);
     this.buildInternals(false);
-
-    this.events = new EventEmitter<SuggestionInputEventMap>(); //this.manager.events;
 
     this.gestureEngine = this.setupInputHandling();
   }
@@ -780,14 +776,6 @@ export class SuggestionBanner extends Banner {
     }
   }
 }
-
-interface SuggestionInputEventMap {
-  highlight: (bannerSuggestion: BannerSuggestion, state: boolean) => void,
-  apply: (bannerSuggestion: BannerSuggestion) => void;
-  hold: (bannerSuggestion: BannerSuggestion) => void;
-  scrollLeft: (val: number) => void;
-}
-
 
 class SuggestionExpandContractAnimation {
   private scrollContainer: HTMLElement | null;


### PR DESCRIPTION
When I was modularizing KMW (the 🧩 chain during 17.0), the banner was the trickiest thing to disentangle.  As such, I believe that I originally set event-raising structures in place as a potential "way forward" to re-link everything.

As it turns out... we didn't need the event-raising structures _on the banner_ whatsoever.  The `PredictionContext` object (currently within `InputProcessor`, introduced in #8056) is where all the actual event-raising happens, with the banner itself consuming those events.  It does appear the stuff being removed here was _also_ introduced in that PR - it was a large PR, so I probably just didn't realize at the time that I'd already made it redundant.

Then again, it may have only _actually_ become redundant once the gesture rework (🐵) had _also_ landed; before that rework, the banner had its own touch-handling infrastructure that may have linked to the events.  Either way, the banner's events are no longer used, so we may as well remove 'em and reclaim a bit of filesize bloat.

@keymanapp-test-bot skip