### PR TITLE
chore: replace git dep on restructure with 3.0.1 in npm

### DIFF
--- a/common/web/types/package.json
+++ b/common/web/types/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@keymanapp/ldml-keyboard-constants": "*",
     "@keymanapp/keyman-version": "*",
-    "restructure": "git+https://github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
+    "restructure": "3.0.1",
     "semver": "^7.5.2",
     "xml2js": "git+https://github.com/keymanapp/dependency-node-xml2js#535fe732dc408d697e0f847c944cc45f0baf0829"
   },

--- a/developer/src/kmc-ldml/package.json
+++ b/developer/src/kmc-ldml/package.json
@@ -28,7 +28,6 @@
     "@keymanapp/keyman-version": "*",
     "@keymanapp/kmc-kmn": "*",
     "@keymanapp/ldml-keyboard-constants": "*",
-    "restructure": "git+https://github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
     "semver": "^7.5.2"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -506,7 +506,7 @@
       "dependencies": {
         "@keymanapp/keyman-version": "*",
         "@keymanapp/ldml-keyboard-constants": "*",
-        "restructure": "git+https://github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
+        "restructure": "3.0.1",
         "semver": "^7.5.2",
         "xml2js": "git+https://github.com/keymanapp/dependency-node-xml2js#535fe732dc408d697e0f847c944cc45f0baf0829"
       },
@@ -664,12 +664,6 @@
     "common/web/types/node_modules/ms": {
       "version": "2.1.3",
       "dev": true,
-      "license": "MIT"
-    },
-    "common/web/types/node_modules/restructure": {
-      "version": "3.0.0",
-      "resolved": "git+ssh://git@github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
-      "integrity": "sha512-TxgE+TFgblOfmvJyv9TCzABfDo4nvNHeYD0+awQ5UoE/KhSuENJ1Uhc1rtegx8SbmvI3nqXFaHgnVATNcCOhXw==",
       "license": "MIT"
     },
     "common/web/types/node_modules/supports-color": {
@@ -1772,7 +1766,6 @@
         "@keymanapp/keyman-version": "*",
         "@keymanapp/kmc-kmn": "*",
         "@keymanapp/ldml-keyboard-constants": "*",
-        "restructure": "git+https://github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
         "semver": "^7.5.2"
       },
       "devDependencies": {
@@ -1935,12 +1928,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
-    },
-    "developer/src/kmc-ldml/node_modules/restructure": {
-      "version": "3.0.0",
-      "resolved": "git+ssh://git@github.com/keymanapp/dependency-restructure.git#7a188a1e26f8f36a175d95b67ffece8702363dfc",
-      "integrity": "sha512-TxgE+TFgblOfmvJyv9TCzABfDo4nvNHeYD0+awQ5UoE/KhSuENJ1Uhc1rtegx8SbmvI3nqXFaHgnVATNcCOhXw==",
-      "license": "MIT"
     },
     "developer/src/kmc-ldml/node_modules/supports-color": {
       "version": "5.5.0",
@@ -13068,6 +13055,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.1.tgz",
+      "integrity": "sha512-6neDpI/yE9eogQo22qmWwKIA9wFPRyYjQleDEh6zaNAf2ZPqLJYUvNBJBWEWNoBlCeQMQkvIOe2YI/K2GOag+g=="
     },
     "node_modules/retry": {
       "version": "0.12.0",


### PR DESCRIPTION
3.0.1 includes our fix. However, 3.0.2 does not yet appear to have been published, which has a patch for our fix?

Fixes: #8616

@keymanapp-test-bot skip