### PR TITLE
fix(ios): delayed banner

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -423,8 +423,6 @@ extension KeymanWebViewController {
     } else {  // We're registering a model in the background - don't change settings.
       webView!.evaluateJavaScript("keyman.addModel(\(stubString));", completionHandler: nil)
     }
-
-    setBannerHeight(to: Int(InputViewController.topBarHeight))
   }
 
   func showBanner(_ display: Bool) {
@@ -743,6 +741,8 @@ extension KeymanWebViewController: KeymanWebDelegate {
     setBannerImage(to: bannerImgPath)
     // Reset the keyboard's size.
     keyboardSize = kbSize
+
+    setBannerHeight(to: Int(InputViewController.topBarHeight))
 
     fixLayout()
 

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -76,7 +76,9 @@ function showBanner(flag) {
     console.log("Setting banner display for dictionaryless keyboards to " + flag);
 
     var bc = keyman.osk.bannerController;
-    bc.inactiveBanner = flag ? new bc.ImageBanner(bannerImgPath) : null;
+    if(bannerImgPath) {
+      bc.inactiveBanner = new bc.ImageBanner(bannerImgPath);
+    }
 }
 
 function setBannerImage(path) {
@@ -88,7 +90,7 @@ function setBannerImage(path) {
     }
 
     // If an inactive banner is set, update its image.
-    bc.inactiveBanner = bc.inactiveBanner ? new bc.ImageBanner(bannerImgPath) : null;
+    bc.inactiveBanner = new bc.ImageBanner(bannerImgPath);
 }
 
 function setBannerHeight(h) {


### PR DESCRIPTION
Fixes #10847.

This PR ensures that the banner displays consistently when it is supposed to do so, and in its intended manner.  The image banner should no longer be distorted or smaller than intended at any time.

## User Testing

**TEST_SYSTEM_KBD**:  Attempt to reproduce the errors documented in #10847 and verify that they are now fixed.

1. Install this PR's test artifact.
2. Open Keyman In-app. 
3. Download and Install sil_ipa or any other keyboard that does not have a dictionary feature. 
4. Enable as a system-wide keyboard. 
5. Open any browser. 
6. Change the Orientation into Landscape. 
7. Long the press the globe key. Switch Keyman Keyboard. 
8. Switch to sil_ipa keyboard.