### PR TITLE
fix(android): use main looper to dispatch key events when OSK is hidden 🏠

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -31,6 +31,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -69,6 +70,10 @@ final class KMKeyboard extends WebView {
 
   protected KeyboardType keyboardType = KeyboardType.KEYBOARD_TYPE_UNDEFINED;
   protected ArrayList<String> javascriptAfterLoad = new ArrayList<>();
+
+  // .getMainLooper() returns the looper associated with the main UI thread.
+  // https://stackoverflow.com/questions/13974661/runonuithread-vs-looper-getmainlooper-post-in-android
+  private Handler jsQueuer = new Handler(Looper.getMainLooper());
 
   private static String currentKeyboard = null;
 
@@ -368,7 +373,7 @@ final class KMKeyboard extends WebView {
     if(this.javascriptAfterLoad.size() > 0) {
       // Don't call this WebView method on just ANY thread - run it on the main UI thread.
       // https://stackoverflow.com/a/22611010
-      this.postDelayed(new Runnable() {
+      jsQueuer.postDelayed(new Runnable() {
         @Override
         public void run() {
           StringBuilder allCalls = new StringBuilder();


### PR DESCRIPTION
🍒 pick of #12871 to stable-17.0 for #12366

@jahorton discovered that
> it would appear that we cannot rely on the `WebView`'s version of `postDelayed`, as apparently that doesn't actually trigger delayed events when the `WebView` has been detached!  We can, however, construct a `Handler` instance and link it to the UI thread's looper in order to achieve our desired effect.

## User Testing

**Setup** - Install the PR build of Keyman for Android on a physical device. Also pair an external keyboard (USB/bluetooth) to the device

**TEST_KEYBOARD** - Verifies external keyboard works when virtual keyboard hidden

1. Launch Keyman
2. From "Get Started", enable Keyman as the default system keyboard
3. Launch a separate app where you can type in (ideally a note taking app like Keep or OneNote as reported in the issue). If those aren't available, Chrome browser works
4. Select a text area with Keyman sil_euro_latin selected as the system keyboard
5. Verify the system keyboard types fine (longpresses, switching, keys, etc).
6. With the virtual keyboard displayed, type on the physical keyboard <kbd>`</kbd> <kbd>a</kbd>
7. Verify the text becomes `à`.
8. From the Android system preferences, select "Language and Keyboard" --> Physical keyboard --> Toggle "show on-screen keyboard" so that the OSK is hidden
9. Return to the note-taking / Chrome app and select a text field
10. Type on the physical keyboard <kbd>`</kbd> <kbd>a</kbd>
11. Verify the text becomes `à`

Please repeat the test a few times, verifying that no errors are triggered during any attempt.
