### PR TITLE
fix(core): add missing dependency for core

### DIFF
--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -16,6 +16,7 @@ builder_describe "Build Keyman Keyboard Compiler kmc" \
   "@/common/include" \
   "@/common/web/keyman-version" \
   "@/common/web/types" \
+  "@/core/include/ldml" \
   "@/developer/src/common/web/utils" \
   "@/developer/src/kmc-analyze" \
   "@/developer/src/kmc-keyboard-info" \


### PR DESCRIPTION
Core depends on `kmc` which in turn depends on `core/include/ldml`. This change adds the missing dependency to the build script and fixes building core from a clean `core` subdirectory.

@keymanapp-test-bot skip