### PR TITLE
fix(web): use fat-finger data with simple keypresses

### DIFF
--- a/common/web/input-processor/src/corrections.ts
+++ b/common/web/input-processor/src/corrections.ts
@@ -80,7 +80,12 @@ export function distributionFromDistanceMaps(squaredDistMaps: Map<ActiveKeyBase,
     for(let key of squaredDistMap.keys()) {
       // We've found that in practice, dist^-4 seems to work pretty well.  (Our input has dist^2.)
       // (Note:  our rule of thumb here has only been tested for layout-based distances.)
-      const entry = 1 / (Math.pow(squaredDistMap.get(key), 2) + 1e-6); // Prevent div-by-0 errors.
+      //
+      // The 3e-5 fudge-factor may seem a bit high, but it has two purposes:
+      // 1. Prevent div-by-0 errors
+      // 2. Ensures that the main key's probability doesn't get SO high that we don't
+      //    consider correcting to immediate neighbors, even if perfectly accurate.
+      const entry = 1 / (Math.pow(squaredDistMap.get(key), 2) + 3e-5);
       totalMass += entry;
 
       // In case of duplicate key IDs; this can occur if multiple sets are specified.

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -628,7 +628,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
           try {
             shouldLockLayer && this.lockLayer(true);
             // Once the best coord to use for fat-finger calculations has been determined:
-            keyResult = this.modelKeyClick(gestureStage.item, coord);
+            keyResult = this.modelKeyClick(gestureStage.item, coord, correctionKeyDistribution);
           } finally {
             shouldLockLayer && this.lockLayer(false);
           }


### PR DESCRIPTION
While investigating the current state of predictive text for a different work item, I noticed that we weren't actually getting fat-finger data from simple keypresses with the current state of `master` and 17.0.  The data was calculated... it just wasn't passed along properly.

## User Testing

TEST_FAT_FINGER: Using Keyman for Android, verify that corrections to nearby keys works properly.

1. Tap `T` near its center, then tap `i`.  
2. Verify that corrections starting with `To` appear.