### PR TITLE
chore(web): drops redundant builder-dependency from early gesture dev

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -17,7 +17,6 @@ cd "$THIS_SCRIPT_PATH"
 
 builder_set_child_base src
 builder_describe "Builds engine modules for Keyman Engine for Web (KMW)." \
-  "@/common/web/gesture-recognizer build:engine/gestures" \
   "clean" \
   "configure" \
   "build" \


### PR DESCRIPTION
Just a minor bit of cleanup.  `build:engine/osk` still has the gesture-engine as a builder-dependency, which is the proper link.

@keymanapp-test-bot skip