### PR TITLE
feat(windows): UI removed from state machine 💽

### DIFF
--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -1104,20 +1104,26 @@ end;
 procedure InstallingState.HandleInstallPackages;
 var
   ucr: TUpdateCheckResponse;
+  hasKeymanInstall : Boolean;
 begin
+  TUpdateCheckStorage.LoadUpdateCacheData(ucr);
+  hasKeymanInstall := TUpdateCheckStorage.HasKeymanInstallFile(ucr);
   // This event should only be reached in elevated process if not then
   // move on to just installing Keyman
   if not kmcom.SystemInfo.IsAdministrator then
   begin
-    DoInstallKeyman;
+    if hasKeymanInstall then
+      DoInstallKeyman;
     Exit;
   end;
+
   if (TUpdateCheckStorage.LoadUpdateCacheData(ucr)) then
   begin
     DoInstallPackages(ucr);
   end;
 
-  DoInstallKeyman;
+  if hasKeymanInstall then
+    DoInstallKeyman;
 end;
 
 procedure InstallingState.HandleFirstRun;

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -564,8 +564,6 @@ begin
 end;
 
 function TUpdateStateMachine.ReadyToInstall: Boolean;
-var
-  ucr: TUpdateCheckResponse;
 begin
   if not IsCurrentStateAssigned then
     Exit(False);


### PR DESCRIPTION
The UI checks have been moved outside the state machine. This was clean for the install now case. For the waiting restart case not so. To help a new method ready to install was added to the state machine.

Also made a second commit that makes sure there is a Keyman install before calling DoInstallKeyman on the Install packages process.

@keymanapp-test-bot skip
