### PR TITLE
fix(android,windows): Update Russian language strings to use Cyrillic script

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/DisplayLanguages.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/DisplayLanguages.java
@@ -66,7 +66,7 @@ public class DisplayLanguages {
       new DisplayLanguageType("el", "Polytonic Greek"),
       new DisplayLanguageType("pt-PT", "Português de Portugal"),
       new DisplayLanguageType("ff-ZA", "Pulaar-Fulfulde"), // or Fulah
-      new DisplayLanguageType("ru-RU", "Pyccĸий (Russian)"),
+      new DisplayLanguageType("ru-RU", "Русский (Russian)"),
       new DisplayLanguageType("shu-latn", "Shuwa (Latin)"),
       new DisplayLanguageType("sv-SE", "svenska (Swedish)"),
       new DisplayLanguageType("vi-VN", "Tiếng Việt (Vietnamese)"),

--- a/windows/src/desktop/kmshell/locale/ru-RU/strings.xml
+++ b/windows/src/desktop/kmshell/locale/ru-RU/strings.xml
@@ -638,11 +638,11 @@
   <!-- Context: _LanguageInfo -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="SKUILanguageName" comment="User interface language name in the UI language">Pyccĸий</string>
+  <string name="SKUILanguageName" comment="User interface language name in the UI language">Русский</string>
   <!-- Context: _LanguageInfo -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->
-  <string name="SKUILanguageNameWithEnglish" comment="UI language name in the UI language with the English name in parentheses  (this message is used when the user gets stuck in a strange UI language)">Pyccĸий (Russian)</string>
+  <string name="SKUILanguageNameWithEnglish" comment="UI language name in the UI language with the English name in parentheses  (this message is used when the user gets stuck in a strange UI language)">Русский (Russian)</string>
   <!-- Context: _LanguageInfo -->
   <!-- String Type: FormatString -->
   <!-- Introduced: 7.0.230.0 -->

--- a/windows/src/desktop/setup/locale/ru-RU/strings.xml
+++ b/windows/src/desktop/setup/locale/ru-RU/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="ssLanguageName" comment="User interface language name in the UI language">Pyccĸий</string>
+  <string name="ssLanguageName" comment="User interface language name in the UI language">Русский</string>
   <string name="ssApplicationTitle">Настройки $APPNAME $VERSION</string>
   <string name="ssTitle">Установить $APPNAME $VERSION</string>
   <string name="ssInstallSuccess">$APPNAME $VERSION успешно установлен.</string>


### PR DESCRIPTION
Relates to #13519

The original Crowdin strings for Russian language incorrectly used Latin instead of Cyrillic characters.

This updates the strings from incorrect `Pyccĸий` to correct `Русский`.

For #13519, there will be a follow-on PR for sorting the language name UI in English (e.g. "Chinese", "Russian"), and involve a new TBD crowdin string.

@keymanapp-test-bot skip