### PR TITLE
chore(linux): run deb-package sourcepackage job on Ubuntu 24.04

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -24,7 +24,7 @@ jobs:
   sourcepackage:
     name: Build source package
     if: github.repository == 'keymanapp/keyman'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       VERSION: ${{ steps.version_step.outputs.VERSION }}
       PRERELEASE_TAG: ${{ steps.prerelease_tag.outputs.PRERELEASE_TAG }}


### PR DESCRIPTION
Ubuntu 22.04 has meson 0.61; 24.04 has meson 1.3, so updated the sourcepackage step in deb-packaging to 24.04 to meet min reqs.

@keymanapp-test-bot skip