### PR TITLE
docs(windows): add whats new Keyman for Windows  17.0

### DIFF
--- a/windows/src/desktop/help/about/whatsnew.md
+++ b/windows/src/desktop/help/about/whatsnew.md
@@ -4,6 +4,9 @@ title: What's New
 
 Here are some of the new features we have added to Keyman 17.0 for Windows:
 
+- Support for the new LDML Keyboard Standard.
+- Updates to the Keyman for Windows engine to align with enhancements made to Keyman Core, improving the efficiency of processing the input text with each keystroke.
+
 ## Related Topics
 
 -   [Version History](history)


### PR DESCRIPTION
Fixes: #10717  
Added two points for what is new in version 17.0 of Keyman for Windows.
@mcdurdin or @darcywong00 is this the correct repo for Windows help files still after the big migration?
@keymanapp-test-bot skip