### PR TITLE
chore(developer): extend timeouts for lm compiler tests to 5 secs

### DIFF
--- a/developer/src/kmc-model/test/test-compile-model.ts
+++ b/developer/src/kmc-model/test/test-compile-model.ts
@@ -9,6 +9,8 @@ import { KeymanFileTypes } from '@keymanapp/common-types';
 describe('LexicalModelCompiler', function () {
   let callbacks = new TestCompilerCallbacks();
 
+  this.timeout(5000);
+
   // Try to compile ALL of the correct models.
   const MODELS = [
     'example.qaa.sencoten',


### PR DESCRIPTION
Fixes: #12271

@keymanapp-test-bot skip