### PR TITLE
fix(android): fixes context-change detection for repeated-char cases

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -297,12 +297,13 @@ public class KMKeyboardJSHandler {
       expectedChars = "";
     }
     ic.deleteSurroundingText(dn + numPairs, 0);
-    CharSequence newContext = getCharacterSequence(ic, originalBufferLength - 2*dn);
+    // Shorten the retrieved context by exactly as many characters as were just deleted.
+    CharSequence newContext = getCharacterSequence(ic, originalBufferLength - dn - numPairs);
 
     CharSequence charsToRestore = CharSequenceUtil.restoreChars(expectedChars, newContext);
     if (charsToRestore.length() > 0) {
       // Restore expectedChars that Chromium deleted.
-      // Use newCusorPosition 1 so cursor will be after the inserted string
+      // Use newCursorPosition 1 so cursor will be after the inserted string
       ic.commitText(charsToRestore, 1);
     }
   }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/util/CharSequenceUtil.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/util/CharSequenceUtil.java
@@ -48,7 +48,7 @@ public final class CharSequenceUtil {
       if (expectedChars.length() != currentContext.length()) {
         String expectedCharsString = expectedChars.toString();
         String currentContextString = currentContext.toString();
-        int index = expectedCharsString.indexOf(currentContextString);
+        int index = expectedCharsString.lastIndexOf(currentContextString);
         if (index > -1) {
           // subSequence indices are start(inclusive) to end(exclusive)
           charsToRestore = expectedChars.subSequence(index + currentContextString.length(), expectedChars.length());

--- a/android/KMEA/app/src/main/java/com/keyman/engine/util/CharSequenceUtil.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/util/CharSequenceUtil.java
@@ -49,6 +49,9 @@ public final class CharSequenceUtil {
         String expectedCharsString = expectedChars.toString();
         String currentContextString = currentContext.toString();
         int index = expectedCharsString.lastIndexOf(currentContextString);
+        if (currentContextString.length() == 0) {
+          index = 0;
+        }
         if (index > -1) {
           // subSequence indices are start(inclusive) to end(exclusive)
           charsToRestore = expectedChars.subSequence(index + currentContextString.length(), expectedChars.length());

--- a/android/KMEA/app/src/test/java/com/keyman/engine/util/CharSequenceUtilTest.java
+++ b/android/KMEA/app/src/test/java/com/keyman/engine/util/CharSequenceUtilTest.java
@@ -151,5 +151,12 @@ public class CharSequenceUtilTest {
     Assert.assertEquals("p" + COMPOSING_CIRCUMFLEX_ACCENT + "p" + COMPOSING_CIRCUMFLEX_ACCENT, charsToRestore);
   }
 
+  @Test
+  public void test_repeated_char_backspace() {
+    CharSequence currentContext = "----------------";
+    CharSequence expectedChars  = "-----------------";
+    CharSequence charsToRestore = CharSequenceUtil.restoreChars(expectedChars, currentContext);
+    Assert.assertEquals("", charsToRestore);
+  }
   //endregion
 }


### PR DESCRIPTION
Fixes #10776.

Backspaces leading up to a heavily-repeated character in the context will no longer replicate the repeated character.  Backspacing the last instance of that character will also function as expected, rather than being blocked.

The method being updated here was tailored to resolve a specialized bug in older versions of Chrome - as such, there is notable potential for regression of #2250.  (Thanks, `git blame`!)  I've made sure to include its original user test as part of the testing suite specified below.  The original test keyboard from back then has been overwritten, but I've reconstructed it from scratch and found it quite useful in getting everything "just right" here.

## User Testing

This PR has a dedicated test keyboard.  It may be downloaded from https://jahorton.github.io/ - you want the [test_robust_deletions.kmp](https://jahorton.github.io/test_robust_deletions.kmp) package.  Alternatively, scan this QR code for the package:

![QR code](https://github.com/keymanapp/keyman/assets/25213402/14f26a3e-6e0a-4881-91fe-302532e4879d)

The keyboard's source is attached to this PR as well:  [test_robust_deletions.zip](https://github.com/keymanapp/keyman/files/14442002/test_robust_deletions.zip)


**TEST_FIX_REPEATED_CHAR_DELETES**:  Verify that backspace is not blocked when attempting to delete a character that has been repeated many times in a row.  (Verify that #10776 is fixed.)

1. Using `sil_euro_latin`, type `h` at least 20 times in a row.
2. Without any other text manipulations, press backspace and verify that one `h` is deleted.
3. Repeat the previous step 3 or so times, verifying that each time, another `h` is deleted.

**TEST_REPEATED_EMOJI**:  Verify that backspace is not blocked when attempting to delete an _emoji_ that has been repeated many times in a row.  (Verify that #10776 is fixed.)

1. Use the [test_robust_deletions.kmp](https://jahorton.github.io/test_robust_deletions.kmp) package.  (The QR code should work, too.)
2. Type _just one_ of the emoji keys at least 10 times in a row.
3. Without any other text manipulations, press backspace and verify that a single copy of the emoji is deleted.
4. Repeat the previous step 3 or so times, verifying that each time, another copy is deleted.

**TEST_CONTEXT_INITIAL_ROTATION**: Verify that rules that output repeated characters in rotation work properly.

1. Use the [test_robust_deletions.kmp](https://jahorton.github.io/test_robust_deletions.kmp) package.  (The QR code should work, too.)
2. Verify that 'p' correctly rotates as follows when starting from an empty context:
    - 'p' will rotate through: `p`, `ṗ`, `p̂`, `p̂p̂`, `p`, ...

**TEST_ANTI_REGRESSION**: Verify that this fix does not trigger a regression of #2250.  Aim to use Android API 25 if possible, or as close as possible if not.  Android Studio emulation _should_ be fine.  

(This is a replication of the original user test for #2281, which tested the original fix.)

**Setup**
1. Load Chrome on the device.
2. Chrome > Settings > About Chrome (near the bottom)
3. **Verify that the version of Chrome predates Chrome 81.**
    - If this fails, try a different setup based on an earlier API... and be sure to avoid updating Chrome if prompted.

**Actual repro**
1. Use the [test_robust_deletions.kmp](https://jahorton.github.io/test_robust_deletions.kmp) package.  (The QR code should work, too.)
2. Install the keyboard.
3. Enable Keyman as system keyboard.
4. **Open the device's primary mail app (gmail).**  If prompted, attempt to sign in **with a Gmail account**.
    - Note:  you don't need to _actually_ sign in, though.  The "Sign in" prompt itself is a perfect test target!
5. With the testing keyboard active, run the following checks:
    - Verify that backspaces typed with an empty context do not crash the app.
    - Verify that 'p' correctly rotates as follows, without affecting any other pre-existing text:
        - 'p' will rotate through: `p`, `ṗ`, `p̂`, `p̂p̂`, `p`, ...
        - The number of code points are: 1, 2, 2, 4, 1, ...
        - One backspace should delete one codepoint; therefore, to delete `p̂p̂` completely should take 4 backspaces.
    - Verify that backspace removes `p` diacritics when they exist, rather than both `p` and its diacritic.
    - Verify that backspace removes emoji cleanly, without leaving junk characters in the context.
        - One emoji per backspace.
        - No surrogate-pair fragment should remain.  (A "junk character", as a user would see it.)
    - Verify that a long context of 8 emojis followed by `p̂p̂`, then by a backspace, only removes the final `p̂`'s circumflex (diacritic).
    - Verify that a long context of 10 or more emojis followed by `p̂p̂`, then by a backspace, only removes the final `p̂`'s circumflex (diacritic).