### PR TITLE
fix(core): properly support 'other' modifier state with `uint32_t` type 🍒 🏠

### DIFF
--- a/core/src/ldml/ldml_processor.cpp
+++ b/core/src/ldml/ldml_processor.cpp
@@ -85,7 +85,7 @@ ldml_processor::ldml_processor(path const & kb_path, const std::vector<uint8_t> 
       } else {
         str = keyEntry->get_to_string();
       }
-      keys.add((km_core_virtual_key)kmapEntry->vkey, (uint16_t)kmapEntry->mod, str);
+      keys.add((km_core_virtual_key)kmapEntry->vkey, kmapEntry->mod, str);
     }
   } // else: no keys! but still valid. Just, no keys.
 

--- a/core/src/ldml/ldml_vkeys.cpp
+++ b/core/src/ldml/ldml_vkeys.cpp
@@ -17,7 +17,7 @@ vkeys::vkeys() : vkey_to_string() {
 }
 
 void
-vkeys::add(km_core_virtual_key vk, uint16_t modifier_state, std::u16string output) {
+vkeys::add(km_core_virtual_key vk, km_core_ldml_modifier_state modifier_state, std::u16string output) {
   // construct key
   const vkey_id id(vk, modifier_state);
   // assign the string

--- a/core/src/ldml/ldml_vkeys.hpp
+++ b/core/src/ldml/ldml_vkeys.hpp
@@ -20,9 +20,16 @@ namespace core {
 namespace ldml {
 
 /**
+ * LDML keyboards have 32-bit modifier flags in order to support
+ * LDML_KEYS_MOD_OTHER (0x10000), unlike the Core APIs which have only 16 bit
+ * modifier flags.
+ */
+typedef uint32_t km_core_ldml_modifier_state;
+
+/**
  * identifier for keybag lookup
  */
-typedef std::pair<km_core_virtual_key, uint16_t> vkey_id;
+typedef std::pair<km_core_virtual_key, km_core_ldml_modifier_state> vkey_id;
 
 /**
  * LDML Class to manage all things key related: vkey remapping and vkey to string
@@ -35,9 +42,9 @@ public:
   vkeys();
 
   /**
-   * add a vkey to the bag
+   * add a vkey to the bag.
    */
-  void add(km_core_virtual_key vk, uint16_t modifier_state, std::u16string output);
+  void add(km_core_virtual_key vk, km_core_ldml_modifier_state ldml_modifier_state, std::u16string output);
 
   /**
    * Lookup a vkey, returns an empty string if not found


### PR DESCRIPTION
While the modifier state property in core's API is 16-bit, internally ldml_processor supports the modifier flag LDML_KEYS_MOD_OTHER with a value of `0x10000`, which requires widening the value (we match the 32-bit size of the KMX_DWORD value from KMX+).

Note: this is not yet well unit-tested.

Relates-to: #11072
Fixes: #12057
Cherry-pick-of: #12281

@keymanapp-test-bot skip