### PR TITLE
fix(android): Skip language counts for lexical-model packages

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -112,7 +112,8 @@ public class PackageActivity extends AppCompatActivity implements
 
     // Number of languages associated with the first keyboard in a keyboard package.
     // lexical-model packages will be 0
-    final int languageCount = kmpProcessor.getLanguageCount(pkgInfo, PackageProcessor.PP_KEYBOARDS_KEY, 0);
+    final int languageCount = (keyboardCount > 0) ?
+      kmpProcessor.getLanguageCount(pkgInfo, PackageProcessor.PP_KEYBOARDS_KEY, 0) : 0;
 
     // Sanity check for keyboard packages
     if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {


### PR DESCRIPTION
Fixes #11368
Fixes [KEYMAN-ANDROID-4G](https://keyman.sentry.io/issues/2705960665)

Turns out when the Android app is install a lexical-model package, we don't need to determine the `languageCount` (number of languages associated with the first keyboard package). That value is only used in the language-picker during keyboard package installation.

@keymanapp-test-bot skip
