### PR TITLE
refactor(web): OSK spacebar-label updates now managed by layer object 🪠

### DIFF
--- a/web/src/engine/osk/src/keyboard-layout/oskLayer.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskLayer.ts
@@ -84,12 +84,12 @@ export default class OSKLayer {
 
     if(this.spaceBarKey) {
       const spacebarLabel = this.spaceBarKey.label;
-      let tParent = <HTMLElement>spacebarLabel.parentNode;
+      let tButton = this.spaceBarKey.btn;
 
-      if (typeof (tParent.className) == 'undefined' || tParent.className == '') {
-        tParent.className = 'kmw-spacebar';
-      } else if (tParent.className.indexOf('kmw-spacebar') == -1) {
-        tParent.className += ' kmw-spacebar';
+      if (typeof (tButton.className) == 'undefined' || tButton.className == '') {
+        tButton.className = 'kmw-spacebar';
+      } else if (tButton.className.indexOf('kmw-spacebar') == -1) {
+        tButton.className += ' kmw-spacebar';
       }
 
       if (spacebarLabel.className != 'kmw-spacebar-caption') {

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -658,6 +658,7 @@ export default abstract class OSKView
       if(this.bannerView.height > 0) {
         availableHeight -= this.bannerView.height + 5;
       }
+      // Triggers the VisualKeyboard.refreshLayout() method, which includes a showLanguage() call.
       this.vkbd.setSize(this.computedWidth, availableHeight, pending);
 
       const bs = this._Box.style;
@@ -665,9 +666,6 @@ export default abstract class OSKView
       // visualizations, not to help text or empty views.
       bs.width  = bs.maxWidth  = this.computedWidth + 'px';
       bs.height = bs.maxHeight = this.computedHeight + 'px';
-
-      // Ensure that the layer's spacebar is properly captioned.
-      this.vkbd.showLanguage();
     } else {
       const bs = this._Box.style;
       bs.width  = 'auto';
@@ -855,9 +853,8 @@ export default abstract class OSKView
       // Also, only change the layer ID itself if there is an actual corresponding layer
       // in the OSK.
       if(this.vkbd?.layerGroup.layers[newValue] && !this.vkbd?.layerLocked) {
+        // triggers state-update + layer refresh automatically.
         this.vkbd.layerId = newValue;
-        // Ensure that the layer's spacebar is properly captioned.
-        this.vkbd.showLanguage();
       }
 
       // Ensure the keyboard view is modeling the correct state.  (Correct layer, etc.)
@@ -891,10 +888,6 @@ export default abstract class OSKView
 
     // First thing after it's made visible.
     this.refreshLayoutIfNeeded();
-
-    if(this.keyboardView instanceof VisualKeyboard) {
-      this.keyboardView.showLanguage();
-    }
 
     this._Visible=true;
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1116,38 +1116,6 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
   //#endregion
 
   /**
-   * Indicate the current language and keyboard on the space bar
-   **/
-  showLanguage() {
-    let activeStub = this.layoutKeyboardProperties;
-    let displayName: string = activeStub?.displayName ?? '(System keyboard)';
-
-    try {
-      var t = <HTMLElement>this.spaceBar.key.label;
-      let tParent = <HTMLElement>t.parentNode;
-      if (typeof (tParent.className) == 'undefined' || tParent.className == '') {
-        tParent.className = 'kmw-spacebar';
-      } else if (tParent.className.indexOf('kmw-spacebar') == -1) {
-        tParent.className += ' kmw-spacebar';
-      }
-
-      if (t.className != 'kmw-spacebar-caption') {
-        t.className = 'kmw-spacebar-caption';
-      }
-
-      // It sounds redundant, but this dramatically cuts down on browser DOM processing;
-      // but sometimes innerText is reported empty when it actually isn't, so set it
-      // anyway in that case (Safari, iOS 14.4)
-      if (t.innerText != displayName || displayName == '') {
-        t.innerText = displayName;
-      }
-
-      this.spaceBar.key.refreshLayout(this);
-    }
-    catch (ex) { }
-  }
-
-  /**
    *  Add or remove a class from a keyboard key (when touched or clicked)
    *  or add a key preview for phone devices
    *
@@ -1269,7 +1237,6 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     const isInDOM = computedStyle.height != '' && computedStyle.height != 'auto';
 
     // Step 2:  determine basic layout geometry, refresh things that might update.
-    this.showLanguage(); // In case the spacebar-text mode setting has changed.
 
     if (fixedSize) {
       this._computedWidth = this.width;
@@ -1307,7 +1274,10 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     // Step 4:  perform layout operations.
     // Needs the refreshed layout info to work correctly.
     if(this.currentLayer) {
-      this.currentLayer.refreshLayout(this, this._computedHeight - this.getVerticalLayerGroupPadding());
+      this.currentLayer.refreshLayout(this, {
+        keyboardHeight: this._computedHeight - this.getVerticalLayerGroupPadding(),
+        spacebarText: this.layoutKeyboardProperties?.displayName ?? '(System keyboard)'
+      });
     }
   }
 


### PR DESCRIPTION
To prepare to optimize layout-reflow for Web's OSK, it will help us to rework how spacebar-text and its styling are managed.  They'll be far easier to "batch" with other layout updates if managed by the layer containing the key, rather than set outside of the standard flow.

Also, we had a _lot_ of redundant calls to the `showLanguage()` function, which is what updated the spacebar.  We only need one.

This PR has been spun off of an older state of #11140.  Certain design decisions may make more sense with the whole picture in mind, though I have tried to recontextualize them to make better sense in isolation for this PR.

## User Testing

TEST_ANDROID_SPACEBAR:  Using Keyman for Android, verify that the spacebar is always appropriately captioned (based on user settings in the menu) for the active keyboard, with the text properly sized.

- If not already installed, download and test using `balochi_phonetic` - it has very high font scaling that will help stress-test part of spacebar-display management.
    - If the text overflows the spacebar at any point, overrunning its boundaries, FAIL this test.
- Test with a few other keyboards as well.
- Be sure to swap the device orientation back and forth a few times - from portrait to landscape and back again.
- Be sure to swap layers and verify that the spacebar for each is always labeled appropriately.