### PR TITLE
chore(linux): Fix autopkg tests

### DIFF
--- a/linux/debian/tests/test-build
+++ b/linux/debian/tests/test-build
@@ -12,7 +12,7 @@ cd "$WORKDIR"
 # Test all include files are available
 cat <<EOF > keymantest.c
 #include <keyman/keyman_core_api.h>
-km_core_context* c;
+km_core_actions* c;
 EOF
 
 # shellcheck disable=SC2046
@@ -22,7 +22,7 @@ echo "build 1: OK"
 # Test pkg-config file - include without path
 cat <<EOF > keymantest.c
 #include <keyman_core_api.h>
-km_core_context* c;
+km_core_actions* c;
 EOF
 
 # shellcheck disable=SC2046


### PR DESCRIPTION
Recent changes removed the `km_core_context` struct which caused the autopkg tests to fail.

@keymanapp-test-bot skip