### PR TITLE
docs(developer): kmc-ldml api documentation

### DIFF
--- a/developer/docs/api/etc/kmc-analyze.api.md
+++ b/developer/docs/api/etc/kmc-analyze.api.md
@@ -33,16 +33,20 @@ export class AnalyzeOskRewritePua {
     };
 }
 
-// @public
+// Warning: (ae-internal-missing-underscore) The name "AnalyzerMessages" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export class AnalyzerMessages {
+    // (undocumented)
     static readonly FATAL_UnexpectedException: number;
-    // @internal (undocumented)
-    static Fatal_UnexpectedException: (o: {
+    // (undocumented)
+    static readonly Fatal_UnexpectedException: (o: {
         e: any;
     }) => CompilerEvent;
+    // (undocumented)
     static readonly INFO_ScanningFile: number;
-    // @internal (undocumented)
-    static Info_ScanningFile: (o: {
+    // (undocumented)
+    static readonly Info_ScanningFile: (o: {
         type: string;
         name: string;
     }) => CompilerEvent;

--- a/developer/docs/api/etc/kmc-keyboard-info.api.md
+++ b/developer/docs/api/etc/kmc-keyboard-info.api.md
@@ -65,10 +65,6 @@ export class KeyboardInfoCompilerMessages {
         email: string;
     }) => CompilerEvent;
     // (undocumented)
-    static Error_LicenseFileDoesNotExist: (o: {
-        filename: string;
-    }) => CompilerEvent;
-    // (undocumented)
     static ERROR_LicenseFileIsDamaged: number;
     // (undocumented)
     static Error_LicenseFileIsDamaged: (o: {
@@ -76,6 +72,10 @@ export class KeyboardInfoCompilerMessages {
     }) => CompilerEvent;
     // (undocumented)
     static ERROR_LicenseFileIsMissing: number;
+    // (undocumented)
+    static Error_LicenseFileIsMissing: (o: {
+        filename: string;
+    }) => CompilerEvent;
     // (undocumented)
     static ERROR_LicenseIsNotValid: number;
     // (undocumented)

--- a/developer/docs/api/etc/kmc-kmn.api.md
+++ b/developer/docs/api/etc/kmc-kmn.api.md
@@ -15,62 +15,10 @@ import { Osk } from '@keymanapp/developer-utils';
 import { UnicodeSet } from '@keymanapp/common-types';
 import { UnicodeSetParser } from '@keymanapp/common-types';
 
-// @public
-export class CompilerMessages {
-    static ERROR_FileNotFound: number;
-    // @internal (undocumented)
-    static Error_FileNotFound: (o: {
-        filename: string;
-    }) => CompilerEvent;
-    static ERROR_InvalidDisplayMapFile: number;
-    // @internal (undocumented)
-    static Error_InvalidDisplayMapFile: (o: {
-        filename: string;
-        e: any;
-    }) => CompilerEvent;
-    static ERROR_InvalidKvkFile: number;
-    // @internal (undocumented)
-    static Error_InvalidKvkFile: (o: {
-        filename: string;
-        e: any;
-    }) => CompilerEvent;
-    static ERROR_InvalidKvksFile: number;
-    // @internal (undocumented)
-    static Error_InvalidKvksFile: (o: {
-        filename: string;
-        e: any;
-    }) => CompilerEvent;
-    static ERROR_UnicodeSetHasProperties: number;
-    // @internal (undocumented)
-    static Error_UnicodeSetHasProperties: () => CompilerEvent;
-    static ERROR_UnicodeSetHasStrings: number;
-    // @internal (undocumented)
-    static Error_UnicodeSetHasStrings: () => CompilerEvent;
-    static ERROR_UnicodeSetSyntaxError: number;
-    // @internal (undocumented)
-    static Error_UnicodeSetSyntaxError: () => CompilerEvent;
-    static FATAL_CallbacksNotSet: number;
-    // @internal (undocumented)
-    static Fatal_CallbacksNotSet: () => CompilerEvent;
-    static FATAL_MissingWasmModule: number;
-    // @internal (undocumented)
-    static Fatal_MissingWasmModule: (o: {
-        e?: any;
-    }) => CompilerEvent;
-    static FATAL_UnexpectedException: number;
-    // @internal (undocumented)
-    static Fatal_UnexpectedException: (o: {
-        e: any;
-    }) => CompilerEvent;
-    static FATAL_UnicodeSetOutOfRange: number;
-    // @internal (undocumented)
-    static Fatal_UnicodeSetOutOfRange: () => CompilerEvent;
-    static WARN_InvalidVkeyInKvksFile: number;
-    // @internal (undocumented)
-    static Warn_InvalidVkeyInKvksFile: (o: {
-        filename: string;
-        invalidVkey: string;
-    }) => CompilerEvent;
+// Warning: (ae-internal-missing-underscore) The name "CompilerMessages" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export class CompilerMessages extends KmnCompilerMessages {
 }
 
 // Warning: (ae-internal-missing-underscore) The name "CompilerResultExtraGroup" should be prefixed with an underscore because the declaration is marked as @internal
@@ -114,338 +62,754 @@ export class KmnCompiler implements KeymanCompiler, UnicodeSetParser {
 
 // @public
 export interface KmnCompilerArtifacts extends KeymanCompilerArtifacts {
-    // (undocumented)
     js?: KeymanCompilerArtifactOptional;
-    // (undocumented)
     kmx?: KeymanCompilerArtifactOptional;
-    // (undocumented)
     kvk?: KeymanCompilerArtifactOptional;
 }
 
-// @public
+// Warning: (ae-internal-missing-underscore) The name "KmnCompilerMessages" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export class KmnCompilerMessages {
     // (undocumented)
     static ERROR_140FeatureOnlyContextAndNotAnyWeb: number;
     // (undocumented)
+    static Error_140FeatureOnlyContextAndNotAnyWeb: () => CompilerEvent;
+    // (undocumented)
     static ERROR_501FeatureOnly_Call: number;
+    // (undocumented)
+    static Error_501FeatureOnly_Call: () => CompilerEvent;
     // (undocumented)
     static ERROR_60FeatureOnly_Contextn: number;
     // (undocumented)
+    static Error_60FeatureOnly_Contextn: () => CompilerEvent;
+    // (undocumented)
     static ERROR_60FeatureOnly_EthnologueCode: number;
+    // (undocumented)
+    static Error_60FeatureOnly_EthnologueCode: () => CompilerEvent;
     // (undocumented)
     static ERROR_60FeatureOnly_MnemonicLayout: number;
     // (undocumented)
+    static Error_60FeatureOnly_MnemonicLayout: () => CompilerEvent;
+    // (undocumented)
     static ERROR_60FeatureOnly_NamedCodes: number;
+    // (undocumented)
+    static Error_60FeatureOnly_NamedCodes: () => CompilerEvent;
     // (undocumented)
     static ERROR_60FeatureOnly_OldCharPosMatching: number;
     // (undocumented)
+    static Error_60FeatureOnly_OldCharPosMatching: () => CompilerEvent;
+    // (undocumented)
     static ERROR_60FeatureOnly_VirtualCharKey: number;
+    // (undocumented)
+    static Error_60FeatureOnly_VirtualCharKey: () => CompilerEvent;
     // (undocumented)
     static ERROR_70FeatureOnly: number;
     // (undocumented)
+    static Error_70FeatureOnly: () => CompilerEvent;
+    // (undocumented)
     static ERROR_80FeatureOnly: number;
+    // (undocumented)
+    static Error_80FeatureOnly: () => CompilerEvent;
     // (undocumented)
     static ERROR_90FeatureOnly_IfSystemStores: number;
     // (undocumented)
+    static Error_90FeatureOnly_IfSystemStores: () => CompilerEvent;
+    // (undocumented)
     static ERROR_90FeatureOnly_SetSystemStores: number;
+    // (undocumented)
+    static Error_90FeatureOnly_SetSystemStores: () => CompilerEvent;
     // (undocumented)
     static ERROR_90FeatureOnlyEmbedCSS: number;
     // (undocumented)
+    static Error_90FeatureOnlyEmbedCSS: () => CompilerEvent;
+    // (undocumented)
     static ERROR_90FeatureOnlyKeyboardVersion: number;
+    // (undocumented)
+    static Error_90FeatureOnlyKeyboardVersion: () => CompilerEvent;
     // (undocumented)
     static ERROR_90FeatureOnlyLayoutFile: number;
     // (undocumented)
+    static Error_90FeatureOnlyLayoutFile: () => CompilerEvent;
+    // (undocumented)
     static ERROR_90FeatureOnlyTargets: number;
+    // (undocumented)
+    static Error_90FeatureOnlyTargets: () => CompilerEvent;
     // (undocumented)
     static ERROR_90FeatureOnlyVirtualKeyDictionary: number;
     // (undocumented)
+    static Error_90FeatureOnlyVirtualKeyDictionary: () => CompilerEvent;
+    // (undocumented)
     static ERROR_AnyInVirtualKeySection: number;
+    // (undocumented)
+    static Error_AnyInVirtualKeySection: () => CompilerEvent;
     // (undocumented)
     static ERROR_BeepInVirtualKeySection: number;
     // (undocumented)
+    static Error_BeepInVirtualKeySection: () => CompilerEvent;
+    // (undocumented)
     static ERROR_CallInVirtualKeySection: number;
+    // (undocumented)
+    static Error_CallInVirtualKeySection: () => CompilerEvent;
     // (undocumented)
     static ERROR_CannotLoadIncludeFile: number;
     // (undocumented)
+    static Error_CannotLoadIncludeFile: () => CompilerEvent;
+    // (undocumented)
     static ERROR_CannotReadBitmapFile: number;
+    // (undocumented)
+    static Error_CannotReadBitmapFile: () => CompilerEvent;
     // (undocumented)
     static ERROR_CannotReadInfile: number;
     // (undocumented)
+    static Error_CannotReadInfile: () => CompilerEvent;
+    // (undocumented)
     static ERROR_CannotUseReadWriteGroupFromReadonlyGroup: number;
+    // (undocumented)
+    static Error_CannotUseReadWriteGroupFromReadonlyGroup: () => CompilerEvent;
     // (undocumented)
     static ERROR_CasedKeysMustContainOnlyVirtualKeys: number;
     // (undocumented)
+    static Error_CasedKeysMustContainOnlyVirtualKeys: () => CompilerEvent;
+    // (undocumented)
     static ERROR_CasedKeysMustNotIncludeShiftStates: number;
+    // (undocumented)
+    static Error_CasedKeysMustNotIncludeShiftStates: () => CompilerEvent;
     // (undocumented)
     static ERROR_CasedKeysNotSupportedWithMnemonicLayout: number;
     // (undocumented)
+    static Error_CasedKeysNotSupportedWithMnemonicLayout: () => CompilerEvent;
+    // (undocumented)
     static ERROR_CharacterExpansionMustBeFollowedByCharacter: number;
+    // (undocumented)
+    static Error_CharacterExpansionMustBeFollowedByCharacter: () => CompilerEvent;
     // (undocumented)
     static ERROR_CodeInvalidInKeyStore: number;
     // (undocumented)
+    static Error_CodeInvalidInKeyStore: () => CompilerEvent;
+    // (undocumented)
     static ERROR_CodeInvalidInThisSection: number;
+    // (undocumented)
+    static Error_CodeInvalidInThisSection: () => CompilerEvent;
     // (undocumented)
     static ERROR_ContextAndIndexInvalidInMatchNomatch: number;
     // (undocumented)
+    static Error_ContextAndIndexInvalidInMatchNomatch: () => CompilerEvent;
+    // (undocumented)
     static ERROR_ContextExHasInvalidOffset: number;
+    // (undocumented)
+    static Error_ContextExHasInvalidOffset: () => CompilerEvent;
     // (undocumented)
     static ERROR_ContextInVirtualKeySection: number;
     // (undocumented)
+    static Error_ContextInVirtualKeySection: () => CompilerEvent;
+    // (undocumented)
     static ERROR_DuplicateGroup: number;
+    // (undocumented)
+    static Error_DuplicateGroup: () => CompilerEvent;
     // (undocumented)
     static ERROR_DuplicateStore: number;
     // (undocumented)
+    static Error_DuplicateStore: () => CompilerEvent;
+    // (undocumented)
     static ERROR_ExpansionMustBePositive: number;
+    // (undocumented)
+    static Error_ExpansionMustBePositive: () => CompilerEvent;
     // (undocumented)
     static ERROR_ExpansionMustFollowCharacterOrVKey: number;
     // (undocumented)
+    static Error_ExpansionMustFollowCharacterOrVKey: () => CompilerEvent;
+    // (undocumented)
+    static ERROR_FileNotFound: number;
+    // (undocumented)
+    static Error_FileNotFound: (o: {
+        filename: string;
+    }) => CompilerEvent;
+    // (undocumented)
     static ERROR_GroupDoesNotExist: number;
+    // (undocumented)
+    static Error_GroupDoesNotExist: () => CompilerEvent;
     // (undocumented)
     static ERROR_IfSystemStore_NotFound: number;
     // (undocumented)
+    static Error_IfSystemStore_NotFound: () => CompilerEvent;
+    // (undocumented)
     static ERROR_IndexDoesNotPointToAny: number;
+    // (undocumented)
+    static Error_IndexDoesNotPointToAny: () => CompilerEvent;
     // (undocumented)
     static ERROR_IndexInVirtualKeySection: number;
     // (undocumented)
+    static Error_IndexInVirtualKeySection: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InfileNotExist: number;
+    // (undocumented)
+    static Error_InfileNotExist: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidAny: number;
     // (undocumented)
+    static Error_InvalidAny: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidBegin: number;
+    // (undocumented)
+    static Error_InvalidBegin: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidBitmapLine: number;
     // (undocumented)
+    static Error_InvalidBitmapLine: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidCall: number;
+    // (undocumented)
+    static Error_InvalidCall: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidCharacter: number;
     // (undocumented)
+    static Error_InvalidCharacter: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidCodeInKeyPartOfRule: number;
+    // (undocumented)
+    static Error_InvalidCodeInKeyPartOfRule: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidCopyright: number;
     // (undocumented)
+    static Error_InvalidCopyright: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidDeadkey: number;
+    // (undocumented)
+    static Error_InvalidDeadkey: () => CompilerEvent;
+    // (undocumented)
+    static ERROR_InvalidDisplayMapFile: number;
+    // (undocumented)
+    static Error_InvalidDisplayMapFile: (o: {
+        filename: string;
+        e: any;
+    }) => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidEthnologueCode: number;
     // (undocumented)
+    static Error_InvalidEthnologueCode: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidGroupLine: number;
+    // (undocumented)
+    static Error_InvalidGroupLine: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidIf: number;
     // (undocumented)
+    static Error_InvalidIf: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidIndex: number;
+    // (undocumented)
+    static Error_InvalidIndex: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidInVirtualKeySection: number;
     // (undocumented)
+    static Error_InvalidInVirtualKeySection: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidKeyCode: number;
+    // (undocumented)
+    static Error_InvalidKeyCode: (o: {
+        keyId: string;
+    }) => CompilerEvent;
+    // (undocumented)
+    static ERROR_InvalidKvkFile: number;
+    // (undocumented)
+    static Error_InvalidKvkFile: (o: {
+        filename: string;
+        e: any;
+    }) => CompilerEvent;
+    // (undocumented)
+    static ERROR_InvalidKvksFile: number;
+    // (undocumented)
+    static Error_InvalidKvksFile: (o: {
+        filename: string;
+        e: any;
+    }) => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidLanguageLine: number;
     // (undocumented)
+    static Error_InvalidLanguageLine: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidLanguageName: number;
+    // (undocumented)
+    static Error_InvalidLanguageName: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidLayoutLine: number;
     // (undocumented)
+    static Error_InvalidLayoutLine: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidLineContinuation: number;
+    // (undocumented)
+    static Error_InvalidLineContinuation: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidMessage: number;
     // (undocumented)
+    static Error_InvalidMessage: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidName: number;
+    // (undocumented)
+    static Error_InvalidName: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidNamedCode: number;
     // (undocumented)
+    static Error_InvalidNamedCode: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidOuts: number;
+    // (undocumented)
+    static Error_InvalidOuts: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidReset: number;
     // (undocumented)
+    static Error_InvalidReset: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidSave: number;
+    // (undocumented)
+    static Error_InvalidSave: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidSet: number;
     // (undocumented)
+    static Error_InvalidSet: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidStoreLine: number;
+    // (undocumented)
+    static Error_InvalidStoreLine: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidSwitch: number;
     // (undocumented)
+    static Error_InvalidSwitch: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidSystemStore: number;
+    // (undocumented)
+    static Error_InvalidSystemStore: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidToken: number;
     // (undocumented)
+    static Error_InvalidToken: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidTouchLayoutFile: number;
+    // (undocumented)
+    static Error_InvalidTouchLayoutFile: (o: {
+        filename: string;
+    }) => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidUse: number;
     // (undocumented)
+    static Error_InvalidUse: () => CompilerEvent;
+    // (undocumented)
     static ERROR_InvalidValue: number;
+    // (undocumented)
+    static Error_InvalidValue: () => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidVersion: number;
     // (undocumented)
+    static Error_InvalidVersion: () => CompilerEvent;
+    // (undocumented)
     static ERROR_KeyboardVersionFormatInvalid: number;
+    // (undocumented)
+    static Error_KeyboardVersionFormatInvalid: () => CompilerEvent;
     // (undocumented)
     static ERROR_LayoutButNoLanguage: number;
     // (undocumented)
+    static Error_LayoutButNoLanguage: () => CompilerEvent;
+    // (undocumented)
     static ERROR_LineTooLong: number;
+    // (undocumented)
+    static Error_LineTooLong: () => CompilerEvent;
     // (undocumented)
     static ERROR_NewContextGroupMustBeReadonly: number;
     // (undocumented)
+    static Error_NewContextGroupMustBeReadonly: () => CompilerEvent;
+    // (undocumented)
     static ERROR_NoTokensFound: number;
+    // (undocumented)
+    static Error_NoTokensFound: () => CompilerEvent;
     // (undocumented)
     static ERROR_NotSupportedInKeymanWebContext: number;
     // (undocumented)
+    static Error_NotSupportedInKeymanWebContext: (o: {
+        line: number;
+        code: String;
+    }) => CompilerEvent;
+    // (undocumented)
     static ERROR_NotSupportedInKeymanWebOutput: number;
+    // (undocumented)
+    static Error_NotSupportedInKeymanWebOutput: (o: {
+        line: number;
+        code: string;
+    }) => CompilerEvent;
     // (undocumented)
     static ERROR_NotSupportedInKeymanWebStore: number;
     // (undocumented)
+    static Error_NotSupportedInKeymanWebStore: (o: {
+        code: string;
+        store: string;
+    }) => CompilerEvent;
+    // (undocumented)
     static ERROR_NoVersionLine: number;
+    // (undocumented)
+    static Error_NoVersionLine: () => CompilerEvent;
     // (undocumented)
     static ERROR_OutputInReadonlyGroup: number;
     // (undocumented)
+    static Error_OutputInReadonlyGroup: () => CompilerEvent;
+    // (undocumented)
     static ERROR_OutsInVirtualKeySection: number;
+    // (undocumented)
+    static Error_OutsInVirtualKeySection: () => CompilerEvent;
     // (undocumented)
     static ERROR_PostKeystrokeGroupMustBeReadonly: number;
     // (undocumented)
+    static Error_PostKeystrokeGroupMustBeReadonly: () => CompilerEvent;
+    // (undocumented)
     static ERROR_RepeatedBegin: number;
+    // (undocumented)
+    static Error_RepeatedBegin: () => CompilerEvent;
     // (undocumented)
     static ERROR_ReservedCharacter: number;
     // (undocumented)
+    static Error_ReservedCharacter: () => CompilerEvent;
+    // (undocumented)
     static ERROR_SetSystemStore_NotFound: number;
+    // (undocumented)
+    static Error_SetSystemStore_NotFound: () => CompilerEvent;
     // (undocumented)
     static ERROR_StatementNotPermittedInReadonlyGroup: number;
     // (undocumented)
+    static Error_StatementNotPermittedInReadonlyGroup: () => CompilerEvent;
+    // (undocumented)
     static ERROR_StoreDoesNotExist: number;
+    // (undocumented)
+    static Error_StoreDoesNotExist: () => CompilerEvent;
     // (undocumented)
     static ERROR_StringInVirtualKeySection: number;
     // (undocumented)
+    static Error_StringInVirtualKeySection: () => CompilerEvent;
+    // (undocumented)
     static ERROR_TooManyIndexToKeyRefs: number;
+    // (undocumented)
+    static Error_TooManyIndexToKeyRefs: () => CompilerEvent;
     // (undocumented)
     static ERROR_TouchLayoutInvalidIdentifier: number;
     // (undocumented)
+    static Error_TouchLayoutInvalidIdentifier: (o: {
+        keyId: string;
+        platformName: string;
+        layerId: string;
+    }) => CompilerEvent;
+    // (undocumented)
+    static ERROR_UnicodeSetHasProperties: number;
+    // (undocumented)
+    static Error_UnicodeSetHasProperties: () => CompilerEvent;
+    // (undocumented)
+    static ERROR_UnicodeSetHasStrings: number;
+    // (undocumented)
+    static Error_UnicodeSetHasStrings: () => CompilerEvent;
+    // (undocumented)
+    static ERROR_UnicodeSetSyntaxError: number;
+    // (undocumented)
+    static Error_UnicodeSetSyntaxError: () => CompilerEvent;
+    // (undocumented)
     static ERROR_UnterminatedString: number;
+    // (undocumented)
+    static Error_UnterminatedString: () => CompilerEvent;
     // (undocumented)
     static ERROR_VersionAlreadyIncluded: number;
     // (undocumented)
+    static Error_VersionAlreadyIncluded: () => CompilerEvent;
+    // (undocumented)
     static ERROR_VirtualCharacterKeysNotSupportedInKeymanWeb: number;
+    // (undocumented)
+    static Error_VirtualCharacterKeysNotSupportedInKeymanWeb: (o: {
+        line: number;
+    }) => CompilerEvent;
     // (undocumented)
     static ERROR_VirtualKeyInContext: number;
     // (undocumented)
+    static Error_VirtualKeyInContext: () => CompilerEvent;
+    // (undocumented)
     static ERROR_VirtualKeyNotAllowedHere: number;
+    // (undocumented)
+    static Error_VirtualKeyNotAllowedHere: () => CompilerEvent;
     // (undocumented)
     static ERROR_VirtualKeysNotValidForMnemonicLayouts: number;
     // (undocumented)
+    static Error_VirtualKeysNotValidForMnemonicLayouts: (o: {
+        line: number;
+    }) => CompilerEvent;
+    // (undocumented)
     static ERROR_VKeyExpansionMustBeFollowedByVKey: number;
+    // (undocumented)
+    static Error_VKeyExpansionMustBeFollowedByVKey: () => CompilerEvent;
     // (undocumented)
     static ERROR_VKeyExpansionMustUseConsistentShift: number;
     // (undocumented)
+    static Error_VKeyExpansionMustUseConsistentShift: () => CompilerEvent;
+    // (undocumented)
     static ERROR_ZeroLengthString: number;
+    // (undocumented)
+    static Error_ZeroLengthString: () => CompilerEvent;
     // (undocumented)
     static FATAL_BadCallParams: number;
     // (undocumented)
+    static Fatal_BadCallParams: () => CompilerEvent;
+    // (undocumented)
     static FATAL_Break: number;
+    // (undocumented)
+    static Fatal_Break: () => CompilerEvent;
     // (undocumented)
     static FATAL_BufferOverflow: number;
     // (undocumented)
+    static Fatal_BufferOverflow: () => CompilerEvent;
+    // (undocumented)
+    static FATAL_CallbacksNotSet: number;
+    // (undocumented)
+    static Fatal_CallbacksNotSet: () => CompilerEvent;
+    // (undocumented)
     static FATAL_CannotAllocateMemory: number;
+    // (undocumented)
+    static Fatal_CannotAllocateMemory: () => CompilerEvent;
     // (undocumented)
     static FATAL_CannotCreateTempfile: number;
     // (undocumented)
+    static Fatal_CannotCreateTempfile: () => CompilerEvent;
+    // (undocumented)
+    static FATAL_MissingWasmModule: number;
+    // (undocumented)
+    static Fatal_MissingWasmModule: (o: {
+        e?: any;
+    }) => CompilerEvent;
+    // (undocumented)
     static FATAL_SomewhereIGotItWrong: number;
+    // (undocumented)
+    static Fatal_SomewhereIGotItWrong: () => CompilerEvent;
     // (undocumented)
     static FATAL_UnableToWriteFully: number;
     // (undocumented)
+    static Fatal_UnableToWriteFully: () => CompilerEvent;
+    // (undocumented)
+    static FATAL_UnexpectedException: number;
+    // (undocumented)
+    static Fatal_UnexpectedException: (o: {
+        e: any;
+    }) => CompilerEvent;
+    // (undocumented)
+    static FATAL_UnicodeSetOutOfRange: number;
+    // (undocumented)
+    static Fatal_UnicodeSetOutOfRange: () => CompilerEvent;
+    // (undocumented)
     static HINT_NonUnicodeFile: number;
+    // (undocumented)
+    static Hint_NonUnicodeFile: () => CompilerEvent;
     // (undocumented)
     static HINT_UnreachableKeyCode: number;
     // (undocumented)
+    static Hint_UnreachableKeyCode: (o: {
+        line: number;
+        key: string;
+    }) => CompilerEvent;
+    // (undocumented)
     static HINT_UnreachableRule: number;
+    // (undocumented)
+    static Hint_UnreachableRule: () => CompilerEvent;
     // (undocumented)
     static INFO_EndOfFile: number;
     // (undocumented)
+    static Info_EndOfFile: () => CompilerEvent;
+    // (undocumented)
     static INFO_Info: number;
     // (undocumented)
-    static INFO_None: number;
+    static Info_Info: () => CompilerEvent;
     // (undocumented)
     static WARN_ANSIInUnicodeGroup: number;
     // (undocumented)
+    static Warn_ANSIInUnicodeGroup: () => CompilerEvent;
+    // (undocumented)
     static WARN_BitmapNotUsed: number;
     // (undocumented)
-    static WARN_CouldNotCopyJsonFile: number;
+    static Warn_BitmapNotUsed: () => CompilerEvent;
     // (undocumented)
     static WARN_CustomLanguagesNotSupported: number;
     // (undocumented)
+    static Warn_CustomLanguagesNotSupported: () => CompilerEvent;
+    // (undocumented)
     static WARN_DontMixChiralAndNonChiralModifiers: number;
+    // (undocumented)
+    static Warn_DontMixChiralAndNonChiralModifiers: () => CompilerEvent;
     // (undocumented)
     static WARN_EmbedJsFileMissing: number;
     // (undocumented)
+    static Warn_EmbedJsFileMissing: (o: {
+        line: number;
+        jsFilename: string;
+        e: any;
+    }) => CompilerEvent;
+    // (undocumented)
     static WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb: number;
+    // (undocumented)
+    static Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb: (o: {
+        line: number;
+        flags: string;
+    }) => CompilerEvent;
     // (undocumented)
     static WARN_HeaderStatementIsDeprecated: number;
     // (undocumented)
+    static Warn_HeaderStatementIsDeprecated: () => CompilerEvent;
+    // (undocumented)
     static WARN_HelpFileMissing: number;
+    // (undocumented)
+    static Warn_HelpFileMissing: (o: {
+        line: number;
+        helpFilename: string;
+        e: any;
+    }) => CompilerEvent;
     // (undocumented)
     static WARN_HotkeyHasInvalidModifier: number;
     // (undocumented)
+    static Warn_HotkeyHasInvalidModifier: () => CompilerEvent;
+    // (undocumented)
     static WARN_IfShouldBeAtStartOfContext: number;
+    // (undocumented)
+    static Warn_IfShouldBeAtStartOfContext: () => CompilerEvent;
     // (undocumented)
     static WARN_IndexStoreShort: number;
     // (undocumented)
-    static WARN_InvalidJSONMetadataFile: number;
+    static Warn_IndexStoreShort: () => CompilerEvent;
     // (undocumented)
-    static WARN_JSONMetadataOSKFontShouldMatchTouchFont: number;
+    static WARN_InvalidVkeyInKvksFile: number;
+    // (undocumented)
+    static Warn_InvalidVkeyInKvksFile: (o: {
+        filename: string;
+        invalidVkey: string;
+    }) => CompilerEvent;
     // (undocumented)
     static WARN_KeyBadLength: number;
     // (undocumented)
+    static Warn_KeyBadLength: () => CompilerEvent;
+    // (undocumented)
     static WARN_KeyShouldIncludeNCaps: number;
+    // (undocumented)
+    static Warn_KeyShouldIncludeNCaps: () => CompilerEvent;
     // (undocumented)
     static WARN_KVKFileIsInSourceFormat: number;
     // (undocumented)
+    static Warn_KVKFileIsInSourceFormat: () => CompilerEvent;
+    // (undocumented)
     static WARN_LanguageHeadersDeprecatedInKeyman10: number;
+    // (undocumented)
+    static Warn_LanguageHeadersDeprecatedInKeyman10: () => CompilerEvent;
     // (undocumented)
     static WARN_MixingLeftAndRightModifiers: number;
     // (undocumented)
+    static Warn_MixingLeftAndRightModifiers: () => CompilerEvent;
+    // (undocumented)
     static WARN_NulNotFirstStatementInContext: number;
+    // (undocumented)
+    static Warn_NulNotFirstStatementInContext: () => CompilerEvent;
     // (undocumented)
     static WARN_OldVersion: number;
     // (undocumented)
+    static Warn_OldVersion: () => CompilerEvent;
+    // (undocumented)
     static WARN_OptionStoreNameInvalid: number;
+    // (undocumented)
+    static Warn_OptionStoreNameInvalid: (o: {
+        name: string;
+    }) => CompilerEvent;
     // (undocumented)
     static WARN_PlatformNotInTargets: number;
     // (undocumented)
+    static Warn_PlatformNotInTargets: () => CompilerEvent;
+    // (undocumented)
     static WARN_PunctuationInEthnologueCode: number;
+    // (undocumented)
+    static Warn_PunctuationInEthnologueCode: () => CompilerEvent;
     // (undocumented)
     static WARN_ReservedCharacter: number;
     // (undocumented)
+    static Warn_ReservedCharacter: () => CompilerEvent;
+    // (undocumented)
     static WARN_StoreAlreadyUsedAsOptionOrCall: number;
+    // (undocumented)
+    static Warn_StoreAlreadyUsedAsOptionOrCall: () => CompilerEvent;
     // (undocumented)
     static WARN_StoreAlreadyUsedAsStoreOrCall: number;
     // (undocumented)
+    static Warn_StoreAlreadyUsedAsStoreOrCall: () => CompilerEvent;
+    // (undocumented)
     static WARN_StoreAlreadyUsedAsStoreOrOption: number;
     // (undocumented)
-    static WARN_TooManyErrorsOrWarnings: number;
+    static Warn_StoreAlreadyUsedAsStoreOrOption: () => CompilerEvent;
     // (undocumented)
     static WARN_TooManyWarnings: number;
     // (undocumented)
+    static Warn_TooManyWarnings: () => CompilerEvent;
+    // (undocumented)
     static WARN_TouchLayoutCustomKeyNotDefined: number;
     // (undocumented)
-    static WARN_TouchLayoutFileMissing: number;
+    static Warn_TouchLayoutCustomKeyNotDefined: (o: {
+        keyId: string;
+        platformName: string;
+        layerId: string;
+    }) => CompilerEvent;
     // (undocumented)
     static WARN_TouchLayoutFontShouldBeSameForAllPlatforms: number;
     // (undocumented)
+    static Warn_TouchLayoutFontShouldBeSameForAllPlatforms: () => CompilerEvent;
+    // (undocumented)
     static WARN_TouchLayoutMissingLayer: number;
+    // (undocumented)
+    static Warn_TouchLayoutMissingLayer: (o: {
+        keyId: string;
+        platformName: string;
+        layerId: string;
+        nextLayer: string;
+    }) => CompilerEvent;
     // (undocumented)
     static WARN_TouchLayoutMissingRequiredKeys: number;
     // (undocumented)
+    static Warn_TouchLayoutMissingRequiredKeys: (o: {
+        layerId: string;
+        platformName: string;
+        missingKeys: string;
+    }) => CompilerEvent;
+    // (undocumented)
     static WARN_TouchLayoutSpecialLabelOnNormalKey: number;
+    // (undocumented)
+    static Warn_TouchLayoutSpecialLabelOnNormalKey: (o: {
+        keyId: string;
+        platformName: string;
+        layerId: string;
+        label: string;
+    }) => CompilerEvent;
     // (undocumented)
     static WARN_TouchLayoutUnidentifiedKey: number;
     // (undocumented)
+    static Warn_TouchLayoutUnidentifiedKey: (o: {
+        layerId: string;
+    }) => CompilerEvent;
+    // (undocumented)
     static WARN_UnicodeInANSIGroup: number;
+    // (undocumented)
+    static Warn_UnicodeInANSIGroup: () => CompilerEvent;
     // (undocumented)
     static WARN_UnicodeSurrogateUsed: number;
     // (undocumented)
+    static Warn_UnicodeSurrogateUsed: () => CompilerEvent;
+    // (undocumented)
     static WARN_UseNotLastStatementInRule: number;
+    // (undocumented)
+    static Warn_UseNotLastStatementInRule: () => CompilerEvent;
     // (undocumented)
     static WARN_VirtualCharKeyWithPositionalLayout: number;
     // (undocumented)
+    static Warn_VirtualCharKeyWithPositionalLayout: () => CompilerEvent;
+    // (undocumented)
     static WARN_VirtualKeyInOutput: number;
+    // (undocumented)
+    static Warn_VirtualKeyInOutput: () => CompilerEvent;
     // (undocumented)
     static WARN_VirtualKeyWithMnemonicLayout: number;
     // (undocumented)
-    static WARN_VisualKeyboardFileMissing: number;
+    static Warn_VirtualKeyWithMnemonicLayout: () => CompilerEvent;
 }
 
 // @public
@@ -454,13 +818,9 @@ export interface KmnCompilerOptions extends CompilerOptions {
 
 // @public
 export interface KmnCompilerResult extends KeymanCompilerResult {
-    // (undocumented)
     artifacts: KmnCompilerArtifacts;
-    // (undocumented)
     displayMap?: Osk.PuaMap;
     // Warning: (ae-incompatible-release-tags) The symbol "extra" is marked as @public, but its signature references "KmnCompilerResultExtra" which is marked as @internal
-    //
-    // (undocumented)
     extra: KmnCompilerResultExtra;
 }
 
@@ -479,138 +839,41 @@ export interface KmnCompilerResultExtra {
     targets: number;
 }
 
-// @public
+// Warning: (ae-internal-missing-underscore) The name "KmwCompilerMessages" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export class KmwCompilerMessages extends KmnCompilerMessages {
-    // @internal (undocumented)
-    static Error_InvalidBegin: () => CompilerEvent;
-    // @internal (undocumented)
-    static Error_InvalidKeyCode: (o: {
-        keyId: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Error_InvalidTouchLayoutFile: (o: {
-        filename: string;
-    }) => CompilerEvent;
     // (undocumented)
     static ERROR_InvalidTouchLayoutFileFormat: number;
-    // @internal (undocumented)
+    // (undocumented)
     static Error_InvalidTouchLayoutFileFormat: (o: {
         msg: string;
     }) => CompilerEvent;
     // (undocumented)
     static ERROR_NotAnyRequiresVersion14: number;
-    // @internal (undocumented)
+    // (undocumented)
     static Error_NotAnyRequiresVersion14: (o: {
         line: number;
     }) => CompilerEvent;
-    // @internal (undocumented)
-    static Error_NotSupportedInKeymanWebContext: (o: {
-        line: number;
-        code: String;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Error_NotSupportedInKeymanWebOutput: (o: {
-        line: number;
-        code: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Error_NotSupportedInKeymanWebStore: (o: {
-        code: string;
-        store: string;
-    }) => CompilerEvent;
     // (undocumented)
     static ERROR_TouchLayoutFileDoesNotExist: number;
-    // @internal (undocumented)
+    // (undocumented)
     static Error_TouchLayoutFileDoesNotExist: (o: {
         filename: string;
     }) => CompilerEvent;
     // (undocumented)
     static ERROR_TouchLayoutIdentifierRequires15: number;
-    // @internal (undocumented)
+    // (undocumented)
     static Error_TouchLayoutIdentifierRequires15: (o: {
         keyId: string;
         platformName: string;
         layerId: string;
     }) => CompilerEvent;
-    // @internal (undocumented)
-    static Error_TouchLayoutInvalidIdentifier: (o: {
-        keyId: string;
-        platformName: string;
-        layerId: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Error_VirtualCharacterKeysNotSupportedInKeymanWeb: (o: {
-        line: number;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Error_VirtualKeysNotValidForMnemonicLayouts: (o: {
-        line: number;
-    }) => CompilerEvent;
     // (undocumented)
     static HINT_TouchLayoutUsesUnsupportedGesturesDownlevel: number;
-    // @internal (undocumented)
+    // (undocumented)
     static Hint_TouchLayoutUsesUnsupportedGesturesDownlevel: (o: {
         keyId: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Hint_UnreachableKeyCode: (o: {
-        line: number;
-        key: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_DontMixChiralAndNonChiralModifiers: () => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_EmbedJsFileMissing: (o: {
-        line: number;
-        jsFilename: string;
-        e: any;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb: (o: {
-        line: number;
-        flags: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_HelpFileMissing: (o: {
-        line: number;
-        helpFilename: string;
-        e: any;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_OptionStoreNameInvalid: (o: {
-        name: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_TouchLayoutCustomKeyNotDefined: (o: {
-        keyId: string;
-        platformName: string;
-        layerId: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_TouchLayoutFontShouldBeSameForAllPlatforms: () => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_TouchLayoutMissingLayer: (o: {
-        keyId: string;
-        platformName: string;
-        layerId: string;
-        nextLayer: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_TouchLayoutMissingRequiredKeys: (o: {
-        layerId: string;
-        platformName: string;
-        missingKeys: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_TouchLayoutSpecialLabelOnNormalKey: (o: {
-        keyId: string;
-        platformName: string;
-        layerId: string;
-        label: string;
-    }) => CompilerEvent;
-    // @internal (undocumented)
-    static Warn_TouchLayoutUnidentifiedKey: (o: {
-        layerId: string;
     }) => CompilerEvent;
 }
 

--- a/developer/docs/api/etc/kmc-ldml.api.md
+++ b/developer/docs/api/etc/kmc-ldml.api.md
@@ -11,52 +11,40 @@ import { KeymanCompiler } from '@keymanapp/common-types';
 import { KeymanCompilerArtifactOptional } from '@keymanapp/common-types';
 import { KeymanCompilerArtifacts } from '@keymanapp/common-types';
 import { KeymanCompilerResult } from '@keymanapp/common-types';
-import { KMXBuilder } from '@keymanapp/common-types';
 import { KMXPlus } from '@keymanapp/common-types';
-import { LDMLKeyboard } from '@keymanapp/common-types';
 import { LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/common-types';
 import { LDMLKeyboardXMLSourceFileReaderOptions } from '@keymanapp/common-types';
-import { SectionIdent } from '@keymanapp/ldml-keyboard-constants';
-import { TouchLayout } from '@keymanapp/common-types';
-import { UnicodeSet } from '@keymanapp/common-types';
 import { UnicodeSetParser } from '@keymanapp/common-types';
-import { VisualKeyboard } from '@keymanapp/common-types';
 
-export { KMXBuilder }
-
-// @public (undocumented)
-export class KMXPlusMetadataCompiler {
-    // Warning: (ae-forgotten-export) The symbol "KMXPlusData" needs to be exported by the entry point main.d.ts
-    // Warning: (ae-forgotten-export) The symbol "KEYBOARD" needs to be exported by the entry point main.d.ts
-    static addKmxMetadata(kmxplus: KMXPlusData, keyboard: KEYBOARD, options: LdmlCompilerOptions): void;
-}
-
-// @public (undocumented)
+// @public
 export interface LdmlCompilerOptions extends CompilerOptions {
     readerOptions: LDMLKeyboardXMLSourceFileReaderOptions;
 }
 
-// @public (undocumented)
+// @public
 export class LdmlKeyboardCompiler implements KeymanCompiler {
+    // @internal
     compile(source: LDMLKeyboardXMLSourceFile, postValidate?: boolean): Promise<KMXPlus.KMXPlusFile>;
+    // @internal
     getUsetParser(): Promise<UnicodeSetParser>;
-    // (undocumented)
     init(callbacks: CompilerCallbacks, options: LdmlCompilerOptions): Promise<boolean>;
     // Warning: (ae-forgotten-export) The symbol "LDMLKeyboardXMLSourceFile" needs to be exported by the entry point main.d.ts
+    //
+    // @internal
     load(filename: string): LDMLKeyboardXMLSourceFile | null;
+    // @internal
     loadTestData(filename: string): LDMLKeyboardTestDataXMLSourceFile | null;
     // Warning: (ae-forgotten-export) The symbol "LdmlKeyboardCompilerResult" needs to be exported by the entry point main.d.ts
-    //
-    // (undocumented)
     run(inputFilename: string, outputFilename?: string): Promise<LdmlKeyboardCompilerResult>;
+    // @internal
     validate(source: LDMLKeyboardXMLSourceFile): Promise<boolean>;
     // Warning: (ae-forgotten-export) The symbol "LdmlKeyboardCompilerArtifacts" needs to be exported by the entry point main.d.ts
-    //
-    // (undocumented)
     write(artifacts: LdmlKeyboardCompilerArtifacts): Promise<boolean>;
 }
 
-// @public (undocumented)
+// Warning: (ae-internal-missing-underscore) The name "LdmlKeyboardCompilerMessages" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
 export class LdmlKeyboardCompilerMessages {
     // (undocumented)
     static ERROR_CantReferenceSetFromUnicodeSet: number;
@@ -305,30 +293,6 @@ export class LdmlKeyboardCompilerMessages {
         count: number;
         lowestCh: number;
     }) => CompilerEvent;
-}
-
-// @public (undocumented)
-export class LdmlKeyboardKeymanWebCompiler {
-    constructor(callbacks: CompilerCallbacks, options?: LdmlCompilerOptions);
-    // (undocumented)
-    compile(name: string, source: LDMLKeyboard.LDMLKeyboardXMLSourceFile): string;
-    // (undocumented)
-    compileTouchLayout(source: LDMLKeyboard.LDMLKeyboardXMLSourceFile): string;
-    // (undocumented)
-    compileVisualKeyboard(source: LDMLKeyboard.LDMLKeyboardXMLSourceFile): string;
-}
-
-// @public (undocumented)
-export class LdmlKeyboardVisualKeyboardCompiler {
-    constructor(callbacks: CompilerCallbacks);
-    // (undocumented)
-    compile(source: LDMLKeyboard.LDMLKeyboardXMLSourceFile): VisualKeyboard.VisualKeyboard;
-}
-
-// @public (undocumented)
-export class TouchLayoutCompiler {
-    // (undocumented)
-    compileToJavascript(source: LDMLKeyboard.LDMLKeyboardXMLSourceFile): TouchLayout.TouchLayoutFile;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/developer/docs/api/etc/kmc-model-info.api.md
+++ b/developer/docs/api/etc/kmc-model-info.api.md
@@ -51,10 +51,6 @@ export class ModelInfoCompilerMessages {
         email: string;
     }) => CompilerEvent;
     // (undocumented)
-    static Error_LicenseFileDoesNotExist: (o: {
-        filename: string;
-    }) => CompilerEvent;
-    // (undocumented)
     static ERROR_LicenseFileIsDamaged: number;
     // (undocumented)
     static Error_LicenseFileIsDamaged: (o: {
@@ -62,6 +58,10 @@ export class ModelInfoCompilerMessages {
     }) => CompilerEvent;
     // (undocumented)
     static ERROR_LicenseFileIsMissing: number;
+    // (undocumented)
+    static Error_LicenseFileIsMissing: (o: {
+        filename: string;
+    }) => CompilerEvent;
     // (undocumented)
     static ERROR_LicenseIsNotValid: number;
     // (undocumented)

--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -59,11 +59,23 @@ export interface KmnCompilerResultExtra {
 
 /**
  * @public
- * Internal in-memory result from a successful compilation
+ * Internal in-memory build artifacts from a successful compilation
  */
 export interface KmnCompilerArtifacts extends KeymanCompilerArtifacts {
+  /**
+   * Binary keyboard filedata and filename - installable into Keyman desktop
+   * projects
+   */
   kmx?: KeymanCompilerArtifactOptional;
+  /**
+   * Binary on screen keyboard filedata and filename - installable into Keyman
+   * desktop projects alongside .kmx
+   */
   kvk?: KeymanCompilerArtifactOptional;
+  /**
+   * Javascript keyboard filedata and filename - installable into KeymanWeb,
+   * Keyman mobile products
+   */
   js?: KeymanCompilerArtifactOptional;
 };
 
@@ -72,8 +84,19 @@ export interface KmnCompilerArtifacts extends KeymanCompilerArtifacts {
  * Build artifacts from the .kmn compiler
  */
 export interface KmnCompilerResult extends KeymanCompilerResult {
+  /**
+   * Internal in-memory build artifacts from a successful compilation. Caller
+   * can write these to disk with {@link KmnCompiler.write}
+   */
   artifacts: KmnCompilerArtifacts;
+  /**
+   * Internal additional metadata used by secondary compile phases such as
+   * KmwCompiler, not intended for external use
+   */
   extra: KmnCompilerResultExtra;
+  /**
+   * Mapping data for `&displayMap`, intended for use by kmc-analyze
+   */
   displayMap?: Osk.PuaMap;
 };
 
@@ -129,7 +152,8 @@ export class KmnCompiler implements KeymanCompiler, UnicodeSetParser {
   /**
    * Initialize the compiler, including loading the WASM host for kmcmplib.
    * Copies options.
-   * @param callbacks - Callbacks for external interfaces, including message reporting and file io
+   * @param callbacks - Callbacks for external interfaces, including message
+   *                    reporting and file io
    * @param options   - Compiler options
    * @returns false if initialization fails
    */

--- a/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
@@ -16,7 +16,7 @@ const m = (code: number, message: string, o?: {filename?: string, line?: number}
 });
 
 /**
- * @public
+ * @internal
  * Error messages reported by the KeymanWeb .kmn compiler.
  */
 export class KmwCompilerMessages extends KmnCompilerMessages {

--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -41,13 +41,33 @@ export const SECTION_COMPILERS = [
   TranCompiler,
 ];
 
+/**
+ * @public
+ * Internal in-memory build artifacts from a successful compilation
+ */
 export interface LdmlKeyboardCompilerArtifacts extends KeymanCompilerArtifacts {
+  /**
+   * Binary keyboard filedata and filename - installable into Keyman desktop
+   * projects
+   */
   kmx?: KeymanCompilerArtifactOptional;
+  /**
+   * Binary on screen keyboard filedata and filename - installable into Keyman
+   * desktop projects alongside .kmx
+   */
   kvk?: KeymanCompilerArtifactOptional;
+  /**
+   * Javascript keyboard filedata and filename - installable into KeymanWeb,
+   * Keyman mobile products
+   */
   js?: KeymanCompilerArtifactOptional;
 };
 
 export interface LdmlKeyboardCompilerResult extends KeymanCompilerResult {
+  /**
+   * Internal in-memory build artifacts from a successful compilation. Caller
+   * can write these to disk with {@link LdmlKeyboardCompiler.write}
+   */
   artifacts: LdmlKeyboardCompilerArtifacts;
 };
 

--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -51,6 +51,12 @@ export interface LdmlKeyboardCompilerResult extends KeymanCompilerResult {
   artifacts: LdmlKeyboardCompilerArtifacts;
 };
 
+/**
+ * @public
+ * Compiles a LDML keyboard .xml file to a .kmx (KMXPlus), .kvk, and/or .js. The
+ * compiler does not read or write from filesystem or network directly, but
+ * relies on callbacks for all external IO.
+ */
 export class LdmlKeyboardCompiler implements KeymanCompiler {
   private callbacks: CompilerCallbacks;
   private options: LdmlCompilerOptions;
@@ -58,12 +64,31 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
   // uset parser
   private usetparser?: UnicodeSetParser = undefined;
 
+  /**
+   * Initialize the compiler, including loading the WASM host for uset parsing.
+   * Copies options.
+   * @param callbacks - Callbacks for external interfaces, including message
+   *                    reporting and file io
+   * @param options   - Compiler options
+   * @returns           false if initialization fails
+   */
   async init(callbacks: CompilerCallbacks, options: LdmlCompilerOptions): Promise<boolean> {
     this.options = {...options};
     this.callbacks = callbacks;
     return true;
   }
 
+  /**
+   * Compiles a LDML keyboard .xml file to .kmx, .kvk, and/or .js files. Returns
+   * an object containing binary artifacts on succes. The files are passed in by
+   * name, and the compiler will use callbacks as passed to the
+   * {@link LdmlKeyboardCompiler.init} function to read any input files by disk.
+   * @param infile  - Path to source file.
+   * @param outfile - Path to output file. The file will not be written to, but
+   *                  will be included in the result for use by
+   *                  {@link LdmlKeyboardCompiler.write}.
+   * @returns         Binary artifacts on success, null on failure.
+   */
   async run(inputFilename: string, outputFilename?: string): Promise<LdmlKeyboardCompilerResult> {
 
     let compilerOptions: LdmlCompilerOptions = {
@@ -115,6 +140,17 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
     };
   }
 
+  /**
+   * Write artifacts from a successful compile to disk, via callbacks methods.
+   * The artifacts written may include:
+   *
+   * - .kmx file - binary keyboard used by Keyman on desktop platforms
+   * - .kvk file - binary on screen keyboard used by Keyman on desktop platforms
+   * - .js file - Javascript keyboard for web and touch platforms
+   *
+   * @param artifacts - object containing artifact binary data to write out
+   * @returns true on success
+   */
   async write(artifacts: LdmlKeyboardCompilerArtifacts): Promise<boolean> {
     if(artifacts.kmx) {
       this.callbacks.fs.writeFileSync(artifacts.kmx.filename, artifacts.kmx.data);
@@ -132,6 +168,7 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
   }
 
   /**
+   * @internal
    * Construct or return a UnicodeSetParser, aka KmnCompiler
    * @returns the held UnicodeSetParser
    */
@@ -155,10 +192,11 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
   }
 
   /**
+   * @internal
    * Loads a LDML Keyboard xml file and compiles into in-memory xml
    * structures.
-   * @param filename  input filename, will use callback to load from disk
-   * @returns the source file, or null if invalid
+   * @param filename - input filename, will use callback to load from disk
+   * @returns          the source file, or null if invalid
    */
   public load(filename: string): LDMLKeyboardXMLSourceFile | null {
     const reader = new LDMLKeyboardXMLSourceFileReader(this.options.readerOptions, this.callbacks);
@@ -188,54 +226,57 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
   }
 
   /**
+   * @internal
    * Loads a LDML Keyboard test data xml file and compiles into in-memory xml
    * structures.
-   * @param filename  input filename, will use callback to load from disk
-   * @returns the source file, or null if invalid
+   * @param filename - input filename, will use callback to load from disk
+   * @returns          the source file, or null if invalid
    */
-    public loadTestData(filename: string): LDMLKeyboardTestDataXMLSourceFile | null {
-      const reader = new LDMLKeyboardXMLSourceFileReader(this.options.readerOptions, this.callbacks);
-      const data = this.callbacks.loadFile(filename);
-      if(!data) {
-        this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to read XML file'}));
-        return null;
-      }
-      const source = reader.loadTestData(data);
-      /* c8 ignore next 4 */
-      if(!source) {
-        this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to load XML file'}));
-        return null;
-      }
-      // TODO-LDML: The unboxed data doesn't match the schema anymore. Skipping validation, for now.
-
-      // try {
-      //   if (!reader.validate(source)) {
-      //     return null;
-      //   }
-      // } catch(e) {
-      //   this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: e.toString()}));
-      //   return null;
-      // }
-
-      return source;
+  public loadTestData(filename: string): LDMLKeyboardTestDataXMLSourceFile | null {
+    const reader = new LDMLKeyboardXMLSourceFileReader(this.options.readerOptions, this.callbacks);
+    const data = this.callbacks.loadFile(filename);
+    if(!data) {
+      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to read XML file'}));
+      return null;
     }
+    const source = reader.loadTestData(data);
+    /* c8 ignore next 4 */
+    if(!source) {
+      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to load XML file'}));
+      return null;
+    }
+    // TODO-LDML: The unboxed data doesn't match the schema anymore. Skipping validation, for now.
+
+    // try {
+    //   if (!reader.validate(source)) {
+    //     return null;
+    //   }
+    // } catch(e) {
+    //   this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: e.toString()}));
+    //   return null;
+    // }
+
+    return source;
+  }
 
 
   /**
+   * @internal
    * Validates that the LDML keyboard source file and lints. Actually just
    * compiles the keyboard and returns `true` if everything is good...
-   * @param     source
-   * @returns   true if the file validates
+   * @param   source - in-memory representation of LDML keyboard xml file
+   * @returns          true if the file validates
    */
   public async validate(source: LDMLKeyboardXMLSourceFile): Promise<boolean> {
     return !!(await this.compile(source, true));
   }
 
   /**
+   * @internal
    * Transforms in-memory LDML keyboard xml file to an intermediate
    * representation of a .kmx file.
-   * @param   source  in-memory representation of LDML keyboard xml file
-   * @returns         KMXPlusFile intermediate file
+   * @param   source - in-memory representation of LDML keyboard xml file
+   * @returns          KMXPlusFile intermediate file
    */
   public async compile(source: LDMLKeyboardXMLSourceFile, postValidate?: boolean): Promise<KMXPlus.KMXPlusFile> {
     const sections = this.buildSections(source);

--- a/developer/src/kmc-ldml/src/compiler/ldml-compiler-options.ts
+++ b/developer/src/kmc-ldml/src/compiler/ldml-compiler-options.ts
@@ -1,5 +1,9 @@
 import { CompilerOptions, LDMLKeyboardXMLSourceFileReaderOptions } from "@keymanapp/common-types";
 
+/**
+ * @public
+ * Options for the .xml LDML keyboard compiler
+ */
 export interface LdmlCompilerOptions extends CompilerOptions {
   /**
    * Paths and other options required for reading .xml files

--- a/developer/src/kmc-ldml/src/compiler/messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/messages.ts
@@ -5,6 +5,9 @@ const SevWarn = CompilerErrorSeverity.Warn | CompilerErrorNamespace.LdmlKeyboard
 const SevError = CompilerErrorSeverity.Error | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevFatal = CompilerErrorSeverity.Fatal | CompilerErrorNamespace.LdmlKeyboardCompiler;
 
+/**
+ * @internal
+ */
 export class CompilerMessages {
   static HINT_NormalizationDisabled = SevHint | 0x0001;
   static Hint_NormalizationDisabled = () => m(this.HINT_NormalizationDisabled, `normalization=disabled is not recommended.`);

--- a/developer/src/kmc-ldml/src/main.ts
+++ b/developer/src/kmc-ldml/src/main.ts
@@ -1,10 +1,4 @@
 
 export { LdmlKeyboardCompiler } from './compiler/compiler.js';
-export { LdmlKeyboardKeymanWebCompiler } from './compiler/keymanweb-compiler.js';
-export { LdmlKeyboardVisualKeyboardCompiler } from './compiler/visual-keyboard-compiler.js';
-export { TouchLayoutCompiler } from './compiler/touch-layout-compiler.js';
 export { LdmlCompilerOptions } from './compiler/ldml-compiler-options.js';
 export { CompilerMessages as LdmlKeyboardCompilerMessages } from './compiler/messages.js'; // TODO: rename messages.js and CompilerMessages
-export { KMXPlusMetadataCompiler } from './compiler/metadata-compiler.js';
-
-export { KMXBuilder } from "@keymanapp/common-types";


### PR DESCRIPTION
Relates to #10207.

Note: reduces the API surface by removing members which should be internal. Fixes a few minor typos in other API docs. Adds missing docs for kmc-kmn also.

@keymanapp-test-bot skip