### PR TITLE
chore: workaround release inc build block

### DIFF
--- a/resources/build/version/src/fixupHistory.ts
+++ b/resources/build/version/src/fixupHistory.ts
@@ -184,7 +184,7 @@ export const sendCommentToPullRequestAndRelatedIssues = async (
  */
 
 export const fixupHistory = async (
-  octokit: GitHub, base: string, force: boolean, writeGithubComment: boolean
+  octokit: GitHub, base: string, force: boolean, writeGithubComment: boolean, from?: string, to?: string
 ): Promise<number> => {
 
   //
@@ -194,7 +194,7 @@ export const fixupHistory = async (
   let pulls: PRInformation[] = [];
 
   try {
-    pulls = await reportHistory(octokit, base, force, false);
+    pulls = await reportHistory(octokit, base, force, false, from, to);
   } catch(e) {
     logWarning(String(e));
     return -1;

--- a/resources/build/version/src/index.ts
+++ b/resources/build/version/src/index.ts
@@ -108,7 +108,7 @@ const main = async (): Promise<void> => {
 
   if(argv._.includes('history')) {
     logInfo(`# Validating history for ${version}`);
-    changeCount = await fixupHistory(octokit, argv.base, argv.force, argv['write-github-comment']);
+    changeCount = await fixupHistory(octokit, argv.base, argv.force, argv['write-github-comment'], argv.from, argv.to);
     logInfo(`# ${changeCount} change(s) found for ${version}\n`);
   }
 


### PR DESCRIPTION
Fixes #10721.

This arose partly because of the change from release- to release@ in at 17.0.30-alpha (triggered by sentry req). Will require a corresponding patch to CI script to pass the --from and --to parameters.

@keymanapp-test-bot skip