### PR TITLE
fix(android): Add back button to "Adjust Keyboard Height "menu

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
@@ -50,14 +50,14 @@ public class AdjustKeyboardHeightActivity extends BaseActivity {
     if (actionBar != null) {
       actionBar.setTitle(null);
       actionBar.setDisplayUseLogoEnabled(false);
-      actionBar.setDisplayShowHomeEnabled(false);
+      actionBar.setDisplayHomeAsUpEnabled(true);
+      actionBar.setDisplayShowHomeEnabled(true);
       actionBar.setDisplayShowTitleEnabled(false);
       actionBar.setDisplayShowCustomEnabled(true);
       actionBar.setBackgroundDrawable(new ColorDrawable(ContextCompat.getColor(this, R.color.keyman_blue)));
     }
 
     TextView adjustKeyboardHeightActivityTitle = (TextView) findViewById(R.id.bar_title);
-    adjustKeyboardHeightActivityTitle.setWidth((int) getResources().getDimension(R.dimen.package_label_width));
 
     String titleStr = getString(R.string.adjust_keyboard_height);
     adjustKeyboardHeightActivityTitle.setTextColor(ContextCompat.getColor(this, R.color.ms_white));
@@ -128,5 +128,9 @@ public class AdjustKeyboardHeightActivity extends BaseActivity {
     refreshSampleKeyboard(this);
   }
 
-
+  @Override
+  public boolean onSupportNavigateUp() {
+    onBackPressed();
+    return true;
+  }
 }


### PR DESCRIPTION
Follows #13635 and fixes #13634

* Adds back button and handler to the "Adjust Keyboard Height" menu
* `setWidth()` removed to center the title
 
![adjust-keyboard-height-back](https://github.com/user-attachments/assets/1235a351-ad98-4032-bb70-e73c86d41b24)

## User Testing
**Setup** - Install the PR build of Keyman for Android on device/emulator

* **TEST_BACK_BUTTON** - Verifies back button exits "Adjust Keyboard Height" menu
1. Launch Keyman for Android and dismiss Get Started menu
2. From Keyman Settings --> Adjust keyboard height
3. Verify the "Adjust keyboard height" titlebar has back button on the left
4. Drag the keyboard to adjust the keyboard height and let go
5. Observe the keyboard height 
6. On the title bar, hit the back button --> and exit back to the Keyman app
7. Verify the keyboard height now matches what was set in the menu
