### PR TITLE
fix(web): disable fat-finger data use when mayCorrect = false

### DIFF
--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -61,6 +61,10 @@ export default class KeymanEngine<
       return;
     }
 
+    if(!this.core.languageProcessor.mayCorrect) {
+      event.keyDistribution = [];
+    }
+
     if(this.keyEventRefocus) {
       // Do anything needed to guarantee that the outputTarget stays active (`app/browser`: maintains focus).
       // (Interaction with the OSK may have de-focused the element providing active context;

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -929,13 +929,6 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
    * @returns
    */
   getSimpleTapCorrectionDistances(input: InputSample<KeyElement, string>, keySpec?: ActiveKey): Map<ActiveKeyBase, number> {
-    // TODO: It'd be nice to optimize by keeping these off when unused, but the wiring
-    //       necessary would get in the way of modularization at the moment.
-    // let keyman = com.keyman.singleton;
-    // if (!keyman.core.languageProcessor.mayCorrect) {
-    //   return null;
-    // }
-
     // Note:  if subkeys are active, they will still be displayed at this time.
     let touchKbdPos = this.getTouchCoordinatesOnKeyboard(input);
     let layerGroup = this.layerGroup.element;  // Always has proper dimensions, unlike kbdDiv itself.


### PR DESCRIPTION
Addresses part of #12214.

Does not fully solve the issue, as we'd need additionally need a way to pass a flag into the worker to further prevent corrective edits.

This fix does restore the correction-toggle back to its state from 16.0, but that still lacks the full intended effect for the toggle.

@keymanapp-test-bot skip