### PR TITLE
fix(linux): correct permissions and paths in Linux docker image

### DIFF
--- a/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
+++ b/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
@@ -251,7 +251,7 @@ function _setup_ibus() {
   #shellcheck disable=SC2086
   ibus-daemon ${ARG_VERBOSE-} --daemonize --panel=disable --address=unix:abstract="${TEMP_DATA_DIR}/test-ibus" ${IBUS_CONFIG-} &> /tmp/ibus-daemon.log
   PID=$(pgrep -f "${TEMP_DATA_DIR}/test-ibus")
-  if [[ "${STANDALONE}" == "--standalone" ]]; then
+  if [[ "${STANDALONE}" == "--standalone" ]] && [[ ! "${DOCKER_RUNNING:-false}" ]]; then
     # manual test run
     echo "if kill -9 ${PID}; then ibus restart || ibus start; fi # ibus-daemon" >> "${CLEANUP_FILE}"
   else

--- a/resources/docker-images/linux/Dockerfile
+++ b/resources/docker-images/linux/Dockerfile
@@ -28,9 +28,12 @@ RUN LCOV_VERSION=$(dpkg -s lcov | grep Version | cut -d' ' -f2) && \
     rm /tmp/lcov.deb ; \
   fi
 
-RUN mkdir -p /var/run/1000 && \
-  chown build:build /var/run/1000 && \
-  echo "export XDG_RUNTIME_DIR=/var/run/1000" >> /usr/bin/bashwrapper
+RUN mkdir -p /run/user/1000 && \
+  chown build:build /run/user/1000 && \
+  chmod 700 /run/user/1000 && \
+  mkdir -p /tmp/.X11-unix && \
+  chmod 1777 /tmp/.X11-unix && \
+  echo "export XDG_RUNTIME_DIR=/run/user/1000" >> /usr/bin/bashwrapper
 
 COPY run-tests.sh /usr/bin/run-tests.sh
 

--- a/resources/docker-images/run.sh
+++ b/resources/docker-images/run.sh
@@ -36,9 +36,11 @@ run_core() {
 
 run_linux() {
   mkdir -p "${KEYMAN_ROOT}/linux/build/docker-linux"
+  mkdir -p "${KEYMAN_ROOT}/linux/keyman-system-service/build/docker-linux"
   docker run -it --privileged --rm -v "${KEYMAN_ROOT}":/home/build/build \
     -v "${KEYMAN_ROOT}/core/build/docker-core":/home/build/build/core/build \
     -v "${KEYMAN_ROOT}/linux/build/docker-linux":/home/build/build/linux/build \
+    -v "${KEYMAN_ROOT}/linux/keyman-system-service/build/docker-linux":/home/build/build/linux/keyman-system-service/build \
     -e DESTDIR=/tmp \
     keymanapp/keyman-linux-ci:default \
     "${builder_extra_params[@]}"


### PR DESCRIPTION
This change fixes two issues in the Linux docker image that showed up when running tests:
- some directories had wrong permissions
- we have to build keyman-system-service in a docker-specific directory as well so that the location of the service executable can be found when running the tests in docker

@keymanapp-test-bot skip