### PR TITLE
fix(android): handle surrogate pairs in selection range indexing

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -168,10 +168,12 @@ final class KMKeyboard extends WebView {
     InputConnection ic = KMManager.getInputConnection(this.keyboardType);
     if (ic != null) {
       ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
-      String rawText = icText.text.toString();
-      if (icText != null) {
-        updateText(rawText.toString());
+      if (icText == null) {
+        return false;
       }
+
+      String rawText = icText.text.toString();
+      updateText(rawText.toString());
 
       /*
         The values of selStart & selEnd provided by the system are in code units,


### PR DESCRIPTION
Fixes [an issue](https://github.com/keymanapp/keyman/pull/10873#issuecomment-1968522738) noted while validating #10873.

This change prevents backspaces and context-deletions from keyboard rules from mishandling the context after moving the text insertion point and/or selecting text.

Recent changes to the codebase have resulted in a need to consistently specify selection ranges with non-BMP indexing.  #10662 recognized the need to keep non-BMP processing enabled as part of a different Android bug fix, and #10728 took things a bit further (for iOS) while further validating this position.  Until now... we missed that Android was actually specifying the selection range with code _unit_ (BMP) indexing, which does not account for surrogate pairs.

## User Testing 

TEST_POST_EMOJI_ROTATION:   

1. Go to https://jahorton.github.io/ and download the [test_robust_deletions.kmp](https://jahorton.github.io/test_robust_deletions.kmp) package.
    Alternatively, scan this QR code for the package:

    ![QR code](https://github.com/keymanapp/keyman/assets/25213402/14f26a3e-6e0a-4881-91fe-302532e4879d)
2. Enable Keyman as system keyboard.
3. Open the device's primary mail app (gmail).  If prompted, attempt to sign in with a Gmail account.
    - Note:  you don't need to _actually_ sign in, though.  The "Sign in" prompt itself is a perfect test target!
4. Type **just one** of the emoji keys **4** times.  (Do _not_ exceed 7.)
5. Type `ggg`.
6. Select `ggg` and hit backspace to delete it.
7. Type `p` once, then continue typing it to verify that 'p' correctly rotates as follows, without affecting any other pre-existing text:
        - 'p' will rotate through: `p`, `ṗ`, `p̂`, `p̂p̂`, `p`, ...
        - The number of code points are: 1, 2, 2, 4, 1, ...
        - One backspace should delete one codepoint; therefore, to delete `p̂p̂` completely should take 4 backspaces.