### PR TITLE
change(web): reworks nearest-key detection to avoid layout reflow 🪠

### DIFF
--- a/web/src/engine/osk/src/keyboard-layout/oskRow.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskRow.ts
@@ -11,6 +11,7 @@ export default class OSKRow {
   public readonly element: HTMLDivElement;
   public readonly keys: OSKBaseKey[];
   public readonly heightFraction: number;
+  public readonly spec: ActiveRow;
 
   public constructor(vkbd: VisualKeyboard,
                       layerSpec: ActiveLayer,
@@ -23,6 +24,7 @@ export default class OSKRow {
 
     // Apply defaults, setting the width and other undefined properties for each key
     const keys=rowSpec.key;
+    this.spec = rowSpec;
     this.keys = [];
 
     // Calculate actual key widths by multiplying by the OSK's width and rounding appropriately,

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1288,6 +1288,10 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       return;
     }
 
+    // Set layer-group copies of the computed-size values; they are used by nearest-key
+    // detection.
+    this.layerGroup.refreshLayout(this._computedWidth, this._computedHeight);
+
     // Step 3: recalculate gesture parameter values
     // Skip for doc-keyboards, since they don't do gestures.
     if(!this.isStatic) {


### PR DESCRIPTION
Addresses the performance concerns noted at https://github.com/keymanapp/keyman/pull/10960#issuecomment-2021978972.

This changes the Web engine's 'nearest key' detection method to run entirely based upon precomputed layout values, completely sidestepping any need to trigger any (costly) layout reflow operations.  This significantly improves keyboard-responsiveness in rapid-typing / "key-mash" scenarios.

# User Testing

**TEST_GESTURE_REGRESSIONS**: Run the full set of Web's gesture-related regression tests and report back on any errors.  Please give details for any error encountered.

----

A couple of profiles with these changes in place, on the same device (SM-T350 / Galaxy Tab A, released May 2015):

![image](https://github.com/keymanapp/keyman/assets/25213402/4b17cf23-9668-4c54-ac25-ecc0e1aba9ce)

This run did include some _actual_ layer changes, and it's those which seemed to have the largest run-time impact.  (With this test device, even triggering a layer change _in isolation_ has perceptible lag.)

![image](https://github.com/keymanapp/keyman/assets/25213402/504852da-021a-4f88-bbf8-26a3e8070a91)

The second-highest run-time contribution came from gesture processing itself.  In order of their listing:
1. The handler that triggers key-preview display and updates - thus, triggering (limited) layout and style operations.
2. touch-events:  'touchmove' handling & related overhead
3. touch-event queue ordering / overhead + the main bulk of 'touchstart' handling.
4. gesture-selection + related handling.  Occasionally includes reflows if layer shifts are triggered (start-of-sentence, modipress, modifier keys)
5. gesture-model updates + evaluation
6. Seems to be a subset of number 4, also relating to gesture-selection.
7. The rest seem to be event-handling & event-ordering overhead.

There certainly _is_ more overhead from ensuring proper event-handling order than we can consider negligible, but even then, it's only a contributing factor.

For comparison, here's a row with only a single layer-shift (due to start-of-sentence) and a similar number of keystrokes (~20).  Same device.

![image](https://github.com/keymanapp/keyman/assets/25213402/237452e0-7f1f-4075-bf60-6f6cd1eff8e3)

Any layer-shifting operations will have a greater performance hit than the remainder of the code.