### PR TITLE
fix(web): fixes key-cap font scaling when very small text is required

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -229,7 +229,7 @@ final class KMKeyboard extends WebView {
 
     getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
     getSettings().setSupportZoom(false);
-
+    getSettings().setMinimumFontSize(4);
     getSettings().setUseWideViewPort(true);
     getSettings().setLoadWithOverviewMode(true);
     if (0 != (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {

--- a/web/src/engine/osk/src/keyboard-layout/oskKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskKey.ts
@@ -231,10 +231,16 @@ export default abstract class OSKKey {
       proportion = yProportion;
     }
 
-    // Never upscale keys past the default * the specified scale - only downscale them.
-    // Proportion < 1:  ratio of key width to (padded [loosely speaking]) text width
-    //                  maxProportion determines the 'padding' involved.
-    return ParsedLengthStyle.forScalar(scale * Math.min(proportion, 1));
+    /*
+      Never upscale keys past the default - only downscale them.  Proportion <
+      1:  ratio of key width to (padded [loosely speaking]) text width
+      maxProportion determines the 'padding' involved.
+
+      Due to behaviors noted with #11203, we use fixed-size scaling based on the
+      relative font-size specifications; this forces font-size scaling even when
+      the resulting text becomes smaller than WebView-default thresholds.
+    */
+    return originalSize.scaledBy(Math.min(proportion, 1));
   }
 
   public get keyText(): string {


### PR DESCRIPTION
Fixes #11203.

It turns out that mobile-device browsers like to apply a minimum to font-size specs based on relative-style font scaling.  Chrome will also threshold fixed-size font scaling within WebViews unless told otherwise.  This tends to make larger key caps scale improperly on the keyboard, so to get a clean render, the easiest way forward on our end is to use font-size specs that the mobile WebViews will actually listen to.

## User Testing

- **TEST_IPHONE_APP**:  Using Keyman within the Keyman app on a narrow iOS phone, verify that the default display-name for Khmer Angkor does not overrun the spacebar's area.
    - If other keys' text size seems unusual compared to normal, FAIL this test.  They should be the same size as usual.

- **TEST_ANDROID_APP**:  Using Keyman within the Keyman app on a narrow Android phone, verify that the default display-name for Khmer Angkor does not overrun the spacebar's area.
    - If other keys' text size seems unusual compared to normal, FAIL this test.  They should be the same size as usual.

- **TEST_IPHONE_STANDALONE**:  Using KeymanWeb via the "Test page for automatic key-cap scaling" on a narrow iOS phone, verify that each key's text is properly scaled, not overrunning its key's boundaries.
    - The two keys between `g` and `l` have the following key-cap text: `ሴሴሴሴሴ`

- **TEST_ANDROID_STANDALONE**:  Using KeymanWeb via the "Test page for automatic key-cap scaling" on a narrow Android phone, verify that each key's text is properly scaled, not overrunning its key's boundaries.
    - The two keys between `g` and `l` have the following key-cap text: `ሴሴሴሴሴ`