### PR TITLE
fix(linux): ignore DBusException during install and uninstall

### DIFF
--- a/linux/keyman-config/keyman_config/dbus_util.py
+++ b/linux/keyman-config/keyman_config/dbus_util.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import contextlib
 import logging
 import os
 
@@ -6,6 +7,8 @@ import dbus
 import dbus.bus
 import dbus.mainloop.glib
 import dbus.service
+
+from dbus import DBusException
 
 BUS_NAME = 'com.Keyman.Config'
 OBJECT_PATH = '/com/Keyman/Config'
@@ -77,7 +80,9 @@ class KeymanConfigServiceManager:
 
     def keyboard_list_changed(self) -> None:
         self.__verify_service_exists()
-        if self.__service:
+        if not self.__service:
+            return
+        with contextlib.suppress(DBusException):
             self.__service.keyboard_list_changed()
 
 

--- a/linux/keyman-config/tests/dbus_util_tests.py
+++ b/linux/keyman-config/tests/dbus_util_tests.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+import unittest
+from unittest.mock import Mock, patch
+
+from dbus import DBusException
+
+from keyman_config.dbus_util import get_keyman_config_service
+
+
+class KeymanConfigServiceManager(unittest.TestCase):
+    def setUp(self):
+        self.mockDbus = self._setupMock('keyman_config.dbus_util.dbus')
+
+    def _setupMock(self, arg0):
+        patcher = patch(arg0)
+        result = patcher.start()
+        self.addCleanup(patcher.stop)
+        return result
+
+    def test_KeyboardListChanged_HappyPath(self):
+        # Setup
+        serviceManager = get_keyman_config_service()
+        serviceManager.__service = Mock()
+        serviceManager.__service.keyboard_list_changed = Mock()
+
+        # Execute
+        serviceManager.keyboard_list_changed()
+
+        # Verify
+        self.assertEqual(serviceManager.__service.keyboard_list_changed.call_count, 1)
+
+    def test_KeyboardListChanged_IgnoreDbusExceptionDisconnected(self):
+        '''#12902: ignore DBus exceptions happening from call to keyboard_list_changed'''
+
+        # Setup
+        serviceManager = get_keyman_config_service()
+        serviceManager.__service = Mock()
+        serviceManager.__service.keyboard_list_changed = Mock(side_effect=DBusException(
+            'org.freedesktop.DBus.Error.NoReply: Message recipient disconnected from message bus without replying'))
+
+        # Execute
+        serviceManager.keyboard_list_changed()
+
+        # Verify
+        self.assertEqual(serviceManager.__service.keyboard_list_changed.call_count, 1)
+
+    def test_KeyboardListChanged_IgnoreDbusExceptionNoReply(self):
+        '''#13283: ignore DBus exceptions happening from call to keyboard_list_changed'''
+
+        # Setup
+        serviceManager = get_keyman_config_service()
+        serviceManager.__service = Mock()
+        serviceManager.__service.keyboard_list_changed = Mock(side_effect=DBusException(
+            'org.freedesktop.DBus.Error.NoReply: Did not receive a reply.'))
+
+        # Execute
+        serviceManager.keyboard_list_changed()
+
+        # Verify
+        self.assertEqual(serviceManager.__service.keyboard_list_changed.call_count, 1)
+

--- a/linux/keyman-config/tests/uninstall_kmp_tests.py
+++ b/linux/keyman-config/tests/uninstall_kmp_tests.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
-import os
-import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
+
 from keyman_config.get_kmp import InstallLocation
 
-from keyman_config.uninstall_kmp import _uninstall_keyboards_from_gnome, _uninstall_keyboards_from_ibus, _uninstall_kmp_common
+from keyman_config.uninstall_kmp import _uninstall_keyboards_from_gnome, _uninstall_keyboards_from_ibus, _uninstall_kmp_common, uninstall_kmp
 
 
 class UninstallKmpGnomeTests(unittest.TestCase):
@@ -118,6 +117,7 @@ class UninstallKmpGnomeTests(unittest.TestCase):
 class UninstallKmpIbusTests(unittest.TestCase):
 
     def setUp(self):
+        self.mockIsDir = self._setupMock('os.path.isdir')
         self.mockIbusUtilClass = self._setupMock('keyman_config.uninstall_kmp.IbusUtil')
         self.mockRestartIbus = self._setupMock('keyman_config.uninstall_kmp.restart_ibus')
         self.mockGetIbusBus = self._setupMock('keyman_config.uninstall_kmp.get_ibus_bus')
@@ -237,6 +237,7 @@ class UninstallKmpIbusTests(unittest.TestCase):
 
 class UninstallKmpCommonTests(unittest.TestCase):
     def setUp(self):
+        self.mockIsDir = self._setupMock('os.path.isdir')
         self.mockGetKeyboardDir = self._setupMock('keyman_config.uninstall_kmp.get_keyboard_dir')
         self.mockGetKeymanDocDir = self._setupMock('keyman_config.uninstall_kmp.get_keyman_doc_dir')
         self.mockGetKeymanFontDir = self._setupMock('keyman_config.uninstall_kmp.get_keyman_font_dir')
@@ -306,3 +307,49 @@ class UninstallKmpCommonTests(unittest.TestCase):
         self.mockUninstallKeyboardsFromIbus.assert_called_once_with(keyboards, '/tmp/foo')
         self.mockUninstallDir.assert_called()
         self.assertEqual(mockCustomKeyboardsInstance.remove.call_count, 2)
+
+
+class UninstallKmpTests(unittest.TestCase):
+    def setUp(self):
+        self.mockIsDir = self._setupMock('os.path.isdir')
+        self.mockGetKeyboardDir = self._setupMock('keyman_config.uninstall_kmp.get_keyboard_dir')
+        self.mockGetKeyboardDir.return_value = '/tmp/foo'
+        self.mockGetKeymanDocDir = self._setupMock('keyman_config.uninstall_kmp.get_keyman_doc_dir')
+        self.mockGetKeymanFontDir = self._setupMock('keyman_config.uninstall_kmp.get_keyman_font_dir')
+        self.mockIsGnomeShell = self._setupMock('keyman_config.uninstall_kmp.is_gnome_desktop')
+        self.mockIsGnomeShell.return_value = False
+        self.mockIsFcitxRunning = self._setupMock('keyman_config.uninstall_kmp.is_fcitx_running')
+        self.mockIsFcitxRunning.return_value = False
+        self.mockUninstallKeyboardsFromIbus = self._setupMock(
+            'keyman_config.uninstall_kmp._uninstall_keyboards_from_ibus')
+        self.mockUninstallDir = self._setupMock('keyman_config.uninstall_kmp._uninstall_dir')
+        self.mockGetMetaData = self._setupMock('keyman_config.uninstall_kmp.get_metadata')
+        self.mockCustomKeyboardsClass = self._setupMock('keyman_config.uninstall_kmp.CustomKeyboards')
+        self.mockGetKeymanConfigService = self._setupMock('keyman_config.uninstall_kmp.get_keyman_config_service')
+        self.mockKeymanConfigServiceManager = Mock()
+        self.mockGetKeymanConfigService.return_value = self.mockKeymanConfigServiceManager
+
+    def _setupMock(self, arg0):
+        patcher = patch(arg0)
+        result = patcher.start()
+        self.addCleanup(patcher.stop)
+        return result
+
+    def test_UninstallKmp_HappyPath(self):
+        # Setup
+        mockCustomKeyboardsInstance = self.mockCustomKeyboardsClass.return_value
+        keyboards = [{'id': 'foo1', 'languages': [{'id': 'en'}]}, {'id': 'bar2', 'languages': [{'id': 'fr'}]}]
+        self.mockGetMetaData.return_value = (None, None, None, keyboards, None)
+
+        keyboardListChangedMock = Mock()
+        self.mockKeymanConfigServiceManager.keyboard_list_changed = keyboardListChangedMock
+
+        # Execute
+        uninstall_kmp('foo', False, True)
+
+        # Verify
+        self.mockUninstallKeyboardsFromIbus.assert_called_once_with(keyboards, '/tmp/foo')
+        self.mockUninstallDir.assert_called()
+        self.assertEqual(mockCustomKeyboardsInstance.remove.call_count, 2)
+        self.assertEqual(keyboardListChangedMock.call_count, 1)
+


### PR DESCRIPTION
Fixes: #12902
Fixes: #13283
Fixes: KEYMAN-LINUX-7J
Fixes: KEYMAN-LINUX-7R

# User Testing

**TEST_INSTALL**: verify that installing a keyboard still works
**TEST_UNINSTALL**: verify that uninstalling a keyboard still works