### PR TITLE
chore: add build.sh edit action for Delphi projects

### DIFF
--- a/common/windows/delphi/components/build.sh
+++ b/common/windows/delphi/components/build.sh
@@ -5,7 +5,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../../resources/build/builder.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-builder_describe "Common Delphi components" clean configure build test
+builder_describe "Common Delphi components" clean configure build test edit
 builder_parse "$@"
 
 #-------------------------------------------------------------------------------------------------------------------
@@ -28,3 +28,4 @@ builder_run_action clean:project        clean_windows_project_files
 builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
+builder_run_action edit:project         start common_components.dproj

--- a/common/windows/delphi/general/KeymanPaths.pas
+++ b/common/windows/delphi/general/KeymanPaths.pas
@@ -19,6 +19,9 @@ type
     const S_CustomisationFilename = 'desktop_pro.pxx';
 
     const S_KeymanAppData_UpdateCache = 'Keyman\UpdateCache\';
+
+    class var FHaveCachedKeymanRoot: Boolean;
+    class var FCachedKeymanRoot: string;
   public
     const S_KMShell = 'kmshell.exe';
     const S_TSysInfoExe = 'tsysinfo.exe';
@@ -434,12 +437,21 @@ end;
 
 class function TKeymanPaths.RunningFromSource(var keyman_root: string): Boolean;
 begin
+  if FHaveCachedKeymanRoot then
+  begin
+    keyman_root := FCachedKeymanRoot;
+    Exit(keyman_root <> '');
+  end;
   // On developer machines, if we are running within the source repo, then use
   // those paths
-  keyman_root := GetEnvironmentVariable('KEYMAN_ROOT');
+  keyman_root := GetEnvironmentVariable('KEYMAN_ROOT').Replace('/', '\', [rfReplaceAll]);
   if keyman_root <> '' then
     keyman_root := IncludeTrailingPathDelimiter(keyman_root);
   Result := (keyman_root <> '') and SameText(keyman_root, ParamStr(0).Substring(0, keyman_root.Length));
+
+  FHaveCachedKeymanRoot := True;
+  if Result then
+    FCachedKeymanRoot := keyman_root;
 end;
 
 class function TKeymanPaths.KeymanCoreLibraryPath(const Filename: string): string;

--- a/common/windows/delphi/tools/build_standards_data/build.sh
+++ b/common/windows/delphi/tools/build_standards_data/build.sh
@@ -5,7 +5,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../../../resources/build/builder.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-builder_describe "Build build_standards_data tool" clean configure build test
+builder_describe "Build build_standards_data tool" clean configure build test edit
 builder_parse "$@"
 
 #-------------------------------------------------------------------------------------------------------------------
@@ -49,3 +49,4 @@ builder_run_action clean:project        clean_windows_project_files
 builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
+builder_run_action edit:project         start build_standards_data.dproj

--- a/common/windows/delphi/tools/buildunidata/build.sh
+++ b/common/windows/delphi/tools/buildunidata/build.sh
@@ -7,7 +7,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 builder_describe "Unicode character database build tool" \
   @/common/windows/delphi:keymanversion \
-  clean configure build test
+  clean configure build test edit
 builder_parse "$@"
 
 #-------------------------------------------------------------------------------------------------------------------
@@ -30,3 +30,4 @@ builder_run_action clean:project        clean_windows_project_files
 builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
+builder_run_action edit:project         start buildunidata.dproj

--- a/common/windows/delphi/tools/devtools/build.sh
+++ b/common/windows/delphi/tools/devtools/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe \
   "Development and build utilities for Delphi" \
   @/common/windows/delphi:keymanversion \
-  clean configure build test prepublish
+  clean configure build test prepublish edit
 
 builder_parse "$@"
 
@@ -30,3 +30,4 @@ builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        delphi_msbuild devtools.dproj "//p:Platform=Win32"
 # builder_run_action test:project         do_test
 builder_run_action prepublish:project   "$DEVTOOLS" -rt
+builder_run_action edit:project         start devtools.dproj

--- a/common/windows/delphi/tools/sentrytool/build.sh
+++ b/common/windows/delphi/tools/sentrytool/build.sh
@@ -5,7 +5,8 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../../../resources/build/builder.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-builder_describe "Sentrytool for converting Delphi symbols into sentry-readable format" clean configure build test
+builder_describe "Sentrytool for converting Delphi symbols into sentry-readable format" \
+  clean configure build test edit
 builder_parse "$@"
 
 #-------------------------------------------------------------------------------------------------------------------
@@ -30,3 +31,4 @@ builder_run_action clean:project        clean_windows_project_files
 builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        delphi_msbuild sentrytool.dproj "//p:Platform=Win32"
 # builder_run_action test:project         do_test
+builder_run_action edit:project         start sentrytoolTests.dproj

--- a/common/windows/delphi/tools/sentrytool/build.sh
+++ b/common/windows/delphi/tools/sentrytool/build.sh
@@ -31,4 +31,4 @@ builder_run_action clean:project        clean_windows_project_files
 builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        delphi_msbuild sentrytool.dproj "//p:Platform=Win32"
 # builder_run_action test:project         do_test
-builder_run_action edit:project         start sentrytoolTests.dproj
+builder_run_action edit:project         start sentrytool.dproj

--- a/common/windows/delphi/tools/test-klog/build.sh
+++ b/common/windows/delphi/tools/test-klog/build.sh
@@ -5,7 +5,8 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../../../resources/build/builder.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-builder_describe "Tool for validating klog is disabled for release builds" clean configure build test prepublish
+builder_describe "Tool for validating klog is disabled for release builds" \
+  clean configure build test prepublish edit
 builder_parse "$@"
 
 #-------------------------------------------------------------------------------------------------------------------
@@ -33,3 +34,4 @@ builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action prepublish:project  "$WIN32_TARGET_PATH/test_klog.exe"
+builder_run_action edit:project         start test_klog.dproj

--- a/common/windows/delphi/tools/verify_signatures/build.sh
+++ b/common/windows/delphi/tools/verify_signatures/build.sh
@@ -5,7 +5,8 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../../../resources/build/builder.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-builder_describe "Tool to verify all Windows executable signatures and manifests" clean configure build test verify
+builder_describe "Tool to verify all Windows executable signatures and manifests" \
+  clean configure build test verify edit
 builder_parse "$@"
 
 #-------------------------------------------------------------------------------------------------------------------
@@ -27,3 +28,4 @@ builder_run_action clean:project        clean_windows_project_files
 builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
+builder_run_action edit:project         start verify_signatures.dproj

--- a/developer/src/common/delphi/build.sh
+++ b/developer/src/common/delphi/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe \
   "Keyman Developer Delphi components" \
   @/common/windows/delphi \
-  clean configure build test
+  clean configure build test edit
 builder_parse "$@"
 
 #-------------------------------------------------------------------------------------------------------------------
@@ -33,3 +33,4 @@ builder_run_action clean:project        clean_windows_project_files
 builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
+builder_run_action edit:project         start delphi_components.dproj

--- a/developer/src/kmconvert/build.sh
+++ b/developer/src/kmconvert/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Keyboard project generation and conversion tool" \
   @/common/include \
   @/common/windows/delphi \
-  clean configure build test publish install
+  clean configure build test publish install edit
 
 builder_parse "$@"
 
@@ -62,3 +62,4 @@ builder_run_action build:project        do_build
 builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
 builder_run_action install:project      cp "$DEVELOPER_PROGRAM/kmconvert.exe" "$INSTALLPATH_KEYMANDEVELOPER/kmconvert.exe"
+builder_run_action edit:project         start kmconvert.dproj

--- a/developer/src/kmdbrowserhost/build.sh
+++ b/developer/src/kmdbrowserhost/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Chromium browser host process for Keyman Developer" \
   @/common/include \
   @/common/windows/delphi \
-  clean configure build test publish install
+  clean configure build test publish install edit
 
 builder_parse "$@"
 
@@ -52,3 +52,5 @@ builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
 builder_run_action install:project      cp "$DEVELOPER_PROGRAM/kmdbrowserhost.exe" "$INSTALLPATH_KEYMANDEVELOPER/kmdbrowserhost.exe"
+builder_run_action edit:project         start kmdbrowserhost.dproj
+

--- a/developer/src/setup/build.sh
+++ b/developer/src/setup/build.sh
@@ -9,7 +9,7 @@ builder_describe \
   "Keyman Developer Setup bootstrap executable" \
   @/common/include \
   @/common/windows/delphi \
-  clean configure build test publish
+  clean configure build test publish edit
 
 builder_parse "$@"
 
@@ -55,3 +55,4 @@ builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        do_build
 builder_run_action publish:project      do_publish
 # builder_run_action test:project         do_test
+builder_run_action edit:project         start setup.dproj

--- a/developer/src/tike/build.sh
+++ b/developer/src/tike/build.sh
@@ -9,7 +9,7 @@ builder_describe "Build Keyman Developer IDE" \
   @/common/include \
   @/core:x86 \
   @/common/windows/delphi \
-  clean configure build test publish install
+  clean configure build test publish install edit
 
 builder_parse "$@"
 
@@ -113,6 +113,7 @@ builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
 builder_run_action install:project      do_install
+builder_run_action edit:project         start tike.dproj
 
 # Note: generating monaco installer:
 # @echo *******************************************************************************************

--- a/windows/src/desktop/insthelp/build.sh
+++ b/windows/src/desktop/insthelp/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Keyman installation helper module" \
   @/common/include \
   @/common/windows/delphi \
-  clean configure build test publish
+  clean configure build test publish edit
 
 builder_parse "$@"
 
@@ -51,3 +51,4 @@ builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
+builder_run_action edit:project         start insthelp.dproj

--- a/windows/src/desktop/kmbrowserhost/build.sh
+++ b/windows/src/desktop/kmbrowserhost/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Chromium browser host process for Keyman" \
   @/common/include \
   @/common/windows/delphi \
-  clean configure build test publish install
+  clean configure build test publish install edit
 
 builder_parse "$@"
 
@@ -50,3 +50,4 @@ builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
 builder_run_action install:project      cp "$WINDOWS_PROGRAM_APP/kmbrowserhost.exe" "$INSTALLPATH_KEYMANAPP/kmbrowserhost.exe"
+builder_run_action edit:project         start kmbrowserhost.dproj

--- a/windows/src/desktop/kmconfig/build.sh
+++ b/windows/src/desktop/kmconfig/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Keyman low-level configuration tool" \
   @/common/include \
   @/common/windows/delphi \
-  clean configure build test publish install
+  clean configure build test publish install edit
 
 builder_parse "$@"
 
@@ -50,3 +50,4 @@ builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
 builder_run_action install:project      cp "$WINDOWS_PROGRAM_APP/kmconfig.exe" "$INSTALLPATH_KEYMANAPP/kmconfig.exe"
+builder_run_action edit:project         start kmconfig.dproj

--- a/windows/src/desktop/kmshell/build.sh
+++ b/windows/src/desktop/kmshell/build.sh
@@ -9,7 +9,7 @@ builder_describe "Keyman Configuration" \
   @/common/include \
   @/common/windows/delphi \
   @/windows/src/global/delphi:message-identifiers \
-  clean configure build test publish install
+  clean configure build test publish install edit
 
 builder_parse "$@"
 
@@ -82,3 +82,4 @@ builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
 builder_run_action install:project      do_install
+builder_run_action edit:project         start kmshell.dproj

--- a/windows/src/desktop/setup/build.sh
+++ b/windows/src/desktop/setup/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Keyman Setup bootstrap" \
   @/common/include \
   @/common/windows/delphi \
-  clean configure build test publish debug-manifest
+  clean configure build test publish debug-manifest edit
 
 builder_parse "$@"
 
@@ -71,3 +71,4 @@ builder_run_action build:project        do_build
 builder_run_action publish:project      do_publish
 
 builder_run_action debug-manifest:project  do_build_debug_manifest
+builder_run_action edit:project         start setup.dproj

--- a/windows/src/engine/insthelper/build.sh
+++ b/windows/src/engine/insthelper/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Installation helper module" \
   @/common/include \
   @/common/windows/delphi \
-  clean configure build test publish
+  clean configure build test publish edit
 
 builder_parse "$@"
 
@@ -46,3 +46,4 @@ builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
+builder_run_action edit:project         start insthelper.dproj

--- a/windows/src/engine/keyman/build.sh
+++ b/windows/src/engine/keyman/build.sh
@@ -9,7 +9,7 @@ builder_describe "Keyman main host process (32-bit)" \
   @/common/include \
   @/common/windows/delphi \
   @/windows/src/global/delphi \
-  clean configure build test publish install debug-manifest
+  clean configure build test publish install debug-manifest edit
 
 builder_parse "$@"
 
@@ -85,3 +85,4 @@ builder_run_action publish:project      do_publish
 builder_run_action install:project      cp "$WINDOWS_PROGRAM_ENGINE/keyman.exe" "$INSTALLPATH_KEYMANENGINE/keyman.exe"
 
 builder_run_action debug-manifest:project  do_build_debug_manifest
+builder_run_action edit:project         start keyman.dproj

--- a/windows/src/engine/kmcomapi/build.sh
+++ b/windows/src/engine/kmcomapi/build.sh
@@ -76,5 +76,5 @@ builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
 builder_run_action install:project      do_install
-builder_run_action edit:project         start kmcompai.dproj
+builder_run_action edit:project         start kmcompapi.dproj
 

--- a/windows/src/engine/kmcomapi/build.sh
+++ b/windows/src/engine/kmcomapi/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "COM API library" \
   @/common/include \
   @/common/windows/delphi \
-  clean configure build test publish install
+  clean configure build test publish install edit
 
 builder_parse "$@"
 
@@ -76,4 +76,5 @@ builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
 builder_run_action install:project      do_install
+builder_run_action edit:project         start kmcompai.dproj
 

--- a/windows/src/engine/tsysinfo/build.sh
+++ b/windows/src/engine/tsysinfo/build.sh
@@ -9,7 +9,7 @@ builder_describe "Diagnostics (32-bit)" \
   @/common/include \
   @/common/windows/delphi \
   @/windows/src/engine/tsysinfox64 \
-  clean configure build test publish install
+  clean configure build test publish install edit
 
 builder_parse "$@"
 
@@ -71,4 +71,5 @@ builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
 builder_run_action install:project      do_install
+builder_run_action edit:project         start tsysinfo.dproj
 

--- a/windows/src/engine/tsysinfox64/build.sh
+++ b/windows/src/engine/tsysinfox64/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe "Diagnostics (64-bit)" \
   @/common/include \
   @/common/windows/delphi \
-  clean configure build test publish install
+  clean configure build test publish install edit
 
 builder_parse "$@"
 
@@ -50,4 +50,4 @@ builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
 builder_run_action publish:project      do_publish
 builder_run_action install:project      do_install
-
+builder_run_action edit:project         start tsysinfox64.dproj

--- a/windows/src/global/delphi/build.sh
+++ b/windows/src/global/delphi/build.sh
@@ -8,7 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 builder_describe \
   "Keyman for Windows Delphi components" \
   @/common/windows/delphi \
-  clean configure build test \
+  clean configure build test edit \
   :components \
   :message-identifiers
 builder_parse "$@"
@@ -45,3 +45,4 @@ builder_run_action build:components                 do_build_components
 builder_run_action clean:message-identifiers        rm -f "$KEYMAN_ROOT/$MESSAGE_IDENTIFIERS"
 builder_run_action build:message-identifiers        do_build_message_identifiers
 # builder_run_action test:project         do_test
+builder_run_action edit:components                  start keyman_components.dproj

--- a/windows/src/support/oskbulkrenderer/build.sh
+++ b/windows/src/support/oskbulkrenderer/build.sh
@@ -6,7 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 builder_describe "oskbuildrenderer" \
-  clean configure build test
+  clean configure build test edit
 
 builder_parse "$@"
 
@@ -37,3 +37,4 @@ builder_run_action clean:project        do_clean
 builder_run_action configure:project    configure_windows_build_environment
 builder_run_action build:project        do_build
 # builder_run_action test:project         do_test
+builder_run_action edit:project         start oskbulkrenderer.dproj


### PR DESCRIPTION
This opens up the Delphi IDE with the correct KEYMAN_ROOT environment, which allows for debugging. This is very helpful when working with multiple worktrees, and also helps to avoid editing a project in the wrong tree.

@keymanapp-test-bot skip