### PR TITLE
fix(web): longpress validation by base key, not current location

### DIFF
--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -443,7 +443,7 @@ export function longpressContactModel(params: GestureParams, enabledFlicks: bool
       duration: spec.waitLength,
       expectedResult: true
     },
-    validateItem: (key: KeyElement) => !!key?.key.spec.sk,
+    validateItem: (_: KeyElement, baseKey: KeyElement) => !!baseKey?.key.spec.sk,
     pathModel: {
       evaluate: (path) => {
         const stats = path.stats;


### PR DESCRIPTION
Fixes #10640.

The model-validation function for longpresses wasn't specified properly; it is supposed to validate based on the touch's _base_ key, not most recent key underneath the finger.  It is possible for the two to differ on lower-performance devices, as confirmed by https://github.com/keymanapp/keyman/issues/10640#issuecomment-1943080633.

## User Testing

TEST_SPACEBAR_UP_FLICK:  Using the Keyman for Android app (emulated or otherwise), ensure that no errors occur when dragging a touch rapidly from the spacebar to the banner.

1. Type a long word, such that there are no suggestions available in the banner. 
2. Starting a touch on the space bar, drag your finger from the space bar to the suggestion banner in different directions.
3. If any error notifications pop up, FAIL this test.
4. Do _not_ fail this test should the predictive-text banner highlight; this PR does not include the fix from #10695.

In essence, attempt to reproduce this user-test failure:  https://github.com/keymanapp/keyman/pull/10695#issuecomment-1941457876

