### PR TITLE
fix(ios): do not show notification for downloaded keyboard when showing its installer

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -23,9 +23,9 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
   private var selectedSection = 0
   private var installedLanguages: [String: Language]
   private var languages: [Language] = []
-  
+
   private var isDidUpdateCheck = false
-  
+
   private var packageDownloadStartedObserver: NotificationObserver?
   private var packageDownloadCompletedObserver: NotificationObserver?
   private var packageDownloadFailedObserver: NotificationObserver?
@@ -40,11 +40,11 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     }
     super.init(nibName: nil, bundle: nil)
   }
-  
+
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-  
+
   override public func loadView() {
     super.loadView()
     languages = languageList(installedLanguages)
@@ -55,7 +55,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
       a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
     }
   }
-  
+
   override public func viewDidLoad() {
     super.viewDidLoad()
 
@@ -73,7 +73,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
       forName: Notifications.packageDownloadFailed,
       observer: self,
       function: InstalledLanguagesViewController.packageDownloadFailed)
-    
+
     batchUpdateStartedObserver = NotificationCenter.default.addObserver(
       forName: Notifications.batchUpdateStarted,
       observer: self,
@@ -82,25 +82,25 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
       forName: Notifications.batchUpdateCompleted,
       observer: self,
       function: InstalledLanguagesViewController.batchUpdateCompleted)
-    
+
     if Manager.shared.canAddNewKeyboards {
       let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self,
                                       action: #selector(self.addClicked))
       navigationItem.rightBarButtonItem = addButton
     }
-    
+
     os_log("viewDidLoad: InstalledLanguagesViewController (registered for keyboardDownloadStarted)", log:KeymanEngineLogger.resources, type: .info)
   }
-  
+
   override public func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     loadUserKeyboards()
     loadUserLexicalModels()
   }
-  
+
   override public func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-    
+
     // if no rows to show yet, show a loading indicator
     if numberOfSections(in: tableView) == 0 {
       showActivityView()
@@ -112,23 +112,23 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
       // Nope; don't make an 'update' button.
       return
     }
-    
+
     if ResourceDownloadManager.shared.updatesAvailable == false {
       // No updates available?  Don't do update-y things.
       return
     }
-    
+
     // We do have updates - prepare the UI!
     if let toolbar = navigationController?.toolbar as? ResourceDownloadStatusToolbar {
       toolbar.displayButton(NSLocalizedString("notification-update-available", bundle: engineBundle, comment: ""), with: self, callback: #selector(self.updateClicked))
     }
   }
-  
+
   @objc func updateClicked(_ sender: Any) {
     if let toolbar = navigationController?.toolbar as? ResourceDownloadStatusToolbar {
       toolbar.displayStatus(NSLocalizedString("notification-update-processing", bundle: engineBundle, comment: ""), withIndicator: true)
     }
-    
+
     // Do the actual updates!
     // TODO:  Consider prompting per resource, rather than wholesale as a group.
     // (This would be an enhancement, though.)
@@ -140,11 +140,11 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
         //        (See `batchUpdateCompleted` later in this file.)
       })
   }
-  
+
   override public func numberOfSections(in tableView: UITableView) -> Int {
     return languages.count
   }
-  
+
   private static func loadUserLanguages() -> [String: Language] {
     //iterate the list of installed languages and save their names
     // Get keyboards list if it exists in user defaults, otherwise create a new one
@@ -185,11 +185,11 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
 
     return keyboardLanguages
   }
-  
+
   override public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return 1
   }
-  
+
   override public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cellIdentifierType1 = "CellType1"
     let cellIdentifierType2 = "CellType2"
@@ -218,13 +218,13 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
       String.localizedStringWithFormat(formatString, keyboards.count)
     return cell
   }
-  
+
   // Create sections by first letter
   override public func sectionIndexTitles(for tableView: UITableView) -> [String] {
     if !sectionIndexTitles.isEmpty {
       return sectionIndexTitles
     }
-    
+
     sectionIndexTitles = []
     indices = []
     for (index, language) in languages.enumerated() {
@@ -236,43 +236,43 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     }
     return sectionIndexTitles
   }
-  
+
   override public func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
     return indices[index]
   }
-  
+
   override public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
     guard let language = languages[safe: indexPath.section] else {
       return
     }
-    
+
     cell.textLabel?.text = language.name
   }
-  
+
   override public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     selectedSection = indexPath.section
     tableView.cellForRow(at: indexPath)?.isSelected = false
     let title = tableView.cellForRow(at: indexPath)?.textLabel?.text ?? ""
     showLanguageSettingsView(title: title, languageIndex: indexPath.section)
   }
-  
+
   override public func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
     let title = tableView.cellForRow(at: indexPath)?.textLabel?.text ?? ""
     showLanguageSettingsView(title: title, languageIndex: indexPath.section)
   }
-  
+
   private func showLanguageSettingsView(title: String, languageIndex: Int) {
     let langSettingsView = LanguageSettingsViewController(languages[languageIndex])
     langSettingsView.title = title
     navigationController?.pushViewController(langSettingsView, animated: true)
   }
-  
+
   func errorAcknowledgmentHandler(withAction action: UIAlertAction) {
     if !languages.isEmpty {
       navigationController?.popToRootViewController(animated: true)
     }
   }
-  
+
   private func restoreNavigation() {
     view.isUserInteractionEnabled = true
     navigationItem.setHidesBackButton(false, animated: true)
@@ -317,7 +317,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
           msg = NSLocalizedString("notification-download-success-lexical-model", bundle: engineBundle, comment: "")
       }
 
-      if let toolbar = self.navigationController?.toolbar as? ResourceDownloadStatusToolbar {
+      if package.resourceType() == .lexicalModel, let toolbar = self.navigationController?.toolbar as? ResourceDownloadStatusToolbar {
         toolbar.displayStatus(msg, withIndicator: false, duration: 3.0)
       }
 
@@ -356,16 +356,16 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
       self.navigationController?.popToRootViewController(animated: true)
     }
   }
-  
+
   private func batchUpdateStarted(_: [AnyLanguageResource]) {
     os_log("batchUpdateStarted: InstalledLanguagesViewController", log:KeymanEngineLogger.resources, type: .info)
     view.isUserInteractionEnabled = false
     navigationItem.setHidesBackButton(true, animated: true)
-    
+
     guard let toolbar = navigationController?.toolbar as? ResourceDownloadStatusToolbar else {
       return
     }
-    
+
     toolbar.displayStatus(NSLocalizedString("notification-update-available", bundle: engineBundle, comment: ""), withIndicator: true)
   }
 
@@ -386,7 +386,7 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
       self.restoreNavigation()
     }
   }
-  
+
   func showActivityView() {
     view.isUserInteractionEnabled = false
     let indicatorView = UIActivityIndicatorView(style: .whiteLarge)
@@ -397,45 +397,45 @@ public class InstalledLanguagesViewController: UITableViewController, UIAlertVie
     activityView.tag = activityViewTag
     activityView.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin,
                                      .flexibleBottomMargin]
-    
+
     indicatorView.center = CGPoint(x: activityView.bounds.size.width * 0.5, y: activityView.bounds.size.height * 0.5)
     indicatorView.startAnimating()
     activityView.addSubview(indicatorView)
     view.addSubview(activityView)
   }
-  
+
   func dismissActivityView() {
     let activityView = view.viewWithTag(activityViewTag)
     activityView?.removeFromSuperview()
     view.isUserInteractionEnabled = true
   }
-  
+
   func loadUserKeyboards() {
     userKeyboards = [:]
     guard let userKbList = Storage.active.userDefaults.userKeyboards else {
       return
     }
-    
+
     for kb in userKbList {
       let dictKey = "\(kb.languageID)_\(kb.id)"
       userKeyboards[dictKey] = kb
     }
     tableView.reloadData()
   }
-  
+
   func loadUserLexicalModels() {
     userLexicalModels = [:]
     guard let userLmList = Storage.active.userDefaults.userLexicalModels else {
       return
     }
-    
+
     for lm in userLmList {
       let dictKey = "\(lm.languageID)_\(lm.id)"
       userLexicalModels[dictKey] = lm
     }
     tableView.reloadData()
  }
-  
+
   private func showConnectionErrorAlert() {
     dismissActivityView()
     Alerts.showDownloadErrorAlert(in: self, handler: errorAcknowledgmentHandler)
@@ -456,6 +456,7 @@ extension InstalledLanguagesViewController {
             os_log("%{public}s", log:KeymanEngineLogger.resources, type: .error, errorMessage)
           }
         case .success(let package, let fullID):
+        self.navigationController?.setToolbarHidden(true, animated: false)
           ResourceFileManager.shared.doInstallPrompt(for: package as! KeyboardKeymanPackage,
                                                      defaultLanguageCode: fullID.languageID,
                                                      in: self.navigationController!,

--- a/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Settings/InstalledLanguagesViewController.swift
@@ -456,7 +456,7 @@ extension InstalledLanguagesViewController {
             os_log("%{public}s", log:KeymanEngineLogger.resources, type: .error, errorMessage)
           }
         case .success(let package, let fullID):
-        self.navigationController?.setToolbarHidden(true, animated: false)
+          self.navigationController?.setToolbarHidden(true, animated: false)
           ResourceFileManager.shared.doInstallPrompt(for: package as! KeyboardKeymanPackage,
                                                      defaultLanguageCode: fullID.languageID,
                                                      in: self.navigationController!,


### PR DESCRIPTION
Fixes: #12590

If we're already showing the package-installer for a keyboard the user found via search... then we clearly downloaded it successfully.  Why double-notify?

There's actually a good reason _not_ to double-notify - it turns out that #12590 itself was due to our usage of a TabBarController outside the prescribed safe use cases.  We're actually fine most of the time... but it seems the tab area doesn't play nicely with a NavigationController toolbar, which is what displays download + update notifications.  Rather than find a way to force that to work, it's simpler to just... not show the toolbar, **ever**, when the package installer is displayed.

See write-up in this comment for more details: https://github.com/keymanapp/keyman/issues/12590#issuecomment-2785200199

## User Testing

TEST_REPRO_12590_SINGLE:  Attempt to reproduce #12590 with this PR's test build on a phone form-factor device.  
- Verify that no toolbar appears - and particularly that no part of the base, text-editing screen is visible at the bottom of the app.
- Aim for packages that support a single languages.
1. Use the in-app keyboard search to find and download the `ekwtamil99uni` keyboard for Tamil. Verify that when the package-installer appears, the effect seen in #12590 does not occur.


TEST_REPRO_12590_MULTIPLE:  Attempt to reproduce #12590 with this PR's test build on a phone form-factor device.  
- Verify that no toolbar appears - and particularly that no part of the base, text-editing screen is visible at the bottom of the app.
- Aim for packages that support multiple languages.
1. Use the in-app keyboard search to find and download the `sil_cameroon_azerty` keyboard.
2. Verify that when the package-installer appears, the effect seen in #12590 does not occur and that two tabs are visible at the bottom.

TEST_REPRO_UPDATES_AVAILABLE:  Repeat the "SINGLE" test above, but this time when keyboard updates are also available.
1. Go to jahorton.github.io and install its `khmer_angkor.kmp` package.  (It is noticeably out of date.)
2. Install a different build of Keyman.
3. Re-install this PR's build of Keyman.  
    - Steps 2 and 3 represent an attempt to force-reset the package-version query cache.
4. Open the Keyman app and drill down through Settings to the Installed Languages screen.
5. Back out to the main screen.
    - Give the update-check a bit of time to trigger.
6. Open the Keyman app (again) and drill down through Settings to the Installed Languages screen.
7. Use keyboard-search to find the `ekwtamil99uni` package.
    - Verify that "Update available" is overlaid visibly on top of the keyboard-search view.
    - Note that if Simulated, the usual green bar may be transparent instead (for some reason)... consider that a separate issue.  (The keyboard-search page is off-white, so "Update Available" should be visible in a pure white tone.)
8. Download the `ekwtamil99uni` package.
9. Verify that when the package installer appears, the base issue's bug (transparent bottom bar) does not occur and that neither "Update available" nor "Keyboard successfully downloaded" appear.