### PR TITLE
chore(linux): remove support of Ubuntu 20.04 Focal 🍒

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [focal, jammy, noble, oracular]
+        dist: [jammy, noble, oracular]
 
     steps:
     - name: Checkout

--- a/docs/linux/README.md
+++ b/docs/linux/README.md
@@ -147,7 +147,7 @@ Run `ibus restart` after installing any of them.
 Keyman tries to activate the keyboard automatically. If you want to activate
 it for a different language, you can do so by following the steps below.
 
-#### GNOME3 (focal and bionic default, also newer Ubuntu versions)
+#### GNOME3 (Ubuntu default)
 
 - Click the connection/sound/shutdown section in the top right. Then the tools
   icon for Settings.

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -66,10 +66,7 @@ override_dh_auto_install:
 	rm $(CURDIR)/debian/keyman/usr/share/locale/*.po*
 	# Don't call `build.sh install` - dh_auto_install does some extra smarts
 	dh_auto_install --sourcedir=linux/keyman-config --buildsystem=pybuild $@
-	# Unfortunately bash-completion 2.10 (focal) doesn't yet provide dh-sequence-bash-completion,
-	# which we could add as build-dependency, so we'll have to explicitly call
-	# dh_bash_completion here instead of using `dh $@ --with-python3 --with bash-completion`
-	dh_bash-completion -O--buildsystem=pybuild
+	dh $@ --with-python3 --with bash-completion
 	dh_python3 -O--buildsystem=pybuild
 
 override_dh_missing:

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -33,7 +33,7 @@ else
 fi
 echo "ppa: ${ppa}"
 
-distributions="${DIST:-focal jammy noble oracular plucky}"
+distributions="${DIST:-jammy noble oracular plucky}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
Ubuntu 20.04 Focal will reach EOL in April and GitHub removes the runner images, so we no longer will be able to build packages for Focal. 

Also remove/update some code that is now obsolete with the removal of Focal.

(Added as cherry-pick because of the additional code cleanup which #13202 doesn't have)

Cherry-pick-of: #13202 

@keymanapp-test-bot skip