### PR TITLE
fix(core): implement ldml_processor::get_key_list()  🍒 🙀 🏠

### DIFF
--- a/core/include/keyman/keyman_core_api_vkeys.h
+++ b/core/include/keyman/keyman_core_api_vkeys.h
@@ -16,6 +16,7 @@
 #pragma once
 
 enum km_core_modifier_state {
+  KM_CORE_MODIFIER_NONE        = 0,
   KM_CORE_MODIFIER_LCTRL       = 1 << 0,
   KM_CORE_MODIFIER_RCTRL       = 1 << 1,
   KM_CORE_MODIFIER_LALT        = 1 << 2,

--- a/core/src/kmx/kmx_plus.h
+++ b/core/src/kmx/kmx_plus.h
@@ -455,7 +455,13 @@ public:
   bool setLayr(const COMP_KMXPLUS_LAYR *newLayr);
   bool valid() const;
 
+  /**
+   * @param list index from 0 to layr->listCount
+   */
   const COMP_KMXPLUS_LAYR_LIST  *getList(KMX_DWORD list) const;
+  /**
+   * @param entry index value: COMP_KMXPLUS_LAYR_LIST.layer but less than COMP_KMXPLUS_LAYR_LIST.layer+COMP_KMXPLUS_LAYR_LIST.count
+   */
   const COMP_KMXPLUS_LAYR_ENTRY *getEntry(KMX_DWORD entry) const;
   const COMP_KMXPLUS_LAYR_ROW   *getRow(KMX_DWORD row) const;
   const COMP_KMXPLUS_LAYR_KEY   *getKey(KMX_DWORD key) const;

--- a/core/src/ldml/ldml_processor.cpp
+++ b/core/src/ldml/ldml_processor.cpp
@@ -348,8 +348,7 @@ km_core_attr const & ldml_processor::attributes() const {
 }
 
 km_core_keyboard_key  * ldml_processor::get_key_list() const {
-  km_core_keyboard_key* key_list = new km_core_keyboard_key(KM_CORE_KEYBOARD_KEY_LIST_END);
-  return key_list;
+  return keys.get_key_list();
 }
 
 km_core_keyboard_imx  * ldml_processor::get_imx_list() const {

--- a/core/src/ldml/ldml_vkeys.cpp
+++ b/core/src/ldml/ldml_vkeys.cpp
@@ -8,6 +8,8 @@
 #include "ldml_vkeys.hpp"
 #include "kmx_file.h"
 #include <ldml/keyman_core_ldml.h>
+#include <set>
+#include <assert.h>
 
 namespace km {
 namespace core {
@@ -22,6 +24,114 @@ vkeys::add(km_core_virtual_key vk, km_core_ldml_modifier_state modifier_state, s
   const vkey_id id(vk, modifier_state);
   // assign the string
   vkey_to_string[id] = output;
+  // includes all keys - including gaps.
+  all_vkeys.insert(id);
+}
+
+km_core_keyboard_key  *
+vkeys::get_key_list() const {
+  // prescan to find out which modifier flags are used
+
+  std::size_t other_key_count = 0;        // number of 'OTHER' keys, which will need to expand to all of the other_state set ( so other_state.size())
+
+  std::set<km::core::ldml::km_core_ldml_modifier_state> all_modifiers;
+  for (const auto &k : all_vkeys) {
+    const auto mod = k.second;
+    if (mod == LDML_KEYS_MOD_OTHER) {
+      other_key_count++;
+    }
+    all_modifiers.insert(mod);
+  }
+  std::set<km_core_modifier_state> other_state;
+
+  // Alt
+  if (all_modifiers.count(LDML_KEYS_MOD_ALT) == 0 && all_modifiers.count(LDML_KEYS_MOD_ALTL) == 0 && all_modifiers.count(LDML_KEYS_MOD_ALTR) == 0) {
+    // no ALT keys were seen, so OTHER includes ALT
+    other_state.insert(KM_CORE_MODIFIER_ALT);
+  } else if(all_modifiers.count(LDML_KEYS_MOD_ALTL) == 0) {
+    other_state.insert(KM_CORE_MODIFIER_RALT);
+  } else if(all_modifiers.count(LDML_KEYS_MOD_ALTR) == 0) {
+    other_state.insert(KM_CORE_MODIFIER_LALT);
+  }
+
+  // ctrl
+  if (all_modifiers.count(LDML_KEYS_MOD_CTRL) == 0 && all_modifiers.count(LDML_KEYS_MOD_CTRLL) == 0 && all_modifiers.count(LDML_KEYS_MOD_CTRLR) == 0) {
+    // no CTRL keys were seen, so OTHER includes CTRL
+    other_state.insert(KM_CORE_MODIFIER_CTRL);
+  } else if(all_modifiers.count(LDML_KEYS_MOD_CTRLL) == 0) {
+    other_state.insert(KM_CORE_MODIFIER_RCTRL);
+  } else if(all_modifiers.count(LDML_KEYS_MOD_CTRLR) == 0) {
+    other_state.insert(KM_CORE_MODIFIER_LCTRL);
+  }
+
+  // shift
+  if (all_modifiers.count(LDML_KEYS_MOD_SHIFT) == 0) {
+    other_state.insert(KM_CORE_MODIFIER_SHIFT);
+  }
+
+  // caps
+  if (all_modifiers.count(LDML_KEYS_MOD_CAPS) == 0) {
+    other_state.insert(KM_CORE_MODIFIER_CAPS);
+  }
+
+  // none- it's possible there is no 'none' layer
+  if (all_modifiers.count(LDML_KEYS_MOD_NONE) == 0) {
+    other_state.insert(KM_CORE_MODIFIER_NONE);
+  }
+
+  // We need ALL combinations of the other_state, except for 'all off'.
+  // The number of additions will be (2**(other_state.size())-1
+  // Also, since the LDML_KEYS_MOD_OTHER modifier is excluded, we
+  // will need to subtract 1 when calculating new_list_size
+  const std::size_t other_expanded_count = (1 << other_state.size()) - 1;
+
+  std::vector<uint32_t> other_expanded_mods(other_expanded_count);
+
+  // populate the expanded list.
+  // we start at 1 because 0 is "all bits off" (00000b)
+  for (std::size_t expansion = 1; expansion <= other_expanded_count; expansion++) {
+    uint32_t &expanded_mod = other_expanded_mods.at(expansion-1) = KM_CORE_MODIFIER_NONE;
+    std::size_t bit_mask = 1;
+    for (const auto mod : other_state) {
+      // Check if this modifier is on in this iteration of the expansion
+      // bit_mask will be 2^0 … 2^(other_state().size()-1)
+      if (bit_mask & expansion) {
+        // do we include this entry? check if this bit is on
+        expanded_mod |= mod;
+      }
+      // shift the bitmask over
+      assert(expanded_mod <= KM_CORE_MODIFIER_MASK_CAPS);
+      bit_mask <<= 1;
+    }
+  }
+
+  const std::size_t new_list_size = all_vkeys.size()                                // original size
+                                    + (other_key_count * (other_expanded_count - 1))// number of additional entries needed
+                                    + 1;                                            // terminator
+  km_core_keyboard_key *list = new km_core_keyboard_key[new_list_size];
+  std::size_t n = 0;
+  for (const auto &k : all_vkeys) {
+    const auto vkey = k.first;
+    const auto mod  = k.second;
+
+    if (mod == LDML_KEYS_MOD_OTHER) {
+      // expand to all of other_state
+      for (const auto expanded_mod : other_expanded_mods) {
+        list[n].key             = vkey;
+        list[n++].modifier_flag = expanded_mod;
+        assert(n <= new_list_size);
+      }
+    } else {
+      assert(mod <= KM_CORE_MODIFIER_MASK_CAPS); // that no LDMLisms escape
+      list[n].key             = vkey;
+      list[n++].modifier_flag = mod;
+      assert(n <= new_list_size);
+    }
+  }
+  // add the list terminator
+  list[n++] = KM_CORE_KEYBOARD_KEY_LIST_END;
+  assert(n == new_list_size);
+  return list;
 }
 
 static const uint16_t BOTH_ALT  = LALTFLAG  | RALTFLAG;

--- a/core/src/ldml/ldml_vkeys.hpp
+++ b/core/src/ldml/ldml_vkeys.hpp
@@ -12,6 +12,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <set>
 
 #include "keyman_core.h"
 
@@ -37,6 +38,7 @@ typedef std::pair<km_core_virtual_key, km_core_ldml_modifier_state> vkey_id;
 class vkeys {
 private:
   std::map<vkey_id, std::u16string> vkey_to_string;
+  std::set<vkey_id> all_vkeys;
 
 public:
   vkeys();
@@ -52,6 +54,11 @@ public:
    */
   std::u16string
   lookup(km_core_virtual_key vk, uint16_t modifier_state, bool &found) const;
+
+  /**
+   * For implementing ldml_processor::get_key_list()
+   */
+  km_core_keyboard_key* get_key_list() const;
 
 private:
   /**

--- a/core/tests/unit/ldml/keyboards/k_004_tinyshift.xml
+++ b/core/tests/unit/ldml/keyboards/k_004_tinyshift.xml
@@ -2,8 +2,9 @@
 
 <!--
 
-@@keys: [SHIFT K_BKQUOTE][K_1][K_BKQUOTE]
-@@expected: \u0037\u1790\u17B6\u0127
+@@keys: [SHIFT K_BKQUOTE][K_1][K_BKQUOTE][LCTRL K_BKQUOTE][RALT K_BKQUOTE]
+@@expected: \u0037\u1790\u17B6\u0127\u1790\u17B6\u0065
+@@keylist: [SHIFT K_BKQUOTE][SHIFT K_1][K_BKQUOTE][K_1][CTRL-do-not-use K_1][ALT-do-not-use K_BKQUOTE][CAPS K_BKQUOTE][ALT-do-not-use CAPS K_BKQUOTE]
 
 -->
 <keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
@@ -22,6 +23,12 @@
     </layer>
     <layer id="shift" modifiers="shift">
       <row keys="seven eee" /> <!-- number row -->
+    </layer>
+    <layer id="control" modifiers="ctrl">
+      <row keys="that gap" /> <!-- number row -->
+    </layer>
+    <layer id="catchall" modifiers="other">
+      <row keys="eee gap" /> <!-- number row -->
     </layer>
   </layers>
 </keyboard3>

--- a/core/tests/unit/ldml/ldml_test_source.cpp
+++ b/core/tests/unit/ldml/ldml_test_source.cpp
@@ -123,9 +123,9 @@ bool LdmlTestSource::get_expected_beep() const {
 }
 
 int LdmlTestSource::load_kmx_plus(const km::core::path &compiled) {
-    // check and load the KMX (yes, once again)
-  rawdata = km::tests::load_kmx_file(compiled);
-  if(!km::core::ldml_processor::is_handled(rawdata)) {
+
+  // check and load the KMX (yes, once again)
+  if(!km::core::ldml_processor::is_kmxplus_file(compiled, rawdata)) {
     std::cerr << "Reading KMX for test purposes failed: " << compiled << std::endl;
     return __LINE__;
   }

--- a/core/tests/unit/ldml/ldml_test_source.cpp
+++ b/core/tests/unit/ldml/ldml_test_source.cpp
@@ -122,6 +122,50 @@ bool LdmlTestSource::get_expected_beep() const {
   return false;
 }
 
+int LdmlTestSource::load_kmx_plus(const km::core::path &compiled) {
+    // check and load the KMX (yes, once again)
+  rawdata = km::tests::load_kmx_file(compiled);
+  if(!km::core::ldml_processor::is_handled(rawdata)) {
+    std::cerr << "Reading KMX for test purposes failed: " << compiled << std::endl;
+    return __LINE__;
+  }
+
+  auto comp_keyboard = (const km::core::kmx::COMP_KEYBOARD*)rawdata.data();
+  // initialize the kmxplus object with our copy
+  kmxplus.reset(new km::core::kmx::kmx_plus(comp_keyboard, rawdata.size()));
+
+  if (!kmxplus->is_valid()) {
+    std::cerr << "kmx_plus invalid" << std::endl;
+    return __LINE__;
+  }
+
+  if (!kmxplus->key2Helper.valid()) {
+    std::cerr << "kmx_plus invalid" << std::endl;
+    return __LINE__;
+  }
+
+  return 0; // success
+}
+
+bool LdmlTestSource::get_vkey_table(std::set<key_event> &fillin) const {
+  if (!kmxplus || !kmxplus->is_valid()) {
+    return false; // fail
+  }
+
+  // just dump the kmap table
+  for (KMX_DWORD kmapIdx = 0; kmapIdx < kmxplus->key2->kmapCount; kmapIdx++) {
+    const km::core::kmx::COMP_KMXPLUS_KEYS_KMAP *kmap = kmxplus->key2Helper.getKmap(kmapIdx);
+    if (kmap == nullptr) {
+      return false;
+    }
+    if (kmap->vkey > 0xFF) {
+      continue; // synthetic key- skip
+    }
+    fillin.insert(key_event(kmap->vkey, kmap->mod));
+  }
+  return true;
+}
+
 // String trim functions from https://stackoverflow.com/a/217605/1836776
 // trim from start (in place)
 static inline void
@@ -259,12 +303,13 @@ LdmlEmbeddedTestSource::is_token(const std::string token, std::string &line) {
 }
 
 int
-LdmlEmbeddedTestSource::load_source( const km::core::path &path ) {
+LdmlEmbeddedTestSource::load_source( const km::core::path &path, const km::core::path &compiled ) {
   const std::string s_keys = "@@keys: ";
   const std::string s_expected = "@@expected: ";
   const std::string s_context = "@@context: ";
   const std::string s_capsLock = "@@capsLock: ";
   const std::string s_expecterror = "@@expect-error: ";
+  const std::string s_keylist = "@@keylist: ";
 
   // Parse out the header statements in file.kmn that tell us (a) environment, (b) key sequence, (c) start context, (d) expected
   // result
@@ -296,6 +341,10 @@ LdmlEmbeddedTestSource::load_source( const km::core::path &path ) {
       context = parse_source_string(line);
     } else if (is_token(s_capsLock, line)) {
       set_caps_lock_on(parse_source_string(line).compare(u"1") == 0);
+    } else if (is_token(s_keylist, line)) {
+      set_keylist(line);
+    } else if (line[0] == '@') {
+      std::cerr << path << " warning, unknown @-command " << line << std::endl;
     }
   }
 
@@ -311,7 +360,13 @@ LdmlEmbeddedTestSource::load_source( const km::core::path &path ) {
     return __LINE__;
   }
 
-  return 0;
+  // and load KMX+ for keylist
+  if (!expected_error) {
+    // don't attempt to load KMX+ on expected error
+    return load_kmx_plus(compiled);
+  } else {
+    return 0;
+  }
 }
 
 km_core_status
@@ -352,13 +407,19 @@ LdmlTestSource::char_to_event(char ch) {
 }
 
 uint16_t
-LdmlTestSource::get_modifier(std::string const m) {
+LdmlTestSource::get_modifier(std::string const &m) {
   for (int i = 0; km::core::kmx::s_modifier_names[i].name; i++) {
     if (m == km::core::kmx::s_modifier_names[i].name) {
       return km::core::kmx::s_modifier_names[i].modifier;
     }
   }
   return 0;
+}
+
+std::string key_event::dump() const {
+  std::stringstream f;
+  f  << "Key: {" << km::core::kmx::Debug_VirtualKey(vk) << ", " << km::core::kmx::Debug_ModifierName(modifier_state) << "}";
+  return f.str();
 }
 
 key_event
@@ -396,34 +457,37 @@ LdmlEmbeddedTestSource::vkey_to_event(std::string const &vk_event) {
 
 void
 LdmlEmbeddedTestSource::next_action(ldml_action &fillin) {
-  if (is_done || keys.empty()) {
-    // We were already done. return done.
-    fillin.type = LDML_ACTION_DONE;
-    return;
+  if (keys.empty()) {
+    // #3 we are almost done, let's run the key check
+    if (check_keylist) {
+      fillin.type = LDML_ACTION_CHECK_KEYLIST;
+      fillin.string = expected_keylist; // could be empty
+      check_keylist = false;
+    } else {
+      fillin.type = LDML_ACTION_DONE;
+    }
   } else if(keys[0].empty()) {
+    // #2. Then, when we finish a key set, we check the 'expected' at the end of it.
     // Got to the end of a key set. time to check
     fillin.type = LDML_ACTION_CHECK_EXPECTED;
     fillin.string = expected[0]; // copy expected
     expected.pop_front();
     keys.pop_front();
-    if (keys.empty()) {
-      is_done = true; // so we get DONE next time
-    }
   } else {
+    // #1 First, we process each key
     fillin.type = LDML_ACTION_KEY_EVENT;
     fillin.k = next_key();
   }
 }
 
-
 key_event
 LdmlEmbeddedTestSource::next_key() {
   // mutate this->keys
-  return next_key(keys[0]);
+  return parse_next_key(keys[0]);
 }
 
 key_event
-LdmlEmbeddedTestSource::next_key(std::string &keys) {
+LdmlEmbeddedTestSource::parse_next_key(std::string &keys) {
   // Parse the next element of the string, chop it off, and return it
   // mutates keys
   if (keys.length() == 0)
@@ -448,10 +512,10 @@ LdmlEmbeddedTestSource::next_key(std::string &keys) {
 
 class LdmlJsonTestSource : public LdmlTestSource {
 public:
-  LdmlJsonTestSource(const std::string &path, km::core::kmx::kmx_plus *kmxplus);
+  LdmlJsonTestSource(const std::string &path);
   virtual ~LdmlJsonTestSource();
   virtual const std::u16string &get_context();
-  int load(const nlohmann::json &test);
+  int load(const nlohmann::json &test, const km::core::path &compiled);
   virtual void next_action(ldml_action &fillin);
 private:
   std::string path;
@@ -462,14 +526,14 @@ private:
    * Which action are we on?
   */
   std::size_t action_index = -1;
-  const km::core::kmx::kmx_plus *kmxplus;
   /** @return false if not found */
   bool set_key_from_id(key_event& k, const std::u16string& id);
   bool loaded_context = false;
+  bool check_keys = true;
 };
 
-LdmlJsonTestSource::LdmlJsonTestSource(const std::string &path, km::core::kmx::kmx_plus *k)
-:path(path), kmxplus(k) {
+LdmlJsonTestSource::LdmlJsonTestSource(const std::string &path)
+:path(path) {
 
 }
 
@@ -514,6 +578,13 @@ bool LdmlJsonTestSource::set_key_from_id(key_event& k, const std::u16string& id)
 void
 LdmlJsonTestSource::next_action(ldml_action &fillin) {
   if ((action_index+1) >= data["/actions"_json_pointer].size()) {
+    // add check keylist
+    if (check_keys) {
+      fillin.type = LDML_ACTION_CHECK_KEYLIST;
+      fillin.string.clear();
+      check_keys = false;
+      return;
+    }
     // at end, done
     fillin.type = LDML_ACTION_DONE;
     return;
@@ -581,19 +652,21 @@ LdmlJsonTestSource::get_context() {
   return context;
 }
 
-int LdmlJsonTestSource::load(const nlohmann::json &data) {
+int LdmlJsonTestSource::load(const nlohmann::json &data, const km::core::path &compiled) {
   this->data        = data;
-  // TODO-LDML: validate here?
-  return 0;
+  // TODO-LDML: validate JSON here?
+
+  // load up the kmx_plus
+  return load_kmx_plus(compiled);
 }
 
 #if defined(HAVE_ICU4C)
 class LdmlJsonRepertoireTestSource : public LdmlTestSource {
 public:
-  LdmlJsonRepertoireTestSource(const std::string &path, km::core::kmx::kmx_plus *kmxplus);
+  LdmlJsonRepertoireTestSource(const std::string &path );
   virtual ~LdmlJsonRepertoireTestSource();
   virtual const std::u16string &get_context();
-  int load(const nlohmann::json &test);
+  int load(const nlohmann::json &test, const km::core::path &compiled);
   virtual void next_action(ldml_action &fillin);
 private:
   std::string path;
@@ -605,11 +678,10 @@ private:
   std::unique_ptr<icu::UnicodeSet> uset;
   std::unique_ptr<icu::UnicodeSetIterator> iterator;
   bool need_check = false; // set this after each char
-  const km::core::kmx::kmx_plus *kmxplus;
 };
 
-LdmlJsonRepertoireTestSource::LdmlJsonRepertoireTestSource(const std::string &path, km::core::kmx::kmx_plus *k)
-:path(path), kmxplus(k){
+LdmlJsonRepertoireTestSource::LdmlJsonRepertoireTestSource(const std::string &path)
+:path(path) {
 
 }
 
@@ -697,7 +769,7 @@ LdmlJsonRepertoireTestSource::get_context() {
   return context; // no context needed
 }
 
-int LdmlJsonRepertoireTestSource::load(const nlohmann::json &data) {
+int LdmlJsonRepertoireTestSource::load(const nlohmann::json &data, const km::core::path &compiled) {
   this->data = data;  // TODO-LDML
   // Need an update to json.hpp to use contains()
   // if (data.contains("/type"_json_pointer)) {
@@ -728,7 +800,7 @@ int LdmlJsonRepertoireTestSource::load(const nlohmann::json &data) {
   // }
   // #endif
   iterator = std::unique_ptr<icu::UnicodeSetIterator>(new icu::UnicodeSetIterator(*uset));
-  return 0;
+  return load_kmx_plus(compiled);
 }
 #endif // HAVE_ICU4C
 
@@ -752,25 +824,6 @@ int LdmlJsonTestSourceFactory::load(const km::core::path &compiled, const km::co
     return __LINE__; // empty
   }
 
-  // check and load the KMX (yes, once again)
-  if(!km::core::ldml_processor::is_kmxplus_file(compiled, rawdata)) {
-    std::cerr << "Reading KMX for test purposes failed: " << compiled << std::endl;
-    return __LINE__;
-  }
-
-  auto comp_keyboard = (const km::core::kmx::COMP_KEYBOARD*)rawdata.data();
-  // initialize the kmxplus object with our copy
-  kmxplus.reset(new km::core::kmx::kmx_plus(comp_keyboard, rawdata.size()));
-
-  if (!kmxplus->is_valid()) {
-    std::cerr << "kmx_plus invalid" << std::endl;
-    return __LINE__;
-  }
-
-  if (!kmxplus->key2Helper.valid()) {
-    std::cerr << "kmx_plus invalid" << std::endl;
-    return __LINE__;
-  }
 
   auto conformsTo = data["/keyboardTest3/conformsTo"_json_pointer].get<std::string>();
   assert_or_return(std::string(LDML_CLDR_TEST_VERSION_LATEST) == conformsTo);
@@ -793,8 +846,8 @@ int LdmlJsonTestSourceFactory::load(const km::core::path &compiled, const km::co
       test_path.append(info_name).append("/tests/").append(tests_name).append("/").append(test_name);
       // std::cout << "JSON: reading " << info_name << "/" << test_path << std::endl;
 
-      std::unique_ptr<LdmlJsonTestSource> subtest(new LdmlJsonTestSource(test_path, kmxplus.get()));
-      assert_or_return(subtest->load(test) == 0);
+      std::unique_ptr<LdmlJsonTestSource> subtest(new LdmlJsonTestSource(test_path));
+      assert_or_return(subtest->load(test, compiled) == 0);
       test_map[test_path] = std::unique_ptr<LdmlTestSource>(subtest.release());
     }
   }
@@ -809,8 +862,8 @@ int LdmlJsonTestSourceFactory::load(const km::core::path &compiled, const km::co
     std::string test_path;
     test_path.append(info_name).append("/repertoire/").append(rep_name);
 
-    std::unique_ptr<LdmlJsonRepertoireTestSource> reptest(new LdmlJsonRepertoireTestSource(test_path, kmxplus.get()));
-    assert_or_return(reptest->load(rep) == 0);
+    std::unique_ptr<LdmlJsonRepertoireTestSource> reptest(new LdmlJsonRepertoireTestSource(test_path));
+    assert_or_return(reptest->load(rep, compiled) == 0);
     test_map[test_path] = std::unique_ptr<LdmlTestSource>(reptest.release());
   }
 


### PR DESCRIPTION
- Cherry pick of https://github.com/keymanapp/keyman/pull/12644
- Cherry pick of https://github.com/keymanapp/keyman/commit/de3397b47668dd3082e9df095a10d007a3731b98

Fixes: #12298


# User Testing

Please paste in the following LDML keyboard source for testing:

```xml
<?xml version="1.0"?>
<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="arc" conformsTo="45">
  <info author="Marc Durdin" name="Test 'other' modifier"/>
  <version number="1.0.0"/>
  <keys>
    <import base="cldr" path="45/keys-Zyyy-punctuation.xml"/>
    <import base="cldr" path="45/keys-Zyyy-currency.xml"/>
  	<!-- switch keys -->

    <key id="a" output="🅐" />
    <key id="b" output="🅑" />
    <key id="c" output="🅒" />
    <key id="d" output="🅓" />
    <key id="e" output="🅔" />
  </keys>
  <layers formId="us">
    <layer modifiers="none">
      <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal"/>
      <row keys="a"/>
      <row keys="gap"/>
      <row keys="gap"/>
      <row keys="space"/>
    </layer>
    <layer modifiers="shift">
      <row keys="tilde bang at hash dollar percent caret amp asterisk open-paren close-paren underscore plus"/>
      <row keys="b"/>
      <row keys="gap"/>
      <row keys="gap"/>
      <row keys="space"/>
    </layer>
    <layer modifiers="ctrl">
      <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal"/>
      <row keys="c"/>
      <row keys="gap"/>
      <row keys="gap"/>
      <row keys="space"/>
    </layer>
    <layer modifiers="other">
      <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal"/>
      <row keys="d e"/>
      <row keys="gap"/>
      <row keys="gap"/>
      <row keys="space"/>
    </layer>
  </layers>
</keyboard3>
```

Create a basic LDML keyboard, and paste in the source above. Compile the keyboard and its package. Use this keyboard in all the subsequent tests.

For all tests, pass the test if:

* <kbd>q</kbd> emits 🅐
* <kbd>shift</kbd>+<kbd>q</kbd> emits 🅑
* <kbd>ctrl</kbd>+<kbd>q</kbd> emits 🅒
* <kbd>alt</kbd>+<kbd>q</kbd> emits 🅓
* <kbd>alt</kbd>+<kbd>w</kbd> emits 🅔
* the following key combinations have no output:
  * <kbd>alt</kbd>+<kbd>e</kbd>
  * <kbd>ctrl</kbd>+<kbd>e</kbd>
  * <kbd>shift</kbd>+<kbd>e</kbd>
  * <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>e</kbd>
  * <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>e</kbd>
  * <kbd>e</kbd>

* **TEST_DEBUGGER:** Test the keyboard in the Keyman Developer Debugger
* **TEST_WINDOWS:** Install the keyboard in Keyman for Windows, and test the keyboard in Notepad
* **TEST_MAC:** Install the keyboard in Keyman for macOS, and test the keyboard in TextEdit
* **TEST_LINUX:** Install the keyboard in Keyman for Linux, and test the keyboard in a text editor
