### PR TITLE
fix(developer): prevent xmlns for LDML keyboard template child elements

### DIFF
--- a/developer/src/kmconvert/Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas
@@ -73,11 +73,12 @@ begin
 end;
 
 const
+  XMLNS = 'https://schemas.unicode.org/cldr/45/keyboard3';
   TemplateXML: string =
     '<?xml version="1.0" encoding="UTF-8"?>'#13#10+
     // We won't inject the DOCTYPE because of pathing challenges, CLDR-15505
     //  '<!DOCTYPE keyboard3 SYSTEM "ldmlKeyboard3.dtd">'#13#10+
-    '<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3">'#13#10+
+    '<keyboard3 xmlns="'+XMLNS+'">'#13#10+
     '  <keys>'#13#10+
     '    <import base="cldr" path="45/keys-Zyyy-punctuation.xml"/>'#13#10+
     '    <import base="cldr" path="45/keys-Zyyy-currency.xml"/>  '#13#10+
@@ -134,21 +135,22 @@ begin
 
   doc.DocumentElement := root;
 
-  node := doc.CreateElement('info', '');
+  node := doc.CreateElement('info', XMLNS);
   node.Attributes['author'] := Author;
   node.Attributes['name'] := Name;
   root.ChildNodes.Insert(0, node);
 
-  node := doc.CreateElement('version', '');
+  node := doc.CreateElement('version', XMLNS);
   node.Attributes['number'] := Version;
   root.ChildNodes.Insert(1, node);
 
   if tags <> '' then
   begin
-    node := doc.CreateElement('locales', '');
+    node := doc.CreateElement('locales', XMLNS);
     while tags <> '' do
     begin
       tag := StrToken(tags, ' ');
+      // note: no XMLNS needed here
       node.AddChild('locale').Attributes['id'] := tag;
     end;
     root.ChildNodes.Insert(2, node);


### PR DESCRIPTION
Fixes #11228.

# User Testing

* **TEST_NEW_PROJECT:** Please rerun the steps reported in #11228, and verify that you can now compile the new LDML keyboard successfully.