### PR TITLE
fix(ios): do not write to shared storage from system keyboard

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -175,6 +175,10 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     keymanWeb = KeymanWebViewController(storage: Storage.active)
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
+    var message = self.hasFullAccess ? "hasFullAccess: true" : "hasFullAccess: false"
+    os_log("%{public}s", log: KeymanEngineLogger.settings, type: .default, message)
+    SentryManager.breadcrumb(message)
+
     addChild(keymanWeb)
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -198,35 +198,37 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
 
     URLProtocol.registerClass(KeymanURLProtocol.self)
 
-    /**
-     * As of 14.0, ResourceFileManager is responsible for handlng resources... including
-     * any necessary "migration" of their internal storage structure & tracked metadata.
-     */
-    ResourceFileManager.shared.runMigrationsIfNeeded()
-
+    if(!Util.isSystemKeyboard) {
+      /**
+       * As of 14.0, ResourceFileManager is responsible for handlng resources... including
+       * any necessary "migration" of their internal storage structure & tracked metadata.
+       */
+      ResourceFileManager.shared.runMigrationsIfNeeded()
+    }
+    
     if Util.isSystemKeyboard || Storage.active.userDefaults.bool(forKey: Key.keyboardPickerDisplayed) {
       isKeymanHelpOn = false
     }
 
-    do {
-      try Storage.active.copyKMWFiles(from: Resources.bundle)
-    } catch {
-      let message = ("Failed to copy KMW files from bundle: \(error)")
-      os_log("%{public}s", log:KeymanEngineLogger.settings, type: .error, message)
-      SentryManager.capture(error, message:message)
-    }
-
-    updateUserKeyboards(with: Defaults.keyboard)
-
-    do {
-      try reachability = Reachability(hostname: KeymanHosts.API_KEYMAN_COM.host!)
-    } catch {
-      let message = ("Could not start Reachability object: \(error)")
-      os_log("%{public}s", log:KeymanEngineLogger.settings, type: .error, message)
-      SentryManager.capture(error, message:message)
-    }
-
     if(!Util.isSystemKeyboard) {
+      do {
+        try Storage.active.copyKMWFiles(from: Resources.bundle)
+      } catch {
+        let message = ("Failed to copy KMW files from bundle: \(error)")
+        os_log("%{public}s", log:KeymanEngineLogger.settings, type: .error, message)
+        SentryManager.capture(error, message:message)
+      }
+      
+      updateUserKeyboards(with: Defaults.keyboard)
+      
+      do {
+        try reachability = Reachability(hostname: KeymanHosts.API_KEYMAN_COM.host!)
+      } catch {
+        let message = ("Could not start Reachability object: \(error)")
+        os_log("%{public}s", log:KeymanEngineLogger.settings, type: .error, message)
+        SentryManager.capture(error, message:message)
+      }
+
       NotificationCenter.default.addObserver(self, selector: #selector(self.reachabilityChanged),
                                            name: .reachabilityChanged, object: reachability)
       do {


### PR DESCRIPTION
During startup of Keyman running from the system keyboard, do not attempt any migrations or keyboard state updates as keyboard extensions are not allowed to modify shared storage:

[Apple's custom keyboard documentation](https://developer.apple.com/documentation/uikit/keyboards_and_input/creating_a_custom_keyboard/configuring_open_access_for_a_custom_keyboard?language=objc):

> Custom keyboards operate in a sandboxed environment running in an isolated process. This sandbox’s default configuration disallows access to the network and prevents writing to the containing app’s shared group containers (reading is permitted). 

Fixes #11602
Fixes KEYMAN-IOS-7E
Fixes KEYMAN-IOS-7D

@keymanapp-test-bot skip
