### PR TITLE
fix(web): support live configuration of longpress delay

### DIFF
--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -254,9 +254,7 @@ export function gestureSetForLayout(flags: LayoutGestureSupportFlags, params: Ge
   // `deepCopy` does not preserve property definitions, instead raw-copying its value.
   // We need to re-instate the longpress delay property here.
   Object.defineProperty(_longpressModel.contacts[0].model.timer, 'duration', {
-    get: () => {
-      return params.longpress.waitLength
-    }
+    get: () => params.longpress.waitLength
   });
 
   // #region Functions for implementing and/or extending path initial-state checks

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -248,7 +248,16 @@ export function gestureSetForLayout(flags: LayoutGestureSupportFlags, params: Ge
 
   const _initialTapModel: GestureModel<KeyElement> = deepCopy(!doRoaming ? initialTapModel(params) : initialTapModelWithReset(params));
   const _simpleTapModel: GestureModel<KeyElement> = deepCopy(!doRoaming ? simpleTapModel(params) : simpleTapModelWithReset(params));
-  const _longpressModel: GestureModel<KeyElement> = deepCopy(longpressModel(params, true, doRoaming));
+  // Ensure all deep-copy operations for longpress modeling occur before the property-redefining block.
+  const _longpressModel: GestureModel<KeyElement> = withKeySpecFiltering(deepCopy(longpressModel(params, true, doRoaming)), 0);
+
+  // `deepCopy` does not preserve property definitions, instead raw-copying its value.
+  // We need to re-instate the longpress delay property here.
+  Object.defineProperty(_longpressModel.contacts[0].model.timer, 'duration', {
+    get: () => {
+      return params.longpress.waitLength
+    }
+  });
 
   // #region Functions for implementing and/or extending path initial-state checks
   function withKeySpecFiltering(model: GestureModel<KeyElement>, contactIndices: number | number[]) {
@@ -281,7 +290,7 @@ export function gestureSetForLayout(flags: LayoutGestureSupportFlags, params: Ge
   const specialStartModel = specialKeyStartModel();
   const _modipressStartModel = modipressStartModel();
   const gestureModels: GestureModel<KeyElement>[] = [
-    withKeySpecFiltering(_longpressModel, 0),
+    _longpressModel,
     withKeySpecFiltering(multitapStartModel(params), 0),
     multitapEndModel(params),
     _initialTapModel,
@@ -481,7 +490,8 @@ export function longpressContactModel(params: GestureParams, enabledFlicks: bool
     itemPriority: 0,
     pathResolutionAction: 'resolve',
     timer: {
-      duration: spec.waitLength,
+      // Needs to be a getter so that it dynamically updates if the backing value is changed.
+      get duration() { return spec.waitLength },
       expectedResult: true
     },
     validateItem: (_: KeyElement, baseKey: KeyElement) => !!baseKey?.key.spec.sk,


### PR DESCRIPTION
While @darcywong00 was working on #12170, he noticed that adjusting the longpress delay timing value wasn't passing through; this PR fixes that.

The cause:  on the longpress contact model, `duration` simply copied the value as a literal - not a function or property that will re-fetch it when needed.  So... it didn't update after the OSK was constructed.

The obvious solution is to make it a `get`-property on the model.  A little extra work was needed to preserve this due to the deep-copying protection that's in place to prevent permanent adjustments to the model definitions, but a well-placed redefinition of the property seems to do the job just fine.

I did a mild inspection of other uses for the gesture parameterization object and its values, and fortunately all other cases appear to be within functions.  The usage pattern appears specific to just this one parameter.

**Note**: at present, any changes to this setting must be reapplied after every time that the keyboard is swapped; we rebuild the gesture engine each time, which involves rebuilding the gesture parameters (from their default values).  Obviously not ideal, but changing this will be its own, separate task... that may need a bit of design work.

@keymanapp-test-bot skip