### PR TITLE
refactor(windows): rename `TKeymanMutex.MutexOwned` to `TakeOwnership` and add `ReleaseOwnership`

### DIFF
--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -526,12 +526,16 @@ begin
     fmMain, fmAbout:
       begin  // I2720
         FMutex := TKeymanMutex.Create('KeymanConfiguration');
-        if FMutex.TakeOwnership then Main else FocusConfiguration;
+        if FMutex.TakeOwnership
+          then Main
+          else FocusConfiguration;
       end;
     fmTextEditor:
       begin  // I2720
         FMutex := TKeymanMutex.Create('KeymanTextEditor');
-        if FMutex.TakeOwnership then OpenTextEditor else FocusTextEditor;
+        if FMutex.TakeOwnership 
+          then OpenTextEditor 
+          else FocusTextEditor;
       end;
 
     fmBaseKeyboard:   // I4169

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -526,12 +526,12 @@ begin
     fmMain, fmAbout:
       begin  // I2720
         FMutex := TKeymanMutex.Create('KeymanConfiguration');
-        if FMutex.MutexOwned then Main else FocusConfiguration;
+        if FMutex.TakeOwnership then Main else FocusConfiguration;
       end;
     fmTextEditor:
       begin  // I2720
         FMutex := TKeymanMutex.Create('KeymanTextEditor');
-        if FMutex.MutexOwned then OpenTextEditor else FocusTextEditor;
+        if FMutex.TakeOwnership then OpenTextEditor else FocusTextEditor;
       end;
 
     fmBaseKeyboard:   // I4169

--- a/windows/src/desktop/kmshell/startup/UfrmSplash.pas
+++ b/windows/src/desktop/kmshell/startup/UfrmSplash.pas
@@ -220,7 +220,7 @@ begin
   begin
     FMutex := TKeymanMutex.Create('KeymanSplash');
     try
-      if not FMutex.MutexOwned then
+      if not FMutex.TakeOwnership then
       begin
         FocusSplash;  // I2562
         Exit;

--- a/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
+++ b/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
@@ -281,7 +281,7 @@ function TKeymanControl.IsConfigurationOpen: WordBool;
 begin
   with TKeymanMutex.Create('KeymanConfiguration') do
   try
-    Result := MutexOwned;
+    Result := TakeOwnership;
   finally
     Free;
   end;
@@ -302,7 +302,7 @@ function TKeymanControl.IsTextEditorOpen: WordBool;
 begin
   with TKeymanMutex.Create('KeymanTextEditor') do
   try
-    Result := MutexOwned;
+    Result := TakeOwnership;
   finally
     Free;
   end;

--- a/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
+++ b/windows/src/engine/kmcomapi/com/system/keymancontrol.pas
@@ -281,7 +281,7 @@ function TKeymanControl.IsConfigurationOpen: WordBool;
 begin
   with TKeymanMutex.Create('KeymanConfiguration') do
   try
-    Result := TakeOwnership;
+    Result := not TakeOwnership;
   finally
     Free;
   end;
@@ -302,7 +302,7 @@ function TKeymanControl.IsTextEditorOpen: WordBool;
 begin
   with TKeymanMutex.Create('KeymanTextEditor') do
   try
-    Result := TakeOwnership;
+    Result := not TakeOwnership;
   finally
     Free;
   end;

--- a/windows/src/global/delphi/general/KeymanMutex.pas
+++ b/windows/src/global/delphi/general/KeymanMutex.pas
@@ -29,7 +29,8 @@ type
   public
     constructor Create(FName: string);
     destructor Destroy; override;
-    function MutexOwned: Boolean;
+    function TakeOwnership: Boolean;
+    function ReleaseOwnership: Boolean;
   end;
 
 implementation
@@ -52,9 +53,14 @@ begin
   inherited Destroy;
 end;
 
-function TKeymanMutex.MutexOwned: Boolean;
+function TKeymanMutex.TakeOwnership: Boolean;
 begin
   Result := WaitForSingleObject(hMutex, 0) = WAIT_OBJECT_0;
+end;
+
+function TKeymanMutex.ReleaseOwnership: Boolean;
+begin
+  Result := ReleaseMutex(hMutex);
 end;
 
 end.


### PR DESCRIPTION
Add a ReleaseOwnership member to TKeymanMutex.
Rename MutexOwned to TakeOwnership.

Fixes: #13167

# User Testing

## TEST_OPEN_CONFIGURATION_FOCUS

- Install Keyman from the PR
- Start Keyman and open Keyman Configuration. 
- Open Notepad so that it is in front of the Keyman Configuration Window
- Now attempt to open Keyman Configuration even though it is already open. Right-click on the Keyman Icon in the system tray and choose `Configuration` from the context menu.

Expected Result: the existing Keyman Configuration Window now has focus and not `Notepad`


