### PR TITLE
fix(web): sticky special-key highlighting

### DIFF
--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -489,8 +489,8 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
           if(previewHost) {
             this.gesturePreviewHost = previewHost;
             trackingEntry.previewHost = previewHost;
-            sourceTrackingMap[source.identifier].key = key;
           }
+          sourceTrackingMap[source.identifier].key = key;
         }
       }
 


### PR DESCRIPTION
Fixes #10687.
Fixes #10703.

## User Testing

TEST_STICKY_SPECIAL_HIGHLIGHTS:  Verify that special key highlighting is no longer 'sticky'.

1. Using the EuroLatin (SIL) keyboard within the Keyman for Android app...
2. Start a touch on the space bar...
3. ...and drag it over the globe and shift keys before reaching the banner leaves those keys highlighted.
4. Verify that no keys are highlighted at the end of this sequence.
5. Verify that there was no point in time where two keys were simultaneously highlighted.