### PR TITLE
fix(linux): pushing of updated changelog branch

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -22,12 +22,6 @@ keyman (17.0.279-1) unstable; urgency=medium
 
  -- Eberhard Beilharz <eb1@sil.org>  Thu, 29 Feb 2024 19:17:08 +0100
 
-keyman (17.0.274-2) UNRELEASED; urgency=medium
-
-  * Add libicu-dev dependency to libkeymancore-dev (closes: #1064915)
-
- -- Eberhard Beilharz <eb1@sil.org>  Wed, 28 Feb 2024 17:54:58 +0100
-
 keyman (17.0.274-1) unstable; urgency=medium
 
   * Fix autopkg tests

--- a/linux/scripts/debian.sh
+++ b/linux/scripts/debian.sh
@@ -36,7 +36,7 @@ for proj in ${projects}; do
         EXTRA_ARGS="--distribution ${DIST} --force-distribution"
     fi
     # shellcheck disable=SC2086
-    dch --newversion "${version}-${DEBREVISION-1}" ${EXTRA_ARGS} "Re-release to Debian"
+    dch --newversion "${version}-${DEBREVISION-1}" ${EXTRA_ARGS} ""
     debuild -d -S -sa -Zxz
     cd "${BASEDIR}"
 done

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -99,7 +99,7 @@ function push_to_github_and_create_pr() {
   local PR_BODY=$4
 
   if [[ -n "${PUSH}" ]]; then
-    ${NOOP} git push --force-with-lease origin "${BRANCH}"
+    ${NOOP} git push --force origin "${BRANCH}"
     PR_NUMBER=$(gh pr list --draft --search "${PR_TITLE}" --base "${BASE}" --json number --jq '.[].number')
     if [[ -n ${PR_NUMBER} ]]; then
       builder_echo "PR #${PR_NUMBER} already exists"

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -92,13 +92,18 @@ function get_latest_stable_branch_name() {
   echo "${stable_branch##* }"
 }
 
+# Push the changelog changes to GitHub and create a PR. Returns the PR#
+# in the environment variable PR_NUMBER.
 function push_to_github_and_create_pr() {
-  local BRANCH=$1
-  local BASE=$2
-  local PR_TITLE=$3
-  local PR_BODY=$4
+  local BRANCH=$1           # `chore/linux/changelog` or `chore/linux/cherry-pick/changelog`
+  local BASE=$2             # stable branch, `beta` or `master`
+  local PR_TITLE=$3         # `Update debian changelog`
+  local PR_BODY=$4          # `@keymanapp-test-bot skip`
 
   if [[ -n "${PUSH}" ]]; then
+    # Push to origin. We force push to reset the branch the commit we just made.
+    # There shouldn't be any other commits on ${BRANCH} except the one we want to replace
+    # (if any).
     ${NOOP} git push --force origin "${BRANCH}"
     PR_NUMBER=$(gh pr list --draft --search "${PR_TITLE}" --base "${BASE}" --json number --jq '.[].number')
     if [[ -n ${PR_NUMBER} ]]; then


### PR DESCRIPTION
This fixes the `upload-to-debian.sh` script if the `chore/linux/changelog` branch was created a while back while the base branch moved in the meantime. In this case we have to use `--force` instead of `--force-with-lease` otherwise `git` gets confused. This is safe to do since the intention is that we replace the previous commit and we know that there is (should be) only one commit on the `chore/linux/changelog` branch.

@keymanapp-test-bot skip