### PR TITLE
chore(linux): Fix `debian.sh` by removing quotes

### DIFF
--- a/linux/scripts/debian.sh
+++ b/linux/scripts/debian.sh
@@ -32,10 +32,11 @@ for proj in ${projects}; do
     downloadSource debianpackage
 
     cd "${proj}-${version}"
-    if [ -n "$DIST" ]; then
-        EXTRA_ARGS="--distribution $DIST --force-distribution"
+    if [[ -n "${DIST}" ]]; then
+        EXTRA_ARGS="--distribution ${DIST} --force-distribution"
     fi
-    dch --newversion "${version}-${DEBREVISION-1}" "${EXTRA_ARGS}" "Re-release to Debian"
+    # shellcheck disable=SC2086
+    dch --newversion "${version}-${DEBREVISION-1}" ${EXTRA_ARGS} "Re-release to Debian"
     debuild -d -S -sa -Zxz
     cd "${BASEDIR}"
 done


### PR DESCRIPTION
We want `EXTRA_ARGS` to be split so that we end up with different arguments.

@keymanapp-test-bot skip