### PR TITLE
chore(web): updates most @types/node dependencies, makes them consistent 🏃

### DIFF
--- a/common/models/templates/package.json
+++ b/common/models/templates/package.json
@@ -54,7 +54,6 @@
     "@keymanapp/models-types": "*",
     "@keymanapp/web-utils": "*",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^14.0.4",
     "c8": "^7.12.0",
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",

--- a/common/models/wordbreakers/package.json
+++ b/common/models/wordbreakers/package.json
@@ -57,8 +57,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
   },
-  "type": "module",
-  "dependencies": {
-    "@types/node": "^14.0.3"
-  }
+  "type": "module"
 }

--- a/common/predictive-text/package.json
+++ b/common/predictive-text/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@keymanapp/models-types": "*",
     "@keymanapp/resources-gosh": "*",
-    "@types/node": "^10.17.21",
     "karma": "^6.4.1",
     "karma-browserstack-launcher": "^1.6.0",
     "karma-chai": "^0.1.0",

--- a/common/test/resources/package.json
+++ b/common/test/resources/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "devDependencies": {
     "@keymanapp/resources-gosh": "*",
-    "@types/node": "^10.17.21",
     "typescript": "^4.9.5"
   }
 }

--- a/common/tools/sourcemap-path-remapper/package.json
+++ b/common/tools/sourcemap-path-remapper/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/keymanapp/keyman#readme",
   "devDependencies": {
     "@keymanapp/resources-gosh": "*",
-    "@types/node": "^10.17.21",
+    "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",
     "sinon": "^7.1.1",
     "ts-node": "^10.9.1",

--- a/common/web/gesture-recognizer/package.json
+++ b/common/web/gesture-recognizer/package.json
@@ -3,7 +3,6 @@
   "description": "The core gesture-recognition engine used by Keyman's Web-based OSKs.",
   "devDependencies": {
     "@keymanapp/resources-gosh": "*",
-    "@types/node": "^11.9.4",
     "@types/sinon": "^10.0.13",
     "karma": "^6.4.1",
     "karma-browserstack-launcher": "^1.6.0",

--- a/common/web/input-processor/package.json
+++ b/common/web/input-processor/package.json
@@ -19,7 +19,6 @@
   "devDependencies": {
     "@keymanapp/kmc": "*",
     "@keymanapp/resources-gosh": "*",
-    "@types/node": "^11.9.4",
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",
     "ts-node": "^10.9.1",

--- a/common/web/keyboard-processor/package.json
+++ b/common/web/keyboard-processor/package.json
@@ -39,8 +39,7 @@
     "@keymanapp/common-types": "*",
     "@keymanapp/models-types": "*",
     "@keymanapp/keyman-version": "*",
-    "@keymanapp/web-utils": "*",
-    "@types/node": "^11.9.4"
+    "@keymanapp/web-utils": "*"
   },
   "type": "module",
   "main": "./build/obj/index.js",

--- a/common/web/lm-worker/package.json
+++ b/common/web/lm-worker/package.json
@@ -28,7 +28,6 @@
     "@keymanapp/common-test-resources": "*",
     "@keymanapp/models-types": "*",
     "@keymanapp/resources-gosh": "*",
-    "@types/node": "^10.17.21",
     "c8": "^7.12.0",
     "combine-source-map": "^0.8.0",
     "karma": "^6.4.1",

--- a/common/web/recorder/package.json
+++ b/common/web/recorder/package.json
@@ -22,8 +22,7 @@
     "@keymanapp/keyboard-processor": "*",
     "@keymanapp/models-types": "*",
     "@keymanapp/keyman-version": "*",
-    "@keymanapp/web-utils": "*",
-    "@types/node": "^11.9.4"
+    "@keymanapp/web-utils": "*"
   },
   "devDependencies": {
     "typescript": "^4.9.5"

--- a/common/web/utils/package.json
+++ b/common/web/utils/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@keymanapp/keyman-version": "*",
     "@keymanapp/resources-gosh": "*",
-    "@types/node": "^14.0.5",
     "c8": "^7.12.0",
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,17 +76,11 @@
         "@keymanapp/models-types": "*",
         "@keymanapp/web-utils": "*",
         "@types/mocha": "^7.0.2",
-        "@types/node": "^14.0.4",
         "c8": "^7.12.0",
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
         "typescript": "^4.9.5"
       }
-    },
-    "common/models/templates/node_modules/@types/node": {
-      "version": "14.18.12",
-      "dev": true,
-      "license": "MIT"
     },
     "common/models/types": {
       "name": "@keymanapp/models-types",
@@ -98,9 +92,6 @@
     "common/models/wordbreakers": {
       "name": "@keymanapp/models-wordbreakers",
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "^14.0.3"
-      },
       "devDependencies": {
         "@keymanapp/models-types": "*",
         "@keymanapp/resources-gosh": "*",
@@ -111,10 +102,6 @@
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
       }
-    },
-    "common/models/wordbreakers/node_modules/@types/node": {
-      "version": "14.18.12",
-      "license": "MIT"
     },
     "common/predictive-text": {
       "name": "@keymanapp/lexical-model-layer",
@@ -130,7 +117,6 @@
       "devDependencies": {
         "@keymanapp/models-types": "*",
         "@keymanapp/resources-gosh": "*",
-        "@types/node": "^10.17.21",
         "karma": "^6.4.1",
         "karma-browserstack-launcher": "^1.6.0",
         "karma-chai": "^0.1.0",
@@ -152,25 +138,13 @@
         "typescript": "^4.9.5"
       }
     },
-    "common/predictive-text/node_modules/@types/node": {
-      "version": "10.17.60",
-      "dev": true,
-      "license": "MIT"
-    },
     "common/test/resources": {
       "name": "@keymanapp/common-test-resources",
       "license": "MIT",
       "devDependencies": {
         "@keymanapp/resources-gosh": "*",
-        "@types/node": "^10.17.21",
         "typescript": "^4.9.5"
       }
-    },
-    "common/test/resources/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true
     },
     "common/tools/hextobin": {
       "name": "@keymanapp/hextobin",
@@ -200,7 +174,7 @@
       },
       "devDependencies": {
         "@keymanapp/resources-gosh": "*",
-        "@types/node": "^10.17.21",
+        "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
         "sinon": "^7.1.1",
         "ts-node": "^10.9.1",
@@ -217,11 +191,6 @@
         "array-from": "^2.1.1",
         "lodash": "^4.17.15"
       }
-    },
-    "common/tools/sourcemap-path-remapper/node_modules/@types/node": {
-      "version": "10.17.60",
-      "dev": true,
-      "license": "MIT"
     },
     "common/tools/sourcemap-path-remapper/node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -325,7 +294,6 @@
       },
       "devDependencies": {
         "@keymanapp/resources-gosh": "*",
-        "@types/node": "^11.9.4",
         "@types/sinon": "^10.0.13",
         "karma": "^6.4.1",
         "karma-browserstack-launcher": "^1.6.0",
@@ -348,12 +316,6 @@
         "typescript": "^4.9.5"
       }
     },
-    "common/web/gesture-recognizer/node_modules/@types/node": {
-      "version": "11.15.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
-      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==",
-      "dev": true
-    },
     "common/web/input-processor": {
       "name": "@keymanapp/input-processor",
       "license": "MIT",
@@ -368,18 +330,11 @@
       "devDependencies": {
         "@keymanapp/kmc": "*",
         "@keymanapp/resources-gosh": "*",
-        "@types/node": "^11.9.4",
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
       }
-    },
-    "common/web/input-processor/node_modules/@types/node": {
-      "version": "11.15.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
-      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==",
-      "dev": true
     },
     "common/web/keyboard-processor": {
       "name": "@keymanapp/keyboard-processor",
@@ -388,8 +343,7 @@
         "@keymanapp/common-types": "*",
         "@keymanapp/keyman-version": "*",
         "@keymanapp/models-types": "*",
-        "@keymanapp/web-utils": "*",
-        "@types/node": "^11.9.4"
+        "@keymanapp/web-utils": "*"
       },
       "devDependencies": {
         "@keymanapp/resources-gosh": "*",
@@ -405,11 +359,6 @@
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
       }
-    },
-    "common/web/keyboard-processor/node_modules/@types/node": {
-      "version": "11.15.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
-      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g=="
     },
     "common/web/keyman-version": {
       "name": "@keymanapp/keyman-version",
@@ -441,7 +390,6 @@
         "@keymanapp/common-test-resources": "*",
         "@keymanapp/models-types": "*",
         "@keymanapp/resources-gosh": "*",
-        "@types/node": "^10.17.21",
         "c8": "^7.12.0",
         "combine-source-map": "^0.8.0",
         "karma": "^6.4.1",
@@ -465,11 +413,6 @@
         "typescript": "^4.9.5"
       }
     },
-    "common/web/lm-worker/node_modules/@types/node": {
-      "version": "10.17.60",
-      "dev": true,
-      "license": "MIT"
-    },
     "common/web/recorder": {
       "name": "@keymanapp/recorder-core",
       "license": "MIT",
@@ -477,17 +420,11 @@
         "@keymanapp/keyboard-processor": "*",
         "@keymanapp/keyman-version": "*",
         "@keymanapp/models-types": "*",
-        "@keymanapp/web-utils": "*",
-        "@types/node": "^11.9.4"
+        "@keymanapp/web-utils": "*"
       },
       "devDependencies": {
         "typescript": "^4.9.5"
       }
-    },
-    "common/web/recorder/node_modules/@types/node": {
-      "version": "11.15.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
-      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g=="
     },
     "common/web/sentry-manager": {
       "name": "@keymanapp/web-sentry-manager",
@@ -748,17 +685,11 @@
       "devDependencies": {
         "@keymanapp/keyman-version": "*",
         "@keymanapp/resources-gosh": "*",
-        "@types/node": "^14.0.5",
         "c8": "^7.12.0",
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
         "typescript": "^4.9.5"
       }
-    },
-    "common/web/utils/node_modules/@types/node": {
-      "version": "14.18.18",
-      "dev": true,
-      "license": "MIT"
     },
     "core/include/ldml": {
       "name": "@keymanapp/ldml-keyboard-constants",
@@ -12840,17 +12771,11 @@
         "yargs": "^17.7.2"
       },
       "devDependencies": {
-        "@types/node": "^13.7.0",
         "@types/semver": "^7.1.0",
         "@types/yargs": "^17.0.26",
         "semver": "^7.5.2",
         "ts-node": "^10.9.1"
       }
-    },
-    "resources/build/version/node_modules/@types/node": {
-      "version": "13.13.52",
-      "dev": true,
-      "license": "MIT"
     },
     "resources/build/version/node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -12972,7 +12897,6 @@
         "@keymanapp/recorder-core": "*",
         "@keymanapp/tslib": "*",
         "@keymanapp/web-utils": "*",
-        "@types/node": "^18.19.3",
         "core-js": "^3.34.0",
         "eventemitter3": "^4.0.0",
         "tslib": "^2.5.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
       "devDependencies": {
         "@microsoft/api-documenter": "^7.23.31",
         "@microsoft/api-extractor": "^7.41.0",
-        "@types/chai": "^4.3.5",
+        "@types/chai": "^4.3.14",
+        "@types/node": "^18.0.0",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "ajv": "^8.12.0",
         "ajv-cli": "^5.0.0",
@@ -183,11 +184,6 @@
       "devDependencies": {
         "@types/node": "^18.7.18"
       }
-    },
-    "common/tools/hextobin/node_modules/@types/node": {
-      "version": "18.11.15",
-      "dev": true,
-      "license": "MIT"
     },
     "common/tools/hextobin/node_modules/commander": {
       "version": "5.1.0",
@@ -352,6 +348,12 @@
         "typescript": "^4.9.5"
       }
     },
+    "common/web/gesture-recognizer/node_modules/@types/node": {
+      "version": "11.15.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
+      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==",
+      "dev": true
+    },
     "common/web/input-processor": {
       "name": "@keymanapp/input-processor",
       "license": "MIT",
@@ -372,6 +374,12 @@
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
       }
+    },
+    "common/web/input-processor/node_modules/@types/node": {
+      "version": "11.15.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
+      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==",
+      "dev": true
     },
     "common/web/keyboard-processor": {
       "name": "@keymanapp/keyboard-processor",
@@ -397,6 +405,11 @@
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
       }
+    },
+    "common/web/keyboard-processor/node_modules/@types/node": {
+      "version": "11.15.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
+      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g=="
     },
     "common/web/keyman-version": {
       "name": "@keymanapp/keyman-version",
@@ -470,6 +483,11 @@
       "devDependencies": {
         "typescript": "^4.9.5"
       }
+    },
+    "common/web/recorder/node_modules/@types/node": {
+      "version": "11.15.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
+      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g=="
     },
     "common/web/sentry-manager": {
       "name": "@keymanapp/web-sentry-manager",
@@ -4150,9 +4168,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
-      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.14.tgz",
+      "integrity": "sha512-Wj71sXE4Q4AkGdG9Tvq1u/fquNz9EdG4LIJMwVVII7ashjD/8cf8fyIfJAjRr6YcsXnSE8cOGQPq1gqeR8z+3w==",
       "dev": true
     },
     "node_modules/@types/component-emitter": {
@@ -4255,8 +4273,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "11.15.54",
-      "license": "MIT"
+      "version": "18.19.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.31.tgz",
+      "integrity": "sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -12979,14 +13001,6 @@
         "modernizr": "^3.11.7",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
-      }
-    },
-    "web/node_modules/@types/node": {
-      "version": "18.19.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
-      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "devDependencies": {
     "@microsoft/api-documenter": "^7.23.31",
     "@microsoft/api-extractor": "^7.41.0",
-    "@types/chai": "^4.3.5",
+    "@types/chai": "^4.3.14",
+    "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "ajv": "^8.12.0",
     "ajv-cli": "^5.0.0",

--- a/resources/build/version/package.json
+++ b/resources/build/version/package.json
@@ -9,7 +9,6 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@types/node": "^13.7.0",
     "@types/semver": "^7.1.0",
     "@types/yargs": "^17.0.26",
     "semver": "^7.5.2",

--- a/web/package.json
+++ b/web/package.json
@@ -120,7 +120,6 @@
     "@keymanapp/recorder-core": "*",
     "@keymanapp/tslib": "*",
     "@keymanapp/web-utils": "*",
-    "@types/node": "^18.19.3",
     "core-js": "^3.34.0",
     "eventemitter3": "^4.0.0",
     "tslib": "^2.5.2"


### PR DESCRIPTION
Amother notable task I identified while working on https://github.com/keymanapp/keyman/pull/11300 (toward resolving https://github.com/keymanapp/keyman/issues/10497) is that a number of our packages have considerably out-of-date `@types/node` dependencies.  The testing framework we'll likely be transitioning to includes a dependency of its own that requires a more recent version than some of the packages currently utilize... including the one installed in our monorepo root package.

Re: `@types/node` updates:  https://stackoverflow.com/a/52404327
- Put simply, the type of the typings package should match that of node.  As we're currently on Node 18, I updated to the latest v18 typings.  If we shift to 20 (or higher) before this lands, this should be updated again.

**Note**: I believe I did leave a few package-specific `@types/node` dependencies in place.  If a package used something more recent than v18, I left it untouched in case there's something v20-specific that is relevant.

Fun(?) fact:  `tsc` loads _all_ `@types/` packages in node-modules when compiling, regardless of whether or not they're actually relevant to the code being compiled.  This fact was breaking builds once I started to use the upcoming test framework.

@keymanapp-test-bot skip