### PR TITLE
chore(linux): Show failed job for next Ubuntu version as failed

### DIFF
--- a/.github/actions/build-binary-packages/action.yml
+++ b/.github/actions/build-binary-packages/action.yml
@@ -31,7 +31,7 @@ runs:
         path: artifacts/keyman-srcpkg
 
     - name: Build
-      uses: sillsdev/gha-ubuntu-packaging@1f4b7e7eacb8c82a4d874ee2c371b9bfef7e16ea # v1.0
+      uses: sillsdev/gha-ubuntu-packaging@7b56f50d5d5537e9e9cafd3f6139ec6da69cfcda # v1.1
       with:
         dist: "${{ inputs.dist }}"
         platform: "${{ inputs.arch }}"

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -112,12 +112,12 @@ jobs:
   binary_packages_released:
     name: Build binary packages for released versions
     needs: sourcepackage
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         dist: [focal, jammy, mantic]
 
-    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
@@ -137,12 +137,13 @@ jobs:
   binary_packages_unreleased:
     name: Build binary packages for next Ubuntu version
     needs: sourcepackage
+    continue-on-error: true
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         dist: [noble]
 
-    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
@@ -151,7 +152,6 @@ jobs:
         sparse-checkout: '.github/actions/'
 
     - name: Build
-      continue-on-error: true
       uses: ./.github/actions/build-binary-packages
       with:
         dist: ${{ matrix.dist }}


### PR DESCRIPTION
This change shows failed package builds for the next Ubuntu version as failed. With the last change it still showed as green in the overview, despite my experiments. Turns out it depends where you put the `continue-on-error: true` statement: if it's in the `steps` section it'll show up green, if you put it in the job's metadata it'll work as expected and show up as failed.

@keymanapp-test-bot skip