### PR TITLE
refactor(web): modernize `web/ci.sh` script

### DIFF
--- a/web/ci.sh
+++ b/web/ci.sh
@@ -190,7 +190,8 @@ function prepare_downloads_keyman_com_action() {
 
   pushd build/publish
   # Zip both the 'debug' and 'release' configurations together.
-  "${COMPRESS_CMD}" ${COMPRESS_ADD} ${ZIP }*
+  # shellcheck disable=SC2086
+  "${COMPRESS_CMD}" ${COMPRESS_ADD} "${ZIP}" ./*
   popd
 
   # --- Second action artifact - the 'static' folder (hosted user testing on downloads.keyman.com) ---

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -12,11 +12,11 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../resources/build/build-utils.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
-. "$KEYMAN_ROOT/resources/build/ci/pull-requests.inc.sh"
+. "${KEYMAN_ROOT}/resources/shellHelperFunctions.sh"
+. "${KEYMAN_ROOT}/resources/build/ci/pull-requests.inc.sh"
 
 # This script runs from its own folder
-cd "$THIS_SCRIPT_PATH"
+cd "${THIS_SCRIPT_PATH}"
 
 # ################################ Main script ################################
 
@@ -37,20 +37,25 @@ builder_parse "$@"
 
 ####
 
-TIER=`cat ../TIER.md`
-BUILD_NUMBER=`cat ../VERSION.md`
+TIER=$(cat ../TIER.md)
+BUILD_NUMBER=$(cat ../VERSION.md)
 
 function web_sentry_upload () {
+  if [[ -z "${SENTRY_ORG:-}" ]] || [[ -z "${SENTRY_PROJECT:-}" ]]; then
+    echo "Skipping Sentry upload: SENTRY_ORG and/or SENTRY_PROJECT are unset."
+    return
+  fi
+
   echo "Uploading $1 to Sentry..."
 
   # --strip-common-prefix does not take an argument, unlike --strip-prefix.  It auto-detects
   # the most common prefix instead.
-  sentry-cli releases files "$VERSION_GIT_TAG" upload-sourcemaps --strip-common-prefix "$1" \
+  sentry-cli releases files "${VERSION_GIT_TAG}" upload-sourcemaps --strip-common-prefix "$1" \
     --rewrite --ext js --ext map --ext ts
   echo "Upload successful."
 }
 
-if builder_start_action build; then
+function build_action() {
   # Build step:  since CI builds start (and should start) from scratch, run the following
   # three actions:
   # - configure:  retrieve all NPM dependencies
@@ -63,19 +68,17 @@ if builder_start_action build; then
 
   # Upload the sentry-configuration engine used by the mobile apps to sentry
   # Also, clean 'em first.
-  for sourcemap in "$KEYMAN_ROOT/web/src/engine/sentry-manager/build/lib/"*.map; do
-    node "$KEYMAN_ROOT/web/build/tools/building/sourcemap-root/index.js" null "$sourcemap" --clean
+  for sourcemap in "${KEYMAN_ROOT}/web/src/engine/sentry-manager/build/lib/"*.map; do
+    node "${KEYMAN_ROOT}/web/build/tools/building/sourcemap-root/index.js" null "${sourcemap}" --clean
   done
-  web_sentry_upload "$KEYMAN_ROOT/web/src/engine/sentry-manager/build/lib/"
+  web_sentry_upload "${KEYMAN_ROOT}/web/src/engine/sentry-manager/build/lib/"
 
   # And, of course, the main build-products too
-  web_sentry_upload "$KEYMAN_ROOT/web/build/app/webview/release/"
-  web_sentry_upload "$KEYMAN_ROOT/web/build/publish/release/"
+  web_sentry_upload "${KEYMAN_ROOT}/web/build/app/webview/release/"
+  web_sentry_upload "${KEYMAN_ROOT}/web/build/publish/release/"
+}
 
-  builder_finish_action success build
-fi
-
-if builder_start_action test; then
+function test_action() {
   # Testing step:  run ALL unit tests, including those of the submodules.
 
   OPTIONS=
@@ -85,24 +88,20 @@ if builder_start_action test; then
 
   # No --reporter option exists yet for the headless modules.
 
-  "$KEYMAN_ROOT/web/src/engine/keyboard/build.sh" test $OPTIONS
-  "$KEYMAN_ROOT/web/src/engine/osk/gesture-processor/build.sh" test $OPTIONS
+  "${KEYMAN_ROOT}/web/src/engine/keyboard/build.sh" test ${OPTIONS}
+  "${KEYMAN_ROOT}/web/src/engine/osk/gesture-processor/build.sh" test ${OPTIONS}
 
-  ./build.sh test $OPTIONS
+  ./build.sh test ${OPTIONS}
+}
 
-  builder_finish_action success test
-fi
-
-if builder_start_action post-test; then
+function post_test_action() {
   # Always make sure BrowserStack stuff is terminated after the test step.
   # Even if it fails and/or hangs.
   # No matter what.  Otherwise, it may leave a lock-file that breaks a later build!
   ../common/test/resources/test_kill_browserstack.sh
+}
 
-  builder_finish_action success post-test
-fi
-
-if builder_start_action validate-size; then
+function validate_size_action() {
   # Performs the web build product size check as reported on Web test PRs.
   FLAGS=
 
@@ -113,18 +112,16 @@ if builder_start_action validate-size; then
   # Do not use --report when in --debug mode; it sets an error code that is VERY difficult to
   # catch with our set -e & `trap` setup.
   ./src/tools/building/check-build-size.sh $FLAGS
+}
 
-  builder_finish_action success validate-size
-fi
-
-if builder_start_action prepare:s.keyman.com; then
+function prepare_s_keyman_com_action() {
   if ! builder_has_option --s.keyman.com; then
     builder_die "--s.keyman.com is unset!"
   fi
 
   if builder_is_debug_build; then
     # First phase: make sure the s.keyman.com repo is locally-available and up to date.
-    pushd "$S_KEYMAN_COM"
+    pushd "${S_KEYMAN_COM}"
 
     # For testing on a local development machine / a machine with the repo already loaded.
     git checkout master
@@ -135,42 +132,40 @@ if builder_start_action prepare:s.keyman.com; then
   # Second phase:  copy the artifacts over
 
   # The main build products are expected to reside at the root of this folder.
-  BASE_PUBLISH_FOLDER="$S_KEYMAN_COM/kmw/engine/$VERSION"
-  echo "FOLDER: $BASE_PUBLISH_FOLDER"
-  mkdir -p "$BASE_PUBLISH_FOLDER"
+  BASE_PUBLISH_FOLDER="${S_KEYMAN_COM}/kmw/engine/${VERSION}"
+  echo "FOLDER: ${BASE_PUBLISH_FOLDER}"
+  mkdir -p "${BASE_PUBLISH_FOLDER}"
 
   # s.keyman.com - release-config only.  It's notably smaller, thus far more favorable
   # for distribution via cloud service.
-  cp -Rf build/publish/release/* "$BASE_PUBLISH_FOLDER"
+  cp -Rf build/publish/release/* "${BASE_PUBLISH_FOLDER}"
 
   # Third phase: tweak the sourcemaps
   # We can use an alt-mode of Web's sourcemap-root tool for this.
-  for sourcemap in "$BASE_PUBLISH_FOLDER/"*.map; do
-    node "$KEYMAN_ROOT/web/build/tools/building/sourcemap-root/index.js" null "$sourcemap" --sourceRoot "https://s.keyman.com/kmw/engine/$VERSION/src"
+  for sourcemap in "${BASE_PUBLISH_FOLDER}/"*.map; do
+    node "${KEYMAN_ROOT}/web/build/tools/building/sourcemap-root/index.js" null "${sourcemap}" --sourceRoot "https://s.keyman.com/kmw/engine/${VERSION}/src"
   done
 
   # Construct the PR
-  echo "Committing and pushing KeymanWeb release $VERSION to s.keyman.com"
+  echo "Committing and pushing KeymanWeb release ${VERSION} to s.keyman.com"
 
-  ci_add_files "$S_KEYMAN_COM" "kmw/engine/$VERSION"
-  if ! ci_repo_has_cached_changes "$S_KEYMAN_COM"; then
+  ci_add_files "${S_KEYMAN_COM}" "kmw/engine/${VERSION}"
+  if ! ci_repo_has_cached_changes "${S_KEYMAN_COM}"; then
     builder_die "No release was added to s.keyman.com, something went wrong"
   fi
 
-  ci_open_pull_request "$S_KEYMAN_COM" auto/keymanweb/release "auto: KeymanWeb release $VERSION"
-
-  builder_finish_action success prepare:s.keyman.com
-fi
+  ci_open_pull_request "${S_KEYMAN_COM}" auto/keymanweb/release "auto: KeymanWeb release ${VERSION}"
+}
 
 # Note:  for now, this command is used to prepare the artifacts used by the download site, but
 #        NOT to actually UPLOAD them via rsync or to produce related .download_info files.
-if builder_start_action prepare:downloads.keyman.com; then
-  UPLOAD_PATH="$KEYMAN_ROOT/web/build/upload/$VERSION"
+function prepare_downloads_keyman_com_action() {
+  UPLOAD_PATH="${KEYMAN_ROOT}/web/build/upload/${VERSION}"
 
   # --- First action artifact - the KMW zip file ---
-  ZIP="$UPLOAD_PATH/keymanweb-$VERSION.zip"
+  ZIP="${UPLOAD_PATH}/keymanweb-${VERSION}.zip"
 
-  mkdir -p "$UPLOAD_PATH"
+  mkdir -p "${UPLOAD_PATH}"
 
   # On Windows, we use 7-zip (SEVEN_Z_HOME env var).  On other platforms, we use zip.
 
@@ -178,8 +173,8 @@ if builder_start_action prepare:downloads.keyman.com; then
   COMPRESS_ADD=
 
   # Marc's preference; use $SEVEN_Z_HOME and have the BAs set up with THAT as an env var.
-  if [ ! -z "${SEVEN_Z_HOME+x}" ]; then
-    COMPRESS_CMD="$SEVEN_Z_HOME/7z"
+  if [[ ! -z "${SEVEN_Z_HOME+x}" ]]; then
+    COMPRESS_CMD="${SEVEN_Z_HOME}/7z"
     COMPRESS_ADD="a -bd -bb0 -r" # add, hide progress, log level 0, recursive
   fi
 
@@ -195,28 +190,33 @@ if builder_start_action prepare:downloads.keyman.com; then
 
   pushd build/publish
   # Zip both the 'debug' and 'release' configurations together.
-  "${COMPRESS_CMD}" $COMPRESS_ADD $ZIP *
+  "${COMPRESS_CMD}" ${COMPRESS_ADD} ${ZIP }*
   popd
 
   # --- Second action artifact - the 'static' folder (hosted user testing on downloads.keyman.com) ---
 
   echo ""
   echo "Building \`static/\` folder for long-term hosting of testing resources..."
-  STATIC="$UPLOAD_PATH/static"
-  mkdir -p "$STATIC"
+  STATIC="${UPLOAD_PATH}/static"
+  mkdir -p "${STATIC}"
 
-  mkdir -p "$STATIC/build"
-  cp -rf build/app    "$STATIC/build/app"
-  cp -rf build/engine "$STATIC/build/engine"
-  cp -rf build/tools  "$STATIC/build/tools"
+  mkdir -p "${STATIC}/build"
+  cp -rf build/app    "${STATIC}/build/app"
+  cp -rf build/engine "${STATIC}/build/engine"
+  cp -rf build/tools  "${STATIC}/build/tools"
   # avoid build/upload, since that's the folder we're building!
 
-  cp -f index.html "$STATIC/index.html"
+  cp -f index.html "${STATIC}/index.html"
 
-  mkdir -p "$STATIC/src/tools"
-  cp -rf src/tools/testing "$STATIC/src/tools/testing"
-  cp -rf src/test          "$STATIC/src/test"
-  cp -rf src/samples       "$STATIC/src/samples"
+  mkdir -p "${STATIC}/src/tools"
+  cp -rf src/tools/testing "${STATIC}/src/tools/testing"
+  cp -rf src/test          "${STATIC}/src/test"
+  cp -rf src/samples       "${STATIC}/src/samples"
+}
 
-  builder_finish_action success prepare:downloads.keyman.com
-fi
+builder_run_action  build                         build_action
+builder_run_action  test                          test_action
+builder_run_action  post-test                     post_test_action
+builder_run_action  validate-size                 validate_size_action
+builder_run_action  prepare:s.keyman.com          prepare_s_keyman_com_action
+builder_run_action  prepare:downloads.keyman.com  prepare_downloads_keyman_com_action


### PR DESCRIPTION
Also add check for necessary environment variables before trying to upload to Sentry. This allows to run the script on a dev machine.

@keymanapp-test-bot skip