### PR TITLE
fix(developer): suppress emission of new empty fields in package editor

### DIFF
--- a/common/windows/delphi/packages/PackageInfo.pas
+++ b/common/windows/delphi/packages/PackageInfo.pas
@@ -1857,7 +1857,8 @@ begin
   Keyboards.SaveXML(ARoot);
   if LexicalModels.Count > 0 then
     LexicalModels.SaveXML(ARoot);
-  RelatedPackages.SaveXML(ARoot);
+  if RelatedPackages.Count > 0 then
+    RelatedPackages.SaveXML(ARoot);
 end;
 
 procedure TPackage.SaveIni;
@@ -2742,6 +2743,9 @@ var
   j: Integer;
   AExample: IXMLNode;
 begin
+  if Count = 0 then
+    Exit;
+
   AExamples := ARoot.AddChild(SXML_PackageKeyboard_Examples);
   for j := 0 to Count - 1 do
   begin


### PR DESCRIPTION
Fixes #11002.

The fields `<RelatedPackages/>` and `<Examples/>` should not be emitted if they have no content, to improve file backward-compatibility.

@keymanapp-test-bot skip