### PR TITLE
chore(developer): remove redundant references from tsconfig.json

### DIFF
--- a/developer/src/common/web/test-helpers/tsconfig.json
+++ b/developer/src/common/web/test-helpers/tsconfig.json
@@ -9,7 +9,4 @@
   "include": [
     "./*.ts",
   ],
-  "references": [
-    { "path": "../../../../../common/web/types/" },
-  ]
 }

--- a/developer/src/common/web/utils/test/tsconfig.json
+++ b/developer/src/common/web/utils/test/tsconfig.json
@@ -15,7 +15,6 @@
       "helpers/*.ts",
   ],
   "references": [
-      { "path": "../" },
-      { "path": "../../test-helpers/" },
-    ]
+    { "path": "../" },
+  ],
 }

--- a/developer/src/kmc-analyze/tsconfig.json
+++ b/developer/src/kmc-analyze/tsconfig.json
@@ -9,9 +9,4 @@
   "include": [
     "src/**/*.ts"
   ],
-  "references": [
-    { "path": "../../../common/web/types" },
-    { "path": "../kmc-kmn" },
-    { "path": "../common/web/utils/" },
-  ]
 }

--- a/developer/src/kmc-keyboard-info/build.sh
+++ b/developer/src/kmc-keyboard-info/build.sh
@@ -10,6 +10,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Build Keyman kmc keyboard-info Compiler module" \
   "@/common/web/types" \
   "@/developer/src/common/web/utils" \
+  "@/developer/src/kmc-package" \
   "clean" \
   "configure" \
   "build" \

--- a/developer/src/kmc-keyboard-info/test/tsconfig.json
+++ b/developer/src/kmc-keyboard-info/test/tsconfig.json
@@ -15,7 +15,5 @@
   ],
   "references": [
       { "path": "../" },
-      { "path": "../../common/web/test-helpers/" },
-      { "path": "../../kmc-package/" },
     ]
 }

--- a/developer/src/kmc-keyboard-info/tsconfig.json
+++ b/developer/src/kmc-keyboard-info/tsconfig.json
@@ -16,9 +16,4 @@
     "src/ttfmeta/lib/*.js",
     "src/imports/langtags.js",
   ],
-  "references": [
-    { "path": "../../../common/web/types" },
-    { "path": "../kmc-package/" },
-    { "path": "../common/web/utils/" },
-  ]
 }

--- a/developer/src/kmc-kmn/tsconfig.json
+++ b/developer/src/kmc-kmn/tsconfig.json
@@ -12,9 +12,4 @@
     "src/**/*.ts",
     "src/import/kmcmplib/wasm-host.js"
   ],
-  "references": [
-    { "path": "../../../common/web/types/" },
-    { "path": "../../../common/web/keyman-version/" },
-    { "path": "../common/web/utils/" },
-  ]
 }

--- a/developer/src/kmc-ldml/test/tsconfig.json
+++ b/developer/src/kmc-ldml/test/tsconfig.json
@@ -13,10 +13,6 @@
       "./helpers/index.ts"
   ],
   "references": [
-      { "path": "../../../../common/web/keyman-version" },
-      { "path": "../../../../common/web/types/" },
-      { "path": "../../../../common/tools/hextobin/" },
-      { "path": "../../common/web/test-helpers/" },
       { "path": "../" }
     ]
 }

--- a/developer/src/kmc-ldml/tsconfig.json
+++ b/developer/src/kmc-ldml/tsconfig.json
@@ -9,10 +9,4 @@
   "include": [
     "src/**/*.ts"
   ],
-  "references": [
-    { "path": "../../../common/web/keyman-version" },
-    { "path": "../../../common/web/types/" },
-    { "path": "../kmc-kmn/" },
-    { "path": "../../../core/include/ldml/"},
-  ]
 }

--- a/developer/src/kmc-model-info/test/tsconfig.json
+++ b/developer/src/kmc-model-info/test/tsconfig.json
@@ -15,7 +15,5 @@
   ],
   "references": [
       { "path": "../" },
-      { "path": "../../common/web/test-helpers/" },
-      { "path": "../../kmc-package/" },
     ]
 }

--- a/developer/src/kmc-model-info/tsconfig.json
+++ b/developer/src/kmc-model-info/tsconfig.json
@@ -8,9 +8,4 @@
   "include": [
     "src/**/*.ts"
   ],
-  "references": [
-    { "path": "../../../common/web/types" },
-    { "path": "../../../common/models/types" },
-    { "path": "../common/web/utils" },
-  ]
 }

--- a/developer/src/kmc-model/test/tsconfig.json
+++ b/developer/src/kmc-model/test/tsconfig.json
@@ -17,6 +17,5 @@
   ],
   "references": [
       { "path": "../" },
-      { "path": "../../common/web/test-helpers/" },
     ]
 }

--- a/developer/src/kmc-model/tsconfig.json
+++ b/developer/src/kmc-model/tsconfig.json
@@ -10,9 +10,4 @@
   "include": [
     "src/**/*.ts"
   ],
-  "references": [
-    { "path": "../../../common/web/keyman-version" },
-    { "path": "../../../common/models/types" },
-    { "path": "../../../common/web/types" },
-  ]
 }

--- a/developer/src/kmc-package/test/tsconfig.json
+++ b/developer/src/kmc-package/test/tsconfig.json
@@ -14,8 +14,5 @@
   ],
   "references": [
       { "path": "../" },
-      { "path": "../../../../common/web/types" },
-      { "path": "../../../../common/web/keyman-version" },
-      { "path": "../../common/web/test-helpers/" },
     ]
 }

--- a/developer/src/kmc-package/tsconfig.json
+++ b/developer/src/kmc-package/tsconfig.json
@@ -9,8 +9,4 @@
   "include": [
     "src/**/*.ts",
   ],
-  "references": [
-    { "path": "../../../common/web/keyman-version" },
-    { "path": "../../../common/web/types" },
-  ]
 }

--- a/developer/src/kmc/test/tsconfig.json
+++ b/developer/src/kmc/test/tsconfig.json
@@ -12,8 +12,6 @@
     "./helpers/index.ts",
   ],
   "references": [
-    { "path": "../../../../common/web/types/" },
-    { "path": "../../common/web/test-helpers/" },
     { "path": "../" }
   ]
 }

--- a/developer/src/kmc/tsconfig.json
+++ b/developer/src/kmc/tsconfig.json
@@ -9,15 +9,4 @@
   "include": [
     "src/**/*.ts"
   ],
-  "references": [
-    { "path": "../../../common/web/keyman-version" },
-    { "path": "../../../common/web/types" },
-    { "path": "../kmc-analyze" },
-    { "path": "../kmc-keyboard-info" },
-    { "path": "../kmc-kmn" },
-    { "path": "../kmc-ldml" },
-    { "path": "../kmc-model" },
-    { "path": "../kmc-model-info" },
-    { "path": "../kmc-package" },
-  ]
 }

--- a/developer/src/server/tsconfig.json
+++ b/developer/src/server/tsconfig.json
@@ -22,8 +22,4 @@
   "include": [
     "src/**/*.ts"
   ],
-  "references": [
-    { "path": "../../../common/web/keyman-version" },
-    { "path": "../common/web/utils" },
-  ]
 }


### PR DESCRIPTION
With the full move to ES Modules, we no longer need to include `references` in tsconfig.json, as we can rely on package.json and build.sh dependency management. Note however that `tsc -b` may not work to build dependencies -- they need to be built using `build.sh`, which calculates which dependencies need building.

kmc-keyboard-info was missing a dependency link to kmc-package in build.sh, correcting this at the same time.

See-also: #12033
See-also: #12028
Relates-to: #12027

@keymanapp-test-bot skip