### PR TITLE
fix(developer): remove platforms from kmc-generate LM readme

### DIFF
--- a/developer/src/kmc-generate/src/template/wordlist-lexical-model/README.md
+++ b/developer/src/kmc-generate/src/template/wordlist-lexical-model/README.md
@@ -11,7 +11,3 @@ Links
 Copyright
 ---------
 See [LICENSE.md](LICENSE.md)
-
-Supported Platforms
--------------------
-$PLATFORMS_DOTLIST_README

--- a/developer/src/kmc-generate/test/fixtures/lexical-model/sample.en.sample/README.md
+++ b/developer/src/kmc-generate/test/fixtures/lexical-model/sample.en.sample/README.md
@@ -11,17 +11,3 @@ Links
 Copyright
 ---------
 See [LICENSE.md](LICENSE.md)
-
-Supported Platforms
--------------------
- * Windows
- * macOS
- * Linux
- * Web
- * iPhone
- * iPad
- * Android phone
- * Android tablet
- * Mobile devices
- * Desktop devices
- * Tablet devices


### PR DESCRIPTION
Lexical models are not specific to a platform, so the readme should not list supported platforms.

Fixes: #12592

@keymanapp-test-bot skip