### PR TITLE
fix(developer): fix for errant \uXXXX error

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/tran.ts
+++ b/developer/src/kmc-ldml/src/compiler/tran.ts
@@ -154,12 +154,12 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
     // add in markers. idempotent if no markers.
     cookedFrom = sections.vars.substituteMarkerString(cookedFrom, true);
 
-    // don't unescape literals here, because we are going to pass them through into the regex
-    cookedFrom = util.unescapeStringToRegex(cookedFrom);
-
     // check for incorrect \uXXXX escapes
     cookedFrom = this.checkEscapes(cookedFrom); // check for \uXXXX escapes before normalizing
     if (cookedFrom === null) return null; // error
+
+    // unescape from \u{} form to plain, or in some cases \uXXXX / \UXXXXXXXX for core
+    cookedFrom = util.unescapeStringToRegex(cookedFrom);
 
     // check for denormalized ranges
     cookedFrom = this.checkRanges(cookedFrom); // check before normalizing

--- a/developer/src/kmc-ldml/test/fixtures/sections/tran/tran-escape.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/tran/tran-escape.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+    <info name="tran-minimal" />
+    <keys>
+        <key id="e" output="\m{hat}e"/>
+    </keys>
+    <layers formId="iso">
+        <layer id="base">
+            <row keys="e"/>
+        </layer>
+    </layers>
+    <transforms type="simple">
+        <transformGroup>
+            <transform from="\m{hat}e" to="ê" />
+            <transform from="a\u{000D}\u{000A}b" to="ROWb" />
+            <transform from="a\u{000A}c" to="ROWc" />
+            <transform from="a\u{100A}d" to="ROWd" />
+            <transform from="a\u{005b}e" to="ROWe" />
+        </transformGroup>
+    </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/test-tran.ts
+++ b/developer/src/kmc-ldml/test/test-tran.ts
@@ -333,6 +333,15 @@ describe('tran', function () {
         CompilerMessages.Error_MissingStringVariable({ id: "missingstr" }),
       ],
     },
+    // escaping
+    {
+      subpath: `sections/tran/tran-escape.xml`,
+      callback(sect) {
+        const tran = <Tran>sect;
+        assert.ok(tran);
+      },
+    }
+
   ], tranDependencies);
 });
 


### PR DESCRIPTION
- check for user-produced \uXXXX errors BEFORE we actually (re)introduce \uXXXX into the stream

Fixes: #10937

@keymanapp-test-bot skip