### PR TITLE
fix(developer): in model compiler, give correct key to shorter prefix words when a longer, higher-frequency word is also present

### DIFF
--- a/developer/src/kmc-model/src/build-trie.ts
+++ b/developer/src/kmc-model/src/build-trie.ts
@@ -376,7 +376,7 @@ namespace Trie {
     let char = item.key[index];
     // If an internal node is the proper site for item, it belongs under the
     // corresponding (sentinel, internal-use) child node signifying this.
-    if(char === null || char === undefined) {
+    if(char == undefined) {
       char = INTERNAL_VALUE;
     }
     if (!node.children[char]) {

--- a/developer/src/kmc-model/src/build-trie.ts
+++ b/developer/src/kmc-model/src/build-trie.ts
@@ -374,6 +374,11 @@ namespace Trie {
    */
   function addItemToInternalNode(node: InternalNode, item: Entry, index: number) {
     let char = item.key[index];
+    // If an internal node is the proper site for item, it belongs under the
+    // corresponding (sentinel, internal-use) child node signifying this.
+    if(char === null || char === undefined) {
+      char = INTERNAL_VALUE;
+    }
     if (!node.children[char]) {
       node.children[char] = createRootNode();
       node.values.push(char);

--- a/developer/src/kmc-model/test/fixtures/example.qaa.wordlist-ordering/example.qaa.wordlist-ordering.model.ts
+++ b/developer/src/kmc-model/test/fixtures/example.qaa.wordlist-ordering/example.qaa.wordlist-ordering.model.ts
@@ -1,0 +1,5 @@
+const source: LexicalModelSource = {
+  format: 'trie-1.0',
+  sources: ['wordlist.tsv'],
+};
+export default source;

--- a/developer/src/kmc-model/test/fixtures/example.qaa.wordlist-ordering/wordlist.tsv
+++ b/developer/src/kmc-model/test/fixtures/example.qaa.wordlist-ordering/wordlist.tsv
@@ -1,0 +1,6 @@
+thesaurus	5	Ordering and frequencies are intentional and aimed to trigger a bug fixed in 17.0.
+thesis	2
+theme	20
+themes	15
+them	10
+the	100

--- a/developer/src/kmc-model/test/fixtures/example.qaa.wordlist-ordering/wordlist.tsv
+++ b/developer/src/kmc-model/test/fixtures/example.qaa.wordlist-ordering/wordlist.tsv
@@ -1,4 +1,4 @@
-thesaurus	5	Ordering and frequencies are intentional and aimed to trigger a bug fixed in 17.0.
+thesaurus	5	Ordering and frequencies are intentional and aimed to maintain #11074, fixing #11073.
 thesis	2
 theme	20
 themes	15

--- a/developer/src/kmc-model/test/test-compile-trie.ts
+++ b/developer/src/kmc-model/test/test-compile-trie.ts
@@ -160,5 +160,15 @@ describe('createTrieDataStructure()', function () {
     })
     assert.match(uppercaseSourceCode, /"key":\s*"TURTLES"/);
     assert.notMatch(uppercaseSourceCode, /"key":\s*"turtles"/);
+  });
+
+  it('does not create `null`/"undefined"-keyed children', function () {
+    const WORDLIST_FILENAME = makePathToFixture('example.qaa.wordlist-ordering', 'wordlist.tsv');
+    // check to ensure the Trie is fully well-formed.
+    let sourceCode = createTrieDataStructure([WORDLIST_FILENAME], (wf) => wf);
+    assert.notMatch(sourceCode, /"undefined"/);
+    assert.notMatch(sourceCode, /null/);
+
+    console.log(sourceCode);
   })
 });

--- a/developer/src/kmc-model/test/test-compile-trie.ts
+++ b/developer/src/kmc-model/test/test-compile-trie.ts
@@ -168,7 +168,5 @@ describe('createTrieDataStructure()', function () {
     let sourceCode = createTrieDataStructure([WORDLIST_FILENAME], (wf) => wf);
     assert.notMatch(sourceCode, /"undefined"/);
     assert.notMatch(sourceCode, /null/);
-
-    console.log(sourceCode);
   })
 });


### PR DESCRIPTION
Fixes #11073.

This fixes an issue where less-frequent words that match the start of higher-frequency words were inaccessible to the predictive-text engine and thus could never be suggested.  This effectively suggested to users that the word doesn't exist, which is certainly less than ideal when spelling assistance is desired.  Also, this is something that would certainly affect auto-correction efforts if and when the time comes.

A unit test is included.  The first commit (with the unit test) fails CI checks with 17.0.294-beta's current state and passes with the fix included (commit 2).

**Note**:  as this is a compiler bug, _all_ models will likely need recompilation so that they may receive the fix's effects.

## User Testing

**TEST_MTNT_THIN**:  Using the Keyman Developer test artifact, recompile the MTNT model and verify that #11073 is fixed.
1. Open Keyman Developer
2. Open the MTNT model's project (from within the keymanapp/lexical-models repo, path = release/nrc/nrc.en.mtnt)
3. Making no changes, build the model project.
4. Use Developer to test the model via the test-host page.
5. Then verify that `thin` shows up as a predictive-text suggestion when "thin" is typed.