### PR TITLE
feat(developer): add searching for message identifiers to `kmc message`

### DIFF
--- a/developer/src/kmc/src/commands/messageCommand.ts
+++ b/developer/src/kmc/src/commands/messageCommand.ts
@@ -7,7 +7,7 @@ import { CompilerMessageSource, messageNamespaceKeys, messageSources } from '../
 import { NodeCompilerCallbacks } from '../util/NodeCompilerCallbacks.js';
 import { exitProcess } from '../util/sysexits.js';
 import { InfrastructureMessages } from '../messages/infrastructureMessages.js';
-import { CompilerMessageDetail, findMessageDetails } from '../util/extendedCompilerOptions.js';
+import { CompilerMessageDetail, findMessageDetails, findMessagesById, getMessageIdentifiersSorted } from '../util/extendedCompilerOptions.js';
 import { escapeMarkdownChar, KeymanUrls } from '@keymanapp/developer-utils';
 
 type MessageFormat = 'text'|'markdown'|'json';
@@ -31,6 +31,10 @@ export function declareMessage(program: Command) {
   program
     .command('message [messages...]')
     .description(`Describe one or more compiler messages. Note: Markdown format is always written to files on disk.`)
+    .addHelpText('after', `
+Message identifiers can be:
+ * numeric, e.g. "KM07006" or "7006", or
+ * [namespace.]id, substring id supported; e.g. "kmc-kmn.INFO_MinimumEngineVersion" or "kmc-kmn." or "INFO_Min"`)
     .addOption(new Option('-f, --format <format>', 'Output format').choices(['text', 'markdown', 'json']).default('text'))
     .option('-o, --out-path <out-path>', 'Output path for Markdown files; output filename for text and json formats')
     .option('-a, --all-messages', 'Emit descriptions for all messages (text, json)')
@@ -57,7 +61,7 @@ async function messageCommand(messages: string[], _options: any, commander: any)
     }
 
     const messageDetails = messages.length
-      ? messages.map(message => translateMessageInputToCode(message, callbacks))
+      ? messages.flatMap(message => translateMessageInputToCode(message, callbacks))
       : allMessageDetails();
 
     if(callbacks.messageCount > 0) {
@@ -96,16 +100,43 @@ async function messageCommand(messages: string[], _options: any, commander: any)
 const helpUrl = (code:any) => KeymanUrls.COMPILER_ERROR_CODE(CompilerError.formatCode(code).toLowerCase());
 const getModuleName = (ms: CompilerMessageSource) => `${ms.module}.${ms.class.name}`;
 
-function translateMessageInputToCode(message: string, callbacks: CompilerCallbacks): CompilerMessageDetail {
+function parseMessageIdentifier(message: string, callbacks: CompilerCallbacks): { namespace?: CompilerErrorNamespace, id?: string } {
+  const parts = message.split('.', 2);
+  if(parts.length == 1) {
+    // searching all namespaces
+    return { id: parts[0] };
+  }
+
+  // searching one namespace
+  const namespace = messageNamespaceKeys.find(ns => messageSources[ns].module == parts[0].toLowerCase());
+  if(!namespace) {
+    return { };
+  }
+  return { namespace, id: parts[1] };
+}
+
+function translateMessageInputToCode(message: string, callbacks: CompilerCallbacks): CompilerMessageDetail[] {
   const pattern = /^(KM)?([0-9a-f]+)$/i;
   const result = message.match(pattern);
   if(!result) {
-    callbacks.reportMessage(InfrastructureMessages.Error_UnrecognizedMessageCode({message}));
-    return null;
+    const { namespace, id } = parseMessageIdentifier(message.toLowerCase(), callbacks);
+    if(!namespace && !id) {
+      callbacks.reportMessage(InfrastructureMessages.Error_MessageNamespaceNameNotFound({message}));
+      return null;
+    }
+
+    // We assume that this is a INFO, HINT, ERROR, etc message, and do a substring search
+    const items = findMessagesById(namespace, id);
+    if(!items.length) {
+      callbacks.reportMessage(InfrastructureMessages.Error_UnrecognizedMessageCode({message}));
+      return null;
+    }
+
+    return items;
   }
 
   const code = Number.parseInt(result[2], 16);
-  return findMessageDetails(code, callbacks);
+  return [findMessageDetails(code, callbacks)];
 }
 
 function initialize(options: any): MessageOptions {
@@ -122,11 +153,6 @@ function initialize(options: any): MessageOptions {
     outPath: options.outPath
   }
 }
-
-const getMessageIdentifiersSorted = (cls: any) =>
-  Object.keys(cls)
-  .filter(id => typeof cls[id] == 'number')
-  .sort((a,b) => CompilerError.error(cls[a])-CompilerError.error(cls[b]));
 
 function allMessageDetails(): CompilerMessageDetail[] {
   let result: CompilerMessageDetail[] = [];

--- a/developer/src/kmc/src/messages/infrastructureMessages.ts
+++ b/developer/src/kmc/src/messages/infrastructureMessages.ts
@@ -115,7 +115,7 @@ export class InfrastructureMessages {
   static ERROR_UnrecognizedMessageCode = SevError | 0x001a;
   static Error_UnrecognizedMessageCode = (o:{message:string}) => m(
     this.ERROR_UnrecognizedMessageCode,
-    `Invalid parameter: message identifier '${def(o.message)}' must match format '[KM]#####'`);
+    `Invalid parameter: message identifier '${def(o.message)}' must match format '[KM]#####' or be a search for a ...`);
 
   static ERROR_MustSpecifyMessageCode = SevError | 0x001b;
   static Error_MustSpecifyMessageCode = () => m(
@@ -136,5 +136,10 @@ export class InfrastructureMessages {
   static Error_OutputPathMustExistAndBeADirectory = (o:{outPath:string}) => m(
     this.ERROR_OutputPathMustExistAndBeADirectory,
     `Output path ${def(o.outPath)} must exist and must be a folder`);
-}
+
+  static ERROR_MessageNamespaceNameNotFound = SevError | 0x001f;
+  static Error_MessageNamespaceNameNotFound = (o:{message: string}) => m(
+    this.ERROR_MessageNamespaceNameNotFound,
+    `Invalid parameter: --message ${def(o.message)} does not have a recognized namespace`);
+ }
 

--- a/developer/src/kmc/src/messages/messageNamespaces.ts
+++ b/developer/src/kmc/src/messages/messageNamespaces.ts
@@ -24,7 +24,7 @@ const messageNamespaces: Record<CompilerErrorNamespace, any> = {
 
 // This works around pain points in enumerating enum members in Typescript
 // ref https://www.totaltypescript.com/iterate-over-object-keys-in-typescript
-export const messageNamespaceKeys = Object.keys(messageNamespaces).map(v => Number.parseInt(v));
+export const messageNamespaceKeys = Object.keys(messageNamespaces).map(v => Number.parseInt(v) as CompilerErrorNamespace);
 
 export type CompilerMessageSource = {
   module: string;

--- a/developer/src/kmc/src/util/extendedCompilerOptions.ts
+++ b/developer/src/kmc/src/util/extendedCompilerOptions.ts
@@ -1,6 +1,6 @@
-import { CompilerCallbacks, CompilerError, CompilerErrorSeverity, CompilerMessageOverride, CompilerMessageOverrideMap, CompilerOptions } from '@keymanapp/common-types';
+import { CompilerCallbacks, CompilerError, CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageOverride, CompilerMessageOverrideMap, CompilerOptions } from '@keymanapp/common-types';
 import { InfrastructureMessages } from '../messages/infrastructureMessages.js';
-import { messageNamespaceKeys, messageSources } from '../messages/messageNamespaces.js';
+import { CompilerMessageSource, messageNamespaceKeys, messageSources } from '../messages/messageNamespaces.js';
 
 export interface ExtendedCompilerOptions extends CompilerOptions {
   /**
@@ -95,6 +95,52 @@ export function findMessageDetails(code: number, callbacks: CompilerCallbacks): 
     return null;
   }
   return {code: m[id], id, module: source.module, class: source.class};
+}
+
+export const getMessageIdentifiersSorted = (cls: any) =>
+  Object.keys(cls)
+  .filter(id => typeof cls[id] == 'number')
+  .sort((a,b) => CompilerError.error(cls[a])-CompilerError.error(cls[b]));
+
+/**
+ * Gets an array of compiler messages matching the search identifier. Substrings
+ * are supported for the id portion of the searchId
+ * @param searchNamespace optional namespace to search in, if omitted, searches
+ *                        all namespaces
+ * @param searchId        a substring to match with optional namespace prefix, e.g.
+ *                        "INFO_"
+ */
+export function findMessagesById(searchNamespace: CompilerErrorNamespace, searchId: string): CompilerMessageDetail[] {
+  searchId = searchId.toLowerCase();
+
+  const messages: CompilerMessageDetail[] = [];
+
+  messageNamespaceKeys.forEach((namespace: CompilerErrorNamespace) => {
+    if(searchNamespace && searchNamespace != namespace) {
+      return;
+    }
+
+    const ms = messageSources[namespace] as CompilerMessageSource;
+
+    const ids = getMessageIdentifiersSorted(ms.class);
+    for(const id of ids) {
+      const code = ms.class[id];
+      const lid = id.toLowerCase();
+      if(typeof code != 'number') {
+        continue;
+      }
+      if(lid.includes(searchId)) {
+        messages.push({
+          code,
+          id,
+          class: ms.class,
+          module: ms.module
+        });
+      }
+    }
+  });
+
+  return messages;
 }
 
 /**


### PR DESCRIPTION
Fixes: #10875

@keymanapp-test-bot skip

(Low priority for user test because this is probably mostly used internally)