### PR TITLE
fix(developer): save touch layout editor selection when loading state

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/builder.js
+++ b/developer/src/tike/xml/layoutbuilder/builder.js
@@ -1109,7 +1109,11 @@ $(function() {
             // The last selected presentation is no longer available; select the first option instead
             $('#selPlatformPresentation').val($('#selPlatformPresentation option:first').val());
           }
+
+          let selection = builder.saveSelection();
           builder.prepareLayer();
+          builder.restoreSelection(selection);
+
           if(data.layer && KVKL[builder.lastPlatform][data.layer]) {
             $('#selLayer').val(data.layer);
             builder.selectLayer();


### PR DESCRIPTION
Key selection was left in a corrupted state in `builder.loadState()`, on first load of the touch layout editor, because the selection was not restored after calling `prepareLayer()`.

This only happens on first load because after first load, the selection will have been saved to the state (which is kept in the backend, associated with the instance of the editor), so pressing F5 to reload the page will not reproduce the issue.

Fixes: #11573
Fixes: KEYMAN-DEVELOPER-1Z8

# User Testing

* **TEST_TOUCH_LAYOUT_EDITOR:** Open the touch layout editor, and perform a variety of standard operations. Verify that they behave as expected. Press F12 to open the Developer Tools, and verify that there are no errors shown in the Console.