### PR TITLE
fix(windows): if kmshell is "silent" don't start a Keyman update

### DIFF
--- a/windows/src/desktop/kmshell/startup/UfrmSplash.pas
+++ b/windows/src/desktop/kmshell/startup/UfrmSplash.pas
@@ -265,10 +265,6 @@ begin
 
     until False;
 
-    if kmcom.Options[KeymanOptionName(TUtilKeymanOption.koCheckForUpdates)].Value then
-    begin
-      RunConfiguration(0, '-buc -s');
-    end;
   end;
 end;
 


### PR DESCRIPTION
Don't start an install of Keyman Update if the user has not been notified.

This also refactors some of the code into a single helper function which is only called once. However, it visually helps follow the logic. 

I also changed in this PR was the removal of a `background update check` in the actualy Keyman Start function. This is superfluous.
It also makes the testing of this PR watching the state machine changes easier to observe.

Fixes: #13329

# User Testing 

We need to test that if Keyman is in `Waiting Restart` and kmshell is started with a `-s` switch for silent mode that we don't install. 

We need to test that if Keyman is in states preceding `Waiting Restart` and kmshell is started with a `-s` switch for a silent mode that the handlekmshell event is passed to the state machine
 
TEST_WAITINGRESTART_KMSHELL_KEYMAN_HAS_NOT_RUN_SILENT_MODE:

Install Keyman attached is the PR

1. Open the Keyman Configuration dialog.
2. In the Options tag uncheck start with Windows
3. In the Options tab under General, check "Automatically check for updates and download"
4. Close the configuration
5. Close Keyman if it is running.
6. Logout and then back into Windows
7. Navigate to the "Update" tab.
8. Open Regedit WinR type regedit
9. Go to the current user key update state found at (Computer\HKEY_CURRENT_USER\SOFTWARE\Keyman\Keyman Engine).
10. If required set the state back to usIdle
11. Go to the key `Computer\HKEY_CURRENT_USER\SOFTWARE\Keyman\Keyman Desktop` and delete `last update check time`. This needs to be done otherwise it will stay in `usIdle` for 7 days.
12. Open Windows Explorer at "C:\Users"yourusername"\AppData\Local\Keyman\UpdateCache" folder.
13. Delete cache.json, any *.kmp and *.exe files.
14. Close Keyman and Keyman Configuration if open
15. Open a command prompt (kbd>WinR type cmd)
16. Change to the directory where kmshell is installed (cd "c:\Program Files (x86)\Keyman\Keyman Desktop")
17. Type kmshell.exe -c
18. In the Regedit window.
19. Verified that the "update state" has advanced to usUpdateAvailable, then usDownloading, and finally usWatingRestart press F5 to refresh.
20. Close Keyman Configuration
21. At the command prompt again type kmshell.exe -s
22. In the Regedit window.
23. Verified that the "update state" does not advance past `usWatingRestart`
24. That a Keyman installation does not start.

TEST_UPDATE_KMSHELL_KEYMAN_HAS_NOT_RUN_SILENT_MODE:

Install Keyman attached is the PR

1. Open the Keyman Configuration dialog.
2. In the Options tag uncheck start with Windows
3. In the Options tab under General, check "Automatically check for updates and download"
4. Close Configuration and Keyman if it is Running.
5. Logout and then back into Windows
6. Navigate to the "Update" tab.
7. Open Regedit WinR type regedit
8. Go to the current user key update state found at (Computer\HKEY_CURRENT_USER\SOFTWARE\Keyman\Keyman Engine).
9. Set the state back to `usUpdateAvailable`
10. Open Windows Explorer at "C:\Users"yourusername"\AppData\Local\Keyman\UpdateCache" folder.
11. Delete cache.json, any *.kmp and *.exe files.
12. Close Keyman and Keyman Configuration if open
13. Open a command prompt (kbd>WinR type cmd)
14. Change to the directory where kmshell is installed (cd "c:\Program Files (x86)\Keyman\Keyman Desktop")
15. Type kmshell.exe -s
16. In the Regedit window.
17. Verified that the "update state" has advanced to usUpdateAvailable, then usDownloading, and finally usWatingRestart press F5 to refresh.
19. In the Regedit window.
20. Verified that the "update state" does not advance past `usWatingRestart`
25. That a Keyman installation does not start.

