### PR TITLE
fix(linux): work around Lintian errors 🍒 🏠

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 SIL International. All rights reserved.
+# Copyright (c) 2022-2023 SIL Global. All rights reserved.
 #
 # builder image for a linux build
 # see ../docs/build/linux-ubuntu.md
@@ -7,7 +7,7 @@ ARG OS_VERSION=latest
 ARG OS_PLATFORM=amd64
 
 FROM --platform=${OS_PLATFORM} ubuntu:${OS_VERSION}
-LABEL org.opencontainers.image.authors="SIL International."
+LABEL org.opencontainers.image.authors="SIL Global."
 LABEL org.opencontainers.image.url="https://github.com/keymanapp/keyman.git"
 LABEL org.opencontainers.image.title="Keyman Linux Build Image"
 

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,11 @@
+keyman (17.0.331-1) UNRELEASED; urgency=medium
+
+  * set environment variable for rendering of downloads dialog (#12617)
+  * add `keymanFacename` to .ldml file (#12283)
+  * ignore exceptions trying to install cache (#11885)
+
+ -- Eberhard Beilharz <eb1@sil.org>  Tue, 10 Dec 2024 16:48:59 +0100
+
 keyman (17.0.326-1) unstable; urgency=medium
 
   * New upstream release

--- a/linux/debian/com.keyman.config.appdata.xml
+++ b/linux/debian/com.keyman.config.appdata.xml
@@ -5,10 +5,15 @@
   <metadata_license>MIT</metadata_license>
   <project_license>MIT</project_license>
   <project_group>Keyman</project_group>
-  <developer_name>SIL International</developer_name>
+  <developer id="org.sil.keyman">
+    <name>SIL Global</name>
+  </developer>
   <icon type="remote" width="96" height="96">https://keyman.com/cdn/dev/img/keyman-logo.png</icon>
   <name>Keyman for Linux</name>
   <summary>Keyman makes it possible for you to type in over 2,000 languages</summary>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">mild</content_attribute>
+  </content_rating>
 
   <description>
     <p>

--- a/linux/debian/com.keyman.ibus_keyman.metainfo.xml
+++ b/linux/debian/com.keyman.ibus_keyman.metainfo.xml
@@ -2,9 +2,11 @@
 <component type="inputmethod">
   <id>com.keyman.ibus_keyman</id>
   <metadata_license>MIT</metadata_license>
-  <project_license>GPL-2+</project_license>
+  <project_license>GPL-2.0+</project_license>
   <project_group>Keyman</project_group>
-  <developer_name>SIL International</developer_name>
+  <developer id="org.sil.keyman">
+    <name>SIL Global</name>
+  </developer>
   <icon type="remote" width="96" height="96">https://keyman.com/cdn/dev/img/keyman-logo.png</icon>
 
   <name>ibus-keyman</name>

--- a/linux/debian/copyright
+++ b/linux/debian/copyright
@@ -4,24 +4,24 @@ Upstream-Contact: Keyman team <support@keyman.com>
 Source: https://github.com/keymanapp/keyman
 
 Files: *
-Copyright: 2018-2024 SIL International
+Copyright: 2018-2024 SIL Global
 License: MIT
 
 Files: linux/ibus-keyman/*
-Copyright: 2004-2024 SIL International
+Copyright: 2004-2024 SIL Global
 License: GPL-2+
 
 Files: linux/ibus-keyman/src/keymanutil.c
        linux/ibus-keyman/src/keymanutil.h
        linux/ibus-keyman/src/kmpdetails.c
        linux/ibus-keyman/src/kmpdetails.h
-Copyright: 2009-2024 SIL International
+Copyright: 2009-2024 SIL Global
 License: GPL-2+ or MIT
 
 Files: linux/ibus-keyman/src/keyman-service.c
        linux/ibus-keyman/src/keyman-service.h
        linux/keyman-config/buildtools/help2md
-Copyright: 2018-2024 SIL International
+Copyright: 2018-2024 SIL Global
 License: GPL-3+
 
 Files: linux/ibus-keyman/tests/ibusimcontext.c
@@ -31,7 +31,7 @@ Copyright: 2008-2010, Peng Huang <shawn.p.huang@gmail.com>
            2008-2013, Peng Huang <shawn.p.huang@gmail.com>
            2008-2021, Red Hat, Inc.
            2015-2021, Takao Fujiwara <takao.fujiwara1@gmail.com>
-           2021-2024, SIL International
+           2021-2024, SIL Global
 License: LGPL-2.1+
 
 Files: linux/keyman-config/buildtools/help2man
@@ -41,7 +41,7 @@ License: GPL-3+
 Files: debian/com.keyman.config.appdata.xml
        debian/com.keyman.ibus_keyman.metainfo.xml
 Copyright: 2019 Daniel Glassey <wdg@debian.org>
-           2022-2024 SIL International
+           2022-2024 SIL Global
 License: MIT
 
 License: MIT

--- a/linux/debian/libkeymancore1.symbols
+++ b/linux/debian/libkeymancore1.symbols
@@ -1,7 +1,8 @@
 libkeymancore.so.1 libkeymancore1 #MINVER#
 * Build-Depends-Package: libkeymancore-dev
 
- (c++|optional)"typeinfo name for std::codecvt_utf8_utf16<char16_t, 1114111ul, (std::codecvt_mode)0>@Base" 17.0.244
+# We only use a C API, so ignore all C++ symbols in the std namespace that bleed through
+ (c++|regex|optional)"std::" 17.0.332
  km_core_context_clear@Base 17.0.195
  km_core_context_get@Base 17.0.195
  km_core_context_item_list_size@Base 17.0.195

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -3,7 +3,7 @@
 /*
  * Keyman Input Method for IBUS (The Input Bus)
  *
- * Copyright (C) 2009-2023 SIL International
+ * Copyright (C) 2009-2023 SIL Global
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public

--- a/linux/ibus-keyman/src/engine.h
+++ b/linux/ibus-keyman/src/engine.h
@@ -3,7 +3,7 @@
 /*
  * Keyman Input Method for IBUS (The Input Bus)
  *
- * Copyright (C) 2018 SIL International
+ * Copyright (C) 2018 SIL Global
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public

--- a/linux/ibus-keyman/src/keyman-service.c
+++ b/linux/ibus-keyman/src/keyman-service.c
@@ -3,7 +3,7 @@
 /*
  * Keyman Input Method for IBUS (The Input Bus)
  *
- * Copyright (C) 2018-2023 SIL International
+ * Copyright (C) 2018-2023 SIL Global
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public

--- a/linux/ibus-keyman/src/keyman-service.h
+++ b/linux/ibus-keyman/src/keyman-service.h
@@ -3,7 +3,7 @@
 /*
  * Keyman Input Method for IBUS (The Input Bus)
  *
- * Copyright (C) 2018-2023 SIL International
+ * Copyright (C) 2018-2023 SIL Global
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public

--- a/linux/ibus-keyman/src/keymanutil.c
+++ b/linux/ibus-keyman/src/keymanutil.c
@@ -3,7 +3,7 @@
 /*
  * Keyman Input Method for IBUS (The Input Bus)
  *
- * Copyright (C) 2018 SIL International
+ * Copyright (C) 2018 SIL Global
  *
  * keymanutil is dual licensed under the MIT or GPL licenses as described below.
  *

--- a/linux/ibus-keyman/src/keymanutil.h
+++ b/linux/ibus-keyman/src/keymanutil.h
@@ -3,7 +3,7 @@
 /*
  * Keyman Input Method for IBUS (The Input Bus)
  *
- * Copyright (C) 2018-2023 SIL International
+ * Copyright (C) 2018-2023 SIL Global
  *
  * keymanutil is dual licensed under the MIT or GPL licenses as described below.
  *

--- a/linux/ibus-keyman/src/kmpdetails.c
+++ b/linux/ibus-keyman/src/kmpdetails.c
@@ -3,7 +3,7 @@
 /*
  * Keyman Input Method for IBUS (The Input Bus)
  *
- * Copyright (C) 2018 SIL International
+ * Copyright (C) 2018 SIL Global
  *
  * kmpdetails is dual licensed under the MIT or GPL licenses as described below.
  *

--- a/linux/ibus-keyman/src/main.c
+++ b/linux/ibus-keyman/src/main.c
@@ -3,7 +3,7 @@
 /*
  * Keyman Input Method for IBUS (The Input Bus)
  *
- * Copyright (C) 2018 SIL International
+ * Copyright (C) 2018 SIL Global
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public

--- a/linux/ibus-keyman/src/test/testdata/kmp.json
+++ b/linux/ibus-keyman/src/test/testdata/kmp.json
@@ -14,7 +14,7 @@
       "description": "LIBTRALO"
     },
     "copyright": {
-      "description": "\u00A9 2008-2018 SIL International"
+      "description": "\u00A9 2008-2018 SIL Global"
     },
     "author": {
       "description": "support@keyman.com",

--- a/linux/ibus-keyman/src/test/testdata/kmp1.json
+++ b/linux/ibus-keyman/src/test/testdata/kmp1.json
@@ -14,7 +14,7 @@
       "description": "LIBTRALO"
     },
     "copyright": {
-      "description": "\u00A9 2008-2018 SIL International"
+      "description": "\u00A9 2008-2018 SIL Global"
     },
     "author": {
       "description": "support@keyman.com",

--- a/linux/ibus-keyman/src/test/testdata/kmp2.json
+++ b/linux/ibus-keyman/src/test/testdata/kmp2.json
@@ -14,7 +14,7 @@
       "description": "LIBTRALO"
     },
     "copyright": {
-      "description": "\u00A9 2008-2018 SIL International"
+      "description": "\u00A9 2008-2018 SIL Global"
     },
     "author": {
       "description": "support@keyman.com",

--- a/linux/ibus-keyman/tests/ibusimcontext.c
+++ b/linux/ibus-keyman/tests/ibusimcontext.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2008-2013 Peng Huang <shawn.p.huang@gmail.com>
  * Copyright (C) 2015-2022 Takao Fujiwara <takao.fujiwara1@gmail.com>
  * Copyright (C) 2008-2022 Red Hat, Inc.
- * Copyright (C) 2021-2022 SIL International
+ * Copyright (C) 2021-2022 SIL Global
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/linux/ibus-keyman/tests/ibusimcontext.h
+++ b/linux/ibus-keyman/tests/ibusimcontext.h
@@ -3,7 +3,7 @@
 /* ibus - The Input Bus
  * Copyright (C) 2008-2010 Peng Huang <shawn.p.huang@gmail.com>
  * Copyright (C) 2008-2010 Red Hat, Inc.
- * Copyright (C) 2021-2022 SIL International
+ * Copyright (C) 2021-2022 SIL Global
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/linux/keyman-config/COPYING
+++ b/linux/keyman-config/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2018 SIL International
+Copyright (c) 2018 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/linux/keyman-config/Makefile
+++ b/linux/keyman-config/Makefile
@@ -48,7 +48,7 @@ MOFILES := $(POFILES:.po=/LC_MESSAGES/keyman-config.mo)
 
 update-template: version
 	xgettext --package-name "keyman" --package-version "$(VERSION)" \
-		--msgid-bugs-address "<support@keyman.com>" --copyright-holder "SIL International" \
+		--msgid-bugs-address "<support@keyman.com>" --copyright-holder "SIL Global" \
 		--language=Python --directory=. --output-dir=locale --output=keyman-config.pot \
 		--add-comments=i18n: --sort-by-file --width=98 \
 		keyman_config/*.py km-*

--- a/linux/keyman-config/buildtools/help2md
+++ b/linux/keyman-config/buildtools/help2md
@@ -5,7 +5,7 @@
 # Copyright (C) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2009,
 # 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2020, 2021 Free Software
 # Foundation, Inc.
-# Copyright (C) 2021 SIL International
+# Copyright (C) 2021 SIL Global
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -76,7 +76,7 @@ my $version_info = enc_user sprintf _(<<'EOT'), $this_program, $this_version;
 Copyright (C) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2009,
 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2020, 2021 Free Software
 Foundation, Inc.
-Copyright (C) 2021 SIL International
+Copyright (C) 2021 SIL Global
 
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/linux/keyman-config/keyman_config/sentry_handling.py
+++ b/linux/keyman-config/keyman_config/sentry_handling.py
@@ -1,4 +1,9 @@
 #!/usr/bin/python3
+'''
+Keyman is copyright (C) SIL Global. MIT License.
+
+Implements the Sentry error handling
+'''
 import getpass
 import hashlib
 import importlib

--- a/linux/keyman-config/locale/keyman-config.pot
+++ b/linux/keyman-config/locale/keyman-config.pot
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR SIL International
+# Copyright (C) YEAR SIL Global
 # This file is distributed under the same license as the keyman package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #


### PR DESCRIPTION
We only use a C API, so we can safely ignore all C++ symbols that show up in the symbols file. Those come from std template instantiations.

Also update AppStream metadata and change SIL International to SIL Global.

Additionally update the changelog file with the recent changes. Note that this uses a bogus version number that is smaller than the current release. This is because as part of the packaging process we set the version number. This only works if existing entries have a lower version number. Because the top entry has the status UNRELEASED it will be merged with the new entry.

Fixes: #12051 
Cherry-pick: #12815 

@keymanapp-test-bot skip