### PR TITLE
chore(linux): Fix wrong merge

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -151,16 +151,6 @@ jobs:
         ref: '${{ github.event.client_payload.buildSha }}'
         sparse-checkout: '.github/actions/'
 
-  binary_packages_unreleased:
-    name: Build binary packages for next Ubuntu version
-    needs: sourcepackage
-    strategy:
-      fail-fast: true
-      matrix:
-        dist: [noble]
-
-    runs-on: ubuntu-latest
-    steps:
     - name: Build
       uses: ./.github/actions/build-binary-packages
       with:


### PR DESCRIPTION
The recent merge from `beta` into `master` introduced a problem when resolving merge conflicts, resulting in duplicate definition of `binary_packages_unreleased` which prevents the workflow from loading. This change rectifies the file.

@keymanapp-test-bot skip