### PR TITLE
fix(developer): handle non bmp numeric entities in xml reader

### DIFF
--- a/developer/src/common/web/utils/package.json
+++ b/developer/src/common/web/utils/package.json
@@ -12,7 +12,7 @@
     "@keymanapp/common-types": "*",
     "@sentry/node": "^7.57.0",
     "eventemitter3": "^5.0.0",
-    "fast-xml-parser": "^4.5.0",
+    "fast-xml-parser": "^5.0.9",
     "path-browserify": "^1.0.1",
     "restructure": "^3.0.1",
     "sax": ">=0.6.0",

--- a/developer/src/common/web/utils/src/xml-utils.ts
+++ b/developer/src/common/web/utils/src/xml-utils.ts
@@ -21,7 +21,7 @@ type KeymanXMLParserOptionsBag = {
   [key in KeymanXMLType]?: X2jOptions;
 };
 
-const commonKeymanXmlParserOptions: X2jOptions = {
+const PARSER_COMMON_OPTIONS: X2jOptions = {
   attributeNamePrefix: '$', // causes remapping into $: { … } objects
   htmlEntities: true,
   ignoreAttributes: false,
@@ -58,14 +58,14 @@ const PARSER_OPTIONS: KeymanXMLParserOptionsBag = {
     preserveOrder: true,     // Gives us a 'special' format
   },
   'kps': {
-    ...commonKeymanXmlParserOptions,
+    ...PARSER_COMMON_OPTIONS,
   },
   'kpj': {
-    ...commonKeymanXmlParserOptions,
+    ...PARSER_COMMON_OPTIONS,
     attributeNamePrefix: '', // to avoid '@_' prefixes
   },
   'kvks': {
-    ...commonKeymanXmlParserOptions,
+    ...PARSER_COMMON_OPTIONS,
     tagValueProcessor: (_tagName: string, tagValue: string, _jPath: string, _hasAttributes: boolean, isLeafNode: boolean) : string | undefined => {
       if (!isLeafNode) {
         return tagValue?.trim(); // trimmed value
@@ -81,7 +81,7 @@ type KeymanXMLGeneratorOptionsBag = {
   [key in KeymanXMLType]?: XmlBuilderOptions
 };
 
-const commonKeymanXmlGeneratorOptions: XmlBuilderOptions = {
+const GENERATOR_COMMON_OPTIONS: XmlBuilderOptions = {
   attributeNamePrefix: '$',
   ignoreAttributes: false,
   format: true,
@@ -91,13 +91,13 @@ const commonKeymanXmlGeneratorOptions: XmlBuilderOptions = {
 
 const GENERATOR_OPTIONS: KeymanXMLGeneratorOptionsBag = {
   kvks: {
-    ...commonKeymanXmlGeneratorOptions,
+    ...GENERATOR_COMMON_OPTIONS,
   },
   kpj: {
-    ...commonKeymanXmlGeneratorOptions,
+    ...GENERATOR_COMMON_OPTIONS,
   },
   kps: {
-    ...commonKeymanXmlGeneratorOptions,
+    ...GENERATOR_COMMON_OPTIONS,
   },
 };
 

--- a/developer/src/common/web/utils/test/fixtures/kvks/hex_escape.kvks
+++ b/developer/src/common/web/utils/test/fixtures/kvks/hex_escape.kvks
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<visualkeyboard>
+  <header>
+    <version>10.0</version>
+    <kbdname>hex_escape</kbdname>
+    <flags/>
+  </header>
+  <encoding name="unicode" fontname="arial" fontsize="-12">
+    <layer shift="">
+      <key vkey="K_1">&#x1234;</key>
+      <key vkey="K_2">&#256;</key>
+      <key vkey="K_3">&#65536;</key>
+      <key vkey="K_4">&#x12345;</key>
+    </layer>
+  </encoding>
+</visualkeyboard>

--- a/developer/src/common/web/utils/test/fixtures/ldml-keyboard/numeric-id.xml
+++ b/developer/src/common/web/utils/test/fixtures/ldml-keyboard/numeric-id.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="46">
+  <info author="srl295" indicator="🙀" layout="qwerty"  name="TestKbd"/>
+
+  <keys>
+    <key id="1" output="ħ" />
+    <key id="2" output="ថា" />
+  </keys>
+
+</keyboard3>

--- a/developer/src/common/web/utils/test/fixtures/ldml-keyboard/test-fr.xml
+++ b/developer/src/common/web/utils/test/fixtures/ldml-keyboard/test-fr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE keyboardTest3 SYSTEM "../../../../../resources/standards-data/ldml-keyboards/46/dtd/ldmlKeyboardTest3.dtd">
+<!DOCTYPE keyboardTest3 SYSTEM "../../../../../../../../resources/standards-data/ldml-keyboards/46/dtd/ldmlKeyboardTest3.dtd">
 <keyboardTest3 conformsTo="techpreview">
     <!--
       Read by:

--- a/developer/src/common/web/utils/test/kvks/kvks-file.tests.ts
+++ b/developer/src/common/web/utils/test/kvks/kvks-file.tests.ts
@@ -40,6 +40,21 @@ describe('kvks-file-reader', function() {
     const reader = new KvksFileReader();
     assert.throws(() => reader.read(input), 'File appears to be a binary .kvk file');
   });
+
+  it('should read non-bmp hex escapes correctly', function() {
+    const path = makePathToFixture('kvks', 'hex_escape.kvks');
+    const input = fs.readFileSync(path);
+
+    const reader = new KvksFileReader();
+    const kvks = reader.read(input);
+    const invalidVkeys: string[] = [];
+    const vk = reader.transform(kvks, invalidVkeys);
+    assert.isEmpty(invalidVkeys);
+    assert.equal(vk.keys[0].text, '\u{1234}');
+    assert.equal(vk.keys[1].text, '\u{100}');
+    assert.equal(vk.keys[2].text, String.fromCodePoint(0x10000));
+    assert.equal(vk.keys[3].text, String.fromCodePoint(0x12345));
+  });
 });
 
 describe('kvks-file-writer', function() {

--- a/developer/src/common/web/utils/test/ldml/ldml-keyboard-testdata-reader.tests.ts
+++ b/developer/src/common/web/utils/test/ldml/ldml-keyboard-testdata-reader.tests.ts
@@ -2,7 +2,7 @@ import { constants } from '@keymanapp/ldml-keyboard-constants';
 import { assert } from 'chai';
 import 'mocha';
 import { testTestdataReaderCases } from '../helpers/reader-callback-test.js';
-import { LKTAnyAction } from '../../src/types/ldml-keyboard/ldml-keyboard-testdata-xml.js';
+import { LKTAnyAction } from '../types/ldml-keyboard/ldml-keyboard-testdata-xml.js';
 
 describe('ldml keyboard xml reader tests', function () {
   this.slow(500); // 0.5 sec -- json schema validation takes a while

--- a/developer/src/common/web/utils/test/ldml/ldml-keyboard-xml-reader.tests.ts
+++ b/developer/src/common/web/utils/test/ldml/ldml-keyboard-xml-reader.tests.ts
@@ -1,9 +1,9 @@
-import { LKKey, ImportStatus } from '../../src/types/ldml-keyboard/ldml-keyboard-xml.js';
 import 'mocha';
 import {assert} from 'chai';
-import { CommonTypesMessages } from '../../src/common-messages.js';
-import { testReaderCases } from '../helpers/reader-callback-test.js';
 import { Constants } from '@keymanapp/common-types';
+import { CommonTypesMessages } from '../../src/common-messages.js';
+import { LKKey, ImportStatus } from '../../src/types/ldml-keyboard/ldml-keyboard-xml.js';
+import { testReaderCases } from '../helpers/reader-callback-test.js';
 
 import CLDRScanToVkey = Constants.CLDRScanToVkey;
 import CLDRScanToKeyMap = Constants.CLDRScanToKeyMap;
@@ -200,6 +200,25 @@ describe('ldml keyboard xml reader tests', function () {
           subtag: 'flicks',
         }),
       ],
+    },
+    {
+      subpath: 'numeric-id.xml',
+      callback: (data, source, subpath, callbacks) => {
+        assert.ok(source?.keyboard3?.keys);
+        const k = pluckKeysFromKeybag(source?.keyboard3?.keys.key, ['1', '2']);
+        assert.sameDeepOrderedMembers(k.map((entry) => {
+          // Drop the Symbol members from the returned keys; assertions may expect their presence.
+          return {
+            id: entry.id,
+            output: entry.output
+          };
+        }), [
+          {id: '1', output: '1'}, //default import
+          {id: '2', output: '2'}, //default import
+          {id: '1', output: 'ħ'}, //override
+          {id: '2', output: 'ថា'}, //override
+        ]);
+      },
     },
   ]);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -342,7 +342,7 @@
         "@keymanapp/common-types": "*",
         "@sentry/node": "^7.57.0",
         "eventemitter3": "^5.0.0",
-        "fast-xml-parser": "^4.5.0",
+        "fast-xml-parser": "^5.0.9",
         "path-browserify": "^1.0.1",
         "restructure": "^3.0.1",
         "sax": ">=0.6.0",
@@ -8962,22 +8962,18 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
-      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.0.9.tgz",
+      "integrity": "sha512-2mBwCiuW3ycKQQ6SOesSB8WeF+fIGb6I/GG5vU5/XEptwFFhp9PE8b9O7fbs2dpq9fXn4ULR3UsfydNUCntf5A==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^2.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -13804,9 +13800,15 @@
       "link": true
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.0.5.tgz",
+      "integrity": "sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/supports-color": {


### PR DESCRIPTION
fast-xml-reader had a bug with numeric entities. See:
  https://github.com/NaturalIntelligence/fast-xml-parser/issues/725

This is a major dependency version bump (4.5.0 to 5.0.9) which we would normally avoid during beta. However, we need the fix https://github.com/NaturalIntelligence/fast-xml-parser/issues/725 for hex escapes in XML, which is incorporated in 5.0.9.

I have assessed the other changes to fast-xml-parser and found no breaking changes for us, but I tightened the types in xml-utils declarations and found some minor inconsistencies which appear to have no impact, and which I have corrected:
* wrong type in unused parameter to `tagValueProcessor`
* reference to unused property `options.emptyTag`

While doing this, I consolidated the common options for the parser in order to verify consistency, but made no changes to the resolved parsing/building options.

Added a test to ldml keyboard reading, to verify that numeric strings are treated as strings, given the divergence in the `numberParseOptions` option, and it shows that numeric strings are treated as strings.

---

Also adds a unit test to verify that non-BMP numeric entities will be parsed correctly with updated fast-xml-parser.

Fixes: #13348
Fixes: #13263

@keymanapp-test-bot skip