### PR TITLE
fix(common): add unit test for --debug flag for builder

### DIFF
--- a/resources/build/test/debug-deps/child/build.sh
+++ b/resources/build/test/debug-deps/child/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../../../resources/build/build-utils.sh"
+# END STANDARD BUILD SCRIPT INCLUDE
+
+builder_describe \
+  "Tests child builds debug flag" \
+  @dep build
+
+function do_build() {
+  # Test the debug flag
+  builder_is_debug_build || builder_die "FAIL: child: expecting builder_is_debug_build to be true"
+  echo "PASS: child: builder_is_debug_build is true"
+
+  builder_has_option --debug || builder_die "FAIL: child: expecting builder_has_option --debug to be true"
+  echo "PASS: child: builder_has_option --debug is true"
+}
+
+builder_parse "$@"
+
+# Sanity Check: verify that we are running as a child (and not a dep) build
+! builder_is_dep_build || builder_die "FAIL: child: builder_is_dep_build should be false"
+builder_is_child_build || builder_die "FAIL: child: builder_is_child_build should be true"
+
+builder_run_action build do_build
+

--- a/resources/build/test/debug-deps/child/dep/build.sh
+++ b/resources/build/test/debug-deps/child/dep/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../../../../resources/build/build-utils.sh"
+# END STANDARD BUILD SCRIPT INCLUDE
+
+builder_describe \
+  "Tests child/dependency builds debug flag" \
+  configure build
+
+function do_build() {
+  # Test the debug flag
+  builder_is_debug_build || builder_die "FAIL: child/dep: expecting builder_is_debug_build to be true"
+  echo "PASS: child/dep: builder_is_debug_build is true"
+
+  builder_has_option --debug || builder_die "FAIL: child/dep: expecting builder_has_option --debug to be true"
+  echo "PASS: child/dep: builder_has_option --debug is true"
+}
+
+builder_parse "$@"
+
+# Sanity Check: verify that we are running as a dep (and not a child) build
+builder_is_dep_build || builder_die "FAIL: child/dep: builder_is_dep_build should be true"
+! builder_is_child_build || builder_die "FAIL: child/dep: builder_is_child_build should be false"
+
+builder_run_action build do_build

--- a/resources/build/test/debug-deps/dep/build.sh
+++ b/resources/build/test/debug-deps/dep/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../../../resources/build/build-utils.sh"
+# END STANDARD BUILD SCRIPT INCLUDE
+
+builder_describe \
+  "Tests dependency builds debug flag" \
+  configure build
+
+function do_build() {
+  # Test the debug flag
+  builder_is_debug_build || builder_die "FAIL: dep: expecting builder_is_debug_build to be true"
+  echo "PASS: dep: builder_is_debug_build is true"
+
+  builder_has_option --debug || builder_die "FAIL: dep: expecting builder_has_option --debug to be true"
+  echo "PASS: dep: builder_has_option --debug is true"
+}
+
+builder_parse "$@"
+
+# Sanity Check: verify that we are running as a dep (and not a child) build
+builder_is_dep_build || builder_die "FAIL: dep: builder_is_dep_build should be true"
+! builder_is_child_build || builder_die "FAIL: dep: builder_is_child_build should be false"
+
+builder_run_action build do_build

--- a/resources/build/test/debug-deps/test.sh
+++ b/resources/build/test/debug-deps/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../../resources/build/build-utils.sh"
+# END STANDARD BUILD SCRIPT INCLUDE
+
+builder_describe \
+  "Tests child and dependency builds --debug flag" \
+  @dep :child build
+
+function do_build() {
+  builder_is_debug_build || builder_die "FAIL: parent: expecting builder_is_debug_build to be true"
+  echo "PASS: parent: builder_is_debug_build is true"
+
+  builder_has_option --debug || builder_die "FAIL: parent: expecting builder_has_option --debug to be true"
+  echo "PASS: parent: builder_has_option --debug is true"
+}
+
+builder_parse build:child -d
+builder_run_action build do_build
+builder_run_child_actions build

--- a/resources/build/test/test.sh
+++ b/resources/build/test/test.sh
@@ -174,6 +174,7 @@ echo -e "${COLOR_BLUE}## Running dependency tests${COLOR_RESET}"
 "$THIS_SCRIPT_PATH/builder-deps.test.sh"
 "$THIS_SCRIPT_PATH/dependencies/test.sh"
 "$THIS_SCRIPT_PATH/trees/test.sh"
+"$THIS_SCRIPT_PATH/debug-deps/test.sh"
 
 echo -e "${COLOR_BLUE}## End external tests${COLOR_RESET}"
 echo


### PR DESCRIPTION
Fixes #10957. The builder --debug flag appears to be passed correctly, according to this test. This is a good test to keep, so won't remove it, but there is something else going on in the base #10953 PR.

@keymanapp-test-bot skip