### PR TITLE
fix(android): adjust keyboard and banner height for xhdpi portrait

### DIFF
--- a/android/KMEA/app/src/main/res/values-xhdpi/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-xhdpi/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dimens for xhdpi Portrait (Phone) -->
+<resources>
+    <dimen name="banner_height">50dp</dimen>
+    <dimen name="keyboard_height">270dp</dimen>
+</resources>

--- a/android/docs/engine/KMManager/applyKeyboardHeight.md
+++ b/android/docs/engine/KMManager/applyKeyboardHeight.md
@@ -39,7 +39,7 @@ For reference, here's a table of the default Keyman keyboard heights for various
 |-------------------------------|---------------------------------|----------------------------------|
 | Default handset (160dpi)      | 205 | 120 |
 | High Density handset (240dpi) | 170 | 100 |
-| Extra High Density handset (320dpi) |     | 140 |
+| Extra High Density handset (320dpi) | 270 | 140 |
 | 7" tablet                     | 305 | 140 |
 | 10" tablet                    | 405 | 200 |
 


### PR DESCRIPTION
Follows #13651 and #13592 in addressing #13609 for xhdpi (320+ dpi) devices in portrait orientation

## Screenshots

Currently, the dimensions fall back to this in portrait

![default-portrait](https://github.com/user-attachments/assets/7f13ee97-ca42-4334-ae87-e89d8cf608d6)

### Adjusted xhdpi portrait 
(landscape already set in #13592)

| latin | khmer | lao |
|--------|------------|-------|
| ![adjusted-portrait](https://github.com/user-attachments/assets/36a655c5-8524-4272-8bc6-42fc07ff3ea9) | ![adjusted-portrait-khmer](https://github.com/user-attachments/assets/6c77e2b4-2c1c-4c93-90c7-ba2ce8b9cb2d) | ![adjusted-portrait-lao](https://github.com/user-attachments/assets/162bd5f9-32bc-4c19-8233-5f1a5795b841) |


@keymanapp-test-bot skip
