### PR TITLE
change(web):  OSK optimization, improved responsiveness 🪠

### DIFF
--- a/web/src/engine/main/src/contextManagerBase.ts
+++ b/web/src/engine/main/src/contextManagerBase.ts
@@ -274,8 +274,6 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
     // (!wasNull || !!keyboard) - blocks events for `null` -> `null` transitions.
     // (keyman/keymanweb.com#96)
     if(this.currentKeyboardSrcTarget() == originalKeyboardTarget && (!wasNull || !!keyboard)) {
-      // Perform standard context-reset ops, including the processing of new-context events.
-      this.resetContext();
       // Will trigger KeymanEngine handler that passes keyboard to the OSK, displays it.
       this.emit('keyboardchange', this.activeKeyboard);
     }

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -597,6 +597,15 @@ export default abstract class OSKView
   }
 
   public batchLayoutAfter(closure: () => void) {
+    /*
+      Is there already an ongoing batch?  If so, just run the closure and don't
+      adjust the tracking variables.  The outermost call will finalize layout.
+    */
+    if(this.deferLayout) {
+      closure();
+      return;
+    }
+
     try {
       this.deferLayout = true;
       if(this.vkbd) {

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -159,6 +159,7 @@ export default abstract class OSKView
   private uiStyleSheetManager: StylesheetManager;
 
   private config: Configuration;
+  private deferLayout: boolean;
 
   private _boxBaseMouseDown:        (e: MouseEvent) => boolean;
   private _boxBaseTouchStart:       (e: TouchEvent) => boolean;
@@ -595,8 +596,24 @@ export default abstract class OSKView
     this.needsLayout = true;
   }
 
+  public batchLayoutAfter(closure: () => void) {
+    try {
+      this.deferLayout = true;
+      if(this.vkbd) {
+        this.vkbd.deferLayout = true;
+      }
+      closure();
+    } finally {
+      this.deferLayout = false;
+      if(this.vkbd) {
+        this.vkbd.deferLayout = false;
+      }
+      this.refreshLayout();
+    }
+  }
+
   public refreshLayout(pending?: boolean): void {
-    if(!this.keyboardView) {
+    if(!this.keyboardView || this.deferLayout) {
       return;
     }
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -231,10 +231,19 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
 
   activeGestures: GestureHandler[] = [];
   activeModipress: Modipress = null;
+  private _deferLayout: boolean;
 
   // The keyboard object corresponding to this VisualKeyboard.
   public readonly layoutKeyboard: Keyboard;
   public readonly layoutKeyboardProperties: KeyboardProperties;
+
+  get deferLayout(): boolean {
+    return this._deferLayout;
+  }
+
+  set deferLayout(value: boolean) {
+    this._deferLayout = value;
+  }
 
   get layerId(): string {
     return this.layerGroup?.activeLayerId ?? 'default';
@@ -253,7 +262,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       }
     }
 
-    if(changedLayer) {
+    if(changedLayer && !this._deferLayout) {
       this.updateState();
       // We changed the active layer, but not any layout property of the keyboard as a whole.
       this.layerGroup.refreshLayout(this.constructLayoutParams());
@@ -1206,6 +1215,10 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
    * when needed.
    */
   refreshLayout() {
+    if(this._deferLayout) {
+      return;
+    }
+
     /*
       Phase 1:  calculations possible at the start without triggering _any_ additional layout reflow.
       (A single, initial reflow may happen depending on DOM manipulations before this method...,


### PR DESCRIPTION
The set of PRs culminating here heavily restructures how the OSK loads and updates during use - especially after device rotation and when swapping layers.  This should help the OSK load faster and change layers faster.

Based on local profiling experiments, observations, and data, with this PR + #11129... [(details in a comment below)](https://github.com/keymanapp/keyman/pull/11140#issuecomment-2036287502)

- keyboard swapping is approximately 33% faster, and even higher for more complex keyboards
- the embedded Web engine within our Android and iOS keyboards initializes approximately 60% faster.
- layer-swapping during rapid-key input is just over 140% faster than previous versions of 17.0-alpha.
- layer-swapping is likely 50% faster or more than 16.0 stable.

The technical catch-all for the underlying issue is known as "layout reflow thrashing".  (This is the focus of #11177.)
- Reference: https://gist.github.com/paulirish/5d52fb081b3570c81e3a

While #11177 optimizes a lot of the lower layout-reflow related code to avoid layout reflow thrashing, **this** PR is concerned with the _high-level_ version of it:  our engine, as currently written, sometimes includes redundant `refreshLayout` calls on the `OSKView` and `VisualKeyboard` level.  As both currently use `getComputedStyle` _and_ change DOM / styling data, it's quite critical - and impactful - to functionally eliminate redundant calls to their `refreshLayout` methods.

### Related PRs 

Since triggering layout reflows is expensive, #11177 reworked the OSK to use precalculated values as often as possible while batching layout changes together, allowing us to skip many of the reflow operations that were previously hindering responsiveness.  There was also some layout reflow during the key highlighting to key preview generation process; similar changes were made there as well, which may help improve "average" keystroke responsiveness as well. 

Fortunately for us, we've _already_ been leveraging precalculated values for _certain_ parts of functionality for a while.  We can leverage those same values to avoid excessive use of `getComputedStyle` by just recomputing it directly, given our knowledge of the tendencies of our own codebase.

On an older Android device (6.0.1, but using Chrome 80+) which has been noted to be significantly affected by OSK performance, these changes significantly cut the time needed for the OSK to swap active layers, often by a factor of two or so.  The delay is still perceptible, with the _first_ swap to each previously-unshown layer the most pronounced.  Swaps back to already-shown layers are consistently improved.

## User Testing

TEST_WINDOWS_DESKTOP:  Test general use of KeymanWeb on a Windows desktop or laptop.  Report any unexpected behavior.

TEST_ANDROID_TABLET:  Test general use of KeymanWeb on an Android tablet.  Report any unexpected behavior.

TEST_IOS_PHONE:  Test general use of KeymanWeb on an iPhone.  Report any unexpected behavior.

TEST_ANDROID_PHONE_RAPID_TYPING:  Try to repro #10592.  Include occasional layer changes during your typing bursts.  Report any unexpected behavior.

TEST_ANDROID_SPACEBAR_RECENT:  Using Keyman for Android _version 12 or greater_, verify that the spacebar is always appropriately captioned (based on user settings in the menu) for the active keyboard, with the text properly sized.

- If not already installed, download and test using `balochi_phonetic` - it has very high font scaling that will help stress-test part of spacebar-display management.
    - If the text overflows the spacebar at any point, overrunning its boundaries, FAIL this test.
- Test with a few other keyboards as well.
- Be sure to swap the device orientation back and forth a few times - from portrait to landscape and back again.
- Be sure to swap layers and verify that the spacebar for each is always labeled appropriately.
