### PR TITLE
fix(common): push branch when creating PR in version history writer

### DIFF
--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -192,7 +192,7 @@ if [ "$action" == "commit" ]; then
       git commit -m "$message (history cherry-pick to master)"
       # TODO: once we are sure this is stable, add `-l auto` to get the "auto:"
       # label
-      hub pull-request -f --no-edit
+      hub pull-request -fp --no-edit
     fi
 
     # Return to our best working branch

--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -192,7 +192,7 @@ if [ "$action" == "commit" ]; then
       git commit -m "$message (history cherry-pick to master)"
       # TODO: once we are sure this is stable, add `-l auto` to get the "auto:"
       # label
-      hub pull-request -f --no-edit -b master
+      hub pull-request -f --no-edit
     fi
 
     # Return to our best working branch


### PR DESCRIPTION
Also remove unnecessary `-b master` because PR will automatically target master anyway

Fixes: #13078

@keymanapp-test-bot skip