### PR TITLE
feat(web): add and enable auto-correction 📚 

### DIFF
--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -333,6 +333,11 @@ declare interface Suggestion {
    * to the input text.  Ex:  'keep', 'emoji', 'correction', etc.
    */
   tag?: SuggestionTag;
+
+  /**
+   * Set to true if this suggestion is a valid auto-accept target.
+   */
+  autoAccept?: boolean
 }
 
 interface Reversion extends Suggestion {

--- a/common/web/input-processor/src/text/prediction/predictionContext.ts
+++ b/common/web/input-processor/src/text/prediction/predictionContext.ts
@@ -341,7 +341,7 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
         this.keepSuggestion = s as Keep;
       }
 
-      if(s.autoAccept) {
+      if(s.autoAccept && !this.selected) {
         this.selected = s;
       }
     }

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -175,6 +175,7 @@ export class BannerSuggestion {
     }
 
     this.currentWidth = this.collapsedWidth;
+    this.highlight(suggestion?.autoAccept);
     this.updateLayout();
   }
 
@@ -551,6 +552,16 @@ export class SuggestionBanner extends Banner {
       if(sourceTracker.source) {
         source.terminate(true);
         return;
+      }
+
+      const autoselection = this._predictionContext.selected;
+      this._predictionContext.selected = null;
+      if(autoselection) {
+        this.options.forEach((entry) => {
+          if(entry.suggestion == autoselection) {
+            entry.highlight(false)
+          };
+        });
       }
 
       this.scrollState = new BannerScrollState(source.currentSample, this.container.scrollLeft);

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -612,11 +612,12 @@ export class SuggestionBanner extends Banner {
           // auto-correct suggestion and its highlighting.
           this._predictionContext.selected = autoselection;
           if(autoselection) {
-            this.options.forEach((entry) => {
+            for(let entry of this.options) {
               if(entry.suggestion == autoselection) {
                 entry.highlight(true);
+                break;
               };
-            });
+            }
           }
         });
 

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -13,7 +13,7 @@ import {
 
 import { BANNER_GESTURE_SET } from './bannerGestureSet.js';
 
-import { DeviceSpec, Keyboard, KeyboardProperties } from '@keymanapp/keyboard-processor';
+import { DeviceSpec, Keyboard, KeyboardProperties, timedPromise } from '@keymanapp/keyboard-processor';
 import { Banner } from './banner.js';
 import { ParsedLengthStyle } from '../lengthStyle.js';
 import { getFontSizeStyle } from '../fontSizeUtils.js';
@@ -559,7 +559,7 @@ export class SuggestionBanner extends Banner {
       if(autoselection) {
         this.options.forEach((entry) => {
           if(entry.suggestion == autoselection) {
-            entry.highlight(false)
+            entry.highlight(false);
           };
         });
       }
@@ -596,6 +596,30 @@ export class SuggestionBanner extends Banner {
       }
 
       const terminationHandler = () => {
+        const currentSuggestions = this.currentSuggestions;
+        // First, schedule reselection of the autoselected suggestion.
+        // We shouldn't do it synchronously, as suggestion acceptance triggers
+        // _after_ this handler is called.
+        // Delaying via the task queue is enough to get the desired order of events.
+        timedPromise(0).then(async () => {
+          // If the suggestion list instance has changed, our state has changed; do
+          // not reselect.
+          if(currentSuggestions != this.currentSuggestions) {
+            return;
+          }
+
+          // The suggestions are still current?  Then restore the original
+          // auto-correct suggestion and its highlighting.
+          this._predictionContext.selected = autoselection;
+          if(autoselection) {
+            this.options.forEach((entry) => {
+              if(entry.suggestion == autoselection) {
+                entry.highlight(true);
+              };
+            });
+          }
+        });
+
         if(sourceTracker.suggestion) {
           clearSelection(sourceTracker.suggestion);
           sourceTracker.suggestion = null;
@@ -614,7 +638,15 @@ export class SuggestionBanner extends Banner {
       // The actual result comes in via the sequence's `stage` event.
       sequence.once('stage', (result) => {
         const suggestion = result.item; // Should also == sourceTracker.suggestion.
-        if(suggestion && !this.scrollState.hasScrolled) {
+        // 1. A valid suggestion has been selected
+        // 2. The user wasn't scrolling the banner.  (If they were, they likely
+        //    need to lift their finger to select a newly-visible suggestion!)
+        // 3. The suggestions themselves are still valid; avoid suggestion
+        //    double-application or similar.
+        if(suggestion && !this.scrollState.hasScrolled && this.currentSuggestions.length > 0) {
+          // Invalidate the suggestions internally, but don't visually update;
+          // this will avoid banner-flicker.
+          this.currentSuggestions = [];
           this.predictionContext.accept(suggestion.suggestion).then(() => {
             // Reset the scroll state
             this.container.scrollLeft = this.isRTL ? this.container.scrollWidth : 0;


### PR DESCRIPTION
This establishes something I've been waiting a long time to enable:  when one prediction is sufficiently more likely than all alternatives, it will be automatically selected for application when tapping the space bar.  In short:  auto-correct.

Current conditions for auto-correct:
- The pre-existing prefix for the correction/prediction is not zero-length.  (We don't want to auto-select 'the' from an empty string with SIL EuroLatin, after all.)
- Any "correction" applied to generate the suggestion must be the highest-probability correction that leads to a valid suggestion.
    - It doesn't have to be the most likely keystroke - just the most likely keystroke that can reasonably produce a word from the model.
- The suggestion to be auto-selected must have at least twice the probability of all other generated suggestions.
    - I started off with a harsher threshold, but auto-selection was pretty rare then.  It could probably be more aggressive... but that does raise the risk of false positives.
    - This is not part-of-speech aware in any sense - if "book" and "books" are about as likely as each other, "boo" would not auto-select either "book" or "books"; neither would win, even if they were the only words in the model, as there's no clear probability winner.

These conditions may, of course, be further tweaked... but this seemed to be a reasonable initial set to use for testing.

One interaction that should probably be reviewed for correctness + user-friendliness:  While the banner is receiving _any_ mouse-based or touch-based interaction, the auto-selected suggestion will be deselected - even if just to scroll before releasing the banner.  If it _was_ a scrolling interaction, the original auto-selected suggestion will be reselected and rehighlighted.  If a suggestion was applied, however, there will be no reselection or re-highlighting.

![Animated gif of the interaction and its variations](https://github.com/keymanapp/keyman/assets/25213402/f9d396b8-3428-4ca5-93d6-89c941622af9)

----

#### Notes for review: 

This PR's changes utilize existing plumbing that was prepared all the way back with #1747 during 12.0-alpha.  We prevented it from actually auto-applying anything at the time, but most of the design work was done back then.  

#3702 was added a while back in order to swallow a single whitespace tap after applying a suggestion via banner UI.  We wish to maintain that here.  However, we don't swallow the whitespace after application if it was triggered by pressing the spacebar... because we'd have already tapped the spacebar once.

----

## User Testing

**TEST_LOOK_AND_FEEL**: Using Keyman for Android, play around with predictive text and report back on how the interactions feel.

- _**When**_ it presents an automatically-selected suggestion, do banner interactions feel intuitive?
    - Be sure to try scrolling the banner when testing this.
    - As might be noticed by the recording above, I find `tempta` to be a good "prompt" input for this.  Do try others, though.
    - Do you see any banner "flicker" during these interactions?  Things should feel as smooth as they usually do.
- _**When**_ it presents an automatically-selected suggestion, do keyboard interactions feel intuitive?
    - Just in case, be sure to hit the spacebar at least twice in a row when an automatically-selected suggestion is selected (before the first tap).
    - Also, try selecting a different suggestion from the banner, then tapping spacebar.
    - Also, try selecting the auto-selected suggestion from the banner, then tapping spacebar.
- If the answer to either question above is "no", FAIL the test and report what felt wrong.
- Do NOT fail this test if you expect something to be automatically selected, but it isn't.
- ... but DO fail this test if a suggestion isn't auto-selected when it's the only one available.

**TEST_POST_APPLY_WHITESPACE**:  Using Keyman for Android...

- With an auto-selected suggestion available, press the spacebar twice in a row.
    - There should be a total of two spaces after the applied suggestion.
- With an auto-selected suggestion available, press the suggestion, then tap the spacebar twice in a row.
    - There should be a total of two spaces after the applied suggestion.

**TEST_POST_APPLY_BACKSPACE**:  Using Keyman for Android...

- With an auto-selected suggestion available, press the spacebar to apply it.
- Then, press backspace.
- You should see a "suggestion" that restores the word as it was before you applied the suggestion.
    - The "suggestion" should not be auto-selected.