### PR TITLE
refactor(developer): reorganize messages for adding details

### DIFF
--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -23,7 +23,7 @@ export * as Constants from './consts/virtual-key-constants.js';
 
 export { defaultCompilerOptions, CompilerBaseOptions, CompilerCallbacks, CompilerOptions, CompilerEvent, CompilerErrorNamespace,
          CompilerErrorSeverity, CompilerPathCallbacks, CompilerFileSystemCallbacks, CompilerCallbackOptions,
-         CompilerError, CompilerMessageSpec, compilerErrorSeverity, CompilerErrorMask, CompilerFileCallbacks, compilerErrorSeverityName,
+         CompilerError, CompilerMessageSpec, CompilerMessageSpecWithException, compilerErrorSeverity, CompilerErrorMask, CompilerFileCallbacks, compilerErrorSeverityName,
          compilerExceptionToString, compilerErrorFormatCode,
          compilerLogLevelToSeverity, CompilerLogLevel, compilerEventFormat, ALL_COMPILER_LOG_LEVELS,
          ALL_COMPILER_LOG_FORMATS, CompilerLogFormat,

--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -24,7 +24,7 @@ export * as Constants from './consts/virtual-key-constants.js';
 export { defaultCompilerOptions, CompilerBaseOptions, CompilerCallbacks, CompilerOptions, CompilerEvent, CompilerErrorNamespace,
          CompilerErrorSeverity, CompilerPathCallbacks, CompilerFileSystemCallbacks, CompilerCallbackOptions,
          CompilerError, CompilerMessageSpec, CompilerMessageSpecWithException, compilerErrorSeverity, CompilerErrorMask, CompilerFileCallbacks, compilerErrorSeverityName,
-         compilerExceptionToString, compilerErrorFormatCode,
+         compilerErrorFormatCode, CompilerMessageDef,
          compilerLogLevelToSeverity, CompilerLogLevel, compilerEventFormat, ALL_COMPILER_LOG_LEVELS,
          ALL_COMPILER_LOG_FORMATS, CompilerLogFormat,
          CompilerMessageOverride,

--- a/common/web/types/src/util/common-events.ts
+++ b/common/web/types/src/util/common-events.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from './compiler-interfaces.js';
+import { CompilerErrorNamespace, CompilerErrorSeverity,  CompilerMessageDef as def, CompilerMessageSpec as m } from './compiler-interfaces.js';
 import { constants } from '@keymanapp/ldml-keyboard-constants';
 
 const CommonTypesErrMask   = CompilerErrorNamespace.CommonTypes;
@@ -10,37 +10,37 @@ const SevError = CompilerErrorSeverity.Error | CommonTypesErrMask;
 
 export class CommonTypesMessages {
   // structured Ajv validation error
-  static Error_SchemaValidationError = (o:{instancePath:string, keyword:string, message: string, params: string}) => m(this.ERROR_SchemaValidationError,
-    `Error validating LDML XML file: ${o.instancePath}: ${o.keyword}: ${o.message} ${o.params}`);
   static ERROR_SchemaValidationError = SevError | 0x0001;
+  static Error_SchemaValidationError = (o:{instancePath:string, keyword:string, message: string, params: string}) => m(this.ERROR_SchemaValidationError,
+    `Error validating LDML XML file: ${def(o.instancePath)}: ${def(o.keyword)}: ${def(o.message)} ${def(o.params)}`);
 
+  static ERROR_ImportInvalidBase = SevError | 0x0002;
   static Error_ImportInvalidBase = (o: { base: string, path: string, subtag: string }) =>
     m(this.ERROR_ImportInvalidBase,
-      `Import element with base ${o.base} is unsupported. Only ${constants.cldr_import_base} is supported.`);
-  static ERROR_ImportInvalidBase = SevError | 0x0002;
+      `Import element with base ${def(o.base)} is unsupported. Only ${constants.cldr_import_base} is supported.`);
 
+  static ERROR_ImportInvalidPath = SevError | 0x0003;
   static Error_ImportInvalidPath = (o: { base: string, path: string, subtag: string }) =>
     m(this.ERROR_ImportInvalidPath,
-      `Import element with invalid path ${o.path}: expected the form '${constants.cldr_version_latest}/*.xml`);
-  static ERROR_ImportInvalidPath = SevError | 0x0003;
+      `Import element with invalid path ${def(o.path)}: expected the form '${constants.cldr_version_latest}/*.xml`);
 
+  static ERROR_ImportReadFail = SevError | 0x0004;
   static Error_ImportReadFail = (o: { base: string, path: string, subtag: string }) =>
     m(this.ERROR_ImportReadFail,
-      `Import could not read data with path ${o.path}: expected the form '${constants.cldr_version_latest}/*.xml'`);
-  static ERROR_ImportReadFail = SevError | 0x0004;
+      `Import could not read data with path ${def(o.path)}: expected the form '${constants.cldr_version_latest}/*.xml'`);
 
+  static ERROR_ImportWrongRoot = SevError | 0x0005;
   static Error_ImportWrongRoot = (o: { base: string, path: string, subtag: string }) =>
     m(this.ERROR_ImportWrongRoot,
-      `Invalid import file ${o.path}: expected ${o.subtag} as root element.`);
-  static ERROR_ImportWrongRoot = SevError | 0x0005;
+      `Invalid import file ${def(o.path)}: expected ${def(o.subtag)} as root element.`);
 
+  static ERROR_ImportMergeFail = SevError | 0x0006;
   static Error_ImportMergeFail = (o: { base: string, path: string, subtag: string, subsubtag: string }) =>
     m(this.ERROR_ImportMergeFail,
-      `Problem importing ${o.path}: not sure how to handle non-array ${o.subtag}.${o.subsubtag}`);
-  static ERROR_ImportMergeFail = SevError | 0x0006;
+      `Problem importing ${def(o.path)}: not sure how to handle non-array ${def(o.subtag)}.${def(o.subsubtag)}`);
 
+  static ERROR_TestDataUnexpectedArray = SevError | 0x0007;
   static Error_TestDataUnexpectedArray = (o: {subtag: string}) =>
     m(this.ERROR_TestDataUnexpectedArray,
-      `Problem reading test data: expected single ${o.subtag} element, found multiple`);
-  static ERROR_TestDataUnexpectedArray = SevError | 0x0007;
+      `Problem reading test data: expected single ${def(o.subtag)} element, found multiple`);
 };

--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -528,14 +528,18 @@ export const defaultCompilerOptions: CompilerOptions = {
  * @param message
  * @returns
  */
-export const CompilerMessageSpec = (code: number, message: string, exceptionVar?: any) : CompilerEvent => ({
+export const CompilerMessageSpec = (code: number, message: string) : CompilerEvent => ({
+  code,
+  message,
+});
+
+export const CompilerMessageSpecWithException = (code: number, message: string, exceptionVar: any) : CompilerEvent => ({
   code,
   message: exceptionVar
     ? (message ?? `Unexpected exception`) + `: ${exceptionVar.toString()}\n\nCall stack:\n${(exceptionVar instanceof Error ? exceptionVar.stack : (new Error()).stack)}` :
     message,
   exceptionVar
 });
-
 /**
  * @deprecated use `CompilerError.exceptionToString` instead
  */

--- a/common/web/types/src/util/compiler-interfaces.ts
+++ b/common/web/types/src/util/compiler-interfaces.ts
@@ -7,6 +7,11 @@ export interface CompilerEvent {
   code: number;
   message: string;
   /**
+   * detailed Markdown-formatted description of the error including
+   * references to documentation, remediation options.
+   */
+  detail?: string;
+  /**
    * an internal error occurred that should be captured with a stack trace
    * e.g. to the Keyman sentry instance by kmc
    */
@@ -524,28 +529,28 @@ export const defaultCompilerOptions: CompilerOptions = {
 
 /**
  * Convenience function for constructing CompilerEvents
- * @param code
- * @param message
+ * @param code     Unique numeric value of the event
+ * @param message  A short description of the error presented to the user
+ * @param detail   Detailed Markdown-formatted description of the error
+ *                 including references to documentation, remediation options.
  * @returns
  */
-export const CompilerMessageSpec = (code: number, message: string) : CompilerEvent => ({
+export const CompilerMessageSpec = (code: number, message: string, detail?: string) : CompilerEvent => ({
   code,
   message,
+  detail,
 });
 
-export const CompilerMessageSpecWithException = (code: number, message: string, exceptionVar: any) : CompilerEvent => ({
+export const CompilerMessageDef = (param: any) => String(param ?? `<param>`);
+
+export const CompilerMessageSpecWithException = (code: number, message: string, exceptionVar: any, detail?: string) : CompilerEvent => ({
   code,
   message: exceptionVar
     ? (message ?? `Unexpected exception`) + `: ${exceptionVar.toString()}\n\nCall stack:\n${(exceptionVar instanceof Error ? exceptionVar.stack : (new Error()).stack)}` :
     message,
-  exceptionVar
+  detail,
+  exceptionVar,
 });
-/**
- * @deprecated use `CompilerError.exceptionToString` instead
- */
-export function compilerExceptionToString(e?: any) : string {
-  return CompilerError.exceptionToString(e);
-}
 
 /**
  * Compiler logging level and correspondence to severity

--- a/developer/src/common/web/utils/src/osk.ts
+++ b/developer/src/common/web/utils/src/osk.ts
@@ -37,8 +37,8 @@ export function parseMapping(mapping: any) {
     throw new Error(JSON.stringify((<any>SchemaValidators.default.displayMap).errors));
   }
 
-  let map: PuaMap = {};
-  for (let item of mapping.map) {
+  const map: PuaMap = {};
+  for (const item of mapping.map) {
     map[item.str] = String.fromCharCode(parseInt(item.pua, 16));
   }
   return map;
@@ -62,7 +62,7 @@ function remap(text: string, map: PuaMap) {
 
 export function remapVisualKeyboard(vk: VisualKeyboard.VisualKeyboard, map: PuaMap): boolean {
   let dirty = false;
-  for(let key of vk.keys) {
+  for(const key of vk.keys) {
     if(!key.text) {
       continue;
     }
@@ -92,18 +92,18 @@ export function remapTouchLayout(source: TouchLayout.TouchLayoutFile, map: PuaMa
     if(!platform) {
       return;
     }
-    for(let layer of platform.layer) {
-      for(let row of layer.row) {
-        for(let key of row.key) {
+    for(const layer of platform.layer) {
+      for(const row of layer.row) {
+        for(const key of row.key) {
           scanKey(key);
           let f: keyof TouchLayout.TouchLayoutFlick;
           for(f in key.flick ?? {}) {
             scanKey(key.flick[f]);
           }
-          for(let sk of key.sk ?? []) {
+          for(const sk of key.sk ?? []) {
             scanKey(sk);
           }
-          for(let mt of key.multitap ?? []) {
+          for(const mt of key.multitap ?? []) {
             scanKey(mt);
           }
         }

--- a/developer/src/kmc-analyze/src/messages.ts
+++ b/developer/src/kmc-analyze/src/messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.Analyzer;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -13,7 +13,7 @@ const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
  */
 export class AnalyzerMessages {
   /** @internal */
-  static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   /**
    * Raised when an analysis components experiences an internal error. If you
    * experience this error, it should be reported to the Keyman team for

--- a/developer/src/kmc-analyze/src/messages.ts
+++ b/developer/src/kmc-analyze/src/messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.Analyzer;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -8,24 +8,24 @@ const SevInfo = CompilerErrorSeverity.Info | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
 /**
- * @public
+ * @internal
  * Compiler messages for `kmc analyze`
  */
 export class AnalyzerMessages {
-  /** @internal */
-  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
-  /**
-   * Raised when an analysis components experiences an internal error. If you
-   * experience this error, it should be reported to the Keyman team for
-   * resolution via https://github.com/keymanapp/keyman/issues/new
-   */
   static readonly FATAL_UnexpectedException = SevFatal | 0x0001;
+  static readonly Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(
+    this.FATAL_UnexpectedException,
+    null,
+    o.e ?? 'unknown error',
+    `Raised when an analysis components experiences an internal error. If you
+    experience this error, it should be reported to the Keyman team for
+    resolution via https://github.com/keymanapp/keyman/issues/new`
+  );
 
-  /** @internal */
-  static Info_ScanningFile = (o:{type: string, name: string}) => m(this.INFO_ScanningFile,
-    `Scanning ${o.type} file ${o.name}`);
-  /**
-   * Informative message reporting on the current file being scanned
-   */
   static readonly INFO_ScanningFile = SevInfo | 0x0002;
+  static readonly Info_ScanningFile = (o:{type: string, name: string}) => m(
+    this.INFO_ScanningFile,
+    `Scanning ${def(o.type)} file ${def(o.name)}`,
+    `Informative message reporting on the current file being scanned`
+  );
 };

--- a/developer/src/kmc-keyboard-info/src/keyboard-info-compiler-messages.ts
+++ b/developer/src/kmc-keyboard-info/src/keyboard-info-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.KeyboardInfoCompiler;
 // const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -8,7 +8,7 @@ const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
 export class KeyboardInfoCompilerMessages {
-  static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   static FATAL_UnexpectedException = SevFatal | 0x0001;
 
   static Error_FileDoesNotExist = (o:{filename: string}) => m(this.ERROR_FileDoesNotExist, `File ${o.filename} does not exist.`);

--- a/developer/src/kmc-keyboard-info/src/keyboard-info-compiler-messages.ts
+++ b/developer/src/kmc-keyboard-info/src/keyboard-info-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.KeyboardInfoCompiler;
 // const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -8,58 +8,58 @@ const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
 export class KeyboardInfoCompilerMessages {
-  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   static FATAL_UnexpectedException = SevFatal | 0x0001;
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
 
-  static Error_FileDoesNotExist = (o:{filename: string}) => m(this.ERROR_FileDoesNotExist, `File ${o.filename} does not exist.`);
   static ERROR_FileDoesNotExist = SevError | 0x0002;
+  static Error_FileDoesNotExist = (o:{filename: string}) => m(this.ERROR_FileDoesNotExist, `File ${def(o.filename)} does not exist.`);
 
-  static Error_FileIsNotValid = (o:{filename: string; e: any}) => m(this.ERROR_FileIsNotValid,
-    `File ${o.filename} could not be parsed: ${(o.e ?? 'unknown error').toString()}.`);
   static ERROR_FileIsNotValid = SevError | 0x0003;
+  static Error_FileIsNotValid = (o:{filename: string; e: any}) => m(this.ERROR_FileIsNotValid,
+    `File ${def(o.filename)} could not be parsed: ${(o.e ?? 'unknown error').toString()}.`);
 
-  static Warn_MetadataFieldInconsistent = (o:{field:string, value:any, expected:any}) => m(this.WARN_MetadataFieldInconsistent,
-    `Warning: field ${o.field} value "${o.value}" does not match "${o.expected}" found in source file metadata.`);
   static WARN_MetadataFieldInconsistent = SevWarn | 0x0004;
+  static Warn_MetadataFieldInconsistent = (o:{field:string, value:any, expected:any}) => m(this.WARN_MetadataFieldInconsistent,
+    `Warning: field ${def(o.field)} value "${def(o.value)}" does not match "${def(o.expected)}" found in source file metadata.`);
 
-  static Error_InvalidAuthorEmail = (o:{email:string}) => m(this.ERROR_InvalidAuthorEmail,
-    `Invalid author email: ${o.email}`);
   static ERROR_InvalidAuthorEmail = SevError | 0x0005;
+  static Error_InvalidAuthorEmail = (o:{email:string}) => m(this.ERROR_InvalidAuthorEmail,
+    `Invalid author email: ${def(o.email)}`);
 
-  static Error_LicenseFileDoesNotExist = (o:{filename:string}) => m(this.ERROR_LicenseFileIsMissing,
-    `License file ${o.filename} does not exist.`);
   static ERROR_LicenseFileIsMissing = SevError | 0x0006;
+  static Error_LicenseFileDoesNotExist = (o:{filename:string}) => m(this.ERROR_LicenseFileIsMissing,
+    `License file ${def(o.filename)} does not exist.`);
 
-  static Error_LicenseFileIsDamaged = (o:{filename:string}) => m(this.ERROR_LicenseFileIsDamaged,
-    `License file ${o.filename} could not be loaded or decoded.`);
   static ERROR_LicenseFileIsDamaged = SevError | 0x0007;
+  static Error_LicenseFileIsDamaged = (o:{filename:string}) => m(this.ERROR_LicenseFileIsDamaged,
+    `License file ${def(o.filename)} could not be loaded or decoded.`);
 
-  static Error_LicenseIsNotValid = (o:{filename:string,message:string}) => m(this.ERROR_LicenseIsNotValid,
-    `An error was encountered parsing license file ${o.filename}: ${o.message}.`);
   static ERROR_LicenseIsNotValid = SevError | 0x0008;
+  static Error_LicenseIsNotValid = (o:{filename:string,message:string}) => m(this.ERROR_LicenseIsNotValid,
+    `An error was encountered parsing license file ${def(o.filename)}: ${def(o.message)}.`);
 
+  static ERROR_CannotBuildWithoutKmpFile = SevError | 0x0009;
   static Error_CannotBuildWithoutKmpFile = () => m(this.ERROR_CannotBuildWithoutKmpFile,
     `Compiling the .keyboard_info file requires a .kmp file for metadata.`);
-  static ERROR_CannotBuildWithoutKmpFile = SevError | 0x0009;
 
+  static ERROR_NoLicenseFound = SevError | 0x000A;
   static Error_NoLicenseFound = () => m(this.ERROR_NoLicenseFound,
     `No license for the keyboard was found. MIT license is required for publication to Keyman keyboards repository.`);
-  static ERROR_NoLicenseFound = SevError | 0x000A;
 
-  static Hint_OutputValidation = (o:{message: any}) => m(this.HINT_OutputValidation,
-    `Validating output: ${o.message}.`);
   static HINT_OutputValidation = SevHint | 0x000B;
+  static Hint_OutputValidation = (o:{message: any}) => m(this.HINT_OutputValidation,
+    `Validating output: ${def(o.message)}.`);
 
-  static Warn_OutputValidation = (o:{message: any}) => m(this.WARN_OutputValidation,
-    `Validating output: ${o.message}.`);
   static WARN_OutputValidation = SevWarn | 0x000C;
+  static Warn_OutputValidation = (o:{message: any}) => m(this.WARN_OutputValidation,
+    `Validating output: ${def(o.message)}.`);
 
-  static Error_OutputValidation = (o:{message: any}) => m(this.ERROR_OutputValidation,
-    `Validating output: ${o.message}.`);
   static ERROR_OutputValidation = SevError | 0x000D;
+  static Error_OutputValidation = (o:{message: any}) => m(this.ERROR_OutputValidation,
+    `Validating output: ${def(o.message)}.`);
 
-  static Error_FontFileCannotBeRead = (o:{filename: string}) => m(this.ERROR_FontFileCannotBeRead,
-    `Font ${o.filename} could not be parsed to extract a font family.`);
   static ERROR_FontFileCannotBeRead = SevError | 0x000E;
+  static Error_FontFileCannotBeRead = (o:{filename: string}) => m(this.ERROR_FontFileCannotBeRead,
+    `Font ${def(o.filename)} could not be parsed to extract a font family.`);
 }
 

--- a/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 import { kmnfile } from "../kmw-compiler/compiler-globals.js";
 
 const Namespace = CompilerErrorNamespace.KmnCompiler;
@@ -51,7 +51,7 @@ export const enum KmnCompilerMessageRanges {
 }
 
 /**
- * @public
+ * @internal
  *
  * Error messages reported by the .kmn compiler. The messages in this class
  * share the namespace with messages from kmn_compiler_errors.h, which are
@@ -79,649 +79,644 @@ export class KmnCompilerMessages {
   // kmc-kmn, which would avoid a number of legacy issues. Questions about
   // parameterisation.
 
-  /** @internal */
-  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
-  /**
-   * Raised when KmnCompiler or one of its components experiences an internal
-   * error. If you experience this error, it should be reported to the Keyman
-   * team for resolution via https://github.com/keymanapp/keyman/issues/new
-   */
   static FATAL_UnexpectedException = SevFatal | 0x900;
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(
+    this.FATAL_UnexpectedException,
+    null,
+    o.e ?? 'unknown error',
+    `Raised when KmnCompiler or one of its components hasan internal
+    error. If you experience this error, it should be reported to the Keyman
+    team for resolution via https://github.com/keymanapp/keyman/issues/new.`
+  );
 
-  /** @internal */
-  static Fatal_MissingWasmModule = (o:{e?: any}) => CompilerMessageSpecWithException(this.FATAL_MissingWasmModule,
-    `Could not instantiate WASM compiler module or initialization failed`, o.e ?? 'unknown error');
-  /**
-   * Raised when the kmcmplib component could be instantiated. This may indicate
-   * a configuration or dependency issue. Make sure you are running a Javascript
-   * engine that supports WASM, and that use of WASM is enabled.
-   */
   static FATAL_MissingWasmModule = SevFatal | 0x901;
+  static Fatal_MissingWasmModule = (o:{e?: any}) => CompilerMessageSpecWithException(
+    this.FATAL_MissingWasmModule,
+    `Could not instantiate WASM compiler module or initialization failed`,
+    o.e ?? 'unknown error',
+    `Raised when the kmcmplib component could be instantiated. This may indicate
+    a configuration or dependency issue. Make sure you are running a Javascript
+    engine that supports WASM, and that use of WASM is enabled.`
+  );
 
   // Note: this is now unused
-  // static Fatal_UnableToSetCompilerOptions = () => m(this.FATAL_UnableToSetCompilerOptions, null, `Unable to set compiler options`);
   // static FATAL_UnableToSetCompilerOptions = SevFatal | 0x902;
+  // static Fatal_UnableToSetCompilerOptions = () => m(this.FATAL_UnableToSetCompilerOptions, null, `Unable to set compiler options`);
 
-  /** @internal */
-  static Fatal_CallbacksNotSet = () => CompilerMessageSpecWithException(this.FATAL_CallbacksNotSet, null, `Callbacks were not set with init`);
-  /**
-   * Raised when KmnCompiler or one of its components experiences an internal
-   * error. If you experience this error, it should be reported to the Keyman
-   * team for resolution via https://github.com/keymanapp/keyman/issues/new
-   */
   static FATAL_CallbacksNotSet = SevFatal | 0x903;
+  static Fatal_CallbacksNotSet = () => CompilerMessageSpecWithException(
+    this.FATAL_CallbacksNotSet,
+    null,
+    `Callbacks were not set with init`,
+    `Raised when KmnCompiler or one of its components experiences an internal
+    error. If you experience this error, it should be reported to the Keyman
+    team for resolution via https://github.com/keymanapp/keyman/issues/new.`
+  );
 
-  /** @internal */
-  static Fatal_UnicodeSetOutOfRange = () => CompilerMessageSpecWithException(this.FATAL_UnicodeSetOutOfRange, null, `UnicodeSet buffer was too small`);
-  /**
-   * Raised when caller to UnicodeSet functions provides an invalid buffer. If
-   * you experience this error, it should be reported to the Keyman team for
-   * resolution via https://github.com/keymanapp/keyman/issues/new
-   */
   static FATAL_UnicodeSetOutOfRange = SevFatal | 0x904;
+  static Fatal_UnicodeSetOutOfRange = () => CompilerMessageSpecWithException(
+    this.FATAL_UnicodeSetOutOfRange,
+    null,
+    `UnicodeSet buffer was too small`,
+    `Raised when caller to UnicodeSet functions provides an invalid buffer. If
+    you experience this error, it should be reported to the Keyman team for
+    resolution via https://github.com/keymanapp/keyman/issues/new.`
+  );
 
   // TODO: rename the following functions to Error_UsetHasStrings etc
 
-  /** @internal */
-  static Error_UnicodeSetHasStrings = () => m(this.ERROR_UnicodeSetHasStrings, `uset contains strings, not allowed`);
-  /**
-   * The provided uset uses multi-character strings, (`{}` notation, e.g.
-   * `[żġħ{ie}{għ}]`. ). Although full UnicodeSets support strings, LDML
-   * keyboards do not support multi-character strings in usets. To resolve this,
-   * reformat the uset to avoid the use of multi-character strings.
-   *
-   * More on uset:
-   * https://www.unicode.org/reports/tr35/tr35-keyboards.html#element-uset
-   */
   static ERROR_UnicodeSetHasStrings = SevError | 0x905;
+  static Error_UnicodeSetHasStrings = () => m(
+    this.ERROR_UnicodeSetHasStrings,
+    `uset contains strings, not allowed`,
+    `The provided uset uses multi-character strings, (\`{}\` notation, e.g.
+    \`[żġħ{ie}{għ}]\`. ). Although full UnicodeSets support strings, LDML
+    keyboards do not support multi-character strings in usets. To resolve this,
+    reformat the uset to avoid the use of multi-character strings.
 
-  /** @internal */
-  static Error_UnicodeSetHasProperties = () => m(this.ERROR_UnicodeSetHasProperties, `uset contains properties, not allowed`);
-  /**
-   * The provided uset uses property notation (`\p{…}` or `[:…:]`). LDML
-   * keyboards do not support Unicode properties in usets, because that would
-   * make implementations dependent on a particular version of Unicode. To
-   * resolve this, reformat the uset to avoid the use of properties.
-   *
-   * More on uset:
-   * https://www.unicode.org/reports/tr35/tr35-keyboards.html#element-uset
-   */
+    More on uset: https://www.unicode.org/reports/tr35/tr35-keyboards.html#element-uset`
+  );
+
   static ERROR_UnicodeSetHasProperties = SevError | 0x906;
+  static Error_UnicodeSetHasProperties = () => m(
+    this.ERROR_UnicodeSetHasProperties,
+    `uset contains properties, not allowed`,
+    `The provided uset uses property notation (\`\\p{…}\` or \`[:…:]\`). LDML
+    keyboards do not support Unicode properties in usets, because that would
+    make implementations dependent on a particular version of Unicode. To
+    resolve this, reformat the uset to avoid the use of properties.
 
-  /** @internal */
-  static Error_UnicodeSetSyntaxError = () => m(this.ERROR_UnicodeSetSyntaxError, `uset had a Syntax Error while parsing`);
-  /**
-   * The provided uset has a syntax error and could not be parsed. Verify the
-   * format of the uset against the specification.
-   *
-   * More on uset: https://www.unicode.org/reports/tr35/tr35-keyboards.html#element-uset
-   */
+    More on uset: https://www.unicode.org/reports/tr35/tr35-keyboards.html#element-uset`
+  );
+
   static ERROR_UnicodeSetSyntaxError = SevError | 0x907;
+  static Error_UnicodeSetSyntaxError = () => m(
+    this.ERROR_UnicodeSetSyntaxError,
+    `uset had a Syntax Error while parsing`,
+    `The provided uset has a syntax error and could not be parsed. Verify the
+    format of the uset against the specification.
 
-  /** @internal */
-  static Error_InvalidKvksFile = (o:{filename: string, e: any}) => m(this.ERROR_InvalidKvksFile,
-    `Error encountered parsing ${o.filename}: ${o.e ?? 'unknown error'}`); // Note, not fatal, not reporting to Sentry
-  /**
-   * The .kvks file could not be parsed because it was not a valid XML file.
-   * There may be additional information in the error message to help you
-   * resolve the error.
-   *
-   * More on .kvks file format: https://help.keyman.com/developer/current-version/reference/file-types/kvks
-   */
+    More on uset: https://www.unicode.org/reports/tr35/tr35-keyboards.html#element-uset`
+  );
+
   static ERROR_InvalidKvksFile = SevError | 0x908;
+  static Error_InvalidKvksFile = (o:{filename: string, e: any}) => m(
+    this.ERROR_InvalidKvksFile,
+    `Error encountered parsing ${def(o.filename)}: ${o.e ?? 'unknown error'}`, // Note, not fatal, not reporting to Sentry
+    `The .kvks file could not be parsed because it was not a valid XML file.
+    There may be additional information in the error message to help you
+    resolve the error.
 
-  /** @internal */
-  static Warn_InvalidVkeyInKvksFile = (o:{filename: string, invalidVkey: string}) => m(this.WARN_InvalidVkeyInKvksFile,
-    `Invalid virtual key ${o.invalidVkey} found in ${o.filename}`);
-  /**
-   * The .kvks file contained a virtual key that was not supported by
-   * Keyman. Remove this virtual key from the .kvks file.
-   *
-   * Supported virtual keys: https://help.keyman.com/developer/language/guide/virtual-keys#common-virtual-key-codes
-   */
+    More on .kvks file format: https://help.keyman.com/developer/current-version/reference/file-types/kvks`
+  );
+
   static WARN_InvalidVkeyInKvksFile = SevWarn | 0x909;
+  static Warn_InvalidVkeyInKvksFile = (o:{filename: string, invalidVkey: string}) => m(
+    this.WARN_InvalidVkeyInKvksFile,
+    `Invalid virtual key ${def(o.invalidVkey)} found in ${def(o.filename)}`,
+    `The .kvks file contained a virtual key that was not supported by
+    Keyman. Remove this virtual key from the .kvks file.
 
-  /** @internal */
-  static Error_InvalidDisplayMapFile = (o:{filename: string, e: any}) => m(this.ERROR_InvalidDisplayMapFile,
-    `Error encountered parsing display map ${o.filename}: ${o.e ?? 'unknown error'}`); // Note, not fatal, not reporting to Sentry
-  /**
-   * The displayMap file could not be parsed because it was not a valid JSON
-   * file. There may be additional information in the error message to help you
-   * resolve the error.
-   *
-   * More on displayMap: https://help.keyman.com/developer/language/reference/displaymap
-   */
+    Supported virtual keys: https://help.keyman.com/developer/language/guide/virtual-keys#common-virtual-key-codes`
+  );
+
   static ERROR_InvalidDisplayMapFile = SevError | 0x90A;
+  static Error_InvalidDisplayMapFile = (o:{filename: string, e: any}) => m(
+    this.ERROR_InvalidDisplayMapFile,
+    `Error encountered parsing display map ${def(o.filename)}: ${o.e ?? 'unknown error'}`, // Note, not fatal, not reporting to Sentry
+    `The displayMap file could not be parsed because it was not a valid JSON
+    file. There may be additional information in the error message to help you
+    resolve the error.
 
-  /** @internal */
-  static Error_InvalidKvkFile = (o:{filename: string, e: any}) => m(this.ERROR_InvalidKvkFile,
-    `Error encountered loading ${o.filename}: ${o.e ?? 'unknown error'}`); // Note, not fatal, not reporting to Sentry
-  /**
-   * The .kvk file could not be loaded because it was not a valid format. There
-   * may be additional information in the error message to help you resolve the
-   * error.
-   *
-   * More on .kvk files: https://help.keyman.com/developer/current-version/reference/file-types/kvk
-   */
+    More on displayMap: https://help.keyman.com/developer/language/reference/displaymap`
+  );
+
   static ERROR_InvalidKvkFile = SevError | 0x90B;
+  static Error_InvalidKvkFile = (o:{filename: string, e: any}) => m(
+    this.ERROR_InvalidKvkFile,
+    `Error encountered loading ${def(o.filename)}: ${o.e ?? 'unknown error'}`, // Note, not fatal, not reporting to Sentry
+    `The .kvk file could not be loaded because it was not a valid format. There
+    may be additional information in the error message to help you resolve the
+    error.
 
-  /** @internal */
-  static Error_FileNotFound = (o:{filename: string}) => m(this.ERROR_FileNotFound,
-    `File ${o.filename} was not found`);
-  /**
-   * The file was not found on the disk. Verify that you have the correct path
-   * to the file.
-   */
+    More on .kvk files: https://help.keyman.com/developer/current-version/reference/file-types/kvk`
+  );
+
   static ERROR_FileNotFound = SevError | 0x90C;
+  static Error_FileNotFound = (o:{filename: string}) => m(this.ERROR_FileNotFound,
+    `File ${def(o.filename)} was not found`,
+    `The file was not found on the disk. Verify that you have the correct path
+    to the file.`
+  );
 
   // static INFO_None                                            = SevInfo | 0x000;
 
-  static Info_EndOfFile                                       = () => m(this.INFO_EndOfFile, `(no error - reserved code)`);
   static INFO_EndOfFile                                       = SevInfo | 0x001;
+  static Info_EndOfFile                                       = () => m(this.INFO_EndOfFile, `(no error - reserved code)`);
 
-  static Fatal_BadCallParams                                  = () => m(this.FATAL_BadCallParams, `CompileKeyboardFile was called with bad parameters`);
   static FATAL_BadCallParams                                  = SevFatal | 0x002;
+  static Fatal_BadCallParams                                  = () => m(this.FATAL_BadCallParams, `CompileKeyboardFile was called with bad parameters`);
 
-  static Fatal_CannotAllocateMemory                           = () => m(this.FATAL_CannotAllocateMemory, `Out of memory`);
   static FATAL_CannotAllocateMemory                           = SevFatal | 0x004;
+  static Fatal_CannotAllocateMemory                           = () => m(this.FATAL_CannotAllocateMemory, `Out of memory`);
 
-  static Error_InfileNotExist                                 = () => m(this.ERROR_InfileNotExist, `Cannot find the input file`);
   static ERROR_InfileNotExist                                 = SevError | 0x005; // #10678: reduced from fatal to error in 17.0
+  static Error_InfileNotExist                                 = () => m(this.ERROR_InfileNotExist, `Cannot find the input file`);
 
-  // static Error_CannotCreateOutfile                            = () => m(this.ERROR_CannotCreateOutfile, `Cannot open output file for writing`); unused
   // static ERROR_CannotCreateOutfile                            = SevError | 0x006; // #10678: reduced from fatal to error in 17.0, but unused
+  // static Error_CannotCreateOutfile                            = () => m(this.ERROR_CannotCreateOutfile, `Cannot open output file for writing`); unused
 
-  static Fatal_UnableToWriteFully                             = () => m(this.FATAL_UnableToWriteFully, `Unable to write the file completely`);
   static FATAL_UnableToWriteFully                             = SevFatal | 0x007;
+  static Fatal_UnableToWriteFully                             = () => m(this.FATAL_UnableToWriteFully, `Unable to write the file completely`);
 
-  static Error_CannotReadInfile                               = () => m(this.ERROR_CannotReadInfile, `Cannot read the input file`);
   static ERROR_CannotReadInfile                               = SevError | 0x008; // #10678: reduced from fatal to error in 17.0
+  static Error_CannotReadInfile                               = () => m(this.ERROR_CannotReadInfile, `Cannot read the input file`);
 
-  static Fatal_SomewhereIGotItWrong                           = () => m(this.FATAL_SomewhereIGotItWrong, `Internal error: contact Keyman`);
   static FATAL_SomewhereIGotItWrong                           = SevFatal | 0x009;
+  static Fatal_SomewhereIGotItWrong                           = () => m(this.FATAL_SomewhereIGotItWrong, `Internal error: contact Keyman`);
 
-  static Error_InvalidToken                                  = () => m(this.ERROR_InvalidToken, `Invalid token found`);
   static ERROR_InvalidToken                                   = SevError | 0x00A;
+  static Error_InvalidToken                                   = () => m(this.ERROR_InvalidToken, `Invalid token found`);
 
   // kmcmplib: static Error_InvalidBegin                                  = () => m(this.ERROR_InvalidBegin, `Invalid 'begin' command`);
+  static ERROR_InvalidBegin                                   = SevError | 0x00B;
   static Error_InvalidBegin = () => mw(this.ERROR_InvalidBegin,
     `A "begin unicode" statement is required to compile a KeymanWeb keyboard`);
-  static ERROR_InvalidBegin                                   = SevError | 0x00B;
 
-  static Error_InvalidName                                   = () => m(this.ERROR_InvalidName, `Invalid 'name' command`);
   static ERROR_InvalidName                                    = SevError | 0x00C;
+  static Error_InvalidName                                    = () => m(this.ERROR_InvalidName, `Invalid 'name' command`);
 
-  static Error_InvalidVersion                                = () => m(this.ERROR_InvalidVersion, `Invalid 'version' command`);
   static ERROR_InvalidVersion                                 = SevError | 0x00D;
+  static Error_InvalidVersion                                 = () => m(this.ERROR_InvalidVersion, `Invalid 'version' command`);
 
-  static Error_InvalidLanguageLine                           = () => m(this.ERROR_InvalidLanguageLine, `Invalid 'language' command`);
   static ERROR_InvalidLanguageLine                            = SevError | 0x00E;
+  static Error_InvalidLanguageLine                            = () => m(this.ERROR_InvalidLanguageLine, `Invalid 'language' command`);
 
-  static Error_LayoutButNoLanguage                           = () => m(this.ERROR_LayoutButNoLanguage, `Layout command found but no language command`);
   static ERROR_LayoutButNoLanguage                            = SevError | 0x00F;
+  static Error_LayoutButNoLanguage                            = () => m(this.ERROR_LayoutButNoLanguage, `Layout command found but no language command`);
 
-  static Error_InvalidLayoutLine                              = () => m(this.ERROR_InvalidLayoutLine, `Invalid 'layout' command`);
   static ERROR_InvalidLayoutLine                              = SevError | 0x010;
+  static Error_InvalidLayoutLine                              = () => m(this.ERROR_InvalidLayoutLine, `Invalid 'layout' command`);
 
-  static Error_NoVersionLine                                  = () => m(this.ERROR_NoVersionLine, `No version line found for file`);
   static ERROR_NoVersionLine                                  = SevError | 0x011;
+  static Error_NoVersionLine                                  = () => m(this.ERROR_NoVersionLine, `No version line found for file`);
 
-  static Error_InvalidGroupLine                               = () => m(this.ERROR_InvalidGroupLine, `Invalid 'group' command`);
   static ERROR_InvalidGroupLine                               = SevError | 0x012;
+  static Error_InvalidGroupLine                               = () => m(this.ERROR_InvalidGroupLine, `Invalid 'group' command`);
 
-  static Error_InvalidStoreLine                               = () => m(this.ERROR_InvalidStoreLine, `Invalid 'store' command`);
   static ERROR_InvalidStoreLine                               = SevError | 0x013;
+  static Error_InvalidStoreLine                               = () => m(this.ERROR_InvalidStoreLine, `Invalid 'store' command`);
 
-  static Error_InvalidCodeInKeyPartOfRule                     = () => m(this.ERROR_InvalidCodeInKeyPartOfRule, `Invalid command or code found in key part of rule`);
   static ERROR_InvalidCodeInKeyPartOfRule                     = SevError | 0x014;
+  static Error_InvalidCodeInKeyPartOfRule                     = () => m(this.ERROR_InvalidCodeInKeyPartOfRule, `Invalid command or code found in key part of rule`);
 
-  static Error_InvalidDeadkey                                 = () => m(this.ERROR_InvalidDeadkey, `Invalid 'deadkey' or 'dk' command`);
   static ERROR_InvalidDeadkey                                 = SevError | 0x015;
+  static Error_InvalidDeadkey                                 = () => m(this.ERROR_InvalidDeadkey, `Invalid 'deadkey' or 'dk' command`);
 
-  static Error_InvalidValue                                   = () => m(this.ERROR_InvalidValue, `Invalid value in extended string`);
   static ERROR_InvalidValue                                   = SevError | 0x016;
+  static Error_InvalidValue                                   = () => m(this.ERROR_InvalidValue, `Invalid value in extended string`);
 
-  static Error_ZeroLengthString                               = () => m(this.ERROR_ZeroLengthString, `A string of zero characters was found`);
   static ERROR_ZeroLengthString                               = SevError | 0x017;
+  static Error_ZeroLengthString                               = () => m(this.ERROR_ZeroLengthString, `A string of zero characters was found`);
 
-  static Error_TooManyIndexToKeyRefs                          = () => m(this.ERROR_TooManyIndexToKeyRefs, `Too many index commands refering to key string`);
   static ERROR_TooManyIndexToKeyRefs                          = SevError | 0x018;
+  static Error_TooManyIndexToKeyRefs                          = () => m(this.ERROR_TooManyIndexToKeyRefs, `Too many index commands refering to key string`);
 
-  static Error_UnterminatedString                             = () => m(this.ERROR_UnterminatedString, `Unterminated string in line`);
   static ERROR_UnterminatedString                             = SevError | 0x019;
+  static Error_UnterminatedString                             = () => m(this.ERROR_UnterminatedString, `Unterminated string in line`);
 
-  static Error_StringInVirtualKeySection                      = () => m(this.ERROR_StringInVirtualKeySection, `extend string illegal in virtual key section`);
   static ERROR_StringInVirtualKeySection                      = SevError | 0x01A;
+  static Error_StringInVirtualKeySection                      = () => m(this.ERROR_StringInVirtualKeySection, `extend string illegal in virtual key section`);
 
-  static Error_AnyInVirtualKeySection                         = () => m(this.ERROR_AnyInVirtualKeySection, `'any' command is illegal in virtual key section`);
   static ERROR_AnyInVirtualKeySection                         = SevError | 0x01B;
+  static Error_AnyInVirtualKeySection                         = () => m(this.ERROR_AnyInVirtualKeySection, `'any' command is illegal in virtual key section`);
 
-  static Error_InvalidAny                                     = () => m(this.ERROR_InvalidAny, `Invalid 'any' command`);
   static ERROR_InvalidAny                                     = SevError | 0x01C;
+  static Error_InvalidAny                                     = () => m(this.ERROR_InvalidAny, `Invalid 'any' command`);
 
-  static Error_StoreDoesNotExist                              = () => m(this.ERROR_StoreDoesNotExist, `Store referenced does not exist`);
   static ERROR_StoreDoesNotExist                              = SevError | 0x01D;
+  static Error_StoreDoesNotExist                              = () => m(this.ERROR_StoreDoesNotExist, `Store referenced does not exist`);
 
-  static Error_BeepInVirtualKeySection                        = () => m(this.ERROR_BeepInVirtualKeySection, `'beep' command is illegal in virtual key section`);
   static ERROR_BeepInVirtualKeySection                        = SevError | 0x01E;
+  static Error_BeepInVirtualKeySection                        = () => m(this.ERROR_BeepInVirtualKeySection, `'beep' command is illegal in virtual key section`);
 
-  static Error_IndexInVirtualKeySection                       = () => m(this.ERROR_IndexInVirtualKeySection, `'index' command is illegal in virtual key section`);
   static ERROR_IndexInVirtualKeySection                       = SevError | 0x01F;
+  static Error_IndexInVirtualKeySection                       = () => m(this.ERROR_IndexInVirtualKeySection, `'index' command is illegal in virtual key section`);
 
-  static Error_InvalidIndex                                   = () => m(this.ERROR_InvalidIndex, `Invalid 'index' command`);
   static ERROR_InvalidIndex                                   = SevError | 0x020;
+  static Error_InvalidIndex                                   = () => m(this.ERROR_InvalidIndex, `Invalid 'index' command`);
 
-  static Error_OutsInVirtualKeySection                        = () => m(this.ERROR_OutsInVirtualKeySection, `'outs' command is illegal in virtual key section`);
   static ERROR_OutsInVirtualKeySection                        = SevError | 0x021;
+  static Error_OutsInVirtualKeySection                        = () => m(this.ERROR_OutsInVirtualKeySection, `'outs' command is illegal in virtual key section`);
 
-  static Error_InvalidOuts                                    = () => m(this.ERROR_InvalidOuts, `Invalid 'outs' command`);
   static ERROR_InvalidOuts                                    = SevError | 0x022;
+  static Error_InvalidOuts                                    = () => m(this.ERROR_InvalidOuts, `Invalid 'outs' command`);
 
-  static Error_ContextInVirtualKeySection                     = () => m(this.ERROR_ContextInVirtualKeySection, `'context' command is illegal in virtual key section`);
   static ERROR_ContextInVirtualKeySection                     = SevError | 0x024;
+  static Error_ContextInVirtualKeySection                     = () => m(this.ERROR_ContextInVirtualKeySection, `'context' command is illegal in virtual key section`);
 
-  static Error_InvalidUse                                     = () => m(this.ERROR_InvalidUse, `Invalid 'use' command`);
   static ERROR_InvalidUse                                     = SevError | 0x025;
+  static Error_InvalidUse                                     = () => m(this.ERROR_InvalidUse, `Invalid 'use' command`);
 
-  static Error_GroupDoesNotExist                              = () => m(this.ERROR_GroupDoesNotExist, `Group does not exist`);
   static ERROR_GroupDoesNotExist                              = SevError | 0x026;
+  static Error_GroupDoesNotExist                              = () => m(this.ERROR_GroupDoesNotExist, `Group does not exist`);
 
-  static Error_VirtualKeyNotAllowedHere                       = () => m(this.ERROR_VirtualKeyNotAllowedHere, `Virtual key is not allowed here`);
   static ERROR_VirtualKeyNotAllowedHere                       = SevError | 0x027;
+  static Error_VirtualKeyNotAllowedHere                       = () => m(this.ERROR_VirtualKeyNotAllowedHere, `Virtual key is not allowed here`);
 
-  static Error_InvalidSwitch                                  = () => m(this.ERROR_InvalidSwitch, `Invalid 'switch' command`);
   static ERROR_InvalidSwitch                                  = SevError | 0x028;
+  static Error_InvalidSwitch                                  = () => m(this.ERROR_InvalidSwitch, `Invalid 'switch' command`);
 
-  static Error_NoTokensFound                                  = () => m(this.ERROR_NoTokensFound, `No tokens found in line`);
   static ERROR_NoTokensFound                                  = SevError | 0x029;
+  static Error_NoTokensFound                                  = () => m(this.ERROR_NoTokensFound, `No tokens found in line`);
 
-  static Error_InvalidLineContinuation                        = () => m(this.ERROR_InvalidLineContinuation, `Invalid line continuation`);
   static ERROR_InvalidLineContinuation                        = SevError | 0x02A;
+  static Error_InvalidLineContinuation                        = () => m(this.ERROR_InvalidLineContinuation, `Invalid line continuation`);
 
-  static Error_LineTooLong                                    = () => m(this.ERROR_LineTooLong, `Line too long`);
   static ERROR_LineTooLong                                    = SevError | 0x02B;
+  static Error_LineTooLong                                    = () => m(this.ERROR_LineTooLong, `Line too long`);
 
-  static Error_InvalidCopyright                               = () => m(this.ERROR_InvalidCopyright, `Invalid 'copyright' command`);
   static ERROR_InvalidCopyright                               = SevError | 0x02C;
+  static Error_InvalidCopyright                               = () => m(this.ERROR_InvalidCopyright, `Invalid 'copyright' command`);
 
-  static Error_CodeInvalidInThisSection                       = () => m(this.ERROR_CodeInvalidInThisSection, `This line is invalid in this section of the file`);
   static ERROR_CodeInvalidInThisSection                       = SevError | 0x02D;
+  static Error_CodeInvalidInThisSection                       = () => m(this.ERROR_CodeInvalidInThisSection, `This line is invalid in this section of the file`);
 
-  static Error_InvalidMessage                                 = () => m(this.ERROR_InvalidMessage, `Invalid 'message' command`);
   static ERROR_InvalidMessage                                 = SevError | 0x02E;
+  static Error_InvalidMessage                                 = () => m(this.ERROR_InvalidMessage, `Invalid 'message' command`);
 
-  static Error_InvalidLanguageName                            = () => m(this.ERROR_InvalidLanguageName, `Invalid 'languagename' command`);
   static ERROR_InvalidLanguageName                            = SevError | 0x02F;
+  static Error_InvalidLanguageName                            = () => m(this.ERROR_InvalidLanguageName, `Invalid 'languagename' command`);
 
-  static Error_InvalidBitmapLine                              = () => m(this.ERROR_InvalidBitmapLine, `Invalid 'bitmaps' command`);
   static ERROR_InvalidBitmapLine                              = SevError | 0x030;
+  static Error_InvalidBitmapLine                              = () => m(this.ERROR_InvalidBitmapLine, `Invalid 'bitmaps' command`);
 
-  static Error_CannotReadBitmapFile                           = () => m(this.ERROR_CannotReadBitmapFile, `Cannot open the bitmap or icon file for reading`);
   static ERROR_CannotReadBitmapFile                           = SevError | 0x031;
+  static Error_CannotReadBitmapFile                           = () => m(this.ERROR_CannotReadBitmapFile, `Cannot open the bitmap or icon file for reading`);
 
-  static Error_IndexDoesNotPointToAny                         = () => m(this.ERROR_IndexDoesNotPointToAny, `An index() in the output does not have a corresponding any() statement`);
   static ERROR_IndexDoesNotPointToAny                         = SevError | 0x032;
+  static Error_IndexDoesNotPointToAny                         = () => m(this.ERROR_IndexDoesNotPointToAny, `An index() in the output does not have a corresponding any() statement`);
 
-  static Error_ReservedCharacter                              = () => m(this.ERROR_ReservedCharacter, `A reserved character was found`);
   static ERROR_ReservedCharacter                              = SevError | 0x033;
+  static Error_ReservedCharacter                              = () => m(this.ERROR_ReservedCharacter, `A reserved character was found`);
 
-  static Error_InvalidCharacter                               = () => m(this.ERROR_InvalidCharacter, `A character was found that is outside the valid Unicode range (U+0000 - U+10FFFF)`);
   static ERROR_InvalidCharacter                               = SevError | 0x034;
+  static Error_InvalidCharacter                               = () => m(this.ERROR_InvalidCharacter, `A character was found that is outside the valid Unicode range (U+0000 - U+10FFFF)`);
 
-  static Error_InvalidCall                                    = () => m(this.ERROR_InvalidCall, `The 'call' command is invalid`);
   static ERROR_InvalidCall                                    = SevError | 0x035;
+  static Error_InvalidCall                                    = () => m(this.ERROR_InvalidCall, `The 'call' command is invalid`);
 
-  static Error_CallInVirtualKeySection                        = () => m(this.ERROR_CallInVirtualKeySection, `'call' command is illegal in virtual key section`);
   static ERROR_CallInVirtualKeySection                        = SevError | 0x036;
+  static Error_CallInVirtualKeySection                        = () => m(this.ERROR_CallInVirtualKeySection, `'call' command is illegal in virtual key section`);
 
-  static Error_CodeInvalidInKeyStore                          = () => m(this.ERROR_CodeInvalidInKeyStore, `The command is invalid inside a store that is used in a key part of the rule`);
   static ERROR_CodeInvalidInKeyStore                          = SevError | 0x037;
+  static Error_CodeInvalidInKeyStore                          = () => m(this.ERROR_CodeInvalidInKeyStore, `The command is invalid inside a store that is used in a key part of the rule`);
 
-  static Error_CannotLoadIncludeFile                          = () => m(this.ERROR_CannotLoadIncludeFile, `Cannot load the included file: it is either invalid or does not exist`);
   static ERROR_CannotLoadIncludeFile                          = SevError | 0x038;
+  static Error_CannotLoadIncludeFile                          = () => m(this.ERROR_CannotLoadIncludeFile, `Cannot load the included file: it is either invalid or does not exist`);
 
 
-  static Error_60FeatureOnly_EthnologueCode                   = () => m(this.ERROR_60FeatureOnly_EthnologueCode, `EthnologueCode system store requires VERSION 6.0 or higher`);
   static ERROR_60FeatureOnly_EthnologueCode                   = SevError | 0x039;
+  static Error_60FeatureOnly_EthnologueCode                   = () => m(this.ERROR_60FeatureOnly_EthnologueCode, `EthnologueCode system store requires VERSION 6.0 or higher`);
 
-  static Error_60FeatureOnly_MnemonicLayout                   = () => m(this.ERROR_60FeatureOnly_MnemonicLayout, `MnemonicLayout functionality requires VERSION 6.0 or higher`);
   static ERROR_60FeatureOnly_MnemonicLayout                   = SevError | 0x03A;
+  static Error_60FeatureOnly_MnemonicLayout                   = () => m(this.ERROR_60FeatureOnly_MnemonicLayout, `MnemonicLayout functionality requires VERSION 6.0 or higher`);
 
-  static Error_60FeatureOnly_OldCharPosMatching               = () => m(this.ERROR_60FeatureOnly_OldCharPosMatching, `OldCharPosMatching system store requires VERSION 6.0 or higher`);
   static ERROR_60FeatureOnly_OldCharPosMatching               = SevError | 0x03B;
+  static Error_60FeatureOnly_OldCharPosMatching               = () => m(this.ERROR_60FeatureOnly_OldCharPosMatching, `OldCharPosMatching system store requires VERSION 6.0 or higher`);
 
-  static Error_60FeatureOnly_NamedCodes                       = () => m(this.ERROR_60FeatureOnly_NamedCodes, `Named character constants requires VERSION 6.0 or higher`);
   static ERROR_60FeatureOnly_NamedCodes                       = SevError | 0x03C;
+  static Error_60FeatureOnly_NamedCodes                       = () => m(this.ERROR_60FeatureOnly_NamedCodes, `Named character constants requires VERSION 6.0 or higher`);
 
-  static Error_60FeatureOnly_Contextn                         = () => m(this.ERROR_60FeatureOnly_Contextn, `Context(n) requires VERSION 6.0 or higher`);
   static ERROR_60FeatureOnly_Contextn                         = SevError | 0x03D;
+  static Error_60FeatureOnly_Contextn                         = () => m(this.ERROR_60FeatureOnly_Contextn, `Context(n) requires VERSION 6.0 or higher`);
 
-  static Error_501FeatureOnly_Call                            = () => m(this.ERROR_501FeatureOnly_Call, `Call() requires VERSION 5.01 or higher`);
   static ERROR_501FeatureOnly_Call                            = SevError | 0x03E;
+  static Error_501FeatureOnly_Call                            = () => m(this.ERROR_501FeatureOnly_Call, `Call() requires VERSION 5.01 or higher`);
 
-  static Error_InvalidNamedCode                               = () => m(this.ERROR_InvalidNamedCode, `Invalid named code constant`);
   static ERROR_InvalidNamedCode                               = SevError | 0x03F;
+  static Error_InvalidNamedCode                               = () => m(this.ERROR_InvalidNamedCode, `Invalid named code constant`);
 
-  static Error_InvalidSystemStore                             = () => m(this.ERROR_InvalidSystemStore, `Invalid system store name found`);
   static ERROR_InvalidSystemStore                             = SevError | 0x040;
+  static Error_InvalidSystemStore                             = () => m(this.ERROR_InvalidSystemStore, `Invalid system store name found`);
 
-  static Error_60FeatureOnly_VirtualCharKey                   = () => m(this.ERROR_60FeatureOnly_VirtualCharKey, `Virtual character keys require VERSION 6.0 or higher`);
   static ERROR_60FeatureOnly_VirtualCharKey                   = SevError | 0x044;
+  static Error_60FeatureOnly_VirtualCharKey                   = () => m(this.ERROR_60FeatureOnly_VirtualCharKey, `Virtual character keys require VERSION 6.0 or higher`);
 
-  static Error_VersionAlreadyIncluded                         = () => m(this.ERROR_VersionAlreadyIncluded, `Only one VERSION or store(version) line allowed in a source file.`);
   static ERROR_VersionAlreadyIncluded                         = SevError | 0x045;
+  static Error_VersionAlreadyIncluded                         = () => m(this.ERROR_VersionAlreadyIncluded, `Only one VERSION or store(version) line allowed in a source file.`);
 
-  static Error_70FeatureOnly                                  = () => m(this.ERROR_70FeatureOnly, `This feature requires store(version) '7.0' or higher`);
   static ERROR_70FeatureOnly                                  = SevError | 0x046;
+  static Error_70FeatureOnly                                  = () => m(this.ERROR_70FeatureOnly, `This feature requires store(version) '7.0' or higher`);
 
-  static Error_80FeatureOnly                                  = () => m(this.ERROR_80FeatureOnly, `This feature requires store(version) '8.0' or higher`);
   static ERROR_80FeatureOnly                                  = SevError | 0x047;
+  static Error_80FeatureOnly                                  = () => m(this.ERROR_80FeatureOnly, `This feature requires store(version) '8.0' or higher`);
 
-  static Error_InvalidInVirtualKeySection                     = () => m(this.ERROR_InvalidInVirtualKeySection, `This statement is not valid in a virtual key section`);
   static ERROR_InvalidInVirtualKeySection                     = SevError | 0x048;
+  static Error_InvalidInVirtualKeySection                     = () => m(this.ERROR_InvalidInVirtualKeySection, `This statement is not valid in a virtual key section`);
 
-  static Error_InvalidIf                                      = () => m(this.ERROR_InvalidIf, `The if() statement is not valid`);
   static ERROR_InvalidIf                                      = SevError | 0x049;
+  static Error_InvalidIf                                      = () => m(this.ERROR_InvalidIf, `The if() statement is not valid`);
 
-  static Error_InvalidReset                                   = () => m(this.ERROR_InvalidReset, `The reset() statement is not valid`);
   static ERROR_InvalidReset                                   = SevError | 0x04A;
+  static Error_InvalidReset                                   = () => m(this.ERROR_InvalidReset, `The reset() statement is not valid`);
 
-  static Error_InvalidSet                                     = () => m(this.ERROR_InvalidSet, `The set() statement is not valid`);
   static ERROR_InvalidSet                                     = SevError | 0x04B;
+  static Error_InvalidSet                                     = () => m(this.ERROR_InvalidSet, `The set() statement is not valid`);
 
-  static Error_InvalidSave                                    = () => m(this.ERROR_InvalidSave, `The save() statement is not valid`);
   static ERROR_InvalidSave                                    = SevError | 0x04C;
+  static Error_InvalidSave                                    = () => m(this.ERROR_InvalidSave, `The save() statement is not valid`);
 
 
-  static Error_InvalidEthnologueCode                          = () => m(this.ERROR_InvalidEthnologueCode, `Invalid ethnologuecode format`);
   static ERROR_InvalidEthnologueCode                          = SevError | 0x04D;
+  static Error_InvalidEthnologueCode                          = () => m(this.ERROR_InvalidEthnologueCode, `Invalid ethnologuecode format`);
 
-  static Fatal_CannotCreateTempfile                          = () => m(this.FATAL_CannotCreateTempfile, `Cannot create temp file`);
   static FATAL_CannotCreateTempfile                           = SevFatal | 0x04E;
+  static Fatal_CannotCreateTempfile                          = () => m(this.FATAL_CannotCreateTempfile, `Cannot create temp file`);
 
-  static Error_90FeatureOnly_IfSystemStores                   = () => m(this.ERROR_90FeatureOnly_IfSystemStores, `if(store) requires store(version) '9.0' or higher`);
   static ERROR_90FeatureOnly_IfSystemStores                   = SevError | 0x04F;
+  static Error_90FeatureOnly_IfSystemStores                   = () => m(this.ERROR_90FeatureOnly_IfSystemStores, `if(store) requires store(version) '9.0' or higher`);
 
-  static Error_IfSystemStore_NotFound                         = () => m(this.ERROR_IfSystemStore_NotFound, `System store in if() not found`);
   static ERROR_IfSystemStore_NotFound                         = SevError | 0x050;
+  static Error_IfSystemStore_NotFound                         = () => m(this.ERROR_IfSystemStore_NotFound, `System store in if() not found`);
 
-  static Error_90FeatureOnly_SetSystemStores                  = () => m(this.ERROR_90FeatureOnly_SetSystemStores, `set(store) requires store(version) '9.0' or higher`);
   static ERROR_90FeatureOnly_SetSystemStores                  = SevError | 0x051;
+  static Error_90FeatureOnly_SetSystemStores                  = () => m(this.ERROR_90FeatureOnly_SetSystemStores, `set(store) requires store(version) '9.0' or higher`);
 
-  static Error_SetSystemStore_NotFound                        = () => m(this.ERROR_SetSystemStore_NotFound, `System store in set() not found`);
   static ERROR_SetSystemStore_NotFound                        = SevError | 0x052;
+  static Error_SetSystemStore_NotFound                        = () => m(this.ERROR_SetSystemStore_NotFound, `System store in set() not found`);
 
-  static Error_90FeatureOnlyVirtualKeyDictionary              = () => m(this.ERROR_90FeatureOnlyVirtualKeyDictionary, `Custom virtual key names require store(version) '9.0'`);
   static ERROR_90FeatureOnlyVirtualKeyDictionary              = SevError | 0x053;
+  static Error_90FeatureOnlyVirtualKeyDictionary              = () => m(this.ERROR_90FeatureOnlyVirtualKeyDictionary, `Custom virtual key names require store(version) '9.0'`);
 
-  static Error_NotSupportedInKeymanWebContext = (o:{line:number, code:String}) => mw(this.ERROR_NotSupportedInKeymanWebContext,
-    `Statement '${o.code}' is not currently supported in context for web and touch targets`, o);
   static ERROR_NotSupportedInKeymanWebContext                 = SevError | 0x054;
+  static Error_NotSupportedInKeymanWebContext = (o:{line:number, code:String}) => mw(this.ERROR_NotSupportedInKeymanWebContext,
+    `Statement '${def(o.code)}' is not currently supported in context for web and touch targets`, o);
 
-  static Error_NotSupportedInKeymanWebOutput = (o:{line:number, code:string}) => mw(this.ERROR_NotSupportedInKeymanWebOutput,
-    `Statement '${o.code}' is not currently supported in output for web and touch targets`, o);
   static ERROR_NotSupportedInKeymanWebOutput                  = SevError | 0x055;
+  static Error_NotSupportedInKeymanWebOutput = (o:{line:number, code:string}) => mw(this.ERROR_NotSupportedInKeymanWebOutput,
+    `Statement '${def(o.code)}' is not currently supported in output for web and touch targets`, o);
 
-  static Error_NotSupportedInKeymanWebStore = (o:{code:string,store:string}) => mw(this.ERROR_NotSupportedInKeymanWebStore,
-    `'${o.code}' is not currently supported in store '${o.store}' when used by any or index for web and touch targets`);
   static ERROR_NotSupportedInKeymanWebStore                   = SevError | 0x056;
+  static Error_NotSupportedInKeymanWebStore = (o:{code:string,store:string}) => mw(this.ERROR_NotSupportedInKeymanWebStore,
+    `'${def(o.code)}' is not currently supported in store '${def(o.store)}' when used by any or index for web and touch targets`);
 
+  static ERROR_VirtualCharacterKeysNotSupportedInKeymanWeb    = SevError | 0x057;
   static Error_VirtualCharacterKeysNotSupportedInKeymanWeb = (o:{line:number}) => mw(this.ERROR_VirtualCharacterKeysNotSupportedInKeymanWeb,
     `Virtual character keys not currently supported in KeymanWeb`, o);
-  static ERROR_VirtualCharacterKeysNotSupportedInKeymanWeb    = SevError | 0x057;
 
+  static ERROR_VirtualKeysNotValidForMnemonicLayouts          = SevError | 0x058;
   static Error_VirtualKeysNotValidForMnemonicLayouts = (o:{line:number}) => mw(this.ERROR_VirtualKeysNotValidForMnemonicLayouts,
     `Virtual keys are not valid for mnemonic layouts`, o);
-  static ERROR_VirtualKeysNotValidForMnemonicLayouts          = SevError | 0x058;
 
-  static Error_InvalidTouchLayoutFile = (o:{filename:string}) => mw(this.ERROR_InvalidTouchLayoutFile,
-    `Touch layout file ${o.filename} is not valid`);
   static ERROR_InvalidTouchLayoutFile                         = SevError | 0x059;
+  static Error_InvalidTouchLayoutFile = (o:{filename:string}) => mw(this.ERROR_InvalidTouchLayoutFile,
+    `Touch layout file ${def(o.filename)} is not valid`);
 
-  static Error_TouchLayoutInvalidIdentifier = (o:{keyId:string, platformName: string, layerId:string}) => mw(this.ERROR_TouchLayoutInvalidIdentifier,
-    `Key "${o.keyId}" on "${o.platformName}", layer "${o.layerId}" has an invalid identifier.`);
   static ERROR_TouchLayoutInvalidIdentifier                   = SevError | 0x05A;
+  static Error_TouchLayoutInvalidIdentifier = (o:{keyId:string, platformName: string, layerId:string}) => mw(this.ERROR_TouchLayoutInvalidIdentifier,
+    `Key "${def(o.keyId)}" on "${def(o.platformName)}", layer "${def(o.layerId)}" has an invalid identifier.`);
 
-  static Error_InvalidKeyCode = (o:{keyId: string}) => mw(this.ERROR_InvalidKeyCode,
-    `Invalid key identifier "${o.keyId}"`);
   static ERROR_InvalidKeyCode                                 = SevError | 0x05B;
+  static Error_InvalidKeyCode = (o:{keyId: string}) => mw(this.ERROR_InvalidKeyCode,
+    `Invalid key identifier "${def(o.keyId)}"`);
 
-  static Error_90FeatureOnlyLayoutFile                        = () => m(this.ERROR_90FeatureOnlyLayoutFile, `Touch layout file reference requires store(version) '9.0'or higher`);
   static ERROR_90FeatureOnlyLayoutFile                        = SevError | 0x05C;
+  static Error_90FeatureOnlyLayoutFile                        = () => m(this.ERROR_90FeatureOnlyLayoutFile, `Touch layout file reference requires store(version) '9.0'or higher`);
 
-  static Error_90FeatureOnlyKeyboardVersion                   = () => m(this.ERROR_90FeatureOnlyKeyboardVersion, `KeyboardVersion system store requires store(version) '9.0'or higher`);
   static ERROR_90FeatureOnlyKeyboardVersion                   = SevError | 0x05D;
+  static Error_90FeatureOnlyKeyboardVersion                   = () => m(this.ERROR_90FeatureOnlyKeyboardVersion, `KeyboardVersion system store requires store(version) '9.0'or higher`);
 
-  static Error_KeyboardVersionFormatInvalid                   = () => m(this.ERROR_KeyboardVersionFormatInvalid, `KeyboardVersion format is invalid, expecting dot-separated integers`);
   static ERROR_KeyboardVersionFormatInvalid                   = SevError | 0x05E;
+  static Error_KeyboardVersionFormatInvalid                   = () => m(this.ERROR_KeyboardVersionFormatInvalid, `KeyboardVersion format is invalid, expecting dot-separated integers`);
 
-  static Error_ContextExHasInvalidOffset                      = () => m(this.ERROR_ContextExHasInvalidOffset, `context() statement has offset out of range`);
   static ERROR_ContextExHasInvalidOffset                      = SevError | 0x05F;
+  static Error_ContextExHasInvalidOffset                      = () => m(this.ERROR_ContextExHasInvalidOffset, `context() statement has offset out of range`);
 
-  static Error_90FeatureOnlyEmbedCSS                          = () => m(this.ERROR_90FeatureOnlyEmbedCSS, `Embedding CSS requires store(version) '9.0'or higher`);
   static ERROR_90FeatureOnlyEmbedCSS                          = SevError | 0x060;
+  static Error_90FeatureOnlyEmbedCSS                          = () => m(this.ERROR_90FeatureOnlyEmbedCSS, `Embedding CSS requires store(version) '9.0'or higher`);
 
-  static Error_90FeatureOnlyTargets                           = () => m(this.ERROR_90FeatureOnlyTargets, `TARGETS system store requires store(version) '9.0'or higher`);
   static ERROR_90FeatureOnlyTargets                           = SevError | 0x061;
+  static Error_90FeatureOnlyTargets                           = () => m(this.ERROR_90FeatureOnlyTargets, `TARGETS system store requires store(version) '9.0'or higher`);
 
-  static Error_ContextAndIndexInvalidInMatchNomatch           = () => m(this.ERROR_ContextAndIndexInvalidInMatchNomatch, `context and index statements cannot be used in a match or nomatch statement`);
   static ERROR_ContextAndIndexInvalidInMatchNomatch           = SevError | 0x062;
+  static Error_ContextAndIndexInvalidInMatchNomatch           = () => m(this.ERROR_ContextAndIndexInvalidInMatchNomatch, `context and index statements cannot be used in a match or nomatch statement`);
 
-  static Error_140FeatureOnlyContextAndNotAnyWeb              = () => m(this.ERROR_140FeatureOnlyContextAndNotAnyWeb, `For web and touch platforms, context() statement referring to notany() requires store(version) '14.0'or higher`);
   static ERROR_140FeatureOnlyContextAndNotAnyWeb              = SevError | 0x063;
+  static Error_140FeatureOnlyContextAndNotAnyWeb              = () => m(this.ERROR_140FeatureOnlyContextAndNotAnyWeb, `For web and touch platforms, context() statement referring to notany() requires store(version) '14.0'or higher`);
 
 
-  static Error_ExpansionMustFollowCharacterOrVKey             = () => m(this.ERROR_ExpansionMustFollowCharacterOrVKey, `An expansion must follow a character or a virtual key`);
   static ERROR_ExpansionMustFollowCharacterOrVKey             = SevError | 0x064;
+  static Error_ExpansionMustFollowCharacterOrVKey             = () => m(this.ERROR_ExpansionMustFollowCharacterOrVKey, `An expansion must follow a character or a virtual key`);
 
-  static Error_VKeyExpansionMustBeFollowedByVKey              = () => m(this.ERROR_VKeyExpansionMustBeFollowedByVKey, `A virtual key expansion must be terminated by a virtual key`);
   static ERROR_VKeyExpansionMustBeFollowedByVKey              = SevError | 0x065;
+  static Error_VKeyExpansionMustBeFollowedByVKey              = () => m(this.ERROR_VKeyExpansionMustBeFollowedByVKey, `A virtual key expansion must be terminated by a virtual key`);
 
-  static Error_CharacterExpansionMustBeFollowedByCharacter    = () => m(this.ERROR_CharacterExpansionMustBeFollowedByCharacter, `A character expansion must be terminated by a character key`);
   static ERROR_CharacterExpansionMustBeFollowedByCharacter    = SevError | 0x066;
+  static Error_CharacterExpansionMustBeFollowedByCharacter    = () => m(this.ERROR_CharacterExpansionMustBeFollowedByCharacter, `A character expansion must be terminated by a character key`);
 
-  static Error_VKeyExpansionMustUseConsistentShift            = () => m(this.ERROR_VKeyExpansionMustUseConsistentShift, `A virtual key expansion must use the same shift state for both terminators`);
   static ERROR_VKeyExpansionMustUseConsistentShift            = SevError | 0x067;
+  static Error_VKeyExpansionMustUseConsistentShift            = () => m(this.ERROR_VKeyExpansionMustUseConsistentShift, `A virtual key expansion must use the same shift state for both terminators`);
 
-  static Error_ExpansionMustBePositive                        = () => m(this.ERROR_ExpansionMustBePositive, `An expansion must have positive difference (i.e. A-Z, not Z-A)`);
   static ERROR_ExpansionMustBePositive                        = SevError | 0x068;
+  static Error_ExpansionMustBePositive                        = () => m(this.ERROR_ExpansionMustBePositive, `An expansion must have positive difference (i.e. A-Z, not Z-A)`);
 
-  static Error_CasedKeysMustContainOnlyVirtualKeys            = () => m(this.ERROR_CasedKeysMustContainOnlyVirtualKeys, `The &CasedKeys system store must contain only virtual keys or characters found on a US English keyboard`);
   static ERROR_CasedKeysMustContainOnlyVirtualKeys            = SevError | 0x069;
+  static Error_CasedKeysMustContainOnlyVirtualKeys            = () => m(this.ERROR_CasedKeysMustContainOnlyVirtualKeys, `The &CasedKeys system store must contain only virtual keys or characters found on a US English keyboard`);
 
-  static Error_CasedKeysMustNotIncludeShiftStates             = () => m(this.ERROR_CasedKeysMustNotIncludeShiftStates, `The &CasedKeys system store must not include shift states`);
   static ERROR_CasedKeysMustNotIncludeShiftStates             = SevError | 0x06A;
+  static Error_CasedKeysMustNotIncludeShiftStates             = () => m(this.ERROR_CasedKeysMustNotIncludeShiftStates, `The &CasedKeys system store must not include shift states`);
 
-  static Error_CasedKeysNotSupportedWithMnemonicLayout        = () => m(this.ERROR_CasedKeysNotSupportedWithMnemonicLayout, `The &CasedKeys system store is not supported with mnemonic layouts`);
   static ERROR_CasedKeysNotSupportedWithMnemonicLayout        = SevError | 0x06B;
+  static Error_CasedKeysNotSupportedWithMnemonicLayout        = () => m(this.ERROR_CasedKeysNotSupportedWithMnemonicLayout, `The &CasedKeys system store is not supported with mnemonic layouts`);
 
-  static Error_CannotUseReadWriteGroupFromReadonlyGroup       = () => m(this.ERROR_CannotUseReadWriteGroupFromReadonlyGroup, `Group used from a readonly group must also be readonly`);
   static ERROR_CannotUseReadWriteGroupFromReadonlyGroup       = SevError | 0x06C;
+  static Error_CannotUseReadWriteGroupFromReadonlyGroup       = () => m(this.ERROR_CannotUseReadWriteGroupFromReadonlyGroup, `Group used from a readonly group must also be readonly`);
 
-  static Error_StatementNotPermittedInReadonlyGroup           = () => m(this.ERROR_StatementNotPermittedInReadonlyGroup, `Statement is not permitted in output of readonly group`);
   static ERROR_StatementNotPermittedInReadonlyGroup           = SevError | 0x06D;
+  static Error_StatementNotPermittedInReadonlyGroup           = () => m(this.ERROR_StatementNotPermittedInReadonlyGroup, `Statement is not permitted in output of readonly group`);
 
-  static Error_OutputInReadonlyGroup                          = () => m(this.ERROR_OutputInReadonlyGroup, `Output is not permitted in a readonly group`);
   static ERROR_OutputInReadonlyGroup                          = SevError | 0x06E;
+  static Error_OutputInReadonlyGroup                          = () => m(this.ERROR_OutputInReadonlyGroup, `Output is not permitted in a readonly group`);
 
-  static Error_NewContextGroupMustBeReadonly                  = () => m(this.ERROR_NewContextGroupMustBeReadonly, `Group used in begin newContext must be readonly`);
   static ERROR_NewContextGroupMustBeReadonly                  = SevError | 0x06F;
+  static Error_NewContextGroupMustBeReadonly                  = () => m(this.ERROR_NewContextGroupMustBeReadonly, `Group used in begin newContext must be readonly`);
 
-  static Error_PostKeystrokeGroupMustBeReadonly               = () => m(this.ERROR_PostKeystrokeGroupMustBeReadonly, `Group used in begin postKeystroke must be readonly`);
   static ERROR_PostKeystrokeGroupMustBeReadonly               = SevError | 0x070;
+  static Error_PostKeystrokeGroupMustBeReadonly               = () => m(this.ERROR_PostKeystrokeGroupMustBeReadonly, `Group used in begin postKeystroke must be readonly`);
 
-  static Error_DuplicateGroup                                 = () => m(this.ERROR_DuplicateGroup, `A group with this name has already been defined.`);
   static ERROR_DuplicateGroup                                 = SevError | 0x071;
+  static Error_DuplicateGroup                                 = () => m(this.ERROR_DuplicateGroup, `A group with this name has already been defined.`);
 
-  static Error_DuplicateStore                                 = () => m(this.ERROR_DuplicateStore, `A store with this name has already been defined.`);
   static ERROR_DuplicateStore                                 = SevError | 0x072;
+  static Error_DuplicateStore                                 = () => m(this.ERROR_DuplicateStore, `A store with this name has already been defined.`);
 
-  static Error_RepeatedBegin                                  = () => m(this.ERROR_RepeatedBegin, `Begin has already been set`);
   static ERROR_RepeatedBegin                                  = SevError | 0x073;
+  static Error_RepeatedBegin                                  = () => m(this.ERROR_RepeatedBegin, `Begin has already been set`);
 
-  static Error_VirtualKeyInContext                            = () => m(this.ERROR_VirtualKeyInContext, `Virtual keys are not permitted in context`);
   static ERROR_VirtualKeyInContext                            = SevError | 0x074;
+  static Error_VirtualKeyInContext                            = () => m(this.ERROR_VirtualKeyInContext, `Virtual keys are not permitted in context`);
 
-  static Warn_TooManyWarnings                                 = () => m(this.WARN_TooManyWarnings, `Too many warnings or errors`);
   static WARN_TooManyWarnings                                 = SevWarn | 0x080;
+  static Warn_TooManyWarnings                                 = () => m(this.WARN_TooManyWarnings, `Too many warnings or errors`);
 
-  static Warn_OldVersion                                      = () => m(this.WARN_OldVersion, `The keyboard file is an old version`);
   static WARN_OldVersion                                      = SevWarn | 0x081;
+  static Warn_OldVersion                                      = () => m(this.WARN_OldVersion, `The keyboard file is an old version`);
 
-  static Warn_BitmapNotUsed                                   = () => m(this.WARN_BitmapNotUsed, `The 'bitmaps' statement is obsolete and only the first bitmap referred to will be used, you should use 'bitmap'.`);
   static WARN_BitmapNotUsed                                   = SevWarn | 0x082;
+  static Warn_BitmapNotUsed                                   = () => m(this.WARN_BitmapNotUsed, `The 'bitmaps' statement is obsolete and only the first bitmap referred to will be used, you should use 'bitmap'.`);
 
-  static Warn_CustomLanguagesNotSupported                     = () => m(this.WARN_CustomLanguagesNotSupported, `Languages over 0x1FF, 0x1F are not supported correctly by Windows. You should use no LANGUAGE line instead.`);
   static WARN_CustomLanguagesNotSupported                     = SevWarn | 0x083;
+  static Warn_CustomLanguagesNotSupported                     = () => m(this.WARN_CustomLanguagesNotSupported, `Languages over 0x1FF, 0x1F are not supported correctly by Windows. You should use no LANGUAGE line instead.`);
 
-  static Warn_KeyBadLength                                    = () => m(this.WARN_KeyBadLength, `There are too many characters in the keystroke part of the rule.`);
   static WARN_KeyBadLength                                    = SevWarn | 0x084;
+  static Warn_KeyBadLength                                    = () => m(this.WARN_KeyBadLength, `There are too many characters in the keystroke part of the rule.`);
 
-  static Warn_IndexStoreShort                                 = () => m(this.WARN_IndexStoreShort, `The store referenced in index() is shorter than the store referenced in any()`);
   static WARN_IndexStoreShort                                 = SevWarn | 0x085;
+  static Warn_IndexStoreShort                                 = () => m(this.WARN_IndexStoreShort, `The store referenced in index() is shorter than the store referenced in any()`);
 
-  static Warn_UnicodeInANSIGroup                              = () => m(this.WARN_UnicodeInANSIGroup, `A Unicode character was found in an ANSI group`);
   static WARN_UnicodeInANSIGroup                              = SevWarn | 0x086;
+  static Warn_UnicodeInANSIGroup                              = () => m(this.WARN_UnicodeInANSIGroup, `A Unicode character was found in an ANSI group`);
 
-  static Warn_ANSIInUnicodeGroup                              = () => m(this.WARN_ANSIInUnicodeGroup, `An ANSI character was found in a Unicode group`);
   static WARN_ANSIInUnicodeGroup                              = SevWarn | 0x087;
+  static Warn_ANSIInUnicodeGroup                              = () => m(this.WARN_ANSIInUnicodeGroup, `An ANSI character was found in a Unicode group`);
 
-  static Warn_UnicodeSurrogateUsed                            = () => m(this.WARN_UnicodeSurrogateUsed, `A Unicode surrogate character was found. You should use Unicode scalar values to represent values > U+FFFF`);
   static WARN_UnicodeSurrogateUsed                            = SevWarn | 0x088;
+  static Warn_UnicodeSurrogateUsed                            = () => m(this.WARN_UnicodeSurrogateUsed, `A Unicode surrogate character was found. You should use Unicode scalar values to represent values > U+FFFF`);
 
-  static Warn_ReservedCharacter                               = () => m(this.WARN_ReservedCharacter, `A Unicode character was found that should not be used`);
   static WARN_ReservedCharacter                               = SevWarn | 0x089;
+  static Warn_ReservedCharacter                               = () => m(this.WARN_ReservedCharacter, `A Unicode character was found that should not be used`);
 
   // Note: INFO_Info is called CWARN_Info in kmn_compiler_errors.h, but should have an "info" severity
-  static Info_Info                                            = () => m(this.INFO_Info, `Information`);
   static INFO_Info                                            = SevInfo | 0x08A;
+  static Info_Info                                            = () => m(this.INFO_Info, `Information`);
 
 
-  static Warn_VirtualKeyWithMnemonicLayout                    = () => m(this.WARN_VirtualKeyWithMnemonicLayout, `Virtual key used instead of virtual character key with a mnemonic layout`);
   static WARN_VirtualKeyWithMnemonicLayout                    = SevWarn | 0x08B;
+  static Warn_VirtualKeyWithMnemonicLayout                    = () => m(this.WARN_VirtualKeyWithMnemonicLayout, `Virtual key used instead of virtual character key with a mnemonic layout`);
 
-  static Warn_VirtualCharKeyWithPositionalLayout              = () => m(this.WARN_VirtualCharKeyWithPositionalLayout, `Virtual character key used with a positional layout instead of mnemonic layout`);
   static WARN_VirtualCharKeyWithPositionalLayout              = SevWarn | 0x08C;
+  static Warn_VirtualCharKeyWithPositionalLayout              = () => m(this.WARN_VirtualCharKeyWithPositionalLayout, `Virtual character key used with a positional layout instead of mnemonic layout`);
 
-  static Warn_StoreAlreadyUsedAsOptionOrCall                  = () => m(this.WARN_StoreAlreadyUsedAsOptionOrCall, `Store already used as an option or in a call statement and should not be used as a normal store`);
   static WARN_StoreAlreadyUsedAsOptionOrCall                  = SevWarn | 0x08D;
+  static Warn_StoreAlreadyUsedAsOptionOrCall                  = () => m(this.WARN_StoreAlreadyUsedAsOptionOrCall, `Store already used as an option or in a call statement and should not be used as a normal store`);
 
-  static Warn_StoreAlreadyUsedAsStoreOrCall                   = () => m(this.WARN_StoreAlreadyUsedAsStoreOrCall, `Store already used as a normal store or in a call statement and should not be used as an option`);
   static WARN_StoreAlreadyUsedAsStoreOrCall                   = SevWarn | 0x08E;
+  static Warn_StoreAlreadyUsedAsStoreOrCall                   = () => m(this.WARN_StoreAlreadyUsedAsStoreOrCall, `Store already used as a normal store or in a call statement and should not be used as an option`);
 
-  static Warn_StoreAlreadyUsedAsStoreOrOption                 = () => m(this.WARN_StoreAlreadyUsedAsStoreOrOption, `Store already used as a normal store or as an option and should not be used in a call statement`);
   static WARN_StoreAlreadyUsedAsStoreOrOption                 = SevWarn | 0x08F;
+  static Warn_StoreAlreadyUsedAsStoreOrOption                 = () => m(this.WARN_StoreAlreadyUsedAsStoreOrOption, `Store already used as a normal store or as an option and should not be used in a call statement`);
 
 
-  static Warn_PunctuationInEthnologueCode                     = () => m(this.WARN_PunctuationInEthnologueCode, `Punctuation should not be used to separate Ethnologue codes; instead use spaces`);
   static WARN_PunctuationInEthnologueCode                     = SevWarn | 0x090;
+  static Warn_PunctuationInEthnologueCode                     = () => m(this.WARN_PunctuationInEthnologueCode, `Punctuation should not be used to separate Ethnologue codes; instead use spaces`);
 
 
-  static Warn_TouchLayoutMissingLayer = (o:{keyId:string, platformName:string, layerId:string, nextLayer:string}) => mw(this.WARN_TouchLayoutMissingLayer,
-    `Key "${o.keyId}" on platform "${o.platformName}", layer "${o.layerId}", references a missing layer "${o.nextLayer}"`);
   static WARN_TouchLayoutMissingLayer                         = SevWarn | 0x091;
+  static Warn_TouchLayoutMissingLayer = (o:{keyId:string, platformName:string, layerId:string, nextLayer:string}) => mw(this.WARN_TouchLayoutMissingLayer,
+    `Key "${def(o.keyId)}" on platform "${def(o.platformName)}", layer "${def(o.layerId)}", references a missing layer "${def(o.nextLayer)}"`);
 
-  static Warn_TouchLayoutCustomKeyNotDefined = (o:{keyId:string, platformName:string, layerId:string}) => mw(this.WARN_TouchLayoutCustomKeyNotDefined,
-    `Key "${o.keyId}" on platform "${o.platformName}", layer "${o.layerId}", is a custom key but has no corresponding rule in the source.`);
   static WARN_TouchLayoutCustomKeyNotDefined                  = SevWarn | 0x092;
+  static Warn_TouchLayoutCustomKeyNotDefined = (o:{keyId:string, platformName:string, layerId:string}) => mw(this.WARN_TouchLayoutCustomKeyNotDefined,
+    `Key "${def(o.keyId)}" on platform "${def(o.platformName)}", layer "${def(o.layerId)}", is a custom key but has no corresponding rule in the source.`);
 
-  static Warn_TouchLayoutMissingRequiredKeys = (o:{layerId:string, platformName:string, missingKeys:string}) => mw(this.WARN_TouchLayoutMissingRequiredKeys,
-    `Layer "${o.layerId}" on platform "${o.platformName}" is missing the required key(s) '${o.missingKeys}'.`);
   static WARN_TouchLayoutMissingRequiredKeys                  = SevWarn | 0x093;
+  static Warn_TouchLayoutMissingRequiredKeys = (o:{layerId:string, platformName:string, missingKeys:string}) => mw(this.WARN_TouchLayoutMissingRequiredKeys,
+    `Layer "${def(o.layerId)}" on platform "${def(o.platformName)}" is missing the required key(s) '${def(o.missingKeys)}'.`);
 
-  static Warn_HelpFileMissing = (o:{line:number, helpFilename:string, e:any}) => mw(this.WARN_HelpFileMissing,
-    `File ${o.helpFilename} could not be loaded: ${(o.e??'').toString()}`,o);
   static WARN_HelpFileMissing                                 = SevWarn | 0x094;
+  static Warn_HelpFileMissing = (o:{line:number, helpFilename:string, e:any}) => mw(this.WARN_HelpFileMissing,
+    `File ${def(o.helpFilename)} could not be loaded: ${(o.e??'').toString()}`,o);
 
-  static Warn_EmbedJsFileMissing = (o:{line:number, jsFilename: string, e:any}) => mw(this.WARN_EmbedJsFileMissing,
-    `File ${o.jsFilename} could not be loaded: ${(o.e??'').toString()}`, o);
   static WARN_EmbedJsFileMissing                              = SevWarn | 0x095;
+  static Warn_EmbedJsFileMissing = (o:{line:number, jsFilename: string, e:any}) => mw(this.WARN_EmbedJsFileMissing,
+    `File ${def(o.jsFilename)} could not be loaded: ${(o.e??'').toString()}`, o);
 
   // static WARN_TouchLayoutFileMissing                          = SevWarn | 0x096;
   // static WARN_VisualKeyboardFileMissing                       = SevWarn | 0x097;
 
-  static Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb = (o:{line:number,flags:string}) => mw(this.WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb,
-    `Extended shift flags ${o.flags} are not supported in KeymanWeb`, o);
   static WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb       = SevWarn | 0x098;
+  static Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb = (o:{line:number,flags:string}) => mw(this.WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb,
+    `Extended shift flags ${def(o.flags)} are not supported in KeymanWeb`, o);
 
-  static Warn_TouchLayoutUnidentifiedKey = (o:{layerId:string}) => mw(this.WARN_TouchLayoutUnidentifiedKey,
-    `A key on layer "${o.layerId}" has no identifier.`);
   static WARN_TouchLayoutUnidentifiedKey                      = SevWarn | 0x099;
+  static Warn_TouchLayoutUnidentifiedKey = (o:{layerId:string}) => mw(this.WARN_TouchLayoutUnidentifiedKey,
+    `A key on layer "${def(o.layerId)}" has no identifier.`);
 
-  static Hint_UnreachableKeyCode = (o:{line:number,key:string}) => mw(this.HINT_UnreachableKeyCode,
-    `The rule will never be matched for key ${o.key} because its key code is never fired.`, o);
   static HINT_UnreachableKeyCode                              = SevHint | 0x09A;
+  static Hint_UnreachableKeyCode = (o:{line:number,key:string}) => mw(this.HINT_UnreachableKeyCode,
+    `The rule will never be matched for key ${def(o.key)} because its key code is never fired.`, o);
 
   // static WARN_CouldNotCopyJsonFile                            = SevWarn | 0x09B;
 
-  static Warn_PlatformNotInTargets                            = () => m(this.WARN_PlatformNotInTargets, `The specified platform is not a target platform`);
   static WARN_PlatformNotInTargets                            = SevWarn | 0x09C;
+  static Warn_PlatformNotInTargets                            = () => m(this.WARN_PlatformNotInTargets, `The specified platform is not a target platform`);
 
-  static Warn_HeaderStatementIsDeprecated                     = () => m(this.WARN_HeaderStatementIsDeprecated, `Header statements are deprecated; use instead the equivalent system store`);
   static WARN_HeaderStatementIsDeprecated                     = SevWarn | 0x09D;
+  static Warn_HeaderStatementIsDeprecated                     = () => m(this.WARN_HeaderStatementIsDeprecated, `Header statements are deprecated; use instead the equivalent system store`);
 
-  static Warn_UseNotLastStatementInRule                       = () => m(this.WARN_UseNotLastStatementInRule, `A rule with use() statements in the output should not have other content following the use() statements`);
   static WARN_UseNotLastStatementInRule                       = SevWarn | 0x09E;
+  static Warn_UseNotLastStatementInRule                       = () => m(this.WARN_UseNotLastStatementInRule, `A rule with use() statements in the output should not have other content following the use() statements`);
 
+  static WARN_TouchLayoutFontShouldBeSameForAllPlatforms      = SevWarn | 0x09F;
   static Warn_TouchLayoutFontShouldBeSameForAllPlatforms = () => mw(this.WARN_TouchLayoutFontShouldBeSameForAllPlatforms,
     `The touch layout font should be the same for all platforms.`);
-  static WARN_TouchLayoutFontShouldBeSameForAllPlatforms      = SevWarn | 0x09F;
 
   // static WARN_InvalidJSONMetadataFile                         = SevWarn | 0x0A0;
   // static WARN_JSONMetadataOSKFontShouldMatchTouchFont         = SevWarn | 0x0A1;
 
-  static Warn_KVKFileIsInSourceFormat                         = () => m(this.WARN_KVKFileIsInSourceFormat, `.kvk file should be binary but is an XML file`);
   static WARN_KVKFileIsInSourceFormat                         = SevWarn | 0x0A2;
+  static Warn_KVKFileIsInSourceFormat                         = () => m(this.WARN_KVKFileIsInSourceFormat, `.kvk file should be binary but is an XML file`);
 
   // kmcmplib: static Warn_DontMixChiralAndNonChiralModifiers              = () => m(this.WARN_DontMixChiralAndNonChiralModifiers, `Don't mix the use of left/right modifiers with non-left/right modifiers in the same platform`);
+  static WARN_DontMixChiralAndNonChiralModifiers              = SevWarn | 0x0A3;
   static Warn_DontMixChiralAndNonChiralModifiers = () => mw(this.WARN_DontMixChiralAndNonChiralModifiers,
     `This keyboard contains Ctrl,Alt and LCtrl,LAlt,RCtrl,RAlt sets of modifiers. Use only one or the other set for web target.`);
-  static WARN_DontMixChiralAndNonChiralModifiers              = SevWarn | 0x0A3;
 
-  static Warn_MixingLeftAndRightModifiers                     = () => m(this.WARN_MixingLeftAndRightModifiers, `Left and right modifiers should not both be used in the same rule`);
   static WARN_MixingLeftAndRightModifiers                     = SevWarn | 0x0A4;
+  static Warn_MixingLeftAndRightModifiers                     = () => m(this.WARN_MixingLeftAndRightModifiers, `Left and right modifiers should not both be used in the same rule`);
 
-  static Warn_LanguageHeadersDeprecatedInKeyman10             = () => m(this.WARN_LanguageHeadersDeprecatedInKeyman10, `This language header has been deprecated in Keyman 10. Instead, add language metadata in the package file`);
   static WARN_LanguageHeadersDeprecatedInKeyman10             = SevWarn | 0x0A5;
+  static Warn_LanguageHeadersDeprecatedInKeyman10             = () => m(this.WARN_LanguageHeadersDeprecatedInKeyman10, `This language header has been deprecated in Keyman 10. Instead, add language metadata in the package file`);
 
-  static Hint_NonUnicodeFile                                  = () => m(this.HINT_NonUnicodeFile, `Keyman Developer has detected that the file has ANSI encoding. Consider converting this file to UTF-8`);
   static HINT_NonUnicodeFile                                  = SevHint | 0x0A6;
+  static Hint_NonUnicodeFile                                  = () => m(this.HINT_NonUnicodeFile, `Keyman Developer has detected that the file has ANSI encoding. Consider converting this file to UTF-8`);
 
   // static WARN_TooManyErrorsOrWarnings                         = SevWarn | 0x0A7;
 
-  static Warn_HotkeyHasInvalidModifier                        = () => m(this.WARN_HotkeyHasInvalidModifier, `Hotkey has modifiers that are not supported. Use only SHIFT, CTRL and ALT`);
   static WARN_HotkeyHasInvalidModifier                        = SevWarn | 0x0A8;
+  static Warn_HotkeyHasInvalidModifier                        = () => m(this.WARN_HotkeyHasInvalidModifier, `Hotkey has modifiers that are not supported. Use only SHIFT, CTRL and ALT`);
 
+  static WARN_TouchLayoutSpecialLabelOnNormalKey              = SevWarn | 0x0A9;
   static Warn_TouchLayoutSpecialLabelOnNormalKey = (o:{keyId:string, platformName:string, layerId:string, label:string}) =>
     mw(this.WARN_TouchLayoutSpecialLabelOnNormalKey,
-    `Key "${o.keyId}" on platform "${o.platformName}", layer "${o.layerId}" does not have `+
-    `the key type "Special" or "Special (active)" but has the label "${o.label}". This feature is only supported in Keyman 14 or later`);
-  static WARN_TouchLayoutSpecialLabelOnNormalKey              = SevWarn | 0x0A9;
+    `Key "${def(o.keyId)}" on platform "${def(o.platformName)}", layer "${def(o.layerId)}" does not have `+
+    `the key type "Special" or "Special (active)" but has the label "${def(o.label)}". This feature is only supported in Keyman 14 or later`);
 
-  static Warn_OptionStoreNameInvalid = (o:{name:string}) => mw(this.WARN_OptionStoreNameInvalid,
-    `The option store ${o.name} should be named with characters in the range A-Z, a-z, 0-9 and _ only.`);
   static WARN_OptionStoreNameInvalid                          = SevWarn | 0x0AA;
+  static Warn_OptionStoreNameInvalid = (o:{name:string}) => mw(this.WARN_OptionStoreNameInvalid,
+    `The option store ${def(o.name)} should be named with characters in the range A-Z, a-z, 0-9 and _ only.`);
 
-  static Warn_NulNotFirstStatementInContext                   = () => m(this.WARN_NulNotFirstStatementInContext, `nul must be the first statement in the context`);
   static WARN_NulNotFirstStatementInContext                   = SevWarn | 0x0AB;
+  static Warn_NulNotFirstStatementInContext                   = () => m(this.WARN_NulNotFirstStatementInContext, `nul must be the first statement in the context`);
 
-  static Warn_IfShouldBeAtStartOfContext                      = () => m(this.WARN_IfShouldBeAtStartOfContext, `if, platform and baselayout should be at start of context (after nul, if present)`);
   static WARN_IfShouldBeAtStartOfContext                      = SevWarn | 0x0AC;
+  static Warn_IfShouldBeAtStartOfContext                      = () => m(this.WARN_IfShouldBeAtStartOfContext, `if, platform and baselayout should be at start of context (after nul, if present)`);
 
-  static Warn_KeyShouldIncludeNCaps                           = () => m(this.WARN_KeyShouldIncludeNCaps, `Other rules which reference this key include CAPS or NCAPS modifiers, so this rule must include NCAPS modifier to avoid inconsistent matches`);
   static WARN_KeyShouldIncludeNCaps                           = SevWarn | 0x0AD;
+  static Warn_KeyShouldIncludeNCaps                           = () => m(this.WARN_KeyShouldIncludeNCaps, `Other rules which reference this key include CAPS or NCAPS modifiers, so this rule must include NCAPS modifier to avoid inconsistent matches`);
 
-  static Hint_UnreachableRule                                 = () => m(this.HINT_UnreachableRule, `This rule will never be matched as another rule takes precedence`);
   static HINT_UnreachableRule                                 = SevHint | 0x0AE;
+  static Hint_UnreachableRule                                 = () => m(this.HINT_UnreachableRule, `This rule will never be matched as another rule takes precedence`);
 
-  static Warn_VirtualKeyInOutput                              = () => m(this.WARN_VirtualKeyInOutput, `Virtual keys are not supported in output`);
   static WARN_VirtualKeyInOutput                              = SevWarn | 0x0AF;
+  static Warn_VirtualKeyInOutput                              = () => m(this.WARN_VirtualKeyInOutput, `Virtual keys are not supported in output`);
 
-  static Fatal_BufferOverflow                                = () => m(this.FATAL_BufferOverflow, `The compiler memory buffer overflowed`);
   static FATAL_BufferOverflow                                 = SevFatal | 0x0C0;
+  static Fatal_BufferOverflow                                = () => m(this.FATAL_BufferOverflow, `The compiler memory buffer overflowed`);
 
-  static Fatal_Break                                         = () => m(this.FATAL_Break, `Compiler interrupted by user`);
   static FATAL_Break                                          = SevFatal | 0x0C1;
+  static Fatal_Break                                         = () => m(this.FATAL_Break, `Compiler interrupted by user`);
 };
 
 /**

--- a/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec as m } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 import { kmnfile } from "../kmw-compiler/compiler-globals.js";
 
 const Namespace = CompilerErrorNamespace.KmnCompiler;
@@ -11,8 +11,8 @@ const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 // For messages from the KeymanWeb compiler, we need to construct our messages
 // slightly differently. This could be refactored in the future, as it is not
 // obvious which messages should use which function.
-const mw = (code: number, message: string, o?: {e?: any, filename?: string, line?: number}) : CompilerEvent => ({
-  ...m(code, message, o?.e),
+const mw = (code: number, message: string, o?: {filename?: string, line?: number}) : CompilerEvent => ({
+  ...m(code, message),
   filename: o?.filename ?? kmnfile,
   line: o?.line,
 });
@@ -80,7 +80,7 @@ export class KmnCompilerMessages {
   // parameterisation.
 
   /** @internal */
-  static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   /**
    * Raised when KmnCompiler or one of its components experiences an internal
    * error. If you experience this error, it should be reported to the Keyman
@@ -89,7 +89,7 @@ export class KmnCompilerMessages {
   static FATAL_UnexpectedException = SevFatal | 0x900;
 
   /** @internal */
-  static Fatal_MissingWasmModule = (o:{e?: any}) => m(this.FATAL_MissingWasmModule,
+  static Fatal_MissingWasmModule = (o:{e?: any}) => CompilerMessageSpecWithException(this.FATAL_MissingWasmModule,
     `Could not instantiate WASM compiler module or initialization failed`, o.e ?? 'unknown error');
   /**
    * Raised when the kmcmplib component could be instantiated. This may indicate
@@ -103,7 +103,7 @@ export class KmnCompilerMessages {
   // static FATAL_UnableToSetCompilerOptions = SevFatal | 0x902;
 
   /** @internal */
-  static Fatal_CallbacksNotSet = () => m(this.FATAL_CallbacksNotSet, null, `Callbacks were not set with init`);
+  static Fatal_CallbacksNotSet = () => CompilerMessageSpecWithException(this.FATAL_CallbacksNotSet, null, `Callbacks were not set with init`);
   /**
    * Raised when KmnCompiler or one of its components experiences an internal
    * error. If you experience this error, it should be reported to the Keyman
@@ -112,7 +112,7 @@ export class KmnCompilerMessages {
   static FATAL_CallbacksNotSet = SevFatal | 0x903;
 
   /** @internal */
-  static Fatal_UnicodeSetOutOfRange = () => m(this.FATAL_UnicodeSetOutOfRange, null, `UnicodeSet buffer was too small`);
+  static Fatal_UnicodeSetOutOfRange = () => CompilerMessageSpecWithException(this.FATAL_UnicodeSetOutOfRange, null, `UnicodeSet buffer was too small`);
   /**
    * Raised when caller to UnicodeSet functions provides an invalid buffer. If
    * you experience this error, it should be reported to the Keyman team for

--- a/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
@@ -9,8 +9,8 @@ const SevHint = CompilerErrorSeverity.Hint | Namespace;
 const SevError = CompilerErrorSeverity.Error | Namespace;
 // const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
-const m = (code: number, message: string, o?: {e?: any, filename?: string, line?: number}) : CompilerEvent => ({
-  ...CompilerMessageSpec(code, message, o?.e),
+const m = (code: number, message: string, o?: {filename?: string, line?: number}) : CompilerEvent => ({
+  ...CompilerMessageSpec(code, message),
   filename: o?.filename ?? kmnfile,
   line: o?.line,
 });

--- a/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
@@ -1,5 +1,5 @@
 import { KmnCompilerMessages } from "../compiler/kmn-compiler-messages.js";
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageDef as def, CompilerMessageSpec } from "@keymanapp/common-types";
 import { kmnfile } from "./compiler-globals.js";
 
 const Namespace = CompilerErrorNamespace.KmwCompiler;
@@ -30,28 +30,23 @@ export class KmwCompilerMessages extends KmnCompilerMessages {
 
   // Following messages are kmw-compiler only, so use KmwCompiler error namespace
 
-  /** @internal */
+  static ERROR_NotAnyRequiresVersion14 = SevError | 0x0001;
   static Error_NotAnyRequiresVersion14 = (o:{line: number}) => m(this.ERROR_NotAnyRequiresVersion14,
     `Statement notany in context() match requires version 14.0+ of KeymanWeb`, o);
-  static ERROR_NotAnyRequiresVersion14 = SevError | 0x0001;
 
-  /** @internal */
-  static Error_TouchLayoutIdentifierRequires15 = (o:{keyId:string, platformName:string, layerId:string}) => m(this.ERROR_TouchLayoutIdentifierRequires15,
-    `Key "${o.keyId}" on "${o.platformName}", layer "${o.layerId}" has a multi-part identifier which requires version 15.0 or newer.`);
   static ERROR_TouchLayoutIdentifierRequires15 = SevError | 0x0002;
+  static Error_TouchLayoutIdentifierRequires15 = (o:{keyId:string, platformName:string, layerId:string}) => m(this.ERROR_TouchLayoutIdentifierRequires15,
+    `Key "${def(o.keyId)}" on "${def(o.platformName)}", layer "${def(o.layerId)}" has a multi-part identifier which requires version 15.0 or newer.`);
 
-  /** @internal */
-  static Error_InvalidTouchLayoutFileFormat = (o:{msg: string}) => m(this.ERROR_InvalidTouchLayoutFileFormat,
-    `Invalid touch layout file: ${o.msg}`);
   static ERROR_InvalidTouchLayoutFileFormat = SevError | 0x0003;
+  static Error_InvalidTouchLayoutFileFormat = (o:{msg: string}) => m(this.ERROR_InvalidTouchLayoutFileFormat,
+    `Invalid touch layout file: ${def(o.msg)}`);
 
-  /** @internal */
-  static Error_TouchLayoutFileDoesNotExist = (o:{filename:string}) => m(this.ERROR_TouchLayoutFileDoesNotExist,
-    `Touch layout file ${o.filename} does not exist`);
   static ERROR_TouchLayoutFileDoesNotExist = SevError | 0x0004;
+  static Error_TouchLayoutFileDoesNotExist = (o:{filename:string}) => m(this.ERROR_TouchLayoutFileDoesNotExist,
+    `Touch layout file ${def(o.filename)} does not exist`);
 
-  /** @internal */
-  static Hint_TouchLayoutUsesUnsupportedGesturesDownlevel = (o:{keyId:string}) => m(this.HINT_TouchLayoutUsesUnsupportedGesturesDownlevel,
-    `The touch layout uses a flick or multi-tap gesture on key ${o.keyId}, which is only available on version 17.0+ of Keyman`);
   static HINT_TouchLayoutUsesUnsupportedGesturesDownlevel = SevHint | 0x0005;
+  static Hint_TouchLayoutUsesUnsupportedGesturesDownlevel = (o:{keyId:string}) => m(this.HINT_TouchLayoutUsesUnsupportedGesturesDownlevel,
+    `The touch layout uses a flick or multi-tap gesture on key ${def(o.keyId)}, which is only available on version 17.0+ of Keyman`);
 };

--- a/developer/src/kmc-ldml/src/compiler/messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/messages.ts
@@ -1,4 +1,4 @@
-import { util, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
+import { util, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 // const SevInfo = CompilerErrorSeverity.Info | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevHint = CompilerErrorSeverity.Hint | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevWarn = CompilerErrorSeverity.Warn | CompilerErrorNamespace.LdmlKeyboardCompiler;
@@ -6,59 +6,59 @@ const SevError = CompilerErrorSeverity.Error | CompilerErrorNamespace.LdmlKeyboa
 const SevFatal = CompilerErrorSeverity.Fatal | CompilerErrorNamespace.LdmlKeyboardCompiler;
 
 export class CompilerMessages {
-  static Hint_NormalizationDisabled = () => m(this.HINT_NormalizationDisabled, `normalization=disabled is not recommended.`);
   static HINT_NormalizationDisabled = SevHint | 0x0001;
+  static Hint_NormalizationDisabled = () => m(this.HINT_NormalizationDisabled, `normalization=disabled is not recommended.`);
 
-  static Error_InvalidLocale = (o:{tag: string}) => m(this.ERROR_InvalidLocale, `Invalid BCP 47 locale form '${o.tag}'`);
   static ERROR_InvalidLocale = SevError | 0x0002;
+  static Error_InvalidLocale = (o:{tag: string}) => m(this.ERROR_InvalidLocale, `Invalid BCP 47 locale form '${def(o.tag)}'`);
 
-  static Error_HardwareLayerHasTooManyRows = () => m(this.ERROR_HardwareLayerHasTooManyRows, `'hardware' layer has too many rows`);
   static ERROR_HardwareLayerHasTooManyRows = SevError | 0x0003;
+  static Error_HardwareLayerHasTooManyRows = () => m(this.ERROR_HardwareLayerHasTooManyRows, `'hardware' layer has too many rows`);
 
-  static Error_RowOnHardwareLayerHasTooManyKeys = (o:{row: number, hardware: string, modifiers: string}) =>  m(this.ERROR_RowOnHardwareLayerHasTooManyKeys, `Row #${o.row} on 'hardware' ${o.hardware} layer for modifier ${o.modifiers || 'none'} has too many keys`);
   static ERROR_RowOnHardwareLayerHasTooManyKeys = SevError | 0x0004;
+  static Error_RowOnHardwareLayerHasTooManyKeys = (o:{row: number, hardware: string, modifiers: string}) =>  m(this.ERROR_RowOnHardwareLayerHasTooManyKeys, `Row #${def(o.row)} on 'hardware' ${def(o.hardware)} layer for modifier ${o.modifiers || 'none'} has too many keys`);
 
-  static Error_KeyNotFoundInKeyBag = (o:{keyId: string, col: number, row: number, layer: string, form: string}) =>
-     m(this.ERROR_KeyNotFoundInKeyBag, `Key '${o.keyId}' in position #${o.col} on row #${o.row} of layer ${o.layer}, form '${o.form}' not found in key bag`);
   static ERROR_KeyNotFoundInKeyBag = SevError | 0x0005;
+  static Error_KeyNotFoundInKeyBag = (o:{keyId: string, col: number, row: number, layer: string, form: string}) =>
+     m(this.ERROR_KeyNotFoundInKeyBag, `Key '${def(o.keyId)}' in position #${def(o.col)} on row #${def(o.row)} of layer ${def(o.layer)}, form '${def(o.form)}' not found in key bag`);
 
+  static HINT_OneOrMoreRepeatedLocales = SevHint | 0x0006;
   static Hint_OneOrMoreRepeatedLocales = () =>
     m(this.HINT_OneOrMoreRepeatedLocales, `After minimization, one or more locales is repeated and has been removed`);
-  static HINT_OneOrMoreRepeatedLocales = SevHint | 0x0006;
 
-  static Error_InvalidFile = (o:{errorText: string}) =>
-    m(this.ERROR_InvalidFile, `The source file has an invalid structure: ${o.errorText}`);
   static ERROR_InvalidFile = SevError | 0x0007;
+  static Error_InvalidFile = (o:{errorText: string}) =>
+    m(this.ERROR_InvalidFile, `The source file has an invalid structure: ${def(o.errorText)}`);
 
-  static Hint_LocaleIsNotMinimalAndClean = (o:{sourceLocale: string, locale: string}) =>
-    m(this.HINT_LocaleIsNotMinimalAndClean, `Locale '${o.sourceLocale}' is not minimal or correctly formatted and should be '${o.locale}'`);
   static HINT_LocaleIsNotMinimalAndClean = SevHint | 0x0008;
+  static Hint_LocaleIsNotMinimalAndClean = (o:{sourceLocale: string, locale: string}) =>
+    m(this.HINT_LocaleIsNotMinimalAndClean, `Locale '${def(o.sourceLocale)}' is not minimal or correctly formatted and should be '${def(o.locale)}'`);
 
-  static Error_InvalidScanCode = (o:{form?: string, codes?: string[]}) =>
-  m(this.ERROR_InvalidScanCode, `Form '${o.form}' has invalid/unknown scancodes '${o.codes?.join(' ')}'`);
   static ERROR_InvalidScanCode = SevError | 0x0009;
+  static Error_InvalidScanCode = (o:{form?: string, codes?: string[]}) =>
+  m(this.ERROR_InvalidScanCode, `Form '${def(o.form)}' has invalid/unknown scancodes '${def(o.codes?.join(' '))}'`);
 
-  static Warn_CustomForm = (o:{id: string}) =>
-  m(this.WARN_CustomForm, `Custom <form id="${o.id}"> element. Key layout may not be as expected.`);
   static WARN_CustomForm = SevWarn | 0x000A;
+  static Warn_CustomForm = (o:{id: string}) =>
+  m(this.WARN_CustomForm, `Custom <form id="${def(o.id)}"> element. Key layout may not be as expected.`);
 
-  static Error_GestureKeyNotFoundInKeyBag = (o:{keyId: string, parentKeyId: string, attribute: string}) =>
-  m(this.ERROR_GestureKeyNotFoundInKeyBag, `Key '${o.keyId}' not found in key bag, referenced from other '${o.parentKeyId}' in ${o.attribute}`);
   static ERROR_GestureKeyNotFoundInKeyBag = SevError | 0x000B;
+  static Error_GestureKeyNotFoundInKeyBag = (o:{keyId: string, parentKeyId: string, attribute: string}) =>
+  m(this.ERROR_GestureKeyNotFoundInKeyBag, `Key '${def(o.keyId)}' not found in key bag, referenced from other '${def(o.parentKeyId)}' in ${def(o.attribute)}`);
 
   // 0x000C - available
 
-  static Error_InvalidVersion = (o:{version: string}) =>
-    m(this.ERROR_InvalidVersion, `Version number '${o.version}' must be a semantic version format string.`);
   static ERROR_InvalidVersion = SevError | 0x000D;
+  static Error_InvalidVersion = (o:{version: string}) =>
+    m(this.ERROR_InvalidVersion, `Version number '${def(o.version)}' must be a semantic version format string.`);
 
+  static ERROR_MustBeAtLeastOneLayerElement = SevError | 0x000E;
   static Error_MustBeAtLeastOneLayerElement = () =>
     m(this.ERROR_MustBeAtLeastOneLayerElement, `The source file must contain at least one layer element.`);
-  static ERROR_MustBeAtLeastOneLayerElement = SevError | 0x000E;
 
-  static Fatal_SectionCompilerFailed = (o:{sect: string}) =>
-  CompilerMessageSpecWithException(this.FATAL_SectionCompilerFailed, null, `The compiler for '${o.sect}' failed unexpectedly.`);
   static FATAL_SectionCompilerFailed = SevFatal | 0x000F;
+  static Fatal_SectionCompilerFailed = (o:{sect: string}) =>
+  CompilerMessageSpecWithException(this.FATAL_SectionCompilerFailed, null, `The compiler for '${def(o.sect)}' failed unexpectedly.`);
 
   /** annotate the to= or id= entry */
   private static outputOrKeyId(o:{output?: string, keyId?: string}) {
@@ -73,110 +73,110 @@ export class CompilerMessages {
     }
   }
 
+  static ERROR_DisplayIsRepeated = SevError | 0x0010;
   static Error_DisplayIsRepeated = (o:{output?: string, keyId?: string}) =>
     m(this.ERROR_DisplayIsRepeated, `display ${CompilerMessages.outputOrKeyId(o)} has more than one display entry.`);
-  static ERROR_DisplayIsRepeated = SevError | 0x0010;
 
-  static Error_KeyMissingToGapOrSwitch = (o:{keyId: string}) =>
-  m(this.ERROR_KeyMissingToGapOrSwitch, `key id='${o.keyId}' must have either output=, gap=, or layerId=.`);
   static ERROR_KeyMissingToGapOrSwitch = SevError | 0x0011;
+  static Error_KeyMissingToGapOrSwitch = (o:{keyId: string}) =>
+  m(this.ERROR_KeyMissingToGapOrSwitch, `key id='${def(o.keyId)}' must have either output=, gap=, or layerId=.`);
 
-  static Error_ExcessHardware = (o:{formId: string}) => m(this.ERROR_ExcessHardware,
-    `layers formId=${o.formId}: Can only have one non-'touch' element`);
   static ERROR_ExcessHardware = SevError | 0x0012;
+  static Error_ExcessHardware = (o:{formId: string}) => m(this.ERROR_ExcessHardware,
+    `layers formId=${def(o.formId)}: Can only have one non-'touch' element`);
 
-  static Error_InvalidHardware = (o:{formId: string}) => m(this.ERROR_InvalidHardware,
-    `layers has invalid value formId=${o.formId}`);
   static ERROR_InvalidHardware = SevError | 0x0013;
+  static Error_InvalidHardware = (o:{formId: string}) => m(this.ERROR_InvalidHardware,
+    `layers has invalid value formId=${def(o.formId)}`);
 
-  static Error_InvalidModifier = (o:{layer: string, modifiers: string}) => m(this.ERROR_InvalidModifier,
-    `layer has invalid modifiers='${o.modifiers}' on layer id=${o.layer}`);
   static ERROR_InvalidModifier = SevError | 0x0014;
+  static Error_InvalidModifier = (o:{layer: string, modifiers: string}) => m(this.ERROR_InvalidModifier,
+    `layer has invalid modifiers='${def(o.modifiers)}' on layer id=${def(o.layer)}`);
 
-  static Error_MissingFlicks = (o:{flickId: string, id: string}) => m(this.ERROR_MissingFlicks,
-    `key id=${o.id} refers to missing flickId=${o.flickId}`);
   static ERROR_MissingFlicks = SevError | 0x0015;
+  static Error_MissingFlicks = (o:{flickId: string, id: string}) => m(this.ERROR_MissingFlicks,
+    `key id=${def(o.id)} refers to missing flickId=${def(o.flickId)}`);
 
-  static Error_DuplicateVariable = (o:{ids: string}) => m(this.ERROR_DuplicateVariable,
-      `duplicate variables: id=${o.ids}`);
   static ERROR_DuplicateVariable = SevError | 0x0016;
+  static Error_DuplicateVariable = (o:{ids: string}) => m(this.ERROR_DuplicateVariable,
+      `duplicate variables: id=${def(o.ids)}`);
 
   // Not hit due to XML parsing
-  static Error_InvalidTransformsType = (o:{types: string[]}) =>
-  m(this.ERROR_InvalidTransformsType, `Invalid transforms types: '${o.types?.join(',')}'`);
   static ERROR_InvalidTransformsType = SevError | 0x0018;
+  static Error_InvalidTransformsType = (o:{types: string[]}) =>
+  m(this.ERROR_InvalidTransformsType, `Invalid transforms types: '${def(o.types?.join(','))}'`);
 
-  static Error_DuplicateTransformsType = (o:{types: string[]}) =>
-  m(this.ERROR_DuplicateTransformsType, `Duplicate transforms types: '${o.types?.join(',')}'`);
   static ERROR_DuplicateTransformsType = SevError | 0x0019;
+  static Error_DuplicateTransformsType = (o:{types: string[]}) =>
+  m(this.ERROR_DuplicateTransformsType, `Duplicate transforms types: '${def(o.types?.join(','))}'`);
 
+  static ERROR_MixedTransformGroup = SevError | 0x001A;
   static Error_MixedTransformGroup = () =>
   m(this.ERROR_MixedTransformGroup, `transformGroup cannot contain both reorder and transform elements`);
-  static ERROR_MixedTransformGroup = SevError | 0x001A;
 
+  static ERROR_EmptyTransformGroup = SevError | 0x001B;
   static Error_EmptyTransformGroup = () =>
   m(this.ERROR_EmptyTransformGroup, `transformGroup must have either reorder or transform elements`);
-  static ERROR_EmptyTransformGroup = SevError | 0x001B;
 
-  static Error_MissingStringVariable = (o:{id: string}) =>
-  m(this.ERROR_MissingStringVariable, `Reference to undefined string variable: \${${o.id}}`);
   static ERROR_MissingStringVariable = SevError | 0x001C;
+  static Error_MissingStringVariable = (o:{id: string}) =>
+  m(this.ERROR_MissingStringVariable, `Reference to undefined string variable: \${${def(o.id)}}`);
 
-  static Error_MissingSetVariable = (o:{id: string}) =>
-  m(this.ERROR_MissingSetVariable, `Reference to undefined set variable: \$[${o.id}]`);
   static ERROR_MissingSetVariable = SevError | 0x001D;
+  static Error_MissingSetVariable = (o:{id: string}) =>
+  m(this.ERROR_MissingSetVariable, `Reference to undefined set variable: \$[${def(o.id)}]`);
 
-  static Error_MissingUnicodeSetVariable = (o:{id: string}) =>
-  m(this.ERROR_MissingUnicodeSetVariable, `Reference to undefined UnicodeSet variable: \$[${o.id}]`);
   static ERROR_MissingUnicodeSetVariable = SevError | 0x001E;
+  static Error_MissingUnicodeSetVariable = (o:{id: string}) =>
+  m(this.ERROR_MissingUnicodeSetVariable, `Reference to undefined UnicodeSet variable: \$[${def(o.id)}]`);
 
-  static Error_NeedSpacesBetweenSetVariables = (o:{item: string}) =>
-  m(this.ERROR_NeedSpacesBetweenSetVariables, `Need spaces between set variables: ${o.item}`);
   static ERROR_NeedSpacesBetweenSetVariables = SevError | 0x001F;
+  static Error_NeedSpacesBetweenSetVariables = (o:{item: string}) =>
+  m(this.ERROR_NeedSpacesBetweenSetVariables, `Need spaces between set variables: ${def(o.item)}`);
 
-  static Error_CantReferenceSetFromUnicodeSet = (o:{id: string}) =>
-  m(this.ERROR_CantReferenceSetFromUnicodeSet, `Illegal use of set variable from within UnicodeSet: \$[${o.id}]`);
   static ERROR_CantReferenceSetFromUnicodeSet = SevError | 0x0020;
+  static Error_CantReferenceSetFromUnicodeSet = (o:{id: string}) =>
+  m(this.ERROR_CantReferenceSetFromUnicodeSet, `Illegal use of set variable from within UnicodeSet: \$[${def(o.id)}]`);
 
-  static Error_MissingMarkers = (o: { ids: string[] }) =>
-  m(this.ERROR_MissingMarkers, `Markers used for matching but not defined: ${o.ids?.join(',')}`);
   static ERROR_MissingMarkers = SevError | 0x0021;
+  static Error_MissingMarkers = (o: { ids: string[] }) =>
+  m(this.ERROR_MissingMarkers, `Markers used for matching but not defined: ${def(o.ids?.join(','))}`);
 
+  static ERROR_DisplayNeedsToOrId = SevError | 0x0022;
   static Error_DisplayNeedsToOrId = (o:{output?: string, keyId?: string}) =>
   m(this.ERROR_DisplayNeedsToOrId, `display ${CompilerMessages.outputOrKeyId(o)} needs output= or keyId=, but not both`);
-  static ERROR_DisplayNeedsToOrId = SevError | 0x0022;
 
-  static Hint_PUACharacters = (o: { count: number, lowestCh: number }) =>
-  m(this.HINT_PUACharacters, `File contains ${o.count} PUA character(s), including ${util.describeCodepoint(o.lowestCh)}`);
   static HINT_PUACharacters = SevHint | 0x0023;
+  static Hint_PUACharacters = (o: { count: number, lowestCh: number }) =>
+  m(this.HINT_PUACharacters, `File contains ${def(o.count)} PUA character(s), including ${util.describeCodepoint(o.lowestCh)}`);
 
-  static Warn_UnassignedCharacters = (o: { count: number, lowestCh: number }) =>
-  m(this.WARN_UnassignedCharacters, `File contains ${o.count} unassigned character(s), including ${util.describeCodepoint(o.lowestCh)}`);
   static WARN_UnassignedCharacters = SevWarn | 0x0024;
+  static Warn_UnassignedCharacters = (o: { count: number, lowestCh: number }) =>
+  m(this.WARN_UnassignedCharacters, `File contains ${def(o.count)} unassigned character(s), including ${util.describeCodepoint(o.lowestCh)}`);
 
-  static Error_IllegalCharacters = (o: { count: number, lowestCh: number }) =>
-  m(this.ERROR_IllegalCharacters, `File contains ${o.count} illegal character(s), including ${util.describeCodepoint(o.lowestCh)}`);
   static ERROR_IllegalCharacters = SevError | 0x0025;
+  static Error_IllegalCharacters = (o: { count: number, lowestCh: number }) =>
+  m(this.ERROR_IllegalCharacters, `File contains ${def(o.count)} illegal character(s), including ${util.describeCodepoint(o.lowestCh)}`);
 
+  static HINT_CharClassImplicitDenorm = SevHint | 0x0026;
   static Hint_CharClassImplicitDenorm = (o: { lowestCh: number }) =>
   m(this.HINT_CharClassImplicitDenorm, `File has character classes which span non-NFD character(s), including ${util.describeCodepoint(o.lowestCh)}. These will not match any text.`);
-  static HINT_CharClassImplicitDenorm = SevHint | 0x0026;
 
+  static WARN_CharClassExplicitDenorm = SevWarn | 0x0027;
   static Warn_CharClassExplicitDenorm = (o: { lowestCh: number }) =>
   m(this.WARN_CharClassExplicitDenorm, `File has character classes which include non-NFD characters(s), including ${util.describeCodepoint(o.lowestCh)}. These will not match any text.`);
-  static WARN_CharClassExplicitDenorm = SevWarn | 0x0027;
 
-  static Error_UnparseableReorderSet = (o: { from: string, set: string }) =>
-  m(this.ERROR_UnparseableReorderSet, `Illegal UnicodeSet "${o.set}" in reorder "${o.from}`);
   static ERROR_UnparseableReorderSet = SevError | 0x0028;
+  static Error_UnparseableReorderSet = (o: { from: string, set: string }) =>
+  m(this.ERROR_UnparseableReorderSet, `Illegal UnicodeSet "${def(o.set)}" in reorder "${def(o.from)}`);
 
-  static Error_UnparseableTransformFrom = (o: { from: string, message: string }) =>
-  m(this.ERROR_UnparseableTransformFrom, `Invalid transfom from "${o.from}": "${o.message}`);
   static ERROR_UnparseableTransformFrom = SevError | 0x0029;
+  static Error_UnparseableTransformFrom = (o: { from: string, message: string }) =>
+  m(this.ERROR_UnparseableTransformFrom, `Invalid transfom from "${def(o.from)}": "${def(o.message)}"`);
 
-  static Error_InvalidQuadEscape = (o: { cp: number }) =>
-  m(this.ERROR_InvalidQuadEscape, `Invalid escape "\\u${util.hexQuad(o?.cp || 0)}", use "\\u{${o?.cp?.toString(16)}}" instead.`);
   static ERROR_InvalidQuadEscape = SevError | 0x0030;
+  static Error_InvalidQuadEscape = (o: { cp: number }) =>
+  m(this.ERROR_InvalidQuadEscape, `Invalid escape "\\u${util.hexQuad(o?.cp || 0)}", use "\\u{${def(o?.cp?.toString(16))}}" instead.`);
 }
 
 

--- a/developer/src/kmc-ldml/src/compiler/messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/messages.ts
@@ -1,4 +1,4 @@
-import { util, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
+import { util, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 // const SevInfo = CompilerErrorSeverity.Info | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevHint = CompilerErrorSeverity.Hint | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevWarn = CompilerErrorSeverity.Warn | CompilerErrorNamespace.LdmlKeyboardCompiler;
@@ -57,7 +57,7 @@ export class CompilerMessages {
   static ERROR_MustBeAtLeastOneLayerElement = SevError | 0x000E;
 
   static Fatal_SectionCompilerFailed = (o:{sect: string}) =>
-    m(this.FATAL_SectionCompilerFailed, null, `The compiler for '${o.sect}' failed unexpectedly.`);
+  CompilerMessageSpecWithException(this.FATAL_SectionCompilerFailed, null, `The compiler for '${o.sect}' failed unexpectedly.`);
   static FATAL_SectionCompilerFailed = SevFatal | 0x000F;
 
   /** annotate the to= or id= entry */

--- a/developer/src/kmc-model-info/src/model-info-compiler-messages.ts
+++ b/developer/src/kmc-model-info/src/model-info-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.ModelInfoCompiler;
 // const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -8,38 +8,38 @@ const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
 export class ModelInfoCompilerMessages {
-  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   static FATAL_UnexpectedException = SevFatal | 0x0001;
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
 
-  static Error_FileDoesNotExist = (o:{filename: string}) => m(this.ERROR_FileDoesNotExist, `File ${o.filename} does not exist.`);
   static ERROR_FileDoesNotExist = SevError | 0x0002;
+  static Error_FileDoesNotExist = (o:{filename: string}) => m(this.ERROR_FileDoesNotExist, `File ${def(o.filename)} does not exist.`);
 
-  static Error_FileIsNotValid = (o:{filename: string; e: any}) => m(this.ERROR_FileIsNotValid,
-    `File ${o.filename} could not be parsed: ${(o.e ?? 'unknown error').toString()}.`);
   static ERROR_FileIsNotValid = SevError | 0x0003;
+  static Error_FileIsNotValid = (o:{filename: string; e: any}) => m(this.ERROR_FileIsNotValid,
+    `File ${def(o.filename)} could not be parsed: ${(o.e ?? 'unknown error').toString()}.`);
 
-  static Warn_MetadataFieldInconsistent = (o:{field:string, value:any, expected:any}) => m(this.WARN_MetadataFieldInconsistent,
-    `Warning: field ${o.field} value "${o.value}" does not match "${o.expected}" found in source file metadata.`);
   static WARN_MetadataFieldInconsistent = SevWarn | 0x0004;
+  static Warn_MetadataFieldInconsistent = (o:{field:string, value:any, expected:any}) => m(this.WARN_MetadataFieldInconsistent,
+    `Warning: field ${def(o.field)} value "${def(o.value)}" does not match "${def(o.expected)}" found in source file metadata.`);
 
-  static Error_InvalidAuthorEmail = (o:{email:string}) => m(this.ERROR_InvalidAuthorEmail,
-    `Invalid author email: ${o.email}`);
   static ERROR_InvalidAuthorEmail = SevError | 0x0005;
+  static Error_InvalidAuthorEmail = (o:{email:string}) => m(this.ERROR_InvalidAuthorEmail,
+    `Invalid author email: ${def(o.email)}`);
 
-  static Error_LicenseFileDoesNotExist = (o:{filename:string}) => m(this.ERROR_LicenseFileIsMissing,
-    `License file ${o.filename} does not exist.`);
   static ERROR_LicenseFileIsMissing = SevError | 0x0006;
+  static Error_LicenseFileDoesNotExist = (o:{filename:string}) => m(this.ERROR_LicenseFileIsMissing,
+    `License file ${def(o.filename)} does not exist.`);
 
-  static Error_LicenseFileIsDamaged = (o:{filename:string}) => m(this.ERROR_LicenseFileIsDamaged,
-    `License file ${o.filename} could not be loaded or decoded.`);
   static ERROR_LicenseFileIsDamaged = SevError | 0x0007;
+  static Error_LicenseFileIsDamaged = (o:{filename:string}) => m(this.ERROR_LicenseFileIsDamaged,
+    `License file ${def(o.filename)} could not be loaded or decoded.`);
 
-  static Error_LicenseIsNotValid = (o:{filename:string,message:string}) => m(this.ERROR_LicenseIsNotValid,
-    `An error was encountered parsing license file ${o.filename}: ${o.message}.`);
   static ERROR_LicenseIsNotValid = SevError | 0x0008;
+  static Error_LicenseIsNotValid = (o:{filename:string,message:string}) => m(this.ERROR_LicenseIsNotValid,
+    `An error was encountered parsing license file ${def(o.filename)}: ${def(o.message)}.`);
 
+  static ERROR_NoLicenseFound = SevError | 0x0009;
   static Error_NoLicenseFound = () => m(this.ERROR_NoLicenseFound,
     `No license for the model was found. MIT license is required for publication to Keyman lexical-models repository.`);
-  static ERROR_NoLicenseFound = SevError | 0x0009;
 }
 

--- a/developer/src/kmc-model-info/src/model-info-compiler-messages.ts
+++ b/developer/src/kmc-model-info/src/model-info-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.ModelInfoCompiler;
 // const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -8,7 +8,7 @@ const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
 export class ModelInfoCompilerMessages {
-  static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   static FATAL_UnexpectedException = SevFatal | 0x0001;
 
   static Error_FileDoesNotExist = (o:{filename: string}) => m(this.ERROR_FileDoesNotExist, `File ${o.filename} does not exist.`);

--- a/developer/src/kmc-model/src/model-compiler-messages.ts
+++ b/developer/src/kmc-model/src/model-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.ModelCompiler;
 // const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -7,8 +7,14 @@ const SevHint = CompilerErrorSeverity.Hint | Namespace;
 const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
-const m = (code: number, message: string, exceptionVar?: any) : CompilerEvent => ({
-  ...CompilerMessageSpec(code, message, exceptionVar),
+const m = (code: number, message: string) : CompilerEvent => ({
+  ...CompilerMessageSpec(code, message),
+  line: ModelCompilerMessageContext.line,
+  filename: ModelCompilerMessageContext.filename,
+});
+
+const m_e = (code: number, message: string, exceptionVar: any) : CompilerEvent => ({
+  ...CompilerMessageSpecWithException(code, message, exceptionVar),
   line: ModelCompilerMessageContext.line,
   filename: ModelCompilerMessageContext.filename,
 });
@@ -21,7 +27,7 @@ export class ModelCompilerMessageContext {
 
 export class ModelCompilerMessages {
 
-  static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
+  static Fatal_UnexpectedException = (o:{e: any}) => m_e(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   static FATAL_UnexpectedException = SevFatal | 0x0001;
 
   static Hint_MixedNormalizationForms = (o:{wordform: string}) => m(this.HINT_MixedNormalizationForms,

--- a/developer/src/kmc-model/src/model-compiler-messages.ts
+++ b/developer/src/kmc-model/src/model-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec, CompilerMessageSpecWithException } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.ModelCompiler;
 // const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -27,43 +27,43 @@ export class ModelCompilerMessageContext {
 
 export class ModelCompilerMessages {
 
-  static Fatal_UnexpectedException = (o:{e: any}) => m_e(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   static FATAL_UnexpectedException = SevFatal | 0x0001;
+  static Fatal_UnexpectedException = (o:{e: any}) => m_e(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
 
-  static Hint_MixedNormalizationForms = (o:{wordform: string}) => m(this.HINT_MixedNormalizationForms,
-    `“${o.wordform}” is not in Unicode NFC. Automatically converting to NFC.`);
   static HINT_MixedNormalizationForms = SevHint | 0x0002;
+  static Hint_MixedNormalizationForms = (o:{wordform: string}) => m(this.HINT_MixedNormalizationForms,
+    `“${def(o.wordform)}” is not in Unicode NFC. Automatically converting to NFC.`);
 
-  static Hint_DuplicateWordInSameFile = (o:{wordform: string}) => m(this.HINT_DuplicateWordInSameFile,
-    `duplicate word “${o.wordform}” found in same file; summing counts`);
   static HINT_DuplicateWordInSameFile = SevHint | 0x0003;
+  static Hint_DuplicateWordInSameFile = (o:{wordform: string}) => m(this.HINT_DuplicateWordInSameFile,
+    `duplicate word “${def(o.wordform)}” found in same file; summing counts`);
 
-  static Error_UnimplementedModelFormat = (o:{format: string}) => m(this.ERROR_UnimplementedModelFormat,
-    `Unimplemented model format: ${o.format}`);
   static ERROR_UnimplementedModelFormat = SevError | 0x0004;
+  static Error_UnimplementedModelFormat = (o:{format: string}) => m(this.ERROR_UnimplementedModelFormat,
+    `Unimplemented model format: ${def(o.format)}`);
 
-  static Error_UnknownModelFormat = (o:{format: string}) => m(this.ERROR_UnknownModelFormat,
-    `Unimplemented model format: ${o.format}`);
   static ERROR_UnknownModelFormat = SevError | 0x0005;
+  static Error_UnknownModelFormat = (o:{format: string}) => m(this.ERROR_UnknownModelFormat,
+    `Unimplemented model format: ${def(o.format)}`);
 
+  static ERROR_NoDefaultExport = SevError | 0x0006;
   static Error_NoDefaultExport = () => m(this.ERROR_NoDefaultExport,
     `Model source does have a default export. Did you remember to write \`export default source;\`?`);
-  static ERROR_NoDefaultExport = SevError | 0x0006;
 
+  static ERROR_SearchTermToKeyMustBeExplicitlySpecified = SevError | 0x0007;
   static Error_SearchTermToKeyMustBeExplicitlySpecified = () => m(this.ERROR_SearchTermToKeyMustBeExplicitlySpecified,
     "searchTermToKey must be explicitly specified");
-  static ERROR_SearchTermToKeyMustBeExplicitlySpecified = SevError | 0x0007;
 
-  static Error_UTF16BEUnsupported = () => m(this.ERROR_UTF16BEUnsupported, 'UTF-16BE is unsupported');
   static ERROR_UTF16BEUnsupported = SevError | 0x0008;
+  static Error_UTF16BEUnsupported = () => m(this.ERROR_UTF16BEUnsupported, 'UTF-16BE is unsupported');
 
-  static Error_UnknownWordBreaker = (o:{spec:string}) => m(this.ERROR_UnknownWordBreaker,
-    `Unknown word breaker: ${o.spec}`);
   static ERROR_UnknownWordBreaker = SevError | 0x0009;
+  static Error_UnknownWordBreaker = (o:{spec:string}) => m(this.ERROR_UnknownWordBreaker,
+    `Unknown word breaker: ${def(o.spec)}`);
 
-  static Error_UnsupportedScriptOverride = (o:{option:string}) => m(this.ERROR_UnsupportedScriptOverride,
-    `Unsupported script override: ${o.option}`);
   static ERROR_UnsupportedScriptOverride = SevError | 0x000A;
+  static Error_UnsupportedScriptOverride = (o:{option:string}) => m(this.ERROR_UnsupportedScriptOverride,
+    `Unsupported script override: ${def(o.option)}`);
 };
 
 /**

--- a/developer/src/kmc-package/src/compiler/package-compiler-messages.ts
+++ b/developer/src/kmc-package/src/compiler/package-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.PackageCompiler;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -8,7 +8,7 @@ const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
 export class CompilerMessages {
-  static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   static FATAL_UnexpectedException = SevFatal | 0x0001;
 
   static Warn_AbsolutePath = (o:{filename: string}) => m(this.WARN_AbsolutePath, `File ${o.filename} has an absolute path, which is not portable.`);

--- a/developer/src/kmc-package/src/compiler/package-compiler-messages.ts
+++ b/developer/src/kmc-package/src/compiler/package-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.PackageCompiler;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -8,124 +8,124 @@ const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
 export class CompilerMessages {
-  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   static FATAL_UnexpectedException = SevFatal | 0x0001;
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
 
-  static Warn_AbsolutePath = (o:{filename: string}) => m(this.WARN_AbsolutePath, `File ${o.filename} has an absolute path, which is not portable.`);
   static WARN_AbsolutePath = SevWarn | 0x0002;
+  static Warn_AbsolutePath = (o:{filename: string}) => m(this.WARN_AbsolutePath, `File ${def(o.filename)} has an absolute path, which is not portable.`);
 
-  static Error_FileDoesNotExist = (o:{filename: string}) => m(this.ERROR_FileDoesNotExist, `File ${o.filename} does not exist.`);
   static ERROR_FileDoesNotExist = SevError | 0x0003;
+  static Error_FileDoesNotExist = (o:{filename: string}) => m(this.ERROR_FileDoesNotExist, `File ${def(o.filename)} does not exist.`);
 
-  static Error_FileCouldNotBeRead = (o:{filename: string; e: any}) => m(this.ERROR_FileCouldNotBeRead,
-    `File ${o.filename} could not be read: ${(o.e ?? 'unknown error').toString()}.`);
   static ERROR_FileCouldNotBeRead = SevError | 0x0004;
+  static Error_FileCouldNotBeRead = (o:{filename: string; e: any}) => m(this.ERROR_FileCouldNotBeRead,
+    `File ${def(o.filename)} could not be read: ${(o.e ?? 'unknown error').toString()}.`);
 
-  static Warn_FileIsNotABinaryKvkFile = (o:{filename: string}) => m(this.WARN_FileIsNotABinaryKvkFile,
-    `File ${o.filename} does not appear to be a valid binary .kvk file; this may be an old package that includes an xml-format .kvk file. `+
-    `You must update the package to include the compiled .kvk file in the package.`);
   static WARN_FileIsNotABinaryKvkFile = SevWarn | 0x0005;
+  static Warn_FileIsNotABinaryKvkFile = (o:{filename: string}) => m(this.WARN_FileIsNotABinaryKvkFile,
+    `File ${def(o.filename)} does not appear to be a valid binary .kvk file; this may be an old package that includes an xml-format .kvk file. `+
+    `You must update the package to include the compiled .kvk file in the package.`);
 
+  static ERROR_FollowKeyboardVersionNotAllowedForModelPackages = SevError | 0x0006;
   static Error_FollowKeyboardVersionNotAllowedForModelPackages = () => m(this.ERROR_FollowKeyboardVersionNotAllowedForModelPackages,
     `FollowKeyboardVersion is not allowed in model packages`);
-  static ERROR_FollowKeyboardVersionNotAllowedForModelPackages = SevError | 0x0006;
 
+  static ERROR_FollowKeyboardVersionButNoKeyboards = SevError | 0x0007;
   static Error_FollowKeyboardVersionButNoKeyboards = () => m(this.ERROR_FollowKeyboardVersionButNoKeyboards,
     `FollowKeyboardVersion is set, but the package contains no keyboards`);
-  static ERROR_FollowKeyboardVersionButNoKeyboards = SevError | 0x0007;
 
-  static Error_KeyboardContentFileNotFound = (o:{id:string}) => m(this.ERROR_KeyboardContentFileNotFound,
-    `Keyboard ${o.id} was listed in <Keyboards> but a corresponding .kmx file was not found in <Files>`);
   static ERROR_KeyboardContentFileNotFound = SevError | 0x0008;
+  static Error_KeyboardContentFileNotFound = (o:{id:string}) => m(this.ERROR_KeyboardContentFileNotFound,
+    `Keyboard ${def(o.id)} was listed in <Keyboards> but a corresponding .kmx file was not found in <Files>`);
 
-  static Error_KeyboardFileNotValid = (o:{filename:string, e:any}) => m(this.ERROR_KeyboardFileNotValid,
-    `Keyboard file ${o.filename} is not a valid .kmx file: ${(o.e ?? 'unknown error').toString()}`);
   static ERROR_KeyboardFileNotValid = SevError | 0x0009;
+  static Error_KeyboardFileNotValid = (o:{filename:string, e:any}) => m(this.ERROR_KeyboardFileNotValid,
+    `Keyboard file ${def(o.filename)} is not a valid .kmx file: ${(o.e ?? 'unknown error').toString()}`);
 
-  static Info_KeyboardFileHasNoKeyboardVersion = (o:{filename:string}) => m(this.INFO_KeyboardFileHasNoKeyboardVersion,
-    `Keyboard file ${o.filename} has no &KeyboardVersion store, using default '0.0'`);
   static INFO_KeyboardFileHasNoKeyboardVersion = SevInfo | 0x000A;
+  static Info_KeyboardFileHasNoKeyboardVersion = (o:{filename:string}) => m(this.INFO_KeyboardFileHasNoKeyboardVersion,
+    `Keyboard file ${def(o.filename)} has no &KeyboardVersion store, using default '0.0'`);
 
+  static ERROR_PackageCannotContainBothModelsAndKeyboards = SevError | 0x000B;
   static Error_PackageCannotContainBothModelsAndKeyboards = () => m(this.ERROR_PackageCannotContainBothModelsAndKeyboards,
     `The package contains both lexical models and keyboards, which is not permitted.`);
-  static ERROR_PackageCannotContainBothModelsAndKeyboards = SevError | 0x000B;
 
-  static Hint_PackageShouldNotRepeatLanguages = (o:{resourceType: string, id: string, minimalTag: string, firstTag: string, secondTag: string}) => m(this.HINT_PackageShouldNotRepeatLanguages,
-    `Two language tags in ${o.resourceType} ${o.id}, '${o.firstTag}' and '${o.secondTag}', reduce to the same minimal tag '${o.minimalTag}'.`);
   static HINT_PackageShouldNotRepeatLanguages = SevHint | 0x000C;
+  static Hint_PackageShouldNotRepeatLanguages = (o:{resourceType: string, id: string, minimalTag: string, firstTag: string, secondTag: string}) => m(this.HINT_PackageShouldNotRepeatLanguages,
+    `Two language tags in ${def(o.resourceType)} ${def(o.id)}, '${def(o.firstTag)}' and '${def(o.secondTag)}', reduce to the same minimal tag '${def(o.minimalTag)}'.`);
 
+  static WARN_PackageNameDoesNotFollowLexicalModelConventions = SevWarn | 0x000D;
   static Warn_PackageNameDoesNotFollowLexicalModelConventions = (o:{filename: string}) => m(this.WARN_PackageNameDoesNotFollowLexicalModelConventions,
-    `The package file ${o.filename} does not follow the recommended model filename conventions. The name should be all lower case, `+
+    `The package file ${def(o.filename)} does not follow the recommended model filename conventions. The name should be all lower case, `+
     `include only alphanumeric characters and underscore (_), not start with a digit, and should have the structure `+
     `<author>.<bcp47>.<uniq>.model.kps.`);
-  static WARN_PackageNameDoesNotFollowLexicalModelConventions = SevWarn | 0x000D;
 
-  static Warn_PackageNameDoesNotFollowKeyboardConventions = (o:{filename: string}) => m(this.WARN_PackageNameDoesNotFollowKeyboardConventions,
-    `The package file ${o.filename} does not follow the recommended keyboard filename conventions. The name should be all lower case, `+
-    `include only alphanumeric characters and underscore (_), and not start with a digit.`);
   static WARN_PackageNameDoesNotFollowKeyboardConventions = SevWarn | 0x000E;
+  static Warn_PackageNameDoesNotFollowKeyboardConventions = (o:{filename: string}) => m(this.WARN_PackageNameDoesNotFollowKeyboardConventions,
+    `The package file ${def(o.filename)} does not follow the recommended keyboard filename conventions. The name should be all lower case, `+
+    `include only alphanumeric characters and underscore (_), and not start with a digit.`);
 
-  static Warn_FileInPackageDoesNotFollowFilenameConventions = (o:{filename: string}) => m(this.WARN_FileInPackageDoesNotFollowFilenameConventions,
-    `The file ${o.filename} does not follow the recommended filename conventions. The extension should be all lower case, `+
-    `and the filename should include only alphanumeric characters, -, _, + and .`);
   static WARN_FileInPackageDoesNotFollowFilenameConventions = SevWarn | 0x000F;
+  static Warn_FileInPackageDoesNotFollowFilenameConventions = (o:{filename: string}) => m(this.WARN_FileInPackageDoesNotFollowFilenameConventions,
+    `The file ${def(o.filename)} does not follow the recommended filename conventions. The extension should be all lower case, `+
+    `and the filename should include only alphanumeric characters, -, _, + and .`);
 
+  static ERROR_PackageNameCannotBeBlank = SevError | 0x0010;
   static Error_PackageNameCannotBeBlank = () => m(this.ERROR_PackageNameCannotBeBlank,
     `Package name cannot be an empty string.`);
-  static ERROR_PackageNameCannotBeBlank = SevError | 0x0010;
 
-  static Error_KeyboardFileNotFound = (o:{filename:string}) => m(this.ERROR_KeyboardFileNotFound,
-    `Keyboard file ${o.filename} was not found. Has it been compiled?`);
   static ERROR_KeyboardFileNotFound = SevError | 0x0011;
+  static Error_KeyboardFileNotFound = (o:{filename:string}) => m(this.ERROR_KeyboardFileNotFound,
+    `Keyboard file ${def(o.filename)} was not found. Has it been compiled?`);
 
-  static Warn_KeyboardVersionsDoNotMatch = (o: {keyboard:string, version:string, firstKeyboard:string, firstVersion:string}) => m(this.WARN_KeyboardVersionsDoNotMatch,
-    `Keyboard ${o.keyboard} version ${o.version} does not match keyboard ${o.firstKeyboard} version ${o.firstVersion}.`);
   static WARN_KeyboardVersionsDoNotMatch = SevWarn | 0x0012;
+  static Warn_KeyboardVersionsDoNotMatch = (o: {keyboard:string, version:string, firstKeyboard:string, firstVersion:string}) => m(this.WARN_KeyboardVersionsDoNotMatch,
+    `Keyboard ${def(o.keyboard)} version ${def(o.version)} does not match keyboard ${def(o.firstKeyboard)} version ${def(o.firstVersion)}.`);
 
   // 0x0013 was WARN_KeyboardVersionsDoNotMatchPackageVersion
 
-  static Error_LanguageTagIsNotValid = (o: {resourceType: string, id:string, lang:string, e:any}) => m(this.ERROR_LanguageTagIsNotValid,
-    `Language tag '${o.lang}' in ${o.resourceType} ${o.id} is invalid.`);
   static ERROR_LanguageTagIsNotValid = SevError | 0x0014;
+  static Error_LanguageTagIsNotValid = (o: {resourceType: string, id:string, lang:string, e:any}) => m(this.ERROR_LanguageTagIsNotValid,
+    `Language tag '${def(o.lang)}' in ${def(o.resourceType)} ${def(o.id)} is invalid.`);
 
-  static Hint_LanguageTagIsNotMinimal = (o: {resourceType: string, id:string, actual:string, expected:string}) => m(this.HINT_LanguageTagIsNotMinimal,
-    `Language tag '${o.actual}' in ${o.resourceType} ${o.id} is not minimal, and should be '${o.expected}'.`);
   static HINT_LanguageTagIsNotMinimal = SevHint | 0x0015;
+  static Hint_LanguageTagIsNotMinimal = (o: {resourceType: string, id:string, actual:string, expected:string}) => m(this.HINT_LanguageTagIsNotMinimal,
+    `Language tag '${def(o.actual)}' in ${def(o.resourceType)} ${def(o.id)} is not minimal, and should be '${def(o.expected)}'.`);
 
-  static Error_ModelMustHaveAtLeastOneLanguage = (o:{id:string}) => m(this.ERROR_ModelMustHaveAtLeastOneLanguage,
-    `The lexical model ${o.id} must have at least one language specified.`);
   static ERROR_ModelMustHaveAtLeastOneLanguage = SevError | 0x0016;
+  static Error_ModelMustHaveAtLeastOneLanguage = (o:{id:string}) => m(this.ERROR_ModelMustHaveAtLeastOneLanguage,
+    `The lexical model ${def(o.id)} must have at least one language specified.`);
 
-  static Warn_RedistFileShouldNotBeInPackage = (o:{filename:string}) => m(this.WARN_RedistFileShouldNotBeInPackage,
-    `The Keyman system file '${o.filename}' should not be compiled into the package.`);
   static WARN_RedistFileShouldNotBeInPackage = SevWarn | 0x0017;
+  static Warn_RedistFileShouldNotBeInPackage = (o:{filename:string}) => m(this.WARN_RedistFileShouldNotBeInPackage,
+    `The Keyman system file '${def(o.filename)}' should not be compiled into the package.`);
 
-  static Warn_DocFileDangerous = (o:{filename:string}) => m(this.WARN_DocFileDangerous,
-    `Microsoft Word .doc or .docx files ('${o.filename}') are not portable. You should instead use HTML or PDF format.`);
   static WARN_DocFileDangerous = SevWarn | 0x0018;
+  static Warn_DocFileDangerous = (o:{filename:string}) => m(this.WARN_DocFileDangerous,
+    `Microsoft Word .doc or .docx files ('${def(o.filename)}') are not portable. You should instead use HTML or PDF format.`);
 
+  static ERROR_PackageMustContainAModelOrAKeyboard = SevError | 0x0019;
   static Error_PackageMustContainAModelOrAKeyboard = () => m(this.ERROR_PackageMustContainAModelOrAKeyboard,
     `Package must contain a lexical model or a keyboard.`);
-  static ERROR_PackageMustContainAModelOrAKeyboard = SevError | 0x0019;
 
-  static Warn_JsKeyboardFileIsMissing = (o:{id: string}) => m(this.WARN_JsKeyboardFileIsMissing,
-    `Keyboard ${o.id} targets touch devices but corresponding ${o.id}.js file is not in the package.`);
   static WARN_JsKeyboardFileIsMissing = SevWarn | 0x001A;
+  static Warn_JsKeyboardFileIsMissing = (o:{id: string}) => m(this.WARN_JsKeyboardFileIsMissing,
+    `Keyboard ${def(o.id)} targets touch devices but corresponding ${def(o.id)}.js file is not in the package.`);
 
-  static Warn_KeyboardShouldHaveAtLeastOneLanguage = (o:{id:string}) => m(this.WARN_KeyboardShouldHaveAtLeastOneLanguage,
-    `The keyboard ${o.id} should have at least one language specified.`);
   static WARN_KeyboardShouldHaveAtLeastOneLanguage = SevWarn | 0x001B;
+  static Warn_KeyboardShouldHaveAtLeastOneLanguage = (o:{id:string}) => m(this.WARN_KeyboardShouldHaveAtLeastOneLanguage,
+    `The keyboard ${def(o.id)} should have at least one language specified.`);
 
-  static Hint_JsKeyboardFileHasNoTouchTargets = (o:{id:string}) => m(this.HINT_JsKeyboardFileHasNoTouchTargets,
-    `The keyboard ${o.id} has been included for touch platforms, but does not include a touch layout.`);
   static HINT_JsKeyboardFileHasNoTouchTargets = SevHint | 0x001C;
+  static Hint_JsKeyboardFileHasNoTouchTargets = (o:{id:string}) => m(this.HINT_JsKeyboardFileHasNoTouchTargets,
+    `The keyboard ${def(o.id)} has been included for touch platforms, but does not include a touch layout.`);
 
-  static Hint_PackageContainsSourceFile = (o:{filename:string}) => m(this.HINT_PackageContainsSourceFile,
-    `The source file ${o.filename} should not be included in the package; instead include the compiled result.`);
   static HINT_PackageContainsSourceFile = SevHint | 0x001D;
+  static Hint_PackageContainsSourceFile = (o:{filename:string}) => m(this.HINT_PackageContainsSourceFile,
+    `The source file ${def(o.filename)} should not be included in the package; instead include the compiled result.`);
 
+  static ERROR_InvalidPackageFile = SevError | 0x001E;
   static Error_InvalidPackageFile = (o:{e:any}) => m(this.ERROR_InvalidPackageFile,
     `Package source file is invalid: ${(o.e ?? 'unknown error').toString()}`);
-  static ERROR_InvalidPackageFile = SevError | 0x001E;
 }
 

--- a/developer/src/kmc/src/messages/infrastructureMessages.ts
+++ b/developer/src/kmc/src/messages/infrastructureMessages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.Infrastructure;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -8,108 +8,108 @@ const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
 export class InfrastructureMessages {
-  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   static FATAL_UnexpectedException = SevFatal | 0x0001;
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
 
   // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
-  static Info_BuildingFile = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_BuildingFile,
-    `Building ${o.relativeFilename}`)});
   static INFO_BuildingFile = SevInfo | 0x0002;
+  static Info_BuildingFile = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_BuildingFile,
+    `Building ${def(o.relativeFilename)}`)});
 
-  static Error_FileDoesNotExist = (o:{filename:string}) => m(this.ERROR_FileDoesNotExist,
-    `File ${o.filename} does not exist`);
   static ERROR_FileDoesNotExist = SevError | 0x0003;
+  static Error_FileDoesNotExist = (o:{filename:string}) => m(this.ERROR_FileDoesNotExist,
+    `File ${def(o.filename)} does not exist`);
 
-  static Error_FileTypeNotRecognized = (o:{filename: string, extensions: string}) => m(this.ERROR_FileTypeNotRecognized,
-    `Unrecognised input file ${o.filename}, expecting ${o.extensions}, or project folder`);
   static ERROR_FileTypeNotRecognized = SevError | 0x0004;
+  static Error_FileTypeNotRecognized = (o:{filename: string, extensions: string}) => m(this.ERROR_FileTypeNotRecognized,
+    `Unrecognised input file ${def(o.filename)}, expecting ${def(o.extensions)}, or project folder`);
 
+  static ERROR_OutFileNotValidForProjects = SevError | 0x0005;
   static Error_OutFileNotValidForProjects = () => m(this.ERROR_OutFileNotValidForProjects,
     `--out-file should not be specified for project builds`);
-  static ERROR_OutFileNotValidForProjects = SevError | 0x0005;
 
   // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
-  static Info_FileBuiltSuccessfully = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_FileBuiltSuccessfully,
-    `${o.relativeFilename} built successfully.`)});
   static INFO_FileBuiltSuccessfully = SevInfo | 0x0006;
+  static Info_FileBuiltSuccessfully = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_FileBuiltSuccessfully,
+    `${def(o.relativeFilename)} built successfully.`)});
 
   // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
-  static Info_FileNotBuiltSuccessfully = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_FileNotBuiltSuccessfully,
-    `${o.relativeFilename} failed to build.`)});
   static INFO_FileNotBuiltSuccessfully = SevInfo | 0x0007;
+  static Info_FileNotBuiltSuccessfully = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_FileNotBuiltSuccessfully,
+    `${def(o.relativeFilename)} failed to build.`)});
 
-  static Error_InvalidProjectFile = (o:{message:string}) => m(this.ERROR_InvalidProjectFile,
-    `Project file is not valid: ${o.message}`);
   static ERROR_InvalidProjectFile = SevError | 0x0008;
+  static Error_InvalidProjectFile = (o:{message:string}) => m(this.ERROR_InvalidProjectFile,
+    `Project file is not valid: ${def(o.message)}`);
 
-  static Hint_FilenameHasDifferingCase = (o:{reference:string, filename:string}) => m(this.HINT_FilenameHasDifferingCase,
-    `File on disk '${o.filename}' does not match case of '${o.reference}' in source file; this is an error on platforms with case-sensitive filesystems.`);
   static HINT_FilenameHasDifferingCase = SevHint | 0x0009;
+  static Hint_FilenameHasDifferingCase = (o:{reference:string, filename:string}) => m(this.HINT_FilenameHasDifferingCase,
+    `File on disk '${def(o.filename)}' does not match case of '${def(o.reference)}' in source file; this is an error on platforms with case-sensitive filesystems.`);
 
-  static Error_UnknownFileFormat = (o:{format:string}) => m(this.ERROR_UnknownFileFormat,
-    `Unknown file format ${o.format}; only Markdown (.md), JSON (.json), and Text (.txt) are supported.`);
   static ERROR_UnknownFileFormat = SevError | 0x000A;
+  static Error_UnknownFileFormat = (o:{format:string}) => m(this.ERROR_UnknownFileFormat,
+    `Unknown file format ${def(o.format)}; only Markdown (.md), JSON (.json), and Text (.txt) are supported.`);
 
   // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
-  static Info_ProjectBuiltSuccessfully = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_ProjectBuiltSuccessfully,
-    `Project ${o.relativeFilename} built successfully.`)});
   static INFO_ProjectBuiltSuccessfully = SevInfo | 0x000B;
+  static Info_ProjectBuiltSuccessfully = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_ProjectBuiltSuccessfully,
+    `Project ${def(o.relativeFilename)} built successfully.`)});
 
   // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
-  static Info_ProjectNotBuiltSuccessfully = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_ProjectNotBuiltSuccessfully,
-    `Project ${o.relativeFilename} failed to build.`)});
   static INFO_ProjectNotBuiltSuccessfully = SevInfo | 0x000C;
+  static Info_ProjectNotBuiltSuccessfully = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_ProjectNotBuiltSuccessfully,
+    `Project ${def(o.relativeFilename)} failed to build.`)});
 
-  static Info_TooManyMessages = (o:{count:number}) => m(this.INFO_TooManyMessages,
-    `More than ${o.count} warnings or errors received; suppressing further messages.`);
   static INFO_TooManyMessages = SevInfo | 0x000D;
+  static Info_TooManyMessages = (o:{count:number}) => m(this.INFO_TooManyMessages,
+    `More than ${def(o.count)} warnings or errors received; suppressing further messages.`);
 
-  static Error_FileTypeNotFound = (o:{ext:string}) => m(this.ERROR_FileTypeNotFound,
-    `A file of type ${o.ext} was not found in the project.`);
   static ERROR_FileTypeNotFound = SevError | 0x000E;
+  static Error_FileTypeNotFound = (o:{ext:string}) => m(this.ERROR_FileTypeNotFound,
+    `A file of type ${def(o.ext)} was not found in the project.`);
 
-  static Error_NotAProjectFile = (o:{filename:string}) => m(this.ERROR_NotAProjectFile,
-    `File ${o.filename} must have a .kpj extension to be treated as a project.`);
   static ERROR_NotAProjectFile = SevError | 0x000F;
+  static Error_NotAProjectFile = (o:{filename:string}) => m(this.ERROR_NotAProjectFile,
+    `File ${def(o.filename)} must have a .kpj extension to be treated as a project.`);
 
+  static INFO_WarningsHaveFailedBuild = SevInfo | 0x0010;
   static Info_WarningsHaveFailedBuild = () => m(this.INFO_WarningsHaveFailedBuild,
     `The build failed because option "treat warnings as errors" is enabled and there are one or more warnings.`);
-  static INFO_WarningsHaveFailedBuild = SevInfo | 0x0010;
 
-  static Error_CannotCreateFolder = (o:{folderName:string, e: any}) => CompilerMessageSpecWithException(this.ERROR_CannotCreateFolder, null,
-    `Unable to create folder ${o.folderName}: ${o.e ?? 'unknown error'}`);
   static ERROR_CannotCreateFolder = SevError | 0x0011;
+  static Error_CannotCreateFolder = (o:{folderName:string, e: any}) => CompilerMessageSpecWithException(this.ERROR_CannotCreateFolder, null,
+    `Unable to create folder ${def(o.folderName)}: ${o.e ?? 'unknown error'}`);
 
-  static Error_InvalidProjectFolder = (o:{folderName:string}) => m(this.ERROR_InvalidProjectFolder,
-    `The folder ${o.folderName} does not appear to be a Keyman Developer project.`);
   static ERROR_InvalidProjectFolder = SevError | 0x0012;
+  static Error_InvalidProjectFolder = (o:{folderName:string}) => m(this.ERROR_InvalidProjectFolder,
+    `The folder ${def(o.folderName)} does not appear to be a Keyman Developer project.`);
 
-  static Error_UnsupportedProjectVersion = (o:{version:string}) => m(this.ERROR_UnsupportedProjectVersion,
-    `Project version ${o.version} is not supported by this version of Keyman Developer.`);
   static ERROR_UnsupportedProjectVersion = SevError | 0x0013;
+  static Error_UnsupportedProjectVersion = (o:{version:string}) => m(this.ERROR_UnsupportedProjectVersion,
+    `Project version ${def(o.version)} is not supported by this version of Keyman Developer.`);
 
+  static HINT_ProjectIsVersion10 = SevHint | 0x0014;
   static Hint_ProjectIsVersion10 = () => m(this.HINT_ProjectIsVersion10,
     `The project file is an older version and can be upgraded to version 17.0`);
-  static HINT_ProjectIsVersion10 = SevHint | 0x0014;
 
+  static ERROR_OutFileCanOnlyBeSpecifiedWithSingleInfile = SevError | 0x0015;
   static Error_OutFileCanOnlyBeSpecifiedWithSingleInfile = () => m(this.ERROR_OutFileCanOnlyBeSpecifiedWithSingleInfile,
     `Parameter --out-file can only be used with a single input file.`);
-  static ERROR_OutFileCanOnlyBeSpecifiedWithSingleInfile = SevError | 0x0015;
 
-  static Error_InvalidMessageFormat = (o:{message:string}) => m(this.ERROR_InvalidMessageFormat,
-    `Invalid parameter: --message ${o.message} must match format '[KM]#####[:Disable|Info|Hint|Warn|Error]'`);
   static ERROR_InvalidMessageFormat = SevError | 0x0016;
+  static Error_InvalidMessageFormat = (o:{message:string}) => m(this.ERROR_InvalidMessageFormat,
+    `Invalid parameter: --message ${def(o.message)} must match format '[KM]#####[:Disable|Info|Hint|Warn|Error]'`);
 
-  static Error_MessageNamespaceNotFound = (o:{code: number}) => m(this.ERROR_MessageNamespaceNotFound,
-    `Invalid parameter: --message KM${o.code?.toString(16)} does not have a recognized namespace`);
   static ERROR_MessageNamespaceNotFound = SevError | 0x0017;
+  static Error_MessageNamespaceNotFound = (o:{code: number}) => m(this.ERROR_MessageNamespaceNotFound,
+    `Invalid parameter: --message KM${def(o.code?.toString(16))} does not have a recognized namespace`);
 
-  static Error_MessageCodeNotFound = (o:{code: number}) => m(this.ERROR_MessageCodeNotFound,
-    `Invalid parameter: --message KM${o.code?.toString(16)} is not a recognized code`);
   static ERROR_MessageCodeNotFound = SevError | 0x0018;
+  static Error_MessageCodeNotFound = (o:{code: number}) => m(this.ERROR_MessageCodeNotFound,
+    `Invalid parameter: --message KM${def(o.code?.toString(16))} is not a recognized code`);
 
-  static Error_MessageCannotBeCoerced = (o:{code: number}) => m(this.ERROR_MessageCannotBeCoerced,
-    `Invalid parameter: --message KM${o.code?.toString(16)} is not a info, hint or warn message type and cannot be coerced`);
   static ERROR_MessageCannotBeCoerced = SevError | 0x0019;
+  static Error_MessageCannotBeCoerced = (o:{code: number}) => m(this.ERROR_MessageCannotBeCoerced,
+    `Invalid parameter: --message KM${def(o.code?.toString(16))} is not a info, hint or warn message type and cannot be coerced`);
 }
 

--- a/developer/src/kmc/src/messages/infrastructureMessages.ts
+++ b/developer/src/kmc/src/messages/infrastructureMessages.ts
@@ -1,4 +1,4 @@
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m } from "@keymanapp/common-types";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 
 const Namespace = CompilerErrorNamespace.Infrastructure;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -8,7 +8,7 @@ const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
 export class InfrastructureMessages {
-  static Fatal_UnexpectedException = (o:{e: any}) => m(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
+  static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
   static FATAL_UnexpectedException = SevFatal | 0x0001;
 
   // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
@@ -76,7 +76,7 @@ export class InfrastructureMessages {
     `The build failed because option "treat warnings as errors" is enabled and there are one or more warnings.`);
   static INFO_WarningsHaveFailedBuild = SevInfo | 0x0010;
 
-  static Error_CannotCreateFolder = (o:{folderName:string, e: any}) => m(this.ERROR_CannotCreateFolder, null,
+  static Error_CannotCreateFolder = (o:{folderName:string, e: any}) => CompilerMessageSpecWithException(this.ERROR_CannotCreateFolder, null,
     `Unable to create folder ${o.folderName}: ${o.e ?? 'unknown error'}`);
   static ERROR_CannotCreateFolder = SevError | 0x0011;
 


### PR DESCRIPTION
Relates to #10207.

A bit embarrassed to be doing this much refactoring during beta, but it's targeted and does not change the API surfaces. These changes will make it easier to fully document the compiler messages.

In order to include message detail in messages, it is helpful to split out the exception messages which have a separate parameter, so that parameter at the same position can be the message detail.

Introduces the CompilerMessageSpecWithException function which takes an exceptionVar parameter to achieve this differentiation.

Moved the ERROR_Message line above the Error_Message line for every message in the compiler message files, as it makes the grouping clearer once we start adding message details. For example, see the start of the KmnCompilerMessages class.

Also wraps potentially-undefined parameters to the messages with a new function `def`, shorthand for `CompilerMessageDef`, which converts the parameter to '<param>' if it is undefined, which is helpful for documentation.

Next up: the actual documentation generation functions!

@keymanapp-test-bot skip