### PR TITLE
fix(web): fix osk touch-focus tracking

### DIFF
--- a/web/src/engine/osk/src/views/touchEventPromiseMap.ts
+++ b/web/src/engine/osk/src/views/touchEventPromiseMap.ts
@@ -13,10 +13,10 @@ export default class TouchEventPromiseMap {
   }
 
   public maintainTouches(list: TouchList) {
-    let keys = [].concat(this.map.keys());
+    let keys = Array.from(this.map.keys());
 
     for(let i=0; i < list.length; i++) {
-      let pos = keys.indexOf('' + list.item(i).identifier);
+      let pos = keys.indexOf(list.item(i).identifier);
       if(pos != -1) {
         keys.splice(pos, 1);
       }


### PR DESCRIPTION
Fixes: #11704
Fixes: KEYMAN-WEB-HY.  Turns out that the original variant of that issue was resolved with #11505, leaving only the current form in place.  (Note:  is not currently commit-tagged; I realized this later.)

The offending code attained its current form in #11462, wherein I converted this class from using a `Record<,>`  Object-based "map" to an actual ES6 `Map`.  

Before: `Object.keys()`.
After: `map.keys()`.

`Object.keys()` actually _does_ return an array, while `map.keys()` does not.  Fortunately, this means that the bug this fixes should only occur for 18.0-alpha.

## User Testing

TEST_ATTEMPT_REPRO:  Using Keyman for Android, attempt to reproduce #11704:

1. Installed this PR's APK file and give all permissions to the application.
2. Check the "Enable Keyman as system-wide keyboard" and set the keyboard as the default keyboard box on the settings page.
3. Open the Keyman app.
4. Press the "123" button.
5. Press the "ELY(Shift) button.
6. Press the "?i-"(Shift) button and move to the right side.
7. Verify that no error-toast / error-notification appears.