### PR TITLE
fix(developer): prevent simultaneous opening of the same project by two processes

### DIFF
--- a/developer/src/tike/main/Keyman.Developer.System.KeymanDeveloperPaths.pas
+++ b/developer/src/tike/main/Keyman.Developer.System.KeymanDeveloperPaths.pas
@@ -9,8 +9,9 @@ uses
 
 type
   TKeymanDeveloperPaths = class sealed
-  private
   public
+    class function LockFilePath: string; static;
+
     class function NodePath: string; static;
 
     const S_LexicalModelCompiler = 'kmlmc.cmd';
@@ -54,6 +55,11 @@ end;
 class function TKeymanDeveloperPaths.ServerDataPath: string;
 begin
   Result := GetFolderPath(CSIDL_APPDATA) + SFolderKeymanDeveloper + '\server\';
+end;
+
+class function TKeymanDeveloperPaths.LockFilePath: string;
+begin
+  Result := GetFolderPath(CSIDL_APPDATA) + SFolderKeymanDeveloper + '\lock\';
 end;
 
 class function TKeymanDeveloperPaths.ServerPath: string;

--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -605,7 +605,10 @@ begin
   if TikeCommandLine.StartupProjectPath <> '' then
   begin
     try
-      LoadGlobalProjectUI(ptUnknown, TikeCommandLine.StartupProjectPath);
+      if LoadGlobalProjectUI(ptUnknown, TikeCommandLine.StartupProjectPath) = nil then
+      begin
+        raise EProjectLoader.Create('Project is already open in another process');
+      end;
     except
       on E:EProjectLoader do
       begin
@@ -1291,7 +1294,10 @@ begin
       // We need to create a temporary project to host this file
       // This can happen if we get a file opened via Explorer without a
       // corresonding project file
-      CreateTempGlobalProjectUI(ptUnknown);
+      if CreateTempGlobalProjectUI(ptUnknown) = nil then
+      begin
+        raise Exception.Create('Keyman Developer was unable to create a temporary project');
+      end;
       UpdateCaption;
     end;
 
@@ -1371,7 +1377,10 @@ begin
   end;
 
   try
-    LoadGlobalProjectUI(ptUnknown, FileName);   // I4687
+    if LoadGlobalProjectUI(ptUnknown, FileName) = nil then   // I4687
+    begin
+      raise EProjectLoader.Create('Project is open in another process');
+    end;
   except
     on E:EProjectLoader do
     begin

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.ProjectUI.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.ProjectUI.pas
@@ -33,9 +33,11 @@ function CreateTempGlobalProjectUI(pt: TProjectType): TProjectUI;
 implementation
 
 uses
+  System.Hash,
   System.SysUtils,
   Winapi.Windows,
 
+  Keyman.Developer.System.KeymanDeveloperPaths,
   Keyman.Developer.System.TikeMultiProcess,
   Keyman.Developer.System.Project.Project,
   utildir;
@@ -122,9 +124,17 @@ var
   hLockFile: THandle = INVALID_HANDLE_VALUE;
 
 function LockProject(const AFilename: string): Boolean;
+var
+  LockFilename: string;
 begin
   Assert(hLockFile = INVALID_HANDLE_VALUE);
-  hLockFile := CreateFile(PChar(AFilename + '.lock'), GENERIC_READ or GENERIC_WRITE, 0, nil, CREATE_ALWAYS, FILE_FLAG_DELETE_ON_CLOSE, 0);
+
+  if not ForceDirectories(TKeymanDeveloperPaths.LockFilePath) then
+    Exit(False);
+
+  LockFilename := TKeymanDeveloperPaths.LockFilePath + THashSHA1.GetHashString(AFilename.ToLower) + '.lock';
+
+  hLockFile := CreateFile(PChar(LockFilename), GENERIC_READ or GENERIC_WRITE, 0, nil, CREATE_ALWAYS, FILE_FLAG_DELETE_ON_CLOSE, 0);
   Result := hLockFile <> INVALID_HANDLE_VALUE;
 end;
 

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.ProjectUI.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.ProjectUI.pas
@@ -109,7 +109,9 @@ begin
   Assert(not Assigned(FGlobalProject));
 
   if not LockProject(AFilename) then
+  begin
     Exit(nil);
+  end;
 
   Result := TProjectUI.Create(pt, AFilename, True);   // I4687
   FGlobalProject := Result;
@@ -130,7 +132,9 @@ begin
   Assert(hLockFile = INVALID_HANDLE_VALUE);
 
   if not ForceDirectories(TKeymanDeveloperPaths.LockFilePath) then
+  begin
     Exit(False);
+  end;
 
   LockFilename := TKeymanDeveloperPaths.LockFilePath + THashSHA1.GetHashString(AFilename.ToLower) + '.lock';
 
@@ -141,7 +145,10 @@ end;
 procedure UnlockProject;
 begin
   if not hLockFile = INVALID_HANDLE_VALUE then
+  begin
     Exit;
+  end;
+
   CloseHandle(hLockFile);
   hLockFile := INVALID_HANDLE_VALUE;
 end;


### PR DESCRIPTION
There is a race condition where two processes may both attempt to open the same project file. This appears to happen, for example, if an author double-clicks on a single-click shortcut, launching Keyman Developer twice in quick succession.

This fix adds a .lock file which is deleted automatically on close of the project or on normal or abnormal process termination. If a second process encounters the .lock file, it will simply open the welcome view instead of attempting to open the project.

Fixes: #11584
Fixes: KEYMAN-DEVELOPER-1PR

# User Testing

* TEST_PROJECT_LOADING: In Keyman Developer, verify that opening and closing a variety of projects works correctly, and that creating projects works correctly, and that opening projects from Windows Explorer works correctly. Try opening a project multiple times from Windows Explorer (double-click on the .kpj file) -- it should only open once. No crashes should occur.