### PR TITLE
fix(android/engine): Ignore updating invalid selections

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -194,12 +194,15 @@ final class KMKeyboard extends WebView {
 
     int selMin = icText.selectionStart, selMax = icText.selectionEnd;
 
-    if (selMin < 0 || selMax < 0 || rawText.length() == 0) {
+    int textLength = rawText.length();
+    
+    if (selMin < 0 || selMax < 0) {
       // There is no selection or cursor
       // Reference https://developer.android.com/reference/android/text/Selection#getSelectionEnd(java.lang.CharSequence)
       return false;
-    } else if (selMin > rawText.length()-1 || selMax > rawText.length()-1) {
-      // Selection is past existing text
+    } else if (selMin > textLength || selMax > textLength) {
+      // Selection is past end of existing text -- should not be possible but we 
+      // are seeing it happen; #11506
       return false;
     }
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -194,9 +194,12 @@ final class KMKeyboard extends WebView {
 
     int selMin = icText.selectionStart, selMax = icText.selectionEnd;
 
-    if (selMin < 0 || selMax < 0) {
+    if (selMin < 0 || selMax < 0 || rawText.length() == 0) {
       // There is no selection or cursor
       // Reference https://developer.android.com/reference/android/text/Selection#getSelectionEnd(java.lang.CharSequence)
+      return false;
+    } else if (selMin > rawText.length()-1 || selMax > rawText.length()-1) {
+      // Selection is past existing text
       return false;
     }
 


### PR DESCRIPTION
Fixes #11506

This adds more sanity-checking to `KMKeyboard.updateSelectionRange()`. Will :cherries: pick to stable-17.0

Don't attempt to process selection if 
* text is empty
* selection is past the current text

I can verify these hit the debugger (selMax is 23 when the raw text length is 23). But I can't repro the crashes in the Sentry issue.

## User Testing
**Setup** - Install the PR build of Keyman for Android

* **TEST_INVALID_SELECTIONS** - Verifies app does not crash on invalid selections
1. Launch Keyman
2. In the Keyman app, type some text
3. Move the cursor to earlier in the text
4. Move the cursor past the text
5. Verify cursor is at the right of the text