### PR TITLE
fix(core): look for `emcc` instead of `emcc.py`

### DIFF
--- a/core/wasm.build.linux.in
+++ b/core/wasm.build.linux.in
@@ -1,4 +1,4 @@
 [binaries]
-c = ['$EMSCRIPTEN_BASE/emcc.py']
-cpp = ['$EMSCRIPTEN_BASE/em++.py']
-ar = ['$EMSCRIPTEN_BASE/emar.py']
+c = ['$EMSCRIPTEN_BASE/emcc']
+cpp = ['$EMSCRIPTEN_BASE/em++']
+ar = ['$EMSCRIPTEN_BASE/emar']

--- a/core/wasm.build.mac.in
+++ b/core/wasm.build.mac.in
@@ -1,4 +1,4 @@
 [binaries]
-c = ['$EMSCRIPTEN_BASE/emcc.py']
-cpp = ['$EMSCRIPTEN_BASE/em++.py']
-ar = ['$EMSCRIPTEN_BASE/emar.py']
+c = ['$EMSCRIPTEN_BASE/emcc']
+cpp = ['$EMSCRIPTEN_BASE/em++']
+ar = ['$EMSCRIPTEN_BASE/emar']

--- a/core/wasm.defs.build
+++ b/core/wasm.defs.build
@@ -1,7 +1,7 @@
 [binaries]
-c = ['emcc.py']
-cpp = ['em++.py']
-ar = ['emar.py']
+c = ['emcc']
+cpp = ['em++']
+ar = ['emar']
 exe_wrapper = 'node'
 
 [properties]

--- a/developer/src/kmcmplib/wasm.build.linux.in
+++ b/developer/src/kmcmplib/wasm.build.linux.in
@@ -1,4 +1,4 @@
 [binaries]
-c = ['$EMSCRIPTEN_BASE/emcc.py']
-cpp = ['$EMSCRIPTEN_BASE/em++.py']
-ar = ['$EMSCRIPTEN_BASE/emar.py']
+c = ['$EMSCRIPTEN_BASE/emcc']
+cpp = ['$EMSCRIPTEN_BASE/em++']
+ar = ['$EMSCRIPTEN_BASE/emar']

--- a/developer/src/kmcmplib/wasm.build.mac.in
+++ b/developer/src/kmcmplib/wasm.build.mac.in
@@ -1,4 +1,4 @@
 [binaries]
-c = ['$EMSCRIPTEN_BASE/emcc.py']
-cpp = ['$EMSCRIPTEN_BASE/em++.py']
-ar = ['$EMSCRIPTEN_BASE/emar.py']
+c = ['$EMSCRIPTEN_BASE/emcc']
+cpp = ['$EMSCRIPTEN_BASE/em++']
+ar = ['$EMSCRIPTEN_BASE/emar']

--- a/resources/locate_emscripten.inc.sh
+++ b/resources/locate_emscripten.inc.sh
@@ -2,30 +2,36 @@
 # no hashbang for .inc.sh
 
 #
-# We don't want to rely on emcc.py being on the path, because Emscripten puts far
+# We don't want to rely on emcc being on the path, because Emscripten puts far
 # too many things onto the path (in particular for us, node).
 #
-# The following comment suggests that we don't need emcc.py on the path.
+# The following comment suggests that we don't need emcc on the path.
 # https://github.com/emscripten-core/emscripten/issues/4848#issuecomment-1097357775
 #
-# So we try and locate emcc.py in common locations ourselves. The search pattern
+# So we try and locate emcc in common locations ourselves. The search pattern
 # is:
 #
 # 1. Look for $EMSCRIPTEN_BASE (our primary emscripten variable), which should
-#    point to the folder that emcc.py is located in
-# 2. Look for $EMCC which should point to the emcc.py executable
-# 3. Look for emcc.py on the path
+#    point to the folder that emcc is located in
+# 2. Look for $EMCC which should point to the emcc executable
+# 3. Look for emcc on the path
 #
 locate_emscripten() {
+  local EMCC_EXECUTABLE
+  if [[ "${BUILDER_OS}" == "win" ]]; then
+    EMCC_EXECUTABLE="emcc.py"
+  else
+    EMCC_EXECUTABLE="emcc"
+  fi
   if [[ -z ${EMSCRIPTEN_BASE+x} ]]; then
     if [[ -z ${EMCC+x} ]]; then
-      local EMCC=`which emcc.py`
-      [[ -z $EMCC ]] && builder_die "locate_emscripten: Could not locate emscripten (emcc.py) on the path or with \$EMCC or \$EMSCRIPTEN_BASE"
+      local EMCC=$(which ${EMCC_EXECUTABLE})
+      [[ -z $EMCC ]] && builder_die "locate_emscripten: Could not locate emscripten (${EMCC_EXECUTABLE}) on the path or with \$EMCC or \$EMSCRIPTEN_BASE"
     fi
-    [[ -f $EMCC && ! -x $EMCC ]] && builder_die "locate_emscripten: Variable EMCC ($EMCC) points to emcc.py but it is not executable"
-    [[ -x $EMCC ]] || builder_die "locate_emscripten: Variable EMCC ($EMCC) does not point to a valid executable emcc.py"
+    [[ -f $EMCC && ! -x $EMCC ]] && builder_die "locate_emscripten: Variable EMCC ($EMCC) points to ${EMCC_EXECUTABLE} but it is not executable"
+    [[ -x $EMCC ]] || builder_die "locate_emscripten: Variable EMCC ($EMCC) does not point to a valid executable ${EMCC_EXECUTABLE}"
     EMSCRIPTEN_BASE="$(dirname "$EMCC")"
   fi
-  [[ -f ${EMSCRIPTEN_BASE}/emcc.py && ! -x ${EMSCRIPTEN_BASE}/emcc.py ]] && builder_die "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) contains emcc.py but it is not executable"
-  [[ -x ${EMSCRIPTEN_BASE}/emcc.py ]] || builder_die "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) does not point to emcc.py's folder"
+  [[ -f ${EMSCRIPTEN_BASE}/${EMCC_EXECUTABLE} && ! -x ${EMSCRIPTEN_BASE}/${EMCC_EXECUTABLE} ]] && builder_die "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) contains ${EMCC_EXECUTABLE} but it is not executable"
+  [[ -x ${EMSCRIPTEN_BASE}/${EMCC_EXECUTABLE} ]] || builder_die "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) does not point to ${EMCC_EXECUTABLE}'s folder"
 }


### PR DESCRIPTION
`emcc.py` is not marked as executable in emcripten's git repo so the build failed when trying to locate emscripten. However, it turns out that `emcc` is marked as executable, so we use that instead on macOS and Linux (on Windows, executable bit is irrelevant).

@keymanapp-test-bot skip