### PR TITLE
fix(linux): set environment variable for rendering of downloads dialog 🍒 🏠

### DIFF
--- a/linux/keyman-config/km-config
+++ b/linux/keyman-config/km-config
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import os
 import sys
 import gi
 
@@ -66,6 +67,10 @@ if __name__ == '__main__':
     elif args.url:
         download_and_install_package(args.url)
     else:
+        # Workaround for bug in webkit2gtk (#12587)
+        if not 'WEBKIT_DISABLE_DMABUF_RENDERER' in os.environ:
+            os.environ['WEBKIT_DISABLE_DMABUF_RENDERER'] = '1'
+
         w = ViewInstalledWindow()
         try:
             w.run()


### PR DESCRIPTION
This works around a problem in webkit2gtk where the download dialog sometimes only renders a blank screen. Setting the environment variable seems to help, not only in the cases that the issue describes (with a NVidia graphics card), but also in my testing in a VM.

Fixes: #12587
Cherry-pick-of: #12616

# User Testing

**TEST_DOWNLOAD_PAGE**: Open Keyman Config and click on the Download Keyboard button. The Download Keyman Keyboards page should show up.