### PR TITLE
feat(developer): errs on unparseable regex 🙀

### DIFF
--- a/common/web/types/src/kmx/element-string.ts
+++ b/common/web/types/src/kmx/element-string.ts
@@ -76,8 +76,7 @@ export class ElementString extends Array<ElemElement> {
         const needRanges = sections.usetparser.sizeUnicodeSet(item.segment);
         const uset = sections.usetparser.parseUnicodeSet(item.segment, needRanges);
         if (!uset) {
-          // TODO-LDML - error callback
-          throw Error(`Could not parse uset ${item.segment}`);
+          return null; // UnicodeSet error already thrown
         }
         elem.uset = sections.uset.allocUset(uset, sections);
         elem.value = sections.strs.allocString('', {singleOk: true}); // no string

--- a/common/web/types/src/kmx/kmx-plus.ts
+++ b/common/web/types/src/kmx/kmx-plus.ts
@@ -43,6 +43,7 @@ export class Elem extends Section {
    */
   allocElementString(sections: DependencySections, source: string | string[], order?: string, tertiary?: string, tertiary_base?: string, prebase?: string): ElementString {
     let s = ElementString.fromStrings(sections, source, order, tertiary, tertiary_base, prebase);
+    if (!s) return s;
     let result = this.strings.find(item => item.isEqual(s));
     if(result === undefined) {
       result = s;

--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -465,6 +465,7 @@ export class KmnCompiler implements KeymanCompiler, UnicodeSetParser {
   public parseUnicodeSet(pattern: string, rangeCount: number) : UnicodeSet | null {
     if(!this.verifyInitialized()) {
       /* c8 ignore next 2 */
+      // verifyInitialized will set a callback if needed
       return null;
     }
 

--- a/developer/src/kmc-ldml/src/compiler/messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/messages.ts
@@ -170,8 +170,8 @@ export class CompilerMessages {
   m(this.ERROR_UnparseableReorderSet, `Illegal UnicodeSet "${o.set}" in reorder "${o.from}`);
   static ERROR_UnparseableReorderSet = SevError | 0x0028;
 
-  static Error_UnparseableTransformFrom = (o: { from: string }) =>
-  m(this.ERROR_UnparseableTransformFrom, `Invalid transfom from "${o.from}"`);
+  static Error_UnparseableTransformFrom = (o: { from: string, message: string }) =>
+  m(this.ERROR_UnparseableTransformFrom, `Invalid transfom from "${o.from}": "${o.message}`);
   static ERROR_UnparseableTransformFrom = SevError | 0x0029;
 }
 

--- a/developer/src/kmc-ldml/src/compiler/messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/messages.ts
@@ -166,6 +166,13 @@ export class CompilerMessages {
   m(this.WARN_CharClassExplicitDenorm, `File has character classes which include non-NFD characters(s), including ${util.describeCodepoint(o.lowestCh)}. These will not match any text.`);
   static WARN_CharClassExplicitDenorm = SevWarn | 0x0027;
 
+  static Error_UnparseableReorderSet = (o: { from: string, set: string }) =>
+  m(this.ERROR_UnparseableReorderSet, `Illegal UnicodeSet "${o.set}" in reorder "${o.from}`);
+  static ERROR_UnparseableReorderSet = SevError | 0x0028;
+
+  static Error_UnparseableTransformFrom = (o: { from: string }) =>
+  m(this.ERROR_UnparseableTransformFrom, `Invalid transfom from "${o.from}"`);
+  static ERROR_UnparseableTransformFrom = SevError | 0x0029;
 }
 
 

--- a/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-bad-reorder.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-bad-reorder.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard3 SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard3.dtd">
+<keyboard3 locale="mt" conformsTo="techpreview">
+  <info name="fail-bad-reorder"/>
+
+  <keys />
+
+  <transforms type="simple">
+    <transformGroup>
+      <reorder from="[unterminated-unicode-set" order="0" tertiaryBase="true" />
+    </transformGroup>
+  </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-bad-tran-1.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-bad-tran-1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE keyboard3 SYSTEM "../../../../../../../resources/standards-data/ldml-keyboards/techpreview/dtd/ldmlKeyboard3.dtd">
+<keyboard3 locale="mt" conformsTo="techpreview">
+  <info name="fail-bad-tran-1"/>
+
+  <keys />
+
+  <transforms type="simple">
+    <transformGroup>
+      <transform from="AB(now if only I would terminate this group.." to="x"/>
+    </transformGroup>
+  </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/test-tran.ts
+++ b/developer/src/kmc-ldml/test/test-tran.ts
@@ -274,7 +274,9 @@ describe('tran', function () {
     {
       subpath: `sections/tran/fail-bad-tran-1.xml`,
       errors: [
-        CompilerMessages.Error_UnparseableTransformFrom({ from: 'AB(now if only I would terminate this group..' }),
+        CompilerMessages.Error_UnparseableTransformFrom({ from: 'AB(now if only I would terminate this group..',
+        // this message is dependent on v8, so this test could be a little brittle.
+        message: 'Invalid regular expression: /AB(now if only I would terminate this group../: Unterminated group' }),
       ],
     },
   ], tranDependencies);

--- a/developer/src/kmc-ldml/test/test-tran.ts
+++ b/developer/src/kmc-ldml/test/test-tran.ts
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import { TranCompiler, BkspCompiler } from '../src/compiler/tran.js';
 import { BASIC_DEPENDENCIES, UsetCompiler } from '../src/compiler/empty-compiler.js';
 import { CompilerMessages } from '../src/compiler/messages.js';
+import { CompilerMessages as KmnOtherCompilerMessages } from '@keymanapp/kmc-kmn';
 import { assertCodePoints, compilerTestCallbacks, testCompilationCases } from './helpers/index.js';
 import { KMXPlus, MarkerParser } from '@keymanapp/common-types';
 
@@ -261,6 +262,19 @@ describe('tran', function () {
       subpath: 'sections/tran/tran-hint-range2.xml',
       warnings: [
         CompilerMessages.Hint_CharClassImplicitDenorm({lowestCh: 0xC0}),
+      ],
+    },
+    {
+      subpath: 'sections/tran/fail-bad-reorder.xml',
+      errors: [
+        KmnOtherCompilerMessages.Error_UnicodeSetSyntaxError()
+      ],
+    },
+    // error due to bad regex
+    {
+      subpath: `sections/tran/fail-bad-tran-1.xml`,
+      errors: [
+        CompilerMessages.Error_UnparseableTransformFrom({ from: 'AB(now if only I would terminate this group..' }),
       ],
     },
   ], tranDependencies);


### PR DESCRIPTION
- also, make sure NFD-incompliant ranges get mapped to escaped chars
- also, propagate UnicodeSet errs out

For: #10389

@keymanapp-test-bot skip