### PR TITLE
fix(web): explicitly terminate banner gesture-handling when banner is swapped 🔩

### DIFF
--- a/web/src/engine/osk/src/banner/banner.ts
+++ b/web/src/engine/osk/src/banner/banner.ts
@@ -115,4 +115,6 @@ export abstract class Banner {
   public readonly refreshLayout?: () => void;
 
   abstract get type();
+
+  public shutdown() { };
 }

--- a/web/src/engine/osk/src/banner/bannerView.ts
+++ b/web/src/engine/osk/src/banner/bannerView.ts
@@ -86,6 +86,7 @@ export class BannerView implements OSKViewComponent {
         let prevBanner = this.currentBanner;
         this.currentBanner = banner;
         this.bannerContainer.replaceChild(banner.getDiv(), prevBanner.getDiv());
+        prevBanner.shutdown();
       }
     } else {
       this.currentBanner = banner;

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -419,6 +419,10 @@ export class SuggestionBanner extends Banner {
     this.gestureEngine = this.setupInputHandling();
   }
 
+  shutdown() {
+    this.gestureEngine.destroy();
+  }
+
   buildInternals(rtl: boolean) {
     this.isRTL = rtl;
     if(this.options.length > 0) {


### PR DESCRIPTION
While working on #11460, I noticed that unlike most of the other DOM-event interacting OSK components, the predictive-text banner lacked a destructor-style method.  In 17.0, the banner utilizes the new gesture engine.  To be safe, it's wisest to explicitly terminate the engine whenever its corresponding banner is swapped out.  

We're _probably_ fine without it due to garbage collection, but I believe part of the engine's setup can register an event handler outside of the banner hierarchy... which would thus _not_ be GC'd after swap without this change.  It should only ever be a _minor_ memory leak, even then, as we've not gotten any related error reports so far as we can tell.

@keymanapp-test-bot skip