### PR TITLE
fix(developer): prevent two touch layout editors opening for the same file 🍒 🏠

### DIFF
--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -1477,8 +1477,12 @@ begin
   if n >= 0 then
     Result.ProjectFile := FGlobalProject.Files[n];
 
-  (Result as frmClass).OpenFile(FFileName);
   LockWindowUpdate(0);
+
+  if not (Result as frmClass).OpenFile(FFileName) then
+  begin
+    Result.Release;
+  end;
 end;
 
 procedure TfrmKeymanDeveloper.HelpTopic(s: string);


### PR DESCRIPTION
The keyboard editor has a complex edit state machine, which has grown a lot over time. This is a minimal patch to address one specific edge case scenario on that state machine, without any attempt to improve the state machine overall. The biggest change here is bubbling failure up to the main form so that it can destroy (aka Release, which is an asynchronous destroy) the editor window if it fails to load completely.

@keymanapp-test-bot skip

Cherry-pick-of: #11717
Fixes: #11715
Fixes: KEYMAN-DEVELOPER-1JC