### PR TITLE
fix(developer): use correct variable when fixing up flick and multitap in Layer Properties dialog

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/layer-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/layer-controls.js
@@ -84,10 +84,10 @@ $(function() {
                     key.sk.forEach(k => fixup(k));
                   }
                   if (key.flick) {
-                    fkey.flick.forEach(k => fixup(k));
+                    key.flick.forEach(k => fixup(k));
                   }
                   if (key.multitap) {
-                    fkey.multitap.forEach(k => fixup(k));
+                    key.multitap.forEach(k => fixup(k));
                   }
                 });
               }


### PR DESCRIPTION
Fixes: #11574
Fixes: KEYMAN-DEVELOPER-1GC

@keymanapp-test-bot skip