### PR TITLE
refactor(common): output number of tests when running on TC

### DIFF
--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -80,13 +80,20 @@ function do_configure() {
 }
 
 function do_test() {
+  local MOCHA_FLAGS=
+
+  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+    # we're running in TeamCity
+    MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
+  fi
+
   eslint .
   tsc --build test
 
   readonly C8_THRESHOLD=60
 
   # Excludes are defined in .c8rc.json
-  c8 -skip-full --reporter=lcov --reporter=text --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha "${builder_extra_params[@]}"
+  c8 -skip-full --reporter=lcov --reporter=text --lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD mocha ${MOCHA_FLAGS} "${builder_extra_params[@]}"
   builder_echo warning "Coverage thresholds are currently $C8_THRESHOLD%, which is lower than ideal."
   builder_echo warning "Please increase threshold in build.sh as test coverage improves."
 }


### PR DESCRIPTION
This change adds the mocha-teamcity-reporter which outputs the running tests in a special format that TeamCity can interpret. This allows TC to show which tests run as well as the number of tests run.

@keymanapp-test-bot skip