### PR TITLE
fix(android): Prioritize certain actions over multi-line for ENTER key

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1274,17 +1274,13 @@ public final class KMManager {
   /**
    * Sets enterMode which specifies how the System keyboard ENTER key is handled
    *
-   * @param imeOptions EditorInfo.imeOptions
-   * @param inputType  InputType
+   * @param imeOptions EditorInfo.imeOptions used to determine the action
+   * @param inputType  InputType used to determine if the text field is multi-line
    */
   public static void setEnterMode(int imeOptions, int inputType) {
-    if ((inputType & InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0) {
-      enterMode = EnterModeType.NEWLINE;
-      return;
-    }
-
-    int imeActions = imeOptions & EditorInfo.IME_MASK_ACTION;
     EnterModeType value = EnterModeType.DEFAULT;
+    int imeActions = imeOptions & EditorInfo.IME_MASK_ACTION;
+    boolean isMultiLine = (inputType & InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0;
 
     switch (imeActions) {
       case EditorInfo.IME_ACTION_GO:
@@ -1296,7 +1292,8 @@ public final class KMManager {
         break;
 
       case EditorInfo.IME_ACTION_SEND:
-        value = EnterModeType.SEND;
+        value = isMultiLine ?
+          EnterModeType.NEWLINE :EnterModeType.SEND;
         break;
 
       case EditorInfo.IME_ACTION_NEXT:
@@ -1304,7 +1301,8 @@ public final class KMManager {
         break;
 
       case EditorInfo.IME_ACTION_DONE:
-        value = EnterModeType.DONE;
+        value = isMultiLine ?
+          EnterModeType.NEWLINE : EnterModeType.DONE;
         break;
 
       case EditorInfo.IME_ACTION_PREVIOUS:
@@ -1312,7 +1310,8 @@ public final class KMManager {
         break;
 
       default:
-        value = EnterModeType.DEFAULT;
+        value = isMultiLine ?
+          EnterModeType.NEWLINE : EnterModeType.DEFAULT;
     }
 
     enterMode = value;


### PR DESCRIPTION
Follows #12125 and fixes #12310

This fixes the system ENTER key to prioritize certain actions (e.g. GO / SEARCH) over inserting a newline for multi-line fields.

## User Testing
**Setup** - Install the PR build of Keyman for Android on a device/emulator and set Keyman as the default system keyboard

* **TEST_SEARCH** - Verifies ENTER key submits search instead of inserting newline
1. Launch the Chrome browser
2. On the top search bar, select Keyman as the keyboard
3. Start typing
4. Hit the <kbd>ENTER</kbd> key
5. Verify Chrome performs the search
6. On Chrome, select the next line to start another search (below the top bar with the URL)
7. Start typing
8. Hit the <kbd>ENTER</kbd> key
9. Verify Chrome performs the search

* **TEST_MESSAGING** - Verifies ENTER key submits a newline instead of  sending text iin messaging apps
1. Launch a messaging app (like Slack, Facebook Messenger, etc)
2. Select a contact to message
3. With Keyman, start typing in the text field
4. Hit the <kbd>ENTER</kbd>
5. Verify a newline is entered 
6. IN the messaging app, click the arrow button above the keyboard to send the text