### PR TITLE
chore(windows): ensure dependencies for keyman32 exclude core:wasm

### DIFF
--- a/windows/src/engine/keyman32/build.sh
+++ b/windows/src/engine/keyman32/build.sh
@@ -7,7 +7,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 builder_describe "Keystroke processing engine" \
   @/common/include \
-  @/core \
+  @/core:win \
   clean configure build test publish install \
   :x86 :x64
 


### PR DESCRIPTION
Add a `:win` meta-target to the /core/build.sh project. This `:win` target triggers both `:x86` and `:x64` targets, and allows us to specify `@/core:win` in the windows/keyman32/build.sh project, in order to build only those two targets, and not `:wasm` target as well (as we don't need WASM Core for Keyman for Windows).

This closely mirrors the pattern we used for `:mac` in /core/build.sh. We could consider using `:arch` instead of `:win` and `:mac` but that needs more careful consideration, as `:arch` implies only the current architecture of the building machine.

This change also sets us up well for when we start doing arm32 and arm64 builds for Windows on ARM in the near future.

Fixes: #13374

@keymanapp-test-bot skip