### PR TITLE
fix(web): headless recorder unhandled paths, invalid test-sequence references 🔩

### DIFF
--- a/common/web/recorder/src/index.ts
+++ b/common/web/recorder/src/index.ts
@@ -572,7 +572,7 @@ export class EventSpecTestSet implements TestSet<InputEventSpecSequence> {
 
     for(var i=0; i < testSet.length; i++) {
       const testSeq = this.testSet[i];
-      const simResult = await testSet[i].test(proctor);
+      const simResult = await testSeq.test(proctor);
       if(!simResult.success) {
         // Failed test!
         failures.push(new TestFailure(this.constraint, testSeq, simResult.result));
@@ -622,7 +622,7 @@ export class RecordedSequenceTestSet implements TestSet<RecordedKeystrokeSequenc
 
     for(var i=0; i < testSet.length; i++) {
       const testSeq = this.testSet[i];
-      const simResult = await testSet[i].test(proctor);
+      const simResult = await testSeq.test(proctor);
       if(!simResult.success) {
         // Failed test!
         failures.push(new TestFailure(this.constraint, testSeq, simResult.result));

--- a/common/web/recorder/src/index.ts
+++ b/common/web/recorder/src/index.ts
@@ -621,8 +621,8 @@ export class RecordedSequenceTestSet implements TestSet<RecordedKeystrokeSequenc
     let testSet = this.testSet;
 
     for(var i=0; i < testSet.length; i++) {
-      var testSeq = this.testSet[i];
-      var simResult = await testSet[i].test(proctor);
+      const testSeq = this.testSet[i];
+      const simResult = await testSet[i].test(proctor);
       if(!simResult.success) {
         // Failed test!
         failures.push(new TestFailure(this.constraint, testSeq, simResult.result));

--- a/common/web/recorder/src/index.ts
+++ b/common/web/recorder/src/index.ts
@@ -8,19 +8,22 @@ export { default as NodeProctor } from "./nodeProctor.js";
 
 import * as utils from "@keymanapp/web-utils";
 
+type EventTypeTag = 'key' | 'osk';
+type TaggedEventObject = { type: EventTypeTag }
+
 //#region Defines the InputEventSpec set, used to reconstruct DOM-based events for browser-based simulation
 export abstract class InputEventSpec {
-  type: "key" | "osk";
-  static fromJSONObject(obj: any): InputEventSpec {
-    if(obj && obj.type) {
+  type: EventTypeTag;
+  static fromJSONObject(obj: TaggedEventObject): InputEventSpec {
+    if(obj) {
       if(obj.type == "key") {
-        return new PhysicalInputEventSpec(obj);
+        return new PhysicalInputEventSpec(obj as PhysicalInputEventSpec);
       } else if(obj.type == "osk") {
-        return new OSKInputEventSpec(obj);
+        return new OSKInputEventSpec(obj as OSKInputEventSpec);
       }
-    } else {
-      throw new SyntaxError("Error in JSON format corresponding to an InputEventSpec!");
     }
+
+    throw new SyntaxError("Error in JSON format corresponding to an InputEventSpec!");
   }
 
   toPrettyJSON(): string {
@@ -93,18 +96,18 @@ export class OSKInputEventSpec extends InputEventSpec {
 //#endregion
 
 export abstract class RecordedKeystroke {
-  type: "key" | "osk";
+  type: EventTypeTag;
 
-  static fromJSONObject(obj: any): RecordedKeystroke {
-    if(obj && obj.type) {
+  static fromJSONObject(obj: TaggedEventObject): RecordedKeystroke {
+    if(obj) {
       if(obj.type == "key") {
         return new RecordedPhysicalKeystroke(obj as RecordedPhysicalKeystroke);
-      } else if(obj && obj.type) {
+      } else if(obj.type == "osk") {
         return new RecordedSyntheticKeystroke(obj as RecordedSyntheticKeystroke);
       }
-    } else {
-      throw new SyntaxError("Error in JSON format corresponding to a RecordedKeystroke!");
     }
+
+    throw new SyntaxError("Error in JSON format corresponding to a RecordedKeystroke!");
   }
 
   toPrettyJSON(): string {
@@ -568,8 +571,8 @@ export class EventSpecTestSet implements TestSet<InputEventSpecSequence> {
     let testSet = this.testSet;
 
     for(var i=0; i < testSet.length; i++) {
-      var testSeq = this[i];
-      var simResult = await testSet[i].test(proctor);
+      const testSeq = this.testSet[i];
+      const simResult = await testSet[i].test(proctor);
       if(!simResult.success) {
         // Failed test!
         failures.push(new TestFailure(this.constraint, testSeq, simResult.result));
@@ -618,7 +621,7 @@ export class RecordedSequenceTestSet implements TestSet<RecordedKeystrokeSequenc
     let testSet = this.testSet;
 
     for(var i=0; i < testSet.length; i++) {
-      var testSeq = this[i];
+      var testSeq = this.testSet[i];
       var simResult = await testSet[i].test(proctor);
       if(!simResult.success) {
         // Failed test!


### PR DESCRIPTION
This bugfix was originally part of #11424 and is now being spun off as its own PR.  It appears that previously, keyboard-simulation test failures would not have been reported properly if they occurred.  

The bug being fixed was discovered due to either "noImplicitAny" or "noImplicitThis" being enforced against the sourcefile.

I ended up extracting all changes from that PR, meaning that this PR makes the source file compatible with stricter .tsconfig settings.  I also added extra tweaks while I was at it, largely around type-names to facilitate checks against `'key' | 'osk'` so that TS could better make inferences about related control flow in line with "noImplicitReturns".

As this PR only adjusts unit-test resources, there's no need to bother 🍒-picking this.

@keymanapp-test-bot skip