### PR TITLE
fix(developer): use U+0001 for deadkey markers in the debugger

### DIFF
--- a/developer/src/tike/child/Keyman.Developer.UI.Debug.UfrmLdmlKeyboardDebug.dfm
+++ b/developer/src/tike/child/Keyman.Developer.UI.Debug.UfrmLdmlKeyboardDebug.dfm
@@ -31,6 +31,7 @@ inherited frmLdmlKeyboardDebug: TfrmLdmlKeyboardDebug
     Font.Name = 'Arial'
     Font.Style = []
     ParentFont = False
+    PlainText = True
     PopupMenu = mnuPopup
     ScrollBars = ssVertical
     TabOrder = 0

--- a/developer/src/tike/child/Keyman.Developer.UI.Debug.UfrmLdmlKeyboardDebug.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.Debug.UfrmLdmlKeyboardDebug.pas
@@ -412,7 +412,7 @@ procedure TfrmLdmlKeyboardDebug.Run(vkey: Word);
       if dk.SavedPosition < 0 then
       begin
         dk.Position := L + dk.SavedPosition;
-        if (dk.Position < 0) or (dk.Position >= L) or (s[dk.Position + 1] <> #$FFFC) then
+        if (dk.Position < 0) or (dk.Position >= L) or (s[dk.Position + 1] <> DeadKey_Marker) then
           // This can happen if the deadkey was in a replaced selection
           dk.Delete;
       end;
@@ -481,7 +481,7 @@ procedure TfrmLdmlKeyboardDebug.Run(vkey: Word);
 
 
   // Returns the length of the context items in UTF16, treating markers as a
-  // single UTF16 code unit (U+FFFC)
+  // single UTF16 code unit (DeadKey_Marker)
   function ContextItemsLengthUTF16(pc: pkm_core_context_item): Integer;
   begin
     Result := 0;
@@ -519,7 +519,7 @@ procedure TfrmLdmlKeyboardDebug.Run(vkey: Word);
         dk.Position := Result.Length + offset;
         dk.SavedPosition := Result.Length + offset;
         FDeadkeys.Add(dk);
-        Result := Result + #$FFFC;
+        Result := Result + DeadKey_Marker;
       end;
       Inc(pc);
     end;

--- a/developer/src/tike/child/UfrmDebug.pas
+++ b/developer/src/tike/child/UfrmDebug.pas
@@ -700,7 +700,7 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
       if dk.SavedPosition < 0 then
       begin
         dk.Position := L + dk.SavedPosition;
-        if (dk.Position < 0) or (dk.Position >= L) or (s[dk.Position + 1] <> #$FFFC) then
+        if (dk.Position < 0) or (dk.Position >= L) or (s[dk.Position + 1] <> DeadKey_Marker) then
           // This can happen if the deadkey was in a replaced selection
           dk.Delete;
       end;
@@ -748,7 +748,7 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
         begin
           Assert(m >= 1, AssertionMessage);
           Assert(m <= t.Length, AssertionMessage);
-          Assert(t[m] = #$FFFC, AssertionMessage);
+          Assert(t[m] = DeadKey_Marker, AssertionMessage);
           dk := FDeadkeys.GetFromPosition(m-1);
           Assert(Assigned(dk));
           dk.Delete;
@@ -758,7 +758,7 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
         begin
           Assert(m >= 1, AssertionMessage);
           Assert(m <= t.Length, AssertionMessage);
-          Assert(t[m] <> #$FFFC, AssertionMessage);
+          Assert(t[m] <> DeadKey_Marker, AssertionMessage);
           // Delete surrogate pairs
           if (m > 1) and
               Uni_IsSurrogate2(t[m]) and
@@ -769,7 +769,7 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
         end;
       KM_CORE_BT_UNKNOWN:
         begin
-          while (m >= 1) and (t[m] = #$FFFC) do
+          while (m >= 1) and (t[m] = DeadKey_Marker) do
           begin
             dk := FDeadkeys.GetFromPosition(m-1);
             Assert(Assigned(dk), AssertionMessage);
@@ -786,7 +786,7 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
             Dec(m);
 
           // Also delete deadkeys to left of current character
-          while (m >= 1) and (t[m] = #$FFFC) do
+          while (m >= 1) and (t[m] = DeadKey_Marker) do
           begin
             dk := FDeadkeys.GetFromPosition(m-1);
             Assert(Assigned(dk), AssertionMessage);
@@ -830,7 +830,7 @@ procedure TfrmDebug.ExecuteEventAction(n: Integer);
     begin
       state := SaveMemoSelectionState;
 
-      memo.SelText := WideChar($FFFC);
+      memo.SelText := DeadKey_Marker;
       memo.SelStart := memo.SelStart + memo.SelLength;  // I1603
       memo.SelLength := 0;
       dk.Position := memo.SelStart - 1;

--- a/developer/src/tike/debug/Keyman.System.Debug.DebugUtils.pas
+++ b/developer/src/tike/debug/Keyman.System.Debug.DebugUtils.pas
@@ -12,6 +12,8 @@ function GetContextFromMemo(Memo: TKeymanDeveloperDebuggerMemo; DeadKeys: TDebug
 implementation
 
 uses
+  System.SysUtils,
+
   Unicode;
 
 function GetContextFromMemo(Memo: TKeymanDeveloperDebuggerMemo; DeadKeys: TDebugDeadkeyInfoList; IncludeMarkers: Boolean): TArray<km_core_context_item>;
@@ -35,7 +37,7 @@ begin
       Result[n].character := Uni_SurrogateToUTF32(ch, t[i+1]);
       Inc(i);
     end
-    else if Ord(ch) = $FFFC then
+    else if ch = DeadKey_Marker then
     begin
       if IncludeMarkers then
       begin

--- a/developer/src/tike/debug/Keyman.UI.Debug.CharacterGridRenderer.pas
+++ b/developer/src/tike/debug/Keyman.UI.Debug.CharacterGridRenderer.pas
@@ -60,7 +60,7 @@ type
         Result[n].ch := Uni_SurrogateToUTF32(text[x+1], text[x+2]);
         Inc(x);
       end
-      else if text[x+1] = #$FFFC then
+      else if text[x+1] = DeadKey_Marker then
       begin
         Result[n].CellType := ctDeadkey;
         Result[n].dk := deadkeys.GetFromPosition(x);
@@ -177,66 +177,6 @@ begin
   if SelAnchor <> SelStart then
     FillGridCursor(X);
   FillGrid(After, 0, X);
-
-(*
-  J := 0; I := SelStart + SelLength; // I is 1-based Delphi string index
-  while (J < MaxCols) and (I > SelStart) do
-  begin
-    if (I > 1) and Uni_IsSurrogate2(s[I]) and Uni_IsSurrogate1(s[I-1]) then
-      Dec(I);
-    Inc(J); Dec(I);
-  end;
-
-  if J = 0 then
-  begin
-    sgChars.ColCount := 1;
-    sgChars.Objects[0,0] := Pointer(0);
-    sgChars.Cells[0,0] := '';
-    sgChars.Cells[0,1] := '';
-    Exit;
-  end
-  else
-    sgChars.ColCount := J + 1;
-
-  Inc(I);
-  J := 0;
-  while J < sgChars.ColCount do
-  begin
-    if I = memo.SelStart + 1 then
-    begin
-      sgChars.Objects[J, 0] := Pointer(2);
-      sgChars.Cells[J, 0] := '|';
-      sgChars.Cells[J, 1] := 'Cursor';
-      Inc(J);
-    end;
-    if Ord(S[I]) = $FFFC then
-    begin
-      sgChars.Objects[J, 0] := Pointer(1);
-      sgChars.Cells[J, 0] := '???';
-      for K := 0 to FDeadkeys.Count-1 do
-        if FDeadkeys[K].Position = I-1 then
-        begin
-          sgChars.Cells[J, 0] := FDeadkeys[K].Deadkey.Name;
-          break;
-        end;
-      sgChars.Cells[J, 1] := 'Deadkey';
-    end
-    else if Uni_IsSurrogate1(s[I]) and (I < Length(s)) and Uni_IsSurrogate2(s[I+1]) then
-    begin
-      sgChars.Objects[J, 0] := Pointer(0);
-      sgChars.Cells[J, 0] := Copy(s, I ,2);
-      sgChars.Cells[J, 1] := 'U+'+IntToHex(Uni_SurrogateToUTF32(s[I], s[I+1]), 5);
-      Inc(I);
-    end
-    else
-    begin
-      sgChars.Objects[J, 0] := Pointer(0);
-      sgChars.Cells[J, 0] := s[I];
-      sgChars.Cells[J, 1] := 'U+'+IntToHex(Ord(s[i]), 4);
-    end;
-    Inc(J); Inc(I);
-  end;
-*)
 end;
 
 class procedure TCharacterGridRenderer.Render(grid: TStringGrid; ACol,

--- a/developer/src/tike/debug/debugdeadkeys.pas
+++ b/developer/src/tike/debug/debugdeadkeys.pas
@@ -1,18 +1,18 @@
 (*
   Name:             debugdeadkeys
   Copyright:        Copyright (C) 2003-2017 SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      18 May 2012
 
   Modified Date:    18 May 2012
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          18 May 2012 - mcdurdin - I3323 - V9.0 - Change from Plus-MemoU to Plus-Memo
 *)
 unit debugdeadkeys;
@@ -48,6 +48,11 @@ type
     procedure FillDeadkeys(startpos: Integer; var s: WideString);
   end;
 
+const
+  // This is not an ideal marker -- we were using U+FFFC previously, but
+  // richedit silently converts it to U+0020.
+  DeadKey_Marker = #$0001;
+
 implementation
 
 uses
@@ -80,7 +85,7 @@ begin
   i := 1;
   while i <= Length(s) do
   begin
-    if s[i] = #$FFFC then
+    if s[i] = DeadKey_Marker then
     begin
       for dk in Self do
       begin


### PR DESCRIPTION
Previously, we used U+FFFC as a marker in the debugger (for deadkeys and LDML keyboard markers), which displayed as the letters OBJ in a small dotted square. However, we switched the underlying component to RichEdit, in order to better support rendering of many scripts (EDIT has some problems). The RichEdit control silently converts U+FFFC to U+0020. I switched to U+0001 as this is handled better, but has an unfortunate missing-glyph marker.

In the future, it would be better to use a non-character marker (leveraging RichEdit), but this is a much more complex change, and this fix at least matches previous functionality.

Fixes: #13293

# User Testing

TEST_DEADKEYS: In the keyboard debugger, select a keyboard that includes deadkeys (such as sil_bengali_phonetic). Try typing keys that generate deadkeys, and verify that they display as a square box and are highlighted in the character grid below. Make sure that the deadkey rules function correctly e.g. type <kbd>q</kbd><kbd>a</kbd> in sil_bengali_phonetic. Also try backspacing a deadkey -- both the deadkey and the preceding character should be deleted with a single keystroke (as normally, deadkeys are not visible to the end user).