### PR TITLE
refactor(web): refactor keyboard-layout preprocessing property transplantation 🔩

### DIFF
--- a/common/web/keyboard-processor/src/keyboards/activeLayout.ts
+++ b/common/web/keyboard-processor/src/keyboards/activeLayout.ts
@@ -558,7 +558,7 @@ export class ActiveRow implements LayoutRow {
     for(let j=0; j<keys.length; j++) {
       let key=keys[j];
       let keySet = Object.keys(DEFAULT_KEY);
-      for(let tp in keySet) {
+      for(let tp of keySet) {
         const typedKey = tp as keyof typeof DEFAULT_KEY;
         if(typeof key[typedKey] != 'string' && typeof key[typedKey] != 'number') {
           // We detected a value of the wrong type.


### PR DESCRIPTION
This is a tweak on a fix originally included within #11424.  As [noted here](https://github.com/keymanapp/keyman/pull/11424/files#r1610884203), there was a pattern in keyboard-layout preprocessing that kept needing `// @ts-ignore` when enforcing stricter TS settings - and particularly `"noImplicitAny"`.  After giving it some thought, I figured a mild DRY-out would make things a bit simpler overall and avoid constant replication of `// @ts-ignore` due to the pattern.

@keymanapp-test-bot skip