### PR TITLE
change(web): add unique classname to mobile-device page-trailer element

### DIFF
--- a/web/src/app/browser/src/context/pageIntegrationHandlers.ts
+++ b/web/src/app/browser/src/context/pageIntegrationHandlers.ts
@@ -57,6 +57,7 @@ export class PageIntegrationHandlers {
     // Add a blank DIV to the bottom of the page to allow the bottom of the page to be shown
     const dTrailer = this.mobilePageTrailer = document.createElement('div');
     const ds=dTrailer.style;
+    dTrailer.className = 'keyman-page-trailer';
     ds.width='100%';
     ds.height=(screen.width/2)+'px';  // ... interesting choice, but okay.
     document.body.appendChild(dTrailer);


### PR DESCRIPTION
Addresses, but does not fix, #13588.  This is about much as we're willing to do for a 'fix' at this point, this late in the beta cycle.  Further work will be considered for future versions.

This change provides a simple classname - 'keyman-page-trailer' - to the page-trailer element Keyman Engine for Web adds to pages when in mobile mode.  This "page trailer" was originally added so that the on-screen keyboard does not hide important elements near the bottom of the page when visible.  That said, we have gotten site-designer complaints about it; exposing a way for site-designers to retrieve it in queries and/or customize its properties will provide a reasonable workaround for such cases.

@keymanapp-test-bot skip