### PR TITLE
docs(android): Document default keyboard height for xxxhdpi devices

### DIFF
--- a/android/docs/engine/KMManager/applyKeyboardHeight.md
+++ b/android/docs/engine/KMManager/applyKeyboardHeight.md
@@ -40,6 +40,7 @@ For reference, here's a table of the default Keyman keyboard heights for various
 | Default handset (160dpi)      | 205 | 120 |
 | High Density handset (240dpi) | 170 | 100 |
 | Extra High Density handset (320dpi) | 270 | 140 |
+| Extra Extra Extra<br>High Density handset (640 dpi) | 270 | 140 |
 | 7" tablet                     | 305 | 200 |
 | 10" tablet                    | 405 | 280 |
 


### PR DESCRIPTION
Follows #13668 and relates to #13609

No change to portrait or landscape keyboard heights for xxxhdpi devices, so just documenting in the table

Using Nexus 6 (obsolete) emulator to generate the screenshots

## Screenshots

### portrait

| latin | khmer | lao |
|--------|-----------|------|
| ![default portrait](https://github.com/user-attachments/assets/b2e08ec6-55fb-4322-a039-e1f1a809cf22) | ![default-portrait-khmer](https://github.com/user-attachments/assets/7311221a-b6c3-4a38-9a9b-e25a0b435b4d) | ![default-portrait-lao](https://github.com/user-attachments/assets/f313ed99-da28-4d32-866a-650e8cdaf54c) |

### landscape

| latin | khmer| lao |
|--------|-----------|------|
| ![default-land](https://github.com/user-attachments/assets/536d0ad1-9bca-41ee-8255-814d2ceff2fc) | ![default-land-khmer](https://github.com/user-attachments/assets/a5dfd698-d4a4-4c36-9b7e-affbae736f37) | ![default-land-lao](https://github.com/user-attachments/assets/6cbd972b-298b-4b5e-ad3a-86a105b5b196) |

@keymanapp-test-bot skip
