### PR TITLE
chore(mac, ios): build and run with xcode 16 🍒 🏠 

### DIFF
--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,4 +1,4 @@
 github "weichsel/ZIPFoundation" ~> 0.9
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
-github "getsentry/sentry-cocoa" ~> 8.7.0
+github "getsentry/sentry-cocoa" ~> 8.38.0

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "ashleymills/Reachability.swift" "v5.1.0"
-github "devicekit/DeviceKit" "5.1.0"
-github "getsentry/sentry-cocoa" "8.15.2"
-github "weichsel/ZIPFoundation" "0.9.17"
+github "ashleymills/Reachability.swift" "v5.2.4"
+github "devicekit/DeviceKit" "5.5.0"
+github "getsentry/sentry-cocoa" "8.38.0"
+github "weichsel/ZIPFoundation" "0.9.19"

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "ashleymills/Reachability.swift" "v5.2.4"
 github "devicekit/DeviceKit" "5.5.0"
-github "getsentry/sentry-cocoa" "8.38.0"
+github "getsentry/sentry-cocoa" "8.44.0"
 github "weichsel/ZIPFoundation" "0.9.19"

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -131,7 +131,7 @@ function getOskWidth() {
 
 function getOskHeight() {
     var height = oskHeight;
-    if(keyman.osk.banner._activeType != 'blank') {
+    if(keyman.osk && keyman.osk.banner && keyman.osk.banner._activeType != 'blank') {
         height = height - keyman.osk.banner.height;
     }
     return height;

--- a/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
+++ b/ios/keyman/Keyman/Keyman.xcodeproj/project.pbxproj
@@ -1002,7 +1002,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/usr/bin/env bash";
-			shellScript = "\"$KEYMAN_ROOT/resources/build/xcode-wrap.sh\" \"$KEYMAN_ROOT/resources/build/set-bundle-versions-and-settings-tagged.sh\"\n";
+			shellScript = "\"$KEYMAN_ROOT/resources/build/xcode-wrap.sh\" \"$KEYMAN_ROOT/resources/build/set-bundle-versions-and-settings-tagged.sh\"\necho \"script - set version complete\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CED3CFDA240E49DF001540A1 /* ShellScript */ = {

--- a/mac/Keyman4MacIM/Podfile
+++ b/mac/Keyman4MacIM/Podfile
@@ -7,11 +7,11 @@ target 'Keyman' do
   # use_frameworks!
 
   # Pods for Keyman
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.24.0'
+  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.38.0'
   
   target 'KeymanTests' do
     inherit! :search_paths
-    pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.24.0'
+    pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.38.0'
     use_frameworks!
     # Pods for testing
   end

--- a/mac/Keyman4MacIM/Podfile.lock
+++ b/mac/Keyman4MacIM/Podfile.lock
@@ -1,24 +1,24 @@
 PODS:
-  - Sentry (8.24.0):
-    - Sentry/Core (= 8.24.0)
-  - Sentry/Core (8.24.0)
+  - Sentry (8.38.0-beta.1):
+    - Sentry/Core (= 8.38.0-beta.1)
+  - Sentry/Core (8.38.0-beta.1)
 
 DEPENDENCIES:
-  - Sentry (from `https://github.com/getsentry/sentry-cocoa.git`, tag `8.24.0`)
+  - Sentry (from `https://github.com/getsentry/sentry-cocoa.git`, tag `8.38.0`)
 
 EXTERNAL SOURCES:
   Sentry:
     :git: https://github.com/getsentry/sentry-cocoa.git
-    :tag: 8.24.0
+    :tag: 8.38.0
 
 CHECKOUT OPTIONS:
   Sentry:
     :git: https://github.com/getsentry/sentry-cocoa.git
-    :tag: 8.24.0
+    :tag: 8.38.0
 
 SPEC CHECKSUMS:
-  Sentry: 2f6baed15a3f8056b875fc903dc3dcb2903117f4
+  Sentry: 4d6027fbfde9ddc35e5c368292843097d039db5f
 
-PODFILE CHECKSUM: 483593d0b294fc5751c2490061e01211db3f9ecc
+PODFILE CHECKSUM: 19b128c35d9c5e59f90d09522c053de65096696a
 
 COCOAPODS: 1.15.2

--- a/oem/firstvoices/ios/Cartfile
+++ b/oem/firstvoices/ios/Cartfile
@@ -1,4 +1,4 @@
 github "weichsel/ZIPFoundation" ~> 0.9
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
-github "getsentry/sentry-cocoa" ~> 8.7.0
+github "getsentry/sentry-cocoa" ~> 8.38.0

--- a/oem/firstvoices/ios/Cartfile.resolved
+++ b/oem/firstvoices/ios/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "ashleymills/Reachability.swift" "v5.1.0"
-github "devicekit/DeviceKit" "5.1.0"
-github "getsentry/sentry-cocoa" "8.15.2"
-github "weichsel/ZIPFoundation" "0.9.17"
+github "ashleymills/Reachability.swift" "v5.2.4"
+github "devicekit/DeviceKit" "5.5.0"
+github "getsentry/sentry-cocoa" "8.44.0"
+github "weichsel/ZIPFoundation" "0.9.19"


### PR DESCRIPTION
Using Xcode 16.2 running on macOS 15.2 (Sequoia) ensure that Keyman for mac and ios builds and runs correctly.

Fixes #12696

Cherry-pick of #13077, #12554, #12570 

@keymanapp-test-bot skip