### PR TITLE
chore(developer): rename kmc-package `CompilerMessages` to `PackageCompilerMessages`

### DIFF
--- a/developer/src/kmc-package/src/compiler/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/kmp-compiler.ts
@@ -3,7 +3,7 @@ import JSZip from 'jszip';
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
 
 import { KmpJsonFile, KpsFile, SchemaValidators, CompilerCallbacks, KeymanFileTypes, KvkFile, KeymanCompiler, CompilerOptions, KeymanCompilerResult, KeymanCompilerArtifacts, KeymanCompilerArtifact } from '@keymanapp/common-types';
-import { CompilerMessages } from './package-compiler-messages.js';
+import { PackageCompilerMessages } from './package-compiler-messages.js';
 import { PackageMetadataCollector } from './package-metadata-collector.js';
 import { KmpInfWriter } from './kmp-inf-writer.js';
 import { transcodeToCP1252 } from './cp1252.js';
@@ -172,7 +172,7 @@ export class KmpCompiler implements KeymanCompiler {
     // Load the KPS data from XML as JS structured data.
     const buffer = this.callbacks.loadFile(kpsFilename);
     if(!buffer) {
-      this.callbacks.reportMessage(CompilerMessages.Error_FileDoesNotExist({filename: kpsFilename}));
+      this.callbacks.reportMessage(PackageCompilerMessages.Error_FileDoesNotExist({filename: kpsFilename}));
       return null;
     }
     const data = new TextDecoder().decode(buffer);
@@ -186,7 +186,7 @@ export class KmpCompiler implements KeymanCompiler {
         try {
           parser.parseString(data, (e: unknown, r: unknown) => { if(e) throw e; a = r as KpsFile.KpsPackage });
         } catch(e) {
-          this.callbacks.reportMessage(CompilerMessages.Error_InvalidPackageFile({e}));
+          this.callbacks.reportMessage(PackageCompilerMessages.Error_InvalidPackageFile({e}));
         }
         return a;
     })();
@@ -277,7 +277,7 @@ export class KmpCompiler implements KeymanCompiler {
       if(!kmp.files.reduce((result: boolean, file) => {
         if(!file.name) {
           // as the filename field is missing or blank, we'll try with the description instead
-          this.callbacks.reportMessage(CompilerMessages.Error_FileRecordIsMissingName({description: file.description ?? '(no description)'}));
+          this.callbacks.reportMessage(PackageCompilerMessages.Error_FileRecordIsMissingName({description: file.description ?? '(no description)'}));
           return false;
         }
         return result;
@@ -509,14 +509,14 @@ export class KmpCompiler implements KeymanCompiler {
 
       if(this.callbacks.path.isAbsolute(filename)) {
         // absolute paths are not portable to other computers
-        this.callbacks.reportMessage(CompilerMessages.Warn_AbsolutePath({filename: filename}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Warn_AbsolutePath({filename: filename}));
       }
 
       filename = this.callbacks.resolveFilename(kpsFilename, filename);
       const basename = this.callbacks.path.basename(filename);
 
       if(!this.callbacks.fs.existsSync(filename)) {
-        this.callbacks.reportMessage(CompilerMessages.Error_FileDoesNotExist({filename: filename}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Error_FileDoesNotExist({filename: filename}));
         failed = true;
         return;
       }
@@ -525,7 +525,7 @@ export class KmpCompiler implements KeymanCompiler {
       try {
         memberFileData = this.callbacks.loadFile(filename);
       } catch(e) {
-        this.callbacks.reportMessage(CompilerMessages.Error_FileCouldNotBeRead({filename: filename, e: e}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Error_FileCouldNotBeRead({filename: filename, e: e}));
         failed = true;
         return;
       }
@@ -605,7 +605,7 @@ export class KmpCompiler implements KeymanCompiler {
       data[1] != KvkFile.KVK_HEADER_IDENTIFIER_BYTES[1] ||
       data[2] != KvkFile.KVK_HEADER_IDENTIFIER_BYTES[2] ||
       data[3] != KvkFile.KVK_HEADER_IDENTIFIER_BYTES[3]) {
-      this.callbacks.reportMessage(CompilerMessages.Warn_FileIsNotABinaryKvkFile({filename: filename}));
+      this.callbacks.reportMessage(PackageCompilerMessages.Warn_FileIsNotABinaryKvkFile({filename: filename}));
     }
   }
 }

--- a/developer/src/kmc-package/src/compiler/package-compiler-messages.ts
+++ b/developer/src/kmc-package/src/compiler/package-compiler-messages.ts
@@ -10,7 +10,7 @@ const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 /**
  * @internal
  */
-export class CompilerMessages {
+export class PackageCompilerMessages {
   static FATAL_UnexpectedException = SevFatal | 0x0001;
   static Fatal_UnexpectedException = (o:{e: any}) => CompilerMessageSpecWithException(this.FATAL_UnexpectedException, null, o.e ?? 'unknown error');
 

--- a/developer/src/kmc-package/src/compiler/package-keyboard-target-validator.ts
+++ b/developer/src/kmc-package/src/compiler/package-keyboard-target-validator.ts
@@ -1,5 +1,5 @@
 import { KeymanTargets, CompilerCallbacks, KmpJsonFile } from "@keymanapp/common-types";
-import { CompilerMessages } from "./package-compiler-messages.js";
+import { PackageCompilerMessages } from "./package-compiler-messages.js";
 import { KeyboardMetadataCollection } from "./package-metadata-collector.js";
 
 
@@ -15,7 +15,7 @@ export class PackageKeyboardTargetValidator {
         hasJS = this.verifyTargets(metadata[keyboard].keyboard, metadata[keyboard].data.targets, kmp);
       }
       if(hasJS && !metadata[keyboard].data.hasTouchLayout) {
-        this.callbacks.reportMessage(CompilerMessages.Hint_JsKeyboardFileHasNoTouchTargets({id: metadata[keyboard].keyboard.id}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Hint_JsKeyboardFileHasNoTouchTargets({id: metadata[keyboard].keyboard.id}));
       }
     }
   }
@@ -38,7 +38,7 @@ export class PackageKeyboardTargetValidator {
     if(targets.some(target => KeymanTargets.TouchKeymanTargets.includes(target))) {
       if(!kmp.files.find(file => this.callbacks.path.basename(file.name ?? '', '.js') == keyboard.id)) {
         // .js version of the keyboard is not found, warn
-        this.callbacks.reportMessage(CompilerMessages.Warn_JsKeyboardFileIsMissing({id: keyboard.id}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Warn_JsKeyboardFileIsMissing({id: keyboard.id}));
         return false;
       }
       // A js file is included and targeted

--- a/developer/src/kmc-package/src/compiler/package-metadata-collector.ts
+++ b/developer/src/kmc-package/src/compiler/package-metadata-collector.ts
@@ -1,6 +1,6 @@
 import { KmpJsonFile, CompilerCallbacks, KmxFileReader, KmxFileReaderError, KMX, KeymanFileTypes } from '@keymanapp/common-types';
 import { getCompiledKmxKeyboardMetadata } from './kmx-keyboard-metadata.js';
-import { CompilerMessages } from './package-compiler-messages.js';
+import { PackageCompilerMessages } from './package-compiler-messages.js';
 import { getCompiledWebKeyboardMetadata, WebKeyboardMetadata } from './web-keyboard-metadata.js';
 
 export type KeyboardMetadata = {
@@ -45,19 +45,19 @@ export class PackageMetadataCollector {
       isJavascript = true;
       file = kmp.files.find(file => this.callbacks.path.basename(file.name ?? '', KeymanFileTypes.Binary.WebKeyboard) == keyboard.id);
       if(!file) {
-        this.callbacks.reportMessage(CompilerMessages.Error_KeyboardContentFileNotFound({id:keyboard.id}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Error_KeyboardContentFileNotFound({id:keyboard.id}));
         return null;
       }
     }
 
     if(!file.name) {
-      this.callbacks.reportMessage(CompilerMessages.Error_FileRecordIsMissingName({description: file.description ?? '(no description)'}));
+      this.callbacks.reportMessage(PackageCompilerMessages.Error_FileRecordIsMissingName({description: file.description ?? '(no description)'}));
       return null;
     }
 
     const filename = this.callbacks.resolveFilename(kpsFilename, file.name);
     if(!this.callbacks.fs.existsSync(filename)) {
-      this.callbacks.reportMessage(CompilerMessages.Error_KeyboardFileNotFound({filename}));
+      this.callbacks.reportMessage(PackageCompilerMessages.Error_KeyboardFileNotFound({filename}));
       return null;
     }
 
@@ -68,7 +68,7 @@ export class PackageMetadataCollector {
     try {
       fileData = this.callbacks.loadFile(filename);
     } catch(e) {
-      this.callbacks.reportMessage(CompilerMessages.Error_FileCouldNotBeRead({filename, e}));
+      this.callbacks.reportMessage(PackageCompilerMessages.Error_FileCouldNotBeRead({filename, e}));
       return null;
     }
 
@@ -83,7 +83,7 @@ export class PackageMetadataCollector {
       } catch(e) {
         if(e instanceof KmxFileReaderError) {
           // The file couldn't be read, it might not be a .kmx file
-          this.callbacks.reportMessage(CompilerMessages.Error_KeyboardFileNotValid({filename, e}));
+          this.callbacks.reportMessage(PackageCompilerMessages.Error_KeyboardFileNotValid({filename, e}));
           return null;
         } else {
           // Unknown error, bubble it up

--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -1,5 +1,5 @@
 import { KmpJsonFile, CompilerCallbacks, CompilerOptions, KeymanFileTypes } from '@keymanapp/common-types';
-import { CompilerMessages } from './package-compiler-messages.js';
+import { PackageCompilerMessages } from './package-compiler-messages.js';
 import { keymanEngineForWindowsFiles, keymanForWindowsInstallerFiles, keymanForWindowsRedistFiles } from './redist-files.js';
 import { isValidEmail } from '@keymanapp/developer-utils';
 
@@ -49,9 +49,9 @@ export class PackageValidation {
 
     if(languages.length == 0) {
       if(resourceType == 'keyboard') {
-        this.callbacks.reportMessage(CompilerMessages.Warn_KeyboardShouldHaveAtLeastOneLanguage({id}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Warn_KeyboardShouldHaveAtLeastOneLanguage({id}));
       } else {
-        this.callbacks.reportMessage(CompilerMessages.Error_ModelMustHaveAtLeastOneLanguage({id}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Error_ModelMustHaveAtLeastOneLanguage({id}));
         return false;
       }
     }
@@ -61,18 +61,18 @@ export class PackageValidation {
       try {
         locale = new Intl.Locale(lang.id);
       } catch(e: any) {
-        this.callbacks.reportMessage(CompilerMessages.Error_LanguageTagIsNotValid({resourceType, id, lang: lang.id, e}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Error_LanguageTagIsNotValid({resourceType, id, lang: lang.id, e}));
         return false;
       }
 
       const minimalTag = locale.minimize().toString();
 
       if(minimalTag.toLowerCase() !== lang.id.toLowerCase()) {
-        this.callbacks.reportMessage(CompilerMessages.Hint_LanguageTagIsNotMinimal({resourceType, id, actual: lang.id, expected: minimalTag}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Hint_LanguageTagIsNotMinimal({resourceType, id, actual: lang.id, expected: minimalTag}));
       }
 
       if(minimalTags[minimalTag]) {
-        this.callbacks.reportMessage(CompilerMessages.Hint_PackageShouldNotRepeatLanguages({resourceType, id, minimalTag, firstTag: lang.id, secondTag: minimalTags[minimalTag]}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Hint_PackageShouldNotRepeatLanguages({resourceType, id, minimalTag, firstTag: lang.id, secondTag: minimalTags[minimalTag]}));
       }
       else {
         minimalTags[minimalTag] = lang.id;
@@ -84,7 +84,7 @@ export class PackageValidation {
 
   private checkForModelsAndKeyboardsInSamePackage(kmpJson: KmpJsonFile.KmpJsonFile): boolean {
     if(kmpJson.lexicalModels?.length > 0 && kmpJson.keyboards?.length > 0) {
-      this.callbacks.reportMessage(CompilerMessages.Error_PackageCannotContainBothModelsAndKeyboards());
+      this.callbacks.reportMessage(PackageCompilerMessages.Error_PackageCannotContainBothModelsAndKeyboards());
       return false;
     }
 
@@ -92,7 +92,7 @@ export class PackageValidation {
       // Note: we require at least 1 keyboard or model in the package. This may
       // change in the future if we start to use packages to distribute, e.g.
       // localizations or themes.
-      this.callbacks.reportMessage(CompilerMessages.Error_PackageMustContainAModelOrAKeyboard());
+      this.callbacks.reportMessage(PackageCompilerMessages.Error_PackageMustContainAModelOrAKeyboard());
       return false;
     }
 
@@ -109,7 +109,7 @@ export class PackageValidation {
     filename = this.callbacks.path.basename(filename);
 
     if(!MODEL_ID_PATTERN_PACKAGE.test(filename)) {
-      this.callbacks.reportMessage(CompilerMessages.Warn_PackageNameDoesNotFollowLexicalModelConventions({filename}));
+      this.callbacks.reportMessage(PackageCompilerMessages.Warn_PackageNameDoesNotFollowLexicalModelConventions({filename}));
     }
 
     for(let model of kmpJson.lexicalModels) {
@@ -129,7 +129,7 @@ export class PackageValidation {
     filename = this.callbacks.path.basename(filename);
 
     if(!KEYBOARD_ID_PATTERN_PACKAGE.test(filename)) {
-      this.callbacks.reportMessage(CompilerMessages.Warn_PackageNameDoesNotFollowKeyboardConventions({filename}));
+      this.callbacks.reportMessage(PackageCompilerMessages.Warn_PackageNameDoesNotFollowKeyboardConventions({filename}));
     }
 
     for(let keyboard of kmpJson.keyboards) {
@@ -159,7 +159,7 @@ export class PackageValidation {
     const base = filename.substring(0, filename.length-ext.length);
     if(this.options.checkFilenameConventions) {
       if(!CONTENT_FILE_BASENAME_PATTERN.test(base) || !CONTENT_FILE_EXTENSION_PATTERN.test(ext)) {
-        this.callbacks.reportMessage(CompilerMessages.Warn_FileInPackageDoesNotFollowFilenameConventions({filename}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Warn_FileInPackageDoesNotFollowFilenameConventions({filename}));
       }
     }
 
@@ -178,13 +178,13 @@ export class PackageValidation {
     if(keymanForWindowsInstallerFiles.includes(filename) ||
         keymanForWindowsRedistFiles.includes(filename) ||
         keymanEngineForWindowsFiles.includes(filename)) {
-      this.callbacks.reportMessage(CompilerMessages.Warn_RedistFileShouldNotBeInPackage({filename}));
+      this.callbacks.reportMessage(PackageCompilerMessages.Warn_RedistFileShouldNotBeInPackage({filename}));
     }
 
     // # Test for inclusion of .doc or .docx files
 
     if(filename.match(/\.doc(x?)$/)) {
-      this.callbacks.reportMessage(CompilerMessages.Warn_DocFileDangerous({filename}));
+      this.callbacks.reportMessage(PackageCompilerMessages.Warn_DocFileDangerous({filename}));
     }
 
     // # Test for inclusion of keyboard source files
@@ -197,7 +197,7 @@ export class PackageValidation {
     // which may be valid, not just LDML keyboards
     const fileType = KeymanFileTypes.sourceTypeFromFilename(file.name);
     if(fileType !== null && fileType !== KeymanFileTypes.Source.LdmlKeyboard) {
-      this.callbacks.reportMessage(CompilerMessages.Hint_PackageContainsSourceFile({filename: file.name}));
+      this.callbacks.reportMessage(PackageCompilerMessages.Hint_PackageContainsSourceFile({filename: file.name}));
     }
 
     return true;
@@ -205,7 +205,7 @@ export class PackageValidation {
 
   private checkPackageInfo(file: KmpJsonFile.KmpJsonFile) {
     if(!file.info || !file.info.name || !file.info.name.description.trim()) {
-      this.callbacks.reportMessage(CompilerMessages.Error_PackageNameCannotBeBlank());
+      this.callbacks.reportMessage(PackageCompilerMessages.Error_PackageNameCannotBeBlank());
       return false;
     }
 
@@ -214,11 +214,11 @@ export class PackageValidation {
       const match = file.info.author.url.match(/^(mailto\:)?(.+)$/);
       /* c8 ignore next 3 */
       if (match === null) {
-        this.callbacks.reportMessage(CompilerMessages.Error_InvalidAuthorEmail({email:file.info.author.url}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Error_InvalidAuthorEmail({email:file.info.author.url}));
         return null;
       }
       if(!isValidEmail(match[2])) {
-        this.callbacks.reportMessage(CompilerMessages.Error_InvalidAuthorEmail({email:file.info.author.url}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Error_InvalidAuthorEmail({email:file.info.author.url}));
         return null;
       }
 

--- a/developer/src/kmc-package/src/compiler/package-version-validator.ts
+++ b/developer/src/kmc-package/src/compiler/package-version-validator.ts
@@ -1,5 +1,5 @@
 import { KmpJsonFile, CompilerCallbacks, KpsFile } from '@keymanapp/common-types';
-import { CompilerMessages } from './package-compiler-messages.js';
+import { PackageCompilerMessages } from './package-compiler-messages.js';
 import { KeyboardMetadataCollection } from './package-metadata-collector.js';
 
 export const DEFAULT_KEYBOARD_VERSION = '1.0';
@@ -65,13 +65,13 @@ export class PackageVersionValidator {
       // most up-to-date keyboard version data here, from the compiled keyboard.
 
       if(followKeyboardVersion && data.data.keyboardVersion === null) {
-        this.callbacks.reportMessage(CompilerMessages.Info_KeyboardFileHasNoKeyboardVersion({filename: keyboard.id}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Info_KeyboardFileHasNoKeyboardVersion({filename: keyboard.id}));
       }
       keyboard.version = data.data.keyboardVersion ?? DEFAULT_KEYBOARD_VERSION;
 
       if(result && followKeyboardVersion) {
         if(kmp.keyboards[0].version !== keyboard.version) {
-          this.callbacks.reportMessage(CompilerMessages.Warn_KeyboardVersionsDoNotMatch({
+          this.callbacks.reportMessage(PackageCompilerMessages.Warn_KeyboardVersionsDoNotMatch({
             keyboard: keyboard.id,
             version: keyboard.version,
             firstKeyboard: kmp.keyboards[0].id,
@@ -91,12 +91,12 @@ export class PackageVersionValidator {
   private checkFollowKeyboardVersion(kmp: KmpJsonFile.KmpJsonFile) {
     // Lexical model packages do not allow FollowKeyboardVersion
     if(kmp.lexicalModels && kmp.lexicalModels.length) {
-      this.callbacks.reportMessage(CompilerMessages.Error_FollowKeyboardVersionNotAllowedForModelPackages());
+      this.callbacks.reportMessage(PackageCompilerMessages.Error_FollowKeyboardVersionNotAllowedForModelPackages());
       return false;
     }
 
     if(!kmp.keyboards || !kmp.keyboards.length) {
-      this.callbacks.reportMessage(CompilerMessages.Error_FollowKeyboardVersionButNoKeyboards());
+      this.callbacks.reportMessage(PackageCompilerMessages.Error_FollowKeyboardVersionButNoKeyboards());
       return false;
     }
 

--- a/developer/src/kmc-package/src/compiler/windows-package-installer-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/windows-package-installer-compiler.ts
@@ -14,7 +14,7 @@ import JSZip from 'jszip';
 import { CompilerCallbacks, KeymanCompiler, KeymanCompilerArtifact, KeymanCompilerArtifacts, KeymanCompilerResult, KeymanFileTypes, KmpJsonFile, KpsFile } from "@keymanapp/common-types";
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
 import { KmpCompiler, KmpCompilerOptions } from "./kmp-compiler.js";
-import { CompilerMessages } from "./package-compiler-messages.js";
+import { PackageCompilerMessages } from "./package-compiler-messages.js";
 
 const SETUP_INF_FILENAME = 'setup.inf';
 const PRODUCT_NAME = 'Keyman';
@@ -120,7 +120,7 @@ export class WindowsPackageInstallerCompiler implements KeymanCompiler {
     // Check existence of required files
     for(const filename of [sources.licenseFilename, sources.msiFilename, sources.setupExeFilename]) {
       if(!this.callbacks.fs.existsSync(filename)) {
-        this.callbacks.reportMessage(CompilerMessages.Error_FileDoesNotExist({filename}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Error_FileDoesNotExist({filename}));
         return null;
       }
     }
@@ -128,7 +128,7 @@ export class WindowsPackageInstallerCompiler implements KeymanCompiler {
     // Check existence of optional files
     for(const filename of [sources.titleImageFilename]) {
       if(filename && !this.callbacks.fs.existsSync(filename)) {
-        this.callbacks.reportMessage(CompilerMessages.Error_FileDoesNotExist({filename}));
+        this.callbacks.reportMessage(PackageCompilerMessages.Error_FileDoesNotExist({filename}));
         return null;
       }
     }
@@ -175,7 +175,7 @@ export class WindowsPackageInstallerCompiler implements KeymanCompiler {
   private async buildZip(kps: KpsFile.KpsFile, kpsFilename: string, sources: WindowsPackageInstallerSources): Promise<Uint8Array> {
     const kmpJson: KmpJsonFile.KmpJsonFile = this.kmpCompiler.transformKpsFileToKmpObject(kpsFilename, kps);
     if(!kmpJson.info?.name?.description) {
-      this.callbacks.reportMessage(CompilerMessages.Error_PackageNameCannotBeBlank());
+      this.callbacks.reportMessage(PackageCompilerMessages.Error_PackageNameCannotBeBlank());
       return null;
     }
 

--- a/developer/src/kmc-package/src/main.ts
+++ b/developer/src/kmc-package/src/main.ts
@@ -7,4 +7,4 @@ export {
   WindowsPackageInstallerCompilerResult,
   WindowsPackageInstallerCompilerArtifacts,
 } from "./compiler/windows-package-installer-compiler.js";
-export { CompilerMessages as PackageCompilerMessages } from './compiler/package-compiler-messages.js';
+export { PackageCompilerMessages } from './compiler/package-compiler-messages.js';

--- a/developer/src/kmc-package/test/test-messages.ts
+++ b/developer/src/kmc-package/test/test-messages.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import { assert } from 'chai';
 import { TestCompilerCallbacks, verifyCompilerMessagesObject } from '@keymanapp/developer-test-helpers';
-import { CompilerMessages } from '../src/compiler/package-compiler-messages.js';
+import { PackageCompilerMessages } from '../src/compiler/package-compiler-messages.js';
 import { makePathToFixture } from './helpers/index.js';
 import { KmpCompiler } from '../src/compiler/kmp-compiler.js';
 import { CompilerErrorNamespace, CompilerOptions } from '@keymanapp/common-types';
@@ -9,9 +9,9 @@ import { CompilerErrorNamespace, CompilerOptions } from '@keymanapp/common-types
 const debug = false;
 const callbacks = new TestCompilerCallbacks();
 
-describe('CompilerMessages', function () {
-  it('should have a valid CompilerMessages object', function() {
-    return verifyCompilerMessagesObject(CompilerMessages, CompilerErrorNamespace.PackageCompiler);
+describe('PackageCompilerMessages', function () {
+  it('should have a valid PackageCompilerMessages object', function() {
+    return verifyCompilerMessagesObject(PackageCompilerMessages, CompilerErrorNamespace.PackageCompiler);
   });
 
 
@@ -43,7 +43,7 @@ describe('CompilerMessages', function () {
   // WARN_FileIsNotABinaryKvkFile
 
   it('should generate WARN_FileIsNotABinaryKvkFile if a non-binary kvk file is included', async function() {
-    await testForMessage(this, ['xml_kvk_file', 'source', 'xml_kvk_file.kps'], CompilerMessages.WARN_FileIsNotABinaryKvkFile);
+    await testForMessage(this, ['xml_kvk_file', 'source', 'xml_kvk_file.kps'], PackageCompilerMessages.WARN_FileIsNotABinaryKvkFile);
   });
 
   it('should not warn if a binary kvk file is included', async function() {
@@ -53,70 +53,70 @@ describe('CompilerMessages', function () {
   // ERROR_FollowKeyboardVersionNotAllowedForModelPackages
 
   it('should generate ERROR_FollowKeyboardVersionNotAllowedForModelPackages if <FollowKeyboardVersion> is set for model packages', async function() {
-    await testForMessage(this, ['invalid', 'followkeyboardversion.qaa.sencoten.model.kps'], CompilerMessages.ERROR_FollowKeyboardVersionNotAllowedForModelPackages);
+    await testForMessage(this, ['invalid', 'followkeyboardversion.qaa.sencoten.model.kps'], PackageCompilerMessages.ERROR_FollowKeyboardVersionNotAllowedForModelPackages);
   });
 
   // ERROR_FollowKeyboardVersionButNoKeyboards
 
   it('should generate ERROR_FollowKeyboardVersionButNoKeyboards if <FollowKeyboardVersion> is set for a package with no keyboards', async function() {
-    await testForMessage(this, ['invalid', 'followkeyboardversion.empty.kps'], CompilerMessages.ERROR_FollowKeyboardVersionButNoKeyboards);
+    await testForMessage(this, ['invalid', 'followkeyboardversion.empty.kps'], PackageCompilerMessages.ERROR_FollowKeyboardVersionButNoKeyboards);
   });
 
   // ERROR_KeyboardContentFileNotFound
 
   it('should generate ERROR_KeyboardContentFileNotFound if a <Keyboard> is listed in a package but not found in <Files>', async function() {
-    await testForMessage(this, ['invalid', 'keyboardcontentfilenotfound.kps'], CompilerMessages.ERROR_KeyboardContentFileNotFound);
+    await testForMessage(this, ['invalid', 'keyboardcontentfilenotfound.kps'], PackageCompilerMessages.ERROR_KeyboardContentFileNotFound);
   });
 
   // ERROR_KeyboardFileNotValid
 
   it('should generate ERROR_KeyboardFileNotValid if a .kmx is not valid in <Files>', async function() {
-    await testForMessage(this, ['invalid', 'keyboardfilenotvalid.kps'], CompilerMessages.ERROR_KeyboardFileNotValid);
+    await testForMessage(this, ['invalid', 'keyboardfilenotvalid.kps'], PackageCompilerMessages.ERROR_KeyboardFileNotValid);
   });
 
   // INFO_KeyboardFileHasNoKeyboardVersion
 
   it('should generate INFO_KeyboardFileHasNoKeyboardVersion if <FollowKeyboardVersion> is set but keyboard has no version', async function() {
-    await testForMessage(this, ['invalid', 'nokeyboardversion.kps'], CompilerMessages.INFO_KeyboardFileHasNoKeyboardVersion);
+    await testForMessage(this, ['invalid', 'nokeyboardversion.kps'], PackageCompilerMessages.INFO_KeyboardFileHasNoKeyboardVersion);
   });
 
   // ERROR_PackageCannotContainBothModelsAndKeyboards
 
   it('should generate ERROR_PackageCannotContainBothModelsAndKeyboards if package has both keyboards and models', async function() {
-    await testForMessage(this, ['invalid', 'error_package_cannot_contain_both_models_and_keyboards.kps'], CompilerMessages.ERROR_PackageCannotContainBothModelsAndKeyboards);
+    await testForMessage(this, ['invalid', 'error_package_cannot_contain_both_models_and_keyboards.kps'], PackageCompilerMessages.ERROR_PackageCannotContainBothModelsAndKeyboards);
   });
 
   // HINT_PackageShouldNotRepeatLanguages (models)
 
   it('should generate HINT_PackageShouldNotRepeatLanguages if model has same language repeated', async function() {
-    await testForMessage(this, ['invalid', 'keyman.en.hint_package_should_not_repeat_languages.model.kps'], CompilerMessages.HINT_PackageShouldNotRepeatLanguages);
+    await testForMessage(this, ['invalid', 'keyman.en.hint_package_should_not_repeat_languages.model.kps'], PackageCompilerMessages.HINT_PackageShouldNotRepeatLanguages);
   });
 
   // HINT_PackageShouldNotRepeatLanguages (keyboards)
 
   it('should generate HINT_PackageShouldNotRepeatLanguages if keyboard has same language repeated', async function() {
-    await testForMessage(this, ['invalid', 'hint_package_should_not_repeat_languages.kps'], CompilerMessages.HINT_PackageShouldNotRepeatLanguages);
+    await testForMessage(this, ['invalid', 'hint_package_should_not_repeat_languages.kps'], PackageCompilerMessages.HINT_PackageShouldNotRepeatLanguages);
   });
 
   // WARN_PackageNameDoesNotFollowLexicalModelConventions
 
   it('should generate WARN_PackageNameDoesNotFollowLexicalModelConventions if filename has wrong conventions', async function() {
-    await testForMessage(this, ['invalid', 'WARN_PackageNameDoesNotFollowLexicalModelConventions.kps'], CompilerMessages.WARN_PackageNameDoesNotFollowLexicalModelConventions);
+    await testForMessage(this, ['invalid', 'WARN_PackageNameDoesNotFollowLexicalModelConventions.kps'], PackageCompilerMessages.WARN_PackageNameDoesNotFollowLexicalModelConventions);
   });
 
   // WARN_PackageNameDoesNotFollowKeyboardConventions
 
   it('should generate WARN_PackageNameDoesNotFollowKeyboardConventions if filename has wrong conventions', async function() {
-    await testForMessage(this, ['invalid', 'WARN_PackageNameDoesNotFollowKeyboardConventions.kps'], CompilerMessages.WARN_PackageNameDoesNotFollowKeyboardConventions);
+    await testForMessage(this, ['invalid', 'WARN_PackageNameDoesNotFollowKeyboardConventions.kps'], PackageCompilerMessages.WARN_PackageNameDoesNotFollowKeyboardConventions);
   });
 
   // WARN_FileInPackageDoesNotFollowFilenameConventions
 
   it('should generate WARN_FileInPackageDoesNotFollowFilenameConventions if content filename has wrong conventions', async function() {
     await testForMessage(this, ['invalid', 'warn_file_in_package_does_not_follow_filename_conventions.kps'],
-      CompilerMessages.WARN_FileInPackageDoesNotFollowFilenameConventions, {checkFilenameConventions: true});
+      PackageCompilerMessages.WARN_FileInPackageDoesNotFollowFilenameConventions, {checkFilenameConventions: true});
     await testForMessage(this, ['invalid', 'warn_file_in_package_does_not_follow_filename_conventions_2.kps'],
-      CompilerMessages.WARN_FileInPackageDoesNotFollowFilenameConventions, {checkFilenameConventions: true});
+      PackageCompilerMessages.WARN_FileInPackageDoesNotFollowFilenameConventions, {checkFilenameConventions: true});
   });
 
   // Test the inverse -- no warning generated if checkFilenameConventions is false
@@ -129,81 +129,81 @@ describe('CompilerMessages', function () {
   // ERROR_PackageNameCannotBeBlank
 
   it('should generate ERROR_PackageNameCannotBeBlank if package info has empty name', async function() {
-    await testForMessage(this, ['invalid', 'error_package_name_cannot_be_blank.kps'], CompilerMessages.ERROR_PackageNameCannotBeBlank); // blank field
-    await testForMessage(this, ['invalid', 'error_package_name_cannot_be_blank_2.kps'], CompilerMessages.ERROR_PackageNameCannotBeBlank); // missing field
+    await testForMessage(this, ['invalid', 'error_package_name_cannot_be_blank.kps'], PackageCompilerMessages.ERROR_PackageNameCannotBeBlank); // blank field
+    await testForMessage(this, ['invalid', 'error_package_name_cannot_be_blank_2.kps'], PackageCompilerMessages.ERROR_PackageNameCannotBeBlank); // missing field
   });
 
   // ERROR_KeyboardFileNotFound
 
   it('should generate ERROR_KeyboardFileNotFound if a <Keyboard> is listed in a package but not found in <Files>', async function() {
-    await testForMessage(this, ['invalid', 'keyboardfilenotfound.kps'], CompilerMessages.ERROR_KeyboardFileNotFound);
+    await testForMessage(this, ['invalid', 'keyboardfilenotfound.kps'], PackageCompilerMessages.ERROR_KeyboardFileNotFound);
   });
 
   // WARN_KeyboardVersionsDoNotMatch
 
   it('should generate WARN_KeyboardVersionsDoNotMatch if two <Keyboards> have different versions', async function() {
-    await testForMessage(this, ['invalid', 'warn_keyboard_versions_do_not_match.kps'], CompilerMessages.WARN_KeyboardVersionsDoNotMatch);
+    await testForMessage(this, ['invalid', 'warn_keyboard_versions_do_not_match.kps'], PackageCompilerMessages.WARN_KeyboardVersionsDoNotMatch);
   });
 
   // ERROR_LanguageTagIsNotValid
 
   it('should generate ERROR_LanguageTagIsNotValid if keyboard has an invalid language tag', async function() {
-    testForMessage(this, ['invalid', 'error_language_tag_is_not_valid.kps'], CompilerMessages.ERROR_LanguageTagIsNotValid);
+    testForMessage(this, ['invalid', 'error_language_tag_is_not_valid.kps'], PackageCompilerMessages.ERROR_LanguageTagIsNotValid);
   });
 
   // HINT_LanguageTagIsNotMinimal
 
   it('should generate HINT_LanguageTagIsNotMinimal if keyboard has a non-minimal language tag', async function() {
-    await testForMessage(this, ['invalid', 'hint_language_tag_is_not_minimal.kps'], CompilerMessages.HINT_LanguageTagIsNotMinimal);
+    await testForMessage(this, ['invalid', 'hint_language_tag_is_not_minimal.kps'], PackageCompilerMessages.HINT_LanguageTagIsNotMinimal);
   });
 
   // ERROR_ModelMustHaveAtLeastOneLanguage
 
   it('should generate ERROR_MustHaveAtLeastOneLanguage if model has zero language tags', async function() {
     await testForMessage(this, ['invalid', 'keyman.en.error_model_must_have_at_least_one_language.model.kps'],
-      CompilerMessages.ERROR_ModelMustHaveAtLeastOneLanguage);
+      PackageCompilerMessages.ERROR_ModelMustHaveAtLeastOneLanguage);
   });
 
   // WARN_RedistFileShouldNotBeInPackage
 
   it('should generate WARN_RedistFileShouldNotBeInPackage if package contains a redist file', async function() {
     await testForMessage(this, ['invalid', 'warn_redist_file_should_not_be_in_package.kps'],
-      CompilerMessages.WARN_RedistFileShouldNotBeInPackage);
+      PackageCompilerMessages.WARN_RedistFileShouldNotBeInPackage);
   });
 
   // WARN_DocFileDangerous
 
   it('should generate WARN_DocFileDangerous if package contains a .doc file', async function() {
     await testForMessage(this, ['invalid', 'warn_doc_file_dangerous.kps'],
-      CompilerMessages.WARN_DocFileDangerous);
+      PackageCompilerMessages.WARN_DocFileDangerous);
   });
 
   // ERROR_PackageMustContainAPackageOrAKeyboard
 
   it('should generate ERROR_PackageMustContainAModelOrAKeyboard if package contains no keyboard or model', async function() {
     await testForMessage(this, ['invalid', 'error_package_must_contain_a_model_or_a_keyboard.kps'],
-      CompilerMessages.ERROR_PackageMustContainAModelOrAKeyboard);
+      PackageCompilerMessages.ERROR_PackageMustContainAModelOrAKeyboard);
   });
 
   // WARN_JsKeyboardFileIsMissing
 
   it('should generate WARN_JsKeyboardFileIsMissing if package is missing corresponding .js for a touch .kmx', async function() {
     await testForMessage(this, ['invalid', 'warn_js_keyboard_file_is_missing.kps'],
-      CompilerMessages.WARN_JsKeyboardFileIsMissing);
+      PackageCompilerMessages.WARN_JsKeyboardFileIsMissing);
   });
 
   // WARN_KeyboardShouldHaveAtLeastOneLanguage
 
   it('should generate WARN_KeyboardShouldHaveAtLeastOneLanguage if keyboard has zero language tags', async function() {
     await testForMessage(this, ['invalid', 'warn_keyboard_should_have_at_least_one_language.kps'],
-      CompilerMessages.WARN_KeyboardShouldHaveAtLeastOneLanguage);
+      PackageCompilerMessages.WARN_KeyboardShouldHaveAtLeastOneLanguage);
   });
 
   // HINT_JsKeyboardFileHasNoTouchTargets
 
   it('should generate HINT_JsKeyboardFileHasNoTouchTargets if keyboard has no touch targets', async function() {
     await testForMessage(this, ['invalid', 'hint_js_keyboard_file_has_no_touch_targets.kps'],
-      CompilerMessages.HINT_JsKeyboardFileHasNoTouchTargets);
+      PackageCompilerMessages.HINT_JsKeyboardFileHasNoTouchTargets);
   });
 
   it('should not generate HINT_JsKeyboardFileHasNoTouchTargets if keyboard has a touch target', async function() {
@@ -214,26 +214,26 @@ describe('CompilerMessages', function () {
 
   it('should generate HINT_PackageContainsSourceFile if package contains a source file', async function() {
     await testForMessage(this, ['invalid', 'hint_source_file_should_not_be_in_package.kps'],
-      CompilerMessages.HINT_PackageContainsSourceFile);
+      PackageCompilerMessages.HINT_PackageContainsSourceFile);
   });
 
   // ERROR_InvalidPackageFile
 
   it('should generate ERROR_InvalidPackageFile if package source file contains invalid XML', async function() {
     await testForMessage(this, ['invalid', 'error_invalid_package_file.kps'],
-      CompilerMessages.ERROR_InvalidPackageFile);
+      PackageCompilerMessages.ERROR_InvalidPackageFile);
   });
 
   // ERROR_InvalidAuthorEmail
 
   it('should generate ERROR_InvalidAuthorEmail if author email address has multiple addresses', async function() {
     await testForMessage(this, ['invalid', 'error_invalid_author_email_multiple.kps'],
-      CompilerMessages.ERROR_InvalidAuthorEmail);
+      PackageCompilerMessages.ERROR_InvalidAuthorEmail);
   });
 
   it('should generate ERROR_InvalidAuthorEmail if author email address is formatted incorrectly', async function() {
     await testForMessage(this, ['invalid', 'error_invalid_author_email.kps'],
-      CompilerMessages.ERROR_InvalidAuthorEmail);
+      PackageCompilerMessages.ERROR_InvalidAuthorEmail);
   });
 
 });

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -11,7 +11,7 @@ import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { makePathToFixture } from './helpers/index.js';
 
 import { KmpCompiler } from '../src/compiler/kmp-compiler.js';
-import { CompilerMessages } from '../src/compiler/package-compiler-messages.js';
+import { PackageCompilerMessages } from '../src/compiler/package-compiler-messages.js';
 
 const debug = false;
 
@@ -214,8 +214,8 @@ describe('KmpCompiler', function () {
     if(debug) callbacks.printMessages();
 
     assert.lengthOf(callbacks.messages, 2);
-    assert.deepEqual(callbacks.messages[0].code, CompilerMessages.WARN_AbsolutePath);
-    assert.deepEqual(callbacks.messages[1].code, CompilerMessages.ERROR_FileDoesNotExist);
+    assert.deepEqual(callbacks.messages[0].code, PackageCompilerMessages.WARN_AbsolutePath);
+    assert.deepEqual(callbacks.messages[1].code, PackageCompilerMessages.ERROR_FileDoesNotExist);
   });
 
   // Testing path normalization
@@ -268,7 +268,7 @@ describe('KmpCompiler', function () {
   it(`should load a package with missing keyboard ID metadata`, function () {
     const kmpJson = kmpCompiler.transformKpsToKmpObject(makePathToFixture('invalid', 'missing_keyboard_id.kps'));
     assert.isNull(kmpJson); // with a missing keyboard_id, the package shouldn't load, but it shouldn't crash either
-    assert.deepEqual(callbacks.messages[0].code, CompilerMessages.ERROR_KeyboardContentFileNotFound);
+    assert.deepEqual(callbacks.messages[0].code, PackageCompilerMessages.ERROR_KeyboardContentFileNotFound);
 
   });
 


### PR DESCRIPTION
It is easier to differentiate between all the compiler message classes if each one has its own name.

@keymanapp-test-bot skip