### PR TITLE
feat(web): extend unit-test oriented dummy model 📚 

### DIFF
--- a/common/models/templates/src/common.ts
+++ b/common/models/templates/src/common.ts
@@ -115,9 +115,12 @@ export function transformToSuggestion(transform: Transform, p: number): WithOutc
 export function transformToSuggestion(transform: Transform, p?: number): Outcome<Suggestion> {
   let suggestion: Outcome<Suggestion> = {
     transform: transform,
-    transformId: transform.id,
     displayAs: transform.insert
   };
+
+  if(transform.id) {
+    suggestion.transformId = transform.id;
+  }
 
   if(p === 0 || p) {
     suggestion.p = p;

--- a/common/models/templates/src/common.ts
+++ b/common/models/templates/src/common.ts
@@ -118,7 +118,7 @@ export function transformToSuggestion(transform: Transform, p?: number): Outcome
     displayAs: transform.insert
   };
 
-  if(transform.id) {
+  if(transform.id !== undefined) {
     suggestion.transformId = transform.id;
   }
 

--- a/common/web/lm-worker/src/main/models/dummy-model.ts
+++ b/common/web/lm-worker/src/main/models/dummy-model.ts
@@ -67,21 +67,10 @@ export class DummyModel implements LexicalModel {
       this.punctuation = options.punctuation;
     }
 
-    if (options.toKey) {
-      this.toKey = options.toKey;
-    }
-
-    if (options.wordbreaker) {
-      this.wordbreaker = options.wordbreaker;
-    }
-
-    if (options.applyCasing) {
-      this.applyCasing = options.applyCasing;
-    }
-
-    if (options.languageUsesCasing) {
-      this.languageUsesCasing = options.languageUsesCasing;
-    }
+    this.toKey = options.toKey;
+    this.wordbreaker = options.wordbreaker;
+    this.applyCasing = options.applyCasing;
+    this.languageUsesCasing = options.languageUsesCasing;
   }
 
   configure(capabilities: Capabilities): Configuration {


### PR DESCRIPTION
The old `DummyModel` used to mock models for automated testing was lacking support for a number of model features we'd like to unit test.  Since we're looking to unit-test the recently-refactored predictive-text component functions, it would be helpful to use it for mocking instead of requiring a fully-compiled model.  So, I thought it wise to give the old test-oriented class an update.  

@keymanapp-test-bot skip