### PR TITLE
fix(web): context save-state on reset

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -240,6 +240,11 @@ function updateKMText(text) {
   if(text != keyman.context.getText()) {
     keyman.context.setText(text);
     keyman.resetContext();
+
+
+    console_debug('result: \n' + build_context_string(keyman.context));
+  } else {
+    console_debug('context unchanged');
   }
 }
 
@@ -270,6 +275,10 @@ function updateKMSelectionRange(start, end) {
   if(context.selStart != start || context.selEnd != end) {
     keyman.context.setSelection(start, end);
     keyman.resetContext();
+
+    console_debug('result:\n' + build_context_string(context));
+  } else {
+    console.debug('range unchanged');
   }
 }
 

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -1,4 +1,4 @@
-var _debug = 0;
+var _debug = false;
 
 // Android harness attachment
 if(window.parent && window.parent.jsInterface && !window.jsInterface) {
@@ -235,7 +235,7 @@ function updateKMText(text) {
       text = '';
   }
 
-  console_debug('updateKMText(text='+text+') context.value='+keyman.context.getText());
+  console_debug('updateKMText(text=' + text + ') with: ' + build_context_string(keyman.context));
 
   if(text != keyman.context.getText()) {
     keyman.context.setText(text);
@@ -249,11 +249,17 @@ function console_debug(s) {
   }
 }
 
+function build_context_string(context) {
+  // Sadly, ES6-style "template strings" - strings with backticks - require Chrome 41+.
+  return 'preCaret: `' + context.getTextBeforeCaret() + '`\n' +
+    'selected: `' + context.getSelectedText() + '`\n' +
+    'postCaret: `' + context.getTextAfterCaret() + '`';
+}
+
 function updateKMSelectionRange(start, end) {
   var context = keyman.context;
 
-  // console_debug('updateKMSelectionRange('+start+','+end+'): context.selStart='+ta.selectionStart+' '+
-  //   '['+ta._KeymanWebSelectionStart+'] context.selEnd='+ta.selectionEnd+' '+ta._KeymanWebSelectionEnd);
+  console_debug('updateKMSelectionRange(' + start + ', ' + end + ') with: ' + build_context_string(context));
 
   if(start > end) {
     var e0 = end;

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -235,7 +235,7 @@ function updateKMText(text) {
       text = '';
   }
 
-  console_debug('updateKMText(text=' + text + ') with: ' + build_context_string(keyman.context));
+  console_debug('updateKMText(text=' + text + ') with: \n' + build_context_string(keyman.context));
 
   if(text != keyman.context.getText()) {
     keyman.context.setText(text);
@@ -259,7 +259,7 @@ function build_context_string(context) {
 function updateKMSelectionRange(start, end) {
   var context = keyman.context;
 
-  console_debug('updateKMSelectionRange(' + start + ', ' + end + ') with: ' + build_context_string(context));
+  console_debug('updateKMSelectionRange(' + start + ', ' + end + ') with: \n' + build_context_string(context));
 
   if(start > end) {
     var e0 = end;

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -12,6 +12,7 @@ export class ContextHost extends Mock {
   constructor(oninserttext: OnInsertTextFunc) {
     super();
     this.oninserttext = oninserttext;
+    this.saveState();
   }
 
   apply(transform: Transform): void {
@@ -45,6 +46,10 @@ export class ContextHost extends Mock {
     }
 
     // Save the current context state for use in future diffs.
+    this.saveState();
+  }
+
+  saveState() {
     this.savedState = Mock.from(this);
   }
 
@@ -77,7 +82,7 @@ export class ContextHost extends Mock {
       this.setSelection(this.text._kmwLength());
     }
 
-    this.savedState = Mock.from(this);
+    this.saveState();
 
     return shouldResetContext;
   }
@@ -182,5 +187,10 @@ export default class ContextManager extends ContextManagerBase<WebviewConfigurat
     }
 
     return activatingKeyboard;
+  }
+
+  public resetContext(): void {
+    super.resetContext();
+    this._rawContext.saveState();
   }
 }


### PR DESCRIPTION
Heavily mitigates #10835. In particular, this outright _fixes_ the increased frequency with which the error happens in 17.0-beta.  

Alas, as the increased frequency can be traced to a recent PR, this likely does not fix the long-running cause behind the pre-17.0 Sentry reports.  It does fix all of our current known repros.

To be precise, the increased frequency of the bug with 17.0-beta can be traced to changes made in #10728.  KMW gained a new context-synchronization method now used by iOS - a method which includes saving a snapshot of the context and comparing against it at later points.  

**That 'snapshot' aspect was _not_ integrated into the codepath for the original sync method**, which is still used by Android; as a result, when the caret is moved, that snapshot doesn't get updated without this fix.  This results in KMW thinking that the caret is still in the old place and not the new place when building the context sync update, providing bad values to the host app.

## User Testing

TEST_BACKSPACE_AFTER_MOVE: Attempt to reproduce #10835 (for Keyman for Android) using the currently known reproduction sequences documented there.

For one such sequence...

1. Use the `euro_latin` keyboard
2. Type some text in any app (even the Keyman app would work)
3. Using the touch screen select the cursor roughly halfway back in the text just typed.
4. Press backspace.

No error should occur; things should 'just work' as you would naturally expect.
