### PR TITLE
refactor(developer): output number of tests when running on TC

### DIFF
--- a/developer/src/common/web/utils/build.sh
+++ b/developer/src/common/web/utils/build.sh
@@ -46,18 +46,24 @@ function do_build() {
   tsc --build
 }
 
-builder_run_action clean       rm -rf ./build/
-builder_run_action configure   verify_npm_setup
-builder_run_action build       do_build
+function do_test() {
+  local MOCHA_FLAGS=
 
-if builder_start_action test; then
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
+
   eslint .
   tsc --build test
   readonly C8_THRESHOLD=50
-  c8 --reporter=lcov --reporter=text --exclude-after-remap --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha
+  c8 --reporter=lcov --reporter=text --exclude-after-remap --check-coverage=false --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha ${MOCHA_FLAGS}
   builder_echo warning "Coverage thresholds are currently $C8_THRESHOLD%, which is lower than ideal."
   builder_echo warning "Please increase threshold in build.sh as test coverage improves."
-  builder_finish_action success test
-fi
+}
 
-builder_run_action publish    builder_publish_npm
+builder_run_action clean       rm -rf ./build/
+builder_run_action configure   verify_npm_setup
+builder_run_action build       do_build
+builder_run_action test        do_test
+builder_run_action publish     builder_publish_npm

--- a/developer/src/kmc-analyze/build.sh
+++ b/developer/src/kmc-analyze/build.sh
@@ -26,12 +26,19 @@ builder_parse "$@"
 #-------------------------------------------------------------------------------------------------------------------
 
 function do_test() {
+  local MOCHA_FLAGS=
+
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
+
   eslint .
   cd test
   tsc --build
   cd ..
   readonly C8_THRESHOLD=70
-  c8 --reporter=lcov --reporter=text --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha
+  c8 --reporter=lcov --reporter=text --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha ${MOCHA_FLAGS}
 }
 
 builder_run_action clean      rm -rf ./build/

--- a/developer/src/kmc-copy/build.sh
+++ b/developer/src/kmc-copy/build.sh
@@ -32,12 +32,19 @@ builder_parse "$@"
 do_test() {
   # note: `export TEST_SAVE_ARTIFACTS=1` to save a copy of artifacts to temp path
   # note: `export TEST_SAVE_FIXTURES=1` to get a copy of cloud-based fixtures saved to online/
+  local MOCHA_FLAGS=
+
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
+
   eslint .
   cd test
   tsc --build
   cd ..
   readonly C8_THRESHOLD=70
-  c8 -skip-full --reporter=lcov --reporter=text --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha "${builder_extra_params[@]}"
+  c8 -skip-full --reporter=lcov --reporter=text --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha ${MOCHA_FLAGS} "${builder_extra_params[@]}"
   builder_echo warning "Coverage thresholds are currently $C8_THRESHOLD%, which is lower than ideal."
   builder_echo warning "Please increase threshold in build.sh as test coverage improves."
 }

--- a/developer/src/kmc-generate/build.sh
+++ b/developer/src/kmc-generate/build.sh
@@ -37,11 +37,18 @@ do_build() {
 }
 
 do_test() {
+  local MOCHA_FLAGS=
+
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
+
   eslint .
   cd test
   tsc --build
   cd ..
-  c8 --reporter=lcov --reporter=text mocha "${builder_extra_params[@]}"
+  c8 --reporter=lcov --reporter=text mocha ${MOCHA_FLAGS} "${builder_extra_params[@]}"
 }
 
 builder_run_action clean      rm -rf ./build/ ./tsconfig.tsbuildinfo

--- a/developer/src/kmc-keyboard-info/build.sh
+++ b/developer/src/kmc-keyboard-info/build.sh
@@ -32,23 +32,28 @@ function do_configure() {
   mkdir -p src/imports
   echo 'export default ' > src/imports/langtags.js
   cat "$KEYMAN_ROOT/resources/standards-data/langtags/langtags.json" >> src/imports/langtags.js
-
 }
+
+function do_test() {
+  local MOCHA_FLAGS=
+
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
+
+  eslint .
+  tsc --build test
+  c8 --reporter=lcov --reporter=text --exclude-after-remap --check-coverage=false mocha ${MOCHA_FLAGS}
+}
+
 #-------------------------------------------------------------------------------------------------------------------
 
 builder_run_action clean       rm -rf ./build/ ./tsconfig.tsbuildinfo
 builder_run_action configure   do_configure
 builder_run_action build       tsc --build
 builder_run_action api         api-extractor run --local --verbose
-
-#-------------------------------------------------------------------------------------------------------------------
-
-if builder_start_action test; then
-  eslint .
-  tsc --build test
-  c8 --reporter=lcov --reporter=text --exclude-after-remap mocha
-  builder_finish_action success test
-fi
+builder_run_action test        do_test
 
 #-------------------------------------------------------------------------------------------------------------------
 

--- a/developer/src/kmc-ldml/build.sh
+++ b/developer/src/kmc-ldml/build.sh
@@ -33,30 +33,19 @@ builder_describe_outputs \
 
 builder_parse "$@"
 
-#-------------------------------------------------------------------------------------------------------------------
-
-if builder_start_action clean; then
+function do_clean() {
   rm -rf ./build/ ./tsconfig.tsbuildinfo
-  builder_finish_action success clean
-fi
+}
 
-#-------------------------------------------------------------------------------------------------------------------
-
-if builder_start_action configure; then
+function do_configure() {
   verify_npm_setup
-  builder_finish_action success configure
-fi
+}
 
-#-------------------------------------------------------------------------------------------------------------------
-
-if builder_start_action build; then
+function do_build() {
   npm run build
-  builder_finish_action success build
-fi
+}
 
-#-------------------------------------------------------------------------------------------------------------------
-
-if builder_start_action build-fixtures; then
+function do_build_fixtures() {
   # Build basic.kmx and emit its checksum
   mkdir -p ./build/test/fixtures
   node ../kmc build ./test/fixtures/basic.xml --no-compiler-version --debug --out-file ./build/test/fixtures/basic-xml.kmx
@@ -65,22 +54,29 @@ if builder_start_action build-fixtures; then
 
   # Generate a binary file from basic.txt for comparison purposes
   node ../../../common/tools/hextobin/build/hextobin.js ./test/fixtures/basic.txt ./build/test/fixtures/basic-txt.kmx
+}
 
-  builder_finish_action success build-fixtures
-fi
+function do_test() {
+  local MOCHA_FLAGS=
 
-builder_run_action api        api-extractor run --local --verbose
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
 
-#-------------------------------------------------------------------------------------------------------------------
-
-if builder_start_action test; then
   eslint .
   cd test
   tsc -b
   cd ..
-  c8 --reporter=lcov --reporter=text mocha "${builder_extra_params[@]}"
-  builder_finish_action success test
-fi
+  c8 --reporter=lcov --reporter=text mocha ${MOCHA_FLAGS} "${builder_extra_params[@]}"
+}
+
+builder_run_action clean           do_clean
+builder_run_action configure       do_configure
+builder_run_action build           do_build
+builder_run_action build-fixtures  do_build_fixtures
+builder_run_action api             api-extractor run --local --verbose
+builder_run_action test            do_test
 
 #-------------------------------------------------------------------------------------------------------------------
 

--- a/developer/src/kmc-model-info/build.sh
+++ b/developer/src/kmc-model-info/build.sh
@@ -50,13 +50,20 @@ builder_run_action api        api-extractor run --local --verbose
 
 #-------------------------------------------------------------------------------------------------------------------
 
-if builder_start_action test; then
+function do_test() {
+  local MOCHA_FLAGS=
+
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
   eslint .
   tsc --build test
-  c8 --reporter=lcov --reporter=text --exclude-after-remap --lines 80 mocha
+  c8 --reporter=lcov --reporter=text --exclude-after-remap --check-coverage=false --lines 80 mocha ${MOCHA_FLAGS}
   # TODO: remove --lines 80 and improve coverage
-  builder_finish_action success test
-fi
+}
+
+builder_run_action test    do_test
 
 #-------------------------------------------------------------------------------------------------------------------
 

--- a/developer/src/kmc-model/build.sh
+++ b/developer/src/kmc-model/build.sh
@@ -35,10 +35,24 @@ function do_build() {
   npm run build
 }
 
+function do_test() {
+  local MOCHA_FLAGS=
+
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
+  npm run lint
+  cd test
+  tsc -b
+  cd ..
+  c8 --reporter=lcov --reporter=text mocha ${MOCHA_FLAGS}
+}
+
 builder_run_action clean        rm -rf ./build/ ./tsconfig.tsbuildinfo
 builder_run_action configure    verify_npm_setup
 builder_run_action build        do_build
 builder_run_action api          api-extractor run --local --verbose
-builder_run_action test         npm test
+builder_run_action test         do_test
 builder_run_action publish      builder_publish_npm
 

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "eslint .",
-    "test": "npm run lint && cd test && tsc -b && cd .. && c8 --reporter=lcov --reporter=text mocha"
+    "test": "./build.sh test"
   },
   "author": "Marc Durdin <marc@keyman.com> (https://github.com/mcdurdin)",
   "contributors": [

--- a/developer/src/kmc-package/build.sh
+++ b/developer/src/kmc-package/build.sh
@@ -30,20 +30,25 @@ builder_describe_outputs \
 
 builder_parse "$@"
 
+function do_test() {
+  local MOCHA_FLAGS=
+
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
+  eslint .
+  cd test
+  tsc --build
+  cd ..
+  c8 --reporter=lcov --reporter=text mocha ${MOCHA_FLAGS}
+}
+
 #-------------------------------------------------------------------------------------------------------------------
 
 builder_run_action clean      rm -rf ./build/ ./tsconfig.tsbuildinfo
 builder_run_action configure  verify_npm_setup
 builder_run_action build      tsc --build
 builder_run_action api        api-extractor run --local --verbose
-
-if builder_start_action test; then
-  eslint .
-  cd test
-  tsc --build
-  cd ..
-  c8 --reporter=lcov --reporter=text mocha
-  builder_finish_action success test
-fi
-
+builder_run_action test       do_test
 builder_run_action publish     builder_publish_npm

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -62,10 +62,17 @@ function do_api() {
 #-------------------------------------------------------------------------------------------------------------------
 
 function do_test() {
+  local MOCHA_FLAGS=
+
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
+
   eslint .
   tsc --build test/
   readonly C8_THRESHOLD=50
-  c8 --reporter=lcov --reporter=text --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha
+  c8 --reporter=lcov --reporter=text --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha ${MOCHA_FLAGS}
   builder_echo warning "Coverage thresholds are currently $C8_THRESHOLD%, which is lower than ideal."
   builder_echo warning "Please increase threshold in build.sh as test coverage improves."
 }


### PR DESCRIPTION
This change adds the mocha-teamcity-reporter which outputs the running tests in a special format that TeamCity can interpret. This allows TC to show which tests run as well as the number of tests run.

Also refactor some of the build scripts to use functions.

Note that we had to explicitly add `--check-coverage=false` (which is the default) to get successful builds when we run on TC.

@keymanapp-test-bot skip