### PR TITLE
feat(windows): add boot switch

### DIFF
--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -453,7 +453,7 @@ begin
       Exit;
   end;
 
-  if not FSilent and (FMode in [fmStart, fmSplash, fmMain, fmAbout, fmBoot]) then   // I4773
+  if not FSilent and (FMode in [fmStart, fmSplash, fmMain, fmAbout]) then   // I4773
   begin
     DoCheckTIPInstallStatus(False);
   end;

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -94,6 +94,7 @@ type
                     fmRepair,
                     fmKeepInTouch,
                     fmSettings,
+                    fmBoot,
 
                     // Commands from Keyman Engine
                     fmShowHint,
@@ -232,6 +233,7 @@ begin
         // package installation. See https://superuser.com/a/1395288/521575 and
         // https://github.com/keymanapp/keyman/issues/2467
       else if s = '-f' then FForce := True
+      else if s = '-boot' then   FMode := fmBoot
       else if s = '-c' then   FMode := fmMain
       else if s = '-m' then   FMode := fmMigrate
       else if s = '-i' then   FMode := fmInstall

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -233,7 +233,7 @@ begin
         // package installation. See https://superuser.com/a/1395288/521575 and
         // https://github.com/keymanapp/keyman/issues/2467
       else if s = '-f' then FForce := True
-      else if s = '-boot' then   FMode := fmBoot
+      else if s = '-boot' then FMode := fmBoot
       else if s = '-c' then   FMode := fmMain
       else if s = '-m' then   FMode := fmMigrate
       else if s = '-i' then   FMode := fmInstall
@@ -453,14 +453,14 @@ begin
       Exit;
   end;
 
-  if not FSilent and (FMode in [fmStart, fmSplash, fmMain, fmAbout]) then   // I4773
+  if not FSilent and (FMode in [fmStart, fmSplash, fmMain, fmAbout, fmBoot]) then   // I4773
   begin
     DoCheckTIPInstallStatus(False);
   end;
 
   // I1818 - remove start mode change
 
-  if FMode = fmStart then FIcon := 'appicon.ico'
+  if (FMode in [fmStart, fmBoot]) then FIcon := 'appicon.ico'
   else FIcon := 'cfgicon.ico';
 
   FIcon := GetDebugPath(FIcon, ExtractFilePath(ParamStr(0)) + FIcon, False);
@@ -511,6 +511,11 @@ begin
 
 ////TODO:          TUtilExecute.Shell(PChar('hh.exe mk:@MSITStore:'+ExtractFilePath(KMShellExe)+'keyman.chm::/context/keyman_usage.html'), SW_SHOWNORMAL);
 
+    fmBoot:
+      begin
+        // on boot splash should be suppressed therefore Silent = True
+        StartKeyman(False, True, FStartWithConfiguration);
+      end;
     fmStart:
       begin  // I2720
         StartKeyman(False, FSilent, FStartWithConfiguration);
@@ -701,8 +706,8 @@ begin
         // UI elements from the state machine we have bring some of logic here.
         UserCanceled := False;
         if BUpdateSM.ReadyToInstall and
-          (not FSilent and (FMode in [fmStart, fmSplash, fmMain, fmAbout, fmHelp,
-          fmShowHelp, fmSettings])) then
+          (not FSilent and (FMode in [fmStart, fmSplash, fmMain, fmAbout,
+          fmHelp, fmShowHelp, fmSettings, fmBoot])) then
         begin
           frmStartInstall := TfrmStartInstall.Create(nil);
           try

--- a/windows/src/engine/kmcomapi/util/utilkeymanoption.pas
+++ b/windows/src/engine/kmcomapi/util/utilkeymanoption.pas
@@ -323,7 +323,7 @@ begin
       if OpenKey('\'+SRegKey_WindowsRun_CU, True) then
       begin
         if FBoolValue then
-          WriteString(SRegValue_WindowsRun_Keyman, '"'+TKeymanPaths.KeymanDesktopInstallPath(TKeymanPaths.S_KMShell)+'" -s')
+          WriteString(SRegValue_WindowsRun_Keyman, '"'+TKeymanPaths.KeymanDesktopInstallPath(TKeymanPaths.S_KMShell)+'" -boot')
         else if ValueExists(SRegValue_WindowsRun_Keyman) then
           DeleteValue(SRegValue_WindowsRun_Keyman);
       end;


### PR DESCRIPTION
Fixes: #12994
This updates the registry entry run on start-up to use `-boot`, add the `-boot` switch
to initprog. The fmBoot option code allows update state machine code so that
on boot a prompt can let the user the new update is about to install.

# User Testing

## TEST_BOOT_SWITCH_POP UP

1. Install Keyman attached the PR
2. Install the Gff_Amharic 3.1.1 version keyboard.
3. Start Keyman
5. Open the Keyman Configuration dialog.
6. In the `Options tab` 
7. Navigate to the "Keyboard Layouts tab".
8. Verified that the installed keyboard shows an older version.
9. Navigate to the "Update" tab.
10. Open the "C:\Users\"yourusername"\AppData\Local\Keyman\UpdateCache" folder.
11. Open the regedit window (Computer\HKEY_CURRENT_USER\SOFTWARE\Keyman\Keyman Engine). 
         <kbd>Win</kbd><kbd>R</kbd> type regedit Go the current user key `update state` 
Press F5 to keep it refreshing it. 
The state will go to `usDownloading` to `usInstalling` at the same time keep checking the `UpdateCache` folder. 
12. Select the "update state"
13. In Keyman Configuration press the "Check for new updates" button.
14. Verified that the "UpdateCache" folder is updating or adding files)
15. On Regedit window. Verify the state changes from usUpdateAvailable --> usDownloading --> usWaitingRestart
16. Logout and Back into Windows
18. Verify a pop-up Keyman is ready to install with two buttons `install` and `close`.

## TEST_ON_STARTUP_UPDATED

I wasn't able to attach an older build but you can install the build from PR #12956 or even the latest version 17 from Keyman.com
2. Open Keyman Configuration and check `Start with Windows option`
2.  Open the regedit window 
  <kbd>Win</kbd><kbd>R</kbd> type regedit Go the current key Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\Keyman 
3. Observe that is  `"C:\Program Files (x86)\Keyman\Keyman Desktop\kmshell.exe" -s`
4. Download the Keyman for windows attached to this PR.
5. Double-click on the file to install it. Ensure you choose the install options and select the 18.0.175-alpha-test-12995 
6. The setup will ask you to reboot the computer to continue installing. Once rebooted and the installing is complete.
7. Open the regedit window 
  <kbd>Win</kbd><kbd>R</kbd> type regedit Go the current key Computer\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\Keyman 
8. Observe that is  `"C:\Program Files (x86)\Keyman\Keyman Desktop\kmshell.exe" -boot`

         