### PR TITLE
chore(common): improve offline builds

### DIFF
--- a/resources/build/_builder_nvm.sh
+++ b/resources/build/_builder_nvm.sh
@@ -41,8 +41,8 @@ type -t nvm >/dev/null || {
   }
 }
 
-nvm install "$REQUIRED_NODE_VERSION"
-nvm use "$REQUIRED_NODE_VERSION"
+nvm use "$REQUIRED_NODE_VERSION" || \
+  (nvm install "$REQUIRED_NODE_VERSION" && nvm use "$REQUIRED_NODE_VERSION")
 
 # Beware the hardcoded path below -- it should already be in the system PATH
 


### PR DESCRIPTION
`nvm install` will fail if trying to build while offline. This change tries to use the required node version first and if that fails installs and then uses it.

@keymanapp-test-bot skip