### PR TITLE
chore(web): proper reporting of errors from es5 KMW

### DIFF
--- a/common/web/sentry-manager/src/index.ts
+++ b/common/web/sentry-manager/src/index.ts
@@ -25,12 +25,14 @@ export class KeymanSentryManager {
   _enabled: boolean = true;
 
   static STANDARD_ALIASABLE_FILES = {
-    'keymanweb.js':     'keymanweb.js',
-    'keymanweb-webview.js': 'keymanweb-webview.js',
-    'kmwuibutton.js':   'kmwuibutton.js',
-    'kmwuifloat.js':    'kmwuifloat.js',
-    'kmwuitoggle.js':   'kmwuitoggle.js',
-    'kmwuitoolbar.js':  'kmwuitoolbar.js'
+    'keymanweb.js':             'keymanweb.js',
+    'keymanweb-webview.js':     'keymanweb-webview.js',
+    'keymanweb.es5.js':         'keymanweb.es5.js',
+    'keymanweb-webview.es5.js': 'keymanweb-webview.es5.js',
+    'kmwuibutton.js':           'kmwuibutton.js',
+    'kmwuifloat.js':            'kmwuifloat.js',
+    'kmwuitoggle.js':           'kmwuitoggle.js',
+    'kmwuitoolbar.js':          'kmwuitoolbar.js'
     // Also add entries for the naming system used by Android and iOS - and map them to the EMBEDDED upload, not the std 'native' one.
   }
 


### PR DESCRIPTION
To facilitate Sentry's efforts in lining up our sourcemaps with the KMW bundled inside our mobile apps, part of our setup "chops off" nearly all of the scripts' actual paths... assuming the filename matches certain expected values.  I just happened to notice that this was never updated to include the ES5 versions of KMW.  (The ES6 versions inherited the original filenames.)

@keymanapp-test-bot skip