### PR TITLE
fix(developer): ensure folder for MRU list is always created 🍒 🏠

### DIFF
--- a/developer/src/tike/project/Keyman.Developer.System.Project.WelcomeRenderer.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.WelcomeRenderer.pas
@@ -34,10 +34,10 @@ begin
   // so it was saving this file in the wrong location. This small patch
   // moves the file into the right location.
   path := GetFolderPath(CSIDL_APPDATA) + SFolderKeymanDeveloper;
+  ForceDirectories(path);
+
   if FileExists(path + SMRUFilename) then
   begin
-    if not DirectoryExists(path) then
-      CreateDir(path);
     if FileExists(path + '\' + SMRuFilename)
       then System.SysUtils.DeleteFile(path + SMRUFilename)
       else RenameFile(path + SMRUFilename, path + '\' + SMRUFilename);


### PR DESCRIPTION
Cherry-pick of #11552.

This arises if `%AppData%/Keyman/Keyman Developer` folder is missing. It is sporadic because most times, Keyman Developer Server wins a startup race and creates the folder before this code is ever reached.

Fixes: #11551
Fixes: KEYMAN-DEVELOPER-1MY

@keymanapp-test-bot skip