### PR TITLE
fix(android): Add gating to setLongpressDelay()

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustLongpressDelayActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustLongpressDelayActivity.java
@@ -31,8 +31,6 @@ public class AdjustLongpressDelayActivity extends BaseActivity {
   // Keeps track of the adjusted longpress delay time for saving.
   // Internally use milliseconds, but GUI displays seconds
   private static int currentDelayTimeMS = KMManager.KMDefault_LongpressDelay;  // ms
-  private static int minLongpressTime = 300;   // ms
-  private static int maxLongpressTime = 1500;  // ms
   private static int delayTimeIncrement = 200; // ms
 
   /**
@@ -112,7 +110,7 @@ public class AdjustLongpressDelayActivity extends BaseActivity {
     findViewById(R.id.delayTimeDownButton).setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
-        if (currentDelayTimeMS > minLongpressTime) {
+        if (currentDelayTimeMS > KMManager.KMMinimum_LongpressDelay) {
           currentDelayTimeMS -= delayTimeIncrement;
           seekBar.setProgress(delayTimeToProgress());
         }
@@ -122,7 +120,7 @@ public class AdjustLongpressDelayActivity extends BaseActivity {
     findViewById(R.id.delayTimeUpButton).setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
-        if (currentDelayTimeMS < maxLongpressTime) {
+        if (currentDelayTimeMS < KMManager.KMMaximum_LongpressDelay) {
           currentDelayTimeMS += delayTimeIncrement;
           seekBar.setProgress(delayTimeToProgress());
         }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -310,8 +310,11 @@ public final class KMManager {
   public static final String KMDefault_DictionaryVersion = "0.1.4";
   public static final String KMDefault_DictionaryKMP = KMDefault_DictionaryPackageID + FileUtils.MODELPACKAGE;
 
-  // Default KeymanWeb longpress delay in milliseconds
+  // Default KeymanWeb longpress delay constants in milliseconds
   public static final int KMDefault_LongpressDelay = 500;
+  public static final int KMMinimum_LongpressDelay = 300;
+  public static final int KMMaximum_LongpressDelay = 1500;
+
 
   // Keyman files
   protected static final String KMFilename_KeyboardHtml = "keyboard.html";
@@ -2097,14 +2100,22 @@ public final class KMManager {
 
   /**
    * Set the longpress delay (in milliseconds) as a stored preference.
+   * Valid range is 300 ms to 1500 ms. Returns true if the preference is successfully stored.
    * @param longpressDelay - int longpress delay in milliseconds
+   * @return boolean
    */
-  public static void setLongpressDelay(int longpressDelay) {
+  public static boolean setLongpressDelay(int longpressDelay) {
+    if (longpressDelay < KMMinimum_LongpressDelay || longpressDelay > KMMaximum_LongpressDelay) {
+      return false;
+    }
+
     SharedPreferences prefs = appContext.getSharedPreferences(
       appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = prefs.edit();
     editor.putInt(KMKey_LongpressDelay, longpressDelay);
     editor.commit();
+
+    return true;
   }
 
   /**


### PR DESCRIPTION
Follows #12170 and #12185 for adjusting the longpress delay.

This adds minimum and maximum longpress delay limits to the API per
https://github.com/keymanapp/help.keyman.com/pull/1500#discussion_r1730879065

@keymanapp-test-bot skip
