### PR TITLE
fix(web): revert #11598 to eliminate use of `finalInput` which caused crash after moving caret

### DIFF
--- a/common/web/lm-worker/src/main/model-compositor.ts
+++ b/common/web/lm-worker/src/main/model-compositor.ts
@@ -249,21 +249,11 @@ export default class ModelCompositor {
           // Worth considering:  extend Traversal to allow direct prediction lookups?
           // let traversal = match.finalTraversal;
 
-          // Find a proper Transform ID to map the correction to.
-          // Without it, we can't apply the suggestion.
-          let finalInput: Transform;
-          if(match.inputSequence.length > 0) {
-            // common case:  from the same keystroke `inputTransform`, with matching `.id`.
-            finalInput = match.inputSequence[match.inputSequence.length - 1].sample;
-          } else {
-            finalInput = inputTransform;  // A fallback measure.  Greatly matters for empty contexts.
-          }
-
           // Replace the existing context with the correction.
           let correctionTransform: Transform = {
             insert: correction,  // insert correction string
             deleteLeft: deleteLeft,
-            id: finalInput.id // The correction should always be based on the most recent external transform/transcription ID.
+            id: inputTransform.id // The correction should always be based on the most recent external transform/transcription ID.
           }
 
           let rootCost = match.totalCost;


### PR DESCRIPTION
Fixes: #11684
Fixes: KEYMAN-WEB-KR
Fixes: #11620
Fixes: KEYMAN-WEB-KT

Fortunately, this one's `alpha`-only, as the triggering code landed in #11598.  This PR essentially reverts it and deletes the no-longer-referenced local (`finalInput`) and the code used to initialize it.

As we already know things were working fine in this regard before #11598...
@keymanapp-test-bot skip

At least now there's a far clearer reason to eliminate that section outright.