### PR TITLE
refactor(developer): move error reporting inside `GetCompileTargetsFromTargetsStore` and `ProcessGroupFinish` 🌋

### DIFF
--- a/developer/src/kmcmplib/src/CompileKeyboardBuffer.cpp
+++ b/developer/src/kmcmplib/src/CompileKeyboardBuffer.cpp
@@ -136,7 +136,9 @@ bool CompileKeyboardBuffer(KMX_BYTE* infile, int sz, PFILE_KEYBOARD fk)
     return FALSE;
   }
 
-  ProcessGroupFinish(fk);
+  if(!ProcessGroupFinish(fk)) {
+    return FALSE;
+  }
 
   if (kmcmp::FSaveDebug) kmcmp::RecordDeadkeyNames(fk);
 

--- a/developer/src/kmcmplib/src/UnreachableRules.cpp
+++ b/developer/src/kmcmplib/src/UnreachableRules.cpp
@@ -25,7 +25,8 @@ namespace kmcmp {
   }
 
 }
-KMX_DWORD VerifyUnreachableRules(PFILE_GROUP gp) {
+
+void VerifyUnreachableRules(PFILE_GROUP gp) {
   PFILE_KEY kp = gp->dpKeyArray;
   KMX_DWORD i;
 
@@ -51,6 +52,4 @@ KMX_DWORD VerifyUnreachableRules(PFILE_GROUP gp) {
   }
 
   kmcmp::currentLine = oldCurrentLine;
-
-  return STATUS_Success;
 }

--- a/developer/src/kmcmplib/src/UnreachableRules.h
+++ b/developer/src/kmcmplib/src/UnreachableRules.h
@@ -1,3 +1,3 @@
 #pragma once
 
-KMX_DWORD VerifyUnreachableRules(PFILE_GROUP gp);
+void VerifyUnreachableRules(PFILE_GROUP gp);

--- a/developer/src/kmcmplib/src/kmcmplib.h
+++ b/developer/src/kmcmplib/src/kmcmplib.h
@@ -34,7 +34,7 @@ KMX_BOOL AddStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, const KMX_WCHAR * str, 
 KMX_DWORD ReadLine(KMX_BYTE* infile, int sz, int& offset, PKMX_WCHAR wstr, KMX_BOOL PreProcess);
 KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str);
 KMX_BOOL ProcessGroupLine(PFILE_KEYBOARD fk, PKMX_WCHAR p);
-KMX_DWORD ProcessGroupFinish(PFILE_KEYBOARD fk);
+KMX_BOOL ProcessGroupFinish(PFILE_KEYBOARD fk);
 KMX_BOOL ProcessStoreLine(PFILE_KEYBOARD fk, PKMX_WCHAR p);
 int LineTokenType(PKMX_WCHAR *str);
 KMX_BOOL BuildVKDictionary(PFILE_KEYBOARD fk); // I3438

--- a/developer/src/kmcmplib/tests/api-test.cpp
+++ b/developer/src/kmcmplib/tests/api-test.cpp
@@ -34,6 +34,7 @@ int main(int argc, char *argv[]) {
   setup();
   test_kmcmp_CompileKeyboard(argv[1]);
 
+  setup();
   test_GetCompileTargetsFromTargetsStore();
 
   return 0;
@@ -70,30 +71,67 @@ void test_kmcmp_CompileKeyboard(char *kmn_file) {
   unlink(kmn_file);
 }
 
-extern KMX_DWORD GetCompileTargetsFromTargetsStore(const KMX_WCHAR* store, int &targets);
+extern KMX_BOOL GetCompileTargetsFromTargetsStore(const KMX_WCHAR* store, int &targets);
 
 void test_GetCompileTargetsFromTargetsStore() {
   int targets = 0;
-  assert(GetCompileTargetsFromTargetsStore(u"any", targets) == STATUS_Success);
+
+  setup();
+  assert(GetCompileTargetsFromTargetsStore(u"any", targets));
+  assert(error_vec.size() == 0);
   assert(targets == (COMPILETARGETS_KMX | COMPILETARGETS_JS));
-  assert(GetCompileTargetsFromTargetsStore(u"windows", targets) == STATUS_Success);
+
+  setup();
+  assert(GetCompileTargetsFromTargetsStore(u"windows", targets));
+  assert(error_vec.size() == 0);
   assert(targets == COMPILETARGETS_KMX);
-  assert(GetCompileTargetsFromTargetsStore(u"desktop", targets) == STATUS_Success);
+
+  setup();
+  assert(GetCompileTargetsFromTargetsStore(u"desktop", targets));
+  assert(error_vec.size() == 0);
   assert(targets == COMPILETARGETS_KMX);
-  assert(GetCompileTargetsFromTargetsStore(u"mobile", targets) == STATUS_Success);
+
+  setup();
+  assert(GetCompileTargetsFromTargetsStore(u"mobile", targets));
+  assert(error_vec.size() == 0);
   assert(targets == COMPILETARGETS_JS);
-  assert(GetCompileTargetsFromTargetsStore(u"web", targets) == STATUS_Success);
+
+  setup();
+  assert(GetCompileTargetsFromTargetsStore(u"web", targets));
+  assert(error_vec.size() == 0);
   assert(targets == COMPILETARGETS_JS);
-  assert(GetCompileTargetsFromTargetsStore(u"desktop mobile", targets) == STATUS_Success);
+
+  setup();
+  assert(GetCompileTargetsFromTargetsStore(u"desktop mobile", targets));
+  assert(error_vec.size() == 0);
   assert(targets == (COMPILETARGETS_KMX | COMPILETARGETS_JS));
-  assert(GetCompileTargetsFromTargetsStore(u"desktop   tablet", targets) == STATUS_Success);
+
+  setup();
+  assert(GetCompileTargetsFromTargetsStore(u"desktop   tablet", targets));
+  assert(error_vec.size() == 0);
   assert(targets == (COMPILETARGETS_KMX | COMPILETARGETS_JS));
-  assert(GetCompileTargetsFromTargetsStore(u"foo bar baz", targets) == KmnCompilerMessages::ERROR_InvalidTarget);
+
+  setup();
+  assert(!GetCompileTargetsFromTargetsStore(u"foo bar baz", targets));
+  assert(error_vec.size() == 1);
+  assert(error_vec[0] == KmnCompilerMessages::ERROR_InvalidTarget);
   assert(targets == 0);
-  assert(GetCompileTargetsFromTargetsStore(u"windows chromeos", targets) == KmnCompilerMessages::ERROR_InvalidTarget);
+
+  setup();
+  assert(!GetCompileTargetsFromTargetsStore(u"windows chromeos", targets));
+  assert(error_vec.size() == 1);
+  assert(error_vec[0] == KmnCompilerMessages::ERROR_InvalidTarget);
   assert(targets == 0);
-  assert(GetCompileTargetsFromTargetsStore(u" ", targets) == KmnCompilerMessages::ERROR_NoTargetsSpecified);
+
+  setup();
+  assert(!GetCompileTargetsFromTargetsStore(u" ", targets));
+  assert(error_vec.size() == 1);
+  assert(error_vec[0] == KmnCompilerMessages::ERROR_NoTargetsSpecified);
   assert(targets == 0);
-  assert(GetCompileTargetsFromTargetsStore(u"", targets) == KmnCompilerMessages::ERROR_NoTargetsSpecified);
+
+  setup();
+  assert(!GetCompileTargetsFromTargetsStore(u"", targets));
+  assert(error_vec.size() == 1);
+  assert(error_vec[0] == KmnCompilerMessages::ERROR_NoTargetsSpecified);
   assert(targets == 0);
 }

--- a/developer/src/kmcmplib/tests/gtest-compiler-test.cpp
+++ b/developer/src/kmcmplib/tests/gtest-compiler-test.cpp
@@ -278,7 +278,7 @@ TEST_F(CompilerTest, ValidateMatchNomatchOutput_test) {
 // KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str)
 // KMX_BOOL ProcessGroupLine(PFILE_KEYBOARD fk, PKMX_WCHAR p)
 // int kmcmp::cmpkeys(const void *key, const void *elem)
-// KMX_DWORD ProcessGroupFinish(PFILE_KEYBOARD fk)
+// KMX_BOOL ProcessGroupFinish(PFILE_KEYBOARD fk)
 // KMX_BOOL ProcessStoreLine(PFILE_KEYBOARD fk, PKMX_WCHAR p)
 // bool resizeStoreArray(PFILE_KEYBOARD fk)
 // bool resizeKeyArray(PFILE_GROUP gp, int increment)


### PR DESCRIPTION
This supports upcoming changes for parameterized errors in `GetCompileTargetsFromTargetsStore` and `VerifyUnreachableRules` (now a `void` return because it always returned success anyway).

Relates-to: #10866

@keymanapp-test-bot skip