### PR TITLE
fix(mac): reevaluate API compliance for each change in context

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -348,8 +348,8 @@ CGEventSourceRef _sourceForGeneratedEvent = nil;
     NSRange selectionRange = [client selectedRange];
     os_log_debug([KMLogs eventsLog], "InputMethodEventHandler readContext, canReadText: true selectionRange %{public}@: ", NSStringFromRange(selectionRange));
     
-      NSUInteger contextLength = MIN(kMaxContext, selectionRange.location);
-      NSUInteger contextStart = selectionRange.location - contextLength;
+    NSUInteger contextLength = MIN(kMaxContext, selectionRange.location);
+    NSUInteger contextStart = selectionRange.location - contextLength;
     
     if (contextLength > 0) {
       NSRange contextRange = NSMakeRange(contextStart, contextLength);

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMInputMethodEventHandler.m
@@ -233,10 +233,14 @@ CGEventSourceRef _sourceForGeneratedEvent = nil;
   return stale;
 }
 
+/**
+ * Handle the flag set in the eventTap when we detect events that cause a change in context.
+ * This includes mouse movement, arrow keys, page up and page down, function keys, and others.
+ */
 - (void) handleContextChangedByLowLevelEvent {
   if (self.appDelegate.contextChangedByLowLevelEvent) {
     if (!self.contextChanged) {
-      os_log_debug([KMLogs complianceLog], "Low-level event has changed the context.");
+      os_log_debug([KMLogs complianceLog], "Handling context change due to low-level event.");
       self.contextChanged = YES;
     }
     self.appDelegate.contextChangedByLowLevelEvent = NO;
@@ -248,10 +252,9 @@ CGEventSourceRef _sourceForGeneratedEvent = nil;
   BOOL handled = NO;
   os_log_debug([KMLogs eventsLog], "handleEvent፡ event = %{public}@", event);
 
-  [self checkTextApiCompliance:sender];
-  
-  // mouse movement requires that the context be invalidated
   [self handleContextChangedByLowLevelEvent];
+
+  [self checkTextApiCompliance:sender];
   
   if (event.type == NSEventTypeKeyDown) {
     [KMSentryHelper addDebugBreadCrumb:@"event" message:@"handling keydown event"];
@@ -343,22 +346,27 @@ CGEventSourceRef _sourceForGeneratedEvent = nil;
   // if we can read the text, then get the context for up to kMaxContext characters
   if (self.apiCompliance.canReadText) {
     NSRange selectionRange = [client selectedRange];
-    NSUInteger contextLength = MIN(kMaxContext, selectionRange.location);
-    NSUInteger contextStart = selectionRange.location - contextLength;
+    os_log_debug([KMLogs eventsLog], "InputMethodEventHandler readContext, canReadText: true selectionRange %{public}@: ", NSStringFromRange(selectionRange));
+    
+      NSUInteger contextLength = MIN(kMaxContext, selectionRange.location);
+      NSUInteger contextStart = selectionRange.location - contextLength;
     
     if (contextLength > 0) {
-      os_log_debug([KMLogs eventsLog], "   *** InputMethodEventHandler readContext, %lu characters", (unsigned long)contextLength);
       NSRange contextRange = NSMakeRange(contextStart, contextLength);
+      os_log_debug([KMLogs eventsLog], " contextRange %{public}@: client: %p", NSStringFromRange(contextRange), client);
       attributedString = [client attributedSubstringFromRange:contextRange];
       
       // adjust string in case that we receive half of a surrogate pair at context start
       // the API appears to always return a full code point, but this could vary by app
       if (attributedString.length > 0) {
         if (CFStringIsSurrogateLowCharacter([attributedString.string characterAtIndex:0])) {
-          os_log_debug([KMLogs eventsLog], "   *** InputMethodEventHandler readContext, first char is low surrogate, reducing context by one character");
+          os_log_debug([KMLogs eventsLog], " first char is low surrogate, reducing context by one character");
           contextString = [attributedString.string substringFromIndex:1];
         } else {
           contextString = attributedString.string;
+          
+          //only uncomment for testing as we do not want to write context in logs
+          //os_log_debug([KMLogs testLog], " length: %lu result: %{public}@", contextString.length, contextString);
         }
       }
     }

--- a/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
@@ -46,6 +46,8 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
 @property (readonly, weak) id client;
 @property BOOL complianceUncertain;
 @property BOOL hasCompliantSelectionApi;
+@property BOOL hasCompliantAttributedSubstringApi;
+@property BOOL didValidateAttributedSubstringApi;
 @property NSRange initialSelection;
 
 @end
@@ -62,15 +64,19 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
     _client = client;
     _clientApplicationId = appId;
     _complianceUncertain = YES;
+    _hasCompliantAttributedSubstringApi = NO;
+    _didValidateAttributedSubstringApi = NO;
     _initialSelection = NSMakeRange(NSNotFound, NSNotFound);
 
     NSString *message = [NSString stringWithFormat:@"TextApiCompliance initWithClient, client: %p applicationId: %@", client, appId];
     [KMSentryHelper addDebugBreadCrumb:@"compliance" message:message];
     os_log_debug([KMLogs complianceLog], "%{public}@", message);
 
-    // if we do not have hard-coded noncompliance, then test the app
-    if (appId && [self applyNoncompliantAppLists:appId]) {
+    // if we do not have hard-coded noncompliance, then test the client APIs for compliance
+    if (appId && [self isAbsentFromNoncompliantAppLists:appId]) {
       [self checkCompliance];
+    } else {
+      [self markAsNoncompliant];
     }
   }
   return self;
@@ -105,9 +111,11 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
 -(BOOL)isMatchingClient:(nullable id) otherClient applicationId:(nullable NSString *)otherAppId {
   BOOL matches = YES;
   if (![(id)[self client] isEqual:otherClient]) {
+    os_log_debug([KMLogs complianceLog], "## isMatchingClient = NO, self.client %p, otherClient %p", [self client], otherClient);
     matches = NO;
   }
   if (![[self clientApplicationId] isEqual:otherAppId]) {
+    os_log_debug([KMLogs complianceLog], "## isMatchingClient = NO, self.clientApplicationId %{public}@ otherAppId %{public}@", [self clientApplicationId], otherAppId);
     matches = NO;
   }
   
@@ -127,7 +135,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
  */
 -(NSString *)shortSentryTagDescription
 {
-  return [NSString stringWithFormat:@"uncertain: %@, compliant: %@, clientAppId: %@, ", self.complianceUncertain?@"true":@"false", self.hasCompliantSelectionApi?@"true":@"false", _clientApplicationId];
+  return [NSString stringWithFormat:@"uncertain: %@, canGetSelection: %@, canReadText: %@, clientAppId: %@, ", self.complianceUncertain?@"true":@"false", self.hasCompliantSelectionApi?@"true":@"false", [self canReadText]?@"true":@"false",_clientApplicationId];
 }
 
 /** test to see if the API selectedRange functions properly for the text input client  */
@@ -184,19 +192,85 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
     return;
   }
   
+  // check whether the location has changed as expected
   NSRange selectionRange = [self.client selectedRange];
+  os_log_debug([KMLogs complianceLog], "  selectionRange: %{public}@", NSStringFromRange(selectionRange));
   if ([self validateNewLocation:selectionRange.location delete:deletedText]) {
     BOOL changeExpected = [self isLocationChangeExpectedOnInsert:deletedText insert:insertedText];
     BOOL locationChanged = [self hasLocationChanged:selectionRange];
     [self validateLocationChange:changeExpected hasLocationChanged:locationChanged];
   }
   
-  NSString *message = [NSString stringWithFormat:@"checkComplianceAfterInsert, self.hasWorkingSelectionApi = %@ for app %@", self.hasCompliantSelectionApi?@"YES":@"NO", self.clientApplicationId];
+  // only validate ability to read if we know we have ability to get selection
+  if (self.hasCompliantSelectionApi) {
+    [self validateCanReadInsertedText:insertedText location:selectionRange.location];
+  }
+  
+  NSString *message = [NSString stringWithFormat:@"checkComplianceAfterInsert, self.canReadText = %@, self.hasWorkingSelectionApi = %@ for app %@", self.canReadText?@"YES":@"NO", self.hasCompliantSelectionApi?@"YES":@"NO", self.clientApplicationId];
   os_log_debug([KMLogs complianceLog], "%{public}@", message);
   [KMSentryHelper addDebugBreadCrumb:@"compliance" message:message];
   [KMSentryHelper addApiComplianceTag:self.shortSentryTagDescription];
 }
 
+/**
+ * Confirm that we can get the string that ends at the current location,
+ * and the end of the string matches the string that  was just inserted
+ */
+- (void)validateCanReadInsertedText:(NSString *)insertedText location: (NSUInteger)newLocation {
+
+  NSString *context = [self getContext:newLocation];
+  
+  if (context && context.length > 0) {
+    if ([context hasSuffix:insertedText]) {
+      self.hasCompliantAttributedSubstringApi = YES;
+      os_log_debug([KMLogs complianceLog], "  validateCanReadInsertedText passed, context: '%{public}@', insertedText '%{public}@'", context, insertedText);
+    } else {
+      self.hasCompliantAttributedSubstringApi = NO;
+      os_log_debug([KMLogs complianceLog], "  validateCanReadInsertedText failed, context: '%{public}@' does not have suffix of insertedText '%{public}@'", context, insertedText);
+    }
+  } else {
+    self.hasCompliantAttributedSubstringApi = NO;
+    os_log_debug([KMLogs complianceLog], "  validateCanReadInsertedText failed, attributedSubstringFromRange returned nil or empty string");
+  }
+
+  self.complianceUncertain = NO;
+  self.didValidateAttributedSubstringApi = YES;
+}
+
+/**
+ * Get the string that ends with the current location using `attributedSubstringFromRange`
+ */
+- (NSString *)getContext: (NSUInteger)newLocation {
+  NSAttributedString *attributedString = nil;
+  NSRange contextRange = [self calculateContextRange: newLocation];
+  
+  attributedString = [self.client attributedSubstringFromRange:contextRange];
+  os_log_debug([KMLogs complianceLog], "getContext substring = '%{public}@', length %lu character range: %{public}@: client: %p", attributedString.string, contextRange.length, NSStringFromRange(contextRange), self.client);
+  
+  if (attributedString) {
+    return attributedString.string;
+  } else {
+    return nil;
+  }
+}
+
+/**
+ * Calculate the range which bounds the context that we want to read, up to 80 characters.
+ */
+- (NSRange) calculateContextRange: (NSUInteger)newLocation {
+  const NSInteger kMaxContextLength = 80;
+  
+  NSUInteger contextLength = MIN(kMaxContextLength, newLocation);
+  NSUInteger contextStart = newLocation - contextLength;
+
+  NSRange contextRange = NSMakeRange(contextStart, contextLength);
+
+  return contextRange;
+}
+
+/**
+ * Inspect the current location returned by `selectionRange` to see whether it is valid.
+ */
 - (BOOL)validateNewLocation:(NSUInteger)location delete:(NSString *)textToDelete  {
   BOOL validLocation = NO;
   
@@ -218,6 +292,9 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   return validLocation;
 }
 
+/**
+ * Compare the the new location to the previous location and validate that it changed as expected after the latest insert.
+ */
 - (void) validateLocationChange:(BOOL) changeExpected hasLocationChanged:(BOOL) locationChanged {
   
   if (changeExpected == locationChanged) {
@@ -249,23 +326,25 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
 }
 
 /**
- * Apply the hard-coded non-compliant app list and the user-managed (via user defaults) non-compliant app list.
- * If true, mark the app as non-compliant and certain (not complianceUncertain).
+ * Check against the hard-coded non-compliant app list and the user-managed (via user defaults) non-compliant app list.
+ * If the specified application ID is not contained in non-compliant app lists, return true
  */
-- (BOOL)applyNoncompliantAppLists:(NSString *)clientAppId {
-  BOOL isAppNonCompliant = [self containedInHardCodedNoncompliantAppList:clientAppId];
-  if (!isAppNonCompliant) {
-    isAppNonCompliant = [self containedInUserManagedNoncompliantAppList:clientAppId];
+- (BOOL)isAbsentFromNoncompliantAppLists:(NSString *)clientAppId {
+  BOOL absent = ![self containedInHardCodedNoncompliantAppList:clientAppId];
+  if (absent) {
+    absent = ![self containedInUserManagedNoncompliantAppList:clientAppId];
   }
   
-  os_log_info([KMLogs complianceLog], "applyNoncompliantAppLists: for app %{public}@: %{public}@", clientAppId, isAppNonCompliant?@"YES":@"NO");
+  os_log_info([KMLogs complianceLog], "isAbsentFromNoncompliantAppLists: for app %{public}@: %{public}@", clientAppId, absent?@"YES":@"NO");
   
-  if (isAppNonCompliant) {
-    self.complianceUncertain = NO;
-    self.hasCompliantSelectionApi = NO;
-  }
-  
-  return isAppNonCompliant;
+  return absent;
+}
+
+-(void)markAsNoncompliant {
+  self.complianceUncertain = NO;
+  self.hasCompliantSelectionApi = NO;
+  self.hasCompliantAttributedSubstringApi = NO;
+  self.didValidateAttributedSubstringApi = YES;
 }
 
 /** Check this hard-coded list to see if the application ID is among those
@@ -352,11 +431,18 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   return self.complianceUncertain;
 }
 
+/**
+ * Returns true if we have a compliant `selectionRange` API and either
+ * 1) we have not yet validated the `attributedSubstringFromRange` API, or
+ * 2) it was found to be compliant (when validated after the first insert)
+ *
+ * What this means is that if getting the selection appears to work ok, then we assume that
+ * we can also read text -- unless we attempt to read it and it returns something unexpected.
+ */
 -(BOOL) canReadText {
-  // seems simple, but every application tested that returned the selection also successfully read the text using attributedSubstringFromRange
-  
   BOOL hasReadApi = [self.client respondsToSelector:@selector(attributedSubstringFromRange:)];
-  return hasReadApi && self.hasCompliantSelectionApi;
+  return hasReadApi && self.hasCompliantSelectionApi &&
+    (!self.didValidateAttributedSubstringApi || self.hasCompliantAttributedSubstringApi);
 }
 
 -(BOOL) canReplaceText {

--- a/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
@@ -223,10 +223,10 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   if (context && context.length > 0) {
     if ([context hasSuffix:insertedText]) {
       self.hasCompliantAttributedSubstringApi = YES;
-      os_log_debug([KMLogs complianceLog], "  validateCanReadInsertedText passed, context: '%{public}@', insertedText '%{public}@'", context, insertedText);
+      os_log_debug([KMLogs complianceLog], "  validateCanReadInsertedText passed, context matches insertedText '%{public}@'", insertedText);
     } else {
       self.hasCompliantAttributedSubstringApi = NO;
-      os_log_debug([KMLogs complianceLog], "  validateCanReadInsertedText failed, context: '%{public}@' does not have suffix of insertedText '%{public}@'", context, insertedText);
+      os_log_debug([KMLogs complianceLog], "  validateCanReadInsertedText failed, context does not have suffix of insertedText '%{public}@'", insertedText);
     }
   } else {
     self.hasCompliantAttributedSubstringApi = NO;
@@ -237,6 +237,9 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   self.didValidateAttributedSubstringApi = YES;
 }
 
+// TODO: getContext and calculateContextRange roughly duplicates code in KMInputMethodHandler
+// These should be moved to a class that wraps the text input client and its three APIs
+
 /**
  * Get the string that ends with the current location using `attributedSubstringFromRange`
  */
@@ -245,7 +248,7 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
   NSRange contextRange = [self calculateContextRange: newLocation];
   
   attributedString = [self.client attributedSubstringFromRange:contextRange];
-  os_log_debug([KMLogs complianceLog], "getContext substring = '%{public}@', length %lu character range: %{public}@: client: %p", attributedString.string, contextRange.length, NSStringFromRange(contextRange), self.client);
+  os_log_debug([KMLogs complianceLog], "getContext length %lu character range: %{public}@: client: %p", contextRange.length, NSStringFromRange(contextRange), self.client);
   
   if (attributedString) {
     return attributedString.string;


### PR DESCRIPTION
When handling a key down event, reevaluate the compliance of the text input client if a change in context has been detected (such as due to a mouse event or a page down or pressing an arrow key). This addresses problems where one part of an application behaves in a compliant way and another does not.

Also, further check compliance by comparing the context read from the text input client to the most recently inserted text. This helps to find problems with applications that support the selection API correctly but do not accurately read the text at the corresponding location.

Fixes: #13465

# User Testing

**TEST_IPA_MSWORD**: 

1. Open Microsoft Word on the Mac and create a new document
1. Switch to the IPA(SIL) keyboard 
1. Type <kbd>u</kbd><kbd><</kbd>
1. Verify that the output is ʊ

**TEST_IPA_MSWORD_TABLE**: 

1. Open Microsoft Word on the Mac and create a new document
1. Type a line or two of text
1. Insert a table below this text
1. Click a cell in the table
1. Switch to the IPA(SIL) keyboard 
1. Type <kbd>u</kbd><kbd><</kbd>
1. Verify that the output is ʊ

**TEST_IPA_MSWORD_TABLE_WITH_APP_SWITCH**: 

1. Open Microsoft Word on the Mac and create a new document
1. Type a line or two of text
1. Insert a table below this text
1. Click a cell in the table
1. Switch to the IPA(SIL) keyboard 
1. Type <kbd>u</kbd><kbd><</kbd>
1. Verify that the output is ʊ
1. Switch to the Stickies app and type a few characters
1. Switch back to Microsoft Word and click in another cell in the table
1. Type <kbd>u</kbd><kbd><</kbd>
1. Verify that the output is ʊ

**TEST_AMHARIC_STICKIES**: 

1. Open the Stickies app on the Mac and create a new note
1. Switch to the gff_amharic keyboard 
1. Type <kbd>s</kbd><kbd>e</kbd><kbd>l</kbd><kbd>a</kbd><kbd>m</kbd>
1. Verify that the output is ሰላም

**TEST_AMHARIC_MSWORD**: 

1. Open Microsoft Word on the Mac and create a new document
1. Switch to the gff_amharic keyboard 
1. Type <kbd>s</kbd><kbd>e</kbd><kbd>l</kbd><kbd>a</kbd><kbd>m</kbd>
1. Verify that the output is ሰላም

**TEST_AMHARIC_MSWORD_TABLE**: 

1. Open Microsoft Word on the Mac and create a new document
1. Type a line or two of text
1. Insert a table below this text
1. Click a cell in the table
1. Switch to the gff_amharic keyboard 
1. Type <kbd>s</kbd><kbd>e</kbd><kbd>l</kbd><kbd>a</kbd><kbd>m</kbd>
1. Verify that the output is ሰላም
