### PR TITLE
fix(developer): correct the inference of default hint from flicks

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/builder.js
+++ b/developer/src/tike/xml/layoutbuilder/builder.js
@@ -304,10 +304,12 @@ $(function() {
     return val;
   }
 
-  this.inferKeyHintText = function(keyHint, longpress, flick, multitap) {
+  this.inferKeyHintText = function(keyHint, longpress, flickArray, multitap) {
     let hint = keyHint;
+    const flick = flickArray ? flickArray.reduce((o,f) => {o[f.direction] = f; return o}, {}) : null;
     if(!hint) {
-      switch(KVKL[builder.lastPlatform].defaultHint ?? 'dot') {
+      const source = KVKL[builder.lastPlatform].defaultHint ?? 'dot';
+      switch(source) {
         case 'none':
           break;
         case 'dot':


### PR DESCRIPTION
There were two problems here:
* An undeclared variable `source`
* The `flick` parameter is an array, not an object, so indexing by direction is invalid

Fixes: #11581
Fixes: KEYMAN-DEVELOPER-1YW

@keymanapp-test-bot skip