### PR TITLE
fix(web): fix handling of data: url fonts, fonts with single quotes in filename

### DIFF
--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -149,20 +149,21 @@ export class StylesheetManager {
       const format = data.substring(formatStartIndex, data.indexOf(';', formatStartIndex));
       s +=`src:url('${data}'), format('${format}');`;
     } else {
+      // Note:  encodeURI("'") == "'", but encodeURI('"') == "%22".
       if(os == DeviceSpec.OperatingSystem.iOS) {
         if(ttf != '') {
           if(this.doCacheBusting) {
             ttf = this.cacheBust(ttf);
           }
-          source = "url('"+encodeURI(ttf)+"') format('truetype')";
+          source = "url(\""+encodeURI(ttf)+"\") format('truetype')";
         }
       } else {
         if(woff != '') {
-          source = "url('"+encodeURI(woff)+"') format('woff')";
+          source = "url(\""+encodeURI(woff)+"\"') format('woff')";
         }
 
         if(ttf != '') {
-          source = "url('"+encodeURI(ttf)+"') format('truetype')";
+          source = "url(\""+encodeURI(ttf)+"\") format('truetype')";
         }
       }
 

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -150,7 +150,7 @@ export class StylesheetManager {
       const format = data.substring(formatStartIndex, data.indexOf(';', formatStartIndex));
       s +=`src:url('${data}'), format('${format}');`;
     } else {
-      // Note:  encodeURI("'") == "'", but encodeURI('"') == "%22".
+      // Note:  encodeURI("'") == "'", but encodeURI('"') == "%22" (#13018, #13022)
       if(os == DeviceSpec.OperatingSystem.iOS) {
         if(ttf != '') {
           if(this.doCacheBusting) {

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -136,8 +136,9 @@ export class StylesheetManager {
     }
 
     // Build the font-face definition according to the browser being used
-    var s='@font-face {\nfont-family:'
-      + fd.family + ';\nfont-style:normal;\nfont-weight:normal;\n';
+    // The OSK will similarly remove double-quotes from font-family names. (#13018, #13022)
+    var s='@font-face {\nfont-family:"'
+      + fd.family.replace(/\u0022/g, '') + '";\nfont-style:normal;\nfont-weight:normal;\n';
 
     // Build the font source string according to the browser,
     // but return without adding the style sheet if the required font type is unavailable

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -148,28 +148,30 @@ export class StylesheetManager {
       const formatStartIndex = 'data:font/'.length;
       const format = data.substring(formatStartIndex, data.indexOf(';', formatStartIndex));
       s +=`src:url('${data}'), format('${format}');`;
-    } else if(os == DeviceSpec.OperatingSystem.iOS) {
-      if(ttf != '') {
-        if(this.doCacheBusting) {
-          ttf = this.cacheBust(ttf);
-        }
-        source = "url('"+encodeURI(ttf)+"') format('truetype')";
-      }
     } else {
-      if(woff != '') {
-        source = "url('"+encodeURI(woff)+"') format('woff')";
+      if(os == DeviceSpec.OperatingSystem.iOS) {
+        if(ttf != '') {
+          if(this.doCacheBusting) {
+            ttf = this.cacheBust(ttf);
+          }
+          source = "url('"+encodeURI(ttf)+"') format('truetype')";
+        }
+      } else {
+        if(woff != '') {
+          source = "url('"+encodeURI(woff)+"') format('woff')";
+        }
+
+        if(ttf != '') {
+          source = "url('"+encodeURI(ttf)+"') format('truetype')";
+        }
       }
 
-      if(ttf != '') {
-        source = "url('"+encodeURI(ttf)+"') format('truetype')";
+      if(!source) {
+        return null;
       }
+  
+      s += 'src:'+source+';';
     }
-
-    if(!source) {
-      return null;
-    }
-
-    s += 'src:'+source+';';
 
     s=s+'\n}\n';
 

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -136,7 +136,8 @@ export class StylesheetManager {
     }
 
     // Build the font-face definition according to the browser being used
-    // The OSK will similarly remove double-quotes from font-family names. (#13018, #13022)
+    // The OSK will similarly remove double-quotes from font-family names and double-quote
+    // the name itself. (#13018, #13022)
     var s='@font-face {\nfont-family:"'
       + fd.family.replace(/\u0022/g, '') + '";\nfont-style:normal;\nfont-weight:normal;\n';
 


### PR DESCRIPTION
Fixes: #13018
Fixes: #13022

Our fontface-defining stylesheet format has been using single-quotes to enclose the filename.  Sadly, `encodeURI` doesn't mangle single-quotes - it mangles double-quotes instead.  So, we should adjust the quote type used there.

Fixed stylesheet:

```
@font-face {
font-family:soninke_n_ti;
font-style:normal;
font-weight:normal;
src:url("./N'tiFont.otf") format('truetype');
}
```

When using the KMP loader to diagnose the problem, I found that data URLs were handled... to a point, and then that process was unnecessarily aborted.  That was simple enough to fix with the first commit of this PR.

## User Testing

This is how the default layer of the keyboard looks in desktop-mode Keyman Engine for Web:

<img width="455" alt="Screenshot 2025-01-24 at 12 56 44 PM" src="https://github.com/user-attachments/assets/be6eb511-f901-4997-971b-5f6915f04e80" />

- TEST_ANDROID:  Using the Android test build from this PR and the `soninke_n_ti.kmp` package from https://jahorton.github.io/soninke_n_ti.kmp, verify that the keyboard loads properly and has proper characters for its font.

- TEST_IOS:  Using the Android test build from this PR and the `soninke_n_ti.kmp` package from https://jahorton.github.io/soninke_n_ti.kmp, verify that the keyboard loads properly and has proper characters for its font.