### PR TITLE
fix(android/engine): Initialize index when resuming KeyboardPicker

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KeyboardPickerActivity.java
@@ -254,11 +254,16 @@ public final class KeyboardPickerActivity extends BaseActivity {
     }
 
 
-    SharedPreferences prefs = this.getSharedPreferences(this.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
-    String currentKeyboard = KMKeyboard.currentKeyboard();
-    int curKbPos = (currentKeyboard == null) ? prefs.getInt(KMManager.KMKey_UserKeyboardIndex, 0) :
-      KeyboardController.getInstance().getKeyboardIndex(KMKeyboard.currentKeyboard());
-    setSelection(curKbPos);
+    // Determine the index to the current keyboard position to highlight as the selected keyboard
+    int currentKeyboardIndex; 
+    String currentKeyboardKey = KMKeyboard.currentKeyboard();
+    if (currentKeyboardKey == null) {
+      SharedPreferences prefs = this.getSharedPreferences(this.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+      currentKeyboardIndex = prefs.getInt(KMManager.KMKey_UserKeyboardIndex, 0);
+    } else {
+      currentKeyboardIndex = KeyboardController.getInstance().getKeyboardIndex(currentKeyboardKey);
+    }     
+    setSelection(currentKeyboardIndex);
 
     imeList = getIMEList(this);
     BaseAdapter imeAdapter = (BaseAdapter)imeListAdapter;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KeyboardPickerActivity.java
@@ -25,6 +25,7 @@ import com.keyman.engine.util.MapCompat;
 
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -252,7 +253,11 @@ public final class KeyboardPickerActivity extends BaseActivity {
       adapter.notifyDataSetChanged();
     }
 
-    int curKbPos = KeyboardController.getInstance().getKeyboardIndex(KMKeyboard.currentKeyboard());
+
+    SharedPreferences prefs = this.getSharedPreferences(this.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+    String currentKeyboard = KMKeyboard.currentKeyboard();
+    int curKbPos = (currentKeyboard == null) ? prefs.getInt(KMManager.KMKey_UserKeyboardIndex, 0) :
+      KeyboardController.getInstance().getKeyboardIndex(KMKeyboard.currentKeyboard());
     setSelection(curKbPos);
 
     imeList = getIMEList(this);


### PR DESCRIPTION
Fixes: #11714
Fixes: KEYMAN-ANDROID-39S

From the crash reports, it's possible for `KeyboardPickerActivity` to resume, and have the keyboard key `KMKeyboard.currentKeyboard()` be uninitialized (null).

This updates `KeyboardPickerActivity.onResume` to get the keyboard index from the saved preference if `KMKeyboard.currentKeyboard()` is null.

@keymanapp-test-bot skip
