### PR TITLE
fix(web): fixes wordbreaker test import path

### DIFF
--- a/common/models/wordbreakers/test/test-search-property.js
+++ b/common/models/wordbreakers/test/test-search-property.js
@@ -3,8 +3,8 @@
  */
 
 import { assert } from 'chai';
-import { searchForProperty } from '../build/obj/default/searchForProperty.js';
-import { propertyMap } from '../build/obj/default/data.inc.js';
+import { searchForProperty } from '../build/main/obj/default/searchForProperty.js';
+import { propertyMap } from '../build/main/obj/default/data.inc.js';
 
 describe('searchForProperty', () => {
   it('correctly finds character classes for standard ASCII characters', () => {


### PR DESCRIPTION
I noticed this after merging in the wordbreaker PRs - it appears one of the late changes to one of them had an unintended side effect in a descendant that wasn't caught before merge.

@keymanapp-test-bot skip