### PR TITLE
fix(web): fix handling of fonts with single quotes in filename 🍒 🏠

### DIFF
--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -133,7 +133,8 @@ export class StylesheetManager {
     }
 
     // Build the font-face definition according to the browser being used
-    // The OSK will similarly remove double-quotes from font-family names. (#13018, #13022)
+    // The OSK will similarly remove double-quotes from font-family names and double-quote
+    // the name itself. (#13018, #13022)
     var s='@font-face {\nfont-family:"'
       + fd.family.replace(/\u0022/g, '') + '";\nfont-style:normal;\nfont-weight:normal;\n';
 

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -140,20 +140,22 @@ export class StylesheetManager {
     // but return without adding the style sheet if the required font type is unavailable
 
     // Modern browsers: use WOFF, TTF and fallback finally to SVG. Don't provide EOT
+
+    // Note:  encodeURI("'") == "'", but encodeURI('"') == "%22".
     if(os == DeviceSpec.OperatingSystem.iOS) {
       if(ttf != '') {
         if(this.doCacheBusting) {
           ttf = this.cacheBust(ttf);
         }
-        source = "url('"+encodeURI(ttf)+"') format('truetype')";
+        source = "url(\""+encodeURI(ttf)+"\") format('truetype')";
       }
     } else {
       if(woff != '') {
-        source = "url('"+encodeURI(woff)+"') format('woff')";
+        source = "url(\""+encodeURI(woff)+"\"') format('woff')";
       }
 
       if(ttf != '') {
-        source = "url('"+encodeURI(ttf)+"') format('truetype')";
+        source = "url(\""+encodeURI(ttf)+"\") format('truetype')";
       }
     }
 

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -142,7 +142,7 @@ export class StylesheetManager {
 
     // Modern browsers: use WOFF, TTF and fallback finally to SVG. Don't provide EOT
 
-    // Note:  encodeURI("'") == "'", but encodeURI('"') == "%22".
+    // Note:  encodeURI("'") == "'", but encodeURI('"') == "%22" (#13018, #13022)
     if(os == DeviceSpec.OperatingSystem.iOS) {
       if(ttf != '') {
         if(this.doCacheBusting) {

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -133,8 +133,9 @@ export class StylesheetManager {
     }
 
     // Build the font-face definition according to the browser being used
-    var s='@font-face {\nfont-family:'
-      + fd.family + ';\nfont-style:normal;\nfont-weight:normal;\n';
+    // The OSK will similarly remove double-quotes from font-family names. (#13018, #13022)
+    var s='@font-face {\nfont-family:"'
+      + fd.family.replace(/\u0022/g, '') + '";\nfont-style:normal;\nfont-weight:normal;\n';
 
     // Build the font source string according to the browser,
     // but return without adding the style sheet if the required font type is unavailable


### PR DESCRIPTION
Cherry-pick-of: #13032, but without the data URL components, as that tidbit was added during 18.0-alpha.

## User Testing

This is how the default layer of the keyboard looks in desktop-mode Keyman Engine for Web:

<img width="455" alt="Screenshot 2025-01-24 at 12 56 44 PM" src="https://github.com/user-attachments/assets/be6eb511-f901-4997-971b-5f6915f04e80" />

- TEST_ANDROID:  Using the Android test build from this PR and the `soninke_n_ti.kmp` package from https://jahorton.github.io/soninke_n_ti.kmp, verify that the keyboard loads properly and has proper characters for its font.

- TEST_IOS:  Using the Android test build from this PR and the `soninke_n_ti.kmp` package from https://jahorton.github.io/soninke_n_ti.kmp, verify that the keyboard loads properly and has proper characters for its font.