### PR TITLE
chore(web): remove `paths` from `tsconfig.json` 🏗️

### DIFF
--- a/common/models/templates/build.sh
+++ b/common/models/templates/build.sh
@@ -16,6 +16,7 @@ builder_describe "Builds the predictive-text model template implementation modul
   "@/common/web/keyman-version" \
   "@/common/web/es-bundling" \
   "@/common/models/wordbreakers" \
+  "@/common/web/utils" \
   "clean" \
   "configure" \
   "build" \

--- a/common/models/templates/tsconfig.json
+++ b/common/models/templates/tsconfig.json
@@ -7,15 +7,10 @@
     "tsBuildInfoFile": "build/obj/tsconfig.tsbuildinfo",
     "rootDir": "./src"
   },
-  "references": [
-    { "path": "../types" },
-    { "path": "../../web/utils" },
-    { "path": "../../models/wordbreakers" }
-  ],
   "include": [
-	"src/**/*.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
-	"test"
+    "test"
   ]
 }

--- a/common/models/wordbreakers/tsconfig.json
+++ b/common/models/wordbreakers/tsconfig.json
@@ -7,14 +7,11 @@
     "tsBuildInfoFile": "build/obj/tsconfig.tsbuildinfo",
     "rootDir": "./src"
   },
-  "references": [
-    { "path": "../types" }
-  ],
   "include": [
-	"src/**/*"
+    "src/**/*"
   ],
   "exclude": [
-	"node_modules",
-	"test/**/*.ts"
+    "node_modules",
+    "test/**/*.ts"
   ]
 }

--- a/common/predictive-text/src/tsconfig.json
+++ b/common/predictive-text/src/tsconfig.json
@@ -7,13 +7,6 @@
     "tsBuildInfoFile": "../build/obj/tsconfig.tsbuildinfo",
     "rootDir": "./"
   },
-  "references": [
-    { "path": "../../web/utils" },
-    { "path": "../../models/types"},
-    { "path": "../../models/wordbreakers"},
-    { "path": "../../web/lm-message-types"},
-    { "path": "../../models/templates"}
-  ],
   "include" : [ "./*.ts" ],
   "exclude" : [
     "node",

--- a/common/predictive-text/tsconfig.all.json
+++ b/common/predictive-text/tsconfig.all.json
@@ -13,11 +13,6 @@
   },
   "files": [],
   "references": [
-    { "path": "../web/utils" },
-    { "path": "../models/types"},
-    { "path": "../models/wordbreakers"},
-    { "path": "../web/lm-message-types"},
-    { "path": "../models/templates"},
     { "path": "src/node" },
     { "path": "src/web" }
   ],

--- a/common/web/gesture-recognizer/src/test/tsconfig.json
+++ b/common/web/gesture-recognizer/src/test/tsconfig.json
@@ -24,7 +24,4 @@
   ],
   // Undo the base config's exclude.
   "exclude": ["../../../../../node_modules/promise-status-async/lib/index.d.ts"],
-  "references": [
-    {"path": "../../"}
-  ]
 }

--- a/common/web/gesture-recognizer/src/tools/unit-test-resources/tsconfig.json
+++ b/common/web/gesture-recognizer/src/tools/unit-test-resources/tsconfig.json
@@ -7,8 +7,5 @@
     "rootDir": "./src",
     "tsBuildInfoFile": "../../../build/tools/tsconfig.tsbuildinfo"
   },
-  "references": [
-    { "path": "../../../." }
-  ],
   "include": ["./src/**/*.ts"]
 }

--- a/common/web/gesture-recognizer/tsconfig.json
+++ b/common/web/gesture-recognizer/tsconfig.json
@@ -9,7 +9,4 @@
   },
   "include": ["./src/engine/**/*.ts"],
   "exclude": ["./src/test/**/*.ts", "./src/tools/**/*.ts"],
-  "references": [
-    { "path": "../utils" }
-  ]
 }

--- a/common/web/input-processor/tsconfig.json
+++ b/common/web/input-processor/tsconfig.json
@@ -8,11 +8,6 @@
     "tsBuildInfoFile": "build/obj/tsconfig.tsbuildinfo",
     "rootDir": "./src"
   },
-  "references": [
-    { "path": "../utils" },
-    { "path": "../keyboard-processor" },
-    { "path": "../../predictive-text/tsconfig.all.json" },
-  ],
   // The extra .d.ts is necessary to avoid issues with lack of a Worker type definition when not including
   // the standard DOM in the TS "lib" configuration.
   "include": ["./src/**/*.ts", "../../predictive-text/src/worker-interface.d.ts"]

--- a/common/web/keyboard-processor/tsconfig.json
+++ b/common/web/keyboard-processor/tsconfig.json
@@ -7,12 +7,6 @@
     "tsBuildInfoFile": "build/obj/tsconfig.tsbuildinfo",
     "rootDir": "./src/"
   },
-  "references": [
-    { "path": "../types" },
-    { "path": "../../models/types" },
-    { "path": "../keyman-version/" },
-    { "path": "../utils/" }
-  ],
   "include": [ "./src/**/*.ts"],
   "exclude": ["./src/keyboards/loaders/**/*.ts"]
 }

--- a/common/web/lm-worker/tsconfig.json
+++ b/common/web/lm-worker/tsconfig.json
@@ -10,16 +10,6 @@
     // As this one is the one that directly interfaces with the worker (from the inside)
     "lib": ["webworker", "es6"],
   },
-  "references": [
-    // types
-    { "path": "../../models/types" },
-    { "path": "../lm-message-types" },
-    // modules
-    { "path": "../keyman-version" },
-    { "path": "../utils" },
-    { "path": "../../models/templates" },
-    { "path": "../../models/wordbreakers" },
-  ],
   "include": [
     "src/main/**/*.ts"
   ]

--- a/common/web/recorder/tsconfig.json
+++ b/common/web/recorder/tsconfig.json
@@ -12,11 +12,4 @@
   "include": [
     "src/**/*.ts"
   ],
-
-  "references": [
-    { "path": "../keyman-version" },
-    { "path": "../utils/" },
-    { "path": "../keyboard-processor/" },
-    { "path": "../lm-message-types" }
-  ],
 }

--- a/common/web/types/test/tsconfig.json
+++ b/common/web/types/test/tsconfig.json
@@ -14,8 +14,6 @@
     "./helpers/*.ts",
   ],
   "references": [
-    { "path": "../../keyman-version" },
-    { "path": "../../../../core/include/ldml/"},
     { "path": "../" },
   ]
 }

--- a/common/web/types/tsconfig.json
+++ b/common/web/types/tsconfig.json
@@ -13,8 +13,4 @@
     "src/**/*.ts",
     "src/schemas/*.mjs", // Import the validators
   ],
-  "references": [
-    { "path": "../keyman-version" },
-    { "path": "../../../core/include/ldml/tsconfig.json"},
-  ]
 }

--- a/common/web/utils/tsconfig.json
+++ b/common/web/utils/tsconfig.json
@@ -6,9 +6,6 @@
     "outDir": "./build/obj/",
     "rootDir": "./src"
   },
-  "references": [
-    { "path": "../keyman-version"}
-  ],
   "include": [
     "src/*.ts"
   ],

--- a/web/src/app/browser/tsconfig.json
+++ b/web/src/app/browser/tsconfig.json
@@ -9,9 +9,4 @@
   },
 
   "include": [ "**/*.ts" ],
-
-  "references": [
-    { "path": "../../engine/attachment" },
-    { "path": "../../engine/main" }
-  ]
 }

--- a/web/src/app/ui/tsconfig.json
+++ b/web/src/app/ui/tsconfig.json
@@ -1,19 +1,16 @@
 {
   "extends": "../../tsconfig.dom.json",
 
-	"compilerOptions": {
+  "compilerOptions": {
     "baseUrl": "./",
-		"outDir": "../../../build/app/ui/obj",
-		"rootDir": "",
+    "outDir": "../../../build/app/ui/obj",
+    "rootDir": "",
     "tsBuildInfoFile": "../../../build/app/ui/obj/tsconfig.tsbuildinfo",
   },
   "files": [
-		"kmwuibutton.ts",
-		"kmwuifloat.ts",
-		"kmwuitoggle.ts",
-		"kmwuitoolbar.ts"
+    "kmwuibutton.ts",
+    "kmwuifloat.ts",
+    "kmwuitoggle.ts",
+    "kmwuitoolbar.ts"
   ],
-	"references": [
-		{ "path": "../browser" }
-	]
 }

--- a/web/src/app/webview/tsconfig.json
+++ b/web/src/app/webview/tsconfig.json
@@ -9,8 +9,4 @@
   },
 
   "include": [ "**/*.ts" ],
-
-  "references": [
-    { "path": "../../engine/main" }
-  ]
 }

--- a/web/src/engine/attachment/tsconfig.json
+++ b/web/src/engine/attachment/tsconfig.json
@@ -9,9 +9,4 @@
   },
 
   "include": [ "src/**/*.ts" ],
-
-  "references": [
-    { "path": "../dom-utils" },
-    { "path": "../element-wrappers" }
-  ]
 }

--- a/web/src/engine/device-detect/tsconfig.json
+++ b/web/src/engine/device-detect/tsconfig.json
@@ -9,9 +9,4 @@
   },
 
   "include": [ "**/*.ts" ],
-
-  "references": [
-    { "path": "../../../../common/web/keyman-version" },
-    { "path": "../../../../common/web/utils" }
-  ]
 }

--- a/web/src/engine/dom-utils/tsconfig.json
+++ b/web/src/engine/dom-utils/tsconfig.json
@@ -9,9 +9,4 @@
   },
 
   "include": [ "src/**/*.ts" ],
-
-  "references": [
-    { "path": "../../../../common/web/keyboard-processor" },
-    { "path": "../../../../common/web/utils" }
-  ]
 }

--- a/web/src/engine/element-wrappers/tsconfig.json
+++ b/web/src/engine/element-wrappers/tsconfig.json
@@ -9,8 +9,4 @@
   },
 
   "include": [ "src/**/*.ts" ],
-
-  "references": [
-    { "path": "../../../../common/web/keyboard-processor" }
-  ]
 }

--- a/web/src/engine/events/tsconfig.json
+++ b/web/src/engine/events/tsconfig.json
@@ -9,9 +9,4 @@
   },
 
   "include": [ "src/**/*.ts" ],
-
-  "references": [
-    { "path": "../../../../common/web/utils" },
-    { "path": "../../../../common/web/keyboard-processor" }
-  ]
 }

--- a/web/src/engine/main/tsconfig.json
+++ b/web/src/engine/main/tsconfig.json
@@ -9,12 +9,4 @@
   },
 
   "include": [ "src/**/*.ts" ],
-
-  "references": [
-    { "path": "../../../../common/web/input-processor" },
-    { "path": "../device-detect" },
-    { "path": "../osk" },
-    { "path": "../package-cache" },
-    { "path": "../paths" },
-  ]
 }

--- a/web/src/engine/osk/tsconfig.json
+++ b/web/src/engine/osk/tsconfig.json
@@ -10,11 +10,4 @@
   },
 
   "include": [ "src/**/*.ts" ],
-
-  "references": [
-    { "path": "../../../../common/web/input-processor" },
-    { "path": "../../../../common/web/gesture-recognizer" },
-    { "path": "../dom-utils" },
-    { "path": "../events" }
-  ]
 }

--- a/web/src/engine/package-cache/tsconfig.json
+++ b/web/src/engine/package-cache/tsconfig.json
@@ -9,9 +9,4 @@
   },
 
   "include": [ "src/**/*.ts" ],
-
-  "references": [
-    { "path": "../../../../common/web/input-processor" },
-    { "path": "../paths" }
-  ]
 }

--- a/web/src/engine/paths/tsconfig.json
+++ b/web/src/engine/paths/tsconfig.json
@@ -10,10 +10,4 @@
   },
 
   "include": [ "**/*.ts" ],
-
-  "references": [
-    // We want OSK to be free from the need to reference this child project for its paths definitions.
-    // There are a number of extra components here the OSK doesn't need.
-    { "path": "../osk" }
-  ]
 }

--- a/web/src/tools/testing/bulk_rendering/tsconfig.json
+++ b/web/src/tools/testing/bulk_rendering/tsconfig.json
@@ -11,9 +11,4 @@
   "files": [
     "renderer_core.ts"
   ],
-
-	"references": [
-    { "path": "../../../app/browser" },
-    { "path": "../../../engine/device-detect" }
-	]
 }

--- a/web/src/tools/testing/recorder/tsconfig.json
+++ b/web/src/tools/testing/recorder/tsconfig.json
@@ -8,14 +8,4 @@
   },
 
   "include": [ "*.ts" ],
-
-  "references": [
-    { "path": "../../../../../common/web/keyman-version" },
-    { "path": "../../../../../common/web/utils" },
-    { "path": "../../../../../common/web/keyboard-processor" },
-    { "path": "../../../../../common/web/input-processor" },
-    { "path": "../../../../../common/web/recorder" },
-    { "path": "../../../../../common/web/lm-message-types" },
-    { "path": "../../../../../web/src/app/browser" }
-  ]
 }


### PR DESCRIPTION
See #12027 (as well as build failures in the current repo restructurings) for the motivation for this change.

Basically remove all `path` lines from `references` except when they reference files in or below the current directory. Another execption is if there is no `package.json` file for the current directory, i.e. the current directory is not a separate module.

@keymanapp-test-bot skip