### PR TITLE
fix(linux): start system service when switching keyboards

### DIFF
--- a/linux/ibus-keyman/src/KeymanSystemServiceClient.cpp
+++ b/linux/ibus-keyman/src/KeymanSystemServiceClient.cpp
@@ -25,6 +25,7 @@ public:
   void SetCapsLockIndicator(guint32 capsLock);
   gint32 GetCapsLockIndicator();
   void CallOrderedOutputSentinel();
+  void Ping();
 };
 
 KeymanSystemServiceClient::KeymanSystemServiceClient() {
@@ -111,6 +112,23 @@ KeymanSystemServiceClient::CallOrderedOutputSentinel() {
   }
 }
 
+void KeymanSystemServiceClient::Ping() {
+  if (!bus) {
+    // we already reported the error in the c'tor, so just return
+    return;
+  }
+
+  sd_bus_error *error = NULL;
+  int result = sd_bus_call_method(bus, KEYMAN_BUS_NAME, KEYMAN_OBJECT_PATH,
+    KEYMAN_INTERFACE_NAME, "Ping", error, &msg, "");
+  if (result < 0) {
+    g_error("%s: Failed to call method Ping: %s. %s. %s.",
+      __FUNCTION__, strerror(-result), error ? error->name : "-", error ? error->message : "-");
+    sd_bus_error_free(error);
+    return;
+  }
+}
+
 void
 set_capslock_indicator(guint32 capsLock) {
   KeymanSystemServiceClient client;
@@ -127,4 +145,11 @@ call_ordered_output_sentinel() {
   g_message("%s: Calling order output sentinel on keyman-system-service", __FUNCTION__);
   KeymanSystemServiceClient client;
   client.CallOrderedOutputSentinel();
+}
+
+void
+ping_keyman_system_service() {
+  g_message("%s: Pinging keyman-system-service", __FUNCTION__);
+  KeymanSystemServiceClient client;
+  client.Ping();
 }

--- a/linux/ibus-keyman/src/KeymanSystemServiceClient.h
+++ b/linux/ibus-keyman/src/KeymanSystemServiceClient.h
@@ -10,6 +10,7 @@ extern "C" {
 void set_capslock_indicator(guint32 capsLockState);
 gint32 get_capslock_indicator();
 void call_ordered_output_sentinel();
+void ping_keyman_system_service();
 
 #ifdef __cplusplus
 }

--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -553,6 +553,8 @@ ibus_keyman_engine_constructor(
       return NULL;
     }
 
+    ping_keyman_system_service();
+
     set_context_if_needed(engine);
 
     return (GObject *) keyman;

--- a/linux/keyman-system-service/src/KeymanSystemService.cpp
+++ b/linux/keyman-system-service/src/KeymanSystemService.cpp
@@ -76,11 +76,22 @@ on_call_ordered_output_sentinel(
   return sd_bus_reply_method_return(msg, "");
 }
 
+static int32_t
+on_ping(
+  sd_bus_message *msg,
+  void *user_data,
+  sd_bus_error *ret_error
+) {
+  *ret_error = SD_BUS_ERROR_NULL;
+  return sd_bus_reply_method_return(msg, "s", "pong");
+}
+
 static const sd_bus_vtable system_service_vtable[] = {
   SD_BUS_VTABLE_START(0),
     SD_BUS_METHOD("SetCapsLockIndicator", "b", "", on_set_caps_lock_indicator, SD_BUS_VTABLE_UNPRIVILEGED),
     SD_BUS_METHOD("GetCapsLockIndicator", "", "b", on_get_caps_lock_indicator, SD_BUS_VTABLE_UNPRIVILEGED),
     SD_BUS_METHOD("CallOrderedOutputSentinel", "", "", on_call_ordered_output_sentinel, SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_METHOD("Ping", "", "s", on_ping, SD_BUS_VTABLE_UNPRIVILEGED),
   SD_BUS_VTABLE_END
 };
 

--- a/linux/keyman-system-service/src/com.keyman.SystemService1.System.xml
+++ b/linux/keyman-system-service/src/com.keyman.SystemService1.System.xml
@@ -34,5 +34,13 @@
     <method name="CallOrderedOutputSentinel">
     </method>
 
+    <!--
+      Ping:
+
+      Verifies that the keyman-system-service is started and available
+    -->
+    <method name="Ping">
+    </method>
+
   </interface>
 </node>


### PR DESCRIPTION
This change fixes #13171 where we failed to output after the first keypress because the keyman system service had to be started. This change introduces a new method `Ping` that we call to force keyman-system-service to be started.

Fixes: #13171

# User Testing

Can be tested on Ubuntu with Gnome Shell and X11, e.g. Ubuntu 24.04 Noble with Gnome Shell and X11.

**TEST_TERMINAL_IPA:** Open a terminal, then switch to "IPA (SIL)" keyboard. Type `an>`. Verify that the result is "aŋ".
