### PR TITLE
fix(android): clear globe highlight when displaying keyboard picker

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -337,6 +337,14 @@ function menuKeyUp() {
   window.location.hash = hash;
 }
 
+// The keyboard-picker displayed via Android longpress disrupts Web-side
+// gesture-handling; this function helps force-clear the globe key's highlighting.
+function clearGlobeHighlight() {
+  if(keyman.osk && keyman.osk.vkbd && keyman.osk.vkbd.currentLayer.globeKey) {
+    keyman.osk.vkbd.currentLayer.globeKey.highlight(false)
+  }
+}
+
 function hideKeyboard() {
   fragmentToggle = (fragmentToggle + 1) % 100;
   window.location.hash = 'hideKeyboard' + fragmentToggle;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -313,7 +313,12 @@ final class KMKeyboard extends WebView {
       public void onLongPress(MotionEvent event) {
          if (KMManager.getGlobeKeyState() == KMManager.GlobeKeyState.GLOBE_KEY_STATE_DOWN) {
           KMManager.setGlobeKeyState(KMManager.GlobeKeyState.GLOBE_KEY_STATE_LONGPRESS);
+
+          // When we activate the keyboard picker, this will disrupt the JS-side's control
+          // flow for gesture-handling; we should pre-emptively clear the globe key,
+          // as Web will not receive a "globe key up" event.
           loadJavascript("clearGlobeHighlight()");
+
           KMManager.handleGlobeKeyAction(context, true, keyboardType);
           return;
         /* For future implementation

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -313,6 +313,7 @@ final class KMKeyboard extends WebView {
       public void onLongPress(MotionEvent event) {
          if (KMManager.getGlobeKeyState() == KMManager.GlobeKeyState.GLOBE_KEY_STATE_DOWN) {
           KMManager.setGlobeKeyState(KMManager.GlobeKeyState.GLOBE_KEY_STATE_LONGPRESS);
+          loadJavascript("clearGlobeHighlight()");
           KMManager.handleGlobeKeyAction(context, true, keyboardType);
           return;
         /* For future implementation


### PR DESCRIPTION
Fixes: #11532

## User Testing

**TEST_REPRO**: Attempt to reproduce #11532.

1. Install this PR's Keyman for Android build and give all permissions to the application.
2. Check the "Enable Keyman as system-wide keyboard" and set the keyboard as the default keyboard box on the settings page.
3. Install the "Khmer angkor" keyboard by clicking Settings/Install Keyboard/Install from keyman.com.
4. Change the keyboard from Khmer to English by short-pressing the globe key.
5. Open the "Keyboard Picker" dialog by long-pressing the globe key.
6. Select the default keyboard (e.g., English) and then return to the keyman home screen.
7. Verify that the globe key is no longer highlighted.
8. Open the "Keyboard Picker" dialog by long-pressing the globe key (again).
9. Dismiss the keyboard picker without selecting any keyboard.
10. Verify that the globe key is no longer highlighted.