### PR TITLE
chore(common): Allow to build offline

### DIFF
--- a/resources/build/builder.md
+++ b/resources/build/builder.md
@@ -327,6 +327,8 @@ The following parameters are pre-defined and should not be overridden:
 * `--no-color`: forces off ANSI color output for the script
 * `--verbose`, `-v`: verbose mode, sets the [`$builder_verbose`] variable
 * `--debug`, `-d`: debug build; see [`builder_is_debug_build`] for more detail
+* `--offline`: allow to build while offline. This might fail if not all
+  dependencies are cached.
 
 --------------------------------------------------------------------------------
 

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -40,6 +40,12 @@ function _builder_init() {
   else
     builder_use_color false
   fi
+
+  # Set shared Meson package cache (works with Meson >= 1.3)
+  if [[ -z ${MESON_PACKAGE_CACHE_DIR:-} ]]; then
+    export MESON_PACKAGE_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/keyman/builder"
+    mkdir -p "${MESON_PACKAGE_CACHE_DIR}"
+  fi
 }
 
 function _builder_findRepoRoot() {
@@ -416,6 +422,7 @@ _builder_execute_child() {
     ${child_options[@]} \
     $builder_verbose \
     $builder_debug \
+    $_builder_offline \
   && (
     if $_builder_debug_internal; then
       builder_echo success "## $action$target completed successfully"
@@ -1267,6 +1274,7 @@ _builder_parse_expanded_parameters() {
   _builder_chosen_options=()
   _builder_current_action=
   _builder_is_child=1
+  _builder_offline=
 
   local n=0
 
@@ -1398,6 +1406,9 @@ _builder_parse_expanded_parameters() {
         --builder-report-dependencies)
           # internal reporting function, ignores all other parameters
           _builder_report_dependencies
+          ;;
+        --offline)
+          _builder_offline=--offline
           ;;
         *)
           # script does not recognize anything of action or target form at this point.
@@ -1565,6 +1576,7 @@ builder_display_usage() {
   _builder_pad $width "  --debug, -d"    "Debug build"
   _builder_pad $width "  --color"        "Force colorized output"
   _builder_pad $width "  --no-color"     "Never use colorized output"
+  _builder_pad $width "  --offline"      "Try to build while being offline"
   if builder_has_dependencies; then
     _builder_pad $width "  --deps"         "Build dependencies if required (default)"
     _builder_pad $width "  --no-deps"      "Skip build of dependencies"
@@ -1731,6 +1743,7 @@ _builder_do_build_deps() {
     "$REPO_ROOT/$dep/build.sh" "configure$dep_target" "build$dep_target" \
       $builder_verbose \
       $builder_debug \
+      $_builder_offline \
       $_builder_build_deps \
       --builder-dep-parent "$THIS_SCRIPT_IDENTIFIER" && (
       if $_builder_debug_internal; then
@@ -1759,6 +1772,18 @@ builder_is_dep_build() {
 #
 builder_is_child_build() {
   return $_builder_is_child
+}
+
+#
+# return `1` for a regular build, `0` to try to build while being offline.
+# The offline build might fail if not all dependencies are cached.
+#
+builder_try_offline() {
+  if [[ "${_builder_offline}" == "--offline" ]]; then
+    return 0
+  else
+    return 1
+  fi
 }
 
 #

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -267,7 +267,12 @@ verify_npm_setup() {
 
   pushd "$KEYMAN_ROOT" > /dev/null
 
-  try_multiple_times npm ci
+  offline_param=
+  if builder_try_offline; then
+    builder_echo "Trying offline build"
+    offline_param=--prefer-offline
+  fi
+  try_multiple_times npm ${offline_param} ci
 
   popd > /dev/null
 }


### PR DESCRIPTION
A lot of the `configure` actions rely on node dependencies and so call `npm install`. Without a internet connection this hangs forever, even if you had successfully installed the dependencies before and nothing changed since then. This change adds a `--offline` parameter that passes `--prefer-offline` to npm, which causes npm to use the cached dependencies.

Also sets the `MESON_PACKAGE_CACHE_DIR` environment variable so that all (sub-)projects share the same package cache dir. This will speed up regular builds a bit (e.g. `developer/src/kmcmplib` and `core` both have `icu4c` as a dependency), but will also help with offline builds.

`MESON_PACKAGE_CACHE_DIR` requires Meson 1.3, however older Meson versions ignore this environment variable and simply continue to use a cache per subproject, so will continue to work (minus offline builds).

@keymanapp-test-bot skip