### PR TITLE
fix(windows): "Keyman" is not localized in UI strings

### DIFF
--- a/windows/src/desktop/kmshell/xml/splash.xsl
+++ b/windows/src/desktop/kmshell/xml/splash.xsl
@@ -30,7 +30,13 @@
   <div id="family"></div>
 
   <a href="keyman:start" id="startNow" class="button">
-    <div class="btn btn-blue"><xsl:value-of select="$locale/string[@name='S_Splash_Start']"/></div>
+    <div class="btn btn-blue">
+      <xsl:variable name="originalText" select="$locale/string[@name='S_Splash_Start_2']"/>
+      <xsl:variable name="replacement" select="'Keyman'"/>
+      <xsl:variable name="beforePlaceholder" select="substring-before($originalText, '%0:s')"/>
+      <xsl:variable name="afterPlaceholder" select="substring-after($originalText, '%0:s')"/>
+      <xsl:value-of select="concat($beforePlaceholder, $replacement, $afterPlaceholder)"/>
+    </div>
   </a>
   <a class="button" id="config" href="keyman:config"><div class="btn btn-orange"><xsl:value-of select="$locale/string[@name='S_Splash_Configuration']"/></div></a>
 

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -10,7 +10,7 @@
   <!-- Context: System -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.1.266.0 -->
-  <string name="S_LocaleAuthors" translatable="false" comment="Name(s) of people who created this translation - i.e. your name">Keyman</string>
+  <string name="S_LocaleAuthors" comment="Name(s) of people who created this translation - i.e. your name">Keyman</string>
 
   <!-- Context: _Font -->
   <!-- String Type: PlainText -->

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -792,12 +792,17 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <!-- Context: Splash Dialog -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.288.0 -->
-  <string name="S_Splash_Name" comment="Splash major title">Keyman</string>
+  <string name="S_Splash_Name" translatable="false" comment="Splash major title">Keyman</string>
 
   <!-- Context: Splash Dialog -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.294.0 -->
   <string name="S_Splash_Start" comment="Start Keyman button">Start Keyman</string>
+
+  <!-- Context: Splash Dialog -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 18.0 -->
+  <string name="S_Splash_Start_2" comment="Start {Keyman} button">Start %1$s</string>
 
   <!-- Context: Splash Dialog -->
   <!-- String Type: PlainText -->

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -10,7 +10,7 @@
   <!-- Context: System -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.1.266.0 -->
-  <string name="S_LocaleAuthors" comment="Name(s) of people who created this translation - i.e. your name">Keyman</string>
+  <string name="S_LocaleAuthors" translatable="false" comment="Name(s) of people who created this translation - i.e. your name">Keyman</string>
 
   <!-- Context: _Font -->
   <!-- String Type: PlainText -->
@@ -860,7 +860,7 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="SKShortApplicationTitle" comment="Product name">Keyman</string>
+  <string name="SKShortApplicationTitle" translatable="false" comment="Product name">Keyman</string>
 
 
 
@@ -1026,7 +1026,7 @@ keyboard that you use in Windows.  Keyman keyboards will adapt automatically to 
   <!-- Context: Formatted Messages -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="SKApplicationTitle" comment="Product name used for the title of message boxes and message dialogs">Keyman</string>
+  <string name="SKApplicationTitle" translatable="false" comment="Product name used for the title of message boxes and message dialogs">Keyman</string>
 
   <!-- Parameters: %1$s = Version number string -->
   <!-- Context: Formatted Messages -->


### PR DESCRIPTION
Fixes: #9635

The attribute `translatable="false"` and be added to the strings.xml for Android resources. This is a hint to the translators not to translate this string. However, that applies to the whole string.
This PR adds a new string for the splash screen which allows the translator to change the word "start" and place it before or after the place holder for Keyman.

# User Testing

# TEST_SPLASH_SCREEN
1. Install the Keyman build for this PR
2. Start Keyman and the splash screen button should still correctly say Start Keyman.

![image](https://github.com/user-attachments/assets/51d0aa14-4f55-44a7-833d-f8cfe0daa95a)
