### PR TITLE
feat(web): add osk.gestureParams for better gesture-config persistence

### DIFF
--- a/web/src/engine/osk/src/config/commonConfiguration.ts
+++ b/web/src/engine/osk/src/config/commonConfiguration.ts
@@ -2,6 +2,7 @@ import { DeviceSpec } from "@keymanapp/web-utils";
 
 import EmbeddedGestureConfig from './embeddedGestureConfig.js';
 import { OSKResourcePathConfiguration } from "keyman/engine/interfaces";
+import { GestureParams } from "../input/gestures/specsForLayout.js";
 
 export default interface CommonConfiguration {
   /**
@@ -30,4 +31,9 @@ export default interface CommonConfiguration {
    * embedded within a WebView.
    */
   embeddedGestureConfig?: EmbeddedGestureConfig;
+
+  /**
+   * Specifies the gesture parameterizations to use for the active keyboard.
+   */
+  gestureParams?: GestureParams;
 }

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -21,12 +21,16 @@ import { calcLockedDistance, lockedAngleForDir, MAX_TOLERANCE_ANGLE_SKEW, type O
 import specs = gestures.specs;
 
 export interface GestureParams<Item = any> {
-  longpress: {
+  readonly longpress: {
     /**
-     * Allows enabling or disabling the longpress up-flick shortcut for keyboards that do not
-     * include any defined flick gestures.
+     * Allows enabling or disabling the longpress up-flick shortcut for
+     * keyboards that do not include any defined flick gestures.
      *
-     * Will be ignored (in favor of `false`) for keyboards that do have defined flicks.
+     * Will be ignored (in favor of `false`) for keyboards that do have defined
+     * flicks.
+     *
+     * Note:  this is automatically overwritten during keyboard initialization
+     * to match the keyboard's properties.
      */
     permitsFlick: (item?: Item) => boolean,
 
@@ -57,7 +61,7 @@ export interface GestureParams<Item = any> {
      */
     waitLength: number
   },
-  multitap: {
+  readonly multitap: {
     /**
      * The duration (in ms) permitted between taps.  Taps with a greater time interval
      * between them will be considered separate.
@@ -70,7 +74,7 @@ export interface GestureParams<Item = any> {
      */
     holdLength: number;
   },
-  flick: {
+  readonly flick: {
     /**
      * The minimum _net_ touch-path distance that must be traversed to "lock in" on
      * a flick gesture.  When keys support both longpresses and flicks, this distance

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -26,6 +26,7 @@ import { EventListener, KeyEventHandler, KeyEventSourceInterface, LegacyEventEmi
 import Configuration from '../config/viewConfiguration.js';
 import Activator, { StaticActivator } from './activator.js';
 import TouchEventPromiseMap from './touchEventPromiseMap.js';
+import { DEFAULT_GESTURE_PARAMS, GestureParams } from '../input/gestures/specsForLayout.js';
 
 // These will likely be eliminated from THIS file at some point.\
 
@@ -173,6 +174,18 @@ export default abstract class OSKView
   };
 
   /**
+   * Provides the current parameterization for timings and distances used by
+   * any gesture-supporting keyboards.  Changing properties of its objects will
+   * automatically update keyboards to use the new configuration.
+   *
+   * If `gestureParams` was set in the configuration object passed in at
+   * construction time, this will be the same instance.
+   */
+  get gestureParams(): GestureParams {
+    return this.config.gestureParams;
+  }
+
+  /**
    * The configured width for this OSKManager.  May be `undefined` or `null`
    * to allow automatic width scaling.
    */
@@ -216,6 +229,8 @@ export default abstract class OSKView
 
     // Clone the config; do not allow object references to be altered later.
     this.config = configuration = {...configuration};
+    // If gesture parameters were not provided in advance, initialize them from defaults.
+    this.config.gestureParams ||= DEFAULT_GESTURE_PARAMS;
 
     // `undefined` is falsy, but we want a `true` default behavior for this config property.
     if(this.config.allowHideAnimations === undefined) {
@@ -820,7 +835,8 @@ export default abstract class OSKView
         family: 'SpecialOSK',
         files: [`${resourcePath}/keymanweb-osk.ttf`],
         path: '' // Not actually used.
-      }
+      },
+      gestureParams: this.config.gestureParams
     });
 
     vkbd.on('keyevent', (keyEvent, callback) => this.emit('keyevent', keyEvent, callback));

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -151,8 +151,8 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
   /**
    * Tweakable gesture parameters referenced by supported gestures and the gesture engine.
    */
-  readonly gestureParams: GestureParams<KeyElement> = {
-    ...DEFAULT_GESTURE_PARAMS,
+  get gestureParams(): GestureParams<KeyElement> {
+    return this.config.gestureParams;
   };
 
   // Legacy alias, maintaining a reference for code built against older
@@ -306,6 +306,10 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     if (config.isStatic) {
       this.isStatic = config.isStatic;
     }
+
+    this.config.gestureParams ||= {
+      ...DEFAULT_GESTURE_PARAMS,
+    };
 
     this._fixedWidthScaling  = this.device.touchable && !this.isStatic;
     this._fixedHeightScaling = this.device.touchable && !this.isStatic;


### PR DESCRIPTION
Adds a more 'stable' internal API point (`keyman.osk.gestureParams`) for configuring gesture parameterization settings.  I'm not convinced it's the long-term best solution as the "true" API point, but I think that even if not, it's likely to be quite usable by whatever we decide on _making_ that API point.

With this changeset, the gesture parameters only need to be adjusted once; the new setting will persist for the lifetime of the OSK, even across keyboard swaps.

Example:
```typescript
keyman.osk.gestureParams.longpress.waitLength = 5000 // sets the longpress delay to 5 sec
```

@keymanapp-test-bot skip