### PR TITLE
fix(android/engine): Ignore key errors if user switched to another IME

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardJSHandler.java
@@ -119,7 +119,9 @@ public class KMKeyboardJSHandler {
 
         InputConnection ic = KMManager.getInputConnection(k.keyboardType);
         if (ic == null) {
-          KMLog.LogError(TAG, "insertText failed: InputConnection is null");
+          // current active InputConnection is no longer bound to the Keyman Engine input method
+          // (user switched to another IME) so disregard the keystroke.
+          // https://developer.android.com/reference/android/inputmethodservice/InputMethodService#getCurrentInputConnection()
           return;
         }
 
@@ -273,7 +275,9 @@ public class KMKeyboardJSHandler {
 
         InputConnection ic = KMManager.getInputConnection(k.keyboardType);
         if (ic == null) {
-          KMLog.LogError(TAG, "dispatchKey failed: InputConnection is null");
+          // current active InputConnection is no longer bound to the Keyman Engine input method
+          // (user switched to another IME) so disregard the keystroke.
+          // https://developer.android.com/reference/android/inputmethodservice/InputMethodService#getCurrentInputConnection()
           return;
         }
 


### PR DESCRIPTION
Fixes: KEYMAN-ANDROID-65D
Fixes: FV-ANDROID-ZY

Reference:
https://developer.android.com/reference/android/inputmethodservice/InputMethodService#getCurrentInputConnection()

Currently, `insertText()` and `dispatchKey()` log errors if `getCurrentInputConnection()` returns null.
This happens when the current active InputConnection is no longer bound to the Keyman Engine input method
 (user switched to another IME) so Keyman Engine for Android should disregard the keystroke.

This can occur if the user is in a single Keyman keyboard and quickly hits keys and the globe key to switch to another IME. By the time KeymanWeb processes the key stroke, the user is now in a different system IME.

@keymanapp-test-bot skip
