### PR TITLE
chore(mac): remove empty options tab from configuration

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/Base.lproj/preferences.xib
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/Base.lproj/preferences.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="22690"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+        <plugIn identifier="com.apple.WebKitIBPlugin" version="23504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -201,12 +201,6 @@
                                             </tableHeaderView>
                                         </scrollView>
                                     </subviews>
-                                </view>
-                            </tabViewItem>
-                            <tabViewItem label="Options" identifier="2" id="frd-No-seV">
-                                <view key="view" id="N1x-px-93m">
-                                    <rect key="frame" x="10" y="33" width="754" height="538"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Support" identifier="3" id="93O-x6-RLF">


### PR DESCRIPTION
After removal of the 'Always Show OSK' and 'Use Verbose console Logging' options from the configuration window, the options tab is empty and can be removed. Only 'Keyboards' and 'Support' tabs remain.

(The Options tab may be added back in the future to hold things like hot key configuration.)

![image](https://github.com/user-attachments/assets/31778a03-5554-4e23-a3c6-e6af60c5bed4)

Related:
#12431 
#12355 

@keymanapp-test-bot skip