### PR TITLE
fix(developer): use correct terms in kmc-generate lexical model help

### DIFF
--- a/developer/src/kmc/src/commands/generate.ts
+++ b/developer/src/kmc/src/commands/generate.ts
@@ -59,12 +59,12 @@ function declareGenerateLexicalModel(command: Command) {
   modelSubCommand
     .description('Generate a wordlist lexical model project')
     .option('-o, --out-path <path>', 'Output path (may exist)')
-    .option('-n, --name <name>', 'Keyboard descriptive name')
+    .option('-n, --name <name>', 'Lexical model descriptive name')
     .option('-c, --copyright <copyright-name>', 'Copyright holder') /* © yyyy <copyright-name> */
-    .option('-v, --version <version-string>', 'Keyboard version', '1.0')
+    .option('-v, --version <version-string>', 'Lexical model version', '1.0')
     .option('-L, --language-tag <bcp-47 tag>', 'BCP-47 language tag',
       (value, previous) => previous.concat([value]), [])
-    .option('-a, --author <author-name>', 'Name of keyboard author')
+    .option('-a, --author <author-name>', 'Name of lexical model author')
     .option('-d, --description <description>', 'Short description of the project, Markdown')
     .action(generateLexicalModel);
 


### PR DESCRIPTION
Fixes: #12959

@keymanapp-test-bot skip