### PR TITLE
fix(web): use correct parameter name in button UI OSK `hide` event 🔩

### DIFF
--- a/web/src/app/ui/kmwuibutton.ts
+++ b/web/src/app/ui/kmwuibutton.ts
@@ -293,7 +293,7 @@ if(!keyman?.ui?.name) {
 
         /* TODO: why is this still needed??? Does it actually do anything?? */
         osk.addEventListener('hide', function(obj) {
-          if((arguments.length > 0) && obj['hiddenByUser']) {
+          if((arguments.length > 0) && obj.HiddenByUser) {
             let _a = document.getElementById('KMW_Keyboard');
             if(_a) {
               _a.className = 'kmw_hide';


### PR DESCRIPTION
Originally part of #11462, this fixes a Button-UI bug identified thanks to enforcing "noImplicitAny".  [(Original thread)](https://github.com/keymanapp/keyman/pull/11462#discussion_r1604515263)

As this _is_ a live bug in 17.0, it may be worth 🍒-picking.  It's _probably_ a niche scenario... but still.

@keymanapp-test-bot skip