### PR TITLE
fix(web): banner robustness when touched 2+ times at once

### DIFF
--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -466,6 +466,9 @@
   width: max-content;  /* Ensure the text span acts like it contains its text */
   min-width: calc(100% - 16px); /* To ensure the span stays centered. */
   white-space: nowrap;
+  /* We need click-through and touch-through - we replace spans when updating suggestions, and that can break gestures. */
+  pointer-events: none;
+  touch-action: none;
 }
 
 .kmw-footer-resize{cursor:se-resize;position:absolute;right:2px;bottom:2px;width:16px;height:16px;overflow:hidden;


### PR DESCRIPTION
Fixes #7158.

With the new gesture engine in place, most of the instability has already been handled, but there was one last detail that evaded us until now.  

The explanation is pretty simple, too - touches on banner suggestions would often register against the suggestion text.  We _also_ happened to _replace_ suggestion text _elements_ when updating suggestions.  So, when we swapped out the element that was the main touch target **_before_** the touch-interaction was completed... we'd lose all further touch-event updates for that interaction, causing gestures to go uncompleted.

## User Testing

**TEST_BANNER_RAPID_TOUCH**:  Rapidly touch the predictive-text banner and ensure its behavior remains stable and acts as would be expected.

1. Using the Keyman for Android app...
2. Adjust the Keyboard height to the maximum. 
3. Activate "EuroLatin (SIL)" (or any other keyboard with predictive text)
4. Press the Predictive text randomly on the banner. 
5. Change the View from Portrait to Landscape mode. 
6. Adjust the Keyboard height to the maximum. 
7. Press the Predictive text randomly on the banner. 
8. If the banner appears to "freeze" or "lock up" at any point, FAIL this test.