### PR TITLE
chore(linux): Fix API verification after adding SONAME

### DIFF
--- a/linux/scripts/deb-packaging.sh
+++ b/linux/scripts/deb-packaging.sh
@@ -105,7 +105,7 @@ is_symbols_file_changed() {
 
 get_changes() {
   local WHAT_CHANGED
-  WHAT_CHANGED=$(git diff -I "^${PKG_NAME}.so" "$1".."$2" -- "debian/${PKG_NAME}.symbols" | diffstat -m -t | tail -n +2)
+  WHAT_CHANGED=$(git diff -I "^${LIB_NAME}.so" "$1".."$2" | diffstat -m -t | grep "${PKG_NAME}.symbols" )
 
   IFS=',' read -r -a CHANGES <<< "${WHAT_CHANGED:-0,0,0}"
 }
@@ -143,7 +143,7 @@ check_updated_version_number() {
 
 get_api_version_in_symbols_file() {
   # Retrieve symbols file at commit $1 and extract "1" from
-  # "libkeymancore.so.1 libkeymancore #MINVER#"
+  # "libkeymancore.so.1 libkeymancore1 #MINVER#"
   local firstline tmpfile
   local sha="$1"
 
@@ -155,7 +155,7 @@ get_api_version_in_symbols_file() {
   fi
 
   firstline="$(head -1 "${tmpfile}")"
-  firstline="${firstline#"${PKG_NAME}".so.}"
+  firstline="${firstline#"${LIB_NAME}".so.}"
   firstline="${firstline%% *}"
 
   rm "${tmpfile}"
@@ -164,7 +164,7 @@ get_api_version_in_symbols_file() {
 
 get_api_version_from_core() {
   # Retrieve CORE_API_VERSION.md from commit $1 and extract major version
-  # number from "1.0.0"
+  # number ("1") from "1.0.0"
   local api_version tmpfile
   local sha="$1"
   tmpfile=$(mktemp)
@@ -284,10 +284,12 @@ check_for_api_version_consistency() {
 }
 
 verify_action() {
-  PKG_NAME=libkeymancore
+  local SONAME
+  SONAME=$(get_api_version_from_core "HEAD")
   LIB_NAME=libkeymancore
+  PKG_NAME="${LIB_NAME}${SONAME}"
   if [[ ! -f debian/${PKG_NAME}.symbols ]]; then
-    output_warning "Missing ${PKG_NAME}.symbols file"
+    output_error "Missing ${PKG_NAME}.symbols file"
     exit 0
   fi
 


### PR DESCRIPTION
Due to Debian policy the `libkeymancore` package will now include the `SONAME` (API version number) in the package name (PR #10800). This change adjusts the API verification checks to be able to cope with the modified .symbols file.

@keymanapp-test-bot skip