### PR TITLE
fix(core): permanently disable logging 🍒

### DIFF
--- a/core/src/kmx/kmx_processevent.cpp
+++ b/core/src/kmx/kmx_processevent.cpp
@@ -12,7 +12,7 @@ using namespace kmx;
 /* Globals */
 
 KMX_BOOL km::core::kmx::g_debug_ToConsole = FALSE;
-KMX_BOOL km::core::kmx::g_debug_KeymanLog = TRUE;
+KMX_BOOL km::core::kmx::g_debug_KeymanLog = FALSE; // workaround for #12661
 KMX_BOOL km::core::kmx::g_silent = FALSE;
 
 /*


### PR DESCRIPTION
This change disables logging at compile time to work around #12661. Logging can be enabled in the debugger, or by re-compiling with `g_debug_KeymanLog` set to TRUE.

Related: #12661
Cherry-pick: #12674

@keymanapp-test-bot skip