### PR TITLE
fix(web): use intended source for prediction-to-context matching 🔩

### DIFF
--- a/common/web/lm-worker/src/main/model-compositor.ts
+++ b/common/web/lm-worker/src/main/model-compositor.ts
@@ -253,6 +253,7 @@ export default class ModelCompositor {
           // Without it, we can't apply the suggestion.
           let finalInput: Transform;
           if(match.inputSequence.length > 0) {
+            // common case:  from the same keystroke `inputTransform`, with matching `.id`.
             finalInput = match.inputSequence[match.inputSequence.length - 1].sample;
           } else {
             finalInput = inputTransform;  // A fallback measure.  Greatly matters for empty contexts.
@@ -262,7 +263,7 @@ export default class ModelCompositor {
           let correctionTransform: Transform = {
             insert: correction,  // insert correction string
             deleteLeft: deleteLeft,
-            id: inputTransform.id // The correction should always be based on the most recent external transform/transcription ID.
+            id: finalInput.id // The correction should always be based on the most recent external transform/transcription ID.
           }
 
           let rootCost = match.totalCost;


### PR DESCRIPTION
Originally part of #11424, this potential bug was spotted due to enforcing `"noUnusedLocals"` against the lm-worker codebase.  It's pretty clear that `finalInput` had an intended use... but... simply wasn't used.

It's notable that we haven't (knowingly) had any related bugs in the time it's been like this, so we're probably safer by _not_ 🍒-picking this change at this time.  I believe the change should actually be fine, as it would usually resolve to the same value, but there's little reason to risk it at this time.

@keymanapp-test-bot skip