### PR TITLE
fix(android): Remove access to MEDIA storage permissions

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -7,10 +7,6 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.VIBRATE" />
 
-  <!-- API 33 and above -->
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-
   <!-- Devices running up to Android 12L
        Starting in API level 33, this permission has no effect:
        https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE -->

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/CheckPermissions.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/CheckPermissions.java
@@ -35,8 +35,8 @@ public class CheckPermissions {
         checkPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE);
     } else {
       // API 33+
-      //https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions
-      // Manifest.permission.READ_MEDIA_AUDIO doesn't seem to be needed
+      // We had to remove these MEDIA permissions from AndroidManifest.xml so these will end up failing
+      // https://support.google.com/googleplay/android-developer/answer/14115180?hl=en
       permissionsOK = permissionsOK && checkPermission(activity, Manifest.permission.READ_MEDIA_IMAGES);
       permissionsOK = permissionsOK && checkPermission(activity, Manifest.permission.READ_MEDIA_VIDEO);
     }

--- a/android/docs/help/troubleshooting/grant-storage-permission.md
+++ b/android/docs/help/troubleshooting/grant-storage-permission.md
@@ -19,13 +19,7 @@ permission to access storage / "file and media". The screenshot below is from An
 
 ### Android 13.0+ Devices
 
-Step 1)
-Go to Android Settings.
+Due to Google Play Store's "Photo and Video Permissions policy", 
+Keyman for Android must use a system picker to browse for .kmp files from within the Keyman app.
 
-Step 2)
-Depending on your device, click "Apps" and grant Keyman permission to the following:
-  * Photos and videos --> Always allow all
-
-The screenshot below is from Android 14.0.
-
-![](../android_images/keyman-storage-permission-34b.png)
+Follow the steps in [Installing Custom Keyboards/Dictionaries](../basic/installing-custom-packages).


### PR DESCRIPTION
Fixes #12996  and undoes part of #11299 for Android 13.0+ devices

In order to comply with Google Play Store's "Photo and Video Permission policy"
https://support.google.com/googleplay/android-developer/answer/14115180?hl=en

we have to remove requesting `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` permissions from the app manifest. This limits Android 13.0+ devices to accessing downloaded .kmp files from the system picker within the Keyman for Android app.

The removal from the app manifest means the user no longer has the option to access device settings --> Privacy --> Photos and Videos permissions to grant Keyman storage permission:
![privacy - photos and videos permissions](https://github.com/user-attachments/assets/c1d961a3-7e16-40c2-b78b-05cfd82a68bc)

* Also updates the in-app help documentation

## User Testing
**Setup** - Install the PR build of "Keyman for Android on an Android 13.0+ device/emulator. This corresponds to Android API 33+. 
* From Chrome, also download the .kmp file:
https://downloads.keyman.com/keyboards/khmer_angkor/1.5/khmer_angkor.kmp
so it will be in the Chrome downloads folder.

* **TEST_KMP_INSTALL** - Verifies downloaded kmp file can install within the Keyman app
1.  Launch Keyman and dismiss the "Get Started" menu.
2. Launch "Chrome" --> Downloads --> click the khmer_angkor.kmp file
3. Verify Keyman is launched but displays the following error (unable to install kmp file)
![install from downloads failed](https://github.com/user-attachments/assets/fe62c65f-0c92-4ac7-be05-4bf851715f75)

4. Dismiss the error message
5. From Keyman --> Settings --> Install Keyboard or Dictionary --> Install from local file --> browse to the Downloads folder and select khmer_angkor.kmp
6. Follow the keyboard installation steps and verify Keyman can install the khmer_angkor keyboard package.

