### PR TITLE
chore(common): rename `chore` GH label to `maint`

### DIFF
--- a/.github/multi-labeler.yml
+++ b/.github/multi-labeler.yml
@@ -33,6 +33,9 @@ labels:
   - label: 'fix'
     matcher:
       title: '^fix(\(|:)'
+  - label: 'maint'
+    matcher:
+      title: '^maint(\(|:)'
   - label: 'refactor'
     matcher:
       title: '^refactor(\(|:)'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -384,10 +384,11 @@ group.
 | `auto` | [search][search-auto] | For PRs only: automatically-opened PRs, e.g. opened by CI. |
 | `bug` | [search][search-bug] | For issues only: confirmed bugs or reports that are very likely to be bugs. PRs use `fix` to mark a bug fix. |
 | `change` | [search][search-change] | Minor change in functionality, but not new. |
-| `chore` | [search][search-chore] | Cleanup work, maintenance, without change in functionality. |
+| `chore` | [search][search-chore] | Cleanup work, without change in functionality. |
 | `docs` | [search][search-docs] | Relating to any type of documentation. |
 | `feat` | [search][search-feat] | Feature requests. |
 | `fix` | [search][search-fix] | For PRs only: a bug fix, corresponds to issue label `bug`. |
+| `maint` | [search][search-maint] | Maintenance work -- continuous integration, build scripts, infrastructure. |
 | `question` | [search][search-question] | Questions more than bug reports or feature requests (e.g. how do I do X). [**Usually better on the Keyman Community**](https://community.software.sil.org/c/keyman) |
 | `refactor` | [search][search-refactor] | Code reorganization and refactoring, without change in functionality. |
 | `spec` | [search][search-spec] | Issues which are specifications for a large scale feature. |
@@ -443,6 +444,7 @@ These labels also include sublabels, such as `windows/config/`.
 [search-docs]: https://github.com/keymanapp/keyman/labels/docs
 [search-feat]: https://github.com/keymanapp/keyman/labels/feat
 [search-fix]: https://github.com/keymanapp/keyman/labels/fix
+[search-maint]: https://github.com/keymanapp/keyman/labels/maint
 [search-question]: https://github.com/keymanapp/keyman/labels/question
 [search-spec]: https://github.com/keymanapp/keyman/labels/spec
 [search-style]: https://github.com/keymanapp/keyman/labels/style

--- a/resources/scopes/commit-types.json
+++ b/resources/scopes/commit-types.json
@@ -6,6 +6,7 @@
     "docs",
     "feat",
     "fix",
+    "maint",
     "refactor",
     "style",
     "test"


### PR DESCRIPTION
During the "M3: Maintenance Sprints" session of the April 2025 planning conference we discussed that we'd rename the `chore` GH label to `maint`.

However, this change doesn't remove the existing `chore` label because that is also used for merge commits.

@keymanapp-test-bot skip