### PR TITLE
fix(linux): set local directory if not specified

### DIFF
--- a/linux/keyman-config/km-kvk2ldml
+++ b/linux/keyman-config/km-kvk2ldml
@@ -15,8 +15,8 @@ def main():
         'print the details of the kvk file.')
     parser.add_argument('-p', "--print", help='print kvk details', action="store_true")
     parser.add_argument('-k', "--keys", help='if printing also print all keys', action="store_true")
-    parser.add_argument('kvkfile', help='kvk file')
     parser.add_argument('-o', '--output', metavar='LDMLFILE', help='output LDML file location')
+    parser.add_argument('kvkfile', help='kvk file')
     add_standard_arguments(parser)
 
     args = parser.parse_args()
@@ -46,6 +46,8 @@ def main():
     outputfile = args.output if args.output else f'{name}.ldml'
 
     dirname = os.path.dirname(outputfile)
+    if dirname == '':
+        dirname = '.'
     if not os.path.isdir(dirname):
         if os.path.exists(dirname):
             logging.error(f'km-kvk2ldml: error, `{dirname}` exists but is not a directory')


### PR DESCRIPTION
If the user specifies just an output file without directory name (or doesn't specify an output file), we will now use the current directory instead of crashing.

@keymanapp-test-bot skip