### PR TITLE
chore(common): update C/C++ formatting options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,7 +19,7 @@ AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: AllDefinitions
+AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
@@ -58,7 +58,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true


### PR DESCRIPTION
This change updates two formatting options:

- pointers and references will be left-aligned (`int* foo`). Previously we had the setting to left-align but that got ignored because of the `DerivePointerAlignment` setting which tries to use the style used elsewhere in the file, which is not good to get consistent styling.
- no longer always add a line break after the return type of a function, only if type and name don't fit in a line. Unfortunately clang-format doesn't have a setting to only add the line break if the method definition is too long to fit in one line. The new setting matches the alternative formatting from our style guide.

@keymanapp-test-bot skip