### PR TITLE
refactor(common): move all lexical model types into `LexicalModelTypes` container

### DIFF
--- a/common/web/types/src/main.ts
+++ b/common/web/types/src/main.ts
@@ -30,6 +30,6 @@ export { UnicodeSetParser, UnicodeSet } from './ldml-keyboard/unicodeset-parser-
 export { VariableParser, MarkerParser } from './ldml-keyboard/pattern-parser.js';
 export { ElementString } from './kmx/kmx-plus/element-string.js';
 
-export { USVString, CasingForm, CasingFunction, TextWithProbability, LexiconTraversal, LexicalModel, LexicalModelPunctuation, Transform, Suggestion, Reversion, Keep, SuggestionTag, Context, Distribution, Outcome, WithOutcome, ProbabilityMass, Configuration, Capabilities, WordBreakingFunction, Span } from './lexical-model-types.js';
+export * as LexicalModelTypes from './lexical-model-types.js';
 
 export * as KeymanWebKeyboard from './keyboard-object.js';

--- a/developer/src/kmc-model/src/join-word-breaker-decorator.ts
+++ b/developer/src/kmc-model/src/join-word-breaker-decorator.ts
@@ -1,4 +1,6 @@
-import { Span, WordBreakingFunction } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Span = LexicalModelTypes.Span;
+import WordBreakingFunction = LexicalModelTypes.WordBreakingFunction;
 
 /**
  * Returns a word breaker that joins spans of an existing word breaker.

--- a/developer/src/kmc-model/src/lexical-model.ts
+++ b/developer/src/kmc-model/src/lexical-model.ts
@@ -3,7 +3,10 @@
  * the LMLayer's internal worker code, so we provide those definitions too.
  */
 
-import { CasingFunction, LexicalModelPunctuation, WordBreakingFunction } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import CasingFunction = LexicalModelTypes.CasingFunction;
+import LexicalModelPunctuation = LexicalModelTypes.LexicalModelPunctuation;
+import WordBreakingFunction = LexicalModelTypes.WordBreakingFunction;
 
 export interface LexicalModelDeclaration {
   readonly format: 'trie-1.0'|'fst-foma-1.0'|'custom-1.0',

--- a/developer/src/kmc-model/src/model-defaults.ts
+++ b/developer/src/kmc-model/src/model-defaults.ts
@@ -1,4 +1,6 @@
-import { CasingForm, CasingFunction } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import CasingForm = LexicalModelTypes.CasingForm;
+import CasingFunction = LexicalModelTypes.CasingFunction;
 
 /**
  * Converts wordforms into an indexable form. It does this by

--- a/developer/src/kmc-model/src/model-definitions.ts
+++ b/developer/src/kmc-model/src/model-definitions.ts
@@ -5,7 +5,9 @@ import { defaultApplyCasing,
 
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
 import { LexicalModelSource, WordformToKeySpec } from "./lexical-model.js";
-import { CasingForm, CasingFunction } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import CasingForm = LexicalModelTypes.CasingForm;
+import CasingFunction = LexicalModelTypes.CasingFunction;
 
 /**
  * Processes certain defined model behaviors in such a way that the needed closures

--- a/developer/src/kmc-model/src/script-overrides-decorator.ts
+++ b/developer/src/kmc-model/src/script-overrides-decorator.ts
@@ -1,4 +1,6 @@
-import { Span, WordBreakingFunction } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Span = LexicalModelTypes.Span;
+import WordBreakingFunction = LexicalModelTypes.WordBreakingFunction;
 import { OverrideScriptDefaults } from "./lexical-model.js";
 import { ModelCompilerError, ModelCompilerMessages } from "./model-compiler-messages.js";
 

--- a/web/src/app/webview/src/configuration.ts
+++ b/web/src/app/webview/src/configuration.ts
@@ -3,14 +3,14 @@ import { EngineConfiguration, InitOptionSpec, InitOptionDefaults } from "keyman/
 import { buildMergedTransform } from '@keymanapp/models-templates';
 
 import { type OnInsertTextFunc } from "./contextManager.js";
-import { Transform } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 export class WebviewConfiguration extends EngineConfiguration {
   private _embeddingApp: string;
   private _oninserttext: OnInsertTextFunc;
   private _hostInsert: OnInsertTextFunc;
 
-  private pendingInserts: Transform[] = [];
+  private pendingInserts: LexicalModelTypes.Transform[] = [];
 
   initialize(options: Required<WebviewInitOptionSpec>) {
     super.initialize(options);

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -3,7 +3,7 @@ import { Mock, OutputTarget, Transcription, findCommonSubstringEndIndex, isEmpty
 import { KeyboardStub } from 'keyman/engine/keyboard-storage';
 import { ContextManagerBase } from 'keyman/engine/main';
 import { WebviewConfiguration } from './configuration.js';
-import { Transform } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 export type OnInsertTextFunc = (deleteLeft: number, text: string, deleteRight: number) => void;
 
@@ -17,7 +17,7 @@ export class ContextHost extends Mock {
     this.saveState();
   }
 
-  apply(transform: Transform): void {
+  apply(transform: LexicalModelTypes.Transform): void {
     super.apply(transform);
     this.updateHost();
   }

--- a/web/src/engine/interfaces/src/prediction/languageProcessor.interface.ts
+++ b/web/src/engine/interfaces/src/prediction/languageProcessor.interface.ts
@@ -1,12 +1,12 @@
-import { Suggestion, Reversion } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 import { EventEmitter } from "eventemitter3";
 import { OutputTarget } from "keyman/engine/keyboard";
 
 export class ReadySuggestions {
-  suggestions: Suggestion[];
+  suggestions: LexicalModelTypes.Suggestion[];
   transcriptionID: number;
 
-  constructor(suggestions: Suggestion[], id: number) {
+  constructor(suggestions: LexicalModelTypes.Suggestion[], id: number) {
     this.suggestions = suggestions;
     this.transcriptionID = id;
   }
@@ -56,7 +56,7 @@ export interface LanguageProcessorSpec extends EventEmitter<LanguageProcessorEve
 
   get state(): StateChangeEnum;
 
-  invalidateContext(outputTarget: OutputTarget, layerId: string): Promise<Suggestion[]>;
+  invalidateContext(outputTarget: OutputTarget, layerId: string): Promise<LexicalModelTypes.Suggestion[]>;
 
   /**
    *
@@ -66,9 +66,9 @@ export interface LanguageProcessorSpec extends EventEmitter<LanguageProcessorEve
    *                        required because layerid can be changed by PostKeystroke
    * @returns
    */
-  applySuggestion(suggestion: Suggestion, outputTarget: OutputTarget, getLayerId: () => string): Promise<Reversion>;
+  applySuggestion(suggestion: LexicalModelTypes.Suggestion, outputTarget: OutputTarget, getLayerId: () => string): Promise<LexicalModelTypes.Reversion>;
 
-  applyReversion(reversion: Reversion, outputTarget: OutputTarget): Promise<Suggestion[]>;
+  applyReversion(reversion: LexicalModelTypes.Reversion, outputTarget: OutputTarget): Promise<LexicalModelTypes.Suggestion[]>;
 
   get wordbreaksAfterSuggestions(): boolean;
 }

--- a/web/src/engine/interfaces/src/prediction/predictionContext.ts
+++ b/web/src/engine/interfaces/src/prediction/predictionContext.ts
@@ -1,5 +1,8 @@
 import { EventEmitter } from "eventemitter3";
-import { Keep, Reversion, Suggestion } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Keep = LexicalModelTypes.Keep;
+import Reversion = LexicalModelTypes.Reversion;
+import Suggestion = LexicalModelTypes.Suggestion;
 import { type LanguageProcessorSpec , ReadySuggestions, type InvalidateSourceEnum, StateChangeHandler } from './languageProcessor.interface.js';
 import { type OutputTarget } from "keyman/engine/keyboard";
 

--- a/web/src/engine/js-processor/src/outputTarget.ts
+++ b/web/src/engine/js-processor/src/outputTarget.ts
@@ -8,18 +8,18 @@ extendString();
 // Defines deadkey management in a manner attachable to each element interface.
 import { type KeyEvent } from 'keyman/engine/keyboard';
 import { Deadkey, DeadkeyTracker } from "./deadkeys.js";
-import { ProbabilityMass, Transform } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 // Also relies on string-extensions provided by the web-utils package.
 
-export function isEmptyTransform(transform: Transform) {
+export function isEmptyTransform(transform: LexicalModelTypes.Transform) {
   if(!transform) {
     return true;
   }
   return transform.insert === '' && transform.deleteLeft === 0 && (transform.deleteRight ?? 0) === 0;
 }
 
-export class TextTransform implements Transform {
+export class TextTransform implements LexicalModelTypes.Transform {
   readonly insert: string;
   readonly deleteLeft: number;
   readonly deleteRight: number;
@@ -64,7 +64,7 @@ export class Transcription {
   }
 }
 
-export type Alternate = ProbabilityMass<Transform>;
+export type Alternate = LexicalModelTypes.ProbabilityMass<LexicalModelTypes.Transform>;
 
 export default abstract class OutputTarget implements OutputTargetInterface {
   private _dks: DeadkeyTracker;
@@ -173,7 +173,7 @@ export default abstract class OutputTarget implements OutputTargetInterface {
     this._dks = original._dks.clone();
   }
 
-  apply(transform: Transform) {
+  apply(transform: LexicalModelTypes.Transform) {
     // Selected text should disappear on any text edit; application of a transform
     // certainly qualifies.
     this.clearSelection();

--- a/web/src/engine/js-processor/src/ruleBehavior.ts
+++ b/web/src/engine/js-processor/src/ruleBehavior.ts
@@ -3,7 +3,7 @@ import { VariableStoreDictionary } from "keyman/engine/keyboard";
 import OutputTarget, { type Transcription } from './outputTarget.js';
 import { Mock } from "./mock.js";
 import { type VariableStore } from "./systemStores.js";
-import { Suggestion } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 /**
  * Represents the commands and state changes that result from a matched keyboard rule.
@@ -53,7 +53,7 @@ export default class RuleBehavior {
   /**
    * If predictive text is active, contains a Promise returning predictive Suggestions.
    */
-  predictionPromise?: Promise<Suggestion[]>;
+  predictionPromise?: Promise<LexicalModelTypes.Suggestion[]>;
 
   /**
    * In reference to https://github.com/keymanapp/keyman/pull/4350#issuecomment-768753852:

--- a/web/src/engine/main/src/headless/contextWindow.ts
+++ b/web/src/engine/main/src/headless/contextWindow.ts
@@ -1,10 +1,10 @@
-import { CasingForm, Configuration, Context } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 import { Mock } from "keyman/engine/js-processor";
 
-export default class ContextWindow implements Context {
+export default class ContextWindow implements LexicalModelTypes.Context {
   // Used to limit the range of context replicated for use of keyboard rules within
   // the engine, as used for fat-finger prep / `Alternate` generation.
-  public static readonly ENGINE_RULE_WINDOW: Configuration = {
+  public static readonly ENGINE_RULE_WINDOW: LexicalModelTypes.Configuration = {
     leftContextCodePoints: 64,
     rightContextCodePoints: 32
   };
@@ -15,9 +15,9 @@ export default class ContextWindow implements Context {
   startOfBuffer: boolean;
   endOfBuffer: boolean;
 
-  casingForm?: CasingForm;
+  casingForm?: LexicalModelTypes.CasingForm;
 
-  constructor(mock: Mock, config: Configuration, layerId: string) {
+  constructor(mock: Mock, config: LexicalModelTypes.Configuration, layerId: string) {
     this.left = mock.getTextBeforeCaret();
     this.startOfBuffer = this.left._kmwLength() <= config.leftContextCodePoints;
     if(!this.startOfBuffer) {

--- a/web/src/engine/main/src/headless/inputProcessor.ts
+++ b/web/src/engine/main/src/headless/inputProcessor.ts
@@ -19,7 +19,7 @@ import {
 } from 'keyman/engine/js-processor';
 
 import { TranscriptionCache } from "./transcriptionCache.js";
-import { Transform } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 export class InputProcessor {
   public static readonly DEFAULT_OPTIONS: ProcessorInitOptions = {
@@ -355,7 +355,7 @@ export class InputProcessor {
           //
           // Also possible that this set of conditions fail for all evaluated alternates.
           if(alternateBehavior && !alternateBehavior.beep && pair.p > 0) {
-            let transform: Transform = alternateBehavior.transcription.transform;
+            let transform: LexicalModelTypes.Transform = alternateBehavior.transcription.transform;
 
             // Ensure that the alternate's token id matches that of the current keystroke, as we only
             // record the matched rule's context (since they match)

--- a/web/src/engine/main/src/headless/languageProcessor.ts
+++ b/web/src/engine/main/src/headless/languageProcessor.ts
@@ -4,7 +4,11 @@ import { OutputTarget, Transcription, Mock } from "keyman/engine/js-processor";
 import { LanguageProcessorEventMap, ModelSpec, StateChangeEnum, ReadySuggestions } from 'keyman/engine/interfaces';
 import ContextWindow from "./contextWindow.js";
 import { TranscriptionCache } from "./transcriptionCache.js";
-import { Capabilities, Configuration, Reversion, Suggestion } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Capabilities = LexicalModelTypes.Capabilities;
+import Configuration = LexicalModelTypes.Configuration;
+import Reversion = LexicalModelTypes.Reversion;
+import Suggestion = LexicalModelTypes.Suggestion;
 
 /* Is more like the model configuration engine */
 export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -19,7 +19,7 @@ import { ParsedLengthStyle } from '../lengthStyle.js';
 import { getFontSizeStyle } from '../fontSizeUtils.js';
 import { getTextMetrics } from '../keyboard-layout/getTextMetrics.js';
 import { BannerScrollState } from './bannerScrollState.js';
-import { Suggestion } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 const TOUCHED_CLASS: string = 'kmw-suggest-touched';
 const BANNER_SCROLLER_CLASS = 'kmw-suggest-banner-scroller';
@@ -82,7 +82,7 @@ export class BannerSuggestion {
 
   public readonly rtl: boolean;
 
-  private _suggestion: Suggestion;
+  private _suggestion: LexicalModelTypes.Suggestion;
 
   private index: number;
 
@@ -142,18 +142,18 @@ export class BannerSuggestion {
     }
   }
 
-  get suggestion(): Suggestion {
+  get suggestion(): LexicalModelTypes.Suggestion {
     return this._suggestion;
   }
 
   /**
    * Function update
-   * @param {Suggestion} suggestion   Suggestion from the lexical model
+   * @param {LexicalModelTypes.Suggestion} suggestion   Suggestion from the lexical model
    * @param {BannerSuggestionFormatSpec} format Formatting metadata to use for the Suggestion
    *
    * Update the ID and text of the BannerSuggestionSpec
    */
-  public update(suggestion: Suggestion, format: BannerSuggestionFormatSpec) {
+  public update(suggestion: LexicalModelTypes.Suggestion, format: BannerSuggestionFormatSpec) {
     this._suggestion = suggestion;
 
     let display = this.generateSuggestionText(this.rtl);
@@ -384,7 +384,7 @@ export class SuggestionBanner extends Banner {
 
   public readonly type = "suggestion";
 
-  private currentSuggestions: Suggestion[] = [];
+  private currentSuggestions: LexicalModelTypes.Suggestion[] = [];
 
   private options : BannerSuggestion[] = [];
   private separators: HTMLElement[] = [];
@@ -715,7 +715,7 @@ export class SuggestionBanner extends Banner {
    * suggestions, including optimization of the banner's layout.
    * @param suggestions
    */
-  public onSuggestionUpdate = (suggestions: Suggestion[]): void => {
+  public onSuggestionUpdate = (suggestions: LexicalModelTypes.Suggestion[]): void => {
     this.currentSuggestions = suggestions;
     // Immediately stop all animations and reset options accordingly.
     this.highlightAnimation?.cancel();

--- a/web/src/engine/predictive-text/templates/src/common.ts
+++ b/web/src/engine/predictive-text/templates/src/common.ts
@@ -1,5 +1,11 @@
 // Allows the kmwstring bindings to resolve.
-import { CasingForm, Context, Outcome, Suggestion, Transform, WithOutcome } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import CasingForm = LexicalModelTypes.CasingForm;
+import Context = LexicalModelTypes.Context;
+import Outcome = LexicalModelTypes.Outcome;
+import Suggestion = LexicalModelTypes.Suggestion;
+import Transform = LexicalModelTypes.Transform;
+import WithOutcome = LexicalModelTypes.WithOutcome;
 import { extendString } from "@keymanapp/web-utils";
 
 extendString();

--- a/web/src/engine/predictive-text/templates/src/quote-behavior.ts
+++ b/web/src/engine/predictive-text/templates/src/quote-behavior.ts
@@ -1,4 +1,4 @@
-import { LexicalModelPunctuation } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 export enum QuoteBehavior {
   noQuotes  = "no-quotes",
@@ -14,7 +14,7 @@ export namespace QuoteBehavior {
    * @param punctuation  The active `LexicalModelPunctuation` settings
    * @param defaultTo    The default quote behavior to use (in case the current value is `.default`)
    */
-  export function apply(behavior: QuoteBehavior, text: string, punctuation: LexicalModelPunctuation, defaultTo: QuoteBehavior): string {
+  export function apply(behavior: QuoteBehavior, text: string, punctuation: LexicalModelTypes.LexicalModelPunctuation, defaultTo: QuoteBehavior): string {
     if(defaultTo == QuoteBehavior.default || !defaultTo) {
       throw "Specified quote behavior may be ambiguous - default behavior not specified (may not be .default)";
     }

--- a/web/src/engine/predictive-text/templates/src/tokenization.ts
+++ b/web/src/engine/predictive-text/templates/src/tokenization.ts
@@ -1,7 +1,7 @@
 // While we _could_ define this within @keymanapp/models-wordbreakers instead, it's probably
 // better to leave that package as _just_ the wordbreakers.
 
-import { WordBreakingFunction, USVString, Context } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 export interface Token {
   text: string,
@@ -30,8 +30,8 @@ export interface Tokenization {
 }
 
 export function tokenize(
-  wordBreaker: WordBreakingFunction,
-  context: Partial<Context>,
+  wordBreaker: LexicalModelTypes.WordBreakingFunction,
+  context: Partial<LexicalModelTypes.Context>,
   options?: {
     /** Characters to rejoin to preceding tokens if found immediately pre-caret. */
     rejoins?: string[]
@@ -197,7 +197,7 @@ export function tokenize(
  * If the last 'token' before the caret is whitespace, returns `''`.
  * @param fullLeftContext the entire left context of the string.
  */
-export function getLastPreCaretToken(wordBreaker: WordBreakingFunction, context: Context): string {
+export function getLastPreCaretToken(wordBreaker: LexicalModelTypes.WordBreakingFunction, context: LexicalModelTypes.Context): string {
   let tokenization = tokenize(wordBreaker, context);
   if (tokenization.left.length > 0) {
     const lastToken = tokenization.left.pop();
@@ -214,6 +214,6 @@ export function getLastPreCaretToken(wordBreaker: WordBreakingFunction, context:
 // While it is currently identical to getLastWord, this may change in the future.
 // It's best not to write ourselves into a corner on this one, as disambiguating later
 // would likely be pretty painful.
-export function wordbreak(wordBreaker: WordBreakingFunction, context: Context): USVString {
+export function wordbreak(wordBreaker: LexicalModelTypes.WordBreakingFunction, context: LexicalModelTypes.Context): LexicalModelTypes.USVString {
   return getLastPreCaretToken(wordBreaker, context);
 }

--- a/web/src/engine/predictive-text/templates/src/trie-model.ts
+++ b/web/src/engine/predictive-text/templates/src/trie-model.ts
@@ -31,7 +31,21 @@ import { default as defaultWordBreaker } from "@keymanapp/models-wordbreakers";
 
 import { applyTransform, isHighSurrogate, isSentinel, SENTINEL_CODE_UNIT, transformToSuggestion } from "./common.js";
 import { getLastPreCaretToken } from "./tokenization.js";
-import { Capabilities, CasingFunction, Configuration, Context, Distribution, LexicalModel, LexicalModelPunctuation, LexiconTraversal, Suggestion, TextWithProbability, Transform, USVString, WithOutcome, WordBreakingFunction } from '@keymanapp/common-types';
+import { LexicalModelTypes } from "@keymanapp/common-types";
+import Capabilities = LexicalModelTypes.Capabilities;
+import CasingFunction = LexicalModelTypes.CasingFunction;
+import Configuration = LexicalModelTypes.Configuration;
+import Context = LexicalModelTypes.Context;
+import Distribution = LexicalModelTypes.Distribution;
+import LexicalModel = LexicalModelTypes.LexicalModel;
+import LexicalModelPunctuation = LexicalModelTypes.LexicalModelPunctuation;
+import LexiconTraversal = LexicalModelTypes.LexiconTraversal;
+import Suggestion = LexicalModelTypes.Suggestion;
+import TextWithProbability = LexicalModelTypes.TextWithProbability;
+import Transform = LexicalModelTypes.Transform;
+import USVString = LexicalModelTypes.USVString;
+import WithOutcome = LexicalModelTypes.WithOutcome;
+import WordBreakingFunction = LexicalModelTypes.WordBreakingFunction;
 
 extendString();
 

--- a/web/src/engine/predictive-text/types/message.d.ts
+++ b/web/src/engine/predictive-text/types/message.d.ts
@@ -20,7 +20,11 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Configuration, Reversion, Suggestion, USVString } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Configuration = LexicalModelTypes.Configuration;
+import Reversion = LexicalModelTypes.Reversion;
+import Suggestion = LexicalModelTypes.Suggestion;
+import USVString = LexicalModelTypes.USVString;
 
 /**
  * Tokens are signed 31-bit integers!

--- a/web/src/engine/predictive-text/wordbreakers/src/main/ascii.ts
+++ b/web/src/engine/predictive-text/wordbreakers/src/main/ascii.ts
@@ -1,13 +1,13 @@
-import { Span } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 /**
  * Splits ASCII words.
  *
  * @param phrase
  */
-export default function ascii(phrase: string): Span[] {
+export default function ascii(phrase: string): LexicalModelTypes.Span[] {
   let matchWord = /[A-Za-z0-9']+/g;
-  let words: Span[] = [];
+  let words: LexicalModelTypes.Span[] = [];
   let match: RegExpExecArray | null;
   while ((match = matchWord.exec(phrase)) !== null) {
     words.push(new RegExpDerivedSpan(match[0], match.index));
@@ -20,7 +20,7 @@ export default function ascii(phrase: string): Span[] {
  * A concrete span class that derives its properties from the result of
  * RegExp.exec() array.
  */
-class RegExpDerivedSpan implements Span {
+class RegExpDerivedSpan implements LexicalModelTypes.Span {
   readonly text: string;
   readonly start: number;
 

--- a/web/src/engine/predictive-text/wordbreakers/src/main/default/index.ts
+++ b/web/src/engine/predictive-text/wordbreakers/src/main/default/index.ts
@@ -1,4 +1,4 @@
-import { Span } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 import { WordBreakProperty, propertyMap } from "./data.inc.js";
 
 import { searchForProperty } from "./searchForProperty.js";
@@ -38,7 +38,7 @@ export interface DefaultWordBreakerOptions {
  * @see http://unicode.org/reports/tr29/#Word_Boundaries
  * @see https://github.com/eddieantonio/unicode-default-word-boundary/tree/v12.0.0
  */
-export default function default_(text: string, options?: DefaultWordBreakerOptions): Span[] {
+export default function default_(text: string, options?: DefaultWordBreakerOptions): LexicalModelTypes.Span[] {
   let boundaries = findBoundaries(text, options);
   if (boundaries.length == 0) {
     return [];
@@ -67,7 +67,7 @@ export default function default_(text: string, options?: DefaultWordBreakerOptio
 /**
  * A span that does not cut out the substring until it absolutely has to!
  */
-class LazySpan implements Span {
+class LazySpan implements LexicalModelTypes.Span {
   private _source: string;
   readonly start: number;
   readonly end: number;

--- a/web/src/engine/predictive-text/wordbreakers/src/main/placeholder.ts
+++ b/web/src/engine/predictive-text/wordbreakers/src/main/placeholder.ts
@@ -1,4 +1,4 @@
-import { Span } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 /**
  * A **VERY** dumb word breaker that simply splits at words. Do not use this
@@ -7,7 +7,7 @@ import { Span } from '@keymanapp/common-types';
  * @param phrase The phrase in which to break words.
  * @deprecated Use a word breaker tailored to your language instead!
  */
-export default function placeholder(phrase: string): Span[] {
+export default function placeholder(phrase: string): LexicalModelTypes.Span[] {
   let nextStart = 0;
   return phrase.split(/\s+/).map(utterance => {
     // XXX: The indices are NOT accurate to the original phrase!

--- a/web/src/engine/predictive-text/worker-main/src/lmlayer.ts
+++ b/web/src/engine/predictive-text/worker-main/src/lmlayer.ts
@@ -20,7 +20,15 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Capabilities, Configuration, Context, Distribution, Reversion, Suggestion, Transform, USVString } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Capabilities = LexicalModelTypes.Capabilities;
+import Configuration = LexicalModelTypes.Configuration;
+import Context = LexicalModelTypes.Context;
+import Distribution = LexicalModelTypes.Distribution;
+import Reversion = LexicalModelTypes.Reversion;
+import Suggestion = LexicalModelTypes.Suggestion;
+import Transform = LexicalModelTypes.Transform;
+import USVString = LexicalModelTypes.USVString;
 import PromiseStore from "./promise-store.js";
 import { OutgoingMessage } from '@keymanapp/lm-message-types';
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -5,7 +5,13 @@ import { SearchSpace } from './distance-modeler.js';
 import TransformUtils from '../transformUtils.js';
 import { determineModelTokenizer } from '../model-helpers.js';
 import { tokenizeTransform, tokenizeTransformDistribution } from './transform-tokenization.js';
-import { Context, Distribution, LexicalModel, Suggestion, Transform, USVString } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Context = LexicalModelTypes.Context;
+import Distribution = LexicalModelTypes.Distribution;
+import LexicalModel = LexicalModelTypes.LexicalModel;
+import Suggestion = LexicalModelTypes.Suggestion;
+import Transform = LexicalModelTypes.Transform;
+import USVString = LexicalModelTypes.USVString;
 
 function textToCharTransforms(text: string, transformId?: number) {
   let perCharTransforms: Transform[] = [];

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/distance-modeler.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/distance-modeler.ts
@@ -3,7 +3,13 @@ import { QueueComparator as Comparator, PriorityQueue } from '@keymanapp/web-uti
 
 import { ClassicalDistanceCalculation, EditToken } from './classical-calculation.js';
 import { ExecutionTimer, STANDARD_TIME_BETWEEN_DEFERS } from './execution-timer.js';
-import { Distribution, LexicalModel, LexiconTraversal, ProbabilityMass, Transform, USVString } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Distribution = LexicalModelTypes.Distribution;
+import LexicalModel = LexicalModelTypes.LexicalModel;
+import LexiconTraversal = LexicalModelTypes.LexiconTraversal;
+import ProbabilityMass = LexicalModelTypes.ProbabilityMass;
+import Transform = LexicalModelTypes.Transform;
+import USVString = LexicalModelTypes.USVString;
 
 type RealizedInput = ProbabilityMass<Transform>[];  // NOT Distribution - they're masses from separate distributions.
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/transform-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/transform-tokenization.ts
@@ -1,4 +1,7 @@
-import { Context, Distribution, Transform } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Context = LexicalModelTypes.Context;
+import Distribution = LexicalModelTypes.Distribution;
+import Transform = LexicalModelTypes.Transform;
 import { applyTransform, type Tokenization } from "@keymanapp/models-templates";
 
 /**

--- a/web/src/engine/predictive-text/worker-thread/src/main/index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/index.ts
@@ -40,7 +40,9 @@ import * as wordBreakers from '@keymanapp/models-wordbreakers';
 
 import ModelCompositor from './model-compositor.js';
 import { ImportScripts, IncomingMessage, LMLayerWorkerState, LoadMessage, ModelEval, ModelFile, ModelSourceSpec, PostMessage } from './worker-interfaces.js';
-import { Capabilities, LexicalModel } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Capabilities = LexicalModelTypes.Capabilities;
+import LexicalModel = LexicalModelTypes.LexicalModel;
 import { OutgoingMessageKind } from '@keymanapp/lm-message-types';
 
 /**

--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -4,7 +4,16 @@ import * as correction from './correction/index.js'
 import TransformUtils from './transformUtils.js';
 import { correctAndEnumerate, dedupeSuggestions, finalizeSuggestions, predictionAutoSelect, processSimilarity, toAnnotatedSuggestion, tupleDisplayOrderSort } from './predict-helpers.js';
 import { detectCurrentCasing, determineModelTokenizer, determineModelWordbreaker, determinePunctuationFromModel } from './model-helpers.js';
-import { CasingForm, Context, Distribution, LexicalModel, LexicalModelPunctuation, Reversion, Suggestion, Transform, USVString } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import CasingForm = LexicalModelTypes.CasingForm;
+import Context = LexicalModelTypes.Context;
+import Distribution = LexicalModelTypes.Distribution;
+import LexicalModel = LexicalModelTypes.LexicalModel;
+import LexicalModelPunctuation = LexicalModelTypes.LexicalModelPunctuation;
+import Reversion = LexicalModelTypes.Reversion;
+import Suggestion = LexicalModelTypes.Suggestion;
+import Transform = LexicalModelTypes.Transform;
+import USVString = LexicalModelTypes.USVString;
 
 export class ModelCompositor {
   private lexicalModel: LexicalModel;

--- a/web/src/engine/predictive-text/worker-thread/src/main/model-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-helpers.ts
@@ -1,4 +1,8 @@
-import { CasingForm, Context, LexicalModel, LexicalModelPunctuation } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import CasingForm = LexicalModelTypes.CasingForm;
+import Context = LexicalModelTypes.Context;
+import LexicalModel = LexicalModelTypes.LexicalModel;
+import LexicalModelPunctuation = LexicalModelTypes.LexicalModelPunctuation;
 import * as models from '@keymanapp/models-templates';
 import * as wordBreakers from '@keymanapp/models-wordbreakers';
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/models/dummy-model.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/models/dummy-model.ts
@@ -1,6 +1,17 @@
 /// <reference types="@keymanapp/lm-message-types" />
 
-import { Capabilities, CasingForm, Configuration, Context, Distribution, LexicalModel, LexicalModelPunctuation, Outcome, Suggestion, Transform, WordBreakingFunction } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Capabilities = LexicalModelTypes.Capabilities;
+import CasingForm = LexicalModelTypes.CasingForm;
+import Configuration = LexicalModelTypes.Configuration;
+import Context = LexicalModelTypes.Context;
+import Distribution = LexicalModelTypes.Distribution;
+import LexicalModel = LexicalModelTypes.LexicalModel;
+import LexicalModelPunctuation = LexicalModelTypes.LexicalModelPunctuation;
+import Outcome = LexicalModelTypes.Outcome;
+import Suggestion = LexicalModelTypes.Suggestion;
+import Transform = LexicalModelTypes.Transform;
+import WordBreakingFunction = LexicalModelTypes.WordBreakingFunction;
 
 /*
  * Copyright (c) 2018 National Research Council Canada (author: Eddie A. Santos)

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -5,7 +5,17 @@ import { determineModelTokenizer, determineModelWordbreaker, determinePunctuatio
 import { ContextTracker, TrackedContextState } from './correction/context-tracker.js';
 import { ExecutionTimer } from './correction/execution-timer.js';
 import ModelCompositor from './model-compositor.js';
-import { ProbabilityMass, Suggestion, LexicalModel, Distribution, Outcome, Keep, SuggestionTag, Reversion, Transform, Context } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Context = LexicalModelTypes.Context;
+import Distribution = LexicalModelTypes.Distribution;
+import Keep = LexicalModelTypes.Keep;
+import LexicalModel = LexicalModelTypes.LexicalModel;
+import Outcome = LexicalModelTypes.Outcome;
+import ProbabilityMass = LexicalModelTypes.ProbabilityMass;
+import Reversion = LexicalModelTypes.Reversion;
+import Suggestion = LexicalModelTypes.Suggestion;
+import SuggestionTag = LexicalModelTypes.SuggestionTag;
+import Transform = LexicalModelTypes.Transform;
 
 /*
  * The functions in this file exist to provide unit-testable stateless components for the

--- a/web/src/engine/predictive-text/worker-thread/src/main/transformUtils.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/transformUtils.ts
@@ -1,17 +1,17 @@
-import { Transform } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
 export default class TransformUtils {
-  static isWhitespace(transform: Transform): boolean {
+  static isWhitespace(transform: LexicalModelTypes.Transform): boolean {
     // Matches a string that is entirely one or more characters with Unicode general property Z* or the following: CR, LF, and Tab.
     const whitespaceRemover = /^[\u0009\u000A\u000D\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u2028\u2029\u202f\u205f\u3000]+$/i;
     return transform.insert.match(whitespaceRemover) != null;
   }
 
-  static isBackspace(transform: Transform): boolean {
+  static isBackspace(transform: LexicalModelTypes.Transform): boolean {
     return transform.insert == "" && transform.deleteLeft > 0 && !transform.deleteRight;
   }
 
-  static isEmpty(transform: Transform): boolean {
+  static isEmpty(transform: LexicalModelTypes.Transform): boolean {
     return transform.insert == '' && transform.deleteLeft == 0 && !transform.deleteRight;
   }
 }

--- a/web/src/engine/predictive-text/worker-thread/src/main/worker-interfaces.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/worker-interfaces.ts
@@ -28,7 +28,14 @@
 
 /// <reference types="@keymanapp/lm-message-types" />
 
-import { Capabilities, Context, Distribution, LexicalModel, Reversion, Suggestion, Transform } from '@keymanapp/common-types';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Capabilities = LexicalModelTypes.Capabilities;
+import Context = LexicalModelTypes.Context;
+import Distribution = LexicalModelTypes.Distribution;
+import LexicalModel = LexicalModelTypes.LexicalModel;
+import Reversion = LexicalModelTypes.Reversion;
+import Suggestion = LexicalModelTypes.Suggestion;
+import Transform = LexicalModelTypes.Transform;
 import type ModelCompositor from './model-compositor.js';
 import { Token } from '@keymanapp/models-templates';
 


### PR DESCRIPTION
Many of the types had very generic names (e.g. `Configuration`), and as the types are now exported from `@keymanapp/common-types`, this was unhelpful.

For units with many references, I used TypeScript's import-equals to reduce the change impact. For units with only a few references, I added the `LexicalModelTypes.` prefix to the references in source.

(Best reference I could find for import-equals: https://github.com/evanw/esbuild/commit/b722fa4e49174d474cd5d6900fe0a1678ba7bcb4)

Fixes: #12516

@keymanapp-test-bot skip