### PR TITLE
fix(android/engine): Fix how keyboard picker menu exits

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2092,7 +2092,6 @@ public final class KMManager {
 
     if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       i.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
-      i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
     }
 
     i.putExtra(KMKey_DisplayKeyboardSwitcher, kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM);


### PR DESCRIPTION
Fixes #9456

By removing the intent flag [FLAG_ACTIVITY_CLEAR_TASK](https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_CLEAR_TASK), this fixes the issue of the keyboard picker clearing the previous task. Hence, the keyboard search within the Keyman app isn't cleared. (in the reported issue)

## User Testing
**Setup** - Install the PR build of Keyman for Android on an Android device/emulator

* **TEST_KEYBOARD_PICKER** - Verifies keyboard picker menu doesn't clear the previous task
1. Open Keyman app
2. Set Keyman as the system-wide keyboard and default keyboard.
3. Click 'Install Keyboard or Dictionary' option from the Settings menu.
4. Click 'Install from keyman.com' option.
5. Click the Search bar to enter a keyboard name.
6. Long press the 'globe key' from the keyman keyboard and release to bring up the keyboard picker menu.
7. Click 'Gboard' or English EuroLatin(SIL) keyboard from the Keyboards picker menu.
8. Verify the keybord search page is still there

* **TEST_IN_APP** - Verifies keyboard picker menu functions in the Keyman app
1. Open Keyman app
2. Longpress the globe key and release to bring up the keyboard picker menu
3. Select English EuroLatin(SIL)
4. Verify the keyboard picker returns to the Keyman app

* **TEST_SYSTEM_KEYBOARD** - Verifies keyboard picker menu functions in the Keyman system keyboard
1. Open Keyman  app
2. Set keyman as the system-wide keyboard and default keyboard
3. Launch Chrome and select a text area
4. With the Keyman keyboard, long press the globe key and release to bring up the keyboard picker menu
5. Click Gboard or English EuroLatin(SIL) keyboard
6. Verify the device returns to the Chrome app

 