### PR TITLE
chore(android,windows): Update crowdin strings for French

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values-fr-rFR/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-fr-rFR/strings.xml
@@ -53,6 +53,7 @@
   <string name="request_storage_permission" comment="Request storage permission to access keyboard packages">    Pour installer des packages du clavier, autoriser Keyman à lire le stockage externe.</string>
   <!-- Context: Android Storage Permission -->
   <string name="storage_permission_denied" comment="Keyboard package installation may fail since Android storage permission not granted">    La demande de permission de stockage a été refusée. Peut ne pas installer le package clavier</string>
+  <string name="storage_permission_denied2" comment="Keyboard package installation failed. Recommend install from local file">    Storage permission request failed. Try Keyman Settings - Install from local file</string>
   <!-- Context: Keyman Settings menu -->
   <string name="keyman_settings" comment="Settings menu title">Paramètres</string>
   <!-- Context: Keyman Settings menu -->

--- a/android/KMEA/app/src/main/res/values-fr-rFR/strings.xml
+++ b/android/KMEA/app/src/main/res/values-fr-rFR/strings.xml
@@ -107,7 +107,7 @@
     <string name="dictionary_download_start_in_background" comment="Notification that a dictionary download has started">Le téléchargement du dictionnaire a commencé en arrière-plan</string>
     <!-- Context: Background download messages-->
     <string name="dictionary_download_is_running_in_background" comment="Notification that a dictionary download is still running">Le dictionnaire sélectionné est déjà en cours de téléchargement ; veuillez réessayer dans un instant !</string>
-    <!-- Context: Background download messages-->
+    <!-- Context: Background download messages. Removed in Keyman 17-->
     <string name="dictionary_download_finished" comment="Notification that a dictionary download has finished">Téléchargement du dictionnaire terminé.</string>
     <!-- Context: Background download messages -->
     <string name="download_failed" comment="Notification that a download failed">Échec du téléchargement</string>
@@ -119,7 +119,7 @@
     <string name="update_check_current" comment="Notification that all resources are up to date">"Toutes les ressources sont à jour !"</string>
     <!-- Context: General Updates -->
     <string name="update_failed" comment="Notification that a resource update failed">Une ou plusieurs ressources n\'ont pas pu être mises à jour !</string>
-    <!-- Context: General Updates -->
+    <!-- Context: General Updates. Removed in Keyman 17 -->
     <string name="update_success" comment="Notification that a resource update successfully updated">Ressources mises à jour avec succès !</string>
     <!-- Context: Model Info -->
     <string name="model_version" comment="Title for a dictionary version">Version du dictionnaire</string>

--- a/windows/src/desktop/kmshell/locale/fr/strings.xml
+++ b/windows/src/desktop/kmshell/locale/fr/strings.xml
@@ -449,7 +449,7 @@
   <!-- Context: Download Keyboard Dialog -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="S_DownloadKeyboard_Title" comment="Download keyboard layout from keyman.com dialog title">Télécharger le clavier à partir du site Tavultesoft</string>
+  <string name="S_DownloadKeyboard_Title" comment="Download keyboard layout from keyman.com dialog title">Télécharger un clavier à partir du site keyman.com</string>
   <!-- Context: Download Keyboard Dialog -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->


### PR DESCRIPTION
@MattGyverLee raised an issue on Crowdin to update one of the Windows French strings.
The Crowdin CLI also pulled in the filler string on Android.

@keymanapp-test-bot skip
