### PR TITLE
chore(core): remove meson warnings for wasm builds

### DIFF
--- a/core/tests/unit/kmx/fixtures/binary/meson.build
+++ b/core/tests/unit/kmx/fixtures/binary/meson.build
@@ -16,11 +16,7 @@ binary_tests = [
 ]
 
 foreach kbd : binary_tests
-  configure_file(
-    input: kbd + '.kmn',
-    output: kbd + '.kmn',
-    copy: true
-  )
+  fs.copyfile(kbd + '.kmn', kbd + '.kmn')
 
   configure_file(
     command: hextobin_cmd + ['@INPUT@', '@OUTPUT@'],

--- a/core/tests/unit/kmx/meson.build
+++ b/core/tests/unit/kmx/meson.build
@@ -139,7 +139,10 @@ foreach kbd : tests
   cfg.set('CONTENT', content)
 
   kbd_kmn = configure_file(
-    copy: true,
+    # not really a file that needs to be configured, but the `copy` parameter
+    # is deprecated and `fs.copyfile` doesn't work with files that are not in
+    # the source directory
+    configuration: cfg,
     input: kbd_src_path,
     output: kbd + '.kmn'
   )

--- a/core/tests/unit/ldml/invalid-keyboards/meson.build
+++ b/core/tests/unit/ldml/invalid-keyboards/meson.build
@@ -11,11 +11,7 @@ invalid_tests = [
 # Build all keyboards in output folder
 
 foreach kbd : invalid_tests
-  configure_file(
-    input: kbd + '.xml',
-    output: kbd + '.xml',
-    copy: true
-  )
+  fs.copyfile(kbd + '.xml', kbd + '.xml')
 
   configure_file(
     command: hextobin_cmd + ['@INPUT@', '@OUTPUT@'],

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -65,11 +65,7 @@ kmc_cmd = [node, '--enable-source-maps', kmc_root]
 # Build all keyboards in output folder
 
 foreach kbd : tests_needing_copy
-  configure_file(
-    copy: true,
-    input: kbd + '.xml',
-    output: kbd + '.xml'
-  )
+  fs.copyfile(kbd + '.xml', kbd + '.xml')
 
   configure_file(
     command: kmc_cmd + ['build', '@INPUT@', '--out-file', '@OUTPUT@'],
@@ -86,13 +82,8 @@ foreach kbd : tests_with_testdata
   )
 endforeach
 
-
 foreach kbd : tests_from_cldr
-  configure_file(
-    copy: true,
-    input: ldml_data / kbd + '.xml',
-    output: kbd + '.xml'
-  )
+  fs.copyfile(ldml_data / kbd + '.xml', kbd + '.xml')
   configure_file(
     command: kmc_cmd + ['build', '@INPUT@', '--out-file', '@OUTPUT@'],
     input: join_paths(ldml_data, kbd + '.xml'),

--- a/core/tests/unit/ldml/meson.build
+++ b/core/tests/unit/ldml/meson.build
@@ -43,16 +43,8 @@ else
 endif
 
 # copy package.json into build dir for test use
-configure_file(
-  copy: true,
-  input: '../../../../package.json',
-  output: 'package.json',
-)
-configure_file(
-  copy: true,
-  input: '../../../../resources/standards-data/unicode-character-database/Blocks.txt',
-  output: 'Blocks.txt',
-)
+fs.copyfile('../../../../package.json', 'package.json')
+fs.copyfile('../../../../resources/standards-data/unicode-character-database/Blocks.txt', 'Blocks.txt')
 
 configure_file(
   command: [node, meson.current_source_dir() / 'write_node_versions.js','@OUTPUT@'],

--- a/core/wasm.build.linux.in
+++ b/core/wasm.build.linux.in
@@ -2,3 +2,4 @@
 c = ['$EMSCRIPTEN_BASE/emcc']
 cpp = ['$EMSCRIPTEN_BASE/em++']
 ar = ['$EMSCRIPTEN_BASE/emar']
+strip = ['$EMSCRIPTEN_BASE/emstrip']

--- a/core/wasm.build.mac.in
+++ b/core/wasm.build.mac.in
@@ -2,3 +2,4 @@
 c = ['$EMSCRIPTEN_BASE/emcc']
 cpp = ['$EMSCRIPTEN_BASE/em++']
 ar = ['$EMSCRIPTEN_BASE/emar']
+strip = ['$EMSCRIPTEN_BASE/emstrip']

--- a/core/wasm.build.win.in
+++ b/core/wasm.build.win.in
@@ -2,5 +2,6 @@
 c = ['python.exe', '$EMSCRIPTEN_BASE/emcc.py']
 cpp = ['python.exe', '$EMSCRIPTEN_BASE/em++.py']
 ar = ['python.exe', '$EMSCRIPTEN_BASE/emar.py']
+strip = ['python.exe', '$EMSCRIPTEN_BASE/emstrip.py']
 
 [properties]

--- a/core/wasm.defs.build
+++ b/core/wasm.defs.build
@@ -2,6 +2,7 @@
 c = ['emcc']
 cpp = ['em++']
 ar = ['emar']
+strip = ['emstrip']
 exe_wrapper = 'node'
 
 [properties]

--- a/developer/src/kmcmplib/tests/meson.build
+++ b/developer/src/kmcmplib/tests/meson.build
@@ -162,7 +162,7 @@ gtestcompilertest = executable('gtest-compiler-tests', 'gtest-compiler.tests.cpp
     include_directories: inc,
     name_suffix: name_suffix,
     link_args: links + tests_links,
-    objects: lib.extract_all_objects(),
+    objects: lib.extract_all_objects(recursive: false),
     dependencies: [ icuuc_dep, gtest_dep, gmock_dep ],
   )
 
@@ -173,7 +173,7 @@ gtest_km_u16_test = executable('gtest-km_u16-tests', 'gtest-km_u16.tests.cpp',
     include_directories: inc,
     name_suffix: name_suffix,
     link_args: links + tests_links,
-    objects: lib.extract_all_objects(),
+    objects: lib.extract_all_objects(recursive: false),
     dependencies: [ icuuc_dep, gtest_dep, gmock_dep ],
   )
 

--- a/developer/src/kmcmplib/wasm.build.linux.in
+++ b/developer/src/kmcmplib/wasm.build.linux.in
@@ -2,3 +2,4 @@
 c = ['$EMSCRIPTEN_BASE/emcc']
 cpp = ['$EMSCRIPTEN_BASE/em++']
 ar = ['$EMSCRIPTEN_BASE/emar']
+strip = ['$EMSCRIPTEN_BASE/emstrip']

--- a/developer/src/kmcmplib/wasm.build.mac.in
+++ b/developer/src/kmcmplib/wasm.build.mac.in
@@ -2,3 +2,4 @@
 c = ['$EMSCRIPTEN_BASE/emcc']
 cpp = ['$EMSCRIPTEN_BASE/em++']
 ar = ['$EMSCRIPTEN_BASE/emar']
+strip = ['$EMSCRIPTEN_BASE/emstrip']

--- a/developer/src/kmcmplib/wasm.build.win.in
+++ b/developer/src/kmcmplib/wasm.build.win.in
@@ -2,3 +2,4 @@
 c = ['python.exe', '$EMSCRIPTEN_BASE/emcc.py']
 cpp = ['python.exe', '$EMSCRIPTEN_BASE/em++.py']
 ar = ['python.exe', '$EMSCRIPTEN_BASE/emar.py']
+strip = ['python.exe', '$EMSCRIPTEN_BASE/emstrip.py']

--- a/developer/src/kmcmplib/wasm.defs.build
+++ b/developer/src/kmcmplib/wasm.defs.build
@@ -1,7 +1,8 @@
 [binaries]
-c = ['emcc.py']
-cpp = ['em++.py']
-ar = ['emar.py']
+c = ['emcc']
+cpp = ['em++']
+ar = ['emar']
+strip = ['emstrip']
 exe_wrapper = 'node'
 
 [properties]


### PR DESCRIPTION
Replace deprecated function calls. Also add `strip` command to wasm build defaults.

@keymanapp-test-bot skip