### PR TITLE
fix(web): get row-height for flick constraints after performing layout

### DIFF
--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -270,7 +270,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
   }
 
   get currentLayer(): OSKLayer {
-    return this.layerGroup?.activeLayer;
+    return this.layerGroup.activeLayer;
   }
 
   // Special keys (for the currently-visible layer)
@@ -1280,8 +1280,12 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       return;
     }
 
-    // Step 3: recalculate gesture parameter values
-    // Skip for doc-keyboards, since they don't do gestures.
+    // Phase 3:  Refresh the layout of the layer-group and active layer.
+    this.layerGroup.refreshLayout(this.constructLayoutParams());
+
+    // Step 4: recalculate gesture parameter values
+    // We do this _after_ "Phase 3" so that this.currentLayer.rowHeight is guaranteed
+    // to be set.  Also, skip for doc-keyboards, since they don't do gestures.
     if(!this.isStatic) {
       const paddingZone = this.gestureEngine.config.maxRoamingBounds as PaddedZoneSource;
       paddingZone.updatePadding([-0.333 * this.currentLayer.rowHeight]);
@@ -1305,9 +1309,6 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       this.gestureParams.flick.triggerDist        = 0.75 * this.currentLayer.rowHeight;
       this.gestureParams.longpress.flickDistFinal = 0.75 * this.currentLayer.rowHeight;
     }
-
-    // Phase 4:  Refresh the layout of the layer-group and active layer.
-    this.layerGroup.refreshLayout(this.constructLayoutParams());
   }
 
   private constructLayoutParams(): LayerLayoutParams {

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -270,7 +270,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
   }
 
   get currentLayer(): OSKLayer {
-    return this.layerGroup.activeLayer;
+    return this.layerGroup?.activeLayer;
   }
 
   // Special keys (for the currently-visible layer)


### PR DESCRIPTION
Fixes #11650.

It turns out that the underlying error for the observed flick-breakages is due to the current layer's row-height being `undefined`... because it's initialized immediately _after_ we try to access it, as part of `this.layerGroup.refreshLayout`:

A layer's `rowHeight` field is initialized only here: 

https://github.com/keymanapp/keyman/blob/b63acb156feb71bb5daee19041c53da766f38706/web/src/engine/osk/src/keyboard-layout/oskLayer.ts#L153-L165

It would appear that _most_ of the time, an extra call is triggered; that extra call would have the value initialized by the first call.

While it's extremely hard to reproduce, and I thus lack any specific test instructions to give...

## User Testing

TEST_GESTURES: Use Keyman for Android or Keyman for iOS with the default (EuroLatin) keyboard and verify that gestures work as expected.
