### PR TITLE
docs(common): update min emscripten version in docs to 3.1.46

### DIFF
--- a/docs/build/macos.md
+++ b/docs/build/macos.md
@@ -77,7 +77,7 @@ PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
 
 ## KeymanWeb Dependencies
 
-* node.js 18+, emscripten, openjdk 8
+* node.js 18+, emscripten 3.1.46 or later, openjdk 8
 
 ```shell
 brew install node emscripten openjdk@8

--- a/docs/build/windows.md
+++ b/docs/build/windows.md
@@ -181,7 +181,7 @@ You can use Windows Settings to add these environment variables permanently:
 * KeymanWeb
 
 **Requirements**:
-* emscripten 3.1.40
+* emscripten 3.1.46 or later
 * node.js 18+
 * [openjdk 11](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-11)+
 
@@ -191,7 +191,7 @@ You can use Windows Settings to add these environment variables permanently:
 # for *much* faster download, hide progress bar (PowerShell/PowerShell#2138)
 $ProgressPreference = 'SilentlyContinue'
 
-choco install emscripten --version 3.1.40
+choco install emscripten --version 3.1.46
 ```
 
 Note: emscripten very unhelpfully overwrites JAVA_HOME, and adds its own


### PR DESCRIPTION
The minimum version for Windows and macOS should be 3.1.46 because that is known to work. See issue #9529 for reasons to avoid 3.1.45. Note: Ubuntu still requires 3.1.44 for now.

@keymanapp-test-bot skip

Fixes: #11369