### PR TITLE
fix(common/web): replace invalid StrsItem identity checks with isEqual()

### DIFF
--- a/common/web/types/tests/kmx/kmx-plus/kmx-plus.tests.ts
+++ b/common/web/types/tests/kmx/kmx-plus/kmx-plus.tests.ts
@@ -8,13 +8,31 @@
 
 import 'mocha';
 import { assert } from 'chai';
+import { Strs, StrsItem, StrsOptions, DependencySections } from '../../../src/kmx/kmx-plus/kmx-plus.js';
+
+const GOTHIC_A = new StrsItem("𐌰", 0x10330);
 
 describe('Test of KMX Plus file', () => {
   describe('Test of Strs', () => {
+    describe('Test of implicit constructor', () => {
+      it('can construct a Strs', () => {
+        const strs = new Strs();
+        assert.isNotNull(strs);
+        assert.deepEqual(strs.strings, [ new StrsItem('') ]);
+        assert.deepEqual(strs.allProcessedStrings, new Set<string>());
+      });
+    });
     describe('Test of allocString()', () => {
-      it('can allocate a StrsItem', () => {
-        assert.isTrue(true);
+      it('can allocate a one-character StrsItem', () => {
+        const strs = new Strs();
+        strs['processString'] = stubStrsProcessString;
+        const csi = strs.allocString("𐌰", { singleOk: true });
+        assert.deepEqual(csi, GOTHIC_A);
       });
     });
   });
 });
+
+function stubStrsProcessString(s: string, opts: StrsOptions, sections: DependencySections) {
+  return s;
+}

--- a/common/web/types/tests/kmx/kmx-plus/kmx-plus.tests.ts
+++ b/common/web/types/tests/kmx/kmx-plus/kmx-plus.tests.ts
@@ -1,0 +1,20 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ * 
+ * Created by Dr Mark C. Sinclair on 2025-02-03
+ * 
+ * Test code for kmx-plus.ts
+ */
+
+import 'mocha';
+import { assert } from 'chai';
+
+describe('Test of KMX Plus file', () => {
+  describe('Test of Strs', () => {
+    describe('Test of allocString()', () => {
+      it('can allocate a StrsItem', () => {
+        assert.isTrue(true);
+      });
+    });
+  });
+});

--- a/common/web/types/tests/kmx/kmx-plus/kmx-plus.tests.ts
+++ b/common/web/types/tests/kmx/kmx-plus/kmx-plus.tests.ts
@@ -18,16 +18,33 @@ describe('Test of KMX Plus file', () => {
       it('can construct a Strs', () => {
         const strs = new Strs();
         assert.isNotNull(strs);
-        assert.deepEqual(strs.strings, [ new StrsItem('') ]);
+        assert.deepEqual(strs.strings, [new StrsItem('')]);
         assert.deepEqual(strs.allProcessedStrings, new Set<string>());
       });
     });
     describe('Test of allocString()', () => {
-      it('can allocate a one-character StrsItem', () => {
+      it('can allocate a one-character string', () => {
         const strs = new Strs();
         strs['processString'] = stubStrsProcessString;
         const csi = strs.allocString("𐌰", { singleOk: true });
         assert.deepEqual(csi, GOTHIC_A);
+      });
+      it('can allocate an unknown string', () => {
+        const strs = new Strs();
+        strs['processString'] = stubStrsProcessString;
+        const si = strs.allocString("𐌰𐌱𐌲");
+        assert.deepEqual(si, new StrsItem("𐌰𐌱𐌲"));
+        assert.deepEqual(strs.strings, [new StrsItem(''), new StrsItem("𐌰𐌱𐌲")]);
+      });
+      it('can allocate a known string', () => {
+        const strs = new Strs();
+        strs['processString'] = stubStrsProcessString;
+        const one = strs.allocString("𐌰𐌱𐌲");
+        assert.deepEqual(one, new StrsItem("𐌰𐌱𐌲"));
+        assert.deepEqual(strs.strings, [new StrsItem(''), new StrsItem("𐌰𐌱𐌲")]);
+        const two = strs.allocString("𐌰𐌱𐌲");
+        assert.isTrue(two === one);
+        assert.deepEqual(strs.strings, [new StrsItem(''), new StrsItem("𐌰𐌱𐌲")]);
       });
     });
   });


### PR DESCRIPTION
In PR [#12868](https://github.com/keymanapp/keyman/pull/12868) a new `isEqual()` mathod was added to `StrsItem` to distinguish identity (`===`) and equality (`toEqual()`) checks. This was needed to get correct behaviour from `ElemElement.isEqual()` and `ElementString.isEqual()` which both (now) depend on `StrsItem.isEqual()`.

This PR checks uses of `StrsItem` to identify where `StrsItem.toEqual()` should be used instead of an identity check.

### Files examined:
- [x] element-string.ts
- [x] kmx-plus.ts
- [x] string-list.ts
- [x] build-keys.ts
- [x] build-layr.ts
- [x] build-strs.ts
- [x] build-uset.ts

Fixes: #12945 

@keymanapp-test-bot skip