### PR TITLE
fix(windows): correct path to output file in publish step for fv keyboards

### DIFF
--- a/oem/firstvoices/windows/src/inst/build.sh
+++ b/oem/firstvoices/windows/src/inst/build.sh
@@ -16,7 +16,7 @@ builder_describe "Installation files for FirstVoices Keyboards" \
 # after all other builds complete
 
 builder_describe_outputs \
-  publish       /oem/firstvoices/windows/src/inst/firstvoices-${VERSION}.exe
+  publish       /windows/release/${VERSION}/firstvoices-${VERSION}.exe
 
 builder_parse "$@"
 


### PR DESCRIPTION
Addresses a build warning. The path for the output file corresponds to the publish step for Keyman.

Fixes: #12636

@keymanapp-test-bot skip