### PR TITLE
fix(linux): Use temp dir if we can't create cache dir

### DIFF
--- a/linux/keyman-config/keyman_config/get_kmp.py
+++ b/linux/keyman-config/keyman_config/get_kmp.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 import os
+import tempfile
 import time
 
 import requests
@@ -120,7 +121,11 @@ def keyman_cache_dir():
     cachebase = os.environ.get('XDG_CACHE_HOME', os.path.join(home, '.cache'))
     km_cache = os.path.join(cachebase, 'keyman')
     if not os.path.isdir(km_cache):
-        os.mkdir(km_cache)
+        try:
+            os.makedirs(km_cache)
+        except:
+            km_cache = tempfile.TemporaryDirectory().name
+            os.makedirs(km_cache)
     return km_cache
 
 

--- a/linux/keyman-config/tests/test_get_kmp.py
+++ b/linux/keyman-config/tests/test_get_kmp.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python3
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from keyman_config.get_kmp import keyman_cache_dir
+
+
+class TestGetKmp(unittest.TestCase):
+    def _setup_mock(self, arg0):
+        patcher = patch(arg0)
+        result = patcher.start()
+        self.addCleanup(patcher.stop)
+        return result
+
+    def setUp(self):
+        super().setUp()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.mock_expanduser = self._setup_mock('os.path.expanduser')
+        self.mock_expanduser.return_value = self.temp_dir.name
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+        return super().tearDown()
+
+    def test_keyman_cache_dir__all_exists(self):
+        cache_dir = os.path.join(self.temp_dir.name, '.cache')
+        os.mkdir(cache_dir)
+        cache_dir = os.path.join(cache_dir, 'keyman')
+        os.mkdir(cache_dir)
+
+        keyman_cache = keyman_cache_dir()
+
+        self.assertEqual(keyman_cache, cache_dir)
+        self.assertTrue(os.path.exists(cache_dir))
+
+    def test_keyman_cache_dir__cachedir_exists(self):
+        cache_dir = os.path.join(self.temp_dir.name, '.cache')
+        os.mkdir(cache_dir)
+
+        keyman_cache = keyman_cache_dir()
+
+        self.assertEqual(keyman_cache, os.path.join(cache_dir, 'keyman'))
+        self.assertTrue(os.path.exists(os.path.join(cache_dir, 'keyman')))
+
+    def test_keyman_cache_dir__xdg_cache_exists(self):
+        cache_dir = os.path.join(self.temp_dir.name, '.cache')
+        os.mkdir(cache_dir)
+        os.environ['XDG_CACHE_HOME'] = cache_dir
+        self.mock_expanduser.return_value = '/foo'
+
+        keyman_cache = keyman_cache_dir()
+
+        self.assertEqual(keyman_cache, os.path.join(cache_dir, 'keyman'))
+        self.assertTrue(os.path.exists(os.path.join(cache_dir, 'keyman')))
+
+    def test_keyman_cache_dir__not_exist(self):
+        cache_dir = os.path.join(self.temp_dir.name, '.cache')
+
+        keyman_cache = keyman_cache_dir()
+
+        self.assertEqual(keyman_cache, os.path.join(cache_dir, 'keyman'))
+        self.assertTrue(os.path.exists(os.path.join(cache_dir, 'keyman')))
+
+    def test_keyman_cache_dir__cache_is_file(self):
+        cache_dir = os.path.join(self.temp_dir.name, '.cache')
+        with open(cache_dir, 'w', encoding='utf-8') as file:
+            file.write('Test')
+
+        keyman_cache = keyman_cache_dir()
+
+        self.assertFalse(keyman_cache.startswith(self.temp_dir.name))
+        self.assertTrue(os.path.exists(keyman_cache))
+
+    def test_keyman_cache_dir__keyman_is_file(self):
+        cache_dir = os.path.join(self.temp_dir.name, '.cache')
+        os.mkdir(cache_dir)
+        keyman_dir = os.path.join(cache_dir, 'keyman')
+        with open(keyman_dir, 'w', encoding='utf-8') as file:
+            file.write('Test')
+
+        keyman_cache = keyman_cache_dir()
+
+        self.assertFalse(keyman_cache.startswith(self.temp_dir.name))
+        self.assertTrue(os.path.exists(keyman_cache))


### PR DESCRIPTION
If we can't create the cache dir, e.g. if `~/.cache` doesn't exist or if we don't have enough permissions, we now return a temporary directory.

Fixes #10033.

@keymanapp-test-bot skip