### PR TITLE
chore(windows): remove `postinstall` state from mermaid diagram

### DIFF
--- a/windows/src/desktop/kmshell/main/BackgroundUpdateStateDiagram.md
+++ b/windows/src/desktop/kmshell/main/BackgroundUpdateStateDiagram.md
@@ -6,6 +6,5 @@ stateDiagram
     Downloading --> Installing
     Downloading --> WaitingRestart
     WaitingRestart --> Installing
-    Installing --> PostInstall
-    PostInstall --> Idle
+    Installing --> Idle
 ```


### PR DESCRIPTION
The postinstall state no longer exists due to the way interaction with the microsoft installer works. This PR just updateds the diagram to match.

The side purpose of this PR is to provide a newer build version to test the online upgrade process. 

@keymanapp-test-bot skip