### PR TITLE
fix(android/engine): Download multiple dictionaries

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
@@ -153,19 +153,21 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
     }
 
     try {
-      JSONObject modelInfo = lmData.getJSONObject(0);
-      if (!modelInfo.has("packageFilename") || !modelInfo.has("id")) {
-        KMLog.LogError(TAG, "Error in lexical model metadata from api.keyman.com - missing metadata");
-        return;
-      }
-
-      String _modelID = modelInfo.getString("id");
       ArrayList<CloudApiTypes.CloudApiParam> urls = new ArrayList<>();
-      urls.add(new CloudApiTypes.CloudApiParam(
-        CloudApiTypes.ApiTarget.LexicalModelPackage,
-        modelInfo.getString("packageFilename")));
-      _r.additionalDownloadid = CloudLexicalPackageDownloadCallback.createDownloadId(_modelID);
-      _r.additionalDownloads= urls;
+      for(int i=0; i< lmData.length(); i++) {
+        JSONObject modelInfo = lmData.getJSONObject(i);
+        if (!modelInfo.has("packageFilename") || !modelInfo.has("id")) {
+          KMLog.LogError(TAG, "Error in lexical model metadata from api.keyman.com - missing metadata");
+          return;
+        }
+
+        String _modelID = modelInfo.getString("id");
+        urls.add(new CloudApiTypes.CloudApiParam(
+          CloudApiTypes.ApiTarget.LexicalModelPackage,
+          modelInfo.getString("packageFilename")));
+        _r.additionalDownloadid = CloudLexicalPackageDownloadCallback.createDownloadId(_modelID);
+        _r.additionalDownloads = urls;
+      };
     } catch (JSONException e) {
       KMLog.LogException(TAG, "Error in lexical model metadata from api.keyman.com. ", e);
     }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
@@ -158,7 +158,7 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
         JSONObject modelInfo = lmData.getJSONObject(i);
         if (!modelInfo.has("packageFilename") || !modelInfo.has("id")) {
           KMLog.LogError(TAG, "Error in lexical model metadata from api.keyman.com - missing metadata");
-          return;
+          continue;
         }
 
         String _modelID = modelInfo.getString("id");
@@ -167,7 +167,7 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
           modelInfo.getString("packageFilename")));
         _r.additionalDownloadid = CloudLexicalPackageDownloadCallback.createDownloadId(_modelID);
         _r.additionalDownloads = urls;
-      };
+      }
     } catch (JSONException e) {
       KMLog.LogException(TAG, "Error in lexical model metadata from api.keyman.com. ", e);
     }


### PR DESCRIPTION
For investigating #10673

Currently, the Android app just downloads whatever lexical-model is listed first for a specific language (`lmData.getJSONObject(0)`).

Now that there are two Khmer lexical-models, this updates the Cloud download callback to download all associated lexical-models (should only be a few).

Will fix the UI and banner refresh on separate PR

## User Testing
**Setup** - Install the PR build of Keyman for Android

* **TEST_KHMER_DICTIONARIES** - Verifies both Khmer lexical-models are downloaded.
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. From Keyman settings, install khmer_angkor keyboard
3. Finish the keyboard installation and wait for associated dictionaries to download/install
4. After the dictionaries have installed, on the device turn on Airplane mode (this prevents future downloads)
5. Return to Keyman settings and select --> Installed languages --> Central Khmer --> Dictionary 
6. On the Model Picker menu verify one of the models is enabled (blue checkbox)
7. select the other lexical model
8. Verify a Toast notification "Dictionary installed" and a blue checkbox appears (the dictionary was already downloaded before going into airplane mode)