### PR TITLE
fix(android): restores DOMRect polyfill for old Chrome support 🏠

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -879,6 +879,9 @@ public final class KMManager {
       copyAsset(context, KMFilename_KmwCss, "", true);
       copyAsset(context, KMFilename_KmwGlobeHintCss, "", true);
       copyAsset(context, KMFilename_Osk_Ttf_Font, "", true);
+      
+      // Needed until our minimum version of Chrome is 61.0+.
+      copyAsset(context, KMFilename_JSPolyfill2, "", true);
 
       // Copy default keyboard font
       copyAsset(context, KMDefault_KeyboardFont, "", true);


### PR DESCRIPTION
Fixes: #11652
Cherry-pick-of: #13012

@keymanapp-test-bot skip