### PR TITLE
fix(android): Remove sendOptionsToKeyboard function from Engine API

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -250,8 +250,6 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
       if (exText != null)
         exText = null;
     }
-    // Initialize keyboard options
-    KMManager.sendOptionsToKeyboard();
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustLongpressDelayActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustLongpressDelayActivity.java
@@ -133,7 +133,6 @@ public class AdjustLongpressDelayActivity extends BaseActivity {
     // Store the longpress delay as a reference
     // and then update KeymanWeb with the longpress delay
     KMManager.setLongpressDelay(currentDelayTimeMS);
-    KMManager.sendOptionsToKeyboard();
 
     super.onBackPressed();
   }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -475,8 +475,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
 
   @Override
   public void onKeyboardLoaded(KeyboardType keyboardType) {
-    // Initialize keyboard options
-    KMManager.sendOptionsToKeyboard();
+    // Do nothing
   }
 
   @Override

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -13,6 +13,7 @@ var bannerImagePath = '';
 var bannerHTMLContents = '';
 var fragmentToggle = 0;
 var deferredBannerCall;
+var longpressDelay = null;
 
 var sentryManager = new KeymanSentryManager({
   hostPlatform: "android"
@@ -71,6 +72,10 @@ function init() {
 
       keyman.refreshOskLayout();
     }
+    // Initialize the longpress delay
+    if(longpressDelay !== null) {
+      setLongpressDelay(longpressDelay);
+    }
   });
 
   keyman.addEventListener('keyboardloaded', setIsChiral);
@@ -128,7 +133,8 @@ function notifyHost(event, params) {
 // Update the KeymanWeb longpress delay
 // delay is in milliseconds
 function setLongpressDelay(delay) {
-  if (keyman.osk) {
+  longpressDelay = delay;
+  if (keyman && keyman.osk) {
     keyman.osk.gestureParams.longpress.waitLength = delay;
     console_debug('setLongpressDelay('+delay+')');
   } else {

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -137,8 +137,6 @@ function setLongpressDelay(delay) {
   if (keyman && keyman.osk) {
     keyman.osk.gestureParams.longpress.waitLength = delay;
     console_debug('setLongpressDelay('+delay+')');
-  } else {
-    window.console.log('setLongpressDelay error: keyman.osk undefined');
   }
 }
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -722,9 +722,9 @@ public final class KMManager {
       }
       keyboard.setBanner(KMManager.BannerType.HTML);
       keyboard.showBanner(true);
+      sendLongpressDelay();
     }
     setEngineWebViewVersionStatus(appContext, keyboard);
-    sendLongpressDelay();
   }
 
   public static String getLanguagePredictionPreferenceKey(String langID) {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -724,6 +724,7 @@ public final class KMManager {
       keyboard.showBanner(true);
     }
     setEngineWebViewVersionStatus(appContext, keyboard);
+    sendLongpressDelay();
   }
 
   public static String getLanguagePredictionPreferenceKey(String langID) {
@@ -921,7 +922,7 @@ public final class KMManager {
       copyAsset(context, KMFilename_KmwCss, "", true);
       copyAsset(context, KMFilename_KmwGlobeHintCss, "", true);
       copyAsset(context, KMFilename_Osk_Ttf_Font, "", true);
-      
+
       // Needed until our minimum version of Chrome is 61.0+.
       copyAsset(context, KMFilename_JSPolyfill2, "", true);
 
@@ -2124,7 +2125,7 @@ public final class KMManager {
   }
 
   /**
-   * Set the longpress delay (in milliseconds) as a stored preference.
+   * Set the longpress delay (in milliseconds) as a stored preference and sends to KeymanWeb.
    * Valid range is 300 ms to 1500 ms. Returns true if the preference is successfully stored.
    * @param longpressDelay - int longpress delay in milliseconds
    * @return boolean
@@ -2140,17 +2141,19 @@ public final class KMManager {
     editor.putInt(KMKey_LongpressDelay, longpressDelay);
     editor.commit();
 
+    // Send longpress delay to KeymanWeb
+    sendLongpressDelay();
+
     return true;
   }
 
   /**
-   * Sends options to the KeymanWeb keyboard.
+   * Sends longpress delay to the KeymanWeb keyboard.
    * 1. number of milliseconds to trigger a longpress gesture.
-   * This method requires a keyboard to be loaded for the value to take effect.
    */
-  public static void sendOptionsToKeyboard() {
+  private static void sendLongpressDelay() {
     int longpressDelay = getLongpressDelay();
-    if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP)) {
+    if (InAppKeyboard != null) {
       InAppKeyboard.loadJavascript(KMString.format("setLongpressDelay(%d)", longpressDelay));
     }
 


### PR DESCRIPTION
Follows #12170 and #12185 re: new menu to adjust the longpress delay
Fixes #13165 

Removes `sendOptionsToKeyboard()` from 18.0 Keyman Engine APi so Keyman Engine handles the responsibility to send the longpress delay value to KeymanWeb.

android-host.js now caches the longpress value, so the call can now work before the keyboard is loaded.

## User Testing
**Setup** - Install the PR build of Keyman for Android. Set and enable Keyman as the default system keyboard.
When the tests ask to adjust the longpress delay value, in Keyman app, go to Settings --> Adjust longpress delay --> 
adjust the slider to the specified time and exit the menu with the back button on the menu

* **TEST_ADJUST_DELAY_MENU** - Verifies the longpress delay value can be adjusted and applied
1. Launch Keyman and dismiss the "Get Started" menu
2. Longpress on the default keyboard and observe the duration to trigger the longpress keys (default 0.5 seconds).
3. Adjust the longpress delay to the maximum 1.5 seconds and return the Keyman app
4. Longpress on the default keyboard and verify longpress keys take 1.5 seconds to trigger.
5. Open a separate app (Chrome browser) and select a text area
6. With Keyman as the system keyboard, longpress on the keyboard and verify longpress keys take 1.5 seconds to trigger.
7. Return to the Keyman app
8. Adjust the longpress delay to the minimum 0.3 seconds and return to the Keyman app
9. Longpress on the default keyboard and verify longpress keys take 0.3 seconds to trigger.
10. Open a separate app (Chrome browser) and select a text area
11. With Keyman as the system keyboard, longpress on the keyboard and verify longpress keys take 0.3 seconds to trigger.

* **TEST_INITIAL_LONGPRESS** - Verifies the stored longpress value is restored when Keyman restarts
1. Launch Keyman and dismiss the "Get Started" menu
2. Adjust the longpress delay to 1.5 seconds and return to the Keyman app
3. Close Keyman and restart
4. When Keyman app returns, longpress on the default keyboard and verify longpress keys take 1.5 seconds to trigger.
5. Open a separate app (Chrome browser) and select text area
6. With Keyman as the system keyboard, longpress on the keyboard and verify longpress keys take 1.5 seconds to trigger.
