### PR TITLE
fix(linux): ignore additional C++ symbol in API check

### DIFF
--- a/linux/debian/libkeymancore2.symbols
+++ b/linux/debian/libkeymancore2.symbols
@@ -2,6 +2,7 @@ libkeymancore.so.2 libkeymancore2 #MINVER#
 * Build-Depends-Package: libkeymancore-dev
 
  (c++|optional)"typeinfo name for std::codecvt_utf8_utf16<char16_t, 1114111ul, (std::codecvt_mode)0>@Base" 17.0.244
+ (c++|optional)std::piecewise_construct@Base 18.0.118
  km_core_context_clear@Base 17.0.195
  km_core_context_get@Base 17.0.195
  km_core_context_item_list_size@Base 17.0.195


### PR DESCRIPTION
I have no idea why this C++ symbol suddenly shows up in the API check, but since it's not part of our API we can ignore it.

@keymanapp-test-bot skip