### PR TITLE
fix(developer): use 'N' for nomatch store debug strings (regression in #12107)

### DIFF
--- a/developer/src/kmcmplib/src/debugstore.h
+++ b/developer/src/kmcmplib/src/debugstore.h
@@ -8,8 +8,8 @@
 #define DEBUGSTORE_MATCH_U		u"M"
 #define DEBUGSTORE_MATCH_L		L"M"
 
-#define DEBUGSTORE_NOMATCH_U	u"M"
-#define DEBUGSTORE_NOMATCH_L	L"M"
+#define DEBUGSTORE_NOMATCH_U	u"N"
+#define DEBUGSTORE_NOMATCH_L	L"N"
 
 #define DEBUGSTORE_GROUP_U		u"G"
 #define DEBUGSTORE_GROUP_L		L"G"
@@ -17,4 +17,4 @@
 #define DEBUGSTORE_DEADKEY_U	u"D"
 #define DEBUGSTORE_DEADKEY_L	L"D"
 
-#endif /* DEBUGSTORE_H */ 
+#endif /* DEBUGSTORE_H */


### PR DESCRIPTION
Fixes a regression arising from #12107 in debug store strings.

Three sets of eyes -- developer and two code reviewers and we still managed to miss this!

![image](https://github.com/user-attachments/assets/1facc3f3-caa9-4048-a0fd-56c66fc7120c)


Relates-to: #12623
Relates-to: #12107

@keymanapp-test-bot skip