### PR TITLE
change(web): add auto-correct filter that requires letter in initial position 🚂

### DIFF
--- a/web/src/engine/predictive-text/wordbreakers/src/main/default/index.ts
+++ b/web/src/engine/predictive-text/wordbreakers/src/main/default/index.ts
@@ -38,7 +38,7 @@ export interface DefaultWordBreakerOptions {
  * @see http://unicode.org/reports/tr29/#Word_Boundaries
  * @see https://github.com/eddieantonio/unicode-default-word-boundary/tree/v12.0.0
  */
-export default function default_(text: string, options?: DefaultWordBreakerOptions): LexicalModelTypes.Span[] {
+ function default_(text: string, options?: DefaultWordBreakerOptions): LexicalModelTypes.Span[] {
   let boundaries = findBoundaries(text, options);
   if (boundaries.length == 0) {
     return [];
@@ -63,6 +63,16 @@ export default function default_(text: string, options?: DefaultWordBreakerOptio
   }
   return spans;
 }
+
+// Exposes `searchForProperty` for external use while associating it with this wordbreaker.
+const def = Object.assign(default_, { 
+  /**
+   * This method returns enum values corresponding to the character type as perceived by the wordbreaking algorithm.
+   */
+  searchForProperty: searchForProperty
+});
+
+export default def;
 
 /**
  * A span that does not cut out the substring until it absolutely has to!

--- a/web/src/engine/predictive-text/wordbreakers/src/main/index.ts
+++ b/web/src/engine/predictive-text/wordbreakers/src/main/index.ts
@@ -1,5 +1,6 @@
 import placeholder from "./placeholder.js";
 import ascii from "./ascii.js";
 import default_ from "./default/index.js";
+import { WordBreakProperty } from "./default/data.inc.js";
 
-export { placeholder, ascii, default_ as default, default_ as defaultWordbreaker };
+export { placeholder, ascii, default_ as default, default_ as defaultWordbreaker, WordBreakProperty };

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/auto-correct.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/auto-correct.js
@@ -26,7 +26,7 @@ describe('predictionAutoSelect', () => {
     const predictions = [
       {
         correction: {
-          sample: 'apple', // can be null / "mocked out"
+          sample: 'apple',
           p: 1
         },
         prediction: {
@@ -52,6 +52,56 @@ describe('predictionAutoSelect', () => {
     assert.isOk(autoselected);
   });
 
+  it(`does not select suggestions if the root correction has no letters`, () => {
+    /**
+     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
+     */
+    const predictions = [
+      {
+        correction: {
+          sample: '5',
+          p: 1
+        },
+        prediction: {
+          sample: {
+            tag: 'keep',
+            transform: {
+              insert: '5',
+              deleteLeft: 0
+            },
+            matchesModel: false
+          },
+          p: 0.01
+        },
+        totalProb: 0.01
+      },
+      {
+        correction: {
+          sample: '5',
+          p: 1
+        },
+        prediction: {
+          sample: {
+            transform: {
+              insert: '5th',
+              deleteLeft: 0
+            },
+            matchesModel: true
+          },
+          p: 0.8
+        },
+        totalProb: 0.8
+      }
+    ];
+
+    const originalPredictions = [].concat(predictions);
+    assert.doesNotThrow(() => predictionAutoSelect(predictions));
+    assert.sameDeepOrderedMembers(predictions, originalPredictions);
+
+    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    assert.isNotOk(autoselected);
+  });
+
   it(`does not select solitary 'keep' suggestion that doesn't match the model`, () => {
     /**
      * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
@@ -59,7 +109,7 @@ describe('predictionAutoSelect', () => {
     const predictions = [
       {
         correction: {
-          sample: 'appl', // can be null / "mocked out"
+          sample: 'appl',
           p: 1
         },
         prediction: {
@@ -91,7 +141,7 @@ describe('predictionAutoSelect', () => {
      */
     const keepSuggestion = {
       correction: {
-        sample: 'thin', // can be null / "mocked out"
+        sample: 'thin',
         p: .8
       },
       prediction: {
@@ -110,7 +160,7 @@ describe('predictionAutoSelect', () => {
 
     const highestNonKeepSuggestion = {
       correction: {
-        sample: 'thin', // can be null / "mocked out"
+        sample: 'thin',
         p: .8
       },
       prediction: {
@@ -133,7 +183,7 @@ describe('predictionAutoSelect', () => {
       highestNonKeepSuggestion,
       {
         correction: {
-          sample: 'thin', // can be null / "mocked out"
+          sample: 'thin',
           p: .8
         },
         prediction: {
@@ -149,7 +199,7 @@ describe('predictionAutoSelect', () => {
       },
       {
         correction: {
-          sample: 'thic', // can be null / "mocked out"
+          sample: 'thic',
           p: .2
         },
         prediction: {
@@ -181,7 +231,7 @@ describe('predictionAutoSelect', () => {
      */
     const keepSuggestion = {
       correction: {
-        sample: 'thin', // can be null / "mocked out"
+        sample: 'thin',
         p: .8
       },
       prediction: {
@@ -204,7 +254,7 @@ describe('predictionAutoSelect', () => {
     // Refer to AUTOSELECT_PROPORTION_THRESHOLD in predict-helpers.ts.
     const onlyNonKeepSuggestion = {
       correction: {
-        sample: 'thin', // can be null / "mocked out"
+        sample: 'thin',
         p: .8
       },
       prediction: {
@@ -246,7 +296,7 @@ describe('predictionAutoSelect', () => {
      */
     const keepSuggestion = {
       correction: {
-        sample: 'thin', // can be null / "mocked out"
+        sample: 'thin',
         p: .8
       },
       prediction: {
@@ -269,7 +319,7 @@ describe('predictionAutoSelect', () => {
     // Refer to AUTOSELECT_PROPORTION_THRESHOLD in predict-helpers.ts.
     const highestNonKeepSuggestion = {
       correction: {
-        sample: 'thin', // can be null / "mocked out"
+        sample: 'thin',
         p: .8
       },
       prediction: {
@@ -292,7 +342,7 @@ describe('predictionAutoSelect', () => {
       highestNonKeepSuggestion,
       {
         correction: {
-          sample: 'thin', // can be null / "mocked out"
+          sample: 'thin',
           p: .8
         },
         prediction: {
@@ -308,7 +358,7 @@ describe('predictionAutoSelect', () => {
       },
       {
         correction: {
-          sample: 'thic', // can be null / "mocked out"
+          sample: 'thic',
           p: .2
         },
         prediction: {
@@ -343,7 +393,7 @@ describe('predictionAutoSelect', () => {
      */
     const keepSuggestion = {
       correction: {
-        sample: 'thin', // can be null / "mocked out"
+        sample: 'thin',
         p: .8
       },
       prediction: {
@@ -362,7 +412,7 @@ describe('predictionAutoSelect', () => {
 
     const highestNonKeepSuggestion = {
       correction: {
-        sample: 'thin', // can be null / "mocked out"
+        sample: 'thin',
         p: .9
       },
       prediction: {
@@ -385,7 +435,7 @@ describe('predictionAutoSelect', () => {
       highestNonKeepSuggestion,
       {
         correction: {
-          sample: 'thin', // can be null / "mocked out"
+          sample: 'thin',
           p: .9
         },
         prediction: {
@@ -401,7 +451,7 @@ describe('predictionAutoSelect', () => {
       },
       {
         correction: {
-          sample: 'thic', // can be null / "mocked out"
+          sample: 'thic',
           p: .1
         },
         prediction: {
@@ -436,7 +486,7 @@ describe('predictionAutoSelect', () => {
      */
     const keepSuggestion = {
       correction: {
-        sample: 'cant', // can be null / "mocked out"
+        sample: 'cant',
         p: 1
       },
       prediction: {
@@ -456,7 +506,7 @@ describe('predictionAutoSelect', () => {
 
     const expectedSuggestion = {
       correction: {
-        sample: 'cant', // can be null / "mocked out"
+        sample: 'cant',
         p: 1
       },
       prediction: {
@@ -480,7 +530,7 @@ describe('predictionAutoSelect', () => {
       expectedSuggestion,
       {
         correction: {
-          sample: 'cant', // can be null / "mocked out"
+          sample: 'cant',
           p: 1
         },
         prediction: {
@@ -515,7 +565,7 @@ describe('predictionAutoSelect', () => {
      */
     const keepSuggestion = {
       correction: {
-        sample: 'thi', // can be null / "mocked out"
+        sample: 'thi',
         p: .7
       },
       prediction: {
@@ -534,7 +584,7 @@ describe('predictionAutoSelect', () => {
 
     const highestCorrectionSuggestion = {
       correction: {
-        sample: 'thi', // can be null / "mocked out"
+        sample: 'thi',
         p: .7
       },
       prediction: {
@@ -551,7 +601,7 @@ describe('predictionAutoSelect', () => {
 
     const highestNonKeepSuggestion = {
       correction: {
-        sample: 'the', // can be null / "mocked out"
+        sample: 'the',
         p: .3
       },
       prediction: {


### PR DESCRIPTION
Addresses one item from the auto-correct initial feedback issue (#12648):

> Numbers get autocorrected, e.g. 23 -> 2nd.

This is accomplished by adding a new 'filter' function to the auto-correct logic:  `correctionValidForAutoSelect`.  A relatively simple guideline, at least for numbers, seems simple enough to define.  We can use the standard programming rule for identifiers - starting with a letter.  That is, if a token starts with a non-letter, we probably shouldn't do auto-correction with it.

We may need to refine and polish it once auto-correct is out and we are made aware of tricky cases with different character classes, but this should be a good starting point for any such logic.

I've also added a unit-test to validate that the motivating case no longer triggers auto-correction.

@keymanapp-test-bot skip