### PR TITLE
fix(web): present a "keep" option when a context-altering suggestion is auto-selected

### DIFF
--- a/common/web/input-processor/src/text/prediction/predictionContext.ts
+++ b/common/web/input-processor/src/text/prediction/predictionContext.ts
@@ -138,8 +138,13 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
     // Insert 'current text' if/when valid as the leading option.
     // Since we don't yet do auto-corrections, we only show 'keep' whenever it's
     // a valid word (according to the model).
+    const mayShowKeep = this.activateKeep() && this.keepSuggestion;
 
-    if(this.activateKeep() && this.keepSuggestion && this.keepSuggestion.matchesModel) {
+    // If there is an auto-select option that doesn't match the current context,
+    // we need to present the user a way to preserve the current context instead.
+    const keepNeeded = this.selected && (this.keepSuggestion != this.selected);
+
+    if(mayShowKeep && (keepNeeded || this.keepSuggestion.matchesModel)) {
       suggestions.push(this.keepSuggestion);
     } else if(this.doRevert) {
       suggestions.push(this.revertSuggestion);


### PR DESCRIPTION
Addresses part of #11963.  In particular, this change ensures that an option to preserve the current context exists whenever auto-correct is ready to activate in a manner that would change the context.

These changes, in isolation, break one input-processor unit test.  The follow-up PR - #11970 - has changes that address the affected area anyway and will fix the unit test as a side-effect.  Accordingly, all user tests for this PR will be included as part of it.

@keymanapp-test-bot skip