### PR TITLE
feat(developer): use .kps folder as initial dir for Add Files

### DIFF
--- a/developer/src/tike/child/UfrmPackageEditor.dfm
+++ b/developer/src/tike/child/UfrmPackageEditor.dfm
@@ -236,7 +236,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 546
           Height = 32
           AutoSize = False
-          Caption = 
+          Caption =
             'A typical package will need keyboards, fonts, and documentation.' +
             ' You shouldn'#39't typically add source files. Also, don'#39't add any s' +
             'tandard Keyman files (such as keyman.exe) here.'
@@ -1342,7 +1342,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Top = 48
           Width = 551
           Height = 13
-          Caption = 
+          Caption =
             'Compiling the package takes all the files you have selected and ' +
             'compresses them into a single package file.'
         end
@@ -1616,12 +1616,5 @@ inherited frmPackageEditor: TfrmPackageEditor
     Title = 'Add Files'
     Left = 32
     Top = 492
-  end
-  object dlgNewCustomisation: TSaveDialog
-    DefaultExt = 'kct'
-    Filter = 'Customisation file (*.kct)|*.kct|All files (*.*)|*.*'
-    Options = [ofOverwritePrompt, ofHideReadOnly, ofPathMustExist, ofEnableSizing]
-    Left = 32
-    Top = 532
   end
 end

--- a/developer/src/tike/child/UfrmPackageEditor.pas
+++ b/developer/src/tike/child/UfrmPackageEditor.pas
@@ -68,7 +68,6 @@ uses
 type
   TfrmPackageEditor = class(TfrmTikeEditor)   // I4689
     dlgFiles: TOpenDialog;
-    dlgNewCustomisation: TSaveDialog;
     pages: TLeftTabbedPageControl;
     pageFiles: TTabSheet;
     pageDetails: TTabSheet;
@@ -628,6 +627,7 @@ begin
     end;
   end;
 
+  dlgFiles.InitialDir := ExtractFileDir(FileName);
   UpdateData;
   Result := True;
 end;
@@ -806,8 +806,10 @@ begin
         if Found then Continue; // Don't add the file again
 
         AddFile(Files[i]);
+        dlgFiles.InitialDir := ExtractFileDir(Files[i]);
       end;
   if lbFiles.CanFocus then lbFiles.SetFocus;  // I3100   // I3506
+  dlgFiles.FileName := '';
 end;
 
 procedure TfrmPackageEditor.cmdRemoveFileClick(Sender: TObject);


### PR DESCRIPTION
Requested by @DavidLRowe. Default was either CWD or My Documents, neither of which is helpful.

The initial dir will now be folder of the .kps file, and then will remember last used folder for each additional use of the dialog for that .kps file.

@keymanapp-test-bot skip