### PR TITLE
fix(web): patch up worker build to provide artifacts for its tests

### DIFF
--- a/common/predictive-text/src/node/tsconfig.json
+++ b/common/predictive-text/src/node/tsconfig.json
@@ -14,7 +14,6 @@
     "*.ts"
   ],
   "references": [
-    { "path": "../tsconfig.json" },
-    { "path": "../../../web/lm-worker" }
+    { "path": "../tsconfig.json" }
   ]
 }

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -55,6 +55,9 @@ function do_build() {
   # Declaration bundling.
   tsc --emitDeclarationOnly --outFile $INTERMEDIATE/worker-main.d.ts
 
+  # Some automated tests currently rely upon the individual output files.
+  tsc
+
   mkdir -p $LIB
 
 


### PR DESCRIPTION
Ran into a scenario just earlier where `$KEYMAN_ROOT/common/web/lm-worker/build.sh clean build test` would fail because `tsc` was never used to actually build the project's files; the tests would report that certain imports from compiled source files were missing.  (The lm-worker currently does not provide a 'test-index', instead providing import maps to each source's compiled form.)

The only reason that our CI builds didn't fail is that `./common/predictive-text` built a project with a reference to the lm-worker project, and _that_ triggered the build that lets the associated tests pass.

@keymanapp-test-bot skip