### PR TITLE
fix(android): Filter out SocketTimeoutExceptions

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/util/Connection.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/util/Connection.java
@@ -3,6 +3,7 @@ package com.keyman.engine.util;
 import java.io.InputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 
 public final class Connection {
@@ -99,6 +100,9 @@ public final class Connection {
           attempt++;
         }
       }
+    } catch (SocketTimeoutException e) {
+      KMLog.LogBreadcrumb(TAG, "Connection.initialize timeout for: " + originalUrl, true);
+      KMLog.LogInfo(TAG, "SocketTimeoutException");
     } catch (Exception e) {
       KMLog.LogException(TAG, "Initialization failed:", e);
     }


### PR DESCRIPTION
Fixes: KEYMAN-ANDROID-54G

Downgrades socket connection errors (due to timeout) in Sentry from `Exception` to `Info` (with a breadcrumb to the URL).

Tested in an engineering build by overriding  
```java
url = new URL("http://10.255.255.1");
```

@keymanapp-test-bot skip