### PR TITLE
fix(android): Investigate `applyKeyboardHeight()`

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
@@ -106,12 +106,6 @@ public class AdjustKeyboardHeightActivity extends BaseActivity {
             refreshSampleKeyboard(context);
             break;
           case MotionEvent.ACTION_UP:
-            // Save the currentHeight when the user releases
-            int orientation = KMManager.getOrientation(context);
-            String keyboardHeightKey = (orientation == Configuration.ORIENTATION_LANDSCAPE) ?
-              KMManager.KMKey_KeyboardHeightLandscape : KMManager.KMKey_KeyboardHeightPortrait;
-            editor.putInt(keyboardHeightKey, currentHeight);
-            editor.commit();
             break;
         }
         return true;

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2232,15 +2232,15 @@ public final class KMManager {
   }
 
   public static void applyKeyboardHeight(Context context, int height) {
-    if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_INAPP)) {
-      InAppKeyboard.loadJavascript(KMString.format("setOskHeight('%s')", height));
-      RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
-      InAppKeyboard.setLayoutParams(params);
-    }
-    if (isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM)) {
-      SystemKeyboard.loadJavascript(KMString.format("setOskHeight('%s')", height));
-      RelativeLayout.LayoutParams params = getKeyboardLayoutParams();
-      SystemKeyboard.setLayoutParams(params);
+    SharedPreferences prefs = context.getSharedPreferences("KMAPreferences", Context.MODE_PRIVATE);
+    SharedPreferences.Editor editor = prefs.edit();
+    int orientation = getOrientation(context);
+    if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+      editor.putInt(KMManager.KMKey_KeyboardHeightLandscape, height);
+      editor.commit();
+    } else if (orientation == Configuration.ORIENTATION_PORTRAIT) {
+      editor.putInt(KMManager.KMKey_KeyboardHeightPortrait, height);
+      editor.commit();
     }
   }
 


### PR DESCRIPTION
This draft PR is for investigating #13511 by applying the code suggestions from @MattGyverLee 

afaict, AdjustKeyboardHeightActivity doesn't seem to work with these changes.

I feel the existing code does two necessary things:
1. Pass the current OSK height to the Javascript side. Keyman Engine for Web is handling the OSK
2. Update the Layout params. This refreshes the dimensions between the "app" and the keyboard. If we don't do this update and the user shrinks the keyboard, there will be a black band between the app and the keyboard.

## User Testing
**Setup** - Install the PR build of Keyman for Android on a device/emulator

**TEST_ADJUST_KEYBOARDHEIGHT** - Tests adjusting keyboard height
1. Dismiss the "Get Started" menu
3. Observe the current keyboard height for the current orientation
4. Go to Keyman settings --> Adjust Keyboard Height --> Drag the OSK to a different height
5. Back out of the menu and return to the Keyman app
6. Verify keyboard OSK matches the adjusted height <----- this seems to fail for me
7. Exit the app and restart Keyman
8. Dismiss the "Get Started" menu
9. Verify the keyboard OSK matches the selected height from the menu <--- this seems to work after restoring the height