### PR TITLE
fix(linux): Restore artifacts for API verification in the correct job

### DIFF
--- a/.github/workflows/api-verification.yml
+++ b/.github/workflows/api-verification.yml
@@ -11,7 +11,8 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
-  setup_environment:
+  api_verification:
+    name: Verify API for libkeymancore.so
     runs-on: ubuntu-latest
     outputs:
       VERSION: ${{ steps.environment_step.outputs.VERSION }}
@@ -37,21 +38,15 @@ jobs:
       run: |
         cat artifacts/env >> $GITHUB_OUTPUT
 
-  api_verification:
-    name: Verify API for libkeymancore.so
-    needs: setup_environment
-    runs-on: ubuntu-latest
-
-    steps:
     - name: Set pending status on PR builds
       id: set_status
-      if: needs.setup_environment.outputs.IS_TEST_BUILD == 'true'
+      if: steps.environment_step.outputs.IS_TEST_BUILD == 'true'
       shell: bash
       run: |
         gh api \
           --method POST \
           -H "Accept: application/vnd.github+json" \
-          /repos/$GITHUB_REPOSITORY/statuses/${{ needs.setup_environment.outputs.GIT_SHA }} \
+          /repos/$GITHUB_REPOSITORY/statuses/${{ steps.environment_step.outputs.GIT_SHA }} \
           -f state='pending' \
           -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
           -f description='API verification started' \
@@ -60,7 +55,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
-        ref: '${{ needs.setup_environment.outputs.GIT_SHA }}'
+        ref: '${{ steps.environment_step.outputs.GIT_SHA }}'
         fetch-depth: 0
 
     - name: Install devscripts
@@ -68,18 +63,18 @@ jobs:
       with:
         packages: devscripts equivs
 
-    - name: "Verify API for libkeymancore.so (${{ needs.setup_environment.outputs.GIT_BRANCH }}, branch ${{ needs.setup_environment.outputs.GIT_BASE_BRANCH }}, by ${{ needs.setup_environment.outputs.GIT_USER }}) - "
+    - name: "Verify API for libkeymancore.so (${{ steps.environment_step.outputs.GIT_BRANCH }}, branch ${{ steps.environment_step.outputs.GIT_BASE_BRANCH }}, by ${{ steps.environment_step.outputs.GIT_USER }}) - "
       run: |
         ls -al ${GITHUB_WORKSPACE}
         ls -al ${GITHUB_WORKSPACE}/artifacts/
-        ls -al "${GITHUB_WORKSPACE}/artifacts/${PKG_NAME}_${{ needs.setup_environment.outputs.VERSION }}-1${{ needs.setup_environment.outputs.PRERELEASE_TAG }}+$(lsb_release -c -s)1_amd64.deb"
+        ls -al "${GITHUB_WORKSPACE}/artifacts/${PKG_NAME}_${{ steps.environment_step.outputs.VERSION }}-1${{ steps.environment_step.outputs.PRERELEASE_TAG }}+$(lsb_release -c -s)1_amd64.deb"
 
         cd linux
         ./scripts/deb-packaging.sh \
           --gha \
-          --bin-pkg "${GITHUB_WORKSPACE}/artifacts/${PKG_NAME}_${{ needs.setup_environment.outputs.VERSION }}-1${{ needs.setup_environment.outputs.PRERELEASE_TAG }}+$(lsb_release -c -s)1_amd64.deb" \
-          --git-sha "${{ needs.setup_environment.outputs.GIT_SHA }}" \
-          --git-base "${{ needs.setup_environment.outputs.GIT_BASE }}" \
+          --bin-pkg "${GITHUB_WORKSPACE}/artifacts/${PKG_NAME}_${{ steps.environment_step.outputs.VERSION }}-1${{ steps.environment_step.outputs.PRERELEASE_TAG }}+$(lsb_release -c -s)1_amd64.deb" \
+          --git-sha "${{ steps.environment_step.outputs.GIT_SHA }}" \
+          --git-base "${{ steps.environment_step.outputs.GIT_BASE }}" \
           verify 2>> $GITHUB_STEP_SUMMARY
 
     - name: Archive .symbols file
@@ -91,9 +86,9 @@ jobs:
 
   set_status:
     name: Set result status on PR builds
-    needs: [setup_environment, api_verification]
+    needs: [api_verification]
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.setup_environment.outputs.IS_TEST_BUILD == 'true' }}
+    if: ${{ always() && needs.api_verification.outputs.IS_TEST_BUILD == 'true' }}
     steps:
     - name: Set success
     # TEMP commented until things are working!
@@ -119,7 +114,7 @@ jobs:
         gh api \
           --method POST \
           -H "Accept: application/vnd.github+json" \
-          /repos/$GITHUB_REPOSITORY/statuses/${{ needs.setup_environment.outputs.GIT_SHA }} \
+          /repos/$GITHUB_REPOSITORY/statuses/${{ needs.api_verification.outputs.GIT_SHA }} \
           -f state="$RESULT" \
           -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
           -f description="$MSG" \


### PR DESCRIPTION
Previously we had an extra job where we setup the environment and restored the artifacts. However, the artifacts then were no longer available in the next job, `api_verification`. Instead of restoring the artifacts a second time this change squashes the two jobs. This will hopefully fix the API verification.

@keymanapp-test-bot skip