### PR TITLE
fix(web): don't crash if second transform is null

### DIFF
--- a/web/src/engine/predictive-text/templates/src/common.ts
+++ b/web/src/engine/predictive-text/templates/src/common.ts
@@ -43,6 +43,10 @@ export function applyTransform(transform: Transform, context: Context): Context 
 export function buildMergedTransform(first: Transform, second: Transform): Transform {
   // These exist to avoid parameter mutation.
   let mergedFirstInsert: string = first.insert;
+  if (!second) {
+    // can happen if we don't have a distribution or an empty transform
+    return first;
+  }
   let mergedSecondDelete: number = second.deleteLeft;
 
   // The 'fun' case:  the second Transform wants to delete something from the first.

--- a/web/src/engine/predictive-text/templates/tests/common.tests.js
+++ b/web/src/engine/predictive-text/templates/tests/common.tests.js
@@ -185,6 +185,16 @@ describe('Common utility functions', function() {
       let mergedTransform = models.buildMergedTransform(apple, banana);
       assert.deepEqual(mergedTransform, final);
     });
+
+    it('empty second transform', () => { // #12494
+      let apple = {
+        insert: 'apple',
+        deleteLeft: 0
+      };
+
+      let mergedTransform = models.buildMergedTransform(apple, null);
+      assert.deepEqual(mergedTransform, apple);
+    });
   });
 
   describe('transformToSuggestion', function() {


### PR DESCRIPTION
Fixes: #12494

# User Testing

**TEST_NOCRASH**: follow the steps outlined in #12494 and verify that the crash no longer happens