### PR TITLE
fix(developer): disable example edit controls if no examples in Package Editor

### DIFF
--- a/developer/src/tike/child/UfrmPackageEditor.pas
+++ b/developer/src/tike/child/UfrmPackageEditor.pas
@@ -1802,7 +1802,7 @@ begin
   cmdKeyboardRemoveLanguage.Enabled := e;
   cmdKeyboardEditLanguage.Enabled := e;
 
-  e := (lbKeyboards.ItemIndex >= 0) and (gridKeyboardLanguages.Row > 0);
+  e := (lbKeyboards.ItemIndex >= 0) and (gridKeyboardExamples.Row > 0);
   gridKeyboardExamples.Enabled := e;
   cmdKeyboardRemoveExample.Enabled := e;
   cmdKeyboardEditExample.Enabled := e;


### PR DESCRIPTION
Fixes: #11700
Fixes: KEYMAN-DEVELOPER-1FT

@keymanapp-test-bot skip