### PR TITLE
chore(developer): use langtags.json for kmc-generate language names

### DIFF
--- a/common/web/langtags/README.md
+++ b/common/web/langtags/README.md
@@ -1,0 +1,33 @@
+# Keyman langtags
+
+This package provides a wrapper for the
+[langtags.json](https://ldml.api.sil.org/langtags.json) dataset from
+https://github.com/silnrsi/langtags.
+
+This package is published in sync with Keyman, so changes in langtags may not
+propagate immediately.
+
+## Usage
+
+* `getLangtagByTag(tag)`: Find a language tag from a given tag; matches on tag,
+  tags, full properties, with a case-insensitive search. Returns unmodified
+  object from langtags.json on match.
+
+* `metadata.conformance()`: Returns script and region conformance data from
+  langtags.json
+
+* `metadata.globalvar()`: Returns global variant data from langtags.json
+
+* `metadata.phonvar()`: Returns phonetic variant data from langtags.json
+
+* `metadata.version()`: Returns version data from langtags.json
+
+* `langtags`: Raw access to the langtags.json array of objects
+
+## Background
+
+Key documents for further reading (from langtags repository):
+
+* [Overview of language tags and how this project works with them](https://github.com/silnrsi/langtags/blob/master/doc/tagging.md)
+
+* [How to use langtags.json](https://github.com/silnrsi/langtags/blob/master/doc/langtags.md)

--- a/common/web/langtags/README.md
+++ b/common/web/langtags/README.md
@@ -31,3 +31,8 @@ Key documents for further reading (from langtags repository):
 * [Overview of language tags and how this project works with them](https://github.com/silnrsi/langtags/blob/master/doc/tagging.md)
 
 * [How to use langtags.json](https://github.com/silnrsi/langtags/blob/master/doc/langtags.md)
+
+## License
+
+* Copyright ©️ 2025 SIL Global.
+* MIT License ([License text](https://github.com/keymanapp/keyman/tree/master/LICENSE.md))

--- a/common/web/langtags/src/main.ts
+++ b/common/web/langtags/src/main.ts
@@ -5,4 +5,118 @@
  */
 
 import langtags from './imports/langtags.js';
-export { langtags };
+
+// These interfaces and types correspond to https://github.com/silnrsi/langtags/blob/master/source/langtags_schema.json
+
+export type LangTagBcp47 = string; // BCP 47
+export type LangTagBcp47Variant = string; // BCP 47 variant
+export type LangTagIso639_3 = string;  // ISO639-3
+export type LangTagIso3166_1 = string; // region
+export type LangTagIso15924 = string; // script
+
+
+export interface LangTag {
+  full: string; // should be LangTagBcp47?
+  iana?: string[];
+  iso639_3?: LangTagIso639_3;
+  latnnames?: string[];
+  localname?: string;
+  localnames?: string;
+  macrolang?: LangTagBcp47;
+  name?: string;
+  names?: string[];
+  nophonvars?: boolean;
+  obsolete?: boolean;
+  region?: LangTagIso3166_1;
+  regionname?: string;
+  regions?: LangTagIso3166_1[];
+  rod?: string;
+  script?: LangTagIso15924;
+  sldr?: boolean;
+  suppress?: boolean;
+  tag?: LangTagBcp47;
+  tags?: LangTagBcp47[];
+  unwritten?: boolean;
+  variants?: LangTagBcp47Variant[];
+  windows?: LangTagBcp47;
+};
+
+export interface LangTagConformance {
+  regions: LangTagIso3166_1[];
+  scripts: LangTagIso15924[];
+  tag: '_conformance';
+};
+
+export interface LangTagGlobalVar {
+  variants: LangTagBcp47Variant[];
+  tag: '_globalvar';
+};
+
+export interface LangTagPhonVar {
+  variants: LangTagBcp47Variant[];
+  tag: '_phonvar';
+};
+
+export interface LangTagVersion {
+  api: string;
+  date: string;
+  tag: '_version';
+};
+
+/**
+ * A map of all language tags, lower cased
+ */
+const langtagsByTag: Map<string, any> = new Map<string, any>();
+
+/* metadata variables */
+let conformance: LangTagConformance = undefined;
+let globalvar: LangTagGlobalVar = undefined;
+let phonvar: LangTagPhonVar = undefined;
+let version: LangTagVersion = undefined;
+
+const metadata = {
+  conformance: () => ({ regions: [...conformance.regions], scripts: [...conformance.scripts] }),
+  globalvar: () => ({ variants: [...globalvar.variants] }),
+  phonvar: () => ({ variants: [...phonvar.variants] }),
+  version: () => ({ api: version.api, date: version.date })
+};
+
+/**
+ * Build a dictionary of language tags from langtags.json. This takes under 10ms
+ * on a reasonable laptop.
+ */
+function preinit(): void {
+  for(const tag of langtags) {
+    if(tag.tag == '_conformance') {
+      conformance = tag;
+    } else if(tag.tag == '_globalvar') {
+      globalvar = tag;
+    } else if(tag.tag == '_phonvar') {
+      phonvar = tag;
+    } else if(tag.tag == '_version') {
+      version = tag;
+    } else if(tag.full && tag.tag) {
+      langtagsByTag.set(tag.tag.toLowerCase(), tag);
+      langtagsByTag.set(tag.full.toLowerCase(), tag);
+      if(tag.tags) {
+        for(const t of tag.tags) {
+          langtagsByTag.set(t.toLowerCase(), tag);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Find a LangTag from a given tag; matches on tag, tags, full properties,
+ * with a case-insensitive search.
+ * @param tag
+ * @returns LangTag or undefined if not found
+ */
+function getLangtagByTag(tag: string): LangTag {
+  return langtagsByTag.get(tag.toLowerCase());
+}
+
+preinit();
+
+export { langtags, getLangtagByTag, metadata };

--- a/developer/src/kmc-generate/build.sh
+++ b/developer/src/kmc-generate/build.sh
@@ -13,6 +13,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 builder_describe "Build Keyman kmc-generate module" \
   "@/common/web/keyman-version" \
+  "@/common/web/langtags" \
   "@/common/web/types" \
   "@/developer/src/common/web/test-helpers" \
   "@/developer/src/common/web/utils" \

--- a/developer/src/kmc-generate/package.json
+++ b/developer/src/kmc-generate/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@keymanapp/common-types": "*",
     "@keymanapp/developer-utils": "*",
-    "@keymanapp/keyman-version": "*"
+    "@keymanapp/keyman-version": "*",
+    "@keymanapp/langtags": "*"
   },
   "devDependencies": {
     "@keymanapp/developer-test-helpers": "*",

--- a/developer/src/kmc-generate/src/basic-generator.ts
+++ b/developer/src/kmc-generate/src/basic-generator.ts
@@ -6,6 +6,7 @@
 
 import { KeymanTargets } from "@keymanapp/common-types";
 import KEYMAN_VERSION from "@keymanapp/keyman-version";
+import { getLangtagByTag } from "@keymanapp/langtags";
 import { AbstractGenerator, GeneratorArtifacts } from "./abstract-generator.js";
 import { GeneratorMessages } from "./generator-messages.js";
 
@@ -72,8 +73,12 @@ export class BasicGenerator extends AbstractGenerator {
   }
 
   private getLanguageName(tag: string) {
-    // TODO-GENERATE: probably need to use langtags.json
-    return new Intl.Locale(tag).language;
+    const langtag = getLangtagByTag(tag);
+    if(!langtag) {
+      // Fallback to Intl.Locale, probably will be undefined
+      return new Intl.Locale(tag).language;
+    }
+    return langtag.name;
   }
 
   private generateLanguageListForPackage(): string {

--- a/developer/src/kmc-generate/test/fixtures/keyman-keyboard/sample/source/sample.kps
+++ b/developer/src/kmc-generate/test/fixtures/keyman-keyboard/sample/source/sample.kps
@@ -39,7 +39,7 @@
       <ID>sample</ID>
       <Version>1.0</Version>
       <Languages>
-        <Language ID="en">en</Language>
+        <Language ID="en">English</Language>
       </Languages>
     </Keyboard>
   </Keyboards>

--- a/developer/src/kmc-generate/test/fixtures/ldml-keyboard/sample/source/sample.kps
+++ b/developer/src/kmc-generate/test/fixtures/ldml-keyboard/sample/source/sample.kps
@@ -39,7 +39,7 @@
       <ID>sample</ID>
       <Version>1.0</Version>
       <Languages>
-        <Language ID="en">en</Language>
+        <Language ID="en">English</Language>
       </Languages>
     </Keyboard>
   </Keyboards>

--- a/developer/src/kmc-generate/test/fixtures/lexical-model/sample.en.sample/source/sample.en.sample.model.kps
+++ b/developer/src/kmc-generate/test/fixtures/lexical-model/sample.en.sample/source/sample.en.sample.model.kps
@@ -36,7 +36,7 @@
       <Name>Sample Project</Name>
       <ID>sample.en.sample</ID>
             <Languages>
-        <Language ID="en">en</Language>
+        <Language ID="en">English</Language>
       </Languages>
     </LexicalModel>
   </LexicalModels>

--- a/developer/src/kmc-generate/tsconfig.json
+++ b/developer/src/kmc-generate/tsconfig.json
@@ -8,6 +8,7 @@
 
     "paths": {
       "@keymanapp/keyman-version": ["../../../common/web/keyman-version/keyman-version.mts"],
+      "@keymanapp/langtags": ["../../../common/web/langtags/src/main"],
       "@keymanapp/common-types": ["../../../common/web/types/src/main"],
     },
 
@@ -20,6 +21,7 @@
   ],
   "references": [
     { "path": "../../../common/web/keyman-version" },
+    { "path": "../../../common/web/langtags" },
     { "path": "../../../common/web/types/" },
   ]
 }

--- a/developer/src/kmc-keyboard-info/src/keyboard-info-compiler.ts
+++ b/developer/src/kmc-keyboard-info/src/keyboard-info-compiler.ts
@@ -7,7 +7,7 @@ import { minKeymanVersion } from "./min-keyman-version.js";
 import { KeyboardInfoFile, KeyboardInfoFileIncludes, KeyboardInfoFileLanguageFont, KeyboardInfoFilePlatform } from "./keyboard-info-file.js";
 import { KeymanFileTypes, KmpJsonFile, KmxFileReader, KMX, KeymanTargets } from "@keymanapp/common-types";
 import { KeyboardInfoCompilerMessages } from "./keyboard-info-compiler-messages.js";
-import { langtags } from "@keymanapp/langtags";
+import { getLangtagByTag } from "@keymanapp/langtags";
 import { CompilerCallbacks, KeymanCompiler, CompilerOptions, KeymanCompilerResult, KeymanCompilerArtifacts, KeymanCompilerArtifact, KeymanUrls, isValidEmail, validateMITLicense } from "@keymanapp/developer-utils";
 import { KmpCompiler } from "@keymanapp/kmc-package";
 
@@ -16,29 +16,6 @@ import { getFontFamily } from "@keymanapp/developer-utils";
 
 const regionNames = new Intl.DisplayNames(['en'], { type: "region" });
 const scriptNames = new Intl.DisplayNames(['en'], { type: "script" });
-const langtagsByTag: any = {};
-
-/**
- * Build a dictionary of language tags from langtags.json
- */
-
-function preinit(): void {
-  if(langtagsByTag['en']) {
-    // Already initialized, we can reasonably assume that 'en' will always be in
-    // langtags.json.
-    return;
-  }
-
-  for(const tag of langtags) {
-    langtagsByTag[tag.tag] = tag;
-    langtagsByTag[tag.full] = tag;
-    if(tag.tags) {
-      for(const t of tag.tags) {
-        langtagsByTag[t] = tag;
-      }
-    }
-  }
-}
 
 /**
  * @public
@@ -107,10 +84,6 @@ export interface KeyboardInfoCompilerResult extends KeymanCompilerResult {
 export class KeyboardInfoCompiler implements KeymanCompiler {
   private callbacks: CompilerCallbacks;
   private options: KeyboardInfoCompilerOptions;
-
-  constructor() {
-    preinit();
-  }
 
   /**
    * Initialize the compiler.
@@ -571,7 +544,7 @@ export class KeyboardInfoCompiler implements KeymanCompiler {
           }
         }
       }
-      const tag = langtagsByTag[bcp47] ?? langtagsByTag[locale.language];
+      const tag = getLangtagByTag(bcp47) ?? getLangtagByTag(locale.language);
       language.languageName = tag ? tag.name : bcp47;
       language.regionName = mapName(locale.region, regionNames);
       language.scriptName = mapName(locale.script, scriptNames);
@@ -586,7 +559,7 @@ export class KeyboardInfoCompiler implements KeymanCompiler {
         ''
       );
 
-      const resolvedScript = locale.script ?? langtagsByTag[bcp47]?.script ?? langtagsByTag[locale.language]?.script ?? undefined;
+      const resolvedScript = locale.script ?? getLangtagByTag(bcp47)?.script ?? getLangtagByTag(locale.language)?.script ?? undefined;
       if(commonScript === null) {
         commonScript = resolvedScript;
       } else {
@@ -648,10 +621,3 @@ export class KeyboardInfoCompiler implements KeymanCompiler {
   }
 
 }
-
-/**
- * these are exported only for unit tests, do not use
- */
-export const unitTestEndpoints = {
-  langtagsByTag,
-};

--- a/developer/src/kmc-keyboard-info/test/keyboard-info-compiler.tests.ts
+++ b/developer/src/kmc-keyboard-info/test/keyboard-info-compiler.tests.ts
@@ -3,8 +3,8 @@ import { assert } from 'chai';
 import 'mocha';
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { makePathToFixture } from './helpers/index.js';
-import { KeyboardInfoCompiler, KeyboardInfoCompilerResult, unitTestEndpoints } from '../src/keyboard-info-compiler.js';
-import { langtags } from "@keymanapp/langtags";
+import { KeyboardInfoCompiler, KeyboardInfoCompilerResult } from '../src/keyboard-info-compiler.js';
+import { getLangtagByTag, langtags } from "@keymanapp/langtags";
 import { KmpCompiler, KmpCompilerOptions } from '@keymanapp/kmc-package';
 import { KMX, KeymanFileTypes, KeymanTargets, KmpJsonFile } from '@keymanapp/common-types';
 import { CompilerCallbacks } from '@keymanapp/developer-utils';
@@ -114,10 +114,10 @@ describe('keyboard-info-compiler', function () {
     const compiler = new KeyboardInfoCompiler(); // indirectly call preinit()
     assert.isNotNull(compiler);
     const en_langtag = langtags.find(({ tag }) => tag === 'en');
-    assert.deepEqual((<any>unitTestEndpoints.langtagsByTag)['en'], en_langtag);
-    assert.deepEqual((<any>unitTestEndpoints.langtagsByTag)['en-Latn-US'], en_langtag);
-    assert.deepEqual((<any>unitTestEndpoints.langtagsByTag)['en-Latn'], en_langtag);
-    assert.deepEqual((<any>unitTestEndpoints.langtagsByTag)['en-US'], en_langtag);
+    assert.deepEqual(getLangtagByTag('en'), en_langtag);
+    assert.deepEqual(getLangtagByTag('en-latn-us'), en_langtag);
+    assert.deepEqual(getLangtagByTag('en-latn'), en_langtag);
+    assert.deepEqual(getLangtagByTag('en-us'), en_langtag);
   });
 
   it('check init initialises KeyboardInfoCompiler correctly', async function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -785,7 +785,8 @@
       "dependencies": {
         "@keymanapp/common-types": "*",
         "@keymanapp/developer-utils": "*",
-        "@keymanapp/keyman-version": "*"
+        "@keymanapp/keyman-version": "*",
+        "@keymanapp/langtags": "*"
       },
       "devDependencies": {
         "@keymanapp/developer-test-helpers": "*",


### PR DESCRIPTION
Also fills out the remaining functionality in @keymanapp/langtags.

Fixes: #13045

@keymanapp-test-bot skip