### PR TITLE
chore(common): Add `minimum-versions.md`

### DIFF
--- a/resources/build/minimum-versions.md
+++ b/resources/build/minimum-versions.md
@@ -2,7 +2,7 @@
 title: Keyman Minimum Versions
 ---
 
-This file reflects the minimum versions in Keyman as defined in [minimum-versions.inc.sh](minimum-versions.inc.sh). Updates should be manually propagated to the linked help files below:
+Changes in [minimum-versions.inc.sh](minimum-versions.inc.sh) should manually be propagated to the linked help files below:
 
 ## Keyman 18.0
 
@@ -10,54 +10,34 @@ Target Operating System and Platform Versions
 
 ### Keyman for Windows
 
-* Minimum supported version of Windows is 10 (KEYMAN_MIN_TARGET_VERSION_WINDOWS)
-
 Helpfile: [os.md](../../windows/src/desktop/help/common/os.md)
 
 ### Keyman for macOS
-
-* Minimum supported version of macOS is 10.13 (High Sierra - KEYMAN_MIN_TARGET_VERSION_MAC)
 
 Helpfile: [requirements.md](../../mac/help/about/requirements.md)
 
 ### Keyman for Linux
 
-* Minimum supported version of Linux is 20.04 (Ubuntu 20.04 Focal - KEYMAN_MIN_TARGET_VERSION_UBUNTU)
-
 Helpfile: [common/index.md](../../linux/help/common/index.md#q-what-linux-distros-will-keyman-work-with)
 
 ### Keyman iPhone and iPad
-
-* Minimum supported version of iOS is 12.2 (KEYMAN_MIN_TARGET_VERSION_IOS)
 
 Helpfile: [system-requirements.md](../../ios/help/about/system-requirements.md)
 
 ### Keyman for Android
 
-* Minimum supported version of Android is 5.0 (KEYMAN_MIN_TARGET_VERSION_ANDROID)
-
-* Minimum version of Chrome on Android is 95.0 (KEYMAN_MIN_TARGET_VERSION_CHROME)
-
 Helpfile: [system-requirements.md](../../android/help/about/system-requirements.md)
-
-### KeymanWeb
-
-* Minimum supported version of Chrome is 95.0 (??)
 
 ----
 
-### Minimum Dependency Versions for Developers
+## Product Build Documentation
 
-* Node 18 (MIN_NODE_MAJOR_VERSION)
-* Emscripten 3.1.44 (MIN_EMSCRIPTEN_VERSION)
-* Visual Studio 2019 (MIN_VISUAL_STUDIO_VERSION)
-* Meson 1.0.0 (MIN_MESON_VERSION)
-* Chrome 95.0 (MIN_CHROME_VERSION)
+[linux-ubuntu.md](../../docs/build/linux-ubuntu.md)
 
-### Language and Runtime Versions
+[macos.md](../../docs/build/macos.md)
 
-* Java/OpenJDK 11 (KEYMAN_MIN_VERSION_JAVA)
-* C++ 17 (KEYMAN_MIN_VERSION_CPP)
+[windows.md](../../docs/build/windows.md)
 
-* Ubuntu 24.04 Noble (DEFAULT_UBUNTU_VERSION)
+## Keyman Engine Documentation
 
+https://help.keyman.com/developer/engine/android/latest-version/

--- a/resources/build/minimum-versions.md
+++ b/resources/build/minimum-versions.md
@@ -1,0 +1,63 @@
+---
+title: Keyman Minimum Versions
+---
+
+This file reflects the minimum versions in Keyman as defined in [minimum-versions.inc.sh](minimum-versions.inc.sh). Updates should be manually propagated to the linked help files below:
+
+## Keyman 18.0
+
+Target Operating System and Platform Versions
+
+### Keyman for Windows
+
+* Minimum supported version of Windows is 10 (KEYMAN_MIN_TARGET_VERSION_WINDOWS)
+
+Helpfile: [os.md](../../windows/src/desktop/help/common/os.md)
+
+### Keyman for macOS
+
+* Minimum supported version of macOS is 10.13 (High Sierra - KEYMAN_MIN_TARGET_VERSION_MAC)
+
+Helpfile: [requirements.md](../../mac/help/about/requirements.md)
+
+### Keyman for Linux
+
+* Minimum supported version of Linux is 20.04 (Ubuntu 20.04 Focal - KEYMAN_MIN_TARGET_VERSION_UBUNTU)
+
+Helpfile: [common/index.md](../../linux/help/common/index.md#q-what-linux-distros-will-keyman-work-with)
+
+### Keyman iPhone and iPad
+
+* Minimum supported version of iOS is 12.2 (KEYMAN_MIN_TARGET_VERSION_IOS)
+
+Helpfile: [system-requirements.md](../../ios/help/about/system-requirements.md)
+
+### Keyman for Android
+
+* Minimum supported version of Android is 5.0 (KEYMAN_MIN_TARGET_VERSION_ANDROID)
+
+* Minimum version of Chrome on Android is 95.0 (KEYMAN_MIN_TARGET_VERSION_CHROME)
+
+Helpfile: [system-requirements.md](../../android/help/about/system-requirements.md)
+
+### KeymanWeb
+
+* Minimum supported version of Chrome is 95.0 (??)
+
+----
+
+### Minimum Dependency Versions for Developers
+
+* Node 18 (MIN_NODE_MAJOR_VERSION)
+* Emscripten 3.1.44 (MIN_EMSCRIPTEN_VERSION)
+* Visual Studio 2019 (MIN_VISUAL_STUDIO_VERSION)
+* Meson 1.0.0 (MIN_MESON_VERSION)
+* Chrome 95.0 (MIN_CHROME_VERSION)
+
+### Language and Runtime Versions
+
+* Java/OpenJDK 11 (KEYMAN_MIN_VERSION_JAVA)
+* C++ 17 (KEYMAN_MIN_VERSION_CPP)
+
+* Ubuntu 24.04 Noble (DEFAULT_UBUNTU_VERSION)
+


### PR DESCRIPTION
Follows #11380 and fixes #11372

This adds a ~human-readable~ `minimum-versions.md` document which cross-references documentation and help files affected by updates to `minimum-versions.inc.sh`.

@keymanapp-test-bot skip
