### PR TITLE
chore(linux): allow to skip API change

### DIFF
--- a/linux/scripts/deb-packaging.sh
+++ b/linux/scripts/deb-packaging.sh
@@ -82,6 +82,10 @@ output_error() {
 }
 
 check_api_not_changed() {
+  if [[ -z "${BIN_PKG:-}" ]]; then
+    output_warning "Skipping check for API change because binary Debian package not specified"
+    return
+  fi
   # Checks that the API did not change compared to what's documented in the .symbols file
   tmpDir=$(mktemp -d)
   # shellcheck disable=SC2064


### PR DESCRIPTION
When running locally it might be beneficial to be able run the API verification checks without having to build a binary package. This change allows to omit the `--bin-pkg` parameter and outputs a warning instead if it's missing.

@keymanapp-test-bot skip