### PR TITLE
fix(linux): Properly use and pass run_id

### DIFF
--- a/.github/workflows/api-verification.yml
+++ b/.github/workflows/api-verification.yml
@@ -22,21 +22,20 @@ jobs:
       GIT_BRANCH: ${{ steps.environment_step.outputs.GIT_BRANCH }}
       GIT_BASE_BRANCH: ${{ steps.environment_step.outputs.GIT_BASE_BRANCH }}
       GIT_USER: ${{ steps.environment_step.outputs.GIT_USER }}
-      ARTIFACTS_KEY: ${{ steps.environment_step.outputs.ARTIFACTS_KEY }}
 
     steps:
-    - name: Read environment
-      id: environment_step
-      run: |
-        cat artifacts/env >> $GITHUB_OUTPUT
-
     - name: Restore artifacts
       uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: |
           artifacts
-        key: ${ARTIFACTS_KEY}
+        key: artifacts-key-${{ github.event.workflow_run.id }}
         restore-keys: artifacts-key-
+
+    - name: Read environment
+      id: environment_step
+      run: |
+        cat artifacts/env >> $GITHUB_OUTPUT
 
   api_verification:
     name: Verify API for libkeymancore.so

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -313,14 +313,13 @@ jobs:
         echo "GIT_BRANCH=${{ github.event.client_payload.branch }}" >> artifacts/env
         echo "GIT_BASE_BRANCH=${{ github.event.client_payload.baseBranch }}" >> artifacts/env
         echo "GIT_USER=${{ github.event.client_payload.user }}" >> artifacts/env
-        echo "ARTIFACTS_KEY=artifacts-key-${GITHUB_RUN_ID}" >> artifacts/env
 
     - name: Cache artifacts
       uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: |
           artifacts
-        key: ${ARTIFACTS_KEY}
+        key: artifacts-key-${{ github.run_id }}
 
   # We intentionally ignore the results of binary_packages_unreleased
   set_status:


### PR DESCRIPTION
The previous attempt where we set a environment variable for the artifacts key resulted in a chicken/egg problem: we needed the environment variable to be able to restore the cached artifacts, but we needed the cached artifacts in order to be able to read the variables...

This change now properly uses run_id: in `deb-packaging.yml` we can directly use `run_id` from the context. In `api-verification.yml` we get it from the payload context.

Cf https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run

@keymanapp-test-bot skip