### PR TITLE
fix(android): atomically updates selection with text

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -130,7 +130,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   @Override
   public void onUpdateSelection(int oldSelStart, int oldSelEnd, int newSelStart, int newSelEnd, int candidatesStart, int candidatesEnd) {
     super.onUpdateSelection(oldSelStart, oldSelEnd, newSelStart, newSelEnd, candidatesStart, candidatesEnd);
-    KMManager.updateSelectionRange(KMManager.KeyboardType.KEYBOARD_TYPE_SYSTEM, newSelStart, newSelEnd);
+    KMManager.updateSelectionRange(KMManager.KeyboardType.KEYBOARD_TYPE_SYSTEM);
   }
 
   /**
@@ -170,9 +170,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
       ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
       if (icText != null) {
         boolean didUpdateText = KMManager.updateText(KeyboardType.KEYBOARD_TYPE_SYSTEM, icText.text.toString());
-        int selStart = icText.startOffset + icText.selectionStart;
-        int selEnd = icText.startOffset + icText.selectionEnd;
-        boolean didUpdateSelection = KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_SYSTEM, selStart, selEnd);
+        boolean didUpdateSelection = KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_SYSTEM);
         if (!didUpdateText || !didUpdateSelection)
           exText = icText;
       }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -197,8 +197,6 @@ final class KMKeyboard extends WebView {
        */
 
       // Count the number of characters which are surrogate pairs.
-      int stringLen = rawText.length();
-
       int pairsAtStart = CharSequenceUtil.countSurrogatePairs(rawText.substring(0, selStart), rawText.length());
       String selectedText = rawText.substring(selStart, selEnd);
       int pairsSelected = CharSequenceUtil.countSurrogatePairs(selectedText, selectedText.length());

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -163,7 +163,7 @@ final class KMKeyboard extends WebView {
     return result;
   }
 
-  protected boolean updateSelectionRange(int selStart, int selEnd) {
+  protected boolean updateSelectionRange() {
     boolean result = false;
     InputConnection ic = KMManager.getInputConnection(this.keyboardType);
     if (ic != null) {
@@ -174,6 +174,17 @@ final class KMKeyboard extends WebView {
 
       String rawText = icText.text.toString();
       updateText(rawText.toString());
+
+      // To determine:  may need `icText.startOffset +`?
+      int selStart = icText.selectionStart;
+      int selEnd = icText.selectionEnd;
+
+      int selMin = selStart, selMax = selEnd;
+      if (selStart > selEnd) {
+        // Selection is reversed so "swap"
+        selMin = selEnd;
+        selMax = selStart;
+      }
 
       /*
         The values of selStart & selEnd provided by the system are in code units,
@@ -187,14 +198,16 @@ final class KMKeyboard extends WebView {
        */
 
       // Count the number of characters which are surrogate pairs.
+      int stringLen = rawText.length();
+
       int pairsAtStart = CharSequenceUtil.countSurrogatePairs(rawText.substring(0, selStart), rawText.length());
       String selectedText = rawText.substring(selStart, selEnd);
       int pairsSelected = CharSequenceUtil.countSurrogatePairs(selectedText, selectedText.length());
 
       selStart -= pairsAtStart;
       selEnd -= (pairsAtStart + pairsSelected);
+      this.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
     }
-    this.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
     result = true;
 
     return result;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -175,7 +175,6 @@ final class KMKeyboard extends WebView {
       String rawText = icText.text.toString();
       updateText(rawText.toString());
 
-      // To determine:  may need `icText.startOffset +`?
       int selStart = icText.selectionStart;
       int selEnd = icText.selectionEnd;
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2137,6 +2137,28 @@ public final class KMManager {
     return result;
   }
 
+  /**
+   * Updates the active range for selected text.
+   * @deprecated
+   * This method no longer needs the `selStart` and `selEnd` parameters.
+   * <p>Use {@link KMManager#updateSelectionRange(KeyboardType)} instead.</p>
+   *
+   * @param kbType    A value indicating if this request is for the in-app keyboard or the system keyboard
+   * @param selStart  (deprecated) the start index for the range
+   * @param selEnd  (deprecated) the end index for the selected range
+   * @return
+   */
+  @Deprecated
+  public static boolean updateSelectionRange(KeyboardType kbType, int selStart, int selEnd) {
+    return updateSelectionRange(kbType);
+  }
+
+  /**
+   * Performs a synchronization check for the active range for selected text,
+   * ensuring it matches the text-editor's current state.
+   * @param kbType  A value indicating if this request is for the in-app or system keyboard.
+   * @return
+   */
   public static boolean updateSelectionRange(KeyboardType kbType) {
     boolean result = false;
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2137,23 +2137,18 @@ public final class KMManager {
     return result;
   }
 
-  public static boolean updateSelectionRange(KeyboardType kbType, int selStart, int selEnd) {
+  public static boolean updateSelectionRange(KeyboardType kbType) {
     boolean result = false;
-    int selMin = selStart, selMax = selEnd;
-    if (selStart > selEnd) {
-      // Selection is reversed so "swap"
-      selMin = selEnd;
-      selMax = selStart;
-    }
+
     if (kbType == KeyboardType.KEYBOARD_TYPE_INAPP) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP) && !InAppKeyboard.shouldIgnoreSelectionChange()) {
-        result = InAppKeyboard.updateSelectionRange(selMin, selMax);
+        result = InAppKeyboard.updateSelectionRange();
       }
 
       InAppKeyboard.setShouldIgnoreSelectionChange(false);
     } else if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM) && !SystemKeyboard.shouldIgnoreSelectionChange()) {
-        result = SystemKeyboard.updateSelectionRange(selMin, selMax);
+        result = SystemKeyboard.updateSelectionRange();
       }
 
       SystemKeyboard.setShouldIgnoreSelectionChange(false);

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMTextView.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMTextView.java
@@ -63,10 +63,8 @@ public final class KMTextView extends AppCompatEditText {
    */
   public static void updateTextContext() {
     KMTextView textView = (KMTextView) activeView;
-    int selStart = textView.getSelectionStart();
-    int selEnd = textView.getSelectionEnd();
     KMManager.updateText(KeyboardType.KEYBOARD_TYPE_INAPP, textView.getText().toString());
-    if (KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd)) {
+    if (KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_INAPP)) {
       KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_INAPP);
     }
   }
@@ -167,7 +165,7 @@ public final class KMTextView extends AppCompatEditText {
   protected void onSelectionChanged(int selStart, int selEnd) {
     super.onSelectionChanged(selStart, selEnd);
     if (activeView != null && activeView.equals(this)) {
-      if (KMManager.updateSelectionRange(KMManager.KeyboardType.KEYBOARD_TYPE_INAPP, selStart, selEnd)) {
+      if (KMManager.updateSelectionRange(KMManager.KeyboardType.KEYBOARD_TYPE_INAPP)) {
         KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_INAPP);
       }
     }


### PR DESCRIPTION
Fixes #11160.
Supersedes #11162.

This PR prevents an error that could randomly occur during quickly-repeated text modifications that could trigger a keyboard crash in the case of repeated backspaces.

Technical details:  we had an invalid assumption that a method signalling text-selection updates and the "source of truth" for app text state were synchronous.  This was untrue, allowing an extra backspace to edit app text state while processing a previous edit's effects.  By relying on a single "source of truth", we can avoid the lack of synchronization between the two.

## User Testing

**Setup** - Install the PR build of Keyman for Android. From the Keyman app, also install basic_kbdosm (Osmonya) keyboard which outputs SMP characters.
Set Keyman as the default system keyboard

* **TEST_REVERSE** - Verifies no crash when selection is reversed (test from #11127)
1. Launch Keyman for Android
2. From "Get Started", install the Keyman keyboard basic_kbdosm (Osmanya which uses SMP characters)
3. Set Keyman as the default system keyboard
4. Launch a separate messaging app (where you can type text).
5. Use Keyman to type a mix of English (sil_eurolatin) and Osmanya (basic_kbdosm) characters.
6. In Keyman,select the basic_kbdosm keyboard
7. Double-tap to select a word in the text area (that contains a mix of English and Osmanya characters). This is the normal direction of selecting text
8. With the Keyman keyboard, press a character
9. Verify the word is replaced with the Osmanya character
10. Double-tap to select a word in the text area.
11. With the word selected, attempt to drag the end to "before" the start so the selection is "reversed"
12 Verify no crash in the Keyboard
13. With the Keyman keyboard, press a character
14. Verify the word is replaced with the Osmanya character

* **TEST_HELD_BACKSPACE** - Verifies no crash when backspace key is held down
1. Launch a separate messaging app (where you can type text)
2.  Use Keyman to type a mix of English (sil_eurolatin) and Osmanya (basic_kbdosm) characters. Type for several lines of text
3. Hold down the backspace key
4. Verify no crash in keyboard is content is deleted
