### PR TITLE
fix(web): do not simplify nul-prefixed contexts when rule-matching

### DIFF
--- a/web/src/engine/js-processor/src/kbdInterface.ts
+++ b/web/src/engine/js-processor/src/kbdInterface.ts
@@ -373,18 +373,6 @@ export default class KeyboardInterface extends KeyboardHarness {
       // Now that we have the cache...
       var subCache = cache;
       subCache.valContext = subCache.valContext.slice(0, ln);
-      for(var i=0; i < subCache.valContext.length; i++) {
-        if(subCache.valContext[i] == '\ufffe') {
-          subCache.valContext.splice(0, 1);
-          subCache.deadContext.splice(0, 1);
-        }
-      }
-
-      if(subCache.valContext.length == 0) {
-        subCache.valContext = ['\ufffe'];
-        subCache.deadContext = [];
-      }
-
       this.cachedContextEx.set(n, ln, subCache);
 
       return subCache;

--- a/web/src/test/auto/headless/engine/js-processor/engine/notany_context.tests.js
+++ b/web/src/test/auto/headless/engine/js-processor/engine/notany_context.tests.js
@@ -20,10 +20,12 @@ const device = {
   browser: 'native'
 }
 
+/** @type {KeyboardInterface} */
 let keyboardWithHarness;
 
 function runEngineRuleSet(ruleSet) {
   for(let ruleDef of ruleSet) {
+    keyboardWithHarness.resetContextCache();
     // Prepare the context!
     const ruleSeq = new RecordedKeystrokeSequence(ruleDef);
     const proctor = new NodeProctor(keyboardWithHarness, device, assert.equal);


### PR DESCRIPTION
Fixes #12987.

For some reason, when the "full/extended context" system introduced in KMW 10 was written, contexts prefixed with the `nul` sentinel would be... "simplified", for lack of a better word.  Unfortunately, this simplification also ruined nearly all ability for any rule to actually _match_ such contexts beyond a simple, single-width `nul`.  It's not clear at this point _why_ it was in place or what it sought to remedy.

Four unit tests will fail at the point of the first commit:  three of the new ones and the one that validates their base context, which highlights this.

<details><summary>A copy of my local results</summary>

```
  107 passing (54ms)
  1 pending
  4 failing

  1) Engine - Context Matching
       properly generates extended context data needed by context-matching checks below:

      AssertionError: expected [ 'a' ] to have the same ordered members as [ '\ufffe', 'a' ]
      + expected - actual

       [
      +  "￾"
         "a"
       ]
      
      at Context.<anonymous> (file:///Users/jahorton/keymanapp/keyman/web/src/test/auto/headless/engine/js-processor/engine/context.tests.js:1129:14)
      at process.processImmediate (node:internal/timers:511:21)

  2) Engine - Context Matching
       handles interactions with nul in requested context
         with context [nul, 'a'] in range:  NUL_TEST_2:

      AssertionError: Rule 1:  basic application of rule failed.: expected false to equal true
      + expected - actual

      -false
      +true
      
      at runEngineRuleSet (file:///Users/jahorton/keymanapp/keyman/web/src/test/auto/headless/engine/js-processor/engine/context.tests.js:76:14)
      at Context.<anonymous> (file:///Users/jahorton/keymanapp/keyman/web/src/test/auto/headless/engine/js-processor/engine/context.tests.js:1211:7)
      at process.processImmediate (node:internal/timers:511:21)

  3) Engine - Context Matching
       handles interactions with nul in requested context
         with context [nul, 'a', 'a'] in range:  NUL_TEST_3:

      AssertionError: Rule 1:  basic application of rule failed.: expected false to equal true
      + expected - actual

      -false
      +true
      
      at runEngineRuleSet (file:///Users/jahorton/keymanapp/keyman/web/src/test/auto/headless/engine/js-processor/engine/context.tests.js:76:14)
      at Context.<anonymous> (file:///Users/jahorton/keymanapp/keyman/web/src/test/auto/headless/engine/js-processor/engine/context.tests.js:1215:7)
      at process.processImmediate (node:internal/timers:511:21)

  4) Engine - Context Matching
       handles interactions with nul in requested context
         with context [nul, dk(1), 'a'] in range:  NUL_TEST_4:

      AssertionError: Rule 1:  basic application of rule failed.: expected false to equal true
      + expected - actual

      -false
      +true
      
      at runEngineRuleSet (file:///Users/jahorton/keymanapp/keyman/web/src/test/auto/headless/engine/js-processor/engine/context.tests.js:76:14)
      at Context.<anonymous> (file:///Users/jahorton/keymanapp/keyman/web/src/test/auto/headless/engine/js-processor/engine/context.tests.js:1219:7)
      at process.processImmediate (node:internal/timers:511:21)

```

</details>

With the second commit in place, everything checks out.  No pre-existing unit test was affected by the dropped code block, so it looks like this is the correct call.  (The one possible counter-argument is the one that failed due to being extended - it served as a test precondition validator-check, and I'm including the new tests' setups in that check.)

## User Testing

TEST_REPRO_12985: Using Keyman for Android and the `sil_greek_polytonic` keyboard from our repository, reproduce #12985.  An error message / alert should result.
1. Empty the context completely
2. Press the OSK's shift.
3. Type the key in the A position.
4. Type the key in the A position a second time.
5. Press backspace once.  The error/alert should appear.

For future reference, `sil_greek_polytonic` is currently version 1.8.1.  Once #12985 is fixed and the keyboard is updated to a newer version, this user test will no longer work.