### PR TITLE
feat(windows): hide update header if no updates are available

### DIFF
--- a/windows/src/desktop/kmshell/xml/keyman_update.xsl
+++ b/windows/src/desktop/kmshell/xml/keyman_update.xsl
@@ -31,10 +31,12 @@
         </div>
 
         <div class="grid_container_update" id="update_details">
+          <!-- hide header if no updates but keep the grid layout -->
+          <xsl:if test="$isNewKeymanVersionAvailable or $isNewKeyboardVersionAvailable">
             <div class='grid_item'><xsl:value-of select="$locale/string[@name='S_Update_ComponentHead']"/></div>
             <div class='grid_item'><xsl:value-of select="$locale/string[@name='S_Update_OldVersionHead']"/></div>
             <div class='grid_item'><xsl:value-of select="$locale/string[@name='S_Update_SizeHead']"/></div>
-
+          </xsl:if>
             <xsl:apply-templates select="/Keyman/Updates/Update" />
 
         </div>


### PR DESCRIPTION
Hide the header for the grid of new updates when
no updates are available. "Updated Component | Old Version | Size "

Fixes: #13069

# User Testing 

# TEST_NO_UPDATES_NO_HEADER

1. Install Keyman attached this PR
2. Once installed, open Keyman Configuration and the Update tab.
3. Verify that there is no table header of "Updated Component | Old Version | Size "

![image](https://github.com/user-attachments/assets/be9c42b2-dcbd-4320-97b9-b007dd61fb07)

Got to next test 

# TEST_UPDATES_HEADER

Continue from TEST_NO_UPDATES_NO_HEADER
1. Press the `Check for new updates` button
2. If Updates are available verify that the header of now appears "Updated Component | Old Version | Size "
3. If there are no updates available install the old euro latin keyboard attached to this PR
[sil_euro_latin.zip](https://github.com/user-attachments/files/19119646/sil_euro_latin.zip)
5. Once installed, go back into to Keyman Configuration and Updates. Press the `Check for new updates` button. 
6. Verify that the header of now appears "Updated Component | Old Version | Size "
![image](https://github.com/user-attachments/assets/5cde0110-3bd6-428f-af46-b86882931f51)
