### PR TITLE
feat(android): add breadcrumbing during package install about package file, source

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -23,6 +23,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.keyman.engine.BaseActivity;
 import com.keyman.engine.KMManager;
+import com.keyman.engine.util.KMLog;
 import com.keyman.engine.util.KMPLink;
 import com.keyman.engine.util.KMString;
 import com.keyman.engine.util.WebViewUtils;
@@ -105,6 +106,7 @@ public class KMPBrowserActivity extends BaseActivity {
           // Create intent with keyboard download link for KMAPro main activity to handle
           Intent intent = new Intent(context, MainActivity.class);
           intent.setData(downloadURI);
+          KMLog.LogBreadcrumb(TAG, "Successful keyboard search now triggering package install", true);
           startActivity(intent);
 
           // Finish activity

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -270,7 +270,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
         case "file":
           requestPermissionIntentUri = loadingIntentUri;
           if (CheckPermissions.isPermissionOK(this)) {
-            KMLog.LogBreadcrumb(TAG, "Installing local KMP: " + loadingIntentUri, true);
+            KMLog.LogBreadcrumb(TAG, "Installing local KMP: " + link, true);
             useLocalKMP(context, loadingIntentUri);
           } else {
             CheckPermissions.requestPermission(this, context);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -262,6 +262,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
 
     if (loadingIntentUri != null) {
       String scheme = loadingIntentUri.getScheme().toLowerCase();
+      final String link = loadingIntentUri.toString();
       switch (scheme) {
         // content:// Android DownloadManager
         // file:// Chrome downloads and Filebrowsers
@@ -269,6 +270,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
         case "file":
           requestPermissionIntentUri = loadingIntentUri;
           if (CheckPermissions.isPermissionOK(this)) {
+            KMLog.LogBreadcrumb(TAG, "Installing local KMP: " + loadingIntentUri, true);
             useLocalKMP(context, loadingIntentUri);
           } else {
             CheckPermissions.requestPermission(this, context);
@@ -277,14 +279,16 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
         case "http" :
         case "https" :
           // Might need to modify link like KMPBrowserActivity
-          String link = loadingIntentUri.toString();
           if (KMPLink.isKeymanInstallLink(link)) {
             loadingIntentUri = KMPLink.getKeyboardDownloadLink(link);
           }
+          // Is usually triggered by KMPBrowserActivity
+          KMLog.LogBreadcrumb(TAG, "Installing via HTTPS intent: " + link, true);
           downloadKMP(loadingIntentUri, KmpInstallMode.Full);
           break;
         case "keyman" :
           // TODO: Only accept download links from Keyman browser activities when universal links work
+          KMLog.LogBreadcrumb(TAG, "Installing via keyman-link intent: " + link, true);
           if (KMPLink.isKeymanDownloadLink(loadingIntentUri.toString())) {
 
             // Convert opaque URI to hierarchical URI so the query parameters can be parsed
@@ -296,7 +300,6 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
             loadingIntentUri = Uri.parse(builder.build().toString());
             downloadKMP(loadingIntentUri, KmpInstallMode.Full);
           } else if (KMPLink.isLegacyKeymanDownloadLink(loadingIntentUri.toString())) {
-            link = loadingIntentUri.toString();
             loadingIntentUri = KMPLink.getLegacyKeyboardDownloadLink(link);
             downloadKMP(loadingIntentUri, KmpInstallMode.Full);
           } else {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/packages/PackageProcessor.java
@@ -447,6 +447,9 @@ public class PackageProcessor {
   public String getPackageTarget(File kmpPath) {
     try {
       File tempPath = unzipKMP(kmpPath);
+      String kmpFilename = kmpPath.getName();
+
+      KMLog.LogBreadcrumb(TAG, "Determining package type for " + kmpFilename, false);
       String target = getPackageTarget(loadPackageInfo(tempPath));
       FileUtils.deleteDirectory(tempPath);
       return target;


### PR DESCRIPTION
We have a few Sentry issues for Android regarding attempts to install what _appear_ to be corrupted or malformed KMPs:

https://keyman.sentry.io/share/issue/198fe1ad9e4646a497ff7a0297b741fb/
https://keyman.sentry.io/share/issue/724a9ca295e14e0899827c0786c2d21b/

I'm sure it's a disappointment to users when this occurs, but we don't have any substantial data available to us about _which_ packages / KMPs / files this is occurring for.  So, the obvious next step:  add breadcrumbing.  This way, we can get a sense of what KMP sources are affected and which packages this occurs for.  That, in turn, should give us a better sense of why these two errors occur.

@keymanapp-test-bot skip