### PR TITLE
cherrypick(android/engine): Handle globe key on lock screen 🍒 🏠

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2361,7 +2361,7 @@ public final class KMManager {
     if (KMManager.shouldAllowSetKeyboard()) {
       // inKeyguardRestrictedInputMode() deprecated, so check isKeyguardLocked() to determine if screen is locked
       if (isLocked()) {
-        if (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM && globeKeyState == GlobeKeyState.GLOBE_KEY_STATE_UP) {
+        if (keyboardType == KeyboardType.KEYBOARD_TYPE_SYSTEM && globeKeyState == GlobeKeyState.GLOBE_KEY_STATE_DOWN) {
           doGlobeKeyLockscreenAction(context);
         }
         // clear globeKeyState


### PR DESCRIPTION
Cherrypick #11458 to stable-17.0

This fixes the transition on the lock screen to handle the Globe key on key press (GLOBE_KEY_STATE_DOWN).

## User Testing
**Setup** - 
1. Install the PR build of Keyman for Android on an emulator. Best to use an emulator in case the lock screen gets stuck on the wrong keyboard for entering the password.
2. On the Android emulator Settings, set the lock screen to use a password of "qwerty".

**TEST_KEYMAN_LOCK_SCREEN** - Verifies Keyman globe key on lock screen
1. Launch Keyman
2. From "Get Started", set Keyman as the default ksystem keyboard.
3. Launch Chrome and select a text field.
4. Switch to Keyman if it's no the current keyboard. 
5. Lock the emulator
6. Press button to enter the lock screen
7. With Keyman on the lock screen, press and release the globe key
8. Verify the keyboard switches to another system keyboard (non-Keyman).