### PR TITLE
fix(common): Fix colorization of help output of builder script

### DIFF
--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -132,7 +132,7 @@ builder_use_color() {
 # $BUILDER_TERM_END
 #
 function builder_term() {
-  echo "${BUILDER_TERM_START}$*${BUILDER_TERM_END}"
+  echo -e "${BUILDER_TERM_START}$*${BUILDER_TERM_END}"
 }
 
 function builder_die() {


### PR DESCRIPTION
This fixes the use of colors in the help output when `builder_term` is used inside of `builder_describe` (e.g. `web/test.sh --help`). Previously the escape sequences were not interpreted but directly output.

@keymanapp-test-bot skip