### PR TITLE
fix(web): add robustness for bad touch-layout fontsize specs

### DIFF
--- a/web/src/engine/osk/src/lengthStyle.ts
+++ b/web/src/engine/osk/src/lengthStyle.ts
@@ -12,6 +12,24 @@ export class ParsedLengthStyle implements LengthStyle {
   public constructor(style: LengthStyle | string) {
     let parsed: LengthStyle = (typeof style == 'string') ? ParsedLengthStyle.parseLengthStyle(style) : style;
 
+    const fallback: LengthStyle = {
+      val: 1,
+      absolute: false
+    };
+
+    if(typeof style == 'number') {
+      // Addresses #13766 for compiled layouts with numbers in the touch-layout `fontsize` field
+
+      // Do not actually emit console warning; we handle those as "errors" in the mobile apps, and
+      // this is more an issue with the compiled keyboard.
+      parsed = fallback;
+    }
+
+    if(isNaN(parsed.val)) {
+      console.error("NaN appeared while trying to calculate style scaling effects");
+      parsed = fallback
+    }
+
     // While Object.assign would be nice (and previously, was used), it will break
     // on old but still supported versions of Android if their Chrome isn't updated.
     // Requires mobile Chrome 45+, but API 21 (5.0) launches with an older browser.
@@ -38,6 +56,11 @@ export class ParsedLengthStyle implements LengthStyle {
   }
 
   public scaledBy(scalar: number): ParsedLengthStyle {
+    if(isNaN(scalar)) {
+      console.error("NaN appeared while trying to calculate style scaling effects");
+      return this;
+    }
+
     return new ParsedLengthStyle({
       val: scalar * this.val,
       absolute: this.absolute

--- a/web/src/engine/osk/src/lengthStyle.ts
+++ b/web/src/engine/osk/src/lengthStyle.ts
@@ -13,7 +13,7 @@ export class ParsedLengthStyle implements LengthStyle {
     let parsed: LengthStyle = (typeof style == 'string') ? ParsedLengthStyle.parseLengthStyle(style) : style;
 
     const fallback: LengthStyle = {
-      val: 1,
+      val: 1, // 100%
       absolute: false
     };
 

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -521,7 +521,13 @@ export default abstract class OSKView
     // Set default OSK font size (Build 344, KMEW-90)
     // If the layer group specifies a fontsize value, we need
     // to apply that to the banner as well.
-    const layerFontSize = this.vkbd?.layerGroup?.spec.fontsize;
+    const layerFontSizeRaw = this.vkbd?.layerGroup?.spec.fontsize;
+    // Addresses issue with touch-layouts specifying a unitless fontsize; this
+    // coerces them to `pt` style sizing, like how word-processors present font-size.
+    //
+    // Returns NaN if not 100% a number.  "12px", "12pt", "12%" all return NaN.
+    const fsRaw = Number(layerFontSizeRaw);
+    const layerFontSize = isNaN(fsRaw) ? layerFontSizeRaw : (fsRaw + 'pt');
 
     if(layerFontSize) {
       const parsedSize = new ParsedLengthStyle(layerFontSize);

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -525,7 +525,7 @@ export default abstract class OSKView
     // Addresses issue with touch-layouts specifying a unitless fontsize; this
     // coerces them to `pt` style sizing, like how word-processors present font-size.
     //
-    // Returns NaN if not 100% a number.  "12px", "12pt", "12%" all return NaN.
+    // Number() returns NaN if not 100% a number.  "12px", "12pt", "12%" all return NaN.
     const fsRaw = Number(layerFontSizeRaw);
     const layerFontSize = isNaN(fsRaw) ? layerFontSizeRaw : (fsRaw + 'pt');
 


### PR DESCRIPTION
Fixes: #13766

It seems that at some point, Developer has been compiling raw "12" values in the touch-layout JSON as a numeric 12 for the fontsize field.  This clearly happened for the [inuktitut_pirurvik keyboard](https://github.com/keymanapp/keyboards/blob/37829949e6883cf39ee0cd13e1b2939f3f5a54bd/release/i/inuktitut_pirurvik/source/inuktitut_pirurvik.keyman-touch-layout#L512); we should also inspect [urdu_phonetic](https://github.com/keymanapp/keyboards/blob/37829949e6883cf39ee0cd13e1b2939f3f5a54bd/release/u/urdu_phonetic/source/urdu_phonetic.keyman-touch-layout#L647), which has the same raw "12".

See the version hosted on s.keyman.com: https://s.keyman.com/keyboard/inuktitut_pirurvik/1.4/inuktitut_pirurvik-1.4.js - it clearly has `12`, not `"12"`, for that field.

![highlighted excerpt](https://github.com/user-attachments/assets/31245e66-07fd-4152-96af-71d1be46deb2)

This change ensures that Web can handle this case without spewing tons of warning/error messages.  It also adds error-logging to help with diagnosis for any related issue in the future.

## User Testing

TEST_INUKTITUT_KEYBOARD: Using Keyman for Android, install the `inuktitut_pirurvik` and verify that no error notifications appear.