### PR TITLE
change(web): keyboard swaps keep original keyboards active until fully ready

### DIFF
--- a/web/src/engine/osk/src/views/floatingOskView.ts
+++ b/web/src/engine/osk/src/views/floatingOskView.ts
@@ -64,6 +64,7 @@ export default class FloatingOSKView extends OSKView {
     this.resizeBar.on('showbuild', () => this.emit('showbuild'));
 
     this.headerView = this.titleBar;
+    this._Box.insertBefore(this.headerView.element, this._Box.firstChild);
 
     const onListenedEvent = (eventName: keyof EventMap | keyof LegacyOSKEventMap) => {
       // As the following title bar buttons (for desktop / FloatingOSKView) do nothing unless a site

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -713,9 +713,6 @@ export default abstract class OSKView
   private loadActiveKeyboard() {
     this.setBoxStyling();
     this.needsLayout = true;
-
-    this.bannerController?.configureForKeyboard(this.keyboardData?.keyboard, this.keyboardData?.metadata);
-
     // Save references to the old kbd & its styles for shutdown after replacement.
     const oldKbd = this.keyboardView;
     const oldKbdStyleManager = this.kbdStyleSheetManager;
@@ -727,6 +724,7 @@ export default abstract class OSKView
     // Perform the replacement.
     this._Box.replaceChild(kbdView.element, oldKbd.element);
     kbdView.postInsert();
+    this.bannerController?.configureForKeyboard(this.keyboardData?.keyboard, this.keyboardData?.metadata);
 
     // Now that the swap has occurred, it's safe to shutdown the old VisualKeyboard and any related stylesheets.
     if(oldKbd instanceof VisualKeyboard) {

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -233,10 +233,22 @@ export default abstract class OSKView
     // Initializes the two constant OSKComponentView fields.
     this.bannerView   = new BannerView();
     this.bannerView.events.on('bannerchange', () => this.refreshLayout());
+    this._Box.appendChild(this.bannerView.element);
 
     this._bannerController = new BannerController(this.bannerView, this.hostDevice, this.config.predictionContextManager);
 
-    this.keyboardView = null;
+    this.keyboardView = this._GenerateKeyboardView(null, null);
+    this._Box.appendChild(this.keyboardView.element);
+
+    // Install the default OSK stylesheets - but don't have it managed by the keyboard-specific stylesheet manager.
+    // We wish to maintain kmwosk.css whenever keyboard-specific styles are reset/removed.
+    // Temp-hack:  embedded products prefer their stylesheet, etc linkages without the /osk path component.
+    const resourcePath = getResourcePath(this.config);
+
+    for(let sheetFile of OSKView.STYLESHEET_FILES) {
+      const sheetHref = `${resourcePath}${sheetFile}`;
+      this.uiStyleSheetManager.linkExternalSheet(sheetHref);
+    }
 
     this.setBaseMouseEventListeners();
     if(this.hostDevice.touchable) {
@@ -700,52 +712,30 @@ export default abstract class OSKView
 
   private loadActiveKeyboard() {
     this.setBoxStyling();
-
-    // Do not erase / 'shutdown' the banner-controller; we simply re-use its elements.
-    if(this.vkbd) {
-      this.vkbd.shutdown();
-    }
-    this.keyboardView = null;
     this.needsLayout = true;
-
-    // Instantly resets the OSK container, erasing / delinking the previously-loaded keyboard.
-    this._Box.innerHTML = '';
-
-    // Since we cleared all inner HTML, that means we cleared the stylesheets, too.
-    this.uiStyleSheetManager.unlinkAll();
-    this.kbdStyleSheetManager.unlinkAll();
-
-    // Install the default OSK stylesheets - but don't have it managed by the keyboard-specific stylesheet manager.
-    // We wish to maintain kmwosk.css whenever keyboard-specific styles are reset/removed.
-    // Temp-hack:  embedded products prefer their stylesheet, etc linkages without the /osk path component.
-    const resourcePath = getResourcePath(this.config);
-
-    for(let sheetFile of OSKView.STYLESHEET_FILES) {
-      const sheetHref = `${resourcePath}${sheetFile}`;
-      this.uiStyleSheetManager.linkExternalSheet(sheetHref);
-    }
-
-    // Any event-cancelers would go here, after the innerHTML reset.
-
-    // Add header element to OSK only for desktop browsers
-    if(this.headerView) {
-      this._Box.appendChild(this.headerView.element);
-    }
-
-    // Add suggestion banner bar to OSK
-    this._Box.appendChild(this.banner.element);
 
     this.bannerController?.configureForKeyboard(this.keyboardData?.keyboard, this.keyboardData?.metadata);
 
-    let kbdView: KeyboardView = this.keyboardView = this._GenerateKeyboardView(this.keyboardData?.keyboard, this.keyboardData?.metadata);
-    this._Box.appendChild(kbdView.element);
+    // Save references to the old kbd & its styles for shutdown after replacement.
+    const oldKbd = this.keyboardView;
+    const oldKbdStyleManager = this.kbdStyleSheetManager;
+
+    // Create new ones for the new, incoming kbd.
+    this.kbdStyleSheetManager = new StylesheetManager(this._Box, this.config.doCacheBusting || false);
+    const kbdView = this.keyboardView = this._GenerateKeyboardView(this.keyboardData?.keyboard, this.keyboardData?.metadata);
+
+    // Perform the replacement.
+    this._Box.replaceChild(kbdView.element, oldKbd.element);
     kbdView.postInsert();
 
-    // Add footer element to OSK only for desktop browsers
-    if(this.footerView) {
-      this._Box.appendChild(this.footerView.element);
+    // Now that the swap has occurred, it's safe to shutdown the old VisualKeyboard and any related stylesheets.
+    if(oldKbd instanceof VisualKeyboard) {
+      oldKbd.shutdown();
     }
+    oldKbdStyleManager.unlinkAll();
+
     // END:  construction of the actual internal layout for the overall OSK
+    // Footer element management is handled within FloatingOSKView.
 
     this.banner.appendStyles();
 
@@ -769,10 +759,6 @@ export default abstract class OSKView
 
   private _GenerateKeyboardView(keyboard: Keyboard, keyboardMetadata: KeyboardProperties): KeyboardView {
     let device = this.targetDevice;
-
-    if(this.vkbd) {
-      this.vkbd.shutdown();
-    }
 
     this._Box.className = "";
 


### PR DESCRIPTION
Fixes #11034.

To make the keyboard & banner less prone to FOUC-style layout flashes, this PR changes Web's keyboard-element management strategy to be more stable, re-using all possible elements rather than throwing away internal DOM and recreating it whenever keyboards are swapped.  It appears a side-effect of that caused older versions of Chrome to need to re-evaluate the stylesheet each time, causing a delay in style activation that caused the problem observed in #11034 as a knock-on effect.

## User Testing

TEST_ATTEMPT_REPRO:  Attempt to reproduce #11034 using this PR's build artifact.

1. Using an Android 7.1.1 / API 25 device or emulator, install Keyman for Android.
2. Install Cameroon Qwerty and SIL (IPA) keyboard. 
3. Swap back and forth between sil_euro_latin (uses predictive text) and the Cameroon - Bafanji & SIL (IPA) keyboards (image banner) using the globe key.

Note that in my personal repro attempts, this wasn't consistent even when the bug was active.  Attempt to repro this for **at least** a minute to observe if any full-keyboard flashes of the image banner occur before PASSing this test.

TEST_DESKTOP_WEB:  Using the "Test unminified KeymanWeb" Web test page on a desktop form-factor device, verify that keyboard swapping works normally.

TEST_TOUCH_WEB: Using the "Test unminified KeymanWeb" Web test page on a touch device / with touch-device emulation, verify that keyboard swapping works normally.