### PR TITLE
chore: use explicit `node:` prefix for node imports

### DIFF
--- a/common/tools/hextobin/index.ts
+++ b/common/tools/hextobin/index.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as rd from 'readline';
+import * as fs from 'node:fs';
+import * as rd from 'node:readline';
 
 export default async function hextobin(inputFilename: string, outputFilename?: string, options?: {silent?: boolean}): Promise<Uint8Array> {
 

--- a/common/tools/sourcemap-path-remapper/src/index.ts
+++ b/common/tools/sourcemap-path-remapper/src/index.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import path from 'path';
+import * as fs from 'node:fs';
+import path from 'node:path';
 import convertSourceMap from 'convert-source-map'; // Transforms sourcemaps among various common formats.
                                                    // Base64, stringified-JSON, end-of-file comment...
 

--- a/core/tools/api-header-extractor/src/index.ts
+++ b/core/tools/api-header-extractor/src/index.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // TODO: support multiple infiles to generate from multiple headers
 

--- a/developer/src/common/web/test-helpers/TestCompilerCallbacks.ts
+++ b/developer/src/common/web/test-helpers/TestCompilerCallbacks.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { CompilerEvent, CompilerCallbacks, CompilerPathCallbacks, CompilerFileSystemCallbacks,
   CompilerError, CompilerNetAsyncCallbacks, DefaultCompilerFileSystemAsyncCallbacks,
   CompilerFileSystemAsyncCallbacks,

--- a/developer/src/common/web/utils/test/helpers/index.ts
+++ b/developer/src/common/web/utils/test/helpers/index.ts
@@ -1,9 +1,9 @@
 /**
  * Helpers and utilities for the Mocha tests.
  */
-import * as path from 'path';
-import * as fs from "fs";
-import { fileURLToPath } from 'url';
+import * as path from 'node:path';
+import * as fs from "node:fs";
+import { fileURLToPath } from 'node:url';
 
 /**
  * Builds a path to the fixture with the given path components.

--- a/developer/src/kmc-model/tools/create-override-script-regexp.ts
+++ b/developer/src/kmc-model/tools/create-override-script-regexp.ts
@@ -9,8 +9,8 @@
  * If you need to add more Unicode blocks, customize SPACELESS_SCRIPT_BLOCKS.
  */
 
-import {readFileSync} from "fs";
-import * as path from "path";
+import {readFileSync} from "node:fs";
+import * as path from "node:path";
 
 // Where to find UnicodeData.txt and Blocks.txt
 const UCD_DIR = path.join("..", "..", "..", "..", "resources", "standards-data", "unicode-character-database");

--- a/resources/build/version/src/fixupHistory.ts
+++ b/resources/build/version/src/fixupHistory.ts
@@ -3,7 +3,7 @@ import {
 } from '@actions/core';
 
 import { GitHub } from '@actions/github';
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { gt } from 'semver';
 import { reportHistory } from './reportHistory.js';
 import { spawnChild } from './util/spawnAwait.js';

--- a/resources/build/version/src/incrementVersion.ts
+++ b/resources/build/version/src/incrementVersion.ts
@@ -1,11 +1,11 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 // ------------------------------------------------------------------------------------
 // incrementVersion
 // ------------------------------------------------------------------------------------
 
 export const incrementVersion = () => {
-  // 1. 
+  // 1.
   const version = readFileSync('./VERSION.md', 'utf8');
   const triplet = version.split('.');
   const patch = parseInt(triplet[2], 10) + 1;

--- a/resources/build/version/src/index.ts
+++ b/resources/build/version/src/index.ts
@@ -5,7 +5,7 @@ import { sendCommentToPullRequestAndRelatedIssues, fixupHistory } from './fixupH
 import { incrementVersion } from './incrementVersion.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { reportHistory } from './reportHistory.js';
 
 const argv = await yargs(hideBin(process.argv))

--- a/web/src/engine/keyboard-storage/src/nodeCloudRequester.ts
+++ b/web/src/engine/keyboard-storage/src/nodeCloudRequester.ts
@@ -7,9 +7,9 @@ import {
   default as CloudQueryEngine
 } from './cloud/queryEngine.js';
 
-import fs from 'fs';
-import https from 'https';
-import vm from 'vm';
+import fs from 'node:fs';
+import https from 'node:https';
+import vm from 'node:vm';
 
 export default class NodeCloudRequester implements CloudRequesterInterface {
   private static QUERY_SEED = 1;

--- a/web/src/engine/predictive-text/wordbreakers/tools/data-compiler/index.ts
+++ b/web/src/engine/predictive-text/wordbreakers/tools/data-compiler/index.ts
@@ -2,8 +2,8 @@
 
 // Original version found at: https://github.com/eddieantonio/unicode-default-word-boundary/blob/master/libexec/compile-word-break.js
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);

--- a/web/src/engine/predictive-text/worker-main/src/node/mappedWorker.ts
+++ b/web/src/engine/predictive-text/worker-main/src/node/mappedWorker.ts
@@ -3,17 +3,17 @@
 /// <reference path="../worker-interface.d.ts" />
 
 // Defines types related to Node workers.
-import * as worker from 'worker_threads';
-import { Buffer } from 'buffer';
-import { URL } from 'url';
+import * as worker from 'node:worker_threads';
+import { Buffer } from 'node:buffer';
+import { URL } from 'node:url';
 
 /**
  * Defines mappings from Node Worker signatures to WebWorker signatures
  */
 const nodeWorkerToWebWorkerMappingSource = `
-import { parentPort } from 'worker_threads';
-import fs from 'fs';
-import vm from 'vm';
+import { parentPort } from 'node:worker_threads';
+import fs from 'node:fs';
+import vm from 'node:vm';
 
 function postMessage(...args) {
   parentPort.postMessage.call(parentPort, args);

--- a/web/src/tools/building/sourcemap-root/index.ts
+++ b/web/src/tools/building/sourcemap-root/index.ts
@@ -1,7 +1,7 @@
 import SourcemapRemapper from "@keymanapp/sourcemap-path-remapper"
 import convertSourceMap from 'convert-source-map'; // Transforms sourcemaps among various common formats.
                                                    // Base64, stringified-JSON, end-of-file comment...
-import fs from 'fs';
+import fs from 'node:fs';
 
 function displayHelp() {
   console.log("KeymanWeb's sourcemap-cleansing tool.  This tool is designed to produce clean filepaths");


### PR DESCRIPTION
This makes it easier for us to enumerate modules that have node dependencies. There may be others I have not yet picked up.

Note: this was pulled out of work on the upcoming kmc-test branch.

@keymanapp-test-bot skip