### PR TITLE
feat(web): improve predictive-text responsiveness when typing rapidly 🕐 

### DIFF
--- a/common/web/lm-worker/src/main/model-compositor.ts
+++ b/common/web/lm-worker/src/main/model-compositor.ts
@@ -7,8 +7,18 @@ import TransformUtils from './transformUtils.js';
 export default class ModelCompositor {
   private lexicalModel: LexicalModel;
   private contextTracker?: correction.ContextTracker;
+
   private static readonly MAX_SUGGESTIONS = 12;
   readonly punctuation: LexicalModelPunctuation;
+
+  // Left exposed to facilitate unit tests.
+  // See worker-model-compositor, "stops predicting early[...]".
+  /**
+   * If there is a prediction request currently beign processed, this will
+   * hold a reference to its time-management ExecutionTimer, which can
+   * be used to have it exit early (once it yields to the task queue).
+   */
+  activeTimer?: correction.ExecutionTimer;
 
   /**
    * Controls the strength of anti-corrective measures for single-character scenarios.
@@ -69,6 +79,10 @@ export default class ModelCompositor {
     let suggestionDistribution: Distribution<Suggestion> = [];
     let lexicalModel = this.lexicalModel;
     let punctuation = this.punctuation;
+
+    // If a prior prediction is still processing, signal to terminate it; we have a new
+    // prediction request to prioritize.
+    this.activeTimer?.terminate();
 
     if(!(transformDistribution instanceof Array)) {
       transformDistribution = [ {sample: transformDistribution, p: 1.0} ];
@@ -239,11 +253,13 @@ export default class ModelCompositor {
       // TODO:  whitespace, backspace filtering.  Do it here.
       //        Whitespace is probably fine, actually.  Less sure about backspace.
 
+      const SEARCH_TIMEOUT = correction.SearchSpace.DEFAULT_ALLOTTED_CORRECTION_TIME_INTERVAL;
+      const timer = this.activeTimer = new correction.ExecutionTimer(this.testMode ? Number.MAX_VALUE : SEARCH_TIMEOUT, this.testMode ? Number.MAX_VALUE : SEARCH_TIMEOUT * 1.5);
+
       let bestCorrectionCost: number;
       let correctionPredictionMap: Record<string, Distribution<Suggestion>> = {};
 
-      const SEARCH_TIMEOUT = this.testMode ? 0 : correction.SearchSpace.DEFAULT_ALLOTTED_CORRECTION_TIME_INTERVAL;
-      for await(let match of searchSpace.getBestMatches(SEARCH_TIMEOUT)) {
+      for await(let match of searchSpace.getBestMatches(timer)) {
         // Corrections obtained:  now to predict from them!
         let correction = match.matchString;
         correctionPredictionMap[match.matchString]
@@ -333,6 +349,13 @@ export default class ModelCompositor {
             }
           }
         }
+      }
+
+      // // For debugging / investigation.
+      // console.log(`execute: ${timer.executionTime}, deferred: ${timer.deferredTime}`); //, total since start: ${timer.timeSinceConstruction}`);
+
+      if(this.activeTimer == timer) {
+        this.activeTimer = null;
       }
     }
 
@@ -741,6 +764,9 @@ export default class ModelCompositor {
   }
 
   public resetContext(context: Context) {
+    // If we're resetting the context, any active prediction requests are no
+    // longer valid.
+    this.activeTimer?.terminate();
     // Force-resets the context, throwing out any previous fat-finger data, etc.
     // Designed for use when the caret has been directly moved and/or the context sourced from a different control
     // than before.

--- a/common/web/lm-worker/src/test/mocha/cases/edit-distance/distance-modeler.js
+++ b/common/web/lm-worker/src/test/mocha/cases/edit-distance/distance-modeler.js
@@ -4,6 +4,10 @@ import * as correction from '#./correction/index.js';
 
 import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
 
+function buildTestTimer() {
+  return new correction.ExecutionTimer(Number.MAX_VALUE, Number.MAX_VALUE);
+}
+
 function assertEdgeChars(edge, input, match) {
   assert.isTrue(edgeHasChars(edge, input, match));
 }
@@ -306,7 +310,7 @@ describe('Correction Distance Modeler', function() {
 
       let searchSpace = new correction.SearchSpace(testModel);
 
-      let iter = searchSpace.getBestMatches();
+      let iter = searchSpace.getBestMatches(buildTestTimer());
       let firstResult = await iter.next();
       assert.isFalse(firstResult.done);
     });
@@ -337,32 +341,8 @@ describe('Correction Distance Modeler', function() {
       searchSpace.addInput(synthDistribution2);
       searchSpace.addInput(synthDistribution3);
 
-      let iter = searchSpace.getBestMatches(0); // disables the correction-search timeout.
+      let iter = searchSpace.getBestMatches(buildTestTimer()); // disables the correction-search timeout.
       await checkResults_teh(iter);
-
-      // // Debugging method:  a simple loop for printing out the generated sets, in succession.
-      // //
-      // for(let i = 1; i <= 8; i++) {  // After 8 tiers, we run out of entries for this particular case.
-      //   console.log();
-      //   console.log("Batch " + i);
-
-      //   let set = iter.next();
-      //   assert.isFalse(set.done);
-
-      //   set = set.value;
-
-      //   let entries = set.map(function(result) {
-      //     return result.matchString;
-      //   });
-
-      //   console.log("Entry count: " + set.length);
-      //   entries.sort();
-      //   console.log(entries);
-      //   console.log("Probablility:  " + set[0].totalCost);
-      //   console.log("Analysis (first entry):");
-      //   console.log(" - Edit cost:  " + set[0].knownCost);
-      //   console.log(" - Input cost: " + set[0].inputSamplingCost);
-      // }
     });
 
     it('Allows reiteration (sequentially)', async function() {
@@ -391,12 +371,12 @@ describe('Correction Distance Modeler', function() {
       searchSpace.addInput(synthDistribution2);
       searchSpace.addInput(synthDistribution3);
 
-      let iter = searchSpace.getBestMatches(0); // disables the correction-search timeout.
+      let iter = searchSpace.getBestMatches(buildTestTimer()); // disables the correction-search timeout.
       await checkResults_teh(iter);
 
       // The key: do we get the same results the second time?
       // Reset the iterator first...
-      let iter2 = searchSpace.getBestMatches(0); // disables the correction-search timeout.
+      let iter2 = searchSpace.getBestMatches(buildTestTimer()); // disables the correction-search timeout.
       await checkResults_teh(iter2);
     });
 
@@ -406,7 +386,8 @@ describe('Correction Distance Modeler', function() {
       assert.isNotEmpty(rootTraversal);
 
       let searchSpace = new correction.SearchSpace(testModel);
-      let iter = searchSpace.getBestMatches();
+      const timer = buildTestTimer();
+      let iter = searchSpace.getBestMatches(timer);
 
       // While there's no input, insertion operations can produce suggestions.
       let resultState = await iter.next();

--- a/common/web/lm-worker/src/test/mocha/cases/worker-model-compositor.js
+++ b/common/web/lm-worker/src/test/mocha/cases/worker-model-compositor.js
@@ -9,6 +9,7 @@ import * as wordBreakers from '@keymanapp/models-wordbreakers';
 import { assert } from 'chai';
 
 import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
+import { timedPromise } from '@keymanapp/web-utils';
 
 var TrieModel = models.TrieModel;
 
@@ -156,6 +157,43 @@ describe('ModelCompositor', function() {
           // replace => nothing for the suggestion to delete.
           assert.equal(suggestion.transform.deleteLeft, 0);
         });
+      });
+
+      it('stops predicting early if new prediction request comes in', async function() {
+        const compositor = new ModelCompositor(plainModel, true);
+
+        const firstPredict = compositor.predict({
+          insert: "a",
+          deleteLeft: 0
+        }, {
+          left: "the ", startOfBuffer: true, endOfBuffer: true
+        });
+
+        const firstTimer = compositor.activeTimer;
+        assert.isOk(firstTimer);
+        assert.isFalse(firstTimer.elapsed);
+
+        const secondPredict = compositor.predict({
+          insert: "l",
+          deleteLeft: 0
+        }, {
+          left: "the apl", startOfBuffer: true, endOfBuffer: true
+        });
+
+        assert.notEqual(compositor.activeTimer, firstTimer);
+        assert.isTrue(firstTimer.elapsed);
+
+        await Promise.race([
+          firstPredict,
+          secondPredict.then(() => Promise.reject(new Error("second prediction should not beat the first"))),
+        ]);
+
+        await Promise.all([firstPredict, secondPredict]);
+
+        const terminatedSuggestions = await firstPredict;
+        const finalSuggestions = await secondPredict;
+        assert.isOk(terminatedSuggestions.find((entry) => entry.displayAs == 'a'));
+        assert.isOk(finalSuggestions.find((entry) => entry.displayAs == 'applied'));
       });
     });
 


### PR DESCRIPTION
Fixes #3580.

The changes in this PR allow the correction/prediction search process to periodically yield to the JS microtask + task queues, rather than having newly-incoming messages be blocked until completion.  Messages, "like _new keystrokes_ have been received", can then request that any currently-deferred prediction requests abort, terminating the now-invalid prediction requests early so that the newly-received requests can start as soon as possible.

## User Testing

TEST_GENERAL_PREDICTIONS:  Using the Keyman for Android app, verify that predictive-text works normally.

TEST_RAPID_TYPE_PREDICTIONS:  Using the Keyman for Android app, verify that predictive-text stays responsive and up-to-date when typing very rapidly.
- The quantity and quality of suggestions may suffer somewhat.
- The key is that you should only have to wait the normal amount of time after you stop typing, regardless of how long and rapid any preceding typing burst was.
