### PR TITLE
chore(linux): display branch name with API verification

### DIFF
--- a/.github/workflows/api-verification.yml
+++ b/.github/workflows/api-verification.yml
@@ -1,4 +1,5 @@
 name: "API Verification"
+run-name: "API Verification for ${{ github.ref_name }}"
 on:
  workflow_run:
     workflows: [Ubuntu packaging]


### PR DESCRIPTION
This change adds the branch name to the API verification workflow so that it's easier to see which run belongs to which PR or branch build.

@keymanapp-test-bot skip