### PR TITLE
fix(web): now auto-scrolls if target element would be hidden after device rotation

### DIFF
--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -73,27 +73,31 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
       const e = target?.getElement();
       (this.osk.activationModel as TwoStateActivator<HTMLElement>).activationTrigger = e;
 
-      if(this.config.hostDevice.touchable) {
-        if(!e || !target || !this.osk) {
-          return;
-        }
-
-        // Get the absolute position of the caret
-        const y = getAbsoluteY(e);
-        const t = window.pageYOffset;
-        let dy = y-t;
-        if(y >= t) {
-          dy -= (window.innerHeight - this.osk._Box.offsetHeight - e.offsetHeight - 2);
-          if(dy < 0) {
-            dy=0;
-          }
-        }
-        // Hide OSK, then scroll, then re-anchor OSK with absolute position (on end of scroll event)
-        if(dy != 0) {
-          window.scrollTo(0, dy + t);
-        }
+      if(this.config.hostDevice.touchable && target) {
+        this.ensureElementVisibility(e);
       }
     });
+  }
+
+  public ensureElementVisibility(e: HTMLElement) {
+    if(!e || !this.osk) {
+      return;
+    }
+
+    // Get the absolute position of the caret
+    const y = getAbsoluteY(e);
+    const t = window.pageYOffset;
+    let dy = y-t;
+    if(y >= t) {
+      dy -= (window.innerHeight - this.osk._Box.offsetHeight - e.offsetHeight - 2);
+      if(dy < 0) {
+        dy=0;
+      }
+    }
+    // Hide OSK, then scroll, then re-anchor OSK with absolute position (on end of scroll event)
+    if(dy != 0) {
+      window.scrollTo(0, dy + t);
+    }
   }
 
   public get util() {

--- a/web/src/app/browser/src/utils/rotationProcessor.ts
+++ b/web/src/app/browser/src/utils/rotationProcessor.ts
@@ -58,6 +58,15 @@ export class RotationProcessor {
       window.clearInterval(this.updateTimer);
       this.rotState = null;
     }
+
+    const target = this.keyman.contextManager.activeTarget;
+    if(target) {
+      // This seems to help with scrolling accuracy in iOS Safari;
+      // the scroll tends to consistently go too far without it.
+      window.setTimeout(() => {
+        this.keyman.ensureElementVisibility(target.getElement());
+      }, 0);
+    }
   }
 
   // Used by both Android and iOS.


### PR DESCRIPTION
Fixes #10139.

## User Testing

TEST_IOS_ROTATION:  Using KeymanWeb on a narrow iOS device, attempt to repro #10139.
- Note:  in my personal experiments, the _first_ device-rotation may scroll too far, with things becoming much more precise on future rotations.  It's not clear why.

TEST_ANDROID_ROTATION:  Using KeymanWeb on a narrow Android device, attempt to repro #10139.