### PR TITLE
fix(android): disable early keyboard-loading when not feasible 🏠

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -42,9 +42,15 @@ function init() {
     if(starterStubStr) {
       KeymanWeb.registerStub(JSON.parse(starterStubStr));
     }
+  } catch (err) {
     // If a Java exception triggers during this time... okay, we can't
     // load a keyboard during startup.  Rely on older loading techniques.
-  } catch (err) {}
+    //
+    // Note:  no information about the Java-side error is available here.
+    if(err.message.indexOf("Java exception") < 0) {
+      throw err;
+    }
+  }
 
   keyman.init({
     'embeddingApp':device,

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -37,7 +37,14 @@ function init() {
   keyman.beepKeyboard = beepKeyboard;
 
   // Readies the keyboard stub for instant loading during the init process.
-  KeymanWeb.registerStub(JSON.parse(jsInterface.initialKeyboard()));
+  try {
+    let starterStubStr = jsInterface.initialKeyboard();
+    if(starterStubStr) {
+      KeymanWeb.registerStub(JSON.parse(starterStubStr));
+    }
+    // If a Java exception triggers during this time... okay, we can't
+    // load a keyboard during startup.  Rely on older loading techniques.
+  } catch (err) {}
 
   keyman.init({
     'embeddingApp':device,

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -74,7 +74,10 @@ public class KMKeyboardJSHandler {
     Keyboard kbd = Keyboard.getDefaultKeyboard(context);
     int index = prefs.getInt(KMManager.KMKey_UserKeyboardIndex, -1);
     if (index >= 0) {
-      kbd = KMManager.getKeyboardInfo(this.context, index);
+      // It is possible for this method to return `null` - especially
+      // if the KeyboardController instance hasn't yet been initialized.
+      Keyboard lastKbd = KMManager.getKeyboardInfo(this.context, index);
+      kbd = lastKbd != null ? lastKbd : kbd;
     }
     return kbd.toStub(context);
   }


### PR DESCRIPTION
Cherry-pick-of: #13001

## User Testing

TEST_ANDROID_GENERAL_USE:  Do some simple tests with the Keyman for Android app, verifying that the keyboard acts normally.  Just a few keystrokes should be fine.