### PR TITLE
docs(android): document control flag for system keyboard picker and task

### DIFF
--- a/android/docs/engine/KMManager/closeParentAppOnShowKeyboardPicker.md
+++ b/android/docs/engine/KMManager/closeParentAppOnShowKeyboardPicker.md
@@ -1,0 +1,39 @@
+---
+title: KMManager.closeParentAppOnShowKeyboardPicker()
+---
+
+## Summary
+The **closeParentAppOnShowKeyboardPicker()** method restores the default behavior of the keyboard picker menu closing the parent app.
+
+## Syntax
+
+```javascript
+KMManager.closeParentAppOnShowKeyboardPicker()
+```
+
+## Description
+Normally, launching the KeyboardPickerActivity from a system keyboard closes the parent app.
+
+(The keyboard picker becomes the root of the activity stack)
+
+Calling this function restores this default behavior.
+
+## Examples
+
+### Example: Using `closeParentAppOnShowKeyboardPicker()`
+
+The following script illustrates the use of `closeParentAppOnShowKeyboardPicker()`:
+```java
+  @Override
+  protected void onResume() {
+    super.onResume();
+    KMManager.onResume();
+    KMManager.hideSystemKeyboard();
+
+    // Reset keyboard picker Activity Task flag
+    KMManager.closeParentAppOnShowKeyboardPicker();
+```
+
+## See also
+* [dontCloseParentAppOnShowKeyboardPicker()](dontCloseParentAppOnShowKeyboardPicker)
+* [showKeyboardPicker()](showKeyboardPicker)

--- a/android/docs/engine/KMManager/closeParentAppOnShowKeyboardPicker.md
+++ b/android/docs/engine/KMManager/closeParentAppOnShowKeyboardPicker.md
@@ -7,14 +7,14 @@ The **closeParentAppOnShowKeyboardPicker()** method restores the default behavio
 
 ## Syntax
 
-```javascript
+```java
 KMManager.closeParentAppOnShowKeyboardPicker()
 ```
 
 ## Description
 Normally, launching the KeyboardPickerActivity from a system keyboard closes the parent app.
 
-(The keyboard picker becomes the root of the activity stack)
+(The keyboard picker becomes the root of the activity stack.)
 
 Calling this function restores this default behavior.
 

--- a/android/docs/engine/KMManager/dontCloseParentAppOnShowKeyboardPicker.md
+++ b/android/docs/engine/KMManager/dontCloseParentAppOnShowKeyboardPicker.md
@@ -1,0 +1,38 @@
+---
+title: KMManager.dontCloseParentAppOnShowKeyboardPicker()
+---
+
+## Summary
+The **dontCloseParentAppOnShowKeyboardPicker()** method disables the keyboard picker task flag so keyboard picker doesn't dismiss the parent app.
+
+## Syntax
+
+```javascript
+KMManager.dontCloseParentAppOnShowKeyboardPicker()
+```
+
+## Description
+Normally, launching the KeyboardPickerActivity from a system keyboard closes the parent app.
+
+(The keyboard picker becomes the root of the activity stack)
+
+Calling this function keeps the parent app running in the background.
+
+## Examples
+
+### Example: Using `dontCloseParentAppOnShowKeyboardPicker()`
+
+The following script illustrates the use of `dontCloseParentAppOnShowKeyboardPicker()`:
+```java
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // When using Keyman system keyboard within the Keyman app, 
+    // disable keyboard picker task flag so keyboard picker doesn't dismiss Keyman app
+    KMManager.dontCloseParentAppOnShowKeyboardPicker();
+```
+
+## See also
+* [closeParentAppOnShowKeyboardPicker()](closeParentAppOnShowKeyboardPicker)
+* [showKeyboardPicker()](showKeyboardPicker)

--- a/android/docs/engine/KMManager/index.md
+++ b/android/docs/engine/KMManager/index.md
@@ -50,6 +50,9 @@ The KMManager is the core class which provides most of the methods and constants
 [`canRemoveKeyboard()`](canRemoveKeyboard)
 : returns whether removing a keyboard is enabled, like in the keyboard picker menu
 
+[`closeParentAppOnShowKeyboardPicker()`](closeParentAppOnShowKeyboardPicker)
+: restores keyboard picker task flag so keyboard picker dismisses the parent app
+
 [`copyHTMLBannerAssets()`](copyHTMLBannerAssets)
 : copies a folder of HTML banner assets so it's available for your keyboard app's resources
 
@@ -58,6 +61,9 @@ The KMManager is the core class which provides most of the methods and constants
 
 [`deregisterLexicalModel()`](deregisterLexicalModel)
 : deregisters the specified lexical model from the LMLayer so it isn't used
+
+[`dontCloseParentAppOnShowKeyboardPicker()`](dontCloseParentAppOnShowKeyboardPicker)
+: disables keyboard picker task flag so keyboard picker doesn't dismiss the parent app
 
 [`executeHardwareKeystroke()`](executeHardwareKeystroke)
 : process the keystroke generated from a physical keyboard


### PR DESCRIPTION
Follows #13313 and documents the KMManager() APIs to control the keyboard picker flag
* closeParentAppOnShowKeyboardPicker()
* dontCloseParentAppOnShowKeyboardPicker()

@keymanapp-test-bot skip
