### PR TITLE
fix(linux): Improve detection of Gnome environment

### DIFF
--- a/linux/keyman-config/keyman_config/gnome_keyboards_util.py
+++ b/linux/keyman-config/keyman_config/gnome_keyboards_util.py
@@ -5,6 +5,9 @@ import os
 from keyman_config.gsettings import GSettings
 
 
+# pylint: disable=global-statement
+
+
 class GnomeKeyboardsUtil():
     def __init__(self):
         self.input_sources = GSettings('org.gnome.desktop.input-sources')
@@ -21,23 +24,29 @@ class GnomeKeyboardsUtil():
         self.input_sources.set('sources', sources, 'a(ss)')
 
 
-__is_gnome_shell = None
+# pylint: disable=invalid-name
+__is_gnome_desktop = None
 
 
-def is_gnome_shell():
-    global __is_gnome_shell
+def is_gnome_desktop():
+    '''
+    Returns true if system is running Gnome shell or another Gnome desktop
+    that stores keyboard data under `org.gnome.desktop.input-sources`.
+    '''
+    global __is_gnome_desktop
 
-    if __is_gnome_shell is None:
+    if __is_gnome_desktop is None:
         code = os.system('pidof gnome-shell >/dev/null 2>&1')
-        __is_gnome_shell = (code == 0)
-    return __is_gnome_shell
+        gnome_env = ('XDG_CURRENT_DESKTOP' in os.environ) and ('gnome' in os.environ['XDG_CURRENT_DESKTOP'].lower())
+        __is_gnome_desktop = (code == 0) or gnome_env
+    return __is_gnome_desktop
 
 
 def _reset_gnome_shell():
     # used in unit tests
-    global __is_gnome_shell
+    global __is_gnome_desktop
 
-    __is_gnome_shell = None
+    __is_gnome_desktop = None
 
 
 def get_ibus_keyboard_id(keyboard, packageDir, language=None, ignore_language=False):

--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -14,7 +14,7 @@ gi.require_version('IBus', '1.0')
 from gi.repository import IBus
 from pkg_resources import parse_version
 
-from keyman_config.gnome_keyboards_util import is_gnome_shell
+from keyman_config.gnome_keyboards_util import is_gnome_desktop
 from keyman_config.gsettings import GSettings
 
 
@@ -164,7 +164,7 @@ def _start_ibus_daemon(realuser):
             # If IBus is too old we have to start ibus-daemon directly and pass
             # what we think are the correct parameters
             args = ['ibus-daemon', '-d', '-r', '--xim']
-            if is_gnome_shell():
+            if is_gnome_desktop():
                 # on Ubuntu 21.10 with Gnome the keyboards don't show in dropdown
                 # list if we don't disable the panel
                 args.extend(['--panel', 'disable'])

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -19,7 +19,7 @@ from keyman_config.get_kmp import (InstallLocation, get_keyboard_data,
                                    get_keyman_font_dir)
 from keyman_config.gnome_keyboards_util import (GnomeKeyboardsUtil,
                                                 get_ibus_keyboard_id,
-                                                is_gnome_shell)
+                                                is_gnome_desktop)
 from keyman_config.ibus_util import get_ibus_bus, install_to_ibus, restart_ibus
 from keyman_config.kmpmetadata import KMFileTypes, get_metadata
 from keyman_config.kvk2ldml import convert_kvk_to_ldml, output_ldml
@@ -261,7 +261,7 @@ class InstallKmp():
             return self._install_keyboards_to_fcitx()
 
         restart_ibus()
-        if is_gnome_shell():
+        if is_gnome_desktop():
             return self._install_keyboards_to_gnome(keyboards, packageDir, language)
         else:
             return self._install_keyboards_to_ibus(keyboards, packageDir, language)

--- a/linux/keyman-config/keyman_config/uninstall_kmp.py
+++ b/linux/keyman-config/keyman_config/uninstall_kmp.py
@@ -13,7 +13,7 @@ from keyman_config.get_kmp import (InstallLocation, get_keyboard_dir,
                                    get_keyman_doc_dir, get_keyman_font_dir)
 from keyman_config.gnome_keyboards_util import (GnomeKeyboardsUtil,
                                                 get_ibus_keyboard_id,
-                                                is_gnome_shell)
+                                                is_gnome_desktop)
 from keyman_config.gsettings import GSettings
 from keyman_config.ibus_util import IbusUtil, get_ibus_bus, restart_ibus
 from keyman_config.kmpmetadata import get_metadata
@@ -56,7 +56,7 @@ def _uninstall_kmp_common(location, packageID, removeLanguages):
         if keyboards:
             if is_fcitx_running():
                 _uninstall_keyboards_from_fcitx5()
-            elif is_gnome_shell():
+            elif is_gnome_desktop():
                 _uninstall_keyboards_from_gnome(keyboards, kbdir)
             else:
                 _uninstall_keyboards_from_ibus(keyboards, kbdir)

--- a/linux/keyman-config/tests/test_gnome_keyboards_util.py
+++ b/linux/keyman-config/tests/test_gnome_keyboards_util.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
+import os
 import unittest
+from unittest import mock
 from unittest.mock import patch
 
-from keyman_config.gnome_keyboards_util import is_gnome_shell, _reset_gnome_shell
+from keyman_config.gnome_keyboards_util import is_gnome_desktop, _reset_gnome_shell
 
 
 class GnomeKeyboardsUtilTests(unittest.TestCase):
@@ -10,18 +12,28 @@ class GnomeKeyboardsUtilTests(unittest.TestCase):
         _reset_gnome_shell()
 
     @patch('os.system')
-    def test_IsGnomeShell_RunningGnomeShell(self, mockSystem):
+    @mock.patch.dict(os.environ, {'XDG_CURRENT_DESKTOP': 'ubuntu:GNOME'})
+    def test_IsGnomeDesktop_RunningGnomeShell(self, mockSystem):
         # Setup
         mockSystem.return_value = 0
         # Execute/Verify
-        self.assertEqual(is_gnome_shell(), True)
+        self.assertEqual(is_gnome_desktop(), True)
 
     @patch('os.system')
-    def test_IsGnomeShell_NotRunningGnomeShell(self, mockSystem):
+    @mock.patch.dict(os.environ, {'XDG_CURRENT_DESKTOP': 'X-Cinnamon'})
+    def test_IsGnomeDesktop_NotRunningGnomeShell(self, mockSystem):
         # Setup
         mockSystem.return_value = 1
         # Execute/Verify
-        self.assertEqual(is_gnome_shell(), False)
+        self.assertEqual(is_gnome_desktop(), False)
+
+    @patch('os.system')
+    @mock.patch.dict(os.environ, {'XDG_CURRENT_DESKTOP': 'budgie:GNOME'})
+    def test_IsGnomeDesktop_RunningBudgie(self, mockSystem):
+        # Setup
+        mockSystem.return_value = 1
+        # Execute/Verify
+        self.assertEqual(is_gnome_desktop(), True)
 
 
 if __name__ == '__main__':

--- a/linux/keyman-config/tests/test_install_kmp.py
+++ b/linux/keyman-config/tests/test_install_kmp.py
@@ -32,7 +32,7 @@ class InstallKmpBase(unittest.TestCase):
         patcher7 = patch('keyman_config.install_kmp.extractico')
         self.mockExtractIco = patcher7.start()
         self.addCleanup(patcher7.stop)
-        patcher8 = patch('keyman_config.install_kmp.is_gnome_shell')
+        patcher8 = patch('keyman_config.install_kmp.is_gnome_desktop')
         self.mockIsGnomeShell = patcher8.start()
         self.addCleanup(patcher8.stop)
         self.mockIsGnomeShell.return_value = False

--- a/linux/keyman-config/tests/test_uninstall_kmp.py
+++ b/linux/keyman-config/tests/test_uninstall_kmp.py
@@ -246,7 +246,7 @@ class UninstallKmpCommonTests(unittest.TestCase):
         patcher3 = patch('keyman_config.uninstall_kmp.get_keyman_font_dir')
         self.mockGetKeymanFontDir = patcher3.start()
         self.addCleanup(patcher3.stop)
-        patcher4 = patch('keyman_config.uninstall_kmp.is_gnome_shell')
+        patcher4 = patch('keyman_config.uninstall_kmp.is_gnome_desktop')
         self.mockIsGnomeShell = patcher4.start()
         self.addCleanup(patcher4.stop)
         self.mockIsGnomeShell.return_value = False


### PR DESCRIPTION
This change improves the way we detect if we're running a Gnome based UI that needs it's keyboards installed under
`org.gnome.desktop.input-sources`. We use the environment variable `XDG_CURRENT_DESKTOP` and check if it contains the word `gnome`. Additionally this change renames `is_gnome_shell()` to `is_gnome_desktop()`.

Fixes #11225.

# User Testing

## Preparations

- The tests should be run on these Linux platforms:
  - **GROUP_FOCAL**: Ubuntu 20.04 Focal with Gnome Shell and X11
  - **GROUP_NOBLE_WAYLAND**: Ubuntu 24.04 Noble with Gnome Shell and Wayland
  - **GROUP_WASTA**: Wasta 22.04 with Cinnamon

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

## Tests

**TEST_INSTALL**:

- open Keyman Configuration
- install a Keyman keyboard
- verify that the keyboard appears in Keyboard/language dropdown list in the task bar