### PR TITLE
change(ios): re-order host page script load so Sentry can report script load failures

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyboard.html
@@ -4,9 +4,9 @@
         <meta http-equiv="content-type" content="text/html; charset=UTF-8">
         <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
         <title>Keyman</title>
-        <script src="keymanweb-webview.js"></script>
         <script src="sentry.min.js"></script>
         <script src="keyman-sentry.js"></script>
+        <script src="keymanweb-webview.js"></script>
         <script src="ios-host.js"></script>
         <style type="text/css">
             body {background-color: rgb(210,214,220);}


### PR DESCRIPTION
This change is designed to help further investigate #13312, in which it appears that the main Keyman Engine for Web script is failing to load on occasion.

## User Testing

TEST_SIMPLE_APP_START:  Launch the Keyman app and verify that it functions and types normally.  A simple "everything looks good" check; no need to be detailed here.