### PR TITLE
fix(web): restore flick functionality

### DIFF
--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -209,7 +209,7 @@ let dummy2: LayoutGestureSupportFlags = dummy;
  * Defines the set of gestures appropriate for use with the specified Keyman
  * keyboard.
  * @param layerGroup  The active keyboard's layer group
- * @param params      A set of tweakable gesture parameters.  It will be
+ * @param paramObj    A set of tweakable gesture parameters.  It will be
  *                    closure-captured and referred to by reference; changes to
  *                    its values will take immediate effect during gesture
  *                    processing.

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -213,9 +213,6 @@ let dummy2: LayoutGestureSupportFlags = dummy;
  *                    closure-captured and referred to by reference; changes to
  *                    its values will take immediate effect during gesture
  *                    processing.
- *
- *                    `params.roamingEnabled` will be initialized by this
- *                    method based upon layout properties.
  * @returns
  */
 export function gestureSetForLayout(flags: LayoutGestureSupportFlags, paramObj: GestureParams): GestureModelDefs<KeyElement, string> {

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -20,20 +20,8 @@ import { calcLockedDistance, lockedAngleForDir, MAX_TOLERANCE_ANGLE_SKEW, type O
 
 import specs = gestures.specs;
 
-export interface GestureParams<Item = any> {
+export interface GestureParams {
   readonly longpress: {
-    /**
-     * Allows enabling or disabling the longpress up-flick shortcut for
-     * keyboards that do not include any defined flick gestures.
-     *
-     * Will be ignored (in favor of `false`) for keyboards that do have defined
-     * flicks.
-     *
-     * Note:  this is automatically overwritten during keyboard initialization
-     * to match the keyboard's properties.
-     */
-    permitsFlick: (item?: Item) => boolean,
-
     /**
      * The minimum _net_ distance traveled before a longpress flick-shortcut will cancel any
      * conflicting flick models.
@@ -98,19 +86,31 @@ export interface GestureParams<Item = any> {
      * Is currently also used as the max radius for valid flick-reset recentering targets.
      */
     dirLockDist: number
+  }
+}
+
+export interface FullGestureParams<Item = any> extends GestureParams {
+  readonly longpress: GestureParams["longpress"] & {
+    /**
+     * Allows enabling or disabling the longpress up-flick shortcut for
+     * keyboards that do not include any defined flick gestures.
+     *
+     * Will be ignored (in favor of `false`) for keyboards that do have defined
+     * flicks.
+     *
+     * Note:  this is automatically overwritten during keyboard initialization
+     * to match the keyboard's properties.
+     */
+    permitsFlick: (item?: Item) => boolean
   },
   /**
    * Indicates whether roaming-touch oriented behaviors should be enabled.
-   *
-   * Note that run-time adjustments to this property after initialization will
-   * not take affect, unlike the other properties of the overall parameter object.
    */
   roamingEnabled?: boolean;
 }
 
 export const DEFAULT_GESTURE_PARAMS: GestureParams = {
   longpress: {
-    permitsFlick: () => true,
     // Note:  actual runtime value is determined at runtime based upon row height.
     // See `VisualKeyboard.refreshLayout`, CTRL-F "Step 3".
     flickDistStart: 8,
@@ -206,17 +206,19 @@ let dummy: ActiveLayout;
 let dummy2: LayoutGestureSupportFlags = dummy;
 
 /**
- * Defines the set of gestures appropriate for use with the specified Keyman keyboard.
+ * Defines the set of gestures appropriate for use with the specified Keyman
+ * keyboard.
  * @param layerGroup  The active keyboard's layer group
- * @param params      A set of tweakable gesture parameters.  It will be closure-captured
- *                    and referred to by reference; changes to its values will take
- *                    immediate effect during gesture processing.
+ * @param params      A set of tweakable gesture parameters.  It will be
+ *                    closure-captured and referred to by reference; changes to
+ *                    its values will take immediate effect during gesture
+ *                    processing.
  *
- *                    If params.roamingEnabled is unset, it will be initialized by this
+ *                    `params.roamingEnabled` will be initialized by this
  *                    method based upon layout properties.
  * @returns
  */
-export function gestureSetForLayout(flags: LayoutGestureSupportFlags, params: GestureParams): GestureModelDefs<KeyElement, string> {
+export function gestureSetForLayout(flags: LayoutGestureSupportFlags, paramObj: GestureParams): GestureModelDefs<KeyElement, string> {
   // To be used among the `allowsInitialState` contact-model specifications as needed.
   const gestureKeyFilter = (key: KeyElement, gestureId: string) => {
     if(!key) {
@@ -248,17 +250,32 @@ export function gestureSetForLayout(flags: LayoutGestureSupportFlags, params: Ge
     }
   };
 
-  const doRoaming = params.roamingEnabled ||= !flags.hasFlicks;
+  const params = paramObj as FullGestureParams;
+
+  // Override any prior entries for keyboard-specific configuration.
+  params.longpress.permitsFlick = (key) => {
+    const flickSpec = key?.key.spec.flick;
+    return !flickSpec || !(flickSpec.n || flickSpec.nw || flickSpec.ne);
+  };
+  const doRoaming = params.roamingEnabled = !flags.hasFlicks;
 
   const _initialTapModel: GestureModel<KeyElement> = deepCopy(!doRoaming ? initialTapModel(params) : initialTapModelWithReset(params));
   const _simpleTapModel: GestureModel<KeyElement> = deepCopy(!doRoaming ? simpleTapModel(params) : simpleTapModelWithReset(params));
   // Ensure all deep-copy operations for longpress modeling occur before the property-redefining block.
   const _longpressModel: GestureModel<KeyElement> = withKeySpecFiltering(deepCopy(longpressModel(params, true, doRoaming)), 0);
+  const _multitapStartModel: GestureModel<KeyElement> = withKeySpecFiltering(multitapStartModel(params), 0);
+  const _modipressMultitapStartModel: GestureModel<KeyElement> = withKeySpecFiltering(modipressMultitapStartModel(params), 0);
 
   // `deepCopy` does not preserve property definitions, instead raw-copying its value.
   // We need to re-instate the longpress delay property here.
   Object.defineProperty(_longpressModel.contacts[0].model.timer, 'duration', {
     get: () => params.longpress.waitLength
+  });
+  Object.defineProperty(_multitapStartModel.sustainTimer, 'duration', {
+    get: () => params.multitap.waitLength
+  });
+  Object.defineProperty(_modipressMultitapStartModel.sustainTimer, 'duration', {
+    get: () => params.multitap.waitLength
   });
 
   // #region Functions for implementing and/or extending path initial-state checks
@@ -293,7 +310,7 @@ export function gestureSetForLayout(flags: LayoutGestureSupportFlags, params: Ge
   const _modipressStartModel = modipressStartModel();
   const gestureModels: GestureModel<KeyElement>[] = [
     _longpressModel,
-    withKeySpecFiltering(multitapStartModel(params), 0),
+    _multitapStartModel,
     multitapEndModel(params),
     _initialTapModel,
     _simpleTapModel,
@@ -304,7 +321,7 @@ export function gestureSetForLayout(flags: LayoutGestureSupportFlags, params: Ge
     modipressHoldModel(params),
     modipressEndModel(),
     modipressMultitapTransitionModel(),
-    withKeySpecFiltering(modipressMultitapStartModel(params), 0),
+    _modipressMultitapStartModel,
     modipressMultitapEndModel(params),
     modipressMultitapLockModel()
   ];
@@ -367,7 +384,7 @@ export function instantContactResolutionModel(): ContactModel {
   };
 }
 
-export function flickStartContactModel(params: GestureParams): gestures.specs.ContactModel<KeyElement, any> {
+export function flickStartContactModel(params: FullGestureParams): gestures.specs.ContactModel<KeyElement, any> {
   const flickParams = params.flick;
 
   return {
@@ -426,7 +443,7 @@ function determineLockFromStats(pathStats: CumulativePathStats<KeyElement>, base
   }
 }
 
-export function flickMidContactModel(params: GestureParams): gestures.specs.ContactModel<KeyElement, any> {
+export function flickMidContactModel(params: FullGestureParams): gestures.specs.ContactModel<KeyElement, any> {
   return {
     itemPriority: 1,
     pathModel: {
@@ -461,7 +478,7 @@ export function flickMidContactModel(params: GestureParams): gestures.specs.Cont
 }
 
 
-export function flickEndContactModel(params: GestureParams): ContactModel {
+export function flickEndContactModel(params: FullGestureParams): ContactModel {
   return {
     itemPriority: 1,
     pathModel: {
@@ -485,7 +502,7 @@ export function flickEndContactModel(params: GestureParams): ContactModel {
   }
 }
 
-export function longpressContactModel(params: GestureParams, enabledFlicks: boolean, resetForRoaming: boolean): ContactModel {
+export function longpressContactModel(params: FullGestureParams, enabledFlicks: boolean, resetForRoaming: boolean): ContactModel {
   const spec = params.longpress;
 
   return {
@@ -581,7 +598,7 @@ export function modipressContactEndModel(): ContactModel {
   };
 }
 
-export function simpleTapContactModel(params: GestureParams, isNotInitial?: boolean): ContactModel {
+export function simpleTapContactModel(params: FullGestureParams, isNotInitial?: boolean): ContactModel {
   // Snapshot at model construction; do not update if changed.
   const roamingEnabled = params?.roamingEnabled ?? true; // ?? true - used by the banner.
 
@@ -650,7 +667,7 @@ export function specialKeyStartModel(): GestureModel<KeyElement> {
   };
 }
 
-export function specialKeyEndModel(params: GestureParams): GestureModel<any> {
+export function specialKeyEndModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'special-key-end',
     resolutionPriority: 0,
@@ -682,7 +699,7 @@ export function specialKeyEndModel(params: GestureParams): GestureModel<any> {
  *                       - the common gesture configuration permits the shortcut where supported
  * @param allowRoaming   Indicates whether "roaming touch" mode should be supported.
  */
-export function longpressModel(params: GestureParams, allowShortcut: boolean, allowRoaming: boolean): GestureModel<any> {
+export function longpressModel(params: FullGestureParams, allowShortcut: boolean, allowRoaming: boolean): GestureModel<any> {
   const base: GestureModel<any> = {
     id: 'longpress',
     // Needs to beat flick-start priority.
@@ -732,7 +749,7 @@ export function longpressModel(params: GestureParams, allowShortcut: boolean, al
 /**
  * For use for transitioning out of roaming-touch.
  */
-export function longpressModelAfterRoaming(params: GestureParams): GestureModel<any> {
+export function longpressModelAfterRoaming(params: FullGestureParams): GestureModel<any> {
   // The longpress-shortcut is always disabled for keys reached by roaming (param 2)
   // Only used when roaming is permitted; continued roaming should be allowed. (param 3)
   const base = longpressModel(params, false, true);
@@ -782,7 +799,7 @@ export function longpressRoamRestoration(): GestureModel<any> {
   }
 }
 
-export function flickStartModel(params: GestureParams): GestureModel<any> {
+export function flickStartModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'flick-start',
     resolutionPriority: 3,
@@ -799,7 +816,7 @@ export function flickStartModel(params: GestureParams): GestureModel<any> {
   }
 }
 
-export function flickRestartModel(params: GestureParams): GestureModel<KeyElement> {
+export function flickRestartModel(params: FullGestureParams): GestureModel<KeyElement> {
   const base = flickStartModel(params);
   return {
     ...base,
@@ -859,7 +876,7 @@ export function flickRestartModel(params: GestureParams): GestureModel<KeyElemen
   }
 }
 
-export function flickMidModel(params: GestureParams): GestureModel<any> {
+export function flickMidModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'flick-mid',
     resolutionPriority: 0,
@@ -889,7 +906,7 @@ export function flickMidModel(params: GestureParams): GestureModel<any> {
 }
 
 // Clears existing flick-scrolling & primes the flick-reset recentering mechanism.
-export function flickResetModel(params: GestureParams): GestureModel<any> {
+export function flickResetModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'flick-reset',
     resolutionPriority: 1,
@@ -909,7 +926,7 @@ export function flickResetModel(params: GestureParams): GestureModel<any> {
   };
 }
 
-export function flickResetCenteringModel(params: GestureParams): GestureModel<KeyElement> {
+export function flickResetCenteringModel(params: FullGestureParams): GestureModel<KeyElement> {
   return {
     id: 'flick-reset-centering',
     resolutionPriority: 1,
@@ -963,7 +980,7 @@ export function flickResetEndModel(): GestureModel<any> {
   };
 };
 
-export function flickEndModel(params: GestureParams): GestureModel<any> {
+export function flickEndModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'flick-end',
     resolutionPriority: 0,
@@ -990,7 +1007,7 @@ export function flickEndModel(params: GestureParams): GestureModel<any> {
   }
 }
 
-export function multitapStartModel(params: GestureParams): GestureModel<any> {
+export function multitapStartModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'multitap-start',
     resolutionPriority: 2,
@@ -1019,7 +1036,7 @@ export function multitapStartModel(params: GestureParams): GestureModel<any> {
   }
 }
 
-export function multitapEndModel(params: GestureParams): GestureModel<any> {
+export function multitapEndModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'multitap-end',
     resolutionPriority: 2,
@@ -1053,7 +1070,7 @@ export function multitapEndModel(params: GestureParams): GestureModel<any> {
   }
 }
 
-export function initialTapModel(params: GestureParams): GestureModel<any> {
+export function initialTapModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'initial-tap',
     resolutionPriority: 1,
@@ -1089,7 +1106,7 @@ export function initialTapModel(params: GestureParams): GestureModel<any> {
   }
 }
 
-export function simpleTapModel(params: GestureParams): GestureModel<any> {
+export function simpleTapModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'simple-tap',
     resolutionPriority: 1,
@@ -1113,7 +1130,7 @@ export function simpleTapModel(params: GestureParams): GestureModel<any> {
   };
 }
 
-export function initialTapModelWithReset(params: GestureParams): GestureModel<any> {
+export function initialTapModelWithReset(params: FullGestureParams): GestureModel<any> {
   const base = initialTapModel(params);
   return {
     ...base,
@@ -1127,7 +1144,7 @@ export function initialTapModelWithReset(params: GestureParams): GestureModel<an
   }
 }
 
-export function simpleTapModelWithReset(params: GestureParams): GestureModel<any> {
+export function simpleTapModelWithReset(params: FullGestureParams): GestureModel<any> {
   const simpleModel = simpleTapModel(params);
   return {
     ...simpleModel,
@@ -1189,7 +1206,7 @@ export function modipressStartModel(): GestureModel<KeyElement> {
   }
 }
 
-export function modipressHoldModel(params: GestureParams): GestureModel<any> {
+export function modipressHoldModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'modipress-hold',
     resolutionPriority: 5,
@@ -1281,7 +1298,7 @@ export function modipressEndModel(): GestureModel<any> {
   }
 }
 
-export function modipressMultitapStartModel(params: GestureParams): GestureModel<KeyElement> {
+export function modipressMultitapStartModel(params: FullGestureParams): GestureModel<KeyElement> {
   return {
     id: 'modipress-multitap-start',
     resolutionPriority: 6,
@@ -1316,7 +1333,7 @@ export function modipressMultitapStartModel(params: GestureParams): GestureModel
   }
 }
 
-export function modipressMultitapEndModel(params: GestureParams): GestureModel<any> {
+export function modipressMultitapEndModel(params: FullGestureParams): GestureModel<any> {
   return {
     id: 'modipress-multitap-end',
     resolutionPriority: 5,

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -151,7 +151,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
   /**
    * Tweakable gesture parameters referenced by supported gestures and the gesture engine.
    */
-  get gestureParams(): GestureParams<KeyElement> {
+  get gestureParams(): GestureParams {
     return this.config.gestureParams;
   };
 
@@ -421,11 +421,6 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       */
       recordingMode: DEBUG_GESTURES,
       historyLength: DEBUG_HISTORY_COUNT
-    };
-
-    this.gestureParams.longpress.permitsFlick = (key) => {
-      const flickSpec = key?.key.spec.flick;
-      return !flickSpec || !(flickSpec.n || flickSpec.nw || flickSpec.ne);
     };
 
     const recognizer = new GestureRecognizer(gestureSetForLayout(this.kbdLayout, this.gestureParams), config);


### PR DESCRIPTION
Turns out that #12176 actually broke flicks due to a side-effect of no longer rebuilding the gesture-parameterization object when swapping keyboards.  The culprit:

https://github.com/keymanapp/keyman/blob/69a3fa1795a457e49608e9f80561318d6dc556b7/web/src/engine/osk/src/input/gestures/specsForLayout.ts#L251

If rebuilding the parameter object from scratch, this is all well and good.  If _not_, however... we run the risk of keeping 'roaming' mode in place if the previous keyboard had roaming enabled.  This was the only spot that ever set the flag, so... it would never turn 'off' once turned 'on'.  Short version:  due to certain initialization patterns, it was basically _always_ turned on.  (When the OSK initializes during standard use, there's no actual Keyman keyboard ready yet... and so the engine builds a default, blank one to match a standard US English keyboard... a keyboard without flicks and thus with roaming support.)

The solution?  Ignore any previous value for the setting and just override it with the value appropriate to the _current_ keyboard.  #12176 made comment changes noting this behavior for `longpress.flickEnabled` as well; now that there are two such members on the overall structure, I felt it worth some type work to hide them from the type visible from the gesture-parameterization API, since they are not to be externally set.

I also did a second check for anything needing similar changes to #12176, just in case, and discovered that the multitap 'sustain' timer needed a similar pattern, so I threw that in.

## User Testing

TEST_GENERAL_GESTURES:  Using the EuroLatin (SIL) keyboard on an Android device, verify that gestures work normally.
- Be sure to test flicks, longpresses, and numeric-key multitap.
- Also test flicks and longpresses while holding down the numeric key with a different finger.