### PR TITLE
chore: changes to use https and removes anchor in docs

### DIFF
--- a/core/docs/api/options.md
+++ b/core/docs/api/options.md
@@ -17,7 +17,7 @@ value.
 
 -------------------------------------------------------------------------------
 
-# km_core_option_scope enum {#km_core_option_scope}
+# km_core_option_scope enum
 
 ## Description
 
@@ -48,7 +48,7 @@ enum km_core_option_scope {
 
 -------------------------------------------------------------------------------
 
-# km_core_option_item struct {#km_core_option_item}
+# km_core_option_item struct
 
 ## Description
 
@@ -78,7 +78,7 @@ struct km_core_option_item {
 
 -------------------------------------------------------------------------------
 
-# km_core_options_list_size() {#km_core_options_list_size}
+# km_core_options_list_size()
 
 ## Description
 Return the length of a terminated [km_core_option_item] array (options
@@ -150,7 +150,7 @@ km_core_state_option_lookup(km_core_state const *state,
 
 -------------------------------------------------------------------------------
 
-# km_core_state_options_update() {#km_core_state_options_update}
+# km_core_state_options_update()
 
 ## Description
 
@@ -188,7 +188,7 @@ km_core_state_options_update(km_core_state *state,
 
 -------------------------------------------------------------------------------
 
-# km_core_state_options_to_json() {#km_core_state_options_to_json}
+# km_core_state_options_to_json()
 
 ## Description
 

--- a/developer/docs/help/guides/distribute/tutorial/step-2.md
+++ b/developer/docs/help/guides/distribute/tutorial/step-2.md
@@ -58,7 +58,7 @@ welcome.htm
     > ### Tip
     If you want links to your website to open in the user's preferred
     browser, preface the href link with `link:`, e.g.
-    `<a href="http://keyman.com/">website</a>`  
+    `<a href="https://keyman.com/">website</a>`  
     The `link:` sceheme will open the referred file in the default
     application - that is, a web browser for URLs and links, Notepad for
     .txt files, Adobe Reader for PDFs. You can use `link:` to open any

--- a/developer/docs/help/guides/distribute/tutorial/step-4.md
+++ b/developer/docs/help/guides/distribute/tutorial/step-4.md
@@ -54,7 +54,7 @@ Website
 
 :   Enter the name of the website where you will have information about
     this keyboard. If you want to host it on keyman.com, you could enter
-    `http://www.keyman.com/`
+    `https://keyman.com/`
 
 Image file
 :   Select the splash image file that you created in Step 2 from the

--- a/developer/docs/help/guides/lexical-models/distribute/tutorial/step-5.md
+++ b/developer/docs/help/guides/lexical-models/distribute/tutorial/step-5.md
@@ -38,7 +38,7 @@ recommendations:
     ZIP archive file!) and you won't save much space by recompressing
     it.
 3.  Include a link to the Keyman download page:
-    `http://keyman.com/downloads/`
+    `https://keyman.com/downloads/`
 
 ## Distributing a package by email
 


### PR DESCRIPTION
More on: https://github.com/keymanapp/keyman.com/issues/415.

Change 1: The removal of Anchor `#` in documentation due to showing incorrectly on the web page (https://help.keyman.com/developer/core/current-version/options#toc-km-core-option-scope-enum-km-core-option-scope-).

Change 2: Can I use `https` here? I've seen some URLs both in 404 Not Found with `www.keyman.com` and in Duplicate pages with `http://...`. This may help remove the URLs from those categories in Google Search Console.

@keymanapp-test-bot skip