### PR TITLE
fix(linux): remove unnecessary files from source tarball

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -17,7 +17,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 BASEDIR=$(pwd)
 
-if [[ ! -z ${1+x} ]] && [ "$1" == "origdist" ]; then
+if [[ ! -z ${1+x} ]] && [[ "$1" == "origdist" ]]; then
     create_origdist=1
     shift
 fi
@@ -30,62 +30,69 @@ cp -a debian ../
 cd ..
 echo "3.0 (native)" > debian/source/format
 dch keyman --newversion "${VERSION}" --force-bad-version --nomultimaint
-dpkg-source --tar-ignore=*~ \
-    --tar-ignore=./.git \
-    --tar-ignore=./.gitattributes \
-    --tar-ignore=./.gitignore \
-    --tar-ignore=experiments \
-    --tar-ignore=debian \
-    --tar-ignore=./.github \
-    --tar-ignore=./.vscode \
-    --tar-ignore=./android \
-    --tar-ignore=./.devcontainer \
-    --tar-ignore=./artifacts \
-    \
-    --tar-ignore=./common/models \
-    --tar-ignore=./common/resources \
-    --tar-ignore=./common/schemas \
-    --tar-ignore=./common/test/keyboards/build.* \
-    --tar-ignore=./common/test/resources \
-    --tar-ignore=./common/web \
-    --tar-ignore=./common/windows \
-    \
-    --tar-ignore=./core/build \
-    --tar-ignore=./developer \
-    --tar-ignore=./docs \
-    --tar-ignore=./ios \
-    --tar-ignore=./linux/keyman-config/keyman_config/version.py \
-    --tar-ignore=./linux/keyman-config/buildtools/build-langtags.py \
-    --tar-ignore=__pycache__ \
-    --tar-ignore=./linux/docs/help \
-    --tar-ignore=./mac \
-    --tar-ignore=node_modules \
-    --tar-ignore=./oem \
-    --tar-ignore=./linux/build \
-    --tar-ignore=./linux/builddebs \
-    --tar-ignore=./linux/ibus-keyman/build \
-    --tar-ignore=./linux/keyman-system-service/build \
-    --tar-ignore=./resources/devbox \
-    --tar-ignore=./resources/environment.sh \
-    --tar-ignore=./resources/git-hooks \
-    --tar-ignore=./resources/scopes \
-    --tar-ignore=./resources/build/*.lua \
-    --tar-ignore=./resources/build/jq* \
-    --tar-ignore=./results \
-    --tar-ignore=./tmp \
-    --tar-ignore=./web \
-    --tar-ignore=./windows \
-    --tar-ignore=keyman_1* \
-    --tar-ignore=dist \
-    --tar-ignore=VERSION \
-    \
-    -Zgzip -b .
+
+# Create the tarball
+# Note: the files end up in subdirectories under `keyman`, so we can
+# include that when matching files and directories to ignore.
+dpkg-source \
+  --tar-ignore=*~ \
+  --tar-ignore=.git \
+  --tar-ignore=.gitattributes \
+  --tar-ignore=.gitignore \
+  --tar-ignore=experiments \
+  --tar-ignore=debian \
+  --tar-ignore=.github \
+  --tar-ignore=.vscode \
+  --tar-ignore=.devcontainer \
+  --tar-ignore=__pycache__ \
+  --tar-ignore=node_modules \
+  --tar-ignore=keyman_1* \
+  --tar-ignore=dist \
+  --tar-ignore=VERSION \
+  \
+  --tar-ignore=keyman/android \
+  --tar-ignore=keyman/artifacts \
+  \
+  --tar-ignore=keyman/common/mac \
+  --tar-ignore=keyman/common/models \
+  --tar-ignore=keyman/common/resources \
+  --tar-ignore=keyman/common/schemas \
+  --tar-ignore=keyman/common/test/keyboards/build.* \
+  --tar-ignore=keyman/common/test/resources \
+  --tar-ignore=keyman/common/web \
+  --tar-ignore=keyman/common/windows \
+  \
+  --tar-ignore=keyman/core/build \
+  --tar-ignore=keyman/developer \
+  --tar-ignore=keyman/docs \
+  --tar-ignore=keyman/ios \
+  --tar-ignore=keyman/linux/build \
+  --tar-ignore=keyman/linux/builddebs \
+  --tar-ignore=keyman/linux/docs/help \
+  --tar-ignore=keyman/linux/ibus-keyman/build \
+  --tar-ignore=keyman/linux/keyman-config/keyman_config/version.py \
+  --tar-ignore=keyman/linux/keyman-config/buildtools/build-langtags.py \
+  --tar-ignore=keyman/linux/keyman-system-service/build \
+  --tar-ignore=keyman/mac \
+  --tar-ignore=keyman/oem \
+  --tar-ignore=keyman/resources/devbox \
+  --tar-ignore=keyman/resources/environment.sh \
+  --tar-ignore=keyman/resources/git-hooks \
+  --tar-ignore=keyman/resources/scopes \
+  --tar-ignore=keyman/resources/build/*.lua \
+  --tar-ignore=keyman/resources/build/jq* \
+  --tar-ignore=keyman/results \
+  --tar-ignore=keyman/tmp \
+  --tar-ignore=keyman/web \
+  --tar-ignore=keyman/windows \
+  \
+  -Zgzip -b .
 mv ../keyman_"${VERSION}".tar.gz linux/dist/keyman-"${VERSION}".tar.gz
 echo "3.0 (quilt)" > debian/source/format
-cd "$BASEDIR"
+cd "${BASEDIR}"
 
 # create orig.tar.gz
-if [ ! -z "${create_origdist+x}" ]; then
+if [[ ! -z "${create_origdist+x}" ]]; then
     cd dist
     pkgvers="keyman-$VERSION"
     tar xfz keyman-"${VERSION}".tar.gz


### PR DESCRIPTION
PR #12642 tried to fix creating the source tarball so that it didn't ignore files we need. However, that now included way to many files. This change fixes this and results in a smaller tarball again.

Fixes: #13010

@keymanapp-test-bot skip