### PR TITLE
fix(android): inverting a selection range would crash Keyman

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -204,13 +204,13 @@ final class KMKeyboard extends WebView {
        */
 
       // Count the number of characters which are surrogate pairs.
-      int pairsAtStart = CharSequenceUtil.countSurrogatePairs(rawText.substring(0, selStart), rawText.length());
-      String selectedText = rawText.substring(selStart, selEnd);
+      int pairsAtStart = CharSequenceUtil.countSurrogatePairs(rawText.substring(0, selMin), rawText.length());
+      String selectedText = rawText.substring(selMin, selMax);
       int pairsSelected = CharSequenceUtil.countSurrogatePairs(selectedText, selectedText.length());
 
-      selStart -= pairsAtStart;
-      selEnd -= (pairsAtStart + pairsSelected);
-      this.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selStart, selEnd));
+      selMin -= pairsAtStart;
+      selMax -= (pairsAtStart + pairsSelected);
+      this.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selMin, selMax));
     }
     result = true;
 


### PR DESCRIPTION
Fixes #11344.

Compare the changes made here against some of the original code changes in #11127 - it appears that a merge conflict got incorrectly applied at some point.  There was originally proper inverted-range handling, but it got overwritten with code that couldn't properly handle it.

## User Testing

TEST_INVERTED_SELECTION_RANGE: Using Keyman for Android as a system keyboard, ensure that backwards selection ranges do not crash the keyboard.
- Select text, then drag one of the end points through and past the other one.
- If the keyboard immediately disappears, or you see an error notification, FAIL this test.