### PR TITLE
refactor(linux): remove warning if no custom keyboards exist

### DIFF
--- a/linux/ibus-keyman/src/keymanutil.c
+++ b/linux/ibus-keyman/src/keymanutil.c
@@ -279,6 +279,9 @@ keyman_add_custom_keyboards(
   gchar * kmx_path
 ) {
   GList * engines_list = kb_data->engines_list;
+  if (custom_keyboards == NULL)
+    return engines_list;
+
   GPtrArray *language_keyboards = g_hash_table_lookup(custom_keyboards, kmx_path);
   if (language_keyboards == NULL)
     return engines_list;


### PR DESCRIPTION
If the dconf setting for custom keyboards doesn't exist, i.e. we never saved custom keyboards before, the previous code resulted in a warning showing up: `(ibus-engine-keyman:4276): GLib-CRITICAL **: 14:31:16.030: g_hash_table_lookup: assertion 'hash_table != NULL' failed`.

This PR adds a null check before trying to access the custom keyboards hash table and thus removes the warning.

@keymanapp-test-bot skip