### PR TITLE
feat(web): enable utf8 charset encoding for the build artifacts

### DIFF
--- a/common/web/es-bundling/src/common-bundle.mts
+++ b/common/web/es-bundling/src/common-bundle.mts
@@ -3,6 +3,7 @@ import esbuild from 'esbuild';
 import { esmConfiguration, forES6, iifeConfiguration } from './configuration.mjs';
 import { prepareTslibTreeshaking } from './tslibTreeshaking.mjs';
 
+let CHARSET = 'ascii';
 let FORMAT = 'iife';
 let MINIFY = false;
 
@@ -28,6 +29,8 @@ Parameters:
 
 Options:
   --help                Shows this script's documentation
+  --charset=<charset>   Sets the charset type for esbuild to emit.  Defaults to 'ascii'
+                        but may also be 'utf8'.
   --format=<format>     Sets the format type to use for the generated bundle.  Should be
                         'iife' or 'esm'.
 
@@ -49,15 +52,28 @@ if(process.argv.length > 2) {
       case '--help':
         doHelp();
         break;
-      case '--format':  // bc TS uses this exact flag.  esbuild... uses sourcemap (in the JS config)
-        let input = process.argv[++i];
-        switch(input) {
-          case 'iife':
-          case 'esm':
-            FORMAT = input;
+      case '--charset':
+        let charsetOption = process.argv[++i];
+        switch(charsetOption) {
+          case 'ascii':
+          case 'utf8':
+            CHARSET = charsetOption;
             break;
           default:
-            console.error(`Invalid bundling format specified: ${input}.  Must be 'iife' or 'esm'.`);
+            console.error(`Invalid bundling format specified: ${charsetOption}.  Must be 'ascii' or 'utf8'.`);
+            doHelp(1);
+            break;
+        }
+        break;
+      case '--format':  // bc TS uses this exact flag.  esbuild... uses sourcemap (in the JS config)
+        let formatOption = process.argv[++i];
+        switch(formatOption) {
+          case 'iife':
+          case 'esm':
+            FORMAT = formatOption;
+            break;
+          default:
+            console.error(`Invalid bundling format specified: ${formatOption}.  Must be 'iife' or 'esm'.`);
             doHelp(1);
             break;
         }
@@ -128,6 +144,7 @@ const baseConfig = FORMAT == 'iife' ? iifeConfiguration : esmConfiguration;
 const config: esbuild.BuildOptions = {
   ...jsVersionTarget == 'es6' ? forES6(baseConfig) : baseConfig,
   entryPoints: [sourceFile],
+  charset: CHARSET as 'ascii' | 'utf8',
   outfile: destFile,
   minify: MINIFY,
   metafile: !!profilePath,

--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -64,6 +64,7 @@ function do_build() {
   # The ES6 target needs no polyfills - we go straight to the wrapped version.
   $bundle_cmd src/main/worker-main.ts \
     --out $INTERMEDIATE/worker-main.js \
+    --charset "utf8" \
     --target "es6" \
     --sourceRoot '@keymanapp/keyman/common/web/lm-worker/src/main'
 
@@ -75,6 +76,7 @@ function do_build() {
   $bundle_cmd src/main/worker-main.ts \
     --out $INTERMEDIATE/worker-main.min.js \
     --minify \
+    --charset "utf8" \
     --profile build/filesize-profile.log \
     --target "es6" \
     --sourceRoot '@keymanapp/keyman/common/web/lm-worker/src/main'

--- a/web/src/app/browser/build.sh
+++ b/web/src/app/browser/build.sh
@@ -55,11 +55,13 @@ compile_and_copy() {
 
   $BUNDLE_CMD    "${SRC_ROOT}/debug-main.js" \
     --out        "${BUILD_ROOT}/debug/keymanweb.js" \
+    --charset    "utf8" \
     --sourceRoot "@keymanapp/keyman/web/build/app/browser/debug" \
     --target     "es6"
 
   $BUNDLE_CMD    "${SRC_ROOT}/release-main.js" \
     --out        "${BUILD_ROOT}/release/keymanweb.js" \
+    --charset    "utf8" \
     --profile    "${BUILD_ROOT}/filesize-profile.log" \
     --sourceRoot "@keymanapp/keyman/web/build/app/browser/release" \
     --minify \
@@ -67,6 +69,7 @@ compile_and_copy() {
 
   $BUNDLE_CMD    "${BUILD_ROOT}/obj/test-index.js" \
     --out        "${BUILD_ROOT}/lib/index.mjs" \
+    --charset    "utf8" \
     --sourceRoot "@keymanapp/keyman/web/build/app/browser/lib" \
     --format esm
 

--- a/web/src/app/webview/build.sh
+++ b/web/src/app/webview/build.sh
@@ -45,11 +45,13 @@ compile_and_copy() {
 
   $BUNDLE_CMD    "${SRC_ROOT}/debug-main.js" \
     --out        "${BUILD_ROOT}/debug/keymanweb-webview.js" \
+    --charset    "utf8" \
     --sourceRoot "@keymanapp/keyman/web/build/app/webview/debug" \
     --target     "es6"
 
   $BUNDLE_CMD    "${SRC_ROOT}/release-main.js" \
     --out        "${BUILD_ROOT}/release/keymanweb-webview.js" \
+    --charset    "utf8" \
     --profile    "${BUILD_ROOT}/filesize-profile.log" \
     --sourceRoot "@keymanapp/keyman/web/build/app/webview/release" \
     --minify \


### PR DESCRIPTION
As esbuild allows us to force use of a utf8 charset, this PR leverages that to further push our filesize gains from #10692.  

We don't use non-ASCII JS identifiers, which would be the biggest concern.  The second-biggest concern is in regard to load time compared to load time when esbuild's default ascii-charset output... something that will need further observation.

Either way, this change drops the 14.8 kB data table size from #10692 further down to a mere 8.0 kB - a roughly 10 kB total savings!

@keymanapp-test-bot skip
