### PR TITLE
fix(android/engine): Swap selection range if reversed

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2139,15 +2139,21 @@ public final class KMManager {
 
   public static boolean updateSelectionRange(KeyboardType kbType, int selStart, int selEnd) {
     boolean result = false;
+    int selMin = selStart, selMax = selEnd;
+    if (selStart > selEnd) {
+      // Selection is reversed so "swap"
+      selMin = selEnd;
+      selMax = selStart;
+    }
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreSelectionChange()) {
-        result = InAppKeyboard.updateSelectionRange(selStart, selEnd);
+        result = InAppKeyboard.updateSelectionRange(selMin, selMax);
       }
 
       InAppKeyboard.setShouldIgnoreSelectionChange(false);
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreSelectionChange()) {
-        result = SystemKeyboard.updateSelectionRange(selStart, selEnd);
+        result = SystemKeyboard.updateSelectionRange(selMin, selMax);
       }
 
       SystemKeyboard.setShouldIgnoreSelectionChange(false);


### PR DESCRIPTION
Fixes [Sentry issue](https://keyman.sentry.io/issues/5022225846)
Fixes #11128

When a selection range is reversed (selection "end" is before the selection "start"), this was causing an IndexOutOfBounds exception at
https://github.com/keymanapp/keyman/blob/6864cb32dd7e0513616b4d32decca924869229f9/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java#L189-L190

where `selStart` was greater than `rawText.length()`.

KMKeyboardJSHandler had code to swap start/end for backward selection, but this happens after the line with the crash.

This PR changes KMKeyboard.updateSelectionRange to swap the selection indexes when the selection is reversed

## User Testing
**Setup** - Install the PR build of Keyman for Android on an Android device/emulator. In Keyman, install a keyboard that has SMP characters (e.g. [basic_kbdosm](https://keyman.com/keyboards/basic_kbdosm) for Osmanya.

**TEST_REVERSE** - Verifies no crash when selection is reversed
1. Launch Keyman for Android
2. From "Get Started", install the Keyman keyboard basic_kbdosm (Osmanya which uses SMP characters)
3. Set Keyman as the default system keyboard
4. Launch a separate messaging app (where you can type text).
5. Use Keyman to type a mix of English (sil_eurolatin) and Osmanya (basic_kbdosm) characters.
6. In Keyman,select the basic_kbdosm keyboard
7. Double-tap to select a word in the text area (that contains a mix of English andOsmanya characters). This is the normal direction of selecting text
8. With the Keyman keyboard, press a character
9. Verify the word is replaced with the Osmanya character
10. Double-tap to select a word in the text area. 
11. With the word selected, drag the end to "before" the start so the selection is "reversed"
12. Verify no crash in the Keyboard
13. With the Keyman keyboard, press a character
14. Verify the word is replaced with the Osmanya character