### PR TITLE
fix(android): fixes kbd text zoom to prevent accessibility cross-effects

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -229,6 +229,7 @@ final class KMKeyboard extends WebView {
 
     getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
     getSettings().setSupportZoom(false);
+    getSettings().setTextZoom(100);
 
     getSettings().setUseWideViewPort(true);
     getSettings().setLoadWithOverviewMode(true);


### PR DESCRIPTION
Fixes #11279.
Fixes #11280.  (By preventing the scenario.)

Reference: https://stackoverflow.com/a/49649302

Device text-size accessibility scaling appears to affect the WebView "text zoom" setting.  Directly setting text-zoom to a specific value bypasses this and locks down our keyboards' font sizes.

## User Testing

TEST_ACCESSIBILITY_FONT_EFFECTS:  Using the Keyman app for Android, verify that system accessibility settings for fonts have no effect on the size of the in-app and system keyboards.
- Note that you will need to force-quit the app after changing system settings in order to properly test this; the app only retrieves font-size data once, when first loaded.