### PR TITLE
fix(web): Improve predictive-text handling of text wordbreaking transitions

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -431,15 +431,14 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
       }
       const transformDistIndex = i - (lastMatch + 1);
       const tokenDistribution = transformSequenceDistribution.map((entry) => {
-        const transform = entry.sample[transformDistIndex];
-        if(transform) {
-          return {
-            sample: entry.sample[transformDistIndex],
-            p: entry.p
-          };
-        } else {
+        const sample = entry.sample[transformDistIndex];
+        if(!sample) {
           return null;
         }
+        return {
+          sample,
+          p: entry.p
+        };
       });
 
       const incomingToken = tokenizedContext[i - poppedTokenCount];

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -309,9 +309,15 @@ interface ContextMatchResult {
   /**
    * Indicates the portion of the incoming keystroke data, if any, that applies to
    * tokens before the last pre-caret token and thus should not be replaced by predictions
-   * based upon `state`.
+   * based upon `state`.  If the provided context state + the incoming transform do not 
+   * adequately match the current context, the match attempt will fail with a `null` result.
    *
-   * Should always be non-null if the token before the caret did not previously exist.
+   * Should generally be non-null if the token before the caret did not previously exist.
+   * 
+   * The result may be null if it does not match the prior context state or if bookkeeping 
+   * based upon it is problematic - say, if wordbreaking effects shift due to new input, 
+   * causing a mismatch with the prior state's tokenization.  
+   * (Refer to #12494 for an example case.)
    */
   preservationTransform?: Transform;
 }
@@ -425,17 +431,36 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
       }
       const transformDistIndex = i - (lastMatch + 1);
       const tokenDistribution = transformSequenceDistribution.map((entry) => {
-        return {
-          sample: entry.sample[transformDistIndex],
-          p: entry.p
-        };
+        const transform = entry.sample[transformDistIndex];
+        if(transform) {
+          return {
+            sample: entry.sample[transformDistIndex],
+            p: entry.p
+          };
+        } else {
+          return null;
+        }
       });
+
+      const incomingToken = tokenizedContext[i - poppedTokenCount];
 
       // If the tokenized part of the input is a completely empty transform,
       // replace it with null.  This can happen with our default wordbreaker
       // immediately after a whitespace.  We don't want to include this
       // transform as part of the input when doing correction-search.
       let primaryInput = hasDistribution ? tokenDistribution[0]?.sample : null;
+
+      // If the incoming token has text but we have no transform to match it with,
+      // abort the matching attempt.  We can't match this case well yet.
+      // These cases are generally infrequent enough to be low-ROI, not worth the
+      // investment to optimize further.  (Doing so isn't the simplest.)
+      //
+      // This may happen if tokenization for pre-existing text changes due to incoming
+      // input - refer to #12494 for an example case.
+      if(!primaryInput && incomingToken.text != '') {
+        return null;
+      }
+
       if(primaryInput && primaryInput.insert == "" && primaryInput.deleteLeft == 0 && !primaryInput.deleteRight) {
         primaryInput = null;
       }
@@ -451,7 +476,6 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
       }
       const isBackspace = primaryInput && TransformUtils.isBackspace(primaryInput);
 
-      const incomingToken = tokenizedContext[i - poppedTokenCount]
       switch(editPath[i]) {
         case 'substitute':
           if(isLastToken) {

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/edit-distance/context-tracker.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/edit-distance/context-tracker.js
@@ -152,6 +152,29 @@ describe('ContextTracker', function() {
       assert.isNotEmpty(state.tokens[state.tokens.length - 2].transformDistributions);
       assert.isEmpty(state.tokens[state.tokens.length - 1].transformDistributions);
     });
+
+    it('rejects hard-to-handle case: tail token is split into three rather than two', function() {
+      let baseContext = models.tokenize(defaultBreaker, {
+        left: "text'"
+      });
+      assert.equal(baseContext.left.length, 1);
+      let baseContextMatch = ContextTracker.modelContextState(baseContext.left);
+
+      // Now the actual check.
+      let newContext = models.tokenize(defaultBreaker, {
+        left: "text'\""
+      });
+      // The reason it's a problem - current internal logic isn't prepared to shift 
+      // from 1 to 3 tokens in a single step.
+      assert.equal(newContext.left.length, 3);
+
+      let transform = {
+        insert: '\"',
+        deleteLeft: 0
+      }
+      let problemContextMatch = ContextTracker.attemptMatchContext(newContext.left, baseContextMatch, toWrapperDistribution(transform));
+      assert.isNull(problemContextMatch);
+    });
   });
 
   describe('modelContextState', function() {


### PR DESCRIPTION
Fixes: #12494.
Replaces #12860.

The underlying issue was occurring due to a previously unforeseen consequence of default wordbreaker use, combined with some of our custom handling.

Good case:  suppose the text just typed reads `isn'`.  A natural suggestion for English is the word `isn't`.  While end-of-token `'` is cause for wordbreaking, since the text insertion point is adjacent to the `'`, we disable wordbreaking for that `'` to facilitate the `isn't` suggestion.

Bad case:  suppose we just typed `text'` and then add _another_ character that should trigger wordbreaking - like a `"` - gets typed.  At _this_ point, due to our handling for the "good case", we transition from a tokenized context of [`text'`] to [`text`, `'`, `"`].  The "old context" no longer matches - [`text'`] vs [`text`, `'`] - but the method responsible for detecting this previously did not do so, which is what led to the original error.

Additionally, I added a unit test for this case to the testing suite.  It checks the circumstance that _leads_ to the error, rather than the original error itself, so user testing is still wise here.

# User Testing

**TEST_NOCRASH**: follow the steps outlined in #12494 and verify that the crash no longer happens.