### PR TITLE
change(mac): adopt unified logging APIs

### DIFF
--- a/mac/Keyman4Mac/Keyman4Mac/AppDelegate.m
+++ b/mac/Keyman4Mac/Keyman4Mac/AppDelegate.m
@@ -8,7 +8,6 @@
 
 #import "AppDelegate.h"
 #import <KeymanEngine4Mac/KeymanEngine4Mac.h>
-#import <os/log.h>
 
 static BOOL debugMode = YES;
 
@@ -68,8 +67,6 @@ NSString *const kKMXFileKey = @"KMXFile";
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "AppDelegate windowDidResize");
   [self.oskView resizeOSKLayout];
 }
 

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		290BC680274B9DB1005CD1C3 /* KMPackageInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 290BC67F274B9DB1005CD1C3 /* KMPackageInfo.m */; };
 		290BC75E274F3FD7005CD1C3 /* KMKeyboardInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 290BC75D274F3FD7005CD1C3 /* KMKeyboardInfo.m */; };
+		2915DC512BFE35DB0051FC52 /* KMLogs.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B4A0D32BF7675A00682049 /* KMLogs.m */; };
 		293EA3E627140D8100545EED /* KMAboutWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 293EA3E827140D8100545EED /* KMAboutWindowController.xib */; };
 		293EA3EB27140DEC00545EED /* preferences.xib in Resources */ = {isa = PBXBuildFile; fileRef = 293EA3ED27140DEC00545EED /* preferences.xib */; };
 		293EA3F427181FDA00545EED /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 293EA3F627181FDA00545EED /* Localizable.strings */; };
@@ -1004,6 +1005,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2915DC512BFE35DB0051FC52 /* KMLogs.m in Sources */,
 				2992F4202A28482800E08929 /* PrivacyWindowController.m in Sources */,
 				2992F41F2A2847C900E08929 /* TextApiCompliance.m in Sources */,
 				2992F41E2A2847AF00E08929 /* PrivacyConsent.m in Sources */,

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		299B5E2129126CA20070841D /* keyman-icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 299B5E1F29126CA20070841D /* keyman-icon.png */; };
 		29B42A572728339900EDD5D3 /* KMInfoWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 29B42A592728339900EDD5D3 /* KMInfoWindowController.xib */; };
 		29B42A602728343B00EDD5D3 /* KMKeyboardHelpWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 29B42A622728343B00EDD5D3 /* KMKeyboardHelpWindowController.xib */; };
+		29B4A0D52BF7675A00682049 /* KMLogs.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B4A0D32BF7675A00682049 /* KMLogs.m */; };
 		29B6FB732BC39DD60074BF7F /* TextApiComplianceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B6FB722BC39DD60074BF7F /* TextApiComplianceTests.m */; };
 		37A245C12565DFA6000BBF92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 37A245C02565DFA6000BBF92 /* Assets.xcassets */; };
 		37AE5C9D239A7B770086CC7C /* qrcode.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 37AE5C9C239A7B770086CC7C /* qrcode.min.js */; };
@@ -216,6 +217,8 @@
 		29B42A612728343B00EDD5D3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/KMKeyboardHelpWindowController.xib; sourceTree = "<group>"; };
 		29B42A642728343F00EDD5D3 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/KMKeyboardHelpWindowController.strings; sourceTree = "<group>"; };
 		29B42A682728344600EDD5D3 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/KMKeyboardHelpWindowController.strings; sourceTree = "<group>"; };
+		29B4A0D32BF7675A00682049 /* KMLogs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KMLogs.m; sourceTree = "<group>"; };
+		29B4A0D42BF7675A00682049 /* KMLogs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KMLogs.h; sourceTree = "<group>"; };
 		29B5BC0328169A6300B86A17 /* ff */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ff; path = ff.lproj/KMAboutWindowController.strings; sourceTree = "<group>"; };
 		29B5BC0428169A6400B86A17 /* ff */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ff; path = ff.lproj/preferences.strings; sourceTree = "<group>"; };
 		29B5BC0528169A6400B86A17 /* ff */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ff; path = ff.lproj/KMInfoWindowController.strings; sourceTree = "<group>"; };
@@ -540,8 +543,10 @@
 		989C9C0A1A7876DE00A20425 /* Keyman4MacIM */ = {
 			isa = PBXGroup;
 			children = (
-				299ABD7029ECE75B00AA5948 /* KeySender.h */,
+				29B4A0D42BF7675A00682049 /* KMLogs.h */,
+				29B4A0D32BF7675A00682049 /* KMLogs.m */,
 				299ABD6F29ECE75B00AA5948 /* KeySender.m */,
+				299ABD7029ECE75B00AA5948 /* KeySender.h */,
 				297A501128DF4D360074EB1B /* Privacy */,
 				98FE105B1B4DE86300525F54 /* Categories */,
 				98D6DA791A799EE700B09822 /* Frameworks */,
@@ -965,6 +970,7 @@
 				9A3D6C5D221531B0008785A3 /* KMOSVersion.m in Sources */,
 				989C9C111A7876DE00A20425 /* main.m in Sources */,
 				290BC680274B9DB1005CD1C3 /* KMPackageInfo.m in Sources */,
+				29B4A0D52BF7675A00682049 /* KMLogs.m in Sources */,
 				98BF924F1BF02DC20002126A /* KMBarView.m in Sources */,
 				E240F599202DED740000067D /* KMPackage.m in Sources */,
 				984B8F441AF1C3D900E096A8 /* OSKWindowController.m in Sources */,

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutBGView.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutBGView.m
@@ -7,6 +7,7 @@
 //
 
 #import "KMAboutBGView.h"
+#import "KMLogs.h"
 
 @implementation KMAboutBGView
 
@@ -20,15 +21,15 @@
   NSRect topFill, botFill;
   topFill = rect;
   botFill = rect;
-  //    NSLog(@"rect origin x %f y %f  size h %f w %f", rect.origin.x, rect.origin.y, rect.size.height, rect.size.width);
+  //os_log_debug([KMLogs uiLog], "rect origin x %f y %f  size h %f w %f", rect.origin.x, rect.origin.y, rect.size.height, rect.size.width);
   NSView *topImgView = [self viewWithTag:1];
-  //    NSLog(@"topImgView origin x %f y %f  size h %f w %f before", topImgView.frame.origin.x, topImgView.frame.origin.y, topImgView.frame.size.height, topImgView.frame.size.width);
+  //os_log_debug([KMLogs uiLog], "topImgView origin x %f y %f  size h %f w %f before", topImgView.frame.origin.x, topImgView.frame.origin.y, topImgView.frame.size.height, topImgView.frame.size.width);
   NSInteger imgOriginHeightDelta = topImgView.frame.origin.y - rect.origin.y;
   topFill.origin.y += imgOriginHeightDelta;
   topFill.size.height -= imgOriginHeightDelta;
   botFill.size.height = imgOriginHeightDelta;
-  //    NSLog(@"topFill origin x %f y %f  size h %f w %f after raising to imgHeight %ld", topFill.origin.x, topFill.origin.y, topFill.size.height, topFill.size.width, imgOriginHeightDelta);
-  //    NSLog(@"botFill origin x %f y %f  size h %f w %f after reducing by imgHeight %ld", botFill.origin.x, botFill.origin.y, botFill.size.height, botFill.size.width, imgOriginHeightDelta);
+  //os_log_debug([KMLogs uiLog], "topFill origin x %f y %f  size h %f w %f after raising to imgHeight %ld", topFill.origin.x, topFill.origin.y, topFill.size.height, topFill.size.width, imgOriginHeightDelta);
+  //os_log_debug([KMLogs uiLog], "botFill origin x %f y %f  size h %f w %f after reducing by imgHeight %ld", botFill.origin.x, botFill.origin.y, botFill.size.height, botFill.size.width, imgOriginHeightDelta);
   [[NSColor whiteColor] setFill];
   NSRectFillUsingOperation(topFill, NSCompositingOperationSourceOver);
   [[NSColor windowBackgroundColor] setFill];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMAboutWindow/KMAboutWindowController.m
@@ -9,6 +9,7 @@
 #import "KMAboutWindowController.h"
 #import "KMInputMethodAppDelegate.h"
 #import "KMOSVersion.h"
+#import "KMLogs.h"
 
 @interface KMAboutWindowController ()
 @property (nonatomic, weak) IBOutlet NSTextField *versionLabel;
@@ -53,12 +54,12 @@
   u_int16_t systemVersion = [KMOSVersion SystemVersion];
   if ([KMOSVersion Version_10_13_1] <= systemVersion && systemVersion <= [KMOSVersion Version_10_13_3]) // between 10.13.1 and 10.13.3 inclusive
   {
-    NSLog(@"About Box: calling workaround instead of showPreferences (sys ver %x)", systemVersion);
+    os_log([KMLogs uiLog], "About Box: calling workaround instead of showPreferences (sys ver %x)", systemVersion);
     [self.AppDelegate showConfigurationWindow]; // call our workaround
   }
   else
   {
-    NSLog(@"About Box: calling Apple's showPreferences (sys ver %x)", systemVersion);
+    os_log([KMLogs uiLog], "About Box: calling Apple's showPreferences (sys ver %x)", systemVersion);
     [self.AppDelegate.inputController showPreferences:sender]; // call Apple API
   }
   [self close];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -8,6 +8,7 @@
 
 #import "KMConfigurationWindowController.h"
 #import "KMDownloadKBWindowController.h"
+#import "KMLogs.h"
 
 @interface KMConfigurationWindowController ()
 @property (nonatomic, weak) IBOutlet NSTableView *tableView;
@@ -79,8 +80,7 @@
 
 - (void)webView:(WebView *)webView decidePolicyForNavigationAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request frame:(WebFrame *)frame decisionListener:(id<WebPolicyDecisionListener>)listener {
   NSString* url = [[request URL] absoluteString];
-  if (self.AppDelegate.debugMode)
-    NSLog(@"decidePolicyForNavigationAction, navigating to %@", url);
+  os_log_debug([KMLogs uiLog], "decidePolicyForNavigationAction, navigating to %{public}@", url);
   
   if([url hasPrefix: @"file:"]) {
     [listener use];
@@ -358,14 +358,12 @@
   NSButton *checkBox = (NSButton *)sender;
   NSString *kmxFilePath = [self kmxFilePathAtIndex:checkBox.tag];
   if (checkBox.state == NSOnState) {
-    if ([self.AppDelegate debugMode])
-      NSLog(@"Adding active keyboard: %@", kmxFilePath);
+    os_log_debug([KMLogs uiLog], "Adding active keyboard: %{public}@", kmxFilePath);
     [self.activeKeyboards addObject:kmxFilePath];
     [self saveActiveKeyboards];
   }
   else if (checkBox.state == NSOffState) {
-    if ([self.AppDelegate debugMode])
-      NSLog(@"Disabling active keyboard: %@", kmxFilePath);
+    os_log_debug([KMLogs uiLog], "Disabling active keyboard: %{public}@", kmxFilePath);
     [self.activeKeyboards removeObject:kmxFilePath];
     [self saveActiveKeyboards];
   }
@@ -443,10 +441,7 @@
   NSString *keyboardInfoString = NSLocalizedString(@"info-install-keyboard-filename", nil);
   [self.confirmKmpInstallAlertView setInformativeText:[NSString localizedStringWithFormat:keyboardInfoString, package.getOrigKmpFilename]];
   
-  if ([self.AppDelegate debugMode]) {
-    NSLog(@"Asking user to confirm installation of %@...", package.getOrigKmpFilename);
-    NSLog(@"KMP - temp file name: %@", package.getTempKmpFilename);
-  }
+  os_log_debug([KMLogs uiLog], "Asking user to confirm installation of %{public}@, KMP - temp file name: %{public}@", package.getOrigKmpFilename, package.getTempKmpFilename);
   
   [self.confirmKmpInstallAlertView beginSheetModalForWindow:self.window
                                               modalDelegate:self
@@ -457,9 +452,7 @@
 - (void)installPackageFile:(NSString *)kmpFile {
   // kmpFile could be a temp file (in fact, it always is!), so don't display the name.
   
-  if ([self.AppDelegate debugMode]) {
-    NSLog(@"KMP - Ready to unzip/install Package File: %@", kmpFile);
-  }
+  os_log_debug([KMLogs dataLog], "KMP - Ready to unzip/install Package File: %{public}@", kmpFile);
   
   BOOL didUnzip = [self.AppDelegate unzipFile:kmpFile];
   
@@ -477,8 +470,8 @@
                        didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:)
                           contextInfo:nil];
   }
-  else if ([self.AppDelegate debugMode]) {
-    NSLog(@"Completed installation of KMP file.");
+  else {
+    os_log_debug([KMLogs dataLog], "Completed installation of KMP file.");
   }
 }
 
@@ -555,9 +548,7 @@
 }
 
 - (void)alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo {
-  if ([self.AppDelegate debugMode]) {
-    NSLog(@"User responded to NSAlert");
-  }
+  os_log_debug([KMLogs uiLog], "User responded to NSAlert");
   if (alert == _deleteAlertView) {
     if (returnCode == NSAlertFirstButtonReturn) { // Delete
       [self deleteFileAtIndex:(__bridge NSNumber *)contextInfo];
@@ -567,9 +558,7 @@
   }
   else if (alert == _confirmKmpInstallAlertView) {
     KMPackage *package = (__bridge KMPackage *)contextInfo;
-    if ([self.AppDelegate debugMode]) {
-      NSLog(@"KMP - Temp file: %@", package.getTempKmpFilename);
-    }
+    os_log_debug([KMLogs uiLog], "KMP - Temp file: %{public}@", package.getTempKmpFilename);
     if (returnCode == NSAlertFirstButtonReturn) { // Install
       [self installPackageFile: package.getTempKmpFilename];
     }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/KMInfoWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInfoWindow/KMInfoWindowController.m
@@ -10,6 +10,7 @@
 #import "KMInputMethodAppDelegate.h"
 #import "KMPackageInfo.h"
 #import "KMKeyboardInfo.h"
+#import "KMLogs.h"
 #import <WebKit/WebKit.h>
 
 @interface KMInfoWindowController ()
@@ -199,7 +200,7 @@
     return htmlStr;
   }
   @catch (NSException *e) {
-    NSLog(@"Error = %@", e.description);
+    os_log_error([KMLogs uiLog], "Error = %@", e.description);
     return nil;
   }
 }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
@@ -23,9 +23,7 @@ NSMutableArray *servers;
 
 - (id)initWithServer:(IMKServer *)server delegate:(id)delegate client:(id)inputClient
 {
-  if ([self.AppDelegate debugMode]) {
-    NSLog(@"Initializing Keyman Input Method with server: %@", server);
-  }
+  os_log_debug([KMLogs lifecycleLog], "Initializing Keyman Input Method for server with bundleID: %{public}@", server.bundle.bundleIdentifier);
   
   self = [super initWithServer:server delegate:delegate client:inputClient];
   if (self) {
@@ -44,12 +42,8 @@ NSMutableArray *servers;
 }
 
 - (BOOL)handleEvent:(NSEvent *)event client:(id)sender {
-  if ([self.AppDelegate debugMode])
-    NSLog(@"handleEvent: event = %@", event);
-  
   if (event == nil || sender == nil || self.kmx == nil || _eventHandler == nil) {
-    if ([self.AppDelegate debugMode])
-      NSLog(@"handleEvent: not handling event");
+    os_log_error([KMLogs eventsLog], "IMInputController handleEvent: not prepared to handle event = %{public}@", event);
     return NO; // Not sure this can ever happen.
   }
   
@@ -78,9 +72,7 @@ NSMutableArray *servers;
     
     NSRunningApplication *currApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
     NSString *clientAppId = [currApp bundleIdentifier];
-    if ([self.AppDelegate debugMode]) {
-      NSLog(@"activateServer, new active app: '%@', sender %@", clientAppId, sender);
-    }
+    os_log_debug([KMLogs lifecycleLog], "activateServer, new active app: '%{public}@'", clientAppId);
     
     _eventHandler = [[KMInputMethodEventHandler alloc] initWithClient:clientAppId client:sender];
     
@@ -89,9 +81,7 @@ NSMutableArray *servers;
 
 - (void)deactivateServer:(id)sender {
   if ([self.AppDelegate debugMode]) {
-    NSLog(@"*** deactivateServer ***");
-    NSLog(@"sender: %@", sender);
-    NSLog(@"***");
+    os_log_debug([KMLogs lifecycleLog], "deactivateServer, sender %{public}@", sender);
   }
   @synchronized(servers) {
     for (int i = 0; i < servers.count; i++) {
@@ -101,9 +91,7 @@ NSMutableArray *servers;
       }
     }
     if (servers.count == 0) {
-      if ([self.AppDelegate debugMode]) {
-        NSLog(@"No known active server for Keyman IM. Starting countdown to sleep...");
-      }
+      os_log_debug([KMLogs lifecycleLog], "No known active server for Keyman IM. Starting countdown to sleep...");
       [self performSelector:@selector(timerAction:) withObject:sender afterDelay:0.7];
     }
   }
@@ -125,7 +113,7 @@ NSMutableArray *servers;
 /*
  - (NSDictionary *)modes:(id)sender {
  if ([self.AppDelegate debugMode])
- NSLog(@"*** Modes ***");
+ os_log_debug([KMLogs lifecycleLog], "*** Modes ***");
  if (_kmModes == nil) {
  NSDictionary *amhMode = [[NSDictionary alloc] initWithObjectsAndKeys:@"keyman.png", kTSInputModeAlternateMenuIconFileKey,
  [NSNumber numberWithBool:YES], kTSInputModeDefaultStateKey,
@@ -172,8 +160,7 @@ NSMutableArray *servers;
 - (void)menuAction:(id)sender {
   NSMenuItem *mItem = [sender objectForKey:kIMKCommandMenuItemName];
   NSInteger itag = mItem.tag;
-  if ([self.AppDelegate debugMode])
-    NSLog(@"Keyman menu clicked - tag: %lu", itag);
+  os_log_debug([KMLogs uiLog], "Keyman menu clicked - tag: %lu", itag);
   if (itag == CONFIG_MENUITEM_TAG) {
     [self showConfigurationWindow:sender];
   }
@@ -195,12 +182,12 @@ NSMutableArray *servers;
   u_int16_t systemVersion = [KMOSVersion SystemVersion];
   if ([KMOSVersion Version_10_13_1] <= systemVersion && systemVersion <= [KMOSVersion Version_10_13_3]) // between 10.13.1 and 10.13.3 inclusive
   {
-    NSLog(@"Input Menu: calling workaround instead of showPreferences (sys ver %x)", systemVersion);
+    os_log_info([KMLogs uiLog], "Input Menu: calling workaround instead of showPreferences (sys ver %x)", systemVersion);
     [self.AppDelegate showConfigurationWindow]; // call our workaround
   }
   else
   {
-    NSLog(@"Input Menu: calling Apple's showPreferences (sys ver %x)", systemVersion);
+    os_log_info([KMLogs uiLog], "Input Menu: calling Apple's showPreferences (sys ver %x)", systemVersion);
     [self showPreferences:sender]; // call Apple API
   }
 }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputController.m
@@ -10,6 +10,7 @@
 #import "KMInputMethodEventHandler.h"
 #import "KMOSVersion.h"
 #include <Carbon/Carbon.h> /* For kVK_ constants. */
+#import "KMLogs.h"
 
 @implementation KMInputController
 
@@ -58,7 +59,7 @@ NSMutableArray *servers;
 // Passthrough from the app delegate low level event hook
 // to the input method event handler for handleBackspace.
 - (void)handleBackspace:(NSEvent *)event {
-  [self.AppDelegate logDebugMessage:@"KMInputController handleBackspace, event = %@", event];
+  os_log_debug([KMLogs keyLog], "KMInputController handleBackspace, event = %{public}@", event);
   if(_eventHandler != nil) {
     [_eventHandler handleBackspace:event];
   }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
@@ -97,7 +97,6 @@ static const int KEYMAN_FIRST_KEYBOARD_MENUITEM_INDEX = 0;
 @property (nonatomic, assign) BOOL useNullChar;
 @property (nonatomic, assign) BOOL debugMode;
 
-- (void)logDebugMessage:(NSString *)format, ...;
 - (NSMenu *)menu;
 - (void)saveActiveKeyboards;
 - (void)readPersistedOptions;

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -23,6 +23,7 @@
 #import "KMPackageInfo.h"
 #import "KMKeyboardInfo.h"
 #import "PrivacyConsent.h"
+#import "KMLogs.h"
 @import Sentry;
 
 /** NSUserDefaults keys */
@@ -107,7 +108,7 @@ NSString* _keymanDataPath = nil;
 }
 
 - (void)initCompletion {
-  NSLog(@"initCompletionHandler method invoked");
+  os_log_info([KMLogs startupLog], "initCompletionHandler method invoked");
   [[NSAppleEventManager sharedAppleEventManager] setEventHandler:self
                                                      andSelector:@selector(handleURLEvent:withReplyEvent:)
                                                    forEventClass:kInternetEventClass
@@ -124,10 +125,10 @@ NSString* _keymanDataPath = nil;
                                            nil);
   
   if (!self.lowLevelEventTap) {
-    NSLog(@"Unable to create lowLevelEventTap!");
+    os_log_error([KMLogs startupLog], "Unable to create lowLevelEventTap!");
   }
   else {
-    NSLog(@"Successfully created lowLevelEventTap with CGEventTapCreate.");
+    os_log([KMLogs startupLog], "Successfully created lowLevelEventTap with CGEventTapCreate.");
     CFRelease(self.lowLevelEventTap);
   }
   
@@ -140,6 +141,7 @@ NSString* _keymanDataPath = nil;
   }
 }
 
+// TODO: remove
 -(void)logDebugMessage:(NSString *)format, ... {
   if (self.debugMode) {
     va_list args;
@@ -178,6 +180,8 @@ NSString* _keymanDataPath = nil;
   KeymanVersionInfo keymanVersionInfo = [self versionInfo];
   NSString *releaseName = [NSString stringWithFormat:@"%@", keymanVersionInfo.versionGitTag];
   
+  [KMLogs reportLogStatus];
+  
   [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"https://960f8b8e574c46e3be385d60ce8e1fea@o1005580.ingest.sentry.io/5983522";
     options.releaseName = releaseName;
@@ -190,9 +194,9 @@ NSString* _keymanDataPath = nil;
 
 #ifdef USE_ALERT_SHOW_HELP_TO_FORCE_EASTER_EGG_CRASH_FROM_ENGINE
 - (BOOL)alertShowHelp:(NSAlert *)alert {
-  NSLog(@"Sentry - KME: Got call to force crash from engine");
+  os_log_error([KMLogs startupLog], "Sentry - KME: Got call to force crash from engine");
   [SentrySDK crash];
-  NSLog(@"Sentry - KME: should not have gotten this far!");
+  os_log_error([KMLogs startupLog], "Sentry - KME: should not have gotten this far!");
   return NO;
 }
 #endif
@@ -206,13 +210,11 @@ NSString* _keymanDataPath = nil;
   NSMutableString *urlStr = [NSMutableString stringWithString:rawUrl];
   [urlStr replaceOccurrencesOfString:@"keyman:" withString:@"keyman/" options:0 range:NSMakeRange(0, 7)];
   NSURL *url = [NSURL URLWithString:urlStr];
-  if (self.debugMode)
-    NSLog(@"url = %@", url);
+  os_log_debug([KMLogs keyboardLog], "processURL, url = %{public}@", url);
   
   if ([url.lastPathComponent isEqualToString:@"download"]) {
     if (_connection != nil) {
-      if (self.debugMode)
-        NSLog(@"Already downloading a keyboard.");
+      os_log_debug([KMLogs keyboardLog], "Already downloading a keyboard.");
       return;
     }
     
@@ -236,23 +238,17 @@ NSString* _keymanDataPath = nil;
 }
 
 -(void) sleepFollowingDeactivationOfServer:(id)lastServer {
-  if ([self debugMode]) {
-    NSLog(@"Keyman no longer active IM.");
-  }
+  os_log_debug([KMLogs lifecycleLog], "Keyman no longer active IM.");
   self.sleeping = YES;
   if ([self.oskWindow.window isVisible]) {
-    if ([self debugMode]) {
-      NSLog(@"Hiding OSK.");
-    }
+    os_log_debug([KMLogs oskLog], "sleepFollowingDeactivationOfServer, Hiding OSK.");
     // Storing this ensures that if the deactivation is temporary, resulting from dropping down a menu,
     // the OSK will re-display when that client application re-activates.
     _lastServerWithOSKShowing = lastServer;
     [self.oskWindow.window setIsVisible:NO];
   }
   if (self.lowLevelEventTap) {
-    if ([self debugMode]) {
-      NSLog(@"Disabling event tap...");
-    }
+    os_log_debug([KMLogs lifecycleLog], "sleepFollowingDeactivationOfServer, disabling event tap...");
     CGEventTapEnable(self.lowLevelEventTap, NO);
   }
 }
@@ -260,9 +256,7 @@ NSString* _keymanDataPath = nil;
 -(void) wakeUpWith:(id)newServer {
   self.sleeping = NO;
   if (self.lowLevelEventTap && !CGEventTapIsEnabled(self.lowLevelEventTap)) {
-    if ([self debugMode]) {
-      NSLog(@"Keyman is now the active IM. Re-enabling event tap...");
-    }
+    os_log_debug([KMLogs lifecycleLog], "wakeUpWith, Keyman is now the active IM. Re-enabling event tap...");
     CGEventTapEnable(self.lowLevelEventTap, YES);
   }
   // See note in sleepFollowingDeactivationOfServer.
@@ -282,7 +276,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
       if (!appDelegate.sleeping) {
         // REVIEW: We might need to consider putting in some kind of counter/flag to ensure that the very next
         // event is not another disable so we don't end up in an endless cycle.
-        NSLog(@"Event tap disabled by %@! Attempting to restart...", (type == kCGEventTapDisabledByTimeout ? @"timeout" : @"user"));
+        os_log([KMLogs eventsLog], "Event tap disabled by %{public}@! Attempting to restart...", (type == kCGEventTapDisabledByTimeout ? @"timeout" : @"user"));
         CGEventTapEnable(appDelegate.lowLevelEventTap, YES);
         if (!CGEventTapIsEnabled(appDelegate.lowLevelEventTap)) {
           if (appDelegate.runLoopEventSrc) { // This should always be true
@@ -306,8 +300,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     
     switch (type) {
       case kCGEventFlagsChanged:
-        if (appDelegate.debugMode)
-          NSLog(@"eventTapFunction: system event kCGEventFlagsChanged to: %x", (int) sysEvent.modifierFlags);
+        os_log_debug([KMLogs eventsLog], "eventTapFunction: system event kCGEventFlagsChanged to: %x", (int) sysEvent.modifierFlags);
         appDelegate.currentModifierFlags = sysEvent.modifierFlags;
         if (appDelegate.currentModifierFlags & NSEventModifierFlagCommand) {
           appDelegate.contextChangedByLowLevelEvent = YES;
@@ -318,26 +311,26 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
       case kCGEventLeftMouseDown:
       case kCGEventOtherMouseUp:
       case kCGEventOtherMouseDown:
-        NSLog(@"Event tap context invalidation flagged due to event: %@", event);
+        os_log_debug([KMLogs eventsLog], "Event tap context invalidation flagged due to event: %{public}@", event);
         appDelegate.contextChangedByLowLevelEvent = YES;
         break;
         
       case kCGEventKeyDown:
-        NSLog(@"Event tap keydown event, keyCode: %hu, event: %@", sysEvent.keyCode, event);
+        os_log_debug([KMLogs eventsLog], "Event tap keydown event, keyCode: %hu, event: %{public}@", sysEvent.keyCode, event);
         // Pass back low-level backspace events to the input method event handler
         // because some non-compliant apps do not allow us to see backspace events
         // that we have generated (and we need to see them, for serialization
         // of events)
         if(sysEvent.keyCode == kVK_Delete && appDelegate.inputController != nil) {
-          NSLog(@"Event tap handling kVK_Delete.");
+          os_log_debug([KMLogs eventsLog], "Event tap handling kVK_Delete.");
           [appDelegate.inputController handleBackspace:sysEvent];
         } else if(sysEvent.keyCode == kVK_Delete) {
-          NSLog(@"Event tap not handling kVK_Delete, appDelegate.inputController = %@", appDelegate.inputController);
+          os_log_debug([KMLogs eventsLog], "Event tap not handling kVK_Delete, appDelegate.inputController = %{public}@", appDelegate.inputController);
         }
         if(sysEvent.keyCode == 255) {
-          NSLog(@"*** kKeymanEventKeyCode = 0xFF");
+          os_log_debug([KMLogs eventsLog], "*** kKeymanEventKeyCode = 0xFF");
         } else {
-          NSLog(@"*** other: %d(%x)", (char) sysEvent.keyCode, sysEvent.keyCode);
+          os_log_debug([KMLogs eventsLog], "*** other: %d(%x)", (char) sysEvent.keyCode, sysEvent.keyCode);
         }
         
         switch(sysEvent.keyCode) {
@@ -439,14 +432,14 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
   }
   NSDictionary *persistedOptionsForSelectedKeyboard = [allPersistedOptions objectForKey:_selectedKeyboard];
   if (!persistedOptionsForSelectedKeyboard) {
-    NSLog(@"no persisted options found in UserDefaults for keyboard %@ ", _selectedKeyboard);
+    os_log_info([KMLogs configLog], "no persisted options found in UserDefaults for keyboard %{public}@ ", _selectedKeyboard);
     return;
   }
   
   // TODO: pass array instead of making repeated calls
   for (NSString *key in persistedOptionsForSelectedKeyboard) {
     NSString *value = [persistedOptionsForSelectedKeyboard objectForKey:key];
-    NSLog(@"persisted options found in UserDefaults for keyboard %@, key: %@, value: %@", _selectedKeyboard, key, value);
+    os_log_info([KMLogs configLog], "persisted options found in UserDefaults for keyboard %{public}@, key: %{public}@, value: %{public}@", _selectedKeyboard, key, value);
     [self.kme setCoreOptions:key withValue:value];
   }
 }
@@ -495,7 +488,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 }
 
 - (void)setUseVerboseLogging:(BOOL)useVerboseLogging {
-  NSLog(@"Turning verbose logging %@", useVerboseLogging ? @"on." : @"off.");
+  os_log_debug([KMLogs configLog], "Turning verbose logging %{public}@", useVerboseLogging ? @"on." : @"off.");
   _debugMode = useVerboseLogging;
   if (_kme != nil)
     [_kme setUseVerboseLogging:useVerboseLogging];
@@ -674,8 +667,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     if (infoDict != nil) {
       NSString *name = [infoDict objectForKey:kKMKeyboardNameKey];
       if (name != nil && [name length]) {
-        if (self.debugMode)
-          NSLog(@"Adding keyboard name: %@", name);
+        os_log_debug([KMLogs configLog], "Adding keyboard name: %{public}@", name);
         [kbNames addObject:name];
       }
     }
@@ -814,9 +806,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 - (void)removeDynamicKeyboardMenuItems {
   int numberToRemove = (int) self.menu.numberOfItems - DEFAULT_KEYMAN_MENU_ITEM_COUNT;
   
-  if (self.debugMode) {
-    NSLog(@"*** removeDynamicKeyboardMenuItems, self.menu.numberOfItems = %ld, number of items to remove = %d", (long)self.menu.numberOfItems, numberToRemove);
-  }
+  os_log_info([KMLogs keyboardLog], "*** removeDynamicKeyboardMenuItems, self.menu.numberOfItems = %ld, number of items to remove = %d", (long)self.menu.numberOfItems, numberToRemove);
   
   if (numberToRemove > 0) {
     for (int i = 0; i < numberToRemove; i++) {
@@ -832,7 +822,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
   int menuItemIndex = KEYMAN_FIRST_KEYBOARD_MENUITEM_INDEX;
   
   if (self.debugMode) {
-    NSLog(@"*** populateKeyboardMenuItems, number of active keyboards=%lu", self.activeKeyboards.count);
+    os_log_info([KMLogs configLog], "*** populateKeyboardMenuItems, number of active keyboards=%lu", self.activeKeyboards.count);
   }
   
   // loop through the active keyboards list and add them to the menu
@@ -908,7 +898,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 - (void)selectKeyboardFromMenu:(NSInteger)tag {
   NSMenuItem *menuItem = [self.menu itemWithTag:tag];
   NSString *title = menuItem.title;
-  NSLog(@"Input Menu, selected Keyboards menu, itag: %lu, title: %@", tag, title);
+  os_log_info([KMLogs keyboardLog], "Input Menu, selected Keyboards menu, itag: %lu, title: %{public}@", tag, title);
   for (NSMenuItem *item in self.menu.itemArray) {
     // set the state of the keyboard items in the Keyman menu based on the new selection
     if (item.tag >= KEYMAN_FIRST_KEYBOARD_MENUITEM_TAG) {
@@ -934,8 +924,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
   }
   [self setKvk:kvk];
   NSString *keyboardName = [kmxInfo objectForKey:kKMKeyboardNameKey];
-  if ([self debugMode])
-    NSLog(@"Selected keyboard from menu: %@", keyboardName);
+  os_log_info([KMLogs keyboardLog], "Selected keyboard from menu: %{public}@", keyboardName);
   [self setKeyboardName:keyboardName];
   [self setKeyboardIcon:[kmxInfo objectForKey:kKMKeyboardIconKey]];
   [self setContextBuffer:nil];
@@ -996,8 +985,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 }
 
 - (void)showConfigurationWindow {
-  if (self.debugMode)
-    NSLog(@"Showing config window...");
+  os_log_debug([KMLogs uiLog], "Showing config window...");
   [self.configWindow.window centerInParent];
   [self.configWindow.window makeKeyAndOrderFront:nil];
   [self.configWindow.window setLevel:NSFloatingWindowLevel];
@@ -1027,8 +1015,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 
 - (NSWindowController *)configWindow {
   if (_configWindow.window == nil) {
-    if (self.debugMode)
-      NSLog(@"Creating config window...");
+    os_log_debug([KMLogs uiLog], "Creating config window...");
     _configWindow = [[KMConfigurationWindowController alloc] initWithWindowNibName:@"preferences"];
     [self observeCloseFor:_configWindow.window];
   }
@@ -1289,7 +1276,7 @@ extern const CGKeyCode kProcessPendingBuffer;
   
   CGEventRef ev = CGEventCreateKeyboardEvent (source, virtualKey, true); //down
   if (postEvent) {
-    NSLog(@"postKeyboardEventWithSource, keycode: %d", virtualKey);
+    os_log_info([KMLogs eventsLog], "postKeyboardEventWithSource, keycode: %d", virtualKey);
     postEvent(ev);
   }
   CFRelease(ev);
@@ -1306,7 +1293,7 @@ extern const CGKeyCode kProcessPendingBuffer;
 - (BOOL)verifyPackageVersionInTempFolder: (NSString *)tempDestFolder filePath:(NSString *)filePath {
   KMPackageInfo *packageInfo = [self loadPackageInfo:tempDestFolder];
   if(packageInfo == nil) {
-    NSLog(@"Could not find kmp.json in %@", filePath);
+    os_log_info([KMLogs eventsLog], "Could not find kmp.json in %{public}@", filePath);
   } else {
     NSString* requiredVersion = [packageInfo.fileVersion minimalVersionNumberString];
     KeymanVersionInfo keymanVersionInfo = [self versionInfo];
@@ -1314,7 +1301,7 @@ extern const CGKeyCode kProcessPendingBuffer;
     
     if ([requiredVersion compare:currentVersion options:NSNumericSearch] == NSOrderedDescending) {
       // currentVersion is lower than the requiredVersion
-      NSLog(@"Package %@ requires a newer version of Keyman: %@", filePath, requiredVersion);
+      os_log_error([KMLogs keyboardLog], "Package %{public}@ requires a newer version of Keyman: %{public}@", filePath, requiredVersion);
     } else {
       return YES;
     }
@@ -1340,10 +1327,9 @@ extern const CGKeyCode kProcessPendingBuffer;
   
   ZipArchive *za = [[ZipArchive alloc] init];
   if ([za UnzipOpenFile:filePath]) {
-    if (self.debugMode) {
-      NSLog(@"Unzipping %@ to %@", filePath, tempDestFolder);
-      if ([[NSFileManager defaultManager] fileExistsAtPath:tempDestFolder])
-        NSLog(@"The temp destination folder already exists. Overwriting...");
+    os_log_debug([KMLogs keyboardLog], "Unzipping %{public}@ to %{public}@", filePath, tempDestFolder);
+    if ([[NSFileManager defaultManager] fileExistsAtPath:tempDestFolder]) {
+      os_log_debug([KMLogs keyboardLog], "The temp destination folder already exists. Overwriting...");
     }
     
     didUnzip = [za UnzipFileTo:tempDestFolder overWrite:YES];
@@ -1351,25 +1337,22 @@ extern const CGKeyCode kProcessPendingBuffer;
   }
   
   if (!didUnzip) {
-    NSLog(@"Failed to unzip file: %@", filePath);
+    os_log_error([KMLogs keyboardLog], "Failed to unzip file: %{public}@", filePath);
     return NO;
   }
   
-  if (self.debugMode)
-    NSLog(@"Unzipped file: %@", filePath);
+  os_log_debug([KMLogs keyboardLog], "Unzipped file: %{public}@", filePath);
   
   BOOL didInstall = [self verifyPackageVersionInTempFolder:tempDestFolder filePath:filePath];
   
   NSString *destFolder = [self.keyboardsPath stringByAppendingPathComponent:folderName];
-  
+
   // Remove existing package if it exists
   if (didInstall && [[NSFileManager defaultManager] fileExistsAtPath:destFolder]) {
-    if(self.debugMode) {
-      NSLog(@"The destination folder already exists. Overwriting...");
-    }
+    os_log_debug([KMLogs keyboardLog], "The destination folder already exists. Overwriting...");
     [[NSFileManager defaultManager] removeItemAtPath:destFolder error:&error];
     if (error != nil) {
-      NSLog(@"Unable to remove destination folder %@", destFolder);
+      os_log_error([KMLogs keyboardLog], "Unable to remove destination folder %{public}@", destFolder);
       didInstall = NO;
     }
   }
@@ -1382,7 +1365,7 @@ extern const CGKeyCode kProcessPendingBuffer;
   if(didInstall) {
     [[NSFileManager defaultManager] moveItemAtPath:tempDestFolder toPath:destFolder error:&error];
     if (error != nil) {
-      NSLog(@"Unable to move temp folder %@ to dest folder %@", tempDestFolder, destFolder);
+      os_log_error([KMLogs keyboardLog], "Unable to move temp folder %{public}@ to dest folder %{public}@", tempDestFolder, destFolder);
       didInstall = NO;
     }
   }
@@ -1390,7 +1373,7 @@ extern const CGKeyCode kProcessPendingBuffer;
   if(!didInstall) {
     [[NSFileManager defaultManager] removeItemAtPath:tempDestFolder error:&error];
     if (error != nil) {
-      NSLog(@"Unable to remove temp folder %@", tempDestFolder);
+      os_log_error([KMLogs keyboardLog], "Unable to remove temp folder %{public}@", tempDestFolder);
     }
     
     return NO;
@@ -1401,8 +1384,7 @@ extern const CGKeyCode kProcessPendingBuffer;
   NSString * keyboardFolderPath = [self.keyboardsPath stringByAppendingPathComponent:folderName];
   [self installFontsAtPath:keyboardFolderPath];
   for (NSString *kmxFile in [self KMXFilesAtPath:keyboardFolderPath]) {
-    if (self.debugMode)
-      NSLog(@"Adding keyboard to list of active keyboards: %@", kmxFile);
+    os_log_debug([KMLogs keyboardLog], "Adding keyboard to list of active keyboards: %{public}@", kmxFile);
     if (![self.activeKeyboards containsObject:kmxFile])
       [self.activeKeyboards addObject:kmxFile];
   }
@@ -1442,7 +1424,7 @@ extern const CGKeyCode kProcessPendingBuffer;
       [[NSFileManager defaultManager] copyItemAtPath:srcPath toPath:destPath error:&error];
     
     if (error != nil)
-      NSLog(@"Error = %@", error);
+      os_log_error([KMLogs keyboardLog], "installFontsAtPath error = %{public}@", error);
   }
 }
 

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -141,16 +141,6 @@ NSString* _keymanDataPath = nil;
   }
 }
 
-// TODO: remove
--(void)logDebugMessage:(NSString *)format, ... {
-  if (self.debugMode) {
-    va_list args;
-    va_start(args, format);
-    NSLogv(format, args);
-    va_end(args);
-  }
-}
-
 - (KeymanVersionInfo)versionInfo {
   KeymanVersionInfo result;
   // Get version information from Info.plist, which is filled in

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -285,8 +285,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     NSEvent* sysEvent = [NSEvent eventWithCGEvent:event];
     // Too many of these to be useful for most debugging sessions, but we'll keep this around to be
     // un-commented when needed.
-    //if (appDelegate.debugMode)
-    //    NSLog(@"System Event: %@", sysEvent);
+    //    os_log_debug([KMLogs eventsLog], "System Event: %@", sysEvent);
     
     switch (type) {
       case kCGEventFlagsChanged:
@@ -301,12 +300,12 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
       case kCGEventLeftMouseDown:
       case kCGEventOtherMouseUp:
       case kCGEventOtherMouseDown:
-        os_log_debug([KMLogs eventsLog], "Event tap context invalidation flagged due to event: %{public}@", event);
+        os_log_debug([KMLogs eventsLog], "Event tap context invalidation flagged due to event of type: %u", type);
         appDelegate.contextChangedByLowLevelEvent = YES;
         break;
         
       case kCGEventKeyDown:
-        os_log_debug([KMLogs eventsLog], "Event tap keydown event, keyCode: %hu, event: %{public}@", sysEvent.keyCode, event);
+        os_log_debug([KMLogs eventsLog], "Event tap keydown event, keyCode: %hu", sysEvent.keyCode);
         // Pass back low-level backspace events to the input method event handler
         // because some non-compliant apps do not allow us to see backspace events
         // that we have generated (and we need to see them, for serialization

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -377,7 +377,7 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
      // assume that all non-compliant apps which require backspaces apply an extra backspace if the original event is a backspace
      if ((self.apiCompliance.mustBackspaceUsingEvents) && (event.keyCode == kVK_Delete)) {
      output.codePointsToDeleteBeforeInsert--;
-     os_log_with_type(keymanLog, OS_LOG_TYPE_INFO, "isDeleteAndInsertScenario, after delete pressed subtracting one backspace to reach %d and insert text '%{public}@'", output.codePointsToDeleteBeforeInsert, output.textToInsert);
+     os_log_info(keymanLog, "isDeleteAndInsertScenario, after delete pressed subtracting one backspace to reach %d and insert text '%{public}@'", output.codePointsToDeleteBeforeInsert, output.textToInsert);
      if (output.codePointsToDeleteBeforeInsert == 0) {
      // no backspace events needed
      [self insertAndReplaceTextForOutput:output client:client];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/KMKeyboardHelpWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMKeyboardHelpWindow/KMKeyboardHelpWindowController.m
@@ -10,6 +10,7 @@
 #import "KMInputMethodAppDelegate.h"
 #import "KMPackageInfo.h"
 #import <WebKit/WebKit.h>
+#import "KMLogs.h"
 
 @interface KMKeyboardHelpWindowController ()
 @property (nonatomic, weak) IBOutlet WebView *welcomeView;
@@ -39,7 +40,7 @@
         [self.window setTitle:title];
     }
     @catch (NSException *e) {
-      NSLog(@"Error = %@", e.description);
+      os_log_error([KMLogs dataLog], "Error = %{public}@", e.description);
     }
     
     NSString *welcomeFile = [packagePath stringByAppendingPathComponent:@"welcome.htm"];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.h
@@ -1,0 +1,25 @@
+/*
+ * Keyman is copyright (C) SIL International. MIT License.
+ * 
+ * KMLogs.h
+ * CoreTesterApp
+ * 
+ * Created by Shawn Schantz on 2024-05-16.
+ * 
+ * Description...
+ */
+
+#import <Foundation/Foundation.h>
+#import <os/log.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface KMLogs : NSObject
+
++ (os_log_t)startupLog;
++ (os_log_t)keyLog;
++ (os_log_t)oskLog;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)reportLogStatus;
 + (os_log_t)startupLog;
++ (os_log_t)complianceLog;
 + (os_log_t)lifecycleLog;
 + (os_log_t)configLog;
 + (os_log_t)uiLog;
@@ -25,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (os_log_t)keyboardLog;
 + (os_log_t)keyLog;
 + (os_log_t)oskLog;
++ (os_log_t)testLog;
 
 @end
 

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.h
@@ -18,9 +18,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)reportLogStatus;
 + (os_log_t)startupLog;
++ (os_log_t)privacyLog;
 + (os_log_t)complianceLog;
 + (os_log_t)lifecycleLog;
 + (os_log_t)configLog;
++ (os_log_t)dataLog;
 + (os_log_t)uiLog;
 + (os_log_t)eventsLog;
 + (os_log_t)keyboardLog;

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.m
@@ -23,7 +23,7 @@
 
 @implementation KMLogs
 
-char *const keymanSubsystem = "org.sil.keyman";
+char *const keymanSubsystem = "com.keyman.app";
 char *const startupCategory = "startup";
 char *const privacyCategory = "privacy";
 char *const complianceCategory = "compliance";

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.m
@@ -25,6 +25,7 @@
 
 char *const keymanSubsystem = "org.sil.keyman";
 char *const startupCategory = "startup";
+char *const complianceCategory = "compliance";
 char *const lifecycleCategory = "lifecycle";
 char *const configCategory = "config";
 char *const uiCategory = "ui";
@@ -32,6 +33,7 @@ char *const eventsCategory = "events";
 char *const keyboardCategory = "keyboard";
 char *const keyCategory = "key";
 char *const oskCategory = "osk";
+char *const testCategory = "test";
 
 + (void)reportLogStatus {
   bool debugLogEnabled = os_log_type_enabled([KMLogs startupLog], OS_LOG_TYPE_DEBUG);
@@ -42,6 +44,10 @@ char *const oskCategory = "osk";
 
 + (os_log_t)startupLog {
   return os_log_create(keymanSubsystem, startupCategory);
+}
+
++ (os_log_t)complianceLog {
+  return os_log_create(keymanSubsystem, complianceCategory);
 }
 
 + (os_log_t)lifecycleLog {
@@ -70,6 +76,10 @@ char *const oskCategory = "osk";
 
 + (os_log_t)oskLog {
   return os_log_create(keymanSubsystem, oskCategory);
+}
+
++ (os_log_t)testLog {
+  return os_log_create(keymanSubsystem, testCategory);
 }
 
 @end

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.m
@@ -1,26 +1,67 @@
-/*
+/**
  * Keyman is copyright (C) SIL International. MIT License.
  * 
- * LoggerUtil.m
- * CoreTesterApp
- * 
+ * KMLogs.m
+ * Keyman
+ *
  * Created by Shawn Schantz on 2024-05-16.
  * 
- * Description...
+ * Contains methods to get singleton logger objects and constants for subsystem and category names.
+ */
+
+/**
+ *
+ * The loggers do not appear to be singletons, but the API which creates them manages
+ * them as singletons within macOS so that any subsequent call to create a log object
+ * using the same subsystem and category will return the existing instance.
+ *
+ * For any new log categories used anywhere in the Keyman Input method, the name should be defined here.
+ * Keyman Engine may define and use the same category name but will use a different subsystem name. 
  */
 
 #import "KMLogs.h"
-#import <os/log.h>
 
 @implementation KMLogs
 
 char *const keymanSubsystem = "org.sil.keyman";
 char *const startupCategory = "startup";
+char *const lifecycleCategory = "lifecycle";
+char *const configCategory = "config";
+char *const uiCategory = "ui";
+char *const eventsCategory = "events";
+char *const keyboardCategory = "keyboard";
 char *const keyCategory = "key";
 char *const oskCategory = "osk";
 
++ (void)reportLogStatus {
+  bool debugLogEnabled = os_log_type_enabled([KMLogs startupLog], OS_LOG_TYPE_DEBUG);
+  os_log([KMLogs startupLog], "startupLog has debug messages enabled: %@", debugLogEnabled?@"YES":@"NO");
+  bool infoLogEnabled = os_log_type_enabled([KMLogs startupLog], OS_LOG_TYPE_INFO);
+  os_log([KMLogs startupLog], "startupLog has info messages enabled: %@", infoLogEnabled?@"YES":@"NO");
+}
+
 + (os_log_t)startupLog {
   return os_log_create(keymanSubsystem, startupCategory);
+}
+
++ (os_log_t)lifecycleLog {
+  return os_log_create(keymanSubsystem, lifecycleCategory);
+}
+
++ (os_log_t)configLog {
+  return os_log_create(keymanSubsystem, configCategory);
+}
+
++ (os_log_t)uiLog {
+  return os_log_create(keymanSubsystem, uiCategory);
+}
+
++ (os_log_t)eventsLog {
+  return os_log_create(keymanSubsystem, eventsCategory);
+}
+
++ (os_log_t)keyboardLog {
+  return os_log_create(keymanSubsystem, keyboardCategory);
 }
 
 + (os_log_t)keyLog {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.m
@@ -25,9 +25,11 @@
 
 char *const keymanSubsystem = "org.sil.keyman";
 char *const startupCategory = "startup";
+char *const privacyCategory = "privacy";
 char *const complianceCategory = "compliance";
 char *const lifecycleCategory = "lifecycle";
 char *const configCategory = "config";
+char *const dataCategory = "data";
 char *const uiCategory = "ui";
 char *const eventsCategory = "events";
 char *const keyboardCategory = "keyboard";
@@ -46,6 +48,10 @@ char *const testCategory = "test";
   return os_log_create(keymanSubsystem, startupCategory);
 }
 
++ (os_log_t)privacyLog {
+  return os_log_create(keymanSubsystem, privacyCategory);
+}
+
 + (os_log_t)complianceLog {
   return os_log_create(keymanSubsystem, complianceCategory);
 }
@@ -56,6 +62,10 @@ char *const testCategory = "test";
 
 + (os_log_t)configLog {
   return os_log_create(keymanSubsystem, configCategory);
+}
+
++ (os_log_t)dataLog{
+  return os_log_create(keymanSubsystem, dataCategory);
 }
 
 + (os_log_t)uiLog {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMLogs.m
@@ -1,0 +1,34 @@
+/*
+ * Keyman is copyright (C) SIL International. MIT License.
+ * 
+ * LoggerUtil.m
+ * CoreTesterApp
+ * 
+ * Created by Shawn Schantz on 2024-05-16.
+ * 
+ * Description...
+ */
+
+#import "KMLogs.h"
+#import <os/log.h>
+
+@implementation KMLogs
+
+char *const keymanSubsystem = "org.sil.keyman";
+char *const startupCategory = "startup";
+char *const keyCategory = "key";
+char *const oskCategory = "osk";
+
++ (os_log_t)startupLog {
+  return os_log_create(keymanSubsystem, startupCategory);
+}
+
++ (os_log_t)keyLog {
+  return os_log_create(keymanSubsystem, keyCategory);
+}
+
++ (os_log_t)oskLog {
+  return os_log_create(keymanSubsystem, oskCategory);
+}
+
+@end

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMOSVersion.m
@@ -7,6 +7,7 @@
 //
 
 #import "KMOSVersion.h"
+#import "KMLogs.h"
 
 static CFStringRef sSystemVersionPath = CFSTR("/System/Library/CoreServices/SystemVersion.plist");
 
@@ -16,19 +17,19 @@ static CFStringRef sSystemVersionPath = CFSTR("/System/Library/CoreServices/Syst
   NSDictionary *systemVersionDict = [NSDictionary dictionaryWithContentsOfFile:(__bridge NSString*)sSystemVersionPath];
   if (NULL ==systemVersionDict)
   {
-    NSLog(@"could not read system version dictionary file: %@", sSystemVersionPath);
+    os_log_info([KMLogs configLog], "Could not read system version dictionary file: %{public}@", sSystemVersionPath);
     return 0;
   }
   NSString *systemVersionString = [systemVersionDict objectForKey:@"ProductVersion"];
   if (NULL ==systemVersionString)
   {
-    NSLog(@"could not retrieve system version from dictionary at %@ with %d keys", sSystemVersionPath, (int)systemVersionDict.count);
+    os_log_info([KMLogs configLog], "Could not retrieve system version from dictionary at %{public}@ with %d keys", sSystemVersionPath, (int)systemVersionDict.count);
     return 0;
   }
   NSArray *systemVersionStringParts = [systemVersionString componentsSeparatedByString:@"."];
   if (systemVersionStringParts.count < 2)
   {
-    NSLog(@"Too few parts to the system version (probably): %@", systemVersionString);
+    os_log_info([KMLogs configLog], "Too few parts to the system version (probably): %{public}@", systemVersionString);
     return [systemVersionString intValue]; // hopefully this will at least be the major OS version, e.g., 10 (all versions so far!)
   }
   
@@ -43,7 +44,7 @@ static CFStringRef sSystemVersionPath = CFSTR("/System/Library/CoreServices/Syst
   }
   if (systemVersionStringParts.count > 3)
   {
-    NSLog(@"Portions of System Version string after third part unused: %@", systemVersionString);
+    os_log_info([KMLogs configLog], "Portions of System Version string after third part unused: %{public}@", systemVersionString);
   }
   return systemVersion;
 }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMPackage.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMPackage.m
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "KMPackage.h"
 #import "KMConfigurationWindowController.h"
+#import "KMLogs.h"
 
 @implementation KMPackage
 
@@ -33,9 +34,8 @@ NSString *filename = nil; // This is the filename from the FileWrapper (if any)
 // they decide to install it or cancel the installation. It also gets called one time up-front
 // when Keyman first loads.
 - (void)makeWindowControllers {
-  if ([self.AppDelegate debugMode])
-    NSLog(@"KMP - in KMPackage.makeWindowControllers");
-  
+  os_log_debug([KMLogs dataLog], "KMP - in KMPackage.makeWindowControllers");
+
   if (filename != nil) { // Should be true every time except maybe the very first time (when loading).
     filename = nil;
     [self closeIfFilesAreReleased];
@@ -47,8 +47,8 @@ NSString *filename = nil; // This is the filename from the FileWrapper (if any)
   // we need to close this document so the controller doesn't hold onto it. Otherwise, if the user
   // double-clicks the same KMP file a second time it will just assume we want to open the window
   // to display the already open document, rather than attempting to read it again.
-  if ([self.AppDelegate debugMode])
-    NSLog(@"Closing document to release presenter...");
+
+  os_log_debug([KMLogs dataLog], "Closing document to release presenter...");
   if (filename == nil && filenameTempKMP == nil)
     [self close];
 }
@@ -61,9 +61,8 @@ NSString *filename = nil; // This is the filename from the FileWrapper (if any)
   
   filename = [fileWrapper filename];
   
-  if ([self.AppDelegate debugMode])
-    NSLog(@"readFromFileWrapper called with file: %@", filename);
-  
+  os_log_debug([KMLogs dataLog], "readFromFileWrapper called with file: %{public}@", filename);
+
   if (![typeName isEqualToString: @"Keyman Package"]) {
     if (outError != NULL) {
       NSString *description = [@"Unexpected file association for type " stringByAppendingString:typeName];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMPackageReader.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMPackageReader.m
@@ -12,6 +12,7 @@
  */
 
 #import "KMPackageReader.h"
+#import "KMLogs.h"
 
 static NSString *const kPackageJsonFile = @"kmp.json";
 static NSString *const kPackageInfFile = @"kmp.inf";
@@ -84,20 +85,19 @@ typedef enum {
 - (KMPackageInfo *) loadPackageInfoFromJsonFile:(NSString *)path {
   KMPackageInfo * packageInfo = nil;
   
-  if (self.debugMode)
-    NSLog(@"Loading JSON package info from path: %@", path);
+  os_log([KMLogs dataLog], "Loading JSON package info from path: %{public}@", path);
   NSError *readError = nil;
   NSData *data = [NSData dataWithContentsOfFile:path options:kNilOptions error:&readError];
   NSDictionary *parsedData = nil;
   
   if (data == nil) {
-    NSLog(@"Error reading JSON file at path : %@, error: %@ ", path, readError);
+    os_log_error([KMLogs dataLog], "Error reading JSON file at path : %{public}@, error: %{public}@ ", path, readError);
   } else {
     NSError *parseError = nil;
     parsedData = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&parseError];
     
     if (parsedData == nil) {
-      NSLog(@"Error parsing JSON file at path : %@, error: %@ ", path, parseError);
+      os_log_error([KMLogs dataLog], "Error parsing JSON file at path : %{public}@, error: %{public}@ ", path, parseError);
     } else {
       packageInfo = [self createPackageInfoFromJsonData:parsedData];
     }
@@ -192,9 +192,8 @@ typedef enum {
  * @return      the corresponding PackageInfo value object or nil if the file cannot be found or parsed
  */
 - (KMPackageInfo *) loadPackageInfoFromInfFile:(NSString *)path {
-  if (self.debugMode)
-    NSLog(@"Loading inf package info from path: %@", path);
-  
+  os_log_debug([KMLogs dataLog], "Loading inf package info from path: %{public}@", path);
+
   NSMutableArray *files = [NSMutableArray arrayWithCapacity:0];
   NSMutableArray *keyboardInfoArray = [NSMutableArray arrayWithCapacity:0];
   NSMutableArray *fontArray = [NSMutableArray arrayWithCapacity:0];
@@ -324,7 +323,7 @@ typedef enum {
     }
   }
   @catch (NSException *e) {
-    NSLog(@"Error = %@", e.description);
+    os_log_error([KMLogs dataLog], "Error = %{public}@", e.description);
     return nil;
   }
   

--- a/mac/Keyman4MacIM/Keyman4MacIM/KeySender.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KeySender.h
@@ -15,7 +15,6 @@ extern const CGKeyCode kKeymanEventKeyCode;
 @interface KeySender : NSObject
 
 - (instancetype)init;
-- (void)sendKeyDown:(NSUInteger)keyCode forSourceEvent:(NSEvent *)event includeKeyUp:(BOOL)includeKeyUpEvent;
 - (void)sendBackspaceforEventSource:(CGEventSourceRef)eventSource;
 - (void)sendKeymanKeyCodeForEvent:(NSEvent *)event;
 

--- a/mac/Keyman4MacIM/Keyman4MacIM/KeySender.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KeySender.m
@@ -12,6 +12,7 @@
 #import <InputMethodKit/InputMethodKit.h>
 #import "KeySender.h"
 #import "KMInputMethodAppDelegate.h"
+#import "KMLogs.h"
 
 const CGKeyCode kKeymanEventKeyCode = 0xFF;
 
@@ -30,8 +31,8 @@ const CGKeyCode kKeymanEventKeyCode = 0xFF;
 }
 
 - (void)sendBackspaceforEventSource:(CGEventSourceRef)eventSource {
-  [self.appDelegate logDebugMessage:@"KeySender sendBackspaceforEventSource"];
-  
+  os_log_debug([KMLogs keyLog], "KeySender sendBackspaceforEventSource");
+
   [self postKeyboardEventWithSource:eventSource code:kVK_Delete postCallback:^(CGEventRef eventToPost) {
     CGEventPost(kCGHIDEventTap, eventToPost);
   }];
@@ -40,11 +41,11 @@ const CGKeyCode kKeymanEventKeyCode = 0xFF;
 - (void)postKeyboardEventWithSource: (CGEventSourceRef)source code:(CGKeyCode) virtualKey postCallback:(PostEventCallback)postEvent{
   
   if (!postEvent) {
-    [self.appDelegate logDebugMessage:@"KeySender postKeyboardEventWithSource callback not specified", virtualKey];
+    os_log_debug([KMLogs keyLog], "KeySender postKeyboardEventWithSource callback not specified for virtualKey: %u", virtualKey);
     return;
   }
   
-  [self.appDelegate logDebugMessage:@"KeySender postKeyboardEventWithSource for virtualKey: @%", virtualKey];
+  os_log_debug([KMLogs keyLog], "KeySender postKeyboardEventWithSource for virtualKey: %u", virtualKey);
   
   CGEventRef ev = CGEventCreateKeyboardEvent (source, virtualKey, true); //down
   postEvent(ev);
@@ -61,8 +62,8 @@ const CGKeyCode kKeymanEventKeyCode = 0xFF;
  */
 
 - (void)sendKeymanKeyCodeForEvent:(NSEvent *)event {
-  [self.appDelegate logDebugMessage:@"KeySender sendKeymanKeyCodeForEvent"];
-  
+  os_log_debug([KMLogs keyLog], "KeySender sendKeymanKeyCodeForEvent");
+
   ProcessSerialNumber psn;
   
   // Returns the frontmost app, which is the app that receives key events.
@@ -70,7 +71,7 @@ const CGKeyCode kKeymanEventKeyCode = 0xFF;
   pid_t processId = app.processIdentifier;
   NSString *bundleId = app.bundleIdentifier;
   
-  [self.appDelegate logDebugMessage:@"sendKeymanKeyCodeForEvent keyCode %lu to app %@ with pid %d", (unsigned long)kKeymanEventKeyCode, bundleId, processId];
+  os_log_debug([KMLogs keyLog], "sendKeymanKeyCodeForEvent keyCode %lu to app %{public}@ with pid %d", (unsigned long)kKeymanEventKeyCode, bundleId, processId);
   
   // use nil as source, as this generated event is not directly tied to the originating event
   CGEventRef keyDownEvent = CGEventCreateKeyboardEvent(nil, kKeymanEventKeyCode, true);

--- a/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
@@ -8,7 +8,7 @@
 
 #import "OSKWindowController.h"
 #import "KMInputMethodAppDelegate.h"
-#import <os/log.h>
+#import "KMLogs.h"
 
 @interface OSKWindowController ()
 @property (nonatomic, strong) NSButton *helpButton;
@@ -30,8 +30,7 @@
 }
 
 - (void)awakeFromNib {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKWC awakeFromNib");
+  os_log_debug([KMLogs oskLog], "OSKWindowController awakeFromNib");
   // Keep the aspect ratio constant at its current value
   [self.window setAspectRatio:self.window.frame.size];
   NSSize size = self.window.frame.size;
@@ -54,8 +53,7 @@
 }
 
 - (void)windowDidLoad {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKWC windowDidLoad");
+  os_log_debug([KMLogs oskLog], "OSKWindowController windowDidLoad");
   [super windowDidLoad];
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowDidResize:) name:NSWindowDidResizeNotification object:self.window];
   [self.oskView setKvk:[self.AppDelegate kvk]];
@@ -64,8 +62,7 @@
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKWC windowDidResize");
+  os_log_debug([KMLogs oskLog], "OSKWindowController windowDidResize");
   [self.oskView resizeOSKLayout];
 }
 
@@ -87,8 +84,7 @@
 }
 
 - (void)resetOSK {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKWC windowDidLoad");
+  os_log_debug([KMLogs oskLog], "OSKWindowController windowDidLoad");
   [self.oskView setKvk:[self.AppDelegate kvk]];
   [self.oskView resetOSK];
   if (_helpButton) {

--- a/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyConsent.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyConsent.m
@@ -28,6 +28,7 @@
  */
 
 #import "PrivacyConsent.h"
+#import "KMLogs.h"
 
 @implementation PrivacyConsent
 
@@ -49,7 +50,7 @@
   BOOL hasAccessibility = NO;
   
   hasAccessibility = AXIsProcessTrusted();
-  NSLog(@"  hasAccessibility: %@",hasAccessibility ? @"YES" : @"NO");
+  os_log([KMLogs privacyLog], "  hasAccessibility: %@",hasAccessibility ? @"YES" : @"NO" );
   return hasAccessibility;
 }
 
@@ -72,13 +73,13 @@
   }
   
   if (hasAccessibility) {
-    NSLog(@"already have Accessibility: no need to make request.");
+    os_log([KMLogs privacyLog], "already has Accessibility: no need to make request.");
     // call completionHandler immediately -> privacyDialog will not be presented
     withCompletionHandler();
   } else {
     // set completionHandler to be called after privacyDialog is dismissed
     _completionHandler = withCompletionHandler;
-    NSLog(@"do not have Accessibility, present Privacy Dialog");
+    os_log([KMLogs privacyLog], "does not have Accessibility, present Privacy Dialog");
     [self showPrivacyDialog];
   }
 }
@@ -90,7 +91,7 @@
 {
   NSDictionary *options = @{(id)CFBridgingRelease(kAXTrustedCheckOptionPrompt): @YES};
   BOOL hasAccessibility = AXIsProcessTrustedWithOptions((CFDictionaryRef)options);
-  NSLog(@"  hasAccessibility: %@",hasAccessibility ? @"YES" : @"NO, requesting...");
+  os_log([KMLogs privacyLog], "hasAccessibility: %@",hasAccessibility ? @"YES" : @"NO, requesting...");
 }
 
 /**
@@ -100,7 +101,7 @@
 - (NSWindowController *)privacyDialog {
   if (!_privacyDialog) {
     _privacyDialog = [[PrivacyWindowController alloc] initWithWindowNibName:@"PrivacyWindowController"];
-    NSLog(@"privacyDialog created");
+    os_log([KMLogs privacyLog], "privacyDialog created");
     [self configureDialogForOsVersion];
   }
   
@@ -171,9 +172,9 @@
   // below checks for ListenEvent access
   if (@available(macOS 10.15, *)) {
     hasAccess = CGPreflightListenEventAccess();
-    NSLog(@"CGPreflightListenEventAccess() returned %@", hasAccess ? @"YES" : @"NO");
+    os_log([KMLogs privacyLog], "CGPreflightListenEventAccess() returned %@", hasAccess ? @"YES" : @"NO");
   } else {
-    NSLog(@"CGPreflightListenEventAccess not available before macOS version 10.15");
+    os_log([KMLogs privacyLog], "CGPreflightListenEventAccess not available before macOS version 10.15");
   }
   return hasAccess;
 }
@@ -192,9 +193,9 @@
   if (@available(macOS 10.15, *)) {
     hasAccess = CGPreflightPostEventAccess();
     
-    NSLog(@"CGPreflightPostEventAccess() returned %@", hasAccess ? @"YES" : @"NO");
+    os_log([KMLogs privacyLog], "CGPreflightPostEventAccess() returned %@", hasAccess ? @"YES" : @"NO");
   } else {
-    NSLog(@"CGPreflightPostEventAccess not available before macOS version 10.15");
+    os_log([KMLogs privacyLog], "CGPreflightPostEventAccess not available before macOS version 10.15");
   }
   return hasAccess;
 }
@@ -209,9 +210,9 @@
   
   if (@available(macOS 10.15, *)) {
     granted = CGRequestListenEventAccess();
-    NSLog(@"CGRequestListenEventAccess() returned %@", granted ? @"YES" : @"NO");
+    os_log([KMLogs privacyLog], "CGRequestListenEventAccess() returned %@", granted ? @"YES" : @"NO");
   } else {
-    NSLog(@"CGRequestListenEventAccess not available before macOS version 10.15");
+    os_log([KMLogs privacyLog], "CGRequestListenEventAccess not available before macOS version 10.15");
   }
   return granted;
 }
@@ -226,9 +227,9 @@
   
   if (@available(macOS 10.15, *)) {
     granted = CGRequestPostEventAccess();
-    NSLog(@"CGRequestPostEventAccess() returned %@", granted ? @"YES" : @"NO");
+    os_log([KMLogs privacyLog], "CGRequestPostEventAccess() returned %@", granted ? @"YES" : @"NO");
   } else {
-    NSLog(@"CGRequestPostEventAccess not available before macOS version 10.15");
+    os_log([KMLogs privacyLog], "CGRequestPostEventAccess not available before macOS version 10.15");
   }
   return granted;
 }

--- a/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
@@ -35,6 +35,7 @@
 #import "TextApiCompliance.h"
 #import <InputMethodKit/InputMethodKit.h>
 #import "KMInputMethodAppDelegate.h"
+#import "KMLogs.h"
 
 // this is the user managed list of non-compliant apps persisted in User Defaults
 NSString *const kKMLegacyApps = @"KMLegacyApps";
@@ -86,10 +87,10 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   else {
     // if API exists, call it and see if it works as expected
     self.initialSelection = [client selectedRange];
-    [self.appDelegate logDebugMessage:@"TextApiCompliance checkCompliance, location = %lu, length = %lu", self.initialSelection.location, self.initialSelection.length];
+    os_log([KMLogs complianceLog], "TextApiCompliance checkCompliance, location = %lu, length = %lu", self.initialSelection.location, self.initialSelection.length);
     [self checkComplianceUsingInitialSelection];
   }
-  [self.appDelegate logDebugMessage:@"TextApiCompliance checkCompliance workingSelectionApi for app %@: set to %@", self.clientApplicationId, self.complianceUncertain?@"YES":@"NO"];
+  os_log([KMLogs complianceLog], "TextApiCompliance checkCompliance workingSelectionApi for app %{public}@: set to %{public}@", self.clientApplicationId, self.complianceUncertain?@"YES":@"NO");
 }
 
 -(void) checkComplianceUsingInitialSelection {
@@ -100,7 +101,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
      */
     self.hasCompliantSelectionApi = NO;
     self.complianceUncertain = YES;
-    [self.appDelegate logDebugMessage:@"TextApiCompliance checkComplianceUsingInitialSelection not compliant but uncertain, range is NSNotFound"];
+    os_log([KMLogs complianceLog], "TextApiCompliance checkComplianceUsingInitialSelection not compliant but uncertain, range is NSNotFound");
   } else if (self.initialSelection.location >= 0) {
     /**
      * location greater than or equal to zero may just mean that the client
@@ -109,7 +110,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
      */
     self.hasCompliantSelectionApi = YES;
     self.complianceUncertain = YES;
-    [self.appDelegate logDebugMessage:@"TextApiCompliance checkComplianceUsingInitialSelection compliant but uncertain, location >= 0"];
+    os_log([KMLogs complianceLog], "TextApiCompliance checkComplianceUsingInitialSelection compliant but uncertain, location >= 0");
   }
 }
 
@@ -122,7 +123,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   
   // return if compliance is already certain
   if(!self.complianceUncertain) {
-    [self.appDelegate logDebugMessage:@"TextApiCompliance checkComplianceAfterInsert, compliance is already known"];
+    os_log([KMLogs complianceLog], "TextApiCompliance checkComplianceAfterInsert, compliance is already known");
     return;
   }
   
@@ -133,7 +134,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
     [self validateLocationChange:changeExpected hasLocationChanged:locationChanged];
   }
   
-  [self.appDelegate logDebugMessage:@"TextApiCompliance checkComplianceAfterInsert, self.hasWorkingSelectionApi = %@ for app %@", self.hasCompliantSelectionApi?@"YES":@"NO", self.clientApplicationId];
+  os_log([KMLogs complianceLog], "TextApiCompliance checkComplianceAfterInsert, self.hasWorkingSelectionApi = %{public}@ for app %{public}@", self.hasCompliantSelectionApi?@"YES":@"NO", self.clientApplicationId);
 }
 
 - (BOOL)validateNewLocation:(NSUInteger)location delete:(NSString *)textToDelete  {
@@ -143,16 +144,16 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
     // invalid location: insertText means we have focus, NSNotFound means selection API not functioning
     self.hasCompliantSelectionApi = NO;
     self.complianceUncertain = NO;
-    [self.appDelegate logDebugMessage:@"TextApiCompliance validateNewLocation = NO, location is NSNotFound"];
+    os_log([KMLogs complianceLog], "TextApiCompliance validateNewLocation = NO, location is NSNotFound");
   } else if ((location == 0) && (textToDelete.length > 0)) {
     // invalid location: cannot have text to delete at location zero
     self.hasCompliantSelectionApi = NO;
     self.complianceUncertain = NO;
-    [self.appDelegate logDebugMessage:@"TextApiCompliance validateNewLocation = NO, location is zero with textToDelete.length > 0"];
+    os_log([KMLogs complianceLog], "TextApiCompliance validateNewLocation = NO, location is zero with textToDelete.length > 0");
   } else {
     // location is valid, but do not know if it is compliant yet
     validLocation = YES;
-    [self.appDelegate logDebugMessage:@"TextApiCompliance validateNewLocation = YES, newLocation = %d, oldLocation = %d", location, self.initialSelection.location];
+    os_log([KMLogs complianceLog], "TextApiCompliance validateNewLocation = YES, newLocation = %lu, oldLocation = %lu", (unsigned long)location, (unsigned long)self.initialSelection.location);
   }
   return validLocation;
 }
@@ -163,18 +164,18 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
     // YES for certain, the location is where we expect it
     self.hasCompliantSelectionApi = YES;
     self.complianceUncertain = NO;
-    [self.appDelegate logDebugMessage:@"TextApiCompliance validateLocationChange compliant, locationChanged = %@, changeExpected = %@", locationChanged?@"YES":@"NO", changeExpected?@"YES":@"NO"];
+    os_log([KMLogs complianceLog], "TextApiCompliance validateLocationChange compliant, locationChanged = %{public}@, changeExpected = %{public}@", locationChanged?@"YES":@"NO", changeExpected?@"YES":@"NO");
   } else if (changeExpected != locationChanged) {
     // NO for certain, when the selection is unchanged after an insert
     self.hasCompliantSelectionApi = NO;
     self.complianceUncertain = NO;
-    [self.appDelegate logDebugMessage:@"TextApiCompliance validateLocationChange non-compliant, locationChanged = %@, changeExpected = %@", locationChanged?@"YES":@"NO", changeExpected?@"YES":@"NO"];
+    os_log([KMLogs complianceLog], "TextApiCompliance validateLocationChange non-compliant, locationChanged = %{public}@, changeExpected = %{public}@", locationChanged?@"YES":@"NO", changeExpected?@"YES":@"NO");
   }
 }
 
 - (BOOL)isLocationChangeExpectedOnInsert:(NSString *)textToDelete insert:(NSString *)textToInsert {
   BOOL changeExpected = textToInsert.length != textToDelete.length;
-  [self.appDelegate logDebugMessage:@"TextApiCompliance isLocationChangeExpected, changeExpected = %@", changeExpected?@"YES":@"NO"];
+  os_log([KMLogs complianceLog], "TextApiCompliance isLocationChangeExpected, changeExpected = %{public}@", changeExpected?@"YES":@"NO");
   
   return changeExpected;
 }
@@ -183,8 +184,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   NSUInteger newLocation = newSelection.location;
   NSUInteger oldLocation = self.initialSelection.location;
   BOOL locationChanged = newLocation != oldLocation;
-  [self.appDelegate logDebugMessage:@"TextApiCompliance hasLocationChanged, currentSelection = %lu, length = %lu", newSelection.location, newSelection.length];
-  
+  os_log([KMLogs complianceLog], "TextApiCompliance hasLocationChanged, currentSelection = %lu, length = %lu", newSelection.location, newSelection.length);
   return locationChanged;
 }
 
@@ -198,7 +198,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
     isAppNonCompliant = [self containedInUserManagedNoncompliantAppList:clientAppId];
   }
   
-  [self.appDelegate logDebugMessage:@"applyNoncompliantAppLists: for app %@: %@", clientAppId, isAppNonCompliant?@"YES":@"NO"];
+  os_log([KMLogs complianceLog], "applyNoncompliantAppLists: for app %{public}@: %{public}@", clientAppId, isAppNonCompliant?@"YES":@"NO");
   
   if (isAppNonCompliant) {
     self.complianceUncertain = NO;
@@ -238,7 +238,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
                             /*||[clientAppId isEqual: @"ro.sync.exml.Oxygen"] - Oxygen has worse problems */
                             );
   
-  [self.appDelegate logDebugMessage:@"containedInHardCodedNoncompliantAppList: for app %@: %@", clientAppId, isAppNonCompliant?@"yes":@"no"];
+  os_log([KMLogs complianceLog], "containedInHardCodedNoncompliantAppList: for app %{public}@: %{public}@", clientAppId, isAppNonCompliant?@"yes":@"no");
   return isAppNonCompliant;
 }
 
@@ -260,7 +260,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   if(legacyAppsUserDefaults != nil) {
     isAppNonCompliant = [self arrayContainsApplicationId:clientAppId fromArray:legacyAppsUserDefaults];
   }
-  [self.appDelegate logDebugMessage:@"containedInUserManagedNoncompliantAppList: for app %@: %@", clientAppId, isAppNonCompliant?@"yes":@"no"];
+  os_log([KMLogs complianceLog], "containedInUserManagedNoncompliantAppList: for app %{public}@: %{public}@", clientAppId, isAppNonCompliant?@"yes":@"no");
   return isAppNonCompliant;
 }
 
@@ -271,7 +271,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   for(id appId in applicationArray) {
     if(![appId isKindOfClass:[NSString class]]) {
       // always log this: bad data in UserDefaults
-      NSLog(@"arrayContainsApplicationId:fromArray: LegacyApps user defaults array should contain only strings");
+      os_log_error([KMLogs complianceLog], "arrayContainsApplicationId:fromArray: LegacyApps user defaults array should contain only strings");
     } else {
       NSError *error = nil;
       NSRange range =  NSMakeRange(0, applicationId.length);
@@ -279,7 +279,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
       NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern: (NSString *) appId options: 0 error: &error];
       NSArray *matchesArray = [regex matchesInString:applicationId options:0 range:range];
       if(matchesArray.count>0) {
-        [self.appDelegate logDebugMessage:@"arrayContainsApplicationId: found match for application ID %@: ", applicationId];
+        os_log([KMLogs complianceLog], "arrayContainsApplicationId: found match for application ID %{public}@: ", applicationId);
         return YES;
       }
     }

--- a/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
@@ -87,10 +87,10 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   else {
     // if API exists, call it and see if it works as expected
     self.initialSelection = [client selectedRange];
-    os_log([KMLogs complianceLog], "TextApiCompliance checkCompliance, location = %lu, length = %lu", self.initialSelection.location, self.initialSelection.length);
+    os_log_debug([KMLogs complianceLog], "checkCompliance, location = %lu, length = %lu", self.initialSelection.location, self.initialSelection.length);
     [self checkComplianceUsingInitialSelection];
   }
-  os_log([KMLogs complianceLog], "TextApiCompliance checkCompliance workingSelectionApi for app %{public}@: set to %{public}@", self.clientApplicationId, self.complianceUncertain?@"YES":@"NO");
+  os_log_debug([KMLogs complianceLog], "checkCompliance workingSelectionApi for app %{public}@: set to %{public}@", self.clientApplicationId, self.complianceUncertain?@"YES":@"NO");
 }
 
 -(void) checkComplianceUsingInitialSelection {
@@ -101,7 +101,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
      */
     self.hasCompliantSelectionApi = NO;
     self.complianceUncertain = YES;
-    os_log([KMLogs complianceLog], "TextApiCompliance checkComplianceUsingInitialSelection not compliant but uncertain, range is NSNotFound");
+    os_log_debug([KMLogs complianceLog], "checkComplianceUsingInitialSelection not compliant but uncertain, range is NSNotFound");
   } else if (self.initialSelection.location >= 0) {
     /**
      * location greater than or equal to zero may just mean that the client
@@ -110,7 +110,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
      */
     self.hasCompliantSelectionApi = YES;
     self.complianceUncertain = YES;
-    os_log([KMLogs complianceLog], "TextApiCompliance checkComplianceUsingInitialSelection compliant but uncertain, location >= 0");
+    os_log_debug([KMLogs complianceLog], "checkComplianceUsingInitialSelection compliant but uncertain, location >= 0");
   }
 }
 
@@ -123,7 +123,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   
   // return if compliance is already certain
   if(!self.complianceUncertain) {
-    os_log([KMLogs complianceLog], "TextApiCompliance checkComplianceAfterInsert, compliance is already known");
+    os_log_debug([KMLogs complianceLog], "checkComplianceAfterInsert, compliance is already known");
     return;
   }
   
@@ -134,7 +134,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
     [self validateLocationChange:changeExpected hasLocationChanged:locationChanged];
   }
   
-  os_log([KMLogs complianceLog], "TextApiCompliance checkComplianceAfterInsert, self.hasWorkingSelectionApi = %{public}@ for app %{public}@", self.hasCompliantSelectionApi?@"YES":@"NO", self.clientApplicationId);
+  os_log_info([KMLogs complianceLog], "checkComplianceAfterInsert, self.hasWorkingSelectionApi = %{public}@ for app %{public}@", self.hasCompliantSelectionApi?@"YES":@"NO", self.clientApplicationId);
 }
 
 - (BOOL)validateNewLocation:(NSUInteger)location delete:(NSString *)textToDelete  {
@@ -144,16 +144,16 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
     // invalid location: insertText means we have focus, NSNotFound means selection API not functioning
     self.hasCompliantSelectionApi = NO;
     self.complianceUncertain = NO;
-    os_log([KMLogs complianceLog], "TextApiCompliance validateNewLocation = NO, location is NSNotFound");
+    os_log_debug([KMLogs complianceLog], "validateNewLocation = NO, location is NSNotFound");
   } else if ((location == 0) && (textToDelete.length > 0)) {
     // invalid location: cannot have text to delete at location zero
     self.hasCompliantSelectionApi = NO;
     self.complianceUncertain = NO;
-    os_log([KMLogs complianceLog], "TextApiCompliance validateNewLocation = NO, location is zero with textToDelete.length > 0");
+    os_log_debug([KMLogs complianceLog], "validateNewLocation = NO, location is zero with textToDelete.length > 0");
   } else {
     // location is valid, but do not know if it is compliant yet
     validLocation = YES;
-    os_log([KMLogs complianceLog], "TextApiCompliance validateNewLocation = YES, newLocation = %lu, oldLocation = %lu", (unsigned long)location, (unsigned long)self.initialSelection.location);
+    os_log_debug([KMLogs complianceLog], "validateNewLocation = YES, newLocation = %lu, oldLocation = %lu", (unsigned long)location, (unsigned long)self.initialSelection.location);
   }
   return validLocation;
 }
@@ -164,18 +164,18 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
     // YES for certain, the location is where we expect it
     self.hasCompliantSelectionApi = YES;
     self.complianceUncertain = NO;
-    os_log([KMLogs complianceLog], "TextApiCompliance validateLocationChange compliant, locationChanged = %{public}@, changeExpected = %{public}@", locationChanged?@"YES":@"NO", changeExpected?@"YES":@"NO");
+    os_log_debug([KMLogs complianceLog], "validateLocationChange compliant, locationChanged = %{public}@, changeExpected = %{public}@", locationChanged?@"YES":@"NO", changeExpected?@"YES":@"NO");
   } else if (changeExpected != locationChanged) {
     // NO for certain, when the selection is unchanged after an insert
     self.hasCompliantSelectionApi = NO;
     self.complianceUncertain = NO;
-    os_log([KMLogs complianceLog], "TextApiCompliance validateLocationChange non-compliant, locationChanged = %{public}@, changeExpected = %{public}@", locationChanged?@"YES":@"NO", changeExpected?@"YES":@"NO");
+    os_log_debug([KMLogs complianceLog], "validateLocationChange non-compliant, locationChanged = %{public}@, changeExpected = %{public}@", locationChanged?@"YES":@"NO", changeExpected?@"YES":@"NO");
   }
 }
 
 - (BOOL)isLocationChangeExpectedOnInsert:(NSString *)textToDelete insert:(NSString *)textToInsert {
   BOOL changeExpected = textToInsert.length != textToDelete.length;
-  os_log([KMLogs complianceLog], "TextApiCompliance isLocationChangeExpected, changeExpected = %{public}@", changeExpected?@"YES":@"NO");
+  os_log_debug([KMLogs complianceLog], "isLocationChangeExpected, changeExpected = %{public}@", changeExpected?@"YES":@"NO");
   
   return changeExpected;
 }
@@ -184,7 +184,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   NSUInteger newLocation = newSelection.location;
   NSUInteger oldLocation = self.initialSelection.location;
   BOOL locationChanged = newLocation != oldLocation;
-  os_log([KMLogs complianceLog], "TextApiCompliance hasLocationChanged, currentSelection = %lu, length = %lu", newSelection.location, newSelection.length);
+  os_log_debug([KMLogs complianceLog], "hasLocationChanged: %{public}@, new location: %lu, selection length: %lu", locationChanged?@"YES":@"NO", newSelection.location, newSelection.length);
   return locationChanged;
 }
 
@@ -198,7 +198,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
     isAppNonCompliant = [self containedInUserManagedNoncompliantAppList:clientAppId];
   }
   
-  os_log([KMLogs complianceLog], "applyNoncompliantAppLists: for app %{public}@: %{public}@", clientAppId, isAppNonCompliant?@"YES":@"NO");
+  os_log_info([KMLogs complianceLog], "applyNoncompliantAppLists: for app %{public}@: %{public}@", clientAppId, isAppNonCompliant?@"YES":@"NO");
   
   if (isAppNonCompliant) {
     self.complianceUncertain = NO;
@@ -238,7 +238,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
                             /*||[clientAppId isEqual: @"ro.sync.exml.Oxygen"] - Oxygen has worse problems */
                             );
   
-  os_log([KMLogs complianceLog], "containedInHardCodedNoncompliantAppList: for app %{public}@: %{public}@", clientAppId, isAppNonCompliant?@"yes":@"no");
+  os_log_debug([KMLogs complianceLog], "containedInHardCodedNoncompliantAppList: for app %{public}@: %{public}@", clientAppId, isAppNonCompliant?@"yes":@"no");
   return isAppNonCompliant;
 }
 
@@ -260,7 +260,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   if(legacyAppsUserDefaults != nil) {
     isAppNonCompliant = [self arrayContainsApplicationId:clientAppId fromArray:legacyAppsUserDefaults];
   }
-  os_log([KMLogs complianceLog], "containedInUserManagedNoncompliantAppList: for app %{public}@: %{public}@", clientAppId, isAppNonCompliant?@"yes":@"no");
+  os_log_debug([KMLogs complianceLog], "containedInUserManagedNoncompliantAppList: for app %{public}@: %{public}@", clientAppId, isAppNonCompliant?@"yes":@"no");
   return isAppNonCompliant;
 }
 
@@ -279,7 +279,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
       NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern: (NSString *) appId options: 0 error: &error];
       NSArray *matchesArray = [regex matchesInString:applicationId options:0 range:range];
       if(matchesArray.count>0) {
-        os_log([KMLogs complianceLog], "arrayContainsApplicationId: found match for application ID %{public}@: ", applicationId);
+        os_log_debug([KMLogs complianceLog], "arrayContainsApplicationId: found match for application ID %{public}@: ", applicationId);
         return YES;
       }
     }

--- a/mac/Keyman4MacIM/Keyman4MacIM/main.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/main.m
@@ -8,14 +8,13 @@
 
 #import <Cocoa/Cocoa.h>
 #import <InputMethodKit/InputMethodKit.h>
-#import <os/log.h>
+#import "KMLogs.h"
 
 const NSString *kConnectionName = @"Keyman_Input_Connection";
 IMKServer *server;
 
 int main(int argc, const char * argv[]) {
-  NSString *identifier;
-  os_log_t configLog = os_log_create("org.sil.keyman", "startup");
+    NSString *identifier;
   
   @autoreleasepool {
     identifier = [[NSBundle mainBundle] bundleIdentifier];
@@ -23,7 +22,7 @@ int main(int argc, const char * argv[]) {
     
     BOOL didLoadNib = [[NSBundle mainBundle] loadNibNamed:@"MainMenu" owner:[NSApplication sharedApplication] topLevelObjects: nil];
     
-    os_log_with_type(configLog, OS_LOG_TYPE_DEBUG, "main Did load MainMenu nib: %@", didLoadNib?@"YES":@"NO");
+    os_log_with_type([KMLogs startupLog], OS_LOG_TYPE_INFO, "main Did load MainMenu nib: %@", didLoadNib?@"YES":@"NO");
     
     [[NSApplication sharedApplication] run];
   }

--- a/mac/Keyman4MacIM/Keyman4MacIM/main.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/main.m
@@ -22,7 +22,7 @@ int main(int argc, const char * argv[]) {
     
     BOOL didLoadNib = [[NSBundle mainBundle] loadNibNamed:@"MainMenu" owner:[NSApplication sharedApplication] topLevelObjects: nil];
     
-    os_log_with_type([KMLogs startupLog], OS_LOG_TYPE_INFO, "main Did load MainMenu nib: %@", didLoadNib?@"YES":@"NO");
+    os_log_info([KMLogs startupLog], "main Did load MainMenu nib: %@", didLoadNib?@"YES":@"NO");
     
     [[NSApplication sharedApplication] run];
   }

--- a/mac/Keyman4MacIM/Keyman4MacIM/main.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/main.m
@@ -14,7 +14,7 @@ const NSString *kConnectionName = @"Keyman_Input_Connection";
 IMKServer *server;
 
 int main(int argc, const char * argv[]) {
-    NSString *identifier;
+  NSString *identifier;
   
   @autoreleasepool {
     identifier = [[NSBundle mainBundle] bundleIdentifier];

--- a/mac/Keyman4MacIM/KeymanTests/TextApiComplianceTests.m
+++ b/mac/Keyman4MacIM/KeymanTests/TextApiComplianceTests.m
@@ -12,6 +12,7 @@
 #import <XCTest/XCTest.h>
 #import "TextApiCompliance.h"
 #import "AppleCompliantTestClient.h"
+#import "KMLogs.h"
 
 @interface TextApiComplianceTests : XCTestCase
 @end
@@ -153,7 +154,7 @@
   NSArray *legacyAppsArray = [NSArray arrayWithObjects:@"com.microsoft.VSCode",@"com.adobe.Photoshop",nil];
   
   BOOL isLegacy = [apiCompliance arrayContainsApplicationId:clientAppId fromArray:legacyAppsArray];
-  NSLog(@"isLegacy = %@", isLegacy?@"yes":@"no");
+  os_log_debug([KMLogs testLog], "isLegacy = %@", isLegacy?@"yes":@"no");
   XCTAssertFalse(isLegacy, @"App not expected to be in legacy list");
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj/project.pbxproj
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		29A1971E2AF091E600512A37 /* CoreKeyOutput.h in Headers */ = {isa = PBXBuildFile; fileRef = 29A1971C2AF091E600512A37 /* CoreKeyOutput.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29A1971F2AF091E600512A37 /* CoreKeyOutput.m in Sources */ = {isa = PBXBuildFile; fileRef = 29A1971D2AF091E600512A37 /* CoreKeyOutput.m */; };
 		29A658C82AF394560038DCFE /* armenian_mnemonic.kmx in Resources */ = {isa = PBXBuildFile; fileRef = 29A658C72AF394560038DCFE /* armenian_mnemonic.kmx */; };
+		29B4A0D82BFAE8A400682049 /* KMELogs.h in Headers */ = {isa = PBXBuildFile; fileRef = 29B4A0D62BFAE8A400682049 /* KMELogs.h */; };
+		29B4A0D92BFAE8A400682049 /* KMELogs.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B4A0D72BFAE8A400682049 /* KMELogs.m */; };
 		378568D122FCCF0A00B481B5 /* sil_ipa.kmx in Resources */ = {isa = PBXBuildFile; fileRef = 378568D022FCCF0A00B481B5 /* sil_ipa.kmx */; };
 		378568D322FCD93300B481B5 /* indexoffset1892.kmx in Resources */ = {isa = PBXBuildFile; fileRef = 378568D222FCD93300B481B5 /* indexoffset1892.kmx */; };
 		980053351B37C9B50088DDDD /* NFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 980053311B37C9B50088DDDD /* NFont.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -97,6 +99,8 @@
 		29A205D82AC2E446000750C0 /* libsicuuc.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsicuuc.a; path = "../../core/build/mac-arm64/release/subprojects/icu/source/common/libsicuuc.a"; sourceTree = "<group>"; };
 		29A205DA2AC2E46A000750C0 /* libsicui18n.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsicui18n.a; path = "../../core/build/mac-arm64/release/subprojects/icu/source/i18n/libsicui18n.a"; sourceTree = "<group>"; };
 		29A658C72AF394560038DCFE /* armenian_mnemonic.kmx */ = {isa = PBXFileReference; lastKnownFileType = file; path = armenian_mnemonic.kmx; sourceTree = "<group>"; };
+		29B4A0D62BFAE8A400682049 /* KMELogs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KMELogs.h; sourceTree = "<group>"; };
+		29B4A0D72BFAE8A400682049 /* KMELogs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KMELogs.m; sourceTree = "<group>"; };
 		378568D022FCCF0A00B481B5 /* sil_ipa.kmx */ = {isa = PBXFileReference; lastKnownFileType = file; path = sil_ipa.kmx; sourceTree = "<group>"; };
 		378568D222FCD93300B481B5 /* indexoffset1892.kmx */ = {isa = PBXFileReference; lastKnownFileType = file; path = indexoffset1892.kmx; sourceTree = "<group>"; };
 		980053311B37C9B50088DDDD /* NFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NFont.h; sourceTree = "<group>"; };
@@ -286,6 +290,8 @@
 		984C2AEE1A79CA4F0023F89D /* KME */ = {
 			isa = PBXGroup;
 			children = (
+				29B4A0D62BFAE8A400682049 /* KMELogs.h */,
+				29B4A0D72BFAE8A400682049 /* KMELogs.m */,
 				981880641BC1EA5800A1FBA5 /* OnScreenKeyboard */,
 				984C2AEF1A79CA4F0023F89D /* Categories */,
 				984C2AF51A79CA4F0023F89D /* KMBinaryFileFormat.h */,
@@ -351,6 +357,7 @@
 				2993C33229B1D92E00FB5E95 /* CoreWrapper.h in Headers */,
 				9818806F1BC1EA5800A1FBA5 /* KeyLabel.h in Headers */,
 				981880751BC1EA5800A1FBA5 /* OSKKey.h in Headers */,
+				29B4A0D82BFAE8A400682049 /* KMELogs.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -501,6 +508,7 @@
 				980053381B37C9B50088DDDD /* NKey.m in Sources */,
 				981880701BC1EA5800A1FBA5 /* KeyLabel.m in Sources */,
 				981880721BC1EA5800A1FBA5 /* KeyLabelCell.m in Sources */,
+				29B4A0D92BFAE8A400682049 /* KMELogs.m in Sources */,
 				981880781BC1EA5800A1FBA5 /* OSKView.m in Sources */,
 				2993C32E29B1D92E00FB5E95 /* CoreWrapper.m in Sources */,
 				984C2B0F1A79CA4F0023F89D /* KMCompKey.m in Sources */,

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreHelper.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreHelper.h
@@ -23,7 +23,6 @@ extern UInt32 VirtualKeyMap[0x80];
 -(unsigned long long) unicharStringLength:(unichar const *)string;
 
 -(instancetype)initWithDebugMode:(BOOL)debugMode;
--(void)logDebugMessage:(NSString *)format, ...;
 -(unsigned short) macVirtualKeyToWindowsVirtualKey:(unsigned short) keyCode;
 -(UTF32Char)macToKeymanModifier:(NSEventModifierFlags)modifiers;
 -(NSString*)utf32ValueToString:(UTF32Char)scalarValue;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreHelper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreHelper.m
@@ -19,6 +19,7 @@
 #import "keyman_core_api.h"
 #import "MacVKCodes.h"
 #import "WindowsVKCodes.h"
+#import "KMELogs.h"
 
 const int VIRTUAL_KEY_ARRAY_SIZE = 0x80;
 UInt32 VirtualKeyMap[VIRTUAL_KEY_ARRAY_SIZE];
@@ -32,7 +33,7 @@ UInt32 VirtualKeyMap[VIRTUAL_KEY_ARRAY_SIZE];
 -(unichar const *) createUnicharStringFromNSString:(NSString *)string {
   NSString *nullTerminatedString = [string stringByAppendingString:@"\0"];
   if (![nullTerminatedString canBeConvertedToEncoding:NSUTF16LittleEndianStringEncoding]) {
-    [self logDebugMessage:@"createUnicharStringFromNSString, canBeConvertedToEncoding false for NSUTF16LittleEndianStringEncoding"];
+    os_log_debug([KMELogs coreLog], "createUnicharStringFromNSString, canBeConvertedToEncoding false for NSUTF16LittleEndianStringEncoding");
     return nil;
   }
   
@@ -77,15 +78,6 @@ UInt32 VirtualKeyMap[VIRTUAL_KEY_ARRAY_SIZE];
   return self;
 }
 
--(void)logDebugMessage:(NSString *)format, ... {
-  if (self.debugMode) {
-    va_list args;
-    va_start(args, format);
-    NSLogv(format, args);
-    va_end(args);
-  }
-}
-
 -(unsigned short) macVirtualKeyToWindowsVirtualKey:(unsigned short) keyCode {
   if ((keyCode<0) || (keyCode>=VIRTUAL_KEY_ARRAY_SIZE)) {
     return 0;
@@ -125,7 +117,7 @@ UInt32 VirtualKeyMap[VIRTUAL_KEY_ARRAY_SIZE];
    keymanModifiers |= KM_CORE_MODIFIER_NOCAPS;
    }*/
   
-  [self logDebugMessage:@"macToKeymanModifier result  = %u", (unsigned int)keymanModifiers];
+  os_log_debug([KMELogs coreLog], "macToKeymanModifier result  = %u", (unsigned int)keymanModifiers);
   return keymanModifiers;
 }
 
@@ -169,7 +161,7 @@ UInt32 VirtualKeyMap[VIRTUAL_KEY_ARRAY_SIZE];
   NSData * characterData = [[NSData alloc] initWithBytes:&scalarValue length:sizeof(scalarValue)];
   
   NSString *characterString=[[NSString alloc] initWithBytes:[characterData bytes] length:[characterData length] encoding:NSUTF32LittleEndianStringEncoding];
-  [self logDebugMessage:@"utf32ValueToString data: '%@', string: %@", characterData, characterString];
+  os_log_debug([KMELogs coreLog], "utf32ValueToString data: '%@', string: %@", characterData, characterString);
   return characterString;
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreHelper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreHelper.m
@@ -117,7 +117,7 @@ UInt32 VirtualKeyMap[VIRTUAL_KEY_ARRAY_SIZE];
    keymanModifiers |= KM_CORE_MODIFIER_NOCAPS;
    }*/
   
-  os_log_debug([KMELogs coreLog], "macToKeymanModifier result  = %u", (unsigned int)keymanModifiers);
+  os_log_debug([KMELogs coreLog], "macToKeymanModifier, macModifiers: %lu / ox%lX keymanModifiers: %d / 0x%X", (unsigned long)modifiers, modifiers, keymanModifiers, keymanModifiers);
   return keymanModifiers;
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreKeyOutput.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreKeyOutput.m
@@ -32,9 +32,10 @@
 
 -(NSString *)description
 {
-  NSData* data = [self.textToInsert dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
-  
-  return [[NSString alloc] initWithFormat: @"codePointsToDeleteBeforeInsert: %li, textToInsert: '%@', optionsToPersist: %@, alert: %d, emitKeystroke: %d, capsLockState: %d ", self.codePointsToDeleteBeforeInsert, data, self.optionsToPersist, self.alert, self.emitKeystroke, self.capsLockState];
+  NSData* deleteData = [self.textToDelete dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
+  NSData* insertData = [self.textToInsert dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
+
+  return [[NSString alloc] initWithFormat: @"codePointsToDeleteBeforeInsert: %li, textToDelete: '%@' [data: '%@'], textToInsert: '%@' [data: '%@], optionsToPersist: %@, alert: %d, emitKeystroke: %d, capsLockState: %d ", self.codePointsToDeleteBeforeInsert, self.textToDelete, deleteData, self.textToInsert, insertData, self.optionsToPersist, self.alert, self.emitKeystroke, self.capsLockState];
 }
 
 -(BOOL)hasCodePointsToDelete {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
@@ -74,7 +74,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   if (self.coreKeyboard) {
     km_core_keyboard_dispose(self.coreKeyboard);
   }
-  os_log_debug([KMELogs coreLog], "CoreWrapper dealloc called.");
+  os_log_debug([KMELogs coreLog], "dealloc called.");
 }
 
 -(void)loadKeyboardUsingCore:(NSString*) path {
@@ -95,7 +95,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
     if (result==KM_CORE_STATUS_OK) {
       _keyboardVersion = [self.coreHelper createNSStringFromUnicharString:keyboardAttributes->version_string];
       _keyboardId = [self.coreHelper createNSStringFromUnicharString:keyboardAttributes->id];
-      os_log_debug([KMELogs coreLog], "keyboardVersion = %{public}@\n, keyboardId  = %{public}@\n", _keyboardVersion, _keyboardId);
+      os_log_debug([KMELogs coreLog], "readKeyboardAttributesUsingCore, keyboardVersion: %{public}@\n, keyboardId: %{public}@\n", _keyboardVersion, _keyboardId);
     } else {
       os_log_error([KMELogs coreLog], "km_core_keyboard_get_attrs() failed with result = %u\n", result);
     }
@@ -150,6 +150,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
                  withModifier:modifierState
                   withKeyDown:keyDown]) {
     output = [self loadOutputForLastKeyProcessed];
+    os_log_debug([KMELogs coreLog], "processMacVirtualKey for macKeyCode: %d / 0x%X, core output: %{public}@", macKeyCode, macKeyCode, output);
   }
   return output;
 }
@@ -172,7 +173,6 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
 }
 
 -(CoreKeyOutput*)loadActionStructUsingCore {
-  os_log_debug([KMELogs coreLog], "CoreWrapper loadActionStructUsingCore");
   km_core_actions * actions = km_core_state_get_actions(self.coreState);
   CoreKeyOutput *output = [self createCoreKeyOutputForActionsStruct:actions];
   return output;
@@ -185,7 +185,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   NSString* deletedText = [self.coreHelper utf32CStringToString:actions->deleted_context];
   
   CoreKeyOutput* coreKeyOutput = [[CoreKeyOutput alloc] init: actions->code_points_to_delete textToDelete:deletedText textToInsert:text optionsToPersist:options alert:actions->do_alert emitKeystroke:actions->emit_keystroke capsLockState:capsLock];
-  
+
   return coreKeyOutput;
 }
 
@@ -232,7 +232,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
 -(void)setContextIfNeeded:(NSString*)context {
   unichar const * unicharContext = [self.coreHelper createUnicharStringFromNSString:context];
   km_core_status result = km_core_state_context_set_if_needed(self.coreState, unicharContext);
-  os_log_debug([KMELogs coreLog], "CoreWrapper setContextIfNeeded, context=%{public}@, km_core_state_context_set_if_needed result=%d", context, result);
+  os_log_debug([KMELogs coreLog], "setContextIfNeeded, context=%{public}@, km_core_state_context_set_if_needed result=%d", context, result);
 }
 
 -(NSString*)contextDebug {
@@ -240,7 +240,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   NSString *debugString = [self.coreHelper createNSStringFromUnicharString:context];
   km_core_cu_dispose(context);
   
-  os_log_debug([KMELogs coreLog], "CoreWrapper contextDebug = %{public}@", debugString);
+  os_log_debug([KMELogs coreLog], "contextDebug = %{public}@", debugString);
   return debugString;
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMELogs.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMELogs.h
@@ -1,8 +1,8 @@
 /**
  * Keyman is copyright (C) SIL International. MIT License.
  * 
- * KMLogs.h
- * Keyman
+ * KMELogs.h
+ * KeymanEngine4Mac
  * 
  * Created by Shawn Schantz on 2024-05-16.
  *
@@ -14,17 +14,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface KMLogs : NSObject
+@interface KMELogs : NSObject
 
-+ (void)reportLogStatus;
 + (os_log_t)startupLog;
-+ (os_log_t)lifecycleLog;
 + (os_log_t)configLog;
-+ (os_log_t)uiLog;
-+ (os_log_t)eventsLog;
-+ (os_log_t)keyboardLog;
 + (os_log_t)keyLog;
++ (os_log_t)coreLog;
 + (os_log_t)oskLog;
++ (os_log_t)uiLog;
++ (os_log_t)testLog;
 
 @end
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMELogs.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMELogs.m
@@ -1,0 +1,63 @@
+/**
+ * Keyman is copyright (C) SIL International. MIT License.
+ * 
+ * KMELogs.m
+ * KeymanEngine4Mac
+ *
+ * Created by Shawn Schantz on 2024-05-16.
+ * 
+ * Contains methods to get singleton logger objects and constants for subsystem and category names.
+ */
+
+/**
+ * The loggers do not appear to be singletons, but the API which creates them manages
+ * them as singletons within macOS so that any subsequent call to create a log object
+ * using the same subsystem and category will return the existing instance.
+ *
+ * For any new log categories used anywhere in the Keyman Engine for Mac, the name should be defined here.
+ * The Keyman Input Method may define and use the same category name but will use a different subsystem name.
+ */
+
+#import "KMELogs.h"
+#import <os/log.h>
+
+@implementation KMELogs
+
+char *const keymanEngineSubsystem = "org.sil.keymanengine";
+char *const startupCategory = "startup";
+char *const configCategory = "config";
+char *const keyCategory = "key";
+char *const coreCategory = "core";
+char *const oskCategory = "osk";
+char *const uiCategory = "ui";
+char *const testCategory = "test";
+
++ (os_log_t)startupLog {
+  return os_log_create(keymanEngineSubsystem, startupCategory);
+}
+
++ (os_log_t)configLog {
+  return os_log_create(keymanEngineSubsystem, configCategory);
+}
+
++ (os_log_t)keyLog {
+  return os_log_create(keymanEngineSubsystem, keyCategory);
+}
+
++ (os_log_t)coreLog {
+  return os_log_create(keymanEngineSubsystem, coreCategory);
+}
+
++ (os_log_t)oskLog {
+  return os_log_create(keymanEngineSubsystem, oskCategory);
+}
+
++ (os_log_t)uiLog {
+  return os_log_create(keymanEngineSubsystem, uiCategory);
+}
+
++ (os_log_t)testLog {
+  return os_log_create(keymanEngineSubsystem, testCategory);
+}
+
+@end

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMELogs.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMELogs.m
@@ -23,7 +23,7 @@
 
 @implementation KMELogs
 
-char *const keymanEngineSubsystem = "org.sil.keymanengine";
+char *const keymanEngineSubsystem = "com.keyman.engine";
 char *const startupCategory = "startup";
 char *const configCategory = "config";
 char *const keyCategory = "key";

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -72,20 +72,20 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
   }
   
   if (useVerboseLogging) {
-    os_log_debug([KMELogs keyLog], "KMEngine - Turning verbose logging on");
+    os_log_debug([KMELogs testLog], "KMEngine - Turning verbose logging on");
     // In Keyman Engine if "debugMode" is turned on (explicitly) with "English plus Spanish" as the current keyboard and you type "Sentrycrash#KME",
     // it will force a simulated crash to test reporting to sentry.keyman.com.
     NSString * kmxName = [[_kmx filePath] lastPathComponent];
-    os_log_debug([KMELogs keyLog], "Sentry - KME: _kmx name = %{public}@", kmxName);
+    os_log_debug([KMELogs testLog], "Sentry - KME: _kmx name = %{public}@", kmxName);
     if ([kEasterEggKmxName isEqualToString:kmxName]) {
-      os_log_debug([KMELogs keyLog], "Sentry - KME: Preparing to detect Easter egg.");
+      os_log_debug([KMELogs testLog], "Sentry - KME: Preparing to detect Easter egg.");
       _easterEggForSentry = [[NSMutableString alloc] init];
     }
     else
       _easterEggForSentry = nil;
   }
   else {
-    os_log_debug([KMELogs keyLog], "KMEngine - Turning verbose logging off");
+    os_log_debug([KMELogs testLog], "KMEngine - Turning verbose logging off");
   }
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -48,7 +48,6 @@ const NSString* kEasterEggKmxName = @"EnglishSpanish.kmx";
 -(void)loadCoreWrapperFromKmxFile:(NSString *)kmxFilePath {
   @try {
     _coreWrapper = [[CoreWrapper alloc] initWithHelper:_coreHelper kmxFilePath:kmxFilePath];
-    os_log([KMELogs coreLog], "loadCoreWrapperFromKmxFile, keyboardId = %{public}@", [self.coreWrapper keyboardId]);
   }
   @catch (NSException *exception) {
     os_log_error([KMELogs coreLog], "loadCoreWrapperFromKmxFile, failed to create keyboard for path '%{public}@' with exception: %{public}@", kmxFilePath, exception.description);

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.m
@@ -17,8 +17,6 @@
 #import "CoreWrapper.h"
 @import Carbon;
 
-//DWORD VKMap[0x80];
-
 @interface KMEngine ()
 @property (readonly) CoreHelper *coreHelper;
 @property (nonatomic, retain) CoreWrapper * coreWrapper;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMXFile.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMXFile.m
@@ -11,6 +11,7 @@
 #import "KMCompGroup.h"
 #import "KMCompKey.h"
 #import "NSString+XString.h"
+#import "KMELogs.h"
 
 NSString *const kKMKeyboardNameKey = @"KMKeyboardNameKey";
 NSString *const kKMKeyboardVersionKey = @"KMKeyboardVersionKey";
@@ -31,7 +32,7 @@ NSString *const kKMVisualKeyboardKey = @"KMVisualKeyboardKey";
     
     NSFileHandle *file = [NSFileHandle fileHandleForReadingAtPath:path];
     if (file == nil) {
-      //NSLog(@"Failed to open kmx file");
+      os_log_error([KMELogs configLog], "Failed to open kmx file");
       _filePath = nil;
       return nil;
     }
@@ -162,7 +163,7 @@ NSString *const kKMVisualKeyboardKey = @"KMVisualKeyboardKey";
   NSFileHandle *file = [NSFileHandle fileHandleForReadingAtPath:path];
   
   if (file == nil) {
-    //NSLog(@"Failed to open file");
+    os_log_error([KMELogs configLog], "Failed to open file");
     return nil;
   }
   

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KVKFile.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KVKFile.m
@@ -8,6 +8,7 @@
 
 #import "KVKFile.h"
 #import "NKey.h"
+#import "KMELogs.h"
 
 @implementation KVKFile
 
@@ -21,7 +22,7 @@
     
     NSFileHandle *file = [NSFileHandle fileHandleForReadingAtPath:path];
     if (file == nil) {
-      //NSLog(@"Failed to open kvk file");
+      os_log_error([KMELogs configLog], "Failed to open kmx file");
       _filePath = nil;
       return nil;
     }

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KVKFile.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KVKFile.m
@@ -22,7 +22,7 @@
     
     NSFileHandle *file = [NSFileHandle fileHandleForReadingAtPath:path];
     if (file == nil) {
-      os_log_error([KMELogs configLog], "Failed to open kmx file");
+      os_log_error([KMELogs configLog], "Failed to open kvk file");
       _filePath = nil;
       return nil;
     }

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -304,7 +304,7 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
 
 - (void)stopTimer {
   @synchronized(self.target) {
-    //NSLog(@"KeyView TIMER - stopping");
+    //os_log_debug([KMELogs uiLog], "KeyView TIMER - stopping");
     if (_keyEventTimer != nil) {
       [_keyEventTimer invalidate];
       _keyEventTimer = nil;
@@ -314,7 +314,7 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
 
 - (void)timerAction:(NSTimer *)timer {
   @synchronized(self.target) {
-    //NSLog(@"KeyView TIMER - Fired for key %lu", [self keyCode]);
+    //os_log_debug([KMELogs uiLog], "KeyView TIMER - Fired for key %lu", [self keyCode]);
     [self processKeyClick];
     
     if ([timer timeInterval] == delayBeforeRepeating) {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/KeyView.m
@@ -10,7 +10,7 @@
 #import "KeyLabel.h"
 #import "MacVKCodes.h"
 #import "TimerTarget.h"
-#import <os/log.h>
+#import "KMELogs.h"
 
 CGFloat lw = 1.0;
 CGFloat r = 7.0;
@@ -39,10 +39,9 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
 @synthesize bgColorRegularKey, bgColorSpecialKey;
 
 - (id)initWithFrame:(NSRect)frame {
-  os_log_t oskKeyLog = os_log_create("org.sil.keyman", "osk-key");
   self = [super initWithFrame:frame];
   if (self) {
-    os_log_with_type(oskKeyLog, OS_LOG_TYPE_DEBUG, "KeyView initWithFrame: %{public}@, bounds: %{public}@, default clipsToBounds %{public}@", NSStringFromRect(frame), NSStringFromRect(self.bounds), self.clipsToBounds?@"YES":@"NO");
+    os_log_debug([KMELogs oskLog], "KeyView initWithFrame: %{public}@, bounds: %{public}@, default clipsToBounds %{public}@", NSStringFromRect(frame), NSStringFromRect(self.bounds), self.clipsToBounds?@"YES":@"NO");
     self.clipsToBounds = true;
     CGSize size = frame.size;
     CGFloat x = size.width*0.05;
@@ -71,8 +70,7 @@ static CGFloat const kRelativeModifierLabelHeight = 0.30f;
 }
 
 - (void)drawRect:(NSRect)rect {
-  os_log_t oskKeyLog = os_log_create("org.sil.keyman", "osk-key");
-  os_log_with_type(oskKeyLog, OS_LOG_TYPE_DEBUG, "KeyView drawRect: %{public}@, bounds: %{public}@, keyCode: 0x%lx, caption: %{public}@, label: %{public}@", NSStringFromRect(rect), NSStringFromRect(self.bounds), self.keyCode, self.caption.stringValue, self.label.stringValue);
+  os_log_debug([KMELogs uiLog], "KeyView drawRect: %{public}@, bounds: %{public}@, keyCode: 0x%lx, caption: %{public}@, label: %{public}@", NSStringFromRect(rect), NSStringFromRect(self.bounds), self.keyCode, self.caption.stringValue, self.label.stringValue);
   
   [[self getOpaqueColorWithRed:241 green:242 blue:242] setFill];
   NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKKey.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKKey.m
@@ -7,15 +7,14 @@
 //
 
 #import "OSKKey.h"
-#import <os/log.h>
+#import "KMELogs.h"
 
 @implementation OSKKey
 
 - (id)initWithKeyCode:(NSUInteger)keyCode caption:(NSString *)caption scale:(CGFloat)scale {
   self = [super init];
   if (self) {
-    os_log_t oskKeyLog = os_log_create("org.sil.keyman", "osk-key");
-    os_log_with_type(oskKeyLog, OS_LOG_TYPE_DEBUG, "OSKKey initWithKeyCode: 0x%lx, caption: %{public}@, scale: %f", keyCode, caption, scale);
+    os_log_debug([KMELogs oskLog], "OSKKey initWithKeyCode: 0x%lx, caption: %{public}@, scale: %f", keyCode, caption, scale);
     _keyCode = keyCode;
     
     if (caption == nil)

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
@@ -12,7 +12,6 @@
 #import "MacVKCodes.h"
 #import "WindowsVKCodes.h"
 #import "NKey.h"
-//#import "KMEngine.h"
 #import "CoreHelper.h"
 
 #include <Carbon/Carbon.h>

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
@@ -15,7 +15,7 @@
 #import "CoreHelper.h"
 
 #include <Carbon/Carbon.h>
-#import <os/log.h>
+#import "KMELogs.h"
 
 @interface OSKView()
 @property (nonatomic, strong) NSArray *oskLayout;
@@ -32,8 +32,7 @@
 @synthesize tag;
 
 - (id)initWithFrame:(NSRect)frame {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView initWithFrame: %{public}@", NSStringFromRect(frame));
+  os_log_debug([KMELogs oskLog], "OSKView initWithFrame: %{public}@", NSStringFromRect(frame));
   self = [super initWithFrame:frame];
   if (self) {
     // Custom initialization
@@ -44,8 +43,7 @@
 }
 
 - (void)drawRect:(NSRect)rect {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView drawRect: %{public}@", NSStringFromRect(rect));
+  os_log_debug([KMELogs uiLog], "OSKView drawRect: %{public}@", NSStringFromRect(rect));
   
   CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext] CGContext];
   CGContextSetLineJoin(context, kCGLineJoinRound);
@@ -103,8 +101,7 @@
 }
 
 - (void)setKvk:(KVKFile *)kvk {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView setKvk, forces keyboard to re-layout");
+  os_log_debug([KMELogs oskLog], "OSKView setKvk, forces keyboard to re-layout");
   _kvk = kvk;
   
   // Force the keyboard to re-layout
@@ -115,8 +112,7 @@
 }
 
 - (void)initOSKKeys {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView initOSKKeys");
+  os_log_debug([KMELogs oskLog], "OSKView initOSKKeys");
   CGFloat viewWidth = self.frame.size.width;
   CGFloat viewHeight = self.frame.size.height;
   CGFloat margin = 2.0;
@@ -151,8 +147,7 @@
 
 - (NSArray *)oskLayout {
   if (_oskLayout == nil) {
-    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "oskLayout -> creating new arrays of OSKKey objects");
+    os_log_debug([KMELogs oskLog], "oskLayout -> creating new arrays of OSKKey objects");
     NSArray *row1 = [NSArray arrayWithObjects:
                      [[OSKKey alloc] initWithKeyCode:MVK_GRAVE caption:@"`" scale:1.0],
                      [[OSKKey alloc] initWithKeyCode:MVK_1 caption:@"1" scale:1.0],
@@ -237,8 +232,7 @@
 
 - (NSArray *)oskDefaultNKeys {
   if (_oskDefaultNKeys == nil) {
-    os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-    os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "oskDefaultNKeys -> creating new arrays of default number OSKKey objects");
+    os_log_debug([KMELogs oskLog], "oskDefaultNKeys -> creating new arrays of default number OSKKey objects");
     NSMutableArray *defNKeys = [[NSMutableArray alloc] initWithCapacity:0];
     
     // row 1
@@ -409,8 +403,7 @@
 }
 
 - (void)resizeOSKLayout {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView resizeOSKLayout, removing all superviews");
+  os_log_debug([KMELogs oskLog], "OSKView resizeOSKLayout, removing all superviews");
   [self.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
   [self initOSKKeys];
 }
@@ -418,8 +411,7 @@
 - (void)keyAction:(id)sender {
   KeyView *keyView = (KeyView *)sender;
   NSUInteger keyCode = [keyView.key keyCode];
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView keyAction keyCode: 0x%lx", keyCode);
+  os_log_debug([KMELogs oskLog], "OSKView keyAction keyCode: 0x%lx", keyCode);
   if (keyCode < 0x100) {
     NSRunningApplication *app = NSWorkspace.sharedWorkspace.frontmostApplication;
     pid_t processId = app.processIdentifier;
@@ -458,8 +450,7 @@
 }
 
 - (void)handleKeyEvent:(NSEvent *)event {
-  os_log_t oskLog = os_log_create("org.sil.keyman", "osk");
-  os_log_with_type(oskLog, OS_LOG_TYPE_DEBUG, "OSKView handleKeyEvent event.type: %lu", event.type);
+  os_log_debug([KMELogs oskLog], "OSKView handleKeyEvent event.type: %lu", event.type);
   NSView *view = [self viewWithTag:event.keyCode|0x1000];
   if (view == nil || ![view isKindOfClass:[KeyView class]])
     return;

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreWrapperTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreWrapperTests.m
@@ -15,6 +15,7 @@
 #import "CoreTestStaticHelperMethods.h"
 #import "CoreAction.h"
 #import "MacVKCodes.h"
+#import "KMELogs.h"
 
 @interface CoreWrapperTests : XCTestCase
 
@@ -28,8 +29,8 @@ CoreWrapper *mockWrapper;
 + (void)setUp {
   NSString *khmerKeyboardPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"khmer_angkor.kmx"];
   
-  NSLog(@"mockKmxFilePath  = %@\n", mockKmxFilePath);
-  
+  os_log_debug([KMELogs testLog], "mockKmxFilePath  = %@\n", mockKmxFilePath);
+
   mockWrapper = [[CoreWrapper alloc] initWithHelper: [CoreTestStaticHelperMethods helper] kmxFilePath:mockKmxFilePath];
 }
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
@@ -11,6 +11,7 @@
 #import "KeymanEngineTestsStaticHelperMethods.h"
 #import "KMEngine.h"
 #import "CoreAction.h"
+#import "KMELogs.h"
 
 @interface KMEngineTests : XCTestCase
 @end
@@ -106,7 +107,7 @@ NSString * names[nCombinations];
   KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"a" charactersIgnoringModifiers:@"a" isARepeat:NO keyCode:kVK_ANSI_A];
   CoreKeyOutput *output = [engine processEvent:event];
-  NSLog(@"output = %@", output);
+  os_log_debug([KMELogs testLog], "output = %{public}@", output);
   XCTAssert(output.hasTextToInsert, @"output has text to insert");
   XCTAssert([output.textToInsert isEqualToString:@"\u00C7"], @"Expected capital C cedille (U+00C7)");
 }
@@ -287,14 +288,14 @@ NSString * names[nCombinations];
     if (modifiers[i] & (LEFT_ALT_FLAG | RIGHT_ALT_FLAG))
       characters = [characters stringByAppendingString:@"\u030A"];
     
-    NSLog(@"Test case: %lu", (NSUInteger)modifiers[i]);
+    os_log_debug([KMELogs testLog], "Test case: %lu", (NSUInteger)modifiers[i]);
     // NOTE: 'a' happens to be keyCode 0 (see initVirtualKeyMapping in CoreHelper)
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:modifiers[i] timestamp:0 windowNumber:0 context:nil characters:characters charactersIgnoringModifiers:charactersIgnoringModifiers isARepeat:NO keyCode:0];
     NSString * keyCombination = [names[i] stringByAppendingFormat:@" %@", charactersIgnoringModifiers];
     CoreKeyOutput *coreKeyOutput = [engine processEvent:event];
     XCTAssert(coreKeyOutput.hasTextToInsert, @"hasTextToInsert for %@", keyCombination);
     NSString *output = coreKeyOutput.textToInsert;
-    NSLog(@"output = %@", output);
+    os_log_debug([KMELogs testLog], "output = %{public}@", output);
     switch (modifiers[i]) {
       case LEFT_SHIFT_FLAG:
       case RIGHT_SHIFT_FLAG:
@@ -358,13 +359,13 @@ NSString * names[nCombinations];
         characters = @"ß";
     }
     
-    NSLog(@"Test case: %lu", (NSUInteger)modifiers[i]);
+    os_log_debug([KMELogs testLog], "Test case: %lu", (NSUInteger)modifiers[i]);
     // NOTE: 's' happens to be keyCode 1 (see initVirtualKeyMapping in CoreHelper)
     NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:modifiers[i] timestamp:0 windowNumber:0 context:nil characters:characters charactersIgnoringModifiers:charactersIgnoringModifiers isARepeat:NO keyCode:1];
     NSString * keyCombination = [names[i] stringByAppendingFormat:@" %@", charactersIgnoringModifiers];
     CoreKeyOutput *coreKeyOutput = [engine processEvent:event];
     NSString *output = coreKeyOutput.textToInsert;
-    NSLog(@"output = %@", output);
+    os_log_debug([KMELogs testLog], "output = %@", output);
     switch (modifiers[i]) {
       case LEFT_SHIFT_FLAG:
       case RIGHT_SHIFT_FLAG:
@@ -548,7 +549,7 @@ NSString * names[nCombinations];
   KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\b" charactersIgnoringModifiers:@"\b" isARepeat:NO keyCode:kVK_Delete];
   CoreKeyOutput *output = [engine processEvent:event];
-  NSLog(@"output: %@", output);
+  os_log_debug([KMELogs testLog], "output = %{public}@", output);
   XCTAssert(!output.hasTextToInsert, @"expected to insert nothing");
   XCTAssert(!output.hasCodePointsToDelete, @"expected to delete nothing");
   XCTAssert(output.emitKeystroke, @"expected to emit key");
@@ -559,7 +560,7 @@ NSString * names[nCombinations];
   KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"ɣ" verboseLogging:YES];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\b" charactersIgnoringModifiers:@"\b" isARepeat:NO keyCode:kVK_Delete];
   CoreKeyOutput *output = [engine processEvent:event];
-  NSLog(@"output: %@", output);
+  os_log_debug([KMELogs testLog], "output = %{public}@", output);
   XCTAssert(output.codePointsToDeleteBeforeInsert == 1, @"Expected output to delete one code point");
   XCTAssert(!output.hasTextToInsert, @"expected to insert nothing");
   NSString *context = engine.getCoreContextDebug;

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
@@ -172,7 +172,7 @@ NSString * names[nCombinations];
  NSString * numeral = [NSString stringWithFormat:@"%d", i];
  NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:numeral charactersIgnoringModifiers:numeral isARepeat:NO keyCode:ansiCode];
  NSArray *actions = [engine processEvent:event];
- NSLog(@"testprocessEvent, actions[0]: %@, expected numeral: %@", actions[0], numeral);
+ os_log_debug([KMELogs testLog], "testprocessEvent, actions[0]: %{public}@, expected numeral: %{public}@", actions[0], numeral);
  XCTAssert(actions.count == 1, @"Expected 1 action");
  CoreAction *action = actions[0];
  XCTAssert([action isCharacter], @"Expected CharacterAction");


### PR DESCRIPTION
* Create `os_log_t` objects to identify different parts of the application for logging purposes
* Define subystem and categories to use for filtering log statements
* Call unified logging APIs `os_log`, `os_log_error`, `os_log_info` and `os_log_debug` to record log statements.
* Remove all references to `logDebugMessage` and the `NSLog` macro, as they do not use unified logging (and do not specify subsystem and category)

Fixes #10997 

@keymanapp-test-bot skip