### PR TITLE
chore(linux): Sign packages even if build for next Ubuntu fails

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -194,7 +194,7 @@ jobs:
     needs: [sourcepackage, binary_packages_released, binary_packages_unreleased]
     runs-on: ubuntu-latest
     environment: "deploy (linux)"
-    if: github.event.client_payload.isTestBuild == 'false'
+    if: ${{always() && needs.sourcepackage.result == 'success' && needs.binary_packages_released.result == 'success' && github.event.client_payload.isTestBuild == 'false'}}
 
     steps:
       - name: Sign packages


### PR DESCRIPTION
We want to run the `deb_signing` job after building binary packages for both released and unreleased Ubuntu versions finished, so we have to specify those in the `needs` field. But that on its own causes the signing job to be skipped if the binary package build for the next Ubuntu version fails. This change adds conditions so that the `deb_signing` job always runs if source package build and the binary package build for the released Ubuntu versions succeeds.

@keymanapp-test-bot skip