### PR TITLE
fix(web): gesture-model initial-state, callback failure handling

### DIFF
--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
@@ -524,6 +524,13 @@ export class GestureMatcher<Type, StateToken = any> implements PredecessorMatch<
   }
 
   update() {
-    this.pathMatchers.forEach((matcher) => matcher.update());
+    this.pathMatchers.forEach((matcher) => {
+      try {
+        matcher.update();
+      } catch(err) {
+        console.error(err);
+        this.finalize(false, 'cancelled');
+      }
+    });
   }
 }

--- a/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
+++ b/common/web/gesture-recognizer/src/engine/headless/gestures/matchers/gestureMatcher.ts
@@ -477,6 +477,13 @@ export class GestureMatcher<Type, StateToken = any> implements PredecessorMatch<
           here, as the decision is made due to a validation check against the initial item.
         */
         this.finalize(false, 'cancelled');
+
+        /*
+         * There's no need to process the gesture-model any further... and the
+         * invalid state may correspond to assumptions in the path-model that
+         * will be invalidated if we continue.
+         */
+        return;
       }
     }
 
@@ -507,6 +514,7 @@ export class GestureMatcher<Type, StateToken = any> implements PredecessorMatch<
         instantly fail and thus cancel.
       */
       this.finalize(false, whileInitializing ? 'cancelled' : 'path');
+      return;
     }
 
     // Standard path:  trigger either resolution or rejection when the contact model signals either.


### PR DESCRIPTION
Fixes #11186.

Adds error-handling for the callbacks of gesture models passed to the gesture engine, adding stability when the models aren't properly defined.  Also prevents a model with invalid initial state from evaluating any further, as that could invalidate assumptions based on said check in the path model.

The gesture engine uses configured callbacks in the specified gesture models to match the needs of the library's consumer.  Should an error arise at critical points in that process, we need to ensure they don't destabilize the general core processes of the gesture engine, even if we do need to cancel the failed gesture-models.

@keymanapp-test-bot skip