### PR TITLE
fix(ios): ensure update notification does not go translucent/transparent

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/ResourceDownloadStatusToolbar.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/ResourceDownloadStatusToolbar.swift
@@ -39,6 +39,15 @@ public class ResourceDownloadStatusToolbar: UIToolbar {
   
   private func setup() {
     barTintColor = Colors.statusToolbar
+    
+    // For scenarios where the system wants to make the toolbar translucent,
+    // we additionally need the actual background color to be set.
+    let appearance = UIToolbarAppearance()
+    appearance.configureWithOpaqueBackground()
+    appearance.backgroundColor = Colors.statusToolbar
+    standardAppearance = appearance
+    // And, for good measure, try to prevent special scrolling-edge appearance changes outright.
+    scrollEdgeAppearance = appearance
   }
   
   /**


### PR DESCRIPTION
Fixes: #12589
Fixes: #13688

It appears that in iOS 15.0, Apple seems to have enacted behavior that will cause a toolbar to go translucent/transparent in certain scenarios - such as when it would cover up the bottom of a fully-scrolled view.  This has been triggering on our keyboard-search page, directly causing the behavior seen in #12589.

Reference: https://stackoverflow.com/a/71985231

It appears fixing this thoroughly _also_ addresses #13688, so... yay for "two birds, one stone"!

## User Testing

TEST_KEYBOARDS_LIST_OVERLAY:  Using the iOS build artifact for this PR, verify that update notifications always display properly and consistently on the "installed languages" list.
1. Install the Keyman app.
2. Install at least 10 keyboards, or enough to fill the initial view for the "Installed Languages" list.
    - An easy way to do this - just download `sil_cameroon_azerty` and select numerous languages from the second tab, rather than just one.
3. Visit jahorton.github.io and install the khmer_angkor.kmp package found there.
4. Force-quit the Keyman app, then relaunch it.
5. Wait a few seconds.
6. Return to the "Installed Languages" list.  The "Update available" notification should visibly appear with a green background.
    - If it does not appear, repeat steps 4-6 again one time.
7. Scroll the list all the way to the bottom.  Verify that the colored background for the notification does not vary at any point.

TEST_KEYBOARD_SEARCH_OVERLAY:  Using the iOS build artifact for this PR, verify that update notifications always display properly and consistently during keyboard-search.
1. Install the Keyman app.
2. Visit jahorton.github.io and install the khmer_angkor.kmp package found there.
3. Force-quit the Keyman app, then relaunch it.
4. Wait a few seconds.
5. Return to the "Installed Languages" list.  The "Update available" notification should visibly appear with a green background.
    - If it does not appear, repeat steps 3-5 again one time.
6. Use the '+' button to start a keyboard search.  Verify that "Update available" remains visible and maintains its background.
7. Enter "English" into the search bar.
8. Scroll up and down the page.  Verify that the colored background for the notification does not vary at any point.


- lots of keyboards; verify no shift in color regardless of scroll position
- keyboard-search; verify acts similar there.  Search English, verify that top and bottom see no difference in behavior.