### PR TITLE
chore(developer): skip masaram_gondi in kmcmplib full test

### DIFF
--- a/developer/src/kmcmplib/tests/get-test-source.sh
+++ b/developer/src/kmcmplib/tests/get-test-source.sh
@@ -7,4 +7,7 @@
 # script directly.
 #
 set -eu
-find "$1" -name '*.kmn' | grep -E '(release|experimental)/([a-z0-9_]+)/([a-z0-9_]+)/source/\3\.kmn$'
+find "$1" -name '*.kmn' | \
+  grep -E '(release|experimental)/([a-z0-9_]+)/([a-z0-9_]+)/source/\3\.kmn$' | \
+  grep -v masaram_gondi
+# #12623: exclude masaram_gondi due to #11806


### PR DESCRIPTION
masaram_gondi.kmx fixture is built from a known-bad source, which is caught in kmcmplib 18.0.

This failure is because the keyboard source had non-BMP characters in the key part of the rule on line 215, which has been picked up by the 18.0 compiler in #11806:

```
$keymanonly: if(opt1 = 'gondi') any(Vyanjana)"𑵄" + any(Vyanjana)	>	index(Vyanjana,2) U+11D45
```

The trick here is that the compiled fixture developer/src/kmcmplib/tests/fixtures/keyboards-repo/masaram_gondi.kmx is based on a [broken version of the keyboard source](https://github.com/keymanapp/keyboards/blob/965ef1941f20a3bc0cb5d405792b4984cc46cd52/release/m/masaram_gondi/source/masaram_gondi.kmn) in the keyboards repo ([fixed version](https://github.com/keymanapp/keyboards/blob/06cfd2d186c9d5bf2fe2888a4121c746e87f2868/release/m/masaram_gondi/source/masaram_gondi.kmn)), and updating to the fixed version will also trigger updates to a bunch of other keyboards. I think the simplest resolution is probably to skip masaram_gondi for 18.0.

Relates-to: #12623
Relates-to: #11806

@keymanapp-test-bot skip