### PR TITLE
chore(web): Improve dependencies

### DIFF
--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -8,6 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 
 builder_describe "Build Keyman common file types module" \
+  "@/core/include/ldml" \
   "@/common/web/keyman-version" \
   "configure" \
   "build" \

--- a/common/web/types/package.json
+++ b/common/web/types/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/keymanapp/keyman/issues"
   },
   "dependencies": {
+    "@keymanapp/ldml-keyboard-constants": "*",
     "@keymanapp/keyman-version": "*",
     "restructure": "git+https://github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
     "semver": "^7.5.2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,6 +35,7 @@
       "@keymanapp/web-utils": ["./common/web/utils"],
       "@keymanapp/lm-message-types": ["./common/web/lm-message-types"],
       "@keymanapp/keyman-version": ["./common/web/keyman-version"],
+      "@keymanapp/ldml-keyboard-constants": [ "./core/include/ldml" ],
     }
   }
 }


### PR DESCRIPTION
This improves the dependency linking between core and web. Changes were made while tracking down a failure building wasm core. However, what made it work in the end was to clear the `developer` sub-directory, so I think we're still missing a dependency somewhere...

@keymanapp-test-bot skip