### PR TITLE
fix(common): calculate already-build dependency targets correctly

### DIFF
--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1682,11 +1682,6 @@ _builder_do_build_deps() {
       continue
     fi
 
-    # Only configure and build the dependency once per invocation
-    if builder_has_module_been_built "$dep"; then
-      continue
-    fi
-
     dep_target=
     if [[ ! -z ${_builder_dep_targets[$dep]+x} ]]; then
       # TODO: in the future split _builder_dep_targets into comma-separated
@@ -1694,14 +1689,19 @@ _builder_do_build_deps() {
       dep_target=${_builder_dep_targets[$dep]}
     fi
 
-    builder_set_module_has_been_built "$dep"
+    # Only configure and build the dependency once per invocation
+    if builder_has_module_been_built "$dep$dep_target"; then
+      continue
+    fi
+
+    builder_set_module_has_been_built "$dep$dep_target"
     "$REPO_ROOT/$dep/build.sh" "configure$dep_target" "build$dep_target" \
       $builder_verbose \
       $builder_debug \
       $_builder_build_deps \
       --builder-dep-parent "$THIS_SCRIPT_IDENTIFIER" && (
       if $_builder_debug_internal; then
-        builder_echo success "## Dependency $dep for $_builder_matched_action_name successfully"
+        builder_echo success "## Dependency $dep$dep_target for $_builder_matched_action_name successfully"
       fi
     ) || (
       result=$?


### PR DESCRIPTION
When using `module:target` style dependencies, Builder would not track the individual targets within the module, causing only the first target to be built; subsequent dependency targets within that module would be treated as already built.

This change means that builder will track individual targets within the dependency. However, it is possible for targets to be built multiple times if there a dependency listed for the entire module as well as for the individual target within dependency, as in the following example, where building `project1` and `project2` in one command would cause `module:mytarget` to be built twice.

```
builder_describe project1 \
  @/module

builder_describe project2 \
  @/module:mytarget
```

This scenario should not break builds as they any configure+build actions should be idempotent, but it could cause builds to be a little slower, so should be corrected if identified. I do not currently plan to further modify the dependency calculations to cater for this scenario.

Finally, if `:mytarget` is a child build, it is better to reference the child module directly than the parent's target, for example:

```
builder_describe project1 \
    @/module/mytarget
```

@keymanapp-test-bot skip