### PR TITLE
chore(core): only install node on Windows if not available

### DIFF
--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -290,7 +290,7 @@ _select_node_version_with_nvm() {
     CURRENT_NODE_VERSION="$(node --version)"
     if [[ "$CURRENT_NODE_VERSION" != "v$REQUIRED_NODE_VERSION" ]]; then
       nvm install "$REQUIRED_NODE_VERSION"
-      nvm use "$REQUIRED_NODE_VERSION"
+      start /wait nvm use "$REQUIRED_NODE_VERSION"
     fi
   fi
 

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -289,8 +289,8 @@ _select_node_version_with_nvm() {
   else
     CURRENT_NODE_VERSION="$(node --version)"
     if [[ "$CURRENT_NODE_VERSION" != "v$REQUIRED_NODE_VERSION" ]]; then
-      nvm install "$REQUIRED_NODE_VERSION"
-      start /wait nvm use "$REQUIRED_NODE_VERSION"
+      start //wait //b nvm install "$REQUIRED_NODE_VERSION"
+      start //wait //b nvm use "$REQUIRED_NODE_VERSION"
     fi
   fi
 

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -281,13 +281,17 @@ verify_npm_setup() {
 # see /docs/build/node.md
 _select_node_version_with_nvm() {
   local REQUIRED_NODE_VERSION="$("$JQ" -r '.engines.node' "$KEYMAN_ROOT/package.json")"
+  local CURRENT_NODE_VERSION
 
   if [[ $BUILDER_OS != win ]]; then
     # launch nvm in a sub process, see _builder_nvm.sh for details
     "$KEYMAN_ROOT/resources/build/_builder_nvm.sh" "$REQUIRED_NODE_VERSION"
   else
-    nvm install "$REQUIRED_NODE_VERSION"
-    nvm use "$REQUIRED_NODE_VERSION"
+    CURRENT_NODE_VERSION="$(node --version)"
+    if [[ "$CURRENT_NODE_VERSION" != "v$REQUIRED_NODE_VERSION" ]]; then
+      nvm install "$REQUIRED_NODE_VERSION"
+      nvm use "$REQUIRED_NODE_VERSION"
+    fi
   fi
 
   # Now, check that the node version is correct, on all systems
@@ -296,7 +300,7 @@ _select_node_version_with_nvm() {
   # https://github.com/coreybutler/nvm-windows/issues/738
 
   # note the 'v' prefix that node emits (and npm doesn't!)
-  local CURRENT_NODE_VERSION="$(node --version)"
+  CURRENT_NODE_VERSION="$(node --version)"
   if [[ "$CURRENT_NODE_VERSION" != "v$REQUIRED_NODE_VERSION" ]]; then
     builder_die "Attempted to select node.js version $REQUIRED_NODE_VERSION but found $CURRENT_NODE_VERSION instead"
   fi
@@ -306,13 +310,13 @@ check-markdown() {
   node "$KEYMAN_ROOT/resources/tools/check-markdown" --root "$1"
 }
 
-# 
+#
 # Runs eslint, builds tests, and then runs tests with mocha + c8 (coverage)
-# 
+#
 # Usage:
 #   builder_run_action  test    builder_do_typescript_tests [coverage_threshold]
 # Parameters:
-#   1: coverage_threshold   optional, minimum coverage for c8 to pass tests, 
+#   1: coverage_threshold   optional, minimum coverage for c8 to pass tests,
 #                           defaults to 90 (percent)
 #
 # Todo:


### PR DESCRIPTION
This fixes the build on my Windows machine. Previously `nvm install/use` for whatever reason caused Windows to no longer be able to find `node` thus causing the build to fail. Waiting for `nvm use` to finish solves the build failure. This change when run on Windows additionally first checks the current node version and installs and activates it only if it is not installed.

@keymanapp-test-bot skip