### PR TITLE
fix(android): prevents mid-keystroke desynchronization when deleting selected text

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -135,13 +135,13 @@ public class KMKeyboardJSHandler {
             end = temp;
           }
           if (end > start) {
+            k.setShouldIgnoreSelectionChange(true);
             if (s.length() == 0) {
               ic.setSelection(start, start);
               ic.deleteSurroundingText(0, end - start);
               ic.endBatchEdit();
               return;
             } else {
-              k.setShouldIgnoreSelectionChange(true);
               ic.setSelection(start, start);
               ic.deleteSurroundingText(0, end - start);
             }


### PR DESCRIPTION
Fixes #11337.

It turns out that in the middle of updating Android context after a keystroke, we were triggering a selection-change before the batch-edit process was complete - though only if there was selected text.  It's not clear why that one branch was left out of the "ignore selection change" mode, but including it is enough to fix the issue.

Refer to #8611 and #8682 for related historical context.

## User Testing

TEST_REPRO:  Using an up-to-date version of Android, attempt to reproduce the base issue (#11337).

2. Open Keyman In-app.
3. Type a sentence (eg., All things are beautiful)
4. Select the last word 'beautiful'.
5. Press Backspace key to delete that word.
6. Type the text 'ha..' (eg.,happen)

Verify that predictive text operates normally, instead of breaking as it did in #11337.