### PR TITLE
fix(android): Updating local current height

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2351,8 +2351,10 @@ public final class KMManager {
       // Store the new height based on the current orientation
       if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
         editor.putInt(KMManager.KMKey_KeyboardHeightLandscape, height);
+        KMManager.KeyboardHeight_Context_Landscape_Current = height;
       } else /* (orientation == Configuration.ORIENTATION_PORTRAIT) */ {
         editor.putInt(KMManager.KMKey_KeyboardHeightPortrait, height);
+        KMManager.KeyboardHeight_Context_Portrait_Current = height;
       } 
     }
     editor.commit();

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -2351,11 +2351,16 @@ public final class KMManager {
       // Store the new height based on the current orientation
       if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
         editor.putInt(KMManager.KMKey_KeyboardHeightLandscape, height);
-        KMManager.KeyboardHeight_Context_Landscape_Current = height;
       } else /* (orientation == Configuration.ORIENTATION_PORTRAIT) */ {
         editor.putInt(KMManager.KMKey_KeyboardHeightPortrait, height);
-        KMManager.KeyboardHeight_Context_Portrait_Current = height;
       } 
+    }
+
+    // Update the height based on the current orientation
+    if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+      KeyboardHeight_Context_Landscape_Current = height;
+    } else /* (orientation == Configuration.ORIENTATION_PORTRAIT) */ {
+      KeyboardHeight_Context_Portrait_Current = height;
     }
     editor.commit();
     // Confirm new LayoutParams for in-app or system keyboards 


### PR DESCRIPTION
We missed a step of updating the local KeyboardHeight_Context_Landscape_Current and KeyboardHeight_Context_Portrait_Current, which means getKeyboardHeight() can report out-of-date values. 

Please apply this 2-line patch to complete the other work. I guess we can use the user test from [the previous PR](https://github.com/keymanapp/keyman/pull/13578).