### PR TITLE
chore(android): Cleanup stray debug statements in console

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -117,7 +117,7 @@ function notifyHost(event, params) {
 function setLongpressDelay(delay) {
   if (keyman.osk) {
     keyman.osk.gestureParams.longpress.waitLength = delay;
-    console.debug('setLongpressDelay('+delay+')');
+    console_debug('setLongpressDelay('+delay+')');
   } else {
     window.console.log('setLongpressDelay error: keyman.osk undefined');
   }
@@ -304,7 +304,7 @@ function updateKMSelectionRange(start, end) {
 
     console_debug('result:\n' + build_context_string(context));
   } else {
-    console.debug('range unchanged');
+    console_debug('range unchanged');
   }
 }
 


### PR DESCRIPTION
I was checking the Chrome console while investigating #12203 and noticed some stray debug statements.
This fixes some `console.debug` calls to use `console_debug` (the wrapper used in android-host.js)

@keymanapp-test-bot skip
