### PR TITLE
fix(web): gracefully disable predictive-text when WebWorkers are unavailable

### DIFF
--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -709,7 +709,7 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
     this.pageIntegration.shutdown();
     this.contextManager.shutdown();
     this.osk?.shutdown();
-    this.core.languageProcessor.shutdown();
+    this.core.languageProcessor?.shutdown();
     this.hardKeyboard.shutdown();
     this.util.shutdown(); // For tracked dom events, stylesheets.
 

--- a/web/src/engine/interfaces/src/prediction/predictionContext.ts
+++ b/web/src/engine/interfaces/src/prediction/predictionContext.ts
@@ -93,19 +93,19 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
   }
 
   private connect() {
-    this.langProcessor.addListener('invalidatesuggestions', this.invalidateSuggestions);
-    this.langProcessor.addListener('suggestionsready', this.updateSuggestions);
-    this.langProcessor.addListener('tryaccept', this.doTryAccept);
-    this.langProcessor.addListener('tryrevert', this.doTryRevert);
-    this.langProcessor.addListener('statechange', this.onModelStateChange);
+    this.langProcessor?.addListener('invalidatesuggestions', this.invalidateSuggestions);
+    this.langProcessor?.addListener('suggestionsready', this.updateSuggestions);
+    this.langProcessor?.addListener('tryaccept', this.doTryAccept);
+    this.langProcessor?.addListener('tryrevert', this.doTryRevert);
+    this.langProcessor?.addListener('statechange', this.onModelStateChange);
   }
 
   public disconnect() {
-    this.langProcessor.removeListener('invalidatesuggestions', this.invalidateSuggestions);
-    this.langProcessor.removeListener('suggestionsready', this.updateSuggestions);
-    this.langProcessor.removeListener('tryaccept', this.doTryAccept);
-    this.langProcessor.removeListener('tryrevert', this.doTryRevert);
-    this.langProcessor.removeListener('statechange', this.onModelStateChange);
+    this.langProcessor?.removeListener('invalidatesuggestions', this.invalidateSuggestions);
+    this.langProcessor?.removeListener('suggestionsready', this.updateSuggestions);
+    this.langProcessor?.removeListener('tryaccept', this.doTryAccept);
+    this.langProcessor?.removeListener('tryrevert', this.doTryRevert);
+    this.langProcessor?.removeListener('statechange', this.onModelStateChange);
     this.clearSuggestions();
   }
 
@@ -356,7 +356,7 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
     if(target) {
       // Note:  should be triggered after the corresponding new-context event rule has been processed,
       // as that may affect the value of layerId here.
-      return this.langProcessor.invalidateContext(target, this.getLayerId());
+      return this.langProcessor?.invalidateContext(target, this.getLayerId()) ?? Promise.resolve([]);
     } else {
       return Promise.resolve([]);
     }

--- a/web/src/engine/main/src/headless/inputProcessor.ts
+++ b/web/src/engine/main/src/headless/inputProcessor.ts
@@ -55,6 +55,11 @@ export class InputProcessor {
     }
   }
 
+  /**
+   * Returns the module directly responsible for communicating with the predictive-text WebWorker.
+   *
+   * Note:  may be `undefined` if the user's browser does not support WebWorkers.  (See #13262.)
+   */
   public get languageProcessor(): LanguageProcessor {
     return this.lngProcessor;
   }

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -61,7 +61,7 @@ export default class KeymanEngine<
       return;
     }
 
-    if(!this.core.languageProcessor.mayCorrect) {
+    if(!this.core.languageProcessor?.mayCorrect) {
       event.keyDistribution = [];
     }
 
@@ -125,7 +125,7 @@ export default class KeymanEngine<
     this.interface = processorConfiguration.keyboardInterface as KeyboardInterface<ContextManager>;
     this.core = new InputProcessor(config.hostDevice, worker, processorConfiguration);
 
-    this.core.languageProcessor.on('statechange', (state) => {
+    this.core.languageProcessor?.on('statechange', (state) => {
       // The banner controller cannot directly trigger a layout-refresh at this time,
       // so we handle that here.
       this.osk?.bannerController.selectBanner(state);
@@ -269,7 +269,7 @@ export default class KeymanEngine<
      * This is called after the suggestion is applied but _before_ new
      * predictions are requested based on the resulting context.
      */
-    this.core.languageProcessor.on('suggestionapplied', () => {
+    this.core.languageProcessor?.on('suggestionapplied', () => {
       // Tell the keyboard that the current layer has not changed
       keyboardProcessor.newLayerStore.set('');
       keyboardProcessor.oldLayerStore.set('');
@@ -418,12 +418,12 @@ export default class KeymanEngine<
 
     if(this.core.activeModel != model) {
       if(this.core.activeModel) {
-        this.core.languageProcessor.unloadModel();
+        this.core.languageProcessor?.unloadModel();
       }
 
       // Semi-hacky management of banner display state.
       if(model) {
-        return this.core.languageProcessor.loadModel(model).then(() => {
+        return this.core.languageProcessor?.loadModel(model).then(() => {
           return model;
         });
       }
@@ -495,7 +495,7 @@ export default class KeymanEngine<
 
     // Is it the active model?
     if(this.core.activeModel && this.core.activeModel.id == modelId) {
-      this.core.languageProcessor.unloadModel();
+      this.core.languageProcessor?.unloadModel();
     }
   }
 


### PR DESCRIPTION
Fixes: #13262

## User Testing

TEST_ANDROID_YETI_WITH_WEB: Using an Android device, verify that our test pages operate normally when using the Yeti browser.

1. Through the play store, install the Yeti browser.
2. Launch Yeti.
3. Navigate to this PR's "Test unminified KeymanWeb" test page.
4. Verify that the page operates normally, displaying our OSK when editing the usual elements, etc.
5. Navigate to this PR's "Predictive Text: Robust Testing" test page.
6. Verify that the page does _not_ display the suggestion banner and that predictive text is disabled.
    - The toggles may throw errors, however.