### PR TITLE
fix(linux): pushing of updated changelog branch 🍒 🏠

### DIFF
--- a/linux/scripts/debian.sh
+++ b/linux/scripts/debian.sh
@@ -36,7 +36,7 @@ for proj in ${projects}; do
         EXTRA_ARGS="--distribution ${DIST} --force-distribution"
     fi
     # shellcheck disable=SC2086
-    dch --newversion "${version}-${DEBREVISION-1}" ${EXTRA_ARGS} "Re-release to Debian"
+    dch --newversion "${version}-${DEBREVISION-1}" ${EXTRA_ARGS} ""
     debuild -d -S -sa -Zxz
     cd "${BASEDIR}"
 done

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -100,7 +100,7 @@ function push_to_github_and_create_pr() {
   local pr_number
 
   if [[ -n "${PUSH}" ]]; then
-      ${NOOP} git push --force-with-lease origin "${BRANCH}"
+      ${NOOP} git push --force origin "${BRANCH}"
       pr_number=$(gh pr list --draft --search "${COMMIT_MSG}" --base "${BASE}" --json number --jq '.[].number')
       if [[ -n ${pr_number} ]]; then
         builder_echo "PR #${pr_number} already exists"

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -92,21 +92,28 @@ function get_latest_stable_branch_name() {
   echo "${stable_branch##* }"
 }
 
+# Push the changelog changes to GitHub and create a PR. Returns the PR#
+# in the environment variable PR_NUMBER.
 function push_to_github_and_create_pr() {
-  local BRANCH=$1
-  local BASE=$2
-  local COMMIT_MSG=$3
-  local PR_MSG=$4
-  local pr_number
+  local BRANCH=$1           # `chore/linux/changelog` or `chore/linux/cherry-pick/changelog`
+  local BASE=$2             # stable branch, `beta` or `master`
+  local PR_TITLE=$3         # `Update debian changelog`
+  local PR_BODY=$4          # `@keymanapp-test-bot skip`
 
   if [[ -n "${PUSH}" ]]; then
-      ${NOOP} git push --force origin "${BRANCH}"
-      pr_number=$(gh pr list --draft --search "${COMMIT_MSG}" --base "${BASE}" --json number --jq '.[].number')
-      if [[ -n ${pr_number} ]]; then
-        builder_echo "PR #${pr_number} already exists"
-      else
-        ${NOOP} gh pr create --draft --base "${BASE}" --title "${PR_MSG}" --body "@keymanapp-test-bot skip"
-      fi
+    # Push to origin. We force push to reset the branch the commit we just made.
+    # There shouldn't be any other commits on ${BRANCH} except the one we want to replace
+    # (if any).
+    ${NOOP} git push --force origin "${BRANCH}"
+    PR_NUMBER=$(gh pr list --draft --search "${PR_TITLE}" --base "${BASE}" --json number --jq '.[].number')
+    if [[ -n ${PR_NUMBER} ]]; then
+      builder_echo "PR #${PR_NUMBER} already exists"
+    else
+      ${NOOP} gh pr create --draft --base "${BASE}" --title "${PR_TITLE}" --body "${PR_BODY}"
+      PR_NUMBER=$(gh pr list --draft --search "${PR_TITLE}" --base "${BASE}" --json number --jq '.[].number')
+    fi
+  else
+    PR_NUMBER=""
   fi
 }
 
@@ -142,12 +149,14 @@ cp debianpackage/keyman-*/debian/changelog debian/
 git add debian/changelog
 COMMIT_MESSAGE="chore(linux): Update debian changelog"
 git commit -m "${COMMIT_MESSAGE}"
-push_to_github_and_create_pr chore/linux/changelog "${DEPLOY_BRANCH#origin/}" "${COMMIT_MESSAGE}" "${COMMIT_MESSAGE}"
+push_to_github_and_create_pr chore/linux/changelog "${DEPLOY_BRANCH#origin/}" "${COMMIT_MESSAGE}" "@keymanapp-test-bot skip"
 
 # Create cherry-pick on master branch
 git checkout -B chore/linux/cherry-pick/changelog origin/master
 git cherry-pick -x chore/linux/changelog
-push_to_github_and_create_pr chore/linux/cherry-pick/changelog master "${COMMIT_MESSAGE}" "${COMMIT_MESSAGE} 🍒"
+push_to_github_and_create_pr chore/linux/cherry-pick/changelog master "${COMMIT_MESSAGE} 🍒" \
+"Cherry-pick-of: #${PR_NUMBER}
+@keymanapp-test-bot skip"
 
 builder_heading "Finishing"
 git checkout "${CURRENT_BRANCH}"


### PR DESCRIPTION
This fixes the `upload-to-debian.sh` script if the `chore/linux/changelog` branch was created a while back while the base branch moved in the meantime. In this case we have to use `--force` instead of `--force-with-lease` otherwise `git` gets confused. This is save to do since the intention is that we replace the previous commit and we know that there is (should be) only one commit on the `chore/linux/changelog` branch.

Cherry-pick: #12818 

@keymanapp-test-bot skip