### PR TITLE
fix(developer): handle unsupported `return` statement in `match` and `nomatch` in web compiler 🍒 🏠

### DIFF
--- a/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
@@ -885,7 +885,7 @@ export function JavaScript_OutputString(fk: KMX.KEYBOARD, FTabStops: string, fkp
         len = -1;
         break;
       default:
-        callbacks.reportMessage(KmwCompilerMessages.Error_NotSupportedInKeymanWebOutput({line: fkp.Line, code: GetCodeName(rec.Code)}));
+        callbacks.reportMessage(KmwCompilerMessages.Error_NotSupportedInKeymanWebOutput({line: fkp?.Line ?? 0, code: GetCodeName(rec.Code)}));
         Result += '';
       }
     }

--- a/developer/src/kmc-kmn/test/fixtures/kmw/error_not_supported_in_keyman_web_output.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/error_not_supported_in_keyman_web_output.kmn
@@ -1,0 +1,10 @@
+﻿store(&VERSION) '9.0'
+store(&NAME) 'error_not_supported_in_keyman_web_output'
+store(&TARGETS) 'web'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+c `return` is supported only in KMX; see also #11545
+nomatch > return

--- a/developer/src/kmc-kmn/test/kmw/test-kmw-messages.ts
+++ b/developer/src/kmc-kmn/test/kmw/test-kmw-messages.ts
@@ -71,4 +71,11 @@ describe('KmwCompilerMessages', function () {
   //   await testForMessage(this, ['kmw', '....kmn'], KmwCompilerMessages.ERROR_TouchLayoutFileDoesNotExist);
   // });
 
+  // ERROR_NotSupportedInKeymanWebOutput
+
+  it('should generate ERROR_NotSupportedInKeymanWebOutput if the command is not supported in output for KeymanWeb', async function() {
+    await testForMessage(this, ['kmw', 'error_not_supported_in_keyman_web_output.kmn'], KmwCompilerMessages.ERROR_NotSupportedInKeymanWebOutput);
+  });
+
+
 });


### PR DESCRIPTION
Cherry-pick of #11546.

The `return` statement is unsupported in the web compiler. This is documented, but the problem here was that the `nomatch` and `match` metarules have no corresponding `fkp` structure, so that caused a fatal error in the compiler if these were used in combination, e.g.

    nomatch > return

Fixes: #11545

@keymanapp-test-bot skip