### PR TITLE
fix(developer): strip markers when generating KVK from LDML

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/visual-keyboard-compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/visual-keyboard-compiler.ts
@@ -135,7 +135,9 @@ export class LdmlKeyboardVisualKeyboardCompiler {
 
   private getDisplayFromKey(keydef: KMXPlus.KeysKeys, source: KMXPlus.KMXPlusData) {
     const display = source.disp?.disps?.find(d => d.id.value == keydef.id.value || d.to.value == keydef.to.value);
-    return display?.display.value ?? keydef.to.value;
+    const value = display?.display.value ?? keydef.to.value;
+    // strip markers from the output (these are valid in keydef.to, but not in display.display, nor in kvk)
+    return value.replaceAll(/\uffff\u0008./g, '');
   }
 
   private translateLayerModifiersToVisualKeyboardShift(modifiers: number): VisualKeyboard.VisualKeyboardShiftState {

--- a/developer/src/kmc-ldml/test/disp.tests.ts
+++ b/developer/src/kmc-ldml/test/disp.tests.ts
@@ -56,7 +56,13 @@ describe('disp', function () {
     assert.equal(disp?.baseCharacter?.value, 'x');
     assert.ok(disp?.disps);
   });
-
+  it('should compile disp without converting markers', async function() {
+    let disp = await loadSectionFixture(DispCompiler, 'sections/disp/not-a-marker.xml', compilerTestCallbacks) as Disp;
+    assert.equal(compilerTestCallbacks.messages.length, 0);
+    assert.ok(disp?.disps);
+    assert.equal(disp.disps.length, 1);
+    assert.equal(disp.disps[0].display?.value, '\\m{hat}');
+  });
   it('should reject duplicate tos', async function() {
     let disp = await loadSectionFixture(DispCompiler, 'sections/disp/invalid-dupto.xml', compilerTestCallbacks) as Disp;
     assert.isNull(disp);

--- a/developer/src/kmc-ldml/test/fixtures/sections/disp/not-a-marker.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/disp/not-a-marker.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+  <info name="disp-marker"/>
+
+  <displays>
+    <!-- this is not a marker, just plain text -->
+    <display output="\u{0300}" display="\m{hat}" />
+  </displays>
+</keyboard3>

--- a/developer/src/kmc-ldml/test/visual-keyboard-compiler.tests.ts
+++ b/developer/src/kmc-ldml/test/visual-keyboard-compiler.tests.ts
@@ -184,6 +184,26 @@ describe('visual-keyboard-compiler', function() {
     assert.equal(vk.keys[0].text, '2');
   });
 
+  it('should strip markers from key.output', async function() {
+    const xml = stripIndent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+        <info name="minimal"/>
+        <keys>
+          <key id="x" output="1\\m{hat}2" />
+        </keys>
+        <layers formId="us">
+          <layer modifiers="none"><row keys="x" /></layer>
+        </layers>
+      </keyboard3>
+    `;
+
+    const vk = await loadVisualKeyboardFromXml(xml, 'test');
+
+    assert.equal(vk.keys.length, 1);
+    assert.equal(vk.keys[0].text, '12'); // marker stripped from `1<marker>2`
+  });
+
   it('should read string variables in display.display', async function() {
     const xml = stripIndent`
       <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Markers are permitted in key outputs, but when these are used to generate a .kvk, they should be stripped out.

Also added a test for disp to verify that markers are not transformed in `<display display=` attribute values.

Fixes: #13469

@keymanapp-test-bot skip