### PR TITLE
fix(developer): keyboard that targets only web can cause crashes and other problems

### DIFF
--- a/developer/src/tike/child/UfrmKeymanWizard.pas
+++ b/developer/src/tike/child/UfrmKeymanWizard.pas
@@ -1012,11 +1012,11 @@ procedure TfrmKeymanWizard.StartDebugging(FStartTest: Boolean);
     ki: TKeyboardInfo;
     buf: WideString;
   begin
-    if not FileExists((ProjectFile as TkmnProjectFile).TargetFilename) then
+    if not FileExists((ProjectFile as TkmnProjectFile).KmxTargetFilename) then
       Exit(False);
 
     try
-      GetKeyboardInfo((ProjectFile as TkmnProjectFile).TargetFilename, True, ki);   // I4695
+      GetKeyboardInfo((ProjectFile as TkmnProjectFile).KmxTargetFilename, True, ki);   // I4695
       try
         Result := GetSystemStore(ki.MemoryDump.Memory, TSS_DEBUG_LINE, buf);
       finally
@@ -1069,7 +1069,7 @@ begin
       Exit;
     end;
 
-    if not FileExists((ProjectFile as TkmnProjectFile).TargetFilename) then
+    if not FileExists((ProjectFile as TkmnProjectFile).KmxTargetFilename) then
     begin
       ShowMessage(SKKeyboardKMXDoesNotExist);
       Exit;
@@ -1085,7 +1085,7 @@ begin
       FDebugForm.UpdateFont(nil);
 //    FDebugForm.Visible := True;
     FDebugForm.DebugFileName := FileName;
-    FDebugForm.CompiledFileName := (ProjectFile as TkmnProjectFile).TargetFilename;   // I4695
+    FDebugForm.CompiledFileName := (ProjectFile as TkmnProjectFile).KmxTargetFilename;   // I4695
     FDebugForm.ShowDebugForm;
   end;
 end;
@@ -2390,7 +2390,7 @@ begin
 
   if FKeyboardParser.Features.ContainsKey(kfOSK) then
   begin
-    frameOSK.KMXFileName := (ProjectFile as TkmnProjectFile).TargetFilename;   // I4695
+    frameOSK.KMXFileName := (ProjectFile as TkmnProjectFile).KmxTargetFilename;   // I4695
     frameOSK.UpdateControls;
   end;
 
@@ -3128,7 +3128,7 @@ end;
 
 procedure TfrmKeymanWizard.SaveOSK;
 begin
-  frameOSK.KMXFileName := (ProjectFile as TkmnProjectFile).TargetFilename;   // I4695
+  frameOSK.KMXFileName := (ProjectFile as TkmnProjectFile).KmxTargetFilename;   // I4695
   if FFeature[kfOSK].FileName = '' then
     FFeature[kfOSK].FileName := ChangeFileExt(FileName, '.kvks');
   frameOSK.FileName := FFeature[kfOSK].Filename;

--- a/developer/src/tike/project/Keyman.Developer.System.Project.kmnProjectFileAction.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.kmnProjectFileAction.pas
@@ -30,21 +30,20 @@ uses
 
   Keyman.Developer.System.Project.ProjectLog,
   Keyman.System.KeyboardUtils,
-  Keyman.Developer.System.KmcWrapper;
+  Keyman.Developer.System.KmcWrapper,
+  utilfiletypes;
 
 function TkmnProjectFileAction.Clean: Boolean;
-var
-  FJS: string;
 begin
-  CleanFile(OutputFileName);
-
   if Targets * KMXKeymanTargets <> [] then
-    CleanFile(ExtractFilePath(FileName) + ExtractFileName(ChangeFileExt(KVKFileName, '.kvk')), True);
+  begin
+    CleanFile(KmxTargetFileName);
+    CleanFile(ExtractFilePath(KmxTargetFileName) + ExtractFileName(ChangeFileExt(KVKFileName, Ext_VisualKeyboard)), True);
+  end;
 
   if Targets * KMWKeymanTargets <> [] then
   begin
-    FJS := TKeyboardUtils.GetKeymanWebCompiledFileName(FileName);
-    CleanFile(FJS); // keyboard-x.y.js
+    CleanFile(JsTargetFileName);
   end;
 
   Result := True;

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.kmnProjectFileUI.pas
@@ -135,7 +135,7 @@ begin
 
   if Result and
       TServerDebugAPI.Running and
-      TServerDebugAPI.IsKeyboardRegistered(ProjectFile.TargetFileName) and
+      TServerDebugAPI.IsKeyboardRegistered(ProjectFile.JSTargetFileName) and
       (ProjectFile.Targets * KMWKeymanTargets <> []) then
     TestKeymanWeb(True);
 end;
@@ -172,7 +172,7 @@ var
   FCompiledName: string;
 begin
   Result := False;
-  FCompiledName := ProjectFile.TargetFileName;
+  FCompiledName := ProjectFile.KmxTargetFileName;
   if not TestKeyboardState(FCompiledName, FSilent) then Exit;
 //  with TfrmFontHelper.Create(frmKeymanDeveloper) do
 //  try
@@ -285,7 +285,7 @@ var
   FCompiledName: string;
 begin
   Result := False;
-  FCompiledName := ProjectFile.TargetFilename;
+  FCompiledName := ProjectFile.KmxTargetFilename;
   if not TestKeyboardState(FCompiledName, False) then Exit;
   KeymanDeveloperUtils.InstallKeyboard(FCompiledName, True);
   Result := True;


### PR DESCRIPTION
Fixes #10655.
Fixes #10663.

If a .kmn file had only a .js target, then Keyman Developer would return an empty string for the target (based on .kmx). This meant that the path for the compiler was an empty string, the path for opening the build folder was an empty string.

Refactored the relevant code to simplify the logic a little.

# User Testing

* **TEST_OPEN_BUILD_FOLDER:** Create a new mobile-only keyboard, open the .kmn, compile the keyboard, and then click Open Build Folder in the Build tab. Verify that the correct build folder opens, and that it contains only a .js file.
* **TEST_KEYBOARD_ON_WEB:** Create a new mobile-only keyboard, open the .kmn, compile the keyboard, and then click Test Keyboard on web in the Build tab. Verify that the web test starts, and that you can test the keyboard successfully in your browser from there.