### PR TITLE
chore: update labels for v19

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,15 +16,11 @@ android/app/: android/KMAPro/**
 android/engine/: android/KMEA/**
 android/samples/: android/Samples/**
 
-common/:
-  - common/**
-  - resources/**
+common/: common/**
 
-common/models/templates/: web/src/engine/predictive-text/templates/**
-common/models/wordbreakers/: web/src/engine/predictive-text/wordbreakers/**
-
-common/resources/: resources/**
 common/web/: common/web/**
+
+m:predictive-text: web/src/engine/predictive-text/**
 
 core/:
   - core/**
@@ -37,7 +33,7 @@ developer/compilers/:
   - developer/src/kmcmplib/**
   - developer/src/kmc-*/**
 
-developer/ide/:
+m:developer-ide:
   - developer/src/server/**
   - developer/src/tike/**
 
@@ -64,6 +60,8 @@ oem/fv/: oem/firstvoices/**
 oem/fv/android/: oem/firstvoices/android/**
 oem/fv/ios/: oem/firstvoices/ios/**
 oem/fv/windows/: oem/firstvoices/windows/**
+
+resources/: resources/**
 
 web/: web/**
 # web/bookmarklet/

--- a/resources/scopes/scopes.json
+++ b/resources/scopes/scopes.json
@@ -2,44 +2,31 @@
   "scopes": {
     "android": {
       "app": null,
-      "browser": null,
       "engine": null,
-      "resources": null,
       "samples": null
     },
     "common": {
-      "models": {
-        "types": null,
-        "templates": null,
-        "wordbreakers": null
-      },
       "resources": null,
       "web": null
     },
     "core": null,
     "developer": {
       "compilers": null,
-      "ide": null,
-      "resources": null,
-      "tools": null
+      "ide": null
     },
     "ios": {
       "app": null,
-      "browser": null,
       "engine": null,
-      "resources": null,
       "samples": null
     },
     "linux": {
       "config": null,
       "engine": null,
-      "resources": null,
       "samples": null
     },
     "mac": {
       "config": null,
       "engine": null,
-      "resources": null,
       "samples": null
     },
     "oem": {
@@ -52,14 +39,12 @@
     "web": {
       "bookmarklet": null,
       "engine": null,
-      "resources": null,
       "ui": null,
       "samples": null
     },
     "windows": {
       "config": null,
       "engine": null,
-      "resources": null,
       "samples": null
     }
   }


### PR DESCRIPTION
Note: m:predictive-text and m:developer-ide mark a change where we have some modules with fuzzy boundaries and where it may not be easy to automatically determine all changes by pathname. I am not altogether comfortable with these so we may iterate a bit further yet.

@keymanapp-test-bot skip