### PR TITLE
fix(web): disabled correction state should prevent predictive corrections

### DIFF
--- a/web/src/engine/main/src/headless/languageProcessor.ts
+++ b/web/src/engine/main/src/headless/languageProcessor.ts
@@ -304,7 +304,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     }
 
     let alternates = transcription.alternates;
-    if(!alternates || alternates.length == 0) {
+    if(!this.mayCorrect || !alternates || alternates.length == 0) {
       alternates = [{
         sample: transcription.transform,
         p: 1.0

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/distance-modeler.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/distance-modeler.ts
@@ -251,6 +251,10 @@ export class SearchNode {
 class SearchSpaceTier {
   correctionQueue: PriorityQueue<SearchNode>;
   processed: SearchNode[] = [];
+
+  /**
+   * Indicates the depth searched, in terms of number of inputs, by this tier of the search space.
+   */
   index: number;
 
   constructor(instance: SearchSpaceTier);
@@ -474,6 +478,12 @@ export class SearchSpace {
 
   increaseMaxEditDistance() {
     this.tierOrdering.forEach(function(tier) { tier.increaseMaxEditDistance() });
+  }
+
+  get correctionsEnabled() {
+    // When corrections are disabled, the Web engine will only provide individual Transforms
+    // for an input, not a distribution.  No distributions means we shouldn't do corrections.
+    return !!this.inputSequence.find((distribution) => distribution.length > 1);
   }
 
   addInput(inputDistribution: Distribution<Transform>) {

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -258,6 +258,29 @@ export async function correctAndEnumerate(
   let bestCorrectionCost: number;
   let correctionPredictionMap: Record<string, Distribution<Suggestion>> = {};
 
+  // If corrections are not enabled, bypass the correction search aspect entirely.
+  // No need to 'search' - just do a direct lookup.
+  if(!searchSpace.correctionsEnabled) {
+    const predictionRoot = {
+      sample: {
+        insert: wordbreak(postContext),  // insert correction string
+        deleteLeft: deleteLeft,
+        id: inputTransform.id // The correction should always be based on the most recent external transform/transcription ID.
+      },
+      p: 1.0
+    };
+
+    let predictions = predictFromCorrections(lexicalModel, [predictionRoot], context);
+    predictions.forEach((entry) => entry.preservationTransform = contextChangeAnalysis.preservationTransform);
+
+    // Only one 'correction' / prediction root is allowed - the actual text.
+    return {
+      postContextState: postContextState,
+      rawPredictions: predictions
+    }
+  }
+
+  // Only run the correction search when corrections are enabled.
   for await(let match of searchSpace.getBestMatches(timer)) {
     // Corrections obtained:  now to predict from them!
     const correction = match.matchString;

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/worker-model-compositor.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/worker-model-compositor.js
@@ -20,6 +20,51 @@ describe('ModelCompositor', function() {
         {wordBreaker: wordBreakers.default}
       );
 
+      it('does not correct when corrections are disabled', async function() {
+        const compositor = new ModelCompositor(plainModel, true);
+
+        // Corrections are disabled when all inputs provided for a token are single-transform.
+        const suggestions1 = await compositor.predict({
+          insert: "x", // Invalid due to the inserted transform; context root is fine.
+          deleteLeft: 0
+        }, {
+          // Context + insert needs to match a word in the model; there is no matching word here.
+          left: "the app", startOfBuffer: true, endOfBuffer: true
+        });
+
+        assert.isEmpty(suggestions1.filter((entry) => entry.tag != 'keep'));
+        assert.isOk(suggestions1.find((entry) => entry.tag == 'keep'));
+
+        const suggestions2 = await compositor.predict({
+          insert: "l",
+          deleteLeft: 0
+        }, {
+          // Context + insert needs to match a word in the model; there is no matching word here.
+          // Invalid due to the existing context root.
+          left: "the apl", startOfBuffer: true, endOfBuffer: true
+        });
+
+        assert.isEmpty(suggestions2.filter((entry) => entry.tag != 'keep'));
+        assert.isOk(suggestions2.find((entry) => entry.tag == 'keep'));
+      });
+
+      it('may predict when corrections are disabled', async function() {
+        const compositor = new ModelCompositor(plainModel, true);
+
+        // Corrections are disabled when all inputs provided for a token are single-transform.
+        const suggestions = await compositor.predict({
+          insert: "l",
+          deleteLeft: 0
+        }, {
+          // Context + insert needs to match a word in the model; 'applied' is a valid entry.
+          left: "the app", startOfBuffer: true, endOfBuffer: true
+        });
+
+        assert.isNotEmpty(suggestions.filter((entry) => entry.tag != 'keep'));
+        assert.isOk(suggestions.find((entry) => entry.tag == 'keep'));
+        assert.isOk(suggestions.find((entry) => entry.displayAs == 'applied'));
+      });
+
       it('generates suggestions with expected properties', async function() {
         let compositor = new ModelCompositor(plainModel, true);
         let context = {
@@ -177,7 +222,9 @@ describe('ModelCompositor', function() {
           insert: "l",
           deleteLeft: 0
         }, {
-          left: "the apl", startOfBuffer: true, endOfBuffer: true
+          // Context + insert needs to match a word in the model; corrections are off with a single-transform
+          // input.
+          left: "the app", startOfBuffer: true, endOfBuffer: true
         });
 
         assert.notEqual(compositor.activeTimer, firstTimer);


### PR DESCRIPTION
Fixes: #12214.

There were a couple of big key issues in the way of a properly-working "enable/disable corrections" toggle:

1. The worker has literally no access to the state of that value at present.
2. The correction-search is always run for each predict() call.

To address the first point, this PR establishes a state for the worker that allows it to reasonably _infer_ the value of the toggle.  "If all inputs for a word lack fat-finger distribution data, then we don't correct."  From there, the key is then to ensure that the worker doesn't _get_ fat-finger distribution data when the correction state is set to disabled.  We can enforce this within the Web engine's `LanguageProcessor` class.

Note that this also means that when corrections _are_ enabled, we will not offer corrections after a backspace until a new keystroke is received.  Backspace triggers a wipe of pre-existing fat-finger data, satisfying the corrections-disabled inference check.  This causes the system to take what's left immediately after the user stops backspacing as gospel.  We already kind of _did_ want this behavior anyway, so I don't believe this to be too concerning.

To address the second point, this PR adds new code - serving as a `guard` block - that checks for the inferred "may correct" state.  If disabled, the `guard` activates and bypasses the correction-search entirely by instead performing a simple, efficient, and direct lookup against the current context.

Should the user pause what they're doing mid-word, enter the settings menu, and toggle corrections on or off, it may take erasing the word or typing a new word for the effects to kick in - assuming our mobile apps didn't already reset the page or do a context reset.  (Which I believe they actually do.) Even then, that's probably enough of an edge case to allow things to work nicely here.

## User Testing

**TEST_ANDROID_NO_CORRECTIONS**:  Using the Keyman for Android app, verify that when the "Enable corrections" toggle is set to off, no corrections of typed text are offered by the prediction banner.

**TEST_IOS_NO_CORRECTIONS**: Using the Keyman for iPhone and iPad app, verify that when the "Enable corrections" toggle is set to off, no corrections of typed text are offered by the prediction banner.

With English, a great example input is `triu` - the only offerings should be `triumph` and `triumphs`.  With corrections enabled, alternatives like `trouble` should start to appear.  (Note the correction of the `i` to an `o`.)