### PR TITLE
chore(web): cherry-pick exportable trie from epic/user-dict to epic/dict-breaker 🔬

### DIFF
--- a/web/src/engine/predictive-text/templates/src/common.ts
+++ b/web/src/engine/predictive-text/templates/src/common.ts
@@ -165,14 +165,12 @@ export function defaultApplyCasing(casing: CasingForm, text: string): string {
  * the trie. There should be a function that converts arbitrary strings
  * (queries) and converts them into a standard search key for a given language
  * model.
- *
- * Fun fact: This opaque type has ALREADY saved my bacon and found a bug!
  */
 export type SearchKey = string & { _: 'SearchKey'};
 
 /**
  * A function that converts a string (word form or query) into a search key
- * (secretly, this is also a string).
+ * (which, internally, is also a string type).
  */
 export interface Wordform2Key {
   (wordform: string): SearchKey;

--- a/web/src/engine/predictive-text/templates/src/common.ts
+++ b/web/src/engine/predictive-text/templates/src/common.ts
@@ -159,3 +159,21 @@ export function defaultApplyCasing(casing: CasingForm, text: string): string {
       return text.substring(0, headUnitLength).toUpperCase() .concat(text.substring(headUnitLength));
   }
 }
+
+/**
+ * An **opaque** type for a string that is exclusively used as a search key in
+ * the trie. There should be a function that converts arbitrary strings
+ * (queries) and converts them into a standard search key for a given language
+ * model.
+ *
+ * Fun fact: This opaque type has ALREADY saved my bacon and found a bug!
+ */
+export type SearchKey = string & { _: 'SearchKey'};
+
+/**
+ * A function that converts a string (word form or query) into a search key
+ * (secretly, this is also a string).
+ */
+export interface Wordform2Key {
+  (wordform: string): SearchKey;
+}

--- a/web/src/engine/predictive-text/templates/src/index.ts
+++ b/web/src/engine/predictive-text/templates/src/index.ts
@@ -4,4 +4,5 @@ export {
 } from "./common.js";
 export { default as QuoteBehavior } from "./quote-behavior.js";
 export { getLastPreCaretToken, Token, Tokenization, tokenize, wordbreak } from "./tokenization.js";
+export { Trie } from "./trie.js";
 export { default as TrieModel, TrieModelOptions } from "./trie-model.js";

--- a/web/src/engine/predictive-text/templates/src/trie-model.ts
+++ b/web/src/engine/predictive-text/templates/src/trie-model.ts
@@ -29,7 +29,8 @@
 import { extendString, PriorityQueue } from "@keymanapp/web-utils";
 import { default as defaultWordBreaker } from "@keymanapp/models-wordbreakers";
 
-import { applyTransform, isHighSurrogate, isSentinel, SENTINEL_CODE_UNIT, transformToSuggestion } from "./common.js";
+import { applyTransform, SearchKey, transformToSuggestion, Wordform2Key } from "./common.js";
+import { Node, Trie } from './trie.js';
 import { getLastPreCaretToken } from "./tokenization.js";
 import { LexicalModelTypes } from "@keymanapp/common-types";
 import Capabilities = LexicalModelTypes.Capabilities;
@@ -88,182 +89,6 @@ export interface TrieModelOptions {
   punctuation?: LexicalModelPunctuation;
 }
 
-class Traversal implements LexiconTraversal {
-  /**
-   * The lexical prefix corresponding to the current traversal state.
-   */
-  prefix: String;
-
-  /**
-   * The current traversal node.  Serves as the 'root' of its own sub-Trie,
-   * and we cannot navigate back to its parent.
-   */
-  root: Node;
-
-  /**
-   * The max weight for the Trie being 'traversed'.  Needed for probability
-   * calculations.
-   */
-  totalWeight: number;
-
-  constructor(root: Node, prefix: string, totalWeight: number) {
-    this.root = root;
-    this.prefix = prefix;
-    this.totalWeight = totalWeight;
-  }
-
-  child(char: USVString): LexiconTraversal | undefined {
-    // May result for blank tokens resulting immediately after whitespace.
-    if(char == '') {
-      return this;
-    }
-
-    // Split into individual code units.
-    let steps = char.split('');
-    let traversal: Traversal | undefined = this;
-
-    while(steps.length > 0 && traversal) {
-      const step: string = steps.shift()!;
-      traversal = traversal._child(step);
-    }
-
-    return traversal;
-  }
-
-  // Handles one code unit at a time.
-  private _child(char: USVString): Traversal | undefined {
-    const root = this.root;
-    const totalWeight = this.totalWeight;
-    const nextPrefix = this.prefix + char;
-
-    if(root.type == 'internal') {
-      let childNode = root.children[char];
-      if(!childNode) {
-        return undefined;
-      }
-
-      return new Traversal(childNode, nextPrefix, totalWeight);
-    } else {
-      // root.type == 'leaf';
-      const legalChildren = root.entries.filter(function(entry) {
-        return entry.key.indexOf(nextPrefix) == 0;
-      });
-
-      if(!legalChildren.length) {
-        return undefined;
-      }
-
-      return new Traversal(root, nextPrefix, totalWeight);
-    }
-  }
-
-  *children(): Generator<{char: USVString, traversal: () => LexiconTraversal}> {
-    let root = this.root;
-
-    // We refer to the field multiple times in this method, and it doesn't change.
-    // This also assists minification a bit, since we can't minify when re-accessing
-    // through `this.`.
-    const totalWeight = this.totalWeight;
-
-    if(root.type == 'internal') {
-      for(let entry of root.values) {
-        let entryNode = root.children[entry];
-
-        // UTF-16 astral plane check.
-        if(isHighSurrogate(entry)) {
-          // First code unit of a UTF-16 code point.
-          // For now, we'll just assume the second always completes such a char.
-          //
-          // Note:  Things get nasty here if this is only sometimes true; in the future,
-          // we should compile-time enforce that this assumption is always true if possible.
-          if(entryNode.type == 'internal') {
-            let internalNode = entryNode;
-            for(let lowSurrogate of internalNode.values) {
-              let prefix = this.prefix + entry + lowSurrogate;
-              yield {
-                char: entry + lowSurrogate,
-                traversal: function() { return new Traversal(internalNode.children[lowSurrogate], prefix, totalWeight) }
-              }
-            }
-          } else {
-            // Determine how much of the 'leaf' entry has no Trie nodes, emulate them.
-            let fullText = entryNode.entries[0].key;
-            entry = entry + fullText[this.prefix.length + 1]; // The other half of the non-BMP char.
-            let prefix = this.prefix + entry;
-
-            yield {
-              char: entry,
-              traversal: function () {return new Traversal(entryNode, prefix, totalWeight)}
-            }
-          }
-        } else if(isSentinel(entry)) {
-          continue;
-        } else if(!entry) {
-          // Prevent any accidental 'null' or 'undefined' entries from having an effect.
-          continue;
-        } else {
-          let prefix = this.prefix + entry;
-          yield {
-            char: entry,
-            traversal: function() { return new Traversal(entryNode, prefix, totalWeight)}
-          }
-        }
-      }
-
-      return;
-    } else { // type == 'leaf'
-      let prefix = this.prefix;
-
-      let children = root.entries.filter(function(entry) {
-        return entry.key != prefix && prefix.length < entry.key.length;
-      })
-
-      for(let {key} of children) {
-        let nodeKey = key[prefix.length];
-
-        if(isHighSurrogate(nodeKey)) {
-          // Merge the other half of an SMP char in!
-          nodeKey = nodeKey + key[prefix.length+1];
-        }
-        yield {
-          char: nodeKey,
-          traversal: function() { return new Traversal(root, prefix + nodeKey, totalWeight)}
-        }
-      };
-      return;
-    }
-  }
-
-  get entries() {
-    const entryMapper = (value: Entry) => {
-      return {
-        text: value.content,
-        p: value.weight / this.totalWeight
-      }
-    }
-
-    if(this.root.type == 'leaf') {
-      let prefix = this.prefix;
-      let matches = this.root.entries.filter(function(entry) {
-        return entry.key == prefix;
-      });
-
-      return matches.map(entryMapper);
-    } else {
-      let matchingLeaf = this.root.children[SENTINEL_CODE_UNIT];
-      if(matchingLeaf && matchingLeaf.type == 'leaf') {
-        return matchingLeaf.entries.map(entryMapper);
-      } else {
-        return [];
-      }
-    }
-  }
-
-  get p(): number {
-    return this.root.weight / this.totalWeight;
-  }
-}
-
 /**
  * @class TrieModel
  *
@@ -309,7 +134,7 @@ export default class TrieModel implements LexicalModel {
   predict(transform: Transform, context: Context): Distribution<Suggestion> {
     // Special-case the empty buffer/transform: return the top suggestions.
     if (!transform.insert && !context.left && !context.right && context.startOfBuffer && context.endOfBuffer) {
-      return makeDistribution(this._trie.firstN(MAX_SUGGESTIONS).map(({text, p}) => ({
+      return makeDistribution(this.firstN(MAX_SUGGESTIONS).map(({text, p}) => ({
         transform: {
           insert: text,
           deleteLeft: 0
@@ -330,7 +155,7 @@ export default class TrieModel implements LexicalModel {
     let prefix = getLastPreCaretToken(this.breakWords, newContext);
 
     // Return suggestions from the trie.
-    return makeDistribution(this._trie.lookup(prefix).map(({text, p}) =>
+    return makeDistribution(this.lookup(prefix).map(({text, p}) =>
       transformToSuggestion({
         insert: text,
         // Delete whatever the prefix that the user wrote.
@@ -361,101 +186,13 @@ export default class TrieModel implements LexicalModel {
   public traverseFromRoot(): LexiconTraversal {
     return this._trie.traverseFromRoot();
   }
-};
 
-/////////////////////////////////////////////////////////////////////////////////
-// What remains in this file is the trie implementation proper. Note: to       //
-// reduce bundle size, any functions/methods related to creating the trie have //
-// been removed.                                                               //
-/////////////////////////////////////////////////////////////////////////////////
-
-/**
- * An **opaque** type for a string that is exclusively used as a search key in
- * the trie. There should be a function that converts arbitrary strings
- * (queries) and converts them into a standard search key for a given language
- * model.
- *
- * Fun fact: This opaque type has ALREADY saved my bacon and found a bug!
- */
-type SearchKey = string & { _: 'SearchKey'};
-
-/**
- * The priority queue will always pop the most probable item - be it a Traversal
- * state or a lexical entry reached via Traversal.
- */
-type TraversableWithProb = TextWithProbability | LexiconTraversal;
-
-/**
- * A function that converts a string (word form or query) into a search key
- * (secretly, this is also a string).
- */
-interface Wordform2Key {
-  (wordform: string): SearchKey;
-}
-
-// The following trie implementation has been (heavily) derived from trie-ing
-// by Conrad Irwin.
-// trie-ing is copyright (C) 2015–2017 Conrad Irwin.
-// Distributed under the terms of the MIT license:
-// https://github.com/ConradIrwin/trie-ing/blob/df55d7af7068d357829db9e0a7faa8a38add1d1d/LICENSE
-
-type Node = InternalNode | Leaf;
-/**
- * An internal node in the trie. Internal nodes NEVER contain entries; if an
- * internal node should contain an entry, then it has a dummy leaf node (see
- * below), that can be accessed by node.children["\uFDD0"].
- */
-interface InternalNode {
-  type: 'internal';
-  weight: number;
-  /** Maintains the keys of children in descending order of weight. */
-  values: string[]; // TODO: As an optimization, "values" can be a single string!
   /**
-   * Maps a single UTF-16 code unit to a child node in the trie. This child
-   * node may be a leaf or an internal node. The keys of this object are kept
-   * in sorted order in the .values array.
+   * Returns the top N suggestions from the trie.
+   * @param n How many suggestions, maximum, to return.
    */
-  children: { [codeunit: string]: Node };
-}
-/** Only leaf nodes actually contain entries (i.e., the words proper). */
-interface Leaf {
-  type: 'leaf';
-  weight: number;
-  entries: Entry[];
-}
-
-/**
- * An entry in the prefix trie (stored in leaf nodes exclusively!)
- */
-interface Entry {
-  /** The actual word form, stored in the trie. */
-  content: string;
-  /** A search key that usually simplifies the word form, for ease of search. */
-  key: SearchKey;
-  weight: number;
-}
-
-/**
- * Wrapper class for the trie and its nodes.
- */
-class Trie {
-  public readonly root: Node;
-  /** The total weight of the entire trie. */
-  readonly totalWeight: number;
-  /**
-   * Converts arbitrary strings to a search key. The trie is built up of
-   * search keys; not each entry's word form!
-   */
-  toKey: Wordform2Key;
-
-  constructor(root: Node, totalWeight: number, wordform2key: Wordform2Key) {
-    this.root = root;
-    this.toKey = wordform2key;
-    this.totalWeight = totalWeight;
-  }
-
-  public traverseFromRoot(): LexiconTraversal {
-    return new Traversal(this.root, '', this.totalWeight);
+  firstN(n: number): TextWithProbability[] {
+    return getSortedResults(this._trie.traverseFromRoot(), n);
   }
 
   /**
@@ -486,15 +223,19 @@ class Trie {
     // priority over anything from its descendants.
     return directEntries.concat(deduplicated);
   }
+};
 
-  /**
-   * Returns the top N suggestions from the trie.
-   * @param n How many suggestions, maximum, to return.
-   */
-  firstN(n: number): TextWithProbability[] {
-    return getSortedResults(this.traverseFromRoot(), n);
-  }
-}
+/////////////////////////////////////////////////////////////////////////////////
+// What remains in this file is the trie implementation proper. Note: to       //
+// reduce bundle size, any functions/methods related to creating the trie have //
+// been removed.                                                               //
+/////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * The priority queue will always pop the most probable item - be it a Traversal
+ * state or a lexical entry reached via Traversal.
+ */
+type TraversableWithProb = TextWithProbability | LexiconTraversal;
 
 /**
  * Returns all entries matching the given prefix, in descending order of

--- a/web/src/engine/predictive-text/templates/src/trie.ts
+++ b/web/src/engine/predictive-text/templates/src/trie.ts
@@ -1,0 +1,244 @@
+import { isHighSurrogate, isSentinel, SearchKey, SENTINEL_CODE_UNIT, Wordform2Key } from "./common.js";
+
+// The following trie implementation has been (heavily) derived from trie-ing
+// by Conrad Irwin.
+// trie-ing is copyright (C) 2015–2017 Conrad Irwin.
+// Distributed under the terms of the MIT license:
+// https://github.com/ConradIrwin/trie-ing/blob/df55d7af7068d357829db9e0a7faa8a38add1d1d/LICENSE
+
+export type Node = InternalNode | Leaf;
+/**
+ * An internal node in the trie. Internal nodes NEVER contain entries; if an
+ * internal node should contain an entry, then it has a dummy leaf node (see
+ * below), that can be accessed by node.children["\uFDD0"].
+ */
+export interface InternalNode {
+  type: 'internal';
+  weight: number;
+  /** Maintains the keys of children in descending order of weight. */
+  values: string[]; // TODO: As an optimization, "values" can be a single string!
+  /**
+   * Maps a single UTF-16 code unit to a child node in the trie. This child
+   * node may be a leaf or an internal node. The keys of this object are kept
+   * in sorted order in the .values array.
+   */
+  children: { [codeunit: string]: Node };
+}
+/** Only leaf nodes actually contain entries (i.e., the words proper). */
+export interface Leaf {
+  type: 'leaf';
+  weight: number;
+  entries: Entry[];
+}
+
+/**
+ * An entry in the prefix trie (stored in leaf nodes exclusively!)
+ */
+export interface Entry {
+  /** The actual word form, stored in the trie. */
+  content: string;
+  /** A search key that usually simplifies the word form, for ease of search. */
+  key: SearchKey;
+  weight: number;
+}
+
+export class TrieTraversal implements LexiconTraversal {
+  /**
+   * The lexical prefix corresponding to the current traversal state.
+   */
+  prefix: String;
+
+  /**
+   * The current traversal node.  Serves as the 'root' of its own sub-Trie,
+   * and we cannot navigate back to its parent.
+   */
+  root: Node;
+
+  /**
+   * The max weight for the Trie being 'traversed'.  Needed for probability
+   * calculations.
+   */
+  totalWeight: number;
+
+  constructor(root: Node, prefix: string, totalWeight: number) {
+    this.root = root;
+    this.prefix = prefix;
+    this.totalWeight = totalWeight;
+  }
+
+  child(char: USVString): LexiconTraversal | undefined {
+    /*
+      Note: would otherwise return the current instance if `char == ''`.  If
+      such a call is happening, it's probably indicative of an implementation
+      issue elsewhere - let's signal now in order to catch such stuff early.
+    */
+    if(char == '') {
+      return undefined;
+    }
+
+    // Split into individual code units.
+    let steps = char.split('');
+    let traversal: ReturnType<TrieTraversal["_child"]> = this;
+
+    while(steps.length > 0 && traversal) {
+      const step: string = steps.shift()!;
+      traversal = traversal._child(step);
+    }
+
+    return traversal;
+  }
+
+  // Handles one code unit at a time.
+  private _child(char: USVString): TrieTraversal | undefined {
+    const root = this.root;
+    const totalWeight = this.totalWeight;
+    const nextPrefix = this.prefix + char;
+
+    if(root.type == 'internal') {
+      let childNode = root.children[char];
+      if(!childNode) {
+        return undefined;
+      }
+
+      return new TrieTraversal(childNode, nextPrefix, totalWeight);
+    } else {
+      // root.type == 'leaf';
+      const legalChildren = root.entries.filter(function(entry) {
+        return entry.key.indexOf(nextPrefix) == 0;
+      });
+
+      if(!legalChildren.length) {
+        return undefined;
+      }
+
+      return new TrieTraversal(root, nextPrefix, totalWeight);
+    }
+  }
+
+  *children(): Generator<{char: USVString, traversal: () => LexiconTraversal}> {
+    let root = this.root;
+    const totalWeight = this.totalWeight;
+
+    if(root.type == 'internal') {
+      for(let entry of root.values) {
+        let entryNode = root.children[entry];
+
+        // UTF-16 astral plane check.
+        if(isHighSurrogate(entry)) {
+          // First code unit of a UTF-16 code point.
+          // For now, we'll just assume the second always completes such a char.
+          //
+          // Note:  Things get nasty here if this is only sometimes true; in the future,
+          // we should compile-time enforce that this assumption is always true if possible.
+          if(entryNode.type == 'internal') {
+            let internalNode = entryNode;
+            for(let lowSurrogate of internalNode.values) {
+              let prefix = this.prefix + entry + lowSurrogate;
+              yield {
+                char: entry + lowSurrogate,
+                traversal: function() { return new TrieTraversal(internalNode.children[lowSurrogate], prefix, totalWeight) }
+              }
+            }
+          } else {
+            // Determine how much of the 'leaf' entry has no Trie nodes, emulate them.
+            let fullText = entryNode.entries[0].key;
+            entry = entry + fullText[this.prefix.length + 1]; // The other half of the non-BMP char.
+            let prefix = this.prefix + entry;
+
+            yield {
+              char: entry,
+              traversal: function () {return new TrieTraversal(entryNode, prefix, totalWeight)}
+            }
+          }
+        } else if(isSentinel(entry)) {
+          continue;
+        } else if(!entry) {
+          // Prevent any accidental 'null' or 'undefined' entries from having an effect.
+          continue;
+        } else {
+          let prefix = this.prefix + entry;
+          yield {
+            char: entry,
+            traversal: function() { return new TrieTraversal(entryNode, prefix, totalWeight)}
+          }
+        }
+      }
+
+      return;
+    } else { // type == 'leaf'
+      let prefix = this.prefix;
+
+      let children = root.entries.filter(function(entry) {
+        return entry.key != prefix && prefix.length < entry.key.length;
+      })
+
+      for(let {key} of children) {
+        let nodeKey = key[prefix.length];
+
+        if(isHighSurrogate(nodeKey)) {
+          // Merge the other half of an SMP char in!
+          nodeKey = nodeKey + key[prefix.length+1];
+        }
+        yield {
+          char: nodeKey,
+          traversal: function() { return new TrieTraversal(root, prefix + nodeKey, totalWeight)}
+        }
+      };
+      return;
+    }
+  }
+
+  get entries() {
+    const totalWeight = this.totalWeight;
+    const entryMapper = function(value: Entry) {
+      return {
+        text: value.content,
+        p: value.weight / totalWeight
+      }
+    }
+
+    if(this.root.type == 'leaf') {
+      let prefix = this.prefix;
+      let matches = this.root.entries.filter(function(entry) {
+        return entry.key == prefix;
+      });
+
+      return matches.map(entryMapper);
+    } else {
+      let matchingLeaf = this.root.children[SENTINEL_CODE_UNIT];
+      if(matchingLeaf && matchingLeaf.type == 'leaf') {
+        return matchingLeaf.entries.map(entryMapper);
+      } else {
+        return [];
+      }
+    }
+  }
+
+  get p(): number {
+    return this.root.weight / this.totalWeight;
+  }
+}
+
+/**
+ * Wrapper class for the trie and its nodes.
+ */
+export class Trie {
+  private root: Node;
+  /** The total weight of the entire trie. */
+  readonly totalWeight: number;
+  /**
+   * Converts arbitrary strings to a search key. The trie is built up of
+   * search keys; not each entry's word form!
+   */
+  toKey: Wordform2Key;
+
+  constructor(root: Node, totalWeight: number, wordform2key: Wordform2Key) {
+    this.root = root;
+    this.toKey = wordform2key;
+    this.totalWeight = totalWeight;
+  }
+
+  public traverseFromRoot(): LexiconTraversal {
+    return new TrieTraversal(this.root, '', this.totalWeight);
+  }
+}

--- a/web/src/engine/predictive-text/templates/src/trie.ts
+++ b/web/src/engine/predictive-text/templates/src/trie.ts
@@ -1,4 +1,7 @@
 import { isHighSurrogate, isSentinel, SearchKey, SENTINEL_CODE_UNIT, Wordform2Key } from "./common.js";
+import { LexicalModelTypes } from "@keymanapp/common-types";
+import LexiconTraversal = LexicalModelTypes.LexiconTraversal;
+import USVString = LexicalModelTypes.USVString;
 
 // The following trie implementation has been (heavily) derived from trie-ing
 // by Conrad Irwin.


### PR DESCRIPTION
This PR cherrypicks 98ccdef181a695419a4a7cf415c4e6aa5aa1d8c7 (from #12080) to epic/dict-breaker.  It's already part of epic/model-encoding and epic/user-dict, but it turns out we could really use it here too - the dict-breaker needs access to the model's dictionary, and that's Trie-backed.

Note:  it uses the literal same commit as exists in those epics; I worked things out that way to proactively prevent conflicts when the different epics eventually converge in the future.  Note the hash of the second commit below - it's a match.

Realized I needed this when tinkering on the side with how to link the dictionary-based breaker to Trie models; got that PR mostly done while on the wrong base-branch!  (A branch that included these commits.)  Well... aside from its testing.  That's complex enough that I probably shouldn't push it through to completion yet due to our current `beta` focus, even if I believe I've worked most of out the toughest parts.  (i.e, it'd be a draft PR for a while.)

@keymanapp-test-bot skip