### PR TITLE
feat(web): adds gesture 'traces' for warning/error logging

### DIFF
--- a/web/src/engine/keyboard/src/keyEvent.ts
+++ b/web/src/engine/keyboard/src/keyEvent.ts
@@ -93,6 +93,15 @@ export default class KeyEvent implements KeyEventSpec {
   keyDistribution?: KeyDistribution;
 
   /**
+   * Information provided here may be used for breadcrumbs regarding internal engine errors and warnings.
+   * It should be scrubbed of info that could be used to directly reproduce what the user has typed.
+   *
+   * One great use is to identify scenarios such as how the current state of an OSK gesture was reached and
+   * culminated in this key event.
+   */
+  inputBreadcrumb?: string;
+
+  /**
    * The device model for web-core to follow when processing the keystroke.
    */
   device: DeviceSpec;

--- a/web/src/engine/main/src/headless/inputProcessor.ts
+++ b/web/src/engine/main/src/headless/inputProcessor.ts
@@ -120,7 +120,9 @@ export class InputProcessor {
                if this is a purely-layer-switching multitap.  (#11230)
           */
         } else {
-          console.warn('The base context for the multitap could not be found');
+          console.warn('The base context for the multitap could not be found!\n\n' + this.contextCache.buildLog());
+          // would be lovely to report a desire for gesture debug output
+          // maybe add something to RuleBehavior?
         }
       }
 
@@ -242,7 +244,7 @@ export class InputProcessor {
 
     // Multitaps operate in part by referencing 'committed' Transcriptions to rewind
     // the context as necessary.
-    this.contextCache.save(ruleBehavior.transcription);
+    this.contextCache.save(ruleBehavior.transcription); //
 
     // The keyboard may want to take an action after all other keystroke processing is
     // finished, for example to switch layers. This action may not have any output

--- a/web/src/engine/main/src/headless/transcriptionCache.ts
+++ b/web/src/engine/main/src/headless/transcriptionCache.ts
@@ -34,4 +34,11 @@ export class TranscriptionCache {
       this.map.delete(this.map.keys().next().value);
     }
   }
+
+  public buildLog(): string {
+    const entries = [...this.map.entries()].reverse();
+    return entries
+      .map(([key, entry]) => `Context state ${key}'s keystroke:\n${entry.keystroke.inputBreadcrumb ?? ''}`)
+      .join('\n');
+  }
 }

--- a/web/src/engine/main/src/headless/transcriptionCache.ts
+++ b/web/src/engine/main/src/headless/transcriptionCache.ts
@@ -36,7 +36,7 @@ export class TranscriptionCache {
   }
 
   public buildLog(): string {
-    const entries = [...this.map.entries()].reverse();
+    const entries = [...this.map.entries()];
     return entries
       .map(([key, entry]) => `Context state ${key}'s keystroke:\n${entry.keystroke.inputBreadcrumb ?? ''}`)
       .join('\n');

--- a/web/src/engine/osk/gesture-processor/src/engine/headless/gestures/matchers/gestureSequence.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/headless/gestures/matchers/gestureSequence.ts
@@ -33,6 +33,9 @@ export class GestureStageReport<Type, StateToken = any> {
    */
   public readonly sources: GestureSourceSubview<Type>[];
 
+  public get currentSourceIds(): string[] {
+    return this.sources.map((entry) => entry.identifier);
+  }
   public readonly allSourceIds: string[];
 
   constructor(selection: MatcherSelection<Type, StateToken>, gestureSetId: string) {
@@ -66,6 +69,32 @@ export class GestureStageReport<Type, StateToken = any> {
 
     this.allSourceIds = matcher?.allSourceIds || [];
   }
+
+  /**
+   * Returns the time interval covered by recorded touch events during this stage and its
+   * matched gesture model.
+   *
+   * May return `undefined` if no actual touches occurred during this time.
+   */
+  public get interval() {
+    if(this.sources.length == 0) {
+      return undefined;
+    }
+
+    const timestamps = this.sources.map((entry => {
+      return {
+        start: entry.path.stats.initialSample.t,
+        end: entry.path.stats.lastTimestamp
+      }
+    }));
+
+    return timestamps.reduce((prior, current) => {
+      return {
+        start: prior.start > current.start ? current.start : prior.start,
+        end: prior.end < current.end ? current.end : prior.end
+      }
+    }, { start: Number.POSITIVE_INFINITY, end: Number.NEGATIVE_INFINITY });
+  }
 }
 
 interface PushConfig<Type> {
@@ -83,10 +112,30 @@ interface PopConfig {
 export type ConfigChangeClosure<Type> = (configStackCommand: PushConfig<Type> | PopConfig) => void;
 
 interface EventMap<Type, StateToken> {
+  /**
+   * This event is raised when a new, valid gesture component for the sequence has been matched and
+   * committed.
+   *
+   * It is always called synchronously with the match, before any further matches are possible.
+   * - The sole exception to the "synchronous" aspect is if this gesture enacted a 'pushed' state
+   *   that has active 'nested' gestures that need to be sustained.
+   * - Even in the case above, no further 'stage' events for this GestureSequence will occur.
+   * @param stageReport
+   * @param changeConfiguration
+   * @returns
+   */
   stage: (
     stageReport: GestureStageReport<Type, StateToken>,
     changeConfiguration: ConfigChangeClosure<Type>
   ) => void;
+  /**
+   * This event is raised when the sequence of connected gesture components has reached its end,
+   * with no further continuation possible.
+   *
+   * It is called synchronously with the end of the gesture sequence, though it may be 'kept alive'
+   * when sustaining 'nested' gestures dependent upon a 'pushed' state.
+   * @returns
+   */
   complete: () => void;
 }
 
@@ -104,7 +153,10 @@ export class GestureSequence<Type, StateToken = any> extends EventEmitter<EventM
   private pushedSelector?: MatcherSelector<Type, StateToken>;
 
   private gestureConfig: GestureModelDefs<Type, StateToken>;
-  private markedComplete: boolean = false;
+  private completionTime: number;
+  private get markedComplete(): boolean {
+    return this.completionTime !== undefined;
+  }
 
   // Note:  the first stage will be available under `stageReports` after awaiting a simple Promise.resolve().
   constructor(
@@ -119,6 +171,8 @@ export class GestureSequence<Type, StateToken = any> extends EventEmitter<EventM
     this.selector = selector;
     this.selector.on('rejectionwithaction', this.modelResetHandler);
     this.once('complete', () => {
+      this.completionTime = performance.now();
+
       if(this.pushedSelector) {
         // The `popSelector` method is responsible for triggering cascading cancellations if
         // there are nested GestureSequences.
@@ -200,6 +254,18 @@ export class GestureSequence<Type, StateToken = any> extends EventEmitter<EventM
       return potentialMatches;
     }
 
+  /**
+   * Processes newly-matched gesture stages and ensures that the corresponding state machines are
+   * set in motion.  Also processes the case where there is no longer a possible matching gesture stage.
+   * - The gesture sources (touchpoints) will no longer be tracked and signal their paths' `complete` events.
+   * - The gesture models for any potential followups to the completed stage will be initialized.
+   *   - If there are none, the `complete` event will be triggered.
+   * - The `stage` event (when there is a matched stage) will be triggered before the corresponding `complete`.
+   *   - It will occur synchronously unless this sequence is kept alive, with no further stages possible and
+   *     pending completion, to 'sustain' nested gestures.
+   * @param selection Data about the matching gesture and match type.
+   * @returns
+   */
   private readonly selectionHandler = async (selection: MatcherSelection<Type, StateToken>) => {
     const gestureSet = this.pushedSelector?.baseGestureSetId || this.selector?.baseGestureSetId;
     const matchReport = new GestureStageReport<Type, StateToken>(selection, gestureSet);
@@ -222,13 +288,13 @@ export class GestureSequence<Type, StateToken = any> extends EventEmitter<EventM
 
       if(!selection.result.matched) {
         if(!this.markedComplete) {
-          this.markedComplete = true;
           this.emit('complete');
         }
         return;
       }
     }
 
+    // Only source of async:  actually completing a gesture that caused an alt-state.
     if(actionType == 'complete' && this.touchpointCoordinator && this.pushedSelector) {
       // Cascade-terminade all nested selectors, but don't remove / pop them yet.
       // Their selection mode remains valid while their gestures are sustained.
@@ -349,7 +415,6 @@ export class GestureSequence<Type, StateToken = any> extends EventEmitter<EventM
     } else {
       // Any extra finalization stuff should go here, before the event, if needed.
       if(!this.markedComplete) {
-        this.markedComplete = true;
         this.emit('complete');
       }
     }
@@ -385,13 +450,54 @@ export class GestureSequence<Type, StateToken = any> extends EventEmitter<EventM
     const sources = this.stageReports[this.stageReports.length - 1].sources;
     sources.forEach((src) => src.baseSource.isPathComplete || src.baseSource.terminate(true));
     if(!this.markedComplete) {
-      this.markedComplete = true;
       this.emit('complete');
     }
   }
 
   public toJSON(): any {
     return this.stageReports;
+  }
+
+  /**
+   * Prints out a 'trace' of the gesture sequence in reverse chronological order.  Each frame includes:
+   * - the unique touch-identifiers active for each stage
+   * - the matched gesture ID
+   * - the time interval spanned by the frame (if at least one touch was active during it)
+   * @returns
+   */
+  public trace(padding?: string): string {
+    padding ||= '  ';
+
+    const logTouches = (idArr: string[]) => {
+      if(idArr.length == 0) {
+        return `<empty>`;
+      } else if(idArr.length == 1) {
+        return idArr[0];
+      } else {
+        return idArr.join(', ');
+      }
+    }
+
+    const logInterval = (interval: {start: number, end: number}) => {
+      if(!interval) {
+        return '';
+      }
+
+      if(interval.start == interval.end) {
+        return `@ ${interval.start.toFixed(2)} ms`;
+      } else {
+        return `from ${interval.start.toFixed(2)} ms - ${interval.end.toFixed(2)} ms`
+      }
+    };
+
+    // Sanitizes the actual keystrokes involved but preserves a decent amount of gesture diagnostic information.
+    let logs = this.stageReports.map((entry) => padding + `${logTouches(entry.currentSourceIds)} - ${entry.matchedId} ${logInterval(entry.interval)}`)
+      // Orders each stage from most recent to least recent
+      .reverse();
+    if(this.markedComplete) {
+      logs.unshift(padding + `complete @ ${this.completionTime}`);
+    }
+    return logs.join('\n');
   }
 }
 

--- a/web/src/engine/osk/gesture-processor/src/engine/headless/touchpointCoordinator.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/headless/touchpointCoordinator.ts
@@ -195,8 +195,7 @@ export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends Even
       *
       * This, in turn, can affect what the initial 'item' for the new gesture will be.
       */
-      const modelingSpinupPromise = potentialSelector.matchGesture(touchpoint, getGestureModelSet(modelDefs, potentialSelector.baseGestureSetId));
-      const modelingSpinupResults = await modelingSpinupPromise;
+      const modelingSpinupResults = await potentialSelector.matchGesture(touchpoint, getGestureModelSet(modelDefs, potentialSelector.baseGestureSetId));
 
       if(modelingSpinupResults.sustainModeWithoutMatch) {
 

--- a/web/src/engine/osk/src/input/gestures/browser/flick.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/flick.ts
@@ -119,7 +119,8 @@ export default class Flick implements GestureHandler {
     let source: GestureSource<KeyElement> = baseSource;
 
     sequence.on('complete', () => {
-      previewHost?.cancel()
+      previewHost?.cancel();
+      this.baseSpec;
     });
 
     this.sequence.on('stage', (result) => {
@@ -206,6 +207,7 @@ export default class Flick implements GestureHandler {
     }
 
     keyEvent.keyDistribution = this.currentStageKeyDistribution(this.baseKeyDistances);
+    keyEvent.inputBreadcrumb = this.sequence.trace();
 
     // emit the keystroke
     vkbd.raiseKeyEvent(keyEvent, null);

--- a/web/src/engine/osk/src/input/gestures/browser/multitap.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/multitap.ts
@@ -26,6 +26,8 @@ export default class Multitap implements GestureHandler {
   public readonly hasModalVisualization = false;
 
   private readonly originalLayer: string;
+  // Used solely for error & warning messages.
+  private readonly keyboardId: string;
 
   private readonly multitaps: ActiveSubKey[];
   private tapIndex = 0;
@@ -56,6 +58,7 @@ export default class Multitap implements GestureHandler {
     }
 
     this.originalLayer = vkbd.layerId;
+    this.keyboardId = vkbd.layoutKeyboard.id;
 
     const tapLookahead = (offset: number) => (this.tapIndex + offset) % this.multitaps.length;
 
@@ -93,7 +96,7 @@ export default class Multitap implements GestureHandler {
         case 'multitap-start':
           break;
         default:
-          throw new Error(`Unsupported gesture state encountered during multitap: ${tap.matchedId}`);
+          throw new Error(`Unsupported gesture state encountered during multitap: \n${this.sequence.trace()}`);
       }
 
       // For rota-style behavior
@@ -103,6 +106,10 @@ export default class Multitap implements GestureHandler {
 
       const keyEvent = vkbd.keyEventFromSpec(selection);
       keyEvent.baseTranscriptionToken = this.baseContextToken;
+
+      if(this.baseContextToken == null) {
+        console.warn('Multitap init warning:  no associated base context (with base key '+ e.key.spec.coreID + ')');
+      }
 
       const coord = tap.sources[0].currentSample;
 
@@ -120,7 +127,7 @@ export default class Multitap implements GestureHandler {
           // with the multitap base key.
           const p = baseDistances.get(matchKey.key.spec);
           if(p == null) {
-            console.warn("Could not find current layer's key")
+            console.warn(`Could not find fat-finger probability for current layer's key:  current key = ${matchKey.key.spec.elementID}, current layer = ${vkbd.layerId}, keyboard = ${this.keyboardId}`);
           } else {
             baseDistances.delete(matchKey.key.spec);
             baseDistances.set(coord.item.key.spec, p);
@@ -140,6 +147,7 @@ export default class Multitap implements GestureHandler {
       // if no such 'nextLayer' is specified by default.
       keyEvent.kNextLayer ||= this.originalLayer;
 
+      keyEvent.inputBreadcrumb = this.sequence.trace();
       vkbd.raiseKeyEvent(keyEvent, null);
 
       // Now that the key has been processed, with a layer possibly changed as a result...
@@ -182,7 +190,7 @@ export default class Multitap implements GestureHandler {
     if(keyIndex == -1) { // also covers undefined, but does not include 0.
       // Modipress keys generally get left out of the key-correction calculations.
       if(!keySupportsModipress(this.baseKey)) {
-        console.warn("Could not find base key's probability for multitap correction");
+        console.warn(`Could not find base key's probability for multitap correction adjustments: ${this.baseKey.key.spec.elementID}, keyboard = ${this.keyboardId}`);
       }
 
       // Decently recoverable; just use the simple-tap distances instead.

--- a/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
@@ -97,6 +97,7 @@ export default class SubkeyPopup implements GestureHandler {
         const keyEvent = vkbd.keyEventFromSpec(key.key.spec);
         keyEvent.keyDistribution = this.currentStageKeyDistribution();
 
+        keyEvent.inputBreadcrumb = this.source.trace();
         vkbd.raiseKeyEvent(keyEvent, key);
       }
     });


### PR DESCRIPTION
To facilitate debugging cases where gestures don't work as intended, this adds sanitized logging for keystrokes resulting for gestures.  These are only to be output when a relevant error or warning is emitted.  They're also pretty handy for obtaining an overview of a gesture's history during code inspection.

This is primarily being added to facilitate investigation of #13344.  An example log that could result for this, though for a properly working state:

```
Context state 31's keystroke:
  touch:10 - initial-tap @ 21596.70 ms
Context state 27's keystroke:
  touch:9 - modipress-multitap-start @ 19390.00 ms
  touch:8 - modipress-multitap-end @ 19271.00 ms
  touch:8 - modipress-multitap-start @ 19271.00 ms
  <empty> - modipress-end-multitap-transition 
  touch:7 - modipress-start @ 19128.00 ms
Context state 23's keystroke:
  touch:7 - modipress-start @ 19128.00 ms
Context state 25's keystroke:
  touch:8 - modipress-multitap-start @ 19271.00 ms
  <empty> - modipress-end-multitap-transition 
  touch:7 - modipress-start @ 19128.00 ms
Context state 21's keystroke:
  touch:6 - subkey-select from 14934.90 ms - 16142.50 ms
  touch:6 - longpress from 14934.90 ms - 15197.50 ms
Context state 17's keystroke:
  touch:5 - subkey-select from 12169.20 ms - 12863.70 ms
  touch:5 - longpress from 12169.20 ms - 12670.10 ms
Context state 13's keystroke:
  touch:4 - initial-tap @ 11465.00 ms
Context state 11's keystroke:
  touch:3 - subkey-select from 8288.10 ms - 10396.00 ms
  touch:3 - longpress from 8288.10 ms - 8507.20 ms
Context state 7's keystroke:
  touch:2 - initial-tap from 7235.80 ms - 7255.50 ms
Context state 5's keystroke:
  touch:1 - initial-tap @ 6288.20 ms
```

Edit:  finalized version will flip the ordering of the context states per https://github.com/keymanapp/keyman/pull/13360#issuecomment-2731440489.

This log is ordered from "newest" to "oldest" context, with the gesture components for each ordered similarly.  Note that "state 23" appears before "state 25" - they're both part of the same multitap, and "state 27" reapplied "state 23" as part of its operation (undoing "state 25", which it invalidated).  

@keymanapp-test-bot skip