### PR TITLE
feat(developer): Report key 'address' in validation failures in layout compiler

### DIFF
--- a/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
@@ -464,7 +464,7 @@ export class KmnCompilerMessages {
 
   static ERROR_TouchLayoutInvalidIdentifier                   = SevError | 0x05A;
   static Error_TouchLayoutInvalidIdentifier = (o:{keyId:string, platformName: string, layerId:string, address:KeyAddress}) => mw(this.ERROR_TouchLayoutInvalidIdentifier,
-    `Key "${def(o.keyId)}" on "${def(o.platformName)}", layer "${def(o.layerId)}" has an invalid identifier.`);
+    `Key "${def(o.keyId)}" on "${def(o.platformName)}", layer "${def(o.layerId)}" (${keyAddress(o.address)}) has an invalid identifier.`);
 
   static ERROR_InvalidKeyCode                                 = SevError | 0x05B;
   static Error_InvalidKeyCode = (o:{keyId: string}) => mw(this.ERROR_InvalidKeyCode,

--- a/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
@@ -1,3 +1,4 @@
+import { KeyAddress } from "src/kmw-compiler/validate-layout-file.js";
 import { kmnfile } from "../kmw-compiler/compiler-globals.js";
 import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException, KeymanUrls } from "@keymanapp/developer-utils";
 
@@ -24,6 +25,17 @@ export const enum KmnCompilerMessageRanges {
   RANGE_LEXICAL_MODEL_MAX   = 0x8FF, // from kmn_compiler_errors.h, deprecated -- this range will not be used in future versions
   RANGE_CompilerMessage_Min = 0x900, // All compiler messages listed here must be >= this value
   RANGE_CompilerMessage_Max = 0xFFF, // Highest available error code for kmc-kmn
+}
+
+export function keyAddress(address: KeyAddress): string {
+  if(!address) {
+    return '<param>';
+  }
+  return `row:${address.rowIndex} col:${address.keyIndex}` +
+    (address.direction ? ` flick:${address.direction}` :
+    (address.subKeyIndex ? ` longPress:${address.subKeyIndex}` :
+    (address.multitapIndex ? ` multitap:${address.multitapIndex}` :
+    '')));
 }
 
 type KmcmpLibMessageParameters = {p:string[]};
@@ -451,7 +463,7 @@ export class KmnCompilerMessages {
     `Touch layout file ${def(o.filename)} is not valid`);
 
   static ERROR_TouchLayoutInvalidIdentifier                   = SevError | 0x05A;
-  static Error_TouchLayoutInvalidIdentifier = (o:{keyId:string, platformName: string, layerId:string}) => mw(this.ERROR_TouchLayoutInvalidIdentifier,
+  static Error_TouchLayoutInvalidIdentifier = (o:{keyId:string, platformName: string, layerId:string, address:KeyAddress}) => mw(this.ERROR_TouchLayoutInvalidIdentifier,
     `Key "${def(o.keyId)}" on "${def(o.platformName)}", layer "${def(o.layerId)}" has an invalid identifier.`);
 
   static ERROR_InvalidKeyCode                                 = SevError | 0x05B;
@@ -619,14 +631,13 @@ export class KmnCompilerMessages {
   static WARN_PunctuationInEthnologueCode                     = SevWarn | 0x090;
   static Warn_PunctuationInEthnologueCode                     = () => m(this.WARN_PunctuationInEthnologueCode, `Punctuation should not be used to separate Ethnologue codes; instead use spaces`);
 
-
   static WARN_TouchLayoutMissingLayer                         = SevWarn | 0x091;
-  static Warn_TouchLayoutMissingLayer = (o:{keyId:string, platformName:string, layerId:string, nextLayer:string}) => mw(this.WARN_TouchLayoutMissingLayer,
-    `Key "${def(o.keyId)}" on platform "${def(o.platformName)}", layer "${def(o.layerId)}", references a missing layer "${def(o.nextLayer)}"`);
+  static Warn_TouchLayoutMissingLayer = (o:{keyId:string, platformName:string, layerId:string, nextLayer:string, address:KeyAddress}) => mw(this.WARN_TouchLayoutMissingLayer,
+    `Key "${def(o.keyId)}" on platform "${def(o.platformName)}", layer "${def(o.layerId)}" (${keyAddress(o.address)}), references a missing layer "${def(o.nextLayer)}"`);
 
   static WARN_TouchLayoutCustomKeyNotDefined                  = SevWarn | 0x092;
-  static Warn_TouchLayoutCustomKeyNotDefined = (o:{keyId:string, platformName:string, layerId:string}) => mw(this.WARN_TouchLayoutCustomKeyNotDefined,
-    `Key "${def(o.keyId)}" on platform "${def(o.platformName)}", layer "${def(o.layerId)}", is a custom key but has no corresponding rule in the source.`);
+  static Warn_TouchLayoutCustomKeyNotDefined = (o:{keyId:string, platformName:string, layerId:string, address:KeyAddress}) => mw(this.WARN_TouchLayoutCustomKeyNotDefined,
+    `Key "${def(o.keyId)}" on platform "${def(o.platformName)}", layer "${def(o.layerId)}"  (${keyAddress(o.address)}), is a custom key but has no corresponding rule in the source.`);
 
   static WARN_TouchLayoutMissingRequiredKeys                  = SevWarn | 0x093;
   static Warn_TouchLayoutMissingRequiredKeys = (o:{layerId:string, platformName:string, missingKeys:string}) => mw(this.WARN_TouchLayoutMissingRequiredKeys,
@@ -648,8 +659,8 @@ export class KmnCompilerMessages {
     `Extended shift flags ${def(o.flags)} are not supported in KeymanWeb`, o);
 
   static WARN_TouchLayoutUnidentifiedKey                      = SevWarn | 0x099;
-  static Warn_TouchLayoutUnidentifiedKey = (o:{layerId:string}) => mw(this.WARN_TouchLayoutUnidentifiedKey,
-    `A key on layer "${def(o.layerId)}" has no identifier.`);
+  static Warn_TouchLayoutUnidentifiedKey = (o:{layerId:string, address:KeyAddress}) => mw(this.WARN_TouchLayoutUnidentifiedKey,
+    `A key (${keyAddress(o.address)}) on layer "${def(o.layerId)}" has no identifier.`);
 
   static HINT_UnreachableKeyCode                              = SevHint | 0x09A;
   static Hint_UnreachableKeyCode = (o:{line:number,key:string}) => mw(this.HINT_UnreachableKeyCode,
@@ -696,9 +707,9 @@ export class KmnCompilerMessages {
   static Warn_HotkeyHasInvalidModifier                        = () => m(this.WARN_HotkeyHasInvalidModifier, `Hotkey has modifiers that are not supported. Use only SHIFT, CTRL and ALT`);
 
   static WARN_TouchLayoutSpecialLabelOnNormalKey              = SevWarn | 0x0A9;
-  static Warn_TouchLayoutSpecialLabelOnNormalKey = (o:{keyId:string, platformName:string, layerId:string, label:string}) =>
+  static Warn_TouchLayoutSpecialLabelOnNormalKey = (o:{keyId:string, platformName:string, layerId:string, label:string, address:KeyAddress}) =>
     mw(this.WARN_TouchLayoutSpecialLabelOnNormalKey,
-    `Key "${def(o.keyId)}" on platform "${def(o.platformName)}", layer "${def(o.layerId)}" does not have `+
+    `Key "${def(o.keyId)}" on platform "${def(o.platformName)}", layer "${def(o.layerId)}"  (${keyAddress(o.address)}) does not have `+
     `the key type "Special" or "Special (active)" but has the label "${def(o.label)}". This feature is only supported in Keyman 14 or later`);
 
   static WARN_OptionStoreNameInvalid                          = SevWarn | 0x0AA;

--- a/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
@@ -1,4 +1,4 @@
-import { KeyAddress } from "src/kmw-compiler/validate-layout-file.js";
+import { KeyAddress } from "../kmw-compiler/validate-layout-file.js";
 import { kmnfile } from "../kmw-compiler/compiler-globals.js";
 import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException, KeymanUrls } from "@keymanapp/developer-utils";
 

--- a/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler-messages.ts
@@ -1,6 +1,7 @@
-import { KmnCompilerMessages } from "../compiler/kmn-compiler-messages.js";
+import { keyAddress, KmnCompilerMessages } from "../compiler/kmn-compiler-messages.js";
 import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageDef as def, CompilerMessageSpec } from "@keymanapp/developer-utils";
 import { kmnfile } from "./compiler-globals.js";
+import { KeyAddress } from "./validate-layout-file.js";
 
 const Namespace = CompilerErrorNamespace.KmwCompiler;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -34,8 +35,8 @@ export class KmwCompilerMessages extends KmnCompilerMessages {
   //          SevError | 0x0001, added in 17.0, removed in 18.0
 
   static ERROR_TouchLayoutIdentifierRequires15 = SevError | 0x0002;
-  static Error_TouchLayoutIdentifierRequires15 = (o:{keyId:string, platformName:string, layerId:string}) => m(this.ERROR_TouchLayoutIdentifierRequires15,
-    `Key "${def(o.keyId)}" on "${def(o.platformName)}", layer "${def(o.layerId)}" has a multi-part identifier which requires version 15.0 or newer.`);
+  static Error_TouchLayoutIdentifierRequires15 = (o:{keyId:string, platformName:string, layerId:string, address:KeyAddress}) => m(this.ERROR_TouchLayoutIdentifierRequires15,
+    `Key "${def(o.keyId)}" on "${def(o.platformName)}", layer "${def(o.layerId)}" (${keyAddress(o.address)}) has a multi-part identifier which requires version 15.0 or newer.`);
 
   static ERROR_InvalidTouchLayoutFileFormat = SevError | 0x0003;
   static Error_InvalidTouchLayoutFileFormat = (o:{msg: string}) => m(this.ERROR_InvalidTouchLayoutFileFormat,


### PR DESCRIPTION
All messages that reference keys in the touch layout will now give the row+column index of the key with the issue (and longpress/flick/multitap index as well if relevant).

Fixes: #12505

@keymanapp-test-bot skip