### PR TITLE
fix(web): prevents auto-accept immediately after reversion

### DIFF
--- a/common/web/input-processor/src/text/prediction/predictionContext.ts
+++ b/common/web/input-processor/src/text/prediction/predictionContext.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "eventemitter3";
 import type LanguageProcessor from "./languageProcessor.js";
-import { type ReadySuggestions, type InvalidateSourceEnum, StateChangeHandler } from './languageProcessor.js';
+import { ReadySuggestions, type InvalidateSourceEnum, StateChangeHandler } from './languageProcessor.js';
 import { type KeyboardProcessor, type OutputTarget } from "@keymanapp/keyboard-processor";
 
 interface PredictionContextEventMap {
@@ -89,11 +89,9 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
     this.suggestionReverter = async (reversion) => {
       if(validSuggestionState()) {
         let suggestions = await langProcessor.applyReversion(reversion, this.currentTarget);
-
-        // We bypass the 'standard' "new suggestions" pipeline, as these aren't NEW suggestions.
-        // We also want to avoid altering flags that would indicate our post-reversion state.
-        this._currentSuggestions = suggestions;
-        this.sendUpdateEvent();
+        // We want to avoid altering flags that would indicate our post-reversion state.
+        this.swallowPrediction = true;
+        this.updateSuggestions(new ReadySuggestions(suggestions, reversion.id ? -reversion.id : undefined));
       }
     }
 

--- a/common/web/input-processor/src/text/prediction/predictionContext.ts
+++ b/common/web/input-processor/src/text/prediction/predictionContext.ts
@@ -89,7 +89,7 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
     this.suggestionReverter = async (reversion) => {
       if(validSuggestionState()) {
         let suggestions = await langProcessor.applyReversion(reversion, this.currentTarget);
-        // We want to avoid altering flags that would indicate our post-reversion state.
+        // We want to avoid altering flags that indicate our post-reversion state.
         this.swallowPrediction = true;
         this.updateSuggestions(new ReadySuggestions(suggestions, reversion.id ? -reversion.id : undefined));
       }

--- a/common/web/input-processor/src/text/prediction/predictionContext.ts
+++ b/common/web/input-processor/src/text/prediction/predictionContext.ts
@@ -86,9 +86,14 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
       }
     }
 
-    this.suggestionReverter = (reversion) => {
+    this.suggestionReverter = async (reversion) => {
       if(validSuggestionState()) {
-        langProcessor.applyReversion(reversion, this.currentTarget);
+        let suggestions = await langProcessor.applyReversion(reversion, this.currentTarget);
+
+        // We bypass the 'standard' "new suggestions" pipeline, as these aren't NEW suggestions.
+        // We also want to avoid altering flags that would indicate our post-reversion state.
+        this._currentSuggestions = suggestions;
+        this.sendUpdateEvent();
       }
     }
 

--- a/common/web/lm-worker/src/main/model-compositor.ts
+++ b/common/web/lm-worker/src/main/model-compositor.ts
@@ -771,6 +771,9 @@ export default class ModelCompositor {
         // A reversion's transform ID is the additive inverse of its original suggestion;
         // we revert to the state of said original suggestion.
         suggestion.transformId = -reversion.transformId;
+        // Prevent auto-selection of any suggestion immediately after a reversion.
+        // It's fine after at least one keystroke, but not before.
+        suggestion.autoAccept = false;
       });
 
       return suggestions;
@@ -813,6 +816,7 @@ export default class ModelCompositor {
       // A reversion's transform ID is the additive inverse of its original suggestion;
       // we revert to the state of said original suggestion.
       suggestion.transformId = -reversion.transformId;
+      suggestion.autoAccept = false;
     });
     return suggestions;
   }


### PR DESCRIPTION
Addresses part of https://github.com/keymanapp/keyman/issues/11963. 

In particular, this change ensures that auto-correct doesn't immediately undo reversions immediately after applying them.  Suppose a name is typed that's not in the dictionary.  (I ran into this personally when typing "Esther" and trying to get "Esther" to actually 'stick'.)  The idea:
- Reverting restores the original text, as it was.
- If I'm undoing an auto-correct, the original text may well have been correct.
- If I tap space right after a reversion, I likely mean for the reverted text to be preserved, rather than re-corrected.  
    - I didn't want whatever suggestion was applied, so we should be way less aggressive about auto-applying one.
- On the other hand, if I make edits to the text before pressing space, auto-correct might be reasonable again.

Note that the logic doesn't actually check that we're reverting an auto-correct.  That would take additional work.

## User Testing

**TEST_GENERAL_PREDICTIONS**:  Test that standard predictive-text operations work as expected.

**TEST_WITHOUT_SELECTION**:   Using Keyman for Android, the EuroLatin (SIL) keyboard, and the MTNT English model, verify that a context-preserving suggestion is not presented unnecessarily.

1. Type `corr`.
2. Verify that multiple suggestions starting with `corr` appear.
3. Verify that no `"corr"` suggestion appears.
4. Type `ect` - resulting in `correct`.
5. Verify that multiple suggestions starting with `correct` appear.
6. Verify that `correct` is auto-selected.
7. Verify that no `"correct"` suggestion appears.  (Specifically, that no such suggestion _with visible quotes_ appears.)
8. Type `l` - resulting in `correctl`.
9. Verify that `"correctl"` appears as a suggestion.
10. Verify that `correctly` is auto-selected.

**TEST_PRESERVE_AMONG_MANY**:  Using Keyman for Android, the EuroLatin (SIL) keyboard, and the MTNT English model, verify that a context-preserving suggestion is presented that operates properly.

1. Type `Esthe`.
    - A non-selected suggestion `"Esthe"` should be presented
    - The suggestion `Either` should be auto-selected.
2. Apply the `"Esthe"` suggestion.
    - The context should be preserved, with space added after it.
3. Type `Esthe` again.
4. This time, press the spacebar.
    - `Esthe` should be replaced with `Either `.

**TEST_PRESERVE_AMONG_ONE**:  Using Keyman for Android, the EuroLatin (SIL) keyboard, and the MTNT English model, verify that a context-preserving suggestion is presented that operates properly.

1. Type `zoologists`.
    - A non-selected suggestion `"zoologists"` should be presented
    - The suggestion 'apologists` should be auto-selected.
    - There should be no other suggestions on display.
    - If `apologists` appears but is not auto-selected, FAIL this test.
    - If it does not appear at all, retry this step.
2. Apply the `zoologists` suggestion.
    - The context should be preserved, with space added after it.

**TEST_REVERSION_BEHAVIOR**: Verify that applying a reversion never results in an automatically-selected suggestion.

1. Using the EuroLatin (SIL) keyboard and the MTNT model...
2. Type `Esther`.
3. Verify that `either` is auto-selected.
4. Press space, automatically accepting `either`.
5. Press backspace once.
6. Select `"Esther"`.
7. Verify that none of the presented suggestions are auto-selected.
8. Press space once and verify that `Esther` remains in the context.
9. Verify that no `"Esther"` suggestion is presented.