### PR TITLE
feat(windows): hard code key cap colour

### DIFF
--- a/common/windows/delphi/components/OnScreenKeyboard.pas
+++ b/common/windows/delphi/components/OnScreenKeyboard.pas
@@ -1418,7 +1418,7 @@ var
         //       but this requires a file format change, so a much bigger scope
 
         if not Enabled then      Font.Color := $808080
-        else                     Font.Color := clLime;
+        else                     Font.Color := KeyFontColor_Cap;
 
         FKeyboard.FDrawChar.DisplayQuality := ctCleartype;
         FKeyboard.FDrawChar.Color := Font.Color;

--- a/common/windows/delphi/components/OnScreenKeyboard.pas
+++ b/common/windows/delphi/components/OnScreenKeyboard.pas
@@ -1418,7 +1418,7 @@ var
         //       but this requires a file format change, so a much bigger scope
 
         if not Enabled then      Font.Color := $808080
-        else                     Font.Color := clWindowText;
+        else                     Font.Color := clLime;
 
         FKeyboard.FDrawChar.DisplayQuality := ctCleartype;
         FKeyboard.FDrawChar.Color := Font.Color;


### PR DESCRIPTION
Fixes: #13106
This only changes the colour of the key caps on the OSK to always be a almost black in colour. Other menus etc in Keyman may still be hard to read depending on the colour theme chosen in for the Windows operating system. This is change is not for full theme support. 


# User Testing
In Windows 10 I had to use High contrast to get the Windows text colour to change. Windows 11 may have more controlability.
# TEST_OSK_KEYCAPS_COLOR
1 Install the Keyman from this PR install a keyboard in my test I chose classical greek.
2 Go to Windows settings and search for the `High Contrast` setting turn this on.
3 The default text colour is most likely white; if it is, leave it as is. If it is black, change it to red. 
4 Start Keyman change to the installed keyboard and turn on the OSK. The key caps should be almost black in colour
expected result.
Key caps back
![image](https://github.com/user-attachments/assets/2a2a7d00-8a8c-4692-8e02-a8f7cf25d484)
