### PR TITLE
chore(models/templates): seed epic/model-encoding with cherry-pick from epic/user-dict 💾 

### DIFF
--- a/common/models/templates/src/common.ts
+++ b/common/models/templates/src/common.ts
@@ -158,14 +158,12 @@ export function defaultApplyCasing(casing: CasingForm, text: string): string {
  * the trie. There should be a function that converts arbitrary strings
  * (queries) and converts them into a standard search key for a given language
  * model.
- *
- * Fun fact: This opaque type has ALREADY saved my bacon and found a bug!
  */
 export type SearchKey = string & { _: 'SearchKey'};
 
 /**
  * A function that converts a string (word form or query) into a search key
- * (secretly, this is also a string).
+ * (which, internally, is also a string type).
  */
 export interface Wordform2Key {
   (wordform: string): SearchKey;

--- a/common/models/templates/src/common.ts
+++ b/common/models/templates/src/common.ts
@@ -152,3 +152,21 @@ export function defaultApplyCasing(casing: CasingForm, text: string): string {
       return text.substring(0, headUnitLength).toUpperCase() .concat(text.substring(headUnitLength));
   }
 }
+
+/**
+ * An **opaque** type for a string that is exclusively used as a search key in
+ * the trie. There should be a function that converts arbitrary strings
+ * (queries) and converts them into a standard search key for a given language
+ * model.
+ *
+ * Fun fact: This opaque type has ALREADY saved my bacon and found a bug!
+ */
+export type SearchKey = string & { _: 'SearchKey'};
+
+/**
+ * A function that converts a string (word form or query) into a search key
+ * (secretly, this is also a string).
+ */
+export interface Wordform2Key {
+  (wordform: string): SearchKey;
+}

--- a/common/models/templates/src/index.ts
+++ b/common/models/templates/src/index.ts
@@ -7,5 +7,5 @@ export { getLastPreCaretToken, Token, Tokenization, tokenize, wordbreak } from "
 export {
   Entry, InternalNode, Leaf, Node
 } from './trie.js';
-export { addUnsorted, TrieBuilder } from './trie-builder.js';
+export { TrieBuilder } from './trie-builder.js';
 export { default as TrieModel, TrieModelOptions } from "./trie-model.js";

--- a/common/models/templates/src/index.ts
+++ b/common/models/templates/src/index.ts
@@ -4,4 +4,8 @@ export {
 } from "./common.js";
 export { default as QuoteBehavior } from "./quote-behavior.js";
 export { getLastPreCaretToken, Token, Tokenization, tokenize, wordbreak } from "./tokenization.js";
+export {
+  Entry, InternalNode, Leaf, Node
+} from './trie.js';
+export { addUnsorted, TrieBuilder } from './trie-builder.js';
 export { default as TrieModel, TrieModelOptions } from "./trie-model.js";

--- a/common/models/templates/src/index.ts
+++ b/common/models/templates/src/index.ts
@@ -8,4 +8,5 @@ export {
   Entry, InternalNode, Leaf, Node
 } from './trie.js';
 export { TrieBuilder } from './trie-builder.js';
+export * as trieConstruction from './trie-builder.js';
 export { default as TrieModel, TrieModelOptions } from "./trie-model.js";

--- a/common/models/templates/src/trie-builder.ts
+++ b/common/models/templates/src/trie-builder.ts
@@ -1,5 +1,5 @@
 import { SENTINEL_CODE_UNIT, Wordform2Key } from "./common.js";
-import { Entry, InternalNode, Leaf, Node, Trie } from "./trie.js";
+import { Entry, InternalNode, Leaf, Node, Trie, sortNode } from "./trie.js";
 
 export function createRootNode(): Node {
   return {
@@ -103,37 +103,6 @@ export function convertLeafToInternalNode(leaf: Leaf, depth: number): void {
   }
 
   internal.unsorted = true;
-}
-
-/**
- * Recursively sort the trie, in descending order of weight.
- * @param node any node in the trie
- */
-export function sortNode(node: Node, onlyLocal?: boolean) {
-  if (node.type === 'leaf') {
-    if (!node.unsorted) {
-      return;
-    }
-
-    node.entries.sort(function (a, b) { return b.weight - a.weight; });
-  } else {
-    if(!onlyLocal) {
-      // We recurse and sort children before returning if sorting the full Trie.
-      for (let char of node.values) {
-        sortNode(node.children[char], onlyLocal);
-      }
-    }
-
-    if (!node.unsorted) {
-      return;
-    }
-
-    node.values.sort((a, b) => {
-      return node.children[b].weight - node.children[a].weight;
-    });
-  }
-
-  delete node.unsorted;
 }
 
 /**

--- a/common/models/templates/src/trie-builder.ts
+++ b/common/models/templates/src/trie-builder.ts
@@ -20,7 +20,7 @@ function createRootNode(): Node {
  * @param index the index in the key and also the trie depth. Should be set to
  *              zero when adding onto the root node of the trie.
  */
-export function addUnsorted(node: Node, entry: Entry, index: number = 0) {
+function addUnsorted(node: Node, entry: Entry, index: number = 0) {
   // Each node stores the MAXIMUM weight out of all of its decesdents, to
   // enable a greedy search through the trie.
   node.weight = Math.max(node.weight, entry.weight);
@@ -145,11 +145,29 @@ export class TrieBuilder extends Trie {
     this.totalWeight = 0;
   }
 
+  addEntry(word: string, weight?: number) {
+    weight = (isNaN(weight ?? NaN) || !weight) ? 1 : weight;
+    this.totalWeight += weight;
+
+    addUnsorted(
+      this.root, {
+        key: this.toKey(word),
+        content: word,
+        weight: weight
+      },
+      0
+    );
+  }
+
   sort() {
     sortTrie(this.root);
   }
 
   getRoot(): Node {
     return this.root;
+  }
+
+  getTotalWeight(): number {
+    return this.totalWeight;
   }
 }

--- a/common/models/templates/src/trie-builder.ts
+++ b/common/models/templates/src/trie-builder.ts
@@ -1,0 +1,155 @@
+import { SENTINEL_CODE_UNIT, Wordform2Key } from "./common.js";
+import { Entry, InternalNode, Leaf, Node, Trie } from "./trie.js";
+
+function createRootNode(): Node {
+  return {
+    type: 'leaf',
+    weight: 0,
+    entries: []
+  };
+}
+
+/**
+ * Adds an entry to the trie.
+ *
+ * Note that the trie will likely be unsorted after the add occurs. Before
+ * performing a lookup on the trie, use call sortTrie() on the root note!
+ *
+ * @param node Which node should the entry be added to?
+ * @param entry the wordform/weight/key to add to the trie
+ * @param index the index in the key and also the trie depth. Should be set to
+ *              zero when adding onto the root node of the trie.
+ */
+export function addUnsorted(node: Node, entry: Entry, index: number = 0) {
+  // Each node stores the MAXIMUM weight out of all of its decesdents, to
+  // enable a greedy search through the trie.
+  node.weight = Math.max(node.weight, entry.weight);
+
+  // When should a leaf become an interior node?
+  // When it already has a value, but the key of the current value is longer
+  // than the prefix.
+  if (node.type === 'leaf' && index < entry.key.length && node.entries.length >= 1) {
+    convertLeafToInternalNode(node, index);
+  }
+
+  if (node.type === 'leaf') {
+    // The key matches this leaf node, so add yet another entry.
+    addItemToLeaf(node, entry);
+  } else {
+    // Push the node down to a lower node.
+    addItemToInternalNode(node, entry, index);
+  }
+
+  node.unsorted = true;
+}
+
+/**
+ * Adds an item to the internal node at a given depth.
+ * @param item
+ * @param index
+ */
+function addItemToInternalNode(node: InternalNode, item: Entry, index: number) {
+  let char = item.key[index];
+  // If an internal node is the proper site for item, it belongs under the
+  // corresponding (sentinel, internal-use) child node signifying this.
+  if(char == undefined) {
+    char = SENTINEL_CODE_UNIT;
+  }
+  if (!node.children[char]) {
+    node.children[char] = createRootNode();
+    node.values.push(char);
+  }
+  addUnsorted(node.children[char], item, index + 1);
+}
+
+function addItemToLeaf(leaf: Leaf, item: Entry) {
+  leaf.entries.push(item);
+}
+
+/**
+ * Mutates the given Leaf to turn it into an InternalNode.
+ *
+ * NOTE: the node passed in will be DESTRUCTIVELY CHANGED into a different
+ * type when passed into this function!
+ *
+ * @param depth depth of the trie at this level.
+ */
+function convertLeafToInternalNode(leaf: Leaf, depth: number): void {
+  let entries = leaf.entries;
+
+  // Alias the current node, as the desired type.
+  let internal = (<unknown> leaf) as InternalNode;
+  internal.type = 'internal';
+
+  delete (leaf as Partial<Leaf>).entries;
+  internal.values = [];
+  internal.children = {};
+
+  // Convert the old values array into the format for interior nodes.
+  for (let item of entries) {
+    let char: string;
+    if (depth < item.key.length) {
+      char = item.key[depth];
+    } else {
+      char = SENTINEL_CODE_UNIT;
+    }
+
+    if (!internal.children[char]) {
+      internal.children[char] = createRootNode();
+      internal.values.push(char);
+    }
+    addUnsorted(internal.children[char], item, depth + 1);
+  }
+
+  internal.unsorted = true;
+}
+
+/**
+ * Recursively sort the trie, in descending order of weight.
+ * @param node any node in the trie
+ */
+function sortTrie(node: Node) {
+  if (node.type === 'leaf') {
+    if (!node.unsorted) {
+      return;
+    }
+
+    node.entries.sort(function (a, b) { return b.weight - a.weight; });
+  } else {
+    // We MUST recurse and sort children before returning.
+    for (let char of node.values) {
+      sortTrie(node.children[char]);
+    }
+
+    if (!node.unsorted) {
+      return;
+    }
+
+    node.values.sort((a, b) => {
+      return node.children[b].weight - node.children[a].weight;
+    });
+  }
+
+  delete node.unsorted;
+}
+
+/**
+ * Wrapper class for the trie and its nodes.
+ */
+export class TrieBuilder extends Trie {
+  /** The total weight of the entire trie. */
+  totalWeight: number;
+
+  constructor(toKey: Wordform2Key) {
+    super(createRootNode(), 0, toKey);
+    this.totalWeight = 0;
+  }
+
+  sort() {
+    sortTrie(this.root);
+  }
+
+  getRoot(): Node {
+    return this.root;
+  }
+}

--- a/common/models/templates/src/trie-model.ts
+++ b/common/models/templates/src/trie-model.ts
@@ -29,7 +29,8 @@
 import { extendString, PriorityQueue } from "@keymanapp/web-utils";
 import { default as defaultWordBreaker } from "@keymanapp/models-wordbreakers";
 
-import { applyTransform, isHighSurrogate, isSentinel, SENTINEL_CODE_UNIT, transformToSuggestion } from "./common.js";
+import { applyTransform, SearchKey, transformToSuggestion, Wordform2Key } from "./common.js";
+import { Node, Trie } from './trie.js';
 import { getLastPreCaretToken } from "./tokenization.js";
 
 extendString();
@@ -71,182 +72,6 @@ export interface TrieModelOptions {
    * Any punctuation to expose to the user.
    */
   punctuation?: LexicalModelPunctuation;
-}
-
-class Traversal implements LexiconTraversal {
-  /**
-   * The lexical prefix corresponding to the current traversal state.
-   */
-  prefix: String;
-
-  /**
-   * The current traversal node.  Serves as the 'root' of its own sub-Trie,
-   * and we cannot navigate back to its parent.
-   */
-  root: Node;
-
-  /**
-   * The max weight for the Trie being 'traversed'.  Needed for probability
-   * calculations.
-   */
-  totalWeight: number;
-
-  constructor(root: Node, prefix: string, totalWeight: number) {
-    this.root = root;
-    this.prefix = prefix;
-    this.totalWeight = totalWeight;
-  }
-
-  child(char: USVString): LexiconTraversal | undefined {
-    // May result for blank tokens resulting immediately after whitespace.
-    if(char == '') {
-      return this;
-    }
-
-    // Split into individual code units.
-    let steps = char.split('');
-    let traversal: Traversal | undefined = this;
-
-    while(steps.length > 0 && traversal) {
-      const step: string = steps.shift()!;
-      traversal = traversal._child(step);
-    }
-
-    return traversal;
-  }
-
-  // Handles one code unit at a time.
-  private _child(char: USVString): Traversal | undefined {
-    const root = this.root;
-    const totalWeight = this.totalWeight;
-    const nextPrefix = this.prefix + char;
-
-    if(root.type == 'internal') {
-      let childNode = root.children[char];
-      if(!childNode) {
-        return undefined;
-      }
-
-      return new Traversal(childNode, nextPrefix, totalWeight);
-    } else {
-      // root.type == 'leaf';
-      const legalChildren = root.entries.filter(function(entry) {
-        return entry.key.indexOf(nextPrefix) == 0;
-      });
-
-      if(!legalChildren.length) {
-        return undefined;
-      }
-
-      return new Traversal(root, nextPrefix, totalWeight);
-    }
-  }
-
-  *children(): Generator<{char: USVString, traversal: () => LexiconTraversal}> {
-    let root = this.root;
-
-    // We refer to the field multiple times in this method, and it doesn't change.
-    // This also assists minification a bit, since we can't minify when re-accessing
-    // through `this.`.
-    const totalWeight = this.totalWeight;
-
-    if(root.type == 'internal') {
-      for(let entry of root.values) {
-        let entryNode = root.children[entry];
-
-        // UTF-16 astral plane check.
-        if(isHighSurrogate(entry)) {
-          // First code unit of a UTF-16 code point.
-          // For now, we'll just assume the second always completes such a char.
-          //
-          // Note:  Things get nasty here if this is only sometimes true; in the future,
-          // we should compile-time enforce that this assumption is always true if possible.
-          if(entryNode.type == 'internal') {
-            let internalNode = entryNode;
-            for(let lowSurrogate of internalNode.values) {
-              let prefix = this.prefix + entry + lowSurrogate;
-              yield {
-                char: entry + lowSurrogate,
-                traversal: function() { return new Traversal(internalNode.children[lowSurrogate], prefix, totalWeight) }
-              }
-            }
-          } else {
-            // Determine how much of the 'leaf' entry has no Trie nodes, emulate them.
-            let fullText = entryNode.entries[0].key;
-            entry = entry + fullText[this.prefix.length + 1]; // The other half of the non-BMP char.
-            let prefix = this.prefix + entry;
-
-            yield {
-              char: entry,
-              traversal: function () {return new Traversal(entryNode, prefix, totalWeight)}
-            }
-          }
-        } else if(isSentinel(entry)) {
-          continue;
-        } else if(!entry) {
-          // Prevent any accidental 'null' or 'undefined' entries from having an effect.
-          continue;
-        } else {
-          let prefix = this.prefix + entry;
-          yield {
-            char: entry,
-            traversal: function() { return new Traversal(entryNode, prefix, totalWeight)}
-          }
-        }
-      }
-
-      return;
-    } else { // type == 'leaf'
-      let prefix = this.prefix;
-
-      let children = root.entries.filter(function(entry) {
-        return entry.key != prefix && prefix.length < entry.key.length;
-      })
-
-      for(let {key} of children) {
-        let nodeKey = key[prefix.length];
-
-        if(isHighSurrogate(nodeKey)) {
-          // Merge the other half of an SMP char in!
-          nodeKey = nodeKey + key[prefix.length+1];
-        }
-        yield {
-          char: nodeKey,
-          traversal: function() { return new Traversal(root, prefix + nodeKey, totalWeight)}
-        }
-      };
-      return;
-    }
-  }
-
-  get entries() {
-    const entryMapper = (value: Entry) => {
-      return {
-        text: value.content,
-        p: value.weight / this.totalWeight
-      }
-    }
-
-    if(this.root.type == 'leaf') {
-      let prefix = this.prefix;
-      let matches = this.root.entries.filter(function(entry) {
-        return entry.key == prefix;
-      });
-
-      return matches.map(entryMapper);
-    } else {
-      let matchingLeaf = this.root.children[SENTINEL_CODE_UNIT];
-      if(matchingLeaf && matchingLeaf.type == 'leaf') {
-        return matchingLeaf.entries.map(entryMapper);
-      } else {
-        return [];
-      }
-    }
-  }
-
-  get p(): number {
-    return this.root.weight / this.totalWeight;
-  }
 }
 
 /**
@@ -294,7 +119,7 @@ export default class TrieModel implements LexicalModel {
   predict(transform: Transform, context: Context): Distribution<Suggestion> {
     // Special-case the empty buffer/transform: return the top suggestions.
     if (!transform.insert && !context.left && !context.right && context.startOfBuffer && context.endOfBuffer) {
-      return makeDistribution(this._trie.firstN(MAX_SUGGESTIONS).map(({text, p}) => ({
+      return makeDistribution(this.firstN(MAX_SUGGESTIONS).map(({text, p}) => ({
         transform: {
           insert: text,
           deleteLeft: 0
@@ -315,7 +140,7 @@ export default class TrieModel implements LexicalModel {
     let prefix = getLastPreCaretToken(this.breakWords, newContext);
 
     // Return suggestions from the trie.
-    return makeDistribution(this._trie.lookup(prefix).map(({text, p}) =>
+    return makeDistribution(this.lookup(prefix).map(({text, p}) =>
       transformToSuggestion({
         insert: text,
         // Delete whatever the prefix that the user wrote.
@@ -346,101 +171,13 @@ export default class TrieModel implements LexicalModel {
   public traverseFromRoot(): LexiconTraversal {
     return this._trie.traverseFromRoot();
   }
-};
 
-/////////////////////////////////////////////////////////////////////////////////
-// What remains in this file is the trie implementation proper. Note: to       //
-// reduce bundle size, any functions/methods related to creating the trie have //
-// been removed.                                                               //
-/////////////////////////////////////////////////////////////////////////////////
-
-/**
- * An **opaque** type for a string that is exclusively used as a search key in
- * the trie. There should be a function that converts arbitrary strings
- * (queries) and converts them into a standard search key for a given language
- * model.
- *
- * Fun fact: This opaque type has ALREADY saved my bacon and found a bug!
- */
-type SearchKey = string & { _: 'SearchKey'};
-
-/**
- * The priority queue will always pop the most probable item - be it a Traversal
- * state or a lexical entry reached via Traversal.
- */
-type TraversableWithProb = TextWithProbability | LexiconTraversal;
-
-/**
- * A function that converts a string (word form or query) into a search key
- * (secretly, this is also a string).
- */
-interface Wordform2Key {
-  (wordform: string): SearchKey;
-}
-
-// The following trie implementation has been (heavily) derived from trie-ing
-// by Conrad Irwin.
-// trie-ing is copyright (C) 2015–2017 Conrad Irwin.
-// Distributed under the terms of the MIT license:
-// https://github.com/ConradIrwin/trie-ing/blob/df55d7af7068d357829db9e0a7faa8a38add1d1d/LICENSE
-
-type Node = InternalNode | Leaf;
-/**
- * An internal node in the trie. Internal nodes NEVER contain entries; if an
- * internal node should contain an entry, then it has a dummy leaf node (see
- * below), that can be accessed by node.children["\uFDD0"].
- */
-interface InternalNode {
-  type: 'internal';
-  weight: number;
-  /** Maintains the keys of children in descending order of weight. */
-  values: string[]; // TODO: As an optimization, "values" can be a single string!
   /**
-   * Maps a single UTF-16 code unit to a child node in the trie. This child
-   * node may be a leaf or an internal node. The keys of this object are kept
-   * in sorted order in the .values array.
+   * Returns the top N suggestions from the trie.
+   * @param n How many suggestions, maximum, to return.
    */
-  children: { [codeunit: string]: Node };
-}
-/** Only leaf nodes actually contain entries (i.e., the words proper). */
-interface Leaf {
-  type: 'leaf';
-  weight: number;
-  entries: Entry[];
-}
-
-/**
- * An entry in the prefix trie (stored in leaf nodes exclusively!)
- */
-interface Entry {
-  /** The actual word form, stored in the trie. */
-  content: string;
-  /** A search key that usually simplifies the word form, for ease of search. */
-  key: SearchKey;
-  weight: number;
-}
-
-/**
- * Wrapper class for the trie and its nodes.
- */
-class Trie {
-  public readonly root: Node;
-  /** The total weight of the entire trie. */
-  readonly totalWeight: number;
-  /**
-   * Converts arbitrary strings to a search key. The trie is built up of
-   * search keys; not each entry's word form!
-   */
-  toKey: Wordform2Key;
-
-  constructor(root: Node, totalWeight: number, wordform2key: Wordform2Key) {
-    this.root = root;
-    this.toKey = wordform2key;
-    this.totalWeight = totalWeight;
-  }
-
-  public traverseFromRoot(): LexiconTraversal {
-    return new Traversal(this.root, '', this.totalWeight);
+  firstN(n: number): TextWithProbability[] {
+    return getSortedResults(this._trie.traverseFromRoot(), n);
   }
 
   /**
@@ -471,15 +208,19 @@ class Trie {
     // priority over anything from its descendants.
     return directEntries.concat(deduplicated);
   }
+};
 
-  /**
-   * Returns the top N suggestions from the trie.
-   * @param n How many suggestions, maximum, to return.
-   */
-  firstN(n: number): TextWithProbability[] {
-    return getSortedResults(this.traverseFromRoot(), n);
-  }
-}
+/////////////////////////////////////////////////////////////////////////////////
+// What remains in this file is the trie implementation proper. Note: to       //
+// reduce bundle size, any functions/methods related to creating the trie have //
+// been removed.                                                               //
+/////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * The priority queue will always pop the most probable item - be it a Traversal
+ * state or a lexical entry reached via Traversal.
+ */
+type TraversableWithProb = TextWithProbability | LexiconTraversal;
 
 /**
  * Returns all entries matching the given prefix, in descending order of

--- a/common/models/templates/src/trie.ts
+++ b/common/models/templates/src/trie.ts
@@ -1,0 +1,244 @@
+import { isHighSurrogate, isSentinel, SearchKey, SENTINEL_CODE_UNIT, Wordform2Key } from "./common.js";
+
+// The following trie implementation has been (heavily) derived from trie-ing
+// by Conrad Irwin.
+// trie-ing is copyright (C) 2015–2017 Conrad Irwin.
+// Distributed under the terms of the MIT license:
+// https://github.com/ConradIrwin/trie-ing/blob/df55d7af7068d357829db9e0a7faa8a38add1d1d/LICENSE
+
+export type Node = InternalNode | Leaf;
+/**
+ * An internal node in the trie. Internal nodes NEVER contain entries; if an
+ * internal node should contain an entry, then it has a dummy leaf node (see
+ * below), that can be accessed by node.children["\uFDD0"].
+ */
+export interface InternalNode {
+  type: 'internal';
+  weight: number;
+  /** Maintains the keys of children in descending order of weight. */
+  values: string[]; // TODO: As an optimization, "values" can be a single string!
+  /**
+   * Maps a single UTF-16 code unit to a child node in the trie. This child
+   * node may be a leaf or an internal node. The keys of this object are kept
+   * in sorted order in the .values array.
+   */
+  children: { [codeunit: string]: Node };
+}
+/** Only leaf nodes actually contain entries (i.e., the words proper). */
+export interface Leaf {
+  type: 'leaf';
+  weight: number;
+  entries: Entry[];
+}
+
+/**
+ * An entry in the prefix trie (stored in leaf nodes exclusively!)
+ */
+export interface Entry {
+  /** The actual word form, stored in the trie. */
+  content: string;
+  /** A search key that usually simplifies the word form, for ease of search. */
+  key: SearchKey;
+  weight: number;
+}
+
+export class TrieTraversal implements LexiconTraversal {
+  /**
+   * The lexical prefix corresponding to the current traversal state.
+   */
+  prefix: String;
+
+  /**
+   * The current traversal node.  Serves as the 'root' of its own sub-Trie,
+   * and we cannot navigate back to its parent.
+   */
+  root: Node;
+
+  /**
+   * The max weight for the Trie being 'traversed'.  Needed for probability
+   * calculations.
+   */
+  totalWeight: number;
+
+  constructor(root: Node, prefix: string, totalWeight: number) {
+    this.root = root;
+    this.prefix = prefix;
+    this.totalWeight = totalWeight;
+  }
+
+  child(char: USVString): LexiconTraversal | undefined {
+    /*
+      Note: would otherwise return the current instance if `char == ''`.  If
+      such a call is happening, it's probably indicative of an implementation
+      issue elsewhere - let's signal now in order to catch such stuff early.
+    */
+    if(char == '') {
+      return undefined;
+    }
+
+    // Split into individual code units.
+    let steps = char.split('');
+    let traversal: ReturnType<TrieTraversal["_child"]> = this;
+
+    while(steps.length > 0 && traversal) {
+      const step: string = steps.shift()!;
+      traversal = traversal._child(step);
+    }
+
+    return traversal;
+  }
+
+  // Handles one code unit at a time.
+  private _child(char: USVString): TrieTraversal | undefined {
+    const root = this.root;
+    const totalWeight = this.totalWeight;
+    const nextPrefix = this.prefix + char;
+
+    if(root.type == 'internal') {
+      let childNode = root.children[char];
+      if(!childNode) {
+        return undefined;
+      }
+
+      return new TrieTraversal(childNode, nextPrefix, totalWeight);
+    } else {
+      // root.type == 'leaf';
+      const legalChildren = root.entries.filter(function(entry) {
+        return entry.key.indexOf(nextPrefix) == 0;
+      });
+
+      if(!legalChildren.length) {
+        return undefined;
+      }
+
+      return new TrieTraversal(root, nextPrefix, totalWeight);
+    }
+  }
+
+  *children(): Generator<{char: USVString, traversal: () => LexiconTraversal}> {
+    let root = this.root;
+    const totalWeight = this.totalWeight;
+
+    if(root.type == 'internal') {
+      for(let entry of root.values) {
+        let entryNode = root.children[entry];
+
+        // UTF-16 astral plane check.
+        if(isHighSurrogate(entry)) {
+          // First code unit of a UTF-16 code point.
+          // For now, we'll just assume the second always completes such a char.
+          //
+          // Note:  Things get nasty here if this is only sometimes true; in the future,
+          // we should compile-time enforce that this assumption is always true if possible.
+          if(entryNode.type == 'internal') {
+            let internalNode = entryNode;
+            for(let lowSurrogate of internalNode.values) {
+              let prefix = this.prefix + entry + lowSurrogate;
+              yield {
+                char: entry + lowSurrogate,
+                traversal: function() { return new TrieTraversal(internalNode.children[lowSurrogate], prefix, totalWeight) }
+              }
+            }
+          } else {
+            // Determine how much of the 'leaf' entry has no Trie nodes, emulate them.
+            let fullText = entryNode.entries[0].key;
+            entry = entry + fullText[this.prefix.length + 1]; // The other half of the non-BMP char.
+            let prefix = this.prefix + entry;
+
+            yield {
+              char: entry,
+              traversal: function () {return new TrieTraversal(entryNode, prefix, totalWeight)}
+            }
+          }
+        } else if(isSentinel(entry)) {
+          continue;
+        } else if(!entry) {
+          // Prevent any accidental 'null' or 'undefined' entries from having an effect.
+          continue;
+        } else {
+          let prefix = this.prefix + entry;
+          yield {
+            char: entry,
+            traversal: function() { return new TrieTraversal(entryNode, prefix, totalWeight)}
+          }
+        }
+      }
+
+      return;
+    } else { // type == 'leaf'
+      let prefix = this.prefix;
+
+      let children = root.entries.filter(function(entry) {
+        return entry.key != prefix && prefix.length < entry.key.length;
+      })
+
+      for(let {key} of children) {
+        let nodeKey = key[prefix.length];
+
+        if(isHighSurrogate(nodeKey)) {
+          // Merge the other half of an SMP char in!
+          nodeKey = nodeKey + key[prefix.length+1];
+        }
+        yield {
+          char: nodeKey,
+          traversal: function() { return new TrieTraversal(root, prefix + nodeKey, totalWeight)}
+        }
+      };
+      return;
+    }
+  }
+
+  get entries() {
+    const totalWeight = this.totalWeight;
+    const entryMapper = function(value: Entry) {
+      return {
+        text: value.content,
+        p: value.weight / totalWeight
+      }
+    }
+
+    if(this.root.type == 'leaf') {
+      let prefix = this.prefix;
+      let matches = this.root.entries.filter(function(entry) {
+        return entry.key == prefix;
+      });
+
+      return matches.map(entryMapper);
+    } else {
+      let matchingLeaf = this.root.children[SENTINEL_CODE_UNIT];
+      if(matchingLeaf && matchingLeaf.type == 'leaf') {
+        return matchingLeaf.entries.map(entryMapper);
+      } else {
+        return [];
+      }
+    }
+  }
+
+  get p(): number {
+    return this.root.weight / this.totalWeight;
+  }
+}
+
+/**
+ * Wrapper class for the trie and its nodes.
+ */
+export class Trie {
+  private root: Node;
+  /** The total weight of the entire trie. */
+  readonly totalWeight: number;
+  /**
+   * Converts arbitrary strings to a search key. The trie is built up of
+   * search keys; not each entry's word form!
+   */
+  toKey: Wordform2Key;
+
+  constructor(root: Node, totalWeight: number, wordform2key: Wordform2Key) {
+    this.root = root;
+    this.toKey = wordform2key;
+    this.totalWeight = totalWeight;
+  }
+
+  public traverseFromRoot(): LexiconTraversal {
+    return new TrieTraversal(this.root, '', this.totalWeight);
+  }
+}

--- a/common/models/templates/src/trie.ts
+++ b/common/models/templates/src/trie.ts
@@ -1,5 +1,4 @@
 import { isHighSurrogate, isSentinel, SearchKey, SENTINEL_CODE_UNIT, Wordform2Key } from "./common.js";
-import { sortNode } from "./trie-builder.js";
 
 // The following trie implementation has been (heavily) derived from trie-ing
 // by Conrad Irwin.
@@ -51,6 +50,37 @@ export interface Entry {
   /** A search key that usually simplifies the word form, for ease of search. */
   key: SearchKey;
   weight: number;
+}
+
+/**
+ * Recursively sort the trie, in descending order of weight.
+ * @param node any node in the trie
+ */
+export function sortNode(node: Node, onlyLocal?: boolean) {
+  if (node.type === 'leaf') {
+    if (!node.unsorted) {
+      return;
+    }
+
+    node.entries.sort(function (a, b) { return b.weight - a.weight; });
+  } else {
+    if(!onlyLocal) {
+      // We recurse and sort children before returning if sorting the full Trie.
+      for (let char of node.values) {
+        sortNode(node.children[char], onlyLocal);
+      }
+    }
+
+    if (!node.unsorted) {
+      return;
+    }
+
+    node.values.sort((a, b) => {
+      return node.children[b].weight - node.children[a].weight;
+    });
+  }
+
+  delete node.unsorted;
 }
 
 export class TrieTraversal implements LexiconTraversal {

--- a/common/models/templates/test/test-trie-builder.js
+++ b/common/models/templates/test/test-trie-builder.js
@@ -1,0 +1,257 @@
+/*
+ * Unit tests for the Trie prediction model.
+ */
+
+import { assert } from 'chai';
+import { SENTINEL_CODE_UNIT, trieConstruction, TrieBuilder } from '@keymanapp/models-templates';
+
+describe('trie construction', () => {
+  it('default root node', () => {
+    const defaultRoot = trieConstruction.createRootNode();
+    assert.equal(defaultRoot.type, 'leaf');
+    assert.equal(defaultRoot.weight, 0);
+    assert.sameMembers(defaultRoot.entries, []);
+  });
+
+  it('addItemToLeaf', () => {
+    // `weight` is managed by addUnsorted, not by addItemToLeaf.
+    // As a result, we don't test for it here.
+    const defaultRoot = trieConstruction.createRootNode();
+    trieConstruction.addItemToLeaf(defaultRoot, {
+      content: 'cafe',
+      weight: 2,
+      key: 'cafe'
+    });
+
+    assert.equal(defaultRoot.type, 'leaf');
+    assert.equal(defaultRoot.entries.length, 1);
+
+    trieConstruction.addItemToLeaf(defaultRoot, {
+      content: 'café',
+      weight: 1,
+      key: 'cafe'
+    });
+
+    assert.equal(defaultRoot.type, 'leaf');
+    assert.equal(defaultRoot.entries.length, 2);
+  });
+
+  it('convertLeafToInternalNode', () => {
+    const defaultRoot = trieConstruction.createRootNode();
+    const cafeEntry = {
+      content: 'cafe',
+      weight: 5,
+      key: 'cafe'
+    };
+    trieConstruction.addItemToLeaf(defaultRoot, cafeEntry);
+
+    defaultRoot.weight = 5;
+    trieConstruction.convertLeafToInternalNode(defaultRoot, 4);
+
+    assert.equal(defaultRoot.type, 'internal');
+    assert.sameMembers(defaultRoot.values, [SENTINEL_CODE_UNIT]);
+    assert.sameMembers(Object.keys(defaultRoot.children), defaultRoot.values);
+    assert.equal(defaultRoot.weight, 5);
+
+    const sentinelChild = defaultRoot.children[SENTINEL_CODE_UNIT];
+    assert.equal(sentinelChild.type, 'leaf');
+    assert.equal(sentinelChild.weight, 5);
+    assert.equal(sentinelChild.entries.length, 1);
+    // Should be strict-equal too, but we only really care if it's deep-equal.
+    assert.deepEqual(sentinelChild.entries[0], cafeEntry);
+  });
+
+  it('addUnsorted - simple initial entry', () => {
+    // `weight` is managed by addUnsorted, not by addItemToLeaf.
+    // As a result, we don't test for it here.
+    const defaultRoot = trieConstruction.createRootNode();
+    trieConstruction.addUnsorted(defaultRoot, {
+      content: 'cafe',
+      weight: 2,
+      key: 'cafe'
+    }, 4);
+
+    assert.equal(defaultRoot.type, 'leaf');
+    assert.equal(defaultRoot.weight, 2);
+    assert.equal(defaultRoot.entries.length, 1);
+
+    // smaller weight, will not override.  Is not additive.
+    trieConstruction.addUnsorted(defaultRoot, {
+      content: 'café',
+      weight: 1,
+      key: 'cafe'
+    }, 4);
+
+    assert.equal(defaultRoot.type, 'leaf');
+    assert.equal(defaultRoot.weight, 2);
+    assert.equal(defaultRoot.entries.length, 2);
+  });
+
+  it('addUnsorted - short word, then longer word with same prefix', () => {
+    const defaultRoot = trieConstruction.createRootNode();
+    trieConstruction.addUnsorted(defaultRoot, {
+      content: 'cafe',
+      weight: 5,
+      key: 'cafe'
+    }, 4);
+
+    assert.equal(defaultRoot.type, 'leaf');
+    assert.equal(defaultRoot.weight, 5);
+    assert.equal(defaultRoot.entries.length, 1);
+
+    // smaller weight, will not override.  Is not additive.
+    trieConstruction.addUnsorted(defaultRoot, {
+      content: 'cafeteria',
+      weight: 3,
+      key: 'cafeteria'
+    }, 4);
+
+    assert.equal(defaultRoot.type, 'internal');
+    assert.equal(defaultRoot.weight, 5);
+    assert.deepEqual(defaultRoot.values, [SENTINEL_CODE_UNIT, 't']);
+    assert.equal(defaultRoot.children[SENTINEL_CODE_UNIT].weight, 5);
+    assert.equal(defaultRoot.children['t'].weight, 3);
+  });
+
+  it('addUnsorted', () => {
+    // Perspective:  current root is actually representing `ca`.
+    const defaultRoot = trieConstruction.createRootNode();
+    trieConstruction.addUnsorted(defaultRoot, {
+      content: 'cafe',
+      weight: 5,
+      key: 'cafe'
+    }, 2);
+
+    // There's only one child, so there's no reason to start making
+    // internal structure just yet.
+    assert.equal(defaultRoot.type, 'leaf');
+    assert.equal(defaultRoot.weight, 5);
+
+    // Adds a second child; that child has more than one letter not-in-common with the first.
+    trieConstruction.addUnsorted(defaultRoot, {
+      content: 'call',
+      weight: 8,
+      key: 'call'
+    }, 2);
+
+    assert.equal(defaultRoot.type, 'internal');
+    assert.equal(defaultRoot.weight, 8);
+    assert.sameMembers(defaultRoot.values, ['f', 'l']);
+    assert.equal(defaultRoot.children['f'].weight, 5);
+    assert.equal(defaultRoot.children['l'].weight, 8);
+  });
+
+  it('addUnsorted - lower frequency prefix', () => {
+    // Will correspond to 'thin'.
+    const root = trieConstruction.createRootNode();
+    trieConstruction.addUnsorted(root, {
+      key: 'think',
+      content: 'think',
+      weight: 100
+    }, 4);
+    trieConstruction.addUnsorted(root, {
+      key: 'thing',
+      content: 'thing',
+      weight: 40
+    }, 4);
+
+    assert.equal(root.type, 'internal');
+    assert.sameMembers(root.values, ['k', 'g']);
+
+    // Interesting noted behavior:  if just 'think' into 'thin', and nothing else...
+    // it remains a leaf!  That doesn't seem... entirely proper.  With 'thing', it
+    // will at least be an 'internal' node already.
+    trieConstruction.addUnsorted(root, {
+      key: 'thin',
+      content: 'thin',
+      weight: 20
+    }, 4);
+
+    assert.sameMembers(root.values, ['k', 'g', SENTINEL_CODE_UNIT]);
+    assert.isOk(root.children[SENTINEL_CODE_UNIT]);
+    assert.equal(root.children[SENTINEL_CODE_UNIT].weight, 20);
+  });
+
+  describe('TrieBuilder', () => {
+    it('standard Trie construction', () => {
+      const builder = new TrieBuilder((text) => text);
+      builder.addEntry('caffeine', 2);
+      builder.addEntry('cafe', 5);
+      builder.addEntry('calm', 3);
+      builder.addEntry('calf', 4);
+      builder.addEntry('call', 6); // total: 20
+      builder.addEntry('can', 10); // total: 30
+      builder.addEntry('and', 20); // total: 50
+
+      assert.equal(builder.getTotalWeight(), 50);
+
+      const root = builder.getRoot();
+      const aNode = root.children['c'].children['a'];
+
+      // As the nodes were not added in sorted order, they should not currently be ordered.
+      assert.sameMembers(aNode.values, ['n', 'l', 'f']);
+      assert.notSameOrderedMembers(aNode.values, ['n', 'l', 'f']);
+
+      const lNode = aNode.children['l'];
+      assert.sameMembers(lNode.values, ['l', 'f', 'm']);
+      assert.notSameOrderedMembers(lNode.values, ['l', 'f', 'm']);
+
+      builder.sort();
+
+      assert.sameOrderedMembers(aNode.values, ['n', 'l', 'f']);
+      assert.sameOrderedMembers(lNode.values, ['l', 'f', 'm']);
+    });
+
+    // In case of high startup-time for user-dictionary processing, this could allow use
+    // of a 'partially' processed user wordlist.  (We'd prioritize predicting when the
+    // user is interacting with text, then resume processing once 'idle'.)
+    it('interspersed construction + lookup', () => {
+      const builder = new TrieBuilder((text) => text);
+      builder.addEntry('caffeine', 2);
+      builder.addEntry('cafe', 5);
+      builder.addEntry('calm', 3);
+      builder.addEntry('calf', 4);
+      builder.addEntry('call', 6); // total: 20
+
+      // ------------------------------------------
+      // Pause construction; actually use the Trie.
+
+      assert.equal(builder.getTotalWeight(), 20);
+      const root = builder.getRoot();
+      const caNode = root.children['c'].children['a'];
+
+      // As the nodes were not added in sorted order, they should not currently be ordered.
+      assert.sameMembers(caNode.values, ['l', 'f']);
+      assert.notSameOrderedMembers(caNode.values, ['l', 'f']);
+
+      const cal = builder.traverseFromRoot().child('cal');
+      // Actually traversing through the node should auto-sort the entries.
+      assert.sameOrderedMembers(caNode.values, ['l', 'f']);
+      // Including the reached node's children.
+      assert.sameOrderedMembers([...cal.children()].map((entry) => entry.char), ['l', 'f', 'm']);
+
+      const cafNode = caNode.children['f'];
+
+      // 'caffeine' was added before 'cafe'.
+      // Parts not 'traversed' should not be unnecessarily sorted.
+      assert.notSameOrderedMembers(cafNode.values, ['e', 'f']);
+
+      // -------------------
+      // Resume construction
+
+      builder.addEntry('can', 10); // total: 30
+      builder.addEntry('and', 20); // total: 50
+
+      assert.equal(builder.getTotalWeight(), 50);
+
+      // As the nodes were not added in sorted order, they should not currently be ordered.
+      assert.sameMembers(caNode.values, ['n', 'l', 'f']);
+      // 'n' was added later, thus will be out of sorted order.
+      assert.notSameOrderedMembers(caNode.values, ['n', 'l', 'f']);
+
+      builder.sort();
+
+      assert.sameOrderedMembers(caNode.values, ['n', 'l', 'f']);
+    });
+  });
+});

--- a/developer/src/kmc-model/build.sh
+++ b/developer/src/kmc-model/build.sh
@@ -13,7 +13,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Keyman kmc Lexical Model Compiler module" \
   "@/common/web/keyman-version" \
   "@/developer/src/common/web/test-helpers" \
-  "@/common/models/templates test" \
+  "@/common/models/templates" \
   "clean" \
   "configure" \
   "build" \

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -32,12 +32,12 @@
   "dependencies": {
     "@keymanapp/common-types": "*",
     "@keymanapp/keyman-version": "*",
+    "@keymanapp/models-templates": "*",
     "@keymanapp/models-types": "*",
     "typescript": "^5.4.5"
   },
   "devDependencies": {
     "@keymanapp/developer-test-helpers": "*",
-    "@keymanapp/models-templates": "*",
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.4.1",
     "c8": "^7.12.0",

--- a/developer/src/kmc-model/src/build-trie.ts
+++ b/developer/src/kmc-model/src/build-trie.ts
@@ -291,11 +291,26 @@ namespace Trie {
    * @returns A JSON-serialiable object that can be given to the TrieModel constructor.
    */
   export function buildTrie(wordlist: WordList, keyFunction: SearchTermToKey): object {
-    let root = new Trie(keyFunction).buildFromWordList(wordlist).root;
+    let trie = new Trie(keyFunction);
+    buildFromWordList(trie, wordlist);
+    const root = trie.root;
     return {
       totalWeight: sumWeights(root),
       root: root
     }
+  }
+
+  /**
+   * Populates the trie with the contents of an entire wordlist.
+   * @param words a list of word and count pairs.
+   */
+  function buildFromWordList(trie: Trie, words: WordList): Trie {
+    for (let [wordform, weight] of Object.entries(words)) {
+      let key = trie.toKey(wordform);
+      addUnsorted(trie.root, { key, weight, content: wordform }, 0);
+    }
+    sortTrie(trie.root);
+    return trie;
   }
 
   /**
@@ -306,19 +321,6 @@ namespace Trie {
     toKey: SearchTermToKey;
     constructor(wordform2key: SearchTermToKey) {
       this.toKey = wordform2key;
-    }
-
-    /**
-     * Populates the trie with the contents of an entire wordlist.
-     * @param words a list of word and count pairs.
-     */
-    buildFromWordList(words: WordList): Trie {
-      for (let [wordform, weight] of Object.entries(words)) {
-        let key = this.toKey(wordform);
-        addUnsorted(this.root, { key, weight, content: wordform }, 0);
-      }
-      sortTrie(this.root);
-      return this;
     }
   }
 

--- a/developer/src/kmc-model/src/build-trie.ts
+++ b/developer/src/kmc-model/src/build-trie.ts
@@ -1,6 +1,8 @@
 import { ModelCompilerError, ModelCompilerMessageContext, ModelCompilerMessages } from "./model-compiler-messages.js";
 import { callbacks } from "./compiler-callbacks.js";
 
+import { addUnsorted, Node, TrieBuilder } from '@keymanapp/models-templates';
+
 // Supports LF or CRLF line terminators.
 const NEWLINE_SEPARATOR = /\u000d?\u000a/;
 
@@ -29,7 +31,7 @@ export function createTrieDataStructure(filenames: string[], searchTermToKey?: (
   let wordlist: WordList = {};
   filenames.forEach(filename => parseWordListFromFilename(wordlist, filename));
 
-  let trie = Trie.buildTrie(wordlist, searchTermToKey as Trie.SearchTermToKey);
+  let trie = buildTrie(wordlist, searchTermToKey as SearchTermToKey);
   return JSON.stringify(trie);
 }
 
@@ -185,304 +187,77 @@ function* enumerateLines(lines: string[]): Generator<LineNoAndText> {
     }
 }
 
-namespace Trie {
-  /**
-   * An **opaque** type for a string that is exclusively used as a search key in
-   * the trie. There should be a function that converts arbitrary strings
-   * (queries) and converts them into a standard search key for a given language
-   * model.
-   *
-   * Fun fact: This opaque type has ALREADY saved my bacon and found a bug!
-   */
-  type SearchKey = string & { _: 'SearchKey'};
+/**
+ * An **opaque** type for a string that is exclusively used as a search key in
+ * the trie. There should be a function that converts arbitrary strings
+ * (queries) and converts them into a standard search key for a given language
+ * model.
+ *
+ * Fun fact: This opaque type has ALREADY saved my bacon and found a bug!
+ */
+type SearchKey = string & { _: 'SearchKey'};
 
-  /**
-   * A function that converts a string (word form or query) into a search key
-   * (secretly, this is also a string).
-   */
-  export interface SearchTermToKey {
-    (wordform: string): SearchKey;
+/**
+ * A function that converts a string (word form or query) into a search key
+ * (secretly, this is also a string).
+ */
+export interface SearchTermToKey {
+  (wordform: string): SearchKey;
+}
+
+/**
+ * Builds a trie from a word list.
+ *
+ * @param wordlist    The wordlist with non-negative weights.
+ * @param keyFunction Function that converts word forms into indexed search keys
+ * @returns A JSON-serialiable object that can be given to the TrieModel constructor.
+ */
+export function buildTrie(wordlist: WordList, keyFunction: SearchTermToKey): object {
+  let collater = new TrieBuilder(keyFunction);
+
+  buildFromWordList(collater, wordlist);
+  return {
+    totalWeight: sumWeights(collater.getRoot()),
+    root: collater.getRoot()
+  }
+}
+
+/**
+ * Populates the trie with the contents of an entire wordlist.
+ * @param words a list of word and count pairs.
+ */
+function buildFromWordList(trieCollator: TrieBuilder, words: WordList): TrieBuilder {
+  for (let [wordform, weight] of Object.entries(words)) {
+    let key = trieCollator.toKey(wordform);
+    addUnsorted(trieCollator.getRoot(), { content: wordform, key, weight });
+  }
+  trieCollator.sort();
+  return trieCollator;
+}
+
+/**
+ * O(n) recursive traversal to sum the total weight of all leaves in the
+ * trie, starting at the provided node.
+ *
+ * @param node The node to start summing weights.
+ */
+function sumWeights(node: Node): number {
+  let val: number;
+  if (node.type === 'leaf') {
+    val = node.entries
+      .map(entry => entry.weight)
+      //.map(entry => isNaN(entry.weight) ? 1 : entry.weight)
+      .reduce((acc, count) => acc + count, 0);
+  } else {
+    val = Object.keys(node.children)
+      .map((key) => sumWeights(node.children[key]))
+      .reduce((acc, count) => acc + count, 0);
   }
 
-  // The following trie implementation has been (heavily) derived from trie-ing
-  // by Conrad Irwin.
-  //
-  // trie-ing is distributed under the terms of the MIT license, reproduced here:
-  //
-  //   The MIT License
-  //   Copyright (c) 2015-2017 Conrad Irwin <conrad.irwin@gmail.com>
-  //   Copyright (c) 2011 Marc Campbell <marc.e.campbell@gmail.com>
-  //
-  //   Permission is hereby granted, free of charge, to any person obtaining a copy
-  //   of this software and associated documentation files (the "Software"), to deal
-  //   in the Software without restriction, including without limitation the rights
-  //   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  //   copies of the Software, and to permit persons to whom the Software is
-  //   furnished to do so, subject to the following conditions:
-  //
-  //   The above copyright notice and this permission notice shall be included in
-  //   all copies or substantial portions of the Software.
-  //
-  //   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  //   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  //   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  //   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  //   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  //   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-  //   THE SOFTWARE.
-  //
-  // See: https://github.com/ConradIrwin/trie-ing/blob/df55d7af7068d357829db9e0a7faa8a38add1d1d/LICENSE
-
-  /**
-   * An entry in the prefix trie. The matched word is "content".
-   */
-  interface Entry {
-    content: string;
-    key: SearchKey;
-    weight: number;
+  if(isNaN(val)) {
+    throw new Error("Unexpected NaN has appeared!");
   }
-
-  /**
-   * The trie is made up of nodes. A node can be EITHER an internal node (whose
-   * only children are other nodes) OR a leaf, which actually contains the word
-   * form entries.
-   */
-  type Node = InternalNode | Leaf;
-
-  /**
-   * An internal node.
-   */
-  interface InternalNode {
-    type: 'internal';
-    weight: number;
-    // TODO: As an optimization, "values" can be a single string!
-    values: string[];
-    children: { [codeunit: string]: Node };
-    unsorted?: true;
-  }
-
-  /**
-   * A leaf node.
-   */
-  interface Leaf {
-    type: 'leaf';
-    weight: number;
-    entries: Entry[];
-    unsorted?: true;
-  }
-
-  /**
-   * A sentinel value for when an internal node has contents and requires an
-   * "internal" leaf. That is, this internal node has content. Instead of placing
-   * entries as children in an internal node, a "fake" leaf is created, and its
-   * key is this special internal value.
-   *
-   * The value is a valid Unicode BMP code point, but it is a "non-character".
-   * Unicode will never assign semantics to these characters, as they are
-   * intended to be used internally as sentinel values.
-   */
-  const INTERNAL_VALUE = '\uFDD0';
-
-  /**
-   * Builds a trie from a word list.
-   *
-   * @param wordlist    The wordlist with non-negative weights.
-   * @param keyFunction Function that converts word forms into indexed search keys
-   * @returns A JSON-serialiable object that can be given to the TrieModel constructor.
-   */
-  export function buildTrie(wordlist: WordList, keyFunction: SearchTermToKey): object {
-    let trie = new Trie(keyFunction);
-    buildFromWordList(trie, wordlist);
-    const root = trie.root;
-    return {
-      totalWeight: sumWeights(root),
-      root: root
-    }
-  }
-
-  /**
-   * Populates the trie with the contents of an entire wordlist.
-   * @param words a list of word and count pairs.
-   */
-  function buildFromWordList(trie: Trie, words: WordList): Trie {
-    for (let [wordform, weight] of Object.entries(words)) {
-      let key = trie.toKey(wordform);
-      addUnsorted(trie.root, { key, weight, content: wordform }, 0);
-    }
-    sortTrie(trie.root);
-    return trie;
-  }
-
-  /**
-   * Wrapper class for the trie and its nodes and wordform to search
-   */
-  class Trie {
-    readonly root = createRootNode();
-    toKey: SearchTermToKey;
-    constructor(wordform2key: SearchTermToKey) {
-      this.toKey = wordform2key;
-    }
-  }
-
-  // "Constructors"
-  function createRootNode(): Node {
-    return {
-      type: 'leaf',
-      weight: 0,
-      entries: []
-    };
-  }
-
-  // Implement Trie creation.
-
-  /**
-   * Adds an entry to the trie.
-   *
-   * Note that the trie will likely be unsorted after the add occurs. Before
-   * performing a lookup on the trie, use call sortTrie() on the root note!
-   *
-   * @param node Which node should the entry be added to?
-   * @param entry the wordform/weight/key to add to the trie
-   * @param index the index in the key and also the trie depth. Should be set to
-   *              zero when adding onto the root node of the trie.
-   */
-  function addUnsorted(node: Node, entry: Entry, index: number = 0) {
-    // Each node stores the MAXIMUM weight out of all of its decesdents, to
-    // enable a greedy search through the trie.
-    node.weight = Math.max(node.weight, entry.weight);
-
-    // When should a leaf become an interior node?
-    // When it already has a value, but the key of the current value is longer
-    // than the prefix.
-    if (node.type === 'leaf' && index < entry.key.length && node.entries.length >= 1) {
-      convertLeafToInternalNode(node, index);
-    }
-
-    if (node.type === 'leaf') {
-      // The key matches this leaf node, so add yet another entry.
-      addItemToLeaf(node, entry);
-    } else {
-      // Push the node down to a lower node.
-      addItemToInternalNode(node, entry, index);
-    }
-
-    node.unsorted = true;
-  }
-
-  /**
-   * Adds an item to the internal node at a given depth.
-   * @param item
-   * @param index
-   */
-  function addItemToInternalNode(node: InternalNode, item: Entry, index: number) {
-    let char = item.key[index];
-    // If an internal node is the proper site for item, it belongs under the
-    // corresponding (sentinel, internal-use) child node signifying this.
-    if(char == undefined) {
-      char = INTERNAL_VALUE;
-    }
-    if (!node.children[char]) {
-      node.children[char] = createRootNode();
-      node.values.push(char);
-    }
-    addUnsorted(node.children[char], item, index + 1);
-  }
-
-  function addItemToLeaf(leaf: Leaf, item: Entry) {
-    leaf.entries.push(item);
-  }
-
-  /**
-   * Mutates the given Leaf to turn it into an InternalNode.
-   *
-   * NOTE: the node passed in will be DESTRUCTIVELY CHANGED into a different
-   * type when passed into this function!
-   *
-   * @param depth depth of the trie at this level.
-   */
-  function convertLeafToInternalNode(leaf: Leaf, depth: number): void {
-    let entries = leaf.entries;
-
-    // Alias the current node, as the desired type.
-    let internal = (<unknown> leaf) as InternalNode;
-    internal.type = 'internal';
-
-    delete leaf.entries;
-    internal.values = [];
-    internal.children = {};
-
-    // Convert the old values array into the format for interior nodes.
-    for (let item of entries) {
-      let char: string;
-      if (depth < item.key.length) {
-        char = item.key[depth];
-      } else {
-        char = INTERNAL_VALUE;
-      }
-
-      if (!internal.children[char]) {
-        internal.children[char] = createRootNode();
-        internal.values.push(char);
-      }
-      addUnsorted(internal.children[char], item, depth + 1);
-    }
-
-    internal.unsorted = true;
-  }
-
-  /**
-   * Recursively sort the trie, in descending order of weight.
-   * @param node any node in the trie
-   */
-  function sortTrie(node: Node) {
-    if (node.type === 'leaf') {
-      if (!node.unsorted) {
-        return;
-      }
-
-      node.entries.sort(function (a, b) { return b.weight - a.weight; });
-    } else {
-      // We MUST recurse and sort children before returning.
-      for (let char of node.values) {
-        sortTrie(node.children[char]);
-      }
-
-      if (!node.unsorted) {
-        return;
-      }
-
-      node.values.sort((a, b) => {
-        return node.children[b].weight - node.children[a].weight;
-      });
-    }
-
-    delete node.unsorted;
-  }
-
-  /**
-   * O(n) recursive traversal to sum the total weight of all leaves in the
-   * trie, starting at the provided node.
-   *
-   * @param node The node to start summing weights.
-   */
-  function sumWeights(node: Node): number {
-    let val: number;
-    if (node.type === 'leaf') {
-      val = node.entries
-        .map(entry => entry.weight)
-        //.map(entry => isNaN(entry.weight) ? 1 : entry.weight)
-        .reduce((acc, count) => acc + count, 0);
-    } else {
-      val = Object.keys(node.children)
-        .map((key) => sumWeights(node.children[key]))
-        .reduce((acc, count) => acc + count, 0);
-    }
-
-    if(isNaN(val)) {
-      throw new Error("Unexpected NaN has appeared!");
-    }
-    return val;
-  }
+  return val;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,12 +1342,12 @@
       "dependencies": {
         "@keymanapp/common-types": "*",
         "@keymanapp/keyman-version": "*",
+        "@keymanapp/models-templates": "*",
         "@keymanapp/models-types": "*",
         "typescript": "^5.4.5"
       },
       "devDependencies": {
         "@keymanapp/developer-test-helpers": "*",
-        "@keymanapp/models-templates": "*",
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.4.1",
         "c8": "^7.12.0",

--- a/web/src/engine/predictive-text/worker-main/README.md
+++ b/web/src/engine/predictive-text/worker-main/README.md
@@ -17,10 +17,12 @@ Build
 Run `build.sh`. This will also automatically install dependencies with `npm`.
 
 ```sh
-./build.sh
+./build.sh configure build
 ```
 
 ### Two-stage compilation process
+
+TODO: this is well and truly out of date...
 
 Since the primary LMLayer code runs within a [Web Worker][], `build.sh` compiles the
 LMLayer in two stages:
@@ -43,19 +45,7 @@ This will run both headless unit tests, and in-browser unit tests and integratio
 tests:
 
 ```sh
-./build.sh -test
+./build.sh test
 ```
 
-### Test-Driven Development
-
-I like to use [entr]() to automatically build and re-run the unit tests anytime I
-change a source code file. Here's the command I run in separate window:
-
-```sh
-git ls-files | entr -c ./build.sh -tdd
-```
-
-Importantly, `./build.sh -tdd` skips running the in-browser tests, and skips
-downloading/updating `npm` dependencies.
-
-[entr]: http://eradman.com/entrproject/
+### TODO: epic/user-dict


### PR DESCRIPTION
This PR extracts the changes currently within the `epic/user-dict` feature branch that are _also_ needed for enhanced model encoding to serve as the base of `epic/model-encoding`.  All were changes were previously reviewed for epic/user-dict:

- #12080
- #12084
- #12083
- #12085
- #12086

Other PRs have since been merged there, but are irrelevant for the purposes of the epic/model-encoding feature.

@keymanapp-test-bot skip