### PR TITLE
docs(common): Update Sentry links to keyman.sentry.io

### DIFF
--- a/android/docs/engine/KMManager/getMaySendCrashReport.md
+++ b/android/docs/engine/KMManager/getMaySendCrashReport.md
@@ -3,7 +3,7 @@ title: KMManager.getMaySendCrashReport()
 ---
 
 ## Summary
-The **getMaySendCrashReport()** method returns whether Keyman Engine is allowed to send crash reports over the network to sentry.keyman.com.
+The **getMaySendCrashReport()** method returns whether Keyman Engine is allowed to send crash reports over the network to Sentry.
 
 ## Syntax
 ```java
@@ -11,7 +11,7 @@ KMManager.getMaySendCrashReport()
 ```
 
 ### Returns
-Returns `true` if crash reports can be sent over the network to sentry.keyman.com, `false` otherwise.
+Returns `true` if crash reports can be sent over the network to Sentry, `false` otherwise.
 
 ## Description
 Use this method to check if Keyman Engine will be accessing the network to send crash reports.

--- a/android/docs/engine/KMManager/index.md
+++ b/android/docs/engine/KMManager/index.md
@@ -147,7 +147,7 @@ The KMManager is the core class which provides most of the methods and constants
 : returns from stored preference the number of milliseconds to trigger a longpress gesture
 
 [`getMaySendCrashReport()`](getMaySendCrashReport)
-: returns whether Keyman Engine is allowed to send crash reports over the network to sentry.keyman.com
+: returns whether Keyman Engine is allowed to send crash reports over the network to Sentry
 
 [`getOrientation()`](getOrientation)
 : returns the device's current orientation (Portrait vs Landscape)
@@ -255,7 +255,7 @@ The KMManager is the core class which provides most of the methods and constants
 : stores the longpress delay in milliseconds as a preference.
 
 [`setMaySendCrashReport()`](setMaySendCrashReport)
-: sets whether Keyman Engine can send crash reports over the network to sentry.keyman.com
+: sets whether Keyman Engine can send crash reports over the network to Sentry
 
 [`setShouldAllowSetKeyboard()`](setShouldAllowSetKeyboard)
 : sets whether Keyman Engine allows setting a keyboard other than the default keyboard

--- a/android/docs/engine/KMManager/setMaySendCrashReport.md
+++ b/android/docs/engine/KMManager/setMaySendCrashReport.md
@@ -4,7 +4,7 @@ title: KMManager.setMaySendCrashReport()
 
 ## Summary
 The **setMaySendCrashReport()** enables or disables whether Keyman Engine can send crash reports over the 
-network to sentry.keyman.com.
+network to Sentry.
 
 ## Syntax
 ```java

--- a/android/docs/help/about/privacy.md
+++ b/android/docs/help/about/privacy.md
@@ -4,7 +4,7 @@ title: Data Privacy Policy
 
 ## Privacy Policy for Keyman
 
-This application will send crash reporting information to https://sentry.keyman.com. No personally identifiable information or keyboard strokes are recorded or shared.
+This application will send crash reporting information to https://keyman.sentry.io. No personally identifiable information or keyboard strokes are recorded or shared.
 
 You can disable crash reporting on the Keyman 
 [settings menu](../basic/config/)

--- a/android/docs/help/basic/config/index.md
+++ b/android/docs/help/basic/config/index.md
@@ -59,4 +59,4 @@ When enabled, the Keyman keyboard will provide haptic feedback (vibrate) when th
 When enabled, the Keyman app will display the 'Get Started' screen on app startup.
 
 ## Allow sending crash reports over network
-When enabled, the Keyman app will send crash reporting information to https://sentry.keyman.com. No personally identifiable information or keyboard strokes are recorded.
+When enabled, the Keyman app will send crash reporting information to [Sentry](https://keyman.sentry.io). No personally identifiable information or keyboard strokes are recorded.

--- a/docs/build/sentry-cli.md
+++ b/docs/build/sentry-cli.md
@@ -2,7 +2,7 @@
 
 Contact the Keyman team if you need access to sentry.keyman.com for development.
 You will also need to install [sentry-cli](https://docs.sentry.io/cli/installation/) for uploading Debug symbols.
-After setting up your personal [Auth token](http://sentry.keyman.com/settings/account/api/auth-tokens/), add the following to **~/.bashrc**
+After setting up your personal [Auth token](http://keyman.sentry.io/settings/account/api/auth-tokens/), add the following to **~/.bashrc**
 
 ```bash
 export SENTRY_AUTH_TOKEN={your Sentry auth token}

--- a/ios/docs/help/basic/config/index.md
+++ b/ios/docs/help/basic/config/index.md
@@ -30,7 +30,7 @@ Click on this to [search for a keyboard or language](../../start/searching-for-k
 When enabled, the Keyman app will display the 'Get Started' screen on app startup.
 
 ## Allow error reporting
-When enabled, the Keyman app will send crash reporting information to https://sentry.keyman.com. No personally identifiable information or keyboard strokes are recorded.
+When enabled, the Keyman app will send crash reporting information to Sentry. No personally identifiable information or keyboard strokes are recorded.
 
 ## Spacebar Caption
 Click on this to [change the displayed keyboard name](spacebar-caption) on the spacebar.

--- a/mac/test/EnglishSpanish/README.md
+++ b/mac/test/EnglishSpanish/README.md
@@ -9,4 +9,4 @@ This keyboard is used only to test the crash reporting.
 5. Type **Sentry force now**
    - With each keystroke, Console messages should indicate that the character is being added to the Easter egg string.
    - When the final **w** is typed, a Console message should indicate: **Forcing crash now!**
-   - After some delay (you may need to switch Keyman off and on again in order for the report to upload), the new crash should appear in the console on sentry.keyman.com.
+   - After some delay (you may need to switch Keyman off and on again in order for the report to upload), the new crash should appear in the console on Sentry.


### PR DESCRIPTION
The previous redirect from sentry.keyman.com is long-gone, so this updates all the links.

Keeping an actual link to the Sentry site for Android privacy pages and developer setup.

@keymanapp-test-bot skip
