### PR TITLE
fix(common): add proper configure output for hextobin

### DIFF
--- a/common/tools/hextobin/build.sh
+++ b/common/tools/hextobin/build.sh
@@ -11,7 +11,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 builder_describe "Build hextobin" clean configure build
 builder_describe_outputs \
-  configure /node_modules \
+  configure /common/tools/hextobin/node_modules/commander \
   build     /common/tools/hextobin/build/index.js
 
 builder_parse "$@"


### PR DESCRIPTION
This change fixes a dependency problem when building Core. Previously this failed on a clean source tree because hextobin was missing dependencies but didn't run its `configure` action if the top-level `node_modules` folder did already exist.

@keymanapp-test-bot skip