### PR TITLE
chore(linux): More fixes for workaround for failing linux builds

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -30,7 +30,7 @@ jobs:
       PRERELEASE_TAG: ${{ steps.prerelease_tag.outputs.PRERELEASE_TAG }}
     steps:
     - name: Checkout
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         ref: '${{ github.event.client_payload.buildSha }}'
 
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         ref: '${{ github.event.client_payload.buildSha }}'
         sparse-checkout: '.github/actions/'
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         ref: '${{ github.event.client_payload.buildSha }}'
         sparse-checkout: '.github/actions/'

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -119,6 +119,12 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+      with:
+        ref: '${{ github.event.client_payload.buildSha }}'
+        sparse-checkout: '.github/actions/'
+
     - name: Build
       uses: ./.github/actions/build-binary-packages
       with:
@@ -138,6 +144,12 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+      with:
+        ref: '${{ github.event.client_payload.buildSha }}'
+        sparse-checkout: '.github/actions/'
+
     - name: Build
       continue-on-error: true
       uses: ./.github/actions/build-binary-packages

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -151,7 +151,6 @@ jobs:
         sparse-checkout: '.github/actions/'
 
     - name: Build
-      continue-on-error: true
       uses: ./.github/actions/build-binary-packages
       with:
         dist: ${{ matrix.dist }}
@@ -194,7 +193,7 @@ jobs:
     needs: [sourcepackage, binary_packages_released, binary_packages_unreleased]
     runs-on: ubuntu-latest
     environment: "deploy (linux)"
-    if: github.event.client_payload.isTestBuild == 'false'
+    if: ${{ github.event.client_payload.isTestBuild == 'false' && needs.sourcepackage.result == 'success' && needs.binary_packages_released.result == 'success' }}
 
     steps:
       - name: Sign packages
@@ -212,7 +211,7 @@ jobs:
     needs: [sourcepackage, deb_signing]
     runs-on: self-hosted
     environment: "deploy (linux)"
-    if: github.event.client_payload.isTestBuild == 'false'
+    if: ${{ github.event.client_payload.isTestBuild == 'false' && needs.sourcepackage.result == 'success' && needs.deb_signing.result == 'success' }}
 
     steps:
     - name: Install dput
@@ -295,6 +294,7 @@ jobs:
     name: Verify API for libkeymancore.so
     needs: [sourcepackage, binary_packages_released]
     runs-on: ubuntu-latest
+    if: ${{ needs.sourcepackage.result == 'success' && needs.binary_packages_released.result == 'success' }}
 
     steps:
     - name: Checkout


### PR DESCRIPTION
- Checkout source before building binary packages. This is necessary because we use an action that is defined in our source tree.
- Update checkout action to v4.1.1
- Ignore failed package builds for the next Ubuntu version in a different way. Previously failed package builds for the next Ubuntu release showed up with a green check mark. This change allows them to fail, but ignores the failure for the following steps.

@keymanapp-test-bot skip