### PR TITLE
docs(android): document longpress up-flick to quick-display shortcut

### DIFF
--- a/android/docs/help/context/gestures.md
+++ b/android/docs/help/context/gestures.md
@@ -8,6 +8,8 @@ There are now several gestures available to interact with some keys on the keybo
 ![](../android_images/touch-hold-ap.png)
 
 * **Long press**: Press and hold a key, and after a moment a submenu will appear. Slide the finger to the submenu to select a key. Release the finger, and the highlighted key from the submenu will be output.
-* **Flick**: Press and hold a key, and then slide the finger in various directions on a key to reach alternate outputs. The key will animate to show the expected output when the finger gets released. A common flick is to slide down to reach numerals on the top row of the keyboard.
-* **Multitap**: Some keys can be pressed repeatedly and rapidly to reach alternate outputs. Tapping rapidly twice on <kbd>Shift</kbd> will activate <kbd>Caps Lock</kbd> on many keyboards.
 
+* **Flick**: Press and hold a key, and then slide the finger in various directions on a key to reach alternate outputs. The key will animate to show the expected output when the finger gets released. A common flick is to slide down to reach numerals on the top row of the keyboard.
+
+  An up-flick on keys that support longpresses but do not have a defined up-flick will skip the wait and immediately display their longpress submenu.
+* **Multitap**: Some keys can be pressed repeatedly and rapidly to reach alternate outputs. Tapping rapidly twice on <kbd>Shift</kbd> will activate <kbd>Caps Lock</kbd> on many keyboards.


### PR DESCRIPTION
I originally put this together at https://github.com/keymanapp/help.keyman.com/pull/1789, but it sounds like this is the correct place to do it now.

@keymanapp-test-bot skip