### PR TITLE
chore(resources,core): CLDR v46 data 🙀 

### DIFF
--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -30,8 +30,8 @@ builder_parse "$@"
 function compile_schemas() {
   # We need the schema files at runtime and bundled, so always copy it for all actions except `clean`
   local schemas=(
-    "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/45/ldml-keyboard3.schema.json"
-    "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/45/ldml-keyboardtest3.schema.json"
+    "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/46/ldml-keyboard3.schema.json"
+    "$KEYMAN_ROOT/resources/standards-data/ldml-keyboards/46/ldml-keyboardtest3.schema.json"
     "$KEYMAN_ROOT/common/schemas/kvks/kvks.schema.json"
     "$KEYMAN_ROOT/common/schemas/kpj/kpj.schema.json"
     "$KEYMAN_ROOT/common/schemas/kpj-9.0/kpj-9.0.schema.json"

--- a/core/include/ldml/keyman_core_ldml.h
+++ b/core/include/ldml/keyman_core_ldml.h
@@ -16,11 +16,11 @@
 #pragma once
 
 #define LDML_BKSP_FLAGS_ERROR 0x1
-#define LDML_CLDR_IMPLIED_FORMS_IMPORT "45/scanCodes-implied.xml"
-#define LDML_CLDR_IMPLIED_KEYS_IMPORT "45/keys-Latn-implied.xml"
+#define LDML_CLDR_IMPLIED_FORMS_IMPORT "46/scanCodes-implied.xml"
+#define LDML_CLDR_IMPLIED_KEYS_IMPORT "46/keys-Latn-implied.xml"
 #define LDML_CLDR_IMPORT_BASE "cldr"
 #define LDML_CLDR_TEST_VERSION_LATEST "techpreview"
-#define LDML_CLDR_VERSION_LATEST "45"
+#define LDML_CLDR_VERSION_LATEST "46"
 #define LDML_ELEM_FLAGS_ORDER_BITSHIFT 0x10
 #define LDML_ELEM_FLAGS_ORDER_MASK 0xFF0000
 #define LDML_ELEM_FLAGS_PREBASE 0x8

--- a/core/include/ldml/keyman_core_ldml.ts
+++ b/core/include/ldml/keyman_core_ldml.ts
@@ -57,9 +57,9 @@ class Constants {
    */
   readonly version = '1.0';
   /**
-   * The current CLDR version
+   * The latest CLDR version
    */
-  readonly cldr_version_latest = '45';
+  readonly cldr_version_latest = '46';
   /**
    * The version for testdata files
    */

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -7,8 +7,16 @@
 
 # keyboards in resources/standards-data/ldml-keyboards/45/3.0/
 # tests     in resources/standards-data/ldml-keyboards/45/test/
-tests_from_cldr = [
+tests_from_cldr_45 = [
   'ja-Latn',
+  # 'pt-t-k0-abnt2',
+  # 'fr-t-k0-test',
+  # 'pcm',
+  # 'bn',
+]
+
+tests_from_cldr_46 = [
+  # 'ja-Latn',
   'pt-t-k0-abnt2',
   'fr-t-k0-test',
   'pcm',
@@ -52,14 +60,18 @@ tests =  tests_without_testdata
 tests += tests_with_testdata
 tests_needing_copy = tests # not including cldr
 
-tests += tests_from_cldr
+tests += tests_from_cldr_46
+tests += tests_from_cldr_45
 
 # Setup kmc
 
 kmc_root = meson.global_source_root() / '../developer/src/kmc'
-ldml_root = meson.global_source_root() / '../resources/standards-data/ldml-keyboards/45'
-ldml_data = join_paths(ldml_root, '3.0')
-ldml_testdata = join_paths(ldml_root, 'test')
+ldml_root_45 = meson.global_source_root() / '../resources/standards-data/ldml-keyboards/45'
+ldml_data_45 = join_paths(ldml_root_45, '3.0')
+ldml_testdata_45 = join_paths(ldml_root_45, 'test')
+ldml_root_46 = meson.global_source_root() / '../resources/standards-data/ldml-keyboards/46'
+ldml_data_46 = join_paths(ldml_root_46, '3.0')
+ldml_testdata_46 = join_paths(ldml_root_46, 'test')
 kmc_cmd = [node, '--enable-source-maps', kmc_root]
 
 # Build all keyboards in output folder
@@ -87,20 +99,38 @@ foreach kbd : tests_with_testdata
 endforeach
 
 
-foreach kbd : tests_from_cldr
+foreach kbd : tests_from_cldr_45
   configure_file(
     copy: true,
-    input: ldml_data / kbd + '.xml',
+    input: ldml_data_45 / kbd + '.xml',
     output: kbd + '.xml'
   )
   configure_file(
     command: kmc_cmd + ['build', '@INPUT@', '--out-file', '@OUTPUT@'],
-    input: join_paths(ldml_data, kbd + '.xml'),
+    input: join_paths(ldml_data_45, kbd + '.xml'),
     output: kbd + '.kmx',
   )
   configure_file(
     command: kmc_cmd + ['build', 'ldml-test-data', '@INPUT@', '--out-file', '@OUTPUT@'],
-    input: join_paths(ldml_testdata, kbd + '-test.xml'),
+    input: join_paths(ldml_testdata_45, kbd + '-test.xml'),
+    output: kbd + '-test.json',
+  )
+endforeach
+
+foreach kbd : tests_from_cldr_46
+  configure_file(
+    copy: true,
+    input: ldml_data_46 / kbd + '.xml',
+    output: kbd + '.xml'
+  )
+  configure_file(
+    command: kmc_cmd + ['build', '@INPUT@', '--out-file', '@OUTPUT@'],
+    input: join_paths(ldml_data_46, kbd + '.xml'),
+    output: kbd + '.kmx',
+  )
+  configure_file(
+    command: kmc_cmd + ['build', 'ldml-test-data', '@INPUT@', '--out-file', '@OUTPUT@'],
+    input: join_paths(ldml_testdata_46, kbd + '-test.xml'),
     output: kbd + '-test.json',
   )
 endforeach

--- a/core/tests/unit/ldml/meson.build
+++ b/core/tests/unit/ldml/meson.build
@@ -162,6 +162,19 @@ foreach kbd : tests
   test(kbd, ldml, args: [kbd_src, kbd_obj], suite: 'ldml-keyboards')
 endforeach
 
+foreach kbd : tests_from_cldr_45
+  kbd_src = test_path / kbd + '.xml'
+  kbd_obj = test_path / kbd + '.kmx'
+  test(kbd, ldml, args: [kbd_src, kbd_obj], suite: 'ldml-keyboards')
+endforeach
+
+foreach kbd : tests_from_cldr_46
+  kbd_src = test_path / kbd + '.xml'
+  kbd_obj = test_path / kbd + '.kmx'
+  test(kbd, ldml, args: [kbd_src, kbd_obj], suite: 'ldml-keyboards')
+endforeach
+
+
 # Run tests on all invalid keyboards (`invalid_tests` defined in invalid-keyboards/meson.build)
 
 foreach kbd : invalid_tests

--- a/developer/src/common/web/utils/test/kmx/test-ldml-keyboard-xml-reader.ts
+++ b/developer/src/common/web/utils/test/kmx/test-ldml-keyboard-xml-reader.ts
@@ -32,7 +32,7 @@ describe('ldml keyboard xml reader tests', function () {
         instancePath: '/keyboard3/conformsTo',
         keyword: 'enum',
         message: `must be equal to one of the allowed values`,
-        params: 'allowedValues="45"',
+        params: 'allowedValues="45,46"',
       })],
     },
     {

--- a/resources/standards-data/ldml-keyboards/46/3.0/bn.xml
+++ b/resources/standards-data/ldml-keyboards/46/3.0/bn.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="bn" conformsTo="46">
+    <!--
+        History:
+          Based on
+    https://github.com/keymanapp/ldml-keyboards-dev/blob/master/keyboards/sil-bengali/bn-t-k0-cldr-phonetic.ldml
+     -->
+    <locales>
+        <locale id="as" />
+        <locale id="syl" />
+    </locales>
+    <version number="1.3.0" />
+    <info name="SIL Bengali-Assamese Phonetic" indicator="bn" layout="QWERTY" />
+
+    <displays>
+        <display keyId="au-lengthener" display="ৗ" />
+        <display keyId="vis-hasant" display="্" /> <!-- TODO: distinguish from regular hasant? -->
+        <display keyId="more" display="…" />
+    </displays>
+
+    <keys>
+        <import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+        <import base="cldr" path="46/keys-Zyyy-currency.xml" />
+
+        <key id="1" output="১" />
+        <key id="2" output="২" />
+        <key id="3" output="৩" />
+        <key id="4" output="৪" />
+        <key id="5" output="৫" />
+        <key id="6" output="৬" />
+        <key id="7" output="৭" />
+        <key id="8" output="৮" />
+        <key id="9" output="৯" />
+        <key id="0" output="০" />
+
+        <!-- special keys and marks -->
+        <key id="au-lengthener" output="\m{A}" />
+        <key id="candrabindu" output="\u{0981}" /> <!-- n̐  -->
+        <key id="hasant" output="\u{09CD}" />
+        <key id="more" output="\m{q}" /> <!-- 'additional characters' -->
+        <key id="nukta" output="\u{09BC}" />
+        <key id="vis-hasant" output="\m{X}" />
+
+        <!-- key names based on https://www.loc.gov/catdir/cpso/romanization/bengali.pdf + Assamese for /wa/ -->
+        <key id="ā" output="\u{09BE}" />
+        <key id="ai" output="\u{09C8}" />
+        <key id="au" output="\u{09CC}" />
+        <key id="ba" output="ব" />
+        <key id="bha" output="ভ" />
+        <key id="ca" output="চ" />
+        <key id="cha" output="ছ" />
+        <key id="ḍa" output="ড" />
+        <key id="da" output="দ" />
+        <key id="dahri" output="।" />
+        <key id="ḍha" output="ঢ" />
+        <key id="dha" output="ধ" />
+        <key id="e" output="\u{09C7}" />
+        <key id="ga" output="গ" />
+        <key id="gha" output="ঘ" />
+        <key id="ha" output="হ" />
+        <key id="i" output="\u{09BF}" />
+        <key id="ī" output="\u{09C0}" />
+        <key id="ja" output="জ" />
+        <key id="jha" output="ঝ" />
+        <key id="ka" output="ক" />
+        <key id="kha" output="খ" />
+        <key id="la" output="ল" />
+        <key id="ṃ" output="\u{0982}" />
+        <key id="ma" output="ম" />
+        <key id="ṅa" output="ঙ" />
+        <key id="ña" output="ঞ" />
+        <key id="ṇa" output="ণ" />
+        <key id="na" output="ন" />
+        <key id="o" output="\u{09CB}" />
+        <key id="pa" output="প" />
+        <key id="pha" output="ফ" />
+        <key id="ṛ" output="\u{09C3}" />
+        <key id="ra" output="র" />
+        <key id="śa" output="শ" />
+        <key id="sa" output="স" />
+        <key id="sha" output="ষ" />
+        <key id="ṭa" output="ট" />
+        <key id="ta" output="ত" />
+        <key id="ṭha" output="ঠ" />
+        <key id="tha" output="থ" />
+        <key id="u" output="\u{09C1}" />
+        <key id="ū" output="\u{09C2}" />
+        <key id="wa" output="ৱ" /> <!-- Assamese transliteration -->
+        <key id="ya" output="য" />
+        <key id="ẏa" output="য়" /> <!-- Missing in Keyman version of file-->
+    </keys>
+    <layers formId="us">
+        <layer modifiers="none">
+            <row keys="candrabindu 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+            <row keys="more wa e ra ta ya u i o pa open-square close-square backslash" />
+            <row keys="ā sa da ṭa ga ha ja ka la semi-colon apos" />
+            <row keys="śa hasant ca ḍa ba na ma comma dahri slash" />
+            <row keys="space" />
+        </layer>
+        <layer modifiers="shift">
+            <row
+                keys="ṃ bang at hash dollar percent caret amp asterisk open-paren close-paren underscore plus" />
+            <row keys="gap ña ai ṛ tha ẏa ū ī au pha open-curly close-curly pipe" />
+            <row keys="au-lengthener sha dha ṭha gha gap jha kha gap colon double-quote" />
+            <row keys="gap vis-hasant cha ḍha bha ṇa ṅa open-angle nukta question" />
+            <row keys="space" />
+        </layer>
+    </layers>
+
+    <transforms type="simple">
+        <transformGroup>
+            <transform from="\u{09C7}\m{A}" to="\u{09CC}" /> <!-- E + au-lengthener = AU -->
+            <!-- <transform from="\u{09C7}\u{09BE}" to="\u09CB" /> --> <!-- E + A = O This is handled by normalization. -->
+
+            <!-- these suport the 'q' key -->
+            <transform from="\m{q}:" to="\u{0983}" />
+            <transform from="\m{q}L" to="ৡ" />
+            <transform from="\m{q}।" to="॥" />
+            <transform from="\m{q}ড" to="ড়" />
+            <transform from="\m{q}ঢ" to="ঢ়" />
+            <transform from="\m{q}ত" to="ৎ" />
+            <transform from="\m{q}য" to="য়" />
+            <transform from="\m{q}র" to="ৰ" />
+            <transform from="\m{q}ল" to="ঌ" />
+            <transform from="\m{q}\u{09BE}" to="অ" />
+            <transform from="\m{q}\u{09BF}" to="ই" />
+            <transform from="\m{q}\u{09C0}" to="ঈ" />
+            <transform from="\m{q}\u{09C1}" to="উ" />
+            <transform from="\m{q}\u{09C2}" to="ঊ" />
+            <transform from="\m{q}\u{09C3}" to="ৠ" />
+            <transform from="\m{q}\u{09C7}" to="এ" />
+            <transform from="\m{q}\u{09C8}" to="ঐ" />
+            <transform from="\m{q}\u{09CB}" to="ও" />
+            <transform from="\m{q}\u{09CC}" to="ঔ" />
+            <transform from="\m{q}\m{A}" to="আ" />
+            <transform from="\m{q}\m{X}" to="\u{09CD}\u{200C}" /> <!-- virama + zwnj-->
+        </transformGroup>
+        <transformGroup>
+            <!-- Nukta is tertiary, that is, it follows a tertiaryBase sequence -->
+            <reorder from="\u{09BC}" tertiary="3"/>
+            <!--
+                virama (hasant) followed by any other spacing chars has order 10, because this sequence goes after the consonant to which the virama pertains.
+                For example:
+
+                U+099A U+09CD U+099B
+                 CA    virama   CHA
+                  0      10      10
+             -->
+            <reorder from="\u{09CD}[\u{0980}\u{0985}-\u{098C}\u{098F}\u{0990}\u{0993}-\u{09A8}\u{09AA}-\u{09B0}\u{09B2}\u{09B6}-\u{09B9}\u{09BD}\u{09DC}\u{09DD}\u{09DF}-\u{09E1}\u{09E6}-\u{09F1}\u{09FC}]" order="10" tertiaryBase="true"/>
+            <!-- 10: virama  + zwj/zwnj + spacing mark is also 10-->
+            <reorder from="\u{09CD}[\u{200C}\u{200D}][\u{0980}\u{0985}-\u{098C}\u{098F}\u{0990}\u{0993}-\u{09A8}\u{09AA}-\u{09B0}\u{09B2}\u{09B6}-\u{09B9}\u{09BD}\u{09DC}\u{09DD}\u{09DF}-\u{09E1}\u{09E6}-\u{09F1}\u{09FC}]" order="10" tertiaryBase="true"/>
+            <!-- 120: A virama not followed by a spacing mark goes further to the right (past the sandhi mark, below) -->
+            <reorder from="\u{09CD}" order="120" tertiaryBase="true"/>
+            <!-- The next three rules make sure the DVs are in the correct order-->
+            <!-- 60: left side dependent vowels -->
+            <reorder from="[\u{09BF}\u{09C7}\u{09C8}]" order="60"/>
+            <!-- 70: lower dependent vowels -->
+            <reorder from="[\u{09C1}-\u{09C4}\u{09E2}\u{09E3}]" order="70"/>
+            <!-- 75: right side dependent vowels. Note U+09D7 AU LENGTH MARK is included due to NFD -->
+            <reorder from="[\u{09BE}\u{09C0}\u{09CB}\u{09CC}\u{09D7}]" order="75"/>
+            <!-- 85: candrabindu -->
+            <reorder from="\u{0981}" order="85"/>
+            <!-- 95: anusvara and visarga -->
+            <reorder from="[\u{0982}\u{0983}]" order="95"/>
+            <!-- 117: sandhi mark -->
+            <reorder from="\u{09FE}" order="117"/>
+        </transformGroup>
+    </transforms>
+</keyboard3>

--- a/resources/standards-data/ldml-keyboards/46/3.0/fr-t-k0-test.xml
+++ b/resources/standards-data/ldml-keyboards/46/3.0/fr-t-k0-test.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    See CLDR-12026 for the real new azerty keyboard
+-->
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="fr-t-k0-test" conformsTo="46">
+	<locales>
+		<locale id="br" /> <!-- example of including Breton -->
+	</locales>
+	<!-- 'conformsTo' gives CLDR spec conformance. Distinguishes from prior
+		keyboard formats -->
+	<!-- 'version' element is now optional -->
+	<version number="1.0.0" />
+	<info name="French Test AZERTY" author="Team Keyboard" layout="AZERTY" indicator="FR" />
+
+	<displays>
+		<!-- Note: displays is only used for keycap presentation -->
+		<!-- this example is not required for this keyboard as we use the spacing
+			modifiers -->
+		<display output="\u{0300}" display="${grave}" /> <!-- display combining grave as modifier letter grave ˋ -->
+		<!-- Note: We discussed why the existing displayMap was used for display.
+			rather than adding something closer to the key layout. 1. This way we can
+			tell the renderer what to do. Could be double diacritics, spacing issues,
+			etc. 2. We expect that keys have output. Otherwise the input content is malformed.
+			3. Don't Repeat Yourself : multiple keys (i.e. on different symbol layers)
+			may have the same display. -->
+
+		<!-- Example of a display mapping for a key by id -->
+		<display keyId="symbol" display="@" />
+		<display keyId="numeric" display="123" />
+		<displayOptions baseCharacter="x" />
+	</displays>
+
+	<keys>
+		<import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="46/keys-Zyyy-currency.xml" />
+
+		<!-- switch keys -->
+		<key id="shift" layerId="shift" />
+		<key id="numeric" layerId="numeric" />
+		<key id="symbol" layerId="symbol" />
+		<key id="base" layerId="base" />
+
+		<!--
+			TODO: need discussion
+		<key id="bksp" gap="true" /> -->
+		<key id="extra" gap="true" />
+		<!--
+			TODO: need discussion
+		<key id="enter" to="\u{000A}" />
+		-->
+		<key id="enter" gap="true" />
+
+		<!-- extra keys -->
+		<key id="u-grave" output="ü" />
+		<key id="e-grave" output="é" /> <!-- 2 -->
+		<key id="e-acute" output="è" /> <!-- 7 -->
+		<key id="c-cedilla" output="ç" /> <!-- 9 -->
+		<key id="a-grave" output="à"  />
+		<key id="a-acute" output="á" />
+		<key id="a-caret" output="â" />
+		<key id="a-umlaut" output="ä" />
+		<key id="a-tilde" output="ã" />
+		<key id="a-ring" output="å" />
+		<key id="a-caron" output="ā" />
+
+		<key id="A-grave" output="À" /> <!-- 0 -->
+		<key id="A-acute" output="Á" />
+		<key id="A-caret" output="Â" />
+		<key id="A-umlaut" output="Ä" />
+		<key id="A-tilde" output="Ã" />
+		<key id="A-ring" output="Å" />
+		<key id="A-caron" output="Ā" />
+
+
+		<!-- extra symbols -->
+		<key id="bullet" output="•" />
+		<key id="umlaut" output="¨" />
+		<key id="super-2" output="²" multiTapKeyIds="sub-2 2" /> <!-- taps produce: ² ₂ 2 -->
+		<key id="sub-2" output="₂" />
+
+		<!-- note that a-caret is the default-->
+		<key id="a" flickId="a" output="a"
+			longPressKeyIds="a-grave a-caret a-acute a-umlaut a-tilde a-ring a-caron"
+			longPressDefaultKeyId="a-caret" />
+		<!-- note that A-caret is the default-->
+		<key id="A" flickId="b" output="A"
+			longPressKeyIds="A-grave A-caret A-acute A-umlaut a-tilde A-ring A-caron"
+			longPressDefaultKeyId="A-caret" />
+	</keys>
+
+	<flicks>
+		<flick id="b">
+			<flickSegment directions="nw" keyId="A-grave" />
+			<flickSegment directions="nw se" keyId="A-acute" />
+			<flickSegment directions="e" keyId="A-caron" />
+			<flickSegment directions="s" keyId="numeric" /> <!-- layer shifting flick-->
+		</flick>
+		<flick id="a">
+			<flickSegment directions="nw" keyId="a-grave" />
+			<flickSegment directions="nw se" keyId="a-acute" />
+			<flickSegment directions="e" keyId="a-caron" />
+		</flick>
+	</flicks>
+
+	<layers formId="iso">
+		<!-- in DTD: required if conformsTo ≥ 41 -->
+		<layer modifiers="none">
+			<row
+				keys="super-2 amp e-grave double-quote apos open-paren hyphen e-acute underscore c-cedilla a-acute close-paren equal" />
+			<row keys="a z e r t y u i o p caret dollar" />
+			<row keys="q s d f g h j k l m u-grave asterisk" />
+			<row keys="open-angle w x c v b n comma semi-colon colon bang" />
+			<row keys="space" />
+		</layer>
+
+		<layer modifiers="shift">
+			<row keys="1 2 3 4 5 6 7 8 9 0 degree plus" />
+			<row keys="A Z E R T Y U I O P umlaut pound" />
+			<row keys="Q S D F G H J K L M percent micro" />
+			<row keys="close-angle W X C V B N question period slash section" />
+			<row keys="space" />
+		</layer>
+	</layers>
+
+	<layers formId="touch" minDeviceWidth="150">
+		<!-- optional attribute for min physical device size -->
+		<layer id="base">
+			<row keys="a z e r t y u i o p" />
+			<row keys="q s d f g h j k l m" />
+			<row keys="shift gap w x c v b n gap" /> <!--TODO:  + bksp -->
+			<row keys="numeric extra space enter" />
+		</layer>
+
+		<layer id="shift">
+			<row keys="A Z E R T Y U I O P" />
+			<row keys="Q S D F G H J K L M" />
+			<row keys="base W X C V B N" />  <!--TODO:  + bksp -->
+			<row keys="numeric extra space enter" />
+		</layer>
+
+		<layer id="numeric">
+			<row keys="1 2 3 4 5 6 7 8 9 0" />
+			<row
+				keys="hyphen slash colon semi-colon open-paren close-paren dollar amp at double-quote" />
+			<row keys="symbol period comma question bang double-quote" /> <!--TODO:  + bksp -->
+			<row keys="base extra space enter" />
+		</layer>
+
+		<layer id="symbol">
+			<row
+				keys="open-square close-square open-curly close-curly hash percent caret asterisk plus equal" />
+			<row keys="underscore backslash pipe tilde open-angle close-angle euro pound yen bullet" />
+			<row keys="numeric period comma question bang double-quote" /> <!--TODO:  + bksp -->
+			<row keys="base extra space enter" />
+		</layer>
+	</layers>
+
+	<variables>
+		<!-- spacing accents as string variables -->
+		<string id="grave"  value="`" />
+		<string id="caret"  value="^" />
+		<string id="umlaut" value="¨" />
+		<string id="tilde"  value="~" />
+
+		<!-- sets representing vowels and accented vowels.  -->
+		<!-- There's an extra space between the lower and upper case for visual separation -->
+		<!-- but, there are only 10 items in the following four sets -->
+		<set id="vowel"       value="a e i o u  A E I O U" />
+		<set id="graveVowel"  value="à è ì ò ù  À È Ì Ò Ù" />
+		<set id="caretVowel"  value="â ê î ô û  Â Ê Î Ô Û" />
+		<set id="umlautVowel" value="ä ë ï ö ü  Ä Ë Ï Ö Ü" />
+
+		<!-- a set containing all spacing accents -->
+		<set id="spacing_accent" value="${grave} ${caret} ${umlaut} ${tilde}" />
+	</variables>
+
+	<transforms type="simple">
+		<transformGroup>
+			<!-- use sets for those that fit neatly into sets -->
+			<transform from="${grave}($[vowel])"  to="$[1:graveVowel]" />
+			<transform from="${caret}($[vowel])"  to="$[1:caretVowel]" />
+			<transform from="${umlaut}($[vowel])" to="$[1:umlautVowel]" />
+
+			<!-- y also takes umlaut (in this sample) -->
+			<transform from="${umlaut}y" to="ÿ" />
+
+			<!-- tilde is on a subset, not all vowels, + n -->
+			<transform from="${tilde}a" to="ã" />
+			<transform from="${tilde}A" to="Ã" />
+			<transform from="${tilde}n" to="ñ" />
+			<transform from="${tilde}N" to="Ñ" />
+			<transform from="${tilde}o" to="õ" />
+			<transform from="${tilde}O" to="Õ" />
+
+			<!-- accent + space = spacing accent -->
+			<transform from="($[spacing_accent]) " to="$1" />
+		</transformGroup>
+		<transformGroup>
+			<!-- this is a reorder group -->
+			<!-- nod-Lana partial example -->
+			<reorder from="\u{1A60}" order="127" />
+			<reorder from="\u{1A6B}" order="42" />
+			<reorder from="[\u{1A75}-\u{1A79}]" order="55" />
+			<!-- ... partial example ... -->
+		</transformGroup>
+	</transforms>
+</keyboard3>

--- a/resources/standards-data/ldml-keyboards/46/3.0/fr.xml
+++ b/resources/standards-data/ldml-keyboards/46/3.0/fr.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" conformsTo="46"
+	locale="fr">
+	<version number="1.0.0" />
+
+	<info author="Team Keyboard" name="Français normalisé (AZERTY)" layout="AZERTY" indicator="FR" />
+
+	<displays>
+		<!-- display for diacritics -->
+		<display output="\u0300" display="${grave}" />
+		<display output="\m{acute}" display="´" />
+		<display output="\m{grave}" display="`" />
+		<display output="\m{umlaut}" display="¨" />
+		<display output="\m{caret}" display="^" />
+		<display output="\m{tilde}" display="~" />
+		<display output="\m{invbreve}" display="\u{20}\u{0311}" />
+
+		<!-- display for 'mode' keys -->
+		<display keyId="mark-currency" display="\u{00A4}" />
+		<display keyId="mark-greek" display="\u{B5}" />
+		<display keyId="mark-euro" display="Eu" />
+	</displays>
+
+	<keys>
+		<import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="46/keys-Zyyy-currency.xml" />
+
+		<!-- deadkeys -->
+		<key id="mark-acute" output="\m{acute}" />
+		<key id="mark-breve" output="\m{breve}" />
+		<key id="mark-caret" output="\m{caret}" />
+		<key id="mark-caron" output="\m{caron}" />
+		<key id="mark-cedilla" output="\m{cedilla}" />
+		<key id="mark-invbreve" output="\m{invbreve}" />
+		<key id="mark-comma" output="\m{comma}" />
+		<key id="mark-currency" output="\m{currency}" />
+		<key id="mark-dotabove" output="\m{dotabove}" />
+		<key id="mark-dotbelow" output="\m{dotbelow}" />
+		<key id="mark-doubleacute" output="\m{doubleacute}" />
+		<key id="mark-doublegrave" output="\m{doublegrave}" />
+		<key id="mark-euro" output="\m{euro}" />
+		<key id="mark-grave" output="\m{grave}" />
+		<key id="mark-macron" output="\m{macron}" />
+		<key id="mark-ogonek" output="\m{ogonek}" />
+		<key id="mark-ring" output="\m{ring}" />
+		<key id="mark-greek" output="\m{greek}" />
+		<key id="mark-solidus" output="\m{solidus}" />
+		<key id="mark-stroke" output="\m{stroke}" />
+		<key id="mark-submacron" output="\m{submacron}" />
+		<key id="mark-tilde" output="\m{tilde}" />
+		<key id="mark-umlaut" output="\m{umlaut}" />
+
+		<!-- spaces -->
+		<key id="nbsp" output="\u{A0}" />
+		<key id="nnbsp" output="\u{202F}" />
+
+		<!-- extra keys -->
+		<key id="e-grave" output="è" />
+		<key id="e-acute" output="é" />
+		<key id="c-cedilla" output="ç" />
+		<key id="a-acute" output="á" />
+		<key id="a-grave" output="à" />
+		<key id="e-caret" output="ê" />
+
+		<!-- extra symbols -->
+		<key id="bullet" output="•" />
+		<key id="umlaut" output="¨" />
+		<key id="sub-2" output="₂" />
+		<key id="super-2" output="²" longPressKeyIds="sub-2" />
+		<key id="en-dash" output="–" />
+		<key id="plus-minus" output="±" />
+		<key id="vulgar-half" output="½" />
+		<key id="vulgar-quarter" output="¼" />
+		<key id="ellipsis" output="…" />
+		<key id="open-apos" output="‘" />
+		<key id="close-apos" output="’" />
+		<key id="open-g" output="«" />
+		<key id="close-g" output="»" />
+
+		<key id="theta" output="θ" /> <!-- "for Romani" -->
+		<key id="Theta" output="ϴ" /> <!-- "for Romani" -->
+		<key id="tm" output="™" />
+		<key id="open-double" output="“" />
+		<key id="close-double" output="”" />
+		<key id="oe" output="œ" />
+		<key id="Oe" output="Œ" />
+		<key id="registered" output="®" />
+		<key id="minus-sign" output="−" />
+		<key id="ss" output="ß" />
+		<key id="infinity" output="∞" />
+		<key id="division" output="÷" />
+		<key id="less-equal" output="⩽" />
+		<key id="greater-equal" output="⩾" />
+		<key id="copy" output="©" />
+		<key id="inverse-question" output="¿" />
+		<key id="inverse-bang" output="¡" />
+		<key id="middle-dot" output="•" />
+		<key id="A-grave" output="À" />
+		<key id="E-acute" output="É" />
+		<key id="E-caret" output="Ê" />
+		<key id="em-dash" output="—" />
+		<key id="open-single" output="’" />
+		<key id="close-single" output="’" />
+		<key id="u-grave" output="Ù" />
+		<key id="radix" output="√" />
+		<key id="C-cedilla" output="Ç" />
+		<key id="not-equal" output="≠" />
+		<key id="open-angle-quote" output="‹" />
+		<key id="close-angle-quote" output="›" />
+
+		<key id="E-grave" output="È" />
+		<key id="U-grave" output="Ù" />
+		<key id="nb-hyphen" output="‑" />
+		<key id="multiplication" output="×" />
+		<key id="ezh" output="ʒ" />
+		<key id="Ezh" output="Ʒ" />
+		<key id="ae" output="æ" />
+		<key id="Ae" output="Æ" />
+		<key id="permille" output="‰" />
+		<key id="dbl-dagger" output="‡" />
+		<key id="dagger" output="†" />
+		<key id="asym-equal" output="≃" />
+		<key id="Ss" output="ẞ" />
+	</keys>
+
+	<layers formId="iso">
+		<layer modifiers="none">
+			<row
+				keys="at a-grave e-acute e-grave e-caret open-paren close-paren open-apos close-apos open-g close-g apos mark-caret" />
+			<row keys="a z e r t y u i o p hyphen plus" />
+			<row keys="q s d f g h j k l m slash asterisk" />
+			<row keys="open-angle w x c v b n period comma colon semi-colon" />
+			<row keys="space" />
+		</layer>
+
+		<layer modifiers="shift">
+			<row keys="hash 1 2 3 4 5 6 7 8 9 0 double-quote mark-umlaut" />
+			<row keys="A Z E R T Y U I O P en-dash plus-minus" />
+			<row keys="Q S D F G H J K L M backslash vulgar-half" />
+			<row keys="close-angle W X C V B N question bang ellipsis equal" />
+			<row keys="space" />
+		</layer>
+		<!-- layer is for AltGr - for now we use ctrl alt -->
+		<layer modifiers="ctrl alt">
+			<row
+				keys="mark-breve section mark-acute mark-grave amp open-square close-square mark-macron underscore open-double close-double degree mark-caron" />
+			<row
+				keys="ae pound euro registered open-curly close-curly u-grave mark-dotabove oe percent minus-sign dagger" />
+			<row
+				keys="theta ss dollar mark-currency mark-greek mark-euro gap mark-solidus pipe infinity division multiplication" />
+			<row
+				keys="less-equal ezh copy c-cedilla mark-cedilla mark-stroke mark-tilde inverse-question inverse-bang middle-dot asym-equal" />
+			<row keys="nbsp" />
+		</layer>
+
+		<layer modifiers="ctrl alt shift">
+			<row
+				keys="mark-invbreve A-grave E-acute E-grave E-caret mark-doubleacute mark-doublegrave gap em-dash open-angle-quote close-angle-quote mark-ring gap" />
+			<row keys="Ae gap gap gap tm gap U-grave mark-dotbelow Oe permille nb-hyphen dbl-dagger" />
+			<row keys="Theta Ss gap gap gap mark-submacron gap gap gap gap radix vulgar-quarter" />
+			<row
+				keys="greater-equal Ezh gap C-cedilla mark-ogonek gap gap gap mark-comma gap not-equal" />
+			<row keys="nnbsp" />
+		</layer>
+	</layers>
+
+	<variables>
+		<!-- spacing accents as string variables -->
+		<string id="grave" value="`" />
+		<string id="caret" value="^" />
+		<string id="umlaut" value="¨" />
+		<string id="tilde" value="~" />
+
+		<!-- sets representing vowels and accented vowels.  -->
+		<!-- There's an extra space between the lower and upper case for visual separation -->
+		<!-- but, there are only 10 vowels in the following four sets -->
+		<!-- plus space at end for the visible version -->
+		<set id="vowel" value="a e i o u  A E I O U" />
+
+		<!-- everything that should take an accented combining char -->
+		<set id="upaccentable" value="A B C D E F G H I J K L M N O P Q R S T U V W X Y Z    Ʒ Æ Œ" />
+		<set id="lwaccentable" value="a b c d e f g h i j k l m n o p q r s t u v w x y z    ʒ æ œ" />
+		<set id="accentable" value="$[upaccentable] $[lwaccentable]" />
+
+		<!-- currency key from/to -->
+		<set id="currfrom" value="e r t y p s d f g h k l m w c b n A R T P S D F L M  C B" />
+		<set id="currto" value="₠ ₽ ₸ ¥ ₱ ₪ ₫ ƒ ₲ ₴ ₭ ₺ ₥ ₩ ¢ ₿ ₦ ₳ ₹ ₮ ₧ ₷ ₯ ₣ ₤ ℳ ₡ ﺀ" />
+
+		<!-- greek from/to: deviating from spec, uppercase final sigma (X) is encoded as another Σ  -->
+		<set id="greekfrom"
+			value="a z e r u i o p s d g h j k l m x b n A Z E R U I O P S D G H J K L M X B N" />
+		<set id="greekto"
+			value="α ζ ε ρ θ ι ο π σ δ γ η ξ κ λ μ ς β ν Α Ζ Ε Ρ Θ Ι Ο Π Σ Δ Γ Η Ξ Κ Λ Μ Σ Β Ν" />
+
+		<!-- euro key from/to -->
+		<set id="eurofrom" value="a e t i o s d g j  ‘ ’ «  » '   E T I D G J  7 8 9 0" />
+		<set id="euroto" value="ª ə þ ı º ſ ð ŋ ij ‚ ‘ „ ‟ ’    Ə Þ İ Đ Ŋ IJ › ‹ » «" />
+
+		<!-- numbers -->
+		<set id="digits" value="0 1 2 3 4 5 6 7 8 9" />
+		<set id="superdigits" value="⁰ ¹ ² ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹" />
+		<set id="subdigits" value="₀ ₁ ₂ ₃ ₄ ₅ ₆ ₇ ₈ ₉" />
+	</variables>
+
+	<transforms type="simple">
+		<transformGroup>
+			<!-- super/sub digits -->
+			<transform from="\m{breve}($[digits])" to="$[1:superdigits]" />
+			<transform from="\m{invbreve}($[digits])" to="$[1:subdigits]" />
+
+			<!-- special cases - any more of these? -->
+			<transform from="\m{dotabove}i" to="ı" />
+
+			<!-- match accentables with combining marks -->
+			<transform from="\m{breve}($[accentable])" to="$1\u{0306}" />
+			<transform from="\m{umlaut}($[accentable])" to="$1\u{0308}" />
+			<transform from="\m{invbreve}($[accentable])" to="$1\u{0311}" />
+			<transform from="\m{acute}($[accentable])" to="$1\u{0301}" />
+			<transform from="\m{caret}($[accentable])" to="$1\u{0302}" />
+			<transform from="\m{caron}($[accentable])" to="$1\u{030c}" />
+			<transform from="\m{cedilla}($[accentable])" to="$1\u{0327}" />
+			<transform from="\m{comma}($[accentable])" to="$1\u{0326}" />
+			<transform from="\m{dotabove}($[accentable])" to="$1\u{0307}" />
+			<transform from="\m{dotbelow}($[accentable])" to="$1\u{0323}" />
+			<transform from="\m{doubleacute}($[accentable])" to="$1\u{030b}" />
+			<transform from="\m{doublegrave}($[accentable])" to="$1\u{030f}" />
+			<transform from="\m{grave}($[accentable])" to="$1\u{0300}" />
+			<transform from="\m{macron}($[accentable])" to="$1\u{0304}" />
+			<transform from="\m{ogonek}($[accentable])" to="$1\u{0328}" />
+			<transform from="\m{ring}($[accentable])" to="$1\u{030a}" />
+			<transform from="\m{solidus}($[accentable])" to="$1\u{338}" />
+			<transform from="\m{stroke}($[accentable])" to="$1\u{0335}" />
+			<transform from="\m{submacron}($[accentable])" to="$1\u{0331}" />
+			<transform from="\m{tilde}($[accentable])" to="$1\u{0303}" />
+
+			<!-- curr/greek/euro layer for hardware -->
+			<transform from="\m{currency}($[currfrom])" to="$[1:currto]" />
+			<transform from="\m{greek}\m{greek}" to="\u{B5}" />
+			<transform from="\m{greek}($[greekfrom])" to="$[1:greekto]" />
+			<transform from="\m{euro}($[eurofrom])" to="$[1:euroto]" />
+
+			<!-- these are harder to see because they are from AltGr and AltGr+Shift layers -->
+			<transform from="\m{currency}®" to="₨" /> <!-- AltGr-R -->
+			<transform from="\m{currency}%" to="₰" /> <!-- AltGr-P -->
+			<transform from="\m{currency}\|" to="₾" /> <!-- AltGr-L  - note pipe is escaped -->
+			<transform from="\m{currency}∞" to="₼" /> <!-- AltGr-M -->
+			<transform from="\m{currency}ç" to="₢" /> <!-- AltGr-C -->
+			<transform from="\m{currency}\m{currency}" to="¤" /> <!-- AltGr-Shift-E -->
+			<transform from="\m{currency}Ç" to="₵" /> <!-- AltGr-Shift-C (Cedi sign) -->
+		</transformGroup>
+		<!-- now, cleanup -->
+		<transformGroup>
+			<!-- catch-all: drop any marker that didn't otherwise match before a char -->
+			<transform from="\m{.}(.)" to="$1" />
+			<!-- not defined, so drop double euro -->
+			<transform from="\m{euro}\m{euro}" />
+		</transformGroup>
+	</transforms>
+</keyboard3>

--- a/resources/standards-data/ldml-keyboards/46/3.0/ja-Hira-t-k0-flicks.xml
+++ b/resources/standards-data/ldml-keyboards/46/3.0/ja-Hira-t-k0-flicks.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="ja-Hira-t-k0-flicks"
+	conformsTo="46">
+	<version number="1.0.0" />
+	<info author="Team Keyboard" name="Japanese Hiragana" />
+
+	<keys>
+		<import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="46/keys-Zyyy-currency.xml" />
+
+        <key id="h-a" output="あ" flickId="h-a"/>
+        <key id="h-i" output="い" />
+        <key id="h-u" output="う" />
+        <key id="h-e" output="え" />
+        <key id="h-o" output="お" />
+
+        <key id="h-ka" output="か"  flickId="h-ka"/>
+        <key id="h-ki" output="き" />
+        <key id="h-ku" output="く" />
+        <key id="h-ke" output="け" />
+        <key id="h-ko" output="こ" />
+
+        <key id="h-sa" output="さ"  flickId="h-sa"/>
+        <key id="h-si" output="し" />
+        <key id="h-su" output="す" />
+        <key id="h-se" output="せ" />
+        <key id="h-so" output="そ" />
+
+        <key id="h-ta" output="た"  flickId="h-ta"/>
+        <key id="h-ti" output="ち" />
+        <key id="h-tu" output="つ" />
+        <key id="h-te" output="て" />
+        <key id="h-to" output="と" />
+
+        <key id="h-na" output="な"  flickId="h-na"/>
+        <key id="h-ni" output="に" />
+        <key id="h-nu" output="ぬ" />
+        <key id="h-ne" output="ね" />
+        <key id="h-no" output="の" />
+
+        <key id="h-ha" output="は"  flickId="h-ha"/>
+        <key id="h-hi" output="ひ" />
+        <key id="h-hu" output="ふ" />
+        <key id="h-he" output="へ" />
+        <key id="h-ho" output="ほ" />
+
+        <key id="h-ma" output="ま"  flickId="h-ma"/>
+        <key id="h-mi" output="み" />
+        <key id="h-mu" output="む" />
+        <key id="h-me" output="め" />
+        <key id="h-mo" output="も" />
+
+        <key id="h-ya" output="や"  flickId="h-ya"/>
+        <key id="h-yu" output="ゆ" />
+        <key id="h-yo" output="よ" />
+
+        <key id="h-ra" output="ら"  flickId="h-ra" />
+        <key id="h-ri" output="り" />
+        <key id="h-ru" output="る" />
+        <key id="h-re" output="れ" />
+        <key id="h-ro" output="ろ" />
+
+        <key id="h-wa" output="わ"  flickId="h-wa"/>
+        <key id="h-wo" output="を" />
+
+        <key id="h-n" output="ん" />
+
+        <key id="h-period" output="。" flickId="marks" />
+
+        <key id="num" layerId="num"/>
+        <key id="sym" layerId="sym"/>
+        <key id="base" layerId="base"/>
+
+        <key id="voiced" output="\u{3099}"/>
+        <key id="semivoiced" output="\u{309A}"/>
+        <key id="smalltsu" output="っ"/>
+        <key id="smallya" output="ゃ"/>
+	</keys>
+
+    <flicks>
+        <flick id="marks">
+            <flickSegment directions="w" keyId="voiced"/>
+            <flickSegment directions="n" keyId="h-period"/>
+            <flickSegment directions="e" keyId="semivoiced"/>
+            <flickSegment directions="s" keyId="period"/>
+        </flick>
+		<flick id="h-a">
+			<flickSegment directions="n"  keyId="h-a" />
+			<flickSegment directions="w"  keyId="h-i" />
+			<flickSegment directions="e"  keyId="h-u" />
+			<flickSegment directions="sw"  keyId="h-e" />
+            <flickSegment directions="s" keyId="h-o" />
+		</flick>
+		<flick id="h-ka">
+			<flickSegment directions="n"  keyId="h-ka" />
+			<flickSegment directions="w"  keyId="h-ki" />
+			<flickSegment directions="e"  keyId="h-ku" />
+			<flickSegment directions="sw"  keyId="h-ke" />
+            <flickSegment directions="s" keyId="h-ko" />
+		</flick>
+		<flick id="h-sa">
+			<flickSegment directions="n"  keyId="h-sa" />
+			<flickSegment directions="w"  keyId="h-si" />
+			<flickSegment directions="e"  keyId="h-su" />
+			<flickSegment directions="sw"  keyId="h-se" />
+            <flickSegment directions="s" keyId="h-so" />
+		</flick>
+		<flick id="h-ta">
+			<flickSegment directions="n"  keyId="h-ta" />
+			<flickSegment directions="w"  keyId="h-ti" />
+			<flickSegment directions="e"  keyId="h-tu" />
+            <flickSegment directions="se" keyId="smalltsu"/>
+			<flickSegment directions="sw"  keyId="h-te" />
+            <flickSegment directions="s" keyId="h-to" />
+		</flick>
+		<flick id="h-na">
+			<flickSegment directions="n"  keyId="h-na" />
+			<flickSegment directions="w"  keyId="h-ni" />
+			<flickSegment directions="e"  keyId="h-nu" />
+			<flickSegment directions="sw"  keyId="h-ne" />
+            <flickSegment directions="s" keyId="h-no" />
+		</flick>
+		<flick id="h-ha">
+			<flickSegment directions="n"  keyId="h-ha" />
+			<flickSegment directions="w"  keyId="h-hi" />
+			<flickSegment directions="e"  keyId="h-hu" />
+			<flickSegment directions="sw"  keyId="h-he" />
+            <flickSegment directions="s" keyId="h-ho" />
+		</flick>
+		<flick id="h-ma">
+			<flickSegment directions="n"  keyId="h-ma" />
+			<flickSegment directions="w"  keyId="h-mi" />
+			<flickSegment directions="e"  keyId="h-mu" />
+			<flickSegment directions="sw"  keyId="h-me" />
+            <flickSegment directions="s" keyId="h-mo" />
+		</flick>
+		<flick id="h-ya">
+			<flickSegment directions="n"  keyId="h-ya" />
+            <flickSegment directions="ne" keyId="smallya"/>
+			<flickSegment directions="e"  keyId="h-yu" />
+            <flickSegment directions="s" keyId="h-yo" />
+		</flick>
+		<flick id="h-ra">
+			<flickSegment directions="n"  keyId="h-ra" />
+			<flickSegment directions="w"  keyId="h-ri" />
+			<flickSegment directions="e"  keyId="h-ru" />
+			<flickSegment directions="sw"  keyId="h-re" />
+            <flickSegment directions="s" keyId="h-ro" />
+		</flick>
+		<flick id="h-wa">
+			<flickSegment directions="n"  keyId="h-wa" />
+            <flickSegment directions="s" keyId="h-wo" />
+		</flick>
+	</flicks>
+
+	<layers formId="touch">
+		<layer id="base">
+            <row keys="h-a h-ka h-sa" />
+            <row keys="h-ta h-na h-ha" />
+            <row keys="h-ma h-ya h-ra" />
+            <row keys="sym h-wa h-period num" />
+            <row keys="space" />
+		</layer>
+
+        <layer id="sym">
+            <row keys="bang double-quote hash" />
+            <row keys="dollar percent amp" />
+            <row keys="apos open-paren close-paren" />
+            <row keys="equal tilde pipe" />
+            <row keys="base"/>
+        </layer>
+
+        <layer id="num">
+            <row keys="1 2 3" />
+            <row keys="4 5 6" />
+            <row keys="7 8 9" />
+            <row keys="comma 0 period" />
+            <row keys="base"/>
+        </layer>
+
+	</layers>
+
+</keyboard3>

--- a/resources/standards-data/ldml-keyboards/46/3.0/ja-Latn.xml
+++ b/resources/standards-data/ldml-keyboards/46/3.0/ja-Latn.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="ja-Latn" conformsTo="46">
+	<locales>
+		<locale id="en" />
+	</locales>
+	<version number="0.0.0" />
+	<info name="Romaji (JIS)" />
+
+	<keys>
+		<import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="46/keys-Zyyy-currency.xml" />
+	</keys>
+
+	<layers formId="jis">
+		<layer modifiers="none">
+			<row keys="1 2 3 4 5 6 7 8 9 0 hyphen caret yen" />
+			<row keys="q w e r t y u i o p at open-square" />
+			<row keys="a s d f g h j k l semi-colon colon close-square" />
+			<row keys="z x c v b n m comma period slash underscore" />
+			<row keys="space"/>
+		</layer>
+		<layer modifiers="shift">
+			<row keys="bang double-quote hash dollar percent amp apos open-paren close-paren 0 equal tilde pipe" /> <!-- 0 is repeated from "none" -->
+			<row keys="Q W E R T Y U I O P grave open-curly" />
+			<row keys="A S D F G H J K L plus asterisk close-curly" />
+			<row keys="Z X C V B N M open-angle close-angle question underscore" /> <!-- underscore is repeated from "none" -->
+			<row keys="space"/>
+		</layer>
+	</layers>
+</keyboard3>

--- a/resources/standards-data/ldml-keyboards/46/3.0/mt-t-k0-47key.xml
+++ b/resources/standards-data/ldml-keyboards/46/3.0/mt-t-k0-47key.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="mt-t-k0-47key" conformsTo="46">
+    <locales>
+        <!-- English is also an official language in Malta.-->
+        <locale id="en" />
+    </locales>
+    <info name="Maltese 47-key" author="Steven R. Loomis" layout="QWERTY" indicator="MT" />
+    <!-- MSA 100:2002 -->
+
+    <keys>
+        <!-- imports -->
+        <import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+        <import base="cldr" path="46/keys-Zyyy-currency.xml" />
+
+        <!-- accent grave -->
+        <key id="a-grave" output="à" />
+        <key id="A-grave" output="À" />
+        <key id="e-grave" output="è" />
+        <key id="E-grave" output="È" />
+        <key id="i-grave" output="ì" />
+        <key id="I-grave" output="Ì" />
+        <key id="o-grave" output="ò" />
+        <key id="O-grave" output="Ò" />
+        <key id="u-grave" output="ù" />
+        <key id="U-grave" output="Ù" />
+
+        <!-- tikka and maqtugha -->
+        <key id="c-tikka" output="ċ" /> <!-- tikka is a dot -->
+        <key id="C-tikka" output="Ċ" />
+        <key id="g-tikka" output="ġ" />
+        <key id="G-tikka" output="Ġ" />
+        <key id="h-maqtugha" output="ħ" /> <!-- maqtugħa, i.e. cut -->
+        <key id="H-maqtugha" output="Ħ" /> <!-- maqtugħa, i.e. cut -->
+        <key id="z-tikka" output="ż" />
+        <key id="Z-tikka" output="Ż" />
+
+        <!-- Cedilla -->
+        <key id="c-cedilla" output="ç" />
+
+        <!-- gaps -->
+        <key id="gap" gap="true" width="1" />
+    </keys>
+
+    <!-- 47-key: MSA 100:2002, Appendix, figure A.1 -->
+    <layers formId="us">
+        <layer modifiers="none">
+            <row keys="c-tikka 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+            <row keys="q w e r t y u i o p g-tikka h-maqtugha z-tikka" />
+            <row keys="a s d f g h j k l semi-colon apos" />
+            <row keys="z x c v b n m comma period slash" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifiers="shift">
+            <row keys="C-tikka bang at euro dollar percent caret amp asterisk open-paren close-paren underscore plus" />
+            <row keys="Q W E R T Y U I O P G-tikka H-maqtugha Z-tikka" />
+            <row keys="A S D F G H J K L colon double-quote" />
+            <row keys="Z X C V B N M open-angle close-angle question" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifiers="altR">
+            <row keys="grave gap gap pound gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap e-grave gap gap gap u-grave i-grave o-grave gap open-square close-square backslash" />
+            <row keys="a-grave gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifiers="altR shift">
+            <row keys="tilde gap gap gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap E-grave gap gap gap U-grave I-grave O-grave gap open-curly close-curly pipe" />
+            <row keys="A-grave gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="space" />
+        </layer>
+    </layers>
+
+</keyboard3>

--- a/resources/standards-data/ldml-keyboards/46/3.0/mt.xml
+++ b/resources/standards-data/ldml-keyboards/46/3.0/mt.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright © 1991-2024 Unicode, Inc.
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="mt" conformsTo="46">
+    <locales>
+        <!-- English is also an official language in Malta.-->
+        <locale id="en" />
+    </locales>
+    <info name="Maltese" author="Steven R. Loomis" layout="QWERTY" indicator="MT" />
+    <!-- MSA 100:2002 -->
+
+    <keys>
+        <!-- imports -->
+        <import base="cldr" path="46/keys-Zyyy-punctuation.xml"/>
+        <import base="cldr" path="46/keys-Zyyy-currency.xml"/>
+
+        <!-- accent grave -->
+        <key id="a-grave" output="à" />
+        <key id="A-grave" output="À" />
+        <key id="e-grave" output="è" />
+        <key id="E-grave" output="È" />
+        <key id="i-grave" output="ì" />
+        <key id="I-grave" output="Ì" />
+        <key id="o-grave" output="ò" />
+        <key id="O-grave" output="Ò" />
+        <key id="u-grave" output="ù" />
+        <key id="U-grave" output="Ù" />
+
+        <!-- tikka and maqtugha -->
+        <key id="c-tikka" output="ċ" /> <!-- tikka is a dot -->
+        <key id="C-tikka" output="Ċ" />
+        <key id="g-tikka" output="ġ" />
+        <key id="G-tikka" output="Ġ" />
+        <key id="h-maqtugha" output="ħ" /> <!-- maqtugħa, i.e. cut -->
+        <key id="H-maqtugha" output="Ħ" /> <!-- maqtugħa, i.e. cut -->
+        <key id="z-tikka" output="ż" />
+        <key id="Z-tikka" output="Ż" />
+
+        <!-- Cedilla -->
+        <key id="c-cedilla" output="ç" />
+    </keys>
+
+     <!-- 48-key -->
+    <layers formId="iso">
+        <layer modifiers="none">
+            <row keys="c-tikka 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+            <row keys="q w e r t y u i o p g-tikka h-maqtugha" />
+            <row keys="a s d f g h j k l semi-colon hash" />
+            <row keys="z-tikka z x c v b n m comma period slash" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifiers="shift">
+            <row keys="C-tikka bang double-quote euro dollar percent caret amp open-paren close-paren underscore plus" />
+            <row keys="Q W E R T Y U I O P G-tikka H-maqtugha" />
+            <row keys="A S D F G H J K L colon at tilde" />
+            <row keys="Z-tikka Z X C V B N M open-angle close-angle question" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifiers="altR">
+            <row keys="grave gap gap pound gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap e-grave gap gap gap u-grave i-grave o-grave gap open-square close-square" />
+            <row keys="a-grave gap gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="backslash gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="space" />
+        </layer>
+
+        <layer modifiers="altR shift">
+            <row keys="not gap gap gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="gap gap E-grave gap gap gap U-grave I-grave O-grave gap open-curly close-curly" />
+            <row keys="A-grave gap gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="pipe gap gap gap gap gap gap gap gap gap gap" />
+            <row keys="space" />
+        </layer>
+    </layers>
+
+</keyboard3>

--- a/resources/standards-data/ldml-keyboards/46/3.0/pcm.xml
+++ b/resources/standards-data/ldml-keyboards/46/3.0/pcm.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="pcm" conformsTo="46">
+  <version number="1.0.0" />
+  <info name="Naijíriá Píjin" />
+  <keys>
+    <import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+    <import base="cldr" path="46/keys-Zyyy-currency.xml" />
+    <key id="grave" output="\u{300}" />
+    <key id="backquote" output="`" />
+    <key id="acute" output="\u{301}" />
+
+    <!-- accented vowels -->
+    <key id="odot" output="ọ" />
+    <key id="Odot" output="Ọ" />
+    <key id="edot" output="ẹ" />
+    <key id="Edot" output="Ẹ" />
+
+    <!-- currency -->
+    <key id="naira" output="₦" />
+  </keys>
+
+  <layers formId="iso">
+    <layer modifiers="none">
+      <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+      <row keys="acute w e r t y u i o p open-square close-square" />
+      <row keys="a s d f g h j k l odot edot slash" />
+      <row keys="slash z c v b n m comma period semi-colon apos" />
+      <row keys="space" />
+    </layer>
+
+    <layer modifiers="shift">
+      <row keys="grave bang at hash dollar naira percent amp asterisk open-paren close-paren underscore plus" />
+      <row keys="A S D F G H J K L Odot Edot question" />
+      <row keys="A S D F G H J K L Odot Edot" />
+      <row keys="question Z C V B N M open-angle close-angle colon double-quote" />
+      <row keys="space" />
+    </layer>
+
+    <layer modifiers="caps">
+      <row keys="backquote 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+      <row keys="Q W E R T Y U I O P open-square close-square" />
+      <row keys="A S D F G H J K L Odot Edot slash" />
+      <row keys="slash Z C V B N M comma period semi-colon apos" />
+      <row keys="space" />
+    </layer>
+
+  </layers>
+
+  <transforms type="simple">
+    <transformGroup>
+      <transform from="''" to="\u{323}" /> <!-- Quick way to add dot below -->
+    </transformGroup>
+  </transforms>
+</keyboard3>

--- a/resources/standards-data/ldml-keyboards/46/3.0/pt-t-k0-abnt2.xml
+++ b/resources/standards-data/ldml-keyboards/46/3.0/pt-t-k0-abnt2.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="pt-t-k0-abnt2" conformsTo="46">
+	<locales>
+		<locale id="pt" />
+	</locales>
+	<version number="0.0.0" />
+	<info name="Portuguese (Brazil) (ABNT2)" />
+	<displays>
+		<display output="\m{acute}"  display="´"/>
+		<display output="\m{grave}"  display="`"/>
+		<display output="\m{umlaut}" display="¨"/>
+		<display output="\m{caret}"  display="^"/>
+		<display output="\m{tilde}"  display="~"/>
+	</displays>
+
+	<keys>
+		<import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="46/keys-Zyyy-currency.xml" />
+
+		<!-- TODO: using the proposed deadkey format -->
+		<key id="d-acute"  output="\m{acute}"/>
+		<key id="d-grave"  output="\m{grave}"/>
+		<key id="d-umlaut" output="\m{umlaut}"/>
+		<key id="d-caret"  output="\m{caret}"/>
+		<key id="d-tilde"  output="\m{tilde}"/>
+
+		<key id="c-cedilla"         output="ç" />
+		<key id="C-cedilla"         output="Ç" />
+
+		<key id="super-1"           output="¹" />
+		<key id="super-2"           output="²" />
+		<key id="super-3"           output="³" />
+		<key id="ordinal-feminine"  output="ª" />
+		<key id="ordinal-masculine" output="º" />
+	</keys>
+	<layers formId="abnt2">
+		<layer modifiers="none">
+			<row keys="apos 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
+			<row keys="q w e r t y u i o p d-acute open-square" />
+			<row keys="a s d f g h j k l c-cedilla d-tilde close-square" />
+			<row keys="backslash z x c v b n m comma period semi-colon slash" />
+			<row keys="space"/>
+		</layer>
+		<layer modifiers="shift">
+			<row keys="double-quote bang at hash dollar percent d-umlaut amp asterisk open-paren close-paren underscore plus" />
+			<row keys="Q W E R T Y U I O P d-grave open-curly" />
+			<row keys="A S D F G H J K L C-cedilla d-caret close-curly" />
+			<row keys="pipe Z X C V B N M open-angle close-angle colon question" />
+			<row keys="space"/>
+		</layer>
+		<layer modifiers="altR">
+			<row keys="gap super-1 super-2 super-3 pound cent not gap gap gap gap gap section" />
+			<row keys="slash question degree gap gap gap gap gap gap gap gap ordinal-feminine" />
+			<row keys="gap gap gap gap gap gap gap gap gap gap gap ordinal-masculine" />
+			<row keys="gap gap gap cruzeiro gap gap gap gap gap gap gap degree" />
+			<row keys="space"/>
+		</layer>
+	</layers>
+
+	<!-- TODO: transform! -->
+</keyboard3>

--- a/resources/standards-data/ldml-keyboards/46/cldr_info.json
+++ b/resources/standards-data/ldml-keyboards/46/cldr_info.json
@@ -1,0 +1,5 @@
+{
+  "sha": "6502c2410ac23818221d61e1535ab38ecf72e0a2",
+  "description": "https://github.com/unicode-org/cldr/pull/4053",
+  "date": "Fri, 13 Sep 2024 19:58:30 +0000"
+}

--- a/resources/standards-data/ldml-keyboards/46/dtd/ldmlKeyboard3.dtd
+++ b/resources/standards-data/ldml-keyboards/46/dtd/ldmlKeyboard3.dtd
@@ -1,0 +1,215 @@
+<!--
+Copyright © 1991-2024 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<!-- Note: This DTD is not compatible with prior versions of the keyboard data.
+     See ldmlKeyboard.dtd  and CLDR v43 and prior. -->
+
+<!ELEMENT keyboard3 ( import*, locales?, version?, info, settings?, displays?, keys?, flicks?, forms?, layers*, variables?, transforms*, special* ) >
+<!ATTLIST keyboard3 locale CDATA #REQUIRED >
+    <!--@MATCH:validity/bcp47-wellformed-->
+<!ATTLIST keyboard3 conformsTo (45 | 46) #REQUIRED >
+    <!--@MATCH:version-->
+    <!--@METADATA-->
+<!ATTLIST keyboard3 xmlns CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@METADATA-->
+
+<!ELEMENT import EMPTY >
+<!ATTLIST import path CDATA #REQUIRED >
+    <!--@MATCH:any-->
+<!ATTLIST import base (cldr) #IMPLIED >
+
+<!ELEMENT locales ( locale* ) >
+
+<!ELEMENT locale EMPTY >
+<!ATTLIST locale id CDATA #REQUIRED >
+    <!--@MATCH:validity/bcp47-wellformed-->
+
+<!ELEMENT version EMPTY >
+<!ATTLIST version number CDATA #IMPLIED >
+    <!--@MATCH:semver-->
+    <!--@VALUE-->
+<!ATTLIST version cldrVersion CDATA #FIXED "46" >
+    <!--@MATCH:version-->
+    <!--@METADATA-->
+
+<!ELEMENT info EMPTY >
+<!ATTLIST info name CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST info author CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST info layout CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST info indicator CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+
+<!ELEMENT settings EMPTY >
+    <!--@ORDERED-->
+<!ATTLIST settings normalization (disabled) #IMPLIED >
+    <!--@VALUE-->
+
+<!ELEMENT displays ( import*, display*, displayOptions*, special* ) >
+
+<!ELEMENT display EMPTY >
+<!ATTLIST display keyId NMTOKEN #IMPLIED >
+    <!--@MATCH:any-->
+<!ATTLIST display output CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@ALLOWS_UESC-->
+<!ATTLIST display display CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+
+<!ELEMENT displayOptions EMPTY >
+<!ATTLIST displayOptions baseCharacter CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+
+<!ELEMENT special ANY >
+
+<!ELEMENT keys ( import*, key*, special* ) >
+
+<!ELEMENT key EMPTY >
+<!ATTLIST key id NMTOKEN #REQUIRED >
+    <!--@MATCH:any-->
+<!ATTLIST key flickId NMTOKEN #IMPLIED >
+    <!--@MATCH:any-->
+<!ATTLIST key gap (true) #IMPLIED >
+    <!--@VALUE-->
+<!ATTLIST key output CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+<!ATTLIST key longPressKeyIds NMTOKENS #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST key longPressDefaultKeyId NMTOKEN #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST key multiTapKeyIds NMTOKENS #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST key stretch (true) #IMPLIED >
+    <!--@VALUE-->
+<!ATTLIST key layerId NMTOKEN #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST key width CDATA #IMPLIED >
+    <!--@MATCH:range/0.01~100.0-->
+    <!--@VALUE-->
+
+<!ELEMENT flicks ( import*, flick*, special* ) >
+
+<!ELEMENT flick ( flickSegment+, special* ) >
+<!ATTLIST flick id NMTOKEN #REQUIRED >
+    <!--@MATCH:any-->
+
+<!ELEMENT flickSegment EMPTY >
+<!ATTLIST flickSegment directions NMTOKENS #REQUIRED >
+    <!--@MATCH:regex/(n|e|s|w|ne|nw|se|sw)([ ]+(n|e|s|w|ne|nw|se|sw))*-->
+<!ATTLIST flickSegment keyId NMTOKEN #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+
+<!ELEMENT forms ( import*, form*, special* ) >
+
+<!ELEMENT form ( scanCodes+, special* ) >
+<!ATTLIST form id NMTOKEN #IMPLIED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9_-]*-->
+
+<!ELEMENT scanCodes EMPTY >
+<!ATTLIST scanCodes codes NMTOKENS #REQUIRED >
+    <!--@MATCH:regex/[0-9a-fA-F]{2}( [0-9a-fA-F]{2})*-->
+    <!--@VALUE-->
+
+<!ELEMENT layers ( import*, layer*, special* ) >
+<!ATTLIST layers formId NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9_-]*-->
+<!ATTLIST layers minDeviceWidth CDATA #IMPLIED >
+    <!--@MATCH:range/1~999-->
+
+<!ELEMENT layer ( row+, special* ) >
+<!ATTLIST layer id NMTOKEN #IMPLIED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9_-]*-->
+<!ATTLIST layer modifiers NMTOKENS #IMPLIED >
+    <!--@MATCH:regex/(none|([A-Za-z0-9]+)( [A-Za-z0-9]+)*)-->
+
+<!ELEMENT row EMPTY >
+    <!--@ORDERED-->
+<!ATTLIST row keys NMTOKENS #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+
+<!ELEMENT variables ( import*, string*, set*, uset*, special* ) >
+
+<!ELEMENT string EMPTY >
+<!ATTLIST string id NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[0-9A-Za-z_]{1,32}-->
+<!ATTLIST string value CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+
+<!ELEMENT set EMPTY >
+<!ATTLIST set id NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[0-9A-Za-z_]{1,32}-->
+<!ATTLIST set value CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+
+<!ELEMENT uset EMPTY >
+<!ATTLIST uset id NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[0-9A-Za-z_]{1,32}-->
+<!ATTLIST uset value CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+
+<!ELEMENT transforms ( import*, transformGroup*, special* ) >
+<!ATTLIST transforms type (simple | backspace) #REQUIRED >
+    <!--@MATCH:literal/simple, backspace-->
+
+<!ELEMENT transformGroup ( import*, ( transform* | reorder* ), special* ) >
+
+<!ELEMENT transform EMPTY >
+    <!--@ORDERED-->
+<!ATTLIST transform from CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+<!ATTLIST transform to CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+
+<!ELEMENT reorder EMPTY >
+    <!--@ORDERED-->
+<!ATTLIST reorder before CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+<!ATTLIST reorder from CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+<!ATTLIST reorder order CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST reorder tertiary CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST reorder tertiaryBase CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST reorder preBase CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->

--- a/resources/standards-data/ldml-keyboards/46/dtd/ldmlKeyboard3.xsd
+++ b/resources/standards-data/ldml-keyboards/46/dtd/ldmlKeyboard3.xsd
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Note: The .xsd files are a Technology Preview. They are subject to change or removal in future CLDR versions.
+Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file validation, use the DTD and CLDR tools.
+-->
+
+<!--
+  Copyright © 1991-2024 Unicode, Inc.
+  For terms of use, see http://www.unicode.org/copyright.html
+  SPDX-License-Identifier: Unicode-3.0
+  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+--><!--
+  Note: This DTD is not compatible with prior versions of the keyboard data.
+  See ldmlKeyboard.dtd  and CLDR v43 and prior.
+--><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="keyboard3">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
+        <xs:element minOccurs="0" ref="locales"/>
+        <xs:element minOccurs="0" ref="version"/>
+        <xs:element ref="info"/>
+        <xs:element minOccurs="0" ref="settings"/>
+        <xs:element minOccurs="0" ref="displays"/>
+        <xs:element minOccurs="0" ref="keys"/>
+        <xs:element minOccurs="0" ref="flicks"/>
+        <xs:element minOccurs="0" ref="forms"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="layers"/>
+        <xs:element minOccurs="0" ref="variables"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="transforms"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="locale" use="required"/>
+      <xs:attribute name="conformsTo" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="45"/>
+            <xs:enumeration value="46"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  
+  <xs:element name="import">
+    <xs:complexType>
+      <xs:attribute name="path" use="required"/>
+      <xs:attribute name="base">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="cldr"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="locales">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="locale"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="locale">
+    <xs:complexType>
+      <xs:attribute name="id" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="version">
+    <xs:complexType>
+      <xs:attribute name="number"/>
+      <xs:attribute default="46" name="cldrVersion">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="46"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  <xs:element name="info">
+    <xs:complexType>
+      <xs:attribute name="name" use="required"/>
+      <xs:attribute name="author"/>
+      <xs:attribute name="layout"/>
+      <xs:attribute name="indicator"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  
+  
+  
+  
+  <xs:element name="settings">
+    <xs:complexType>
+      <xs:attribute name="normalization">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="disabled"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  <xs:element name="displays">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="display"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="displayOptions"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="display">
+    <xs:complexType>
+      <xs:attribute name="keyId" type="xs:NMTOKEN"/>
+      <xs:attribute name="output"/>
+      <xs:attribute name="display" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  
+  
+  <xs:element name="displayOptions">
+    <xs:complexType>
+      <xs:attribute name="baseCharacter"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  <xs:element name="special" type="any"/>
+  <xs:element name="keys">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="key"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="key">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
+      <xs:attribute name="flickId" type="xs:NMTOKEN"/>
+      <xs:attribute name="gap">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="output"/>
+      <xs:attribute name="longPressKeyIds" type="xs:NMTOKENS"/>
+      <xs:attribute name="longPressDefaultKeyId" type="xs:NMTOKEN"/>
+      <xs:attribute name="multiTapKeyIds" type="xs:NMTOKENS"/>
+      <xs:attribute name="stretch">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="layerId" type="xs:NMTOKEN"/>
+      <xs:attribute name="width"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  <xs:element name="flicks">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="flick"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="flick">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="flickSegment"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="flickSegment">
+    <xs:complexType>
+      <xs:attribute name="directions" type="xs:NMTOKENS" use="required"/>
+      <xs:attribute name="keyId" type="xs:NMTOKEN" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  <xs:element name="forms">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="form"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="form">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="scanCodes"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="scanCodes">
+    <xs:complexType>
+      <xs:attribute name="codes" type="xs:NMTOKENS" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  <xs:element name="layers">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="layer"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="formId" type="xs:NMTOKEN" use="required"/>
+      <xs:attribute name="minDeviceWidth"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  <xs:element name="layer">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="row"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:NMTOKEN"/>
+      <xs:attribute name="modifiers" type="xs:NMTOKENS"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  <xs:element name="row">
+    <xs:complexType>
+      <xs:attribute name="keys" type="xs:NMTOKENS" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  <xs:element name="variables">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="string"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="set"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="uset"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="string">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
+      <xs:attribute name="value" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  <xs:element name="set">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
+      <xs:attribute name="value" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  <xs:element name="uset">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
+      <xs:attribute name="value" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  <xs:element name="transforms">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="transformGroup"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="simple"/>
+            <xs:enumeration value="backspace"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="transformGroup">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
+        <xs:choice>
+          <xs:element maxOccurs="unbounded" minOccurs="0" ref="transform"/>
+          <xs:element maxOccurs="unbounded" minOccurs="0" ref="reorder"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="transform">
+    <xs:complexType>
+      <xs:attribute name="from" use="required"/>
+      <xs:attribute name="to"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  
+  
+  
+  <xs:element name="reorder">
+    <xs:complexType>
+      <xs:attribute name="before"/>
+      <xs:attribute name="from" use="required"/>
+      <xs:attribute name="order"/>
+      <xs:attribute name="tertiary"/>
+      <xs:attribute name="tertiaryBase"/>
+      <xs:attribute name="preBase"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType mixed="true" name="any">
+    <xs:sequence>
+      <xs:any maxOccurs="unbounded" minOccurs="0" processContents="strict"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/resources/standards-data/ldml-keyboards/46/dtd/ldmlKeyboardTest3.dtd
+++ b/resources/standards-data/ldml-keyboards/46/dtd/ldmlKeyboardTest3.dtd
@@ -1,0 +1,92 @@
+<!--
+Copyright © 1991-2024 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<!-- Important Note:
+
+This DTD describes a technical preview of Keyboard Test Data -->
+
+<!ELEMENT keyboardTest3 ( info, repertoire*, tests*, special* ) >
+    <!--@TECHPREVIEW-->
+<!ATTLIST keyboardTest3 conformsTo (techpreview) #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@METADATA-->
+
+<!ELEMENT info EMPTY >
+    <!--@TECHPREVIEW-->
+<!ATTLIST info keyboard CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST info author CDATA #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@METADATA-->
+<!ATTLIST info name NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
+
+<!ELEMENT repertoire EMPTY >
+    <!--@TECHPREVIEW-->
+<!ATTLIST repertoire chars CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST repertoire type (default | simple | gesture | flick | longPress | multiTap | hardware) #IMPLIED >
+    <!--@VALUE-->
+<!ATTLIST repertoire name NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
+
+<!ELEMENT tests ( test+, special* ) >
+    <!--@TECHPREVIEW-->
+<!ATTLIST tests name NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
+
+<!ELEMENT test ( startContext?, ( keystroke | emit | backspace | check )*, special* ) >
+    <!--@TECHPREVIEW-->
+<!ATTLIST test name NMTOKEN #REQUIRED >
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9-]*-->
+
+<!ELEMENT startContext EMPTY >
+    <!--@TECHPREVIEW-->
+<!ATTLIST startContext to CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+
+<!ELEMENT keystroke EMPTY >
+    <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
+<!ATTLIST keystroke key NMTOKEN #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST keystroke flick NMTOKENS #IMPLIED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+<!ATTLIST keystroke longPress CDATA #IMPLIED >
+    <!--@MATCH:range/1~999-->
+    <!--@VALUE-->
+<!ATTLIST keystroke tapCount CDATA #IMPLIED >
+    <!--@MATCH:range/2~999-->
+    <!--@VALUE-->
+
+<!ELEMENT emit EMPTY >
+    <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
+<!ATTLIST emit to CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+
+<!ELEMENT backspace EMPTY >
+    <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
+
+<!ELEMENT check EMPTY >
+    <!--@ORDERED-->
+    <!--@TECHPREVIEW-->
+<!ATTLIST check result CDATA #REQUIRED >
+    <!--@MATCH:any-->
+    <!--@VALUE-->
+    <!--@ALLOWS_UESC-->
+
+<!ELEMENT special ANY >
+    <!--@TECHPREVIEW-->

--- a/resources/standards-data/ldml-keyboards/46/dtd/ldmlKeyboardTest3.xsd
+++ b/resources/standards-data/ldml-keyboards/46/dtd/ldmlKeyboardTest3.xsd
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Note: The .xsd files are a Technology Preview. They are subject to change or removal in future CLDR versions.
+Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file validation, use the DTD and CLDR tools.
+-->
+
+<!--
+  Copyright © 1991-2024 Unicode, Inc.
+  For terms of use, see http://www.unicode.org/copyright.html
+  SPDX-License-Identifier: Unicode-3.0
+  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+--><!--
+  Important Note:
+  
+  This DTD describes a technical preview of Keyboard Test Data
+--><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="keyboardTest3">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="info"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="repertoire"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="tests"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="conformsTo" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="techpreview"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  <xs:element name="info">
+    <xs:complexType>
+      <xs:attribute name="keyboard" use="required"/>
+      <xs:attribute name="author"/>
+      <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  
+  
+  <xs:element name="repertoire">
+    <xs:complexType>
+      <xs:attribute name="chars" use="required"/>
+      <xs:attribute name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="default"/>
+            <xs:enumeration value="simple"/>
+            <xs:enumeration value="gesture"/>
+            <xs:enumeration value="flick"/>
+            <xs:enumeration value="longPress"/>
+            <xs:enumeration value="multiTap"/>
+            <xs:enumeration value="hardware"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  
+  <xs:element name="tests">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="test"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  <xs:element name="test">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="startContext"/>
+        <xs:choice maxOccurs="unbounded" minOccurs="0">
+          <xs:element ref="keystroke"/>
+          <xs:element ref="emit"/>
+          <xs:element ref="backspace"/>
+          <xs:element ref="check"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  <xs:element name="startContext">
+    <xs:complexType>
+      <xs:attribute name="to" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  <xs:element name="keystroke">
+    <xs:complexType>
+      <xs:attribute name="key" type="xs:NMTOKEN" use="required"/>
+      <xs:attribute name="flick" type="xs:NMTOKENS"/>
+      <xs:attribute name="longPress"/>
+      <xs:attribute name="tapCount"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  <xs:element name="emit">
+    <xs:complexType>
+      <xs:attribute name="to" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  
+  <xs:element name="backspace">
+    <xs:complexType/>
+  </xs:element>
+  
+  
+  <xs:element name="check">
+    <xs:complexType>
+      <xs:attribute name="result" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  
+  
+  
+  
+  <xs:element name="special" type="any"/>
+  <xs:complexType mixed="true" name="any">
+    <xs:sequence>
+      <xs:any maxOccurs="unbounded" minOccurs="0" processContents="strict"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/resources/standards-data/ldml-keyboards/46/import/README.md
+++ b/resources/standards-data/ldml-keyboards/46/import/README.md
@@ -1,0 +1,23 @@
+# Keyboard imports
+
+The XML files in this directory are importable using the keyboard syntax as follows:
+
+```xml
+<import base="cldr" path="45/somefile.xml"/>
+```
+
+This is the naming convention being used:
+
+- _type_`-`_script_`-`_description_`.xml`
+
+Where _type_ is the top level element such as `<keys>`.
+
+So,
+
+- `keys-Zyyy-punctuation.xml` is of [script](https://www.unicode.org/iso15924/iso15924-codes.html) `Zyyy`, aka "Common".
+
+See [tr35-keyboard.md](../../docs/ldml/tr35-keyboards.md#Element_import)
+
+## Copyright and License
+
+See the top level [README.md](../../README.md#copyright--licenses)

--- a/resources/standards-data/ldml-keyboards/46/import/keys-Latn-implied.xml
+++ b/resources/standards-data/ldml-keyboards/46/import/keys-Latn-implied.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright © 1991-2024 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<!--
+    This is the implied import for implied keys.
+    Please note that any implied keys may be overridden by keyboard layouts.
+ -->
+<!DOCTYPE keys SYSTEM "../dtd/ldmlKeyboard3.dtd">
+<keys>
+
+    <key id="gap" gap="true" width="1"/>
+    <key id="space" output="\u{0020}" stretch="true" width="1"/>
+
+    <key id="0" output="0"/>
+    <key id="1" output="1"/>
+    <key id="2" output="2"/>
+    <key id="3" output="3"/>
+    <key id="4" output="4"/>
+    <key id="5" output="5"/>
+    <key id="6" output="6"/>
+    <key id="7" output="7"/>
+    <key id="8" output="8"/>
+    <key id="9" output="9"/>
+    <key id="A" output="A"/>
+    <key id="B" output="B"/>
+    <key id="C" output="C"/>
+    <key id="D" output="D"/>
+    <key id="E" output="E"/>
+    <key id="F" output="F"/>
+    <key id="G" output="G"/>
+    <key id="H" output="H"/>
+    <key id="I" output="I"/>
+    <key id="J" output="J"/>
+    <key id="K" output="K"/>
+    <key id="L" output="L"/>
+    <key id="M" output="M"/>
+    <key id="N" output="N"/>
+    <key id="O" output="O"/>
+    <key id="P" output="P"/>
+    <key id="Q" output="Q"/>
+    <key id="R" output="R"/>
+    <key id="S" output="S"/>
+    <key id="T" output="T"/>
+    <key id="U" output="U"/>
+    <key id="V" output="V"/>
+    <key id="W" output="W"/>
+    <key id="X" output="X"/>
+    <key id="Y" output="Y"/>
+    <key id="Z" output="Z"/>
+    <key id="a" output="a"/>
+    <key id="b" output="b"/>
+    <key id="c" output="c"/>
+    <key id="d" output="d"/>
+    <key id="e" output="e"/>
+    <key id="f" output="f"/>
+    <key id="g" output="g"/>
+    <key id="h" output="h"/>
+    <key id="i" output="i"/>
+    <key id="j" output="j"/>
+    <key id="k" output="k"/>
+    <key id="l" output="l"/>
+    <key id="m" output="m"/>
+    <key id="n" output="n"/>
+    <key id="o" output="o"/>
+    <key id="p" output="p"/>
+    <key id="q" output="q"/>
+    <key id="r" output="r"/>
+    <key id="s" output="s"/>
+    <key id="t" output="t"/>
+    <key id="u" output="u"/>
+    <key id="v" output="v"/>
+    <key id="w" output="w"/>
+    <key id="x" output="x"/>
+    <key id="y" output="y"/>
+    <key id="z" output="z"/>
+</keys>

--- a/resources/standards-data/ldml-keyboards/46/import/keys-Zyyy-currency.xml
+++ b/resources/standards-data/ldml-keyboards/46/import/keys-Zyyy-currency.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright © 1991-2024 Unicode, Inc.
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<!DOCTYPE keys SYSTEM "../dtd/ldmlKeyboard3.dtd">
+<keys>
+    <key id="dollar" output="$" />
+    <key id="euro" output="€" />
+    <key id="pound" output="£" />
+    <key id="yen" output="¥" />
+    <key id="cruzeiro" output="₢" />
+    <key id="cent" output="¢" />
+</keys>

--- a/resources/standards-data/ldml-keyboards/46/import/keys-Zyyy-punctuation.xml
+++ b/resources/standards-data/ldml-keyboards/46/import/keys-Zyyy-punctuation.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright © 1991-2024 Unicode, Inc.
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<!DOCTYPE keys SYSTEM "../dtd/ldmlKeyboard3.dtd">
+<keys>
+    <!-- General Symbols -->
+    <key id="amp" output="\u{0026}" />
+    <key id="apos" output="'" />
+    <key id="asterisk" output="*" />
+    <key id="at" output="@" />
+    <key id="backslash" output="\u{005C}" />
+    <key id="bang" output="!" />
+    <key id="caret" output="^" />
+    <key id="close-angle" output=">" />
+    <key id="close-curly" output="}" />
+    <key id="close-paren" output=")" />
+    <key id="close-square" output="]" />
+    <key id="colon" output=":" />
+    <key id="comma" output="," />
+    <key id="degree" output="°" />
+    <key id="double-quote" output="\u{0022}" />
+    <key id="equal" output="=" />
+    <key id="grave" output="`" />
+    <key id="hash" output="#" />
+    <key id="hyphen" output="-" />
+    <key id="micro" output="µ" />
+    <key id="not" output="¬" />
+    <key id="open-angle" output="\u{003C}" />
+    <key id="open-curly" output="{" />
+    <key id="open-paren" output="(" />
+    <key id="open-square" output="[" />
+    <key id="percent" output="%" />
+    <key id="period" output="." />
+    <key id="pipe" output="|" />
+    <key id="plus" output="+" />
+    <key id="question" output="?" />
+    <key id="section" output="§" />
+    <key id="semi-colon" output=";" />
+    <key id="slash" output="/" />
+    <key id="tilde" output="~" />
+    <key id="underscore" output="_" />
+</keys>

--- a/resources/standards-data/ldml-keyboards/46/import/scanCodes-implied.xml
+++ b/resources/standards-data/ldml-keyboards/46/import/scanCodes-implied.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<forms>
+    <!--
+        These are the implied form values for hardware layouts.
+        Per the spec, this file is assumed to be imported into
+        every keyboard file.
+
+        Each row is a separate scanCodes element.
+        Values are space separated hex bytes.
+        Frame keys are not included.
+    -->
+
+    <form id="us">
+        <scanCodes codes="29 02 03 04 05 06 07 08 09 0A 0B 0C 0D" /> <!-- 13 keys, ` to = -->
+        <scanCodes codes="10 11 12 13 14 15 16 17 18 19 1A 1B 2B" /> <!-- 13 keys, Q to \ -->
+        <scanCodes codes="1E 1F 20 21 22 23 24 25 26 27 28" />  <!-- 11 keys, A to ' -->
+        <scanCodes codes="2C 2D 2E 2F 30 31 32 33 34 35" /> <!-- 10 keys, Z to / -->
+        <scanCodes codes="39" /> <!-- 1 key, spacebar -->
+    </form>
+    <form id="iso">
+        <scanCodes codes="29 02 03 04 05 06 07 08 09 0A 0B 0C 0D" /> <!-- 13 keys -->
+        <scanCodes codes="10 11 12 13 14 15 16 17 18 19 1A 1B" />    <!-- 12 keys -->
+        <scanCodes codes="1E 1F 20 21 22 23 24 25 26 27 28 2B" />    <!-- 12 keys -->
+        <scanCodes codes="56 2C 2D 2E 2F 30 31 32 33 34 35" />       <!-- 11 keys-->
+        <scanCodes codes="39" /> <!-- 1 key, spacebar -->
+    </form>
+    <form id="abnt2">
+        <scanCodes codes="29 02 03 04 05 06 07 08 09 0A 0B 0C 0D" /> <!-- 13 keys -->
+        <scanCodes codes="10 11 12 13 14 15 16 17 18 19 1A 1B" />    <!-- 12 keys -->
+        <scanCodes codes="1E 1F 20 21 22 23 24 25 26 27 28 2B" />    <!-- 12 keys -->
+        <scanCodes codes="56 2C 2D 2E 2F 30 31 32 33 34 35 73" />    <!-- 12 keys-->
+        <scanCodes codes="39" /> <!-- 1 key, spacebar -->
+    </form>
+    <form id="jis">
+        <scanCodes codes="29 02 03 04 05 06 07 08 09 0A 0B 0C 0D 7D" /> <!-- 14 keys -->
+        <scanCodes codes="10 11 12 13 14 15 16 17 18 19 1A 1B" />    <!-- 12 keys -->
+        <scanCodes codes="1E 1F 20 21 22 23 24 25 26 27 28 2B" />    <!-- 12 keys -->
+        <scanCodes codes="2C 2D 2E 2F 30 31 32 33 34 35 73" />       <!-- 11 keys-->
+        <scanCodes codes="39" /> <!-- 1 key, spacebar -->
+    </form>
+    <form id="ks">
+        <scanCodes codes="29 02 03 04 05 06 07 08 09 0A 0B 0C 0D 2B" /> <!-- 14 keys -->
+        <scanCodes codes="10 11 12 13 14 15 16 17 18 19 1A 1B" />    <!-- 12 keys -->
+        <scanCodes codes="1E 1F 20 21 22 23 24 25 26 27 28" />    <!-- 11 keys -->
+        <scanCodes codes="2C 2D 2E 2F 30 31 32 33 34 35" /> <!-- 10 keys, Z to / -->
+        <scanCodes codes="39" /> <!-- 1 key, spacebar -->
+    </form>
+
+    <!--
+        "touch" is not a hardware layout form, and so is not defined here.
+        <form id="touch"/>
+    -->
+</forms>

--- a/resources/standards-data/ldml-keyboards/46/ldml-keyboard3.schema.json
+++ b/resources/standards-data/ldml-keyboards/46/ldml-keyboard3.schema.json
@@ -1,0 +1,697 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "any": {
+      "type": "string"
+    },
+    "display": {
+      "additionalProperties": false,
+      "properties": {
+        "display": {
+          "type": "string"
+        },
+        "keyId": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "display"
+      ],
+      "type": "object"
+    },
+    "displayOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "baseCharacter": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "displays": {
+      "additionalProperties": false,
+      "properties": {
+        "display": {
+          "items": {
+            "$ref": "#/definitions/display"
+          },
+          "type": "array"
+        },
+        "displayOptions": {
+          "$ref": "#/definitions/displayOptions"
+        },
+        "import": {
+          "items": {
+            "$ref": "#/definitions/import"
+          },
+          "type": "array"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "flick": {
+      "additionalProperties": false,
+      "properties": {
+        "flickSegment": {
+          "items": {
+            "$ref": "#/definitions/flickSegment"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "id": {
+          "type": "string"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "flickSegment",
+        "id"
+      ],
+      "type": "object"
+    },
+    "flickSegment": {
+      "additionalProperties": false,
+      "properties": {
+        "directions": {
+          "type": "string"
+        },
+        "keyId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "directions",
+        "keyId"
+      ],
+      "type": "object"
+    },
+    "flicks": {
+      "additionalProperties": false,
+      "properties": {
+        "flick": {
+          "items": {
+            "$ref": "#/definitions/flick"
+          },
+          "type": "array"
+        },
+        "import": {
+          "items": {
+            "$ref": "#/definitions/import"
+          },
+          "type": "array"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "form": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "scanCodes": {
+          "items": {
+            "$ref": "#/definitions/scanCodes"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "scanCodes"
+      ],
+      "type": "object"
+    },
+    "forms": {
+      "additionalProperties": false,
+      "properties": {
+        "form": {
+          "items": {
+            "$ref": "#/definitions/form"
+          },
+          "type": "array"
+        },
+        "import": {
+          "items": {
+            "$ref": "#/definitions/import"
+          },
+          "type": "array"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "import": {
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "enum": [
+            "cldr"
+          ],
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "info": {
+      "additionalProperties": false,
+      "properties": {
+        "author": {
+          "type": "string"
+        },
+        "indicator": {
+          "type": "string"
+        },
+        "layout": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "key": {
+      "additionalProperties": false,
+      "properties": {
+        "flickId": {
+          "type": "string"
+        },
+        "gap": {
+          "enum": [
+            "true"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "layerId": {
+          "type": "string"
+        },
+        "longPressDefaultKeyId": {
+          "type": "string"
+        },
+        "longPressKeyIds": {
+          "type": "string"
+        },
+        "multiTapKeyIds": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        },
+        "stretch": {
+          "enum": [
+            "true"
+          ],
+          "type": "string"
+        },
+        "width": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "keys": {
+      "additionalProperties": false,
+      "properties": {
+        "import": {
+          "items": {
+            "$ref": "#/definitions/import"
+          },
+          "type": "array"
+        },
+        "key": {
+          "items": {
+            "$ref": "#/definitions/key"
+          },
+          "type": "array"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "layer": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "modifiers": {
+          "type": "string"
+        },
+        "row": {
+          "items": {
+            "$ref": "#/definitions/row"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "row"
+      ],
+      "type": "object"
+    },
+    "layers": {
+      "additionalProperties": false,
+      "properties": {
+        "formId": {
+          "type": "string"
+        },
+        "import": {
+          "items": {
+            "$ref": "#/definitions/import"
+          },
+          "type": "array"
+        },
+        "layer": {
+          "items": {
+            "$ref": "#/definitions/layer"
+          },
+          "type": "array"
+        },
+        "minDeviceWidth": {
+          "type": "string"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "formId"
+      ],
+      "type": "object"
+    },
+    "locale": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "locales": {
+      "additionalProperties": false,
+      "properties": {
+        "locale": {
+          "items": {
+            "$ref": "#/definitions/locale"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "reorder": {
+      "additionalProperties": false,
+      "properties": {
+        "before": {
+          "type": "string"
+        },
+        "from": {
+          "type": "string"
+        },
+        "order": {
+          "type": "string"
+        },
+        "preBase": {
+          "type": "string"
+        },
+        "tertiary": {
+          "type": "string"
+        },
+        "tertiaryBase": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "from"
+      ],
+      "type": "object"
+    },
+    "row": {
+      "additionalProperties": false,
+      "properties": {
+        "keys": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "keys"
+      ],
+      "type": "object"
+    },
+    "scanCodes": {
+      "additionalProperties": false,
+      "properties": {
+        "codes": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "codes"
+      ],
+      "type": "object"
+    },
+    "set": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "value"
+      ],
+      "type": "object"
+    },
+    "settings": {
+      "additionalProperties": false,
+      "properties": {
+        "normalization": {
+          "enum": [
+            "disabled"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "special": {
+      "$ref": "#/definitions/any"
+    },
+    "stringVariable": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "value"
+      ],
+      "type": "object"
+    },
+    "transform": {
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "from"
+      ],
+      "type": "object"
+    },
+    "transformGroup": {
+      "additionalProperties": false,
+      "properties": {
+        "import": {
+          "items": {
+            "$ref": "#/definitions/import"
+          },
+          "type": "array"
+        },
+        "reorder": {
+          "items": {
+            "$ref": "#/definitions/reorder"
+          },
+          "type": "array"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        },
+        "transform": {
+          "items": {
+            "$ref": "#/definitions/transform"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "transforms": {
+      "additionalProperties": false,
+      "properties": {
+        "import": {
+          "items": {
+            "$ref": "#/definitions/import"
+          },
+          "type": "array"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        },
+        "transformGroup": {
+          "items": {
+            "$ref": "#/definitions/transformGroup"
+          },
+          "type": "array"
+        },
+        "type": {
+          "enum": [
+            "simple",
+            "backspace"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "uset": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "value"
+      ],
+      "type": "object"
+    },
+    "variables": {
+      "additionalProperties": false,
+      "properties": {
+        "import": {
+          "items": {
+            "$ref": "#/definitions/import"
+          },
+          "type": "array"
+        },
+        "set": {
+          "items": {
+            "$ref": "#/definitions/set"
+          },
+          "type": "array"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        },
+        "string": {
+          "items": {
+            "$ref": "#/definitions/stringVariable"
+          },
+          "type": "array"
+        },
+        "uset": {
+          "items": {
+            "$ref": "#/definitions/uset"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "version": {
+      "additionalProperties": false,
+      "properties": {
+        "cldrVersion": {
+          "enum": [
+            "46"
+          ],
+          "type": "string"
+        },
+        "number": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "keyboard3": {
+      "additionalProperties": false,
+      "properties": {
+        "conformsTo": {
+          "enum": [
+            "45",
+            "46"
+          ],
+          "type": "string"
+        },
+        "displays": {
+          "$ref": "#/definitions/displays"
+        },
+        "flicks": {
+          "$ref": "#/definitions/flicks"
+        },
+        "forms": {
+          "$ref": "#/definitions/forms"
+        },
+        "import": {
+          "items": {
+            "$ref": "#/definitions/import"
+          },
+          "type": "array"
+        },
+        "info": {
+          "$ref": "#/definitions/info"
+        },
+        "keys": {
+          "$ref": "#/definitions/keys"
+        },
+        "layers": {
+          "items": {
+            "$ref": "#/definitions/layers"
+          },
+          "type": "array"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "locales": {
+          "$ref": "#/definitions/locales"
+        },
+        "settings": {
+          "$ref": "#/definitions/settings"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        },
+        "transforms": {
+          "items": {
+            "$ref": "#/definitions/transforms"
+          },
+          "type": "array"
+        },
+        "variables": {
+          "$ref": "#/definitions/variables"
+        },
+        "version": {
+          "$ref": "#/definitions/version"
+        },
+        "xmlns": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "info",
+        "locale",
+        "conformsTo"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "keyboard3"
+  ],
+  "title": "46/dtd/ldmlKeyboard3.xsd",
+  "type": "object"
+}

--- a/resources/standards-data/ldml-keyboards/46/ldml-keyboardtest3.schema.json
+++ b/resources/standards-data/ldml-keyboards/46/ldml-keyboardtest3.schema.json
@@ -1,0 +1,225 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "any": {
+      "type": "string"
+    },
+    "backspace": {
+      "type": "string"
+    },
+    "check": {
+      "additionalProperties": false,
+      "properties": {
+        "result": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "result"
+      ],
+      "type": "object"
+    },
+    "emit": {
+      "additionalProperties": false,
+      "properties": {
+        "to": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "to"
+      ],
+      "type": "object"
+    },
+    "info": {
+      "additionalProperties": false,
+      "properties": {
+        "author": {
+          "type": "string"
+        },
+        "keyboard": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "keyboard",
+        "name"
+      ],
+      "type": "object"
+    },
+    "keystroke": {
+      "additionalProperties": false,
+      "properties": {
+        "flick": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "longPress": {
+          "type": "string"
+        },
+        "tapCount": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object"
+    },
+    "repertoire": {
+      "additionalProperties": false,
+      "properties": {
+        "chars": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "default",
+            "simple",
+            "gesture",
+            "flick",
+            "longPress",
+            "multiTap",
+            "hardware"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "chars",
+        "name"
+      ],
+      "type": "object"
+    },
+    "special": {
+      "$ref": "#/definitions/any"
+    },
+    "startContext": {
+      "additionalProperties": false,
+      "properties": {
+        "to": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "to"
+      ],
+      "type": "object"
+    },
+    "test": {
+      "additionalProperties": false,
+      "properties": {
+        "backspace": {
+          "$ref": "#/definitions/backspace"
+        },
+        "check": {
+          "$ref": "#/definitions/check"
+        },
+        "emit": {
+          "$ref": "#/definitions/emit"
+        },
+        "keystroke": {
+          "$ref": "#/definitions/keystroke"
+        },
+        "name": {
+          "type": "string"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        },
+        "startContext": {
+          "$ref": "#/definitions/startContext"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "tests": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        },
+        "test": {
+          "items": {
+            "$ref": "#/definitions/test"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "test",
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "keyboardTest3": {
+      "additionalProperties": false,
+      "properties": {
+        "conformsTo": {
+          "enum": [
+            "techpreview"
+          ],
+          "type": "string"
+        },
+        "info": {
+          "$ref": "#/definitions/info"
+        },
+        "repertoire": {
+          "items": {
+            "$ref": "#/definitions/repertoire"
+          },
+          "type": "array"
+        },
+        "special": {
+          "items": {
+            "$ref": "#/definitions/special"
+          },
+          "type": "array"
+        },
+        "tests": {
+          "items": {
+            "$ref": "#/definitions/tests"
+          },
+          "type": "array"
+        },
+        "xmlns": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "info",
+        "conformsTo"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "keyboardTest3"
+  ],
+  "title": "46/dtd/ldmlKeyboardTest3.xsd",
+  "type": "object"
+}

--- a/resources/standards-data/ldml-keyboards/46/test/README.md
+++ b/resources/standards-data/ldml-keyboards/46/test/README.md
@@ -1,0 +1,395 @@
+# Technical Preview: CLDR Keyboard Test Data
+
+## <a name="Contents" href="#Contents">Contents of CLDR Keyboard Test Data</a>
+
+* [Keyboard Test Data](#keyboard-test-data)
+  * [Test Doctype](#test-doctype)
+  * [Test Element: keyboardTest](#test-element-keyboardtest)
+  * [Test Element: info](#test-element-info)
+  * [Test Element: repertoire](#test-element-repertoire)
+  * [Test Element: tests](#test-element-tests)
+  * [Test Element: test](#test-element-test)
+  * [Test Element: startContext](#test-element-startcontext)
+  * [Test Element: keystroke](#test-element-keystroke)
+  * [Test Element: emit](#test-element-emit)
+  * [Test Element: backspace](#test-element-backspace)
+  * [Test Element: check](#test-element-check)
+  * [Test Examples](#test-examples)
+* [Copyright and License](#copyright-and-license)
+
+## Keyboard Test Data
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+Keyboard Test Data allows the keyboard author to provide regression test data to validate the repertoire and behavior of a keyboard. Tooling can run these regression tests against an implementation, and can also be used as part of the development cycle to validate that keyboard changes do not deviate from expected behavior.  In the interest of complete coverage, tooling could also indicate whether all keys and gestures in a layout are exercised by the test data.
+
+Test data files have a separate DTD, named `ldmlKeyboardTest3.dtd`.  Note that multiple test data files can refer to the same keyboard. Test files should be named similarly to the keyboards which they test, such as `fr_test.xml` to test `fr.xml`.
+
+Sample test data files are located in the `keyboards/test` subdirectory.
+
+The following describes the structure of a keyboard test file.
+
+### Test Doctype
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboardTest3 SYSTEM "../dtd/ldmlKeyboardTest3.dtd">
+```
+
+The top level element is named `keyboardTest`.
+
+### Test Element: keyboardTest
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+> <small>
+>
+> Children: [info](#test-element-info), [repertoire](#test-element-repertoire), [_special_](tr35.md#special), [tests](#test-element-tests)
+> </small>
+
+This is the top level element.
+
+_Attribute:_ `conformsTo` (required)
+
+The `conformsTo` attribute value here is a fixed value of `techpreview`, because the test data is a Technical Preview.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboardTest3 SYSTEM "../dtd/ldmlKeyboardTest3.dtd">
+<keyboardTest3 conformsTo="techpreview">
+    …
+</keyboardTest3>
+```
+
+### Test Element: info
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+> <small>
+>
+> Parents: [keyboardTest](#test-element-keyboardtest)
+>>
+> Occurrence: Required, Single
+> </small>
+
+_Attribute:_ `author`
+
+This freeform attribute value allows for description of the author or authors of this test file.
+
+_Attribute:_ `keyboard` (required)
+
+This attribute value specifies the keyboard’s file name, such as `fr-t-k0-azerty.xml`.
+
+_Attribute:_ `name` (required)
+
+This attribute value specifies a name for this overall test file. These names could be output to the user during test execution, used to summarize success and failure, or used to select or deselect test components.
+
+**Example**
+
+```xml
+<info keyboard="fr-t-k0-azerty.xml" author="Team Keyboard" name="fr-test" />
+```
+
+### Test Element: repertoire
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+> <small>
+>
+> Parents: [keyboardTest](#test-element-keyboardtest)
+>
+> Children: _none_
+>
+> Occurrence: Optional, Multiple
+> </small>
+
+This element contains a repertoire test, to validate the available characters and their reachability. This test ensures that each of the specified characters is somehow typeable on the keyboard, after transforms have been applied. The characters in the repertoire will be matched against the complete set of possible generated outputs, post-transform, of all keys on the keyboard.
+
+_Attribute:_ `name` (required)
+
+This attribute value specifies a unique name for this repertoire test. These names could be output to the user during test execution, used to summarize success and failure, or used to select or deselect test components.
+
+_Attribute:_ `type`
+
+This attribute value is one of the following:
+
+|  type     | Meaning                                                                                                  |
+|-----------|----------------------------------------------------------------------------------------------------------|
+| default   | This is the default, indicates that _any_ gesture or keystroke may be used to generate each character    |
+| simple    | Each of the characters must be typeable by simple single keystrokes without needing any gestures.        |
+| gesture   | The characters are typeable by use of any gestures such as flicks, long presses, or multiple taps.       |
+| flick     | The characters are typeable by use of any `flick` element.                                               |
+| longPress | The characters are typeable by use of any `longPress` value.                                             |
+| multiTap  | The characters are typeable by use of any `multiTap` value.                                              |
+| hardware  | The characters are typeable by use of any simple keystrokes on any hardware layout.                      |
+
+_Attribute:_ `chars` (required)
+
+This attribute value specifies a list of characters in UnicodeSet format, which is specified in [UTS #35 Part One](tr35.md#Unicode_Sets).
+
+**Example**
+
+```xml
+<repertoire chars="[a b c d e \u{22}]" type="default" />
+
+<!-- taken from CLDR's common/main/fr.xml main exemplars - indicates that all of these characters should be reachable without requiring a gesture.
+Note that the 'name' is arbitrary. -->
+<repertoire name="cldr-fr-main" chars="[a à â æ b c ç d e é è ê ë f g h i î ï j k l m n o ô œ p q r s t u ù û ü v w x y ÿ z]" type="simple" />
+
+<!-- taken from CLDR's common/main/fr.xml auxiliary exemplars - indicates that all of these characters should be reachable even if a gesture is required.-->
+<repertoire name="cldr-fr-auxiliary" chars="[á å ä ã ā ć ē í ì ī ĳ ñ ó ò ö õ ø ř š ſ ß ú ǔ]" type="gesture" />
+
+```
+
+Note: CLDR’s extensive [exemplar set](tr35-general.md#Character_Elements) data may be useful in validating a language’s repertoire against a keyboard. Tooling may wish to make use of this data in order to suggest recommended repertoire values for a language.
+
+### Test Element: tests
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+
+> <small>
+>
+> Parents: [keyboardTest](#test-element-keyboardtest)
+>
+> Children: [_special_](tr35.md#special), [test](#test-element-test)
+>
+> Occurrence: Optional, Multiple
+> </small>
+
+This element specifies a particular suite of `<test>` elements.
+
+_Attribute:_ `name` (required)
+
+This attribute value specifies a unique name for this suite of tests. These names could be output to the user during test execution, used to summarize success and failure, or used to select or deselect test components.
+
+**Example**
+
+```xml
+<tests name="key-tests">
+    <test name="key-test">
+        …
+    </test>
+    <test name="gestures-test">
+        …
+    </test>
+</tests>
+<tests name="transform tests">
+    <test name="transform test">
+        …
+    </test>
+</tests>
+```
+
+### Test Element: test
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+
+> <small>
+>
+> Parents: [tests](#test-element-tests)
+>
+> Children: [startContext](#test-element-startcontext), [emit](#test-element-emit), [keystroke](#test-element-keystroke), [backspace](#test-element-backspace), [check](#test-element-check), [_special_](tr35.md#special)
+>
+> Occurrence: Required, Multiple
+> </small>
+
+This attribute value specifies a specific isolated regression test. Multiple test elements do not interact with each other.
+
+The order of child elements is significant, with cumulative effects: they must be processed from first to last.
+
+_Attribute:_ `name` (required)
+
+This attribute value specifies a unique name for this particular test. These names could be output to the user during test execution, used to summarize success and failure, or used to select or deselect test components.
+
+**Example**
+
+```xml
+<info keyboard="fr-t-k0-azerty.xml" author="Team Keyboard" name="fr-test" />
+```
+
+### Test Element: startContext
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+This element specifies pre-existing text in a document, as if prior to the user’s insertion point. This is useful for testing transforms and reordering. If not specified, the startContext can be considered to be the empty string ("").
+
+> <small>
+>
+> Parents: [test](#test-element-test)
+>
+> Children: _none_
+>
+> Occurrence: Optional, Single
+> </small>
+
+_Attribute:_ `to` (required)
+
+Specifies the starting context. This text may be escaped with `\u` notation, see [Escaping](#escaping).
+
+**Example**
+
+```xml
+<startContext to="abc\u{0022}"/>
+```
+
+
+### Test Element: keystroke
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+
+> <small>
+>
+> Parents: [test](#test-element-test)
+>
+> Children: _none_
+>
+> Occurrence: Optional, Multiple
+> </small>
+
+This element contains a single keystroke or other gesture event, identified by a particular key element.
+
+Optionally, one of the gesture attributes, either `flick`, `longPress`, or `tapCount` may be specified. If none of the gesture attribute values are specified, then a regular keypress is effected on the key.  It is an error to specify more than one gesture attribute.
+
+If a key is not found, or a particular gesture has no definition, the output should be behave as if the user attempted to perform such an action.  For example, an unspecified `flick` would result in no output.
+
+When a key is found, processing continues with the transform and other elements before updating the test output buffer.
+
+_Attribute:_ `key` (required)
+
+This attribute value specifies a key by means of the key’s `id` attribute.
+
+_Attribute:_ `flick`
+
+This attribute value specifies a flick gesture to be performed on the specified key instead of a keypress, such as `e` or `nw se`. This value corresponds to the `directions` attribute value of the [`<flickSegment>`](#element-flicksegment) element.
+
+_Attribute:_ `longPress`
+
+This attribute value specifies that a long press gesture should be performed on the specified key instead of a keypress. For example, `longPress="2"` indicates that the second character in a longpress series should be chosen. `longPress="0"` indicates that the `longPressDefault` value, if any, should be chosen. This corresponds to `longPress` and `longPressDefault` on [`<key>`](#element-key).
+
+_Attribute:_ `tapCount`
+
+This attribute value specifies that a multi-tap gesture should be performed on the specified key instead of a keypress. For example, `tapCount="3"` indicates that the key should be tapped three times in rapid succession. This corresponds to `multiTap` on [`<key>`](#element-key). The minimum tapCount is 2.
+
+**Example**
+
+```xml
+<keystroke key="q"/>
+<keystroke key="doublequote"/>
+<keystroke key="s" flick="nw se"/>
+<keystroke key="e" longPress="1"/>
+<keystroke key="E" tapCount="2"/>
+```
+
+### Test Element: emit
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+
+> <small>
+>
+> Parents: [test](#test-element-test)
+>
+> Children: _none_
+>
+> Occurrence: Optional, Multiple
+> </small>
+
+This element also contains an input event, except that the input is specified in terms of textual value rather than key or gesture identity. This element is particularly useful for testing transforms.
+
+Processing of the specified text continues with the transform and other elements before updating the test output buffer.
+
+_Attribute:_ `to` (required)
+
+This attribute value specifies a string of output text representing a single keystroke or gesture. This string is intended to match the output of a `key`, `flick`, `longPress` or `multiTap` element or attribute.
+Tooling should give a hint if this attribute value does not match at least one keystroke or gesture. Note that the specified text is not injected directly into the output buffer.
+
+This attribute value may be escaped with `\u` notation, see [Escaping](#escaping).
+
+**Example**
+
+```xml
+<emit to="s"/>
+```
+
+
+### Test Element: backspace
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+
+> <small>
+>
+> Parents: [test](#test-element-test)
+>
+> Children: _none_
+>
+> Occurrence: Optional, Multiple
+> </small>
+
+This element contains a backspace action, as if the user typed the backspace key
+
+**Example**
+
+```xml
+<backspace/>
+```
+
+### Test Element: check
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+
+> <small>
+>
+> Parents: [test](#test-element-test)
+>
+> Children: _none_
+>
+> Occurrence: Optional, Multiple
+> </small>
+
+This element contains a check on the current output buffer.
+
+_Attribute:_ `result` (required)
+
+This attribute value specifies the expected resultant text in a document after processing this event and all prior events, and including any `startContext` text.  This text may be escaped with `\u` notation, see [Escaping](#escaping).
+
+**Example**
+
+```xml
+<check result="abc\u{0022}s\u{0022}•éÈ"/>
+```
+
+
+### Test Examples
+
+```xml
+
+<test name="spec-sample">
+    <startContext to="abc\u{0022}"/>
+    <!-- simple, key specified by to -->
+    <emit to="s"/>
+    <check result="abc\u{0022}s"/>
+    <!-- simple, key specified by id -->
+    <keystroke key="doublequote"/>
+    <check result="abc\u{0022}s\u{0022}"/>
+    <!-- flick -->
+    <keystroke key="s" flick="nw se"/>
+    <check result="abc\u{0022}s\u{0022}•"/>
+    <!-- longPress -->
+    <keystroke key="e" longPress="1"/>
+    <check result="abc\u{0022}s\u{0022}•é"/>
+    <!-- multiTap -->
+    <keystroke key="E" tapCount="2"/>
+    <check result="abc\u{0022}s\u{0022}•éÈ"/>
+</test>
+```
+
+## Copyright and License
+
+See the top level [README.md](../../README.md#copyright--licenses)

--- a/resources/standards-data/ldml-keyboards/46/test/bn-test.xml
+++ b/resources/standards-data/ldml-keyboards/46/test/bn-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboardTest3 SYSTEM "../dtd/ldmlKeyboardTest3.dtd">
+<keyboardTest3 conformsTo="techpreview">
+    <info keyboard="bn.xml" author="Team Keyboard" name="bn-test" />
+    <tests name="tests">
+        <test name="au">
+            <keystroke key="ka"/>
+            <keystroke key="e"/>
+            <keystroke key="au-lengthener"/>
+            <check result="কৌ" /> <!-- ka + AU -->
+        </test>
+        <test name="greetings">
+          <keystroke key="śa"/>
+          <keystroke key="u"/>
+          <keystroke key="bha"/>
+          <keystroke key="e"/>
+          <keystroke key="ca"/>
+          <keystroke key="hasant"/>
+          <keystroke key="cha"/>
+          <keystroke key="ā"/>
+          <check result="শুভেচ্ছা"/>
+        </test>
+    </tests>
+</keyboardTest3>

--- a/resources/standards-data/ldml-keyboards/46/test/fr-t-k0-test-test.xml
+++ b/resources/standards-data/ldml-keyboards/46/test/fr-t-k0-test-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboardTest3 SYSTEM "../dtd/ldmlKeyboardTest3.dtd">
+<keyboardTest3 conformsTo="techpreview">
+    <info keyboard="fr-t-k0-test.xml" author="Team Keyboard" name="fr-test" />
+    <repertoire name="simple-repertoire" chars="[a b c d e \u{22}]" type="simple" /> <!-- verify that these outputs are all available from simple keys on any layer, for all form factors -->
+    <repertoire name="chars-repertoire" chars="[á é ó]" type="gesture" /> <!-- verify that these outputs are all available from simple or gesture keys on any layer, for touch -->
+    <tests name="key-tests">
+        <test name="key-test">
+            <startContext to="abc\u{0022}..."/>
+            <!-- tests by pressing key ids -->
+            <keystroke key="s"/>
+            <check result="abc\u{0022}...s" />
+            <keystroke key="t"/>
+            <check result="abc\u{0022}...st" />
+            <keystroke key="u"/>
+            <check result="abc\u{0022}...stu" />
+            <!-- tests by specifying 'to' output char -->
+            <emit to="v"/>
+            <check result="abc\u{0022}...stuv" />
+        </test>
+    </tests>
+</keyboardTest3>

--- a/resources/standards-data/ldml-keyboards/46/test/ja-Latn-test.xml
+++ b/resources/standards-data/ldml-keyboards/46/test/ja-Latn-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboardTest3 SYSTEM "../dtd/ldmlKeyboardTest3.dtd">
+<keyboardTest3 conformsTo="techpreview">
+	<info keyboard="ja-Latn.xml" author="Team Keyboard" name="ja-Latn-test" />
+	<repertoire name="latn-repertoire"
+		chars="[a-z A-Z 0-9 !\u{0022}#$%\u{0026}\[\]\{\}=\-|¥~\^_\u{0020}\u{003c}>,./?`@\+\*]" type="simple" />
+	<tests name="tests">
+		<test name="test1">
+			<startContext to="" /> <!-- empty startContext -->
+			<keystroke key="n" />
+			<keystroke key="m" />
+			<keystroke key="comma" />
+			<keystroke key="period" />
+			<keystroke key="slash" />
+			<check result="nm,./" />
+		</test>
+		<test name="test2">
+			<startContext to="" /> <!-- empty startContext -->
+			<keystroke key="open-square" />
+			<keystroke key="8" />
+			<keystroke key="9" />
+			<keystroke key="0" />
+			<keystroke key="pipe" />
+			<check result="[890|" />
+		</test>
+	</tests>
+</keyboardTest3>

--- a/resources/standards-data/ldml-keyboards/46/test/pcm-test.xml
+++ b/resources/standards-data/ldml-keyboards/46/test/pcm-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboardTest3 SYSTEM "../dtd/ldmlKeyboardTest3.dtd">
+<keyboardTest3 conformsTo="techpreview">
+  <info keyboard="pcm.xml" author="Team Keyboard" name="pcm-test" />
+  <repertoire name="simple-repertoire" chars="[a b c d e ọ Ọ ẹ Ẹ ₦]" type="simple" />
+  <tests name="key-tests">
+    <test name="abc-test">
+      <startContext to="abc" />
+      <keystroke key="d" />
+      <check result="abcd" />
+    </test>
+    <test name="dot-below-test">
+      <startContext to="" />
+      <keystroke key="e" />
+      <keystroke key="apos" />
+      <check result="e'" />
+      <keystroke key="apos" />
+      <check result="e\u{323}" />
+    </test>
+  </tests>
+</keyboardTest3>

--- a/resources/standards-data/ldml-keyboards/46/test/pt-t-k0-abnt2-test.xml
+++ b/resources/standards-data/ldml-keyboards/46/test/pt-t-k0-abnt2-test.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboardTest3 SYSTEM "../dtd/ldmlKeyboardTest3.dtd">
+<keyboardTest3 conformsTo="techpreview">
+    <info keyboard="pt-t-k0-abnt2.xml" author="Team Keyboard" name="pt-test" />
+    <repertoire name="latn-repertoire"
+        chars="[a-z A-Z 0-9 !\u{0022}#$%\u{0026}\[\]\{\}=\-|~_\u{0020}\u{003c}>,./?`@\+\*çÇ]"
+        type="simple" />
+    <repertoire name="currency-and-symbols"
+        chars="[₢ ° ¹²³ § ¬ ªº]" />
+    <tests name="tests">
+        <test name="test1">
+            <startContext to="" /> <!-- empty startContext -->
+            <keystroke key="n" />
+            <keystroke key="m" />
+            <keystroke key="comma" />
+            <keystroke key="period" />
+            <keystroke key="slash" />
+            <check result="nm,./" />
+        </test>
+        <test name="test2">
+            <startContext to="" /> <!-- empty startContext -->
+            <keystroke key="open-square" />
+            <keystroke key="8" />
+            <keystroke key="9" />
+            <keystroke key="0" />
+            <keystroke key="pipe" />
+            <check result="[890|" />
+        </test>
+        <test name="test3">
+            <startContext to="" /> <!-- empty startContext -->
+            <keystroke key="slash" />
+            <keystroke key="semi-colon" />
+            <keystroke key="backslash" />
+            <keystroke key="C-cedilla" />
+            <keystroke key="c-cedilla" />
+            <keystroke key="8" />
+            <keystroke key="ordinal-feminine" />
+            <check result="/;\u{005c}Çç8ª" />
+        </test>
+    </tests>
+</keyboardTest3>


### PR DESCRIPTION
- [ ] TODO: Per CLDR, rework this to treat 46-as-45.  I don't know if we're going to get metadata on this, but we could somehow diff 45/46 and from inspection build an alias list.

-----

- no schema, spec, or data change - just a version bump.

Fixes: #11307

See also: https://github.com/unicode-org/cldr/pull/4053

@keymanapp-test-bot skip