### PR TITLE
fix(linux): disable assertions in release builds of ibus-keyman

### DIFF
--- a/linux/ibus-keyman/meson.build
+++ b/linux/ibus-keyman/meson.build
@@ -8,6 +8,11 @@ project('ibus-keyman', 'c', 'cpp',
 # meson doesn't allow us to reference a file outside its root
 subdir('resources')
 
+if get_option('buildtype') != 'debug'
+  # Disable assertions on release builds
+  defns += ['-DG_DISABLE_ASSERT']
+endif
+
 conf = configuration_data()
 
 ibus =           dependency('ibus-1.0',             version: '>= 1.2.0')

--- a/linux/ibus-keyman/src/meson.build
+++ b/linux/ibus-keyman/src/meson.build
@@ -40,6 +40,8 @@ configure_file(
 
 exe = executable(
   'ibus-engine-keyman',
+  c_args: defns,
+  cpp_args: defns,
   sources: [engine_files, util_files],
   dependencies: deps,
   include_directories: include_dirs,


### PR DESCRIPTION
This change uses the G_DISABLE_ASSERT flag to disable assertions for release builds.

See https://docs.gtk.org/glib/func.assert.html

Related: #12715

@keymanapp-test-bot skip