### PR TITLE
feat(windows): add localized button captions and form labels

### DIFF
--- a/windows/src/desktop/kmshell/kmshell.dproj
+++ b/windows/src/desktop/kmshell/kmshell.dproj
@@ -356,11 +356,9 @@
         <DCCReference Include="..\..\..\..\common\windows\delphi\general\Keyman.System.ExecutionHistory.pas"/>
         <DCCReference Include="main\Keyman.Configuration.UI.UfrmStartInstallNow.pas">
             <Form>frmInstallNow</Form>
-            <FormType>dfm</FormType>
         </DCCReference>
         <DCCReference Include="main\Keyman.Configuration.UI.UfrmStartInstall.pas">
             <Form>frmStartInstall</Form>
-            <FormType>dfm</FormType>
         </DCCReference>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
@@ -429,21 +427,27 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="bin\Win32\Debug\kmshell.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>kmshell.exe</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="bin\Win32\Debug\kmshell.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>kmshell.exe</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
                 <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
                     <Platform Name="Win32">
                         <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="bin\Win32\Debug\kmshell.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>kmshell.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="kmshell.rsm" Configuration="Debug" Class="DebugSymbols">
+                    <Platform Name="Win32">
+                        <RemoteName>kmshell.rsm</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="kmshell.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>kmshell.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>

--- a/windows/src/desktop/kmshell/kmshell.dproj
+++ b/windows/src/desktop/kmshell/kmshell.dproj
@@ -427,9 +427,9 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
+                <DeployFile LocalName="bin\Win32\Debug\kmshell.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
-                        <RemoteDir>.\</RemoteDir>
+                        <RemoteName>kmshell.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -439,15 +439,9 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="kmshell.rsm" Configuration="Debug" Class="DebugSymbols">
+                <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
                     <Platform Name="Win32">
-                        <RemoteName>kmshell.rsm</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="kmshell.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>kmshell.exe</RemoteName>
+                        <RemoteDir>.\</RemoteDir>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>

--- a/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstall.dfm
+++ b/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstall.dfm
@@ -34,7 +34,7 @@ object frmStartInstall: TfrmStartInstall
     Top = 104
     Width = 75
     Height = 25
-    Caption = 'Install'
+    Caption = 'Update'
     ModalResult = 1
     TabOrder = 0
   end

--- a/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstall.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstall.pas
@@ -26,9 +26,9 @@ type
     cmdInstall: TButton;
     cmdLater: TButton;
     lblInstallUpdate: TLabel;
+    procedure FormCreate(Sender: TObject);
   private
   public
-    constructor Create(AOwner: TComponent); override;
   end;
 
 
@@ -39,12 +39,12 @@ uses
 
 {$R *.dfm}
 
-constructor TfrmStartInstall.Create(AOwner: TComponent);
+procedure TfrmStartInstall.FormCreate(Sender: TObject);
 begin
-  inherited Create(AOwner);
+  inherited;
   cmdInstall.Caption := MsgFromId(S_Update);
   cmdLater.Caption := MsgFromId(S_Button_Close);
-  lblInstallUpdate.Caption := 'Keyman Update ready to install.';
+  lblInstallUpdate.Caption := MsgFromId(S_Ready_To_Install);
 end;
 
 end.

--- a/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstall.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstall.pas
@@ -28,12 +28,23 @@ type
     lblInstallUpdate: TLabel;
   private
   public
+    constructor Create(AOwner: TComponent); override;
   end;
 
 
 implementation
+uses
+  MessageIdentifiers,
+  MessageIdentifierConsts;
 
 {$R *.dfm}
 
+constructor TfrmStartInstall.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  cmdInstall.Caption := MsgFromId(S_Update);
+  cmdLater.Caption := MsgFromId(S_Button_Close);
+  lblInstallUpdate.Caption := 'Keyman Update ready to install.';
+end;
 
 end.

--- a/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstallNow.dfm
+++ b/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstallNow.dfm
@@ -14,14 +14,15 @@ object frmStartInstallNow: TfrmStartInstallNow
   Font.Style = []
   OldCreateOrder = False
   Position = poScreenCenter
+  OnCreate = FormCreate
   PixelsPerInch = 96
   TextHeight = 13
   object lblUpdateMessage: TLabel
-    Left = 32
-    Top = 48
-    Width = 290
-    Height = 41
-    Caption = 'Your computer will be restarted if you update now.'
+    Left = 16
+    Top = 32
+    Width = 323
+    Height = 19
+    Caption = 'Updating now will require a computer restart.'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
     Font.Height = -16
@@ -35,7 +36,7 @@ object frmStartInstallNow: TfrmStartInstallNow
     Top = 120
     Width = 75
     Height = 25
-    Caption = 'Update now'
+    Caption = 'Update'
     ModalResult = 1
     TabOrder = 0
   end

--- a/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstallNow.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstallNow.pas
@@ -26,14 +26,25 @@ type
     cmdInstall: TButton;
     cmdLater: TButton;
     lblUpdateMessage: TLabel;
+    procedure FormCreate(Sender: TObject);
   private
   public
   end;
 
 implementation
+uses
+  MessageIdentifiers,
+  MessageIdentifierConsts;
 
 {$R *.dfm}
 
 
+procedure TfrmStartInstallNow.FormCreate(Sender: TObject);
+begin
+  inherited;
+  cmdInstall.Caption := MsgFromId(S_Update);
+  cmdLater.Caption := MsgFromId(S_Button_Close);
+  lblUpdateMessage.Caption := 'Updating now will require a computer restart.';
+end;
 
 end.

--- a/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstallNow.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.Configuration.UI.UfrmStartInstallNow.pas
@@ -44,7 +44,7 @@ begin
   inherited;
   cmdInstall.Caption := MsgFromId(S_Update);
   cmdLater.Caption := MsgFromId(S_Button_Close);
-  lblUpdateMessage.Caption := 'Updating now will require a computer restart.';
+  lblUpdateMessage.Caption := MsgFromId(S_Update_Restart_Req);
 end;
 
 end.

--- a/windows/src/desktop/kmshell/xml/keyman_update.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_update.xsl
@@ -23,10 +23,10 @@
 
         <div id="update_status">
             <xsl:if test="$isNewKeymanVersionAvailable or $isNewKeyboardVersionAvailable">
-                Updates are available which will be applied when Windows is next restarted:
+              <xsl:value-of select="$locale/string[@name='S_Updates_Available']"/>
             </xsl:if>
             <xsl:if test="not($isNewKeymanVersionAvailable or $isNewKeyboardVersionAvailable)">
-                No updates are available.
+              <xsl:value-of select="$locale/string[@name='S_No_Updates_Available']"/>
             </xsl:if>
         </div>
 

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -156,9 +156,6 @@
   <!-- Introduced: 9.0.492.0 -->
   <string name="S_KeepInTouch_AccessChar" comment="Direct access to the Keep in Touch tab using alt+">T</string>
 
-
-
-
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
@@ -590,6 +587,26 @@
   <!-- String Type: PlainText -->
   <!-- Introduced: 7.0.230.0 -->
   <string name="S_Menu_Diagnostics_Diagnostics" comment="Support button submenu - performs a diagnostic report">Diagnostics</string>
+
+  <!-- Context: Configuration Dialog - Update tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 18.0.168 -->
+  <string name="S_No_Updates_Available" comment="Update tab - no updates are available">No Updates are available.</string>
+
+  <!-- Context: Configuration Dialog - Update tab -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 18.0.168 -->
+  <string name="S_Updates_Available" comment="Update tab - informs user updates are available ">Updates are available which will be applied when Windows is next restarted.</string>
+
+  <!-- Context: Configuration Dialog - Update tab pop up -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 18.0.168 -->
+  <string name="S_Update_Restart_Req" comment="Update tab pop up - warns user restart will require restart ">Updating now will require a computer restart.</string>
+
+  <!-- Context: Configuration Dialog - Update on boot pop up -->
+  <!-- String Type: PlainText -->
+  <!-- Introduced: 18.0.168 -->
+  <string name="S_Ready_To_Install" comment="Update on boot pop up - inform user update about to install">Keyman Update ready to install.</string>
 
   <!-- Context: Download Keyboard Dialog -->
   <!-- String Type: PlainText -->


### PR DESCRIPTION
Fixes: #12887 

# User Testing 

Just testing the text that appears on the forms/windows and not just a message id or some other text error.

## TEST_UPDATE_TAB_TEXT

Install the Keyman from the PR
Open the configuration and go to the updates tab observe the `No Updates are available.`
Then press the `check for updates now`.
Observe the Configuration line if updates are found now shows 
`Updates are available which will be applied when Windows is next restarted.`
Press the `Apply update now button`
Observe both the text message and both buttons have text. Then press `close` button.
Message `Updating now will require a computer restart`
Buttons `Update` and `Close`

![no_updates](https://github.com/user-attachments/assets/fbeb8458-3732-4c50-b30a-f0145cd474e5)

![updates_are_available](https://github.com/user-attachments/assets/14524f92-21e5-4b40-88b4-ecfd9c8995d4)

![updated_pop_up](https://github.com/user-attachments/assets/4bdc5f2b-23ed-40b9-afd4-c5e72a6f9dba)
