### PR TITLE
fix(windows): add text selected bool emit backspace key when text selected in TSF

### DIFF
--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -276,8 +276,7 @@ BOOL AITIP::ReadContext(PWSTR buf) {
 
   PKEYMAN64THREADDATA _td = ThreadGlobals();
   if(!_td) return FALSE;
-
-	if(_td->TIPGetContext && (*_td->TIPGetContext)(MAXCONTEXT-1, buf) == S_OK) {   // I3575   // I4262
+  if (_td->TIPGetContext && (*_td->TIPGetContext)(MAXCONTEXT - 1, buf, &isTextSelected) == S_OK) {  // I3575   // I4262
     if(ShouldDebug(sdmKeyboard)) {
       SendDebugMessageFormat(0, sdmAIDefault, 0, "AITIP::ReadContext: full context [Updateable=%d] %s", _td->TIPFUpdateable, Debug_UnicodeString(buf));
     }

--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -275,7 +275,11 @@ BOOL AITIP::ReadContext(PWSTR buf) {
   }
 
   PKEYMAN64THREADDATA _td = ThreadGlobals();
-  if(!_td) return FALSE;
+
+  if(!_td) {
+    return FALSE;
+  }
+
   if (_td->TIPGetContext && (*_td->TIPGetContext)(MAXCONTEXT - 1, buf, &isTextSelected) == S_OK) {  // I3575   // I4262
     if(ShouldDebug(sdmKeyboard)) {
       SendDebugMessageFormat(0, sdmAIDefault, 0, "AITIP::ReadContext: full context [Updateable=%d] %s", _td->TIPFUpdateable, Debug_UnicodeString(buf));

--- a/windows/src/engine/keyman32/appint/aiTIP.h
+++ b/windows/src/engine/keyman32/appint/aiTIP.h
@@ -68,7 +68,10 @@ public:
 
 	/* TIP interactions */
 
-  BOOL IsLegacy() { return useLegacy; }
+  BOOL IsLegacy() {
+    return useLegacy;
+  }
+
   BOOL
   IsTextSelected() {
     return isTextSelected;

--- a/windows/src/engine/keyman32/appint/aiTIP.h
+++ b/windows/src/engine/keyman32/appint/aiTIP.h
@@ -39,6 +39,7 @@ class AITIP : public AIWin2000Unicode
 {
 private:
   BOOL useLegacy;
+  BOOL isTextSelected;
 
 	BOOL PostKeys();
 //TOUCH  	void PostTouchContext();
@@ -68,6 +69,10 @@ public:
 	/* TIP interactions */
 
   BOOL IsLegacy() { return useLegacy; }
+  BOOL
+  IsTextSelected() {
+    return isTextSelected;
+  }
 };
 
 /**

--- a/windows/src/engine/keyman32/globals.h
+++ b/windows/src/engine/keyman32/globals.h
@@ -151,7 +151,7 @@ public:
 /* External interface functions */
 
 typedef HRESULT (WINAPI *PKEYMANPROCESSOUTPUTFUNC)(int n, WCHAR *buf, int nbuf);
-typedef HRESULT (WINAPI *PKEYMANGETCONTEXTFUNC)(int n, PWSTR buf);
+typedef HRESULT (WINAPI *PKEYMANGETCONTEXTFUNC)(int n, PWSTR buf, BOOL* isTextSelected);
 typedef BOOL (WINAPI *PTIPCALLBACK)();  // Tells the TIP to update its status (used to be done through 0x88)
 
 typedef BOOL (WINAPI *PKeymanOutputBackspace)(HWND hwnd);

--- a/windows/src/engine/keyman32/kmprocessactions.cpp
+++ b/windows/src/engine/keyman32/kmprocessactions.cpp
@@ -42,12 +42,9 @@ processBack(
     }
   }
   else {
-    // If there is a selection the TSF documentation suggests an empty string
-    // to the select range. However this would require a change to QueueAction
-    // and the ProcessOutput callback. Instead we will pass through the emit the character
-    // and let the application clear the the selected text.
+    // If there is a selection emit the key (backspace)
+    // allowing the application handle clearing selected text in the correct manner.
     if (app->IsTextSelected() && (vkey == VK_BACK)) {
-      //SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessBack: Emit Keystroke [%d].", app->IsTextSelected());
       *emitKeystroke = TRUE;
       return;
     }

--- a/windows/src/engine/kmtip/globals.h
+++ b/windows/src/engine/kmtip/globals.h
@@ -45,7 +45,7 @@ void DllRelease();
 
 void InsertTextAtSelection(TfEditCookie ec, ITfContext *pContext, const WCHAR *pchText, ULONG cchText);
 void DeleteLeftOfSelection(TfEditCookie ec, ITfContext *pContext, LONG n);
-BOOL GetLeftOfSelection(TfEditCookie ec, ITfContext *pContext, WCHAR *buf, LONG n);   // I4933
+BOOL GetLeftOfSelection(TfEditCookie ec, ITfContext *pContext, WCHAR *buf, LONG n, HRESULT *hrGetSelection, ULONG *cFetched, TF_SELECTION *tfSelection);  // I4933
 void GetDeadkeyFlags(TfEditCookie ec, ITfContext *pContext, PWSTR buf, int n);
 
 //

--- a/windows/src/engine/kmtip/globals.h
+++ b/windows/src/engine/kmtip/globals.h
@@ -45,6 +45,19 @@ void DllRelease();
 
 void InsertTextAtSelection(TfEditCookie ec, ITfContext *pContext, const WCHAR *pchText, ULONG cchText);
 void DeleteLeftOfSelection(TfEditCookie ec, ITfContext *pContext, LONG n);
+/**
+ * Retrieves the text to the left of the current selection in the context.
+ * In addition it also returns the output values of the TSF call 'GetSelection'.
+ * 
+ * @param[in]   ec               The edit cookie.
+ * @param[in]   pContext         The text input context.
+ * @param[out]  buf              The buffer to store the text.
+ * @param[in]   n                The maximum number of characters to retrieve.
+ * @param[out]  hrGetSelection   The result of the 'GetSelection' call.
+ * @param[out]  cFetched         The number of selections fetched.
+ * @param[out]  tfSelection      The selection details.
+ * @return                       TRUE if successful, otherwise FALSE.
+ */
 BOOL GetLeftOfSelection(TfEditCookie ec, ITfContext *pContext, WCHAR *buf, LONG n, HRESULT *hrGetSelection, ULONG *cFetched, TF_SELECTION *tfSelection);  // I4933
 void GetDeadkeyFlags(TfEditCookie ec, ITfContext *pContext, PWSTR buf, int n);
 

--- a/windows/src/engine/kmtip/inserttext.cpp
+++ b/windows/src/engine/kmtip/inserttext.cpp
@@ -165,13 +165,13 @@ char *debugstr(PWSTR buf) {
 
 BOOL
 GetLeftOfSelection(
-    TfEditCookie ec,
-    ITfContext *pContext,
-    WCHAR *buf,
-    LONG n,
-    HRESULT *hrGetSelection,
-    ULONG *cFetched,
-    TF_SELECTION *tfSelection)  // I4933
+  TfEditCookie ec,
+  ITfContext *pContext,
+  WCHAR *buf,
+  LONG n,
+  HRESULT *hrGetSelection,
+  ULONG *cFetched,
+  TF_SELECTION *tfSelection)  // I4933
 {
   LogEnter();
 
@@ -242,7 +242,7 @@ GetLeftOfSelection(
   if (tfSelectionLocal.range) {
     tfSelectionLocal.range->AddRef();
   }
-  
+
   if(cFetchedLocal == 0)   // I3565
   {
     Log(L"GetLeftOfSelection: Exit -- cFetchedLocal == 0");   // I3565

--- a/windows/src/engine/kmtip/kmkey.cpp
+++ b/windows/src/engine/kmtip/kmkey.cpp
@@ -64,6 +64,13 @@ public:
   STDMETHODIMP DoEditSession(TfEditCookie ec);
 
   HRESULT WINAPI KeymanProcessOutput(int n, PWSTR buf, int nbuf);   // I3567
+  /**
+   * Retrieves the current context and checks if text is selected.
+   * @param[in]   n               The size of the buffer.
+   * @param[out]  buf             The buffer to store the context.
+   * @param[out]  isTextSelected  A flag indicating whether text is selected.
+   * @return                      S_OK if successful, otherwise an HRESULT error code.
+   */
   HRESULT WINAPI KeymanGetContext(int n, PWSTR buf, BOOL* isTextSelected);   // I3567
   HRESULT GetResult() { return _hr; }
 
@@ -75,8 +82,16 @@ private:
   LPARAM _lParam;   // I3589
   DWORD _dwDeepIntegration;   // I4375
   TfEditCookie _ec;
+  /**
+   * Checks if any text is selected in the given context.
+   *
+   * @param[in]   hrGetSelection  The result of a call to GetSelection selection.
+   * @param[in]   cFetched        The number of selections fetched.
+   * @param[in]   tfSelection     The selection details.
+   * @param[out]  isTextSelected  A flag indicating whether text is selected.
+   * @return                      S_OK if successful, otherwise an HRESULT error code.
+   */
   HRESULT KeymanIsTextSelected(HRESULT hrGetSelection, ULONG cFetched, TF_SELECTION tfSelection, BOOL *isTextSelected);
-  ;
 };
 
 #define KEYEVENT_EXTRAINFO_KEYMAN 0xF00F0000   // I4370
@@ -256,8 +271,9 @@ HRESULT WINAPI CKeymanEditSession::KeymanGetContext(int n, PWSTR buf, BOOL* isTe
   // now check for selected text
   if (!SUCCEEDED(hr = KeymanIsTextSelected(hrGetSelection, cFetched, tfSelection, isTextSelected))) {
     Log(L"KeymanGetContext: Warning: KeymanIsTextSelected failed");
-    // Continue to return S_OK, as IsTextSelected defaults to not selected.
-    // If we have gotten this far, the context in buf is valid.
+    // Continue to return S_OK, even though checking if a text selection exists has failed.
+    // Reaching this point means the context in 'buf' is valid and will be passed to the caller.
+    // isTextSelected will be false, which is better than returning E_FAIL at this point.
   }
   return S_OK;
 }

--- a/windows/src/engine/kmtip/kmtip.h
+++ b/windows/src/engine/kmtip/kmtip.h
@@ -139,7 +139,9 @@ private:
 //
 
 typedef HRESULT(WINAPI *PKEYMANPROCESSOUTPUTFUNC)(int n, WCHAR *buf, int nbuf);   // I3567
-typedef HRESULT(WINAPI *PKEYMANGETCONTEXTFUNC)(int n, PWSTR buf);   // I3567
+// Adding a new interface call IsTextSelected could make sense however this would
+// also require update TIPProcessKey to have another call back function as an argument
+typedef HRESULT(WINAPI *PKEYMANGETCONTEXTFUNC)(int n, PWSTR buf, BOOL* isTextSelected);   // I3567
 
 class Keyman32Interface {
 public:

--- a/windows/src/test/manual-tests/test_i3619/i3619tip/i3619tip/i3619tip/kmkey.cpp
+++ b/windows/src/test/manual-tests/test_i3619/i3619tip/i3619tip/i3619tip/kmkey.cpp
@@ -1,18 +1,18 @@
 /*
   Name:             kmkey
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      19 Jun 2007
 
   Modified Date:    1 Dec 2012
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          19 Jun 2007 - mcdurdin - I890 - Deadkeys not working correctly in TSF
                     19 Jun 2007 - mcdurdin - I822 - TSF Addin not working
                     07 Sep 2009 - mcdurdin - I2095 - TSF addin is not threadsafe
@@ -49,7 +49,7 @@ public:
     STDMETHODIMP DoEditSession(TfEditCookie ec);
 
 	HRESULT WINAPI KeymanProcessOutput(int n, PWSTR buf, int nbuf);   // I3567
-	HRESULT WINAPI KeymanGetContext(int n, PWSTR buf);   // I3567
+	HRESULT WINAPI KeymanGetContext(int n, PWSTR buf, BOOL* isTextSelected);   // I3567
 	HRESULT GetResult() { return _hr; }
 
 private:
@@ -77,7 +77,7 @@ BOOL CKMTipTextService::_KeymanProcessKeystroke(ITfContext *pContext, WPARAM wPa
   }
 	else
 	{
-		if (pContext->RequestEditSession(_tfClientId, pEditSession, 
+		if (pContext->RequestEditSession(_tfClientId, pEditSession,
 			fUpdate ? TF_ES_SYNC | TF_ES_READWRITE : TF_ES_SYNC | TF_ES_READ, &hr) != S_OK)
 		{
 			hr = E_FAIL;


### PR DESCRIPTION
Fixes: #7870
Add a bool to the KeymanGetContext call, the Windows engine will emit backspace keystroke when text is selected and a backspace key is pressed allowing the application to make the correct decision on how to handle it.  

This change feels like it is half the solution the full solution would be to have a mechanism for allowing the Keyman Core to know if text has been selected. &hasSelection As discussed in issue #9073 as a Future solution. 

With this change the core will request the character closest to the selection to be deleted its internal cache will match this, even though the engine will essentially overide this request and just emit the backspace keystroke.  As it is TSF - context aware it will be updated on the next key stroke anyway with the correct context. 
 
# User Testing

## TEST_DELETE_SELECTED_TEXT
Install the Keyman for Windows build artifact with this PR.
This test must be done with an application using the Text Services Framework (TSF). You cannot use
the Web version of Word. Use WordPad that comes installed with Windows 10 and Windows 11.

Install a Keyman keyboard like EuroLatin

1. Select the EuroLatin Keyboard
2. Open MS Word or WordPad
3. Type `mySchool`
4. Select `School` and type <kbd>backspace</kbd> 

Expected result
`my`

Some regression tests.

## TEST_BACKSPACE_NO_SELECTION

Install a Keyman keyboard like euro_latin

1. Select the EuroLatin Keyboard
2. Open MS Word or WordPad
3. Type `mySchool`
4. With the cursor still to the right of 'l' type <kbd>backspace</kbd> 

Expected result
`mySchoo`

## TEST_SELECTION_TYPE_CHAR
1. Select the EuroLatin Keyboard
2. Open MS Word or WordPad
3. Type `mySchool`
4. Select `School` and type <kbd>t</kbd> 

Expected result
`myt`

 


