### PR TITLE
fix(developer): lazy initialization of test window

### DIFF
--- a/developer/src/server/src/site/test.js
+++ b/developer/src/server/src/site/test.js
@@ -64,16 +64,24 @@ keyman.init({
 fetch('/api-public/version').
   then(response => response.json()).
   then(value => {
-    const versionMajorRx = /^(\d+\.\d+)/.exec(value.version);
-    versionMajor = versionMajorRx[1];
-    helpUrl = 'https://help.keyman.com/developer/'+versionMajor+'/context/server';
-    document.getElementById('about-version').innerText = value.version;
-    document.getElementById('about-help-link').href = helpUrl;
-    document.getElementById('keyman-developer-logo').title = 'Keyman Developer Server '+value.version;
-    if(!value.isApiAvailable) {
-      document.body.classList.add('disable-upload');
+    const prep = () => {
+      const versionMajorRx = /^(\d+\.\d+)/.exec(value.version);
+      versionMajor = versionMajorRx[1];
+      helpUrl = 'https://help.keyman.com/developer/'+versionMajor+'/context/server';
+      document.getElementById('about-version').innerText = value.version;
+      document.getElementById('about-help-link').href = helpUrl;
+      document.getElementById('keyman-developer-logo').title = 'Keyman Developer Server '+value.version;
+      if(!value.isApiAvailable) {
+        document.body.classList.add('disable-upload');
+      } else {
+        initDropArea();
+      }
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener('DOMContentLoaded', prep);
     } else {
-      initDropArea();
+      prep();
     }
   });
 


### PR DESCRIPTION
Fixes #11273.

On some devices, the fetch() would return faster than the remaining script loads, which caused this script error. Lazy initialization should address this.

@keymanapp-test-bot skip