### PR TITLE
fix(common): fail builds with low test coverage for all typescript projects

### DIFF
--- a/developer/src/common/web/utils/build.sh
+++ b/developer/src/common/web/utils/build.sh
@@ -49,5 +49,5 @@ function do_build() {
 builder_run_action clean       rm -rf ./build/
 builder_run_action configure   verify_npm_setup
 builder_run_action build       do_build
-builder_run_action test        builder_do_typescript_tests 50
+builder_run_action test        builder_do_typescript_tests 45
 builder_run_action publish     builder_publish_npm

--- a/developer/src/kmc-model-info/build.sh
+++ b/developer/src/kmc-model-info/build.sh
@@ -31,7 +31,7 @@ builder_run_action clean        rm -rf ./build/ ./tsconfig.tsbuildinfo
 builder_run_action configure    verify_npm_setup
 builder_run_action build        tsc --build
 builder_run_action api          api-extractor run --local --verbose
-builder_run_action test         builder_do_typescript_tests 80
+builder_run_action test         builder_do_typescript_tests 55
 
 #-------------------------------------------------------------------------------------------------------------------
 

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -344,7 +344,7 @@ builder_do_typescript_tests() {
     THRESHOLD_PARAMS="--lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD"
   fi
 
-  c8 --reporter=lcov --reporter=text --exclude-after-remap --check-coverage=false $THRESHOLD_PARAMS mocha ${MOCHA_FLAGS} "${builder_extra_params[@]}"
+  c8 --reporter=lcov --reporter=text --exclude-after-remap --check-coverage $THRESHOLD_PARAMS mocha ${MOCHA_FLAGS} "${builder_extra_params[@]}"
 
   if [[ ! -z "$C8_THRESHOLD" ]]; then
     builder_echo warning "Coverage thresholds are currently $C8_THRESHOLD%, which is lower than ideal."

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -342,6 +342,13 @@ builder_do_typescript_tests() {
   if [[ $# -gt 0 ]]; then
     C8_THRESHOLD=$1
     THRESHOLD_PARAMS="--lines $C8_THRESHOLD --statements $C8_THRESHOLD --branches $C8_THRESHOLD --functions $C8_THRESHOLD"
+  else
+    # Seems like a bug in TeamCity reporter if we don't list default thresholds,
+    # see #13418.
+    #
+    # Making branch and function thresholds slightly lower, because the default
+    # for c8 is 0 for these anyway.
+    THRESHOLD_PARAMS="--lines 90 --statements 90 --branches 80 --functions 80"
   fi
 
   c8 --reporter=lcov --reporter=text --exclude-after-remap --check-coverage $THRESHOLD_PARAMS mocha ${MOCHA_FLAGS} "${builder_extra_params[@]}"


### PR DESCRIPTION
This is probably my fault, when I consolidated the typescript test scripts, I didn't spot the `--check-coverage=false` flag which meant that although the coverage tests were run, the builds would not fail if they were too low.

I am anticipating some builds failing until I adjust thresholds...

Fixes: #13417

@keymanapp-test-bot skip