### PR TITLE
fix(developer): include `nul` in offset calculations for kmw v10 compiler

### DIFF
--- a/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/javascript-strings.ts
@@ -643,7 +643,7 @@ export function JavaScript_OutputString(fk: KMX.KEYBOARD, FTabStops: string, fkp
       let recContext = ExpandSentinel(fk, pwszContext, x);
 
       if(isKeyboardVersion10OrLater()) {
-        if(recContext.IsSentinel && [KMX.KMXFile.CODE_NUL, KMX.KMXFile.CODE_IFOPT, KMX.KMXFile.CODE_IFSYSTEMSTORE].includes(recContext.Code)) {
+        if(recContext.IsSentinel && [KMX.KMXFile.CODE_IFOPT, KMX.KMXFile.CODE_IFSYSTEMSTORE].includes(recContext.Code)) {
           Result--;
         }
       }

--- a/developer/src/kmc-kmn/test/fixtures/kmw/test_index_12980_v10.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/test_index_12980_v10.kmn
@@ -1,8 +1,9 @@
 ﻿c test_index_12980 generated from template at 2025-01-22 13:25:35
 c Validates index() offsets when used with if() - see #12980
+c Test with v10+ kmw compiler
 
 store(&VERSION) '14.0'
-store(&NAME) 'test_index_12980'
+store(&NAME) 'test_index_12980_v10'
 store(&TARGETS) 'web'
 
 

--- a/developer/src/kmc-kmn/test/fixtures/kmw/test_index_12980_v9.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/kmw/test_index_12980_v9.kmn
@@ -1,0 +1,22 @@
+﻿c test_index_12980 generated from template at 2025-01-22 13:25:35
+c Validates index() offsets when used with if() - see #12980
+c Test with v9 KMW compiler (does not support notany)
+
+store(&VERSION) '9.0'
+store(&NAME) 'test_index_12980_v9'
+store(&TARGETS) 'web'
+
+
+begin Unicode > use(main)
+
+group(main) using keys
+
+store(a) '1'
+store(b) '2'
+store(e) '5'
+store(f) '6'
+
+if(&platform = 'web') any(a) + 'a' > context 'A'
+if(&platform = 'web') any(b) + 'b' > context(2) 'B'
+nul any(e) + 'e' > context 'E'
+nul any(f) + 'f' > context(2) 'F'


### PR DESCRIPTION
The cached context comparison for v10 kmw compiler includes the `nul` statement, unlike the comparison in the earlier compiler. This difference was missed in earlier iterations including the recent patch in #13003. This patch fixes the problem for both `context(n)` and `index(store,n)` offset calculations.

The earlier v9 kmw compiler is not impacted by this change.

Fixes: #13306
Fixes: #13307
Follows: #13003

@keymanapp-test-bot skip

Note: I will do some low-level tests before merging and add results as a comment.