### PR TITLE
fix(ios): slide dismissal of keyboard-height adjuster will properly resize the keyboard

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/SettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/SettingsViewController.swift
@@ -44,6 +44,8 @@ open class SettingsViewController: UITableViewController {
     if ((previousPortraitKeyboardHeight != newPortraitHeight) || (previousLandscapeKeyboardHeight != newLandscapeHeight)) {
       Manager.shared.keyboardHeightChanged()
     }
+    
+    navigationController?.presentationController?.delegate = nil
   }
   
   open func launchSettings(launchingVC: UIViewController, sender: Any?) -> Void {
@@ -148,6 +150,13 @@ open class SettingsViewController: UITableViewController {
                              width: switchWidth,
                              height: cellFrame.size.height)
     return switchFrame
+  }
+  
+  override open func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    
+    // Helps to handle slide-dismissal.
+    navigationController?.presentationController?.delegate = self
   }
 
   override open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -467,5 +476,11 @@ open class SettingsViewController: UITableViewController {
       os_log("%{public}s", log:KeymanEngineLogger.settings, type: .error, message)
       SentryManager.capture(message)
     }
+  }
+}
+
+extension SettingsViewController: UIAdaptivePresentationControllerDelegate {
+  public func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
+    doneClicked(1)
   }
 }

--- a/ios/engine/KMEI/KeymanEngine/Classes/SettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/SettingsViewController.swift
@@ -27,15 +27,15 @@ open class SettingsViewController: UITableViewController {
     
     title = NSLocalizedString("menu-settings-title", bundle: engineBundle, comment: "")
     let doneButton = UIBarButtonItem(title: NSLocalizedString("Done", bundle: engineBundle, comment: ""), style: .plain, target: self,
-                                     action: #selector(self.doneClicked))
+                                     action: #selector(self.settingsDismissed))
     navigationItem.leftBarButtonItem = doneButton
 
     navigationController?.toolbar?.barTintColor = Colors.statusToolbar
   }
   
-  @objc func doneClicked(_ sender: Any) {
+  @objc func settingsDismissed() {
     // This resets KMW so that any new and/or updated resources can be properly loaded.
-    os_log("SettingsViewController doneClicked", log:KeymanEngineLogger.settings, type: .info)
+    os_log("SettingsViewController settingsDismissed", log:KeymanEngineLogger.settings, type: .info)
     Manager.shared.dismissKeyboardPicker(self)
     
     let newPortraitHeight = Storage.active.userDefaults.portraitKeyboardHeight
@@ -427,7 +427,7 @@ open class SettingsViewController: UITableViewController {
     let doneOrCancel = value
     if doneOrCancel {
       let doneButton = UIBarButtonItem(title: NSLocalizedString("command-done", bundle: engineBundle, comment: ""), style: .plain, target: self,
-                                       action: nil /* #selector(self.doneClicked) */ )
+                                       action: nil /* #selector(self.settingsDismissed) */ )
       nc.navigationItem.leftBarButtonItem = doneButton
     } else {
       let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self,
@@ -481,6 +481,6 @@ open class SettingsViewController: UITableViewController {
 
 extension SettingsViewController: UIAdaptivePresentationControllerDelegate {
   public func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
-    doneClicked(1)
+    settingsDismissed()
   }
 }


### PR DESCRIPTION
Fixes: #13443

Slide-dismissal of the settings menu, and of the keyboard-height setting view in particular, should apply changes after dismissal... not only after backing out via navigation buttons.

Certain aspects of the iOS API didn't make it easy, though.  After some searching, I found that "presentation controllers" and related can be leveraged to ensure we can detect Settings menu dismissal.  With that detection in place, we can use the same method that's been working fine for us when backing out of Settings via button.  This also ensures the keyboard will immediately display after dismissal, too!

## User Testing

TEST_REPRO_13443:  Use this PR's test artifact and verify that slide-dismissal of the keyboard-height adjuster automatically displays the keyboard at the newly-set size.
1. Open Keyman Settings -> Adjust Keyboard Height
2. Change the height of the keyboard enough so that it will be noticeable when you leave the setting
3. Swipe down on the sheet, so that it is dismissed and you see the blank editor page
4. Verify that the keyboard appears automatically, with no need to tap
5. Confirm that the keyboard size is changed to it match the adjustment from step 2

TEST_BUTTON_DISMISSAL:  Use this PR's test artifact and verify that the keyboard-height adjuster automatically displays the keyboard at the newly-set size when backing out via navigation menu.

1. Open Keyman Settings -> Adjust Keyboard Height
2. Change the height of the keyboard enough so that it will be noticeable when you leave the setting
3. Tap the "Back" button at the top left, then "Done", to return to the main, text-editing view.
4. Verify that the keyboard appears automatically, with no need to tap
5. Confirm that the keyboard size is changed to it match the adjustment from step 2