### PR TITLE
feat(web): custom infrastructure for @web/test-runner use 🏃

### DIFF
--- a/common/test/resources/test-runner-TC-reporter.mjs
+++ b/common/test/resources/test-runner-TC-reporter.mjs
@@ -27,7 +27,7 @@ export default function teamcityReporter({ name="Web Test Runner JavaScript test
     return text
       .replace(/\|/g, '||')
       .replace(/\[/g, '|[')
-      .replace(/]/g, '|]')
+      .replace(/\]/g, '|]')
       .replace(/\'/g, '|\'');
   }
 
@@ -75,7 +75,7 @@ export default function teamcityReporter({ name="Web Test Runner JavaScript test
           logger.log(`##teamcity[testFailed name='${e(test.name)}' ${e(message)}] ${e(details)}']`);
         }
 
-        logger.log(`##teamcity[testFinished name='${e(test.name)}' duration='${e(test.duration)}']`);
+        logger.log(`##teamcity[testFinished name='${e(test.name)}' duration='${e(test.duration ?? 0)}']`);
       }
     }
     for(const suite of suiteResult?.suites ?? []) {
@@ -169,18 +169,6 @@ export default function teamcityReporter({ name="Web Test Runner JavaScript test
           }
         }
       }
-
-      // To consider:  could link in coverage reports via
-      // https://www.jetbrains.com/help/teamcity/service-messages.html#Reporting+Build+Statistics
-      // (is what my sources narrow down to)
-      // Can hard-link in the statistics numbers.
-      // There are other ways to at least "attach" the coverage map if desired, I think.
-      // https://www.jetbrains.com/help/teamcity/including-third-party-reports-in-the-build-results.html
-      // (ooh, custom tab!?  ... via artifact HTML)
-      const testCoverage = args.testCoverage;
-      if(testCoverage) {
-        console.log(testCoverage?.coverageMap.toJSON());
-      }
     },
     reportTestFileResults({logger, sessionsForTestFile, testFile}) {
       if(!reportResults) {
@@ -194,7 +182,7 @@ export default function teamcityReporter({ name="Web Test Runner JavaScript test
 
       const repoPath = path.relative(rootDir, testFile);
 
-      logger.log(`##teamcity[testSuiteStarted name='${e(repoPath)}']`);
+      logger.log(`##teamcity[testSuiteStarted name='file ${e(repoPath)}']`);
       for(let session of sessionsForTestFile) {
         const sessionName = buildSessionName(session);
         logger.log(`##teamcity[testSuiteStarted name='${e(sessionName)}']`);

--- a/common/test/resources/test-runner-TC-reporter.mjs
+++ b/common/test/resources/test-runner-TC-reporter.mjs
@@ -1,0 +1,115 @@
+import path from 'path';
+
+// Yay for references!
+// https://www.jetbrains.com/help/teamcity/service-messages.html#Supported+Test+ServiceMessages
+// https://modern-web.dev/docs/test-runner/reporters/write-your-own/
+export default function teamcityReporter({ name="Web Test Runner JavaScript testing", reportResults = true, reportProgress = false } = {}) {
+  /** @type {Map<import('@web/test-runner').BrowserLauncher, number>} */
+  let browserFlowIdMap = new Map();
+  /** @type {import('@web/test-runner').Logger} */
+  let logger;
+
+  /** @type {string} */
+  let rootDir;
+
+  /**
+   * @param {import('@web/test-runner').Logger} logger
+   * @param {import('@web/test-runner').TestSuiteResult} suiteResult
+   * @param {number=} flowId Not actually used... but the pattern may prove very useful for custom naming in the reports.
+   */
+  const generateSuiteReport = (logger, suiteResult, flowId) => {
+    // TODO:  have seen in some outputs:  [, ] escaped by |.
+    // Need to check re: ' and | as well, since formatting will matter.
+    // Also need to check \n.
+
+    if(suiteResult.name) {
+      logger.log(`##teamcity[testSuiteStarted name='${suiteResult.name}']`);
+    }
+    for(const test of suiteResult?.tests ?? []) {
+      if(test.skipped) {
+        logger.log(`##teamcity[testIgnored name='${test.name}']`);
+      } else {
+        logger.log(`##teamcity[testStarted name='${test.name}' captureStandardOutput='true']`);
+        if(!test.passed) {
+          const message = test.error ? `message='${test.error.message}'` : '';
+          const details = test.error ? `\ndetails='${test.error.stack}\n`: '';
+
+          if(test.error?.actual !== undefined && test.error?.expected !== undefined) {
+            logger.log(`##teamcity[testFailed type='comparisonFailure' name='${test.name}' ${message}] ${details} expected='${test.error?.expected}' actual='${test.error?.actual}']`);
+          }
+          logger.log(`##teamcity[testFailed name='${test.name}' ${message}] ${details}']`);
+        }
+        logger.log(`##teamcity[testFinished name='${test.name}' duration='${test.duration}']`);
+      }
+    }
+    for(const suite of suiteResult?.suites ?? []) {
+      generateSuiteReport(logger, suite, flowId);
+    }
+    if(suiteResult.name) {
+      logger.log(`##teamcity[testSuiteFinished name='${suiteResult.name}']`);
+    }
+  }
+
+  /** @type {import('@web/test-runner').Reporter} */
+  const reporter = {
+    start({browsers, config}) {
+      rootDir = config.rootDir;
+      const existingIds = Array.from(browserFlowIdMap.values());
+
+      for(const browser of browsers) {
+        /** @type {number} */
+        let flowId;
+        do {
+        flowId = Math.floor(Math.random() * 1e9);
+        } while(existingIds.find((val) => val == flowId));
+
+        browserFlowIdMap.set(browser, flowId);
+      }
+
+      logger = config.logger;
+      logger.log(`##teamcity[blockOpened name='${name}']`);
+    },
+    stop({testCoverage}) {
+      logger.log(`##teamcity[blockClosed name='${name}']`);
+
+      // To consider:  could link in coverage reports via
+      // https://www.jetbrains.com/help/teamcity/service-messages.html#Reporting+Build+Statistics
+      // (is what my sources narrow down to)
+      // Can hard-link in the statistics numbers.
+      // There are other ways to at least "attach" the coverage map if desired, I think.
+      // https://www.jetbrains.com/help/teamcity/including-third-party-reports-in-the-build-results.html
+      // (ooh, custom tab!?  ... via artifact HTML)
+      if(testCoverage) {
+        console.log(testCoverage?.coverageMap.toJSON());
+      }
+    },
+    reportTestFileResults({logger, sessionsForTestFile, testFile}) {
+      if(!reportResults) {
+        return;
+      }
+
+      // Add extra "suite" layers:  testFile (filename), then group-browser.
+
+      // What is TC's "flowId" bit for?  [Answer: resolving asynchronous text output -
+      // which mattered for BrowserStack.  @web/test-runner handles that for us.]
+
+      const repoPath = path.relative(rootDir, testFile);
+
+      logger.log(`##teamcity[testSuiteStarted name='${repoPath}']`);
+      for(let session of sessionsForTestFile) {
+        const sessionName = `${session.group.name} - ${session.browser.name}`;
+        logger.log(`##teamcity[testSuiteStarted name='${sessionName}']`);
+
+        const results = session.testResults;
+        if(results) {
+          generateSuiteReport(logger, results, browserFlowIdMap.get(session.browser));
+        }
+
+        logger.log(`##teamcity[testSuiteFinished name='${sessionName}']`);
+      }
+      logger.log(`##teamcity[testSuiteFinished name='file ${repoPath}']`);
+    }
+  };
+
+  return reporter;
+}

--- a/common/test/resources/test-runner-TC-reporter.mjs
+++ b/common/test/resources/test-runner-TC-reporter.mjs
@@ -91,6 +91,11 @@ export default function teamcityReporter({ name="Web Test Runner JavaScript test
     return summary;
   }
 
+  /**
+   * @param {import('@web/test-runner').BasicTestSession} session
+   */
+  const buildSessionName = (session) => `${session.group.name} - ${session.browser.name}`;
+
   /** @type {import('@web/test-runner').Reporter} */
   const reporter = {
     start({browsers, config, sessions}) {
@@ -114,7 +119,7 @@ export default function teamcityReporter({ name="Web Test Runner JavaScript test
       logger = config.logger;
       logger.log(`##teamcity[blockOpened name='${e(name)}']`);
     },
-    stop({testCoverage}) {
+    stop(args) {
       logger.log(`##teamcity[blockClosed name='${e(name)}']`);
 
       // If there are failures, what can we report about the cause of failures?
@@ -172,6 +177,7 @@ export default function teamcityReporter({ name="Web Test Runner JavaScript test
       // There are other ways to at least "attach" the coverage map if desired, I think.
       // https://www.jetbrains.com/help/teamcity/including-third-party-reports-in-the-build-results.html
       // (ooh, custom tab!?  ... via artifact HTML)
+      const testCoverage = args.testCoverage;
       if(testCoverage) {
         console.log(testCoverage?.coverageMap.toJSON());
       }
@@ -190,7 +196,7 @@ export default function teamcityReporter({ name="Web Test Runner JavaScript test
 
       logger.log(`##teamcity[testSuiteStarted name='${e(repoPath)}']`);
       for(let session of sessionsForTestFile) {
-        const sessionName = `${session.group.name} - ${session.browser.name}`;
+        const sessionName = buildSessionName(session);
         logger.log(`##teamcity[testSuiteStarted name='${e(sessionName)}']`);
 
         const results = session.testResults;

--- a/common/test/resources/test-runner-rename-browser.mjs
+++ b/common/test/resources/test-runner-rename-browser.mjs
@@ -1,0 +1,4 @@
+export default function named(/** @type {import('@web/test-runner').BrowserLauncher} */ launcher, /** @type {string} */ name) {
+  launcher.name = name;
+  return launcher;
+}

--- a/common/test/resources/test-runner-stability-reporter.mjs
+++ b/common/test/resources/test-runner-stability-reporter.mjs
@@ -1,0 +1,279 @@
+import EventEmitter from 'node:events';
+
+/**
+ * @typedef LauncherError
+ * @prop {string} sessionId
+ * @prop {string} activeMethod
+ * @prop {Error} error
+ * @prop {string=} url
+ */
+
+/**
+ * A wrapper object for the PlaywrightRunner type used with @web/test-runner to
+ * launch tests in various browser engines.  This wrapper allows us to spy on
+ * each function as it is called and detect when errors occur that are not otherwise
+ * exposed by @web/test-runner.
+ */
+export class LauncherWrapper extends EventEmitter {
+  /** @type {import("@web/test-runner-playwright").PlaywrightLauncher} */
+  wrapped;
+
+  /** @param launcher {import("@web/test-runner-playwright").PlaywrightLauncher} */
+  constructor(launcher) {
+    super();
+    this.wrapped = launcher;
+  }
+
+  /**
+   * @param config { import("@web/test-runner").TestRunnerCoreConfig }
+   * @param testFiles { string[] }
+   */
+  async initialize(config, testFiles) {
+    try {
+      return await this.wrapped.initialize?.(config, testFiles);
+    } catch(err) {
+      try {
+        /** @type {LauncherError} */
+        const msg = {
+          sessionId: '',
+          activeMethod: 'initialize',
+          error: err
+        };
+        this.emit('error', msg);
+      } catch { /* Do not allow errors in our messaging to break the flow. */}
+      throw err;
+    }
+  }
+
+  async stop() {
+    return this.wrapped.stop?.();
+  }
+
+  /**
+   * @param sessionId {string}
+   * @param url {string}
+   */
+  async startSession(sessionId, url) {
+    try {
+      return await this.wrapped.startSession(sessionId, url);
+    } catch(err) {
+      try {
+        /** @type {LauncherError} */
+        const msg = {
+          sessionId: sessionId,
+          activeMethod: 'startSession',
+          error: err,
+          url: url
+        };
+        this.emit('error', msg);
+      } catch { /* Do not allow errors in our messaging to break the flow. */}
+      throw err;
+    }
+  }
+
+  /**
+   * @param sessionId {string}
+   */
+  isActive(sessionId) {
+    return this.wrapped.isActive(sessionId);
+  }
+
+  /**
+   * @param sessionId {string}
+   */
+  getBrowserUrl(sessionId) {
+    return this.wrapped.getBrowserUrl(sessionId);
+  }
+
+  /**
+   * @param sessionId {string}
+   * @param url {string}
+   */
+  async startDebugSession(sessionId, url) {
+    return this.wrapped.startDebugSession(sessionId, url);
+  }
+
+  /** @param browser { import('playwright').Browser } */
+  async createNewPage(browser) {
+    try {
+      return await this.wrapped.createNewPage(browser);
+    } catch (err) {
+      try {
+        /** @type {LauncherError} */
+        const msg = {
+          sessionId: '',
+          activeMethod: 'createNewPage',
+          error: err
+        };
+        this.emit('error', msg);
+      } catch { /* Do not allow errors in our messaging to break the flow. */}
+      throw err;
+    }
+  }
+
+  /** @param sessionId {string} */
+  async stopSession(sessionId) {
+    const lastUrl =  this.wrapped.getBrowserUrl(sessionId);
+    try {
+      return await this.wrapped.stopSession(sessionId);
+    } catch (err) {
+      try {
+        /** @type {LauncherError} */
+        const msg = {
+          sessionId: sessionId,
+          activeMethod: 'stopSession',
+          error: err,
+          url: lastUrl
+        };
+        this.emit('error', msg);
+      } catch { /* Do not allow errors in our messaging to break the flow. */}
+      throw err;
+    }
+  }
+
+  /** @param sessionId {string} */
+  getPage(sessionId) {
+    try {
+      return this.wrapped.getPage(sessionId);
+    } catch(err) {
+      try {
+        /** @type {LauncherError} */
+        const msg = {
+          sessionId: sessionId,
+          activeMethod: 'getPage',
+          error: err
+        };
+        this.emit('error', msg);
+      } catch { /* Do not allow errors in our messaging to break the flow. */}
+      throw err;
+    }
+  }
+
+  get name() {
+    return this.wrapped.name;
+  }
+
+  set name(text) {
+    this.wrapped.name = text;
+  }
+
+  get type() {
+    return this.wrapped.type;
+  }
+
+  get concurrency() {
+    return this.wrapped.concurrency;
+  }
+}
+
+// Yay for references!
+// https://www.jetbrains.com/help/teamcity/service-messages.html#Supported+Test+ServiceMessages
+// https://modern-web.dev/docs/test-runner/reporters/write-your-own/
+
+/**
+ * Returns a custom reporter that allows us to report on testing stability
+ * issues.  This will only provide useful information for launchers that are
+ * wrapped with `LauncherWrapper`.
+ */
+export function sessionStabilityReporter({ ciMode = false } = {}) {
+  // const name = "Test-session stability reporter";
+
+  /** @type {import('@web/test-runner').Logger} */
+  let logger;
+
+  /** @type {Map<string, LauncherError[]} */
+  let sessionMsgMap = new Map();
+
+  function tcReportEscaping(data) {
+    /** @type{string} */
+    let text;
+
+    if(typeof data == 'string') {
+      text = data;
+    } else if(data) {
+      text = data.toString();
+    } else {
+      text = '';
+    }
+
+    return text
+      .replace(/\|/g, '||')
+      .replace(/\[/g, '|[')
+      .replace(/]/g, '|]')
+      .replace(/\'/g, '|\'');
+  }
+
+  const e = tcReportEscaping;
+
+  /**
+   * @param {import('@web/test-runner').BasicTestSession} session
+   */
+  const buildSessionName = (session) => `${session.group.name} - ${session.browser.name}`;
+
+  /** @type {import('@web/test-runner').Reporter} */
+  const reporter = {
+    start({browsers, config, sessions}) {
+      logger = config.logger;
+      for(const browser of browsers) {
+        if(browser instanceof EventEmitter) {
+          browser.on('error', (msg) => {
+            const list = sessionMsgMap.get(msg.sessionId) ?? [];
+            if(!list.length) {
+              sessionMsgMap.set(msg.sessionId, list);
+            }
+            list.push(msg);
+          });
+        }
+      }
+    },
+    stop(args) {
+      let errorReported = false;
+      let failingTargets = [];
+
+      for(const session of args.sessions) {
+        const sessionId = session.id;
+        const sessionName = buildSessionName(session);
+        if(!failingTargets.find((entry) => entry == sessionName)) {
+          failingTargets.push(sessionName);
+        }
+        const msgList = sessionMsgMap.get(sessionId) ?? [];
+        if(msgList.length > 0) {
+          errorReported = true;
+          logger.log('');
+          logger.log(`Error for session ${sessionName}`);
+          logger.log(`  Affected test files: ${JSON.stringify(session.group.testFiles)}`);
+          for(const msg of msgList) {
+            if(msg.url) {
+              logger.log(`  For URL: ${msg.url}`);
+            }
+            logger.log(`  In \`${msg.activeMethod}\`:`);
+            logger.log(msg.error);
+          }
+        }
+      }
+
+      const globalMsgs = sessionMsgMap.get('') ?? [];
+      if(globalMsgs.length > 0) {
+        errorReported = true;
+        failingTargets.unshift('General setup');
+        logger.log("General errors:")
+        for(const msg of globalMsgs) {
+          logger.log('');
+          logger.log(`  In \`${msg.activeMethod}\`:`);
+          logger.log(msg.error);
+        }
+      }
+
+      if(errorReported) {
+        logger.log('');
+        if(ciMode) {
+          logger.log(`##teamcity[message text='${e('One or more stability errors occurred during testing for the following test groups')}' errorDetails='${JSON.stringify(failingTargets)}' status='ERROR']`);
+        } else {
+          logger.log(`Stability summary: failures occurred for the following test groups: ${JSON.stringify(failingTargets)}`);
+        }
+      }
+    }
+  };
+
+  return reporter;
+}

--- a/web/common.inc.sh
+++ b/web/common.inc.sh
@@ -94,7 +94,7 @@ function test-headless() {
     TEST_OPTS="--reporter mocha-teamcity-reporter"
   fi
   if [[ -n "$TEST_EXTENSIONS" ]]; then
-    TEST_OPTS=" --extension $TEST_EXTENSIONS"
+    TEST_OPTS="$TEST_OPTS --extension $TEST_EXTENSIONS"
     TEST_CD_REQD=true
   fi
 


### PR DESCRIPTION
Try as I might, I couldn't find any reporters for @web/test-runner designed for use with TeamCity.  Fortunately, they've got pretty good documentation for their reporter API... so I decided to roll our own.  As work went on and I remembered some issues we've had with browser-level automated tests in the past, I also added a couple more features to enhance our build logs and surface data that wasn't easily accessible otherwise.

Obviously, I worked on these _after_ actually migrating many of our automated tests to @web/test-runner.  That said... it'd be simpler and more time-efficient to review such PRs with the changes near-finalized out of the gate, so I've hoisted this earlier in the commit chain.

So, the new modules:

1. test-runner-TC-reporter
    - This formats test results in the format that TeamCity natively parses, allowing us to have nice reports on the tests in build reports.  I've also added some checks here to add a small, human-readable summary after the TC-formatting section is complete on which test-files, platforms, etc had failures and why (when available), providing a central point of reference than requiring a search through the build logs to find a lead for test-related build failures.
    - If there were no errors, no "failure report" section appears.
2. test-runner-rename-browser
    - The BrowserLaunchers support a name field, but don't take custom names when initializing them - at least as far as I can see.  Fortunately, they're mutable after construction, so the workaround is pretty simple.
3.  test-runner-stability-reporter.js
    - After some research and code-inspection into our preferred browser-engine launching setup, I found a way to "spy" on calls used to manage browser-engine state in order to surface otherwise-silent errors that can result sometimes when running tests.
    - As I managed to find a scenario in which the test-runner failed against WebKit without providing _any_ relevant information, I felt this important.

Also, rather than require pre-compilation... I just used JSDoc comments to achieve pseudo-TypeScript.  That can be changed if desired easily enough.  I'm also not sure this is the best place to leave the definitions, so I'd like to address concerns on code location and the JS/TS question at the same time.  As it is, this implementation is enough to proceed with further work, so I decided to move on to questions with clearer answers.

See related CI build logs for #11404 (Test - Language Modeling Layer) to inspect and verify the output and usefulness of these reporters.

@keymanapp-test-bot skip