### PR TITLE
fix(developer): Treat Right Shift as Shift in debugger

### DIFF
--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -434,6 +434,13 @@ begin
   // mapping; the best way to do this is to extract the scan code from
   // the message data and work from that
   vkey := MapScanCodeToUSVK((Message.LParam and $FF0000) shr 16);
+
+  // We don't support the Right Shift modifier in Keyman;
+  // we treat it as Left Shift, even though MapScanCodeToUSVK
+  // recognizes it
+  if vkey = VK_RSHIFT then
+    vkey := VK_SHIFT;
+
   modifier := 0;
 
   if GetKeyState(VK_LCONTROL) < 0 then modifier := modifier or KM_CORE_MODIFIER_LCTRL;


### PR DESCRIPTION
Fixes #10915.

Note that a more systemic fix to keyman core will involve ensuring that the debug list is always properly terminated, but that does not need to happen in beta.

# User Testing

* **TEST_DEBUG_MODIFIERS:** In the Keyman Developer integrated debugger, verify that _none_ of the keys on the keyboard cause Keyman Developer to crash as shown in #10915.