### PR TITLE
chore: update macOS environment-variable shell script

### DIFF
--- a/resources/devbox/macos/keyman.macos.env.sh
+++ b/resources/devbox/macos/keyman.macos.env.sh
@@ -14,9 +14,14 @@ export PATH=$ANDROID_HOME/tools/bin:$PATH
 export PATH=$ANDROID_HOME/platform-tools:$PATH
 export PATH=$ANDROID_HOME/cmdline-tools/latest/bin:$PATH
 export PATH=$ANDROID_HOME/build-tools/30.0.3:$PATH
-export PATH="/opt/homebrew/opt/java11/bin:$PATH"
+
+if [ -z "$HOMEBREW_PREFIX" ]; then
+  HOMEBREW_PREFIX=`brew --prefix`
+fi
+
 export PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
-export JAVA_HOME=/opt/homebrew/opt/java11
+export PATH="$HOMEBREW_PREFIX/opt/java11/bin:$PATH"
+export JAVA_HOME="$HOMEBREW_PREFIX/opt/java11"
 
 # Python 2.7
 eval "$(pyenv init --path)"

--- a/resources/devbox/macos/keyman.macos.env.sh
+++ b/resources/devbox/macos/keyman.macos.env.sh
@@ -5,7 +5,6 @@ export ANT_HOME=/usr/local/opt/ant
 export MAVEN_HOME=/usr/local/opt/maven
 export GRADLE_HOME=/usr/local/opt/gradle
 export ANDROID_HOME=~/.android
-export ANDROID_SDK_ROOT="$HOME/Library/Android/sdk"
 
 export PATH=$ANT_HOME/bin:$PATH
 export PATH=$MAVEN_HOME/bin:$PATH
@@ -13,10 +12,11 @@ export PATH=$GRADLE_HOME/bin:$PATH
 export PATH=$ANDROID_HOME/tools:$PATH
 export PATH=$ANDROID_HOME/tools/bin:$PATH
 export PATH=$ANDROID_HOME/platform-tools:$PATH
+export PATH=$ANDROID_HOME/cmdline-tools/latest/bin:$PATH
 export PATH=$ANDROID_HOME/build-tools/30.0.3:$PATH
-export PATH="/usr/local/opt/openjdk@8/bin:$PATH"
+export PATH="/opt/homebrew/opt/java11/bin:$PATH"
 export PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
-export JAVA_HOME=/usr/local/opt/openjdk@8
+export JAVA_HOME=/opt/homebrew/opt/java11
 
 # Python 2.7
 eval "$(pyenv init --path)"


### PR DESCRIPTION
I ran into a couple of issues when getting my Mac development laptop set up to build our Android app, some of them related to this script.  One distinctly noticeable item:  we use OpenJDK 11, not Java 8... yet the variables in the script still reference the latter!

Reference (current `master`):
https://github.com/keymanapp/keyman/blob/f268d04a27f4d9ac571f6d7e2ecd4ad6da063080/docs/build/macos.md?plain=1#L156-L161

@keymanapp-test-bot skip