### PR TITLE
chore(common): add offline support for emscripten

### DIFF
--- a/resources/locate_emscripten.inc.sh
+++ b/resources/locate_emscripten.inc.sh
@@ -66,10 +66,20 @@ _select_emscripten_version_with_emsdk() {
   fi
 
   export EMSDK_KEEP_DOWNLOADS=1
-  git pull
-  ./emsdk install "$KEYMAN_MIN_VERSION_EMSCRIPTEN"
-  ./emsdk activate "$KEYMAN_MIN_VERSION_EMSCRIPTEN"
-  cd upstream/emscripten
-  npm install
+  if builder_try_offline; then
+    if [[ ! -f ./emsdk_env.sh ]]; then
+      builder_die "emsdk_env.sh not found - emsdk not installed?"
+    fi
+    . ./emsdk_env.sh
+    if ! emcc --version | grep -q "$KEYMAN_MIN_VERSION_EMSCRIPTEN"; then
+      builder_die "Wrong emsdk version installed"
+    fi
+  else
+    git pull
+    ./emsdk install "$KEYMAN_MIN_VERSION_EMSCRIPTEN"
+    ./emsdk activate "$KEYMAN_MIN_VERSION_EMSCRIPTEN"
+    cd upstream/emscripten
+    npm install
+  fi
   popd > /dev/null
 }


### PR DESCRIPTION
This change allows to build with emscripten if offline (when passing the `--offline` parameter). Previously this failed because as part of locating emscripten we try to pull the latest repo version and install the desired emscripten version. With this change when `--offline` is specified we try to use the currently installed version of emsdk. If it isn't installed or if the wrong version is installed we will fail the build.

@keymanapp-test-bot skip