### PR TITLE
chore(web): drop flaky auto-test component

### DIFF
--- a/common/web/lm-worker/src/test/mocha/cases/worker-model-compositor.js
+++ b/common/web/lm-worker/src/test/mocha/cases/worker-model-compositor.js
@@ -200,11 +200,9 @@ describe('ModelCompositor', function() {
         //   secondary corrections may be found
         // - It's possible to interrupt "too late" if the correction search proceeds quickly,
         //   returning a standard full set.
-        const terminatedSuggestions = await firstPredict;
+        await firstPredict;
         const finalSuggestions = await secondPredict;
-        if(terminatedSuggestions.length > 0) {
-          assert.isOk(terminatedSuggestions.find((entry) => entry.displayAs == 'a'));
-        }
+
         assert.isOk(finalSuggestions.find((entry) => entry.displayAs == 'applied'));
       });
     });


### PR DESCRIPTION
So, it looks like I messed up with a merge conflict resolution a while back and restored a flaky component of one of our worker-oriented automated tests.  I can't seem to reproduce it on my local machine, but it has been affecting [a few of our CI builds](https://build.palaso.org/buildConfiguration/Keyman_Common_LMLayer_TestPullRequests/485803?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true&expandBuildTestsSection=true).

The easiest solution is to drop that piece, especially since the value returned by the `await firstPredict` line is quite subject to race-condition-like effects.  The key thing to check is the stability for `await secondPredict`.

Ideally, I'd want to reproduce the bug locally and better understand where my assumptions for `firstPredict`'s results are invalid, but oh well.  It's not worth leaving the automated test instability untouched.

@keymanapp-test-bot skip