### PR TITLE
fix(linux): improve emitting keystrokes

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -703,18 +703,19 @@ process_persist_action(IBusEngine *engine, km_core_option_item *persist_options)
 
 static void
 process_emit_keystroke_action(IBusEngine *engine, km_core_bool emit_keystroke) {
-  if (!emit_keystroke) {
-    return;
-  }
   IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
   if (client_supports_surrounding_text(engine)) {
     // compliant app
+    if (!emit_keystroke) {
+      return;
+    }
     ibus_engine_forward_key_event(engine, keyman->commit_item->keyval,
       keyman->commit_item->keycode, keyman->commit_item->state);
     return;
   }
+
   // non-compliant app
-  keyman->commit_item->emitting_keystroke = TRUE;
+  keyman->commit_item->emitting_keystroke = emit_keystroke;
 }
 
 static void


### PR DESCRIPTION
For some reason when using a LDML keyboard we ended up emitting a keystroke even though Core returned `FALSE` for `emitting_keystroke`. I wasn't able to track down where this happened, but this change seems like an easy way to fix it.

This showed up when debugging why the changes in #13372 didn't work for non-compliant apps.

# User Testing

## Preparations

- The tests can be run on one of these Linux platforms:
  - Ubuntu 22.04 Jammy with Gnome Shell and X11
  - Ubuntu 24.04 Noble with Gnome Shell and X11
  - Ubuntu 24.10 Oracular with Gnome Shell and X11
  - Wasta 24.04 with Cinnamon

- Install gedit:
  ```bash
  sudo apt update
  sudo apt install gedit
  ```

- Install Firefox as snap package:
  ```bash
  snap install firefox
  ```

- Install flatpak
  ```bash
  sudo apt install flatpak
  flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
  ```

- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)

- Reboot

- Install Chrome as flatpak:
  ```bash
  flatpak install flathub com.google.Chrome
  ```
 
- Install Anki as flatpak by running
  ```bash
  flatpak install flathub net.ankiweb.Anki
  ```

- Install the following keyboards in Keyman:
  * [IPA (SIL)](https://keyman.com/keyboards/sil_ipa)
  * [Korean KORDA Jamo (SIL)](https://keyman.com/keyboards/sil_korda_jamo)
  * [Khmer Angkor](https://keyman.com/keyboards/khmer_angkor)
  * [Vedic Sanskrit Devanagari Phonetic (ITRANS)](https://keyman.com/keyboards/itrans_devanagari_sanskrit_vedic)

## SUITE_WRITER: LibreOffice Writer

Open LibreOffice Writer.

### Tests

- **TEST_WRITER_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_WRITER_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_WRITER_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री". (If the result looks wrong, select all text and change the font to "Siddhanta")
- **TEST_WRITER_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_WRITER_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.

## SUITE_GEDIT: gedit

Open gedit.

### Tests

- **TEST_GEDIT_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_GEDIT_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_GEDIT_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री".
- **TEST_GEDIT_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_GEDIT_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.

## SUITE_FIREFOX: Firefox

Open https://keyman.com/keyboards in Firefox.

**NOTE:** If the output looks wrong, copy the text from the browser and paste it into gedit and verify that it there.

### Tests

- **TEST_FIREFOX_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_FIREFOX_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_FIREFOX_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री".
- **TEST_FIREFOX_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_FIREFOX_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.

## SUITE_CHROME: Chrome

Run Chrome with `flatpak run com.google.Chrome`, then open https://keyman.com/keyboards.

**NOTE:** If the output looks wrong, copy the text from the browser and paste it into gedit and verify that it there.

### Tests

- **TEST_CHROME_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_CHROME_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_CHROME_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री".
- **TEST_CHROME_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_CHROME_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.

## SUITE_TERMINAL: gnome-terminal

Open Terminal.

### Tests

- **TEST_TERMINAL_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".

## SUITE_ANKI: Anki

Open Anki and select e.g. "Tools"/"Study Deck". Start Anki with:

```
flatpak run net.ankiweb.Anki
```

### Tests

- **TEST_ANKI_IPA:** Switch to "IPA (SIL)" keyboard. Type `n>`. Verify that the result is "ŋ".
- **TEST_ANKI_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_ANKI_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `shrI`. Verify that the result is "श्री" (If the result looks wrong, copy/paste it in text editor and verify there).
- **TEST_ANKI_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_ANKI_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.

## SUITE_SEARCHBAR: Searchbar in gnome-shell

Press Windows key to open searchbar.

### Tests

- **TEST_SEARCHBAR_IPA:** Switch to "IPA (SIL)" keyboard. Type `an>`. Verify that the result is "aŋ".
- **TEST_SEARCHBAR_KO:** Switch to "Korean KORDA Jamo (SIL)" keyboard. Type `han<space>geul<space>`. Verify that the result is "한글".
- **TEST_SEARCHBAR_HI:** Switch to "Vedic Sanskrit Devanagari Phonetic (ITRANS)" keyboard. Type `s shrI`. Verify that the result is "स् श्री".
- **TEST_SEARCHBAR_KM:** Switch to "Khmer Angkor" keyboard. Type `xEjmr`. Verify that the output is "ខ្មែរ".
- **TEST_SEARCHBAR_KM_BS:** With the output "ខ្មែរ" still being displayed, press Backspace key 5 times. Verify that after each keystroke a part of the string is removed and after the 5th backspace the entire word is deleted.

