### PR TITLE
fix(android): first keystroke when context is empty

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -237,7 +237,7 @@ function updateKMText(text) {
 
   console_debug('updateKMText(text='+text+') context.value='+keyman.context.getText());
 
-  if(text != keyman.context.getText()) {
+  if(!text || text != keyman.context.getText()) {
     keyman.context.setText(text);
     keyman.resetContext();
   }


### PR DESCRIPTION
After the changes made in #10728, it appears that the _first_ keystroke entered via the keyboard on Android may sometimes be ignored - specifically if the context is also empty at the time.  It's a simple fix, fortunately - there's no harm in resetting the context when it is empty, after all.

@keymanapp-test-bot skip