### PR TITLE
fix(ios): uninstalls keyboards upon failure to load

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift
@@ -351,6 +351,8 @@ public class Manager: NSObject, UIGestureRecognizerDelegate {
       try inputViewController.setKeyboard(kb)
     } catch {
       // Here, errors are logged by the error's thrower.
+      // But we should remove the keyboard's entry in the registered-keyboards list.
+      _ = self.removeKeyboard(withFullID: kb.fullID)
       return false
     }
 


### PR DESCRIPTION
Fixes #13120.

Well, fixes the state left by the error, but doesn't prevent it - that part is covered by the predecessor, #13548.

Cross-reference with:

 https://github.com/keymanapp/keyman/blob/b77fcfc3da370886faafa79635671851604e92c3/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift#L286

There are three types of errors here that _could_ be thrown from this method:

https://github.com/keymanapp/keyman/blob/b77fcfc3da370886faafa79635671851604e92c3/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift#L317
https://github.com/keymanapp/keyman/blob/b77fcfc3da370886faafa79635671851604e92c3/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift#L342
https://github.com/keymanapp/keyman/blob/b77fcfc3da370886faafa79635671851604e92c3/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift#L353

Only one - the "file missing" error - appears in our Sentry logs at this time.

In regard to the added code line, that reaches this section:  

https://github.com/keymanapp/keyman/blob/b77fcfc3da370886faafa79635671851604e92c3/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift#L532

https://github.com/keymanapp/keyman/blob/b77fcfc3da370886faafa79635671851604e92c3/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift#L544-L548

As this is the same sort of code used to preserve installed keyboards from the app, thus might be affected when "full access" is off, I did some experimentation to ensure this won't have undesired side-effects when "full access" is off - when the keyboard has no permission to write to app-group space.  (I temporarily added a function called only from the system keyboard for this.)  The app continued to function fine when writing to `UserDefaults`.

That said, we may get events logged when the system keyboard attempts (and fails, with "full access" off) to delete files for any unloadable keyboard:

https://github.com/keymanapp/keyman/blob/b77fcfc3da370886faafa79635671851604e92c3/ios/engine/KMEI/KeymanEngine/Classes/Manager.swift#L569-L573

----

Note that there is no clear way at present to reproduce the state this is intended to address.  These changes are intended to clean up "loose ends" that cause the reported error to be logged; if the keyboard's backing file is missing, it's not going to be loadable _at all_, so why keep it listed?

I'm not going to claim this is "the best" solution, but it should prove reasonably serviceable and intuitive.  Feel free to suggest alternative solutions, improvements, etc if you like.

If the user installs a keyboard, but it fails to load immediately after installation, it'll also be automatically installed at that point.  The user should be seeing an error notification about the error, and that + removing the failed keyboard from the installed keyboard list should be enough to say "that keyboard has a problem and isn't usable" to users.

## User Testing

TEST_NORMAL_KEYBOARD_USE:  Use the Keyman app for iOS platforms and verify that keyboard swapping and installation work normally, with no side effects.  

No need to go super detailed - a bit of light use in these areas should be enough to serve as a "smoke test" here.