### PR TITLE
fix(windows): reload right modifier key option

### DIFF
--- a/windows/src/engine/keyman32/hotkeys.cpp
+++ b/windows/src/engine/keyman32/hotkeys.cpp
@@ -40,6 +40,7 @@ Hotkeys *Hotkeys::Instance() {   // I4326
   if(g_Hotkeys == NULL) {
     g_Hotkeys = new Hotkeys;
     g_Hotkeys->Load();   // I4390
+    g_Hotkeys->load_right_modifier_hotkey_option();
   }
 
   return g_Hotkeys;
@@ -64,6 +65,7 @@ void Hotkeys::Reload() {   // I4326   // I4390
   }
 
   hotkeys->Load();   // I4390
+  hotkeys->load_right_modifier_hotkey_option();
 }
 
 void Hotkeys::Load() {   // I4390
@@ -143,6 +145,22 @@ Hotkey *Hotkeys::GetHotkey(DWORD hotkey)
     }
   }
 	return NULL;
+}
+
+void Hotkeys::load_right_modifier_hotkey_option() {
+  if (GetCurrentThreadId() == Globals::get_InitialisingThread()) {
+    m_allow_right_modifier_hotkey = FALSE; // Default to off
+    RegistryReadOnly reg(HKEY_CURRENT_USER);
+    if (reg.OpenKeyReadOnly(REGSZ_KeymanCU)) {
+      if (reg.ValueExists(REGSZ_AllowRightModifierHotKey)) {
+        m_allow_right_modifier_hotkey = !!reg.ReadInteger(REGSZ_AllowRightModifierHotKey);
+      }
+    }
+  }
+}
+
+BOOL Hotkeys::allow_right_modifier_hotkey() {
+  return m_allow_right_modifier_hotkey;
 }
 
 #endif

--- a/windows/src/engine/keyman32/hotkeys.cpp
+++ b/windows/src/engine/keyman32/hotkeys.cpp
@@ -40,7 +40,6 @@ Hotkeys *Hotkeys::Instance() {   // I4326
   if(g_Hotkeys == NULL) {
     g_Hotkeys = new Hotkeys;
     g_Hotkeys->Load();   // I4390
-    g_Hotkeys->LoadRightModifierHotkeyOption();
   }
 
   return g_Hotkeys;
@@ -65,13 +64,15 @@ void Hotkeys::Reload() {   // I4326   // I4390
   }
 
   hotkeys->Load();   // I4390
-  hotkeys->LoadRightModifierHotkeyOption();
 }
 
 void Hotkeys::Load() {   // I4390
 	SendDebugEntry();
 	m_nHotkeys = 0;
-	RegistryReadOnly reg(HKEY_CURRENT_USER);
+
+  LoadRightModifierHotkeyOption();
+
+  RegistryReadOnly reg(HKEY_CURRENT_USER);
 
   /* Load interface hotkeys */
 

--- a/windows/src/engine/keyman32/hotkeys.cpp
+++ b/windows/src/engine/keyman32/hotkeys.cpp
@@ -40,7 +40,7 @@ Hotkeys *Hotkeys::Instance() {   // I4326
   if(g_Hotkeys == NULL) {
     g_Hotkeys = new Hotkeys;
     g_Hotkeys->Load();   // I4390
-    g_Hotkeys->load_right_modifier_hotkey_option();
+    g_Hotkeys->LoadRightModifierHotkeyOption();
   }
 
   return g_Hotkeys;
@@ -65,7 +65,7 @@ void Hotkeys::Reload() {   // I4326   // I4390
   }
 
   hotkeys->Load();   // I4390
-  hotkeys->load_right_modifier_hotkey_option();
+  hotkeys->LoadRightModifierHotkeyOption();
 }
 
 void Hotkeys::Load() {   // I4390
@@ -147,20 +147,22 @@ Hotkey *Hotkeys::GetHotkey(DWORD hotkey)
 	return NULL;
 }
 
-void Hotkeys::load_right_modifier_hotkey_option() {
-  if (GetCurrentThreadId() == Globals::get_InitialisingThread()) {
-    m_allow_right_modifier_hotkey = FALSE; // Default to off
-    RegistryReadOnly reg(HKEY_CURRENT_USER);
-    if (reg.OpenKeyReadOnly(REGSZ_KeymanCU)) {
-      if (reg.ValueExists(REGSZ_AllowRightModifierHotKey)) {
-        m_allow_right_modifier_hotkey = !!reg.ReadInteger(REGSZ_AllowRightModifierHotKey);
-      }
+void Hotkeys::LoadRightModifierHotkeyOption() {
+  m_AllowRightModifierHotkey = FALSE; // Default to off
+  RegistryReadOnly reg(HKEY_CURRENT_USER);
+  if (reg.OpenKeyReadOnly(REGSZ_KeymanCU)) {
+    if (reg.ValueExists(REGSZ_AllowRightModifierHotKey)) {
+      m_AllowRightModifierHotkey = !!reg.ReadInteger(REGSZ_AllowRightModifierHotKey);
     }
   }
 }
 
-BOOL Hotkeys::allow_right_modifier_hotkey() {
-  return m_allow_right_modifier_hotkey;
+BOOL Hotkeys::AllowRightModifierHotkey() {
+  if (GetCurrentThreadId() != Globals::get_InitialisingThread()) {
+    OutputThreadDebugString("Unexpected: no other thread should be attempting read allow right modifier option");
+    return FALSE;
+  }
+  return m_AllowRightModifierHotkey;
 }
 
 #endif

--- a/windows/src/engine/keyman32/hotkeys.h
+++ b/windows/src/engine/keyman32/hotkeys.h
@@ -39,10 +39,14 @@ class Hotkeys
 private:
 	int m_nHotkeys;
 	Hotkey m_hotkeys[MAX_HOTKEYS];
+  BOOL m_allow_right_modifier_hotkey;
 	void Load();
+  
 public:
 	Hotkey *GetHotkey(DWORD hotkey);
   static void Reload();   // I4326
   static Hotkeys *Instance();   // I4326
   static void Unload();
+  void load_right_modifier_hotkey_option();
+  BOOL allow_right_modifier_hotkey();
  };

--- a/windows/src/engine/keyman32/hotkeys.h
+++ b/windows/src/engine/keyman32/hotkeys.h
@@ -1,18 +1,18 @@
 /*
   Name:             hotkeys
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      1 Aug 2006
 
   Modified Date:    25 Oct 2016
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          01 Aug 2006 - mcdurdin - Initial version
                     11 Dec 2009 - mcdurdin - I934 - x64 - Initial version
                     03 Aug 2014 - mcdurdin - I4326 - V9.0 - Switch-off hotkey not working, then keyboard hotkey stopped working (win 8.1 jeremy) [High]
@@ -39,14 +39,13 @@ class Hotkeys
 private:
 	int m_nHotkeys;
 	Hotkey m_hotkeys[MAX_HOTKEYS];
-  BOOL m_allow_right_modifier_hotkey;
+  BOOL m_AllowRightModifierHotkey;
 	void Load();
-  
+  void LoadRightModifierHotkeyOption();
 public:
 	Hotkey *GetHotkey(DWORD hotkey);
   static void Reload();   // I4326
   static Hotkeys *Instance();   // I4326
   static void Unload();
-  void load_right_modifier_hotkey_option();
-  BOOL allow_right_modifier_hotkey();
+  BOOL AllowRightModifierHotkey();
  };

--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -151,14 +151,18 @@ LRESULT _kmnLowLevelKeyboardProc(
   // #5190: Don't cache modifier state because sometimes we won't receive
   // modifier change events (e.g. on lock screen)
   FHotkeyShiftState = 0;
+  BOOL AllowRightModifierHotkey = FALSE;
   Hotkeys* hotkeys  = Hotkeys::Instance();
+  if (hotkeys) {
+    AllowRightModifierHotkey = hotkeys->AllowRightModifierHotkey();
+  }
 
   if (GetKeyState(VK_LCONTROL) < 0) {
     FHotkeyShiftState |= HK_CTRL;
   }
 
   if (GetKeyState(VK_RCONTROL) < 0) {
-    FHotkeyShiftState |= hotkeys->AllowRightModifierHotkey() ? HK_CTRL : HK_RCTRL_INVALID;
+    FHotkeyShiftState |= AllowRightModifierHotkey ? HK_CTRL : HK_RCTRL_INVALID;
   }
 
   if (GetKeyState(VK_LMENU) < 0) {
@@ -166,14 +170,14 @@ LRESULT _kmnLowLevelKeyboardProc(
   }
 
   if (GetKeyState(VK_RMENU) < 0) {
-    FHotkeyShiftState |= hotkeys->AllowRightModifierHotkey() ? HK_ALT : HK_RALT_INVALID;
+    FHotkeyShiftState |= AllowRightModifierHotkey ? HK_ALT : HK_RALT_INVALID;
   }
 
   if (GetKeyState(VK_LSHIFT) < 0) {
     FHotkeyShiftState |= HK_SHIFT;
   }
   if (GetKeyState(VK_RSHIFT) < 0) {
-    FHotkeyShiftState |= hotkeys->AllowRightModifierHotkey() ? HK_SHIFT : HK_RSHIFT_INVALID;
+    FHotkeyShiftState |= AllowRightModifierHotkey ? HK_SHIFT : HK_RSHIFT_INVALID;
   }
 
   //TODO: #8064. Can remove debug message once issue #8064 is resolved

--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -158,7 +158,7 @@ LRESULT _kmnLowLevelKeyboardProc(
   }
 
   if (GetKeyState(VK_RCONTROL) < 0) {
-    FHotkeyShiftState |= hotkeys->allow_right_modifier_hotkey() ? HK_CTRL : HK_RCTRL_INVALID;
+    FHotkeyShiftState |= hotkeys->AllowRightModifierHotkey() ? HK_CTRL : HK_RCTRL_INVALID;
   }
 
   if (GetKeyState(VK_LMENU) < 0) {
@@ -166,14 +166,14 @@ LRESULT _kmnLowLevelKeyboardProc(
   }
 
   if (GetKeyState(VK_RMENU) < 0) {
-    FHotkeyShiftState |= hotkeys->allow_right_modifier_hotkey() ? HK_ALT : HK_RALT_INVALID;
+    FHotkeyShiftState |= hotkeys->AllowRightModifierHotkey() ? HK_ALT : HK_RALT_INVALID;
   }
 
   if (GetKeyState(VK_LSHIFT) < 0) {
     FHotkeyShiftState |= HK_SHIFT;
   }
   if (GetKeyState(VK_RSHIFT) < 0) {
-    FHotkeyShiftState |= hotkeys->allow_right_modifier_hotkey() ? HK_SHIFT : HK_RSHIFT_INVALID;
+    FHotkeyShiftState |= hotkeys->AllowRightModifierHotkey() ? HK_SHIFT : HK_RSHIFT_INVALID;
   }
 
   //TODO: #8064. Can remove debug message once issue #8064 is resolved

--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -129,25 +129,6 @@ BOOL IsTouchPanelVisible() {
   return touchPanelVisible;
 }
 
-/*
-  Cache AllowRightModifierHotKey for this session
-*/
-BOOL AllowRightModifierHotKey() {
-  static BOOL flag_AllowRightModifierHotKey = FALSE;
-  static BOOL loaded = FALSE;
-
-  if (!loaded) {
-    RegistryReadOnly reg(HKEY_CURRENT_USER);
-    if (reg.OpenKeyReadOnly(REGSZ_KeymanCU)) {
-      if (reg.ValueExists(REGSZ_AllowRightModifierHotKey)) {
-        flag_AllowRightModifierHotKey = !!reg.ReadInteger(REGSZ_AllowRightModifierHotKey);
-      }
-    }
-    loaded = TRUE; // Set loaded to TRUE whether or not the key exists
-  }
-  return flag_AllowRightModifierHotKey;
-}
-
 LRESULT _kmnLowLevelKeyboardProc(
   _In_  int nCode,
   _In_  WPARAM wParam,
@@ -170,13 +151,14 @@ LRESULT _kmnLowLevelKeyboardProc(
   // #5190: Don't cache modifier state because sometimes we won't receive
   // modifier change events (e.g. on lock screen)
   FHotkeyShiftState = 0;
+  Hotkeys* hotkeys  = Hotkeys::Instance();
 
   if (GetKeyState(VK_LCONTROL) < 0) {
     FHotkeyShiftState |= HK_CTRL;
   }
 
   if (GetKeyState(VK_RCONTROL) < 0) {
-    FHotkeyShiftState |= AllowRightModifierHotKey() ? HK_CTRL : HK_RCTRL_INVALID;
+    FHotkeyShiftState |= hotkeys->allow_right_modifier_hotkey() ? HK_CTRL : HK_RCTRL_INVALID;
   }
 
   if (GetKeyState(VK_LMENU) < 0) {
@@ -184,14 +166,14 @@ LRESULT _kmnLowLevelKeyboardProc(
   }
 
   if (GetKeyState(VK_RMENU) < 0) {
-    FHotkeyShiftState |= AllowRightModifierHotKey() ? HK_ALT : HK_RALT_INVALID;
+    FHotkeyShiftState |= hotkeys->allow_right_modifier_hotkey() ? HK_ALT : HK_RALT_INVALID;
   }
 
   if (GetKeyState(VK_LSHIFT) < 0) {
     FHotkeyShiftState |= HK_SHIFT;
   }
   if (GetKeyState(VK_RSHIFT) < 0) {
-    FHotkeyShiftState |= AllowRightModifierHotKey() ? HK_SHIFT : HK_RSHIFT_INVALID;
+    FHotkeyShiftState |= hotkeys->allow_right_modifier_hotkey() ? HK_SHIFT : HK_RSHIFT_INVALID;
   }
 
   //TODO: #8064. Can remove debug message once issue #8064 is resolved


### PR DESCRIPTION
Fixes: #13440

This refactors the caching of the right modifier key used in the hotkeys option. In the lowlevelhook you couldn't reset the cached value as you could access the static loaded bool value. 
It is now part of the hotkeys class, which is a more logical encapsulation of the logic associated with the hotkeys.

# User Testing
## TEST_LANGUAGE_HOTKEYS_RIGHT_SIDE

For this test the and right modifier keys will trigger the hotkeys.  It will also test that you can change the option to allow the right modifier key for hotkeys, and it works without requiring a restart of Keyman.


1. Install Keyman
2. Install some keyboard layouts Tamil and IPA SIL
3. Open Configuration and assign hotkeys to Ctrl+G to Tamil and
4. Ctrl+Shift+Ito IPA SIL
5. In Configuration Options tab uncheck the check box for "Use right modifier for hotkeys"
6. Open Notepad and type some text
7. Attempt Switch to Tamil using the Hotkey press Right Ctrl+G
8. Verify that the switching to the Tamil Keyboard does not not occur.
9. In Configuration Options tab check the check box for "Use right modifier for hotkeys"
10. In Notepad and type some text
11. Attempt Switch to Tamil using the Hotkey press Right Ctrl+G
12. Verify that it has switched in the task and language bar to Tamil and type some text.
13. Switch to IPA SIL using the Hotkey press Ctrl+Right Shift+I
14. Verify it has it has switched in the task and language bar to IPA SIL and type some text.