### PR TITLE
fix(developer): check HISTORY.md to get last modified date for keyboard_info and model_info 🍒 🏠

### DIFF
--- a/common/web/types/src/util/file-types.ts
+++ b/common/web/types/src/util/file-types.ts
@@ -65,6 +65,16 @@ export type All = Source | Binary;
 export type Any = string;
 
 /**
+ * Standard project file name - history of project in Markdown format
+ */
+export const HISTORY_MD = 'HISTORY.md';
+
+/**
+ * Standard project file name - README in Markdown format
+ */
+export const README_MD = 'README.md';
+
+/**
  * Gets the file type based on extension, dealing with multi-part file
  * extensions. Does not sniff contents of file or assume file existence. Does
  * transform upper-cased file extensions to lower-case.

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -86,7 +86,7 @@ fi
 if builder_start_action test; then
   eslint .
   tsc --build test/
-  readonly C8_THRESHOLD=48
+  readonly C8_THRESHOLD=50
   c8 --reporter=lcov --reporter=text --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha
   builder_echo warning "Coverage thresholds are currently $C8_THRESHOLD%, which is lower than ideal."
   builder_echo warning "Please increase threshold in build.sh as test coverage improves."

--- a/developer/src/kmc/src/commands/buildClasses/BuildKeyboardInfo.ts
+++ b/developer/src/kmc/src/commands/buildClasses/BuildKeyboardInfo.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import { BuildActivity } from './BuildActivity.js';
 import { CompilerCallbacks, KeymanFileTypes } from '@keymanapp/common-types';
 import { KeyboardInfoCompiler } from '@keymanapp/kmc-keyboard-info';
@@ -34,7 +35,8 @@ export class BuildKeyboardInfo extends BuildActivity {
 
     const keyboard = project.files.find(file => file.fileType == KeymanFileTypes.Source.KeymanKeyboard);
     const jsFilename = keyboard ? project.resolveOutputFilePath(keyboard, KeymanFileTypes.Source.KeymanKeyboard, KeymanFileTypes.Binary.WebKeyboard) : null;
-    const lastCommitDate = getLastGitCommitDate(project.projectPath);
+    const historyPath = path.join(project.projectPath, KeymanFileTypes.HISTORY_MD);
+    const lastCommitDate = getLastGitCommitDate(fs.existsSync(historyPath) ? historyPath : project.projectPath);
     const sources = {
       kmpFilename:  project.resolveOutputFilePath(kps, KeymanFileTypes.Source.Package, KeymanFileTypes.Binary.Package),
       kpsFilename: project.resolveInputFilePath(kps),

--- a/developer/src/kmc/src/commands/buildClasses/BuildModelInfo.ts
+++ b/developer/src/kmc/src/commands/buildClasses/BuildModelInfo.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import { BuildActivity } from './BuildActivity.js';
 import { CompilerCallbacks, KeymanFileTypes } from '@keymanapp/common-types';
@@ -62,7 +63,8 @@ export class BuildModelInfo extends BuildActivity {
       return false;
     }
 
-    const lastCommitDate = getLastGitCommitDate(project.projectPath);
+    const historyPath = path.join(project.projectPath, KeymanFileTypes.HISTORY_MD);
+    const lastCommitDate = getLastGitCommitDate(fs.existsSync(historyPath) ? historyPath : project.projectPath);
     const sources = {
       model_id: path.basename(project.projectPath, KeymanFileTypes.Source.Project),
       kmpJsonData,

--- a/developer/src/kmc/src/util/getLastGitCommitDate.ts
+++ b/developer/src/kmc/src/util/getLastGitCommitDate.ts
@@ -6,7 +6,7 @@ export const expectedGitDateFormat = /^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d\d\
 /**
  * Returns the date and time of the last commit from git for the passed in path
  * @param path   Path for which to retrieve the last commit message
- * @returns string, in RFC3339, 'YYYY-MM-DDThh:nn:ssZ'
+ * @returns string, in RFC3339, 'YYYY-MM-DDThh:nn:ss.SSSZ'
  */
 export function getLastGitCommitDate(path: string): string {
   // TZ=UTC0 git log -1 --no-merges --date=format:%Y-%m-%dT%H:%M:%SZ --format=%ad

--- a/developer/src/kmc/test/fixtures/get-last-git-commit-date/README.md
+++ b/developer/src/kmc/test/fixtures/get-last-git-commit-date/README.md
@@ -1,0 +1,5 @@
+# Test file for getLastGitCommitDate.
+
+Note that if changes to this file are committed, the corresponding test in
+test-getLastGitCommitDate.ts will need to be updated to reflect the new date in
+git history.

--- a/developer/src/kmc/test/test-getLastGitCommitDate.ts
+++ b/developer/src/kmc/test/test-getLastGitCommitDate.ts
@@ -14,4 +14,13 @@ describe('getLastGitCommitDate', function () {
     const date = getLastGitCommitDate('/');
     assert.isNull(date);
   });
+
+  it('should return a valid date for a specific file in the repo', async function() {
+    const path = makePathToFixture('get-last-git-commit-date/README.md');
+    const date = getLastGitCommitDate(path);
+    // The expected date was manually extracted using the following command, with msec appended:
+    //   TZ=UTC git log --date=iso-strict-local -- fixtures/get-last-git-commit-date/README.md
+    // If the fixture modified, then this will also need to be updated.
+    assert.equal(date, '2024-06-17T20:43:48.000Z');
+  });
 });


### PR DESCRIPTION
This updates the calculation of the lastModifiedDate property of the .keyboard_info and .model_info file. It now looks for the most recent commit to HISTORY.md, and then falls back to the project folder for .keyboard_info and .model_info.

getLastGitCommitDate now also returns UTC date (it was giving TZ=0 which is affected by daylight saving), and works for a file rather than just for a folder, and a corresponding unit test has been added.

The date strings returned will now always include '.000' msec suffix. I have manually verified that the import into the api.keyman.com database copes with this, and that this change still conforms to the expected schema for .keyboard_info and .model_info files.

Fixes: #11793
Cherry-pick-of: #11805

@keymanapp-test-bot skip