### PR TITLE
change(developer): use full github url in kmc copy parameters 🍒

### DIFF
--- a/developer/docs/help/reference/kmc/cli/reference.md
+++ b/developer/docs/help/reference/kmc/cli/reference.md
@@ -493,9 +493,8 @@ following sources:
   `author.bcp47.uniq` id pattern, or a keyboard id pattern (where period `.` is
   not permitted)
 * A GitHub repository or subfolder within a repository that matches the Keyman
-  keyboard/model repository layout. The branch name is optional, and will use
-  the default branch from the repository if omitted. For example,
-  `github:keyman-keyboards/khmer_angkor:main:/khmer_angkor.kpj`
+  keyboard/model repository layout. For example,
+  `https://github.com/keyman-keyboards/khmer_angkor/tree/main/khmer_angkor.kpj`
 
 `-o, --out-path <filename>`
 

--- a/developer/src/common/web/utils/src/cloud-urls.ts
+++ b/developer/src/common/web/utils/src/cloud-urls.ts
@@ -1,0 +1,18 @@
+/**
+ * Matches a Keyman keyboard resource, based on the permanent home page for the
+ * keyboard on keyman.com, `https://keyman.com/keyboards/<id>`
+ */
+export const KEYMANCOM_CLOUD_URI = /^(?:http(?:s)?:\/\/)?keyman\.com\/keyboards\/(?<id>[a-z0-9_.-]+)/i;
+
+/**
+ * Matches a `cloud:<id>` URI for a Keyman resource (e.g. keyboard or lexical
+ * model)
+ */
+export const CLOUD_URI = /^cloud:(?<id>.+)$/i;
+
+
+export interface CloudUriRegexMatchArray extends RegExpMatchArray {
+  groups?: {
+    id?: string;
+  }
+}

--- a/developer/src/common/web/utils/src/github-urls.ts
+++ b/developer/src/common/web/utils/src/github-urls.ts
@@ -1,0 +1,35 @@
+/**
+ * Matches only a GitHub permanent raw URI with a commit hash, without any other
+ * components; note hash is called branch to match other URI formats
+ */
+export const GITHUB_STABLE_SOURCE = /^https:\/\/github\.com\/(?<owner>[a-zA-Z0-9-]+)\/(?<repo>[\w\.-]+)\/raw\/(?<branch>[a-f0-9]{40})\/(?<path>.+)$/;
+
+/**
+ * Matches any GitHub git resource raw 'user content' URI which can be
+ * translated to a permanent URI with a commit hash
+ */
+export const GITHUB_RAW_URI = /^https:\/\/raw\.githubusercontent\.com\/(?<owner>[a-zA-Z0-9-]+)\/(?<repo>[\w\.-]+)\/(?:refs\/(?:heads|tags)\/)?(?<branch>[^/]+)\/(?<path>.+)$/;
+
+/**
+ * Matches any GitHub git resource raw URI which can be translated to a
+ * permanent URI with a commit hash
+ */
+export const GITHUB_URI = /^https:\/\/github\.com\/(?<owner>[a-zA-Z0-9-]+)\/(?<repo>[\w\.-]+)\/(?:raw|blob|tree)\/(?:refs\/(?:heads|tags)\/)?(?<branch>[^/]+)\/(?<path>.+)$/;
+
+/**
+ * Matches any GitHub git resource raw URI which can be translated to a
+ * permanent URI with a commit hash, with the http[s] protocol optional, for
+ * matching user-supplied URLs. groups are: `owner`, `repo`, `branch`, and
+ * `path`.
+ */
+export const GITHUB_URI_OPTIONAL_PROTOCOL = /^(?:http(?:s)?:\/\/)?github\.com\/(?<owner>[a-zA-Z0-9-]+)\/(?<repo>[\w\.-]+)(?:\/(?:(?:raw|blob|tree)\/(?:refs\/(?:heads|tags)\/)?(?<branch>[^/]+)\/(?<path>.*))?)?$/;
+
+
+export interface GitHubRegexMatchArray extends RegExpMatchArray {
+  groups?: {
+    owner?: string;
+    repo?: string;
+    branch?: string;
+    path?: string;
+  }
+}

--- a/developer/src/common/web/utils/src/index.ts
+++ b/developer/src/common/web/utils/src/index.ts
@@ -66,3 +66,5 @@ export { UrlSubpathCompilerCallback } from './utils/UrlSubpathCompilerCallback.j
 export { CommonTypesMessages } from './common-messages.js';
 export * as SourceFilenamePatterns from './source-filename-patterns.js';
 export { KeymanXMLType, KeymanXMLWriter, KeymanXMLReader } from './xml-utils.js';
+
+export * as GitHubUrls from './github-urls.js';

--- a/developer/src/common/web/utils/src/index.ts
+++ b/developer/src/common/web/utils/src/index.ts
@@ -68,3 +68,4 @@ export * as SourceFilenamePatterns from './source-filename-patterns.js';
 export { KeymanXMLType, KeymanXMLWriter, KeymanXMLReader } from './xml-utils.js';
 
 export * as GitHubUrls from './github-urls.js';
+export * as CloudUrls from './cloud-urls.js';

--- a/developer/src/kmc-copy/src/KeymanProjectCopier.ts
+++ b/developer/src/kmc-copy/src/KeymanProjectCopier.ts
@@ -4,7 +4,7 @@
  * Copy a keyboard or lexical model project
  */
 
-import { CompilerCallbacks, CompilerLogLevel, KeymanCompiler, KeymanCompilerArtifact, KeymanCompilerArtifacts, KeymanCompilerResult, KeymanDeveloperProject, KeymanDeveloperProjectOptions, KPJFileReader, KPJFileWriter, KpsFileReader, KpsFileWriter } from "@keymanapp/developer-utils";
+import { GitHubUrls, CompilerCallbacks, CompilerLogLevel, KeymanCompiler, KeymanCompilerArtifact, KeymanCompilerArtifacts, KeymanCompilerResult, KeymanDeveloperProject, KeymanDeveloperProjectOptions, KPJFileReader, KPJFileWriter, KpsFileReader, KpsFileWriter } from "@keymanapp/developer-utils";
 import { KeymanFileTypes } from "@keymanapp/common-types";
 
 import { CopierMessages } from "./copier-messages.js";
@@ -14,6 +14,9 @@ import { GitHubRef, KeymanCloudSource } from "./cloud.js";
 type CopierFunction = (
   project: KeymanDeveloperProject, filename: string, outputPath: string, source: string, result: CopierResult
 ) => Promise<boolean>;
+
+const KEYMANCOM_CLOUD_URI = /^(?:http(?:s)?:\/\/)?keyman\.com\/keyboards\/(?<id>[a-z0-9_.-]+)/i;
+const CLOUD_URI = /^cloud:(?<id>.+)$/i;
 
 /**
  * @public
@@ -86,6 +89,9 @@ export class KeymanProjectCopier implements KeymanCompiler {
   relocateExternalFiles: boolean = false; // TODO-COPY: support
 
   public async init(callbacks: CompilerCallbacks, options: CopierOptions): Promise<boolean> {
+    if(!callbacks || !options) {
+      return false;
+    }
     this.callbacks = callbacks;
     this.options = options;
     this.cloudSource = new KeymanCloudSource(this.callbacks);
@@ -97,7 +103,7 @@ export class KeymanProjectCopier implements KeymanCompiler {
    * artifacts on success. The files are passed in by name, and the compiler
    * will use callbacks as passed to the {@link KeymanProjectCopier.init}
    * function to read any input files by disk.
-   * @param   source  Source file or folder to copy. Can be a local file or folder, github:repo[:path], or cloud:id
+   * @param   source  Source file or folder to copy. Can be a local file or folder, https://github.com/.../repo[/path], or cloud:id
    * @returns         Binary artifacts on success, null on failure.
    */
   public async run(source: string): Promise<CopierResult> {
@@ -151,10 +157,10 @@ export class KeymanProjectCopier implements KeymanCompiler {
    * @returns  path to .kpj (either local or remote)
    */
   private async getSourceProject(source: string): Promise<string | GitHubRef> {
-    if(source.startsWith('github:')) {
-      // `github:owner/repo:path/to/kpj`, referencing a .kpj file
+    if(source.match(GitHubUrls.GITHUB_URI_OPTIONAL_PROTOCOL) || source.match(GitHubUrls.GITHUB_RAW_URI)) {
+      // `[https://]github.com/owner/repo/[tree|blob|raw]/[refs/...]/branch/path/to/kpj`, referencing a .kpj file
       return await this.getGitHubSourceProject(source);
-    } else if(source.startsWith('cloud:')) {
+    } else if(source.match(CLOUD_URI) || source.match(KEYMANCOM_CLOUD_URI)) {
       // `cloud:id`, referencing a Keyman Cloud keyboard
       return await this.getCloudSourceProject(source);
     } else if(this.callbacks.fs.existsSync(source) && source.endsWith(KeymanFileTypes.Source.Project) && !this.callbacks.isDirectory(source)) {
@@ -194,43 +200,44 @@ export class KeymanProjectCopier implements KeymanCompiler {
 
   /**
    * Resolve path to GitHub source, which must be in the following format:
-   *   `github:owner/repo[:branch]:path/to/kpj`
+   *   `[https://]github.com/owner/repo/branch/path/to/kpj`
    * The path must be fully qualified, referencing the .kpj file; it
    * cannot just be the folder where the .kpj is found
    * @param source
    * @returns a promise: GitHub reference to the source for the keyboard, or null on failure
    */
   private async getGitHubSourceProject(source: string): Promise<GitHubRef> {
-    const parts = source.split(':');
-    if(parts.length < 3 || parts.length > 4 || !parts[1].match(/^[a-z0-9-]+\/[a-z0-9._-]+$/i)) {
-      // https://stackoverflow.com/questions/59081778/rules-for-special-characters-in-github-repository-name
-      this.callbacks.reportMessage(CopierMessages.Error_InvalidGitHubSource({source}));
-      return null;
+    const parts: GitHubUrls.GitHubRegexMatchArray =
+      GitHubUrls.GITHUB_URI_OPTIONAL_PROTOCOL.exec(source) ??
+      GitHubUrls.GITHUB_RAW_URI.exec(source);
+    if(!parts) {
+      throw new Error('Expected GITHUB_URI_OPTIONAL_PROTOCOL or GITHUB_RAW_URI to match');
     }
 
-    const origin = parts[1].split('/');
+    const ref: GitHubRef = new GitHubRef(parts);
 
-    const ref: GitHubRef = new GitHubRef({
-      owner: origin[0],
-      repo: origin[1],
-      branch: null,
-      path: null
-    });
-
-    if(parts.length == 4) {
-      ref.branch = parts[2];
-      ref.path = parts[3];
-    } else {
+    if(!ref.branch) {
       ref.branch = await this.cloudSource.getDefaultBranchFromGitHub(ref);
       if(!ref.branch) {
         this.callbacks.reportMessage(CopierMessages.Error_CouldNotFindDefaultBranchOnGitHub({ref: ref.toString()}));
         return null;
       }
-      ref.path = parts[2];
-
     }
+    if(!ref.path) {
+      ref.path = '/'
+    };
     if(!ref.path.startsWith('/')) {
       ref.path = '/' + ref.path;
+    }
+
+    if(ref.path != '/') {
+      if(!ref.path.endsWith('.kpj')) {
+        // Assumption, project filename matches folder name
+        if(ref.path.endsWith('/')) {
+          ref.path = ref.path.substring(0, ref.path.length-1);
+        }
+        ref.path = ref.path + '/' + this.callbacks.path.basename(ref.path) + '.kpj';
+      }
     }
 
     return ref;
@@ -239,16 +246,18 @@ export class KeymanProjectCopier implements KeymanCompiler {
   /**
    * Resolve path to Keyman Cloud source (which is on GitHub), which must be in
    * the following format:
-   *   `cloud:keyboard_id|model_id`
+   *   `cloud:keyboard_id`, or
+   *   `cloud:model_id`, or
+   *   `https://keyman.com/keyboards/keyboard_id`
    * The `keyboard_id` parameter should be a valid id (a-z0-9_), as found at
-   * https://keyman.com/keyboards; alternativel if it is a model_id, it should
+   * https://keyman.com/keyboards; alternatively if it is a model_id, it should
    * have the format author.bcp47.uniq
    * @param source
    * @returns a promise: GitHub reference to the source for the keyboard, or null on failure
    */
   private async getCloudSourceProject(source: string): Promise<GitHubRef> {
-    const parts = source.split(':');
-    const id = parts[1];
+    const parts = CLOUD_URI.exec(source) ?? KEYMANCOM_CLOUD_URI.exec(source);
+    const id: string = parts.groups.id;
 
     const isModel = /^[^.]+\.[^.]+\.[^.]+$/.test(id);
 
@@ -687,4 +696,11 @@ export class KeymanProjectCopier implements KeymanCompiler {
     return true;
   }
   /* c8 ignore stop */
+
+  /** @internal */
+  public unitTestEndPoints = {
+    getGithubSourceProject: this.getGitHubSourceProject.bind(this),
+    getCloudSourceProject: this.getCloudSourceProject.bind(this)
+  };
+
 }

--- a/developer/src/kmc-copy/src/cloud.ts
+++ b/developer/src/kmc-copy/src/cloud.ts
@@ -3,7 +3,7 @@
  *
  * GitHub and Keyman Cloud interface wrappers
  */
-import { CompilerCallbacks } from "@keymanapp/developer-utils";
+import { CompilerCallbacks, GitHubUrls } from "@keymanapp/developer-utils";
 import { CopierMessages } from "./copier-messages.js";
 import { KeymanFileTypes } from "@keymanapp/common-types";
 
@@ -12,17 +12,24 @@ export class GitHubRef {
   public repo: string;
   public branch: string;
   public path: string;
-  constructor(owner: string | GitHubRef, repo?: string, branch?: string, path?: string) {
+  constructor(owner: string | GitHubRef | GitHubUrls.GitHubRegexMatchArray, repo?: string, branch?: string, path?: string) {
     if(typeof owner == 'string') {
       this.owner = owner;
       this.repo = repo;
       this.branch = branch;
       this.path = path;
-    } else {
+    } else if("groups" in owner) {
+      this.owner = owner.groups.owner;
+      this.repo = owner.groups.repo;
+      this.branch = owner.groups.branch;
+      this.path = owner.groups.path;
+    } else if("owner" in owner) {
       this.owner = owner.owner;
       this.repo = owner.repo;
       this.branch = owner.branch;
       this.path = owner.path;
+    } else {
+      throw new Error(`Unrecognized GitHubRef '${owner}'`)
     }
   }
   toString() {

--- a/developer/src/kmc-copy/src/copier-messages.ts
+++ b/developer/src/kmc-copy/src/copier-messages.ts
@@ -117,18 +117,7 @@ export class CopierMessages {
     `Dry run requested. No changes have been saved`
   );
 
-  static ERROR_InvalidGitHubSource = SevError | 0x0011;
-  static Error_InvalidGitHubSource = (o:{source: string}) => m(
-    this.ERROR_InvalidGitHubSource,
-    `Source project specification '${def(o.source)}' is not a valid GitHub reference`,
-    `The source project specification for GitHub sources must match the pattern:
-        github:\\<owner/repo>[:\\<branch>]:\\<path>
-    The path must include the .kpj filename and may optionally begin with a forward slash.
-    The following are valid examples:
-        github:keymanapp/keyboards:master:release/k/khmer_angkor/khmer_angkor.kpj
-        github:keymanapp/keyboards:release/k/khmer_angkor/khmer_angkor.kpj
-        github:keymanapp/keyboards:/release/k/khmer_angkor/khmer_angkor.kpj`
-  );
+  // 0x0011 unused
 
   static ERROR_CannotDownloadFolderFromGitHub = SevError | 0x0012;
   static Error_CannotDownloadFolderFromGitHub = (o:{ref: string, message?: string, cause?: string}) => m(

--- a/developer/src/kmc-copy/test/fixtures/online/api.keyman.com/#keyboard#khmer_angkor
+++ b/developer/src/kmc-copy/test/fixtures/online/api.keyman.com/#keyboard#khmer_angkor
@@ -1,0 +1,65 @@
+{
+    "id": "khmer_angkor",
+    "name": "Khmer Angkor",
+    "license": "mit",
+    "authorName": "Makara Sok",
+    "authorEmail": "makara_sok@sil.org",
+    "description": "<p>Khmer Unicode keyboard layout based on the NiDA keyboard layout.\nAutomatically corrects many common keying errors.</p>",
+    "languages": {
+        "km": {
+            "examples": [
+                {
+                    "keys": "x j m E r",
+                    "note": "Name of language",
+                    "text": "\u1781\u17d2\u1798\u17c2\u179a"
+                }
+            ],
+            "font": {
+                "family": "Khmer Mondulkiri",
+                "source": [
+                    "Mondulkiri-R.ttf"
+                ]
+            },
+            "oskFont": {
+                "family": "KbdKhmr",
+                "source": [
+                    "KbdKhmr.ttf"
+                ]
+            },
+            "languageName": "Khmer",
+            "displayName": "Khmer"
+        }
+    },
+    "lastModifiedDate": "2024-07-03T15:47:38.000Z",
+    "packageFilename": "khmer_angkor.kmp",
+    "packageFileSize": 4259005,
+    "jsFilename": "khmer_angkor.js",
+    "jsFileSize": 70494,
+    "packageIncludes": [
+        "visualKeyboard",
+        "welcome",
+        "fonts",
+        "documentation"
+    ],
+    "version": "1.5",
+    "encodings": [
+        "unicode"
+    ],
+    "platformSupport": {
+        "windows": "full",
+        "macos": "full",
+        "linux": "full",
+        "desktopWeb": "full",
+        "ios": "full",
+        "android": "full",
+        "mobileWeb": "full"
+    },
+    "minKeymanVersion": "10.0",
+    "sourcePath": "release/k/khmer_angkor",
+    "helpLink": "https://help.keyman.com/keyboard/khmer_angkor",
+    "related": {
+        "khmer10": {
+            "deprecates": true
+        }
+    }
+}

--- a/developer/src/kmc-copy/test/fixtures/online/api.keyman.com/#model#nrc.en.mtnt
+++ b/developer/src/kmc-copy/test/fixtures/online/api.keyman.com/#model#nrc.en.mtnt
@@ -1,0 +1,23 @@
+{
+    "languages": [
+        "en",
+        "en-us",
+        "en-ca"
+    ],
+    "id": "nrc.en.mtnt",
+    "name": "English language model mined from MTNT",
+    "license": "mit",
+    "authorName": "Eddie Antonio Santos",
+    "authorEmail": "easantos@ualberta.ca",
+    "description": "<p>A unigram language model for English derived from the MTNT corpus <a href=\"http://www.cs.cmu.edu/~pmichel1/mtnt/\">http://www.cs.cmu.edu/~pmichel1/mtnt/</a>. This corpus itself is gathered from Reddit, so it is unfiltered internet discussion. This is not humanity at its prettiest!</p>",
+    "lastModifiedDate": "2024-09-16T01:05:45.000Z",
+    "packageFilename": "https://keyman.com/go/package/download/model/nrc.en.mtnt?version=0.3.3&update=1",
+    "packageFileSize": 332955,
+    "jsFilename": "https://downloads.keyman.com/models/nrc.en.mtnt/0.3.3/nrc.en.mtnt.model.js",
+    "jsFileSize": 2713050,
+    "packageIncludes": [],
+    "version": "0.3.3",
+    "minKeymanVersion": "12.0",
+    "helpLink": "https://help.keyman.com/model/nrc.en.mtnt",
+    "sourcePath": "release/nrc/nrc.en.mtnt"
+}

--- a/developer/src/kmc/src/commands/copy.ts
+++ b/developer/src/kmc/src/commands/copy.ts
@@ -27,8 +27,9 @@ export function declareCopy(program: Command) {
       * a .kpj file, e.g. ./keyboards/khmer_angkor/khmer_angkor.kpj
       * a local folder (with a .kpj file in it), e.g. ./keyboards/khmer_angkor
       * a cloud keyboard or lexical model, cloud:id, e.g. cloud:khmer_angkor
-      * a GitHub repository, optional branch, and path, github:owner/repo[:branch]:path
-        e.g. github:keyman-keyboards/khmer_angkor:main:/khmer_angkor.kpj
+      * a GitHub repository, branch, and path, [https://]github.com/owner/repo/tree/branch/path
+        e.g. https://github.com/keyman-keyboards/khmer_angkor/tree/main/khmer_angkor.kpj or
+             github.com/keymanapp/keyboards/tree/master/release/k/khmer_angkor
     `);
   }
 


### PR DESCRIPTION
Cherry-picking to master as epic/shared-fonts may not land in 18.0, and we don't want the new `kmc copy` command to have unnecessarily changes to command line after release.

Fixes: #12746
Cherry-pick-of: #12754

@keymanapp-test-bot skip