### PR TITLE
fix(android/engine): Skip updating selection range if invalid

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -185,6 +185,12 @@ final class KMKeyboard extends WebView {
       int selStart = icText.selectionStart;
       int selEnd = icText.selectionEnd;
 
+      if (selStart < 0 || selEnd < 0) {
+        // There is no selection or cursor
+        // Reference https://developer.android.com/reference/android/text/Selection#getSelectionEnd(java.lang.CharSequence)
+        return false;
+      }
+
       int selMin = selStart, selMax = selEnd;
       if (selStart > selEnd) {
         // Selection is reversed so "swap"


### PR DESCRIPTION
Fixes #11360

@mcdurdin went spelunking in the Android code and found `getSelectionStart()` and `getSelectionEnd()` return -1 if there's no selection or cursor.
Reference https://developer.android.com/reference/android/text/Selection#getSelectionEnd(java.lang.CharSequence

In those cases (likely a race condition), we should no-op on `updateSelectionRange()` since there's no valid selection to pass to KeymanWeb.

## User Testing (from #11360)
**Setup** - Install PR build of Keyman for Android and enable Keyman as the default system keyboard

* **TEST_INVERTED_SELECTION_RANGE**: Using Keyman for Android as a system keyboard, ensure that backwards selection ranges do not crash the keyboard.
1. Select text, then drag one of the end points through and past the other one.
2. If the keyboard immediately disappears, or you see an error notification, FAIL this test.