### PR TITLE
refactor(android/app): Move storage permission checks

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -5,8 +5,12 @@
   <!-- Keyman Engine removes INTERNET permission, so add it back -->
   <uses-permission android:name="android.permission.INTERNET" tools:node="replace" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.VIBRATE" />
+
+  <!-- Devices running up to Android 12L
+       Starting in API level 33, this permission has no effect:
+       https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE -->
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
 
   <!-- Ideally we would declare this permission so we can get other installed keyboard names.
   But would involve a long review process with the Play Store:

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/CheckPermissions.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/CheckPermissions.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2024 SIL International
+ */
+package com.tavultesoft.kmapro;
+
+import static com.tavultesoft.kmapro.MainActivity.PERMISSION_REQUEST_STORAGE;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Environment;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+public class CheckPermissions {
+
+  public static boolean isPermissionOK(Activity activity) {
+    boolean permissionsOK = true;
+
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return permissionsOK;
+    }
+
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
+      permissionsOK = Environment.isExternalStorageManager();
+      if (Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU) {
+        // TODO: Workout scoped storage permission #10659
+      }
+    } else {
+      permissionsOK = checkPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    }
+
+    return permissionsOK;
+  }
+
+  public static boolean checkPermission(Activity activity, String permission) {
+    return ContextCompat.checkSelfPermission(activity.getApplicationContext(), permission) == PackageManager.PERMISSION_GRANTED;
+  }
+
+  public static void requestPermission (Activity activity, Context context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      // Need to request multiple permissions at once
+      // TODO: request multiple permissions at once #10659
+      showPermissionDenied(context);
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      // TODO: find alternative to below. #10659
+      // It works, but would need Play Store approval
+      // For now, show permission denied
+      showPermissionDenied(context);
+      /*
+      try {
+        Intent intent = new Intent();
+        intent.setAction(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
+        Uri uri = Uri.fromParts("package", activity.getPackageName(), null);
+        intent.setData(uri);
+        activity.startActivity(intent);
+      } catch (Exception e) {
+        Intent intent = new Intent();
+        intent.setAction(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
+        activity.startActivity(intent);
+      }
+       */
+    } else if (ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+      // Provide additional rationale to the user if the permission was not granted
+      String message = activity.getApplicationContext().getString(R.string.request_storage_permission);
+      Toast.makeText(activity.getApplicationContext(), message ,
+        Toast.LENGTH_LONG).show();
+      ActivityCompat.requestPermissions(activity,
+        new String[]{ Manifest.permission.READ_EXTERNAL_STORAGE },
+        PERMISSION_REQUEST_STORAGE);
+    } else {
+      // Request the permission. The result will be received in onRequestPermissionsResult().
+      ActivityCompat.requestPermissions(activity,
+        new String[]{ Manifest.permission.READ_EXTERNAL_STORAGE },
+        PERMISSION_REQUEST_STORAGE);
+    }
+  }
+
+  public static void showPermissionDenied(Context context) {
+    // Permission request denied
+    AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
+    dialogBuilder.setTitle(String.format(context.getString(R.string.title_add_keyboard)));
+    dialogBuilder.setMessage(String.format(context.getString(R.string.storage_permission_denied2)));
+    dialogBuilder.setPositiveButton(context.getString(R.string.label_ok), null);
+    AlertDialog dialog = dialogBuilder.create();
+    dialog.show();
+
+  }
+}

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -4,6 +4,8 @@
 
 package com.tavultesoft.kmapro;
 
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
@@ -50,11 +52,17 @@ import android.net.Uri;
 import android.net.Uri.Builder;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.Handler;
 import android.os.ParcelFileDescriptor;
 import android.os.Parcelable;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.widget.Toolbar;
 import androidx.appcompat.app.AlertDialog;
 import android.content.ClipData;
@@ -75,7 +83,9 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
+import android.provider.Settings;
 import android.text.Html;
 import android.util.Log;
 import android.util.TypedValue;
@@ -101,7 +111,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   public static Context context;
 
   // Fields used for installing kmp packages
-  private static final int PERMISSION_REQUEST_STORAGE = 0;
+  public static final int PERMISSION_REQUEST_STORAGE = 0;
   public static final int READ_REQUEST_CODE = 42;
 
   private static final String TAG = "MainActivity";
@@ -256,7 +266,12 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
         // file:// Chrome downloads and Filebrowsers
         case "content":
         case "file":
-          checkStoragePermission(loadingIntentUri);
+          requestPermissionIntentUri = loadingIntentUri;
+          if (CheckPermissions.isPermissionOK(this)) {
+            useLocalKMP(context, loadingIntentUri);
+          } else {
+            CheckPermissions.requestPermission(this, context);
+          }
           break;
         case "http" :
         case "https" :
@@ -784,51 +799,13 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     if (requestCode == PERMISSION_REQUEST_STORAGE) {
       // Request for storage permission
       if (grantResults.length == 1 &&
-          grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+          grantResults[0] == PERMISSION_GRANTED) {
         // Permission has been granted. Resume task needing this permission
         useLocalKMP(context, requestPermissionIntentUri);
       } else {
         // Permission request denied
-        String message = getString(R.string.storage_permission_denied);
-        Toast.makeText(getApplicationContext(), message,
-          Toast.LENGTH_SHORT).show();
+        CheckPermissions.showPermissionDenied(context);
       }
-    }
-  }
-
-  private void checkStoragePermission(Uri data) {
-    // Check if the Storage permission has been granted
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      if (checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-        useLocalKMP(context, data);
-      } else {
-        // Permission is missing and must be requested
-        requestPermissionIntentUri = data;
-        requestStoragePermission();
-      }
-    } else {
-      // Permission automatically granted on older Android versions
-      useLocalKMP(context, data);
-    }
-  }
-
-  /**
-   * Requests the {@link android.Manifest.permission#READ_EXTERNAL_STORAGE} permissions
-   */
-  private void requestStoragePermission() {
-    if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
-      // Provide additional rationale to the user if the permission was not granted
-      String message = getString(R.string.request_storage_permission);
-      Toast.makeText(getApplicationContext(), message ,
-        Toast.LENGTH_LONG).show();
-      ActivityCompat.requestPermissions(this,
-        new String[]{ Manifest.permission.READ_EXTERNAL_STORAGE },
-        PERMISSION_REQUEST_STORAGE);
-    } else {
-      // Request the permission. The result will be received in onRequestPermissionsResult().
-      ActivityCompat.requestPermissions(this,
-        new String[]{ Manifest.permission.READ_EXTERNAL_STORAGE },
-        PERMISSION_REQUEST_STORAGE);
     }
   }
 

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -92,6 +92,9 @@
   <string name="storage_permission_denied" comment="Keyboard package installation may fail since Android storage permission not granted">
     Storage permission request was denied. May fail to install keyboard package</string>
 
+  <string name="storage_permission_denied2" comment="Keyboard package installation failed. Recommend install from local file">
+    Storage permission request failed. Try Keyman Settings - Install from local file</string>
+
   <!-- Context: Keyman Settings menu -->
   <string name="keyman_settings" comment="Settings menu title">Settings</string>
 


### PR DESCRIPTION
Relates to #10659

Android keeps limiting how external storage permissions are granted, which breaks how we currently use READ_EXTERNAL_STORAGE 

Per the documentation,
> Starting in API level 33, this permission has no effect:
https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE

This PR refactors the current permission checks out of MainActivity. There's still remaining TODO's on getting them to work for Android 12.0+

For now, the alert prompt is updated to try installing the KMP from Keyman Settings - Install from local file

## User Testing
**Setup** - Install the PR build of Keyman for Android for the specified Android version on a device/emulator. For each test, also have downloaded khmer_angkor.kmp locally (usually in the Downloads folder). Download from https://downloads.keyman.com/keyboards/khmer_angkor/1.3/khmer_angkor.kmp

* **TEST_ANDROID_5** - Verifies no permission prompt needed
1. Do setup on an Android 5.0 (Lollipop) device.
2. On the test device, go to  the Downloads folder and select khmer_angkor.kmp
3. Verify Keyman gets launched and shows the keyboard installation wizard for khmer_angkor
4. Complete the installation and verify khmer_angkor.kmp is installed

* **TEST_ANDROID_28_ALLOWED** - Verifies kmp installs when permission granted
1. Do setup on an Android 9.0 (Pie) device
2. On the test device, go to  the Downloads folder and select khmer_angkor.kmp
3. Verify Keyman gets launched and prompts user to grant storage permission
![P request permission](https://github.com/keymanapp/keyman/assets/7358010/9fc7ba2f-65d9-4f12-9508-486230aaa844)
4. Click "Allow" and verify Keyman shows the keyboard installation wizard  for khmer_angkor
5. Complete the installation and verify khmer_angkor.kmp is installed

* **TEST_ANDROID_28_DENIED** - Verifies kmp fails to install when permission denied
1. Do setup on an Android 9.0 (Pie) device
2. On the test device, go to  the Downloads folder and select khmer_angkor.kmp
3. Verify Keyman gets launched and prompts user to grant storage permission
4. Click "Deny" and verify Keyman shows a prompt that permission is denied
![P permission denied](https://github.com/keymanapp/keyman/assets/7358010/3e3bf962-7266-422b-803d-460a79fb734d)
5. Click "OK" on the prompt and verify khmer_angkor is **not** installed

* **TEST_ANDROID_34_DENIED** - Verifies no storage prompt displayed and kmp only installs "from local file"
1. Do setup on an Android 14.0 (UpsideDownCake) device
2. On the test device, go to  the Downloads folder and select khmer_angkor.kmp
3. Verify Keyman gets launched and shows a prompt that permission is denied
4. Click "OK" on the prompt and verify Keyman shows khmer_angkor is **not** installed
5. From Keyman Settings --> Install Keyboard or Dictionary -> Install from Local File --> Browse to Downloads and select khmer_angkor
6. Verify Keyman shows the keyboard installation wizard for khmer_angkor
7. Complete the installation and verify khmer_angkor.kmp is installed.