### PR TITLE
chore: add a workflow to automatically close linked issues

### DIFF
--- a/.github/workflows/close-linked-issues-for-merged-prs.yml
+++ b/.github/workflows/close-linked-issues-for-merged-prs.yml
@@ -1,0 +1,20 @@
+name: Close linked issues for merged pull requests
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - beta
+      - 'stable-*'
+      - 'epic/*'
+
+jobs:
+  closeIssueOnPrMergeTrigger:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Closes issues related to a merged pull request.
+        uses: ldez/gha-mjolnir@v1.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-linked-issues-for-merged-prs.yml
+++ b/.github/workflows/close-linked-issues-for-merged-prs.yml
@@ -15,6 +15,6 @@ jobs:
 
     steps:
       - name: Closes issues related to a merged pull request.
-        uses: ldez/gha-mjolnir@v1.5.0
+        uses: ldez/gha-mjolnir@5574ed1f1151e4d2f11e3513cd85920a3a46bb7b # v1.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automatically closes issues when PR is merged into beta, epic/* or stable-*

@keymanapp-test-bot skip