### PR TITLE
fix(web): megabranch - gesture-engine rapid typing issues

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -1,4 +1,4 @@
-var _debug = 0;
+var _debug = true;
 
 // Android harness attachment
 if(window.parent && window.parent.jsInterface && !window.jsInterface) {
@@ -237,7 +237,7 @@ function updateKMText(text) {
 
   console_debug('updateKMText(text='+text+') context.value='+keyman.context.getText());
 
-  if(text != keyman.context.getText()) {
+  if(!text || text != keyman.context.getText()) {
     keyman.context.setText(text);
     keyman.resetContext();
   }

--- a/common/web/gesture-recognizer/src/engine/eventSequentializationQueue.ts
+++ b/common/web/gesture-recognizer/src/engine/eventSequentializationQueue.ts
@@ -1,0 +1,72 @@
+import { timedPromise } from "@keymanapp/web-utils";
+
+export class EventSequentializationQueue {
+  private queue: (() => Promise<void> | void)[];
+  private defermentPromise: Promise<void>;
+
+  constructor() {
+    this.queue = [];
+  }
+
+  private setDeferment(promise: Promise<any>) {
+    this.defermentPromise = promise;
+    promise.then(() => {
+      this.defermentPromise = null;
+      this.triggerEvent();
+    });
+  }
+
+  private async triggerEvent() {
+    while(this.queue.length > 0) {
+      const functor = this.queue.shift();
+      console.log("Executing: " + functor.toString());
+      //console.log("Queue: " + JSON.stringify(this.queue.map((functor) => functor.toString()), null, 2));
+      console.log("Queue length: " + this.queue.length);
+      // Is either undefined or is a Promise.
+      try {
+        const result = functor();
+        if(result) {
+          const withMsg = result.then(() => {
+            console.log("Specialized deferment complete: " + functor.toString())
+            // return timedPromise(0);
+          });
+          this.setDeferment(withMsg);
+          return;
+        } else {
+          const defaultDelay = timedPromise(0);
+          const withMsg = defaultDelay.then(() => console.debug("triggerEvent - microtask queue clear"));
+          this.setDeferment(withMsg);
+        }
+      } catch (err) {
+        console.error("Error sequentializing received inputs");
+        console.error(err);
+      }
+
+      // // Allow the microtask queue to clear out before proceeding.
+      // //
+      // // With the exception of 'inputstart' events, all related gesture processing is dependent
+      // // on the microtask queue.  As for events that should follow an 'inputstart', they're
+      // // guarded via ManagedPromise-based locks established within InputEventEngine and
+      // // unlocked only after the 'inputstart' event itself signals.
+
+      // const stdDeferment = timedPromise(0).then(() => timedPromise(0));
+      // stdDeferment.then(() => console.log("Std deferment complete: " + functor.toString()));
+      // this.setDeferment(stdDeferment);
+
+      // await timedPromise(0);
+      // console.log("timedPromise 1: " + functor.toString());
+      // await timedPromise(0);
+      // console.log("timedPromise 2: " + functor.toString());
+    }
+  }
+
+  queueEventFunctor(functor: () => Promise<void> | void) {
+    console.log("Queuing: " + functor.toString());
+    this.queue.push(functor);
+    // We only need to trigger events if the queue has no prior entries and there isn't an
+    // active deferment that will auto-trigger the event at the appropriate time.
+    if(this.queue.length == 1 && !this.defermentPromise) {
+      this.triggerEvent();
+    }
+  }
+}

--- a/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gesturePath.ts
@@ -106,7 +106,9 @@ export class GesturePath<Type, StateToken = any> extends EventEmitter<EventMap<T
   extend(sample: InputSample<Type, StateToken>) {
     /* c8 ignore next 3 */
     if(this._isComplete) {
-      throw new Error("Invalid state:  this GesturePath has already terminated.");
+      return;
+      console.log("Update event swallowed:  this GesturePath has already terminated.");
+      // throw new Error("Invalid state:  this GesturePath has already terminated.");
     }
 
     // The tracked path should emit InputSample events before Segment events and

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
@@ -454,9 +454,14 @@ export class GestureMatcher<Type, StateToken = any> implements PredecessorMatch<
       }
     }
 
-    contactModel.update();
-    // Now that we've done the initial-state check, we can check for instantly-matching path models.
+    // Now that we've done the initial-state check, we can check for instantly-matching and
+    // instantly-rejecting path models.
+    let result = contactModel.update();
+    if(result?.type == 'reject') {
+      this.finalize(false, 'cancelled');
+    }
 
+    // If there's nothing instant, then we set up listeners to help trigger future resolution.
     contactModel.promise.then((resolution) => {
       this.finalize(resolution.type == 'resolve', resolution.cause);
     });

--- a/common/web/gesture-recognizer/src/engine/headless/inputEngineBase.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/inputEngineBase.ts
@@ -56,6 +56,10 @@ export abstract class InputEngineBase<HoveredItemType, StateToken = any> extends
     return source;
   }
 
+  getTouchpointEventId(touchpoint: GestureSource<HoveredItemType, StateToken>) {
+    return Number.parseInt(Object.keys(this.identifierMap).find((key) => this.identifierMap[key] == touchpoint.rawIdentifier), 10);
+  }
+
   /**
    * Calls to this method will cancel any touchpoints whose internal IDs are _not_ included in the parameter.
    * Designed to facilitate recovery from error cases and peculiar states that sometimes arise when debugging.
@@ -63,6 +67,13 @@ export abstract class InputEngineBase<HoveredItemType, StateToken = any> extends
    */
   maintainTouchpointsWithIds(identifiers: number[]) {
     const identifiersToMaintain = identifiers.map((internal_id) => this.identifierMap[internal_id]);
+
+    const dropped = this._activeTouchpoints.filter((source) => !identifiersToMaintain.includes(source.rawIdentifier));
+
+    dropped.forEach((point) =>
+      console.log(`maintainTouchpointsWithIds: dropping ${point.identifier}, original id ${point.rawIdentifier}`)
+    );
+
     this._activeTouchpoints
       .filter((source) => !identifiersToMaintain.includes(source.rawIdentifier))
       // Will trigger `.dropTouchpoint` later in the event chain.
@@ -72,7 +83,7 @@ export abstract class InputEngineBase<HoveredItemType, StateToken = any> extends
   /**
    * @param identifier The identifier number corresponding to the input sequence.
    */
-  hasActiveTouchpoint(identifier: number) {
+  hasRegisteredTouchpoint(identifier: number) {
     return this.identifierMap[identifier] !== undefined;
   }
 
@@ -110,6 +121,8 @@ export abstract class InputEngineBase<HoveredItemType, StateToken = any> extends
 
   protected dropTouchpoint(point: GestureSource<HoveredItemType>) {
     const id = point.rawIdentifier;
+
+    console.log(`dropTouchpoint: ${point.identifier}, original id ${point.rawIdentifier}`);
 
     this._activeTouchpoints = this._activeTouchpoints.filter((pt) => point != pt);
     for(const key of Object.keys(this.identifierMap)) {

--- a/common/web/gesture-recognizer/src/engine/mouseEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/mouseEventEngine.ts
@@ -94,7 +94,7 @@ export class MouseEventEngine<HoveredItemType, StateToken = any> extends InputEv
   }
 
   onMouseMove(event: MouseEvent) {
-    if(!this.hasActiveTouchpoint(this.activeIdentifier)) {
+    if(!this.hasRegisteredTouchpoint(this.activeIdentifier)) {
       return;
     }
 
@@ -119,7 +119,7 @@ export class MouseEventEngine<HoveredItemType, StateToken = any> extends InputEv
   }
 
   onMouseEnd(event: MouseEvent) {
-    if(!this.hasActiveTouchpoint(this.activeIdentifier)) {
+    if(!this.hasRegisteredTouchpoint(this.activeIdentifier)) {
       return;
     }
 

--- a/common/web/gesture-recognizer/src/engine/touchEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/touchEventEngine.ts
@@ -4,6 +4,13 @@ import { InputSample } from "./headless/inputSample.js";
 import { Nonoptional } from "./nonoptional.js";
 import { ZoneBoundaryChecker } from "./configuration/zoneBoundaryChecker.js";
 import { GestureSource } from "./headless/gestureSource.js";
+import { ManagedPromise } from "@keymanapp/web-utils";
+
+interface TouchpointTimestamps {
+  trueStart: number;
+  dispatch?: number;
+  delta?: number;
+}
 
 function touchListToArray(list: TouchList) {
   const arr: Touch[] = [];
@@ -14,12 +21,31 @@ function touchListToArray(list: TouchList) {
 
   return arr;
 }
+
 export class TouchEventEngine<HoveredItemType, StateToken = any> extends InputEventEngine<HoveredItemType, StateToken> {
   private readonly _touchStart: typeof TouchEventEngine.prototype.onTouchStart;
   private readonly _touchMove:  typeof TouchEventEngine.prototype.onTouchMove;
   private readonly _touchEnd:   typeof TouchEventEngine.prototype.onTouchEnd;
 
   private safeBoundMaskMap: {[id: number]: number} = {};
+
+  // ******** END OF DAY 2/22/2024 *******
+  // This approach does not appear to be viable - it shifts too much during lag spikes / heavy typing.
+  // Needs to be ON THE TOUCHPOINT, not the event ID.
+  //
+  // Idea:  closure-capture the object!  It's totally proper when the original event is live, of course.
+  // Will need to tweak the sample-builder to reference the object.
+  // *************************************
+
+  /**
+   * Maintains timing data about live, incoming events as they are seen, discarding them when the original
+   * touch-end occurs (or when the corresponding GestureSource is terminated for other reasons).
+   *
+   * During heavy lag / with rapid typing, there is no guarantee that the corresponding GestureSource is actually being
+   * actively processed, nor is there a guarantee that a actively-processed GestureSource still has corresponding data here.
+   */
+  private pendingTimestamps: Map<number, TouchpointTimestamps> = new Map();
+  protected inputStartSignalMap: Map<GestureSource<HoveredItemType, StateToken>, ManagedPromise<void>> = new Map();
 
   public constructor(config: Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>) {
     super(config);
@@ -34,17 +60,6 @@ export class TouchEventEngine<HoveredItemType, StateToken = any> extends InputEv
   private get eventRoot(): HTMLElement {
     return this.config.touchEventRoot;
   }
-
-  // public static forPredictiveBanner(banner: SuggestionBanner, handlerRoot: SuggestionManager) {
-  //   const config: GestureRecognizerConfiguration = {
-  //     targetRoot: banner.getDiv(),
-  //     // document.body is the event root b/c we need to track the mouse if it leaves
-  //     // the VisualKeyboard's hierarchy.
-  //     eventRoot: banner.getDiv(),
-  //   };
-
-  //   return new TouchEventEngine(config);
-  // }
 
   registerEventHandlers() {
     // The 'passive' property ensures we can prevent MouseEvent followups from TouchEvents.
@@ -86,13 +101,36 @@ export class TouchEventEngine<HoveredItemType, StateToken = any> extends InputEv
     }
   }
 
-  private buildSampleFromTouch(touch: Touch, timestamp: number) {
+  public unlockTouchpoint(touchpoint: GestureSource<HoveredItemType, StateToken>) {
+    const map = this.inputStartSignalMap;
+    const lock = map.get(touchpoint);
+    if(lock) {
+      lock.resolve();
+      map.delete(touchpoint);
+    }
+  }
+
+  hasRegisteredTouchpoint(identifier: number): boolean {
+    if(super.hasRegisteredTouchpoint(identifier)) {
+      return true;
+    } else {
+      return !!this.pendingTimestamps.has(identifier);
+    }
+  }
+
+  private buildSampleFromTouch(touch: Touch, timestamp: number, timeMeta: TouchpointTimestamps) {
     // WILL be null for newly-starting `GestureSource`s / contact points.
     const source = this.getTouchpointWithId(touch.identifier);
-    return this.buildSampleFor(touch.clientX, touch.clientY, touch.target, timestamp, source);
+
+    // The actual timestamp passed in is from the observation's original time.
+    // We adjust this timestamp forward by whatever lag was required to sequentialize the touchstart,
+    // keeping all relative timings otherwise the same.
+    const timestampDelta = timeMeta.delta;
+    return this.buildSampleFor(touch.clientX, touch.clientY, touch.target, timestamp + timestampDelta, source);
   }
 
   onTouchStart(event: TouchEvent) {
+    console.log('onTouchStart');
     // If it's not an event we'd consider handling, do not prevent event
     // propagation!  Just don't process it.
     if(!this.config.targetRoot.contains(event.target as Node)) {
@@ -106,89 +144,159 @@ export class TouchEventEngine<HoveredItemType, StateToken = any> extends InputEv
     // during a touchstart.)
     const allTouches = touchListToArray(event.touches);
     const newTouches = touchListToArray(event.changedTouches);
-    // Maintain all touches in the `.touches` array that are NOT marked as `.changedTouches` (and therefore, new)
-    this.maintainTouchpointsWithIds(allTouches
-      .filter((touch1) => newTouches.findIndex(touch2 => touch1.identifier == touch2.identifier) == -1)
-      .map((touch) => touch.identifier)
-    );
+
+    // *** PROBLEM:  could accidentally cancel touches after it due to the delay it induces and how
+    //               we store the touchpoint immediately instead of after a delay.
+
+    this.sequentializer.queueEventFunctor(() => {
+      // Maintain all touches in the `.touches` array that are NOT marked as `.changedTouches` (and therefore, new)
+      this.maintainTouchpointsWithIds(allTouches
+        .filter((touch1) => newTouches.findIndex(touch2 => touch1.identifier == touch2.identifier) == -1)
+        .map((touch) => touch.identifier)
+      );
+    });
 
     // Ensure the same timestamp is used for all touches being updated.
     const timestamp = performance.now();
 
-    // During a touch-start, only _new_ touch contact points are listed here;
-    // we shouldn't signal "input start" for any previously-existing touch points,
-    // so `.changedTouches` is the best way forward.
-    for(let i=0; i < event.changedTouches.length; i++) {
-      const touch = event.changedTouches.item(i);
-      const sample = this.buildSampleFromTouch(touch, timestamp);
+    // Used to closure-capture the timestamp object state at the time that the incoming event is
+    // initially recorded.
+    const timeMetaMap: TouchpointTimestamps[] = [];
 
-      if(!ZoneBoundaryChecker.inputStartOutOfBoundsCheck(sample, this.config)) {
-        // If we started very close to a safe zone border, remember which one(s).
-        // This is important for input-sequence cancellation check logic.
-        this.safeBoundMaskMap[touch.identifier] = ZoneBoundaryChecker.inputStartSafeBoundProximityCheck(sample, this.config);
-      } else {
-        // This touchpoint shouldn't be considered; do not signal a touchstart for it.
-        continue;
+    for(let i=0; i < event.changedTouches.length; i++) {
+      const id = event.changedTouches.item(i).identifier;
+      this.pendingTimestamps.set(id, {
+        trueStart: timestamp
+      });
+      timeMetaMap[id] = this.pendingTimestamps.get(id);
+      // this.markTrueStart(id, 0); // Only now should 'maintain touchpoint' stuff actually affect the touchpoint.
+    }
+
+    const initialStartSignal = () => {
+      const dispatchTime = performance.now();
+      let lastValidTouchpoint: GestureSource<HoveredItemType, StateToken> = null;
+
+      // During a touch-start, only _new_ touch contact points are listed here;
+      // we shouldn't signal "input start" for any previously-existing touch points,
+      // so `.changedTouches` is the best way forward.
+      for(let i=0; i < event.changedTouches.length; i++) {
+        const touch = event.changedTouches.item(i);
+        const eventId = touch.identifier;
+
+        const timeMeta = timeMetaMap[eventId];
+        timeMeta.dispatch = dispatchTime;
+        timeMeta.delta = dispatchTime - timeMeta.trueStart;
+
+        const sample = this.buildSampleFromTouch(touch, timestamp, timeMeta);
+
+        if(!ZoneBoundaryChecker.inputStartOutOfBoundsCheck(sample, this.config)) {
+          // If we started very close to a safe zone border, remember which one(s).
+          // This is important for input-sequence cancellation check logic.
+          this.safeBoundMaskMap[eventId] = ZoneBoundaryChecker.inputStartSafeBoundProximityCheck(sample, this.config);
+        } else {
+          // This touchpoint shouldn't be considered; do not signal a touchstart for it.
+          continue;
+        }
+
+        lastValidTouchpoint = this.onInputStart(eventId, sample, event.target, true);
+
+        // Ensure we only do the cleanup if and when it hasn't already been replaced by new events later.
+        const cleanup = () => {
+          if(this.pendingTimestamps.get(eventId) == timeMeta) {
+            this.pendingTimestamps.delete(eventId);
+          }
+        }
+
+        lastValidTouchpoint.path.on('complete', cleanup);
+        lastValidTouchpoint.path.on('invalidated', cleanup);
       }
 
-      this.onInputStart(touch.identifier, sample, event.target, true);
+      // The 'lock' should only be released when the last simultaneously-registered touch is published.
+      let eventSignalPromise = new ManagedPromise<void>();
+      this.inputStartSignalMap.set(lastValidTouchpoint, eventSignalPromise);
+
+      console.log('returning specialized promise');
+      return eventSignalPromise.corePromise;
     }
+
+    // Signals the new gesture-source and prevents any further input signals from processing until
+    // the fate of the gesture source is clear:
+    // - may auto-complete an existing gesture
+    // - may need remapping due to said auto-complete triggering a state change (layer change in KMW)
+    // - actual generation of the 'inputstart' event (if it remains independent from an ongoingly-multi-touch gesture model)
+    this.sequentializer.queueEventFunctor(initialStartSignal);
   }
 
   onTouchMove(event: TouchEvent) {
-    let propagationActive = true;
+    console.log('onTouchMove');
+
+    // Used to closure-capture the timestamp object state at the time that the incoming event is
+    // initially recorded.
+    const timeMetaMap: TouchpointTimestamps[] = [];
+
+    for(let i=0; i < event.touches.length; i++) {
+      const touch = event.touches.item(i);
+      if(this.hasRegisteredTouchpoint(touch.identifier) /* || hasPendingTouchpoint */) {
+        this.preventPropagation(event);
+      }
+      timeMetaMap[touch.identifier] = this.pendingTimestamps.get(touch.identifier);
+    }
+
+    this.sequentializer.queueEventFunctor(() => {
+      this.maintainTouchpointsWithIds(touchListToArray(event.touches)
+        .map((touch) => touch.identifier)
+      );
+    });
+
     // Ensure the same timestamp is used for all touches being updated.
     const timestamp = performance.now();
 
-    this.maintainTouchpointsWithIds(touchListToArray(event.touches)
-      .map((touch) => touch.identifier)
-    );
+    this.sequentializer.queueEventFunctor(() => {
+      // Do not change to `changedTouches` - we need a sample for all active touches in order
+      // to facilitate path-update synchronization for multi-touch gestures.
+      //
+      // May be worth doing changedTouches _first_ though.
+      for(let i=0; i < event.touches.length; i++) {
+        const touch = event.touches.item(i);
+        const eventId = touch.identifier;
+        const timeMeta = timeMetaMap[eventId];
 
-    // Do not change to `changedTouches` - we need a sample for all active touches in order
-    // to facilitate path-update synchronization for multi-touch gestures.
-    //
-    // May be worth doing changedTouches _first_ though.
-    for(let i=0; i < event.touches.length; i++) {
-      const touch = event.touches.item(i);
+        if(!this.hasRegisteredTouchpoint(eventId)) {
+          continue;
+        }
 
-      if(!this.hasActiveTouchpoint(touch.identifier)) {
-        continue;
+        const sample = this.buildSampleFromTouch(touch, timestamp, timeMeta);
+        const config = this.getConfigForId(eventId);
+
+        if(!ZoneBoundaryChecker.inputMoveCancellationCheck(sample, config, this.safeBoundMaskMap[eventId])) {
+          this.onInputMove(eventId, sample, touch.target);
+        } else {
+          this.onInputMoveCancel(eventId, sample, touch.target);
+        }
       }
-
-      if(propagationActive) {
-        this.preventPropagation(event);
-        propagationActive = false;
-      }
-
-      const config = this.getConfigForId(touch.identifier);
-
-      const sample = this.buildSampleFromTouch(touch, timestamp);
-
-      if(!ZoneBoundaryChecker.inputMoveCancellationCheck(sample, config, this.safeBoundMaskMap[touch.identifier])) {
-        this.onInputMove(touch.identifier, sample, touch.target);
-      } else {
-        this.onInputMoveCancel(touch.identifier, sample, touch.target);
-      }
-    }
+    });
   }
 
   onTouchEnd(event: TouchEvent) {
-    let propagationActive = true;
+    console.log('onTouchEnd');
 
-    // Only lists touch contact points that have been lifted; touchmove is raised separately if any movement occurred.
     for(let i=0; i < event.changedTouches.length; i++) {
       const touch = event.changedTouches.item(i);
-
-      if(!this.hasActiveTouchpoint(touch.identifier)) {
-        continue;
-      }
-
-      if(propagationActive) {
+      if(!this.hasRegisteredTouchpoint(touch.identifier) /* || hasPendingTouchpoint */) {
         this.preventPropagation(event);
-        propagationActive = false;
       }
-
-      this.onInputEnd(touch.identifier, event.target);
     }
+
+    this.sequentializer.queueEventFunctor(() => {
+      // Only lists touch contact points that have been lifted; touchmove is raised separately if any movement occurred.
+      for(let i=0; i < event.changedTouches.length; i++) {
+        const touch = event.changedTouches.item(i);
+        if(!this.hasRegisteredTouchpoint(touch.identifier)) {
+          continue;
+        }
+
+        this.onInputEnd(touch.identifier, event.target);
+      }
+    });
   }
 }

--- a/web/src/app/webview/src/configuration.ts
+++ b/web/src/app/webview/src/configuration.ts
@@ -22,6 +22,7 @@ export class WebviewConfiguration extends EngineConfiguration {
         deleteRight: dr
       });
 
+      console.debug('pending insert');
       Promise.resolve().then((this.pushInserts));
     }
 
@@ -29,6 +30,7 @@ export class WebviewConfiguration extends EngineConfiguration {
   }
 
   private readonly pushInserts = () => {
+    console.debug(`concatenating inserts: length ${this.pendingInserts.length}`);
     const finalTransform = this.pendingInserts.reduce((concatenated, current) => {
       return buildMergedTransform(concatenated, current);
     }, {

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -21,6 +21,7 @@ export class ContextHost extends Mock {
 
   updateHost(transcription?: Transcription): void {
     const savedState = this.savedState;
+    console.debug('has saved state: ' + !!savedState);
 
     if(this.savedState) {
       let transform = null;
@@ -45,10 +46,12 @@ export class ContextHost extends Mock {
     }
 
     // Save the current context state for use in future diffs.
+    console.debug('updateHost');
     this.savedState = Mock.from(this);
   }
 
   restoreTo(original: OutputTarget): void {
+    console.debug('restoreTo');
     this.savedState = Mock.from(this);
     super.restoreTo(original);
   }
@@ -77,6 +80,7 @@ export class ContextHost extends Mock {
       this.setSelection(this.text._kmwLength());
     }
 
+    console.debug('restoreTo');
     this.savedState = Mock.from(this);
 
     return shouldResetContext;
@@ -91,6 +95,7 @@ export class ContextHost extends Mock {
     // and we want a consistent interface for context synchronization between
     // host app + app/webview KMW.
     this.setSelection(this.text._kmwLength());
+    console.debug('setText');
     this.savedState = Mock.from(this);
   }
 }

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -47,11 +47,13 @@ export default class KeymanEngine<
 
   private keyEventListener: KeyEventHandler = (event, callback) => {
     const outputTarget = this.contextManager.activeTarget;
+    console.debug(`keyEventListener: Lcode = ${event.Lcode}, keyID: ${event.kName}, layer: ${event.kLayer}`);
 
     if(!this.contextManager.activeKeyboard || !outputTarget) {
       if(callback) {
         callback(null, null);
       }
+      console.debug(`keyEventListener: early return 1`);
       return;
     }
 
@@ -76,10 +78,17 @@ export default class KeymanEngine<
         this.core.keyboardProcessor.layerId = oskLayer;
       }
     }
+
+    console.debug(`keyEventListener: processKeyEvent`);
     const result = this.core.processKeyEvent(event, outputTarget);
+    console.debug(`keyEventListener: back from key event`);
+
 
     if(result && result.transcription?.transform) {
+      console.debug('rule finalization');
       this.config.onRuleFinalization(result, this.contextManager.activeTarget);
+    } else {
+      console.debug('no rule finalization');
     }
 
     if(callback) {

--- a/web/src/engine/osk/src/input/gestures/browser/keytip.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/keytip.ts
@@ -213,6 +213,8 @@ export default class KeyTip implements KeyTipInterface {
         this.previewHost.on('preferredOrientation', this.reorient);
         this.preview = this.previewHost.element;
         this.tip.replaceChild(this.preview, oldHost);
+        console.log("showing keytip");
+        // console.log(`installing gesture preview ${previewHost.tempId} in phone keytip`);
         previewHost.setCancellationHandler(() => this.show(null, false, null));
         previewHost.on('startFade', () => {
           this.element.classList.remove('kmw-preview-fade');
@@ -229,6 +231,8 @@ export default class KeyTip implements KeyTipInterface {
       this.preview = document.createElement('div');
       this.tip.replaceChild(this.preview, oldPreview);
       this.element.classList.remove('kmw-preview-fade');
+
+      console.log(`Keytip hide called`);
 
       this.orientation = DEFAULT_TIP_ORIENTATION;
     }

--- a/web/src/engine/osk/src/input/gestures/browser/tabletPreview.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/tabletPreview.ts
@@ -97,6 +97,8 @@ export class TabletKeyTip implements KeyTipInterface {
       if(previewHost) {
         this.preview = this.previewHost.element;
         this.element.replaceChild(this.preview, oldHost);
+        console.log("showing key tip");
+        // console.log(`installing gesture preview ${previewHost.tempId} in phone keytip`);
         previewHost.setCancellationHandler(() => this.show(null, false, null));
         previewHost.on('startFade', () => {
           this.element.classList.remove('kmw-preview-fade');
@@ -114,6 +116,8 @@ export class TabletKeyTip implements KeyTipInterface {
       this.preview = document.createElement('div');
       this.element.replaceChild(this.preview, oldPreview);
       this.element.classList.remove('kmw-preview-fade');
+
+      console.log(`Keytip hide called`);
     }
 
     // Save the key preview state

--- a/web/src/engine/osk/src/keyboard-layout/gesturePreviewHost.ts
+++ b/web/src/engine/osk/src/keyboard-layout/gesturePreviewHost.ts
@@ -36,6 +36,9 @@ export class GesturePreviewHost extends EventEmitter<EventMap> {
 
   private onCancel: () => void;
 
+  // private static seed = 0;
+  // public tempId: number;
+
   get element(): HTMLDivElement {
     return this.div;
   }
@@ -43,6 +46,7 @@ export class GesturePreviewHost extends EventEmitter<EventMap> {
   constructor(key: KeyElement, isPhone: boolean, width: number, height: number) {
     super();
 
+    // this.tempId = GesturePreviewHost.seed++;
     const keySpec = key.key.spec;
     const edgeLength = this.flickEdgeLength = Math.max(width, height);
 
@@ -130,6 +134,11 @@ export class GesturePreviewHost extends EventEmitter<EventMap> {
   }
 
   public cancel() {
+    // if(this.onCancel) {
+    //   // Can get a bit noisy otherwise.
+    //   console.log(`clearing gesture preview ${this.tempId}`);
+    //   console.log((new Error()).stack);
+    // }
     this.onCancel?.();
     this.onCancel = null;
   }


### PR DESCRIPTION
Currently includes copious amounts of console logging that helped me narrow down the various issues at play here.  I have plans to split this into multiple pieces.  In planned order, here's my "rough notes" on what to split & how to do so:

1. gestureMatcher.ts, addContactInternal
- there was no check for non-initial-state instant-rejections - that's why longpress-roam had a looping reset!
- this in itself might actually be a very significant thing to publish as its own PR... and it may have
  noticeable performance impacts during rapid typing.
- Happened to notice this a few times during development/investigation of the rapid-typing issues... and it became reproducible with ease after a certain level of logging, interestingly.

```
    // Now that we've done the initial-state check, we can check for instantly-matching and
    // instantly-rejecting path models.
    let result = contactModel.update();
    if(result?.type == 'reject') {
      this.finalize(false, 'cancelled');
    }
```

2. matcherSelector:  pendingMatchSetup
- have seen double-stacking on the promise; we need to swap it out & replace to ensure things **_queue_** up.
- also, the early lock should probably only trigger if sourceNotYetStaged; no need to delay multitaps, since they just _continue_ the old gesture, rather than starting afresh.

3. Oh wow, THIS one was tricky.
- selection matchGesture() startup for NEW paths:
  - that double timedPromise() wait - so, what happens if any model matches before the second one returns?
  - the "standalone" models won't get a chance to match!  (This is the number 1 reason keys were getting outright-skipped!)
  - there are a lot of moving Promises at times across the whole gesture-engine system; we need to ensure that matchGesture() setup acts atomically when setting up both "matching old" and "considering new" behaviors.

4. Sequentialization Queue 
- Ensures that the promises stay in a logical start-to-end order despite all the promise shenanigans in the selector and matcher phases
- also remaps gesture timestamps to prevent automatic longpresses that could occur due to long input lag on older devices during heavy rapid-typing bursts.  They now "start" whenever they can safely be pulled from the input queue, but time differences within the gesture itself are otherwise preserved.
- is likely the most complex change, so we should definitely isolate it from the other tidbits mentioned herein.

In my tests since getting "all the ducks in a row", I get the same number of output chars as the number of keys I pressed.  Can't 100% say they're the exact intended keys when typing in very rapid bursts, but the keypresses _are_ countable, at least, and that's holding up - even if it takes a certain older test device the better part of a second to catch up (due to excessive console logging, most likely).