### PR TITLE
fix(developer): handle missing OSK when importing a Windows keyboard into a touch-only project 🍒 🏠

### DIFF
--- a/developer/src/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
@@ -80,7 +80,7 @@ uses
   BCP47Tag,
   Keyman.Developer.System.ImportKeyboardDLL,
   Keyman.Developer.System.GenerateKeyboardIcon,
-  Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter,
+  Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter,
   Keyman.System.KeyboardUtils,
   KeymanVersion,
   KeyboardParser,
@@ -383,11 +383,11 @@ end;
 
 function TImportWindowsKeyboard.ConvertOSKToTouchLayout(const OSKFilename, TouchLayoutFilename: string): Boolean;
 var
-  converter: TTouchLayoutToVisualKeyboardConverter;
+  converter: TVisualKeyboardToTouchLayoutConverter;
   FNewLayout: string;
   ss: TStringStream;
 begin
-  converter := TTouchLayoutToVisualKeyboardConverter.Create(OSKFilename);
+  converter := TVisualKeyboardToTouchLayoutConverter.Create(OSKFilename);
   try
     if converter.Execute(FNewLayout) then
     begin

--- a/developer/src/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
@@ -86,6 +86,7 @@ uses
   KeyboardParser,
   kmxfileconsts,
   RegistryKeys,
+  TempFileManager,
   utilfiletypes;
 
 { TImportWindowsKeyboard }
@@ -206,6 +207,8 @@ end;
 function TImportWindowsKeyboard.Execute: Boolean;
 var
   FTemplate: TKeyboardProjectTemplate;
+  DestinationOSKTempFile: TTempFile;
+  DestinationOSKFilename: string;
 begin
   if not ForceDirectories(FDestinationPath) then
     Exit(Fail('The destination path '+FDestinationPath+' could not be created.'));
@@ -216,6 +219,7 @@ begin
 
   // Create a new folder in destination path
 
+  DestinationOSKTempFile := nil;
   FTemplate := TKeyboardProjectTemplate.Create(FDestinationPath, Format(FKeyboardIDTemplate, [FBaseKeyboardID]), FTargets);
   try
     //
@@ -251,27 +255,43 @@ begin
 
     FProjectFilename := FTemplate.ProjectFilename;
 
+    if FTemplate.OSKFilename = '' then
+    begin
+      // We need an OSK file in order to generate the touch layout. OSKFilename
+      // will be empty if the user selects a touch-only target. So we'll use a
+      // temp file in this scenario.
+      DestinationOSKTempFile := TTempFileManager.Get(Ext_VisualKeyboardSource);
+      DestinationOSKFilename := DestinationOSKTempFile.Name;
+    end
+    else
+      DestinationOSKFilename := FTemplate.OSKFilename;
+
+
     // Run importkeyboard into destination file; this replaces the keyboard template
     // file that has been generated
-    if not ImportKeyboard(FTemplate.KeyboardFilename, FTemplate.OSKFilename) then
+    if not ImportKeyboard(FTemplate.KeyboardFilename, DestinationOSKFilename) then
       Exit(Fail('Unable to run importkeyboard on '+FSourceKLID));
 
     // Replace .ico with a new one based on the language id
     // TODO: this goes in the keyboard project template generation I think
-    if not GenerateIcon(FTemplate.IconFilename) then
-      Exit(Fail('Unable to generate an icon for '+FTemplate.KeyboardFilename));
+    if FTemplate.IconFilename <> '' then
+      if not GenerateIcon(FTemplate.IconFilename) then
+        Exit(Fail('Unable to generate an icon for '+FTemplate.KeyboardFilename));
 
     // Load the source .kmn and add bitmap, copyright, visualkeyboard, touch layout fields
+    // note, we use FTemplate.OSKFilename here deliberately, because we only
+    // generate OSK-related fields if they are in use
     InjectSystemStores(FTemplate.KeyboardFilename, FTemplate.OSKFilename, FTemplate.IconFilename, FTemplate.TouchLayoutFilename);
 
     if FTemplate.TouchLayoutFilename <> '' then
     begin
       // Take the generated OSK and convert it into a default touch layout
-      if not ConvertOSKToTouchLayout(FTemplate.OSKFilename, FTemplate.TouchLayoutFilename) then
+      if not ConvertOSKToTouchLayout(DestinationOSKFilename, FTemplate.TouchLayoutFilename) then
         Exit(Fail('Unable to create a default touch layout based on the OSK for '+FTemplate.KeyboardFilename));
     end;
   finally
     FreeAndNil(FTemplate);
+    FreeAndNil(DestinationOSKTempFile);
   end;
 
   Result := True;
@@ -302,8 +322,10 @@ begin
   try
     kp.FileName := KeyboardFilename;
     kp.LoadFromFile(KeyboardFilename);
-    kp.Features.Add(kfIcon);
-    kp.Features.Add(kfOSK);
+    if IconFilename <> '' then
+      kp.Features.Add(kfIcon);
+    if OSKFilename <> '' then
+      kp.Features.Add(kfOSK);
     if (TouchKeymanTargets+[ktAny]) * FTargets <> [] then
       kp.Features.Add(kfTouchLayout);
     // TODO: Are these file settings actually doing anything? Or is it controlled
@@ -311,8 +333,10 @@ begin
     // if we change filenames for any reason in the future
     kp.SetSystemStoreValue(ssName, Format(FNameTemplate, [FBaseName]));
     kp.SetSystemStoreValue(ssVersion, SKeymanKeyboardVersion);
-    kp.SetSystemStoreValue(ssVisualKeyboard, ExtractFileName(OSKFilename));
-    kp.SetSystemStoreValue(ssBitmap, ExtractFilename(IconFilename));
+    if OSKFilename <> '' then
+      kp.SetSystemStoreValue(ssVisualKeyboard, ExtractFileName(OSKFilename));
+    if IconFilename <> '' then
+      kp.SetSystemStoreValue(ssBitmap, ExtractFilename(IconFilename));
     kp.SetSystemStoreValue(ssLayoutFile, ExtractFileName(TouchLayoutFilename));
     kp.SetSystemStoreValue(ssTargets, KeymanTargetsToString(FTargets));
     kp.SetSystemStoreValue(ssCopyright, FCopyright);

--- a/developer/src/kmconvert/Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter.pas
@@ -1,4 +1,4 @@
-unit Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter;
+unit Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter;
 
 interface
 
@@ -8,7 +8,7 @@ uses
   VisualKeyboard;
 
 type
-  TTouchLayoutToVisualKeyboardConverter = class
+  TVisualKeyboardToTouchLayoutConverter = class
   private
     FOwnsVisualKeyboard: Boolean;
     FVisualKeyboard: TVisualKeyboard;
@@ -34,7 +34,7 @@ uses
   Unicode,
   VKeys;
 
-constructor TTouchLayoutToVisualKeyboardConverter.Create(
+constructor TVisualKeyboardToTouchLayoutConverter.Create(
   const AFileName: string);
 begin
   inherited Create;
@@ -43,7 +43,7 @@ begin
   FVisualKeyboard.LoadFromFile(AFileName);
 end;
 
-constructor TTouchLayoutToVisualKeyboardConverter.Create(
+constructor TVisualKeyboardToTouchLayoutConverter.Create(
   AVisualKeyboard: TVisualKeyboard);
 begin
   inherited Create;
@@ -51,7 +51,7 @@ begin
   FVisualKeyboard := AVisualKeyboard;
 end;
 
-constructor TTouchLayoutToVisualKeyboardConverter.Create(
+constructor TVisualKeyboardToTouchLayoutConverter.Create(
   const AStream: TStream);
 begin
   inherited Create;
@@ -60,21 +60,21 @@ begin
   FVisualKeyboard.LoadFromStream(AStream);
 end;
 
-destructor TTouchLayoutToVisualKeyboardConverter.Destroy;
+destructor TVisualKeyboardToTouchLayoutConverter.Destroy;
 begin
   if FOwnsVisualKeyboard then
     FreeAndNil(FVisualKeyboard);
   inherited Destroy;
 end;
 
-function TTouchLayoutToVisualKeyboardConverter.Execute(
+function TVisualKeyboardToTouchLayoutConverter.Execute(
   var KeymanTouchLayout: string): Boolean;
 begin
   KeymanTouchLayout := ImportFromKVK;
   Result := KeymanTouchLayout <> '';
 end;
 
-function TTouchLayoutToVisualKeyboardConverter.ImportFromKVK: string;
+function TVisualKeyboardToTouchLayoutConverter.ImportFromKVK: string;
 type
   TKeyData = record
     Data: TOnScreenKeyboardKeyData;
@@ -296,7 +296,7 @@ end;
  * each layer on each given platform. Will rewrite the K_LCONTROL key
  * or remove it if there are no extended layers.
  *}
-function TTouchLayoutToVisualKeyboardConverter.SetupModifierKeysForImportedLayout(TouchLayout: string): string;
+function TVisualKeyboardToTouchLayoutConverter.SetupModifierKeysForImportedLayout(TouchLayout: string): string;
   procedure SetupModifierKeysForPlatform(p: TTouchLayoutPlatform);
   var
     l, l2: TTouchLayoutLayer;

--- a/developer/src/kmconvert/kmconvert.dpr
+++ b/developer/src/kmconvert/kmconvert.dpr
@@ -68,7 +68,7 @@ uses
   Keyman.Developer.System.KMConvertParameters in 'Keyman.Developer.System.KMConvertParameters.pas',
   Keyman.Developer.System.ImportKeyboardDLL in 'Keyman.Developer.System.ImportKeyboardDLL.pas',
   ScanCodeMap in '..\..\..\common\windows\delphi\general\ScanCodeMap.pas',
-  Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter in 'Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter.pas',
+  Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter in 'Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter.pas',
   OnScreenKeyboardData in '..\..\..\common\windows\delphi\visualkeyboard\OnScreenKeyboardData.pas',
   TouchLayout in '..\TIKE\oskbuilder\TouchLayout.pas',
   TouchLayoutDefinitions in '..\TIKE\oskbuilder\TouchLayoutDefinitions.pas',

--- a/developer/src/kmconvert/kmconvert.dproj
+++ b/developer/src/kmconvert/kmconvert.dproj
@@ -174,7 +174,7 @@
         <DCCReference Include="Keyman.Developer.System.KMConvertParameters.pas"/>
         <DCCReference Include="Keyman.Developer.System.ImportKeyboardDLL.pas"/>
         <DCCReference Include="..\..\..\common\windows\delphi\general\ScanCodeMap.pas"/>
-        <DCCReference Include="Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter.pas"/>
+        <DCCReference Include="Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter.pas"/>
         <DCCReference Include="..\..\..\common\windows\delphi\visualkeyboard\OnScreenKeyboardData.pas"/>
         <DCCReference Include="..\TIKE\oskbuilder\TouchLayout.pas"/>
         <DCCReference Include="..\TIKE\oskbuilder\TouchLayoutDefinitions.pas"/>

--- a/developer/src/tike/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/developer/src/tike/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -140,7 +140,7 @@ uses
   xmldoc,
 
   Keyman.Developer.System.HelpTopics,
-  Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter,
+  Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter,
 
   CharacterDragObject,
   CharMapDropTool,
@@ -246,7 +246,7 @@ end;
 
 procedure TframeTouchLayoutBuilder.ImportFromKVK(const KVKFileName: string);   // I3945
 var
-  converter: TTouchLayoutToVisualKeyboardConverter;
+  converter: TVisualKeyboardToTouchLayoutConverter;
   FVK: TVisualKeyboard;
   FJS: string;
 begin
@@ -268,7 +268,7 @@ begin
       end;
     end;
 
-    converter := TTouchLayoutToVisualKeyboardConverter.Create(FVK);
+    converter := TVisualKeyboardToTouchLayoutConverter.Create(FVK);
     try
       if not converter.Execute(FJS) then
       begin

--- a/developer/src/tike/tike.dpr
+++ b/developer/src/tike/tike.dpr
@@ -225,7 +225,7 @@ uses
   Keyman.System.HttpServer.Base in '..\..\..\common\windows\delphi\web\Keyman.System.HttpServer.Base.pas',
   Keyman.Developer.System.HttpServer.AppSource in 'http\Keyman.Developer.System.HttpServer.AppSource.pas',
   Keyman.UI.FontUtils in 'main\Keyman.UI.FontUtils.pas',
-  Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter in '..\kmconvert\Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter.pas',
+  Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter in '..\kmconvert\Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter.pas',
   Keyman.Developer.System.Project.kmnProjectFileAction in 'project\Keyman.Developer.System.Project.kmnProjectFileAction.pas',
   Keyman.Developer.System.Project.kpsProjectFileAction in 'project\Keyman.Developer.System.Project.kpsProjectFileAction.pas',
   Keyman.Developer.UI.Project.UfrmNewProjectParameters in 'project\Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas' {frmNewProjectParameters},

--- a/developer/src/tike/tike.dproj
+++ b/developer/src/tike/tike.dproj
@@ -468,7 +468,7 @@
         <DCCReference Include="..\..\..\common\windows\delphi\web\Keyman.System.HttpServer.Base.pas"/>
         <DCCReference Include="http\Keyman.Developer.System.HttpServer.AppSource.pas"/>
         <DCCReference Include="main\Keyman.UI.FontUtils.pas"/>
-        <DCCReference Include="..\kmconvert\Keyman.Developer.System.TouchLayoutToVisualKeyboardConverter.pas"/>
+        <DCCReference Include="..\kmconvert\Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter.pas"/>
         <DCCReference Include="project\Keyman.Developer.System.Project.kmnProjectFileAction.pas"/>
         <DCCReference Include="project\Keyman.Developer.System.Project.kpsProjectFileAction.pas"/>
         <DCCReference Include="project\Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas">


### PR DESCRIPTION
Also, renames `TouchLayoutToVisualKeyboardConverter` to `VisualKeyboardToTouchLayoutConverter`.

Cherry-pick-of: #11720
Fixes: KEYMAN-DEVELOPER-1NN
Fixes: #11719

@keymanapp-test-bot skip