### PR TITLE
fix(windows): decode uri for Package ID and filename

### DIFF
--- a/common/windows/delphi/general/Upload_Settings.pas
+++ b/common/windows/delphi/general/Upload_Settings.pas
@@ -94,7 +94,7 @@ uses
   DebugPaths,
   ErrorControlledRegistry,
   RegistryKeys,
-  IdURI,
+  utilhttp,
   VersionInfo;
 
 const
@@ -170,7 +170,7 @@ var
 begin
   if IsUpdate then IsUpdateInt := 1 else IsUpdateInt := 0;
 
-  Result := Format(URLPath_PackageDownload_Format, [TIdURI.URLEncode(PackageID), CKeymanVersionInfo.Tier, BCP47, IsUpdateInt]);
+  Result := Format(URLPath_PackageDownload_Format, [URLEncode(PackageID), URLEncode(CKeymanVersionInfo.Tier), URLEncode(BCP47), IsUpdateInt]);
 end;
 
 end.

--- a/common/windows/delphi/general/Upload_Settings.pas
+++ b/common/windows/delphi/general/Upload_Settings.pas
@@ -94,6 +94,7 @@ uses
   DebugPaths,
   ErrorControlledRegistry,
   RegistryKeys,
+  IdURI,
   VersionInfo;
 
 const
@@ -169,7 +170,7 @@ var
 begin
   if IsUpdate then IsUpdateInt := 1 else IsUpdateInt := 0;
 
-  Result := Format(URLPath_PackageDownload_Format, [PackageID, CKeymanVersionInfo.Tier, BCP47, IsUpdateInt]);
+  Result := Format(URLPath_PackageDownload_Format, [TIdURI.URLEncode(PackageID), CKeymanVersionInfo.Tier, BCP47, IsUpdateInt]);
 end;
 
 end.

--- a/developer/src/kmconvert/kmconvert.dpr
+++ b/developer/src/kmconvert/kmconvert.dpr
@@ -88,7 +88,8 @@ uses
   Keyman.System.LexicalModelUtils in '..\common\delphi\lexicalmodels\Keyman.System.LexicalModelUtils.pas',
   KeymanDeveloperOptions in '..\tike\main\KeymanDeveloperOptions.pas',
   Keyman.Developer.System.KeymanDeveloperPaths in '..\tike\main\Keyman.Developer.System.KeymanDeveloperPaths.pas',
-  Keyman.Developer.System.LdmlKeyboardProjectTemplate in 'Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas';
+  Keyman.Developer.System.LdmlKeyboardProjectTemplate in 'Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas',
+  utilhttp in '..\..\..\common\windows\delphi\general\utilhttp.pas';
 
 {$R icons.RES}
 {$R version.res}

--- a/developer/src/kmconvert/kmconvert.dproj
+++ b/developer/src/kmconvert/kmconvert.dproj
@@ -195,6 +195,7 @@
         <DCCReference Include="..\tike\main\KeymanDeveloperOptions.pas"/>
         <DCCReference Include="..\tike\main\Keyman.Developer.System.KeymanDeveloperPaths.pas"/>
         <DCCReference Include="Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas"/>
+        <DCCReference Include="..\..\..\common\windows\delphi\general\utilhttp.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/developer/src/setup/setup.dpr
+++ b/developer/src/setup/setup.dpr
@@ -25,7 +25,8 @@ uses
   utilexecute in '..\..\..\common\windows\delphi\general\utilexecute.pas',
   KeymanVersion in '..\..\..\common\windows\delphi\general\KeymanVersion.pas',
   SFX in '..\..\..\common\windows\delphi\setup\SFX.pas',
-  Keyman.System.UpdateCheckResponse in '..\..\..\common\windows\delphi\general\Keyman.System.UpdateCheckResponse.pas';
+  Keyman.System.UpdateCheckResponse in '..\..\..\common\windows\delphi\general\Keyman.System.UpdateCheckResponse.pas',
+  utilhttp in '..\..\..\common\windows\delphi\general\utilhttp.pas';
 
 {$R icons.res}
 {$R version.res}

--- a/developer/src/setup/setup.dproj
+++ b/developer/src/setup/setup.dproj
@@ -124,6 +124,7 @@
         <DCCReference Include="..\..\..\common\windows\delphi\general\KeymanVersion.pas"/>
         <DCCReference Include="..\..\..\common\windows\delphi\setup\SFX.pas"/>
         <DCCReference Include="..\..\..\common\windows\delphi\general\Keyman.System.UpdateCheckResponse.pas"/>
+        <DCCReference Include="..\..\..\common\windows\delphi\general\utilhttp.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
@@ -184,7 +185,7 @@
                 <Platform value="Win64">False</Platform>
             </Platforms>
             <Deployment Version="3">
-                <DeployFile LocalName="setup.exe" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="bin\Win32\Debug\setup.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>setup.exe</RemoteName>
                         <Overwrite>true</Overwrite>

--- a/developer/src/setup/setup.dproj
+++ b/developer/src/setup/setup.dproj
@@ -185,7 +185,7 @@
                 <Platform value="Win64">False</Platform>
             </Platforms>
             <Deployment Version="3">
-                <DeployFile LocalName="bin\Win32\Debug\setup.exe" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="setup.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>setup.exe</RemoteName>
                         <Overwrite>true</Overwrite>

--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.KeymanProtocolHandler.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.KeymanProtocolHandler.pas
@@ -75,7 +75,7 @@ begin
   if not m.Success then
     Exit(False);
 
-  PackageID := m.Groups[1].Value;
+  PackageID := TIdURI.URLDecode(m.Groups[1].Value);
   if m.Groups.Count > 2
     then BCP47 := m.Groups[2].Value
     else BCP47 := '';
@@ -85,7 +85,7 @@ begin
   // TODO: refactor into separate unit together with code from UfrmInstallKeyboardFromWeb
   FTempDir := IncludeTrailingPathDelimiter(CreateTempPath);  // I1679
   try
-    FDownloadFilename := FTempDir + TIdURI.URLDecode(PackageID) + Ext_PackageFile;
+    FDownloadFilename := FTempDir + PackageID + Ext_PackageFile;
     FDownloadURL := KeymanCom_Protocol_Server + URLPath_PackageDownload(PackageID, BCP47, False);
 
     frmDownloadProgress := TfrmDownloadProgress.Create(nil);

--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.KeymanProtocolHandler.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.KeymanProtocolHandler.pas
@@ -39,6 +39,7 @@ uses
   UfrmInstallKeyboard,
   Upload_Settings,
   utildir,
+  IdURI,
   utilfiletypes;
 
 { TKeymanProtocolHandler }
@@ -84,7 +85,7 @@ begin
   // TODO: refactor into separate unit together with code from UfrmInstallKeyboardFromWeb
   FTempDir := IncludeTrailingPathDelimiter(CreateTempPath);  // I1679
   try
-    FDownloadFilename := FTempDir + PackageID + Ext_PackageFile;
+    FDownloadFilename := FTempDir + TIdURI.URLDecode(PackageID) + Ext_PackageFile;
     FDownloadURL := KeymanCom_Protocol_Server + URLPath_PackageDownload(PackageID, BCP47, False);
 
     frmDownloadProgress := TfrmDownloadProgress.Create(nil);

--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.KeymanProtocolHandler.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.KeymanProtocolHandler.pas
@@ -77,7 +77,7 @@ begin
 
   PackageID := URLDecode(m.Groups[1].Value);
   if m.Groups.Count > 2
-    then BCP47 := m.Groups[2].Value
+    then BCP47 := URLDecode(m.Groups[2].Value)
     else BCP47 := '';
 
   // Download the package

--- a/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.KeymanProtocolHandler.pas
+++ b/windows/src/desktop/kmshell/install/Keyman.Configuration.UI.KeymanProtocolHandler.pas
@@ -39,7 +39,7 @@ uses
   UfrmInstallKeyboard,
   Upload_Settings,
   utildir,
-  IdURI,
+  utilhttp,
   utilfiletypes;
 
 { TKeymanProtocolHandler }
@@ -75,7 +75,7 @@ begin
   if not m.Success then
     Exit(False);
 
-  PackageID := TIdURI.URLDecode(m.Groups[1].Value);
+  PackageID := URLDecode(m.Groups[1].Value);
   if m.Groups.Count > 2
     then BCP47 := m.Groups[2].Value
     else BCP47 := '';

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboardFromWeb.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboardFromWeb.pas
@@ -191,7 +191,7 @@ begin
   if m.Success then
   begin
     // We want to install the keyboard found in the path.
-    PackageID := m.Groups[1].Value;
+    PackageID := TIdURI.URLDecode(m.Groups[1].Value);
     uri := TURI.Create(url);
 
     try
@@ -216,7 +216,7 @@ var
 begin
   FTempDir := IncludeTrailingPathDelimiter(CreateTempPath);  // I1679
   try
-    FDownloadFilename := FTempDir + TIdURI.URLDecode(PackageID) + Ext_PackageFile;
+    FDownloadFilename := FTempDir + PackageID + Ext_PackageFile;
     FDownloadURL := KeymanCom_Protocol_Server + URLPath_PackageDownload(PackageID, BCP47, False);
 
     frmDownloadProgress := TfrmDownloadProgress.Create(Self);

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboardFromWeb.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboardFromWeb.pas
@@ -91,6 +91,7 @@ uses
   Upload_Settings,
   utilfiletypes,
   utildir,
+  IdURI,
   utilexecute,
   VersionInfo;
 
@@ -215,7 +216,7 @@ var
 begin
   FTempDir := IncludeTrailingPathDelimiter(CreateTempPath);  // I1679
   try
-    FDownloadFilename := FTempDir + PackageID + Ext_PackageFile;
+    FDownloadFilename := FTempDir + TIdURI.URLDecode(PackageID) + Ext_PackageFile;
     FDownloadURL := KeymanCom_Protocol_Server + URLPath_PackageDownload(PackageID, BCP47, False);
 
     frmDownloadProgress := TfrmDownloadProgress.Create(Self);

--- a/windows/src/desktop/kmshell/install/UfrmInstallKeyboardFromWeb.pas
+++ b/windows/src/desktop/kmshell/install/UfrmInstallKeyboardFromWeb.pas
@@ -91,7 +91,7 @@ uses
   Upload_Settings,
   utilfiletypes,
   utildir,
-  IdURI,
+  utilhttp,
   utilexecute,
   VersionInfo;
 
@@ -191,7 +191,7 @@ begin
   if m.Success then
   begin
     // We want to install the keyboard found in the path.
-    PackageID := TIdURI.URLDecode(m.Groups[1].Value);
+    PackageID := URLDecode(m.Groups[1].Value);
     uri := TURI.Create(url);
 
     try

--- a/windows/src/desktop/setup/setup.dpr
+++ b/windows/src/desktop/setup/setup.dpr
@@ -45,7 +45,8 @@ uses
   Keyman.System.MITLicense in '..\..\global\delphi\general\Keyman.System.MITLicense.pas',
   Keyman.Setup.System.Locales in 'Keyman.Setup.System.Locales.pas',
   Keyman.System.UILanguageManager in '..\..\global\delphi\general\Keyman.System.UILanguageManager.pas',
-  Keyman.Setup.System.SetupUILanguageManager in 'Keyman.Setup.System.SetupUILanguageManager.pas';
+  Keyman.Setup.System.SetupUILanguageManager in 'Keyman.Setup.System.SetupUILanguageManager.pas',
+  utilhttp in '..\..\..\..\common\windows\delphi\general\utilhttp.pas';
 
 {$R icons.res}
 {$R version.res}

--- a/windows/src/desktop/setup/setup.dproj
+++ b/windows/src/desktop/setup/setup.dproj
@@ -210,7 +210,7 @@
                 <Platform value="Win64">False</Platform>
             </Platforms>
             <Deployment Version="3">
-                <DeployFile LocalName="bin\Win32\Debug\setup.exe" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="setup.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>setup.exe</RemoteName>
                         <Overwrite>true</Overwrite>

--- a/windows/src/desktop/setup/setup.dproj
+++ b/windows/src/desktop/setup/setup.dproj
@@ -149,6 +149,7 @@
         <DCCReference Include="Keyman.Setup.System.Locales.pas"/>
         <DCCReference Include="..\..\global\delphi\general\Keyman.System.UILanguageManager.pas"/>
         <DCCReference Include="Keyman.Setup.System.SetupUILanguageManager.pas"/>
+        <DCCReference Include="..\..\..\..\common\windows\delphi\general\utilhttp.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
@@ -209,7 +210,7 @@
                 <Platform value="Win64">False</Platform>
             </Platforms>
             <Deployment Version="3">
-                <DeployFile LocalName="setup.exe" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="bin\Win32\Debug\setup.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>setup.exe</RemoteName>
                         <Overwrite>true</Overwrite>


### PR DESCRIPTION
Fixes: #11005  
It fixes the root cause,  that is the Package ID was not decoded correctly and the filesystem would end up with a directory with %20 encoding. Once this was fixed uninstalling worked correctly.
 
The uri for the downloaded filename is decoded to turn %20 back to spaces etc. For the download location encoding is maintained.

# User Testing

## TEST_UNINSTALL_KEYBOARD

Install the Keyman from this PR
1. Open in the configuration 
2. Select the `Download keyboard...`
3. Install `Greek polytonic SA`
4. Once installed go to Keyboard Layouts Configuration tab
5. Choose any of the Greek keyboards such as `Greek Polytonic LS EZ`
6. Select the Uninstall button.

Expected result: 
All of the Greek Polytonic SA keyboards are uninstalled.
