### PR TITLE
fix(developer): test existence of ngrok.exe before atttempting to start 🍒 🏠

### DIFF
--- a/developer/src/server/src/index.ts
+++ b/developer/src/server/src/index.ts
@@ -91,7 +91,10 @@ export async function run() {
 
   configuration.ngrokEndpoint = '';
 
-  if(configuration.useNgrok && os.platform() == 'win32' && fs.existsSync(configuration.ngrokBinPath)) {
+  if(configuration.useNgrok
+    && os.platform() == 'win32'
+    && fs.existsSync(path.join(configuration.ngrokBinPath, 'ngrok.exe'))
+  ) {
     const ngrok: any = await import('ngrok');
     (async function() {
       configuration.ngrokEndpoint = await ngrok.connect({


### PR DESCRIPTION
Cherry-pick of #11543.

Fixes the scenario where the `%AppData%\Keyman\Keyman Developer\Server\bin` folder exists, but ngrok.exe is not in the folder, which caused Keyman Developer Server to crash.

Fixes: #11542
Fixes: KEYMAN-DEVELOPER-1JE

@keymanapp-test-bot skip