### PR TITLE
feat(windows): hack in some fun features for kmdevlink

### DIFF
--- a/windows/src/support/kmdevlink/UfrmOpenCRMRecord.dfm
+++ b/windows/src/support/kmdevlink/UfrmOpenCRMRecord.dfm
@@ -20,9 +20,9 @@ object frmOpenCRMRecord: TfrmOpenCRMRecord
   object TntLabel1: TLabel
     Left = 20
     Top = 20
-    Width = 62
+    Width = 115
     Height = 19
-    Caption = '&Issue/PR'
+    Caption = '&Issue/PR/Search'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
     Font.Height = -16
@@ -45,9 +45,9 @@ object frmOpenCRMRecord: TfrmOpenCRMRecord
     ParentFont = False
   end
   object editSearchFor: TEdit
-    Left = 108
+    Left = 156
     Top = 17
-    Width = 341
+    Width = 293
     Height = 27
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
@@ -66,7 +66,7 @@ object frmOpenCRMRecord: TfrmOpenCRMRecord
     Caption = 'OK'
     Default = True
     ModalResult = 1
-    TabOrder = 1
+    TabOrder = 3
   end
   object cmdCancel: TButton
     Left = 240
@@ -76,12 +76,12 @@ object frmOpenCRMRecord: TfrmOpenCRMRecord
     Cancel = True
     Caption = 'Cancel'
     ModalResult = 2
-    TabOrder = 2
+    TabOrder = 4
   end
   object cbRepository: TComboBox
-    Left = 108
+    Left = 156
     Top = 69
-    Width = 341
+    Width = 293
     Height = 27
     Style = csDropDownList
     Font.Charset = DEFAULT_CHARSET
@@ -90,7 +90,16 @@ object frmOpenCRMRecord: TfrmOpenCRMRecord
     Font.Name = 'Tahoma'
     Font.Style = []
     ParentFont = False
-    TabOrder = 3
+    TabOrder = 1
     OnClick = cbRepositoryClick
+  end
+  object cmdCopyHTML: TButton
+    Left = 156
+    Top = 110
+    Width = 159
+    Height = 25
+    Caption = 'Copy short form as &HTML link'
+    TabOrder = 2
+    OnClick = cmdCopyHTMLClick
   end
 end


### PR DESCRIPTION
This was an evening activity scratching itches on kmdevlink's 'Open Issue' dialog. The search box now supports three different types of strings:

1. `[[repo]#]num` -> open issue/PR #num in repo (if repo omitted, will use 'keyman'):
   * `13235` or `#13235` or `keyman#13235` -> opens PR #13235
   * `keyman.com#545` -> opens PR keymanapp/keyman.com#545
   * `api#172` -> opens PR keymanapp/api.keyman.com#172
2. `[[repo]#]searchtext` -> any non-numeric string does an issue search:
   * `label:ios/ font` -> opens an issue search for 'ios/' label and 'font' in keymanapp/keyman repo
   * `api#db` -> opens an issue search for 'db' in keymanapp/api.keyman.com repo
3. `[[repo]#]` -> opens issue list for repo (keymanapp/keyman if repo is omitted, or empty box)

A second feature is construction of a HTML snippet of our usual short-form links to issues/PRs for Google Docs. Note that this dialog does not check if the target is an issue or PR, it just builds a link to the issue URL and lets GitHub redirect to PR. To use this, just type the `[[repo]#]num` format into the search field and click the Copy button.

@keymanapp-test-bot skip