### PR TITLE
fix(developer): handle missing files in kmc-kmn

### DIFF
--- a/developer/src/kmc-kmn/src/compiler/compiler.ts
+++ b/developer/src/kmc-kmn/src/compiler/compiler.ts
@@ -310,7 +310,7 @@ export class KmnCompiler implements KeymanCompiler, UnicodeSetParser {
       },
       loadFile: function(filename: string, baseFilename: string): number[] {
         const data: Uint8Array = compiler.callbacks.loadFile(compiler.callbacks.resolveFilename(baseFilename, filename));
-        return data ? Array.from(data) : null;
+        return data ? Array.from(data) : [];
       }
     });
 

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_cannot_read_bitmap_file.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_cannot_read_bitmap_file.kmn
@@ -1,0 +1,7 @@
+store(&NAME) 'test_missing_icon'
+store(&TARGETS) 'windows'
+store(&BITMAP) 'test_missing_icon_missing.ico'
+
+begin Unicode > use(main)
+
+group(main) using keys

--- a/developer/src/kmc-kmn/test/test-messages.ts
+++ b/developer/src/kmc-kmn/test/test-messages.ts
@@ -175,6 +175,12 @@ describe('KmnCompilerMessages', function () {
     await testForMessage(this, ['invalid-keyboards', 'error_character_range_too_long.kmn'], KmnCompilerMessages.ERROR_CharacterRangeTooLong);
   });
 
+  // ERROR_CannotReadBitmapFile
+
+  it('should generate ERROR_CannotReadBitmapFile if the bitmap file is missing', async function() {
+    await testForMessage(this, ['invalid-keyboards', 'error_cannot_read_bitmap_file.kmn'], KmnCompilerMessages.ERROR_CannotReadBitmapFile);
+  });
+
   // WARN_IndexStoreShort
 
   it('should generate WARN_IndexStoreShort if a store referenced in index() is shorter than the corresponding any() store', async function() {


### PR DESCRIPTION
If a file is not found, the loadfile callback now returns an empty array rather than null, which kmcmplib interprets as a missing file. This means a zero-byte file will have the same outcome but as it is also generally invalid, I think that is acceptable.

The 17.0 compiler has a different callback mechanism, so won't cherry-pick to 17.0.

Fixes: #12546
Fixes: KEYMAN-DEVELOPER-292

@keymanapp-test-bot skip