### PR TITLE
chore(web): ensure /web/build.sh clean triggers all predictive-text child actions

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -35,7 +35,7 @@ builder_describe "Builds engine modules for Keyman Engine for Web (KMW)." \
   ":engine/keyboard-storage  Subset used to collate keyboards and request them from the cloud" \
   ":engine/main              Builds all common code used by KMW's app/-level targets" \
   ":engine/osk               Builds the Web OSK module" \
-  ":engine/predictive-text=src/engine/predictive-text/worker-main     Builds KMW's predictive text module" \
+  ":engine/predictive-text   Builds KMW's predictive text module" \
   ":help                     Online documentation" \
   ":samples                  Builds all needed resources for the KMW sample-page set" \
   ":tools                    Builds engine-related development resources" \

--- a/web/src/engine/predictive-text/build.sh
+++ b/web/src/engine/predictive-text/build.sh
@@ -53,7 +53,6 @@ builder_run_child_actions configure
 ## Build actions
 
 builder_run_child_actions build:wordbreakers
-
 builder_run_child_actions build:templates
 builder_run_child_actions build:worker-thread
 builder_run_child_actions build:worker-main


### PR DESCRIPTION
Addresses parts of #12735.

Addresses some observations from https://github.com/keymanapp/keyman/pull/13141#issuecomment-2641778131 - namely, that predictive-text tests were running in the Web-test configuration, not just in the predictive-text configuration.

@keymanapp-test-bot skip