### PR TITLE
refactor(common/models): convert traversal.children method to return array 📖 

### DIFF
--- a/common/models/templates/src/trie.ts
+++ b/common/models/templates/src/trie.ts
@@ -160,9 +160,11 @@ export class TrieTraversal implements LexiconTraversal {
     }
   }
 
-  *children(): Generator<{char: USVString, traversal: () => LexiconTraversal}> {
+  children(): {char: USVString, p: number, traversal: () => LexiconTraversal}[] {
     let root = this.root;
     const totalWeight = this.totalWeight;
+
+    const results: {char: USVString, p: number, traversal: () => LexiconTraversal}[] = [];
 
     // Sorts _just_ the current level, and only if needed.
     // We only care about sorting parts that we're actually accessing.
@@ -183,21 +185,26 @@ export class TrieTraversal implements LexiconTraversal {
             let internalNode = entryNode;
             for(let lowSurrogate of internalNode.values) {
               let prefix = this.prefix + entry + lowSurrogate;
-              yield {
+              results.push({
                 char: entry + lowSurrogate,
+                p: internalNode.children[lowSurrogate].weight / totalWeight,
                 traversal: function() { return new TrieTraversal(internalNode.children[lowSurrogate], prefix, totalWeight) }
-              }
+              });
             }
           } else {
-            // Determine how much of the 'leaf' entry has no Trie nodes, emulate them.
+            // No deduplication needed.  If there were multiple keys available,
+            // we wouldn't be in a leaf node.
             let fullText = entryNode.entries[0].key;
             entry = entry + fullText[this.prefix.length + 1]; // The other half of the non-BMP char.
             let prefix = this.prefix + entry;
 
-            yield {
+            const weight = entryNode.entries.reduce((best, current) => Math.max(best, current.weight), 0);
+
+            results.push({
               char: entry,
+              p: weight / totalWeight,
               traversal: function () {return new TrieTraversal(entryNode, prefix, totalWeight)}
-            }
+            });
           }
         } else if(isSentinel(entry)) {
           continue;
@@ -206,34 +213,41 @@ export class TrieTraversal implements LexiconTraversal {
           continue;
         } else {
           let prefix = this.prefix + entry;
-          yield {
+          results.push({
             char: entry,
+            p: entryNode.weight / totalWeight,
             traversal: function() { return new TrieTraversal(entryNode, prefix, totalWeight)}
-          }
+          });
         }
       }
 
-      return;
+      return results;
     } else { // type == 'leaf'
       let prefix = this.prefix;
 
+      // No actual deduplication needed.  If there were multiple keys available,
+      // we wouldn't be in a leaf node.
       let children = root.entries.filter(function(entry) {
         return entry.key != prefix && prefix.length < entry.key.length;
-      })
+      });
 
-      for(let {key} of children) {
+      let weight = children.reduce((best, current) => Math.max(current.weight, best), 0);
+
+      if(children.length > 0) {
+        const key = children[0].content;
         let nodeKey = key[prefix.length];
 
         if(isHighSurrogate(nodeKey)) {
           // Merge the other half of an SMP char in!
           nodeKey = nodeKey + key[prefix.length+1];
         }
-        yield {
+        results.push({
           char: nodeKey,
+          p: weight / totalWeight,
           traversal: function() { return new TrieTraversal(root, prefix + nodeKey, totalWeight)}
-        }
+        });
       };
-      return;
+      return results;
     }
   }
 

--- a/common/models/templates/test/test-trie-traversal.js
+++ b/common/models/templates/test/test-trie-traversal.js
@@ -174,15 +174,13 @@ describe('Trie traversal abstractions', function() {
                 do {
                   assert.isNotEmpty(leafChildSequence);
 
-                  let iter = curChild.traversal().children();
-                  let curr = iter.next();
-                  curChild = curr.value;
+                  let children = curChild.traversal().children();
+                  assert.equal(children.length, 1);
+                  curChild = children[0];
 
                   // Test generator behavior - there should be one child, then the 'done' state.
                   assert.isDefined(curChild);
                   assert.equal(curChild.char, leafChildSequence[0]);
-                  curr = iter.next();
-                  assert.isTrue(curr.done);
 
                   // Prepare for iteration.
                   leafChildSequence.shift();
@@ -275,15 +273,13 @@ describe('Trie traversal abstractions', function() {
                 do {
                   assert.isNotEmpty(leafChildSequence);
 
-                  let iter = curChild.traversal().children();
-                  let curr = iter.next();
-                  curChild = curr.value;
+                  let children = curChild.traversal().children();
+                  assert.equal(children.length, 1);
+                  curChild = children[0];
 
                   // Test generator behavior - there should be one child, then the 'done' state.
                   assert.isDefined(curChild);
                   assert.equal(curChild.char, leafChildSequence[0]);
-                  curr = iter.next();
-                  assert.isTrue(curr.done);
 
                   // Prepare for iteration.
                   leafChildSequence.shift();
@@ -336,9 +332,6 @@ describe('Trie traversal abstractions', function() {
 
     // Just to be sure our utility function is working right.
     assert.equal(smpA + smpP + 'pl' + smpE, "𝖺𝗉pl𝖾");
-
-    let pKeys = ['p', smpP];
-    let leafChildSequence = ['l', smpE];
 
     const aNode = rootTraversal.child(smpA);
     assert.isOk(aNode);

--- a/common/models/types/index.d.ts
+++ b/common/models/types/index.d.ts
@@ -67,7 +67,7 @@ declare interface LexiconTraversal {
    * - If `char` = 'e', the child represents a prefix of 'the'.
    * - Then `traversal` allows traversing the part of the lexicon prefixed by 'the'.
    */
-  children(): Generator<{char: USVString, traversal: () => LexiconTraversal}>;
+  children(): {char: USVString, p: number, traversal: () => LexiconTraversal}[];
 
   /**
    * Allows direct access to the traversal state that results when appending one


### PR DESCRIPTION
At present, our correction and prediction search methods are not leveraging the generator-based form of the `children()` field on the `LexiconTraversal` type.  When we ask for it, we always utilize every entry in the array in some form.  So, why continue to maintain the generator pattern if we can just return an array instead?

To support #11994, this also adds a new entry to the returned objects:  `p`, the probability of the highest-frequency entry on the node's path.  We've already been returning it on the node itself, but there can be benefits to making it available _before_ constructing the traversal itself; we can compare against the value and avoid overhead if we decide not to take the path, rather than constructing it and only _then_ checking.

Part of the motivation here:

https://github.com/keymanapp/keyman/blob/dd12e7315353d7d8276825f36be6fe29cb796abd/common/models/types/index.d.ts#L46-L70

Examining the current specification of the method (within the linked block above)... note that nowhere within that spec is a requirement or guarantee that the entries be in sorted order.  Granted, our _current_ implementation certainly does enforce this for Trie wordlist models.  Interestingly, upon further examination... there's not actually a need to even require that the entries be sorted.  We generally toss them into a priority queue, and they'll be "sorted" there.

Specifying `p` here gives us the basis to enforce a sort if and needed, without having to call the traversal-generating functions in advance.  There are other cases (such as for model-blending) where the `p` value is needed more as a "filter" than as a sorting condition; it's useful for that as well.

@keymanapp-test-bot skip