### PR TITLE
chore(developer): rename kmc-ldml `CompilerMessages`, `LdmlKeyboardCompilerMessages` to `LdmlCompilerMessages`

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -1,6 +1,6 @@
 import { LDMLKeyboardXMLSourceFileReader, LDMLKeyboard, KMXPlus, CompilerCallbacks, LDMLKeyboardTestDataXMLSourceFile, UnicodeSetParser, KeymanCompiler, KeymanCompilerResult, KeymanCompilerArtifacts, defaultCompilerOptions, KMXBuilder, KvkFileWriter, KeymanCompilerArtifactOptional } from '@keymanapp/common-types';
 import { LdmlCompilerOptions } from './ldml-compiler-options.js';
-import { CompilerMessages } from './messages.js';
+import { LdmlCompilerMessages } from './ldml-compiler-messages.js';
 import { BkspCompiler, TranCompiler } from './tran.js';
 import { DispCompiler } from './disp.js';
 import { KeysCompiler } from './keys.js';
@@ -229,13 +229,13 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
     // load the file from disk into a string
     const data = this.callbacks.loadFile(filename);
     if(!data) {
-      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to read XML file'}));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidFile({errorText: 'Unable to read XML file'}));
       return null;
     }
     // parse (load) the string into an object tree
     const source = reader.load(data);
     if(!source) {
-      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to load XML file'}));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidFile({errorText: 'Unable to load XML file'}));
       return null;
     }
     try {
@@ -244,7 +244,7 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
         return null;
       }
     } catch(e) {
-      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: e.toString()}));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidFile({errorText: e.toString()}));
       return null;
     }
 
@@ -262,13 +262,13 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
     const reader = new LDMLKeyboardXMLSourceFileReader(this.options.readerOptions, this.callbacks);
     const data = this.callbacks.loadFile(filename);
     if(!data) {
-      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to read XML file'}));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidFile({errorText: 'Unable to read XML file'}));
       return null;
     }
     const source = reader.loadTestData(data);
     /* c8 ignore next 4 */
     if(!source) {
-      this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: 'Unable to load XML file'}));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidFile({errorText: 'Unable to load XML file'}));
       return null;
     }
     // TODO-LDML: The unboxed data doesn't match the schema anymore. Skipping validation, for now.
@@ -278,7 +278,7 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
     //     return null;
     //   }
     // } catch(e) {
-    //   this.callbacks.reportMessage(CompilerMessages.Error_InvalidFile({errorText: e.toString()}));
+    //   this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidFile({errorText: e.toString()}));
     //   return null;
     // }
 

--- a/developer/src/kmc-ldml/src/compiler/disp.ts
+++ b/developer/src/kmc-ldml/src/compiler/disp.ts
@@ -1,7 +1,7 @@
 import { constants } from "@keymanapp/ldml-keyboard-constants";
 import { KMXPlus, LDMLKeyboard } from '@keymanapp/common-types';
 
-import { CompilerMessages } from "./messages.js";
+import { LdmlCompilerMessages } from "./ldml-compiler-messages.js";
 import { SectionCompiler } from "./section-compiler.js";
 
 import DependencySections = KMXPlus.DependencySections;
@@ -32,18 +32,18 @@ export class DispCompiler extends SectionCompiler {
     if (this.keyboard3.displays?.display) {
       for (const { output, keyId } of this.keyboard3.displays?.display) {
         if ((output && keyId) || (!output && !keyId)) {
-          this.callbacks.reportMessage(CompilerMessages.Error_DisplayNeedsToOrId({ output, keyId }));
+          this.callbacks.reportMessage(LdmlCompilerMessages.Error_DisplayNeedsToOrId({ output, keyId }));
           return false;
         } else if (output) {
           if (tos.has(output)) {
-            this.callbacks.reportMessage(CompilerMessages.Error_DisplayIsRepeated({ output }));
+            this.callbacks.reportMessage(LdmlCompilerMessages.Error_DisplayIsRepeated({ output }));
             return false;
           } else {
             tos.add(output);
           }
         } else if (keyId) {
           if (ids.has(keyId)) {
-            this.callbacks.reportMessage(CompilerMessages.Error_DisplayIsRepeated({ keyId }));
+            this.callbacks.reportMessage(LdmlCompilerMessages.Error_DisplayIsRepeated({ keyId }));
             return false;
           } else {
             ids.add(keyId);

--- a/developer/src/kmc-ldml/src/compiler/empty-compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/empty-compiler.ts
@@ -2,7 +2,7 @@ import { SectionIdent, constants } from '@keymanapp/ldml-keyboard-constants';
 import { SectionCompiler } from "./section-compiler.js";
 import { LDMLKeyboard, KMXPlus, CompilerCallbacks, util, MarkerParser } from "@keymanapp/common-types";
 import { VarsCompiler } from './vars.js';
-import { CompilerMessages } from './messages.js';
+import { LdmlCompilerMessages } from './ldml-compiler-messages.js';
 
 /**
  * Compiler for typrs that don't actually consume input XML
@@ -58,16 +58,16 @@ export class StrsCompiler extends EmptyCompiler {
         const illegals = m.get(util.BadStringType.illegal);
         if (puas) {
           const [count, lowestCh] = [puas.size, Array.from(puas.values()).sort((a, b) => a - b)[0]];
-          this.callbacks.reportMessage(CompilerMessages.Hint_PUACharacters({ count, lowestCh }))
+          this.callbacks.reportMessage(LdmlCompilerMessages.Hint_PUACharacters({ count, lowestCh }))
         }
         if (unassigneds) {
           const [count, lowestCh] = [unassigneds.size, Array.from(unassigneds.values()).sort((a, b) => a - b)[0]];
-          this.callbacks.reportMessage(CompilerMessages.Warn_UnassignedCharacters({ count, lowestCh }))
+          this.callbacks.reportMessage(LdmlCompilerMessages.Warn_UnassignedCharacters({ count, lowestCh }))
         }
         if (illegals) {
           // do this last, because we will return false.
           const [count, lowestCh] = [illegals.size, Array.from(illegals.values()).sort((a, b) => a - b)[0]];
-          this.callbacks.reportMessage(CompilerMessages.Error_IllegalCharacters({ count, lowestCh }))
+          this.callbacks.reportMessage(LdmlCompilerMessages.Error_IllegalCharacters({ count, lowestCh }))
           return false;
         }
       }

--- a/developer/src/kmc-ldml/src/compiler/keys.ts
+++ b/developer/src/kmc-ldml/src/compiler/keys.ts
@@ -1,6 +1,6 @@
 import { SectionIdent, constants } from '@keymanapp/ldml-keyboard-constants';
 import { LDMLKeyboard, KMXPlus, Constants } from '@keymanapp/common-types';
-import { CompilerMessages } from './messages.js';
+import { LdmlCompilerMessages } from './ldml-compiler-messages.js';
 import { SectionCompiler } from "./section-compiler.js";
 
 import DependencySections = KMXPlus.DependencySections;
@@ -71,7 +71,7 @@ export class KeysCompiler extends SectionCompiler {
     this.keyboard3.forms?.form?.forEach((form) => {
       if (!LDMLKeyboard.ImportStatus.isImpliedImport(form)) {
         // If it's not an implied import, give a warning.
-        this.callbacks.reportMessage(CompilerMessages.Warn_CustomForm({ id: form.id }));
+        this.callbacks.reportMessage(LdmlCompilerMessages.Warn_CustomForm({ id: form.id }));
       }
     });
 
@@ -98,7 +98,7 @@ export class KeysCompiler extends SectionCompiler {
         if (!flickHash.has(flickId)) {
           valid = false;
           this.callbacks.reportMessage(
-            CompilerMessages.Error_MissingFlicks({ flickId, id: keyId })
+            LdmlCompilerMessages.Error_MissingFlicks({ flickId, id: keyId })
           );
         }
       }
@@ -110,7 +110,7 @@ export class KeysCompiler extends SectionCompiler {
           // TODO-LDML: could keep track of already missing keys so we don't warn multiple times on gesture keys
           valid = false;
           this.callbacks.reportMessage(
-            CompilerMessages.Error_GestureKeyNotFoundInKeyBag({keyId: gestureKeyId, parentKeyId: keyId, attribute: attrs.join(',')})
+            LdmlCompilerMessages.Error_GestureKeyNotFoundInKeyBag({keyId: gestureKeyId, parentKeyId: keyId, attribute: attrs.join(',')})
           );
         } else {
           usedKeys.add(gestureKeyId);
@@ -407,7 +407,7 @@ export class KeysCompiler extends SectionCompiler {
     const { modifiers } = layer;
     if (!validModifier(modifiers)) {
       this.callbacks.reportMessage(
-        CompilerMessages.Error_InvalidModifier({ modifiers, layer: layer.id })
+        LdmlCompilerMessages.Error_InvalidModifier({ modifiers, layer: layer.id })
       );
       valid = false;
     }
@@ -416,14 +416,14 @@ export class KeysCompiler extends SectionCompiler {
     const keymap = this.getKeymapFromForm(hardware, badScans);
     if (!keymap) {
       this.callbacks.reportMessage(
-        CompilerMessages.Error_InvalidHardware({ formId: hardware })
+        LdmlCompilerMessages.Error_InvalidHardware({ formId: hardware })
       );
       valid = false;
       return valid;
     } else if (badScans.size !== 0) {
       const codes = Array.from(badScans.values()).map(n => Number(n).toString(16)).sort();
       this.callbacks.reportMessage(
-        CompilerMessages.Error_InvalidScanCode({ form: hardware, codes })
+        LdmlCompilerMessages.Error_InvalidScanCode({ form: hardware, codes })
       );
       valid = false;
       return valid;
@@ -431,7 +431,7 @@ export class KeysCompiler extends SectionCompiler {
 
     if (layer.row.length > keymap.length) {
       this.callbacks.reportMessage(
-        CompilerMessages.Error_HardwareLayerHasTooManyRows()
+        LdmlCompilerMessages.Error_HardwareLayerHasTooManyRows()
       );
       valid = false;
     }
@@ -441,7 +441,7 @@ export class KeysCompiler extends SectionCompiler {
 
       if (keys.length > keymap[y].length) {
         this.callbacks.reportMessage(
-          CompilerMessages.Error_RowOnHardwareLayerHasTooManyKeys({
+          LdmlCompilerMessages.Error_RowOnHardwareLayerHasTooManyKeys({
             row: y + 1,
             hardware,
             modifiers,
@@ -457,7 +457,7 @@ export class KeysCompiler extends SectionCompiler {
         let keydef = keyHash.get(key);
         if (!keydef) {
           this.callbacks.reportMessage(
-            CompilerMessages.Error_KeyNotFoundInKeyBag({
+            LdmlCompilerMessages.Error_KeyNotFoundInKeyBag({
               keyId: key,
               col: x + 1,
               row: y + 1,
@@ -470,7 +470,7 @@ export class KeysCompiler extends SectionCompiler {
         }
         if (!keydef.output && !keydef.gap && !keydef.layerId) {
           this.callbacks.reportMessage(
-            CompilerMessages.Error_KeyMissingToGapOrSwitch({ keyId: key })
+            LdmlCompilerMessages.Error_KeyMissingToGapOrSwitch({ keyId: key })
           );
           valid = false;
           continue;

--- a/developer/src/kmc-ldml/src/compiler/layr.ts
+++ b/developer/src/kmc-ldml/src/compiler/layr.ts
@@ -1,6 +1,6 @@
 import { constants } from '@keymanapp/ldml-keyboard-constants';
 import { KMXPlus } from '@keymanapp/common-types';
-import { CompilerMessages } from './messages.js';
+import { LdmlCompilerMessages } from './ldml-compiler-messages.js';
 import { SectionCompiler } from "./section-compiler.js";
 import { translateLayerAttrToModifier, validModifier } from '../util/util.js';
 
@@ -33,14 +33,14 @@ export class LayrCompiler extends SectionCompiler {
         hardwareLayers++;
         if (hardwareLayers > 1) {
           valid = false;
-          this.callbacks.reportMessage(CompilerMessages.Error_ExcessHardware({formId}));
+          this.callbacks.reportMessage(LdmlCompilerMessages.Error_ExcessHardware({formId}));
         }
       }
       layers.layer.forEach((layer) => {
         const { modifiers, id } = layer;
         totalLayerCount++;
         if (!validModifier(modifiers)) {
-          this.callbacks.reportMessage(CompilerMessages.Error_InvalidModifier({ modifiers, layer: id || '' }));
+          this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidModifier({ modifiers, layer: id || '' }));
           valid = false;
         }
       });
@@ -48,7 +48,7 @@ export class LayrCompiler extends SectionCompiler {
     if (totalLayerCount === 0) { // TODO-LDML: does not validate touch layers yet
       // no layers seen anywhere
       valid = false;
-      this.callbacks.reportMessage(CompilerMessages.Error_MustBeAtLeastOneLayerElement());
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_MustBeAtLeastOneLayerElement());
     }
     return valid;
   }

--- a/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
@@ -11,7 +11,7 @@ const SevErrorTransform = SevError | 0xF00;
 /**
  * @internal
  */
-export class CompilerMessages {
+export class LdmlCompilerMessages {
   static HINT_NormalizationDisabled = SevHint | 0x0001;
   static Hint_NormalizationDisabled = () => m(this.HINT_NormalizationDisabled, `normalization=disabled is not recommended.`);
 
@@ -83,7 +83,7 @@ export class CompilerMessages {
 
   static ERROR_DisplayIsRepeated = SevError | 0x0010;
   static Error_DisplayIsRepeated = (o:{output?: string, keyId?: string}) =>
-    m(this.ERROR_DisplayIsRepeated, `display ${CompilerMessages.outputOrKeyId(o)} has more than one display entry.`);
+    m(this.ERROR_DisplayIsRepeated, `display ${LdmlCompilerMessages.outputOrKeyId(o)} has more than one display entry.`);
 
   static ERROR_KeyMissingToGapOrSwitch = SevError | 0x0011;
   static Error_KeyMissingToGapOrSwitch = (o:{keyId: string}) =>
@@ -107,7 +107,7 @@ export class CompilerMessages {
 
   static ERROR_InvalidModifier = SevError | 0x0014;
   static Error_InvalidModifier = (o:{layer: string, modifiers: string}) => m(this.ERROR_InvalidModifier,
-    `layer has invalid modifiers='${def(o.modifiers)}'` + CompilerMessages.layerIdOrEmpty(o.layer));
+    `layer has invalid modifiers='${def(o.modifiers)}'` + LdmlCompilerMessages.layerIdOrEmpty(o.layer));
 
   static ERROR_MissingFlicks = SevError | 0x0015;
   static Error_MissingFlicks = (o:{flickId: string, id: string}) => m(this.ERROR_MissingFlicks,
@@ -160,7 +160,7 @@ export class CompilerMessages {
 
   static ERROR_DisplayNeedsToOrId = SevError | 0x0022;
   static Error_DisplayNeedsToOrId = (o:{output?: string, keyId?: string}) =>
-  m(this.ERROR_DisplayNeedsToOrId, `display ${CompilerMessages.outputOrKeyId(o)} needs output= or keyId=, but not both`);
+  m(this.ERROR_DisplayNeedsToOrId, `display ${LdmlCompilerMessages.outputOrKeyId(o)} needs output= or keyId=, but not both`);
 
   static HINT_PUACharacters = SevHint | 0x0023;
   static Hint_PUACharacters = (o: { count: number, lowestCh: number }) =>

--- a/developer/src/kmc-ldml/src/compiler/linter-keycaps.ts
+++ b/developer/src/kmc-ldml/src/compiler/linter-keycaps.ts
@@ -1,6 +1,6 @@
 import { MarkerParser } from "@keymanapp/common-types";
 import { Linter } from "./linter.js";
-import { CompilerMessages } from "./messages.js";
+import { LdmlCompilerMessages } from "./ldml-compiler-messages.js";
 
 /** A linter concerned with the display of keycaps */
 export class LinterKeycaps extends Linter {
@@ -35,13 +35,13 @@ export class LinterKeycaps extends Linter {
                 const disp = this.findDisp(id.value, to.value);
 
                 if (!disp) {
-                    this.callbacks.reportMessage(CompilerMessages.Hint_NoDisplayForSwitch({ id: id.value }));
+                    this.callbacks.reportMessage(LdmlCompilerMessages.Hint_NoDisplayForSwitch({ id: id.value }));
                 }
             } else if (to.value !== '' && nonMarkerOutput === '') {
                 // has output, but only markers
                 const disp = this.findDisp(id.value, to.value);
                 if (!disp) {
-                    this.callbacks.reportMessage(CompilerMessages.Hint_NoDisplayForMarker({ id: id.value }));
+                    this.callbacks.reportMessage(LdmlCompilerMessages.Hint_NoDisplayForMarker({ id: id.value }));
                 }
             }
         }

--- a/developer/src/kmc-ldml/src/compiler/loca.ts
+++ b/developer/src/kmc-ldml/src/compiler/loca.ts
@@ -1,7 +1,7 @@
 import { constants } from "@keymanapp/ldml-keyboard-constants";
 import { LDMLKeyboard, KMXPlus } from '@keymanapp/common-types';
 import { SectionCompiler } from "./section-compiler.js";
-import { CompilerMessages } from "./messages.js";
+import { LdmlCompilerMessages } from "./ldml-compiler-messages.js";
 
 import DependencySections = KMXPlus.DependencySections;
 import Loca = KMXPlus.Loca;
@@ -30,7 +30,7 @@ export class LocaCompiler extends SectionCompiler {
         new Intl.Locale(tag);
       } catch(e) {
         if(e instanceof RangeError) {
-          this.callbacks.reportMessage(CompilerMessages.Error_InvalidLocale({tag}));
+          this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidLocale({tag}));
           valid = false;
         } else {
           /* c8 ignore next 2 */
@@ -50,7 +50,7 @@ export class LocaCompiler extends SectionCompiler {
     const locales = sourceLocales.map((sourceLocale: string) => {
       const locale = new Intl.Locale(sourceLocale).minimize().toString();
       if(locale != sourceLocale) {
-        this.callbacks.reportMessage(CompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale, locale}));
+        this.callbacks.reportMessage(LdmlCompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale, locale}));
       }
       return locale;
     });
@@ -62,7 +62,7 @@ export class LocaCompiler extends SectionCompiler {
     result.locales = canonicalLocales.map(locale => sections.strs.allocString(locale));
 
     if(result.locales.length < locales.length) {
-      this.callbacks.reportMessage(CompilerMessages.Hint_OneOrMoreRepeatedLocales());
+      this.callbacks.reportMessage(LdmlCompilerMessages.Hint_OneOrMoreRepeatedLocales());
     }
 
     return result;

--- a/developer/src/kmc-ldml/src/compiler/meta.ts
+++ b/developer/src/kmc-ldml/src/compiler/meta.ts
@@ -1,7 +1,7 @@
 import { SectionIdent, constants } from "@keymanapp/ldml-keyboard-constants";
 import { KMXPlus } from '@keymanapp/common-types';
 
-import { CompilerMessages } from "./messages.js";
+import { LdmlCompilerMessages } from "./ldml-compiler-messages.js";
 import { SectionCompiler } from "./section-compiler.js";
 import semver from "semver";
 
@@ -28,11 +28,11 @@ export class MetaCompiler extends SectionCompiler {
     if(versionNumber !== undefined) {
       if(versionNumber.match(/^[=v]/i)) {
         // semver ignores a preceding '=' or 'v'
-        this.callbacks.reportMessage(CompilerMessages.Error_InvalidVersion({ version: versionNumber }));
+        this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidVersion({ version: versionNumber }));
         return false;
       }
       if(!semver.parse(versionNumber, {loose: false})) {
-        this.callbacks.reportMessage(CompilerMessages.Error_InvalidVersion({ version: versionNumber }));
+        this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidVersion({ version: versionNumber }));
         return false;
       }
     }
@@ -41,7 +41,7 @@ export class MetaCompiler extends SectionCompiler {
 
   private validateNormalization(normalization?: string) {
     if (normalization === 'disabled') {
-      this.callbacks.reportMessage(CompilerMessages.Hint_NormalizationDisabled());
+      this.callbacks.reportMessage(LdmlCompilerMessages.Hint_NormalizationDisabled());
     }
     return true;
   }

--- a/developer/src/kmc-ldml/src/compiler/tran.ts
+++ b/developer/src/kmc-ldml/src/compiler/tran.ts
@@ -14,7 +14,7 @@ import LKReorder = LDMLKeyboard.LKReorder;
 import LKTransform = LDMLKeyboard.LKTransform;
 import LKTransforms = LDMLKeyboard.LKTransforms;
 import { verifyValidAndUnique } from "../util/util.js";
-import { CompilerMessages } from "./messages.js";
+import { LdmlCompilerMessages } from "./ldml-compiler-messages.js";
 import { Substitutions, SubstitutionUse } from "./substitution-tracker.js";
 
 type TransformCompilerType = 'simple' | 'backspace';
@@ -59,9 +59,9 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
     if (transforms) {
       const types : string[] = transforms.map(({type}) => type);
       if (!verifyValidAndUnique(types,
-        types => reportMessage(CompilerMessages.Error_DuplicateTransformsType({ types })),
+        types => reportMessage(LdmlCompilerMessages.Error_DuplicateTransformsType({ types })),
         new Set(['simple', 'backspace']),
-        types => reportMessage(CompilerMessages.Error_InvalidTransformsType({ types })))) {
+        types => reportMessage(LdmlCompilerMessages.Error_InvalidTransformsType({ types })))) {
         valid = false;
       }
 
@@ -78,11 +78,11 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
       }));
       if (mixed) {
         valid = false;
-        reportMessage(CompilerMessages.Error_MixedTransformGroup()); // report this once
+        reportMessage(LdmlCompilerMessages.Error_MixedTransformGroup()); // report this once
       }
       if (empty) {
         valid = false;
-        reportMessage(CompilerMessages.Error_EmptyTransformGroup()); // report this once
+        reportMessage(LdmlCompilerMessages.Error_EmptyTransformGroup()); // report this once
       }
 
       // TODO-LDML: linting here should check for identical from, but this involves a double-parse which is ugly
@@ -200,15 +200,15 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
   private isValidRegex(cookedFrom: string, from: string) : boolean {
     // check for any unescaped dollar sign here
     if (/(?<!\\)(?:\\\\)*\$/.test(cookedFrom)) {
-      this.callbacks.reportMessage(CompilerMessages.Error_IllegalTransformDollarsign({ from }));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_IllegalTransformDollarsign({ from }));
       return false;
     }
     if (/(?<!\\)(?:\\\\)*\*/.test(cookedFrom)) {
-      this.callbacks.reportMessage(CompilerMessages.Error_IllegalTransformAsterisk({ from }));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_IllegalTransformAsterisk({ from }));
       return false;
     }
     if (/(?<!\\)(?:\\\\)*\+/.test(cookedFrom)) {
-      this.callbacks.reportMessage(CompilerMessages.Error_IllegalTransformPlus({ from }));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_IllegalTransformPlus({ from }));
       return false;
     }
     // Verify that the regex is syntactically valid
@@ -218,14 +218,14 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
 
       // does it match an empty string?
       if (rg.test('')) {
-        this.callbacks.reportMessage(CompilerMessages.Error_TransformFromMatchesNothing({ from }));
+        this.callbacks.reportMessage(LdmlCompilerMessages.Error_TransformFromMatchesNothing({ from }));
         return false;
       }
     } catch (e) {
       // We're exposing the internal regex error message here.
       // In the future, CLDR plans to expose the EBNF for the transform,
       // at which point we would have more precise validation prior to getting to this point.
-      this.callbacks.reportMessage(CompilerMessages.Error_UnparseableTransformFrom({ from, message: e.message }));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_UnparseableTransformFrom({ from, message: e.message }));
       return false;
     }
     return true;
@@ -295,7 +295,7 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
     for (const [, sub] of cookedFrom.matchAll(anyQuad)) {
       const s = util.unescapeOne(sub);
       if (s !== '\uffff' && s !== '\u0008') { // markers
-        this.callbacks.reportMessage(CompilerMessages.Error_InvalidQuadEscape({ cp: s.codePointAt(0) }));
+        this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidQuadEscape({ cp: s.codePointAt(0) }));
         return null; // exit on the first error
       }
     }
@@ -357,13 +357,13 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
     let needCooking = false;
     const explicitSet = rangeExplicit.analyze()?.get(util.BadStringType.denormalized);
     if (explicitSet) {
-      this.callbacks.reportMessage(CompilerMessages.Warn_CharClassExplicitDenorm({ lowestCh: explicitSet.values().next().value }));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Warn_CharClassExplicitDenorm({ lowestCh: explicitSet.values().next().value }));
       needCooking = true;
     } else {
       // don't analyze the implicit set of THIS range, if explicit is already problematic
       const implicitSet = rangeImplicit.analyze()?.get(util.BadStringType.denormalized);
       if (implicitSet) {
-        this.callbacks.reportMessage(CompilerMessages.Hint_CharClassImplicitDenorm({ lowestCh: implicitSet.values().next().value }));
+        this.callbacks.reportMessage(LdmlCompilerMessages.Hint_CharClassImplicitDenorm({ lowestCh: implicitSet.values().next().value }));
         needCooking = true;
       }
     }

--- a/developer/src/kmc-ldml/src/compiler/vars.ts
+++ b/developer/src/kmc-ldml/src/compiler/vars.ts
@@ -8,7 +8,7 @@ import SetVarItem = KMXPlus.SetVarItem;
 import UnicodeSetItem = KMXPlus.UnicodeSetItem;
 import DependencySections = KMXPlus.DependencySections;
 import LDMLKeyboardXMLSourceFile = LDMLKeyboard.LDMLKeyboardXMLSourceFile;
-import { CompilerMessages } from "./messages.js";
+import { LdmlCompilerMessages } from "./ldml-compiler-messages.js";
 import { KeysCompiler } from "./keys.js";
 import { TransformCompiler } from "./tran.js";
 import { DispCompiler } from "./disp.js";
@@ -87,7 +87,7 @@ export class VarsCompiler extends SectionCompiler {
           if (setrefs.length > 1) {
             // this is the form $[seta]$[setb]
             valid = false;
-            this.callbacks.reportMessage(CompilerMessages.Error_NeedSpacesBetweenSetVariables({ item }));
+            this.callbacks.reportMessage(LdmlCompilerMessages.Error_NeedSpacesBetweenSetVariables({ item }));
           } else {
             st.set.add(SubstitutionUse.variable, setrefs); // the reference to a 'map'
           }
@@ -106,7 +106,7 @@ export class VarsCompiler extends SectionCompiler {
             valid = false;
             if (allSets.has(id2)) {
               // $[set] in a UnicodeSet must be another UnicodeSet.
-              this.callbacks.reportMessage(CompilerMessages.Error_CantReferenceSetFromUnicodeSet({ id: id2 }));
+              this.callbacks.reportMessage(LdmlCompilerMessages.Error_CantReferenceSetFromUnicodeSet({ id: id2 }));
             } else {
               st.uset.add(SubstitutionUse.variable, [id2]);
             }
@@ -116,7 +116,7 @@ export class VarsCompiler extends SectionCompiler {
     }
     // one report if any dups
     if (dups.size > 0) {
-      this.callbacks.reportMessage(CompilerMessages.Error_DuplicateVariable({
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_DuplicateVariable({
         ids: Array.from(dups.values()).sort().join(', ')
       }));
       valid = false;
@@ -128,19 +128,19 @@ export class VarsCompiler extends SectionCompiler {
       // intended. collisions are handled separately.
       if (!allSets.has(id) && !allUnicodeSets.has(id)) {
         valid = false;
-        this.callbacks.reportMessage(CompilerMessages.Error_MissingSetVariable({ id }));
+        this.callbacks.reportMessage(LdmlCompilerMessages.Error_MissingSetVariable({ id }));
       }
     }
     for (const id of st.string.all) {
       if (!allStrings.has(id)) {
         valid = false;
-        this.callbacks.reportMessage(CompilerMessages.Error_MissingStringVariable({ id }));
+        this.callbacks.reportMessage(LdmlCompilerMessages.Error_MissingStringVariable({ id }));
       }
     }
     for (const id of st.uset.all) {
       if (!allUnicodeSets.has(id)) {
         valid = false;
-        this.callbacks.reportMessage(CompilerMessages.Error_MissingUnicodeSetVariable({ id }));
+        this.callbacks.reportMessage(LdmlCompilerMessages.Error_MissingUnicodeSetVariable({ id }));
       }
     }
 
@@ -179,7 +179,7 @@ export class VarsCompiler extends SectionCompiler {
 
     // report once
     if (matchedNotEmitted.size > 0) {
-      this.callbacks.reportMessage(CompilerMessages.Error_MissingMarkers({ ids: Array.from(matchedNotEmitted.values()).sort() }));
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_MissingMarkers({ ids: Array.from(matchedNotEmitted.values()).sort() }));
       valid = false;
     }
 

--- a/developer/src/kmc-ldml/src/compiler/visual-keyboard-compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/visual-keyboard-compiler.ts
@@ -1,6 +1,6 @@
 import { VisualKeyboard, LDMLKeyboard, CompilerCallbacks } from "@keymanapp/common-types";
 import { KeysCompiler } from "./keys.js";
-import { CompilerMessages } from "./messages.js";
+import { LdmlCompilerMessages } from "./ldml-compiler-messages.js";
 
 export class LdmlKeyboardVisualKeyboardCompiler {
   public constructor(private callbacks: CompilerCallbacks) {
@@ -40,7 +40,7 @@ export class LdmlKeyboardVisualKeyboardCompiler {
     const keymap = KeysCompiler.getKeymapFromForms(source.keyboard3?.forms?.form, hardware);
     if (!keymap) {
       this.callbacks.reportMessage(
-        CompilerMessages.Error_InvalidHardware({ formId: hardware })
+        LdmlCompilerMessages.Error_InvalidHardware({ formId: hardware })
       );
       return;
     }
@@ -60,7 +60,7 @@ export class LdmlKeyboardVisualKeyboardCompiler {
 
         if (!keydef) {
           this.callbacks.reportMessage(
-            CompilerMessages.Error_KeyNotFoundInKeyBag({ keyId, layer: layerId, row: y, col: x, form: hardware })
+            LdmlCompilerMessages.Error_KeyNotFoundInKeyBag({ keyId, layer: layerId, row: y, col: x, form: hardware })
           );
         } else {
           vk.keys.push({

--- a/developer/src/kmc-ldml/src/main.ts
+++ b/developer/src/kmc-ldml/src/main.ts
@@ -1,5 +1,4 @@
 
 export { LdmlKeyboardCompiler } from './compiler/compiler.js';
 export { LdmlCompilerOptions } from './compiler/ldml-compiler-options.js';
-export { LdmlCompilerMessages as LdmlKeyboardCompilerMessages } from './compiler/ldml-compiler-messages.js';
-// TODO: rename LdmlKeyboardCompilerMessages to LdmlCompilerMessages
+export { LdmlCompilerMessages } from './compiler/ldml-compiler-messages.js';

--- a/developer/src/kmc-ldml/src/main.ts
+++ b/developer/src/kmc-ldml/src/main.ts
@@ -1,4 +1,5 @@
 
 export { LdmlKeyboardCompiler } from './compiler/compiler.js';
 export { LdmlCompilerOptions } from './compiler/ldml-compiler-options.js';
-export { CompilerMessages as LdmlKeyboardCompilerMessages } from './compiler/messages.js'; // TODO: rename messages.js and CompilerMessages
+export { LdmlCompilerMessages as LdmlKeyboardCompilerMessages } from './compiler/ldml-compiler-messages.js';
+// TODO: rename LdmlKeyboardCompilerMessages to LdmlCompilerMessages

--- a/developer/src/kmc-ldml/test/test-disp.ts
+++ b/developer/src/kmc-ldml/test/test-disp.ts
@@ -3,7 +3,7 @@ import {assert} from 'chai';
 import { DispCompiler } from '../src/compiler/disp.js';
 import { compilerTestCallbacks, loadSectionFixture, testCompilationCases } from './helpers/index.js';
 import { KMXPlus } from '@keymanapp/common-types';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 
 import Disp = KMXPlus.Disp;
 
@@ -61,32 +61,32 @@ describe('disp', function () {
     let disp = await loadSectionFixture(DispCompiler, 'sections/disp/invalid-dupto.xml', compilerTestCallbacks) as Disp;
     assert.isNull(disp);
     assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_DisplayIsRepeated({ output: 'e' }));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_DisplayIsRepeated({ output: 'e' }));
   });
   it('should reject duplicate ids', async function() {
     let disp = await loadSectionFixture(DispCompiler, 'sections/disp/invalid-dupid.xml', compilerTestCallbacks) as Disp;1
     assert.isNull(disp);
     assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_DisplayIsRepeated({ keyId: 'e' }));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_DisplayIsRepeated({ keyId: 'e' }));
   });
   it('should reject if neither to nor id', async function() {
     let disp = await loadSectionFixture(DispCompiler, 'sections/disp/invalid-none.xml', compilerTestCallbacks) as Disp;
     assert.isNull(disp);
     assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_DisplayNeedsToOrId({}));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_DisplayNeedsToOrId({}));
   });
   it('should reject if both to and id', async function() {
     let disp = await loadSectionFixture(DispCompiler, 'sections/disp/invalid-both.xml', compilerTestCallbacks) as Disp;
     assert.isNull(disp);
     assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_DisplayNeedsToOrId({ output: 'e', keyId: 'e' }));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_DisplayNeedsToOrId({ output: 'e', keyId: 'e' }));
   });
   testCompilationCases(DispCompiler, [
     {
       subpath: 'sections/disp/invalid-var.xml',
       errors: [
-        CompilerMessages.Error_MissingStringVariable({id: "missingdisplay"}),
-        CompilerMessages.Error_MissingStringVariable({id: "missingoutput"}),
+        LdmlCompilerMessages.Error_MissingStringVariable({id: "missingdisplay"}),
+        LdmlCompilerMessages.Error_MissingStringVariable({id: "missingoutput"}),
       ],
     },
   ]);

--- a/developer/src/kmc-ldml/test/test-helpers.ts
+++ b/developer/src/kmc-ldml/test/test-helpers.ts
@@ -2,20 +2,20 @@ import { CompilerEvent } from '@keymanapp/common-types';
 import 'mocha';
 import {assert} from 'chai';
 import { CompilerEventOrMatch, matchCompilerEvents } from './helpers/index.js';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 
 
 describe('test of test/helpers/CompilerMatch', () => {
     /** the message(s) to test */
     const messages : CompilerEvent[] = [
-        CompilerMessages.Error_InvalidHardware({ formId: 'outdated' }),
-        CompilerMessages.Hint_NormalizationDisabled(),
+        LdmlCompilerMessages.Error_InvalidHardware({ formId: 'outdated' }),
+        LdmlCompilerMessages.Hint_NormalizationDisabled(),
     ];
 
     it('should work for exact matches', () => {
         const spec : CompilerEventOrMatch[] = [
-            CompilerMessages.Hint_NormalizationDisabled(),
-            CompilerMessages.Error_InvalidHardware({ formId: 'outdated' }),
+            LdmlCompilerMessages.Hint_NormalizationDisabled(),
+            LdmlCompilerMessages.Error_InvalidHardware({ formId: 'outdated' }),
         ];
         const matched = matchCompilerEvents(messages, spec);
         assert.sameDeepMembers(messages, spec); // exact match works here
@@ -24,9 +24,9 @@ describe('test of test/helpers/CompilerMatch', () => {
     it('should work for a fuzzy matches', () => {
         const spec : CompilerEventOrMatch[] = [
             // mixed messages here - this one is a CompilerEvent
-            CompilerMessages.Hint_NormalizationDisabled(),
+            LdmlCompilerMessages.Hint_NormalizationDisabled(),
             // fuzzy match on this one - CompilerMatch
-            { code: CompilerMessages.ERROR_InvalidHardware, matchMessage: /(out|up|inun)dated/ },
+            { code: LdmlCompilerMessages.ERROR_InvalidHardware, matchMessage: /(out|up|inun)dated/ },
         ];
         const matched = matchCompilerEvents(messages, spec);
         assert.sameDeepMembers(messages, matched);

--- a/developer/src/kmc-ldml/test/test-keys.ts
+++ b/developer/src/kmc-ldml/test/test-keys.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { KeysCompiler } from '../src/compiler/keys.js';
 import { assertCodePoints, compilerTestCallbacks, loadSectionFixture, testCompilationCases } from './helpers/index.js';
 import { KMXPlus, Constants, MarkerParser } from '@keymanapp/common-types';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 import { constants } from '@keymanapp/ldml-keyboard-constants';
 import { MetaCompiler } from '../src/compiler/meta.js';
 const keysDependencies = [ ...BASIC_DEPENDENCIES, MetaCompiler ];
@@ -120,7 +120,7 @@ describe('keys', function () {
 
       },
       warnings: [
-        CompilerMessages.Hint_NormalizationDisabled()
+        LdmlCompilerMessages.Hint_NormalizationDisabled()
       ],
     },
     {
@@ -298,18 +298,18 @@ describe('keys.kmap', function () {
     {
       subpath: 'sections/keys/invalid-bad-modifier.xml',
       errors: [
-        CompilerMessages.Error_InvalidModifier({layer:'base',modifiers:'altR-shift'}),
+        LdmlCompilerMessages.Error_InvalidModifier({layer:'base',modifiers:'altR-shift'}),
       ]
     },
     {
       subpath: 'sections/keys/invalid-missing-flick.xml',
       errors: [
-        CompilerMessages.Error_MissingFlicks({flickId:'an-undefined-flick-id',id:'Q'}),
+        LdmlCompilerMessages.Error_MissingFlicks({flickId:'an-undefined-flick-id',id:'Q'}),
       ]
     },
     {
       subpath: 'sections/layr/invalid-invalid-form.xml',
-      errors: [CompilerMessages.Error_InvalidHardware({
+      errors: [LdmlCompilerMessages.Error_InvalidHardware({
         formId: 'holographic',
       }),],
     },
@@ -317,7 +317,7 @@ describe('keys.kmap', function () {
       // warning on custom form
       subpath: 'sections/layr/warn-custom-us-form.xml',
       warnings: [
-        CompilerMessages.Warn_CustomForm({id: "us"}),
+        LdmlCompilerMessages.Warn_CustomForm({id: "us"}),
       ],
       callback: (sect, subpath, callbacks) => {
         const keys = sect as Keys;
@@ -347,7 +347,7 @@ describe('keys.kmap', function () {
       // warning on a custom unknown form - but no error!
       subpath: 'sections/layr/warn-custom-zzz-form.xml',
       warnings: [
-        CompilerMessages.Warn_CustomForm({id: "zzz"}),
+        LdmlCompilerMessages.Warn_CustomForm({id: "zzz"}),
       ],
       callback: (sect, subpath, callbacks) => {
         const keys = sect as Keys;
@@ -376,31 +376,31 @@ describe('keys.kmap', function () {
     {
       subpath: 'sections/layr/error-custom-us-form.xml',
       warnings: [
-        CompilerMessages.Warn_CustomForm({id: "us"}),
+        LdmlCompilerMessages.Warn_CustomForm({id: "us"}),
       ],
       errors: [
-        CompilerMessages.Error_InvalidScanCode({ form: "us", codes: ['ff'] }),
+        LdmlCompilerMessages.Error_InvalidScanCode({ form: "us", codes: ['ff'] }),
       ],
     },
     {
       subpath: 'sections/layr/error-custom-zzz-form.xml',
       warnings: [
-        CompilerMessages.Warn_CustomForm({id: "zzz"}),
+        LdmlCompilerMessages.Warn_CustomForm({id: "zzz"}),
       ],
       errors: [
-        CompilerMessages.Error_InvalidScanCode({ form: "zzz", codes: ['ff'] }),
+        LdmlCompilerMessages.Error_InvalidScanCode({ form: "zzz", codes: ['ff'] }),
       ],
     },
     {
       subpath: 'sections/keys/invalid-undefined-var-1.xml',
       errors: [
-        CompilerMessages.Error_MissingStringVariable({id: "varsok"}),
+        LdmlCompilerMessages.Error_MissingStringVariable({id: "varsok"}),
       ],
     },
     {
       subpath: 'sections/keys/invalid-undefined-var-1b.xml',
       errors: [
-        CompilerMessages.Error_MissingStringVariable({id: "varsok"}),
+        LdmlCompilerMessages.Error_MissingStringVariable({id: "varsok"}),
       ],
     },
     // modifiers test
@@ -429,7 +429,7 @@ describe('keys.kmap', function () {
     assert.isNull(keys);
     assert.equal(compilerTestCallbacks.messages.length, 1);
 
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_HardwareLayerHasTooManyRows());
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_HardwareLayerHasTooManyRows());
   });
 
   it('should reject layouts with too many hardware keys', async function() {
@@ -437,7 +437,7 @@ describe('keys.kmap', function () {
     assert.isNull(keys);
     assert.equal(compilerTestCallbacks.messages.length, 1);
 
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_RowOnHardwareLayerHasTooManyKeys({row: 1, hardware: 'us', modifiers: 'none'}));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_RowOnHardwareLayerHasTooManyKeys({row: 1, hardware: 'us', modifiers: 'none'}));
   });
 
   it('should reject layouts with undefined keys', async function() {
@@ -445,13 +445,13 @@ describe('keys.kmap', function () {
     assert.isNull(keys);
     assert.equal(compilerTestCallbacks.messages.length, 1);
 
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_KeyNotFoundInKeyBag({col: 1, form: 'hardware', keyId: 'foo', layer: 'base', row: 1}));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_KeyNotFoundInKeyBag({col: 1, form: 'hardware', keyId: 'foo', layer: 'base', row: 1}));
   });
   it('should reject layouts with invalid keys', async function() {
     let keys = await loadSectionFixture(KeysCompiler, 'sections/keys/invalid-key-missing-attrs.xml', compilerTestCallbacks, keysDependencies) as Keys;
     assert.isNull(keys);
     assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_KeyMissingToGapOrSwitch({keyId: 'Q'}));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_KeyMissingToGapOrSwitch({keyId: 'Q'}));
   });
   it('should accept layouts with gap/switch keys', async function() {
     let keys = await loadSectionFixture(KeysCompiler, 'sections/keys/gap-switch.xml', compilerTestCallbacks, keysDependencies) as Keys;

--- a/developer/src/kmc-ldml/test/test-layr.ts
+++ b/developer/src/kmc-ldml/test/test-layr.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import { assert } from 'chai';
 import { LayrCompiler } from '../src/compiler/layr.js';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 import { compilerTestCallbacks, testCompilationCases } from './helpers/index.js';
 import { KMXPlus } from '@keymanapp/common-types';
 import { constants } from '@keymanapp/ldml-keyboard-constants';
@@ -95,7 +95,7 @@ describe('layr', function () {
     {
       subpath: 'sections/keys/invalid-bad-modifier.xml',
       errors: [
-        CompilerMessages.Error_InvalidModifier({
+        LdmlCompilerMessages.Error_InvalidModifier({
           layer: 'base',
           modifiers: 'altR-shift'
         }),
@@ -103,12 +103,12 @@ describe('layr', function () {
     },
     {
       subpath: 'sections/layr/invalid-multi-hardware.xml',
-      errors: [CompilerMessages.Error_ExcessHardware({ formId: 'iso' })],
+      errors: [LdmlCompilerMessages.Error_ExcessHardware({ formId: 'iso' })],
     },
     {
       // missing layer element
       subpath: 'sections/layr/invalid-missing-layer.xml',
-      errors: [CompilerMessages.Error_MustBeAtLeastOneLayerElement()],
+      errors: [LdmlCompilerMessages.Error_MustBeAtLeastOneLayerElement()],
     },
     {
       // keep in sync with similar test in test-keys.ts
@@ -132,7 +132,7 @@ describe('layr', function () {
     {
       subpath: 'sections/layr/error-bogus-modifiers.xml',
       errors: [
-        CompilerMessages.Error_InvalidModifier({ layer: '', modifiers: 'caps bogus'}),
+        LdmlCompilerMessages.Error_InvalidModifier({ layer: '', modifiers: 'caps bogus'}),
       ]
     },
   ]);

--- a/developer/src/kmc-ldml/test/test-linter.ts
+++ b/developer/src/kmc-ldml/test/test-linter.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import {assert} from 'chai';
 import {compileKeyboard, compilerTestCallbacks, compilerTestOptions, makePathToFixture} from './helpers/index.js';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 
 /** Overall tests that have to do with cross-section linting or hinting */
 describe('linter-tests', function() {
@@ -15,9 +15,9 @@ describe('linter-tests', function() {
       // unassigned not implemented yet
       const inputFilename = makePathToFixture('sections/keys/warn-no-keycap.xml');
       const msgs = [
-        CompilerMessages.Hint_NoDisplayForMarker({ id: 'mark-dotbelow' }),
-        CompilerMessages.Hint_NoDisplayForMarker({ id: 'mark-dotbelowabove' }),
-        CompilerMessages.Hint_NoDisplayForSwitch({ id: 'rebase' }),
+        LdmlCompilerMessages.Hint_NoDisplayForMarker({ id: 'mark-dotbelow' }),
+        LdmlCompilerMessages.Hint_NoDisplayForMarker({ id: 'mark-dotbelowabove' }),
+        LdmlCompilerMessages.Hint_NoDisplayForSwitch({ id: 'rebase' }),
       ];
       const kmx = await compileKeyboard(inputFilename, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false },
         msgs,

--- a/developer/src/kmc-ldml/test/test-loca.ts
+++ b/developer/src/kmc-ldml/test/test-loca.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { LocaCompiler } from '../src/compiler/loca.js';
 import { compilerTestCallbacks, loadSectionFixture } from './helpers/index.js';
 import { KMXPlus } from '@keymanapp/common-types';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 
 import Loca = KMXPlus.Loca;
 
@@ -26,10 +26,10 @@ describe('loca', function () {
 
     // Note: multiple.xml includes fr-FR twice, with differing case, which should be canonicalized
     assert.equal(compilerTestCallbacks.messages.length, 4);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale: 'fr-FR', locale: 'fr'}));
-    assert.deepEqual(compilerTestCallbacks.messages[1], CompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale: 'km-khmr-kh', locale: 'km'}));
-    assert.deepEqual(compilerTestCallbacks.messages[2], CompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale: 'fr-fr', locale: 'fr'}));
-    assert.deepEqual(compilerTestCallbacks.messages[3], CompilerMessages.Hint_OneOrMoreRepeatedLocales());
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale: 'fr-FR', locale: 'fr'}));
+    assert.deepEqual(compilerTestCallbacks.messages[1], LdmlCompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale: 'km-khmr-kh', locale: 'km'}));
+    assert.deepEqual(compilerTestCallbacks.messages[2], LdmlCompilerMessages.Hint_LocaleIsNotMinimalAndClean({sourceLocale: 'fr-fr', locale: 'fr'}));
+    assert.deepEqual(compilerTestCallbacks.messages[3], LdmlCompilerMessages.Hint_OneOrMoreRepeatedLocales());
 
     // Original is 6 locales, now five minimized in the results
     assert.equal(loca.locales.length, 5);
@@ -46,6 +46,6 @@ describe('loca', function () {
     assert.equal(compilerTestCallbacks.messages.length, 1);
     // We'll only test one invalid BCP 47 tag to verify that we are properly calling BCP 47 validation routines.
     // Furthermore, we are testing BCP 47 structure, not the validity of each subtag -- we must assume the author knows of new subtags!
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_InvalidLocale({tag:'en-*'}));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_InvalidLocale({tag:'en-*'}));
   })
 });

--- a/developer/src/kmc-ldml/test/test-messages.ts
+++ b/developer/src/kmc-ldml/test/test-messages.ts
@@ -1,10 +1,10 @@
 import 'mocha';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 import { verifyCompilerMessagesObject } from '@keymanapp/developer-test-helpers';
 import { CompilerErrorNamespace } from '@keymanapp/common-types';
 
-describe('CompilerMessages', function () {
-  it('should have a valid CompilerMessages object', function() {
-    return verifyCompilerMessagesObject(CompilerMessages, CompilerErrorNamespace.LdmlKeyboardCompiler);
+describe('LdmlCompilerMessages', function () {
+  it('should have a valid LdmlCompilerMessages object', function() {
+    return verifyCompilerMessagesObject(LdmlCompilerMessages, CompilerErrorNamespace.LdmlKeyboardCompiler);
   });
 });

--- a/developer/src/kmc-ldml/test/test-meta.ts
+++ b/developer/src/kmc-ldml/test/test-meta.ts
@@ -3,7 +3,7 @@ import {assert} from 'chai';
 import { MetaCompiler } from '../src/compiler/meta.js';
 import { compilerTestCallbacks, loadSectionFixture } from './helpers/index.js';
 import { KMXPlus } from '@keymanapp/common-types';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 
 import KeyboardSettings = KMXPlus.KeyboardSettings;
 import Meta = KMXPlus.Meta;
@@ -39,19 +39,19 @@ describe('meta', function () {
     let meta = await loadSectionFixture(MetaCompiler, 'sections/meta/hint-normalization.xml', compilerTestCallbacks) as Meta;
     assert.isNotNull(meta);
     assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Hint_NormalizationDisabled());
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Hint_NormalizationDisabled());
   });
 
   it('should reject invalid version', async function() {
     let meta = await loadSectionFixture(MetaCompiler, 'sections/meta/invalid-version-1.0.xml', compilerTestCallbacks) as Meta;
     assert.isNull(meta);
     assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_InvalidVersion({version:'1.0'}));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_InvalidVersion({version:'1.0'}));
 
     meta = await loadSectionFixture(MetaCompiler, 'sections/meta/invalid-version-v1.0.3.xml', compilerTestCallbacks) as Meta;
     assert.isNull(meta);
     assert.equal(compilerTestCallbacks.messages.length, 1);
-    assert.deepEqual(compilerTestCallbacks.messages[0], CompilerMessages.Error_InvalidVersion({version:'v1.0.3'}));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_InvalidVersion({version:'v1.0.3'}));
   });
 });
 

--- a/developer/src/kmc-ldml/test/test-strs.ts
+++ b/developer/src/kmc-ldml/test/test-strs.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import { assert } from 'chai';
 import { compileKeyboard, compilerTestCallbacks, compilerTestOptions, makePathToFixture } from './helpers/index.js';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 
 
 /** strs tests */
@@ -17,8 +17,8 @@ describe('strs', function () {
         const kmx = await compileKeyboard(inputFilename, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false },
             [
                 // validation messages
-                CompilerMessages.Error_IllegalCharacters({ count: 5, lowestCh: 0xFDD0 }),
-                CompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
+                LdmlCompilerMessages.Error_IllegalCharacters({ count: 5, lowestCh: 0xFDD0 }),
+                LdmlCompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
             ],
             true, // validation should fail
             [
@@ -32,12 +32,12 @@ describe('strs', function () {
         const kmx = await compileKeyboard(inputFilename, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false },
             [
                 // validation messages
-                CompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
+                LdmlCompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
             ],
             false, // validation should pass
             [
                 // same messages
-                CompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
+                LdmlCompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
             ]);
         assert.isNotNull(kmx);
     });
@@ -47,14 +47,14 @@ describe('strs', function () {
         const kmx = await compileKeyboard(inputFilename, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false },
             [
                 // validation messages
-                CompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
-                CompilerMessages.Warn_UnassignedCharacters({ count: 1, lowestCh: 0x0CFFFD }),
+                LdmlCompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
+                LdmlCompilerMessages.Warn_UnassignedCharacters({ count: 1, lowestCh: 0x0CFFFD }),
             ],
             false, // validation should pass
             [
                 // same messages
-                CompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
-                CompilerMessages.Warn_UnassignedCharacters({ count: 1, lowestCh: 0x0CFFFD }),
+                LdmlCompilerMessages.Hint_PUACharacters({ count: 2, lowestCh: 0xE010 }),
+                LdmlCompilerMessages.Warn_UnassignedCharacters({ count: 1, lowestCh: 0x0CFFFD }),
             ]);
         assert.isNotNull(kmx);
     });
@@ -63,7 +63,7 @@ describe('strs', function () {
         const inputFilename = makePathToFixture('sections/tran/fail-bad-tran-2.xml');
         const kmx = await compileKeyboard(inputFilename, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false },
             [
-                CompilerMessages.Error_InvalidQuadEscape({ cp: 295 }),
+                LdmlCompilerMessages.Error_InvalidQuadEscape({ cp: 295 }),
             ],
             true, // validation should fail
             [

--- a/developer/src/kmc-ldml/test/test-tran.ts
+++ b/developer/src/kmc-ldml/test/test-tran.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import { assert } from 'chai';
 import { TranCompiler, BkspCompiler } from '../src/compiler/tran.js';
 import { BASIC_DEPENDENCIES, UsetCompiler } from '../src/compiler/empty-compiler.js';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 import { KmnCompilerMessages } from '@keymanapp/kmc-kmn';
 import { assertCodePoints, compilerTestCallbacks, testCompilationCases } from './helpers/index.js';
 import { KMXPlus, MarkerParser } from '@keymanapp/common-types';
@@ -120,7 +120,7 @@ describe('tran', function () {
           `\u{1f76}${m(1,false)}\u{033c}`);
       },
       warnings: [
-        CompilerMessages.Hint_NormalizationDisabled()
+        LdmlCompilerMessages.Hint_NormalizationDisabled()
       ],
     },    {
       subpath: 'sections/tran/fail-invalid-type.xml',
@@ -129,7 +129,7 @@ describe('tran', function () {
     {
       subpath: 'sections/tran/fail-duplicate-type.xml',
       errors: [
-        CompilerMessages.Error_DuplicateTransformsType({types: ['simple']})
+        LdmlCompilerMessages.Error_DuplicateTransformsType({types: ['simple']})
       ]
     },
     {
@@ -139,13 +139,13 @@ describe('tran', function () {
     {
       subpath: 'sections/tran/fail-mixed.xml',
       errors: [
-        CompilerMessages.Error_MixedTransformGroup(),
+        LdmlCompilerMessages.Error_MixedTransformGroup(),
       ],
     },
     {
       subpath: 'sections/tran/fail-empty.xml',
       errors: [
-        CompilerMessages.Error_EmptyTransformGroup(),
+        LdmlCompilerMessages.Error_EmptyTransformGroup(),
       ],
     },
     // reorder test
@@ -249,19 +249,19 @@ describe('tran', function () {
     {
       subpath: 'sections/tran/tran-warn-range.xml',
       warnings: [
-        CompilerMessages.Warn_CharClassExplicitDenorm({lowestCh: 0xE1}),
+        LdmlCompilerMessages.Warn_CharClassExplicitDenorm({lowestCh: 0xE1}),
       ],
     },
     {
       subpath: 'sections/tran/tran-hint-range.xml',
       warnings: [
-        CompilerMessages.Hint_CharClassImplicitDenorm({lowestCh: 0xc0}),
+        LdmlCompilerMessages.Hint_CharClassImplicitDenorm({lowestCh: 0xc0}),
       ],
     },
     {
       subpath: 'sections/tran/tran-hint-range2.xml',
       warnings: [
-        CompilerMessages.Hint_CharClassImplicitDenorm({lowestCh: 0xC0}),
+        LdmlCompilerMessages.Hint_CharClassImplicitDenorm({lowestCh: 0xC0}),
       ],
     },
     {
@@ -273,20 +273,20 @@ describe('tran', function () {
     {
       subpath: 'sections/tran/fail-bad-reorder-2.xml',
       errors: [
-        CompilerMessages.Error_InvalidQuadEscape({ cp: 0x1a6b }),
+        LdmlCompilerMessages.Error_InvalidQuadEscape({ cp: 0x1a6b }),
       ],
     },
     {
       subpath: 'sections/tran/fail-bad-reorder-3.xml',
       errors: [
-        CompilerMessages.Error_InvalidQuadEscape({ cp: 0x1a60 }),
+        LdmlCompilerMessages.Error_InvalidQuadEscape({ cp: 0x1a60 }),
       ],
     },
     // error due to bad regex
     {
       subpath: `sections/tran/fail-bad-tran-1.xml`,
       errors: [
-        { code: CompilerMessages.ERROR_UnparseableTransformFrom,
+        { code: LdmlCompilerMessages.ERROR_UnparseableTransformFrom,
           matchMessage: /Invalid regular expression.*Unterminated group/,
         }
       ],
@@ -295,43 +295,43 @@ describe('tran', function () {
       // also used in test-compiler-e2e.ts
       subpath: `sections/tran/fail-bad-tran-2.xml`,
       errors: [
-        CompilerMessages.Error_InvalidQuadEscape({ cp: 295 }),
+        LdmlCompilerMessages.Error_InvalidQuadEscape({ cp: 295 }),
       ],
     },
     {
       subpath: `sections/tran/fail-missing-var-1.xml`,
       errors: [
-        CompilerMessages.Error_MissingStringVariable({ id: "missingfrom" }),
+        LdmlCompilerMessages.Error_MissingStringVariable({ id: "missingfrom" }),
       ],
     },
     {
       subpath: `sections/tran/fail-missing-var-2.xml`,
       errors: [
-        CompilerMessages.Error_MissingStringVariable({ id: "missingto" }),
+        LdmlCompilerMessages.Error_MissingStringVariable({ id: "missingto" }),
       ],
     },
     {
       subpath: `sections/tran/fail-missing-var-3.xml`,
       errors: [
-        CompilerMessages.Error_MissingSetVariable({ id: "missingset" }),
+        LdmlCompilerMessages.Error_MissingSetVariable({ id: "missingset" }),
       ],
     },
     {
       subpath: `sections/tran/fail-missing-var-4.xml`,
       errors: [
-        CompilerMessages.Error_MissingSetVariable({ id: "missingset" }),
+        LdmlCompilerMessages.Error_MissingSetVariable({ id: "missingset" }),
       ],
     },
     {
       subpath: `sections/tran/fail-missing-var-5.xml`,
       errors: [
-        CompilerMessages.Error_MissingSetVariable({ id: "missingset" }),
+        LdmlCompilerMessages.Error_MissingSetVariable({ id: "missingset" }),
       ],
     },
     {
       subpath: `sections/tran/fail-missing-var-6.xml`,
       errors: [
-        CompilerMessages.Error_MissingStringVariable({ id: "missingstr" }),
+        LdmlCompilerMessages.Error_MissingStringVariable({ id: "missingstr" }),
       ],
     },
     // cases that share the same error code
@@ -339,7 +339,7 @@ describe('tran', function () {
       subpath: `sections/tran/fail-IllegalTransformDollarsign-${n}.xml`,
       errors: [
         {
-          code: CompilerMessages.ERROR_IllegalTransformDollarsign,
+          code: LdmlCompilerMessages.ERROR_IllegalTransformDollarsign,
           matchMessage: /.*/,
         }
       ],
@@ -348,7 +348,7 @@ describe('tran', function () {
       subpath: `sections/tran/fail-IllegalTransformAsterisk-${n}.xml`,
       errors: [
         {
-          code: CompilerMessages.ERROR_IllegalTransformAsterisk,
+          code: LdmlCompilerMessages.ERROR_IllegalTransformAsterisk,
           matchMessage: /.*/,
         }
       ],
@@ -357,7 +357,7 @@ describe('tran', function () {
       subpath: `sections/tran/fail-IllegalTransformPlus-${n}.xml`,
       errors: [
         {
-          code: CompilerMessages.ERROR_IllegalTransformPlus,
+          code: LdmlCompilerMessages.ERROR_IllegalTransformPlus,
           matchMessage: /.*/,
         }
       ],
@@ -372,7 +372,7 @@ describe('tran', function () {
       subpath: `sections/tran/fail-matches-nothing-${n}.xml`,
       errors: [
         {
-          code: CompilerMessages.ERROR_TransformFromMatchesNothing,
+          code: LdmlCompilerMessages.ERROR_TransformFromMatchesNothing,
           matchMessage: /.*/,
         }
       ],
@@ -411,7 +411,7 @@ describe('bksp', function () {
       subpath: 'sections/vars/fail-markers-badref-0.xml',
       strictErrors: true,
       errors: [
-        CompilerMessages.Error_MissingMarkers({
+        LdmlCompilerMessages.Error_MissingMarkers({
           ids: [
             'doesnt_exist_1',
             'doesnt_exist_2',

--- a/developer/src/kmc-ldml/test/test-vars.ts
+++ b/developer/src/kmc-ldml/test/test-vars.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import { assert } from 'chai';
 import { VarsCompiler } from '../src/compiler/vars.js';
-import { CompilerMessages } from '../src/compiler/messages.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
 import { KmnCompilerMessages } from '@keymanapp/kmc-kmn';
 import { testCompilationCases } from './helpers/index.js';
 import { KMXPlus, KMX } from '@keymanapp/common-types';
@@ -112,13 +112,13 @@ describe('vars', function () {
     {
       subpath: 'sections/vars/dup0.xml',
       errors: [
-        CompilerMessages.Error_DuplicateVariable({ids: 'y'})
+        LdmlCompilerMessages.Error_DuplicateVariable({ids: 'y'})
       ],
     },
     {
       subpath: 'sections/vars/dup1.xml',
       errors: [
-        CompilerMessages.Error_DuplicateVariable({ids: 'upper, y'})
+        LdmlCompilerMessages.Error_DuplicateVariable({ids: 'upper, y'})
       ],
     },
     {
@@ -148,43 +148,43 @@ describe('vars', function () {
     {
       subpath: 'sections/vars/fail-badref-0.xml',
       errors: [
-        CompilerMessages.Error_MissingStringVariable({id: "yes"}),
+        LdmlCompilerMessages.Error_MissingStringVariable({id: "yes"}),
       ],
     },
     {
       subpath: 'sections/vars/fail-badref-1.xml',
       errors: [
-        CompilerMessages.Error_MissingSetVariable({id: "lower"}),
+        LdmlCompilerMessages.Error_MissingSetVariable({id: "lower"}),
       ],
     },
     {
       subpath: 'sections/vars/fail-badref-2.xml',
       errors: [
-        CompilerMessages.Error_MissingStringVariable({ id: 'doesnotexist' })
+        LdmlCompilerMessages.Error_MissingStringVariable({ id: 'doesnotexist' })
       ],
     },
     {
       subpath: 'sections/vars/fail-badref-3.xml',
       errors: [
-        CompilerMessages.Error_MissingUnicodeSetVariable({id: 'doesnotexist'})
+        LdmlCompilerMessages.Error_MissingUnicodeSetVariable({id: 'doesnotexist'})
       ],
     },
     {
       subpath: 'sections/vars/fail-badref-4.xml',
       errors: [
-        CompilerMessages.Error_NeedSpacesBetweenSetVariables({item: '$[vowels]$[consonants]'})
+        LdmlCompilerMessages.Error_NeedSpacesBetweenSetVariables({item: '$[vowels]$[consonants]'})
       ],
     },
     {
       subpath: 'sections/vars/fail-badref-5.xml',
       errors: [
-        CompilerMessages.Error_CantReferenceSetFromUnicodeSet({id: 'nonUnicodeSet'})
+        LdmlCompilerMessages.Error_CantReferenceSetFromUnicodeSet({id: 'nonUnicodeSet'})
       ],
     },
     {
       subpath: 'sections/vars/fail-badref-6.xml',
       errors: [
-        CompilerMessages.Error_MissingStringVariable({id: 'missingStringInSet'})
+        LdmlCompilerMessages.Error_MissingStringVariable({id: 'missingStringInSet'})
       ],
     },
   ], varsDependencies);
@@ -211,7 +211,7 @@ describe('vars', function () {
       {
         subpath: 'sections/vars/fail-markers-badref-0.xml',
         errors: [
-          CompilerMessages.Error_MissingMarkers({
+          LdmlCompilerMessages.Error_MissingMarkers({
             ids: [
               'doesnt_exist_1',
               'doesnt_exist_2',

--- a/developer/src/kmc/src/messages/messageNamespaces.ts
+++ b/developer/src/kmc/src/messages/messageNamespaces.ts
@@ -2,7 +2,7 @@ import { CommonTypesMessages, CompilerErrorNamespace } from '@keymanapp/common-t
 import { AnalyzerMessages } from '@keymanapp/kmc-analyze';
 import { KeyboardInfoCompilerMessages } from '@keymanapp/kmc-keyboard-info';
 import { KmnCompilerMessages, KmwCompilerMessages } from '@keymanapp/kmc-kmn';
-import { LdmlKeyboardCompilerMessages } from '@keymanapp/kmc-ldml';
+import { LdmlCompilerMessages } from '@keymanapp/kmc-ldml';
 import { ModelCompilerMessages } from '@keymanapp/kmc-model';
 import { ModelInfoCompilerMessages } from '@keymanapp/kmc-model-info';
 import { PackageCompilerMessages } from '@keymanapp/kmc-package';
@@ -10,7 +10,7 @@ import { InfrastructureMessages } from './infrastructureMessages.js';
 
 // Maps every compiler error namespace to the corresponding implementation
 const messageNamespaces: Record<CompilerErrorNamespace, any> = {
-  [CompilerErrorNamespace.LdmlKeyboardCompiler]: LdmlKeyboardCompilerMessages,
+  [CompilerErrorNamespace.LdmlKeyboardCompiler]: LdmlCompilerMessages,
   [CompilerErrorNamespace.CommonTypes]: CommonTypesMessages,
   [CompilerErrorNamespace.KmnCompiler]: KmnCompilerMessages,
   [CompilerErrorNamespace.ModelCompiler]: ModelCompilerMessages,
@@ -33,7 +33,7 @@ export type CompilerMessageSource = {
 
 // TODO: consolidate with messageNamespaces above
 export const messageSources: Record<CompilerErrorNamespace, CompilerMessageSource> = {
-  [CompilerErrorNamespace.LdmlKeyboardCompiler]: { module: 'kmc-ldml',          class: LdmlKeyboardCompilerMessages },
+  [CompilerErrorNamespace.LdmlKeyboardCompiler]: { module: 'kmc-ldml',          class: LdmlCompilerMessages },
   [CompilerErrorNamespace.CommonTypes]:          { module: 'common-types',      class: CommonTypesMessages },
   [CompilerErrorNamespace.KmnCompiler]:          { module: 'kmc-kmn',           class: KmnCompilerMessages },
   [CompilerErrorNamespace.ModelCompiler]:        { module: 'kmc-model',         class: ModelCompilerMessages },


### PR DESCRIPTION
It is easier to differentiate between all the compiler message classes if each one has its own name; and this makes it consistent with other compiler message classes and removes one more unnecessary alias.

BREAKING: `LdmlKeyboardCompilerMessages` export is renamed to `LdmlCompilerMessages`.

@keymanapp-test-bot skip