### PR TITLE
fix(linux): match digit in package filename

### DIFF
--- a/.github/workflows/api-verification.yml
+++ b/.github/workflows/api-verification.yml
@@ -70,7 +70,7 @@ jobs:
         cd ${{ github.workspace }}/keyman/linux
         ./scripts/deb-packaging.sh \
           --gha \
-          --bin-pkg "${GITHUB_WORKSPACE}/artifacts/${PKG_NAME}*_${{ steps.environment_step.outputs.VERSION }}-1${{ steps.environment_step.outputs.PRERELEASE_TAG }}+$(lsb_release -c -s)1_amd64.deb" \
+          --bin-pkg "${GITHUB_WORKSPACE}/artifacts/${PKG_NAME}[0-9]*_${{ steps.environment_step.outputs.VERSION }}-1${{ steps.environment_step.outputs.PRERELEASE_TAG }}+$(lsb_release -c -s)1_amd64.deb" \
           --git-sha "${{ steps.environment_step.outputs.GIT_SHA }}" \
           --git-base "${{ steps.environment_step.outputs.GIT_BASE }}" \
           verify 2>> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The previous wildcard was too broad and matched on `libkeymancore-dev` which is missing the API version number in the filename. This change requires a digit after the name.

@keymanapp-test-bot skip