### PR TITLE
fix(developer): crash opening invalid project

### DIFF
--- a/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFile.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.ProjectFile.pas
@@ -835,6 +835,7 @@ var
   buf: TBytes;  // I3310
   encoding: TEncoding;
 begin
+  encoding := nil;
   FState := psLoading;
   try
     SetLength(buf, 32);


### PR DESCRIPTION
Fixes #10684.

If a project .kpj file was not saved in UTF-8 or ANSI, or had a BOM, then Keyman Developer would crash with an access violation due to an uninitialized variable.

@keymanapp-test-bot skip