### PR TITLE
fix(web): remove dead code-branches 🔩

### DIFF
--- a/web/src/app/webview/src/oskConfiguration.ts
+++ b/web/src/app/webview/src/oskConfiguration.ts
@@ -12,14 +12,10 @@ export function setupEmbeddedListeners(engine: KeymanEngine, osk: OSKView) {
       if(typeof engine.showKeyboardList == 'function') { // OSKView event: shouldShowLanguageMenu
         engine.showKeyboardList();                       // Is connected to VisualKeyboard event: globeKey
       }
-    } else if(osk.vkbd) {
-      if(osk.vkbd.menuEvent) {
-        this.highlightKey(osk.vkbd.menuEvent, false);
-      }
+    } else {
       if(typeof(engine.menuKeyUp) == 'function') { // VisualKeyboard event:  globeKey
         engine.menuKeyUp();
       }
-      osk.vkbd.menuEvent = null;
     }
 
     if(osk.vkbd) {

--- a/web/src/engine/element-wrappers/src/utils.ts
+++ b/web/src/engine/element-wrappers/src/utils.ts
@@ -5,11 +5,11 @@
  * See https://stackoverflow.com/questions/43587286/why-does-instanceof-return-false-on-chrome-safari-and-edge-and-true-on-firefox
  * for more details.
  *
- * @param {Element|Event}   Pelem       An element of the web page or one of its IFrame-based subdocuments.
- * @param {string}          className   The plain-text name of the expected Element type.
+ * @param {EventTarget}   Pelem       An element of the web page or one of its IFrame-based subdocuments.
+ * @param {string}        className   The plain-text name of the expected Element type.
  * @return {boolean}
  */
-export function nestedInstanceOf(Pelem: Event|EventTarget, className: string): boolean {
+export function nestedInstanceOf(Pelem: EventTarget, className: string): boolean {
   var scopedClass;
 
   if(!Pelem) {
@@ -23,16 +23,6 @@ export function nestedInstanceOf(Pelem: Event|EventTarget, className: string): b
     scopedClass = Pelem['defaultView'][className];
   } else if(Pelem['ownerDocument']) {
     scopedClass = (Pelem as Node).ownerDocument.defaultView[className];
-  } else if(Pelem['target']) {
-    var event = Pelem as Event;
-
-    if(this.instanceof(event.target, 'Window')) {
-      scopedClass = event.target[className];
-    } else if(this.instanceof(event.target, 'Document')) {
-      scopedClass = (event.target as Document).defaultView[className];
-    } else if(this.instanceof(event.target, 'HTMLElement')) {
-      scopedClass = (event.target as HTMLElement).ownerDocument.defaultView[className];
-    }
   }
 
   if(scopedClass) {

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -241,9 +241,6 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
   touchCount: number;
   currentTarget: KeyElement;
 
-  // Used by embedded-mode's globe key
-  menuEvent: KeyElement; // Used by embedded-mode.
-
   // Popup key management
   keytip: KeyTip;
   gesturePreviewHost: GesturePreviewHost;


### PR DESCRIPTION
Originally part of #11459, this PR extracts fixes for a couple of bugs found in dead code branches when using enhanced TS strictness settings.  The easy fix:  just remove the code, as requested by https://github.com/keymanapp/keyman/pull/11459#pullrequestreview-2062626843:

> Sounds like there are some dead code removal PRs coming up before too long as well?

In both cases, we were calling functions against `this` that simply didn't exist there.

The deleted `menuEvent` is removed because it becomes an "unused local" according to other TS strictness settings about to be enforced.

As the code paths are dead, we don't _have_ to 🍒-pick this... but again, as they're dead, there's no reason it wouldn't be safe to do so.  (Yay, file-size shrinkage!)

@keymanapp-test-bot skip