### PR TITLE
fix(developer): filter incorrect fonts out of .keyboard_info

### DIFF
--- a/developer/src/kmc-keyboard-info/src/keyboard-info-compiler.ts
+++ b/developer/src/kmc-keyboard-info/src/keyboard-info-compiler.ts
@@ -499,9 +499,6 @@ export class KeyboardInfoCompiler implements KeymanCompiler {
       keyboard_info.languages[language] = {};
     }
 
-    const fontSource = [].concat(...kmpJsonData.keyboards.map(e => e.displayFont ? [e.displayFont] : []), ...kmpJsonData.keyboards.map(e => e.webDisplayFonts ?? []));
-    const oskFontSource = [].concat(...kmpJsonData.keyboards.map(e => e.oskFont ? [e.oskFont] : []), ...kmpJsonData.keyboards.map(e => e.webOskFonts ?? []));
-
     let commonScript = null;
 
     for(const bcp47 of Object.keys(keyboard_info.languages)) {
@@ -527,6 +524,20 @@ export class KeyboardInfoCompiler implements KeymanCompiler {
       // optimization, but it's another keyboard_info breaking change so don't want to
       // do it right now.
       //
+
+      // The code below:
+      // 1. Only includes fonts associated with keyboards which support the current bcp47 (filter)
+      // 2. Joins the displayFont and webDisplayFonts data, and removes duplicates (...new Set())
+
+      const supportedKeyboards = kmpJsonData.keyboards.filter(k => k.languages.find(lang => lang.id == bcp47));
+      const fontSource = [...new Set([].concat(
+        ...supportedKeyboards.map(e => e.displayFont ? [e.displayFont] : []),
+        ...supportedKeyboards.map(e => e.webDisplayFonts ?? [])
+      ))];
+      const oskFontSource = [...new Set([].concat(
+        ...supportedKeyboards.map(e => e.oskFont ? [e.oskFont] : []),
+        ...supportedKeyboards.map(e => e.webOskFonts ?? [])
+      ))];
 
       if(fontSource.length) {
         language.font = await this.fontSourceToKeyboardInfoFont(kpsFilename, kmpJsonData, fontSource);


### PR DESCRIPTION
The font collection code was somewhat wrong in kmc-keyboard-info. It collected all fonts referenced in the package, even for multi-keyboard packages, which meant that the .keyboard_info file listed all fonts for all languages. Furthermore, if a font was referenced in multiple language entries in the .kps, then it would be repeated for each language in the .keyboard_info. This patch addresses both of these bugs.

The good news is that this makes some of the .keyboard_info files smaller. In particular, fv_all.keyboard_info goes from 4675 lines down to 695 lines!

Fixes: #12852

@keymanapp-test-bot skip