### PR TITLE
fix(common): make `isEmptyTransform` return true if passed a nullish transform

### DIFF
--- a/common/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/web/keyboard-processor/src/text/outputTarget.ts
@@ -13,7 +13,7 @@ import { Deadkey, DeadkeyTracker } from "./deadkeys.js";
 
 export function isEmptyTransform(transform: Transform) {
   if(!transform) {
-    return false;
+    return true;
   }
   return transform.insert === '' && transform.deleteLeft === 0 && (transform.deleteRight ?? 0) === 0;
 }


### PR DESCRIPTION
Fixes #11084.

@keymanapp-test-bot skip