### PR TITLE
fix(web): handling of page-elements focused before engine initialization

### DIFF
--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -1,7 +1,7 @@
 import { type Keyboard, KeyboardScriptError } from '@keymanapp/keyboard-processor';
 import { type KeyboardStub } from 'keyman/engine/package-cache';
 import { CookieSerializer } from 'keyman/engine/dom-utils';
-import { eventOutputTarget, PageContextAttachment } from 'keyman/engine/attachment';
+import { eventOutputTarget, outputTargetForElement, PageContextAttachment } from 'keyman/engine/attachment';
 import { DomEventTracker, LegacyEventEmitter } from 'keyman/engine/events';
 import { DesignIFrame, OutputTarget, nestedInstanceOf } from 'keyman/engine/element-wrappers';
 import {
@@ -121,6 +121,10 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
             this.domEventTracker.attachDOMEvent(Lelem.body,'focus', this._ControlFocus);
             this.domEventTracker.attachDOMEvent(Lelem.body,'blur', this._ControlBlur);
           }
+        }
+
+        if(elem.ownerDocument.activeElement == elem) {
+          this.setActiveTarget(outputTargetForElement(elem), true);
         }
       });
 

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -52,6 +52,7 @@ export default class KeymanEngine<
       if(callback) {
         callback(null, null);
       }
+      return;
     }
 
     if(this.keyEventRefocus) {

--- a/web/src/test/manual/web/index.html
+++ b/web/src/test/manual/web/index.html
@@ -74,6 +74,7 @@
   <h2><a href="./issue9469/index.html">Test special characters rendering with keymanweb-osk.ttf (#9469)</a></h2>
   <h2><a href="./text_selection_tests_9073/index.html">Test text selection (#9073)</a></h2>
   <h2><a href="./pr10506/index.html">Test key-cap scaling / font load interactions (#10506)</a></h2>
+  <h2><a href="./init-race-10743/index.html">Test page interaction + engine-initialization race condition handling (#10743)</a></h2>
   <h1>Other</h1>
   <h2><a href="./regression-tests/index.html">Keystroke processing regression test engine.</a></h2>
   <hr>

--- a/web/src/test/manual/web/init-race-10743/index.html
+++ b/web/src/test/manual/web/init-race-10743/index.html
@@ -53,7 +53,7 @@
 
 <!-- Sample page HTML -->
   <body>
-    <h2>KeymanWeb Sample Page - Page-init racing</h2>
+    <h2>KeymanWeb Sample Page - Page interaction / engine-init racing</h2>
 
     <div>KeymanWeb will not initialize for the first five seconds after loading.  Start typing in
       one of the elements indicated below before that in order to test engine-init / user-typing

--- a/web/src/test/manual/web/init-race-10743/index.html
+++ b/web/src/test/manual/web/init-race-10743/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+
+    <!-- Set the viewport width to match phone and tablet device widths -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
+
+    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+
+    <!-- Enable IE9 Standards mode -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+    <title>KeymanWeb Sample Page - Unminified Source</title>
+
+    <!-- Your page CSS -->
+    <style type='text/css'>
+      body {font-family: Tahoma,helvetica;}
+      h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
+      .test {font-size: 24px; width:80%; min-height:30px; border: 1px solid gray;}
+      #KeymanWebControl {width:50%;min-width:600px;}
+    </style>
+
+    <!-- Insert uncompiled KeymanWeb source scripts -->
+    <script src="../../../../../build/publish/debug/keymanweb.js" type="application/javascript"></script>
+
+    <!--
+      For desktop browsers, a script for the user interface must be inserted here.
+
+      Standard UIs are toggle, button, float and toolbar.
+      The toolbar UI is best for any page designed to support keyboards for
+      a large number of languages.
+    -->
+    <script src="../../../../../build/publish/debug/kmwuitoggle.js"></script>
+
+    <!-- Initialization: set paths to keyboards, resources and fonts as required -->
+    <script>
+      var kmw=window.keyman;
+      window.setTimeout(() => {
+        kmw.init({
+          attachType:'auto',
+        }).then(function() {
+          loadKeyboards(1);
+        });
+      }, 5000);
+    </script>
+
+    <!-- Add keyboard management script for local selection of keyboards to use -->
+    <script src="../commonHeader.js"></script>
+
+  </head>
+
+<!-- Sample page HTML -->
+  <body>
+    <h2>KeymanWeb Sample Page - Page-init racing</h2>
+
+    <div>KeymanWeb will not initialize for the first five seconds after loading.  Start typing in
+      one of the elements indicated below before that in order to test engine-init / user-typing
+      race condition handling.
+    </div>
+    <!--
+      The following DIV is used to position the Button or Toolbar User Interfaces on the page.
+      If omitted, those User Interfaces will appear at the top of the document body.
+      (It is ignored by other User Interfaces.)
+    -->
+    <div id='KeymanWebControl'></div>
+
+    <h3>Type in your language in this text area:</h3>
+    <textarea id='ta1' class='test' placeholder='Type here'></textarea>
+
+    <h3>or in this input field:</h3>
+    <input class='test' value='' placeholder='or here'/>
+
+    <!--  The following elements show how the language menu can be dynamically extended at any time -->
+    <h3>Add a keyboard by keyboard name:</h3>
+    <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
+    <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
+
+    <h3>Add a keyboard by BCP-47 language code:</h3>
+    <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
+    <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
+
+    <h3>Add a keyboard by language name(s):</h3>
+    <input type='input' id='kbd_id3' class='kmw-disabled' onkeypress="clickOnEnter(event,3);"/>
+    <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />
+
+    <h3><a href="./">Return to testing home page</a></h3>
+  </div>
+
+  <!-- include a blank div to enable scrolling -->
+  <div style="height:1000px"></div>
+  <p>--End of Document--</p>
+
+  </body>
+
+  <!--
+    *** DEVELOPER NOTE -- FIREFOX CONFIGURATION FOR TESTING ***
+    *
+    * If the URL bar starts with <b>file://</b>, Firefox may not load the font used
+    * to display the special characters used in the On-Screen Keyboard.
+    *
+    * To work around this Firefox bug, navigate to <b>about:config</b>
+    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b>
+    * while testing.
+    *
+    * Firefox resolves website-based CSS URI references correctly without needing
+    * any configuration change, so this change should only be made for file-based testing.
+    *
+    ***
+  -->
+</html>


### PR DESCRIPTION
Fixes #10743.

It was possible for a user to experience a race condition against KMW's initialization process if they attempted to start typing too quickly.  While we won't defer keystrokes that occur before initialization, we can at least prevent them from triggering errors.

## User Testing

TEST_MAIN:  Using the new "Test page interaction + engine-initialization race condition handling (#10743)" KeymanWeb test page, verify that the OSK displays under the following condition:

1. Go to the new "Test page interaction + engine-initialization race condition handling (#10743)" KeymanWeb test page on a desktop device.
2. Quickly select either of the two first text-accepting page elements ("Type here", "or here")
3. Type random text for at least 10 seconds.  Do not change to a different element or press TAB.
4. If the output text's font does not change after 10 seconds, FAIL this test.
5. If the OSK does not appear after 10 seconds, FAIL this test.
6. If both conditions are met, you no longer need to wait the 10 seconds.