### PR TITLE
refactor(developer): define output path in kmc-generate artifacts

### DIFF
--- a/developer/src/kmc-generate/src/keyman-keyboard-generator.ts
+++ b/developer/src/kmc-generate/src/keyman-keyboard-generator.ts
@@ -41,7 +41,7 @@ export class KeymanKeyboardGenerator extends BasicGenerator implements KeymanCom
   async run(): Promise<GeneratorResult> {
     this.preGenerate();
 
-    const artifacts: GeneratorArtifacts = {};
+    const artifacts: GeneratorArtifacts = this.defaultArtifacts();
 
     this.templatePath = 'kmn-keyboard';
 

--- a/developer/src/kmc-generate/src/ldml-keyboard-generator.ts
+++ b/developer/src/kmc-generate/src/ldml-keyboard-generator.ts
@@ -30,7 +30,7 @@ export class LdmlKeyboardGenerator extends BasicGenerator implements KeymanCompi
   async run(): Promise<GeneratorResult> {
     this.preGenerate();
 
-    const artifacts: GeneratorArtifacts = {};
+    const artifacts: GeneratorArtifacts = this.defaultArtifacts();
     this.templatePath = 'ldml-keyboard';
     this.filenameMap[LdmlKeyboardGenerator.SFile_Project] =
       this.options.id+KeymanFileTypes.Source.Project;

--- a/developer/src/kmc-generate/src/lexical-model-generator.ts
+++ b/developer/src/kmc-generate/src/lexical-model-generator.ts
@@ -33,7 +33,7 @@ export class LexicalModelGenerator extends BasicGenerator implements KeymanCompi
   async run(): Promise<GeneratorResult> {
     this.preGenerate();
 
-    const artifacts: GeneratorArtifacts = {};
+    const artifacts: GeneratorArtifacts = this.defaultArtifacts();
 
     this.templatePath = 'wordlist-lexical-model';
     this.filenameMap[LexicalModelGenerator.SFile_Project] =

--- a/developer/src/kmc-generate/test/test-abstract-generator.ts
+++ b/developer/src/kmc-generate/test/test-abstract-generator.ts
@@ -4,38 +4,48 @@
 
 import 'mocha';
 import * as path from 'path';
+import * as os from 'os';
 import * as fs from 'fs';
-import { fileURLToPath } from 'url';
 import { assert } from 'chai';
 import { AbstractGenerator, GeneratorArtifacts } from '../src/abstract-generator.js';
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { options } from './shared-options.js';
 
 describe('AbstractGenerator', function () {
-  it('should have a valid targetPath', async function() {
-    const ag = new AbstractGenerator();
-    const callbacks = new TestCompilerCallbacks();
-    assert(await ag.init(callbacks, options));
-    assert.equal(ag.unitTestEndpoints.targetPath(), path.join('.','sample'));
-    // assert(ag.verifyInitialize());
+  const callbacks = new TestCompilerCallbacks();
+
+  this.beforeEach(function() {
+    callbacks.clear();
+  });
+
+  this.afterEach(function() {
+    if(this.currentTest.isFailed()) {
+      callbacks.printMessages();
+    }
   });
 
   it('should write out files successfully', async function() {
     const ag = new AbstractGenerator();
-    const callbacks = new TestCompilerCallbacks();
     assert(await ag.init(callbacks, options));
 
-    const filename = path.join(path.dirname(fileURLToPath(import.meta.url)), 'test_artifact.bin');
+    // Generates a path that should be unique so that we can test
+    // that it does not exist correctly
+    const base = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'kmc-generate-')), 'unique');
+
+    const filename = path.join(base, 'test_artifact.bin');
     const data = new Uint8Array([1,2,3]);
     const artifacts: GeneratorArtifacts = {
+      "kmc-generate:outputPath": {filename: base, data: null},
       'test_artifact.bin': {filename, data}
     };
-    assert(await ag.write(artifacts));
-    assert(fs.existsSync(filename));
+    assert.isTrue(await ag.write(artifacts));
+    assert.isTrue(fs.existsSync(filename));
     const buf = fs.readFileSync(filename);
     assert.deepEqual(buf, data);
 
     fs.unlinkSync(filename);
+    fs.rmdirSync(base);
+    fs.rmdirSync(path.dirname(base));
     // assert(ag.verifyInitialize());
   });
 });

--- a/developer/src/kmc-generate/test/test-keyman-keyboard-generator.ts
+++ b/developer/src/kmc-generate/test/test-keyman-keyboard-generator.ts
@@ -53,9 +53,14 @@ describe('KeymanKeyboardGenerator', function () {
     const samplePath = makePathToFixture('keyman-keyboard');
     const files = getFilenames(samplePath);
 
+    assert.isOk(result.artifacts['kmc-generate:outputPath']);
+    assert.isNull(result.artifacts['kmc-generate:outputPath'].data);
+
     // Verify that there are no unexpected artifacts
     for(const artifact of Object.keys(result.artifacts)) {
-      assert.include(files, artifact);
+      if(artifact != 'kmc-generate:outputPath') {
+        assert.include(files, artifact);
+      }
     }
 
     // Compare each file content as a UTF-8 string

--- a/developer/src/kmc-generate/test/test-ldml-keyboard-generator.ts
+++ b/developer/src/kmc-generate/test/test-ldml-keyboard-generator.ts
@@ -53,9 +53,14 @@ describe('LdmlKeyboardGenerator', function () {
     const samplePath = makePathToFixture('ldml-keyboard');
     const files = getFilenames(samplePath);
 
+    assert.isOk(result.artifacts['kmc-generate:outputPath']);
+    assert.isNull(result.artifacts['kmc-generate:outputPath'].data);
+
     // Verify that there are no unexpected artifacts
     for(const artifact of Object.keys(result.artifacts)) {
-      assert.include(files, artifact);
+      if(artifact != 'kmc-generate:outputPath') {
+        assert.include(files, artifact);
+      }
     }
 
     // compare each file content as a UTF-8 string

--- a/developer/src/kmc-generate/test/test-lexical-model-generator.ts
+++ b/developer/src/kmc-generate/test/test-lexical-model-generator.ts
@@ -59,9 +59,14 @@ describe('LexicalModelGenerator', function () {
     const samplePath = makePathToFixture('lexical-model');
     const files = getFilenames(samplePath);
 
+    assert.isOk(result.artifacts['kmc-generate:outputPath']);
+    assert.isNull(result.artifacts['kmc-generate:outputPath'].data);
+
     // Verify that there are no unexpected artifacts
     for(const artifact of Object.keys(result.artifacts)) {
-      assert.include(files, artifact);
+      if(artifact != 'kmc-generate:outputPath') {
+        assert.include(files, artifact);
+      }
     }
 
     // compare each file content as a UTF-8 string

--- a/developer/src/kmc-generate/test/tsconfig.json
+++ b/developer/src/kmc-generate/test/tsconfig.json
@@ -6,7 +6,7 @@
       "rootDirs": ["./", "../src/"],
       "outDir": "../build/test",
       "baseUrl": ".",
-      "strictNullChecks": true,
+      "strictNullChecks": false,
       "paths": {
         // "@keymanapp/keyman-version": ["../../../common/web/keyman-version/keyman-version.mts"],
         "@keymanapp/common-types": ["../../../../common/web/types/src/main"],


### PR DESCRIPTION
Follows the pattern established with kmc copy

@keymanapp-test-bot skip