### PR TITLE
fix(web): allow `lm-worker` to build on Linux

### DIFF
--- a/common/web/lm-worker/build.sh
+++ b/common/web/lm-worker/build.sh
@@ -98,7 +98,7 @@ function do_test() {
 
   if builder_has_option --ci; then
     MOCHA_FLAGS="$MOCHA_FLAGS --reporter mocha-teamcity-reporter"
-    WTR_CONFIG=.ci
+    WTR_CONFIG=.CI
   fi
 
   if builder_has_option --debug; then


### PR DESCRIPTION
Linux' file system is case-sensitive. This change fixes building `lm-worker` on case-sensitive systems.

@keymanapp-test-bot skip