### PR TITLE
fix(linux): Use raw string for regex

### DIFF
--- a/linux/keyman-config/keyman_config/bcp47tag.py
+++ b/linux/keyman-config/keyman_config/bcp47tag.py
@@ -70,13 +70,13 @@ class Bcp47Tag():
 
     def _processTag(self, tag):
         # Adapted from https://github.com/gagle/node-bcp47 [MIT]
-        regex = re.compile('^(?:(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|' +
-                           'i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|' +
-                           'sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|' +
-                           'no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))$' +
-                           '|^((?:[a-z]{2,3}(?:(?:-[a-z]{3}){1,3})?)|[a-z]{4}|' +
-                           '[a-z]{5,8})(?:-([a-z]{4}))?(?:-([a-z]{2}|\d{3}))?((?:-(?:[\da-z]{5,8}' +
-                           '|\d[\da-z]{3}))*)?((?:-[\da-wy-z](?:-[\da-z]{2,8})+)*)?(-x(?:-[\da-z]{1,8})+)?$|^(x(?:-[\da-z]{1,8})+)$', re.IGNORECASE)
+        regex = re.compile(r'^(?:(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|' +
+                           r'i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|' +
+                           r'sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|' +
+                           r'no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))$' +
+                           r'|^((?:[a-z]{2,3}(?:(?:-[a-z]{3}){1,3})?)|[a-z]{4}|' +
+                           r'[a-z]{5,8})(?:-([a-z]{4}))?(?:-([a-z]{2}|\d{3}))?((?:-(?:[\da-z]{5,8}' +
+                           r'|\d[\da-z]{3}))*)?((?:-[\da-wy-z](?:-[\da-z]{2,8})+)*)?(-x(?:-[\da-z]{1,8})+)?$|^(x(?:-[\da-z]{1,8})+)$', re.IGNORECASE)
         match = regex.match(tag)
         if not match:
             return None


### PR DESCRIPTION
This change fixes a syntax warning with Python 3.12. See https://stackoverflow.com/a/50504635/487503 and
https://docs.python.org/3/whatsnew/3.12.html#other-language-changes.

@keymanapp-test-bot skip