### PR TITLE
feat(developer): support language reference in context help

### DIFF
--- a/developer/src/tike/xml/help/contexthelp.xml
+++ b/developer/src/tike/xml/help/contexthelp.xml
@@ -2,6 +2,10 @@
 <?xml-stylesheet type="text/xsl" href="help.xsl" ?>
 <ContextHelp>
 
+  <LanguageReference Name="group">
+    <p>(TODO: add  documentation on group)</p>
+  </LanguageReference>
+
   <Form Name="context/character-map">
     <Control Name="editFilter" Title="Character Map Filter">
       <p>The Filter allows a user to reduce the number of characters displayed in the character map. The standard filter options used are by font name or block name.</p>
@@ -12,63 +16,63 @@
     </Control>
 
     <Control Name="cmdFilter" Title="Character Map Filter">
-      <p>The Filter allows a user to reduce the number of characters displayed in the 
+      <p>The Filter allows a user to reduce the number of characters displayed in the
       character map. The standard filter options used are by font name or block name.</p>
     </Control>
 
     <Control Name="rbRange" Title="Character Map Filter">
-      <p>The filter format for a range is: [U+]XXXX-[U+]YYYY, where U+ is optional, 
+      <p>The filter format for a range is: [U+]XXXX-[U+]YYYY, where U+ is optional,
       XXXX is the starting Unicode value and YYYY is the finishing Unicode value.</p>
     </Control>
 
     <Control Name="editRangeStart" Title="Character Map Filter">
-      <p>The filter format for a range is: [U+]XXXX-[U+]YYYY, where U+ is optional, 
+      <p>The filter format for a range is: [U+]XXXX-[U+]YYYY, where U+ is optional,
       XXXX is the starting Unicode value and YYYY is the finishing Unicode value.</p>
     </Control>
 
     <Control Name="editRangeStop" Title="Character Map Filter">
-      <p>The filter format for a range is: [U+]XXXX-[U+]YYYY, where U+ is optional, 
+      <p>The filter format for a range is: [U+]XXXX-[U+]YYYY, where U+ is optional,
       XXXX is the starting Unicode value and YYYY is the finishing Unicode value.</p>
     </Control>
 
     <Control Name="rbName" Title="Character Map Filter">
-      <p>The Filter allows a user to reduce the number of characters displayed in the 
+      <p>The Filter allows a user to reduce the number of characters displayed in the
       character map. The standard filter options used are by font name or block name.</p>
     </Control>
 
     <Control Name="cmdCharactersInCurrentFontOnly" Title="Character Map Filter">
-      <p> "&gt;" placed at the start of an entry will only show characters in the currently 
-      selected Character Map font. This is helpful when trying to determine which characters 
+      <p> "&gt;" placed at the start of an entry will only show characters in the currently
+      selected Character Map font. This is helpful when trying to determine which characters
       a given font supports.</p><br></br>
       <p>Example: &gt;LAO </p><br></br>
       <p>finds all characters with names starting in "LAO" in the current font</p>
     </Control>
 
     <Control Name="cmdBlock" Title="Character Map Filter">
-      <p> "&lt;" placed at the start of an entry will search Unicode block names instead of 
-      character names. This is helpful when searching for characters within related 
+      <p> "&lt;" placed at the start of an entry will search Unicode block names instead of
+      character names. This is helpful when searching for characters within related
       blocks</p><br></br>
       <p>Example:  &lt;Thai </p><br></br>
       <p>finds the Thai Unicode block</p>
     </Control>
 
     <Control Name="cmdStar" Title="Character Map Filter">
-      <p>Using "*" in an entry serves as a wildcard for any number of places in that entry. 
-      For example, searching for "greek*alpha" will find characters whose Unicode names begin 
-      with the word "Greek" and contain the word "Alpha" any number of places later. 
-      This is helpful when searching for characters that share a common element in 
+      <p>Using "*" in an entry serves as a wildcard for any number of places in that entry.
+      For example, searching for "greek*alpha" will find characters whose Unicode names begin
+      with the word "Greek" and contain the word "Alpha" any number of places later.
+      This is helpful when searching for characters that share a common element in
       their names (e.g. capital).</p>
     </Control>
 
     <Control Name="cmdQuestionMark" Title="Character Map Filter">
-      <p>Using "?" anywhere in an entry serves as a wildcard for that single place in the entry. 
-      For example, searching for "s???e" will return both the SPACE and the SMILE characters, 
+      <p>Using "?" anywhere in an entry serves as a wildcard for that single place in the entry.
+      For example, searching for "s???e" will return both the SPACE and the SMILE characters,
       among others.</p><br></br>
     </Control>
 
     <Control Name="cmdRange" Title="Character Map Filter">
       <p>Example: 1000-119F </p><br></br>
-      <p>finds all characters between U+1000 and U+119F (inclusive) - 
+      <p>finds all characters between U+1000 and U+119F (inclusive) -
       the Myanmar alphabet in this case</p>
     </Control>
 
@@ -78,7 +82,7 @@
     </Control>
 
     <Control Name="cmdDollar" Title="Character Map Filter">
-      <p>"$" placed at the end of an entry will match from the end of a Unicode character name. 
+      <p>"$" placed at the end of an entry will match from the end of a Unicode character name.
       This option works best when used with "*" or "?".</p><br></br>
       <p>Example: LATIN * LETTER A$ </p><br></br>
       <p>finds only "a" and "A"</p>
@@ -471,18 +475,18 @@
 
   <Form Name="context/new-model-project-parameters">
     <Control Name="editAuthor" Title="Author Name">
-      <p>The name of the developer of the keyboard. This is either your full name or 
+      <p>The name of the developer of the keyboard. This is either your full name or
       the organization you're creating a model for.</p>
     </Control>
 
     <Control Name="editModelName" Title="Model Name">
-      <p>We recommend the name of the language, dialect, or community that this model is 
+      <p>We recommend the name of the language, dialect, or community that this model is
       intended for. The name must be written in all the Latin letters or Arabic numerals.</p>
     </Control>
 
     <Control Name="editCopyright" Title="Copyright">
-      <p>Who owns the rights to this model and its data? Typically, 
-      you can use the automatically generated default value: © 2024 Your Full Name or 
+      <p>Who owns the rights to this model and its data? Typically,
+      you can use the automatically generated default value: © 2024 Your Full Name or
       Your Organization.</p>
     </Control>
 
@@ -491,18 +495,18 @@
     </Control>
 
     <Control Name="editVersion" Title="Version">
-      <p>If this is the first time you've created a lexical model for you language, you should 
-      leave the version as 1.0. Otherwise, your version number must conform to the following 
+      <p>If this is the first time you've created a lexical model for you language, you should
+      leave the version as 1.0. Otherwise, your version number must conform to the following
       rules: A version string made of major revision number.minor revision number.</p>
     </Control>
 
     <Control Name="gridLanguages" Title="Languages">
-      <p>Specifies the default BCP 47 language tags which will be added to the package 
+      <p>Specifies the default BCP 47 language tags which will be added to the package
       metadata and project metadata.</p>
     </Control>
 
     <Control Name="cmdAddLanguage" Title="Add...">
-      <p>To add a language tag, click the Add button to bring up the “Select BCP 47 Tag” 
+      <p>To add a language tag, click the Add button to bring up the “Select BCP 47 Tag”
       dialog box.</p>
     </Control>
 
@@ -524,7 +528,7 @@
     </Control>
 
     <Control Name="editAuthorID" Title="Author ID">
-      <p>An Author ID is a unique identifier used to distinguish you from others 
+      <p>An Author ID is a unique identifier used to distinguish you from others
       who have the same or similar names. </p>
     </Control>
 
@@ -533,13 +537,13 @@
     </Control>
 
     <Control Name="editUniq" Title="Unique Name">
-      <p>Enter a unique name of the model. You can use the name of the language, dialect, 
+      <p>Enter a unique name of the model. You can use the name of the language, dialect,
       or community that this model is intended for.</p>
     </Control>
 
     <Control Name="editModelID" Title="Model ID">
-      <p>Keyman automatically generates a model ID for you, given all the 
-      information already filled out. Model ID helps Keyman sorts and organizes 
+      <p>Keyman automatically generates a model ID for you, given all the
+      information already filled out. Model ID helps Keyman sorts and organizes
       different lexical models.</p>
     </Control>
 
@@ -558,15 +562,15 @@
 
   <Form Name="context/wordlist-editor">
     <Control Name="pages" Title="Wordlist tabs">
-      <p>Wordlist tabs have two views: Design, and Code. Changes to one view are reflected 
-      immedaitely in the other view. Wordlist files should be stored in UTF-8 encoding 
+      <p>Wordlist tabs have two views: Design, and Code. Changes to one view are reflected
+      immedaitely in the other view. Wordlist files should be stored in UTF-8 encoding
       (preferably without BOM), and tab-separated format.</p>
     </Control>
 
     <Control Name="gridWordlist" Title="Wordlist tabs">
-      <p>Every line of the tab-separated format file is shown here, and can be edited directly. 
-      For most wordlists, it will be more effective to use an external dictionary tool, 
-      such as SIL Fieldworks or SIL PrimerPrep to generate the wordlist from a text corpus, 
+      <p>Every line of the tab-separated format file is shown here, and can be edited directly.
+      For most wordlists, it will be more effective to use an external dictionary tool,
+      such as SIL Fieldworks or SIL PrimerPrep to generate the wordlist from a text corpus,
       and use this tab just to preview the contents of the file.</p>
     </Control>
 
@@ -575,24 +579,24 @@
     </Control>
 
     <Control Name="cmdSortByFrequency" Title="Wordlist tabs">
-      <p>The Sort by frequency button has no effect on the functioning of the wordlist, 
+      <p>The Sort by frequency button has no effect on the functioning of the wordlist,
       but can help you, the editor, by showing more common words earlier in the list.</p>
     </Control>
   </Form>
 
   <Form Name="context/editor">
     <Control Name="cefwp" Title="Editor Window">
-      <p>Editor windows in Keyman Developer supports standard Windows editing keystrokes. 
-      Many file formats, including .kmn, .kps, .xml, .html, .js and .json, support syntax 
-      highlighting. The text editor in Keyman uses the Monaco component from Visual Studio Code, 
+      <p>Editor windows in Keyman Developer supports standard Windows editing keystrokes.
+      Many file formats, including .kmn, .kps, .xml, .html, .js and .json, support syntax
+      highlighting. The text editor in Keyman uses the Monaco component from Visual Studio Code,
       so all the functionality available in that editor is also available here.</p>
     </Control>
   </Form>
 
   <Form Name="context/character-identifier">
     <Control Name="gridFonts" Title="Character Identifier">
-      <p>Attempt to identify the fonts on your system that will support the 
-      characters. You can quickly change fonts by clicking on a font name in the grid of 
+      <p>Attempt to identify the fonts on your system that will support the
+      characters. You can quickly change fonts by clicking on a font name in the grid of
       identified fonts.</p>
     </Control>
 
@@ -603,47 +607,47 @@
 
   <Form Name="context/messages">
     <Control Name="memoMessage" Title="Message Window">
-      <p>The message window appears at the bottom of the screen, or floating in a toolbar 
-      window. It contains a list of error and warning messages returned from a compilation 
+      <p>The message window appears at the bottom of the screen, or floating in a toolbar
+      window. It contains a list of error and warning messages returned from a compilation
       session. You can undock and dock the window by dragging its title bar.</p>
     </Control>
   </Form>
 
   <Form Name="context/debug">
     <Control Name="memo" Title="Debugger input window">
-      <p>The debugger input window is used for typing input to test the keyboard. 
-      In the top half of this window, input you type while testing your keyboard will be 
-      displayed, exactly the same as in use, with one exception: deadkeys will be shown 
+      <p>The debugger input window is used for typing input to test the keyboard.
+      In the top half of this window, input you type while testing your keyboard will be
+      displayed, exactly the same as in use, with one exception: deadkeys will be shown
       visually with an OBJ symbol.</p>
     </Control>
 
     <Control Name="sgChars" Title="Debugger input window">
-      <p>The lower half of the window shows a grid of the characters to the virtual left 
-      of the insertion point, or the selected characters if you make a selection. Deadkeys 
-      will be identified in the grid. The grid will show characters in right-to-left scripts 
-      in backing store order, from left to right. If there are more characters in your text 
+      <p>The lower half of the window shows a grid of the characters to the virtual left
+      of the insertion point, or the selected characters if you make a selection. Deadkeys
+      will be identified in the grid. The grid will show characters in right-to-left scripts
+      in backing store order, from left to right. If there are more characters in your text
       than can fit on the screen, then only those that fit will be shown in the grid.</p>
     </Control>
   </Form>
 
   <Form Name="context/debug#toc-regression-testing">
     <Control Name="lbRegTestLog" Title="Regression Testing">
-      <p>The idea in regression testing is to record a sequence of keystrokes and the 
-      output the keyboard produced, in order to test for the same behaviour when you 
+      <p>The idea in regression testing is to record a sequence of keystrokes and the
+      output the keyboard produced, in order to test for the same behaviour when you
       make changes to the keyboard.</p>
     </Control>
 
     <Control Name="cmdRegTestStartStopLog" Title="Regression Testing">
-      <p>Use Start Log/Stop Log to record the input and output. You can then use Start Test 
-      to run the test again, or go the Options menu to clear the log, or save or load a test, 
+      <p>Use Start Log/Stop Log to record the input and output. You can then use Start Test
+      to run the test again, or go the Options menu to clear the log, or save or load a test,
       or use the batch mode to run several tests in a row. </p><br></br>
-      <p>If the output produced while running a test is different to that stored when recording it, 
-      Keyman will halt the test on the line where the failure occurred, and activate 
+      <p>If the output produced while running a test is different to that stored when recording it,
+      Keyman will halt the test on the line where the failure occurred, and activate
       Single Step mode.</p>
     </Control>
 
     <Control Name="cmdRegTestOptions" Title="Regression Testing">
-      <p>In the Options menu, you can clear the log, save or load a test, 
+      <p>In the Options menu, you can clear the log, save or load a test,
       or use the batch mode to run several tests in a row.</p>
     </Control>
   </Form>
@@ -655,39 +659,39 @@
     </Control>
 
     <Control Name="lbKeystrokeLog" Title="State">
-      <p>This window shows the current keystroke state, and the sequence of 
+      <p>This window shows the current keystroke state, and the sequence of
       keystrokes that were typed to arrive at this state. </p>
     </Control>
   </Form>
 
   <Form Name="context/debug#toc-elements">
     <Control Name="lvElements" Title="Elements">
-      <p>This shows the elements that make up rule currently being processed: the context, 
-      the key, and also what the output will be. If the rule uses stores, the contents of 
+      <p>This shows the elements that make up rule currently being processed: the context,
+      the key, and also what the output will be. If the rule uses stores, the contents of
       the store will be shown in the right-hand column, with the matched letter in red.</p>
     </Control>
   </Form>
 
   <Form Name="context/debug#toc-call-stack">
     <Control Name="lbCallStack" Title="Call Stack">
-      <p>Here all the lines that have been processed to this point are shown in a list. 
-      You can double-click on any entry in the list to display the line in the 
+      <p>Here all the lines that have been processed to this point are shown in a list.
+      You can double-click on any entry in the list to display the line in the
       keyboard source.</p>
     </Control>
   </Form>
 
   <Form Name="context/debug#toc-deadkeys">
     <Control Name="lbDeadkeys" Title="Deadkeys">
-      <p>This lists all the deadkeys that are currently in the context. 
-      You can select one from the list to see it highlighted in the debug input box. 
-      This information can also be seen in the character grid in the lower half of 
+      <p>This lists all the deadkeys that are currently in the context.
+      You can select one from the list to see it highlighted in the debug input box.
+      This information can also be seen in the character grid in the lower half of
       the debugger input window.</p>
     </Control>
   </Form>
 
   <Form Name="context/about-tike">
     <Control Name="cmdOK" Title="About Dialog">
-      <p>The About dialog displays copyright and registration information for Keyman Developer, 
+      <p>The About dialog displays copyright and registration information for Keyman Developer,
       and has a link to the Keyman website.</p>
     </Control>
   </Form>

--- a/developer/src/tike/xml/help/help.xsl
+++ b/developer/src/tike/xml/help/help.xsl
@@ -53,6 +53,7 @@
           </script>
       </head>
       <body>
+        <xsl:apply-templates select="//LanguageReference" />
         <xsl:apply-templates select="//Control" />
         <div class="control" id="nohelp">
           Context help is not available for <b><span id="nohelp_name"></span></b>.
@@ -64,6 +65,18 @@
 
   <xsl:template match="/ContextHelp/Form">
     <xsl:apply-templates select="Control" />
+  </xsl:template>
+
+  <xsl:template match="//LanguageReference">
+    <div class="control">
+      <xsl:attribute name="id">language/reference/<xsl:value-of select="@Name"/></xsl:attribute>
+      <div class="title"><xsl:value-of select="@Title"/></div>
+      <xsl:copy-of select="." />
+      <div class="morehelp"><a>
+        <xsl:attribute name='href'>help:language/reference/<xsl:value-of select="@Name"/></xsl:attribute>
+        More help...
+      </a></div>
+    </div>
   </xsl:template>
 
   <xsl:template match="//Control">


### PR DESCRIPTION
Adds support for `<LanguageReference Name='keyword'>` in contexthelp.xml.

@keymanapp-test-bot skip