### PR TITLE
chore(linux): add support for Ubuntu 25.04 Plucky Puffin

### DIFF
--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -33,7 +33,7 @@ else
 fi
 echo "ppa: ${ppa}"
 
-distributions="${DIST:-focal jammy noble oracular}"
+distributions="${DIST:-focal jammy noble oracular plucky}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
With this change we will also build and provide binaries on Launchpad for the next Ubuntu release, 25.04 Plucky Puffin.

@keymanapp-test-bot skip