### PR TITLE
refactor(developer/compilers): prepare for trie-compiler split 📖 

### DIFF
--- a/developer/src/kmc-model/src/build-trie.ts
+++ b/developer/src/kmc-model/src/build-trie.ts
@@ -291,11 +291,26 @@ namespace Trie {
    * @returns A JSON-serialiable object that can be given to the TrieModel constructor.
    */
   export function buildTrie(wordlist: WordList, keyFunction: SearchTermToKey): object {
-    let root = new Trie(keyFunction).buildFromWordList(wordlist).root;
+    let trie = new Trie(keyFunction);
+    buildFromWordList(trie, wordlist);
+    const root = trie.root;
     return {
       totalWeight: sumWeights(root),
       root: root
     }
+  }
+
+  /**
+   * Populates the trie with the contents of an entire wordlist.
+   * @param words a list of word and count pairs.
+   */
+  function buildFromWordList(trie: Trie, words: WordList): Trie {
+    for (let [wordform, weight] of Object.entries(words)) {
+      let key = trie.toKey(wordform);
+      addUnsorted(trie.root, { key, weight, content: wordform }, 0);
+    }
+    sortTrie(trie.root);
+    return trie;
   }
 
   /**
@@ -306,19 +321,6 @@ namespace Trie {
     toKey: SearchTermToKey;
     constructor(wordform2key: SearchTermToKey) {
       this.toKey = wordform2key;
-    }
-
-    /**
-     * Populates the trie with the contents of an entire wordlist.
-     * @param words a list of word and count pairs.
-     */
-    buildFromWordList(words: WordList): Trie {
-      for (let [wordform, weight] of Object.entries(words)) {
-        let key = this.toKey(wordform);
-        addUnsorted(this.root, { key, weight, content: wordform }, 0);
-      }
-      sortTrie(this.root);
-      return this;
     }
   }
 

--- a/developer/src/kmc-model/src/build-trie.ts
+++ b/developer/src/kmc-model/src/build-trie.ts
@@ -291,7 +291,7 @@ namespace Trie {
    * @returns A JSON-serialiable object that can be given to the TrieModel constructor.
    */
   export function buildTrie(wordlist: WordList, keyFunction: SearchTermToKey): object {
-    let trie = new Trie(keyFunction);
+    const trie = new Trie(keyFunction);
     buildFromWordList(trie, wordlist);
     const root = trie.root;
     return {

--- a/developer/src/kmc-model/src/build-trie.ts
+++ b/developer/src/kmc-model/src/build-trie.ts
@@ -302,6 +302,7 @@ namespace Trie {
 
   /**
    * Populates the trie with the contents of an entire wordlist.
+   * @param trie The Trie object under construction
    * @param words a list of word and count pairs.
    */
   function buildFromWordList(trie: Trie, words: WordList): void {

--- a/developer/src/kmc-model/src/build-trie.ts
+++ b/developer/src/kmc-model/src/build-trie.ts
@@ -304,13 +304,12 @@ namespace Trie {
    * Populates the trie with the contents of an entire wordlist.
    * @param words a list of word and count pairs.
    */
-  function buildFromWordList(trie: Trie, words: WordList): Trie {
+  function buildFromWordList(trie: Trie, words: WordList): void {
     for (let [wordform, weight] of Object.entries(words)) {
-      let key = trie.toKey(wordform);
+      const key = trie.toKey(wordform);
       addUnsorted(trie.root, { key, weight, content: wordform }, 0);
     }
     sortTrie(trie.root);
-    return trie;
   }
 
   /**


### PR DESCRIPTION
This PR is direct prep-work for #12083, making the code migration there much more straightforward by relocating a part of the code that should _not_ be migrated out from the part that _is_ migrated in advance.

@keymanapp-test-bot skip