### PR TITLE
fix(mac): restore OSK keys that became invisible in mac OS 14 Sonoma

### DIFF
--- a/mac/Keyman4Mac/Keyman4Mac/AppDelegate.m
+++ b/mac/Keyman4Mac/Keyman4Mac/AppDelegate.m
@@ -8,6 +8,7 @@
 
 #import "AppDelegate.h"
 #import <KeymanEngine4Mac/KeymanEngine4Mac.h>
+#import <os/log.h>
 
 static BOOL debugMode = YES;
 
@@ -67,7 +68,9 @@ NSString *const kKMXFileKey = @"KMXFile";
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
-    [self.oskView resizeOSKLayout];
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "AppDelegate windowDidResize");
+   [self.oskView resizeOSKLayout];
 }
 
 - (BOOL)createEventTap {
@@ -205,7 +208,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
             [alert addButtonWithTitle:@"OK"];
             [alert setMessageText:@"Invalid KMX file"];
             [alert setInformativeText:@"This KMX file contains some invalid code!"];
-            [alert setAlertStyle:NSWarningAlertStyle];
+            [alert setAlertStyle:NSAlertStyleWarning];
             [alert runModal];
         }
         

--- a/mac/Keyman4Mac/Keyman4Mac/KMBarView.m
+++ b/mac/Keyman4Mac/Keyman4Mac/KMBarView.m
@@ -11,7 +11,7 @@
 @implementation KMBarView
 
 - (void)drawRect:(NSRect)rect {
-    CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
+    CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] CGContext];
     
     NSRect rect1 = NSMakeRect(0, 0, rect.size.width*0.56, rect.size.height);
     NSRect rect2 = NSMakeRect(rect1.size.width, 0, rect.size.width*0.23, rect.size.height);

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutBGView.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutBGView.m
@@ -30,9 +30,9 @@
 //    NSLog(@"topFill origin x %f y %f  size h %f w %f after raising to imgHeight %ld", topFill.origin.x, topFill.origin.y, topFill.size.height, topFill.size.width, imgOriginHeightDelta);
 //    NSLog(@"botFill origin x %f y %f  size h %f w %f after reducing by imgHeight %ld", botFill.origin.x, botFill.origin.y, botFill.size.height, botFill.size.width, imgOriginHeightDelta);
     [[NSColor whiteColor] setFill];
-    NSRectFillUsingOperation(topFill, NSCompositeSourceOver);
+    NSRectFillUsingOperation(topFill, NSCompositingOperationSourceOver);
     [[NSColor windowBackgroundColor] setFill];
-    NSRectFillUsingOperation(botFill, NSCompositeSourceOver);
+    NSRectFillUsingOperation(botFill, NSCompositingOperationSourceOver);
 }
 
 - (BOOL)mouseDownCanMoveWindow {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMBarView.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMBarView.m
@@ -11,7 +11,7 @@
 @implementation KMBarView
 
 - (void)drawRect:(NSRect)rect {
-    CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
+    CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] CGContext];
     
     NSRect rect1 = NSMakeRect(0, 0, rect.size.width*0.56, rect.size.height);
     NSRect rect2 = NSMakeRect(rect1.size.width, 0, rect.size.width*0.23, rect.size.height);

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -471,7 +471,7 @@
         [failure setMessageText:[NSString localizedStringWithFormat:errorString, kmpFile.lastPathComponent]];
 
         [failure setIcon:[[NSBundle mainBundle] imageForResource:@"logo.png"]];
-        [failure setAlertStyle:NSWarningAlertStyle];
+        [failure setAlertStyle:NSAlertStyleWarning];
         [failure beginSheetModalForWindow:self.window
                             modalDelegate:self
                            didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:)
@@ -534,7 +534,7 @@
         [_deleteAlertView setInformativeText:NSLocalizedString(@"info-cannot-undo-delete-keyboard", nil)];
         [_deleteAlertView addButtonWithTitle:NSLocalizedString(@"button-delete-keyboard", nil)];
         [_deleteAlertView addButtonWithTitle:NSLocalizedString(@"button-cancel-delete-keyboard", nil)];
-        [_deleteAlertView setAlertStyle:NSWarningAlertStyle];
+        [_deleteAlertView setAlertStyle:NSAlertStyleWarning];
         [_deleteAlertView setIcon:[[NSBundle mainBundle] imageForResource:@"logo.png"]];
     }
     
@@ -547,7 +547,7 @@
         [_confirmKmpInstallAlertView addButtonWithTitle:NSLocalizedString(@"button-install-keyboard", nil)];
         [_confirmKmpInstallAlertView addButtonWithTitle:NSLocalizedString(@"button-cancel-install-keyboard", nil)];
         [_confirmKmpInstallAlertView setMessageText:NSLocalizedString(@"message-confirm-install-keyboard", nil)];
-        [_confirmKmpInstallAlertView setAlertStyle:NSInformationalAlertStyle];
+        [_confirmKmpInstallAlertView setAlertStyle:NSAlertStyleInformational];
         [_confirmKmpInstallAlertView setIcon:[[NSBundle mainBundle] imageForResource:@"logo.png"]];
     }
     

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -216,7 +216,7 @@
         [textField setEditable:NO];
         [textField setBordered:NO];
         [textField setBackgroundColor:[NSColor clearColor]];
-        [textField setAlignment:NSLeftTextAlignment];
+      [textField setAlignment:NSTextAlignmentLeft];
         [textField setFont:[NSFont systemFontOfSize:tableView.rowHeight*0.5]];
         [textField setTextColor:[NSColor colorWithSRGBRed:0.0 green:0.0 blue:0.1 alpha:1.0]];
         [textField setStringValue:[info objectForKey:@"HeaderTitle"]];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -224,12 +224,7 @@ NSString* _keymanDataPath = nil;
                 _downloadFilename = [NSString stringWithString:[value substringFromIndex:index+9]];
             else if ((index = [value rangeOfString:@"url="].location) != NSNotFound) {
                 NSString *urlString = [NSString stringWithString:[value substringFromIndex:index+4]];
-                if ([urlString respondsToSelector:@selector(stringByRemovingPercentEncoding)])
-                    urlString = [urlString stringByRemovingPercentEncoding];
-                else if ([urlString respondsToSelector:@selector(stringByReplacingPercentEscapesUsingEncoding:)]) {
-                    // OS version prior to 10.9 - use this (now deprecated) method instead:
-                    urlString = [urlString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-                }
+                urlString = [urlString stringByRemovingPercentEncoding];
                 downloadUrl = [NSURL URLWithString:urlString];
             }
         }
@@ -1161,7 +1156,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
         [_downloadInfoView setMessageText:NSLocalizedString(@"message-keyboard-downloading", nil)];
         [_downloadInfoView setInformativeText:@""];
         [_downloadInfoView addButtonWithTitle:NSLocalizedString(@"button-cancel-downloading", nil)];
-        [_downloadInfoView setAlertStyle:NSInformationalAlertStyle];
+        [_downloadInfoView setAlertStyle:NSAlertStyleInformational];
         [_downloadInfoView setAccessoryView:self.progressIndicator];
     }
 

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -119,7 +119,7 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
 - (CoreKeyOutput*) processEventWithKeymanEngine:(NSEvent *)event in:(id) sender {
   CoreKeyOutput* coreKeyOutput = nil;
   if (self.appDelegate.lowLevelEventTap != nil) {
-      NSEvent *eventWithOriginalModifierFlags = [NSEvent keyEventWithType:event.type location:event.locationInWindow modifierFlags:self.appDelegate.currentModifierFlags timestamp:event.timestamp windowNumber:event.windowNumber context:event.context characters:event.characters charactersIgnoringModifiers:event.charactersIgnoringModifiers isARepeat:event.isARepeat keyCode:event.keyCode];
+      NSEvent *eventWithOriginalModifierFlags = [NSEvent keyEventWithType:event.type location:event.locationInWindow modifierFlags:self.appDelegate.currentModifierFlags timestamp:event.timestamp windowNumber:event.windowNumber context:[NSGraphicsContext currentContext] characters:event.characters charactersIgnoringModifiers:event.charactersIgnoringModifiers isARepeat:event.isARepeat keyCode:event.keyCode];
       coreKeyOutput = [self.kme processEvent:eventWithOriginalModifierFlags];
       [self.appDelegate logDebugMessage:@"processEventWithKeymanEngine, using AppDelegate.currentModifierFlags %lu, instead of event.modifiers = %lu", (unsigned long)self.appDelegate.currentModifierFlags, (unsigned long)event.modifierFlags];
   }
@@ -223,7 +223,7 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
   // mouse movement requires that the context be invalidated
   [self handleContextChangedByLowLevelEvent];
 
-  if (event.type == NSKeyDown) {
+  if (event.type == NSEventTypeKeyDown) {
     // indicates that our generated backspace event(s) are consumed
     // and we can insert text that followed the backspace(s)
     if (event.keyCode == kKeymanEventKeyCode) {
@@ -253,7 +253,7 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
     return NO; // let the client app handle all Command-key events.
   }
 
-  if (event.type == NSKeyDown) {
+  if (event.type == NSEventTypeKeyDown) {
     [self reportContext:event forClient:sender];
     handled = [self handleEventWithKeymanEngine:event in: sender];
   }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KeySender.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KeySender.m
@@ -69,14 +69,13 @@ const CGKeyCode kKeymanEventKeyCode = 0xFF;
   NSRunningApplication *app = NSWorkspace.sharedWorkspace.frontmostApplication;
   pid_t processId = app.processIdentifier;
   NSString *bundleId = app.bundleIdentifier;
-  GetProcessForPID(processId, &psn);
   
   [self.appDelegate logDebugMessage:@"sendKeymanKeyCodeForEvent keyCode %lu to app %@ with pid %d", (unsigned long)kKeymanEventKeyCode, bundleId, processId];
   
   // use nil as source, as this generated event is not directly tied to the originating event
   CGEventRef keyDownEvent = CGEventCreateKeyboardEvent(nil, kKeymanEventKeyCode, true);
 
-  CGEventPostToPSN(&psn, keyDownEvent);
+  CGEventPostToPid(processId, keyDownEvent);
   CFRelease(keyDownEvent);
   
   // this is not a real keycode, so we do not need a key up event

--- a/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
@@ -43,7 +43,7 @@
         _helpButton = helpBtn;
         [_helpButton setTitle:@""];
         [_helpButton setBezelStyle:NSHelpButtonBezelStyle];
-        [_helpButton setControlSize:NSMiniControlSize];
+        [_helpButton setControlSize:NSControlSizeMini];
         [_helpButton setAction:@selector(helpAction:)];
         [_helpButton setEnabled:[self hasHelpDocumentation]];
         [self.window addViewToTitleBar:_helpButton positionX:NSWidth(self.window.frame) - NSWidth(_helpButton.frame) -10];

--- a/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
@@ -8,6 +8,7 @@
 
 #import "OSKWindowController.h"
 #import "KMInputMethodAppDelegate.h"
+#import <os/log.h>
 
 @interface OSKWindowController ()
 @property (nonatomic, strong) NSButton *helpButton;
@@ -29,6 +30,8 @@
 }
 
 - (void)awakeFromNib {
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKWC awakeFromNib");
     // Keep the aspect ratio constant at its current value
     [self.window setAspectRatio:self.window.frame.size];
     NSSize size = self.window.frame.size;
@@ -51,6 +54,8 @@
 }
 
 - (void)windowDidLoad {
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKWC windowDidLoad");
     [super windowDidLoad];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowDidResize:) name:NSWindowDidResizeNotification object:self.window];
     [self.oskView setKvk:[self.AppDelegate kvk]];
@@ -59,6 +64,8 @@
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKWC windowDidResize");
     [self.oskView resizeOSKLayout];
 }
 
@@ -80,6 +87,8 @@
 }
 
 - (void)resetOSK {
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKWC windowDidLoad");
     [self.oskView setKvk:[self.AppDelegate kvk]];
     [self.oskView resetOSK];
     if (_helpButton) {

--- a/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.xib
+++ b/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9059" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="OSKWindowController">
@@ -13,16 +14,16 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Keyman" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" animationBehavior="default" id="F0z-JX-Cv5">
+        <window title="Keyman" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="614" height="212"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
-            <view key="contentView" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="1" width="614" height="212"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
+            <view key="contentView" clipsToBounds="YES" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="614" height="212"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="UaK-0H-MfR" customClass="OSKView">
+                    <customView clipsToBounds="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UaK-0H-MfR" customClass="OSKView">
                         <rect key="frame" x="5" y="5" width="604" height="202"/>
                     </customView>
                 </subviews>

--- a/mac/Keyman4MacIM/Keyman4MacIM/main.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/main.m
@@ -23,7 +23,7 @@ int main(int argc, const char * argv[]) {
       
         BOOL didLoadNib = [[NSBundle mainBundle] loadNibNamed:@"MainMenu" owner:[NSApplication sharedApplication] topLevelObjects: nil];
       
-      os_log_with_type(configLog, OS_LOG_TYPE_INFO, "main Did load MainMenu nib: %@", didLoadNib?@"YES":@"NO");
+        os_log_with_type(configLog, OS_LOG_TYPE_DEBUG, "main Did load MainMenu nib: %@", didLoadNib?@"YES":@"NO");
 
         [[NSApplication sharedApplication] run];
     }

--- a/mac/Keyman4MacIM/Keyman4MacIM/main.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/main.m
@@ -8,16 +8,23 @@
 
 #import <Cocoa/Cocoa.h>
 #import <InputMethodKit/InputMethodKit.h>
+#import <os/log.h>
 
 const NSString *kConnectionName = @"Keyman_Input_Connection";
 IMKServer *server;
 
 int main(int argc, const char * argv[]) {
     NSString *identifier;
+    os_log_t configLog = os_log_create("org.sil.keyman", "startup");
+  
     @autoreleasepool {
         identifier = [[NSBundle mainBundle] bundleIdentifier];
         server = [[IMKServer alloc] initWithName:(NSString *)kConnectionName bundleIdentifier:identifier];
-        [NSBundle loadNibNamed:@"MainMenu" owner:[NSApplication sharedApplication]];
+      
+        BOOL didLoadNib = [[NSBundle mainBundle] loadNibNamed:@"MainMenu" owner:[NSApplication sharedApplication] topLevelObjects: nil];
+      
+      os_log_with_type(configLog, OS_LOG_TYPE_INFO, "main Did load MainMenu nib: %@", didLoadNib?@"YES":@"NO");
+
         [[NSApplication sharedApplication] run];
     }
     return 0;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreKeyOutput.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreKeyOutput.m
@@ -32,7 +32,6 @@
 
 -(NSString *)description
 {
-  NSString* str = @"teststring";
   NSData* data = [self.textToInsert dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
 
   return [[NSString alloc] initWithFormat: @"codePointsToDeleteBeforeInsert: %li, textToInsert: '%@', optionsToPersist: %@, alert: %d, emitKeystroke: %d, capsLockState: %d ", self.codePointsToDeleteBeforeInsert, data, self.optionsToPersist, self.alert, self.emitKeystroke, self.capsLockState];

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -48,7 +48,7 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
         [_label setEditable:NO];
         [_label setBordered:NO];
         [_label setDrawsBackground:NO];
-        [_label setAlignment:NSCenterTextAlignment];
+        [_label setAlignment:NSTextAlignmentCenter];
         if ([_caption respondsToSelector:@selector(setLineBreakMode:)]) {
             [_label setLineBreakMode:NSLineBreakByClipping];
         } // There might be some problem not calling this, but it seems to be okay as far as I can tell
@@ -69,7 +69,7 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
 
 - (void)drawRect:(NSRect)rect {
     [[self getOpaqueColorWithRed:241 green:242 blue:242] setFill];
-    NSRectFillUsingOperation(rect, NSCompositeSourceOver);
+    NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
 
     // Drawing code here.
     CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
@@ -238,7 +238,7 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
         [_caption setBordered:NO];
         [_caption setDrawsBackground:NO];
         //[_caption setBackgroundColor:[NSColor yellowColor]];
-        [_caption setAlignment:NSLeftTextAlignment];
+        [_caption setAlignment:NSTextAlignmentLeft];
         if ([_caption respondsToSelector:@selector(setLineBreakMode:)]) {
             [_caption setLineBreakMode:NSLineBreakByClipping];
         } // There might be some problem not calling this, but it seems to be okay as far as I can tell

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -10,6 +10,7 @@
 #import "KeyLabel.h"
 #import "MacVKCodes.h"
 #import "TimerTarget.h"
+#import <os/log.h>
 
 CGFloat lw = 1.0;
 CGFloat r = 7.0;
@@ -27,20 +28,22 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
 @property (nonatomic, assign) BOOL isCharacterKey;
 @property (nonatomic, strong) KeyLabel *label;
 @property (nonatomic, strong) NSTextField *caption;
-@property (nonatomic, strong) NSImageView *bitmapView;
-@property (nonatomic, strong) NSColor *bgColor1;
-@property (nonatomic, strong) NSColor *bgColor2;
+@property (nonatomic, strong) NSColor *bgColorRegularKey;
+@property (nonatomic, strong) NSColor *bgColorSpecialKey;
 @property (nonatomic, strong) NSTimer *keyEventTimer;
 @property (readwrite) NSInteger tag;
 @end
 
 @implementation KeyView
 @synthesize tag;
-@synthesize bgColor1, bgColor2;
+@synthesize bgColorRegularKey, bgColorSpecialKey;
 
 - (id)initWithFrame:(NSRect)frame {
+    os_log_t oskKeyLog = os_log_create("org.sil.keyman", "osk-key");
     self = [super initWithFrame:frame];
     if (self) {
+        os_log_with_type(oskKeyLog, OS_LOG_TYPE_DEBUG, "KeyView initWithFrame: %{public}@, bounds: %{public}@, default clipsToBounds %{public}@", NSStringFromRect(frame), NSStringFromRect(self.bounds), self.clipsToBounds?@"YES":@"NO");
+        self.clipsToBounds = true;
         CGSize size = frame.size;
         CGFloat x = size.width*0.05;
         NSRect labelFrame = NSMakeRect(x, 0, size.width -lw -2*x, size.height);
@@ -60,22 +63,26 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
         [_label setLineBreakMode:NSLineBreakByClipping];
         [self addSubview:_label];
 
-        bgColor1 = [self getOpaqueColorWithRed:209 green:211 blue:212];
-        bgColor2 = [self getOpaqueColorWithRed:166 green:169 blue:172];
+        bgColorRegularKey = [self getOpaqueColorWithRed:209 green:211 blue:212];
+        bgColorSpecialKey = [self getOpaqueColorWithRed:166 green:169 blue:172];
     }
 
     return self;
 }
 
 - (void)drawRect:(NSRect)rect {
+    os_log_t oskKeyLog = os_log_create("org.sil.keyman", "osk-key");
+    os_log_with_type(oskKeyLog, OS_LOG_TYPE_DEBUG, "KeyView drawRect: %{public}@, bounds: %{public}@, keyCode: 0x%lx, caption: %{public}@, label: %{public}@", NSStringFromRect(rect), NSStringFromRect(self.bounds), self.keyCode, self.caption.stringValue, self.label.stringValue);
+  
     [[self getOpaqueColorWithRed:241 green:242 blue:242] setFill];
     NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);
 
     // Drawing code here.
-    CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
+    CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] CGContext];
+
     CGContextSetLineJoin(context, kCGLineJoinRound);
     CGContextSetLineWidth(context, lw);
-    CGContextSetStrokeColorWithColor(context, bgColor1.CGColor);
+    CGContextSetStrokeColorWithColor(context, bgColorRegularKey.CGColor);
 
     CGFloat x = rect.origin.x + lw;
     CGFloat y = rect.origin.y + lw;
@@ -100,10 +107,10 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
     CGContextClosePath(context);
     CGContextClip(context);
 
-    NSColor *bgColor = bgColor1;
+    NSColor *bgColor = bgColorRegularKey;
 
     if ([self isSpecialKey])
-        bgColor = bgColor2;
+        bgColor = bgColorSpecialKey;
 
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     CGFloat gradientLocations[] = {0, 1};
@@ -325,26 +332,18 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
 - (void)setKeyPressed:(BOOL)keyPressed {
     _keyPressed = keyPressed;
     if (keyPressed) {
-        bgColor1 = [self getOpaqueColorWithRed:109 green:111 blue:112];
-        bgColor2 = [self getOpaqueColorWithRed:236 green:239 blue:242];
+        bgColorRegularKey = [self getOpaqueColorWithRed:109 green:111 blue:112];
+        bgColorSpecialKey = [self getOpaqueColorWithRed:236 green:239 blue:242];
         [self setNeedsDisplay:YES];
     }
     else {
-        bgColor1 = [self getOpaqueColorWithRed:209 green:211 blue:212];
-        bgColor2 = [self getOpaqueColorWithRed:166 green:169 blue:172];
+        bgColorRegularKey = [self getOpaqueColorWithRed:209 green:211 blue:212];
+        bgColorSpecialKey = [self getOpaqueColorWithRed:166 green:169 blue:172];
         [self setNeedsDisplay:YES];
     }
 }
 
 - (NSColor *)getOpaqueColorWithRed:(NSUInteger) red green: (NSUInteger) green blue: (NSUInteger) blue {
-    // RGB is what was in the code originally I can't tell any difference between that and SRGB for the
-    // colors we're using in the OSK, but at the risk of causing an unintended change, I'm leaving it as
-    // it was for versions of macOS that support colorWithRed:green:blue:
-    if ([NSColor respondsToSelector:@selector(colorWithRed:green:blue:alpha:)]) {
-        return [NSColor colorWithRed:red/255.0 green:green/255.0 blue:blue/255.0 alpha:1.0];
-    }
-    else {
         return [NSColor colorWithSRGBRed:red/255.0 green:green/255.0 blue:blue/255.0 alpha:1.0];
-    }
 }
 @end

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKKey.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKKey.m
@@ -7,12 +7,15 @@
 //
 
 #import "OSKKey.h"
+#import <os/log.h>
 
 @implementation OSKKey
 
 - (id)initWithKeyCode:(NSUInteger)keyCode caption:(NSString *)caption scale:(CGFloat)scale {
     self = [super init];
     if (self) {
+        os_log_t oskKeyLog = os_log_create("org.sil.keyman", "osk-key");
+      os_log_with_type(oskKeyLog, OS_LOG_TYPE_DEBUG, "OSKKey initWithKeyCode: 0x%lx, caption: %{public}@, scale: %f", keyCode, caption, scale);
         _keyCode = keyCode;
         
         if (caption == nil)

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
@@ -403,8 +403,8 @@
     KeyView *keyView = (KeyView *)sender;
     NSUInteger keyCode = [keyView.key keyCode];
     if (keyCode < 0x100) {
-        ProcessSerialNumber psn;
-        GetFrontProcess(&psn);
+        NSRunningApplication *app = NSWorkspace.sharedWorkspace.frontmostApplication;
+        pid_t processId = app.processIdentifier;
         CGEventSourceRef source = CGEventSourceCreate(kCGEventSourceStatePrivate);
         CGEventRef keyDownEvent = CGEventCreateKeyboardEvent(source, (CGKeyCode)keyCode, true);
         CGEventRef keyUpEvent = CGEventCreateKeyboardEvent(source, (CGKeyCode)keyCode, false);
@@ -420,8 +420,8 @@
             CGEventSetFlags(keyDownEvent, CGEventGetFlags(keyDownEvent) | kCGEventFlagMaskControl);
             CGEventSetFlags(keyUpEvent, CGEventGetFlags(keyUpEvent) | kCGEventFlagMaskControl);
         }
-        CGEventPostToPSN(&psn, keyDownEvent);
-        CGEventPostToPSN(&psn, keyUpEvent);
+        CGEventPostToPid(processId, keyDownEvent);
+        CGEventPostToPid(processId, keyUpEvent);
         CFRelease(source);
         CFRelease(keyDownEvent);
         CFRelease(keyUpEvent);
@@ -445,7 +445,7 @@
         return;
     
     KeyView *keyView = (KeyView *)view;
-    if (event.type == NSKeyDown)
+    if (event.type == NSEventTypeKeyDown)
         [keyView setKeyPressed:YES];
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(setKeyPressedOff:) object:keyView];
     [self performSelector:@selector(setKeyPressedOff:) withObject:keyView afterDelay:0.1];

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
@@ -16,6 +16,7 @@
 #import "CoreHelper.h"
 
 #include <Carbon/Carbon.h>
+#import <os/log.h>
 
 @interface OSKView()
 @property (nonatomic, strong) NSArray *oskLayout;
@@ -32,6 +33,8 @@
 @synthesize tag;
 
 - (id)initWithFrame:(NSRect)frame {
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView initWithFrame: %{public}@", NSStringFromRect(frame));
     self = [super initWithFrame:frame];
     if (self) {
         // Custom initialization
@@ -42,7 +45,10 @@
 }
 
 - (void)drawRect:(NSRect)rect {
-    CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] graphicsPort];
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView drawRect: %{public}@", NSStringFromRect(rect));
+
+    CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] CGContext];
     CGContextSetLineJoin(context, kCGLineJoinRound);
     CGContextSetLineWidth(context, 1.0);
     CGColorRef cgClearColor = CGColorGetConstantColor(kCGColorClear);
@@ -57,9 +63,10 @@
     CGContextAddRect(context, CGRectMake(1.0, 1.0, rect.size.width-1.0, rect.size.height-1.0));
     CGContextClip(context);
     
+    //TODO: gradient from clear to clear -- what does this do?
     NSColor *bgColor = [NSColor clearColor]; //[NSColor colorWithWhite:0.7 alpha:1.0];
     NSColor *bgColor2 = [NSColor clearColor]; //[NSColor colorWithWhite:0.5 alpha:1.0];
-    
+
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     NSArray *gradientColors = [NSArray arrayWithObjects:(id)bgColor.CGColor, bgColor2.CGColor, nil];
     CGFloat gradientLocations[] = {0, 1};
@@ -97,6 +104,8 @@
 }
 
 - (void)setKvk:(KVKFile *)kvk {
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView setKvk, forces keyboard to re-layout");
     _kvk = kvk;
 
     // Force the keyboard to re-layout
@@ -107,6 +116,8 @@
 }
 
 - (void)initOSKKeys {
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView initOSKKeys");
     CGFloat viewWidth = self.frame.size.width;
     CGFloat viewHeight = self.frame.size.height;
     CGFloat margin = 2.0;
@@ -141,6 +152,8 @@
 
 - (NSArray *)oskLayout {
     if (_oskLayout == nil) {
+        os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+        os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "oskLayout -> creating new arrays of OSKKey objects");
         NSArray *row1 = [NSArray arrayWithObjects:
                          [[OSKKey alloc] initWithKeyCode:MVK_GRAVE caption:@"`" scale:1.0],
                          [[OSKKey alloc] initWithKeyCode:MVK_1 caption:@"1" scale:1.0],
@@ -225,6 +238,8 @@
 
 - (NSArray *)oskDefaultNKeys {
     if (_oskDefaultNKeys == nil) {
+        os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+        os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "oskDefaultNKeys -> creating new arrays of default number OSKKey objects");
         NSMutableArray *defNKeys = [[NSMutableArray alloc] initWithCapacity:0];
         
         // row 1
@@ -395,6 +410,8 @@
 }
 
 - (void)resizeOSKLayout {
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView resizeOSKLayout, removing all superviews");
     [self.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
     [self initOSKKeys];
 }
@@ -402,6 +419,8 @@
 - (void)keyAction:(id)sender {
     KeyView *keyView = (KeyView *)sender;
     NSUInteger keyCode = [keyView.key keyCode];
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView keyAction keyCode: 0x%lx", keyCode);
     if (keyCode < 0x100) {
         NSRunningApplication *app = NSWorkspace.sharedWorkspace.frontmostApplication;
         pid_t processId = app.processIdentifier;
@@ -440,6 +459,8 @@
 }
 
 - (void)handleKeyEvent:(NSEvent *)event {
+    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
+    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView handleKeyEvent event.type: %lu", event.type);
     NSView *view = [self viewWithTag:event.keyCode|0x1000];
     if (view == nil || ![view isKindOfClass:[KeyView class]])
         return;
@@ -624,7 +645,7 @@
 }
 
 - (void)setOskCtrlState:(BOOL)oskCtrlState {
-    if (_oskCtrlState != oskCtrlState && !self.ctrlState) {
+   if (_oskCtrlState != oskCtrlState && !self.ctrlState) {
         _oskCtrlState = oskCtrlState;
         KeyView *ctrlKeyL = (KeyView *)[self viewWithTag:MVK_LEFT_CTRL|0x1000];
         KeyView *ctrlKeyR = (KeyView *)[self viewWithTag:MVK_RIGHT_CTRL|0x1000];


### PR DESCRIPTION
According to [AppKit Release Notes for macOS 14](https://developer.apple.com/documentation/macos-release-notes/appkit-release-notes-for-macos-14#NSView) the property NSView.clipsToBounds which was defaulted to true was changed to default to false. This caused the Keyman OSK keys to not be drawn correctly under Sonoma, giving the appearance of a blank OSK. This change is to override the new default behavior and set the property back to true.

Fixes #11379 

Also, with the move to Xcode 15.3, there are several APIs called from Keyman for Mac that were deprecated before our minimum supported version of macOS (now set to 10.13). These can be replaced without doing version checks because the replacements are available for all of our supported OS versions. It was suspected that these may have caused the OSK issue, but they had no effect.

To support the debugging of the OSK issue, log statements were also added using the Unified Logging API for which we now have support in our minimum target version of macOS.

# User Testing

* **TEST_OSK_KEYS_VISIBLE**: confirm that the OSK looks as expected

1. Select On-screen Keyboard from the Keyman menu 
1. Confirm that the keyboard is not blank but populated with dozens of keys as expected

* **TEST_OSK_VIEW_RESIZABLE**: confirm that the OSK is resizable

1. Select On-screen Keyboard from the Keyman menu 
1. Resize the OSK
1. Confirm that the keys resize appropriately and are still visible
