### PR TITLE
fix(developer): ldml don't allow a uset as right-hand-side variable

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
@@ -229,4 +229,11 @@ export class LdmlCompilerMessages {
   m(this.ERROR_IllegalTransformAsterisk,  `Invalid transform from="${def(o.from)}": Unescaped asterisk (*) is not valid transform syntax.`,
                                             '**Hint**: Use `\\*` to match a literal asterisk.');
 
+  static ERROR_IllegalTransformToUset = SevErrorTransform | 0x05;
+  static Error_IllegalTransformToUset = (o: { to: string }) => m(
+    this.ERROR_IllegalTransformToUset,
+    `Invalid transform to="${def(o.to)}": Set variable (\\$[…]) cannot be used in 'to=' unless part of a map.`,
+    '**Hint**: If a map was meant, must use the form `<transform from="($[fromSet])" to="$[1:toSet]"/>`.'
+  );
+
 }

--- a/developer/src/kmc-ldml/src/compiler/tran.ts
+++ b/developer/src/kmc-ldml/src/compiler/tran.ts
@@ -152,6 +152,11 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
     } else {
       result.mapFrom = sections.strs.allocString('');
       result.mapTo = sections.strs.allocString('');
+
+      // validate 'to' here
+      if (!this.isValidTo(transform.to || '')) {
+        return null;
+      }
     }
 
     if (cookedFrom === null) return null; // error
@@ -190,6 +195,19 @@ export abstract class TransformCompiler<T extends TransformCompilerType, TranBas
       nfd: true,
     }, sections);
     return result;
+  }
+
+  /**
+   * Validate the 'to' string.
+   * We have already checked that it's not a mapTo,
+   * so there should not be any illegal substitutions.
+   */
+  private isValidTo(to: string) : boolean {
+    if (/(?<!\\)(?:\\\\)*\$\[/.test(to)) {
+      this.callbacks.reportMessage(LdmlCompilerMessages.Error_IllegalTransformToUset({ to }));
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-IllegalTransformUsetRHS-1.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-IllegalTransformUsetRHS-1.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+    <info name="tran-minimal" />
+
+    <keys>
+        <key id="w" output="w"/>
+    </keys>
+
+    <variables>
+        <uset id="triisap" value="[\u{17CA}]" />
+    </variables>
+    <transforms type="simple">
+        <transformGroup>
+            <transform from="w" to="$[triisap]" /> <!-- uset should not be RHS -->
+        </transformGroup>
+    </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/fixtures/sections/tran/ok-2.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/tran/ok-2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+    <info name="tran-minimal" />
+
+    <keys>
+        <key id="w" output="w"/>
+    </keys>
+
+    <variables>
+        <uset id="triisap" value="[\u{17CA}]" /> <!-- unused. -->
+    </variables>
+    <transforms type="simple">
+        <transformGroup>
+            <!-- this test is identical to fail-IllegalTransformUsetRHS-1.xml except for the backslash before the dollarsign. -->
+            <transform from="w" to="\$[triisap]" /> <!-- Strange but OK- the dollarsign is escaped. -->
+        </transformGroup>
+    </transforms>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/test-tran.ts
+++ b/developer/src/kmc-ldml/test/test-tran.ts
@@ -362,8 +362,17 @@ describe('tran', function () {
         }
       ],
     })),
-    // successful compile
     ...[1].map(n => ({
+      subpath: `sections/tran/fail-IllegalTransformUsetRHS-${n}.xml`,
+      errors: [
+        {
+          code: LdmlCompilerMessages.ERROR_IllegalTransformToUset,
+          matchMessage: /.*/,
+        }
+      ],
+    })),
+    // successful compile
+    ...[1, 2].map(n => ({
       subpath: `sections/tran/ok-${n}.xml`,
       errors: false,
     })),


### PR DESCRIPTION
- to="$[triisap]" is a mistake and not allowed.
- it's either meant to be a regular variable, or a map. Both of those are different syntax.
- add a test for the failing case, and also for the escaped case (to="\$[…)

Fixes: #12455

@keymanapp-test-bot skip