### PR TITLE
fix(web): fix documentation-keyboard spacebar-text scaling

### DIFF
--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1608,7 +1608,8 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
 
     // Unset the width + height we used thus far; this method's consumer may choose to rescale
     // the returned element.  If so, we don't want to use our outdated value by mistake.
-    kbdObj.setSize();
+    delete kbdObj._width;
+    delete kbdObj._height;
 
     return classWrapper;
   }

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1246,6 +1246,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     const groupStyle = getComputedStyle(this.layerGroup.element);
 
     const isInDOM = computedStyle.height != '' && computedStyle.height != 'auto';
+    const isGroupInDOM = groupStyle.height != '' && groupStyle.height != 'auto';
 
     if (computedStyle.border) {
       this._borderWidth = new ParsedLengthStyle(computedStyle.borderWidth).val;
@@ -1258,10 +1259,11 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       this._computedHeight = this.height;
     } else if (isInDOM) {
       this._computedWidth = parseInt(computedStyle.width, 10);
-      if (!this._computedWidth) {
-        this._computedWidth = parseInt(groupStyle.width, 10);
-      }
       this._computedHeight = parseInt(computedStyle.height, 10);
+    } else if (isGroupInDOM) {
+      // May occur for documentation-keyboards, which are detached from their VisualKeyboard base.
+      this._computedWidth = parseInt(groupStyle.width, 10);
+      this._computedHeight = parseInt(groupStyle.height, 10);
     } else {
       // Cannot perform layout operations!
       return;
@@ -1603,6 +1605,11 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     // The stylesheet is currently built + constructed in the same code that attaches it to
     // the page.
     kbdObj.appendStyleSheet();
+
+    // Unset the width + height we used thus far; this method's consumer may choose to rescale
+    // the returned element.  If so, we don't want to use our outdated value by mistake.
+    delete kbdObj._width;
+    delete kbdObj._height;
 
     return classWrapper;
   }

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1608,6 +1608,11 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
 
     // Unset the width + height we used thus far; this method's consumer may choose to rescale
     // the returned element.  If so, we don't want to use our outdated value by mistake.
+    //
+    // While `kbdObj.setSize()` could be used in theory, it _also_ unsets the element styling.
+    // We actually wish to _leave_ this styling in place - one of our parameters is `height`, and
+    // it should remain in place in the styling on the output element as the default in case
+    // the consumer _doesn't_ add styling afterward.
     delete kbdObj._width;
     delete kbdObj._height;
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1608,8 +1608,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
 
     // Unset the width + height we used thus far; this method's consumer may choose to rescale
     // the returned element.  If so, we don't want to use our outdated value by mistake.
-    delete kbdObj._width;
-    delete kbdObj._height;
+    kbdObj.setSize();
 
     return classWrapper;
   }


### PR DESCRIPTION
Fixes: #12231

## User Testing

TEST_DOC_KEYBOARDS:  Using the "Tests keyboard documentation rendering" Web test page, verify that the spacebar labels are always properly constrained within the space allotted to the spacebar.