### PR TITLE
fix(oem/fv/android): Avoid resetting keyboard index

### DIFF
--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -169,9 +169,6 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
                 }
             }
         }
-
-        if (KMManager.getCurrentKeyboardIndex(this) < 0)
-            KMManager.setKeyboard(this, 0);
     }
 
     @Override


### PR DESCRIPTION
Fixes: FV-ANDROID-5G
FixeS: FV-ANDROID-7N

From the days of stable-12.0 when the FirstVoices for Android app was configured in the main repo, the SystemKeyboard initialized with

https://github.com/keymanapp/keyman/blob/3148aa7b8c8a4b5de574d49bdf6edc80dcb6761a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java#L111-L113

In the scenario FV for Android installed and enabled as the system keyboard (from the Android settings menu instead of launching the FV app), the initial usage as a system keyboard would have an uninitialized keyboard key (language and keyboard ID pairing to determine the current keyboard).

### Change
This is all managed by KeyboardController() now, so these spurious lines can be removed. (They never existed in the Keyman for Android app)

## User Testing
**Setup** - 
1. In Android Studio, edit the Configuration so the Launch Action does "Nothing" instead of the default "Default Activity". This prevents the FirstVoices app from launching after install.
![Screenshot from 2025-03-07 11-22-30](https://github.com/user-attachments/assets/e7ffb930-998b-4335-bc9b-f59ebbf56f7c)
2. Install the PR build of FirstVoices for Android on an emulator
3. On the Android emulator, go to device Settings --> System --> Keyboard --> On-screen keyboard --> Enable FirstVoices


* **TEST_INITIAL_KEYBOARD** - Verifies FirstVoices runs as system keyboard when not configured through FV
1. On the device (without running FirstVoices for Android), open Chrome browser and select text field
2. On the navigation bar, click the keyboard icon and set FirstVoices as the system keyboard
3. Verify FirstVoices keyboard appears (fallsback to English - EuroLatin)
4. Verify the keyboard functions
5. This concludes the test. Go back to Android Studio configuration settings and edit Configuration so the "Launch Action" is back to "Default Activity".