### PR TITLE
fix(linux): update location of lcov.deb for Jammy

### DIFF
--- a/resources/docker-images/linux/Dockerfile
+++ b/resources/docker-images/linux/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 # version 2.0-1 from Mantic.
 RUN LCOV_VERSION=$(dpkg -s lcov | grep Version | cut -d' ' -f2) && \
   if dpkg --compare-versions "${LCOV_VERSION}" lt 2.0; then \
-    curl -sS -o /tmp/lcov.deb --location http://mirrors.kernel.org/ubuntu/pool/universe/l/lcov/lcov_2.0-1_all.deb && \
+    curl -sS -o /tmp/lcov.deb --location https://old-releases.ubuntu.com/ubuntu/pool/universe/l/lcov/lcov_2.0-1ubuntu0.2_all.deb && \
     apt-get -qy install /tmp/lcov.deb && \
     rm /tmp/lcov.deb ; \
   fi

--- a/resources/docker-images/run.sh
+++ b/resources/docker-images/run.sh
@@ -7,6 +7,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "${KEYMAN_ROOT}/resources/build/minimum-versions.inc.sh"
+. "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
 
 ################################ Main script ################################
 
@@ -35,6 +36,12 @@ run_core() {
 }
 
 run_linux() {
+  if [[ -z "${UBUNTU_VERSION:-}" ]]; then
+    image_version=default
+  else
+    image_version="${UBUNTU_VERSION}-java${KEYMAN_VERSION_JAVA}-node$(_print_expected_node_version)-emsdk${KEYMAN_MIN_VERSION_EMSCRIPTEN}"
+  fi
+
   mkdir -p "${KEYMAN_ROOT}/linux/build/docker-linux"
   mkdir -p "${KEYMAN_ROOT}/linux/keyman-system-service/build/docker-linux"
   docker run -it --privileged --rm -v "${KEYMAN_ROOT}":/home/build/build \
@@ -42,7 +49,7 @@ run_linux() {
     -v "${KEYMAN_ROOT}/linux/build/docker-linux":/home/build/build/linux/build \
     -v "${KEYMAN_ROOT}/linux/keyman-system-service/build/docker-linux":/home/build/build/linux/keyman-system-service/build \
     -e DESTDIR=/tmp \
-    keymanapp/keyman-linux-ci:default \
+    "keymanapp/keyman-linux-ci:${image_version}" \
     "${builder_extra_params[@]}"
 }
 


### PR DESCRIPTION
This changes the download URL for the lcov package to the official Ubuntu archive, after it was no longer available at kernel.org.

@keymanapp-test-bot skip
