### PR TITLE
chore(developer): deploy compiler messages to help site

### DIFF
--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -32,7 +32,7 @@ builder_describe "Build Keyman Keyboard Compiler kmc" \
   "build                     (default) builds kmc to build/" \
   "clean                     cleans build/ folder" \
   "bundle                    creates a bundled version of kmc" \
-  "api                       analyze API and prepare API documentation (no-op for kmc)" \
+  "api                       prepare compiler error documentation" \
   "test                      run automated tests for kmc" \
   "pack                      build a local .tgz pack for testing (note: all npm modules in the repo will be packed by this script)" \
   "publish                   publish to npm (note: all npm modules in the repo will be published by this script)" \
@@ -70,6 +70,15 @@ if builder_start_action build; then
   tsc -b
   cp "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/unicode-license.txt" ./build/unicode-license.txt
   builder_finish_action success build
+fi
+
+#-------------------------------------------------------------------------------------------------------------------
+
+if builder_start_action api; then
+  rm -rf ./build/messages
+  mkdir -p ./build/messages
+  node . message --format markdown --out-path build/messages
+  builder_finish_action success api
 fi
 
 #-------------------------------------------------------------------------------------------------------------------

--- a/resources/build/help-keyman-com.sh
+++ b/resources/build/help-keyman-com.sh
@@ -29,13 +29,11 @@ shopt -s nullglob
 #
 
 if [ -z ${HELP_KEYMAN_COM+x} ]; then
-  >&2 echo "Not uploading documentation: must set HELP_KEYMAN_COM in environment."
-  exit 1
+  builder_die "Not uploading documentation: must set HELP_KEYMAN_COM in environment."
 fi
 
 if [ ! -d "$HELP_KEYMAN_COM/products/" ]; then
-  >&2 echo "HELP_KEYMAN_COM path ($HELP_KEYMAN_COM) does not appear to be valid."
-  exit 1
+  builder_die "HELP_KEYMAN_COM path ($HELP_KEYMAN_COM) does not appear to be valid."
 fi
 
 function display_usage {
@@ -47,43 +45,26 @@ function display_usage {
 }
 
 #
-# Define terminal colours
-#
-
-if [ -t 2 ]; then
-  t_red=$'\e[1;31m'
-  t_grn=$'\e[1;32m'
-  t_yel=$'\e[1;33m'
-  t_blu=$'\e[1;34m'
-  t_mag=$'\e[1;35m'
-  t_cyn=$'\e[1;36m'
-  t_end=$'\e[0m'
-fi
-
-#
 # Uploading Keyman documentation
 #
 
-## Determine the help.keyman.com product path based on $platform
-function help_product_path {
-  if [ $platform == 'ios' ]; then
-    echo "products/iphone-and-ipad/$VERSION_RELEASE"
-  elif [ $platform == 'developer' ]; then
-    # developer/17.0/reference/api -- we only publish Typescript APIs here at present
-    # and this would need to change for future deployment if we do more on this repo
-    echo "developer/$VERSION_RELEASE/reference/api"
-  else
-    echo "products/$platform/$VERSION_RELEASE"
-  fi
-}
+function upload {
+  local srcpath="$KEYMAN_ROOT/$1"
+  local dstpath="$HELP_KEYMAN_COM/$2"
 
-# Generate markdown help files
-function generate_markdown_help {
-  if [ $platform == 'linux' ]; then
-    pushd $KEYMAN_ROOT/linux/keyman-config > /dev/null
-    ./build.sh build
-    popd
+  #
+  # Look for help source folder.
+  #
+
+  if [[ ! -d "$srcpath" ]]; then
+    builder_die "Error: The source path $srcpath does not exist"
+    exit 1
   fi
+
+  rm -rf "$dstpath"
+  mkdir -p "$dstpath"
+
+  cp -rv "$srcpath"/* "$dstpath/"
 }
 
 ##
@@ -91,50 +72,34 @@ function generate_markdown_help {
 ## Paths depend on $platform
 ##
 function upload_keyman_help {
-
-  local helppath
-  local dstpath
-
   case $platform in
     android)
-      helppath=$KEYMAN_ROOT/android/help
+      upload android/help products/android/$VERSION_RELEASE
       ;;
     ios)
-      helppath=$KEYMAN_ROOT/ios/help
+      upload ios/help products/iphone-and-ipad/$VERSION_RELEASE
       ;;
     linux)
-      helppath=$KEYMAN_ROOT/linux/help
+      pushd "$KEYMAN_ROOT/linux/keyman-config" > /dev/null
+      ./build.sh build
+      popd > /dev/null
+      upload linux/help products/linux/$VERSION_RELEASE
       ;;
     mac)
-      helppath=$KEYMAN_ROOT/mac/help
+      upload mac/help products/mac/$VERSION_RELEASE
       ;;
     windows)
       # Note: `/windows/src/desktop/help/build.sh web` must be run first
-      helppath=$KEYMAN_ROOT/windows/bin/help/md/desktop
+      upload windows/bin/help/md/desktop products/windows/$VERSION_RELEASE
       ;;
     developer)
-      # Note: `/developer/build.sh api` must be run first
-      helppath="$KEYMAN_ROOT/developer/build/docs"
+      # Note: `/developer/build.sh api` must be run first - covers both uploads
+      upload developer/build/docs developer/$VERSION_RELEASE/reference/api
+      upload developer/src/kmc/build/messages developer/$VERSION_RELEASE/reference/messages
       ;;
     *)
       display_usage
     esac
-
-    dstpath="$HELP_KEYMAN_COM/$(help_product_path)"
-
-  #
-  # Look for help source folder.
-  #
-
-  if [[ ! -d "$helppath" ]]; then
-    echo "${t_yel}Warning: The source path $helppath does not exist${t_end}"
-    exit 1
-  fi
-
-  rm -rf "$dstpath"
-  mkdir -p "$dstpath"
-
-  cp -rv "$helppath"/* "$dstpath/"
 }
 
 #
@@ -167,13 +132,11 @@ if [ -z ${platform} ]; then
   exit 1
 fi
 
-generate_markdown_help || exit 1
-
 echo "Uploading Keyman for $platform documentation to help.keyman.com"
 
 upload_keyman_help || exit 1
 
-ci_add_files "$HELP_KEYMAN_COM" "$(help_product_path)"
+ci_add_files "$HELP_KEYMAN_COM" .
 if ! ci_repo_has_cached_changes "$HELP_KEYMAN_COM"; then
   echo "No changes to commit"
   exit 0


### PR DESCRIPTION
Fixes #10889.

This involved a bit more refactoring to help-keyman-com.sh in order to allow for multiple paths to be uploaded.

I opted _not_ to move the entire Keyman Developer documentation into this repository, partly because a number of pages are still in PHP rather than Markdown.

@keymanapp-test-bot skip