### PR TITLE
fix(common): specify title explicitly when opening PR with hub

### DIFF
--- a/resources/build/ci/pull-requests.inc.sh
+++ b/resources/build/ci/pull-requests.inc.sh
@@ -107,7 +107,7 @@ function ci_open_pull_request {
   git push origin "$branch"
   builder_echo "Push complete"
 
-  hub pull-request -f --no-edit -l auto
+  hub pull-request --force --message "$commit_message" --labels auto
   builder_echo "Pull request created"
 
   git switch "$current_branch"


### PR DESCRIPTION
Fixes #11125 by working around the base issue.

Arising from discussion in #11125. It's unclear exactly what is causing this; the commit is the latest (only) on the branch according to the code:

https://github.com/keymanapp/keyman/blob/02812af97f6fdc312dd83bf0c8b529ed15f28229/resources/build/ci/pull-requests.inc.sh#L103-L107

From the [logs](https://build.palaso.org/buildConfiguration/Keymanweb_Build/452314?buildTab=log&focusLine=1033&logView=flowAware&linesState=1026), we can see that recent changes were pulled into master immediately before the branch and new commit:

```
...
03:45:22   From https://github.com/keymanapp/s.keyman.com
03:45:22    * branch              master     -> FETCH_HEAD
03:45:29   Updating 27a81d24..416d852a
03:45:29   Fast-forward
03:45:30    kmw/engine/18.0.13/keymanweb.es5.js               |    2 +
...
03:45:34   [web] Creating new branch 'auto/keymanweb/release/TC-17.0.298' on '..\..\s.keyman.com'
03:45:34   Switched to a new branch 'auto/keymanweb/release/TC-17.0.298'
03:45:34   [web] auto: KeymanWeb release 17.0.298
03:45:35   [auto/keymanweb/release/TC-17.0.298 f8cae3e8] auto: KeymanWeb release 17.0.298
03:45:35    31 files changed, 10576 insertions(+)
03:45:35    create mode 100644 kmw/engine/17.0.298/keymanweb.es5.js
...
```

But hub's [code](https://github.com/mislav/hub/blob/5c547ed804368763064e51f3990851e267e88edd/commands/pull_request.go#L266-L273) for pulling the latest commit's message seems pretty straightforward:

```go
  } else if args.Flag.Bool("--no-edit") {
    commits, _ := git.RefList(baseTracking, head)
    if len(commits) == 0 {
      utils.Check(fmt.Errorf("Aborted: no commits detected between %s and %s", baseTracking, head))
    }
    message, err := git.Show(commits[len(commits)-1])
    utils.Check(err)
    messageBuilder.Message = message
```

So not really sure why it is picking up the previous commit message at this point. 

@keymanapp-test-bot skip