### PR TITLE
chore(windows): remove QIT_VSHIFTDOWN QIT _VSHIFTUP

### DIFF
--- a/developer/src/samples/imsample/imdllref.rtf
+++ b/developer/src/samples/imsample/imdllref.rtf
@@ -1,274 +1,316 @@
-{\rtf1\ansi\ansicpg1252\uc1 \deff0\deflang1033\deflangfe1033{\fonttbl{\f0\froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f1\fswiss\fcharset0\fprq2{\*\panose 020b0604020202020204}Arial;}
-{\f2\fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}{\f3\froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f74\froman\fcharset238\fprq2 Times New Roman CE;}{\f75\froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\f77\froman\fcharset161\fprq2 Times New Roman Greek;}{\f78\froman\fcharset162\fprq2 Times New Roman Tur;}{\f79\froman\fcharset186\fprq2 Times New Roman Baltic;}{\f80\fswiss\fcharset238\fprq2 Arial CE;}{\f81\fswiss\fcharset204\fprq2 Arial Cyr;}
-{\f83\fswiss\fcharset161\fprq2 Arial Greek;}{\f84\fswiss\fcharset162\fprq2 Arial Tur;}{\f85\fswiss\fcharset186\fprq2 Arial Baltic;}{\f86\fmodern\fcharset238\fprq1 Courier New CE;}{\f87\fmodern\fcharset204\fprq1 Courier New Cyr;}
-{\f89\fmodern\fcharset161\fprq1 Courier New Greek;}{\f90\fmodern\fcharset162\fprq1 Courier New Tur;}{\f91\fmodern\fcharset186\fprq1 Courier New Baltic;}}{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;
-\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;
-\red192\green192\blue192;}{\stylesheet{\widctlpar\adjustright \fs20\lang3081\cgrid \snext0 Normal;}{\s1\sb240\sa60\keepn\widctlpar\adjustright \b\f1\fs28\lang3081\kerning28\cgrid \sbasedon0 \snext0 heading 1;}{\s2\sb240\sa60\keepn\widctlpar\adjustright 
-\b\i\f1\lang3081\cgrid \sbasedon0 \snext0 heading 2;}{\s3\sb120\keepn\widctlpar\adjustright \b\f1\fs20\lang3081\cgrid \sbasedon0 \snext0 heading 3;}{\*\cs10 \additive Default Paragraph Font;}{\s15\fi-425\li709\widctlpar\adjustright 
-\f2\fs16\lang3081\cgrid \sbasedon0 \snext15 Code;}{\s16\widctlpar\adjustright \b\f1\fs16\lang3081\cgrid \sbasedon0 \snext16 TableHeader;}{\*\cs17 \additive \f2\fs16 \sbasedon10 PCode;}{\s18\widctlpar\adjustright \f1\fs16\lang3081\cgrid 
-\sbasedon0 \snext18 TCell;}{\s19\qc\sb240\sa60\widctlpar\outlinelevel0\adjustright \b\f1\fs32\lang3081\kerning28\cgrid \sbasedon0 \snext19 Title;}{\s20\fi-283\li567\widctlpar\adjustright \fs20\lang3081\cgrid \sbasedon0 \snext20 Arial;}{\*\cs21 \additive 
-\f1\fs18 \sbasedon10 filename;}{\s22\widctlpar\adjustright \fs20\lang3081\cgrid \sbasedon0 \snext22 pc;}{\s23\widctlpar\tqc\tx4153\tqr\tx8306\adjustright \fs20\lang3081\cgrid \sbasedon0 \snext23 header;}{\s24\widctlpar\tqc\tx4153\tqr\tx8306\adjustright 
-\fs20\lang3081\cgrid \sbasedon0 \snext24 footer;}{\*\cs25 \additive \sbasedon10 page number;}}{\*\listtable{\list\listtemplateid-963727900\listsimple{\listlevel\levelnfc0\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
-\'02\'00.;}{\levelnumbers\'01;}\fi-360\li1492\jclisttab\tx1492 }{\listname ;}\listid-132}{\list\listtemplateid1736061876\listsimple{\listlevel\levelnfc0\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'00.;}{\levelnumbers\'01;}
-\fi-360\li1209\jclisttab\tx1209 }{\listname ;}\listid-131}{\list\listtemplateid-1759738300\listsimple{\listlevel\levelnfc0\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'00.;}{\levelnumbers\'01;}\fi-360\li926\jclisttab\tx926 
-}{\listname ;}\listid-130}{\list\listtemplateid-1902884938\listsimple{\listlevel\levelnfc0\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'00.;}{\levelnumbers\'01;}\fi-360\li643\jclisttab\tx643 }{\listname ;}\listid-129}
-{\list\listtemplateid1956535276\listsimple{\listlevel\levelnfc23\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li1492\jclisttab\tx1492 }{\listname ;}\listid-128}
-{\list\listtemplateid-392499776\listsimple{\listlevel\levelnfc23\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li1209\jclisttab\tx1209 }{\listname ;}\listid-127}
-{\list\listtemplateid-967173064\listsimple{\listlevel\levelnfc23\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li926\jclisttab\tx926 }{\listname ;}\listid-126}
-{\list\listtemplateid-1624359846\listsimple{\listlevel\levelnfc23\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li643\jclisttab\tx643 }{\listname ;}\listid-125}
-{\list\listtemplateid-323179536\listsimple{\listlevel\levelnfc0\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'00.;}{\levelnumbers\'01;}\fi-360\li360\jclisttab\tx360 }{\listname ;}\listid-120}{\list\listtemplateid1800809868
-\listsimple{\listlevel\levelnfc23\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li360\jclisttab\tx360 }{\listname ;}\listid-119}{\list\listtemplateid201916431\listsimple{\listlevel
-\levelnfc0\leveljc0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'00.;}{\levelnumbers\'01;}\fi-360\li360\jclisttab\tx360 }{\listname ;}\listid1081215738}{\list\listtemplateid201916431\listsimple{\listlevel\levelnfc0\leveljc0
-\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\'02\'00.;}{\levelnumbers\'01;}\fi-360\li360\jclisttab\tx360 }{\listname ;}\listid1620605434}}{\*\listoverridetable{\listoverride\listid-119\listoverridecount0\ls1}{\listoverride\listid-125
-\listoverridecount0\ls2}{\listoverride\listid-126\listoverridecount0\ls3}{\listoverride\listid-127\listoverridecount0\ls4}{\listoverride\listid-128\listoverridecount0\ls5}{\listoverride\listid-120\listoverridecount0\ls6}{\listoverride\listid-129
-\listoverridecount0\ls7}{\listoverride\listid-130\listoverridecount0\ls8}{\listoverride\listid-131\listoverridecount0\ls9}{\listoverride\listid-132\listoverridecount0\ls10}{\listoverride\listid1620605434\listoverridecount0\ls11}
-{\listoverride\listid1081215738\listoverridecount0\ls12}}{\info{\title DLL Interface for Keyman}{\author Marc Durdin}{\operator Marc Durdin}{\creatim\yr2001\mo6\dy5\hr11\min48}{\revtim\yr2001\mo6\dy5\hr12\min28}{\version3}{\edmins1}{\nofpages6}
-{\nofwords1968}{\nofchars11219}{\*\company Tavultesoft}{\nofcharsws13777}{\vern89}}\paperw11906\paperh16838 \widowctrl\ftnbj\aenddoc\hyphcaps0\formshade\viewkind1\viewscale117\viewzk2\pgbrdrhead\pgbrdrfoot \fet0\sectd 
-\linex0\headery709\footery709\colsx709\endnhere\sectdefaultcl {\header \pard\plain \s23\widctlpar\brdrb\brdrs\brdrw10\brsp20 \tqc\tx4153\tqr\tx8306\adjustright \fs20\lang3081\cgrid {\b\f1 DLL Interface for Keyman\tab \tab 5 June 2001
-\par }}{\footer \pard\plain \s24\widctlpar\brdrt\brdrs\brdrw10\brsp20 \tqc\tx4153\tqr\tx8306\adjustright \fs20\lang3081\cgrid {\b\f1 Page }{\field{\*\fldinst {\cs25\b\f1  PAGE }}{\fldrslt {\cs25\b\f1\lang1024 5}}}{\cs25\b\f1  of }{\field{\*\fldinst {
-\cs25\b\f1  NUMPAGES }}{\fldrslt {\cs25\b\f1\lang1024 1}}}{\cs25\b\f1 \tab \tab \'a9 2001 Tavultesoft}{\b\f1 
-\par }}{\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang{\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang{\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang{\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang{\pntxta )}}
-{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang{\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang{\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang{\pntxtb (}{\pntxta )}}{\*\pnseclvl8
-\pnlcltr\pnstart1\pnindent720\pnhang{\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang{\pntxtb (}{\pntxta )}}\pard\plain \s19\qc\sb240\sa60\widctlpar\outlinelevel0\adjustright \b\f1\fs32\lang3081\kerning28\cgrid {
-DLL Interface for Keyman
-\par }\pard\plain \s1\sb240\sa60\keepn\widctlpar\outlinelevel0\adjustright \b\f1\fs28\lang3081\kerning28\cgrid {Introduction
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-Keyman's multiple group processing is powerful, but sometimes you need to be able to do something a bit more complex, such as a dictionary lookup.  Keyman's DLL interface let you do this.  You can call a function in a DLL in the same way as you call anoth
-er group.  The function can read the context, deadkeys and the current keystroke, and output characters, deadkeys, virtual keys, beeps and other items.
-\par 
-\par The DLL interface also allows you to create a popup Input Method Composition (IMC) window.  This window 
-allows the user to select visually the characters they are wishing to input.  The window can be set to be visible when the keyboard is active, or after an appropriate key sequence.  When the window is visible, it can be set to capture all keyboard input, 
-or be passive.
-\par }\pard\plain \s1\sb240\sa60\keepn\widctlpar\outlinelevel0\adjustright \b\f1\fs28\lang3081\kerning28\cgrid {File locations
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {The DLL should be placed in any of the following locations:
-\par 
-\par {\pntext\pard\plain\fs20\cgrid \hich\af0\dbch\af0\loch\f0 1.\tab}}\pard \fi-360\li1080\widctlpar\jclisttab\tx1080{\*\pn \pnlvlbody\ilvl0\ls12\pnrnot0\pndec\pnstart1\pnindent360\pnhang{\pntxta .}}\ls12\adjustright {
-The same directory as the .kmx file (e.g. use a package to install it)
-\par {\pntext\pard\plain\fs20\cgrid \hich\af0\dbch\af0\loch\f0 2.\tab}}\pard \fi-360\li1080\widctlpar\jclisttab\tx1080{\*\pn \pnlvlbody\ilvl0\ls12\pnrnot0\pndec\pnstart1\pnindent360\pnhang{\pntxta .}}\ls12\adjustright {
-The Keyman program directory (same place as keyman32.dll)
-\par {\pntext\pard\plain\fs20\cgrid \hich\af0\dbch\af0\loch\f0 3.\tab}}\pard \fi-360\li1080\widctlpar\jclisttab\tx1080{\*\pn \pnlvlbody\ilvl0\ls12\pnrnot0\pndec\pnstart1\pnindent360\pnhang{\pntxta .}}\ls12\adjustright {Anywhere on the path (suc
-h as the Windows directory)
-\par }\pard \widctlpar\adjustright {
-\par The best option is (1), as you can then include the DLL in a Keyman package for easy installation and uninstallation.
-\par }\pard\plain \s1\sb240\sa60\keepn\widctlpar\outlinelevel0\adjustright \b\f1\fs28\lang3081\kerning28\cgrid {General usage information
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {DLL functions used in place of groups are called }{\i DLL group functions}{.
-\par 
-\par All strings, apart from keyboard names, are passed as WCHAR, regardless of whether the active window is a Unicode window or not.  ANSI characters are represented as 16-bit WCHAR, with high bits zeroed out.
-\par 
-\par The DLL will be loaded for each process in which the keyboard is activated.  Remember that the DLL will }{\b\i not}{
- share memory between these processes by default, so if you have large memory requirements, you should use memory mapped files or possibly SHARDATA segments to minimize the memory consumption.
-\par 
-\par DLL group functi
-ons are called in a fairly time-critical environment.  It is important that you minimise the processing time in these functions.  It is essential that you avoid any window focus or activation -- message boxes are definitely out of the question.  For debug
-ging purposes, there is a Keyman32.dll function exported for writing to the logfile (see the section titled }{\i Keyman32 imports}{).
-\par 
-\par DLLs can handle multiple keyboards at once.  The keyboards are identified by a name which is the filename of the keyboard, minus path and extension.  For example, given }{\f1 c:\\keyman\\imsample\\imsample.kmx}{, the keyboard name is }{\cs17\f2\fs16 
-imsample}{.  These are the same names that Keyman uses internally, for example in the registry and directory names.
-\par }\pard\plain \s1\sb240\sa60\keepn\widctlpar\outlinelevel0\adjustright \b\f1\fs28\lang3081\kerning28\cgrid {Registry settings
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par Par
-ameters for the DLL can be stored in two locations in the registry.  They should always be stored under HKEY_CURRENT_USER, as the user may not have permission to change machine-wide settings, and the settings should not affect other users.  The following 
-locations are recommended:
-\par 
-\par }\pard\plain \s20\fi-283\li567\widctlpar\adjustright \fs20\lang3081\cgrid {\f1\fs18 HKEY_CURRENT_USER\\Software\\Tavultesoft\\Keyman\\5.0\\<DLLName>
-\par HKEY_CURRENT_USER\\Software\\Tavultesoft\\Keyman\\5.0\\Installed Keyboards\\<kbdname>
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par The first key should be used for settings that pertain to any keyboard associated with t
-he DLL.  The second key should be used for any keyboard-specific settings.  Values stored under the second key should be prefixed with the name of the dll, so that they will not conflict with Keyman or other dll values.
-\par }\pard\plain \s1\sb240\sa60\keepn\widctlpar\outlinelevel0\adjustright \b\f1\fs28\lang3081\kerning28\cgrid {The .kmn interface
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {Inside a .kmn file, you define the DLL group function interface as follows:
-\par 
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {store(DLLFunction) "myfile.dll:KeyEvent"
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par You can use this anywhere where you would place the }{\cs17\f2\fs16 use}{ statement (except in the }{\cs17\f2\fs16 begin}{ statement), with the }{\cs17\f2\fs16 call}{ statement.  For example,
-\par 
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {+ 'a' > call(DLLFunction)
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par A single .kmn file can reference multiple DLL group functions, in a single or multiple DLLs.
-\par }\pard\plain \s1\sb240\sa60\keepn\widctlpar\outlinelevel0\adjustright \b\f1\fs28\lang3081\kerning28\cgrid {DLL exports
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {The DLL is called from Keyman with LoadLibrary.  All functions are then found with GetProcAddress.  You must ensure that the function expor
-ts do not have ordinals encoded in the names.  The best way to accomplish this in C/C++ is to use a .def file.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {DLL group function exports
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {The function declaration for the DLL group function is:
-\par 
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI }{\i KeyEvent}{(HWND hwndFocus, WORD KeyStroke, WCHAR KeyChar, DWORD ShiftFlags);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par Note that }{\cs17\f2\fs16 KeyEvent}{ is a placeholder for any name that you wish to use.  You can have multiple exports for Keyman use in a single DLL.
-\par }\pard\plain \s3\sb120\keepn\widctlpar\outlinelevel2\adjustright \b\f1\fs20\lang3081\cgrid {Parameters
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par }\trowd \trgaph108\trbrdrt\brdrs\brdrw10 \trbrdrl\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrh\brdrs\brdrw10 \trbrdrv\brdrs\brdrw10 \clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr
-\brdrs\brdrw10 \cltxlrtb \cellx1418\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx6238\pard\plain \s16\widctlpar\intbl\adjustright \b\f1\fs16\lang3081\cgrid {Parameter\cell Description
-\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\trowd \trgaph108\trbrdrt\brdrs\brdrw10 \trbrdrl\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrh\brdrs\brdrw10 \trbrdrv\brdrs\brdrw10 \clvertalt\clbrdrt
-\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx1418\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx6238\pard 
-\widctlpar\intbl\adjustright {\cs17\f2\fs16 hwndFocus\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {The currently focused window.  You will probably never have a need to use this. \cell }\pard\plain 
-\widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 KeyStroke\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {The virtual key code for the current key.\cell }\pard\plain 
-\widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 KeyChar\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {
-The character code for the current key (based on US English layout).  This will be 0 if KeyStroke does not generate a character (e.g. function keys).\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\trowd \trgaph108\trbrdrt
-\brdrs\brdrw10 \trbrdrl\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrh\brdrs\brdrw10 \trbrdrv\brdrs\brdrw10 \clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx1418
-\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx6238\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 ShiftFlags\cell }\pard\plain \s18\widctlpar\intbl\adjustright 
-\f1\fs16\lang3081\cgrid {The shift state for the current key.  See the table in the Notes section for possible shift states. \cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\pard\plain 
-\s3\sb120\keepn\widctlpar\outlinelevel2\adjustright \b\f1\fs20\lang3081\cgrid {Notes
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par The following shift states are possible:
-\par 
-\par }\trowd \trgaph108\trbrdrt\brdrs\brdrw10 \trbrdrl\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrh\brdrs\brdrw10 \trbrdrv\brdrs\brdrw10 \clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr
-\brdrs\brdrw10 \cltxlrtb \cellx1701\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx2694\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr
-\brdrs\brdrw10 \cltxlrtb \cellx5670\pard\plain \s16\widctlpar\intbl\adjustright \b\f1\fs16\lang3081\cgrid {Flag\cell Value\cell Description\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\trowd \trgaph108\trbrdrt\brdrs\brdrw10 
-\trbrdrl\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrh\brdrs\brdrw10 \trbrdrv\brdrs\brdrw10 \clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx1701\clvertalt\clbrdrt
-\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx2694\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx5670\pard 
-\widctlpar\intbl\adjustright {\cs17\f2\fs16 LCTRLFLAG\cell 0x0001\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Left Control flag\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\fs16 \row }\pard 
-\widctlpar\intbl\adjustright {\cs17\f2\fs16 RCTRLFLAG\cell 0x0002\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Right Control flag\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\fs16 \row }\pard 
-\widctlpar\intbl\adjustright {\cs17\f2\fs16 LALTFLAG\cell 0x0004\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Left Alt flag\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\fs16 \row }\pard 
-\widctlpar\intbl\adjustright {\cs17\f2\fs16 RALTFLAG\cell 0x0008\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Right Alt flag\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\fs16 \row }\pard 
-\widctlpar\intbl\adjustright {\cs17\f2\fs16 K_SHIFTFLAG\cell 0x0010\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Shift flag\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\pard 
-\widctlpar\intbl\adjustright {\cs17\f2\fs16 K_CTRLFLAG\cell 0x0020\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Ctrl flag (unused here; see l/r flags) \cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {
-\row }\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 K_ALTFLAG\cell 0x0040\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Alt flag (unused here; see l/r flags)\cell }\pard\plain \widctlpar\intbl\adjustright 
-\fs20\lang3081\cgrid {\row }\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 CAPITALFLAG\cell 0x0100\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Caps lock on\cell }\pard\plain \widctlpar\intbl\adjustright 
-\fs20\lang3081\cgrid {\fs16 \row }\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 NUMLOCKFLAG\cell 0x0400\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Num lock on\cell }\pard\plain \widctlpar\intbl\adjustright 
-\fs20\lang3081\cgrid {\fs16 \row }\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 SCROLLFLAG\cell 0x1000\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Scroll lock on\cell }\pard\plain \widctlpar\intbl\adjustright 
-\fs20\lang3081\cgrid {\fs16 \row }\trowd \trgaph108\trbrdrt\brdrs\brdrw10 \trbrdrl\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrh\brdrs\brdrw10 \trbrdrv\brdrs\brdrw10 \clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb
-\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx1701\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx2694\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb
-\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx5670\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 ISVIRTUALKEY\cell 0x4000\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {It is a Virtual Key Sequence\cell 
-}\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\fs16 \row }\pard\plain \s1\sb240\sa60\keepn\widctlpar\outlinelevel0\adjustright \b\f1\fs28\lang3081\kerning28\cgrid {Optional DLL exports
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-Keyman recognises a number of other exports, if they are defined in the DLL.  None of these are required.  These functions will be called when a keyboard that references the DLL is manipulated.  They will not be called for keyboards that do not reference 
-the DLL.
-\par 
-\par The following exports are available:
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KeymanIMInit
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KeymanIMInit(PSTR keyboardname);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par }{\cs17\f2\fs16 KeymanIMInit}{ is called once when the keyboard identified by }{\cs17\f2\fs16 keyboardname}{ is loaded for a given process.  It is called for each process in which the keyboard is loaded.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KeymanIMDestroy
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KeymanIMDestroy(PSTR keyboardname);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par This is called once when the keyboard identified by }{\cs17\f2\fs16 keyboardname}{ is unloaded in a given process
-.  It is called when the process exits normally, or when Keyman refreshes its keyboard list after keyboards are added or removed.  If the keyboard is subsequently reloaded, }{\cs17\f2\fs16 KeymanIMInit}{ will be called again.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KeymanIMActivate
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KeymanIMActivate(PSTR keyboardname);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par This function is called whenever the user or a program activates the keyboard.  It is never called before KeymanIMInit (unless KeymanIMInit is not exported).  This is an appropriate place to switch on permanently-visible IMC windows.  }{\cs17\f2\fs16 Ke
-ymanIMActivate}{ can also be called when switching processes and the target process has a related keyboard already active.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KeymanIMDeactivate
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KeymanIMDeactivate(PSTR keyboardname);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par This function is called when the user or a program switches off a related keyboard.  It is always called before }{\cs17\f2\fs16 KeymanIMActivate}{
- for the next keyboard.  It will also be called when the user activates another process, to give the DLL a chance to hide top-most IMC windows.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KeymanIMConfigure
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KeymanIMConfigure(PSTR keyboardname, HWND hwndParent);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par KeymanIMConfigure is called when the user clicks the Configure button in KMShell to configure the DLL-specific functionality for the keyboard.  The appropriate behaviour is to display a dialog box, and save the settings in the registry.
-\par 
-\par This function is separate from all the other functions.  It can be called when there are no keyboards loaded, or even if Keyman itself is not loaded.  You should not attempt to call Keyman32.dll from this function.
-\par }\pard\plain \s1\sb240\sa60\keepn\widctlpar\outlinelevel0\adjustright \b\f1\fs28\lang3081\kerning28\cgrid {The imlib.cpp library module
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {imlib.cpp, included in the development kit, contains a set of useful functions for interfacing to Keyman.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {PrepIM
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL PrepIM(void);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par }{\cs17\f2\fs16 PrepIM}{ initialises the Keyman32 imports.  You should not call any of the Keyman imports without calling }{\cs17\f2\fs16 PrepIM}{ first.  If }{\cs17\f2\fs16 PrepIM}{ fails, you should exit without doing any processing.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {IMDefWindowProc
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL IMDefWindowProc(HWND hwnd, UINT msg, WPARAM wParam, \line LPARAM lParam, LRESULT *lResult);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par }{\cs17\f2\fs16 IMDefWindowProc}{ should be called from an IMC window procedure (see section titled }{\i Input Method Composition windows}{).  If it returns TRUE you should return the value stored in }{\cs17\f2\fs16 lResult}{
- without any further processing.  }{\cs17\f2\fs16 IMDefWindowProc}{ mostly manages window activation and movement.
-\par 
-\par }\pard\plain \s1\sb240\sa60\keepn\widctlpar\outlinelevel0\adjustright \b\f1\fs28\lang3081\kerning28\cgrid {Keyman Imports
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-The DLL can call Keyman functions to interact with Keyman and the target application.  It should not attempt to directly control the application as Keyman will be doing this.  You should never call any of the functions here from the }{\cs17\f2\fs16 
-KeymanIMConfigure}{ callback.
-\par 
-\par You can use }{\cs17\f2\fs16 PrepIM()}{, declared in }{\cs21\f1\fs18 imlib.cpp}{ to get access to the the Keyman functions.  When using }{\cs21\f1\fs18 imlib.cpp}{
-, the functions are declared as pointers, so you need to dereference them to call them in C (e.g. for }{\cs17\f2\fs16 KMGetContext}{, call }{\cs17\f2\fs16 (*KMGetcontext)(buf,len);}{
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KMGetContext
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KMGetContext(PWSTR buf, DWORD len);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par }{\cs17\f2\fs16 KMGetContext}{ returns the last }{\cs17\f2\fs16 len-1}{ characters of the context stack.  If there are not enough characters in the context stack, it will return as many as it can.  On success, the }{\cs17\f2\fs16 buf}{
- variable will be null terminated.
-\par 
-\par The context stack can contain a special code for deadkeys.  See }{\cs17\f2\fs16 KMQueueAction}{ for a way to output a deadkey.  The code sequence for a deadkey is (3 words):
-\par  
-\par }\pard\plain \s15\fi436\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {UC_SENTINEL, CODE_DEADKEY, }{\i deadkeyID}{
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par }{\cs17\f2\fs16 UC_SENTINEL}{ is }{\cs17\f2\fs16 0xFFFF}{; }{\cs17\f2\fs16 CODE_DEADKEY}{ is }{\cs17\f2\fs16 0x0008}{; }{\cs17\i\f2\fs16 deadkeyID}{ can be any value from }{\cs17\f2\fs16 0x0001}{ to }{\cs17\f2\fs16 0xFFFE}{.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KMSetOutput
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KMSetOutput(PWSTR buf, DWORD backlen); 
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par }{\cs17\f2\fs16 KMSetOutput}{ is a wrapper for }{\cs17\f2\fs16 KMQueueAction}{.  It simplifies the process of deleting contextual characte
-rs and outputting a new string.  The results will not be output to the screen until the current function returns.  If called within the context of an IMC window, the results will not be output to the screen until the window posts the }{\cs17\f2\fs16 
-wm_keymanim_close}{ message.
-\par 
-\par }{\cs17\f2\fs16 buf}{ is a pointer to a null-terminated string of characters to output.
-\par }{\cs17\f2\fs16 backlen}{ is the number of characters to backspace from the current context before displaying }{\cs17\f2\fs16 buf}{.
-\par 
-\par This function modifies the context returned from }{\cs17\f2\fs16 KMGetContext}{, even if the output is not yet on the screen.
-\par 
-\par Internally, this function does the following code:
-\par 
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {while(backlen-- > 0) KMQueueAction(QIT_BACK, 0);
-\par while(*buf) KMQueueAction(QIT_CHAR, *buf++);
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KMQueueAction
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KMQueueAction(int itemType, DWORD dwData);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par KMQueueAction lets you send any Keyman action to a target application.  This can be virtual keys, characters, shift keys up and down, deadkeys, beeps, or backspaces (a special case of virtual keys).
-\par 
-\par }\trowd \trgaph108\trleft284\trbrdrt\brdrs\brdrw10 \trbrdrl\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrh\brdrs\brdrw10 \trbrdrv\brdrs\brdrw10 \clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr
-\brdrs\brdrw10 \cltxlrtb \cellx2519\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx6780\pard\plain \s16\widctlpar\intbl\adjustright \b\f1\fs16\lang3081\cgrid {itemType code\cell 
-Description\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\trowd \trgaph108\trleft284\trbrdrt\brdrs\brdrw10 \trbrdrl\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrh\brdrs\brdrw10 \trbrdrv\brdrs\brdrw10 
-\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx2519\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx6780\pard 
-\widctlpar\intbl\adjustright {\cs17\f2\fs16 QIT_VKEYDOWN\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Simulate any key press on the keyboard; }{\b dwData}{ is the virtual key code\cell }\pard\plain 
-\widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 QIT_VKEYUP\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Simulate any key release on the keyboard; }{\b dwData}{
- is the virtual key code\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 QIT_VSHIFTDOWN\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {
-Simulate pressing a set of shift keys.  }{\b dwData}{ can be a combination of the following flags:
-\par LCTRLFLAG, RCTRLFLAG, LALTFLAG, RALTFLAG, K_SHIFTFLAG, K_CTRLFLAG, K_ALTFLAG\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 QIT_VSHIFTUP\cell }\pard\plain 
-\s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {Release the shift state, }{\b dwData}{ is the same as the previous flags.\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\pard \widctlpar\intbl\adjustright {
-\cs17\f2\fs16 QIT_CHAR\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {\b dwdata}{ is any WCHAR.  For an ANSI window, zero-pad an 8-bit character.\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row 
-}\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 QIT_DEADKEY\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {\b dwData }{is any value from 0x0001 to 0xFFFE.  This can be matched in the context with }{\b KMGetContext}{.\cell 
-}\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\pard \widctlpar\intbl\adjustright {\cs17\f2\fs16 QIT_BELL\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {\b dwData}{ should be zero (0).\cell }\pard\plain 
-\widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\trowd \trgaph108\trleft284\trbrdrt\brdrs\brdrw10 \trbrdrl\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrh\brdrs\brdrw10 \trbrdrv\brdrs\brdrw10 \clvertalt\clbrdrt\brdrs\brdrw10 
-\clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx2519\clvertalt\clbrdrt\brdrs\brdrw10 \clbrdrl\brdrs\brdrw10 \clbrdrb\brdrs\brdrw10 \clbrdrr\brdrs\brdrw10 \cltxlrtb \cellx6780\pard \widctlpar\intbl\adjustright {
-\cs17\f2\fs16 QIT_BACK\cell }\pard\plain \s18\widctlpar\intbl\adjustright \f1\fs16\lang3081\cgrid {\b dwData}{ should be zero (0).\cell }\pard\plain \widctlpar\intbl\adjustright \fs20\lang3081\cgrid {\row }\pard\plain 
-\s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KMHideIM
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KMHideIM(HWND hwndIM);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par }{\cs17\f2\fs16 KMHideIM}{ hides the IMC window referred to by }{\cs17\f2\fs16 hwndIM}{ and ensures that Keyman processes input from the keyboard through the correct method.  You should call this rather than hiding the window manually with }{
-\cs17\f2\fs16 ShowWindow(hwnd, SW_HIDE);}{ or post the message }{\cs17\f2\fs16 wm_keymanim_close}{ to hide the window.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KMDisplayIM
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KMDisplayIM(HWND hwndIM, BOOL FCaptureAll);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par }{\cs17\f2\fs16 KMDisplayIM}{ displays the IMC window referred to by }{\cs17\f2\fs16 hwndIM}{.  It does not do any movement of the window.  If the }{\cs17\f2\fs16 FCaptureAll}{ flag is set, all keyboard input (character-generating keys only) will be red
-irected to the IMC window until the message }{\cs17\f2\fs16 wm_keymanim_close}{ is posted, }{\cs17\f2\fs16 KMHideIM}{ is called, or }{\cs17\f2\fs16 KMDisplayIM}{ with }{\cs17\f2\fs16 FCaptureAll}{ is set to false.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KMGetKeyboardPath
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KMGetKeyboardPath(PSTR keyboardname, PWSTR dir, DWORD length);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par This function returns the full path to the keyboard referred to by }{\cs17\f2\fs16 keyboardname}{.  The buffer }{\cs17\f2\fs16 dir}{ should be 260 characters long.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KMGetActiveKeyboard
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {BOOL WINAPI KMGetActiveKeyboard(PSTR keyboardname, DWORD length);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par This function can be called while processing to determine which is the active keyboard.  Alternatively, use the callbacks }{\cs17\f2\fs16 KeymanIMActivate}{ and }{\cs17\f2\fs16 KeymanIMDeactivate}{.
-\par }\pard\plain \s2\sb240\sa60\keepn\widctlpar\outlinelevel1\adjustright \b\i\f1\lang3081\cgrid {KMSendDebugString
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {\cs17 BOOL WINAPI KMSendDebugString(PSTR str);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par This function outputs the string }{\cs17\f2\fs16 str}{ to the Keyman debug window or debug log file (usually }{\cs21\f1\fs18 c:\\keyman.log}{).
-\par }\pard\plain \s1\sb240\sa60\keepn\widctlpar\outlinelevel0\adjustright \b\f1\fs28\lang3081\kerning28\cgrid {The Input Method Composition window
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {The IMC window can be shown or hidden at any time that the associated keyboard is active.  This means that you can have an IMC window permanently open or open at appropriate times.
-\par 
-\par The keyboard IMSample included with Keyman is a good example of manipulating the IMC display.
-\par 
-\par The window should be created invisible, most probaly as a popup window.  The window can use }{\cs17\f2\fs16 KMGetContext}{, }{\cs17\f2\fs16 KMSetOutput}{ at any time, but output will not be put to the screen until it has posted (}{\b not }{sent) }{
-\cs17\f2\fs16 wm_keymanim_close}{ to itself.
-\par }\pard\plain \s15\fi-425\li709\widctlpar\adjustright \f2\fs16\lang3081\cgrid {
-\par PostMessage(hwnd, wm_keymanim_close, (WPARAM) FSuccess, (LPARAM) FActuallyClose);
-\par }\pard\plain \widctlpar\adjustright \fs20\lang3081\cgrid {
-\par Keyman will manage the window display, focus, and message loop.  The window procedure should set the position and size appropriately.
-\par 
-\par Keyman will recognise this window and any child windows to be part of the IM and will not attempt to process any input that goes through the window.
-\par 
-\par The IMC window must not take focus at any time.
-\par }\pard\plain \s3\sb120\keepn\widctlpar\outlinelevel2\adjustright \b\f1\fs20\lang3081\cgrid {Limitations
-\par {\pntext\pard\plain\fs20\cgrid \hich\af0\dbch\af0\loch\f0 1.\tab}}\pard\plain \fi-360\li360\widctlpar\jclisttab\tx360{\*\pn \pnlvlbody\ilvl0\ls11\pnrnot0\pndec\pnstart1\pnindent360\pnhang{\pntxta .}}\ls11\adjustright \fs20\lang3081\cgrid {
-Clicks outside the window will cancel the IM and lose context.
-\par {\pntext\pard\plain\fs20\cgrid \hich\af0\dbch\af0\loch\f0 2.\tab}}\pard \fi-360\li360\widctlpar\jclisttab\tx360{\*\pn \pnlvlbody\ilvl0\ls11\pnrnot0\pndec\pnstart1\pnindent360\pnhang{\pntxta .}}\ls11\adjustright {
-Switching applications will cancel the IM and lose context.
-\par }\pard \widctlpar\adjustright {
-\par }}
+{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033\deflangfe1033{\fonttbl{\f0\fswiss\fprq2\fcharset0 Arial;}{\f1\froman\fprq2\fcharset0 Times New Roman;}{\f2\fmodern\fprq1\fcharset0 Courier New;}}
+{\stylesheet{ Normal;}{\s1 heading 1;}{\s2 heading 2;}{\s3 heading 3;}}
+{\*\generator Riched20 10.0.19041}\viewkind4\uc1 
+\pard\widctlpar\sb240\sa60\qc\kerning28\b\f0\fs32\lang3081 DLL Interface for Keyman\par
+
+\pard\keepn\widctlpar\s1\sb240\sa60\fs28 Introduction\par
+
+\pard\widctlpar\kerning0\b0\f1\fs20 Keyman's multiple group processing is powerful, but sometimes you need to be able to do something a bit more complex, such as a dictionary lookup.  Keyman's DLL interface let you do this.  You can call a function in a DLL in the same way as you call another group.  The function can read the context, deadkeys and the current keystroke, and output characters, deadkeys, virtual keys, beeps and other items.\par
+\par
+The DLL interface also allows you to create a popup Input Method Composition (IMC) window.  This window allows the user to select visually the characters they are wishing to input.  The window can be set to be visible when the keyboard is active, or after an appropriate key sequence.  When the window is visible, it can be set to capture all keyboard input, or be passive.\par
+
+\pard\keepn\widctlpar\s1\sb240\sa60\kerning28\b\f0\fs28 File locations\par
+
+\pard\widctlpar\kerning0\b0\f1\fs20 The DLL should be placed in any of the following locations:\par
+\par
+
+\pard 
+{\pntext\f1 1.\tab}{\*\pn\pnlvlbody\pnf1\pnindent360\pnstart1\pndec{\pntxta.}}
+\widctlpar\fi-360\li1080 The same directory as the .kmx file (e.g. use a package to install it)\par
+{\pntext\f1 2.\tab}The Keyman program directory (same place as keyman32.dll)\par
+{\pntext\f1 3.\tab}Anywhere on the path (such as the Windows directory)\par
+
+\pard\widctlpar\par
+The best option is (1), as you can then include the DLL in a Keyman package for easy installation and uninstallation.\par
+
+\pard\keepn\widctlpar\s1\sb240\sa60\kerning28\b\f0\fs28 General usage information\par
+
+\pard\widctlpar\kerning0\b0\f1\fs20 DLL functions used in place of groups are called \i DLL group functions\i0 .\par
+\par
+All strings, apart from keyboard names, are passed as WCHAR, regardless of whether the active window is a Unicode window or not.  ANSI characters are represented as 16-bit WCHAR, with high bits zeroed out.\par
+\par
+The DLL will be loaded for each process in which the keyboard is activated.  Remember that the DLL will \b\i not\b0\i0  share memory between these processes by default, so if you have large memory requirements, you should use memory mapped files or possibly SHARDATA segments to minimize the memory consumption.\par
+\par
+DLL group functions are called in a fairly time-critical environment.  It is important that you minimise the processing time in these functions.  It is essential that you avoid any window focus or activation -- message boxes are definitely out of the question.  For debugging purposes, there is a Keyman32.dll function exported for writing to the logfile (see the section titled \i Keyman32 imports\i0 ).\par
+\par
+DLLs can handle multiple keyboards at once.  The keyboards are identified by a name which is the filename of the keyboard, minus path and extension.  For example, given \f0 c:\\keyman\\imsample\\imsample.kmx\f1 , the keyboard name is \f2\fs16 imsample\f1\fs20 .  These are the same names that Keyman uses internally, for example in the registry and directory names.\par
+
+\pard\keepn\widctlpar\s1\sb240\sa60\kerning28\b\f0\fs28 Registry settings\par
+
+\pard\widctlpar\kerning0\b0\f1\fs20\par
+Parameters for the DLL can be stored in two locations in the registry.  They should always be stored under HKEY_CURRENT_USER, as the user may not have permission to change machine-wide settings, and the settings should not affect other users.  The following locations are recommended:\par
+\par
+
+\pard\widctlpar\fi-283\li567\f0\fs18 HKEY_CURRENT_USER\\Software\\Tavultesoft\\Keyman\\5.0\\<DLLName>\par
+HKEY_CURRENT_USER\\Software\\Tavultesoft\\Keyman\\5.0\\Installed Keyboards\\<kbdname>\par
+
+\pard\widctlpar\f1\fs20\par
+The first key should be used for settings that pertain to any keyboard associated with the DLL.  The second key should be used for any keyboard-specific settings.  Values stored under the second key should be prefixed with the name of the dll, so that they will not conflict with Keyman or other dll values.\par
+
+\pard\keepn\widctlpar\s1\sb240\sa60\kerning28\b\f0\fs28 The .kmn interface\par
+
+\pard\widctlpar\kerning0\b0\f1\fs20 Inside a .kmn file, you define the DLL group function interface as follows:\par
+\par
+
+\pard\widctlpar\fi-425\li709\f2\fs16 store(DLLFunction) "myfile.dll:KeyEvent"\par
+
+\pard\widctlpar\f1\fs20\par
+You can use this anywhere where you would place the \f2\fs16 use\f1\fs20  statement (except in the \f2\fs16 begin\f1\fs20  statement), with the \f2\fs16 call\f1\fs20  statement.  For example,\par
+\par
+
+\pard\widctlpar\fi-425\li709\f2\fs16 + 'a' > call(DLLFunction)\par
+
+\pard\widctlpar\f1\fs20\par
+A single .kmn file can reference multiple DLL group functions, in a single or multiple DLLs.\par
+
+\pard\keepn\widctlpar\s1\sb240\sa60\kerning28\b\f0\fs28 DLL exports\par
+
+\pard\widctlpar\kerning0\b0\f1\fs20 The DLL is called from Keyman with LoadLibrary.  All functions are then found with GetProcAddress.  You must ensure that the function exports do not have ordinals encoded in the names.  The best way to accomplish this in C/C++ is to use a .def file.\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 DLL group function exports\par
+
+\pard\widctlpar\b0\i0\f1\fs20 The function declaration for the DLL group function is:\par
+\par
+
+\pard\widctlpar\fi-425\li709\f2\fs16 BOOL WINAPI \i KeyEvent\i0 (HWND hwndFocus, WORD KeyStroke, WCHAR KeyChar, DWORD ShiftFlags);\par
+
+\pard\widctlpar\f1\fs20\par
+Note that \f2\fs16 KeyEvent\f1\fs20  is a placeholder for any name that you wish to use.  You can have multiple exports for Keyman use in a single DLL.\par
+
+\pard\keepn\widctlpar\s3\sb120\b\f0 Parameters\par
+
+\pard\widctlpar\b0\f1\par
+\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1418\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6238 
+\pard\intbl\widctlpar\b\f0\fs16 Parameter\cell Description\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1418\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6238 
+\pard\intbl\widctlpar\b0\f2 hwndFocus\cell\f0 The currently focused window.  You will probably never have a need to use this. \cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1418\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6238 
+\pard\intbl\widctlpar\f2 KeyStroke\cell\f0 The virtual key code for the current key.\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1418\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6238 
+\pard\intbl\widctlpar\f2 KeyChar\cell\f0 The character code for the current key (based on US English layout).  This will be 0 if KeyStroke does not generate a character (e.g. function keys).\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1418\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6238 
+\pard\intbl\widctlpar\f2 ShiftFlags\cell\f0 The shift state for the current key.  See the table in the Notes section for possible shift states. \cell\row 
+\pard\keepn\widctlpar\s3\sb120\b\fs20 Notes\par
+
+\pard\widctlpar\b0\f1\par
+The following shift states are possible:\par
+\par
+\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\b\f0\fs16 Flag\cell Value\cell Description\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\b0\f2 LCTRLFLAG\cell 0x0001\cell\f0 Left Control flag\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\f2 RCTRLFLAG\cell 0x0002\cell\f0 Right Control flag\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\f2 LALTFLAG\cell 0x0004\cell\f0 Left Alt flag\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\f2 RALTFLAG\cell 0x0008\cell\f0 Right Alt flag\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\f2 K_SHIFTFLAG\cell 0x0010\cell\f0 Shift flag\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\f2 K_CTRLFLAG\cell 0x0020\cell\f0 Ctrl flag (unused here; see l/r flags) \cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\f2 K_ALTFLAG\cell 0x0040\cell\f0 Alt flag (unused here; see l/r flags)\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\f2 CAPITALFLAG\cell 0x0100\cell\f0 Caps lock on\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\f2 NUMLOCKFLAG\cell 0x0400\cell\f0 Num lock on\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\f2 SCROLLFLAG\cell 0x1000\cell\f0 Scroll lock on\cell\row\trowd\trgaph108\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx1701\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2694\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx5670 
+\pard\intbl\widctlpar\f2 ISVIRTUALKEY\cell 0x4000\cell\f0 It is a Virtual Key Sequence\cell\row 
+\pard\keepn\widctlpar\s1\sb240\sa60\kerning28\b\fs28 Optional DLL exports\par
+
+\pard\widctlpar\kerning0\b0\f1\fs20 Keyman recognises a number of other exports, if they are defined in the DLL.  None of these are required.  These functions will be called when a keyboard that references the DLL is manipulated.  They will not be called for keyboards that do not reference the DLL.\par
+\par
+The following exports are available:\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KeymanIMInit\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KeymanIMInit(PSTR keyboardname);\par
+
+\pard\widctlpar\f1\fs20\par
+\f2\fs16 KeymanIMInit\f1\fs20  is called once when the keyboard identified by \f2\fs16 keyboardname\f1\fs20  is loaded for a given process.  It is called for each process in which the keyboard is loaded.\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KeymanIMDestroy\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KeymanIMDestroy(PSTR keyboardname);\par
+
+\pard\widctlpar\f1\fs20\par
+This is called once when the keyboard identified by \f2\fs16 keyboardname\f1\fs20  is unloaded in a given process.  It is called when the process exits normally, or when Keyman refreshes its keyboard list after keyboards are added or removed.  If the keyboard is subsequently reloaded, \f2\fs16 KeymanIMInit\f1\fs20  will be called again.\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KeymanIMActivate\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KeymanIMActivate(PSTR keyboardname);\par
+
+\pard\widctlpar\f1\fs20\par
+This function is called whenever the user or a program activates the keyboard.  It is never called before KeymanIMInit (unless KeymanIMInit is not exported).  This is an appropriate place to switch on permanently-visible IMC windows.  \f2\fs16 KeymanIMActivate\f1\fs20  can also be called when switching processes and the target process has a related keyboard already active.\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KeymanIMDeactivate\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KeymanIMDeactivate(PSTR keyboardname);\par
+
+\pard\widctlpar\f1\fs20\par
+This function is called when the user or a program switches off a related keyboard.  It is always called before \f2\fs16 KeymanIMActivate\f1\fs20  for the next keyboard.  It will also be called when the user activates another process, to give the DLL a chance to hide top-most IMC windows.\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KeymanIMConfigure\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KeymanIMConfigure(PSTR keyboardname, HWND hwndParent);\par
+
+\pard\widctlpar\f1\fs20\par
+KeymanIMConfigure is called when the user clicks the Configure button in KMShell to configure the DLL-specific functionality for the keyboard.  The appropriate behaviour is to display a dialog box, and save the settings in the registry.\par
+\par
+This function is separate from all the other functions.  It can be called when there are no keyboards loaded, or even if Keyman itself is not loaded.  You should not attempt to call Keyman32.dll from this function.\par
+
+\pard\keepn\widctlpar\s1\sb240\sa60\kerning28\b\f0\fs28 The imlib.cpp library module\par
+
+\pard\widctlpar\kerning0\b0\f1\fs20 imlib.cpp, included in the development kit, contains a set of useful functions for interfacing to Keyman.\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 PrepIM\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL PrepIM(void);\par
+
+\pard\widctlpar\f1\fs20\par
+\f2\fs16 PrepIM\f1\fs20  initialises the Keyman32 imports.  You should not call any of the Keyman imports without calling \f2\fs16 PrepIM\f1\fs20  first.  If \f2\fs16 PrepIM\f1\fs20  fails, you should exit without doing any processing.\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 IMDefWindowProc\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL IMDefWindowProc(HWND hwnd, UINT msg, WPARAM wParam, \line LPARAM lParam, LRESULT *lResult);\par
+
+\pard\widctlpar\f1\fs20\par
+\f2\fs16 IMDefWindowProc\f1\fs20  should be called from an IMC window procedure (see section titled \i Input Method Composition windows\i0 ).  If it returns TRUE you should return the value stored in \f2\fs16 lResult\f1\fs20  without any further processing.  \f2\fs16 IMDefWindowProc\f1\fs20  mostly manages window activation and movement.\par
+\par
+
+\pard\keepn\widctlpar\s1\sb240\sa60\kerning28\b\f0\fs28 Keyman Imports\par
+
+\pard\widctlpar\kerning0\b0\f1\fs20 The DLL can call Keyman functions to interact with Keyman and the target application.  It should not attempt to directly control the application as Keyman will be doing this.  You should never call any of the functions here from the \f2\fs16 KeymanIMConfigure\f1\fs20  callback.\par
+\par
+You can use \f2\fs16 PrepIM()\f1\fs20 , declared in \f0\fs18 imlib.cpp\f1\fs20  to get access to the the Keyman functions.  When using \f0\fs18 imlib.cpp\f1\fs20 , the functions are declared as pointers, so you need to dereference them to call them in C (e.g. for \f2\fs16 KMGetContext\f1\fs20 , call \f2\fs16 (*KMGetcontext)(buf,len);\f1\fs20\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KMGetContext\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KMGetContext(PWSTR buf, DWORD len);\par
+
+\pard\widctlpar\f1\fs20\par
+\f2\fs16 KMGetContext\f1\fs20  returns the last \f2\fs16 len-1\f1\fs20  characters of the context stack.  If there are not enough characters in the context stack, it will return as many as it can.  On success, the \f2\fs16 buf\f1\fs20  variable will be null terminated.\par
+\par
+The context stack can contain a special code for deadkeys.  See \f2\fs16 KMQueueAction\f1\fs20  for a way to output a deadkey.  The code sequence for a deadkey is (3 words):\par
+ \par
+
+\pard\widctlpar\fi436\li709\f2\fs16 UC_SENTINEL, CODE_DEADKEY, \i deadkeyID\i0\par
+
+\pard\widctlpar\f1\fs20\par
+\f2\fs16 UC_SENTINEL\f1\fs20  is \f2\fs16 0xFFFF\f1\fs20 ; \f2\fs16 CODE_DEADKEY\f1\fs20  is \f2\fs16 0x0008\f1\fs20 ; \i\f2\fs16 deadkeyID\i0\f1\fs20  can be any value from \f2\fs16 0x0001\f1\fs20  to \f2\fs16 0xFFFE\f1\fs20 .\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KMSetOutput\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KMSetOutput(PWSTR buf, DWORD backlen); \par
+
+\pard\widctlpar\f1\fs20\par
+\f2\fs16 KMSetOutput\f1\fs20  is a wrapper for \f2\fs16 KMQueueAction\f1\fs20 .  It simplifies the process of deleting contextual characters and outputting a new string.  The results will not be output to the screen until the current function returns.  If called within the context of an IMC window, the results will not be output to the screen until the window posts the \f2\fs16 wm_keymanim_close\f1\fs20  message.\par
+\par
+\f2\fs16 buf\f1\fs20  is a pointer to a null-terminated string of characters to output.\par
+\f2\fs16 backlen\f1\fs20  is the number of characters to backspace from the current context before displaying \f2\fs16 buf\f1\fs20 .\par
+\par
+This function modifies the context returned from \f2\fs16 KMGetContext\f1\fs20 , even if the output is not yet on the screen.\par
+\par
+Internally, this function does the following code:\par
+\par
+
+\pard\widctlpar\fi-425\li709\f2\fs16 while(backlen-- > 0) KMQueueAction(QIT_BACK, 0);\par
+while(*buf) KMQueueAction(QIT_CHAR, *buf++);\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KMQueueAction\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KMQueueAction(int itemType, DWORD dwData);\par
+
+\pard\widctlpar\f1\fs20\par
+KMQueueAction lets you send any Keyman action to a target application.  This can be virtual keys, characters, shift keys up and down, deadkeys, beeps, or backspaces (a special case of virtual keys).\par
+\par
+\trowd\trgaph108\trleft284\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2519\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6780 
+\pard\intbl\widctlpar\b\f0\fs16 itemType code\cell Description\cell\row\trowd\trgaph108\trleft284\trrh375\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2519\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6780 
+\pard\intbl\widctlpar\b0\f2 QIT_VKEYDOWN\cell\f0 Simulate any key press on the keyboard; \b dwData\b0  is the virtual key code\cell\row\trowd\trgaph108\trleft284\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2519\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6780 
+\pard\intbl\widctlpar\f2 QIT_VKEYUP\cell\f0 Simulate any key release on the keyboard; \b dwData\b0  is the virtual key code\cell\row\trowd\trgaph108\trleft284\trrh870\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2519\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6780 
+\pard\intbl\widctlpar\strike\f2 QIT_VSHIFTDOWN\strike0\cell\f0 Simulate pressing a set of shift keys.  \b dwData\b0  can be a combination of the following flags:\par
+LCTRLFLAG, RCTRLFLAG, LALTFLAG, RALTFLAG, K_SHIFTFLAG, K_CTRLFLAG, K_ALTFLAG\par
+\b From Version: 17.0 this is not supported\b0\cell\row\trowd\trgaph108\trleft284\trrh450\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2519\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6780 
+\pard\intbl\widctlpar\strike\f2 QIT_VSHIFTUP\strike0\cell\f0 Release the shift state, \b dwData\b0  is the same as the previous flags.\par
+\b From Version: 17.0 this is not supported\b0\cell\row\trowd\trgaph108\trleft284\trrh495\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2519\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6780 
+\pard\intbl\widctlpar\f2 QIT_CHAR\cell\b\f0 dwdata\b0  is any WCHAR.  For an ANSI window, zero-pad an 8-bit character.\cell\row\trowd\trgaph108\trleft284\trrh450\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2519\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6780 
+\pard\intbl\widctlpar\f2 QIT_DEADKEY\cell\b\f0 dwData \b0 is any value from 0x0001 to 0xFFFE.  This can be matched in the context with \b KMGetContext\b0 .\cell\row\trowd\trgaph108\trleft284\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2519\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6780 
+\pard\intbl\widctlpar\f2 QIT_BELL\cell\b\f0 dwData\b0  should be zero (0).\cell\row\trowd\trgaph108\trleft284\trbrdrl\brdrs\brdrw10 \trbrdrt\brdrs\brdrw10 \trbrdrr\brdrs\brdrw10 \trbrdrb\brdrs\brdrw10 \trpaddl108\trpaddr108\trpaddfl3\trpaddfr3
+\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx2519\clbrdrl\brdrw10\brdrs\clbrdrt\brdrw10\brdrs\clbrdrr\brdrw10\brdrs\clbrdrb\brdrw10\brdrs \cellx6780 
+\pard\intbl\widctlpar\f2 QIT_BACK\cell\b\f0 dwData\b0  should be zero (0).\cell\row 
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\fs24 KMHideIM\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KMHideIM(HWND hwndIM);\par
+
+\pard\widctlpar\f1\fs20\par
+\f2\fs16 KMHideIM\f1\fs20  hides the IMC window referred to by \f2\fs16 hwndIM\f1\fs20  and ensures that Keyman processes input from the keyboard through the correct method.  You should call this rather than hiding the window manually with \f2\fs16 ShowWindow(hwnd, SW_HIDE);\f1\fs20  or post the message \f2\fs16 wm_keymanim_close\f1\fs20  to hide the window.\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KMDisplayIM\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KMDisplayIM(HWND hwndIM, BOOL FCaptureAll);\par
+
+\pard\widctlpar\f1\fs20\par
+\f2\fs16 KMDisplayIM\f1\fs20  displays the IMC window referred to by \f2\fs16 hwndIM\f1\fs20 .  It does not do any movement of the window.  If the \f2\fs16 FCaptureAll\f1\fs20  flag is set, all keyboard input (character-generating keys only) will be redirected to the IMC window until the message \f2\fs16 wm_keymanim_close\f1\fs20  is posted, \f2\fs16 KMHideIM\f1\fs20  is called, or \f2\fs16 KMDisplayIM\f1\fs20  with \f2\fs16 FCaptureAll\f1\fs20  is set to false.\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KMGetKeyboardPath\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KMGetKeyboardPath(PSTR keyboardname, PWSTR dir, DWORD length);\par
+
+\pard\widctlpar\f1\fs20\par
+This function returns the full path to the keyboard referred to by \f2\fs16 keyboardname\f1\fs20 .  The buffer \f2\fs16 dir\f1\fs20  should be 260 characters long.\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KMGetActiveKeyboard\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KMGetActiveKeyboard(PSTR keyboardname, DWORD length);\par
+
+\pard\widctlpar\f1\fs20\par
+This function can be called while processing to determine which is the active keyboard.  Alternatively, use the callbacks \f2\fs16 KeymanIMActivate\f1\fs20  and \f2\fs16 KeymanIMDeactivate\f1\fs20 .\par
+
+\pard\keepn\widctlpar\s2\sb240\sa60\b\i\f0\fs24 KMSendDebugString\par
+
+\pard\widctlpar\fi-425\li709\b0\i0\f2\fs16 BOOL WINAPI KMSendDebugString(PSTR str);\par
+
+\pard\widctlpar\f1\fs20\par
+This function outputs the string \f2\fs16 str\f1\fs20  to the Keyman debug window or debug log file (usually \f0\fs18 c:\\keyman.log\f1\fs20 ).\par
+
+\pard\keepn\widctlpar\s1\sb240\sa60\kerning28\b\f0\fs28 The Input Method Composition window\par
+
+\pard\widctlpar\kerning0\b0\f1\fs20 The IMC window can be shown or hidden at any time that the associated keyboard is active.  This means that you can have an IMC window permanently open or open at appropriate times.\par
+\par
+The keyboard IMSample included with Keyman is a good example of manipulating the IMC display.\par
+\par
+The window should be created invisible, most probaly as a popup window.  The window can use \f2\fs16 KMGetContext\f1\fs20 , \f2\fs16 KMSetOutput\f1\fs20  at any time, but output will not be put to the screen until it has posted (\b not \b0 sent) \f2\fs16 wm_keymanim_close\f1\fs20  to itself.\par
+
+\pard\widctlpar\fi-425\li709\f2\fs16\par
+PostMessage(hwnd, wm_keymanim_close, (WPARAM) FSuccess, (LPARAM) FActuallyClose);\par
+
+\pard\widctlpar\f1\fs20\par
+Keyman will manage the window display, focus, and message loop.  The window procedure should set the position and size appropriately.\par
+\par
+Keyman will recognise this window and any child windows to be part of the IM and will not attempt to process any input that goes through the window.\par
+\par
+The IMC window must not take focus at any time.\par
+
+\pard\keepn\widctlpar\s3\sb120\b\f0 Limitations\par
+
+\pard 
+{\pntext\f1 1.\tab}{\*\pn\pnlvlbody\pnf1\pnindent360\pnstart1\pndec{\pntxta.}}
+\widctlpar\fi-360\li360\b0\f1 Clicks outside the window will cancel the IM and lose context.\par
+{\pntext\f1 2.\tab}Switching applications will cancel the IM and lose context.\par
+
+\pard\widctlpar\par
+}
+ 

--- a/developer/src/samples/imsample/imlib.h
+++ b/developer/src/samples/imsample/imlib.h
@@ -4,8 +4,8 @@
 
 #define QIT_VKEYDOWN	0
 #define QIT_VKEYUP		1
-#define QIT_VSHIFTDOWN	2
-#define QIT_VSHIFTUP	3
+//#define QIT_VSHIFTDOWN	2 // deprecated see #11925
+//#define QIT_VSHIFTUP	3
 #define QIT_CHAR		4
 #define QIT_DEADKEY		5
 #define QIT_BELL		6

--- a/developer/src/tike/debug/UfrmDebugStatus_Events.pas
+++ b/developer/src/tike/debug/UfrmDebugStatus_Events.pas
@@ -116,8 +116,6 @@ procedure TfrmDebugStatus_Events.AddActionEvent(action: TDebugEventActionData);
 begin
   case action.ActionType of
     KM_CORE_IT_EMIT_KEYSTROKE: AddItem('emit_keystroke', action);
-//    QIT_VSHIFTDOWN:  AddItem('vshiftdown', action);
-//    QIT_VSHIFTUP:    AddItem('vshiftup', action);
     KM_CORE_IT_CHAR:        AddItem('char', action);
     KM_CORE_IT_MARKER:     AddItem('marker', action);
     KM_CORE_IT_ALERT:        AddItem('alert', action);

--- a/windows/src/engine/keyman32/appint/aiWin2000Unicode.cpp
+++ b/windows/src/engine/keyman32/appint/aiWin2000Unicode.cpp
@@ -82,8 +82,8 @@ BOOL AIWin2000Unicode::IsUnicode()
 
 BOOL AIWin2000Unicode::ReadContext(PWSTR buf) {
   UNREFERENCED_PARAMETER(buf);
-  // We cannot read any context from legacy apps, so we return a 
-  // failure here -- telling Core to maintain its own cached 
+  // We cannot read any context from legacy apps, so we return a
+  // failure here -- telling Core to maintain its own cached
   // context.
   return FALSE;
 }
@@ -178,10 +178,6 @@ BOOL AIWin2000Unicode::PostKeys()
         pInputs[i++].ki.dwExtraInfo = 0; //KEYEVENT_EXTRAINFO_KEYMAN;   // I4370   // I4378
       }
 
-		  break;
-	  case QIT_VSHIFTDOWN:
-		  break;
-	  case QIT_VSHIFTUP:
 		  break;
 	  case QIT_CHAR:
       pInputs[i].type = INPUT_KEYBOARD;

--- a/windows/src/engine/keyman32/appint/appint.cpp
+++ b/windows/src/engine/keyman32/appint/appint.cpp
@@ -28,8 +28,10 @@
 
 PWSTR decxstr(PWSTR p, PWSTR pStart);
 
+// QIT_VSHIFTDOWN and QIT_VSHIFTUP deprecated see #11925
+// Change to Deprecated to avoid array and index reshuffle
 const LPSTR ItemTypes[8] = {
-	"QIT_VKEYDOWN", "QIT_VKEYUP", "QIT_VSHIFTDOWN", "QIT_VSHIFTUP",
+	"QIT_VKEYDOWN", "QIT_VKEYUP", "QIT_DEPRECATED", "QIT_DEPRECATED",
     "QIT_CHAR", "QIT_DEADKEY", "QIT_BELL", "QIT_BACK" };
 
 /* AppActionQueue */

--- a/windows/src/engine/keyman32/appint/appint.h
+++ b/windows/src/engine/keyman32/appint/appint.h
@@ -34,8 +34,8 @@ typedef struct
 // QueueAction ItemTypes
 #define QIT_VKEYDOWN	0
 #define QIT_VKEYUP		1
-#define QIT_VSHIFTDOWN	2
-#define QIT_VSHIFTUP	3
+//#define QIT_VSHIFTDOWN	2  // deprecated see #11925
+//#define QIT_VSHIFTUP	3    // deprecated see #11925
 #define QIT_CHAR		4
 #define QIT_DEADKEY		5
 #define QIT_BELL		6

--- a/windows/src/engine/keyman32/kmprocess.cpp
+++ b/windows/src/engine/keyman32/kmprocess.cpp
@@ -177,10 +177,8 @@ BOOL ProcessHook()
     SendDebugMessageFormat(0, sdmGlobal, 0, "ProcessHook: %d events in queue and default output requested. [IsLegacy:%d, IsUpdateable:%d]", _td->app->GetQueueSize(), _td->app->IsLegacy(), _td->TIPFUpdateable);
 
     if (_td->app->IsLegacy()) {
-      _td->app->QueueAction(QIT_VSHIFTDOWN, Globals::get_ShiftState());
       _td->app->QueueAction(QIT_VKEYDOWN, _td->state.vkey);
       _td->app->QueueAction(QIT_VKEYUP, _td->state.vkey);
-      _td->app->QueueAction(QIT_VSHIFTUP, Globals::get_ShiftState());
       fOutputKeystroke = FALSE;
     }
 		else if (!_td->TIPFUpdateable) {

--- a/windows/src/engine/testhost/testhost.cpp
+++ b/windows/src/engine/testhost/testhost.cpp
@@ -223,8 +223,8 @@ typedef struct
 // QueueAction ItemTypes
 #define QIT_VKEYDOWN	0
 #define QIT_VKEYUP		1
-#define QIT_VSHIFTDOWN	2
-#define QIT_VSHIFTUP	3
+//#define QIT_VSHIFTDOWN	2 // deprecated see #11925
+//#define QIT_VSHIFTUP	3   // deprecated see #11925
 #define QIT_CHAR		4
 #define QIT_DEADKEY		5
 #define QIT_BELL		6
@@ -267,10 +267,6 @@ BOOL WINAPI PostKeyCallback(APPACTIONQUEUEITEM* Queue, int QueueSize) {
         //pInputs[i].ki.wScan = SCAN_FLAG_KEYMAN_KEY_EVENT;
         //pInputs[i].ki.dwFlags = KEYEVENTF_KEYUP | ((Queue[n].dwData & QVK_EXTENDED) ? KEYEVENTF_EXTENDEDKEY : 0);  // I3438
       }
-      break;
-    case QIT_VSHIFTDOWN:
-      break;
-    case QIT_VSHIFTUP:
       break;
     case QIT_CHAR:
       // TODO: surrogate pairs


### PR DESCRIPTION
Fixes: #11925
QIT_VSHIFTDOWN and QIT_VSHIFTUP is no longer sent out in the windows engine. This commit cleans up any remnant references to these.

@keymanapp-test-bot skip

