### PR TITLE
fix(android): Fix system  keyboard banner on reload

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -110,9 +110,6 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   @Override
   public void onInitializeInterface() {
     super.onInitializeInterface();
-
-    // KeymanWeb reloaded, so we have to pass the banner again
-    BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
   }
 
   /**
@@ -272,7 +269,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
 
   @Override
   public void onKeyboardShown() {
-    // Do nothing
+    // Refresh banner theme
+    BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
   }
 
   @Override

--- a/android/docs/engine/KMManager/setHTMLBanner.md
+++ b/android/docs/engine/KMManager/setHTMLBanner.md
@@ -28,7 +28,7 @@ Use this method to specify the HTML content to display in the banner to theme yo
 
 If the banner theme references assets (like .svg or .css files), ensure you've also called [copyHTMLBannerAssets()](copyHTMLBannerAssets).
 
-Note: The HTML banner needs to be updated whenever the keyboard is reloaded, so call this in `SystemKeyboard.onInitializeInterface(()`.
+Note: The HTML banner needs to be updated whenever the keyboard is reloaded, so call this in `SystemKeyboard.onKeyboardShown()`.
 
 ## Examples
 

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -85,9 +85,6 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     @Override
     public void onInitializeInterface() {
       super.onInitializeInterface();
-
-      // KeymanWeb reloaded, so we have to pass the banner again
-      BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
     }
 
     /** Called by the framework when your view for creating input needs to
@@ -231,7 +228,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
 
     @Override
     public void onKeyboardShown() {
-        // Handle Keyman keyboard shown event here if needed
+      // Refresh banner theme
+      BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
     }
 
     @Override


### PR DESCRIPTION
Follows the in-app keyboard pattern of refreshing banner theme when the keyboard is shown

Fixes: #13693

## User Testing

**Setup**
* Install the PR build of Keyman for Android on device/emulator

* **TEST_BANNER_REFRESHES** - Verifies banner theme displays after keyboard install
1. Accept all the Android permission requests for storage.
2. Open the Keyman app.
3. On the "Get Started" dialog.
  * Check the "Enable Keyman as system-wide keyboard" box.
  * Check the "Set the keyboard as the default keyboard" box.
3. Navigate to the settings page and then select "Installed Languages"
4. Add a "EuroLatin" keyboard for an "Albanian" keyboard by clicking the "+" button.
5. Return to the Keyman app.
6. Observed that the Albanian keyman appeared and the keyman banner appeared.
7. Observed that the back line appeared on the keyman banner. (this issue is tracked separately)
8. Launch the Chrome browser.
9. Navigate to the Google search box(text area)
10. Verify that the Keyman keyboard appeared for Albanian.
11. Verify the Keyman banner appears with the Albanian keyboard
