### PR TITLE
fix(developer): create Server config directory before options save

### DIFF
--- a/developer/src/tike/main/KeymanDeveloperOptions.pas
+++ b/developer/src/tike/main/KeymanDeveloperOptions.pas
@@ -508,7 +508,7 @@ begin
   until count >= Max_Retries;
 
   if TKeymanSentryClient.Instance <> nil then
-    TKeymanSentryClient.Instance.ReportMessage('TKeymanDeveloperOptions: Failed to write '+Filename+' after 5 tries');
+    TKeymanSentryClient.Instance.ReportMessage('TKeymanDeveloperOptions: Failed to write '+Filename+' after '+IntToStr(Max_Retries)+' tries');
 
   Result := False;
 end;


### PR DESCRIPTION
Also use back-off logic for saving in case config file is locked by another process.

Fixes: #12607
Fixes: KEYMAN-DEVELOPER-1Z1

@keymanapp-test-bot skip