### PR TITLE
chore(common): pass ldml import path from caller 🙀 

### DIFF
--- a/developer/src/common/web/utils/src/types/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/developer/src/common/web/utils/src/types/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -22,10 +22,6 @@ export class LDMLKeyboardXMLSourceFileReader {
   constructor(private options: LDMLKeyboardXMLSourceFileReaderOptions, private callbacks : CompilerCallbacks) {
   }
 
-  static get defaultImportsURL(): [string,string] {
-    return ['../../import/', import.meta.url];
-  }
-
   readImportFile(version: string, subpath: string): Uint8Array {
     const importPath = this.callbacks.resolveFilename(this.options.importsPath, `${version}/${subpath}`);
     return this.callbacks.loadFile(importPath);

--- a/developer/src/common/web/utils/test/helpers/reader-callback-test.ts
+++ b/developer/src/common/web/utils/test/helpers/reader-callback-test.ts
@@ -8,8 +8,13 @@ import { LDMLKeyboardTestDataXMLSourceFile } from '../../src/types/ldml-keyboard
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { fileURLToPath } from 'url';
 
+
+function defaultImportsURL(): [string,string] {
+  return ['../../src/import/', import.meta.url];
+}
+
 const readerOptions: LDMLKeyboardXMLSourceFileReaderOptions = {
-  importsPath: fileURLToPath(new URL(...LDMLKeyboardXMLSourceFileReader.defaultImportsURL))
+  importsPath: fileURLToPath(new URL(...defaultImportsURL()))
 };
 
 export interface CompilationCase {

--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -107,6 +107,13 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
   async init(callbacks: CompilerCallbacks, options: LdmlCompilerOptions): Promise<boolean> {
     this.options = { ...options };
     this.callbacks = callbacks;
+
+    // catch this early, as it must be provided.
+    if (!this.options.readerOptions?.importsPath) {
+      callbacks.reportMessage(LdmlCompilerMessages.Fatal_MissingImportsPath());
+      return false;
+    }
+
     return true;
   }
 

--- a/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
@@ -4,7 +4,7 @@ import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m
 const SevHint = CompilerErrorSeverity.Hint | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevWarn = CompilerErrorSeverity.Warn | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevError = CompilerErrorSeverity.Error | CompilerErrorNamespace.LdmlKeyboardCompiler;
-// const SevFatal = CompilerErrorSeverity.Fatal | CompilerErrorNamespace.LdmlKeyboardCompiler;
+const SevFatal = CompilerErrorSeverity.Fatal | CompilerErrorNamespace.LdmlKeyboardCompiler;
 
 // sub-numberspace for transform errors
 const SevErrorTransform = SevError | 0xF00;
@@ -13,6 +13,7 @@ const SevErrorTransform = SevError | 0xF00;
  * @internal
  */
 export class LdmlCompilerMessages {
+  // Note: These are indented so that the error symbols line up after the underscore (_)
   static HINT_NormalizationDisabled = SevHint | 0x0001;
   static Hint_NormalizationDisabled = () => m(this.HINT_NormalizationDisabled, `normalization=disabled is not recommended.`);
 
@@ -27,7 +28,7 @@ export class LdmlCompilerMessages {
 
   static ERROR_KeyNotFoundInKeyBag = SevError | 0x0005;
   static Error_KeyNotFoundInKeyBag = (o:{keyId: string, col: number, row: number, layer: string, form: string}) =>
-    m(this.ERROR_KeyNotFoundInKeyBag, `Key '${def(o.keyId)}' in position #${def(o.col)} on row #${def(o.row)} of layer ${def(o.layer)}, form '${def(o.form)}' not found in key bag`);
+  m(this.ERROR_KeyNotFoundInKeyBag, `Key '${def(o.keyId)}' in position #${def(o.col)} on row #${def(o.row)} of layer ${def(o.layer)}, form '${def(o.form)}' not found in key bag`);
 
   static HINT_OneOrMoreRepeatedLocales = SevHint | 0x0006;
   static Hint_OneOrMoreRepeatedLocales = () =>
@@ -84,7 +85,7 @@ export class LdmlCompilerMessages {
 
   static ERROR_DisplayIsRepeated = SevError | 0x0010;
   static Error_DisplayIsRepeated = (o:{output?: string, keyId?: string}) =>
-    m(this.ERROR_DisplayIsRepeated, `display ${LdmlCompilerMessages.outputOrKeyId(o)} has more than one display entry.`);
+  m(this.ERROR_DisplayIsRepeated, `display ${LdmlCompilerMessages.outputOrKeyId(o)} has more than one display entry.`);
 
   static ERROR_KeyMissingToGapOrSwitch = SevError | 0x0011;
   static Error_KeyMissingToGapOrSwitch = (o:{keyId: string}) =>
@@ -187,7 +188,9 @@ export class LdmlCompilerMessages {
   static Error_UnparseableReorderSet = (o: { from: string, set: string }) =>
   m(this.ERROR_UnparseableReorderSet, `Illegal UnicodeSet "${def(o.set)}" in reorder "${def(o.from)}`);
 
-  // Available: 0x029
+  static FATAL_MissingImportsPath = SevFatal | 0x0029;
+  static Fatal_MissingImportsPath = () =>
+  m(this.FATAL_MissingImportsPath, `Internal Error: readerOptions.importsPath was not set.`);
 
   static ERROR_InvalidQuadEscape = SevError | 0x0030;
   static Error_InvalidQuadEscape = (o: { cp: number }) =>

--- a/developer/src/kmc-ldml/test/helpers/index.ts
+++ b/developer/src/kmc-ldml/test/helpers/index.ts
@@ -36,9 +36,13 @@ export function makePathToFixture(...components: string[]): string {
 
 export const compilerTestCallbacks = new TestCompilerCallbacks();
 
+function defaultImportsURL(): [string,string] {
+  return ['../../../../common/web/utils/build/src/import/', import.meta.url];
+}
+
 export const compilerTestOptions: LdmlCompilerOptions = {
   readerOptions: {
-    importsPath: fileURLToPath(new URL(...LDMLKeyboardXMLSourceFileReader.defaultImportsURL))
+    importsPath: fileURLToPath(new URL(...defaultImportsURL()))
   }
 };
 

--- a/developer/src/kmc-ldml/test/test-compiler-e2e.ts
+++ b/developer/src/kmc-ldml/test/test-compiler-e2e.ts
@@ -4,6 +4,8 @@ import hextobin from '@keymanapp/hextobin';
 import { KMXBuilder } from '@keymanapp/developer-utils';
 import {checkMessages, compileKeyboard, compilerTestCallbacks, compilerTestOptions, makePathToFixture} from './helpers/index.js';
 import { LdmlKeyboardCompiler } from '../src/compiler/compiler.js';
+import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js';
+import { LdmlCompilerOptions } from './main.js';
 
 /** Overall compiler tests */
 describe('compiler-tests', function() {
@@ -71,5 +73,22 @@ describe('compiler-tests', function() {
     await k.init(compilerTestCallbacks, { ...compilerTestOptions, saveDebug: true, shouldAddCompilerVersion: false });
     const source = k.load(filename);
     assert.notOk(source, `Trying to loadTestData(${filename})`);
+  });
+
+  it('should complain if importPath not set', async function() {
+    {
+      compilerTestCallbacks.clear();
+      const k = new LdmlKeyboardCompiler();
+      assert.isFalse(await k.init(compilerTestCallbacks,
+        { /* no compilerTestOptions */ readerOptions: { importsPath: null }, saveDebug: true, shouldAddCompilerVersion: false }));
+      assert.isTrue(compilerTestCallbacks.hasMessage(LdmlCompilerMessages.FATAL_MissingImportsPath));
+    }
+    {
+      compilerTestCallbacks.clear();
+      const k = new LdmlKeyboardCompiler();
+      assert.isFalse(await k.init(compilerTestCallbacks, <LdmlCompilerOptions>
+        { /* no compilerTestOptions or readerOptions */ saveDebug: true, shouldAddCompilerVersion: false }));
+      assert.isTrue(compilerTestCallbacks.hasMessage(LdmlCompilerMessages.FATAL_MissingImportsPath));
+    }
   });
 });

--- a/developer/src/kmc/src/commands/buildClasses/BuildLdmlKeyboard.ts
+++ b/developer/src/kmc/src/commands/buildClasses/BuildLdmlKeyboard.ts
@@ -1,9 +1,13 @@
 import * as kmcLdml from '@keymanapp/kmc-ldml';
 import { KeymanFileTypes } from '@keymanapp/common-types';
 import { CompilerOptions, CompilerCallbacks } from '@keymanapp/developer-utils';
-import { LDMLKeyboardXMLSourceFileReader } from '@keymanapp/developer-utils';
 import { BuildActivity } from './BuildActivity.js';
 import { fileURLToPath } from 'url';
+
+function defaultImportsURL(): [string,string] {
+  // TODO: Need to pull from node_modules!
+  return ['../../../../../common/web/utils/build/src/import/', import.meta.url];
+}
 
 export class BuildLdmlKeyboard extends BuildActivity {
   public get name(): string { return 'LDML keyboard'; }
@@ -13,7 +17,7 @@ export class BuildLdmlKeyboard extends BuildActivity {
   public async build(infile: string, outfile: string, callbacks: CompilerCallbacks, options: CompilerOptions): Promise<boolean> {
     // TODO-LDML: consider hardware vs touch -- touch-only layout will not have a .kvk
     const ldmlCompilerOptions: kmcLdml.LdmlCompilerOptions = {...options, readerOptions: {
-      importsPath: fileURLToPath(new URL(...LDMLKeyboardXMLSourceFileReader.defaultImportsURL))
+      importsPath: fileURLToPath(new URL(...defaultImportsURL()))
     }};
     const compiler = new kmcLdml.LdmlKeyboardCompiler();
     return await super.runCompiler(compiler, infile, outfile, callbacks, ldmlCompilerOptions);

--- a/developer/src/kmc/src/commands/buildTestData/index.ts
+++ b/developer/src/kmc/src/commands/buildTestData/index.ts
@@ -1,12 +1,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as kmcLdml from '@keymanapp/kmc-ldml';
-import { CompilerCallbacks, defaultCompilerOptions, LDMLKeyboardTestDataXMLSourceFile, LDMLKeyboardXMLSourceFileReader } from '@keymanapp/developer-utils';
+import { CompilerCallbacks, defaultCompilerOptions, LDMLKeyboardTestDataXMLSourceFile } from '@keymanapp/developer-utils';
 import { NodeCompilerCallbacks } from '../../util/NodeCompilerCallbacks.js';
 import { fileURLToPath } from 'url';
 import { CommandLineBaseOptions } from 'src/util/baseOptions.js';
 import { exitProcess } from '../../util/sysexits.js';
 import { InfrastructureMessages } from '../../messages/infrastructureMessages.js';
+
+function defaultImportsURL(): [string,string] {
+  return ['../../import/', import.meta.url];
+}
 
 export async function buildTestData(infile: string, _options: any, commander: any): Promise<void> {
   const options: CommandLineBaseOptions = commander.optsWithGlobals();
@@ -17,7 +21,7 @@ export async function buildTestData(infile: string, _options: any, commander: an
     saveDebug: false,
     shouldAddCompilerVersion: false,
     readerOptions: {
-      importsPath: fileURLToPath(new URL(...LDMLKeyboardXMLSourceFileReader.defaultImportsURL))
+      importsPath: fileURLToPath(new URL(...defaultImportsURL()))
     }
   };
 


### PR DESCRIPTION
- remove use of import.meta.url in libraries
- use relative path between tests
- may need some improvement before it works via npm!

Fixes: #10358

@keymanapp-test-bot skip