### PR TITLE
chore(developer): improve kmc-ldml 'invalid version' message

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
@@ -61,12 +61,14 @@ export class LdmlCompilerMessages {
   static Error_InvalidVersion = (o:{version: string}) => m(
     this.ERROR_InvalidVersion,
     `Version number '${def(o.version)}' must be a semantic version format string with 'major.minor.patch' components.`,
-    `The version number in the LDML keyboard file must be a [semantic version](https://semver.org) (semver) string.
-    This string has a format of three integers representing major, minor, and patch versions, separated by periods.
-    In the LDML keyboard specification, the full semver format is permitted, including pre-release suffix strings,
-    but the Keyman toolchain currently restricts the format to the three integer components.
+    `The version number in the LDML keyboard file must be a [semantic
+    version](https://semver.org) (semver) string. This string has a format of three
+    integers representing major, minor, and patch versions, separated by periods. In
+    the LDML keyboard specification, the full semver format is permitted, including
+    pre-release suffix strings, but the Keyman toolchain currently restricts the
+    format to the three integer components.
 
-    Example: \`"1.2.3"\``
+    Example: \`"1.12.3"\``
   );
 
   static ERROR_MustBeAtLeastOneLayerElement = SevError | 0x000E;

--- a/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
@@ -58,8 +58,16 @@ export class LdmlCompilerMessages {
   m(this.HINT_NoDisplayForMarker, `Key element with id "${def(o.id)}" has only marker output, but there is no matching display element by output or keyId. Keycap may be blank.`);
 
   static ERROR_InvalidVersion = SevError | 0x000D;
-  static Error_InvalidVersion = (o:{version: string}) =>
-  m(this.ERROR_InvalidVersion, `Version number '${def(o.version)}' must be a semantic version format string.`);
+  static Error_InvalidVersion = (o:{version: string}) => m(
+    this.ERROR_InvalidVersion,
+    `Version number '${def(o.version)}' must be a semantic version format string with 'major.minor.patch' components.`,
+    `The version number in the LDML keyboard file must be a [semantic version](https://semver.org) (semver) string.
+    This string has a format of three integers representing major, minor, and patch versions, separated by periods.
+    In the LDML keyboard specification, the full semver format is permitted, including pre-release suffix strings,
+    but the Keyman toolchain currently restricts the format to the three integer components.
+
+    Example: \`"1.2.3"\``
+  );
 
   static ERROR_MustBeAtLeastOneLayerElement = SevError | 0x000E;
   static Error_MustBeAtLeastOneLayerElement = () =>


### PR DESCRIPTION
Suggested by @Nnyny. Give more detail on the semantic version format for keyboard version, as well as details on the limitations to semver imposed by the Keyman toolchain.

@keymanapp-test-bot skip