### PR TITLE
feat(linux): rename symbols throughout mcompile-linux 🐘

### DIFF
--- a/linux/mcompile/keymap/deadkey.cpp
+++ b/linux/mcompile/keymap/deadkey.cpp
@@ -1,8 +1,8 @@
 #include "keymap.h"
 #include "deadkey.h"
 
-v_dw_1D createLine(std::string  first, std::string second, KMX_DWORD number, std::string nameresult) {
-	v_dw_1D line;
+vec_dword_1D createLine(std::string  first, std::string second, KMX_DWORD number, std::string nameresult) {
+	vec_dword_1D line;
 	line.push_back(convertNamesTo_DWORD_Value(first));
 	line.push_back(convertNamesTo_DWORD_Value(second));
 	//line.push_back(convertNamesTo_DWORD_Value(nameresult));
@@ -10,9 +10,9 @@ v_dw_1D createLine(std::string  first, std::string second, KMX_DWORD number, std
 	return line;
 }
 
-std::vector<DeadKey*> create_alDead() {
+std::vector<DeadKey*> create_deadkeys_by_basechar() {
 	std::vector<DeadKey*> alDead;
-	v_dw_2D dk_ComposeTable;
+	vec_dword_2D dk_ComposeTable;
 
   create_DKTable(dk_ComposeTable);
 
@@ -54,8 +54,8 @@ bool found_dk_inVector(KMX_WCHAR dk, std::vector<DeadKey*> &dkVec) {
 	return false;
 }
 
-bool query_dk_combinations_for_specific_dk(v_dw_2D * p_dk_ComposeTable, v_dw_2D  &dk_SingleTable, KMX_DWORD dk) {
-	v_dw_1D line;
+bool query_dk_combinations_for_specific_dk(vec_dword_2D * p_dk_ComposeTable, vec_dword_2D  &dk_SingleTable, KMX_DWORD dk) {
+	vec_dword_1D line;
 
 	for ( int i =0; i< (int) (*p_dk_ComposeTable).size(); i++) {
 		if (((*p_dk_ComposeTable)[i][0] == dk) && (IsKeymanUsedChar((*p_dk_ComposeTable)[i][1]))) {
@@ -73,25 +73,25 @@ bool query_dk_combinations_for_specific_dk(v_dw_2D * p_dk_ComposeTable, v_dw_2D 
 		return false;
 }
 
-KMX_DWORD KMX_changeKeynameToCapital(KMX_DWORD KVal, KMX_DWORD &shift, GdkKeymap* keymap) {
-  guint Keyval = (guint) KVal;
+KMX_DWORD KMX_change_keyname_to_capital(KMX_DWORD kVal, KMX_DWORD &shift, GdkKeymap* keymap) {
+  guint keyval = (guint) kVal;
   GdkKeymapKey* keys;
   gint n_keys;
 
-	KMX_DWORD Cap = (KMX_DWORD) gdk_keyval_to_upper (KVal);
-	if( Keyval !=0) {
-		gdk_keymap_get_entries_for_keyval(keymap, Keyval, &keys, &n_keys);
+	KMX_DWORD capitalKeyval = (KMX_DWORD) gdk_keyval_to_upper (kVal);
+	if( keyval !=0) {
+		gdk_keymap_get_entries_for_keyval(keymap, keyval, &keys, &n_keys);
 		for (int i = 0; i < n_keys; i++) {
 			if (keys[i].group == 0) {
 				shift = keys[i].level;
-				return Cap;
+				return capitalKeyval;
 			}
 		}
 	}
-	return Cap;
+	return capitalKeyval;
 }	
 
-void create_DKTable(v_dw_2D & dk_ComposeTable) {
+void create_DKTable(vec_dword_2D & dk_ComposeTable) {
   //create a 2D-Vector which contains data for ALL existing deadkey combinations on a Linux Keyboard:
   //dk_ComposeTable[i][0] : First    (e.g. dead_circumflex)
   //dk_ComposeTable[i][1] : Second   (e.g. a)
@@ -100,7 +100,7 @@ void create_DKTable(v_dw_2D & dk_ComposeTable) {
   //values taken from: https://help.ubuntu.com/community/GtkDeadKeyTable#Accents
 	// _S2 Do we want to use GTK instead of this function?
 
-  v_dw_1D line;
+  vec_dword_1D line;
 
 	line = createLine("dead_circumflex",  "a",  0x00E2, "small A with circumflex");
 	  dk_ComposeTable.push_back(line);	line.clear();

--- a/linux/mcompile/keymap/deadkey.cpp
+++ b/linux/mcompile/keymap/deadkey.cpp
@@ -28,11 +28,11 @@ std::vector<DeadKey*> create_deadkeys_by_basechar() {
 }
 
 void refine_alDead(KMX_WCHAR dk, std::vector<DeadKey*> &dkVec, std::vector<DeadKey*> *p_All_Vec) {
-	if( dk == 0)
+	if (dk == 0)
 		return;
 
 	for (int j=0; j < (int) (*p_All_Vec).size()-1;j++) {
-		if( dk == (*p_All_Vec)[j]->KMX_GetDeadCharacter()) {
+		if (dk == (*p_All_Vec)[j]->KMX_GetDeadCharacter()) {
 			if(! found_dk_inVector(dk, dkVec)) {
 				dkVec.push_back((*p_All_Vec)[j]);
 				return;
@@ -44,9 +44,9 @@ void refine_alDead(KMX_WCHAR dk, std::vector<DeadKey*> &dkVec, std::vector<DeadK
 
 bool found_dk_inVector(KMX_WCHAR dk, std::vector<DeadKey*> &dkVec) {
 	int i=0;
-	if( dkVec.size() > 0) {
+	if (dkVec.size() > 0) {
 		do {
-			if( dk == dkVec[i]->KMX_GetDeadCharacter())
+			if (dk == dkVec[i]->KMX_GetDeadCharacter())
 				return true;
 			i++;
 		} while (i < (int) dkVec.size());
@@ -67,7 +67,7 @@ bool query_dk_combinations_for_specific_dk(vec_dword_2D * p_dk_ComposeTable, vec
 		}
 	}
 
-	if( dk_SingleTable.size()>0)
+	if (dk_SingleTable.size()>0)
 		return true;
 	else
 		return false;
@@ -79,7 +79,7 @@ KMX_DWORD KMX_change_keyname_to_capital(KMX_DWORD kVal, KMX_DWORD &shift, GdkKey
   gint n_keys;
 
 	KMX_DWORD capitalKeyval = (KMX_DWORD) gdk_keyval_to_upper (kVal);
-	if( keyval !=0) {
+	if (keyval !=0) {
 		gdk_keymap_get_entries_for_keyval(keymap, keyval, &keys, &n_keys);
 		for (int i = 0; i < n_keys; i++) {
 			if (keys[i].group == 0) {
@@ -382,7 +382,6 @@ void create_DKTable(vec_dword_2D & dk_ComposeTable) {
 	  dk_ComposeTable.push_back(line);	line.clear();
 	line = createLine("dead_ogonek",  "U",  0x0172, "capital U with ogonek");
 	  dk_ComposeTable.push_back(line);	line.clear();
-
 	line = createLine("dead_circumflex",  "space",  0x005E, "CIRCUMFLEX_ACCENT");
 	  dk_ComposeTable.push_back(line);	line.clear();
 

--- a/linux/mcompile/keymap/deadkey.h
+++ b/linux/mcompile/keymap/deadkey.h
@@ -7,13 +7,13 @@
 #include "mc_import_rules.h"
 
 // create a vector for a dk combination ( ` + a  ->  à )
-v_dw_1D createLine(std::string  first, std::string second, KMX_DWORD number, std::string nameresult);
+vec_dword_1D createLine(std::string  first, std::string second, KMX_DWORD number, std::string nameresult);
 
 // create a 2D-vector of all dk combinations ( ` + a -> à ;  ^ + a -> â ; `+ e -> è; ...)
-void create_DKTable(v_dw_2D & dk_ComposeTable);
+void create_DKTable(vec_dword_2D & dk_ComposeTable);
 
 // find all possible dk combinations that exist
-std::vector<DeadKey*> create_alDead();
+std::vector<DeadKey*> create_deadkeys_by_basechar();
 
 // refine dk to those used in the underlying keyboard
 void refine_alDead(KMX_WCHAR dk, std::vector<DeadKey*> &myVec, std::vector<DeadKey*> *p_All_Vec);
@@ -21,9 +21,9 @@ void refine_alDead(KMX_WCHAR dk, std::vector<DeadKey*> &myVec, std::vector<DeadK
 bool found_dk_inVector(KMX_WCHAR dk, std::vector<DeadKey*> &myVec);
 
 // get all combination for a specific deadkey(dk) from the dk_vector query_dk_combinations_for_specific_dk which holds all possible dk: ^-> â,ê,î,ô,û,...
-bool query_dk_combinations_for_specific_dk(v_dw_2D * dk_ComposeTable, v_dw_2D & dk_SingleTable, KMX_DWORD dk);
+bool query_dk_combinations_for_specific_dk(vec_dword_2D * dk_ComposeTable, vec_dword_2D & dk_SingleTable, KMX_DWORD dk);
 
 // get the shifted character of a key and write shiftstate of KVal to shift
-KMX_DWORD KMX_changeKeynameToCapital(KMX_DWORD KVal, KMX_DWORD &shift, GdkKeymap* keymap);
+KMX_DWORD KMX_change_keyname_to_capital(KMX_DWORD kVal, KMX_DWORD &shift, GdkKeymap* keymap);
 
 # endif /*DEADKEY_H*/

--- a/linux/mcompile/keymap/keymap.cpp
+++ b/linux/mcompile/keymap/keymap.cpp
@@ -278,7 +278,7 @@ KMX_DWORD convertNamesTo_DWORD_Value(std::string tok_str) {
 
   first["acute accent"]      = 0xB4;
 
-  if ( tok_str.size() == 1) {
+  if (tok_str.size() == 1) {
     return (KMX_DWORD) ( *tok_str.c_str() );
   }
   else {
@@ -291,9 +291,9 @@ KMX_DWORD convertNamesTo_DWORD_Value(std::string tok_str) {
   return INVALID_NAME;
 }
 
-int createOneVectorFromBothKeyboards(vec_dword_3D &All_Vector,GdkKeymap *keymap) {
+int createOneVectorFromBothKeyboards(vec_dword_3D &all_vector,GdkKeymap *keymap) {
   // create a 3D-Vector which contains data of the US keyboard and the underlying Keyboard:
-  //    All_Vector[  US_Keyboard ]
+  //    all_vector[  US_Keyboard ]
   //                     [KeyCode_US        ]
   //                     [Keyval unshifted  ]
   //                     [Keyval shifted    ]
@@ -305,13 +305,13 @@ int createOneVectorFromBothKeyboards(vec_dword_3D &All_Vector,GdkKeymap *keymap)
   std::string us_language    = "us";
   const char* text_us        = "xkb_symbols \"basic\"";
 
-  if(write_US_ToVector(All_Vector,us_language, text_us)) {
+  if (write_US_ToVector(all_vector,us_language, text_us)) {
     wprintf(L"ERROR: can't write US to Vector \n");
     return 1;
   }
 
-  // add contents of other keyboard to All_Vector
-  if( append_underlying_ToVector(All_Vector,keymap)) {
+  // add contents of other keyboard to all_vector
+  if (append_underlying_ToVector(all_vector,keymap)) {
     wprintf(L"ERROR: can't append underlying ToVector \n");
     return 2;
   }
@@ -324,20 +324,20 @@ int write_US_ToVector( vec_dword_3D &vec,std::string language, const char* secti
 
   const char* path = fullPathName.c_str();
   FILE* fp = fopen((path), "r");
-  if ( !fp) {
+  if (!fp) {
     wprintf(L"ERROR: could not open file!\n");
     return 1;
   }
 
   // create 1D-vector of the complete line
   vec_string_1D vector_completeUS;
-  if( createCompleteVector_US(fp, section , vector_completeUS)) {
+  if (createCompleteVector_US(fp, section, vector_completeUS)) {
     wprintf(L"ERROR: can't Create complete row US \n");
     return 1;
   }
 
   // split contents of 1D Vector to 3D vector
-  if( split_US_To_3D_Vector( vec,vector_completeUS)) {
+  if (split_US_To_3D_Vector(vec,vector_completeUS)) {
     return 1;
   }
 
@@ -345,7 +345,7 @@ int write_US_ToVector( vec_dword_3D &vec,std::string language, const char* secti
   return 0;
 }
 
-bool createCompleteVector_US(FILE* fp, const char* section , vec_string_1D &complete_List) {
+bool createCompleteVector_US(FILE* fp, const char* section, vec_string_1D &complete_List) {
   // in the Configuration file we find the appopriate paragraph between "xkb_symbol <text>" and the next xkb_symbol
   // and then copy all rows starting with "key <" to a 1D-Vector
 
@@ -353,7 +353,7 @@ bool createCompleteVector_US(FILE* fp, const char* section , vec_string_1D &comp
   char line[buffer_size];
   bool create_row   = false;
   const char* key = "key <";
-  std::string str_us_kbd_name(section );
+  std::string str_us_kbd_name(section);
   std::string xbk_mark = "xkb_symbol";
 
   if (fp) {
@@ -442,7 +442,7 @@ int replace_KeyName_with_Keycode(std::string  in) {
   return out;
 }
 
-int split_US_To_3D_Vector(vec_dword_3D &all_US,vec_string_1D completeList) {
+int split_US_To_3D_Vector(vec_dword_3D& all_US, vec_string_1D completeList) {
   // 1: take the whole line of the 1D-Vector and remove unwanted characters.
   // 2: seperate the name e.g. key<AD06> from the shiftstates
   // 3: convert to KMX_DWORD
@@ -500,7 +500,7 @@ int split_US_To_3D_Vector(vec_dword_3D &all_US,vec_string_1D completeList) {
   }
   all_US.push_back(shift_states);
 
-  if ( all_US.size() == 0) {
+  if (all_US.size() == 0) {
     wprintf(L"ERROR: Can't split US to 3D-Vector\n");
     return 1;
   }
@@ -522,30 +522,30 @@ vec_dword_2D create_empty_2D_Vector( int dim_rows,int dim_ss) {
   return vector_2D;
 }
 
-int append_underlying_ToVector(vec_dword_3D &All_Vector,GdkKeymap *keymap) {
+int append_underlying_ToVector(vec_dword_3D& all_vector,GdkKeymap *keymap) {
 
   // create a 2D vector all filled with " " and push to 3D-Vector
-  vec_dword_2D underlying_Vector2D = create_empty_2D_Vector(All_Vector[0].size(),All_Vector[0][0].size());
+  vec_dword_2D underlying_Vector2D = create_empty_2D_Vector(all_vector[0].size(),all_vector[0][0].size());
 
   if (underlying_Vector2D.size() == 0) {
     wprintf(L"ERROR: can't create empty 2D-Vector\n");
     return 1;
   }
-  All_Vector.push_back(underlying_Vector2D);
+  all_vector.push_back(underlying_Vector2D);
 
-  if (All_Vector.size() < 2) {
+  if (all_vector.size() < 2) {
     wprintf(L"ERROR: creation of 3D-Vector failed\n");
     return 1;
   }
 
-  for(int i =0; i< (int) All_Vector[1].size();i++) {
+  for(int i =0; i< (int) all_vector[1].size();i++) {
 
     // get key name US stored in [0][i][0] and copy to name in "underlying"-block[1][i][0]
-    All_Vector[1][i][0] = All_Vector[0][i][0];
+    all_vector[1][i][0] = all_vector[0][i][0];
 
     // get Keyvals of this key and copy to unshifted/shifted in "underlying"-block[1][i][1] / block[1][i][2]
-    All_Vector[1][i][0+1] = KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(keymap,All_Vector[0][i][0],0);   //shift state: unshifted:0
-    All_Vector[1][i][1+1] = KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(keymap,All_Vector[0][i][0],1);   //shift state: shifted:1
+    all_vector[1][i][0+1] = KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(keymap,all_vector[0][i][0],0);   //shift state: unshifted:0
+    all_vector[1][i][1+1] = KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(keymap,all_vector[0][i][0],1);   //shift state: shifted:1
   }
 
   return 0;
@@ -583,9 +583,9 @@ std::u16string convert_DeadkeyValues_To_U16str(int in) {
   if (in == 0 )
     return u"\0";
 
-  std::string long_name((const char*) gdk_keyval_name (in));                      // e.g. "dead_circumflex" , "U+017F" , "t"
+  std::string long_name((const char*) gdk_keyval_name (in));                      // e.g. "dead_circumflex",  "U+017F",  "t"
 
-  if ( long_name.substr (0,2) == "U+" )                                           // U+... Unicode value
+  if (long_name.substr (0,2) == "U+" )                                           // U+... Unicode value
     return  CodePointToU16String(in-0x1000000);                                   // GDK's gdk_keymap_translate_keyboard_state() returns (Keyvalue | 0x01000000)
                                                                                   // since we never have a carry-over we can just subtract 0x01000000
   if (in < (int) deadkey_min) {                                                   // no deadkey; no Unicode
@@ -614,7 +614,7 @@ int KMX_get_KeyVal_From_KeyCode(GdkKeymap *keymap, guint keycode, ShiftState ss,
   //BASE (shiftstate: 0)
   if (( ss == Base ) && ( caps == 0 )) {
     GdkModifierType MOD_base = (GdkModifierType) ( ~GDK_MODIFIER_MASK );
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_base , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_base,  0, keyvals, NULL, NULL, & consumed);
   }
 
   //BASE + CAPS (shiftstate: 0)
@@ -626,61 +626,61 @@ int KMX_get_KeyVal_From_KeyCode(GdkKeymap *keymap, guint keycode, ShiftState ss,
   //SHIFT (shiftstate: 1)
   else if (( ss == Shft ) && ( caps == 0 )) {
     GdkModifierType MOD_Shift = (GdkModifierType) ( GDK_SHIFT_MASK );
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_Shift , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_Shift,  0, keyvals, NULL, NULL, & consumed);
   }
 
   //SHIFT + CAPS (shiftstate: 1)
-  else if ( ( ss == Shft ) && ( caps ==1 )) {
+  else if (( ss == Shft ) && ( caps ==1 )) {
     GdkModifierType MOD_ShiftCaps= (GdkModifierType) ((GDK_SHIFT_MASK | GDK_LOCK_MASK));
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_ShiftCaps , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_ShiftCaps,  0, keyvals, NULL, NULL, & consumed);
   }
 
   // Ctrl (shiftstate: 2)
   else if (( ss == Ctrl ) && ( caps == 0 )){
     GdkModifierType MOD_Ctrl = (GdkModifierType) ( GDK_MOD5_MASK  );
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_Ctrl , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_Ctrl,  0, keyvals, NULL, NULL, & consumed);
   }
 
   // Ctrl + CAPS  (shiftstate: 2)
   else if (( ss == Ctrl ) && ( caps == 1 )){
     GdkModifierType MOD_CtrlCaps = (GdkModifierType) (GDK_MOD5_MASK | GDK_LOCK_MASK);
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_CtrlCaps , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_CtrlCaps,  0, keyvals, NULL, NULL, & consumed);
   }
 
   // SHIFT+Ctrl (shiftstate: 3)
   else if (( ss == ShftCtrl ) && ( caps == 0 )){
     GdkModifierType MOD_Ctrl = (GdkModifierType) (GDK_SHIFT_MASK |  GDK_MOD5_MASK  );
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_Ctrl , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_Ctrl,  0, keyvals, NULL, NULL, & consumed);
   }
 
   // SHIFT+Ctrl + CAPS  (shiftstate: 3)
   else if (( ss == ShftCtrl ) && ( caps == 1 )){
     GdkModifierType MOD_CtrlCaps = (GdkModifierType) ( GDK_SHIFT_MASK | GDK_MOD5_MASK | GDK_LOCK_MASK);
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_CtrlCaps , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_CtrlCaps,  0, keyvals, NULL, NULL, & consumed);
   }
 
   //ALT-GR (shiftstate: 6)
   else if (( ss == MenuCtrl ) && ( caps == 0 )){
     GdkModifierType MOD_AltGr = (GdkModifierType) (GDK_MOD2_MASK | GDK_MOD5_MASK);
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_AltGr , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_AltGr,  0, keyvals, NULL, NULL, & consumed);
   }
 
   //ALT-GR + CAPS (shiftstate: 6)
   else if (( ss == MenuCtrl ) && ( caps == 1 )){
     GdkModifierType MOD_AltGr = (GdkModifierType) (GDK_MOD2_MASK | GDK_MOD5_MASK | GDK_LOCK_MASK);
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_AltGr , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_AltGr,  0, keyvals, NULL, NULL, & consumed);
   }
 
   //ALT-GR (shiftstate: 7)
   else if (( ss == ShftMenuCtrl ) && ( caps == 0 )){
     GdkModifierType MOD_AltGr = (GdkModifierType) ( (GDK_SHIFT_MASK | GDK_MOD2_MASK | GDK_MOD5_MASK) );
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_AltGr , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_AltGr,  0, keyvals, NULL, NULL, & consumed);
   }
 
   //ALT-GR +CAPS (shiftstate: 7)
   else if (( ss == ShftMenuCtrl ) && ( caps == 1 )){
     GdkModifierType MOD_AltGr = (GdkModifierType) ( (GDK_SHIFT_MASK | GDK_MOD2_MASK | GDK_MOD5_MASK | GDK_LOCK_MASK) );
-    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_AltGr , 0, keyvals, NULL, NULL, & consumed);
+    gdk_keymap_translate_keyboard_state (keymap, keycode, MOD_AltGr,  0, keyvals, NULL, NULL, & consumed);
   }
   else
     return 0;
@@ -738,18 +738,18 @@ KMX_DWORD KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(GdkKeymap *keymap, UIN
     *deadkey = *dky;
     return 0xFFFF;
   }
-  else if((keyV >  deadkey_max) || ((keyV <  deadkey_min)  &&  ( keyV > 0xFF)))             // out of range
+  else if ((keyV >  deadkey_max) || ((keyV <  deadkey_min)  &&  ( keyV > 0xFF)))             // out of range
     return 0xFFFE;
   else                                                                                      // usable char
     return keyV;
 }
 //_S2 vk_us or underlying!!"!!"
-KMX_WCHAR KMX_get_KeyValUnderlying_From_KeyValUS(vec_dword_3D & All_Vector, KMX_DWORD vk_US) {
+KMX_WCHAR KMX_get_KeyValUnderlying_From_KeyValUS(vec_dword_3D & all_vector, KMX_DWORD vk_US) {
   KMX_DWORD vk_underlying;
-  for( int i=0; i< (int)All_Vector[0].size()-1 ;i++) {
-    for( int j=1; j< (int)All_Vector[0][0].size();j++) {
-      if ( ( All_Vector[0][i][j] == vk_US ) ) {
-        vk_underlying = All_Vector[1][i][j];
+  for( int i=0; i< (int)all_vector[0].size()-1 ;i++) {
+    for( int j=1; j< (int)all_vector[0][0].size();j++) {
+      if (( all_vector[0][i][j] == vk_US ) ) {
+        vk_underlying = all_vector[1][i][j];
         return vk_underlying;
       }
     }
@@ -757,14 +757,14 @@ KMX_WCHAR KMX_get_KeyValUnderlying_From_KeyValUS(vec_dword_3D & All_Vector, KMX_
   return vk_US;
 }
 
-KMX_DWORD KMX_get_KeyCodeUnderlying_From_KeyCodeUS(GdkKeymap *keymap, vec_dword_3D &All_Vector, KMX_DWORD kc_us, ShiftState ss, int caps) {
+KMX_DWORD KMX_get_KeyCodeUnderlying_From_KeyCodeUS(GdkKeymap *keymap, vec_dword_3D &all_vector, KMX_DWORD kc_us, ShiftState ss, int caps) {
   KMX_DWORD kc_underlying;
   std::u16string u16str = convert_DeadkeyValues_To_U16str(KMX_get_KeyVal_From_KeyCode(keymap, kc_us, ss, caps));
 
-  for( int i=0; i< (int)All_Vector[1].size()-1 ;i++) {
-    for( int j=1; j< (int)All_Vector[1][0].size();j++) {
-      if ( ( All_Vector[1][i][j] == (KMX_DWORD)  *u16str.c_str() ) ) {
-        kc_underlying = All_Vector[1][i][0];
+  for( int i=0; i< (int)all_vector[1].size()-1 ;i++) {
+    for( int j=1; j< (int)all_vector[1][0].size();j++) {
+      if (( all_vector[1][i][j] == (KMX_DWORD)  *u16str.c_str() ) ) {
+        kc_underlying = all_vector[1][i][0];
         return kc_underlying;
       }
     }
@@ -777,7 +777,7 @@ UINT  KMX_get_KeyCodeUnderlying_From_VKUS(KMX_DWORD virtualKeyUS) {
 }
 
 KMX_DWORD KMX_get_VKUS_From_KeyCodeUnderlying(KMX_DWORD keycode) {
-  if ( keycode >7)
+  if (keycode >7)
     return  (KMX_DWORD) ScanCodeToUSVirtualKey[keycode-8];
 
   return 0;

--- a/linux/mcompile/keymap/keymap.cpp
+++ b/linux/mcompile/keymap/keymap.cpp
@@ -2,12 +2,12 @@
 #include <xkbcommon/xkbcommon.h>
 
 // unmodified, shift, RALT, shift+RALT
-int map_VKShiftState_to_LinModifier(int VKShiftState) {
-  if      (VKShiftState == 0 )      return 0;		/* 0000 0000 */
-  else if (VKShiftState == 16)      return 1;		/* 0001 0000 */
-  else if (VKShiftState == 9 )      return 2;		/* 0000 1001 */
-  else if (VKShiftState == 25)      return 3; 	/* 0001 1001 */
-  else return VKShiftState;
+int map_VKShiftState_to_LinModifier(int vk_ShiftState) {
+  if      (vk_ShiftState == 0 )      return 0;		/* 0000 0000 */
+  else if (vk_ShiftState == 16)      return 1;		/* 0001 0000 */
+  else if (vk_ShiftState == 9 )      return 2;		/* 0000 1001 */
+  else if (vk_ShiftState == 25)      return 3; 	/* 0001 1001 */
+  else return vk_ShiftState;
 }
 
 KMX_DWORD convertNamesTo_DWORD_Value(std::string tok_str) {
@@ -288,10 +288,10 @@ KMX_DWORD convertNamesTo_DWORD_Value(std::string tok_str) {
 				return it->second;
 		}
   }
-  return returnIfCharInvalid;
+  return INVALID_NAME;
 }
 
-int createOneVectorFromBothKeyboards(v_dw_3D &All_Vector,GdkKeymap *keymap) {
+int createOneVectorFromBothKeyboards(vec_dword_3D &All_Vector,GdkKeymap *keymap) {
   // create a 3D-Vector which contains data of the US keyboard and the underlying Keyboard:
   //    All_Vector[  US_Keyboard ]
   //                     [KeyCode_US        ]
@@ -302,10 +302,10 @@ int createOneVectorFromBothKeyboards(v_dw_3D &All_Vector,GdkKeymap *keymap) {
   //                     [Keyval unshifted  ]
   //                     [Keyval shifted    ]
 
-  std::string US_language    = "us";
+  std::string us_language    = "us";
   const char* text_us        = "xkb_symbols \"basic\"";
 
-  if(write_US_ToVector(All_Vector,US_language, text_us)) {
+  if(write_US_ToVector(All_Vector,us_language, text_us)) {
     wprintf(L"ERROR: can't write US to Vector \n");
     return 1;
   }
@@ -318,11 +318,11 @@ int createOneVectorFromBothKeyboards(v_dw_3D &All_Vector,GdkKeymap *keymap) {
   return 0;
 }
 
-int write_US_ToVector( v_dw_3D &vec,std::string language, const char* text) {
+int write_US_ToVector( vec_dword_3D &vec,std::string language, const char* section ) {
 
-  std::string FullPathName = "/usr/share/X11/xkb/symbols/" + language;
+  std::string fullPathName = "/usr/share/X11/xkb/symbols/" + language;
 
-  const char* path = FullPathName.c_str();
+  const char* path = fullPathName.c_str();
   FILE* fp = fopen((path), "r");
   if ( !fp) {
     wprintf(L"ERROR: could not open file!\n");
@@ -330,14 +330,14 @@ int write_US_ToVector( v_dw_3D &vec,std::string language, const char* text) {
   }
 
   // create 1D-vector of the complete line
-  v_str_1D Vector_completeUS;
-  if( createCompleteRow_US(Vector_completeUS,fp , text, language)) {
+  vec_string_1D vector_completeUS;
+  if( createCompleteVector_US(fp, section , vector_completeUS)) {
     wprintf(L"ERROR: can't Create complete row US \n");
     return 1;
   }
 
   // split contents of 1D Vector to 3D vector
-  if( split_US_To_3D_Vector( vec,Vector_completeUS)) {
+  if( split_US_To_3D_Vector( vec,vector_completeUS)) {
     return 1;
   }
 
@@ -345,32 +345,32 @@ int write_US_ToVector( v_dw_3D &vec,std::string language, const char* text) {
   return 0;
 }
 
-bool createCompleteRow_US(v_str_1D &complete_List, FILE* fp, const char* text, std::string language) {
+bool createCompleteVector_US(FILE* fp, const char* section , vec_string_1D &complete_List) {
   // in the Configuration file we find the appopriate paragraph between "xkb_symbol <text>" and the next xkb_symbol
   // and then copy all rows starting with "key <" to a 1D-Vector
 
   int buffer_size = 512;
-  char buffer[buffer_size];
+  char line[buffer_size];
   bool create_row   = false;
   const char* key = "key <";
-  std::string str_txt(text);
+  std::string str_us_kbd_name(section );
   std::string xbk_mark = "xkb_symbol";
 
   if (fp) {
-    while (fgets(buffer, buffer_size, fp) != NULL) {
-      std::string str_buf(buffer);
+    while (fgets(line, buffer_size, fp) != NULL) {
+      std::string str_buf(line);
 
       // stop when finding the mark xkb_symbol
       if (std::string(str_buf).find(xbk_mark) != std::string::npos)
         create_row = false;
 
       // start when finding the mark xkb_symbol + correct layout
-      if (std::string(str_buf).find(str_txt) != std::string::npos)
+      if (std::string(str_buf).find(str_us_kbd_name) != std::string::npos)
         create_row = true;
 
       // as long as we are in the same xkb_symbol layout block and find "key <" we push the whole line into a 1D-vector
       if (create_row && (std::string(str_buf).find(key) != std::string::npos)) {
-        complete_List.push_back(buffer);
+        complete_List.push_back(line);
       }
     }
   }
@@ -384,7 +384,7 @@ bool createCompleteRow_US(v_str_1D &complete_List, FILE* fp, const char* text, s
 }
 
 int replace_KeyName_with_Keycode(std::string  in) {
-  int out = returnIfCharInvalid;
+  int out = INVALID_NAME;
 
   if      ( in == "key<TLDE>")    out = 49;    /* VK_ BKQUOTE         */
   else if ( in == "key<AE01>")    out = 10;    /* VK_1                */
@@ -442,7 +442,7 @@ int replace_KeyName_with_Keycode(std::string  in) {
   return out;
 }
 
-int split_US_To_3D_Vector(v_dw_3D &all_US,v_str_1D completeList) {
+int split_US_To_3D_Vector(vec_dword_3D &all_US,vec_string_1D completeList) {
   // 1: take the whole line of the 1D-Vector and remove unwanted characters.
   // 2: seperate the name e.g. key<AD06> from the shiftstates
   // 3: convert to KMX_DWORD
@@ -451,10 +451,10 @@ int split_US_To_3D_Vector(v_dw_3D &all_US,v_str_1D completeList) {
   std::vector<char> delim{' ', '[', ']', '}', ';', '\t', '\n'};
   char split_bracel = '{';
   char split_comma  = ',';
-  int Keycde;
-  v_str_1D tokens;
-  v_dw_1D tokens_dw;
-  v_dw_2D shift_states;
+  int keyCode;
+  vec_string_1D tokens;
+  vec_dword_1D tokens_dw;
+  vec_dword_2D shift_states;
   KMX_DWORD tokens_int;
 
   // loop through the whole vector
@@ -469,21 +469,23 @@ int split_US_To_3D_Vector(v_dw_3D &all_US,v_str_1D completeList) {
     if (completeList[k].find("key<") != std::string::npos) {
 
       //split off the key names
-      std::istringstream split1(completeList[k]);
-      for (std::string each; std::getline(split1, each, split_bracel); tokens.push_back(each));
+      std::istringstream split_Keyname(completeList[k]);
+      for (std::string each; std::getline(split_Keyname, each, split_bracel); tokens.push_back(each)) {
+          // empty
+      }
 
       // replace keys names with Keycode (<AD06> with 21,...)
-      Keycde = replace_KeyName_with_Keycode(tokens[0]);
-      tokens[0] = std::to_string(Keycde);
+      keyCode = replace_KeyName_with_Keycode(tokens[0]);
+      tokens[0] = std::to_string(keyCode);
 
       // seperate rest of the vector to its elements and push to 'tokens'
-      std::istringstream split(tokens[1]);
+      std::istringstream split_Characters(tokens[1]);
       tokens.pop_back();
 
-      for (std::string each; std::getline(split, each, split_comma); tokens.push_back(each));
+      for (std::string each; std::getline(split_Characters, each, split_comma); tokens.push_back(each));
 
       // now convert all to KMX_DWORD and fill tokens
-      tokens_dw.push_back((KMX_DWORD) Keycde);
+      tokens_dw.push_back((KMX_DWORD) keyCode);
 
       for ( int i = 1; i< (int) tokens.size();i++) {
         // replace a name with a single character ( a -> a  ; equal -> = )
@@ -505,25 +507,25 @@ int split_US_To_3D_Vector(v_dw_3D &all_US,v_str_1D completeList) {
   return 0;
 }
 
-v_dw_2D create_empty_2D_Vector( int dim_rows,int dim_ss) {
+vec_dword_2D create_empty_2D_Vector( int dim_rows,int dim_ss) {
 
-  v_dw_1D shifts;
-  v_dw_2D Vector_2D;
+  vec_dword_1D shifts;
+  vec_dword_2D vector_2D;
 
   for ( int i=0; i< dim_rows;i++) {
     for ( int j=0; j< dim_ss;j++) {
-      shifts.push_back(returnIfCharInvalid);
+      shifts.push_back(INVALID_NAME);
     }
-    Vector_2D.push_back(shifts);
+    vector_2D.push_back(shifts);
     shifts.clear();
   }
-  return Vector_2D;
+  return vector_2D;
 }
 
-int append_underlying_ToVector(v_dw_3D &All_Vector,GdkKeymap *keymap) {
+int append_underlying_ToVector(vec_dword_3D &All_Vector,GdkKeymap *keymap) {
 
   // create a 2D vector all filled with " " and push to 3D-Vector
-  v_dw_2D underlying_Vector2D = create_empty_2D_Vector(All_Vector[0].size(),All_Vector[0][0].size());
+  vec_dword_2D underlying_Vector2D = create_empty_2D_Vector(All_Vector[0].size(),All_Vector[0][0].size());
 
   if (underlying_Vector2D.size() == 0) {
     wprintf(L"ERROR: can't create empty 2D-Vector\n");
@@ -584,15 +586,15 @@ std::u16string convert_DeadkeyValues_To_U16str(int in) {
   std::string long_name((const char*) gdk_keyval_name (in));                      // e.g. "dead_circumflex" , "U+017F" , "t"
 
   if ( long_name.substr (0,2) == "U+" )                                           // U+... Unicode value
-    return  CodePointToU16String(in-0x1000000);
-
+    return  CodePointToU16String(in-0x1000000);                                   // GDK's gdk_keymap_translate_keyboard_state() returns (Keyvalue | 0x01000000)
+                                                                                  // since we never have a carry-over we can just subtract 0x01000000
   if (in < (int) deadkey_min) {                                                   // no deadkey; no Unicode
     return  std::u16string(1, in);
   }
 
   KMX_DWORD lname = convertNamesTo_DWORD_Value(long_name);                        // 65106 => "dead_circumflex" => 94 => "^"
 
-  if (lname != returnIfCharInvalid) {
+  if (lname != INVALID_NAME) {
     return std::u16string(1, lname );
   }
   else
@@ -690,7 +692,7 @@ KMX_DWORD KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(GdkKeymap *keymap, gui
   GdkKeymapKey *maps;
   guint *keyvals;
   gint count;
-  KMX_DWORD KVal;
+  KMX_DWORD kVal;
 
   if (!gdk_keymap_get_entries_for_keycode(keymap, keycode, &maps, &keyvals, &count))
     return 0;
@@ -701,15 +703,15 @@ KMX_DWORD KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(GdkKeymap *keymap, gui
    if (!(keycode <= keycode_max))
     return 0;
 
-  KVal = (KMX_DWORD) KMX_get_KeyVal_From_KeyCode(keymap, keycode, (ShiftState) shift_state_pos, 0);
+  kVal = (KMX_DWORD) KMX_get_KeyVal_From_KeyCode(keymap, keycode, (ShiftState) shift_state_pos, 0);
 
   g_free(keyvals);
   g_free(maps);
 
-  return KVal;
+  return kVal;
 }
 
-KMX_DWORD KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(GdkKeymap *keymap, UINT VKShiftState, UINT KC_underlying, PKMX_WCHAR DeadKey) {
+KMX_DWORD KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(GdkKeymap *keymap, UINT vk_ShiftState, UINT kc_underlying, PKMX_WCHAR deadkey) {
 
   GdkKeymapKey *maps;
   guint *keyvals;
@@ -717,61 +719,61 @@ KMX_DWORD KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(GdkKeymap *keymap, UIN
   PKMX_WCHAR dky=NULL;
 
 
-  if (!gdk_keymap_get_entries_for_keycode(keymap, KC_underlying, &maps, &keyvals, &count))
+  if (!gdk_keymap_get_entries_for_keycode(keymap, kc_underlying, &maps, &keyvals, &count))
     return 0;
 
-  if (!(map_VKShiftState_to_LinModifier(VKShiftState) <= count))
+  if (!(map_VKShiftState_to_LinModifier(vk_ShiftState) <= count))
   return 0;
 
-  if (!(KC_underlying <= keycode_max))
+  if (!(kc_underlying <= keycode_max))
     return 0;
 
-  KMX_DWORD KeyV = KMX_get_KeyVal_From_KeyCode(keymap, KC_underlying, ShiftState(map_VKShiftState_to_LinModifier(VKShiftState)), 0);
+  KMX_DWORD keyV = KMX_get_KeyVal_From_KeyCode(keymap, kc_underlying, ShiftState(map_VKShiftState_to_LinModifier(vk_ShiftState)), 0);
 
   g_free(keyvals);
   g_free(maps);
 
-  if ((KeyV >= deadkey_min) && (KeyV <= deadkey_max) ){                                     // deadkey
-    dky = (PKMX_WCHAR) (convert_DeadkeyValues_To_U16str((int) KeyV)).c_str();
-    *DeadKey = *dky;
+  if ((keyV >= deadkey_min) && (keyV <= deadkey_max) ){                                     // deadkey
+    dky = (PKMX_WCHAR) (convert_DeadkeyValues_To_U16str((int) keyV)).c_str();
+    *deadkey = *dky;
     return 0xFFFF;
   }
-  else if((KeyV >  deadkey_max) || ((KeyV <  deadkey_min)  &&  ( KeyV > 0xFF)))             // out of range
+  else if((keyV >  deadkey_max) || ((keyV <  deadkey_min)  &&  ( keyV > 0xFF)))             // out of range
     return 0xFFFE;
   else                                                                                      // usable char
-    return KeyV;
+    return keyV;
 }
-
-KMX_WCHAR KMX_get_KeyValUnderlying_From_KeyValUS(v_dw_3D & All_Vector, KMX_DWORD VK_US) {
-  KMX_DWORD VK_underlying;
+//_S2 vk_us or underlying!!"!!"
+KMX_WCHAR KMX_get_KeyValUnderlying_From_KeyValUS(vec_dword_3D & All_Vector, KMX_DWORD vk_US) {
+  KMX_DWORD vk_underlying;
   for( int i=0; i< (int)All_Vector[0].size()-1 ;i++) {
     for( int j=1; j< (int)All_Vector[0][0].size();j++) {
-      if ( ( All_Vector[0][i][j] == VK_US ) ) {
-        VK_underlying = All_Vector[1][i][j];
-        return VK_underlying;
+      if ( ( All_Vector[0][i][j] == vk_US ) ) {
+        vk_underlying = All_Vector[1][i][j];
+        return vk_underlying;
       }
     }
   }
-  return VK_US;
+  return vk_US;
 }
 
-KMX_DWORD KMX_get_KeyCodeUnderlying_From_KeyCodeUS(GdkKeymap *keymap, v_dw_3D &All_Vector, KMX_DWORD KC_US, ShiftState ss, int caps) {
-  KMX_DWORD KC_underlying;
-  std::u16string u16str = convert_DeadkeyValues_To_U16str(KMX_get_KeyVal_From_KeyCode(keymap, KC_US, ss, caps));
+KMX_DWORD KMX_get_KeyCodeUnderlying_From_KeyCodeUS(GdkKeymap *keymap, vec_dword_3D &All_Vector, KMX_DWORD kc_us, ShiftState ss, int caps) {
+  KMX_DWORD kc_underlying;
+  std::u16string u16str = convert_DeadkeyValues_To_U16str(KMX_get_KeyVal_From_KeyCode(keymap, kc_us, ss, caps));
 
   for( int i=0; i< (int)All_Vector[1].size()-1 ;i++) {
     for( int j=1; j< (int)All_Vector[1][0].size();j++) {
       if ( ( All_Vector[1][i][j] == (KMX_DWORD)  *u16str.c_str() ) ) {
-        KC_underlying = All_Vector[1][i][0];
-        return KC_underlying;
+        kc_underlying = All_Vector[1][i][0];
+        return kc_underlying;
       }
     }
   }
-  return KC_US;
+  return kc_us;
 }
 
-UINT  KMX_get_KeyCodeUnderlying_From_VKUS(KMX_DWORD VirtualKeyUS) {
-  return (8 + USVirtualKeyToScanCode[VirtualKeyUS]);
+UINT  KMX_get_KeyCodeUnderlying_From_VKUS(KMX_DWORD virtualKeyUS) {
+  return (8 + USVirtualKeyToScanCode[virtualKeyUS]);
 }
 
 KMX_DWORD KMX_get_VKUS_From_KeyCodeUnderlying(KMX_DWORD keycode) {

--- a/linux/mcompile/keymap/keymap.h
+++ b/linux/mcompile/keymap/keymap.h
@@ -57,17 +57,16 @@ const KMX_DWORD KMX_VKMap[] = {
   0
 };
 
-typedef std::vector<std::string> v_str_1D;
+typedef std::vector<std::string> vec_string_1D;
 
-typedef std::vector<KMX_DWORD> v_dw_1D;
-typedef std::vector<std::vector<KMX_DWORD> > v_dw_2D;
-typedef std::vector<std::vector<std::vector<KMX_DWORD> > > v_dw_3D;
+typedef std::vector<KMX_DWORD> vec_dword_1D;
+typedef std::vector<std::vector<KMX_DWORD> > vec_dword_2D;
+typedef std::vector<std::vector<std::vector<KMX_DWORD> > > vec_dword_3D;
 
-static KMX_DWORD returnIfCharInvalid = 0;
+static KMX_DWORD INVALID_NAME = 0;
 static KMX_DWORD keycode_max = 94;
-static KMX_DWORD deadkey_min = 0xfe50;
-static KMX_DWORD deadkey_max = 0xfe93;
-//static KMX_DWORD deadkey_max = 0xfe52;  // _S2 TOP_6 TODO This has to go! my test: to only return 3 dk
+static KMX_DWORD deadkey_min = 0xfe50;		// X11's keysymdef.h defines deadkeys between 0xfe50-0xfe93
+static KMX_DWORD deadkey_max = 0xfe93;		// https://fossies.org/linux/tk/xlib/X11/keysymdef.h
 
 // map Shiftstate to modifier (e.g. 0->0; 16-1; 9->2; 25->3)
 int map_VKShiftState_to_LinModifier(int VKShiftState);
@@ -76,25 +75,25 @@ int map_VKShiftState_to_LinModifier(int VKShiftState);
 KMX_DWORD convertNamesTo_DWORD_Value(std::string tok_str);
 
 // create a Vector with all entries of both keymaps
-int createOneVectorFromBothKeyboards(v_dw_3D &All_Vector,GdkKeymap *keymap);
+int createOneVectorFromBothKeyboards(vec_dword_3D &All_Vector,GdkKeymap *keymap);
 
 // read configuration file, split and write to 3D-Vector (Data for US on Vector[0][ ][ ]  )
-int write_US_ToVector(v_dw_3D &vec, std::string language, const char *text);
+int write_US_ToVector(vec_dword_3D &vec, std::string language, const char *text);
 
 // 1. step: read complete Row of Configuration file US
-bool createCompleteRow_US(v_str_1D &complete_List, FILE *fpp, const char *text, std::string language);
+bool createCompleteVector_US(FILE *fpp, const char *text, vec_string_1D &complete_List);
 
 // replace Name of Key (e.g. <AD06>)  wih Keycode ( e.g. 15 )
 int replace_KeyName_with_Keycode(std::string  in);
 
 // 2. step: write contents to 3D vector
-int split_US_To_3D_Vector(v_dw_3D &all_US, v_str_1D completeList);
+int split_US_To_3D_Vector(vec_dword_3D &all_US, vec_string_1D completeList);
 
 // create an empty 2D vector containing 0 in all fields
-v_dw_2D create_empty_2D_Vector(int dim_rows, int dim_shifts);
+vec_dword_2D create_empty_2D_Vector(int dim_rows, int dim_shifts);
 
 // append characters to 3D-Vector using GDK (Data for underlying Language on Vector[1][ ][ ]  )
-int append_underlying_ToVector(v_dw_3D &All_Vector, GdkKeymap *keymap);
+int append_underlying_ToVector(vec_dword_3D &All_Vector, GdkKeymap *keymap);
 
 // initialize GDK
 bool InitializeGDK(GdkKeymap **keymap,int argc, gchar *argv[]);
@@ -512,16 +511,16 @@ int KMX_get_KeyVal_From_KeyCode(GdkKeymap *keymap, guint keycode, ShiftState ss,
 KMX_DWORD KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(GdkKeymap *keymap, guint keycode, int shift_state_pos);
 
 // fill Deadkey with dk and return CATEGORY
-KMX_DWORD KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(GdkKeymap *keymap, UINT VKShiftState, UINT KC_underlying, PKMX_WCHAR DeadKey);
+KMX_DWORD KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(GdkKeymap *keymap, UINT vk_ShiftState, UINT kc_underlying, PKMX_WCHAR deadkey);
 
 // use Vector to return the Keyval of underlying Keyboard
-KMX_WCHAR KMX_get_KeyValUnderlying_From_KeyValUS(v_dw_3D &All_Vector,KMX_DWORD VK_underlying);
+KMX_WCHAR KMX_get_KeyValUnderlying_From_KeyValUS(vec_dword_3D &All_Vector,KMX_DWORD VK_underlying);
 
 // use Vector to return the Keycode of the underlying Keyboard for given VK_US using GDK
-KMX_DWORD KMX_get_KeyCodeUnderlying_From_KeyCodeUS(GdkKeymap *keymap, v_dw_3D &All_Vector,KMX_DWORD KC_US, ShiftState ss, int caps);
+KMX_DWORD KMX_get_KeyCodeUnderlying_From_KeyCodeUS(GdkKeymap *keymap, vec_dword_3D &All_Vector,KMX_DWORD kc_us, ShiftState ss, int caps);
 
 // return the Keycode of the underlying Keyboard for given VK_US
-UINT KMX_get_KeyCodeUnderlying_From_VKUS(KMX_DWORD VirtualKeyUS);
+UINT KMX_get_KeyCodeUnderlying_From_VKUS(KMX_DWORD virtualKeyUS);
 
 // return the VirtualKey of the US Keyboard for a given Keyode using GDK
 KMX_DWORD KMX_get_VKUS_From_KeyCodeUnderlying(KMX_DWORD keycode);

--- a/linux/mcompile/keymap/mc_import_rules.cpp
+++ b/linux/mcompile/keymap/mc_import_rules.cpp
@@ -241,7 +241,7 @@ public:
     return nkeys;
   }
 
-  bool KMX_LayoutRow(int MaxShiftState, LPKMX_KEY key, std::vector<DeadKey*> *deadkeys, int deadkeyBase, BOOL bDeadkeyConversion,vec_dword_3D &All_Vector, GdkKeymap *keymap) {   // I4552
+  bool KMX_LayoutRow(int MaxShiftState, LPKMX_KEY key, std::vector<DeadKey*> *deadkeys, int deadkeyBase, BOOL bDeadkeyConversion,vec_dword_3D& all_vector, GdkKeymap *keymap) {   // I4552
     // Get the CAPSLOCK value
    int capslock =
         (this->KMX_IsCapsEqualToShift() ? 1 : 0) |
@@ -301,7 +301,7 @@ public:
             // key->Key      stores VK-US ( not underlying !!)
             // key->dpOutput stores character Underlying
 
-            KMX_DWORD SC_Underlying = KMX_get_KeyCodeUnderlying_From_KeyCodeUS(keymap, All_Vector, this->SC(), (ShiftState) ss, caps);
+            KMX_DWORD SC_Underlying = KMX_get_KeyCodeUnderlying_From_KeyCodeUS(keymap, all_vector, this->SC(), (ShiftState) ss, caps);
             key->Key = KMX_get_VKUS_From_KeyCodeUnderlying( SC_Underlying);
 
             key->Line = 0;
@@ -362,7 +362,7 @@ int KMX_GetMaxDeadkeyIndex(KMX_WCHAR *p) {
   return n;
 }
 
-bool KMX_ImportRules(LPKMX_KEYBOARD kp,vec_dword_3D  &All_Vector, GdkKeymap **keymap, std::vector<KMX_DeadkeyMapping> *FDeadkeys, KMX_BOOL bDeadkeyConversion) {   // I4353   // I4552
+bool KMX_ImportRules(LPKMX_KEYBOARD kp, vec_dword_3D& all_vector, GdkKeymap **keymap, std::vector<KMX_DeadkeyMapping> *FDeadkeys, KMX_BOOL bDeadkeyConversion) {   // I4353   // I4552
   KMX_Loader loader;
 
   std::vector<KMX_VirtualKey*> rgKey; //= new VirtualKey[256];
@@ -380,7 +380,7 @@ bool KMX_ImportRules(LPKMX_KEYBOARD kp,vec_dword_3D  &All_Vector, GdkKeymap **ke
     // ( mcompile win uses MapVirtualKeyEx() to fill m_vk with the VK of the Underlying keyboard)
     // Linux can get a VK for the US Keyboard using USVirtualKeyToScanCode/ScanCodeToUSVirtualKey
     // Linux cannot get a VK for the underling Keyboard
-    // this "connection" is possible only when using All_Vector
+    // this "connection" is possible only when using all_vector
 
     KMX_VirtualKey *key = new KMX_VirtualKey(sc);
 
@@ -409,9 +409,9 @@ bool KMX_ImportRules(LPKMX_KEYBOARD kp,vec_dword_3D  &All_Vector, GdkKeymap **ke
           }
 
           //_S2 TOP_6 TODO to compare win-lin kmn-files skip ss6+7; MUST BE removed later!!!!
-         /*if(ss == MenuCtrl|| ss == ShftMenuCtrl) {
+         if(ss == MenuCtrl|| ss == ShftMenuCtrl) {
             continue;
-          }*/
+          }
 
           KMX_DWORD kc_us = (KMX_DWORD) KMX_get_KeyCodeUnderlying_From_VKUS(iKey);
 
@@ -423,7 +423,7 @@ bool KMX_ImportRules(LPKMX_KEYBOARD kp,vec_dword_3D  &All_Vector, GdkKeymap **ke
                 rgKey[iKey]->KMX_SetShiftState(ss, u"", false, (caps));       // different to windows since behavior on Linux is different
               }
               else {
-                if( (ss == Ctrl || ss == ShftCtrl) ) {
+                if ((ss == Ctrl || ss == ShftCtrl) ) {
                 continue;
               }
               sbBuffer[rc] = 0;
@@ -432,7 +432,7 @@ bool KMX_ImportRules(LPKMX_KEYBOARD kp,vec_dword_3D  &All_Vector, GdkKeymap **ke
           }
           else if(rc < 0) {
             sbBuffer[2] = 0;
-            rgKey[iKey]->KMX_SetShiftState(ss, sbBuffer, true, (caps ));      // different to windows since behavior on Linux is different
+            rgKey[iKey]->KMX_SetShiftState(ss, sbBuffer, true, (caps));      // different to windows since behavior on Linux is different
 
             refine_alDead(sbBuffer[0], alDead, &alDead_cpl);
           }
@@ -498,7 +498,7 @@ bool KMX_ImportRules(LPKMX_KEYBOARD kp,vec_dword_3D  &All_Vector, GdkKeymap **ke
   //
   for (UINT iKey = 0; iKey < rgKey.size(); iKey++) {
     if ((rgKey[iKey] != NULL) && rgKey[iKey]->KMX_IsKeymanUsedKey() && (!rgKey[iKey]->KMX_IsEmpty())) {
-      if(rgKey[iKey]->KMX_LayoutRow(loader.KMX_MaxShiftState(), &gp->dpKeyArray[nkeys], &alDead, nDeadkey, bDeadkeyConversion, All_Vector,*keymap)) {   // I4552
+      if(rgKey[iKey]->KMX_LayoutRow(loader.KMX_MaxShiftState(), &gp->dpKeyArray[nkeys], &alDead, nDeadkey, bDeadkeyConversion, all_vector,*keymap)) {   // I4552
         nkeys+=rgKey[iKey]->KMX_GetKeyCount(loader.KMX_MaxShiftState());
       }
     }

--- a/linux/mcompile/keymap/mc_import_rules.cpp
+++ b/linux/mcompile/keymap/mc_import_rules.cpp
@@ -76,17 +76,17 @@ int KMX_ToUnicodeEx(guint keycode, PKMX_WCHAR pwszBuff, int shift_state_pos, int
   if (!(keycode <= keycode_max))
     return 0;
 
-  KMX_DWORD KeyVal= (KMX_DWORD) KMX_get_KeyVal_From_KeyCode(keymap, keycode, ShiftState(shift_state_pos), caps);
-  std::u16string str = convert_DeadkeyValues_To_U16str(KeyVal);
+  KMX_DWORD keyVal= (KMX_DWORD) KMX_get_KeyVal_From_KeyCode(keymap, keycode, ShiftState(shift_state_pos), caps);
+  std::u16string str = convert_DeadkeyValues_To_U16str(keyVal);
   pwszBuff[0]= * (PKMX_WCHAR)  str.c_str();
 
 
   g_free(keyvals);
   g_free(maps);
 
-  if((KeyVal >=  deadkey_min) && (KeyVal <=  deadkey_max))          // deadkeys
+  if((keyVal >=  deadkey_min) && (keyVal <=  deadkey_max))          // deadkeys
     return -1;
-  else if(gdk_keyval_to_unicode(KeyVal)  == 0)                      // NO UNICODE
+  else if(gdk_keyval_to_unicode(keyVal)  == 0)                      // NO UNICODE
     return 0;
   else                                                              // usable char
     return 1;
@@ -241,7 +241,7 @@ public:
     return nkeys;
   }
 
-  bool KMX_LayoutRow(int MaxShiftState, LPKMX_KEY key, std::vector<DeadKey*> *deadkeys, int deadkeyBase, BOOL bDeadkeyConversion,v_dw_3D &All_Vector, GdkKeymap *keymap) {   // I4552
+  bool KMX_LayoutRow(int MaxShiftState, LPKMX_KEY key, std::vector<DeadKey*> *deadkeys, int deadkeyBase, BOOL bDeadkeyConversion,vec_dword_3D &All_Vector, GdkKeymap *keymap) {   // I4552
     // Get the CAPSLOCK value
    int capslock =
         (this->KMX_IsCapsEqualToShift() ? 1 : 0) |
@@ -362,12 +362,12 @@ int KMX_GetMaxDeadkeyIndex(KMX_WCHAR *p) {
   return n;
 }
 
-bool KMX_ImportRules(LPKMX_KEYBOARD kp,v_dw_3D  &All_Vector, GdkKeymap **keymap, std::vector<KMX_DeadkeyMapping> *FDeadkeys, KMX_BOOL bDeadkeyConversion) {   // I4353   // I4552
+bool KMX_ImportRules(LPKMX_KEYBOARD kp,vec_dword_3D  &All_Vector, GdkKeymap **keymap, std::vector<KMX_DeadkeyMapping> *FDeadkeys, KMX_BOOL bDeadkeyConversion) {   // I4353   // I4552
   KMX_Loader loader;
 
   std::vector<KMX_VirtualKey*> rgKey; //= new VirtualKey[256];
   std::vector<DeadKey*> alDead;
-  std::vector<DeadKey*> alDead_cpl = create_alDead();
+  std::vector<DeadKey*> alDead_cpl = create_deadkeys_by_basechar();
 
   rgKey.resize(256);
 
@@ -413,10 +413,10 @@ bool KMX_ImportRules(LPKMX_KEYBOARD kp,v_dw_3D  &All_Vector, GdkKeymap **keymap,
             continue;
           }*/
 
-          KMX_DWORD KC_US = (KMX_DWORD) KMX_get_KeyCodeUnderlying_From_VKUS(iKey);
+          KMX_DWORD kc_us = (KMX_DWORD) KMX_get_KeyCodeUnderlying_From_VKUS(iKey);
 
           for(int caps = 0; caps <= 1; caps++) {
-            int rc = KMX_ToUnicodeEx(KC_US, sbBuffer, ss, caps, *keymap);
+            int rc = KMX_ToUnicodeEx(kc_us, sbBuffer, ss, caps, *keymap);
 
             if(rc > 0) {
               if(*sbBuffer == 0) {

--- a/linux/mcompile/keymap/mc_kmxfile.cpp
+++ b/linux/mcompile/keymap/mc_kmxfile.cpp
@@ -21,7 +21,7 @@ KMX_BOOL KMX_SaveKeyboard(LPKMX_KEYBOARD kbd, PKMX_WCHAR filename) {
     return FALSE;
   }
 
-  KMX_DWORD err = KMX_WriteCompiledKeyboard(kbd, fp, FALSE);
+  KMX_DWORD err = KMX_WriteCompiledKeyboardToFile(kbd, fp, FALSE);
   fclose(fp);
 
   if(err != CERR_None) {
@@ -37,7 +37,7 @@ KMX_BOOL KMX_SaveKeyboard(LPKMX_KEYBOARD kbd, PKMX_WCHAR filename) {
   return TRUE;
 }
 
-KMX_DWORD KMX_WriteCompiledKeyboard(LPKMX_KEYBOARD fk, FILE* hOutfile, KMX_BOOL FSaveDebug) {
+KMX_DWORD KMX_WriteCompiledKeyboardToFile(LPKMX_KEYBOARD fk, FILE* hOutfile, KMX_BOOL FSaveDebug) {
 
 	LPKMX_GROUP fgp;
 	LPKMX_STORE fsp;
@@ -102,22 +102,6 @@ KMX_DWORD KMX_WriteCompiledKeyboard(LPKMX_KEYBOARD fk, FILE* hOutfile, KMX_BOOL 
 	ck->dwFlags = fk->dwFlags;
 
 	offset = sizeof(KMX_COMP_KEYBOARD);
-
-	// ck->dpLanguageName = offset;
-	//wcscpy((PWSTR)(buf + offset), fk->szLanguageName);
-	//offset += wcslen(fk->szLanguageName)*2 + 2;
-
-	//ck->dpName = offset;
-	//wcscpy((PWSTR)(buf + offset), fk->szName);
-	//offset += wcslen(fk->szName)*2 + 2;
-
-	//ck->dpCopyright = offset;
-	//wcscpy((PWSTR)(buf + offset), fk->szCopyright);
-	//offset += wcslen(fk->szCopyright)*2 + 2;
-
-	//ck->dpMessage = offset;
-	//wcscpy((PWSTR)(buf + offset), fk->szMessage);
-	//offset += wcslen(fk->szMessage)*2 + 2;
 
 	ck->dpStoreArray = offset;
 	sp = (PKMX_COMP_STORE)(buf+offset);
@@ -196,12 +180,6 @@ KMX_DWORD KMX_WriteCompiledKeyboard(LPKMX_KEYBOARD fk, FILE* hOutfile, KMX_BOOL 
   } else {
     ck->dwBitmapSize = 0;
 	  ck->dpBitmapOffset = 0;
-  }
-
-	if(offset != size)
-  {
-    delete[] buf;
-    return CERR_SomewhereIGotItWrong;
   }
 
   fwrite(buf, size,1,hOutfile);

--- a/linux/mcompile/keymap/mc_kmxfile.cpp
+++ b/linux/mcompile/keymap/mc_kmxfile.cpp
@@ -70,8 +70,8 @@ KMX_DWORD KMX_WriteCompiledKeyboardToFile(LPKMX_KEYBOARD fk, FILE* hOutfile, KMX
 			size += u16len(fkp->dpContext)*2 + 2;
 		}
 
-		if( fgp->dpMatch ) size += u16len(fgp->dpMatch)*2 + 2;
-		if( fgp->dpNoMatch ) size += u16len(fgp->dpNoMatch)*2 + 2;
+		if (fgp->dpMatch ) size += u16len(fgp->dpMatch)*2 + 2;
+		if (fgp->dpNoMatch ) size += u16len(fgp->dpNoMatch)*2 + 2;
 	}
 
 	for(i = 0; i < fk->cxStoreArray; i++)

--- a/linux/mcompile/keymap/mc_kmxfile.h
+++ b/linux/mcompile/keymap/mc_kmxfile.h
@@ -74,7 +74,7 @@ KMX_BOOL KMX_LoadKeyboard(char16_t* fileName, LPKMX_KEYBOARD *lpKeyboard);
 
 KMX_BOOL KMX_SaveKeyboard(LPKMX_KEYBOARD kbd, PKMX_WCHAR filename);
 
-KMX_DWORD KMX_WriteCompiledKeyboard(LPKMX_KEYBOARD fk, FILE* hOutfile, KMX_BOOL FSaveDebug);
+KMX_DWORD KMX_WriteCompiledKeyboardToFile(LPKMX_KEYBOARD fk, FILE* hOutfile, KMX_BOOL FSaveDebug);
 
 #endif // _KMXFILE_H
 

--- a/linux/mcompile/keymap/mcompile.cpp
+++ b/linux/mcompile/keymap/mcompile.cpp
@@ -31,7 +31,7 @@
 
 KMX_BOOL KMX_DoConvert(LPKMX_KEYBOARD kbd, KMX_BOOL bDeadkeyConversion, gint argc, gchar *argv[]);
 
-bool KMX_ImportRules( LPKMX_KEYBOARD kp,v_dw_3D &All_Vector, GdkKeymap **keymap,std::vector<KMX_DeadkeyMapping> *KMX_FDeadkeys, KMX_BOOL bDeadkeyConversion); // I4353   // I4327
+bool KMX_ImportRules( LPKMX_KEYBOARD kp,vec_dword_3D &All_Vector, GdkKeymap **keymap,std::vector<KMX_DeadkeyMapping> *KMX_FDeadkeys, KMX_BOOL bDeadkeyConversion); // I4353   // I4327
 
 std::vector<KMX_DeadkeyMapping> KMX_FDeadkeys; // I4353
 
@@ -67,7 +67,7 @@ int run(int argc, std::vector<std::u16string> str_argv, char* argv_ch[] = NULL){
     wprintf(
         L"Usage: mcompile [-d] infile.kmx outfile.kmx\n"
         L"       mmcompile -u ...  (not available for Linux)\n "
-        L"      mcompile converts a Keyman mnemonic layout to a\n"
+        L"       mcompile converts a Keyman mnemonic layout to a\n"
         L"       positional one based on the Linux keyboard\n"
         L"       layout on top position\n"
         L"       (-d   convert deadkeys to plain keys) not available yet \n\n"
@@ -154,7 +154,7 @@ void KMX_TranslateKey(LPKMX_KEY key, KMX_WORD vk, UINT shift, KMX_WCHAR ch) {
   if(key->ShiftFlags == 0 && key->Key == ch) {
     // Key is a mnemonic key with no shift state defined.
     // Remap the key according to the character on the key cap.
-    //LogError(L"Converted mnemonic rule on line %d, + '%c' TO + [%x K_%d]", key->Line, key->Key, shift, vk);
+    //KMX_LogError(L"Converted mnemonic rule on line %d, + '%c' TO + [%x K_%d]", key->Line, key->Key, shift, vk);
     key->ShiftFlags = ISVIRTUALKEY | shift;
     key->Key = vk;
   } else if(key->ShiftFlags & VIRTUALCHARKEY && key->Key == ch) {
@@ -163,7 +163,7 @@ void KMX_TranslateKey(LPKMX_KEY key, KMX_WORD vk, UINT shift, KMX_WCHAR ch) {
     // This will not result in 100% wonderful mappings as there could
     // be overlap, depending on how keys are arranged on the target layout.
     // But that is up to the designer.
-    //LogError(L"Converted mnemonic virtual char key rule on line %d, + [%x '%c'] TO + [%x K_%d]", key->Line, key->ShiftFlags, key->Key, key->ShiftFlags & ~VIRTUALCHARKEY, vk);
+    //KMX_LogError(L"Converted mnemonic virtual char key rule on line %d, + [%x '%c'] TO + [%x K_%d]", key->Line, key->ShiftFlags, key->Key, key->ShiftFlags & ~VIRTUALCHARKEY, vk);
     key->ShiftFlags &= ~VIRTUALCHARKEY;
     key->Key = vk;
   }
@@ -185,7 +185,7 @@ void KMX_TranslateKeyboard(LPKMX_KEYBOARD kbd, KMX_WORD vk, UINT shift, KMX_WCHA
 
 void KMX_ReportUnconvertedKeyRule(LPKMX_KEY key) {
   if(key->ShiftFlags == 0) {
-    KMX_LogError(L"Did not find a match for mnemonic rule on line %d, + '%c' > ...", key->Line, key->Key);
+    //KMX_LogError(L"Did not find a match for mnemonic rule on line %d, + '%c' > ...", key->Line, key->Key);
   } else if(key->ShiftFlags & VIRTUALCHARKEY) {
     KMX_LogError(L"Did not find a match for mnemonic virtual character key rule on line %d, + [%x '%c'] > ...", key->Line, key->ShiftFlags, key->Key);
   }
@@ -348,7 +348,7 @@ KMX_WCHAR KMX_GetUniqueDeadkeyID(LPKMX_KEYBOARD kbd, KMX_WCHAR deadkey) {
   return s_dkids[s_ndkids++].dst_deadkey = s_next_dkid = ++dkid;
 }
 
-void KMX_ConvertDeadkey(LPKMX_KEYBOARD kbd, KMX_WORD vk_US, UINT shift, KMX_WCHAR deadkey, v_dw_3D &All_Vector, GdkKeymap* keymap,v_dw_2D dk_Table) {
+void KMX_ConvertDeadkey(LPKMX_KEYBOARD kbd, KMX_WORD vk_US, UINT shift, KMX_WCHAR deadkey, vec_dword_3D &All_Vector, GdkKeymap* keymap,vec_dword_2D dk_Table) {
   KMX_WORD deadkeys[512], *pdk;
 
   // Lookup the deadkey table for the deadkey in the physical keyboard
@@ -411,13 +411,13 @@ KMX_BOOL KMX_DoConvert(LPKMX_KEYBOARD kbd, KMX_BOOL bDeadkeyConversion, gint arg
   }
 
   // create vector that contains Keycode, base, shift for US-KEyboard and underlying keyboard
-  v_dw_3D All_Vector;
+  vec_dword_3D All_Vector;
   if(createOneVectorFromBothKeyboards(All_Vector, keymap)){
     wprintf(L"ERROR: can't create one vector from both keyboards\n");
     return FALSE;
   }
 
-  v_dw_2D  dk_Table;
+  vec_dword_2D  dk_Table;
   create_DKTable(dk_Table);
 
   for (int j = 0; VKShiftState[j] != 0xFFFF; j++) { // I4651
@@ -429,7 +429,7 @@ KMX_BOOL KMX_DoConvert(LPKMX_KEYBOARD kbd, KMX_BOOL bDeadkeyConversion, gint arg
       UINT scUnderlying =  KMX_get_KeyCodeUnderlying_From_VKUS(KMX_VKMap[i]);
       KMX_WCHAR ch = KMX_get_KeyValUnderlying_From_KeyCodeUnderlying(keymap, VKShiftState[j], scUnderlying, &DeadKey);
 
-      //wprintf(L"--- VK_%d -> SC_ [%c] dk=%d  ( ss %i) \n", VKMap[i], ch == 0 ? 32 : ch, DeadKey, VKShiftState[j]);
+      //wprintf(L"--- VK_%d -> SC_ [%c] dk=%d  ( ss %i) \n", KMX_VKMap[i], ch == 0 ? 32 : ch, DeadKey, VKShiftState[j]);
 
       if(bDeadkeyConversion) {   // I4552
         if(ch == 0xFFFF) {
@@ -453,15 +453,15 @@ KMX_BOOL KMX_DoConvert(LPKMX_KEYBOARD kbd, KMX_BOOL bDeadkeyConversion, gint arg
   return TRUE;
 }
 
-int KMX_GetDeadkeys(v_dw_2D & dk_Table, KMX_WORD DeadKey, KMX_WORD *OutputPairs, GdkKeymap* keymap) {
+int KMX_GetDeadkeys(vec_dword_2D & dk_Table, KMX_WORD deadkey, KMX_WORD *OutputPairs, GdkKeymap* keymap) {
 
   KMX_WORD *p = OutputPairs;
   KMX_DWORD shift;
 
-  v_dw_2D  dk_SingleTable;
-  query_dk_combinations_for_specific_dk(&dk_Table, dk_SingleTable, DeadKey);
+  vec_dword_2D  dk_SingleTable;
+  query_dk_combinations_for_specific_dk(&dk_Table, dk_SingleTable, deadkey);
   for ( int i=0; i< (int) dk_SingleTable.size();i++) {
-    KMX_WORD vk = KMX_changeKeynameToCapital(dk_SingleTable[i][1], shift, keymap);
+    KMX_WORD vk = KMX_change_keyname_to_capital(dk_SingleTable[i][1], shift, keymap);
     if(vk != 0) {
       *p++ = vk;
       *p++ = shift;

--- a/linux/mcompile/keymap/mcompile.cpp
+++ b/linux/mcompile/keymap/mcompile.cpp
@@ -31,7 +31,7 @@
 
 KMX_BOOL KMX_DoConvert(LPKMX_KEYBOARD kbd, KMX_BOOL bDeadkeyConversion, gint argc, gchar *argv[]);
 
-bool KMX_ImportRules( LPKMX_KEYBOARD kp,vec_dword_3D &All_Vector, GdkKeymap **keymap,std::vector<KMX_DeadkeyMapping> *KMX_FDeadkeys, KMX_BOOL bDeadkeyConversion); // I4353   // I4327
+bool KMX_ImportRules( LPKMX_KEYBOARD kp,vec_dword_3D& all_vector, GdkKeymap **keymap,std::vector<KMX_DeadkeyMapping> *KMX_FDeadkeys, KMX_BOOL bDeadkeyConversion); // I4353   // I4327
 
 std::vector<KMX_DeadkeyMapping> KMX_FDeadkeys; // I4353
 
@@ -348,7 +348,7 @@ KMX_WCHAR KMX_GetUniqueDeadkeyID(LPKMX_KEYBOARD kbd, KMX_WCHAR deadkey) {
   return s_dkids[s_ndkids++].dst_deadkey = s_next_dkid = ++dkid;
 }
 
-void KMX_ConvertDeadkey(LPKMX_KEYBOARD kbd, KMX_WORD vk_US, UINT shift, KMX_WCHAR deadkey, vec_dword_3D &All_Vector, GdkKeymap* keymap,vec_dword_2D dk_Table) {
+void KMX_ConvertDeadkey(LPKMX_KEYBOARD kbd, KMX_WORD vk_US, UINT shift, KMX_WCHAR deadkey, vec_dword_3D& all_vector, GdkKeymap* keymap,vec_dword_2D dk_Table) {
   KMX_WORD deadkeys[512], *pdk;
 
   // Lookup the deadkey table for the deadkey in the physical keyboard
@@ -365,7 +365,7 @@ void KMX_ConvertDeadkey(LPKMX_KEYBOARD kbd, KMX_WORD vk_US, UINT shift, KMX_WCHA
 
   while(*pdk) {
     // Look up the ch
-    UINT KeyValUnderlying = KMX_get_KeyValUnderlying_From_KeyValUS(All_Vector, *pdk);
+    UINT KeyValUnderlying = KMX_get_KeyValUnderlying_From_KeyValUS(all_vector, *pdk);
     KMX_TranslateDeadkeyKeyboard(kbd, dkid, KeyValUnderlying, *(pdk+1), *(pdk+2));
     pdk+=3;
   }
@@ -405,14 +405,14 @@ KMX_BOOL KMX_DoConvert(LPKMX_KEYBOARD kbd, KMX_BOOL bDeadkeyConversion, gint arg
   // For now, we get the least shifted version, which is hopefully adequate.
 
   GdkKeymap *keymap;
-  if(InitializeGDK(&keymap , argc, argv)) {
+  if(InitializeGDK(&keymap,  argc, argv)) {
       wprintf(L"ERROR: can't Initialize GDK\n");
       return FALSE;
   }
 
   // create vector that contains Keycode, base, shift for US-KEyboard and underlying keyboard
-  vec_dword_3D All_Vector;
-  if(createOneVectorFromBothKeyboards(All_Vector, keymap)){
+  vec_dword_3D all_vector;
+  if(createOneVectorFromBothKeyboards(all_vector, keymap)){
     wprintf(L"ERROR: can't create one vector from both keyboards\n");
     return FALSE;
   }
@@ -439,7 +439,7 @@ KMX_BOOL KMX_DoConvert(LPKMX_KEYBOARD kbd, KMX_BOOL bDeadkeyConversion, gint arg
 
       switch(ch) {
         case 0x0000: break;
-        case 0xFFFF: KMX_ConvertDeadkey(kbd, KMX_VKMap[i], VKShiftState[j], DeadKey, All_Vector, keymap , dk_Table); break;
+        case 0xFFFF: KMX_ConvertDeadkey(kbd, KMX_VKMap[i], VKShiftState[j], DeadKey, all_vector, keymap,  dk_Table); break;
         default: KMX_TranslateKeyboard(kbd, KMX_VKMap[i], VKShiftState[j], ch);
       }
     }
@@ -447,7 +447,7 @@ KMX_BOOL KMX_DoConvert(LPKMX_KEYBOARD kbd, KMX_BOOL bDeadkeyConversion, gint arg
 
   KMX_ReportUnconvertedKeyboardRules(kbd);
 
-  if(!KMX_ImportRules(kbd, All_Vector, &keymap, &KMX_FDeadkeys, bDeadkeyConversion)) {   // I4353   // I4552
+  if(!KMX_ImportRules(kbd, all_vector, &keymap, &KMX_FDeadkeys, bDeadkeyConversion)) {   // I4353   // I4552
     return FALSE;
   }
   return TRUE;

--- a/linux/mcompile/keymap/mcompile.h
+++ b/linux/mcompile/keymap/mcompile.h
@@ -36,7 +36,7 @@ int run(int argc, std::vector<std::u16string>  str_argv, char* argv[]);
 
 PKMX_WCHAR KMX_incxstr(PKMX_WCHAR p);
 
-int KMX_GetDeadkeys(v_dw_2D & dk_Table, KMX_WORD DeadKey, KMX_WORD *OutputPairs, GdkKeymap* keymap);
+int KMX_GetDeadkeys(vec_dword_2D & dk_Table, KMX_WORD DeadKey, KMX_WORD *OutputPairs, GdkKeymap* keymap);
 
 void KMX_LogError(const wchar_t* fmt, ...);
 

--- a/windows/src/engine/mcompile/mc_savekeyboard.cpp
+++ b/windows/src/engine/mcompile/mc_savekeyboard.cpp
@@ -67,8 +67,8 @@ DWORD WriteCompiledKeyboard(LPKEYBOARD fk, HANDLE hOutfile, BOOL FSaveDebug)
 			size += wcslen(fkp->dpContext)*2 + 2;
 		}
 
-		if( fgp->dpMatch ) size += wcslen(fgp->dpMatch)*2 + 2;
-		if( fgp->dpNoMatch ) size += wcslen(fgp->dpNoMatch)*2 + 2;
+		if (fgp->dpMatch ) size += wcslen(fgp->dpMatch)*2 + 2;
+		if (fgp->dpNoMatch ) size += wcslen(fgp->dpNoMatch)*2 + 2;
 	}
 
 	for(i = 0; i < fk->cxStoreArray; i++)


### PR DESCRIPTION
fixes parts of [PR #9384](https://github.com/keymanapp/keyman/pull/9384) 

This PR addresses and bundles comments made on [PR #9384](https://github.com/keymanapp/keyman/pull/9384) about renaming symbols. 

While reviewing [PR #9384](https://github.com/keymanapp/keyman/pull/9384) several comments on renaming symbols came up. Most of them address the use of non-capital letters in variable names, renaming symbols to other names and adding comments into the code.
This PR only addresses requests for changes in comments and symbol names throughout all mcompile-linux. There might still be other unaddressed comments in functions or modules that have already had symbols renamed.

@keymanapp-test-bot skip