### PR TITLE
docs(common): Document Keyman website server-side dependencies

### DIFF
--- a/docs/websites/README.md
+++ b/docs/websites/README.md
@@ -92,6 +92,22 @@ Refer to **Port lookup table** above for Docker container names
 
 ---------
 
+## Website Dependencies
+
+The table below shows server-side dependencies for each website
+
+|Website               | Depends On           |
+|----------------------|-------------         |
+| s.keyman.com         | <br><br>             |
+| downloads.keyman.com | <br><br>             |
+| api.keyman.com       | downloads.keyman.com<br>s.keyman.com |
+| keymanweb.com        | api.keyman.com       |
+| keyman.com           | api.keyman.com<br>downloads.keyman.com |
+| help.keyman.com      | api.keyman.com<br>downloads.keyman.com |
+
+
+---------
+
 ## Kubernetes Deployment
 For production, the websites are deployed with Kubernetes.
 


### PR DESCRIPTION
In preparation for some server migration this week, DevOps asked what Keyman websites depended on each other (namely which ones don't need api.keyman.com access)

Documenting a table showing server-side dependencies per @mcdurdin 
> I  haven't got it in a pretty diagram yet

```
s.keyman.com
downloads.keyman.com

api.keyman.com --> downloads.keyman.com
api.keyman.com --> s.keyman.com

keymanweb.com --> api.keyman.com
keyman.com --> api.keyman.com
keyman.com --> downloads.keyman.com
help.keyman.com --> api.keyman.com
help.keyman.com --> downloads.keyman.com
```

@keymanapp-test-bot skip