### PR TITLE
chore(linux): update actions/cache to non-deprecated version

### DIFF
--- a/.github/workflows/api-verification.yml
+++ b/.github/workflows/api-verification.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Restore artifacts
-      uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: |
           artifacts

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -315,7 +315,7 @@ jobs:
         echo "GIT_USER=${{ github.event.client_payload.user }}" >> artifacts/env
 
     - name: Cache artifacts
-      uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: |
           artifacts


### PR DESCRIPTION
Our previous version of actions/cache will stop working at the end of February. This change updates to the latest version.

https://github.com/actions/cache/discussions/1510

@keymanapp-test-bot skip