### PR TITLE
chore(common): update base-package node-engine setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=18.20.0 <23.0.0"
+        "node": "^18.20.0 || ^20.10.0 || ^22.0.0"
       }
     },
     "common/models/templates": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": "^18.20.0 || ^20.10.0 || ^22.0.0"
+        "node": "^22.0.0"
       }
     },
     "common/models/templates": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": "^18.x"
+        "node": ">=18.20.0 <23.0.0"
       }
     },
     "common/models/templates": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "@keymanapp/ldml-keyboard-constants": "file:core/include/ldml"
   },
   "engines": {
-    "node": ">=18.20.0 <23.0.0"
+    "node": "^18.20.0 || ^20.10.0 || ^22.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "@keymanapp/ldml-keyboard-constants": "file:core/include/ldml"
   },
   "engines": {
-    "node": "^18.x"
+    "node": ">=18.20.0 <23.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "@keymanapp/ldml-keyboard-constants": "file:core/include/ldml"
   },
   "engines": {
-    "node": "^18.20.0 || ^20.10.0 || ^22.0.0"
+    "node": "^22.0.0"
   }
 }


### PR DESCRIPTION
Fixes: #11689

I set the minimum to 18.20.0 because it's [the first version of `node 18` that has proper support for import attributes](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2024-03-26-version-18200-hydrogen-lts-richardlau).  [20.10.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2023-11-22-version-20100-iron-lts-targos) is the minimum Node 20 version for the same reason.

@keymanapp-test-bot skip