### PR TITLE
refactor(common): move `enabled` declaration into test_color.cpp

### DIFF
--- a/common/include/test_color.cpp
+++ b/common/include/test_color.cpp
@@ -1,0 +1,5 @@
+#include "test_color.h"
+
+namespace console_color {
+  bool enabled = false;
+};

--- a/common/include/test_color.h
+++ b/common/include/test_color.h
@@ -23,7 +23,7 @@ enum ansi_code {
     BRIGHT_RED = 196
 };
 
-bool enabled = false;   // TODO: move to test_color.c because test_color.h cannot be #included in more than 1 file in a project otherwise.
+extern bool enabled;
 
 class fg {
     ansi_code code;

--- a/core/tests/unit/kmnkbd/meson.build
+++ b/core/tests/unit/kmnkbd/meson.build
@@ -38,7 +38,7 @@ if cpp_compiler.get_id() == 'emscripten'
 endif
 
 foreach t : tests
-  bin = executable(t[0], [t[1], '../emscripten_filesystem.cpp'],
+  bin = executable(t[0], [t[1], common_test_files],
     cpp_args: local_defns + defns + warns,
     include_directories: [inc, libsrc],
     link_args: links + tests_flags,

--- a/core/tests/unit/kmx/meson.build
+++ b/core/tests/unit/kmx/meson.build
@@ -27,7 +27,7 @@ if cpp_compiler.get_id() == 'emscripten'
 endif
 
 kmx = executable('kmx',
-    ['kmx.cpp', '../emscripten_filesystem.cpp'],
+    ['kmx.cpp', common_test_files],
     cpp_args: defns + warns,
     include_directories: [inc, libsrc, '../../kmx_test_source'],
     link_args: links + tests_flags,
@@ -176,7 +176,7 @@ subdir('fixtures')
 # should work for Linux, macOS, and WASM.
 test_path = source_path
 
-key_e = executable('key_list', ['kmx_key_list.cpp', '../emscripten_filesystem.cpp'],
+key_e = executable('key_list', ['kmx_key_list.cpp', common_test_files],
                 cpp_args: defns + warns,
                 include_directories: [inc, libsrc],
                 link_args: links + tests_flags,
@@ -195,7 +195,7 @@ test('key_list', key_e,  depends: kbd_log, args: [kbd_obj] )
 
 # test for imx list
 
-imx_e = executable('imx_list', ['kmx_imx.cpp', '../emscripten_filesystem.cpp'],
+imx_e = executable('imx_list', ['kmx_imx.cpp', common_test_files],
                 cpp_args: defns + warns,
                 include_directories: [inc, libsrc],
                 link_args: links + tests_flags,
@@ -213,7 +213,7 @@ kbd_log = custom_target(test_kbd + '.kmx'.underscorify(),
 )
   test('imx_list', imx_e,  depends: kbd_log, args: [kbd_obj] )
 
-external_e = executable('ext_event', ['kmx_external_event.cpp', '../emscripten_filesystem.cpp'],
+external_e = executable('ext_event', ['kmx_external_event.cpp', common_test_files],
                 cpp_args: defns + warns,
                 include_directories: [inc, libsrc],
                 link_args: links + tests_flags,

--- a/core/tests/unit/ldml/ldml_test_source.cpp
+++ b/core/tests/unit/ldml/ldml_test_source.cpp
@@ -36,6 +36,8 @@
 #include "unicode/uniset.h"
 #include "unicode/usetiter.h"
 
+#include <test_color.h>
+
 #define assert_or_return(expr) if(!(expr)) { \
   std::wcerr << __FILE__ << ":" << __LINE__ << ": " << \
   console_color::fg(console_color::BRIGHT_RED) \
@@ -49,7 +51,6 @@
 namespace km {
 namespace tests {
 
-#include <test_color.h>
 
 
 

--- a/core/tests/unit/ldml/meson.build
+++ b/core/tests/unit/ldml/meson.build
@@ -50,9 +50,10 @@ else
 endif
 
 ldml = executable('ldml',
-    'ldml.cpp',
+    ['ldml.cpp',
     'ldml_test_source.cpp',
     'ldml_test_utils.cpp',
+    common_test_files],
     cpp_args: defns + warns,
     include_directories: [inc, libsrc, '../../../../developer/src/ext/json'],
     link_args: links + tests_flags,
@@ -66,6 +67,7 @@ ldml = executable('ldml',
 
 e = executable('test_kmx_plus', 'test_kmx_plus.cpp',
     'ldml_test_utils.cpp',
+    common_test_files,
     cpp_args: defns + warns,
     include_directories: [inc, libsrc, '../../../../developer/src/ext/json'],
     link_args: links + tests_flags,
@@ -76,6 +78,7 @@ test('test_kmx_plus', e, suite: 'ldml')
 # run transforms / ldml utilities unit test
 
 t = executable('test_transforms', 'test_transforms.cpp',
+    common_test_files,
     cpp_args: defns + warns,
     include_directories: [inc, libsrc, '../../../../developer/src/ext/json'],
     link_args: links + tests_flags,
@@ -92,7 +95,7 @@ if cpp_compiler.get_id() == 'emscripten'
 endif
 
 t = executable('test_context_normalization',
-    ['test_context_normalization.cpp', '../emscripten_filesystem.cpp'],
+    ['test_context_normalization.cpp', common_test_files],
     cpp_args: defns + warns,
     include_directories: [inc, libsrc, '../../../../developer/src/ext/json'],
     link_args: links + normalization_tests_flags,

--- a/core/tests/unit/meson.build
+++ b/core/tests/unit/meson.build
@@ -1,5 +1,10 @@
 node = find_program('node', required: true)
 
+common_test_files = [
+  meson.current_source_dir() / 'emscripten_filesystem.cpp',
+  meson.source_root() / '../common/include/test_color.cpp'
+]
+
 hextobin_root = join_paths(meson.source_root(),'..','common','tools','hextobin','build','hextobin.js')
 hextobin_cmd = [node, hextobin_root]
 

--- a/developer/src/kmcmplib/tests/meson.build
+++ b/developer/src/kmcmplib/tests/meson.build
@@ -129,9 +129,11 @@ if get_option('full_test')
 
 endif
 
+common_test_files = [ meson.source_root() / '../../../common/include/test_color.cpp' ]
+
 # Test the API endpoints
 
-apitest = executable('api-test', ['api-test.cpp','util_filesystem.cpp','util_callbacks.cpp'],
+apitest = executable('api-test', ['api-test.cpp','util_filesystem.cpp','util_callbacks.cpp', common_test_files],
     cpp_args: defns + flags,
     include_directories: inc,
     name_suffix: name_suffix,
@@ -142,7 +144,7 @@ apitest = executable('api-test', ['api-test.cpp','util_filesystem.cpp','util_cal
 
 test('api-test', apitest, args: [output_path / 'blank_keyboard.kmx'])
 
-usetapitest = executable('uset-api-test', 'uset-api-test.cpp',
+usetapitest = executable('uset-api-test', 'uset-api-test.cpp', common_test_files,
     cpp_args: defns + flags,
     include_directories: inc,
     name_suffix: name_suffix,


### PR DESCRIPTION
Moves variable declaration for `bool enabled` from .h to .cpp and fixes up builds. Fixes `#include` in ldml_test_source.cpp which was inside a namespace.

Fixes: #10426

@keymanapp-test-bot skip