### PR TITLE
fix(linux): properly check for missing dependencies

### DIFF
--- a/linux/keyman-config/km-config
+++ b/linux/keyman-config/km-config
@@ -13,9 +13,6 @@ from keyman_config import (
   _, __versionwithtag__, __pkgversion__, add_standard_arguments,
   are_requirements_missing, initialize_logging, initialize_sentry,
   verify_dbus_running)
-from keyman_config.handle_install import download_and_install_package
-from keyman_config.ibus_util import verify_ibus_daemon
-from keyman_config.view_installed import ViewInstalledWindow
 
 
 if __name__ == '__main__':
@@ -50,11 +47,17 @@ if __name__ == '__main__':
             logging.error('Missing requirements. Please install python3-fonttools.')
         else:
             dialog = Gtk.MessageDialog(
-                None, 0, Gtk.MessageType.ERROR,
-                Gtk.ButtonsType.OK, _("Missing requirements. Please install python3-fonttools."))
+                parent=None, flags=0, message_type=Gtk.MessageType.ERROR,
+                buttons=Gtk.ButtonsType.OK,
+                text=_("Missing requirements. Please install python3-fonttools."))
             dialog.run()
             dialog.destroy()
         sys.exit(1)
+
+    # Add these imports only after the check for missing dependencies!
+    from keyman_config.handle_install import download_and_install_package
+    from keyman_config.ibus_util import verify_ibus_daemon
+    from keyman_config.view_installed import ViewInstalledWindow
 
 
     logging.info('Keyman version %s %s', __versionwithtag__, __pkgversion__)


### PR DESCRIPTION
The previous implementation didn't work because the import of `download_and_install_package` happened before we checked for the missing dependencies and so the program crashed. This change fixes this and now does the imports after checking for the missing dependencies so that we can display an error message to the user.

Also fix a warning (positional arguments in `Gtk.MessageDialog` are deprecated).

@keymanapp-test-bot skip