### PR TITLE
docs(android/app): Add data privacy policy page

### DIFF
--- a/android/help/about/index.md
+++ b/android/help/about/index.md
@@ -5,4 +5,5 @@ title: About Keyman
 * [Welcome to Keyman](welcome)
 * [What's New](whatsnew)
 * [System Requirements](system-requirements)
+* [Data Privacy Policy](privacy)
 * [Version History](history)

--- a/android/help/about/privacy.md
+++ b/android/help/about/privacy.md
@@ -1,0 +1,34 @@
+---
+title: Data Privacy Policy
+---
+
+## Privacy Policy for Keyman
+
+This application will send crash reporting information to https://sentry.keyman.com. No personally identifiable information or keyboard strokes are recorded or shared.
+
+You can disable crash reporting on the Keyman 
+[settings menu](../basic/config/)
+
+### Data Deletion
+
+Crash reporting information is retained for 90 days. 
+
+Keyman does not use user accounts, so we are unable to identify which crash reports associated with you or your device can be deleted.
+
+
+
+### Developer Information
+
+Keyman is developed and published by SIL International.
+
+You can contact SIL or provide any feedback using the app store.
+
+https://play.google.com/store/apps/details?id=com.tavultesoft.kmapro
+
+The full SIL software privacy policy is at
+
+https://software.sil.org/language-software-privacy-policy/
+
+This Keyman data privacy policy is also available at
+
+https://help.keyman.com/products/android/current-version/about/privacy

--- a/android/help/index.md
+++ b/android/help/index.md
@@ -6,6 +6,7 @@ title: Keyman for Android 17.0 Help
 * [Welcome to Keyman](about/welcome)
 * [What's New](about/whatsnew)
 * [System Requirements](about/system-requirements)
+* [Data Privacy Policy](about/privacy)
 * [Version History](about/history)
 
 ## [Getting Started](start/)


### PR DESCRIPTION
This is an attempt to sate the Play Store data policy
https://support.google.com/googleplay/android-developer/answer/10144311#safetysection
* Developer information and a privacy point of contact or a mechanism to submit inquiries.
* Disclosing the types of personal and sensitive user data your app accesses, collects, uses, and shares; and any parties with which any personal or sensitive user data is shared.
* Secure data handling procedures for personal and sensitive user data.
* The developer’s data retention and deletion policy.
* Clear labeling as a privacy policy (for example, listed as “privacy policy” in title).

When this merges back to master, the link will also be available at
https://help.keyman.com/products/android/current-version/about/privacy

## User Testing
**Setup** - Install the PR build of Keyman for Android

* **TEST_HELP_PRIVACY** - verifies policy page available in the in-app help
1. Launch Keyman for Android and dismiss the Get Started menu
2. From Keyman menu --> Info
3. In the in-app help, browse to "Data Privacy Policy"
4. Verify privacy page displays
