### PR TITLE
chore(web): integrates predictive-text builds to top level script, reconnects headless tests

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -193,7 +193,7 @@ builder_run_child_actions build:test-pages
 builder_run_action build:_all build_action
 
 # Run tests
-# builder_run_child_actions test
+builder_run_child_actions test
 builder_run_action test:_all test_action
 
 function do_test_help() {

--- a/web/build.sh
+++ b/web/build.sh
@@ -166,7 +166,10 @@ builder_run_child_actions build:engine/attachment
 # Uses engine/interfaces (due to resource-path config interface)
 builder_run_child_actions build:engine/keyboard-storage
 
-# Uses engine/interfaces, engine/keyboard-storage, & engine/osk
+# Builds the predictive-text components
+builder_run_child_actions build:engine/predictive-text
+
+# Uses engine/interfaces, engine/keyboard-storage, engine/predictive-text, & engine/osk
 builder_run_child_actions build:engine/main
 
 # Uses all but engine/element-wrappers and engine/attachment

--- a/web/src/engine/predictive-text/build.sh
+++ b/web/src/engine/predictive-text/build.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Compile keymanweb predictive-text components.
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../../resources/build/builder.inc.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+
+# ################################ Main script ################################
+
+builder_describe "Builds predictive-text components used within Keyman Engine for Web (KMW)." \
+  "clean" \
+  "configure" \
+  "build" \
+  "test" \
+  ":templates                Builds the model templates utlilized by compiled lexical models" \
+  ":wordbreakers             Builds the wordbreakers provided for lexical model use" \
+  ":worker-main              Builds the predictive-text worker interface module" \
+  ":worker-thread            Builds the predictive-text worker" \
+  ":_all                     (Meta build target used when targets are not specified)" \
+  "--ci+                     Set to utilize CI-based test configurations & reporting."
+
+# Possible TODO?
+# "upload-symbols   Uploads build product to Sentry for error report symbolification.  Only defined for $DOC_BUILD_EMBED_WEB" \
+
+builder_parse "$@"
+
+config=release
+if builder_is_debug_build; then
+  config=debug
+fi
+
+builder_describe_outputs \
+  configure                     "/node_modules" \
+  build:templates               "/web/src/engine/predictive-text/build/obj/index.js" \
+  build:wordbreakers            "/web/src/engine/wordbreakers/build/main/obj/index.js" \
+  build:worker-main             "/web/src/engine/worker-main/build/obj/lmlayer.js" \
+  build:worker-thread           "/web/src/engine/worker-thread/build/obj/worker-main.wrapped.js"
+
+BUNDLE_CMD="node ${KEYMAN_ROOT}/web/src/tools/es-bundling/build/common-bundle.mjs"
+
+#### Build action definitions ####
+
+# We can run all clean & configure actions at once without much issue.
+
+builder_run_child_actions clean
+
+## Clean actions
+
+builder_run_child_actions configure
+
+## Build actions
+
+builder_run_child_actions build:wordbreakers
+
+builder_run_child_actions build:templates
+builder_run_child_actions build:worker-thread
+builder_run_child_actions build:worker-main
+
+builder_run_child_actions test

--- a/web/src/engine/predictive-text/build.sh
+++ b/web/src/engine/predictive-text/build.sh
@@ -61,4 +61,8 @@ builder_run_child_actions build:templates
 builder_run_child_actions build:worker-thread
 builder_run_child_actions build:worker-main
 
-builder_run_child_actions test
+# If doing CI testing, the predictive-text child actions have their own build configuration.
+# For local testing, though, we can allow them to proceed.
+if ! builder_has_option --ci; then
+  builder_run_child_actions test
+fi

--- a/web/src/engine/predictive-text/build.sh
+++ b/web/src/engine/predictive-text/build.sh
@@ -17,7 +17,7 @@ builder_describe "Builds predictive-text components used within Keyman Engine fo
   "configure" \
   "build" \
   "test" \
-  ":templates                Builds the model templates utlilized by compiled lexical models" \
+  ":templates                Builds the model templates utilized by compiled lexical models" \
   ":wordbreakers             Builds the wordbreakers provided for lexical model use" \
   ":worker-main              Builds the predictive-text worker interface module" \
   ":worker-thread            Builds the predictive-text worker" \
@@ -48,9 +48,6 @@ BUNDLE_CMD="node ${KEYMAN_ROOT}/web/src/tools/es-bundling/build/common-bundle.mj
 # We can run all clean & configure actions at once without much issue.
 
 builder_run_child_actions clean
-
-## Clean actions
-
 builder_run_child_actions configure
 
 ## Build actions

--- a/web/src/engine/predictive-text/worker-main/build.sh
+++ b/web/src/engine/predictive-text/worker-main/build.sh
@@ -57,12 +57,13 @@ function do_build() {
 function do_test() {
   local TEST_OPTIONS=
   if builder_has_option --ci; then
-    TEST_OPTIONS=--ci
+    # We'll test the included libraries here for now.  At some point, we may wish
+    # to establish a ci.sh script for predictive-text to handle this instead.
+    ./unit_tests/test.sh test:libraries test:headless test:browser --ci
+  else
+    # If we're not in --ci mode, then this doesn't need to trigger the sibling projects' tests.
+    ./unit_tests/test.sh test:headless test:browser
   fi
-
-  # We'll test the included libraries here for now.  At some point, we may wish
-  # to establish a ci.sh script for predictive-text to handle this instead.
-  ./unit_tests/test.sh test:libraries test:headless test:browser $TEST_OPTIONS
 }
 
 builder_run_action configure  do_configure


### PR DESCRIPTION
The main reason I started this PR was the fact that `web/build.sh build:engine/predictive-text` had absolutely no effect.  Calling it when an older version of predictive-text existed on my filesystem would not update it; I had to drill-down into the child projects to get them rebuilt.

I also discovered that web's headless test suite was left disconnected for some reason.  This seems to have been done at some point within the 18.0 filesystem reorganization, but was never undone.  I believe things should be stable enough to reconnect them now.

For the third commit, the reorg has placed things in such a manner that it... kind of makes sense to have a `web/build.sh test` actually trigger them.  We do still have the two separate build configurations though, so this probably shouldn't happen when doing CI testing - the third commit prevents it, but only in CI mode.

@keymanapp-test-bot skip