### PR TITLE
fix(android): fix keyboard size after rotation and restore via onSizeChanged, after layout

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -129,7 +129,7 @@ function setOskHeight(h) {
 
 function setOskWidth(w) {
   if(w > 0) {
-    oskWidth = w;
+    oskWidth = w / window.devicePixelRatio;
   }
 }
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -195,13 +195,13 @@ final class KMKeyboard extends WebView {
     int selMin = icText.selectionStart, selMax = icText.selectionEnd;
 
     int textLength = rawText.length();
-    
+
     if (selMin < 0 || selMax < 0) {
       // There is no selection or cursor
       // Reference https://developer.android.com/reference/android/text/Selection#getSelectionEnd(java.lang.CharSequence)
       return false;
     } else if (selMin > textLength || selMax > textLength) {
-      // Selection is past end of existing text -- should not be possible but we 
+      // Selection is past end of existing text -- should not be possible but we
       // are seeing it happen; #11506
       return false;
     }
@@ -231,7 +231,7 @@ final class KMKeyboard extends WebView {
     selMin -= pairsAtStart;
     selMax -= (pairsAtStart + pairsSelected);
     this.loadJavascript(KMString.format("updateKMSelectionRange(%d,%d)", selMin, selMax));
-  
+
     return true;
   }
 
@@ -262,7 +262,7 @@ final class KMKeyboard extends WebView {
     // When `.isTestMode() == true`, the setWebContentsDebuggingEnabled method is not available
     // and thus will trigger unit-test failures.
     if (!KMManager.isTestMode() && (
-      (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0 || 
+      (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0 ||
       KMManager.getTier(null) != KMManager.Tier.STABLE
     )) {
       // Enable debugging of WebView via adb. Not used during unit tests
@@ -443,26 +443,42 @@ final class KMKeyboard extends WebView {
     dismissHelpBubble();
   }
 
+  @Override
   public void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
 
     RelativeLayout.LayoutParams params = KMManager.getKeyboardLayoutParams();
+    // I suspect this is the part we should actually be calling directly...
     this.setLayoutParams(params);
-
-    int bannerHeight = KMManager.getBannerHeight(context);
-    int oskHeight = KMManager.getKeyboardHeight(context);
-    if (this.htmlBannerString != null && !this.htmlBannerString.isEmpty()) {
-      setHTMLBanner(this.htmlBannerString);
-    }
-    loadJavascript(KMString.format("setBannerHeight(%d)", bannerHeight));
-    loadJavascript(KMString.format("setOskWidth(%d)", newConfig.screenWidthDp));
-    loadJavascript(KMString.format("setOskHeight(%d)", oskHeight));
+    this.invalidate();
+    this.requestLayout();
 
     this.dismissHelpBubble();
 
     if(this.getShouldShowHelpBubble()) {
       this.showHelpBubbleAfterDelay(2000);
     }
+  }
+
+  @Override
+  public void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
+    super.onSizeChanged(width, height, oldWidth, oldHeight);
+    int bannerHeight = KMManager.getBannerHeight(context);
+    int oskHeight = KMManager.getKeyboardHeight(context);
+
+    if(bannerHeight + oskHeight != height) {
+      // We'll proceed, but cautiously and with logging.
+      KMLog.LogInfo(TAG, "Height mismatch: onSizeChanged = " + height + ", our version = " + (bannerHeight + oskHeight));
+    }
+
+    if (this.htmlBannerString != null && !this.htmlBannerString.isEmpty()) {
+      setHTMLBanner(this.htmlBannerString);
+    }
+
+    loadJavascript(KMString.format("setBannerHeight(%d)", bannerHeight));
+    loadJavascript(KMString.format("setOskWidth(%d)", width));
+    // Must be last - it's the one that triggers a Web-engine layout refresh.
+    loadJavascript(KMString.format("setOskHeight(%d)", oskHeight));
   }
 
   public void dismissSuggestionMenuWindow() {


### PR DESCRIPTION
Fixes: #10054

This aims to fix the size and orientation issues we've been seeing for our touch-keyboards on Android.

Note that this PR _adds_ to the adjustments made by ##11604.  That does appear to properly ensure the correct "outer size" of the keyboard - that of the hosting WebView.  The remaining issues appear to lie within the keyboard host-page inside of the WebView.

In order to properly handle this, ensuring proper layout for our WebView-internal keyboard, we split management of WebView's layout operations from the JS calls used to set the WebView-internal layout, the latter of which are based on the final size of the hosting WebView.  To do so, we relocate the latter set of calls to `onSizeChanged`, overriding a superclass method that ought be triggered after `onConfigurationChanged` and its layout-update.

## User Testing 

**TEST_KEYBOARD_REPEATED_RESTORE**
1. Install the PR build of Keyman for Android on an Android device/emulator Android 13 (SDK 33) 
2. Ensure the keyboard may be used as the system keyboard.
3. Pick any application and start editing text via the Keyman system keyboard (without changing orientation).
4. Dismiss the keyboard (by finishing your input and selecting something that doesn't need the keyboard).
5. Change your device's orientation:  if in 'portrait', go to 'landscape' mode and vice-versa.
6. Re-activate the keyboard.
7. Repeat steps 3 through 6 at least five times, verifying that the OSK always displays with the correct width for the device's orientation.

**TEST_GENERAL_USE**: Test the system keyboard in general use, tossing in a few orientation changes from time to time.  Verify that the keyboard always displays correctly for the current orientation.