### PR TITLE
fix(android/engine): Check font available before setting Typeface

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1346,7 +1346,7 @@ public final class KMManager {
         }
 
         File file = new File(fontFilename);
-        if (file.exists()) {
+        if (file != null && file.exists() && file.length() > 0) {
           return Typeface.createFromFile(file);
         }
       }


### PR DESCRIPTION
Fixes #11038 

The Sentry crash shows the file packages/sil_ipa/CharisSIL-Regular.ttf file exists, but was invalid to set as a Typeface (possibly corrupted during extraction?)

This adds additional sanity checks to a fontfile before it gets used for a Typeface.
@bharanidharanj said it shouldn't show an error, so we proceed without using the font if the file is invalid.

## User Testing
**Setup** - Install the PR build of Keyman for Android. Also download a **modified sil_ipa.kmp file** from https://darcywong00.github.io/examples/sil_ipa/sil_ipa.kmp where CharisSIL-Regular.ttf is in the zip but has filesize 0.

* **TEST_IPA** - Verifies sil_ipa keyboard can be used without errors
1. Launch Keyman for Android
2. From Keyman settings, install the modified sil_ipa.kmp file that was downloaded in setup
3. When sil_ipa finishes installing, return to the Keyman app
4. Verify the IPA (SIL) keyboard is displayed without errors
