### PR TITLE
fix(web): support SVG elements when checking className

### DIFF
--- a/web/src/app/browser/src/context/pageIntegrationHandlers.ts
+++ b/web/src/app/browser/src/context/pageIntegrationHandlers.ts
@@ -122,10 +122,10 @@ export class PageIntegrationHandlers {
       // The following tests are needed to prevent the OSK from being hidden during normal input!
       let p=(e.target as HTMLElement).parentElement;
       if(typeof(p) != 'undefined' && p != null) {
-        if(p.className.indexOf('kmw-key-') >= 0) return false;
+        if(p.getAttribute('class')?.indexOf('kmw-key-') >= 0) return false;
         if(typeof(p.parentElement) != 'undefined' && p.parentElement != null) {
           p=p.parentElement;
-          if(p.className.indexOf('kmw-key-') >= 0) return false;
+          if(p.getAttribute('class')?.indexOf('kmw-key-') >= 0) return false;
         }
       }
 

--- a/web/src/app/browser/src/hardwareEventKeyboard.ts
+++ b/web/src/app/browser/src/hardwareEventKeyboard.ts
@@ -275,7 +275,7 @@ export default class HardwareEventKeyboard extends HardKeyboard {
 
     // Prevent mapping element is readonly or tagged as kmw-disabled
     const el = target.getElement();
-    if(el?.className?.indexOf('kmw-disabled') >= 0) {
+    if(el?.getAttribute('class')?.indexOf('kmw-disabled') >= 0) {
       return true;
     }
 


### PR DESCRIPTION
Fixes #11364.

Instead of using `className` which may be of type `SVGAnimatedString` if the element is an SVG element, use `getAttribute('class')`. As that function can return `null` if the class attribute is not defined, use optional chaining to avoid a new error...

Uses the same pattern in hardwareEventKeyboard.ts, although I suspect the problem may never arise there.

I audited the uses of className in our KeymanWeb source and found only these three instances which may be problematic. I have not searched elsewhere.

@keymanapp-test-bot skip