### PR TITLE
fix(developer): remove redundant keyboard fields from .kps

### DIFF
--- a/common/windows/delphi/packages/PackageInfo.pas
+++ b/common/windows/delphi/packages/PackageInfo.pas
@@ -315,14 +315,11 @@ type
 
   TPackageKeyboard = class(TPackageBaseObject)
   private
-    FName: string;
     FOSKFont: TPackageContentFile;
     FID: string;
-    FRTL: Boolean;
     FDisplayFont: TPackageContentFile;
     FLanguages: TPackageKeyboardLanguageList;
     FExamples: TPackageKeyboardExampleList;
-    FVersion: string;
     FMinKeymanVersion: string;
     FWebOSKFonts: TPackageContentFileReferenceList;
     FWebDisplayFonts: TPackageContentFileReferenceList;
@@ -336,10 +333,7 @@ type
     constructor Create(APackage: TPackage); override;
     destructor Destroy; override;
     procedure Assign(Source: TPackageKeyboard); virtual;
-    property Name: string read FName write FName;
     property ID: string read FID write FID;
-    property RTL: Boolean read FRTL write FRTL;
-    property Version: string read FVersion write FVersion;
     property Languages: TPackageKeyboardLanguageList read FLanguages;
     property Examples: TPackageKeyboardExampleList read FExamples;
     property OSKFont: TPackageContentFile read FOSKFont write SetOSKFont;
@@ -528,10 +522,7 @@ const
 const
   SXML_PackageKeyboards = 'Keyboards';
   SXML_PackageKeyboard = 'Keyboard';
-  SXML_PackageKeyboard_Name = 'Name';
   SXML_PackageKeyboard_ID = 'ID';
-  SXML_PackageKeyboard_Version = 'Version';
-  SXML_PackageKeyboard_RTL = 'RTL';
   SXML_PackageKeyboard_OSKFont = 'OSKFont';
   SXML_PackageKeyboard_DisplayFont = 'DisplayFont';
   SXML_PackageKeyboard_Languages = 'Languages';
@@ -620,10 +611,7 @@ const
   SJSON_Files_CopyLocation = 'copyLocation';
 
   SJSON_Keyboards = 'keyboards';
-  SJSON_Keyboard_Name = 'name';
   SJSON_Keyboard_ID = 'id';
-  SJSON_Keyboard_RTL = 'rtl';
-  SJSON_Keyboard_Version = 'version';
   SJSON_Keyboard_OSKFont = 'oskFont';
   SJSON_Keyboard_DisplayFont = 'displayFont';
 
@@ -2023,11 +2011,8 @@ var
   FLanguage: TPackageKeyboardLanguage;
   FExample: TPackageKeyboardExample;
 begin
-  FName := Source.Name;
   FID := Source.ID;
-  FVersion := Source.Version;
   FMinKeymanVersion := Source.FMinKeymanVersion;
-  FRTL := Source.RTL;
   if Assigned(Source.OSKFont)
     then FOSKFont := Package.Files.FromFileNameEx(Source.OSKFont.FileName)
     else FOSKFont := nil;
@@ -2186,10 +2171,7 @@ begin
         Break;
 
       keyboard := TPackageKeyboard.Create(Package);
-      keyboard.Name := AIni.ReadString(FSectionName, SXML_PackageKeyboard_Name, '');
       keyboard.ID := AIni.ReadString(FSectionName, SXML_PackageKeyboard_ID, '');
-      keyboard.Version := AIni.ReadString(FSectionName, SXML_PackageKeyboard_Version, '1.0');
-      keyboard.RTL := AIni.ReadBool(FSectionName, SXML_PackageKeyboard_RTL, False);
       keyboard.OSKFont := Package.Files.FromFileNameEx(AIni.ReadString(FSectionName, SXML_PackageKeyboard_OSKFont, ''));
       keyboard.DisplayFont := Package.Files.FromFileNameEx(AIni.ReadString(FSectionName, SXML_PackageKeyboard_DisplayFont, ''));
 
@@ -2231,10 +2213,7 @@ begin
     AKeyboard := ANode.Items[i] as TJSONObject;
 
     keyboard := TPackageKeyboard.Create(Package);
-    keyboard.Name := GetJsonValueString(AKeyboard, SJSON_Keyboard_Name);
     keyboard.ID := GetJsonValueString(AKeyboard,SJSON_Keyboard_ID);
-    keyboard.Version := GetJsonValueString(AKeyboard, SJSON_Keyboard_Version);
-    keyboard.RTL := GetJsonValueBool(AKeyboard, SJSON_Keyboard_RTL);
     keyboard.OSKFont := Package.Files.FromFileNameEx(GetJsonValueString(AKeyboard, SJSON_Keyboard_OSKFont));
     keyboard.DisplayFont := Package.Files.FromFileNameEx(GetJsonValueString(AKeyboard, SJSON_Keyboard_DisplayFont));
     keyboard.Languages.LoadJSON(AKeyboard);
@@ -2266,10 +2245,7 @@ begin
     AKeyboard := ANode.ChildNodes[i];
 
     keyboard := TPackageKeyboard.Create(Package);
-    keyboard.Name := XmlVarToStr(AKeyboard.ChildValues[SXML_PackageKeyboard_Name]);
     keyboard.ID := XmlVarToStr(AKeyboard.ChildValues[SXML_PackageKeyboard_ID]);
-    keyboard.Version := XmlVarToStr(AKeyboard.ChildValues[SXML_PackageKeyboard_Version]);
-    keyboard.RTL := ANode.ChildNodes.IndexOf(SXML_PackageKeyboard_RTL) >= 0;
     keyboard.OSKFont := Package.Files.FromFileNameEx(XmlVarToStr(AKeyboard.ChildValues[SXML_PackageKeyboard_OSKFont]));
     keyboard.DisplayFont := Package.Files.FromFileNameEx(XmlVarToStr(AKeyboard.ChildValues[SXML_PackageKeyboard_DisplayFont]));
 
@@ -2300,10 +2276,7 @@ begin
   for i := 0 to Count-1 do
   begin
     FSectionName := 'Keyboard'+IntToStr(i);
-    AIni.WriteString(FSectionName, SXML_PackageKeyboard_Name, Items[i].Name);
     AIni.WriteString(FSectionName, SXML_PackageKeyboard_ID, Items[i].ID);
-    AIni.WriteString(FSectionName, SXML_PackageKeyboard_Version, Items[i].Version);
-    if Items[i].RTL then AIni.WriteBool(FSectionName, SXML_PackageKeyboard_RTL, True);
     if Assigned(Items[i].OSKFont) then
       AIni.WriteString(FSectionName, SXML_PackageKeyboard_OSKFont, Items[i].OSKFont.RelativeFileName);
     if Assigned(Items[i].DisplayFont) then
@@ -2335,10 +2308,7 @@ begin
     AKeyboard := TJSONObject.Create;
     AKeyboards.Add(AKeyboard);
 
-    AKeyboard.AddPair(SJSON_Keyboard_Name, Items[i].Name);
     AKeyboard.AddPair(SJSON_Keyboard_ID, Items[i].ID);
-    AKeyboard.AddPair(SJSON_Keyboard_Version, Items[i].Version);
-    if Items[i].RTL then AKeyboard.AddPair(SJSON_Keyboard_RTL, TJSONTrue.Create);
     if Assigned(Items[i].OSKFont) then
       AKeyboard.AddPair(SJSON_Keyboard_OSKFont, Items[i].OSKFont.RelativeFileName);
     if Assigned(Items[i].DisplayFont) then
@@ -2372,11 +2342,7 @@ begin
   begin
     AKeyboard := ANode.AddChild(SXML_PackageKeyboard);
 
-    AKeyboard.ChildNodes[SXML_PackageKeyboard_Name].NodeValue := Items[i].Name;
     AKeyboard.ChildNodes[SXML_PackageKeyboard_ID].NodeValue := Items[i].ID;
-    AKeyboard.ChildNodes[SXML_PackageKeyboard_Version].NodeValue := Items[i].Version;
-    if Items[i].RTL then
-      AKeyboard.ChildNodes[SXML_PackageKeyboard_RTL].NodeValue := True;
     if Assigned(Items[i].OSKFont) then
       AKeyboard.ChildNodes[SXML_PackageKeyboard_OSKFont].NodeValue := Items[i].OSKFont.RelativeFileName;
     if Assigned(Items[i].DisplayFont) then

--- a/developer/src/common/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
+++ b/developer/src/common/delphi/packages/Keyman.System.PackageInfoRefreshKeyboards.pas
@@ -120,15 +120,8 @@ begin
 
       if FillKeyboardDetails(pack.Files[i], pki) then
       begin
-        k.Name := pki.Name;
         k.ID := pki.ID;
-        k.Version := pki.Version;
         k.MinKeymanVersion := pki.MinKeymanVersion;
-        if IsKeyboardFileByName(pack.Files[i]) = ftJavascript then
-          // RTL flag is currently only relevant for KMW so although the
-          // information can be read from .kmx we only copy it over for
-          // js keyboards.
-          k.RTL := pki.RTL;
       end;
     end;
   end;

--- a/developer/src/common/web/utils/src/types/kps/kps-file.ts
+++ b/developer/src/common/web/utils/src/types/kps/kps-file.ts
@@ -113,12 +113,12 @@ export interface KpsFileRelatedPackage {
 }
 
 export interface KpsFileKeyboard {
-  Name: string;     /// the descriptive name of the keyboard
+  // Defined in .kps schema but not used: Name: string; #13593
   ID: string;       /// the keyboard identifier, equal to the basename of the keyboard file sans extension
-  Version: string;
+  // Defined in .kps schema but not used: Version: string; #13593
   OSKFont?: string;
   DisplayFont?: string;
-  RTL?: string;
+  // Defined in .kps schema but not used: RTL?: string; #13593
   Languages?: KpsFileLanguages;
   Examples?: KpsFileLanguageExamples;
   /**

--- a/developer/src/common/web/utils/test/kps/kps-file-reader.tests.ts
+++ b/developer/src/common/web/utils/test/kps/kps-file-reader.tests.ts
@@ -47,8 +47,6 @@ describe('kps-file-reader', function () {
 
     assert.lengthOf(kps.Package.Keyboards.Keyboard, 1);
     assert.equal(kps.Package.Keyboards.Keyboard[0].ID, 'khmer_angkor');
-    assert.equal(kps.Package.Keyboards.Keyboard[0].Name, 'Khmer Angkor');
-    assert.equal(kps.Package.Keyboards.Keyboard[0].Version, '1.3');
 
     assert.lengthOf(kps.Package.Keyboards.Keyboard[0].Languages.Language, 1);
     assert.equal(kps.Package.Keyboards.Keyboard[0].Languages.Language[0]._, 'Central Khmer (Khmer, Cambodia)');

--- a/developer/src/kmc-generate/src/template/kmn-keyboard/source/keyboard.kps
+++ b/developer/src/kmc-generate/src/template/kmn-keyboard/source/keyboard.kps
@@ -38,9 +38,7 @@ $KVKS:    </File>
   </Files>
   <Keyboards>
     <Keyboard>
-      <Name>$NAME</Name>
       <ID>$ID</ID>
-      <Version>$VERSION</Version>
 $PACKAGE_LANGUAGES
     </Keyboard>
   </Keyboards>

--- a/developer/src/kmc-generate/src/template/ldml-keyboard/source/keyboard.kps
+++ b/developer/src/kmc-generate/src/template/ldml-keyboard/source/keyboard.kps
@@ -35,9 +35,7 @@
   </Files>
   <Keyboards>
     <Keyboard>
-      <Name>$NAME</Name>
       <ID>$ID</ID>
-      <Version>$VERSION</Version>
 $PACKAGE_LANGUAGES
     </Keyboard>
   </Keyboards>

--- a/developer/src/kmc-generate/test/fixtures/keyman-keyboard/sample/source/sample.kps
+++ b/developer/src/kmc-generate/test/fixtures/keyman-keyboard/sample/source/sample.kps
@@ -35,9 +35,7 @@
   </Files>
   <Keyboards>
     <Keyboard>
-      <Name>Sample Project</Name>
       <ID>sample</ID>
-      <Version>1.0</Version>
       <Languages>
         <Language ID="en">English</Language>
       </Languages>

--- a/developer/src/kmc-generate/test/fixtures/ldml-keyboard/sample/source/sample.kps
+++ b/developer/src/kmc-generate/test/fixtures/ldml-keyboard/sample/source/sample.kps
@@ -35,9 +35,7 @@
   </Files>
   <Keyboards>
     <Keyboard>
-      <Name>Sample Project</Name>
       <ID>sample</ID>
-      <Version>1.0</Version>
       <Languages>
         <Language ID="en">English</Language>
       </Languages>

--- a/developer/src/kmc-package/src/compiler/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/kmp-compiler.ts
@@ -13,7 +13,7 @@ import { PackageCompilerMessages } from './package-compiler-messages.js';
 import { PackageMetadataCollector } from './package-metadata-collector.js';
 import { KmpInfWriter } from './kmp-inf-writer.js';
 import { transcodeToCP1252 } from './cp1252.js';
-import { MIN_LM_FILEVERSION_KMP_JSON, PackageVersionValidator } from './package-version-validator.js';
+import { DEFAULT_KEYBOARD_VERSION, MIN_LM_FILEVERSION_KMP_JSON, PackageVersionValidator } from './package-version-validator.js';
 import { PackageKeyboardTargetValidator } from './package-keyboard-target-validator.js';
 import { PackageMetadataUpdater } from './package-metadata-updater.js';
 import { markdownToHTML } from './markdown.js';
@@ -292,10 +292,10 @@ export class KmpCompiler implements KeymanCompiler {
       kmp.keyboards = kps.Keyboards.Keyboard.map((keyboard: KpsFile.KpsFileKeyboard) => ({
         displayFont: keyboard.DisplayFont ? this.callbacks.path.basename(this.normalizePath(keyboard.DisplayFont)) : undefined,
         oskFont: keyboard.OSKFont ? this.callbacks.path.basename(this.normalizePath(keyboard.OSKFont)) : undefined,
-        name:keyboard.Name?.trim(),
+        name: '', // filled by PackageMetadataUpdater
         id:keyboard.ID?.trim(),
-        version:keyboard.Version?.trim(),
-        rtl:keyboard.RTL == 'True' ? true : undefined,
+        version: DEFAULT_KEYBOARD_VERSION,  // filled by PackageMetadataUpdater
+        rtl: false, // filled by PackageMetadataUpdater
         languages: keyboard.Languages?.Language?.length ?
           this.kpsLanguagesToKmpLanguages(keyboard.Languages.Language) :
           [],

--- a/developer/src/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
@@ -274,9 +274,7 @@ begin
 
     // Add metadata about the keyboard
     pk := TPackageKeyboard.Create(kps);
-    pk.Name := Name;
     pk.ID := ID;
-    pk.Version := Version;
     kps.Keyboards.Add(pk);
 
     SetPackageLanguageMetadata(kps, pk.Languages);

--- a/developer/src/kmconvert/Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas
@@ -233,9 +233,7 @@ begin
 
     // Add metadata about the keyboard
     pk := TPackageKeyboard.Create(kps);
-    pk.Name := Name;
     pk.ID := ID;
-    pk.Version := Version;
     kps.Keyboards.Add(pk);
 
     SetPackageLanguageMetadata(kps, pk.Languages);

--- a/developer/src/test/auto/package-info/PackageInfoTest.pas
+++ b/developer/src/test/auto/package-info/PackageInfoTest.pas
@@ -278,9 +278,7 @@ begin
   Assert.AreEqual(k1.Keyboards.Count, k2.Keyboards.Count);
   for i := 0 to k1.Keyboards.Count - 1 do
   begin
-    Assert.AreEqual(k1.Keyboards[i].Name, k2.Keyboards[i].Name);
     Assert.AreEqual(k1.Keyboards[i].ID, k2.Keyboards[i].ID);
-    Assert.AreEqual(k1.Keyboards[i].Version, k2.Keyboards[i].Version);
     Assert.IsTrue(
       (
         Assigned(k1.Keyboards[i].OSKFont) and

--- a/developer/src/tike/child/UfrmPackageEditor.dfm
+++ b/developer/src/tike/child/UfrmPackageEditor.dfm
@@ -184,7 +184,7 @@ inherited frmPackageEditor: TfrmPackageEditor
     Top = 0
     Width = 965
     Height = 622
-    ActivePage = pageDetails
+    ActivePage = pageKeyboards
     Align = alClient
     Images = modActionsMain.ilEditorPages
     MultiLine = True
@@ -390,30 +390,11 @@ inherited frmPackageEditor: TfrmPackageEditor
         end
         object lblKeyboardFiles: TLabel
           Left = 15
-          Top = 516
+          Top = 492
           Width = 26
           Height = 13
           Anchors = [akLeft, akBottom]
           Caption = 'Files:'
-          ExplicitTop = 341
-        end
-        object lblKeyboardDescription: TLabel
-          Left = 15
-          Top = 489
-          Width = 62
-          Height = 13
-          Anchors = [akLeft, akBottom]
-          Caption = 'Description:'
-          ExplicitTop = 314
-        end
-        object lblKeyboardVersion: TLabel
-          Left = 15
-          Top = 568
-          Width = 41
-          Height = 13
-          Anchors = [akLeft, akBottom]
-          Caption = 'Version:'
-          ExplicitTop = 393
         end
         object lblKeyboardOSKFont: TLabel
           Left = 260
@@ -436,15 +417,6 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 13
           Caption = 'Languages'
           FocusControl = gridKeyboardLanguages
-        end
-        object lblKeyboardRTL: TLabel
-          Left = 15
-          Top = 595
-          Width = 75
-          Height = 13
-          Anchors = [akLeft, akBottom]
-          Caption = 'Is right-to-left:'
-          ExplicitTop = 420
         end
         object lblKeyboardExamples: TLabel
           Left = 260
@@ -478,38 +450,16 @@ inherited frmPackageEditor: TfrmPackageEditor
           TabOrder = 0
           OnClick = lbKeyboardsClick
         end
-        object editKeyboardDescription: TEdit
+        object memoKeyboardFiles: TMemo
           Left = 96
-          Top = 486
+          Top = 489
           Width = 148
-          Height = 21
+          Height = 70
           TabStop = False
           Anchors = [akLeft, akBottom]
           ParentColor = True
           ReadOnly = True
           TabOrder = 1
-        end
-        object memoKeyboardFiles: TMemo
-          Left = 96
-          Top = 513
-          Width = 148
-          Height = 46
-          TabStop = False
-          Anchors = [akLeft, akBottom]
-          ParentColor = True
-          ReadOnly = True
-          TabOrder = 2
-        end
-        object editKeyboardVersion: TEdit
-          Left = 96
-          Top = 565
-          Width = 148
-          Height = 21
-          TabStop = False
-          Anchors = [akLeft, akBottom]
-          ParentColor = True
-          ReadOnly = True
-          TabOrder = 3
         end
         object cbKeyboardOSKFont: TComboBox
           Left = 339
@@ -517,7 +467,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 174
           Height = 21
           Style = csDropDownList
-          TabOrder = 5
+          TabOrder = 2
           OnClick = cbKeyboardOSKFontClick
         end
         object cbKeyboardDisplayFont: TComboBox
@@ -526,7 +476,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 174
           Height = 21
           Style = csDropDownList
-          TabOrder = 6
+          TabOrder = 3
           OnClick = cbKeyboardDisplayFontClick
         end
         object gridKeyboardLanguages: TStringGrid
@@ -540,7 +490,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           FixedCols = 0
           RowCount = 9
           Options = [goFixedVertLine, goFixedHorzLine, goVertLine, goHorzLine, goColSizing, goRowSelect]
-          TabOrder = 7
+          TabOrder = 4
           OnClick = gridKeyboardLanguagesClick
           OnDblClick = gridKeyboardLanguagesDblClick
           ColWidths = (
@@ -553,7 +503,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 73
           Height = 25
           Caption = '&Add...'
-          TabOrder = 8
+          TabOrder = 5
           OnClick = cmdKeyboardAddLanguageClick
         end
         object cmdKeyboardRemoveLanguage: TButton
@@ -562,19 +512,8 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 72
           Height = 25
           Caption = '&Remove'
-          TabOrder = 10
+          TabOrder = 7
           OnClick = cmdKeyboardRemoveLanguageClick
-        end
-        object editKeyboardRTL: TEdit
-          Left = 96
-          Top = 592
-          Width = 148
-          Height = 21
-          TabStop = False
-          Anchors = [akLeft, akBottom]
-          ParentColor = True
-          ReadOnly = True
-          TabOrder = 4
         end
         object cmdKeyboardEditLanguage: TButton
           Left = 339
@@ -582,7 +521,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 73
           Height = 25
           Caption = 'Ed&it...'
-          TabOrder = 9
+          TabOrder = 6
           OnClick = cmdKeyboardEditLanguageClick
         end
         object gridKeyboardExamples: TStringGrid
@@ -596,7 +535,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           FixedCols = 0
           RowCount = 9
           Options = [goFixedVertLine, goFixedHorzLine, goVertLine, goHorzLine, goColSizing, goRowSelect]
-          TabOrder = 11
+          TabOrder = 8
           OnClick = gridKeyboardExamplesClick
           OnDblClick = gridKeyboardExamplesDblClick
           ColWidths = (
@@ -612,7 +551,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 25
           Anchors = [akLeft, akBottom]
           Caption = 'Add...'
-          TabOrder = 12
+          TabOrder = 9
           OnClick = cmdKeyboardAddExampleClick
         end
         object cmdKeyboardEditExample: TButton
@@ -622,7 +561,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 25
           Anchors = [akLeft, akBottom]
           Caption = 'Ed&it...'
-          TabOrder = 13
+          TabOrder = 10
           OnClick = cmdKeyboardEditExampleClick
         end
         object cmdKeyboardRemoveExample: TButton
@@ -632,7 +571,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 25
           Anchors = [akLeft, akBottom]
           Caption = '&Remove'
-          TabOrder = 14
+          TabOrder = 11
           OnClick = cmdKeyboardRemoveExampleClick
         end
         object cmdKeyboardWebOSKFonts: TButton
@@ -641,7 +580,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 75
           Height = 25
           Caption = 'Web fonts...'
-          TabOrder = 15
+          TabOrder = 12
           OnClick = cmdKeyboardWebOSKFontsClick
         end
         object cmdKeyboardWebDisplayFonts: TButton
@@ -650,7 +589,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 75
           Height = 25
           Caption = 'Web fonts...'
-          TabOrder = 16
+          TabOrder = 13
           OnClick = cmdKeyboardWebDisplayFontsClick
         end
       end

--- a/developer/src/tike/child/UfrmPackageEditor.pas
+++ b/developer/src/tike/child/UfrmPackageEditor.pas
@@ -138,12 +138,8 @@ type
     Label2: TLabel;
     Label3: TLabel;
     lblKeyboardFiles: TLabel;
-    lblKeyboardDescription: TLabel;
     lbKeyboards: TListBox;
-    editKeyboardDescription: TEdit;
     memoKeyboardFiles: TMemo;
-    lblKeyboardVersion: TLabel;
-    editKeyboardVersion: TEdit;
     lblKeyboardOSKFont: TLabel;
     cbKeyboardOSKFont: TComboBox;
     cbKeyboardDisplayFont: TComboBox;
@@ -153,8 +149,6 @@ type
     cmdKeyboardAddLanguage: TButton;
     cmdKeyboardRemoveLanguage: TButton;
     chkFollowKeyboardVersion: TCheckBox;
-    lblKeyboardRTL: TLabel;
-    editKeyboardRTL: TEdit;
     cmdKeyboardEditLanguage: TButton;
     panBuildMobile: TPanel;
     lblDebugHostCaption: TLabel;
@@ -1628,10 +1622,7 @@ begin
     k := SelectedKeyboard;
     if not Assigned(k) then
     begin
-      editKeyboardDescription.Text := '';
-      editKeyboardVersion.Text := '';
       memoKeyboardFiles.Text := '';
-      editKeyboardRTL.Text := '';
       cbKeyboardOSKFont.ItemIndex := -1;
       cbKeyboardDisplayFont.ItemIndex := -1;
       gridKeyboardLanguages.RowCount := 1;
@@ -1645,12 +1636,6 @@ begin
     // Details
 
     memoKeyboardFiles.Text := '';
-    editKeyboardDescription.Text := k.Name;
-    editKeyboardVersion.Text := k.Version;
-
-    if k.RTL
-      then editKeyboardRTL.Text := 'True'
-      else editKeyboardRTL.Text := 'False (or not .js format)';
 
     for i := 0 to pack.Files.Count - 1 do
       if SameText(TKeyboardUtils.KeyboardFileNameToID(pack.Files[i].FileName), k.ID) then
@@ -1779,12 +1764,8 @@ var
   e: Boolean;
 begin
   e := lbKeyboards.ItemIndex >= 0;
-  lblKeyboardDescription.Enabled := e;
-  editKeyboardDescription.Enabled := e;
   lblKeyboardFiles.Enabled := e;
   memoKeyboardFiles.Enabled := e;
-  lblKeyboardVersion.Enabled := e;
-  editKeyboardVersion.Enabled := e;
   lblKeyboardOSKFont.Enabled := e;
   cbKeyboardOSKFont.Enabled := e;
   lblKeyboardDisplayFont.Enabled := e;


### PR DESCRIPTION
The fields 'name', 'version', and 'rtl' were defined in the .kps file, but were not actually used by the compiler, as kmc-package reads the metadata from the keyboard file rather than relying on this data, which often is out of date. This led to confusion for keyboard authors, so this change removes that metadata from the package.

The one visible side-effect (apart from the data disappearing from future .kps files) is that the package editor no longer shows this metadata in the Keyboards view (but as it may be out-of-date, this is probably a good thing).

Updated package editor removes these three read-only fields from above/below the 'Files' field:

![image](https://github.com/user-attachments/assets/16d788a2-3fe7-40df-bc4b-5e717557b856)

Fixes: #13576
Fixes: #13593

# Full test report

I ran a full test of recompiling with the change against keyboards repo:

```bash
# run with 18.0.221-beta
unset KMC
# update package.json with 18.0.221-beta (or could do with jq...)
# npm ci # (if you have messed up your build)
./build.sh 
mkdir kmp-18-baseline
find {experimental,release} -name '*.kmp' | xargs -I % cp % ./kmp-18-baseline/
for d in kmp-18-baseline/*.kmp; do unzip -p $d kmp.json > $d.json; done

# run with beta compiler
export KMC="node /d/Projects/keyman/beta/developer/src/kmc"
./build.sh
mkdir kmp-18.0
find {experimental,release} -name '*.kmp' | xargs -I % cp % ./kmp-18.0/
for d in kmp-18.0/*.kmp; do unzip -p $d kmp.json > $d.json; done

# diff the results, ignoring JSON key order (which depends on insertion order in the compiler):
cd kmp-18.0
for d in *.json; do diff <(jq --sort-keys . ../kmp-18-baseline/$d) <(jq --sort-keys . $d); done
```

There were zero differences.

(It was probably possible to diff the old and new JSON files by text content rather than via jq, as I believe the key order would have been the same, but the jq pipe is a helpful technique to know!)

# User Testing

TEST_COMPILE: Load a keyboard project from the keyboards repository. Open the .kps file, make an inconsequential change, save it, and try and build the entire project. Verify that the project builds. Open the .kps file in a text editor, and verify that the fields `Package/Keyboards/Keyboard/Version`, `Package/Keyboards/Keyboard/RTL` (if previously present), and `Package/Keyboards/Keyboard/Name` have all been removed.

TEST_NEW_PROJECT: Create a new keyboard project and verify that it builds correctly