### PR TITLE
fix(linux): Don't clean workdir after checkout in API verification

### DIFF
--- a/.github/workflows/api-verification.yml
+++ b/.github/workflows/api-verification.yml
@@ -57,6 +57,7 @@ jobs:
       with:
         ref: '${{ steps.environment_step.outputs.GIT_SHA }}'
         fetch-depth: 0
+        clean: false
 
     - name: Install devscripts
       uses: ./.github/actions/apt-install


### PR DESCRIPTION
Set the option for the Checkout step to not  run `git clean` after checkout because that gets rid of the artifacts we previously restored.

@keymanapp-test-bot skip