### PR TITLE
fix(developer): test that MRU project exists before attempting to reference on startup

### DIFF
--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -1300,7 +1300,7 @@ begin
 
       if ext = Ext_ProjectSource then
       begin
-        if SameFileName(GetGlobalProjectUI.FileName, FFileName) then
+        if IsGlobalProjectUIReady and SameFileName(GetGlobalProjectUI.FileName, FFileName) then
         begin
           ShowProject;
           Exit;


### PR DESCRIPTION
Fixes #11194.

If the last-used project file no longer exists (e.g. has been renamed), then Keyman Developer would crash as it did not test that the file had been loaded successfully before attempting to reference it.

# User Testing

* **TEST_PROJECT_LOAD:** Follow the steps in #11194 and ensure that Keyman Developer no longer crashes on startup.