### PR TITLE
fix(ios): selection range sync for long contexts

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -287,9 +287,16 @@ function setKeymanContext(text, doSync, selStart, selLength) {
     let selEnd = selStart + selLength;
     selEnd = isNaN(selEnd) ? undefined : selEnd;
 
-    const shouldReset = keyman.context.updateContext(text, selStart, selEnd);
-    if(!doSync || shouldReset) {
+    if(doSync) {
+      const shouldReset = keyman.context.updateContext(text, selStart, selEnd);
+      if(shouldReset) {
         keyman.resetContext();
+      }
+    } else {
+      // if not in "sync" mode, we have a hard context reset; just full-reset it.
+      keyman.context.setText(text);
+      keyman.context.setSelection(selStart, selStart+selLength);
+      keyman.resetContext();
     }
 }
 

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -60,18 +60,24 @@ export class ContextHost extends Mock {
 
   updateContext(text: string, selStart: number, selEnd: number): boolean {
     let shouldResetContext = false;
+    let tempMock = new Mock(text, selStart ?? text._kmwLength(), selEnd ?? text._kmwLength());
+    let newLeft = tempMock.getTextBeforeCaret();
+    let oldLeft = this.getTextBeforeCaret();
+
     if(text != this.text) {
-      let tempMock = new Mock(text, selStart ?? text._kmwLength(), selEnd ?? text._kmwLength());
-
-      let newLeft = tempMock.getTextBeforeCaret();
-      let oldLeft = this.getTextBeforeCaret();
-
       let unexpectedBeforeCharCount = findCommonSubstringEndIndex(newLeft, oldLeft, true) + 1;
       shouldResetContext = !!unexpectedBeforeCharCount;
     }
 
     if(shouldResetContext) {
       this.text = text;
+      this.selStart = selStart;
+      this.selEnd = selEnd;
+    } else {
+      // Transform selection coordinates to their location within the longform context window.
+      let delta = oldLeft._kmwLength() - newLeft._kmwLength();
+      this.selStart = selStart - delta;
+      this.selEnd = selEnd - delta;
     }
 
     if(selStart === undefined || selEnd === undefined) {


### PR DESCRIPTION
Fixes corrections and predictions after recently-typed paragraph breaks.

So... I forgot to properly remap the selection-range coordinates when updating the internal web-engine's context across paragraph boundaries in #10728.  Fortunately, the mapping calculations are pretty simple - we only avoid resetting context if there's a very specific relation between the old and new left-hand contexts, after all.

## User Testing

To easily navigate to this page from a mobile device:

![image](https://github.com/keymanapp/keyman/assets/25213402/ea883b74-d576-4022-9a7c-ec0b7fac0133)

Sample text:
```
Almost half of all people in the world today speak an Indo-European language.

Over the last couple of hundred years, linguists have figured out a lot about the first Indo-European language including many
```

**TEST_NEW_PARAGRAPH_PREDICTIONS**:  Using the sample text specified above as existing context, verify that predictive text operates as expected.

1. Using Keyman as a system keyboard on an iOS device, paste the "sample text" above into an iOS app.

    - Personal recommendation:  Notes app
    - If using Simulator to test: Messages app

2. After pasting, the text insertion point should be at the end of the pasted text.  If not, make it so.
3. Hit ENTER twice.
4. If no predictions are shown at this specific moment, this is fine - it's a separate issue.
5. Type `p`, then hit backspace to delete it.
6. Verify that the usual default suggestions are displayed: "the", "to", "and", etc.
7. Type `ot` and verify that suggestions mostly starting with `o` and `t` are displayed.
8. Select `others` and verify that the expected results occur.
9. Once applied, directly apply suggestions that pop up at least ten times.  Verify that each is applied as expected.

**TEST_PREDICTION_AFTER_DELETIONS**:  Using the same sample text as specified above, verify that predictive text operates as expected after deleting lots of text.

1. Using Keyman as a system keyboard on an iOS device, paste the "sample text" above into an iOS app.
    - Personal recommendation:  Notes
    - If using Simulator to test: Messages
2. After pasting, the text insertion point should be at the end of the pasted text.  If not, make it so.
3. Hit ENTER twice.
4. Type `others`.
5. Press and hold backspace until you reach the middle of the second paragraph - try to stop in the middle of a word.
6. If not in the middle of a word, tap backspace a few times until the text insertion point is in the middle of a word.
7. Verify that the suggestions shown are all suggestions that make sense for the half-word.
    - Example:  if you've deleted part of `about` and are now at `abo`, the following make sense as the first suggestions: "about", "above", "abortion".  Other suggestions should include at least two of the three letters as well.
8. Apply one of the displayed suggestions and verify that it acts as expected.

**TEST_PREDICTION_AFTER_MOVE**: 
Using the same sample text as specified above, verify that predictive text operates as expected after deleting lots of text.

1. Using Keyman as a system keyboard on an iOS device, paste the "sample text" above into an iOS app.
    - Personal recommendation:  Notes
    - If using Simulator to test: Messages
2. After pasting, the text insertion point should be at the end of the pasted text.  If not, make it so.
3. Move the text insertion point into the middle of the word `peo` `ple`, which is in the middle of the first paragraph.
4. Verify that the suggestions shown are all suggestions that make sense for `peo`:  you might expect to see "people", "people's", "peoples", "person", etc.  
5. Apply one of the displayed suggestions and verify that it acts as expected.
