### PR TITLE
chore(developer): Revert "chore(developer): remove redundant references from tsconfig.json"

### DIFF
--- a/developer/src/common/web/test-helpers/tsconfig.json
+++ b/developer/src/common/web/test-helpers/tsconfig.json
@@ -9,4 +9,7 @@
   "include": [
     "./*.ts",
   ],
+  "references": [
+    { "path": "../../../../../common/web/types/" },
+  ]
 }

--- a/developer/src/common/web/utils/test/tsconfig.json
+++ b/developer/src/common/web/utils/test/tsconfig.json
@@ -15,6 +15,7 @@
       "helpers/*.ts",
   ],
   "references": [
-    { "path": "../" },
-  ],
+      { "path": "../" },
+      { "path": "../../test-helpers/" },
+    ]
 }

--- a/developer/src/kmc-analyze/tsconfig.json
+++ b/developer/src/kmc-analyze/tsconfig.json
@@ -9,4 +9,9 @@
   "include": [
     "src/**/*.ts"
   ],
+  "references": [
+    { "path": "../../../common/web/types" },
+    { "path": "../kmc-kmn" },
+    { "path": "../common/web/utils/" },
+  ]
 }

--- a/developer/src/kmc-keyboard-info/build.sh
+++ b/developer/src/kmc-keyboard-info/build.sh
@@ -10,6 +10,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Build Keyman kmc keyboard-info Compiler module" \
   "@/common/web/types" \
   "@/developer/src/common/web/utils" \
+  "@/developer/src/kmc-package" \  
   "clean" \
   "configure" \
   "build" \

--- a/developer/src/kmc-keyboard-info/build.sh
+++ b/developer/src/kmc-keyboard-info/build.sh
@@ -10,7 +10,6 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Build Keyman kmc keyboard-info Compiler module" \
   "@/common/web/types" \
   "@/developer/src/common/web/utils" \
-  "@/developer/src/kmc-package" \
   "clean" \
   "configure" \
   "build" \

--- a/developer/src/kmc-keyboard-info/build.sh
+++ b/developer/src/kmc-keyboard-info/build.sh
@@ -10,7 +10,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Build Keyman kmc keyboard-info Compiler module" \
   "@/common/web/types" \
   "@/developer/src/common/web/utils" \
-  "@/developer/src/kmc-package" \  
+  "@/developer/src/kmc-package" \
   "clean" \
   "configure" \
   "build" \

--- a/developer/src/kmc-keyboard-info/test/tsconfig.json
+++ b/developer/src/kmc-keyboard-info/test/tsconfig.json
@@ -15,5 +15,7 @@
   ],
   "references": [
       { "path": "../" },
+      { "path": "../../common/web/test-helpers/" },
+      { "path": "../../kmc-package/" },
     ]
 }

--- a/developer/src/kmc-keyboard-info/tsconfig.json
+++ b/developer/src/kmc-keyboard-info/tsconfig.json
@@ -16,4 +16,9 @@
     "src/ttfmeta/lib/*.js",
     "src/imports/langtags.js",
   ],
+  "references": [
+    { "path": "../../../common/web/types" },
+    { "path": "../kmc-package/" },
+    { "path": "../common/web/utils/" },
+  ]
 }

--- a/developer/src/kmc-kmn/tsconfig.json
+++ b/developer/src/kmc-kmn/tsconfig.json
@@ -12,4 +12,9 @@
     "src/**/*.ts",
     "src/import/kmcmplib/wasm-host.js"
   ],
+  "references": [
+    { "path": "../../../common/web/types/" },
+    { "path": "../../../common/web/keyman-version/" },
+    { "path": "../common/web/utils/" },
+  ]
 }

--- a/developer/src/kmc-ldml/test/tsconfig.json
+++ b/developer/src/kmc-ldml/test/tsconfig.json
@@ -13,6 +13,10 @@
       "./helpers/index.ts"
   ],
   "references": [
+      { "path": "../../../../common/web/keyman-version" },
+      { "path": "../../../../common/web/types/" },
+      { "path": "../../../../common/tools/hextobin/" },
+      { "path": "../../common/web/test-helpers/" },
       { "path": "../" }
     ]
 }

--- a/developer/src/kmc-ldml/tsconfig.json
+++ b/developer/src/kmc-ldml/tsconfig.json
@@ -9,4 +9,10 @@
   "include": [
     "src/**/*.ts"
   ],
+  "references": [
+    { "path": "../../../common/web/keyman-version" },
+    { "path": "../../../common/web/types/" },
+    { "path": "../kmc-kmn/" },
+    { "path": "../../../core/include/ldml/"},
+  ]
 }

--- a/developer/src/kmc-model-info/test/tsconfig.json
+++ b/developer/src/kmc-model-info/test/tsconfig.json
@@ -15,5 +15,7 @@
   ],
   "references": [
       { "path": "../" },
+      { "path": "../../common/web/test-helpers/" },
+      { "path": "../../kmc-package/" },
     ]
 }

--- a/developer/src/kmc-model-info/tsconfig.json
+++ b/developer/src/kmc-model-info/tsconfig.json
@@ -8,4 +8,9 @@
   "include": [
     "src/**/*.ts"
   ],
+  "references": [
+    { "path": "../../../common/web/types" },
+    { "path": "../../../common/models/types" },
+    { "path": "../common/web/utils" },
+  ]
 }

--- a/developer/src/kmc-model/test/tsconfig.json
+++ b/developer/src/kmc-model/test/tsconfig.json
@@ -17,5 +17,6 @@
   ],
   "references": [
       { "path": "../" },
+      { "path": "../../common/web/test-helpers/" },
     ]
 }

--- a/developer/src/kmc-model/tsconfig.json
+++ b/developer/src/kmc-model/tsconfig.json
@@ -10,4 +10,9 @@
   "include": [
     "src/**/*.ts"
   ],
+  "references": [
+    { "path": "../../../common/web/keyman-version" },
+    { "path": "../../../common/models/types" },
+    { "path": "../../../common/web/types" },
+  ]
 }

--- a/developer/src/kmc-package/test/tsconfig.json
+++ b/developer/src/kmc-package/test/tsconfig.json
@@ -14,5 +14,8 @@
   ],
   "references": [
       { "path": "../" },
+      { "path": "../../../../common/web/types" },
+      { "path": "../../../../common/web/keyman-version" },
+      { "path": "../../common/web/test-helpers/" },
     ]
 }

--- a/developer/src/kmc-package/tsconfig.json
+++ b/developer/src/kmc-package/tsconfig.json
@@ -9,4 +9,8 @@
   "include": [
     "src/**/*.ts",
   ],
+  "references": [
+    { "path": "../../../common/web/keyman-version" },
+    { "path": "../../../common/web/types" },
+  ]
 }

--- a/developer/src/kmc/test/tsconfig.json
+++ b/developer/src/kmc/test/tsconfig.json
@@ -12,6 +12,8 @@
     "./helpers/index.ts",
   ],
   "references": [
+    { "path": "../../../../common/web/types/" },
+    { "path": "../../common/web/test-helpers/" },
     { "path": "../" }
   ]
 }

--- a/developer/src/kmc/tsconfig.json
+++ b/developer/src/kmc/tsconfig.json
@@ -9,4 +9,15 @@
   "include": [
     "src/**/*.ts"
   ],
+  "references": [
+    { "path": "../../../common/web/keyman-version" },
+    { "path": "../../../common/web/types" },
+    { "path": "../kmc-analyze" },
+    { "path": "../kmc-keyboard-info" },
+    { "path": "../kmc-kmn" },
+    { "path": "../kmc-ldml" },
+    { "path": "../kmc-model" },
+    { "path": "../kmc-model-info" },
+    { "path": "../kmc-package" },
+  ]
 }

--- a/developer/src/server/tsconfig.json
+++ b/developer/src/server/tsconfig.json
@@ -22,4 +22,8 @@
   "include": [
     "src/**/*.ts"
   ],
+  "references": [
+    { "path": "../../../common/web/keyman-version" },
+    { "path": "../common/web/utils" },
+  ]
 }


### PR DESCRIPTION
Reverts keymanapp/keyman#12037. The references are needed currently, for `tsc -b` to rebuild the referenced projects.

@keymanapp-test-bot skip