### PR TITLE
fix(developer): make LDML import path consistent for all bundlings of kmc

### DIFF
--- a/developer/src/common/web/utils/build.sh
+++ b/developer/src/common/web/utils/build.sh
@@ -35,9 +35,9 @@ function copy_cldr_imports() {
     # TODO-LDML: developer/src/inst/download.in.mak needs these also...
     CLDR_PATH=$(dirname "$CLDR_INFO_PATH")
     CLDR_VER=$(basename "$CLDR_PATH")
-    mkdir -p "$THIS_SCRIPT_PATH/build/src/import/$CLDR_VER"
+    mkdir -p "$THIS_SCRIPT_PATH/build/src/types/import/$CLDR_VER"
     # TODO-LDML: When these are copied, the DOCTYPE will break due to the wrong path. We don't use the DTD so it should be OK.
-    cp "$CLDR_INFO_PATH" "$CLDR_PATH/import/"*.xml "$THIS_SCRIPT_PATH/build/src/import/$CLDR_VER/"
+    cp "$CLDR_INFO_PATH" "$CLDR_PATH/import/"*.xml "$THIS_SCRIPT_PATH/build/src/types/import/$CLDR_VER/"
   done
 }
 

--- a/developer/src/common/web/utils/src/types/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/developer/src/common/web/utils/src/types/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -23,7 +23,7 @@ export class LDMLKeyboardXMLSourceFileReader {
   }
 
   static get defaultImportsURL(): [string,string] {
-    return ['../../import/', import.meta.url];
+    return ['../import/', import.meta.url];
   }
 
   readImportFile(version: string, subpath: string): Uint8Array {


### PR DESCRIPTION
The default import path is relative to ldml-keyboard-xml-reader.js. The bundling of kmc with Keyman Developer reduces the directory tree depth, so we move the import path to be a subdirectory of the immediate parent directory, rather than two levels up, so that `C:\Program Files\Keyman\Keyman Developer\kmc` can refer to `C:\Program Files\Keyman\Keyman Developer\import` when kmc is bundled.

Fixes: #12279

# User Testing

**TEST_LDML_COMPILE:** Create an LDML keyboard and try to compile it -- it should not have the error "Import could not read data"