### PR TITLE
chore(linux): allow to build and use Debian docker image 🍒⛵

### DIFF
--- a/resources/docker-images/base/Dockerfile
+++ b/resources/docker-images/base/Dockerfile
@@ -1,7 +1,8 @@
 # Keyman is copyright (C) SIL Global. MIT License.
 
-ARG UBUNTU_VERSION=latest
-FROM ubuntu:${UBUNTU_VERSION}
+ARG DISTRO=ubuntu
+ARG DISTRO_VERSION=latest
+FROM ${DISTRO}:${DISTRO_VERSION}
 
 LABEL org.opencontainers.image.authors="SIL Global."
 LABEL org.opencontainers.image.url="https://github.com/keymanapp/keyman.git"
@@ -21,8 +22,10 @@ ENV DEBCONF_NOWARNINGS=yes
 # Update to the latest
 RUN apt-get -q -y update &&  \
   apt-get -q -y install ca-certificates curl gnupg meson software-properties-common sudo && \
-  add-apt-repository ppa:keymanapp/keyman && \
-  add-apt-repository ppa:keymanapp/keyman-alpha
+  if [[ "$(lsb_release -is)" == "Ubuntu" ]]; then \
+    add-apt-repository ppa:keymanapp/keyman && \
+    add-apt-repository ppa:keymanapp/keyman-alpha ; \
+  fi
 RUN apt-get -q -y update &&  \
   apt-get -q -y upgrade
 

--- a/resources/docker-images/build.sh
+++ b/resources/docker-images/build.sh
@@ -33,11 +33,7 @@ _add_build_args() {
   local name=$3
   local value
 
-  if [[ -n "${!var:-}" ]]; then
-    value="${!var}"
-  else
-    value="${!default_var:-}"
-  fi
+  value="${!var:=${!default_var:-}}"
 
   build_args+=(--build-arg="${var}=${value}")
 
@@ -77,10 +73,8 @@ build_action() {
 
   builder_echo debug "Building image for ${platform}"
 
-  _convert_parameters_to_build_args
-
   if [[ "${platform}" == "base" ]]; then
-    docker pull --platform "amd64" "${DISTRO:-ubuntu}:${DISTRO_VERSION:-${KEYMAN_DEFAULT_VERSION_UBUNTU_CONTAINER}}"
+    docker pull --platform "amd64" "${DISTRO}:${DISTRO_VERSION}"
   elif [[ "${platform}" == "linux" ]]; then
     cp "${KEYMAN_ROOT}/linux/debian/control" "${platform}"
   fi
@@ -111,6 +105,8 @@ test_action() {
   ./run.sh --distro "${DISTRO}" --distro-version "${DISTRO_VERSION}" \
     "${platform}" -- ./build.sh configure,build,test:"${platform}"
 }
+
+_convert_parameters_to_build_args
 
 if builder_has_action build; then
   build_action base

--- a/resources/docker-images/build.sh
+++ b/resources/docker-images/build.sh
@@ -64,8 +64,16 @@ _convert_parameters_to_build_args() {
   fi
 }
 
+_check_for_default_values() {
+  if [[ -z "${DISTRO_VERSION:-}" ]] && [[ -z "${JAVA_VERSION:-}" ]]; then
+    is_default_values=true
+  else
+    is_default_values=false
+  fi
+}
+
 _is_default_values() {
-  [[ -z "${DISTRO_VERSION:-}" ]] && [[ -z "${JAVA_VERSION:-}" ]]
+  ${is_default_values}
 }
 
 build_action() {
@@ -74,6 +82,7 @@ build_action() {
   builder_echo debug "Building image for ${platform}"
 
   if [[ "${platform}" == "base" ]]; then
+    # shellcheck disable=SC2154 # set by _convert_parameters_to_build_args
     docker pull --platform "amd64" "${DISTRO}:${DISTRO_VERSION}"
   elif [[ "${platform}" == "linux" ]]; then
     cp "${KEYMAN_ROOT}/linux/debian/control" "${platform}"
@@ -106,6 +115,7 @@ test_action() {
     "${platform}" -- ./build.sh configure,build,test:"${platform}"
 }
 
+_check_for_default_values
 _convert_parameters_to_build_args
 
 if builder_has_action build; then

--- a/resources/docker-images/run.sh
+++ b/resources/docker-images/run.sh
@@ -16,44 +16,53 @@ builder_describe \
   "core" \
   "linux" \
   "web" \
-  "--ubuntu-version=UBUNTU_VERSION  The Ubuntu version (default: ${KEYMAN_DEFAULT_VERSION_UBUNTU_CONTAINER})"
+  "--distro=DISTRO                  The distribution (debian or ubuntu, default: ubuntu)" \
+  "--distro-version=DISTRO_VERSION  The Ubuntu/Debian version (default: ${KEYMAN_DEFAULT_VERSION_UBUNTU_CONTAINER})"
 
 builder_parse "$@"
 
 run_android() {
   docker run -it --rm -v "${KEYMAN_ROOT}":/home/build/build \
-    -v "${KEYMAN_ROOT}/core/build/docker-core":/home/build/build/core/build \
-    keymanapp/keyman-android-ci:default \
+    -v "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}":/home/build/build/core/build \
+    "keymanapp/keyman-android-ci:${image_version}" \
     "${builder_extra_params[@]}"
 }
 
 run_core() {
   docker run -it --rm -v "${KEYMAN_ROOT}":/home/build/build \
-    -v "${KEYMAN_ROOT}/core/build/docker-core":/home/build/build/core/build \
-    keymanapp/keyman-core-ci:default \
+    -v "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}":/home/build/build/core/build \
+    "keymanapp/keyman-core-ci:${image_version}" \
     "${builder_extra_params[@]}"
 }
 
 run_linux() {
-  mkdir -p "${KEYMAN_ROOT}/linux/build/docker-linux"
-  mkdir -p "${KEYMAN_ROOT}/linux/keyman-system-service/build/docker-linux"
+  mkdir -p "${KEYMAN_ROOT}/linux/build/docker-linux/${build_dir}"
+  mkdir -p "${KEYMAN_ROOT}/linux/keyman-system-service/build/docker-linux/${build_dir}"
   docker run -it --privileged --rm -v "${KEYMAN_ROOT}":/home/build/build \
-    -v "${KEYMAN_ROOT}/core/build/docker-core":/home/build/build/core/build \
-    -v "${KEYMAN_ROOT}/linux/build/docker-linux":/home/build/build/linux/build \
-    -v "${KEYMAN_ROOT}/linux/keyman-system-service/build/docker-linux":/home/build/build/linux/keyman-system-service/build \
+    -v "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}":/home/build/build/core/build \
+    -v "${KEYMAN_ROOT}/linux/build/docker-linux/${build_dir}":/home/build/build/linux/build \
+    -v "${KEYMAN_ROOT}/linux/keyman-system-service/build/docker-linux/${build_dir}":/home/build/build/linux/keyman-system-service/build \
     -e DESTDIR=/tmp \
-    keymanapp/keyman-linux-ci:default \
+    "keymanapp/keyman-linux-ci:${image_version}" \
     "${builder_extra_params[@]}"
 }
 
 run_web() {
   docker run -it --privileged --rm -v "${KEYMAN_ROOT}":/home/build/build \
-    -v "${KEYMAN_ROOT}/core/build/docker-core":/home/build/build/core/build \
-    keymanapp/keyman-web-ci:default \
+    -v "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}":/home/build/build/core/build \
+    "keymanapp/keyman-web-ci:${image_version}" \
     "${builder_extra_params[@]}"
 }
 
-mkdir -p "${KEYMAN_ROOT}/core/build/docker-core"
+if [[ -z "${DISTRO_VERSION:-}" ]]; then
+  image_version=default
+  build_dir=default
+else
+  image_version="${DISTRO:-}-${DISTRO_VERSION}-java${KEYMAN_VERSION_JAVA}-node$(_print_expected_node_version)-emsdk${KEYMAN_MIN_VERSION_EMSCRIPTEN}"
+  build_dir="${DISTRO:-}-${DISTRO_VERSION}"
+fi
+
+mkdir -p "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}"
 
 builder_run_action android  run_android
 builder_run_action core     run_core


### PR DESCRIPTION
This PR allows to build and use Debian as base for a docker image. Also initialize variables with default values if the
corresponding parameter is not passed on the command line.

Cherry-pick from master branch to fit in some additional docker related changes.

Cherry-pick-of: #13284

  @keymanapp-test-bot skip