### PR TITLE
chore(android/engine): Reduce toast notifications after installations

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalPackageDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalPackageDownloadCallback.java
@@ -2,7 +2,6 @@ package com.keyman.engine.cloud.impl;
 
 import android.content.Context;
 import android.net.Uri;
-import android.widget.Toast;
 
 import com.keyman.engine.BaseActivity;
 import com.keyman.engine.KMKeyboardDownloaderActivity;
@@ -99,8 +98,6 @@ public class CloudLexicalPackageDownloadCallback implements ICloudDownloadCallba
   @Override
   public void applyCloudDownloadToModel(Context aContext, Void aModel, CloudKeyboardDownloadReturns aCloudResult)
   {
-    BaseActivity.makeToast(aContext, R.string.dictionary_download_finished, Toast.LENGTH_SHORT);
-
     if(aCloudResult.installedResource != null)
     {
       KeyboardEventHandler.notifyListeners(KMKeyboardDownloaderActivity.getKbDownloadEventListeners(),

--- a/android/KMEA/app/src/main/java/com/keyman/engine/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/logic/ResourcesUpdateTool.java
@@ -572,7 +572,6 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
         updateFailed = true;
         checkingUpdates = false;
       } else {
-        BaseActivity.makeToast(currentContext, R.string.update_success, Toast.LENGTH_SHORT);
         lastUpdateCheck = Calendar.getInstance();
         SharedPreferences prefs = currentContext.getSharedPreferences(currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -172,7 +172,7 @@
     <!-- Context: Background download messages-->
     <string name="dictionary_download_is_running_in_background" comment="Notification that a dictionary download is still running">The selected dictionary is already downloading; please try again in a moment!</string>
 
-    <!-- Context: Background download messages-->
+    <!-- Context: Background download messages. Removed in Keyman 17-->
     <string name="dictionary_download_finished" comment="Notification that a dictionary download has finished">Dictionary download is finished.</string>
 
     <!-- Context: Background download messages -->
@@ -190,7 +190,7 @@
     <!-- Context: General Updates -->
     <string name="update_failed" comment="Notification that a resource update failed">One or more resources failed to update!</string>
 
-    <!-- Context: General Updates -->
+    <!-- Context: General Updates. Removed in Keyman 17 -->
     <string name="update_success" comment="Notification that a resource update successfully updated">Resources successfully updated!</string>
 
     <!-- Context: Model Info -->


### PR DESCRIPTION
Fixes #10812

Per user request, remove remove Toast notifications for:
* Dictionary download is finished
* Resources successfully updated

This reduces the noise when installing a keyboard+dictionary set.

## User Testing

**Setup** - Install the PR build of Keyman for Android

**TEST_LESS_TOASTS** - Verifies only 2 Toasts seen (previously 4)
1. Launch Keyman for Android
2. On the "Get Started" menu --> "Add a keyboard for your language" --> "Install from keyman.com" --> search for khmer_angkor and install
3. Observe Toast notifications are displayed when 
    * khmer_angkor keyboard is done installing
    * Download of Khmer dictionary started in the background
4. Verify Toasts do **not** appear for
    * Dictionary download is finished
    * Resources successfully updated 
 