### PR TITLE
fix(developer): handle errors parsing .kps file when loading project

### DIFF
--- a/developer/src/tike/project/Keyman.Developer.System.Project.kpsProjectFile.pas
+++ b/developer/src/tike/project/Keyman.Developer.System.Project.kpsProjectFile.pas
@@ -77,6 +77,7 @@ implementation
 
 uses
   System.Variants,
+  System.Win.ComObj,
 
   Keyman.Developer.System.Project.Project,
   PackageInfo;
@@ -117,6 +118,12 @@ begin
         end;
         on E:DOMException do
         begin
+          // ignore errors in the xml; reduce metadata visible to the user
+          Exit;
+        end;
+        on E:EOleException do
+        begin
+          // ignore errors in interpreting xml; reduce metadata visible to the user
           Exit;
         end;
       end;


### PR DESCRIPTION
When a project is loaded, the IDE parses .kps files to retrieve metadata for viewing. If the .kps file was malformed, then the parser could fail, blocking the load of the project. Instead, we just ignore the errors and show no metadata. Note that the Package Editor already loads the file successfully and reports on the problem, allowing the user to fix it.

Fixes: #11992
Fixes: KEYMAN-DEVELOPER-23W

@keymanapp-test-bot skip