### PR TITLE
fix(linux): ignore exceptions trying to install cache

### DIFF
--- a/linux/keyman-config/keyman_config/get_kmp.py
+++ b/linux/keyman-config/keyman_config/get_kmp.py
@@ -21,6 +21,7 @@ class InstallLocation(GObject.GEnum):
     User = 3
     Unknown = 99
 
+can_use_cache = True
 
 def get_install_area_string(area):
     if area == InstallLocation.OS:
@@ -30,6 +31,35 @@ def get_install_area_string(area):
     elif area == InstallLocation.User:
         return _('User')
     return _('Unknown')
+
+
+def _install_cache(cache_name, backend, expire_after):
+    global can_use_cache
+    if can_use_cache:
+        try:
+            requests_cache.install_cache(cache_name=cache_name, backend=backend, expire_after=expire_after)
+        except AttributeError as e:
+            logging.debug(f'Got exception trying to use `install_cache`: {e}')
+            can_use_cache = False
+
+
+def _uninstall_cache():
+    global can_use_cache
+    if can_use_cache:
+        try:
+            requests_cache.uninstall_cache()
+        except AttributeError as e:
+            logging.debug(f'Got exception trying to use `uninstall_cache`: {e}')
+            can_use_cache = False
+
+
+def _did_use_cache(response):
+    if can_use_cache:
+        try:
+            return response.from_cache
+        except AttributeError as e:
+            logging.debug(f'Got exception trying to access `response.from_cache`: {e}')
+    return False
 
 
 def get_package_download_data(packageID, weekCache=False):
@@ -52,12 +82,12 @@ def get_package_download_data(packageID, weekCache=False):
     else:
         expire_after = datetime.timedelta(days=1)
     os.chdir(cache_dir)
-    requests_cache.install_cache(cache_name='keyman_cache', backend='sqlite', expire_after=expire_after)
+    _install_cache(cache_name='keyman_cache', backend='sqlite', expire_after=expire_after)
     now = time.ctime(int(time.time()))
     response = requests.get(api_url)
-    logging.debug('Time: {0} / Used Cache: {1}'.format(now, response.from_cache))
+    logging.debug('Time: {0} / Used Cache: {1}'.format(now, _did_use_cache(response)))
     os.chdir(current_dir)
-    requests_cache.uninstall_cache()
+    _uninstall_cache()
     if response.status_code == 200:
         return response.json()
     else:
@@ -84,15 +114,15 @@ def get_keyboard_data(keyboardID, weekCache=False):
     else:
         expire_after = datetime.timedelta(days=1)
     os.chdir(cache_dir)
-    requests_cache.install_cache(cache_name='keyman_cache', backend='sqlite', expire_after=expire_after)
+    _install_cache(cache_name='keyman_cache', backend='sqlite', expire_after=expire_after)
     now = time.ctime(int(time.time()))
     try:
         response = requests.get(api_url)
-    except requests.exceptions.RequestException as e:  # This is the correct syntax
+    except requests.exceptions.RequestException:  # This is the correct syntax
         return None
-    logging.debug('Time: {0} / Used Cache: {1}'.format(now, response.from_cache))
+    logging.debug('Time: {0} / Used Cache: {1}'.format(now, _did_use_cache(response)))
     os.chdir(current_dir)
-    requests_cache.uninstall_cache()
+    _uninstall_cache()
     if response.status_code == 200:
         return response.json()
     else:
@@ -212,7 +242,7 @@ def download_kmp_file(url, kmpfile, cache=False):
         if not os.path.isdir(cache_dir):
             os.makedirs(cache_dir)
         os.chdir(cache_dir)
-        requests_cache.install_cache(cache_name='keyman_kmp_cache', backend='sqlite', expire_after=expire_after)
+        _install_cache(cache_name='keyman_kmp_cache', backend='sqlite', expire_after=expire_after)
         now = time.ctime(int(time.time()))
 
     try:
@@ -222,9 +252,9 @@ def download_kmp_file(url, kmpfile, cache=False):
         return downloadfile
 
     if cache:
-        logging.debug('Time: {0} / Used Cache: {1}'.format(now, response.from_cache))
+        logging.debug('Time: {0} / Used Cache: {1}'.format(now, _did_use_cache(response)))
         os.chdir(current_dir)
-        requests_cache.uninstall_cache()
+        _uninstall_cache()
 
     if response.status_code == 200:
         try:


### PR DESCRIPTION
Using the cache when getting data from the server is just an optimization to speed up things. However, things still work if we don't use the cache. This change therefore catches the AttributeError that sometimes happen on some machines for unknown reasons and falls back to not using the cache.

Fixes: #11855
Fixes: KEYMAN-LINUX-6R
Cherry-pick-of: #11861

@keymanapp-test-bot skip