### PR TITLE
fix(web): prevent unintuitive space-output blocking for mid-context suggestions

### DIFF
--- a/web/src/engine/interfaces/src/prediction/predictionContext.ts
+++ b/web/src/engine/interfaces/src/prediction/predictionContext.ts
@@ -209,7 +209,9 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
 
     if(!recentAcceptCause && this.selected) {
       this.accept(this.selected);
-      returnObj.shouldSwallow = true;
+      // If there is right-context, DO emit the space instead of swallowing it.
+      // It's not auto-added by the predictive-text worker for such cases.
+      returnObj.shouldSwallow = !this.currentTarget.getTextAfterCaret();
 
       // doTryAccept is the path for keystroke-based auto-acceptance.
       // Overwrite the cause to reflect this.
@@ -229,7 +231,7 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
       // If the model doesn't insert wordbreaks, there's no space to alias, so
       // don't swallow the space.  If it does, we consider that insertion to be
       // the results of the first post-accept space.
-      returnObj.shouldSwallow = !!this.langProcessor.wordbreaksAfterSuggestions; // can be handed outside
+      returnObj.shouldSwallow = !!this.langProcessor.wordbreaksAfterSuggestions && !this.currentTarget.getTextAfterCaret();; // can be handed outside
     } else {
       returnObj.shouldSwallow = false;
     }


### PR DESCRIPTION
Fixes: #12309

## User Testing

TEST_MID_CONTEXT_SUGGESTIONS:  Edit words in the middle of context and test their interactions with predictive-text.
- If a suggestion is applied via the banner...
    - Verify that no new space is appended
    - Verify that tapping the space bar afterward does emit the expected space.
- If a suggestion is applied automatically via the spacebar...
    - Verify that a new space is appended.