### PR TITLE
fix(web): set new-context rules' device to match that of the active OSK 🍒 🏠

### DIFF
--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -347,6 +347,10 @@ export default class KeymanEngine<
       this.core.keyboardProcessor.layerStore.handler = this.osk.layerChangeHandler;
     }
     this._osk = value;
+    // As the `new context` ruleset is designed to facilitate OSK layer-change updates
+    // based on the context being entered, we want the keyboard processor's current
+    // contextDevice to match that of the active OSK.  See #11740.
+    this.core.keyboardProcessor.contextDevice = value.targetDevice ?? this.config.softDevice;
     if(value) {
       // Don't build an OSK if no keyboard is available yet; avoid the extra flash.
       if(this.contextManager.activeKeyboard) {


### PR DESCRIPTION
Fixes: #11740
Cherry-pick-of: #11743

@keymanapp-test-bot skip