### PR TITLE
fix(mac): delete correct number of characters from current context when processing BMP or SMP deletes

### DIFF
--- a/mac/Keyman4MacIM/KeymanTests/InputMethodTests.m
+++ b/mac/Keyman4MacIM/KeymanTests/InputMethodTests.m
@@ -11,12 +11,13 @@
 
 #import <XCTest/XCTest.h>
 #import "KMInputMethodEventHandler.h"
-#import "LegacyTestClient.h"
 #import "AppleCompliantTestClient.h"
 #import "TextApiCompliance.h"
+#import "AppleCompliantTestClient.h"
+
+KMInputMethodEventHandler *testEventHandler = nil;
 
 @interface InputMethodTests : XCTestCase
-
 @end
 
 // included following interface that we can see and test private methods of TextApiCompliance
@@ -26,10 +27,19 @@
 
 @end
 
+@interface KMInputMethodEventHandler (Testing)
+
+- (instancetype)initWithClient:(NSString *)clientAppId client:(id) sender;
+- (NSRange) calculateInsertRangeForDeletedText:(NSString*)textToDelete selectionRange:(NSRange) selection;
+
+@end
+
 @implementation InputMethodTests
 
 - (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+  id client = [[AppleCompliantTestClient alloc] init];
+  NSString *clientAppId = @"com.compliant.app";
+  testEventHandler = [[KMInputMethodEventHandler alloc]initWithClient:clientAppId client:client];
 }
 
 - (void)tearDown {
@@ -45,7 +55,7 @@
 
   BOOL isLegacy = [apiCompliance arrayContainsApplicationId:clientAppId fromArray:legacyAppsArray];
   NSLog(@"isLegacy = %@", isLegacy?@"yes":@"no");
-    XCTAssert(isLegacy == NO, @"App not expected to be in legacy list");
+    XCTAssertFalse(isLegacy, @"App not expected to be in legacy list");
 }
 
 - (void)testIsClientAppLegacy_listedClientAppId_returnsYes {
@@ -56,8 +66,54 @@
   NSArray *legacyAppsArray = [NSArray arrayWithObjects:@"com.adobe.Photoshop",@"com.microsoft.VSCode",nil];
 
   BOOL isLegacy = [apiCompliance arrayContainsApplicationId:clientAppId fromArray:legacyAppsArray];
-  NSLog(@"isLegacy = %@", isLegacy?@"yes":@"no");
-    XCTAssert(isLegacy == YES, @"App expected to be in legacy list");
+  XCTAssertTrue(isLegacy, @"App expected to be in legacy list");
+}
+
+- (void)testCalculateInsertRange_noDelete_returnsCurrentLocation {
+  NSRange selectionRange = NSMakeRange(1, 0);
+  NSRange insertRange = [testEventHandler calculateInsertRangeForDeletedText:@"" selectionRange:selectionRange];
+  BOOL notFound = (insertRange.length == NSNotFound) && (insertRange.location == NSNotFound);
+  XCTAssertTrue(notFound, @"insert or replacement range expected to be NSNotFound ");
+}
+
+- (void)testCalculateInsertRange_noDeleteWithOneSelected_returnsCurrentLocation {
+  NSRange selectionRange = NSMakeRange(1, 1);
+  NSRange insertRange = [testEventHandler calculateInsertRangeForDeletedText:@"" selectionRange:selectionRange];
+  BOOL notFound = (insertRange.length == NSNotFound) && (insertRange.location == NSNotFound);
+  XCTAssertTrue(notFound, @"insert or replacement range expected to be NSNotFound ");
+}
+
+- (void)testCalculateInsertRange_deleteNonexistentCharacters_returnsCurrentLocation {
+  NSRange selectionRange = NSMakeRange(0, 0);
+  NSRange insertRange = [testEventHandler calculateInsertRangeForDeletedText:@"a" selectionRange:selectionRange];
+  BOOL notFound = (insertRange.length == NSNotFound) && (insertRange.location == NSNotFound);
+  XCTAssertTrue(notFound, @"insert or replacement range expected to be NSNotFound ");
+}
+
+- (void)testCalculateInsertRange_deleteOneSurrogatePair_returnsRangeLengthTwo {
+  // Brahmi 𑀓 D804 DC13 surrogate pair
+  NSRange selectionRange = NSMakeRange(2, 0);
+  NSRange insertRange = [testEventHandler calculateInsertRangeForDeletedText:@"𑀓" selectionRange:selectionRange];
+  BOOL correctResult = (insertRange.location == 0) && (insertRange.length == 2);
+  XCTAssertTrue(correctResult, @"insert or replacement range expected to be {0,2}");
+}
+
+- (void)testCalculateInsertRange_deleteTwoBMPCharacters_returnsRangeLengthTwo {
+  NSRange selectionRange = NSMakeRange(3, 0);
+  // deletedText = KHMER VOWEL SIGN OE, KHMER SIGN COENG
+  NSRange insertRange = [testEventHandler calculateInsertRangeForDeletedText:@"\u17BE\u17D2" selectionRange:selectionRange];
+  BOOL correctResult = (insertRange.location == 1) && (insertRange.length == 2);
+  XCTAssertTrue(correctResult, @"insert or replacement range expected to be {1,2}");
+}
+
+// equivalent to Kenya BTL, type "b^x", select 'x' and type 'u'
+// selected x should be deleted, as should "^" and replaced with 'û'
+
+- (void)testCalculateInsertRange_deleteOneBMPCharacterWithOneSelected_returnsRangeLengthTwo {
+  NSRange selectionRange = NSMakeRange(2, 1); // location = 2, length = 1
+  NSRange insertRange = [testEventHandler calculateInsertRangeForDeletedText:@"'" selectionRange:selectionRange];
+  BOOL correctResult = (insertRange.location == 1) && (insertRange.length == 2);
+  XCTAssertTrue(correctResult, @"insert or replacement range expected to be {1,2}");
 }
 
 @end

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj/xcshareddata/xcschemes/KeymanEngine4Mac.xcscheme
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj/xcshareddata/xcschemes/KeymanEngine4Mac.xcscheme
@@ -106,6 +106,16 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E29F22F0201A59B1005EA234"
+               BuildableName = "KeymanTests.xctest"
+               BlueprintName = "KeymanTests"
+               ReferencedContainer = "container:../Keyman4MacIM/Keyman4MacIM.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreKeyOutput.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreKeyOutput.h
@@ -20,11 +20,12 @@ typedef enum {
 @interface CoreKeyOutput : NSObject
 @property (nonatomic, readonly) NSUInteger codePointsToDeleteBeforeInsert;
 @property (strong, nonatomic, readonly) NSString *textToInsert;
+@property (strong, nonatomic, readonly) NSString *textToDelete;
 @property (strong, nonatomic, readonly) NSDictionary *optionsToPersist;
 @property (nonatomic, readonly) BOOL alert;
 @property (nonatomic, readonly) BOOL emitKeystroke;
 @property (nonatomic, readonly) CapsLockState capsLockState;
--(instancetype)init:(NSUInteger)codePointsToDelete textToInsert:(NSString*)text optionsToPersist:(NSDictionary*)options alert:(BOOL)alert emitKeystroke:(BOOL)emit capsLockState:(CapsLockState)capsLock;
+-(instancetype)init:(NSUInteger)codePointsToDelete textToDelete:(NSString*)deletedText textToInsert:(NSString*)text optionsToPersist:(NSDictionary*)options alert:(BOOL)alert emitKeystroke:(BOOL)emit capsLockState:(CapsLockState)capsLock;
 -(NSString *)description;
 -(BOOL)hasCodePointsToDelete;
 -(BOOL)hasTextToInsert;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreKeyOutput.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreKeyOutput.m
@@ -16,10 +16,11 @@
 
 @implementation CoreKeyOutput
 
--(instancetype)init:(NSUInteger)codePointsToDelete textToInsert:(NSString*)text optionsToPersist:(NSDictionary*)options alert:(BOOL)alert emitKeystroke:(BOOL)emit capsLockState:(CapsLockState)capsLock {
+-(instancetype)init:(NSUInteger)codePointsToDelete textToDelete:(NSString*)deletedText textToInsert:(NSString*)text optionsToPersist:(NSDictionary*)options alert:(BOOL)alert emitKeystroke:(BOOL)emit capsLockState:(CapsLockState)capsLock {
   self = [super init];
   if (self) {
     self->_codePointsToDeleteBeforeInsert = codePointsToDelete;
+    self->_textToDelete = deletedText;
     self->_textToInsert = text;
     self->_optionsToPersist = options;
     self->_alert = alert;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
@@ -181,9 +181,10 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   NSString* text = [self.coreHelper utf32CStringToString:actions->output];
   NSDictionary* options = [self convertOptionsArray:actions->persist_options];
   CapsLockState capsLock = [self convertCapsLockState:actions->new_caps_lock_state];
+  NSString* deletedText = [self.coreHelper utf32CStringToString:actions->deleted_context];
 
-  CoreKeyOutput* coreKeyOutput = [[CoreKeyOutput alloc] init: actions->code_points_to_delete textToInsert:text optionsToPersist:options alert:actions->do_alert emitKeystroke:actions->emit_keystroke capsLockState:capsLock];
-
+  CoreKeyOutput* coreKeyOutput = [[CoreKeyOutput alloc] init: actions->code_points_to_delete textToDelete:deletedText textToInsert:text optionsToPersist:options alert:actions->do_alert emitKeystroke:actions->emit_keystroke capsLockState:capsLock];
+  
   return coreKeyOutput;
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreHelperTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreHelperTests.m
@@ -115,6 +115,18 @@
   XCTAssertTrue([dataFromLiteral isEqualToData:dataFromConversion], @"Converted unichar string is not equal to literal unichar string.");
 }
 
+- (void)testConversionToUnicharString_brahmiAndLatinString_matchesLiteral {
+  NSString *mixedString = @"𑀧a𑀫";
+  unichar const * mixedUnicharString = u"𑀧a𑀫";
+  
+  NSUInteger stringLength = [mixedString lengthOfBytesUsingEncoding:NSUTF16StringEncoding];
+  
+  unichar const *  convertedString = [[CoreTestStaticHelperMethods helper] createUnicharStringFromNSString: mixedString];
+  NSData *dataFromConversion = [NSData dataWithBytes:convertedString length:stringLength];
+  NSData *dataFromLiteral = [NSData dataWithBytes:mixedUnicharString length:stringLength];
+  XCTAssertTrue([dataFromLiteral isEqualToData:dataFromConversion], @"Converted unichar string is not equal to literal unichar string.");
+}
+
 - (void)testConversionFromUnicharString_optionName_matchesLiteral {
   unichar const * unicharString = u"option_ligature_ew";
   NSString *optionNameString = @"option_ligature_ew";


### PR DESCRIPTION
When processing keystrokes for compliant apps (which have the ability to replace text while inserting characters from Keyman), the number of characters to delete must be determined correctly whether the context contains BMP code points or surrogate pairs. Also, if there is any text selected when the character is typed, the selection should also be replaced by the newly inserted character.

Fixes #1643 

# User Testing

* **TEST_REPLACE_BMP_CHARACTER**: typing a character with one selected causes it to be replaced

1. Open the Stickies app and create a new Note
1. Switch to the EuroLatin (SIL) keyboard
1. Type <kbd>a</kbd><kbd>b</kbd>
1. Select the letter 'b' that was just typed
1. Type <kbd>x</kbd>
1. Confirm that the b was replaced by x, and the text now reads  'ax'

* **TEST_REPLACE_SURROGATE_PAIR_CHARACTER**: processing a character that causes the replacement of a surrogate pair produces the correct, uncorrupted output

1. Open the Stickies app and create a new Note
1. Switch to the Malar Tirhuta keyboard
1. Type <kbd>k</kbd>
1. Confirm that the letter 𑒏𑓂 was typed
1. Type <kbd>e</kbd>
1. Confirm that output now reads: 𑒏𑒹
1. Confirm that the text can be selected and successfully copied into a TextEdit document

* **TEST_REPLACE_MULTIPLE_CHARACTERS**: processing a character that causes the replacement of multiple characters produces the correct output (multiple deletes are returned from core because this key combination causes the Khmer characters to be re-ordered)

1. Open the Stickies app and create a new Note
1. Switch to the Khmer Angkor keyboard
1. Hold down <kbd>shift</kbd> and type <kbd>p</kbd>
1. Type <kbd>;</kbd>
1. Confirm that output now reads: ភើ
1. Type <kbd>j</kbd><kbd>l</kbd>
1. Confirm that the text now reads ភ្លើ
