### PR TITLE
refactor(developer): rename developer/web/utils/common-messages.ts to developer-utils-messages.ts

### DIFF
--- a/developer/src/common/web/utils/src/compiler-interfaces.ts
+++ b/developer/src/common/web/utils/src/compiler-interfaces.ts
@@ -233,9 +233,10 @@ export enum CompilerErrorNamespace {
    */
   LdmlKeyboardCompiler = 0x0000,
   /**
-   * common/web/types errors between 0x1000…0x1FFF
+   * common/web/utils errors between 0x1000…0x1FFF
+   * was previously called CommonTypes
    */
-  CommonTypes = 0x1000,
+  DeveloperUtils = 0x1000,
   /**
    * kmc-kmn errors between 0x2000…0x2FFF; these map to
    * the base codes found in kmn_compiler_errors.h, exclusive severity flags

--- a/developer/src/common/web/utils/src/developer-utils-messages.ts
+++ b/developer/src/common/web/utils/src/developer-utils-messages.ts
@@ -4,14 +4,14 @@
 import { CompilerErrorNamespace, CompilerErrorSeverity,  CompilerMessageDef as def, CompilerMessageSpec as m } from './compiler-interfaces.js';
 import { constants } from '@keymanapp/ldml-keyboard-constants';
 
-const CommonTypesErrMask   = CompilerErrorNamespace.CommonTypes;
-// const SevInfo = CompilerErrorSeverity.Info   | CommonTypesErrMask;
-// const SevHint = CompilerErrorSeverity.Hint   | CommonTypesErrMask;
-// const SevWarn = CompilerErrorSeverity.Warn   | CommonTypesErrMask;
-const SevError = CompilerErrorSeverity.Error | CommonTypesErrMask;
-// const SevFatal = CompilerErrorSeverity.Fatal | CommonTypesErrMask;
+const DeveloperUtilsErrMask   = CompilerErrorNamespace.DeveloperUtils;
+// const SevInfo = CompilerErrorSeverity.Info   | DeveloperUtilsErrMask;
+// const SevHint = CompilerErrorSeverity.Hint   | DeveloperUtilsErrMask;
+// const SevWarn = CompilerErrorSeverity.Warn   | DeveloperUtilsErrMask;
+const SevError = CompilerErrorSeverity.Error | DeveloperUtilsErrMask;
+// const SevFatal = CompilerErrorSeverity.Fatal | DeveloperUtilsErrMask;
 
-export class CommonTypesMessages {
+export class DeveloperUtilsMessages {
   // structured Ajv validation error
   static ERROR_SchemaValidationError = SevError | 0x0001;
   static Error_SchemaValidationError = (o:{instancePath:string, keyword:string, message: string, params: string}) => m(this.ERROR_SchemaValidationError,

--- a/developer/src/common/web/utils/src/index.ts
+++ b/developer/src/common/web/utils/src/index.ts
@@ -63,7 +63,7 @@ export { defaultCompilerOptions, CompilerBaseOptions, CompilerOptions, CompilerE
 
 export { UrlSubpathCompilerCallback } from './utils/UrlSubpathCompilerCallback.js';
 
-export { CommonTypesMessages } from './common-messages.js';
+export { DeveloperUtilsMessages } from './developer-utils-messages.js';
 export * as SourceFilenamePatterns from './source-filename-patterns.js';
 export { KeymanXMLType, KeymanXMLWriter, KeymanXMLReader } from './xml-utils.js';
 

--- a/developer/src/common/web/utils/src/types/kps/kps-file-reader.ts
+++ b/developer/src/common/web/utils/src/types/kps/kps-file-reader.ts
@@ -9,7 +9,7 @@
 import { util } from '@keymanapp/common-types';
 import boxXmlArray = util.boxXmlArray;
 
-import { CommonTypesMessages } from "../../common-messages.js";
+import { DeveloperUtilsMessages } from "../../developer-utils-messages.js";
 import { CompilerCallbacks } from "../../compiler-callbacks.js";
 import { KeymanXMLReader } from "../../xml-utils.js";
 import { KpsPackage } from "./kps-file.js";
@@ -29,7 +29,7 @@ export class KpsFileReader {
           a = new KeymanXMLReader('kps')
             .parse(data) as KpsPackage;
         } catch(e) {
-          this.callbacks.reportMessage(CommonTypesMessages.Error_InvalidPackageFile({e}));
+          this.callbacks.reportMessage(DeveloperUtilsMessages.Error_InvalidPackageFile({e}));
         }
         return a;
     })();

--- a/developer/src/common/web/utils/src/types/ldml-keyboard/ldml-keyboard-xml-reader.ts
+++ b/developer/src/common/web/utils/src/types/ldml-keyboard/ldml-keyboard-xml-reader.ts
@@ -4,7 +4,7 @@
  * Reads a LDML XML keyboard file into JS object tree and resolves imports
  */
 import { SchemaValidators, util } from '@keymanapp/common-types';
-import { CommonTypesMessages } from '../../common-messages.js';
+import { DeveloperUtilsMessages } from '../../developer-utils-messages.js';
 import { CompilerCallbacks } from "../../compiler-callbacks.js";
 import { LDMLKeyboardXMLSourceFile, LKImport, ImportStatus } from './ldml-keyboard-xml.js';
 import { constants } from '@keymanapp/ldml-keyboard-constants';
@@ -219,7 +219,7 @@ export class LDMLKeyboardXMLSourceFileReader {
     const { base, path } = asImport;
     // If base is not an empty string (or null/undefined), then it must be 'cldr'
     if (base && base !== constants.cldr_import_base) {
-      this.callbacks.reportMessage(CommonTypesMessages.Error_ImportInvalidBase({base, path, subtag}));
+      this.callbacks.reportMessage(DeveloperUtilsMessages.Error_ImportInvalidBase({base, path, subtag}));
       return false;
     }
     let importData: Uint8Array;
@@ -228,7 +228,7 @@ export class LDMLKeyboardXMLSourceFileReader {
       // CLDR import
       const paths = path.split('/');
       if (paths[0] == '' || paths[1] == '' || paths.length !== 2) {
-        this.callbacks.reportMessage(CommonTypesMessages.Error_ImportInvalidPath({base, path, subtag}));
+        this.callbacks.reportMessage(DeveloperUtilsMessages.Error_ImportInvalidPath({base, path, subtag}));
         return false;
       }
       if (constants.treatAsLatest(paths[0])) {
@@ -241,7 +241,7 @@ export class LDMLKeyboardXMLSourceFileReader {
       importData = this.readLocalImportFile(path);
     }
     if (!importData || !importData.length) {
-      this.callbacks.reportMessage(CommonTypesMessages.Error_ImportReadFail({base, path, subtag}));
+      this.callbacks.reportMessage(DeveloperUtilsMessages.Error_ImportReadFail({base, path, subtag}));
       return false;
     }
     const importXml: any = this.loadUnboxed(importData); // TODO-LDML: have to load as any because it is an arbitrary part
@@ -249,7 +249,7 @@ export class LDMLKeyboardXMLSourceFileReader {
 
     // importXml will have one property: the root element.
     if (!importRootNode) {
-      this.callbacks.reportMessage(CommonTypesMessages.Error_ImportWrongRoot({base, path, subtag}));
+      this.callbacks.reportMessage(DeveloperUtilsMessages.Error_ImportWrongRoot({base, path, subtag}));
       return false;
     }
     // pull all children of importXml[subtag] into obj
@@ -259,7 +259,7 @@ export class LDMLKeyboardXMLSourceFileReader {
       if (!Array.isArray(subsubval)) {
         // This is somewhat of an internal error, indicating that a non-mergeable XML file was imported
         // Not exercisable with the standard LDML imports.
-        this.callbacks.reportMessage(CommonTypesMessages.Error_ImportMergeFail({base, path, subtag, subsubtag}));
+        this.callbacks.reportMessage(DeveloperUtilsMessages.Error_ImportMergeFail({base, path, subtag, subsubtag}));
         return false;
       }
       // Mark all children as an import
@@ -286,7 +286,7 @@ export class LDMLKeyboardXMLSourceFileReader {
   public validate(source: LDMLKeyboardXMLSourceFile | LDMLKeyboardTestDataXMLSourceFile): boolean {
     if(!SchemaValidators.default.ldmlKeyboard3(source)) {
       for (const err of (<any>SchemaValidators.default.ldmlKeyboard3).errors) {
-        this.callbacks.reportMessage(CommonTypesMessages.Error_SchemaValidationError({
+        this.callbacks.reportMessage(DeveloperUtilsMessages.Error_SchemaValidationError({
           instancePath: err.instancePath,
           keyword: err.keyword,
           message: err.message || 'Unknown AJV Error', // docs say 'message' is optional if 'messages:false' in options
@@ -318,7 +318,7 @@ export class LDMLKeyboardXMLSourceFileReader {
     try {
       source = this.loadUnboxed(file);
     } catch(e) {
-      this.callbacks.reportMessage(CommonTypesMessages.Error_InvalidXml({e}));
+      this.callbacks.reportMessage(DeveloperUtilsMessages.Error_InvalidXml({e}));
       return null;
     }
 
@@ -359,7 +359,7 @@ export class LDMLKeyboardXMLSourceFileReader {
     } else if (r.length === 1) {
       return r[0];
     } else {
-      this.callbacks.reportMessage(CommonTypesMessages.Error_TestDataUnexpectedArray({subtag}));
+      this.callbacks.reportMessage(DeveloperUtilsMessages.Error_TestDataUnexpectedArray({subtag}));
       return null; // ERROR
     }
   }

--- a/developer/src/common/web/utils/test/kps/kps-file-reader.tests.ts
+++ b/developer/src/common/web/utils/test/kps/kps-file-reader.tests.ts
@@ -14,7 +14,7 @@ import { makePathToFixture } from '../helpers/index.js';
 
 import { KpsFileReader } from "../../src/types/kps/kps-file-reader.js";
 import { KpsFileWriter } from '../../src/types/kps/kps-file-writer.js';
-import { CommonTypesMessages } from '../../src/common-messages.js';
+import { DeveloperUtilsMessages } from '../../src/developer-utils-messages.js';
 
 const callbacks = new TestCompilerCallbacks();
 
@@ -80,6 +80,6 @@ describe('kps-file-reader', function () {
 
     assert.isNull(kps);
     assert.lengthOf(callbacks.messages, 1);
-    assert.isTrue(callbacks.hasMessage(CommonTypesMessages.ERROR_InvalidPackageFile));
+    assert.isTrue(callbacks.hasMessage(DeveloperUtilsMessages.ERROR_InvalidPackageFile));
   });
 });

--- a/developer/src/common/web/utils/test/ldml/ldml-keyboard-xml-reader.tests.ts
+++ b/developer/src/common/web/utils/test/ldml/ldml-keyboard-xml-reader.tests.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import {assert} from 'chai';
+import { DeveloperUtilsMessages } from '../../src/developer-utils-messages.js';
 import { Constants } from '@keymanapp/common-types';
-import { CommonTypesMessages } from '../../src/common-messages.js';
 import { LKKey, ImportStatus } from '../../src/types/ldml-keyboard/ldml-keyboard-xml.js';
 import { testReaderCases } from '../helpers/reader-callback-test.js';
 
@@ -19,7 +19,7 @@ describe('ldml keyboard xml reader tests', function () {
   testReaderCases([
     {
       subpath: 'invalid-structure-per-dtd.xml',
-      errors: [CommonTypesMessages.Error_SchemaValidationError({
+      errors: [DeveloperUtilsMessages.Error_SchemaValidationError({
         instancePath: '/keyboard3',
         keyword: 'required',
         message: `must have required property 'info'`,
@@ -28,7 +28,7 @@ describe('ldml keyboard xml reader tests', function () {
     },
     {
       subpath: 'invalid-conforms-to.xml',
-      errors: [CommonTypesMessages.Error_SchemaValidationError({
+      errors: [DeveloperUtilsMessages.Error_SchemaValidationError({
         instancePath: '/keyboard3/conformsTo',
         keyword: 'enum',
         message: `must be equal to one of the allowed values`,
@@ -150,7 +150,7 @@ describe('ldml keyboard xml reader tests', function () {
       subpath: 'invalid-import-base.xml',
       loadfail: true,
       errors: [
-        CommonTypesMessages.Error_ImportInvalidBase({
+        DeveloperUtilsMessages.Error_ImportInvalidBase({
           base: 'SOME_INVALID_BASE',
           path: 'B',
           subtag: 'C'
@@ -161,7 +161,7 @@ describe('ldml keyboard xml reader tests', function () {
       subpath: 'invalid-import-local.xml',
       loadfail: true,
       errors: [
-        CommonTypesMessages.Error_ImportReadFail({
+        DeveloperUtilsMessages.Error_ImportReadFail({
           base: undefined,
           path: 'keys-Zyyy-DOESNOTEXIST.xml',
           subtag: 'keys'
@@ -172,7 +172,7 @@ describe('ldml keyboard xml reader tests', function () {
       subpath: 'invalid-import-path.xml',
       loadfail: true,
       errors: [
-        CommonTypesMessages.Error_ImportInvalidPath({
+        DeveloperUtilsMessages.Error_ImportInvalidPath({
           base: 'cldr',
           path: '45/too/many/slashes/leading/to/nothing-Zxxx-does-not-exist.xml',
           subtag: null,
@@ -183,7 +183,7 @@ describe('ldml keyboard xml reader tests', function () {
       subpath: 'invalid-import-readfail.xml',
       loadfail: true,
       errors: [
-        CommonTypesMessages.Error_ImportReadFail({
+        DeveloperUtilsMessages.Error_ImportReadFail({
           base: 'cldr',
           path: '45/none-Zxxx-does-not-exist.xml',
           subtag: null,
@@ -194,7 +194,7 @@ describe('ldml keyboard xml reader tests', function () {
       subpath: 'invalid-import-wrongroot.xml',
       loadfail: true,
       errors: [
-        CommonTypesMessages.Error_ImportWrongRoot({
+        DeveloperUtilsMessages.Error_ImportWrongRoot({
           base: null,
           path: '45/keys-Zyyy-punctuation.xml',
           subtag: 'flicks',

--- a/developer/src/kmc-package/src/compiler/package-compiler-messages.ts
+++ b/developer/src/kmc-package/src/compiler/package-compiler-messages.ts
@@ -144,7 +144,7 @@ export class PackageCompilerMessages {
     `The source file '${def(o.filename)}' should not be included in the package; instead include the compiled result.`
   );
 
-  // 0x001E was ERROR_InvalidPackageFile, now CommonTypesMessages.Error_InvalidPackageFile
+  // 0x001E was ERROR_InvalidPackageFile, now DeveloperUtilsMessages.Error_InvalidPackageFile
 
   static ERROR_FileRecordIsMissingName = SevError | 0x001F;
   static Error_FileRecordIsMissingName = (o:{description:string}) => m(this.ERROR_FileRecordIsMissingName,
@@ -191,7 +191,7 @@ export class PackageCompilerMessages {
     `The format for version numbers should be number[.number[.number]]. Each
     number component should be an integer, without leading zeroes.`
   );
-  
+
   static ERROR_PackageMustNotContainItself = SevError | 0x0028;
   static Error_PackageMustNotContainItself = (o:{outputFilename: string}) => m(
     this.ERROR_PackageMustNotContainItself, `The package may not include a .kmp file of the same name '${def(o.outputFilename)}'.`, `

--- a/developer/src/kmc/src/messages/messageNamespaces.ts
+++ b/developer/src/kmc/src/messages/messageNamespaces.ts
@@ -1,4 +1,4 @@
-import { CommonTypesMessages, CompilerErrorNamespace } from '@keymanapp/developer-utils';
+import { DeveloperUtilsMessages, CompilerErrorNamespace } from '@keymanapp/developer-utils';
 import { AnalyzerMessages } from '@keymanapp/kmc-analyze';
 import { CopierMessages } from '@keymanapp/kmc-copy';
 import { GeneratorMessages } from '@keymanapp/kmc-generate';
@@ -13,7 +13,7 @@ import { InfrastructureMessages } from './infrastructureMessages.js';
 // Maps every compiler error namespace to the corresponding implementation
 const messageNamespaces: Record<CompilerErrorNamespace, any> = {
   [CompilerErrorNamespace.LdmlKeyboardCompiler]: LdmlCompilerMessages,
-  [CompilerErrorNamespace.CommonTypes]: CommonTypesMessages,
+  [CompilerErrorNamespace.DeveloperUtils]: DeveloperUtilsMessages,
   [CompilerErrorNamespace.KmnCompiler]: KmnCompilerMessages,
   [CompilerErrorNamespace.ModelCompiler]: ModelCompilerMessages,
   [CompilerErrorNamespace.PackageCompiler]: PackageCompilerMessages,
@@ -38,7 +38,7 @@ export type CompilerMessageSource = {
 // TODO: consolidate with messageNamespaces above
 export const messageSources: Record<CompilerErrorNamespace, CompilerMessageSource> = {
   [CompilerErrorNamespace.LdmlKeyboardCompiler]: { module: 'kmc-ldml',          class: LdmlCompilerMessages },
-  [CompilerErrorNamespace.CommonTypes]:          { module: 'common-types',      class: CommonTypesMessages },
+  [CompilerErrorNamespace.DeveloperUtils]:       { module: 'developer-utils',   class: DeveloperUtilsMessages },
   [CompilerErrorNamespace.KmnCompiler]:          { module: 'kmc-kmn',           class: KmnCompilerMessages },
   [CompilerErrorNamespace.ModelCompiler]:        { module: 'kmc-model',         class: ModelCompilerMessages },
   [CompilerErrorNamespace.PackageCompiler]:      { module: 'kmc-package',       class: PackageCompilerMessages },


### PR DESCRIPTION
Renames common-messages.ts to developer-utils-messages.ts. This was split from /common/web/types, but the messages module retained the old name, which was confusing (two modules with same name).

This is more groundwork coming out of the upcoming kmc-test epic.

@keymanapp-test-bot skip