### PR TITLE
fix(android): Hide suggestion banner on password fields

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
@@ -164,7 +164,7 @@ public final class KMKeyboardWebViewClient extends WebViewClient {
       // appContext instead of context?
       SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
       boolean modelPredictionPref = false;
-      if (KMManager.currentLexicalModel != null) {
+      if (!KMManager.getMayPredictOverride() && KMManager.currentLexicalModel != null) {
         modelPredictionPref = prefs.getBoolean(KMManager.getLanguagePredictionPreferenceKey(KMManager.currentLexicalModel.get(KMManager.KMKey_LanguageID)), true);
       }
       KMManager.setBannerOptions(modelPredictionPref);


### PR DESCRIPTION
Fixes #12441 and needs to :cherries: pick to stable-17.0

This adds a check in System Keyboard to disable suggestion banner on certain fields (e.g. password field)

## User Testing
* **Setup** - Install the PR build of Keyman for Android on an Android device/emulator

* **TEST_BANNER_DISABLED_ON_PASSWORD** - Verifies suggestion banner is disabled on certain fields
1. Launch Keyman for Android
2. On the Get Started menu, set Keyman as the default system keyboard
3. Launch Chrome and select a text area
4. With Keyman selected as the system keyboard, verify the OSK displays suggestions as you type
5. On Chrome, go to a page with password fields (e.g. https://darcywong00.github.io/examples/form.html). That page is small so you may need to zoom in
7. On the test page, select the "Visible Text Field"
8. Verify the OSK displays suggestions as you type
9. On the test page, select the "Password Field"
10. Verify the OSK disables suggestions (replaced with the Keyman banner) as you type
11. On the test page, select "Search Field"
12. Verify the OSK re-enables suggestions as you type
