### PR TITLE
fix(web): fixes pred-text unit test instability

### DIFF
--- a/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-trie-integration.js
@@ -60,7 +60,7 @@ describe('LMLayer using the trie model', function () {
     //
     // https://community.software.sil.org/t/search-term-to-key-in-lexical-model-not-working-both-ways-by-default/3133
     it('should use the default searchTermToKey()', function () {
-      var lmLayer = new LMLayer(helpers.defaultCapabilities, Worker.constructInstance());
+      var lmLayer = new LMLayer(helpers.defaultCapabilities, Worker.constructInstance(), /* testMode */ true);
 
       return lmLayer.loadModel(
         // We need to provide an absolute path since the worker is based within a blob.


### PR DESCRIPTION
Well, I finally found out why one of the predictive-text unit tests has been unstable for a while; it was never updated with the parameter that enhances test stability.  That test-oriented feature was added with #7571, with the line changed here having been missed at the time.

@keymanapp-test-bot skip