### PR TITLE
fix(android): case of incomplete error handling for keyboard, model downloads

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
@@ -48,6 +48,12 @@ public class CloudDownloadMgr{
    */
   boolean isInitialized = false;
 
+  /**
+   * Marks that `registerReceiver` was successfully called, and thus should be unregistered
+   * at some later point in time.
+   */
+  boolean hasRegistered = false;
+
   private HashMap<Long,String> internalDownloadIdToDownloadIdentifier = new HashMap<>();
   private HashMap<String, CloudApiTypes.CloudDownloadSet> downloadSetByDownloadIdentifier = new HashMap<>();
 
@@ -69,6 +75,7 @@ public class CloudDownloadMgr{
       } else {
         aContext.registerReceiver(completeListener, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
       }
+      hasRegistered = true;
     } catch (IllegalStateException e) {
       String message = "initialize error: ";
       KMLog.LogException(TAG, message, e);
@@ -80,9 +87,8 @@ public class CloudDownloadMgr{
    * Remove downloadreceiver from the main context.
    * @param aContext the context
    */
-  public synchronized void shutdown(Context aContext)
-  {
-    if(!isInitialized)
+  public synchronized void shutdown(Context aContext) {
+    if(!isInitialized || !hasRegistered)
       return;
     try {
       aContext.unregisterReceiver(completeListener);
@@ -91,6 +97,7 @@ public class CloudDownloadMgr{
       KMLog.LogException(TAG, message, e);
     }
     isInitialized = false;
+    hasRegistered = false;
   }
 
   /**


### PR DESCRIPTION
Fixes #11561.

This patches error handling for part of the keyboard / lexical-model downloading process.  Technical details may be found within #11561.

## User Testing

TEST_KBD_DOWNLOAD:  Use the in-app keyboard-search to find and install an existing keyboard that supports a lexical model.
- This is likely easiest from a fresh install, but is possible without that so long as the keyboard hasn't previously been downloaded.
- A few candidate keyboard IDs:
    - `khmer_angkor`
    - `gff_amharic`
    - `fv_sencoten`
    - `naijatype`
- Testing with any one of these, or of any other known keyboard with an associated model in our repositories, should be sufficient.
- If the keyboard fails to download, or fails to activate an associated lexical model when swapped to (after a brief wait), fail this test.