### PR TITLE
fix(web): cancel held backspace on new key input

### DIFF
--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -522,7 +522,7 @@ export function longpressContactModel(params: FullGestureParams, enabledFlicks: 
          * The 'indexOf' allows 'n', 'nw', and 'ne' - approx 67.5 degrees on
          * each side of due N in total.
          */
-        if((enabledFlicks && spec.permitsFlick(stats.lastSample.item)) && (stats.cardinalDirection?.indexOf('n') != -1 ?? false)) {
+        if((enabledFlicks && spec.permitsFlick(stats.lastSample.item)) && ((stats.cardinalDirection ?? '').indexOf('n') != -1)) {
           const baseDistance = stats.netDistance;
           const angle = stats.angle; // from <0, -1> (straight up) going clockwise.
           const verticalDistance = baseDistance * Math.cos(angle);
@@ -675,6 +675,9 @@ export function specialKeyEndModel(params: FullGestureParams): GestureModel<any>
           itemChangeAction: 'resolve'
         },
         endOnResolve: true,
+      }, {
+        model: instantContactResolutionModel(),
+        resetOnInstantFulfill: true
       }
     ],
     resolutionAction: {


### PR DESCRIPTION
As identified in the analysis for #13344, held backspaces have not been cancelled when receiving new inputs.  It's better and cleaner to have it act similarly to normal keystrokes - receiving a new key input autocompletes any currently-held output keys.

The current, existing behavior also has the potential to get particularly messy with multitaps, which restore the context at their start.  If a backspace is held and then a multitap begins, each new tap of the multitap would undo the backspaces that triggered since the first tap of the multitap.

## User Testing

TEST_BACKSPACE_AUTOCANCEL:  Using Keyman for Android, verify that holding backspace continues to delete characters _until_ a new key is typed.
- It should then stop deleting characters, even without releasing the held backspace.
