### PR TITLE
fix(developer): make top row of Character Map 1 pixel to avoid DIV/0 in gestures

### DIFF
--- a/common/windows/delphi/charmap/UfrmCharacterMapNew.pas
+++ b/common/windows/delphi/charmap/UfrmCharacterMapNew.pas
@@ -342,7 +342,8 @@ begin
 
     grid.RowCount := n+1; //FCharCount div grid.ColCount + 1;
     if n = 0
-      then grid.RowHeights[n] := 0 {Don't show the first block title}
+      // Top row must be 1 pixel in order to avoid DIV/0 in Grids.pas #11589
+      then grid.RowHeights[n] := 1 {Don't show the first block title}
       else grid.RowHeights[n] := 28;
     Blocks[i].Tag := n;
 
@@ -589,6 +590,18 @@ var
   uc: Integer;
   RectBmp: TRect;
 begin
+  if ARow = 0 then
+  begin
+    // #11589 -- we have a single pixel top row to avoid DIV/0, so format it as
+    // 'invisible' by making it look the same as gridlines. It is not selectable
+    // so there is no real behaviour change.
+    grid.Canvas.Brush.Color := $909090;
+    grid.Canvas.Font.Color := $909090;
+    grid.Canvas.TextRect(Rect, Rect.Left, Rect.Top, ' ');
+    grid.Canvas.FillRect(Rect);
+    Exit;
+  end;
+
   ub := GetHeaderCellProperties(ACol, ARow);
   if Assigned(ub) then
   begin


### PR DESCRIPTION
An apparent issue in the Grid control in Delphi is that if the top row is zero pixels high (hiding it), a pan gesture on touchscreen causes an EDivByZero. This patch works around the issue by making the top row 1 pixel high.

Fixes: #11589
Fixes: KEYMAN-DEVELOPER-1C3
Fixes: KEYMAN-WINDOWS-43C

@keymanapp-test-bot skip