### PR TITLE
fix(web): fix crash in nearest-key row lookup when touch moves out-of-bounds

### DIFF
--- a/web/src/engine/osk/src/keyboard-layout/oskLayerGroup.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskLayerGroup.ts
@@ -198,7 +198,7 @@ export default class OSKLayerGroup {
       Assumes there is no fine-tuning of the row ranges to be done - each takes a perfect
       fraction of the overall layer height without any padding above or below.
     */
-    const rowIndex = Math.floor(proportionalCoords.y * layer.rows.length);
+    const rowIndex = Math.max(0, Math.min(layer.rows.length-1, Math.floor(proportionalCoords.y * layer.rows.length)));
     const row = layer.rows[rowIndex];
 
     // Assertion:  row no longer `null`.


### PR DESCRIPTION
Fixes #11165.

A simple logic error - forgetting to validate index bounds - resulted in an error during input of certain gestures.

## User Testing

TEST_FLICKS: Verify that flicks work without triggering error messages.

1. Install and open Keyman for Android on a test device.
2. Press and drag a key straight downward direction then release the key to print the special characters. 
3. Repeat step 3 several times. 
4. Press and drag a key straight upward as if it supported a flick.  Drag your finger past the banner.
5. Repeat step 4 several times.