### PR TITLE
fix(ios): suppress Get Started dialog when closing help page

### DIFF
--- a/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
@@ -554,11 +554,7 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
       navigationItem.titleView = nil
       navigationItem.rightBarButtonItem = nil
       setNavBarButtons()
-      if shouldShowGetStarted {
-        perform(#selector(self.showGetStartedView), with: nil, afterDelay: 0.75)
-      } else if wasKeyboardVisible {
-        perform(#selector(self.displayKeyboard), with: nil, afterDelay: 0.75)
-      }
+      perform(#selector(self.displayKeyboard), with: nil, afterDelay: 0.75)
     } else {
       _ = dismissDropDownMenu()
       popover?.dismiss(animated: false)


### PR DESCRIPTION
Do not show the Get Started dialog when dismissing the help page. This was only an issue when Keyman is configured to show the Get Started dialog, and it is not set up as the System keyboard.

From the code, it was clear that this was behaving as designed, but it does seem like overkill.

Fixes: #8662

## User Testing

* **TEST_NO_GET_STARTED_ON_HELP_DISMISSAL**: The Get Started dialog does not appear when help page is closed

1. Install and run the Keyman build associated with this PR
1. Confirm that the Get Started dialog is presented when starting Keyman
1. If the Get Started dialog is not presented, then disable Keyman under Settings->Apps->Keyman->Keyboards
1. Confirm that the Get Started dialog is presented when starting Keyman
1. Dismiss the Get Started dialog
1. From the menu in Keyman, choose the Info item to access the help page
1. Dismiss the help page by tapping Done
1. Confirm that the Get Started dialog is not presented

* **TEST_GET_STARTED_ON_KEYBOARD_INSTALL**: The Get Started dialog does appear a keyboard is installed

1. Run the Keyman build associated with this PR
1. Confirm that the Get Started dialog is presented when starting Keyman
1. If the Get Started dialog is not presented, then disable Keyman under Settings->Apps->Keyman->Keyboards
1. Confirm that the Get Started dialog is presented when starting Keyman
1. Dismiss the Get Started dialog
1. Install a new keyboard
1. Confirm that the Get Started dialog is presented after keyboard installation is complete
