### PR TITLE
fix(linux): address compiling with ICU 76

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,9 @@
+keyman (18.0-1) UNRELEASED; urgency=medium
+
+  * closes: 1092463
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 19 Feb 2025 17:21:51 +0100
+
 keyman (17.0.335-1) unstable; urgency=medium
 
   * New upstream release.


### PR DESCRIPTION
Turns out that Keyman 18 already compiles with ICU 76, so the only thing left to do is mark the Debian bug as being closed by this change.

Fixes: #12920

@keymanapp-test-bot skip