### PR TITLE
fix(android): Adjust keyboard height for 10" tablet landscape

### DIFF
--- a/android/KMEA/app/src/main/res/values-sw720dp-land/dimens.xml
+++ b/android/KMEA/app/src/main/res/values-sw720dp-land/dimens.xml
@@ -2,7 +2,7 @@
 <!-- Dimens for Landscape (Tablet 10") -->
 <resources>
     <dimen name="banner_height">60dp</dimen>
-    <dimen name="keyboard_height">200dp</dimen>
+    <dimen name="keyboard_height">280dp</dimen>
     <dimen name="key_width">98.5dp</dimen>
     <dimen name="key_height">98.5dp</dimen>
     <dimen name="popup_arrow_width">42dp</dimen>

--- a/android/docs/engine/KMManager/applyKeyboardHeight.md
+++ b/android/docs/engine/KMManager/applyKeyboardHeight.md
@@ -41,7 +41,7 @@ For reference, here's a table of the default Keyman keyboard heights for various
 | High Density handset (240dpi) | 170 | 100 |
 | Extra High Density handset (320dpi) | 270 | 140 |
 | 7" tablet                     | 305 | 200 |
-| 10" tablet                    | 405 | 200 |
+| 10" tablet                    | 405 | 280 |
 
 **Note:** This new keyboard height would be applied for all platforms, so an 
 adjusted keyboard height for a phone would appear too small for a tablet.


### PR DESCRIPTION
Follows #13657 in addressing #13609 for sw720 (10" tablet) devices adjusting keyboard height for landscape orientation

## Screenshots


### Portrait orientation (no change)

| latin | khmer| lao |
|-------|-----------|-------|
| ![default-portrait](https://github.com/user-attachments/assets/2ae1d33e-7cbc-459d-9674-acae2a8218ff) | ![defualt-portrait-khmer](https://github.com/user-attachments/assets/ff45166a-09c2-4252-955a-4765a944f341) | ![default-portrait-lao](https://github.com/user-attachments/assets/afb331dc-69f5-4538-8210-7570d6143cda) |


-----

### Landscape orientation

**Original**
| latin | khmer| lao |
|-------|-----------|-------|
| ![default-land](https://github.com/user-attachments/assets/f5a7c8f5-3650-49e9-b326-20ba7f146472) | ![default-land-khmer](https://github.com/user-attachments/assets/846bdf28-aa87-4ae5-a7c0-566511dfce32) | ![default-land-lao](https://github.com/user-attachments/assets/2df82fa5-914a-4f7c-b5b0-5ef2ab05839a) |

**Adjusted**
Increased keyboard height to make usable

| latin | khmer| lao |
|-------|-----------|-------|
| ![adjusted-land](https://github.com/user-attachments/assets/a2ef1697-5a64-4d64-8697-2e3c9b4b46ec) | ![adjusted-land-khmer](https://github.com/user-attachments/assets/b3e85d03-d7e2-4879-bc6e-ef00b833c7a2) | ![adjusted-land-lao](https://github.com/user-attachments/assets/b193a3de-e717-4dc7-9edb-fece172d413d) |


@keymanapp-test-bot skip

