### PR TITLE
fix(core): fix generated `core.js` file for debug builds 🎼

### DIFF
--- a/core/src/meson.build
+++ b/core/src/meson.build
@@ -136,7 +136,7 @@ mock_files = files(
 
 if cpp_compiler.get_id() == 'emscripten'
   host_links = ['--whole-archive', '-sALLOW_MEMORY_GROWTH=1', '-sMODULARIZE=1',
-    '-sEXPORT_ES6', '-sENVIRONMENT=webview',
+    '-sEXPORT_ES6', '-sENVIRONMENT=web,webview',
     '--emit-tsd', 'core-interface.d.ts', '-sERROR_ON_UNDEFINED_SYMBOLS=0']
 
   links += ['-sEXPORTED_RUNTIME_METHODS=[\'UTF8ToString\',\'stringToNewUTF8\',\'wasmExports\']',


### PR DESCRIPTION
Due to emscripten bug emscripten-core/emscripten#22754 specifying only `webview` as environment resulted in a broken `core.js` file when doing a debug build. In release builds things worked because of the `-Wl,-O1 -O2` that meson added for the release build. This change works around that bug by adding `web` as additional environment.

@keymanapp-test-bot skip