### PR TITLE
fix(web): model unload and load should use consistent, canEnable check

### DIFF
--- a/web/src/engine/main/src/headless/languageProcessor.ts
+++ b/web/src/engine/main/src/headless/languageProcessor.ts
@@ -68,7 +68,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
   }
 
   public unloadModel() {
-    if(!this.isActive) {
+    if(!this.canEnable) {
       return;
     }
 


### PR DESCRIPTION
Fixes: #13512
Fixes: KEYMAN-WEB-QD

Refer to #13290, which added the old version of this check and a match for the new version of check in the same class's `loadModel`.  These should have been consistent and the same, but were not... and as the goal was to support workerless modes of the Web engine, `canEnable` makes much better sense to use here.

## User Testing

TEST_REPRO_13512:  Attempt to reproduce #13512 on an Android device.
1. Important:  make sure the test device has a lock screen with password before starting the repro, as it depends on such a setup.
1. Installed the test artifact for this PR.
2. Launch Keyman for Android
3. From "Get Started" menu, enable Keyman as the default system keyboard
4. Enter a text content.
5. Install a khmer_angkor keyboard by clicking three dots --> Settings --> Install Keyboard or Dictionary.
6. Return to keyman's note app.
7. Change the keyboard from Khmer to euro_latin by the globe key.
8. Lock the screen by pressing the power key.
9. Open the unlock screen by pressing the power key.
10. Ignore any issues with the banner here; those are a separate issue (#13531)
11. Enter the password to unlock the mobile.
12. Ignore any issues with the banner here; those are a separate issue (#13531)
13. Press the globe key.

No error should result.