### PR TITLE
fix(android): Revert Sentry version for FV Android

### DIFF
--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.12.0'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation 'io.sentry:sentry-android:7.8.0'
+    implementation 'io.sentry:sentry-android:6.9.2'
     implementation 'androidx.preference:preference:1.2.1'
 }
 

--- a/oem/firstvoices/android/build.gradle
+++ b/oem/firstvoices/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath 'io.sentry:sentry-android-gradle-plugin:4.6.0'
+        classpath 'io.sentry:sentry-android-gradle-plugin:2.1.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
Another attempt at addressing #11491

For OEM FV Android app, this reverts the Sentry dependencies done in #11393 back to what's in stable-17.0

https://github.com/keymanapp/keyman/blob/d3f41a518aeb900b80500f212023cf782f9bcecc/oem/firstvoices/android/app/build.gradle#L124

https://github.com/keymanapp/keyman/blob/d3f41a518aeb900b80500f212023cf782f9bcecc/oem/firstvoices/android/build.gradle#L10

@keymanapp-test-bot skip
