### PR TITLE
fix(developer): verify `context(n)` offsets are valid in kmcmplib

### DIFF
--- a/developer/src/common/include/kmn_compiler_errors.h
+++ b/developer/src/common/include/kmn_compiler_errors.h
@@ -272,6 +272,9 @@ namespace KmnCompilerMessages {
 
     HINT_IndexStoreLong =                               SevHint | 0x0B0,
 
+    ERROR_ContextExCannotReferenceIf =                  SevError | 0x0B1,
+    ERROR_ContextExCannotReferenceNul =                 SevError | 0x0B2,
+
     FATAL_BufferOverflow =                                SevFatal | 0x0C0
 //    FATAL_Break =                                         SevFatal | 0x0C1,      unused
   };

--- a/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
@@ -737,7 +737,19 @@ export class KmnCompilerMessages {
   static HINT_IndexStoreLong                                  = SevHint | 0x0B0;
   static Hint_IndexStoreLong                                  = () => m(
     this.HINT_IndexStoreLong,
-    `The store referenced in index() is longer than the store referenced in any()`
+    `The store referenced in index() is longer than the store referenced in any()`,
+  );
+
+  static ERROR_ContextExCannotReferenceIf                     = SevError | 0x0B1;
+  static Error_ContextExCannotReferenceIf                     = () => m(
+    this.ERROR_ContextExCannotReferenceIf,
+    `The offset in context() points to a non-character if() statement in the context`,
+  );
+
+  static ERROR_ContextExCannotReferenceNul                    = SevError | 0x0B2;
+  static Error_ContextExCannotReferenceNul                     = () => m(
+    this.ERROR_ContextExCannotReferenceNul,
+    `The offset in context() points to a non-character nul statement in the context`,
   );
 
   static FATAL_BufferOverflow                                 = SevFatal | 0x0C0;

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_cannot_reference_if.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_cannot_reference_if.kmn
@@ -1,0 +1,11 @@
+﻿store(&TARGETS) 'any'
+
+begin Unicode > use(main)
+
+store(cons) 'bcd'
+store(ifx) '1'
+
+group(main) using keys
+
+c ERROR_ContextExCannotReferenceIf:
+if(ifx = '1') any(cons) + 'd' > context(1)

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_cannot_reference_nul.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_cannot_reference_nul.kmn
@@ -1,0 +1,10 @@
+﻿store(&TARGETS) 'any'
+
+begin Unicode > use(main)
+
+store(cons) 'bcd'
+
+group(main) using keys
+
+c ERROR_ContextExCannotReferenceNul:
+nul any(cons) + 'a' > 'x' context(1)

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_has_invalid_offset_if.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_has_invalid_offset_if.kmn
@@ -1,0 +1,12 @@
+﻿store(&TARGETS) 'any'
+
+begin Unicode > use(main)
+
+store(cons) 'bcd'
+store(ifx) '1'
+
+group(main) using keys
+
+c ERROR_ContextExHasInvalidOffset: `context(3)` should be `context(2)`
+if(ifx='1') any(cons) + 'a' > 'x' context(3) 'z'
+

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_has_invalid_offset_long.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_has_invalid_offset_long.kmn
@@ -1,0 +1,11 @@
+﻿store(&TARGETS) 'any'
+
+begin Unicode > use(main)
+
+store(cons) 'bcd'
+
+group(main) using keys
+
+c ERROR_ContextExHasInvalidOffset: `context(2)` is longer than range
+any(cons) + 'a' > 'x' context(2) 'z'
+

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_has_invalid_offset_nul.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_has_invalid_offset_nul.kmn
@@ -1,0 +1,12 @@
+﻿store(&TARGETS) 'any'
+
+begin Unicode > use(main)
+
+store(cons) 'bcd'
+store(ifx) '1'
+
+group(main) using keys
+
+c ERROR_ContextExHasInvalidOffset: `context(3)` should be `context(2)`
+nul any(cons) + 'a' > 'x' context(3) 'z'
+

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_has_invalid_offset_zero.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/error_contextex_has_invalid_offset_zero.kmn
@@ -1,0 +1,11 @@
+﻿store(&TARGETS) 'any'
+
+begin Unicode > use(main)
+
+store(cons) 'bcd'
+
+group(main) using keys
+
+c ERROR_ContextExHasInvalidOffset: `context(0)` is lower than 1
+any(cons) + 'a' > 'x' context(0) 'z'
+

--- a/developer/src/kmc-kmn/test/messages.tests.ts
+++ b/developer/src/kmc-kmn/test/messages.tests.ts
@@ -185,7 +185,6 @@ describe('KmnCompilerMessages', function () {
 
   it('should generate WARN_IndexStoreShort if a store referenced in index() is shorter than the corresponding any() store', async function() {
     await testForMessage(this, ['keyboards', 'warn_index_store_short.kmn'], KmnCompilerMessages.WARN_IndexStoreShort);
-    callbacks.clear();
     await testForMessage(this, ['keyboards', 'warn_index_store_short_key.kmn'], KmnCompilerMessages.WARN_IndexStoreShort);
   });
 
@@ -193,8 +192,28 @@ describe('KmnCompilerMessages', function () {
 
   it('should generate HINT_IndexStoreLong if a store referenced in index() is longer than the corresponding any() store', async function() {
     await testForMessage(this, ['keyboards', 'hint_index_store_long.kmn'], KmnCompilerMessages.HINT_IndexStoreLong);
-    callbacks.clear();
     await testForMessage(this, ['keyboards', 'hint_index_store_long_key.kmn'], KmnCompilerMessages.HINT_IndexStoreLong);
+  });
+
+  // ERROR_ContextExHasInvalidOffset
+
+  it('should generate ERROR_ContextExHasInvalidOffset if the offset is lower than 1 or greater than the context length', async function() {
+    await testForMessage(this, ['invalid-keyboards', 'error_contextex_has_invalid_offset_if.kmn'], KmnCompilerMessages.ERROR_ContextExHasInvalidOffset);
+    await testForMessage(this, ['invalid-keyboards', 'error_contextex_has_invalid_offset_long.kmn'], KmnCompilerMessages.ERROR_ContextExHasInvalidOffset);
+    await testForMessage(this, ['invalid-keyboards', 'error_contextex_has_invalid_offset_nul.kmn'], KmnCompilerMessages.ERROR_ContextExHasInvalidOffset);
+    await testForMessage(this, ['invalid-keyboards', 'error_contextex_has_invalid_offset_zero.kmn'], KmnCompilerMessages.ERROR_ContextExHasInvalidOffset);
+  });
+
+  // ERROR_ContextExCannotReferenceIf
+
+  it('should generate ERROR_ContextExCannotReferenceIf if the offset points to an if() statement', async function() {
+    await testForMessage(this, ['invalid-keyboards', 'error_contextex_cannot_reference_if.kmn'], KmnCompilerMessages.ERROR_ContextExCannotReferenceIf);
+  });
+
+  // ERROR_ContextExCannotReferenceNul
+
+  it('should generate ERROR_ContextExCannotReferenceNul if the offset points to a nul statement', async function() {
+    await testForMessage(this, ['invalid-keyboards', 'error_contextex_cannot_reference_nul.kmn'], KmnCompilerMessages.ERROR_ContextExCannotReferenceNul);
   });
 
 });


### PR DESCRIPTION
Add validity checks to kmcmplib to verify that offsets provided to `context(n)` are in range for the context, and do not point to non-character elements (`nul` and `if`) in the context string.

Fixes: #13301
Fixes: #13302
Relates-to: #13299
Relates-to: #13276

@keymanapp-test-bot skip