### PR TITLE
refactor(common/models): move TS priority-queue implementation to web-utils 📚 

### DIFF
--- a/common/models/templates/src/index.ts
+++ b/common/models/templates/src/index.ts
@@ -2,7 +2,6 @@ export {
   SENTINEL_CODE_UNIT, applyTransform, buildMergedTransform, isHighSurrogate, isLowSurrogate, isSentinel,
   transformToSuggestion, defaultApplyCasing
 } from "./common.js";
-export { default as PriorityQueue, Comparator } from "./priority-queue.js";
 export { default as QuoteBehavior } from "./quote-behavior.js";
 export { Tokenization, tokenize, getLastPreCaretToken, wordbreak } from "./tokenization.js";
 export { default as TrieModel, TrieModelOptions } from "./trie-model.js";

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -26,12 +26,11 @@
 // Should probably make a 'lm-utils' submodule.
 
 // Allows the kmwstring bindings to resolve.
-import { extendString } from "@keymanapp/web-utils";
+import { extendString, PriorityQueue } from "@keymanapp/web-utils";
 import { default as defaultWordBreaker } from "@keymanapp/models-wordbreakers";
 
 import { applyTransform, isHighSurrogate, isSentinel, SENTINEL_CODE_UNIT, transformToSuggestion } from "./common.js";
 import { getLastPreCaretToken } from "./tokenization.js";
-import PriorityQueue from "./priority-queue.js";
 
 extendString();
 

--- a/common/web/lm-worker/src/main/correction/distance-modeler.ts
+++ b/common/web/lm-worker/src/main/correction/distance-modeler.ts
@@ -1,4 +1,5 @@
-import { Comparator, isHighSurrogate, SENTINEL_CODE_UNIT, PriorityQueue } from '@keymanapp/models-templates';
+import { isHighSurrogate, SENTINEL_CODE_UNIT } from '@keymanapp/models-templates';
+import { QueueComparator as Comparator, PriorityQueue } from '@keymanapp/web-utils';
 
 import { ClassicalDistanceCalculation, EditToken } from './classical-calculation.js';
 import { ExecutionTimer, STANDARD_TIME_BETWEEN_DEFERS } from './execution-timer.js';

--- a/common/web/lm-worker/src/test/mocha/cases/edit-distance/distance-modeler.js
+++ b/common/web/lm-worker/src/test/mocha/cases/edit-distance/distance-modeler.js
@@ -2,6 +2,7 @@ import { assert } from 'chai';
 import * as models from '#./models/index.js';
 import * as correction from '#./correction/index.js';
 
+import { PriorityQueue } from '@keymanapp/web-utils';
 import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
 
 function buildTestTimer() {
@@ -142,7 +143,7 @@ describe('Correction Distance Modeler', function() {
       assert.equal(edges.length, expectedChildCount);
 
       // One final bit, which is a bit of integration - we know the top two nodes that should result.
-      let queue = new models.PriorityQueue(correction.QUEUE_NODE_COMPARATOR, edges);
+      let queue = new PriorityQueue(correction.QUEUE_NODE_COMPARATOR, edges);
 
       let firstEdge = queue.dequeue();
       assert.equal(firstEdge.priorInput[0].sample.insert, 't');
@@ -185,13 +186,13 @@ describe('Correction Distance Modeler', function() {
       ];
 
       let layer1Edges = rootNode.buildSubstitutionEdges(synthDistribution1);
-      let layer1Queue = new models.PriorityQueue(correction.QUEUE_NODE_COMPARATOR, layer1Edges);
+      let layer1Queue = new PriorityQueue(correction.QUEUE_NODE_COMPARATOR, layer1Edges);
 
       let tEdge = layer1Queue.dequeue();
       assertEdgeChars(tEdge, 't', 't');
 
       let layer2Edges = tEdge.buildSubstitutionEdges(synthDistribution2);
-      let layer2Queue = new models.PriorityQueue(correction.QUEUE_NODE_COMPARATOR, layer2Edges);
+      let layer2Queue = new PriorityQueue(correction.QUEUE_NODE_COMPARATOR, layer2Edges);
 
       let eEdge = layer2Queue.dequeue();
       assertEdgeChars(eEdge, 'e', 'e');
@@ -208,7 +209,7 @@ describe('Correction Distance Modeler', function() {
       let layer3eEdges  = eEdge.buildSubstitutionEdges(synthDistribution3);
       let layer3hEdges  = hEdge.buildSubstitutionEdges(synthDistribution3);
       let layer3ehEdges = ehEdge.buildSubstitutionEdges(synthDistribution3);
-      let layer3Queue = new models.PriorityQueue(correction.QUEUE_NODE_COMPARATOR, layer3eEdges.concat(layer3hEdges).concat(layer3ehEdges));
+      let layer3Queue = new PriorityQueue(correction.QUEUE_NODE_COMPARATOR, layer3eEdges.concat(layer3hEdges).concat(layer3ehEdges));
 
       // Find the first result with an actual word directly represented.
       let bestEdge;

--- a/common/web/utils/src/index.ts
+++ b/common/web/utils/src/index.ts
@@ -23,6 +23,8 @@ export { default as TimeoutPromise, timedPromise } from "./timeoutPromise.js";
 
 export { Uni_IsSurrogate1, Uni_IsSurrogate2 } from "./surrogates.js";
 
+export { default as PriorityQueue, QueueComparator } from "./priority-queue.js"
+
 // // Uncomment the following line and run the bundled output to verify successful
 // // esbuild bundling of this submodule:
 // console.log(Version.CURRENT.toString());

--- a/common/web/utils/src/priority-queue.ts
+++ b/common/web/utils/src/priority-queue.ts
@@ -11,11 +11,11 @@
  * - value > 0 if `b` should come before `a`
  * - 0 if they should be treated equally.
  */
-export type Comparator<Type> = (a: Type, b: Type) => number;
+export type QueueComparator<Type> = (a: Type, b: Type) => number;
 
 export default class PriorityQueue<Type> {
 
-  private comparator: Comparator<Type>;
+  private comparator: QueueComparator<Type>;
   private heap: Type[];
 
   /**
@@ -29,8 +29,8 @@ export default class PriorityQueue<Type> {
    * the first parameter should precede the second parameter.
    * @param initialEntries
    */
-  constructor(comparator: Comparator<Type>, initialEntries?: Type[]);
-  constructor(arg1: Comparator<Type> | PriorityQueue<Type>, initialEntries?: Type[]) {
+  constructor(comparator: QueueComparator<Type>, initialEntries?: Type[]);
+  constructor(arg1: QueueComparator<Type> | PriorityQueue<Type>, initialEntries?: Type[]) {
     if(typeof arg1 != 'function') {
       this.comparator = arg1.comparator;
       // Shallow-copies are fine.

--- a/common/web/utils/src/test/priorityQueue.js
+++ b/common/web/utils/src/test/priorityQueue.js
@@ -3,7 +3,7 @@
  */
 
 import { assert } from 'chai';
-import { PriorityQueue } from '@keymanapp/models-templates';
+import { PriorityQueue } from '@keymanapp/web-utils';
 
 describe('Priority queue', function() {
   it('can act as a min-heap', function () {


### PR DESCRIPTION
This PR was originally part of #10973.  

Note how the `PriorityQueue` implementation is currently part of `common/models/templates`, but for dictionary-based wordbreaking, it's needed in `common/models/wordbreakers` as well.   As the `wordbreakers` package is lower-level and is imported _by_ `common/models/templates`, it'd be awkward to have an inverted import.

Note that it's already used fairly extensively within `common/web/lm-worker` via import from the `common/models/template` package.

@keymanapp-test-bot skip