### PR TITLE
fix(mac): avoid crash on startup with macOS 10.15 (Catalina) 🍒 🏠 

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyConsent.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyConsent.m
@@ -1,4 +1,4 @@
-/**
+/*
  * Keyman is copyright (C) SIL International. MIT License.
  * 
  * PrivacyConsent.m
@@ -7,8 +7,8 @@
  * Created by Shawn Schantz on 2022-09-22.
  * 
  * Used to determine if the user has provided consent to the services it needs
- * and, if not, to request that consent. For versions of macOS prior to 10.15,
- * Keyman requires Accessibility access. For 10.15 and later, Keyman requires
+ * and, if not, to request that consent. For versions of macOS prior to 11.0,
+ * Keyman requires Accessibility access. For 11.0 and later, Keyman requires
  * PostEvent access. Both are presented to the user as a need for Accessibility
  * when prompted by the system and are listed under Accessibility in the Privacy
  * tab in System Preferences, Security & Privacy. Both Accessibility and
@@ -16,7 +16,11 @@
  * that access is not explicitly needed as long as one of the others is provided
  * first.
  *
- * Access this functionality through the shared instance. Call
+ * Note that Apple's documentation states that the PostEvent access APIs are
+ * available with macOS 10.15 (Catalina) but testing showed that it was only
+ * available with macOS 11.0 (Big Sur). This is documented with issue #12295.
+ *
+ * To access this functionality, used the shared instance. Call
  * requestPrivacyAccess which will check whether access has been granted. If
  * not, then a dialog will be presented to the user to inform them that
  * Accessibility is required. Dismissing this dialog will trigger the API call
@@ -24,7 +28,7 @@
  * only happen once. If the user was prompted earlier and did not grant access,
  * they can still go to System Preferences and enable it there. So it is useful
  * to prompt with a dialog from Keyman at startup. Without Accessibility, the
- * shift layer and the OSK do not work -- so Keyman is basically useless.
+ * shift layer and the OSK do not work.
  */
 
 #import "PrivacyConsent.h"
@@ -42,7 +46,7 @@
 }
 
 /**
- * For macOS earlier than 10.15: check for Accessibility access.
+ * For macOS earlier than 11.0: check for Accessibility access.
  */
 - (BOOL)checkAccessibility
 {
@@ -65,7 +69,7 @@
   BOOL hasAccessibility = NO;
   
   // check if we already have accessibility
-  if (@available(macOS 10.15, *)) {
+  if (@available(macOS 11.0, *)) {
     hasAccessibility = [self checkPostEventAccess];
   } else {
     hasAccessibility = [self checkAccessibility];
@@ -84,7 +88,7 @@
 }
 
 /**
- * For macOS earlier than 10.15: request Accessibility access.
+ * For macOS earlier than 11.0: request Accessibility access.
  */
 - (void)requestAccessibility
 {
@@ -111,19 +115,18 @@
  * Initialize privacy alert appropriately as determined by macOS version.
  */
 - (void)configureDialogForOsVersion {
-
-  if (@available(macOS 10.15, *)) {
-    [self configureDialogForCatalinaAndLater];
+  if (@available(macOS 11.0, *)) {
+    [self configureDialogForBigSurAndLater];
   } else {
-    [self configureDialogForPreCatalina];
+    [self configureDialogForPreBigSur];
   }
 }
 
 /**
- * Initialize privacy dialog for macOS versions prior to Catalina (10.15).
+ * Initialize privacy dialog for macOS versions prior to Big Sur (11.0).
  * In this case, request Accessibility access, not PostEvent.
  */
-- (void)configureDialogForPreCatalina {
+- (void)configureDialogForPreBigSur {
   void (^consentPrompt)(void) = ^(void) {
     [self requestAccessibility];
     
@@ -135,10 +138,10 @@
 }
 
 /**
- * Initialize privacy dialog for macOS versions of Catalina (10.15) or later.
+ * Initialize privacy dialog for macOS versions of Big Sur (11.0) or later.
  * In this case, request PostEvent access, not Accessibility.
  */
-- (void)configureDialogForCatalinaAndLater {
+- (void)configureDialogForBigSurAndLater {
   void (^consentPrompt)(void) = ^(void) {
     [self requestPostEventAccess];
     
@@ -159,7 +162,7 @@
 
 /**
  * Check whether the user has allowed ListenEvent access.
- * Only available with macOS Catalina (10.15) or later.
+ * Only available with macOS Big Sur (11.0) or later.
  *
  * If user has granted Accessibility or PostEvent access, then
  * ListenEvent access is also granted.
@@ -169,18 +172,18 @@
   BOOL hasAccess = NO;
   
   // below checks for ListenEvent access
-  if (@available(macOS 10.15, *)) {
+  if (@available(macOS 11.0, *)) {
     hasAccess = CGPreflightListenEventAccess();
     NSLog(@"CGPreflightListenEventAccess() returned %@", hasAccess ? @"YES" : @"NO");
   } else {
-    NSLog(@"CGPreflightListenEventAccess not available before macOS version 10.15");
+    NSLog(@"CGPreflightListenEventAccess not available before macOS version 11.0");
   }
   return hasAccess;
 }
 
 /**
  * Check whether the user has allowed PostEvent access.
- * Only available with macOS Catalina (10.15) or later.
+ * Only available with macOS Big Sur (11.0) or later.
  *
  * If user has granted Accessibility, then PostEvent access is also granted.
  */
@@ -189,46 +192,46 @@
   BOOL hasAccess = NO;
   
   // below checks for PostEvent access
-  if (@available(macOS 10.15, *)) {
+  if (@available(macOS 11.0, *)) {
     hasAccess = CGPreflightPostEventAccess();
     
     NSLog(@"CGPreflightPostEventAccess() returned %@", hasAccess ? @"YES" : @"NO");
   } else {
-    NSLog(@"CGPreflightPostEventAccess not available before macOS version 10.15");
+    NSLog(@"CGPreflightPostEventAccess not available before macOS version 11.0");
   }
   return hasAccess;
 }
 
 /**
  * Request ListenEvent access.
- * Only available with macOS Catalina (10.15) or later.
+ * Only available with macOS Big Sur (11.0) or later.
  */
 - (BOOL)requestListenEventAccess
 {
   BOOL granted = NO;
   
-  if (@available(macOS 10.15, *)) {
+  if (@available(macOS 11.0, *)) {
     granted = CGRequestListenEventAccess();
     NSLog(@"CGRequestListenEventAccess() returned %@", granted ? @"YES" : @"NO");
   } else {
-    NSLog(@"CGRequestListenEventAccess not available before macOS version 10.15");
+    NSLog(@"CGRequestListenEventAccess not available before macOS version 11.0");
   }
   return granted;
 }
 
 /**
  * Request PostEvent access.
- * Only available with macOS Catalina (10.15) or later.
+ * Only available with macOS Big Sur (11.0) or later.
  */
 - (BOOL)requestPostEventAccess
 {
   BOOL granted = NO;
   
-  if (@available(macOS 10.15, *)) {
+  if (@available(macOS 11.0, *)) {
     granted = CGRequestPostEventAccess();
     NSLog(@"CGRequestPostEventAccess() returned %@", granted ? @"YES" : @"NO");
   } else {
-    NSLog(@"CGRequestPostEventAccess not available before macOS version 10.15");
+    NSLog(@"CGRequestPostEventAccess not available before macOS version 11.0");
   }
   return granted;
 }


### PR DESCRIPTION
Cherry-pick of #12354 

To read the state and gain access to the Accessibility permission under the macOS Privacy & Security settings, Keyman calls the API `CGPreflightPostEventAccess`.  This API is [documented as being available with with macOS 10.15](https://developer.apple.com/documentation/coregraphics/3656520-cgpreflightposteventaccess?language=objc) (Catalina), but, based on experience, this does not appear to be the case. Limit use of API `CGPreflightPostEventAccess` to macOS 11.0 (Big Sur) and later, and, instead, use an older API, `AXIsProcessTrusted`, with OS versions before 11.0.

Fixes: #12295

# User Testing

## TEST_RUNS_SUCCESSFULLY_ON_MACOS_CATALINA

1. Install this version of Keyman on a system running macOS Catalina
1. Confirm that keyboards can be installed and that they appear in the Keyman menu
1. Type with the installed Keyman keyboards and confirm that keystrokes are processed as expected