### PR TITLE
fix(android): Auto-mirror increment and decrement arrows for RTL support 📟

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -646,7 +646,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     final View textSizeController = inflater.inflate(R.layout.text_size_controller, null);
     final AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(MainActivity.this);
     dialogBuilder.setIcon(R.drawable.ic_light_action_textsize);
-    dialogBuilder.setTitle(String.format(getString(R.string.text_size), textSize));
+    dialogBuilder.setTitle(getTextSizeString());
     dialogBuilder.setView(textSizeController);
     dialogBuilder.setPositiveButton(getString(R.string.label_ok), new DialogInterface.OnClickListener() {
       @Override
@@ -677,7 +677,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
       public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
         textSize = progress + minTextSize;
         textView.setTextSize((float) textSize);
-        dialog.setTitle(String.format(getString(R.string.text_size), textSize));
+        dialog.setTitle(getTextSizeString());
       }
     });
 
@@ -700,6 +700,16 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
         }
       }
     });
+  }
+
+  /**
+   * Combine a localized string for "Text Size" plus Arabic numerals
+   * @return String
+   */
+  private String getTextSizeString() {
+    // Instead of formatting the number, will truncate formatting and concat the actual textSize
+    String label = getString(R.string.text_size).replace("%1$d", "");
+    return label + KMString.format(" %d", textSize);
   }
 
   private void showClearTextDialog() {

--- a/android/KMAPro/kMAPro/src/main/res/drawable/ic_action_decrement.xml
+++ b/android/KMAPro/kMAPro/src/main/res/drawable/ic_action_decrement.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
+    android:src="@drawable/ic_light_dialog_textsize_down"
+    android:tint="@android:color/black"
+    android:autoMirrored="true" />

--- a/android/KMAPro/kMAPro/src/main/res/drawable/ic_action_increment.xml
+++ b/android/KMAPro/kMAPro/src/main/res/drawable/ic_action_increment.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
+    android:src="@drawable/ic_light_dialog_textsize_up"
+    android:tint="@android:color/black"
+    android:autoMirrored="true"/>

--- a/android/KMAPro/kMAPro/src/main/res/layout/text_size_controller.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/text_size_controller.xml
@@ -15,7 +15,7 @@
         android:layout_marginStart="5dp"
         android:layout_marginEnd="5dp"
         android:contentDescription="@string/ic_text_size_down"
-        android:src="@drawable/ic_light_dialog_textsize_down" />
+        android:src="@drawable/ic_action_decrement" />
 
     <SeekBar
         android:id="@+id/seekBar"
@@ -32,6 +32,6 @@
         android:layout_marginStart="5dp"
         android:layout_marginEnd="5dp"
         android:contentDescription="@string/ic_text_size_up"
-        android:src="@drawable/ic_light_dialog_textsize_up" />
+        android:src="@drawable/ic_action_increment" />
 
 </LinearLayout>


### PR DESCRIPTION
Follows #12227 and #12228 for #12215

This fixes the increment/decrement arrows on the "Text Size" dialog to be RTL compatible.
In RTL locales, the decrement arrow points to the right and increment arrow points to the left.

Also refactored the "Text size: " string so the numerals appear with regular Arabic numbers.

## Screenshot
![text size](https://github.com/user-attachments/assets/1e573151-d4d7-4749-972b-d2ca191663fa)


## User Testing
**Setup** - Install the PR build of Keyman for Android on an Android device/emulator. Then in Keyman for Android, change the display language to Arabic (an RTL language)

**TEST_TEXT_SIZE** - Verifies arrow keys on Text Size dialog are RTL compatible
1. Launch Keyman for Android where the display language is Arabic.
2. From the Keyman menu --> Text Size
3. On the "Text Size" dialog, verify the decrement arrow pointing right makes the text size smaller
4. On the "Text size" dialog, verify the increment arrow pointing left makes the text size bigger
