### PR TITLE
feat(developer): automatically upgrade version when gestures are found in the touch layout

### DIFF
--- a/developer/src/kmc-kmn/src/kmw-compiler/compiler-globals.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/compiler-globals.ts
@@ -106,6 +106,21 @@ export function verifyMinimumRequiredKeymanVersion15(): boolean {
   return verifyMinimumRequiredKeymanVersion(KMX.KMX_Version.VERSION_150);
 }
 
+/**
+ * Verify that minimum supported Keyman version in the keyboard is version 17.0,
+ * and upgrade to that version if possible and necessary.
+ *
+ * Will upgrade the minimum version to 17.0 if `KF_AUTOMATICVERSION` flag is set
+ * for the keyboard, which correlates to having no `store(&version)` line in the
+ * .kmn source file.
+ *
+ * @returns `true` if the version is now 17.0 or higher, `false` if a lower
+ * version has been specified in the source file `store(&version)` line.
+ */
+export function verifyMinimumRequiredKeymanVersion17(): boolean {
+  return verifyMinimumRequiredKeymanVersion(KMX.KMX_Version.VERSION_170);
+}
+
 export function isKeyboardVersion10OrLater(): boolean {
   return fk.fileVersion >= KMX.KMXFile.VERSION_100;
 }

--- a/developer/src/kmc-kmn/src/kmw-compiler/validate-layout-file.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/validate-layout-file.ts
@@ -1,7 +1,8 @@
 import { KMX, TouchLayout, TouchLayoutFileReader, TouchLayoutFileWriter } from "@keymanapp/common-types";
 import { callbacks, minimumKeymanVersion, verifyMinimumRequiredKeymanVersion15,
          isKeyboardVersion14OrLater, isKeyboardVersion17OrLater,
-         verifyMinimumRequiredKeymanVersion14 } from "./compiler-globals.js";
+         verifyMinimumRequiredKeymanVersion14,
+         verifyMinimumRequiredKeymanVersion17} from "./compiler-globals.js";
 import { JavaScript_Key } from "./javascript-strings.js";
 import { TRequiredKey, CRequiredKeys, CSpecialText, CSpecialText14Map, CSpecialText17Map,
          CSpecialTextMinVer, CSpecialTextMaxVer } from "./constants.js";
@@ -242,8 +243,7 @@ export function ValidateLayoutFile(fk: KMX.KEYBOARD, FDebug: boolean, sLayoutFil
 
   let hasWarnedOfGestureUseDownlevel = false;
   const warnGesturesIfNeeded = function(keyId: string) {
-    // TODO: automatic version upgrade
-    if(!hasWarnedOfGestureUseDownlevel && !isKeyboardVersion17OrLater()) {
+    if(!hasWarnedOfGestureUseDownlevel && !verifyMinimumRequiredKeymanVersion17()) {
       hasWarnedOfGestureUseDownlevel = true;
       callbacks.reportMessage(KmwCompilerMessages.Hint_TouchLayoutUsesUnsupportedGesturesDownlevel({keyId}));
     }

--- a/developer/src/kmc-kmn/test/fixtures/kmw/version_gestures.keyman-touch-layout
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/version_gestures.keyman-touch-layout
@@ -1,0 +1,51 @@
+{
+  "tablet": {
+    "font": "Tahoma",
+    "layer": [
+      {
+        "id": "default",
+        "row": [
+          {
+            "id": 1,
+            "key": [
+              {
+                "id": "K_Q",
+                "text": "q",
+                "flick": {
+                  "n": {
+                    "id": "K_Q",
+                    "text": "Q"
+                  }
+                }
+              },
+              {
+                "id": "K_BKSP",
+                "text": "*BkSp*",
+                "width": 90,
+                "sp": 1
+              },
+              {
+                "id": "K_LOPT",
+                "text": "*Menu*",
+                "width": 120,
+                "sp": 1
+              },
+              {
+                "id": "K_SPACE",
+                "text": "",
+                "width": 630,
+                "sp": 0
+              },
+              {
+                "id": "K_ENTER",
+                "text": "*Enter*",
+                "width": 140,
+                "sp": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/developer/src/kmc-kmn/test/fixtures/kmw/version_gestures.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/version_gestures.kmn
@@ -1,0 +1,9 @@
+﻿store(&NAME) 'version_gestures'
+store(&TARGETS) 'mobile'
+store(&LAYOUTFILE) 'version_gestures.keyman-touch-layout'
+
+c Use of gestures should make compiler select version 17
+
+begin Unicode > use(main)
+
+group(main) using keys

--- a/developer/src/kmc-kmn/test/fixtures/kmw/version_gestures_16.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/version_gestures_16.kmn
@@ -1,0 +1,11 @@
+﻿store(&NAME) 'version_gestures_16'
+store(&TARGETS) 'mobile'
+store(&LAYOUTFILE) 'version_gestures.keyman-touch-layout'
+store(&VERSION) '16.0'
+
+c Use of gestures should make compiler generate warning
+c HINT_TouchLayoutUsesUnsupportedGesturesDownlevel due to version < 17.0
+
+begin Unicode > use(main)
+
+group(main) using keys

--- a/developer/src/kmc-kmn/test/kmw/test-kmw-compiler.ts
+++ b/developer/src/kmc-kmn/test/kmw/test-kmw-compiler.ts
@@ -178,7 +178,6 @@ describe('KeymanWeb Compiler', function() {
   });
 
   it('should give warning WARN_TouchLayoutSpecialLabelOnNormalKey if the minimum version specified in the keyboard does not support special key caps on normal keys', async function() {
-    // Note that the logic being tested here is in kmx compiler.cpp, not kmw compiler
     const filenames = generateTestFilenames('version_special_key_caps_14');
 
     let result = await kmnCompiler.run(filenames.source, null);
@@ -187,6 +186,31 @@ describe('KeymanWeb Compiler', function() {
     assert.isFalse(callbacks.hasMessage(KmnCompilerMessages.INFO_Info));
     assert.isFalse(callbacks.hasMessage(KmwCompilerMessages.INFO_MinimumEngineVersion));
     assert.isTrue(callbacks.hasMessage(KmwCompilerMessages.WARN_TouchLayoutSpecialLabelOnNormalKey));
+  });
+
+  it('should determine the minimum version correctly with v17 gestures', async function() {
+    const filenames = generateTestFilenames('version_gestures');
+
+    let result = await kmnCompiler.run(filenames.source, null);
+    assert.isNotNull(result);
+    assert.isTrue(callbacks.hasMessage(KmwCompilerMessages.INFO_MinimumEngineVersion));
+    // The min version message from the .kmn compiler is generic 208A INFO_Info;
+    // we expect only 1 of the info messages -- for the .kmx target (not 2)
+    assert.equal(callbacks.messages.filter(item => item.code == KmnCompilerMessages.INFO_Info).length, 1);
+
+    const data = new TextDecoder('utf-8').decode(result.artifacts.js.data);
+    assert.match(data, /KMINVER="17.0"/, `Could not find expected 'KMINVER="17.0"'`);
+  });
+
+  it('should give warning HINT_TouchLayoutUsesUnsupportedGesturesDownlevel if the minimum version specified in the keyboard does not support special key caps on normal keys', async function() {
+    const filenames = generateTestFilenames('version_gestures_16');
+
+    let result = await kmnCompiler.run(filenames.source, null);
+    assert.isNotNull(result);
+    // The min version message from the .kmn compiler is generic 208A INFO_Info
+    assert.isFalse(callbacks.hasMessage(KmnCompilerMessages.INFO_Info));
+    assert.isFalse(callbacks.hasMessage(KmwCompilerMessages.INFO_MinimumEngineVersion));
+    assert.isTrue(callbacks.hasMessage(KmwCompilerMessages.HINT_TouchLayoutUsesUnsupportedGesturesDownlevel));
   });
 
 });

--- a/developer/src/kmc-kmn/test/kmw/test-kmw-messages.ts
+++ b/developer/src/kmc-kmn/test/kmw/test-kmw-messages.ts
@@ -57,6 +57,11 @@ describe('KmwCompilerMessages', function () {
   //   WARN_TouchLayoutSpecialLabelOnNormalKey if the minimum version specified
   //   in the keyboard does not support special key caps on normal keys'
 
+  // HINT_TouchLayoutUsesUnsupportedGesturesDownlevel
+  // * Implemented in test-kmw-compiler.ts: 'should give warning
+  //   HINT_TouchLayoutUsesUnsupportedGesturesDownlevel if the minimum version
+  //   specified in the keyboard does not support gestures'
+
   // ERROR_NotAnyRequiresVersion14
 
   // it('should generate ERROR_NotAnyRequiresVersion14 if ...', async function() {


### PR DESCRIPTION
When gestures are found in the touch layout file, the compiler will now automatically upgrade the version to 17.0, if no `store(&VERSION)` rule is found. Also adds corresponding unit tests.

Fixes: #11961

@keymanapp-test-bot skip