### PR TITLE
docs(web): fix `adding-keyboards.md`

### DIFF
--- a/web/docs/engine/guide/adding-keyboards.md
+++ b/web/docs/engine/guide/adding-keyboards.md
@@ -4,8 +4,6 @@ title: Adding Keyboards
 
 There are multiple ways to add and install keyboards into your KeymanWeb installation.
 
-In the examples that follow, please note the use of variable `kmw` as shorthand for the `keyman` object.
-
 ## Directly linking a local copy
 
 The most efficient way to utilize a keyboard is to obtain a local copy of it and place this copy in a static location on your website. Once this is done, it can be directly linked into KeymanWeb as follows.
@@ -21,6 +19,7 @@ keyman.addKeyboards({
     filename:'./us-1.0.js'    // A valid path to the compiled *.js file representing the keyboard.
 });
 ```
+
 Custom fonts may also be utilized via the `language.font` property. For example:
 
 ```c
@@ -53,7 +52,7 @@ The `@` prefix indicates the use of the BCP 47 language code, which in this case
 To obtain a specific keyboard by name or by keyboard name and language code as a pair, see the following:
 
 ```c
-keyman.addKeyboards('french','european2@sv','european2@no')
+keyman.addKeyboards('french','sil_euro_latin@sv','sil_euro_latin@no')
 ```
 
-This will install three keyboards - one for French (named, quite simply, "French") and two copies of the EuroLatin2 keyboard - one for Swedish and one for Norwegian.
+This will install three keyboards - one for French (named, quite simply, "French") and two copies of the EuroLatin keyboard - one for Swedish and one for Norwegian.


### PR DESCRIPTION
- `kmw` is no longer used on this page, so we don't have to mention it
- the `european2` keyboard is deprecated and the text mentions EuroLatin, so changed the sample to `sil_euro_latin`

@keymanapp-test-bot skip