### PR TITLE
fix(windows): help links updated

### DIFF
--- a/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
+++ b/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
@@ -638,10 +638,10 @@ begin
   if Command in [HELP_CONTEXT, HELP_CONTEXTPOPUP, HELP_INDEX, HELP_CONTENTS] then
   begin
     case ActivePage of
-      apKeyboard: TKeymanDesktopShell.OpenHelp('context_onscreenkeyboard');
-      apCharacterMap: TKeymanDesktopShell.OpenHelp('context_charactermap');
-      apFontHelper: TKeymanDesktopShell.OpenHelp('context_fonthelper');
-      apEntryHelper: TKeymanDesktopShell.OpenHelp('context_entryhelper');
+      apKeyboard: TKeymanDesktopShell.OpenHelp('context/toolbox-onscreenkeyboard');
+      apCharacterMap: TKeymanDesktopShell.OpenHelp('context/toolbox-charactermap');
+      apFontHelper: TKeymanDesktopShell.OpenHelp('context/toolbox-_fonthelper');
+      apEntryHelper: TKeymanDesktopShell.OpenHelp('index');
     end;
   end;
 end;
@@ -1546,7 +1546,7 @@ end;
 
 procedure TfrmVisualKeyboard.BtnHelpClick(Sender: TObject);
 begin
-  TKeymanDesktopShell.OpenHelpJump('context_onscreenkeyboard', frmKeyman7Main.ActiveKeyboard);
+  TKeymanDesktopShell.OpenHelpJump('context/toolbox-onscreenkeyboard', frmKeyman7Main.ActiveKeyboard);
 end;
 
 procedure TfrmVisualKeyboard.BtnHideHint(Sender: TObject);

--- a/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
+++ b/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
@@ -1,4 +1,4 @@
-(*
+﻿(*
   Name:             UfrmVisualKeyboard
   Copyright:        Copyright (C) SIL International.
   Documentation:
@@ -1546,7 +1546,12 @@ end;
 
 procedure TfrmVisualKeyboard.BtnHelpClick(Sender: TObject);
 begin
-  TKeymanDesktopShell.OpenHelpJump('context/toolbox-onscreenkeyboard', frmKeyman7Main.ActiveKeyboard);
+  case ActivePage of
+    apKeyboard: TKeymanDesktopShell.OpenHelpJump('context/toolbox-onscreenkeyboard', frmKeyman7Main.ActiveKeyboard);
+    apCharacterMap: TKeymanDesktopShell.OpenHelpJump('context/toolbox-charactermap', frmKeyman7Main.ActiveKeyboard);
+    apFontHelper: TKeymanDesktopShell.OpenHelpJump('context/toolbox-_fonthelper', frmKeyman7Main.ActiveKeyboard);
+    apEntryHelper: TKeymanDesktopShell.OpenHelpJump('index', frmKeyman7Main.ActiveKeyboard);
+  end;
 end;
 
 procedure TfrmVisualKeyboard.BtnHideHint(Sender: TObject);

--- a/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
+++ b/windows/src/engine/keyman/viskbd/UfrmVisualKeyboard.pas
@@ -640,7 +640,7 @@ begin
     case ActivePage of
       apKeyboard: TKeymanDesktopShell.OpenHelp('context/toolbox-onscreenkeyboard');
       apCharacterMap: TKeymanDesktopShell.OpenHelp('context/toolbox-charactermap');
-      apFontHelper: TKeymanDesktopShell.OpenHelp('context/toolbox-_fonthelper');
+      apFontHelper: TKeymanDesktopShell.OpenHelp('context/toolbox-fonthelper');
       apEntryHelper: TKeymanDesktopShell.OpenHelp('index');
     end;
   end;
@@ -1549,7 +1549,7 @@ begin
   case ActivePage of
     apKeyboard: TKeymanDesktopShell.OpenHelpJump('context/toolbox-onscreenkeyboard', frmKeyman7Main.ActiveKeyboard);
     apCharacterMap: TKeymanDesktopShell.OpenHelpJump('context/toolbox-charactermap', frmKeyman7Main.ActiveKeyboard);
-    apFontHelper: TKeymanDesktopShell.OpenHelpJump('context/toolbox-_fonthelper', frmKeyman7Main.ActiveKeyboard);
+    apFontHelper: TKeymanDesktopShell.OpenHelpJump('context/toolbox-fonthelper', frmKeyman7Main.ActiveKeyboard);
     apEntryHelper: TKeymanDesktopShell.OpenHelpJump('index', frmKeyman7Main.ActiveKeyboard);
   end;
 end;


### PR DESCRIPTION
Fixes:#12463

The help link passed to the opening of the keyman help(CHM) on windows was broken for a number of the help links. This updates them.
Note: no help exists for apEntryHelper so it was set to the main `index` instead