### PR TITLE
feat(common/models): support direct-child access for Trie node iteration 📚 

### DIFF
--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -144,7 +144,7 @@ class Traversal implements LexiconTraversal {
     } else {
       // root.type == 'leaf';
       const legalChildren = root.entries.filter(function(entry) {
-        return entry.content.indexOf(nextPrefix) == 0;
+        return entry.key.indexOf(nextPrefix) == 0;
       });
 
       if(!legalChildren.length) {

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -118,7 +118,7 @@ class Traversal implements LexiconTraversal {
 
     // Split into individual code units.
     let steps = char.split('');
-    let traversal: ReturnType<Traversal["_child"]> = this;
+    let traversal: Traversal | undefined = this;
 
     while(steps.length > 0 && traversal) {
       const step: string = steps.shift()!;

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -354,7 +354,7 @@ export default class TrieModel implements LexicalModel {
   }
 
   public traverseFromRoot(): LexiconTraversal {
-    return new Traversal(this._trie['root'], '', this._trie.totalWeight);
+    return this._trie.traverseFromRoot();
   }
 };
 
@@ -448,6 +448,10 @@ class Trie {
     this.root = root;
     this.toKey = wordform2key;
     this.totalWeight = totalWeight;
+  }
+
+  public traverseFromRoot(): LexiconTraversal {
+    return new Traversal(this.root, '', this.totalWeight);
   }
 
   /**

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -100,13 +100,62 @@ class Traversal implements LexiconTraversal {
    */
   totalWeight: number;
 
-  constructor(root: Node, prefix: string, maxWeight: number) {
+  constructor(root: Node, prefix: string, totalWeight: number) {
     this.root = root;
     this.prefix = prefix;
-    this.totalWeight = maxWeight;
+    this.totalWeight = totalWeight;
   }
 
-  *children(): Generator<{char: string, traversal: () => LexiconTraversal}> {
+  child(char: USVString): LexiconTraversal | undefined {
+    /*
+      Note: would otherwise return the current instance if `char == ''`.  If
+      such a call is happening, it's probably indicative of an implementation
+      issue elsewhere - let's signal now in order to catch such stuff early.
+    */
+    if(char == '') {
+      return undefined;
+    }
+
+    // Split into individual code units.
+    let steps = char.split('');
+    let traversal: ReturnType<Traversal["_child"]> = this;
+
+    while(steps.length > 0 && traversal) {
+      const step: string = steps.shift()!;
+      traversal = traversal._child(step);
+    }
+
+    return traversal;
+  }
+
+  // Handles one code unit at a time.
+  private _child(char: USVString): Traversal | undefined {
+    const root = this.root;
+    const totalWeight = this.totalWeight;
+    const nextPrefix = this.prefix + char;
+
+    if(root.type == 'internal') {
+      let childNode = root.children[char];
+      if(!childNode) {
+        return undefined;
+      }
+
+      return new Traversal(childNode, nextPrefix, totalWeight);
+    } else {
+      // root.type == 'leaf';
+      const legalChildren = root.entries.filter(function(entry) {
+        return entry.content.indexOf(nextPrefix) == 0;
+      });
+
+      if(!legalChildren.length) {
+        return undefined;
+      }
+
+      return new Traversal(root, nextPrefix, totalWeight);
+    }
+  }
+
+  *children(): Generator<{char: USVString, traversal: () => LexiconTraversal}> {
     let root = this.root;
     const totalWeight = this.totalWeight;
 

--- a/common/models/templates/test/test-trie-traversal.js
+++ b/common/models/templates/test/test-trie-traversal.js
@@ -23,6 +23,10 @@ describe('Trie traversal abstractions', function() {
     let rootKeys = ['t', 'o', 'a', 'i', 'w', 'h', 'f', 'b', 'n', 'y', 's', 'm',
                     'u', 'c', 'd', 'l', 'e', 'j', 'p', 'g', 'v', 'k', 'r', 'q'];
 
+    rootKeys.forEach((entry) => assert.isOk(rootTraversal.child(entry)));
+    assert.isNotOk(rootTraversal.child('x'));
+    assert.isNotOk(rootTraversal.child('z'));
+
     for(let child of rootTraversal.children()) {
       let keyIndex = rootKeys.indexOf(child.char);
       assert.notEqual(keyIndex, -1);
@@ -99,6 +103,38 @@ describe('Trie traversal abstractions', function() {
     assert.isTrue(eSuccess);
 
     assert.isEmpty(eKeys);
+  });
+
+  it('direct traversal with simple internal nodes', function() {
+    var model = new TrieModel(jsonFixture('tries/english-1000'));
+
+    let rootTraversal = model.traverseFromRoot();
+    assert.isDefined(rootTraversal);
+
+    let eKeys = ['y', 'r', 'i', 'm', 's', 'n', 'o'];
+
+    const tNode = rootTraversal.child('t');
+    assert.isOk(tNode);
+    assert.isDefined(tNode);
+    assert.isArray(tNode.entries);
+    assert.isEmpty(tNode.entries);
+
+    const hNode = tNode.child('h');
+    assert.isOk(hNode);
+    assert.isDefined(hNode);
+    assert.isArray(hNode.entries);
+    assert.isEmpty(hNode.entries);
+
+    const eNode = hNode.child('e');
+    assert.isOk(eNode);
+    assert.isDefined(eNode);
+    assert.isArray(eNode.entries);
+    assert.isNotEmpty(eNode.entries);
+    assert.equal(eNode.entries[0].text, "the");
+
+    for(let key of eKeys) {
+      assert.isOk(eNode.child(key));
+    }
   });
 
   it('traversal over compact leaf node', function() {

--- a/common/models/templates/test/test-trie-traversal.js
+++ b/common/models/templates/test/test-trie-traversal.js
@@ -365,6 +365,6 @@ describe('Trie traversal abstractions', function() {
         p: 1/2
       }
     ]);
-    assert.equal(eNode.maxP, 0.5);
+    assert.equal(eNode.p, 0.5);
   });
 });

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -59,6 +59,10 @@ declare interface LexiconTraversal {
    * If such a traversal state is not supported, returns `undefined`.
    * Implementations may choose to return `undefined` if more than one UTF-16
    * codepoint is appended, even if such a descendant exists.
+   *
+   * Note: traversals navigate and represent the lexicon in its "keyed" state,
+   * as produced by use of the search-term keying function defined for the model.
+   * That is, if a model "keys" `è` to `e`, there will be no `è` child.
    * @param char
    */
   child(char: USVString): LexiconTraversal | undefined;

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -51,10 +51,9 @@ declare interface LexiconTraversal {
   children(): Generator<{char: USVString, traversal: () => LexiconTraversal}>;
 
   /**
-   * Allows direct access to the traversal state that results when appending a
-   * `char` representing a single UTF-16 codepoint to the current traversal
-   * state's prefix.  This bypasses the need to iterate among all legal child
-   * Traversals.
+   * Allows direct access to the traversal state that results when appending one
+   * or more codepoints encoded in UTF-16 to the current traversal state's prefix.
+   * This allows bypassing iteration among all legal child Traversals.
    *
    * If such a traversal state is not supported, returns `undefined`.
    * Implementations may choose to return `undefined` if more than one UTF-16

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -51,6 +51,19 @@ declare interface LexiconTraversal {
   children(): Generator<{char: USVString, traversal: () => LexiconTraversal}>;
 
   /**
+   * Allows direct access to the traversal state that results when appending a
+   * `char` representing a single UTF-16 codepoint to the current traversal
+   * state's prefix.  This bypasses the need to iterate among all legal child
+   * Traversals.
+   *
+   * If such a traversal state is not supported, returns `undefined`.
+   * Implementations may choose to return `undefined` if more than one UTF-16
+   * codepoint is appended, even if such a descendant exists.
+   * @param char
+   */
+  child(char: USVString): LexiconTraversal | undefined;
+
+  /**
    * Any entries directly keyed by the currently-represented lookup prefix.  Entries and
    * children may exist simultaneously, but `entries` must always exist when no children are
    * available in the returned `children()` iterable.


### PR DESCRIPTION
This PR was originally part of https://github.com/keymanapp/keyman/pull/10973.

These changes will facilitate the next PR's changes (#11870), in which it becomes possible to support prediction, in full, solely via the `LexiconTraversal` iterator structure.

Note that this gives us a neat way to support new model types:  if a `LexiconTraversal` can be defined for that model, we can efficiently search it and predict for it, even if it's not actually supported by a Trie!  There would be no need for the model to define a separate `predict` method on the model itself, as it can be implemented via the traversal.

@keymanapp-test-bot skip