### PR TITLE
chore(linux): docker build: update package index before installing packages in Dockerfiles

### DIFF
--- a/resources/docker-images/android/Dockerfile
+++ b/resources/docker-images/android/Dockerfile
@@ -22,6 +22,7 @@ RUN <<EOF
     PKG_SDKMANAGER=sdkmanager
     DIR_SDK=/opt/android-sdk
   fi
+  apt-get update
   apt-get -q -y install gradle maven pandoc $PKG_SDKMANAGER jq openjdk-${JAVA_VERSION}-jdk
   sdkmanager platform-tools
   yes | sdkmanager --licenses

--- a/resources/docker-images/core/Dockerfile
+++ b/resources/docker-images/core/Dockerfile
@@ -12,8 +12,8 @@ LABEL org.opencontainers.image.url="https://github.com/keymanapp/keyman.git"
 LABEL org.opencontainers.image.title="Keyman Core Build Image"
 
 USER root
-RUN apt-get install -qy git jq llvm meson pkgconf \
-  xvfb xserver-xephyr metacity
+RUN apt-get update && \
+  apt-get install -qy git jq llvm meson pkgconf xvfb xserver-xephyr metacity
 
 # Pre-install emscripten
 USER build

--- a/resources/docker-images/linux/Dockerfile
+++ b/resources/docker-images/linux/Dockerfile
@@ -9,7 +9,8 @@ LABEL org.opencontainers.image.title="Keyman Linux Build Image"
 # Install dependencies
 ADD control /tmp/control
 # Answer 'yes' to install questions
-RUN apt-get install -qy python3 python3-setuptools python3-coverage \
+RUN apt-get update && \
+  apt-get install -qy python3 python3-setuptools python3-coverage \
       devscripts equivs libdatetime-perl lcov gcovr xvfb \
       xserver-xephyr metacity mutter dbus-x11 weston xwayland && \
   (yes | mk-build-deps --install /tmp/control) || true && \

--- a/resources/docker-images/web/Dockerfile
+++ b/resources/docker-images/web/Dockerfile
@@ -12,7 +12,8 @@ LABEL org.opencontainers.image.url="https://github.com/keymanapp/keyman.git"
 LABEL org.opencontainers.image.title="Keyman for Web Build Image"
 
 USER root
-RUN apt-get install -qy git jq xvfb xserver-xephyr metacity
+RUN apt-get update && \
+  apt-get install -qy git jq xvfb xserver-xephyr metacity
 # For playwright:
 RUN apt-get install -qy  libevent-2.1-7t64 libxslt1.1 libwoff1 libvpx9 \
   libgstreamer-plugins-bad1.0-0 libwebpdemux2 libharfbuzz-icu0 \


### PR DESCRIPTION
We need to run `apt-get update` first before trying to install packages. We did update the package index when we built the base image, but that might have been some time ago so that the index is now outdated.

@keymanapp-test-bot skip