### PR TITLE
fix(web): Don't crash if `text` is undefined

### DIFF
--- a/web/src/engine/package-cache/src/stubAndKeyboardCache.ts
+++ b/web/src/engine/package-cache/src/stubAndKeyboardCache.ts
@@ -6,7 +6,7 @@ import KeyboardStub from "./keyboardStub.js";
 const KEYBOARD_PREFIX = "Keyboard_";
 
 function prefixed(text: string) {
-  if(!text.startsWith(KEYBOARD_PREFIX)) {
+  if(text && !text.startsWith(KEYBOARD_PREFIX)) {
     return KEYBOARD_PREFIX + text;
   } else {
     return text;


### PR DESCRIPTION
This can happen during startup if the keyboard stub isn't set yet. It's more a hack than a fix, but at least it prevents the crash.

@keymanapp-test-bot skip