### PR TITLE
fix(windows): `wstrtostr` should use `WideCharToMultiByte`

### DIFF
--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -221,11 +221,11 @@ PWSTR strtowstr(PSTR in)
 PSTR wstrtostr(PCWSTR in)
 {
     PSTR result;
-    size_t len;
+    int len;
 
-    wcstombs_s(&len, NULL, 0, in, wcslen(in));
+    len = WideCharToMultiByte(CP_ACP, 0, in, -1, NULL, 0, NULL, NULL);
     result = new CHAR[len+1];
-    wcstombs_s(&len, result, len, in, wcslen(in));
+    WideCharToMultiByte(CP_ACP, 0, in, -1, result, len, NULL, NULL);
     result[len] = 0;
     return result;
 }


### PR DESCRIPTION
Relates to #10604: "Note also wstrtostr crashes if you pass it surrogate pairs because they won't convert ... ouch."

@keymanapp-test-bot skip