### PR TITLE
fix(developer): reconnect `--full-test` in kmcmplib build and enable for CI

### DIFF
--- a/developer/src/kmcmplib/build.bat
+++ b/developer/src/kmcmplib/build.bat
@@ -80,7 +80,11 @@ shift
 if "!COMMAND!" == "configure" (
   echo === Configuring Keyman KMX Compiler for Windows !ARCH! !BUILDTYPE! ===
   if exist build\!ARCH!\!BUILDTYPE! rd /s/q build\!ARCH!\!BUILDTYPE!
-  meson setup build\!ARCH!\!BUILDTYPE! !STATIC_LIBRARY! --buildtype !BUILDTYPE! --werror %1 %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
+  if "%1"=="--full-test" (
+    meson setup build\!ARCH!\!BUILDTYPE! !STATIC_LIBRARY! --buildtype !BUILDTYPE! --werror -D full_test=true %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
+  ) else (
+    meson setup build\!ARCH!\!BUILDTYPE! !STATIC_LIBRARY! --buildtype !BUILDTYPE! --werror %1 %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
+  )
   shift
 )
 

--- a/developer/src/kmcmplib/build.sh
+++ b/developer/src/kmcmplib/build.sh
@@ -7,6 +7,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 . "$THIS_SCRIPT_PATH/checkout-keyboards.inc.sh"
 . "$THIS_SCRIPT_PATH/commands.inc.sh"
 

--- a/developer/src/kmcmplib/build.sh
+++ b/developer/src/kmcmplib/build.sh
@@ -78,7 +78,7 @@ do_action() {
   done
 }
 
-if builder_has_option --full-test; then
+if should_do_full_test; then
   locate_keyboards_repo
 fi
 
@@ -101,7 +101,7 @@ if builder_start_action configure; then
   # We have to checkout the keyboards repo in a 'configure' action because
   # otherwise meson will not get the right list of keyboard source files,
   # even though we only use it in the 'test' action
-  if builder_has_option --full-test; then
+  if should_do_full_test; then
     checkout_keyboards
   fi
 

--- a/developer/src/kmcmplib/src/CompilerInterfaces.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfaces.cpp
@@ -1,5 +1,4 @@
 #include "pch.h"
-#include <clocale>
 #include <kmcmplibapi.h>
 #include <kmn_compiler_errors.h>
 #include "kmcmplib.h"
@@ -14,9 +13,6 @@ EXTERN bool kmcmp_CompileKeyboard(
   const void* procContext,
   KMCMP_COMPILER_RESULT& result
 ) {
-
-  std::setlocale(LC_ALL, "C.UTF-8");
-
   FILE_KEYBOARD fk;
   fk.extra = new KMCMP_COMPILER_RESULT_EXTRA;
   fk.extra->kmnFilename = pszInfile;

--- a/developer/src/kmcmplib/src/CompilerInterfaces.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfaces.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include <clocale>
 #include <kmcmplibapi.h>
 #include <kmn_compiler_errors.h>
 #include "kmcmplib.h"

--- a/developer/src/kmcmplib/src/CompilerInterfaces.cpp
+++ b/developer/src/kmcmplib/src/CompilerInterfaces.cpp
@@ -14,6 +14,8 @@ EXTERN bool kmcmp_CompileKeyboard(
   KMCMP_COMPILER_RESULT& result
 ) {
 
+  std::setlocale(LC_ALL, "C.UTF-8");
+
   FILE_KEYBOARD fk;
   fk.extra = new KMCMP_COMPILER_RESULT_EXTRA;
   fk.extra->kmnFilename = pszInfile;

--- a/developer/src/kmcmplib/tests/get-test-source.sh
+++ b/developer/src/kmcmplib/tests/get-test-source.sh
@@ -9,5 +9,6 @@
 set -eu
 find "$1" -name '*.kmn' | \
   grep -E '(release|experimental)/([a-z0-9_]+)/([a-z0-9_]+)/source/\3\.kmn$' | \
-  grep -v masaram_gondi
+  grep -vE 'masaram_gondi|anii|sil_kmhmu'
 # #12623: exclude masaram_gondi due to #11806
+# #12630: exclude anii, sil_kmhmu as ico references have mismatching case

--- a/developer/src/kmcmplib/tests/get-test-source.sh
+++ b/developer/src/kmcmplib/tests/get-test-source.sh
@@ -11,6 +11,6 @@ find "$1" -name '*.kmn' | \
   grep -E '(release|experimental)/([a-z0-9_]+)/([a-z0-9_]+)/source/\3\.kmn$' | \
   grep -vE 'masaram_gondi|anii|sil_kmhmu|fv_statimcets|fv_nuucaanul'
 # #12623: exclude masaram_gondi due to #11806
-# #12630: exclude anii, sil_kmhmu as ico references have mismatching case
-# #12630: exclude fv_statimcets, fv_nuucaanul as these include U+2002 which is not
+# #12631: exclude anii, sil_kmhmu as ico references have mismatching case
+# #12631: exclude fv_statimcets, fv_nuucaanul as these include U+2002 which is not
 #         treated as whitespace on mac arch

--- a/developer/src/kmcmplib/tests/get-test-source.sh
+++ b/developer/src/kmcmplib/tests/get-test-source.sh
@@ -9,6 +9,8 @@
 set -eu
 find "$1" -name '*.kmn' | \
   grep -E '(release|experimental)/([a-z0-9_]+)/([a-z0-9_]+)/source/\3\.kmn$' | \
-  grep -vE 'masaram_gondi|anii|sil_kmhmu'
+  grep -vE 'masaram_gondi|anii|sil_kmhmu|fv_statimcets|fv_nuucaanul'
 # #12623: exclude masaram_gondi due to #11806
 # #12630: exclude anii, sil_kmhmu as ico references have mismatching case
+# #12630: exclude fv_statimcets, fv_nuucaanul as these include U+2002 which is not
+#         treated as whitespace on mac arch

--- a/developer/src/kmcmplib/tests/util_callbacks.cpp
+++ b/developer/src/kmcmplib/tests/util_callbacks.cpp
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string>
+#include <algorithm>
 #include <kmcmplibapi.h>
 #include "util_filesystem.h"
 #include "../src/compfile.h"
@@ -29,6 +30,14 @@ void msgproc(const KMCMP_COMPILER_RESULT_MESSAGE &message, void* context) {
   printf(")\n");
 }
 
+void normalizeSlashes(std::string& s) {
+#ifdef _WIN32
+  std::replace(s.begin(), s.end(), '/', '\\');
+#else
+  std::replace(s.begin(), s.end(), '\\', '/');
+#endif
+}
+
 const std::vector<uint8_t> loadfileProc(const std::string& filename, const std::string& baseFilename) {
   std::string resolvedFilename = filename;
   if(baseFilename.length() && IsRelativePath(filename.c_str())) {
@@ -39,6 +48,8 @@ const std::vector<uint8_t> loadfileProc(const std::string& filename, const std::
       resolvedFilename.append(filename);
     }
   }
+
+  normalizeSlashes(resolvedFilename);
 
   std::vector<uint8_t> buf;
 

--- a/resources/build/build-utils-ci.inc.sh
+++ b/resources/build/build-utils-ci.inc.sh
@@ -8,6 +8,38 @@
 . "$KEYMAN_ROOT/resources/build/jq.inc.sh"
 
 #
+# Returns 0 if current build is running in CI, as a pull request test, or as a
+# mainline branch test, or as a release build
+#
+builder_is_ci_build() {
+  if builder_is_ci_release_build || builder_is_ci_test_build; then
+    return 0
+  fi
+  return 1
+}
+
+#
+# Returns 0 if current build is running as a release build in CI
+#
+builder_is_ci_release_build() {
+  if [[ "$VERSION_ENVIRONMENT" =~ ^alpha|beta|stable$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+#
+# Returns 0 if current build is running in CI, as a pull request test, or as a
+# mainline branch test
+#
+builder_is_ci_test_build() {
+  if [[ "$VERSION_ENVIRONMENT" == test ]]; then
+    return 0
+  fi
+  return 1
+}
+
+#
 # Returns 0 if current build is in CI and triggered from a pull request. If it
 # returns 0, then a call is made to GitHub to get pull request details, and the
 # PR details are added to $builder_pull_title, $builder_pull_number, and


### PR DESCRIPTION
The `--full-test` parameter in kmcmplib build.sh has not been working. This PR reconnects the parameter and also enables it by default for CI test builds (not release builds).

Note: the following keyboards are excluded because the snapshot versions have issues that the compiler now flags (these issues have all been resolved):

* (#12623) masaram_gondi: due to #11806
* (#12631) anii, sil_kmhmu: as ico references have mismatching case
* (#12631) fv_statimcets, fv_nuucaanul: as these include U+2002 which is not treated as whitespace on mac arch

See developer/src/kmcmplib/tests/get-test-source.sh

These keyboards could be included again if we update the snapshot to a later version -- but that requires a rebuild of the fixture expected keyboards with v16.0 compiler, so will necessarily exclude other keyboards which are now v17+.

Fixes: #12623

@keymanapp-test-bot skip