### PR TITLE
fix(linux): fix crash if kmp doesn't have name field

### DIFF
--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -36,11 +36,12 @@ class KeyboardDetailsView(Gtk.Dialog):
     # TODO clean up file once have what we want
     def __init__(self, parent, kmp):
         self.kmp = kmp
+        name = secure_lookup(kmp, 'name')
         # kmp has name, version, packageID, area
-        if "keyboard" in self.kmp["name"].lower():
-            wintitle = self.kmp["name"]
+        if name and "keyboard" in name.lower():
+            wintitle = name
         else:
-            wintitle = _("{name} keyboard").format(name=self.kmp["name"])
+            wintitle = _("{name} keyboard").format(name=name)
         super().__init__(wintitle, parent=parent)
         init_accel(self)
 

--- a/linux/keyman-config/keyman_config/keyboard_details.py
+++ b/linux/keyman-config/keyman_config/keyboard_details.py
@@ -36,8 +36,8 @@ class KeyboardDetailsView(Gtk.Dialog):
     # TODO clean up file once have what we want
     def __init__(self, parent, kmp):
         self.kmp = kmp
-        name = secure_lookup(kmp, 'name')
         # kmp has name, version, packageID, area
+        name = secure_lookup(kmp, 'name') or self.kmp['packageID']
         if name and "keyboard" in name.lower():
             wintitle = name
         else:


### PR DESCRIPTION
Fixes: #13647 
Fixes: KEYMAN-LINUX-80

@keymanapp-test-bot skip