### PR TITLE
fix(web): provide informative error + message when loading UI without the engine

### DIFF
--- a/web/src/app/ui/kmwuibutton.ts
+++ b/web/src/app/ui/kmwuibutton.ts
@@ -5,9 +5,20 @@
 
 import type { KeymanEngine, UIModule } from 'keyman/app/browser';
 
-declare var keyman: KeymanEngine
+declare global {
+  interface Window {
+    keyman: KeymanEngine
+  }
+}
 
-if(!keyman?.ui?.name) {
+const keymanweb=window.keyman;
+
+// If a UI module has been loaded, we can rely on the publically-published 'name' property
+// having been set as a way to short-out a UI reload.  Its parent object always exists by
+// this point in the build process.
+if(!keymanweb) {
+  throw new Error("`keyman` global is missing; Keyman Engine for Web script has not been loaded");
+} else if(!keymanweb.ui?.name) {
 
   /********************************/
   /*                              */
@@ -26,7 +37,6 @@ if(!keyman?.ui?.name) {
 
   try {
     // Declare KeymanWeb, OnScreen keyboard and Util objects
-    const keymanweb = keyman;
     const util=keymanweb.util;
     // var dbg=keymanweb['debug'];
 

--- a/web/src/app/ui/kmwuifloat.ts
+++ b/web/src/app/ui/kmwuifloat.ts
@@ -5,12 +5,20 @@
 
 import type { KeymanEngine, UIModule } from 'keyman/app/browser';
 
-declare var keyman: KeymanEngine
+declare global {
+  interface Window {
+    keyman: KeymanEngine
+  }
+}
+
+const keymanweb=window.keyman;
 
 // If a UI module has been loaded, we can rely on the publically-published 'name' property
 // having been set as a way to short-out a UI reload.  Its parent object always exists by
 // this point in the build process.
-if(!keyman?.ui?.name) {
+if(!keymanweb) {
+  throw new Error("`keyman` global is missing; Keyman Engine for Web script has not been loaded");
+} else if(!keymanweb.ui?.name) {
   /********************************/
   /*                              */
   /* Floating User Interface      */
@@ -29,7 +37,6 @@ if(!keyman?.ui?.name) {
   try {
 
     // Declare KeymanWeb, OnScreen keyboard and Util objects
-    const keymanweb = keyman;
     const util=keymanweb.util;
 
     // Disable UI for touch devices

--- a/web/src/app/ui/kmwuitoggle.ts
+++ b/web/src/app/ui/kmwuitoggle.ts
@@ -6,7 +6,11 @@
 import type { KeymanEngine, KeyboardCookie, UIModule } from 'keyman/app/browser';
 import type { FloatingOSKViewCookie } from 'keyman/engine/osk';
 
-declare var keyman: KeymanEngine
+declare global {
+  interface Window {
+    keyman: KeymanEngine
+  }
+}
 
 type KeyboardMenuEntry = {
   _InternalName: string,
@@ -18,10 +22,14 @@ interface Owned<T> {
   _owningObject?: T;
 }
 
+const keymanweb=window.keyman;
+
 // If a UI module has been loaded, we can rely on the publically-published 'name' property
 // having been set as a way to short-out a UI reload.  Its parent object always exists by
 // this point in the build process.
-if(!keyman?.ui?.name) {
+if(!keymanweb) {
+  throw new Error("`keyman` global is missing; Keyman Engine for Web script has not been loaded");
+} else if(!keymanweb.ui?.name) {
   /********************************/
   /*                              */
   /* Toggle User Interface Code   */
@@ -39,7 +47,6 @@ if(!keyman?.ui?.name) {
 
   try {
     // Declare KeymanWeb, OnScreen Keyboard and Util objects
-    const keymanweb = keyman;
     //var dbg=keymanweb['debug'];
     const util = keymanweb.util;
 

--- a/web/src/app/ui/kmwuitoolbar.ts
+++ b/web/src/app/ui/kmwuitoolbar.ts
@@ -5,7 +5,11 @@
 
 import type { KeymanEngine, KeyboardCookie, UIModule } from 'keyman/app/browser';
 
-declare var keyman: KeymanEngine
+declare global {
+  interface Window {
+    keyman: KeymanEngine
+  }
+}
 
 type MapRegion = {
   /** The title of the region */
@@ -50,10 +54,14 @@ interface ListedKeyboard {
   aNode: HTMLAnchorElement;
 }
 
+const keymanweb=window.keyman;
+
 // If a UI module has been loaded, we can rely on the publically-published 'name' property
 // having been set as a way to short-out a UI reload.  Its parent object always exists by
 // this point in the build process.
-if(!keyman?.ui?.name) {
+if(!keymanweb) {
+  throw new Error("`keyman` global is missing; Keyman Engine for Web script has not been loaded");
+} else if(!keymanweb.ui?.name) {
   /********************************/
   /*                              */
   /* Toolbar User Interface       */
@@ -71,7 +79,6 @@ if(!keyman?.ui?.name) {
 
   try {
     // Declare KeymanWeb, OnScreen keyboard and Util objects
-    const keymanweb=keyman;
     const util=keymanweb.util;
 
     // Disable UI for touch devices


### PR DESCRIPTION
Fixes: #13261

Rather than have the UI module (attempt to) silently fail, it's probably better for site developers if we provide a more clear, informative, and explicit error when such modules fail to load properly.

Granted, this doesn't exactly make the Sentry reports on our own sites in which the engine appears to fail to load (and silently, at that - then fail on attempted engine use) go away.

@keymanapp-test-bot skip