### PR TITLE
fix(common): correctly display result of multiple option parameters in builder

### DIFF
--- a/resources/build/test/test.sh
+++ b/resources/build/test/test.sh
@@ -111,7 +111,9 @@ builder_describe \
   ":engine      Thomas, y'know" \
   "--power,-p   Use powerful mode" \
   "--zoom,-z    Use zoom mode" \
-  "--feature=FOO Enable feature foo"
+  "--feature=FOO Enable feature foo" \
+  "--bar=BAR    Enable bar" \
+  "--baz=BAZ    Enable baz"
 
 #----------------------------------------------------------------------
 # Test --options
@@ -132,21 +134,39 @@ else
   builder_die "FAIL: --zoom option not found"
 fi
 
+function verify_option() {
+  local OPTIONNAME=$1
+  local VARIABLE=$2
+  local EXCPECTED=$3
+
+  if builder_has_option ${OPTIONNAME}; then
+    if [[ ${!VARIABLE} == ${EXCPECTED} ]]; then
+      echo "PASS: ${OPTIONNAME} option variable \$${VARIABLE} has expected value '${EXCPECTED}'"
+    else
+      builder_die "FAIL: ${OPTIONNAME} option variable \$${VARIABLE} had value '${!VARIABLE}' but should have had '${EXCPECTED}'"
+    fi
+  else
+    builder_die "FAIL: ${OPTIONNAME} option not found"
+  fi
+}
+
 #----------------------------------------------------------------------
 # Test --feature <foo>
 
 echo -e "${COLOR_BLUE}## Testing: builder_parse --feature xyzzy${COLOR_RESET}"
 builder_parse --feature xyzzy
 
-if builder_has_option --feature; then
-  if [[ $FOO == xyzzy ]]; then
-    echo "PASS: --feature option variable \$FOO has expected value 'xyzzy'"
-  else
-    builder_die "FAIL: --feature option variable \$FOO had value '$FOO' but should have had 'xyzzy'"
-  fi
-else
-  builder_die "FAIL: --feature option not found"
-fi
+verify_option --feature FOO xyzzy
+
+#----------------------------------------------------------------------
+# Test --feature <foo> --bar <bar> --baz <baz>
+
+echo -e "${COLOR_BLUE}## Testing: builder_parse --feature xyzzy --bar abc --baz def test${COLOR_RESET}"
+builder_parse --feature xyzzy --bar abc --baz def test
+
+verify_option --feature FOO xyzzy
+verify_option --bar BAR abc
+verify_option --baz BAZ def
 
 builder_parse -- one two "three four five"
 if [[ ${builder_extra_params[0]} != "one" ]]; then
@@ -157,6 +177,15 @@ if [[ ${builder_extra_params[1]} != "two" ]]; then
 fi
 if [[ ${builder_extra_params[2]} != "three four five" ]]; then
   builder_die "FAIL: -- extra parameter 'three four five' not found"
+fi
+
+#----------------------------------------------------------------------
+# Test output of: --feature <foo> --bar <bar> --baz <baz> (#11676)
+echo -e "${COLOR_BLUE}## Testing output of: builder_parse --feature xyzzy --bar abc --baz def test${COLOR_RESET}"
+parse_output=$(builder_parse --feature xyzzy --bar abc --baz def test)
+expected="$(builder_echo setmark "test.sh parameters: <--feature xyzzy --bar abc --baz def test>")"
+if [[ "${parse_output[*]}" != "${expected}" ]]; then
+  builder_die "FAIL: Wrong output for '--feature xyzzy --bar abc --baz def test':\n  Actual  : ${parse_output[*]}\n  Expected: ${expected}"
 fi
 
 # Run tests based in separate scripts to facilitate their operation

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1344,6 +1344,7 @@ _builder_parse_expanded_parameters() {
       _builder_chosen_options+=("$key")
       if [[ ! -z ${_builder_options_var[$key]+x} ]]; then
         shift
+        n=$((n + 1))
         # Set the variable associated with this option to the next parameter value
         # A little bit of hoop jumping here to avoid issues with cygwin paths being
         # corrupted too early in the game

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1379,7 +1379,7 @@ _builder_parse_expanded_parameters() {
           shift
           builder_dep_parent="$1"
           builder_echo setmark "dependency build, started by $builder_dep_parent"
-          builder_echo grey "build.sh parameters: <${_params[@]}>"
+          builder_echo grey "$(basename "$0") parameters: <${_params[@]}>"
           ;;
         --builder-child)
           _builder_is_child=0
@@ -1437,9 +1437,9 @@ _builder_parse_expanded_parameters() {
   else
     # This is a top-level invocation, so we want to track which dependencies
     # have been built, so they don't get built multiple times.
-    builder_echo setmark "build.sh parameters: <${_params[@]}>"
+    builder_echo setmark "$(basename "$0") parameters: <${_params[@]}>"
     if [[ ${#builder_extra_params[@]} -gt 0 ]]; then
-      builder_echo grey "build.sh extra parameters: <${builder_extra_params[@]}>"
+      builder_echo grey "$(basename "$0") extra parameters: <${builder_extra_params[@]}>"
     fi
     export _builder_deps_built=`mktemp`
   fi


### PR DESCRIPTION
Previously with the right number of parameters that take values and the right order it could happen that a parameter value got replaced by an action when the script output the parameters. This change fixes this.

Also output the actual script name instead of hard-coded `build.sh`.

Fixes: #11676

@keymanapp-test-bot skip