### PR TITLE
fix(core): permanently disable logging

### DIFF
--- a/core/src/kmx/kmx_processevent.cpp
+++ b/core/src/kmx/kmx_processevent.cpp
@@ -12,7 +12,7 @@ using namespace kmx;
 /* Globals */
 
 KMX_BOOL km::core::kmx::g_debug_ToConsole = FALSE;
-KMX_BOOL km::core::kmx::g_debug_KeymanLog = TRUE;
+KMX_BOOL km::core::kmx::g_debug_KeymanLog = FALSE; // workaround for #12661
 KMX_BOOL km::core::kmx::g_silent = FALSE;
 
 /*


### PR DESCRIPTION
This change disables logging at compile time to work around #12661. Logging can be enabled in the debugger, or by re-compiling with `g_debug_KeymanLog` set to TRUE.

Related: #12661

# User Testing

**TEST_NOLOG**: Run this test on Linux to verify that logging is disabled

- open a terminal window and show the syslog: `tail -f /var/log/syslog`
- switch to a Keyman keyboard and type a few characters in any application, e.g. Writer
- verify that a keypress doesn't output lines containing `ibus-engine-keyman` in the `syslog`