### PR TITLE
fix(web): prevent desktop OSK crash when addKeyboards is called before engine init 🍒  🏠

### DIFF
--- a/web/src/engine/osk/src/views/floatingOskView.ts
+++ b/web/src/engine/osk/src/views/floatingOskView.ts
@@ -51,6 +51,7 @@ export default class FloatingOSKView extends OSKView {
 
     // Add header element to OSK only for desktop browsers
     this.titleBar = new TitleBar(this.titleDragHandler);
+    //
     this.titleBar.on('help', () => {
       this.legacyEvents.callEvent('helpclick', {});
     });
@@ -91,6 +92,12 @@ export default class FloatingOSKView extends OSKView {
       listenerSpy.on('listenerremoved', onListenedEvent);
     }
 
+    if(this.activeKeyboard) {
+      // If the keyboard was loaded during OSK init, we may need to set the
+      // title in place now, as it wasn't possible at the standard time.
+      this.postKeyboardAdjustments();
+    }
+
     this.loadPersistedLayout();
   }
 
@@ -119,6 +126,12 @@ export default class FloatingOSKView extends OSKView {
   }
 
   protected postKeyboardAdjustments() {
+    // It is possible for this to be called during OSK initialization,
+    // when `this.titleBar` has not yet been initialized.
+    if(!this.titleBar) {
+      return;
+    }
+
     // Add header element to OSK only for desktop browsers
     this.enableMoveResizeHandlers();
     if(this.activeKeyboard) {

--- a/web/src/test/manual/web/index.html
+++ b/web/src/test/manual/web/index.html
@@ -75,6 +75,7 @@
   <h2><a href="./text_selection_tests_9073/index.html">Test text selection (#9073)</a></h2>
   <h2><a href="./pr10506/index.html">Test key-cap scaling / font load interactions (#10506)</a></h2>
   <h2><a href="./init-race-10743/index.html">Test page interaction + engine-initialization race condition handling (#10743)</a></h2>
+  <h2><a href="./issue11785/index.html">Test OSK loading with early add-keyboard calls (#11785)</a></h2>
   <h1>Other</h1>
   <h2><a href="./regression-tests/index.html">Keystroke processing regression test engine.</a></h2>
   <hr>

--- a/web/src/test/manual/web/issue11785/index.html
+++ b/web/src/test/manual/web/issue11785/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+
+    <!-- Set the viewport width to match phone and tablet device widths -->
+    <meta name="viewport" content="width=device-width,user-scalable=no" />
+
+    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+
+    <!-- Enable IE9 Standards mode -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+    <title>KeymanWeb Test Page - Keyboard Quick-Load</title>
+
+    <!-- Your page CSS -->
+    <style type='text/css'>
+      body {font-family: Tahoma,helvetica;}
+      h3 {font-size: 1em;font-weight:normal;color: darkred; margin-bottom: 4px}
+      .test {font-size: 24px; width:80%; min-height:30px; border: 1px solid gray;}
+      #KeymanWebControl {width:50%;min-width:600px;}
+    </style>
+
+    <!-- Insert uncompiled KeymanWeb source scripts -->
+    <script src="../../../../../build/publish/debug/keymanweb.js" type="application/javascript"></script>
+
+    <!--
+      For desktop browsers, a script for the user interface must be inserted here.
+
+      Standard UIs are toggle, button, float and toolbar.
+      The toolbar UI is best for any page designed to support keyboards for
+      a large number of languages.
+    -->
+    <script src="../../../../../build/publish/debug/kmwuitoggle.js"></script>
+
+    <!-- Add keyboard management script for local selection of keyboards to use -->
+    <script src="../commonHeader.js"></script>
+
+    <!-- Initialization: set paths to keyboards, resources and fonts as required -->
+    <script>
+      var kmw=window.keyman;
+      kmw.init({
+		    attachType:'auto',
+      });
+
+      // Note:  explicitly NOT deferred or waiting on the `init` Promise.  This is
+      // the trigger for this page's test!
+      loadKeyboards(1);
+    </script>
+
+  </head>
+
+<!-- Sample page HTML -->
+  <body>
+    <h2>KeymanWeb Test Page - Keyboard Quick-Load</h2>
+
+    <div>
+    <!--
+      The following DIV is used to position the Button or Toolbar User Interfaces on the page.
+      If omitted, those User Interfaces will appear at the top of the document body.
+      (It is ignored by other User Interfaces.)
+    -->
+    <div id='KeymanWebControl'></div>
+
+    <h3>Type in your language in this text area:</h3>
+    <textarea id='ta1' class='test' placeholder='Type here'></textarea>
+
+    <h3>or in this input field:</h3>
+    <input class='test' value='' placeholder='or here'/>
+
+    <!--  The following elements show how the language menu can be dynamically extended at any time -->
+    <h3>Add a keyboard by keyboard name:</h3>
+    <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>
+    <input type='button' id='btn1' onclick='addKeyboard(1);' value='Add' />
+
+    <h3>Add a keyboard by BCP-47 language code:</h3>
+    <input type='input' id='kbd_id2' class='kmw-disabled' onkeypress="clickOnEnter(event,2);"/>
+    <input type='button' id='btn2' onclick='addKeyboard(2);' value='Add' />
+
+    <h3>Add a keyboard by language name(s):</h3>
+    <input type='input' id='kbd_id3' class='kmw-disabled' onkeypress="clickOnEnter(event,3);"/>
+    <input type='button' id='btn3' onclick='addKeyboard(3);' value='Add' />
+
+    <h3><a href="../.">Return to testing home page</a></h3>
+  </div>
+
+  <!-- include a blank div to enable scrolling -->
+  <div style="height:1000px"></div>
+  <p>--End of Document--</p>
+
+  </body>
+
+  <!--
+    *** DEVELOPER NOTE -- FIREFOX CONFIGURATION FOR TESTING ***
+    *
+    * If the URL bar starts with <b>file://</b>, Firefox may not load the font used
+    * to display the special characters used in the On-Screen Keyboard.
+    *
+    * To work around this Firefox bug, navigate to <b>about:config</b>
+    * and set <b>security.fileuri.strict_origin_policy</b> to <b>false</b>
+    * while testing.
+    *
+    * Firefox resolves website-based CSS URI references correctly without needing
+    * any configuration change, so this change should only be made for file-based testing.
+    *
+    ***
+  -->
+</html>


### PR DESCRIPTION
Fixes: #11785
Fixes: KEYMAN-WEB-KC
Cherry-pick-of: #11786

@keymanapp-test-bot skip