### PR TITLE
fix(developer): use '-' as placeholder for temp project name in cmdline

### DIFF
--- a/developer/src/tike/main/Keyman.Developer.System.LaunchProjects.pas
+++ b/developer/src/tike/main/Keyman.Developer.System.LaunchProjects.pas
@@ -16,6 +16,7 @@ type
     FProjectFilename: string;
     FFilenames: TStringList;
     FStatus: TLaunchProjectStatus;
+    function GetLaunchProjectFilename: string;
   public
     constructor Create(const AProjectFilename: string);
     destructor Destroy; override;
@@ -64,11 +65,21 @@ begin
   inherited Destroy;
 end;
 
+/// Use the project filename '-' to indicate launch of a new temporary project
+/// instance, because passing empty string is not possible as a commandline
+/// parameter.
+function TLaunchProject.GetLaunchProjectFilename: string;
+begin
+  if Self.ProjectFilename = ''
+    then Result := '-'
+    else Result := Self.ProjectFilename;
+end;
+
 function TLaunchProject.LaunchAsNewInstance: Boolean;
 var
   filename, cmdline: string;
 begin
-  cmdline := '"'+ParamStr(0)+'" --sub-process "'+Self.ProjectFilename+'"';
+  cmdline := '"'+ParamStr(0)+'" --sub-process "'+Self.GetLaunchProjectFilename+'"';
   for filename in Self.Filenames do
     cmdline := cmdline + ' "'+filename+'"';
 

--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -547,6 +547,8 @@ end;
 
 
 procedure TfrmKeymanDeveloper.FormCreate(Sender: TObject);
+var
+  newProject: TProjectUI;
 begin
   inherited;
 
@@ -605,7 +607,10 @@ begin
   if TikeCommandLine.StartupProjectPath <> '' then
   begin
     try
-      if LoadGlobalProjectUI(ptUnknown, TikeCommandLine.StartupProjectPath) = nil then
+      if TikeCommandLine.StartupProjectPath = '-'
+        then newProject := CreateTempGlobalProjectUI(ptUnknown)
+        else newProject := LoadGlobalProjectUI(ptUnknown, TikeCommandLine.StartupProjectPath);
+      if newProject = nil then
       begin
         raise EProjectLoader.Create('Project is already open in another process');
       end;


### PR DESCRIPTION
When launching a new instance of TIKE to open a source file that does not have an owning project, use '-' as a placeholder for the project filename, because passing an empty string as a parameter does not work.

Fixes: #13317

# User Testing

To prepare for this test, copy a .kmn file from an existing Keyman Developer projet onto your desktop.

* TEST_OPEN_FILE: Open a project in Keyman Developer. Then, using File|Open, open the .kmn file that is on your desktop. The file should open in a new Keyman Developer instance, in a "temporary project".