### PR TITLE
chore(developer): remove '--rename' option from kmc-copy

### DIFF
--- a/developer/src/kmc-copy/src/KeymanProjectCopier.ts
+++ b/developer/src/kmc-copy/src/KeymanProjectCopier.ts
@@ -29,11 +29,6 @@ export interface CopierOptions /* not inheriting from CompilerBaseOptions */ {
    * output path where project folder will be created
    */
   outPath: string;
-  /*
-   * TODO-COPY rename: rename existing files rather than copy
-
-  rename: boolean;
-  */
   /**
    * dryRun: show what would happen
    */

--- a/developer/src/kmc-copy/test/copier.tests.ts
+++ b/developer/src/kmc-copy/test/copier.tests.ts
@@ -306,7 +306,6 @@ describe('KeymanProjectCopier', function() {
       assert.isTrue(await copier.init(callbacks, {
         dryRun: false,
         outPath,
-        // TODO-COPY rename: false,
       }));
 
       const result = await copier.run(fullSource);
@@ -370,7 +369,6 @@ describe('KeymanProjectCopier', function() {
     assert.isTrue(await copier.init(callbacks, {
       dryRun: false,
       outPath,
-      // TODO-COPY rename: false,
     }));
 
     // armenian_mnemonic selected because (a) small, and (b) has v2.0 project, so
@@ -400,7 +398,6 @@ describe('KeymanProjectCopier', function() {
       assert.isTrue(await copier.init(callbacks, {
         dryRun: false,
         outPath,
-        // TODO-COPY rename: false,
       }));
 
       const result = await copier.run('cloud:'+id);

--- a/developer/src/kmc/src/commands/copy.ts
+++ b/developer/src/kmc/src/commands/copy.ts
@@ -19,7 +19,6 @@ export function declareCopy(program: Command) {
   command
     .description('Copy a Keyman keyboard or lexical model project')
     .option('-o, --out-path <path>', 'New name and path for project')
-    // TODO-COPY .option('-r, --rename', 'Rename instead of copying project')
     .option('-n, --dry-run', 'Show what would happen, without making changes')
     .action(copyProject)
     .addHelpText('before', `
@@ -36,7 +35,6 @@ export function declareCopy(program: Command) {
 function commanderOptionsToCopierOptions(options: any): CopierOptions {
   const result: CopierOptions = {
     outPath: options.outPath,
-    // TODO-COPY rename: options.rename ?? false,
     dryRun: options.dryRun ?? false,
   };
   return result;


### PR DESCRIPTION
An in-place rename is dangerous and destructive, so we won't support it.

Fixes: #12972

@keymanapp-test-bot skip