### PR TITLE
chore(ios): removes the "Show Banner" settings option

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Constants.swift
@@ -61,6 +61,7 @@ public enum Key {
 
   // Settings-related keys
   static let optShouldReportErrors = "ShouldReportErrors"
+  // Deprecated - no longer used
   static let optShouldShowBanner = "ShouldShowBanner"
   static let optSpacebarText = "SpacebarText"
   // This one SHOULD be app-only, but is needed by the currently

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -427,20 +427,11 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
       case .doNothing:
         break
       }
-
-      // If we allow the system keyboard to show no banners, this line is needed
-      // for variable system keyboard height.
-      updateShowBannerSetting()
     } else { // Use in-app keyboard behavior instead.
       if !(Manager.shared.currentResponder?.showKeyboardPicker() ?? false) {
         _ = Manager.shared.switchToNextKeyboard
       }
     }
-  }
-
-  // Needed due to protection level on the `keymanWeb` property
-  func updateShowBannerSetting() {
-    keymanWeb.updateShowBannerSetting()
   }
 
   func updateSpacebarText() {
@@ -469,14 +460,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   }
 
   public var isTopBarActive: Bool {
-    let userData = Storage.active.userDefaults
-    let alwaysShow = userData.bool(forKey: Key.optShouldShowBanner)
-
-    if alwaysShow || Manager.shared.isSystemKeyboard || keymanWeb.activeModel {
-      return true
-    }
-
-    return false
+    return true
   }
 
   public var activeTopBarHeight: CGFloat {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -153,7 +153,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   }
 
   var expandedHeight: CGFloat {
-    return keymanWeb.keyboardHeight + activeTopBarHeight
+    return keymanWeb.keyboardHeight + InputViewController.topBarHeight
   }
 
   public convenience init() {
@@ -457,15 +457,6 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     baseWidthConstraint = self.inputView!.widthAnchor.constraint(equalTo: parent!.view.safeAreaLayoutGuide.widthAnchor)
     baseWidthConstraint.priority = UILayoutPriority(rawValue: 999)
     baseWidthConstraint.isActive = true
-  }
-
-  public var isTopBarActive: Bool {
-    return true
-  }
-
-  public var activeTopBarHeight: CGFloat {
-    // If 'isSystemKeyboard' is true, always show the top bar.
-    return isTopBarActive ? CGFloat(InputViewController.topBarHeight) : 0
   }
 
   public var kmwHeight: CGFloat {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeyboardMenuView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeyboardMenuView.swift
@@ -339,7 +339,6 @@ class KeyboardMenuView: UIView, UITableViewDelegate, UITableViewDataSource, UIGe
       // keyboard loaded does not provide suggestions.  Parking it here as it's not
       // worth pursuing further at this stage.
       inputViewController?.updateViewConstraints()
-      inputViewController?.updateShowBannerSetting()
       return
     }
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -425,11 +425,11 @@ extension KeymanWebViewController {
     }
   }
 
-  func showBanner(_ display: Bool) {
-    let message = "Changing banner's alwaysShow property to \(display)"
+  func setUpBanner() {
+    let message = "Changing banner's alwaysShow property to true"
     os_log("%{public}s", log: KeymanEngineLogger.settings, type: .debug, message)
     SentryManager.breadcrumb(message, category: "engine", sentryLevel: .debug)
-    webView?.evaluateJavaScript("showBanner(\(display ? "true" : "false"))", completionHandler: nil)
+    webView?.evaluateJavaScript("showBanner(true)", completionHandler: nil)
   }
 
   func setBannerImage(to path: String) {
@@ -737,7 +737,7 @@ extension KeymanWebViewController: KeymanWebDelegate {
     }
 
     updateSpacebarText()
-    updateShowBannerSetting()
+    setUpBanner()
     setBannerImage(to: bannerImgPath)
     // Reset the keyboard's size.
     keyboardSize = kbSize
@@ -754,16 +754,6 @@ extension KeymanWebViewController: KeymanWebDelegate {
       NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(self.resetKeyboard), object: nil)
       perform(#selector(self.resetKeyboard), with: nil, afterDelay: 0.25)
       shouldReload = false
-    }
-  }
-
-  func updateShowBannerSetting() {
-    let userData = Storage.active.userDefaults
-    let alwaysShow = userData.bool(forKey: Key.optShouldShowBanner)
-    if !Manager.shared.isSystemKeyboard {
-      showBanner(false)
-    } else {
-      showBanner(alwaysShow)
     }
   }
 
@@ -1128,8 +1118,6 @@ extension KeymanWebViewController {
     isLoading = true
 
     updateSpacebarText()
-    // Check for a change of "always show banner" state
-    updateShowBannerSetting()
   }
 
   /*

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -425,13 +425,6 @@ extension KeymanWebViewController {
     }
   }
 
-  func setUpBanner() {
-    let message = "Changing banner's alwaysShow property to true"
-    os_log("%{public}s", log: KeymanEngineLogger.settings, type: .debug, message)
-    SentryManager.breadcrumb(message, category: "engine", sentryLevel: .debug)
-    webView?.evaluateJavaScript("showBanner(true)", completionHandler: nil)
-  }
-
   func setBannerImage(to path: String) {
     bannerImgPath = path // Save the path in case delayed initializaiton is needed.
     var logString: String
@@ -737,7 +730,6 @@ extension KeymanWebViewController: KeymanWebDelegate {
     }
 
     updateSpacebarText()
-    setUpBanner()
     setBannerImage(to: bannerImgPath)
     // Reset the keyboard's size.
     keyboardSize = kbSize

--- a/ios/engine/KMEI/KeymanEngine/Classes/SettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/SettingsViewController.swift
@@ -62,12 +62,6 @@ open class SettingsViewController: UITableViewController {
       ])
     
     itemsArray.append([
-      "title": NSLocalizedString("menu-settings-show-banner", bundle: engineBundle, comment: ""),
-      "subtitle": "",
-      "reuseid" : "showbanner"
-      ])
-    
-    itemsArray.append([
       "title": NSLocalizedString("menu-settings-startup-get-started", bundle: engineBundle, comment: ""),
       "subtitle": "",
       "reuseid" : "showgetstarted"
@@ -151,21 +145,6 @@ open class SettingsViewController: UITableViewController {
     switch(cellIdentifier) {
       case "languages":
         break
-      case "showbanner":
-        let showBannerSwitch = UISwitch()
-        showBannerSwitch.translatesAutoresizingMaskIntoConstraints = false
-        
-        let switchFrame = frameAtRightOfCell(cell: cell.frame, controlSize: showBannerSwitch.frame.size)
-        showBannerSwitch.frame = switchFrame
-        
-        showBannerSwitch.isOn = showBanner
-        showBannerSwitch.addTarget(self, action: #selector(self.bannerSwitchValueChanged),
-                                      for: .valueChanged)
-        cell.addSubview(showBannerSwitch)
-        cell.contentView.isUserInteractionEnabled = false
-
-        showBannerSwitch.rightAnchor.constraint(equalTo: cell.layoutMarginsGuide.rightAnchor).isActive = true
-        showBannerSwitch.centerYAnchor.constraint(equalTo: cell.layoutMarginsGuide.centerYAnchor).isActive = true
       case "showgetstarted":
         let showAgainSwitch = UISwitch()
         showAgainSwitch.translatesAutoresizingMaskIntoConstraints = false
@@ -216,30 +195,12 @@ open class SettingsViewController: UITableViewController {
     }
   }
   
-  @objc func bannerSwitchValueChanged(_ sender: Any) {
-    let userData = Storage.active.userDefaults
-    if let toggle = sender as? UISwitch {
-      // actually this should call into KMW, which controls the banner
-      userData.set(toggle.isOn, forKey: Key.optShouldShowBanner)
-      userData.synchronize()
-    }
-
-    // Necessary for the keyboard to visually update to match
-    // the new setting.
-    Manager.shared.inputViewController.setShouldReload()
-  }
-  
   @objc func showGetStartedSwitchValueChanged(_ sender: Any) {
     let userData = Storage.active.userDefaults
     if let toggle = sender as? UISwitch {
       userData.set(toggle.isOn, forKey: Key.optShouldShowGetStarted)
       userData.synchronize()
     }
-  }
-
-  private var showBanner: Bool {
-    let userData = Storage.active.userDefaults
-    return userData.bool(forKey: Key.optShouldShowBanner)
   }
   
   private var showGetStarted: Bool {

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -60,6 +60,11 @@ function init() {
         kmw.osk.bannerView.activeBannerHeight = bannerHeight;
         keyman.refreshOskLayout();
       }
+
+      var bc = keyman.osk.bannerController;
+      if(bannerImgPath) {
+        bc.inactiveBanner = new bc.ImageBanner(bannerImgPath);
+      }
     });
 }
 
@@ -69,15 +74,6 @@ function verifyLoaded() {
     // against the stub count.
     if(!keyman.core.activeKeyboard && !keyman.keyboardRequisitioner.cache.defaultStub) {
     location.reload();
-    }
-}
-
-function showBanner(flag) {
-    console.log("Setting banner display for dictionaryless keyboards to " + flag);
-
-    var bc = keyman.osk.bannerController;
-    if(bannerImgPath) {
-      bc.inactiveBanner = new bc.ImageBanner(bannerImgPath);
     }
 }
 


### PR DESCRIPTION
Fully removes the "Show Banner" settings option.  We've elected to force the banner to always be on in 17.0 due for multiple reasons:
- (For phones) This provides space for a key tip for keys in the top row.
- (Phones and tablets) This facilitates upward flicks for keys in the top row.
- (For phones) This provides better visibility of the flick preview for flicks in non-upward directions for keys in the top row.
- (Phones and tablets) This makes subkey menu interactions less awkward for such keys as well.

After piecing together my other two PRs today, I noticed that we hadn't actually removed the "Show Banner" option from the iOS app yet - something we already _have_ done in the Android app.  We've already stated our intent to remove it internally, so I figured I'd go ahead and knock this one out while I was mentally dwelling on it.

## User Testing

**TEST_SETTINGS**: Verify that all remaining top-level settings menu options work as intended.

**TEST_BANNER**:  Verify that the appropriate banner type is displayed for the active keyboard at all times, whether in-app or when used as the system keyboard.