### PR TITLE
chore(common): add support for build target platform exclusions

### DIFF
--- a/common/build.sh
+++ b/common/build.sh
@@ -16,6 +16,11 @@ builder_describe "Keyman common and resources modules" \
   build \
   test
 
+builder_describe_platform \
+  :linux    linux \
+  :mac      mac \
+  :windows  win
+
 builder_parse "$@"
 
 #-------------------------------------------------------------------------------------------------------------------

--- a/developer/src/.build-builder
+++ b/developer/src/.build-builder
@@ -1,0 +1,1 @@
+The presence of this file tells CI that we can build Developer on mac and linux, as of 18.0. We will be able to remove this file in 19.0.

--- a/developer/src/.build-builder
+++ b/developer/src/.build-builder
@@ -1,1 +1,0 @@
-The presence of this file tells CI that we can build Developer on mac and linux, as of 18.0. We will be able to remove this file in 19.0.

--- a/developer/src/build.sh
+++ b/developer/src/build.sh
@@ -42,6 +42,18 @@ builder_describe \
   "--npm-publish+               For publish, do a npm publish, not npm pack (only for CI)" \
   "--dry-run,-n+                Don't actually publish anything to external endpoints, just dry run"
 
+builder_describe_platform \
+  :ext       win,delphi \
+  :kmanalyze win \
+  :kmdbrowserhost win,delphi \
+  :kmdecomp  win \
+  :kmconvert win,delphi \
+  :samples   win \
+  :setup     win,delphi \
+  :test      win,delphi \
+  :tike      win,delphi \
+  :inst      win,delphi
+
 builder_parse "$@"
 
 #-------------------------------------------------------------------------------------------------------------------

--- a/developer/src/common/build.sh
+++ b/developer/src/common/build.sh
@@ -11,5 +11,8 @@ builder_describe \
   ":delphi                      Delphi components" \
   ":web                         Web components"
 
+builder_describe_platform \
+  :delphi win,delphi
+
 builder_parse "$@"
 builder_run_child_actions clean configure build test

--- a/resources/build/builder.md
+++ b/resources/build/builder.md
@@ -229,6 +229,14 @@ builder_describe \
   "--feature=FOO   Enable feature foo"
 ```
 
+## Constraining build targets by platform or tooling
+
+You can use [`builder_describe_platform`](#builderdescribeplatform-function) to
+constrain certain targets to only run on specific platforms or if specific
+toolchains are installed.
+
+## Parsing command line
+
 After describing the available parameters, you need to pass the command line
 parameters in for parsing and validation:
 
@@ -555,6 +563,47 @@ repository root, not filesystem root.
 
 --------------------------------------------------------------------------------
 
+## `builder_describe_platform` function
+
+Describes the platforms for which a given target will be available, and
+filters the list of targets accordingly, removing targets that cannot be built
+on the current platform. Removed targets will be listed in a separate section
+in the help documentation.
+
+### Usage
+
+```bash
+builder_describe_platform :target platform[,...] [:target platform[,...] ...]
+```
+
+### Parameters
+
+* `target platform[s]` ...:     Target and its list of corresponding platform(s)
+
+### Description
+
+Multiple targets can be listed. Each target must be followed by a comma
+separated list of platforms. The currently supported platforms are:
+
+Operating System platforms:
+* `win`:        Windows
+* `mac`:        macOS
+* `linux`:      Linux
+
+Development tooling platforms:
+* `delphi`:     (On Windows only, Delphi is installed)
+
+Targets not specified will be built on all platforms.
+
+### Example
+
+```bash
+builder_describe_platform \
+  :tike  win,delphi
+```
+
+--------------------------------------------------------------------------------
+
 ## `builder_display_usage` function
 
 Prints the help for the script, constructed from the [`builder_describe`]
@@ -792,6 +841,21 @@ It should never be declared in [`builder_describe`], because it is always
 available anyway.
 
 `--debug` is automatically passed to child scripts and dependency scripts.
+
+--------------------------------------------------------------------------------
+
+## `builder_is_target_excluded_by_platform` function
+
+Returns `true` (aka 0) if the target has been excluded from the build because
+it is for a different platform, or because the required tools are not installed.
+
+### Usage
+
+```bash
+if builder_is_target_excluded_by_platform $target; then
+  ...
+fi
+```
 
 --------------------------------------------------------------------------------
 

--- a/resources/build/test/builder-platform.test.sh
+++ b/resources/build/test/builder-platform.test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../resources/builder.inc.sh"
+# END STANDARD BUILD SCRIPT INCLUDE
+
+. "${THIS_SCRIPT_PATH}/test-utils.inc.sh"
+
+# Test overrides which disable win, delphi
+
+BUILDER_PLATFORM_OVERRIDE=linux
+BUILDER_TOOLS_OVERRIDE=
+
+builder_describe \
+  "Tests platform requirements" \
+  build \
+  :linux-project \
+  :mac-project \
+  :win-project \
+  :delphi-project
+
+builder_describe_platform \
+  :linux-project linux \
+  :mac-project mac \
+  :win-project win \
+  :delphi-project win,delphi
+
+assert-equal "${_builder_targets[*]}" ":linux-project" "_builder_targets"
+assert-equal "${!_builder_targets_excluded_by_platform[*]}" ":delphi-project :win-project :mac-project" "_builder_targets_excluded_by_platform"
+
+# Test overrides with enable win, delphi
+
+BUILDER_PLATFORM_OVERRIDE=win
+BUILDER_TOOLS_OVERRIDE=(delphi)
+
+builder_describe \
+  "Tests platform requirements" \
+  build \
+  :linux-project \
+  :mac-project \
+  :win-project \
+  :delphi-project
+
+builder_describe_platform \
+  :linux-project linux \
+  :mac-project mac \
+  :win-project win \
+  :delphi-project win,delphi
+
+assert-equal "${_builder_targets[*]}" ":win-project :delphi-project" "_builder_targets"
+assert-equal "${!_builder_targets_excluded_by_platform[*]}" ":linux-project :mac-project" "_builder_targets_excluded_by_platform"

--- a/resources/build/test/builder-platform.test.sh
+++ b/resources/build/test/builder-platform.test.sh
@@ -30,7 +30,10 @@ builder_describe_platform \
   :delphi-project win,delphi
 
 assert-equal "${_builder_targets[*]}" ":linux-project" "_builder_targets"
-assert-equal "${!_builder_targets_excluded_by_platform[*]}" ":delphi-project :win-project :mac-project" "_builder_targets_excluded_by_platform"
+
+# seems bash associative array order is unstable? so sort array for test
+readarray -t btebp_sorted < <(printf '%s\n' "${!_builder_targets_excluded_by_platform[@]}" | sort)
+assert-equal "${btebp_sorted[*]}" ":delphi-project :mac-project :win-project" "_builder_targets_excluded_by_platform"
 
 # Test overrides with enable win, delphi
 
@@ -51,5 +54,8 @@ builder_describe_platform \
   :win-project win \
   :delphi-project win,delphi
 
-assert-equal "${_builder_targets[*]}" ":win-project :delphi-project" "_builder_targets"
-assert-equal "${!_builder_targets_excluded_by_platform[*]}" ":linux-project :mac-project" "_builder_targets_excluded_by_platform"
+readarray -t bt_sorted < <(printf '%s\n' "${_builder_targets[@]}" | sort)
+assert-equal "${bt_sorted[*]}" ":delphi-project :win-project" "_builder_targets"
+
+readarray -t btebp_sorted < <(printf '%s\n' "${!_builder_targets_excluded_by_platform[@]}" | sort)
+assert-equal "${btebp_sorted[*]}" ":linux-project :mac-project" "_builder_targets_excluded_by_platform"

--- a/resources/build/test/test-utils.inc.sh
+++ b/resources/build/test/test-utils.inc.sh
@@ -1,0 +1,16 @@
+function assert-equal() {
+  local actual="$1"
+  local expected="$2"
+  local message=
+  if [[ $# -gt 2 ]]; then
+    message="$3: "
+  fi
+
+  builder_echo "Testing: '$*'"
+
+  if [[ "$actual" != "$expected" ]]; then
+    builder_die "FAIL: ${message}expected actual '$actual' to equal expected '$expected'"
+  else
+    builder_echo green "PASS: ${message}expected actual '$actual' to be equal to expected '$expected'"
+  fi
+}

--- a/resources/build/test/test-utils.inc.sh
+++ b/resources/build/test/test-utils.inc.sh
@@ -6,8 +6,6 @@ function assert-equal() {
     message="$3: "
   fi
 
-  builder_echo "Testing: '$*'"
-
   if [[ "$actual" != "$expected" ]]; then
     builder_die "FAIL: ${message}expected actual '$actual' to equal expected '$expected'"
   else

--- a/resources/build/test/test.sh
+++ b/resources/build/test/test.sh
@@ -206,6 +206,10 @@ echo -e "${COLOR_BLUE}## Running dependency tests${COLOR_RESET}"
 "$THIS_SCRIPT_PATH/debug-deps/test.sh"
 "$THIS_SCRIPT_PATH/ignored-flags/test.sh"
 
+echo -e "${COLOR_BLUE}## Test builder.inc.sh platform and tool constraints${COLOR_RESET}"
+"$THIS_SCRIPT_PATH/builder-platform.test.sh"
+
+
 echo -e "${COLOR_BLUE}## Test builder.inc.sh 'builder-style' script${COLOR_RESET}"
 ./builder-invalid-script.test.sh || builder_die "FAIL: builder-invalid-script.test.sh returned failure code $?"
 


### PR DESCRIPTION
Add `builder_describe_platform` function to builder.inc.sh, associated documentation and unit test, and use it in Developer and Common build scripts.

If you run `./developer/src/build.sh` with no targets, it will build all available targets on the current platform -- for example on Linux, excluding projects like :tike.

However, if you run `./developer/src/build.sh :tike` on a mac or linux machine, then the build will fail with an error which is hopefully clear enough: 

```
Target :tike is unavailable because it requires win
```

Relates-to: #11755

@keymanapp-test-bot skip