### PR TITLE
fix(android/engine): Increase robustness when checking package kmp.json languages

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/packages/JSONUtils.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/packages/JSONUtils.java
@@ -38,6 +38,9 @@ public class JSONUtils {
       return new JSONArray();
     }
     File[] packages = resourceRoot.listFiles();
+    if (packages == null) {
+      return new JSONArray();
+    }
     JSONArray languagesArray = new JSONArray();
     JSONParser parser = new JSONParser();
 
@@ -60,6 +63,9 @@ public class JSONUtils {
               String kbdFilename = pkg.getName() + "/" + kbdID + ".js";
 
               // Merge languages
+              if (!kmpKeyboardObj.has("languages")) {
+                continue;
+              }
               JSONArray kmpLanguageArray = kmpKeyboardObj.getJSONArray("languages");
               for (int j=0; j<kmpLanguageArray.length(); j++) {
                 JSONObject languageObj = kmpLanguageArray.getJSONObject(j);

--- a/android/KMEA/app/src/test/java/com/keyman/engine/packages/JSONUtilsTest.java
+++ b/android/KMEA/app/src/test/java/com/keyman/engine/packages/JSONUtilsTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 @RunWith(RobolectricTestRunner.class)
 public class JSONUtilsTest {
   private static final File TEST_RESOURCE_ROOT = new File("test_resources", "packages");
+  private static final File TEST_INVALID_RESOURCE_ROOT = new File("test_resources", "invalid_packages");
   private static final String TAG = "JSONUtilsTest";
 
   @Before
@@ -50,6 +51,18 @@ public class JSONUtilsTest {
     } catch (JSONException e) {
       Log.e(TAG, "test_getLanguages error: " + e);
     }
+  }
+
+  /**
+   * Test parsing null_languages/kmp.json which has no languages
+   */
+  @Test
+  public void test_invalid_getLanguages() {
+    JSONUtils.initialize(TEST_INVALID_RESOURCE_ROOT);
+    JSONArray result = JSONUtils.getLanguages();
+    final int EXPECTED_NUM_LANGUAGES = 0;
+
+    Assert.assertEquals(EXPECTED_NUM_LANGUAGES, result.length());
   }
 
   @Test

--- a/android/KMEA/test_resources/invalid_packages/null_languages/kmp.json
+++ b/android/KMEA/test_resources/invalid_packages/null_languages/kmp.json
@@ -1,0 +1,127 @@
+{
+  "system": {
+    "keymanDeveloperVersion": "11.0.1304.0",
+    "fileVersion": "7.0"
+  },
+  "options": {
+    "graphicFile": "splash.bmp"
+  },
+  "info": {
+    "name": {
+      "description": "Cameroon QWERTY"
+    },
+    "version": {
+      "description": "6.0.2"
+    },
+    "copyright": {
+      "description": "\u00A92018 SIL Cameroon"
+    },
+    "author": {
+      "description": "Matthew Lee",
+      "url": "mailto:keyboards_cameroon@sil.org"
+    },
+    "website": {
+      "description": "LangTechCameroon.info",
+      "url": "LangTechCameroon.info"
+    }
+  },
+  "files": [
+    {
+      "name": "Cameroon.ico",
+      "description": "File Cameroon.ico"
+    },
+    {
+      "name": "sil_cameroon_qwerty.css",
+      "description": "File sil_cameroon_qwerty.css"
+    },
+    {
+      "name": "AndikaAfr-R.ttf",
+      "description": "Font Andika Afr"
+    },
+    {
+      "name": "sil_cameroon_qwerty.kvk",
+      "description": "File sil_cameroon_qwerty.kvk"
+    },
+    {
+      "name": "sil_cameroon_qwerty.kmx",
+      "description": "Keyboard Cameroon QWERTY"
+    },
+    {
+      "name": "splash.bmp",
+      "description": "File splash.bmp"
+    },
+    {
+      "name": "welcome.htm",
+      "description": "File welcome.htm"
+    },
+    {
+      "name": "e_chart.png",
+      "description": "File e_chart.png"
+    },
+    {
+      "name": "e_tableau.png",
+      "description": "File e_tableau.png"
+    },
+    {
+      "name": "helpIcon.png",
+      "description": "File helpIcon.png"
+    },
+    {
+      "name": "ic_launcher.png",
+      "description": "File ic_launcher.png"
+    },
+    {
+      "name": "icon.png",
+      "description": "File icon.png"
+    },
+    {
+      "name": "QwertyColor.png",
+      "description": "File QwertyColor.png"
+    },
+    {
+      "name": "sil-logo-blue.png",
+      "description": "File sil-logo-blue.png"
+    },
+    {
+      "name": "kb.css",
+      "description": "File kb.css"
+    },
+    {
+      "name": "sil_cameroon_qwerty.js",
+      "description": "File sil_cameroon_qwerty.js"
+    },
+    {
+      "name": "globe.png",
+      "description": "File globe.png"
+    },
+    {
+      "name": "longpress-qwerty.png",
+      "description": "File longpress-qwerty.png"
+    },
+    {
+      "name": "modkeys-en-q.png",
+      "description": "File modkeys-en-q.png"
+    },
+    {
+      "name": "modkeys-fr-q.png",
+      "description": "File modkeys-fr-q.png"
+    },
+    {
+      "name": "kmp.inf",
+      "description": "Package information"
+    },
+    {
+      "name": "kmp.json",
+      "description": "Package information (JSON)"
+    }
+  ],
+  "keyboards": [
+    {
+      "name": "Cameroon QWERTY",
+      "id": "sil_cameroon_qwerty",
+      "version": "6.0.2",
+      "oskFont": "AndikaAfr-R.ttf",
+      "displayFont": "AndikaAfr-R.ttf"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #11812 

This adds more error handling to JSONUtils.getLanguages() where the reported issue had crashed from
```
Exception java.lang.NullPointerException: Attempt to get length of null array
```

Also added a unit test.

@keymanapp-test-bot skip
