### PR TITLE
chore(common): move CLDR import copy into build step for common/web/types

### DIFF
--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -89,8 +89,12 @@ function copy_cldr_imports() {
 
 function do_configure() {
   compile_schemas
-  copy_cldr_imports
   verify_npm_setup
+}
+
+function do_build() {
+  copy_cldr_imports
+  tsc --build
 }
 
 function do_test() {
@@ -103,6 +107,6 @@ function do_test() {
 
 builder_run_action clean      rm -rf ./build/ ./tsconfig.tsbuildinfo
 builder_run_action configure  do_configure
-builder_run_action build      tsc --build
+builder_run_action build      do_build
 builder_run_action test       do_test
 builder_run_action publish    builder_publish_npm


### PR DESCRIPTION
The CLDR imports are copied into the build/ folder, so it makes more sense for them to be done during the build phase, particularly as it is a very quick operation. (Before this, removing the build/ folder did not trigger a build.sh configure, so subsequent tests and usage would fail with confusing LDML import errors. An alternative solution would have
been to declare the configure output to be one of these files.)

@keymanapp-test-bot skip