### PR TITLE
fix(android): Replace deprecated APIs for Display, Size, Metrics

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -218,9 +218,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     super.onComputeInsets(outInsets);
 
     // We should extend the touchable region so that Keyman sub keys menu can receive touch events outside the keyboard frame
-    WindowManager wm = (WindowManager) getSystemService(Context.WINDOW_SERVICE);
-    Point size = new Point(0, 0);
-    wm.getDefaultDisplay().getSize(size);
+    Point size = KMManager.getWindowSize(getApplicationContext());
 
     int inputViewHeight = 0;
     if (inputView != null) {

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -603,8 +603,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     if (resourceId > 0)
       statusBarHeight = getResources().getDimensionPixelSize(resourceId);
 
-    Point size = new Point(0, 0);
-    getWindowManager().getDefaultDisplay().getSize(size);
+    Point size = KMManager.getWindowSize(context);
     int screenHeight = size.y;
     Log.d(TAG, "Main resizeTextView bannerHeight: " + bannerHeight);
     textView.setHeight(screenHeight - statusBarHeight - actionBarHeight - bannerHeight - keyboardHeight);
@@ -867,9 +866,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   }
 
   public static Drawable getActionBarDrawable(Context context) {
-    Point size = new Point();
-    WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-    wm.getDefaultDisplay().getSize(size);
+    Point size = KMManager.getWindowSize(context);
     int width = size.x;
 
     TypedValue outValue = new TypedValue();

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -907,10 +907,7 @@ final class KMKeyboard extends WebView {
     rotateSuggestions.setClickable(false);
 
     // Compute the actual display position (offset coordinate by actual screen pos of kbd)
-    WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-    DisplayMetrics metrics = new DisplayMetrics();
-    wm.getDefaultDisplay().getMetrics(metrics);
-    float density = metrics.density;
+    float density = KMManager.getWindowDensity(context);
 
     int posX, posY;
     if (keyboardType == KeyboardType.KEYBOARD_TYPE_INAPP) {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -25,6 +25,8 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.graphics.Point;
 import android.graphics.Typeface;
 import android.inputmethodservice.InputMethodService;
 import android.net.ConnectivityManager;
@@ -32,6 +34,7 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.IBinder;
 import android.text.InputType;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
 import android.view.Display;
@@ -39,6 +42,7 @@ import android.view.Surface;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.WindowMetrics;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
@@ -2005,7 +2009,20 @@ public final class KMManager {
   }
 
   public static int getOrientation(Context context) {
-    Display display = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+    Display display;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      // https://developer.android.com/reference/android/content/Context#getDisplay()
+      try {
+        display = context.getDisplay();
+      } catch (UnsupportedOperationException e) {
+        // if the method is called on an instance that is not associated with any display.
+        return context.getResources().getConfiguration().orientation;
+      }
+    } else {
+      WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+      // Deprecated in API 30
+      display = wm.getDefaultDisplay();
+    }
     int rotation = display.getRotation();
     if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180) {
       return Configuration.ORIENTATION_PORTRAIT;
@@ -2050,6 +2067,34 @@ public final class KMManager {
       RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
       SystemKeyboard.setLayoutParams(params);
     }
+  }
+
+  /**
+   * Get the size of the area the window would occupy.
+   * API 30+
+   * https://developer.android.com/reference/android/view/WindowManager#getCurrentWindowMetrics()
+   * @param context
+   * @return Point (width, height)
+   */
+  public static Point getWindowSize(Context context) {
+    WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      WindowMetrics windowMetrics = wm.getCurrentWindowMetrics();
+      return new Point(
+        windowMetrics.getBounds().width(),
+        windowMetrics.getBounds().height());
+    }
+
+    // Deprecated in API 30
+    Point size = new Point(0, 0);
+    wm.getDefaultDisplay().getSize(size);
+    return size;
+  }
+
+  public static float getWindowDensity(Context context) {
+    DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+    Log.d(TAG, "KMManager: metrics.density " + metrics.density);
+    return metrics.density;
   }
 
   protected static void setPersistentShouldShowHelpBubble(boolean flag) {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2078,17 +2078,17 @@ public final class KMManager {
    */
   public static Point getWindowSize(Context context) {
     WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      WindowMetrics windowMetrics = wm.getCurrentWindowMetrics();
-      return new Point(
-        windowMetrics.getBounds().width(),
-        windowMetrics.getBounds().height());
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+      // Deprecated in API 30
+      Point size = new Point(0, 0);
+      wm.getDefaultDisplay().getSize(size);
+      return size;
     }
-
-    // Deprecated in API 30
-    Point size = new Point(0, 0);
-    wm.getDefaultDisplay().getSize(size);
-    return size;
+    
+    WindowMetrics windowMetrics = wm.getCurrentWindowMetrics();
+    return new Point(
+      windowMetrics.getBounds().width(),
+      windowMetrics.getBounds().height());    
   }
 
   public static float getWindowDensity(Context context) {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMPopoverView.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMPopoverView.java
@@ -10,6 +10,7 @@ import android.graphics.LinearGradient;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
 import android.graphics.Path;
+import android.graphics.Point;
 import android.graphics.RectF;
 import android.graphics.Shader;
 import android.util.AttributeSet;
@@ -31,13 +32,11 @@ final class KMPopoverView extends View {
 
   public KMPopoverView(Context context, AttributeSet attrs) {
     super(context, attrs);
-    WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-    DisplayMetrics metrics = new DisplayMetrics();
-    wm.getDefaultDisplay().getMetrics(metrics);
-    density = metrics.density;
+    Point size = KMManager.getWindowSize(context);
+    density = KMManager.getWindowDensity(context);
 
-    viewWidth = metrics.widthPixels;
-    viewHeight = metrics.heightPixels;
+    viewWidth = size.x;
+    viewHeight = size.y;
     borderRadius = 6 * density;
     strokeWidth = 2.0f;
     bgColor = context.getResources().getColor(R.color.popup_bg);

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -176,9 +176,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     super.onComputeInsets(outInsets);
 
     // We should extend the touchable region so that Keyman sub keys menu can receive touch events outside the keyboard frame
-    WindowManager wm = (WindowManager) getSystemService(Context.WINDOW_SERVICE);
-    Point size = new Point(0, 0);
-    wm.getDefaultDisplay().getSize(size);
+    Point size = KMManager.getWindowSize(getApplicationContext());
 
     int inputViewHeight = 0;
     if (inputView != null)

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -202,13 +202,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
         super.onComputeInsets(outInsets);
 
         // We should extend the touchable region so that Keyman sub keys menu can receive touch events outside the keyboard frame
-        WindowManager wm = (WindowManager)getSystemService(Context.WINDOW_SERVICE);
-        if(wm == null) return;
-        Point size = new Point(0, 0);
-        Display display = wm.getDefaultDisplay();
-        if(display == null) return;
-
-        display.getSize(size);
+        Point size = KMManager.getWindowSize(getApplicationContext());
 
         int inputViewHeight = 0;
         if (inputView != null)


### PR DESCRIPTION
Fixes #9586

Android API 30 deprecated several calls used to determine Window Display, Size, and Metrics. This refactors the calls to KMManager to handle the different API calls.

## User Testing
### Setup
* These tests should run the PR builds on an Android Device/emulator of the specified API level to test each side of API 30
  * GROUP_API_28: Android 9.0 Pie
  * GROUP_API_34: Android 14.0 UpsideDown Cake

**Tests**
**TEST_KEYMAN** - Verifies orientation and keyboard height for Keyman app
1. Install Keyman for Android with the device in Portrait orientation
2. From "Get Started", enable Keyman as the default system keyboard. 
3. Dismiss "Get Started"
4. Note the current keyboard height.
5. From Keyman Settings --> Adjust keyboard height
6. From "Adjust keyboard height" menu, adjust the keyboard height for both portrait and landscape orientation.
7. From the nav bar, hit back arrow to return to the Keyman app
8. Verify the keyboard height matches what was set from the "adjust keyboard height" menu for both
  * Portrait orientation
  * Landscape orientation
9. Launch Chrome browser and select a text area
10. With Keyman selected as the system keyboard, verify the system keyboard height matches what was set from the "adjust keyboard height" menu for both
  * Portrait orientation
  * Landscape orientation
 
**TEST_FIRSTVOICES** - Verifies orientation and keyboard height for FirstVoices app
1. Install FirstVoices for Android with the device in Portrait orientation
2. From the FV setup menu, install a keyboard (BC Coast --> SENCOTEN) and enable FirstVoices as the default system keyboard
3. Launch Chrome browser and select a text area
4. With FirstVoices selected as the system keyboard, verify the system keyboard appears
5. Verify the keyboard outputs:
  * Regular key press
  * longpress key
  * suggestion from the suggestion banner (if  fv_sencoten is selected and installed dictionary)
 