### PR TITLE
fix(mac): handle command keys without crashing 🏠 

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -84,14 +84,16 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
 }
 
 - (void)handleCommand:(NSEvent *)event {
-    // There are a bunch of common navigation/selection command-key combinations, but individual
-    // apps may implement specific commands that also change the selection. There is probably no
-    // situation where a user could reasonably hope that any dead-keys typed before using a
-    // command shortcut would be remembered, so other than an insignificant performance penalty,
-    // the only downside to treating all commands as having the potential to change the selection
-    // is that some non-compliant apps can't get their context at all. This can be overridden so that
-    // non-compliant apps can mitigate this problem as appropriate.
-    [self.appDelegate logDebugMessage:@"KMInputMethodEventHandler handleCommand, event type=%@, must refresh context", event.type];
+  /**
+    * There are many common navigation/selection command-key combinations, but individual
+    * apps may implement specific commands that also change the selection. There is probably no
+    * situation where a user could reasonably hope that any dead-keys typed before using a
+    * command shortcut would be remembered, so other than an insignificant performance penalty,
+    * the only downside to treating all commands as having the potential to change the selection
+    * is that some non-compliant apps can't get their context at all. This can be overridden so that
+    * non-compliant apps can mitigate this problem as appropriate.
+    */
+    [self.appDelegate logDebugMessage:@"KMInputMethodEventHandler handleCommand: command key executed, must refresh context"];
     self.contextChanged = YES;
 }
 


### PR DESCRIPTION
When handling command keys, which are passed through after marking the context as stale, a call to logDebugMessage was formatting the event type, which is an integer value, as an object. This caused Keyman to crash for users that had verbose logging enabled.

The event type could safely be written to the logs by formatting it correctly, but it was removed as it was not particularly useful.

Fixes #11673
Fixes KEYMAN-MAC-FC

@keymanapp-test-bot skip