### PR TITLE
cherrypick(android): Use TIER.md to determine Play Store tier 🏠

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -9,6 +9,8 @@ plugins {
 ext.rootPath = '../../'
 apply from: "$rootPath/version.gradle"
 
+String tier = new File('../../TIER.md').getText('UTF-8').trim();
+
 android {
     compileSdk 34
     namespace="com.tavultesoft.kmapro"
@@ -75,7 +77,7 @@ android {
         //  - PR builds also have "-test-1234" suffix (where 1234 is PR#)
         // Gradle sync will nullify these values, so have a fallback
         String appSuffix = ''
-        String tag = VERSION_TAG ? VERSION_TAG : '-' + new File('../../TIER.md').getText('UTF-8');
+        String tag = VERSION_TAG ? VERSION_TAG : '-' + tier;
         if (tag.startsWithAny("-beta", "beta")) {
             appSuffix = ' Beta';
         } else if (tag.startsWithAny("-alpha", "alpha")) {
@@ -127,7 +129,7 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE)
-        switch (System.env.TIER) {
+        switch (tier) {
             case 'beta':
                 track.set("beta")
                 println "TIER set to beta"

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -95,7 +95,8 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE)
-        switch (System.env.TIER) {
+        String tier = new File('../../../TIER.md').getText('UTF-8').trim();
+        switch (tier) {
             case 'beta':
                 track.set("beta")
                 println "TIER set to beta"


### PR DESCRIPTION
:cherries: pick of #13259 and #13268 to stable-17.0

This is in case we need to do another stable-17.0 build before 18.0 is released

We recently removed `System.env.TIER` from the Android CI configurations. 
Both Keyman and FirstVoices app build.gradle files were using the environment var to determine the tier to publish on the Play Store.

This updates the gradle files to use TIER.md.

@keymanapp-test-bot skip