### PR TITLE
fix(linux): ignore exception when fcitx5-configtool is not found

### DIFF
--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -367,7 +367,10 @@ class InstallKmpWindow(Gtk.Dialog):
                 dialog.run()
                 dialog.destroy()
                 if is_fcitx_running():
-                    subprocess.run(['fcitx5-configtool'])
+                    try:
+                        subprocess.run(['fcitx5-configtool'])
+                    except FileNotFoundError:
+                        logging.warning('Ignoring not found fcitx5-configtool')
 
             if self.viewwindow:
                 self.viewwindow.refresh_installed_kmp()


### PR DESCRIPTION
Fixes: #13282
Fixes: KEYMAN-LINUX-7S

@keymanapp-test-bot skip