### PR TITLE
fix(common): export `KEYMAN_ROOT` so that it is available in subprocesses 🎼

### DIFF
--- a/resources/build/builder.inc.sh
+++ b/resources/build/builder.inc.sh
@@ -25,6 +25,7 @@ function __builder_find_keyman_root() {
     KEYMAN_ROOT="${BASH_SOURCE[0]%/*/*/*}"
     KEYMAN_ROOT="$( cd "$KEYMAN_ROOT" && echo "$PWD" )"
     readonly KEYMAN_ROOT
+    export KEYMAN_ROOT
   fi
 }
 


### PR DESCRIPTION
Without the export we had the case where a web test relied on `KEYMAN_ROOT` to get the path, but it was undefined. I have no idea why this suddenly showed up with changes that just renamed a file and a class (#13710), but exporting it fixes it.

@keymanapp-test-bot skip