### PR TITLE
fix(developer): support non-US base keyboard layouts in debuggers

### DIFF
--- a/developer/src/tike/child/Keyman.Developer.UI.Debug.UfrmLdmlKeyboardDebug.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.Debug.UfrmLdmlKeyboardDebug.pas
@@ -39,7 +39,7 @@ uses
   UframeTextEditor,
   UfrmMDIEditor,
   UfrmTike,
-  UserMessages;
+  UserMessages, Keyman.Developer.UI.RichEdit41;
 
 type
   TLdmlDebugUIStatus = (
@@ -340,7 +340,7 @@ begin
   if not SetKeyEventContext then
     Exit(False);
 
-  if km_core_process_event(FDebugCore.State, Message.WParam, modifier, 1, KM_CORE_EVENT_FLAG_DEFAULT) = KM_CORE_STATUS_OK then
+  if km_core_process_event(FDebugCore.State, VKToScanCodeToVK(Message.WParam, GetKeyboardLayout(0)), modifier, 1, KM_CORE_EVENT_FLAG_DEFAULT) = KM_CORE_STATUS_OK then
   begin
     // Process keystroke -- true = swallow keystroke
     Result := True;

--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -41,7 +41,7 @@ uses
   UfrmDebugStatus,
   UfrmMDIEditor,
   UfrmTike,
-  UserMessages;
+  UserMessages, Keyman.Developer.UI.RichEdit41;
 
 type
   TDebugLineEvent = procedure(Sender: TObject; ALine: Integer) of object;
@@ -465,7 +465,7 @@ begin
   if not SetKeyEventContext then
     Exit(False);
 
-  if km_core_process_event(FDebugCore.State, Message.WParam, modifier, 1, KM_CORE_EVENT_FLAG_DEFAULT) = KM_CORE_STATUS_OK then
+  if km_core_process_event(FDebugCore.State, VKToScanCodeToVK(Message.WParam, GetKeyboardLayout(0)), modifier, 1, KM_CORE_EVENT_FLAG_DEFAULT) = KM_CORE_STATUS_OK then
   begin
     // Process keystroke -- true = swallow keystroke
     Result := True;


### PR DESCRIPTION
Keyman Core expects US English virtual key codes, so make sure that the debuggers translate the key codes they receive from Windows to the hard- coded values for US English, as defined in ScanCodeMap.

Fixes: #13052

# User Testing

TEST_US_ENGLISH_DEBUGGER: Using any Keyman keyboard, open the debugger, make sure US English keyboard is selected in Windows, and try each key on the keyboard and verify that it gives the expected output.

TEST_FRENCH_AZERTY_DEBUGGER: Install the French (AZERTY) keyboard in Windows (under 'French (France)'). Using any Keyman keyboard, open the debugger, make sure French AZERTY keyboard is selected in Windows, and try each key on the keyboard and verify that it gives the expected output based on US English, rather than swapping keys such as A and Q. (You can verify that French AZERTY keyboard is active in Keyman Developer by typing 'QWERTY' keys into the source code view -- it should show 'AZERTY' if French AZERTY is active.)