### PR TITLE
feat(developer): include command line in kmc sentry reports

### DIFF
--- a/developer/src/common/web/utils/src/utils/KeymanSentry.ts
+++ b/developer/src/common/web/utils/src/utils/KeymanSentry.ts
@@ -64,11 +64,17 @@ export class KeymanSentry {
     }
   }
 
-  static async captureException(e: any): Promise<never> {
+  /**
+   * capture an exception for Sentry; note that in local environments, this will normally
+   * throw the exception rather than sending to Sentry
+   * @param e
+   * @param force if true, reports to Sentry even in local environments
+   */
+  static async captureException(e: any, force?: boolean): Promise<never> {
     if(isInit) {
       // For local development, we don't want to bury the trace; we need the cast to avoid
       // TS2367 (comparison appears to be unintentional)
-      if((KEYMAN_VERSION.VERSION_ENVIRONMENT as string) == 'local') {
+      if(!force && (KEYMAN_VERSION.VERSION_ENVIRONMENT as string) == 'local') {
         throw e;
       }
 

--- a/developer/src/kmc/src/util/TestKeymanSentry.ts
+++ b/developer/src/kmc/src/util/TestKeymanSentry.ts
@@ -43,7 +43,7 @@ export class TestKeymanSentry {
       try {
         throw new Error('Test error from -sentry-client-test-exception event');
       } catch(e: any) {
-        await KeymanSentry.captureException(e);
+        await KeymanSentry.captureException(e, true);
       }
     }
   }

--- a/developer/src/kmc/src/util/kmcSentryOptions.ts
+++ b/developer/src/kmc/src/util/kmcSentryOptions.ts
@@ -3,7 +3,15 @@ import * as process from "node:process";
 import { SentryNodeOptions } from "@keymanapp/developer-utils";
 
 Sentry.setContext('Command Line', {
-  argv: process.argv.join(' ')
+  // obfusate parameters with longer paths e.g. from 'c:/users/name/a/b' to
+  // '…/a/b' to minimize PII risk without losing all command line data.
+  // Also normalizes backslashes to slashes for simplicity.
+  argv: process.argv.map(param => {
+    const p = param.replaceAll('\\', '/').split('/');
+    return (p.length < 3)
+      ? param
+      : ("…/" + p.slice(-2).join('/'));
+  }).join(' ')
 });
 
 /**

--- a/developer/src/kmc/src/util/kmcSentryOptions.ts
+++ b/developer/src/kmc/src/util/kmcSentryOptions.ts
@@ -1,4 +1,10 @@
+import Sentry from "@sentry/node";
+import * as process from "node:process";
 import { SentryNodeOptions } from "@keymanapp/developer-utils";
+
+Sentry.setContext('Command Line', {
+  argv: process.argv.join(' ')
+});
 
 /**
  * Rewrites sourcemap paths for the esbuild distribution of kmc (as used in


### PR DESCRIPTION
In order to reproduce kmc errors, it's very helpful to know how it was instantiated. This change includes the command line call for kmc. This includes things such as a keyboard filename and may include file paths, but does not include private personal information or secrets.

Sample capture:

![image](https://github.com/user-attachments/assets/f3924f37-7f95-41ce-a1e9-e4e67edd7e4d)

```
Command Line
argv: C:\Users\marc\AppData\Roaming\nvm\v20.16.0\node.exe D:\Projects\keyman\app\developer\src\kmc --sentry-client-test-exception
```

@keymanapp-test-bot skip