### PR TITLE
chore(linux): Don't set VERSION_TAG to …-local in .deb packages

### DIFF
--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -79,8 +79,8 @@ function findVersion() {
         VERSION_TAG=
     fi
 
-    if [ -z "${TEAMCITY_VERSION-}" ] && [ -z "${GITHUB_ACTIONS-}" ]; then
-        # Local dev machine, not TeamCity or GitHub Action
+    if [[ -z "${TEAMCITY_VERSION-}" && -z "${GITHUB_ACTIONS-}" && -z "${KEYMAN_PKG_BUILD-}" ]]; then
+        # Local dev machine, not TeamCity or GitHub Action and not .deb package build
         VERSION_TAG="$VERSION_TAG-local"
         VERSION_ENVIRONMENT=local
     elif [ -n "${TEAMCITY_PR_NUMBER-}" ]; then


### PR DESCRIPTION
Previously we didn't detect that we were building a .deb package on Launchpad or a Debian server, so we set VERSION_TAG to end in `-local`. This change now checks the `KEYMAN_PKG_BUILD` environment variable which will be set during .deb package builds (set in `debian/rules`). The downside of this solution is that now `-local` also gets omitted if we build a .deb package on a local dev machine, but that probably doesn't happen too often, and even less often with modified source code. The majority of builds where we want `-local` are local builds that get installed locally, and those cases are covered by this change. And what is more important is that for release builds we no longer append `-local`.

Similar to #9400 but for Debian/Launchpad.

@keymanapp-test-bot skip