### PR TITLE
fix(mac): change build configuration to prevent cycle error in Xcode 15 🍒 🏠 

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -112,13 +112,13 @@
 		};
 		E211CCF420B5FE7A00505C36 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			dstPath = "";
 			dstSubfolderSpec = 16;
 			files = (
 				E211CCF620B600A500505C36 /* KeymanEngine4Mac.framework.dSYM in CopyFiles */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 		};
 		E27BA9CF202036BA00D273E7 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;


### PR DESCRIPTION
Cherry-pick of #11730 

For the Keyman Input Method (Keyman target -> Build Phases) task 'Copy Files' to copy the Keyman Engine dsym file to the Products directory, change the project setting runOnlyForDeploymentPostprocessing=1. (In Xcode this corresponds to the 'Copy only when installing' checkbox.)

It is unclear why this was needed in Xcode 15 and not earlier versions, but with this change, the cycle error stopped occurring, and the application built successfully.


Fixes: #11726

@keymanapp-test-bot skip