### PR TITLE
chore(common): Update dependencies in crowdin GitHub action

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: crowdin action
-      uses: crowdin/github-action@1.3.2
+      uses: crowdin/github-action@2.7.0
       with:
         upload_sources: true
 


### PR DESCRIPTION
Part of maintenance sprint

This is the action that automatically updates the Crowdin project as new strings get added to the master branch

@keymanapp-test-bot skip
