### PR TITLE
fix(mac): standardize interaction between OSK and physical keyboard

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.h
+++ b/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.h
@@ -13,6 +13,8 @@
 
 @property (nonatomic, weak) IBOutlet OSKView *oskView;
 
+- (void)prepareToShowOsk;
 - (void)resetOSK;
+- (NSEventModifierFlags)getOskEventModifierFlags;
 
 @end

--- a/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
@@ -74,6 +74,12 @@
   [self.oskView clearOskModifiers];
 }
 
+- (void) showWindow:(id) sender {
+  [super showWindow:sender];
+
+  os_log_info([KMLogs oskLog], "OSKWindowController showWindow");
+}
+
 - (void)helpAction:(id)sender {
   NSString *kvkPath = [self AppDelegate].kvk.filePath;
   if (!kvkPath)

--- a/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
@@ -66,18 +66,16 @@
   [self.oskView resizeOSKLayout];
 }
 
+- (void)prepareToShowOsk {
+  os_log_info([KMLogs oskLog], "OSKWindowController prepareToShowOsk");
+}
+
 - (void)windowWillClose:(NSNotification *)notification {
   os_log_debug([KMLogs oskLog], "OSKWindowController windowWillClose");
   [KMSettingsRepository.shared writeShowOskOnActivate:NO];
   
-  // whenever the OSK is closed clear all of its modifier keys
+  // whenever the OSK is closing clear all of its modifier keys
   [self.oskView clearOskModifiers];
-}
-
-- (void) showWindow:(id) sender {
-  [super showWindow:sender];
-
-  os_log_info([KMLogs oskLog], "OSKWindowController showWindow");
 }
 
 - (void)helpAction:(id)sender {
@@ -106,6 +104,16 @@
   }
 }
 
+/**
+ * returns current event flags representing the state of the modifiers on the OSK or zero if OSK is closed
+ */
+- (NSEventModifierFlags)getOskEventModifierFlags {
+  if (self.window.isVisible) {
+    return [self.oskView getOskEventModifierFlags];
+  } else {
+    return 0;
+  }
+}
 - (void)startTimerWithTimeInterval:(NSTimeInterval)interval {
   if (_modFlagsTimer == nil) {
     TimerTarget *timerTarget = [[TimerTarget alloc] init];

--- a/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.m
@@ -67,8 +67,11 @@
 }
 
 - (void)windowWillClose:(NSNotification *)notification {
+  os_log_debug([KMLogs oskLog], "OSKWindowController windowWillClose");
   [KMSettingsRepository.shared writeShowOskOnActivate:NO];
-  os_log_debug([KMLogs oskLog], "OSKWindowController windowWillClose, updating settings writeShowOsk to NO");
+  
+  // whenever the OSK is closed clear all of its modifier keys
+  [self.oskView clearOskModifiers];
 }
 
 - (void)helpAction:(id)sender {

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.h
@@ -25,6 +25,7 @@
 - (void)setOskOptionState:(BOOL)oskAltState;
 - (void)setPhysicalControlState:(BOOL)ctrlState;
 - (void)setOskControlState:(BOOL)oskCtrlState;
+- (void)clearOskModifiers;
 - (void)resetOSK;
 - (void)resizeOSKLayout;
 - (int64_t)createOskEventUserData;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.h
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.h
@@ -26,6 +26,7 @@
 - (void)setPhysicalControlState:(BOOL)ctrlState;
 - (void)setOskControlState:(BOOL)oskCtrlState;
 - (void)clearOskModifiers;
+- (NSEventModifierFlags)getOskEventModifierFlags;
 - (void)resetOSK;
 - (void)resizeOSKLayout;
 - (int64_t)createOskEventUserData;

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
@@ -435,6 +435,7 @@ const int64_t OSK_EVENT_MODIFIER_MASK = 0x00000000FFFFFFFF;
   _oskShiftState = NO;
   _oskOptionState = NO;
   _oskControlState = NO;
+  [self displayModifierKeysState];
   [self displayKeyLabelsForLayer];
 }
 
@@ -643,16 +644,9 @@ const int64_t OSK_EVENT_MODIFIER_MASK = 0x00000000FFFFFFFF;
      */
     _oskShiftState = NO;
     
-    if (state) {
-      os_log_debug([KMELogs oskLog], "hardware shift key pressed");
-      [self displayKeyLabelsForLayer];
-      [self displaysShiftKeysAsPressed:YES];
-    }
-    else {
-      os_log_debug([KMELogs oskLog], "hardware shift key released");
-      [self displayKeyLabelsForLayer];
-      [self displaysShiftKeysAsPressed:NO];
-    }
+    os_log_debug([KMELogs oskLog], "hardware shift key released");
+    [self displayKeyLabelsForLayer];
+    [self displayShiftKeysState];
   }
 }
 
@@ -662,12 +656,12 @@ const int64_t OSK_EVENT_MODIFIER_MASK = 0x00000000FFFFFFFF;
     if (state) {
       os_log_debug([KMELogs oskLog], "OSK shift key selected");
       [self displayKeyLabelsForLayer];
-      [self displaysShiftKeysAsPressed:YES];
+      [self displayShiftKeysState];
     }
     else if (!self.physicalShiftState) {
       os_log_debug([KMELogs oskLog], "OSK shift key de-selected");
       [self displayKeyLabelsForLayer];
-      [self displaysShiftKeysAsPressed:NO];
+      [self displayShiftKeysState];
     }
   }
 }
@@ -681,15 +675,8 @@ const int64_t OSK_EVENT_MODIFIER_MASK = 0x00000000FFFFFFFF;
      * The state of the physical key overrides the modifier key clicked in the OSK.
      */
     _oskOptionState = NO;
-
-    if (state) {
-      [self displayKeyLabelsForLayer];
-      [self displaysOptionKeysAsPressed:YES];
-    }
-    else {
-      [self displayKeyLabelsForLayer];
-      [self displaysOptionKeysAsPressed:NO];
-    }
+    [self displayKeyLabelsForLayer];
+    [self displayOptionKeysState];
   }
 }
 
@@ -698,11 +685,11 @@ const int64_t OSK_EVENT_MODIFIER_MASK = 0x00000000FFFFFFFF;
     _oskOptionState = state;
     if (state) {
       [self displayKeyLabelsForLayer];
-      [self displaysOptionKeysAsPressed:YES];
+      [self displayOptionKeysState];
     }
     else if (!self.physicalOptionState) {
       [self displayKeyLabelsForLayer];
-      [self displaysOptionKeysAsPressed:NO];
+      [self displayOptionKeysState];
     }
   }
 }
@@ -716,15 +703,8 @@ const int64_t OSK_EVENT_MODIFIER_MASK = 0x00000000FFFFFFFF;
      * The state of the physical key overrides the modifier key clicked in the OSK.
      */
     _oskControlState = NO;
-
-    if (state) {
-      [self displayKeyLabelsForLayer];
-      [self displaysControlKeysAsPressed:YES];
-    }
-    else {
-      [self displayKeyLabelsForLayer];
-      [self displaysControlKeysAsPressed:NO];
-    }
+    [self displayKeyLabelsForLayer];
+    [self displayControlKeysState];
   }
 }
 
@@ -733,30 +713,39 @@ const int64_t OSK_EVENT_MODIFIER_MASK = 0x00000000FFFFFFFF;
     _oskControlState = state;
     if (state) {
       [self displayKeyLabelsForLayer];
-      [self displaysControlKeysAsPressed:YES];
+      [self displayControlKeysState];
     }
     else if (!self.physicalControlState) {
       [self displayKeyLabelsForLayer];
-      [self displaysControlKeysAsPressed:NO];
+      [self displayControlKeysState];
     }
   }
 }
 
-- (void)displaysShiftKeysAsPressed:(BOOL)pressed {
+- (void)displayModifierKeysState {
+  [self displayShiftKeysState];
+  [self displayOptionKeysState];
+  [self displayControlKeysState];
+}
+
+- (void)displayShiftKeysState {
+  BOOL pressed = self.oskShiftState || self.physicalShiftState;
   KeyView *leftShiftKey = (KeyView *)[self viewWithTag:MVK_LEFT_SHIFT|0x1000];
   KeyView *rightShiftKey = (KeyView *)[self viewWithTag:MVK_RIGHT_SHIFT|0x1000];
   [leftShiftKey setKeyPressed:pressed];
   [rightShiftKey setKeyPressed:pressed];
 }
 
-- (void)displaysOptionKeysAsPressed:(BOOL)pressed {
+- (void)displayOptionKeysState {
+  BOOL pressed = self.oskOptionState || self.physicalOptionState;
   KeyView *leftOptionKey = (KeyView *)[self viewWithTag:MVK_LEFT_ALT|0x1000];
   KeyView *rightOptionKey = (KeyView *)[self viewWithTag:MVK_RIGHT_ALT|0x1000];
   [leftOptionKey setKeyPressed:pressed];
   [rightOptionKey setKeyPressed:pressed];
 }
 
-- (void)displaysControlKeysAsPressed:(BOOL)pressed {
+- (void)displayControlKeysState {
+  BOOL pressed = self.oskControlState || self.physicalControlState;
   KeyView *leftControlKey = (KeyView *)[self viewWithTag:MVK_LEFT_CTRL|0x1000];
   KeyView *rightControlKey = (KeyView *)[self viewWithTag:MVK_RIGHT_CTRL|0x1000];
   [leftControlKey setKeyPressed:pressed];

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/OnScreenKeyboard/OSKView.m
@@ -427,6 +427,17 @@ const int64_t OSK_EVENT_MODIFIER_MASK = 0x00000000FFFFFFFF;
   return _oskDefaultNKeys;
 }
 
+/**
+ * called when closing the OSK
+ * when the OSK is not visible then modifier state is determined solely by the physical keyboard
+ */
+- (void)clearOskModifiers {
+  _oskShiftState = NO;
+  _oskOptionState = NO;
+  _oskControlState = NO;
+  [self displayKeyLabelsForLayer];
+}
+
 - (void)resetOSK {
   [self setOskShiftState:NO];
   [self setOskOptionState:NO];


### PR DESCRIPTION
The OSK conforms to these rules:

1. The state of the physical keyboard modifier keys takes precedence over the OSK modifiers
a. If an OSK modifier such as shift is unselected, but the shift key is held down, then the OSK will display the shift layer
b. If an OSK modifier is selected, it is reset when the corresponding physical modifier is pressed or released
1. If the OSK is open with a modifier key selected, the modifier will be applied to a character key pressed with the physical keyboard
1. Selected modifiers from the OSK can be combined with physical modifier keys to display a different layer in the OSK. For example with Shift selected in the OSK, if a user holds down the Option/Alt key,  the shift-alt layer will be displayed in the OSK
1. Closing the OSK resets the state of all its modifiers so that it has no effect on what is typed with the physical keyboard

Fixes #12584 


# User Testing

* **TEST_OSK_RESETS_ON_CLOSE**: OSK modifiers are cleared when the OSK window is closed

1. Install and run the Keyman build associated with this PR
1. Switch to the Khmer Angkor keyboard and open the OSK
1. Click with the mouse on the shift key of the OSK
1. Confirm that the 'T' key on the OSK displays 'ទ'
1. Click <kbd>T</kbd> on the OSK and confirm that the ouptut is 'ទ'
1. Close the OSK
1. Open the OSK and confirm that the shift key is no longer selected and that the 'T' key on the OSK displays 'ត'


* **TEST_OSK_SHIFT_LAYER_AFFECTS_PHYSICAL_KEYBOARD**: OSK shift key affects physical typing

1. Switch to the Khmer Angkor keyboard and open the OSK
1. Open a note in the Stickies app
1. Click with the mouse on the shift key of the OSK
1. Confirm that the 'T' key on the OSK displays 'ទ'
1. Type <kbd>T</kbd> on the physical keyboard and confirm that the ouptut is 'ទ'

* **TEST_OSK_SHIFT_OPTION_LAYER_AFFECTS_PHYSICAL_KEYBOARD**: OSK shift-alt keys affect physical typing

1. Switch to the Khmer Angkor keyboard and open the OSK
1. Open a note in the Stickies app
1. Click with the mouse on the shift and alt keys of the OSK
1. Confirm that the 'T' key on the OSK displays '᧤'
1. Type <kbd>T</kbd> on the physical keyboard and confirm that the ouptut is '᧤'

* **TEST_OSK_OPTION_LAYER_AFFECTS_PHYSICAL_KEYBOARD**: OSK alt key affects physical typing

1. Switch to the Khmer Angkor keyboard and open the OSK
1. Open a note in the Stickies app
1. Click with the mouse on the alt key of the OSK
1. Confirm that the 'T' key on the OSK displays 'ឨ'
1. Type <kbd>T</kbd> on the physical keyboard and confirm that the ouptut is 'ឨ'
