### PR TITLE
chore(developer): add INFO messages for `kmc copy` and `kmc generate`

### DIFF
--- a/developer/src/kmc-copy/src/copier-messages.ts
+++ b/developer/src/kmc-copy/src/copier-messages.ts
@@ -25,11 +25,7 @@ export class CopierMessages {
     o.e ?? 'unknown error'
   );
 
-  static INFO_CopyingProject = SevInfo | 0x0002;
-  static Info_CopyingProject = (o:{type: string, id: string}) => m(
-    this.INFO_CopyingProject,
-    `Copying project of type ${def(o.type)} with id ${def(o.id)}`
-  );
+  // unused 0x0002 (was INFO_CopyingProject, now in InfrastructureMessages)
 
   static ERROR_CannotCreateFolder = SevError | 0x0003;
   static Error_CannotCreateFolder = (o:{folderName:string, e: any}) => CompilerMessageSpecWithException(

--- a/developer/src/kmc-generate/src/generator-messages.ts
+++ b/developer/src/kmc-generate/src/generator-messages.ts
@@ -7,7 +7,7 @@
 import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException } from "@keymanapp/developer-utils";
 
 const Namespace = CompilerErrorNamespace.Generator;
-const SevInfo = CompilerErrorSeverity.Info | Namespace;
+// const SevInfo = CompilerErrorSeverity.Info | Namespace;
 // const SevHint = CompilerErrorSeverity.Hint | Namespace;
 const SevWarn = CompilerErrorSeverity.Warn | Namespace;
 const SevError = CompilerErrorSeverity.Error | Namespace;
@@ -23,11 +23,7 @@ export class GeneratorMessages {
     o.e ?? 'unknown error',
   );
 
-  static INFO_GeneratingProject = SevInfo | 0x0002;
-  static Info_GeneratingProject = (o:{type: string, id: string}) => m(
-    this.INFO_GeneratingProject,
-    `Generating project of type ${def(o.type)} with id ${def(o.id)}`
-  );
+  // unused 0x0002 (was INFO_GeneratingProject, now in InfrastructureMessages)
 
   static ERROR_CannotCreateFolder = SevError | 0x0003;
   static Error_CannotCreateFolder = (o:{folderName:string, e: any}) => CompilerMessageSpecWithException(

--- a/developer/src/kmc/src/commands/copy.ts
+++ b/developer/src/kmc/src/commands/copy.ts
@@ -79,6 +79,18 @@ async function doCopy(callbacks: NodeCompilerCallbacks, sources: string | string
     return false;
   }
 
+  const dest = options.outPath;
+  callbacks.reportMessage(InfrastructureMessages.Info_CopyingProject({source, dest}));
+  const result = runCopier(callbacks, source, options);
+  if(result) {
+    callbacks.reportMessage(InfrastructureMessages.Info_ProjectCopiedSuccessfully({source, dest}));
+  } else {
+    callbacks.reportMessage(InfrastructureMessages.Info_ProjectNotCopiedSuccessfully({source, dest}));
+  }
+  return result;
+}
+
+async function runCopier(callbacks: NodeCompilerCallbacks, source: string, options: CopierOptions) {
   const copier = new KeymanProjectCopier();
   try {
     if(!await copier.init(callbacks, options)) {

--- a/developer/src/kmc/src/commands/generate.ts
+++ b/developer/src/kmc/src/commands/generate.ts
@@ -113,9 +113,16 @@ async function generate(generator: KeymanCompiler, ids: string | string[], comma
   }
 
   const options = commanderOptionsToGeneratorOptions(id, commanderOptions);
-
+  const outPath = options.outPath;
   const callbacks = new NodeCompilerCallbacks(options);
-  if(!await doGenerate(callbacks, generator, options)) {
+  callbacks.reportMessage(InfrastructureMessages.Info_GeneratingProject({id, outPath}));
+
+  const result = await doGenerate(callbacks, generator, options);
+
+  if(result) {
+    callbacks.reportMessage(InfrastructureMessages.Info_ProjectGeneratedSuccessfully({id}));
+  } else {
+    callbacks.reportMessage(InfrastructureMessages.Info_ProjectNotGeneratedSuccessfully({id}));
     return await exitProcess(1);
   }
 }

--- a/developer/src/kmc/src/messages/infrastructureMessages.ts
+++ b/developer/src/kmc/src/messages/infrastructureMessages.ts
@@ -177,7 +177,7 @@ export class InfrastructureMessages {
   static INFO_ProjectNotCopiedSuccessfully = SevInfo | 0x0025;
   static Info_ProjectNotCopiedSuccessfully = (o:{source:string, dest:string}) => ({filename:o.source, ...m(
     this.INFO_ProjectNotCopiedSuccessfully,
-    `'${def(o.source)}' was not successfully copied to '${def(o.dest)}'.`,
+    `Failed to copy '${def(o.source)}' to '${def(o.dest)}'.`,
   )});
 
   // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
@@ -198,7 +198,7 @@ export class InfrastructureMessages {
   static INFO_ProjectNotGeneratedSuccessfully = SevInfo | 0x0028;
   static Info_ProjectNotGeneratedSuccessfully = (o:{id:string}) => ({filename:o.id, ...m(
     this.INFO_ProjectNotGeneratedSuccessfully,
-    `New project '${def(o.id)}' was not successfully generated.`,
+    `Failed to generate new project '${def(o.id)}'.`,
   )});
 
 }

--- a/developer/src/kmc/src/messages/infrastructureMessages.ts
+++ b/developer/src/kmc/src/messages/infrastructureMessages.ts
@@ -158,5 +158,48 @@ export class InfrastructureMessages {
     this.ERROR_CopyRequiresOutPath,
     `The copy command requires the --out-path, -o parameter`
   );
- }
+
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static INFO_CopyingProject = SevInfo | 0x0023;
+  static Info_CopyingProject = (o:{source:string,dest:string}) => ({filename:o.source, ...m(
+    this.INFO_CopyingProject,
+    `Copying project '${def(o.source)}' to '${def(o.dest)}'`,
+  )});
+
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static INFO_ProjectCopiedSuccessfully = SevInfo | 0x0024;
+  static Info_ProjectCopiedSuccessfully = (o:{source:string, dest:string}) => ({filename:o.source, ...m(
+    this.INFO_ProjectCopiedSuccessfully,
+    `'${def(o.source)}' copied to '${def(o.dest)}' successfully.`,
+  )});
+
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static INFO_ProjectNotCopiedSuccessfully = SevInfo | 0x0025;
+  static Info_ProjectNotCopiedSuccessfully = (o:{source:string, dest:string}) => ({filename:o.source, ...m(
+    this.INFO_ProjectNotCopiedSuccessfully,
+    `'${def(o.source)}' was not successfully copied to '${def(o.dest)}'.`,
+  )});
+
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static INFO_GeneratingProject = SevInfo | 0x0026;
+  static Info_GeneratingProject = (o:{id:string, outPath: string}) => ({filename:o.id, ...m(
+    this.INFO_GeneratingProject,
+    `Generating new project '${def(o.id)}' in '${def(o.outPath)}'.`,
+  )});
+
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static INFO_ProjectGeneratedSuccessfully = SevInfo | 0x0027;
+  static Info_ProjectGeneratedSuccessfully = (o:{id:string}) => ({filename:o.id, ...m(
+    this.INFO_ProjectGeneratedSuccessfully,
+    `New project '${def(o.id)}' generated successfully.`,
+  )});
+
+  // For this message, we override the filename with the passed-in file. A bit of a hack but does the job
+  static INFO_ProjectNotGeneratedSuccessfully = SevInfo | 0x0028;
+  static Info_ProjectNotGeneratedSuccessfully = (o:{id:string}) => ({filename:o.id, ...m(
+    this.INFO_ProjectNotGeneratedSuccessfully,
+    `New project '${def(o.id)}' was not successfully generated.`,
+  )});
+
+}
 

--- a/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
+++ b/developer/src/kmc/src/util/NodeCompilerCallbacks.ts
@@ -242,12 +242,18 @@ export class NodeCompilerCallbacks implements CompilerCallbacks {
   messageSpecialColor(event: CompilerEvent) {
     switch(event.code) {
       case InfrastructureMessages.INFO_BuildingFile:
+      case InfrastructureMessages.INFO_CopyingProject:
+      case InfrastructureMessages.INFO_GeneratingProject:
         return color.whiteBright;
       case InfrastructureMessages.INFO_FileNotBuiltSuccessfully:
       case InfrastructureMessages.INFO_ProjectNotBuiltSuccessfully:
+      case InfrastructureMessages.INFO_ProjectNotCopiedSuccessfully:
+      case InfrastructureMessages.INFO_ProjectNotGeneratedSuccessfully:
         return color.red;
       case InfrastructureMessages.INFO_FileBuiltSuccessfully:
       case InfrastructureMessages.INFO_ProjectBuiltSuccessfully:
+      case InfrastructureMessages.INFO_ProjectCopiedSuccessfully:
+      case InfrastructureMessages.INFO_ProjectGeneratedSuccessfully:
         return color.green;
     }
     return null;


### PR DESCRIPTION
Note: these messages are in `kmc`, not in `kmc-copy` or `kmc-generate`, matching the structure for existing `INFO_BuildingProject` and related messages.

Sample messages:

```
$ kmc generate keyman-keyboard wagaga
wagaga - info KM05026: Generating new project 'wagaga' in '.'.
wagaga - info KM05027: New project 'wagaga' generated successfully.
```

```
$ kmc copy /d/Projects/keyman/keyboards/release/a/anii/ -o /c/temp/ano
anii - info KM05023: Copying project 'D:/Projects/keyman/keyboards/release/a/anii' to 'C:/temp/ano'
anii - info KM05024: 'D:/Projects/keyman/keyboards/release/a/anii' copied to 'C:/temp/ano' successfully.
```

Fixes: #13127

@keymanapp-test-bot skip