### PR TITLE
feat(linux): add `--remote-debug` flag to `run-tests.sh` script  🕷️

### DIFF
--- a/docs/settings/linux/launch.json
+++ b/docs/settings/linux/launch.json
@@ -40,7 +40,7 @@
       "valuesFormatting": "parseText"
     },
     {
-      // start: gdbserver 10.3.0.58:2345 /media/sf_Develop/keyman/keyman/linux/build/x86_64/debug/tests/ibus-keyman-tests
+      // start: linux/ibus-keyman/tests/scripts/run-tests.sh --remote-debug --no-surrounding-text --no-wayland -- k_001___basic_input_unicodei
       // then attach debugger in vscode
       "type": "gdb",
       "request": "attach",

--- a/linux/ibus-keyman/tests/README.md
+++ b/linux/ibus-keyman/tests/README.md
@@ -24,3 +24,26 @@ To run a single test you pass the testname (as found in
 ```bash
 scripts/run-tests.sh -- k_000___null_keyboard k_005___nul_with_initial_context
 ```
+
+## Debugging tests
+
+This is most easily done by running the tests in a VM and then remote debugging
+into the VM. The VM should be the same Linux version as the host, and the
+Keyman repo should be shared with the VM through a shared folder.
+
+Then you can start the `run-tests.sh` script on the VM with the
+`--remote-debug` option. This will start the background services and then
+start a GDB session waiting for the debugger to connect.
+
+For example:
+
+```bash
+linux/ibus-keyman/tests/scripts/run-tests.sh --remote-debug \
+  --no-surrounding-text --no-wayland -- k_001___basic_input_unicodei
+```
+
+On the host, you can then attach to the VM. See the
+`Attach to gdbserver (ibus-keyman integration tests)` configuration
+in `docs/settings/linux/launch.json` for a sample configuration in
+vscode. You'll have to adjust the IP address to match the VM which the
+`run-tests.sh` script will output.


### PR DESCRIPTION
This allows to run the tests in a VM and debug them remotely. Also document debugging the integration tests, and improve the output if dependencies are missing.

Also some cleanup.

@keymanapp-test-bot skip