### PR TITLE
feat(android): Enhance how ENTER key is handled for FV and KMSample2

### DIFF
--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -130,6 +130,11 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     super.onStartInput(attribute, restarting);
     KMManager.onStartInput(attribute, restarting);
     KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+
+    // Determine special handling for ENTER key
+    int inputType = attribute.inputType;
+    KMManager.setEnterMode(attribute.imeOptions, inputType);
+
     // User switched to a new input field so we should extract the text from input field
     // and pass it to Keyman Engine together with selection range
     InputConnection ic = getCurrentInputConnection();

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -150,6 +150,10 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
             KMManager.setBannerOptions(mayPredict);
           }
         }
+
+        // Determine special handling for ENTER key
+        KMManager.setEnterMode(attribute.imeOptions, inputType);
+
         // User switched to a new input field so we should extract the text from input field
         // and pass it to Keyman Engine together with selection range
         InputConnection ic = getCurrentInputConnection();


### PR DESCRIPTION
Follows #12125 and fixes #12743

The ENTER key was enhanced in the Keyman system keyboard depending on the type of input field.
This ports the functionality to the FirstVoices for Android and KMSample2 apps.

Copying user tests from the original PR:

## User Testing

**Setup** - On an Android device, install the PR build of FirstVoices for Android and the Android KMSample2 app. Preferably use a physical device instead of emulator because you'll also need additional Android apps installed:
* Google Keep
* Messaging app like Facebook Messenger
* X (twitter)

For the corresponding groups, setup a keyboard and enable as the default corresponding keyboard. 
On FirstVoices, can do Region --> BC Coast --> SENCOTEN keyboard.

* GROUP_FV: Use FirstVoices for Android as system keyboard
* GROUP_SAMPLE2: Use KMSample2 as system keyboard

* **TEST_KEEP** - Verifies how ENTER key is handled in Keep app
1. Launch Keep
2. With the GROUP_ keyboard selected as the system keyboard, type in the Keep app
3. Press the "ENTER" key
4. Verify a newline is inserted in the text

* **TEST_MESSAGING** - Verifies how ENTER key is handled in a multi-line text field (as requested in the original issue)
1. Launch messaging app (like Facebook Messenger)
2. Select a contact to message and start typing a message with GROUP_  keyboard as the system keyboard
3. Press the "ENTER" key
4. Verify a newline is inserted in the text
5. Above the keyboard, the device should have an arrow key to send the message
6. Press the arrow key
7. Verify the message is sent

* **TEST_SEARCH** - Verifies how ENTER key is handled in a search field (as @dyacob requested in the original issue)
* Launch X (Twitter app)
* Click the eyeglass icon to start a search
* Start typing in the search field with the GROUP_ keyboard as the system keyboard
* Press the "ENTER" key
* Verify the search is triggered
