### PR TITLE
refactor(developer): rename compiler error reporting functions in kmcmplib 🌋

### DIFF
--- a/developer/src/kmcmplib/src/CheckForDuplicates.cpp
+++ b/developer/src/kmcmplib/src/CheckForDuplicates.cpp
@@ -18,7 +18,7 @@ KMX_BOOL CheckForDuplicateGroup(PFILE_KEYBOARD fk, PFILE_GROUP gp) noexcept {
       continue;
     }
     if (u16icmp(gp0->szName, gp->szName) == 0) {
-      AddCompileError(KmnCompilerMessages::ERROR_DuplicateGroup, {
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_DuplicateGroup, {
         /*groupName*/  string_from_u16string(gp->szName),
         /*lineNumber*/ std::to_string(gp0->Line)
       });
@@ -41,7 +41,7 @@ KMX_BOOL CheckForDuplicateStore(PFILE_KEYBOARD fk, PFILE_STORE sp) noexcept {
       continue;
     }
     if (u16icmp(sp0->szName, sp->szName) == 0) {
-      AddCompileError(KmnCompilerMessages::ERROR_DuplicateStore, {
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_DuplicateStore, {
         /*storeName*/  string_from_u16string(sp0->szName),
         /*lineNumber*/ std::to_string(sp0->line)
       });

--- a/developer/src/kmcmplib/src/CheckNCapsConsistency.cpp
+++ b/developer/src/kmcmplib/src/CheckNCapsConsistency.cpp
@@ -33,7 +33,7 @@
  *
  * @param fk     Keyboard to check
  */
-bool CheckNCapsConsistency(PFILE_KEYBOARD fk) {
+void CheckNCapsConsistency(PFILE_KEYBOARD fk) {
   struct CapsUsage {
     int ncaps_line, caps_line, neither_line;
   };
@@ -87,13 +87,11 @@ bool CheckNCapsConsistency(PFILE_KEYBOARD fk) {
     if (caps_ncaps_usage[i].neither_line && (caps_ncaps_usage[i].caps_line || caps_ncaps_usage[i].ncaps_line)) {
       // We set the current line to one needing work: the developer should add the NCAPS flag
       kmcmp::currentLine = caps_ncaps_usage[i].neither_line;
-      AddWarningBool(KmnCompilerMessages::WARN_KeyShouldIncludeNCaps);
+      ReportCompilerMessage(KmnCompilerMessages::WARN_KeyShouldIncludeNCaps);
     }
   }
 
   delete[] caps_ncaps_usage;
 
   kmcmp::currentLine = oldCurrentLine;
-
-  return TRUE;
 }

--- a/developer/src/kmcmplib/src/CheckNCapsConsistency.h
+++ b/developer/src/kmcmplib/src/CheckNCapsConsistency.h
@@ -2,4 +2,4 @@
 
 #include <compfile.h>
 
-bool CheckNCapsConsistency(PFILE_KEYBOARD fk);
+void CheckNCapsConsistency(PFILE_KEYBOARD fk);

--- a/developer/src/kmcmplib/src/CompileKeyboardBuffer.cpp
+++ b/developer/src/kmcmplib/src/CompileKeyboardBuffer.cpp
@@ -20,13 +20,13 @@ bool CompileKeyboardBuffer(KMX_BYTE* infile, int sz, PFILE_KEYBOARD fk)
   kmcmp::FMnemonicLayout = FALSE;
 
   if (!fk) {
-    AddCompileError(KmnCompilerMessages::FATAL_SomewhereIGotItWrong);
+    ReportCompilerMessage(KmnCompilerMessages::FATAL_SomewhereIGotItWrong);
     return FALSE;
   }
 
   str = new KMX_WCHAR[LINESIZE];
   if (!str) {
-    AddCompileError(KmnCompilerMessages::FATAL_CannotAllocateMemory);
+    ReportCompilerMessage(KmnCompilerMessages::FATAL_CannotAllocateMemory);
     return FALSE;
   }
 
@@ -112,7 +112,7 @@ bool CompileKeyboardBuffer(KMX_BYTE* infile, int sz, PFILE_KEYBOARD fk)
   }
 
   if (msg != STATUS_EndOfFile) {
-    AddCompileError(msg);
+    ReportCompilerMessage(msg);
     return FALSE;
   }
 
@@ -132,7 +132,7 @@ bool CompileKeyboardBuffer(KMX_BYTE* infile, int sz, PFILE_KEYBOARD fk)
   }
 
   if (msg != STATUS_EndOfFile) {
-    AddCompileError(msg);
+    ReportCompilerMessage(msg);
     return FALSE;
   }
 

--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -274,7 +274,7 @@ KMX_BOOL ProcessBeginLine(PFILE_KEYBOARD fk, PKMX_WCHAR p) {
 
   q = (PKMX_WCHAR) u16chr(p, '>');
   if (!q) {
-    AddCompileError(KmnCompilerMessages::ERROR_NoTokensFound);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_NoTokensFound);
     return FALSE;
   }
 
@@ -284,29 +284,29 @@ KMX_BOOL ProcessBeginLine(PFILE_KEYBOARD fk, PKMX_WCHAR p) {
   else if (u16nicmp(p, u"newContext", 10) == 0) BeginMode = BEGIN_NEWCONTEXT;
   else if (u16nicmp(p, u"postKeystroke", 13) == 0) BeginMode = BEGIN_POSTKEYSTROKE;
   else if (*p != '>') {
-    AddCompileError(KmnCompilerMessages::ERROR_InvalidToken);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidToken);
     return FALSE;
   }
   else BeginMode = BEGIN_ANSI;
 
   if(kmcmp::BeginLine[BeginMode] != -1) {
-    AddCompileError(KmnCompilerMessages::ERROR_RepeatedBegin);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_RepeatedBegin);
     return FALSE;
   }
 
   kmcmp::BeginLine[BeginMode] = kmcmp::currentLine;
 
   if ((msg = GetRHS(fk, p, tstr, 80, (int)(p - pp), FALSE)) != STATUS_Success) {
-    AddCompileError(msg);
+    ReportCompilerMessage(msg);
     return FALSE;
   }
 
   if (tstr[0] != UC_SENTINEL || tstr[1] != CODE_USE) {
-    AddCompileError(KmnCompilerMessages::ERROR_InvalidBegin);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidBegin);
     return FALSE;
   }
   if (tstr[3] != 0) {
-    AddCompileError(KmnCompilerMessages::ERROR_InvalidToken);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidToken);
     return FALSE;
   }
 
@@ -323,7 +323,7 @@ KMX_BOOL ProcessBeginLine(PFILE_KEYBOARD fk, PKMX_WCHAR p) {
   } else {
     PFILE_GROUP gp = &fk->dpGroupArray[tstr[2] - 1];
     if (!gp->fReadOnly) {
-      AddCompileError(BeginMode == BEGIN_NEWCONTEXT ?
+      ReportCompilerMessage(BeginMode == BEGIN_NEWCONTEXT ?
         KmnCompilerMessages::ERROR_NewContextGroupMustBeReadonly :
         KmnCompilerMessages::ERROR_PostKeystrokeGroupMustBeReadonly);
       return FALSE;
@@ -391,7 +391,7 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
     kmcmp::WarnDeprecatedHeader();   // I4866
     q = GetDelimitedString(&p, u"\"\"", 0);
     if (!q) {
-      AddCompileError(KmnCompilerMessages::ERROR_InvalidName);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidName);
       return FALSE;
     }
 
@@ -404,7 +404,7 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
     kmcmp::WarnDeprecatedHeader();   // I4866
     q = GetDelimitedString(&p, u"\"\"", 0);
     if (!q) {
-      AddCompileError(KmnCompilerMessages::ERROR_InvalidCopyright);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidCopyright);
       return FALSE;
     }
 
@@ -417,7 +417,7 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
     kmcmp::WarnDeprecatedHeader();   // I4866
     q = GetDelimitedString(&p, u"\"\"", 0);
     if (!q) {
-      AddCompileError(KmnCompilerMessages::ERROR_InvalidMessage);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidMessage);
       return FALSE;
     }
 
@@ -430,7 +430,7 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
     kmcmp::WarnDeprecatedHeader();   // I4866
     q = GetDelimitedString(&p, u"\"\"", 0);
     if (!q) {
-      AddCompileError(KmnCompilerMessages::ERROR_InvalidLanguageName);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidLanguageName);
       return FALSE;
     }
 
@@ -486,7 +486,7 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
     kmcmp::WarnDeprecatedHeader();   // I4866
     KMX_WCHAR *tokcontext = NULL;
     if ((q = u16tok(p,  p_sep, &tokcontext)) == NULL) {
-      AddCompileError(KmnCompilerMessages::ERROR_CodeInvalidInThisSection);  // I3481
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_CodeInvalidInThisSection);  // I3481
       return FALSE;
     }
     if (!AddStore(fk, TSS_HOTKEY, q)) {
@@ -499,7 +499,7 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
     kmcmp::WarnDeprecatedHeader();   // I4866
     KMX_WCHAR *tokcontext = NULL;
     if ((q = u16tok(p,  p_sep, &tokcontext)) == NULL) {
-      AddCompileError(KmnCompilerMessages::ERROR_InvalidBitmapLine);  // I3481
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidBitmapLine);  // I3481
       return FALSE;
     }
 
@@ -508,7 +508,7 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
       p = q;
       q = GetDelimitedString(&p, u"\"\"", 0);
       if (!q) {
-        AddCompileError(KmnCompilerMessages::ERROR_InvalidBitmapLine);
+        ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidBitmapLine);
         return FALSE;
       }
     }
@@ -525,7 +525,7 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
     AddWarning(KmnCompilerMessages::WARN_BitmapNotUsed);
 
     if ((q = u16tok(p,  p_sep, &tokcontext)) == NULL) {
-      AddCompileError(KmnCompilerMessages::ERROR_InvalidBitmapLine);  // I3481
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidBitmapLine);  // I3481
       return FALSE;
     }
 
@@ -540,18 +540,18 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
   }
   case T_KEYTOKEY:			// A rule
     if (fk->currentGroup == 0xFFFFFFFF) {
-      AddCompileError(KmnCompilerMessages::ERROR_CodeInvalidInThisSection);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_CodeInvalidInThisSection);
       return FALSE;
     }
     if ((msg = ProcessKeyLine(fk, p, IsUnicode)) != STATUS_Success) {
-      AddCompileError(msg);
+      ReportCompilerMessage(msg);
       return FALSE;
     }
     break;
 
   case T_MATCH:
     if (fk->currentGroup == 0xFFFFFFFF) {
-      AddCompileError(KmnCompilerMessages::ERROR_CodeInvalidInThisSection);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_CodeInvalidInThisSection);
       return FALSE;
     }
     {
@@ -559,13 +559,13 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
       if ((msg = GetRHS(fk, p, buf, GLOBAL_BUFSIZE - 1, (int)(p - pp), IsUnicode)) != STATUS_Success)
       {
         delete[] buf;
-        AddCompileError(msg);
+        ReportCompilerMessage(msg);
         return FALSE;
       }
 
       if ((msg = ValidateMatchNomatchOutput(buf)) != STATUS_Success) {
         delete[] buf;
-        AddCompileError(msg);
+        ReportCompilerMessage(msg);
         return FALSE;
       }
 
@@ -592,7 +592,7 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
 
   case T_NOMATCH:
     if (fk->currentGroup == 0xFFFFFFFF) {
-      AddCompileError(KmnCompilerMessages::ERROR_CodeInvalidInThisSection);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_CodeInvalidInThisSection);
       return FALSE;
     }
     {
@@ -600,13 +600,13 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
       if ((msg = GetRHS(fk, p, buf, GLOBAL_BUFSIZE, (int)(p - pp), IsUnicode)) != STATUS_Success)
       {
         delete[] buf;
-        AddCompileError(msg);
+        ReportCompilerMessage(msg);
         return FALSE;
       }
 
       if ((msg = ValidateMatchNomatchOutput(buf)) != STATUS_Success) {
         delete[] buf;
-        AddCompileError(msg);
+        ReportCompilerMessage(msg);
         return FALSE;
       }
 
@@ -629,7 +629,7 @@ KMX_BOOL ParseLine(PFILE_KEYBOARD fk, PKMX_WCHAR str) {
     break;
 
   default:
-    AddCompileError(KmnCompilerMessages::ERROR_InvalidToken);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidToken);
     return FALSE;
   }
 
@@ -645,7 +645,7 @@ KMX_BOOL ProcessGroupLine(PFILE_KEYBOARD fk, PKMX_WCHAR p)
 
   gp = new FILE_GROUP[fk->cxGroupArray + 1];
   if (!gp) {
-    AddCompileError(KmnCompilerMessages::FATAL_CannotAllocateMemory);
+    ReportCompilerMessage(KmnCompilerMessages::FATAL_CannotAllocateMemory);
     return FALSE;
   }
 
@@ -666,7 +666,7 @@ KMX_BOOL ProcessGroupLine(PFILE_KEYBOARD fk, PKMX_WCHAR p)
 
   q = GetDelimitedString(&p, u"()", GDS_CUTLEAD | GDS_CUTFOLL);
   if (!q) {
-    AddCompileError(KmnCompilerMessages::ERROR_InvalidGroupLine);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidGroupLine);
     return FALSE;
   }
 
@@ -744,7 +744,7 @@ KMX_BOOL ProcessGroupFinish(PFILE_KEYBOARD fk) {
 
   // Finish off the previous group stuff!
   if ((msg = ExpandCapsRulesForGroup(fk, gp)) != STATUS_Success) {
-    AddCompileError(msg);
+    ReportCompilerMessage(msg);
     return FALSE;
   }
   qsort(gp->dpKeyArray, gp->cxKeyArray, sizeof(FILE_KEY), kmcmp::cmpkeys);
@@ -767,7 +767,7 @@ KMX_BOOL ProcessStoreLine(PFILE_KEYBOARD fk, PKMX_WCHAR p) {
   pp = p;
 
   if ((q = GetDelimitedString(&p, u"()", GDS_CUTLEAD | GDS_CUTFOLL)) == NULL) {
-    AddCompileError(KmnCompilerMessages::ERROR_InvalidStoreLine);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidStoreLine);
     return FALSE;
   }
 
@@ -778,13 +778,13 @@ KMX_BOOL ProcessStoreLine(PFILE_KEYBOARD fk, PKMX_WCHAR p) {
       }
     }
     if (!StoreTokens[i]) {
-      AddCompileError(KmnCompilerMessages::ERROR_InvalidSystemStore);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidSystemStore);
       return FALSE;
     }
   }
 
   if(!resizeStoreArray(fk)) {
-    AddCompileError(KmnCompilerMessages::FATAL_CannotAllocateMemory);
+    ReportCompilerMessage(KmnCompilerMessages::FATAL_CannotAllocateMemory);
     return FALSE;
   }
   sp = &fk->dpStoreArray[fk->cxStoreArray];
@@ -802,7 +802,7 @@ KMX_BOOL ProcessStoreLine(PFILE_KEYBOARD fk, PKMX_WCHAR p) {
 
     if ((msg = GetXString(fk, p, u"c\n", temp, GLOBAL_BUFSIZE - 1, (int)(p - pp), &p, FALSE, TRUE)) != STATUS_Success) {
       delete[] temp;
-      AddCompileError(msg);
+      ReportCompilerMessage(msg);
       return FALSE;
     }
 
@@ -876,7 +876,7 @@ bool resizeKeyArray(PFILE_GROUP gp, int increment) {
 KMX_BOOL AddStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, const KMX_WCHAR * str, KMX_DWORD *dwStoreID) {
   PFILE_STORE sp;
   if(!resizeStoreArray(fk)) {
-    AddCompileError(KmnCompilerMessages::FATAL_CannotAllocateMemory);
+    ReportCompilerMessage(KmnCompilerMessages::FATAL_CannotAllocateMemory);
     return FALSE;
   }
 
@@ -948,7 +948,7 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
 
   case TSS_BITMAP:
     if ((msg = ImportBitmapFile(fk, sp->dpString, &fk->dwBitmapSize, &fk->lpBitmap)) != STATUS_Success) {
-      AddCompileError(msg);
+      ReportCompilerMessage(msg);
       return FALSE;
     }
     break;
@@ -985,14 +985,14 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
   case TSS_ETHNOLOGUECODE:
     VERIFY_KEYBOARD_VERSION(fk, VERSION_60, KmnCompilerMessages::ERROR_60FeatureOnly_EthnologueCode);
     if ((msg = ProcessEthnologueStore(sp->dpString)) != STATUS_Success) {
-      AddCompileError(msg);
+      ReportCompilerMessage(msg);
       return FALSE;  // I2646
     }
     break;
 
   case TSS_HOTKEY:
     if ((msg = ProcessHotKey(sp->dpString, &fk->dwHotKey)) != STATUS_Success) {
-      AddCompileError(msg);
+      ReportCompilerMessage(msg);
       return FALSE;
     }
     u16sprintf(buf, GLOBAL_BUFSIZE, L"%d", (int)fk->dwHotKey);  // I3481
@@ -1004,7 +1004,7 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
   case TSS_INCLUDECODES:
     VERIFY_KEYBOARD_VERSION(fk, VERSION_60, KmnCompilerMessages::ERROR_60FeatureOnly_NamedCodes);
     if (!kmcmp::CodeConstants->LoadFile(fk, sp->dpString)) {
-      AddCompileError(KmnCompilerMessages::ERROR_CannotLoadIncludeFile);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_CannotLoadIncludeFile);
       return FALSE;
     }
     kmcmp::CodeConstants->reindex();   // I4982
@@ -1020,7 +1020,7 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
     PKMX_WCHAR p_sep_c = sep_c;
     q = u16tok(sp->dpString, p_sep_c, &context);  // I3481
     if (!q) {
-      AddCompileError(KmnCompilerMessages::ERROR_InvalidLanguageLine);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidLanguageLine);
       return FALSE;
     }
 
@@ -1038,7 +1038,7 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
       j = xatoi(&q);
 
     if (i < 1 || j < 1 || i > 0x3FF || j > 0x3F) {
-      AddCompileError(KmnCompilerMessages::ERROR_InvalidLanguageLine);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidLanguageLine);
       return FALSE;
     }
     if (i >= 0x200 || j >= 0x20) AddWarning(KmnCompilerMessages::WARN_CustomLanguagesNotSupported);
@@ -1060,7 +1060,7 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
 
   case TSS_LAYOUT:
     if (fk->KeyboardID == 0) {
-      AddCompileError(KmnCompilerMessages::ERROR_LayoutButNoLanguage);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_LayoutButNoLanguage);
       return FALSE;
     }
 
@@ -1078,7 +1078,7 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
     if (kmcmp::FMnemonicLayout && FindSystemStore(fk, TSS_CASEDKEYS) != NULL) {
       // The &CasedKeys system store is not supported for
       // mnemonic layouts
-      AddCompileError(KmnCompilerMessages::ERROR_CasedKeysNotSupportedWithMnemonicLayout);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_CasedKeysNotSupportedWithMnemonicLayout);
       return FALSE;
     }
     break;
@@ -1103,7 +1103,7 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
 
   case TSS_VERSION:
     if ((fk->dwFlags & KF_AUTOMATICVERSION) == 0) {
-      AddCompileError(KmnCompilerMessages::ERROR_VersionAlreadyIncluded);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_VersionAlreadyIncluded);
       return FALSE;
     }
     p = sp->dpString;
@@ -1128,7 +1128,7 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
     else if (u16ncmp(p, u"17.0", 4) == 0)  fk->version = VERSION_170; // Flicks and gestures
 
     else {
-      AddCompileError(KmnCompilerMessages::ERROR_InvalidVersion);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidVersion);
       return FALSE;
     }
 
@@ -1207,7 +1207,7 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
 
       if (i < 1 || j < 1 || i > 0x3FF || j > 0x3F) {
         delete[] q;
-        AddCompileError(KmnCompilerMessages::ERROR_InvalidLanguageLine);
+        ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidLanguageLine);
         return FALSE;
       }
 
@@ -1238,14 +1238,14 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
   case TSS_KEYBOARDVERSION:   // I4140
     VERIFY_KEYBOARD_VERSION(fk, VERSION_90, KmnCompilerMessages::ERROR_90FeatureOnlyKeyboardVersion);
     if (!IsValidKeyboardVersion(sp->dpString)) {
-      AddCompileError(KmnCompilerMessages::ERROR_KeyboardVersionFormatInvalid);
+      ReportCompilerMessage(KmnCompilerMessages::ERROR_KeyboardVersionFormatInvalid);
       return FALSE;
     }
     break;
 
   case TSS_CASEDKEYS:
     if ((msg = VerifyCasedKeys(sp)) != STATUS_Success) {
-      AddCompileError(msg);
+      ReportCompilerMessage(msg);
       return FALSE;
     }
     break;
@@ -1266,7 +1266,7 @@ KMX_BOOL ProcessSystemStore(PFILE_KEYBOARD fk, KMX_DWORD SystemID, PFILE_STORE s
     break;
 
   default:
-    AddCompileError(KmnCompilerMessages::ERROR_InvalidSystemStore);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidSystemStore);
     return FALSE;
   }
   return TRUE;
@@ -1312,7 +1312,7 @@ KMX_BOOL GetCompileTargetsFromTargetsStore(const KMX_WCHAR* store, int &targets)
       }
 
       if(!found) {
-        AddCompileError(KmnCompilerMessages::ERROR_InvalidTarget, {
+        ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidTarget, {
           /*target*/ string_from_u16string(token).c_str()
         });
         delete[] p;
@@ -1325,7 +1325,7 @@ KMX_BOOL GetCompileTargetsFromTargetsStore(const KMX_WCHAR* store, int &targets)
   delete[] p;
 
   if(targets == 0) {
-    AddCompileError(KmnCompilerMessages::ERROR_NoTargetsSpecified);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_NoTargetsSpecified);
     return FALSE;
   }
 
@@ -1451,7 +1451,7 @@ KMX_BOOL CheckContextStatementPositions(PKMX_WCHAR context) {
         }
         break;
       case CODE_EXTENDED:
-        AddCompileError(KmnCompilerMessages::ERROR_VirtualKeyInContext);
+        ReportCompilerMessage(KmnCompilerMessages::ERROR_VirtualKeyInContext);
         break;
       default:
         hadContextChar = TRUE;
@@ -3706,7 +3706,7 @@ bool UTF16TempFromUTF8(KMX_BYTE* infile, int sz, KMX_BYTE** tempfile, int *sz16)
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
     result = converter.from_bytes((char*)infile, (char*)infile+sz);
   } catch(std::range_error& e) {
-    AddCompileError(KmnCompilerMessages::HINT_NonUnicodeFile);
+    ReportCompilerMessage(KmnCompilerMessages::HINT_NonUnicodeFile);
     result.resize(sz);
     for(int i = 0; i < sz; i++) {
       result[i] = CP1252_UNICODE[infile[i]];

--- a/developer/src/kmcmplib/src/CompilerErrors.cpp
+++ b/developer/src/kmcmplib/src/CompilerErrors.cpp
@@ -10,7 +10,7 @@ namespace kmcmp {
   kmcmp_CompilerMessageProc msgproc = nullptr;
 }
 
-void AddCompileError(KMX_DWORD msg, const std::vector<std::string>& parameters) {
+void ReportCompilerMessage(KMX_DWORD msg, const std::vector<std::string>& parameters) {
   const KMX_DWORD severity = msg & MESSAGE_SEVERITY_MASK;
 
   if (severity == CompilerErrorSeverity::Error || severity == CompilerErrorSeverity::Fatal) {

--- a/developer/src/kmcmplib/src/CompilerErrors.h
+++ b/developer/src/kmcmplib/src/CompilerErrors.h
@@ -8,9 +8,4 @@ namespace kmcmp {
 }
 
 extern void* msgprocContext;
-void ReportCompilerMessage(KMX_DWORD msg, const std::vector<std::string>& parameters = {}); // TODO rename to AddCompileMessage
-
-/// Use AddWarningBool for functions that return bool or KMX_BOOL; TODO merge with AddCompileMessage
-#define AddWarningBool(warn)  ReportCompilerMessage(warn)
-/// Use AddWarning for functions that return KMX_DWORD; TODO merge with AddCompileMessage
-#define AddWarning(warn)      ReportCompilerMessage(warn)
+void ReportCompilerMessage(KMX_DWORD msg, const std::vector<std::string>& parameters = {});

--- a/developer/src/kmcmplib/src/CompilerErrors.h
+++ b/developer/src/kmcmplib/src/CompilerErrors.h
@@ -8,9 +8,9 @@ namespace kmcmp {
 }
 
 extern void* msgprocContext;
-void AddCompileError(KMX_DWORD msg, const std::vector<std::string>& parameters = {}); // TODO rename to AddCompileMessage
+void ReportCompilerMessage(KMX_DWORD msg, const std::vector<std::string>& parameters = {}); // TODO rename to AddCompileMessage
 
 /// Use AddWarningBool for functions that return bool or KMX_BOOL; TODO merge with AddCompileMessage
-#define AddWarningBool(warn)  AddCompileError(warn)
+#define AddWarningBool(warn)  ReportCompilerMessage(warn)
 /// Use AddWarning for functions that return KMX_DWORD; TODO merge with AddCompileMessage
-#define AddWarning(warn)      AddCompileError(warn)
+#define AddWarning(warn)      ReportCompilerMessage(warn)

--- a/developer/src/kmcmplib/src/CompilerInterfaces.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfaces.cpp
@@ -25,7 +25,7 @@ EXTERN bool kmcmp_CompileKeyboard(
   kmcmp::CompileTarget = options.target;
 
   if (!messageProc || !loadFileProc || !pszInfile) {
-    AddCompileError(KmnCompilerMessages::FATAL_BadCallParams);
+    ReportCompilerMessage(KmnCompilerMessages::FATAL_BadCallParams);
     return FALSE;
   }
 
@@ -39,20 +39,20 @@ EXTERN bool kmcmp_CompileKeyboard(
   std::vector<uint8_t> bufvec = loadFileProc(pszInfile, "");
   sz = bufvec.size();
   if(!sz) {
-    AddCompileError(KmnCompilerMessages::ERROR_InfileNotExist);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_InfileNotExist);
     return FALSE;
   }
 
   if(sz < 3) {
     // Technically, a 3 byte file can never be a valid .kmn, so we can shortcut
     // here and avoid testing outside memory bounds for looking at BOM
-    AddCompileError(KmnCompilerMessages::ERROR_CannotReadInfile);
+    ReportCompilerMessage(KmnCompilerMessages::ERROR_CannotReadInfile);
     return FALSE;
   }
 
   KMX_BYTE* infile = new KMX_BYTE[sz+1];
   if(!infile) {
-    AddCompileError(KmnCompilerMessages::FATAL_CannotAllocateMemory);
+    ReportCompilerMessage(KmnCompilerMessages::FATAL_CannotAllocateMemory);
     return FALSE;
   }
   std::copy(bufvec.begin(), bufvec.end(), infile);
@@ -68,7 +68,7 @@ EXTERN bool kmcmp_CompileKeyboard(
     int sz16;
     if(!UTF16TempFromUTF8(infile, sz, &infile16, &sz16)) {
       delete[] infile;
-      AddCompileError(KmnCompilerMessages::FATAL_CannotCreateTempfile);
+      ReportCompilerMessage(KmnCompilerMessages::FATAL_CannotCreateTempfile);
       return FALSE;
     }
     delete[] infile;
@@ -95,7 +95,7 @@ EXTERN bool kmcmp_CompileKeyboard(
   //TODO: FreeKeyboardPointers(fk);
 
   if(msg != STATUS_Success) {
-    AddCompileError(msg);
+    ReportCompilerMessage(msg);
     return FALSE;
   }
 

--- a/developer/src/kmcmplib/src/DeprecationChecks.cpp
+++ b/developer/src/kmcmplib/src/DeprecationChecks.cpp
@@ -6,15 +6,14 @@
 #include "kmcmplib.h"
 #include "DeprecationChecks.h"
 
-KMX_BOOL kmcmp::WarnDeprecatedHeader() {   // I4866
-if( AWarnDeprecatedCode_GLOBAL_LIB){
-  AddWarningBool(KmnCompilerMessages::WARN_HeaderStatementIsDeprecated);
+void kmcmp::WarnDeprecatedHeader() {   // I4866
+  if (AWarnDeprecatedCode_GLOBAL_LIB) {
+    ReportCompilerMessage(KmnCompilerMessages::WARN_HeaderStatementIsDeprecated);
   }
-  return TRUE;
 }
 
 /* Flag presence of deprecated features */
-KMX_BOOL kmcmp::CheckForDeprecatedFeatures(PFILE_KEYBOARD fk) {
+void kmcmp::CheckForDeprecatedFeatures(PFILE_KEYBOARD fk) {
   /*
     For Keyman 10, we deprecated:
       // < Keyman 7
@@ -31,7 +30,7 @@ KMX_BOOL kmcmp::CheckForDeprecatedFeatures(PFILE_KEYBOARD fk) {
   PFILE_STORE sp;
 
   if (!AWarnDeprecatedCode_GLOBAL_LIB) {
-    return TRUE;
+    return;
   }
 
   if (fk->version >= VERSION_100) {
@@ -42,12 +41,10 @@ KMX_BOOL kmcmp::CheckForDeprecatedFeatures(PFILE_KEYBOARD fk) {
           sp->dwSystemID == TSS_ETHNOLOGUECODE ||
           sp->dwSystemID == TSS_WINDOWSLANGUAGES) {
         kmcmp::currentLine = sp->line;
-        AddWarningBool(KmnCompilerMessages::WARN_LanguageHeadersDeprecatedInKeyman10);
+        ReportCompilerMessage(KmnCompilerMessages::WARN_LanguageHeadersDeprecatedInKeyman10);
       }
     }
   }
 
   kmcmp::currentLine = oldCurrentLine;
-
-  return TRUE;
 }

--- a/developer/src/kmcmplib/src/DeprecationChecks.h
+++ b/developer/src/kmcmplib/src/DeprecationChecks.h
@@ -4,6 +4,6 @@
 #include "kmcmplib.h"
 
 namespace kmcmp{
-KMX_BOOL WarnDeprecatedHeader();
-KMX_BOOL CheckForDeprecatedFeatures(PFILE_KEYBOARD fk);
+  void WarnDeprecatedHeader();
+  void CheckForDeprecatedFeatures(PFILE_KEYBOARD fk);
 }

--- a/developer/src/kmcmplib/src/UnreachableRules.cpp
+++ b/developer/src/kmcmplib/src/UnreachableRules.cpp
@@ -42,7 +42,7 @@ void VerifyUnreachableRules(PFILE_GROUP gp) {
       if (kp->Line != k1.Line && reportedLines.count(kp->Line) == 0) {
         reportedLines.insert(kp->Line);
         kmcmp::currentLine = kp->Line;
-        AddCompileError(KmnCompilerMessages::HINT_UnreachableRule, {
+        ReportCompilerMessage(KmnCompilerMessages::HINT_UnreachableRule, {
           /* LineNumber */ std::to_string(k1.Line)
         });
       }

--- a/developer/src/kmcmplib/src/versioning.cpp
+++ b/developer/src/kmcmplib/src/versioning.cpp
@@ -13,7 +13,7 @@ KMX_BOOL kmcmp::CheckKeyboardFinalVersion(PFILE_KEYBOARD fk) {
     if(kmcmp::CompileTarget != CKF_KEYMANWEB) {
       // Note: the KeymanWeb compiler is responsible for reporting minimum
       // version for the web targets
-      AddCompileError(KmnCompilerMessages::INFO_MinimumCoreEngineVersion, {
+      ReportCompilerMessage(KmnCompilerMessages::INFO_MinimumCoreEngineVersion, {
         /* majorVersion */ std::to_string((fk->version & 0xFF00) >> 8),
         /* minorVersion */ std::to_string(fk->version & 0xFF)
       });

--- a/developer/src/kmcmplib/src/versioning.h
+++ b/developer/src/kmcmplib/src/versioning.h
@@ -5,7 +5,7 @@
 
 #define VERIFY_KEYBOARD_VERSION(fk, ver, err) { \
   if(!VerifyKeyboardVersion((fk), (ver))) { \
-    AddCompileError((err)); \
+    ReportCompilerMessage((err)); \
     return FALSE; \
   } \
 }

--- a/developer/src/kmcmplib/tests/gtest-compiler-test.cpp
+++ b/developer/src/kmcmplib/tests/gtest-compiler-test.cpp
@@ -253,7 +253,7 @@ TEST_F(CompilerTest, IsValidKeyboardVersion_test) {
 
 // KMX_DWORD kmcmp::AddCompilerVersionStore(PFILE_KEYBOARD fk)
 // KMX_DWORD CheckStatementOffsets(PFILE_KEYBOARD fk, PFILE_GROUP gp, PKMX_WCHAR context, PKMX_WCHAR output, PKMX_WCHAR key)
-// KMX_BOOL CheckContextStatementPositions(PKMX_WCHAR context)
+// void CheckContextStatementPositions(PKMX_WCHAR context)
 // KMX_DWORD CheckUseStatementsInOutput(PKMX_WCHAR output)
 // KMX_DWORD CheckVirtualKeysInOutput(PKMX_WCHAR output)
 // KMX_DWORD InjectContextToReadonlyOutput(PKMX_WCHAR pklOut)
@@ -798,7 +798,7 @@ TEST_F(CompilerTest, GetXStringImpl_type_i_test) {
 // KMX_DWORD ProcessEthnologueStore(PKMX_WCHAR p)
 // KMX_DWORD ProcessHotKey(PKMX_WCHAR p, KMX_DWORD *hk)
 // void SetChecksum(PKMX_BYTE buf, PKMX_DWORD CheckSum, KMX_DWORD sz)
-// KMX_BOOL kmcmp::CheckStoreUsage(PFILE_KEYBOARD fk, int storeIndex, KMX_BOOL fIsStore, KMX_BOOL fIsOption, KMX_BOOL fIsCall)
+// void kmcmp::CheckStoreUsage(PFILE_KEYBOARD fk, int storeIndex, KMX_BOOL fIsStore, KMX_BOOL fIsOption, KMX_BOOL fIsCall)
 // KMX_DWORD WriteCompiledKeyboard(PFILE_KEYBOARD fk, KMX_BYTE**data, size_t& dataSize)
 // KMX_DWORD ReadLine(KMX_BYTE* infile, int sz, int& offset, PKMX_WCHAR wstr, KMX_BOOL PreProcess)
 

--- a/developer/src/kmcmplib/tests/gtest-compiler-test.cpp
+++ b/developer/src/kmcmplib/tests/gtest-compiler-test.cpp
@@ -122,25 +122,25 @@ TEST_F(CompilerTest, wstrtostr_test) {
     EXPECT_EQ(0, strcmp("", wstrtostr((PKMX_WCHAR)u"")));
 };
 
-// TEST_F(CompilerTest, AddCompileError_test) {
+// TEST_F(CompilerTest, ReportCompilerMessage_test) {
 //     msgproc = msgproc_true_stub;
 //     kmcmp::ErrChr = 0;
 
 //     // SevFatal
 //     EXPECT_EQ(0, kmcmp::nErrors);
 //     EXPECT_EQ(SevFatal, KmnCompilerMessages::FATAL_CannotCreateTempfile & SevFatal);
-//     EXPECT_TRUE(AddCompileError(KmnCompilerMessages::FATAL_CannotCreateTempfile));
+//     EXPECT_TRUE(ReportCompilerMessage(KmnCompilerMessages::FATAL_CannotCreateTempfile));
 //     EXPECT_EQ(1, kmcmp::nErrors);
 
 //     // SevError
 //     EXPECT_EQ(SevError, KmnCompilerMessages::ERROR_InvalidLayoutLine & SevError);
-//     EXPECT_FALSE(AddCompileError(KmnCompilerMessages::ERROR_InvalidLayoutLine));
+//     EXPECT_FALSE(ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidLayoutLine));
 //     EXPECT_EQ(2, kmcmp::nErrors);
 
 //     // Unknown
 //     const KMX_DWORD UNKNOWN_ERROR = 0x00004FFF; // top of range ERROR
 //     EXPECT_EQ(SevError, UNKNOWN_ERROR & SevError);
-//     EXPECT_FALSE(AddCompileError(UNKNOWN_ERROR));
+//     EXPECT_FALSE(ReportCompilerMessage(UNKNOWN_ERROR));
 //     sprintf(expected, "Unknown error %x", UNKNOWN_ERROR);
 //     EXPECT_EQ(3, kmcmp::nErrors);
 
@@ -148,14 +148,14 @@ TEST_F(CompilerTest, wstrtostr_test) {
 //     const int ERROR_CHAR_INDEX = 42;
 //     kmcmp::ErrChr = ERROR_CHAR_INDEX ;
 //     EXPECT_EQ(SevError, KmnCompilerMessages::ERROR_InvalidLayoutLine & SevError);
-//     EXPECT_FALSE(AddCompileError(KmnCompilerMessages::ERROR_InvalidLayoutLine));
+//     EXPECT_FALSE(ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidLayoutLine));
 //     kmcmp::ErrChr = 0;
 //     EXPECT_EQ(4, kmcmp::nErrors);
 
 //     // msgproc returns FALSE
 //     msgproc = msgproc_false_stub;
 //     EXPECT_EQ(SevError, KmnCompilerMessages::ERROR_InvalidLayoutLine & SevError);
-//     EXPECT_TRUE(AddCompileError(KmnCompilerMessages::ERROR_InvalidLayoutLine));
+//     EXPECT_TRUE(ReportCompilerMessage(KmnCompilerMessages::ERROR_InvalidLayoutLine));
 //     EXPECT_EQ(6, kmcmp::nErrors);
 // };
 


### PR DESCRIPTION
This can be reviewed commit-by-commit

1. Replace `AddWarning()` and `AddWarningBool()` macro usage with call to `ReportCompilerMessage()`

   The `AddWarning()` and `AddWarningBool()` macros just called `ReportCompilerMessage()`. A side-effect of removing `AddWarningBool()` is that the functions that called it always returned `TRUE` (and the return value was never checked anyway), and so these functions have been made `void`.

2. rename `AddCompileError()` to `ReportCompilerMessage()`

Relates-to: #10866

@keymanapp-test-bot skip