### PR TITLE
change(web): change after-word whitespace check to be more selective

### DIFF
--- a/common/web/lm-worker/src/main/model-compositor.ts
+++ b/common/web/lm-worker/src/main/model-compositor.ts
@@ -456,18 +456,21 @@ export default class ModelCompositor {
       // Valid 'keep' suggestions may have zero length; we still need to evaluate the following code
       // for such cases.
 
-      // Do we need to manipulate the suggestion's transform based on the current state of the context?
-      if(!context.right) {
+      // If we're mid-word, delete its original post-caret text.
+      const tokenization = compositor.tokenize(context);
+      if(tokenization && tokenization.caretSplitsToken) {
+        // While we wait on the ability to provide a more 'ideal' solution, let's at least
+        // go with a more stable, if slightly less ideal, solution for now.
+        //
+        // A predictive text default (on iOS, at least) - immediately wordbreak
+        // on suggestions accepted mid-word.
         suggestion.transform.insert += punctuation.insertAfterWord;
-      } else {
-        // If we're mid-word, delete its original post-caret text.
-        const tokenization = compositor.tokenize(context);
-        if(tokenization && tokenization.caretSplitsToken) {
-          // While we wait on the ability to provide a more 'ideal' solution, let's at least
-          // go with a more stable, if slightly less ideal, solution for now.
-          //
-          // A predictive text default (on iOS, at least) - immediately wordbreak
-          // on suggestions accepted mid-word.
+
+        // Do we need to manipulate the suggestion's transform based on the current state of the context?
+      } else if(!context.right) {
+        suggestion.transform.insert += punctuation.insertAfterWord;
+      } else if(punctuation.insertAfterWord != '') {
+        if(context.right.indexOf(punctuation.insertAfterWord) != 0) {
           suggestion.transform.insert += punctuation.insertAfterWord;
         }
       }


### PR DESCRIPTION
Now only skips emitting the after-word text if it is the immediate prefix of the current right-hand context.

Fixes: #5256

## User Testing

**TEST_GOOGLE_DOCS_SUGGESTIONS**:  Using Keyman for Android and the Google Docs app, verify that applying predictive-text suggestions properly appends whitespace for English.

1. Install Keyman for Android and ensure that it is set as the default system keyboard.
2. Load Google Docs (doing any sign-in, etc necessary)
3. Type `th`, then select the `the` suggestion.
4. Verify that the caret is after a space following `the`.
5. Type some more text - a few words.
6. Move the caret to directly after the `the`.
7. Tap an available suggestion - `they` and `there` will likely be available options, so pick one.
8. Verify that no _additional_ space is added and that `the` is correctly replaced by the selected suggestion.

**TEST_IN_APP_SUGGESTIONS**:  Using Keyman for Android, verify that predictive-text operates normally within the app.

Be sure to include this as part of the test:
1. Type `th`, then select the `the` suggestion.
2. Verify that the caret is after a space following `the`.