### PR TITLE
chore(windows): remove the posting WM_KEYUP/DOWN events to IM

### DIFF
--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -282,12 +282,6 @@ LRESULT _kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
 
     if(!*Globals::hwndIMAlways())
     {
-/* TODO: IM windows no longer receive these messages, what is going on? #11919?
-      if(mp->message == wxm_keymankeydown)
-        PostMessage(*Globals::hwndIM(), WM_KEYDOWN, mp->wParam, mp->lParam);
-      else if(mp->message == wxm_keymankeyup)
-        PostMessage(*Globals::hwndIM(), WM_KEYUP, mp->wParam, mp->lParam);
-*/
       return CallNextHookEx(Globals::get_hhookGetMessage(), nCode, wParam, lParam);
     }
   }


### PR DESCRIPTION
Fixes: #11919 
The code has already been commented out, this was more a clean-up of dead code. WM_KEYDOWN events are not expected by the IM window anymore.

@keymanapp-test-bot skip