### PR TITLE
fix(developer):  in ldml compiler, generate compiler error if `from=` regex matches empty string 🙀

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/messages.ts
@@ -49,7 +49,9 @@ export class CompilerMessages {
   static Error_GestureKeyNotFoundInKeyBag = (o:{keyId: string, parentKeyId: string, attribute: string}) =>
   m(this.ERROR_GestureKeyNotFoundInKeyBag, `Key '${def(o.keyId)}' not found in key bag, referenced from other '${def(o.parentKeyId)}' in ${def(o.attribute)}`);
 
-  // 0x000C - available
+  static ERROR_TransformFromMatchesNothing = SevError | 0x000C;
+  static Error_TransformFromMatchesNothing = (o: { from: string }) =>
+  m(this.ERROR_TransformFromMatchesNothing, `Invalid transfom from="${def(o.from)}": Matches an empty string.`);
 
   static ERROR_InvalidVersion = SevError | 0x000D;
   static Error_InvalidVersion = (o:{version: string}) =>
@@ -178,6 +180,7 @@ export class CompilerMessages {
   static ERROR_InvalidQuadEscape = SevError | 0x0030;
   static Error_InvalidQuadEscape = (o: { cp: number }) =>
   m(this.ERROR_InvalidQuadEscape, `Invalid escape "\\u${util.hexQuad(o?.cp || 0)}", use "\\u{${def(o?.cp?.toString(16))}}" instead.`);
+
 }
 
 

--- a/developer/src/kmc-ldml/src/compiler/tran.ts
+++ b/developer/src/kmc-ldml/src/compiler/tran.ts
@@ -174,7 +174,12 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
 
     // Verify that the regex is syntactically valid
     try {
-      new RegExp(cookedFrom, 'ug');
+      const rg = new RegExp(cookedFrom + '$', 'ug');
+      // does it match an empty string?
+      if (rg.test('')) {
+        this.callbacks.reportMessage(CompilerMessages.Error_TransformFromMatchesNothing({ from: transform.from }));
+        return null;
+      }
     } catch (e) {
       this.callbacks.reportMessage(CompilerMessages.Error_UnparseableTransformFrom({ from: transform.from, message: e.message }));
       return null; // error

--- a/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-matches-nothing-1.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-matches-nothing-1.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<keyboard3 conformsTo="45" xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" >
+  <info name="fail-matches-nothing"/>
+
+  <keys />
+
+  <transforms type="simple">
+    <transformGroup>
+      <transform from=""/>
+    </transformGroup>
+  </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-matches-nothing-2.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-matches-nothing-2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<keyboard3 conformsTo="45" xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" >
+  <info name="fail-matches-nothing"/>
+
+  <keys />
+
+  <transforms type="simple">
+    <transformGroup>
+      <transform from="X{0,1}Y{0,1}"/>
+    </transformGroup>
+  </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-matches-nothing-3.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-matches-nothing-3.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<keyboard3 conformsTo="45" xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" >
+  <info name="fail-matches-nothing"/>
+
+  <keys />
+
+  <transforms type="simple">
+    <transformGroup>
+      <transform from="X|"/>
+    </transformGroup>
+  </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/test-tran.ts
+++ b/developer/src/kmc-ldml/test/test-tran.ts
@@ -334,6 +334,16 @@ describe('tran', function () {
         CompilerMessages.Error_MissingStringVariable({ id: "missingstr" }),
       ],
     },
+    // three cases that share the same error message
+    ...[1, 2, 3].map(n => ({
+      subpath: `sections/tran/fail-matches-nothing-${n}.xml`,
+      errors: [
+        {
+          code: CompilerMessages.ERROR_TransformFromMatchesNothing,
+          matchMessage: /.*/,
+        }
+      ],
+    })),
     // escaping
     {
       subpath: `sections/tran/tran-escape.xml`,


### PR DESCRIPTION
- add message and check if the regex matches '' (empty string) and error if so
- add test cases

Fixes: bug(core): assert with vertical pipe #11062

@keymanapp-test-bot skip