### PR TITLE
fix(common): Retry curl downloads up to 5 times

### DIFF
--- a/resources/build/build-download-resources.sh
+++ b/resources/build/build-download-resources.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Download default keyboard and lexical model packages from downloads.keyman.com
+# Retries up to 5 times
 
 # Set sensible script defaults:
 # set -e: Terminate script if a command returns an error
@@ -29,10 +30,12 @@ function downloadKeyboardPackage() {
 
   local URL_DOWNLOAD=https://downloads.keyman.com
   local URL_API_KEYBOARD_VERSION=${URL_DOWNLOAD}/api/keyboard/
+  local RETRY=5       # Curl retries this number of times before giving up
+  local RETRY_DELAY=5 # Make curl sleep this amount of time before each retry when a transfer has failed
 
-  echo "Downloading ${ID}.kmp from downloads.keyman.com"
-  local URL_DOWNLOAD_FILE=`curl -s "$URL_API_KEYBOARD_VERSION/${ID}" | "$JQ" -r .kmp`
-  curl -f -s "$URL_DOWNLOAD_FILE" -o "$KEYBOARDS_TARGET" || {
+  echo "Downloading ${ID}.kmp from downloads.keyman.com up to ${RETRY} attempts"
+  local URL_DOWNLOAD_FILE=`curl --silent "$URL_API_KEYBOARD_VERSION/${ID}" | "$JQ" -r .kmp`
+  curl --fail --retry "$RETRY" --retry-delay "$RETRY_DELAY" --silent "$URL_DOWNLOAD_FILE" --output "$KEYBOARDS_TARGET" || {
       builder_die "Downloading $KEYBOARDS_TARGET failed with error $?"
   }
 }
@@ -48,10 +51,12 @@ function downloadModelPackage() {
 
   local URL_DOWNLOAD=https://downloads.keyman.com
   local URL_API_MODEL_VERSION=${URL_DOWNLOAD}/api/model/
+  local RETRY=5       # Curl retries this number of times before giving up
+  local RETRY_DELAY=5 # Make curl sleep this amount of time before each retry when a transfer has failed
 
-  echo "Downloading ${ID}.model.kmp from downloads.keyman.com"
-  local URL_DOWNLOAD_FILE=`curl -s "$URL_API_MODEL_VERSION/${ID}" | "$JQ" -r .kmp`
-  curl -f -s "$URL_DOWNLOAD_FILE" -o "$MODELS_TARGET" || {
+  echo "Downloading ${ID}.model.kmp from downloads.keyman.com up to ${RETRY} attempts"
+  local URL_DOWNLOAD_FILE=`curl --silent "$URL_API_MODEL_VERSION/${ID}" | "$JQ" -r .kmp`
+  curl --fail --retry "$RETRY" --retry-delay "$RETRY_DELAY" --silent "$URL_DOWNLOAD_FILE" --output "$MODELS_TARGET" || {
       builder_die "Downloading $MODELS_TARGET failed with error $?"
   }
 }

--- a/resources/build/build-download-resources.sh
+++ b/resources/build/build-download-resources.sh
@@ -34,7 +34,7 @@ function downloadKeyboardPackage() {
   local RETRY_DELAY=5 # Make curl sleep this amount of time before each retry when a transfer has failed
 
   echo "Downloading ${ID}.kmp from downloads.keyman.com up to ${RETRY} attempts"
-  local URL_DOWNLOAD_FILE=`curl --silent "$URL_API_KEYBOARD_VERSION/${ID}" | "$JQ" -r .kmp`
+  local URL_DOWNLOAD_FILE=`curl --retry "$RETRY" --retry-delay "$RETRY_DELAY" --silent "$URL_API_KEYBOARD_VERSION/${ID}" | "$JQ" -r .kmp`
   curl --fail --retry "$RETRY" --retry-delay "$RETRY_DELAY" --silent "$URL_DOWNLOAD_FILE" --output "$KEYBOARDS_TARGET" || {
       builder_die "Downloading $KEYBOARDS_TARGET failed with error $?"
   }
@@ -55,7 +55,7 @@ function downloadModelPackage() {
   local RETRY_DELAY=5 # Make curl sleep this amount of time before each retry when a transfer has failed
 
   echo "Downloading ${ID}.model.kmp from downloads.keyman.com up to ${RETRY} attempts"
-  local URL_DOWNLOAD_FILE=`curl --silent "$URL_API_MODEL_VERSION/${ID}" | "$JQ" -r .kmp`
+  local URL_DOWNLOAD_FILE=`curl --retry "$RETRY" --retry-delay "$RETRY_DELAY" --silent "$URL_API_MODEL_VERSION/${ID}" | "$JQ" -r .kmp`
   curl --fail --retry "$RETRY" --retry-delay "$RETRY_DELAY" --silent "$URL_DOWNLOAD_FILE" --output "$MODELS_TARGET" || {
       builder_die "Downloading $MODELS_TARGET failed with error $?"
   }


### PR DESCRIPTION
Fixes #10670 

This updates the curl downloads to try up to 5 times (with 5s delay in between).
Reference
https://curl.se/docs/manpage.html#--retry

Also updated to use long option names. And since the curl still uses `--silent`, the retry statuses aren't output.

@keymanapp-test-bot skip

