### PR TITLE
fix(common): remove subpackage entries for older TS version

### DIFF
--- a/common/models/templates/package.json
+++ b/common/models/templates/package.json
@@ -57,7 +57,7 @@
     "c8": "^7.12.0",
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "@keymanapp/keyman-version": "*",

--- a/common/models/types/package.json
+++ b/common/models/types/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/keymanapp/keyman/tree/master/common/models/types#readme",
   "devDependencies": {
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "files": [
     "README.md",

--- a/common/models/wordbreakers/package.json
+++ b/common/models/wordbreakers/package.json
@@ -55,7 +55,7 @@
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "type": "module"
 }

--- a/common/predictive-text/package.json
+++ b/common/predictive-text/package.json
@@ -47,7 +47,7 @@
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "@keymanapp/models-templates": "*",

--- a/common/test/resources/package.json
+++ b/common/test/resources/package.json
@@ -5,6 +5,6 @@
   "license": "MIT",
   "devDependencies": {
     "@keymanapp/resources-gosh": "*",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   }
 }

--- a/common/tools/sourcemap-path-remapper/package.json
+++ b/common/tools/sourcemap-path-remapper/package.json
@@ -21,7 +21,7 @@
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "convert-source-map": "^2.0.0"

--- a/common/web/gesture-recognizer/package.json
+++ b/common/web/gesture-recognizer/package.json
@@ -7,7 +7,7 @@
     "mocha-teamcity-reporter": "^4.0.0",
     "promise-status-async": "^1.2.10",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "imports": {
     "#tools": "./build/tools/obj/index.js"

--- a/common/web/gesture-recognizer/src/test/resources/simulateMultiSourceInput.ts
+++ b/common/web/gesture-recognizer/src/test/resources/simulateMultiSourceInput.ts
@@ -80,7 +80,7 @@ function prepareSourcesFromPriorMatcher<Type>(
 ): ReturnType<typeof prepareSimContact<Type>> {
   const spec = contactSpec;
   const existingSources = spec.matcher.sources.map((src) => {
-    return src instanceof GestureSourceSubview<Type> ? src.baseSource : src;
+    return src instanceof GestureSourceSubview ? src.baseSource : src;
   });
 
   const sequences = spec.continuation;
@@ -330,7 +330,7 @@ export function simulateMultiSourceMatcherInput<Type>(
   const config: SimulationConfig<GestureMatcher<Type>, Type> = {
     construction: (source) => new gestures.matchers.GestureMatcher<Type>(modelSpec, source),
     addSource: (obj, source) => {
-      if(source instanceof GestureSource<Type>) {
+      if(source instanceof GestureSource) {
         obj.addContact(source)
       } else {
         throw new Error("Error in internal sim-engine configuration");

--- a/common/web/input-processor/package.json
+++ b/common/web/input-processor/package.json
@@ -21,8 +21,7 @@
     "@keymanapp/resources-gosh": "*",
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "scripts": {
     "test": "gosh ./test.sh"

--- a/common/web/keyboard-processor/package.json
+++ b/common/web/keyboard-processor/package.json
@@ -22,7 +22,7 @@
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "scripts": {
     "build": "gosh build.sh",

--- a/common/web/keyman-version/package.json
+++ b/common/web/keyman-version/package.json
@@ -13,6 +13,6 @@
   "license": "MIT",
   "type": "module",
   "devDependencies": {
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   }
 }

--- a/common/web/lm-message-types/package.json
+++ b/common/web/lm-message-types/package.json
@@ -7,7 +7,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "files": [
     "message.d.ts"

--- a/common/web/lm-worker/package.json
+++ b/common/web/lm-worker/package.json
@@ -35,7 +35,7 @@
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "@keymanapp/keyman-version": "*",

--- a/common/web/recorder/package.json
+++ b/common/web/recorder/package.json
@@ -25,6 +25,6 @@
     "@keymanapp/web-utils": "*"
   },
   "devDependencies": {
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   }
 }

--- a/common/web/sentry-manager/package.json
+++ b/common/web/sentry-manager/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/keymanapp/keyman#readme",
   "devDependencies": {
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "@keymanapp/keyman-version": "*",

--- a/common/web/tslib/package.json
+++ b/common/web/tslib/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "tslib": "^2.5.2",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "devDependencies": {
     "@keymanapp/resources-gosh": "*",

--- a/common/web/types/package.json
+++ b/common/web/types/package.json
@@ -52,7 +52,7 @@
     "hexy": "^0.3.4",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/common/web/utils/package.json
+++ b/common/web/utils/package.json
@@ -29,7 +29,7 @@
     "c8": "^7.12.0",
     "mocha": "^10.0.0",
     "mocha-teamcity-reporter": "^4.0.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "type": "module",
   "paths": {

--- a/developer/src/common/web/test-helpers/package.json
+++ b/developer/src/common/web/test-helpers/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/node": "^20.4.1",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "scripts": {
     "build": "tsc -b"

--- a/developer/src/common/web/utils/package.json
+++ b/developer/src/common/web/utils/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/node": "^20.4.1",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5",
+    "typescript": "^5.4.5",
     "c8": "^7.12.0",
     "mocha": "^8.4.0"
   },

--- a/developer/src/kmc-analyze/package.json
+++ b/developer/src/kmc-analyze/package.json
@@ -35,7 +35,7 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "repository": {
     "type": "git",

--- a/developer/src/kmc-keyboard-info/package.json
+++ b/developer/src/kmc-keyboard-info/package.json
@@ -34,7 +34,7 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-kmn/package.json
+++ b/developer/src/kmc-kmn/package.json
@@ -42,7 +42,7 @@
     "mocha": "^8.4.0",
     "sinon-chai": "^3.7.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-ldml/package.json
+++ b/developer/src/kmc-ldml/package.json
@@ -40,7 +40,7 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-model-info/package.json
+++ b/developer/src/kmc-model-info/package.json
@@ -41,7 +41,7 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -33,7 +33,7 @@
     "@keymanapp/common-types": "*",
     "@keymanapp/keyman-version": "*",
     "@keymanapp/models-types": "*",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "devDependencies": {
     "@keymanapp/developer-test-helpers": "*",

--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -41,7 +41,7 @@
     "chalk": "^2.4.2",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -62,7 +62,7 @@
     "esbuild": "^0.15.8",
     "mocha": "^8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "mocha": {
     "spec": "build/test/**/test-*.js",

--- a/developer/src/server/package.json
+++ b/developer/src/server/package.json
@@ -34,7 +34,7 @@
     "mocha": "^10.0.0",
     "ts-node": "^10.9.1",
     "tsc-watch": "^4.5.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.5"
   },
   "mocha": {
     "require": "ts-node/register",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,40 +85,14 @@
         "c8": "^7.12.0",
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/models/templates/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/models/types": {
       "name": "@keymanapp/models-types",
       "license": "MIT",
       "devDependencies": {
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/models/types/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/models/wordbreakers": {
@@ -132,20 +106,7 @@
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/models/wordbreakers/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/predictive-text": {
@@ -165,20 +126,7 @@
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/predictive-text/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/test/resources": {
@@ -186,20 +134,7 @@
       "license": "MIT",
       "devDependencies": {
         "@keymanapp/resources-gosh": "*",
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/test/resources/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/tools/hextobin": {
@@ -230,25 +165,12 @@
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "common/tools/sourcemap-path-remapper/node_modules/convert-source-map": {
       "version": "2.0.0",
       "license": "MIT"
-    },
-    "common/tools/sourcemap-path-remapper/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "common/web/es6-shim": {
       "name": "@keymanapp/es6-shim",
@@ -270,20 +192,7 @@
         "mocha-teamcity-reporter": "^4.0.0",
         "promise-status-async": "^1.2.10",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/web/gesture-recognizer/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/web/input-processor": {
@@ -302,21 +211,7 @@
         "@keymanapp/resources-gosh": "*",
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
-        "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/web/input-processor/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/web/keyboard-processor": {
@@ -334,60 +229,21 @@
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/web/keyboard-processor/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/web/keyman-version": {
       "name": "@keymanapp/keyman-version",
       "license": "MIT",
       "devDependencies": {
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/web/keyman-version/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/web/lm-message-types": {
       "name": "@keymanapp/lm-message-types",
       "license": "MIT",
       "devDependencies": {
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/web/lm-message-types/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/web/lm-worker": {
@@ -411,20 +267,7 @@
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/web/lm-worker/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/web/recorder": {
@@ -437,20 +280,7 @@
         "@keymanapp/web-utils": "*"
       },
       "devDependencies": {
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/web/recorder/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/web/sentry-manager": {
@@ -461,43 +291,18 @@
         "@sentry/browser": "^5.27.4"
       },
       "devDependencies": {
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/web/sentry-manager/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "common/web/tslib": {
       "name": "@keymanapp/tslib",
       "dependencies": {
         "tslib": "^2.5.2",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       },
       "devDependencies": {
         "@keymanapp/resources-gosh": "*",
         "esbuild": "^0.15.16"
-      }
-    },
-    "common/web/tslib/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "common/web/types": {
@@ -527,7 +332,7 @@
         "hexy": "^0.3.4",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "common/web/types/node_modules/@types/mocha": {
@@ -721,19 +526,6 @@
         "node": ">=0.3.1"
       }
     },
-    "common/web/types/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "common/web/utils": {
       "name": "@keymanapp/web-utils",
       "license": "MIT",
@@ -743,20 +535,7 @@
         "c8": "^7.12.0",
         "mocha": "^10.0.0",
         "mocha-teamcity-reporter": "^4.0.0",
-        "typescript": "^4.9.5"
-      }
-    },
-    "common/web/utils/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "typescript": "^5.4.5"
       }
     },
     "core/include/ldml": {
@@ -772,7 +551,7 @@
       "devDependencies": {
         "@types/node": "^20.4.1",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "developer/src/common/web/test-helpers/node_modules/diff": {
@@ -810,19 +589,6 @@
         "typescript": ">=2.7"
       }
     },
-    "developer/src/common/web/test-helpers/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "developer/src/common/web/utils": {
       "name": "@keymanapp/developer-utils",
       "license": "MIT",
@@ -834,7 +600,7 @@
         "c8": "^7.12.0",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "developer/src/common/web/utils/node_modules/escape-string-regexp": {
@@ -973,19 +739,6 @@
         "node": ">=0.3.1"
       }
     },
-    "developer/src/common/web/utils/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "developer/src/kmc": {
       "name": "@keymanapp/kmc",
       "license": "MIT",
@@ -1019,7 +772,7 @@
         "esbuild": "^0.15.8",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "developer/src/kmc-analyze": {
@@ -1038,7 +791,7 @@
         "chalk": "^2.4.2",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "developer/src/kmc-analyze/node_modules/@types/mocha": {
@@ -1245,19 +998,6 @@
         "node": ">=0.3.1"
       }
     },
-    "developer/src/kmc-analyze/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "developer/src/kmc-keyboard": {
       "name": "@keymanapp/kmc-keyboard",
       "extraneous": true,
@@ -1282,7 +1022,7 @@
         "chalk": "^2.4.2",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "developer/src/kmc-keyboard-info": {
@@ -1300,7 +1040,7 @@
         "chalk": "^2.4.2",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "developer/src/kmc-keyboard-info/node_modules/@types/mocha": {
@@ -1507,19 +1247,6 @@
         "node": ">=0.3.1"
       }
     },
-    "developer/src/kmc-keyboard-info/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "developer/src/kmc-kmn": {
       "name": "@keymanapp/kmc-kmn",
       "license": "MIT",
@@ -1540,7 +1267,7 @@
         "mocha": "^8.4.0",
         "sinon-chai": "^3.7.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "developer/src/kmc-kmn/node_modules/@types/mocha": {
@@ -1747,19 +1474,6 @@
         "node": ">=0.3.1"
       }
     },
-    "developer/src/kmc-kmn/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "developer/src/kmc-ldml": {
       "name": "@keymanapp/kmc-ldml",
       "license": "MIT",
@@ -1779,7 +1493,7 @@
         "chalk": "^2.4.2",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "developer/src/kmc-ldml/node_modules/@types/mocha": {
@@ -1986,19 +1700,6 @@
         "node": ">=0.3.1"
       }
     },
-    "developer/src/kmc-ldml/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "developer/src/kmc-model": {
       "name": "@keymanapp/kmc-model",
       "license": "MIT",
@@ -2006,7 +1707,7 @@
         "@keymanapp/common-types": "*",
         "@keymanapp/keyman-version": "*",
         "@keymanapp/models-types": "*",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       },
       "devDependencies": {
         "@keymanapp/developer-test-helpers": "*",
@@ -2035,7 +1736,7 @@
         "chalk": "^2.4.2",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "developer/src/kmc-model-info/node_modules/@types/mocha": {
@@ -2229,19 +1930,6 @@
         "node": ">=0.3.1"
       }
     },
-    "developer/src/kmc-model-info/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "developer/src/kmc-model/node_modules/@types/mocha": {
       "version": "5.2.7",
       "dev": true,
@@ -2303,18 +1991,6 @@
         "node": ">=4"
       }
     },
-    "developer/src/kmc-model/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "developer/src/kmc-package": {
       "name": "@keymanapp/kmc-package",
       "license": "MIT",
@@ -2331,7 +2007,7 @@
         "chalk": "^2.4.2",
         "mocha": "^8.4.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       }
     },
     "developer/src/kmc-package/node_modules/@types/mocha": {
@@ -2523,19 +2199,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "developer/src/kmc-package/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "developer/src/kmc/node_modules/@types/mocha": {
@@ -2737,19 +2400,6 @@
         "node": ">=0.3.1"
       }
     },
-    "developer/src/kmc/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "developer/src/server": {
       "name": "@keymanapp/developer-server",
       "license": "MIT",
@@ -2775,7 +2425,7 @@
         "mocha": "^10.0.0",
         "ts-node": "^10.9.1",
         "tsc-watch": "^4.5.0",
-        "typescript": "^4.9.5"
+        "typescript": "^5.4.5"
       },
       "optionalDependencies": {
         "hetrodo-node-hide-console-window-napi": "keymanapp/hetrodo-node-hide-console-window-napi#keyman-15.0",
@@ -2816,19 +2466,6 @@
       "version": "1.1.0",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "developer/src/server/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -14869,7 +14506,7 @@
         "@actions/core": "^1.9.1",
         "@actions/github": "^2.1.0",
         "emoji-regex": "^10.3.0",
-        "typescript": "^4.9.5",
+        "typescript": "^5.4.5",
         "yargs": "^17.7.2"
       },
       "devDependencies": {
@@ -14942,18 +14579,6 @@
         "node": ">=8"
       }
     },
-    "resources/build/version/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "resources/build/version/node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -15022,21 +14647,7 @@
         "c8": "^7.12.0",
         "jsdom": "^23.0.1",
         "mocha": "^10.0.0",
-        "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
-      }
-    },
-    "web/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "ts-node": "^10.9.1"
       }
     }
   }

--- a/resources/build/version/package.json
+++ b/resources/build/version/package.json
@@ -5,7 +5,7 @@
     "@actions/core": "^1.9.1",
     "@actions/github": "^2.1.0",
     "emoji-regex": "^10.3.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.4.5",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I thought I'd done this originally in #11414, but it seems I'd neglected to delete the older-version TS entries for subpackages within the repository.  Time to finish that cleanup.

@keymanapp-test-bot skip