### PR TITLE
change(ios): prevent memory leaks from keyboard-related notification observers

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -165,6 +165,8 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   // For now, should be mostly upon keymanWeb.view.heightAnchor.
   var portraitConstraint: NSLayoutConstraint?
   var landscapeConstraint: NSLayoutConstraint?
+  
+  var outerWidthConstraint: NSLayoutConstraint?
 
   private var keymanWeb: KeymanWebViewController
   private var swallowBackspaceTextChange: Bool = false
@@ -298,6 +300,16 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     // as system keyboard.  Do NOT perform if in-app, as this unnecessarily resets the WebView.
     if(Manager.shared.isSystemKeyboard) {
       keymanWeb.shouldReload = true
+    }
+  }
+  
+  open override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    
+    if outerWidthConstraint != nil {
+      outerWidthConstraint?.isActive = false
+      self.inputView?.removeConstraint(self.outerWidthConstraint!)
+      outerWidthConstraint = nil
     }
   }
 
@@ -527,11 +539,15 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   }
 
   // These require the view to appear - parent and our relationship with it must exist!
+  // ... wait, is THIS possibly a leak source?
   private func setOuterConstraints() {
-    var baseWidthConstraint: NSLayoutConstraint
-    baseWidthConstraint = self.inputView!.widthAnchor.constraint(equalTo: parent!.view.safeAreaLayoutGuide.widthAnchor)
-    baseWidthConstraint.priority = UILayoutPriority(rawValue: 999)
-    baseWidthConstraint.isActive = true
+    guard outerWidthConstraint == nil else {
+      outerWidthConstraint!.isActive = true
+      return
+    }
+    outerWidthConstraint = self.inputView!.widthAnchor.constraint(equalTo: parent!.view.safeAreaLayoutGuide.widthAnchor)
+    outerWidthConstraint!.priority = UILayoutPriority(rawValue: 999)
+    outerWidthConstraint!.isActive = true
   }
 
   public var kmwHeight: CGFloat {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -206,7 +206,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
     keymanWeb = KeymanWebViewController(storage: Storage.active)
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
-    var message = self.hasFullAccess ? "hasFullAccess: true" : "hasFullAccess: false"
+    let message = self.hasFullAccess ? "hasFullAccess: true" : "hasFullAccess: false"
     os_log("%{public}s", log: KeymanEngineLogger.settings, type: .default, message)
     SentryManager.breadcrumb(message)
 
@@ -623,9 +623,17 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   func showHelpBubble() {
     keymanWeb.showHelpBubble()
   }
+  
+  func dismissHelpBubble() {
+    keymanWeb.dismissHelpBubble()
+  }
 
   func showHelpBubble(afterDelay delay: TimeInterval) {
     keymanWeb.showHelpBubble(afterDelay: delay)
+  }
+  
+  internal func enforceKeyboardSize() {
+    keymanWeb.resizeKeyboard()
   }
 
   func clearText() {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/InputViewController.swift
@@ -589,7 +589,7 @@ open class InputViewController: UIInputViewController, KeymanWebDelegate {
   }
 
   // KeymanWebViewController maintenance methods
-  func reload() {
+  public func reload() {
     keymanWeb.reloadKeyboard()
   }
 

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeyboardMenuView.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeyboardMenuView.swift
@@ -26,7 +26,9 @@ class KeyboardMenuView: UIView, UITableViewDelegate, UITableViewDataSource, UIGe
   private var tableView: UITableView?
   private let closeButtonTitle: String?
 
-  private var _inputViewController: InputViewController?
+  // Is populated during init from a weak ref by KeymanWebViewController,
+  // and instances of this class are owned by the same.
+  private weak var _inputViewController: InputViewController?
   override var inputViewController: InputViewController? {
     return _inputViewController
   }

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -72,14 +72,6 @@ class KeymanWebViewController: UIViewController {
     super.init(nibName: nil, bundle: nil)
 
     _ = view
-
-    NotificationCenter.default.addObserver(
-      forName: UIApplication.willEnterForegroundNotification,
-      object: nil,
-      queue: OperationQueue.main
-    ) { _ in
-      self.reloadKeyboard()
-    }
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -146,11 +146,6 @@ class KeymanWebViewController: UIViewController {
 
     view = webView
 
-    NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillShow),
-                                           name: UIResponder.keyboardWillShowNotification, object: nil)
-    NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillHide),
-                                           name: UIResponder.keyboardWillHideNotification, object: nil)
-
     reloadKeyboard()
   }
 
@@ -980,20 +975,5 @@ extension KeymanWebViewController {
 
   var isKeyboardMenuVisible: Bool {
     return keyboardMenuView != nil
-  }
-}
-
-// MARK: - Keyboard Notifications
-extension KeymanWebViewController {
-  @objc func keyboardWillShow(_ notification: Notification) {
-    resizeKeyboard()
-
-    if Manager.shared.isKeymanHelpOn {
-      showHelpBubble(afterDelay: 1.5)
-    }
-  }
-
-  @objc func keyboardWillHide(_ notification: Notification) {
-    dismissHelpBubble()
   }
 }

--- a/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
@@ -112,6 +112,14 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
       forName: Notifications.keyboardRemoved,
       observer: self,
       function: MainViewController.keyboardRemoved)
+    
+    NotificationCenter.default.addObserver(
+      forName: UIApplication.willEnterForegroundNotification,
+      object: nil,
+      queue: OperationQueue.main
+    ) { _ in
+      Manager.shared.inputViewController.reload()
+    }
 
     // Unfortunately, it's the main app with the file definitions.
     // We have to gerry-rig this so that the framework-based SettingsViewController


### PR DESCRIPTION
Addresses parts of #12216.

Note that part of this is sort of reversing much of #683's commit 46a6b3013e89f9b7d358e4c020a020cbd95d6b7f.

While I find it interesting that this doesn't resolve #12216, the fact that those parts of the code did not interfere with the results of #6552 at the time, which did fix the memory leaks (for a while?) kind of does hint that these changes weren't likely to be enough.  Still, knocking out potential contributors to memory leaks is still wise.

## User Testing

TEST_IOS_FRESH_INSTALL:  Using the Keyman app for iPhone and iPad, verify that the help bubble tip for fresh installs above the globe key displays when it should.

1. If the test device has a prior installation of the app, remove it completely.
2. Install the test artifact of the app from this PR.
3. When the app launches, verify that the help bubble tip ("Tap here to change keyboard") appears above the globe key.
4. Open the app's `...` menu.
5. Close that menu by tapping the `...` again or touching a non-menu area.
6. The help bubble tip should not be visible _at first_.
7. After about 1.5 seconds, the help bubble tip should reappear.
8. Return to the home screen of your device.
9. Re-open the app.
10. If is appears, close out the "Get Started" screen.
11. Repeat steps 6 and 7.

TEST_IOS_APP_RESTORE:  Using the Keyman app for iPhone and iPad, verify that the keyboard works correctly **after** the app is restored from a background state.

- At a minimum, do the following tests with `sil_euro_latin`:
    - Use a longpress + select a subkey
    - Use a downward flick
    - Try a multitap on the numeric key to change layers.
    - Try holding a layer-switching key and typing with the temporarily-active layer.
- If standard gesture visualizations do not show up or operate correctly, FAIL this test.
- If the output or layer-switches do not act as expected, FAIL this test.