### PR TITLE
fix(web): fix keyboard-processing bugs uncovered by stricter TS settings 🔩

### DIFF
--- a/common/web/input-processor/src/correctionLayout.ts
+++ b/common/web/input-processor/src/correctionLayout.ts
@@ -81,7 +81,7 @@ export function correctionKeyFilter(key: ActiveKeyBase): boolean {
     return false;
     // Attempt to filter out known non-output keys.
     // Results in a more optimized distribution.
-  } else if(Codes.isKnownOSKModifierKey(key.baseKeyID)) {
+  } else if(Codes.isKeyNotCorrected(key.baseKeyID)) {
     return false;
   } else if(key.isPadding) { // to the user, blank / padding keys do not exist.
     return false;

--- a/common/web/input-processor/src/correctionLayout.ts
+++ b/common/web/input-processor/src/correctionLayout.ts
@@ -81,7 +81,7 @@ export function correctionKeyFilter(key: ActiveKeyBase): boolean {
     return false;
     // Attempt to filter out known non-output keys.
     // Results in a more optimized distribution.
-  } else if(Codes.isKeyNotCorrected(key.baseKeyID)) {
+  } else if(Codes.isFrameKey(key.baseKeyID)) {
     return false;
   } else if(key.isPadding) { // to the user, blank / padding keys do not exist.
     return false;

--- a/common/web/input-processor/src/text/inputProcessor.ts
+++ b/common/web/input-processor/src/text/inputProcessor.ts
@@ -199,7 +199,7 @@ export default class InputProcessor {
 
     // If it's a key that we 'optimize out' of our fat-finger correction algorithm,
     // we MUST NOT trigger it for this keystroke.
-    let isOnlyLayerSwitchKey = Codes.isKeyNotCorrected(keyEvent.kName);
+    let isOnlyLayerSwitchKey = Codes.isFrameKey(keyEvent.kName);
 
     // Best-guess stopgap for possible custom modifier keys.
     // If a key (1) does not affect the context and (2) shifts the active layer,

--- a/common/web/input-processor/src/text/inputProcessor.ts
+++ b/common/web/input-processor/src/text/inputProcessor.ts
@@ -199,7 +199,7 @@ export default class InputProcessor {
 
     // If it's a key that we 'optimize out' of our fat-finger correction algorithm,
     // we MUST NOT trigger it for this keystroke.
-    let isOnlyLayerSwitchKey = Codes.isKnownOSKModifierKey(keyEvent.kName);
+    let isOnlyLayerSwitchKey = Codes.isKeyNotCorrected(keyEvent.kName);
 
     // Best-guess stopgap for possible custom modifier keys.
     // If a key (1) does not affect the context and (2) shifts the active layer,

--- a/common/web/keyboard-processor/src/keyboards/defaultLayouts.ts
+++ b/common/web/keyboard-processor/src/keyboards/defaultLayouts.ts
@@ -61,7 +61,10 @@ export class Layouts {
   static readonly dfltText='`1234567890-=\xA7~~qwertyuiop[]\\~~~asdfghjkl;\'~~~~~?zxcvbnm,./~~~~~ '
     +'~!@#$%^&*()_+\xA7~~QWERTYUIOP{}\\~~~ASDFGHJKL:"~~~~~?ZXCVBNM<>?~~~~~ ';
 
-  static readonly DEFAULT_RAW_SPEC = {'F':'Tahoma', 'BK': Layouts.dfltText} as const;
+  // The function baked into keyboards by the current Web compiler creates an
+  // array of single-char strings for BK. Refer to
+  // developer/src/kmc-kmn/src/kmw-compiler/visual-keyboard-compiler.ts.
+  static readonly DEFAULT_RAW_SPEC = {'F':'Tahoma', 'BK': Layouts.dfltText.split('')} as const;
 
   static modifierSpecials = {
     'leftalt': '*LAlt*',

--- a/common/web/keyboard-processor/src/text/codes.ts
+++ b/common/web/keyboard-processor/src/text/codes.ts
@@ -95,6 +95,8 @@ const Codes = {
       case 'K_CAPS':
         return true;
       default:
+        // 50000:  start of the range defining key-codes for special frame-key symbols
+        // and specialized common layer-switching key IDs.  See .keyCodes above.
         if(Codes.keyCodes[keyID] >= 50000) { // A few are used by `sil_euro_latin`.
           return true; // is a 'K_' key defined for layer shifting or 'control' use.
         }

--- a/common/web/keyboard-processor/src/text/codes.ts
+++ b/common/web/keyboard-processor/src/text/codes.ts
@@ -86,8 +86,10 @@ const Codes = {
     [')!@#$%^&*(',':+<_>?~', '{|}"']
   ],
 
-  isKeyNotCorrected(keyID: string): boolean {
+  isFrameKey(keyID: string): boolean {
     switch(keyID) {
+      // TODO:  consider adding K_ALT, K_CTRL.
+      // Not currently here as they typically don't show up on mobile layouts.
       case 'K_SHIFT':
       case 'K_LOPT':
       case 'K_ROPT':

--- a/common/web/keyboard-processor/src/text/codes.ts
+++ b/common/web/keyboard-processor/src/text/codes.ts
@@ -86,7 +86,7 @@ const Codes = {
     [')!@#$%^&*(',':+<_>?~', '{|}"']
   ],
 
-  isKnownOSKModifierKey(keyID: string): boolean {
+  isKeyNotCorrected(keyID: string): boolean {
     switch(keyID) {
       case 'K_SHIFT':
       case 'K_LOPT':
@@ -97,13 +97,6 @@ const Codes = {
       default:
         if(Codes.keyCodes[keyID] >= 50000) { // A few are used by `sil_euro_latin`.
           return true; // is a 'K_' key defined for layer shifting or 'control' use.
-        }
-        // Refer to text/codes.ts - these are Keyman-custom "keycodes" used for
-        // layer shifting keys.  To be safe, we currently let K_TABBACK and
-        // K_TABFWD through, though we might be able to drop them too.
-        const code = Codes[keyID];
-        if(code > 50000 && code < 50011) {
-          return true;
         }
     }
 

--- a/common/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/web/keyboard-processor/src/text/kbdInterface.ts
@@ -939,9 +939,8 @@ export default class KeyboardInterface extends KeyboardHarness {
       // Denote the changed store as part of the matched rule's behavior.
       this.ruleBehavior.setStore[systemId] = strValue;
       return true;
-    } else {
-      return false;
-    }
+    } 
+    return false;
   }
 
   /**

--- a/common/web/keyboard-processor/src/text/kbdInterface.ts
+++ b/common/web/keyboard-processor/src/text/kbdInterface.ts
@@ -938,6 +938,7 @@ export default class KeyboardInterface extends KeyboardHarness {
     if(systemId == SystemStoreIDs.TSS_LAYER && this.activeDevice.touchable) {
       // Denote the changed store as part of the matched rule's behavior.
       this.ruleBehavior.setStore[systemId] = strValue;
+      return true;
     } else {
       return false;
     }


### PR DESCRIPTION
Originally part of #11424, these changes address bugs that were uncovered thanks to stricter TS settings.  There are three in total, but they're in the same region of code and are all quite small, so I lumped 'em together.

@keymanapp-test-bot skip