### PR TITLE
fix(android): improve resource-update tool handling of host Activity's closure

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/logic/ResourcesUpdateTool.java
@@ -566,7 +566,7 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
         checkingUpdates = false;
       } else {
         lastUpdateCheck = Calendar.getInstance();
-        SharedPreferences prefs = appContext.getSharedPreferences(currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+        SharedPreferences prefs = currentContext.getSharedPreferences(currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
         editor.putLong(PREF_KEY_LAST_UPDATE_CHECK, lastUpdateCheck.getTime().getTime());
         editor.commit();

--- a/android/KMEA/app/src/main/java/com/keyman/engine/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/logic/ResourcesUpdateTool.java
@@ -520,10 +520,6 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
 
   @Override
   public void onPackageInstalled(List<Map<String, String>> keyboardsInstalled) {
-    if (!isContextAvailable()) {
-      KMLog.LogError(TAG, "onPackageInstalled where context is null.");
-    }
-
     if (! openUpdates.isEmpty() && keyboardsInstalled != null) {
       for (Map<String, String> k : keyboardsInstalled) {
         String _langid = k.get(KMManager.KMKey_LanguageID);
@@ -537,10 +533,6 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
 
   @Override
   public void onLexicalModelInstalled(List<Map<String, String>> lexicalModelsInstalled) {
-    if (!isContextAvailable()) {
-      KMLog.LogError(TAG, "onLexicalModelInstalled where context is null.");
-    }
-
     if (! openUpdates.isEmpty()) {
       for(Map<String,String> _lm:lexicalModelsInstalled) {
         String _langid = _lm.get(KMManager.KMKey_LanguageID);

--- a/android/KMEA/app/src/main/java/com/keyman/engine/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/logic/ResourcesUpdateTool.java
@@ -558,14 +558,15 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
       // TODO: make it smoother.  Documented as #11097.
       KMManager.clearKeyboardCache();
 
+      Context appContext = currentContext.getApplicationContext();
       if (failedUpdateCount > 0) {
-        BaseActivity.makeToast(currentContext, R.string.update_failed, Toast.LENGTH_SHORT);
+        BaseActivity.makeToast(appContext, R.string.update_failed, Toast.LENGTH_SHORT);
         lastUpdateCheck = Calendar.getInstance();
         updateFailed = true;
         checkingUpdates = false;
       } else {
         lastUpdateCheck = Calendar.getInstance();
-        SharedPreferences prefs = currentContext.getSharedPreferences(currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
+        SharedPreferences prefs = appContext.getSharedPreferences(currentContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
         editor.putLong(PREF_KEY_LAST_UPDATE_CHECK, lastUpdateCheck.getTime().getTime());
         editor.commit();


### PR DESCRIPTION
Fixes: #13002 

Refer to https://github.com/keymanapp/keyman/issues/13002#issuecomment-2609041009.

It is my belief that the resource update functionality is actually working without issue, though it _is_ generating Sentry event logging that is inflating our error numbers.  It doesn't hurt to polish things up a bit and ensure that any needed notifications don't trigger issues, though.

To be clear, I personally tested the new setup for toasts within the tool (depending on `appContext`) and confirmed that it should work without issue.  (I added a matching setup in the `onBackPressed()` method of `LanguagesSettingsActivity` and had it trigger 4 sec after dismissal, giving plenty of time to return to the app's top level.)

<details><summary>The test setup I used to validate this (dropdown)</summary>

    // Within LanguagesSettingsActivity.java, onBackPressed(), after the `finish()` method is called
    Handler queuer = new Handler(Looper.getMainLooper());
    Context appContext = this.context.getApplicationContext();
    queuer.postDelayed(new Runnable() {
      @Override
      public void run() {
        BaseActivity.makeToast(appContext, "Artificial delayed update (by 4 seconds)", Toast.LENGTH_SHORT);
      }
    }, 4000);

</details>

Validations for the approach used:

<details><summary>If the user stays in the app, the toast still shows up.</summary>

![Wait 4 seconds, and it shall appear...](https://github.com/user-attachments/assets/3c1ad423-5e22-4deb-9502-0e02c5e4c5c6)

</details>

<details><summary>Went back into the menu?  We're still fine.</summary>

![Dived into deeper menus?  Doesn't matter - still showing!](https://github.com/user-attachments/assets/f6013ece-faaa-49cf-8393-40b8446c538f)

</details>

<details><summary>If the user backs out of the app entirely, going to the home screen, the toast will simply be suppressed.</summary>

![Animation - suppressed toast](https://github.com/user-attachments/assets/06ac64df-daf3-426e-abcf-44dfd42b2d91)

</details>

@keymanapp-test-bot skip

Or, perhaps it _is_ possible to make a user test, but with a complicated setup?