### PR TITLE
fix(core): fix pointer math in actions_normalize() 🙀 

### DIFF
--- a/core/src/actions_normalize.cpp
+++ b/core/src/actions_normalize.cpp
@@ -141,10 +141,10 @@ bool km::core::actions_normalize(
     At this point, our output and cached_context are coherent and normalization
     will be complete at the edit boundary.
 
-    Now, we need to adjust the delete_back to match the number of code units
+    Now, we need to adjust the delete_back to match the number of codepoints
     that must actually be deleted from the applications's NFU context
 
-    To adjust, we remove one code unit at a time from the app_context until
+    To adjust, we remove one codepoint at a time from the app_context until
     its normalized form matches the cached_context normalized form.
   */
 

--- a/core/src/actions_normalize.cpp
+++ b/core/src/actions_normalize.cpp
@@ -119,25 +119,22 @@ bool km::core::actions_normalize(
     normalization in our output, we now need to look for a normalization
     boundary prior to the intersection of the cached_context and the output.
   */
+  if(!output.isEmpty()) {
+    while(n > 0 && !nfd->hasBoundaryBefore(output[0])) {
+      // The output may interact with the context further in normalization. We
+      // need to copy characters back further until we reach a normalization
+      // boundary.
 
-  while(n > 0 && output[0] && !nfd->hasBoundaryBefore(output[0])) {
-    // The output may interact with the context further in normalization. We
-    // need to copy characters back further until we reach a normalization
-    // boundary.
+      // Remove last code point from the context ...
 
-    // Remove last code point from the context ...
+      n = cached_context_string.moveIndex32(n, -1);
+      UChar32 chr = cached_context_string.char32At(n);
+      cached_context_string.remove(n);
 
-    n = cached_context_string.moveIndex32(n, -1);
-    UChar32 chr = cached_context_string.char32At(n);
-    cached_context_string.remove(n);
+      // And prepend it to the output ...
 
-    // And prepend it to the output ...
-
-    output.insert(0, chr);
-
-    // And finally remember that we now need to delete an additional NFD codepoint
-
-    actions.code_points_to_delete++;
+      output.insert(0, chr);
+    }
   }
 
   /*

--- a/core/src/km_core_action_api.cpp
+++ b/core/src/km_core_action_api.cpp
@@ -56,7 +56,9 @@ void km::core::actions_dispose(
 
 km_core_usv const *km::core::get_deleted_context(context const &app_context, unsigned int code_points_to_delete) {
   auto p = app_context.end();
-  for(size_t i = code_points_to_delete; i > 0; i--, p--);
+  for(size_t i = code_points_to_delete; i > 0; i--, p--) {
+    assert(p != app_context.begin());
+  }
 
   auto deleted_context = new km_core_usv[code_points_to_delete + 1];
   for(size_t i = 0; i < code_points_to_delete; i++) {

--- a/core/tests/unit/kmnkbd/test_actions_normalize.cpp
+++ b/core/tests/unit/kmnkbd/test_actions_normalize.cpp
@@ -152,7 +152,7 @@ void test_actions_normalize(
  *                                      this is initial_cached_context -
  *                                      actions_code_points_to_delete +
  *                                      actions_output) - no markers supported.
- *                                      If specified, final_cached_context_items 
+ *                                      If specified, final_cached_context_items
  *                                      must be nullptr.
  * @param final_cached_context_items    cached context _after_ actions have been
  *                                      applied -- NFU (essentially,
@@ -440,6 +440,23 @@ void run_actions_normalize_tests() {
     /* app_context: */                   u"a\U0001F607bca\U0001F60E"
   );
 
+  km_core_context_item items_11067[] = {
+    { KM_CORE_CT_CHAR,   {0,}, { U'𐒻' } },
+    { KM_CORE_CT_CHAR,   {0,}, { U'𐒷' } },
+    KM_CORE_CONTEXT_ITEM_END
+  };
+
+  // regression #11067
+  test_actions_normalize(
+    "A non-BMP char in context (#11067)",
+    /* app context pre transform: */     u"𐒻",
+    /* cached context post transform: */ u"𐒻𐒷",
+    /* cached context post transform: */ &items_11067[0],
+    /* action del, output: */            0, U"𐒻𐒷",
+    // ---- results ----
+    /* action del, output: */            1, U"𐒻𐒷",
+    /* app_context: */                   u"𐒻𐒷"
+  );
 }
 
 void run_actions_update_app_context_nfu_tests() {


### PR DESCRIPTION
- UnicodeString is UTF-16, but can be used with UTF-32 boundaries.
- fix calculation of code_points_to_delete

Fixes: #11067

@keymanapp-test-bot skip