### PR TITLE
fix(developer): allow more parameters in kmc.cmd

### DIFF
--- a/developer/src/inst/node/kmc.cmd
+++ b/developer/src/inst/node/kmc.cmd
@@ -8,5 +8,15 @@ if "%1" == "--enable-source-maps" (
 ) else (
   set ESM=
 )
-"%~dp0\node.js\node.exe" %ESM% "%~dp0\kmc\kmc.mjs" %1 %2 %3 %4 %5 %6 %7 %8 %9
+
+rem "%*" doesn't work with shift https://stackoverflow.com/a/34005255/1836776
+set params=
+:build_params
+if @%1==@ goto :finished_building_params
+set params=%params% %1
+shift
+goto :build_params
+:finished_building_params
+
+"%~dp0\node.js\node.exe" %ESM% "%~dp0\kmc\kmc.mjs" %params%
 exit /b %errorlevel%

--- a/developer/src/inst/node/kmc.cmd
+++ b/developer/src/inst/node/kmc.cmd
@@ -2,6 +2,9 @@
 rem This script avoids path dependencies for node for distribution
 rem with Keyman Developer. When used on platforms other than Windows,
 rem node can be used directly with the compiler (`npm link` will setup).
+
+set root=%~dp0
+
 if "%1" == "--enable-source-maps" (
   set ESM=--enable-source-maps
   shift
@@ -18,5 +21,5 @@ shift
 goto :build_params
 :finished_building_params
 
-"%~dp0\node.js\node.exe" %ESM% "%~dp0\kmc\kmc.mjs" %params%
+"%root%\node.js\node.exe" %ESM% "%root%\kmc\kmc.mjs" %params%
 exit /b %errorlevel%


### PR DESCRIPTION
Fixes #10751.

# User Testing

* **TEST_DEBUGGER:** Try to debug a keyboard in Keyman Developer, in the same way as described in #10751. The debugger should start without the error now.