### PR TITLE
chore(windows): add const to argument definition

### DIFF
--- a/common/windows/cpp/include/registry.h
+++ b/common/windows/cpp/include/registry.h
@@ -187,9 +187,9 @@ public:
 	BOOL DeleteKey(LPCSTR AKey);
 	BOOL DeleteValue(LPCSTR AName);
 	BOOL OpenKey(LPCSTR AKey, BOOL ACreate);
-	BOOL WriteInteger(LPCSTR AName, int AValue);
-	BOOL WriteString(LPCSTR AName, LPSTR AValue);
-	BOOL WriteString(LPCWSTR AName, LPWSTR AValue);
+	BOOL WriteInteger(LPCSTR AName, const int AValue);
+	BOOL WriteString(LPCSTR AName, LPCSTR AValue);
+	BOOL WriteString(LPCWSTR AName, LPCWSTR AValue);
 };
 
 RegistryReadOnly *Reg_GetKeymanActiveKeyboard(LPSTR kbname);

--- a/common/windows/cpp/src/registry.cpp
+++ b/common/windows/cpp/src/registry.cpp
@@ -211,18 +211,16 @@ BOOL RegistryReadOnly::WrapError(DWORD res)
 	return res == ERROR_SUCCESS;
 }
 
-BOOL RegistryFullAccess::WriteInteger(LPCSTR AName, int AValue)
+BOOL RegistryFullAccess::WriteInteger(LPCSTR AName, const int AValue)
 {
 	return WrapError(RegSetValueEx(FhKey, AName, 0, REG_DWORD, (LPBYTE) &AValue, sizeof(int)));
 }
 
-BOOL RegistryFullAccess::WriteString(LPCSTR AName, LPSTR AValue)
-{
+BOOL RegistryFullAccess::WriteString(LPCSTR AName, LPCSTR AValue) {
 	return WrapError(RegSetValueEx(FhKey, AName, 0, REG_SZ, (LPBYTE) AValue, (DWORD) strlen(AValue)+1));
 }
 
-BOOL RegistryFullAccess::WriteString(LPCWSTR AName, LPWSTR AValue)
-{
+BOOL RegistryFullAccess::WriteString(LPCWSTR AName, LPCWSTR AValue) {
 	return WrapError(RegSetValueExW(FhKey, AName, 0, REG_SZ, (LPBYTE) AValue, (DWORD) wcslen(AValue)*2+2));
 }
 

--- a/windows/src/engine/keyman32/keyboardoptions.cpp
+++ b/windows/src/engine/keyman32/keyboardoptions.cpp
@@ -20,7 +20,7 @@
 #include "pch.h"
 
 BOOL IntLoadKeyboardOptionsRegistrytoCore(LPCSTR key, LPINTKEYBOARDINFO kp, km_core_state* const state);
-void IntSaveKeyboardOptionCoretoRegistry(LPCSTR REGKey, LPINTKEYBOARDINFO kp, LPCWSTR key, LPWSTR value);
+void IntSaveKeyboardOptionCoretoRegistry(LPCSTR REGKey, LPINTKEYBOARDINFO kp, LPCWSTR key, LPCWSTR value);
 
 static km_core_cp* CloneKeymanCoreCP(const km_core_cp* cp) {
   LPCWSTR buf      = reinterpret_cast<LPCWSTR>(cp);
@@ -35,13 +35,11 @@ static km_core_cp* CloneKeymanCoreCPFromWSTR(LPWSTR buf) {
   return clone;
 }
 
-void SaveKeyboardOptionCoretoRegistry(LPINTKEYBOARDINFO kp, LPCWSTR key, LPWSTR value)
-{
+void SaveKeyboardOptionCoretoRegistry(LPINTKEYBOARDINFO kp, LPCWSTR key, LPCWSTR value) {
   IntSaveKeyboardOptionCoretoRegistry(REGSZ_KeyboardOptions, kp, key, value);
 }
 
-void IntSaveKeyboardOptionCoretoRegistry(LPCSTR REGKey, LPINTKEYBOARDINFO kp, LPCWSTR key, LPWSTR value)
-{
+void IntSaveKeyboardOptionCoretoRegistry(LPCSTR REGKey, LPINTKEYBOARDINFO kp, LPCWSTR key, LPCWSTR value) {
   assert(REGKey != NULL);
   assert(kp != NULL);
   assert(key);

--- a/windows/src/engine/keyman32/keyboardoptions.h
+++ b/windows/src/engine/keyman32/keyboardoptions.h
@@ -33,6 +33,6 @@ void LoadKeyboardOptionsRegistrytoCore(LPINTKEYBOARDINFO kp, km_core_state* stat
  * @param  key    keyboard key to save
  * @param  value  keyboard option value to save
  */
-void SaveKeyboardOptionCoretoRegistry(LPINTKEYBOARDINFO kp, LPCWSTR key, LPWSTR value);
+void SaveKeyboardOptionCoretoRegistry(LPINTKEYBOARDINFO kp, LPCWSTR key, LPCWSTR value);
 
 

--- a/windows/src/engine/keyman32/kmprocessactions.cpp
+++ b/windows/src/engine/keyman32/kmprocessactions.cpp
@@ -60,11 +60,8 @@ processPersistOpt(km_core_actions const* actions, LPINTKEYBOARDINFO activeKeyboa
 ) {
   for (auto option = actions->persist_options; option->key; option++) {
     SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessPersistOpt: Saving option to registry for keyboard [%s].", activeKeyboard->Name);
-    size_t value_length = wcslen(reinterpret_cast<LPCWSTR>(option->value));
-    LPWSTR value = new WCHAR[value_length + 1];
-    wcscpy_s(value, value_length + 1, reinterpret_cast<LPCWSTR>(option->value));
-    SaveKeyboardOptionCoretoRegistry(activeKeyboard, reinterpret_cast<LPCWSTR>(option->key), value);
-    delete[] value;
+    SaveKeyboardOptionCoretoRegistry(
+        activeKeyboard, reinterpret_cast<LPCWSTR>(option->key), reinterpret_cast<LPCWSTR>(option->value));
   }
 }
 

--- a/windows/src/engine/kmtip/registryw.cpp
+++ b/windows/src/engine/kmtip/registryw.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             registryw
   Copyright:        Copyright (C) 2003-2017 SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Dec 2012
 
   Modified Date:    13 Dec 2012
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Dec 2012 - mcdurdin - I3622 - V9.0 - Add Registry*W classes for Unicode
                     13 Dec 2012 - mcdurdin - I3675 - V9.0 - Minor updates to I3622 for consistency
 */
@@ -42,7 +42,7 @@ BOOL RegistryReadOnlyW::CloseKey(void)
 BOOL RegistryFullAccessW::CreateKey(LPCWSTR AKey)
 {
 	DWORD dwDisposition;
-	return WrapError(RegCreateKeyExW(FhKey ? FhKey : FhRootKey, AKey, 0, NULL, 0, KEY_ALL_ACCESS, NULL, 
+	return WrapError(RegCreateKeyExW(FhKey ? FhKey : FhRootKey, AKey, 0, NULL, 0, KEY_ALL_ACCESS, NULL,
 		&FhKey, &dwDisposition));
 }
 
@@ -53,7 +53,7 @@ BOOL RegistryFullAccessW::RecursiveDeleteKey(LPCWSTR AKey)
 	if(RegOpenKeyExW(FhKey ? FhKey : FhRootKey, AKey, 0, KEY_ALL_ACCESS, &hkey) != ERROR_SUCCESS)
 		return FALSE;
 
-	if(!IntRecursiveDeleteKey(hkey)) 
+	if(!IntRecursiveDeleteKey(hkey))
 	{
 		RegCloseKey(hkey);
 		return FALSE;
@@ -192,7 +192,7 @@ BOOL RegistryFullAccessW::WriteInteger(LPCWSTR AName, int AValue)
 	return WrapError(RegSetValueExW(FhKey, AName, 0, REG_DWORD, (LPBYTE) &AValue, sizeof(int)));
 }
 
-BOOL RegistryFullAccessW::WriteString(LPCWSTR AName, LPWSTR AValue)
+BOOL RegistryFullAccessW::WriteString(LPCWSTR AName, LPCWSTR AValue)
 {
   DWORD dwLen = (DWORD) (wcslen(AValue)+1) * sizeof(WCHAR);   // I3675
 	return WrapError(RegSetValueExW(FhKey, AName, 0, REG_SZ, (LPBYTE) AValue, dwLen));
@@ -205,7 +205,7 @@ RegistryReadOnlyW *Reg_GetKeymanInstalledKeyboardW(LPWSTR kbname)
 	{
 		delete reg;
 		reg = new RegistryReadOnlyW(HKEY_CURRENT_USER);
-		if(!reg->OpenKeyReadOnly(REGSZ_KeymanInstalledKeyboardsCUW) || !reg->OpenKeyReadOnly(kbname)) 
+		if(!reg->OpenKeyReadOnly(REGSZ_KeymanInstalledKeyboardsCUW) || !reg->OpenKeyReadOnly(kbname))
 		{
 			delete reg;
 			return NULL;

--- a/windows/src/engine/kmtip/registryw.h
+++ b/windows/src/engine/kmtip/registryw.h
@@ -155,8 +155,8 @@ public:
 	BOOL DeleteKey(LPCWSTR AKey);
 	BOOL DeleteValue(LPCWSTR AName);
 	BOOL OpenKey(LPCWSTR AKey, BOOL ACreate);
-	BOOL WriteInteger(LPCWSTR AName, int AValue);
-	BOOL WriteString(LPCWSTR AName, LPWSTR AValue);
+	BOOL WriteInteger(LPCWSTR AName, const int AValue);
+	BOOL WriteString(LPCWSTR AName, LPCWSTR AValue);
 };
 
 RegistryReadOnlyW *Reg_GetKeymanActiveKeyboardW(LPWSTR kbname);

--- a/windows/src/test/manual-tests/test_i3619/i3619tip/i3619tip/i3619tip/registryw.cpp
+++ b/windows/src/test/manual-tests/test_i3619/i3619tip/i3619tip/i3619tip/registryw.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             registryw
   Copyright:        Copyright (C) 2003-2017 SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Dec 2012
 
   Modified Date:    13 Dec 2012
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Dec 2012 - mcdurdin - I3622 - V9.0 - Add Registry*W classes for Unicode
                     13 Dec 2012 - mcdurdin - I3675 - V9.0 - Minor updates to I3622 for consistency
 */
@@ -42,7 +42,7 @@ BOOL RegistryReadOnlyW::CloseKey(void)
 BOOL RegistryFullAccessW::CreateKey(LPCWSTR AKey)
 {
 	DWORD dwDisposition;
-	return WrapError(RegCreateKeyExW(FhKey ? FhKey : FhRootKey, AKey, 0, NULL, 0, KEY_ALL_ACCESS, NULL, 
+	return WrapError(RegCreateKeyExW(FhKey ? FhKey : FhRootKey, AKey, 0, NULL, 0, KEY_ALL_ACCESS, NULL,
 		&FhKey, &dwDisposition));
 }
 
@@ -53,7 +53,7 @@ BOOL RegistryFullAccessW::RecursiveDeleteKey(LPCWSTR AKey)
 	if(RegOpenKeyExW(FhKey ? FhKey : FhRootKey, AKey, 0, KEY_ALL_ACCESS, &hkey) != ERROR_SUCCESS)
 		return FALSE;
 
-	if(!IntRecursiveDeleteKey(hkey)) 
+	if(!IntRecursiveDeleteKey(hkey))
 	{
 		RegCloseKey(hkey);
 		return FALSE;
@@ -187,12 +187,12 @@ BOOL RegistryReadOnlyW::WrapError(DWORD res)
 	return res == ERROR_SUCCESS;
 }
 
-BOOL RegistryFullAccessW::WriteInteger(LPCWSTR AName, int AValue)
+BOOL RegistryFullAccessW::WriteInteger(LPCWSTR AName, const int AValue)
 {
 	return WrapError(RegSetValueExW(FhKey, AName, 0, REG_DWORD, (LPBYTE) &AValue, sizeof(int)));
 }
 
-BOOL RegistryFullAccessW::WriteString(LPCWSTR AName, LPWSTR AValue)
+BOOL RegistryFullAccessW::WriteString(LPCWSTR AName, LPCWSTR AValue)
 {
   DWORD dwLen = (DWORD) (wcslen(AValue)+1) * sizeof(WCHAR);   // I3675
 	return WrapError(RegSetValueExW(FhKey, AName, 0, REG_SZ, (LPBYTE) AValue, dwLen));

--- a/windows/src/test/manual-tests/test_i3619/i3619tip/i3619tip/i3619tip/registryw.h
+++ b/windows/src/test/manual-tests/test_i3619/i3619tip/i3619tip/i3619tip/registryw.h
@@ -1,20 +1,20 @@
 /*
   Name:             registryw
   Copyright:        Copyright (C) 2003-2017 SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Dec 2012
 
   Modified Date:    1 Dec 2012
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
-  History:          01 Dec 2012 - mcdurdin - I3622 - V9.0 - Add Registry*W classes for Unicode 
-                    
+  Bugs:
+  Todo:
+  Notes:
+  History:          01 Dec 2012 - mcdurdin - I3622 - V9.0 - Add Registry*W classes for Unicode
+
 */
 #ifndef _REGISTRYW_H   // I3622
 #define _REGISTRYW_H
@@ -74,18 +74,18 @@
 #define REGSZ_ShouldShowStartupW		L"show keyman startup"
 #define REGSZ_ShouldStartInternatW	L"should start internat"
 
-/* Addins */ 
+/* Addins */
 
 #define REGSZ_AddinNameW			 L"addin name"
 #define REGSZ_AddinFileNameW	 L"addin file name"
 #define REGSZ_AddinEnabledW    L"addin enabled"
 
-/* Registry keys for upgrade purposes only */ 
+/* Registry keys for upgrade purposes only */
 
 #define REGSZ_KeymanDeveloper50W	L"software\\tavultesoft\\keyman developer\\5.0"
 #define REGSZ_Keyman50W			L"software\\tavultesoft\\keyman\\5.0"
 
-/* Splitting Registry into ReadOnly and FullAccess makes it much easier to ensure that we are using the registry 
+/* Splitting Registry into ReadOnly and FullAccess makes it much easier to ensure that we are using the registry
    correctly -- readonly wherever possible. */
 
 class RegistryReadOnlyW
@@ -115,7 +115,7 @@ public:
 
 class RegistryFullAccessW: public RegistryReadOnlyW
 {
-protected:	
+protected:
 	HKEY GetKey(LPCWSTR AKey);
 	BOOL IntRecursiveDeleteKey(HKEY hkey);
 
@@ -128,8 +128,8 @@ public:
 	BOOL DeleteKey(LPCWSTR AKey);
 	BOOL DeleteValue(LPCWSTR AName);
 	BOOL OpenKey(LPCWSTR AKey, BOOL ACreate);
-	BOOL WriteInteger(LPCWSTR AName, int AValue);
-	BOOL WriteString(LPCWSTR AName, LPWSTR AValue);
+	BOOL WriteInteger(LPCWSTR AName, const int AValue);
+	BOOL WriteString(LPCWSTR AName, LPCWSTR AValue);
 };
 
 RegistryReadOnlyW *Reg_GetKeymanActiveKeyboardW(LPWSTR kbname);


### PR DESCRIPTION
Updated the call stack to keep a const string for the value parameter being written to the registry.

SaveKeyboardOptionCoretoRegistry calls
IntSaveKeyboardOptionCoretoRegistry which calls
RegistryFullAccess::WriteString which calls
RegSetValueExW, which takes a const data parameter.

## User Testing

## Testing Persiting Options

* **TEST_PERSITING_OPTIONS**

1. Install k_022___options_with_preset.kmx
2. Open Notepad 
3. Type <kbd>a</kbd> 
4. Expected reasult "no. foo"
5. Type <kbd>1</kbd> 
6. Type <kbd>a</kbd> 
7. Expected reasult "foo"
8. Type <kbd>Win</kbd> +<kbd>r</kbd> 
9. In the run Window type regedit
10. Find the registry key for the k_022___options_with_preset.kmx keyboard under active keyboards\options  veriy that "foo" key is there and the value is `1`.  Full path for the registry key is `Computer\HKEY_CURRENT_USER\SOFTWARE\Keyman\Keyman Engine\Active Keyboards\k_022___options_with_preset\options`
11. 5. Type <kbd>0</kbd> 
12. Verify the key in registry is now `0`