### PR TITLE
chore(linux): Ignore missing .symbols file in stable branch

### DIFF
--- a/linux/scripts/deb-packaging.sh
+++ b/linux/scripts/deb-packaging.sh
@@ -150,6 +150,14 @@ get_api_version_in_symbols_file() {
   echo "${firstline}"
 }
 
+# Check if the API version got updated
+# Returns:
+#   0 - if the API version got updated
+#   1 - the .symbols file got changed but the API version didn't get updated
+#   2 - if we're in the alpha tier and the API version got updated since
+#       the last stable version
+# NOTE: it is up to the caller to check if this is a major version
+# change that requires an API version update.
 is_api_version_updated() {
   local NEW_VERSION OLD_VERSION TIER
   git checkout "${GIT_BASE}" -- "debian/${PKG_NAME}.symbols"
@@ -168,7 +176,12 @@ is_api_version_updated() {
     alpha)
       local STABLE_VERSION
       STABLE_VERSION=$((${VERSION%%.*} - 1))
-      git checkout "stable-${STABLE_VERSION}.0" -- "debian/${PKG_NAME}.symbols"
+      if ! git cat-file -e "origin/stable-${STABLE_VERSION}.0" "debian/${PKG_NAME}.symbols" 2>/dev/null; then
+        # .symbols file doesn't exist in stable branch; that's ok
+        echo "2"
+        return
+      fi
+      git checkout "origin/stable-${STABLE_VERSION}.0" -- "debian/${PKG_NAME}.symbols"
       STABLE_API_VERSION=$(get_api_version_in_symbols_file)
       git checkout "${GIT_SHA}" -- "debian/${PKG_NAME}.symbols"
       if (( NEW_VERSION > STABLE_API_VERSION )); then


### PR DESCRIPTION
This fixes a bug in the API verification if the stable branch doesn't have the expected .symbols file.

@keymanapp-test-bot skip