### PR TITLE
docs(common): Update website README

### DIFF
--- a/docs/websites/README.md
+++ b/docs/websites/README.md
@@ -1,11 +1,8 @@
 # How to Set Up a Local Web Server for the Keyman Web Pages
 
-Currently, most of the Keyman websites are running via IIS. Refer to the Keyman [wiki](https://github.com/keymanapp/keyman/wiki/How-to-set-up-a-local-web-server-for-the-Keyman-web-pages) for setting that up on Windows 10.
+Currently, most of the Keyman websites (*.keyman.com, *.keyman-staging.com) are running PHP 7.4 via Apache.
 
-To make IIS redirects compatible with the Docker sites below, see
-https://github.com/keymanapp/keyman.com/issues/337#issuecomment-1336339387
-
-As the websites get migrated to Apache via Docker, follow the installation steps below:
+For legacy configuration of IIS on Windows 10, refer to the deprecated Keyman [wiki](https://github.com/keymanapp/keyman/wiki/%5BDeprecated%5D-How-to-set-up-a-local-IIS-web-server-for-the-Keyman-web-pages).
 
 ## Pre-requisite Installs
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/)
@@ -19,7 +16,7 @@ https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers
 #### Other Docker Notes
 Docker tends to throttle Docker image downloads, so some developer offices may want to set up a proxy server. If the proxy server is set up, carefully edit the JSON file per in Docker Settings -> Docker Engine https://docs.docker.com/registry/recipes/mirror/#configure-the-docker-daemon and click 'Apply & Restart'. Note the example (lingnet) is for running inside the Linguistics Institute (Chiang Mai)
 
-```
+```json
  "registry-mirrors": ["https://docker.io.registry.lingnet/"],
   "insecure-registries" : [
     "docker.io.registry.lingnet",
@@ -30,7 +27,7 @@ Docker tends to throttle Docker image downloads, so some developer offices may w
 ### Using Website-Local-Proxy
 Rather than remembering localhost port values below, you can clone and run [website-local-proxy](https://github.com/keymanapp/website-local-proxy).
 
-Follow https://github.com/keymanapp/website-local-proxy?tab=readme-ov-file#using-website-local-proxy and you can access the local websites at
+Refer to the [port lookup table](#port-lookup-table) to access the local websites at
 http://*keyman.com.localhost
 
 ## Builder BASH Script Actions
@@ -58,6 +55,7 @@ This maps the local directory to the the Docker image.
 For sites that use Composer dependencies, this step also creates a link in the Docker image from /var/www/vendor/ to /var/www/html/vendor.
 The link file also appears locally.
 
+##### Port lookup table
 After this, you can access the website at the following ports:
 
 | Website        |          URL          |  with website-local-proxy running |
@@ -73,6 +71,10 @@ After this, you can access the website at the following ports:
 1. Run `./build.sh clean`.
 
 #### Running tests
+You might need to install the broken-link-checker first
+
+`npm install broken-link-checker`
+
 Checks for broken links
 1. Run `./build.sh test`
 

--- a/docs/websites/README.md
+++ b/docs/websites/README.md
@@ -2,8 +2,6 @@
 
 Currently, most of the Keyman websites (*.keyman.com, *.keyman-staging.com) are running PHP 7.4 via Apache.
 
-For legacy configuration of IIS on Windows 10, refer to the deprecated Keyman [wiki](https://github.com/keymanapp/keyman/wiki/%5BDeprecated%5D-How-to-set-up-a-local-IIS-web-server-for-the-Keyman-web-pages).
-
 ## Pre-requisite Installs
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 


### PR DESCRIPTION
Now that the Keyman websites have migrated from IIS to Apache, this does some minor cleanup of the websites/README.md.

@keymanapp-test-bot skip
