### PR TITLE
fix(android): Catch when WebView provider unavailable

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboard.java
@@ -32,6 +32,7 @@ import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.AndroidRuntimeException;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -110,7 +111,14 @@ final class KMKeyboard extends WebView {
 
   public String specialOskFont = "";
 
-  public KMKeyboard(Context context) {
+  /**
+   * Constructor for KMKeyboard.
+   * If System WebView not installed/enabled, will throw AndroidRuntimeException.
+   * Can't catch the exception here because super(context) must be the first line.
+   * @param context
+   * @throws AndroidRuntimeException
+   */
+  public KMKeyboard(Context context) throws AndroidRuntimeException {
     super(context);
     this.context = context;
     this.keyboardType = KeyboardType.KEYBOARD_TYPE_INAPP;

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -127,9 +127,13 @@
     <string name="fatal_keyboard_error" comment="Fatal keyboard error (keyboard ID::packageID for language). Will load default keyboard">
       Fatal keyboard error with %1$s:%2$s for %3$s language. Loading default keyboard.</string>
 
-  <!-- Context: Fatal keyboard error.  -->
-  <string name="fatal_keyboard_error_short" comment="Error in keyboard (keyboard ID::packageID for language).">
+    <!-- Context: Fatal keyboard error.  -->
+    <string name="fatal_keyboard_error_short" comment="Error in keyboard (keyboard ID::packageID for language).">
       Error in keyboard %1$s:%2$s for %3$s language.</string>
+
+    <!-- Context: Fatal keyboard error. System WebView not installed/enabled -->
+    <string name="webview_failed_text" comment="Notification when WebView failed because it's uninstalled or not enabled">
+        Fatal Error: WebView must be installed or enabled. Exiting"</string>
 
     <!-- Context: Query for associated dictionary -->
     <string name="query_associated_model" comment="Check if there's an available dictionary to download">Checking for associated dictionary to download</string>
@@ -278,4 +282,5 @@
 
     <!-- Context: anywhere -->
     <string name="unable_to_open_browser" comment="Notification when a browser activity cannot be launched">Unable to launch web browser</string>
+
 </resources>


### PR DESCRIPTION
Fixes: #11560
Fixes: KEYMAN-ANDROID-5E9
Fixes: KEYMAN-ANDROID-6MA

Keyman requires system WebView to be installed and enabled.

This updates KMManager to catch when the system WebView is not installed/enabled, and attempt to notify via Toast.

At the moment, the Toast notification doesn't appear when the system keyboard fails to initialize. I suspect there's no IME available to display the message...

## User Testing

*Setup* - Install the PR build of Keyman for Android on an Android device/emulator. 
Launch Keyman and enable as the default system keyboard. Then close the app.
Next, go to system Settings --> Apps --> expand and find "Android System WebView --> Disable.
This disables the system WebView which Keyman requires to run.

* **TEST_INAPP_KEYBOARD** - Verifies inapp keyboard doesn't crash when WebView disabled
1. Launch Keyman for Android
2. Observe the splash screen and verify a Toast notification appears about the WebView failing
![fatal webview not enabled](https://github.com/user-attachments/assets/4e53cce8-aeba-4012-918c-b6ed002ac393)

3. Verify Keyman automatically closes without errors about crashing

* **TEST_SYSTEM_KEYBOARD** - Verifies system keyboard doesn't crash when WebView disabled
1. Launch the Chrome browser and select a text field
2. Verify Keyman system keyboard **fails** to appear. 
3. Verify device doesn't show errors about Keyman crashing.
 