### PR TITLE
feat(developer): handle automatic versioning of chiral modifiers

### DIFF
--- a/developer/src/kmc-kmn/src/kmw-compiler/compiler-globals.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/compiler-globals.ts
@@ -62,6 +62,21 @@ function verifyMinimumRequiredKeymanVersion(version: KMX.KMX_Version) {
 }
 
 /**
+ * Verify that minimum supported Keyman version in the keyboard is version 10.0,
+ * and upgrade to that version if possible and necessary.
+ *
+ * Will upgrade the minimum version to 10.0 if `KF_AUTOMATICVERSION` flag is set
+ * for the keyboard, which correlates to having no `store(&version)` line in the
+ * .kmn source file.
+ *
+ * @returns `true` if the version is now 10.0 or higher, `false` if a lower
+ * version has been specified in the source file `store(&version)` line.
+ */
+export function verifyMinimumRequiredKeymanVersion10(): boolean {
+  return verifyMinimumRequiredKeymanVersion(KMX.KMX_Version.VERSION_100);
+}
+
+/**
  * Verify that minimum supported Keyman version in the keyboard is version 15.0,
  * and upgrade to that version if possible and necessary.
  *

--- a/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
@@ -2,7 +2,8 @@ import { TSentinelRecord, GetSuppChar, ExpandSentinel, incxstr, xstrlen, xstrlen
 import { KMX } from "@keymanapp/common-types";
 
 import { callbacks, FCallFunctions, FFix183_LadderLength, FMnemonic, FTabStop, FUnreachableKeys,
-         kmxResult, nl, options, isKeyboardVersion10OrLater, isKeyboardVersion14OrLater } from "./compiler-globals.js";
+         kmxResult, nl, options, isKeyboardVersion10OrLater, isKeyboardVersion14OrLater,
+         verifyMinimumRequiredKeymanVersion10 } from "./compiler-globals.js";
 import { KmwCompilerMessages } from "./kmw-compiler-messages.js";
 import { FormatModifierAsBitflags, RuleIsExcludedByPlatform } from "./kmw-compiler.js";
 import { KMXCodeNames, SValidIdentifierCharSet, UnreachableKeyCodes, USEnglishShift,
@@ -257,22 +258,20 @@ export function JavaScript_Shift(fkp: KMX.KEY, FMnemonic: boolean): number {
 
     // Non-chiral support only and no support for state keys
     if (fkp.ShiftFlags & (KMX.KMXFile.LCTRLFLAG | KMX.KMXFile.RCTRLFLAG | KMX.KMXFile.LALTFLAG | KMX.KMXFile.RALTFLAG)) {   // I4118
-      // TODO: automatic version upgrade
-      // if(verifyMinimumRequiredKeymanVersion10()) {
-      //   // upgrade to v10 if possible
-      //   return fkp.ShiftFlags;
-      // }
+      if(verifyMinimumRequiredKeymanVersion10()) {
+        // upgrade to v10 if possible
+        return fkp.ShiftFlags;
+      }
       callbacks.reportMessage(KmwCompilerMessages.Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb({line:fkp.Line, flags: 'LALT, RALT, LCTRL, RCTRL'}));
     }
 
     if (fkp.ShiftFlags & (
       KMX.KMXFile.CAPITALFLAG | KMX.KMXFile.NOTCAPITALFLAG | KMX.KMXFile.NUMLOCKFLAG | KMX.KMXFile.NOTNUMLOCKFLAG |
       KMX.KMXFile.SCROLLFLAG | KMX.KMXFile.NOTSCROLLFLAG)) {   // I4118
-        // TODO: automatic version upgrade
-        // if(verifyMinimumRequiredKeymanVersion10()) {
-        // // upgrade to v10 if possible
-        // return fkp.ShiftFlags;
-        // }
+        if(verifyMinimumRequiredKeymanVersion10()) {
+          // upgrade to v10 if possible
+          return fkp.ShiftFlags;
+        }
         callbacks.reportMessage(KmwCompilerMessages.Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb({line:fkp.Line, flags: 'CAPS and NCAPS'}));
     }
 

--- a/developer/src/kmc-kmn/test/fixtures/kmw/version_9_caps_lock.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/version_9_caps_lock.kmn
@@ -1,0 +1,11 @@
+﻿store(&NAME) 'version_9_caps_lock'
+store(&TARGETS) 'web'
+store(&VERSION) '9.0'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+c Use of CAPS should make compiler generate warning Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb
+
++ [CAPS K_A] > 'a'

--- a/developer/src/kmc-kmn/test/fixtures/kmw/version_9_chiral_modifiers.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/version_9_chiral_modifiers.kmn
@@ -1,0 +1,11 @@
+﻿store(&NAME) 'version_9_chiral_modifiers'
+store(&TARGETS) 'web'
+store(&VERSION) '9.0'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+c Use of LCTRL should make compiler generate warning Warn_ExtendedShiftFlagsNotSupportedInKeymanWeb
+
++ [LCTRL K_A] > 'a'

--- a/developer/src/kmc-kmn/test/fixtures/kmw/version_auto_caps_lock.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/version_auto_caps_lock.kmn
@@ -1,0 +1,10 @@
+﻿store(&NAME) 'version_auto_caps_lock'
+store(&TARGETS) 'web'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+c Use of CAPS should make compiler select version 10
+
++ [CAPS K_A] > 'a'

--- a/developer/src/kmc-kmn/test/fixtures/kmw/version_auto_chiral_modifiers.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/version_auto_chiral_modifiers.kmn
@@ -1,0 +1,10 @@
+﻿store(&NAME) 'version_auto_chiral_modifiers'
+store(&TARGETS) 'web'
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+c Use of LCTRL should make compiler select version 10
+
++ [LCTRL K_A] > 'a'

--- a/developer/src/kmc-kmn/test/kmw/test-kmw-messages.ts
+++ b/developer/src/kmc-kmn/test/kmw/test-kmw-messages.ts
@@ -47,6 +47,9 @@ describe('KmwCompilerMessages', function () {
 
   // TODO: other messages
 
+  // WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb:
+  // * Implemented in test-kmw-compiler.ts: 'should give warning WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb for v9 keyboards if ${mode} found'
+
   // ERROR_NotAnyRequiresVersion14
 
   // it('should generate ERROR_NotAnyRequiresVersion14 if ...', async function() {


### PR DESCRIPTION
Adds support for determining minimum version 10.0 when chiral modifiers or state modifiers are found in virtual keys, e.g. `[LCTRL K_A]`, `[CAPS K_A]`, and corresponding unit tests.

Fixes: #11958

@keymanapp-test-bot skip
