### PR TITLE
feat(android): Pass longpress delay to KeymanWeb

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -4,6 +4,7 @@
 
 package com.keyman.android;
 
+import com.tavultesoft.kmapro.AdjustLongpressDelayActivity;
 import com.tavultesoft.kmapro.BuildConfig;
 import com.tavultesoft.kmapro.DefaultLanguageResource;
 import com.tavultesoft.kmapro.KeymanSettingsActivity;
@@ -79,6 +80,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     // Set the system keyboard HTML banner
     BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
 
+    int longpressDelay = KMManager.getLongpressDelay(this);
+    KMManager.setLongpressDelay(longpressDelay);
     boolean mayHaveHapticFeedback = prefs.getBoolean(KeymanSettingsActivity.hapticFeedbackKey, false);
     KMManager.setHapticFeedback(mayHaveHapticFeedback);
 
@@ -244,6 +247,9 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
       if (exText != null)
         exText = null;
     }
+    // Initialize the longpress delay
+    int longpressDelay = KMManager.getLongpressDelay(this);
+    KMManager.setLongpressDelay(longpressDelay);
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustLongpressDelayActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustLongpressDelayActivity.java
@@ -29,7 +29,7 @@ public class AdjustLongpressDelayActivity extends BaseActivity {
 
   // Keeps track of the adjusted longpress delay time for saving.
   // Internally use milliseconds, but GUI displays seconds
-  private static int currentDelayTime = 500;  // ms
+  private static int currentDelayTime = KMManager.KMDefault_LongpressDelay;  // ms
   private static int minLongpressTime = 300;   // ms
   private static int maxLongpressTime = 1500;  // ms
   private static int delayTimeIncrement = 200; // ms

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -472,7 +472,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
 
   @Override
   public void onKeyboardLoaded(KeyboardType keyboardType) {
-    // Do nothing
+    checkLongpressDelay();
   }
 
   @Override
@@ -748,6 +748,12 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     SharedPreferences prefs = getSharedPreferences(getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
     boolean maySendCrashReport = prefs.getBoolean(KeymanSettingsActivity.sendCrashReport, true);
     KMManager.setMaySendCrashReport(maySendCrashReport);
+  }
+
+  private void checkLongpressDelay() {
+    // Initialize the longpress delay
+    int longpressDelay = KMManager.getLongpressDelay(this);
+    KMManager.setLongpressDelay(longpressDelay);
   }
 
   private void checkHapticFeedback() {

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -115,6 +115,10 @@ function notifyHost(event, params) {
 // Update the KeymanWeb longpress delay
 // delay is in milliseconds
 function setLongpressDelay(delay) {
+  if (keyman.osk) {
+    keyman.osk.gestureParams.longpress.waitLength = delay;
+    console.debug('setLongpressDelay('+delay+')');
+  }
 }
 
 // Update the KMW banner height

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -295,6 +295,9 @@ public final class KMManager {
   public static final String KMDefault_DictionaryVersion = "0.1.4";
   public static final String KMDefault_DictionaryKMP = KMDefault_DictionaryPackageID + FileUtils.MODELPACKAGE;
 
+  // Default KeymanWeb long-press delay
+  public static final int KMDefault_LongpressDelay = 500; // ms
+
   // Keyman files
   protected static final String KMFilename_KeyboardHtml = "keyboard.html";
   protected static final String KMFilename_JSEngine = "keymanweb-webview.js";
@@ -2018,10 +2021,11 @@ public final class KMManager {
    * @return int - long-press delay in milliseconds
    */
   public static int getLongpressDelay(Context context) {
-    int defaultDelay = 500; // default longpress delay in KeymanWeb (ms)
     SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
 
-    return prefs.getInt(KMManager.KMKey_LongpressDelay, defaultDelay);
+    return prefs.getInt(
+      KMKey_LongpressDelay,
+      KMDefault_LongpressDelay);
   }
 
   /**


### PR DESCRIPTION
Follows #1270 and fixes #877

This adds KMManager APIs to get/set the longpress duration between 300 ms and 1500 ms. Default KeymanWeb longpress delay is 500ms.

Since the keyboard needs to be loaded for the setting to take effect, I put the initialization in MainActivity.onKeyboardLoaded

## User Testing
**Setup** - Install the PR build of Keyman for Android on a device/emulator

**TEST_LONGPRESS** - Verifies longpress delay changes with the menu
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. On the default SIL EuroLatin keyboard, longpress a key and observe the long press delay
3. Verify long press appears after about 0.5 seconds.
4. From Keyman Settings --> Adjust longpress delay
5. From the "Adjust longpress delay" menu, increase the delay to 1.5 seconds and exit the menu
6. On the Keyman keyboard, longpress a key and observe the long press delay
7. Verify long press appears after about 1.5 seconds.
8. From Keyman Settings --> Adjust longpress delay
9. From the "Adjust longpress delay" menu, decrease the delay to 0.3 seconds and exit the menu
10. On the Keyman keyboard, longpress a key and observe the long press delay
11. Verify long press appears after about 0.3 seconds
