### PR TITLE
fix(web): disabled autoaccept should not autohighlight suggestions

### DIFF
--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -176,7 +176,6 @@ export class BannerSuggestion {
     }
 
     this.currentWidth = this.collapsedWidth;
-    this.highlight(suggestion?.autoAccept);
     this.updateLayout();
   }
 
@@ -557,13 +556,10 @@ export class SuggestionBanner extends Banner {
 
       const autoselection = this._predictionContext.selected;
       this._predictionContext.selected = null;
-      if(autoselection) {
-        this.options.forEach((entry) => {
-          if(entry.suggestion == autoselection) {
-            entry.highlight(false);
-          };
-        });
-      }
+      // Always clear pre-existing selections when a new banner input/gesture starts.
+      this.options.forEach((entry) => {
+          entry.highlight(false);
+      });
 
       this.scrollState = new BannerScrollState(source.currentSample, this.container.scrollLeft);
       const suggestion = source.baseItem;
@@ -753,6 +749,9 @@ export class SuggestionBanner extends Banner {
       if(suggestions.length > i) {
         const suggestion = suggestions[i];
         d.update(suggestion, optionFormat);
+        if(this.predictionContext.selected == suggestion) {
+          d.highlight(true);
+        }
       } else {
         d.update(null, optionFormat);
       }


### PR DESCRIPTION
I've written this PR in such a way that it should be fully compatible with #12893 when merged in.

There was no pre-existing issue for it, but I just realized that we still had a tiny bit of active autocorrect behavior enabled on `master` - the suggestion we _would_ autocorrect to was being highlighted.  It wouldn't trigger, but it could lead to "fun" cases where that suggestion _and_ a touched suggestion would both be highlighted at the same time.

Part of me... actually kind of liked having the autocorrect "hint" active, but this was definitely not intended.

## User Testing

TEST_ANDROID_AUTOHIGHLIGHT:  Using Keyman for Android and `sil_euro_latin` set to English, type `troub` and verify that `trouble` is not automatically highlighted.