### PR TITLE
fix(ios):  address crash by reading full code point rather than code unit when trimming initial directional-mark

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Extension/String+Helpers.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Extension/String+Helpers.swift
@@ -53,10 +53,9 @@ func trimDirectionalMarkPrefix(_ str: String?) -> String {
   // If the first intended char in context is a diacritic (such as U+0300), Swift's
   // standard string-handling will treat it and a preceding directional character
   // as a single unit.  This code block exists to avoid the issue.
-  if text.utf16.count > 0 {
-    let head = UnicodeScalar(text.utf16[text.utf16.startIndex])!
-    let tail = text.utf16.count > 1 ? String(text.utf16[text.utf16.index(text.utf16.startIndex, offsetBy: 1)..<text.utf16.endIndex])! : ""
-
+  if text.unicodeScalars.count > 0 {
+    let head = text.unicodeScalars.first!
+    let tail = String(text.unicodeScalars.dropFirst(1))
 
 //    // "%02X" - to hex-format the integer for the string conversion.
 //    let headEncoding = String(format:"%02X", text.utf16[text.utf16.startIndex])


### PR DESCRIPTION
Fixes #11093.

Rather than having the directional-mark trimming process swap between two encoding patterns, we should just use one.  While investigating exactly what the context was at the time of the reported error, I noted a few extra String functions that can be used to provide much cleaner-looking String manipulations.

The most likely culprit is a simple, context-initial non-BMP char.  A simple non-BMP emoji, for example, would likely be enough to have triggered the bug.  Within the Keyman app, this _shouldn't_ be possible after initialization is complete due to our insertion of an LTR or RTL mark as the context's prefix... but said mark is only established when editing begins, which is likely _after_ the context itself is initialized.  (So, there would be a "window of vulnerability" during init.)  For system-keyboard mode, there is no such directionality mark to affect things, so no further explanation is needed there.

@keymanapp-test-bot skip