### PR TITLE
chore(linux): add support for Ubuntu 25.04 Plucky Puffin

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [focal, jammy, noble]
+        dist: [focal, jammy, noble, oracular]
 
     steps:
     - name: Checkout
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [oracular]
+        dist: [plucky]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This change adds support for Plucky when building for llso/pso. #12614 already added support when building on Launchpad.

@keymanapp-test-bot skip