### PR TITLE
chore: additional tweaks to scopes/labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,10 +17,7 @@ android/engine/: android/KMEA/**
 android/samples/: android/Samples/**
 
 common/: common/**
-
 common/web/: common/web/**
-
-m:predictive-text: web/src/engine/predictive-text/**
 
 core/:
   - core/**
@@ -33,10 +30,9 @@ developer/compilers/:
   - developer/src/kmcmplib/**
   - developer/src/kmc-*/**
 
-m:developer-ide:
+developer/ide/:
   - developer/src/server/**
   - developer/src/tike/**
-
 
 ios/: ios/**
 ios/app/: ios/keyman/**
@@ -68,6 +64,7 @@ web/: web/**
 web/engine/: web/source/**
 web/ui/: web/source/kmwui*
 web/samples/: web/samples/**
+web/predictive-text/: web/src/engine/predictive-text/**
 
 windows/: windows/**
 windows/config/: windows/src/desktop/**

--- a/.github/multi-labeler.yml
+++ b/.github/multi-labeler.yml
@@ -57,11 +57,6 @@ labels:
     matcher:
       title: '(🍒|:cherries:)'
 
-  # long-lived feature branches
-  - label: 'feature-branch'
-    matcher:
-      branch: '^feature-.+'
-
   #
   # Scopes that we look for in the PR title
   #
@@ -90,6 +85,9 @@ labels:
   - label: 'oem/'
     matcher:
       title: '\(.*oem.*\):'
+  - label: 'resources/'
+    matcher:
+      title: '\(.*resources.*\):'
   - label: 'web/'
     matcher:
       title: '\(.*web.*\):'

--- a/resources/scopes/scopes.json
+++ b/resources/scopes/scopes.json
@@ -6,7 +6,6 @@
       "samples": null
     },
     "common": {
-      "resources": null,
       "web": null
     },
     "core": null,
@@ -36,11 +35,13 @@
         "windows": null
       }
     },
+    "resources": null,
     "web": {
       "bookmarklet": null,
       "engine": null,
       "ui": null,
-      "samples": null
+      "samples": null,
+      "predictive-text": null
     },
     "windows": {
       "config": null,


### PR DESCRIPTION
@keymanapp-test-bot skip

renaming m:predictive-text to web/predictive-text/ and m:developer-ide to developer/ide/ (matching other module names).