### PR TITLE
fix(ios): cross-paragraph keyboard rules

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -389,7 +389,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       textDocumentProxy.deleteBackward()
       let newContext = textDocumentProxy.documentContextBeforeInput ?? ""
       let unitsDeleted = oldContext.utf16.count - newContext.utf16.count
-      let unitsInPoint = InputViewController.isSurrogate(oldContext.utf16.last!) ? 2 : 1
+      let unitsInPoint = InputViewController.isSurrogate(oldContext.utf16.last ?? 0) ? 2 : 1
 
       // This CAN happen when a surrogate pair is deleted.
       // For example, the emoji 👍🏻 is made of TWO surrogate pairs.
@@ -416,7 +416,6 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
           os_log("Failed to swallow a recent textDidChange call!", log: KeymanEngineLogger.ui, type: .default)
         }
         self.swallowBackspaceTextChange = true
-        break
       }
     }
 


### PR DESCRIPTION
Fixes #10761.

Turns out my concerns in that issue were well-founded; rules crossing a context-window boundary were not being properly applied.  Fortunately, it only takes a couple of small tweaks to fix that... as well as can be done under iOS constraints given 17.0.

Limitations:
- If a surrogate pair exists out-of-context that would be deleted by such a rule, an extra character will be deleted.
- If a combining character exists out-of-context that would be deleted by such a rule, an extra character will be deleted.

To "do better" would require us to track our own version of a context window manually on the iOS side that slides, rather than "jumping" upon a new paragraph start.  _**This**_ is only an idea at this stage, though; it's also certainly too big a project to tackle during the beta cycle.

Given these limitations, I'm not opposed to rejecting this PR at this time due to what is essentially an incomplete solution - those caveats may matter greatly for some scripts and/or languages.

## User Testing

TEST_CROSS_PARAGRAPH_RULES:  Use the provided specialized test keyboard to verify that the last a-z character is properly rotated by the "rota" key.

Specialized test keyboard:  https://jahorton.github.io/last_alphanumeric_rotater.kmp
Source: [last_alphanumeric_rotater.zip](https://github.com/keymanapp/keyman/files/14456112/last_alphanumeric_rotater.zip)
- [ ] Should this be added to `common/test/keyboards`?  (For desktop use, the 'rota' key is `K_BKSLASH`.)

![frame 2](https://github.com/keymanapp/keyman/assets/25213402/0e033f04-aa56-49c5-a710-21014534d2f4)

1. Install the test keyboard package.
2. With it installed, type 'a', then hit the ENTER key twice.
3. Tap the "rota" key repeatedly.  The original `a` should rotate to `b`, then `c`, etc until reaching `z`.  After `z`, it will return to `a`.
4. If any other effects occur, FAIL this test.