### PR TITLE
fix(developer): use richedit in debug memo to support Egyptian cartouches

### DIFF
--- a/developer/src/common/delphi/components/Keyman.Developer.UI.RichEdit41.pas
+++ b/developer/src/common/delphi/components/Keyman.Developer.UI.RichEdit41.pas
@@ -1,0 +1,150 @@
+unit Keyman.Developer.UI.RichEdit41;
+
+interface
+
+uses
+  Vcl.Controls,
+  Vcl.ComCtrls,
+  Vcl.Themes,
+  Winapi.Windows;
+
+type
+  TRichEdit41 = class(TCustomRichEdit)
+  strict private
+    class constructor Create;
+    class destructor Destroy;
+  protected
+    procedure CreateParams(var Params: TCreateParams); override;
+  published
+    property Align;
+    property Alignment;
+    property Anchors;
+    property BevelEdges;
+    property BevelInner;
+    property BevelOuter;
+    property BevelKind default bkNone;
+    property BevelWidth;
+    property BiDiMode;
+    property BorderStyle;
+    property BorderWidth;
+    property Color;
+    property Ctl3D;
+    property DragCursor;
+    property DragKind;
+    property DragMode;
+    property Enabled;
+    property Font;
+    property HideSelection;
+    property HideScrollBars;
+    property ImeMode;
+    property ImeName;
+    property Constraints;
+    property Lines;
+    property MaxLength;
+    property ParentBiDiMode;
+    property ParentColor;
+    property ParentCtl3D;
+    property ParentFont;
+    property ParentShowHint;
+    property PlainText;
+    property PopupMenu;
+    property ReadOnly;
+    property ScrollBars;
+    property ShowHint;
+    property TabOrder;
+    property TabStop default True;
+    property Touch;
+    property Visible;
+    property WantTabs;
+    property WantReturns;
+    property WordWrap;
+    property StyleElements;
+    property Zoom;
+    property OnChange;
+    property OnClick;
+    property OnContextPopup;
+    property OnDblClick;
+    property OnDragDrop;
+    property OnDragOver;
+    property OnEndDock;
+    property OnEndDrag;
+    property OnEnter;
+    property OnExit;
+    property OnGesture;
+    property OnKeyDown;
+    property OnKeyPress;
+    property OnKeyUp;
+    property OnMouseActivate;
+    property OnMouseDown;
+    property OnMouseEnter;
+    property OnMouseLeave;
+    property OnMouseMove;
+    property OnMouseUp;
+    property OnMouseWheel;
+    property OnMouseWheelDown;
+    property OnMouseWheelUp;
+    property OnProtectChange;
+    property OnResizeRequest;
+    property OnSaveClipboard;
+    property OnSelectionChange;
+    property OnStartDock;
+    property OnStartDrag;
+  end;
+
+procedure Register;
+
+implementation
+
+uses
+  System.Classes,
+  Winapi.RichEdit;
+
+{ TRichEdit41 }
+
+class constructor TRichEdit41.Create;
+begin
+  TCustomStyleEngine.RegisterStyleHook(TRichEdit41, TRichEditStyleHook);
+end;
+
+class destructor TRichEdit41.Destroy;
+begin
+  TCustomStyleEngine.UnRegisterStyleHook(TRichEdit41, TRichEditStyleHook);
+end;
+
+var
+  FRichEditModule: THandle = 0;
+
+procedure TRichEdit41.CreateParams(var Params: TCreateParams);
+const
+  HideScrollBars: array[Boolean] of DWORD = (ES_DISABLENOSCROLL, 0);
+  HideSelections: array[Boolean] of DWORD = (ES_NOHIDESEL, 0);
+  RichEditClassName = 'RICHEDIT50W';
+  RichEditModuleName = 'MSFTEDIT.DLL';
+begin
+  if FRichEditModule = 0 then
+  begin
+    FRichEditModule := LoadLibrary(RichEditModuleName);
+    if FRichEditModule <= HINSTANCE_ERROR then FRichEditModule := 0;
+  end;
+
+  inherited CreateParams(Params);
+
+  CreateSubClass(Params, RichEditClassName);
+
+  with Params do
+  begin
+    Style := Style or HideScrollBars[Self.HideScrollBars] or
+      HideSelections[HideSelection];
+  end;
+end;
+
+procedure Register;
+begin
+  RegisterComponents('Keyman', [TRichEdit41]);
+end;
+
+initialization
+finalization
+  if FRichEditModule <> 0 then FreeLibrary(FRichEditModule);
+end.
+

--- a/developer/src/common/delphi/components/KeymanDeveloperDebuggerMemo.pas
+++ b/developer/src/common/delphi/components/KeymanDeveloperDebuggerMemo.pas
@@ -1,18 +1,18 @@
 (*
   Name:             KeymanDeveloperDebuggerMemo
   Copyright:        Copyright (C) 2003-2017 SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      8 Jun 2012
 
   Modified Date:    8 Jun 2012
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          08 Jun 2012 - mcdurdin - I3323 - V9.0 - Extract debug-related code TPlus-Memo into subclass
 *)
 unit KeymanDeveloperDebuggerMemo;  // I3323
@@ -24,6 +24,7 @@ uses
   Winapi.Messages,
   Winapi.Windows,
   Vcl.Controls,
+  Vcl.ComCtrls,
   Vcl.StdCtrls;
 
 type
@@ -34,7 +35,7 @@ type
     Anchor: Integer;
   end;
 
-  TKeymanDeveloperDebuggerMemo = class(TMemo)
+  TKeymanDeveloperDebuggerMemo = class(TRichEdit)
   private
     FOnMessage: TKeymanDeveloperDebuggerMessageEvent;
     FAllowUnicodeInput: Boolean;
@@ -77,6 +78,7 @@ constructor TKeymanDeveloperDebuggerMemo.Create(AOwner: TComponent);
 begin
   FAllowUnicodeInput := True;
   inherited Create(AOwner);
+  PlainText := True;
 end;
 
 procedure TKeymanDeveloperDebuggerMemo.CreateHandle;

--- a/developer/src/tike/child/Keyman.Developer.UI.Debug.UfrmLdmlKeyboardDebug.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.Debug.UfrmLdmlKeyboardDebug.pas
@@ -831,12 +831,22 @@ begin
 end;
 
 procedure TfrmLdmlKeyboardDebug.UpdateCharacterGrid;   // I4808
+var
+  start, len: Integer;
 begin
   if csDestroying in ComponentState then
     Exit;
 
-  TCharacterGridRenderer.Fill(sgChars, memo.Text, FDeadkeys, memo.SelStart,
-    memo.SelLength, memo.Selection.Anchor, True);
+  start := memo.SelStart;
+  len := memo.SelLength;
+  if start + len > Length(memo.Text) then
+  begin
+    // RichEdit has a virtual final character, which is selected when
+    // pressing Ctrl+A, etc.
+    len := Length(memo.Text) - start;
+  end;
+  TCharacterGridRenderer.Fill(sgChars, memo.Text, FDeadkeys, start, len
+    memo.Selection.Anchor, True);
   TCharacterGridRenderer.Size(sgChars, memo.Font);
 end;
 

--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -1354,11 +1354,22 @@ begin
 end;
 
 procedure TfrmDebug.UpdateCharacterGrid;   // I4808
+var
+  start, len: Integer;
 begin
   if csDestroying in ComponentState then
     Exit;
 
-  TCharacterGridRenderer.Fill(sgChars, memo.Text, FDeadkeys, memo.SelStart, memo.SelLength, memo.Selection.Anchor);
+  start := memo.SelStart;
+  len := memo.SelLength;
+  if start + len > Length(memo.Text) then
+  begin
+    // RichEdit has a virtual final character, which is selected when
+    // pressing Ctrl+A, etc.
+    len := Length(memo.Text) - start;
+  end;
+
+  TCharacterGridRenderer.Fill(sgChars, memo.Text, FDeadkeys, start, len, memo.Selection.Anchor);
   TCharacterGridRenderer.Size(sgChars, memo.Font);
 end;
 

--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -583,10 +583,6 @@ begin
   finally
     FRunning := False;
     EnableUI;
-    UpdateCharacterGrid;
-    // We want to refresh the memo and character grid for rapid typing
-    memo.Update;
-    sgChars.Update;
   end;
 
   if UIStatus <> duiTest then
@@ -802,8 +798,13 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
       Assert(False, AssertionMessage); // Unrecognised backspace type
     end;
 
-    memo.Text := Copy(memo.Text, 1, m) + Copy(memo.Text, n+1, MaxInt);
-    memo.SelStart := m;
+    memo.Lines.BeginUpdate;
+    try
+      memo.Text := Copy(memo.Text, 1, m) + Copy(memo.Text, n+1, MaxInt);
+      memo.SelStart := m;
+    finally
+      memo.Lines.EndUpdate;
+    end;
 
     RealignMemoSelectionState(state);
   end;
@@ -1346,7 +1347,7 @@ begin
     frmKeymanDeveloper.barStatus.Panels[0].Text := 'Debugger Active';
   end;
 
-  if not memo.ReadOnly then
+  if not memo.ReadOnly and not memo.SelectionChanging then
   begin
     FSavedSelection := memo.Selection;
     UpdateCharacterGrid;   // I4808

--- a/developer/src/tike/tike.dpr
+++ b/developer/src/tike/tike.dpr
@@ -299,7 +299,8 @@ uses
   Keyman.Developer.System.ProjectOwningFile in 'main\Keyman.Developer.System.ProjectOwningFile.pas',
   Keyman.Developer.System.Main in 'main\Keyman.Developer.System.Main.pas',
   Keyman.Developer.System.LaunchProjects in 'main\Keyman.Developer.System.LaunchProjects.pas',
-  Keyman.System.Debug.DebugUtils in 'debug\Keyman.System.Debug.DebugUtils.pas';
+  Keyman.System.Debug.DebugUtils in 'debug\Keyman.System.Debug.DebugUtils.pas',
+  Keyman.Developer.UI.RichEdit41 in '..\common\delphi\components\Keyman.Developer.UI.RichEdit41.pas';
 
 {$R *.RES}
 {$R ICONS.RES}

--- a/developer/src/tike/tike.dproj
+++ b/developer/src/tike/tike.dproj
@@ -584,6 +584,7 @@
         <DCCReference Include="main\Keyman.Developer.System.Main.pas"/>
         <DCCReference Include="main\Keyman.Developer.System.LaunchProjects.pas"/>
         <DCCReference Include="debug\Keyman.System.Debug.DebugUtils.pas"/>
+        <DCCReference Include="..\common\delphi\components\Keyman.Developer.UI.RichEdit41.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>


### PR DESCRIPTION
RichEdit allows text selection one character past end-of-string, so we need to cater for that as well in passing text ranges to the character grid.

Note: in draft as this uses RichEdit 2.0 which has other spacing issues for complex scripts (e.g. Khmer), need to be basing on RichEdit 4.1 preferably.

Fixes: #12454

# User Testing

* **TEST_KMN_DEBUGGER:** In Keyman Developer, open a Keyman .kmn keyboard, and press F5 to start the debugger. Run through a number of normal operations in the debugger, selecting text, typing, etc, and look for any unexpected display issues or anomalies. Pass this test if no issues are encountered.

* **TEST_LDML_DEBUGGER:** In Keyman Developer, open or create a Keyman LDML keyboard, and press F5 to start the debugger. Run through a number of normal operations in the debugger, selecting text, typing, etc, and look for any unexpected display issues or anomalies. Pass this test if no issues are encountered.
