### PR TITLE
fix(android): check current orientation when redisplaying system keyboard

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -147,6 +147,16 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     KMManager.onStartInput(attribute, restarting);
     KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_SYSTEM);
 
+    // This method (likely) includes the IME equivalent to `onResume` for `Activity`-based classes,
+    // making it an important time to detect orientation changes.
+    Context appContext = getApplicationContext();
+    int newOrientation = KMManager.getOrientation(appContext);
+    if(newOrientation != lastOrientation) {
+      lastOrientation = newOrientation;
+      Configuration newConfig = this.getResources().getConfiguration();
+      KMManager.onConfigurationChanged(newConfig);
+    }
+
     // Temporarily disable predictions on certain fields (e.g. hidden password field or numeric)
     int inputType = attribute.inputType;
     KMManager.setMayPredictOverride(inputType);
@@ -154,7 +164,6 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
       KMManager.setBannerOptions(false);
     } else if (KMManager.isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM)){
       // Check if predictions needs to be re-enabled per Settings preference
-      Context appContext = getApplicationContext();
       Keyboard kbInfo = KMManager.getCurrentKeyboardInfo(appContext);
       if (kbInfo != null) {
         String langId = kbInfo.getLanguageID();

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -180,7 +180,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
       ExtractedText icText = ic.getExtractedText(new ExtractedTextRequest(), 0);
       /*
         We do sometimes receive null `icText.text`, even though
-        getExtractedText() docs does not list this as a possible 
+        getExtractedText() docs does not list this as a possible
         return value, so we test for that as well (#11479)
       */
       if (icText != null && icText.text != null) {
@@ -206,15 +206,6 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   @Override
   public void onUpdateExtractingVisibility(EditorInfo ei) {
     super.onUpdateExtractingVisibility(ei);
-  }
-
-  @Override
-  public void onConfigurationChanged(Configuration newConfig) {
-    super.onConfigurationChanged(newConfig);
-    if (newConfig.orientation != lastOrientation) {
-      lastOrientation = newConfig.orientation;
-      KMManager.onConfigurationChanged(newConfig);
-    }
   }
 
   @Override


### PR DESCRIPTION
Replaces #11484.

Noting [two](https://github.com/keymanapp/keyman/pull/11484#issuecomment-2130521268) [different](https://github.com/keymanapp/keyman/pull/11484#issuecomment-2136533495) comments from #11484, I now suspect the issue is that the _system keyboard_ simply lacked "on resume"-style orientation checking.  After some investigation, I _think_ I've identified the correct place for it.

The new code essentially duplicates the following in-app block for handling orientation changes when the app is restored:

https://github.com/keymanapp/keyman/blob/c8d8e4187aa20f7db7f22c8fa7ccd21a04a2615b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java#L243-L251

While a bit WET, note that a special state variable is needed for tracking.  Both would lie within "app" space, so I suppose I could DRY it out if this approach is in fact the solution.

## User Testing

**TEST_KEYBOARD_REPEATED_RESTORE**
1. Install the PR build of Keyman for Android on an Android device/emulator Android 13 (SDK 33) 
2. Ensure the keyboard may be used as the system keyboard.
3. Pick any application and start editing text via the Keyman system keyboard (without changing orientation).
4. Dismiss the keyboard (by finishing your input and selecting something that doesn't need the keyboard).
5. Change your device's orientation:  if in 'portrait', go to 'landscape' mode and vice-versa.
6. Re-activate the keyboard.
7. Repeat steps 3 through 6 at least five times, verifying that the OSK always displays with the correct width for the device's orientation.

Sadly, just this isn't enough to get a repro with the current state of master for me within Android Studio's emulator.