### PR TITLE
fix(android): restores DOMRect polyfill for old Chrome support

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -921,6 +921,9 @@ public final class KMManager {
       copyAsset(context, KMFilename_KmwCss, "", true);
       copyAsset(context, KMFilename_KmwGlobeHintCss, "", true);
       copyAsset(context, KMFilename_Osk_Ttf_Font, "", true);
+      
+      // Needed until our minimum version of Chrome is 61.0+.
+      copyAsset(context, KMFilename_JSPolyfill2, "", true);
 
       // Copy default keyboard font
       copyAsset(context, KMDefault_KeyboardFont, "", true);


### PR DESCRIPTION
Fixes #11652.

From our current `master`:

https://github.com/keymanapp/keyman/blob/486807fd7d3fe09390154837648093331f85f921/android/docs/help/about/system-requirements.md?plain=1#L11-L15

`DOMRect` has native support starting in Chrome 61.

@keymanapp-test-bot skip