### PR TITLE
fix(mac): load only 80 characters from context when processing keystrokes

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -309,7 +309,7 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
   NSString *contextString = @"";
   NSAttributedString *attributedString = nil;
   
-  // if we can read the text, then get the context for up to kMaxContent characters
+  // if we can read the text, then get the context for up to kMaxContext characters
   if (self.apiCompliance.canReadText) {
     NSRange selectionRange = [client selectedRange];
     NSUInteger contextLength = MIN(kMaxContext, selectionRange.location);


### PR DESCRIPTION
When reading the current context to process keystrokes, load only 80 characters instead of the entire context.

Asking for all of the existing context degrades performance in Pages and appears to cause null to be returned when exceeding a certain limit in Slack.

Fixes #11087
Fixes #10970 

# User Testing

* **TEST_TYPING_IN_PAGES**: typing reasonable amounts of text should not become noticeable slow

1. Open Pages and create a new document
1. Switch to the EuroLatin (SIL) keyboard
1. Type a couple hundred characters
1. Confirm that inserting characters does not become noticeably slower as you continue to type (for comparison try typing with the Apple US keyboard and see if it is equally responsive)

* **TEST_TYPING_IN_SLACK**: keys should continue processing correctly after typing over 100 characters

1. Open Slack
1. Switch to the fv_southern_carrier keyboard
1. Go to compose a new message to yourself and type at least 101 characters
1. Without moving from the text field where you are typing, type the following sequence of keys: <kbd>t</kbd><kbd>s</kbd><kbd>'</kbd><kbd>i</kbd><kbd>y</kbd><kbd>a</kbd><kbd>w</kbd><kbd>h</kbd>
1. Confirm that the resulting text for these additional keystrokes is ᙫᘓᗛ
