### PR TITLE
change(web): track the base correction for generated predictions 📚 

### DIFF
--- a/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.spec.ts
+++ b/common/predictive-text/unit_tests/in_browser/cases/worker-dummy-integration.spec.ts
@@ -36,6 +36,18 @@ describe('LMLayer using dummy model', function () {
     // Since Firefox can't do JSON imports quite yet.
     const hazelFixture = await fetch(new URL(`${domain}/resources/json/models/future_suggestions/i_got_distracted_by_hazel.json`));
     hazelModel = await hazelFixture.json();
+    hazelModel = hazelModel.map((set) => set.map((entry) => {
+      return {
+        ...entry,
+        // Dummy-model predictions all claim probability 1; there's no actual probability stuff
+        // used here.
+        'lexical-p': 1,
+        // We're predicting from a single transform, not a distribution, so probability 1.
+        'correction-p': 1,
+        // Multiply 'em together.
+        p: 1,
+      }
+    }));
   });
 
   describe('Prediction', function () {

--- a/common/test/resources/model-helpers.mjs
+++ b/common/test/resources/model-helpers.mjs
@@ -113,7 +113,18 @@ export function randomToken() {
 }
 
 export function iGotDistractedByHazel() {
-  return jsonFixture('models/future_suggestions/i_got_distracted_by_hazel');
+  return jsonFixture('models/future_suggestions/i_got_distracted_by_hazel').map((set) => set.map((entry) => {
+    return {
+      ...entry,
+      // Dummy-model predictions all claim probability 1; there's no actual probability stuff
+      // used here.
+      'lexical-p': 1,
+      // We're predicting from a single transform, not a distribution, so probability 1.
+      'correction-p': 1,
+      // Multiply 'em together.
+      p: 1,
+    }
+  }));
 }
 
 export function jsonFixture(name, root, import_root) {

--- a/common/web/lm-worker/src/test/mocha/cases/worker-predict.js
+++ b/common/web/lm-worker/src/test/mocha/cases/worker-predict.js
@@ -76,14 +76,7 @@ describe('LMLayerWorker', function () {
         token: token,
         suggestions: hazel[0].map((entry) => {
           return {
-            ...entry,
-            // Dummy-model predictions all claim probability 1; there's no actual probability stuff
-            // used here.
-            'lexical-p': 1,
-            // We're predicting from a single transform, not a distribution, so probability 1.
-            'correction-p': 1,
-            // Multiply 'em together.
-            p: 1,
+            ...entry
           }
         })
       });

--- a/common/web/lm-worker/src/test/mocha/cases/worker-predict.js
+++ b/common/web/lm-worker/src/test/mocha/cases/worker-predict.js
@@ -74,7 +74,18 @@ describe('LMLayerWorker', function () {
       sinon.assert.calledWithMatch(fakePostMessage.lastCall, {
         message: 'suggestions',
         token: token,
-        suggestions: hazel[0]
+        suggestions: hazel[0].map((entry) => {
+          return {
+            ...entry,
+            // Dummy-model predictions all claim probability 1; there's no actual probability stuff
+            // used here.
+            'lexical-p': 1,
+            // We're predicting from a single transform, not a distribution, so probability 1.
+            'correction-p': 1,
+            // Multiply 'em together.
+            p: 1,
+          }
+        })
       });
     });
 

--- a/common/web/lm-worker/src/test/mocha/cases/worker-predict.js
+++ b/common/web/lm-worker/src/test/mocha/cases/worker-predict.js
@@ -74,11 +74,7 @@ describe('LMLayerWorker', function () {
       sinon.assert.calledWithMatch(fakePostMessage.lastCall, {
         message: 'suggestions',
         token: token,
-        suggestions: hazel[0].map((entry) => {
-          return {
-            ...entry
-          }
-        })
+        suggestions: hazel[0]
       });
     });
 


### PR DESCRIPTION
This PR serves to facilitate autocorrect. 

After some brainstorming and design work, I've determined that a suggestion's underlying correction will be an important factor in deciding whether or not to enable the suggestion for automatic application.  While it _is_ possible to recompute some of the properties after the fact, the logic will be much more straightforward if we properly track each prediction's underlying correction from the outset.

While making the change, I remembered a comment from one of my recent PRs: https://github.com/keymanapp/keyman/pull/11424#discussion_r1619739920

> Where else would this type be used?

(In regard to `lexical-p`, `correction-p`, etc)

We're able to more cleanly compute these values now.  Additionally... we don't really need to emit them during standard use, though they _are_ useful sometimes when debugging... so I added a flag that can be used to turn them off.  Allowing this to be toggled by Keyman Engine for Web would require additional work, but it's at least a start.  (I don't think they'll actually be needed outside of the worker, even with active autocorrect.)

@keymanapp-test-bot skip