### PR TITLE
fix(android): Match phone suggestion banner styling on tablet

### DIFF
--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -204,7 +204,8 @@
 
 .phone.android.kmw-osk-frame { background-color: #222;}
 
-.phone.android .kmw-banner-bar {
+.phone.android .kmw-banner-bar,
+.tablet.android .kmw-banner-bar {  
   background-color: #222;
   position: relative;
   margin-top: 4px;
@@ -293,14 +294,6 @@
 .tablet.android .kmw-key.kmw-spacebar.kmw-key-touched {background-color: #447;}
 .tablet.android .kmw-spacebar-caption {color: #aaa;}
 .tablet.android .kmw-key-deadkey{color:#0d0;background-color:#777;}
-
-.tablet.android .kmw-banner-bar {
-  background-color: #222;
-  position: relative;
-  margin-top: 4px;
-  height: 100%;
-  width: 100%;
-}
 
 .tablet.android .kmw-suggest-option::before {
   background: linear-gradient(90deg, #222 0px, transparent 100%);

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -295,7 +295,7 @@
 .tablet.android .kmw-key-deadkey{color:#0d0;background-color:#777;}
 
 .tablet.android .kmw-banner-bar {
-  background-color: #b4b4b8;
+  background-color: #222;
   position: relative;
   margin-top: 4px;
   height: 100%;
@@ -303,11 +303,11 @@
 }
 
 .tablet.android .kmw-suggest-option::before {
-  background: linear-gradient(90deg, #b4b4b8 0px, transparent 100%);
+  background: linear-gradient(90deg, #222 0px, transparent 100%);
 }
 
 .tablet.android .kmw-suggest-option::after {
-  background: linear-gradient(90deg, transparent 0%, #b4b4b8 100%);
+  background: linear-gradient(90deg, transparent 0%, #222 100%);
 }
 
 .tablet.android .kmw-banner-bar .kmw-suggest-option {
@@ -317,17 +317,17 @@
 }
 
 .tablet.android .kmw-suggestion-text {
-  color:#77f;
+  color:#fff;
 }
 
-.tablet.android .kmw-suggest-option.kmw-suggest-touched {background-color:#447;}
+.tablet.android .kmw-suggest-option.kmw-suggest-touched {background-color:#bbb;}
 
 .tablet.android .kmw-suggest-option.kmw-suggest-touched::before {
-  background: linear-gradient(90deg, #447 0px, transparent 100%);
+  background: linear-gradient(90deg, #bbb 0px, transparent 100%);
 }
 
 .tablet.android .kmw-suggest-option.kmw-suggest-touched::after {
-  background: linear-gradient(90deg, transparent 0%, #447 100%);
+  background: linear-gradient(90deg, transparent 0%, #bbb 100%);
 }
 
 /* Vertical centering of text labels on keys */


### PR DESCRIPTION
Fixes #10755
Back in #4153 the Android tablet OSK styling was changed to match the phone OSK styling.

To fix the tablet suggestion banner contrast, this PR changes the tablet suggestion banner styling to match the phone.

## User Testing
**Setup** - Install the PR build of Keyman for Android and a tablet emulator/device

* **TEST_TABLET_BANNER** - Verifies tablet suggestion banner text is visible
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. Verify the default English suggestion banner shows black background and white text
![portrait](https://github.com/keymanapp/keyman/assets/7358010/428f976d-0999-41ba-bc09-9d6dbcb3bef3)

3. Press and hold a suggestion
4. Verify the touched suggestion has a gray background with white text
![selected](https://github.com/keymanapp/keyman/assets/7358010/e5573874-efe8-4938-aa2e-0463f8341d38)
