### PR TITLE
fix(windows): add -k parameter for keyboards build.sh 🏠

### DIFF
--- a/oem/firstvoices/windows/src/inst/Makefile
+++ b/oem/firstvoices/windows/src/inst/Makefile
@@ -37,11 +37,11 @@ prereq:
     cd $(KEYMAN_ROOT)\..\keyboards
 
 !ifdef GIT_BASH_FOR_KEYMAN
-    $(GIT_BASH_FOR_KEYMAN) build.sh release/fv
-    $(GIT_BASH_FOR_KEYMAN) build.sh release/packages/fv_all
+    $(GIT_BASH_FOR_KEYMAN) build.sh -k release/fv
+    $(GIT_BASH_FOR_KEYMAN) build.sh -k release/packages/fv_all
 !else
-    start /wait ./build.sh release/fv
-    start /wait ./build.sh release/packages/fv_all
+    start /wait ./build.sh -k release/fv
+    start /wait ./build.sh -k release/packages/fv_all
 !endif
 
     copy release\packages\fv_all\build\fv_all.kmp $(FVROOT)\src\inst


### PR DESCRIPTION
keyboards repo build.sh now uses -k parameter to specify the keyboard to build. This patch does not need to be ported to 18.0 as the 18.0 build does not directly build the keyboard package, but rather uses the currently released version.

Blocked-by: keymanapp/keyboards#2828
Fixes: #11683

@keymanapp-test-bot skip