### PR TITLE
fix(android): handle `IllegalArgumentException` when initializing `CloudDownloadMgr`, add logging to check for unhandled side-effects

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/util/KMLog.java
@@ -42,35 +42,39 @@ public final class KMLog {
    * @param msg String of the info message
    */
   public static void LogBreadcrumb(String tag, String msg, boolean addStackTrace) {
-    if (msg != null && !msg.isEmpty()) {
-      Log.i(tag, msg);
+    if (msg == null || msg.isEmpty()) {
+      return;
+    }
 
-      if (DependencyUtil.libraryExists(LibraryType.SENTRY) && Sentry.isEnabled()) {
-        Breadcrumb crumb = new Breadcrumb();
-        crumb.setMessage(msg);
-        crumb.setLevel(SentryLevel.INFO);
+    Log.i(tag, msg);
 
-        if(addStackTrace) {
-          StackTraceElement[] rawTrace = Thread.currentThread().getStackTrace();
+    if (!DependencyUtil.libraryExists(LibraryType.SENTRY) || !Sentry.isEnabled()) {
+      return;
+    }
 
-          // The call that gets us the stack-trace above... shows up in the
-          // stack trace, so we'll skip the first few (redundant) entries.
-          int skipCount = 3;
+    Breadcrumb crumb = new Breadcrumb();
+    crumb.setMessage(msg);
+    crumb.setLevel(SentryLevel.INFO);
 
-          // Sentry does limit the size of messages... so let's just
-          // keep 10 entries and call it a day.
-          int limit = Math.min(rawTrace.length, 10 + skipCount);
-          if(rawTrace.length > skipCount) {
-            String[] trace = new String[limit - skipCount];
-            for (int i = skipCount; i < limit; i++) {
-              trace[i-skipCount] = rawTrace[i].toString();
-            }
-            crumb.setData("stacktrace", trace);
-          }
+    if(addStackTrace) {
+      StackTraceElement[] rawTrace = Thread.currentThread().getStackTrace();
+
+      // The call that gets us the stack-trace above... shows up in the
+      // stack trace, so we'll skip the first few (redundant) entries.
+      int skipCount = 3;
+
+      // Sentry does limit the size of messages... so let's just
+      // keep 10 entries and call it a day.
+      int limit = Math.min(rawTrace.length, 10 + skipCount);
+      if(rawTrace.length > skipCount) {
+        String[] trace = new String[limit - skipCount];
+        for (int i = skipCount; i < limit; i++) {
+          trace[i-skipCount] = rawTrace[i].toString();
         }
-        Sentry.addBreadcrumb(crumb);
+        crumb.setData("stacktrace", trace);
       }
     }
+    Sentry.addBreadcrumb(crumb);
   }
 
   /**


### PR DESCRIPTION
Replaces #11580.
Addresses #11561.  This change should prevent crashes, but there may be lingering side-effects we want to resolve before closing the issue outright.

This PR does two main things:
1. It ensures we `catch` the _right_ exception type - `IllegalArgumentException` instead of `IllegalStateException` - in our existing error handlers.  This should, at least, prevent a crash.
2. We didn't have manual breadcrumb logging yet within Keyman Engine for Android, so this adds a method to accomplish that.

Toward that latter point, here's how a stack-traced breadcrumb appears in Sentry:

![image](https://github.com/keymanapp/keyman/assets/25213402/696ed2b6-e253-4be4-b8d8-bcc5b3b98ab2)

Here's a link to the Sentry event I temporarily generated in order to expose this: https://keyman.sentry.io/share/issue/0d3661c2239842ff8ba31bed996087ec/

The `stacktrace` entry is initially collapsed, but expands when clicked.  To keep the message-envelope size down, breadcrumb-logging will only include the 10 most recent entries of the stack trace.

@keymanapp-test-bot skip