### PR TITLE
fix(web): numpad + and - with zoom shortcut use

### DIFF
--- a/web/src/engine/keyboard/src/defaultRules.ts
+++ b/web/src/engine/keyboard/src/defaultRules.ts
@@ -131,6 +131,13 @@ export default class DefaultRules {
 
   // Should not be used for mnenomic keyboards.  forAny()'s use of this method checks first.
   public forNumpadKeys(Lkc: KeyEvent) {
+    // Do not provide output if modifiers other than Shift are held.
+    // There may be associated shortcuts we might otherwise block.
+    // See #12483 - zooming shortcuts can trigger from CTRL & + or - on the numpad
+    if(Lkc.Lmodifiers != ModifierKeyConstants.K_SHIFTFLAG && Lkc.Lmodifiers != 0) {
+      return null;
+    }
+
     // Translate numpad keystrokes into their non-numpad equivalents
     if(Lkc.Lcode >= Codes.keyCodes["K_NP0"]  &&  Lkc.Lcode <= Codes.keyCodes["K_NPSLASH"]) {
       // Number pad, numlock on


### PR DESCRIPTION
Addresses part of #12483.

Default-output rules should not take effect for keystrokes that could reasonably trigger shortcuts and/or key commands, but there was no logic enforcing this natural expectation where numpad keys were involved.  

## User Testing

TEST_NUMPAD_ZOOM:  Confirm that numpad-based zooming works as expected.
1. With Keyman Engine for Web active, with an active keyboard, use CTRL with numpad `+`.
2. If the page does not zoom, FAIL this test.
3. If a character appears in the output as a result of step 1, FAIL this test.
4. Repeat steps 1-3 for CTRL with numpad `-`.
