### PR TITLE
chore(web): disable auto-correct

### DIFF
--- a/web/src/engine/interfaces/src/prediction/languageProcessor.interface.ts
+++ b/web/src/engine/interfaces/src/prediction/languageProcessor.interface.ts
@@ -71,4 +71,6 @@ export interface LanguageProcessorSpec extends EventEmitter<LanguageProcessorEve
   applyReversion(reversion: LexicalModelTypes.Reversion, outputTarget: OutputTarget): Promise<LexicalModelTypes.Suggestion[]>;
 
   get wordbreaksAfterSuggestions(): boolean;
+
+  get mayAutoCorrect(): boolean;
 }

--- a/web/src/engine/interfaces/src/prediction/predictionContext.ts
+++ b/web/src/engine/interfaces/src/prediction/predictionContext.ts
@@ -324,7 +324,7 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
         this.keepSuggestion = s as Keep;
       }
 
-      if(s.autoAccept && !this.selected) {
+      if (this.langProcessor.mayAutoCorrect && s.autoAccept && !this.selected) {
         this.selected = s;
       }
     }


### PR DESCRIPTION
I had to add the KeymanWeb API for auto-correct first in order to be able to disable it (#12857) :smile: 

Fixes: #12767

# User Testing

**TEST_DISABLED**: with SIL EuroLatin installed for English, type 5 followed by space and verify that the result is `5` instead of `5th`.