### PR TITLE
fix(web): Await the async `predictionContext.resetContext()`

### DIFF
--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -197,8 +197,8 @@ export default class ContextManager extends ContextManagerBase<WebviewConfigurat
     return activatingKeyboard;
   }
 
-  public resetContext(): void {
-    super.resetContext();
+  public async resetContext(): Promise<void> {
+    await super.resetContext();
     this._rawContext.saveState();
   }
 }

--- a/web/src/engine/main/src/contextManagerBase.ts
+++ b/web/src/engine/main/src/contextManagerBase.ts
@@ -118,9 +118,9 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
     return false;
   }
 
-  resetContext() {
+  public async resetContext(): Promise<void> {
     this._resetContext(this.activeTarget);
-    this.predictionContext.resetContext();
+    await this.predictionContext.resetContext();
   }
 
   abstract get activeKeyboard(): {keyboard: Keyboard, metadata: KeyboardStub};


### PR DESCRIPTION
This came out of the work for #11593 and might not be directly related, but it looks like it could possibly cause problems. Originally part of #11594 but split into separate PR.

@keymanapp-test-bot skip