### PR TITLE
feat(web): provide lexicon probabilities directly on the search path 📚 

### DIFF
--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -205,7 +205,7 @@ class Traversal implements LexiconTraversal {
     }
   }
 
-  get maxP(): number {
+  get p(): number {
     return this.root.weight / this.totalWeight;
   }
 }

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -108,6 +108,10 @@ class Traversal implements LexiconTraversal {
 
   *children(): Generator<{char: string, traversal: () => LexiconTraversal}> {
     let root = this.root;
+
+    // We refer to the field multiple times in this method, and it doesn't change.
+    // This also assists minification a bit, since we can't minify when re-accessing
+    // through `this.`.
     const totalWeight = this.totalWeight;
 
     if(root.type == 'internal') {
@@ -180,11 +184,10 @@ class Traversal implements LexiconTraversal {
   }
 
   get entries() {
-    const totalWeight = this.totalWeight;
-    const entryMapper = function(value: Entry) {
+    const entryMapper = (value: Entry) => {
       return {
         text: value.content,
-        p: value.weight / totalWeight
+        p: value.weight / this.totalWeight
       }
     }
 
@@ -305,7 +308,7 @@ export default class TrieModel implements LexicalModel {
   }
 
   public traverseFromRoot(): LexiconTraversal {
-    return new Traversal(this._trie['root'], '', this._trie.totalWeight);
+    return new Traversal(this._trie.root, '', this._trie.totalWeight);
   }
 };
 
@@ -386,7 +389,7 @@ interface Entry {
  * Wrapper class for the trie and its nodes.
  */
 class Trie {
-  private root: Node;
+  public readonly root: Node;
   /** The total weight of the entire trie. */
   readonly totalWeight: number;
   /**

--- a/common/models/templates/test/test-trie-traversal.js
+++ b/common/models/templates/test/test-trie-traversal.js
@@ -13,6 +13,12 @@ var smpForUnicode = function(code){
   return String.fromCharCode(H, L);
 }
 
+// Prob:  entry weight / total weight
+// "the" is the highest-weighted word in the fixture.
+const PROB_OF_THE     = 1000 / 500500;
+const PROB_OF_TRUE    =  607 / 500500;
+const PROB_OF_TROUBLE =  267 / 500500;
+
 describe('Trie traversal abstractions', function() {
   it('root-level iteration over child nodes', function() {
     var model = new TrieModel(jsonFixture('tries/english-1000'));
@@ -34,10 +40,6 @@ describe('Trie traversal abstractions', function() {
 
   it('traversal with simple internal nodes', function() {
     var model = new TrieModel(jsonFixture('tries/english-1000'));
-
-    // Prob:  entry weight / total weight
-    // "the" is the highest-weighted word in the fixture.
-    const PROB_OF_THE = 1000 / 500500;
 
     let rootTraversal = model.traverseFromRoot();
     assert.isDefined(rootTraversal);
@@ -103,7 +105,6 @@ describe('Trie traversal abstractions', function() {
 
   it('traversal over compact leaf node', function() {
     var model = new TrieModel(jsonFixture('tries/english-1000'));
-    const PROB_OF_TROUBLE = 267 / 500500;
 
     let rootTraversal = model.traverseFromRoot();
     assert.isDefined(rootTraversal);
@@ -117,7 +118,7 @@ describe('Trie traversal abstractions', function() {
         assert.isDefined(traversalInner1);
         assert.isArray(child.traversal().entries);
         assert.isEmpty(child.traversal().entries);
-        assert.equal(traversalInner1.p, 1000 / 500500 /* prob of 'the' */);
+        assert.equal(traversalInner1.p, PROB_OF_THE);
 
         for(let tChild of traversalInner1.children()) {
           if(tChild.char == 'r') {
@@ -125,7 +126,7 @@ describe('Trie traversal abstractions', function() {
             assert.isDefined(traversalInner2);
             assert.isArray(tChild.traversal().entries);
             assert.isEmpty(tChild.traversal().entries);
-            assert.equal(traversalInner2.p, 607 / 500500 /* prob of 'true', the best 'tr-' entry */);
+            assert.equal(traversalInner2.p, PROB_OF_TRUE);
 
             for(let rChild of traversalInner2.children()) {
               if(rChild.char == 'o') {

--- a/common/models/templates/test/test-trie-traversal.js
+++ b/common/models/templates/test/test-trie-traversal.js
@@ -21,7 +21,7 @@ describe('Trie traversal abstractions', function() {
     assert.isDefined(rootTraversal);
 
     let rootKeys = ['t', 'o', 'a', 'i', 'w', 'h', 'f', 'b', 'n', 'y', 's', 'm',
-                    'u', 'c', 'd', 'l', 'e', 'j', 'p', 'g', 'v', 'k', 'r', 'q']
+                    'u', 'c', 'd', 'l', 'e', 'j', 'p', 'g', 'v', 'k', 'r', 'q'];
 
     for(let child of rootTraversal.children()) {
       let keyIndex = rootKeys.indexOf(child.char);
@@ -66,7 +66,7 @@ describe('Trie traversal abstractions', function() {
                 assert.isDefined(traversalInner3);
 
                 assert.isDefined(traversalInner3.entries);
-                assert.equal(traversalInner3.entries[0], "the");
+                assert.equal(traversalInner3.entries[0].text, "the");
 
                 for(let eChild of traversalInner3.children()) {
                   let keyIndex = eKeys.indexOf(eChild.char);
@@ -140,7 +140,7 @@ describe('Trie traversal abstractions', function() {
                   } else {
                     let finalTraversal = curChild.traversal();
                     assert.isDefined(finalTraversal.entries);
-                    assert.equal(finalTraversal.entries[0], 'trouble');
+                    assert.equal(finalTraversal.entries[0].text, 'trouble');
                     eSuccess = true;
                   }
                 } while (leafChildSequence.length > 0);
@@ -232,7 +232,7 @@ describe('Trie traversal abstractions', function() {
                   } else {
                     let finalTraversal = curChild.traversal();
                     assert.isDefined(finalTraversal.entries);
-                    assert.equal(finalTraversal.entries[0], smpA + smpP + 'pl' + smpE);
+                    assert.equal(finalTraversal.entries[0].text, smpA + smpP + 'pl' + smpE);
                     eSuccess = true;
                   }
                 } while (leafChildSequence.length > 0);

--- a/common/models/templates/test/test-trie-traversal.js
+++ b/common/models/templates/test/test-trie-traversal.js
@@ -54,7 +54,7 @@ describe('Trie traversal abstractions', function() {
         assert.isDefined(traversalInner1);
         assert.isArray(child.traversal().entries);
         assert.isEmpty(child.traversal().entries);
-        assert.equal(traversalInner1.maxP, PROB_OF_THE);
+        assert.equal(traversalInner1.p, PROB_OF_THE);
 
         for(let tChild of traversalInner1.children()) {
           if(tChild.char == 'h') {
@@ -63,7 +63,7 @@ describe('Trie traversal abstractions', function() {
             assert.isDefined(traversalInner2);
             assert.isEmpty(tChild.traversal().entries);
             assert.isArray(tChild.traversal().entries);
-            assert.equal(traversalInner2.maxP, PROB_OF_THE);
+            assert.equal(traversalInner2.p, PROB_OF_THE);
 
             for(let hChild of traversalInner2.children()) {
               if(hChild.char == 'e') {
@@ -77,14 +77,14 @@ describe('Trie traversal abstractions', function() {
                     p: PROB_OF_THE
                   }
                 ]);
-                assert.equal(traversalInner3.maxP, PROB_OF_THE);
+                assert.equal(traversalInner3.p, PROB_OF_THE);
 
                 for(let eChild of traversalInner3.children()) {
                   let keyIndex = eKeys.indexOf(eChild.char);
                   assert.notEqual(keyIndex, -1, "Did not find char '" + eChild.char + "' in array!");
 
                   // THE is not accessible if any of the sub-tries of our 'e' node (traversalInner3).
-                  assert.isBelow(eChild.traversal().maxP, PROB_OF_THE);
+                  assert.isBelow(eChild.traversal().p, PROB_OF_THE);
                   eKeys.splice(keyIndex, 1);
                 }
               }
@@ -117,7 +117,7 @@ describe('Trie traversal abstractions', function() {
         assert.isDefined(traversalInner1);
         assert.isArray(child.traversal().entries);
         assert.isEmpty(child.traversal().entries);
-        assert.equal(traversalInner1.maxP, 1000 / 500500 /* prob of 'the' */);
+        assert.equal(traversalInner1.p, 1000 / 500500 /* prob of 'the' */);
 
         for(let tChild of traversalInner1.children()) {
           if(tChild.char == 'r') {
@@ -125,7 +125,7 @@ describe('Trie traversal abstractions', function() {
             assert.isDefined(traversalInner2);
             assert.isArray(tChild.traversal().entries);
             assert.isEmpty(tChild.traversal().entries);
-            assert.equal(traversalInner2.maxP, 607 / 500500 /* prob of 'true', the best 'tr-' entry */);
+            assert.equal(traversalInner2.p, 607 / 500500 /* prob of 'true', the best 'tr-' entry */);
 
             for(let rChild of traversalInner2.children()) {
               if(rChild.char == 'o') {
@@ -154,10 +154,10 @@ describe('Trie traversal abstractions', function() {
                   if(leafChildSequence.length > 0) {
                     assert.isArray(curChild.traversal().entries);
                     assert.isEmpty(curChild.traversal().entries);
-                    assert.equal(curChild.traversal().maxP, PROB_OF_TROUBLE);
+                    assert.equal(curChild.traversal().p, PROB_OF_TROUBLE);
                   } else {
                     let finalTraversal = curChild.traversal();
-                    assert.equal(finalTraversal.maxP, PROB_OF_TROUBLE);
+                    assert.equal(finalTraversal.p, PROB_OF_TROUBLE);
                     assert.isDefined(finalTraversal.entries);
                     assert.deepEqual(finalTraversal.entries, [
                       {
@@ -207,7 +207,7 @@ describe('Trie traversal abstractions', function() {
         assert.isDefined(traversalInner1);
         assert.isArray(traversalInner1.entries);
         assert.isEmpty(traversalInner1.entries);
-        assert.equal(traversalInner1.maxP, 0.5); // The two entries are equally weighted.
+        assert.equal(traversalInner1.p, 0.5); // The two entries are equally weighted.
 
         for(let aChild of traversalInner1.children()) {
           if(aChild.char == smpP) {
@@ -216,7 +216,7 @@ describe('Trie traversal abstractions', function() {
             assert.isDefined(traversalInner2);
             assert.isArray(traversalInner2.entries);
             assert.isEmpty(traversalInner2.entries);
-            assert.equal(traversalInner2.maxP, 0.5);
+            assert.equal(traversalInner2.p, 0.5);
 
             for(let pChild of traversalInner2.children()) {
               let keyIndex = pKeys.indexOf(pChild.char);
@@ -228,7 +228,7 @@ describe('Trie traversal abstractions', function() {
                 assert.isDefined(traversalInner3);
                 assert.isArray(traversalInner3.entries);
                 assert.isEmpty(traversalInner3.entries);
-                assert.equal(traversalInner3.maxP, 0.5);
+                assert.equal(traversalInner3.p, 0.5);
 
                 // Now to handle the rest, knowing it's backed by a leaf node.
                 let curChild = pChild;
@@ -257,7 +257,7 @@ describe('Trie traversal abstractions', function() {
                     const nextTraversal = curChild.traversal()
                     assert.isArray(nextTraversal.entries);
                     assert.isEmpty(nextTraversal.entries);
-                    assert.equal(nextTraversal.maxP, 0.5);
+                    assert.equal(nextTraversal.p, 0.5);
                   } else {
                     let finalTraversal = curChild.traversal();
                     assert.isDefined(finalTraversal.entries);
@@ -267,7 +267,7 @@ describe('Trie traversal abstractions', function() {
                         p: 1/2
                       }
                     ]);
-                    assert.equal(finalTraversal.maxP, 0.5);
+                    assert.equal(finalTraversal.p, 0.5);
                     eSuccess = true;
                   }
                 } while (leafChildSequence.length > 0);

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -25,7 +25,7 @@ declare type CasingForm = 'lower' | 'initial' | 'upper';
  */
 declare interface LexiconTraversal {
   /**
-   * Provides an iterable pattern used to search for words with a prefix matching
+   * Provides an iterable pattern used to search for words with a 'keyed' prefix matching
    * the current traversal state's prefix when a new character is appended.  Iterating
    * across `children` provides 'breadth' to a lexical search.
    *
@@ -70,13 +70,25 @@ declare interface LexiconTraversal {
    * - prefix of 'crepe': ['crêpe', 'crêpé']
    * - other examples:  https://www.thoughtco.com/french-accent-homographs-1371072
    */
-  entries: { text: USVString, p: number }[];
+  entries: {
+    /**
+     * A lexical entry (word) offered by the model.
+     *
+     * Note:  not the search-term keyed part.  This will match the actual, unkeyed form.
+     */
+    text: USVString,
+    /**
+     * The probability of the lexical entry, directly based upon its frequency.
+     */
+    p: number
+  }[];
 
+  // Note:  `p`, not `maxP` - we want to see the same name for `this.entries.p` and `this.p`
   /**
    * Gives the probability of the highest-frequency lexical entry that is either a member or
    * descendent of the represented trie `Node`.
    */
-  maxP: number;
+  p: number;
 }
 
 /**

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -70,7 +70,13 @@ declare interface LexiconTraversal {
    * - prefix of 'crepe': ['crêpe', 'crêpé']
    * - other examples:  https://www.thoughtco.com/french-accent-homographs-1371072
    */
-  entries: USVString[];
+  entries: { text: USVString, p: number }[];
+
+  /**
+   * Gives the probability of the highest-frequency lexical entry that is either a member or
+   * descendent of the represented trie `Node`.
+   */
+  maxP: number;
 }
 
 /**


### PR DESCRIPTION
This PR was originally part of #10973.

In order to efficiently traverse a full lexical efficiently for dictionary-based wordbreaking, it's best to directly provide relevant probability data as efficiently as possible.  Fortunately, it's easily possible to make this O(1) on the lexical model's internal iterator - the `LexiconTraversal` type.  It would take O(log(N)) time to recompute it via the model's `.predict` method instead.

Note that this provides two different probability value types:
1. The probability of each reached entry.
2. The probability of the highest-frequency entry either represented by the current node or by any of its descendants.

There are uses for this outside of dictionary-based wordbreaking, too.  The latter 'probability' listed above can be useful for optimizing the correction-search - if a path only produces low-frequency words, we should consider other paths that could yield higher-frequency words first.

There's also _notable_ potential for being able to merge / blend two different models together via their `LexiconTraversal` iterators in this manner.  Noting our upcoming push toward #11872, this would facilitate a fantastic way to achieve that goal - to create a stand-in model for the OS's dictionary and blend that with the loaded lexical-model via traversals.

@keymanapp-test-bot skip