### PR TITLE
feat(web): bundle trie-decoder with lexical models to maintain back-compatibility 💾

### DIFF
--- a/web/src/engine/predictive-text/templates/build.sh
+++ b/web/src/engine/predictive-text/templates/build.sh
@@ -34,6 +34,23 @@ function do_build() {
 
   # Declaration bundling.
   tsc --emitDeclarationOnly --outFile ./build/lib/index.d.ts
+
+  # Bundler definition
+  BUNDLE_CMD="node ${KEYMAN_ROOT}/web/src/tools/es-bundling/build/common-bundle.mjs"
+
+  # Bundles and minifies the back-compatibility trie-decoding functionality for inclusion in compiled models
+  # (Still needs a bit of rework to get it _just_ right, though.)
+  #
+  # May want to use the `global_name` esbuild setting to allow a directly-embeddable export, though that
+  # may in itself add extra overhead
+  $BUNDLE_CMD "${KEYMAN_ROOT}/web/src/engine/predictive-text/templates/src/decompressor-main.js" \
+    --out        "${KEYMAN_ROOT}/web/src/engine/predictive-text/templates/build/lib/decompressor.js" \
+    --charset    "utf8" \
+    --format     "iife" \
+    --globalName "triecompat" \
+    --sourceRoot "@keymanapp/keyman/web/src/engine/predictive-text/templates/build/lib" \
+    --target     "es6" \
+    --minify
 }
 
 function do_test() {

--- a/web/src/engine/predictive-text/templates/src/decompressor-main.ts
+++ b/web/src/engine/predictive-text/templates/src/decompressor-main.ts
@@ -1,0 +1,1 @@
+export { buildDecoder as wrap } from "./trie-decoder.js";

--- a/web/src/engine/predictive-text/templates/src/trie-decoder.ts
+++ b/web/src/engine/predictive-text/templates/src/trie-decoder.ts
@@ -1,0 +1,35 @@
+import { type Wordform2Key } from './common.js';
+import { decompressNode } from './trie-compression.js';
+import { type InternalNode } from './trie.js';
+
+export function buildDecoder(encodedRoot: string, searchTermKeyer: Wordform2Key) {
+  const root = decompressNode(encodedRoot, searchTermKeyer, 0) as InternalNode;
+  retrofitInternalNode(root, searchTermKeyer);
+
+  return root;
+}
+
+function retrofitInternalNode(node: InternalNode, searchTermKeyer: Wordform2Key) {
+  const originalChildren = node.children;
+
+  node.children = {};
+  const children = node.children;
+  for(let char of node.values) {
+    const child = originalChildren[char] as string;
+    Object.defineProperty(children, char, {
+      configurable: true,
+      get: (() => {
+        const childNode = decompressNode(child, searchTermKeyer, 0);
+
+        if(childNode.type == 'internal') {
+          retrofitInternalNode(childNode, searchTermKeyer);
+        }
+
+        Object.defineProperty(children, char, {
+          value: childNode
+        })
+        return childNode;
+      })
+    });
+  }
+}

--- a/web/src/engine/predictive-text/templates/tests/trie-compression.tests.js
+++ b/web/src/engine/predictive-text/templates/tests/trie-compression.tests.js
@@ -10,6 +10,10 @@ import {
   ENCODED_NUM_BASE
 } from '@keymanapp/models-templates/obj/trie-compression.js';
 
+import {
+  buildDecoder
+} from '@keymanapp/models-templates/obj/trie-decoder.js';
+
 import { TrieBuilder } from '@keymanapp/models-templates';
 import { Trie } from '../build/obj/trie.js';
 
@@ -235,6 +239,22 @@ describe('Trie decompression', function () {
 
     // The test:  did it throw?  If no, we'll assume we're good.
   });
+
+  it('can be decoded into the original unencoded format', () => {
+    const trieFixture = jsonFixture('tries/english-1000');
+    const builder = new TrieBuilder((word) => word, trieFixture.root, trieFixture.totalWeight);
+    const compressedTrie = builder.compress();
+
+    const decompressor = buildDecoder(compressedTrie, (word) => word);
+
+    // Note:  no obvious method calls here; it needs to match the original, non-encoded Trie's specification.
+    assert.doesNotThrow(() => decompressor.children.a.children.b.children.l);
+
+    // Must be able to fully follow this chain without any modifications.
+    // All children objects and the entry lookup near the end should appear decoded to code of this form
+    // when the base object is 'wrapped' with the decoder.
+    assert.equal(decompressor.children.a.children.b.children.l.entries[0].content, 'able');
+  })
 
   describe('surrogate-pair handling', () => {
     it('compresses a Trie with non-BMP characters without throwing an error', () => {

--- a/web/src/tools/es-bundling/src/common-bundle.mts
+++ b/web/src/tools/es-bundling/src/common-bundle.mts
@@ -5,6 +5,7 @@ import { prepareTslibTreeshaking } from './tslibTreeshaking.mjs';
 
 let CHARSET = 'ascii';
 let FORMAT = 'iife';
+let GLOBAL_NAME = '';
 let MINIFY = false;
 
 let sourceFromArgs;
@@ -35,6 +36,8 @@ Options:
                         'iife' or 'esm'.
 
                         If not specified, 'iife' will be used.
+  --globalName          If 'iife' is specified, exports are assigned to this name as a
+                        script-global variable
   --minify              Enables minification.
   --platform=<platform> Sets the 'platform' property of the esbuild config accordingly.
   --profile=<out-file>  Generates an associated filesize profile at the specified path.
@@ -77,6 +80,9 @@ if(process.argv.length > 2) {
             doHelp(1);
             break;
         }
+        break;
+      case '--globalName':
+        GLOBAL_NAME = process.argv[++i];
         break;
       case '--minify':
         MINIFY = true;
@@ -151,6 +157,10 @@ const config: esbuild.BuildOptions = {
   sourceRoot: sourceRoot, // may be undefined - is fine if so.
   platform: platform as esbuild.Platform || "browser"
 };
+
+if(GLOBAL_NAME && FORMAT == 'iife') {
+  config.globalName = GLOBAL_NAME;
+}
 
 await prepareTslibTreeshaking(config);
 const results = await esbuild.build(config);


### PR DESCRIPTION
This PR adds one function called `buildDecoder` that can progressively decode an encoded `Trie` without referencing the predictive-text engine's specialized class for the process.  By bundling and minifying the trie-decoding function properly, we gain a build output that can be included with compiled lexical models to maintain backward-compatibility in older versions of the predictive-text engine.

As of the second commit, this new, model-bundlable "decompressor" script weighs in at a mere **1985 bytes** when minified.  That's a drop in the bucket compared to the standard lexical model size, especially when not compressed.

So far, this PR only covers the Web side of this push; the new decoding/back-compatibility component is not yet set for inclusion within compiled lexical models.

One question I'm currently dwelling on:  would it be wise to ask if the model file should check whether or not the engine is current and provides built-in support?
- The predictive-text engine's built-in method will be needed for models using `epic/dict-breaker`; we'll need to keep it around as a result, even if we don't "check" for the common case.
- If we can foresee any reason down the road to perform such a check in order to let the engine's version of the code take precedence over what the model includes, it may be wise to start such checks "sooner" rather than "later".
- Otherwise, perhaps time and effort should be spent to remove the decoding references from the built-in method in favor of _always_ decoding within the model file itself?  
    - The pred-text engine class that does the decoding... can also just take in a pre-decoded version.  (That's why it's an _optional_ thing out of the gate; otherwise we'd _have_ to check first.)
    - This code _does_ only weigh in around 2kb, and we _may_ want the ability to compress and cache user-dict data live for `epic/user-dict` needs... so maybe the code should be kept around within the engine for `epic/user-dict` use?
 
@keymanapp-test-bot skip

... though maybe a test _should_ be added soon.

Basic user-test skeleton:
1. Compile an existing lexical model with this epic-branch's compiled `kmc`.
2. Use a `master` or `beta` version of KeymanWeb (or one of the two mobile apps) and load the model within that.
3. Verify that predictions work normally (despite that version of the predictive-text engine not having trie-decoding built in!)