### PR TITLE
feat(core): rename `core.js` to `km-core.js` 🎼

### DIFF
--- a/core/src/meson.build
+++ b/core/src/meson.build
@@ -137,7 +137,7 @@ mock_files = files(
 if cpp_compiler.get_id() == 'emscripten'
   host_links = ['--whole-archive', '-sALLOW_MEMORY_GROWTH=1', '-sMODULARIZE=1',
     '-sEXPORT_ES6', '-sENVIRONMENT=web,webview',
-    '--emit-tsd', 'core-interface.d.ts', '-sERROR_ON_UNDEFINED_SYMBOLS=0']
+    '--emit-tsd', 'km-core-interface.d.ts', '-sERROR_ON_UNDEFINED_SYMBOLS=0']
 
   links += ['-sEXPORTED_RUNTIME_METHODS=[\'UTF8ToString\',\'stringToNewUTF8\',\'wasmExports\']',
       # Forcing inclusion of debug symbols
@@ -174,7 +174,7 @@ pkg.generate(
 
 if cpp_compiler.get_id() == 'emscripten'
   # Build an executable
-  host = executable('core',
+  host = executable('km-core',
     cpp_args: defns,
     include_directories: inc,
     link_args: links + host_links,

--- a/web/src/app/browser/build.sh
+++ b/web/src/app/browser/build.sh
@@ -73,8 +73,8 @@ compile_and_copy() {
   cp -R "$KEYMAN_ROOT/web/src/resources/osk/." "$KEYMAN_ROOT/web/build/app/resources/osk/"
 
   # Copy Keyman Core build artifacts for local reference
-  cp "${KEYMAN_ROOT}/web/build/engine/core-processor/obj/import/core/"core.{js,wasm} "${KEYMAN_ROOT}/web/build/app/browser/debug/"
-  cp "${KEYMAN_ROOT}/web/build/engine/core-processor/obj/import/core/"core.{js,wasm} "${KEYMAN_ROOT}/web/build/app/browser/release/"
+  cp "${KEYMAN_ROOT}/web/build/engine/core-processor/obj/import/core/"km-core.{js,wasm} "${KEYMAN_ROOT}/web/build/app/browser/debug/"
+  cp "${KEYMAN_ROOT}/web/build/engine/core-processor/obj/import/core/"km-core.{js,wasm} "${KEYMAN_ROOT}/web/build/app/browser/release/"
 
   # Update the build/publish copy of our build artifacts
   prepare

--- a/web/src/app/webview/build.sh
+++ b/web/src/app/webview/build.sh
@@ -61,12 +61,12 @@ compile_and_copy() {
   cp -R "$KEYMAN_ROOT/web/src/resources/osk/." "$KEYMAN_ROOT/web/build/app/resources/osk/"
 
   # Copy Keyman Core build artifacts for local reference
-  cp "${KEYMAN_ROOT}/web/build/engine/core-processor/obj/import/core/"core.{js,wasm} "${KEYMAN_ROOT}/web/build/app/webview/debug/"
-  cp "${KEYMAN_ROOT}/web/build/engine/core-processor/obj/import/core/"core.{js,wasm} "${KEYMAN_ROOT}/web/build/app/webview/release/"
+  cp "${KEYMAN_ROOT}/web/build/engine/core-processor/obj/import/core/"km-core.{js,wasm} "${KEYMAN_ROOT}/web/build/app/webview/debug/"
+  cp "${KEYMAN_ROOT}/web/build/engine/core-processor/obj/import/core/"km-core.{js,wasm} "${KEYMAN_ROOT}/web/build/app/webview/release/"
 
   # Clean the sourcemaps of .. and . components
   for script in "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME/debug/"*.js; do
-    if [[ "${script}" == *"/core.js" ]]; then
+    if [[ "${script}" == *"/km-core.js" ]]; then
       continue
     fi
 
@@ -78,7 +78,7 @@ compile_and_copy() {
   # Do NOT inline sourcemaps for release builds - we don't want them to affect
   # load time.
   for script in "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME/release/"*.js; do
-    if [[ "${script}" == *"/core.js" ]]; then
+    if [[ "${script}" == *"/km-core.js" ]]; then
       continue
     fi
     sourcemap="$script.map"

--- a/web/src/engine/core-processor/build.sh
+++ b/web/src/engine/core-processor/build.sh
@@ -23,7 +23,7 @@ builder_describe "Keyman Core WASM integration" \
   "--ci+                     Set to utilize CI-based test configurations & reporting."
 
 builder_describe_outputs \
-  configure    "/web/src/engine/core-processor/src/import/core/core-interface.d.ts" \
+  configure    "/web/src/engine/core-processor/src/import/core/km-core-interface.d.ts" \
   build        "/web/build/${SUBPROJECT_NAME}/lib/index.mjs"
 
 builder_parse "$@"
@@ -41,12 +41,13 @@ do_configure() {
   mkdir -p "src/import/core/"
   # we don't need this file for release builds, but it's nice to have
   # for reference and auto-completion
-  cp "${KEYMAN_ROOT}/core/build/wasm/${BUILDER_CONFIGURATION}/src/core-interface.d.ts" "src/import/core/"
+  cp "${KEYMAN_ROOT}/core/build/wasm/${BUILDER_CONFIGURATION}/src/km-core-interface.d.ts" "src/import/core/"
 }
 
 copy_deps() {
   mkdir -p "${KEYMAN_ROOT}/web/build/${SUBPROJECT_NAME}/obj/import/core/"
-  cp "${KEYMAN_ROOT}/core/build/wasm/${BUILDER_CONFIGURATION}/src/"core{.js,.wasm,-interface.d.ts} "${KEYMAN_ROOT}/web/build/${SUBPROJECT_NAME}/obj/import/core/"
+  cp "${KEYMAN_ROOT}/core/build/wasm/${BUILDER_CONFIGURATION}/src/"km-core-interface.d.ts "${KEYMAN_ROOT}/web/build/${SUBPROJECT_NAME}/obj/import/core/"
+  cp "${KEYMAN_ROOT}/core/build/wasm/${BUILDER_CONFIGURATION}/src/"km-core{.js,.wasm} "${KEYMAN_ROOT}/web/build/${SUBPROJECT_NAME}/obj/import/core/"
 }
 
 do_build () {

--- a/web/src/engine/core-processor/src/core-processor.ts
+++ b/web/src/engine/core-processor/src/core-processor.ts
@@ -1,17 +1,17 @@
-type km_core_attr = import('./import/core/core-interface.js').km_core_attr;
+type km_core_attr = import('./import/core/km-core-interface.js').km_core_attr;
 
 export class CoreProcessor {
   private instance: any;
 
   /**
-     * Initialize Core Processor
-     * @param baseurl - The url where core.js is located
-     */
+   * Initialize Core Processor
+   * @param baseurl - The url where km-core.js is located
+   */
   public async init(baseurl: string): Promise<boolean> {
 
     if (!this.instance) {
       try {
-        const module = await import(baseurl + '/core.js');
+        const module = await import(baseurl + '/km-core.js');
         this.instance = await module.default({
           locateFile: function (path: string, scriptDirectory: string) {
             return baseurl + '/' + path;

--- a/web/src/engine/core-processor/tsconfig.json
+++ b/web/src/engine/core-processor/tsconfig.json
@@ -9,5 +9,5 @@
     "rootDir": "./src"
   },
 
-  "include": [ "**/*.ts", "src/import/core/core.js" ],
+  "include": [ "**/*.ts", "src/import/core/km-core.js" ],
 }

--- a/web/src/test/auto/dom/cases/core-processor/basic.spec.ts
+++ b/web/src/test/auto/dom/cases/core-processor/basic.spec.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import { CoreProcessor } from 'keyman/engine/core-processor';
 
-const coreurl = '/web/build/engine/core-processor/obj/import/core/';
+const coreurl = '/web/build/engine/core-processor/obj/import/core';
 
 // Test the CoreProcessor interface.
 describe('CoreProcessor', function () {


### PR DESCRIPTION
There are too many `core.js` out there, so renaming it to a unique name makes it a bit easier to track down problems when debugging.

@keymanapp-test-bot skip