### PR TITLE
fix(windows): use Automatically check for updates and download for the english xml

### DIFF
--- a/oem/firstvoices/windows/src/xml/strings.xml
+++ b/oem/firstvoices/windows/src/xml/strings.xml
@@ -390,8 +390,8 @@
 
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koCheckForUpdates" comment="Startup options - check online weekly for updates">Automatically check keyman.com weekly for updates</string>
+  <!-- Modified: 18.0.96.0 -->
+  <string name="koCheckForUpdates" comment="Automatically check for updates and download">Automatically check for updates and download</string>
 
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->

--- a/windows/src/desktop/kmshell/xml/strings.xml
+++ b/windows/src/desktop/kmshell/xml/strings.xml
@@ -416,8 +416,8 @@
 
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->
-  <!-- Introduced: 7.0.230.0 -->
-  <string name="koCheckForUpdates" comment="Startup options - check online weekly for updates">Automatically check keyman.com weekly for updates</string>
+  <!-- Modified: 18.0.96.0 -->
+  <string name="koCheckForUpdates" comment="Automatically check for updates and download">Automatically check for updates and download</string>
 
   <!-- Context: Configuration Dialog - Options tab -->
   <!-- String Type: FormatString -->


### PR DESCRIPTION
I missed the english phrase being copied over to the koCheckForUpdates flag.  I only removed the koAutomaticUpdate in the base strings.xml but didn't copy over the phrase.
I did it for the already translated languages but missed the english in the file I committed and pushed.


# User Testing
# TEST_CORRECT_TEXT_AUTOMATIC_UPDATES

Install Keyman from this PR
Open Keyman Options and verify the text appears 
see the expected result (which I got by downloading the attached PR :))
"Automatically check for updates and download"
![image](https://github.com/user-attachments/assets/143840a2-4065-489d-82e1-a3de35caa42c)











