### PR TITLE
chore(android/app): Remove logging for install referrer details

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/CheckInstallReferrer.java
@@ -91,7 +91,7 @@ public class CheckInstallReferrer {
     }
     
     if (!installerInfo.equalsIgnoreCase(GOOGLE_PLAY)) {
-      KMLog.LogInfo(TAG, "Skipping install referrer. Installed from " + installerInfo);
+      // Don't log install referrer #10762
       return;
     }
 


### PR DESCRIPTION
Fixes #10762 
We're not using Install referrer details in Sentry, so remove logging

@keymanapp-test-bot skip