### PR TITLE
fix(web): match banner font scaling to osk font scaling

### DIFF
--- a/web/src/engine/osk/src/keyboard-layout/oskLayerGroup.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskLayerGroup.ts
@@ -40,14 +40,6 @@ export default class OSKLayerGroup {
       return;
     }
 
-    // Set default OSK font size (Build 344, KMEW-90)
-    let layoutFS = layout['fontsize'];
-    if(typeof layoutFS == 'undefined' || layoutFS == null || layoutFS == '') {
-      ls.fontSize='1em';
-    } else {
-      ls.fontSize=layout['fontsize'];
-    }
-
     ls.width = '100%';
     ls.height = '100%';
 

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -518,7 +518,17 @@ export default abstract class OSKView
       this._baseFontSize = OSKView.defaultFontSize(this.targetDevice, this.computedHeight, this.isEmbedded);
     }
 
-    return this._baseFontSize;
+    // Set default OSK font size (Build 344, KMEW-90)
+    // If the layer group specifies a fontsize value, we need
+    // to apply that to the banner as well.
+    const layerFontSize = this.vkbd?.layerGroup?.spec.fontsize;
+
+    if(layerFontSize) {
+      const parsedSize = new ParsedLengthStyle(layerFontSize);
+      return parsedSize.absolute ? parsedSize : this._baseFontSize.scaledBy(parsedSize.val);
+    } else {
+      return this._baseFontSize;
+    }
   }
 
   public static defaultFontSize(device: DeviceSpec, computedHeight: number, isEmbedded: boolean): ParsedLengthStyle {

--- a/web/src/resources/osk/kmwosk.css
+++ b/web/src/resources/osk/kmwosk.css
@@ -49,7 +49,6 @@
   color: #000;
   text-align: center;
   display: block;
-  line-height: normal;
   position: relative;
   top: 50%;
   transform: translateY(-50%);
@@ -64,6 +63,7 @@
   width: 100%;
   height: 100%;
   scrollbar-width: none; /* Firefox scrollbar prevention */
+  line-height: 100%;
 }
 
 .kmw-suggest-banner-scroller::-webkit-scrollbar {
@@ -463,7 +463,6 @@
 .kmw-banner-bar .kmw-suggest-option {display:inline-block; text-align: center; height: 85%; position: relative; z-index: 10001}
 .kmw-suggestion-text {
   color:#fff;
-  line-height: normal;
   position: relative;
   vertical-align: middle;
   /* Contrast with .kmw-suggest-option::before .width styling.  */


### PR DESCRIPTION
Fixes: #13644

When a keyboard's layout specifies font-upscaling, that scaling should also be applied to the banner.  This was not previously being done, which could lead to font-size discrepancies between the two (as noted with `khmer_angkor` in the base issue).  Additionally, the banner should also double-check the height of its suggestions, applying downscaling where needed to ensure the suggestions' text does not flow out of bounds.  If the main keyboard body's keys require downscaling due to text height, this change will likely also result in similar scaling for the suggestions.

Note that not all cases are a perfect match:  on iOS tablets, there's an automatic 75% scaling applied to suggestion text, which can lead suggestions to appear smaller than main key text for some cases.  I assume there's a reason this has been applied there, so I decided against changing it without further discussion.  That said, my current tests suggest that it currently serves to align the font-size for two of the three keyboards in question here... just manually, with a prescribed, fixed value in CSS.

https://github.com/keymanapp/keyman/blob/8e8d769d58e5b57211e2f6d758afa9581094aaa7/web/src/resources/osk/kmwosk.css#L58-L60

`git blame` points to #1835 for this one - back in the 12.0 days.

## User Testing

About the test keyboards below:
- `sil_euro_latin` maintains default text scaling.
- `balochi_phonetic` applies a 1.4x multiplier to the default font scale.
- `khmer_angkor` applies a 0.8x multiplier to the default font scale.

GROUP_PIXEL_8a:  Use Keyman for Android on a Pixel 8a device (emulated or real)
GROUP_ANDROID_TABLET:  Use Keyman for Android on an Android tablet device (emulated or real)
GROUP_IOS_PHONE:  Use Keyman for iPhone and iPad on an iPhone SE device (emulated or real)
GROUP_IOS_TABLET:  Use Keyman for iPhone and iPad on an iPad device (emulated or real)

TEST_EUROLATIN:  Using `sil_euro_latin` and the default model associated with it, verify that suggestion text is scaled reasonably close to the size of text on the keyboard keys.
- Note:  on tablets, this may be somewhat smaller.  Verify that it is **_not significantly larger_**.

TEST_BALOCHI_PHONETIC:  Using the `balochi_phonetic` keyboard and the default model associated with it, verify that suggestion text is scaled reasonably close to the size of text on the keyboard keys.

TEST_KHMER_ANGKOR: Using the `khmer_angkor` keyboard and the default model associated with it, verify that suggestion text is scaled reasonably close to the size of text on the keyboard keys.