### PR TITLE
chore(android): Use `builder_is_ci_build` rather than `--ci` flag

### DIFF
--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -7,6 +7,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-help.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-download-resources.sh"
 
@@ -28,7 +29,6 @@ builder_describe "Builds Keyman for Android app." \
   "build" \
   "test             Runs lint and unit tests." \
   "publish          Publishes symbols to Sentry and the APK to the Play Store." \
-  "--ci             Don't start the Gradle daemon. For CI" \
   "--upload-sentry  Upload to sentry"
 
 # parse before describe_outputs to check debug flags
@@ -50,7 +50,7 @@ builder_describe_outputs \
 
 # Parse args
 
-if builder_has_option --ci; then
+if builder_is_ci_build; then
   DAEMON_FLAG=--no-daemon
 fi
 

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -8,6 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 # ################################ Main script ################################
 
@@ -28,8 +29,7 @@ builder_describe "Builds Keyman Engine for Android." \
   "configure" \
   "build" \
   "test             Runs lint and unit tests." \
-  ":engine          Builds Engine" \
-  "--ci             Don't start the Gradle daemon. For CI"
+  ":engine          Builds Engine" 
 
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
@@ -51,7 +51,7 @@ builder_describe_outputs \
 # Parse args
 
 DAEMON_FLAG=
-if builder_has_option --ci; then
+if builder_is_ci_build; then
   DAEMON_FLAG=--no-daemon
 fi
 
@@ -98,7 +98,7 @@ fi
 
 if builder_start_action test:engine; then
 
-  if builder_has_option --ci; then
+  if builder_is_ci_test_build; then
     # Report JUnit test results to CI
     echo "$JUNIT_RESULTS"
   fi

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -98,7 +98,7 @@ fi
 
 if builder_start_action test:engine; then
 
-  if builder_is_ci_test_build; then
+  if builder_is_ci_build; then
     # Report JUnit test results to CI
     echo "$JUNIT_RESULTS"
   fi

--- a/android/Samples/KMSample1/build.sh
+++ b/android/Samples/KMSample1/build.sh
@@ -8,6 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 ################################ Main script ################################
 
@@ -22,8 +23,7 @@ builder_describe "Build KMSample1 app for Android." \
   "configure" \
   "build" \
   "test" \
-  ":app                   KMSample1" \
-  "--ci                   Don't start the Gradle daemon. Use for CI"
+  ":app                   KMSample1" 
 
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
@@ -46,7 +46,7 @@ builder_describe_outputs \
 
 # Parse args
 
-if builder_has_option --ci; then
+if builder_is_ci_build; then
   SAMPLE_FLAGS="$SAMPLE_FLAGS -no-daemon"
 fi
 

--- a/android/Samples/KMSample2/build.sh
+++ b/android/Samples/KMSample2/build.sh
@@ -8,6 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 ################################ Main script ################################
 
@@ -22,8 +23,7 @@ builder_describe "Build KMSample2 app for Android." \
   "configure" \
   "build" \
   "test" \
-  ":app                   KMSample2" \
-  "--ci                   Don't start the Gradle daemon. Use for CI"
+  ":app                   KMSample2" 
 
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
@@ -47,7 +47,7 @@ builder_describe_outputs \
 
 # Parse args
 
-if builder_has_option --ci; then
+if builder_is_ci_build; then
   SAMPLE_FLAGS="$SAMPLE_FLAGS -no-daemon"
 fi
 

--- a/android/Tests/KeyboardHarness/build.sh
+++ b/android/Tests/KeyboardHarness/build.sh
@@ -8,6 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 ################################ Main script ################################
 
@@ -22,8 +23,7 @@ builder_describe "Build KeyboardHarness test app for Android." \
   "configure" \
   "build" \
   "test" \
-  ":app                   KeyboardHarness" \
-  "--ci                   Don't start the Gradle daemon. Use for CI"
+  ":app                   KeyboardHarness" 
 
 # parse before describe outputs to check debug flags
 builder_parse "$@"
@@ -55,7 +55,7 @@ SHLVL=0
 # Parse args
 
 # Build flags that apply to all targets
-if builder_has_option --ci; then
+if builder_is_ci_build; then
   BUILD_FLAGS="$BUILD_FLAGS -no-daemon"
   TEST_FLAGS="$TEST_FLAGS -no-daemon"
 fi

--- a/android/build.sh
+++ b/android/build.sh
@@ -37,6 +37,7 @@ builder_describe \
   build \
   test \
   "publish                                  Publishes symbols to Sentry and the APKs to the Play Store." \
+  "--ci+                                    Deprecated build option. Remove in 20.0" \
   --upload-sentry+ \
   ":engine=KMEA                             Keyman Engine for Android" \
   ":app=KMAPro                              Keyman for Android" \

--- a/android/build.sh
+++ b/android/build.sh
@@ -14,6 +14,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 ################################ Main script ################################
 
@@ -36,7 +37,6 @@ builder_describe \
   build \
   test \
   "publish                                  Publishes symbols to Sentry and the APKs to the Play Store." \
-  --ci+ \
   --upload-sentry+ \
   ":engine=KMEA                             Keyman Engine for Android" \
   ":app=KMAPro                              Keyman for Android" \

--- a/oem/firstvoices/android/build.sh
+++ b/oem/firstvoices/android/build.sh
@@ -8,6 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/shellHelperFunctions.sh"
+. "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-download-resources.sh"
 
 # ################################ Main script ################################
@@ -25,8 +26,7 @@ builder_describe "Builds FirstVoices for Android app." \
   "configure" \
   "build" \
   "test             Runs lint and tests." \
-  "publish          Publishes symbols to Sentry and the APK to the Play Store." \
-  "--ci             Don't start the Gradle daemon. For CI"
+  "publish          Publishes symbols to Sentry and the APK to the Play Store." 
 
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
@@ -48,7 +48,7 @@ builder_describe_outputs \
 
 # Parse args
 
-if builder_has_option --ci; then
+if builder_is_ci_build; then
   DAEMON_FLAG=--no-daemon
 fi
 


### PR DESCRIPTION
Fixes #12640

* ~Remove builder flag `--ci`~ Deprecated `--ci` build option to remove in 20.0
* Use `builder_is_ci_build` check instead.

@keymanapp-test-bot skip
