### PR TITLE
chore(common): override check when running on TC

### DIFF
--- a/linux/keyman-config/run-tests.sh
+++ b/linux/keyman-config/run-tests.sh
@@ -12,14 +12,14 @@ if [[ "$1" == "--coverage" ]]; then
   coverage="-m coverage run --source=. --data-file=build/.coverage"
 fi
 
-if [[ -n "${TEAMCITY_VERSION}" ]]; then
+if [[ -n "${TEAMCITY_GIT_PATH}" ]]; then
   if ! pip3 list --format=columns | grep -q teamcity-messages; then
       if [[ -n "${TEAMCITY_PLATFORM}" ]] || [[ -n "${DOCKER_RUNNING}" ]]; then
         # Ubuntu 24.04+ prevents mixing pip and system packages and wants us
         # to use a virtualenv. However, that causes other problems, so we
         # override this check only if we're running in a TC agent or docker
         # so that we don't accidentally break the local system.
-        # Note: it is intentional that we use TEAMCITY_VERSION as well
+        # Note: it is intentional that we use TEAMCITY_GIT_PATH as well
         # as TEAMCITY_PLATFORM here so that it is possible to simulate
         # running in a TC agent and still not break your local system
         # (run in a docker container or explicitly set TEAMCITY_PLATFORM

--- a/linux/keyman-config/run-tests.sh
+++ b/linux/keyman-config/run-tests.sh
@@ -19,6 +19,11 @@ if [[ -n "${TEAMCITY_VERSION}" ]]; then
         # to use a virtualenv. However, that causes other problems, so we
         # override this check only if we're running in a TC agent or docker
         # so that we don't accidentally break the local system.
+        # Note: it is intentional that we use TEAMCITY_VERSION as well
+        # as TEAMCITY_PLATFORM here so that it is possible to simulate
+        # running in a TC agent and still not break your local system
+        # (run in a docker container or explicitly set TEAMCITY_PLATFORM
+        # to cause the script to install the package).
         PIP_ARGS="--break-system-packages"
       fi
       # shellcheck disable=SC2086

--- a/linux/keyman-config/run-tests.sh
+++ b/linux/keyman-config/run-tests.sh
@@ -14,7 +14,15 @@ fi
 
 if [[ -n "${TEAMCITY_VERSION}" ]]; then
   if ! pip3 list --format=columns | grep -q teamcity-messages; then
-      pip3 install teamcity-messages
+      if [[ -n "${TEAMCITY_PLATFORM}" ]] || [[ -n "${DOCKER_RUNNING}" ]]; then
+        # Ubuntu 24.04+ prevents mixing pip and system packages and wants us
+        # to use a virtualenv. However, that causes other problems, so we
+        # override this check only if we're running in a TC agent or docker
+        # so that we don't accidentally break the local system.
+        PIP_ARGS="--break-system-packages"
+      fi
+      # shellcheck disable=SC2086
+      pip3 install --user ${PIP_ARGS:-} teamcity-messages
   fi
   test_module=teamcity.unittestpy
 else

--- a/resources/tools/check-markdown/build.sh
+++ b/resources/tools/check-markdown/build.sh
@@ -15,7 +15,7 @@ builder_describe "Check markdown internal links" \
   "build"
 
 builder_describe_outputs \
-  configure          /node_modules \
+  configure          "${THIS_SCRIPT_PATH}/node_modules" \
   build              build/index.js
 
 builder_parse "$@"


### PR DESCRIPTION
This change overrides a check added in Ubuntu 24.04+ that prevents mixing Python packages installed through apt and through pip. This allows to install the necessary Python package for TC which isn't available as Debian package. This change allows builds on Ubuntu 24.04 based TC agents.

@keymanapp-test-bot skip