### PR TITLE
fix(common): upgrade sentry-cli to 2.31.0

### DIFF
--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -126,7 +126,7 @@ if builder_start_action bundle; then
   mkdir -p build/dist
   node build-bundler.js
 
-  ./node_modules/.bin/sentry-cli sourcemaps inject \
+  sentry-cli sourcemaps inject \
     --org keyman \
     --project keyman-developer \
     --release "$VERSION_GIT_TAG"  \

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -55,7 +55,7 @@
     "build/unicode-license.txt"
   ],
   "devDependencies": {
-    "@sentry/cli": "^2.19.4",
+    "@sentry/cli": "^2.31.0",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.4.1",

--- a/developer/src/tools/sentry-upload-difs.sh
+++ b/developer/src/tools/sentry-upload-difs.sh
@@ -65,7 +65,7 @@ sourcemap_paths=(
 )
 
 echo "Uploading symbols for developer/"
-./src/kmc/node_modules/.bin/sentry-cli upload-dif \
+sentry-cli upload-dif \
   --project keyman-developer \
   --include-sources \
   --no-zips \
@@ -73,7 +73,7 @@ echo "Uploading symbols for developer/"
 
 upload_sourcemap() {
   local smpath="$1"
-  "$KEYMAN_ROOT/developer/src/kmc/node_modules/.bin/sentry-cli" sourcemaps upload \
+  sentry-cli sourcemaps upload \
     --no-dedupe \
     --org keyman \
     --project keyman-developer \

--- a/package-lock.json
+++ b/package-lock.json
@@ -995,7 +995,7 @@
         "kmlmp": "build/src/kmlmp.js"
       },
       "devDependencies": {
-        "@sentry/cli": "^2.19.4",
+        "@sentry/cli": "^2.31.0",
         "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.4.1",
@@ -2547,26 +2547,6 @@
         "node": ">=0.3.1"
       }
     },
-    "developer/src/kmc/node_modules/@sentry/cli": {
-      "version": "2.19.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.19.4.tgz",
-      "integrity": "sha512-wsSr2O/GVgr/i+DYtie+DNhODyI+HL7F5/0t1HwWMjHJWm4+5XTEauznYgbh2mewkzfUk9+t0CPecA82lEgspg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "sentry-cli": "bin/sentry-cli"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "developer/src/kmc/node_modules/@types/mocha": {
       "version": "5.2.7",
       "dev": true,
@@ -3792,14 +3772,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/cli": {
-      "version": "2.2.0",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.31.0.tgz",
+      "integrity": "sha512-nCESoXAG3kRUO5n3QbDYAqX6RU3z1ORjnd7a3sqijYsCGHfOpcjGdS7JYLVg5if+tXMEF5529BPXFe5Kg/J9tw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.7",
-        "npmlog": "^6.0.1",
         "progress": "^2.0.3",
         "proxy-from-env": "^1.1.0",
         "which": "^2.0.2"
@@ -3808,7 +3788,131 @@
         "sentry-cli": "bin/sentry-cli"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.31.0",
+        "@sentry/cli-linux-arm": "2.31.0",
+        "@sentry/cli-linux-arm64": "2.31.0",
+        "@sentry/cli-linux-i686": "2.31.0",
+        "@sentry/cli-linux-x64": "2.31.0",
+        "@sentry/cli-win32-i686": "2.31.0",
+        "@sentry/cli-win32-x64": "2.31.0"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.31.0.tgz",
+      "integrity": "sha512-VM5liyxMnm4K2g0WsrRPXRCMLhaT09C7gK5Fz/CxKYh9sbMZB7KA4hV/3klkyuyw1+ECF1J66cefhNkFZepUig==",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.31.0.tgz",
+      "integrity": "sha512-AZoCN3waXEfXGCd3YSrikcX/y63oQe0Tiyapkeoifq/0QhI+2MOOrAQb60gthsXwb0UDK/XeFi3PaxyUCphzxA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.31.0.tgz",
+      "integrity": "sha512-eENJTmXoFX3uNr8xRW7Bua2Sw3V1tylQfdtS85pNjZPdbm3U8wYQSWu2VoZkK2ASOoC+17YC8jTQxq62KWnSeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.31.0.tgz",
+      "integrity": "sha512-cQUFb3brhLaNSIoNzjU/YASnTM1I3TDJP9XXzH0eLK9sSopCcDcc6OrYEYvdjJXZKzFv5sbc9UNMsIDbh4+rYg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.31.0.tgz",
+      "integrity": "sha512-z1zTNg91nZJRdcGHC/bCU1KwIaifV0MLJteip9KrFDprzhJk1HtMxFOS0+OZ5/UH21CjAFmg9Pj6IAGqm3BYjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.31.0.tgz",
+      "integrity": "sha512-+K7fdk57aUd4CmYrQfDGYPzVyxsTnVro6IPb5QSSLpP03dL7ko5208epu4m2SyN/MkFvscy9Di3n3DTvIfDU2w==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.31.0.tgz",
+      "integrity": "sha512-w5cvpZ6VVlhlyleY8TYHmrP7g48vKHnoVt5xFccfxT+HqQI/AxodvzgVvBTM2kB/sh/kHwexp6bJGWCdkGftww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/core": {
@@ -4775,13 +4879,13 @@
     },
     "node_modules/aproba": {
       "version": "2.0.0",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -4792,8 +4896,8 @@
     },
     "node_modules/are-we-there-yet/node_modules/readable-stream": {
       "version": "3.6.0",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5454,8 +5558,8 @@
     },
     "node_modules/color-support": {
       "version": "1.1.3",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -5570,8 +5674,8 @@
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -5861,8 +5965,8 @@
     },
     "node_modules/delegates": {
       "version": "1.0.0",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/depd": {
       "version": "1.1.2",
@@ -7581,8 +7685,8 @@
     },
     "node_modules/gauge": {
       "version": "4.0.4",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.3",
@@ -7599,24 +7703,24 @@
     },
     "node_modules/gauge/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/gauge/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/gauge/node_modules/string-width": {
       "version": "4.2.3",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7628,8 +7732,8 @@
     },
     "node_modules/gauge/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -7639,8 +7743,8 @@
     },
     "node_modules/gauge/node_modules/wide-align": {
       "version": "1.1.5",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
@@ -7996,8 +8100,8 @@
     },
     "node_modules/has-unicode": {
       "version": "2.0.1",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -10252,8 +10356,8 @@
     },
     "node_modules/npmlog": {
       "version": "6.0.2",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
@@ -12719,7 +12823,7 @@
       "devDependencies": {
         "@keymanapp/resources-gosh": "*",
         "@keymanapp/web-sentry-manager": "*",
-        "@sentry/cli": "2.2.0",
+        "@sentry/cli": "^2.31.0",
         "c8": "^7.12.0",
         "chai": "^4.3.4",
         "jsdom": "^23.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@keymanapp/resources-gosh": "*",
     "@keymanapp/web-sentry-manager": "*",
-    "@sentry/cli": "2.2.0",
+    "@sentry/cli": "^2.31.0",
     "c8": "^7.12.0",
     "chai": "^4.3.4",
     "jsdom": "^23.0.1",


### PR DESCRIPTION
fix not #11091.

Updating to latest sentry-cli on all projects, reviewed release notes and there do not appear to be any breaking changes.

sentry-cli 2.19.4 had a bug with uploading wasm symbols: https://github.com/getsentry/sentry-cli/issues/1682

It was fixed in 2.20.0: https://github.com/getsentry/sentry-cli/releases/tag/2.20.0

@keymanapp-test-bot skip