### PR TITLE
fix(android): Don't report missing kmp.json

### DIFF
--- a/android/KMAPro/kMAPro/src/main/res/values-kr-rNG/strings.xml
+++ b/android/KMAPro/kMAPro/src/main/res/values-kr-rNG/strings.xml
@@ -148,7 +148,7 @@
   <!-- Context: KMP Package strings -->
   <string name="no_new_predictive_text_to_install" comment="Notification when no dictionaries can be installed">No new predictive text to install</string>
   <!-- Context: KMP Package strings -->
-  <string name="no_targets_to_install" comment="Notification when a package doesn't contain keyboards or dictionaries">No keyboards or predictive text to install</string>
+  <string name="no_targets_to_install" comment="Notification when a package doesn't contain keyboards or dictionaries">This is not a valid Keyman keyboard or predictive text package.</string>
   <!-- Context: KMP Package strings -->
   <string name="no_associated_languages" comment="Notification when a keyboard package doesn't contain languages">Keyboard package has no associated languages to install</string>
   <!-- Context: KMP Package strings -->

--- a/android/KMEA/app/src/main/java/com/keyman/engine/packages/PackageProcessor.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/packages/PackageProcessor.java
@@ -122,8 +122,8 @@ public class PackageProcessor {
    */
   public File unzipKMP(File path) throws IOException {
     File tempKeyboardPath = constructPath(path, true);
-    if (!tempKeyboardPath.exists()) {
-      tempKeyboardPath.mkdir();
+    if (!tempKeyboardPath.exists() && !tempKeyboardPath.mkdir()) {
+      KMLog.LogBreadcrumb(TAG, "Unable to mkdir for: " + tempKeyboardPath.toString(), true);
     }
     ZipUtils.unzip(path, tempKeyboardPath);
 
@@ -165,7 +165,6 @@ public class PackageProcessor {
       JSONParser parser = new JSONParser();
       return parser.getJSONObjectFromFile(infoFile);
     } else {
-      KMLog.LogError(TAG, "kmp.json does not exist");
       return null;
     }
   }
@@ -421,7 +420,6 @@ public class PackageProcessor {
    */
   public String getPackageTarget(JSONObject json) {
     if (json == null) {
-      KMLog.LogError(TAG, "kmp.json is null");
       return PP_TARGET_INVALID;
     }
     try {


### PR DESCRIPTION
Fixes KEYMAN-ANDROID-4G and follows the guidance on #11368

> There's a few causes of this in the Sentry crashes
> * kmp.json is null
> * kmp.json doesn't exist
> * kmp.json doesn't contain keyboards or lexical-models
> in those cases we should be telling the user that the package is not Android-compat, and not logging an error on our end.

Removing these Sentry errors, the user gets Toast notification "~No keyboards or predictive text to install~" "This is not a valid Keyman keyboard or predictive text package."

* Also for more info, added a breadcrumb if the temporary directory can't be made for extracting the kmp file.

## User Testing
**Setup** - Install the PR build of Keyman for Android.
Also download a test keyboard which intentionally doesn't contain kmp.json
https://darcywong00.github.io/examples/invalid/khmer10/khmer10_noJson.kmp

* **TEST_NO_KMP** - Verifies user notified "No keyboards or predictive text to install" when kmp.json missing
1. Launch Keyman for Android and dismiss the Get Started menu
2. From Keyman settings --> Install Keyboard or Dictionary --> Install from local file --> browse to where khmer10_noJson.kmp was saved (in setup)
3. Verify the toast notification appears "No keyboards or predictive text to install"