### PR TITLE
fix(common): properly quote `builder_run_action` call

### DIFF
--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -577,7 +577,7 @@ function builder_run_action() {
   local action=$1
   shift
   if builder_start_action $action; then
-    ($@)
+    ("$@")
     builder_finish_action success $action
   fi
   return 0


### PR DESCRIPTION
The call to the command listed for `builder_run_action` was not properly quoted, which meant that quoted parameters would have been corrupted, for example:

```
builder_run_action clean   rm -rf "temp folder/"
```

Would have run:

```
rm -rf temp folder/
```

@keymanapp-test-bot skip