### PR TITLE
fix(developer): ignore excess whitespace in `<row keys>` attribute

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/layr.ts
+++ b/developer/src/kmc-ldml/src/compiler/layr.ts
@@ -63,7 +63,7 @@ export class LayrCompiler extends SectionCompiler {
       for (const layer of layers.layer) {
         const rows = layer.row.map((row) => {
           const erow: LayrRow = {
-            keys: row.keys.split(' ').map((id) => sections.strs.allocString(id)),
+            keys: row.keys.trim().split(/[ \t]+/).map((id) => sections.strs.allocString(id)),
           };
           return erow;
         });

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/row-keys-whitespace.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/row-keys-whitespace.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+  <info name="keys-minimal"/>
+
+  <keys>
+    <key id="grave" output="🪦" />
+    <key id="mistake" output="oops" />
+  </keys>
+
+  <layers formId="us">
+    <layer id="base">
+      <row keys=" grave mistake" />
+      <row keys="   grave   mistake " />
+    </layer>
+  </layers>
+
+</keyboard3>

--- a/developer/src/kmc-ldml/test/test-layr.ts
+++ b/developer/src/kmc-ldml/test/test-layr.ts
@@ -135,5 +135,30 @@ describe('layr', function () {
         LdmlCompilerMessages.Error_InvalidModifier({ layer: '', modifiers: 'caps bogus'}),
       ]
     },
+    {
+      subpath: 'sections/layr/row-keys-whitespace.xml',
+      callback(sect) {
+        const layr = <Layr> sect;
+        assert.ok(layr);
+        assert.equal(compilerTestCallbacks.messages.length, 0);
+
+        assert.equal(layr.lists?.length, 1);
+        const list0 = layr.lists[0];
+        assert.ok(list0);
+        assert.equal(list0.layers.length, 1);
+        assert.equal(list0.hardware.value, 'us');
+        const layer0 = list0.layers[0];
+        assert.ok(layer0);
+        assert.equal(layer0.rows.length, 2);
+        assert.equal(layer0.id.value, 'base');
+        assert.equal(layer0.mod, constants.keys_mod_none);
+        for(const row of layer0.rows) {
+          assert.ok(row);
+          assert.equal(row.keys.length, 2);
+          assert.equal(row.keys[0]?.value, 'grave');
+          assert.equal(row.keys[1]?.value, 'mistake');
+        }
+      },
+    },
   ]);
 });


### PR DESCRIPTION
Fixes: #12449

@keymanapp-test-bot skip