### PR TITLE
fix(common): handle undefined input in `@keymanapp/langtags` lookups

### DIFF
--- a/common/web/langtags/src/main.ts
+++ b/common/web/langtags/src/main.ts
@@ -114,7 +114,7 @@ function preinit(): void {
  * @returns LangTag or undefined if not found
  */
 function getLangtagByTag(tag: string): LangTag {
-  return langtagsByTag.get(tag.toLowerCase());
+  return langtagsByTag.get(tag?.toLowerCase());
 }
 
 preinit();


### PR DESCRIPTION
Matches prior behaviour when langtags was part of kmc-keyboard-info.

Fixes: #13116

@keymanapp-test-bot skip