### PR TITLE
fix(ios): prevent re-display of keyboard when re-entering app to its menus

### DIFF
--- a/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/MainViewController/MainViewController.swift
@@ -67,6 +67,10 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
   private var keyboardPickerDismissedObserver: NotificationObserver?
   private var keyboardChangedObserver: NotificationObserver?
   private var keyboardRemovedObserver: NotificationObserver?
+  
+  var shouldKeyboardBeVisible: Bool {
+    return navigationController?.visibleViewController == self
+  }
 
   var appDelegate: AppDelegate! {
     return UIApplication.shared.delegate as? AppDelegate
@@ -498,7 +502,9 @@ class MainViewController: UIViewController, TextViewDelegate, UIActionSheetDeleg
     // queue is complete.  There are still ongoing calculations - including within the
     // keyboard's WebView itself!  (This function's call is actually triggered _by_ it!)
     DispatchQueue.main.async {
-      self.textView.becomeFirstResponder()
+      if self.shouldKeyboardBeVisible {
+        self.textView.becomeFirstResponder()
+      }
     }
     if shouldShowGetStarted {
       perform(#selector(self.showGetStartedView), with: nil, afterDelay: 1.0)


### PR DESCRIPTION
Fixes: #13629
Fixes: #11953
Fixes: #6387

This change makes sure that upon app re-entry, the keyboard only displays when the main view will be the active view.  If the app had been in a menu or in the picker, the keyboard will no longer show up on top of it.  Additionally, if the app is re-entered to directly install a KMP from a file, the keyboard will not overlay the package installer.

The core of the problem is that upon app re-entry, the WebView reloads the keyboard, which in turns triggers the `keyboardLoaded` internal notification.  That notification did not check if the main view was the currently-visible view or not, and would always display the keyboard.

## User Testing

TEST_STANDARD_USE:  Use the test build from this PR and verify that the keyboard is displayed and hidden at normal times.
1. Verify that the keyboard appears once the app launches
2. If the "Get Started" menu appears, verify that the keyboard does not appear while it's visible, but does afterward
3. Verify that the keyboard disappears when the keyboard picker is visible and reappears afterward
4. Verify that the keyboard disappears when the Settings menu (or a submenu) is open and that the keyboard reappears when returning to the main, text-editing view after the Settings menu is dismissed (in any fashion)

TEST_REPRO_13629:  Use the test build from this PR and attempt to repro #13629.
1. Open the Keyman app's Settings menu
5. Select "System Keyboard Settings"
6. At the top-left corner of the device, use the "< Keyman" system option to return directly from the system's Settings app to the Keyman app
7. Verify that the keyboard is _not_ displayed.

TEST_REPRO_11953:  Use the test build from this PR and attempt to repro #11953.
1. Installed the "keyman-18.0.70.dmg" file.
2. Checked the "Enable Keyman as system-wide keyboard" and set the keyboard as the default keyboard box on the settings page.
3. Open the Keyman app. Enable the "Predictions" and install the "Dictionary."
5. Add the "Khmer" keyboard by clicking Settings -> Installed Languages.
8. Open the "Keyboards" dialog by clicking the globe key.
9. Minimize the Keyman app using the "swipe gestures (it stays under the recent).
10. Open the Chrome browser, and then close it.
11. Reopen the Keyman app from the recent changes.
12. Verify that the keyboard is _not_ displayed.

TEST_REPRO_6387:  Use the test build from this PR and attempt to repro #6387.  (No explicit repro in base issue)
1. Launch your test device's Safari and visit https://jahorton.github.io.
2. Download the `sil_ipa.kmp` option near the top.
3. Once the download is complete, enter the downloads menu and select the file.
    - For repeat attempts, you can likely find the file again in the Files app under recents.  Selecting the file here will also work.
4. Verify that the package installer appears _and_ that the keyboard is not visible.