### PR TITLE
chore(linux): improve compatibility with Gentoo Linux 🏠

### DIFF
--- a/linux/ibus-keyman/meson.build
+++ b/linux/ibus-keyman/meson.build
@@ -8,8 +8,16 @@ conf = configuration_data()
 ibus =           dependency('ibus-1.0',             version: '>= 1.2.0')
 gtk =            dependency('gtk+-3.0',             version: '>= 2.4')
 json_glib =      dependency('json-glib-1.0',        version: '>= 1.0')
-systemd  =       dependency('libsystemd')
 icu =            dependency('icu-i18n')
+
+systemd  =       dependency('libsystemd', 'libelogind', required: false)
+if systemd.found()
+  conf.set('DBUS_IMPLEMENTATION', 'SYSTEMD')
+else
+  # Gentoo can use libelogind or basu
+  systemd = dependency('basu')
+  conf.set('DBUS_IMPLEMENTATION', 'BASU')
+endif
 
 core_dir = meson.current_source_dir() / '../../core'
 common_dir = meson.current_source_dir() / '../../common'

--- a/linux/ibus-keyman/meson.build
+++ b/linux/ibus-keyman/meson.build
@@ -15,7 +15,7 @@ if systemd.found()
   conf.set('DBUS_IMPLEMENTATION', 'SYSTEMD')
 else
   # Gentoo can use libelogind or basu
-  systemd = dependency('basu')
+  systemd = dependency('basu', required: true)
   conf.set('DBUS_IMPLEMENTATION', 'BASU')
 endif
 

--- a/linux/ibus-keyman/src/KeymanSystemServiceClient.cpp
+++ b/linux/ibus-keyman/src/KeymanSystemServiceClient.cpp
@@ -1,5 +1,10 @@
+#include "config.h"
 #include <cassert>
+#if DBUS_IMPLEMENTATION == SYSTEMD
 #include <systemd/sd-bus.h>
+#else
+#include <basu/sd-bus.h>
+#endif
 #include "KeymanSystemServiceClient.h"
 
 #define KEYMAN_BUS_NAME "com.keyman.SystemService1"

--- a/linux/ibus-keyman/tests/KmDbusTestServer.cpp
+++ b/linux/ibus-keyman/tests/KmDbusTestServer.cpp
@@ -1,9 +1,14 @@
 // DBus test server. The server will start and listen on a non-standard DBus.
 // It runs until the DBus Exit method gets called.
+#include "config.h"
 #include <fstream>
 #include <gio/gio.h>
 #include <iostream>
+#if DBUS_IMPLEMENTATION == SYSTEMD
 #include <systemd/sd-bus.h>
+#else
+#include <basu/sd-bus.h>
+#endif
 
 #ifndef KEYMAN_TEST_SERVICE_PATH
 #warning KEYMAN_TEST_SERVICE_PATH is undefined
@@ -73,7 +78,10 @@ KmDbusTestServer::~KmDbusTestServer()
 {
   if (bus)  sd_bus_release_name(bus, KEYMAN_TESTSVC_BUS_NAME);
   if (slot) sd_bus_slot_unref(slot);
-  if (bus)  sd_bus_close_unref(bus);
+  if (bus) {
+    sd_bus_close(bus);
+    sd_bus_unref(bus);
+  }
 
   g_test_dbus_down(dbus);
   g_object_unref(dbus);

--- a/linux/ibus-keyman/tests/StopTestServer.cpp
+++ b/linux/ibus-keyman/tests/StopTestServer.cpp
@@ -1,8 +1,13 @@
 // Call the Exit method on the km-dbus-test-server. Remember to source
 // `/tmp/km-test-server.env` prior to running stop-test-server in order
 // to run on our non-standard DBus.
+#include "config.h"
 #include <iostream>
+#if DBUS_IMPLEMENTATION == SYSTEMD
 #include <systemd/sd-bus.h>
+#else
+#include <basu/sd-bus.h>
+#endif
 
 using namespace std;
 

--- a/linux/ibus-keyman/tests/meson.build
+++ b/linux/ibus-keyman/tests/meson.build
@@ -38,6 +38,7 @@ dbus_test_server = executable(
   'km-dbus-test-server',
   'KmDbusTestServer.cpp',
   dependencies: dbus_deps,
+  include_directories: ['..'],
   cpp_args: [
   '-DKEYMAN_TEST_SERVICE_PATH="' + system_service_dir + '"'
  ]
@@ -47,6 +48,7 @@ stop_test_server = executable(
   'stop-test-server',
   'StopTestServer.cpp',
   dependencies: dbus_deps,
+  include_directories: ['..'],
 )
 
 env_file = '/tmp/env.txt'

--- a/linux/keyman-system-service/meson.build
+++ b/linux/keyman-system-service/meson.build
@@ -3,8 +3,21 @@ project('keyman-system-service', 'c', 'cpp',
         license: 'GPL-2+',
         meson_version: '>=0.61')
 
+conf = configuration_data()
+
 evdev    = dependency('libevdev', version: '>= 1.9')
-systemd  = dependency('libsystemd')
+
+systemd  = dependency('libsystemd', 'libelogind', required: false)
+if systemd.found()
+  conf.set('DBUS_IMPLEMENTATION', 'SYSTEMD')
+else
+  # Gentoo can use libelogind or basu
+  systemd = dependency('basu')
+  conf.set('DBUS_IMPLEMENTATION', 'BASU')
+endif
+
+configure_file(output : 'config.h',
+               configuration : conf)
 
 subdir('resources')
 subdir('src')

--- a/linux/keyman-system-service/meson.build
+++ b/linux/keyman-system-service/meson.build
@@ -12,7 +12,7 @@ if systemd.found()
   conf.set('DBUS_IMPLEMENTATION', 'SYSTEMD')
 else
   # Gentoo can use libelogind or basu
-  systemd = dependency('basu')
+  systemd = dependency('basu', required: true)
   conf.set('DBUS_IMPLEMENTATION', 'BASU')
 endif
 

--- a/linux/keyman-system-service/resources/com.keyman.SystemService1.service.basu
+++ b/linux/keyman-system-service/resources/com.keyman.SystemService1.service.basu
@@ -1,0 +1,7 @@
+# /usr/share/dbus-1/system-services/com.keyman.SystemService1.service
+# This version used with elogind and basu (e.g. on Gentoo)
+
+[D-BUS Service]
+Name=com.keyman.SystemService1
+Exec=/usr/libexec/systemd-keyman.service
+User=root

--- a/linux/keyman-system-service/resources/com.keyman.SystemService1.service.systemd
+++ b/linux/keyman-system-service/resources/com.keyman.SystemService1.service.systemd
@@ -1,4 +1,5 @@
 # /usr/share/dbus-1/system-services/com.keyman.SystemService1.service
+# This version used with systemd (e.g. on Debian)
 
 [D-BUS Service]
 Name=com.keyman.SystemService1

--- a/linux/keyman-system-service/resources/meson.build
+++ b/linux/keyman-system-service/resources/meson.build
@@ -1,3 +1,10 @@
 install_data('com.keyman.SystemService1.conf', install_dir: get_option('datadir') / 'dbus-1/system.d/')
-install_data('com.keyman.SystemService1.service', install_dir: get_option('datadir') / 'dbus-1/system-services/')
+
+if systemd.name() == 'libsystemd'
+  install_data('com.keyman.SystemService1.service.systemd', install_dir: get_option('datadir') / 'dbus-1/system-services/', rename: ['com.keyman.SystemService1.service'])
+else
+  # libelogind or basu
+  install_data('com.keyman.SystemService1.service.basu', install_dir: get_option('datadir') / 'dbus-1/system-services/')
+endif
+
 install_data('systemd-keyman.service', install_dir: get_option('prefix') / 'lib/systemd/system/')

--- a/linux/keyman-system-service/src/KeymanSystemService.cpp
+++ b/linux/keyman-system-service/src/KeymanSystemService.cpp
@@ -2,6 +2,7 @@
 // based on the sd-bus library, see
 // https://0pointer.net/blog/the-new-sd-bus-api-of-systemd.html
 
+#include "config.h"
 #include <cstdint>
 #include <dirent.h>
 #include <errno.h>
@@ -11,7 +12,11 @@
 #include <string.h>
 #include <sys/types.h>
 #include <syslog.h>
+#if DBUS_IMPLEMENTATION == SYSTEMD
 #include <systemd/sd-bus.h>
+#else
+#include <basu/sd-bus.h>
+#endif
 #include "KeymanSystemService.h"
 #include "KeyboardDevice.h"
 

--- a/linux/keyman-system-service/src/KeymanSystemService.h
+++ b/linux/keyman-system-service/src/KeymanSystemService.h
@@ -1,8 +1,13 @@
 #ifndef __KEYMANSYSTEMSERVICE_H__
 #define __KEYMANSYSTEMSERVICE_H__
 
+#include "config.h"
 #include <list>
+#if DBUS_IMPLEMENTATION == SYSTEMD
 #include <systemd/sd-bus.h>
+#else
+#include <basu/sd-bus.h>
+#endif
 #include "KeyboardDevice.h"
 
 using namespace std;

--- a/linux/keyman-system-service/src/meson.build
+++ b/linux/keyman-system-service/src/meson.build
@@ -10,6 +10,7 @@ exe = executable(
   'keyman-system-service',
   sources: [service_files],
   dependencies: deps,
+  include_directories: ['..'],
   install: true,
   install_dir: get_option('libexecdir'),
 )

--- a/linux/keyman-system-service/tests/meson.build
+++ b/linux/keyman-system-service/tests/meson.build
@@ -17,7 +17,7 @@ exe = executable(
   c_args: test_c_args,
   cpp_args: test_c_args,
   dependencies: deps,
-  include_directories: [ '../src' ]
+  include_directories: [ '..', '../src' ]
 )
 
 # we currently don't have any unit tests for keyman-system-service.


### PR DESCRIPTION
Gentoo doesn't use systemd. `libelogind` or `basu` implement some aspects of systemd, so we use that on Gentoo (or rather when `libsystemd` is not available but `libelogind` or `basu` is).

Patch from https://forums.gentoo.org/viewtopic.php?p=8850566.
See also https://community.software.sil.org/t/keyman-for-gentoo-linux/9615.

@keymanapp-test-bot skip