### PR TITLE
fix(developer): ensure fatal errors report message or made non-fatal

### DIFF
--- a/common/test/keyboards/invalid/README.md
+++ b/common/test/keyboards/invalid/README.md
@@ -43,20 +43,20 @@ While running, kmcompxtest extracts those 4 characters from the Filename (e.g. 4
 ### Tests are available for the following CERR_:
 <font size="1">
 
-|     | Error Number | CERR_                               
+|     | Error Number | CERR_
 | :-: | :-----------:| :-------------------------------------
-|     | 00000800     |  CERR_LEXICAL_MODEL_MIN  
+|     | 00000800     |  CERR_LEXICAL_MODEL_MIN
 |     | 000008FF     |  CERR_LEXICAL_MODEL_MAX
 |     | 00000800     |  CERR_LEXICAL_MODEL_MIN
 |     | 000008FF     |  CERR_LEXICAL_MODEL_MAX
 |     | 00000000     |  CERR_None
-|     | 00000001     |  CERR_EndOfFile 
+|     | 00000001     |  CERR_EndOfFile
 |     | 00008002     |  CERR_BadCallParams
 |     | 00008004     |  CERR_CannotAllocateMemory
-|     | 00008005     |  CERR_InfileNotExist
-|     | 00008006     |  CERR_CannotCreateOutfile
+|     | 00004005     |  CERR_InfileNotExist
+|     | 00004006     |  // CERR_CannotCreateOutfile
 |     | 00008007     |  CERR_UnableToWriteFully
-|     | 00008008     |  CERR_CannotReadInfile
+|     | 00004008     |  CERR_CannotReadInfile
 |     | 00008009     |  CERR_SomewhereIGotItWrong
 |**X**| 0000400A     |  CERR_InvalidToken
 |     | 0000400B     |  CERR_InvalidBegin

--- a/developer/src/common/include/kmn_compiler_errors.h
+++ b/developer/src/common/include/kmn_compiler_errors.h
@@ -41,19 +41,20 @@
 
 // Message codes
 //
-// All errors here and below are mirrored in kmc-kmn/src/compiler/messages.ts;
-// if you add a new error here be sure to update that file also. Note that this
-// correlation is currently maintained manually. All values must be below
-// 0x1000 (exclusive of severity code).
+// All errors here and below are mirrored in
+// kmc-kmn/src/compiler/kmn-compiler-messages.ts; if you add a new error here be
+// sure to update that file also. Note that this correlation is currently
+// maintained manually. All values must be below 0x1000 (exclusive of severity
+// code).
 #define CERR_None                                          0x00000000
 #define CERR_EndOfFile                                     0x00000001
 
 #define CERR_BadCallParams                                 0x00008002
 #define CERR_CannotAllocateMemory                          0x00008004
-#define CERR_InfileNotExist                                0x00008005
-#define CERR_CannotCreateOutfile                           0x00008006
+#define CERR_InfileNotExist                                0x00004005   // #10678: reduced from fatal to error in 17.0
+// #define CERR_CannotCreateOutfile                           0x00004006   // #10678: reduced from fatal to error in 17.0, but unused
 #define CERR_UnableToWriteFully                            0x00008007
-#define CERR_CannotReadInfile                              0x00008008
+#define CERR_CannotReadInfile                              0x00004008   // #10678: reduced from fatal to error in 17.0
 #define CERR_SomewhereIGotItWrong                          0x00008009
 
 #define CERR_InvalidToken                                  0x0000400A

--- a/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
@@ -112,10 +112,10 @@ export class KmnCompilerMessages {
 
   static FATAL_BadCallParams                                  = SevFatal | 0x002;
   static FATAL_CannotAllocateMemory                           = SevFatal | 0x004;
-  static FATAL_InfileNotExist                                 = SevFatal | 0x005;
-  static FATAL_CannotCreateOutfile                            = SevFatal | 0x006;
+  static ERROR_InfileNotExist                                 = SevError | 0x005; // #10678: reduced from fatal to error in 17.0
+  // static ERROR_CannotCreateOutfile                            = SevError | 0x006; // #10678: reduced from fatal to error in 17.0, but unused
   static FATAL_UnableToWriteFully                             = SevFatal | 0x007;
-  static FATAL_CannotReadInfile                               = SevFatal | 0x008;
+  static ERROR_CannotReadInfile                               = SevError | 0x008; // #10678: reduced from fatal to error in 17.0
   static FATAL_SomewhereIGotItWrong                           = SevFatal | 0x009;
 
   static ERROR_InvalidToken                                   = SevError | 0x00A;

--- a/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
@@ -139,7 +139,7 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
     if(CompilerError.severity(event.code) == CompilerErrorSeverity.Fatal) {
       // this is async so returns a Promise, we'll let it resolve in its own
       // time, and it will emit a message to stderr with details at that time
-      KeymanSentry.reportException(event.exceptionVar, false);
+      KeymanSentry.reportException(event.exceptionVar ?? event.message, false);
     }
 
     if(disable || CompilerError.severity(event.code) < compilerLogLevelToSeverity[this.options.logLevel]) {

--- a/developer/src/kmcmplib/src/CompMsg.cpp
+++ b/developer/src/kmcmplib/src/CompMsg.cpp
@@ -24,7 +24,7 @@ const struct CompilerError CompilerErrors[] = {
     { CERR_IndexInVirtualKeySection                      , "'index' command is illegal in virtual key section"},
     { CERR_BadCallParams                                 , "CompileKeyboardFile was called with bad parameters"},
     { CERR_InfileNotExist                                , "Cannot find the input file"},
-    { CERR_CannotCreateOutfile                           , "Cannot open output file for writing"},
+    // { CERR_CannotCreateOutfile                           , "Cannot open output file for writing"}, unused
     { CERR_UnableToWriteFully                            , "Unable to write the file completely"},
     { CERR_CannotReadInfile                              , "Cannot read the input file"},
     { CERR_SomewhereIGotItWrong                          , "Internal error: contact Keyman"},


### PR DESCRIPTION
Fixes #10678.

Some messages have been reduced to ERROR instead of FATAL, as they are not internal compiler errors.

Where fatal messages are raised, the message will now be reported through correctly to Sentry.

@keymanapp-test-bot skip