### PR TITLE
chore(web): improve the clarity of hints on OSK for Android

### DIFF
--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -360,7 +360,7 @@
 }
 
 .android .kmw-key-popup-icon{
-  font-size: 0.6em;
+  font-size: 0.5em;
   color: #ccc;
 }
 

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -205,7 +205,7 @@
 .phone.android.kmw-osk-frame { background-color: #222;}
 
 .phone.android .kmw-banner-bar,
-.tablet.android .kmw-banner-bar {  
+.tablet.android .kmw-banner-bar {
   background-color: #222;
   position: relative;
   margin-top: 4px;
@@ -348,8 +348,16 @@
 .desktop .kmw-key-label{position:absolute;left:2px;top:2px;font:0.5em Arial;color:#888;background-color:transparent;}
 
 /* Popup icon style (and content)*/
-.kmw-key-popup-icon{position:absolute;display:block;visibility:visible;right:4%;top:1%;/*width:8px;height:8px;*/
-      font-size:0.5em;color:#aaa; line-height:initial}
+.kmw-key-popup-icon{
+  position: absolute;
+  display: block;
+  visibility: visible;
+  right: 4%;
+  top: 1%;
+  font-size: 0.75em;
+  color: #ccc;
+  line-height: initial;
+}
 
 /* For certain form-factors, #aaa blends in with the special-key background-color _way_ too well. */
 /* e.g: .phone.ios .kmw-key.kmw-key-special {background-color:#b2b9c5;} */

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -354,9 +354,14 @@
   visibility: visible;
   right: 4%;
   top: 1%;
+  font-size: 0.5em;
+  color: #aaa;
+  line-height: initial;
+}
+
+.android .kmw-key-popup-icon{
   font-size: 0.75em;
   color: #ccc;
-  line-height: initial;
 }
 
 /* For certain form-factors, #aaa blends in with the special-key background-color _way_ too well. */

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -361,7 +361,7 @@
 
 .android .kmw-key-popup-icon{
   font-size: 0.5em;
-  color: #ccc;
+  color: #eee;
 }
 
 /* For certain form-factors, #aaa blends in with the special-key background-color _way_ too well. */

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -360,7 +360,7 @@
 }
 
 .android .kmw-key-popup-icon{
-  font-size: 0.75em;
+  font-size: 0.6em;
   color: #ccc;
 }
 


### PR DESCRIPTION
I found the hints too hard to see on my phone, so this ~~increases size of the hint from 0.5em to 0.75em, and~~ changes color from #aaa to ~~#ccc~~ #eee, on Android.

Font size changes rolled back, because they overlapped with base char on small key sizes. Can be more creative in future versions.

## Before

![image](https://github.com/keymanapp/keyman/assets/4498365/b7eb25a4-aff4-4fc4-ad58-6ebe4805c47a)

## After

![image](https://github.com/keymanapp/keyman/assets/4498365/1cc3b5db-8ebd-42a1-a7cf-7dc0054e5f18)

@keymanapp-test-bot skip
