### PR TITLE
refactor(developer): consolidate project loader

### DIFF
--- a/developer/src/common/web/utils/src/developer-utils-messages.ts
+++ b/developer/src/common/web/utils/src/developer-utils-messages.ts
@@ -58,4 +58,22 @@ export class DeveloperUtilsMessages {
     this.ERROR_InvalidPackageFile,
     `Package source file is invalid: ${(o.e ?? 'unknown error').toString()}`
   );
+
+  static ERROR_InvalidProjectFile = SevError | 0x000A;
+  static Error_InvalidProjectFile = (o:{message:string}) => m(
+    this.ERROR_InvalidProjectFile,
+    `Project file is not valid: ${def(o.message)}`,
+  );
+
+  static ERROR_UnsupportedProjectVersion = SevError | 0x0013;
+  static Error_UnsupportedProjectVersion = (o:{version:string}) => m(
+    this.ERROR_UnsupportedProjectVersion,
+    `Project version ${def(o.version)} is not supported by this version of Keyman Developer.`,
+  );
+
+  static ERROR_ProjectFileCouldNotBeRead = SevError | 0x0014;
+  static Error_ProjectFileCouldNotBeRead = () => m(
+    this.ERROR_ProjectFileCouldNotBeRead,
+    `Project file could not be read`
+  );
 };

--- a/developer/src/common/web/utils/src/index.ts
+++ b/developer/src/common/web/utils/src/index.ts
@@ -71,3 +71,5 @@ export * as CloudUrls from './cloud-urls.js';
 export { getFontFamily, getFontFamilySync } from './font-family.js';
 
 export * as ValidIds from './valid-ids.js';
+
+export * as ProjectLoader from './project-loader.js';

--- a/developer/src/common/web/utils/src/project-loader.ts
+++ b/developer/src/common/web/utils/src/project-loader.ts
@@ -1,0 +1,34 @@
+import { KeymanDeveloperProject } from "./types/kpj/keyman-developer-project.js";
+import { KPJFileReader } from "./types/kpj/kpj-file-reader.js";
+import { CompilerAsyncCallbacks, CompilerCallbacks } from "./compiler-callbacks.js";
+import { DeveloperUtilsMessages } from "./developer-utils-messages.js";
+
+// TODO-KMC-TEST: refactor asyncCallbacks, make it a first-class part of CompilerCallbacks
+export async function loadProjectFromFile(infile: string, callbacks: CompilerCallbacks, asyncCallbacks: CompilerAsyncCallbacks = null): Promise<KeymanDeveloperProject> {
+  const kpjData = await (asyncCallbacks ?? callbacks).fsAsync.readFile(infile);
+  if(!kpjData) {
+    callbacks.reportMessage(DeveloperUtilsMessages.Error_ProjectFileCouldNotBeRead());
+    return null;
+  }
+  const reader = new KPJFileReader(callbacks);
+  let kpj = null;
+  try {
+    kpj = reader.read(kpjData);
+    if(!kpj) {
+      callbacks.reportMessage(DeveloperUtilsMessages.Error_ProjectFileCouldNotBeRead());
+      return null;
+    }
+
+    if(kpj.KeymanDeveloperProject?.Options?.Version && kpj.KeymanDeveloperProject.Options.Version != "1.0" && kpj.KeymanDeveloperProject.Options.Version != "2.0") {
+      callbacks.reportMessage(DeveloperUtilsMessages.Error_UnsupportedProjectVersion({version: kpj.KeymanDeveloperProject.Options.Version}));
+      return null;
+    }
+    reader.validate(kpj);
+  } catch(e) {
+    callbacks.reportMessage(DeveloperUtilsMessages.Error_InvalidProjectFile({message: (e??'').toString()}));
+    return null;
+  }
+  const project = await reader.transform(infile, kpj);
+  return project;
+}
+

--- a/developer/src/kmc-copy/src/copier-messages.ts
+++ b/developer/src/kmc-copy/src/copier-messages.ts
@@ -92,22 +92,9 @@ export class CopierMessages {
     `The package source file '${def(o.filename)}' could not be loaded. The file may have an invalid format`
   );
 
-  static ERROR_UnsupportedProjectVersion = SevError | 0x000D;
-  static Error_UnsupportedProjectVersion = (o:{filename: string, version: string}) => m(this.ERROR_UnsupportedProjectVersion,
-    `Project version ${def(o.version)} for '${def(o.filename)}' is not supported by this version of Keyman Developer`
-  );
-
-  static ERROR_InvalidProjectFile = SevError | 0x000E;
-  static Error_InvalidProjectFile = (o:{filename: string, message: string}) => m(
-    this.ERROR_InvalidProjectFile,
-    `Project file '${def(o.filename)}' is not valid: ${def(o.message)}`
-  );
-
-  static ERROR_ProjectFileCouldNotBeRead = SevError | 0x000F;
-  static Error_ProjectFileCouldNotBeRead = (o:{filename: string}) => m(
-    this.ERROR_ProjectFileCouldNotBeRead,
-    `Project file '${def(o.filename)}' could not be read`
-  );
+  // 0x000D ERROR_UnsupportedProjectVersion: moved to developer-utils-messages
+  // 0x000E ERROR_InvalidProjectFile: moved to developer-utils-messages
+  // 0x000F ERROR_ProjectFileCouldNotBeRead: moved to developer-utils-messages
 
   static INFO_DryRun = SevInfo | 0x0010;
   static Info_DryRun = (o:{outPath: string}) => m(

--- a/developer/src/kmc-copy/tsconfig.json
+++ b/developer/src/kmc-copy/tsconfig.json
@@ -9,6 +9,7 @@
     "paths": {
       "@keymanapp/keyman-version": ["../../../common/web/keyman-version/keyman-version.mts"],
       "@keymanapp/common-types": ["../../../common/web/types/src/main"],
+      "@keymanapp/developer-utils": ["../common/web/utils"],
     },
 
   },
@@ -21,5 +22,6 @@
   "references": [
     { "path": "../../../common/web/keyman-version" },
     { "path": "../../../common/web/types/" },
+    { "path": "../common/web/utils/" },
   ]
 }

--- a/developer/src/kmc/src/messages/infrastructureMessages.ts
+++ b/developer/src/kmc/src/messages/infrastructureMessages.ts
@@ -38,9 +38,7 @@ export class InfrastructureMessages {
   static Info_FileNotBuiltSuccessfully = (o:{filename:string,relativeFilename:string}) => ({filename:o.filename, ...m(this.INFO_FileNotBuiltSuccessfully,
     `${def(o.relativeFilename)} failed to build.`)});
 
-  static ERROR_InvalidProjectFile = SevError | 0x0008;
-  static Error_InvalidProjectFile = (o:{message:string}) => m(this.ERROR_InvalidProjectFile,
-    `Project file is not valid: ${def(o.message)}`);
+  // 0x0008: ERROR_InvalidProjectFile moved to DeveloperUtilsMessages
 
   static HINT_FilenameHasDifferingCase = SevHint | 0x0009;
   static Hint_FilenameHasDifferingCase = (o:{reference:string, filename:string}) => m(this.HINT_FilenameHasDifferingCase,
@@ -84,9 +82,7 @@ export class InfrastructureMessages {
   static Error_InvalidProjectFolder = (o:{folderName:string}) => m(this.ERROR_InvalidProjectFolder,
     `The folder ${def(o.folderName)} does not appear to be a Keyman Developer project.`);
 
-  static ERROR_UnsupportedProjectVersion = SevError | 0x0013;
-  static Error_UnsupportedProjectVersion = (o:{version:string}) => m(this.ERROR_UnsupportedProjectVersion,
-    `Project version ${def(o.version)} is not supported by this version of Keyman Developer.`);
+  // 0x0013: ERROR_UnsupportedProjectVersion moved to developer-utils-messages
 
   static HINT_ProjectIsVersion10 = SevHint | 0x0014;
   static Hint_ProjectIsVersion10 = () => m(this.HINT_ProjectIsVersion10,

--- a/developer/src/kmc/test/infrastructureMessages.tests.ts
+++ b/developer/src/kmc/test/infrastructureMessages.tests.ts
@@ -10,7 +10,7 @@ import { unitTestEndpoints } from '../src/commands/build.js';
 import { KmnCompilerMessages } from '@keymanapp/kmc-kmn';
 import { clearOptions } from '../src/util/options.js';
 import { loadProject } from '../src/util/projectLoader.js';
-import { CompilerErrorNamespace, CompilerEvent, defaultCompilerOptions, CompilerOptions} from '@keymanapp/developer-utils';
+import { CompilerErrorNamespace, CompilerEvent, defaultCompilerOptions, CompilerOptions, DeveloperUtilsMessages} from '@keymanapp/developer-utils';
 import { analyzeUnitTestEndpoints } from '../src/commands/analyze.js';
 import { BuildKeyboardInfo } from '../src/commands/buildClasses/BuildKeyboardInfo.js';
 import { BuildModelInfo } from '../src/commands/buildClasses/BuildModelInfo.js';
@@ -71,12 +71,12 @@ describe('InfrastructureMessages', function () {
       'ERROR_OutFileNotValidForProjects not generated, instead got: '+JSON.stringify(ncb.messages,null,2));
   });
 
-  // ERROR_InvalidProjectFile
+  // ERROR_InvalidProjectFile - test stays here for now though referencing developer-messages
 
   it('should generate ERROR_InvalidProjectFile if a project file is invalid', async function() {
     const ncb = new NodeCompilerCallbacks({logLevel: 'silent'});
     await unitTestEndpoints.build(makePathToFixture('invalid-projects', 'error_invalid_project_file.kpj'), null, ncb, {});
-    assert.isTrue(ncb.hasMessage(InfrastructureMessages.ERROR_InvalidProjectFile),
+    assert.isTrue(ncb.hasMessage(DeveloperUtilsMessages.ERROR_InvalidProjectFile),
       'ERROR_InvalidProjectFile not generated, instead got: '+JSON.stringify(ncb.messages,null,2));
   });
 
@@ -202,14 +202,14 @@ describe('InfrastructureMessages', function () {
     assertMessagesEqual(ncb.messages, expectedMessages);
   });
 
-  // ERROR_UnsupportedProjectVersion
+  // ERROR_UnsupportedProjectVersion (test stays here for now though referencing developer-utils)
 
   it('should generate ERROR_UnsupportedProjectVersion if a project file with an unsupported version is loaded', async function() {
     const ncb = new NodeCompilerCallbacks({logLevel: 'silent'});
     const filename = makePathToFixture('invalid-projects', 'error_unsupported_project_version.kpj');
     const expectedMessages = [
       InfrastructureMessages.INFO_BuildingFile,
-      InfrastructureMessages.ERROR_UnsupportedProjectVersion,
+      DeveloperUtilsMessages.ERROR_UnsupportedProjectVersion,
       InfrastructureMessages.INFO_ProjectNotBuiltSuccessfully
     ];
     await unitTestEndpoints.build(filename, null, ncb, {compilerWarningsAsErrors: true});


### PR DESCRIPTION
Consolidates project loading code from kmc and kmc-copy, in preparation for kmc-test epic. This leaves open a change we need to make to CompilerCallbacks, to consolidate the fsAsync and net callbacks into CompilerCallbacks as a first-class part of CompilerCallbacks. We will then need to start to move all the fs and net callback interactions to the async model across all kmc modules, at some point.

@keymanapp-test-bot skip