### PR TITLE
change(web): make 'keep' transform pattern match standard suggestion pattern by including the prefix string

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -558,11 +558,13 @@ export function processSimilarity(
     return;
   }
 
-  // Generate a default 'keep' option if one was not otherwise produced.
-
-  // IMPORTANT:  duplicate the original transform.  Causes nasty side-effects
-  // for context-tracking otherwise!
-  let keepTransform: Transform = { ...inputTransform };
+  // Generate a full-word 'keep' replacement like other suggestions when one is not otherwise
+  // produced; we want to replace the full token in the same manner used for other suggestions.
+  const basePrefixLength = truePrefix.kmwLength() - inputTransform.insert.kmwLength() + inputTransform.deleteLeft;
+  const keepTransform = {
+    insert: truePrefix,
+    deleteLeft: basePrefixLength
+  };
 
   // 1 is a filler value; goes unused b/c is for a 'keep'.
   let keepSuggestion = models.transformToSuggestion(keepTransform, 1);

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/suggestion-similarity.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/suggestion-similarity.js
@@ -340,8 +340,8 @@ describe('processSimilarity', () => {
       prediction: {
         sample: {
           transform: {
-            insert: 'e',
-            deleteLeft: 0
+            insert: 'iphone',
+            deleteLeft: 5
           },
           displayAs: '<iphone>',
           matchesModel: false,

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/worker-model-compositor.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/worker-model-compositor.js
@@ -932,8 +932,8 @@ describe('ModelCompositor', function() {
       assert.equal(suggestions.length, 1);
 
       let expectedTransform = {
-        insert: ' ',  // Keeps current context the same, though it adds a wordbreak.
-        deleteLeft: 0
+        insert: 'hi ',  // Keeps current context the same, though it adds a wordbreak.
+        deleteLeft: 2
       }
       assert.deepEqual(suggestions[0].transform, expectedTransform);
     });


### PR DESCRIPTION
This has been spun off from #12884.

One obstacle toward handling delayed reversions is that our current 'keep' suggestion generation builds transforms that perform as minimal an edit as possible... unlike literally every other suggestion transform we build, which deletes the prefix and re-adds it within the 'insert' section.  As it turns out, the latter case is much more favorable for implementing delayed reversions.  This change will make 'keep' suggestion transforms consistent with those from predictive and corrective suggestions.

@keymanapp-test-bot skip