### PR TITLE
fix(android): Resize keyboard on orientation change

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
@@ -107,7 +107,7 @@ public class AdjustKeyboardHeightActivity extends BaseActivity {
             break;
           case MotionEvent.ACTION_UP:
             // Save the currentHeight when the user releases
-            int orientation = KMManager.getOrientation(context);
+            int orientation = KMManager.detectOrientation(context);
             String keyboardHeightKey = (orientation == Configuration.ORIENTATION_LANDSCAPE) ?
               KMManager.KMKey_KeyboardHeightLandscape : KMManager.KMKey_KeyboardHeightPortrait;
             editor.putInt(keyboardHeightKey, currentHeight);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -240,15 +240,6 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     KMManager.onResume();
     KMManager.hideSystemKeyboard();
 
-    // onConfigurationChanged() only triggers when device is rotated while app is in foreground
-    // This handles when device is rotated while app is in background
-    // using KMManager.getOrientation() since getConfiguration().orientation is unreliable #10241
-    int newOrientation = KMManager.getOrientation(context);
-    if (newOrientation != lastOrientation) {
-      lastOrientation = newOrientation;
-      Configuration newConfig = this.getResources().getConfiguration();
-      KMManager.onConfigurationChanged(newConfig);
-    }
     resizeTextView(textView.isKeyboardVisible());
 
     KMManager.addKeyboardEventListener(this);

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -225,7 +225,7 @@ final class KMKeyboard extends WebView {
     selMin -= pairsAtStart;
     selMax -= (pairsAtStart + pairsSelected);
     this.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selMin, selMax));
-  
+
     return true;
   }
 
@@ -256,7 +256,7 @@ final class KMKeyboard extends WebView {
     // When `.isTestMode() == true`, the setWebContentsDebuggingEnabled method is not available
     // and thus will trigger unit-test failures.
     if (!KMManager.isTestMode() && (
-      (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0 || 
+      (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0 ||
       KMManager.getTier(null) != KMManager.Tier.STABLE
     )) {
       // Enable debugging of WebView via adb. Not used during unit tests
@@ -417,13 +417,8 @@ final class KMKeyboard extends WebView {
     return super.onTouchEvent(event);
   }
 
+  @Override
   public void onResume() {
-    DisplayMetrics dms = context.getResources().getDisplayMetrics();
-    int kbWidth = (int) (dms.widthPixels / dms.density);
-    // Ensure window is loaded for javascript functions
-    loadJavascript(KMString.format(
-      "window.onload = function(){ setOskWidth(\"%d\");"+
-      "setOskHeight(\"0\"); };", kbWidth));
     if (this.getShouldShowHelpBubble()) {
       this.showHelpBubbleAfterDelay(2000);
     }
@@ -439,7 +434,14 @@ final class KMKeyboard extends WebView {
 
   public void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
+    this.dismissHelpBubble();
 
+    if(this.getShouldShowHelpBubble()) {
+      this.showHelpBubbleAfterDelay(2000);
+    }
+  }
+
+  void updateOrientation() {
     RelativeLayout.LayoutParams params = KMManager.getKeyboardLayoutParams();
     this.setLayoutParams(params);
 
@@ -448,15 +450,13 @@ final class KMKeyboard extends WebView {
     if (this.htmlBannerString != null && !this.htmlBannerString.isEmpty()) {
       setHTMLBanner(this.htmlBannerString);
     }
+
+    DisplayMetrics dms = context.getResources().getDisplayMetrics();
+    int kbWidth = (int) (dms.widthPixels / dms.density);
+
     loadJavascript(KMString.format("setBannerHeight(%d)", bannerHeight));
-    loadJavascript(KMString.format("setOskWidth(%d)", newConfig.screenWidthDp));
+    loadJavascript(KMString.format("setOskWidth(%d)", kbWidth));
     loadJavascript(KMString.format("setOskHeight(%d)", oskHeight));
-
-    this.dismissHelpBubble();
-
-    if(this.getShouldShowHelpBubble()) {
-      this.showHelpBubbleAfterDelay(2000);
-    }
   }
 
   public void dismissSuggestionMenuWindow() {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -627,7 +627,6 @@ public final class KMManager {
    * @return RelativeLayout.LayoutParams
    */
   public static RelativeLayout.LayoutParams getKeyboardLayoutParams() {
-    // Note: this func always has a reference to app context b/c class field.
     int bannerHeight = getBannerHeight(appContext);
     int kbHeight = getKeyboardHeight(appContext);
     RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(
@@ -720,7 +719,6 @@ public final class KMManager {
 
   @SuppressLint("InflateParams")
   public static View createInputView(InputMethodService inputMethodService) {
-    //final Context context = appContext;
     IMService = inputMethodService;
     Context appContext = IMService.getApplicationContext();
     final FrameLayout mainLayout = new FrameLayout(appContext);
@@ -729,8 +727,6 @@ public final class KMManager {
     RelativeLayout keyboardLayout = new RelativeLayout(appContext);
     keyboardLayout.setLayoutParams(new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
 
-    // sticks the keyboard's webview into our locally-generated keyboard-hosting
-    // view hierarchy (after ensuring that it's removed from a prior one if applicable)
     ViewGroup parent = (ViewGroup) SystemKeyboard.getParent();
     if (parent != null)
       parent.removeView(SystemKeyboard);
@@ -2033,6 +2029,10 @@ public final class KMManager {
   /* package-private */
   static void setOrientation(int orientationFlag) {
     orientation = orientationFlag;
+  }
+
+  public static int getOrientation(Context context) {
+    return orientation;
   }
 
   public static int detectOrientation(Context context) {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -800,8 +800,8 @@ public final class KMManager {
     updateOrientation();
   }
 
+  /* package-private */
   static void updateOrientation() {
-    // KMKeyboard
     if (InAppKeyboard != null) {
       RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
       InAppKeyboard.updateOrientation();

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2032,7 +2032,11 @@ public final class KMManager {
   }
 
   public static int getOrientation(Context context) {
-    return orientation;
+    if(orientation == Configuration.ORIENTATION_UNDEFINED) {
+      return detectOrientation(context);
+    } else {
+      return orientation;
+    }
   }
 
   public static int detectOrientation(Context context) {


### PR DESCRIPTION
This PR attempts to resolve the tricky wrong-keyboard-size bug that continues to occur within our Android app, despite our best efforts.

After analyzing the codebase, I feel that there are two different types of orientation-change triggers within the code:

1. `onResume`, when restoring the app/keyboard from the background.  We just need to set whatever the current orientation is in place, even if it changed since being backgrounded.
2. `onConfigurationChanged`, during an actual orientation-change event.

The solution for point 1 - reliant on the `Display`-based pathway, seems to work quite well for reading the current orientation when it's **not** being mutated.

For point 2, we currently ignore the provided parameter for `onConfigurationChange` in favor of reusing the same solution as is used for `onResume`.  (This seems to have been established in either #10373 or #10442.)  We used to read it from `activity.getResources().getConfiguration().orientation` instead... until we found that sometimes reading it _specifically from_ that consistent source could be prone to a known bug on certain devices.  Interestingly, the external references I could find to that bug... require accessing it in that manner, rather than from `onConfigurationChange`'s parameter.
- Example reference:  https://stackoverflow.com/q/48777084
- Cross-reference with:
    https://github.com/keymanapp/keyman/blob/4718b5bb20103b8dd8fd3a4fd77f40f0c3587623/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java#L268-L276
    - Also see the "before" state viewable through #10442's changelog, where the `.orientation` field was explicitly referenced by the equivalent to the block above.

If we instead use the value directly from the `onConfigurationChanged` parameter when possible, perhaps that may allow us to dodge that particular bug issue entirely.  It's worth noting that this is the "standard solution" I found, repeatedly, when searching for how to detect device orientation - using `onConfigurationChanged` and the `.orientation` field of its parameter.

Meanwhile, my current "best guess" for the _current_ problem is that the `onResume` pathway, reliant upon `Display` - isn't intended for use _during_ an orientation change.  If it's updated in a manner susceptible to race-conditions, we could be getting the old orientation via the `Display`-based pathway when the "race" is "lost".  It's hard to say for sure without thorough testing and/or a solid repro that could be used as proof, though.  I'm not seeing much external mention of this as a possibility, but this is the possibility that makes most sense to me via process of elimination.

## User Testing 


**TEST_OSK** - Verifies OSK is full width after using keyboard picker

1. Launch Keyman for Android in landscape
2. Type some letters on the input text screen.
3. Longpress the globe key to open the Keyboard picker menu.
4. Click the default keyboard.
5. Verify the app shows the OSK full-width and full height.

**TEST_LANDSCAPE_KEYBOARD_PICKER** - Verifies menu to adjust keyboard height works
1. Install the PR build of Keyman for Android on an Android device/emulator
2. with the device in Landscape mode, Launch Keyman and dismiss the Get Started menu
3. In the Keyman app, type some letter using the OSK
4. Longpress the globe key to display the keyboard picker menu
5. Select the same keyboard from the picker menu
6. Verify OSK is still full width and full height

**TEST_OSK_ROTATION_ANDROID_12**
1. Install the PR build of Keyman for Android on an Android device/emulator Android 12 (SDK 32) 
2. Open Keyman In-App.
3. Open the Settings menu.
4. Open Adjust keyboard height menu.
5. Set the height to the maximum size.
6. Revert to Keyman Home screen.
7. Change the Orientation from Portrait to Landscape.
8. Verify OSK displays and is full width and full height.
9. Change the orientation from Landscape to Portrait.
10. Verify OSK displays and is full width and full height.
11. Repeat steps 7 through 10 at least ten times, verifying that the OSK always displays with the correct width. 
 
**TEST_OSK_ROTATION_ANDROID_13**
1. Install the PR build of Keyman for Android on an Android device/emulator Android 13 (SDK 33) 
2. Open Keyman In-App.
3. Open the Settings menu.
4. Open Adjust keyboard height menu.
5. Set the height to the maximum size.
6. Revert to Keyman Home screen.
7. Change the Orientation from Portrait to Landscape.
8. Verify OSK displays and is full width and full height.
9. Change the orientation from Landscape to Portrait.
10. Verify OSK displays and is full width and full height.
11. Repeat steps 7 through 10 at least ten times, verifying that the OSK always displays with the correct width. 