### PR TITLE
fix(core,developer): variable/marker substitution in sets and strings🙀

### DIFF
--- a/common/web/types/src/kmx/kmx-plus.ts
+++ b/common/web/types/src/kmx/kmx-plus.ts
@@ -2,7 +2,7 @@ import { constants } from '@keymanapp/ldml-keyboard-constants';
 import * as r from 'restructure';
 import { ElementString } from './element-string.js';
 import { ListItem } from './string-list.js';
-import { isOneChar, toOneChar, unescapeString } from '../util/util.js';
+import { isOneChar, toOneChar, unescapeString, escapeStringForRegex } from '../util/util.js';
 import { KMXFile } from './kmx.js';
 import { UnicodeSetParser, UnicodeSet } from '@keymanapp/common-types';
 import { VariableParser } from '../ldml-keyboard/pattern-parser.js';
@@ -291,9 +291,9 @@ export class Vars extends Section {
       // try as set
       const set = Vars.findVariable(this.sets, id);
       if (set !== null) {
-        const items = set.rawItems;
-        const inner = items.join('|');
-        // TODO-LDML: string substitution here, #11037
+        const { items } = set;
+        const escapedStrings = items.map(v => escapeStringForRegex(v.value.value));
+        const inner = escapedStrings.join('|');
         return `(?:${inner})`;
       }
 

--- a/common/web/types/src/kmx/kmx-plus.ts
+++ b/common/web/types/src/kmx/kmx-plus.ts
@@ -291,9 +291,10 @@ export class Vars extends Section {
       // try as set
       const set = Vars.findVariable(this.sets, id);
       if (set !== null) {
-        const { items } = set;
-        const inner = items.map(i => i.value.value).join('|');
-        return `(?:${inner})`; // TODO-LDML: need to escape here
+        const items = set.rawItems;
+        const inner = items.join('|');
+        // TODO-LDML: string substitution here, #11037
+        return `(?:${inner})`;
       }
 
       // try as unicodeset
@@ -372,11 +373,15 @@ export class UnicodeSetItem extends VarsItem {
 };
 
 export class SetVarItem extends VarsItem {
-  constructor(id: string, value: string[], sections: DependencySections) {
+  constructor(id: string, value: string[], sections: DependencySections, rawItems: string[]) {
     super(id, value.join(' '), sections);
     this.items = sections.elem.allocElementString(sections, value);
+    this.rawItems = rawItems;
   }
+  // element string array
   items: ElementString;
+  // like items, but with unprocessed marker strings
+  rawItems: string[];
   valid() : boolean {
     return !!this.items;
   }

--- a/common/web/types/src/kmx/kmx-plus.ts
+++ b/common/web/types/src/kmx/kmx-plus.ts
@@ -272,7 +272,7 @@ export class Vars extends Section {
       return v.value.value; // string value
     });
   }
-  substituteStrings(str: string, sections: DependencySections): string {
+  substituteStrings(str: string, sections: DependencySections, forMatch?: boolean): string {
     if (!str) return str;
     return str.replaceAll(VariableParser.STRING_REFERENCE, (_entire, id) => {
       const val = this.findStringVariableValue(id);
@@ -280,6 +280,7 @@ export class Vars extends Section {
         // Should have been caught during validation.
         throw Error(`Internal Error: reference to missing string variable ${id}`);
       }
+      if (forMatch) return escapeStringForRegex(val);
       return val;
     });
   }

--- a/common/web/types/src/util/util.ts
+++ b/common/web/types/src/util/util.ts
@@ -127,7 +127,7 @@ export function escapeRegexChar(ch: string) {
 }
 
 /** chars that must be escaped: syntax, C0 + C1 controls */
-const REGEX_SYNTAX_CHAR = /^[\u0000-\u001F\u007F-\u009F{}\[\]\\?.^$*()/-]$/;
+const REGEX_SYNTAX_CHAR = /^[\u0000-\u001F\u007F-\u009F{}\[\]\\?|.^$*()/-]$/;
 
 function escapeRegexCharIfSyntax(ch: string) {
   // escape if syntax or not valid

--- a/common/web/types/src/util/util.ts
+++ b/common/web/types/src/util/util.ts
@@ -149,6 +149,13 @@ function regexOne(hex: string): string {
   return Array.from(unescaped).map(ch => escapeRegexCharIfSyntax(ch)).join('');
 }
 /**
+ * Escape a string (\uxxxx form) if there are any problematic codepoints
+ */
+export function escapeStringForRegex(s: string) : string {
+  return s.split('').map(ch => escapeRegexCharIfSyntax(ch)).join('');
+}
+
+/**
  * Unescapes a string according to UTS#18§1.1, see <https://www.unicode.org/reports/tr18/#Hex_notation>
  * @param s escaped string
  * @returns

--- a/core/tests/unit/ldml/keyboards/k_007_transform_rgx-test.xml
+++ b/core/tests/unit/ldml/keyboards/k_007_transform_rgx-test.xml
@@ -88,4 +88,56 @@
       <check result="E"/>
     </test>
   </tests>
+  <tests name="regression-11037">
+    <test name="caret">
+      <keystroke key="caret" />
+      <keystroke key="a" />
+      <check result="â"/>
+    </test>
+    <test name="pipe">
+      <keystroke key="pipe" />
+      <keystroke key="a" />
+      <check result="ą"/>
+    </test>
+  </tests>
+  <tests name="regression-11045-d">
+    <test name="caret">
+      <keystroke key="d" />
+      <keystroke key="name" />
+      <keystroke key="caret" />
+      <check result="caret" />
+    </test>
+    <test name="pipe">
+      <keystroke key="d" />
+      <keystroke key="name" />
+      <keystroke key="pipe" />
+      <check result="pipe" />
+    </test>
+    <test name="grave">
+      <keystroke key="d" />
+      <keystroke key="name" />
+      <keystroke key="grave" />
+      <check result="grave" />
+    </test>
+  </tests>
+  <tests name="regression-11045-i">
+    <test name="caret">
+      <keystroke key="i" />
+      <keystroke key="name" />
+      <keystroke key="caret" />
+      <check result="caret" />
+    </test>
+    <test name="pipe">
+      <keystroke key="i" />
+      <keystroke key="name" />
+      <keystroke key="pipe" />
+      <check result="pipe" />
+    </test>
+    <test name="grave">
+      <keystroke key="i" />
+      <keystroke key="name" />
+      <keystroke key="grave" />
+      <check result="grave" />
+    </test>
+  </tests>
 </keyboardTest3>

--- a/core/tests/unit/ldml/keyboards/k_007_transform_rgx.xml
+++ b/core/tests/unit/ldml/keyboards/k_007_transform_rgx.xml
@@ -12,6 +12,9 @@ from https://github.com/unicode-org/cldr/blob/keyboard-preview/docs/ldml/tr35-ke
     <key id="zz" output="zz" />
     <key id="zzz" output="zzz" />
     <key id="zzzz" output="zzzz" />
+    <key id="caret" output="${caret}"/>
+    <key id="pipe" output="${pipe}"/>
+    <key id="name" output="\m{name}"/>
   </keys>
 
   <layers formId="us">
@@ -26,7 +29,7 @@ from https://github.com/unicode-org/cldr/blob/keyboard-preview/docs/ldml/tr35-ke
       <row keys="grave 1 2 3 4 5 6 7 8 9 0" />
       <row keys="Q W E R T Y U I O P" />
       <row keys="A S D F G H J K L" />
-      <row keys="Z X C V zz zzz zzzz" />
+      <row keys="Z X C V zz zzz zzzz caret pipe name" />
       <row keys="space" />
     </layer>
   </layers>
@@ -34,6 +37,13 @@ from https://github.com/unicode-org/cldr/blob/keyboard-preview/docs/ldml/tr35-ke
   <variables>
     <set id="upper" value="A E I O U YY" />
     <set id="lower" value="a e i o u yy" />
+    <set id="direct" value="| ^ `"/>
+    <set id="indirect" value="${pipe} ${caret} ${grave}"/>
+    <set id="name" value="pipe caret grave"/>
+    <!-- for regression #11037 -->
+    <string id="caret" value="^" />
+    <string id="pipe" value="|" />
+    <string id="grave" value="`" />
   </variables>
 
   <transforms type="simple">
@@ -45,6 +55,11 @@ from https://github.com/unicode-org/cldr/blob/keyboard-preview/docs/ldml/tr35-ke
     </transformGroup>
     <transformGroup>
       <transform from="ez{2,3}" to="E" />
+      <transform from="${caret}a" to="â" />
+      <transform from="${pipe}a" to="ą" />
+      <!-- 'd' and 'i' should give the same result. -->
+      <transform from="d\m{name}($[direct])" to="$[1:name]"/>
+      <transform from="i\m{name}($[indirect])" to="$[1:name]"/>
     </transformGroup>
   </transforms>
 </keyboard3>

--- a/core/tests/unit/ldml/keyboards/k_210_marker-test.xml
+++ b/core/tests/unit/ldml/keyboards/k_210_marker-test.xml
@@ -52,9 +52,14 @@
   </tests>
   <tests name="regression-11045">
     <test name="regression-11045-grave">
+      <keystroke key="v" />
       <keystroke key="grave"/>
-      <keystroke key="x" />
       <check result="`"/>
+    </test>
+    <test name="regression-11045-acute">
+      <keystroke key="v" />
+      <keystroke key="acute"/>
+      <check result="´"/>
     </test>
   </tests>
 </keyboardTest3>

--- a/core/tests/unit/ldml/keyboards/k_210_marker-test.xml
+++ b/core/tests/unit/ldml/keyboards/k_210_marker-test.xml
@@ -50,4 +50,11 @@
       <check result="x" />
     </test>
   </tests>
+  <tests name="regression-11045">
+    <test name="regression-11045-grave">
+      <keystroke key="grave"/>
+      <keystroke key="x" />
+      <check result="`"/>
+    </test>
+  </tests>
 </keyboardTest3>

--- a/core/tests/unit/ldml/keyboards/k_210_marker.xml
+++ b/core/tests/unit/ldml/keyboards/k_210_marker.xml
@@ -24,7 +24,7 @@
       <row keys="grave acute caret hacek" />
       <row keys="q w e" /> <!-- etc -->
       <row keys="a s d" /> <!-- etc -->
-      <row keys="z x c" /> <!-- etc -->
+      <row keys="z x c v" /> <!-- etc -->
     </layer>
   </layers>
 
@@ -37,7 +37,7 @@
   <transforms type="simple">
     <transformGroup>
       <!-- for regression  #11045 -->
-      <transform from="($[mark_accent])x" to="$[1:spacing_accent]" />
+      <transform from="v($[mark_accent])" to="$[1:spacing_accent]" />
       <transform from="\m{.}z" to="Z" />
     </transformGroup>
     <transformGroup>

--- a/core/tests/unit/ldml/keyboards/k_210_marker.xml
+++ b/core/tests/unit/ldml/keyboards/k_210_marker.xml
@@ -28,8 +28,16 @@
     </layer>
   </layers>
 
+  <variables>
+    <!-- for regression  #11045 -->
+    <set id="mark_accent" value="\m{acute} \m{grave}"/>
+    <set id="spacing_accent" value="´ `"/>
+  </variables>
+
   <transforms type="simple">
     <transformGroup>
+      <!-- for regression  #11045 -->
+      <transform from="($[mark_accent])x" to="$[1:spacing_accent]" />
       <transform from="\m{.}z" to="Z" />
     </transformGroup>
     <transformGroup>

--- a/developer/src/kmc-ldml/src/compiler/tran.ts
+++ b/developer/src/kmc-ldml/src/compiler/tran.ts
@@ -146,9 +146,10 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
       result.mapFrom = sections.strs.allocString(mapFrom[1]); // var name
       result.mapTo = sections.strs.allocString(mapTo[1]); // var name
     } else {
-      result.mapFrom = sections.strs.allocString(''); // TODO-LDML
-      result.mapTo = sections.strs.allocString(''); // TODO-LDML
+      result.mapFrom = sections.strs.allocString('');
+      result.mapTo = sections.strs.allocString('');
     }
+    // the set substution will not produce raw markers `\m{...}` but they will already be in sentinel form.
     cookedFrom = sections.vars.substituteSetRegex(cookedFrom, sections);
 
     // add in markers. idempotent if no markers.

--- a/developer/src/kmc-ldml/src/compiler/tran.ts
+++ b/developer/src/kmc-ldml/src/compiler/tran.ts
@@ -139,7 +139,10 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
     let result = new TranTransform();
     let cookedFrom = transform.from;
 
-    cookedFrom = sections.vars.substituteStrings(cookedFrom, sections);
+    // check for incorrect \uXXXX escapes. Do this before substituting markers or sets.
+    cookedFrom = this.checkEscapes(cookedFrom); // check for \uXXXX escapes before normalizing
+
+    cookedFrom = sections.vars.substituteStrings(cookedFrom, sections, true);
     const mapFrom = VariableParser.CAPTURE_SET_REFERENCE.exec(cookedFrom);
     const mapTo = VariableParser.MAPPED_SET_REFERENCE.exec(transform.to || '');
     if (mapFrom && mapTo) { // TODO-LDML: error cases
@@ -149,15 +152,14 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
       result.mapFrom = sections.strs.allocString('');
       result.mapTo = sections.strs.allocString('');
     }
+
+    if (cookedFrom === null) return null; // error
+
     // the set substution will not produce raw markers `\m{...}` but they will already be in sentinel form.
     cookedFrom = sections.vars.substituteSetRegex(cookedFrom, sections);
 
     // add in markers. idempotent if no markers.
     cookedFrom = sections.vars.substituteMarkerString(cookedFrom, true);
-
-    // check for incorrect \uXXXX escapes
-    cookedFrom = this.checkEscapes(cookedFrom); // check for \uXXXX escapes before normalizing
-    if (cookedFrom === null) return null; // error
 
     // unescape from \u{} form to plain, or in some cases \uXXXX / \UXXXXXXXX for core
     cookedFrom = util.unescapeStringToRegex(cookedFrom);

--- a/developer/src/kmc-ldml/src/compiler/vars.ts
+++ b/developer/src/kmc-ldml/src/compiler/vars.ts
@@ -248,6 +248,8 @@ export class VarsCompiler extends SectionCompiler {
     // raw items - without marker substitution
     const rawItems: string[] = VariableParser.setSplitter(value);
     // cooked items - has substutition of markers
+    // this is not 'forMatch', all variables are to be assumed as string literals, not regex
+    // content.
     const cookedItems: string[] = rawItems.map(v => result.substituteMarkerString(v, false));
     result.sets.push(new SetVarItem(id, cookedItems, sections, rawItems));
   }

--- a/developer/src/kmc-ldml/src/compiler/vars.ts
+++ b/developer/src/kmc-ldml/src/compiler/vars.ts
@@ -192,6 +192,9 @@ export class VarsCompiler extends SectionCompiler {
   validateSubstitutions(keyboard: LDMLKeyboard.LKKeyboard, st : Substitutions) : boolean {
     keyboard?.variables?.string?.forEach(({value}) =>
           st.markers.add(SubstitutionUse.variable, MarkerParser.allReferences(value)));
+    // get markers mentioned in a set
+    keyboard?.variables?.set?.forEach(({ value }) =>
+      VariableParser.setSplitter(value).forEach(v => st.markers.add(SubstitutionUse.match, MarkerParser.allReferences(v))));
     return true;
   }
 
@@ -208,8 +211,6 @@ export class VarsCompiler extends SectionCompiler {
     // first, strings.
     variables?.string?.forEach((e) =>
       this.addString(result, e, sections));
-    variables?.set?.forEach((e) =>
-      this.addSet(result, e, sections));
     variables?.uset?.forEach((e) =>
       this.addUnicodeSet(result, e, sections));
 
@@ -221,6 +222,10 @@ export class VarsCompiler extends SectionCompiler {
     // collect all markers, excluding the match-all
     const allMarkers : string[] = Array.from(mt.all).filter(m => m !== MarkerParser.ANY_MARKER_ID).sort();
     result.markers = sections.list.allocList(allMarkers, {}, sections);
+
+    // sets need to be added late, because they can refer to markers
+    variables?.set?.forEach((e) =>
+      this.addSet(result, e, sections));
 
     return result.valid() ? result : null;
   }
@@ -240,8 +245,11 @@ export class VarsCompiler extends SectionCompiler {
     value = result.substituteStrings(value, sections);
     // OK to do this as a substitute, because we've already validated the set above.
     value = result.substituteSets(value, sections);
-    const items : string[] = VariableParser.setSplitter(value);
-    result.sets.push(new SetVarItem(id, items, sections));
+    // raw items - without marker substitution
+    const rawItems: string[] = VariableParser.setSplitter(value);
+    // cooked items - has substutition of markers
+    const cookedItems: string[] = rawItems.map(v => result.substituteMarkerString(v, false));
+    result.sets.push(new SetVarItem(id, cookedItems, sections, rawItems));
   }
   addUnicodeSet(result: Vars, e: LDMLKeyboard.LKUSet, sections: DependencySections): void {
     const { id } = e;


### PR DESCRIPTION
Bug: When sets contain markers, the 'map' operation fails, because the matched string was not found in the KMX+ set list.

Cause: inconsistent escaping due to the in-memory set variable being used for regex updating AND also used by core for the runtime match.

Similar for string variables (#11037)

Solution: 
1. The in-memory variables should be string literals, not regex (see #11037)
2. Need to push all escaping down to the regex substitution layer. Don't perform it 'early' in the lists.

Fixes: #11045
Fixes: #11037 

@keymanapp-test-bot skip
