### PR TITLE
fix(developer): handle `KM_CORE_IT_INVALIDATE_CONTEXT` in debugger 🍒 🏠

### DIFF
--- a/developer/src/tike/debug/Keyman.System.Debug.DebugEvent.pas
+++ b/developer/src/tike/debug/Keyman.System.Debug.DebugEvent.pas
@@ -360,6 +360,13 @@ begin
 
   AddDebugItem(debug, debugkeyboard, vk, modifier_state);
 
+  if action._type = KM_CORE_IT_INVALIDATE_CONTEXT then
+  begin
+    // We always ignore invalidate context which can come when a frame key is
+    // pressed (#11172, #11486)
+    Inc(action);
+  end;
+
   if action._type = KM_CORE_IT_EMIT_KEYSTROKE then
   begin
     // The EMIT_KEYSTROKE action comes after all rules have completed processing


### PR DESCRIPTION
Cherry-pick of #11488.

The output from Keyman Core changed in #11172 to emit a `KM_CORE_IT_INVALIDATE_CONTEXT` action when a frame key is pressed, but the debugger was not catering for this scenario, causing an assertion failure.

Fixes: #11486
Fixes: KEYMAN-DEVELOPER-1Y4

@keymanapp-test-bot skip