### PR TITLE
refactor(oem/fv/android): Install fallback keyboard

### DIFF
--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/DefaultLanguageResource.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/DefaultLanguageResource.java
@@ -44,8 +44,7 @@ public class DefaultLanguageResource {
     SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
 
     // Add default keyboard
-    boolean installDefaultKeyboard = prefs.getBoolean(defaultKeyboardInstalled, false);
-    if (!installDefaultKeyboard) {
+    if (!prefs.getBoolean(defaultKeyboardInstalled, false)) {
       if (!KMManager.keyboardExists(context, FVShared.FVDefault_PackageID, KMManager.KMDefault_KeyboardID,
         KMManager.KMDefault_LanguageID)) {
 

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/DefaultLanguageResource.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/DefaultLanguageResource.java
@@ -1,0 +1,62 @@
+package com.firstvoices.keyboards;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.keyman.engine.KMManager;
+import com.keyman.engine.data.Keyboard;
+import com.keyman.engine.data.LexicalModel;
+
+import java.util.HashMap;
+
+public class DefaultLanguageResource {
+  private static final String defaultKeyboardInstalled = "DefaultKeyboardInstalled";
+  private static final String defaultDictionaryInstalled = "DefaultDictionaryInstalled";
+
+  /**
+   * Check if app has installed default keyboard. If not, install it as fallback
+   * @param context
+   */
+  public static void install(Context context) {
+    /**
+     * We need to set the default (fallback) keyboard to sil_euro_latin inside the fv_all package
+     * rather than the normal default of sil_euro_latin inside the sil_euro_latin package.
+     * Fallback keyboard needed in case the user never selects a FV keyboard to add
+     * as a system keyboard.
+     */
+    String version = KMManager.getLatestKeyboardFileVersion(
+      context, FVShared.FVDefault_PackageID, KMManager.KMDefault_KeyboardID);
+    KMManager.setDefaultKeyboard(
+      new Keyboard(
+        FVShared.FVDefault_PackageID,
+        KMManager.KMDefault_KeyboardID,
+        KMManager.KMDefault_KeyboardName,
+        KMManager.KMDefault_LanguageID,
+        KMManager.KMDefault_LanguageName,
+        version,
+        null, // will use help.keyman.com link because context required to determine local welcome.htm path,
+        "",
+        false,
+        KMManager.KMDefault_KeyboardFont,
+        KMManager.KMDefault_KeyboardFont)
+    );
+
+    SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+
+    // Add default keyboard
+    boolean installDefaultKeyboard = prefs.getBoolean(defaultKeyboardInstalled, false);
+    if (!installDefaultKeyboard) {
+      if (!KMManager.keyboardExists(context, FVShared.FVDefault_PackageID, KMManager.KMDefault_KeyboardID,
+        KMManager.KMDefault_LanguageID)) {
+
+        KMManager.addKeyboard(context, KMManager.getDefaultKeyboard(context.getApplicationContext()));
+      }
+      SharedPreferences.Editor editor = prefs.edit();
+      editor.putBoolean(defaultKeyboardInstalled, true);
+      editor.commit();
+    }
+
+    // No default dictionary to install
+
+  }
+}

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -61,29 +61,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
         KMManager.setShouldCheckKeyboardUpdates(false);
         KMManager.setKeyboardPickerFont(Typeface.createFromAsset(getAssets(), "fonts/NotoSansCanadianAboriginal.ttf"));
         KMManager.initialize(getApplicationContext(), KeyboardType.KEYBOARD_TYPE_SYSTEM);
-
-        /**
-         * We need to set the default (fallback) keyboard to sil_euro_latin inside the fv_all package
-         * rather than the normal default of sil_euro_latin inside the sil_euro_latin package.
-         * Fallback keyboard needed in case the user never selects a FV keyboard to add
-         * as a system keyboard.
-         */
-        String version = KMManager.getLatestKeyboardFileVersion(
-          this, FVShared.FVDefault_PackageID, KMManager.KMDefault_KeyboardID);
-        KMManager.setDefaultKeyboard(
-          new Keyboard(
-            FVShared.FVDefault_PackageID,
-            KMManager.KMDefault_KeyboardID,
-            KMManager.KMDefault_KeyboardName,
-            KMManager.KMDefault_LanguageID,
-            KMManager.KMDefault_LanguageName,
-            version,
-            null, // will use help.keyman.com link because context required to determine local welcome.htm path,
-            "",
-            false,
-            KMManager.KMDefault_KeyboardFont,
-            KMManager.KMDefault_KeyboardFont)
-        );
+        DefaultLanguageResource.install(this);
 
         interpreter = new KMHardwareKeyboardInterpreter(getApplicationContext(), KeyboardType.KEYBOARD_TYPE_SYSTEM);
         KMManager.setInputMethodService(this); // for HW interface


### PR DESCRIPTION
Follows #10794 and applies it for FV Android app - addresses some of the instances for Sentry crashes in #7412

If users use the Android settings to enable (FV) as a system keyboard without adding keyboards through the FV app, 
it could create a scenario where the Javascript file isn't available

## User Testing
Similar to tests from #10794

**Setup** - This involves modifying Android Studio configuration so the IDE will install the PR build of Keyman for Android, without launching the app.
1. From Android Studio --> Run --> Edit Configurations
2. In the Run/Debug Configurations dialog, change "Launch Options --> Launch" dropdown from "Default Activity" to "Nothing". 
![edit configuration](https://github.com/keymanapp/keyman/assets/7358010/e914791d-cfe0-4b12-bf19-21133f2846c7)
3. **For each test** on an Android device/emulator, do a clean install of the PR build of FirstVoices for Android. (If FirstVoices was previously installed, uninstall it first)
4. When testing is complete,  revert the Android Studio Configuration settings so future PR testing with launch the app.

* **TEST_SYSTEM_KEYBOARD** - Verifies system default keyboard works
(remember setup step 3. If FirstVoices was previously installed for another test, uninstall and do a clean installation of Keyman)
1. On the Android device, go to the Android Settings --> Languages menu and enable FirstVoices as a system keyboard
2. Launch Chrome and click on the textbar
3. Select FirstVoices as the system keyboard
4. Once the keyboard, verify the OSK appears (dictionary not bundled for suggestions)
5. Verify you can type with the FirstVoices keyboard
