### PR TITLE
change(web): input-event sequentialization 🪠

### DIFF
--- a/common/web/gesture-recognizer/src/engine/eventSequentializationQueue.ts
+++ b/common/web/gesture-recognizer/src/engine/eventSequentializationQueue.ts
@@ -1,0 +1,51 @@
+import { timedPromise } from "@keymanapp/web-utils";
+
+export class EventSequentializationQueue {
+  private queue: (() => Promise<void> | void)[];
+  private defermentPromise: Promise<void>;
+
+  constructor() {
+    this.queue = [];
+  }
+
+  private setDeferment(promise: Promise<any>) {
+    this.defermentPromise = promise;
+    promise.then(() => {
+      this.defermentPromise = null;
+      this.triggerEvent();
+    });
+  }
+
+  private async triggerEvent() {
+    while(this.queue.length > 0) {
+      const functor = this.queue.shift();
+
+      // Things break _badly_ if we don't keep the queue running if errors are triggered by the functor.
+      // It's best to ignore the error and let things play out.
+      try {
+        // Is either undefined or is a Promise.
+        const result = functor();
+        // We either wait on a manual lock (from within an InputEventEngine) or a macrotask queue wait,
+        // allowing gesture-matching microtask queue Promises to complete before proceeding.
+        this.setDeferment(result ? result : timedPromise(0));
+      } catch (err) {
+        const baseMsg = 'Error sequentializing received inputs';
+        if(err instanceof Error) {
+          console.error(`${baseMsg}: ${err.message}\n\n${err.stack}`);
+        } else {
+          console.error(baseMsg);
+          console.error(err);
+        }
+      }
+    }
+  }
+
+  queueEventFunctor(functor: () => Promise<void> | void) {
+    this.queue.push(functor);
+    // We only need to trigger events if the queue has no prior entries and there isn't an
+    // active deferment that will auto-trigger the event at the appropriate time.
+    if(this.queue.length == 1 && !this.defermentPromise) {
+      this.triggerEvent();
+    }
+  }
+}

--- a/common/web/gesture-recognizer/src/engine/headless/inputEngineBase.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/inputEngineBase.ts
@@ -56,6 +56,8 @@ export abstract class InputEngineBase<HoveredItemType, StateToken = any> extends
     return source;
   }
 
+  public unlockTouchpoint?: (touchpoint: GestureSource<HoveredItemType, StateToken>) => void;
+
   /**
    * Calls to this method will cancel any touchpoints whose internal IDs are _not_ included in the parameter.
    * Designed to facilitate recovery from error cases and peculiar states that sometimes arise when debugging.

--- a/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
+++ b/common/web/gesture-recognizer/src/engine/inputEventEngine.ts
@@ -48,6 +48,7 @@ export abstract class InputEventEngine<HoveredItemType, StateToken> extends Inpu
     });
 
     this.emit('pointstart', touchpoint);
+    return touchpoint;
   }
 
   protected onInputMove(identifier: number, sample: InputSample<HoveredItemType, StateToken>, target: EventTarget) {

--- a/common/web/gesture-recognizer/src/test/auto/browser/cases/canary.js
+++ b/common/web/gesture-recognizer/src/test/auto/browser/cases/canary.js
@@ -72,16 +72,18 @@ describe("'Canary' checks", function() {
       let fireEvent = () => {
         playbackEngine.replayTouchSamples(/*relative coord:*/ [ { sample: {targetX: 10, targetY: 10}, identifier: 1}],
                                           /*state:*/         "start",
-                                          /*recentTouches:*/  [],
+                                          /*recentTouches:*/  [/* TODO */],
                                         );
       }
 
       // Ensure that the expected handler is called.
       let fakeHandler = sinon.fake();
-      this.controller.recognizer.on('inputstart', fakeHandler)
+      this.controller.recognizer.on('inputstart', fakeHandler);
       fireEvent();
 
-      await Promise.resolve();
+      await new Promise((resolve) => {
+        window.setTimeout(resolve, 0);
+      });
 
       assert.isTrue(fakeHandler.called, "Unit test attempt failed:  handler was not called successfully.");
     });
@@ -99,10 +101,12 @@ describe("'Canary' checks", function() {
 
       // Ensure that the expected handler is called.
       let fakeHandler = sinon.fake();
-      this.controller.recognizer.on('inputstart', fakeHandler)
+      this.controller.recognizer.on('inputstart', fakeHandler);
       fireEvent();
 
-      await Promise.resolve();
+      await new Promise((resolve) => {
+        window.setTimeout(resolve, 0);
+      });
 
       assert.isTrue(fakeHandler.called, "Unit test attempt failed:  handler was not called successfully.");
     });


### PR DESCRIPTION
Fixes #10592.
Fixes #10646.

Continues from #10840.

This change introduces a "sequentialization" queue, ensuring that all incoming touch-based events are processed in the proper sequence.  In particular, it helps to ensure that:

- gesture model-matching will update after every relevant event before the next input-event is dequeued
- a gesture source's events will be delayed until _all_ possible models to match are able to receive and utilize update events

As a result, the internals of the gesture engine now work with three layers of task queues:

1. The microtask queue - is used by gesture model-matching and gesture-selection processes.
2. The macrotask queue - is used during gesture-match initialization of new sources and for gesture-source updates once initialized.
3. Two Promise-based "lock" queues, working together:
    1. An implicit, private one within `MatcherSelector.matchGesture`, ensuring that gesture-match initialization acts atomically with regard to incoming gesture sources
    2. One within `TouchInputEngine` (and unlatched within `TouchpointCoordinator`) ensuring that _all_ gesture-source updates are paused while `matchGesture`'s "lock" is engaged.

// TODO:  define user tests.