### PR TITLE
fix(common): show description even if child projects specifies path

### DIFF
--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -866,6 +866,7 @@ builder_describe() {
         IFS="=" read -r -a sub <<< "$value"
         target_path="${sub[@]:1}"
         value="${sub[0]}"
+        original_value="$value"
         if [[ ! -d "$THIS_SCRIPT_PATH/$target_path" ]]; then
           builder_die "Target path '$target_path' for $value does not exist."
         fi


### PR DESCRIPTION
Previously we didn't show the description for the target if the target definition specified a an alternate folder, e.g. `:app=src/app`. This change fixes this.

# User Testing

**TEST_FIXED**:
- run `web/build.sh --help`
- verify that the following line displays (under Targets):
  ```
  :test-pages                 Builds resources needed for the KMW manual testing pages
  ```