### PR TITLE
chore(common): allow build agents to automatically select emsdk version, and enable support for 3.1.60+

### DIFF
--- a/developer/src/kmcmplib/src/CompilerInterfacesWasm.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfacesWasm.cpp
@@ -75,9 +75,16 @@ struct BindingType<std::vector<T, Allocator>> {
     using ValBinding = BindingType<val>;
     using WireType = ValBinding::WireType;
 
+#if __EMSCRIPTEN_major__ == 3 && __EMSCRIPTEN_minor__ == 1 && __EMSCRIPTEN_tiny__ >= 60
+    // emscripten-core/emscripten#21692
+    static WireType toWireType(const std::vector<T, Allocator> &vec, rvp::default_tag) {
+        return ValBinding::toWireType(val::array(vec), rvp::default_tag{});
+    }
+#else
     static WireType toWireType(const std::vector<T, Allocator> &vec) {
         return ValBinding::toWireType(val::array(vec));
     }
+#endif
 
     static std::vector<T, Allocator> fromWireType(WireType value) {
         return vecFromJSArray<T>(ValBinding::fromWireType(value));

--- a/resources/build/minimum-versions.inc.sh
+++ b/resources/build/minimum-versions.inc.sh
@@ -20,8 +20,7 @@ KEYMAN_MIN_TARGET_VERSION_CHROME=95.0         # Final version that runs on Andro
 # Dependency versions
 KEYMAN_MIN_VERSION_NODE_MAJOR=20              # node version source of truth is /package.json:/engines/node
 KEYMAN_MIN_VERSION_NPM=10.5.1                 # 10.5.0 has bug, discussed in #10350
-KEYMAN_MIN_VERSION_EMSCRIPTEN=3.1.44          # Warning: 3.1.45 is bad (#9529); newer versions work
-KEYMAN_MAX_VERSION_EMSCRIPTEN=3.1.58          # See #9529
+KEYMAN_MIN_VERSION_EMSCRIPTEN=3.1.58          # Use KEYMAN_USE_EMSDK to automatically update to this version
 KEYMAN_MIN_VERSION_VISUAL_STUDIO=2019
 KEYMAN_MIN_VERSION_MESON=1.0.0
 


### PR DESCRIPTION
The build agents will now automatically install and activate the Emscripten version found in minimum-versions.inc.sh when configuring WASM projects. For developer machines, this behaviour can be enabled by setting the environment variable `KEYMAN_USE_EMSDK` (recommended).

This will be back-ported to 17.0 so that we can ensure that all builds use a consistent Emscripten version.

Also, Emscripten 3.1.60 made a breaking change to `BindingType::toWireType` (why is this done in a patch version?) so this change ensures that we can continue to build on 3.1.58 and 3.1.64 (which is needed for #12234), as a bridging strategy.

Relates-to: emscripten-core/emscripten#21692
Relates-to: #12234

@keymanapp-test-bot skip