### PR TITLE
chore(android): enables debugging and inspection of mobile app internal webviews

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -232,11 +232,11 @@ final class KMKeyboard extends WebView {
 
     getSettings().setUseWideViewPort(true);
     getSettings().setLoadWithOverviewMode(true);
-    if (0 != (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {
+    // if (0 != (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {
       // Enable debugging of WebView via adb. Not used during unit tests
       // Refer: https://developer.chrome.com/docs/devtools/remote-debugging/webviews/#configure_webviews_for_debugging
       setWebContentsDebuggingEnabled(true);
-    }
+    // }
     setWebChromeClient(new WebChromeClient() {
       public boolean onConsoleMessage(ConsoleMessage cm) {
         String msg = KMString.format("KMW JS Log: Line %d, %s:%s", cm.lineNumber(), cm.sourceId(), cm.message());

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -236,8 +236,8 @@ final class KMKeyboard extends WebView {
     // When `.isTestMode() == true`, the setWebContentsDebuggingEnabled method is not available
     // and thus will trigger unit-test failures.
     if (!KMManager.isTestMode() && (
-      0 != (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)
-      || KMManager.getTier(null) != KMManager.Tier.STABLE
+      (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0 || 
+      KMManager.getTier(null) != KMManager.Tier.STABLE
     )) {
       // Enable debugging of WebView via adb. Not used during unit tests
       // Refer: https://developer.chrome.com/docs/devtools/remote-debugging/webviews/#configure_webviews_for_debugging

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -232,11 +232,17 @@ final class KMKeyboard extends WebView {
 
     getSettings().setUseWideViewPort(true);
     getSettings().setLoadWithOverviewMode(true);
-    // if (0 != (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {
+
+    // When `.isTestMode() == true`, the setWebContentsDebuggingEnabled method is not available
+    // and thus will trigger unit-test failures.
+    if (!KMManager.isTestMode() && (
+      0 != (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)
+      || KMManager.getTier(null) != KMManager.Tier.STABLE
+    )) {
       // Enable debugging of WebView via adb. Not used during unit tests
       // Refer: https://developer.chrome.com/docs/devtools/remote-debugging/webviews/#configure_webviews_for_debugging
       setWebContentsDebuggingEnabled(true);
-    // }
+    }
     setWebChromeClient(new WebChromeClient() {
       public boolean onConsoleMessage(ConsoleMessage cm) {
         String msg = KMString.format("KMW JS Log: Line %d, %s:%s", cm.lineNumber(), cm.sourceId(), cm.message());


### PR DESCRIPTION
This PR exists to facilitate diagnosis of #11186 when it occurs.

@keymanapp-test-bot skip