### PR TITLE
change(android): re-order host page script load so Sentry can report script load failures

### DIFF
--- a/android/KMEA/app/src/main/assets/keyboard.html
+++ b/android/KMEA/app/src/main/assets/keyboard.html
@@ -9,9 +9,9 @@
   <title>Keyman</title>
   <!-- DOMRect only exists as of Chrome 61... thus coming later than ES6. -->
   <script src="other-polyfills.js"></script>
-  <script src="keymanweb-webview.js"></script>
   <script src="sentry.min.js"></script>
   <script src="keyman-sentry.js"></script>
+  <script src="keymanweb-webview.js"></script>
   <script src="android-host.js"></script>
   <style type="text/css">
       body {background-color:#000000;}


### PR DESCRIPTION
Parallels #13332, though we haven't seen similar host-page Keyman Engine for Web script-loading issues for Android at this point.

## User Testing

TEST_SIMPLE_APP_START:  Launch the Keyman app and verify that it functions and types normally.  A simple "everything looks good" check; no need to be detailed here.