### PR TITLE
feat(linux): re-create missing files at run-time

### DIFF
--- a/linux/keyman-config/keyman_config/convertico.py
+++ b/linux/keyman-config/keyman_config/convertico.py
@@ -11,8 +11,8 @@ from PIL import Image, ImageFile
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 
-def changeblacktowhite(im):
-    data = np.array(im)   # "data" is a height x width x 4 numpy array
+def _changeblacktowhite(image):
+    data = np.array(image)   # "data" is a height x width x 4 numpy array
     red, green, blue, alpha = data.T  # Temporarily unpack the bands for readability
 
     # Replace black with white... (leaves alpha values alone...)
@@ -50,15 +50,15 @@ def checkandsaveico(icofile):
 
 
 def _convert_ico_to_bmp(icofile, bmpfile):
-    with Image.open(icofile) as im:
-        with im.convert('RGBA') as im2:
-            num, colour = max(im.getcolors(im2.size[0] * im2.size[1]))
+    with Image.open(icofile) as image:
+        with image.convert('RGBA') as image2:
+            num, colour = max(image.getcolors(image2.size[0] * image2.size[1]))
             logging.debug(f"checkandsaveico maxcolour: num {num}: colour {colour}")
             if num > 160 and colour == (0, 0, 0, 0):
                 logging.info(f"checkandsaveico:{icofile} mostly black so changing black to white")
-                im2.close()
-                im2 = changeblacktowhite(im)
-            im2.save(bmpfile)
+                image2.close()
+                image2 = _changeblacktowhite(image)
+            image2.save(bmpfile)
 
 
 def extractico(kmxfile):
@@ -109,7 +109,7 @@ def extractico(kmxfile):
     return True
 
 
-def main(argv):
+def main():
     if len(sys.argv) != 2:
         logging.error("convertico.py <ico file | kmx file>")
         sys.exit(2)
@@ -122,4 +122,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -307,9 +307,9 @@ def extract_kmp(kmpfile, directory):
         raise InstallError(InstallStatus.Abort, e) from e
 
 
-def process_keyboard_data(keyboardID, packageDir) -> None:
+def process_keyboard_data(keyboardID, packageDir) -> bool:
     if not (kbdata := get_keyboard_data(keyboardID)):
-        return
+        return False
     if not os.path.isdir(packageDir) and os.access(os.path.join(packageDir, os.pardir), os.X_OK | os.W_OK):
         try:
             os.makedirs(packageDir)
@@ -318,11 +318,13 @@ def process_keyboard_data(keyboardID, packageDir) -> None:
 
     if os.access(packageDir, os.X_OK | os.W_OK):
         try:
-            with open(os.path.join(packageDir, f'{keyboardID}.json'), 'w') as outfile:
+            with open(os.path.join(packageDir, f'{keyboardID}.json'), 'w', encoding='utf-8') as outfile:
                 json.dump(kbdata, outfile)
                 logging.info("Installing api data file %s.json as keyman file", keyboardID)
+                return True
         except Exception as e:
             logging.warning('Exception %s writing %s/%s.json %s', type(e), packageDir, keyboardID, e.args)
+    return False
 
 
 def install_kmp(inputfile, sharedarea=False, language=None):


### PR DESCRIPTION
This changes re-creates the `<package>.bmp.png` as well as the `<package>.json` files if they are missing when `km-config` starts.

- `<package.bmp.png` gets created from a `.bmp` or `.ico` file included in the package, similar to what happens when installing the keyboard.
- `<package>.json` gets created from downloaded metadata, similar to the installation.

If the files are missing or we can't write to the directory, e.g. if it's the shared area, we skip the re-creation.

Fixes: https://github.com/keymanapp/keyman/issues/9396

Also some small refactorings.

# User Testing

## Preparations

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot
- Install the Khmer Angkor keyboard
- Install the SIL IPA keyboard into the shared area (`sudo km-package-install --shared -p sil_ipa`)
- remove the following files (e.g. with Files):
  - `$HOME/.local/share/keyman/khmer_angkor/khmer_angkor.bmp.png`
  - `$HOME/.local/share/keyman/khmer_angkor/khmer_angkor.json`
  - `/usr/local/share/keyman/sil_ipa/sil_ipa.bmp.png`
  - `/usr/local/share/keyman/sil_ipa/sil_ipa.json`

## Tests

**TEST_REGENERATE**: 

- Start `km-config`
- verify that the correct icon is shown for "Khmer Angkor" (shows Cambodian flag)
- verify that for "IPA (SIL)" a generic orange icon is shown (because of missing permissions to write in `/usr/local`)
- verify that opening `km-config` re-created the files `khmer_angkor.bmp.png` and `khmer_angkor.json` in `$HOME/.local/share/keyman/khmer_angkor`
- verify that `sil_ipa.bmp.png` and `sil_ipa.json` are still missing from  `/usr/local/share/keyman/sil_ipa`