### PR TITLE
chore(core): explicitly add dependency in `core/build.sh`

### DIFF
--- a/core/build.sh
+++ b/core/build.sh
@@ -59,6 +59,7 @@ Libraries will be built in 'build/<target>/<configuration>/src'.
 " \
   "@/common/tools/hextobin" \
   "@/common/web/keyman-version" \
+  "@/core/include/ldml" \
   "@/developer/src/kmc" \
   "clean" \
   "configure" \

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -60,7 +60,8 @@ dpkg-source --tar-ignore=*~ --tar-ignore=.git --tar-ignore=.gitattributes \
     --tar-ignore=resources/environment.sh \
     --tar-ignore=resources/git-hooks \
     --tar-ignore=resources/scopes \
-    --tar-ignore=resources/build/*.lua --tar-ignore=resources/build/jq* \
+    --tar-ignore=resources/build/*.lua \
+    --tar-ignore=resources/build/jq-license.txt --tar-ignore=resources/build/jq-win64.exe \
     --tar-ignore=results \
     --tar-ignore=tmp \
     --tar-ignore=web --tar-ignore=windows --tar-ignore=keyman_1* \


### PR DESCRIPTION
This fixes a dependency problem with building Core after cleaning the `core` directory: `core` depends on `common/web/types` which in turn depends on `core/include/ldml`. If the result of building `common/web/types` still exists, we previously didn't build `core/include/ldml` which lead to a failure building `core`. Explicitly adding the reference to `core` fixes it.

@keymanapp-test-bot skip