### PR TITLE
chore(developer): vscode:package dependency 🗼

### DIFF
--- a/developer/src/vscode-plugin/.gitignore
+++ b/developer/src/vscode-plugin/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode-test/
 *.vsix
 !.vscode
+/LICENSE.md

--- a/developer/src/vscode-plugin/README.md
+++ b/developer/src/vscode-plugin/README.md
@@ -26,6 +26,12 @@ There is also a `build.sh` which works the usual way.
 
 - You can use the **Developer: Reload Window** command to reload the `[extension development]` window with a new version of the plugin.
 
+## Packaging .vsix
+
+- `npm run vscode:package`
+
+(Doesn't work yet.)
+
 ## License
 
 Copyright (c) SIL Global.

--- a/developer/src/vscode-plugin/package.json
+++ b/developer/src/vscode-plugin/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@keymanapp/keyman-developer-vscode",
+  "name": "keyman-developer-vscode",
+  "version": "18.0.0-PREALPHA",
   "displayName": "Keyman Developer for VSCode",
   "description": "Plugin for compiling Keyman projects in VSCode",
   "engines": {
@@ -17,13 +18,14 @@
   "contributes": {
   },
   "scripts": {
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "npm run compile && cp ../../../LICENSE.md .",
     "compile": "tsc -b ./",
     "watch": "tsc -watch -b ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",
     "test": "echo use 'ui-test' to run the test - TODO-LDML-EDITOR",
-    "ui-test": "vscode-test"
+    "ui-test": "vscode-test",
+    "vscode:package": "npx '@vscode/vsce' package"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.0",
@@ -39,5 +41,6 @@
     "@keymanapp/kmc-kmn": "*",
     "@keymanapp/kmc-ldml": "*",
     "@keymanapp/kmc-package": "*"
-  }
+  },
+  "private": "true"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2141,7 +2141,8 @@
       }
     },
     "developer/src/vscode-plugin": {
-      "name": "@keymanapp/keyman-developer-vscode",
+      "name": "keyman-developer-vscode",
+      "version": "18.0.0-PREALPHA",
       "license": "MIT",
       "dependencies": {
         "@keymanapp/common-types": "*",
@@ -3026,10 +3027,6 @@
     },
     "node_modules/@keymanapp/hextobin": {
       "resolved": "common/tools/hextobin",
-      "link": true
-    },
-    "node_modules/@keymanapp/keyman-developer-vscode": {
-      "resolved": "developer/src/vscode-plugin",
       "link": true
     },
     "node_modules/@keymanapp/keyman-version": {
@@ -11309,6 +11306,10 @@
     },
     "node_modules/keyman": {
       "resolved": "web",
+      "link": true
+    },
+    "node_modules/keyman-developer-vscode": {
+      "resolved": "developer/src/vscode-plugin",
       "link": true
     },
     "node_modules/keyv": {


### PR DESCRIPTION
- rename the package to keyman-developer-vscode because of vscode naming rules (and private: true)
- add a step to copy the LICENSE.md file in vscode:prepublish
- add a version 18.0.0-PREALPHA to the package.json

For: #12835