### PR TITLE
fix(developer): Use 'desktop' for target in OSK fill temp keyboard

### DIFF
--- a/developer/src/tike/child/UfrmKeymanWizard.pas
+++ b/developer/src/tike/child/UfrmKeymanWizard.pas
@@ -3000,7 +3000,7 @@ begin
       else kbdparser.KeyboardText := frameSource.EditorText;
 
     kbdparser.AddRequiredLines;
-    kbdparser.SetSystemStoreValue(ssTargets, 'windows native');
+    kbdparser.SetSystemStoreValue(ssTargets, 'desktop');
     kbdparser.SetSystemStoreValue(ssVersion, SKeymanVersion90);
     kbdparser.DeleteSystemStore(ssVisualKeyboard);
     kbdparser.DeleteSystemStore(ssBitmap);


### PR DESCRIPTION
When the IDE fills the On Screen Keyboard on the basis of the .kmn rules, it generates a temporary .kmn and builds it. When it does this, it temporarily replaces the `&targets` system store with one that is supposed to ensure that a .kmx is generated. However, previously, for reasons long lost in history, the store was filled with the value 'windows native'.

'native' is not a valid target (this may be due to confusion with `if(&platform)` where 'native' is permitted), and now the compiler verifies `&targets` (as of #11918), so this broke the compile.

Now uses 'desktop' (which encompasses 'windows', 'macos', 'linux').

Fixes: #13256
Relates-to: #11918

# User Testing

* TEST_GENERATE_OSK: Please verify that the issue described in #13256 is resolved with this build.