### PR TITLE
chore(developer): use keyboard3 tag rather than DTD to identify LDML keyboard xml files

### DIFF
--- a/common/web/types/src/kpj/keyman-developer-project.ts
+++ b/common/web/types/src/kpj/keyman-developer-project.ts
@@ -40,7 +40,7 @@ export class KeymanDeveloperProject {
         try {
           const data = this.callbacks.loadFile(fullPath);
           const text = new TextDecoder().decode(data);
-          if(!text?.match(/ldmlKeyboard3\.dtd/)) {
+          if(!text?.match(/<keyboard3/)) {
             // Skip this .xml because we assume it isn't really a keyboard .xml
             continue;
           }


### PR DESCRIPTION
Relates to #10469. Apply same test in kmc that we are using in TIKE.

@keymanapp-test-bot skip