### PR TITLE
fix(web): prevent layer switch key from erasing selection

### DIFF
--- a/common/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/web/keyboard-processor/src/text/outputTarget.ts
@@ -21,15 +21,17 @@ export function isEmptyTransform(transform: Transform) {
 export class TextTransform implements Transform {
   readonly insert: string;
   readonly deleteLeft: number;
-  readonly deleteRight?: number;
+  readonly deleteRight: number;
+  readonly erasedSelection: boolean;
 
-  constructor(insert: string, deleteLeft: number, deleteRight?: number) {
+  constructor(insert: string, deleteLeft: number, deleteRight: number, erasedSelection: boolean) {
     this.insert = insert;
     this.deleteLeft = deleteLeft;
-    this.deleteRight = deleteRight || 0;
+    this.deleteRight = deleteRight;
+    this.erasedSelection = erasedSelection;
   }
 
-  public static readonly nil = new TextTransform('', 0, 0);
+  public static readonly nil = new TextTransform('', 0, 0, false);
 }
 
 export class Transcription {
@@ -138,7 +140,7 @@ export default abstract class OutputTarget {
     // caret mid-word..
     const deletedRight = fromRight.substring(0, rightDivergenceIndex + 1)._kmwLength();
 
-    return new TextTransform(insertedText, deletedLeft, deletedRight);
+    return new TextTransform(insertedText, deletedLeft, deletedRight, original.getSelectedText() && !this.getSelectedText());
   }
 
   buildTranscriptionFrom(original: OutputTarget, keyEvent: KeyEvent, readonly: boolean, alternates?: Alternate[]): Transcription {

--- a/common/web/keyboard-processor/tests/node/transcriptions.js
+++ b/common/web/keyboard-processor/tests/node/transcriptions.js
@@ -448,7 +448,8 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
       assert.deepEqual(transform, {
         insert: '',
         deleteLeft: 0,
-        deleteRight: 0
+        deleteRight: 0,
+        erasedSelection: false
       });
     });
 
@@ -459,7 +460,8 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
       const transform = {
         insert: '',
         deleteLeft: 0,
-        deleteRight: 0
+        deleteRight: 0,
+        erasedSelection: false
       };
 
       target.apply(transform);

--- a/common/web/keyboard-processor/tests/node/transcriptions.js
+++ b/common/web/keyboard-processor/tests/node/transcriptions.js
@@ -449,7 +449,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
         insert: '',
         deleteLeft: 0,
         deleteRight: 0,
-        erasedSelection: false
+        erasedSelection: true
       });
     });
 
@@ -461,7 +461,7 @@ but not himself.`;  // Sheev Palpatine, in the Star Wars prequels.
         insert: '',
         deleteLeft: 0,
         deleteRight: 0,
-        erasedSelection: false
+        erasedSelection: true
       };
 
       target.apply(transform);

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -41,7 +41,7 @@ export class ContextHost extends Mock {
 
       // Signal the necessary text changes to the embedding app, if it exists.
       if(this.oninserttext) {
-        if(transform.deleteLeft > 0 || transform.insert != '' || transform.deleteRight > 0 || transform.erasedSelection) {
+        if(!isEmptyTransform(transform) || transform.erasedSelection) {
           this.oninserttext(transform.deleteLeft, transform.insert, transform.deleteRight);
         }
       }

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -1,4 +1,4 @@
-import { type Keyboard, Mock, OutputTarget, Transcription, findCommonSubstringEndIndex } from '@keymanapp/keyboard-processor';
+import { type Keyboard, Mock, OutputTarget, Transcription, findCommonSubstringEndIndex, isEmptyTransform } from '@keymanapp/keyboard-processor';
 import { KeyboardStub } from 'keyman/engine/package-cache';
 import { ContextManagerBase, ContextManagerConfiguration } from 'keyman/engine/main';
 import { WebviewConfiguration } from './configuration.js';

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -41,7 +41,9 @@ export class ContextHost extends Mock {
 
       // Signal the necessary text changes to the embedding app, if it exists.
       if(this.oninserttext) {
-        this.oninserttext(transform.deleteLeft, transform.insert, transform.deleteRight);
+        if(transform.deleteLeft > 0 || transform.insert != '' || transform.deleteRight > 0 || transform.erasedSelection) {
+          this.oninserttext(transform.deleteLeft, transform.insert, transform.deleteRight);
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #7866.

When the transform generated by a key event results in no changes to the text, this will no longer trigger a change event in the apps. This means that layer switch keys will no longer erase the selection.

Fix proposed by @jahorton.

# User Testing

GROUP_IOS: Run these tests in Keyman for iPhone and iPad
GROUP_ANDROID: Run these tests in Keyman for Android

TEST_BASIC_INPUT: Verify that basic input continues to function correctly.
TEST_BACKSPACE: Type some text, then verify that backspace continues to work as normal.
TEST_CONTEXT_SYNC: Using Khmer Angkor keyboard, type <kbd>ខ</kbd> <kbd>េ</kbd>. Select the numeric/symbol layer, and return to the default layer. Press <kbd>្ម</kbd> (longpress on <kbd>ម</kbd>). Press <kbd>Backspace</kbd> and verify that the output on screen is ខ្ម (and not ខេ).
TEST_SELECTION_DELETION: Type two words, select the second word, and press backspace on the touch keyboard to delete it. Verify that the word is deleted as expected.
TEST_SELECTION_REPLACEMENT: Type two words, select the second word, and press a letter on the touch keybaord to replace it. Verify that the word is deleted as expected, and the new letter is left in its place.
TEST_SELECTION_LAYER_SWITCH: Type two words, select the second word, and press any layer switch key on the touch keyboard. The active layer should change, but the text should not be modified.