### PR TITLE
docs(web): fix link to documentation page

### DIFF
--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -660,7 +660,7 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
    *  @param  {(string)=}  argLayerId    name or index of layer to show, defaulting to 'default'
    *  @return {Object}                          DIV object with filled keyboard layer content
    *
-   * See https://help.keyman.com/developer/engine/web/current-version/reference/osk/BuildVisualKeyboard
+   * See https://help.keyman.com/developer/engine/web/current-version/reference/core/BuildVisualKeyboard
    */
   public BuildVisualKeyboard(
     PInternalName: string,


### PR DESCRIPTION
The help page for `BuildVisualKeyboard` is under `core`, not `osk`.

@keymanapp-test-bot skip