### PR TITLE
fix(developer): publish keymancore-1.dll symbols

### DIFF
--- a/core/meson.build
+++ b/core/meson.build
@@ -11,7 +11,8 @@ project('keyman_core', 'cpp', 'c',
         default_options : ['buildtype=release',
                            'cpp_std=c++14',
                            'b_vscrt=static_from_buildtype',
-                           'warning_level=2'],
+                           'warning_level=2',
+                           'debug=true'],
         meson_version: '>=0.57.0')
 
 # Import our standard compiler defines; this is copied from

--- a/developer/src/tike/Makefile
+++ b/developer/src/tike/Makefile
@@ -16,6 +16,8 @@ build: version.res manifest.res icons dirs xml xsd pull-core
     $(COPY) kmc.cmd $(DEVELOPER_PROGRAM)
     $(COPY) $(KEYMAN_ROOT)\core\build\x86\$(TARGET_PATH)\src\keymancore-1.dll $(DEVELOPER_PROGRAM)
     if exist $(WIN32_TARGET_PATH)\tike.dbg $(COPY) $(WIN32_TARGET_PATH)\tike.dbg $(DEVELOPER_DEBUGPATH)
+    $(COPY) $(KEYMAN_ROOT)\core\build\x86\$(TARGET_PATH)\src\keymancore-1.dll $(WIN32_TARGET_PATH)
+    $(COPY) $(KEYMAN_ROOT)\core\build\x86\$(TARGET_PATH)\src\keymancore-1.pdb $(WIN32_TARGET_PATH)
 
 xsd:
     $(COPY) $(KEYMAN_ROOT)\common\schemas\kps\kps.xsd $(DEVELOPER_PROGRAM)


### PR DESCRIPTION
Fixes #10737.

Two parts to this: first, Keyman Core release build needs to generate the .pdb file, and second, the build needs to put it and the .dll into a place where the sentry-cli scan will find it.

@keymanapp-test-bot skip