### PR TITLE
fix(windows): Check for updates registry value stored under the one Key

### DIFF
--- a/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
@@ -216,7 +216,7 @@ begin
 
   Registry := TRegistryErrorControlled.Create; // I2890
   try
-    if Registry.OpenKey(SRegKey_KeymanDesktop_CU, True) then
+    if Registry.OpenKey(SRegKey_KeymanEngine_CU, True) then
       Registry.WriteDateTime(SRegValue_LastUpdateCheckTime, Now);
   finally
     Registry.Free;
@@ -232,7 +232,7 @@ begin
   try
     Registry := TRegistryErrorControlled.Create; // I2890
     try
-      if Registry.OpenKeyReadOnly(SRegKey_KeymanDesktop_CU) then
+      if Registry.OpenKeyReadOnly(SRegKey_KeymanEngine_CU) then
       begin
         if Registry.ValueExists(SRegValue_CheckForUpdates) and
           not Registry.ReadBool(SRegValue_CheckForUpdates) then

--- a/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/OnlineUpdateCheck.pas
@@ -418,7 +418,7 @@ begin
   try
     with TRegistryErrorControlled.Create do  // I2890
     try
-      if OpenKeyReadOnly(SRegKey_KeymanDesktop_CU) then
+      if OpenKeyReadOnly(SRegKey_KeymanEngine_CU) then
       begin
         if ValueExists(SRegValue_CheckForUpdates) and not ReadBool(SRegValue_CheckForUpdates) and not FForce then
         begin
@@ -520,7 +520,7 @@ begin
 
   with TRegistryErrorControlled.Create do  // I2890
   try
-    if OpenKey(SRegKey_KeymanDesktop_CU, True) then
+    if OpenKey(SRegKey_KeymanEngine_CU, True) then
       WriteDateTime(SRegValue_LastUpdateCheckTime, Now);
   finally
     Free;

--- a/windows/src/desktop/setup/UfrmRunDesktop.pas
+++ b/windows/src/desktop/setup/UfrmRunDesktop.pas
@@ -1038,19 +1038,26 @@ begin
 end;
 
 procedure TfrmRunDesktop.GetSavedSettings;
+var
+  CheckForUpdatesFound: Boolean;
 begin
   GetDefaultSettings;
+  CheckForUpdatesFound := False;
   try
     with CreateHKCURegistry do  // I2749
     try
       if OpenKeyReadOnly('\' + SRegKey_KeymanEngine_CU) then
       begin
-        if ValueExists(SRegValue_AutomaticallyReportUsage) then
-          FAutomaticallyReportUsage := ReadBool(SRegValue_AutomaticallyReportUsage)
+        FAutomaticallyReportUsage := ValueExists(SRegValue_AutomaticallyReportUsage) and ReadBool(SRegValue_AutomaticallyReportUsage)
+        if ValueExists(SRegValue_CheckForUpdates) then
+        begin
+          FCheckForUpdates := ReadBool(SRegValue_CheckForUpdates);
+          CheckForUpdatesFound := True;
+        end;
       end;
       if OpenKeyReadOnly(SRegKey_KeymanDesktop_CU) then
       begin
-        FCheckForUpdates := ValueExists(SRegValue_CheckForUpdates) and ReadBool(SRegValue_CheckForUpdates);
+        FCheckForUpdates := (not CheckForUpdatesFound) and ValueExists(SRegValue_CheckForUpdates) and ReadBool(SRegValue_CheckForUpdates);
         FStartWithWindows := ValueExists(SRegValue_UpgradeRunKeyman) or
           (OpenKeyReadOnly('\' + SRegKey_WindowsRun_CU) and ValueExists(SRegValue_WindowsRun_Keyman));
       end

--- a/windows/src/desktop/setup/UfrmRunDesktop.pas
+++ b/windows/src/desktop/setup/UfrmRunDesktop.pas
@@ -1052,10 +1052,12 @@ begin
     try
       if OpenKeyReadOnly('\' + SRegKey_KeymanEngine_CU) then
       begin
-        // only update the the flag if the value exists in the registry, otherwise leave them as defaults
+        // only update the flag if the value exists in the registry, otherwise leave them as defaults
         // leave as the the default values
         if ValueExists(SRegValue_AutomaticallyReportUsage) then
-          FAutomaticallyReportUsage := ReadBool(SRegValue_AutomaticallyReportUsage)
+        begin
+          FAutomaticallyReportUsage := ReadBool(SRegValue_AutomaticallyReportUsage);
+        end;
         if ValueExists(SRegValue_CheckForUpdates) then
         begin
           FCheckForUpdates := ReadBool(SRegValue_CheckForUpdates);

--- a/windows/src/desktop/setup/UfrmRunDesktop.pas
+++ b/windows/src/desktop/setup/UfrmRunDesktop.pas
@@ -1043,10 +1043,10 @@ end;
 
 procedure TfrmRunDesktop.GetSavedSettings;
 var
-  CheckForUpdatesFound: Boolean;
+  CheckForUpdatesKeyFound: Boolean;
 begin
   GetDefaultSettings;
-  CheckForUpdatesFound := False;
+  CheckForUpdatesKeyFound := False;
   try
     with CreateHKCURegistry do  // I2749
     try
@@ -1061,12 +1061,12 @@ begin
         if ValueExists(SRegValue_CheckForUpdates) then
         begin
           FCheckForUpdates := ReadBool(SRegValue_CheckForUpdates);
-          CheckForUpdatesFound := True;
+          CheckForUpdatesKeyFound := True;
         end;
       end;
       if OpenKeyReadOnly(SRegKey_KeymanDesktop_CU) then
       begin
-        FCheckForUpdates := (not CheckForUpdatesFound) and ValueExists(SRegValue_CheckForUpdates) and ReadBool(SRegValue_CheckForUpdates);
+        FCheckForUpdates := (not CheckForUpdatesKeyFound) and ValueExists(SRegValue_CheckForUpdates) and ReadBool(SRegValue_CheckForUpdates);
         FStartWithWindows := ValueExists(SRegValue_UpgradeRunKeyman) or
           (OpenKeyReadOnly('\' + SRegKey_WindowsRun_CU) and ValueExists(SRegValue_WindowsRun_Keyman));
       end

--- a/windows/src/desktop/setup/UfrmRunDesktop.pas
+++ b/windows/src/desktop/setup/UfrmRunDesktop.pas
@@ -1032,6 +1032,10 @@ end;
 
 procedure TfrmRunDesktop.GetDefaultSettings; // I2651
 begin
+  // Due to the way the TUtilKeymanOptionEntry.Save works it only
+  // saves the values that are different from the defaults.  So we
+  // need to set the defaults here. Two locations for the defaults is
+  // not ideal, but leave for now.
   FStartWithWindows := True; // I2607
   FCheckForUpdates := True;  // I2609
   FAutomaticallyReportUsage := True;
@@ -1048,7 +1052,10 @@ begin
     try
       if OpenKeyReadOnly('\' + SRegKey_KeymanEngine_CU) then
       begin
-        FAutomaticallyReportUsage := ValueExists(SRegValue_AutomaticallyReportUsage) and ReadBool(SRegValue_AutomaticallyReportUsage)
+        // only update the the flag if the value exists in the registry, otherwise leave them as defaults
+        // leave as the the default values
+        if ValueExists(SRegValue_AutomaticallyReportUsage) then
+          FAutomaticallyReportUsage := ReadBool(SRegValue_AutomaticallyReportUsage)
         if ValueExists(SRegValue_CheckForUpdates) then
         begin
           FCheckForUpdates := ReadBool(SRegValue_CheckForUpdates);

--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -1842,7 +1842,7 @@ procedure TfrmKeyman7Main.tmrBackgroundUpdateCheckTimer(Sender: TObject);
 begin
   with TRegistryErrorControlled.Create do  // I2890
   try
-    if OpenKeyReadOnly(SRegKey_KeymanDesktop_CU) then
+    if OpenKeyReadOnly(SRegKey_KeymanEngine_CU) then
     begin
       if ValueExists(SRegValue_CheckForUpdates) and not ReadBool(SRegValue_CheckForUpdates) then Exit;
       if ValueExists(SRegValue_LastUpdateCheckTime) and (Now - ReadDateTime(SRegValue_LastUpdateCheckTime) < 7) then Exit;

--- a/windows/src/engine/kmcomapi/util/utilkeymanoption.pas
+++ b/windows/src/engine/kmcomapi/util/utilkeymanoption.pas
@@ -121,6 +121,7 @@ type
     GroupName: string;
   end;
 
+// The Default options here need to be consistent with the defaults set in TfrmRunDesktop.GetDefaultSettings
 const KeymanOptionInfo: array[0..16] of TKeymanOptionInfo = (  // I3331   // I3620   // I4552
   // Global options
 


### PR DESCRIPTION
Fixes: #13216 
The `SRegValue_CheckForUpdates` was written by `utilkeymanoptions`
to the `Keyman Engine` Key but read from `Keyman Desktop` Key.  
This change moves it to only be read in Keyman Engine Key.
It also move the last update time to this Key for completeness.

I was curious why it seemed to work before.
The logic previously (since I think about version 10) was     

```
if OpenKeyReadOnly(SRegKey_KeymanDesktop_CU) then
       begin
      if ValueExists(SRegValue_CheckForUpdates) and not ReadBool(SRegValue_CheckForUpdates) then Exit;
      if ValueExists(SRegValue_LastUpdateCheckTime) and (Now - ReadDateTime(SRegValue_LastUpdateCheckTime) < 7) then Exit;
      TKeymanDesktopShell.RunKeymanConfiguration('-ouc');
    end; 
```

It would continue after the second if because `ValueExists(SRegValue_CheckForUpdates)` was never existed under `SRegKey_KeymanDesktop_CU`. This meant you couldn't really turn off periodically checking for updates. 


# User Testing

# TEST_CHECK_REG_VALUES_TRUE
1. Download the Keyman build from this PR
2. Start the install select the install options and - Check the box for "Check for updates online periodically" to be checked
5. Also, make sure the version being installed is this PR's version
Expected Result:
6. After installation has finished, go to Keyman options and verify the option   "Automatically check for updates and download" is checked.
7. Open Keyman Configuration go to the Update tab and press the `check for updates button`
8. Open Regedit <kbd>Win</kbd><kbd>R</kbd> type regedit 
9. Go to the current user key at (Computer\HKEY_CURRENT_USER\SOFTWARE\Keyman\Keyman Engine). 
10. Verify that you there is a `last update check` value. 