### PR TITLE
fix(developer): add special handling for 'und' in kmc-keyboard-info

### DIFF
--- a/developer/src/kmc-keyboard-info/src/keyboard-info-compiler-messages.ts
+++ b/developer/src/kmc-keyboard-info/src/keyboard-info-compiler-messages.ts
@@ -3,7 +3,7 @@ import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m
 const Namespace = CompilerErrorNamespace.KeyboardInfoCompiler;
 // const SevInfo = CompilerErrorSeverity.Info | Namespace;
 const SevHint = CompilerErrorSeverity.Hint | Namespace;
-// const SevWarn = CompilerErrorSeverity.Warn | Namespace;
+const SevWarn = CompilerErrorSeverity.Warn | Namespace;
 const SevError = CompilerErrorSeverity.Error | Namespace;
 const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 
@@ -63,8 +63,29 @@ export class KeyboardInfoCompilerMessages {
     `The Info.Description field in the package ${def(o.filename)} is required, but is missing or empty.`);
 
   static HINT_ScriptDoesNotMatch = SevHint | 0x0011;
-  static Hint_ScriptDoesNotMatch = (o:{script: string, bcp47:string, commonScript: string}) => m(
+  static Hint_ScriptDoesNotMatch = (o:{script: string, bcp47:string, commonScript: string, firstBcp47: string}) => m(
     this.HINT_ScriptDoesNotMatch,
-    `The script '${def(o.script)}' associated with language tag '${def(o.bcp47)}' does not match the script '${def(o.commonScript)}' for the first language in the package.`);
+    `The script '${def(o.script)}' associated with language tag '${def(o.bcp47)}' does not match the script '${def(o.commonScript)}' for the first language ('${def(o.firstBcp47)}') in the package.`,
+  );
+
+  static WARN_LanguageTagNotFound = SevWarn | 0x0012;
+  static Warn_LanguageTagNotFound = (o:{bcp47:string, langSubtag:string}) => m(
+    this.WARN_LanguageTagNotFound,
+    `Neither the listed BCP 47 tag '${def(o.bcp47)}' nor the language subtag '${def(o.langSubtag)}' were found in langtags.json`,
+    `The [langtags.json dataset](https://github.com/silnrsi/langtags?tab=readme-ov-file) lists all
+    the registered language tags. If a tag is not found, then it will not be
+    searchable in the Keyman keyboard catalogue, and it may indicate that the
+    tag is incorrect.`
+  );
+
+  static WARN_LanguageTagNotFound2 = SevWarn | 0x0013;
+  static Warn_LanguageTagNotFound2 = (o:{bcp47:string}) => m(
+    this.WARN_LanguageTagNotFound2,
+    `The listed BCP 47 tag '${def(o.bcp47)}' was not found in langtags.json`,
+    `The [langtags.json dataset](https://github.com/silnrsi/langtags?tab=readme-ov-file) lists all
+    the registered language tags. If a tag is not found, then it will not be
+    searchable in the Keyman keyboard catalogue, and it may indicate that the
+    tag is incorrect.`
+  );
 }
 

--- a/developer/src/kmc-keyboard-info/test/keyboard-info-compiler-messages.tests.ts
+++ b/developer/src/kmc-keyboard-info/test/keyboard-info-compiler-messages.tests.ts
@@ -296,6 +296,27 @@ describe('KeyboardInfoCompilerMessages', function () {
   it('should generate ERROR_DescriptionIsMissing if there is no description in .kps', async function() {
     await testMessage(KeyboardInfoCompilerMessages.ERROR_DescriptionIsMissing,'error_description_is_missing', false);
   });
+
+  // WARN_LanguageTagNotFound
+
+  it('should generate WARN_LanguageTagNotFound if a language tag is not found (and no other subtags)', async function() {
+    const compiler = new KeyboardInfoCompiler();
+    assert.isTrue(await compiler.init(callbacks, {sources: KHMER_ANGKOR_SOURCES}));
+    const result = compiler.unitTestEndPoints.fillLanguageMetadata({}, 'grk-Latn', null, null);
+    assert.isOk(result);
+    assert.isTrue(callbacks.hasMessage(KeyboardInfoCompilerMessages.WARN_LanguageTagNotFound));
+  });
+
+  // WARN_LanguageTagNotFound2
+
+  it('should generate WARN_LanguageTagNotFound2 if a language tag is not found', async function() {
+    const compiler = new KeyboardInfoCompiler();
+    assert.isTrue(await compiler.init(callbacks, {sources: KHMER_ANGKOR_SOURCES}));
+    const result = compiler.unitTestEndPoints.fillLanguageMetadata({}, 'grk', null, null);
+    assert.isOk(result);
+    assert.isTrue(callbacks.hasMessage(KeyboardInfoCompilerMessages.WARN_LanguageTagNotFound2));
+  });
+
 });
 
 function nodeCompilerMessage(ncb: TestCompilerCallbacks, code: number): string {

--- a/developer/src/kmc-keyboard-info/test/keyboard-info-compiler.tests.ts
+++ b/developer/src/kmc-keyboard-info/test/keyboard-info-compiler.tests.ts
@@ -16,6 +16,12 @@ beforeEach(function() {
   callbacks.clear();
 });
 
+afterEach(function() {
+  if(this.currentTest?.isFailed()) {
+    callbacks.printMessages();
+  }
+});
+
 const KHMER_ANGKOR_KPJ = makePathToFixture('khmer_angkor', 'khmer_angkor.kpj');
 const KHMER_ANGKOR_JS  = makePathToFixture('khmer_angkor', 'build', 'khmer_angkor.js');
 const KHMER_ANGKOR_KPS = makePathToFixture('khmer_angkor', 'source', 'khmer_angkor.kps');
@@ -835,4 +841,63 @@ describe('keyboard-info-compiler', function () {
     const result = await compiler['fontSourceToKeyboardInfoFont'](KHMER_ANGKOR_KPS, kmpJsonData, fonts);
     assert.deepEqual(result, KHMER_ANGKOR_DISPLAY_FONT_INFO);
   });
+});
+
+describe('fillLanguageMetadata', function() {
+  const tests: { bcp47: string, lang: KeyboardInfoFileLanguage, commonScript: string }[] = [
+
+    // 'und' language subtag
+
+    {
+      bcp47: 'und',
+      lang: { languageName: 'Undetermined', regionName: undefined, scriptName: undefined, displayName: 'Undetermined' },
+      commonScript: 'Zyyy',
+    },
+    {
+      bcp47: 'und-Latn',
+      lang: { languageName: 'Undetermined', regionName: undefined, scriptName: 'Latin', displayName: 'Undetermined (Latin)' },
+      commonScript: 'Latn',
+    },
+    {
+      bcp47: 'und-MX',
+      lang: { languageName: 'Undetermined', regionName: 'Mexico', scriptName: undefined, displayName: 'Undetermined (Mexico)' },
+      commonScript: 'Zyyy',
+    },
+    {
+      bcp47: 'und-Khmr-MX',
+      lang: { languageName: 'Undetermined', regionName: 'Mexico', scriptName: 'Khmer', displayName: 'Undetermined (Khmer, Mexico)' },
+      commonScript: 'Khmr',
+    },
+
+    // Private use subtags
+
+    {
+      bcp47: 'qaa-Qabx-QQ',
+      lang: { languageName: 'qaa-Qabx-QQ', regionName: 'QQ', scriptName: 'Qabx', displayName: 'qaa-Qabx-QQ (Qabx, QQ)' },
+      commonScript: 'Qabx',
+    }
+  ];
+
+  for(const test of tests) {
+    it(`should handle ${test.bcp47} correctly`, async function() {
+      const compiler = new KeyboardInfoCompiler();
+      await compiler.init(callbacks, {sources: KHMER_ANGKOR_SOURCES});
+      const lang: KeyboardInfoFileLanguage = {};
+      const result = compiler.unitTestEndPoints.fillLanguageMetadata(
+        lang,
+        test.bcp47,
+        null, null
+      );
+      assert.isOk(result);
+      assert.equal(result.firstBcp47, test.bcp47);
+      assert.equal(result.commonScript, test.commonScript);
+
+      assert.equal(lang.languageName, test.lang.languageName);
+      assert.equal(lang.regionName, test.lang.regionName);
+      assert.equal(lang.scriptName, test.lang.scriptName);
+      assert.equal(lang.displayName, test.lang.displayName);
+
+      assert.isEmpty(callbacks.messages);
+    });
+  }
 });


### PR DESCRIPTION
This is a workaround for missing 'und' language tag.

`(new Intl.Locale('und')).language` returns `undefined` in V8, as of 31 March 2025. This means we cannot rely on `Intl.Locale` to parse the bcp47 string for us. The implemented workaround is to replace `und` with a known-good language subtag, and then swap it back out in later processing.

Also adds unit test and new warning messages for invalid language tags that were exposed during testing of this.

Fixes: #13610

@keymanapp-test-bot skip