### PR TITLE
fix(web): prevents dropping of input during rapid multitouch typing

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
@@ -49,7 +49,7 @@ export class GestureMatcher<Type, StateToken = any> implements PredecessorMatch<
 
   public get sources(): GestureSource<Type>[] {
     return this.pathMatchers.map((pathMatch, index) => {
-      if(this.model.contacts[index].resetOnResolve) {
+      if(this.model.contacts[index].resetOnInstantFulfill) {
         return undefined;
       } else {
         return pathMatch.source;
@@ -106,7 +106,7 @@ export class GestureMatcher<Type, StateToken = any> implements PredecessorMatch<
       if(source && entry == source) {
         // Due to internal delays that can occur when an incoming tap triggers
         // completion of a previously-existing gesture but is not included in it
-        // (`resetOnResolve` mechanics), it is technically possible for a very
+        // (`resetOnInstantFulfill` mechanics), it is technically possible for a very
         // quick tap to be 'complete' by the time we start trying to match
         // against it on some devices.  We should still try in such cases.
         return source;

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/specs/gestureModel.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/specs/gestureModel.ts
@@ -116,7 +116,7 @@ export interface GestureModel<Type, StateToken = any> {
      * Only takes effect if a model instantly resolves or rejects upon being considered for
      * inclusion in the model.
      */
-    resetOnResolve?: boolean,
+    resetOnInstantFulfill?: boolean,
     /**
      * Indicates that the corresponding GestureSource should be terminated whenever this GestureModel
      * is successfully matched.

--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedGestureSpecs.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedGestureSpecs.ts
@@ -124,7 +124,7 @@ export const SimpleTapModel: GestureModel = {
       endOnResolve: true
     }, {
       model: specs.InstantResolutionModel,
-      resetOnResolve: true
+      resetOnInstantFulfill: true
     }
   ],
   resolutionAction: {

--- a/web/src/engine/osk/src/input/gestures/browser/flick.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/flick.ts
@@ -118,7 +118,7 @@ export default class Flick implements GestureHandler {
     let source: GestureSource<KeyElement> = baseSource;
 
     sequence.on('complete', () => {
-      previewHost.cancel()
+      previewHost?.cancel()
     });
 
     this.sequence.on('stage', (result) => {

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -643,7 +643,8 @@ export function longpressModel(params: GestureParams, allowShortcut: boolean, al
         },
         endOnResolve: false
       }, {
-        model: instantContactRejectionModel()
+        model: instantContactRejectionModel(),
+        resetOnInstantFulfill: true
       }
     ],
     resolutionAction: {
@@ -815,7 +816,7 @@ export function flickMidModel(params: GestureParams): GestureModel<any> {
         endOnReject: true,
       }, {
         model: instantContactRejectionModel(),
-        resetOnResolve: true,
+        resetOnInstantFulfill: true,
       }
     ],
     rejectionActions: {
@@ -917,7 +918,7 @@ export function flickEndModel(params: GestureParams): GestureModel<any> {
       },
       {
         model: instantContactResolutionModel(),
-        resetOnResolve: true
+        resetOnInstantFulfill: true
       }
     ],
     rejectionActions: {
@@ -980,7 +981,7 @@ export function multitapEndModel(params: GestureParams): GestureModel<any> {
         endOnResolve: true
       }, {
         model: instantContactResolutionModel(),
-        resetOnResolve: true
+        resetOnInstantFulfill: true
       }
     ],
     rejectionActions: {
@@ -1015,7 +1016,7 @@ export function initialTapModel(params: GestureParams): GestureModel<any> {
         endOnResolve: true
       }, {
         model: instantContactResolutionModel(),
-        resetOnResolve: true
+        resetOnInstantFulfill: true
       }
     ],
     sustainWhenNested: true,
@@ -1046,7 +1047,7 @@ export function simpleTapModel(params: GestureParams): GestureModel<any> {
         endOnResolve: true
       }, {
         model: instantContactResolutionModel(),
-        resetOnResolve: true
+        resetOnInstantFulfill: true
       }
     ],
     sustainWhenNested: true,
@@ -1160,7 +1161,7 @@ export function modipressHoldModel(params: GestureParams): GestureModel<any> {
         },
         // The incoming tap belongs to a different gesture; we just care to know that it
         // happened.
-        resetOnResolve: true
+        resetOnInstantFulfill: true
       }
     ],
     // To be clear:  any time modipress-hold is triggered and the timer duration elapses,
@@ -1284,7 +1285,7 @@ export function modipressMultitapEndModel(params: GestureParams): GestureModel<a
         },
         // The incoming tap belongs to a different gesture; we just care to know that it
         // happened.
-        resetOnResolve: true
+        resetOnInstantFulfill: true
       }
     ],
     resolutionAction: {


### PR DESCRIPTION
Fixes #11221.

Turns out that there was a flag missing on the longpress model; if a second touch started during the longpress timer, it cancelled _both_ the longpress _and_ the new touch as a result, rather than just the longpress.  Fortunately, it's a quite simple fix.

## User Testing

TEST_RAPID_TYPE_WORDS:  Using the Keyman app on an Android device, attempt to reproduce #11221 with normal typing patterns - type rapidly and ensure no keys are unexpectedly dropped.
- Try typing `the quick brown fox jumped over the lazy dog` as fast as possible.  Don't worry about accuracy (aside from avoiding the globe key).
- Feel free to try additional sentences and/or paragraphs.
- Be sure you can compare the results with what you meant to type, so no random keymash.

TEST_RAPID_TYPE_HOME_ROW:  Using the Keyman app on an Android device, attempt to reproduce #11221 using the identified reproduction in [this comment](https://github.com/keymanapp/keyman/issues/11221#issuecomment-2062924021).

TEST_STICKY_BACKSPACE:  Using the Keyman app on an Android device, attempt to reproduce #11223.  The reporting user provided a repro.


Note:  I've added the last test, regarding backspace, because I _suspect_ the underlying issue is the same, with this PR _likely_ fixing it... but I'm willing to be wrong.  I won't block a merge of this PR should only that one user-test fail.