### PR TITLE
fix(web): add limited Array.from polyfill for lm-worker use

### DIFF
--- a/common/models/wordbreakers/src/default/index.ts
+++ b/common/models/wordbreakers/src/default/index.ts
@@ -274,7 +274,7 @@ export class BreakerContext {
  * @param chunk a chunk of text. Starts and ends at word boundaries.
  */
 function isNonSpace(chunk: string, options?: DefaultWordBreakerOptions): boolean {
-  return !Array.from(chunk).map((char) => property(char, options)).every(wb => (
+  return !chunk.split('').map((char) => property(char, options)).every(wb => (
     wb === WordBreakProperty.CR ||
     wb === WordBreakProperty.LF ||
     wb === WordBreakProperty.Newline ||

--- a/common/web/lm-worker/build-polyfiller.js
+++ b/common/web/lm-worker/build-polyfiller.js
@@ -144,6 +144,9 @@ let sourceFileSet = [
   // Needed for Android / Chromium browser pre-41.
   loadPolyfill('../../../node_modules/string.prototype.codepointat/codepointat.js', 'src/polyfills/string.codepointat.js'),
   // Needed for Android / Chromium browser pre-45.
+  // Not used in this codebase, but used by some compiled model defaults.
+  loadPolyfill('src/polyfills/array.from.js', 'src/polyfills/array.from.js'),
+  // Needed for Android / Chromium browser pre-45.
   loadPolyfill('src/polyfills/array.fill.js', 'src/polyfills/array.fill.js'),
   // Needed for Android / Chromium browser pre-45.
   loadPolyfill('src/polyfills/array.findIndex.js', 'src/polyfills/array.findIndex.js'),

--- a/common/web/lm-worker/src/polyfills/array.from.js
+++ b/common/web/lm-worker/src/polyfills/array.from.js
@@ -1,47 +1,50 @@
-if(!Array.from) {
-  function isHighSurrogate(codeUnit) {
-    if(typeof codeUnit == 'string') {
-      codeUnit = codeUnit.charCodeAt(0);
-    }
-
-    return codeUnit >= 0xD800 && codeUnit <= 0xDBFF;
-  }
-
-  function isLowSurrogate(codeUnit) {
-    if(typeof codeUnit == 'string') {
-      codeUnit = codeUnit.charCodeAt(0);
-    }
-
-    return codeUnit >= 0xDC00 && codeUnit <= 0xDFFF;
-  }
-
-  Array.from = function (obj) {
-    if(Array.isArray(obj)) {
-      // Simple array clone
-      return obj.slice();
-    } else if(typeof obj == 'string') {
-      // Array.from is surrogate-aware and will not split surrogate pairs.
-      // We can start with a full split and then remerge the pairs.
-      var simpleSplit = obj.split();
-
-      /** @type {string[]} */
-      var finalSplit = [];
-      /** @type {number} */
-      var i;
-
-      for(i=0; i < simpleSplit.length; i++) {
-        // Do we have a surrogate pair?
-        var a = simpleSplit.shift();
-        if(isHighSurrogate(a) && isLowSurrogate(simpleShift[0] || '')) {
-          // yes, so merge them before pushing.
-          a = a + simpleSplit.shift();
-        } // else:  'no', so just push the current char to the array and continue
-
-        finalSplit.push(a);
+(function() {
+  if(!Array.from) {
+    function isHighSurrogate(codeUnit) {
+      if(typeof codeUnit == 'string') {
+        codeUnit = codeUnit.charCodeAt(0);
       }
-      return finalSplit;
-    } else {
-      throw "Unexpected + nonpolyfilled use of Array.from encountered; aborting";
+
+      return codeUnit >= 0xD800 && codeUnit <= 0xDBFF;
+    }
+
+    function isLowSurrogate(codeUnit) {
+      if(typeof codeUnit == 'string') {
+        codeUnit = codeUnit.charCodeAt(0);
+      }
+
+      return codeUnit >= 0xDC00 && codeUnit <= 0xDFFF;
+    }
+
+    Array.from = function (obj) {
+      if(Array.isArray(obj)) {
+        // Simple array clone
+        return obj.slice();
+      } else if(typeof obj == 'string') {
+        // Array.from is surrogate-aware and will not split surrogate pairs.
+        // We can start with a full split and then remerge the pairs.
+        var simpleSplit = obj.split('');
+
+        /** @type {string[]} */
+        var finalSplit = [];
+        /** @type {number} */
+        var i;
+
+        while(simpleSplit.length > 0) {
+          // Do we have a surrogate pair?
+          var a = simpleSplit.shift();
+          if(isHighSurrogate(a) && (isLowSurrogate(simpleSplit[0] || ''))) {
+            // yes, so merge them before pushing.
+            a = a + simpleSplit.shift();
+            console.log(a);
+          } // else:  'no', so just push the current char to the array and continue
+
+          finalSplit.push(a);
+        }
+        return finalSplit;
+      } else {
+        throw "Unexpected + nonpolyfilled use of Array.from encountered; aborting";
+      }
     }
   }
-}
+}());

--- a/common/web/lm-worker/src/polyfills/array.from.js
+++ b/common/web/lm-worker/src/polyfills/array.from.js
@@ -1,0 +1,47 @@
+if(!Array.from) {
+  function isHighSurrogate(codeUnit) {
+    if(typeof codeUnit == 'string') {
+      codeUnit = codeUnit.charCodeAt(0);
+    }
+
+    return codeUnit >= 0xD800 && codeUnit <= 0xDBFF;
+  }
+
+  function isLowSurrogate(codeUnit) {
+    if(typeof codeUnit == 'string') {
+      codeUnit = codeUnit.charCodeAt(0);
+    }
+
+    return codeUnit >= 0xDC00 && codeUnit <= 0xDFFF;
+  }
+
+  Array.from = function (obj) {
+    if(Array.isArray(obj)) {
+      // Simple array clone
+      return obj.slice();
+    } else if(typeof obj == 'string') {
+      // Array.from is surrogate-aware and will not split surrogate pairs.
+      // We can start with a full split and then remerge the pairs.
+      var simpleSplit = obj.split();
+
+      /** @type {string[]} */
+      var finalSplit = [];
+      /** @type {number} */
+      var i;
+
+      for(i=0; i < simpleSplit.length; i++) {
+        // Do we have a surrogate pair?
+        var a = simpleSplit.shift();
+        if(isHighSurrogate(a) && isLowSurrogate(simpleShift[0] || '')) {
+          // yes, so merge them before pushing.
+          a = a + simpleSplit.shift();
+        } // else:  'no', so just push the current char to the array and continue
+
+        finalSplit.push(a);
+      }
+      return finalSplit;
+    } else {
+      throw "Unexpected + nonpolyfilled use of Array.from encountered; aborting";
+    }
+  }
+}

--- a/common/web/lm-worker/src/polyfills/array.from.js
+++ b/common/web/lm-worker/src/polyfills/array.from.js
@@ -1,18 +1,12 @@
 (function() {
   if(!Array.from) {
     function isHighSurrogate(codeUnit) {
-      if(typeof codeUnit == 'string') {
-        codeUnit = codeUnit.charCodeAt(0);
-      }
-
+      codeUnit = codeUnit.charCodeAt(0);
       return codeUnit >= 0xD800 && codeUnit <= 0xDBFF;
     }
 
     function isLowSurrogate(codeUnit) {
-      if(typeof codeUnit == 'string') {
-        codeUnit = codeUnit.charCodeAt(0);
-      }
-
+      codeUnit = codeUnit.charCodeAt(0);
       return codeUnit >= 0xDC00 && codeUnit <= 0xDFFF;
     }
 


### PR DESCRIPTION
Fixes: #11502
Fixes: KEYMAN-WEB-K4

We removed almost all uses of `Array.from` from the lm-worker and its subpackages during 17.0's release cycle, aiming to simplify the number of polyfills needed.  However, two cases were missed:

1. https://github.com/keymanapp/keyman/blob/614f957de583e68aaad9193c397bcc88ff065c09/common/models/wordbreakers/src/default/index.ts#L277
2. https://github.com/keymanapp/keyman/blob/614f957de583e68aaad9193c397bcc88ff065c09/developer/src/kmc-model/src/model-defaults.ts#L58

While it's possible to correct the first one and simply "move on", the second poses a greater problem.  We've baked use of `Array.from` into a number of our distributed models, and so we _must_ provide some form of polyfill for `Array.from`.

To remedy that, this adds a very limited version of `Array.from` that can handle array-cloning and standard `string` uses of `Array.from`, though not a complete polyfill.  We don't want to exacerbate the issue by supporting alternate uses at this time.

## User Testing

TEST_ANDROID_22:  Use Android Studio or similar to set up a Pixel 2 XL with API 22 (Lollipop) and verify that no error is displayed when the app loads.