### PR TITLE
refactor(linux): rename methods that deal with keyboard options :checkered_flag: 

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -407,7 +407,7 @@ load_keyboard_options(IBusKeymanEngine *keyman) {
   // Retrieve keyboard options from DConf
   // TODO: May need unique packageID and keyboard ID
   g_message("%s: Loading options for kb_name: %s", __FUNCTION__, keyman->kb_name);
-  GQueue *queue_options = keyman_get_options_queue_fromdconf(keyman->kb_name, keyman->kb_name);
+  GQueue *queue_options = keyman_get_keyboard_options_queue_fromdconf(keyman->kb_name, keyman->kb_name);
   int num_options       = g_queue_get_length(queue_options);
   if (num_options < 1) {
     g_queue_free_full(queue_options, free_km_core_option_item);
@@ -655,7 +655,7 @@ process_persist_action(IBusEngine *engine, km_core_option_item *persist_options)
     g_assert(option->key != NULL && option->value != NULL);
     g_message("%s: Saving keyboard option to DConf", __FUNCTION__);
     // Load the current keyboard options from DConf
-    keyman_put_options_todconf(keyman->kb_name, keyman->kb_name, (gchar *)option->key, (gchar *)option->value);
+    keyman_put_keyboard_options_todconf(keyman->kb_name, keyman->kb_name, (gchar *)option->key, (gchar *)option->value);
   }
 }
 

--- a/linux/ibus-keyman/src/keymanutil.h
+++ b/linux/ibus-keyman/src/keymanutil.h
@@ -78,43 +78,39 @@ void             ibus_keyman_init           (void);
 GList           *ibus_keyman_list_engines   (void);
 IBusComponent   *ibus_keyman_get_component  (void);
 
-// Obtain Keyboard Options list from DConf
-// DConf options are in a list of strings like ['option_key1=value1', 'option_key2=value2']
-//
-// Parameters:
-// package_id  (gchar *): Package ID
-// keyboard_id (gchar *): Keyboard ID
-//
-// Returns a newly allocated gchar**; free with g_strfreev()
-gchar**  keyman_get_options_fromdconf
-                                            (gchar *package_id,
-                                             gchar *keyboard_id);
+/**
+ * Obtain Keyboard Options list from DConf
+ *
+ * DConf options are in a list of strings like ['option_key1=value1', 'option_key2=value2']
+ *
+ * @param   package_id   Package ID
+ * @param   keyboard_id  Keyboard ID
+ * @return               A newly allocated gchar**; free with g_strfreev()
+ */
+gchar **keyman_get_keyboard_options_fromdconf(const gchar *package_id, const gchar *keyboard_id);
 
-// Obtain Keyboard Options from DConf and parse into a GQueue of struct km_core_option_item
-//
-// Parameters:
-// package_id  (gchar *): Package ID
-// keyboard_id (gchar *): Keyboard ID
-//
-// Return a newly allocated GQueue; free with g_queue_free_full()
-GQueue*  keyman_get_options_queue_fromdconf
-                                            (gchar *package_id,
-                                             gchar *keyboard_id);
+/**
+ * Obtain Keyboard Options from DConf and parse into a GQueue of struct km_core_option_item
+ *
+ * @param   package_id   Package ID
+ * @param   keyboard_id  Keyboard ID
+ * @return               A newly allocated GQueue; free with g_queue_free_full()
+ */
+GQueue *keyman_get_keyboard_options_queue_fromdconf(const gchar *package_id, const gchar *keyboard_id);
 
-// Write new keyboard option to DConf.
-// DConf options are in a list of strings like ['option_key1=value1', 'option_key2=value2']
-// If the option key already exists, the value is updated. Otherwise a new string 'option_key=option_value' is appended.
-//
-// Parameters:
-// package_id   (gchar *): Package ID
-// keyboard_id  (gchar *): Keyboard ID
-// option_key   (gchar *): Key for the new option
-// option_value (gchar *): Value of the new option
-void keyman_put_options_todconf
-                                            (gchar *package_id,
-                                             gchar *keyboard_id,
-                                             gchar *option_key,
-                                             gchar *option_value);
+/**
+ * Write new keyboard option to DConf
+ *
+ * DConf options are in a list of strings like ['option_key1=value1', 'option_key2=value2']
+ * If the option key already exists, the value is updated. Otherwise a new string
+ * 'option_key=option_value' is appended.
+ *
+ * @param package_id     Package ID
+ * @param keyboard_id    Keyboard ID
+ * @param option_key     Key for the new option
+ * @param option_value   Value of the new option
+ */
+void keyman_put_keyboard_options_todconf(const gchar *package_id, const gchar *keyboard_id, const gchar *option_key, const gchar *option_value);
 
 G_END_DECLS
 

--- a/linux/ibus-keyman/src/test/keymanutil_tests.c
+++ b/linux/ibus-keyman/src/test/keymanutil_tests.c
@@ -10,21 +10,21 @@
 #define TEST_FIXTURE "keymanutil-test"
 
 void
-_delete_tst_options_key(gchar* testname) {
+_delete_tst_keyboard_options_key(const gchar* testname) {
   g_autofree gchar *path = g_strdup_printf("%s%s/%s/", KEYMAN_DCONF_OPTIONS_PATH, TEST_FIXTURE, testname);
   g_autoptr(GSettings) settings = g_settings_new_with_path(KEYMAN_DCONF_OPTIONS_CHILD_NAME, path);
   g_settings_reset(settings, KEYMAN_DCONF_OPTIONS_KEY);
 }
 
 void
-_set_tst_options_key(gchar* testname, gchar** options) {
+_set_tst_keyboard_options_key(const gchar* testname, const gchar* const* options) {
   g_autofree gchar* path = g_strdup_printf("%s%s/%s/", KEYMAN_DCONF_OPTIONS_PATH, TEST_FIXTURE, testname);
   g_autoptr(GSettings) settings = g_settings_new_with_path(KEYMAN_DCONF_OPTIONS_CHILD_NAME, path);
-  g_settings_set_strv(settings, KEYMAN_DCONF_OPTIONS_KEY, (const gchar* const*)options);
+  g_settings_set_strv(settings, KEYMAN_DCONF_OPTIONS_KEY, options);
 }
 
 gchar**
-_get_tst_options_key(gchar* testname) {
+_get_tst_keyboard_options_key(const gchar* testname) {
   g_autofree gchar* path = g_strdup_printf("%s%s/%s/", KEYMAN_DCONF_OPTIONS_PATH, TEST_FIXTURE, testname);
   g_autoptr(GSettings) settings = g_settings_new_with_path(KEYMAN_DCONF_OPTIONS_CHILD_NAME, path);
   gchar** result = g_settings_get_strv(settings, KEYMAN_DCONF_OPTIONS_KEY);
@@ -126,58 +126,58 @@ _kmn_assert_cmpstrv(gchar** result, gchar** expected) {
 
 //----------------------------------------------------------------------------------------------
 void
-test_keyman_put_options_todconf__invalid() {
+test_keyman_put_keyboard_options_todconf__invalid() {
   // Initialize
-  gchar* testname = "test_keyman_put_options_todconf__test_keyman_put_options_todconf__invalid";
-  _delete_tst_options_key(testname);
+  const gchar* testname = __FUNCTION__;
+  _delete_tst_keyboard_options_key(testname);
 
   // Execute
-  keyman_put_options_todconf(TEST_FIXTURE, testname, "new_key", NULL);
+  keyman_put_keyboard_options_todconf(TEST_FIXTURE, testname, "new_key", NULL);
 
   // Verify
-  g_auto(GStrv) options = _get_tst_options_key(testname);
+  g_auto(GStrv) options = _get_tst_keyboard_options_key(testname);
   g_assert_nonnull(options);
   g_assert_null(options[0]);
 
   // Cleanup
-  _delete_tst_options_key(testname);
+  _delete_tst_keyboard_options_key(testname);
 }
 
 void
-test_keyman_put_options_todconf__new_key() {
+test_keyman_put_keyboard_options_todconf__new_key() {
   // Initialize
-  gchar* testname = "test_keyman_put_options_todconf__new_key";
-  _delete_tst_options_key(testname);
+  const gchar* testname = __FUNCTION__;
+  _delete_tst_keyboard_options_key(testname);
   g_autofree gchar* value = g_strdup_printf("%d", g_test_rand_int());
 
   // Execute
-  keyman_put_options_todconf(TEST_FIXTURE, testname, "new_key", value);
+  keyman_put_keyboard_options_todconf(TEST_FIXTURE, testname, "new_key", value);
 
   // Verify
-  g_auto(GStrv) options = _get_tst_options_key(testname);
+  g_auto(GStrv) options = _get_tst_keyboard_options_key(testname);
   g_autofree gchar* expected = g_strdup_printf("new_key=%s", value);
   g_assert_nonnull(options);
   g_assert_cmpstr(options[0], ==, expected);
   g_assert_null(options[1]);
 
   // Cleanup
-  _delete_tst_options_key(testname);
+  _delete_tst_keyboard_options_key(testname);
 }
 
 void
-test_keyman_put_options_todconf__other_keys() {
+test_keyman_put_keyboard_options_todconf__other_keys() {
   // Initialize
-  gchar* testname = "test_keyman_put_options_todconf__other_keys";
-  _delete_tst_options_key(testname);
-  gchar* existingKeys[] = {"key1=val1", "key2=val2", NULL};
-  _set_tst_options_key(testname, existingKeys);
+  const gchar* testname = __FUNCTION__;
+  _delete_tst_keyboard_options_key(testname);
+  const gchar* const existingKeys[] = {"key1=val1", "key2=val2", NULL};
+  _set_tst_keyboard_options_key(testname, existingKeys);
   g_autofree gchar* value = g_strdup_printf("%d", g_test_rand_int());
 
   // Execute
-  keyman_put_options_todconf(TEST_FIXTURE, testname, "new_key", value);
+  keyman_put_keyboard_options_todconf(TEST_FIXTURE, testname, "new_key", value);
 
   // Verify
-  g_auto(GStrv) options = _get_tst_options_key(testname);
+  g_auto(GStrv) options = _get_tst_keyboard_options_key(testname);
   g_autofree gchar* expected = g_strdup_printf("new_key=%s", value);
   g_assert_nonnull(options);
   g_assert_cmpstr(options[0], ==, "key1=val1");
@@ -186,23 +186,23 @@ test_keyman_put_options_todconf__other_keys() {
   g_assert_null(options[3]);
 
   // Cleanup
-  _delete_tst_options_key(testname);
+  _delete_tst_keyboard_options_key(testname);
 }
 
 void
-test_keyman_put_options_todconf__existing_key() {
+test_keyman_put_keyboard_options_todconf__existing_key() {
   // Initialize
-  gchar* testname = "test_keyman_put_options_todconf__existing_key";
-  _delete_tst_options_key(testname);
-  gchar* existingKeys[] = {"key1=val1", "new_key=val2", NULL};
-  _set_tst_options_key(testname, existingKeys);
+  const gchar* testname = __FUNCTION__;
+  _delete_tst_keyboard_options_key(testname);
+  const gchar* const existingKeys[] = {"key1=val1", "new_key=val2", NULL};
+  _set_tst_keyboard_options_key(testname, existingKeys);
   g_autofree gchar* value = g_strdup_printf("%d", g_test_rand_int());
 
   // Execute
-  keyman_put_options_todconf(TEST_FIXTURE, testname, "new_key", value);
+  keyman_put_keyboard_options_todconf(TEST_FIXTURE, testname, "new_key", value);
 
   // Verify
-  g_auto(GStrv) options = _get_tst_options_key(testname);
+  g_auto(GStrv) options = _get_tst_keyboard_options_key(testname);
   g_autofree gchar* expected = g_strdup_printf("new_key=%s", value);
   g_assert_nonnull(options);
   g_assert_cmpstr(options[0], ==, "key1=val1");
@@ -210,7 +210,7 @@ test_keyman_put_options_todconf__existing_key() {
   g_assert_null(options[2]);
 
   // Cleanup
-  _delete_tst_options_key(testname);
+  _delete_tst_keyboard_options_key(testname);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -1107,10 +1107,10 @@ int main(int argc, char* argv[]) {
   }
 
   // Add tests
-  g_test_add_func("/keymanutil/keyman_put_options_todconf/invalid", test_keyman_put_options_todconf__invalid);
-  g_test_add_func("/keymanutil/keyman_put_options_todconf/new_key", test_keyman_put_options_todconf__new_key);
-  g_test_add_func("/keymanutil/keyman_put_options_todconf/other_keys", test_keyman_put_options_todconf__other_keys);
-  g_test_add_func("/keymanutil/keyman_put_options_todconf/existing_key", test_keyman_put_options_todconf__existing_key);
+  g_test_add_func("/keymanutil/keyman_put_keyboard_options_todconf/invalid", test_keyman_put_keyboard_options_todconf__invalid);
+  g_test_add_func("/keymanutil/keyman_put_keyboard_options_todconf/new_key", test_keyman_put_keyboard_options_todconf__new_key);
+  g_test_add_func("/keymanutil/keyman_put_keyboard_options_todconf/other_keys", test_keyman_put_keyboard_options_todconf__other_keys);
+  g_test_add_func("/keymanutil/keyman_put_keyboard_options_todconf/existing_key", test_keyman_put_keyboard_options_todconf__existing_key);
 
   g_test_add_func("/keymanutil/keyman_get_custom_keyboard_dictionary/values", test_keyman_get_custom_keyboard_dictionary__values);
   g_test_add_func("/keymanutil/keyman_get_custom_keyboard_dictionary/invalid", test_keyman_get_custom_keyboard_dictionary__invalid);

--- a/linux/ibus-keyman/tests/testfixture.cpp
+++ b/linux/ibus-keyman/tests/testfixture.cpp
@@ -320,7 +320,7 @@ static void test_source(IBusKeymanTestsFixture *fixture, gconstpointer user_data
     if (option.type == km::tests::KOT_INPUT) {
       auto key = g_utf16_to_utf8((gunichar2 *)option.key.c_str(), option.key.length(), NULL, NULL, NULL);
       auto value = g_utf16_to_utf8((gunichar2 *)option.value.c_str(), option.value.length(), NULL, NULL, NULL);
-      keyman_put_options_todconf(data->test_name, data->test_name, key, value);
+      keyman_put_keyboard_options_todconf(data->test_name, data->test_name, key, value);
     }
   }
   g_settings_sync();


### PR DESCRIPTION
This renames the existing methods that read and write keyboard options so that it's visible from the name that they read/write keyboard options. This is in preparation of new methods that read and write more general options, related to #7697.

@keymanapp-test-bot skip