### PR TITLE
change(mac): add custom tags in sentry to better identify errors

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -167,19 +167,36 @@ NSString* _keymanDataPath = nil;
 -(void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   [[NSUserDefaults standardUserDefaults] registerDefaults:@{ @"NSApplicationCrashOnExceptions": @YES }];
   
+  [KMLogs reportLogStatus];
+  
+  [self startSentry];
+  [self setPostLaunchKeymanSentryTags];
+}
+
+- (void)startSentry {
   KeymanVersionInfo keymanVersionInfo = [self versionInfo];
   NSString *releaseName = [NSString stringWithFormat:@"%@", keymanVersionInfo.versionGitTag];
-  
-  [KMLogs reportLogStatus];
   
   [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
     options.dsn = @"https://960f8b8e574c46e3be385d60ce8e1fea@o1005580.ingest.sentry.io/5983522";
     options.releaseName = releaseName;
     options.environment = keymanVersionInfo.sentryEnvironment;
-    // options.debug = @YES;
+    //options.debug = YES;
   }];
   
-  // [SentrySDK captureMessage:@"Starting Keyman [test message]"];
+}
+
+- (void)setPostLaunchKeymanSentryTags {
+  NSString *keyboardFileName = [self.kmx.filePath lastPathComponent];
+   os_log_info([KMLogs keyboardLog], "initial kmx set to %{public}@", keyboardFileName);
+
+  NSString *hasAccessibility = [PrivacyConsent.shared checkAccessibility]?@"Yes":@"No";
+
+   // assign custom keyboard tag in Sentry to initial keyboard
+   [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
+      [scope setTagValue:hasAccessibility forKey:@"accessibilityEnabled"];
+      [scope setTagValue:keyboardFileName forKey:@"keyboard"];
+   }];
 }
 
 #ifdef USE_ALERT_SHOW_HELP_TO_FORCE_EASTER_EGG_CRASH_FROM_ENGINE
@@ -399,6 +416,14 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 - (void)setKmx:(KMXFile *)kmx {
   _kmx = kmx;
   [self.kme setKmx:_kmx];
+  
+  NSString *keyboardFileName = [kmx.filePath lastPathComponent];
+   os_log_info([KMLogs keyboardLog], "setKmx to %{public}@", keyboardFileName);
+
+   // assign custom keyboard tag in Sentry to default keyboard
+   [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
+       [scope setTagValue:keyboardFileName forKey:@"keyboard"];
+   }];
 }
 
 - (void)setKvk:(KVKFile *)kvk {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -54,6 +54,18 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
   else
     _easterEggForSentry = nil;
   
+  /*
+  SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] init];
+  crumb.level = kSentryLevelInfo;
+  crumb.category = @"keyboard";
+  crumb.message = [NSString stringWithFormat:@"init text client app, id: %@", clientAppId];
+  [SentrySDK addBreadcrumb:crumb];
+   */
+  
+  [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
+      [scope setTagValue:clientAppId forKey:@"clientAppId"];
+  }];
+
   return self;
 }
 
@@ -229,6 +241,14 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
       return YES;
     }
     
+    // TODO: remove temporary Sentry test code
+    if (event.keyCode == kVK_ANSI_Slash) {
+      os_log_debug([KMLogs testLog], "handleEvent, calling Sentry captureMessage");
+      [SentrySDK captureMessage:@"handleEvent, slash typed: test message sent"];
+      //[SentrySDK crash];
+      //[SentrySDK captureError:(nonnull NSError *)];
+    }
+
     // for some apps, handleEvent will not be called for the generated backspace
     // but if it is, we need to let it pass through rather than process again in core
     if((event.keyCode == kVK_Delete) && (self.lowLevelBackspaceCount > 0)) {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -54,14 +54,6 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
   else
     _easterEggForSentry = nil;
   
-  /*
-  SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] init];
-  crumb.level = kSentryLevelInfo;
-  crumb.category = @"keyboard";
-  crumb.message = [NSString stringWithFormat:@"init text client app, id: %@", clientAppId];
-  [SentrySDK addBreadcrumb:crumb];
-   */
-  
   [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
       [scope setTagValue:clientAppId forKey:@"clientAppId"];
   }];
@@ -241,14 +233,6 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
       return YES;
     }
     
-    // TODO: remove temporary Sentry test code
-    if (event.keyCode == kVK_ANSI_Slash) {
-      os_log_debug([KMLogs testLog], "handleEvent, calling Sentry captureMessage");
-      [SentrySDK captureMessage:@"handleEvent, slash typed: test message sent"];
-      //[SentrySDK crash];
-      //[SentrySDK captureError:(nonnull NSError *)];
-    }
-
     // for some apps, handleEvent will not be called for the generated backspace
     // but if it is, we need to let it pass through rather than process again in core
     if((event.keyCode == kVK_Delete) && (self.lowLevelBackspaceCount > 0)) {


### PR DESCRIPTION
Add custom tags to Sentry so that Mac issues display whether accessibility is enabled when keyman starts and also the current clientAppId and keyboard.

The new tags will be displayed in Sentry as shown below:
![image](https://github.com/user-attachments/assets/c3cdf9dd-ef35-4119-89ce-349da98a2c2d)

@keymanapp-test-bot skip