### PR TITLE
fix(core): serialize tests for core/wasm on mac agents

### DIFF
--- a/core/commands.inc.sh
+++ b/core/commands.inc.sh
@@ -91,7 +91,14 @@ do_test() {
   if [[ $target =~ ^(x86|x64)$ ]]; then
     cmd //C build.bat $target $BUILDER_CONFIGURATION test $testparams
   else
-    meson test -C "$MESON_PATH" $testparams
+    if [[ $target == wasm ]] && [[ $BUILDER_OS == mac ]]; then
+      # 11794 -- parallel tests failing on some mac build agents; temporary
+      # mitigation until we diagnose root cause
+      meson test -j 1 -C "$MESON_PATH" $testparams
+    else
+      meson test -C "$MESON_PATH" $testparams
+    fi
+
   fi
   builder_finish_action success test:$target
 }

--- a/docs/build/macos.md
+++ b/docs/build/macos.md
@@ -77,10 +77,10 @@ PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
 
 ## KeymanWeb Dependencies
 
-* node.js 18+, emscripten 3.1.46 or later, openjdk 8
+* node.js 22+, emscripten 3.1.46 or later
 
 ```shell
-brew install node emscripten openjdk@8
+brew install node emscripten
 ```
 
 Note: if you install emscripten with brew on macOS, only emscripten binaries are


### PR DESCRIPTION
Mitigates: #11794

@keymanapp-test-bot skip