### PR TITLE
feat(web): support transform tokenization when given a root context 📚 

### DIFF
--- a/common/web/lm-worker/src/main/correction/transform-tokenization.ts
+++ b/common/web/lm-worker/src/main/correction/transform-tokenization.ts
@@ -1,0 +1,51 @@
+import { applyTransform, type Tokenization } from "@keymanapp/models-templates";
+
+export function tokenizeTransform(
+  tokenize: (context: Context) => Tokenization,
+  context: Context,
+  transform: Transform
+): Transform[] {
+  // Context does not slide within this function.
+  const postContext = applyTransform(transform, context);
+  const postTokenization = tokenize(postContext).left;
+
+  let insert = transform.insert;
+
+  const tokenizedTransforms: Transform[] = [];
+  for(let index = postTokenization.length - 1; index >= 0; index--) {
+    const currentToken = postTokenization[index];
+    const textLen = currentToken.text.length;
+
+    if(textLen < insert.length) {
+      tokenizedTransforms.unshift({
+        insert: currentToken.text,
+        deleteLeft: 0
+      });
+
+      insert = insert.substring(0, insert.length - textLen);
+    } else {
+      tokenizedTransforms.unshift({
+        insert: insert,
+        deleteLeft: transform.deleteLeft
+      });
+      break;
+    }
+  }
+
+  return tokenizedTransforms;
+}
+
+// If and when we look to do phrase-based suggestions and/or auto-correction on accidental
+// spaces, this function should prove useful.
+export function tokenizeTransformDistribution(
+  tokenize: (context: Context) => Tokenization,
+  context: Context,
+  transformDistribution: Distribution<Transform>
+): Distribution<Transform[]> {
+  return transformDistribution.map((transform) => {
+    return {
+      sample: tokenizeTransform(tokenize, context, transform.sample),
+      p: transform.p
+    };
+  });
+}

--- a/common/web/lm-worker/src/test/mocha/cases/transform-tokenization.js
+++ b/common/web/lm-worker/src/test/mocha/cases/transform-tokenization.js
@@ -1,0 +1,377 @@
+import { assert } from 'chai';
+
+import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
+
+import { tokenize } from '@keymanapp/models-templates';
+import { tokenizeTransform } from '#./correction/transform-tokenization.js';
+
+const defaultTokenize = (context) => tokenize(defaultBreaker, context);
+
+describe('tokenizeTransform', () => {
+  describe('with default wordbreaking', () => {
+    it('properly handles simple token-edit transform', () => {
+      const context = {
+        left: 'an apple a date',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: 'y',
+        deleteLeft: 2
+      };
+
+      const result = tokenizeTransform(
+        defaultTokenize,
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 1);
+      assert.deepEqual(result[0], editTransform);
+    });
+
+    it('properly handles simple token-replacing transform', () => {
+      const context = {
+        left: 'an apple a date',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: 'week',
+        deleteLeft: 4
+      };
+
+      const result = tokenizeTransform(
+        defaultTokenize,
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 1);
+      assert.deepEqual(result[0], editTransform);
+    });
+
+    it('handles simple token-replacing transform with cross-token deleteLeft', () => {
+      const context = {
+        left: 'an apple a date',
+        right: ''
+      };
+
+      // 'an apple any'
+      const editTransform = {
+        insert: 'ny',
+        deleteLeft: 6
+      };
+
+      const result = tokenizeTransform(
+        defaultTokenize,
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 1);
+      assert.deepEqual(result[0], editTransform);
+    });
+
+    it('properly handles a simple appended whitespace', () => {
+      const context = {
+        left: 'an apple a day',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: ' ',
+        deleteLeft: 0
+      };
+
+      const result = tokenizeTransform(
+        defaultTokenize,
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 2);
+      assert.deepEqual(result, [
+        // The whitespace belongs on the whitespace token that will be added.
+        editTransform,
+        // The default-breaker adds an empty token after whitespace, hence this
+        // empty transform.
+        { insert: '', deleteLeft: 0 }
+      ]);
+    });
+
+    it('properly handles a simple appended period', () => {
+      const context = {
+        left: 'an apple a day',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: '.',
+        deleteLeft: 0
+      };
+
+      const result = tokenizeTransform(
+        defaultTokenize,
+        context,
+        editTransform
+      );
+
+      // The default wordbreaker does not (currently) append a blank token
+      // after standard English punctuation.
+      assert.equal(result.length, 1);
+      assert.deepEqual(result, [
+        editTransform
+      ]);
+    });
+
+    it('handles word-breakable transforms (case 1)', () => {
+      const context = {
+        left: 'an apple a dat',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: 'y k',
+        deleteLeft: 1
+      };
+
+      const result = tokenizeTransform(
+        defaultTokenize,
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 3);
+      assert.deepEqual(result, [
+        { insert: 'y', deleteLeft: 1 },
+        { insert: ' ', deleteLeft: 0 },
+        { insert: 'k', deleteLeft: 0 }
+      ]);
+    });
+
+    it('handles word-breakable transforms (case 2)', () => {
+      const context = {
+        left: 'an apple a dat',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: 'y. ',
+        deleteLeft: 1
+      };
+
+      const result = tokenizeTransform(
+        defaultTokenize,
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 4);
+      assert.deepEqual(result, [
+        { insert: 'y', deleteLeft: 1 },
+        { insert: '.', deleteLeft: 0 },
+        { insert: ' ', deleteLeft: 0 },
+        { insert: '', deleteLeft: 0 }
+      ]);
+    });
+
+    it('handles complex breakable cases', () => {
+      const context = {
+        left: 'an apple a date',
+        right: ''
+      };
+
+      // 'an apple any'
+      const editTransform = {
+        insert: 'ny day',
+        deleteLeft: 6
+      };
+
+      const result = tokenizeTransform(
+        defaultTokenize,
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 3);
+      assert.deepEqual(result, [
+        { insert: 'ny', deleteLeft: 6 },
+        { insert: ' ', deleteLeft: 0 },
+        { insert: 'day', deleteLeft: 0 }
+      ]);
+    });
+  });
+
+  describe('with mocked dictionary-based wordbreaking', () => {
+    function mockedTokenization(entries) {
+      return {
+        left: entries.map((text) => {
+          return {text: text}
+        })
+      };
+    }
+
+    it('properly handles simple token-edit transform', () => {
+      const context = {
+        left: 'anappleadate',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: 'y',
+        deleteLeft: 2
+      };
+
+      const result = tokenizeTransform(
+        () => mockedTokenization(['an', 'apple', 'a', 'day']),
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 1);
+      assert.deepEqual(result[0], editTransform);
+    });
+
+    it('properly handles simple token-replacing transform', () => {
+      const context = {
+        left: 'anappleadate',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: 'week',
+        deleteLeft: 4
+      };
+
+      const result = tokenizeTransform(
+        () => mockedTokenization(['an', 'apple', 'a', 'week']),
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 1);
+      assert.deepEqual(result[0], editTransform);
+    });
+
+    it('handles simple token-replacing transform with cross-token deleteLeft', () => {
+      const context = {
+        left: 'anappleadate',
+        right: ''
+      };
+
+      // 'an apple any'
+      const editTransform = {
+        insert: 'ny',
+        deleteLeft: 5
+      };
+
+      const result = tokenizeTransform(
+        () => mockedTokenization(['an', 'apple', 'any']),
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 1);
+      assert.deepEqual(result[0], editTransform);
+    });
+
+    it('handles word-breakable transforms (case 1)', () => {
+      const context = {
+        left: 'anappleadat',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: 'yk',
+        deleteLeft: 1
+      };
+
+      const result = tokenizeTransform(
+        () => mockedTokenization(['an', 'apple', 'any', 'k']),
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 2);
+      assert.deepEqual(result, [
+        { insert: 'y', deleteLeft: 1 },
+        { insert: 'k', deleteLeft: 0 }
+      ]);
+    });
+
+    it('handles word-breakable transforms (case 2)', () => {
+      const context = {
+        left: 'anappleadat',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: 'y.',
+        deleteLeft: 1
+      };
+
+      const result = tokenizeTransform(
+        () => mockedTokenization(['an', 'apple', 'any', 'day', '.']),
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 2);
+      assert.deepEqual(result, [
+        { insert: 'y', deleteLeft: 1 },
+        { insert: '.', deleteLeft: 0 }
+      ]);
+    });
+
+    it('handles word-breakable transforms (case 2 alternate output)', () => {
+      const context = {
+        left: 'anappleadat',
+        right: ''
+      };
+
+      const editTransform = {
+        insert: 'y.',
+        deleteLeft: 1
+      };
+
+      const result = tokenizeTransform(
+        () => mockedTokenization(['an', 'apple', 'any', 'day', '.', '']),
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 3);
+      assert.deepEqual(result, [
+        { insert: 'y', deleteLeft: 1 },
+        { insert: '.', deleteLeft: 0 },
+        { insert: '', deleteLeft: 0 }
+      ]);
+    });
+
+    it('handles complex breakable cases', () => {
+      const context = {
+        left: 'anappleadate',
+        right: ''
+      };
+
+      // 'an apple any'
+      const editTransform = {
+        insert: 'nyday',
+        deleteLeft: 5
+      };
+
+      const result = tokenizeTransform(
+        () => mockedTokenization(['an', 'apple', 'any', 'day']),
+        context,
+        editTransform
+      );
+
+      assert.equal(result.length, 2);
+      assert.deepEqual(result, [
+        { insert: 'ny', deleteLeft: 5 },
+        { insert: 'day', deleteLeft: 0 }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
In order to better handle complex keystrokes that trigger context tokenization, this PR adds a method designed to split incoming keystroke Transforms according to their contribution to the tokenization of the context that results from applying it.

I'm not sure how to clearly and concisely describe it; I feel like the clearest "explanation" is via example.  So, toward that...

Example:
- Current context, before keystroke: `an apple b` 
    - Tokenization: `['an', ' ', 'apple', ' ', 'b']`
- Context after keystroke: `an apple a day.`
    - Tokenization: `['an', ' ', 'apple', ' ', 'a', ' ', 'day', '.']`
- Keystroke transform: `{ insert: 'a day', deleteLeft: 1 }` (delete one character - the 'b')
    - Tokenization:
        - `{ insert: 'a', deleteLeft: 1 }` - delete `'b'` from the corresponding token, inserting `'a'` in its place.
        - `{ insert: ' ', deleteLeft: 0 }` - append a whitespace token
        - `{ insert: 'day', deleteLeft: 0 }` - append `'day'` as a token
        - `{ insert: '.', deleteLeft: 0 }` - append `'.'` as a token

In the current form of predictive-text, note that all but the last of the tokenized transforms should inherently be preserved for any new predictions based upon the input.  If `'day'` were the final token, predictions based on `day` would be reasonable - rather than predictions based on the full value of insert: `a day`.

In _some_ cases, even the final transform may be worth consideration - for English, a final '.', '?', or '!', among other punctuation marks, would be special cases that are reasonable to preserve as well.  Each typically forces a "word-break" in English text, though an argument could be made against `.` due to use in some abbreviations.  Design work is needed to facilitate handling these punctuation marks in this manner, though - that "manner" being to automatically preserve + skip past them.

@keymanapp-test-bot skip