### PR TITLE
chore(linux): remove Ubuntu Mantic, add Oracular

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [focal, jammy, mantic, noble]
+        dist: [focal, jammy, noble]
 
     steps:
     - name: Checkout

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -33,7 +33,7 @@ else
 fi
 echo "ppa: ${ppa}"
 
-distributions="${DIST:-focal jammy mantic noble}"
+distributions="${DIST:-focal jammy noble oracular}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
Ubuntu 23.10 Mantic is EOL, Ubuntu 24.10 Oracular will be the next release.

@keymanapp-test-bot skip