### PR TITLE
chore(developer): stub out icon support in kmc-generate

### DIFF
--- a/developer/docs/help/reference/kmc/cli/reference.md
+++ b/developer/docs/help/reference/kmc/cli/reference.md
@@ -367,10 +367,13 @@ and the files in that folder will follow the
 
 : The name of keyboard author (default: blank)
 
+<!-- TODO-GENERATE: uncomment once supported
+
 `-i, --icon`
 
 : Include a generated icon. The icon will be a 16x16 pixel box with the first
   letters of the first language tag (default: true, include an icon)
+-->
 
 `-d, --description <description>`
 

--- a/developer/src/kmc-generate/src/abstract-generator.ts
+++ b/developer/src/kmc-generate/src/abstract-generator.ts
@@ -53,11 +53,14 @@ export interface GeneratorOptions /* not inheriting from CompilerBaseOptions */ 
    * name of the author of the keyboard
    */
   author?: string;
-  /**
+
+  // TODO-GENERATE: icon support
+  /* *
    * set to true to generate an icon for a Keyman keyboard with the first
    * characters of the first specified BCP 47 tag
    */
-  icon?: boolean;
+  // icon?: boolean;
+
   /**
    * description of the keyboard, Markdown permissible
    */

--- a/developer/src/kmc-generate/src/keyman-keyboard-generator.ts
+++ b/developer/src/kmc-generate/src/keyman-keyboard-generator.ts
@@ -72,9 +72,10 @@ export class KeymanKeyboardGenerator extends BasicGenerator implements KeymanCom
         KeymanKeyboardGenerator.SPath_Source+this.options.id+KeymanFileTypes.Source.TouchLayout;
     }
 
-    if(this.hasIcon()) {
-      this.includedPrefixes.push('Icon');
-    }
+    // TODO-GENERATE: icon support
+    // if(this.hasIcon()) {
+    //   this.includedPrefixes.push('Icon');
+    // }
 
     if(this.hasKMX()) {
       this.includedPrefixes.push('KMX');
@@ -91,9 +92,9 @@ export class KeymanKeyboardGenerator extends BasicGenerator implements KeymanCom
 
     // Special case for creating icon, run after successful creation of other
     // project bits and pieces
-    if(this.hasIcon()) {
-      this.writeIcon(artifacts);
-    }
+    // if(this.hasIcon()) {
+    //   this.writeIcon(artifacts);
+    // }
 
     return {artifacts};
   }
@@ -107,13 +108,13 @@ export class KeymanKeyboardGenerator extends BasicGenerator implements KeymanCom
   private readonly hasKMX         = () => this.targetIncludes(KeymanTargets.KMXKeymanTargets);
   private readonly hasTouchLayout = () => this.targetIncludes(KeymanTargets.TouchKeymanTargets);
 
-  // TODO-GENERATE, once writeIcon is implemented:
+  // TODO-GENERATE: icon support
   // hasIcon = () => this.options.icon && this.targetIncludes(KeymanTargets.KMXKeymanTargets);
-  private readonly hasIcon = () => false;
+  // private readonly hasIcon = () => false;
 
-  private writeIcon(artifacts: GeneratorArtifacts) {
-    // TODO-GENERATE: this will require some effort
-    // proposal: generate 16x16 icon with 2-3 letters. Following TKeyboardIconGenerator.GenerateIcon
-    // research for .ico writer in node
-  }
+  // TODO-GENERATE: icon support
+  // private writeIcon(artifacts: GeneratorArtifacts) {
+  //   proposal: generate 16x16 icon with 2-3 letters. Following TKeyboardIconGenerator.GenerateIcon
+  //   research for .ico writer in node
+  // }
 }

--- a/developer/src/kmc-generate/test/shared-options.ts
+++ b/developer/src/kmc-generate/test/shared-options.ts
@@ -6,7 +6,8 @@ import { KeymanTargets } from "@keymanapp/common-types";
 import { GeneratorOptions } from "../src/abstract-generator.js";
 
 export const options: GeneratorOptions = {
-  icon: false,
+  // TODO-GENERATE: icon support
+  // icon: false,
   id: 'sample',
   languageTags: ['en'],
   name: 'Sample Project',

--- a/developer/src/kmc/src/commands/generate.ts
+++ b/developer/src/kmc/src/commands/generate.ts
@@ -30,7 +30,8 @@ function declareGenerateKmnKeyboard(command: Command) {
     .option('-L, --language-tag <bcp-47 tag>', 'BCP-47 language tag',
       (value, previous) => previous.concat([value]), [])
     .option('-a, --author <author-name>', 'Name of keyboard author')
-    .option('-i, --icon', 'Include a generated icon', true)
+    // TODO-GENERATE: icon support
+    // .option('-i, --icon', 'Include a generated icon', true)
     .option('-d, --description <description>', 'Short description of the project, Markdown')
     .action(generateKmnKeyboard);
 }
@@ -73,7 +74,8 @@ function declareGenerateLexicalModel(command: Command) {
 
 function commanderOptionsToGeneratorOptions(id: string, options: any): GeneratorOptions {
   const result: GeneratorOptions = {
-    icon: options.icon ?? true,
+    // TODO-GENERATE: icon support
+    // icon: options.icon ?? true,
     id,
     languageTags: options.languageTag ?? [],
     name: options.name ?? id,


### PR DESCRIPTION
As icon generation turns out to be challenging due to limitations or native dependencies in node.js libraries for image generation, icon options are now stubbed out to avoid confusion.

See #12641 for TODO to implement icon support.

@keymanapp-test-bot skip