### PR TITLE
chore(android): Disable auto-correct UI controls

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/LanguageSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/LanguageSettingsActivity.java
@@ -108,11 +108,11 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
     RadioGroup radioGroup = (RadioGroup) findViewById(R.id.suggestion_radio_group);
     radioGroup.clearCheck();
 
+    // Auto-correct disabled for Keyman 18.0 #12767
     int[] RadioButtonArray = {
       R.id.suggestion_radio_0,
       R.id.suggestion_radio_1,
-      R.id.suggestion_radio_2,
-      R.id.suggestion_radio_3};
+      R.id.suggestion_radio_2};
     RadioButton radioButton = (RadioButton)radioGroup.findViewById(RadioButtonArray[maySuggest]);
     radioButton.setChecked(true);
 

--- a/android/KMEA/app/src/main/res/layout/language_settings_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/language_settings_list_layout.xml
@@ -90,12 +90,13 @@
                 android:layout_gravity="center_vertical"
                 android:text="@string/suggestions_radio_2" />
 
-            <com.google.android.material.radiobutton.MaterialRadioButton
+            <!-- Auto-correct disabled for Keyman 18.0 #12767 -->
+            <!--com.google.android.material.radiobutton.MaterialRadioButton
                 android:id="@+id/suggestion_radio_3"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                android:text="@string/suggestions_radio_3" />
+                android:text="@string/suggestions_radio_3" /-->
 
         </RadioGroup>
 


### PR DESCRIPTION
Addresses the Android portion of #12767

For Keyman 18.0, we'll disable auto-correct to mature the feature.

This disables the "Predictions with auto-corrections" UI that was added in #12443

## User Testing
**Setup** - Install the PR build of Keyman for Android on an Android device/emulator

* **TEST_AUTO_CORRECT_DISABLED** - Verifies UI for "predictions with auto-corrections" disabled
1. Launch Keyman for Android and dismiss the "Get Started" keyboard
2. With the default sil_euro_latin keyboard, verify the keyboard displays suggestions by default
3. Go to Keyman Settings --> Installed Languages --> English --> 
4. On the "English Settings" menu, verify the radio button "Predictions with corrections" is enabled by default
5. Verify "Predictions with auto-corrections" does not appear
6. Set the radio button to "Disable suggestions" and exit the settings menus
7. Back in the Keyman app, verify the OSK refreshes with the Keyman image banner
8. Verify suggestions no longer appear

