### PR TITLE
fix(windows,mac): Update Spanish configuration string and mac strings

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/es.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/es.lproj/Localizable.strings
@@ -67,8 +67,11 @@
 /* copyright label in the Package Information window */
 "copyright-label" = "Derechos de autor:";
 
-/* message displayed to alert user to need grant accessibility permission */
+/* message displayed to alert user to need grant accessibility permission in Preferences, pre-Ventura */
 "privacy-alert-text" = "Para funcionar correctamente, Keyman requiere las siguientes características de accesibilidad:\nel acceso en Preferencias del Sistema, Seguridad y Privacidad.\nel reinicio del sistema.";
+
+/* message displayed to alert user to need grant accessibility permission in Settings, for macOS Ventura and later */
+"privacy-alert-text-ventura" = "To function properly, Keyman requires accessibility features:\n\nGrant access in System Settings, Privacy & Security.\nRestart your system.";
 
 /* Text of menu item in Input Menu when no Keyboards are configured -- include parentheses  */
 "no-keyboard-configured-menu-placeholder" = "(Sin teclado configurado)";

--- a/windows/src/desktop/kmshell/locale/es-ES/strings.xml
+++ b/windows/src/desktop/kmshell/locale/es-ES/strings.xml
@@ -664,7 +664,7 @@
   <!-- Context: Splash Dialog -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 8.0.294.0 -->
-  <string name="S_Splash_Configuration" comment="Keyman Configuration link">COnfiguración</string>
+  <string name="S_Splash_Configuration" comment="Keyman Configuration link">Configuración</string>
   <!-- Context: Splash Dialog -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.341.0 -->


### PR DESCRIPTION
Fixes #13529

Via zoom, I walked @sze2st through the Crowdin processes of:
* Updating a string (`S_Splash_Configuration`)
* Approving a string
* Using the Crowdin CLI tool to download strings for a language
`crowdin download -b master -l es-ES`
* Reference the [README](https://github.com/keymanapp/keyman/blob/master/resources/build/l10n/README.md)

At this point, he doesn't need to get setup for using the CLI tool (so he can focus working on #13519)

@keymaanpp-test-bot skip

