### PR TITLE
chore(linux): Temporarily disable autopkgtests gha

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -158,25 +158,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Download Artifacts
-      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
-      with:
-        path: artifacts
-        merge-multiple: true
+    # - name: Download Artifacts
+    #   uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+    #   with:
+    #     path: artifacts
+    #     merge-multiple: true
 
-    - name: Install dependencies
-      run: |
-        sudo DEBIAN_FRONTEND=noninteractive apt-get -q -y install autopkgtest qemu-system qemu-utils autodep8 genisoimage python3-distro-info
+    # - name: Install dependencies
+    #   run: |
+    #     sudo DEBIAN_FRONTEND=noninteractive apt-get -q -y install autopkgtest qemu-system qemu-utils autodep8 genisoimage python3-distro-info
 
-    - name: Build test image
-      run: |
-        cd "${GITHUB_WORKSPACE}/artifacts"
-        autopkgtest-buildvm-ubuntu-cloud -v --release=jammy
+    # - name: Build test image
+    #   run: |
+    #     cd "${GITHUB_WORKSPACE}/artifacts"
+    #     autopkgtest-buildvm-ubuntu-cloud -v --release=jammy
 
-    - name: Run tests
+    # - name: Run tests
+    #   run: |
+    #     cd "${GITHUB_WORKSPACE}/artifacts"
+    #     autopkgtest -B *.deb keyman_*.dsc -- qemu autopkgtest-jammy-amd64.img
+    - name: Ignore
       run: |
-        cd "${GITHUB_WORKSPACE}/artifacts"
-        autopkgtest -B *.deb keyman_*.dsc -- qemu autopkgtest-jammy-amd64.img
+        echo "Ignored for now - until working solution is in place"
 
   deb_signing:
     name: Sign source and binary packages


### PR DESCRIPTION
Turns out this doesn't work with gha the way I thought it would. I'll add a working solution, but in order not to keep the builds broken I'll disable the autopkg tests until then.

@keymanapp-test-bot skip