### PR TITLE
fix(web): default parse of length styling for empty string

### DIFF
--- a/web/src/engine/osk/src/lengthStyle.ts
+++ b/web/src/engine/osk/src/lengthStyle.ts
@@ -61,12 +61,15 @@ export class ParsedLengthStyle implements LengthStyle {
   }
 
   private static parseLengthStyle(spec: string): LengthStyle {
+    if(spec == '') {
+      return { val: 1, absolute: false };
+    }
+
     const val = parseFloat(spec);
 
     if(isNaN(val)) {
       // Cannot parse.
       console.error("Could not properly parse specified length style info: '" + spec + "'.");
-      return { val: 1, absolute: false };
     }
 
     return spec.indexOf('px') != -1 ? {val: val, absolute: true} :

--- a/web/src/engine/osk/src/lengthStyle.ts
+++ b/web/src/engine/osk/src/lengthStyle.ts
@@ -62,7 +62,7 @@ export class ParsedLengthStyle implements LengthStyle {
 
   private static parseLengthStyle(spec: string): LengthStyle {
     if(spec == '') {
-      return { val: 1, absolute: false };
+      return CONSTANT_STYLE;
     }
 
     const val = parseFloat(spec);
@@ -70,6 +70,7 @@ export class ParsedLengthStyle implements LengthStyle {
     if(isNaN(val)) {
       // Cannot parse.
       console.error("Could not properly parse specified length style info: '" + spec + "'.");
+      return CONSTANT_STYLE;
     }
 
     return spec.indexOf('px') != -1 ? {val: val, absolute: true} :
@@ -86,3 +87,5 @@ export class ParsedLengthStyle implements LengthStyle {
       {val: (4 * val / 3), absolute: true};
   }
 }
+
+const CONSTANT_STYLE = new ParsedLengthStyle('1em');

--- a/web/src/engine/osk/src/lengthStyle.ts
+++ b/web/src/engine/osk/src/lengthStyle.ts
@@ -66,7 +66,7 @@ export class ParsedLengthStyle implements LengthStyle {
     if(isNaN(val)) {
       // Cannot parse.
       console.error("Could not properly parse specified length style info: '" + spec + "'.");
-      return null;
+      return { val: 1, absolute: false };
     }
 
     return spec.indexOf('px') != -1 ? {val: val, absolute: true} :

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1302,7 +1302,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       widthStyle: this.layoutWidth,
       heightStyle: this.internalHeight,
       baseEmFontSize: this.getKeyEmFontSize(),
-      layoutFontSize: new ParsedLengthStyle(this.layerGroup.element.style.fontSize),
+      layoutFontSize: new ParsedLengthStyle(this.layerGroup.element.style.fontSize || '1em'),
       spacebarText: this.layoutKeyboardProperties?.displayName ?? '(System keyboard)'
     };
   }

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1302,7 +1302,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       widthStyle: this.layoutWidth,
       heightStyle: this.internalHeight,
       baseEmFontSize: this.getKeyEmFontSize(),
-      layoutFontSize: new ParsedLengthStyle(this.layerGroup.element.style.fontSize || '1em'),
+      layoutFontSize: new ParsedLengthStyle(this.layerGroup.element.style.fontSize),
       spacebarText: this.layoutKeyboardProperties?.displayName ?? '(System keyboard)'
     };
   }

--- a/web/src/test/auto/headless/engine/osk/lengthStyles.js
+++ b/web/src/test/auto/headless/engine/osk/lengthStyles.js
@@ -4,6 +4,12 @@ import sinon from 'sinon';
 import { ParsedLengthStyle } from 'keyman/engine/osk';
 
 describe('Length style processing', () => {
+  it("constructs from empty-string", () => {
+    let length = new ParsedLengthStyle('');
+    assert.equal(length.val, 1);
+    assert.equal(length.absolute, false);
+  })
+
   it("constructs from 'px' styling", () => {
     let length = new ParsedLengthStyle("20px");
 

--- a/web/src/test/auto/headless/engine/osk/lengthStyles.js
+++ b/web/src/test/auto/headless/engine/osk/lengthStyles.js
@@ -8,6 +8,12 @@ describe('Length style processing', () => {
     let length = new ParsedLengthStyle('');
     assert.equal(length.val, 1);
     assert.equal(length.absolute, false);
+  });
+
+  it("constructs from garbage", () => {
+    let length = new ParsedLengthStyle('garbage');
+    assert.equal(length.val, 1);
+    assert.equal(length.absolute, false);
   })
 
   it("constructs from 'px' styling", () => {


### PR DESCRIPTION
Fixes #11234.

@keymanapp-test-bot skip