### PR TITLE
fix(ios): ensure keyboard height is set when engine settings view is used in a NavigationController

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/SettingsViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/SettingsViewController.swift
@@ -427,7 +427,7 @@ open class SettingsViewController: UITableViewController {
     let doneOrCancel = value
     if doneOrCancel {
       let doneButton = UIBarButtonItem(title: NSLocalizedString("command-done", bundle: engineBundle, comment: ""), style: .plain, target: self,
-                                       action: nil /* #selector(self.settingsDismissed) */ )
+                                       action: #selector(self.settingsDismissed))
       nc.navigationItem.leftBarButtonItem = doneButton
     } else {
       let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self,


### PR DESCRIPTION
I happened to notice, while polishing up #13631, that our keyboard-height might not take effect properly if it were being used in certain setups.  Those setups don't occur within our Keyman app, but we can't guarantee that no uses will occur for Keyman Engine for iPhone and iPad as used by third-parties.

@keymanapp-test-bot skip