### PR TITLE
chore(linux): Fix typo in path of `build-binary-packages` action

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Build
-      uses: ./.github/actions/build-binary-package
+      uses: ./.github/actions/build-binary-packages
       with:
         dist: ${{ matrix.dist }}
         version: ${{ needs.sourcepackage.outputs.VERSION }}
@@ -140,7 +140,7 @@ jobs:
     steps:
     - name: Build
       continue-on-error: true
-      uses: ./.github/actions/build-binary-package
+      uses: ./.github/actions/build-binary-packages
       with:
         dist: ${{ matrix.dist }}
         version: ${{ needs.sourcepackage.outputs.VERSION }}


### PR DESCRIPTION
Follow-up of #11145 to correct the spelling of the path...

@keymanapp-test-bot skip