### PR TITLE
change(mac): remove verbose logging option

### DIFF
--- a/mac/Keyman4Mac/Keyman4Mac/AppDelegate.m
+++ b/mac/Keyman4Mac/Keyman4Mac/AppDelegate.m
@@ -45,8 +45,6 @@ NSString *const kKMXFileKey = @"KMXFile";
    NSArray *kvkFiles = [self KVKFiles];
    for (NSString *path in kvkFiles){
    KVKFile *kvkFile = [[KVKFile alloc] initWithFilePath:path];
-   if (debugMode)
-   NSLog(@"%@", kvkFile);
    }*/
 }
 
@@ -225,18 +223,6 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
       NSLog(@"%d: %@", index, kmStore);
       index++;
     }
-    
-    for (NSObject *gp in kmx.group) {
-      if (debugMode) {
-        NSLog(@"Group %@", gp);
-        //NSLog(@"match = %@", gp.match);
-        //NSLog(@"nomatch = %@", gp.noMatch);
-        /*
-         for (KMCompKey *kmKey in gp.keys) {
-         NSLog(@"\nKey: %@", kmKey);
-         }*/
-      }
-    }
   }
 }
 
@@ -257,9 +243,6 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     if (!infoDict)
       continue;
     
-    //if (debugMode)
-    //    NSLog(@"%@", infoDict);
-    //NSString *str = [NSString stringWithFormat:@"%@ (%@)", [infoDict objectForKey:kKMKeyboardNameKey], [infoDict objectForKey:kKMKeyboardVersionKey]];
     NSString *str = [infoDict objectForKey:kKMKeyboardNameKey];
     [kmxDesc addObject:str];
   }

--- a/mac/Keyman4Mac/Keyman4Mac/AppDelegate.m
+++ b/mac/Keyman4Mac/Keyman4Mac/AppDelegate.m
@@ -9,8 +9,6 @@
 #import "AppDelegate.h"
 #import <KeymanEngine4Mac/KeymanEngine4Mac.h>
 
-static BOOL debugMode = YES;
-
 BOOL isKeyMapEnabled;
 const unsigned short keyMapSize = 0x80;
 
@@ -116,7 +114,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     NSLog(@"AppDelegate eventTapFunction key down event: %@", event);
     // Key down event
     NSEvent *mEvent = [NSEvent eventWithCGEvent:event];
-    KMEngine *kme = [[KMEngine alloc] initWithKMX:kmx context:contextBuffer verboseLogging:debugMode];
+    KMEngine *kme = [[KMEngine alloc] initWithKMX:kmx context:contextBuffer];
     CoreKeyOutput *coreKeyOutput = [kme processEvent:mEvent];
     if (coreKeyOutput) {
       if (coreKeyOutput.hasTextToInsert) {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/Base.lproj/preferences.xib
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/Base.lproj/preferences.xib
@@ -2,8 +2,8 @@
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="22689"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
+        <plugIn identifier="com.apple.WebKitIBPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,8 +13,6 @@
                 <outlet property="supportForward" destination="OSG-wW-VHs" id="8dG-cd-ByI"/>
                 <outlet property="supportHome" destination="RUX-eW-d6h" id="i5g-Lo-6zG"/>
                 <outlet property="tableView" destination="epz-Md-JOY" id="fHy-6f-hXN"/>
-                <outlet property="useVerboseLoggingCheckBox" destination="uWx-3J-U0D" id="deO-CV-6KJ"/>
-                <outlet property="verboseLoggingInfo" destination="PiJ-pY-UY7" id="o0X-ZY-NKX"/>
                 <outlet property="webView" destination="gTQ-rF-m9S" id="u7r-Sf-QKb"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
             </connections>
@@ -209,29 +207,6 @@
                                 <view key="view" id="N1x-px-93m">
                                     <rect key="frame" x="10" y="33" width="754" height="538"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    <subviews>
-                                        <button toolTip="Turn this on if you are having problems with a specific keyboard or with Keyman in general." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uWx-3J-U0D">
-                                            <rect key="frame" x="15" y="483" width="200" height="18"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <buttonCell key="cell" type="check" title="Use verbose Console logging" bezelStyle="regularSquare" imagePosition="left" inset="2" id="7J6-zy-R20">
-                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                <font key="font" metaFont="system"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="useVerboseLoggingCheckBoxAction:" target="-2" id="DGX-fy-5qP"/>
-                                            </connections>
-                                        </button>
-                                        <textField hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PiJ-pY-UY7">
-                                            <rect key="frame" x="34" y="414" width="705" height="63"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="MrI-GM-7d6">
-                                                <font key="font" metaFont="system"/>
-                                                <string key="title">When the verbose logging option is on, Keyman will log actions that might help Keyman Support diagnose a problem. The Console program can be used to see a log of messages from Keyman. In Console, filter to show all messages from the "Keyman" process. This log can be exported and sent to Keyman support if needed.</string>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                    </subviews>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Support" identifier="3" id="93O-x6-RLF">

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -14,8 +14,6 @@
 @interface KMConfigurationWindowController ()
 @property (nonatomic, weak) IBOutlet NSTableView *tableView;
 @property (nonatomic, weak) IBOutlet WebView *webView;
-@property (nonatomic, weak) IBOutlet NSButton *useVerboseLoggingCheckBox;
-@property (nonatomic, weak) IBOutlet NSTextField *verboseLoggingInfo;
 @property (nonatomic, weak) IBOutlet NSButton *supportBack;
 @property (nonatomic, weak) IBOutlet NSButton *supportForward;
 @property (nonatomic, weak) IBOutlet NSButton *supportHome;
@@ -68,8 +66,6 @@
   
   NSURL *homeUrl = [[NSBundle mainBundle] URLForResource:@"index" withExtension:@"html" subdirectory:@"Help"];
   [self.webView.mainFrame loadRequest:[NSURLRequest requestWithURL:homeUrl]];
-  
-  [self.useVerboseLoggingCheckBox setState:(self.AppDelegate.useVerboseLogging ? NSOnState : NSOffState)];
 }
 
 - (void)webView:(WebView *)sender decidePolicyForNewWindowAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request newFrameName:(NSString *)frameName decisionListener:(id<WebPolicyDecisionListener>)listener {
@@ -435,13 +431,6 @@
   [self.window addChildWindow:self.AppDelegate.downloadKBWindow.window ordered:NSWindowAbove];
   [self.AppDelegate.downloadKBWindow.window centerInParent];
   [self.AppDelegate.downloadKBWindow.window makeKeyAndOrderFront:nil];
-}
-
-- (IBAction)useVerboseLoggingCheckBoxAction:(id)sender {
-  NSButton *checkBox = (NSButton *)sender;
-  BOOL verboseLoggingOn = checkBox.state == NSOnState;
-  [self.AppDelegate setUseVerboseLogging:verboseLoggingOn];
-  [self.verboseLoggingInfo setHidden:!verboseLoggingOn];
 }
 
 - (void)handleRequestToInstallPackage:(KMPackage *) package {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.h
@@ -89,9 +89,7 @@ static const int KEYMAN_FIRST_KEYBOARD_MENUITEM_INDEX = 0;
 @property (nonatomic, strong) NSString *downloadFilename;
 @property (nonatomic, strong) NSMutableData *receivedData;
 @property (nonatomic, assign) NSUInteger expectedBytes;
-@property (nonatomic, assign) BOOL useVerboseLogging;
 @property (nonatomic, assign) BOOL useNullChar;
-@property (nonatomic, assign) BOOL debugMode;
 
 - (NSMenu *)menu;
 - (void)saveActiveKeyboards;

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -64,16 +64,7 @@ id _lastServerWithOSKShowing = nil;
 
 - (id)init {
   self = [super init];
-  if (self) {
-#ifdef DEBUG
-    // If debugging, we'll turn it on by default, regardless of setting. If developer
-    // really wants it off, they can either change this line of code temporarily or
-    // go to the config screen and turn it off explicitly.
-    _debugMode = YES;
-#else
-    _debugMode = self.useVerboseLogging;
-#endif
-    
+  if (self) {    
     // first notify user and request access to Accessibility/PostEvent permissions
     // pass block as completion handler to complete init with initCompletion
     [PrivacyConsent.shared requestPrivacyAccess:^void (void){
@@ -384,7 +375,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 
 - (KMEngine *)kme {
   if (_kme == nil) {
-    _kme = [[KMEngine alloc] initWithKMX:nil context:self.contextBuffer verboseLogging:self.debugMode];
+    _kme = [[KMEngine alloc] initWithKMX:nil context:self.contextBuffer];
   }
   
   return _kme;
@@ -439,19 +430,6 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
     return [NSString stringWithFormat:@"Keyman"];
   else
     return [NSString stringWithFormat:@"%@ - Keyman", _keyboardName];
-}
-
-- (void)setUseVerboseLogging:(BOOL)useVerboseLogging {
-  os_log_debug([KMLogs configLog], "Turning verbose logging %{public}@", useVerboseLogging ? @"on." : @"off.");
-  _debugMode = useVerboseLogging;
-  if (_kme != nil)
-    [_kme setUseVerboseLogging:useVerboseLogging];
-
-  [[KMSettingsRepository shared] writeUseVerboseLogging:useVerboseLogging];
-}
-
-- (BOOL)useVerboseLogging {
-  return [[KMSettingsRepository shared] readUseVerboseLogging];
 }
 
 #pragma mark - Keyman Data
@@ -769,9 +747,7 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
   NSString *keyboardMenuName = @"";
   int menuItemIndex = KEYMAN_FIRST_KEYBOARD_MENUITEM_INDEX;
   
-  if (self.debugMode) {
-    os_log_info([KMLogs configLog], "*** populateKeyboardMenuItems, number of active keyboards=%lu", self.activeKeyboards.count);
-  }
+  os_log_debug([KMLogs configLog], "*** populateKeyboardMenuItems, number of active keyboards=%lu", self.activeKeyboards.count);
   
   // loop through the active keyboards list and add them to the menu
   for (NSString *path in self.activeKeyboards) {

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -45,11 +45,14 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
   _lowLevelBackspaceCount = 0;
   _queuedText = nil;
   
-  // In Xcode, if Keyman is the active IM and is in "debugMode" and "English plus Spanish" is 
-  // the current keyboard and you type "Sentry force now", it will force a simulated crash to 
+  BOOL forceSentryCrash = [KMSettingsRepository.shared readForceSentryError];
+  
+  // In Xcode, if Keyman is the active IM and the settings include the
+  // forceSentryCrash flag and "English plus Spanish" is the current keyboard
+  // and you type "Sentry force now", it will force a simulated crash to
   // test reporting to sentry.keyman.com
-  if ([self.appDelegate debugMode] && [clientAppId isEqual: @"com.apple.dt.Xcode"]) {
-    os_log_debug([KMLogs testLog], "Sentry - Preparing to detect Easter egg.");
+  if (forceSentryCrash && [clientAppId isEqual: @"com.apple.dt.Xcode"]) {
+    os_log_debug([KMLogs testLog], "initWithClient, preparing to force Sentry crash.");
     _easterEggForSentry = [[NSMutableString alloc] init];
   }
   else
@@ -66,9 +69,7 @@ NSString* const kEasterEggKmxName = @"EnglishSpanish.kmx";
   if (_generatedBackspaceCount > 0 || (_queuedText != nil && _queuedText.length > 0) ||
       _keyCodeOfOriginalEvent != 0 || _sourceFromOriginalEvent != nil)
   {
-    if ([self.appDelegate debugMode]) {
-      os_log_error([KMLogs lifecycleLog], "ERROR: new app activated before previous app finished processing pending events! _generatedBackspaceCount: %lu, _queuedText: '%{public}@' _keyCodeOfOriginalEvent: %hu", _generatedBackspaceCount, _queuedText == nil ? @"(NIL)" : (NSString*)[self queuedText], _keyCodeOfOriginalEvent);
-    }
+    os_log_error([KMLogs lifecycleLog], "ERROR: new app activated before previous app finished processing pending events! _generatedBackspaceCount: %lu, _queuedText: '%{public}@' _keyCodeOfOriginalEvent: %hu", _generatedBackspaceCount, _queuedText == nil ? @"(NIL)" : (NSString*)[self queuedText], _keyCodeOfOriginalEvent);
     _keyCodeOfOriginalEvent = 0;
     _generatedBackspaceCount = 0;
     _queuedText = nil;

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMSettingsRepository.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMSettingsRepository.h
@@ -26,8 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeOptionForSelectedKeyboard:(NSString *)key withValue:(NSString*)value;
 - (BOOL)readShowOskOnActivate;
 - (void)writeShowOskOnActivate:(BOOL)show;
-- (BOOL)readUseVerboseLogging;
-- (void)writeUseVerboseLogging:(BOOL)verboseLogging;
+- (BOOL)readForceSentryError;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMSettingsRepository.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMSettingsRepository.m
@@ -15,7 +15,7 @@ NSString *const kActiveKeyboardsKey = @"KMActiveKeyboardsKey";
 NSString *const kSelectedKeyboardKey = @"KMSelectedKeyboardKey";
 NSString *const kPersistedOptionsKey = @"KMPersistedOptionsKey";
 NSString *const kShowOskOnActivate = @"KMShowOskOnActivate";
-NSString *const kUseVerboseLogging = @"KMUseVerboseLogging";
+NSString *const kForceSentryError = @"KMForceSentryError";
 
 /**
  * The following constant "KMSavedStoresKey" is left here for documentation
@@ -30,6 +30,11 @@ NSString *const kKMDeprecatedPersistedOptionsKey = @"KMSavedStoresKey";
  * but the related UI has been removed according to issue #12342
  */
 NSString *const kAlwaysShowOSKKey = @"KMAlwaysShowOSKKey";
+/**
+ * The following constant "KMUseVerboseLogging" is left here for documentation
+ * but it is obsolete and removed issue #11525
+ */
+NSString *const kUseVerboseLogging = @"KMUseVerboseLogging";
 
 NSString *const kObsoletePathComponent = @"/Documents/Keyman-Keyboards";
 NSString *const kNewPathComponent = @"/Library/Application Support/keyman.inputmethod.Keyman/";
@@ -321,14 +326,9 @@ NSInteger const kCurrentDataModelVersionNumber = kVersionStoreDataInLibraryDirec
   [userData setBool:show forKey:kShowOskOnActivate];
 }
 
-- (BOOL)readUseVerboseLogging {
+- (BOOL)readForceSentryError {
   NSUserDefaults *userData = [NSUserDefaults standardUserDefaults];
-  return [userData boolForKey:kUseVerboseLogging];
-}
-
-- (void)writeUseVerboseLogging:(BOOL)verboseLogging {
-  NSUserDefaults *userData = [NSUserDefaults standardUserDefaults];
-  [userData setBool:verboseLogging forKey:kUseVerboseLogging];
+  return [userData boolForKey:kForceSentryError];
 }
 
 @end

--- a/mac/Keyman4MacIM/KeymanTests/TestAppDelegate.h
+++ b/mac/Keyman4MacIM/KeymanTests/TestAppDelegate.h
@@ -22,7 +22,6 @@ typedef void(^PostEventCallback)(CGEventRef eventToPost);
 @property (nonatomic, assign) CFMachPortRef lowLevelEventTap; // Always nil for tests
 @property (nonatomic, assign) BOOL contextChangingEventDetected;
 @property (nonatomic, assign) BOOL useNullChar;
-@property (nonatomic, assign) BOOL debugMode;
 @property (nonatomic, assign) CGKeyCode virtualKeyPosted;
 
 // Helper method

--- a/mac/Keyman4MacIM/KeymanTests/TestAppDelegate.m
+++ b/mac/Keyman4MacIM/KeymanTests/TestAppDelegate.m
@@ -16,7 +16,7 @@
 
 - (KMEngine *)kme {
   if (_kme == nil) {
-    _kme = [[KMEngine alloc] initWithKMX:nil context:self.contextBuffer verboseLogging:self.debugMode];
+    _kme = [[KMEngine alloc] initWithKMX:nil context:self.contextBuffer];
   }
   
   return _kme;
@@ -40,10 +40,6 @@
   if (_contextBuffer.length)
     [_contextBuffer replaceOccurrencesOfString:@"\0" withString:[NSString nullChar] options:0 range:NSMakeRange(0, 1)];
   [self.kme setCoreContextIfNeeded:self.contextBuffer];
-}
-
-- (BOOL)debugMode {
-  return YES;
 }
 
 -(NSEvent *)keyStrokeEventForCharacter:(NSString *)character keyCode:(unsigned short) keyCode {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreHelper.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreHelper.h
@@ -16,13 +16,10 @@ extern UInt32 VirtualKeyMap[0x80];
 
 @interface CoreHelper : NSObject
 
-@property (assign, nonatomic) BOOL debugMode;
-
 -(unichar const *) createUnicharStringFromNSString:(NSString *)string;
 -(NSString *) createNSStringFromUnicharString:(unichar const *)string;
 -(unsigned long long) unicharStringLength:(unichar const *)string;
 
--(instancetype)initWithDebugMode:(BOOL)debugMode;
 -(unsigned short) macVirtualKeyToWindowsVirtualKey:(unsigned short) keyCode;
 -(UTF32Char)macToKeymanModifier:(NSEventModifierFlags)modifiers;
 -(NSString*)utf32ValueToString:(UTF32Char)scalarValue;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreHelper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreHelper.m
@@ -69,10 +69,9 @@ UInt32 VirtualKeyMap[VIRTUAL_KEY_ARRAY_SIZE];
   return length;
 }
 
--(instancetype)initWithDebugMode:(BOOL)debugMode {
+-(instancetype)init {
   self = [super init];
   if (self) {
-    _debugMode = debugMode;
     [self initVirtualKeyMapping];
   }
   return self;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMEngine.h
@@ -18,16 +18,14 @@
 @interface KMEngine : NSObject
 
 @property (weak, nonatomic) KMXFile *kmx;
-@property (assign, nonatomic) BOOL debugMode;
 
-- (id)initWithKMX:(KMXFile *)kmx context:(NSString *)ctxBuf verboseLogging:(BOOL)enableDebugLogging;
+- (id)initWithKMX:(KMXFile *)kmx context:(NSString *)ctxBuf;
 - (NSString *)getCoreContextDebug;
 - (void)clearCoreContext;
 - (void)setCoreContextIfNeeded:(NSString *)context;
 
 - (void)setCoreOptions:(NSString *)key withValue:(NSString *)value;
 - (CoreKeyOutput *)processEvent:(NSEvent *)event;
-- (void)setUseVerboseLogging:(BOOL)useVerboseLogging;
 
 @end
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreTestStaticHelperMethods.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/CoreTestStaticHelperMethods.m
@@ -16,7 +16,7 @@
 + (CoreHelper *)helper {
   static CoreHelper *coreHelper = nil;
   if (coreHelper == nil) {
-    coreHelper = [[CoreHelper alloc] initWithDebugMode:YES];
+    coreHelper = [[CoreHelper alloc] init];
   }
   return coreHelper;
 }

--- a/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4MacTests/KMEngineTests.m
@@ -32,7 +32,7 @@ NSString * names[nCombinations];
 }
 
 - (void)testinitWithKMX_NilKmx_ProcessEventReturnsNil {
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:nil context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:nil context:@""];
   NSEvent *event = [[NSEvent alloc] init];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert(output == nil, @"Expected processEvent to return nil for nil kmx");
@@ -40,7 +40,7 @@ NSString * names[nCombinations];
 
 - (void)testinitWithKMX_ValidKmxEmptyContext_InitializedWithEmptyContext {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   XCTAssert(engine != nil, @"Expected non-nil engine");
   // Note: relying on km_core_state_context_debug output format is just barely
   // acceptable for a unit test
@@ -49,7 +49,7 @@ NSString * names[nCombinations];
 
 - (void)testinitWithKMX_ValidKmxNonEmptyContext_InitializedWithContext {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"abc" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"abc"];
   XCTAssert(engine != nil, @"Expected non-nil engine");
   // Note: relying on km_core_state_context_debug output format is just barely
   // acceptable for a unit test
@@ -58,7 +58,7 @@ NSString * names[nCombinations];
 
 - (void)testsetCoreContextIfNeeded_NonEmptyContext_InitialContextUpdated {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"a" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"a"];
   [engine setCoreContextIfNeeded:@"xyz"];
   // Note: relying on km_core_state_context_debug output format is just barely
   // acceptable for a unit test
@@ -69,7 +69,7 @@ NSString * names[nCombinations];
 /*
  - (void)testsetCoreContextIfNeeded_EmptyContext_InitialContextUpdated {
  KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
- KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+ KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
  [engine setCoreContextIfNeeded:@"xyz"];
  // Note: relying on km_core_state_context_debug output format is just barely
  // acceptable for a unit test
@@ -79,7 +79,7 @@ NSString * names[nCombinations];
 
 - (void)testprocessEvent_eventForCommandKey_ReturnsNilOutput {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:NSEventModifierFlagCommand timestamp:0 windowNumber:0 context:nil characters:@"a" charactersIgnoringModifiers:@"a" isARepeat:NO keyCode:kVK_ANSI_A];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert(output == nil, @"expected nil output from core");
@@ -87,7 +87,7 @@ NSString * names[nCombinations];
 
 - (void)testprocessEvent_eventWithoutKeycode_ReturnsNilOutput {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   NSEvent *event = [NSEvent mouseEventWithType:NSEventTypeMouseMoved location:NSMakePoint(29, 21) modifierFlags:NSEventModifierFlagShift timestamp:0 windowNumber:0 context:nil eventNumber:23 clickCount:0 pressure:0];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert(output == nil, @"nil CoreKeyOutput");
@@ -96,7 +96,7 @@ NSString * names[nCombinations];
 // TODO: shouldn't this return emitKeystroke = YES?
 - (void)testprocessEvent_eventForUnmappedKey_ReturnsNoActions {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"z" charactersIgnoringModifiers:@"z" isARepeat:NO keyCode:kVK_ANSI_Z];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert(output == nil, @"Expected nil array of actions");
@@ -104,7 +104,7 @@ NSString * names[nCombinations];
 
 - (void)testprocessEvent_eventForLowercaseA_ReturnsCharacterActionWithExpectedCharacterBasedOnKmx {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"a" charactersIgnoringModifiers:@"a" isARepeat:NO keyCode:kVK_ANSI_A];
   CoreKeyOutput *output = [engine processEvent:event];
   os_log_debug([KMELogs testLog], "output = %{public}@", output);
@@ -116,7 +116,7 @@ NSString * names[nCombinations];
 /*
  -(void)testprocessEvent_eventForCtrlShiftNumeralWithCipherMusicKmx_ReturnsQstrActionForCorrectUnicodeSurrogatePair {
  KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForCipherMusicTests];
- KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@"" verboseLogging:YES];
+ KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@""];
  for (int i = 1; i <= 6; i++)
  {
  unsigned short ansiCode = kVK_ANSI_1 + i - 1;
@@ -152,7 +152,7 @@ NSString * names[nCombinations];
 
 - (void)testprocessEvent_eventsForOpenCurlyBraceWithCipherMusicKmx_ReturnsCharacterForStartSlide {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForCipherMusicTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   UTF32Char expectedUtf32Char = 0x1D177;
   NSString * expectedStartSlideSurrogatePair = [[NSString alloc] initWithBytes:&expectedUtf32Char length:4 encoding:NSUTF32LittleEndianStringEncoding];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:NSEventModifierFlagShift timestamp:0 windowNumber:0 context:nil characters:@"{" charactersIgnoringModifiers:@"[" isARepeat:NO keyCode:kVK_ANSI_LeftBracket];
@@ -165,7 +165,7 @@ NSString * names[nCombinations];
  // TODO: fails with core, investigate
  - (void)testprocessEvent_eventForUnshiftedNumeralWithCipherMusicKmx_ReturnsCharacterActionToInsertNumeral {
  KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForCipherMusicTests];
- KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@"" verboseLogging:YES];
+ KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile contextBuffer:@""];
  for (int i = 1; i <= 9; i++)
  {
  unsigned short ansiCode = kVK_ANSI_1 + i - 1;
@@ -185,7 +185,7 @@ NSString * names[nCombinations];
 // TODO: fails with core, returns CharacterAction
 - (void)testprocessEvent_eventForShiftNumeralsWithoutRulesInCipherMusicKmx_ReturnsNoAction {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForCipherMusicTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   for (int i = 0; i <= 9; i++)
   {
     if (i == 6)
@@ -228,7 +228,7 @@ NSString * names[nCombinations];
 // TODO: fails with core, returns CharacterAction
 - (void)testprocessEvent_eventForPeriodWithCipherMusicKmx_ReturnsNoAction {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForCipherMusicTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"." charactersIgnoringModifiers:@"." isARepeat:NO keyCode:kVK_ANSI_Period];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert(!output.hasTextToInsert, @"expected no text to insert");
@@ -236,7 +236,7 @@ NSString * names[nCombinations];
 
 - (void)testprocessEvent_eventForCtrl8WithCipherMusicKmx_ReturnsEmit {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForCipherMusicTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:NSEventModifierFlagControl timestamp:0 windowNumber:0 context:nil characters:@"8" charactersIgnoringModifiers:@"8" isARepeat:NO keyCode:kVK_ANSI_8];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert(output.emitKeystroke, @"emitKeystroke == YES");
@@ -279,7 +279,7 @@ NSString * names[nCombinations];
   [KMEngineTests fillInNamesAndModifiersForAllChiralCombinations];
   
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   
   for (i = 0; i < nCombinations; i++) {
     [engine clearCoreContext];
@@ -346,7 +346,7 @@ NSString * names[nCombinations];
   [KMEngineTests fillInNamesAndModifiersForAllChiralCombinations];
   
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileTestMacEngine];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   
   for (i = 0; i < nCombinations; i++) {
     [engine clearCoreContext];
@@ -419,7 +419,7 @@ NSString * names[nCombinations];
 
 - (NSString *)checkPlatform_getOutputForKeystroke: (NSString*) character modifierFlags: (NSEventModifierFlags) flag keyCode:(unsigned short)code {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForPlatformTest];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   NSString *lcChar = [character lowercaseString];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:flag timestamp:0 windowNumber:0 context:nil characters:character charactersIgnoringModifiers:lcChar isARepeat:NO keyCode:code];
   CoreKeyOutput *output = [engine processEvent:event];
@@ -516,7 +516,7 @@ NSString * names[nCombinations];
 
 - (void)testEngine_ipaKeyboardAction_DoesNotCrash_Issue1892 {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForIndexOffsetTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"z" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"z"];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"a" charactersIgnoringModifiers:@"a" isARepeat:NO keyCode:kVK_ANSI_A];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert(output.hasCodePointsToDelete, @"output hasCodePointsToDelete == YES");
@@ -525,7 +525,7 @@ NSString * names[nCombinations];
 
 - (void)testCoreProcessEvent_eventForFWithElNuerKmx_ReturnsCorrectCharacter {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"f" charactersIgnoringModifiers:@"f" isARepeat:NO keyCode:kVK_ANSI_F];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert([output.textToInsert isEqualToString:@"ɣ"], @"Expected output to be 'ɣ'.");
@@ -535,7 +535,7 @@ NSString * names[nCombinations];
 
 - (void)testArmenianMnemonic_triggerPersistOptions_ReturnsOptions {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForArmenianMnemonicTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"√" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"√"];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"w" charactersIgnoringModifiers:@"w" isARepeat:NO keyCode:kVK_ANSI_W];
   CoreKeyOutput *output = [engine processEvent:event];
   NSString *key = @"option_ligature_ew";
@@ -546,7 +546,7 @@ NSString * names[nCombinations];
 
 - (void)testCoreProcessEvent_backspaceElNuerEmptyContext_PassesThrough {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@""];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\b" charactersIgnoringModifiers:@"\b" isARepeat:NO keyCode:kVK_Delete];
   CoreKeyOutput *output = [engine processEvent:event];
   os_log_debug([KMELogs testLog], "output = %{public}@", output);
@@ -557,7 +557,7 @@ NSString * names[nCombinations];
 
 - (void)testCoreProcessEvent_backspaceElNuerWithContext_EmptiesContextReturnsDelete {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"ɣ" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"ɣ"];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\b" charactersIgnoringModifiers:@"\b" isARepeat:NO keyCode:kVK_Delete];
   CoreKeyOutput *output = [engine processEvent:event];
   os_log_debug([KMELogs testLog], "output = %{public}@", output);
@@ -571,7 +571,7 @@ NSString * names[nCombinations];
 
 - (void)testCoreProcessEvent_eventReturnWithElNuerKmx_EmitWithContextEmpty {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"ɣ" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"ɣ"];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\n" charactersIgnoringModifiers:@"\n" isARepeat:NO keyCode:kVK_Return];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert(output.emitKeystroke, @"Expected emitKeystroke==YES");
@@ -583,7 +583,7 @@ NSString * names[nCombinations];
 
 - (void)testCoreProcessEvent_eventTabWithElNuerKmx_EmitWithContextEmpty {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"ɣ" verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:@"ɣ"];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"\t" charactersIgnoringModifiers:@"\t" isARepeat:NO keyCode:kVK_Tab];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert(output.emitKeystroke, @"Expected emitKeystroke==YES");
@@ -596,7 +596,7 @@ NSString * names[nCombinations];
 - (void)testCoreProcessEvent_eventSingleQuoteWithElNuerKmx_ReturnsDiacritic {
   KMXFile *kmxFile = [KeymanEngineTestsStaticHelperMethods getKmxFileForElNuerTests];
   NSString *context = @"ɛ";
-  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:context verboseLogging:YES];
+  KMEngine *engine = [[KMEngine alloc] initWithKMX:kmxFile context:context];
   NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0 windowNumber:0 context:nil characters:@"'" charactersIgnoringModifiers:@"'" isARepeat:NO keyCode:kVK_ANSI_Quote];
   CoreKeyOutput *output = [engine processEvent:event];
   XCTAssert(output.hasTextToInsert, @"returns text to insert");


### PR DESCRIPTION
In the Options tab of the Configuration window, removed the checkbox titled 'Use verbose Console logging'.
Also remove code related to debug mode. Instead of using the verbose logging option to determine whether we are in debug mode or not, write to the log based solely on the unified logging settings for Keyman. This change follows naturally from #11515.

Because the related UserDefaults setting is retired, introduce a new UserDefaults flag with a narrower scope to force a sentry crash for testing purposes. The key for this flag is "KMForceSentryError". It is not tied to any UI but can be set manually from the command line if needed for testing purposes.

Fixes: #11525

@keymanapp-test-bot skip