### PR TITLE
chore(linux): Fix typo

### DIFF
--- a/linux/keyman-config/tests/test_uninstall_kmp.py
+++ b/linux/keyman-config/tests/test_uninstall_kmp.py
@@ -317,4 +317,4 @@ class UninstallKmpCommonTests(unittest.TestCase):
         # Verify
         self.mockUninstallKeyboardsFromIbus.assert_called_once_with(keyboards, '/tmp/foo')
         self.mockUninstallDir.assert_called()
-        self.assertEquals(mockCustomKeyboardsInstance.remove.call_count, 2)
+        self.assertEqual(mockCustomKeyboardsInstance.remove.call_count, 2)


### PR DESCRIPTION
This suddenly started failing. I guess there was a deprecated `assertEquals` in older Python libraries, but with the latest version in Ubuntu 24.04 Noble this disappeared. Anyway, with this change we use the same assert method as in the other test files.

@keymanapp-test-bot skip