### PR TITLE
fix(linux): Fix icon for .kmp files

### DIFF
--- a/linux/keyman-config/resources/keyman.sharedmimeinfo
+++ b/linux/keyman-config/resources/keyman.sharedmimeinfo
@@ -5,6 +5,7 @@
 		<sub-class-of type="application/zip"/>
 		<glob pattern="*.kmp"/>
 		<icon name="application-x-kmp"/>
+		<generic-icon name="application-x-kmp"/>
 	</mime-type>
 	<mime-type type="application/keyman">
 		<comment>Keyman keyboard installation link</comment>


### PR DESCRIPTION
It seems some Ubuntu versions ignore the `icon` field and only use `generic-icon`, so this change adds that field. This will fix displaying the icon on newer Ubuntu versions. And since we keep the `icon` field it should still work everywhere else.

Fixes #11144.

# User Testing

## Preparations

- The tests should be run on these Linux platforms:
  - **GROUP_NOBLE_WAYLAND**: Ubuntu 24.04 Noble with Gnome Shell and Wayland
  - **GROUP_WASTA**: Wasta 20.04 with Cinnamon

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

## Tests

**TEST_ICON**: 

- Download a .kmp file from keyman.com
- Verify that the correct icon shows for the .kmp file in the file manager
