### PR TITLE
change(common/models): change model tokenization to also tokenize whitespace 📚 

### DIFF
--- a/common/models/templates/src/index.ts
+++ b/common/models/templates/src/index.ts
@@ -3,5 +3,5 @@ export {
   transformToSuggestion, defaultApplyCasing
 } from "./common.js";
 export { default as QuoteBehavior } from "./quote-behavior.js";
-export { Tokenization, tokenize, getLastPreCaretToken, wordbreak } from "./tokenization.js";
+export { getLastPreCaretToken, Token, Tokenization, tokenize, wordbreak } from "./tokenization.js";
 export { default as TrieModel, TrieModelOptions } from "./trie-model.js";

--- a/common/models/templates/src/tokenization.ts
+++ b/common/models/templates/src/tokenization.ts
@@ -113,7 +113,7 @@ export function tokenize(
       // But we don't have character class access here; it's all wordbreaker-function internal.
       // Upon inspection of the wordbreaker data definitions... the single-quote-class is ONLY "'".
       // So... we'll just be lazy for now and append the `'`.
-      if(rejoins.indexOf(leftTail!.text) != -1) {
+      if(rejoins.indexOf(leftTail.text) != -1) {
         tokenization.left.pop(); // leftTail
         tokenization.left.pop(); // leftTailBase
         tokenization.left.push({

--- a/common/models/templates/src/tokenization.ts
+++ b/common/models/templates/src/tokenization.ts
@@ -143,13 +143,15 @@ export function tokenize(
       });
       currentIndex = nextSpan.start;
     } else {
-      // If the first non-whitespace token to the right is non-whitespace,
-      // and the last token to the left is non-whitespace, the caret may
-      // be splitting a token.
       const leftTail = tokenization.left[leftTokenCount-1];
-      if(firstRightToken && !leftTail.isWhitespace) {
-        if(wordBreaker(leftTail!.text + nextSpan.text).length == 1) {
-          tokenization.caretSplitsToken = true;
+      if(leftTail) {
+        // If the first non-whitespace token to the right is non-whitespace,
+        // and the last token to the left is non-whitespace, the caret may
+        // be splitting a token.
+        if(firstRightToken && !leftTail.isWhitespace) {
+          if(wordBreaker(leftTail!.text + nextSpan.text).length == 1) {
+            tokenization.caretSplitsToken = true;
+          }
         }
       }
 

--- a/common/models/templates/src/tokenization.ts
+++ b/common/models/templates/src/tokenization.ts
@@ -1,24 +1,23 @@
 // While we _could_ define this within @keymanapp/models-wordbreakers instead, it's probably
 // better to leave that package as _just_ the wordbreakers.
 
+export interface Token {
+  text: string,
+  isWhitespace?: boolean
+}
+
 export interface Tokenization {
   /**
    * An array of tokens to the left of the caret.  If the caret is in the middle of a token,
    * only the part to the left of the caret is included.
    */
-  left: {
-    text: USVString,
-    isWhitespace?: boolean
-  }[],
+  left: Token[],
 
   /**
    * An array of tokens to the right of the caret.  If the caret is in the middle of a token,
    * only the part to the right of the caret is included.
    */
-  right: {
-    text: USVString,
-    isWhitespace?: boolean
-  }[],
+  right: Token[],
 
   /**
    * A flag indicating whether or not the caret's position in the context caused a token
@@ -113,7 +112,7 @@ export function tokenize(
       // But we don't have character class access here; it's all wordbreaker-function internal.
       // Upon inspection of the wordbreaker data definitions... the single-quote-class is ONLY "'".
       // So... we'll just be lazy for now and append the `'`.
-      if(rejoins.indexOf(leftTail.text) != -1) {
+      if(rejoins.indexOf(leftTail!.text) != -1) {
         tokenization.left.pop(); // leftTail
         tokenization.left.pop(); // leftTailBase
         tokenization.left.push({

--- a/common/models/templates/test/test-tokenization.js
+++ b/common/models/templates/test/test-tokenization.js
@@ -169,7 +169,7 @@ describe('Tokenization functions', function() {
       assert.deepEqual(tokenization, expectedResult);
     });
 
-    it('empty context case', function() {
+    it('properly handles empty-context cases', function() {
       // Wordbreaking on a empty space => no word.
       let context = {
         left: '', startOfBuffer: true,
@@ -187,7 +187,7 @@ describe('Tokenization functions', function() {
       assert.deepEqual(tokenization, expectedResult);
     });
 
-    it('nil context case', function() {
+    it('properly handles null context cases', function() {
       // Wordbreaking on a empty space => no word.
       let tokenization = models.tokenize(wordBreakers.default, null);
 
@@ -200,7 +200,7 @@ describe('Tokenization functions', function() {
       assert.deepEqual(tokenization, expectedResult);
     });
 
-    it('near-empty context:  one space before caret', function() {
+    it('properly handles a near-empty context:  one space before caret', function() {
       // Wordbreaking on a empty space => no word.
       let context = {
         left: ' ', startOfBuffer: true,
@@ -437,7 +437,7 @@ describe('Tokenization functions', function() {
       return wordBreakers.default(text, customization);
     }
 
-    it('treats caret as `eot` for pre-caret text', function() {
+    it('treats caret as `eot` for pre-caret text tokenization', function() {
       let context = {
         left: "don-",  // We use a hyphen here b/c single-quote is hardcoded.
         right: " worry",
@@ -493,7 +493,7 @@ describe('Tokenization functions', function() {
   });
 
   describe('getLastPreCaretToken', function() {
-    it('with pre-whitespace caret', function() {
+    it('operates properly with pre-whitespace caret', function() {
       let context = {
         left: "The quick brown fox",
         right: " jumped over the lazy dog",
@@ -506,7 +506,7 @@ describe('Tokenization functions', function() {
       assert.equal(tokenization, 'fox');
     });
 
-    it('with post-whitespace caret', function() {
+    it('operates properly with post-whitespace caret', function() {
       let context = {
         left: "The quick brown fox ",
         right: "jumped over the lazy dog",
@@ -520,7 +520,7 @@ describe('Tokenization functions', function() {
     });
 
 
-    it('with post-whitespace caret, ascii breaker', function() {
+    it('operates properly with post-whitespace caret, ascii breaker', function() {
       let context = {
         left: "The quick brown fox ",
         right: "jumped over the lazy dog",
@@ -533,7 +533,7 @@ describe('Tokenization functions', function() {
       assert.equal(tokenization, '');
     });
 
-    it('within a token', function() {
+    it('operates properly within a token', function() {
       let context = {
         left: "The quick brown fox jum",
         right: "ped over the lazy dog",
@@ -546,14 +546,14 @@ describe('Tokenization functions', function() {
       assert.equal(tokenization, 'jum');
     });
 
-    it('with no context', function() {
+    it('operates properly with no context', function() {
       let tokenization = models.getLastPreCaretToken(wordBreakers.default, null);
       assert.equal(tokenization, '');
     });
   });
 
   describe('wordbreak', function() {
-    it('with pre-whitespace caret', function() {
+    it('operates properly with pre-whitespace caret', function() {
       let context = {
         left: "The quick brown fox",
         right: " jumped over the lazy dog",
@@ -566,7 +566,7 @@ describe('Tokenization functions', function() {
       assert.equal(tokenization, 'fox');
     });
 
-    it('with post-whitespace caret', function() {
+    it('operates properly with post-whitespace caret', function() {
       let context = {
         left: "The quick brown fox ",
         right: "jumped over the lazy dog",
@@ -581,7 +581,7 @@ describe('Tokenization functions', function() {
 
     // This version is subject to change.  In the future, we may wish the wordbreak
     // operation to include "the rest of the word" - the post-caret part.
-    it('within a token', function() {
+    it('operates properly within a token', function() {
       let context = {
         left: "The quick brown fox jum",
         right: "ped over the lazy dog",

--- a/common/web/lm-worker/src/main/correction/context-tracker.ts
+++ b/common/web/lm-worker/src/main/correction/context-tracker.ts
@@ -536,8 +536,8 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
       throw "This lexical model does not provide adequate data for correction algorithms and context reuse";
     }
 
-    let tokenize = determineModelTokenizer(model);
-    let tokenizedContext = tokenize(context);
+    const tokenize = determineModelTokenizer(model);
+    const tokenizedContext = tokenize(context);
 
     if(tokenizedContext.left.length > 0) {
       for(let i = this.count - 1; i >= 0; i--) {

--- a/common/web/lm-worker/src/main/correction/context-tracker.ts
+++ b/common/web/lm-worker/src/main/correction/context-tracker.ts
@@ -1,9 +1,9 @@
-import { applyTransform, tokenize } from '@keymanapp/models-templates';
-import { defaultWordbreaker } from '@keymanapp/models-wordbreakers';
+import { applyTransform } from '@keymanapp/models-templates';
 
 import { ClassicalDistanceCalculation } from './classical-calculation.js';
 import { SearchSpace } from './distance-modeler.js';
 import TransformUtils from '../transformUtils.js';
+import { determineModelTokenizer } from '../model-helpers.js';
 
 function textToCharTransforms(text: string, transformId?: number) {
   let perCharTransforms: Transform[] = [];
@@ -536,7 +536,8 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
       throw "This lexical model does not provide adequate data for correction algorithms and context reuse";
     }
 
-    let tokenizedContext = tokenize(model.wordbreaker || defaultWordbreaker, context);
+    let tokenize = determineModelTokenizer(model);
+    let tokenizedContext = tokenize(context);
 
     if(tokenizedContext.left.length > 0) {
       for(let i = this.count - 1; i >= 0; i--) {

--- a/common/web/lm-worker/src/main/model-compositor.ts
+++ b/common/web/lm-worker/src/main/model-compositor.ts
@@ -323,7 +323,7 @@ export class ModelCompositor {
     return breaker(context);
   }
 
-  private tokenize(context: Context): models.Tokenization {
+  private tokenize(context: Context) {
     const tokenizer = determineModelTokenizer(this.lexicalModel);
     return tokenizer(context);
   }

--- a/common/web/lm-worker/src/main/model-helpers.ts
+++ b/common/web/lm-worker/src/main/model-helpers.ts
@@ -62,7 +62,13 @@ export function determineModelWordbreaker(model: LexicalModel): (context: Contex
 export function determineModelTokenizer(model: LexicalModel) {
   return (context: Context) => {
     if(model.wordbreaker) {
-      return models.tokenize(model.wordbreaker, context);
+      const fullTokenization = models.tokenize(model.wordbreaker, context);
+
+      return {
+        left:  fullTokenization.left .filter((entry) => !entry.isWhitespace).map((entry) => entry.text),
+        right: fullTokenization.right.filter((entry) => !entry.isWhitespace).map((entry) => entry.text),
+        caretSplitsToken: fullTokenization.caretSplitsToken
+      }
     } else {
       return null;
     }


### PR DESCRIPTION
In pursuit of a fix for #11963 - particularly, for better punctuation handling in our predictive-text engine - this PR changes the tokenization function to emit tokens for whitespace in addition to non-whitespace.  This is only done at the `common/models/template` level thus far in order to keep the changeset constrained.

I've adapted the original tokenization unit tests to work with the new return format.  For now, within the lm-worker at large, the new tokenization output format is simply mapped to the original output format.

The next three PRs in sequence will integrate the enhanced tokenization pattern into the predictive-text process:
- #11998
- #11979 
- #11997

----

For the reasoning behind this change, see https://github.com/keymanapp/keyman/issues/11963#issuecomment-2246953233.

With the new `tokenize` function, whitespaces _and_ word-breaking punctuation now produce a new "token" from the new keystroke.  
- Either way, we should still preserve all text before the "new token".  
- Predictions should only affect the newest token.
- Note: At present... we don't have anything that lets us know punctuation marks should result in an automatic new token afterward.
    - Even so, replacing _just_ the `.` is better than replacing both it and the prior token.
    - Suggestion casing + reversion display-as make far more sense either way - basing predictions on `.` or upon a new empty token following the `.`, as that would be all that is affected.


@keymanapp-test-bot skip