### PR TITLE
fix(android): Adjust keyboard and banner heights for mdpi and hdpi devices

### DIFF
--- a/android/KMEA/app/src/main/res/values-hdpi/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-hdpi/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dimens for hdpi Portrait (Phone) -->
+<resources>
+    <dimen name="banner_height">40dp</dimen>
+    <dimen name="keyboard_height">170dp</dimen>
+</resources>

--- a/android/KMEA/app/src/main/res/values-land-hdpi/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-land-hdpi/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dimens for hdpi Landscape (Phone) -->
+<resources>
+    <dimen name="banner_height">25dp</dimen>
+    <dimen name="keyboard_height">100dp</dimen>
+</resources>

--- a/android/KMEA/app/src/main/res/values-land/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-land/dimens.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Dimens for Landscape (Phone) -->
 <resources>
-    <dimen name="banner_height">40dp</dimen>
-    <dimen name="keyboard_height">100dp</dimen>
+    <dimen name="banner_height">28dp</dimen>
+    <dimen name="keyboard_height">120dp</dimen>
     <dimen name="key_width">49.25dp</dimen>
     <dimen name="key_height">49.25dp</dimen>
     <dimen name="popup_arrow_width">21dp</dimen>

--- a/android/docs/engine/KMManager/applyKeyboardHeight.md
+++ b/android/docs/engine/KMManager/applyKeyboardHeight.md
@@ -35,15 +35,13 @@ the height of the suggestion banner frame.
 
 For reference, here's a table of the default Keyman keyboard heights for various devices and screen orientation.
  
- Device Type and Screen Orientation | Default height (dp) |
-|-----------------------------------|---------------------|
-| Default handset in portrait | 205 |
-| Default handset in landscape | 150 |
-| Extra High Density handset in landscape | 140 |
-| 7" tablet in portrait | 305 |
-| 7" tablet in landscape | 140 |
-| 10" tablet in portrait | 405 |
-| 10" tablet in landscape | 200 |
+ Device Type                    | Default height (dp)<br>Portrait | Default height (dp)<br>Landscape |
+|-------------------------------|---------------------------------|----------------------------------|
+| Default handset (160dpi)      | 205 | 120 |
+| High Density handset (240dpi) | 170 | 100 |
+| Extra High Density handset (320dpi) |     | 140 |
+| 7" tablet                     | 305 | 140 |
+| 10" tablet                    | 405 | 200 |
 
 **Note:** This new keyboard height would be applied for all platforms, so an 
 adjusted keyboard height for a phone would appear too small for a tablet.


### PR DESCRIPTION
Addresses mdpi (160dpi using the baseline `values`) and hdpi (240 dpi using `values-hdpi`) devices for #13609

## Screenshots
Trying to squeeze into a table for side by side comparison. Dimensions should be the same - GH just scaling the previews.

### mdpi portrait
no change - shown for comparison
![baseline-portrait](https://github.com/user-attachments/assets/e2dd556e-ba40-4913-a499-13c54cbfb1a7)


### mdpi landscape
Made keyboard a little taller and banner smaller to be usable

| Before | New (latin ) | New (Khmer) | New ( Lao ) |
|-----------|------------------------------|---------------------|----------------|
 ![baseline-land](https://github.com/user-attachments/assets/5afe6ffd-1c50-4dbf-923c-c9e27ba6a777) |![baseline-land-adjusted](https://github.com/user-attachments/assets/aa0381ca-ed3d-4491-9f75-4b1e1ff98c11) |![baseline-land-adjusted-khmer](https://github.com/user-attachments/assets/91d6baf7-b6d9-4fc3-a188-e44602d6c8ab) |![baseline-land-adjusted-lao](https://github.com/user-attachments/assets/70b32589-ada8-4e34-b7e6-7a49808daa0f) |

------

### hdpi portrait
| Before | New (latin ) | New (Khmer) | New ( Lao ) |
|-----------|------------------------------|---------------------|----------------|
| ![hdpi-portait](https://github.com/user-attachments/assets/ba317aed-4247-4fea-9227-c4f210acda0a) | ![hdpi-portrait-adjusted](https://github.com/user-attachments/assets/545f558d-7bc7-4793-bbbb-d4c047269c7e) | ![hdpi-portrait-adjusted-khmer](https://github.com/user-attachments/assets/66338794-0e58-447c-822a-3a888d7c7bf0) | ![hdpi-portrait-adjusted-lao](https://github.com/user-attachments/assets/cdbdf31d-8ffc-4b55-9980-5fb35a7eb6a5) |


### hdpi landscape
| Before | New (latin ) | New (Khmer) | New ( Lao ) |
|-----------|------------------------------|---------------------|----------------|
| ![hdpi-land](https://github.com/user-attachments/assets/35d36f1c-e560-4857-a407-bd6e1c7f6019) | ![hdpi-land-adjusted](https://github.com/user-attachments/assets/7156ed33-5e40-42ed-8285-3f28a383c0d3) | ![hdpi-land-adjusted-khmer](https://github.com/user-attachments/assets/e3f61d1f-7041-4d70-824c-97f95bb91571) | ![hdpi-land-adjusted-lao](https://github.com/user-attachments/assets/b2b26968-606f-47f3-aa09-a1ff3a85e7b5) |


## User Testing
**Setup** - Install the PR build of Keyman for Android on Android emulator for following devices (corresponds to dpi). Phone form factor + Will need to check the box "Show obsolete device profiles".
* 5.1 WVGA (baseline mdpi 160 dpi device)
* Nexus S (hdpi 240 dpi device)
In Keyman, install khmer_angkor and basic_kbdlao keyboards

* **TEST_MDPI** - Verifies heights match sample screenshots in "mdpi landscape" table
1.  Launch Keyman for Android in 5.1 WVGA emulator in landscape orientation
2. Verify default sil_euro_latin matches screenshot in table
3. Switch to khmer_angkor
4. Verify khmer_angkor matches screenshot in table
5. Switch to Basic Lao
6. Verify basic_kbdlao matches screenshot in table

* **TEST_HDPI_PORTRAIT** - Verifies heights match sample screenshots in "hdpi portrait" table
1.  Launch Keyman for Android in Nexus S in portrait orientation
2. Verify default sil_euro_latin matches screenshot in table
3. Switch to khmer_angkor
4. Verify khmer_angkor matches screenshot in table
5. Switch to Basic Lao
6. Verify basic_kbdlao matches screenshot in table

* **TEST_HDPI_LANDSCAPE** - Verifies heights match sample screenshots in "hdpi landscape" table
1.  Launch Keyman for Android in Nexus S in landscape orientation
2. Verify default sil_euro_latin matches screenshot in table
3. Switch to khmer_angkor
4. Verify khmer_angkor matches screenshot in table
5. Switch to Basic Lao
6. Verify basic_kbdlao matches screenshot in table

