### PR TITLE
fix(web): fixes up-flick shortcut issue for longpress when keys support downflicks

### DIFF
--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -632,7 +632,8 @@ export function specialKeyEndModel(params: GestureParams): GestureModel<any> {
 export function longpressModel(params: GestureParams, allowShortcut: boolean, allowRoaming: boolean): GestureModel<any> {
   const base: GestureModel<any> = {
     id: 'longpress',
-    resolutionPriority: 0,
+    // Needs to beat flick-start priority.
+    resolutionPriority: 4,
     contacts: [
       {
         model: {

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1280,8 +1280,13 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       const paddingZone = this.gestureEngine.config.maxRoamingBounds as PaddedZoneSource;
       paddingZone.updatePadding([-0.333 * this.currentLayer.rowHeight]);
 
+      /*
+        Note:  longpress.flickDist needs to be no greater than flick.startDist.
+        Otherwise, the longpress up-flick shortcut will not work on keys that
+        support flick gestures.  (Such as sil_euro_latin 3.0+)
+      */
       this.gestureParams.longpress.flickDist = 0.25 * this.currentLayer.rowHeight;
-      this.gestureParams.flick.startDist     = 0.15 * this.currentLayer.rowHeight;
+      this.gestureParams.flick.startDist     = 0.25 * this.currentLayer.rowHeight;
       this.gestureParams.flick.dirLockDist   = 0.35 * this.currentLayer.rowHeight;
       this.gestureParams.flick.triggerDist   = 0.75 * this.currentLayer.rowHeight;
     }


### PR DESCRIPTION
I happened to notice this one yesterday while using `sil_euro_latin` - our up-flick shortcut for quick longpresses wasn't working.

Rather than make things convoluted with special-case handling this close to release, I figured the simplest way forward is to simply parameterize longpresses and flicks in a way that allows the longpress-flick to win when a key supports both.  The old parameterization locked in the start of a full-fledged flick gesture before the longpress up-flick shortcut had a chance to trigger.

## User Testing

TEST_LONGPRESSES_AND_FLICKS:  Using the `sil_euro_latin` keyboard, verify the following:
- A simple longpress on a key.
- Holding a key, then moving upward quickly causes the subkey menu to display early.
- Holding a key, then moving downward quickly triggers the key's flick.