### PR TITLE
fix(developer): emit JSON strings as characters, not surrogate pairs

### DIFF
--- a/common/windows/delphi/general/JsonUtil.pas
+++ b/common/windows/delphi/general/JsonUtil.pas
@@ -46,10 +46,24 @@ function JSONToString(obj: TJSONAncestor; ReplaceSlashes: Boolean = False): stri
 var
   bytes: TBytes;
   len: Integer;
+  builder: TStringBuilder;
 begin
-  SetLength(bytes, obj.EstimatedByteSize);
-  len := obj.ToBytes(bytes, 0);
-  Result := TEncoding.UTF8.GetString(bytes, 0, len);
+  if obj is TJSONString then
+  begin
+    builder := TStringBuilder.Create;
+    try
+      obj.ToChars(builder);
+      Result := builder.ToString;
+    finally
+      builder.Free;
+    end;
+  end
+  else
+  begin
+    SetLength(bytes, obj.EstimatedByteSize);
+    len := obj.ToBytes(bytes, 0);
+    Result := TEncoding.UTF8.GetString(bytes, 0, len);
+  end;
   if ReplaceSlashes then
     Result := ReplaceStr(Result, '\/', '/');
 end;


### PR DESCRIPTION
Fixes #11193.

The JSON pretty-printed format in Delphi would emit strings with
surrogate pairs as e.g. "\uD801\uDDB0" instead of the character. This
change uses TStringBuilder which emits the characters cleanly.

# User Testing

This involves adding an emoji to a touch layout, and verifying that in code view it always is presented as an emoji, and not a surrogate pair sequence (`\uDxxx\uDxxx`).

* **TEST_TOUCH_LAYOUT_NO_SURROGATES:** Verify that no surrogate pairs are shown in the code view.
  1. In Keyman Developer, create a new keyboard. In the touch layout editor, add an emoji to any key on the keyboard.
  2. Open Code View, find the key with the emoji key cap, and verify that the emoji is shown as an emoji -- and not as a surrogate pair sequence.
  3. Open Keyboard/Fonts dialog, and click OK.
  4. Verify that in Code View, the emoji is still shown as an emoji.