### PR TITLE
fix(android/engine): Remove logs for uninitialized default keyboard

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
@@ -90,10 +90,7 @@ public final class KMKeyboardWebViewClient extends WebViewClient {
         // Revert to default (index 0) or fallback keyboard
         keyboardInfo = KMManager.getKeyboardInfo(context, 0);
         if (keyboardInfo == null) {
-          // Only log SystemKeyboard to Sentry because some keyboard apps like FV don't install keyboards until the user chooses
-          if (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
-            KMLog.LogError(TAG, "No keyboards installed. Reverting to fallback");
-          }
+          // Don't log to Sentry because some keyboard apps like FV don't install keyboards until the user chooses
           keyboardInfo = KMManager.getDefaultKeyboard(context);
         }
         if (keyboardInfo != null) {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1633,10 +1633,10 @@ public final class KMManager {
   }
 
   public static boolean isDefaultKey(String key) {
-    if (key != null && key.equals(KMString.format("%s_%s", KMDefault_LanguageID, KMDefault_KeyboardID))) {
-      return true;
-    }
-    return false;
+    return (
+      key != null && 
+      key.equals(KMString.format("%s_%s", KMDefault_LanguageID, KMDefault_KeyboardID)
+    );
   }
 
   /**

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1635,8 +1635,7 @@ public final class KMManager {
   public static boolean isDefaultKey(String key) {
     return (
       key != null && 
-      key.equals(KMString.format("%s_%s", KMDefault_LanguageID, KMDefault_KeyboardID)
-    );
+      key.equals(KMString.format("%s_%s", KMDefault_LanguageID, KMDefault_KeyboardID)));
   }
 
   /**

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1632,6 +1632,13 @@ public final class KMManager {
     return KeyboardPickerActivity.removeKeyboard(context, position);
   }
 
+  public static boolean isDefaultKey(String key) {
+    if (key != null && key.equals(KMString.format("%s_%s", KMDefault_LanguageID, KMDefault_KeyboardID))) {
+      return true;
+    }
+    return false;
+  }
+
   /**
    * Some apps have the user select which keyboard to add. To ensure there's always a fallback
    * system keyboard when the keyboard list is empty, use this method.
@@ -2171,13 +2178,13 @@ public final class KMManager {
   public static Keyboard getCurrentKeyboardInfo(Context context) {
     int index = getCurrentKeyboardIndex(context);
     if(index < 0) {
-      // As of 15.0-beta and 15.0-stable, this only appears to occur when
-      // #6703 would trigger.  This logging may help us better identify the
-      // root cause.
+      // index can be undefined if user installs Keyman (without launching it)
+      // and then enables Keyaman as a system keyboard from the Android settings menus.
+      // We'll only log if key isn't for fallback keyboard
       String key = KMKeyboard.currentKeyboard();
-      // Even if it's null, it's still a notable error.  This function shouldn't
-      // be reachable in execution (15.0) at a time this variable would be set to `null`.
-      KMLog.LogError(TAG, "Failed getCurrentKeyboardIndex check for keyboard: " + key);
+      if (!isDefaultKey(key)) {
+        KMLog.LogError(TAG, "Failed getCurrentKeyboardIndex check for keyboard: " + key);
+      }
       return null;
     }
     return KeyboardController.getInstance().getKeyboardInfo(index);

--- a/android/KMEA/app/src/main/java/com/keyman/engine/data/KeyboardController.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/data/KeyboardController.java
@@ -12,6 +12,7 @@ import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.KeyboardPickerActivity;
 import com.keyman.engine.util.BCP47;
 import com.keyman.engine.util.FileUtils;
+import com.keyman.engine.util.KMString;
 import com.keyman.engine.util.MapCompat;
 import com.keyman.engine.KMManager;
 import com.keyman.engine.util.KMLog;
@@ -167,7 +168,7 @@ public class KeyboardController {
       KMLog.LogError(TAG, "getKeyboardInfo while KeyboardController() not initialized");
       return null;
     } else if (index < 0) {
-      KMLog.LogError(TAG, "getKeyboardInfo with invalid index: " + index);
+      // Don't need to report to Sentry
       return null;
     }
 
@@ -208,7 +209,10 @@ public class KeyboardController {
       }
     }
 
-    KMLog.LogError(TAG, "getKeyboardIndex failed for key " + key);
+    // We'll only log if key isn't for fallback keyboard
+    if (!KMManager.isDefaultKey(key)) {
+      KMLog.LogError(TAG, "getKeyboardIndex failed for key " + key);
+    }
     return index;
   }
 


### PR DESCRIPTION
Fixes #7712

The 4 sets of Sentry reports stem from the following scenario (obscure)

1. User installs Keyman (but doesn't launch the app). Hence, sil_euro_latin never gets "added" (done in MainActivity)
2. From the Android settings --> Languages menus, the user enables Keyman as a system keyboard
3. User then attempts to use Keyman as a keyboard
4. SystemKeyboard initializes (--> KMManger.initialize() which extracts sil_euro_latin.kmp so it can be "used). Since the keyboard sees no keyboards installed (index is -1), we get a bunch of Sentry reports from attempting to fallback.

This PR quiets the Sentry noise so we only log if the key is **not** for the default sil_euro_latin keyboard.

## User Testing
**Setup** - This involves modifying Android Studio configuration so the IDE will install the PR build of Keyman for Android, without launching the app.
1. From Android Studio --> Run --> Edit Configurations
2. In the Run/Debug Configurations dialog, change "Launch Options --> Launch" dropdown from "Default Activity" to "Nothing". 
![edit configuration](https://github.com/keymanapp/keyman/assets/7358010/e914791d-cfe0-4b12-bf19-21133f2846c7)

3. On an Android device/emulator, install the PR build of Keyman for Android



* **TEST_SYSTEM_KEYBOARD** - Verifies system keyboard runs
1. On the Android device, go to the Android Settings --> Languages menu and enable Keyman as a system keyboard
2. Launch Chrome and click on the textbar
3. Select Keyman as the system keyboard
4. Once Keyman loads, verify the OSK appears
5. Verify you can type with the Keyman keyboard
6. Notify @darcywong00 to check Sentry to verify no new Sentry logs appear from the test build.
7. Revert the Android Studio settings so future PR testing with launch the app.
