### PR TITLE
fix(android): Correct the scope of `tier` in build.gradle

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -9,6 +9,8 @@ plugins {
 ext.rootPath = '../../'
 apply from: "$rootPath/version.gradle"
 
+String tier = new File('../../TIER.md').getText('UTF-8').trim();
+
 android {
     compileSdk 34
     namespace="com.tavultesoft.kmapro"
@@ -67,7 +69,6 @@ android {
     productFlavors {
     }
 
-    String tier = new File('../../TIER.md').getText('UTF-8').trim();
     applicationVariants.all { variant ->
         // Append tag to app name to help differentiate versions for app testers:
         //  - stable builds have no suffix
@@ -128,7 +129,7 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE)
-        switch (String.valueOf(tier)) {
+        switch (tier) {
             case 'beta':
                 track.set("beta")
                 println "TIER set to beta"

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -54,7 +54,6 @@ android {
     productFlavors {
     }
 
-    String tier = new File('../../../TIER.md').getText('UTF-8').trim();
     applicationVariants.all { variant ->
         // Adjust output name to "firstvoices-${VERSION_MD}.apk"
         variant.outputs.all {
@@ -96,7 +95,8 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE)
-        switch (String.valueOf(tier)) {
+        String tier = new File('../../../TIER.md').getText('UTF-8').trim();
+        switch (tier) {
             case 'beta':
                 track.set("beta")
                 println "TIER set to beta"


### PR DESCRIPTION
Fixes #13265 and follow-on to #13259

I tried to refactor `tier` in the build.gradle files and didn't have the scope high enough to be visible to where the build failed.

This is take-2

The FirstVoices build.gradle only uses tier in once place, so made that one local.

@keymanapp-test-bot skip


