### PR TITLE
fix(common): properly handle illegal UnicodeSets to prevent crash in kmc-ldml compiler 🙀 

### DIFF
--- a/common/web/types/src/kmx/element-string.ts
+++ b/common/web/types/src/kmx/element-string.ts
@@ -75,6 +75,8 @@ export class ElementString extends Array<ElemElement> {
         // TODO-LDML: err on max buffer size
         const needRanges = sections.usetparser.sizeUnicodeSet(item.segment);
         if (needRanges < 0) {
+          // Note that sizeUnicodeSet() already will notify via callback if there's an
+          // error. So we can just exit here.
           return null; // UnicodeSet error
         }
         const uset = sections.usetparser.parseUnicodeSet(item.segment, needRanges);

--- a/common/web/types/src/kmx/element-string.ts
+++ b/common/web/types/src/kmx/element-string.ts
@@ -74,6 +74,9 @@ export class ElementString extends Array<ElemElement> {
         typeFlag |= constants.elem_flags_type_uset;
         // TODO-LDML: err on max buffer size
         const needRanges = sections.usetparser.sizeUnicodeSet(item.segment);
+        if (needRanges < 0) {
+          return null; // UnicodeSet error
+        }
         const uset = sections.usetparser.parseUnicodeSet(item.segment, needRanges);
         if (!uset) {
           return null; // UnicodeSet error already thrown

--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -562,8 +562,8 @@ export class KmnCompiler implements KeymanCompiler, UnicodeSetParser {
     // fix \u1234 pattern format
     pattern = KmnCompiler.fixNewPattern(pattern);
     const rc = Module.kmcmp_parseUnicodeSet(pattern, buf, rangeCount * 2);
-    /** If <= 0: error return code. If positive: it's a range count */
     if (rc >= 0) {
+      // If >= 0: it's a range count (which could be zero, an empty set).
       const ranges = [];
       const startu = (buf / Module.HEAPU32.BYTES_PER_ELEMENT);
       for (let i = 0; i < rc; i++) {
@@ -574,6 +574,7 @@ export class KmnCompiler implements KeymanCompiler, UnicodeSetParser {
       this.wasmExports.free(buf);
       return new UnicodeSet(pattern, ranges);
     } else {
+      // rc is negative: it's an error code.
       this.wasmExports.free(buf);
       // translate error code into callback
       this.callbacks.reportMessage(getUnicodeSetError(rc));

--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -556,6 +556,12 @@ export class KmnCompiler implements KeymanCompiler, UnicodeSetParser {
     // fix \u1234 pattern format
     pattern = KmnCompiler.fixNewPattern(pattern);
     /** If <= 0: return code. If positive: range count */
+    if (buf < 0) {
+      throw new RangeError(`Internal error: wasm malloc() returned ${buf}`);
+    }
+    if ((rangeCount*2) < 0) {
+      throw new RangeError(`Internal error: negative rangeCount * 2 = ${rangeCount * 2}`);
+    }
     const rc = Module.kmcmp_parseUnicodeSet(pattern, buf, rangeCount * 2);
     if (rc >= 0) {
       const ranges = [];


### PR DESCRIPTION
- similar fix to https://github.com/keymanapp/keyman/pull/9492 (a similar error message was seen, perhaps on some versions of wasm?)
- again may be due to a wasm version variant
- also additional rangechecking on the input side

The error message I saw was:

> `TypeError: Passing a number "-2" from JS side to C/C++ side to an argument of type "unsigned int", which is outside the valid range [0, 4294967295]!`


@keymanapp-test-bot skip