### PR TITLE
fix(android): Use TIER.md to determine Play Store tier

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -128,7 +128,7 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE)
-        switch (tier) {
+        switch (String.valueOf(tier)) {
             case 'beta':
                 track.set("beta")
                 println "TIER set to beta"

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -67,6 +67,7 @@ android {
     productFlavors {
     }
 
+    String tier = new File('../../TIER.md').getText('UTF-8').trim();
     applicationVariants.all { variant ->
         // Append tag to app name to help differentiate versions for app testers:
         //  - stable builds have no suffix
@@ -75,7 +76,7 @@ android {
         //  - PR builds also have "-test-1234" suffix (where 1234 is PR#)
         // Gradle sync will nullify these values, so have a fallback
         String appSuffix = ''
-        String tag = VERSION_TAG ? VERSION_TAG : '-' + new File('../../TIER.md').getText('UTF-8');
+        String tag = VERSION_TAG ? VERSION_TAG : '-' + tier;
         if (tag.startsWithAny("-beta", "beta")) {
             appSuffix = ' Beta';
         } else if (tag.startsWithAny("-alpha", "alpha")) {
@@ -127,7 +128,7 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE)
-        switch (System.env.TIER) {
+        switch (tier) {
             case 'beta':
                 track.set("beta")
                 println "TIER set to beta"

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -96,7 +96,7 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE)
-        switch (tier) {
+        switch (String.valueOf(tier)) {
             case 'beta':
                 track.set("beta")
                 println "TIER set to beta"

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -54,6 +54,7 @@ android {
     productFlavors {
     }
 
+    String tier = new File('../../../TIER.md').getText('UTF-8').trim();
     applicationVariants.all { variant ->
         // Adjust output name to "firstvoices-${VERSION_MD}.apk"
         variant.outputs.all {
@@ -95,7 +96,7 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE)
-        switch (System.env.TIER) {
+        switch (tier) {
             case 'beta':
                 track.set("beta")
                 println "TIER set to beta"


### PR DESCRIPTION
Fixes #13254

Recent Android beta builds fail to publish to the Play Store because we recently removed `System.env.TIER` from the Android CI configurations. Both Keyman and FirstVoices app build.gradle files were using the environment var to determine the tier to publish on the Play Store.

This updates the gradle files to use TIER.md.

@keymanapp-test-bot skip


