### PR TITLE
fix(android/engine): Cleanup KMManager API keys and calls

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1709,26 +1709,6 @@ public final class KMManager {
     return KeyboardPickerActivity.addKeyboard(context, keyboardInfo);
   }
 
-  // Intend to deprecate in Keyman 15.0
-  public static boolean addKeyboard(Context context, HashMap<String, String> keyboardInfo) {
-    String packageID = keyboardInfo.get(KMManager.KMKey_PackageID);
-    String keyboardID =  keyboardInfo.get(KMManager.KMKey_KeyboardID);
-    String keyboardName = keyboardInfo.get(KMManager.KMKey_KeyboardName);
-    String languageID = keyboardInfo.get(KMManager.KMKey_LanguageID);
-    String languageName = keyboardInfo.get(KMManager.KMKey_LanguageName);
-    String version = keyboardInfo.get(KMManager.KMKey_KeyboardVersion);
-    String helpLink = keyboardInfo.get(KMManager.KMKey_CustomHelpLink);
-    String kmpLink = MapCompat.getOrDefault(keyboardInfo, KMManager.KMKey_KMPLink, "");
-    String font = keyboardInfo.get(KMManager.KMKey_Font);
-    String oskFont = keyboardInfo.get(KMManager.KMKey_OskFont);
-    boolean isNewKeyboard = true;
-
-    Keyboard k = new Keyboard(packageID, keyboardID, keyboardName,
-          languageID, languageName, version, helpLink, kmpLink,
-      isNewKeyboard, font, oskFont);
-    return addKeyboard(context, k);
-  }
-
   public static boolean removeKeyboard(Context context, int position) {
     return KeyboardPickerActivity.removeKeyboard(context, position);
   }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -249,7 +249,7 @@ public final class KMManager {
 
   public final static String predictionPrefSuffix = ".mayPredict";
   public final static String correctionPrefSuffix = ".mayCorrect";
-  public final static String autoCorrectionPrefSuffix = ".mayAutoCorect";
+  public final static String autoCorrectionPrefSuffix = ".mayAutoCorrect";
 
   // Special override for when the keyboard may have haptic feedback when typing.
   // haptic feedback disabled for hardware keystrokes
@@ -304,11 +304,6 @@ public final class KMManager {
   public static final String KMKey_LexicalModelName = "lmName";
   public static final String KMKey_LexicalModelVersion = "lmVersion";
   public static final String KMKey_LexicalModelPackageFilename = "kmpPackageFilename";
-
-  // DEPRECATED keys
-  public static final String KMKey_CustomKeyboard = "CustomKeyboard";
-  public static final String KMKey_CustomModel = "CustomModel";
-  public static final String KMKey_HelpLink = "helpLink";
 
   // Keyman internal keys
   protected static final String KMKey_ShouldShowHelpBubble = "ShouldShowHelpBubble";

--- a/android/KMEA/app/src/test/java/com/keyman/engine/KMManagerTest.java
+++ b/android/KMEA/app/src/test/java/com/keyman/engine/KMManagerTest.java
@@ -126,7 +126,6 @@ public class KMManagerTest {
     HashMap<String, String> kmInfo = new HashMap<String, String>();
     kmInfo.put(KMManager.KMKey_PackageID, "khmer_angkor");
     kmInfo.put(KMManager.KMKey_KeyboardID, "khmer_angkor");
-    kmInfo.put(KMManager.KMKey_CustomKeyboard, "Y");
     kmInfo.put(KMManager.KMKey_LanguageID, "km");
     kmInfo.put(KMManager.KMKey_KeyboardName, "Khmer Angkor");
     kmInfo.put(KMManager.KMKey_LanguageName, "Central Khmer");

--- a/android/KMEA/app/src/test/java/com/keyman/engine/view/FunctionalTestHelper.java
+++ b/android/KMEA/app/src/test/java/com/keyman/engine/view/FunctionalTestHelper.java
@@ -66,7 +66,21 @@ public class FunctionalTestHelper {
 
     Assert.assertEquals(installedKbds.size(),1);
 
-    KMManager.addKeyboard(ApplicationProvider.getApplicationContext(),(HashMap<String, String>) installedKbds.get(0));
+    HashMap<String, String> map = (HashMap<String, String>)installedKbds.get(0);
+    Keyboard keyboard = new Keyboard(
+      map.get(KMManager.KMKey_PackageID),
+      map.get(KMManager.KMKey_KeyboardID),
+      map.get(KMManager.KMKey_KeyboardName),
+      map.get(KMManager.KMKey_LanguageID),
+      map.get(KMManager.KMKey_LanguageName),
+      map.get(KMManager.KMKey_KeyboardVersion),
+      map.get(KMManager.KMKey_CustomHelpLink),
+      map.get(KMManager.KMKey_KMPLink),
+      true,
+      null,
+      null
+    );
+    KMManager.addKeyboard(ApplicationProvider.getApplicationContext(), keyboard);
   }
 
 


### PR DESCRIPTION
I took a quick look at some KMManager keys for https://github.com/keymanapp/keyman/issues/12767#issuecomment-2573431096
and noticed KMManager had some minor cleanup TODO

* Remove deprecated keys no longer used from #4462 during Keyman 14.0
* Fix typo in `autoCorrectionPrefSuffix`
* Remove addKeyboard API call that should have been deprecated in Keyman 15

## User Testing
**Setup** - Install the PR build of Keyman for Android

* **TEST_ADD_KEYBOARD** - Verifies Keyman app can add keyboard
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. In the Keyman app, verify the default sil_euro_latin keyboard appears
3. In Keyman settings --> "Install Keyboard or Dictionary" --> Install from keyman.com
4. Search for a keyboard and install it
5. In the Keyman app, verify the installed keyboard appears
