### PR TITLE
fix(developer): remove redundant Name and RTL fields from .kps `LexicalModel`

### DIFF
--- a/common/schemas/kps/README.md
+++ b/common/schemas/kps/README.md
@@ -2,6 +2,14 @@
 
 Master version: https://github.com/keymanapp/api.keyman.com/blob/master/schemas/kps/17.0/kps.xsd
 
+## 2025-04-02 18.0
+* Version 18.0 deprecates the following fields, and kmc-package does not use them (#13600):
+  - Keyboards/Keyboard/Version
+  - Keyboards/Keyboard/Name
+  - Keyboards/Keyboard/RTL
+  - LexicalModels/LexicalModel/Name
+  - LexicalModels/LexicalModel/RTL (Note: was never read or written by any Keyman tooling)
+
 ## 2023-10-19 17.0
 * Version 17.0 adds:
   - LicenseFile - a .md file, usually named LICENSE.md
@@ -9,13 +17,13 @@ Master version: https://github.com/keymanapp/api.keyman.com/blob/master/schemas/
   - Info/Description - a short Markdown description of the content of the package, e.g. shown in search results on keyman.com
   - RelatedPackages - a list of other packages which relate to this one, or are deprecated by it
   - Keyboards/Keyboard/Examples - a list of typing examples for the keyboard
-  - Keyboarsd/Keyboard/WebOSKFonts - a list of font filenames (not necessarily in package) suitable for rendering the on screen keyboard
-  - Keyboarsd/Keyboard/WebDisplayFonts - a list of font filenames (not necessarily in package) suitable for use with the keyboard
+  - Keyboards/Keyboard/WebOSKFonts - a list of font filenames (not necessarily in package) suitable for rendering the on screen keyboard
+  - Keyboards/Keyboard/WebDisplayFonts - a list of font filenames (not necessarily in package) suitable for use with the keyboard
 * Version 17.0 removes:
   - LexicalModels/LexicalModel/Version - version information is not stored in the models, but only in the package metadata (was unused)
 
 ## 2023-04-21 7.0.1
-* Removes LexicalModel.Version, as it was never read or written
+* Removes LexicalModels/LexicalModel/Version, as it was never read or written
 
 ## 2021-07-19 7.0
 * Initial version 7.0

--- a/common/schemas/kps/kps.xsd
+++ b/common/schemas/kps/kps.xsd
@@ -119,10 +119,10 @@
             <xs:element minOccurs="0" maxOccurs="unbounded" name="Keyboard">
               <xs:complexType>
                 <xs:all>
-                  <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" /> <!-- deprecated: 18.0 -->
                   <xs:element minOccurs="0" maxOccurs="1" name="ID" type="xs:string" />
-                  <xs:element minOccurs="0" maxOccurs="1" name="Version" type="xs:string" />
-                  <xs:element minOccurs="0" maxOccurs="1" name="RTL" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Version" type="xs:string" /> <!-- deprecated: 18.0 -->
+                  <xs:element minOccurs="0" maxOccurs="1" name="RTL" type="xs:string" /> <!-- deprecated: 18.0 -->
                   <xs:element minOccurs="0" maxOccurs="1" name="OSKFont" type="xs:string" />
                   <xs:element minOccurs="0" maxOccurs="1" name="DisplayFont" type="xs:string" />
                   <xs:element minOccurs="0" maxOccurs="1" name="Languages" type="km-keyboard-languages" />
@@ -143,9 +143,9 @@
             <xs:element minOccurs="0" maxOccurs="unbounded" name="LexicalModel">
               <xs:complexType>
                 <xs:all>
-                  <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="Name" type="xs:string" /> <!-- deprecated: 18.0 -->
                   <xs:element minOccurs="0" maxOccurs="1" name="ID" type="xs:string" />
-                  <xs:element minOccurs="0" maxOccurs="1" name="RTL" type="xs:string" />
+                  <xs:element minOccurs="0" maxOccurs="1" name="RTL" type="xs:string" /> <!-- deprecated: 18.0 -->
                   <xs:element minOccurs="0" maxOccurs="1" name="Languages" type="km-keyboard-languages" />
                 </xs:all>
               </xs:complexType>

--- a/common/windows/delphi/packages/PackageInfo.pas
+++ b/common/windows/delphi/packages/PackageInfo.pas
@@ -401,17 +401,13 @@ type
 
   TPackageLexicalModel = class(TPackageBaseObject)
   private
-    FName: string;
     FID: string;
     FLanguages: TPackageKeyboardLanguageList;
-    FRTL: Boolean;
   public
     constructor Create(APackage: TPackage); override;
     destructor Destroy; override;
     procedure Assign(Source: TPackageLexicalModel); virtual;
-    property Name: string read FName write FName;
     property ID: string read FID write FID;
-    property RTL: Boolean read FRTL write FRTL;
     property Languages: TPackageKeyboardLanguageList read FLanguages;
   end;
 
@@ -545,9 +541,7 @@ const
 
   SXML_PackageLexicalModels = 'LexicalModels';
   SXML_PackageLexicalModel = 'LexicalModel';
-  SXML_PackageLexicalModel_Name = 'Name';
   SXML_PackageLexicalModel_ID = 'ID';
-  SXML_PackageLexicalModel_RTL = 'RTL';
   SXML_PackageLexicalModel_Languages = 'Languages';
 
   SXML_PackageRelatedPackages = 'RelatedPackages';
@@ -629,9 +623,7 @@ const
   SJSON_Keyboard_WebDisplayFonts = 'webDisplayFonts';
 
   SJSON_LexicalModels = 'lexicalModels';
-  SJSON_LexicalModel_Name = 'name';
   SJSON_LexicalModel_ID = 'id';
-  SJSON_LexicalModel_RTL = 'rtl';
   SJSON_LexicalModel_Languages = 'languages';
 
   SJSON_RelatedPackages = 'relatedPackages';
@@ -2386,9 +2378,7 @@ var
   i: Integer;
   FLanguage: TPackageKeyboardLanguage;
 begin
-  FName := Source.Name;
   FID := Source.ID;
-  FRTL := Source.RTL;
   FLanguages.Clear;
   for i := 0 to Source.Languages.Count - 1 do
   begin
@@ -2453,9 +2443,7 @@ begin
     ALexicalModel := ANode.Items[i] as TJSONObject;
 
     lexicalModel := TPackageLexicalModel.Create(Package);
-    lexicalModel.Name := GetJsonValueString(ALexicalModel, SJSON_LexicalModel_Name);
     lexicalModel.ID := GetJsonValueString(ALexicalModel,SJSON_LexicalModel_ID);
-    lexicalModel.RTL := GetJsonValueBool(ALexicalModel, SJSON_LexicalModel_RTL);
     lexicalModel.Languages.LoadJSON(ALexicalModel);
 
     Add(lexicalModel);
@@ -2476,9 +2464,7 @@ begin
     ALexicalModel := ANode.ChildNodes[i];
 
     lexicalModel := TPackageLexicalModel.Create(Package);
-    lexicalModel.Name := XmlVarToStr(ALexicalModel.ChildValues[SXML_PackageLexicalModel_Name]);
     lexicalModel.ID := XmlVarToStr(ALexicalModel.ChildValues[SXML_PackageLexicalModel_ID]);
-    lexicalModel.RTL := ALexicalModel.ChildNodes.IndexOf(SXML_PackageLexicalModel_RTL) >= 0;
     lexicalModel.Languages.LoadXML(ALexicalModel);
     Add(lexicalModel);
   end;
@@ -2501,9 +2487,7 @@ begin
     ALexicalModel := TJSONObject.Create;
     ALexicalModels.Add(ALexicalModel);
 
-    ALexicalModel.AddPair(SJSON_LexicalModel_Name, Items[i].Name);
     ALexicalModel.AddPair(SJSON_LexicalModel_ID, Items[i].ID);
-    if Items[i].RTL then ALexicalModel.AddPair(SJSON_LexicalModel_RTL, TJSONTrue.Create);
     Items[i].Languages.SaveJSON(ALexicalModel);
   end;
 end;
@@ -2518,10 +2502,7 @@ begin
   begin
     ALexicalModel := ANode.AddChild(SXML_PackageLexicalModel);
 
-    ALexicalModel.ChildNodes[SXML_PackageLexicalModel_Name].NodeValue := Items[i].Name;
     ALexicalModel.ChildNodes[SXML_PackageLexicalModel_ID].NodeValue := Items[i].ID;
-    if Items[i].RTL then
-      ALexicalModel.ChildNodes[SXML_PackageLexicalModel_RTL].NodeValue := True;
 
     Items[i].Languages.SaveXML(ALexicalModel);
   end;

--- a/developer/src/common/web/utils/src/types/kps/kps-file.ts
+++ b/developer/src/common/web/utils/src/types/kps/kps-file.ts
@@ -80,8 +80,9 @@ export interface KpsFileContentFile {
 }
 
 export interface KpsFileLexicalModel {
-  Name: string;
+  // Defined in .kps schema but not used: Name: string; #13600(comment)
   ID: string;
+  // Defined in .kps schema but not used: RTL: string; #13600(comment)
   Languages: KpsFileLanguages;
 }
 

--- a/developer/src/kmc-package/src/compiler/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/kmp-compiler.ts
@@ -323,7 +323,7 @@ export class KmpCompiler implements KeymanCompiler {
 
     if(kps.LexicalModels?.LexicalModel?.length) {
       kmp.lexicalModels = kps.LexicalModels.LexicalModel.map((model: KpsFile.KpsFileLexicalModel) => ({
-        name:model.Name.trim(),
+        name:model.ID.trim(),
         id:model.ID.trim(),
         languages: model.Languages?.Language?.length ?
           this.kpsLanguagesToKmpLanguages(model.Languages.Language) : []

--- a/developer/src/kmc-package/test/fixtures/example.qaa.sencoten/example.qaa.sencoten.model.kmp.intermediate.json
+++ b/developer/src/kmc-package/test/fixtures/example.qaa.sencoten/example.qaa.sencoten.model.kmp.intermediate.json
@@ -31,7 +31,7 @@
   ],
   "lexicalModels": [
     {
-      "name": "SENĆOŦEN dictionary",
+      "name": "example.qaa.sencoten",
       "id": "example.qaa.sencoten",
       "languages": [
         {

--- a/developer/src/kmc-package/test/fixtures/example.qaa.sencoten/example.qaa.sencoten.model.kmp.json
+++ b/developer/src/kmc-package/test/fixtures/example.qaa.sencoten/example.qaa.sencoten.model.kmp.json
@@ -31,7 +31,7 @@
   ],
   "lexicalModels": [
     {
-      "name": "SENĆOŦEN dictionary",
+      "name": "example.qaa.sencoten",
       "id": "example.qaa.sencoten",
       "languages": [
         {

--- a/developer/src/kmc-package/test/fixtures/example.qaa.sencoten/example.qaa.sencoten.model.kmp.zipped.json
+++ b/developer/src/kmc-package/test/fixtures/example.qaa.sencoten/example.qaa.sencoten.model.kmp.zipped.json
@@ -28,7 +28,7 @@
   ],
   "lexicalModels": [
     {
-      "name": "SENĆOŦEN dictionary",
+      "name": "example.qaa.sencoten",
       "id": "example.qaa.sencoten",
       "languages": [
         {

--- a/developer/src/kmc-package/test/fixtures/withfolders.qaa.sencoten/withfolders.qaa.sencoten.model.kmp.intermediate.json
+++ b/developer/src/kmc-package/test/fixtures/withfolders.qaa.sencoten/withfolders.qaa.sencoten.model.kmp.intermediate.json
@@ -35,7 +35,7 @@
   ],
   "lexicalModels": [
     {
-      "name": "SENĆOŦEN dictionary",
+      "name": "withfolders.qaa.sencoten",
       "id": "withfolders.qaa.sencoten",
       "languages": [
         {

--- a/developer/src/kmc-package/test/fixtures/withfolders.qaa.sencoten/withfolders.qaa.sencoten.model.kmp.zipped.json
+++ b/developer/src/kmc-package/test/fixtures/withfolders.qaa.sencoten/withfolders.qaa.sencoten.model.kmp.zipped.json
@@ -33,7 +33,7 @@
   ],
   "lexicalModels": [
     {
-      "name": "SENĆOŦEN dictionary",
+      "name": "withfolders.qaa.sencoten",
       "id": "withfolders.qaa.sencoten",
       "languages": [
         {

--- a/developer/src/kmconvert/Keyman.Developer.System.ModelProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.ModelProjectTemplate.pas
@@ -178,7 +178,6 @@ begin
 
     // Add metadata about the lexical model
     plm := TPackageLexicalModel.Create(kps);
-    plm.Name := Name;
     plm.ID := ID;
     kps.LexicalModels.Add(plm);
 

--- a/developer/src/tike/child/UfrmPackageEditor.dfm
+++ b/developer/src/tike/child/UfrmPackageEditor.dfm
@@ -184,7 +184,7 @@ inherited frmPackageEditor: TfrmPackageEditor
     Top = 0
     Width = 965
     Height = 622
-    ActivePage = pageKeyboards
+    ActivePage = pageLexicalModels
     Align = alClient
     Images = modActionsMain.ilEditorPages
     MultiLine = True
@@ -236,7 +236,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Width = 546
           Height = 32
           AutoSize = False
-          Caption =
+          Caption = 
             'A typical package will need keyboards, fonts, and documentation.' +
             ' You shouldn'#39't typically add source files. Also, don'#39't add any s' +
             'tandard Keyman files (such as keyman.exe) here.'
@@ -261,7 +261,7 @@ inherited frmPackageEditor: TfrmPackageEditor
         object lblFileType: TLabel
           Left = 256
           Top = 107
-          Width = 47
+          Width = 46
           Height = 13
           Caption = 'File Type:'
           FocusControl = editFilePath
@@ -639,16 +639,9 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 13
           Caption = 'Filename:'
         end
-        object lblLexicalModelDescription: TLabel
-          Left = 261
-          Top = 102
-          Width = 62
-          Height = 13
-          Caption = 'Description:'
-        end
         object lblLexicalModelLanguages: TLabel
-          Left = 260
-          Top = 181
+          Left = 261
+          Top = 101
           Width = 59
           Height = 13
           Caption = 'Languages:'
@@ -663,27 +656,18 @@ inherited frmPackageEditor: TfrmPackageEditor
           TabOrder = 0
           OnClick = lbLexicalModelsClick
         end
-        object editLexicalModelDescription: TEdit
-          Left = 342
-          Top = 99
-          Width = 275
-          Height = 21
-          TabStop = False
-          TabOrder = 1
-          OnChange = editLexicalModelDescriptionChange
-        end
         object gridLexicalModelLanguages: TStringGrid
           Left = 260
-          Top = 200
+          Top = 120
           Width = 593
-          Height = 376
+          Height = 456
           Anchors = [akLeft, akTop, akRight, akBottom]
           ColCount = 2
           DefaultRowHeight = 16
           FixedCols = 0
           RowCount = 9
           Options = [goFixedVertLine, goFixedHorzLine, goVertLine, goHorzLine, goColSizing, goRowSelect]
-          TabOrder = 2
+          TabOrder = 1
           OnClick = gridLexicalModelLanguagesClick
           OnDblClick = gridLexicalModelLanguagesDblClick
           ColWidths = (
@@ -697,7 +681,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 25
           Anchors = [akLeft, akBottom]
           Caption = '&Add...'
-          TabOrder = 3
+          TabOrder = 2
           OnClick = cmdLexicalModelLanguageAddClick
         end
         object cmdLexicalModelLanguageRemove: TButton
@@ -707,7 +691,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 25
           Anchors = [akLeft, akBottom]
           Caption = '&Remove'
-          TabOrder = 4
+          TabOrder = 3
           OnClick = cmdLexicalModelLanguageRemoveClick
         end
         object cmdLexicalModelLanguageEdit: TButton
@@ -717,17 +701,8 @@ inherited frmPackageEditor: TfrmPackageEditor
           Height = 25
           Anchors = [akLeft, akBottom]
           Caption = 'Ed&it...'
-          TabOrder = 5
+          TabOrder = 4
           OnClick = cmdLexicalModelLanguageEditClick
-        end
-        object chkLexicalModelRTL: TCheckBox
-          Left = 342
-          Top = 126
-          Width = 97
-          Height = 17
-          Caption = 'Is Right-to-left'
-          TabOrder = 6
-          OnClick = chkLexicalModelRTLClick
         end
         object editLexicalModelFilename: TEdit
           Left = 342
@@ -737,7 +712,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           TabStop = False
           ParentColor = True
           ReadOnly = True
-          TabOrder = 7
+          TabOrder = 5
         end
       end
     end
@@ -883,7 +858,7 @@ inherited frmPackageEditor: TfrmPackageEditor
         object lblDescriptionMarkdown: TLabel
           Left = 114
           Top = 497
-          Width = 215
+          Width = 214
           Height = 13
           Caption = 'Markdown accepted, no embedded HTML'
           Transparent = True
@@ -1281,7 +1256,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           Top = 48
           Width = 551
           Height = 13
-          Caption =
+          Caption = 
             'Compiling the package takes all the files you have selected and ' +
             'compresses them into a single package file.'
         end
@@ -1514,7 +1489,7 @@ inherited frmPackageEditor: TfrmPackageEditor
           object Label5: TLabel
             Left = 9
             Top = 73
-            Width = 82
+            Width = 81
             Height = 13
             Caption = 'Target filename:'
           end

--- a/developer/src/tike/child/UfrmPackageEditor.pas
+++ b/developer/src/tike/child/UfrmPackageEditor.pas
@@ -166,15 +166,12 @@ type
     lblLexlicalModels: TLabel;
     lblLexicalModelsSubtitle: TLabel;
     lblLexicalModelFilename: TLabel;
-    lblLexicalModelDescription: TLabel;
     lblLexicalModelLanguages: TLabel;
     lbLexicalModels: TListBox;
-    editLexicalModelDescription: TEdit;
     gridLexicalModelLanguages: TStringGrid;
     cmdLexicalModelLanguageAdd: TButton;
     cmdLexicalModelLanguageRemove: TButton;
     cmdLexicalModelLanguageEdit: TButton;
-    chkLexicalModelRTL: TCheckBox;
     editLexicalModelFilename: TEdit;
     imgQRCode: TImage;
     panOpenInExplorer: TPanel;
@@ -2311,18 +2308,13 @@ begin
     lm := SelectedLexicalModel;
     if not Assigned(lm) then
     begin
-      editLexicalModelDescription.Text := '';
       editLexicalModelFilename.Text := '';
-      chkLexicalModelRTL.Checked := False;
       gridLexicalModelLanguages.RowCount := 1;
       EnableLexicalModelTabControls;
       Exit;
     end;
 
     // Details
-
-    editLexicalModelDescription.Text := lm.Name;
-    chkLexicalModelRTL.Checked := lm.RTL;
 
     for i := 0 to pack.Files.Count - 1 do
       if TLexicalModelUtils.LexicalModelFileNameToID(pack.Files[i].FileName) = lm.ID then
@@ -2345,13 +2337,10 @@ var
   e: Boolean;
 begin
   e := lbLexicalModels.ItemIndex >= 0;
-  lblLexicalModelDescription.Enabled := e;
-  editLexicalModelDescription.Enabled := e;
   lblLexicalModelFilename.Enabled := e;
   editLexicalModelFilename.Enabled := e;
   lblLexicalModelLanguages.Enabled := e;
   cmdLexicalModelLanguageAdd.Enabled := e;
-  chkLexicalModelRTL.Enabled := e;
 
   e := e and (gridLexicalModelLanguages.Row > 0);
   gridLexicalModelLanguages.Enabled := e;
@@ -2417,7 +2406,6 @@ begin
 
   lm := SelectedLexicalModel;
   Assert(Assigned(lm));
-  lm.Name := editLexicalModelDescription.Text;
   Modified := True;
 end;
 
@@ -2429,7 +2417,6 @@ begin
     Exit;
   lm := SelectedLexicalModel;
   Assert(Assigned(lm));
-  lm.RTL := chkLexicalModelRTL.Checked;
   Modified := True;
 end;
 


### PR DESCRIPTION
Follows on from the similar changes to `Keyboard` fields in #13600. This deprecates the `RTL` and `Name` fields. `RTL` was never used. `Name` was written but never presented to end users, so effectively irrelevant. `Name` also was present in `File.Description` (already deprecated) for the corresponding model.js _and_ `Info.Name`, so doubly redundant.

Also updates the schema documentation to mark the deprecated fields.

Relates-to: #13600

# TODO

- [ ] Copy schema updates to api.keyman.com

# User Testing

TEST_COMPILE: Load a lexical model project from the lexical models repository. Open the .kps file, make an inconsequential change, save it, and try and build the entire project. Verify that the project builds. Open the .kps file in a text editor, and verify that the field `Package/LexicalModels/LexicalModel/Name` has been removed.

TEST_NEW_PROJECT: Create a new lexical model project and verify that it builds correctly