### PR TITLE
fix(web): pre-init keyboard activation awaits init before proceeding 🍒 🏠

### DIFF
--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -155,6 +155,18 @@ export default class ContextManager extends ContextManagerBase<WebviewConfigurat
   }
 
   public async activateKeyboard(keyboardId: string, languageCode?: string, saveCookie?: boolean): Promise<boolean> {
+    /*
+      this.keyboardCache isn't set until partway through KMW initialization.
+      Also, keyboard stubs aren't processed until initialization is complete,
+      so it's best to wait for initialization anyway.
+    */
+    if(!this.engineConfig.deferForInitialization.isFulfilled) {
+      await this.engineConfig.deferForInitialization.corePromise;
+
+      // Our mobile app-engines all register the stub before attempting to set the keyboard,
+      // so the Promise ordering here should work in our favor.
+    }
+
     // If the default keyboard is requested, load that.  May vary based on form-factor, which is
     // part of what .getFallbackStubKey() handles.
     if(!keyboardId) {


### PR DESCRIPTION
Fixes: #11504
Cherry-pick-of: #11505

@keymanapp-test-bot skip