### PR TITLE
fix(developer): enforce presence of Version field when FollowKeyboardVersion is not set, in package compiler

### DIFF
--- a/developer/src/kmc-keyboard-info/test/test-keyboard-info-compiler.ts
+++ b/developer/src/kmc-keyboard-info/test/test-keyboard-info-compiler.ts
@@ -835,17 +835,4 @@ describe('keyboard-info-compiler', function () {
     const result = await compiler['fontSourceToKeyboardInfoFont'](KHMER_ANGKOR_KPS, kmpJsonData, fonts);
     assert.deepEqual(result, KHMER_ANGKOR_DISPLAY_FONT_INFO);
   });
-
-  it('handles missing info.version in a package file', async function() {
-    const sources = {
-      ...KHMER_ANGKOR_SOURCES,
-      kpsFilename: makePathToFixture('missing-info-version-in-kps-11856', 'khmer_angkor.kps')
-    };
-    const compiler = new KeyboardInfoCompiler();
-    assert.isTrue(await compiler.init(callbacks, {sources}));
-    const kpjFilename = KHMER_ANGKOR_KPJ;
-    const result = await compiler.run(kpjFilename);
-    const actual = JSON.parse(new TextDecoder().decode(result.artifacts.keyboard_info.data));
-    assert.equal(actual.version, '1.0');
-  });
 });

--- a/developer/src/kmc-package/src/compiler/package-compiler-messages.ts
+++ b/developer/src/kmc-package/src/compiler/package-compiler-messages.ts
@@ -138,5 +138,11 @@ export class PackageCompilerMessages {
   static ERROR_InvalidAuthorEmail = SevError | 0x0020;
   static Error_InvalidAuthorEmail = (o:{email:string}) => m(this.ERROR_InvalidAuthorEmail,
     `Invalid author email: ${def(o.email)}`);
+
+  static ERROR_PackageFileHasEmptyVersion = SevError | 0x0021;
+  static Error_PackageFileHasEmptyVersion = () => m(
+    this.ERROR_PackageFileHasEmptyVersion,
+    `Package version is not following keyboard version, but the package version field is blank.`
+  );
 }
 

--- a/developer/src/kmc-package/src/compiler/package-version-validator.ts
+++ b/developer/src/kmc-package/src/compiler/package-version-validator.ts
@@ -42,6 +42,11 @@ export class PackageVersionValidator {
       if(!this.checkFollowKeyboardVersion(kmp)) {
         return false;
       }
+    } else {
+      if(!kmp.info.version) {
+        this.callbacks.reportMessage(PackageCompilerMessages.Error_PackageFileHasEmptyVersion());
+        return false;
+      }
     }
 
     if(!kmp.keyboards) {

--- a/developer/src/kmc-package/test/fixtures/absolute_path/source/absolute_path.kps
+++ b/developer/src/kmc-package/test/fixtures/absolute_path/source/absolute_path.kps
@@ -17,6 +17,7 @@
   </StartMenu>
   <Info>
     <Name URL="">Absolute Path</Name>
+    <Version>1.0</Version>
   </Info>
   <Files>
     <File>

--- a/developer/src/kmc-package/test/fixtures/invalid/error_package_file_has_empty_version.kps
+++ b/developer/src/kmc-package/test/fixtures/invalid/error_package_file_has_empty_version.kps
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>15.0.266.0</KeymanDeveloperVersion>
+    <FileVersion>7.0</FileVersion>
+  </System>
+  <Info>
+    <!-- blank name -->
+    <Name URL="">Invalid Email Address</Name>
+    <Copyright URL="">© 2019 National Research Council Canada</Copyright>
+    <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
+    <Version></Version>
+  </Info>
+  <Files>
+    <File>
+      <Name>basic.kmx</Name>
+      <Description>Keyboard Basic</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.kmx</FileType>
+    </File>
+  </Files>
+  <Keyboards>
+    <Keyboard>
+      <Name>Basic</Name>
+      <ID>basic</ID>
+      <Version>1.0</Version>
+      <Languages>
+        <Language ID="km">Central Khmer (Khmer, Cambodia)</Language>
+      </Languages>
+    </Keyboard>
+  </Keyboards>
+</Package>

--- a/developer/src/kmc-package/test/test-messages.ts
+++ b/developer/src/kmc-package/test/test-messages.ts
@@ -236,4 +236,8 @@ describe('PackageCompilerMessages', function () {
       PackageCompilerMessages.ERROR_InvalidAuthorEmail);
   });
 
+  it('should generate ERROR_PackageFileHasEmptyVersion if FollowKeyboardVersion is not present and Version is empty', async function() {
+    await testForMessage(this, ['invalid', 'error_package_file_has_empty_version.kps'],
+      PackageCompilerMessages.ERROR_PackageFileHasEmptyVersion);
+  });
 });

--- a/developer/src/kmc-package/test/test-package-compiler.ts
+++ b/developer/src/kmc-package/test/test-package-compiler.ts
@@ -209,6 +209,8 @@ describe('KmpCompiler', function () {
       kmpJson = kmpCompiler.transformKpsToKmpObject(kpsPath);
     });
 
+    assert.isNotNull(kmpJson);
+
     await assert.isNull(kmpCompiler.buildKmpFile(kpsPath, kmpJson));
 
     if(debug) callbacks.printMessages();


### PR DESCRIPTION
Fixes: #12193

@keymanapp-test-bot skip