### PR TITLE
chore(linux): remove support of Ubuntu 20.04 Focal

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [focal, jammy, noble, oracular]
+        dist: [jammy, noble, oracular]
 
     steps:
     - name: Checkout

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -33,7 +33,7 @@ else
 fi
 echo "ppa: ${ppa}"
 
-distributions="${DIST:-focal jammy noble oracular plucky}"
+distributions="${DIST:-jammy noble oracular plucky}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
Ubuntu 20.04 Focal will reach EOL in April and GitHub removes the runner images, so we no longer will be able to build packages for Focal.

@keymanapp-test-bot skip