### PR TITLE
fix(core): work around alignment problem when using Emscripten 🎼

### DIFF
--- a/common/include/km_types.h
+++ b/common/include/km_types.h
@@ -14,12 +14,20 @@
 
 #if defined(__LP64__) || defined(_LP64)
 /* 64-bit, g++ */
-#define KMX_64BIT
+#define KMX_REQUIRES_REALIGNMENT
 #endif
 
 #if defined(_WIN64) && !defined(USE_64)
 /* 64-bit, Windows */
-#define KMX_64BIT
+#define KMX_REQUIRES_REALIGNMENT
+#endif
+
+#if defined(__EMSCRIPTEN__)
+// Emscripten/WASM. Emscripten even though it uses 32-bit (and not 64-bit
+// pointers like the 64-bit architectures above) requires 32-bit alignment
+// for pointers which we don't always have in the KMX data from file
+// (see #12844).
+#define KMX_REQUIRES_REALIGNMENT
 #endif
 
 typedef uint32_t   KMX_DWORD;

--- a/core/src/kmx/kmx_file.cpp
+++ b/core/src/kmx/kmx_file.cpp
@@ -68,11 +68,11 @@ KMX_BOOL KMX_ProcessEvent::LoadKeyboardFromBlob(
 
   *lpKeyboard = NULL;
 
-#ifdef KMX_64BIT
+#if defined(KMX_64BIT) || defined(__EMSCRIPTEN__)
   // allocate enough memory for expanded data structure + original data.
-  // Expanded data structure is double the size of data on disk (8-byte
-  // pointers) - on disk the "pointers" are relative to the beginning of
-  // the file.
+  // Expanded data structure is no more than double the size of data on
+  // disk (8-byte pointers) - on disk the "pointers" are relative to the
+  // beginning of the file.
   // We save the original data at the end of buf; we don't copy strings, so
   // those will remain in the location at the end of the buffer.
   buf = new KMX_BYTE[sz * 3];
@@ -84,7 +84,7 @@ KMX_BOOL KMX_ProcessEvent::LoadKeyboardFromBlob(
     DebugLog("Not allocmem");
     return FALSE;
   }
-#ifdef KMX_64BIT
+#if defined(KMX_64BIT) || defined(__EMSCRIPTEN__)
   filebase = buf + sz * 2;
 #else
   filebase = buf;
@@ -103,7 +103,7 @@ KMX_BOOL KMX_ProcessEvent::LoadKeyboardFromBlob(
     return FALSE;
   }
 
-#ifdef KMX_64BIT
+#if defined(KMX_64BIT) || defined(__EMSCRIPTEN__)
   kbp = CopyKeyboard(buf, filebase);
 #else
   kbp = FixupKeyboard(buf, filebase);
@@ -132,13 +132,15 @@ PKMX_WCHAR KMX_ProcessEvent::StringOffset(PKMX_BYTE base, KMX_DWORD offset)
   return (PKMX_WCHAR)(base + offset);
 }
 
-#ifdef KMX_64BIT
+#if defined(KMX_64BIT) || defined(__EMSCRIPTEN__)
 /**
   CopyKeyboard will copy the data read into bufp from x86-sized structures into
   x64-sized structures starting at `base`
   * After this function finishes, we still need to keep the original data because
     we don't copy the strings
-  This method is used on 64-bit architectures.
+  This method is used on 64-bit architectures as well as with Emscripten.
+  Emscripten requires 32-bit alignment for pointers which we don't always
+  have in the KMX data (see #12844).
 */
 LPKEYBOARD KMX_ProcessEvent::CopyKeyboard(PKMX_BYTE bufp, PKMX_BYTE base)
 {

--- a/core/src/kmx/kmx_file.cpp
+++ b/core/src/kmx/kmx_file.cpp
@@ -68,11 +68,11 @@ KMX_BOOL KMX_ProcessEvent::LoadKeyboardFromBlob(
 
   *lpKeyboard = NULL;
 
-#if defined(KMX_64BIT) || defined(__EMSCRIPTEN__)
+#ifdef KMX_REQUIRES_REALIGNMENT
   // allocate enough memory for expanded data structure + original data.
   // Expanded data structure is no more than double the size of data on
-  // disk (8-byte pointers) - on disk the "pointers" are relative to the
-  // beginning of the file.
+  // disk (8-byte pointers for 64-bit architectures) - on disk the
+  // "pointers" are relative to the beginning of the file.
   // We save the original data at the end of buf; we don't copy strings, so
   // those will remain in the location at the end of the buffer.
   buf = new KMX_BYTE[sz * 3];
@@ -84,7 +84,7 @@ KMX_BOOL KMX_ProcessEvent::LoadKeyboardFromBlob(
     DebugLog("Not allocmem");
     return FALSE;
   }
-#if defined(KMX_64BIT) || defined(__EMSCRIPTEN__)
+#ifdef KMX_REQUIRES_REALIGNMENT
   filebase = buf + sz * 2;
 #else
   filebase = buf;
@@ -103,7 +103,7 @@ KMX_BOOL KMX_ProcessEvent::LoadKeyboardFromBlob(
     return FALSE;
   }
 
-#if defined(KMX_64BIT) || defined(__EMSCRIPTEN__)
+#ifdef KMX_REQUIRES_REALIGNMENT
   kbp = CopyKeyboard(buf, filebase);
 #else
   kbp = FixupKeyboard(buf, filebase);
@@ -132,7 +132,7 @@ PKMX_WCHAR KMX_ProcessEvent::StringOffset(PKMX_BYTE base, KMX_DWORD offset)
   return (PKMX_WCHAR)(base + offset);
 }
 
-#if defined(KMX_64BIT) || defined(__EMSCRIPTEN__)
+#ifdef KMX_REQUIRES_REALIGNMENT
 /**
   CopyKeyboard will copy the data read into bufp from x86-sized structures into
   x64-sized structures starting at `base`

--- a/core/src/kmx/kmx_processevent.h
+++ b/core/src/kmx/kmx_processevent.h
@@ -57,7 +57,7 @@ private:
   KMX_BOOL LoadKeyboardFromBlob(PKMX_BYTE buf, size_t sz, LPKEYBOARD* lpKeyboard);
   KMX_BOOL VerifyKeyboard(PKMX_BYTE filebase, size_t sz);
   KMX_BOOL VerifyChecksum(PKMX_BYTE buf,  size_t sz);
-#if defined(KMX_64BIT) || defined(__EMSCRIPTEN__)
+#ifdef KMX_REQUIRES_REALIGNMENT
   LPKEYBOARD CopyKeyboard(PKMX_BYTE bufp, PKMX_BYTE base);
 #else
   LPKEYBOARD FixupKeyboard(PKMX_BYTE bufp, PKMX_BYTE base);

--- a/core/src/kmx/kmx_processevent.h
+++ b/core/src/kmx/kmx_processevent.h
@@ -57,7 +57,7 @@ private:
   KMX_BOOL LoadKeyboardFromBlob(PKMX_BYTE buf, size_t sz, LPKEYBOARD* lpKeyboard);
   KMX_BOOL VerifyKeyboard(PKMX_BYTE filebase, size_t sz);
   KMX_BOOL VerifyChecksum(PKMX_BYTE buf,  size_t sz);
-#ifdef KMX_64BIT
+#if defined(KMX_64BIT) || defined(__EMSCRIPTEN__)
   LPKEYBOARD CopyKeyboard(PKMX_BYTE bufp, PKMX_BYTE base);
 #else
   LPKEYBOARD FixupKeyboard(PKMX_BYTE bufp, PKMX_BYTE base);


### PR DESCRIPTION
The data we read from the KMX file is not in all places 32-bit aligned, e.g. `dpGroupArray` will often start at a 16-bit boundary. Emscripten doesn't like this and will abort the program if `SAFE_HEAP=1` is defined.

This change works around the problem by calling `CopyKeyboard` and thus expanding the structure.

See #12844.

@keymanapp-test-bot skip