### PR TITLE
change(web): adjusts multitap timings

### DIFF
--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -109,8 +109,8 @@ export const DEFAULT_GESTURE_PARAMS: GestureParams = {
     noiseTolerance: 10
   },
   multitap: {
-    waitLength: 500,
-    holdLength: 500
+    waitLength: 300,
+    holdLength: 150
   },
   // Note:  all actual runtime values are determined at runtime based upon row height.
   // See `VisualKeyboard.refreshLayout`, CTRL-F "Step 3".


### PR DESCRIPTION
This changes the timings for multitap gestures to be far closer to the default settings used for multitaps on Android.

References:
- https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/android/view/GestureDetector.java#251
- https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/android/view/GestureDetector.java#871
- https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/ViewConfiguration.java#146

This sets the wait time from key-up to key-down to match their `DOUBLE_TAP_TIMEOUT` and uses the `HOVER_TAP_TIMEOUT` as a key-down to key-up timeout to prevent an ongoing multitap from proceeding further, based on its documentation.

As per https://stackoverflow.com/a/2900851, `DOUBLE_TAP_TIMEOUT` seems to match the equivalent Apple value as well, so far as we can tell.

@keymanapp-test-bot skip

It'd probably be wise to test how the resulting builds feel, but all this does is tweak the timings involved.