### PR TITLE
fix(developer): repeated options in kmc must now be fully specified

### DIFF
--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -89,7 +89,7 @@ export class CompilerError {
    * ```
    */
   static formatCode(code: number): string {
-    return 'KM' + CompilerError.error(code).toString(16).toUpperCase().padStart(5, '0');
+    return Number.isInteger(code) ? 'KM' + CompilerError.error(code).toString(16).toUpperCase().padStart(5, '0') : 'KM?????';
   }
 
   /**

--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -26,7 +26,8 @@ export function declareBuild(program: Command) {
     .option('-d, --debug', 'Include debug information in output')
     .option('-w, --compiler-warnings-as-errors', 'Causes warnings to fail the build; overrides project-level warnings-as-errors option')
     .option('-W, --no-compiler-warnings-as-errors', 'Warnings do not fail the build; overrides project-level warnings-as-errors option')
-    .option('-m, --message <numbers...>', 'Adjust severity of info, hint or warning message to Disable (default), Info, Hint, Warn or Error')
+    .option('-m, --message <number>', 'Adjust severity of info, hint or warning message to Disable (default), Info, Hint, Warn or Error (option can be repeated)',
+      (value, previous) => previous.concat([value]), [])
     .option('--no-compiler-version', 'Exclude compiler version metadata from output')
     .option('--no-warn-deprecated-code', 'Turn off warnings for deprecated code styles');
 

--- a/developer/src/kmc/src/messages/infrastructureMessages.ts
+++ b/developer/src/kmc/src/messages/infrastructureMessages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
+import { CompilerError, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.Infrastructure;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -101,15 +101,15 @@ export class InfrastructureMessages {
   static ERROR_InvalidMessageFormat = SevError | 0x0016;
 
   static Error_MessageNamespaceNotFound = (o:{code: number}) => m(this.ERROR_MessageNamespaceNotFound,
-    `Invalid parameter: --message KM${o.code?.toString(16)} does not have a recognized namespace`);
+    `Invalid parameter: --message ${CompilerError.formatCode(o.code)} does not have a recognized namespace`);
   static ERROR_MessageNamespaceNotFound = SevError | 0x0017;
 
   static Error_MessageCodeNotFound = (o:{code: number}) => m(this.ERROR_MessageCodeNotFound,
-    `Invalid parameter: --message KM${o.code?.toString(16)} is not a recognized code`);
+    `Invalid parameter: --message ${CompilerError.formatCode(o.code)} is not a recognized code`);
   static ERROR_MessageCodeNotFound = SevError | 0x0018;
 
   static Error_MessageCannotBeCoerced = (o:{code: number}) => m(this.ERROR_MessageCannotBeCoerced,
-    `Invalid parameter: --message KM${o.code?.toString(16)} is not a info, hint or warn message type and cannot be coerced`);
+    `Invalid parameter: --message ${CompilerError.formatCode(o.code)} is not of type 'info', 'hint' or 'warn', and cannot be coerced`);
   static ERROR_MessageCannotBeCoerced = SevError | 0x0019;
 }
 


### PR DESCRIPTION
Fixes #10396.

Instead of `--message 20ae 5006`, which is ambiguous, because 5006 could be a filename, you must now specify the parameter option flag each time: `--message 20ae --message 5006` (or `-m 20ae -m 5006`).

Turns out this is documented as an example in Commander, just not very visible.

Should we also support `-m 20ae,5006`? This would be a fairly straightforward tweak.

![image](https://github.com/keymanapp/keyman/assets/4498365/73f9e16a-c7ef-4544-bf7c-48cbc9a9d520)


@keymanapp-test-bot skip