### PR TITLE
fix(web): defer keyboard activation requests made during engine initialization

### DIFF
--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -489,6 +489,12 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
     saveCookie ||= false;
     const originalKeyboardTarget = this.currentKeyboardSrcTarget();
 
+    // If someone tries to activate a keyboard before we've had a chance to load it,
+    // we should defer the activation, just as we'd have deferred the load attempt.
+    if(!this.engineConfig.deferForInitialization.isFulfilled) {
+      await this.engineConfig.deferForInitialization.corePromise;
+    }
+
     // Must do here b/c of fallback behavior stuff defined below.
     // If the default keyboard is requested, load that.  May vary based on form-factor, which is
     // part of what .getFallbackStubKey() handles.


### PR DESCRIPTION
This PR implements the changes that have already been made by #11505, but this time within the app/browser variant of the Web engine.  Those fixes successfully stopped related errors we'd been seeing within the app/webview variant, and there's little reason not to include the fix for app/browser.

We don't currently have any matching error reports yet for stable, but that may just mean we haven't received any _yet_.

@keymanapp-test-bot skip