### PR TITLE
fix(developer): message export filename was title case

### DIFF
--- a/developer/src/kmc/src/commands/messageCommand.ts
+++ b/developer/src/kmc/src/commands/messageCommand.ts
@@ -271,7 +271,7 @@ title: Compiler Messages Reference for @keymanapp/${ms.module}
     fs.writeFileSync(path.join(outPath, filename + '.md'), content, 'utf-8');
   }
 
-  fs.writeFileSync(path.join(outPath, moduleName + '.md'), index, 'utf-8');
+  fs.writeFileSync(path.join(outPath, moduleName.toLowerCase() + '.md'), index, 'utf-8');
 }
 
 function formatMessageAsMarkdown(moduleName: string, id: string, message: CompilerEvent) {


### PR DESCRIPTION
Triggered failure seen in https://github.com/keymanapp/help.keyman.com/pull/1085.

@keymanapp-test-bot skip