### PR TITLE
fix(linux): allow unhandled keys to pass through to compliant apps

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -701,6 +701,14 @@ process_persist_action(IBusEngine *engine, km_core_option_item *persist_options)
   }
 }
 
+/**
+ * Process the emit_keystroke action
+ *
+ * @param engine          A pointer to the IBusEngine instance.
+ * @param emit_keystroke  A boolean indicating whether to emit a keystroke.
+ *
+ * @returns TRUE if Keyman handled the event, FALSE otherwise.
+ */
 static gboolean
 process_emit_keystroke_action(IBusEngine *engine, km_core_bool emit_keystroke) {
   IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
@@ -809,6 +817,14 @@ finish_process_actions(IBusEngine *engine) {
   }
 }
 
+/**
+ * Process the actions from Keyman Core
+ *
+ * @param engine   A pointer to the IBusEngine instance.
+ * @param actions  A pointer to the km_core_actions structure containing the actions to process.
+ *
+ * @returns TRUE if Keyman handled the event, FALSE otherwise.
+ */
 static gboolean
 process_actions(
   IBusEngine *engine,


### PR DESCRIPTION
This change fixes a bug introduced in #13372. Before that `engine.c` determined if keys are handled or not. For keys that we didn't handle we returned `FALSE`. However, that didn't allow the Core to adjust the context where necessary, so #13372 moved that to Core. However, this caused `ibus_keyman_engine_process_key_event` to return `TRUE` even if we didn't handle the key. Instead we called `ibus_engine_forward_key_event` with the non-handled key. This worked in most applications, but not in the Text Editor.

This change now does no longer call `ibus_engine_forward_key_event` for compliant apps but instead returns `FALSE` from `ibus_keyman_engine_process_key_event` for unhandled keys, allowing the app to see and act on the key event.

An 'unhandled' key here is a key that doesn't match a rule in the keyboard and isn't a character key. Core returns a `QIT_EMIT_KEYSTROKE` action for that key.

Fixes: #13590

# User Testing

Run these tests in Ubuntu 24.04 Noble or 24.10 Oracular.

## Preparations

- Install [ldml_contextreset.zip](https://github.com/user-attachments/files/19393917/ldml_contextreset.zip) ldml keyboard
- Install SIL Euro Latin
- Install gedit

## SUITE_KMX_PROCESSOR_NON_COMPLIANT:

Test in the **Chrome** browser (https://keyman.com/keyboards) with the **SIL Euro Latin** keyboard.

### TEST_LEFT_ARROW
1. Type `abc`
2. Press <kbd>←</kbd> left arrow
Verify that the Cursor is now between the `b` and the `c`.

### TEST_CONTROL_1
1. Press <kbd>`</kbd> 
4. press <kbd>e</kbd>
Expected result: è

### TEST_FRAME_KEY_RESET_MARKERS
This tests the markers are lost
1. Press <kbd>`</kbd> 
2. Press <kbd>→</kbd>    right arrow
5. Press <kbd>e</kbd>
Expected result: `e

### TEST_FRAME_KEY_RESET_NOMARKERS

1. Press <kbd>1</kbd> <kbd>/</kbd> <kbd>/</kbd>
2. Press <kbd>→</kbd>    right arrow
3. Press <kbd>2</kbd>
Expected result: 1//2

### TEST_SCROLLLOCK_KEY_NO_RESET
Do not reset for scroll lock
1. Press <kbd>`</kbd>
2. Press <kbd>scroll lock</kbd>
3. Press <kbd>e</kbd>
Expected Result: è

## SUITE_KMX_PROCESSOR_COMPLIANT:

### GROUP_GEDIT
Test in **gedit** with the **SIL Euro Latin** keyboard.


### GROUP_TEXTEDITOR
Test in **text editor** with the **SIL Euro Latin** keyboard.

### TEST_LEFT_ARROW
1. Type `abc`
2. Press <kbd>←</kbd> left arrow
Verify that the Cursor is now between the `b` and the `c`.

### TEST_CONTROL_1
1. Press <kbd>`</kbd> 
2. press <kbd>e</kbd>
Expected result: è

### TEST_FRAME_KEY_RESET_MARKERS
This tests the markers are lost
1. Press <kbd>`</kbd> 
2. Press <kbd>→</kbd>    right arrow
3. Press <kbd>e</kbd>
Expected result: `e

### TEST_FRAME_KEY_RESET_NOMARKERS

1. Press <kbd>1</kbd> <kbd>/</kbd> <kbd>/</kbd>
2. Press <kbd>→</kbd>    right arrow
3. Press <kbd>2</kbd>
Expected result: ½

### TEST_SCROLLLOCK_KEY_NO_RESET
Do not reset for scroll lock
1. Press <kbd>`</kbd>
2. Press <kbd>scroll lock</kbd>
3. Press <kbd>e</kbd>
Expected Result: è

## SUITE_LDML_PROCESSOR_NON_COMPLIANT:

Test in the **Chrome** browser (https://keyman.com/keyboards) with the **ldml_contextreset** keyboard.

### TEST_CONTROL_1
1. Press <kbd>^</kbd> 
2. Press <kbd>e</kbd>
Expected result: ê

### TEST_FRAME_KEY_RESET_MARKERS
1. Press <kbd>^</kbd>
2. Press <kbd>→</kbd>    right arrow
3. Press <kbd>e</kbd>
Expected result: e

### TEST_FRAME_KEY_RESET_NO_MARKERS
1. Press <kbd>a</kbd>
2. Press <kbd>→</kbd>    right arrow
3. Press <kbd>Shift</kbd> + <kbd>8</kbd> 
Expected result: a*

### TEST_MODIFIER_TAP_NO_RESET
Do not reset for modifier tap
1. Press <kbd>^</kbd>
2. Press  and Release <kbd>ctrl</kbd>
3. Press <kbd>e</kbd>
Expected result: ê

## SUITE_LDML_PROCESSOR_COMPLIANT:

### GROUP_GEDIT
Test in **gedit** with the **ldml_contextreset** keyboard.

### GROUP_TEXTEDITOR
Test in **text editor** with the **ldml_contextreset** keyboard.

### TEST_CONTROL_1
1. Press <kbd>^</kbd> 
2. Press <kbd>e</kbd>
Expected result: ê

### TEST_FRAME_KEY_RESET_MARKERS
1. Press <kbd>^</kbd>
2. Press <kbd>→</kbd>    right arrow
3. Press <kbd>e</kbd>
Expected result: e

### TEST_FRAME_KEY_RESET_NO_MARKERS
1. Press <kbd>a</kbd>
2. Press <kbd>→</kbd>    right arrow
3. Press <kbd>Shift</kbd> + <kbd>8</kbd> 
Expected result: Star

### TEST_MODIFIER_TAP_NO_RESET
Do not reset for modifier tap
1. Press <kbd>^</kbd>
2. Press  and Release <kbd>ctrl</kbd>
3. Press <kbd>e</kbd>
Expected result: ê
