### PR TITLE
change(web): drops need for closures to optimize layout-reflow 🪠

### DIFF
--- a/web/src/engine/osk/src/keyboard-layout/oskBaseKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskBaseKey.ts
@@ -197,22 +197,15 @@ export default class OSKBaseKey extends OSKKey {
   }
 
   public refreshLayout(layoutParams: KeyLayoutParams) {
-    const keyTextClosure = super.refreshLayout(layoutParams);  // key labels in particular.
+    super.refreshLayout(layoutParams);  // key labels in particular.
 
-    return () => {
-      // part 2:  key internals - these do depend on recalculating internal layout.
-
-      // Ideally, the rest would be in yet another calculation layer... need to figure out a good design for this.
-      keyTextClosure?.(); // we're already in that phase, so go ahead and run it.
-
-      const emFont = layoutParams.baseEmFontSize;
-      // Rescale keycap labels on small phones
-      if(emFont.val < 12) {
-        this.capLabel.style.fontSize = '6px';
-      } else {
-        // The default value set within kmwosk.css.
-        this.capLabel.style.fontSize = ParsedLengthStyle.forScalar(0.5).styleString;
-      }
+    const emFont = layoutParams.baseEmFontSize;
+    // Rescale keycap labels on small phones
+    if(emFont.val < 12) {
+      this.capLabel.style.fontSize = '6px';
+    } else {
+      // The default value set within kmwosk.css.
+      this.capLabel.style.fontSize = ParsedLengthStyle.forScalar(0.5).styleString;
     }
   }
 

--- a/web/src/engine/osk/src/keyboard-layout/oskKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskKey.ts
@@ -311,7 +311,14 @@ export default abstract class OSKKey {
     this.label.style.fontSize = '';
   }
 
-  public refreshLayout(layoutParams: KeyLayoutParams) {
+  /**
+   * Any style-caching behavior needed for use in layout manipulation should be
+   * computed within this method, not within refreshLayout.  This is to prevent
+   * unnecessary layout-reflow.
+   * @param layoutParams
+   * @returns
+   */
+  public detectStyles(layoutParams: KeyLayoutParams) {
     // Avoid doing any font-size related calculations if there's no text to display.
     if(this.spec.sp == ButtonClasses.spacer || this.spec.sp == ButtonClasses.blank) {
       return null;
@@ -341,26 +348,26 @@ export default abstract class OSKKey {
         this._fontSize = ParsedLengthStyle.forScalar(localFontScaling);
       }
     }
+  }
 
+  // Avoid any references to getComputedStyle, offset_, or other layout-reflow
+  // dependent values.  Refer to https://gist.github.com/paulirish/5d52fb081b3570c81e3a.
+  public refreshLayout(layoutParams: KeyLayoutParams) {
     // space bar may not define the text span!
     if(this.label) {
       if(!this.label.classList.contains('kmw-spacebar-caption')) {
         // Do not use `this.keyText` - it holds *___* codes for special keys, not the actual glyph!
         const keyCapText = this.label.textContent;
         const fontSize = this.getIdealFontSize(keyCapText, layoutParams);
-        return () => {
-          this.label.style.fontSize = fontSize.styleString;
-        };
+        this.label.style.fontSize = fontSize.styleString;
       } else {
         // Spacebar text, on the other hand, is available via this.keyText.
         // Using this field helps prevent layout reflow during updates.
         const fontSize = this.getIdealFontSize(this.keyText, layoutParams);
 
-        return () => {
-          // Since the kmw-spacebar-caption version uses !important, we must specify
-          // it directly on the element too; otherwise, scaling gets ignored.
-          this.label.style.setProperty("font-size", fontSize.styleString, "important");
-        };
+        // Since the kmw-spacebar-caption version uses !important, we must specify
+        // it directly on the element too; otherwise, scaling gets ignored.
+        this.label.style.setProperty("font-size", fontSize.styleString, "important");
       }
     }
   }

--- a/web/src/engine/osk/src/keyboard-layout/oskLayer.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskLayer.ts
@@ -126,29 +126,35 @@ export default class OSKLayer {
    **/
   showLanguage(displayName: string) {
     if(!this.spaceBarKey) {
-      return () => {};
+      return;
     }
 
     try {
       const spacebarLabel = this.spaceBarKey.label;
 
-      // The key can read the text from here during the display update without us
-      // needing to trigger a reflow by running the closure below early.
+      // The key can read the text from here during the display update without
+      // triggering a reflow.
       this.spaceBarKey.spec.text = displayName;
 
-      return () => {
-        // It sounds redundant, but this dramatically cuts down on browser DOM processing;
-        // but sometimes innerText is reported empty when it actually isn't, so set it
-        // anyway in that case (Safari, iOS 14.4)
-        if (spacebarLabel.innerText != displayName || displayName == '') {
-          spacebarLabel.innerText = displayName;
-        }
+      // It sounds redundant, but this dramatically cuts down on browser DOM processing;
+      // but sometimes innerText is reported empty when it actually isn't, so set it
+      // anyway in that case (Safari, iOS 14.4)
+      if (spacebarLabel.innerText != displayName || displayName == '') {
+        spacebarLabel.innerText = displayName;
       }
     }
     catch (ex) { }
   }
 
   public refreshLayout(layoutParams: LayerLayoutParams) {
+    // Do all layout-reflow / style-refresh dependent precalculations here,
+    // before we perform any DOM manipulation.
+    this.rows.forEach((row) => row.detectStyles(layoutParams));
+
+    // Hereafter, avoid any references to getComputedStyle, offset_, or other
+    // layout-reflow dependent values.  Refer to
+    // https://gist.github.com/paulirish/5d52fb081b3570c81e3a.
+
     // Check the heights of each row, in case different layers have different row counts.
     const layerHeight = layoutParams.keyboardHeight;
     const nRows = this.rows.length;
@@ -159,10 +165,9 @@ export default class OSKLayer {
       this.element.style.height=(layerHeight)+'px';
     }
 
-    const spacebarTextClosure = this.showLanguage(layoutParams.spacebarText);
+    this.showLanguage(layoutParams.spacebarText);
 
     // Update row layout properties
-    const rowClosures: (() => void)[] = [];
     for(let nRow=0; nRow<nRows; nRow++) {
       const oskRow = this.rows[nRow];
       const bottom = (nRows-nRow-1)*rowHeight+1;
@@ -172,27 +177,14 @@ export default class OSKLayer {
         this.spec.row[nRow].proportionalY = ((layerHeight - bottom) - rowHeight/2) / layerHeight;
       }
 
-      let rowClosure = oskRow.refreshLayout(layoutParams);
+      oskRow.refreshLayout(layoutParams);
       if(nRow == nRows-1) {
-        const oldRowClosure = rowClosure;
-        rowClosure = () => {
-          oldRowClosure();
-          oskRow.element.style.bottom = '1px';
-        };
+        oskRow.element.style.bottom = '1px';
       }
-      rowClosures.push(rowClosure);
     }
 
-    const rowKeyClosures: (() => void)[] = [];
     for(const row of this.rows) {
-      const batchedUpdates = row.refreshKeyLayouts(layoutParams);
-      rowKeyClosures.push(batchedUpdates);
+      row.refreshKeyLayouts(layoutParams);
     }
-
-    // After row layout properties have been updated, _then_ update key internals.
-    // Doing this separately like this helps to reduce layout reflow.
-    spacebarTextClosure();
-    rowClosures.forEach((closure) => closure());
-    rowKeyClosures.forEach((closure) => closure());
   }
 }


### PR DESCRIPTION
Addresses post-merge review comments from recent optimization PRs - in particular, for #11177. 

## User Testing

TEST_LIGHT_GESTURES:  Do some light testing of a few gesture-enabled keyboards and make sure things work as well as they did before.  Nothing too rigorous - we'll handle that with regression & platform-acceptance testing.