### PR TITLE
feat(windows): keyboard load blob 🎼

### DIFF
--- a/windows/src/engine/keyman32/K32_load.cpp
+++ b/windows/src/engine/keyman32/K32_load.cpp
@@ -108,7 +108,6 @@ BOOL LoadlpKeyboard(int i)
   }
 
   rewind(kmx_file);
-
   buffer = malloc(length);
 
   if (!buffer) {

--- a/windows/src/engine/keyman32/K32_load.cpp
+++ b/windows/src/engine/keyman32/K32_load.cpp
@@ -29,6 +29,7 @@
 */
 
 #include "pch.h"
+#include <stdio.h>
 
 BOOL GetKeyboardFileName(LPSTR kbname, LPSTR buf, int nbuf)
 {
@@ -78,13 +79,41 @@ BOOL LoadlpKeyboard(int i)
     _td->lpKeyboards[i].lpCoreKeyboardState = NULL;
   }
 
-  char buf[256];
-  if (!GetKeyboardFileName(_td->lpKeyboards[i].Name, buf, 255)) {
+  char kmx_filename[256];
+  if (!GetKeyboardFileName(_td->lpKeyboards[i].Name, kmx_filename, 255)) {
     return_SendDebugExit(FALSE);
   }
 
-  PWCHAR keyboardPath = strtowstr(buf);
-  km_core_status err_status = km_core_keyboard_load(keyboardPath, &_td->lpKeyboards[i].lpCoreKeyboard);
+  FILE* kmx_file;
+  errno_t status = fopen_s(&kmx_file, kmx_filename, "rb");
+  if (!status) {
+    SendDebugMessageFormat("Problem reading opening kmx_file %s status [%d].", kmx_filename, status);
+    return_SendDebugExit(FALSE);
+  }
+
+  fseek(kmx_file, 0, SEEK_END);
+  size_t length = ftell(kmx_file);
+  fseek(kmx_file, 0, SEEK_SET);
+  void* buffer = malloc(length);
+
+  if (!buffer) {
+    fclose(kmx_file);
+    return_SendDebugExit(FALSE);
+  }
+
+  if (fread(buffer, 1, length, kmx_file) != length) {
+    SendDebugMessageFormat("Problem reading entire kmx_file %s.", kmx_filename);
+    fclose(kmx_file);
+    free(buffer);
+    return_SendDebugExit(FALSE);
+  }
+
+  fclose(kmx_file);
+  PWCHAR keyboardPath = strtowstr(kmx_filename);
+  km_core_status err_status = km_core_keyboard_load_from_blob(keyboardPath, buffer, length, &_td->lpKeyboards[i].lpCoreKeyboard);
+
+  free(buffer);
+
   if (err_status != KM_CORE_STATUS_OK) {
     SendDebugMessageFormat("km_core_keyboard_load failed for %ls with error status [%d]", keyboardPath, err_status);
     delete[] keyboardPath;

--- a/windows/src/engine/keyman32/K32_load.cpp
+++ b/windows/src/engine/keyman32/K32_load.cpp
@@ -89,8 +89,8 @@ BOOL LoadlpKeyboard(int i)
   void* buffer = nullptr;
   errno_t status = fopen_s(&kmx_file, kmx_filename, "rb");
 
-  if (!status) {
-    SendDebugMessageFormat("Problem reading opening kmx_file %s status [%d].", kmx_filename, status);
+  if (status) {
+    SendDebugMessageFormat("Problem opening kmx_file %s status [%d].", kmx_filename, status);
     return_SendDebugExit(FALSE);
   }
 


### PR DESCRIPTION
Fixes: #12500 
Keyman Engine and one of the old unit tests has been updated to use keyman load.

# User Testing

**TEST_SWITCHING_KEYBOARDS**:  Keyman keyboards should still work as before, i.e. switch to a Keyman keyboard and verify that it behaves as expected. Switch to a second Keyman  keyboard and verify that is behaves as expected.