### PR TITLE
chore(web): trim unused string helper methods 🧶 

### DIFF
--- a/web/src/engine/common/web-utils/src/kmwstring.ts
+++ b/web/src/engine/common/web-utils/src/kmwstring.ts
@@ -16,9 +16,6 @@ declare global {
   interface String {
     kmwCharCodeAt(codePointIndex: number): number,
     kmwCharAt(codePointIndex: number) : string,
-    kmwIndexOf(searchValue: string, fromIndex?: number) : number,
-    kmwLastIndexOf(searchValue: string, fromIndex?: number) : number,
-    kmwSlice(beginSlice: number, endSlice: number) : string,
     kmwSubstring(start: number, length: number) : string,
     kmwSubstr(start: number, length?: number) : string,
     kmwBMPSubstr(start: number, length?: number) : string,
@@ -34,9 +31,6 @@ declare global {
     kmwBMPCodeUnitToCodePoint(codeUnitIndex: number) : number,
     _kmwCharCodeAt(codePointIndex: number): number,
     _kmwCharAt(codePointIndex: number) : string,
-    _kmwIndexOf(searchValue: string, fromIndex?: number) : number,
-    _kmwLastIndexOf(searchValue: string, fromIndex?: number) : number,
-    _kmwSlice(beginSlice: number, endSlice: number) : string,
     _kmwSubstring(start: number, length?: number) : string,
     _kmwSubstr(start: number, length?: number) : string,
     _kmwLength(): number,
@@ -80,49 +74,6 @@ export default function extendString() {
   }
 
   /**
-   * Returns the code point index within the calling String object of the first occurrence
-   * of the specified value, or -1 if not found.
-   *
-   * @param  {string}  searchValue    The value to search for
-   * @param  {number}  [fromIndex]    Optional code point index to start searching from
-   * @return {number}                 The code point index of the specified search value
-   */
-  String.prototype.kmwIndexOf = function(searchValue, fromIndex) {
-    var str = String(this);
-    var codeUnitIndex = str.indexOf(searchValue, fromIndex);
-
-    if(codeUnitIndex < 0) {
-      return codeUnitIndex;
-    }
-
-    var codePointIndex = 0;
-    for(var i = 0; i !== null && i < codeUnitIndex; i = str.kmwNextChar(i)) codePointIndex++;
-    return codePointIndex;
-  }
-
-  /**
-   * Returns the code point index within the calling String object of the last occurrence
-   * of the specified value, or -1 if not found.
-   *
-   * @param  {string}  searchValue    The value to search for
-   * @param  {number}  fromIndex      Optional code point index to start searching from
-   * @return {number}                 The code point index of the specified search value
-   */
-  String.prototype.kmwLastIndexOf = function(searchValue, fromIndex)
-  {
-    var str = String(this);
-    var codeUnitIndex = str.lastIndexOf(searchValue, fromIndex);
-
-    if(codeUnitIndex < 0) {
-      return codeUnitIndex;
-    }
-
-    var codePointIndex = 0;
-    for(var i = 0; i !== null && i < codeUnitIndex; i = str.kmwNextChar(i)) codePointIndex++;
-    return codePointIndex;
-  }
-
-  /**
    * Returns the length of the string in code points, as opposed to code units.
    *
    * @return {number}                 The length of the string in code points
@@ -135,26 +86,6 @@ export default function extendString() {
     for(var i = 0, codeUnitIndex = 0; codeUnitIndex !== null; i++)
       codeUnitIndex = str.kmwNextChar(codeUnitIndex);
     return i;
-  }
-
-  /**
-   * Extracts a section of a string and returns a new string.
-   *
-   * @param  {number}  beginSlice    The start code point index in the string to
-   *                                 extract from
-   * @param  {number}  endSlice      Optional end code point index in the string
-   *                                 to extract to
-   * @return {string}                The substring as selected by beginSlice and
-   *                                 endSlice
-   */
-  String.prototype.kmwSlice = function(beginSlice, endSlice) {
-    var str = String(this);
-    var beginSliceCodeUnit = str.kmwCodePointToCodeUnit(beginSlice);
-    var endSliceCodeUnit = str.kmwCodePointToCodeUnit(endSlice);
-    if(beginSliceCodeUnit === null || endSliceCodeUnit === null)
-      return '';
-    else
-      return str.slice(beginSliceCodeUnit, endSliceCodeUnit);
   }
 
   /**
@@ -431,16 +362,15 @@ export default function extendString() {
     var p=String.prototype;
     p._kmwCharAt = bEnable ? p.kmwCharAt : p.charAt;
     p._kmwCharCodeAt = bEnable ? p.kmwCharCodeAt : p.charCodeAt;
-    p._kmwIndexOf = bEnable ? p.kmwIndexOf :p.indexOf;
-    p._kmwLastIndexOf = bEnable ? p.kmwLastIndexOf : p.lastIndexOf ;
-    p._kmwSlice = bEnable ? p.kmwSlice : p.slice;
     p._kmwSubstring = bEnable ? p.kmwSubstring : p.substring;
     p._kmwSubstr = bEnable ? p.kmwSubstr : p.kmwBMPSubstr;
     p._kmwLength = bEnable ? p.kmwLength : p.kmwBMPLength;
-    p._kmwNextChar = bEnable ? p.kmwNextChar : p.kmwBMPNextChar;
-    p._kmwPrevChar = bEnable ? p.kmwPrevChar : p.kmwBMPPrevChar;
     p._kmwCodePointToCodeUnit = bEnable ? p.kmwCodePointToCodeUnit : p.kmwBMPCodePointToCodeUnit;
     p._kmwCodeUnitToCodePoint = bEnable ? p.kmwCodeUnitToCodePoint : p.kmwBMPCodeUnitToCodePoint;
+
+    // These are only used internally.
+    p._kmwNextChar = bEnable ? p.kmwNextChar : p.kmwBMPNextChar;
+    p._kmwPrevChar = bEnable ? p.kmwPrevChar : p.kmwBMPPrevChar;
   }
 
   // Ensure that _all_ String extensions are established, even if disabled by default.


### PR DESCRIPTION
After searching the Web codebase, it turns out that a few of the string utility methods are unused; they should be safe to trim.

@keymanapp-test-bot skip