### PR TITLE
fix(android): Delete sentry-cli-2.31.1.exe during CI builds

### DIFF
--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
         // sentry-android-gradle-plugin 2.1.5+ requires AGP 7.0
-        classpath 'io.sentry:sentry-android-gradle-plugin:4.5.1'
+        classpath 'io.sentry:sentry-android-gradle-plugin:4.6.0'
         classpath 'name.remal:gradle-plugins:1.5.0'
 
         // From jcenter() which could be sunset in future

--- a/oem/firstvoices/android/build.gradle
+++ b/oem/firstvoices/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath 'io.sentry:sentry-android-gradle-plugin:4.5.1'
+        classpath 'io.sentry:sentry-android-gradle-plugin:4.6.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/oem/firstvoices/android/build.sh
+++ b/oem/firstvoices/android/build.sh
@@ -25,8 +25,7 @@ builder_describe "Builds FirstVoices for Android app." \
   "configure" \
   "build" \
   "test             Runs lint and tests." \
-  "--ci             Don't start the Gradle daemon. For CI" \
-  "--upload-sentry  Upload to sentry"
+  "--ci             Don't start the Gradle daemon. For CI"
 
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
@@ -54,15 +53,10 @@ fi
 
 #### Build action definitions ####
 
-function makeLocalSentryRelease() {
-  echo "Placeholder for uploading symbols to Sentry"
-}
-
-#### Build action definitions ####
-
 # Check about cleaning artifact paths
 if builder_start_action clean; then
   rm -rf "$KEYMAN_ROOT/oem/firstvoices/android/app/build/outputs"
+  rm -rf "$KEYMAN_ROOT/oem/firstvoices/android/app/build/tmp"
   builder_finish_action success clean
 fi
 


### PR DESCRIPTION
Attempts to address #11491 and follows #11393

This bumps the sentry-android-gradle-plugin (the [4.6.0 release notes](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/4.6.0) mentioned fixes for sentry-cli)

FV build.sh updates:
*  `fv:clean` to also clean the /build/tmp
* Remove unused `--upload-sentry` parameter

@keymanapp-test-bot skip
