### PR TITLE
docs(developer): add help site links

### DIFF
--- a/developer/src/tike/child/Keyman.Developer.UI.UfrmLdmlKeyboardEditor.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.UfrmLdmlKeyboardEditor.pas
@@ -32,6 +32,7 @@ type
   protected
     procedure LoadSettings; override;
     procedure SaveSettings(SaveProject: Boolean); override;
+    function GetHelpTopic: string; override;
   public
     procedure StartDebugging;
     procedure StopDebugging;
@@ -45,6 +46,7 @@ implementation
 uses
   keymanstrings,
   KeymanDeveloperOptions,
+  Keyman.Developer.System.HelpTopics,
   Keyman.System.Debug.DebugUIStatus,
   Keyman.Developer.System.Project.xmlLdmlProjectFile,
   Keyman.Developer.UI.Project.ProjectFileUI,
@@ -63,6 +65,11 @@ begin
   inherited;
   EditorFormat := efXML;
   SetupDebugForm;
+end;
+
+function TfrmLdmlKeyboardEditor.GetHelpTopic: string;
+begin
+  Result := SHelpTopic_Context_LdmlEditor;
 end;
 
 function TfrmLdmlKeyboardEditor.GetIsDebugVisible: Boolean;

--- a/developer/src/tike/help/Keyman.Developer.System.HelpTopics.pas
+++ b/developer/src/tike/help/Keyman.Developer.System.HelpTopics.pas
@@ -8,6 +8,8 @@ const
   SHelpTopic_Context_CharacterMap = 'context/character-map';
   SHelpTopic_Context_CharacterIdentifier = 'context/character-identifier';
   SHelpTopic_Context_Debug = 'context/debug';
+  SHelpTopic_Context_LdmlDebug = 'context/ldml-debug';
+  SHelpTopic_Context_LdmlEditor = 'context/ldml-editor';
   SHelpTopic_Context_DebugStatus = 'context/debug#toc-state';
   SHelpTopic_Context_DebugStatus_CallStack = 'context/debug#toc-call-stack';
   SHelpTopic_Context_DebugStatus_DeadKeys = 'context/debug#toc-deadkeys';
@@ -25,6 +27,7 @@ const
   SHelpTopic_Context_NewProject = 'context/new-project';
   SHelpTopic_Context_NewProjectParameters = 'context/new-project-parameters';
   SHelpTopic_Context_NewModelProjectParameters = 'context/new-model-project-parameters';
+  SHelpTopic_Context_NewLdmlProjectParameters = 'context/new-ldml-project-parameters';
   SHelpTopic_Context_NewFileDetails = 'context/new-file-details';
   SHelpTopic_Context_OnScreenKeyboardEditor = 'context/keyboard-editor#toc-on-screen-tab';
   SHelpTopic_Context_Options = 'context/options';

--- a/developer/src/tike/main/UframeTextEditor.pas
+++ b/developer/src/tike/main/UframeTextEditor.pas
@@ -105,6 +105,7 @@ type
       State: TDragState; var Accept: Boolean);
     procedure DelayedFindError;
     procedure DoOpenLinkIfExternal(const url: string; var handled: Boolean);
+    procedure cefHelpTopic(Sender: TObject);
 
   protected
     function GetHelpTopic: string; override;
@@ -349,6 +350,7 @@ begin
   cef.OnCommand := cefCommand;
   cef.OnLoadEnd := cefLoadEnd;
   cef.OnBeforeBrowseSync := cefBeforeBrowseSync;
+  cef.OnHelpTopic := cefHelpTopic;
 
   cef.cef.OnBeforeContextMenu := cefBeforeContextMenu;
   cef.cef.OnContextMenuCommand := cefContextMenuCommand;
@@ -362,6 +364,11 @@ end;
 procedure TframeTextEditor.SetupCharMapDrop;
 begin
   GetCharMapDropTool.Handle(cef, cmimDefault, CharMapDragOver, CharMapDragDrop);
+end;
+
+procedure TframeTextEditor.cefHelpTopic(Sender: TObject);
+begin
+  frmKeymanDeveloper.HelpTopic(Self);
 end;
 
 procedure TframeTextEditor.cefLoadEnd(Sender: TObject);
@@ -1126,7 +1133,11 @@ end;
 function TframeTextEditor.GetHelpTopic: string;
 begin
   if FEditorFormat <> efKMN then
+  begin
+    if Parent is TTIKEForm then
+      Exit((Parent as TTIKEForm).HelpTopic);
     Exit(SHelpTopic_Context_TextEditor);
+  end;
 
   Result := HelpKeyword;
 end;

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewLDMLKeyboardProjectParameters.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewLDMLKeyboardProjectParameters.pas
@@ -293,7 +293,7 @@ end;
 
 function TfrmNewLDMLKeyboardProjectParameters.GetHelpTopic: string;
 begin
-  Result := SHelpTopic_Context_NewProjectParameters;
+  Result := SHelpTopic_Context_NewLdmlProjectParameters;
 end;
 
 function TfrmNewLDMLKeyboardProjectParameters.GetKeyboardID: string;


### PR DESCRIPTION
Fixes #10550.

Also fixes an inadvertent issue where F1 was not opening context help in the text editor anywhere in Keyman Developer. This means that pressing F1 while a keyword is highlighted in a .kmn keyboard will not re-open the context help for that keyword once more (yay!)

# User Testing

Wait for keymanapp/help.keyman.com#1090 to be merged before doing this test.

* TEST_NEW_PROJECT_HELP: In the New Project, New LDML Keyboard Project window, press F1. The help for the window should open in your browser.
* TEST_LDML_EDITOR_HELP: Open an LDML XML keyboard and press F1. The help for the LDML editor window should open in your browser.
* TEST_LDML_DEBUGGER_HELP: Open an LDML XML keyboard, compile and start testing (F5) and press F1. The help for the LDML debug window should open in your browser.
* TEST_KMN_CONTEXT_HELP: Open a Keyman .kmn keyboard, click on a keyword in the source view (e.g. `begin`, `store`, `index`, etc) and press F1. The help for that topic should open in your browser. You may wish to try with a few keywords.