### PR TITLE
refactor(linux): rename `initialize_queue` method

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -232,7 +232,7 @@ get_context_debug(IBusEngine *engine) {
 static gchar *
 debug_utf8_with_codepoints(const gchar *utf8) {
   GString *output = g_string_new("");
-  g_string_append_printf(output, "|%s| len:%ld) [", utf8, g_utf8_strlen(utf8, -1));
+  g_string_append_printf(output, "|%s| (len:%ld) [", utf8, g_utf8_strlen(utf8, -1));
   gunichar2 *utf16 = g_utf8_to_utf16(utf8, -1, NULL, NULL, NULL);
   for (int i = 0; utf16[i] != '\0'; i++) {
     g_string_append_printf(output, "U+%04x ", utf16[i]);
@@ -290,7 +290,7 @@ set_context_if_needed(IBusEngine *engine) {
 }
 
 static void
-initialize_queue(IBusKeymanEngine *keyman, int index, int count) {
+initialize_queue_items(IBusKeymanEngine *keyman, int index, int count) {
   g_assert(keyman != NULL);
   g_assert(index >= 0 && index < MAX_QUEUE_SIZE);
   g_assert(count > 0 && count <= MAX_QUEUE_SIZE);
@@ -463,7 +463,7 @@ ibus_keyman_engine_constructor(
     keyman->lctrl_pressed = FALSE;
     keyman->ralt_pressed = FALSE;
     keyman->rctrl_pressed = FALSE;
-    initialize_queue(keyman, 0, MAX_QUEUE_SIZE);
+    initialize_queue_items(keyman, 0, MAX_QUEUE_SIZE);
     keyman->commit_item    = &keyman->commit_queue[0];
     gchar **split_name     = g_strsplit(engine_name, ":", 2);
     if (split_name[0] == NULL)
@@ -768,7 +768,7 @@ commit_current_queue_item(IBusKeymanEngine *keyman) {
   }
   keyman->commit_item--;
   memmove(keyman->commit_queue, &keyman->commit_queue[1], sizeof(commit_queue_item) * MAX_QUEUE_SIZE - 1);
-  initialize_queue(keyman, MAX_QUEUE_SIZE - 1, 1);
+  initialize_queue_items(keyman, MAX_QUEUE_SIZE - 1, 1);
 }
 
 static void


### PR DESCRIPTION
The new name `initialize_queue_items` makes it clearer that we initialize some items in the queue and not the entire queue (which might still contain items that we do want to keep).

@keymanapp-test-bot skip