### PR TITLE
fix(developer): layr: fix modifier err message on layer w/o id 🙀 

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/messages.ts
@@ -93,9 +93,17 @@ export class CompilerMessages {
   static Error_InvalidHardware = (o:{formId: string}) => m(this.ERROR_InvalidHardware,
     `layers has invalid value formId=${def(o.formId)}`);
 
+  private static layerIdOrEmpty(layer : string) {
+    if (layer) {
+      return ` on layer id=${def(layer)}`;
+    } else {
+      return '';
+    }
+  }
+
   static ERROR_InvalidModifier = SevError | 0x0014;
   static Error_InvalidModifier = (o:{layer: string, modifiers: string}) => m(this.ERROR_InvalidModifier,
-    `layer has invalid modifiers='${def(o.modifiers)}' on layer id=${def(o.layer)}`);
+    `layer has invalid modifiers='${def(o.modifiers)}'` + CompilerMessages.layerIdOrEmpty(o.layer));
 
   static ERROR_MissingFlicks = SevError | 0x0015;
   static Error_MissingFlicks = (o:{flickId: string, id: string}) => m(this.ERROR_MissingFlicks,

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/error-bogus-modifiers.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/error-bogus-modifiers.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="und" conformsTo="45">
+  <info name="layr-hint-custom-form" />
+
+  <layers formId="us">
+    <layer modifiers="caps bogus">
+      <row keys="a b c" />
+    </layer>
+  </layers>
+
+</keyboard3>

--- a/developer/src/kmc-ldml/test/test-layr.ts
+++ b/developer/src/kmc-ldml/test/test-layr.ts
@@ -129,5 +129,11 @@ describe('layr', function () {
         ]);
       },
     },
+    {
+      subpath: 'sections/layr/error-bogus-modifiers.xml',
+      errors: [
+        CompilerMessages.Error_InvalidModifier({ layer: '', modifiers: 'caps bogus'}),
+      ]
+    },
   ]);
 });


### PR DESCRIPTION
- the error message was broken when there wasn't a layer id (which is allowed)
- add a test case

Fixes: #10553

@keymanapp-test-bot skip