### PR TITLE
chore(web): remove dead methods regarding keyboard state

### DIFF
--- a/web/src/engine/keyboard/src/keyboards/keyboard.ts
+++ b/web/src/engine/keyboard/src/keyboards/keyboard.ts
@@ -27,8 +27,7 @@ class CacheTag {
 
 export enum LayoutState {
   NOT_LOADED = undefined,
-  POLYFILLED = 1,
-  CALIBRATED = 2
+  POLYFILLED = 1
 }
 
 export interface VariableStoreDictionary {
@@ -454,22 +453,9 @@ export default class Keyboard {
     let _this = this;
 
     formFactors.forEach(function(form) {
-      // Currently doesn't work if we reset it to POLYFILLED, likely due to how 'calibration'
-      // currently works.
       _this.layoutStates[form] = LayoutState.NOT_LOADED;
     });
   }
-
-  public markLayoutCalibrated(formFactor: DeviceSpec.FormFactor) {
-    if(this.layoutStates[formFactor] != LayoutState.NOT_LOADED) {
-      this.layoutStates[formFactor] = LayoutState.CALIBRATED;
-    }
-  }
-
-  public getLayoutState(formFactor: DeviceSpec.FormFactor) {
-    return this.layoutStates[formFactor];
-  }
-
 
   constructNullKeyEvent(device: DeviceSpec, stateKeys?: StateKeyMap): KeyEvent {
     stateKeys = stateKeys || {

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -354,11 +354,6 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
 
     this.layerGroup = new OSKLayerGroup(this, this.layoutKeyboard, formFactor);
 
-    // Now that we've properly processed the keyboard's layout, mark it as calibrated.
-    // TODO:  drop the whole 'calibration' thing.  The newer layout system supersedes the
-    // need for it.  (Is no longer really used, so the drop ought be clean.)
-    this.layoutKeyboard.markLayoutCalibrated(formFactor);
-
     // Append the OSK layer group container element to the containing element
     //osk.keyMap = divLayerContainer;
     Lkbd.appendChild(this.layerGroup.element);


### PR DESCRIPTION
@keymanapp-test-bot skip

I've tested locally and verified no ill effects result from these changes.