### PR TITLE
docs(web): fix structure of test document

### DIFF
--- a/web/src/test/manual/web/index.html
+++ b/web/src/test/manual/web/index.html
@@ -29,7 +29,7 @@
   <h2><a href="./gesture-recognizer/index.html">Stand-alone gesture recognition</a></h2>
 
   <h1>Miscellaneous tests for smaller features</h1>
-  <h2><a href="./chirality/index.html">Chirality testing/bootstrapping</a><h2>
+  <h2><a href="./chirality/index.html">Chirality testing/bootstrapping</a></h2>
   <h2><a href="./options-with-save/index.html">Tests option/variable store functionality</a></h2>
   <h2><a href="./platform/index.html">Platform testing</a></h2>
   <h2><a href="./prediction-ui/index.html">Prediction UI testing</a></h2>
@@ -40,7 +40,7 @@
   <h2><a href="./osk-event-buttons/index.html">Tests toggling & use of desktop OSK config & help buttons</a></h2>
 
   <h1>Page integration (attachment) tests</h1>
-  <h2><a href="./attachment-api/index.html?mode=auto">Tests the Attachment/Enablement API functionality</a><h2>
+  <h2><a href="./attachment-api/index.html?mode=auto">Tests the Attachment/Enablement API functionality</a></h2>
   <h2><a href="./issue29/index.html">Test desktop MutationObserver functionality</a></h2>
   <h2><a href="./issue62/index.html">Light test for touch-based MutationObserver functionality</a></h2>
   <h2><a href="./issue63/index.html">Test/stress-test touch-based MutationObserver functionality</a></h2>


### PR DESCRIPTION
When looking at `index.html` in VSCode's hierarchical view I noticed that the structure was off because some closing tags were missing. This fixes that.

@keymanapp-test-bot skip