### PR TITLE
fix(web): properly pass test-runner verbose-logging flag

### DIFF
--- a/web/test.sh
+++ b/web/test.sh
@@ -62,7 +62,7 @@ fi
 # Prepare the flags for the karma command.
 WTR_DEBUG=
 if builder_is_debug_build; then
-  WTR_DEBUG=" --manual"
+  WTR_DEBUG="--manual"
 fi
 
 # End common configs.

--- a/web/test.sh
+++ b/web/test.sh
@@ -67,6 +67,6 @@ fi
 
 # End common configs.
 
-builder_run_action test:dom web-test-runner --config "src/test/auto/dom/web-test-runner${WTR_CONFIG}.config.mjs" "${WTR_DEBUG}"
+builder_run_action test:dom web-test-runner --config "src/test/auto/dom/web-test-runner${WTR_CONFIG}.config.mjs" ${WTR_DEBUG}
 
-builder_run_action test:integrated web-test-runner --config "src/test/auto/integrated/web-test-runner${WTR_CONFIG}.config.mjs" "${WTR_DEBUG}"
+builder_run_action test:integrated web-test-runner --config "src/test/auto/integrated/web-test-runner${WTR_CONFIG}.config.mjs" ${WTR_DEBUG}


### PR DESCRIPTION
I'm not sure how it wasn't caught as part of the test-runner PRs, but the manner in which the verbose-logging flag (`--debug`) was being passed caused it to have a prepended space that had a nasty unintended side-effect breaking runs like this one: https://build.palaso.org/buildConfiguration/Keymanweb_TestPullRequests/465297?buildTab=log&linesState=719&logView=flowAware

@keymanapp-test-bot skip