### PR TITLE
fix(developer): search-term quote replacement was not global

### DIFF
--- a/developer/src/kmc-model/src/model-defaults.ts
+++ b/developer/src/kmc-model/src/model-defaults.ts
@@ -60,9 +60,7 @@ export function defaultCasedSearchTermToKey(wordform: string, applyCasing: Casin
         // Remove any combining diacritics (if input is in NFKD)
         .replace(/[\u0300-\u036F]/g, '')
       ) // end of `Array.from`
-      .map(function(c) {
-        return applyCasing('lower', c)
-      })
+      .map(function(c) { return applyCasing('lower', c)})
       .join('')
       // Replace directional quotation marks with plain apostrophes
       .replace(/[‘’]/g, "'")

--- a/developer/src/kmc-model/src/model-defaults.ts
+++ b/developer/src/kmc-model/src/model-defaults.ts
@@ -25,11 +25,9 @@ export function defaultSearchTermToKey(wordform: string): string {
       // Remove any combining diacritics (if input is in NFKD)
       .replace(/[\u0300-\u036F]/g, '')
       // Replace directional quotation marks with plain apostrophes
-      .replace(/‘/, "'")
-      .replace(/’/, "'")
+      .replace(/[‘’]/g, "'")
       // Also double-quote marks.
-      .replace(/“/, '"')
-      .replace(/”/, '"');
+      .replace(/[“”]/g, '"');
 }
 
 /**
@@ -62,14 +60,14 @@ export function defaultCasedSearchTermToKey(wordform: string, applyCasing: Casin
         // Remove any combining diacritics (if input is in NFKD)
         .replace(/[\u0300-\u036F]/g, '')
       ) // end of `Array.from`
-      .map(function(c) { return applyCasing('lower', c)})
+      .map(function(c) {
+        return applyCasing('lower', c)
+      })
       .join('')
       // Replace directional quotation marks with plain apostrophes
-      .replace(/‘/, "'")
-      .replace(/’/, "'")
+      .replace(/[‘’]/g, "'")
       // Also double-quote marks.
-      .replace(/“/, '"')
-      .replace(/”/, '"');
+      .replace(/[“”]/g, '"');
 }
 
 /**


### PR DESCRIPTION
Noted this one while working on https://github.com/keymanapp/lexical-models/pull/244.

Should a single word contain multiple directional quotes and/or apostrophes, all should be corrected - not just the first.

@keymanapp-test-bot skip