### PR TITLE
chore(common): allow build agents to automatically select emsdk version, and enable support for 3.1.60+ 🍒 🏠

### DIFF
--- a/core/wasm.build.linux.in
+++ b/core/wasm.build.linux.in
@@ -1,4 +1,4 @@
 [binaries]
-c = ['$EMSCRIPTEN_BASE/emcc.py']
-cpp = ['$EMSCRIPTEN_BASE/em++.py']
-ar = ['$EMSCRIPTEN_BASE/emar.py']
+c = ['$EMSCRIPTEN_BASE/emcc']
+cpp = ['$EMSCRIPTEN_BASE/em++']
+ar = ['$EMSCRIPTEN_BASE/emar']

--- a/core/wasm.build.mac.in
+++ b/core/wasm.build.mac.in
@@ -1,4 +1,4 @@
 [binaries]
-c = ['$EMSCRIPTEN_BASE/emcc.py']
-cpp = ['$EMSCRIPTEN_BASE/em++.py']
-ar = ['$EMSCRIPTEN_BASE/emar.py']
+c = ['$EMSCRIPTEN_BASE/emcc']
+cpp = ['$EMSCRIPTEN_BASE/em++']
+ar = ['$EMSCRIPTEN_BASE/emar']

--- a/core/wasm.defs.build
+++ b/core/wasm.defs.build
@@ -1,7 +1,7 @@
 [binaries]
-c = ['emcc.py']
-cpp = ['em++.py']
-ar = ['emar.py']
+c = ['emcc']
+cpp = ['em++']
+ar = ['emar']
 exe_wrapper = 'node'
 
 [properties]

--- a/developer/src/kmcmplib/src/CompilerInterfacesWasm.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfacesWasm.cpp
@@ -90,9 +90,16 @@ struct BindingType<std::vector<T, Allocator>> {
     using ValBinding = BindingType<val>;
     using WireType = ValBinding::WireType;
 
+#if __EMSCRIPTEN_major__ == 3 && __EMSCRIPTEN_minor__ == 1 && __EMSCRIPTEN_tiny__ >= 60
+    // emscripten-core/emscripten#21692
+    static WireType toWireType(const std::vector<T, Allocator> &vec, rvp::default_tag) {
+        return ValBinding::toWireType(val::array(vec), rvp::default_tag{});
+    }
+#else
     static WireType toWireType(const std::vector<T, Allocator> &vec) {
         return ValBinding::toWireType(val::array(vec));
     }
+#endif
 
     static std::vector<T, Allocator> fromWireType(WireType value) {
         return vecFromJSArray<T>(ValBinding::fromWireType(value));

--- a/developer/src/kmcmplib/wasm.build.linux.in
+++ b/developer/src/kmcmplib/wasm.build.linux.in
@@ -1,4 +1,4 @@
 [binaries]
-c = ['$EMSCRIPTEN_BASE/emcc.py']
-cpp = ['$EMSCRIPTEN_BASE/em++.py']
-ar = ['$EMSCRIPTEN_BASE/emar.py']
+c = ['$EMSCRIPTEN_BASE/emcc']
+cpp = ['$EMSCRIPTEN_BASE/em++']
+ar = ['$EMSCRIPTEN_BASE/emar']

--- a/developer/src/kmcmplib/wasm.build.mac.in
+++ b/developer/src/kmcmplib/wasm.build.mac.in
@@ -1,4 +1,4 @@
 [binaries]
-c = ['$EMSCRIPTEN_BASE/emcc.py']
-cpp = ['$EMSCRIPTEN_BASE/em++.py']
-ar = ['$EMSCRIPTEN_BASE/emar.py']
+c = ['$EMSCRIPTEN_BASE/emcc']
+cpp = ['$EMSCRIPTEN_BASE/em++']
+ar = ['$EMSCRIPTEN_BASE/emar']

--- a/resources/locate_emscripten.inc.sh
+++ b/resources/locate_emscripten.inc.sh
@@ -1,31 +1,73 @@
 # shellcheck shell=bash
 # no hashbang for .inc.sh
 
+KEYMAN_MIN_VERSION_EMSCRIPTEN=3.1.58
+
 #
-# We don't want to rely on emcc.py being on the path, because Emscripten puts far
+# We don't want to rely on emcc being on the path, because Emscripten puts far
 # too many things onto the path (in particular for us, node).
 #
-# The following comment suggests that we don't need emcc.py on the path.
+# The following comment suggests that we don't need emcc on the path.
 # https://github.com/emscripten-core/emscripten/issues/4848#issuecomment-1097357775
 #
-# So we try and locate emcc.py in common locations ourselves. The search pattern
+# So we try and locate  in common locations ourselves. The search pattern
 # is:
 #
 # 1. Look for $EMSCRIPTEN_BASE (our primary emscripten variable), which should
-#    point to the folder that emcc.py is located in
-# 2. Look for $EMCC which should point to the emcc.py executable
-# 3. Look for emcc.py on the path
+#    point to the folder that emcc is located in
+# 2. Look for $EMCC which should point to the emcc executable
+# 3. Look for emcc on the path
 #
 locate_emscripten() {
+  local EMCC_EXECUTABLE
+  if [[ "${BUILDER_OS}" == "win" ]]; then
+    EMCC_EXECUTABLE="emcc.py"
+  else
+    EMCC_EXECUTABLE="emcc"
+  fi
   if [[ -z ${EMSCRIPTEN_BASE+x} ]]; then
     if [[ -z ${EMCC+x} ]]; then
-      local EMCC=`which emcc.py`
-      [[ -z $EMCC ]] && builder_die "locate_emscripten: Could not locate emscripten (emcc.py) on the path or with \$EMCC or \$EMSCRIPTEN_BASE"
+      local EMCC=`which ${EMCC_EXECUTABLE}`
+      [[ -z $EMCC ]] && builder_die "locate_emscripten: Could not locate emscripten (emcc) on the path or with \$EMCC or \$EMSCRIPTEN_BASE"
     fi
-    [[ -f $EMCC && ! -x $EMCC ]] && builder_die "locate_emscripten: Variable EMCC ($EMCC) points to emcc.py but it is not executable"
-    [[ -x $EMCC ]] || builder_die "locate_emscripten: Variable EMCC ($EMCC) does not point to a valid executable emcc.py"
+    [[ -f $EMCC && ! -x $EMCC ]] && builder_die "locate_emscripten: Variable EMCC ($EMCC) points to emcc but it is not executable"
+    [[ -x $EMCC ]] || builder_die "locate_emscripten: Variable EMCC ($EMCC) does not point to a valid executable emcc"
     EMSCRIPTEN_BASE="$(dirname "$EMCC")"
   fi
-  [[ -f ${EMSCRIPTEN_BASE}/emcc.py && ! -x ${EMSCRIPTEN_BASE}/emcc.py ]] && builder_die "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) contains emcc.py but it is not executable"
-  [[ -x ${EMSCRIPTEN_BASE}/emcc.py ]] || builder_die "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) does not point to emcc.py's folder"
+  [[ -f ${EMSCRIPTEN_BASE}/${EMCC_EXECUTABLE} && ! -x ${EMSCRIPTEN_BASE}/${EMCC_EXECUTABLE} ]] && builder_die "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) contains ${EMCC_EXECUTABLE} but it is not executable"
+  [[ -x ${EMSCRIPTEN_BASE}/${EMCC_EXECUTABLE} ]] || builder_die "locate_emscripten: Variable EMSCRIPTEN_BASE ($EMSCRIPTEN_BASE) does not point to ${EMCC_EXECUTABLE}'s folder"
+
+  verify_emscripten_version
+}
+
+# Ensure that we use correct version of emsdk on build agents.
+# For developers, define KEYMAN_USE_SDK to do this on your
+# build machine.
+verify_emscripten_version() {
+  if [[ "$VERSION_ENVIRONMENT" != local || ! -z "${KEYMAN_USE_EMSDK+x}" ]]; then
+    _select_emscripten_version_with_emsdk
+  fi
+}
+
+# Use emsdk to select the appropriate version of Emscripten
+# according to minimum-versions.inc.sh
+_select_emscripten_version_with_emsdk() {
+  if [[ -z "${EMSCRIPTEN_BASE+x}" ]]; then
+    builder_die "Variable EMSCRIPTEN_BASE must be set"
+  fi
+
+  if [[ -z "${KEYMAN_MIN_VERSION_EMSCRIPTEN+x}" ]]; then
+    builder_die "Variable KEYMAN_MIN_VERSION_EMSCRIPTEN must be set"
+  fi
+
+  pushd "${EMSCRIPTEN_BASE}/../.." > /dev/null
+  if [[ ! -f emsdk ]]; then
+    builder_die "emsdk[.bat] should be in $(pwd)"
+  fi
+
+  export EMSDK_KEEP_DOWNLOADS=1
+  git pull
+  ./emsdk install "$KEYMAN_MIN_VERSION_EMSCRIPTEN"
+  ./emsdk activate "$KEYMAN_MIN_VERSION_EMSCRIPTEN"
+  popd > /dev/null
 }


### PR DESCRIPTION
The build agents will now automatically install and activate the Emscripten version found in minimum-versions.inc.sh when configuring WASM projects. For developer machines, this behaviour can be enabled by setting the environment variable `KEYMAN_USE_EMSDK` (recommended).

Also, Emscripten 3.1.60 made a breaking change to `BindingType::toWireType` (why is this done in a patch version?) so this change ensures that we can continue to build on 3.1.58 and 3.1.64 (which is needed for #12234), as a bridging strategy.

Relates-to: emscripten-core/emscripten#21692
Relates-to: #12234
Cherry-pick-of: #12243
Cherry-pick-of: #12235

@keymanapp-test-bot skip