### PR TITLE
change(web): change after-word whitespace check to be more selective 🍒  🏠

### DIFF
--- a/common/web/lm-worker/src/main/model-compositor.ts
+++ b/common/web/lm-worker/src/main/model-compositor.ts
@@ -459,18 +459,21 @@ export default class ModelCompositor {
       // Valid 'keep' suggestions may have zero length; we still need to evaluate the following code
       // for such cases.
 
-      // Do we need to manipulate the suggestion's transform based on the current state of the context?
-      if(!context.right) {
+      // If we're mid-word, delete its original post-caret text.
+      const tokenization = compositor.tokenize(context);
+      if(tokenization && tokenization.caretSplitsToken) {
+        // While we wait on the ability to provide a more 'ideal' solution, let's at least
+        // go with a more stable, if slightly less ideal, solution for now.
+        //
+        // A predictive text default (on iOS, at least) - immediately wordbreak
+        // on suggestions accepted mid-word.
         suggestion.transform.insert += punctuation.insertAfterWord;
-      } else {
-        // If we're mid-word, delete its original post-caret text.
-        const tokenization = compositor.tokenize(context);
-        if(tokenization && tokenization.caretSplitsToken) {
-          // While we wait on the ability to provide a more 'ideal' solution, let's at least
-          // go with a more stable, if slightly less ideal, solution for now.
-          //
-          // A predictive text default (on iOS, at least) - immediately wordbreak
-          // on suggestions accepted mid-word.
+
+        // Do we need to manipulate the suggestion's transform based on the current state of the context?
+      } else if(!context.right) {
+        suggestion.transform.insert += punctuation.insertAfterWord;
+      } else if(punctuation.insertAfterWord != '') {
+        if(context.right.indexOf(punctuation.insertAfterWord) != 0) {
           suggestion.transform.insert += punctuation.insertAfterWord;
         }
       }


### PR DESCRIPTION
Now only skips emitting the after-word text if it is the immediate prefix of the current right-hand context.

Fixes: #5256
Cherry-pick-of: #11800

@keymanapp-test-bot skip