### PR TITLE
feat(web): demo page for current state of dictionary-based wordbreaking feature 🔬 

### DIFF
--- a/web/src/test/manual/build.sh
+++ b/web/src/test/manual/build.sh
@@ -60,13 +60,13 @@ function do_copy() {
   mkdir -p "$WORDBREAK_DEMO_TARGET"
 
   $BUNDLE_CMD    "${KEYMAN_ROOT}/web/src/predictive-text/templates/build/obj/index.js" \
-    --out        "${WORDBREAK_DEMO_TARGET}/templates.mjs" \
+    --out        "${WORDBREAK_DEMO_TARGET}/templates.js" \
     --format esm
 
   # One of the functions (timedPromise) is quite helpful for automated testing, even in the DOM.
   # So, to make sure it's easily-accessible for the DOM-based tests...
   $BUNDLE_CMD    "${KEYMAN_ROOT}/web/src/predictive-text/wordbreakers/build/obj/index.js" \
-    --out        "${WORDBREAK_DEMO_TARGET}/wordbreakers.mjs" \
+    --out        "${WORDBREAK_DEMO_TARGET}/wordbreakers.js" \
     --format esm
 }
 

--- a/web/src/test/manual/build.sh
+++ b/web/src/test/manual/build.sh
@@ -9,6 +9,10 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 builder_describe "Builds the Keyman Engine for Web's sample page setups." \
   "@/common/web/sentry-manager build" \
+  "@/web/src/engine/predictive-text build" \
+  "@/web/src/app/browser build" \
+  "@/web/src/app/ui build" \
+  "@/web/src/tools build" \
   "configure           Does nothing for this project" \
   "clean" \
   "build" \
@@ -20,6 +24,20 @@ DEST="web/build/test-resources"
 
 builder_describe_outputs \
   build       "/${DEST}/sentry-manager.js"
+
+#### Resource paths ####
+
+BUNDLE_CMD="node $KEYMAN_ROOT/common/web/es-bundling/build/common-bundle.mjs"
+
+TEMPLATES_SRC="$KEYMAN_ROOT/common/models/templates/build/lib/index.mjs"
+TEMPLATES_MAP="$KEYMAN_ROOT/common/models/templates/build/lib/index.mjs"
+WORDBREAKING_SRC="$KEYMAN_ROOT/common/models/wordbreakers/build/lib/index.mjs"
+WORDBREAKING_MAP="$KEYMAN_ROOT/common/models/wordbreakers/build/lib/index.mjs"
+
+SENTRY_MANAGER_SRC="$KEYMAN_ROOT/common/web/sentry-manager/build/lib/index.js"
+SENTRY_MANAGER_MAP="$KEYMAN_ROOT/common/web/sentry-manager/build/lib/index.js.map"
+SENTRY_SRC="$KEYMAN_ROOT/node_modules/@sentry/browser/build/bundle.min.js"
+SENTRY_MAP="$KEYMAN_ROOT/node_modules/@sentry/browser/build/bundle.min.js.map"
 
 #### Build action definitions ####
 
@@ -36,6 +54,20 @@ function do_copy() {
   cp -f "${KEYMAN_ROOT}/common/test/keyboards/platform-rules/platformtest.js" "${KEYMAN_ROOT}/${DEST}/keyboards/"
   cp -f "${KEYMAN_ROOT}/common/test/keyboards/test9469/build/test9469.js" "${KEYMAN_ROOT}/${DEST}/keyboards/"
   cp -f "${KEYMAN_ROOT}/common/test/resources/keyboards/"*.js "${KEYMAN_ROOT}/${DEST}/keyboards/"
+
+  WORDBREAK_DEMO_TARGET="$KEYMAN_ROOT/web/build/demos/wordbreaker-libs/"
+
+  mkdir -p "$WORDBREAK_DEMO_TARGET"
+
+  $BUNDLE_CMD    "${KEYMAN_ROOT}/web/src/predictive-text/templates/build/obj/index.js" \
+    --out        "${WORDBREAK_DEMO_TARGET}/templates.mjs" \
+    --format esm
+
+  # One of the functions (timedPromise) is quite helpful for automated testing, even in the DOM.
+  # So, to make sure it's easily-accessible for the DOM-based tests...
+  $BUNDLE_CMD    "${KEYMAN_ROOT}/web/src/predictive-text/wordbreakers/build/obj/index.js" \
+    --out        "${WORDBREAK_DEMO_TARGET}/wordbreakers.mjs" \
+    --format esm
 }
 
 builder_run_action clean   rm -rf "${KEYMAN_ROOT}/${DEST}"

--- a/web/src/test/manual/build.sh
+++ b/web/src/test/manual/build.sh
@@ -27,17 +27,7 @@ builder_describe_outputs \
 
 #### Resource paths ####
 
-BUNDLE_CMD="node $KEYMAN_ROOT/common/web/es-bundling/build/common-bundle.mjs"
-
-TEMPLATES_SRC="$KEYMAN_ROOT/common/models/templates/build/lib/index.mjs"
-TEMPLATES_MAP="$KEYMAN_ROOT/common/models/templates/build/lib/index.mjs"
-WORDBREAKING_SRC="$KEYMAN_ROOT/common/models/wordbreakers/build/lib/index.mjs"
-WORDBREAKING_MAP="$KEYMAN_ROOT/common/models/wordbreakers/build/lib/index.mjs"
-
-SENTRY_MANAGER_SRC="$KEYMAN_ROOT/common/web/sentry-manager/build/lib/index.js"
-SENTRY_MANAGER_MAP="$KEYMAN_ROOT/common/web/sentry-manager/build/lib/index.js.map"
-SENTRY_SRC="$KEYMAN_ROOT/node_modules/@sentry/browser/build/bundle.min.js"
-SENTRY_MAP="$KEYMAN_ROOT/node_modules/@sentry/browser/build/bundle.min.js.map"
+BUNDLE_CMD="node $KEYMAN_ROOT/common/tools/es-bundling/build/common-bundle.mjs"
 
 #### Build action definitions ####
 
@@ -59,13 +49,13 @@ function do_copy() {
 
   mkdir -p "$WORDBREAK_DEMO_TARGET"
 
-  $BUNDLE_CMD    "${KEYMAN_ROOT}/web/src/predictive-text/templates/build/obj/index.js" \
+  $BUNDLE_CMD    "${KEYMAN_ROOT}/web/src/engine/predictive-text/templates/build/obj/index.js" \
     --out        "${WORDBREAK_DEMO_TARGET}/templates.js" \
     --format esm
 
   # One of the functions (timedPromise) is quite helpful for automated testing, even in the DOM.
   # So, to make sure it's easily-accessible for the DOM-based tests...
-  $BUNDLE_CMD    "${KEYMAN_ROOT}/web/src/predictive-text/wordbreakers/build/obj/index.js" \
+  $BUNDLE_CMD    "${KEYMAN_ROOT}/web/src/engine/predictive-text/wordbreakers/build/main/obj/index.js" \
     --out        "${WORDBREAK_DEMO_TARGET}/wordbreakers.js" \
     --format esm
 }

--- a/web/src/test/manual/web/dictionary-wordbreaking/index.html
+++ b/web/src/test/manual/web/dictionary-wordbreaking/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+
+    <!-- Set the viewport width to match phone and tablet device widths -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
+
+    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+
+    <!-- Enable IE9 Standards mode -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+    <title>KeymanWeb Testing Page - dictionary-based wordbreaking demo / test harness</title>
+
+    <!-- Your page CSS -->
+    <style type='text/css'>
+      body {font-family: Tahoma,helvetica;}
+      h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
+      .test {font-size: 1.5em; width:80%; min-height:30px; border: 1px solid gray;}
+      #KeymanWebControl {width:50%;min-width:600px;}
+    </style>
+
+    <!-- Insert uncompiled KeymanWeb source scripts -->
+    <script src="../../../../../build/publish/debug/keymanweb.js" type="application/javascript"></script>
+
+    <!--
+      For desktop browsers, a script for the user interface must be inserted here.
+
+      Standard UIs are toggle, button, float and toolbar.
+      The toolbar UI is best for any page designed to support keyboards for
+      a large number of languages.
+    -->
+    <script src="../../../../../build/publish/debug/kmwuitoggle.js"></script>
+
+    <script src="./model-hacker.mjs" type="module"></script>
+
+    <!-- Initialization: set paths to keyboards, resources and fonts as required -->
+    <script>
+      var kmw=window.keyman;
+      kmw.init({
+		    attachType:'auto'
+      }).then(function() {
+        kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'}, filename:'../us-1.0.js'});
+        kmw.addKeyboards('khmer_angkor')
+      });
+    </script>
+  </head>
+
+<!-- Sample page HTML -->
+  <body>
+    <h2>KeymanWeb Sample Page - Dictionary-based wordbreaking demo / host-page</h2>
+    <p>This page allows live inspection of what the predictive-text wordbreaker gets for
+      word boundaries when using the specialized wordbreaker.
+
+      Note:  unexpected stuff may happen if very short words have been trimmed from a
+      lexical model.  See:  'a' in English (when using MTNT).
+    </p>
+    <div>
+    <!--
+      The following DIV is used to position the Button or Toolbar User Interfaces on the page.
+      If omitted, those User Interfaces will appear at the top of the document body.
+      (It is ignored by other User Interfaces.)
+    -->
+    <div id='KeymanWebControl'></div>
+
+    <h3>Select a pre-built Trie-based model.js file to use as the lexicon:</h3>
+    <input id='model-select' type="file" onchange="fetchModelLexicon()">
+
+    <h3>Wordbreaking results here:</h3>
+    <textarea id='output' class='test' readonly></textarea>
+
+    <h3>Type in your language in this text area:</h3>
+    <textarea id='ta1' class='test' placeholder='Type here'></textarea>
+
+    <h3><a href="./">Return to testing home page</a></h3>
+  </div>
+
+  </body>
+
+  <!--
+    *** DEVELOPER NOTE -- FIREFOX CONFIGURATION FOR TESTING ***
+    *
+    * If the URL bar starts with <b>file://</b>, Firefox may not load the font used
+    * to display the special characters used in the On-Screen Keyboard.
+    *
+    * To work around this Firefox bug, navigate to <b>about:config</b>
+    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b>
+    * while testing.
+    *
+    * Firefox resolves website-based CSS URI references correctly without needing
+    * any configuration change, so this change should only be made for file-based testing.
+    *
+    ***
+  -->
+</html>

--- a/web/src/test/manual/web/dictionary-wordbreaking/index.html
+++ b/web/src/test/manual/web/dictionary-wordbreaking/index.html
@@ -34,7 +34,11 @@
     -->
     <script src="../../../../../build/publish/debug/kmwuitoggle.js"></script>
 
-    <script src="./model-hacker.mjs" type="module"></script>
+    <script type="module">
+      import { install, fetchModelLexicon } from './model-hacker.mjs';
+      window.fetchModelLexicon = fetchModelLexicon;
+      window.installHelper = install;
+    </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->
     <script src="../commonHeader.js"></script>
@@ -45,6 +49,7 @@
       kmw.init({
 		    attachType:'auto'
       }).then(function() {
+        window.installHelper();
         kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'}, filename:'../us-1.0.js'});
         kmw.addKeyboards('khmer_angkor')
       });

--- a/web/src/test/manual/web/dictionary-wordbreaking/index.html
+++ b/web/src/test/manual/web/dictionary-wordbreaking/index.html
@@ -36,6 +36,9 @@
 
     <script src="./model-hacker.mjs" type="module"></script>
 
+    <!-- Add keyboard management script for local selection of keyboards to use -->
+    <script src="../commonHeader.js"></script>
+
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
       var kmw=window.keyman;
@@ -73,6 +76,21 @@
 
     <h3>Type in your language in this text area:</h3>
     <textarea id='ta1' class='test' placeholder='Type here'></textarea>
+
+    <hr>
+
+    <!--  The following elements show how the language menu can be dynamically extended at any time -->
+    <h3>Add a keyboard by keyboard name:</h3>
+    <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
+    <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
+
+    <h3>Add a keyboard by BCP-47 language code:</h3>
+    <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
+    <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
+
+    <h3>Add a keyboard by language name(s):</h3>
+    <input type='input' id='kbd_id3' class='kmw-disabled' onkeypress="clickOnEnter(event,3);"/>
+    <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />
 
     <h3><a href="./">Return to testing home page</a></h3>
   </div>

--- a/web/src/test/manual/web/dictionary-wordbreaking/index.html
+++ b/web/src/test/manual/web/dictionary-wordbreaking/index.html
@@ -69,10 +69,10 @@
     <div id='KeymanWebControl'></div>
 
     <h3>Select a pre-built Trie-based .model.js file to use as the lexicon:</h3>
-    <input id='model-select' type="file" onchange="fetchModelLexicon()">
+    <input id='model-select' type="file" onchange="fetchModelLexicon()" accept=".model.js">
 
     <h3>Wordbreaking results here:</h3>
-    <textarea id='output' class='test' readonly></textarea>
+    <textarea id='output' class='test' readonly placeholder="Readonly - wordbreaking results appear here"></textarea>
 
     <h3>Type in your language in this text area:</h3>
     <textarea id='ta1' class='test' placeholder='Type here'></textarea>

--- a/web/src/test/manual/web/dictionary-wordbreaking/index.html
+++ b/web/src/test/manual/web/dictionary-wordbreaking/index.html
@@ -52,7 +52,7 @@
   <body>
     <h2>KeymanWeb Sample Page - Dictionary-based wordbreaking demo / host-page</h2>
     <p>This page allows live inspection of what the predictive-text wordbreaker gets for
-      word boundaries when using the specialized wordbreaker.
+      word boundaries when using the specialized wordbreaker instead of its normal one.
 
       Note:  unexpected stuff may happen if very short words have been trimmed from a
       lexical model.  See:  'a' in English (when using MTNT).
@@ -65,7 +65,7 @@
     -->
     <div id='KeymanWebControl'></div>
 
-    <h3>Select a pre-built Trie-based model.js file to use as the lexicon:</h3>
+    <h3>Select a pre-built Trie-based .model.js file to use as the lexicon:</h3>
     <input id='model-select' type="file" onchange="fetchModelLexicon()">
 
     <h3>Wordbreaking results here:</h3>

--- a/web/src/test/manual/web/dictionary-wordbreaking/index.html
+++ b/web/src/test/manual/web/dictionary-wordbreaking/index.html
@@ -35,7 +35,7 @@
     <script src="../../../../../build/publish/debug/kmwuitoggle.js"></script>
 
     <script type="module">
-      import { install, fetchModelLexicon } from './model-hacker.mjs';
+      import { install, fetchModelLexicon } from './model-hacker.js';
       window.fetchModelLexicon = fetchModelLexicon;
       window.installHelper = install;
     </script>

--- a/web/src/test/manual/web/dictionary-wordbreaking/model-hacker.js
+++ b/web/src/test/manual/web/dictionary-wordbreaking/model-hacker.js
@@ -1,6 +1,7 @@
-// TODO:  imports of lexical-model packages.  (Add to relevant build.sh / test.sh.)
-import * as wordbreakers from "../../../../../build/demos/wordbreaker-libs/wordbreakers.mjs";
-import * as models from "../../../../../build/demos/wordbreaker-libs/templates.mjs";
+// Would be `.mjs`, but TC doesn't seem to serve those correctly for live browser use when they're artifacts.
+
+import * as wordbreakers from "../../../../../build/demos/wordbreaker-libs/wordbreakers.js";
+import * as models from "../../../../../build/demos/wordbreaker-libs/templates.js";
 
 window.models = models;
 window.wordBreakers = wordbreakers;

--- a/web/src/test/manual/web/dictionary-wordbreaking/model-hacker.mjs
+++ b/web/src/test/manual/web/dictionary-wordbreaking/model-hacker.mjs
@@ -1,0 +1,46 @@
+// TODO:  imports of lexical-model packages.  (Add to relevant build.sh / test.sh.)
+import * as wordbreakers from "../../../../../build/demos/wordbreaker-libs/wordbreakers.mjs";
+import * as models from "../../../../../build/demos/wordbreaker-libs/templates.mjs";
+
+window.models = models;
+window.wordBreakers = wordbreakers;
+
+async function fetchModelLexicon() {
+  const files = document.getElementById('model-select').files;
+  if(files.length == 0) {
+    return;
+  }
+
+  const file = files[0];
+  const contents = await file.text();
+
+  const script = document.createElement('script');
+  script.innerHTML = contents;
+  document.head.appendChild(script);
+}
+
+const HackedWordbreaker = {
+  loadModel: function (model) {
+    const dictRoot = model.traverseFromRoot();
+    this.dictBreaker = (text) => wordbreakers.dict(text, dictRoot);
+  }
+}
+
+const output = document.getElementById('output');
+const ta1 = document.getElementById('ta1');
+ta1.addEventListener('input', updateWordbreak);
+
+function updateWordbreak() {
+  if(!HackedWordbreaker.dictBreaker) {
+    return;
+  }
+
+  const text = ta1.value;
+  const breaks = HackedWordbreaker.dictBreaker(text).map((entry) => entry.text);
+
+  output.value = breaks.join(' | ');
+}
+
+window.fetchModelLexicon = fetchModelLexicon;
+
+window['LMLayerWorker'] = HackedWordbreaker;

--- a/web/src/test/manual/web/dictionary-wordbreaking/model-hacker.mjs
+++ b/web/src/test/manual/web/dictionary-wordbreaking/model-hacker.mjs
@@ -5,7 +5,7 @@ import * as models from "../../../../../build/demos/wordbreaker-libs/templates.m
 window.models = models;
 window.wordBreakers = wordbreakers;
 
-async function fetchModelLexicon() {
+export async function fetchModelLexicon() {
   const files = document.getElementById('model-select').files;
   if(files.length == 0) {
     return;
@@ -19,28 +19,29 @@ async function fetchModelLexicon() {
   document.head.appendChild(script);
 }
 
-const HackedWordbreaker = {
-  loadModel: function (model) {
-    const dictRoot = model.traverseFromRoot();
-    this.dictBreaker = (text) => wordbreakers.dict(text, dictRoot);
-  }
-}
-
-const output = document.getElementById('output');
-const ta1 = document.getElementById('ta1');
-ta1.addEventListener('input', updateWordbreak);
-
-function updateWordbreak() {
-  if(!HackedWordbreaker.dictBreaker) {
-    return;
+export function install() {
+  const HackedWordbreaker = {
+    loadModel: function (model) {
+      const dictRoot = model.traverseFromRoot();
+      this.dictBreaker = (text) => wordbreakers.dict(text, dictRoot);
+    }
   }
 
-  const text = ta1.value;
-  const breaks = HackedWordbreaker.dictBreaker(text).map((entry) => entry.text);
+  const output = document.getElementById('output');
+  const ta1 = document.getElementById('ta1');
 
-  output.value = breaks.join(' | ');
+  const updateWordbreak = () => {
+    if(!HackedWordbreaker.dictBreaker) {
+      return;
+    }
+
+    const text = ta1.value;
+    const breaks = HackedWordbreaker.dictBreaker(text).map((entry) => entry.text);
+
+    output.value = breaks.join(' | ');
+  }
+
+  ta1.addEventListener('input', updateWordbreak);
+
+  window['LMLayerWorker'] = HackedWordbreaker;
 }
-
-window.fetchModelLexicon = fetchModelLexicon;
-
-window['LMLayerWorker'] = HackedWordbreaker;

--- a/web/src/test/manual/web/index.html
+++ b/web/src/test/manual/web/index.html
@@ -43,6 +43,7 @@
   <h2><a href="./osk-movement/index.html">Test page for osk setRect() and restorePosition() interaction (osk-movement)</a></h2>
   <h2><a href="./ckeditor/index.html">Integration with CKEditor (ckeditor)</a></h2>
   <h2><a href="./osk-event-buttons/index.html">Tests toggling & use of desktop OSK config & help buttons (osk-event-buttons)</a></h2>
+  <h2><a href="./dictionary-wordbreaking/">Demo / test-harness for dictionary-based wordbreaking</a></h2>
 
   <h1>Page integration (attachment) tests</h1>
   <h2><a href="./attachment-api/index.html?mode=auto">Tests the Attachment/Enablement API functionality (attachment-api)</a></h2>


### PR DESCRIPTION
This PR currently provides a demo representing current efforts to resolve #5025.  Significant progress has been made, but there's notably more to do before we can call the effort complete.  

⚠️ This page is intended as a demo of the intermediate state of this feature.  We will probably NOT want to actually merge it, though. ⚠️ 

Known tasks that would still need to be done:
- The new wordbreaker cannot yet be specified for use by any Developer-compiled lexical model
    - This is not straight-forward - our existing Trie model pattern requires that the wordbreaker be built first... but this wordbreaker requires a pre-built Trie to be provided to its constructor.
    - Fortunately, PR #12080 on `epic/user-dict` provides a great path forward - we can instantiate a Trie first, pass that to the breaker, then pass both off to the final `TrieModel`.

- If a typo occurs while typing a long word that has a prefix which is a valid shorter word, sometimes the wordbreaker will auto-break at the end of that prefix, meaning that we can no longer correct as expected.
    - Suppose when typing `basketball`, we typed `basker`.  `bask` is a perfectly valid English word.  `basker` is technically legal English but is likely quite rare. 
    - If `basker` is not available, we then end up with `bask | er`, thus with corrections and predictions based on `er` rather than `basker`.
    - So... how to mitigate and/or work around this issue?
    - We could probably adjust aspects of #12141 to help as a first-pass attempt:  "if unmatched and immediately pre-caret, merge with prior word".
        - Would likely be best to try _both_ versions, though.  Hmm.  We don't currently have support for that sort of variability, though...

----

This PR is devoted to the demo / testing-host page that supports a state in which the wordbreaker is usable outside of the worker, able to report the state of wordbreaking as context is edited. I aimed to create something like the Developer JS-keyboard test-host has for character map viewing.  To do so means building some extra JS bundles in order to support it, and I'm not sure if these specific changes (for the specialized page) should ever fully land.

Anyway, about the page:

![image](https://github.com/keymanapp/keyman/assets/25213402/671e8468-d343-42ea-92a0-0e53e00edcba)

Test page link - currently bottom of the testing-index's second section, labeled "[Demo / test-harness for dictionary-based wordbreaking](https://build.palaso.org/repository/download/Keymanweb_TestPullRequests/448893:id/src/test/manual/web/dictionary-wordbreaking/)".  (Link matches commit https://github.com/keymanapp/keyman/pull/10973/commits/9b580aa161b0e0af33b566182899d23f1537353b.)

The test page allows retrieving any Keyman _keyboard_ from the cloud while retrieving the lexical model file _locally_ via file-selector.  The lexical model will then be 'lightly hacked' - its backing data will be retrieved (via known private field) and fed to the prototype `dict` wordbreaker, regardless of whatever the model's actual wordbreaking setting is.  (Note:  no model is pre-loaded for the page.)  Predictive-text itself is not activated, though.

This page should help make assessment easier, allowing us to experiment with how it operates with the data from any existing lexical model.  I've already tested it out with our English (MTNT) model quite a bit and found the results fairly enlightening; they've already led to a bug fix or two.

A few sample runs, using English:

![dict-breaker sample 1](https://github.com/keymanapp/keyman/assets/25213402/cda6c279-11a9-4063-8823-f929e4ab77a0)

But how well does it handle stuff not in the lexical-model?

![dict-breaker sample 2](https://github.com/keymanapp/keyman/assets/25213402/df35ef43-b146-49cf-955e-a2740b439a1e)

Things not in the lexical model:
- `joshua`
    - Note: in the built version I have locally, `josh` _is_ an entry.  (I didn't edit it in, either...)
- `i` / `I`
- `am`
- `38`

Notably, short words not in the model... naturally aren't available as reference points when doing word-breaking.

These facts combined make some behaviors a bit interesting - note how it acts when `and I am` (minus the spaces) is typed:
- `and | ia`
- `an | diam` (because "an" and "diam[ond]" starts to look like a real possibility)
- When `diam` is no longer the most recent thing in context, it reverts back to `and | iam` - `diam` isn't a word, after all.

As for actual predictive-text use though... note that it's currently fairly impacted by any misspellings in recent context, possibly triggering undesiredly-early wordbreaks when typos occur.  That's something that'll need to be addressed in some way.

Known issues:
- I haven't linked in the search-term keyer yet.
    - Mapping "keyed" spans to their pre-keyed equivalents in the actual text doesn't sound trivial, though - leaving it out definitely helped with quicker prototyping.
- The patterns for Trie model initialization and for dict-breaker specification aren't currently compatible.
    - The Trie model wants a fully-built wordbreaker at initialization time.
    - The dict-breaker wants the root `LexiconTraversal` from the Trie, which (currently) isn't available until the Trie model is initialized.
        - I have a pretty decent idea on how to resolve this, but it would need some work - both in the models department and in the model-compiler.
        - Again, #12080's changes should help here.