### PR TITLE
fix(android): Handle banner overrides independently when device is locked and unlocked

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -159,8 +159,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     Context appContext = getApplicationContext();
     // Temporarily disable predictions on certain fields (e.g. hidden password field or numeric)
     inputType = attribute.inputType;
-    KMManager.setMayPredictOverride(inputType, KeyboardType.KEYBOARD_TYPE_SYSTEM);
-    if (KMManager.getMayPredictOverride(KeyboardType.KEYBOARD_TYPE_SYSTEM)) {
+    KMManager.setPredictionsSuspended(inputType, KeyboardType.KEYBOARD_TYPE_SYSTEM);
+    if (KMManager.getPredictionsSuspended(KeyboardType.KEYBOARD_TYPE_SYSTEM)) {
       KMManager.setBannerOptions(false);
       // Set the system keyboard HTML banner
       BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -159,8 +159,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     Context appContext = getApplicationContext();
     // Temporarily disable predictions on certain fields (e.g. hidden password field or numeric)
     inputType = attribute.inputType;
-    KMManager.setMayPredictOverride(inputType);
-    if (KMManager.getMayPredictOverride()) {
+    KMManager.setMayPredictOverride(inputType, KeyboardType.KEYBOARD_TYPE_SYSTEM);
+    if (KMManager.getMayPredictOverride(KeyboardType.KEYBOARD_TYPE_SYSTEM)) {
       KMManager.setBannerOptions(false);
       // Set the system keyboard HTML banner
       BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -162,6 +162,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     KMManager.setMayPredictOverride(inputType);
     if (KMManager.getMayPredictOverride()) {
       KMManager.setBannerOptions(false);
+      // Set the system keyboard HTML banner
+      BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
     } else if (KMManager.isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM)){
       // Check if predictions needs to be re-enabled per Settings preference
       Keyboard kbInfo = KMManager.getCurrentKeyboardInfo(appContext);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -247,7 +247,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
 
     if (textView != null) {
       // Reset mayPredictOverride
-      KMManager.setMayPredictOverride(textView.getInputType(), KeyboardType.KEYBOARD_TYPE_INAPP);
+      KMManager.setPredictionsSuspended(textView.getInputType(), KeyboardType.KEYBOARD_TYPE_INAPP);
     }
 
     KMManager.onResume();

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -244,29 +244,14 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   @Override
   protected void onResume() {
     super.onResume();
-    KMManager.onResume();
-    KMManager.hideSystemKeyboard();
 
     if (textView != null) {
       // Reset mayPredictOverride
-      KMManager.setMayPredictOverride(textView.getInputType());
+      KMManager.setMayPredictOverride(textView.getInputType(), KeyboardType.KEYBOARD_TYPE_INAPP);
     }
 
-    if (KMManager.getKMKeyboard(KeyboardType.KEYBOARD_TYPE_INAPP) != null) {
-      // Reset banner
-      Keyboard kbInfo = KMManager.getCurrentKeyboardInfo(context);
-      if (kbInfo != null) {
-        String langId = kbInfo.getLanguageID();
-        HashMap<String, String> currentLexicalModel = KMManager.getAssociatedLexicalModel(langId);
-        if (currentLexicalModel != null) {
-          SharedPreferences prefs = context.getSharedPreferences(context.getString(com.keyman.engine.R.string.kma_prefs_name), Context.MODE_PRIVATE);
-          boolean modelPredictionPref = prefs.getInt(KMManager.getLanguageAutoCorrectionPreferenceKey(
-            currentLexicalModel.get(KMManager.KMKey_LanguageID)), KMManager.KMDefault_Suggestion)
-            != KMManager.SuggestionType.SUGGESTIONS_DISABLED.toInt();
-          KMManager.setBannerOptions(modelPredictionPref);
-        }
-      }
-    }
+    KMManager.onResume();
+    KMManager.hideSystemKeyboard();
 
     // Reset keyboard picker Activity Task flag
     KMManager.closeParentAppOnShowKeyboardPicker();

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -247,6 +247,27 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     KMManager.onResume();
     KMManager.hideSystemKeyboard();
 
+    if (textView != null) {
+      // Reset mayPredictOverride
+      KMManager.setMayPredictOverride(textView.getInputType());
+    }
+
+    if (KMManager.getKMKeyboard(KeyboardType.KEYBOARD_TYPE_INAPP) != null) {
+      // Reset banner
+      Keyboard kbInfo = KMManager.getCurrentKeyboardInfo(context);
+      if (kbInfo != null) {
+        String langId = kbInfo.getLanguageID();
+        HashMap<String, String> currentLexicalModel = KMManager.getAssociatedLexicalModel(langId);
+        if (currentLexicalModel != null) {
+          SharedPreferences prefs = context.getSharedPreferences(context.getString(com.keyman.engine.R.string.kma_prefs_name), Context.MODE_PRIVATE);
+          boolean modelPredictionPref = prefs.getInt(KMManager.getLanguageAutoCorrectionPreferenceKey(
+            currentLexicalModel.get(KMManager.KMKey_LanguageID)), KMManager.KMDefault_Suggestion)
+            != KMManager.SuggestionType.SUGGESTIONS_DISABLED.toInt();
+          KMManager.setBannerOptions(modelPredictionPref);
+        }
+      }
+    }
+
     // Reset keyboard picker Activity Task flag
     KMManager.closeParentAppOnShowKeyboardPicker();
 

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -246,7 +246,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     super.onResume();
 
     if (textView != null) {
-      // Reset mayPredictOverride
+      // Reset inAppPredictionsSuspendedForSensitiveInput flag
       KMManager.setPredictionsSuspended(textView.getInputType(), KeyboardType.KEYBOARD_TYPE_INAPP);
     }
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
@@ -165,7 +165,7 @@ public final class KMKeyboardWebViewClient extends WebViewClient {
       // appContext instead of context?
       SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
       boolean modelPredictionPref = false;
-      if (!KMManager.getMayPredictOverride(keyboardType) && KMManager.currentLexicalModel != null) {
+      if (!KMManager.getPredictionsSuspended(keyboardType) && KMManager.currentLexicalModel != null) {
         modelPredictionPref = prefs.getInt(KMManager.getLanguageAutoCorrectionPreferenceKey(
           KMManager.currentLexicalModel.get(KMManager.KMKey_LanguageID)), KMManager.KMDefault_Suggestion)
           != SuggestionType.SUGGESTIONS_DISABLED.toInt();

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMKeyboardWebViewClient.java
@@ -165,12 +165,12 @@ public final class KMKeyboardWebViewClient extends WebViewClient {
       // appContext instead of context?
       SharedPreferences prefs = context.getSharedPreferences(context.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
       boolean modelPredictionPref = false;
-      if (!KMManager.getMayPredictOverride() && KMManager.currentLexicalModel != null) {
+      if (!KMManager.getMayPredictOverride(keyboardType) && KMManager.currentLexicalModel != null) {
         modelPredictionPref = prefs.getInt(KMManager.getLanguageAutoCorrectionPreferenceKey(
           KMManager.currentLexicalModel.get(KMManager.KMKey_LanguageID)), KMManager.KMDefault_Suggestion)
           != SuggestionType.SUGGESTIONS_DISABLED.toInt();
       }
-      KMManager.setBannerOptions(modelPredictionPref);
+      KMManager.setBannerOptions(modelPredictionPref, keyboardType);
       RelativeLayout.LayoutParams params = KMManager.getKeyboardLayoutParams();
       kmKeyboard.setLayoutParams(params);
     } else if (url.indexOf("suggestPopup") >= 0) {

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -257,7 +257,7 @@ public final class KMManager {
   // haptic feedback disabled for hardware keystrokes
   private static boolean mayHaveHapticFeedback = false;
 
-  // Special overrides to temporarily disable predictions when editing a password field.
+  // Special flags to temporarily disable predictions when editing a password field.
   // These are maintained independently for inapp keyboard and system keyboard.
   // When true, the suggestion banner passes the option {'mayPredict' = false} to KeymanWeb in the lm-layer
   // regardless what the Settings preference is.

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1642,12 +1642,10 @@ public final class KMManager {
     String url = KMString.format("setBannerOptions(%s)", mayPredict);
     if (InAppKeyboard != null) {
       InAppKeyboard.loadJavascript(url);
-      Log.d(TAG, "InApp.setBannerOptions(mayPredict: " + mayPredict + ")");
     }
 
     if (SystemKeyboard != null) {
       SystemKeyboard.loadJavascript(url);
-      Log.d(TAG, "System.setBannerOptions(mayPredict: " + mayPredict + ")");
     }
 
     return true;

--- a/android/docs/engine/KMManager/getPredictionsSuspended.md
+++ b/android/docs/engine/KMManager/getPredictionsSuspended.md
@@ -1,0 +1,29 @@
+---
+title: KMManager.getPredictionsSuspended()
+---
+
+## Summary
+The **getPredictionsSuspended()** method returns whether whether predictions are temporarily disabled because the currently selected text field is a hidden password text field or a numeric text field.
+
+## Syntax
+```java
+KMManager.getPredictionsSuspended(KeyboardType keyboardType)
+```
+
+### Parameters
+
+`keyboardType`
+:   The keyboard type. `KEYBOARD_TYPE_INAPP` or
+    `KEYBOARD_TYPE_SYSTEM`.
+
+### Returns
+Returns `true` if predictions are temporarily disabled because the currently selected text field is a hidden password text field or a numeric text field. `false` otherwise.
+
+## Description
+Use this method to check if predictions are temporarily disabled because of the type of currently selected text field. This value takes precedence over the user preference in the LanguageSettings menu.
+
+## History
+Added syntax in Keyman Engine for Android 18.0.
+
+## See also
+* [setPredictionsSuspended](setPredictionsSuspended)

--- a/android/docs/engine/KMManager/getPredictionsSuspended.md
+++ b/android/docs/engine/KMManager/getPredictionsSuspended.md
@@ -3,7 +3,7 @@ title: KMManager.getPredictionsSuspended()
 ---
 
 ## Summary
-The **getPredictionsSuspended()** method returns whether whether predictions are temporarily disabled because the currently selected text field is a hidden password text field or a numeric text field.
+The **getPredictionsSuspended()** method returns a flag that determines whether predictions are temporarily disabled because the currently selected text field is a hidden password text field or a numeric text field.
 
 ## Syntax
 ```java

--- a/android/docs/engine/KMManager/index.md
+++ b/android/docs/engine/KMManager/index.md
@@ -152,6 +152,9 @@ The KMManager is the core class which provides most of the methods and constants
 [`getOrientation()`](getOrientation)
 : returns the device's current orientation (Portrait vs Landscape)
 
+[`getPredictionsSuspended()`](getPredictionsSuspended)
+: returns whether predictions are temporarily disabled because the currently selected text field is a hidden password text field or a numeric text field. 
+
 [`getSpacebarText()`](getSpacebarText)
 : returns the current text display pattern for the spacebar
 
@@ -256,6 +259,9 @@ The KMManager is the core class which provides most of the methods and constants
 
 [`setMaySendCrashReport()`](setMaySendCrashReport)
 : sets whether Keyman Engine can send crash reports over the network to Sentry
+
+[`setPredictionsSuspended()`](setPredictionsSuspended)
+: sets whether predictions are temporarily disabled because the currently selected text field is a hidden password text field or a numeric text field. 
 
 [`setShouldAllowSetKeyboard()`](setShouldAllowSetKeyboard)
 : sets whether Keyman Engine allows setting a keyboard other than the default keyboard

--- a/android/docs/engine/KMManager/setPredictionsSuspended.md
+++ b/android/docs/engine/KMManager/setPredictionsSuspended.md
@@ -3,7 +3,7 @@ title: KMManager.setPredictionsSuspended()
 ---
 
 ## Summary
-The **setPredictionsSuspended()** method sets an override to temporarily disable predictions when the currently selected text field is a hidden password text field or a numeric text field.
+The **setPredictionsSuspended()** method sets a flag to temporarily disable predictions when the currently selected text field is a hidden password text field or a numeric text field.
 
 ## Syntax
 ```java

--- a/android/docs/engine/KMManager/setPredictionsSuspended.md
+++ b/android/docs/engine/KMManager/setPredictionsSuspended.md
@@ -1,0 +1,36 @@
+---
+title: KMManager.setPredictionsSuspended()
+---
+
+## Summary
+The **setPredictionsSuspended()** method sets an override to temporarily disable predictions when the currently selected text field is a hidden password text field or a numeric text field.
+
+## Syntax
+```java
+KMManager.setPredictionsSuspended(int inputType, KeyboardType keyboardType)
+```
+
+### Parameters
+
+[`inputType`](https://developer.android.com/reference/android/text/InputType)
+:   An integer defining the basic context type of text being edited. If the text is one of the following InputTypes, this methods returns `true`:
+
+* TYPE_CLASS_TEXT
+* TYPE_TEXT_VARIATION_PASSWORD
+* TYPE_CLASS_TEXT
+* TYPE_TEXT_VARIATION_WEB_PASSWORD
+* TYPE_CLASS_NUMBER
+* TYPE_CLASS_PHONE
+
+`keyboardType`
+:   The keyboard type. `KEYBOARD_TYPE_INAPP` or
+    `KEYBOARD_TYPE_SYSTEM`.
+
+## Description
+Use this method to temporarily disable predictions because of the currently selected text field. This value takes precedence over the user preference in the LanguageSettings menu.
+
+## History
+Added syntax in Keyman Engine for Android 18.0.
+
+## See also
+* [getPredictionsSuspended](getPredictionsSuspended)

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -135,8 +135,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
             KMManager.setNumericLayer(KeyboardType.KEYBOARD_TYPE_SYSTEM);
         }
 
-        // Temporarily disable predictions if entering a hidden password field
-        KMManager.setMayPredictOverride(inputType);
+        // Temporarily disable predictions on certain fields (e.g. hidden password field or numeric)
+        KMManager.setPredictionsSuspended(inputType, KeyboardType.KEYBOARD_TYPE_SYSTEM);
         if (KMManager.getMayPredictOverride()) {
             KMManager.setBannerOptions(false);
         } else if (KMManager.isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM)){

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -137,7 +137,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
 
         // Temporarily disable predictions on certain fields (e.g. hidden password field or numeric)
         KMManager.setPredictionsSuspended(inputType, KeyboardType.KEYBOARD_TYPE_SYSTEM);
-        if (KMManager.getMayPredictOverride()) {
+        if (KMManager.getPredictionsSuspended(KeyboardType.KEYBOARD_TYPE_SYSTEM)) {
             KMManager.setBannerOptions(false);
         } else if (KMManager.isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM)){
           // Check if predictions needs to be re-enabled per Settings preference


### PR DESCRIPTION
Fixes #13531 (both bugs)
* A broken image appeared on the lock screen's keyboard.
* Also it seems clear that `KMManager.mayPredictOverride` is set to disable predictions... so it must not be getting unset when the lock screen's conditions are satisfied.

### Broken image bug
The first bug about the broken image link is fixed with 1 line to SystemKeyboard.java.
```java
BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
```

### Override bug
Currently, when the SYSTEM Keyman keyboard is on a password field, the `mayPredictOverride` override is set to true and concurrently disables suggestions for both INAPP Keyman keyboard and SYSTEM Keyman keyboard.

(edited after applying review comments)
This PR refactors undocumented API's so `mayPredictOverride` API calls are independently handled in INAPP and SYSTEM keyboards.
API renames:
| From (Keyman 12.0-17.0) | To (Keyman 18.0+) |
|---------|------|
| `inAppMayPredictOverride` | `inAppPredictionsSuspendedForSensitiveInput` |
| `systemMayPredictOverride`  |`systemPredictionsSuspendedForSensitiveInput` |
| | |
| `getMayPredictOverride()` | `getPredictionsSuspended()` |
| `setMayPredictOverride()` | `setPredictionsSuspended()` |


TODO - update KMManager API docs

## User Testing
**Setup** - Install the PR build of Keyman for Android. In the "Get Started" menu, set Keyman as the default system keyboard. Also install a Keyman Basic Lao keyboard [basic_kbdlao](https://keyman.com/keyboards/basic_kbdlao) that doesn't use a suggestion banner. On the Android device/emulator also do system settings and set a simple "1234" password for the lock screen. If using an actual device, have a secondary unlock method (fingerprint)

* **TEST_BANNER_TOGGLE** - Verifies HTML and suggestion banners toggle correctly
1. Start Keyman for Android
2. In the Keyman app, use the globe key to select sil_euro_latin keyboard.
3. Verify suggestions appear on the banner
4. Use the globe key to switch to the Basic Lao keyboard
5. Verify the image banner appears
6. Launch Chrome and browse to this test page. (It has basic text fields and a password text field)
 https://darcywong00.github.io/examples/form.html
7. With Keyman as the system keyboard, select the "Visible Text Field".
8. Use the globe key to select the sil_euro_latin keyboard
9. Verify suggestions appear on the banner
10. Use the globe key to switch to Basic Lao keyboard
11. Verify the image banner appears
12. Use the globe key to select sil_euro_latin keyboard
13. Verify suggestions appear on the banner
14. Select the "Password Field"
15. Verify the suggestions are disabled and the image banner appears
16. Return the Keyman app
17. With the sil_euro_latin keyboard verify suggestions appear in the app
18. Make sure the Keyman app is the active app
19. Lock the device
20. Unlock the device - use Keyman to enter the password. Verify suggestions are disabled
21. When the device is unlocked and the Keyman app is resumed, observe the sil_euro_latin keyboard and verify suggestions appear.

