### PR TITLE
fix(android): Change Alert Dialog instead of Toast if package missing languages

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -116,12 +116,14 @@ public class PackageActivity extends AppCompatActivity implements
       kmpProcessor.getLanguageCount(pkgInfo, PackageProcessor.PP_KEYBOARDS_KEY, 0) : 0;
 
     // Sanity check for keyboard packages
+    // Not using showErrorToast to avoid cluttering Sentry with noise
     if (pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
       if (keyboardCount == 0) {
         showErrorDialog(context, pkgId, getString(R.string.no_new_touch_keyboards_to_install));
         return;
       } else if (languageCount == 0) {
-        showErrorToast(getString(R.string.no_associated_languages));
+        showErrorDialog(context, pkgId, getString(R.string.no_associated_languages));
+        return;
       }
     }
 


### PR DESCRIPTION
###  Background
Currently, Toast notifications displayed to the user are also sent as errors to Sentry. (#7189)

### Scenario
User attempts to install a keyboard package where no languages are associated with the keyboard

### Change
This PR changes the Toast notification to an alert dialog that doesn't send the error (really warning) to Sentry.
Keyman already displays a similar alert dialog if the keyboard package doesn't contain a touch layout keyboard.

This way we don't clutter Sentry with noise.

Fixes: #13782

Fixes: KEYMAN-ANDROID-251

Will :cherries: pick to stable-18.0

## User Testing

**Setup** - On an Android device/emulator, install the PR build of Keyman for Android. Also download a test keyboard [ge.kmp](https://darcywong00.github.io/examples/invalid/ge.kmp) which has no languages associated with the keyboard.

* **TEST_NO_LANGUAGES** - Verifies error dialog shown if keyboard package missing languages
1. Launch Keyman for Android and dismiss the "Get Started" menu
2. From Keyman settings --> Install Keyboard or Dictionary --> Install from local file
3. Browse to where ge.kmp was downloaded and select it
4. Verify error dialog appears showing package ID "ge" failed to install
![ge-no-language](https://github.com/user-attachments/assets/7881fca0-bd7b-4bf1-bbb3-7cd44df826ec)
