### PR TITLE
fix(android): Add breadcrumb when kmp file has no targets to install

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -84,6 +84,7 @@ public class PackageActivity extends AppCompatActivity implements
       if (pkgTarget.equals(PackageProcessor.PP_TARGET_LEXICAL_MODELS)) {
         kmpProcessor = new LexicalModelPackageProcessor(resourceRoot);
       } else if (!pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
+        KMLog.LogBreadcrumb(TAG, "kmpFile: " + kmpFile, true);
         showErrorToast(getString(R.string.no_targets_to_install));
         return;
       }


### PR DESCRIPTION
For investigating KEYMAN-ANDROID-251

> No keyboards or predictive text to install

This adds a breadcrumb to get more info why a kmp file fails to install.

@keymanapp-test-bot skip
