### PR TITLE
fix(android/engine): Check selection indexes

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -24,6 +24,7 @@ import com.keyman.engine.KMManager.KeyboardType;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.util.CharSequenceUtil;
 import com.keyman.engine.util.KMLog;
+import com.keyman.engine.util.KMString;
 
 public class KMKeyboardJSHandler {
   private Context context;
@@ -284,7 +285,17 @@ public class KMKeyboardJSHandler {
 
     // Chop dn+numPairs code points from the end of charsBackup
     // subSequence indices are start(inclusive) to end(exclusive)
-    CharSequence expectedChars = charsBackup.subSequence(0, charsBackup.length() - (dn + numPairs));
+    int start = 0;
+    int end = charsBackup.length() - (dn + numPairs);
+    CharSequence expectedChars;
+    try {
+      expectedChars = charsBackup.subSequence(start, end);
+    } catch (IndexOutOfBoundsException e) {
+      KMLog.LogException(TAG,
+        KMString.format("Bad subSequence of start %d, end is %d, length %d, dn %d, numPairs %d",
+        start, end, charsBackup.length(), dn, numPairs), e);
+      expectedChars = charsBackup;
+    }
     ic.deleteSurroundingText(dn + numPairs, 0);
     CharSequence newContext = getCharacterSequence(ic, originalBufferLength - 2*dn);
 
@@ -327,7 +338,15 @@ public class KMKeyboardJSHandler {
     if (Character.isLowSurrogate(sequence.charAt(0))) {
       // Adjust if the first char is also a split surrogate pair
       // subSequence indices are start(inclusive) to end(exclusive)
-      sequence = sequence.subSequence(1, sequence.length());
+      int start = 1;
+      int end = sequence.length();
+      try {
+        sequence = sequence.subSequence(start, end);
+      } catch (IndexOutOfBoundsException e) {
+        KMLog.LogException(TAG,
+          KMString.format("Bad subSequence of start %d, end is %d",
+          start, end), e);
+      }      
     }
 
     return sequence;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -294,7 +294,7 @@ public class KMKeyboardJSHandler {
       KMLog.LogException(TAG,
         KMString.format("Bad subSequence of start %d, end is %d, length %d, dn %d, numPairs %d",
         start, end, charsBackup.length(), dn, numPairs), e);
-      expectedChars = charsBackup;
+      expectedChars = "";
     }
     ic.deleteSurroundingText(dn + numPairs, 0);
     CharSequence newContext = getCharacterSequence(ic, originalBufferLength - 2*dn);


### PR DESCRIPTION
For investigation of #10835

Currently the Keyman Android context gets out of sync with KeymanWeb when the cursor is moved. This causes [charSequence.subSequence()](https://developer.android.com/reference/java/lang/CharSequence#subSequence(int,%20int)) to throw IndexOutOfBoundsException when:
* start or end are negative
* end is greater than length()
* start > end

This adds checks so I can continue to investigate why the selection gets out of sync.
Note, for now it's logged to Sentry, which causes the errors to appear as Toast notifications. I'm not sure we want a full confirmation dialog to appear each time this happens...

## User Testing
**Setup** - Install the PR build of Keyman for Android on an Android device/emulator.

* **TEST_INAPP** - Verifies inapp keyboard doesn't crash
1. Start Keyman and dismiss the "Get Started" menu
2. In the Keyman app, start typing text
3. move the cursor to an earlier part of the text
4. Press backspace.
5. Verify the app doesn't crash (Note, KeymanWeb is still out of sync, so there may be unexpected deletions to still fix for #10835
6. move the cursor
7. Press a key
8. Verify the app doesn't crash

* **TEST_SYSTEM** - Verifies system keyboard doesn't crash
1. Enable Keyman as a default system keyboard
2. Launch Chrome and select a text area to type
3. In the text field, start typing teext
4. move the cursor to an earlier part of the text
5. Press backspace
6. Verify the keyboard doesn't crash
7. Continue typing and then move the cursor
8. Press a key
9. Verify the keyboard doesn't crash
