### PR TITLE
fix(developer): use TextDecoder to convert Uint8Array to string

### DIFF
--- a/developer/src/common/web/utils/src/types/kpj/kpj-file-reader.ts
+++ b/developer/src/common/web/utils/src/types/kpj/kpj-file-reader.ts
@@ -14,7 +14,7 @@ export class KPJFileReader {
     let data: KPJFile;
 
     data = new KeymanXMLReader('kpj')
-      .parse(file.toString());
+      .parse(new TextDecoder().decode(file));
 
     data = this.boxArrays(data);
     if(data.KeymanDeveloperProject?.Files?.File?.length) {

--- a/developer/src/common/web/utils/src/types/kvks/kvks-file-reader.ts
+++ b/developer/src/common/web/utils/src/types/kvks/kvks-file-reader.ts
@@ -22,7 +22,7 @@ export default class KVKSFileReader {
 
     try {
       source = new KeymanXMLReader('kvks')
-        .parse(file.toString()) as KVKSourceFile;
+        .parse(new TextDecoder().decode(file)) as KVKSourceFile;
     } catch(e) {
       if(file.byteLength > 4 && file.subarray(0,3).every((v,i) => v == KVK_HEADER_IDENTIFIER_BYTES[i])) {
         throw new Error('File appears to be a binary .kvk file', {cause: e});

--- a/developer/src/common/web/utils/src/types/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/developer/src/common/web/utils/src/types/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -302,7 +302,7 @@ export class LDMLKeyboardXMLSourceFileReader {
 
   loadTestDataUnboxed(file: Uint8Array): any {
     const source = new KeymanXMLReader('keyboardTest3')
-      .parse(file.toString()) as any;
+      .parse(new TextDecoder().decode(file)) as any;
     return source;
   }
 

--- a/developer/src/kmc-package/src/compiler/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/kmp-compiler.ts
@@ -183,7 +183,7 @@ export class KmpCompiler implements KeymanCompiler {
 
         try {
           a = new KeymanXMLReader('kps')
-            .parse(data.toString()) as KpsFile.KpsPackage;
+            .parse(data) as KpsFile.KpsPackage;
         } catch(e) {
           this.callbacks.reportMessage(PackageCompilerMessages.Error_InvalidPackageFile({e}));
         }


### PR DESCRIPTION
`toString()` only works when the Uint8Array is actually a Node Buffer.

@keymanapp-test-bot skip