### PR TITLE
fix(ios): remove incorrect cast in log statement to prevent crash 🍒 🏠 

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -314,7 +314,7 @@ extension KeymanWebViewController {
         event.extra?["package"] = packageID
       }
       SentryManager.capture(event)
-      os_log("%{public}s id: %s file: %{public}s", log: KeymanEngineLogger.resources, type: .error, errorMessage, keyboard.id, fileURL as CVarArg)
+      os_log("%{public}s id: %{public}s file: %{public}s", log: KeymanEngineLogger.resources, type: .error, errorMessage, keyboard.id, fileURL.absoluteString)
       throw KeyboardError.fileMissing
     }
 
@@ -339,7 +339,7 @@ extension KeymanWebViewController {
       event.extra!["package"] = stub["KP"]
 
       SentryManager.capture(event)
-      os_log("%{public}s id: %{public}s file: %{public}s", log: KeymanEngineLogger.resources, type: .error, errorMessage, keyboard.id, fileURL as CVarArg)
+      os_log("%{public}s id: %{public}s file: %{public}s", log: KeymanEngineLogger.resources, type: .error, errorMessage, keyboard.id, fileURL.absoluteString)
       throw KeyboardError.keyboardLoadingError
     }
     guard let stubString = String(data: data, encoding: .utf8) else {


### PR DESCRIPTION
Cherry-pick of #11569

When writing a filename to the log, the fileUrl variable representing the file was miscast causing the app to crash. Removes cast and logs the absoluteString for the fileUrl instead.

Fixes #11567
Fixes KEYMAN-IOS-7A

@keymanapp-test-bot skip