### PR TITLE
fix(android): Separate `publishSentry` Gradle task to publish symbols to Sentry

### DIFF
--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -19,7 +19,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 CONFIG="release"
 BUILD_FLAGS="build -x lint -x test"                     # Gradle build w/o test
 TEST_FLAGS="-x assembleRelease lintRelease testRelease" # Gradle test w/o build
-PUBLISH_FLAGS="publishReleaseApk"                       # Gradle publish
+PUBLISH_FLAGS="publishSentry publishReleaseApk"         # Gradle publish task
 DAEMON_FLAG=
 
 builder_describe "Builds Keyman for Android app." \
@@ -28,7 +28,7 @@ builder_describe "Builds Keyman for Android app." \
   "configure" \
   "build" \
   "test             Runs lint and unit tests." \
-  "publish          Publishes the APK to the Play Store." \
+  "publish          Publishes symbols to Sentry and the APK to the Play Store." \
   "--ci             Don't start the Gradle daemon. For CI" \
   "--upload-sentry  Upload to sentry"
 
@@ -118,7 +118,7 @@ if builder_start_action publish; then
   # Copy Release Notes
   generateReleaseNotes
 
-  # Publish Keyman for Android to Play Store
+  # Publish symbols and Keyman for Android to Play Store
   echo "PUBLISH_FLAGS $PUBLISH_FLAGS"
   cd "$KEYMAN_ROOT/android/KMAPro/"
   ./gradlew $DAEMON_FLAG $PUBLISH_FLAGS

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -105,12 +105,17 @@ android {
 }
 
 // how to configure the sentry android gradle plugin
-sentry {
-    // Disables or enables the automatic configuration of Native symbols
-    uploadNativeSymbols = true
+task publishSentry {
+    doLast {
+        println 'Publishing Keyman symbols to Sentry'
+        sentry {
+            // Disables or enables the automatic configuration of Native symbols
+            uploadNativeSymbols = true
 
-    // Does or doesn't include the source code of native code for Sentry
-    includeNativeSources = true
+            // Does or doesn't include the source code of native code for Sentry
+            includeNativeSources = true
+        }
+    }
 }
 
 String env_keys_json_file = System.getenv("keys_json_file")

--- a/android/build.sh
+++ b/android/build.sh
@@ -18,7 +18,7 @@ builder_describe \
   configure \
   build \
   test \
-  "publish                                  Publishes the APKs to the Play Store." \
+  "publish                                  Publishes symbols to Sentry and the APKs to the Play Store." \
   --ci+ \
   --upload-sentry+ \
   ":engine=KMEA                             Keyman Engine for Android" \

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -73,12 +73,17 @@ java {
 }
 
 // how to configure the sentry android gradle plugin
-sentry {
-    // Disables or enables the automatic configuration of Native symbols
-    uploadNativeSymbols = true
+task publishSentry {
+    doLast {
+        println 'Publishing FirstVoices symbols to Sentry'
+        sentry {
+            // Disables or enables the automatic configuration of Native symbols
+            uploadNativeSymbols = true
 
-    // Does or doesn't include the source code of native code for Sentry
-    includeNativeSources = true
+            // Does or doesn't include the source code of native code for Sentry
+            includeNativeSources = true
+        }
+    }
 }
 
 String env_keys_json_file = System.getenv("oem_firstvoices_keys_json_file")

--- a/oem/firstvoices/android/build.sh
+++ b/oem/firstvoices/android/build.sh
@@ -17,7 +17,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 CONFIG="release"
 BUILD_FLAGS="build -x lint -x test"                     # Gradle build w/o test
 TEST_FLAGS="-x assembleRelease lintRelease testRelease" # Gradle test w/o build
-PUBLISH_FLAGS="publishReleaseApk"                       # Gradle publish
+PUBLISH_FLAGS="publishSentry publishReleaseApk"         # Gradle publish task
 DAEMON_FLAG=
 
 builder_describe "Builds FirstVoices for Android app." \
@@ -26,7 +26,7 @@ builder_describe "Builds FirstVoices for Android app." \
   "configure" \
   "build" \
   "test             Runs lint and tests." \
-  "publish          Publishes the APK to the Play Store." \
+  "publish          Publishes symbols to Sentry and the APK to the Play Store." \
   "--ci             Don't start the Gradle daemon. For CI"
 
 # parse before describe_outputs to check debug flags
@@ -89,8 +89,8 @@ if builder_start_action test; then
 fi
 
 if builder_start_action publish; then
+  # Publish symbols and FirstVoices to Play Store
   echo "PUBLISH_FLAGS $PUBLISH_FLAGS"
-
   cd "$KEYMAN_ROOT/oem/firstvoices/android/"
   ./gradlew $DAEMON_FLAG $PUBLISH_FLAGS  
 


### PR DESCRIPTION
Fixes #12325 and follows #12351

This creates a separate Gradle task `publishSentry` for uploading symbols to Sentry.
This way, developers can compile release builds locally without configure SENTRY environment variables
`./build.sh build:engine build:app build:fv`

Will also need to change Android CI  release configure steps to call
`./build.sh publish:app publish:fv`

Once we verify this works, may need to :cherries: pick to stable-17.0 


@keymanapp-test-bot skip


