### PR TITLE
fix(web): add null guard for missing debug info when reporting to Sentry

### DIFF
--- a/common/web/sentry-manager/src/index.ts
+++ b/common/web/sentry-manager/src/index.ts
@@ -104,7 +104,7 @@ export class KeymanSentryManager {
   attachEventMetadata(event: any) {
     // Ensure that the 'extra' object exists.  (May not exist for synthetic/custom Errors.)
     event.extra = event.extra || {};
-    event.extra.keymanState = window['keyman']['getDebugInfo']();
+    event.extra.keymanState = window['keyman']?.['getDebugInfo']?.();
     event.extra.keymanHostPlatform = this.keymanPlatform;
   }
 


### PR DESCRIPTION
Fixes #11548.

@keymanapp-test-bot skip