### PR TITLE
chore(common): improve configuration detection for hextobin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ lcov.info
 /keyman*.buildinfo
 /keyman*.changes
 /keyman*.tar.?z
+
+# flag file for build script
+.configured

--- a/common/tools/hextobin/build.sh
+++ b/common/tools/hextobin/build.sh
@@ -11,7 +11,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 builder_describe "Build hextobin" clean configure build
 builder_describe_outputs \
-  configure /common/tools/hextobin/node_modules/commander \
+  configure /common/tools/hextobin/build/.configured \
   build     /common/tools/hextobin/build/index.js
 
 builder_parse "$@"

--- a/common/tools/hextobin/build.sh
+++ b/common/tools/hextobin/build.sh
@@ -11,7 +11,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 builder_describe "Build hextobin" clean configure build
 builder_describe_outputs \
-  configure /common/tools/hextobin/build/.configured \
+  configure /common/tools/hextobin/.configured \
   build     /common/tools/hextobin/build/index.js
 
 builder_parse "$@"

--- a/common/tools/hextobin/package.json
+++ b/common/tools/hextobin/package.json
@@ -17,6 +17,6 @@
     "hextobin": "build/hextobin.js"
   },
   "scripts": {
-    "postinstall": "node --eval \"const fs =require('fs'); const path = require('path'); var dir = 'build'; if (!fs.existsSync(dir)) { fs.mkdirSync(dir); } fs.writeFileSync(path.join(dir, '.configured'), '');\""
+    "postinstall": "echo configured > .configured"
   }
 }

--- a/common/tools/hextobin/package.json
+++ b/common/tools/hextobin/package.json
@@ -15,5 +15,8 @@
   "main": "build/index.js",
   "bin": {
     "hextobin": "build/hextobin.js"
+  },
+  "scripts": {
+    "postinstall": "mkdir -p build && touch build/.configured"
   }
 }

--- a/common/tools/hextobin/package.json
+++ b/common/tools/hextobin/package.json
@@ -17,6 +17,6 @@
     "hextobin": "build/hextobin.js"
   },
   "scripts": {
-    "postinstall": "mkdir -p build && touch build/.configured"
+    "postinstall": "node --eval \"const fs =require('fs'); const path = require('path'); var dir = 'build'; if (!fs.existsSync(dir)) { fs.mkdirSync(dir); } fs.writeFileSync(path.join(dir, '.configured'), '');\""
   }
 }


### PR DESCRIPTION
This improves #12440. The previous change was a bit fragile if we updated commander versions. This change now implements a better solution that doesn't rely on dependencies and their locations for detecting if we need to run the `configure` action for hextobin.

@keymanapp-test-bot skip