### PR TITLE
fix(mac): show and hide OSK consistently for all keyboards

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -158,7 +158,7 @@ id _lastServerWithOSKShowing = nil;
  
   os_log_debug([KMLogs lifecycleLog], "--- inputMethodActivated, kvk is non-nil: %{public}@ showOskOnActivate: %{public}@", (_kvk!=nil)?@"true":@"false", [KMInputMethodLifecycle.shared shouldShowOskOnActivate]?@"true":@"false");
 
-  if (_kvk != nil && ([KMInputMethodLifecycle.shared shouldShowOskOnActivate])) {
+  if ([KMInputMethodLifecycle.shared shouldShowOskOnActivate]) {
     os_log_debug([KMLogs oskLog], "***KMInputMethodAppDelegate inputMethodActivated, showing OSK");
     [KMSentryHelper addBreadCrumb:@"lifecycle" message:@"opening OSK on input method activation"];
     [self showOSK];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodAppDelegate.m
@@ -148,7 +148,7 @@ id _lastServerWithOSKShowing = nil;
 }
 
 /**
- * When the input method is activated, show the OSK and enable the low-level event tap
+ * When the input method is activated, enable the low-level event tap and show the OSK 
  */
 - (void)inputMethodActivated:(NSNotification *)notification {
   if (self.lowLevelEventTap && !CGEventTapIsEnabled(self.lowLevelEventTap)) {
@@ -966,8 +966,11 @@ CGEventRef eventTapFunction(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 }
 
 - (NSWindowController *)oskWindow {
-  if (!_oskWindow)
+  if (!_oskWindow) {
     _oskWindow = [[OSKWindowController alloc] initWithWindowNibName:@"OSKWindowController"];
+    
+    os_log_debug([KMLogs oskLog], "Loaded oskWindow from Nib, isVisible: %{public}@ readShowOskOnActivate: %{public}@", [_oskWindow.window isVisible]?@"true":@"false", [KMSettingsRepository.shared readShowOskOnActivate]?@"true":@"false");
+  }
   
   return _oskWindow;
 }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodLifecycle.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodLifecycle.m
@@ -278,11 +278,10 @@ typedef enum {
 }
 
 /**
- * Returns true if lifecycleState is  Active and the Settings require us to show the OSK
+ * Returns true the Settings require us to show the OSK on activation
  */
 - (BOOL)shouldShowOskOnActivate {
-  return [KMSettingsRepository.shared readShowOskOnActivate]
-    && (self.lifecycleState == Active);
+  return [KMSettingsRepository.shared readShowOskOnActivate];
 }
 
 @end

--- a/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.xib
+++ b/mac/Keyman4MacIM/Keyman4MacIM/OnScreenKeyboard/OSKWindowController.xib
@@ -14,7 +14,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Keyman" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" frameAutosaveName="KeymanOsk" animationBehavior="default" id="F0z-JX-Cv5">
+        <window title="Keyman" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="KeymanOsk" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="614" height="212"/>


### PR DESCRIPTION
Show and hide the OSK consistently, according to its saved state, for all keyboards (not just keyboards that include a KVK file).

Fixes #12928 

# User Testing

* GROUP_IPA_SIL: Test with IPA (SIL) as the active keyboard
* GROUP_EUROLATIN_SIL: Test with EuroLatin (SIL) as the active keyboard
* GROUP_KHMER_ANGKOR: Test with Khmer Angkor as the active keyboard

## TEST_OSK_REMEMBERS_SHOW_HIDE_STATE_DURING_SESSION

1. Open the OSK while using Keyman
1. Change from Keyman to another input method such as the U.S. Keyboard provided by Apple
1. Confirm that the OSK automatically hides
1. Switch back to the Keyman input method
1. Confirm that the OSK reappears

## TEST_OSK_STABILITY

1. Open the OSK while using Keyman
1. Change between text input applications with OSK open
1. Click on menus in the various applications
1. Confirm that the OSK does not flicker or disappear while switching apps or using menus

## TEST_OSK_REMAINS_HIDDEN_WITH_KEYMAN_INACTIVE

1. Open the OSK while using Keyman
1. Change from Keyman to another input method such as the U.S. Keyboard provided by Apple
1. Switch applications and click on various menus and windows
1. Confirm that the Keyman OSK never flashes on screen while Keyman is inactive

## TEST_OSK_REMEMBERS_SHOW_HIDE_STATE_AFTER_RESTART

1. Open the OSK while using Keyman
1. Restart the machine
1. Switch to the Keyman input method
1. Confirm that the OSK appears
