### PR TITLE
feat(web): support reversion of accepted suggestions after edits 🖲️ 🚂

### DIFF
--- a/web/src/engine/interfaces/src/prediction/predictionContext.ts
+++ b/web/src/engine/interfaces/src/prediction/predictionContext.ts
@@ -322,9 +322,14 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
     // Do we have a keep suggestion?  If so, remove it from the list so that we can control its display position
     // and prevent it from being hidden after reversion operations.
     this.keepSuggestion = null;
+    this.revertSuggestion = null;
+    this.doRevert = false;
+
     for (const s of suggestions) {
       if(s.tag == 'keep') {
         this.keepSuggestion = s as Keep;
+      } else if(s.tag == 'revert') {
+        this.revertSuggestion = s as Reversion;
       }
 
       if (this.langProcessor.mayAutoCorrect && s.autoAccept && !this.selected) {
@@ -332,7 +337,9 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
       }
     }
 
-    if(this.keepSuggestion) {
+    if(this.revertSuggestion) {
+      this._currentSuggestions.splice(this._currentSuggestions.indexOf(this.revertSuggestion), 1);
+    } else if(this.keepSuggestion) {
       this._currentSuggestions.splice(this._currentSuggestions.indexOf(this.keepSuggestion), 1);
     }
 
@@ -343,6 +350,10 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
       this.recentRevert = false;
     } else { // This prediction was triggered by a recent 'accept.'  Now that it's fulfilled, we clear the flag.
       this.swallowPrediction = false;
+    }
+
+    if(this.revertSuggestion) {
+      this.doRevert = true;
     }
 
     // The rest is the same, whether from input or from "self-updating" after a reversion to provide new suggestions.

--- a/web/src/engine/interfaces/src/prediction/predictionContext.ts
+++ b/web/src/engine/interfaces/src/prediction/predictionContext.ts
@@ -168,6 +168,12 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
     this.selected = null;
     this.doRevert = false;
 
+    // By default, we assume we were triggered by the banner.
+    // Acceptance by keystroke will overwrite this later (in `tryAccept`)
+    this.recentAcceptCause = 'banner';
+    this.recentRevert = false;
+    this.selected = null;
+
     this.revertAcceptancePromise = this.acceptInternal(suggestion);
     if(!this.revertAcceptancePromise) {
       // We get here either if suggestion acceptance fails or if it was a reversion.
@@ -186,11 +192,6 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
         _this.revertSuggestion = suggestion;
       }
     });
-
-    // By default, we assume we were triggered by the banner.
-    // Acceptance by keystroke will overwrite this later (in `tryAccept`)
-    this.recentAcceptCause = 'banner';
-    this.recentRevert = false;
 
     this.swallowPrediction = true;
 
@@ -211,6 +212,8 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
   private doTryAccept = (source: string, returnObj: {shouldSwallow: boolean}): void => {
     const recentAcceptCause = this.recentAcceptCause;
 
+    // TODO:  rotating suggestions on the banner; should check if it's the same suggestion that was just applied or
+    // if we're replacing the prior one... I think?
     if(!recentAcceptCause && this.selected) {
       this.accept(this.selected);
       // If there is right-context, DO emit the space instead of swallowing it.

--- a/web/src/engine/main/src/headless/transcriptionCache.ts
+++ b/web/src/engine/main/src/headless/transcriptionCache.ts
@@ -1,6 +1,6 @@
 import { Transcription } from "keyman/engine/js-processor";
 
-const TRANSCRIPTION_BUFFER_SIZE = 10;
+const TRANSCRIPTION_BUFFER_SIZE = 20;
 
 export class TranscriptionCache {
   private readonly map = new Map<number, Transcription>();

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -773,11 +773,10 @@ export class SuggestionBanner extends Banner {
       if(suggestions.length > i) {
         const suggestion = suggestions[i];
         d.update(suggestion, optionFormat);
-        if(this.predictionContext.selected == suggestion) {
-          d.highlight(true);
-        }
+        d.highlight(this.predictionContext.selected == suggestion);
       } else {
         d.update(null, optionFormat);
+        d.highlight(false);
       }
     }
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -13,12 +13,6 @@ import LexicalModel = LexicalModelTypes.LexicalModel;
 import Suggestion = LexicalModelTypes.Suggestion;
 import Transform = LexicalModelTypes.Transform;
 
-/**
- * Indicates that the owning token's 'replacement' represents part of an
- * actually-applied suggestion.
- */
-export const APPLIED_SUGGESTION_COMPONENT = -2;
-
 function textToCharTransforms(text: string, transformId?: number) {
   let perCharTransforms: Transform[] = [];
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -13,6 +13,12 @@ import LexicalModel = LexicalModelTypes.LexicalModel;
 import Suggestion = LexicalModelTypes.Suggestion;
 import Transform = LexicalModelTypes.Transform;
 
+/**
+ * Indicates that the owning token's 'replacement' represents part of an
+ * actually-applied suggestion.
+ */
+export const APPLIED_SUGGESTION_COMPONENT = -2;
+
 function textToCharTransforms(text: string, transformId?: number) {
   let perCharTransforms: Transform[] = [];
 
@@ -56,6 +62,7 @@ export class TrackedContextToken {
   transformDistributions: Distribution<Transform>[] = [];
   replacements: TrackedContextSuggestion[] = [];
   activeReplacementId: number = -1;
+  replacementTransformId: number = -1;
 
   constructor();
   constructor(instance: TrackedContextToken);
@@ -86,6 +93,7 @@ export class TrackedContextToken {
   clearReplacements() {
     this.activeReplacementId = -1;
     this.replacements = []
+    this.replacementTransformId = -1;
   }
 
   /**

--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -286,7 +286,7 @@ export class ModelCompositor {
     // when reverting.
     if(contextState.tail.replacement) {
       console.log(contextState.tail.replacement);
-      
+
       // No trace of the original text (currently) remains (end of day 2025-01-17)
       //
       // Or is there one?  I found a tagged 'keep', even if not in the standard position within replacements.
@@ -328,12 +328,13 @@ export class ModelCompositor {
       let substitutionTokenIndex = (contextState.tokens.length - 1) - matchResults.headTokensRemoved;
 
       const tokenizer = determineModelTokenizer(this.lexicalModel)
-      // TODO:  
       let tokenizedApplication = tokenizeTransform(tokenizer, context, suggestion.transform);
 
       // We build our suggestions to do whole-word replacement.  Fortunately, that means we already have
       // the full suggestions!
       const suggestions = contextState.tail.replacements;
+
+      // FIXME: Does not handle cases where the prior context is an applied suggestion, thus already has the wordbreak!
       if(suggestions && (substitutionTokenIndex + tokenizedApplication.length == matchResults.state.tokens.length)) {
 
         for(let j = 1; j <= tokenizedApplication.length; j++) {

--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -5,7 +5,7 @@ import APPLIED_SUGGESTION_COMPONENT = correction.APPLIED_SUGGESTION_COMPONENT;
 import { KMWString } from '@keymanapp/web-utils';
 
 import TransformUtils from './transformUtils.js';
-import { correctAndEnumerate, dedupeSuggestions, finalizeSuggestions, predictionAutoSelect, processSimilarity, toAnnotatedSuggestion, tupleDisplayOrderSort } from './predict-helpers.js';
+import { correctAndEnumerate, dedupeSuggestions, finalizeSuggestions, isContextAtAcceptedSuggestionEdge, predictionAutoSelect, processSimilarity, suggestFromPriorContext, toAnnotatedSuggestion, tupleDisplayOrderSort } from './predict-helpers.js';
 import { detectCurrentCasing, determineModelTokenizer, determineModelWordbreaker, determinePunctuationFromModel } from './model-helpers.js';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 import CasingForm = LexicalModelTypes.CasingForm;
@@ -132,6 +132,11 @@ export class ModelCompositor {
     const timer = this.activeTimer = new correction.ExecutionTimer(this.testMode ? Number.MAX_VALUE : SEARCH_TIMEOUT, this.testMode ? Number.MAX_VALUE : SEARCH_TIMEOUT * 1.5);
 
     const { postContextState, rawPredictions } = await correctAndEnumerate(this.contextTracker, this.lexicalModel, timer, transformDistribution, context);
+
+    // Check:  did we just reach the tail of a prior token via BKSP?
+    if(isContextAtAcceptedSuggestionEdge(postContextState)) {
+      return suggestFromPriorContext(postContextState, inputTransform, this.punctuation);
+    }
 
     if(this.activeTimer == timer) {
       this.activeTimer = null;

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -441,6 +441,8 @@ export function suggestFromPriorContext(
   suggestions.forEach((entry) => {
     entry.suggestion.transform.deleteLeft = deleteLeft;
     if(inputTransform.id) {
+      // TODO: Consider replacing with or annotating with the ORIGINAL ID - the one that prompted the
+      // original suggestion pass.
       entry.suggestion.transformId = inputTransform.id;
     }
   });

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -470,12 +470,11 @@ export function suggestFromPriorContext(
   const keepId = baseKeepSuggestion.suggestion.transformId;
   suggestions[suggestions.indexOf(baseKeepSuggestion)] = keepSuggestion;
 
-  // First up:  we can safely use the raw insert string as the needed length to erase.
-  // Also, we need to include whatever backspacing occured to reach that point, as the suggestion
-  // is applied to the context BEFORE the backspace takes effect.
-  suggestions.forEach((entry) => {
-    entry.suggestion.transformId = keepId;
-  });
+  if(keepId !== undefined) {
+    suggestions.forEach((entry) => {
+      entry.suggestion.transformId = keepId;
+    });
+  }
 
   // oh yeah, make sure we map the input's transform ID...
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -310,6 +310,7 @@ export async function correctAndEnumerate(
 
     // Only one 'correction' / prediction root is allowed - the actual text.
     return {
+      preContextState: contextState,
       postContextState: postContextState,
       rawPredictions: predictions
     }
@@ -413,9 +414,9 @@ export async function correctAndEnumerate(
  * suggestions based on the current state of the context, altering the 'keep' suggestion
  * into a 'revert' suggestion that will restore the original input.
  * @param postContextState
- * @param inputTransform 
- * @param punctuation 
- * @returns 
+ * @param inputTransform
+ * @param punctuation
+ * @returns
  */
 export function suggestFromPriorContext(
   postContextState: TrackedContextState,
@@ -437,7 +438,7 @@ export function suggestFromPriorContext(
   // First up:  we can safely use the raw insert string as the needed length to erase.
   // Also, we need to include whatever backspacing occured to reach that point, as the suggestion
   // is applied to the context BEFORE the backspace takes effect.
-  const deleteLeft = appliedSuggestion.suggestion.transform.insert.kmwLength() + inputTransform.deleteLeft;
+  const deleteLeft = KMWString.length(appliedSuggestion.suggestion.transform.insert) + inputTransform.deleteLeft;
   suggestions.forEach((entry) => {
     entry.suggestion.transform.deleteLeft = deleteLeft;
     if(inputTransform.id) {
@@ -724,12 +725,12 @@ export function processSimilarity(
  * unexpected ways.  For example, when typing numbers in English, we don't expect
  * '5' to auto-correct to '5th' just because there are no pure-number entries in
  * the lexicon rooted on '5'.
- * @param correction 
- * @returns 
+ * @param correction
+ * @returns
  */
 export function correctionValidForAutoSelect(correction: string) {
   let chars = [...correction];
-  
+
   // If the _correction_ - the actual, existing text - does not include any letters,
   // then predictions built upon it should not be considered valid for auto-correction.
   for(let c of chars) {


### PR DESCRIPTION
The work in this PR corresponds to this idea: https://github.com/keymanapp/keyman/issues/12648#issuecomment-2586130933

> > When typing rapidly, one often does not notice if the autocorrect chose wrongly. Backspacing to undo autocorrect only seems to work immediately after the spacebar is pressed; once any other keys are pressed, you have to delete the entire word and retype.
> 
> For this one... I think the "context tracker" system could, in theory, be leveraged to detect this case with some additional work. We're basically looking to revert the suggestion after a delay in this case, rather than immediately after its application. This is also presently a limitation outside of autocorrect, so it's something I could look into for the current release cycle if desired.

This PR _should_ have user testing done on it once ready; the behavior it'll add will be user-facing.