### PR TITLE
refactor(developer): `km_core_keyboard_load_from_blob` in debugger 🎼

### DIFF
--- a/developer/src/tike/debug/Keyman.System.Debug.DebugCore.pas
+++ b/developer/src/tike/debug/Keyman.System.Debug.DebugCore.pas
@@ -57,7 +57,7 @@ begin
   FKeyboard := nil;
   FState := nil;
 
-  buffer := nil;
+  Buffer := nil;
   try
     fs := TFileStream.Create(Filename, fmOpenRead or fmShareDenyWrite);
     try

--- a/developer/src/tike/main/Keyman.System.KeymanCore.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCore.pas
@@ -245,8 +245,10 @@ type
 
   pkm_core_keyboard_attrs = ^km_core_keyboard_attrs;
 
-function km_core_keyboard_load(
-  kb_path: km_core_path_name;
+function km_core_keyboard_load_from_blob(
+  kb_name: km_core_path_name;
+  blob: Pointer;
+  blob_size: NativeUint;
   var keyboard: pkm_core_keyboard
 ): km_core_status; cdecl; external keymancore delayed;
 


### PR DESCRIPTION
Replaces `km_core_keyboard_load` with `km_core_keyboard_load_from_blob`.

Fixes: #12690

@keymanapp-test-bot skip