### PR TITLE
fix(developer): ignore scan code if zero in debugger 🍒 🏠

### DIFF
--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -424,14 +424,21 @@ function TfrmDebug.ProcessKeyEvent(var Message: TMessage): Boolean;
     end;
   end;
 var
-  vkey, modifier: uint16_t;
+  scan, vkey, modifier: uint16_t;
 begin
   Assert(Assigned(FDebugCore));
 
   // We always use the US virtual key code as a basis for our keystroke
   // mapping; the best way to do this is to extract the scan code from
   // the message data and work from that
-  vkey := MapScanCodeToUSVK((Message.LParam and $FF0000) shr 16);
+
+  // Note: if a key event has a zero scan code, it has probably been
+  // injected, so we will do our best with it, using the VK as provided.
+  // See also #11978
+  scan := (Message.LParam and $FF0000) shr 16;
+  if scan = 0
+    then vkey := Message.WParam
+    else vkey := MapScanCodeToUSVK(scan);
 
   // We don't support the Right Shift modifier in Keyman;
   // we treat it as Left Shift, even though MapScanCodeToUSVK


### PR DESCRIPTION
The Windows Clipboard Win+V key event emits Ctrl+V after rewriting the clipboard, in order to trigger a Paste action in the active app. However, the Ctrl key event has been given a scan code value of zero by Windows Clipboard, which was confusing the Keyman Developer Debugger, causing it to process Ctrl as an unrecognized key rather than as a modifier, and leading to an unsupported state.

This is a fix for the immediate issue. We could do more to improve resilience such that `km_core_state_debug_items()` can never end up with this exception when `km_core_process_event()` has returned true.

Fixes: #11978
Fixes: KEYMAN-DEVELOPER-20W
Cherry-pick-of: #12166

@keymanapp-test-bot skip