### PR TITLE
feat(android): Add device Settings link to KeymanSettingsActivity

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/xml/method.xml
+++ b/android/KMAPro/kMAPro/src/main/res/xml/method.xml
@@ -22,4 +22,5 @@
 
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
     android:icon="@drawable/ic_action_language"
+    android:settingsActivity="com.tavultesoft.kmapro.KeymanSettingsActivity"
     android:supportsSwitchingToNextInputMethod="true" />


### PR DESCRIPTION
While configuring test steps for #12381, I noticed the Android "General Management" settings had a link to keyboard settings for the current default keyboard.

This adds a link from the Android settings to the Keyman settings activity

## User Testing
**Setup** - Install the PR build of Keyman for Android on a physical device. Enable Keyman as a system keyboard, but don't set to default yet.

* **TEST_ANDROID_KEYBOARD_SETTINGS**- Verifies path from Android settings to Keyman settings
1. From Android settings, select a non-Keyman keyboard selected as the default system keyboard. 
    * On modern devices: Android settings --> General management --> Keyboard list and default
 2. Return to the"General management" settings and observe a link to that keyboard's settings
 
![gboard settings](https://github.com/user-attachments/assets/3f651021-3f97-437e-b311-2bdd4faecda4)

3. Select the "keyboard list and default" and set Keyman as the default system keyboard
4. Return to the "General management" settings and observe a link to Keyman settings

![keyman alpha settings](https://github.com/user-attachments/assets/706f1e95-942c-4d30-9d07-7d803bf48164)

5. Select "Keyman (alpha) settings"
6. Verify the Keyman settings screen is launched
7. From Keyman settings, install another Keyman keyboard
8. Verify keyboard is installed.
 
