### PR TITLE
fix(ios): remove `description` field from lexical model queries to address parse errors

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+LexicalModel.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Queries/Queries+LexicalModel.swift
@@ -17,7 +17,6 @@ extension Queries {
       let version: String
       let languages: [String]
       let packageFilename: String
-      let description: String
       let minKeymanVersion: String
 
       enum CodingKeys: String, CodingKey {
@@ -27,7 +26,6 @@ extension Queries {
         case languages
         case packageFilename
         case minKeymanVersion
-        case description
       }
 
       var models: [InstallableLexicalModel] {


### PR DESCRIPTION
So... I just discovered a quite notable bug in our iOS app, possibly due to a shift in the data backing our APIs?

Our lexical model queries run against the following endpoint, here configured to query for lexical models for English (`en`): https://api.keyman.com/model?q=bcp47:en

There used to be a `description` field, but this no longer appears to be the case.  The iOS query code expects it, though, and was throwing "parse" errors due to its unavailability.

I noticed this when removing my (Simulator) installation of `khmer_angkor` and re-installing it, hoping to get an updated model due to something _else_ I noticed... so imagine my surprise when _no_ model was installed!

Fortunately, we weren't actually using that description field for anything important within the iOS engine, so we can just remove it to get things working again.

## User Testing

TEST_DOWNLOAD_MODEL_AUTO:  Using a _fresh_ installation of Keyman for iOS, install the `khmer_angkor` keyboard and verify that a model is automatically downloaded for it.

TEST_DOWNLOAD_MODEL_MANUAL:  Using Keyman for iOS, use the settings menus to view downloadable models for English.
- Settings > Installed Languages > English > Dictionaries > `+`
    - There may be a brief but noticeable delay after pressing the `+`.
    - The list should appear without any error alerts appearing.
    - Assuming a fresh install, the only entry in the list should appear greyed out with a checkmark to its right.