### PR TITLE
chore(web): finalize web/ project parity with base-repo TS config settings (aside from JS version target) 🔩

### DIFF
--- a/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedPathSpecs.ts
+++ b/common/web/gesture-recognizer/src/test/auto/headless/gestures/isolatedPathSpecs.ts
@@ -38,6 +38,8 @@ export const MainLongpressSourceModel: ContactModel = {
       if(path.isComplete) {
         return 'reject';
       }
+
+      return undefined;
     }
   }
 };
@@ -78,6 +80,8 @@ export const ModipressEndModel: ContactModel = {
       if(path.isComplete) {
         return 'resolve';
       }
+
+      return undefined;
     }
   }
 }
@@ -91,6 +95,8 @@ export const SimpleTapModel: ContactModel = {
       if(path.isComplete && !path.wasCancelled) {
         return 'resolve';
       }
+
+      return undefined;
     }
   }
 }
@@ -103,6 +109,8 @@ export const SubkeySelectModel: ContactModel = {
       if(path.isComplete && !path.wasCancelled) {
         return 'resolve';
       }
+
+      return undefined;
     }
   }
 }
@@ -145,6 +153,8 @@ export const FlickEndContactModel: ContactModel = {
         // - or, take a regression & look at the coefficient of determination.
         return 'resolve';
       }
+
+      return undefined;
     }
   },
   pathResolutionAction: 'resolve',

--- a/common/web/gesture-recognizer/tsconfig.json
+++ b/common/web/gesture-recognizer/tsconfig.json
@@ -6,12 +6,6 @@
     "outDir": "./build/obj/",
     "rootDir": "./src/engine",
     "tsBuildInfoFile": "./build/obj/tsconfig.tsbuildinfo",
-
-    // TODO: These override ../tsconfig.base.json settings, and so should be removed if possible,
-    //       but existing code in web/ breaks some of these settings
-    //
-    // At present, the code actually compiles without them... but the TS tests are a different matter.
-    "noImplicitReturns": false
   },
   "include": ["./src/engine/**/*.ts"],
   "exclude": ["./src/test/**/*.ts", "./src/tools/**/*.ts"],

--- a/web/package.json
+++ b/web/package.json
@@ -93,8 +93,7 @@
     "c8": "^7.12.0",
     "jsdom": "^23.0.1",
     "mocha": "^10.0.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "ts-node": "^10.9.1"
   },
   "scripts": {
     "test": "gosh ./test.sh"

--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -283,7 +283,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
 
     // Always do the common focus stuff, instantly returning if we're in an editable iframe.
     if(this._CommonFocusHelper(target)) {
-      return true;
+      return;
     };
 
     // Set element directionality (but only if element is empty)

--- a/web/src/app/browser/src/languageMenu.ts
+++ b/web/src/app/browser/src/languageMenu.ts
@@ -440,7 +440,7 @@ export class LanguageMenu {
       // preserve the original state so that we can still restore it later!
       if(this.originalBodyStyle) {
         console.error("Unexpected state:  `originalBodyStyle` was not cleared by a previous `unlockBodyScroll()` call");
-        return;
+        return false;
       }
 
       // Preserve the original style for the body element; we're going to change
@@ -510,7 +510,7 @@ export class LanguageMenu {
       } else if("undefined" != typeof e.touches) {
         y = e.touches[0].pageY;
       } else {
-        return;
+        return false;
       }
 
       dy=y-languageMenu.y0;
@@ -527,7 +527,7 @@ export class LanguageMenu {
         }
         // Dont' scroll - can happen if changing scroll direction
       } else {
-        return;
+        return false;
       }
 
       // Disable selected language if drag more than 5px

--- a/web/src/app/ui/kmwuitoolbar.ts
+++ b/web/src/app/ui/kmwuitoolbar.ts
@@ -912,7 +912,7 @@ if(!keyman?.ui?.name) {
       readonly showOSK = (event: Event) => {
         let osk = keymanweb.osk;
         if(!osk) {
-          return;
+          return false;
         }
         keymanweb.activatingUI(true);
         //Toggle OSK on or off

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -83,11 +83,11 @@ export class StylesheetManager {
   addStyleSheetForFont(fd: KeyboardFont, fontPathRoot: string, os?: DeviceSpec.OperatingSystem) {
     // Test if a valid font descriptor
     if(!fd) {
-      return;
+      return null;
     }
 
     if(typeof(fd.files) == 'undefined') {
-      return;
+      return null;
     }
 
     const fontKey = fd.family;
@@ -110,7 +110,7 @@ export class StylesheetManager {
       if(!sheet.parentNode) {
         this.linkStylesheet(sheet);
       }
-      return;
+      return null;
     }
 
     if(typeof(fd.files) == 'string') {

--- a/web/src/engine/main/src/contextManagerBase.ts
+++ b/web/src/engine/main/src/contextManagerBase.ts
@@ -200,6 +200,8 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
       // Restore the popped element; it doesn't match the current activation attempt.
       this.pendingActivations.push(activationAfterAwait);
       return null;
+    } else {
+      return null;
     }
   }
 

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -440,6 +440,8 @@ export function flickMidContactModel(params: GestureParams): gestures.specs.Cont
         } else if(path.isComplete) {
           return 'reject';
         }
+
+        return undefined;
       }
     },
     pathResolutionAction: 'resolve',
@@ -464,6 +466,7 @@ export function flickEndContactModel(params: GestureParams): ContactModel {
             return 'reject';
           }
         }
+        return undefined;
       }
     },
     pathResolutionAction: 'resolve',
@@ -544,6 +547,7 @@ export function modipressContactHoldModel(): ContactModel {
         if(path.isComplete) {
           return 'reject';
         }
+        return undefined;
       }
     }
   }
@@ -559,6 +563,7 @@ export function modipressContactEndModel(): ContactModel {
         if(path.isComplete) {
           return 'resolve';
         }
+        return undefined;
       }
     }
   };
@@ -580,6 +585,8 @@ export function simpleTapContactModel(params: GestureParams, isNotInitial?: bool
         if(path.isComplete && !path.wasCancelled) {
           return 'resolve';
         }
+
+        return undefined;
       }
     }
   };
@@ -594,6 +601,7 @@ export function subkeySelectContactModel(): ContactModel {
         if(path.isComplete && !path.wasCancelled) {
           return 'resolve';
         }
+        return undefined;
       }
     }
   }
@@ -908,6 +916,8 @@ export function flickResetCenteringModel(params: GestureParams): GestureModel<Ke
               if(oldDist < newDist) {
                 return 'resolve';
               }
+
+              return undefined;
             },
           },
           itemPriority: 0,

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1137,7 +1137,9 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
    **/
   highlightKey(key: KeyElement, on: boolean): GesturePreviewHost {
     // Do not change element class unless a key
-    if (!key || !key.key || (key.className == '') || (key.className.indexOf('kmw-key-row') >= 0)) return;
+    if (!key || !key.key || (key.className == '') || (key.className.indexOf('kmw-key-row') >= 0)) {
+      return null;
+    }
 
     // For phones, use key preview rather than highlighting the key,
     const usePreview = key.key.allowsKeyTip();

--- a/web/src/engine/package-cache/src/modelCache.ts
+++ b/web/src/engine/package-cache/src/modelCache.ts
@@ -46,7 +46,7 @@ export default class ModelManager {
       model = this.registeredModels[modelId];
       delete this.registeredModels[modelId];
     } else {
-      return;
+      return null;
     }
 
     // Ensure the model is deregistered for each targeted language code variant.

--- a/web/src/tools/testing/recorder/browserProctor.ts
+++ b/web/src/tools/testing/recorder/browserProctor.ts
@@ -99,6 +99,8 @@ export class BrowserProctor extends Proctor {
       // Converts the sequence back to version 10.0, since it's very well made for browser simulation.
       let eventSpecSequence = new InputEventSpecSequence(inputSpecs, sequence.output, sequence.msg);
       return driver.simulateSequence(eventSpecSequence);
+    } else {
+      throw new Error("Unexpected test-recording type");
     }
   }
 }

--- a/web/src/tsconfig.dom.json
+++ b/web/src/tsconfig.dom.json
@@ -2,10 +2,6 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "lib": [ "DOM", "ES6"],
-    // TODO: These override ../tsconfig.base.json settings, and so should be removed if possible,
-    //       but existing code in web/ breaks some of these settings
-    "noImplicitReturns": false,
-    "strictNullChecks": false,
+    "lib": [ "DOM", "ES6"]
   }
 }


### PR DESCRIPTION
For some reason, I expected these final flags to be worse than enforcing `strictFunctionTypes`.  Maybe it's due to some of the changes the previous setting triggered, but this part went quite swimmingly.

Fixes #11473.

## User Testing

TEST_DEVELOPER_KMC:  Using the test build of Keyman Developer, verify that keyboard compilation works properly.
1. In your local copy of the keyboards repo, run `./build.sh clean`.
2. Open Keyman Developer.
3. Open any keyboard project - say, `ekwtamil99uni` (at https://github.com/keymanapp/keyboards/tree/master/release/e/ekwtamil99uni).
4. Use Keyboards > `ekwtamil99uni.kmn` > Build > Compile Keyboard and verify that no errors are emitted.
5. Returning to the .kpj overview, use Packaging > `ekwtamil99uni.kps` > Build > Compile Package and verify that no errors are emitted.

TEST_DEVELOPER_SERVER:  Using the test build of Keyman Developer, verify that the Web test-host page works properly for testing Web keyboards.
1. Open Keyman Developer.
2. Open any keyboard project - say, `ekwtamil99uni` (at https://github.com/keymanapp/keyboards/tree/master/release/e/ekwtamil99uni).
3. Use Keyboards > `ekwtamil99uni.kmn` > Build > Compile Keyboard and verify that no errors are emitted.
4. From the same screen, click "Test Keyboard on web", then "Open in browser".
5. Verify that the keyboard can be selected and that it loads and types properly.