### PR TITLE
fix(android/app): Verify extracted text is not null

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -169,7 +169,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     InputConnection ic = getCurrentInputConnection();
     if (ic != null) {
       ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
-      if (icText != null) {
+      if (icText != null && icText.text != null) {
         boolean didUpdateText = KMManager.updateText(KeyboardType.KEYBOARD_TYPE_SYSTEM, icText.text.toString());
         boolean didUpdateSelection = KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_SYSTEM);
         if (!didUpdateText || !didUpdateSelection)

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -169,6 +169,11 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     InputConnection ic = getCurrentInputConnection();
     if (ic != null) {
       ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
+      /*
+        We do sometimes receive null `icText.text`, even though
+        getExtractedText() docs does not list this as a possible 
+        return value, so we test for that as well (#11479)
+      */
       if (icText != null && icText.text != null) {
         boolean didUpdateText = KMManager.updateText(KeyboardType.KEYBOARD_TYPE_SYSTEM, icText.text.toString());
         boolean didUpdateSelection = KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_SYSTEM);


### PR DESCRIPTION
Fixes #11479 - 
Will :cherries: pick to stable-17.0


Adds additional null check since getExtractedText 
> may fail either if the input connection has become invalid or the client is taking too long to respond with the text...

This was causing the crash:
> Attempt to invoke interface method 'java.lang.String java.lang.CharSequence.toString()' on a null object reference

@keymanapp-test-bot skip
