### PR TITLE
fix(web): disables banner interaction when suggestions are absent

### DIFF
--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -498,7 +498,9 @@ export class SuggestionBanner extends Banner {
           const optionBounding = option.div.getBoundingClientRect();
 
           if(optionBounding.left <= sample.clientX && sample.clientX < optionBounding.right) {
-            return option;
+            // If there is no backing suggestion, then there's no real selection.
+            // May happen when no suggestions are available.
+            return option.suggestion ? option : null;
           } else {
             const dist = (sample.clientX < optionBounding.left ? -1 : 1) * (sample.clientX - optionBounding.left);
 
@@ -509,7 +511,8 @@ export class SuggestionBanner extends Banner {
           }
         }
 
-        return bestMatch;
+        // If there is no backing suggestion, then there's no real selection.
+        return bestMatch.suggestion ? bestMatch : null;
       }
     };
 
@@ -557,7 +560,7 @@ export class SuggestionBanner extends Banner {
       sourceTracker.source = source;
       sourceTracker.scrollingHandler = (sample) => {
         const newScrollLeft = this.scrollState.updateTo(sample);
-        this.highlightAnimation.setBaseScroll(newScrollLeft);
+        this.highlightAnimation?.setBaseScroll(newScrollLeft);
 
           // Only re-enable the original suggestion, even if the touchpoint finds
           // itself over a different suggestion.  Might happen if a scroll boundary
@@ -578,9 +581,9 @@ export class SuggestionBanner extends Banner {
       };
 
       sourceTracker.suggestion = source.currentSample.item;
-      markSelection(sourceTracker.suggestion);
-
-      source.currentSample.item.highlight(true);
+      if(sourceTracker.suggestion) {
+        markSelection(sourceTracker.suggestion);
+      }
 
       const terminationHandler = () => {
         if(sourceTracker.suggestion) {


### PR DESCRIPTION
Fixes #10694.

When no suggestions are available, the banner should be non-interactive.  However, at present (17.0.265), you can select an "empty suggestion".  This can lead to other unintended interactions, such as #10642, and feels a bit unpolished - it _is_ weird to "select nothing" and have that be acknowledged.

## User Testing

TEST_NO_SUGGESTIONS:  Using the Android test artifact, verify that the banner is not interactive when no suggestions are present.

- Suggested keyboard: EuroLatin (SIL)
- Simply type a long bit of random text until no suggestions are available, then try to interact with the banner.
   - When touching a suggestion, drag your finger side to side for a bit, then up and down for a bit. 
- If any part of the banner highlights during the attempted interaction, FAIL this test.
- If any error notifications appear when interacting with the banner, FAIL this test.

TEST_NORMAL_PREDICTIONS:  Using the Android test artifact, verify that the banner acts normally when suggestions are present.