### PR TITLE
fix(windows): add exception handling for loading xml file in XSL Rendering

### DIFF
--- a/windows/src/desktop/kmshell/render/XMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/XMLRenderer.pas
@@ -243,7 +243,7 @@ begin
       xml.LoadFromFile(FTemplatePath + FRenderTemplate);
     except
       on E: Exception do
-        raise EXMLRenderer.Create('Unexpected error while loading XSLT: ' + E.Message);
+        raise EXMLRenderer.Create('Unexpected error while loading XSLT: ' + E.ClassName+': ' + E.Message);
     end;
 
     try
@@ -251,7 +251,7 @@ begin
       Result := s;
     except
       on E: Exception do
-        raise EXMLRenderer.Create('Error transforming XML with XSLT: ' + E.Message);
+        raise EXMLRenderer.Create('Error transforming XML with XSLT: ' + E.ClassName+': ' + E.Message);
     end;
 
     Result := s;

--- a/windows/src/desktop/kmshell/render/XMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/XMLRenderer.pas
@@ -107,6 +107,7 @@ uses
   UFixupMissingFile,
   UILanguages,
   Keyman.Configuration.System.UmodWebHttpServer,
+  Keyman.System.KeymanSentryClient,
   Unicode,
   utildir,
   utilhttp,
@@ -200,7 +201,7 @@ begin
   FOutput := TStringList.Create;
   try
     LanguageCode := (kmcom.Control as IKeymanCustomisationAccess).KeymanCustomisation.CustMessages.LanguageCode;
-
+    TKeymanSentryClient.Breadcrumb('ui.configuration', ClassName +' LanguagueCode: '+LanguageCode, 'file-io');
     FOutput.Add(
       '<?xml version="1.0" encoding="utf-8"?>'+
 
@@ -229,6 +230,7 @@ begin
     if not FileExists(FTemplatePath + FRenderTemplate) then
     begin
       try
+        TKeymanSentryClient.Breadcrumb('ui.configuration', ClassName+' Call FixupMissingFile for ' +FTemplatePath +FRenderTemplate, 'file-io');
         FixupMissingFile(FTemplatePath + FRenderTemplate);
       except
         on E:EFixupMissingFile do
@@ -237,6 +239,7 @@ begin
     end;
 
     try
+      TKeymanSentryClient.Breadcrumb('ui.configuration', ClassName+' Loading XSLT '+FTemplatePath +FRenderTemplate, 'file-io');
       xml.LoadFromFile(FTemplatePath + FRenderTemplate);
     except
       on E: Exception do

--- a/windows/src/desktop/kmshell/render/XMLRenderer.pas
+++ b/windows/src/desktop/kmshell/render/XMLRenderer.pas
@@ -236,9 +236,21 @@ begin
       end;
     end;
 
-    xml.LoadFromFile(FTemplatePath + FRenderTemplate);
+    try
+      xml.LoadFromFile(FTemplatePath + FRenderTemplate);
+    except
+      on E: Exception do
+        raise EXMLRenderer.Create('Unexpected error while loading XSLT: ' + E.Message);
+    end;
 
-    doc.Node.transformNode(xml.Node, s);
+    try
+      doc.Node.transformNode(xml.Node, s);
+      Result := s;
+    except
+      on E: Exception do
+        raise EXMLRenderer.Create('Error transforming XML with XSLT: ' + E.Message);
+    end;
+
     Result := s;
 
     if KLEnabled or (GetDebugPath('Debug_XMLRenderer', '', False) <> '') then  // I3269   // I3545


### PR DESCRIPTION
Does not really F i x: #12679 it adds bread crumbs and exception handling to and get more information about what is actually failing.

We can see there is an exception being thrown on line  https://github.com/keymanapp/keyman/blob/19994a95af7fa6476b9c391c9db997d59ed730ac/windows/src/desktop/kmshell/render/XMLRenderer.pas#L247
I wanted to see if maybe the loading of the XML file was failing even though it seems there is a check to ensure the file exists. May be the load still fails.

@keymanapp-test-bot skip