### PR TITLE
fix(android): Cleanup setBannerOptions() API call

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -161,7 +161,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     inputType = attribute.inputType;
     KMManager.setPredictionsSuspended(inputType, KeyboardType.KEYBOARD_TYPE_SYSTEM);
     if (KMManager.getPredictionsSuspended(KeyboardType.KEYBOARD_TYPE_SYSTEM)) {
-      KMManager.setBannerOptions(false);
+      KMManager.setBannerOptions(false, KeyboardType.KEYBOARD_TYPE_SYSTEM);
       // Set the system keyboard HTML banner
       BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
     } else if (KMManager.isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM)){
@@ -172,9 +172,9 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
         SharedPreferences prefs = appContext.getSharedPreferences(appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
         int maySuggest = prefs.getInt(KMManager.getLanguageAutoCorrectionPreferenceKey(langId), KMManager.KMDefault_Suggestion);
         // Enable banner if maySuggest is not SuggestionType.SUGGESTIONS_DISABLED (0)
-        KMManager.setBannerOptions(maySuggest != SuggestionType.SUGGESTIONS_DISABLED.toInt());
+        KMManager.setBannerOptions(maySuggest != SuggestionType.SUGGESTIONS_DISABLED.toInt(), KeyboardType.KEYBOARD_TYPE_SYSTEM);
       } else {
-        KMManager.setBannerOptions(false);
+        KMManager.setBannerOptions(false, KeyboardType.KEYBOARD_TYPE_SYSTEM);
       }
     }
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1559,7 +1559,8 @@ public final class KMManager {
     // Disable sugestions if lexical-model file doesn't exist
     if (!modelFile.exists()) {
       modelFileExists = false;
-      setBannerOptions(false);
+      setBannerOptions(false, KeyboardType.KEYBOARD_TYPE_INAPP);
+      setBannerOptions(false, KeyboardType.KEYBOARD_TYPE_SYSTEM);
       KMLog.LogError(TAG, modelFile.getAbsolutePath() + " does not exist");
     }
 
@@ -1633,28 +1634,12 @@ public final class KMManager {
   }
 
   /**
-   * setBannerOptions - Update KMW whether to generate predictions.
-   *                    For now, also display banner
-   * @param mayPredict - boolean whether KMW should generate predictions
-   * @return boolean - Success
-   */
-  public static boolean setBannerOptions(boolean mayPredict) {
-    String url = KMString.format("setBannerOptions(%s)", mayPredict);
-    if (InAppKeyboard != null) {
-      InAppKeyboard.loadJavascript(url);
-    }
-
-    if (SystemKeyboard != null) {
-      SystemKeyboard.loadJavascript(url);
-    }
-
-    return true;
-  }
-
-  /**
-   * setBannerOptions - Update KMW for inapp/system keyboard whether to generate predictions.
-   *                    For now, also display banner
-   * @param mayPredict - boolean whether KMW should generate predictions
+   * setBannerOptions - Update KeymanWeb for inapp/system keyboard whether to generate predictions.
+   *                    For now, also display banner. This is generally controlled by the user preference
+   *                    in the LanguageSettings menu, with priority to
+   *                    the PredictionsSuspendedForSensitiveInput flag.
+   * API published in Keyman 18.0
+   * @param mayPredict - boolean whether KeymanWeb should generate predictions
    * @param {KeyboardType} keyboard
    * @return boolean - Success
    */

--- a/android/docs/engine/KMManager/index.md
+++ b/android/docs/engine/KMManager/index.md
@@ -221,6 +221,9 @@ The KMManager is the core class which provides most of the methods and constants
 [`removeKeyboardEventListener()`](removeKeyboardEventListener)
 : removes the specified listener from the list of keyboard event listeners
 
+[`setBannerOptions()`](setBannerOptions)
+: send options to the KeymanWeb engine for controlling whether to generate predictions
+
 [`setCanAddNewKeyboard()`](setCanAddNewKeyboard)
 : sets whether adding a new keyboard is allowed
 

--- a/android/docs/engine/KMManager/setBannerOptions.md
+++ b/android/docs/engine/KMManager/setBannerOptions.md
@@ -4,7 +4,7 @@ title: KMManager.setBannerOptions()
 
 ## Summary
 
-The **`setBannerOoptions()`** method sends options to the KeymanWeb engine for controlling whether to generate predictions.
+The **`setBannerOptions()`** method sets options relating to the predictive text banner, such as controlling whether to enable predictions.
 
 ## Syntax
 

--- a/android/docs/engine/KMManager/setBannerOptions.md
+++ b/android/docs/engine/KMManager/setBannerOptions.md
@@ -1,0 +1,52 @@
+---
+title: KMManager.setBannerOptions()
+---
+
+## Summary
+
+The **`setBannerOoptions()`** method sends options to the KeymanWeb engine for controlling whether to generate predictions.
+
+## Syntax
+
+``` javascript
+KMManager.setBannerOptions(boolean mayPredict, KeyboardType keyboardType)
+```
+
+### Parameters
+
+`mayPredict`
+:   If `false`, KeymanWeb engine will disable predications and not show suggestions on the banner.
+
+`keyboardType`
+:   The keyboard type. `KEYBOARD_TYPE_INAPP` or
+    `KEYBOARD_TYPE_SYSTEM`.
+
+## Description
+
+Use this method to enable or disable the KeymanWeb engine from generating and displaying predictions on the suggestion banner.
+
+## Examples
+
+### Example: Using `setBannerOptions()`
+
+The following script illustrate the use of `setBannerOptions()`:
+
+``` javascript
+
+    // Temporarily disable predictions on certain fields (e.g. hidden password field or numeric)
+    inputType = attribute.inputType;
+    KMManager.setPredictionsSuspended(inputType, KeyboardType.KEYBOARD_TYPE_SYSTEM);
+    if (KMManager.getPredictionsSuspended(KeyboardType.KEYBOARD_TYPE_SYSTEM)) {
+      KMManager.setBannerOptions(false, KeyboardType.KEYBOARD_TYPE_SYSTEM);
+      // Set the system keyboard HTML banner
+      BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
+    }
+```
+
+## History
+Added in Keyman Engine for Android 18.0.
+
+## See also
+
+-   [`getPredictionsSuspended`](getPredictionsSuspended)
+-   [`setPredictionsSuspended`](setPredictionsSuspended)

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -138,7 +138,9 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
         // Temporarily disable predictions on certain fields (e.g. hidden password field or numeric)
         KMManager.setPredictionsSuspended(inputType, KeyboardType.KEYBOARD_TYPE_SYSTEM);
         if (KMManager.getPredictionsSuspended(KeyboardType.KEYBOARD_TYPE_SYSTEM)) {
-            KMManager.setBannerOptions(false);
+          KMManager.setBannerOptions(false, KeyboardType.KEYBOARD_TYPE_SYSTEM);
+          // Set the system keyboard HTML banner
+          BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
         } else if (KMManager.isKeyboardLoaded(KeyboardType.KEYBOARD_TYPE_SYSTEM)){
           // Check if predictions needs to be re-enabled per Settings preference
           Context appContext = getApplicationContext();
@@ -147,7 +149,9 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
             String langId = kbInfo.getLanguageID();
             SharedPreferences prefs = appContext.getSharedPreferences(appContext.getString(R.string.kma_prefs_name), Context.MODE_PRIVATE);
             boolean mayPredict = prefs.getBoolean(KMManager.getLanguagePredictionPreferenceKey(langId), true);
-            KMManager.setBannerOptions(mayPredict);
+            KMManager.setBannerOptions(mayPredict, KeyboardType.KEYBOARD_TYPE_SYSTEM);
+          } else {
+            KMManager.setBannerOptions(false, KeyboardType.KEYBOARD_TYPE_SYSTEM);
           }
         }
 


### PR DESCRIPTION
Follows #13546

While cleaning up the Keyman Engine for Android 18.0 API, this adds a required parameter `KeyboardType` to `setBannerOptions()` since it was never documented as an API call (in use since Keyman 12.0)...

```java
KMManager.setBannerOptions(boolean mayPredict, KeyboardType keyboardType)
```

`setBannerOptions()` - Use this call to enable or disable the KeymanWeb engine from generating and displaying predictions on the suggestion banner.

This PR also updates the FirstVoices for Android system keyboard to match the banner pattern of Keyman for Android.

@keymanapp-test-bot skip

