### PR TITLE
chore(linux): Build packages for next Ubuntu version separately :cherries: 

### DIFF
--- a/.github/actions/build-binary-packages/action.yml
+++ b/.github/actions/build-binary-packages/action.yml
@@ -1,0 +1,58 @@
+name: build-binary-packages
+description: |
+  Build binary packages
+inputs:
+  dist:
+    description: 'dist to build binary packages for'
+    required: true
+  arch:
+    description: 'the architecture'
+    required: false
+    default: 'amd64'
+  version:
+    description: 'The Keyman version'
+    required: true
+  prerelease_tag:
+    description: 'The prerelease tag'
+    required: true
+  deb_fullname:
+    description: 'The full name used for the packages'
+    required: true
+  deb_email:
+    description: 'The email address used for the packages'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Download Artifacts
+      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      with:
+        name: keyman-srcpkg
+        path: artifacts/keyman-srcpkg
+
+    - name: Build
+      uses: sillsdev/gha-ubuntu-packaging@1f4b7e7eacb8c82a4d874ee2c371b9bfef7e16ea # v1.0
+      with:
+        dist: "${{ inputs.dist }}"
+        platform: "${{ inputs.arch }}"
+        source_dir: "artifacts/keyman-srcpkg"
+        sourcepackage: "keyman_${{ inputs.version }}-1.dsc"
+        deb_fullname: ${{inputs.deb_fullname}}
+        deb_email: ${{inputs.deb_email}}
+        prerelease_tag: ${{ inputs.prerelease_tag }}
+
+    - name: Output resulting .deb files
+      shell: bash
+      run: |
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "$(find artifacts/ -name \*.deb)" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+
+    - name: Store binary packages
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+      with:
+        name: keyman-binarypkgs-${{ inputs.dist }}_${{ inputs.arch }}
+        path: |
+          artifacts/*
+          !artifacts/keyman-srcpkg/
+      if: always()

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Build
-      uses: ./.github/actions/build-binary-package
+      uses: ./.github/actions/build-binary-packages
       with:
         dist: ${{ matrix.dist }}
         version: ${{ needs.sourcepackage.outputs.VERSION }}
@@ -140,7 +140,7 @@ jobs:
     steps:
     - name: Build
       continue-on-error: true
-      uses: ./.github/actions/build-binary-package
+      uses: ./.github/actions/build-binary-packages
       with:
         dist: ${{ matrix.dist }}
         version: ${{ needs.sourcepackage.outputs.VERSION }}

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -109,52 +109,77 @@ jobs:
           debian/***/*
       if: always()
 
-  binary_packages:
-    name: Build binary packages
+  binary_packages_released:
+    name: Build binary packages for released versions
     needs: sourcepackage
     strategy:
       fail-fast: true
       matrix:
-        dist: [focal, jammy, mantic, noble]
-        arch: [amd64]
+        dist: [focal, jammy, mantic]
 
     runs-on: ubuntu-latest
     steps:
-    - name: Download Artifacts
-      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
-      with:
-        name: keyman-srcpkg
-        path: artifacts/keyman-srcpkg
-
     - name: Build
-      uses: sillsdev/gha-ubuntu-packaging@1f4b7e7eacb8c82a4d874ee2c371b9bfef7e16ea # v1.0
+      uses: ./.github/actions/build-binary-package
       with:
-        dist: "${{ matrix.dist }}"
-        platform: "${{ matrix.arch }}"
-        source_dir: "artifacts/keyman-srcpkg"
-        sourcepackage: "keyman_${{ needs.sourcepackage.outputs.VERSION }}-1.dsc"
+        dist: ${{ matrix.dist }}
+        version: ${{ needs.sourcepackage.outputs.VERSION }}
+        prerelease_tag: ${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}
         deb_fullname: ${{env.DEBFULLNAME}}
         deb_email: ${{env.DEBEMAIL}}
-        prerelease_tag: ${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}
 
-    - name: Output resulting .deb files
-      run: |
-        echo '```' >> $GITHUB_STEP_SUMMARY
-        echo "$(find artifacts/ -name \*.deb)" >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
+  binary_packages_unreleased:
+    name: Build binary packages for next Ubuntu version
+    needs: sourcepackage
+    strategy:
+      fail-fast: true
+      matrix:
+        dist: [noble]
 
-    - name: Store binary packages
-      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build
+      continue-on-error: true
+      uses: ./.github/actions/build-binary-package
       with:
-        name: keyman-binarypkgs-${{ matrix.dist }}_${{ matrix.arch }}
-        path: |
-          artifacts/*
-          !artifacts/keyman-srcpkg/
-      if: always()
+        dist: ${{ matrix.dist }}
+        version: ${{ needs.sourcepackage.outputs.VERSION }}
+        prerelease_tag: ${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}
+        deb_fullname: ${{env.DEBFULLNAME}}
+        deb_email: ${{env.DEBEMAIL}}
+
+  autopkg_test:
+    name: Run autopkgtests
+    needs: [binary_packages_released]
+    runs-on: ubuntu-latest
+
+    steps:
+    # - name: Download Artifacts
+    #   uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+    #   with:
+    #     path: artifacts
+    #     merge-multiple: true
+
+    # - name: Install dependencies
+    #   run: |
+    #     sudo DEBIAN_FRONTEND=noninteractive apt-get -q -y install autopkgtest qemu-system qemu-utils autodep8 genisoimage python3-distro-info
+
+    # - name: Build test image
+    #   run: |
+    #     cd "${GITHUB_WORKSPACE}/artifacts"
+    #     autopkgtest-buildvm-ubuntu-cloud -v --release=jammy
+
+    # - name: Run tests
+    #   run: |
+    #     cd "${GITHUB_WORKSPACE}/artifacts"
+    #     autopkgtest -B *.deb keyman_*.dsc -- qemu autopkgtest-jammy-amd64.img
+    - name: Ignore
+      run: |
+        echo "Ignored for now - until working solution is in place"
 
   deb_signing:
     name: Sign source and binary packages
-    needs: [sourcepackage, binary_packages]
+    needs: [sourcepackage, binary_packages_released, binary_packages_unreleased]
     runs-on: ubuntu-latest
     environment: "deploy (linux)"
     if: github.event.client_payload.isTestBuild == 'false'
@@ -256,7 +281,7 @@ jobs:
 
   api_verification:
     name: Verify API for libkeymancore.so
-    needs: [sourcepackage, binary_packages]
+    needs: [sourcepackage, binary_packages_released]
     runs-on: ubuntu-latest
 
     steps:
@@ -295,26 +320,27 @@ jobs:
         path: linux/debian/tmp/DEBIAN/symbols
       if: always()
 
+  # We intentionally ignore the results of binary_packages_unreleased
   set_status:
     name: Set result status on PR builds
-    needs: [sourcepackage, binary_packages, api_verification]
+    needs: [sourcepackage, binary_packages_released, api_verification, autopkg_test]
     runs-on: ubuntu-latest
     if: ${{ always() && github.event.client_payload.isTestBuild == 'true' }}
     steps:
     - name: Set success
-      if: needs.sourcepackage.result == 'success' && needs.binary_packages.result == 'success' && needs.api_verification.result == 'success'
+      if: needs.sourcepackage.result == 'success' && needs.binary_packages_released.result == 'success' && needs.api_verification.result == 'success' && needs.autopkg_test.result == 'success'
       run: |
         echo "RESULT=success" >> $GITHUB_ENV
         echo "MSG=Package build succeeded" >> $GITHUB_ENV
 
     - name: Set cancelled
-      if: needs.sourcepackage.result == 'cancelled' || needs.binary_packages.result == 'cancelled' || needs.api_verification.result == 'cancelled'
+      if: needs.sourcepackage.result == 'cancelled' || needs.binary_packages_released.result == 'cancelled' || needs.api_verification.result == 'cancelled' || needs.autopkg_test.result == 'cancelled'
       run: |
         echo "RESULT=error" >> $GITHUB_ENV
         echo "MSG=Package build cancelled" >> $GITHUB_ENV
 
     - name: Set failure
-      if: needs.sourcepackage.result == 'failure' || needs.binary_packages.result == 'failure' || needs.api_verification.result == 'failure'
+      if: needs.sourcepackage.result == 'failure' || needs.binary_packages_released.result == 'failure' || needs.api_verification.result == 'failure' || needs.autopkg_test.result == 'failure'
       run: |
         echo "RESULT=failure" >> $GITHUB_ENV
         echo "MSG=Package build failed" >> $GITHUB_ENV


### PR DESCRIPTION
This change splits the package builds into building packages for the released Ubuntu versions and for the next version. A failure to build packages for the next version will no longer fail the packaging GHA.

Closes #11143.

(🍒 picked from PR #11145)

@keymanapp-test-bot skip