### PR TITLE
fix(linux): Fix libkeymancore-dev dependencies

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,9 @@
+keyman (17.0.274-2) UNRELEASED; urgency=medium
+
+  * Add libicu-dev dependency to libkeymancore-dev (closes: #1064915)
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 28 Feb 2024 17:54:58 +0100
+
 keyman (17.0.274-1) unstable; urgency=medium
 
   * Fix autopkg tests

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -111,6 +111,7 @@ Package: libkeymancore-dev
 Architecture: amd64 arm64 armel armhf i386 loong64 mipsel mips64el ppc64el riscv64
 Section: libdevel
 Depends:
+ libicu-dev,
  libkeymancore1 (= ${binary:Version}),
  ${misc:Depends},
 Conflicts: libkmnkbp-dev

--- a/linux/debian/tests/control
+++ b/linux/debian/tests/control
@@ -1,6 +1,5 @@
 Tests: test-build
 Depends: @,
  build-essential,
- libicu-dev,
  pkg-config,
 Architecture: amd64 arm64 armel armhf i386 loong64 mips64el mipsel ppc64el riscv64

--- a/linux/debian/tests/test-build
+++ b/linux/debian/tests/test-build
@@ -6,25 +6,69 @@
 set -e
 
 WORKDIR=$(mktemp -d)
-trap "rm -rf $WORKDIR" 0 INT QUIT ABRT PIPE TERM
-cd "$WORKDIR"
+# shellcheck disable=SC2064
+trap "rm -rf ${WORKDIR}" 0 INT QUIT ABRT PIPE TERM
+cd "${WORKDIR}"
 
+#
 # Test all include files are available
 cat <<EOF > keymantest.c
 #include <keyman/keyman_core_api.h>
-km_core_actions* c;
+km_core_actions* a;
 EOF
 
-# shellcheck disable=SC2046
+# shellcheck disable=SC2046 disable=SC2312
 gcc -c keymantest.c $(pkg-config --cflags --libs keyman_core)
 echo "build 1: OK"
 
+#
 # Test pkg-config file - include without path
 cat <<EOF > keymantest.c
 #include <keyman_core_api.h>
-km_core_actions* c;
+km_core_actions* a;
 EOF
 
-# shellcheck disable=SC2046
+# shellcheck disable=SC2046 disable=SC2312
 gcc -c keymantest.c $(pkg-config --cflags --libs keyman_core)
 echo "build 2: OK"
+
+#
+# Test dynamic linking
+cat <<EOF > keymantest.c
+#include <keyman/keyman_core_api.h>
+
+int main(int argc, char *argv[]) {
+  km_core_option_item opts[] = {KM_CORE_OPTIONS_END};
+  km_core_keyboard *kb = NULL;
+  km_core_state *state = NULL;
+  km_core_keyboard_load(NULL, &kb);
+  km_core_state_create(kb, opts, &state);
+  km_core_actions const *a = km_core_state_get_actions(state);
+}
+EOF
+
+# shellcheck disable=SC2046 disable=SC2312
+g++ keymantest.c $(pkg-config --cflags --libs keyman_core)
+echo "build 3: OK"
+
+# It would be nice to test static linking, but that results in a warning
+# which causes autopkgtest to report the tests as FAILED. See #10882.
+# #
+# # Test static linking
+# cat <<EOF > keymantest.c
+# #include <keyman/keyman_core_api.h>
+
+# int main(int argc, char *argv[]) {
+#   km_core_option_item opts[] = {KM_CORE_OPTIONS_END};
+#   km_core_keyboard *kb = NULL;
+#   km_core_state *state = NULL;
+#   km_core_keyboard_load(NULL, &kb);
+#   km_core_state_create(kb, opts, &state);
+#   km_core_actions const *a = km_core_state_get_actions(state);
+# }
+# EOF
+
+# # shellcheck disable=SC2046 disable=SC2312
+# g++ keymantest.c -static $(pkg-config --cflags --libs keyman_core) \
+#   $(pkg-config --cflags --libs icu-uc) $(pkg-config --cflags --libs icu-i18n)
+# echo "build 4: OK"


### PR DESCRIPTION
This change adds `libicu-dev` as a dependency for `libkeymancore-dev`. While it is possible to dynamically build without ICU it is required when doing a static build.

Closes #10864 and [Debian bug #1064915](
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1064915).

@keymanapp-test-bot skip