### PR TITLE
fix(web): disables modipress for layer-switch keys with subkeys

### DIFF
--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -153,8 +153,16 @@ function buildDistFromKeyCentroidFunctor(key: KeyElement) {
 
 export function keySupportsModipress(key: KeyElement) {
   const keySpec = key.key.spec;
+
+  // A key cannot reasonably support both longpresses and modipresses.
+  // It'd be quite ugly to overlay the subkey menu over the new layer during a modipress.
+  if(keySpec.sk) {
+    return false;
+  }
+
   const modifierKeyIds = ['K_SHIFT', 'K_ALT', 'K_CTRL', 'K_NUMERALS', 'K_SYMBOLS', 'K_CURRENCIES'];
   for(const modKeyId of modifierKeyIds) {
+
     if(keySpec.id == modKeyId) {
       return true;
     }


### PR DESCRIPTION
Fixes #10742.

I'm not sure it's the _ideal_ solution, as it does cause such keys to behave noticeably different from layer-switch keys without subkeys... but it does resolve the main issue in which certain parts of the keyboard became wholly inaccessible.

If naught else, that caveat is simply one more push toward not designing longpresses on layer-switch keys.

@keymanapp-test-bot skip