### PR TITLE
fix(core): set mac build version for meson cli build to 10.13 🍒 🏠

### DIFF
--- a/core/cross-mac-arm64.build
+++ b/core/cross-mac-arm64.build
@@ -5,9 +5,9 @@ cpu = 'arm64'
 endian = 'little'
 
 [binaries]
-c = ['clang', '-arch', 'arm64']
-objc = ['clang', '-arch', 'arm64']
-cpp = ['clang++', '-arch', 'arm64']
+c = ['clang', '-arch', 'arm64', '-mmacosx-version-min=10.13']
+objc = ['clang', '-arch', 'arm64', '-mmacosx-version-min=10.13']
+cpp = ['clang++', '-arch', 'arm64', '-mmacosx-version-min=10.13']
 ar = 'ar'
 ld = 'ld'
 strip = 'strip'

--- a/core/cross-mac-x86_64.build
+++ b/core/cross-mac-x86_64.build
@@ -5,9 +5,9 @@ cpu = 'x86_64'
 endian = 'little'
 
 [binaries]
-c = ['clang', '-arch', 'x86_64']
-objc = ['clang', '-arch', 'x86_64']
-cpp = ['clang++', '-arch', 'x86_64']
+c = ['clang', '-arch', 'x86_64', '-mmacosx-version-min=10.13']
+objc = ['clang', '-arch', 'x86_64', '-mmacosx-version-min=10.13']
+cpp = ['clang++', '-arch', 'x86_64', '-mmacosx-version-min=10.13']
 ar = 'ar'
 ld = 'ld'
 strip = 'strip'


### PR DESCRIPTION
- add as option to compiler
- Match version in #11302

Fixes: #11423
Cherry-pick-of: #12223

@keymanapp-test-bot skip