### PR TITLE
fix(developer): return after calling await exitProcess

### DIFF
--- a/developer/src/kmc/src/commands/analyze.ts
+++ b/developer/src/kmc/src/commands/analyze.ts
@@ -36,7 +36,7 @@ function declareOskCharUse(command: Command) {
     .option('--include-counts', 'Include number of times each character is referenced', false)
     .option('--strip-dotted-circle', 'Strip U+25CC (dotted circle base) from results', false)
     .addOption(new Option('-m, --mapping-file <filename>', 'Result file to write to (.json, .md, or .txt)').makeOptionMandatory())
-    .action(async (filenames: string[], _options: any, commander: any) => {
+    .action(async (filenames: string[], _options: any, commander: any): Promise<never|void> => {
       const options = commander.optsWithGlobals();
       if(!filenames.length) {
         // If there are no filenames provided, then we are building the current
@@ -46,7 +46,7 @@ function declareOskCharUse(command: Command) {
 
       if(!await analyze(analyzeOskCharUse, filenames, options)) {
         // Once a file fails to build, we bail on subsequent builds
-        await exitProcess(1);
+        return await exitProcess(1);
       }
     });
 
@@ -66,8 +66,10 @@ function declareOskRewrite(command: Command) {
 
       if(!await analyze(analyzeOskRewritePua, filenames, options)) {
         // Once a file fails to build, we bail on subsequent builds
-        await exitProcess(1);
+        return await exitProcess(1);
       }
+
+      return null;
     });
 }
 

--- a/developer/src/kmc/src/commands/build.ts
+++ b/developer/src/kmc/src/commands/build.ts
@@ -77,11 +77,11 @@ function initialize(commanderOptions: any) {
   return options;
 }
 
-async function buildFile(filenames: string[], _options: any, commander: any)  {
+async function buildFile(filenames: string[], _options: any, commander: any): Promise<never|void> {
   const commanderOptions/*:{TODO?} CommandLineCompilerOptions*/ = commander.optsWithGlobals();
   const options = initialize(commanderOptions);
   if(!options) {
-    await exitProcess(1);
+    return await exitProcess(1);
   }
 
   const callbacks = new NodeCompilerCallbacks(options);
@@ -97,17 +97,17 @@ async function buildFile(filenames: string[], _options: any, commander: any)  {
   if(filenames.length > 1 && commanderOptions.outFile) {
     // -o can only be specified with a single input file
     callbacks.reportMessage(InfrastructureMessages.Error_OutFileCanOnlyBeSpecifiedWithSingleInfile());
-    await exitProcess(1);
+    return await exitProcess(1);
   }
 
   if(!expandFileLists(filenames, callbacks)) {
-    await exitProcess(1);
+    return await exitProcess(1);
   }
 
   for(let filename of filenames) {
     if(!await build(filename, commanderOptions.outFile, callbacks, options)) {
       // Once a file fails to build, we bail on subsequent builds
-      await exitProcess(1);
+      return await exitProcess(1);
     }
   }
 }

--- a/developer/src/kmc/src/commands/buildWindowsPackageInstaller/index.ts
+++ b/developer/src/kmc/src/commands/buildWindowsPackageInstaller/index.ts
@@ -16,7 +16,7 @@ interface WindowsPackageInstallerCommandLineOptions extends CommandLineBaseOptio
   startWithConfiguration: boolean;
 };
 
-export async function buildWindowsPackageInstaller(infile: string, _options: any, commander: any) {
+export async function buildWindowsPackageInstaller(infile: string, _options: any, commander: any): Promise<never|void> {
   // TODO(lowpri): we probably should cleanup the options management here, move
   // translation of command line options to kmc-* options into a separate module
   const options: WindowsPackageInstallerCommandLineOptions = commander.optsWithGlobals();
@@ -39,7 +39,7 @@ export async function buildWindowsPackageInstaller(infile: string, _options: any
   const callbacks: CompilerCallbacks = new NodeCompilerCallbacks({...defaultCompilerOptions, ...options});
   const compiler = new WindowsPackageInstallerCompiler();
   if(!await compiler.init(callbacks, {...options, sources})) {
-    await exitProcess(1);
+    return await exitProcess(1);
   }
 
   const fileBaseName = outfile ?? infile;
@@ -50,10 +50,10 @@ export async function buildWindowsPackageInstaller(infile: string, _options: any
   const result = await compiler.run(infile, outFileExe);
   if(!result) {
     // errors will have been reported already
-    await exitProcess(1);
+    return await exitProcess(1);
   }
 
   if(!await compiler.write(result.artifacts)) {
-    await exitProcess(1);
+    return await exitProcess(1);
   }
 }


### PR DESCRIPTION
Because exitProcess is async, static analysis of the function does not show process termination, even though it returns `Promise<Never>`. This can lead to compiler warnings when it gets confused about missing return values. So have moved to always returning the value from exitProcess, even though it will never actually return!

@keymanapp-test-bot skip