### PR TITLE
fix(mac): change text in privacy alert for macOS 13.0 and later

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/Privacy/PrivacyWindowController.m
@@ -13,6 +13,7 @@
  */
 
 #import "PrivacyWindowController.h"
+#import "KMLogs.h"
 
 @interface PrivacyWindowController ()
 @end
@@ -25,7 +26,14 @@
   NSString *bundleDisplayName = [[[NSBundle mainBundle] localizedInfoDictionary]
                                  objectForKey:@"CFBundleDisplayName"];
   [self.window setTitle:bundleDisplayName];
-  [_alertText setStringValue:NSLocalizedString(@"privacy-alert-text", nil)];
+
+  if (@available(macOS 13.0, *)) {
+    os_log_info([KMLogs privacyLog], "setting privacy window text for ventura and later");
+    [_alertText setStringValue:NSLocalizedString(@"privacy-alert-text-ventura", nil)];
+  } else {
+    os_log_info([KMLogs privacyLog], "setting privacy window text for pre-ventura");
+   [_alertText setStringValue:NSLocalizedString(@"privacy-alert-text", nil)];
+  }
   
   NSImage *keymanLogo = [NSImage imageNamed:NSImageNameApplicationIcon];
   if (keymanLogo) {

--- a/mac/Keyman4MacIM/Keyman4MacIM/en.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/en.lproj/Localizable.strings
@@ -68,8 +68,11 @@
 /* copyright label in the Package Information window */
 "copyright-label" = "Copyright:";
 
-/* message displayed to alert user to need grant accessibility permission */
+/* message displayed to alert user to need grant accessibility permission in Preferences, pre-Ventura */
 "privacy-alert-text" = "To function properly, Keyman requires accessibility features:\n\nGrant access in System Preferences, Security & Privacy.\nRestart your system.";
+
+/* message displayed to alert user to need grant accessibility permission in Settings, for macOS Ventura and later */
+"privacy-alert-text-ventura" = "To function properly, Keyman requires accessibility features:\n\nGrant access in System Settings, Privacy & Security.\nRestart your system.";
 
 /* Text of menu item in Input Menu when no Keyboards are configured -- include parentheses  */
 "no-keyboard-configured-menu-placeholder" = "(No Keyboard Configured)";


### PR DESCRIPTION
With macOS 13.0 (Ventura) there were several UI changes in macOS to make the System Settings look more like iOS. A couple of things that were renamed are referenced in a Keyman alert.

The impacting changes are:
- 'System Preferences' was renamed to 'System Settings' 
- 'Security & Privacy' was renamed to 'Privacy & Security'

Change the alert text so that it correctly references the UI elements when running macOS Ventura or later.

**Old Alert** (pre macOS 13.0):
![image](https://github.com/user-attachments/assets/dd5b4b5f-72d9-48e7-821d-89d3a3171402)

**New Alert** (macOS 13.0 and later):
![image](https://github.com/user-attachments/assets/64dd6436-67bf-43ec-9353-97910ee4d29c)

@keymanapp-test-bot skip