### PR TITLE
fix(developer): enforce presence of kps Info.Description field in info compilers 🍒 🏠

### DIFF
--- a/developer/src/kmc-keyboard-info/src/keyboard-info-compiler-messages.ts
+++ b/developer/src/kmc-keyboard-info/src/keyboard-info-compiler-messages.ts
@@ -52,8 +52,14 @@ export class KeyboardInfoCompilerMessages {
   static Error_FontFileCannotBeRead = (o:{filename: string}) => m(this.ERROR_FontFileCannotBeRead,
     `Font ${def(o.filename)} could not be parsed to extract a font family.`);
 
-static ERROR_FontFileMetaDataIsInvalid = SevError | 0x000F;
-static Error_FontFileMetaDataIsInvalid = (o:{filename: string,message:string}) => m(this.ERROR_FontFileMetaDataIsInvalid,
+  static ERROR_FontFileMetaDataIsInvalid = SevError | 0x000F;
+  static Error_FontFileMetaDataIsInvalid = (o:{filename: string,message:string}) => m(
+    this.ERROR_FontFileMetaDataIsInvalid,
     `Font ${def(o.filename)} meta data invalid: ${def(o.message)}.`);
+
+  static ERROR_DescriptionIsMissing = SevError | 0x0010;
+  static Error_DescriptionIsMissing = (o:{filename:string}) => m(
+    this.ERROR_DescriptionIsMissing,
+    `The Info.Description field in the package ${def(o.filename)} is required, but is missing or empty.`);
 }
 

--- a/developer/src/kmc-keyboard-info/src/keyboard-info-compiler.ts
+++ b/developer/src/kmc-keyboard-info/src/keyboard-info-compiler.ts
@@ -246,6 +246,9 @@ export class KeyboardInfoCompiler implements KeymanCompiler {
 
     if(kmpJsonData.info.description?.description) {
       keyboard_info.description = kmpJsonData.info.description.description.trim();
+    } else {
+      this.callbacks.reportMessage(KeyboardInfoCompilerMessages.Error_DescriptionIsMissing({filename:sources.kpsFilename}));
+      return null;
     }
 
     // extract the language identifiers from the language metadata arrays for

--- a/developer/src/kmc-model-info/src/model-info-compiler-messages.ts
+++ b/developer/src/kmc-model-info/src/model-info-compiler-messages.ts
@@ -44,5 +44,10 @@ export class ModelInfoCompilerMessages {
   static ERROR_NoLicenseFound = SevError | 0x0009;
   static Error_NoLicenseFound = () => m(this.ERROR_NoLicenseFound,
     `No license for the model was found. MIT license is required for publication to Keyman lexical-models repository.`);
+
+  static ERROR_DescriptionIsMissing = SevError | 0x000A;
+  static Error_DescriptionIsMissing = (o:{filename:string}) => m(
+    this.ERROR_DescriptionIsMissing,
+    `The Info.Description field in the package ${def(o.filename)} is required, but is missing or empty.`);
 }
 

--- a/developer/src/kmc-model-info/src/model-info-compiler.ts
+++ b/developer/src/kmc-model-info/src/model-info-compiler.ts
@@ -199,6 +199,9 @@ export class ModelInfoCompiler implements KeymanCompiler {
 
     if(sources.kmpJsonData.info.description?.description) {
       model_info.description = sources.kmpJsonData.info.description.description.trim();
+    } else {
+      this.callbacks.reportMessage(ModelInfoCompilerMessages.Error_DescriptionIsMissing({filename:sources.kpsFilename}));
+      return null;
     }
 
     // isRTL -- this is a little bit of a heuristic from a compiled .js


### PR DESCRIPTION
The Description field should be required for published keyboards and models, so this change means kmc-keyboard-info and kmc-model-info will report an error if it is missing.

Relates-to: keymanapp/keyboards#3037
Relates-to: keymanapp/lexical-models#262
Fixes: #12202

@keymanapp-test-bot skip