### PR TITLE
fix(windows): check font count display none found

### DIFF
--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -1186,7 +1186,10 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <!-- Introduced: 8.0.294.0 -->
   <string name="S_OSK_FontHelper_ChooseKeyboard" comment="OSK Font helper choose keyboard">Please select a Keyman keyboard to find related fonts.</string>
 
-
+  <!-- Context: OSK Font Helper -->
+  <!-- String Type: FormatString -->
+  <!-- Introduced: 17.0.312.0 -->
+  <string name="S_OSK_FontHelper_NoFonts" comment="OSK Font helper no fonts found for keyboard">No fonts have been found as suggestions for Keyboard %1$s .</string>
 
   <!-- Context: Text Editor -->
   <!-- String Type: FormatString -->

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -1189,7 +1189,7 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <!-- Context: OSK Font Helper -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 17.0.312.0 -->
-  <string name="S_OSK_FontHelper_NoFonts" comment="OSK Font helper no fonts found for keyboard">No fonts have been found as suggestions for Keyboard %1$s .</string>
+  <string name="S_OSK_FontHelper_NoFonts" comment="OSK Font helper no fonts found for keyboard">No fonts have been found as suggestions for Keyboard %1$s.</string>
 
   <!-- Context: Text Editor -->
   <!-- String Type: FormatString -->

--- a/windows/src/engine/keyman/viskbd/UfrmOSKFontHelper.pas
+++ b/windows/src/engine/keyman/viskbd/UfrmOSKFontHelper.pas
@@ -413,6 +413,11 @@ var
   i: Integer;
   m: Integer;
 begin
+  if FSelectedKeyboard.Fonts.Count = 0 then
+  begin
+    Exit;   // Exit as grid needs at least one font
+  end;
+
   grid.DefaultColWidth := tbSize.Position;
   grid.DefaultRowHeight := tbSize.Position;
 

--- a/windows/src/engine/keyman/viskbd/UfrmOSKFontHelper.pas
+++ b/windows/src/engine/keyman/viskbd/UfrmOSKFontHelper.pas
@@ -1,18 +1,18 @@
 (*
   Name:             UfrmOSKFontHelper
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      27 Mar 2008
 
   Modified Date:    25 Sep 2014
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          27 Mar 2008 - mcdurdin - Initial version I1374
                     20 Jul 2008 - mcdurdin - I1533 - Show hint for non-Unicode keyboards
                     29 Mar 2010 - mcdurdin - I2199 - Shift+click
@@ -447,39 +447,47 @@ begin
   FKeyboard := FCheckFontKeyboards.Keyboards[FLastSelectedKeyboardID];
   if (FLastSelectedKeyboardID <> '') and Assigned(FKeyboard) then
   begin
-    SetLength(FChars, Length(FKeyboard.Chars));
-    J := 0;
-    I := 1;
-    while I <= Length(FKeyboard.Chars) do  // I2712
+    if FKeyboard.Fonts.Count > 0 then
     begin
-      ch := FKeyboard.Chars[I];
-      if Uni_IsSurrogate1(ch) and (I < Length(FKeyboard.Chars)) and Uni_IsSurrogate2(FKeyboard.Chars[I+1]) then
+      SetLength(FChars, Length(FKeyboard.Chars));
+      J := 0;
+      I := 1;
+      while I <= Length(FKeyboard.Chars) do  // I2712
       begin
-        ch2 := FKeyboard.Chars[I+1];
-        FChars[J] := Uni_SurrogateToUTF32(ch, ch2);
+        ch := FKeyboard.Chars[I];
+        if Uni_IsSurrogate1(ch) and (I < Length(FKeyboard.Chars)) and Uni_IsSurrogate2(FKeyboard.Chars[I+1]) then
+        begin
+          ch2 := FKeyboard.Chars[I+1];
+          FChars[J] := Uni_SurrogateToUTF32(ch, ch2);
+          Inc(I);
+        end
+        else
+          FChars[J] := Ord(ch);
         Inc(I);
-      end
-      else
-        FChars[J] := Ord(ch);
-      Inc(I);
-      Inc(J);
-    end;
-
-    SetLength(FChars, J);
-
-    grid.ColCount := Length(FChars) + 2;
-    grid.RowCount := FKeyboard.Fonts.Count;
-
-    for i := 0 to FKeyboard.Fonts.Count - 1 do
-      if FKeyboard.Fonts[i].Coverage < 50 then
-      begin
-        grid.RowCount := i;
-        Break;
+        Inc(J);
       end;
 
-    FSelectedKeyboard := FKeyboard;
-    FormatGrid;
-    SetDisplay('');
+      SetLength(FChars, J);
+
+      grid.ColCount := Length(FChars) + 2;
+      grid.RowCount := FKeyboard.Fonts.Count;
+
+      for i := 0 to FKeyboard.Fonts.Count - 1 do
+        if FKeyboard.Fonts[i].Coverage < 50 then
+        begin
+          grid.RowCount := i;
+          Break;
+        end;
+
+      FSelectedKeyboard := FKeyboard;
+      FormatGrid;
+      SetDisplay('');
+    end
+    else
+    begin
+       FSelectedKeyboard := FKeyboard;
+       SetDisplay(MsgFromIdFormat(S_OSK_FontHelper_NoFonts, [FSelectedKeyboard.Name]));
+    end;
   end
   else
   begin


### PR DESCRIPTION
Fixes: #10933 
This change is to check the number of fonts found for the keyboard to guard against trying to index it when there are no fonts.

1. In the procedure `FormatGrid` check the font count if it is zero exit straight away. 

```
          for i := 0 to grid.RowCount - 1 do
                 m := System.Math.Max(m, Canvas.TextWidth(FSelectedKeyboard.Fonts[i].FontName) + 6)
```
2. Update the procedure `DisplayKeyboardFonts` to let the user know that no fonts were found as a suggestion.

Note: 
This line in `DisplayKeyboardFonts`
```
grid.RowCount := FKeyboard.Fonts.Count;
```
grid.RowCount cannot be less than 1. Therefore if font count is 0 the row count value will be 1 after this assignment. 

## User Testing

### TEST_KEYBOARD_WITH_FONTS

1. Install Keyman for Windows build artifact
2. Using Keyman Configuration install Simplified Chinese, Tamil 99 Basic, and Ahom Star keyboards
3. Start Keyman 
4. From the language selector in the taskbar menu select Tamil_99
5. Right-click on the keyman icon to bring up the context menu and select the "Font Helper"
6. It should load some suggested fonts with the characters in a grid display
7. Exit the Font helper

### TEST_KEYBOARD_WITHOUT_FONTS

1. Now select the cs_pinyin keyboard from the language selector in the taskbar menu
2. Right-click on the keyman icon to bring up the context menu and select the "Font Helper"
3. It should display the following message in the font helper window `No fonts have been found as suggestions for Keyboard %1$s.`

### TEST_KEYBOARD_FONT_HELPER_SELECT_KEYBOARDS
1. From the language selector in the taskbar menu select a non keyman keyboard
2. Right-click on the keyman icon to bring up the context menu and select the "Font Helper"
3. From the font helper select keyboard cs_pinyin.
4. It should display the following message in the font helper window `No fonts have been found as suggestions for Keyboard %1$s.`
5. Now select Tamil_99
6. Observe the suggested fonts are loaded with the characters in a grid format.
7. Now Select Ahom Star
8. Observe the suggested fonts are loaded with the characters in a grid format or if not found the message `No fonts have been found as suggestions for Keyboard %1$s.` is displayed


