### PR TITLE
fix(web): unrevert #11258, leaving OSK hidden before instructed to display

### DIFF
--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -257,6 +257,8 @@ export default abstract class OSKView
     if(this.hostDevice.touchable) {
       this.setBaseTouchEventListeners();
     }
+
+    this._Box.style.display = 'none';
   }
 
   protected get configuration(): Configuration {


### PR DESCRIPTION
#12015 included a reversion to #11258, which was originally a followup that edited the same region as edited by #11174, the focus of #12015.  #11258's changes should be fine to include though, so this PR restores its change.

## User Testing

**TEST_REPRO**:  Attempt to reproduce #11962 using Keyman for Android.

- Install the package provided within that issue.
- Force-quit the app.
- Relaunch the app.
    - If the issue is not properly fixed, an error notification will appear on app-relaunch.

**TEST_ANDROID**:   Do simple general-use testing with Keyman for Android and report back if any odd behaviors occur.

**TEST_IOS**: Do simple general-use testing with Keyman for iOS and report back if any odd behaviors occur.

**TEST_WEB**:  Do simple general-use testing with the "Test unminified Web" test page and report back if any odd behaviors occur.

**TEST_DEV_SERVER**:  Use Keyman Developer's web-keyboard testing page and verify that it still works correctly.  (We're mostly checking to see that this doesn't result in an immediate, obvious break.)