### PR TITLE
chore(web): improve error logging in predictive-text worker message validation

### DIFF
--- a/web/src/engine/predictive-text/worker-main/src/lmlayer.ts
+++ b/web/src/engine/predictive-text/worker-main/src/lmlayer.ts
@@ -202,11 +202,12 @@ export default class LMLayer {
   //       Worker code must recognize message and call self.close().
 
   private onMessage(event: MessageEvent): void {
-    let payload: OutgoingMessage = event.data;
+    const payload: OutgoingMessage = event.data;
     if (payload.message === 'error') {
-      console.error(payload.log);
-      if(payload.error) {
-        console.error(payload.error);
+      if (payload.error) {
+        console.error(`${payload.log}\n${payload.error}`);
+      } else {
+        console.error(payload.log);
       }
     }
     else if (payload.message === 'ready') {


### PR DESCRIPTION
Previously logging an error resulted in two Sentry issues to be created. This change now combines the log message and the error into one call to `console.error`, thus resulting in only one Sentry issue being created.

@keymanapp-test-bot skip