### PR TITLE
refactor(mac): pass kmx data blob to keyman core instead of file path

### DIFF
--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/CoreWrapper/CoreWrapper.m
@@ -115,6 +115,7 @@ const int CORE_ENVIRONMENT_ARRAY_LENGTH = 6;
   
   if (dataError != nil) {
     os_log_error([KMELogs coreLog], "loadKeyboardUsingCore, path: %{public}@\n dataError: %{public}@", path, dataError);
+    [NSException raise:@"LoadKeyboardException" format:@"%@", dataError];
   } else {
     NSUInteger dataLength = data.length;
     os_log_info([KMELogs coreLog], "loadKeyboardUsingCore, path: %{public}@\n dataLength: %lu", path, dataLength);


### PR DESCRIPTION
To load a keyboard using Keyman Core, call `km_core_keyboard_load_from_blob instead` of `km_core_keyboard_load`. This allows for the removal of platform file access from within Core.

Fixes: #12499

# User Testing

* **TEST_LOAD_KEYBOARD**: keyboards load and are usable

1. Install this version of Keyman and switch to the Khmer Angkor keyboard
1. Verify that typing produces Khmer characters
