### PR TITLE
fix(developer): handle invalid project file when scanning for owner project 🍒 🏠

### DIFF
--- a/developer/src/tike/main/Keyman.Developer.System.ProjectOwningFile.pas
+++ b/developer/src/tike/main/Keyman.Developer.System.ProjectOwningFile.pas
@@ -9,7 +9,8 @@ implementation
 uses
   System.SysUtils,
 
-  Keyman.Developer.System.Project.ProjectFile;
+  Keyman.Developer.System.Project.ProjectFile,
+  Keyman.Developer.System.Project.ProjectLoader;
 
 function CheckOwnerProjectForFile(const project, filename: string): Boolean; forward;
 
@@ -71,7 +72,15 @@ begin
   if SameFileName(project, filename) then
     Exit(True);
 
-  p := TProject.Create(ptUnknown, project, True);
+  try
+    p := TProject.Create(ptUnknown, project, True);
+  except
+    on E:EProjectLoader do
+    begin
+      Result := False;
+      Exit;
+    end;
+  end;
   try
     Result := p.Files.IndexOfFileName(filename) >= 0;
   finally


### PR DESCRIPTION
Cherry-pick of #11558.

Also updates the only other place where a project file is loaded like this, in the project renderer, and handles it too (this scenario is less likely to happen because the project file must already have been loaded in order to be presented in the UI).

Fixes: #11557
Fixes: KEYMAN-DEVELOPER-1Z2

@keymanapp-test-bot skip