### PR TITLE
fix(developer): fix building with Ubuntu 24.04

### DIFF
--- a/developer/src/kmcmplib/include/kmcmplibapi.h
+++ b/developer/src/kmcmplib/include/kmcmplibapi.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include <fstream>
 #include <vector>
 


### PR DESCRIPTION
For whatever reason I suddenly got compile errors on Ubuntu 24.04 when building Developer. Including `cstdint` solves this.

See also #11926.

@keymanapp-test-bot skip