### PR TITLE
chore(linux): add a stub unit test to allow successful coverage reporting

### DIFF
--- a/linux/keyman-system-service/build.sh
+++ b/linux/keyman-system-service/build.sh
@@ -60,13 +60,13 @@ check_missing_coverage_configuration() {
 }
 
 configure_action() {
-  # shellcheck disable=SC2086,SC2154
-  meson setup ${MESON_COVERAGE} --werror --buildtype $MESON_TARGET "${builder_extra_params[@]}" "$MESON_PATH"
+  # shellcheck disable=SC2086,SC2154,SC2248
+  meson setup ${MESON_COVERAGE} --werror --buildtype ${MESON_TARGET} "${builder_extra_params[@]}" "${MESON_PATH}"
 }
 
 test_action() {
   # shellcheck disable=SC2086,SC2154
-  meson test --print-errorlogs $builder_verbose
+  meson test --print-errorlogs ${builder_verbose}
   if builder_has_option --coverage; then
     # Note: requires lcov > 1.16 to properly work (see https://github.com/mesonbuild/meson/issues/6747)
     ninja coverage-html
@@ -88,7 +88,7 @@ fi
 builder_run_action clean       clean_action
 builder_run_action configure   configure_action
 
-[ -d "$MESON_PATH" ] && cd "$MESON_PATH"
+[[ -d "${MESON_PATH}" ]] && cd "${MESON_PATH}"
 
 builder_run_action build       ninja
 builder_run_action test        test_action

--- a/linux/keyman-system-service/tests/meson.build
+++ b/linux/keyman-system-service/tests/meson.build
@@ -22,8 +22,30 @@ exe = executable(
   include_directories: [ '..', '../src' ]
 )
 
-# we currently don't have any unit tests for keyman-system-service.
+# we currently don't have any real unit tests for keyman-system-service.
 # The keyman-test-service we build here gets used by the ibus-keyman
 # integration tests.
+# The unit test we have here is just a stub to make coverage reporting
+# happy.
+
+gtk = dependency('gtk+-3.0', version: '>= 2.4')
+
+test_deps = [gtk]
+test_env = [
+  'G_TEST_SRCDIR=' + meson.current_source_dir(),
+  'G_TEST_BUILDDIR=' + meson.current_build_dir(),
+]
+
+test_exe = executable(
+  'keyman-system-service-tests',
+  'testfixture.cpp',
+  dependencies: test_deps,
+)
+
+test(
+  'test-stub',
+  test_exe,
+  protocol: 'tap'
+)
 
 subdir('services')

--- a/linux/keyman-system-service/tests/testfixture.cpp
+++ b/linux/keyman-system-service/tests/testfixture.cpp
@@ -1,0 +1,18 @@
+#include <glib.h>
+
+typedef struct {
+} TestObjectFixture;
+
+// The purpose of this unit "test" is to have a test so that generating code
+// coverage report works with Ubuntu 24.04+.
+static void test_stub(TestObjectFixture* fixture, gconstpointer user_data) {
+  g_assert_true(TRUE);
+}
+
+int main(int argc, char* argv[]) {
+  g_test_init(&argc, &argv, NULL);
+
+  g_test_add("/test/test_stub", TestObjectFixture, NULL, NULL, test_stub, NULL);
+
+  return g_test_run();
+}


### PR DESCRIPTION
Previously keyman-system-service didn't have any unit tests. With the gcov/lcov versions available for Ubuntu 24.04 Noble this suddenly caused a failure when trying to generate the test coverage report, although it worked fine with older versions.

This change adds a do-nothing unit test stub for keyman-system-service. This allows to generate the coverage reporting with Ubuntu 24.04 Noble.

@keymanapp-test-bot skip