### PR TITLE
feat(common): add top-level build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/resources/build/builder.inc.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+builder_describe "Keyman -- all projects" \
+  ":common" \
+  ":core" \
+  ":android" \
+  ":ios" \
+  ":linux" \
+  ":mac" \
+  ":web" \
+  ":windows" \
+  ":developer" \
+  clean \
+  configure \
+  build \
+  test \
+  install \
+  publish
+
+builder_describe_platform \
+  :android  android-studio \
+  :ios      mac \
+  :linux    linux \
+  :mac      mac \
+  :windows  win
+
+builder_parse "$@"
+
+#-------------------------------------------------------------------------------------------------------------------
+
+builder_run_child_actions clean configure build test publish install

--- a/resources/build/builder.md
+++ b/resources/build/builder.md
@@ -586,12 +586,13 @@ Multiple targets can be listed. Each target must be followed by a comma
 separated list of platforms. The currently supported platforms are:
 
 Operating System platforms:
-* `win`:        Windows
-* `mac`:        macOS
-* `linux`:      Linux
+* `win`: Windows
+* `mac`: macOS
+* `linux`: Linux
 
 Development tooling platforms:
-* `delphi`:     (On Windows only, Delphi is installed)
+* `delphi`: Delphi is installed (Windows only)
+* `android-studio`: Android Studio is installed (`$ANDROID_HOME` variable)
 
 Targets not specified will be built on all platforms.
 

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1945,12 +1945,13 @@ _builder_has_function_been_called() {
 #   linux      Linux
 #
 # Development tooling platforms:
-#   delphi     (On Windows only, Delphi is installed)
+#   delphi     Delphi is installed (on Windows only)
+#   android    Android Studio is installed
 #
 builder_describe_platform() {
 
   local builder_platforms=(linux mac win)
-  local builder_tools=(delphi)
+  local builder_tools=(android-studio delphi)
 
   # --- Detect platform ---
 
@@ -1977,6 +1978,13 @@ builder_describe_platform() {
       builder_installed_tools+=(delphi)
     fi
   fi
+
+  # Detect Android Studio based on ANDROID_HOME environment variable
+  if [[ ! -z ${ANDROID_HOME+x} ]]; then
+    builder_installed_tools+=(android-studio)
+  fi
+
+  # --- Overrides ---
 
   # For testing, we can override the current platform
   if [[ ! -z "${BUILDER_PLATFORM_OVERRIDE+x}" ]]; then


### PR DESCRIPTION
This top-level builder script will build as many projects as are possible to build on the current platform. For example, iOS and macOS projects can only be built on macOS; Windows and parts of Developer can only be built on Windows.

Relates-to: #6268

@keymanapp-test-bot skip