### PR TITLE
fix(android): Control when system keyboard Keyboard Picker clears activity stack

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsActivity.java
@@ -3,6 +3,7 @@ package com.tavultesoft.kmapro;
 import android.os.Bundle;
 
 import com.keyman.engine.BaseActivity;
+import com.keyman.engine.KMManager;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
@@ -32,6 +33,9 @@ public class KeymanSettingsActivity extends BaseActivity {
     }
 
     innerFragment = (KeymanSettingsFragment) getSupportFragmentManager().findFragmentById(R.id.keyman_settings_fragment);
+
+    // For Keyman sites, disable keyboard picker task flag so keyboard picker doesn't dismiss Keyman app
+    KMManager.disableClearActivityTask();
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsActivity.java
@@ -35,7 +35,7 @@ public class KeymanSettingsActivity extends BaseActivity {
     innerFragment = (KeymanSettingsFragment) getSupportFragmentManager().findFragmentById(R.id.keyman_settings_fragment);
 
     // For Keyman sites, disable keyboard picker task flag so keyboard picker doesn't dismiss Keyman app
-    KMManager.disableClearActivityTask();
+    KMManager.dontCloseParentAppOnShowKeyboardPicker();
   }
 
   @Override

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -248,7 +248,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     KMManager.hideSystemKeyboard();
 
     // Reset keyboard picker Activity Task flag
-    KMManager.enableClearActivityTask();
+    KMManager.closeParentAppOnShowKeyboardPicker();
 
     // onConfigurationChanged() only triggers when device is rotated while app is in foreground
     // This handles when device is rotated while app is in background

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -247,6 +247,9 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     KMManager.onResume();
     KMManager.hideSystemKeyboard();
 
+    // Reset keyboard picker Activity Task flag
+    KMManager.enableClearActivityTask();
+
     // onConfigurationChanged() only triggers when device is rotated while app is in foreground
     // This handles when device is rotated while app is in background
     // using KMManager.getOrientation() since getConfiguration().orientation is unreliable #10241

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -791,6 +791,20 @@ public final class KMManager {
     }
   }
 
+  /**
+   * Calls disableClearActivityTask() so keyboard picker from system keyboard won't become the root of the activity stack
+   */
+  public static void disableClearActivityTask() {
+    KeyboardPickerActivity.disableClearActivityTask();
+  }
+
+  /**
+   * Calls enableClearActivityTask() keyboard picker from system keyboard becomes the root of the activity stack
+   */
+  public static void enableClearActivityTask() {
+    KeyboardPickerActivity.enableClearActivityTask();
+  }
+
   @SuppressLint("InflateParams")
   public static View createInputView(InputMethodService inputMethodService) {
     //final Context context = appContext;
@@ -2299,7 +2313,10 @@ public final class KMManager {
 
     if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       i.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
-      i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+      if (KeyboardPickerActivity.getClearActivityTask()) {
+        // Keyboard Picker Activity becomes root activity and clears Keyman app
+        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+      }
     }
 
     i.putExtra(KMKey_DisplayKeyboardSwitcher, kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM);

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -792,17 +792,21 @@ public final class KMManager {
   }
 
   /**
-   * Calls disableClearActivityTask() so keyboard picker from system keyboard won't become the root of the activity stack
+   * Normally, launching the KeyboardPickerActivity from a system keyboard closes the parent app
+   * (The keyboard picker becomes the root of the activity stack)
+   * Calling this function keeps the parent app running in the background
    */
-  public static void disableClearActivityTask() {
-    KeyboardPickerActivity.disableClearActivityTask();
+  public static void dontCloseParentAppOnShowKeyboardPicker() {
+    KeyboardPickerActivity.dontCloseParentAppOnShowKeyboardPicker();
   }
 
   /**
-   * Calls enableClearActivityTask() keyboard picker from system keyboard becomes the root of the activity stack
+   * Normally, launching the KeyboardPickerActivity from a system keyboard closes the parent app
+   * (The keyboard picker becomes the root of the activity stack)
+   * Calling this function restores this default behavior
    */
-  public static void enableClearActivityTask() {
-    KeyboardPickerActivity.enableClearActivityTask();
+  public static void closeParentAppOnShowKeyboardPicker() {
+    KeyboardPickerActivity.closeParentAppOnShowKeyboardPicker();
   }
 
   @SuppressLint("InflateParams")
@@ -2313,7 +2317,7 @@ public final class KMManager {
 
     if (kbType == KeyboardType.KEYBOARD_TYPE_SYSTEM) {
       i.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
-      if (KeyboardPickerActivity.getClearActivityTask()) {
+      if (KeyboardPickerActivity.getCanCloseParentAppOnShowKeyboardPicker()) {
         // Keyboard Picker Activity becomes root activity and clears Keyman app
         i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
       }

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KeyboardPickerActivity.java
@@ -85,9 +85,9 @@ public final class KeyboardPickerActivity extends BaseActivity {
   /*
   // When the System Keyboard launches the keyboard picker while this flag is set,
   // the intent includes Intent.FLAG_ACTIVITY_CLEAR_TASK which clears the activity stack.
-  // Disable this to keep the keyboard picker from clearing the Keyman app.
+  // Disable this to keep the keyboard picker from clearing the parent app.
    */
-  private static boolean canClearActivityTask = true;
+  private static boolean canCloseParentAppOnShowKeyboardPicker = true;
 
   protected static boolean canAddNewKeyboard = true;
   protected static boolean canRemoveKeyboard = true;
@@ -483,23 +483,29 @@ public final class KeyboardPickerActivity extends BaseActivity {
   }
 
   /**
-   * Returns canClearActivityTask
+   * Returns canCloseParentAppOnShowKeyboardPicker
    * @return boolean
    */
-  public static boolean getClearActivityTask() { return canClearActivityTask; }
-
-  /**
-   * Set canClearActivityTask to false so keyboard picker won't become the root of the activity stack
-   */
-  protected static void disableClearActivityTask() {
-    canClearActivityTask = false;
+  public static boolean getCanCloseParentAppOnShowKeyboardPicker() {
+    return canCloseParentAppOnShowKeyboardPicker;
   }
 
   /**
-   * Set canClearActivityTask to true so keyboard picker becomes the root of the activity stack
+   * Normally, launching the KeyboardPickerActivity from a system keyboard closes the parent app
+   * (The keyboard picker becomes the root of the activity stack)
+   * Calling this function keeps the parent app running in the background
    */
-  protected static void enableClearActivityTask() {
-    canClearActivityTask = true;
+  protected static void dontCloseParentAppOnShowKeyboardPicker() {
+    canCloseParentAppOnShowKeyboardPicker = false;
+  }
+
+  /**
+   * Normally, launching the KeyboardPickerActivity from a system keyboard closes the parent app
+   * (The keyboard picker becomes the root of the activity stack)
+   * Calling this function restores this default behavior
+   */
+  protected static void closeParentAppOnShowKeyboardPicker() {
+    canCloseParentAppOnShowKeyboardPicker = true;
   }
 
   /**

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KeyboardPickerActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KeyboardPickerActivity.java
@@ -81,6 +81,14 @@ public final class KeyboardPickerActivity extends BaseActivity {
   }
 
   private boolean dismissOnSelect = true;
+
+  /*
+  // When the System Keyboard launches the keyboard picker while this flag is set,
+  // the intent includes Intent.FLAG_ACTIVITY_CLEAR_TASK which clears the activity stack.
+  // Disable this to keep the keyboard picker from clearing the Keyman app.
+   */
+  private static boolean canClearActivityTask = true;
+
   protected static boolean canAddNewKeyboard = true;
   protected static boolean canRemoveKeyboard = true;
   protected static boolean shouldCheckKeyboardUpdates = true;
@@ -472,6 +480,26 @@ public final class KeyboardPickerActivity extends BaseActivity {
     }
 
     notifyKeyboardsUpdate(context);
+  }
+
+  /**
+   * Returns canClearActivityTask
+   * @return boolean
+   */
+  public static boolean getClearActivityTask() { return canClearActivityTask; }
+
+  /**
+   * Set canClearActivityTask to false so keyboard picker won't become the root of the activity stack
+   */
+  protected static void disableClearActivityTask() {
+    canClearActivityTask = false;
+  }
+
+  /**
+   * Set canClearActivityTask to true so keyboard picker becomes the root of the activity stack
+   */
+  protected static void enableClearActivityTask() {
+    canClearActivityTask = true;
   }
 
   /**


### PR DESCRIPTION
Fixes #12991 

For as long as Keyman for Android 2.8, the system keyboard KeyboardPickerActivity has been setting the `Intent.FLAG_ACTIVITY_CLEAR_TASK` flag which becomes the root activity and clears previous tasks (Keyman app).

When using Keyman as a system keyboard within the Keyman app, we don't want this to occur.

TODO:
- [x] Update API docs #13373

## Change
Add call to  disable/enable when the system keyboard Keyboard Picker clears previous tasks.

## User Testing
**Setup** - Install PR build of Keyman for Android
From "Get Started", set Keyman as the default system keyboard.

* **TEST_INAPP** - Verifies keyboard picker within the Keyman app
1. Launch Keyman for Android
2. With the inapp keyboard, hold the globe key to launch the Keyboard Picker
3. Dismiss the keyboard picker
4. Verify the Keyman app is not dismissed
5. From Keyman, access Keyman settings --> Install Keyboard or Dictionary --> Install from keyman.com
6. From the keyboard search page, select the search box and select Keyman keyboard if need be
7. With the Keyman OSK displayed, hold the globe key to launch the Keyboard Picker
8. Dismiss the keyboard picker
9. Verify the Keyman app is not dismissed

* **TEST_SYSTEM** - Verifies keyboard picker outside the Keyman app
1. Close Keyman if it's running
2. Launch Chrome browser and select the text area and select Keyman keyboard if need be
3. With the Keyman system keyboard OSK displayed, hold the globe key to launch the Keyboard Picker
4. Dismiss the keyboard picker
5. Verify Keyman is not launched in the background

7. 