### PR TITLE
fix(android): Update system keyboard height consistently

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -155,16 +155,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     KMManager.onStartInput(attribute, restarting);
     KMManager.resetContext(KeyboardType.KEYBOARD_TYPE_SYSTEM);
 
-    // This method (likely) includes the IME equivalent to `onResume` for `Activity`-based classes,
-    // making it an important time to detect orientation changes.
     Context appContext = getApplicationContext();
-    int newOrientation = KMManager.getOrientation(appContext);
-    if(newOrientation != lastOrientation) {
-      lastOrientation = newOrientation;
-      Configuration newConfig = this.getResources().getConfiguration();
-      KMManager.onConfigurationChanged(newConfig);
-    }
-
     // Temporarily disable predictions on certain fields (e.g. hidden password field or numeric)
     int inputType = attribute.inputType;
     KMManager.setMayPredictOverride(inputType);
@@ -233,6 +224,16 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   @Override
   public void onComputeInsets(InputMethodService.Insets outInsets) {
     super.onComputeInsets(outInsets);
+
+    // This method (likely) includes the IME equivalent to `onResume` for `Activity`-based classes,
+    // making it an important time to detect orientation changes.
+    Context appContext = getApplicationContext();
+    int newOrientation = KMManager.getOrientation(appContext);
+    if(newOrientation != lastOrientation) {
+      lastOrientation = newOrientation;
+      Configuration newConfig = this.getResources().getConfiguration();
+      KMManager.onConfigurationChanged(newConfig);
+    }
 
     // We should extend the touchable region so that Keyman sub keys menu can receive touch events outside the keyboard frame
     Point size = KMManager.getWindowSize(getApplicationContext());


### PR DESCRIPTION
Fixes #13245 and follows #11604 in the long line of changes to fix OSK height after an orientation change (portrait <--> landscape)

This moves the SystemKeyboard orientation update from `onStartInput()` (init only) to [`onComputeInsets()`](https://developer.android.com/reference/android/inputmethodservice/InputMethodService#onComputeInsets(android.inputmethodservice.InputMethodService.Insets)) where it's consistently called on configuration changes.

## User Testing
**Setup** - Install the PR build of Keyman for Android. 

* **TEST_OSK_HEIGHT_AFTER_ADJUSTING** - Verifies system keyboard OSK height is correct after adjusting the height and rotating
1. Launch the Keyman app in portrait view.
2. The "Get Started" menu appears, enable Keyman as a system keyboard and set it as the default keyboard.
3. Resize the keyboard height by choosing Keyman settings --> Adjust keyboard height
  * adjust the height
  * back to the Keyman app
4. Rotate the mobile device from portrait view to landscape view.
5. Resize the keyboard height by choosing Keyman settings --> Adjust keyboard height
  * adjust the height
  * back to the Keyman app 
6.Verify the keyboard height in landscape view matches the setting.
7. Rotate the mobile device from landscape view to portrait view.
8. Open the Chrome app and then navigate to the Google search box.
9. Click in the search box.
10. Verify the keyboard height matches the adjusted portrait height.
