### PR TITLE
fix(web): reconnect, patch up engine/main headless unit tests

### DIFF
--- a/web/src/engine/main/build.sh
+++ b/web/src/engine/main/build.sh
@@ -49,6 +49,7 @@ do_build () {
 builder_run_action configure verify_npm_setup
 builder_run_action clean rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
 builder_run_action build do_build
+builder_run_action test test-headless "${SUBPROJECT_NAME}"
 
 # No headless tests for this child project.  Currently, DOM-based unit &
 # integrated tests are run solely by the top-level $KEYMAN_ROOT/web project.


### PR DESCRIPTION
During work on #13290, I happened to discover that the `engine/main` child project for Web did not have an actual `test` action, despite having defined headless unit tests.  This PR rectifies the issue and also patches up said tests to operate with the current state of the codebase.

@keymanapp-test-bot skip