### PR TITLE
fix(windows): GetKeyboardLanguage exits early on an invalid keyboard ID 

### DIFF
--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.System.TIPMaintenance.pas
@@ -396,11 +396,16 @@ class function TTIPMaintenance.GetKeyboardLanguage(const KeyboardID,
   BCP47Tag: string): IKeymanKeyboardLanguageInstalled;
 var
   keyboard: IKeymanKeyboardInstalled;
-  i: Integer;
+  i, n: Integer;
 begin
-  keyboard := kmcom.Keyboards[KeyboardID];
-  if keyboard = nil then
+  n := kmcom.Keyboards.IndexOf(KeyboardID);
+  if n < 0 then
+  begin
+    KL.Log('TTIPMaintenance.GetKeyboardLanguage = KeyboardID:%s not found', [KeyboardID]);
     Exit(nil);
+  end;
+
+  keyboard := kmcom.Keyboards[n];
 
   for i := 0 to keyboard.Languages.Count - 1 do
     if SameText(keyboard.Languages[i].BCP47Code, BCP47Tag) then


### PR DESCRIPTION
fixes: #10793 


# User Testing

## TEST_INVALID_KEYBOARD_ID

1. Install Keyman for Windows from this PR build
2. Install the BJCreeUNI keyboard
3. Open a command prompt and change to the path of kmshell.exe. 
`cd %ProgramFiles(x86)%\Keyman\Keyman Desktop`
4. Type: `kmshell.exe  -s -ikl bj_cree-east crj-Cans-CA` 
Observe that no crash report is generated. Nothing observable should happen. 
Note: the error here is the hyphen in the keyboard id `bj_cree-east` instead of an underscore.

## TEST_VALID_KEYBOARD_ID

Now test the command still works for valid keyboard ids.

1. Install Keyman for Windows from this PR build
2. Install the BJCreeUNI keyboard
3. Open a command prompt and change to the path of kmshell.exe. 
`cd %ProgramFiles(x86)%\Keyman\Keyman Desktop`
4. Type: `kmshell.exe  -s -ikl bj_cree_east crj-Cans-CA` 
5. Observe that no crash report is generated. Nothing observable on the command prompt will happen.
6. Open Keyman Configuration->Keyboard Layouts tab
7. Select BJCreeUNI (east)
Expected Result: Observe that the Languages: Has crj-Cans-CA
![Screenshot 2024-03-05 153825](https://github.com/keymanapp/keyman/assets/58423624/90844540-3d33-490d-9163-e2aa85bbeacb)


