### PR TITLE
fix(core): include `nul` in context offset calculations in kmx processor

### DIFF
--- a/core/src/kmx/kmx_processevent.h
+++ b/core/src/kmx/kmx_processevent.h
@@ -38,7 +38,10 @@ class KMX_ProcessEvent {
 private:
   PKMX_WORD m_indexStack;
   PKMX_WCHAR m_miniContext;
-  int m_miniContextIfLen; // number of if() statements excluded from start of m_miniContext
+  /** number of `if()` statements excluded from start of `m_miniContext` for offset calculations */
+  int m_miniContextIfLen;
+  /** flag if we need to account for `nul` in offset calculations */
+  bool m_miniContextStartsWithNul;
   KMSTATE m_state;
   km_core_state *m_core_state;
 


### PR DESCRIPTION
Two separate bugs addressed, with `index()` references and with `context()` references -- both have the same root cause, of not taking `nul` at the start of the context into account (as `nul` is not included in the `m_miniContext` member, being a non-character). We already fixed this issue for `if()` quite a long time ago, and some of the same patterns can be seen with `m_miniContextIfLen` for example.

Fixes: #13304
Fixes: #13316

@keymanapp-test-bot skip