### PR TITLE
fix(web): prevents selection-clear for pure layer-switching multitaps

### DIFF
--- a/common/web/input-processor/src/text/inputProcessor.ts
+++ b/common/web/input-processor/src/text/inputProcessor.ts
@@ -107,8 +107,20 @@ export default class InputProcessor {
       if(keyEvent.baseTranscriptionToken) {
         const transcription = this.contextCache.get(keyEvent.baseTranscriptionToken);
         if(transcription) {
-          // Restores full context, including deadkeys in their exact pre-keystroke state.
-          outputTarget.restoreTo(transcription.preInput);
+          // Has there been a context change at any point during the multitap?  If so, we need
+          // to revert it.  If not, we assume it's a layer-change multitap, in which case
+          // no such reset is needed.
+          if(!isEmptyTransform(transcription.transform) || !transcription.preInput.isEqual(Mock.from(outputTarget))) {
+            // Restores full context, including deadkeys in their exact pre-keystroke state.
+            outputTarget.restoreTo(transcription.preInput);
+          }
+          /*
+            else:
+            1. We don't need to restore the original context, as it's already
+               in-place.
+            2. Restoring anyway would obliterate any selected text, which is bad
+               if this is a purely-layer-switching multitap.  (#11230)
+          */
         } else {
           console.warn('The base context for the multitap could not be found');
         }

--- a/common/web/keyboard-processor/src/text/deadkeys.ts
+++ b/common/web/keyboard-processor/src/text/deadkeys.ts
@@ -38,6 +38,10 @@ export class Deadkey {
     return dk;
   }
 
+  equal(other: Deadkey) {
+    return this.d == other.d && this.p == other.d && this.o == other.o;
+  }
+
   /**
    * Sorts the deadkeys in reverse order.
    */
@@ -149,6 +153,24 @@ export class DeadkeyTracker {
         dk.p += Ldelta;
       }
     }
+  }
+
+  equal(other: DeadkeyTracker) {
+    if(this.dks.length != other.dks.length) {
+      return false;
+    }
+
+    const otherDks = other.dks;
+    const matchedDks: Deadkey[] = [];
+
+    for(let dk of this.dks) {
+      const match = otherDks.find((otherDk) => dk.equal(otherDk));
+      if(!match) {
+        return false;
+      }
+    }
+
+    return matchedDks.length == otherDks.length;
   }
 
   count(): number {

--- a/common/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/web/keyboard-processor/src/text/outputTarget.ts
@@ -448,13 +448,14 @@ export class Mock extends OutputTarget {
 
   /**
    * Indicates if this Mock represents an identical context to that of another Mock.
-   *
-   * Does not currently validate a match for deadkeys.
    * @param other
    * @returns
    */
   isEqual(other: Mock) {
-    return this.text == other.text && this.selStart == other.selStart && this.selEnd == other.selEnd;
+    return this.text == other.text
+      && this.selStart == other.selStart
+      && this.selEnd == other.selEnd
+      && this.deadkeys().equal(other.deadkeys());
   }
 
   doInputEvent() {

--- a/common/web/keyboard-processor/src/text/outputTarget.ts
+++ b/common/web/keyboard-processor/src/text/outputTarget.ts
@@ -446,6 +446,17 @@ export class Mock extends OutputTarget {
     this.text = this.getTextBeforeCaret() + s;
   }
 
+  /**
+   * Indicates if this Mock represents an identical context to that of another Mock.
+   *
+   * Does not currently validate a match for deadkeys.
+   * @param other
+   * @returns
+   */
+  isEqual(other: Mock) {
+    return this.text == other.text && this.selStart == other.selStart && this.selEnd == other.selEnd;
+  }
+
   doInputEvent() {
     // Mock isn't backed by an element, so it won't have any event listeners.
   }


### PR DESCRIPTION
Fixes #11230.

Previously, we _always_ cleared the selection as part of resetting the context-state for multitaps.  Problem is... that has unwanted cross-effects if the _only_ thing the multitap is doing is to layer-switch.

It's possible to shorten the changes with a "naive" fix, but naive solutions don't account for potential deadkey solutions very well.  I figure it's best to nip all such issues in the bud now, especially since I don't think there are related preventative warnings and/or errors for keyboard developers in Developer.

## User Testing

Any Web-based touch-platform will suffice for these tests.

**TEST_CAPS_WITH_SELECTION**:  Verify that selected text is not erased when double-tapping SHIFT to enter a keyboard's caps-lock state.  (A direct repro attempt for #11230.)

**TEST_MULTITAP_ROTA**: Using a keyboard with multitap keys that output text, verify that the output text is properly replaced on each tap.
- `ye_old_ten_key` and `diacritic_rota` from https://jahorton.github.io/ should work.