### PR TITLE
chore(developer): consolidate external links in Developer messages

### DIFF
--- a/developer/src/common/web/utils/index.ts
+++ b/developer/src/common/web/utils/index.ts
@@ -3,3 +3,4 @@ export { KeymanSentry } from './src/KeymanSentry.js';
 export { getOption, loadOptions, clearOptions } from './src/options.js';
 export * as Osk from './src/osk.js';
 export { escapeMarkdownChar } from './src/markdown.js';
+export { KeymanUrls } from './src/keyman-urls.js';

--- a/developer/src/common/web/utils/src/keyman-urls.ts
+++ b/developer/src/common/web/utils/src/keyman-urls.ts
@@ -13,8 +13,8 @@ export class KeymanUrls {
   static readonly VIRTUAL_KEYS = ()         => `${KeymanUrls.HELP_KEYMAN_COM}/developer/language/guide/virtual-keys#common-virtual-key-codes`;
   static readonly FILE_TYPE = (ext: string) => `${KeymanUrls.HELP_KEYMAN_COM}/developer/current-version/reference/file-types/${ext}`;
   static readonly KMN_REF = (topic: string) => `${KeymanUrls.HELP_KEYMAN_COM}/developer/language/reference/${topic}`;
-  static readonly HELP_KEYBOARD_ROOT = (id: string)   => `${KeymanUrls.HELP_KEYMAN_COM}/keyboard/${id}`;
-  static readonly HELP_MODEL_ROOT = (id: string)      => `${KeymanUrls.HELP_KEYMAN_COM}/model/${id}`;
+  static readonly HELP_KEYBOARD = (id: string)   => `${KeymanUrls.HELP_KEYMAN_COM}/keyboard/${id}`;
+  static readonly HELP_MODEL = (id: string)      => `${KeymanUrls.HELP_KEYMAN_COM}/model/${id}`;
 
 
   // keyman.com

--- a/developer/src/common/web/utils/src/keyman-urls.ts
+++ b/developer/src/common/web/utils/src/keyman-urls.ts
@@ -1,0 +1,24 @@
+export class KeymanUrls {
+  static readonly HELP_KEYMAN_COM = `https://help.keyman.com`;
+  static readonly KEYMAN_COM = `https://keyman.com`;
+
+  // Various Sites
+  static readonly NEW_KEYMAN_ISSUE = ()       => 'https://github.com/keymanapp/keyman/issues/new';
+  static readonly LDML_SPEC = (topic: string) => `https://www.unicode.org/reports/tr35/tr35-keyboards.html#${topic}`;
+
+  // TODO: Not formatting code here to avoid dep on @keymanapp/common-types for developer-utils
+  static readonly COMPILER_ERROR_CODE = (code: string) => `https://kmn.sh/${code}`; // code should be km##### (already formatted)
+
+  // help.keyman.com
+  static readonly VIRTUAL_KEYS = ()         => `${KeymanUrls.HELP_KEYMAN_COM}/developer/language/guide/virtual-keys#common-virtual-key-codes`;
+  static readonly FILE_TYPE = (ext: string) => `${KeymanUrls.HELP_KEYMAN_COM}/developer/current-version/reference/file-types/${ext}`;
+  static readonly KMN_REF = (topic: string) => `${KeymanUrls.HELP_KEYMAN_COM}/developer/language/reference/${topic}`;
+  static readonly HELP_KEYBOARD_ROOT = ()   => `${KeymanUrls.HELP_KEYMAN_COM}/keyboard/`;
+  static readonly HELP_MODEL_ROOT = ()      => `${KeymanUrls.HELP_KEYMAN_COM}/model/`;
+
+
+  // keyman.com
+  static readonly KeymanDeveloper_KeymanForAndroidDownload = (version: string) => `${KeymanUrls.KEYMAN_COM}/go/developer/${version}/android-app`;
+  static readonly KeymanDeveloper_KeymanForIosDownload     = (version: string) => `${KeymanUrls.KEYMAN_COM}/go/developer/${version}/ios-app`;
+
+}

--- a/developer/src/common/web/utils/src/keyman-urls.ts
+++ b/developer/src/common/web/utils/src/keyman-urls.ts
@@ -13,8 +13,8 @@ export class KeymanUrls {
   static readonly VIRTUAL_KEYS = ()         => `${KeymanUrls.HELP_KEYMAN_COM}/developer/language/guide/virtual-keys#common-virtual-key-codes`;
   static readonly FILE_TYPE = (ext: string) => `${KeymanUrls.HELP_KEYMAN_COM}/developer/current-version/reference/file-types/${ext}`;
   static readonly KMN_REF = (topic: string) => `${KeymanUrls.HELP_KEYMAN_COM}/developer/language/reference/${topic}`;
-  static readonly HELP_KEYBOARD_ROOT = ()   => `${KeymanUrls.HELP_KEYMAN_COM}/keyboard/`;
-  static readonly HELP_MODEL_ROOT = ()      => `${KeymanUrls.HELP_KEYMAN_COM}/model/`;
+  static readonly HELP_KEYBOARD_ROOT = (id: string)   => `${KeymanUrls.HELP_KEYMAN_COM}/keyboard/${id}`;
+  static readonly HELP_MODEL_ROOT = (id: string)      => `${KeymanUrls.HELP_KEYMAN_COM}/model/${id}`;
 
 
   // keyman.com

--- a/developer/src/kmc-analyze/src/messages.ts
+++ b/developer/src/kmc-analyze/src/messages.ts
@@ -1,4 +1,5 @@
 import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/common-types";
+import { KeymanUrls } from "@keymanapp/developer-utils";
 
 const Namespace = CompilerErrorNamespace.Analyzer;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -19,7 +20,7 @@ export class AnalyzerMessages {
     o.e ?? 'unknown error',
     `Raised when an analysis components has an internal error. If you
     experience this error, it should be reported to the Keyman team for
-    resolution via https://github.com/keymanapp/keyman/issues/new`
+    resolution via ${KeymanUrls.NEW_KEYMAN_ISSUE()}`
   );
 
   static readonly INFO_ScanningFile = SevInfo | 0x0002;

--- a/developer/src/kmc-keyboard-info/src/keyboard-info-compiler.ts
+++ b/developer/src/kmc-keyboard-info/src/keyboard-info-compiler.ts
@@ -306,7 +306,7 @@ export class KeyboardInfoCompiler implements KeymanCompiler {
 
     keyboard_info.minKeymanVersion = minVersion;
     keyboard_info.sourcePath = sources.sourcePath;
-    keyboard_info.helpLink = KeymanUrls.HELP_KEYBOARD_ROOT() + keyboard_info.id;
+    keyboard_info.helpLink = KeymanUrls.HELP_KEYBOARD(keyboard_info.id);
 
     // Related packages
     if(kmpJsonData.relatedPackages?.length) {

--- a/developer/src/kmc-keyboard-info/src/keyboard-info-compiler.ts
+++ b/developer/src/kmc-keyboard-info/src/keyboard-info-compiler.ts
@@ -8,7 +8,7 @@ import { KeyboardInfoFile, KeyboardInfoFileIncludes, KeyboardInfoFileLanguageFon
 import { KeymanFileTypes, CompilerCallbacks, KmpJsonFile, KmxFileReader, KMX, KeymanTargets, KeymanCompiler, CompilerOptions, KeymanCompilerResult, KeymanCompilerArtifacts, KeymanCompilerArtifact } from "@keymanapp/common-types";
 import { KeyboardInfoCompilerMessages } from "./keyboard-info-compiler-messages.js";
 import langtags from "./imports/langtags.js";
-import { validateMITLicense } from "@keymanapp/developer-utils";
+import { KeymanUrls, validateMITLicense } from "@keymanapp/developer-utils";
 import { KmpCompiler } from "@keymanapp/kmc-package";
 
 import { SchemaValidators } from "@keymanapp/common-types";
@@ -17,8 +17,6 @@ import { getFontFamily } from "./font-family.js";
 const regionNames = new Intl.DisplayNames(['en'], { type: "region" });
 const scriptNames = new Intl.DisplayNames(['en'], { type: "script" });
 const langtagsByTag = {};
-
-const HelpRoot = 'https://help.keyman.com/keyboard/';
 
 /**
  * Build a dictionary of language tags from langtags.json
@@ -308,7 +306,7 @@ export class KeyboardInfoCompiler implements KeymanCompiler {
 
     keyboard_info.minKeymanVersion = minVersion;
     keyboard_info.sourcePath = sources.sourcePath;
-    keyboard_info.helpLink = HelpRoot + keyboard_info.id;
+    keyboard_info.helpLink = KeymanUrls.HELP_KEYBOARD_ROOT() + keyboard_info.id;
 
     // Related packages
     if(kmpJsonData.relatedPackages?.length) {

--- a/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
@@ -1,5 +1,6 @@
 import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/common-types";
 import { kmnfile } from "../kmw-compiler/compiler-globals.js";
+import { KeymanUrls } from "@keymanapp/developer-utils";
 
 const Namespace = CompilerErrorNamespace.KmnCompiler;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -86,7 +87,7 @@ export class KmnCompilerMessages {
     o.e ?? 'unknown error',
     `Raised when KmnCompiler or one of its components has an internal
     error. If you experience this error, it should be reported to the Keyman
-    team for resolution via https://github.com/keymanapp/keyman/issues/new.`
+    team for resolution via ${KeymanUrls.NEW_KEYMAN_ISSUE()}.`
   );
 
   static FATAL_MissingWasmModule = SevFatal | 0x901;
@@ -110,7 +111,7 @@ export class KmnCompilerMessages {
     `Callbacks were not set with init`,
     `Raised when KmnCompiler or one of its components experiences an internal
     error. If you experience this error, it should be reported to the Keyman
-    team for resolution via https://github.com/keymanapp/keyman/issues/new.`
+    team for resolution via ${KeymanUrls.NEW_KEYMAN_ISSUE()}.`
   );
 
   static FATAL_UnicodeSetOutOfRange = SevFatal | 0x904;
@@ -120,7 +121,7 @@ export class KmnCompilerMessages {
     `UnicodeSet buffer was too small`,
     `Raised when caller to UnicodeSet functions provides an invalid buffer. If
     you experience this error, it should be reported to the Keyman team for
-    resolution via https://github.com/keymanapp/keyman/issues/new.`
+    resolution via ${KeymanUrls.NEW_KEYMAN_ISSUE()}.`
   );
 
   // TODO: rename the following functions to Error_UsetHasStrings etc
@@ -134,7 +135,7 @@ export class KmnCompilerMessages {
     keyboards do not support multi-character strings in usets. To resolve this,
     reformat the uset to avoid the use of multi-character strings.
 
-    More on uset: https://www.unicode.org/reports/tr35/tr35-keyboards.html#element-uset`
+    More on uset: ${KeymanUrls.LDML_SPEC('element-uset')}`
   );
 
   static ERROR_UnicodeSetHasProperties = SevError | 0x906;
@@ -146,7 +147,7 @@ export class KmnCompilerMessages {
     make implementations dependent on a particular version of Unicode. To
     resolve this, reformat the uset to avoid the use of properties.
 
-    More on uset: https://www.unicode.org/reports/tr35/tr35-keyboards.html#element-uset`
+    More on uset: ${KeymanUrls.LDML_SPEC('element-uset')}`
   );
 
   static ERROR_UnicodeSetSyntaxError = SevError | 0x907;
@@ -156,7 +157,7 @@ export class KmnCompilerMessages {
     `The provided uset has a syntax error and could not be parsed. Verify the
     format of the uset against the specification.
 
-    More on uset: https://www.unicode.org/reports/tr35/tr35-keyboards.html#element-uset`
+    More on uset: ${KeymanUrls.LDML_SPEC('element-uset')}`
   );
 
   static ERROR_InvalidKvksFile = SevError | 0x908;
@@ -167,7 +168,7 @@ export class KmnCompilerMessages {
     There may be additional information in the error message to help you
     resolve the error.
 
-    More on .kvks file format: https://help.keyman.com/developer/current-version/reference/file-types/kvks`
+    More on .kvks file format: ${KeymanUrls.FILE_TYPE('kvks')}`
   );
 
   static WARN_InvalidVkeyInKvksFile = SevWarn | 0x909;
@@ -177,7 +178,7 @@ export class KmnCompilerMessages {
     `The .kvks file contained a virtual key that was not supported by
     Keyman. Remove this virtual key from the .kvks file.
 
-    Supported virtual keys: https://help.keyman.com/developer/language/guide/virtual-keys#common-virtual-key-codes`
+    Supported virtual keys: ${KeymanUrls.VIRTUAL_KEYS()}`
   );
 
   static ERROR_InvalidDisplayMapFile = SevError | 0x90A;
@@ -188,7 +189,7 @@ export class KmnCompilerMessages {
     file. There may be additional information in the error message to help you
     resolve the error.
 
-    More on displayMap: https://help.keyman.com/developer/language/reference/displaymap`
+    More on displayMap: ${KeymanUrls.KMN_REF('displaymap')}`
   );
 
   static ERROR_InvalidKvkFile = SevError | 0x90B;
@@ -199,7 +200,7 @@ export class KmnCompilerMessages {
     may be additional information in the error message to help you resolve the
     error.
 
-    More on .kvk files: https://help.keyman.com/developer/current-version/reference/file-types/kvk`
+    More on .kvk files: ${KeymanUrls.FILE_TYPE('kvk')}`
   );
 
   static ERROR_FileNotFound = SevError | 0x90C;

--- a/developer/src/kmc-model-info/src/model-info-compiler.ts
+++ b/developer/src/kmc-model-info/src/model-info-compiler.ts
@@ -183,7 +183,7 @@ export class ModelInfoCompiler implements KeymanCompiler {
     model_info.packageIncludes = sources.kmpJsonData.files.filter((e) => !!e.name.match(/.[ot]tf$/i)).length ? ['fonts'] : [];
     model_info.version = sources.kmpJsonData.info.version.description;
     model_info.minKeymanVersion = minKeymanVersion;
-    model_info.helpLink = KeymanUrls.HELP_MODEL_ROOT() + model_info.id;
+    model_info.helpLink = KeymanUrls.HELP_MODEL(model_info.id);
 
     if(sources.sourcePath) {
       model_info.sourcePath = sources.sourcePath;

--- a/developer/src/kmc-model-info/src/model-info-compiler.ts
+++ b/developer/src/kmc-model-info/src/model-info-compiler.ts
@@ -7,9 +7,7 @@ import { minKeymanVersion } from "./min-keyman-version.js";
 import { ModelInfoFile } from "./model-info-file.js";
 import { CompilerCallbacks, CompilerOptions, KeymanCompiler, KeymanCompilerArtifact, KeymanCompilerArtifacts, KeymanCompilerResult, KmpJsonFile } from "@keymanapp/common-types";
 import { ModelInfoCompilerMessages } from "./model-info-compiler-messages.js";
-import { validateMITLicense } from "@keymanapp/developer-utils";
-
-const HelpRoot = 'https://help.keyman.com/model/';
+import { KeymanUrls, validateMITLicense } from "@keymanapp/developer-utils";
 
 /* c8 ignore start */
 export class ModelInfoSources {
@@ -185,7 +183,7 @@ export class ModelInfoCompiler implements KeymanCompiler {
     model_info.packageIncludes = sources.kmpJsonData.files.filter((e) => !!e.name.match(/.[ot]tf$/i)).length ? ['fonts'] : [];
     model_info.version = sources.kmpJsonData.info.version.description;
     model_info.minKeymanVersion = minKeymanVersion;
-    model_info.helpLink = HelpRoot + model_info.id;
+    model_info.helpLink = KeymanUrls.HELP_MODEL_ROOT() + model_info.id;
 
     if(sources.sourcePath) {
       model_info.sourcePath = sources.sourcePath;

--- a/developer/src/kmc/src/commands/messageCommand.ts
+++ b/developer/src/kmc/src/commands/messageCommand.ts
@@ -8,7 +8,7 @@ import { NodeCompilerCallbacks } from '../util/NodeCompilerCallbacks.js';
 import { exitProcess } from '../util/sysexits.js';
 import { InfrastructureMessages } from '../messages/infrastructureMessages.js';
 import { CompilerMessageDetail, findMessageDetails } from '../util/extendedCompilerOptions.js';
-import { escapeMarkdownChar } from '@keymanapp/developer-utils';
+import { escapeMarkdownChar, KeymanUrls } from '@keymanapp/developer-utils';
 
 type MessageFormat = 'text'|'markdown'|'json';
 
@@ -90,10 +90,10 @@ async function messageCommand(messages: string[], _options: any, commander: any)
   }
 }
 
-// We have a redirect pattern for https://help.keyman.com/go/km<#####> to
+// We have a redirect pattern for kmn.sh/km<#####> to
 // the corresponding compiler message reference document in
-// /developer/latest-version/reference/errors/km<#####>
-const helpUrl = (code:any) => `https://help.keyman.com/go/${CompilerError.formatCode(code).toLowerCase()}`;
+// help.keyman.com/developer/latest-version/reference/errors/km<#####>
+const helpUrl = (code:any) => KeymanUrls.COMPILER_ERROR_CODE(CompilerError.formatCode(code).toLowerCase());
 const getModuleName = (ms: CompilerMessageSource) => `${ms.module}.${ms.class.name}`;
 
 function translateMessageInputToCode(message: string, callbacks: CompilerCallbacks): CompilerMessageDetail {

--- a/developer/src/server/src/handlers/inc/packages-json.ts
+++ b/developer/src/server/src/handlers/inc/packages-json.ts
@@ -1,3 +1,4 @@
+import { KeymanUrls } from '@keymanapp/developer-utils';
 import * as express from 'express';
 import { data } from "../../data.js";
 import { environment } from '../../environment.js';
@@ -7,15 +8,8 @@ export default function handleIncPackagesJson (req: express.Request, res: expres
   res.send({
     packages: packages,
     urls: {
-      installLinkAndroid: makeKeymanURL(URLPath_KeymanDeveloper_KeymanForAndroidDownload),
-      installLinkIos: makeKeymanURL(URLPath_KeymanDeveloper_KeymanForIosDownload),
+      installLinkAndroid: KeymanUrls.KeymanDeveloper_KeymanForAndroidDownload(environment.versionRelease),
+      installLinkIos: KeymanUrls.KeymanDeveloper_KeymanForIosDownload(environment.versionRelease),
     }
   });
-}
-
-const URLPath_KeymanDeveloper_KeymanForAndroidDownload = '/go/developer/'+environment.versionRelease+'/android-app'
-const URLPath_KeymanDeveloper_KeymanForIosDownload = '/go/developer/'+environment.versionRelease+'/ios-app'
-
-function makeKeymanURL(base: string) {
-  return 'https://keyman.com' + base;
 }


### PR DESCRIPTION
Establishes keyman-urls.ts as a single place for any links to external websites.

I searched all .ts files in Keyman Developer source and replaced references to websites with function calls here. Note that the names of individual functions within this class can be easily changed as needed, as the hard part was the consolidation.

@keymanapp-test-bot skip