### PR TITLE
fix(developer): reset debugger after ldml keyboard compile

### DIFF
--- a/developer/src/tike/actions/dmActionsKeyboardEditor.pas
+++ b/developer/src/tike/actions/dmActionsKeyboardEditor.pas
@@ -1,18 +1,18 @@
 (*
   Name:             dmActionsKeyboardEditor
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      23 Aug 2006
 
   Modified Date:    4 May 2015
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          23 Aug 2006 - mcdurdin - Initial version
                     14 Sep 2006 - mcdurdin - Add debugger actions
                     28 Sep 2006 - mcdurdin - Added Test Keyboard menu item
@@ -33,7 +33,7 @@
                     04 Nov 2014 - mcdurdin - I4504 - V9.0 - Consolidate the compile action into single command
                     04 May 2015 - mcdurdin - I4686 - V9.0 - Refactor compile into project file action
                     04 May 2015 - mcdurdin - I4687 - V9.0 - Split project UI actions into separate classes
-                    
+
 *)
 unit dmActionsKeyboardEditor;  // I3306  // I3323
 
@@ -202,7 +202,11 @@ begin
   end
   else if ActiveLdmlKeyboardEditor <> nil then
   begin
-    ActiveProjectFileUI.DoAction(pfaCompile, False);
+    if not ActiveLdmlKeyboardEditor.PrepareForBuild(DebugReset) then
+      Exit;
+
+    if ActiveProjectFileUI.DoAction(pfaCompile, False) and DebugReset then
+      ActiveLdmlKeyboardEditor.StartDebugging;
   end
   else if ActivePackageEditor <> nil then
   begin

--- a/developer/src/tike/child/Keyman.Developer.UI.UfrmLdmlKeyboardEditor.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.UfrmLdmlKeyboardEditor.pas
@@ -35,6 +35,7 @@ type
   public
     procedure StartDebugging;
     procedure StopDebugging;
+    function PrepareForBuild(var DebugReset: Boolean): Boolean;
     property DebugForm: TfrmLdmlKeyboardDebug read FDebugForm;
     property IsDebugVisible: Boolean read GetIsDebugVisible;
   end;
@@ -43,10 +44,12 @@ implementation
 
 uses
   keymanstrings,
+  KeymanDeveloperOptions,
   Keyman.System.Debug.DebugUIStatus,
   Keyman.Developer.System.Project.xmlLdmlProjectFile,
   Keyman.Developer.UI.Project.ProjectFileUI,
   Keyman.Developer.UI.Project.xmlLdmlProjectFileUI,
+  Keyman.Developer.UI.UfrmMessageDlgWithSave,
   KeymanDeveloperUtils,
   TextFileFormat,
   UfrmMessages;
@@ -144,5 +147,33 @@ begin
 
   inherited;
 end;
+
+function TfrmLdmlKeyboardEditor.PrepareForBuild(var DebugReset: Boolean): Boolean;
+var
+  FSave: Boolean;
+begin
+  if IsDebugVisible then
+  begin
+    if not FKeymanDeveloperOptions.DebuggerAutoResetBeforeCompiling then
+    begin
+      if TfrmMessageDlgWithSave.Execute(
+          'You must reset the debugger before recompiling your keyboard.  Reset the debugger and recompile?',
+          'Always reset the debugger automatically before compiling',
+          '', True, FSave) in [mrNo, mrCancel] then
+        Exit(False);
+      if FSave then
+      begin
+        FKeymanDeveloperOptions.DebuggerAutoResetBeforeCompiling := True;
+        FKeymanDeveloperOptions.Write;
+      end;
+    end;
+
+    DebugReset := True;
+    StopDebugging;
+  end;
+
+  Result := True;
+end;
+
 
 end.


### PR DESCRIPTION
Fixes #10545.

@keymanapp-test-bot skip