### PR TITLE
fix(core): properly support 'other' modifier state with `uint32_t` type

### DIFF
--- a/core/src/ldml/ldml_processor.cpp
+++ b/core/src/ldml/ldml_processor.cpp
@@ -85,7 +85,7 @@ ldml_processor::ldml_processor(path const & kb_path, const std::vector<uint8_t> 
       } else {
         str = keyEntry->get_to_string();
       }
-      keys.add((km_core_virtual_key)kmapEntry->vkey, (uint16_t)kmapEntry->mod, str);
+      keys.add((km_core_virtual_key)kmapEntry->vkey, kmapEntry->mod, str);
     }
   } // else: no keys! but still valid. Just, no keys.
 

--- a/core/src/ldml/ldml_vkeys.cpp
+++ b/core/src/ldml/ldml_vkeys.cpp
@@ -17,7 +17,7 @@ vkeys::vkeys() : vkey_to_string() {
 }
 
 void
-vkeys::add(km_core_virtual_key vk, uint16_t modifier_state, std::u16string output) {
+vkeys::add(km_core_virtual_key vk, km_core_ldml_modifier_state modifier_state, std::u16string output) {
   // construct key
   const vkey_id id(vk, modifier_state);
   // assign the string

--- a/core/src/ldml/ldml_vkeys.hpp
+++ b/core/src/ldml/ldml_vkeys.hpp
@@ -20,9 +20,16 @@ namespace core {
 namespace ldml {
 
 /**
+ * LDML keyboards have 32-bit modifier flags in order to support
+ * LDML_KEYS_MOD_OTHER (0x10000), unlike the Core APIs which have only 16 bit
+ * modifier flags.
+ */
+typedef uint32_t km_core_ldml_modifier_state;
+
+/**
  * identifier for keybag lookup
  */
-typedef std::pair<km_core_virtual_key, uint16_t> vkey_id;
+typedef std::pair<km_core_virtual_key, km_core_ldml_modifier_state> vkey_id;
 
 /**
  * LDML Class to manage all things key related: vkey remapping and vkey to string
@@ -35,9 +42,9 @@ public:
   vkeys();
 
   /**
-   * add a vkey to the bag
+   * add a vkey to the bag.
    */
-  void add(km_core_virtual_key vk, uint16_t modifier_state, std::u16string output);
+  void add(km_core_virtual_key vk, km_core_ldml_modifier_state ldml_modifier_state, std::u16string output);
 
   /**
    * Lookup a vkey, returns an empty string if not found


### PR DESCRIPTION
While the modifier state property in core's API is 16-bit, internally ldml_processor supports the modifier flag LDML_KEYS_MOD_OTHER with a value of `0x10000`, which requires widening the value (we match the 32-bit size of the KMX_DWORD value from KMX+).

Note: this is not yet well unit-tested.

Will cherry-pick once approved.

Relates-to: #11072
Fixes: #12057

# User Testing

Please paste in the following LDML keyboard source for testing:

```xml
<?xml version="1.0"?>
<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="arc" conformsTo="45">
  <info author="Marc Durdin" name="Test 'other' modifier"/>
  <version number="1.0.0"/>
  <keys>
    <import base="cldr" path="45/keys-Zyyy-punctuation.xml"/>
    <import base="cldr" path="45/keys-Zyyy-currency.xml"/>
  	<!-- switch keys -->

    <key id="a" output="🅐" />
    <key id="b" output="🅑" />
    <key id="c" output="🅒" />
    <key id="d" output="🅓" />
    <key id="e" output="🅔" />
  </keys>
  <layers formId="us">
    <layer modifiers="none">
      <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal"/>
      <row keys="a"/>
      <row keys="gap"/>
      <row keys="gap"/>
      <row keys="space"/>
    </layer>
    <layer modifiers="shift">
      <row keys="tilde bang at hash dollar percent caret amp asterisk open-paren close-paren underscore plus"/>
      <row keys="b"/>
      <row keys="gap"/>
      <row keys="gap"/>
      <row keys="space"/>
    </layer>
    <layer modifiers="ctrl">
      <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal"/>
      <row keys="c"/>
      <row keys="gap"/>
      <row keys="gap"/>
      <row keys="space"/>
    </layer>
    <layer modifiers="other">
      <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal"/>
      <row keys="d e"/>
      <row keys="gap"/>
      <row keys="gap"/>
      <row keys="space"/>
    </layer>
  </layers>
</keyboard3>
```

Create a basic LDML keyboard, and paste in the source above. Compile the keyboard and its package. Use this keyboard in all the subsequent tests.

For all tests, pass the test if:

* <kbd>q</kbd> emits 🅐
* <kbd>shift</kbd>+<kbd>q</kbd> emits 🅑
* <kbd>ctrl</kbd>+<kbd>q</kbd> emits 🅒
* <kbd>alt</kbd>+<kbd>q</kbd> emits 🅓
* <kbd>alt</kbd>+<kbd>w</kbd> emits 🅔
* the following key combinations have no output:
  * <kbd>alt</kbd>+<kbd>e</kbd>
  * <kbd>ctrl</kbd>+<kbd>e</kbd>
  * <kbd>shift</kbd>+<kbd>e</kbd>
  * <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>e</kbd>
  * <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>e</kbd>
  * <kbd>e</kbd>

* **TEST_DEBUGGER:** Test the keyboard in the Keyman Developer Debugger
* **TEST_WINDOWS:** Install the keyboard in Keyman for Windows, and test the keyboard in Notepad
* **TEST_MAC:** Install the keyboard in Keyman for macOS, and test the keyboard in TextEdit
* **TEST_LINUX:** Install the keyboard in Keyman for Linux, and test the keyboard in a text editor