### PR TITLE
fix(ios): resummon keyboard when keyboard picker is dismissed

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardSwitcherViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/LanguagePicker/KeyboardSwitcherViewController.swift
@@ -38,6 +38,13 @@ class KeyboardSwitcherViewController: UITableViewController, UIAlertViewDelegate
     scroll(toSelectedKeyboard: false)
   }
   
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    
+    // Helps to handle slide-dismissal.
+    navigationController?.presentationController?.delegate = self
+  }
+  
   public func scroll(toSelectedKeyboard animated: Bool) {
     let index = userKeyboards.firstIndex { kb in
       return Manager.shared.currentKeyboardID == kb.fullID
@@ -108,6 +115,7 @@ class KeyboardSwitcherViewController: UITableViewController, UIAlertViewDelegate
       tableView.reloadData()
     }
     
+    navigationController?.presentationController?.delegate = nil
     Manager.shared.dismissKeyboardPicker(self)
   }
   
@@ -119,5 +127,13 @@ class KeyboardSwitcherViewController: UITableViewController, UIAlertViewDelegate
   public func loadUserKeyboards() {
     userKeyboards = Storage.active.userDefaults.userKeyboards ?? []
     tableView.reloadData()
+  }
+}
+
+extension KeyboardSwitcherViewController: UIAdaptivePresentationControllerDelegate {
+  public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+    
+    navigationController?.presentationController?.delegate = nil
+    Manager.shared.dismissKeyboardPicker(self)
   }
 }


### PR DESCRIPTION
Fixes: #13699

This change ensures that swipe-dismissal of the in-app keyboard picker is properly handled, resummoning the keyboard once it closes.  The underlying issue was much the same as for #13443.

## User Testing

TEST_PICKER_DISMISSAL: Verify that down-swipe dismissal of the in-app keyboard picker automatically redisplays the keyboard.  (There may be a delay of a second or two due to iOS animations.)