### PR TITLE
fix(core): add an assert on code_points_to_delete 🌱

### DIFF
--- a/core/src/km_core_action_api.cpp
+++ b/core/src/km_core_action_api.cpp
@@ -56,7 +56,9 @@ void km::core::actions_dispose(
 
 km_core_usv const *km::core::get_deleted_context(context const &app_context, unsigned int code_points_to_delete) {
   auto p = app_context.end();
-  for(size_t i = code_points_to_delete; i > 0; i--, p--);
+  for(size_t i = code_points_to_delete; i > 0; i--, p--) {
+    assert(p != app_context.begin());
+  }
 
   auto deleted_context = new km_core_usv[code_points_to_delete + 1];
   for(size_t i = 0; i < code_points_to_delete; i++) {


### PR DESCRIPTION
Investigating this as part of #11045. May be some internal error, but adding an assert here that `p` doesn't go off the beginning of the array.

I added some context to part 3 of #11067 

@keymanapp-test-bot skip