### PR TITLE
chore(common): use `nvm` to select version of node for builds 🍒 🏠

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": "^18.x"
+        "node": "18.17.0"
       }
     },
     "common/models/templates": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "@keymanapp/ldml-keyboard-constants": "file:core/include/ldml"
   },
   "engines": {
-    "node": "^18.x"
+    "node": "18.17.0"
   }
 }

--- a/resources/build/_builder_nvm.sh
+++ b/resources/build/_builder_nvm.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# See also /docs/build/node.md
+
+set -e
+set -u
+
+if [[ $# -lt 1 ]]; then
+  echo "This script is called by shellHelperFunctions.sh, _select_node_version_with_nvm()"
+  echo "during build.sh configure steps. It is not intended to be called directly, as it"
+  echo "is a wrapper for nvm."
+  exit 99
+fi
+
+REQUIRED_NODE_VERSION="$1"
+
+if [[ -z "${NVM_DIR+x}" ]]; then
+  export NVM_DIR="$HOME/.nvm"
+fi
+
+#
+# nvm on macos and linux is a shell function. `source`ing it into our scripts is
+# fragile because it uses some of the same variable names that we do. We have
+# marked our most precious variables as `readonly`, which breaks nvm re-use of
+# them also! Safest way to work around this is to load nvm in a child process
+# and run it there. Downside is then of course we don't get the `PATH` changes
+# that nvm does for us, so we have to do it ourselves back in the caller,
+# `_select_node_version_with_nvm()`.
+#
+# Note: the readonly attribute for variables is not inherited by child
+#       processes.
+#
+# See also https://github.com/nvm-sh/nvm/issues/3257 (among others)
+#
+
+type -t nvm >/dev/null || {
+  source "$NVM_DIR/nvm.sh"
+  type -t nvm >/dev/null || {
+    echo "Failed to find nvm"
+    exit 1
+  }
+}
+
+nvm install "$REQUIRED_NODE_VERSION"
+nvm use "$REQUIRED_NODE_VERSION"
+
+# Beware the hardcoded path below -- it should already be in the system PATH
+
+mkdir -p "$HOME/.keyman"
+rm -f "$HOME/.keyman/node"
+ln -s "$NVM_BIN" "$HOME/.keyman/node"

--- a/resources/build/jq.inc.sh
+++ b/resources/build/jq.inc.sh
@@ -6,27 +6,29 @@
 # Linux/macOS: jq
 #
 
-## START STANDARD BUILD SCRIPT INCLUDE
-# adjust relative paths as necessary
-JQ_THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-# . "${THIS_SCRIPT%/*}/build-utils.sh"
-## END STANDARD BUILD SCRIPT INCLUDE
+if [[ -z "${JQ+x}" ]]; then
+  ## START STANDARD BUILD SCRIPT INCLUDE
+  # adjust relative paths as necessary
+  JQ_THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+  # . "${THIS_SCRIPT%/*}/build-utils.sh"
+  ## END STANDARD BUILD SCRIPT INCLUDE
 
-case "${OSTYPE}" in
-  "cygwin")
-    JQ=$(dirname "$JQ_THIS_SCRIPT")/jq-win64.exe
-    ;;
-  "msys")
-    JQ=$(dirname "$JQ_THIS_SCRIPT")/jq-win64.exe
-    ;;
-  *)
-    JQ=jq
-    ;;
-esac
+  case "${OSTYPE}" in
+    "cygwin")
+      JQ=$(dirname "$JQ_THIS_SCRIPT")/jq-win64.exe
+      ;;
+    "msys")
+      JQ=$(dirname "$JQ_THIS_SCRIPT")/jq-win64.exe
+      ;;
+    *)
+      JQ=jq
+      ;;
+  esac
 
-readonly JQ
+  readonly JQ
 
-# JQ with inplace file replacement
-function jqi() {
-  cat <<< "$($JQ -c "$1" < "$2")" > "$2"
-}
+  # JQ with inplace file replacement
+  function jqi() {
+    cat <<< "$($JQ -c "$1" < "$2")" > "$2"
+  }
+fi


### PR DESCRIPTION
Used by default only on build agents. See docs/build/node.md and resources/build/_builder_nvm.sh on  master (18.0) branch for documentation of this change -- documentation only added on master.

Specifies node v18.17.0.

Fixes: #11376
Cherry-pick-of: #12069

@keymanapp-test-bot skip