### PR TITLE
fix(oem/fv/android): Only add default keyboard if no keyboards exist

### DIFF
--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/DefaultLanguageResource.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/DefaultLanguageResource.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 
 import com.keyman.engine.KMManager;
 import com.keyman.engine.data.Keyboard;
+import com.keyman.engine.data.KeyboardController;
 import com.keyman.engine.data.LexicalModel;
 
 import java.util.HashMap;
@@ -43,10 +44,10 @@ public class DefaultLanguageResource {
 
     SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
 
-    // Add default keyboard
+    // Add default keyboard if no keyboards exist
     if (!prefs.getBoolean(defaultKeyboardInstalled, false)) {
       if (!KMManager.keyboardExists(context, FVShared.FVDefault_PackageID, KMManager.KMDefault_KeyboardID,
-        KMManager.KMDefault_LanguageID)) {
+        KMManager.KMDefault_LanguageID) && KeyboardController.getInstance().get().size() < 1) {
 
         KMManager.addKeyboard(context, KMManager.getDefaultKeyboard(context.getApplicationContext()));
       }


### PR DESCRIPTION
Fixes #11079 - Checks no keyboards are installed before installing the fallback keyboard.

## User Testing ##

**Setup** - Install the PR build of FV for Android on a device/emulator

* **TEST_FV** - Verifies extra EuroLatin keyboard isn't installed
1. Launch FV for Android
2. From the FV setup, add the keyboard BC --> BC Coast --> Sencoten
3. From the FV setup, set FV as the default system keyboard
4. Launch a separate app (e.g. Chrome)
5. Select a text area to type to bring up FV as the system keyboard
6. Long-press on the globe key to bring up the Keyboard Picker menu
7. Verify EuroLatin (SIL) is **not** installed
