### PR TITLE
refactor(developer): move osk module from common-types to developer-utils 📚

### DIFF
--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -54,7 +54,5 @@ export * as util from './util/util.js';
 
 export * as KeymanFileTypes from './util/file-types.js';
 
-export * as Osk from './osk/osk.js';
-
 export * as Schemas from './schemas.js';
 export * as SchemaValidators from './schema-validators.js';

--- a/developer/src/common/web/utils/index.ts
+++ b/developer/src/common/web/utils/index.ts
@@ -1,3 +1,4 @@
 export { validateMITLicense } from './src/validate-mit-license.js';
 export { KeymanSentry } from './src/KeymanSentry.js';
 export { getOption, loadOptions, clearOptions } from './src/options.js';
+export * as Osk from './src/osk.js';

--- a/developer/src/common/web/utils/src/osk.ts
+++ b/developer/src/common/web/utils/src/osk.ts
@@ -1,6 +1,6 @@
-import { TouchLayoutFile, TouchLayoutFlick, TouchLayoutKey, TouchLayoutPlatform, TouchLayoutSubKey } from "../keyman-touch-layout/keyman-touch-layout-file.js";
-import { VisualKeyboard } from "../kvk/visual-keyboard.js";
-import SchemaValidators from "../schema-validators.js";
+import { TouchLayout } from "@keymanapp/common-types";
+import { VisualKeyboard } from "@keymanapp/common-types";
+import { SchemaValidators } from "@keymanapp/common-types";
 
 export interface StringRefUsage {
   filename: string;
@@ -12,20 +12,29 @@ export interface StringRef {
   usages: StringRefUsage[];
 };
 
+/**
+ * Represents a single key cap found by `AnalyzeOskCharacterUse`
+ */
 export interface StringResult {
-  str: string;                         // the key cap string
-  unicode: string;                     // unicode code points in <str> for reference
-  pua: string;                         // hexadecimal single character in PUA range
-  usages: StringRefUsage[] | string[]; // files in which the string is referenced
+  /** the key cap string */
+  str: string;
+  /** unicode code points in <str> for reference, without 'U+' prefix, e.g. '0061 0301' */
+  unicode: string;
+  /** hexadecimal single character in PUA range, without 'U+' prefix, e.g. 'F100' */
+  pua: string;
+  /** files in which the string is referenced; will be an array of
+   * {@link StringRefUsage} if includeCounts is true, otherwise will be an array
+   * of strings listing files in which the key cap may be found */
+  usages: StringRefUsage[] | string[];
 };
 
 export type PuaMap = {[index:string]: string};
 
 export function parseMapping(mapping: any) {
-  if(!SchemaValidators.displayMap(<any>mapping))
+  if(!SchemaValidators.default.displayMap(<any>mapping))
   /* c8 ignore next 3 */
   {
-    throw new Error(JSON.stringify((<any>SchemaValidators.displayMap).errors));
+    throw new Error(JSON.stringify((<any>SchemaValidators.default.displayMap).errors));
   }
 
   let map: PuaMap = {};
@@ -51,7 +60,7 @@ function remap(text: string, map: PuaMap) {
   return text;
 }
 
-export function remapVisualKeyboard(vk: VisualKeyboard, map: PuaMap): boolean {
+export function remapVisualKeyboard(vk: VisualKeyboard.VisualKeyboard, map: PuaMap): boolean {
   let dirty = false;
   for(let key of vk.keys) {
     if(!key.text) {
@@ -64,9 +73,9 @@ export function remapVisualKeyboard(vk: VisualKeyboard, map: PuaMap): boolean {
   return dirty;
 }
 
-export function remapTouchLayout(source: TouchLayoutFile, map: PuaMap) {
+export function remapTouchLayout(source: TouchLayout.TouchLayoutFile, map: PuaMap) {
   let dirty = false;
-  const scanKey = (key: TouchLayoutKey | TouchLayoutSubKey) => {
+  const scanKey = (key: TouchLayout.TouchLayoutKey | TouchLayout.TouchLayoutSubKey) => {
     if(!key.text) {
       return;
     }
@@ -79,7 +88,7 @@ export function remapTouchLayout(source: TouchLayoutFile, map: PuaMap) {
     key.text = text;
   }
 
-  const scanPlatform = (platform: TouchLayoutPlatform) => {
+  const scanPlatform = (platform: TouchLayout.TouchLayoutPlatform) => {
     if(!platform) {
       return;
     }
@@ -87,7 +96,7 @@ export function remapTouchLayout(source: TouchLayoutFile, map: PuaMap) {
       for(let row of layer.row) {
         for(let key of row.key) {
           scanKey(key);
-          let f: keyof TouchLayoutFlick;
+          let f: keyof TouchLayout.TouchLayoutFlick;
           for(f in key.flick ?? {}) {
             scanKey(key.flick[f]);
           }

--- a/developer/src/kmc-analyze/package.json
+++ b/developer/src/kmc-analyze/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "@keymanapp/common-types": "*",
+    "@keymanapp/developer-utils": "*",
     "@keymanapp/kmc-kmn": "*"
   },
   "devDependencies": {

--- a/developer/src/kmc-analyze/src/osk-character-use/index.ts
+++ b/developer/src/kmc-analyze/src/osk-character-use/index.ts
@@ -1,5 +1,6 @@
-import { CompilerCallbacks, KeymanFileTypes, KvksFile, KvksFileReader, Osk, TouchLayout, TouchLayoutFileReader } from "@keymanapp/common-types";
+import { CompilerCallbacks, KeymanFileTypes, KvksFile, KvksFileReader, TouchLayout, TouchLayoutFileReader } from "@keymanapp/common-types";
 import { CompilerMessages } from '@keymanapp/kmc-kmn';
+import { Osk } from '@keymanapp/developer-utils';
 import { getOskFromKmnFile } from "../util/get-osk-from-kmn-file.js";
 import { AnalyzerMessages } from "../messages.js";
 

--- a/developer/src/kmc-analyze/src/osk-rewrite-pua/index.ts
+++ b/developer/src/kmc-analyze/src/osk-rewrite-pua/index.ts
@@ -1,4 +1,5 @@
-import { CompilerCallbacks, KeymanFileTypes, KvksFile, KvksFileReader, KvksFileWriter, Osk, TouchLayoutFileReader, TouchLayoutFileWriter } from "@keymanapp/common-types";
+import { CompilerCallbacks, KeymanFileTypes, KvksFile, KvksFileReader, KvksFileWriter, TouchLayoutFileReader, TouchLayoutFileWriter } from "@keymanapp/common-types";
+import { Osk } from '@keymanapp/developer-utils';
 import { CompilerMessages } from '@keymanapp/kmc-kmn';
 import { getOskFromKmnFile } from "../util/get-osk-from-kmn-file.js";
 import { AnalyzerMessages } from "../messages.js";

--- a/developer/src/kmc-analyze/tsconfig.json
+++ b/developer/src/kmc-analyze/tsconfig.json
@@ -8,6 +8,7 @@
     "paths": {
       "@keymanapp/common-types": [ "../../../common/web/types/src/main" ],
       "@keymanapp/kmc-kmn": [ "../kmc-kmn/src/main" ],
+      "@keymanapp/developer-utils": ["../common/web/utils/index"],
     },
   },
   "include": [
@@ -16,5 +17,6 @@
   "references": [
     { "path": "../../../common/web/types" },
     { "path": "../kmc-kmn" },
+    { "path": "../common/web/utils/" },
   ]
 }

--- a/developer/src/kmc-kmn/package.json
+++ b/developer/src/kmc-kmn/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@keymanapp/keyman-version": "*",
+    "@keymanapp/developer-utils": "*",
     "@keymanapp/kmc-kmn": "*"
   },
   "devDependencies": {

--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -6,8 +6,9 @@ TODO: implement additional interfaces:
 */
 
 // TODO: rename wasm-host?
-import { UnicodeSetParser, UnicodeSet, Osk, VisualKeyboard, KvkFileReader, KeymanCompiler, KeymanCompilerArtifacts, KeymanCompilerArtifactOptional, KeymanCompilerResult, KeymanCompilerArtifact } from '@keymanapp/common-types';
+import { UnicodeSetParser, UnicodeSet, VisualKeyboard, KvkFileReader, KeymanCompiler, KeymanCompilerArtifacts, KeymanCompilerArtifactOptional, KeymanCompilerResult, KeymanCompilerArtifact } from '@keymanapp/common-types';
 import { CompilerCallbacks, CompilerEvent, CompilerOptions, KeymanFileTypes, KvkFileWriter, KvksFileReader } from '@keymanapp/common-types';
+import { Osk } from '@keymanapp/developer-utils';
 import loadWasmHost from '../import/kmcmplib/wasm-host.js';
 import { CompilerMessages, mapErrorFromKmcmplib } from './kmn-compiler-messages.js';
 import { WriteCompiledKeyboard } from '../kmw-compiler/kmw-compiler.js';

--- a/developer/src/kmc-kmn/src/kmw-compiler/validate-layout-file.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/validate-layout-file.ts
@@ -1,10 +1,10 @@
-import { KMX, Osk, TouchLayout, TouchLayoutFileReader, TouchLayoutFileWriter } from "@keymanapp/common-types";
+import { KMX, TouchLayout, TouchLayoutFileReader, TouchLayoutFileWriter } from "@keymanapp/common-types";
 import { callbacks, fk, IsKeyboardVersion14OrLater, IsKeyboardVersion15OrLater, IsKeyboardVersion17OrLater } from "./compiler-globals.js";
 import { JavaScript_Key } from "./javascript-strings.js";
 import { TRequiredKey, CRequiredKeys, CSpecialText, CSpecialText14Map, CSpecialText17Map, CSpecialTextMinVer, CSpecialTextMaxVer } from "./constants.js";
 import { KeymanWebTouchStandardKeyNames, KMWAdditionalKeyNames, VKeyNames } from "./keymanweb-key-codes.js";
 import { KmwCompilerMessages } from "./kmw-compiler-messages.js";
-
+import { Osk } from '@keymanapp/developer-utils';
 
 interface VLFOutput {
   output: string;

--- a/developer/src/kmc-kmn/tsconfig.json
+++ b/developer/src/kmc-kmn/tsconfig.json
@@ -9,6 +9,7 @@
     "preserveConstEnums": true,
     "paths": {
       "@keymanapp/common-types": ["../../../common/web/types/src/main"],
+      "@keymanapp/developer-utils": ["../common/web/utils/index"],
     },
 
   },
@@ -19,5 +20,6 @@
   "references": [
     { "path": "../../../common/web/keyman-version/tsconfig.json" },
     { "path": "../../../common/web/types/" },
+    { "path": "../common/web/utils/" },
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1012,6 +1012,7 @@
       "license": "MIT",
       "dependencies": {
         "@keymanapp/common-types": "*",
+        "@keymanapp/developer-utils": "*",
         "@keymanapp/kmc-kmn": "*"
       },
       "devDependencies": {
@@ -1499,6 +1500,7 @@
       "name": "@keymanapp/kmc-kmn",
       "license": "MIT",
       "dependencies": {
+        "@keymanapp/developer-utils": "*",
         "@keymanapp/keyman-version": "*",
         "@keymanapp/kmc-kmn": "*"
       },


### PR DESCRIPTION
This module is used only by Keyman Developer compiler. It was originally in common-types because we didn't have a shared module for Developer.

Moving it to @keymanapp/developer-utils in order to improve its documentation.

@keymanapp-test-bot skip