### PR TITLE
change(ios): set host-app bundle identifier in embedded Web debug-report

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -137,7 +137,7 @@ class KeymanWebViewController: UIViewController {
     webView!.backgroundColor = UIColor.clear
     webView!.navigationDelegate = self
     webView!.scrollView.isScrollEnabled = false
-    
+
     if #available(iOSApplicationExtension 16.4, *) {
       if(Version.current.tier != .stable) {
         webView!.isInspectable = true
@@ -600,6 +600,10 @@ extension KeymanWebViewController: KeymanWebDelegate {
     os_log("%{public}s", log: KeymanEngineLogger.engine, type: .info, message)
     SentryManager.breadcrumb(message, sentryLevel: .debug)
 
+    // Overwrites the baseline "embeddingApp" text available before Web engine init with the
+    // active bundle identifier.
+    webView!.evaluateJavaScript("setHostAppName(\"\(Bundle.main.infoDictionary!["CFBundleIdentifier"]!)\")")
+
     self.setSentryState()
     resizeKeyboard()
 
@@ -696,7 +700,7 @@ extension KeymanWebViewController: KeymanWebDelegate {
 // MARK: - Manage views
 extension KeymanWebViewController {
   // MARK: - Sizing
-  
+
   @objc func menuKeyHeld(_ keymanWeb: KeymanWebViewController) {
     self.delegate?.menuKeyHeld(self)
   }
@@ -713,10 +717,10 @@ extension KeymanWebViewController {
     let width: CGFloat
     width = UIScreen.main.bounds.width
     var height: CGFloat
-    
+
     // get orientation differently if system or in-app keyboard
     let portrait = Util.isSystemKeyboard ? InputViewController.isPortrait : UIDevice.current.orientation.isPortrait
-    
+
     /**
      * If keyboard height is saved in UserDefaults, then use it
      */
@@ -728,17 +732,17 @@ extension KeymanWebViewController {
        */
       height = self.determineDefaultKeyboardHeight(isPortrait: portrait)
       self.writeKeyboardHeightIfDoesNotExist(isPortrait: portrait, height: height)
-      
+
       /**
        * If we need to write out the keyboard height for one orientation, then we
-       * expect that the other must be written also. 
+       * expect that the other must be written also.
        * Write it out now, but only if a value for keyboard height does not already exist.
        */
       height = self.determineDefaultKeyboardHeight(isPortrait: !portrait)
       self.writeKeyboardHeightIfDoesNotExist(isPortrait: !portrait, height: height)
     }
-    
-    /** 
+
+    /**
      * no need to check for Util.isSystemKeyboard because this is shared storage
      * the UserDefaults are readable and writeable by both system and in-app
      */
@@ -768,7 +772,7 @@ extension KeymanWebViewController {
 
     return height;
   }
-  
+
   /**
    * Write out the keyboard height to the UserDefaults but only if it does not exist there yet.
    * If it exists, then we assume it was configured by the user and do not want to
@@ -789,7 +793,7 @@ extension KeymanWebViewController {
       }
     }
   }
-  
+
   var keyboardSize: CGSize {
     get {
       if kbSize.equalTo(CGSize.zero) {

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -149,6 +149,11 @@ function setKeymanLanguage(stub) {
     });
 }
 
+function setHostAppName(name) {
+    // Sentry will capture this in a breadcrumb for Web errors.
+    keyman.config.embeddingApp = name;
+}
+
 var fragmentToggle = 0;
 /**
  * Inserts the selected string <i>s</i>

--- a/web/src/app/webview/src/configuration.ts
+++ b/web/src/app/webview/src/configuration.ts
@@ -47,6 +47,10 @@ export class WebviewConfiguration extends EngineConfiguration {
     return this._embeddingApp;
   }
 
+  set embeddingApp(name: string) {
+    this._embeddingApp = name;
+  }
+
   get oninserttext() {
     return this._oninserttext;
   }


### PR DESCRIPTION
In our current Sentry reports coming from within the iOS app's keyboard host-page, we get the following under `keymanState`:

```
{
  configReport: {
  embeddingApp: AppleTablet,
  hostDevice: {
    browser: native,
    formFactor: tablet,
    OS: ios,
    touchable: true
  },
  initialized: true,
  keymanEngine: app/webview
}
```

It is certainly helpful to know that the error occurred with the `app/webview` build on an Apple tablet - that tells us it's from some variant of our iOS engine.  But... which one?  This PR fetches the active bundle identifier and ferries that into the Web engine once it loads, which will allow us to have the actual active identifier.

- Is it the Keyman app?  `Tavultesoft.Keyman`.
- Is it the app's system keyboard?  `Tavultesoft.Keyman.SWKeyboard`
- Is it coming from a different app that's embedding KeymanEngine?  We'll get _that_ identifier here.

I decided to pursue this due to some questions I had after investigation into #13102; namely, we've noticed in the past that users of the FirstVoices app often decide not to utilize `sil_euro_latin`, which is our engine's default keyboard.  There's a chance that #13102 is related to side effects that result when users enforce this preference.

@keymanapp-test-bot skip