### PR TITLE
fix(core): allow to successfully build on Ubuntu 24.04

### DIFF
--- a/core/tests/unit/ldml/test_kmx_plus.cpp
+++ b/core/tests/unit/ldml/test_kmx_plus.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <test_assert.h>
 #include "kmx/kmx_plus.h"
 #include "kmx/kmx_xstring.h"


### PR DESCRIPTION
Without this change trying to build the core tests on Ubuntu 24.04 fails with "error: 'intptr_t' has not been declared in '::'". I'm not sure why that is happening, but this is an easy fix.

@keymanapp-test-bot skip