### PR TITLE
fix(core): cleanup include directories 🎼

### DIFF
--- a/core/tests/meson.build
+++ b/core/tests/meson.build
@@ -10,10 +10,7 @@
 cmpfiles = ['-c', 'import sys; a = open(sys.argv[1], \'r\').read(); b = open(sys.argv[2], \'r\').read(); exit(not (a==b))']
 stnds = join_paths(meson.current_source_dir(), 'standards')
 
-libsrc = include_directories(
-  '../src',
-  '../../common/include'
-)
+libsrc = include_directories('../src')
 
 # kmx_test_source is required for linux builds, so always enable it even when we
 # disable all other tests

--- a/core/tests/unit/json/meson.build
+++ b/core/tests/unit/json/meson.build
@@ -11,7 +11,7 @@ else
 endif
 
 e = executable('jsontest', 'jsontest.cpp',
-    include_directories: [libsrc],
+    include_directories: [inc, libsrc],
     link_args: links + tests_flags,
     objects: lib.extract_objects('jsonpp.cpp'))
 test('jsontest', e, args: 'jsontest.json')

--- a/core/tests/unit/utftest/meson.build
+++ b/core/tests/unit/utftest/meson.build
@@ -6,5 +6,5 @@
 
 e = executable('utftest', 'utftest.cpp',
                objects: lib.extract_objects('../../common/cpp/utfcodec.cpp'),
-               include_directories: [libsrc])
+               include_directories: [inc, libsrc])
 test('utftest', e)


### PR DESCRIPTION
This fixes a meson warning that `common/include` was specified multiple times (in `core/include/meson.build` and
`core/tests/meson.build`).

@keymanapp-test-bot skip