### PR TITLE
fix(web): keyboard query error states should always provide informative Error objects, reports

### DIFF
--- a/web/src/engine/keyboard-storage/src/cloud/queryEngine.ts
+++ b/web/src/engine/keyboard-storage/src/cloud/queryEngine.ts
@@ -333,11 +333,6 @@ export default class CloudQueryEngine extends EventEmitter<EventMap> {
       return await this.keymanCloudRequest(cmd,false);
     } catch(err) {
       // We don't have keyboard info for this ErrorStub
-      if(err instanceof Error) {
-        console.error(`Error for request command-string ${cmd}: ${err.message}\n  ${err.stack}`);
-      } else {
-        console.error(err);
-      }
       return Promise.reject(err);
     }
   }

--- a/web/src/engine/keyboard-storage/src/cloud/queryEngine.ts
+++ b/web/src/engine/keyboard-storage/src/cloud/queryEngine.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'eventemitter3';
 
 import { PathConfiguration } from 'keyman/engine/interfaces';
 
-import { default as KeyboardStub, ErrorStub, KeyboardAPISpec, mergeAndResolveStubPromises } from '../keyboardStub.js';
+import { default as KeyboardStub, ErrorStub, KeyboardAPISpec } from '../keyboardStub.js';
 import { LanguageAPIPropertySpec, ManagedPromise, Version } from 'keyman/engine/keyboard';
 import CloudRequesterInterface from './requesterInterface.js';
 
@@ -310,7 +310,7 @@ export default class CloudQueryEngine extends EventEmitter<EventMap> {
    * @param   x  keyboard name string or keyboard metadata JSON object
    * @returns resolved or rejected promise with merged array of stubs.
    */
-  async fetchCloudStubs(cloudList: string[]): Promise<(KeyboardStub|ErrorStub)[]> {
+  async fetchCloudStubs(cloudList: string[]): Promise<(KeyboardStub)[]> {
     // // Ensure keymanweb is initialized before continuing to add keyboards
     // if(!this.keymanweb.initialized) {
     //   await this.deferment;
@@ -328,17 +328,17 @@ export default class CloudQueryEngine extends EventEmitter<EventMap> {
       comma=',';
     }
 
-    let errorStubs: ErrorStub[] = [];
     // Request keyboard metadata from the Keyman Cloud keyboard metadata server
     try {
-      let result: (KeyboardStub|ErrorStub)[]|Error = await this.keymanCloudRequest(cmd,false);
-      return mergeAndResolveStubPromises(result, errorStubs);
+      return await this.keymanCloudRequest(cmd,false);
     } catch(err) {
       // We don't have keyboard info for this ErrorStub
-      console.error(err);
-      let stub: ErrorStub = {error: err};
-      errorStubs.push(stub);
-      return Promise.reject(errorStubs);
+      if(err instanceof Error) {
+        console.error(`Error for request command-string ${cmd}: ${err.message}\n  ${err.stack}`);
+      } else {
+        console.error(err);
+      }
+      return Promise.reject(err);
     }
   }
 }

--- a/web/src/engine/keyboard-storage/src/keyboardRequisitioner.ts
+++ b/web/src/engine/keyboard-storage/src/keyboardRequisitioner.ts
@@ -18,6 +18,7 @@ import {
   toUnprefixedKeyboardId as unprefixed
  } from "./index.js";
 import { default as CloudRequesterInterface } from "./cloud/requesterInterface.js";
+import { rejectErrorStubs } from "./keyboardStub.js";
 
 class CloudRequestEntry {
   id: string;
@@ -287,7 +288,7 @@ export default class KeyboardRequisitioner {
 
     if(cmd == '') {
       // No command so return errors
-      return Promise.reject(errorStubs);
+      return rejectErrorStubs(errorStubs);
     }
 
     return this.cloudQueryEngine.keymanCloudRequest('&keyboardid='+cmd, false).then(async (result) => {
@@ -305,7 +306,7 @@ export default class KeyboardRequisitioner {
       console.error(err);
       let stub: ErrorStub = {error: err};
       errorStubs.push(stub);
-      return Promise.reject(errorStubs);
+      return rejectErrorStubs(errorStubs);
     });
   }
 

--- a/web/src/engine/keyboard-storage/src/keyboardStub.ts
+++ b/web/src/engine/keyboard-storage/src/keyboardStub.ts
@@ -205,12 +205,22 @@ export interface ErrorStub {
   error: Error;
 }
 
+export function rejectErrorStubs(errorStubs: ErrorStub[]) {
+  if(errorStubs.length > 1) {
+    const msgs = errorStubs.map((entry) => `${entry.error.message}:\n  ${entry.error.stack ?? ''}`);
+    return Promise.reject(new Error(msgs.join('\n\n')));
+  } else {
+    // The messages for errors we'd return here should already include data about their triggering request.
+    return Promise.reject(errorStubs[0].error);
+  }
+}
+
 export function mergeAndResolveStubPromises(keyboardStubs: (KeyboardStub|ErrorStub)[], errorStubs: ErrorStub[]) :
   Promise<(KeyboardStub|ErrorStub)[]> {
   if (errorStubs.length == 0) {
     return Promise.resolve(keyboardStubs);
   } if (keyboardStubs.length == 0) {
-    return Promise.reject(errorStubs);
+    return rejectErrorStubs(errorStubs);
   } else {
     // Merge this with errorStubs
     let result: (KeyboardStub|ErrorStub)[] = keyboardStubs;

--- a/web/src/test/manual/web/sentry-integration/errorhdr.js
+++ b/web/src/test/manual/web/sentry-integration/errorhdr.js
@@ -20,7 +20,7 @@ function loadKeyboards() {
     filename:'./missing_file.js' // Intentional error - the file doesn't exist, so the <script> tag will raise an error event.
     });   
   
-// Insert a keyboard that will generate a timing error.  
+  // Insert a keyboard that is unparsable
   kmw.addKeyboards({id:'unparsable',name:'non-parsable',
     languages:{
       id:'lo',name:'debugging',region:'Asia',

--- a/web/src/test/manual/web/sentry-integration/errorhdr.js
+++ b/web/src/test/manual/web/sentry-integration/errorhdr.js
@@ -4,39 +4,49 @@
     This script is designed to test KeymanWeb error message handling.
 */
 
-  function loadKeyboards() 
-  { 
-    var kmw=keyman;
+function loadKeyboards() { 
+  var kmw=keyman;
+  
+  // We start by adding a keyboard correctly.  It's best to include a 'control' in our experiment.
+  kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+    filename:'../us-1.0.js'});
     
-    // We start by adding a keyboard correctly.  It's best to include a 'control' in our experiment.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
-      filename:'../us-1.0.js'});
-      
-    // Insert a keyboard that cannot be found.
-    kmw.addKeyboards({id:'lao_2008_basic',name:'wrong-filename',
-      languages:{
-        id:'lo',name:'debugging',region:'Asia',
-        font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
-        },
-      filename:'./missing_file.js' // Intentional error - the file doesn't exist, so the <script> tag will raise an error event.
-      });   
-	  
-	// Insert a keyboard that will generate a timing error.  
-    kmw.addKeyboards({id:'unparsable',name:'non-parsable',
-      languages:{
-        id:'lo',name:'debugging',region:'Asia',
-        font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
-        },
-      filename:'./unparsable.js' // Intentional error - the file has no parsable keyboard, so while the <script> tag will load,
-        // registration will fail.
-      });
+  // Insert a keyboard that cannot be found.
+  kmw.addKeyboards({id:'lao_2008_basic',name:'wrong-filename',
+    languages:{
+      id:'lo',name:'debugging',region:'Asia',
+      font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
+      },
+    filename:'./missing_file.js' // Intentional error - the file doesn't exist, so the <script> tag will raise an error event.
+    });   
+  
+// Insert a keyboard that will generate a timing error.  
+  kmw.addKeyboards({id:'unparsable',name:'non-parsable',
+    languages:{
+      id:'lo',name:'debugging',region:'Asia',
+      font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
+      },
+    filename:'./unparsable.js' // Intentional error - the file has no parsable keyboard, so while the <script> tag will load,
+      // registration will fail.
+    });
 
-	// Insert a keyboard that will generate a timing error.  
-    kmw.addKeyboards({id:'timeout',name:'timeout',
-      languages:{
-        id:'lo',name:'debugging',region:'Asia',
-        font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
-        },
-      filename:'./timeout.js' // Intentional (simulated) error - the file never loads, simulating a server timeout.
-      }); 
-  }
+// Insert a keyboard that will generate a timing error.  
+  kmw.addKeyboards({id:'timeout',name:'timeout',
+    languages:{
+      id:'lo',name:'debugging',region:'Asia',
+      font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
+      },
+    filename:'./timeout.js' // Intentional (simulated) error - the file never loads, simulating a server timeout.
+    }); 
+}
+
+function badStubRequest(entry) {
+  switch(entry) {
+    case 1:
+      kmw.addKeyboards('1nval1d5tub@reque5t'); 
+      break;
+    case 2:
+      keyman.addKeyboardsForLanguage(['PigLatn','1337sp34k']);
+      break;
+  } 
+}

--- a/web/src/test/manual/web/sentry-integration/index.html
+++ b/web/src/test/manual/web/sentry-integration/index.html
@@ -72,6 +72,10 @@
     <h3>or in this input field:</h3>
     <input class='test' value='' placeholder='or here'/>
 
+    <h3>Trigger stub registration errors:</h3>
+    <input type='button' id='btnStub1' onclick='badStubRequest(1);' value='Request single stub' />
+    <input type='button' id='btnStub2' onclick='badStubRequest(2);' value='Request stubs for two invalid languages' />
+
     <!--  The following elements show how the language menu can be dynamically extended at any time -->
     <h3>Add a keyboard by keyboard name:</h3>
     <input type='input' id='kbd_id1' class='kmw-disabled' onkeypress="clickOnEnter(event,1);"/>


### PR DESCRIPTION
Fixes: #13043.

This PR makes sure that when errors occur during Cloud API use, we always get:
1. actual error objects
2. a bit of data about the keyboard and/or request

Some example cases I triggered during development:
- https://keyman.sentry.io/share/issue/b312db1563fc4d978d7b6fe45a4ec0a2/
    - Request info is "breadcrumbed" on this one. 
- https://keyman.sentry.io/share/issue/561abbc6c6094335b06f5154e59fbe47/
- https://keyman.sentry.io/share/issue/9019333c56574ab9aaddbebd3aafcda6/
- https://keyman.sentry.io/share/issue/546fae38088d47d4a587b4af91d0097a/

@keymanapp-test-bot skip