### PR TITLE
fix(android/engine): Revert how keyboard picker menu launches

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2267,6 +2267,7 @@ public final class KMManager {
 
     if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       i.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+      i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
     }
 
     i.putExtra(KMKey_DisplayKeyboardSwitcher, kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM);


### PR DESCRIPTION
Fixes #12801 and reverts #10806.

#12801 impacts a lot more users (using the keyboard picker menu from the system keyboard) than #10806 (using the Keyman system keyboard within the embedded keyman.com keyboard search)

This restores the KeyboardPickerActivity intent flag `FLAG_ACTIVITY_CLEAR_TASK` to how it's been longstanding since [Keyman for Android 2.8](https://github.com/keymanapp/keyman/blob/2b3fa63cea49f47201226d74d35ad57f25d2385e/android/KMEA/app/src/main/java/com/tavultesoft/kmea/KMManager.java#L1661)

I'll either re-open #10806 or re-open as a new issue to chase down this sprint.

## User Testing
**Setup** - Install the PR build of Keyman for Android

* **TEST_KEYBOARD_PICKER_DOESNT_REOPEN_KEYMAN** - Verifies exiting the system keyboard Keyboard Picker menu doesn't transition to Keyman app
1. Launch Keyman for Android
2. From the "Get Started" menu, enable Keyman as a system keyboard and set Keyman as the default system keyboard
3. Launch a separate app (e.g. Chrome browser)
4. Select a text area and bring up Keyman as the system keyboard
5. Long-press on the globe key to launch the Keyman Keyboard picker menu
6. Click the back arrow to dismiss the Keyman keyboard picker menu
7. Verify it returns to Chrome and not the Keyman app
