### PR TITLE
fix(android): skip language counts for lexical-model packages 🏠

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -112,7 +112,8 @@ public class PackageActivity extends AppCompatActivity implements
 
     // Number of languages associated with the first keyboard in a keyboard package.
     // lexical-model packages will be 0
-    final int languageCount = kmpProcessor.getLanguageCount(pkgInfo, PackageProcessor.PP_KEYBOARDS_KEY, 0);
+    final int languageCount = (keyboardCount > 0) ?
+      kmpProcessor.getLanguageCount(pkgInfo, PackageProcessor.PP_KEYBOARDS_KEY, 0) : 0;
 
     // Sanity check for keyboard packages
     if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {


### PR DESCRIPTION
:cherries: pick of #12361 to stable-17.0

skips computing languageCount for lexical-model packages

@keymanapp-test-bot skip
