### PR TITLE
change(common): remove `is:open` from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
         ### Before you start
 
         Before you submit this bug report, have you searched other reports for this bug?
-          https://github.com/keymanapp/keyman/issues?q=is%3Aopen+is%3Aissue+label%3Abug
+          https://github.com/keymanapp/keyman/issues?q=is%3Aissue+label%3Abug
 
         * If you find a matching issue, go ahead and add a comment on that issue.
         * If you find related issues, make sure you list them below.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       value: |
         Before you submit this feature request, have you searched existing requests?
-          https://github.com/keymanapp/keyman/issues?q=is%3Aopen+is%3Aissue+label%3Afeat
+          https://github.com/keymanapp/keyman/issues?q=is%3Aissue+label%3Afeat
 
         * If you find a matching issue, go ahead and add a comment on that issue.
         * If you find related issues, make sure you list them below.


### PR DESCRIPTION
Where bugs have been fixed and closed, users tend to miss this if the bug has not yet stable. So expanding the search to show all issues that match by default, whether open or closed.

Fixes: #11212

@keymanapp-test-bot skip