### PR TITLE
fix(android): Add dimensions for 320+dpi phones in landscape

### DIFF
--- a/android/KMEA/app/src/main/res/values-land-xhdpi/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-land-xhdpi/dimens.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dimens for Landscape (Tablet 7") -->
+<resources>
+    <dimen name="banner_height">50dp</dimen>
+    <dimen name="keyboard_height">140dp</dimen>
+    <dimen name="key_width">73.5dp</dimen>
+    <dimen name="key_height">58.5dp</dimen>
+    <dimen name="popup_arrow_width">32dp</dimen>
+    <dimen name="popup_arrow_height">12dp</dimen>
+    <dimen name="popup_margin">6dp</dimen>
+    <dimen name="popup_padding">4dp</dimen>
+    <dimen name="popup_offset_y">8dp</dimen>
+    <dimen name="help_bubble_width">125dp</dimen>
+    <dimen name="help_bubble_height">85dp</dimen>
+    <dimen name="help_bubble_offset_x">0.5dp</dimen>
+    <dimen name="help_bubble_offset_y">8dp</dimen>
+</resources>

--- a/android/KMEA/app/src/main/res/values-land-xhdpi/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-land-xhdpi/dimens.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Dimens for Landscape (Tablet 7") -->
+<!-- Dimens for Landscape (Extra-high-density ~320dpi) -->
 <resources>
     <dimen name="banner_height">50dp</dimen>
     <dimen name="keyboard_height">140dp</dimen>
-    <dimen name="key_width">73.5dp</dimen>
-    <dimen name="key_height">58.5dp</dimen>
-    <dimen name="popup_arrow_width">32dp</dimen>
-    <dimen name="popup_arrow_height">12dp</dimen>
+    <dimen name="key_width">83.5dp</dimen>
+    <dimen name="key_height">78.5dp</dimen>
+    <dimen name="popup_arrow_width">38dp</dimen>
+    <dimen name="popup_arrow_height">14dp</dimen>
     <dimen name="popup_margin">6dp</dimen>
     <dimen name="popup_padding">4dp</dimen>
     <dimen name="popup_offset_y">8dp</dimen>
@@ -14,4 +14,5 @@
     <dimen name="help_bubble_height">85dp</dimen>
     <dimen name="help_bubble_offset_x">0.5dp</dimen>
     <dimen name="help_bubble_offset_y">8dp</dimen>
+    <dimen name="fab_margin">6dp</dimen>
 </resources>

--- a/android/KMEA/app/src/main/res/values-land-xhdpi/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-land-xhdpi/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Dimens for Landscape (Extra-high-density ~320dpi) -->
 <resources>
-    <dimen name="banner_height">50dp</dimen>
+    <dimen name="banner_height">30dp</dimen>
     <dimen name="keyboard_height">140dp</dimen>
     <dimen name="key_width">83.5dp</dimen>
     <dimen name="key_height">78.5dp</dimen>

--- a/android/docs/engine/KMManager/applyKeyboardHeight.md
+++ b/android/docs/engine/KMManager/applyKeyboardHeight.md
@@ -31,6 +31,7 @@ For reference, here's a table of the default Keyman keyboard heights for various
 |-----------------------------------|---------------------|
 | Default handset in portrait | 205 |
 | Default handset in landscape | 150 |
+| Extra High Density handset in landscape | 140 |
 | 7" tablet in portrait | 305 |
 | 7" tablet in landscape | 200 |
 | 10" tablet in portrait | 405 |


### PR DESCRIPTION
Fixes #13584

Getting in a crowd-pleaser for @MattGyverLee who reported the default landscape keyboard height on a Pixel 8a device is too small to be usable.

This PR adds dimensions for that pixel density
The Pixel 8a is 430dpi which corresponds to `values-land-xhdpi` (320dpi+ up to 480dpi)

First commit copied values-sw600dp-land as a starting point.

**Reference**
https://developer.android.com/guide/topics/resources/providing-resources.html#table2 (screen pixel density)

## Screenshots

### Current (as reported on the issue)
![image](https://github.com/user-attachments/assets/88d7ef41-9d56-43f8-a005-7e3e0445eafc)

![image](https://github.com/user-attachments/assets/1710d1aa-9acd-43a6-900e-66dbbf35cfd8)

### With this change

![1000022695](https://github.com/user-attachments/assets/7248aa97-1753-4d05-b1d0-a698654102c7)

@keymanapp-test-bot skip

