### PR TITLE
fix(android): include DOMRect polyfill for older ES6-supporting devices

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -7,6 +7,8 @@
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, user-scalable=no">
   <title>Keyman</title>
+  <!-- DOMRect only exists as of Chrome 61... thus coming later than ES6. -->
+  <script src="other-polyfills.js"></script>
   <script src="keymanweb-webview.js"></script>
   <script src="sentry.min.js"></script>
   <script src="keyman-sentry.js"></script>


### PR DESCRIPTION
@keymanapp-test-bot skip