### PR TITLE
chore(linux): Revert "Ignore failed package builds differently"

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -151,6 +151,7 @@ jobs:
         sparse-checkout: '.github/actions/'
 
     - name: Build
+      continue-on-error: true
       uses: ./.github/actions/build-binary-packages
       with:
         dist: ${{ matrix.dist }}
@@ -193,7 +194,7 @@ jobs:
     needs: [sourcepackage, binary_packages_released, binary_packages_unreleased]
     runs-on: ubuntu-latest
     environment: "deploy (linux)"
-    if: ${{ github.event.client_payload.isTestBuild == 'false' && needs.sourcepackage.result == 'success' && needs.binary_packages_released.result == 'success' }}
+    if: github.event.client_payload.isTestBuild == 'false'
 
     steps:
       - name: Sign packages
@@ -211,7 +212,7 @@ jobs:
     needs: [sourcepackage, deb_signing]
     runs-on: self-hosted
     environment: "deploy (linux)"
-    if: ${{ github.event.client_payload.isTestBuild == 'false' && needs.sourcepackage.result == 'success' && needs.deb_signing.result == 'success' }}
+    if: github.event.client_payload.isTestBuild == 'false'
 
     steps:
     - name: Install dput
@@ -294,7 +295,6 @@ jobs:
     name: Verify API for libkeymancore.so
     needs: [sourcepackage, binary_packages_released]
     runs-on: ubuntu-latest
-    if: ${{ needs.sourcepackage.result == 'success' && needs.binary_packages_released.result == 'success' }}
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This reverts commit 2fe4da7cca369558a5696f82bf618b42d4cd6f8d.

In my tests in a test repo `continue-on-error` worked as desired but also seeds the total result as succeeded if the other jobs succeed. It's possible that we got the behavior we saw because of syntax errors in our file, so this change tries with the original approach again.

@keymanapp-test-bot skip