### PR TITLE
chore(linux): remove Ubuntu 23.10 Mantic 🏠

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [focal, jammy, mantic]
+        dist: [focal, jammy]
 
     runs-on: ubuntu-latest
     steps:

--- a/linux/.pbuilderrc
+++ b/linux/.pbuilderrc
@@ -14,7 +14,7 @@ DEBIAN_SUITES=($UNSTABLE_CODENAME $TESTING_CODENAME $STABLE_CODENAME $STABLE_BAC
     "experimental" "unstable" "testing" "stable")
 
 # List of Ubuntu suites. Update these when needed.
-UBUNTU_SUITES=("noble" "mantic" "jammy" "focal")
+UBUNTU_SUITES=("noble" "jammy" "focal")
 
 # Mirrors to use. Update these to your preferred mirror.
 DEBIAN_MIRROR="deb.debian.org"

--- a/linux/scripts/cow.sh
+++ b/linux/scripts/cow.sh
@@ -3,7 +3,7 @@
 # If needed set cowbuilder up for building Keyman Debian packages
 # Then cowbuilder update
 
-distributions='focal jammy mantic noble'
+distributions='focal jammy noble'
 
 if ! dpkg-query -l cowbuilder; then
     echo "installing pbuilder and cowbuilder"

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -33,7 +33,7 @@ else
 fi
 echo "ppa: ${ppa}"
 
-distributions="${DIST:-focal jammy mantic noble}"
+distributions="${DIST:-focal jammy noble}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
Mantic is EOL.

Kind of cherry-pick of #12003, but doesn't add Oracular and removes Mantic from some additional files that no longer exist in `master` branch.

@keymanapp-test-bot skip