### PR TITLE
fix(android): prevent update-checks from crashing system keyboard and app if `DownloadManager` is disabled 🍒  🏠

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -4,6 +4,10 @@
 
 package com.keyman.android;
 
+import com.keyman.engine.cloud.DownloadManagerDisabledException;
+import com.keyman.engine.util.DownloadFileUtils;
+import com.keyman.engine.util.KMLog;
+import com.tavultesoft.kmapro.AdjustLongpressDelayActivity;
 import com.tavultesoft.kmapro.BuildConfig;
 import com.tavultesoft.kmapro.DefaultLanguageResource;
 import com.tavultesoft.kmapro.KeymanSettingsActivity;
@@ -82,7 +86,12 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     boolean mayHaveHapticFeedback = prefs.getBoolean(KeymanSettingsActivity.hapticFeedbackKey, false);
     KMManager.setHapticFeedback(mayHaveHapticFeedback);
 
-    KMManager.executeResourceUpdate(this);
+    // Checking for updates should never be allowed to crash the keyboard.
+    // Just silently fail if this occurs.
+    if(DownloadFileUtils.getDownloadManager(this) != null) {
+      // Will try to emit a toast if it fails - i.e., is not silent.
+      KMManager.executeResourceUpdate(this);
+    }
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -4,7 +4,6 @@
 
 package com.keyman.android;
 
-import com.keyman.engine.cloud.DownloadManagerDisabledException;
 import com.keyman.engine.util.DownloadFileUtils;
 import com.keyman.engine.util.KMLog;
 import com.tavultesoft.kmapro.AdjustLongpressDelayActivity;

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -5,7 +5,6 @@
 package com.keyman.android;
 
 import com.keyman.engine.util.DownloadFileUtils;
-import com.keyman.engine.util.KMLog;
 import com.tavultesoft.kmapro.AdjustLongpressDelayActivity;
 import com.tavultesoft.kmapro.BuildConfig;
 import com.tavultesoft.kmapro.DefaultLanguageResource;

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -5,7 +5,6 @@
 package com.keyman.android;
 
 import com.keyman.engine.util.DownloadFileUtils;
-import com.tavultesoft.kmapro.AdjustLongpressDelayActivity;
 import com.tavultesoft.kmapro.BuildConfig;
 import com.tavultesoft.kmapro.DefaultLanguageResource;
 import com.tavultesoft.kmapro.KeymanSettingsActivity;

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -971,9 +971,15 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
           aPreparedCloudApiParams.add(new CloudApiTypes.CloudApiParam(
             CloudApiTypes.ApiTarget.KeyboardLexicalModels, url).setType(CloudApiTypes.JSONType.Array));
 
-          CloudDownloadMgr.getInstance().executeAsDownload(
-            context, _downloadid, null, _callback,
-            aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
+          try {
+            CloudDownloadMgr.getInstance().executeAsDownload(
+              context, _downloadid, null, _callback,
+              aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
+          } catch (DownloadManagerDisabledException e) {
+            Toast.makeText(context,
+              context.getString(R.string.update_check_unavailable),
+              Toast.LENGTH_SHORT).show();
+          }
         }
       }
     }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -32,7 +32,6 @@ import com.keyman.engine.KeyboardEventHandler.OnKeyboardDownloadEventListener;
 import com.keyman.engine.KeyboardEventHandler.OnKeyboardEventListener;
 import com.keyman.engine.cloud.CloudApiTypes;
 import com.keyman.engine.cloud.CloudDownloadMgr;
-import com.keyman.engine.cloud.DownloadManagerDisabledException;
 import com.keyman.engine.cloud.impl.CloudLexicalModelMetaDataDownloadCallback;
 import com.keyman.engine.data.CloudRepository;
 import com.keyman.engine.data.Dataset;

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -32,6 +32,7 @@ import com.keyman.engine.KeyboardEventHandler.OnKeyboardDownloadEventListener;
 import com.keyman.engine.KeyboardEventHandler.OnKeyboardEventListener;
 import com.keyman.engine.cloud.CloudApiTypes;
 import com.keyman.engine.cloud.CloudDownloadMgr;
+import com.keyman.engine.cloud.DownloadManagerDisabledException;
 import com.keyman.engine.cloud.impl.CloudLexicalModelMetaDataDownloadCallback;
 import com.keyman.engine.data.CloudRepository;
 import com.keyman.engine.data.Dataset;
@@ -154,6 +155,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     }
 
     KMManager.initialize(getApplicationContext(), KeyboardType.KEYBOARD_TYPE_INAPP);
+
     KMManager.executeResourceUpdate(this);
 
     DefaultLanguageResource.install(context);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -971,14 +971,19 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
           aPreparedCloudApiParams.add(new CloudApiTypes.CloudApiParam(
             CloudApiTypes.ApiTarget.KeyboardLexicalModels, url).setType(CloudApiTypes.JSONType.Array));
 
+          Toast errorToast = Toast.makeText(context,
+            context.getString(com.keyman.engine.R.string.update_check_unavailable),
+            Toast.LENGTH_SHORT);
+
           try {
             CloudDownloadMgr.getInstance().executeAsDownload(
               context, _downloadid, null, _callback,
               aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
           } catch (DownloadManagerDisabledException e) {
-            Toast.makeText(context,
-              context.getString(R.string.update_check_unavailable),
-              Toast.LENGTH_SHORT).show();
+            errorToast.show();
+          } catch (Exception e) {
+            errorToast.show();
+            KMLog.LogException(TAG, "Unexpected exception occurred during download attempt", e);
           }
         }
       }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -971,20 +971,9 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
           aPreparedCloudApiParams.add(new CloudApiTypes.CloudApiParam(
             CloudApiTypes.ApiTarget.KeyboardLexicalModels, url).setType(CloudApiTypes.JSONType.Array));
 
-          Toast errorToast = Toast.makeText(context,
-            context.getString(com.keyman.engine.R.string.update_check_unavailable),
-            Toast.LENGTH_SHORT);
-
-          try {
-            CloudDownloadMgr.getInstance().executeAsDownload(
-              context, _downloadid, null, _callback,
-              aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
-          } catch (DownloadManagerDisabledException e) {
-            errorToast.show();
-          } catch (Exception e) {
-            errorToast.show();
-            KMLog.LogException(TAG, "Unexpected exception occurred during download attempt", e);
-          }
+          CloudDownloadMgr.getInstance().executeAsDownload(
+            context, _downloadid, null, _callback,
+            aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
         }
       }
     }

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -27,9 +27,6 @@
   <!-- Context: Menu Action -->
   <string name="action_install_updates" comment="Menu notification that keyboard or dictionary updates available">Install Updates</string>
 
-  <!-- Context:  Update check failure notification -->
-  <string name="update_check_impossible" comment="Notification that the app cannot check for keyboard updates">DownloadManager disabled - cannot check for updates</string>
-
   <!-- Context: Title -->
   <string name="title_version" comment="Title of Keyman for Android version">Version: %1$s</string>
 

--- a/android/KMAPro/kMAPro/src/main/res/values/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values/strings.xml
@@ -27,6 +27,8 @@
   <!-- Context: Menu Action -->
   <string name="action_install_updates" comment="Menu notification that keyboard or dictionary updates available">Install Updates</string>
 
+  <!-- Context:  Update check failure notification -->
+  <string name="update_check_impossible" comment="Notification that the app cannot check for keyboard updates">DownloadManager disabled - cannot check for updates</string>
 
   <!-- Context: Title -->
   <string name="title_version" comment="Title of Keyman for Android version">Version: %1$s</string>

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
@@ -166,20 +166,9 @@ public class KMKeyboardDownloaderActivity extends BaseActivity {
         context.getString(R.string.keyboard_download_start_in_background),
         Toast.LENGTH_SHORT).show();
 
-      Toast errorToast = Toast.makeText(context,
-        context.getString(R.string.update_check_unavailable),
-        Toast.LENGTH_SHORT);
-
-      try {
-        CloudDownloadMgr.getInstance().executeAsDownload(
-          context, _downloadid, null, _callback,
-          aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
-      } catch (DownloadManagerDisabledException e) {
-        errorToast.show();
-      } catch (Exception e) {
-        errorToast.show();
-        KMLog.LogException(TAG, "Unexpected exception occurred during download attempt", e);
-      }
+      CloudDownloadMgr.getInstance().executeAsDownload(
+        context, _downloadid, null, _callback,
+        aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
     }
 
     ((AppCompatActivity) context).finish();
@@ -232,20 +221,9 @@ public class KMKeyboardDownloaderActivity extends BaseActivity {
         context.getString(R.string.dictionary_download_start_in_background),
         Toast.LENGTH_SHORT).show();
 
-      Toast errorToast = Toast.makeText(context,
-        context.getString(R.string.update_check_unavailable),
-        Toast.LENGTH_SHORT);
-
-      try {
-        CloudDownloadMgr.getInstance().executeAsDownload(
-          context, _downloadid, null, _callback,
-          aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
-      } catch (DownloadManagerDisabledException e) {
-        errorToast.show();
-      } catch (Exception e) {
-        errorToast.show();
-        KMLog.LogException(TAG, "Unexpected exception occurred during download attempt", e);
-      }
+      CloudDownloadMgr.getInstance().executeAsDownload(
+        context, _downloadid, null, _callback,
+        aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
     }
 
     ((AppCompatActivity) context).finish();

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
@@ -15,6 +15,7 @@ import com.keyman.engine.cloud.impl.CloudKeyboardPackageDownloadCallback;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.data.KeyboardController;
 import com.keyman.engine.cloud.impl.CloudLexicalPackageDownloadCallback;
+import com.keyman.engine.util.KMLog;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -165,14 +166,19 @@ public class KMKeyboardDownloaderActivity extends BaseActivity {
         context.getString(R.string.keyboard_download_start_in_background),
         Toast.LENGTH_SHORT).show();
 
+      Toast errorToast = Toast.makeText(context,
+        context.getString(R.string.update_check_unavailable),
+        Toast.LENGTH_SHORT);
+
       try {
         CloudDownloadMgr.getInstance().executeAsDownload(
           context, _downloadid, null, _callback,
           aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
       } catch (DownloadManagerDisabledException e) {
-        Toast.makeText(context,
-          context.getString(R.string.update_check_unavailable),
-          Toast.LENGTH_SHORT).show();
+        errorToast.show();
+      } catch (Exception e) {
+        errorToast.show();
+        KMLog.LogException(TAG, "Unexpected exception occurred during download attempt", e);
       }
     }
 
@@ -226,14 +232,19 @@ public class KMKeyboardDownloaderActivity extends BaseActivity {
         context.getString(R.string.dictionary_download_start_in_background),
         Toast.LENGTH_SHORT).show();
 
+      Toast errorToast = Toast.makeText(context,
+        context.getString(R.string.update_check_unavailable),
+        Toast.LENGTH_SHORT);
+
       try {
         CloudDownloadMgr.getInstance().executeAsDownload(
           context, _downloadid, null, _callback,
           aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
       } catch (DownloadManagerDisabledException e) {
-        Toast.makeText(context,
-          context.getString(R.string.update_check_unavailable),
-          Toast.LENGTH_SHORT).show();
+        errorToast.show();
+      } catch (Exception e) {
+        errorToast.show();
+        KMLog.LogException(TAG, "Unexpected exception occurred during download attempt", e);
       }
     }
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
@@ -10,7 +10,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.keyman.engine.cloud.CloudApiTypes;
 import com.keyman.engine.cloud.CloudDataJsonUtil;
 import com.keyman.engine.cloud.CloudDownloadMgr;
-import com.keyman.engine.cloud.DownloadManagerDisabledException;
 import com.keyman.engine.cloud.impl.CloudKeyboardPackageDownloadCallback;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.data.KeyboardController;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
@@ -13,8 +13,7 @@ import com.keyman.engine.cloud.CloudDownloadMgr;
 import com.keyman.engine.cloud.impl.CloudKeyboardPackageDownloadCallback;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.data.KeyboardController;
-import com.keyman.engine.cloud.impl.CloudLexicalPackageDownloadCallback;
-import com.keyman.engine.util.KMLog;
+import com.keyman.engine.cloud.impl.CloudLexicalPackageDownloadCallback;=
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.keyman.engine.cloud.CloudApiTypes;
 import com.keyman.engine.cloud.CloudDataJsonUtil;
 import com.keyman.engine.cloud.CloudDownloadMgr;
+import com.keyman.engine.cloud.DownloadManagerDisabledException;
 import com.keyman.engine.cloud.impl.CloudKeyboardPackageDownloadCallback;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.data.KeyboardController;
@@ -72,7 +73,7 @@ public class KMKeyboardDownloaderActivity extends BaseActivity {
 
   //TODO: move to keyboard manager class
   private static ArrayList<KeyboardEventHandler.OnKeyboardDownloadEventListener> kbDownloadEventListeners = null;
-  
+
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -164,9 +165,15 @@ public class KMKeyboardDownloaderActivity extends BaseActivity {
         context.getString(R.string.keyboard_download_start_in_background),
         Toast.LENGTH_SHORT).show();
 
-      CloudDownloadMgr.getInstance().executeAsDownload(
-        context, _downloadid, null, _callback,
-        aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
+      try {
+        CloudDownloadMgr.getInstance().executeAsDownload(
+          context, _downloadid, null, _callback,
+          aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
+      } catch (DownloadManagerDisabledException e) {
+        Toast.makeText(context,
+          context.getString(R.string.update_check_unavailable),
+          Toast.LENGTH_SHORT).show();
+      }
     }
 
     ((AppCompatActivity) context).finish();
@@ -219,9 +226,15 @@ public class KMKeyboardDownloaderActivity extends BaseActivity {
         context.getString(R.string.dictionary_download_start_in_background),
         Toast.LENGTH_SHORT).show();
 
-      CloudDownloadMgr.getInstance().executeAsDownload(
-        context, _downloadid, null, _callback,
-        aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
+      try {
+        CloudDownloadMgr.getInstance().executeAsDownload(
+          context, _downloadid, null, _callback,
+          aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
+      } catch (DownloadManagerDisabledException e) {
+        Toast.makeText(context,
+          context.getString(R.string.update_check_unavailable),
+          Toast.LENGTH_SHORT).show();
+      }
     }
 
     ((AppCompatActivity) context).finish();

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardDownloaderActivity.java
@@ -13,7 +13,7 @@ import com.keyman.engine.cloud.CloudDownloadMgr;
 import com.keyman.engine.cloud.impl.CloudKeyboardPackageDownloadCallback;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.data.KeyboardController;
-import com.keyman.engine.cloud.impl.CloudLexicalPackageDownloadCallback;=
+import com.keyman.engine.cloud.impl.CloudLexicalPackageDownloadCallback;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/ModelPickerActivity.java
@@ -112,20 +112,9 @@ public final class ModelPickerActivity extends BaseActivity {
         aPreparedCloudApiParams.add(new CloudApiTypes.CloudApiParam(
           CloudApiTypes.ApiTarget.KeyboardLexicalModels, url).setType(CloudApiTypes.JSONType.Array));
 
-        Toast errorToast = Toast.makeText(context,
-          context.getString(R.string.update_check_unavailable),
-          Toast.LENGTH_SHORT);
-
-        try {
-          CloudDownloadMgr.getInstance().executeAsDownload(
-            context, _downloadid, null, _callback,
-            aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
-        } catch (DownloadManagerDisabledException e) {
-          errorToast.show();
-        } catch (Exception e) {
-          errorToast.show();
-          KMLog.LogException(TAG, "Unexpected exception occurred during download attempt", e);
-        }
+        CloudDownloadMgr.getInstance().executeAsDownload(
+          context, _downloadid, null, _callback,
+          aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
       } else {
         Toast.makeText(context,
           context.getString(R.string.cannot_connect),

--- a/android/KMEA/app/src/main/java/com/keyman/engine/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/ModelPickerActivity.java
@@ -29,6 +29,7 @@ import com.keyman.engine.data.Dataset;
 import com.keyman.engine.data.LexicalModel;
 import com.keyman.engine.data.adapters.NestedAdapter;
 import com.keyman.engine.util.BCP47;
+import com.keyman.engine.util.KMLog;
 import com.keyman.engine.util.MapCompat;
 
 import java.io.File;
@@ -111,14 +112,19 @@ public final class ModelPickerActivity extends BaseActivity {
         aPreparedCloudApiParams.add(new CloudApiTypes.CloudApiParam(
           CloudApiTypes.ApiTarget.KeyboardLexicalModels, url).setType(CloudApiTypes.JSONType.Array));
 
+        Toast errorToast = Toast.makeText(context,
+          context.getString(R.string.update_check_unavailable),
+          Toast.LENGTH_SHORT);
+
         try {
           CloudDownloadMgr.getInstance().executeAsDownload(
             context, _downloadid, null, _callback,
             aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
         } catch (DownloadManagerDisabledException e) {
-          Toast.makeText(context,
-            context.getString(R.string.update_check_unavailable),
-            Toast.LENGTH_SHORT).show();
+          errorToast.show();
+        } catch (Exception e) {
+          errorToast.show();
+          KMLog.LogException(TAG, "Unexpected exception occurred during download attempt", e);
         }
       } else {
         Toast.makeText(context,

--- a/android/KMEA/app/src/main/java/com/keyman/engine/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/ModelPickerActivity.java
@@ -22,6 +22,7 @@ import androidx.appcompat.widget.Toolbar;
 
 import com.keyman.engine.cloud.CloudApiTypes;
 import com.keyman.engine.cloud.CloudDownloadMgr;
+import com.keyman.engine.cloud.DownloadManagerDisabledException;
 import com.keyman.engine.cloud.impl.CloudLexicalModelMetaDataDownloadCallback;
 import com.keyman.engine.data.CloudRepository;
 import com.keyman.engine.data.Dataset;
@@ -110,9 +111,15 @@ public final class ModelPickerActivity extends BaseActivity {
         aPreparedCloudApiParams.add(new CloudApiTypes.CloudApiParam(
           CloudApiTypes.ApiTarget.KeyboardLexicalModels, url).setType(CloudApiTypes.JSONType.Array));
 
-        CloudDownloadMgr.getInstance().executeAsDownload(
-          context, _downloadid, null, _callback,
-          aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
+        try {
+          CloudDownloadMgr.getInstance().executeAsDownload(
+            context, _downloadid, null, _callback,
+            aPreparedCloudApiParams.toArray(new CloudApiTypes.CloudApiParam[0]));
+        } catch (DownloadManagerDisabledException e) {
+          Toast.makeText(context,
+            context.getString(R.string.update_check_unavailable),
+            Toast.LENGTH_SHORT).show();
+        }
       } else {
         Toast.makeText(context,
           context.getString(R.string.cannot_connect),

--- a/android/KMEA/app/src/main/java/com/keyman/engine/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/ModelPickerActivity.java
@@ -28,7 +28,6 @@ import com.keyman.engine.data.Dataset;
 import com.keyman.engine.data.LexicalModel;
 import com.keyman.engine.data.adapters.NestedAdapter;
 import com.keyman.engine.util.BCP47;
-import com.keyman.engine.util.KMLog;
 import com.keyman.engine.util.MapCompat;
 
 import java.io.File;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/ModelPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/ModelPickerActivity.java
@@ -22,7 +22,6 @@ import androidx.appcompat.widget.Toolbar;
 
 import com.keyman.engine.cloud.CloudApiTypes;
 import com.keyman.engine.cloud.CloudDownloadMgr;
-import com.keyman.engine.cloud.DownloadManagerDisabledException;
 import com.keyman.engine.cloud.impl.CloudLexicalModelMetaDataDownloadCallback;
 import com.keyman.engine.data.CloudRepository;
 import com.keyman.engine.data.Dataset;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.keyman.engine.R;
 import com.keyman.engine.util.KMLog;
 import com.keyman.engine.util.DownloadFileUtils;
 
@@ -214,17 +215,16 @@ public class CloudDownloadMgr{
                                 ModelType aTargetModel,
                                 ICloudDownloadCallback<ModelType,ResultType> aCallback,
                                 CloudApiTypes.CloudApiParam... params) throws DownloadManagerDisabledException {
-    Toast errorToast = Toast.makeText(aContext,
-      // TODO:  reintroduce custom error message
-      aContext.getString(com.keyman.engine.R.string.update_check_unavailable),
-      Toast.LENGTH_SHORT);
-
     try {
       executeAsDownloadInternal(aContext, aDownloadIdentifier, aTargetModel, aCallback, params);
     } catch (DownloadManagerDisabledException e) {
-      errorToast.show();
+      Toast.makeText(aContext,
+        aContext.getString(R.string.update_check_download_manager_disabled),
+        Toast.LENGTH_SHORT).show();
     } catch (Exception e) {
-      errorToast.show();
+      Toast.makeText(aContext,
+        aContext.getString(R.string.update_check_unavailable),
+        Toast.LENGTH_SHORT).show();
       KMLog.LogException(TAG, "Unexpected exception occurred during download/query attempt", e);
     }
   }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
@@ -242,10 +242,9 @@ public class CloudDownloadMgr{
 
     DownloadManager downloadManager = DownloadFileUtils.getDownloadManager(aContext);
     if(downloadManager == null) {
-      aCallback.initializeContext(aContext);
-
-      // Signal the failure state; we literally can't do this right now!
-      // Fortunately, that does mean there's no need to signal via callback.
+      // The callback object provided to us provides no way to directly signal a
+      // failure.  That said, we can also immediately detect that we WILL fail and
+      // corresponding error _now_, rather than later.
       //
       // Unique custom error so it's easy to explicitly filter.
       throw new DownloadManagerDisabledException();

--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.keyman.engine.util.KMLog;
 import com.keyman.engine.util.DownloadFileUtils;
@@ -212,8 +213,26 @@ public class CloudDownloadMgr{
   public <ModelType,ResultType> void executeAsDownload(Context aContext, String aDownloadIdentifier,
                                 ModelType aTargetModel,
                                 ICloudDownloadCallback<ModelType,ResultType> aCallback,
-                                CloudApiTypes.CloudApiParam... params) throws DownloadManagerDisabledException
-  {
+                                CloudApiTypes.CloudApiParam... params) throws DownloadManagerDisabledException {
+    Toast errorToast = Toast.makeText(aContext,
+      // TODO:  reintroduce custom error message
+      aContext.getString(com.keyman.engine.R.string.update_check_unavailable),
+      Toast.LENGTH_SHORT);
+
+    try {
+      executeAsDownloadInternal(aContext, aDownloadIdentifier, aTargetModel, aCallback, params);
+    } catch (DownloadManagerDisabledException e) {
+      errorToast.show();
+    } catch (Exception e) {
+      errorToast.show();
+      KMLog.LogException(TAG, "Unexpected exception occurred during download/query attempt", e);
+    }
+  }
+
+  private <ModelType,ResultType> void executeAsDownloadInternal(Context aContext, String aDownloadIdentifier,
+                                ModelType aTargetModel,
+                                ICloudDownloadCallback<ModelType,ResultType> aCallback,
+                                CloudApiTypes.CloudApiParam... params) throws DownloadManagerDisabledException {
     if(!isInitialized) {
       Log.w(TAG, "DownloadManager not initialized. Initializing CloudDownloadMgr.");
       initialize(aContext);

--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/CloudDownloadMgr.java
@@ -210,23 +210,28 @@ public class CloudDownloadMgr{
    * @param params the cloud api params for download
    * @param <ModelType> the target models type
    * @param <ResultType> the cloud requests result type
+   * @return `false` if the download request cannot be executed; `true` otherwise.
    */
-  public <ModelType,ResultType> void executeAsDownload(Context aContext, String aDownloadIdentifier,
+  public <ModelType,ResultType> boolean executeAsDownload(Context aContext, String aDownloadIdentifier,
                                 ModelType aTargetModel,
                                 ICloudDownloadCallback<ModelType,ResultType> aCallback,
-                                CloudApiTypes.CloudApiParam... params) throws DownloadManagerDisabledException {
+                                CloudApiTypes.CloudApiParam... params) {
     try {
       executeAsDownloadInternal(aContext, aDownloadIdentifier, aTargetModel, aCallback, params);
     } catch (DownloadManagerDisabledException e) {
       Toast.makeText(aContext,
         aContext.getString(R.string.update_check_download_manager_disabled),
         Toast.LENGTH_SHORT).show();
+      return false;
     } catch (Exception e) {
       Toast.makeText(aContext,
         aContext.getString(R.string.update_check_unavailable),
         Toast.LENGTH_SHORT).show();
       KMLog.LogException(TAG, "Unexpected exception occurred during download/query attempt", e);
+      return false;
     }
+
+    return true;
   }
 
   private <ModelType,ResultType> void executeAsDownloadInternal(Context aContext, String aDownloadIdentifier,

--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/DownloadManagerDisabledException.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/DownloadManagerDisabledException.java
@@ -1,0 +1,7 @@
+package com.keyman.engine.cloud;
+
+public class DownloadManagerDisabledException extends RuntimeException {
+  DownloadManagerDisabledException() {
+    super("System service DownloadManager is not available and cannot facilitate downloads or queries.");
+  }
+}

--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
@@ -12,6 +12,7 @@ import com.keyman.engine.R;
 import com.keyman.engine.cloud.CloudApiTypes;
 import com.keyman.engine.cloud.CloudDataJsonUtil;
 import com.keyman.engine.cloud.CloudDownloadMgr;
+import com.keyman.engine.cloud.DownloadManagerDisabledException;
 import com.keyman.engine.cloud.ICloudDownloadCallback;
 import com.keyman.engine.util.KMLog;
 
@@ -111,9 +112,15 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
 
           BaseActivity.makeToast(aContext, R.string.dictionary_download_start_in_background, Toast.LENGTH_SHORT);
 
-          CloudDownloadMgr.getInstance().executeAsDownload(aContext,
-            _r.additionalDownloadid, null, _callback,
-            _r.additionalDownloads.toArray(new CloudApiTypes.CloudApiParam[0]));
+          try {
+            CloudDownloadMgr.getInstance().executeAsDownload(aContext,
+              _r.additionalDownloadid, null, _callback,
+              _r.additionalDownloads.toArray(new CloudApiTypes.CloudApiParam[0]));
+          } catch (DownloadManagerDisabledException e) {
+            Toast.makeText(aContext,
+              aContext.getString(R.string.update_check_unavailable),
+              Toast.LENGTH_SHORT).show();
+          }
         }
       }
     }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
@@ -112,14 +112,19 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
 
           BaseActivity.makeToast(aContext, R.string.dictionary_download_start_in_background, Toast.LENGTH_SHORT);
 
+          Toast errorToast = Toast.makeText(aContext,
+            aContext.getString(R.string.update_check_unavailable),
+            Toast.LENGTH_SHORT);
+
           try {
-            CloudDownloadMgr.getInstance().executeAsDownload(aContext,
-              _r.additionalDownloadid, null, _callback,
+            CloudDownloadMgr.getInstance().executeAsDownload(
+              aContext, _r.additionalDownloadid, null, _callback,
               _r.additionalDownloads.toArray(new CloudApiTypes.CloudApiParam[0]));
           } catch (DownloadManagerDisabledException e) {
-            Toast.makeText(aContext,
-              aContext.getString(R.string.update_check_unavailable),
-              Toast.LENGTH_SHORT).show();
+            errorToast.show();
+          } catch (Exception e) {
+            errorToast.show();
+            KMLog.LogException(TAG, "Unexpected exception occurred during download attempt", e);
           }
         }
       }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
@@ -12,7 +12,6 @@ import com.keyman.engine.R;
 import com.keyman.engine.cloud.CloudApiTypes;
 import com.keyman.engine.cloud.CloudDataJsonUtil;
 import com.keyman.engine.cloud.CloudDownloadMgr;
-import com.keyman.engine.cloud.DownloadManagerDisabledException;
 import com.keyman.engine.cloud.ICloudDownloadCallback;
 import com.keyman.engine.util.KMLog;
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/cloud/impl/CloudLexicalModelMetaDataDownloadCallback.java
@@ -112,20 +112,9 @@ public class CloudLexicalModelMetaDataDownloadCallback implements ICloudDownload
 
           BaseActivity.makeToast(aContext, R.string.dictionary_download_start_in_background, Toast.LENGTH_SHORT);
 
-          Toast errorToast = Toast.makeText(aContext,
-            aContext.getString(R.string.update_check_unavailable),
-            Toast.LENGTH_SHORT);
-
-          try {
-            CloudDownloadMgr.getInstance().executeAsDownload(
-              aContext, _r.additionalDownloadid, null, _callback,
-              _r.additionalDownloads.toArray(new CloudApiTypes.CloudApiParam[0]));
-          } catch (DownloadManagerDisabledException e) {
-            errorToast.show();
-          } catch (Exception e) {
-            errorToast.show();
-            KMLog.LogException(TAG, "Unexpected exception occurred during download attempt", e);
-          }
+          CloudDownloadMgr.getInstance().executeAsDownload(
+            aContext, _r.additionalDownloadid, null, _callback,
+            _r.additionalDownloads.toArray(new CloudApiTypes.CloudApiParam[0]));
         }
       }
     }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/data/CloudRepository.java
@@ -416,6 +416,9 @@ public class CloudRepository {
             context, DOWNLOAD_IDENTIFIER_CATALOGUE, memCachedDataset, _download_callback, params);
         } catch (DownloadManagerDisabledException e) {
           onFailure.run();
+        } catch (Exception e) {
+          KMLog.LogException(TAG, "Unexpected exception type occurred when trying to query the server", e);
+          onFailure.run();
         }
       }
     }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/data/CloudRepository.java
@@ -411,15 +411,9 @@ public class CloudRepository {
         BaseActivity.makeToast(context, R.string.catalog_download_is_running_in_background, Toast.LENGTH_SHORT);
       } else {
         updateIsRunning = true;
-        try {
-          CloudDownloadMgr.getInstance().executeAsDownload(
-            context, DOWNLOAD_IDENTIFIER_CATALOGUE, memCachedDataset, _download_callback, params);
-        } catch (DownloadManagerDisabledException e) {
-          onFailure.run();
-        } catch (Exception e) {
-          KMLog.LogException(TAG, "Unexpected exception type occurred when trying to query the server", e);
-          onFailure.run();
-        }
+        CloudDownloadMgr.getInstance().executeAsDownload(
+          context, DOWNLOAD_IDENTIFIER_CATALOGUE, memCachedDataset, _download_callback, params);
+        // if it fails, we should `updateIsRunning = false`, right?
       }
     }
   }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/data/CloudRepository.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/data/CloudRepository.java
@@ -411,9 +411,13 @@ public class CloudRepository {
         BaseActivity.makeToast(context, R.string.catalog_download_is_running_in_background, Toast.LENGTH_SHORT);
       } else {
         updateIsRunning = true;
-        CloudDownloadMgr.getInstance().executeAsDownload(
+        boolean executionStarted = CloudDownloadMgr.getInstance().executeAsDownload(
           context, DOWNLOAD_IDENTIFIER_CATALOGUE, memCachedDataset, _download_callback, params);
-        // if it fails, we should `updateIsRunning = false`, right?
+        if(!executionStarted) {
+          // Since we couldn't initiate the execution's async components,
+          // we need to immediately clear the update-running flag.
+          updateIsRunning = false;
+        }
       }
     }
   }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/logic/ResourcesUpdateTool.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/logic/ResourcesUpdateTool.java
@@ -122,6 +122,8 @@ public class ResourcesUpdateTool implements KeyboardEventHandler.OnKeyboardDownl
           return;
         }
 
+        // Warning:  can be run by our system keyboard, which will attempt to
+        // display the toast if it or the app is visible!
         BaseActivity.makeToast(currentContext, R.string.update_check_unavailable, Toast.LENGTH_SHORT);
         lastUpdateCheck = Calendar.getInstance();
         updateCheckFailed = true;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/util/DownloadFileUtils.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/util/DownloadFileUtils.java
@@ -3,7 +3,9 @@
  */
 package com.keyman.engine.util;
 
+import android.app.DownloadManager;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.OpenableColumns;
@@ -20,6 +22,35 @@ import java.io.InputStream;
  */
 public final class DownloadFileUtils {
   private static final String TAG = "DownloadFileUtils";
+
+  private static final String DOWNLOAD_MANAGER_PACKAGE_NAME = "com.android.providers.downloads";
+
+  /**
+   * Determines whether or not Android's `DownloadManager` service is active;
+   * downloads and cloud queries are impossible when it's disabled.
+   *
+   * This solution is based heavily on
+   * https://gist.github.com/Folyd/b9412bb6e2b06eb511f7.
+   * @return
+   */
+  public static DownloadManager getDownloadManager(Context context) {
+    DownloadManager downloadManager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
+    if(downloadManager==null) {
+      return null;
+    }
+
+    int state = context.getPackageManager().getApplicationEnabledSetting(DOWNLOAD_MANAGER_PACKAGE_NAME);
+
+    if(
+      state == PackageManager.COMPONENT_ENABLED_STATE_DISABLED ||
+        state == PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER ||
+        state == PackageManager.COMPONENT_ENABLED_STATE_DISABLED_UNTIL_USED
+    ) {
+      return null;
+    };
+
+    return downloadManager;
+  }
 
   /**
    * Small class for returning information about a file downloaded via DownloadManager.

--- a/android/KMEA/app/src/main/java/com/keyman/engine/util/DownloadFileUtils.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/util/DownloadFileUtils.java
@@ -26,12 +26,14 @@ public final class DownloadFileUtils {
   private static final String DOWNLOAD_MANAGER_PACKAGE_NAME = "com.android.providers.downloads";
 
   /**
-   * Determines whether or not Android's `DownloadManager` service is active;
-   * downloads and cloud queries are impossible when it's disabled.
+   * Determines whether or not Android's `DownloadManager` service is active, only
+   * returning an instance of DownloadManager when it is currently accessible and enabled.
+   * Downloads and cloud queries are impossible when it's disabled.
    *
    * This solution is based heavily on
    * https://gist.github.com/Folyd/b9412bb6e2b06eb511f7.
-   * @return
+   * @return A valid and enabled reference to the system's DownloadManager service.  May be null
+   * if it is not accessible or is disabled.
    */
   public static DownloadManager getDownloadManager(Context context) {
     DownloadManager downloadManager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);

--- a/android/KMEA/app/src/main/res/values/strings.xml
+++ b/android/KMEA/app/src/main/res/values/strings.xml
@@ -184,6 +184,9 @@
     <!-- Context: General Updates -->
     <string name="update_check_unavailable" comment="Error message when a Keyman server can't be reached">Failed to access server!</string>
 
+    <!-- Context:  Update-check failure notification -->
+    <string name="update_check_download_manager_disabled" comment="Notification that a system service needed for updates is disabled">DownloadManager disabled - cannot check for updates</string>
+
     <!-- Context: General Updates -->
     <string name="update_check_current" comment="Notification that all resources are up to date">"All resources are up to date!"</string>
 


### PR DESCRIPTION
Fixes: #11568
Fixes: KEYMAN-ANDROID-3AB
Cherry-pick-of: #13218

@keymanapp-test-bot skip