### PR TITLE
chore: increase kmc-kmn build test timeout

### DIFF
--- a/developer/src/kmc-kmn/test/test-compiler.ts
+++ b/developer/src/kmc-kmn/test/test-compiler.ts
@@ -58,6 +58,7 @@ describe('Compiler class', function() {
   // Note, above test case is essentially a subset of this one, but will leave both because
   // the basic keyboard test is slightly simpler to read
   it('should build all baseline fixtures', async function() {
+    this.timeout(10000); // there are quite a few fixtures, sometimes CI agents are slow
     const compiler = new KmnCompiler();
     const callbacks = new TestCompilerCallbacks();
     assert(await compiler.init(callbacks, {saveDebug: true, shouldAddCompilerVersion: false}));


### PR DESCRIPTION
Rarely, CI builds have been timing out building the test fixtures, with the default 2,000msec timeout. Increasing to 10,000msec.

@keymanapp-test-bot skip