### PR TITLE
fix(developer): handle editor initializing after debugger when setting execution point

### DIFF
--- a/developer/src/tike/xml/app/editor/editor.js
+++ b/developer/src/tike/xml/app/editor/editor.js
@@ -199,6 +199,13 @@ async function loadSettings() {
   };
 
   context.updateExecutionPoint = function (row) {
+    if(!editor) {
+      // At debugger startup time, it initializes asynchronously at the same
+      // time as the editor, which means that in some circumstances the
+      // debugger will call to SetExecutionPointLine before the editor has
+      // loaded. The safest thing to do here is just exit. #11586
+      return;
+    }
     if(row >= 0) {
       executionPoint = editor.deltaDecorations(
         executionPoint,


### PR DESCRIPTION
Note: this was a silent exception for the user.

Fixes: #11586
Fixes: KEYMAN-DEVELOPER-1K7

@keymanapp-test-bot skip