### PR TITLE
fix(developer): min Keyman version for LDML is 17.0

### DIFF
--- a/common/web/types/src/kmx/kmx-builder.ts
+++ b/common/web/types/src/kmx/kmx-builder.ts
@@ -36,7 +36,7 @@ export default class KMXBuilder {
 
     this.comp_header = {
       dwIdentifier: KMXFile.FILEID_COMPILED,
-      dwFileVersion: KMXFile.VERSION_160,
+      dwFileVersion: KMXFile.VERSION_170,
       dwCheckSum: 0,  // Deprecated in Keyman 16.0
       KeyboardID: 0,
       IsRegistered: 1,

--- a/developer/src/kmc-ldml/test/fixtures/basic.txt
+++ b/developer/src/kmc-ldml/test/fixtures/basic.txt
@@ -22,7 +22,7 @@
 block(kmxheader)  #  struct COMP_KEYBOARD {
   4b 58 54 53      #    KMX_DWORD dwIdentifier;   // 0000 Keyman compiled keyboard id
 
-  00 10 00 00      #    KMX_DWORD dwFileVersion;  // 0004 Version of the file - Keyman 4.0 is 0x0400
+  00 11 00 00      #    KMX_DWORD dwFileVersion;  // 0004 Version of the file - Keyman 4.0 is 0x0400
 
   00 00 00 00      #    KMX_DWORD dwCheckSum;     // 0008 deprecated in 16.0, always 0
   00 00 00 00      #    KMX_DWORD KeyboardID;     // 000C as stored in HKEY_LOCAL_MACHINE//system//currentcontrolset//control//keyboard layouts


### PR DESCRIPTION
Fixes #10959.

@keymanapp-test-bot skip