### PR TITLE
chore(core): use source maps when running wasm tests

### DIFF
--- a/core/wasm.defs.build
+++ b/core/wasm.defs.build
@@ -2,7 +2,7 @@
 c = ['emcc.py']
 cpp = ['em++.py']
 ar = ['emar.py']
-exe_wrapper = 'node'
+exe_wrapper = ['node', '--enable-source-maps']
 
 [properties]
 root = '$EMSCRIPTEN_BASE/system'

--- a/developer/src/kmcmplib/wasm.defs.build
+++ b/developer/src/kmcmplib/wasm.defs.build
@@ -2,7 +2,7 @@
 c = ['emcc.py']
 cpp = ['em++.py']
 ar = ['emar.py']
-exe_wrapper = 'node'
+exe_wrapper = ['node', '--enable-source-maps']
 
 [properties]
 root = '$EMSCRIPTEN_BASE/system'


### PR DESCRIPTION
- update exe_wrapper so meson uses `node --enable-source-maps`

Fixes: #11534

@keymanapp-test-bot skip