### PR TITLE
feat(web): add unit tests for predict auto-selection method 📚 

### DIFF
--- a/common/web/lm-worker/src/main/predict-helpers.ts
+++ b/common/web/lm-worker/src/main/predict-helpers.ts
@@ -11,6 +11,8 @@ import ModelCompositor from './model-compositor.js';
  * correction/prediction process at the core of our predictive-text engine.
  */
 
+export const AUTOSELECT_PROPORTION_THRESHOLD = .66;
+
 export type CorrectionPredictionTuple = {
   prediction: ProbabilityMass<Suggestion>,
   correction: ProbabilityMass<string>,
@@ -561,7 +563,7 @@ export function predictionAutoSelect(suggestionDistribution: CorrectionPredictio
   // compare best vs other probabilities.
   const probSum = suggestionDistribution.reduce((accum, current) => accum + current.totalProb, 0);
   const proportionOfBest = bestSuggestion.totalProb / probSum;
-  if(proportionOfBest < .66) {
+  if(proportionOfBest < AUTOSELECT_PROPORTION_THRESHOLD) {
     return;
   }
 

--- a/common/web/lm-worker/src/main/predict-helpers.ts
+++ b/common/web/lm-worker/src/main/predict-helpers.ts
@@ -560,8 +560,19 @@ export function predictionAutoSelect(suggestionDistribution: CorrectionPredictio
     return;
   }
 
-  // compare best vs other probabilities.
-  const probSum = suggestionDistribution.reduce((accum, current) => accum + current.totalProb, 0);
+  // If we allow an option to allow same-key suggestions to replace context automatically
+  // - such as replacing `cant` with `can't` if the latter is much more frequent -
+  // we may wish to group matchLevel values below by 'mapping' them with an appropriate
+  // function.  (Both on the next line and within the reduce functor.)
+  const bestSuggestionTier = bestSuggestion.matchLevel;
+
+  // compare best vs other probabilities of compatible tier.
+  const probSum = suggestionDistribution.reduce((accum, current) => {
+    // If the suggestion is from a different similarity tier, do not count it against
+    // the required auto-select probability ratio threshold.  That threshold should
+    // only apply within the suggestion's tier.
+    return accum + (current.matchLevel == bestSuggestionTier ? current.totalProb : 0)
+  }, 0);
   const proportionOfBest = bestSuggestion.totalProb / probSum;
   if(proportionOfBest < AUTOSELECT_PROPORTION_THRESHOLD) {
     return;

--- a/common/web/lm-worker/src/test/mocha/cases/auto-correct.js
+++ b/common/web/lm-worker/src/test/mocha/cases/auto-correct.js
@@ -8,7 +8,7 @@ import sinon from 'sinon';
   *   `.matchesModel` - that can vary.
   * - Predictions should be in sorted order (see tupleDisplaySortOrder).
   */
-describe.only('predictionAutoSelect', () => {
+describe('predictionAutoSelect', () => {
   it(`does not throw when no suggestions are available`, () => {
     /**
      * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}

--- a/common/web/lm-worker/src/test/mocha/cases/auto-correct.js
+++ b/common/web/lm-worker/src/test/mocha/cases/auto-correct.js
@@ -1,0 +1,522 @@
+import { AUTOSELECT_PROPORTION_THRESHOLD, predictionAutoSelect, tupleDisplayOrderSort } from "#./predict-helpers.js";
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+/*
+  * Preconditions:
+  * - there should always be a 'keep' option.  Now, whether or not that option
+  *   `.matchesModel` - that can vary.
+  * - Predictions should be in sorted order (see tupleDisplaySortOrder).
+  */
+describe.only('predictionAutoSelect', () => {
+  it(`does not throw when no suggestions are available`, () => {
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
+     */
+    const predictions = [];
+    const originalPredictions = [].concat(predictions);
+    assert.doesNotThrow(() => predictionAutoSelect(predictions));
+
+    assert.sameDeepOrderedMembers(predictions, originalPredictions);
+  });
+
+  it(`selects solitary 'keep' suggestion that does match the model`, () => {
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
+     */
+    const predictions = [
+      {
+        correction: {
+          sample: 'apple', // can be null / "mocked out"
+          p: 1
+        },
+        prediction: {
+          sample: {
+            tag: 'keep',
+            transform: {  // can be null / "mocked out"
+              insert: 'e',
+              deleteLeft: 0
+            },
+            matchesModel: true
+          },
+          p: 1
+        },
+        totalProb: 1
+      }
+    ];
+
+    const originalPredictions = [].concat(predictions);
+    assert.doesNotThrow(() => predictionAutoSelect(predictions));
+    assert.sameDeepOrderedMembers(predictions, originalPredictions);
+
+    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    assert.isOk(autoselected);
+  });
+
+  it(`does not select solitary 'keep' suggestion that doesn't match the model`, () => {
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
+     */
+    const predictions = [
+      {
+        correction: {
+          sample: 'appl', // can be null / "mocked out"
+          p: 1
+        },
+        prediction: {
+          sample: {
+            tag: 'keep',
+            transform: { // can be null / "mocked out"
+              insert: 'l',
+              deleteLeft: 0
+            },
+            matchesModel: false
+          },
+          p: 1
+        },
+        totalProb: 1
+      }
+    ];
+
+    const originalPredictions = [].concat(predictions);
+    assert.doesNotThrow(() => predictionAutoSelect(predictions));
+    assert.sameDeepOrderedMembers(predictions, originalPredictions);
+
+    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    assert.isNotOk(autoselected);
+  });
+
+  it(`selects 'keep' suggestion that does match the model over any alternatives`, () => {
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
+     */
+    const keepSuggestion = {
+      correction: {
+        sample: 'thin', // can be null / "mocked out"
+        p: .8
+      },
+      prediction: {
+        sample: {
+          tag: 'keep',
+          transform: {  // can be null / "mocked out"
+            insert: 'n',
+            deleteLeft: 0
+          },
+          matchesModel: true
+        },
+        p: .05
+      },
+      totalProb: .04
+    }
+
+    const highestNonKeepSuggestion = {
+      correction: {
+        sample: 'thin', // can be null / "mocked out"
+        p: .8
+      },
+      prediction: {
+        sample: {
+          transform: {  // can be null / "mocked out"
+            insert: 'nk',
+            deleteLeft: 0
+          },
+        },
+        p: .55
+      },
+      totalProb: .44
+    };
+
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
+     */
+    const predictions = [
+      keepSuggestion,
+      highestNonKeepSuggestion,
+      {
+        correction: {
+          sample: 'thin', // can be null / "mocked out"
+          p: .8
+        },
+        prediction: {
+          sample: {
+            transform: {  // can be null / "mocked out"
+              insert: 'ng',
+              deleteLeft: 0
+            },
+          },
+          p: .4
+        },
+        totalProb: .32
+      },
+      {
+        correction: {
+          sample: 'thic', // can be null / "mocked out"
+          p: .2
+        },
+        prediction: {
+          sample: {
+            transform: {  // can be null / "mocked out"
+              insert: 'ck',
+              deleteLeft: 0
+            },
+          },
+          p: 1
+        },
+        totalProb: .2
+      }
+    ];
+
+    predictions.sort(tupleDisplayOrderSort);
+
+    const originalPredictions = [].concat(predictions);
+    assert.doesNotThrow(() => predictionAutoSelect(predictions));
+    assert.sameDeepOrderedMembers(predictions, originalPredictions);
+
+    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    assert.equal(autoselected, keepSuggestion);
+  });
+
+  it(`selects solitary non-'keep' suggestion when 'keep' does not match model`, () => {
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
+     */
+    const keepSuggestion = {
+      correction: {
+        sample: 'thin', // can be null / "mocked out"
+        p: .8
+      },
+      prediction: {
+        sample: {
+          tag: 'keep',
+          transform: {  // can be null / "mocked out"
+            insert: 'n',
+            deleteLeft: 0
+          },
+          matchesModel: false
+        },
+        p: .05
+      },
+      totalProb: .04
+    }
+
+    // To 'win', a suggestion (currently) needs at least twice the probability of the sum of all alternatives.
+    // This threshold may be subject to change.
+    //
+    // Refer to AUTOSELECT_PROPORTION_THRESHOLD in predict-helpers.ts.
+    const onlyNonKeepSuggestion = {
+      correction: {
+        sample: 'thin', // can be null / "mocked out"
+        p: .8
+      },
+      prediction: {
+        sample: {
+          transform: {  // can be null / "mocked out"
+            insert: 'nk',
+            deleteLeft: 0
+          },
+        },
+        p: .01
+      },
+      totalProb: .008
+    };
+
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
+     */
+    const predictions = [
+      keepSuggestion,
+      onlyNonKeepSuggestion
+    ];
+
+    const totalProb = predictions.reduce((accum, current) => accum + current.totalProb, 0);
+    assert.isBelow(onlyNonKeepSuggestion.totalProb, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
+
+    predictions.sort(tupleDisplayOrderSort);
+
+    const originalPredictions = [].concat(predictions);
+    assert.doesNotThrow(() => predictionAutoSelect(predictions));
+    assert.sameDeepOrderedMembers(predictions, originalPredictions);
+
+    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    assert.equal(autoselected, onlyNonKeepSuggestion);
+  });
+
+  it(`does not select non-'keep' without sufficient winning probability`, () => {
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
+     */
+    const keepSuggestion = {
+      correction: {
+        sample: 'thin', // can be null / "mocked out"
+        p: .8
+      },
+      prediction: {
+        sample: {
+          tag: 'keep',
+          transform: {  // can be null / "mocked out"
+            insert: 'n',
+            deleteLeft: 0
+          },
+          matchesModel: false
+        },
+        p: .05
+      },
+      totalProb: .04
+    }
+
+    // To 'win', a suggestion (currently) needs at least twice the probability of the sum of all alternatives.
+    // This threshold may be subject to change.
+    //
+    // Refer to AUTOSELECT_PROPORTION_THRESHOLD in predict-helpers.ts.
+    const highestNonKeepSuggestion = {
+      correction: {
+        sample: 'thin', // can be null / "mocked out"
+        p: .8
+      },
+      prediction: {
+        sample: {
+          transform: {  // can be null / "mocked out"
+            insert: 'nk',
+            deleteLeft: 0
+          },
+        },
+        p: .55
+      },
+      totalProb: .44
+    };
+
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
+     */
+    const predictions = [
+      keepSuggestion,
+      highestNonKeepSuggestion,
+      {
+        correction: {
+          sample: 'thin', // can be null / "mocked out"
+          p: .8
+        },
+        prediction: {
+          sample: {
+            transform: {  // can be null / "mocked out"
+              insert: 'ng',
+              deleteLeft: 0
+            },
+          },
+          p: .4
+        },
+        totalProb: .32
+      },
+      {
+        correction: {
+          sample: 'thic', // can be null / "mocked out"
+          p: .2
+        },
+        prediction: {
+          sample: {
+            transform: {  // can be null / "mocked out"
+              insert: 'ck',
+              deleteLeft: 0
+            },
+          },
+          p: 1
+        },
+        totalProb: .2
+      }
+    ];
+
+    const totalProb = predictions.reduce((accum, current) => accum + current.totalProb, 0);
+    assert.isBelow(highestNonKeepSuggestion.totalProb, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
+
+    predictions.sort(tupleDisplayOrderSort);
+
+    const originalPredictions = [].concat(predictions);
+    assert.doesNotThrow(() => predictionAutoSelect(predictions));
+    assert.sameDeepOrderedMembers(predictions, originalPredictions);
+
+    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    assert.isNotOk(autoselected);
+  });
+
+  it(`does select non-'keep' with sufficient winning probability`, () => {
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
+     */
+    const keepSuggestion = {
+      correction: {
+        sample: 'thin', // can be null / "mocked out"
+        p: .8
+      },
+      prediction: {
+        sample: {
+          tag: 'keep',
+          transform: {  // can be null / "mocked out"
+            insert: 'n',
+            deleteLeft: 0
+          },
+          matchesModel: false
+        },
+        p: .05
+      },
+      totalProb: .04
+    }
+
+    const highestNonKeepSuggestion = {
+      correction: {
+        sample: 'thin', // can be null / "mocked out"
+        p: .9
+      },
+      prediction: {
+        sample: {
+          transform: {  // can be null / "mocked out"
+            insert: 'nk',
+            deleteLeft: 0
+          },
+        },
+        p: .75
+      },
+      totalProb: .675
+    };
+
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
+     */
+    const predictions = [
+      keepSuggestion,
+      highestNonKeepSuggestion,
+      {
+        correction: {
+          sample: 'thin', // can be null / "mocked out"
+          p: .9
+        },
+        prediction: {
+          sample: {
+            transform: {  // can be null / "mocked out"
+              insert: 'ng',
+              deleteLeft: 0
+            },
+          },
+          p: .2
+        },
+        totalProb: .18
+      },
+      {
+        correction: {
+          sample: 'thic', // can be null / "mocked out"
+          p: .1
+        },
+        prediction: {
+          sample: {
+            transform: {  // can be null / "mocked out"
+              insert: 'ck',
+              deleteLeft: 0
+            },
+          },
+          p: 1
+        },
+        totalProb: .1
+      }
+    ];
+
+    const totalProb = predictions.reduce((accum, current) => accum + current.totalProb, 0);
+    assert.isAbove(highestNonKeepSuggestion.totalProb, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
+
+    predictions.sort(tupleDisplayOrderSort);
+
+    const originalPredictions = [].concat(predictions);
+    assert.doesNotThrow(() => predictionAutoSelect(predictions));
+    assert.sameDeepOrderedMembers(predictions, originalPredictions);
+
+    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    assert.equal(autoselected, highestNonKeepSuggestion);
+  });
+
+  it.skip('ignores non key-matched suggestions when key-matched suggestions exist', () => {
+    // great example:  can't
+    // cant isn't a word, but can't - the keyed form - totally is.
+    //
+    // should leverage tuple.matchLevel... which isn't actually defined on the prior inline
+    // fixtures.
+  });
+
+  // The idea:  avoid "over-correcting" when a potential correction has a
+  // super-high-frequency word.
+  it('does not auto-select suggestion if its root correction is not most likely', () => {
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
+     */
+    const keepSuggestion = {
+      correction: {
+        sample: 'thi', // can be null / "mocked out"
+        p: .7
+      },
+      prediction: {
+        sample: {
+          tag: 'keep',
+          transform: {  // can be null / "mocked out"
+            insert: 'i',
+            deleteLeft: 0
+          },
+          matchesModel: false
+        },
+        p: .05
+      },
+      totalProb: .035
+    }
+
+    const highestCorrectionSuggestion = {
+      correction: {
+        sample: 'thi', // can be null / "mocked out"
+        p: .7
+      },
+      prediction: {
+        sample: {
+          transform: {  // can be null / "mocked out"
+            insert: 'in',
+            deleteLeft: 0
+          },
+        },
+        p: .1
+      },
+      totalProb: .07
+    };
+
+    const highestNonKeepSuggestion = {
+      correction: {
+        sample: 'the', // can be null / "mocked out"
+        p: .3
+      },
+      prediction: {
+        sample: {
+          transform: {  // can be null / "mocked out"
+            insert: 'e',
+            deleteLeft: 0
+          },
+        },
+        p: 1
+      },
+      totalProb: .3
+    };
+
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
+     */
+    const predictions = [
+      keepSuggestion,
+      highestNonKeepSuggestion,
+      highestCorrectionSuggestion
+    ];
+
+    const totalProb = predictions.reduce((accum, current) => accum + current.totalProb, 0);
+    assert.isAbove(highestNonKeepSuggestion.totalProb, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
+
+    predictions.sort(tupleDisplayOrderSort);
+
+    const originalPredictions = [].concat(predictions);
+    assert.doesNotThrow(() => predictionAutoSelect(predictions));
+    assert.sameDeepOrderedMembers(predictions, originalPredictions);
+
+    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    assert.isNotOk(autoselected);
+  });
+});


### PR DESCRIPTION
Fixes: #11935

Also adds a fix for this comment on an ancestor PR: https://github.com/keymanapp/keyman/pull/11876#issuecomment-2216341032

> we're not currently auto-selecting something like can't with priority when the current context is cant - where there's no exact context match, but there is an exact-key match. I'll want to fix that, whether it be within this PR or within a descendant.

In retrospect, `cant` actually _is_ a valid English word, but it's rare enough to communicate the core idea here, I believe.

@keymanapp-test-bot skip