### PR TITLE
chore(developer): add extra logging for assertion failure when pressing backspace in debugger

### DIFF
--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -705,11 +705,21 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
     UpdateDeadkeys;
   end;
 
-  procedure DoBackspace(BackspaceType: km_core_backspace_type);
+  procedure DoBackspace(BackspaceType: km_core_backspace_type; ExpectedValue: NativeUInt);
   var
     m, n: Integer;
     dk: TDeadKeyInfo;
     state: TMemoSelectionState;
+
+    function AssertionMessage: string;
+    begin
+      Result := 'Assertion failed. Extra data: '+
+      'BackspaceType='+IntToStr(Ord(BackspaceType))+'; '+
+      'ExpectedValue=U+'+IntToHex(ExpectedValue, 4)+'; '+
+      'memo.SelStart='+IntToStr(memo.SelStart)+'; '+
+      'memo.SelLength='+IntToStr(memo.SelLength)+'; '+
+      'memo.Text='+Copy(memo.Text, 1, 256);
+    end;
   begin
     // Offset is zero-based, but string is 1-based. Beware!
     state := SaveMemoSelectionState;
@@ -721,7 +731,7 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
       // If the memo has a selection, we have given Core an empty context,
       // which forces it to emit a KM_CORE_BT_UNKNOWN backspace, which is
       // exactly what we want here. We just delete the selection
-      Assert(BackspaceType = KM_CORE_BT_UNKNOWN);
+      Assert(BackspaceType = KM_CORE_BT_UNKNOWN, AssertionMessage);
       memo.SelText := '';
       RealignMemoSelectionState(state);
       Exit;
@@ -730,8 +740,8 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
     case BackspaceType of
       KM_CORE_BT_MARKER:
         begin
-          Assert(m >= 1);
-          Assert(memo.Text[m] = #$FFFC);
+          Assert(m >= 1, AssertionMessage);
+          Assert(memo.Text[m] = #$FFFC, AssertionMessage);
           dk := FDeadkeys.GetFromPosition(m-1);
           Assert(Assigned(dk));
           dk.Delete;
@@ -739,8 +749,8 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
         end;
       KM_CORE_BT_CHAR:
         begin
-          Assert(m >= 1);
-          Assert(memo.Text[m] <> #$FFFC);
+          Assert(m >= 1, AssertionMessage);
+          Assert(memo.Text[m] <> #$FFFC, AssertionMessage);
           // Delete surrogate pairs
           if (m > 1) and
               Uni_IsSurrogate2(memo.Text[m]) and
@@ -759,7 +769,7 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
           while (m >= 1) and (memo.Text[m] = #$FFFC) do
           begin
             dk := FDeadkeys.GetFromPosition(m-1);
-            Assert(Assigned(dk));
+            Assert(Assigned(dk), AssertionMessage);
             dk.Delete;
             Dec(m);
           end;
@@ -776,13 +786,13 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
           while (m >= 1) and (memo.Text[m] = #$FFFC) do
           begin
             dk := FDeadkeys.GetFromPosition(m-1);
-            Assert(Assigned(dk));
+            Assert(Assigned(dk), AssertionMessage);
             dk.Delete;
             Dec(m);
           end;
         end;
     else
-      Assert(False, 'Unrecognised backspace type');
+      Assert(False, AssertionMessage); // Unrecognised backspace type
     end;
 
     memo.Text := Copy(memo.Text, 1, m) + Copy(memo.Text, n+1, MaxInt);
@@ -904,7 +914,7 @@ begin
       KM_CORE_IT_CHAR:           DoChar(Text);
       KM_CORE_IT_MARKER:         DoDeadkey(dwData);
       KM_CORE_IT_ALERT:          DoBell;
-      KM_CORE_IT_BACK:           DoBackspace(km_core_backspace_type(dwData));
+      KM_CORE_IT_BACK:           DoBackspace(km_core_backspace_type(dwData), nExpectedValue);
       KM_CORE_IT_PERSIST_OPT: ; //TODO
       KM_CORE_IT_CAPSLOCK:    ; //TODO
       KM_CORE_IT_INVALIDATE_CONTEXT: ; // no-op

--- a/developer/src/tike/debug/Keyman.System.Debug.DebugEvent.pas
+++ b/developer/src/tike/debug/Keyman.System.Debug.DebugEvent.pas
@@ -33,6 +33,7 @@ type
   TDebugEventActionData = class
     ActionType: km_core_action_type;
     dwData: Integer;
+    nExpectedValue: NativeUInt;
     Text: WideString;
   end;
 
@@ -198,6 +199,7 @@ begin
   event.EventType := etAction;
   event.Action.ActionType := KM_CORE_IT_BACK;
   event.Action.dwData := expected_type;
+  event.Action.nExpectedValue := expected_value;
   Add(event);
 end;
 


### PR DESCRIPTION
I have not been able to reproduce this problem, so adding some extra debug logs in an attempt to determine what is causing the assertion failure.

Relates to: #11706

@keymanapp-test-bot skip