### PR TITLE
fix(web): remove extra px offset from last OSK row

### DIFF
--- a/web/src/engine/osk/src/keyboard-layout/oskLayer.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskLayer.ts
@@ -182,9 +182,6 @@ export default class OSKLayer {
       }
 
       oskRow.refreshLayout(layoutParams);
-      if(nRow == nRows-1) {
-        oskRow.element.style.bottom = '1px';
-      }
     }
 
     for(const row of this.rows) {


### PR DESCRIPTION
Fixes: #13620

Turns out there was actually a final-row pixel offset being applied for the OSK.  I _believe_ this was something originally done for touch-oriented OSKs that ended up applied to all during 17.0's OSK refactoring efforts.

kmwosk.css does define layer-group padding above and below (1 px each) for touch keyboards already.  Furthermore, things look fine when removing this extra 1px offset on the bottom from the last row - there's still a margin below the final row keys that appears to match half the usual gap between rows.  I think we're fine to just drop this minor offset and move on for now.

@keymanapp-test-bot skip