### PR TITLE
fix(android): Adjust keyboard and banner height for 7" tablet landscape

### DIFF
--- a/android/KMEA/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Dimens for Landscape (Tablet 7") -->
 <resources>
-    <dimen name="banner_height">50dp</dimen>
-    <dimen name="keyboard_height">140dp</dimen>
+    <dimen name="banner_height">45dp</dimen>
+    <dimen name="keyboard_height">200dp</dimen>
     <dimen name="key_width">73.5dp</dimen>
     <dimen name="key_height">58.5dp</dimen>
     <dimen name="popup_arrow_width">32dp</dimen>

--- a/android/docs/engine/KMManager/applyKeyboardHeight.md
+++ b/android/docs/engine/KMManager/applyKeyboardHeight.md
@@ -40,7 +40,7 @@ For reference, here's a table of the default Keyman keyboard heights for various
 | Default handset (160dpi)      | 205 | 120 |
 | High Density handset (240dpi) | 170 | 100 |
 | Extra High Density handset (320dpi) | 270 | 140 |
-| 7" tablet                     | 305 | 140 |
+| 7" tablet                     | 305 | 200 |
 | 10" tablet                    | 405 | 200 |
 
 **Note:** This new keyboard height would be applied for all platforms, so an 


### PR DESCRIPTION
Follows #13655 in addressing #13609 for sw600 (7" tablet) devices adjusting keyboard and banner height for landscape orientation

## Screenshots


### Portrait orientation (no change)

| latin | khmer| lao |
|-------|-----------|-------|
| ![default-portrait](https://github.com/user-attachments/assets/5fddfed8-474a-49db-83db-68b9a6cf7276) | ![default-portrait-khmer](https://github.com/user-attachments/assets/d22cc73a-58cb-4794-b72a-c8965396811a) | ![default-portrait-lao](https://github.com/user-attachments/assets/73116416-0cf5-4541-a329-93cce18bd3d1) |

-----

### Landscape orientation

**Original**
| latin | khmer| lao |
|-------|-----------|-------|
| ![default-land](https://github.com/user-attachments/assets/48ebc05d-7978-4af8-aee0-b9f57d87f05e) | ![default-land-khmer](https://github.com/user-attachments/assets/7e1b3399-f69e-4d70-bea5-5bbc4c7d1f80) | ![default-land-lao](https://github.com/user-attachments/assets/2878f054-bfa8-4ca2-a5e8-973f273e90be) |

**Adjusted**
Increased keyboard height and lowered banner height to make usable

| latin | khmer| lao |
|-------|-----------|-------|
| ![adjusted-land](https://github.com/user-attachments/assets/f2f78248-27bd-4923-be87-9f337f86c8aa) | ![adjusted-land-khmer](https://github.com/user-attachments/assets/df5590bd-a3c8-4ff1-9a9f-d86bb94b122e) | ![adjusted-land-lao](https://github.com/user-attachments/assets/beaaff6a-3ceb-422d-98f8-22baec7e3f87) |

@keymanapp-test-bot skip

