### PR TITLE
feat(web): add `Keyboard` and `KMXKeyboard` classes 🎼

### DIFF
--- a/web/src/app/browser/src/beepHandler.ts
+++ b/web/src/app/browser/src/beepHandler.ts
@@ -1,4 +1,5 @@
 import { type JSKeyboardInterface } from 'keyman/engine/js-processor';
+import { JSKeyboard, type KeyboardMinimalInterface } from 'keyman/engine/keyboard';
 import { DesignIFrame, OutputTarget } from 'keyman/engine/element-wrappers';
 
 // Utility object used to handle beep (keyboard error response) operations.
@@ -17,9 +18,9 @@ class BeepData {
 }
 
 export class BeepHandler {
-  readonly keyboardInterface: JSKeyboardInterface;
+  readonly keyboardInterface: KeyboardMinimalInterface;
 
-  constructor(keyboardInterface: JSKeyboardInterface) {
+  constructor(keyboardInterface: KeyboardMinimalInterface) {
     this.keyboardInterface = keyboardInterface;
   }
 
@@ -75,11 +76,13 @@ export class BeepHandler {
    * Description  Reset/terminate beep or flash (not currently used: Aug 2011)
    */
   readonly reset = () => {
-    this.keyboardInterface.resetContextCache();
+    // TODO-web-core: implement for KMX keyboards if needed
+    if (this.keyboardInterface.activeKeyboard instanceof JSKeyboard) {
+      (this.keyboardInterface as JSKeyboardInterface).resetContextCache();
+    }
 
-    var Lbo;
     this._BeepTimeout = 0;
-    for(Lbo=0;Lbo<this._BeepObjects.length;Lbo++) { // I1511 - array prototype extended
+    for(let Lbo=0;Lbo<this._BeepObjects.length;Lbo++) { // I1511 - array prototype extended
       this._BeepObjects[Lbo].reset();
     }
     this._BeepObjects = [];

--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -1,4 +1,4 @@
-import { type JSKeyboard, KeyboardScriptError } from 'keyman/engine/keyboard';
+import { JSKeyboard, type Keyboard, KeyboardScriptError } from 'keyman/engine/keyboard';
 import { type KeyboardStub } from 'keyman/engine/keyboard-storage';
 import { CookieSerializer } from 'keyman/engine/dom-utils';
 import { eventOutputTarget, outputTargetForElement, PageContextAttachment } from 'keyman/engine/attachment';
@@ -23,10 +23,12 @@ export interface KeyboardCookie {
  * has the same directionality, text runs will be re-ordered which is confusing and causes
  * incorrect caret positioning
  *
- * @param       {Object}      Ptarg      Target element
+ * @param       {Object}      Ptarg           Target element
+ * @param       {Keyboard}    activeKeyboard  The active keyboard
  */
-function _SetTargDir(Ptarg: HTMLElement, activeKeyboard: JSKeyboard) {
-  const elDir = activeKeyboard?.isRTL ? 'rtl' : 'ltr';
+function _SetTargDir(Ptarg: HTMLElement, activeKeyboard: Keyboard) {
+  // TODO-web-core: do we need to support RTL in Core?
+  const elDir = activeKeyboard instanceof JSKeyboard && activeKeyboard?.isRTL ? 'rtl' : 'ltr';
 
   if(Ptarg) {
     if(Ptarg instanceof Ptarg.ownerDocument.defaultView.HTMLInputElement

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -1,4 +1,4 @@
-import { type JSKeyboard  } from 'keyman/engine/keyboard';
+import { JSKeyboard, Keyboard  } from 'keyman/engine/keyboard';
 import { Mock, OutputTarget, Transcription, findCommonSubstringEndIndex, isEmptyTransform, TextTransform } from 'keyman/engine/js-processor';
 import { KeyboardStub } from 'keyman/engine/keyboard-storage';
 import { ContextManagerBase } from 'keyman/engine/main';
@@ -192,7 +192,7 @@ export default class ContextManager extends ContextManagerBase<WebviewConfigurat
   protected prepareKeyboardForActivation(
     keyboardId: string,
     languageCode?: string
-  ): {keyboard: Promise<JSKeyboard>, metadata: KeyboardStub} {
+  ): {keyboard: Promise<Keyboard>, metadata: KeyboardStub} {
     const originalKeyboard = this.activeKeyboard;
     const activatingKeyboard = super.prepareKeyboardForActivation(keyboardId, languageCode);
 
@@ -203,7 +203,10 @@ export default class ContextManager extends ContextManagerBase<WebviewConfigurat
     // That said, it's best to keep it around for now and verify later.
     if(originalKeyboard?.metadata?.id == activatingKeyboard?.metadata?.id) {
       activatingKeyboard.keyboard = activatingKeyboard.keyboard.then((kbd) => {
-        kbd.refreshLayouts()
+        // TODO-web-core: Do we need to refresh layouts for KMX keyboards also?
+        if (kbd instanceof JSKeyboard) {
+          kbd.refreshLayouts();
+        }
         return kbd;
       });
     }

--- a/web/src/app/webview/src/passthroughKeyboard.ts
+++ b/web/src/app/webview/src/passthroughKeyboard.ts
@@ -1,10 +1,10 @@
-import { DeviceSpec, JSKeyboard, KeyEvent, ManagedPromise } from 'keyman/engine/keyboard';
+import { DeviceSpec, Keyboard, KeyEvent, ManagedPromise } from 'keyman/engine/keyboard';
 
 import { HardKeyboard, processForMnemonicsAndLegacy } from 'keyman/engine/main';
 
 export default class PassthroughKeyboard extends HardKeyboard {
   readonly baseDevice: DeviceSpec;
-  public activeKeyboard: JSKeyboard;
+  public activeKeyboard: Keyboard;
 
   constructor(baseDevice: DeviceSpec) {
     super();

--- a/web/src/engine/keyboard/build.sh
+++ b/web/src/engine/keyboard/build.sh
@@ -22,6 +22,7 @@ builder_describe \
   "@/web/src/tools/testing/recorder-core  test" \
   "@/web/src/tools/es-bundling" \
   "@/web/src/engine/common/web-utils" \
+  "@/web/src/engine/core-processor" \
   configure \
   clean \
   build \

--- a/web/src/engine/keyboard/src/index.ts
+++ b/web/src/engine/keyboard/src/index.ts
@@ -1,8 +1,10 @@
 export { ActiveKeyBase, ActiveKey, ActiveSubKey, ActiveRow, ActiveLayer, ActiveLayout } from "./keyboards/activeLayout.js";
 export { ButtonClass, ButtonClasses, LayoutLayer, LayoutFormFactor, LayoutRow, LayoutKey, LayoutSubKey, Layouts } from "./keyboards/defaultLayouts.js";
 export { JSKeyboard, LayoutState, VariableStoreDictionary } from "./keyboards/jsKeyboard.js";
+export { KeyboardMinimalInterface } from './keyboards/keyboardMinimalInterface.js';
+export { KMXKeyboard } from './keyboards/kmxKeyboard.js';
 export { KeyboardHarness, KeyboardKeymanGlobal, MinimalCodesInterface, MinimalKeymanGlobal } from "./keyboards/keyboardHarness.js";
-export { KeyboardLoaderBase } from "./keyboards/keyboardLoaderBase.js";
+export { Keyboard, KeyboardLoaderBase } from "./keyboards/keyboardLoaderBase.js";
 export { KeyboardLoadErrorBuilder, KeyboardMissingError, KeyboardScriptError, KeyboardDownloadError, InvalidKeyboardError } from './keyboards/keyboardLoadError.js'
 export {
   CloudKeyboardFont,

--- a/web/src/engine/keyboard/src/keyboards/keyboardMinimalInterface.ts
+++ b/web/src/engine/keyboard/src/keyboards/keyboardMinimalInterface.ts
@@ -1,0 +1,5 @@
+import { Keyboard } from './keyboardLoaderBase.js';
+
+export interface KeyboardMinimalInterface {
+    activeKeyboard: Keyboard;
+}

--- a/web/src/engine/keyboard/src/keyboards/kmxKeyboard.ts
+++ b/web/src/engine/keyboard/src/keyboards/kmxKeyboard.ts
@@ -6,12 +6,12 @@ import { km_core_keyboard } from 'keyman/engine/core-processor';
 export class KMXKeyboard {
 
   constructor(id: string, keyboard: km_core_keyboard) {
-    this.id = id;
-    this.keyboard = keyboard;
+    this._id = id;
+    this._keyboard = keyboard;
   }
 
-  id: string;
-  keyboard: km_core_keyboard;
+  private _id: string;
+  private _keyboard: km_core_keyboard;
 
   get isMnemonic(): boolean {
     return false;
@@ -20,5 +20,13 @@ export class KMXKeyboard {
   get version(): string {
     // TODO-web-core: get version from `km_core_keyboard_get_attrs`
     return '';
+  }
+
+  get id(): string {
+    return this._id;
+  }
+
+  get keyboard(): km_core_keyboard {
+    return this._keyboard;
   }
 }

--- a/web/src/engine/keyboard/src/keyboards/kmxKeyboard.ts
+++ b/web/src/engine/keyboard/src/keyboards/kmxKeyboard.ts
@@ -1,0 +1,24 @@
+import { km_core_keyboard } from 'keyman/engine/core-processor';
+
+/**
+ * Acts as a wrapper class for KMX(+) Keyman keyboards
+ */
+export class KMXKeyboard {
+
+  constructor(id: string, keyboard: km_core_keyboard) {
+    this.id = id;
+    this.keyboard = keyboard;
+  }
+
+  id: string;
+  keyboard: km_core_keyboard;
+
+  get isMnemonic(): boolean {
+    return false;
+  }
+
+  get version(): string {
+    // TODO-web-core: get version from `km_core_keyboard_get_attrs`
+    return '';
+  }
+}

--- a/web/src/engine/main/src/contextManagerBase.ts
+++ b/web/src/engine/main/src/contextManagerBase.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'eventemitter3';
-import { ManagedPromise, type JSKeyboard } from 'keyman/engine/keyboard';
+import { ManagedPromise, type Keyboard } from 'keyman/engine/keyboard';
 import { type JSKeyboardInterface, type OutputTarget } from 'keyman/engine/js-processor';
 import { StubAndKeyboardCache, type KeyboardStub } from 'keyman/engine/keyboard-storage';
 import { PredictionContext } from 'keyman/engine/interfaces';
@@ -37,7 +37,7 @@ interface EventMap {
    * @param kbd
    * @returns
    */
-  'keyboardchange': (kbd: {keyboard: JSKeyboard, metadata: KeyboardStub}) => void;
+  'keyboardchange': (kbd: {keyboard: Keyboard, metadata: KeyboardStub}) => void;
 }
 
 export interface ContextManagerConfiguration {
@@ -65,7 +65,7 @@ export interface ContextManagerConfiguration {
 
 interface PendingActivation {
   target: OutputTarget,
-  keyboard: Promise<JSKeyboard>,
+  keyboard: Promise<Keyboard>,
   stub: KeyboardStub;
 }
 
@@ -124,7 +124,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
     this.predictionContext.resetContext();
   }
 
-  abstract get activeKeyboard(): {keyboard: JSKeyboard, metadata: KeyboardStub};
+  abstract get activeKeyboard(): {keyboard: Keyboard, metadata: KeyboardStub};
 
   /**
    * Determines the 'target' currently used to determine which keyboard should be active.
@@ -143,7 +143,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
    * @param kbd
    * @param target
    */
-  protected abstract activateKeyboardForTarget(kbd: {keyboard: JSKeyboard, metadata: KeyboardStub}, target: OutputTarget): void;
+  protected abstract activateKeyboardForTarget(kbd: {keyboard: Keyboard, metadata: KeyboardStub}, target: OutputTarget): void;
 
   /**
    * Checks the pending keyboard-activation array for an entry corresponding to the specified
@@ -178,7 +178,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
    * @returns
    */
   protected async deferredKeyboardActivation(
-    kbdPromise: Promise<JSKeyboard>,
+    kbdPromise: Promise<Keyboard>,
     metadata: KeyboardStub,
     target: OutputTarget
   ): Promise<PendingActivation> {
@@ -263,7 +263,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
       this.emit('beforekeyboardchange', activatingKeyboard.metadata);
     }
 
-    let kbdStubPair: { keyboard: JSKeyboard, metadata: KeyboardStub } = null;
+    let kbdStubPair: { keyboard: Keyboard, metadata: KeyboardStub } = null;
     if(keyboard) {
       kbdStubPair = {
         keyboard: keyboard,
@@ -298,7 +298,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
   protected prepareKeyboardForActivation(
     keyboardId: string,
     languageCode?: string
-  ): {keyboard: Promise<JSKeyboard>, metadata: KeyboardStub} {
+  ): {keyboard: Promise<Keyboard>, metadata: KeyboardStub} {
     // Set default language code
     languageCode ||= '';
 
@@ -333,7 +333,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
     }
 
     // Determine if the keyboard was previously loaded but is not active; use the cached, pre-loaded version if so.
-    let keyboard: JSKeyboard;
+    let keyboard: Keyboard;
     if(keyboard = this.keyboardCache.getKeyboardForStub(requestedStub)) {
       return {
         keyboard: Promise.resolve(keyboard),
@@ -351,7 +351,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
         this.emit('keyboardasyncload', requestedStub, completionPromise.corePromise);
 
         let keyboardPromise = this.keyboardCache.fetchKeyboardForStub(requestedStub);
-        let timeoutPromise = new Promise<JSKeyboard>((resolve, reject) => {
+        let timeoutPromise = new Promise<Keyboard>((resolve, reject) => {
           const timeoutMsg = `Sorry, the ${requestedStub.name} keyboard for ${requestedStub.langName} is not currently available.`;
           window.setTimeout(() => reject(new Error(timeoutMsg)), ContextManagerBase.TIMEOUT_THRESHOLD);
         });

--- a/web/src/engine/main/src/headless/inputProcessor.ts
+++ b/web/src/engine/main/src/headless/inputProcessor.ts
@@ -7,11 +7,10 @@ import { globalObject, DeviceSpec } from "@keymanapp/web-utils";
 
 import { CoreFactory, MainModule as KmCoreModule } from 'keyman/engine/core-processor';
 
-import { Codes, type JSKeyboard, type KeyEvent } from "keyman/engine/keyboard";
+import { Codes, JSKeyboard, KeyboardMinimalInterface, type Keyboard, type KeyEvent } from "keyman/engine/keyboard";
 import {
   type Alternate,
   isEmptyTransform,
-  JSKeyboardInterface,
   JSKeyboardProcessor,
   Mock,
   type OutputTarget,
@@ -66,7 +65,7 @@ export class InputProcessor {
     return this.kbdProcessor;
   }
 
-  public get keyboardInterface(): JSKeyboardInterface {
+  public get keyboardInterface(): KeyboardMinimalInterface {
     return this.keyboardProcessor.keyboardInterface;
   }
 
@@ -74,11 +73,11 @@ export class InputProcessor {
     return this.km_core;
   }
 
-  public get activeKeyboard(): JSKeyboard {
+  public get activeKeyboard(): Keyboard {
     return this.keyboardInterface.activeKeyboard;
   }
 
-  public set activeKeyboard(keyboard: JSKeyboard) {
+  public set activeKeyboard(keyboard: Keyboard) {
     this.keyboardInterface.activeKeyboard = keyboard;
 
     // All old deadkeys and keyboard-specific cache should immediately be invalidated
@@ -156,7 +155,7 @@ export class InputProcessor {
 
     // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
     // It's the OSK equivalent to doModifierPress on 'desktop' form factors.
-    if((formFactor == DeviceSpec.FormFactor.Desktop || !this.activeKeyboard || this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device)) && fromOSK) {
+    if((formFactor == DeviceSpec.FormFactor.Desktop || !this.activeKeyboard || (this.activeKeyboard instanceof JSKeyboard && this.activeKeyboard.usesDesktopLayoutOnDevice(keyEvent.device))) && fromOSK) {
       // If it's a desktop OSK style and this triggers a layer change,
       // a modifier key was clicked.  No output expected, so it's safe to instantly exit.
       if(this.keyboardProcessor.selectLayer(keyEvent)) {

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -1,8 +1,8 @@
-import { type KeyEvent, type JSKeyboard, KeyboardKeymanGlobal } from "keyman/engine/keyboard";
+import { type KeyEvent, JSKeyboard, Keyboard, KeyboardProperties, KeyboardKeymanGlobal } from "keyman/engine/keyboard";
 import { OutputTarget, ProcessorInitOptions, RuleBehavior } from 'keyman/engine/js-processor';
 import { DOMKeyboardLoader as KeyboardLoader } from "keyman/engine/keyboard/dom-keyboard-loader";
 import { InputProcessor } from './headless/inputProcessor.js';
-import { OSKView } from "keyman/engine/osk";
+import { OSKView, JSKeyboardData } from "keyman/engine/osk";
 import { KeyboardRequisitioner, ModelCache, toUnprefixedKeyboardId as unprefixed } from "keyman/engine/keyboard-storage";
 import { ModelSpec, PredictionContext } from "keyman/engine/interfaces";
 
@@ -146,11 +146,11 @@ export default class KeymanEngine<
       });
     });
 
-    this.contextManager.on('keyboardchange', (kbd) => {
+    this.contextManager.on('keyboardchange', (kbdData: { keyboard: Keyboard, metadata: KeyboardProperties }) => {
       // Hide OSK and do not update keyboard list if using internal keyboard (desktops).
       // Condition will not be met for touch form-factors; they force selection of a
       // default keyboard.
-      if(!kbd) {
+      if(!kbdData) {
         this.osk.startHide(false);
       }
 
@@ -158,11 +158,11 @@ export default class KeymanEngine<
         this.refreshModel();
         // Triggers context resets that can trigger layout stuff.
         // It's not the final such context-reset, though.
-        this.core.activeKeyboard = kbd?.keyboard;
+        this.core.activeKeyboard = kbdData?.keyboard;
 
         this.legacyAPIEvents.callEvent('keyboardchange', {
-          internalName: kbd?.metadata.id ?? '',
-          languageCode: kbd?.metadata.langId ?? ''
+          internalName: kbdData?.metadata.id ?? '',
+          languageCode: kbdData?.metadata.langId ?? ''
         });
       }
 
@@ -174,10 +174,10 @@ export default class KeymanEngine<
         If possible, we want to only perform layout operations once the correct layer is
         set to active.
       */
-      if(this.osk) {
+      if(this.osk && (!kbdData || kbdData.keyboard instanceof JSKeyboard)) { // TODO-web-core: add support for OSK for KMX keyboards
         this.osk.batchLayoutAfter(() => {
           prepareKeyboardSwap();
-          this.osk.activeKeyboard = kbd;
+          this.osk.activeKeyboard = kbdData ? { keyboard: kbdData.keyboard as JSKeyboard, metadata: kbdData.metadata } : undefined;
           // Note:  when embedded within the mobile apps, the keyboard will still be visible
           // at this time.
 
@@ -243,6 +243,7 @@ export default class KeymanEngine<
     // Since we're not sandboxing keyboard loads yet, we just use `window` as the jsGlobal object.
     // All components initialized below require a properly-configured `config.paths` or similar.
     const keyboardLoader = new KeyboardLoader(this.interface, config.applyCacheBusting);
+    keyboardLoader.coreModule = this.core.keymanCore;
     this.keyboardRequisitioner = new KeyboardRequisitioner(keyboardLoader, new DOMCloudRequester(), this.config.paths);
     this.modelCache = new ModelCache();
     const kbdCache = this.keyboardRequisitioner.cache;
@@ -382,7 +383,7 @@ export default class KeymanEngine<
     this.core.keyboardProcessor.contextDevice = value?.targetDevice ?? this.config.softDevice;
     if(value) {
       // Don't build an OSK if no keyboard is available yet; avoid the extra flash.
-      if(this.contextManager.activeKeyboard) {
+      if (this.contextManager.activeKeyboard && this.contextManager.activeKeyboard instanceof JSKeyboardData) { // TODO-web-core: add support for OSK for KMX keyboards
         value.activeKeyboard = this.contextManager.activeKeyboard;
       }
       value.on('keyevent', this.keyEventListener);
@@ -555,22 +556,29 @@ export default class KeymanEngine<
    * See https://help.keyman.com/developer/engine/web/current-version/reference/core/isChiral
    */
   public isChiral(k0?: string | JSKeyboard) {
-    let kbd: JSKeyboard;
+    let jsKbd: JSKeyboard;
     if(k0) {
       if(typeof k0 == 'string') {
         const kbdObj = this.keyboardRequisitioner.cache.getKeyboard(k0);
-        if(!kbdObj) {
+        if (!kbdObj) {
           throw new Error(`Keyboard '${k0}' has not been loaded.`);
+        } else if (!(kbdObj instanceof JSKeyboard)) {
+          return false; // TODO-web-core: implement for KMX keyboards
         } else {
           k0 = kbdObj;
         }
       }
 
-      kbd = k0;
+      jsKbd = k0;
     } else {
-      kbd = this.core.activeKeyboard;
+      const kbd = this.core.activeKeyboard;
+      if (kbd instanceof JSKeyboard) {
+        jsKbd = kbd;
+      } else {
+        return false; // TODO-web-core: implement for KMX keyboards
+      }
     }
-    return kbd.isChiral;
+    return jsKbd.isChiral;
   }
 
   /**

--- a/web/src/engine/osk/src/index.ts
+++ b/web/src/engine/osk/src/index.ts
@@ -1,6 +1,6 @@
 export { Codes, DeviceSpec, JSKeyboard, KeyboardProperties, SpacebarText } from 'keyman/engine/keyboard';
 
-export { default as OSKView } from './views/oskView.js';
+export { default as OSKView, JSKeyboardData } from './views/oskView.js';
 export { default as FloatingOSKView, FloatingOSKViewConfiguration } from './views/floatingOskView.js';
 export { default as AnchoredOSKView } from './views/anchoredOskView.js';
 export { default as InlinedOSKView } from './views/inlinedOskView.js';

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -59,6 +59,11 @@ export interface LegacyOSKEventMap {
   }): void;
 }
 
+export class JSKeyboardData {
+  keyboard: JSKeyboard;
+  metadata: KeyboardProperties;
+};
+
 /**
  * For now, these will serve as undocumented, internal events.  We need a proper
  * design round and discussion before we consider promoting them to long-term,
@@ -168,10 +173,7 @@ export default abstract class OSKView
   private _boxBaseTouchStart:       (e: TouchEvent) => boolean;
   private _boxBaseTouchEventCancel: (e: TouchEvent) => boolean;
 
-  private keyboardData: {
-    keyboard: JSKeyboard,
-    metadata: KeyboardProperties
-  };
+  private keyboardData: JSKeyboardData;
 
   /**
    * Provides the current parameterization for timings and distances used by
@@ -532,17 +534,11 @@ export default abstract class OSKView
     }
   }
 
-  public get activeKeyboard(): {
-    keyboard: JSKeyboard,
-    metadata: KeyboardProperties
-  } {
+  public get activeKeyboard(): JSKeyboardData {
     return this.keyboardData;
   }
 
-  public set activeKeyboard(keyboardData: {
-    keyboard: JSKeyboard,
-    metadata: KeyboardProperties
-  }) {
+  public set activeKeyboard(keyboardData: JSKeyboardData) {
     this.keyboardData = keyboardData;
     this.loadActiveKeyboard();
 

--- a/web/src/test/auto/dom/cases/keyboard/domKeyboardLoader.tests.ts
+++ b/web/src/test/auto/dom/cases/keyboard/domKeyboardLoader.tests.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 
 import { DOMKeyboardLoader } from 'keyman/engine/keyboard/dom-keyboard-loader';
-import { extendString, KeyboardHarness, JSKeyboard, MinimalKeymanGlobal, DeviceSpec, KeyboardKeymanGlobal, KeyboardDownloadError, KeyboardScriptError } from 'keyman/engine/keyboard';
+import { extendString, KeyboardHarness, JSKeyboard, MinimalKeymanGlobal, DeviceSpec, KeyboardKeymanGlobal, KeyboardDownloadError, KeyboardScriptError, Keyboard } from 'keyman/engine/keyboard';
 import { JSKeyboardInterface, Mock } from 'keyman/engine/js-processor';
 import { assertThrowsAsync } from 'keyman/tools/testing/test-utils';
 
@@ -49,12 +49,14 @@ describe('Keyboard loading in DOM', function() {
   it('`window`, disabled rule processing', async () => {
     const harness = new KeyboardHarness(window, MinimalKeymanGlobal);
     let keyboardLoader = new DOMKeyboardLoader(harness);
-    let keyboard: JSKeyboard = await keyboardLoader.loadKeyboardFromPath('/common/test/resources/keyboards/khmer_angkor.js');
+    let keyboard: Keyboard = await keyboardLoader.loadKeyboardFromPath('/common/test/resources/keyboards/khmer_angkor.js');
 
     assert.isOk(keyboard);
-    assert.equal(keyboard.id, 'Keyboard_khmer_angkor');
-    assert.isTrue(keyboard.isChiral);
-    assert.isFalse(keyboard.isCJK);
+    assert.instanceOf(keyboard, JSKeyboard);
+    const jsKeyboard = keyboard as JSKeyboard;
+    assert.equal(jsKeyboard.id, 'Keyboard_khmer_angkor');
+    assert.isTrue(jsKeyboard.isChiral);
+    assert.isFalse(jsKeyboard.isCJK);
     assert.isOk(KeymanWeb);
     assert.isOk(keyman);
     assert.isOk(keyman.osk);
@@ -65,24 +67,26 @@ describe('Keyboard loading in DOM', function() {
   });
 
   it('`window`, enabled rule processing', async () => {
-    const harness = new JSKeyboardInterface(window, MinimalKeymanGlobal);
-    const keyboardLoader = new DOMKeyboardLoader(harness);
-    const keyboard: JSKeyboard = await keyboardLoader.loadKeyboardFromPath('/common/test/resources/keyboards/khmer_angkor.js');
-    harness.activeKeyboard = keyboard;
+    const jsHarness = new JSKeyboardInterface(window, MinimalKeymanGlobal);
+    const keyboardLoader = new DOMKeyboardLoader(jsHarness);
+    const keyboard: Keyboard = await keyboardLoader.loadKeyboardFromPath('/common/test/resources/keyboards/khmer_angkor.js');
+    const jsKeyboard = keyboard as JSKeyboard;
+    jsHarness.activeKeyboard = jsKeyboard;
 
     assert.isOk(keyboard);
-    assert.equal(keyboard.id, 'Keyboard_khmer_angkor');
-    assert.isTrue(keyboard.isChiral);
-    assert.isFalse(keyboard.isCJK);
+    assert.instanceOf(keyboard, JSKeyboard);
+    assert.equal(jsKeyboard.id, 'Keyboard_khmer_angkor');
+    assert.isTrue(jsKeyboard.isChiral);
+    assert.isFalse(jsKeyboard.isCJK);
     assert.isOk(KeymanWeb);
     assert.isOk(keyman);
     assert.isOk(keyman.osk);
     assert.isOk(keyman.osk.keyCodes);
 
     // TODO:  verify actual rule processing.
-    const nullKeyEvent = keyboard.constructNullKeyEvent(device);
+    const nullKeyEvent = jsKeyboard.constructNullKeyEvent(device);
     const mock = new Mock();
-    const result = harness.processKeystroke(mock, nullKeyEvent);
+    const result = jsHarness.processKeystroke(mock, nullKeyEvent);
 
     assert.isOk(result);
     assert.isOk(KeymanWeb);
@@ -91,17 +95,19 @@ describe('Keyboard loading in DOM', function() {
     assert.isOk(keyman.osk.keyCodes);
 
     // Should be cleared post-keyboard-load.
-    assert.isNotOk(harness.loadedKeyboard);
+    assert.isNotOk(jsHarness.loadedKeyboard);
   });
 
   it('load keyboards successfully in parallel without side effects', async () => {
-    let harness = new JSKeyboardInterface(window, MinimalKeymanGlobal);
-    let keyboardLoader = new DOMKeyboardLoader(harness);
+    let jsHarness = new JSKeyboardInterface(window, MinimalKeymanGlobal);
+    let keyboardLoader = new DOMKeyboardLoader(jsHarness);
 
     // Preload a keyboard and make it active.
-    const test_kbd: JSKeyboard = await keyboardLoader.loadKeyboardFromPath('/common/test/resources/keyboards/test_917.js');
-    harness.activeKeyboard = test_kbd;
-    assert.isNotOk(harness.loadedKeyboard);
+    const test_kbd: Keyboard = await keyboardLoader.loadKeyboardFromPath('/common/test/resources/keyboards/test_917.js');
+    assert.instanceOf(test_kbd, JSKeyboard);
+    const test_jskbd = test_kbd as JSKeyboard;
+    jsHarness.activeKeyboard = test_jskbd;
+    assert.isNotOk(jsHarness.loadedKeyboard);
 
     // With an active keyboard, load three keyboards but activate none of them.
     const lao_keyboard_promise = keyboardLoader.loadKeyboardFromPath('/common/test/resources/keyboards/lao_2008_basic.js');
@@ -113,8 +119,8 @@ describe('Keyboard loading in DOM', function() {
     const lao_keyboard = await lao_keyboard_promise;
     const khmer_keyboard = await khmer_keyboard_promise;
 
-    assert.strictEqual(test_kbd, harness.activeKeyboard);
-    assert.isNotOk(harness.loadedKeyboard);
+    assert.strictEqual(test_kbd, jsHarness.activeKeyboard);
+    assert.isNotOk(jsHarness.loadedKeyboard);
 
     assert.isOk(lao_keyboard);
     assert.isOk(chiral_keyboard);
@@ -125,6 +131,6 @@ describe('Keyboard loading in DOM', function() {
     assert.equal(khmer_keyboard.id, "Keyboard_khmer_angkor");
     assert.equal(chiral_keyboard.id, "Keyboard_test_chirality");
 
-    harness.activeKeyboard = lao_keyboard;
+    jsHarness.activeKeyboard = lao_keyboard as JSKeyboard;
   });
 });

--- a/web/src/test/auto/dom/kbdLoader.ts
+++ b/web/src/test/auto/dom/kbdLoader.ts
@@ -37,7 +37,12 @@ export function loadKeyboardsFromStubs(apiStubs: any, baseDir: string) {
       const overwriteLoader = (id: number, path: string) => {
         const loader = loadKeyboardFromPath(path);
         return loader.then(kbd => {
-          keyboards[stub.id].keyboard = kbd;
+          if (kbd instanceof JSKeyboard) {
+            keyboards[stub.id].keyboard = kbd;
+          } else {
+            // TODO-web-core: implement for KMX keyboards if needed
+            keyboards[stub.id].keyboard = null;
+          }
         });
       }
       keyboards[stub.id] = {

--- a/web/src/test/auto/headless/engine/js-processor/kbdInterface.tests.ts
+++ b/web/src/test/auto/headless/engine/js-processor/kbdInterface.tests.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
-import { DeviceSpec, MinimalKeymanGlobal } from 'keyman/engine/keyboard';
+import { DeviceSpec, JSKeyboard, MinimalKeymanGlobal } from 'keyman/engine/keyboard';
 import { JSKeyboardInterface, Mock } from 'keyman/engine/js-processor';
 import { NodeKeyboardLoader } from 'keyman/engine/keyboard/node-keyboard-loader';
 
@@ -24,10 +24,10 @@ describe('Headless keyboard loading', function () {
   describe('Full harness loading', () => {
     it('successfully loads', async function () {
       // -- START: Standard Recorder-based unit test loading boilerplate --
-      const harness = new JSKeyboardInterface({}, MinimalKeymanGlobal);
-      const keyboardLoader = new NodeKeyboardLoader(harness);
+      const jsHarness = new JSKeyboardInterface({}, MinimalKeymanGlobal);
+      const keyboardLoader = new NodeKeyboardLoader(jsHarness);
       const keyboard = await keyboardLoader.loadKeyboardFromPath(laoPath);
-      harness.activeKeyboard = keyboard;
+      jsHarness.activeKeyboard = keyboard as JSKeyboard;
       // --  END:  Standard Recorder-based unit test loading boilerplate --
 
       // This part provides assurance that the keyboard properly loaded.
@@ -39,11 +39,11 @@ describe('Headless keyboard loading', function () {
       const harness = new JSKeyboardInterface({}, MinimalKeymanGlobal);
       const keyboardLoader = new NodeKeyboardLoader(harness);
       const keyboard = await keyboardLoader.loadKeyboardFromPath(laoPath);
-      harness.activeKeyboard = keyboard;
+      harness.activeKeyboard = keyboard as JSKeyboard;
       // --  END:  Standard Recorder-based unit test loading boilerplate --
 
       // Runs a blank KeyEvent through the keyboard's rule processing.
-      harness.processKeystroke(new Mock(), keyboard.constructNullKeyEvent(device));
+      harness.processKeystroke(new Mock(), (keyboard as JSKeyboard).constructNullKeyEvent(device));
     });
 
     it('does not change the active kehboard', async function () {
@@ -56,7 +56,7 @@ describe('Headless keyboard loading', function () {
       // This part provides assurance that the keyboard properly loaded.
       assert.equal(lao_keyboard.id, "Keyboard_lao_2008_basic");
 
-      harness.activeKeyboard = lao_keyboard;
+      harness.activeKeyboard = lao_keyboard as JSKeyboard;
 
       const khmer_keyboard = await keyboardLoader.loadKeyboardFromPath(khmerPath);
       assert.strictEqual(lao_keyboard, harness.activeKeyboard);

--- a/web/src/test/auto/headless/engine/keyboard/keyboard.tests.ts
+++ b/web/src/test/auto/headless/engine/keyboard/keyboard.tests.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
-import { KeyboardHarness, MinimalKeymanGlobal, DeviceSpec } from 'keyman/engine/keyboard';
+import { KeyboardHarness, MinimalKeymanGlobal, DeviceSpec, JSKeyboard } from 'keyman/engine/keyboard';
 import { NodeKeyboardLoader } from 'keyman/engine/keyboard/node-keyboard-loader';
 
 
@@ -14,7 +14,8 @@ describe('Keyboard tests', function () {
     // -- START: Standard Recorder-based unit test loading boilerplate --
     const harness = new KeyboardHarness({}, MinimalKeymanGlobal);
     const keyboardLoader = new NodeKeyboardLoader(harness);
-    const km_keyboard = await keyboardLoader.loadKeyboardFromPath(khmerPath);
+    const keyboard = await keyboardLoader.loadKeyboardFromPath(khmerPath);
+    const km_keyboard = keyboard as JSKeyboard;
     // --  END:  Standard Recorder-based unit test loading boilerplate --
 
     // `khmer_angkor` - supports longpresses, but not flicks or multitaps.

--- a/web/src/test/auto/headless/engine/keyboard/keyboardLoaderBase.tests.ts
+++ b/web/src/test/auto/headless/engine/keyboard/keyboardLoaderBase.tests.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
-import { KeyboardHarness, MinimalKeymanGlobal, KeyboardDownloadError, DeviceSpec, InvalidKeyboardError } from 'keyman/engine/keyboard';
+import { KeyboardHarness, MinimalKeymanGlobal, KeyboardDownloadError, DeviceSpec, InvalidKeyboardError, JSKeyboard } from 'keyman/engine/keyboard';
 import { JSKeyboardInterface, Mock } from 'keyman/engine/js-processor';
 import { NodeKeyboardLoader } from 'keyman/engine/keyboard/node-keyboard-loader';
 import { assertThrowsAsync, assertThrows } from 'keyman/tools/testing/test-utils';
@@ -76,14 +76,15 @@ describe('Headless keyboard loading', function() {
       const keyboard = await keyboardLoader.loadKeyboardFromPath(laoPath);
       // --  END:  Standard Recorder-based unit test loading boilerplate --
 
+      assert.instanceOf(keyboard, JSKeyboard);
       // Runs a blank KeyEvent through the keyboard's rule processing...
       // but via separate harness configured with a different captured global.
       // This shows an important detail: the 'global' object is effectively
       // closure-captured. (Similar constraints may occur when experimenting with
       // 'sandboxed' keyboard loading in the DOM!)
       const ruleHarness = new JSKeyboardInterface({}, MinimalKeymanGlobal);
-      ruleHarness.activeKeyboard = keyboard;
-      assertThrows(() => ruleHarness.processKeystroke(new Mock(), keyboard.constructNullKeyEvent(device)), 'k.KKM is not a function');
+      ruleHarness.activeKeyboard = keyboard as JSKeyboard;
+      assertThrows(() => ruleHarness.processKeystroke(new Mock(), (keyboard as JSKeyboard).constructNullKeyEvent(device)), 'k.KKM is not a function');
     });
   });
 });

--- a/web/src/test/auto/integrated/web-test-runner.config.mjs
+++ b/web/src/test/auto/integrated/web-test-runner.config.mjs
@@ -24,7 +24,7 @@ export default {
   concurrency: 10,
   nodeResolve: true,
   files: [
-    'web/build/test/integrated//**/*.tests.mjs',
+    'web/build/test/integrated/**/*.tests.mjs',
     // '**/*.tests.html'
   ],
   middleware: [


### PR DESCRIPTION
The `Keyboard` class can be either a JS or KMX keyboard. Also make use of the `Keyboard` class where it makes sense and add TODOs in the places that still need to be implemented for KMX keyboard support.

Part-of: #11293 
@keymanapp-test-bot skip