### PR TITLE
fix(developer): handle encoding errors when loading wordlists

### DIFF
--- a/developer/src/tike/child/Keyman.Developer.UI.UframeWordlistEditor.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.UframeWordlistEditor.pas
@@ -186,7 +186,15 @@ function TframeWordlistEditor.DoOpenFile: Boolean;
 begin
   if FileExists(FileName) then
   begin
-    FWordlist.LoadFromFile(FileName);
+    try
+      FWordlist.LoadFromFile(FileName);
+    except
+      on E:EEncodingError do
+      begin
+        ShowMessage('Error loading '+FileName+': '+E.Message);
+        Exit(False);
+      end;
+    end;
     FModified := False;
   end;
   UpdateData;


### PR DESCRIPTION
@keymanapp-test-bot skip

Fixes: #11710
Fixes: KEYMAN-DEVELOPER-1S4