### PR TITLE
change(web): enable linting for Keyman Engine for Web modules

### DIFF
--- a/web/common.inc.sh
+++ b/web/common.inc.sh
@@ -23,6 +23,8 @@ function compile() {
     builder_die "Scripting error: insufficient argument count!"
   fi
 
+  eslint .
+
   local COMPILE_TARGET="$1"
   local SRC_DIR=${2:-"${KEYMAN_ROOT}/web/src"}
   local BUILD_DIR=${3:-"${KEYMAN_ROOT}/web/build"}

--- a/web/src/app/browser/src/beepHandler.ts
+++ b/web/src/app/browser/src/beepHandler.ts
@@ -38,7 +38,7 @@ export class BeepHandler {
     }
 
     // All code after this point is DOM-based, triggered by the beep.
-    var Pelem: HTMLElement = outputTarget.getElement();
+    let Pelem: HTMLElement = outputTarget.getElement();
     if(outputTarget instanceof DesignIFrame) {
       Pelem = outputTarget.docRoot; // I1446 - beep sometimes fails to flash when using OSK and rich control
     }
@@ -51,7 +51,7 @@ export class BeepHandler {
       return;
     }
 
-    for(var Lbo=0; Lbo<this._BeepObjects.length; Lbo++) { // I1446 - beep sometimes fails to return background color to normal
+    for(let Lbo=0; Lbo<this._BeepObjects.length; Lbo++) { // I1446 - beep sometimes fails to return background color to normal
                                                                 // I1511 - array prototype extended
       if(this._BeepObjects[Lbo].e == Pelem) {
         return;
@@ -77,7 +77,7 @@ export class BeepHandler {
   readonly reset = () => {
     this.keyboardInterface.resetContextCache();
 
-    var Lbo;
+    let Lbo;
     this._BeepTimeout = 0;
     for(Lbo=0;Lbo<this._BeepObjects.length;Lbo++) { // I1511 - array prototype extended
       this._BeepObjects[Lbo].reset();

--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -112,7 +112,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
           // For design-mode iframes:
 
           // This block:  has to do with maintaining focus.
-          var Lelem=(elem as HTMLIFrameElement).contentWindow.document;
+          const Lelem=(elem as HTMLIFrameElement).contentWindow.document;
           // I2404 - Attach to IFRAMEs child objects, only editable IFRAMEs here
           if(device.browser == 'firefox') {
             this.domEventTracker.attachDOMEvent(Lelem,'focus', this._ControlFocus);
@@ -149,7 +149,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
           // For design-mode iframes:
 
           // This block:  has to do with maintaining focus.
-          let Lelem = (elem as HTMLIFrameElement).contentWindow.document;
+          const Lelem = (elem as HTMLIFrameElement).contentWindow.document;
           // Mozilla      // I2404 - Attach to  IFRAMEs child objects, only editable IFRAMEs here
           if(device.browser == 'firefox') {
             // Firefox won't handle these events on Lelem.body - only directly on Lelem (the doc) instead.
@@ -162,7 +162,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
         }
 
         // This block:  has to do with maintaining focus (and consequences)
-        var lastElem = this.mostRecentTarget?.getElement();
+        const lastElem = this.mostRecentTarget?.getElement();
         if(lastElem && lastElem == elem) {
           this.forgetActiveTarget(); // should already auto-hide the OSK while at it via event.
         }
@@ -268,7 +268,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
     }
 
     // We condition on 'priorElement' below as a check to allow KMW to set a default active keyboard.
-    let hadRecentElement = !!previousTarget;
+    const hadRecentElement = !!previousTarget;
 
     // Must set before _Blur / _Focus to avoid infinite recursion due to complications
     // in setActiveKeyboard behavior with managed keyboard settings.
@@ -368,7 +368,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
    * This is based on the current `.activeTarget` and its related attachment metadata.
    */
   protected currentKeyboardSrcTarget(): OutputTarget<any> {
-    let target = this.currentTarget || this.mostRecentTarget;
+    const target = this.currentTarget || this.mostRecentTarget;
 
     if(this.isTargetKeyboardIndependent(target)) {
       return target;
@@ -378,7 +378,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
   }
 
   private isTargetKeyboardIndependent(target: OutputTarget<any>): boolean {
-    let attachmentInfo = target?.getElement()._kmwAttachment;
+    const attachmentInfo = target?.getElement()._kmwAttachment;
 
     // If null or undefined, we're in 'global' mode.
     return !!(attachmentInfo?.keyboard || attachmentInfo?.keyboard === '');
@@ -386,7 +386,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
 
   // Note:  is part of the keyboard activation process.  Not to be called directly by published API.
   activateKeyboardForTarget(kbd: {keyboard: Keyboard, metadata: KeyboardStub}, target: OutputTarget<any>) {
-    let attachment = target?.getElement()._kmwAttachment;
+    const attachment = target?.getElement()._kmwAttachment;
 
     if(!attachment) {
       // if not set with an "independent keyboard", changes the global.
@@ -425,7 +425,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
       return;
     }
 
-    let attachment = target.getElement()._kmwAttachment;
+    const attachment = target.getElement()._kmwAttachment;
 
     // Catches if the target is already in independent-mode, even if it's being cancelled
     // during this call.
@@ -504,7 +504,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
     }
 
     try {
-      let result = await super.activateKeyboard(keyboardId, languageCode, saveCookie);
+      const result = await super.activateKeyboard(keyboardId, languageCode, saveCookie);
 
       this.engineConfig.alertHost?.wait(); // clear any pending waits.
 
@@ -568,8 +568,8 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
    *                      whenever a KMW-enabled page element loses control.
    */
   _BlurKeyboardSettings(lastElem: HTMLElement, PInternalName?: string, PLgCode?: string) {
-    var keyboardID = this.activeKeyboard ? this.activeKeyboard.keyboard.id : '';
-    var langCode = this.activeKeyboard?.metadata.langId;
+    let keyboardID = this.activeKeyboard ? this.activeKeyboard.keyboard.id : '';
+    let langCode = this.activeKeyboard?.metadata.langId;
 
     if(PInternalName !== undefined && PLgCode !== undefined) {
       keyboardID = PInternalName;
@@ -593,7 +593,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
    */
   _FocusKeyboardSettings(lastElem: HTMLElement, blockGlobalChange: boolean) {
     // Important pre-condition:  the newly-focused element must be set as active.
-    let attachment = lastElem._kmwAttachment;
+    const attachment = lastElem._kmwAttachment;
     const global = this.globalKeyboard;
 
     if(attachment.keyboard != null) {
@@ -615,7 +615,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
   _CommonFocusHelper(outputTarget: OutputTarget<any>): boolean {
     const focusAssistant = this.focusAssistant;
 
-    let activeKeyboard = this.activeKeyboard?.keyboard;
+    const activeKeyboard = this.activeKeyboard?.keyboard;
     if(!focusAssistant.restoringFocus) {
       outputTarget?.deadkeys().clear();
       activeKeyboard?.notify(0, outputTarget, 1);  // I2187
@@ -684,7 +684,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
     }
 
     // Step 1: determine the corresponding OutputTarget instance.
-    let target = eventOutputTarget(e);
+    const target = eventOutputTarget(e);
     if (target == null) {
       return true;
     }
@@ -715,7 +715,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
      */
     this.focusAssistant.restoringFocus = false;
 
-    let activeKeyboard = this.activeKeyboard;
+    const activeKeyboard = this.activeKeyboard;
     const maintainingFocus = this.focusAssistant.maintainingFocus;
     if(!maintainingFocus && activeKeyboard) {
       activeKeyboard.keyboard.notify(0, target, 0);  // I2187
@@ -738,7 +738,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
 
   doChangeEvent(target: OutputTarget<any>) {
     if(target.changed) {
-      let event = new Event('change', {"bubbles": true, "cancelable": false});
+      const event = new Event('change', {"bubbles": true, "cancelable": false});
       target.getElement().dispatchEvent(event);
     }
 
@@ -756,7 +756,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
    **/
   getSavedKeyboardRaw(): string {
     const cookie = new CookieSerializer<KeyboardCookie>('KeymanWeb_Keyboard');
-    var v = cookie.load(decodeURIComponent);
+    const v = cookie.load(decodeURIComponent);
 
     if(typeof(v.current) != 'string') {
       return null;
@@ -776,7 +776,7 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
    * @return      {string}          InternalName:LanguageCode
    **/
   getSavedKeyboard(): string {
-    let cookieValue = this.getSavedKeyboardRaw();
+    const cookieValue = this.getSavedKeyboardRaw();
 
     // Check that the requested keyboard is included in the available keyboard stubs
     const stubs = this.keyboardCache.getStubList()
@@ -814,13 +814,13 @@ export default class ContextManager extends ContextManagerBase<BrowserConfigurat
     const d=kbd;
 
     // Identify the stub with the saved keyboard
-    let t=d.split(':');
+    const t=d.split(':');
     if(t.length < 2) {
       t[1]='';
     }
 
     // Find the matching stub; if it doesn't exist, default to the first available stub.
-    let stub = this.keyboardCache.getStub(t[0], t[1]);
+    const stub = this.keyboardCache.getStub(t[0], t[1]);
 
     // Sets the default stub (as specified with the `getSavedKeyboard` call) as active.
     if(stub) {

--- a/web/src/app/browser/src/debug-main.ts
+++ b/web/src/app/browser/src/debug-main.ts
@@ -8,9 +8,9 @@ import { SourcemappedWorker } from '@keymanapp/lexical-model-layer/web'
   * This can only be done during load when the active script will be the
   * last script loaded.  Otherwise the script must be identified by name.
  */
- var scripts = document.getElementsByTagName('script');
- var ss = scripts[scripts.length-1].src;
- var sPath = ss.substr(0,ss.lastIndexOf('/')+1);
+ const scripts = document.getElementsByTagName('script');
+ const ss = scripts[scripts.length-1].src;
+ const sPath = ss.substr(0,ss.lastIndexOf('/')+1);
 
 // @ts-ignore
 window['keyman'] = new KeymanEngine(SourcemappedWorker, sPath);

--- a/web/src/app/browser/src/defaultBrowserRules.ts
+++ b/web/src/app/browser/src/defaultBrowserRules.ts
@@ -17,7 +17,7 @@ export default class DefaultBrowserRules extends DefaultRules {
   }
 
   isCommand(Lkc: KeyEvent): boolean {
-    let code = this.codeForEvent(Lkc);
+    const code = this.codeForEvent(Lkc);
 
     switch(code) {
       case Codes.keyCodes['K_TAB']:
@@ -33,7 +33,7 @@ export default class DefaultBrowserRules extends DefaultRules {
    * applyCommand - used when a RuleBehavior represents a non-text "command" within the Engine.
    */
   applyCommand(Lkc: KeyEvent, outputTarget: OutputTarget): void {
-    let code = this.codeForEvent(Lkc);
+    const code = this.codeForEvent(Lkc);
 
     const moveToNext = (back: boolean) => {
       const contextManager = this.contextManager;

--- a/web/src/app/browser/src/hardwareEventKeyboard.ts
+++ b/web/src/app/browser/src/hardwareEventKeyboard.ts
@@ -59,10 +59,11 @@ export function preprocessKeyboardEvent(e: KeyboardEvent, keyboardState: Keyboar
   }
 
   // Stage 1 - track the true state of the keyboard's modifiers.
-  var prevModState = keyboardState.modStateFlags, curModState = 0x0000;
-  var ctrlEvent = false, altEvent = false;
+  const prevModState = keyboardState.modStateFlags;
+  let curModState = 0x0000;
+  let ctrlEvent = false, altEvent = false;
 
-  let keyCodes = Codes.keyCodes;
+  const keyCodes = Codes.keyCodes;
   switch(Lcode) {
     case keyCodes['K_CTRL']:      // The 3 shorter "K_*CTRL" entries exist in some legacy keyboards.
     case keyCodes['K_LCTRL']:
@@ -129,7 +130,7 @@ export function preprocessKeyboardEvent(e: KeyboardEvent, keyboardState: Keyboar
   keyboardState.modStateFlags = curModState;
 
   // For European keyboards, not all browsers properly send both key-up events for the AltGr combo.
-  let altGrMask = ModifierKeyConstants.RALTFLAG | ModifierKeyConstants.LCTRLFLAG;
+  const altGrMask = ModifierKeyConstants.RALTFLAG | ModifierKeyConstants.LCTRLFLAG;
   if((prevModState & altGrMask) == altGrMask && (curModState & altGrMask) != altGrMask) {
     // We just released AltGr - make sure it's all released.
     curModState &= ~ altGrMask;
@@ -139,7 +140,7 @@ export function preprocessKeyboardEvent(e: KeyboardEvent, keyboardState: Keyboar
     curModState &= ~ModifierKeyConstants.LCTRLFLAG;
   }
 
-  let modifierBitmasks = Codes.modifierBitmasks;
+  const modifierBitmasks = Codes.modifierBitmasks;
   // Stage 4 - map the modifier set to the appropriate keystroke's modifiers.
   const activeKeyboard = keyboardState.activeKeyboard;
   let Lmodifiers: number;
@@ -192,12 +193,12 @@ export function preprocessKeyboardEvent(e: KeyboardEvent, keyboardState: Keyboar
   });
 
   // The 0x6F used to be 0x60 - this adjustment now includes the chiral alt and ctrl modifiers in that check.
-  let LisVirtualKeyCode = (typeof e.charCode != 'undefined' && e.charCode != null  &&  (e.charCode == 0 || (Lmodifiers & 0x6F) != 0));
+  const LisVirtualKeyCode = (typeof e.charCode != 'undefined' && e.charCode != null  &&  (e.charCode == 0 || (Lmodifiers & 0x6F) != 0));
   s.LisVirtualKey = LisVirtualKeyCode || e.type != 'keypress';
 
   s = processForMnemonicsAndLegacy(s, activeKeyboard, keyboardState.baseLayout);
 
-  let processedEvent = new KeyEvent(s);
+  const processedEvent = new KeyEvent(s);
   processedEvent.source = e;
   return processedEvent;
 }
@@ -304,17 +305,17 @@ export default class HardwareEventKeyboard extends HardKeyboard {
    */
   _KeyUp: (e: KeyboardEvent) => boolean = (e) => {
     const target = eventOutputTarget(e);
-    var Levent = preprocessKeyboardEvent(e, this.processor, this.hardDevice);
+    const Levent = preprocessKeyboardEvent(e, this.processor, this.hardDevice);
     if(Levent == null || target == null) {
       return true;
     }
 
-    var inputEle = target.getElement();
+    const inputEle = target.getElement();
 
     // Since this part concerns DOM element + browser interaction management, we preprocess it for
     // browser form commands before passing control to the Processor module.
     if(Levent.Lcode == 13) {
-      var ignore = false;
+      let ignore = false;
       if(nestedInstanceOf(inputEle, "HTMLTextAreaElement")) {
         ignore = true;
       }
@@ -349,12 +350,12 @@ export default class HardwareEventKeyboard extends HardKeyboard {
     this.swallowKeypress = false;
 
     // Get event properties
-    var Levent = preprocessKeyboardEvent(e, this.processor, this.hardDevice);
+    const Levent = preprocessKeyboardEvent(e, this.processor, this.hardDevice);
     if(Levent == null) {
       return true;
     }
 
-    let resultCapture: { LeventMatched: boolean } = {
+    const resultCapture: { LeventMatched: boolean } = {
       LeventMatched: false
     }
 
@@ -385,17 +386,17 @@ export default class HardwareEventKeyboard extends HardKeyboard {
   // 1)  To detect browser form submissions (handled in kmwdomevents.ts)
   // 2)  To detect modifier state changes.
   private keyUp(e: KeyboardEvent): boolean {
-    var Levent = preprocessKeyboardEvent(e, this.processor, this.hardDevice);
+    const Levent = preprocessKeyboardEvent(e, this.processor, this.hardDevice);
     if(Levent == null) {
       return true;
     }
 
-    let outputTarget = eventOutputTarget(e);
+    const outputTarget = eventOutputTarget(e);
     return this.processor.doModifierPress(Levent, outputTarget, false);
   }
 
   private keyPress(e: KeyboardEvent): boolean {
-    var Levent = preprocessKeyboardEvent(e, this.processor, this.hardDevice);
+    const Levent = preprocessKeyboardEvent(e, this.processor, this.hardDevice);
     if(Levent == null || Levent.LisVirtualKey) {
       return true;
     }
@@ -417,7 +418,7 @@ export default class HardwareEventKeyboard extends HardKeyboard {
 
     // Only reached if it's a mnemonic keyboard.
 
-    let resultCapture: { preventDefaultKeystroke?: boolean } = {};
+    const resultCapture: { preventDefaultKeystroke?: boolean } = {};
 
     // Should only be run if `preventDefaultKeystroke` is required by the following conditional
     // block.  If it isn't - that is, swallowKeypress == true, we want to swallow that keypress

--- a/web/src/app/browser/src/hotkeyManager.ts
+++ b/web/src/app/browser/src/hotkeyManager.ts
@@ -29,7 +29,7 @@ export class HotkeyManager {
    */
   addHotKey(keyCode: number, shiftState: number, handler: () => void) {
     // Test if existing handler for this code and replace it if so
-    for(var i=0; i<this.hotkeys.length; i++) {
+    for(let i=0; i<this.hotkeys.length; i++) {
       if(this.hotkeys[i].code == keyCode && this.hotkeys[i].shift == shiftState) {
         this.hotkeys[i].handler = handler;
         return;
@@ -48,7 +48,7 @@ export class HotkeyManager {
    * Description  Remove a hot key handler from array of document-level hotkeys triggered by key up event
    */
   removeHotkey(keyCode: number, shiftState: number) {
-    for(var i=0; i<this.hotkeys.length; i++) {
+    for(let i=0; i<this.hotkeys.length; i++) {
       if(this.hotkeys[i].matches(keyCode, shiftState)) {
         this.hotkeys.splice(i,1);
         return;
@@ -67,18 +67,18 @@ export class HotkeyManager {
       e = window.event as KeyboardEvent;
     }
 
-    var _Lcode = _GetEventKeyCode(e);
+    const _Lcode = _GetEventKeyCode(e);
     if(_Lcode == null) {
       return false;
     }
 
     // Removed testing of e.shiftKey==null  I3363 (Build 301)
-    var _Lmodifiers =
+    const _Lmodifiers =
       (e.shiftKey ? 0x10 : 0) |
       (e.ctrlKey ? 0x20 : 0) |
       (e.altKey ? 0x40 : 0);
 
-    for(var i=0; i<this.hotkeys.length; i++) {
+    for(let i=0; i<this.hotkeys.length; i++) {
       if(this.hotkeys[i].matches(_Lcode, _Lmodifiers)) {
         this.hotkeys[i].handler();
         e.returnValue = false;

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -158,8 +158,8 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
    * @returns A Promise that only resolves once the engine is fully initialized.
    */
   public async init(options: Required<BrowserInitOptionSpec>) {
-    let deviceDetector = new DeviceDetector();
-    let device = deviceDetector.detect();
+    const deviceDetector = new DeviceDetector();
+    const device = deviceDetector.detect();
 
     const totalOptions = {...BrowserInitOptionDefaults, ...options};
 
@@ -397,7 +397,7 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
    *
    */
   private _GetKeyboardDetail = function(Lstub: KeyboardStub, Lkbd: Keyboard) { // I2078 - Full keyboard detail
-    let Lr = {
+    const Lr = {
       Name: Lstub.KN,
       InternalName: Lstub.KI,
       LanguageName: Lstub.KL,  // I1300 - Add support for language names
@@ -433,7 +433,7 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
   public isCJK(k0?: KeyboardObject | ReturnType<KeymanEngine['_GetKeyboardDetail']> /* [b/c Toolbar UI]*/) {
     let kbd: Keyboard;
     if(k0) {
-      let kbdDetail = k0 as ReturnType<KeymanEngine['_GetKeyboardDetail']>;
+      const kbdDetail = k0 as ReturnType<KeymanEngine['_GetKeyboardDetail']>;
       if(kbdDetail.KeyboardID){
         kbd = this.keyboardRequisitioner.cache.getKeyboard(kbdDetail.KeyboardID);
       } else {
@@ -682,7 +682,7 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
     }
 
     PKbd = PKbd || this.core.activeKeyboard;
-    let Pstub = this.keyboardRequisitioner.cache.getStub(PKbd);
+    const Pstub = this.keyboardRequisitioner.cache.getStub(PKbd);
 
     // help.keyman.com will set this function in place to specify the desired
     // dimensions for the documentation-keyboards, so we'll give it priority.  One of those
@@ -691,7 +691,7 @@ export default class KeymanEngine extends KeymanEngineBase<BrowserConfiguration,
     // Note that the main intended use of that function is for embedded KMW on the mobile apps...
     // but they never call `BuildVisualKeyboard`, so it's all good.
     const getOskHeight = this['getOskHeight'];
-    let targetHeight = (typeof getOskHeight == 'function' ? getOskHeight() : null) || this.osk.computedHeight || 200;
+    const targetHeight = (typeof getOskHeight == 'function' ? getOskHeight() : null) || this.osk.computedHeight || 200;
 
     return VisualKeyboard.buildDocumentationKeyboard(
       PKbd,

--- a/web/src/app/browser/src/languageMenu.ts
+++ b/web/src/app/browser/src/languageMenu.ts
@@ -44,9 +44,9 @@ export class LanguageMenu {
   }
 
   constructShim(): HTMLDivElement {
-    let languageMenu = this;
-    let shim = util._CreateElement('div');
-    let osk = this.keyman.osk;
+    const languageMenu = this;
+    const shim = util._CreateElement('div');
+    const osk = this.keyman.osk;
 
     shim.id='kmw-language-menu-background';
     shim.addEventListener('touchstart', (e) => {
@@ -55,8 +55,8 @@ export class LanguageMenu {
 
       // Display build only if touching menu, space *and* one other point on screen (build 369)
       if(e.touches.length > 2) {
-        var sX=e.touches[1].pageX,sY=e.touches[1].pageY;
-        let spaceBar = osk.vkbd.spaceBar;
+        const sX=e.touches[1].pageX,sY=e.touches[1].pageY;
+        const spaceBar = osk.vkbd.spaceBar;
         if(sX > spaceBar.offsetLeft && sX < spaceBar.offsetLeft+spaceBar.offsetWidth &&
            sY > spaceBar.offsetTop && sY < spaceBar.offsetTop+spaceBar.offsetHeight
         ) {
@@ -73,26 +73,26 @@ export class LanguageMenu {
    **/
   show() {
     const device = this.keyman.config.hostDevice;
-    let kbdList=this.keyman.keyboardRequisitioner.cache.getStubList();
-    let nKbds=kbdList.length;
+    const kbdList=this.keyman.keyboardRequisitioner.cache.getStubList();
+    const nKbds=kbdList.length;
     if(nKbds < 1) {
       return;
     }
 
     // Create the menu list container element
-    var menu=this.lgList=util._CreateElement('div');
+    const menu=this.lgList=util._CreateElement('div');
     this.lgList.id='kmw-language-menu';
 
     // Insert a transparent overlay to prevent anything else happening during keyboard selection,
     // but allow the menu to be closed if anywhere else on screen is touched
 
-    let languageMenu = this;
+    const languageMenu = this;
 
     document.body.appendChild(this.shim);
 
     // Add two nested DIVs to properly support iOS scrolling with momentum
     //  c.f. https://github.com/joelambert/ScrollFix/issues/2
-    var m2=util._CreateElement('div'),s2=m2.style,
+    const m2=util._CreateElement('div'),s2=m2.style,
         m3=util._CreateElement('div');
     m2.id='kmw-menu-scroll-container'; m3.id='kmw-menu-scroller';
 
@@ -105,7 +105,8 @@ export class LanguageMenu {
     menu.appendChild(m2);
 
     // Add menu index strip
-    let x,mx=util._CreateElement('div');
+    let x: HTMLParagraphElement;
+    const mx=util._CreateElement('div');
     mx.id='kmw-menu-index';
     for(let i=1; i<=26; i++) {
       x=util._CreateElement('p');
@@ -154,7 +155,7 @@ export class LanguageMenu {
 
     // Adjust width for pixel scaling on Android tablets
     if(device.OS == 'android' && device.formFactor == 'tablet' && 'devicePixelRatio' in window) {
-      var w=parseInt(util.getStyleValue(menu,'width'),10),
+      let w=parseInt(util.getStyleValue(menu,'width'),10),
       ms=menu.style;
       if(!isNaN(w)) {
         ms.width=ms.maxWidth=(2*w/window.devicePixelRatio)+'px';
@@ -175,17 +176,17 @@ export class LanguageMenu {
     this.adjust(0);
 
     // Adjust the index font size and line height
-    var dy=(<HTMLElement>mx.childNodes[1]).offsetTop-(<HTMLElement>mx.childNodes[0]).offsetTop,
-        lineHeight=Math.floor(menu.offsetHeight/26.0),
-        scale=Math.round(100.0*lineHeight/dy)/100.0,
-        factor=(scale > 0.6 ? 1 : 2);
+    const dy=(<HTMLElement>mx.childNodes[1]).offsetTop-(<HTMLElement>mx.childNodes[0]).offsetTop;
+    const lineHeight=Math.floor(menu.offsetHeight/26.0);
+    let scale=Math.round(100.0*lineHeight/dy)/100.0;
+    const factor=(scale > 0.6 ? 1 : 2);
 
     if(scale > 1.25) {
       scale=1.25;
     }
 
     for(let i=0;i<26;i++) {
-      var qs=(<HTMLElement>mx.childNodes[i]).style;
+      const qs=(<HTMLElement>mx.childNodes[i]).style;
       if(factor == 2 && (i%2) == 1) {
         qs.display='none';
       } else {
@@ -195,7 +196,7 @@ export class LanguageMenu {
     }
 
     // Increase width of outer menu DIV by index, else hide index
-    var menuWidth=m2.offsetWidth;
+    let menuWidth=m2.offsetWidth;
     if(m2.scrollHeight > m2.offsetHeight+3) {
       menuWidth = menuWidth+mx.offsetWidth;
     } else {
@@ -216,15 +217,16 @@ export class LanguageMenu {
    * @param   {number}  nKbds number of displayed keyboards to add to number of languages
    **/
   adjust(nKbds: number) {
-    let osk = this.keyman.osk;
-    let device = this.keyman.config.hostDevice;
+    const osk = this.keyman.osk;
+    const device = this.keyman.config.hostDevice;
 
-    var menu=this.lgList, m2=<HTMLElement>menu.firstChild, m3=<HTMLElement>m2.firstChild,
-      barWidth=0,s=menu.style,mx=<HTMLElement>menu.childNodes[1],
-      maxHeight=window.innerHeight-osk.vkbd.lgKey.offsetHeight-16,
+    const menu=this.lgList, m2=<HTMLElement>menu.firstChild, m3=<HTMLElement>m2.firstChild;
+    let barWidth=0;
+    let maxHeight=window.innerHeight-osk.vkbd.lgKey.offsetHeight-16;
+    const s=menu.style,mx=<HTMLElement>menu.childNodes[1],
       nItems=m3.childNodes.length+nKbds-1,      // Number of (visible) keyboard selectors
-      itemHeight=(<HTMLElement>m3.firstChild.firstChild).offsetHeight,
-      menuHeight=nItems*itemHeight;
+      itemHeight=(<HTMLElement>m3.firstChild.firstChild).offsetHeight;
+    let menuHeight=nItems*itemHeight;
 
     // Correct maxheight for viewport scaling (iPhone/iPod only) and internal position corrections
     if(device.OS == 'ios') {
@@ -263,17 +265,18 @@ export class LanguageMenu {
     e.stopPropagation();
     e.preventDefault();
 
-    let target = <HTMLElement> e.touches[0].target;
+    const target = <HTMLElement> e.touches[0].target;
 
     // Will return 'P', not 'p'.
     if(target.nodeName != 'P') {
       return;
     }
 
-    var i,t,initial=target.innerHTML.charCodeAt(0),nn=menu.childNodes;
+    let i: number;
+    const initial=target.innerHTML.charCodeAt(0), nn=menu.childNodes;
     try {
       for(i=0; i<nn.length-1; i++) {
-        t=(<HTMLElement>nn[i].firstChild).innerHTML.toUpperCase().charCodeAt(0);
+        const t=(<HTMLElement>nn[i].firstChild).innerHTML.toUpperCase().charCodeAt(0);
         if(t >= initial) {
           break;
         }
@@ -316,11 +319,11 @@ export class LanguageMenu {
    *    @return   {number}              index of currently active language
    **/
   addLanguages(menu: HTMLDivElement, kbdList: KeyboardStub[]): number {
-    var nStubs=kbdList.length;
-    let device = this.keyman.config.hostDevice;
+    const nStubs=kbdList.length;
+    const device = this.keyman.config.hostDevice;
 
     // Create and sort a list of languages
-    let langs: string[] = [];
+    const langs: string[] = [];
     for(let n=0; n<nStubs; n++) {
       const lg=kbdList[n]['KL'];
       if(langs.indexOf(lg) == -1) {
@@ -330,7 +333,7 @@ export class LanguageMenu {
     langs.sort();
 
     // Get current scale factor (reciprocal of viewport scale)
-    var scale=Math.round(100/util.getViewportScale(device.formFactor))/100;
+    const scale=Math.round(100/util.getViewportScale(device.formFactor))/100;
 
     let activeLanguageIndex=-1;
 
@@ -402,9 +405,9 @@ export class LanguageMenu {
     }
 
     // Add a non-selectable bottom bar so to allow scrolling to the last language
-    var padLast=util._CreateElement('div');
+    const padLast=util._CreateElement('div');
     padLast.id='kmw-menu-footer';
-    var cancelTouch=function(e: TouchEvent){
+    const cancelTouch=function(e: TouchEvent){
       if(e.cancelable) {
         e.preventDefault();
       }
@@ -498,9 +501,9 @@ export class LanguageMenu {
     // Touchmove drags the list and prevents release from selecting the language
     const touchMove=function(this: HTMLElement, e: TouchEvent) {
       e.stopImmediatePropagation();
-      var scroller=<HTMLElement>languageMenu.lgList.childNodes[0],
-          yMax=scroller.scrollHeight-scroller.offsetHeight,
-      y, dy;
+      const scroller=<HTMLElement>languageMenu.lgList.childNodes[0];
+      const yMax=scroller.scrollHeight-scroller.offsetHeight;
+      let y: number;
 
       // TS does not have a standard definition for TouchEvent.pageY.
       //@ts-ignore
@@ -513,7 +516,7 @@ export class LanguageMenu {
         return false;
       }
 
-      dy=y-languageMenu.y0;
+      const dy=y-languageMenu.y0;
 
       // Scroll up (show later listed languages)
       if(dy < 0) {
@@ -577,7 +580,7 @@ export class LanguageMenu {
    * Remove the language menu again
    **/
   hide() {
-    let osk = this.keyman.osk;
+    const osk = this.keyman.osk;
 
     if(this.lgList) {
       osk.vkbd.highlightKey(osk.vkbd.lgKey,false);

--- a/web/src/app/browser/src/release-main.ts
+++ b/web/src/app/browser/src/release-main.ts
@@ -8,9 +8,9 @@ import { Worker } from '@keymanapp/lexical-model-layer/web'
   * This can only be done during load when the active script will be the
   * last script loaded.  Otherwise the script must be identified by name.
  */
- var scripts = document.getElementsByTagName('script');
- var ss = scripts[scripts.length-1].src;
- var sPath = ss.substr(0,ss.lastIndexOf('/')+1);
+ const scripts = document.getElementsByTagName('script');
+ const ss = scripts[scripts.length-1].src;
+ const sPath = ss.substr(0,ss.lastIndexOf('/')+1);
 
 // @ts-ignore
 window['keyman'] = new KeymanEngine(Worker, sPath);

--- a/web/src/app/browser/src/utils/rotationProcessor.ts
+++ b/web/src/app/browser/src/utils/rotationProcessor.ts
@@ -40,7 +40,7 @@ export class RotationProcessor {
   }
 
   resolve() {
-    var osk = this.keyman.osk;
+    const osk = this.keyman.osk;
 
     // `keyman: KeymanEngine` (modularized app/browser)
     this.keyman.touchLanguageMenu?.hide();
@@ -81,8 +81,8 @@ export class RotationProcessor {
    */
   init() {
     // Note:  we use wrapper functions instead of `.bind(this)` in this method to facilitate stubbing for our rotation test page.
-    var os = this.keyman.config.hostDevice.OS;
-    var util = this.keyman.util;
+    const os = this.keyman.config.hostDevice.OS;
+    const util = this.keyman.util;
 
     if(os == 'ios') {
     /* iOS is rather inconsistent about these events, with changes to important window state information -
@@ -137,7 +137,7 @@ export class RotationProcessor {
   }
 
   iOSEventUpdate() {
-    var newState = new RotationState();
+    const newState = new RotationState();
 
     if(this.rotState.equals(newState)) {
       if(++this.idlePermutationCounter == RotationProcessor.IDLE_PERMUTATION_CAP) {

--- a/web/src/app/browser/src/viewsAnchorpoint.ts
+++ b/web/src/app/browser/src/viewsAnchorpoint.ts
@@ -18,7 +18,7 @@ function buildBaseOskConfiguration(engine: KeymanEngine) {
 
 class PublishedAnchoredOSKView extends AnchoredOSKView {
   constructor(engine: KeymanEngine, config?: ViewConfiguration) {
-    let finalConfig = {
+    const finalConfig = {
       ...buildBaseOskConfiguration(engine),
       ...(config || {})
     };
@@ -29,7 +29,7 @@ class PublishedAnchoredOSKView extends AnchoredOSKView {
 
 class PublishedFloatingOSKView extends FloatingOSKView {
   constructor(engine: KeymanEngine, config?: FloatingOSKViewConfiguration) {
-    let finalConfig: FloatingOSKViewConfiguration = {
+    const finalConfig: FloatingOSKViewConfiguration = {
       ...buildBaseOskConfiguration(engine),
       ...(config || {})
     };
@@ -40,7 +40,7 @@ class PublishedFloatingOSKView extends FloatingOSKView {
 
 class PublishedInlineOSKView extends InlinedOSKView {
   constructor(engine: KeymanEngine, config?: ViewConfiguration) {
-    let finalConfig: ViewConfiguration = {
+    const finalConfig: ViewConfiguration = {
       ...buildBaseOskConfiguration(engine),
       ...(config || {})
     };

--- a/web/src/app/ui/kmwuibutton.ts
+++ b/web/src/app/ui/kmwuibutton.ts
@@ -78,10 +78,10 @@ if(!keymanweb) {
        * Highlight the currently active keyboard in the list of keyboards
        **/
       private _ShowSelected() {
-        let kbd=keymanweb.getActiveKeyboard();
-        let lgc=keymanweb.getActiveLanguage();
-        let kList = this._KeymanWeb_KbdList.childNodes;
-        let _r = /^KMWSel_(.*)\$(.*)$/;
+        const kbd=keymanweb.getActiveKeyboard();
+        const lgc=keymanweb.getActiveLanguage();
+        const kList = this._KeymanWeb_KbdList.childNodes;
+        const _r = /^KMWSel_(.*)\$(.*)$/;
 
         for(let i=1; i<kList.length; i++) {
           (kList[i].childNodes[0] as HTMLElement).className = '';
@@ -89,7 +89,7 @@ if(!keymanweb) {
 
         let i: number;
         for(i=2; i<kList.length; i++) {
-          let _rv = _r.exec((kList[i].childNodes[0] as HTMLElement).id);
+          const _rv = _r.exec((kList[i].childNodes[0] as HTMLElement).id);
           if(_rv && (_rv[1] == kbd) && (_rv[2] == lgc)) {
             break;
           }
@@ -121,15 +121,16 @@ if(!keymanweb) {
           }
         }
 
-        let _r=/^KMWSel_(.*)\$(.*)$/;
-        let _rv=_r.exec(id),_lgc='',_name='';
+        const _r=/^KMWSel_(.*)\$(.*)$/;
+        const _rv=_r.exec(id);
+        let _lgc='',_name='';
         if(_rv !== null) {
           _name = _rv[1].split('$')[0]; //new code
           _lgc = id.split('$')[1];
           if(this._KMWSel != null) {
             this._KMWSel.className = '';
           }
-          let _k = document.getElementById(id);
+          const _k = document.getElementById(id);
           if(_k) {
             _k.className='selected';
           }
@@ -140,7 +141,7 @@ if(!keymanweb) {
         }
 
         keymanweb.focusLastActiveElement();
-        let osk = keymanweb.osk;
+        const osk = keymanweb.osk;
         if(osk && osk.isEnabled()) {
           osk.show(true);
         }
@@ -265,7 +266,7 @@ if(!keymanweb) {
        */
       private _ShowKeyboardButton(_name?: string) {
         let kbdName = keymanweb.getActiveKeyboard();
-        let kbdId = document.getElementById("KMW_Keyboard");
+        const kbdId = document.getElementById("KMW_Keyboard");
         if(arguments.length > 0) {
           kbdName = _name;
         }
@@ -274,14 +275,14 @@ if(!keymanweb) {
           if((kbdName == '') || keymanweb.isCJK()) {
             kbdId.className='kmw_disabled';
           } else {
-            let osk = keymanweb.osk;
+            const osk = keymanweb.osk;
             kbdId.className = osk && osk.isEnabled() ? 'kmw_show' : 'kmw_hide';
           }
         }
       }
 
       registerEvents() {
-        let osk = keymanweb.osk;
+        const osk = keymanweb.osk;
         if(!osk) {
           return;
         }
@@ -304,7 +305,7 @@ if(!keymanweb) {
         /* TODO: why is this still needed??? Does it actually do anything?? */
         osk.addEventListener('hide', function(obj) {
           if((arguments.length > 0) && obj.HiddenByUser) {
-            let _a = document.getElementById('KMW_Keyboard');
+            const _a = document.getElementById('KMW_Keyboard');
             if(_a) {
               _a.className = 'kmw_hide';
             }
@@ -320,7 +321,7 @@ if(!keymanweb) {
        **/
       readonly _ShowKeymanWebKeyboard = () => {
         const kbdId=document.getElementById("KMW_Keyboard");
-        let osk = keymanweb.osk;
+        const osk = keymanweb.osk;
 
         if((kbdId.className!='kmw_disabled') && osk && osk.show) {
           if(osk.isEnabled()) {
@@ -384,7 +385,7 @@ if(!keymanweb) {
         }
 
 
-        let imgPath=util.getOption('resources')+'ui/button/';
+        const imgPath=util.getOption('resources')+'ui/button/';
         if(_elem) {
           // Append another DIV to follow the main control with clear:both to prevent selection over entire width of window
           const dx=document.createElement('DIV')
@@ -417,9 +418,9 @@ if(!keymanweb) {
         // Thus, in essence:  if(true) { /* ... */ }
         // @ts-ignore
         if(!keymanweb['iOS']) {
-          var _li = util.createElement('li');
-          var _a = util.createElement('a');
-          var _img = util.createElement('img');
+          const _li = util.createElement('li');
+          const _a = util.createElement('a');
+          const _img = util.createElement('img');
           _img.src = imgPath+'kbdicon.gif';
           _a.appendChild(_img);
 
@@ -430,7 +431,7 @@ if(!keymanweb) {
           _sp1.appendChild(_txt1);
           _a.appendChild(_sp1);
 
-          var _sp2 = util.createElement('span');
+          const _sp2 = util.createElement('span');
           _sp2.id = 'KMW_KbdHiddenMsg';
           _sp2.appendChild(_txt2);
           _a.appendChild(_sp2);
@@ -443,9 +444,9 @@ if(!keymanweb) {
           this._KeymanWeb_KbdList.appendChild(_li);
         }
 
-        var _li1 = util.createElement('li');
+        const _li1 = util.createElement('li');
         _li1.id = 'KMW_ButtonUI_KbdList';
-        var _a1 = util.createElement('a');
+        const _a1 = util.createElement('a');
         _a1.appendChild(document.createTextNode('(System keyboard)'));
 
         _a1.onclick = this._SelectKeyboard;
@@ -460,7 +461,7 @@ if(!keymanweb) {
 
         document.getElementById('kmwico_li').appendChild(this._KeymanWeb_KbdList);
 
-        var _sfEl = document.getElementById("kmwico_li");
+        const _sfEl = document.getElementById("kmwico_li");
         util.attachDOMEvent(_sfEl,'mousedown',this._SelectorMouseDown);
         util.attachDOMEvent(_sfEl,'mouseover',this._SelectorMouseOver);
         util.attachDOMEvent(_sfEl,'mouseout',this._SelectorMouseOut);
@@ -494,7 +495,7 @@ if(!keymanweb) {
 
         const kbds=keymanweb.getKeyboards();
         if(kbds.length > 0) {
-          for(var i:number=0; i<kbds.length; i++) {
+          for(let i:number=0; i<kbds.length; i++) {
             this.registerKeyboard(
               kbds[i].InternalName,
               kbds[i].LanguageName,
@@ -524,7 +525,7 @@ if(!keymanweb) {
         let _t = Lkn.replace(/\s?keyboard/i,'');
 
         if(Lkl) {
-          var lg=Lkl.split(',')[0];
+          const lg=Lkl.split(',')[0];
           if(Lkn.search(lg) == -1) {
             _t = lg+' ('+_t+')';
           }

--- a/web/src/app/ui/kmwuifloat.ts
+++ b/web/src/app/ui/kmwuifloat.ts
@@ -88,7 +88,7 @@ if(!keymanweb) {
        */
       readonly toggleOSK = () => {
         keymanweb.activatingUI(true);
-        let osk = keymanweb.osk;
+        const osk = keymanweb.osk;
         if(osk && osk.show) {
           if(osk.isEnabled()) {
             osk.hide();
@@ -133,7 +133,7 @@ if(!keymanweb) {
         this.outerDiv.innerHTML = "<a href='http://keyman.com/web/' target='KeymanWebHelp'>"
           + "<img src='"+imgPath+"kmicon.gif' border='0' style='padding: 0px 2px 0 1px; margin:0px;' title='KeymanWeb' alt='KeymanWeb' /></a>"; /* I2081 */
 
-        var s=this.outerDiv.style;
+        let s=this.outerDiv.style;
         s.backgroundColor='white'; s.border='solid 1px black'; s.position='absolute'; s.height='18px';
         s.font='bold 8pt sans-serif'; s.display='none'; s.textAlign='left';s.overflow='hidden';
 
@@ -150,7 +150,7 @@ if(!keymanweb) {
         // Set initial OSK button style (off by default)
         this.oskButtonState(false);
 
-        var Lhdiv = util.createElement('div');
+        const Lhdiv = util.createElement('div');
         this.oskButton = Lhdiv;
         Lhdiv.onclick = this.toggleOSK;
         Lhdiv.appendChild(this.kbdIcon);
@@ -177,7 +177,8 @@ if(!keymanweb) {
         this.innerDiv.appendChild(this.KeyboardSelector);  //this may need to be moved up....
 
         // Check required interface alignment and default keyboard
-        var opt=util.getOption('ui'), dfltKeyboard='(System keyboard)';
+        const opt=util.getOption('ui');
+        let dfltKeyboard='(System keyboard)';
         if(opt && typeof(opt) == 'object') {
           if(typeof(opt['position']) == 'string' && opt['position'] == 'right') {
             this.floatRight = true;
@@ -186,7 +187,7 @@ if(!keymanweb) {
           }
         }
 
-        var Lopt = util.createElement('option');
+        let Lopt = util.createElement('option');
         Lopt.value = '-';
         Lopt.innerHTML = dfltKeyboard;
         this.KeyboardSelector.appendChild(Lopt);
@@ -209,7 +210,7 @@ if(!keymanweb) {
        * UI removal - resource cleanup
        */
       shutdown() {
-        var root = this.outerDiv;
+        const root = this.outerDiv;
         if(root) {
           root.parentNode.removeChild(root);
         }
@@ -238,14 +239,14 @@ if(!keymanweb) {
           }
 
           // Loop over installed keyboards and add to selection list
-          var Lkbds=keymanweb.getKeyboards();
+          const Lkbds=keymanweb.getKeyboards();
 
           for(let Ln=0; Ln<Lkbds.length; Ln++) {
             let Lopt = util.createElement('option');
             Lopt.value = Lkbds[Ln].InternalName+':'+Lkbds[Ln].LanguageCode;
             Lopt.innerHTML = Lkbds[Ln].Name.replace(/\s?keyboard/i,'');
             if(Lkbds[Ln].LanguageName) {
-              var lg=Lkbds[Ln].LanguageName;
+              let lg=Lkbds[Ln].LanguageName;
               // Only show the main language name if variants indicated (this is tentative)
               // e.g. Chinese rather than Chinese, Mandarin, which is in the keyboard name
               lg = lg.split(',')[0];
@@ -284,14 +285,14 @@ if(!keymanweb) {
        *              is listed more than once for different language codes
        */
       readonly updateMenu = (kbd: string, lg: string) => {
-        var i=0;
+        let i=0;
 
         // This can be called during startup before fully initialized - ignore if so
         if(!this.initialized) {
           return;
         }
 
-        var match = kbd;
+        let match = kbd;
         if(lg != '') {
           match += ':' + lg;
         }
@@ -321,7 +322,7 @@ if(!keymanweb) {
        * Description  Update kbd icon border style to indicate whether OSK is enabled for display or not
        **/
       readonly oskButtonState = (oskEnabled: boolean) => {
-        var s = this.kbdIcon.style;
+        const s = this.kbdIcon.style;
         s.width='24px';
         s.height='13px';
         s.top='1px';
@@ -383,7 +384,7 @@ if(!keymanweb) {
           this.addButtonOSK();
         });
 
-        let osk = keymanweb.osk;
+        const osk = keymanweb.osk;
         if(!osk) {
           return;
         }
@@ -453,8 +454,8 @@ if(!keymanweb) {
         keymanweb.activatingUI(true);
 
         if(this.KeyboardSelector.value != '-') {
-          var i=this.KeyboardSelector.selectedIndex;
-          var t=this.KeyboardSelector.options[i].value.split(':');
+          const i=this.KeyboardSelector.selectedIndex;
+          const t=this.KeyboardSelector.options[i].value.split(':');
           keymanweb.setActiveKeyboard(t[0],t[1]);
         } else {
           keymanweb.setActiveKeyboard('');
@@ -489,7 +490,7 @@ if(!keymanweb) {
       readonly ShowInterface = (Px?: number, Py?: number) => {
         if(!this.initialized) return;
 
-        var Ls = this.outerDiv.style;
+        const Ls = this.outerDiv.style;
 
         if(Px  &&  Py) {
           Ls.left = Px + 'px';
@@ -531,7 +532,7 @@ if(!keymanweb) {
             this.outerDiv.style.width = this.KeyboardSelector.offsetWidth+30+'px';
           } else {
             this.oskButton.style.display = 'block';
-            let osk = keymanweb.osk;
+            const osk = keymanweb.osk;
             if(osk) {
               this.oskButtonState(osk.isEnabled());
             } else {
@@ -551,7 +552,7 @@ if(!keymanweb) {
        */
       readonly _Resize = (e: Event) => {
         if(this.outerDiv.style.display =='block') {
-          var elem = keymanweb.getLastActiveElement();
+          const elem = keymanweb.getLastActiveElement();
           if(this.floatRight) {  // I1296
             this.ShowInterface(util.getAbsoluteX(elem) + elem.offsetWidth + 1, util.getAbsoluteY(elem) + 1);
           } else {

--- a/web/src/app/ui/kmwuitoggle.ts
+++ b/web/src/app/ui/kmwuitoggle.ts
@@ -118,7 +118,7 @@ if(!keymanweb) {
         let x = p.x;
         let y = p.y;
 
-        var ownerDoc = someElement.ownerDocument;
+        const ownerDoc = someElement.ownerDocument;
         if(ownerDoc.designMode == 'on' && ownerDoc.defaultView && ownerDoc.defaultView.frameElement) {
           w = ownerDoc.defaultView.frameElement.clientWidth;
           h = ownerDoc.defaultView.frameElement.clientHeight;
@@ -145,7 +145,7 @@ if(!keymanweb) {
       }
 
       registerEvents() {
-        let osk = keymanweb.osk;
+        const osk = keymanweb.osk;
 
         if(!osk) {
           return;
@@ -288,7 +288,7 @@ if(!keymanweb) {
           };
 
           private __updatestyle() {
-            var ss=this._elem.style;
+            const ss=this._elem.style;
             if(this._over) {
               ss.margin = '0px';
               if(this._selected) {
@@ -370,8 +370,8 @@ if(!keymanweb) {
           constructor(/* TODO: put wrapping method's params HERE instead upon class-extraction */) {
             this._selected = _selected;
 
-            let imgPath=util.getOption('resources') + 'ui/toggle/';
-            let _elemImg = util.createElement('img') as HTMLImageElement & Owned<Button>;
+            const imgPath=util.getOption('resources') + 'ui/toggle/';
+            const _elemImg = util.createElement('img') as HTMLImageElement & Owned<Button>;
             this._elem = util.createElement('div');
             this._elem['_owningObject'] = this;
             _elemImg.style.display = 'block';
@@ -475,7 +475,7 @@ if(!keymanweb) {
       }
 
       shutdown() {
-        var root = this.controller;
+        const root = this.controller;
 
         if(root) {
           root.parentNode.removeChild(root);
@@ -524,8 +524,8 @@ if(!keymanweb) {
           this.kbdButton.getElem().id = 'kmwico';
           this.kbdButton.getElem().style.width = '24px';
 
-          var Lki=_kbds[0].InternalName;
-          var Lklc=_kbds[0].LanguageCode;
+          const Lki=_kbds[0].InternalName;
+          const Lklc=_kbds[0].LanguageCode;
           this.controller.style.background = 'url('+imgPath+'kmwcontroller2.gif)';
           this.keyboards.push({_InternalName: Lki, _LanguageCode: Lklc, _Index: 0});
           this.kbdButton._onclick = this.switchSingleKbd;
@@ -542,7 +542,7 @@ if(!keymanweb) {
         }
 
         // Highlight the last active keyboard
-        var sk=keymanweb.getSavedKeyboard().split(':');
+        const sk=keymanweb.getSavedKeyboard().split(':');
         this.updateMenu(sk[0],sk[1]);
       }
 
@@ -701,8 +701,8 @@ if(!keymanweb) {
           this.keyboardMenu.innerHTML = '';  // I2403 - Allow toggle design to be loaded twice
         }
 
-        var _li = util.createElement('li');
-        var _a = util.createElement('a');
+        const _li = util.createElement('li');
+        const _a = util.createElement('a');
         _a.innerHTML='(System keyboard)';
         _a.href="#";
         _a.onclick = () => {
@@ -717,14 +717,14 @@ if(!keymanweb) {
 
         const _kbds=keymanweb.getKeyboards(), _added: Record<string, number> = {};
         this.keyboards = [];
-        for(var _kbd = 0; _kbd < _kbds.length; _kbd++) {
-          var _li1=util.createElement('li');
-          var _a1=util.createElement('a');
+        for(let _kbd = 0; _kbd < _kbds.length; _kbd++) {
+          const _li1=util.createElement('li');
+          const _a1=util.createElement('a');
           _a1.innerHTML=_kbds[_kbd].LanguageName + ' - ' + _kbds[_kbd].Name;
           if(!_added[_kbds[_kbd].InternalName]) _added[_kbds[_kbd].InternalName]=0;
           _added[_kbds[_kbd].InternalName]++;
 
-          var _n=_added[_kbds[_kbd].InternalName];
+          const _n=_added[_kbds[_kbd].InternalName];
           this.keyboards.push({_InternalName: _kbds[_kbd].InternalName, _LanguageCode:_kbds[_kbd].LanguageCode, _Index: _n});
 
           _a1.href="#";

--- a/web/src/app/ui/kmwuitoolbar.ts
+++ b/web/src/app/ui/kmwuitoolbar.ts
@@ -300,7 +300,7 @@ if(!keymanweb) {
 
         const mapNode = this.createNode('map', 'kmw_worldgrey16');
         mapNode.name='kmw_worldgrey16';
-        for(let i in this.regions) {
+        for(const i in this.regions) {
           const areaNode = this.createNode('area');
           areaNode.shape = 'poly';
           areaNode.alt = '';
@@ -326,7 +326,7 @@ if(!keymanweb) {
         this.regionNodes = {};
 
         const listNode = this.createNode('ul');
-        for(let i in this.regions) {
+        for(const i in this.regions) {
           const itemNode = this.createNode('li');
           this.regionNodes[i] = this.createNode('a', null, null, this.regions[i].t);
           this.regionNodes[i].href='#';
@@ -435,7 +435,7 @@ if(!keymanweb) {
         this.regionLanguageListNodes = {};
 
         // Build list of keyboards by region and language
-        let Keyboards = keymanweb.getKeyboards();
+        const Keyboards = keymanweb.getKeyboards();
 
         // Sort the keyboards by region and language
         Keyboards.sort(this.sortKeyboards);
@@ -448,15 +448,15 @@ if(!keymanweb) {
           }
         }
 
-        for(let i in this.regions) {
+        for(const i in this.regions) {
           this.regionLanguageListNodes[i] = this.createNode('div', null, 'kmw_selector_region');
           let colNode = this.createNode('div', null, 'kmw_keyboard_col');
-          var max = 0, count = 0, languageCode = '';
+          let max = 0, count = 0, languageCode = '';
 
           // Get number of languages for the region
           for(let j=0; j<Keyboards.length; j++) {
             // REVERT:  ensures that keyboards without visible map region get displayed SOMEWHERE.
-            var kbdRegion = Keyboards[j].RegionCode;
+            const kbdRegion = Keyboards[j].RegionCode;
             if(!this.regions[kbdRegion]) {
               // For now, we'll display them within the 'middle-east' region.
               if(i != this.catchAllRegion) {
@@ -467,7 +467,7 @@ if(!keymanweb) {
             }
 
             // Get JUST the language code for this section.  BCP-47 codes can include more!
-            var bcpSubtags: string[] = keymanweb.util.getLanguageCodes(Keyboards[j].LanguageCode);
+            const bcpSubtags: string[] = keymanweb.util.getLanguageCodes(Keyboards[j].LanguageCode);
             if(bcpSubtags[0] == languageCode) {
               continue; // Same language as previous keyboard
             }
@@ -491,9 +491,9 @@ if(!keymanweb) {
               continue; // Not this region
             }
 
-            var bcpSubtags: string[] = keymanweb.util.getLanguageCodes(Keyboards[j].LanguageCode);
+            const bcpSubtags: string[] = keymanweb.util.getLanguageCodes(Keyboards[j].LanguageCode);
             if(bcpSubtags[0] == languageCode) {  // Same language as previous keyboard, so add it to that entry
-              var x = this.languages[languageCode].keyboards;
+              const x = this.languages[languageCode].keyboards;
 
               // While we could avoid duplicating keyboard entries that occur for multiple regions, we'll instead
               // allow them to display while distinguishing them more directly.  (That part is handled later.)
@@ -612,7 +612,7 @@ if(!keymanweb) {
        * @param       {Object}  kbd
        **/
       addKeyboardToList(lang: LanguageEntry, kbd: KeyboardDetail) {
-        let found = this.findListedKeyboard(lang);
+        const found = this.findListedKeyboard(lang);
         if(found == null) {
           // Add the button
           if(this.listedKeyboards.length >= this.maxListedKeyboards) {
@@ -627,7 +627,7 @@ if(!keymanweb) {
 
             // delete the oldest used control
             if(oldestFound != null) {
-              let rk = this.listedKeyboards[oldestFound];
+              const rk = this.listedKeyboards[oldestFound];
               this.langKeyboardListNodes[rk.lang.id] = null;
               this.langKeyboardNodes[rk.lang.id] = null;
               this.languageButtonsNode.removeChild(rk.buttonNode);
@@ -640,12 +640,12 @@ if(!keymanweb) {
               }
             }
           }
-          let buttonNode = this.createNode('div', null/*'kmw_button_keyboard_'+lang.id*/, 'kmw_button');
+          const buttonNode = this.createNode('div', null/*'kmw_button_keyboard_'+lang.id*/, 'kmw_button');
           let aNode = this.createNode('a', null, 'kmw_button_a'+(lang.keyboards.length>1 ? ' kmw_norightgap' : ''));
           aNode.href='#';
 
           let p1=this.ToolBar_Text['SelectKeyboardPre'] + kbd.Name;
-          let p2=this.ToolBar_Text['SelectKeyboardSuf'];
+          const p2=this.ToolBar_Text['SelectKeyboardSuf'];
           if(p1.toLowerCase().indexOf(p2.toLowerCase()) < 0) {
             p1=p1+' '+ p2;
           }
@@ -657,14 +657,14 @@ if(!keymanweb) {
           aNode.appendChild(this.createNode('div', null, 'kmw_a', this.lgText));
           buttonNode.appendChild(aNode);
 
-          let thisANode = aNode;
+          const thisANode = aNode;
 
           if(lang.keyboards.length > 1) {
             aNode = this.createNode('a', null, 'kmw_button_a kmw_noleftgap');
             aNode.href = '#';
             aNode.title = this.ToolBar_Text['AltKeyboardsPre']+lang.name + this.ToolBar_Text['AltKeyboardsSuf'];
             aNode.onclick = (event) => this.showKeyboardsForLanguage(event, lang);
-            let divNode = this.createNode('div', null, 'kmw_a');
+            const divNode = this.createNode('div', null, 'kmw_a');
             let kbdText = this.truncate(kbd.Name.replace(/\s?keyboard/i,''),40-this.lgText.length);
             divNode.appendChild(this.langKeyboardNodes[lang.id] = this.createNode('span', null, 'kmw_kbd', kbdText));
             aNode.appendChild(divNode);
@@ -674,8 +674,8 @@ if(!keymanweb) {
             this.langKeyboardListNodes[lang.id] = this.createNode('ul', null, 'kmw_selector_kbd');
             this.langKeyboardListNodes[lang.id].style.display='none';
 
-            for(let n in lang.keyboards) {
-              let itemNode = this.createNode('li');
+            for(const n in lang.keyboards) {
+              const itemNode = this.createNode('li');
               kbdText = lang.keyboards[n].Name.replace(/\s?keyboard/i,'');
               // We append the full BCP-47 code here for disambiguation when regional and/or script variants exist.
               kbdText = kbdText + " [" + lang.keyboards[n].LanguageCode + "]";
@@ -694,20 +694,20 @@ if(!keymanweb) {
 
           this.languageButtonsNode.appendChild(buttonNode);
 
-          let thisLang = lang, thisButtonNode = buttonNode;
+          const thisLang = lang, thisButtonNode = buttonNode;
           this.listedKeyboards.push({priority: this.keyboardListPriority++, lang:thisLang, keyboard:kbd, buttonNode:thisButtonNode, aNode:thisANode});
         } else {
           this.listedKeyboards[found].priority = this.keyboardListPriority++;
           this.listedKeyboards[found].keyboard = kbd;
-          let e = this.langKeyboardNodes[lang.id];
+          const e = this.langKeyboardNodes[lang.id];
           if(e) {
-            var kbdText=kbd.Name.replace(/\s?keyboard/i,'');
+            const kbdText=kbd.Name.replace(/\s?keyboard/i,'');
             e.innerHTML = this.truncate(kbdText,40-this.lgText.length);
           }
 
           if(this.listedKeyboards[found].aNode) {
             let p1 = this.ToolBar_Text['SelectKeyboardPre']+kbd.Name;
-            let p2 = this.ToolBar_Text['SelectKeyboardSuf'];
+            const p2 = this.ToolBar_Text['SelectKeyboardSuf'];
             if(p1.toLowerCase().indexOf(p2.toLowerCase()) < 0) {
               p1=p1+' '+ p2;
             }
@@ -754,7 +754,7 @@ if(!keymanweb) {
        * Description  Hide the list of keyboards for this language
        **/
       readonly hideKeyboardsForLanguage = (event: Event) => {
-        var e = this.keyboardsForLangPopup;
+        const e = this.keyboardsForLangPopup;
         if(e) {
           e.style.display='none';
         }
@@ -794,7 +794,7 @@ if(!keymanweb) {
        * @return      {boolean}
        **/
       selectLanguage(event: Event, lang: LanguageEntry) {
-        let found = this.findListedKeyboard(lang);
+        const found = this.findListedKeyboard(lang);
         let kbd: KeyboardDetail = null;
 
         if(found == null) {
@@ -824,7 +824,7 @@ if(!keymanweb) {
         keymanweb.activatingUI(true);
 
         if(this.selectedLanguage) {
-          let found = this.findListedKeyboard(this.selectedLanguage);
+          const found = this.findListedKeyboard(this.selectedLanguage);
           if(found != null) {
             this.listedKeyboards[found].buttonNode.className = 'kmw_button';
           }
@@ -863,7 +863,7 @@ if(!keymanweb) {
        * @return      {boolean}
        **/
       enableControls(): boolean {
-        let elems = [
+        const elems = [
           this.offButtonNode,
           this.offBarNode,
           this.oskButtonNode,
@@ -917,7 +917,7 @@ if(!keymanweb) {
        * @return      {boolean}
        **/
       readonly showOSK = (event: Event) => {
-        let osk = keymanweb.osk;
+        const osk = keymanweb.osk;
         if(!osk) {
           return false;
         }
@@ -947,7 +947,7 @@ if(!keymanweb) {
         if(this.toolbarNode.className != 'kmw_controls_disabled') {
           this.hideKeyboardsForLanguage(null);
           if(this.selectedLanguage) {
-            var found = this.findListedKeyboard(this.selectedLanguage);
+            const found = this.findListedKeyboard(this.selectedLanguage);
             if(found != null) {
               this.listedKeyboards[found].buttonNode.className = 'kmw_button';
             }
@@ -997,7 +997,7 @@ if(!keymanweb) {
        * Description  Select the region for which to list languages
        **/
       readonly selectRegion = (event: Event, region: string) => {
-        let e = this.browseMapNode;
+        const e = this.browseMapNode;
 
         if(!e) {
           return this.eventCapture(event);
@@ -1073,7 +1073,7 @@ if(!keymanweb) {
           return true;
         }
 
-        let t=params.target;
+        const t=params.target;
         if(t.tagName.toLowerCase() == 'textarea' ||
           (t.tagName.toLowerCase() == 'input' && (t as HTMLInputElement).type.toLowerCase() == 'text')
         ) {
@@ -1087,7 +1087,7 @@ if(!keymanweb) {
               if(keymanweb.isCJK()) {
                 this.oskButtonNode.style.display = this.oskBarNode.style.display = 'none';
               } else {
-                let osk = keymanweb.osk;
+                const osk = keymanweb.osk;
                 this.oskButtonNode.className = (osk && osk.isEnabled()) ? 'kmw_button_selected' : 'kmw_button';
               }
             }
@@ -1155,10 +1155,10 @@ if(!keymanweb) {
         // https://help.keyman.com/developer/engine/web/16.0/reference/core/getKeyboards vs
         // https://help.keyman.com/developer/engine/web/16.0/reference/events/kmw.keyboardchange
         this.lastSelectedKeyboard = null;
-        let kbName=p.internalName,
+        const kbName=p.internalName,
             lgName=keymanweb.util.getLanguageCodes(p.languageCode)[0];
         if(lgName != '' && kbName != '') {
-          let lg = this.languages[lgName];
+          const lg = this.languages[lgName];
           if(lg != null) {
             for(let j=0; j<lg.keyboards.length; j++) {
               if(lg.keyboards[j].InternalName == kbName) {
@@ -1202,7 +1202,7 @@ if(!keymanweb) {
       }
 
       registerEvents() {
-        let osk = keymanweb.osk;
+        const osk = keymanweb.osk;
         if(!osk) {
           return;
         }
@@ -1256,7 +1256,7 @@ if(!keymanweb) {
        * @return  {boolean}
       **/
       readonly hideAllPopups = (event: Event) => {
-        var e = this.keyboardsForLangPopup;
+        const e = this.keyboardsForLangPopup;
         if((!e || (e.style.display =='none')) && (this.selectorNode.className == '')) {
           return true;
         }
@@ -1367,15 +1367,15 @@ if(!keymanweb) {
           for(let i=0; i < c.maxrecent; i++) {
             // Is the entry actually defined?
             if(c[`recent${i}`] != undefined) {
-              var r=c[`recent${i}`].split(',');
+              const r=c[`recent${i}`].split(',');
               // Does its definition have the expected format?  That is: langID,keyboardID
               if(r.length == 2) {
-                var k = this.languages[r[0]];
+                const k = this.languages[r[0]];
                 // If the language has a defined entry in our list of loaded languages...
                 if(k != null) {
                   // Then, for our loaded keyboards for said loaded language...
                   // find the most recent match that is available in our current list.
-                  for(var j=0; j<k.keyboards.length; j++) {
+                  for(let j=0; j<k.keyboards.length; j++) {
                     if(k.keyboards[j].InternalName == r[1]) {
                       this.addKeyboardToList(k, k.keyboards[j]);
                       if(k.keyboards[j].InternalName == currentKeyboard) {
@@ -1394,12 +1394,12 @@ if(!keymanweb) {
         } else {
           // If language list and keyboard list have not yet been saved as a cookie,
           // initialize to the current (default) language and keyboard, if set by KMW
-          let kbName=keymanweb.getActiveKeyboard();
-          let lgName=keymanweb.getActiveLanguage();
+          const kbName=keymanweb.getActiveKeyboard();
+          const lgName=keymanweb.getActiveLanguage();
           if(lgName != '' && kbName != '') {
-            var lg = this.languages[lgName];
+            const lg = this.languages[lgName];
             if(lg != null) {
-              for(var j=0; j<lg.keyboards.length; j++) {
+              for(let j=0; j<lg.keyboards.length; j++) {
                 if(lg.keyboards[j].InternalName == kbName) {
                   this.selectKeyboard(null, lg, lg.keyboards[j], true);
                   window.focus();
@@ -1415,14 +1415,14 @@ if(!keymanweb) {
        * Save the current UI state in the KeymanWeb_Toolbar cookie
        **/
       saveCookie() {
-        let vs: ToolbarCookie ={
+        const vs: ToolbarCookie ={
           region: this.selectedRegion,
           maxrecent: this.listedKeyboards.length
         };
         vs.region = this.selectedRegion;
         vs.maxrecent = this.listedKeyboards.length;
 
-        for(var i=0; i<this.listedKeyboards.length; i++) {
+        for(let i=0; i<this.listedKeyboards.length; i++) {
           vs[`recent${i}`] = this.listedKeyboards[i].lang.id+","+this.listedKeyboards[i].keyboard.InternalName;
         }
 

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -64,12 +64,12 @@ export class ContextHost extends Mock {
 
   updateContext(text: string, selStart: number, selEnd: number): boolean {
     let shouldResetContext = false;
-    let tempMock = new Mock(text, selStart ?? text._kmwLength(), selEnd ?? text._kmwLength());
-    let newLeft = tempMock.getTextBeforeCaret();
-    let oldLeft = this.getTextBeforeCaret();
+    const tempMock = new Mock(text, selStart ?? text._kmwLength(), selEnd ?? text._kmwLength());
+    const newLeft = tempMock.getTextBeforeCaret();
+    const oldLeft = this.getTextBeforeCaret();
 
     if(text != this.text) {
-      let unexpectedBeforeCharCount = findCommonSubstringEndIndex(newLeft, oldLeft, true) + 1;
+      const unexpectedBeforeCharCount = findCommonSubstringEndIndex(newLeft, oldLeft, true) + 1;
       shouldResetContext = !!unexpectedBeforeCharCount;
     }
 
@@ -79,7 +79,7 @@ export class ContextHost extends Mock {
       this.selEnd = selEnd;
     } else {
       // Transform selection coordinates to their location within the longform context window.
-      let delta = oldLeft._kmwLength() - newLeft._kmwLength();
+      const delta = oldLeft._kmwLength() - newLeft._kmwLength();
       this.selStart = selStart - delta;
       this.selEnd = selEnd - delta;
     }

--- a/web/src/app/webview/src/keymanEngine.ts
+++ b/web/src/app/webview/src/keymanEngine.ts
@@ -44,7 +44,7 @@ export default class KeymanEngine extends KeymanEngineBase<WebviewConfiguration,
   }
 
   async init(options: Required<WebviewInitOptionSpec>) {
-    let device = new DeviceSpec(
+    const device = new DeviceSpec(
       'native',
       options.embeddingApp.indexOf('Tablet') >= 0 ? 'tablet' : 'phone',
       this.config.hostDevice.OS,
@@ -125,7 +125,7 @@ export default class KeymanEngine extends KeymanEngineBase<WebviewConfiguration,
       key = child;
     }
 
-    var w=key.offsetWidth,
+    const w=key.offsetWidth,
         h=key.offsetHeight,
         // Since the full OSKManager '_Box' is displayed within the keyboards' WebViews,
         // these calculations should be performed with respect to that, rather than osk.vkbd.kbdDiv.

--- a/web/src/app/webview/src/osk/globeHint.ts
+++ b/web/src/app/webview/src/osk/globeHint.ts
@@ -38,7 +38,7 @@ export class GlobeHint implements GlobeHintInterface {
   constructor(vkbd: VisualKeyboard) {
     this.vkbd = vkbd;
 
-    let tipElement = this.element=document.createElement('div');
+    const tipElement = this.element=document.createElement('div');
     tipElement.className = 'kmw-globehint';
     tipElement.id = 'kmw-globehint';
 
@@ -77,28 +77,28 @@ export class GlobeHint implements GlobeHintInterface {
       // The key element is positioned relative to its key-square, which is,
       // in turn, relative to its row.  Rows take 100% width, so this is sufficient.
       //
-      let rowElement = (key.key as OSKBaseKey).row.element;
+      const rowElement = (key.key as OSKBaseKey).row.element;
 
       // May need adjustment for borders if ever enabled for the desktop form-factor target.
-      let rkey = key.getClientRects()[0], rrow = rowElement.getClientRects()[0];
-      let xLeft = rkey.left - rrow.left,
+      const rkey = key.getClientRects()[0], rrow = rowElement.getClientRects()[0];
+      const xLeft = rkey.left - rrow.left,
           xWidth = rkey.width,
           xHeight = rkey.height;
 
-      let center = rkey.left + rkey.width/2;
+      const center = rkey.left + rkey.width/2;
 
-      let bubbleStyle = this.element.style;
+      const bubbleStyle = this.element.style;
 
       // Roughly matches how the subkey positioning is set.
       const _Box = this.vkbd.element.parentNode as HTMLDivElement;
       const _BoxRect = _Box.getBoundingClientRect();
       const keyRect = key.getBoundingClientRect();
-      let y = (keyRect.bottom - _BoxRect.top + 1);
+      const y = (keyRect.bottom - _BoxRect.top + 1);
 
       // Width dimensions must be set explicitly to prevent clipping.
       // We'll assume that the globe key is always positioned on the bottom row.
-      let oskBaseFontSize = new ParsedLengthStyle(this.vkbd.fontSize.styleString);
-      let bubbleWidth = Math.ceil(xWidth * 3);
+      const oskBaseFontSize = new ParsedLengthStyle(this.vkbd.fontSize.styleString);
+      const bubbleWidth = Math.ceil(xWidth * 3);
 
       bubbleStyle.bottom = Math.floor(this.vkbd.height - y) + 'px';
       // CSS already defines transform: translateX(-50%) - this centers the element.
@@ -132,7 +132,7 @@ export class GlobeHint implements GlobeHintInterface {
         this.element.style.fontSize = this.vkbd.fontSize.styleString;
       }
 
-      let capHeight = xHeight / 3;
+      const capHeight = xHeight / 3;
 
       this.cap.style.bottom = (rrow.height - capHeight) + 'px';
       this.cap.style.width = '0px';

--- a/web/src/engine/attachment/src/outputTargetForElement.ts
+++ b/web/src/engine/attachment/src/outputTargetForElement.ts
@@ -7,7 +7,7 @@ import { nestedInstanceOf } from "keyman/engine/element-wrappers";
  * @returns
  */
 export function eventOutputTarget(e: Event) {
-  let Ltarg: HTMLElement = e?.target as HTMLElement;
+  const Ltarg: HTMLElement = e?.target as HTMLElement;
   return outputTargetForElement(Ltarg);
 }
 

--- a/web/src/engine/attachment/src/pageContextAttachment.ts
+++ b/web/src/engine/attachment/src/pageContextAttachment.ts
@@ -95,7 +95,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
    * be in order of definition within the document.
    */
   public get inputList(): readonly HTMLElement[] {
-    let embeddedInputs = this.embeddedPageContexts.map(
+    const embeddedInputs = this.embeddedPageContexts.map(
       // Gets the input list for any pages embedded via iframe
       (embeddedPage) => embeddedPage.inputList
     ).reduce(
@@ -201,7 +201,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
       // The elements in the contained document get separately wrapped, so this doesn't need a proper wrapper.
       //
       // Its attachment process might need some work.
-      let eleInterface = wrapElement(x);
+      const eleInterface = wrapElement(x);
 
       // May should filter better for IFrames.
       if(!(eleInterface || nestedInstanceOf(x, "HTMLIFrameElement"))) {
@@ -288,7 +288,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
       }
 
       // If not this one, perhaps a child?
-      for(let child of this.embeddedPageContexts) {
+      for(const child of this.embeddedPageContexts) {
         if(child.isAttached(x)) {
           return true;
         }
@@ -378,13 +378,13 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
         this.enableInputModeObserver();
       }
 
-      let cnIndex = Pelem.className.indexOf('keymanweb-font');
+      const cnIndex = Pelem.className.indexOf('keymanweb-font');
       if(cnIndex >= 0) { // See note about the alias below.
         Pelem.className = Pelem.className.replace('keymanweb-font', '').trim();
       }
 
       // Remove the element from our internal input tracking.
-      var index = this.inputList.indexOf(Pelem);
+      const index = this.inputList.indexOf(Pelem);
       if(index > -1) {
         this._inputList.splice(index, 1);
       }
@@ -504,7 +504,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
           // If already attached, do not attempt to attach again.
           if(this.embeddedPageContexts.filter((context) => context.document == Lelem).length == 0) {
             // Lelem is the IFrame's internal document; set 'er up!
-            let embeddedPageAttachment = new PageContextAttachment(Lelem, {
+            const embeddedPageAttachment = new PageContextAttachment(Lelem, {
               ...this.options,
               owner: Pelem
             });
@@ -533,7 +533,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
     const detachFromDesignIframe = () => {
       this.clearElementAttachment(Pelem);
 
-      let index = this._inputList.indexOf(Pelem);
+      const index = this._inputList.indexOf(Pelem);
       if(index != -1) {
         this._inputList.splice(index, 1);
       }
@@ -586,7 +586,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
    * Description  Attaches KMW to control (or IFrame)
    */
   attachToControl(Pelem: HTMLElement) {
-    var touchable = this.device.touchable;
+    const touchable = this.device.touchable;
 
     // Exception for IFrame elements, in case of async loading issues.  (Fixes fun iframe loading bug with Chrome.)
     if(this.isAttached(Pelem) && !(Pelem instanceof Pelem.ownerDocument.defaultView.HTMLIFrameElement)) {
@@ -693,7 +693,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
       console.warn("KeymanWeb is not attached to element " + Pelem);
     }
 
-    var cn = Pelem.className;
+    const cn = Pelem.className;
     if(cn.indexOf('kmw-disabled') < 0) { // if not already explicitly disabled...
       Pelem.className = cn ? cn + ' kmw-disabled' : 'kmw-disabled';
     }
@@ -715,8 +715,8 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
       console.warn("KeymanWeb is not attached to element " + Pelem);
     }
 
-    var cn = Pelem.className;
-    var tagIndex = cn.indexOf('kmw-disabled');
+    const cn = Pelem.className;
+    const tagIndex = cn.indexOf('kmw-disabled');
     if(tagIndex >= 0) { // if already explicitly disabled...
       Pelem.className = cn.replace('kmw-disabled', '').trim();
     }
@@ -729,9 +729,9 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
   // except any tagged with class 'kmw-disabled'
   // TODO: email and url types should perhaps use default keyboard only
   listInputs() {
-    let eList: SortableInput[]=[];
-    let t1=document.getElementsByTagName('input');
-    let t2=document.getElementsByTagName('textarea');
+    const eList: SortableInput[]=[];
+    const t1=document.getElementsByTagName('input');
+    const t2=document.getElementsByTagName('textarea');
 
     for(let i=0; i<t1.length; i++) {
       if (Input.isSupportedType(t1[i].type) && t1[i].className.indexOf('kmw-disabled') < 0) {
@@ -754,7 +754,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
     });
 
     // Create a new list of sorted elements
-    let tList: HTMLElement[] = [];
+    const tList: HTMLElement[] = [];
     for(let i=0; i<eList.length; i++) {
       tList.push(eList[i].ip);
     }
@@ -773,7 +773,8 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
    * @param      {number|boolean}  bBack     Direction to move (0 or 1)
    */
   findNeighboringInput(activeBase: HTMLElement, bBack: number|boolean) {
-    var i,t=this.sortedInputs;
+    let i: number;
+    const t=this.sortedInputs;
 
     if(t.length == 0) {
       return null;
@@ -814,7 +815,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
 
     // Document.ownerDocument === null, so we better check that it's not null before proceeding.
     if(Pelem.ownerDocument && Pelem instanceof Pelem.ownerDocument.defaultView.HTMLElement) {
-      let dv = Pelem.ownerDocument.defaultView;
+      const dv = Pelem.ownerDocument.defaultView;
 
       if(Pelem instanceof dv.HTMLInputElement || Pelem instanceof dv.HTMLTextAreaElement) {
         possibleInputs.push(Pelem);
@@ -832,7 +833,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
        * @return      {Array<Element>}  array of elements of specified type
        * Description  Local function to get list of editable controls
        */
-      var LiTmp = function(_colon: string): HTMLElement[] {
+      const LiTmp = function(_colon: string): HTMLElement[] {
         return arrayFromNodeList(Pelem.getElementsByTagName(_colon));
       };
 
@@ -859,9 +860,9 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
    * Description  Used to automatically attach KMW to editable controls, regardless of control path.
    */
   private _SetupDocument(Pelem: HTMLElement) { // I1961
-    let possibleInputs = this._GetDocumentEditables(Pelem);
+    const possibleInputs = this._GetDocumentEditables(Pelem);
 
-    for(var Li = 0; Li < possibleInputs.length; Li++) {
+    for(let Li = 0; Li < possibleInputs.length; Li++) {
       // It knows how to handle pre-loaded iframes appropriately.
       this.attachToControl(possibleInputs[Li]);
     }
@@ -875,9 +876,9 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
    *              Mostly used to clear out all controls of a detached IFrame.
    */
   private _ClearDocument(Pelem: HTMLElement) { // I1961
-    let possibleInputs = this._GetDocumentEditables(Pelem);
+    const possibleInputs = this._GetDocumentEditables(Pelem);
 
-    for(var Li = 0; Li < possibleInputs.length; Li++) {
+    for(let Li = 0; Li < possibleInputs.length; Li++) {
       // It knows how to handle pre-loaded iframes appropriately.
       this.detachFromControl(possibleInputs[Li]);
     }
@@ -885,12 +886,12 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
 
 
   _EnablementMutationObserverCore = (mutations: MutationRecord[]) => {
-    for(var i=0; i < mutations.length; i++) {
-      var mutation = mutations[i];
+    for(let i=0; i < mutations.length; i++) {
+      const mutation = mutations[i];
 
       // ( ? : ) needed as a null check.
-      var disabledBefore = mutation.oldValue ? mutation.oldValue.indexOf('kmw-disabled') >= 0 : false;
-      var disabledAfter = (mutation.target as HTMLElement).className.indexOf('kmw-disabled') >= 0;
+      const disabledBefore = mutation.oldValue ? mutation.oldValue.indexOf('kmw-disabled') >= 0 : false;
+      const disabledAfter = (mutation.target as HTMLElement).className.indexOf('kmw-disabled') >= 0;
 
       if(disabledBefore && !disabledAfter) {
         this._EnableControl(mutation.target as HTMLElement);
@@ -900,12 +901,12 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
 
       // 'readonly' triggers on whether or not the attribute exists, not its value.
       if(!disabledAfter && mutation.attributeName == "readonly") {
-        var readonlyBefore = mutation.oldValue ? mutation.oldValue != null : false;
-        var elem = mutation.target;
+        const readonlyBefore = mutation.oldValue ? mutation.oldValue != null : false;
+        const elem = mutation.target;
 
         if(elem instanceof elem.ownerDocument.defaultView.HTMLInputElement
             || elem instanceof elem.ownerDocument.defaultView.HTMLTextAreaElement) {
-          var readonlyAfter = elem.readOnly;
+          const readonlyAfter = elem.readOnly;
 
           if(readonlyBefore && !readonlyAfter) {
             this._EnableControl(mutation.target as HTMLElement);
@@ -918,28 +919,28 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
   };
 
   _AutoAttachObserverCore = (mutations: MutationRecord[]) => {
-    var inputElementAdditions: HTMLElement[] = [];
-    var inputElementRemovals: HTMLElement[] = [];
+    let inputElementAdditions: HTMLElement[] = [];
+    let inputElementRemovals: HTMLElement[] = [];
 
-    for(var i=0; i < mutations.length; i++) {
-      let mutation = mutations[i];
+    for(let i=0; i < mutations.length; i++) {
+      const mutation = mutations[i];
 
-      for(var j=0; j < mutation.addedNodes.length; j++) {
+      for(let j=0; j < mutation.addedNodes.length; j++) {
         inputElementAdditions = inputElementAdditions.concat(this._GetDocumentEditables(mutation.addedNodes[j] as HTMLElement));
       }
 
-      for(j = 0; j < mutation.removedNodes.length; j++) {
+      for(let j = 0; j < mutation.removedNodes.length; j++) {
         inputElementRemovals = inputElementRemovals.concat(this._GetDocumentEditables(mutation.removedNodes[j] as HTMLElement));
       }
     }
 
-    for(var k = 0; k < inputElementAdditions.length; k++) {
+    for(let k = 0; k < inputElementAdditions.length; k++) {
       if(this.isKMWInput(inputElementAdditions[k])) { // Apply standard element filtering!
         this._MutationAdditionObserved(inputElementAdditions[k]);
       }
     }
 
-    for(k = 0; k < inputElementRemovals.length; k++) {
+    for(let k = 0; k < inputElementRemovals.length; k++) {
       let matched = false;
       const elem = inputElementRemovals[k];
 
@@ -1041,7 +1042,8 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
   // To be called by the object responsible for webpage-integration.
   initMutationObservers(document: Document, manualAttach: boolean) {
     if(typeof MutationObserver == 'function') {
-      var observationTarget = document.querySelector('body'), observationConfig: MutationObserverInit;
+      const observationTarget = document.querySelector('body');
+      let observationConfig: MutationObserverInit;
       if(!manualAttach) { //I1961
         observationConfig = { childList: true, subtree: true};
         this.attachmentObserver = new MutationObserver(this._AutoAttachObserverCore);
@@ -1080,9 +1082,10 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
    *  @return   {string}
    */
   getBaseFont() {
-    var ipInput = document.getElementsByTagName<'input'>('input'),
-        ipTextArea=document.getElementsByTagName<'textarea'>('textarea'),
-        n=0,fs,fsDefault='Arial,sans-serif';
+    const ipInput    = document.getElementsByTagName('input');
+    const ipTextArea = document.getElementsByTagName('textarea');
+    let n=0, fs: string;
+    const fsDefault='Arial,sans-serif';
 
     // Find the first input element (if it exists)
     if(ipInput.length == 0 && ipTextArea.length == 0) {
@@ -1092,8 +1095,8 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
     } else if(ipInput.length == 0 && ipTextArea.length > 0) {
       n=2;
     } else {
-      var firstInput = ipInput[0];
-      var firstTextArea = ipTextArea[0];
+      const firstInput = ipInput[0];
+      const firstTextArea = ipTextArea[0];
 
       if(firstInput.offsetTop < firstTextArea.offsetTop) {
         n=1;
@@ -1133,7 +1136,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
    *
    **/
   buildAttachmentFontStyle(keyboardFontDescriptor: InternalKeyboardFont): string {
-    let kfd = keyboardFontDescriptor;
+    const kfd = keyboardFontDescriptor;
 
     // Get name of font to be applied
     let fontName = this.baseFont;
@@ -1146,7 +1149,8 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
 
     // Set font family chain for mapped elements and remove any double quotes
     // font-family:  maintains the base font as a fallback.
-    var rx = new RegExp('\\s?' + fontName + ',?'), fontFamily = this.appliedFont.replace(/\u0022/g, '');
+    const rx = new RegExp('\\s?' + fontName + ',?');
+    let fontFamily = this.appliedFont.replace(/\u0022/g, '');
 
     // Remove base font name from chain if present
     fontFamily = fontFamily.replace(rx, '');
@@ -1163,7 +1167,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
     fontFamily = '"' + fontFamily.replace(/\,\s?/g, '","') + '"';
 
     // Add to the stylesheet, quoted, and with !important to override any explicit style
-    let s = '.keymanweb-font{\nfont-family:' + fontFamily + ' !important;\n}\n';
+    const s = '.keymanweb-font{\nfont-family:' + fontFamily + ' !important;\n}\n';
 
     // Store the current font chain (with quote-delimited font names)
     this.appliedFont = fontFamily;
@@ -1210,7 +1214,7 @@ export class PageContextAttachment extends EventEmitter<EventMap> {
         } catch (e) {}
       });
 
-      for(let input of this.inputList) {
+      for(const input of this.inputList) {
         try {
           this.detachFromControl(input);
         } catch(e) {

--- a/web/src/engine/dom-utils/src/arrayFromNodeList.ts
+++ b/web/src/engine/dom-utils/src/arrayFromNodeList.ts
@@ -6,7 +6,7 @@
  * @return      {Array<Element>}
  */
 export function arrayFromNodeList(nl: NodeList|HTMLCollectionOf<Element>): HTMLElement[] {
-  let res: (HTMLElement)[] = [];
+  const res: (HTMLElement)[] = [];
   for(let i=0; i < nl.length; i++) {
     // Typing says we could get Node instances; it's up to use to use this method responsibly.
     res.push(nl[i] as HTMLElement);

--- a/web/src/engine/dom-utils/src/cookieSerializer.ts
+++ b/web/src/engine/dom-utils/src/cookieSerializer.ts
@@ -24,11 +24,11 @@ export default class CookieSerializer<Type extends Record<keyof Type, DecodedCoo
    * @return      {Object}                  array of names and strings
    */
   private _loadRawCookies(): Record<string, string> {
-    let v: Record<string, string> = {};
+    const v: Record<string, string> = {};
     if(typeof(document.cookie) != 'undefined' && document.cookie != '') {
-      let c = document.cookie.split(/;\s*/);
+      const c = document.cookie.split(/;\s*/);
       for(let i = 0; i < c.length; i++) {
-        let d = c[i].split('=');
+        const d = c[i].split('=');
         if(d.length == 2) {
           v[d[0]] = d[1];
         }
@@ -45,19 +45,19 @@ export default class CookieSerializer<Type extends Record<keyof Type, DecodedCoo
    * @return      {Object}                  array of variables and values
    */
   private loadCookie(cookieName: string, decoder: FilteredRecordDecoder): Record<string, DecodedCookieFieldValue> {
-    let cookie: Record<string, DecodedCookieFieldValue> = {};
-    let allCookies = this._loadRawCookies();
+    const cookie: Record<string, DecodedCookieFieldValue> = {};
+    const allCookies = this._loadRawCookies();
     const encodedCookie = allCookies[cookieName];
 
     if(encodedCookie) {
-      let rawDecode = decodeURIComponent(encodedCookie).split(';');
+      const rawDecode = decodeURIComponent(encodedCookie).split(';');
       for(let i=0; i<rawDecode.length; i++) {
         // Prevent accidental empty-key entries caused by cookie-final ';'.
         if(i == rawDecode.length - 1 && !rawDecode[i]) {
           break;
         }
 
-        let record = rawDecode[i].split('=');
+        const record = rawDecode[i].split('=');
         if(record.length > 1) {
           const [key, value] = record;
           // key, value
@@ -79,12 +79,12 @@ export default class CookieSerializer<Type extends Record<keyof Type, DecodedCoo
    */
   private saveCookie(cookieName: string, cookieValueMap: Record<string, DecodedCookieFieldValue>, encoder: FilteredRecordEncoder) {
     let serialization='';
-    for(let key in cookieValueMap) {
+    for(const key in cookieValueMap) {
       serialization += key + '=' + encoder(cookieValueMap[key], key) + ";";
     }
 
-    let d = new Date(new Date().valueOf() + 1000 * 60 * 60 * 24 * 30).toUTCString();
-    let cookieConfig = ' path=/; expires=' + d;  //Fri, 31 Dec 2099 23:59:59 GMT;';
+    const d = new Date(new Date().valueOf() + 1000 * 60 * 60 * 24 * 30).toUTCString();
+    const cookieConfig = ' path=/; expires=' + d;  //Fri, 31 Dec 2099 23:59:59 GMT;';
     document.cookie = `${cookieName}=${encodeURIComponent(serialization)}; ${cookieConfig}`;
   }
 }

--- a/web/src/engine/dom-utils/src/getAbsolute.ts
+++ b/web/src/engine/dom-utils/src/getAbsolute.ts
@@ -6,13 +6,13 @@
  * Description  Returns x-coordinate of Pobj element absolute position with respect to page
  */
 export function getAbsoluteX(Pobj: HTMLElement): number { // I1476 - Handle SELECT overlapping END
-  var Lobj: HTMLElement
+  let Lobj: HTMLElement
 
   if(!Pobj) {
     return 0;
   }
 
-  var Lcurleft = Pobj.offsetLeft ? Pobj.offsetLeft : 0;
+  let Lcurleft = Pobj.offsetLeft ? Pobj.offsetLeft : 0;
   Lobj = Pobj;   	// I2404 - Support for IFRAMEs
 
   if (Lobj.offsetParent) {
@@ -22,7 +22,7 @@ export function getAbsoluteX(Pobj: HTMLElement): number { // I1476 - Handle SELE
     }
 
     // On mobile devices, the OSK uses 'fixed' - this requires some extra offset work to handle.
-    let Ldoc = Lobj.ownerDocument;
+    const Ldoc = Lobj.ownerDocument;
     if(Lobj.style.position == 'fixed' && Ldoc && Ldoc.scrollingElement) {
       Lcurleft += Ldoc.scrollingElement.scrollLeft;
     }
@@ -30,7 +30,7 @@ export function getAbsoluteX(Pobj: HTMLElement): number { // I1476 - Handle SELE
   // Correct position if element is within a frame (but not if the controller is in document within that frame)
   // We used to reference a KMW state variable `this.keyman._MasterDocument`, but it was only ever set to `window.document`.
   if(Lobj && Lobj.ownerDocument && (Pobj.ownerDocument != window.document)) {
-    var Ldoc=Lobj.ownerDocument;   // I2404 - Support for IFRAMEs
+    const Ldoc=Lobj.ownerDocument;   // I2404 - Support for IFRAMEs
 
     if(Ldoc && Ldoc.defaultView && Ldoc.defaultView.frameElement) {
       return Lcurleft + getAbsoluteX(<HTMLElement>Ldoc.defaultView.frameElement) - Ldoc.documentElement.scrollLeft;
@@ -47,12 +47,12 @@ export function getAbsoluteX(Pobj: HTMLElement): number { // I1476 - Handle SELE
  * Description  Returns y-coordinate of Pobj element absolute position with respect to page
  */
 export function getAbsoluteY(Pobj: HTMLElement): number {
-  var Lobj: HTMLElement
+  let Lobj: HTMLElement
 
   if(!Pobj) {
     return 0;
   }
-  var Lcurtop = Pobj.offsetTop ? Pobj.offsetTop : 0;
+  let Lcurtop = Pobj.offsetTop ? Pobj.offsetTop : 0;
   Lobj = Pobj;  // I2404 - Support for IFRAMEs
 
   if (Lobj.ownerDocument && Lobj instanceof Lobj.ownerDocument.defaultView.HTMLElement) {
@@ -62,7 +62,7 @@ export function getAbsoluteY(Pobj: HTMLElement): number {
     }
 
     // On mobile devices, the OSK uses 'fixed' - this requires some extra offset work to handle.
-    let Ldoc = Lobj.ownerDocument;
+    const Ldoc = Lobj.ownerDocument;
     if(Lobj.style.position == 'fixed' && Ldoc && Ldoc.scrollingElement) {
       Lcurtop += Ldoc.scrollingElement.scrollTop;
     }
@@ -71,7 +71,7 @@ export function getAbsoluteY(Pobj: HTMLElement): number {
   // Correct position if element is within a frame (but not if the controller is in document within that frame)
   // We used to reference a KMW state variable `this.keyman._MasterDocument`, but it was only ever set to `window.document`.
   if(Lobj && Lobj.ownerDocument && (Pobj.ownerDocument != window.document)) {
-    var Ldoc=Lobj.ownerDocument;   // I2404 - Support for IFRAMEs
+    const Ldoc=Lobj.ownerDocument;   // I2404 - Support for IFRAMEs
 
     if(Ldoc && Ldoc.defaultView && Ldoc.defaultView.frameElement) {
       return Lcurtop + getAbsoluteY(<HTMLElement>Ldoc.defaultView.frameElement);

--- a/web/src/engine/dom-utils/src/landscapeView.ts
+++ b/web/src/engine/dom-utils/src/landscapeView.ts
@@ -4,7 +4,7 @@
  * @return      {boolean}
  */
 export default function landscapeView(): boolean	{ // new for I3363 (Build 301)
-  var orientation: number;
+  let orientation: number;
 
   // Assume portrait mode if orientation undefined
   if(typeof window.orientation != 'undefined') { // Used by iOS Safari

--- a/web/src/engine/dom-utils/src/stylesheets.ts
+++ b/web/src/engine/dom-utils/src/stylesheets.ts
@@ -20,7 +20,7 @@ export class StylesheetManager {
 
   public constructor(linkNode?: Node, doCacheBusting?: boolean) {
     if(!linkNode) {
-      let _ElemHead=document.getElementsByTagName('HEAD');
+      const _ElemHead=document.getElementsByTagName('HEAD');
       if(_ElemHead.length > 0) {
         linkNode = _ElemHead[0];
       } else {
@@ -138,7 +138,7 @@ export class StylesheetManager {
     // Build the font-face definition according to the browser being used
     // The OSK will similarly remove double-quotes from font-family names and double-quote
     // the name itself. (#13018, #13022)
-    var s='@font-face {\nfont-family:"'
+    let s='@font-face {\nfont-family:"'
       + fd.family.replace(/\u0022/g, '') + '";\nfont-style:normal;\nfont-weight:normal;\n';
 
     // Build the font source string according to the browser,
@@ -191,7 +191,7 @@ export class StylesheetManager {
      */
     const fontFace = new FontFace(fd.family, source);
 
-    let loadPromise = fontFace.load();
+    const loadPromise = fontFace.load();
     const clearPromise = () => {
       this.fontPromises = this.fontPromises.filter((entry) => entry != loadPromise);
     }
@@ -248,7 +248,7 @@ export class StylesheetManager {
   }
 
   public unlinkAll() {
-    for(let tuple of this.linkedSheets) {
+    for(const tuple of this.linkedSheets) {
       const sheet = tuple.sheet;
       if(sheet.parentNode) {
         sheet.parentNode.removeChild(sheet);
@@ -268,7 +268,7 @@ export class StylesheetManager {
  * @return      {Object}                      returns the object reference
  **/
 export function createStyleSheet(styleString: string): HTMLStyleElement {
-  var _ElemStyle: HTMLStyleElement = <HTMLStyleElement>document.createElement<'style'>('style');
+  const _ElemStyle: HTMLStyleElement = <HTMLStyleElement>document.createElement<'style'>('style');
 
   _ElemStyle.type = 'text/css';
   _ElemStyle.appendChild(document.createTextNode(styleString));

--- a/web/src/engine/element-wrappers/src/contentEditable.ts
+++ b/web/src/engine/element-wrappers/src/contentEditable.ts
@@ -49,7 +49,7 @@ export default class ContentEditable extends OutputTarget<{}> {
   }
 
   hasSelection(): boolean {
-    let Lsel = this.root.ownerDocument.getSelection();
+    const Lsel = this.root.ownerDocument.getSelection();
 
     if(this.root != Lsel.anchorNode && !this.root.contains(Lsel.anchorNode)) {
       return false;
@@ -64,7 +64,7 @@ export default class ContentEditable extends OutputTarget<{}> {
 
   clearSelection(): void {
     if(this.hasSelection()) {
-      let Lsel = this.root.ownerDocument.getSelection();
+      const Lsel = this.root.ownerDocument.getSelection();
 
       if(!Lsel.isCollapsed) {
         Lsel.deleteFromDocument();  // I2134, I2192
@@ -79,15 +79,15 @@ export default class ContentEditable extends OutputTarget<{}> {
                                   */  }
 
   getCarets(): SelectionRange {
-    let Lsel = this.root.ownerDocument.getSelection();
+    const Lsel = this.root.ownerDocument.getSelection();
     let code = Lsel.anchorNode.compareDocumentPosition(Lsel.focusNode);
 
     if(Lsel.isCollapsed) {
-      let caret = new SelectionCaret(Lsel.anchorNode, Lsel.anchorOffset);
+      const caret = new SelectionCaret(Lsel.anchorNode, Lsel.anchorOffset);
       return new SelectionRange(caret, caret);
     } else {
-      let anchor = new SelectionCaret(Lsel.anchorNode, Lsel.anchorOffset);
-      let focus = new SelectionCaret(Lsel.focusNode, Lsel.focusOffset);
+      const anchor = new SelectionCaret(Lsel.anchorNode, Lsel.anchorOffset);
+      const focus = new SelectionCaret(Lsel.focusNode, Lsel.focusOffset);
 
       if(anchor.node == focus.node) {
         code = (focus.offset - anchor.offset > 0) ? 2 : 4;
@@ -111,7 +111,7 @@ export default class ContentEditable extends OutputTarget<{}> {
       return this.getText();
     }
 
-    let caret = this.getCarets().start;
+    const caret = this.getCarets().start;
 
     if(caret.node.nodeType != 3) {
       return ''; // Must be a text node to provide a context.
@@ -131,7 +131,7 @@ export default class ContentEditable extends OutputTarget<{}> {
       return '';
     }
 
-    let caret = this.getCarets().end;
+    const caret = this.getCarets().end;
 
     if(caret.node.nodeType != 3) {
       return ''; // Must be a text node to provide a context.
@@ -149,7 +149,7 @@ export default class ContentEditable extends OutputTarget<{}> {
       return;
     }
 
-    let start = this.getCarets().start;
+    const start = this.getCarets().start;
 
     // Bounds-check on the number of chars to delete.
     if(dn > start.offset) {
@@ -161,8 +161,8 @@ export default class ContentEditable extends OutputTarget<{}> {
       return; // No context to delete characters from.
     }
 
-    let range = this.root.ownerDocument.createRange();
-    let dnOffset = start.offset - start.node.nodeValue.substr(0, start.offset)._kmwSubstr(-dn).length;
+    const range = this.root.ownerDocument.createRange();
+    const dnOffset = start.offset - start.node.nodeValue.substr(0, start.offset)._kmwSubstr(-dn).length;
 
     range.setStart(start.node, dnOffset);
     range.setEnd(start.node, start.offset);
@@ -178,9 +178,9 @@ export default class ContentEditable extends OutputTarget<{}> {
       return;
     }
 
-    let start = this.getCarets().start;
-    let delta = s._kmwLength();
-    let Lsel = this.root.ownerDocument.getSelection();
+    const start = this.getCarets().start;
+    const delta = s._kmwLength();
+    const Lsel = this.root.ownerDocument.getSelection();
 
     if(delta == 0) {
       return;
@@ -193,17 +193,17 @@ export default class ContentEditable extends OutputTarget<{}> {
     // able to manage the caret properly.
     //
     // TODO:  double-check that it was only IE-motivated, re-implement with Selection.extend().
-    let finalCaret = this.root.ownerDocument.createRange();
+    const finalCaret = this.root.ownerDocument.createRange();
 
     if(start.node.nodeType == 3) {
-      let textStart = <Text> start.node;
+      const textStart = <Text> start.node;
       textStart.insertData(start.offset, s);
       finalCaret.setStart(textStart, start.offset + s.length);
     } else {
       // Create a new text node - empty control
-      var n = start.node.ownerDocument.createTextNode(s);
+      const n = start.node.ownerDocument.createTextNode(s);
 
-      let range = this.root.ownerDocument.createRange();
+      const range = this.root.ownerDocument.createRange();
       range.setStart(start.node, start.offset);
       range.collapse(true);
       range.insertNode(n);
@@ -242,8 +242,8 @@ export default class ContentEditable extends OutputTarget<{}> {
       return;
     }
 
-    let caret = this.getCarets().end;
-    let delta = s._kmwLength();
+    const caret = this.getCarets().end;
+    const delta = s._kmwLength();
 
     if(delta == 0) {
       return;
@@ -253,13 +253,13 @@ export default class ContentEditable extends OutputTarget<{}> {
     // will be handled after this method.
 
     if(caret.node.nodeType == 3) {
-      let textStart = <Text> caret.node;
+      const textStart = <Text> caret.node;
       textStart.replaceData(caret.offset, textStart.length, s);
     } else {
       // Create a new text node - empty control
-      var n = caret.node.ownerDocument.createTextNode(s);
+      const n = caret.node.ownerDocument.createTextNode(s);
 
-      let range = this.root.ownerDocument.createRange();
+      const range = this.root.ownerDocument.createRange();
       range.setStart(caret.node, caret.offset);
       range.collapse(true);
       range.insertNode(n);

--- a/web/src/engine/element-wrappers/src/designIFrame.ts
+++ b/web/src/engine/element-wrappers/src/designIFrame.ts
@@ -71,8 +71,8 @@ export default class DesignIFrame extends OutputTarget<{}> {
   }
 
   hasSelection(): boolean {
-    let Lsel = this.doc.getSelection();
-    let outerSel = document.getSelection();
+    const Lsel = this.doc.getSelection();
+    const outerSel = document.getSelection();
 
     // If the outer doc's selection matches, we're active.
     if(outerSel.anchorNode == Lsel.anchorNode && outerSel.focusNode == Lsel.focusNode) {
@@ -86,7 +86,7 @@ export default class DesignIFrame extends OutputTarget<{}> {
 
   clearSelection(): void {
     if(this.hasSelection()) {
-      let Lsel = this.doc.getSelection();
+      const Lsel = this.doc.getSelection();
 
       if(!Lsel.isCollapsed) {
         Lsel.deleteFromDocument();  // I2134, I2192
@@ -101,15 +101,15 @@ export default class DesignIFrame extends OutputTarget<{}> {
                                   */  }
 
   getCarets(): SelectionRange {
-    let Lsel = this.doc.getSelection();
+    const Lsel = this.doc.getSelection();
     let code = Lsel.anchorNode.compareDocumentPosition(Lsel.focusNode);
 
     if(Lsel.isCollapsed) {
-      let caret = new SelectionCaret(Lsel.anchorNode, Lsel.anchorOffset);
+      const caret = new SelectionCaret(Lsel.anchorNode, Lsel.anchorOffset);
       return new SelectionRange(caret, caret);
     } else {
-      let anchor = new SelectionCaret(Lsel.anchorNode, Lsel.anchorOffset);
-      let focus = new SelectionCaret(Lsel.focusNode, Lsel.focusOffset);
+      const anchor = new SelectionCaret(Lsel.anchorNode, Lsel.anchorOffset);
+      const focus = new SelectionCaret(Lsel.focusNode, Lsel.focusOffset);
 
       if(anchor.node == focus.node) {
         code = (focus.offset - anchor.offset > 0) ? 2 : 4;
@@ -133,7 +133,7 @@ export default class DesignIFrame extends OutputTarget<{}> {
       return this.getText();
     }
 
-    let caret = this.getCarets().start;
+    const caret = this.getCarets().start;
 
     if(caret.node.nodeType != 3) {
       return ''; // Must be a text node to provide a context.
@@ -153,7 +153,7 @@ export default class DesignIFrame extends OutputTarget<{}> {
       return '';
     }
 
-    let caret = this.getCarets().end;
+    const caret = this.getCarets().end;
 
     if(caret.node.nodeType != 3) {
       return ''; // Must be a text node to provide a context.
@@ -171,7 +171,7 @@ export default class DesignIFrame extends OutputTarget<{}> {
       return;
     }
 
-    let start = this.getCarets().start;
+    const start = this.getCarets().start;
 
     // Bounds-check on the number of chars to delete.
     if(dn > start.offset) {
@@ -183,8 +183,8 @@ export default class DesignIFrame extends OutputTarget<{}> {
       return; // No context to delete characters from.
     }
 
-    let range = this.doc.createRange();
-    let dnOffset = start.offset - start.node.nodeValue.substr(0, start.offset)._kmwSubstr(-dn).length;
+    const range = this.doc.createRange();
+    const dnOffset = start.offset - start.node.nodeValue.substr(0, start.offset)._kmwSubstr(-dn).length;
 
     range.setStart(start.node, dnOffset);
     range.setEnd(start.node, start.offset);
@@ -200,9 +200,9 @@ export default class DesignIFrame extends OutputTarget<{}> {
       return;
     }
 
-    let start = this.getCarets().start;
-    let delta = s._kmwLength();
-    let Lsel = this.doc.getSelection();
+    const start = this.getCarets().start;
+    const delta = s._kmwLength();
+    const Lsel = this.doc.getSelection();
 
     if(delta == 0) {
       return;
@@ -215,17 +215,17 @@ export default class DesignIFrame extends OutputTarget<{}> {
     // able to manage the caret properly.
     //
     // TODO:  double-check that it was only IE-motivated, re-implement with Selection.extend().
-    let finalCaret = this.root.ownerDocument.createRange();
+    const finalCaret = this.root.ownerDocument.createRange();
 
     if(start.node.nodeType == 3) {
-      let textStart = <Text> start.node;
+      const textStart = <Text> start.node;
       textStart.insertData(start.offset, s);
       finalCaret.setStart(textStart, start.offset + s.length);
     } else {
       // Create a new text node - empty control
-      var n = this.doc.createTextNode(s);
+      const n = this.doc.createTextNode(s);
 
-      let range = this.doc.createRange();
+      const range = this.doc.createRange();
       range.setStart(start.node, start.offset);
       range.collapse(true);
       range.insertNode(n);
@@ -264,8 +264,8 @@ export default class DesignIFrame extends OutputTarget<{}> {
       return;
     }
 
-    let caret = this.getCarets().end;
-    let delta = s._kmwLength();
+    const caret = this.getCarets().end;
+    const delta = s._kmwLength();
 
     if(delta == 0) {
       return;
@@ -275,13 +275,13 @@ export default class DesignIFrame extends OutputTarget<{}> {
     // will be handled after this method.
 
     if(caret.node.nodeType == 3) {
-      let textStart = <Text> caret.node;
+      const textStart = <Text> caret.node;
       textStart.replaceData(caret.offset, textStart.length, s);
     } else {
       // Create a new text node - empty control
-      var n = caret.node.ownerDocument.createTextNode(s);
+      const n = caret.node.ownerDocument.createTextNode(s);
 
-      let range = this.root.ownerDocument.createRange();
+      const range = this.root.ownerDocument.createRange();
       range.setStart(caret.node, caret.offset);
       range.collapse(true);
       range.insertNode(n);
@@ -295,7 +295,7 @@ export default class DesignIFrame extends OutputTarget<{}> {
    */
   saveProperties() {
     // Formerly _CacheCommands.
-    var _CacheableCommands=[
+    const _CacheableCommands=[
       new StyleCommand('backcolor',1), new StyleCommand('fontname',1), new StyleCommand('fontsize',1),
       new StyleCommand('forecolor',1), new StyleCommand('bold',0), new StyleCommand('italic',0),
       new StyleCommand('strikethrough',0), new StyleCommand('subscript',0),
@@ -306,8 +306,8 @@ export default class DesignIFrame extends OutputTarget<{}> {
       _CacheableCommands.push(new StyleCommand('hilitecolor',1));
     }
 
-    for(var n=0; n < _CacheableCommands.length; n++) { // I1511 - array prototype extended
-      let cmd = _CacheableCommands[n];
+    for(let n=0; n < _CacheableCommands.length; n++) { // I1511 - array prototype extended
+      const cmd = _CacheableCommands[n];
       //KeymanWeb._Debug('Command:'+_CacheableCommands[n][0]);
       if(cmd.stateType == 1) {
         cmd.cache = this.doc.queryCommandValue(cmd.cmd);
@@ -329,8 +329,8 @@ export default class DesignIFrame extends OutputTarget<{}> {
       console.error("No command cache exists to restore!");
     }
 
-    for(var n=0; n < this.commandCache.length; n++) { // I1511 - array prototype extended
-      let cmd = this.commandCache[n];
+    for(let n=0; n < this.commandCache.length; n++) { // I1511 - array prototype extended
+      const cmd = this.commandCache[n];
 
       //KeymanWeb._Debug('ResetCacheCommand:'+_CacheableCommands[n][0]+'='+_CacheableCommands[n][2]);
       if(cmd.stateType == 1) {

--- a/web/src/engine/element-wrappers/src/input.ts
+++ b/web/src/engine/element-wrappers/src/input.ts
@@ -106,8 +106,8 @@ export default class Input extends OutputTarget<EventMap> {
   }
 
   setSelection(start: number, end: number, direction: "forward" | "backward" | "none") {
-    let domStart = this.root.value._kmwCodePointToCodeUnit(start);
-    let domEnd = this.root.value._kmwCodePointToCodeUnit(end);
+    const domStart = this.root.value._kmwCodePointToCodeUnit(start);
+    const domEnd = this.root.value._kmwCodePointToCodeUnit(end);
     this.root.setSelectionRange(domStart, domEnd, direction);
 
     this.processedSelectionStart = start;
@@ -124,8 +124,8 @@ export default class Input extends OutputTarget<EventMap> {
     // We bypass this whenever operating in the embedded format.
     const element = this.getElement();
 
-    let selectionStart = element.selectionStart;
-    let selectionEnd = element.selectionEnd;
+    const selectionStart = element.selectionStart;
+    const selectionEnd = element.selectionEnd;
 
     this._activeForcedScroll = true;
 
@@ -162,16 +162,16 @@ export default class Input extends OutputTarget<EventMap> {
 
   setTextBeforeCaret(text: string) {
     this.getCaret();
-    let selectionLength = this.processedSelectionEnd - this.processedSelectionStart;
-    let direction = this.getSelectionDirection();
-    let newCaret = text._kmwLength();
+    const selectionLength = this.processedSelectionEnd - this.processedSelectionStart;
+    const direction = this.getSelectionDirection();
+    const newCaret = text._kmwLength();
     this.root.value = text + this.getText()._kmwSubstring(this.processedSelectionStart);
 
     this.setSelection(newCaret, newCaret + selectionLength, direction);
   }
 
   protected setTextAfterCaret(s: string) {
-    let direction = this.getSelectionDirection();
+    const direction = this.getSelectionDirection();
 
     this.root.value = this.getTextBeforeCaret() + s;
     this.setSelection(this.processedSelectionStart, this.processedSelectionEnd, direction);
@@ -188,8 +188,8 @@ export default class Input extends OutputTarget<EventMap> {
 
   deleteCharsBeforeCaret(dn: number) {
     if(dn > 0) {
-      let curText = this.getTextBeforeCaret();
-      let caret = this.processedSelectionStart;
+      const curText = this.getTextBeforeCaret();
+      const caret = this.processedSelectionStart;
 
       if(dn > caret) {
         dn = caret;
@@ -206,9 +206,9 @@ export default class Input extends OutputTarget<EventMap> {
       return;
     }
 
-    let caret = this.getCaret();
-    let front = this.getTextBeforeCaret();
-    let back = this.getText()._kmwSubstring(this.processedSelectionStart);
+    const caret = this.getCaret();
+    const front = this.getTextBeforeCaret();
+    const back = this.getText()._kmwSubstring(this.processedSelectionStart);
 
     this.adjustDeadkeys(s._kmwLength());
     this.root.value = front + s + back;

--- a/web/src/engine/element-wrappers/src/textarea.ts
+++ b/web/src/engine/element-wrappers/src/textarea.ts
@@ -81,8 +81,8 @@ export default class TextArea extends OutputTarget<{}> {
   }
 
   setSelection(start: number, end: number, direction: "forward" | "backward" | "none") {
-    let domStart = this.root.value._kmwCodePointToCodeUnit(start);
-    let domEnd = this.root.value._kmwCodePointToCodeUnit(end);
+    const domStart = this.root.value._kmwCodePointToCodeUnit(start);
+    const domEnd = this.root.value._kmwCodePointToCodeUnit(end);
     this.root.setSelectionRange(domStart, domEnd, direction);
 
     this.processedSelectionStart = start;
@@ -99,8 +99,8 @@ export default class TextArea extends OutputTarget<{}> {
     // We bypass this whenever operating in the embedded format.
     const element = this.getElement();
 
-    let selectionStart = element.selectionStart;
-    let selectionEnd = element.selectionEnd;
+    const selectionStart = element.selectionStart;
+    const selectionEnd = element.selectionEnd;
 
     this._activeForcedScroll = true;
 
@@ -132,16 +132,16 @@ export default class TextArea extends OutputTarget<{}> {
 
   setTextBeforeCaret(text: string) {
     this.getCaret();
-    let selectionLength = this.processedSelectionEnd - this.processedSelectionStart;
-    let direction = this.getSelectionDirection();
-    let newCaret = text._kmwLength();
+    const selectionLength = this.processedSelectionEnd - this.processedSelectionStart;
+    const direction = this.getSelectionDirection();
+    const newCaret = text._kmwLength();
     this.root.value = text + this.getText()._kmwSubstring(this.processedSelectionStart);
 
     this.setSelection(newCaret, newCaret + selectionLength, direction);
   }
 
   protected setTextAfterCaret(s: string) {
-    let direction = this.getSelectionDirection();
+    const direction = this.getSelectionDirection();
 
     this.root.value = this.getTextBeforeCaret() + s;
     this.setSelection(this.processedSelectionStart, this.processedSelectionEnd, direction);
@@ -163,8 +163,8 @@ export default class TextArea extends OutputTarget<{}> {
 
   deleteCharsBeforeCaret(dn: number) {
     if(dn > 0) {
-      let curText = this.getTextBeforeCaret();
-      let caret = this.processedSelectionStart;
+      const curText = this.getTextBeforeCaret();
+      const caret = this.processedSelectionStart;
 
       if(dn > caret) {
         dn = caret;
@@ -181,9 +181,9 @@ export default class TextArea extends OutputTarget<{}> {
       return;
     }
 
-    let caret = this.getCaret();
-    let front = this.getTextBeforeCaret();
-    let back = this.getText()._kmwSubstring(this.processedSelectionStart);
+    const caret = this.getCaret();
+    const front = this.getTextBeforeCaret();
+    const back = this.getText()._kmwSubstring(this.processedSelectionStart);
 
     this.adjustDeadkeys(s._kmwLength());
     this.root.value = front + s + back;

--- a/web/src/engine/element-wrappers/src/utils.ts
+++ b/web/src/engine/element-wrappers/src/utils.ts
@@ -10,7 +10,7 @@
  * @return {boolean}
  */
 export function nestedInstanceOf(Pelem: EventTarget, className: string): boolean {
-  var scopedClass;
+  let scopedClass;
 
   if(!Pelem) {
     // If we're bothering to check something's type, null references don't match

--- a/web/src/engine/element-wrappers/src/wrapElement.ts
+++ b/web/src/engine/element-wrappers/src/wrapElement.ts
@@ -13,7 +13,7 @@ export default function wrapElement(e: HTMLElement): OutputTarget<any> {
   } else if(nestedInstanceOf(e, "HTMLTextAreaElement")) {
     return new TextArea(<HTMLTextAreaElement> e);
   } else if(nestedInstanceOf(e, "HTMLIFrameElement")) {
-    let iframe = <HTMLIFrameElement> e;
+    const iframe = <HTMLIFrameElement> e;
 
     if(iframe.contentWindow && iframe.contentWindow.document && iframe.contentWindow.document.designMode == "on") {
       return new DesignIFrame(iframe);

--- a/web/src/engine/events/src/domEventTracker.ts
+++ b/web/src/engine/events/src/domEventTracker.ts
@@ -61,7 +61,7 @@ export class DomEventTracker {
     Pelem.addEventListener(Peventname, Phandler, PuseCapture ? true : false);
 
     // Since we're attaching to the DOM, these events should be tracked for detachment during shutdown.
-    var event = new DomEventTracking(Pelem, Peventname, Phandler, PuseCapture);
+    const event = new DomEventTracking(Pelem, Peventname, Phandler, PuseCapture);
     this.domEvents.push(event);
   }
 
@@ -96,8 +96,8 @@ export class DomEventTracker {
     Pelem.removeEventListener(Peventname, Phandler, PuseCapture);
 
     // Since we're detaching, we should drop the tracking data from the old event.
-    var event = new DomEventTracking(Pelem, Peventname, Phandler, PuseCapture);
-    for(var i = 0; i < this.domEvents.length; i++) {
+    const event = new DomEventTracking(Pelem, Peventname, Phandler, PuseCapture);
+    for(let i = 0; i < this.domEvents.length; i++) {
       if(this.domEvents[i].equals(event)) {
         this.domEvents.splice(i, 1);
         break;
@@ -109,7 +109,7 @@ export class DomEventTracker {
     // Remove all events linking to elements of the original, unaltered page.
     // This should sever any still-existing page ties to this instance of KMW,
     // allowing browser GC to do its thing.
-    for(let event of this.domEvents) {
+    for(const event of this.domEvents) {
       // @ts-ignore // since it's simpler this way and doesn't earn us much to re-check types.
       this.detachDOMEvent(event.Pelem, event.Peventname, event.Phandler, event.PuseCapture);
     }

--- a/web/src/engine/events/src/legacyEventEmitter.ts
+++ b/web/src/engine/events/src/legacyEventEmitter.ts
@@ -107,7 +107,7 @@ export class LegacyEventEmitter<EventTypes extends LegacyEventMap> {
       this.events[event] = [];
     }
 
-    for(var i=0; i<this.events[event].length; i++) {
+    for(let i=0; i<this.events[event].length; i++) {
       if(this.events[event][i] == func) {
         this.events[event].splice(i, 1);
         return true;
@@ -138,8 +138,9 @@ export class LegacyEventEmitter<EventTypes extends LegacyEventMap> {
 
     this.currentEvents.push(event);
 
-    for(var i=0; i<this.events[event].length; i++) {
-      var func=this.events[event][i] as EventListener<EventTypes, T>, result=false;
+    for(let i=0; i<this.events[event].length; i++) {
+      const func=this.events[event][i] as EventListener<EventTypes, T>;
+      let result=false;
       try {
         result=func(params as any);
       } catch(strExcept) {

--- a/web/src/engine/interfaces/src/prediction/predictionContext.ts
+++ b/web/src/engine/interfaces/src/prediction/predictionContext.ts
@@ -82,7 +82,7 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
 
     this.suggestionReverter = async (reversion) => {
       if(validSuggestionState()) {
-        let suggestions = await langProcessor.applyReversion(reversion, this.currentTarget);
+        const suggestions = await langProcessor.applyReversion(reversion, this.currentTarget);
         // We want to avoid altering flags that indicate our post-reversion state.
         this.swallowPrediction = true;
         this.updateSuggestions(new ReadySuggestions(suggestions, reversion.id ? -reversion.id : undefined));
@@ -110,7 +110,7 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
   }
 
   public get currentSuggestions(): Suggestion[] {
-    let suggestions: Suggestion[] = [];
+    const suggestions: Suggestion[] = [];
     // Insert 'current text' if/when valid as the leading option.
     // Since we don't yet do auto-corrections, we only show 'keep' whenever it's
     // a valid word (according to the model).
@@ -161,7 +161,7 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
    * @returns if `suggestion` is a `Suggestion`, will return a `Promise<Reversion>`; else, `null`.
    */
   public accept(suggestion: Suggestion): Promise<Reversion> | Promise<null> {
-    let _this = this;
+    const _this = this;
 
     // Selecting a suggestion or a reversion should both clear selection
     // and clear the reversion-displaying state of the banner.
@@ -311,7 +311,7 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
    * Description    Update the displayed suggestions in the SuggestionBanner
    */
   private updateSuggestions = (prediction: ReadySuggestions): void => {
-    let suggestions = prediction.suggestions;
+    const suggestions = prediction.suggestions;
 
     this._currentSuggestions = suggestions;
     this.selected = null;
@@ -319,7 +319,7 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
     // Do we have a keep suggestion?  If so, remove it from the list so that we can control its display position
     // and prevent it from being hidden after reversion operations.
     this.keepSuggestion = null;
-    for (let s of suggestions) {
+    for (const s of suggestions) {
       if(s.tag == 'keep') {
         this.keepSuggestion = s as Keep;
       }

--- a/web/src/engine/js-processor/src/deadkeys.ts
+++ b/web/src/engine/js-processor/src/deadkeys.ts
@@ -14,7 +14,7 @@ export class Deadkey {
   }
 
   match(p: number, d: number): boolean {
-    var result:boolean = (this.p == p && this.d == d);
+    const result:boolean = (this.p == p && this.d == d);
 
     return result;
   }
@@ -32,7 +32,7 @@ export class Deadkey {
   }
 
   clone(): Deadkey {
-    let dk = new Deadkey(this.p, this.d);
+    const dk = new Deadkey(this.p, this.d);
     dk.o = this.o;
 
     return dk;
@@ -65,8 +65,8 @@ export class DeadkeyTracker {
   }
 
   clone(): DeadkeyTracker {
-    let dkt = new DeadkeyTracker();
-    let dks = this.toSortedArray();
+    const dkt = new DeadkeyTracker();
+    const dks = this.toSortedArray();
 
     // Make sure to clone the deadkeys themselves - the Deadkey object is mutable.
     dkt.dks = [];
@@ -91,9 +91,9 @@ export class DeadkeyTracker {
       return false; // I3318
     }
 
-    var sp=caretPos;
+    const sp=caretPos;
     n = sp - n;
-    for(var i = 0; i < this.dks.length; i++) {
+    for(let i = 0; i < this.dks.length; i++) {
       // Don't re-match an already-matched deadkey.  It's possible to have two identical
       // entries, and they should be kept separately.
       if(this.dks[i].match(n, d) && !this.dks[i].matched) {
@@ -114,7 +114,7 @@ export class DeadkeyTracker {
   }
 
   remove(dk: Deadkey) {
-    var index = this.dks.indexOf(dk);
+    const index = this.dks.indexOf(dk);
     this.dks.splice(index, 1);
   }
 
@@ -123,13 +123,13 @@ export class DeadkeyTracker {
   }
 
   resetMatched() {
-    for(let dk of this.dks) {
+    for(const dk of this.dks) {
       dk.reset();
     }
   }
 
   deleteMatched(): void {
-    for(var Li = 0; Li < this.dks.length; Li++) {
+    for(let Li = 0; Li < this.dks.length; Li++) {
       if(this.dks[Li].matched) {
         this.dks.splice(Li--, 1); // Don't forget to decrement!
       }
@@ -148,7 +148,7 @@ export class DeadkeyTracker {
       return;
     }
 
-    for(let dk of this.dks) {
+    for(const dk of this.dks) {
       if(dk.p > Lstart) {
         dk.p += Ldelta;
       }
@@ -163,7 +163,7 @@ export class DeadkeyTracker {
     const otherDks = other.dks;
     const matchedDks: Deadkey[] = [];
 
-    for(let dk of this.dks) {
+    for(const dk of this.dks) {
       const match = otherDks.find((otherDk) => dk.equal(otherDk));
       if(!match) {
         return false;

--- a/web/src/engine/js-processor/src/kbdInterface.ts
+++ b/web/src/engine/js-processor/src/kbdInterface.ts
@@ -157,7 +157,7 @@ class CachedContextEx {
   }
 
   clone(): CachedContextEx {
-    let r = new CachedContextEx();
+    const r = new CachedContextEx();
     r._cache = this._cache;
     return r;
   }
@@ -231,7 +231,7 @@ export default class KeyboardInterface extends KeyboardHarness {
   registerKeyboard(Pk: any): void {
     // NOTE:  This implementation is web-core specific and is intentionally replaced, whole-sale,
     //        by DOM-aware code.
-    let keyboard = new Keyboard(Pk);
+    const keyboard = new Keyboard(Pk);
     this.loadedKeyboard = keyboard;
   }
 
@@ -250,12 +250,12 @@ export default class KeyboardInterface extends KeyboardHarness {
    */
 
   context(n: number, ln: number, outputTarget: OutputTarget): string {
-    var v = this.cachedContext.get(n, ln);
+    const v = this.cachedContext.get(n, ln);
     if(v !== null) {
       return v;
     }
 
-    var r = this.KC_(n, ln, outputTarget);
+    const r = this.KC_(n, ln, outputTarget);
     this.cachedContext.set(n, ln, r);
     return r;
   }
@@ -274,7 +274,7 @@ export default class KeyboardInterface extends KeyboardHarness {
    *             KC(10,10,Pelem) == "XXXXabcdef"  i.e. return as much as possible of the requested string, where X = \uFFFE
    */
   private KC_(n: number, ln: number, outputTarget: OutputTarget): string {
-    var tempContext = '';
+    let tempContext = '';
 
     // If we have a selection, we have an empty context
     tempContext = outputTarget.isSelectionEmpty() ? outputTarget.getTextBeforeCaret() : "";
@@ -300,7 +300,7 @@ export default class KeyboardInterface extends KeyboardHarness {
    *             KN(4,Pelem) == TRUE
    */
   nul(n: number, outputTarget: OutputTarget): boolean {
-    var cx=this.context(n+1, 1, outputTarget);
+    const cx=this.context(n+1, 1, outputTarget);
 
     // With #31, the result will be a replacement character if context is empty.
     return cx === "\uFFFE";
@@ -317,7 +317,7 @@ export default class KeyboardInterface extends KeyboardHarness {
    * Description  Test keyboard context for match
    */
   contextMatch(n: number, outputTarget: OutputTarget, val: string, ln: number): boolean {
-    var cx=this.context(n, ln, outputTarget);
+    const cx=this.context(n, ln, outputTarget);
     if(cx === val) {
       return true; // I3318
     }
@@ -334,7 +334,7 @@ export default class KeyboardInterface extends KeyboardHarness {
    * @return      {Array}               Context array (of strings and numbers)
    */
   private _BuildExtendedContext(n: number, ln: number, outputTarget: OutputTarget): CachedExEntry {
-    var cache: CachedExEntry = this.cachedContextEx.get(n, ln);
+    let cache: CachedExEntry = this.cachedContextEx.get(n, ln);
     if(cache !== null) {
       return cache;
     } else {
@@ -343,15 +343,15 @@ export default class KeyboardInterface extends KeyboardHarness {
       cache = this.cachedContextEx.get(n, n);
       if(cache === null) {
         // First, let's make sure we have a cloned, sorted copy of the deadkey array.
-        let unmatchedDeadkeys = outputTarget.deadkeys().toSortedArray(); // Is reverse-order sorted for us already.
+        const unmatchedDeadkeys = outputTarget.deadkeys().toSortedArray(); // Is reverse-order sorted for us already.
 
         // Time to build from scratch!
-        var index = 0;
+        let index = 0;
         cache = { valContext: [], deadContext: []};
         while(cache.valContext.length < n) {
           // As adapted from `deadkeyMatch`.
-          var sp = outputTarget.getDeadkeyCaret();
-          var deadPos = sp - index;
+          const sp = outputTarget.getDeadkeyCaret();
+          const deadPos = sp - index;
           if(unmatchedDeadkeys.length > 0 && unmatchedDeadkeys[0].p > deadPos) {
             // We have deadkeys at the right-hand side of the caret!  They don't belong in the context, so pop 'em off.
             unmatchedDeadkeys.splice(0, 1);
@@ -363,7 +363,7 @@ export default class KeyboardInterface extends KeyboardHarness {
             unmatchedDeadkeys.splice(0, 1);
           } else {
             // Take the character.  We get "\ufffe" if it doesn't exist.
-            var kc = this.context(++index, 1, outputTarget);
+            const kc = this.context(++index, 1, outputTarget);
             cache.valContext = ([kc] as (string|number)[]).concat(cache.valContext);
           }
         }
@@ -371,7 +371,7 @@ export default class KeyboardInterface extends KeyboardHarness {
       }
 
       // Now that we have the cache...
-      var subCache = cache;
+      const subCache = cache;
       subCache.valContext = subCache.valContext.slice(0, ln);
       this.cachedContextEx.set(n, ln, subCache);
 
@@ -392,32 +392,32 @@ export default class KeyboardInterface extends KeyboardHarness {
    */
   fullContextMatch(n: number, outputTarget: OutputTarget, rule: ContextEntry[]): boolean {
     // Stage one:  build the context index map.
-    var fullContext = this._BuildExtendedContext(n, rule.length, outputTarget);
+    const fullContext = this._BuildExtendedContext(n, rule.length, outputTarget);
     this.ruleContextEx = this.cachedContextEx.clone();
-    var context = fullContext.valContext;
-    var deadContext = fullContext.deadContext;
+    const context = fullContext.valContext;
+    const deadContext = fullContext.deadContext;
 
-    var mismatch = false;
+    let mismatch = false;
 
     // This symbol internally indicates lack of context in a position.  (See KC_)
     const NUL_CONTEXT = "\uFFFE";
 
-    var assertNever = function(x: never): never {
+    const assertNever = function(x: never): never {
       // Could be accessed by improperly handwritten calls to `fullContextMatch`.
       throw new Error("Unexpected object in fullContextMatch specification: " + x);
     }
 
     // Stage two:  time to match against the rule specified.
-    for(var i=0; i < rule.length; i++) {
+    for(let i=0; i < rule.length; i++) {
       if(typeof rule[i] == 'string') {
-        var str = rule[i] as string;
+        const str = rule[i] as string;
         if(str !== context[i]) {
           mismatch = true;
           break;
         }
       } else {
         // TypeScript needs a cast to this intermediate type to do its discriminated union magic.
-        var r = rule[i] as ContextNonCharEntry;
+        const r = rule[i] as ContextNonCharEntry;
         switch(r.t) {
           case 'd':
             // We still need to set a flag here;
@@ -428,7 +428,7 @@ export default class KeyboardInterface extends KeyboardHarness {
             }
             break;
           case 'a':
-            var lookup: KeyboardStoreElement;
+            let lookup: KeyboardStoreElement;
 
             if(typeof context[i] == 'string') {
               lookup = context[i] as string;
@@ -436,7 +436,7 @@ export default class KeyboardInterface extends KeyboardHarness {
               lookup = {'t': 'd', 'd': context[i] as number};
             }
 
-            var result = this.any(i, lookup, r.a);
+            const result = this.any(i, lookup, r.a);
 
             if(!r.n) { // If it's a standard 'any'...
               if(!result) {
@@ -454,7 +454,7 @@ export default class KeyboardInterface extends KeyboardHarness {
             break;
           case 'i':
             // The context will never hold a 'beep.'
-            var ch = this._Index(r.i, r.o) as string | RuleDeadkey;
+            const ch = this._Index(r.i, r.o) as string | RuleDeadkey;
 
             if(ch !== undefined && (typeof(ch) == 'string' ? ch : ch.d) !== context[i]) {
               mismatch = true;
@@ -552,12 +552,12 @@ export default class KeyboardInterface extends KeyboardHarness {
    * Description  Test keystroke with modifiers against rule
    */
   keyMatch(e: KeyEvent, Lruleshift:number, Lrulekey:number): boolean {
-    var retVal = false; // I3318
-    var keyCode = (e.Lcode == 173 ? 189 : e.Lcode);  //I3555 (Firefox hyphen issue)
+    let retVal = false; // I3318
+    let keyCode = (e.Lcode == 173 ? 189 : e.Lcode);  //I3555 (Firefox hyphen issue)
 
-    let bitmask = this.activeKeyboard.modifierBitmask;
-    var modifierBitmask = bitmask & Codes.modifierBitmasks["ALL"];
-    var stateBitmask = bitmask & Codes.stateBitmasks["ALL"];
+    const bitmask = this.activeKeyboard.modifierBitmask;
+    const modifierBitmask = bitmask & Codes.modifierBitmasks["ALL"];
+    const stateBitmask = bitmask & Codes.stateBitmasks["ALL"];
 
     const eventModifiers = KeyboardInterface.matchModifiersToRuleChirality(e.Lmodifiers, Lruleshift);
 
@@ -598,7 +598,7 @@ export default class KeyboardInterface extends KeyboardHarness {
    * Description  Get object with extended key event information
    */
   keyInformation(e: KeyEvent): KeyInformation {
-    var ei = new KeyInformation();
+    const ei = new KeyInformation();
     ei['vk'] = e.LisVirtualKey;
     ei['code'] = e.Lcode;
     ei['modifiers'] = e.Lmodifiers;
@@ -633,7 +633,7 @@ export default class KeyboardInterface extends KeyboardHarness {
 
   _ExplodeStore(store: KeyboardStore): ComplexKeyboardStore {
     if(typeof(store) == 'string') {
-      let cachedStores = this.activeKeyboard.explodedStores;
+      const cachedStores = this.activeKeyboard.explodedStores;
 
       // Is the result cached?
       if(cachedStores[store]) {
@@ -641,8 +641,8 @@ export default class KeyboardInterface extends KeyboardHarness {
       }
 
       // Nope, so let's build its cache.
-      var result: ComplexKeyboardStore = [];
-      for(var i=0; i < store._kmwLength(); i++) {
+      const result: ComplexKeyboardStore = [];
+      for(let i=0; i < store._kmwLength(); i++) {
         result.push(store._kmwCharAt(i));
       }
 
@@ -669,8 +669,8 @@ export default class KeyboardInterface extends KeyboardHarness {
     }
 
     s = this._ExplodeStore(s);
-    var Lix = -1;
-    for(var i=0; i < s.length; i++) {
+    let Lix = -1;
+    for(let i=0; i < s.length; i++) {
       const entry = s[i];
       if(typeof(entry) == 'string') {
         if(s[i] == ch) {
@@ -720,12 +720,12 @@ export default class KeyboardInterface extends KeyboardHarness {
   indexOutput(Pdn: number, Ps: KeyboardStore, Pn: number, outputTarget: OutputTarget): void {
     this.resetContextCache();
 
-    var assertNever = function(x: never): never {
+    const assertNever = function(x: never): never {
       // Could be accessed by improperly handwritten calls to `fullContextMatch`.
       throw new Error("Unexpected object in fullContextMatch specification: " + x);
     }
 
-    var indexChar = this._Index(Ps, Pn);
+    const indexChar = this._Index(Ps, Pn);
     if(indexChar !== "") {
       if(typeof indexChar == 'string' ) {
         this.output(Pdn, outputTarget, indexChar);  //I3319
@@ -756,15 +756,15 @@ export default class KeyboardInterface extends KeyboardHarness {
    * Description  Keyboard output
    */
   deleteContext(dn: number, outputTarget: OutputTarget): void {
-    var context: CachedExEntry;
+    let context: CachedExEntry;
 
     // We want to control exactly which deadkeys get removed.
     if(dn > 0) {
       context = this._BuildExtendedContext(dn, dn, outputTarget);
       let nulCount = 0;
 
-      for(var i=0; i < context.valContext.length; i++) {
-        var dk = context.deadContext[i];
+      for(let i=0; i < context.valContext.length; i++) {
+        const dk = context.deadContext[i];
 
         if(dk) {
           // Remove deadkey in context.
@@ -780,7 +780,7 @@ export default class KeyboardInterface extends KeyboardHarness {
 
       // Prevent attempts to delete nul sentinels, as they don't exist in the actual context.
       // (Addresses regression from KMW v 12.0 paired with Developer bug through same version)
-      let contextLength = context.valContext.length - nulCount;
+      const contextLength = context.valContext.length - nulCount;
       if(dn > contextLength) {
         dn = contextLength;
       }
@@ -874,8 +874,8 @@ export default class KeyboardInterface extends KeyboardHarness {
    * @return      {boolean}                 True if the test succeeds
    */
   ifStore(systemId: number, strValue: string, outputTarget: OutputTarget): boolean {
-    var result=true;
-    let store = this.systemStores[systemId];
+    let result=true;
+    const store = this.systemStores[systemId];
     if(store) {
       result = store.matches(strValue);
     }
@@ -919,7 +919,7 @@ export default class KeyboardInterface extends KeyboardHarness {
   loadStore(kbdName: string, storeName:string, dfltValue:string): string {
     this.resetContextCache();
     if(this.variableStoreSerializer) {
-      let cValue = this.variableStoreSerializer.loadStore(kbdName, storeName);
+      const cValue = this.variableStoreSerializer.loadStore(kbdName, storeName);
       return cValue[storeName] || dfltValue;
     } else {
       return dfltValue;
@@ -939,13 +939,13 @@ export default class KeyboardInterface extends KeyboardHarness {
    */
   saveStore(storeName:string, optValue:string): boolean {
     this.resetContextCache();
-    var kbd=this.activeKeyboard;
+    const kbd=this.activeKeyboard;
     if(!kbd || typeof kbd.id == 'undefined' || kbd.id == '') {
       return false;
     }
 
     // And the lookup under that entry looks for the value under the store name, again.
-    let valueObj: VariableStore = {};
+    const valueObj: VariableStore = {};
     valueObj[storeName] = optValue;
 
     // Null-check in case of invocation during unit-test
@@ -1035,7 +1035,7 @@ export default class KeyboardInterface extends KeyboardHarness {
     this.resetContextCache();
 
     // Capture the initial state of the OutputTarget before any rules are matched.
-    let preInput = Mock.from(outputTarget, true);
+    const preInput = Mock.from(outputTarget, true);
 
     // Capture the initial state of any variable stores
     const cachedVariableStores = this.activeKeyboard.variableStores;
@@ -1049,7 +1049,7 @@ export default class KeyboardInterface extends KeyboardHarness {
 
     // Calls the start-group of the active keyboard.
     this.activeTargetOutput = outputTarget;
-    var matched = callee(outputTarget, keystroke);
+    const matched = callee(outputTarget, keystroke);
     this.activeTargetOutput = null;
 
     // Finalize the rule's results.
@@ -1069,7 +1069,7 @@ export default class KeyboardInterface extends KeyboardHarness {
     this.ruleBehavior.triggerKeyDefault = !matched;
 
     // Clear our result-tracking variable to prevent any possible pollution for future processing.
-    let behavior = this.ruleBehavior;
+    const behavior = this.ruleBehavior;
     this.ruleBehavior = null;
 
     return behavior;
@@ -1098,9 +1098,9 @@ export default class KeyboardInterface extends KeyboardHarness {
    */
   static __publishShorthandAPI() {
     // Keyboard callbacks
-    let prototype = this.prototype;
+    const prototype = this.prototype;
 
-    var exportKBCallback = function(miniName: string, longName: keyof KeyboardInterface) {
+    const exportKBCallback = function(miniName: string, longName: keyof KeyboardInterface) {
       if(prototype[longName]) {
         // @ts-ignore
         prototype[miniName] = prototype[longName];

--- a/web/src/engine/js-processor/src/keyboardProcessor.ts
+++ b/web/src/engine/js-processor/src/keyboardProcessor.ts
@@ -129,12 +129,12 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
    * @return  {string}
    */
   defaultRuleBehavior(Lkc: KeyEvent, outputTarget: OutputTarget, readonly: boolean): RuleBehavior {
-    let preInput = Mock.from(outputTarget, readonly);
-    let ruleBehavior = new RuleBehavior();
+    const preInput = Mock.from(outputTarget, readonly);
+    const ruleBehavior = new RuleBehavior();
 
     let matched = false;
-    var char = '';
-    var special: EmulationKeystrokes;
+    let char = '';
+    let special: EmulationKeystrokes;
     if(Lkc.isSynthetic || outputTarget.isSynthetic) {
       matched = true;  // All the conditions below result in matches until the final else, which restores the expected default
                         // if no match occurs.
@@ -166,7 +166,7 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
       }
     }
 
-    let isMnemonic = this.activeKeyboard && this.activeKeyboard.isMnemonic;
+    const isMnemonic = this.activeKeyboard && this.activeKeyboard.isMnemonic;
 
     if(!matched) {
       if((char = this.defaultRules.forAny(Lkc, isMnemonic, ruleBehavior)) != null) {
@@ -192,7 +192,7 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
       return ruleBehavior;
     }
 
-    let transcription = outputTarget.buildTranscriptionFrom(preInput, Lkc, readonly);
+    const transcription = outputTarget.buildTranscriptionFrom(preInput, Lkc, readonly);
     ruleBehavior.transcription = transcription;
 
     return ruleBehavior;
@@ -211,7 +211,7 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
   }
 
   processKeystroke(keyEvent: KeyEvent, outputTarget: OutputTarget): RuleBehavior {
-    var matchBehavior: RuleBehavior;
+    let matchBehavior: RuleBehavior;
 
     // Before keyboard rules apply, check if the left-context is empty.
     const nothingDeletable = outputTarget.getTextBeforeCaret().kmwLength() == 0 && outputTarget.isSelectionEmpty();
@@ -244,7 +244,7 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
 
       // Match against the 'default keyboard' - rules to mimic the default string output when typing in a browser.
       // Many keyboards rely upon these 'implied rules'.
-      let defaultBehavior = this.defaultRuleBehavior(keyEvent, outputTarget, false);
+      const defaultBehavior = this.defaultRuleBehavior(keyEvent, outputTarget, false);
       if(defaultBehavior) {
         if(!matchBehavior) {
           matchBehavior = defaultBehavior;
@@ -355,9 +355,9 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
    *  @return {boolean}                               return true if keyboard layer changed
    */
   selectLayer(keyEvent: KeyEvent): boolean {
-    let keyName = keyEvent.kName;
-    var nextLayer = keyEvent.kNextLayer;
-    var isChiral = this.activeKeyboard && this.activeKeyboard.isChiral;
+    const keyName = keyEvent.kName;
+    let nextLayer = keyEvent.kNextLayer;
+    const isChiral = this.activeKeyboard && this.activeKeyboard.isChiral;
 
     // Layer must be identified by name, not number (27/08/2015)
     if(typeof nextLayer == 'number') {
@@ -438,20 +438,20 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
    * @param       {string}      id      layer id (e.g. ctrlshift)
    */
   updateLayer(keyEvent: KeyEvent, id: string) {
-    let activeLayer = this.layerId;
-    var s = activeLayer;
+    const activeLayer = this.layerId;
+    let s = activeLayer;
 
     // Do not change layer unless needed (27/08/2015)
     if(id == activeLayer && keyEvent.device.formFactor != DeviceSpec.FormFactor.Desktop) {
       return;
     }
 
-    var idx=id;
-    var i;
+    let idx=id;
+    let i;
 
     if(keyEvent.device.formFactor == DeviceSpec.FormFactor.Desktop) {
       // Need to test if target layer is a standard layer (based on the plain 'default')
-      var replacements= ['leftctrl', 'rightctrl', 'ctrl', 'leftalt', 'rightalt', 'alt', 'shift'];
+      const replacements= ['leftctrl', 'rightctrl', 'ctrl', 'leftalt', 'rightalt', 'alt', 'shift'];
 
       for(i=0; i < replacements.length; i++) {
         // Don't forget to remove the kebab-case hyphens!
@@ -471,7 +471,7 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
       // if(idx == '') with accompanying if-else structural shift would be a far better test here.
       else {
         // Save our current modifier state.
-        var modifier=Codes.getModifierState(s);
+        let modifier=Codes.getModifierState(s);
 
         // Strip down to the base modifiable layer.
         for(i=0; i < replacements.length; i++) {
@@ -526,14 +526,14 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
       s = id;
     }
 
-    let layout = this.activeKeyboard.layout(keyEvent.device.formFactor);
+    const layout = this.activeKeyboard.layout(keyEvent.device.formFactor);
     if(layout.getLayer(s)) {
       this.layerId = s;
     } else {
       this.layerId = 'default';
     }
 
-    let baseModifierState = Codes.getModifierState(this.layerId);
+    const baseModifierState = Codes.getModifierState(this.layerId);
     this.modStateFlags = baseModifierState | keyEvent.Lstates;
   }
 
@@ -603,7 +603,7 @@ export default class KeyboardProcessor extends EventEmitter<EventMap> {
 
   setNumericLayer(device: DeviceSpec) {
     if (this.activeKeyboard) {
-      let layout = this.activeKeyboard.layout(device.formFactor);
+      const layout = this.activeKeyboard.layout(device.formFactor);
       if(layout.getLayer('numeric')) {
         this.layerId = 'numeric';
       }

--- a/web/src/engine/js-processor/src/mock.ts
+++ b/web/src/engine/js-processor/src/mock.ts
@@ -13,7 +13,7 @@ export class Mock extends OutputTarget {
     super();
 
     this.text = text ? text : "";
-    var defaultLength = this.text._kmwLength();
+    const defaultLength = this.text._kmwLength();
 
     // Ensures that `caretPos == 0` is handled correctly.
     this.selStart = typeof selStart == "number" ? selStart : defaultLength;
@@ -31,7 +31,7 @@ export class Mock extends OutputTarget {
     if (outputTarget instanceof Mock) {
       // Avoids the need to run expensive kmwstring.ts / `_kmwLength()`
       // calculations when deep-copying Mock instances.
-      let priorMock = outputTarget as Mock;
+      const priorMock = outputTarget as Mock;
       clone = new Mock(priorMock.text, priorMock.selStart, priorMock.selEnd);
     } else {
       const text = outputTarget.getText();
@@ -42,8 +42,8 @@ export class Mock extends OutputTarget {
       let selectionEnd: number = 0;
 
       if (outputTarget.hasSelection()) {
-        let beforeText = outputTarget.getTextBeforeCaret();
-        let afterText = outputTarget.getTextAfterCaret();
+        const beforeText = outputTarget.getTextBeforeCaret();
+        const afterText = outputTarget.getTextAfterCaret();
         selectionStart = beforeText._kmwLength();
         selectionEnd = textLen - afterText._kmwLength();
       }
@@ -88,7 +88,7 @@ export class Mock extends OutputTarget {
 
     this.selForward = end >= start;
     if (!this.selForward) {
-      let temp = this.selStart;
+      const temp = this.selStart;
       this.selStart = this.selEnd;
       this.selEnd = temp;
     }

--- a/web/src/engine/js-processor/src/outputTarget.ts
+++ b/web/src/engine/js-processor/src/outputTarget.ts
@@ -46,7 +46,7 @@ export class Transcription {
   private static tokenSeed: number = 0;
 
   constructor(keystroke: KeyEvent, transform: TextTransform, preInput: Mock, alternates?: Alternate[]/*, removedDks: Deadkey[], insertedDks: Deadkey[]*/) {
-    let token = this.token = Transcription.tokenSeed++;
+    const token = this.token = Transcription.tokenSeed++;
 
     this.keystroke = keystroke;
     this.transform = transform;
@@ -94,7 +94,7 @@ export default abstract class OutputTarget implements OutputTargetInterface {
   }
 
   insertDeadkeyBeforeCaret(d: number) {
-    var dk: Deadkey = new Deadkey(this.getDeadkeyCaret(), d);
+    const dk: Deadkey = new Deadkey(this.getDeadkeyCaret(), d);
     this.deadkeys().add(dk);
   }
 
@@ -146,7 +146,7 @@ export default abstract class OutputTarget implements OutputTargetInterface {
   }
 
   buildTranscriptionFrom(original: OutputTarget, keyEvent: KeyEvent, readonly: boolean, alternates?: Alternate[]): Transcription {
-    let transform = this.buildTransformFrom(original);
+    const transform = this.buildTransformFrom(original);
 
     // If we ever decide to re-add deadkey tracking, this is the place for it.
 

--- a/web/src/engine/js-processor/src/ruleBehavior.ts
+++ b/web/src/engine/js-processor/src/ruleBehavior.ts
@@ -74,8 +74,8 @@ export default class RuleBehavior {
       processor.beepHandler(outputTarget);
     }
 
-    for(let storeID in this.setStore) {
-      let sysStore = processor.keyboardInterface.systemStores[storeID];
+    for(const storeID in this.setStore) {
+      const sysStore = processor.keyboardInterface.systemStores[storeID];
       if(sysStore) {
         try {
           sysStore.set(this.setStore[storeID]);
@@ -92,13 +92,13 @@ export default class RuleBehavior {
     processor.keyboardInterface.applyVariableStores(this.variableStores);
 
     if(processor.keyboardInterface.variableStoreSerializer) {
-      for(let storeID in this.saveStore) {
+      for(const storeID in this.saveStore) {
         processor.keyboardInterface.variableStoreSerializer.saveStore(processor.activeKeyboard.id, storeID, this.saveStore[storeID]);
       }
     }
 
     if(this.triggersDefaultCommand) {
-      let keyEvent = this.transcription.keystroke;
+      const keyEvent = this.transcription.keystroke;
       processor.defaultRules.applyCommand(keyEvent, outputTarget);
     }
 
@@ -121,15 +121,15 @@ export default class RuleBehavior {
    * @param other
    */
   mergeInDefaults(other: RuleBehavior) {
-    let keystroke = this.transcription.keystroke;
-    let keyFromOther = other.transcription.keystroke;
+    const keystroke = this.transcription.keystroke;
+    const keyFromOther = other.transcription.keystroke;
     if(keystroke.Lcode != keyFromOther.Lcode || keystroke.Lmodifiers != keyFromOther.Lmodifiers) {
       throw "RuleBehavior default-merge not supported unless keystrokes are identical!";
     }
 
     this.triggersDefaultCommand = this.triggersDefaultCommand || other.triggersDefaultCommand;
 
-    let mergingMock = Mock.from(this.transcription.preInput, false);
+    const mergingMock = Mock.from(this.transcription.preInput, false);
     mergingMock.apply(this.transcription.transform);
     mergingMock.apply(other.transcription.transform);
 

--- a/web/src/engine/js-processor/src/systemStores.ts
+++ b/web/src/engine/js-processor/src/systemStores.ts
@@ -96,11 +96,11 @@ export class PlatformSystemStore extends SystemStore {
   }
 
   matches(value: string) {
-    var i,constraint,constraints=value.split(' ');
-    let device = this.kbdInterface.activeDevice;
+    const constraints=value.split(' ');
+    const device = this.kbdInterface.activeDevice;
 
-    for(i=0; i<constraints.length; i++) {
-      constraint=constraints[i].toLowerCase();
+    for(let i=0; i<constraints.length; i++) {
+      let constraint=constraints[i].toLowerCase();
       switch(constraint) {
         case 'touch':
         case 'hardware':

--- a/web/src/engine/keyboard-storage/src/cloud/queryEngine.ts
+++ b/web/src/engine/keyboard-storage/src/cloud/queryEngine.ts
@@ -113,7 +113,7 @@ export default class CloudQueryEngine extends EventEmitter<EventMap> {
 
     const query = URL + queryConfig + cmd;
 
-    let { promise, queryId } = this.requestEngine.request<KeyboardStub[] | LanguageAPIPropertySpec[]>(query);
+    const { promise, queryId } = this.requestEngine.request<KeyboardStub[] | LanguageAPIPropertySpec[]>(query);
     this.cloudResolutionPromises.set(queryId, promise);
 
     promise.finally(() => {
@@ -187,9 +187,9 @@ export default class CloudQueryEngine extends EventEmitter<EventMap> {
     // Indicate if unable to register keyboard
     if(typeof(queryResult.error) == 'string') {
       // Currently unreachable (24 May 2021 - API returns a 404; returned 'script' does not call register)
-      var badName='';
+      let badName='';
       if(typeof(queryResult.options.keyboardid) == 'string') {
-        let keyboardId = queryResult.options.keyboardid;
+        const keyboardId = queryResult.options.keyboardid;
         badName = keyboardId.substring(0,1).toUpperCase() + keyboardId.substring(1);
       }
 
@@ -205,10 +205,10 @@ export default class CloudQueryEngine extends EventEmitter<EventMap> {
     let stubs: KeyboardStub[] = [];
 
     if(options.context == 'keyboard') {
-      let i, kp=(queryResult as CloudKeyboardQueryResult).keyboard;
+    const kp=(queryResult as CloudKeyboardQueryResult).keyboard;
       // Process array of keyboard definitions
       if(Array.isArray(kp)) {
-        for(i=0; i<kp.length; i++) {
+        for(let i=0; i<kp.length; i++) {
           // Note:  if an invalid language code is specified, the elements here may be
           //        empty arrays.  Will not report an error if so.
           stubs = stubs.concat(CloudQueryEngine.registerLanguagesForKeyboard(kp[i],options,i));
@@ -273,7 +273,7 @@ export default class CloudQueryEngine extends EventEmitter<EventMap> {
           }
 
           if(Array.isArray(kp[i].languages)) {
-            let langArray = kp[i].languages as LanguageAPIPropertySpec[];
+            const langArray = kp[i].languages as LanguageAPIPropertySpec[];
             for(let j=0; j < langArray.length; j++) {
               if(id == langArray[j].name.toLowerCase()) {
                 nDflt = i;
@@ -287,7 +287,7 @@ export default class CloudQueryEngine extends EventEmitter<EventMap> {
       }
     } else { // Otherwise, process a single keyboard for the specified languages
       // Font path defined by cloud entry
-      let fontPath = options.fontBaseUri || '';
+      const fontPath = options.fontBaseUri || '';
 
       const allStubs = KeyboardStub.toStubs(kp, options.keyboardBaseUri, fontPath);
 

--- a/web/src/engine/keyboard-storage/src/domCloudRequester.ts
+++ b/web/src/engine/keyboard-storage/src/domCloudRequester.ts
@@ -10,7 +10,7 @@ export default class DOMCloudRequester implements CloudRequesterInterface {
   }
 
   request<T>(query: string) {
-    let promise = new ManagedPromise<T>();
+    const promise = new ManagedPromise<T>();
 
     // Set callback timer
     const timeoutID = window.setTimeout(() => {

--- a/web/src/engine/keyboard-storage/src/keyboardRequisitioner.ts
+++ b/web/src/engine/keyboard-storage/src/keyboardRequisitioner.ts
@@ -61,7 +61,7 @@ function convertToErrorStub(stub: {id: string, name: string}, err: Error | strin
 }
 
 function toQuerySpecs(id: string, langId: string, version?: string): CloudRequestEntry {
-  let obj = new CloudRequestEntry(id, langId);
+  const obj = new CloudRequestEntry(id, langId);
   if(version) {
     obj.version = version;
   }
@@ -116,15 +116,15 @@ export default class KeyboardRequisitioner {
   }
 
   addKeyboardArray(x: (string|RawKeyboardMetadata)[]): Promise<(KeyboardStub | ErrorStub)[]> {
-    let completeStubs: KeyboardStub[] = [];
-    let incompleteStubs: KeyboardStub[] = [];
-    let stubs: KeyboardStub[] = [];
-    let identifiers: string[] = [];
-    let errorStubs: ErrorStub[] = [];
+    const completeStubs: KeyboardStub[] = [];
+    const incompleteStubs: KeyboardStub[] = [];
+    const stubs: KeyboardStub[] = [];
+    const identifiers: string[] = [];
+    const errorStubs: ErrorStub[] = [];
 
     // #region Parameter preprocessing: is incoming data already 'complete', or do we need to fetch the 'complete' version?
 
-    for(let entry of x) {
+    for(const entry of x) {
       if(typeof entry == 'string') {
         if(entry.length > 0) {
           identifiers.push(entry);
@@ -134,18 +134,18 @@ export default class KeyboardRequisitioner {
         if(entry['KI'] || entry['KL'] || entry['KLC'] || entry['KFont'] || entry['KOskFont']) {
           stubs.push(new KeyboardStub(entry as RawKeyboardStub));
         } else {
-          let apiSpecEntry = entry as KeyboardAPISpec;
+          const apiSpecEntry = entry as KeyboardAPISpec;
           if(typeof(apiSpecEntry.language) != "undefined") {
             console.warn("The 'language' property for keyboard stubs has been deprecated.  Please use the 'languages' property instead.");
           }
           apiSpecEntry.languages ||= apiSpecEntry.language;
 
           if(typeof apiSpecEntry.languages === 'undefined') {
-            let msg = 'To use keyboard \'' + apiSpecEntry.id + '\', you must specify languages.';
+            const msg = 'To use keyboard \'' + apiSpecEntry.id + '\', you must specify languages.';
             errorStubs.push(convertToErrorStub(apiSpecEntry, msg));
           } else if(Array.isArray(apiSpecEntry.languages)) {
-            let splitStubs = KeyboardStub.toStubs(apiSpecEntry, this.pathConfig.keyboards, this.pathConfig.fonts);
-            for(let stub of splitStubs) {
+            const splitStubs = KeyboardStub.toStubs(apiSpecEntry, this.pathConfig.keyboards, this.pathConfig.fonts);
+            for(const stub of splitStubs) {
               if(stub instanceof KeyboardStub) {
                 stubs.push(stub);
               } else {
@@ -161,9 +161,9 @@ export default class KeyboardRequisitioner {
     }
 
     // Next pass: determine which stubs are fully-formed and which are not.
-    for(let stub of stubs) {
+    for(const stub of stubs) {
       if(stub.KF) {
-        let err = stub.validateForCustomKeyboard();
+        const err = stub.validateForCustomKeyboard();
         if(err) {
           errorStubs.push(convertToErrorStub(stub, err));
         } else {
@@ -178,8 +178,8 @@ export default class KeyboardRequisitioner {
 
     // After that, request stubs that aren't fully-formed / are just requested by string.
     // Verify that we have at least a keyboard ID or a language code.
-    let cloudList: CloudRequestEntry[] = [];
-    for(let incomplete of incompleteStubs) {
+    const cloudList: CloudRequestEntry[] = [];
+    for(const incomplete of incompleteStubs) {
       if(!incomplete.KI && !incomplete.KLC) {
         errorStubs.push(convertToErrorStub(incomplete, "Cannot fetch keyboard information without a keyboard ID or language code."));
         continue;
@@ -194,7 +194,7 @@ export default class KeyboardRequisitioner {
     }
 
     // Double-check the incoming string-based queries, too!
-    for(let identifier of identifiers) {
+    for(const identifier of identifiers) {
       const pList=identifier.split('@');
       let lList=[''];
       if(pList[0].toLowerCase() == 'english') {
@@ -221,9 +221,9 @@ export default class KeyboardRequisitioner {
     completeStubs.forEach((stub) => this.cache.addStub(stub));
 
     // After that, note that we do merge non-fully-formed stubs with returned stubs that match?
-    let resultPromise = this.cloudQueryEngine.fetchCloudStubs(cloudList.map((spec) => spec.toString()));
+    const resultPromise = this.cloudQueryEngine.fetchCloudStubs(cloudList.map((spec) => spec.toString()));
     return resultPromise.then((queryResults) => {
-      for(let result of queryResults) {
+      for(const result of queryResults) {
         if(result instanceof KeyboardStub) {
           // Register the newly-complete stub.
           this.cache.addStub(result);
@@ -239,7 +239,7 @@ export default class KeyboardRequisitioner {
 
   async addLanguageKeyboards(languages: string[]): Promise<(ErrorStub | KeyboardStub)[]> {
     // Covers the 'add a keyboard by language name' angle.
-    let errorStubs: ErrorStub[] = [];
+    const errorStubs: ErrorStub[] = [];
     let fetchedLanguageList: LanguageAPIPropertySpec[] = [];
 
     try {
@@ -257,7 +257,7 @@ export default class KeyboardRequisitioner {
     let cmd = '';
     for(let i=0; i<languages.length; i++) {
       let lgName = languages[i].toLowerCase();
-      let addAll = (lgName.substr(-1,1) == '$');
+      const addAll = (lgName.substr(-1,1) == '$');
       if(addAll) {
         lgName = lgName.substr(0,lgName.length-1);
       }
@@ -281,7 +281,7 @@ export default class KeyboardRequisitioner {
       if (!languageFound) {
         // Construct response array of errors (failed-query keyboards)
         // that will be merged with stubs (successfully-queried keyboards)
-        let stub: ErrorStub = {language: {name: lgName}, error: new Error(this.alertLanguageUnavailable(lgName))};
+        const stub: ErrorStub = {language: {name: lgName}, error: new Error(this.alertLanguageUnavailable(lgName))};
         errorStubs.push(stub);
       }
     }
@@ -294,7 +294,7 @@ export default class KeyboardRequisitioner {
     return this.cloudQueryEngine.keymanCloudRequest('&keyboardid='+cmd, false).then(async (result) => {
       const results = await mergeAndResolveStubPromises(result, errorStubs);
 
-      for(let result of results) {
+      for(const result of results) {
         // If not an error stub...
         if(typeof (result as ErrorStub).error == 'undefined') {
           this.cache.addStub(result as KeyboardStub);
@@ -304,7 +304,7 @@ export default class KeyboardRequisitioner {
       return results;
     }, (err) => {
       console.error(err);
-      let stub: ErrorStub = {error: err};
+      const stub: ErrorStub = {error: err};
       errorStubs.push(stub);
       return rejectErrorStubs(errorStubs);
     });
@@ -326,7 +326,7 @@ export default class KeyboardRequisitioner {
    * @returns string of Error message
    */
   private alertLanguageUnavailable(languageName: string): string {
-    let msg = 'No keyboards are available for '+ languageName + '. '
+    const msg = 'No keyboards are available for '+ languageName + '. '
       +'Does it have another language name?';
 
     // TODO:  hooks for internal alerts!

--- a/web/src/engine/keyboard-storage/src/keyboardStub.ts
+++ b/web/src/engine/keyboard-storage/src/keyboardStub.ts
@@ -63,13 +63,13 @@ export default class KeyboardStub extends KeyboardProperties {
   constructor(arg0: string | RawKeyboardStub | (APISimpleKeyboard & { filename: string }), arg1?: string, arg2?: string) {
     if(typeof arg0 !== 'string') {
       if(arg0.id !== undefined) {
-        let apiSpec = arg0 as APISimpleKeyboard & { filename: string };
+        const apiSpec = arg0 as APISimpleKeyboard & { filename: string };
         apiSpec.id = prefixed(apiSpec.id);
         super(apiSpec, arg2);
         this.KF = configureFilePathing(apiSpec.filename, arg1);
         this.mapRegion(apiSpec.languages);
       } else {
-        let rawStub = arg0 as RawKeyboardStub;
+        const rawStub = arg0 as RawKeyboardStub;
         rawStub.KI = prefixed(rawStub.KI);
         super(rawStub, arg2);
 
@@ -97,7 +97,7 @@ export default class KeyboardStub extends KeyboardProperties {
         rIndex = region-1;
       }
     } else if(typeof(region) == 'string') {
-      let list = (region.length == 2 ? REGION_CODES : REGIONS);
+      const list = (region.length == 2 ? REGION_CODES : REGIONS);
       for(let i=0; i<list.length; i++) {
         if(region.toLowerCase() == list[i].toLowerCase()) {
           rIndex=i;
@@ -156,7 +156,7 @@ export default class KeyboardStub extends KeyboardProperties {
       languages = languages.concat(arg.languages);
     }
 
-    let stubs: KeyboardStub[] = [];
+    const stubs: KeyboardStub[] = [];
     languages.forEach(language => {
       // The deprecated `language` is assigned to satisfy TS type-checking.
       const intermediate = {...arg, languages: language, language: undefined as LanguageAPIPropertySpec};
@@ -223,7 +223,7 @@ export function mergeAndResolveStubPromises(keyboardStubs: (KeyboardStub|ErrorSt
     return rejectErrorStubs(errorStubs);
   } else {
     // Merge this with errorStubs
-    let result: (KeyboardStub|ErrorStub)[] = keyboardStubs;
+    const result: (KeyboardStub|ErrorStub)[] = keyboardStubs;
     return Promise.resolve(result.concat(errorStubs));
   }
 }

--- a/web/src/engine/keyboard-storage/src/modelCache.ts
+++ b/web/src/engine/keyboard-storage/src/modelCache.ts
@@ -24,7 +24,7 @@ export default class ModelManager {
     this.registeredModels[model.id] = model;
 
     // Register the model for each targeted language code variant.
-    let mm = this;
+    const mm = this;
     model.languages.forEach(function(code: string) {
       // Prevent null / undefined codes; they're invalid.
       if(!code) {
@@ -50,7 +50,7 @@ export default class ModelManager {
     }
 
     // Ensure the model is deregistered for each targeted language code variant.
-    let mm = this;
+    const mm = this;
     model.languages.forEach(function(code: string) {
       if(mm.languageModelMap[code].id == modelId) {
         delete mm.languageModelMap[code];

--- a/web/src/engine/keyboard-storage/src/nodeCloudRequester.ts
+++ b/web/src/engine/keyboard-storage/src/nodeCloudRequester.ts
@@ -30,7 +30,7 @@ export default class NodeCloudRequester implements CloudRequesterInterface {
       throw new Error("Invalid state:  must be linked with a CloudQueryEngine instance.");
     }
 
-    let promise = new ManagedPromise<T>();
+    const promise = new ManagedPromise<T>();
 
     // Set callback timer
     const timeoutObj = setTimeout(() => {
@@ -42,7 +42,7 @@ export default class NodeCloudRequester implements CloudRequesterInterface {
     const tFlag='&timerid='+ queryId;
     const fullRef = query + tFlag;
 
-    let _this = this;
+    const _this = this;
 
     const finalize = (fetchedContents: string) => {
       clearTimeout(timeoutObj);

--- a/web/src/engine/keyboard-storage/src/stubAndKeyboardCache.ts
+++ b/web/src/engine/keyboard-storage/src/stubAndKeyboardCache.ts
@@ -192,7 +192,7 @@ export default class StubAndKeyboardCache extends EventEmitter<EventMap> {
   getStub(keyboard: Keyboard, languageID?: string): KeyboardStub;
   getStub(arg0: string | Keyboard, arg1?: string): KeyboardStub {
     let keyboardID: string;
-    let languageID = arg1 || '---';
+    const languageID = arg1 || '---';
 
     if(arg0 instanceof Keyboard) {
       keyboardID = arg0.id;
@@ -226,7 +226,7 @@ export default class StubAndKeyboardCache extends EventEmitter<EventMap> {
    *              If `false`, only forgets the metadata (stubs).
    */
   forgetKeyboard(keyboard: string | Keyboard, purge: boolean = false) {
-    let id: string = (keyboard instanceof Keyboard) ? keyboard.id : prefixed(keyboard);
+    const id: string = (keyboard instanceof Keyboard) ? keyboard.id : prefixed(keyboard);
 
     if(this.stubSetTable[id]) {
       delete this.stubSetTable[id];
@@ -238,13 +238,13 @@ export default class StubAndKeyboardCache extends EventEmitter<EventMap> {
   }
 
   getStubList(): KeyboardStub[] {
-    let arr: KeyboardStub[] = [];
+    const arr: KeyboardStub[] = [];
 
     const kbdIds = Object.keys(this.stubSetTable);
-    for(let kbdId of kbdIds) {
-      let row = this.stubSetTable[kbdId];
+    for(const kbdId of kbdIds) {
+      const row = this.stubSetTable[kbdId];
       const langIds = Object.keys(row);
-      for(let langId of langIds) {
+      for(const langId of langIds) {
         arr.push(row[langId]);
       }
     }

--- a/web/src/engine/main/src/contextManagerBase.ts
+++ b/web/src/engine/main/src/contextManagerBase.ts
@@ -350,13 +350,13 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
         const completionPromise = new ManagedPromise<Error>();
         this.emit('keyboardasyncload', requestedStub, completionPromise.corePromise);
 
-        let keyboardPromise = this.keyboardCache.fetchKeyboardForStub(requestedStub);
-        let timeoutPromise = new Promise<Keyboard>((resolve, reject) => {
+        const keyboardPromise = this.keyboardCache.fetchKeyboardForStub(requestedStub);
+        const timeoutPromise = new Promise<Keyboard>((resolve, reject) => {
           const timeoutMsg = `Sorry, the ${requestedStub.name} keyboard for ${requestedStub.langName} is not currently available.`;
           window.setTimeout(() => reject(new Error(timeoutMsg)), ContextManagerBase.TIMEOUT_THRESHOLD);
         });
 
-        let combinedPromise = Promise.race([keyboardPromise, timeoutPromise]);
+        const combinedPromise = Promise.race([keyboardPromise, timeoutPromise]);
 
         // Ensure the async-load Promise completes properly.
         combinedPromise.then(() => {
@@ -373,7 +373,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
       });
 
       // Now the fun part:  note the original call's parameters as a pending activation.
-      let promise = this.deferredKeyboardActivation(defermentPromise, requestedStub, this.currentKeyboardSrcTarget());
+      const promise = this.deferredKeyboardActivation(defermentPromise, requestedStub, this.currentKeyboardSrcTarget());
       return {
         keyboard: promise.then(async (activation) => {
           // Is the activation we requested still pending, or was it cancelled in favor of a

--- a/web/src/engine/main/src/hardKeyboard.ts
+++ b/web/src/engine/main/src/hardKeyboard.ts
@@ -27,7 +27,7 @@ export function processForMnemonicsAndLegacy(s: KeyEvent, activeKeyboard: Keyboa
     // Positional Layout
 
     /* 13/03/2007 MCD: Swedish: Start mapping of keystroke to US keyboard */
-    var Lbase = KeyMapping.languageMap[baseLayout];
+    const Lbase = KeyMapping.languageMap[baseLayout];
     if(Lbase && Lbase['k'+s.Lcode]) {
       s.Lcode=Lbase['k'+s.Lcode];
     }

--- a/web/src/engine/main/src/headless/contextWindow.ts
+++ b/web/src/engine/main/src/headless/contextWindow.ts
@@ -38,7 +38,7 @@ export default class ContextWindow implements LexicalModelTypes.Context {
   }
 
   public toMock(): Mock {
-    let caretPos = this.left._kmwLength();
+    const caretPos = this.left._kmwLength();
 
     return new Mock(this.left + (this.right || ""), caretPos);
   }

--- a/web/src/engine/main/src/headless/deviceDetector.ts
+++ b/web/src/engine/main/src/headless/deviceDetector.ts
@@ -42,7 +42,9 @@ export class DeviceDetector {
    * @return      {number}
    */
   getDPI(): number {
-    var t=document.createElement('DIV') ,s=t.style,dpi=96;
+    const t=document.createElement('DIV');
+    const s=t.style;
+    let dpi=96;
     if(document.readyState !== 'complete') {
       return dpi;
     }
@@ -57,10 +59,10 @@ export class DeviceDetector {
   }
 
   detect() : DeviceSpec {
-    var possMacSpoof = false;
+    let possMacSpoof = false;
 
     if(navigator && navigator.userAgent) {
-      var agent=navigator.userAgent;
+      const agent=navigator.userAgent;
 
       if(agent.indexOf('iPad') >= 0) {
         this.OS='iOS';
@@ -76,7 +78,7 @@ export class DeviceDetector {
         this.dyPortrait=75;
         this.dyLandscape=25;
         try {
-          var rx=new RegExp("(?:Android\\s+)(\\d+\\.\\d+\\.\\d+)");
+          const rx=new RegExp("(?:Android\\s+)(\\d+\\.\\d+\\.\\d+)");
           this.version=agent.match(rx)[1];
         } catch(ex) {}
       } else if(agent.indexOf('Linux') >= 0) {
@@ -88,8 +90,8 @@ export class DeviceDetector {
         //
         // Firefox uses '.' between version components, while Chrome and Safari use
         // '_' instead.  So, we have to check for both.  Yay.
-        let regex = /Intel Mac OS X (\d+(?:[_\.]\d+)+)/i;
-        let results = regex.exec(agent);
+        const regex = /Intel Mac OS X (\d+(?:[_\.]\d+)+)/i;
+        const results = regex.exec(agent);
 
         // Match result:  a version string with components separated by underscores.
         if(!results) {
@@ -98,8 +100,8 @@ export class DeviceDetector {
           this.OS='MacOSX';
         } else if(results.length > 1 && results[1]) {
           // Convert version string into a usable form.
-          let versionString = results[1].replace('_', '.');
-          let version = new Version(versionString);
+          const versionString = results[1].replace('_', '.');
+          const version = new Version(versionString);
 
           possMacSpoof = Version.MAC_POSSIBLE_IPAD_ALIAS.compareTo(version) <= 0;
           this.OS='MacOSX';
@@ -136,7 +138,7 @@ export class DeviceDetector {
     }
 
     // Test for potential Chrome emulation on Windows or macOS X (used only in next if-check)
-    let possibleChromeEmulation = navigator.platform == 'Win32' || navigator.platform == 'MacIntel'
+    const possibleChromeEmulation = navigator.platform == 'Win32' || navigator.platform == 'MacIntel'
 
     //                           alert(sxx+'->'+device.formFactor);
     // Check for phony iOS devices (but don't undo for Chrome emulation used during development)
@@ -150,7 +152,7 @@ export class DeviceDetector {
       this.browser='safari';
     }
 
-    var bMatch=/Firefox|Chrome|OPR|Safari|Edge/;
+    const bMatch=/Firefox|Chrome|OPR|Safari|Edge/;
     if(bMatch.test(navigator.userAgent)) {
       if((navigator.userAgent.indexOf('Firefox') >= 0) && ('onmozorientationchange' in screen)) {
         this.browser='firefox';

--- a/web/src/engine/main/src/headless/inputProcessor.ts
+++ b/web/src/engine/main/src/headless/inputProcessor.ts
@@ -143,8 +143,8 @@ export class InputProcessor {
    * @returns
    */
   private _processKeyEvent(keyEvent: KeyEvent, outputTarget: OutputTarget): RuleBehavior {
-    let formFactor = keyEvent.device.formFactor;
-    let fromOSK = keyEvent.isSynthetic;
+    const formFactor = keyEvent.device.formFactor;
+    const fromOSK = keyEvent.isSynthetic;
 
     // The default OSK layout for desktop devices does not include nextlayer info, relying on modifier detection here.
     // It's the OSK equivalent to doModifierPress on 'desktop' form factors.
@@ -185,7 +185,7 @@ export class InputProcessor {
 
     // Create a "mock" backup of the current outputTarget in its pre-input state.
     // Current, long-existing assumption - it's DOM-backed.
-    let preInputMock = Mock.from(outputTarget, true);
+    const preInputMock = Mock.from(outputTarget, true);
 
     const startingLayerId = this.keyboardProcessor.layerId;
 
@@ -223,7 +223,7 @@ export class InputProcessor {
     if(keepRuleBehavior) {
       // alternates are our fat-finger alternate outputs. We don't build these for keys we detect as
       // layer switch keys
-      let alternates = isOnlyLayerSwitchKey ? null : this.buildAlternates(ruleBehavior, keyEvent, preInputMock);
+      const alternates = isOnlyLayerSwitchKey ? null : this.buildAlternates(ruleBehavior, keyEvent, preInputMock);
 
       // Now that we've done all the keystroke processing needed, ensure any extra effects triggered
       // by the actual keystroke occur.
@@ -257,7 +257,7 @@ export class InputProcessor {
     this.keyboardProcessor.newLayerStore.set(hasLayerChanged ? this.keyboardProcessor.layerId : '');
     this.keyboardProcessor.oldLayerStore.set(hasLayerChanged ? startingLayerId : '');
 
-    let postRuleBehavior = this.keyboardProcessor.processPostKeystroke(this.contextDevice, outputTarget);
+    const postRuleBehavior = this.keyboardProcessor.processPostKeystroke(this.contextDevice, outputTarget);
     if(postRuleBehavior) {
       postRuleBehavior.finalize(this.keyboardProcessor, outputTarget, true);
     }
@@ -280,14 +280,14 @@ export class InputProcessor {
     // If we're performing a 'default command', it's not a standard 'typing' event - don't do fat-finger stuff.
     // Also, don't do fat-finger stuff if predictive text isn't enabled.
     if(this.languageProcessor.isActive && !ruleBehavior.triggersDefaultCommand) {
-      let keyDistribution = keyEvent.keyDistribution;
+      const keyDistribution = keyEvent.keyDistribution;
 
       // We don't need to track absolute indexing during alternate-generation;
       // only position-relative, so it's better to use a sliding window for context
       // when making alternates.  (Slightly worse for short text, matters greatly
       // for long text.)
-      let contextWindow = new ContextWindow(preInputMock, ContextWindow.ENGINE_RULE_WINDOW, this.keyboardProcessor.layerId);
-      let windowedMock = contextWindow.toMock();
+      const contextWindow = new ContextWindow(preInputMock, ContextWindow.ENGINE_RULE_WINDOW, this.keyboardProcessor.layerId);
+      const windowedMock = contextWindow.toMock();
 
       // Note - we don't yet do fat-fingering with longpress keys.
       if(this.languageProcessor.isActive && keyDistribution && keyEvent.kbdLayer) {
@@ -297,7 +297,7 @@ export class InputProcessor {
         // Consider use of https://developer.mozilla.org/en-US/docs/Web/API/Performance/now instead?
         // Would allow finer-tuned control.
         let TIMEOUT_THRESHOLD: number = Number.MAX_VALUE;
-        let _globalThis = globalObject();
+        const _globalThis = globalObject();
         let timer: () => number;
 
         // Available by default on `window` in browsers, but _not_ on `global` in Node,
@@ -321,7 +321,7 @@ export class InputProcessor {
         // Seek to match SearchSpace.EDIT_DISTANCE_COST_SCALE from the predictive-text engine.
         // Reasoning for the selected value may be seen there.  Short version - keystrokes
         // that _appear_ very precise may otherwise not even consider directly-neighboring keys.
-        let KEYSTROKE_EPSILON = Math.exp(-5);
+        const KEYSTROKE_EPSILON = Math.exp(-5);
 
         // Sort the distribution into probability-descending order.
         keyDistribution.sort((a, b) => b.p - a.p);
@@ -329,7 +329,7 @@ export class InputProcessor {
         alternates = [];
 
         let totalMass = 0; // Tracks sum of non-error probabilities.
-        for(let pair of keyDistribution) {
+        for(const pair of keyDistribution) {
           if(pair.p < KEYSTROKE_EPSILON) {
             totalMass += pair.p;
             break;
@@ -342,7 +342,7 @@ export class InputProcessor {
             break;
           }
 
-          let mock = Mock.from(windowedMock, false);
+          const mock = Mock.from(windowedMock, false);
 
           const altKey = pair.keySpec;
           if(!altKey) {
@@ -350,15 +350,15 @@ export class InputProcessor {
             continue;
           }
 
-          let altEvent = this.keyboardProcessor.activeKeyboard.constructKeyEvent(altKey, keyEvent.device, this.keyboardProcessor.stateKeys);
-          let alternateBehavior = this.keyboardProcessor.processKeystroke(altEvent, mock);
+          const altEvent = this.keyboardProcessor.activeKeyboard.constructKeyEvent(altKey, keyEvent.device, this.keyboardProcessor.stateKeys);
+          const alternateBehavior = this.keyboardProcessor.processKeystroke(altEvent, mock);
 
           // If alternateBehavior.beep == true, ignore it.  It's a disallowed key sequence,
           // so we expect users to never intend their use.
           //
           // Also possible that this set of conditions fail for all evaluated alternates.
           if(alternateBehavior && !alternateBehavior.beep && pair.p > 0) {
-            let transform: LexicalModelTypes.Transform = alternateBehavior.transcription.transform;
+            const transform: LexicalModelTypes.Transform = alternateBehavior.transcription.transform;
 
             // Ensure that the alternate's token id matches that of the current keystroke, as we only
             // record the matched rule's context (since they match)

--- a/web/src/engine/main/src/headless/languageProcessor.ts
+++ b/web/src/engine/main/src/headless/languageProcessor.ts
@@ -32,7 +32,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
 
     // Establishes KMW's platform 'capabilities', which limit the range of context a LMLayer
     // model may expect.
-    let capabilities: Capabilities = {
+    const capabilities: Capabilities = {
       maxLeftContextCodePoints: 64,
       // Since the apps don't yet support right-deletions.
       maxRightContextCodePoints: supportsRightDeletions ? 0 : 64
@@ -89,8 +89,8 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
       return Promise.resolve();
     }
 
-    let specType: 'file'|'raw' = model.path ? 'file' : 'raw';
-    let source = specType == 'file' ? model.path : model.code;
+    const specType: 'file'|'raw' = model.path ? 'file' : 'raw';
+    const source = specType == 'file' ? model.path : model.code;
 
     // We pre-emptively emit so that the banner's DOM elements may update synchronously.
     // Prevents an ugly "flash of unstyled content" layout issue during keyboard load
@@ -142,7 +142,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     this.emit('invalidatesuggestions', 'context');
 
     if(outputTarget) {
-      let transcription = outputTarget.buildTranscriptionFrom(outputTarget, null, false);
+      const transcription = outputTarget.buildTranscriptionFrom(outputTarget, null, false);
       return this.predict_internal(transcription, true, layerId);
     } else {
       // if there's no active context source, there's nothing to
@@ -158,7 +158,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
       return null;
     }
 
-    let context = new ContextWindow(Mock.from(target, false), this.configuration, layerId);
+    const context = new ContextWindow(Mock.from(target, false), this.configuration, layerId);
     return this.lmEngine.wordbreak(context);
   }
 
@@ -214,13 +214,13 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
       // Apply the Suggestion!
 
       // Step 1:  determine the final output text
-      let final = Mock.from(original.preInput, false);
+      const final = Mock.from(original.preInput, false);
       final.apply(suggestion.transform);
 
       // Step 2:  build a final, master Transform that will produce the desired results from the CURRENT state.
       // In embedded mode, both Android and iOS are best served by calculating this transform and applying its
       // values as needed for use with their IME interfaces.
-      let transform = final.buildTransformFrom(outputTarget);
+      const transform = final.buildTransformFrom(outputTarget);
       outputTarget.apply(transform);
 
       // Tell the banner that a suggestion was applied, so it can call the
@@ -229,12 +229,12 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
 
       // Build a 'reversion' Transcription that can be used to undo this apply() if needed,
       // replacing the suggestion transform with the original input text.
-      let preApply = Mock.from(original.preInput, false);
+      const preApply = Mock.from(original.preInput, false);
       preApply.apply(original.transform);
 
       // Builds the reversion option according to the loaded lexical model's known
       // syntactic properties.
-      let suggestionContext = new ContextWindow(original.preInput, this.configuration, getLayerId());
+      const suggestionContext = new ContextWindow(original.preInput, this.configuration, getLayerId());
 
       // We must accept the Suggestion from its original context, which was before
       // `original.transform` was applied.
@@ -242,7 +242,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
 
       // Also, request new prediction set based on the resulting context.
       reversionPromise = reversionPromise.then((reversion) => {
-        let mappedReversion: Reversion = {
+        const mappedReversion: Reversion = {
           // By mapping back to the original Transcription that generated the Suggestion,
           // the input will be automatically rewound to the preInput state.
           transform: original.transform,
@@ -278,7 +278,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     //
     // Reversions use the additive inverse of the id token of the Transcription being
     // reverted to.
-    let original = this.getPredictionState(-reversion.transformId);
+    const original = this.getPredictionState(-reversion.transformId);
     if(!original) {
       console.warn("Could not apply the Suggestion!");
       return Promise.resolve([] as Suggestion[]);
@@ -287,17 +287,17 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     // Apply the Reversion!
 
     // Step 1:  determine the final output text
-    let final = Mock.from(original.preInput, false);
+    const final = Mock.from(original.preInput, false);
     final.apply(reversion.transform); // Should match original.transform, actually. (See applySuggestion)
 
     // Step 2:  build a final, master Transform that will produce the desired results from the CURRENT state.
     // In embedded mode, both Android and iOS are best served by calculating this transform and applying its
     // values as needed for use with their IME interfaces.
-    let transform = final.buildTransformFrom(outputTarget);
+    const transform = final.buildTransformFrom(outputTarget);
     outputTarget.apply(transform);
 
     // The reason we need to preserve the additive-inverse 'transformId' property on Reversions.
-    let promise = this.currentPromise = this.lmEngine.revertSuggestion(reversion, new ContextWindow(original.preInput, this.configuration, null))
+    const promise = this.currentPromise = this.lmEngine.revertSuggestion(reversion, new ContextWindow(original.preInput, this.configuration, null))
     // If the "current Promise" is as set above, clear it.
     // If another one has been triggered since... don't.
     promise.then(() => this.currentPromise = (this.currentPromise == promise) ? null : this.currentPromise);
@@ -310,7 +310,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
       return null;
     }
 
-    let transcription = outputTarget.buildTranscriptionFrom(outputTarget, null, false);
+    const transcription = outputTarget.buildTranscriptionFrom(outputTarget, null, false);
     return this.predict(transcription, layerId);
   }
 
@@ -324,7 +324,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
       return null;
     }
 
-    let context = new ContextWindow(transcription.preInput, this.configuration, layerId);
+    const context = new ContextWindow(transcription.preInput, this.configuration, layerId);
     this.recordTranscription(transcription);
 
     if(resetContext) {
@@ -339,12 +339,12 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
       }];
     }
 
-    let transform = transcription.transform;
-    var promise = this.currentPromise = this.lmEngine.predict(alternates, context);
+    const transform = transcription.transform;
+    const promise = this.currentPromise = this.lmEngine.predict(alternates, context);
 
     return promise.then((suggestions: Suggestion[]) => {
       if(promise == this.currentPromise) {
-        let result = new ReadySuggestions(suggestions, transform.id);
+        const result = new ReadySuggestions(suggestions, transform.id);
         this.emit("suggestionsready", result);
         this.currentPromise = null;
       }
@@ -395,7 +395,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
       return;
     }
 
-    let oldVal = this._mayPredict;
+    const oldVal = this._mayPredict;
     this._mayPredict = flag;
 
     if(oldVal != flag) {
@@ -406,7 +406,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
       if(this.activeModel) {
         // If someone toggles predictions on and off without changing the model, it is possible
         // that the model is already configured!
-        let state: StateChangeEnum = flag ? 'active' : 'inactive';
+        const state: StateChangeEnum = flag ? 'active' : 'inactive';
 
         // We always signal the 'active' state here, even if 'configured', b/c of an
         // anti-banner-flicker optimization in the Android app.
@@ -451,7 +451,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     // The object below is to facilitate a pass-by-reference on the boolean flag,
     // allowing the event's handler to signal if whitespace has been added via
     // auto-applied suggestion that should be blocked on the next keystroke.
-    let returnObj = {shouldSwallow: false};
+    const returnObj = {shouldSwallow: false};
     this.emit('tryaccept', source, returnObj);
 
     return returnObj.shouldSwallow ?? false;

--- a/web/src/engine/main/src/keyboardInterface.ts
+++ b/web/src/engine/main/src/keyboardInterface.ts
@@ -25,14 +25,14 @@ export default class KeyboardInterface<ContextManagerType extends ContextManager
 
   // Preserves a keyboard's ID, even if namespaced, via script tag tagging.
   preserveID(Pk: any /** a `Keyboard`'s `scriptObject` entry */) {
-    var trueID;
+    let trueID;
 
     // Find the currently-executing script tag; KR is called directly from each keyboard's definition script.
     if(document.currentScript) {
       trueID = document.currentScript.id;
     } else {
-      var scripts = document.getElementsByTagName('script');
-      var currentScript = scripts[scripts.length-1];
+      const scripts = document.getElementsByTagName('script');
+      const currentScript = scripts[scripts.length-1];
 
       trueID = currentScript.id;
     }

--- a/web/src/engine/main/src/keymanEngine.ts
+++ b/web/src/engine/main/src/keymanEngine.ts
@@ -289,7 +289,7 @@ export default class KeymanEngine<
     });
 
     kbdCache.on('stubadded', (stub) => {
-      let eventRaiser = () => {
+      const eventRaiser = () => {
         // The corresponding event is needed in order to update UI modules as new keyboard stubs "come online".
         this.legacyAPIEvents.callEvent('keyboardregistered', {
           internalName: stub.KI,
@@ -314,7 +314,7 @@ export default class KeymanEngine<
     });
 
     kbdCache.on('keyboardadded', (keyboard) => {
-      let eventRaiser = () => {
+      const eventRaiser = () => {
         // Execute any external (UI) code needed after loading keyboard
         this.legacyAPIEvents.callEvent('keyboardloaded', {
           keyboardName: keyboard.id

--- a/web/src/engine/osk/gesture-processor/src/engine/configuration/gestureRecognizerConfiguration.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/configuration/gestureRecognizerConfiguration.ts
@@ -110,7 +110,7 @@ export function preprocessRecognizerConfig<HoveredItemType, StateToken = any>(
   config: GestureRecognizerConfiguration<HoveredItemType, StateToken>
 ): Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>> {
   // Allows configuration pre-processing during this method.
-  let processingConfig: Mutable<Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>> = {...config} as
+  const processingConfig: Mutable<Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>> = {...config} as
     Nonoptional<GestureRecognizerConfiguration<HoveredItemType, StateToken>>;
 
   processingConfig.mouseEventRoot = processingConfig.mouseEventRoot ?? processingConfig.targetRoot;

--- a/web/src/engine/osk/gesture-processor/src/engine/configuration/zoneBoundaryChecker.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/configuration/zoneBoundaryChecker.ts
@@ -62,7 +62,7 @@ export class ZoneBoundaryChecker {
       return true;
     }
 
-    let borderProximityBitmask = this.getCoordZoneBitmask(coord, config.safeBounds);
+    const borderProximityBitmask = this.getCoordZoneBitmask(coord, config.safeBounds);
 
     // If the active input sequence started close enough to a safe zone border, we
     // disable that part of the said border for any cancellation checks.

--- a/web/src/engine/osk/gesture-processor/src/engine/headless/cumulativePathStats.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/headless/cumulativePathStats.ts
@@ -164,7 +164,7 @@ export class CumulativePathStats<Type = any> {
       throw 'Invalid argument:  stats missing necessary tracking variable.';
     }
 
-    for(let dim in result.rawLinearSums) {
+    for(const dim in result.rawLinearSums) {
       // TS refuses to infer beyond 'string' in a `let... in` construct; we can't
       // even assert it directly on `dim` via declaring it early!
       const d = dim as PathCoordAxis;
@@ -221,7 +221,7 @@ export class CumulativePathStats<Type = any> {
   }
 
   public replaceInitialSample(sample: InputSample<Type>): CumulativePathStats<Type> {
-    let result = new CumulativePathStats(this);
+    const result = new CumulativePathStats(this);
 
     return this._replaceInitialSample(result, sample);
   }

--- a/web/src/engine/osk/gesture-processor/src/engine/headless/gestureDebugPath.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/headless/gestureDebugPath.ts
@@ -63,7 +63,7 @@ export class GestureDebugPath<Type, StateToken = any> extends GesturePath<Type, 
     instance._isComplete = true;
     instance._wasCancelled = jsonObj.wasCancelled;
 
-    let stats = instance.samples.reduce((stats: CumulativePathStats<Type>, sample) => stats.extend(sample), new CumulativePathStats<Type>());
+    const stats = instance.samples.reduce((stats: CumulativePathStats<Type>, sample) => stats.extend(sample), new CumulativePathStats<Type>());
     instance._stats = stats;
 
     return instance;
@@ -107,7 +107,7 @@ export class GestureDebugPath<Type, StateToken = any> extends GesturePath<Type, 
    * `JSON.stringify`.
    */
   toJSON() {
-    let jsonClone: SerializedGesturePath<Type, StateToken> = {
+    const jsonClone: SerializedGesturePath<Type, StateToken> = {
       // Replicate array and its entries, but with certain fields of each entry missing.
       // No .clientX, no .clientY.
       coords: [].concat(this.samples.map((obj) => ({
@@ -121,7 +121,7 @@ export class GestureDebugPath<Type, StateToken = any> extends GesturePath<Type, 
     }
 
     // Removes components of each sample that we don't want serialized.
-    for(let sample of jsonClone.coords) {
+    for(const sample of jsonClone.coords) {
       delete sample.clientX;
       delete sample.clientY;
 

--- a/web/src/engine/osk/gesture-processor/src/engine/headless/gestureSource.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/headless/gestureSource.ts
@@ -235,7 +235,7 @@ export class GestureSource<
   */
  /* c8 ignore start */
  toJSON(): SerializedGestureSource {
-   let jsonClone: SerializedGestureSource = {
+   const jsonClone: SerializedGestureSource = {
      identifier: this.identifier,
      isFromTouch: this.isFromTouch,
      path: this.path.toJSON(),

--- a/web/src/engine/osk/gesture-processor/src/engine/headless/gestures/matchers/gestureMatcher.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/headless/gestures/matchers/gestureMatcher.ts
@@ -227,7 +227,7 @@ export class GestureMatcher<Type, StateToken = any> implements PredecessorMatch<
       }
 
       // Do actual resolution now that we can convert the spec into a proper resolution object.
-      let resolveObj: MatchResult<Type> = {
+      const resolveObj: MatchResult<Type> = {
         matched: matched,
         action: {
           ...action,
@@ -305,7 +305,7 @@ export class GestureMatcher<Type, StateToken = any> implements PredecessorMatch<
   public get primaryPath(): GestureSource<Type> {
     let bestMatcher: PathMatcher<Type>;
     let highestPriority = Number.NEGATIVE_INFINITY;
-    for(let matcher of this.pathMatchers) {
+    for(const matcher of this.pathMatchers) {
       if(matcher.model.itemPriority > highestPriority) {
         highestPriority = matcher.model.itemPriority;
         bestMatcher = matcher;

--- a/web/src/engine/osk/gesture-processor/src/engine/headless/gestures/matchers/gestureSequence.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/headless/gestures/matchers/gestureSequence.ts
@@ -243,7 +243,7 @@ export class GestureSequence<Type, StateToken = any> extends EventEmitter<EventM
         )
       }).reduce((flattened, arr) => flattened.concat(arr))
       .reduce((deduplicated, arr) => {
-        for(let entry of arr) {
+        for(const entry of arr) {
           if(deduplicated.indexOf(entry) == -1) {
             deduplicated.push(entry);
           }
@@ -491,7 +491,7 @@ export class GestureSequence<Type, StateToken = any> extends EventEmitter<EventM
     };
 
     // Sanitizes the actual keystrokes involved but preserves a decent amount of gesture diagnostic information.
-    let logs = this.stageReports.map((entry) => padding + `${logTouches(entry.currentSourceIds)} - ${entry.matchedId} ${logInterval(entry.interval)}`)
+    const logs = this.stageReports.map((entry) => padding + `${logTouches(entry.currentSourceIds)} - ${entry.matchedId} ${logInterval(entry.interval)}`)
       // Orders each stage from most recent to least recent
       .reverse();
     if(this.markedComplete) {

--- a/web/src/engine/osk/gesture-processor/src/engine/headless/gestures/specs/gestureModelDefs.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/headless/gestures/specs/gestureModelDefs.ts
@@ -37,7 +37,7 @@ export function getGestureModel<Type, StateToken>(defs: GestureModelDefs<Type, S
 }
 
 export function getGestureModelSet<Type, StateToken>(defs: GestureModelDefs<Type, StateToken>, id: string): gestures.specs.GestureModel<Type, StateToken>[] {
-  let idSet = defs.sets[id];
+  const idSet = defs.sets[id];
   if(!idSet) {
     throw new Error(`Could not find a defined gesture-set with id '${id}'`);
   }

--- a/web/src/engine/osk/gesture-processor/src/engine/headless/touchpointCoordinator.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/headless/touchpointCoordinator.ts
@@ -50,7 +50,7 @@ export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends Even
     this.gestureModelDefinitions = gestureModelDefinitions;
     this.inputEngines = [];
     if(inputEngines) {
-      for(let engine of inputEngines) {
+      for(const engine of inputEngines) {
         this.addEngine(engine);
       }
     }
@@ -281,7 +281,7 @@ export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends Even
 
     // For multitouch gestures, only report the gesture **once**.
     const sourceIDs = selection.matcher.allSourceIds;
-    for(let sequence of this._activeGestures) {
+    for(const sequence of this._activeGestures) {
       if(!!sequence.allSourceIds.find((id1) => !!sourceIDs.find((id2) => id1 == id2))) {
         // We've already established (and thus, already reported) a GestureSequence for this selection.
         return;
@@ -372,12 +372,12 @@ export class TouchpointCoordinator<HoveredItemType, StateToken=any> extends Even
       // Currently, we're going with the latter.
 
       // Also mark the touchpoint as no longer active.
-      let i = this._activeSources.indexOf(touchpoint);
+      const i = this._activeSources.indexOf(touchpoint);
       this._activeSources = this._activeSources.splice(i, 1);
     });
     touchpoint.path.on('complete', () => {
       // Also mark the touchpoint as no longer active.
-      let i = this._activeSources.indexOf(touchpoint);
+      const i = this._activeSources.indexOf(touchpoint);
       this._activeSources = this._activeSources.splice(i, 1);
     });
   }

--- a/web/src/engine/osk/gesture-processor/src/engine/touchEventEngine.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/touchEventEngine.ts
@@ -180,7 +180,7 @@ export class TouchEventEngine<ItemType, StateToken = any> extends InputEventEngi
           this.safeBoundMaskMap[touchId] = ZoneBoundaryChecker.inputStartSafeBoundProximityCheck(sample, this.config);
         } else {
           // This touchpoint shouldn't be considered; do not signal a touchstart for it.
-          let sourcePromise = capturedSourcePromises.get(touchId);
+          const sourcePromise = capturedSourcePromises.get(touchId);
           sourcePromise.resolve(null);
           continue;
         }
@@ -195,7 +195,7 @@ export class TouchEventEngine<ItemType, StateToken = any> extends InputEventEngi
           The resolved Promise may then be used to retrieve the correct source in the other event
           handlers' closures.
         */
-        let sourcePromise = capturedSourcePromises.get(touchId);
+        const sourcePromise = capturedSourcePromises.get(touchId);
         sourcePromise.resolve(touchpoint);
 
         /*
@@ -223,7 +223,7 @@ export class TouchEventEngine<ItemType, StateToken = any> extends InputEventEngi
       if(touchpoint) {
         // This 'lock' should only be released when the last simultaneously-registered touch is published via
         // gesture-recognizer event.
-        let eventSignalPromise = new ManagedPromise<void>();
+        const eventSignalPromise = new ManagedPromise<void>();
         this.inputStartSignalMap.set(touchpoint, eventSignalPromise);
 
         return eventSignalPromise.corePromise;

--- a/web/src/engine/osk/gesture-processor/src/tools/unit-test-resources/src/headlessInputEngine.ts
+++ b/web/src/engine/osk/gesture-processor/src/tools/unit-test-resources/src/headlessInputEngine.ts
@@ -30,7 +30,7 @@ export class HeadlessInputEngine<Type = any> extends InputEngineBase<Type> {
     const headSample = recordedSource.path.coords[0];
 
     const pathID = this.PATH_ID_SEED++;
-    let replaySource = this.createTouchpoint(pathID, recordedSource.isFromTouch);
+    const replaySource = this.createTouchpoint(pathID, recordedSource.isFromTouch);
     replaySource.update(headSample); // is included before the point is made available.
     replaySource.path.on('invalidated', () => this.dropTouchpoint(replaySource));
     replaySource.path.on('complete', () => this.dropTouchpoint(replaySource));

--- a/web/src/engine/osk/gesture-processor/src/tools/unit-test-resources/src/hostFixtureLayoutController.ts
+++ b/web/src/engine/osk/gesture-processor/src/tools/unit-test-resources/src/hostFixtureLayoutController.ts
@@ -53,14 +53,14 @@ export class HostFixtureLayoutController extends EventEmitter {
   };
 
   private _setup: () => void = function(this: HostFixtureLayoutController) {
-    let config = this.buildBaseFixtureConfig();
+    const config = this.buildBaseFixtureConfig();
     this._recognizer = new GestureRecognizer<any>(null /* TODO */, config);
     this._hostFixture = document.getElementById('host-fixture');
   }.bind(this);
 
   public connect(): Promise<GestureRecognizer<any>> {
     this._loadPromise = new Promise<GestureRecognizer<any>>((resolve, reject) => {
-      let pageLoadHandler = () => {
+      const pageLoadHandler = () => {
         try {
           this._setup();
           this._applyLayoutConfig();

--- a/web/src/engine/osk/gesture-processor/src/tools/unit-test-resources/src/inputSequenceSimulator.ts
+++ b/web/src/engine/osk/gesture-processor/src/tools/unit-test-resources/src/inputSequenceSimulator.ts
@@ -29,8 +29,8 @@ export class InputSequenceSimulator<HoveredItemType> {
   }
 
   getSampleClientPos(sample: JSONObject<InputSample<HoveredItemType>>): {clientX: number, clientY: number} {
-    let targetRoot = this.controller.recognizer.config.targetRoot;
-    let targetRect = targetRoot.getBoundingClientRect();
+    const targetRoot = this.controller.recognizer.config.targetRoot;
+    const targetRect = targetRoot.getBoundingClientRect();
 
     return {
       clientX: sample.targetX + targetRect.left,
@@ -39,9 +39,9 @@ export class InputSequenceSimulator<HoveredItemType> {
   }
 
   private buildSyntheticTouchEvent(name: string, dict: TouchEventInit): TouchEvent {
-    let config = this.controller.recognizer.config;
+    const config = this.controller.recognizer.config;
 
-    let baseDict = {
+    const baseDict = {
       srcElement: config.touchEventRoot,
       view: window
     } as any;
@@ -66,7 +66,7 @@ export class InputSequenceSimulator<HoveredItemType> {
     //@ts-ignore
     dict.changedTouches = arrToTouchList(dict.changedTouches);
 
-    let event = new Event(name, baseDict) as TouchEvent;
+    const event = new Event(name, baseDict) as TouchEvent;
 
     // Since touch-related properties aren't expected by some browsers' Event constructors,
     // we must add them "in post" when testing in some non-touch environments.  For those,
@@ -79,7 +79,7 @@ export class InputSequenceSimulator<HoveredItemType> {
                     state: InputState,
                     recentTouches: Touch[],
                     targetElement?: HTMLElement): Touch[] {
-    let config = this.controller.recognizer.config;
+    const config = this.controller.recognizer.config;
 
     let event: TouchEvent;
 
@@ -87,7 +87,7 @@ export class InputSequenceSimulator<HoveredItemType> {
       const mappedSample = this.getSampleClientPos(data.sample);
 
       let touch: Touch;
-      let touchDict = {
+      const touchDict = {
         identifier: data.identifier,
         target: targetElement || config.targetRoot,
         ...mappedSample
@@ -108,14 +108,14 @@ export class InputSequenceSimulator<HoveredItemType> {
     let otherTouches = recentTouches.concat([]).filter((entry) => !!entry);
     otherTouches = otherTouches.filter((a) => !changedTouches.find((b) => a.identifier == b.identifier));
 
-    let touchEventDict: TouchEventInit = {
+    const touchEventDict: TouchEventInit = {
       bubbles: true,
       // Ending touchpoints should NOT show up in `touches`.
       touches: state == 'end' ? otherTouches : changedTouches.concat(otherTouches),
       changedTouches: changedTouches,
     }
 
-    let buildEvent = (type: string, dict: TouchEventInit) => {
+    const buildEvent = (type: string, dict: TouchEventInit) => {
       if(window['TouchEvent'] !== undefined) {
         // Nothing beats the real thing.
         try {
@@ -145,10 +145,10 @@ export class InputSequenceSimulator<HoveredItemType> {
   }
 
   replayMouseSample(sample: JSONObject<InputSample<HoveredItemType>>, state: string, targetElement?: HTMLElement) {
-    let config = this.controller.recognizer.config;
+    const config = this.controller.recognizer.config;
 
     let event: MouseEvent;
-    let eventDict: MouseEventInit = {
+    const eventDict: MouseEventInit = {
       bubbles: true,
       buttons: state == 'end' ? 0 : 1,
       ...this.getSampleClientPos(sample)
@@ -186,7 +186,7 @@ export class InputSequenceSimulator<HoveredItemType> {
    */
   private replayCore(sequenceTestSpec: RecordedCoordSequenceSet,
     replayExecutor: (func: () => void, timestamp: number) => void): number {
-    let inputs = sequenceTestSpec.inputs;
+    const inputs = sequenceTestSpec.inputs;
     const config = sequenceTestSpec.config;
 
     this.controller.layoutConfiguration = new FixtureLayoutConfiguration(config);
@@ -198,8 +198,8 @@ export class InputSequenceSimulator<HoveredItemType> {
      * next sample to be 'replayed'.  If the full sequence has already been
      * replayed, its corresponding entry will be set to Number.MAX_VALUE instead.
      */
-    let sequenceProgress: number[] = new Array(inputs.length).fill(0);
-    let sequenceTouches: Touch[] = new Array(inputs.length).fill(null);
+    const sequenceProgress: number[] = new Array(inputs.length).fill(0);
+    const sequenceTouches: Touch[] = new Array(inputs.length).fill(null);
 
     let lastTimestamp = null;
 
@@ -320,7 +320,7 @@ export class InputSequenceSimulator<HoveredItemType> {
     // We technically don't have access to 'samples' for the actual recorded object.
     // Obtaining a 'deep copy' (though methodless) works around this nicely and
     // matches the original `sequenceTestSpec`'s format to boot.
-    let recording = JSON.parse(recorder.recordingsToJSON()) as RecordedCoordSequenceSet;
+    const recording = JSON.parse(recorder.recordingsToJSON()) as RecordedCoordSequenceSet;
     recorder.clear();
     return recording;
   }
@@ -357,7 +357,7 @@ export class InputSequenceSimulator<HoveredItemType> {
         // We technically don't have access to 'samples' for the actual recorded object.
         // Obtaining a 'deep copy' (though methodless) works around this nicely and
         // matches the original `sequenceTestSpec`'s format to boot.
-        let recording = JSON.parse(recorder.recordingsToJSON()) as RecordedCoordSequenceSet;
+        const recording = JSON.parse(recorder.recordingsToJSON()) as RecordedCoordSequenceSet;
         recorder.clear();
         resolve(recording);
       }, finalTimestamp + 30);

--- a/web/src/engine/osk/gesture-processor/src/tools/unit-test-resources/src/sequenceRecorder.ts
+++ b/web/src/engine/osk/gesture-processor/src/tools/unit-test-resources/src/sequenceRecorder.ts
@@ -41,15 +41,15 @@ export class SequenceRecorder {
   }
 
   public recordingsToJSON() {
-    let arr = [];
+    const arr = [];
 
     // Ensure a deterministic ordering for the recording's sequences.
     // This facilitates copmarison checks needed for unit testing.
-    for(let entry of this.startOrder) {
+    for(const entry of this.startOrder) {
       arr.push(this.records[entry].toJSON());
     }
 
-    let jsonOut: RecordedCoordSequenceSet = {
+    const jsonOut: RecordedCoordSequenceSet = {
       inputs: arr,
       config: this.controller.layoutConfiguration
     }

--- a/web/src/engine/osk/gesture-processor/src/tools/unit-test-resources/src/touchpathTurtle.ts
+++ b/web/src/engine/osk/gesture-processor/src/tools/unit-test-resources/src/touchpathTurtle.ts
@@ -113,7 +113,7 @@ export class TouchpathTurtle<HoveredItemType> extends EventEmitter<EventMap<Hove
 
     // Base sample always exists in advance.
     for(let i = 1; i <= sampleCount; i++) {
-      let sample = {...startSample};
+      const sample = {...startSample};
       sample.t += timeDelta * i;
       this.trackSample(sample);
     }
@@ -131,9 +131,9 @@ export class TouchpathTurtle<HoveredItemType> extends EventEmitter<EventMap<Hove
       throw new Error("Invalid parameter value:  may not be negative!");
     }
 
-    let angle = (90 - angleInDegrees) * Math.PI / 180;
-    let xDistance = Math.cos(angle) * distance;
-    let yDistance = -Math.sin(angle) * distance;
+    const angle = (90 - angleInDegrees) * Math.PI / 180;
+    const xDistance = Math.cos(angle) * distance;
+    const yDistance = -Math.sin(angle) * distance;
 
     const xTickDist = xDistance / sampleCount;
     const yTickDist = yDistance / sampleCount;

--- a/web/src/engine/osk/src/banner/banner.ts
+++ b/web/src/engine/osk/src/banner/banner.ts
@@ -51,9 +51,9 @@ export abstract class Banner {
    * Description   Update the height and display styling of the banner
    */
   protected update() : boolean {
-    let ds = this.div.style;
-    let currentHeightStyle = ds.height;
-    let currentDisplayStyle = ds.display;
+    const ds = this.div.style;
+    const currentHeightStyle = ds.height;
+    const currentDisplayStyle = ds.display;
 
     if (this._height > 0) {
       ds.height = this._height + 'px';
@@ -68,7 +68,7 @@ export abstract class Banner {
   }
 
   public constructor(height?: number) {
-    let d = createUnselectableElement('div');
+    const d = createUnselectableElement('div');
     d.id = Banner.BANNER_ID;
     d.className = Banner.BANNER_CLASS;
     this.div = d;

--- a/web/src/engine/osk/src/banner/bannerController.ts
+++ b/web/src/engine/osk/src/banner/bannerController.ts
@@ -77,7 +77,7 @@ export class BannerController {
     if(!on) {
       this.container.banner = this.inactiveBanner;
     } else {
-      let suggestBanner = new SuggestionBanner(this.hostDevice, this.container.activeBannerHeight);
+      const suggestBanner = new SuggestionBanner(this.hostDevice, this.container.activeBannerHeight);
       suggestBanner.predictionContext = this.predictionContext;
 
       // Registers for prediction-engine events & handles its needed connections.

--- a/web/src/engine/osk/src/banner/bannerScrollState.ts
+++ b/web/src/engine/osk/src/banner/bannerScrollState.ts
@@ -29,10 +29,10 @@ export class BannerScrollState {
   }
 
   updateTo(coord: InputSample<any>): number {
-    let prevCoord = this.curCoord;
+    const prevCoord = this.curCoord;
     this.curCoord = coord;
 
-    let delta = this.baseCoord.targetX - this.curCoord.targetX + this.baseScrollLeft;
+    const delta = this.baseCoord.targetX - this.curCoord.targetX + this.baseScrollLeft;
     // Track the total amount of scrolling used, even if just a pixel-wide back and forth wiggle.
     this.totalLength += Math.abs(this.curCoord.targetX - prevCoord.targetX);
 

--- a/web/src/engine/osk/src/banner/bannerView.ts
+++ b/web/src/engine/osk/src/banner/bannerView.ts
@@ -47,7 +47,7 @@ export class BannerView implements OSKViewComponent {
    * Constructs the <div> element used to contain hot-swapped `Banner` instances.
    */
   private constructContainer(): HTMLDivElement {
-    let d = createUnselectableElement('div');
+    const d = createUnselectableElement('div');
     d.id = "keymanweb_banner_container";
     d.className = "kmw-banner-container";
     return this.bannerContainer = d;
@@ -83,7 +83,7 @@ export class BannerView implements OSKViewComponent {
       if(banner == this.currentBanner) {
         return;
       } else {
-        let prevBanner = this.currentBanner;
+        const prevBanner = this.currentBanner;
         this.currentBanner = banner;
         this.bannerContainer.replaceChild(banner.getDiv(), prevBanner.getDiv());
         prevBanner.shutdown();

--- a/web/src/engine/osk/src/banner/imageBanner.ts
+++ b/web/src/engine/osk/src/banner/imageBanner.ts
@@ -29,7 +29,7 @@ export class ImageBanner extends Banner {
     }
     this.img = document.createElement('img');
     this.img.setAttribute('src', imagePath);
-    let ds = this.img.style;
+    const ds = this.img.style;
 
     // We may want to eliminate the width-spec in the future, once we're sure of
     // no unintended side-effects for iOS's use of this banner.

--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -105,7 +105,7 @@ export class BannerSuggestion {
 
     // Provides an empty, base SPAN for text display.  We'll swap these out regularly;
     // `Suggestion`s will have varying length and may need different styling.
-    let display = this.display = createUnselectableElement('span');
+    const display = this.display = createUnselectableElement('span');
     display.className = 'kmw-suggestion-text';
     this.container.appendChild(display);
   }
@@ -116,20 +116,20 @@ export class BannerSuggestion {
 
   private constructRoot() {
     // Add OSK suggestion labels
-    let div = this.div = createUnselectableElement('div');
+    const div = this.div = createUnselectableElement('div');
     div.className = "kmw-suggest-option";
     div.id = BannerSuggestion.BASE_ID + this.index;
 
     // @ts-ignore // Tags the element with its backing object.
     this.div['suggestion'] = this;
 
-    let container = this.container = document.createElement('div');
+    const container = this.container = document.createElement('div');
     container.className = "kmw-suggestion-container";
 
     // Ensures that a reasonable default width, based on % is set. (Since it's not yet in the DOM, we may not yet have actual width info.)
-    let usableWidth = 100 - SuggestionBanner.MARGIN * (SuggestionBanner.LONG_SUGGESTION_DISPLAY_LIMIT - 1);
+    const usableWidth = 100 - SuggestionBanner.MARGIN * (SuggestionBanner.LONG_SUGGESTION_DISPLAY_LIMIT - 1);
 
-    let widthpc = usableWidth / (SuggestionBanner.LONG_SUGGESTION_DISPLAY_LIMIT);
+    const widthpc = usableWidth / (SuggestionBanner.LONG_SUGGESTION_DISPLAY_LIMIT);
     container.style.minWidth = widthpc + '%';
 
     div.appendChild(container);
@@ -144,7 +144,7 @@ export class BannerSuggestion {
       }
 
       // Establish base font settings
-      let font = keyboardProperties['KFont'];
+      const font = keyboardProperties['KFont'];
       if(font && font.family && font.family != '') {
         div.style.fontFamily = font.family;
       }
@@ -165,7 +165,7 @@ export class BannerSuggestion {
   public update(suggestion: LexicalModelTypes.Suggestion, format: BannerSuggestionFormatSpec) {
     this._suggestion = suggestion;
 
-    let display = this.generateSuggestionText(this.rtl);
+    const display = this.generateSuggestionText(this.rtl);
     this.container.replaceChild(display, this.display);
     this.display = display;
 
@@ -310,9 +310,9 @@ export class BannerSuggestion {
    */
   public get collapsedWidth(): number {
     // Allow shrinking a suggestion's width if it has excess whitespace.
-    let utilizedWidth = this.spanWidth < this.targetCollapsedWidth ? this.spanWidth : this.targetCollapsedWidth;
+    const utilizedWidth = this.spanWidth < this.targetCollapsedWidth ? this.spanWidth : this.targetCollapsedWidth;
     // If a minimum width has been specified, enforce that minimum.
-    let maxWidth = utilizedWidth < this.expandedWidth ? utilizedWidth : this.expandedWidth;
+    const maxWidth = utilizedWidth < this.expandedWidth ? utilizedWidth : this.expandedWidth;
 
     // Will return maxWidth if this.minWidth is undefined.
     return (this.minWidth > maxWidth ? this.minWidth : maxWidth);
@@ -366,10 +366,10 @@ export class BannerSuggestion {
    */
   //
   public generateSuggestionText(rtl: boolean): HTMLSpanElement {
-    let suggestion = this._suggestion;
-    var suggestionText: string;
+    const suggestion = this._suggestion;
+    let suggestionText: string;
 
-    var s=createUnselectableElement('span');
+    const s=createUnselectableElement('span');
     s.className = 'kmw-suggestion-text';
 
     if(suggestion == null) {
@@ -380,7 +380,7 @@ export class BannerSuggestion {
       suggestionText = '\xa0';  // default:  nbsp.
     } else {
       // Default the LTR ordering to match that of the active keyboard.
-      let orderCode = rtl ? 0x202e /* RTL */ : 0x202d /* LTR */;
+      const orderCode = rtl ? 0x202e /* RTL */ : 0x202d /* LTR */;
       suggestionText = String.fromCharCode(orderCode) + suggestion.displayAs;
     }
 
@@ -448,8 +448,8 @@ export class SuggestionBanner extends Banner {
       this.separators = [];
     }
 
-    for (var i=0; i<SuggestionBanner.SUGGESTION_LIMIT; i++) {
-      let d = new BannerSuggestion(i, rtl);
+    for (let i=0; i<SuggestionBanner.SUGGESTION_LIMIT; i++) {
+      const d = new BannerSuggestion(i, rtl);
       this.options[i] = d;
     }
 
@@ -460,8 +460,8 @@ export class SuggestionBanner extends Banner {
       * the elements are inserted for RTL.  This allows the banner to be RTL
       * for visuals/UI while still being internally LTR.
       */
-    for (var i=0; i<SuggestionBanner.SUGGESTION_LIMIT; i++) {
-      let indexToInsert = rtl ? SuggestionBanner.SUGGESTION_LIMIT - i - 1 : i;
+    for (let i=0; i<SuggestionBanner.SUGGESTION_LIMIT; i++) {
+      const indexToInsert = rtl ? SuggestionBanner.SUGGESTION_LIMIT - i - 1 : i;
       this.container.appendChild(this.options[indexToInsert].div);
 
       // RTL should start right-aligned, thus @ max scroll.
@@ -471,10 +471,10 @@ export class SuggestionBanner extends Banner {
 
       if(i != SuggestionBanner.SUGGESTION_LIMIT - 1) {
         // Adds a 'separator' div element for UI purposes.
-        let separatorDiv = createUnselectableElement('div');
+        const separatorDiv = createUnselectableElement('div');
         separatorDiv.className = 'kmw-banner-separator';
 
-        let ds = separatorDiv.style;
+        const ds = separatorDiv.style;
         ds.marginLeft = `calc(${(SuggestionBanner.MARGIN / 2)}% - 0.5px)`;
         ds.marginRight = `calc(${(SuggestionBanner.MARGIN / 2)}% - 0.5px)`;
 
@@ -631,7 +631,7 @@ export class SuggestionBanner extends Banner {
           // auto-correct suggestion and its highlighting.
           this._predictionContext.selected = autoselection;
           if(autoselection) {
-            for(let entry of this.options) {
+            for(const entry of this.options) {
               if(entry.suggestion == autoselection) {
                 entry.highlight(true);
                 break;
@@ -758,7 +758,7 @@ export class SuggestionBanner extends Banner {
     const textLeftPad = new ParsedLengthStyle(textElementStyle.paddingLeft   || '4px');
     const textRightPad = new ParsedLengthStyle(textElementStyle.paddingRight || '4px');
 
-    let optionFormat: BannerSuggestionFormatSpec = {
+    const optionFormat: BannerSuggestionFormatSpec = {
       paddingWidth: textLeftPad.val + textRightPad.val, // Assumes fixed px padding.
       emSize: emSize,
       styleForFont: fontStyle,
@@ -785,7 +785,7 @@ export class SuggestionBanner extends Banner {
   }
 
   readonly refreshLayout = () => {
-    let collapsedOptions: BannerSuggestion[] = [];
+    const collapsedOptions: BannerSuggestion[] = [];
     let totalWidth = 0;
 
     let displayCount = Math.min(this.currentSuggestions.length, 8);
@@ -807,17 +807,17 @@ export class SuggestionBanner extends Banner {
     displayCount = displayCount || 1;
 
     if(totalWidth < this.width) {
-      let separatorWidth = (this.width * 0.01 * (displayCount-1));
+      const separatorWidth = (this.width * 0.01 * (displayCount-1));
       // Prioritize adding padding to suggestions that actually need it.
       // Use equal measure for each so long as it still could use extra display space.
       while(totalWidth < this.width && collapsedOptions.length > 0) {
-        let maxFillPadding = (this.width - totalWidth - separatorWidth) / collapsedOptions.length;
+        const maxFillPadding = (this.width - totalWidth - separatorWidth) / collapsedOptions.length;
         collapsedOptions.sort((a, b) => a.expandedWidth - b.expandedWidth);
 
-        let shortestCollapsed = collapsedOptions[0];
-        let neededWidth = shortestCollapsed.expandedWidth - shortestCollapsed.collapsedWidth;
+        const shortestCollapsed = collapsedOptions[0];
+        const neededWidth = shortestCollapsed.expandedWidth - shortestCollapsed.collapsedWidth;
 
-        let padding = Math.min(neededWidth, maxFillPadding);
+        const padding = Math.min(neededWidth, maxFillPadding);
 
         // Check: it is possible that two elements were matched for equal length, thus the second loop's takes no additional padding.
         // No need to trigger re-layout ops for that case.
@@ -830,7 +830,7 @@ export class SuggestionBanner extends Banner {
       }
 
       // If there's STILL leftover padding to distribute, let's do that now.
-      let fillPadding = (this.width - totalWidth - separatorWidth) / displayCount;
+      const fillPadding = (this.width - totalWidth - separatorWidth) / displayCount;
 
       for(let i=0; i < displayCount; i++) {
         const d = this.options[i];
@@ -1005,8 +1005,8 @@ class SuggestionExpandContractAnimation {
     // set timestamp, adjusting the current time based on intermediate progress
     this.startTimestamp = performance.now();
 
-    let progress = this.option.currentWidth - this.option.collapsedWidth;
-    let expansionDiff = this.option.expandedWidth - this.option.collapsedWidth;
+    const progress = this.option.currentWidth - this.option.collapsedWidth;
+    const expansionDiff = this.option.expandedWidth - this.option.collapsedWidth;
 
     if(progress != 0) {
       // Offset the timestamp by noting what start time would have given rise to
@@ -1023,15 +1023,15 @@ class SuggestionExpandContractAnimation {
     }
 
     let progressTime = timestamp - this.startTimestamp;
-    let fin = progressTime > SuggestionExpandContractAnimation.TRANSITION_TIME;
+    const fin = progressTime > SuggestionExpandContractAnimation.TRANSITION_TIME;
 
     if(fin) {
       progressTime = SuggestionExpandContractAnimation.TRANSITION_TIME;
     }
 
     // -- Part 1:  handle option expand / collapse state --
-    let expansionDiff = this.option.expandedWidth - this.option.collapsedWidth;
-    let expansionRatio = progressTime / SuggestionExpandContractAnimation.TRANSITION_TIME;
+    const expansionDiff = this.option.expandedWidth - this.option.collapsedWidth;
+    const expansionRatio = progressTime / SuggestionExpandContractAnimation.TRANSITION_TIME;
 
     // expansionDiff * expansionRatio:  the total adjustment from 'collapsed' width, in px.
     const expansionPx = expansionDiff * expansionRatio;
@@ -1056,8 +1056,8 @@ class SuggestionExpandContractAnimation {
     // set timestamp, adjusting the current time based on intermediate progress
     this.startTimestamp = performance.now();
 
-    let progress = this.option.expandedWidth - this.option.currentWidth;
-    let expansionDiff = this.option.expandedWidth - this.option.collapsedWidth;
+    const progress = this.option.expandedWidth - this.option.currentWidth;
+    const expansionDiff = this.option.expandedWidth - this.option.collapsedWidth;
 
     if(progress != 0) {
       // Offset the timestamp by noting what start time would have given rise to
@@ -1074,14 +1074,14 @@ class SuggestionExpandContractAnimation {
     }
 
     let progressTime = timestamp - this.startTimestamp;
-    let fin = progressTime > SuggestionExpandContractAnimation.TRANSITION_TIME;
+    const fin = progressTime > SuggestionExpandContractAnimation.TRANSITION_TIME;
     if(fin) {
       progressTime = SuggestionExpandContractAnimation.TRANSITION_TIME;
     }
 
     // -- Part 1:  handle option expand / collapse state --
-    let expansionDiff = this.option.expandedWidth - this.option.collapsedWidth;
-    let expansionRatio = 1 - progressTime / SuggestionExpandContractAnimation.TRANSITION_TIME;
+    const expansionDiff = this.option.expandedWidth - this.option.collapsedWidth;
+    const expansionRatio = 1 - progressTime / SuggestionExpandContractAnimation.TRANSITION_TIME;
 
     // expansionDiff * expansionRatio:  the total adjustment from 'collapsed' width, in px.
     const expansionPx = expansionDiff * expansionRatio;

--- a/web/src/engine/osk/src/buttonClassNames.ts
+++ b/web/src/engine/osk/src/buttonClassNames.ts
@@ -2,7 +2,7 @@
 /**
  * Maps 'sp' properties on a touch-layout spec to their corresponding CSS class names.
  */
-let BUTTON_CLASSES = [
+const BUTTON_CLASSES = [
   'default',
   'shift',
   'shift-on',

--- a/web/src/engine/osk/src/components/emptyView.ts
+++ b/web/src/engine/osk/src/components/emptyView.ts
@@ -5,7 +5,7 @@ export default class EmptyView implements KeyboardView {
   readonly element: HTMLDivElement;
 
   constructor() {
-    let Ldiv = this.element = document.createElement('div');
+    const Ldiv = this.element = document.createElement('div');
     Ldiv.style.userSelect = 'none';
     Ldiv.className='kmw-osk-none';
   }

--- a/web/src/engine/osk/src/components/helpPageView.ts
+++ b/web/src/engine/osk/src/components/helpPageView.ts
@@ -12,7 +12,7 @@ export default class HelpPageView implements KeyboardView {
   constructor(keyboard: Keyboard) {
     this.kbd = keyboard;
 
-    var Ldiv = this.element = document.createElement('div');
+    const Ldiv = this.element = document.createElement('div');
     Ldiv.style.userSelect = "none";
     Ldiv.className = 'kmw-osk-static';
     Ldiv.id = HelpPageView.ID;

--- a/web/src/engine/osk/src/components/resizeBar.ts
+++ b/web/src/engine/osk/src/components/resizeBar.ts
@@ -54,12 +54,12 @@ export default class ResizeBar extends EventEmitter<EventMap, ResizeBar> impleme
    * Create a bottom bar with a resizing icon for the desktop OSK
    */
   buildResizeBar(): HTMLDivElement {
-    var bar = createUnselectableElement('div');
+    const bar = createUnselectableElement('div');
     bar.className='kmw-footer';
     bar.onmousedown = this.mouseCancellingHandler;
 
     // Add caption
-    var Ltitle=createUnselectableElement('div');
+    const Ltitle=createUnselectableElement('div');
     Ltitle.className='kmw-footer-caption';
     Ltitle.innerHTML='<a href="https://keyman.com/developer/keymanweb/">KeymanWeb</a>';
     Ltitle.id='keymanweb-osk-footer-caption';
@@ -73,7 +73,7 @@ export default class ResizeBar extends EventEmitter<EventMap, ResizeBar> impleme
 
     bar.appendChild(Ltitle);
 
-    var Limg = createUnselectableElement('div');
+    const Limg = createUnselectableElement('div');
     Limg.className='kmw-footer-resize';
     bar.appendChild(Limg);
     this._resizeHandle=Limg;

--- a/web/src/engine/osk/src/components/titleBar.ts
+++ b/web/src/engine/osk/src/components/titleBar.ts
@@ -103,7 +103,7 @@ export default class TitleBar extends EventEmitter<EventMap, TitleBar> implement
   }
 
   public setTitleFromKeyboard(keyboard: Keyboard) {
-    let title = "<span style='font-weight:bold'>" + keyboard?.name + '</span>';  // I1972  // I2186
+    const title = "<span style='font-weight:bold'>" + keyboard?.name + '</span>';  // I1972  // I2186
     this._caption.innerHTML = title;
   }
 
@@ -111,16 +111,16 @@ export default class TitleBar extends EventEmitter<EventMap, TitleBar> implement
    * Create a control bar with title and buttons for the desktop OSK
    */
   buildTitleBar(): HTMLDivElement {
-    let bar = createUnselectableElement('div');
+    const bar = createUnselectableElement('div');
     bar.id='keymanweb_title_bar';
     bar.className='kmw-title-bar';
 
-    var Ltitle = this._caption = createUnselectableElement('span');
+    const Ltitle = this._caption = createUnselectableElement('span');
     Ltitle.className='kmw-title-bar-caption';
     Ltitle.style.color='#fff';
     bar.appendChild(Ltitle);
 
-    var Limg = this._closeButton = this.buildCloseButton();
+    let Limg = this._closeButton = this.buildCloseButton();
     this._closeButton.onclick = () => {
       this.emit('close');
       return false;
@@ -152,7 +152,7 @@ export default class TitleBar extends EventEmitter<EventMap, TitleBar> implement
   }
 
   private buildCloseButton(): HTMLDivElement {
-    var Limg = createUnselectableElement('div');
+    const Limg = createUnselectableElement('div');
 
     Limg.id='kmw-close-button';
     Limg.className='kmw-title-bar-image';
@@ -162,7 +162,7 @@ export default class TitleBar extends EventEmitter<EventMap, TitleBar> implement
   }
 
   private buildHelpButton(): HTMLDivElement {
-    let Limg = createUnselectableElement('div');
+    const Limg = createUnselectableElement('div');
     Limg.id='kmw-help-image';
     Limg.className='kmw-title-bar-image';
     Limg.title='KeymanWeb Help';
@@ -171,7 +171,7 @@ export default class TitleBar extends EventEmitter<EventMap, TitleBar> implement
   }
 
   private buildConfigButton(): HTMLDivElement {
-    let Limg = createUnselectableElement('div');
+    const Limg = createUnselectableElement('div');
 
     Limg.id='kmw-config-image';
     Limg.className='kmw-title-bar-image';
@@ -185,7 +185,7 @@ export default class TitleBar extends EventEmitter<EventMap, TitleBar> implement
    * Builds an 'unpin' button for restoring OSK to default location, handle mousedown and click events
    */
   private buildUnpinButton(): HTMLDivElement {
-    let Limg = createUnselectableElement('div');  //I2186
+    const Limg = createUnselectableElement('div');  //I2186
 
     Limg.id = 'kmw-pin-image';
     Limg.className = 'kmw-title-bar-image';

--- a/web/src/engine/osk/src/corrections.ts
+++ b/web/src/engine/osk/src/corrections.ts
@@ -11,7 +11,7 @@ import { CorrectionLayout } from "./correctionLayout.js";
  * @returns A mapping of key IDs to the 'squared pseudo-distance' of the touchpoint to each key.
  */
 export function keyTouchDistances(touchCoords: {x: number, y: number}, correctiveLayout: CorrectionLayout): Map<ActiveKeyBase, number> {
-  let keyDists: Map<ActiveKeyBase, number> = new Map<ActiveKeyBase, number>();
+  const keyDists: Map<ActiveKeyBase, number> = new Map<ActiveKeyBase, number>();
 
   // This loop computes a pseudo-distance for the touch from each key. Quite useful for
   // generating a probability distribution.
@@ -74,10 +74,10 @@ export function distributionFromDistanceMaps(squaredDistMaps: Map<ActiveKeyBase,
     squaredDistMaps = [squaredDistMaps];
   }
 
-  for(let squaredDistMap of squaredDistMaps) {
+  for(const squaredDistMap of squaredDistMaps) {
     // Should we wish to allow multiple different transforms for distance -> probability, use a function parameter in place
     // of the formula in the loop below.
-    for(let key of squaredDistMap.keys()) {
+    for(const key of squaredDistMap.keys()) {
       // We've found that in practice, dist^-4 seems to work pretty well.  (Our input has dist^2.)
       // (Note:  our rule of thumb here has only been tested for layout-based distances.)
       //
@@ -95,7 +95,7 @@ export function distributionFromDistanceMaps(squaredDistMaps: Map<ActiveKeyBase,
 
   const list: {keySpec: ActiveKeyBase, p: number}[] = [];
 
-  for(let key of keyProbs.keys()) {
+  for(const key of keyProbs.keys()) {
     list.push({keySpec: key, p: keyProbs.get(key) / totalMass});
   }
 

--- a/web/src/engine/osk/src/fontSizeUtils.ts
+++ b/web/src/engine/osk/src/fontSizeUtils.ts
@@ -2,7 +2,7 @@ import { DeviceSpec } from "@keymanapp/web-utils";
 import { ParsedLengthStyle } from "./lengthStyle.js";
 
 export function getFontSizeStyle(e: HTMLElement|string): {val: number, absolute: boolean} {
-  var fs: string;
+  let fs: string;
 
   if(typeof e == 'string') {
     fs = e;

--- a/web/src/engine/osk/src/input/gestures/browser/flick.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/flick.ts
@@ -53,7 +53,7 @@ export function buildFlickScroller(
     const lockedAngle = lockedAngleForDir(lockedDir);
 
     const maxProgressDist = gestureParams.flick.triggerDist - gestureParams.flick.dirLockDist;
-    let progressDist =  Math.max(0, calcLockedDistance(source.path.stats, lockedDir) - gestureParams.flick.dirLockDist);
+    const progressDist =  Math.max(0, calcLockedDistance(source.path.stats, lockedDir) - gestureParams.flick.dirLockDist);
 
     // Make progress appear slightly less than it really is; 'near complete' slides thus actually are, so
     // the user doesn't get aggrevated by 'near misses' in that regard.
@@ -62,7 +62,7 @@ export function buildFlickScroller(
     // This is about when the flick's key-cap preview starts becoming "mostly visible".
     const FUDGE_SCALE_FACTOR = 0.7;
     // Prevent overshoot
-    let slidePc = Math.min(1, FUDGE_SCALE_FACTOR * progressDist / maxProgressDist);
+    const slidePc = Math.min(1, FUDGE_SCALE_FACTOR * progressDist / maxProgressDist);
 
     const previewX =  Math.sin(lockedAngle) * slidePc;
     const previewY = -Math.cos(lockedAngle) * slidePc;

--- a/web/src/engine/osk/src/input/gestures/browser/keytip.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/keytip.ts
@@ -41,7 +41,7 @@ export default class KeyTip implements KeyTipInterface {
    */
   constructor(vkbd: VisualKeyboard, constrain: boolean) {
     this.vkbd = vkbd;
-    let tipElement = this.element=document.createElement('div');
+    const tipElement = this.element=document.createElement('div');
     tipElement.className='kmw-keytip';
     tipElement.id = 'kmw-keytip';
 
@@ -84,16 +84,16 @@ export default class KeyTip implements KeyTipInterface {
       // The key element is positioned relative to its key-square, which is,
       // in turn, relative to its row.  Rows take 100% width, so this is sufficient.
       //
-      let rowElement = (key.key as OSKBaseKey).row.element;
+      const rowElement = (key.key as OSKBaseKey).row.element;
 
       // May need adjustment for borders if ever enabled for the desktop form-factor target.
-      let rkey = key.getClientRects()[0], rrow = rowElement.getClientRects()[0];
-      let xLeft = rkey.left - rrow.left,
-          xWidth = rkey.width,
-          xHeight = rkey.height,
-          previewFontScale = 1.8;
+      const rkey = key.getClientRects()[0], rrow = rowElement.getClientRects()[0];
+      let xLeft = rkey.left - rrow.left;
+      const xWidth = rkey.width,
+            xHeight = rkey.height,
+            previewFontScale = 1.8;
 
-      let kts = this.element.style;
+      const kts = this.element.style;
 
       // Roughly matches how the subkey positioning is set.
       const _Box = vkbd.topContainer as HTMLDivElement;
@@ -104,12 +104,12 @@ export default class KeyTip implements KeyTipInterface {
       const orientation = this.orientation;
       const distFromTop = keyRect.bottom - _BoxRect.top;
       y = (distFromTop + (orientation == 'top' ? 1 : -1));
-      let ySubPixelPadding = y - Math.floor(y);
+      const ySubPixelPadding = y - Math.floor(y);
 
       // Canvas dimensions must be set explicitly to prevent clipping
       // This gives us exactly the same number of pixels on left and right
-      let canvasWidth = xWidth + Math.ceil(xWidth * 0.3) * 2;
-      let canvasHeight = Math.ceil(2.3 * xHeight) + (ySubPixelPadding); //
+      const canvasWidth = xWidth + Math.ceil(xWidth * 0.3) * 2;
+      const canvasHeight = Math.ceil(2.3 * xHeight) + (ySubPixelPadding); //
 
       if(orientation == 'bottom') {
         y += canvasHeight - xHeight;
@@ -134,13 +134,13 @@ export default class KeyTip implements KeyTipInterface {
       const ckts = getComputedStyle(vkbd.element);
       kts.fontFamily = key.key.spec.font || layerFontFamily || ckts.fontFamily;
 
-      var px=parseInt(ckts.fontSize,10);
+      let px=parseInt(ckts.fontSize,10);
       if(px == Number.NaN) {
         px = 0;
       }
 
       if(px != 0) {
-        let scaleStyle = {
+        const scaleStyle = {
           keyWidth: 1.6 * xWidth,
           keyHeight: 1.6 * xHeight, // as opposed to the canvas height of 2.3 * xHeight.
           baseEmFontSize: vkbd.getKeyEmFontSize(),
@@ -151,7 +151,7 @@ export default class KeyTip implements KeyTipInterface {
       }
 
       // Adjust shape if at edges
-      var xOverflow = (canvasWidth - xWidth) / 2;
+      const xOverflow = (canvasWidth - xWidth) / 2;
       if(xLeft < xOverflow) {
         this.cap.style.left = '1px';
         xLeft += xOverflow - 1;
@@ -164,11 +164,11 @@ export default class KeyTip implements KeyTipInterface {
 
       kts.left=(xLeft - xOverflow) + 'px';
 
-      let cs = getComputedStyle(this.element);
-      let oskHeight = _BoxRect.height;
-      let bottomY = parseFloat(cs.bottom);
-      let tipHeight = parseFloat(cs.height);
-      let halfHeight = Math.ceil(canvasHeight / 2);
+      const cs = getComputedStyle(this.element);
+      const oskHeight = _BoxRect.height;
+      const bottomY = parseFloat(cs.bottom);
+      const tipHeight = parseFloat(cs.height);
+      const halfHeight = Math.ceil(canvasHeight / 2);
 
       this.cap.style.width = xWidth + 'px';
       this.tip.style.height = halfHeight + 'px';

--- a/web/src/engine/osk/src/input/gestures/browser/multitap.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/multitap.ts
@@ -200,7 +200,7 @@ export default class Multitap implements GestureHandler {
     const baseProb = baseDistribution.splice(keyIndex, 1)[0].p;
 
     let totalWeight = 0;
-    let multitapEntries: {keySpec: ActiveKeyBase, p: number}[] = [];
+    const multitapEntries: {keySpec: ActiveKeyBase, p: number}[] = [];
     for(let i = 0; i < this.multitaps.length; i++) {
       const key = this.multitaps[i];
       // 'standard distance', no real modular effects needed.

--- a/web/src/engine/osk/src/input/gestures/browser/oskSubKey.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/oskSubKey.ts
@@ -20,10 +20,10 @@ export default class OSKSubKey extends OSKKey {
   }
 
   construct(osk: VisualKeyboard, baseKey: KeyElement, width: number, topMargin: boolean): HTMLDivElement {
-    let spec = this.spec;
+    const spec = this.spec;
 
-    let kDiv=document.createElement('div');
-    let ks=kDiv.style;
+    const kDiv=document.createElement('div');
+    const ks=kDiv.style;
 
     kDiv.className='kmw-key-square-ex';
     if(topMargin) {
@@ -33,14 +33,14 @@ export default class OSKSubKey extends OSKKey {
     ks.width=width+'px';
     ks.height=baseKey.offsetHeight+'px';
 
-    let btnEle=document.createElement('div');
-    let btn = this.btn = link(btnEle, new KeyData(this, spec['id']));
+    const btnEle=document.createElement('div');
+    const btn = this.btn = link(btnEle, new KeyData(this, spec['id']));
 
     this.setButtonClass();
     btn.id = this.getId();
 
     // Must set button size (in px) dynamically, not from CSS
-    let bs=btn.style;
+    const bs=btn.style;
     bs.height=ks.height;
     bs.lineHeight=baseKey.style.lineHeight;
     bs.width=ks.width;

--- a/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
@@ -121,7 +121,7 @@ export default class SubkeyPopup implements GestureHandler {
     e.key.highlight(true);
 
     // A tag we directly set on a key element during its construction.
-    let subKeySpec: ActiveSubKey[] = e['subKeys'];
+    const subKeySpec: ActiveSubKey[] = e['subKeys'];
 
     // The holder is position:fixed, but the keys do not need to be, as no scrolling
     // is possible while the array is visible.  So it is simplest to let the keys have
@@ -133,7 +133,7 @@ export default class SubkeyPopup implements GestureHandler {
     // #3718: No longer prepend base key to popup array
 
     // Must set position dynamically, not in CSS
-    var ss=elements.style;
+    const ss=elements.style;
 
     // Set key font according to layout, or defaulting to OSK font
     // (copied, not inherited, since OSK is not a parent of popup keys)
@@ -264,7 +264,7 @@ export default class SubkeyPopup implements GestureHandler {
         }
 
         // Step 2:  okay, selection is permitted.  So... what to select?
-        for(let key of this.subkeys) {
+        for(const key of this.subkeys) {
           const keyBounds = key.getBoundingClientRect();
 
           let xDist = Number.MAX_VALUE;
@@ -298,16 +298,16 @@ export default class SubkeyPopup implements GestureHandler {
   }
 
   reposition(vkbd: VisualKeyboard) {
-    let subKeys = this.element;
-    let e = this.baseKey;
+    const subKeys = this.element;
+    const e = this.baseKey;
 
     // And correct its position with respect to that element
     const _Box = vkbd.topContainer;
-    let rowElement = (e.key as OSKBaseKey).row.element;
-    let ss=subKeys.style;
-    let parentOffsetLeft = e.offsetParent ? (<HTMLElement>e.offsetParent).offsetLeft : 0;
-    var x = e.offsetLeft + parentOffsetLeft + 0.5*(e.offsetWidth-subKeys.offsetWidth);
-    var xMax = vkbd.width - subKeys.offsetWidth;
+    const rowElement = (e.key as OSKBaseKey).row.element;
+    const ss=subKeys.style;
+    const parentOffsetLeft = e.offsetParent ? (<HTMLElement>e.offsetParent).offsetLeft : 0;
+    let x = e.offsetLeft + parentOffsetLeft + 0.5*(e.offsetWidth-subKeys.offsetWidth);
+    const xMax = vkbd.width - subKeys.offsetWidth;
 
     if(x > xMax) {
       x=xMax;
@@ -317,18 +317,18 @@ export default class SubkeyPopup implements GestureHandler {
     }
     ss.left=x+'px';
 
-    let _BoxRect = _Box.getBoundingClientRect();
-    let rowElementRect = rowElement.getBoundingClientRect();
+    const _BoxRect = _Box.getBoundingClientRect();
+    const rowElementRect = rowElement.getBoundingClientRect();
     ss.top = (rowElementRect.top - _BoxRect.top - subKeys.offsetHeight - SUBKEY_MENU_VERT_OFFSET) + 'px';
 
     // Make the popup keys visible
     ss.visibility='visible';
 
     // For now, should only be true (in production) when keyman.isEmbedded == true.
-    let constrainPopup = vkbd.isEmbedded;
+    const constrainPopup = vkbd.isEmbedded;
 
-    let cs = getComputedStyle(subKeys);
-    let topY = parseFloat(cs.top);
+    const cs = getComputedStyle(subKeys);
+    const topY = parseFloat(cs.top);
 
     // Adjust the vertical position of the popup to keep it within the
     // bounds of the keyboard rectangle, when on iPhone (system keyboard)
@@ -362,14 +362,14 @@ export default class SubkeyPopup implements GestureHandler {
     const borderRadius = Math.max(Number.parseInt(cms.borderRadius), 0);
 
     // Create the callout
-    let keyRect = key.getBoundingClientRect();
-    let _BoxRect = _Box.getBoundingClientRect();
+    const keyRect = key.getBoundingClientRect();
+    const _BoxRect = _Box.getBoundingClientRect();
 
     // Set position and style
     // We're going to adjust the top of the box to ensure it stays
     // pixel aligned, otherwise we can get antialiasing artifacts
     // that look ugly
-    let calloutTop = Math.floor(
+    const calloutTop = Math.floor(
       Number.parseInt(cms.top, 10) +
       Number.parseInt(cms.height, 10) +
       // Padding is not included in content-box (or in content-box's top positioning)...
@@ -423,11 +423,11 @@ export default class SubkeyPopup implements GestureHandler {
   }
 
   selectDefaultSubkey(baseKey: KeyElement, popupBase: HTMLElement) {
-    var bk: KeyElement;
-    let subkeys = baseKey['subKeys'];
+    let bk: KeyElement;
+    const subkeys = baseKey['subKeys'];
     for(let i=0; i < subkeys.length; i++) {
-      let skSpec = subkeys[i];
-      let skElement = <KeyElement> popupBase.childNodes[i].firstChild;
+      const skSpec = subkeys[i];
+      const skElement = <KeyElement> popupBase.childNodes[i].firstChild;
 
       // Preference order:
       // #1:  if a default subkey has been specified, select it.
@@ -517,14 +517,14 @@ export default class SubkeyPopup implements GestureHandler {
      */
 
     // The concept:  how likely is it that the user MEANT to output a subkey?
-    let timeDistance = Math.min(
+    const timeDistance = Math.min(
       // The full path is included by the model - meaning the base wait is included here in
       // in the stats;  we subtract it to get just the duration of the subkey menu.
       gestureSource.path.stats.duration - baseStage.sources[0].path.stats.duration,
       this.gestureParams.longpress.waitLength
       ) / (2 * this.gestureParams.longpress.waitLength);  // normalize:  max time distance of 0.5
 
-    let pathDistance = Math.min(
+    const pathDistance = Math.min(
       gestureSource.path.stats.rawDistance,
       this.gestureParams.longpress.noiseTolerance*4
     ) / (this.gestureParams.longpress.noiseTolerance * 8); // normalize similarly.

--- a/web/src/engine/osk/src/input/gestures/specsForLayout.ts
+++ b/web/src/engine/osk/src/input/gestures/specsForLayout.ts
@@ -203,7 +203,7 @@ interface LayoutGestureSupportFlags {
 // Simple compile-time validation that OSKLayerGroup's spec object provides the fields expected above.
 let dummy: ActiveLayout;
 // @ts-ignore // so that we don't trigger "unused local" warnings.
-let dummy2: LayoutGestureSupportFlags = dummy;
+const dummy2: LayoutGestureSupportFlags = dummy;
 
 /**
  * Defines the set of gestures appropriate for use with the specified Keyman

--- a/web/src/engine/osk/src/keyElement.ts
+++ b/web/src/engine/osk/src/keyElement.ts
@@ -16,10 +16,10 @@ export type KeyElement = HTMLDivElement & KeyData;
 
 // Many thanks to https://www.typescriptlang.org/docs/handbook/advanced-types.html for this.
 export function link(elem: HTMLDivElement, data: KeyData): KeyElement {
-  let e = <KeyElement> elem;
+  const e = <KeyElement> elem;
 
   // Merges all properties and methods of KeyData onto the underlying HTMLDivElement, creating a merged class.
-  for(let id in data) {
+  for(const id in data) {
     if(!e.hasOwnProperty(id)) {
       (<any>e)[id] = (<any>data)[id];
     }

--- a/web/src/engine/osk/src/keyboard-layout/getTextMetrics.ts
+++ b/web/src/engine/osk/src/keyboard-layout/getTextMetrics.ts
@@ -29,10 +29,10 @@ export function getTextMetrics(text: string, emScale: number, style: {fontFamily
     style.fontSize = '1em';
   }
 
-  let fontFamily = style.fontFamily;
-  let fontSpec = getFontSizeStyle(style.fontSize);
+  const fontFamily = style.fontFamily;
+  const fontSpec = getFontSizeStyle(style.fontSize);
 
-  var fontSize: string;
+  let fontSize: string;
   if(fontSpec.absolute) {
     // We've already got an exact size - use it!
     fontSize = fontSpec.val + 'px';
@@ -43,9 +43,9 @@ export function getTextMetrics(text: string, emScale: number, style: {fontFamily
   // re-use canvas object for better performance
   metricsCanvas = metricsCanvas ?? document.createElement("canvas");
 
-  var context = metricsCanvas.getContext("2d");
+  const context = metricsCanvas.getContext("2d");
   context.font = fontSize + " " + fontFamily;
-  var metrics = context.measureText(text);
+  const metrics = context.measureText(text);
 
   return metrics;
 }

--- a/web/src/engine/osk/src/keyboard-layout/oskBaseKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskBaseKey.ts
@@ -35,7 +35,7 @@ export default class OSKBaseKey extends OSKKey {
   // Produces a small reference label for the corresponding physical key on a US keyboard.
   private generateKeyCapLabel(): HTMLDivElement {
     // Create the default key cap labels (letter keys, etc.)
-    var x = Codes.keyCodes[this.spec.baseKeyID];
+    let x = Codes.keyCodes[this.spec.baseKeyID];
     switch(x) {
       // Converts the keyman key id code for common symbol keys into its representative ASCII code.
       // K_COLON -> K_BKQUOTE
@@ -58,7 +58,7 @@ export default class OSKBaseKey extends OSKKey {
         }
     }
 
-    let q = document.createElement('div');
+    const q = document.createElement('div');
     q.className='kmw-key-label';
     if(x > 0) {
       q.innerText=String.fromCharCode(x);
@@ -71,11 +71,12 @@ export default class OSKBaseKey extends OSKKey {
 
   private processSubkeys(btn: KeyElement, vkbd: VisualKeyboard) {
     // Add reference to subkey array if defined
-    var bsn: number, bsk=btn['subKeys'] = this.spec['sk'];
+    let bsn: number;
+    const bsk=btn['subKeys'] = this.spec['sk'];
     // Transform any special keys into their PUA representations.
     for(bsn=0; bsn<bsk.length; bsn++) {
       if(bsk[bsn]['sp'] == 1 || bsk[bsn]['sp'] == 2) {
-        var oldText=bsk[bsn]['text'];
+        const oldText=bsk[bsn]['text'];
         bsk[bsn]['text']=renameSpecialKey(oldText, vkbd);
       }
 
@@ -87,19 +88,19 @@ export default class OSKBaseKey extends OSKKey {
   }
 
   construct(vkbd: VisualKeyboard): HTMLDivElement {
-    let spec = this.spec;
+    const spec = this.spec;
 
-    let kDiv = document.createElement('div');
+    const kDiv = document.createElement('div');
     kDiv.className='kmw-key-square';
 
-    let btnEle = document.createElement('div');
-    let btn = this.btn = link(btnEle, new KeyData(this, spec['id']));
+    const btnEle = document.createElement('div');
+    const btn = this.btn = link(btnEle, new KeyData(this, spec['id']));
 
     // Set button class
     this.setButtonClass();
 
     // Add the (US English) keycap label for layouts requesting display of underlying keys
-    let keyCap = this.capLabel = this.generateKeyCapLabel();
+    const keyCap = this.capLabel = this.generateKeyCapLabel();
     btn.appendChild(keyCap);
 
     // Define each key element id by layer id and key id (duplicate possible for SHIFT - does it matter?)

--- a/web/src/engine/osk/src/keyboard-layout/oskKey.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskKey.ts
@@ -43,7 +43,7 @@ export function renameSpecialKey(oldText: string, vkbd: VisualKeyboard): string 
  }
 
  const specialCode = specialChars[oldText as keyof typeof specialChars];
- let specialCodePUA = 0XE000 + specialCode;
+ const specialCodePUA = 0XE000 + specialCode;
 
  return specialCode ?
    String.fromCharCode(specialCodePUA) :
@@ -84,10 +84,10 @@ export default abstract class OSKKey {
    * @param       {Object=}   layout  source layout description (optional, sometimes)
    */
   public setButtonClass() {
-    let key = this.spec;
-    let btn = this.btn;
+    const key = this.spec;
+    const btn = this.btn;
 
-    var n=0;
+    let n=0;
     // @ts-ignore // (Probably) supports legacy KMW keyboards that predate the sp entry
     if(typeof key['dk'] == 'string' && key['dk'] == '1') {
       n=8;
@@ -110,9 +110,7 @@ export default abstract class OSKKey {
    * @param {boolean=} flag The new toggle state
    */
   public setToggleState(flag?: boolean) {
-    let btnClassId: number;
-
-    btnClassId = this.spec['sp'];
+    const btnClassId = this.spec.sp;
 
     // 1 + 2:   shift  +  shift-on
     // 3 + 4:  special + special-on
@@ -144,7 +142,7 @@ export default abstract class OSKKey {
 
   // "Frame key" - generally refers to non-linguistic keys on the keyboard
   public isFrameKey(): boolean {
-    let classIndex = this.spec['sp'] || 0;
+    const classIndex = this.spec['sp'] || 0;
     switch(buttonClassNames[classIndex]) {
       case 'default':
       case 'deadkey':
@@ -164,7 +162,7 @@ export default abstract class OSKKey {
   }
 
   public highlight(on: boolean) {
-    var classes=this.btn.classList;
+    const classes=this.btn.classList;
 
     if(on) {
       if(!classes.contains(OSKKey.HIGHLIGHT_CLASS)) {
@@ -211,24 +209,24 @@ export default abstract class OSKKey {
       height: layoutParams.keyHeight
     }
 
-    let metrics = getTextMetrics(text, emScale.scaledBy(scale).val, style);
+    const metrics = getTextMetrics(text, emScale.scaledBy(scale).val, style);
 
     const MAX_X_PROPORTION = 0.90;
     const MAX_Y_PROPORTION = 0.90;
     const X_PADDING = 2;
 
-    var fontHeight: number;
+    let fontHeight: number;
     if(metrics.fontBoundingBoxAscent) {
       fontHeight = metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent;
     }
 
     // Don't add extra padding to height - multiplying with MAX_Y_PROPORTION already gives
     // padding
-    let textHeight = fontHeight ?? 0;
-    let xProportion = (keyWidth * MAX_X_PROPORTION) / (metrics.width + X_PADDING); // How much of the key does the text want to take?
-    let yProportion = textHeight && keyHeight ? (keyHeight * MAX_Y_PROPORTION) / textHeight : undefined;
+    const textHeight = fontHeight ?? 0;
+    const xProportion = (keyWidth * MAX_X_PROPORTION) / (metrics.width + X_PADDING); // How much of the key does the text want to take?
+    const yProportion = textHeight && keyHeight ? (keyHeight * MAX_Y_PROPORTION) / textHeight : undefined;
 
-    var proportion: number = xProportion;
+    let proportion: number = xProportion;
     if(yProportion && yProportion < xProportion) {
       proportion = yProportion;
     }
@@ -264,12 +262,12 @@ export default abstract class OSKKey {
   protected generateKeyText(vkbd: VisualKeyboard): HTMLSpanElement {
     const spec = this.spec;
 
-    let t = document.createElement('span'), ts=t.style;
+    const t = document.createElement('span'), ts=t.style;
     t.className='kmw-key-text';
 
     // Add OSK key labels
     let keyText = this.keyText;
-    let specialText = renameSpecialKey(keyText, vkbd);
+    const specialText = renameSpecialKey(keyText, vkbd);
     if(specialText != keyText) {
       // The keyboard wants to use the code for a special glyph defined by the SpecialOSK font.
       keyText = specialText;
@@ -287,7 +285,7 @@ export default abstract class OSKKey {
 
     // For some reason, fonts will sometimes 'bug out' for the embedded iOS page if we
     // instead assign fontFamily to the existing style 'ts'.  (Occurs in iOS 12.)
-    let styleSpec: {fontFamily?: string, fontSize: string} = {fontSize: ts.fontSize};
+    const styleSpec: {fontFamily?: string, fontSize: string} = {fontSize: ts.fontSize};
 
     if(ts.fontFamily) {
       styleSpec.fontFamily = ts.fontFamily;

--- a/web/src/engine/osk/src/keyboard-layout/oskLayer.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskLayer.ts
@@ -46,7 +46,7 @@ export default class OSKLayer {
     const gs=gDiv.style;
     gDiv.className='kmw-key-layer';
 
-    var nRows=layer['row'].length;
+    const nRows=layer['row'].length;
     if(nRows > 4 && vkbd.device.formFactor == 'phone') {
       gDiv.className = gDiv.className + ' kmw-5rows';
     }
@@ -69,11 +69,11 @@ export default class OSKLayer {
     }
 
     // Create a DIV for each row of the group
-    let rows=layer['row'];
+    const rows=layer['row'];
     this.rows = [];
 
     for(let i=0; i<rows.length; i++) {
-      let rowObj = new OSKRow(vkbd, layer, rows[i]);
+      const rowObj = new OSKRow(vkbd, layer, rows[i]);
       rowObj.displaysKeyCaps = layout["displayUnderlying"];
       gDiv.appendChild(rowObj.element);
       this.rows.push(rowObj);
@@ -93,7 +93,7 @@ export default class OSKLayer {
 
     if(this.spaceBarKey) {
       const spacebarLabel = this.spaceBarKey.label;
-      let tButton = this.spaceBarKey.btn;
+      const tButton = this.spaceBarKey.btn;
 
       if (typeof (tButton.className) == 'undefined' || tButton.className == '') {
         tButton.className = 'kmw-spacebar';

--- a/web/src/engine/osk/src/keyboard-layout/oskLayerGroup.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskLayerGroup.ts
@@ -105,7 +105,7 @@ export default class OSKLayerGroup {
     // Trigger construction of the layer if it does not already exist.
     this.getLayer(id);
 
-    for (let key of Object.keys(this._layers)) {
+    for (const key of Object.keys(this._layers)) {
       const layer = this._layers[key];
       const layerElement = layer.element;
       if (layer.id == id) {
@@ -164,7 +164,7 @@ export default class OSKLayerGroup {
     // Note:  we do NOT manipulate `._activeLayerId` here!  This is designed
     // explicitly to be temporary.
     if(layer.element.style.display != 'block') {
-      for(let id in this._layers) {
+      for(const id in this._layers) {
         if(this._layers[id].element.style.display == 'block') {
           const priorLayer = this._layers[id];
           priorLayer.element.style.display = 'none';
@@ -237,7 +237,7 @@ export default class OSKLayerGroup {
     // Is percentage-based!
     let minDistance = Number.MAX_VALUE;
 
-    for (let key of row.keys) {
+    for (const key of row.keys) {
       const keySpec = key.spec;
       if(keySpec.sp == ButtonClasses.blank || keySpec.sp == ButtonClasses.spacer) {
         continue;
@@ -312,8 +312,8 @@ export default class OSKLayerGroup {
       const computedGroupStyle = getComputedStyle(this.element);
 
       // parseInt('') => NaN, which is falsy; we want to fallback to zero.
-      let pt = parseInt(computedGroupStyle.paddingTop, 10) || 0;
-      let pb = parseInt(computedGroupStyle.paddingBottom, 10) || 0;
+      const pt = parseInt(computedGroupStyle.paddingTop, 10) || 0;
+      const pb = parseInt(computedGroupStyle.paddingBottom, 10) || 0;
       this._heightPadding = pt + pb;
     }
 

--- a/web/src/engine/osk/src/keyboard-layout/oskRow.ts
+++ b/web/src/engine/osk/src/keyboard-layout/oskRow.ts
@@ -43,9 +43,9 @@ export default class OSKRow {
     // All key widths and paddings are rounded for uniformity
     for(let j=0; j<keys.length; j++) {
       const key = keys[j];
-      var keyObj = new OSKBaseKey(key as ActiveKey, layerSpec.id, this);
+      const keyObj = new OSKBaseKey(key as ActiveKey, layerSpec.id, this);
 
-      var element = keyObj.construct(vkbd);
+      const element = keyObj.construct(vkbd);
       this.keys.push(keyObj);
 
       rDiv.appendChild(element);

--- a/web/src/engine/osk/src/lengthStyle.ts
+++ b/web/src/engine/osk/src/lengthStyle.ts
@@ -10,7 +10,7 @@ export class ParsedLengthStyle implements LengthStyle {
   public readonly special: 'em' | 'rem';
 
   public constructor(style: LengthStyle | string) {
-    let parsed: LengthStyle = (typeof style == 'string') ? ParsedLengthStyle.parseLengthStyle(style) : style;
+    const parsed: LengthStyle = (typeof style == 'string') ? ParsedLengthStyle.parseLengthStyle(style) : style;
 
     // While Object.assign would be nice (and previously, was used), it will break
     // on old but still supported versions of Android if their Chrome isn't updated.

--- a/web/src/engine/osk/src/screenUtils.ts
+++ b/web/src/engine/osk/src/screenUtils.ts
@@ -16,7 +16,7 @@ export function getViewportScale(formFactor: DeviceSpec.FormFactor): number {
     }
 
     // Get viewport width
-    var viewportWidth = document.documentElement.clientWidth;
+    const viewportWidth = document.documentElement.clientWidth;
 
     // Return a default value if screen width is greater than the viewport width (not fullscreen).
     if(screen.width > viewportWidth) {
@@ -24,7 +24,7 @@ export function getViewportScale(formFactor: DeviceSpec.FormFactor): number {
     }
 
     // Get the orientation corrected screen width
-    var screenWidth = screen.width;
+    let screenWidth = screen.width;
     if(landscapeView()) {
       // Take larger of the two dimensions
       if(screen.width < screen.height) {

--- a/web/src/engine/osk/src/specialCharacters.ts
+++ b/web/src/engine/osk/src/specialCharacters.ts
@@ -1,6 +1,6 @@
 // Defines the PUA code mapping for the various 'special' modifier/control/non-printing keys on keyboards.
 // `specialCharacters` must be kept in sync with the same variable in constants.js. See also CompileKeymanWeb.pas: CSpecialText10
-let specialCharacters = {
+const specialCharacters = {
   '*Shift*':    8,
   '*Enter*':    5,
   '*Tab*':      6,

--- a/web/src/engine/osk/src/views/anchoredOskView.ts
+++ b/web/src/engine/osk/src/views/anchoredOskView.ts
@@ -78,7 +78,7 @@ export default class AnchoredOSKView extends OSKView {
 
   protected doResize() {
     if(this.vkbd) {
-      let targetOSKHeight = this.getDefaultKeyboardHeight();
+      const targetOSKHeight = this.getDefaultKeyboardHeight();
       this.setSize(this.getDefaultWidth(), targetOSKHeight + this.banner.height);
     }
   }
@@ -104,7 +104,7 @@ export default class AnchoredOSKView extends OSKView {
    *  @return   {number}    height in pixels
    **/
   getDefaultKeyboardHeight(): number {
-    let device = this.targetDevice;
+    const device = this.targetDevice;
 
     // KeymanTouch - get OSK height from device
     if(this.configuration.heightOverride) {
@@ -134,14 +134,13 @@ export default class AnchoredOSKView extends OSKView {
       baseHeight = Math.max(screen.height, screen.width);
 
       if(landscapeView()) {
-        let temp = baseWidth;
+        const temp = baseWidth;
         baseWidth = baseHeight;
         baseHeight = temp;
       }
     }
 
-    var oskHeightLandscapeView=Math.floor(Math.min(baseHeight, baseWidth)/2),
-        height=oskHeightLandscapeView;
+    let height=Math.floor(Math.min(baseHeight, baseWidth)/2);
 
     if(device.formFactor == 'phone') {
       /**
@@ -173,14 +172,14 @@ export default class AnchoredOSKView extends OSKView {
    *  @return   {number}    height in pixels
    **/
   getDefaultWidth(): number {
-    let device = this.targetDevice;
+    const device = this.targetDevice;
 
     // KeymanTouch - get OSK height from device
     if(this.configuration.widthOverride) {
       return this.configuration.widthOverride();
     }
 
-    var width: number;
+    let width: number;
 
     width = document?.documentElement?.clientWidth;
     if(typeof width == 'undefined') {
@@ -212,7 +211,7 @@ export default class AnchoredOSKView extends OSKView {
    * @return      {Object.<string,number>}     Array object with OSK window position
   **/
   getPos(): OSKPos {
-    var Lkbd=this._Box, p={
+    const Lkbd=this._Box, p={
       left: this._Visible ? Lkbd.offsetLeft : this.x,
       top: this._Visible ? Lkbd.offsetTop : this.y
     };
@@ -231,7 +230,7 @@ export default class AnchoredOSKView extends OSKView {
   }
 
   protected setDisplayPositioning() {
-    let Ls = this._Box.style;
+    const Ls = this._Box.style;
 
     // The following code will always be executed except for externally created OSK such as EuroLatin
     if(this.vkbd) {

--- a/web/src/engine/osk/src/views/floatingOskView.ts
+++ b/web/src/engine/osk/src/views/floatingOskView.ts
@@ -70,7 +70,7 @@ export default class FloatingOSKView extends OSKView {
     const onListenedEvent = (eventName: keyof EventMap | keyof LegacyOSKEventMap) => {
       // As the following title bar buttons (for desktop / FloatingOSKView) do nothing unless a site
       // designer uses these events, we disable / hide them unless an event-handler is attached.
-      let titleBar = this.headerView;
+      const titleBar = this.headerView;
       if(titleBar && titleBar instanceof TitleBar) {
         switch(eventName) {
           case 'configclick':
@@ -87,7 +87,7 @@ export default class FloatingOSKView extends OSKView {
 
     const listenerSpyNew = new EmitterListenerSpy(this);
     const listenerSpyOld = new EmitterListenerSpy(this.legacyEvents);
-    for(let listenerSpy of [listenerSpyNew, listenerSpyOld]) {
+    for(const listenerSpy of [listenerSpyNew, listenerSpyOld]) {
       listenerSpy.on('listeneradded', onListenedEvent);
       listenerSpy.on('listenerremoved', onListenedEvent);
     }
@@ -162,9 +162,9 @@ export default class FloatingOSKView extends OSKView {
    * See https://help.keyman.com/developer/engine/web/current-version/reference/osk/restorePosition
    */
   public restorePosition: (keepDefaultPosition?: boolean) => void = function(this: FloatingOSKView, keepDefaultPosition?: boolean) {
-    let isVisible = this._Visible;
+    const isVisible = this._Visible;
 
-    let dragPromise = new ManagedPromise<void>();
+    const dragPromise = new ManagedPromise<void>();
     this.emit('dragmove', dragPromise.corePromise);
 
     this.loadPersistedLayout();
@@ -209,7 +209,7 @@ export default class FloatingOSKView extends OSKView {
    * Save size, position, font size and visibility of OSK
    */
   private savePersistedLayout() {
-    var p = this.getPos();
+    const p = this.getPos();
 
     const c: FloatingOSKCookie = {
       visible: this.displayIfActive ? 1 : 0,
@@ -233,7 +233,7 @@ export default class FloatingOSKView extends OSKView {
    *  @return {boolean}
    */
   private loadPersistedLayout(): void {
-    let c = this.layoutSerializer.loadWithDefaults({
+    const c = this.layoutSerializer.loadWithDefaults({
       visible: 1,
       userSet: 0,
       left: -1,
@@ -313,11 +313,10 @@ export default class FloatingOSKView extends OSKView {
       return this.configuration.heightOverride();
     }
 
-    var oskHeightLandscapeView=Math.floor(Math.min(screen.availHeight,screen.availWidth)/2),
-        height=oskHeightLandscapeView;
+    let height=Math.floor(Math.min(screen.availHeight,screen.availWidth)/2);
 
     if(this.targetDevice.formFactor == 'phone') {
-      var sx=Math.min(screen.height,screen.width),
+      const sx=Math.min(screen.height,screen.width),
           sy=Math.max(screen.height,screen.width);
 
       if(!landscapeView())
@@ -345,7 +344,7 @@ export default class FloatingOSKView extends OSKView {
       return this.configuration.widthOverride();
     }
 
-    var width: number;
+    let width: number;
     if(this.targetDevice.OS == DeviceSpec.OperatingSystem.iOS) {
       // iOS does not interchange these values when the orientation changes!
       //width = util.portraitView() ? screen.width : screen.height;
@@ -386,7 +385,7 @@ export default class FloatingOSKView extends OSKView {
       return;
     }
 
-    var b = this._Box, bs = b.style;
+    const b = this._Box, bs = b.style;
     if('left' in p) {
       this.x = p['left'] - getAbsoluteX(b) + b.offsetLeft;
       bs.left= this.x + 'px';
@@ -401,11 +400,11 @@ export default class FloatingOSKView extends OSKView {
 
     //Do not allow user resizing for non-standard keyboards (e.g. EuroLatin)
     if(this.vkbd != null) {
-      var d=this.vkbd.kbdDiv, ds=d.style;
+      const d=this.vkbd.kbdDiv, ds=d.style;
 
       // Set width, but limit to reasonable value
       if('width' in p) {
-        var w=(p['width']-(b.offsetWidth-d.offsetWidth));
+        let w=(p['width']-(b.offsetWidth-d.offsetWidth));
         if(w < 0.2*screen.width) {
           w=0.2*screen.width;
         }
@@ -423,7 +422,7 @@ export default class FloatingOSKView extends OSKView {
       // can be modified at the key text level by setting
       // the font size in em in the kmw-key-text class
       if('height' in p) {
-        var h=(p['height']-(b.offsetHeight-d.offsetHeight));
+        let h=(p['height']-(b.offsetHeight-d.offsetHeight));
         if(h < 0.1*screen.height) {
           h=0.1*screen.height;
         }
@@ -457,7 +456,7 @@ export default class FloatingOSKView extends OSKView {
    * @return      {Object.<string,number>}     Array object with OSK window position
   **/
   getPos(): OSKPos {
-    var Lkbd=this._Box, p={
+    const Lkbd=this._Box, p={
       left: this._Visible ? Lkbd.offsetLeft : this.x,
       top: this._Visible ? Lkbd.offsetTop : this.y
     };
@@ -479,7 +478,7 @@ export default class FloatingOSKView extends OSKView {
     }
 
     if(this.userPositioned) {
-      var Px=p['left'], Py=p['top'];
+      let Px=p['left'], Py=p['top'];
 
       if(typeof(Px) != 'undefined') {
         if(Px < -0.8*this._Box.offsetWidth) {
@@ -507,7 +506,7 @@ export default class FloatingOSKView extends OSKView {
   }
 
   public setDisplayPositioning() {
-    var Ls = this._Box.style;
+    const Ls = this._Box.style;
 
     Ls.position='absolute';
     // Keep it hidden if not currently displayed.
@@ -519,7 +518,7 @@ export default class FloatingOSKView extends OSKView {
       Ls.left = this.x+'px';
       Ls.top  = this.y+'px';
     } else {
-      let el: HTMLElement = this.typedActivationModel.activationTrigger || null;
+      const el: HTMLElement = this.typedActivationModel.activationTrigger || null;
 
       if(this.dfltX) {
         Ls.left=this.dfltX;
@@ -680,7 +679,7 @@ export default class FloatingOSKView extends OSKView {
         _this._Box.style.left = (this.startX + cumulativeX) + 'px';
         _this._Box.style.top  = (this.startY + cumulativeY) + 'px';
 
-        var r=_this.getRect();
+        const r=_this.getRect();
         _this.setSize(r.width, r.height, true);
         _this.x = r.left;
         _this.y = r.top;

--- a/web/src/engine/osk/src/views/inlinedOskView.ts
+++ b/web/src/engine/osk/src/views/inlinedOskView.ts
@@ -97,7 +97,7 @@ export default class InlinedOSKView extends OSKView {
    * @return Array object with OSK window position
   **/
   getPos(): OSKPos {
-    var Lkbd=this._Box, p={
+    const Lkbd=this._Box, p={
       left: this._Visible ? Lkbd.offsetLeft : undefined,
       top:  this._Visible ? Lkbd.offsetTop  : undefined
     };

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -263,7 +263,7 @@ export default abstract class OSKView
     // Temp-hack:  embedded products prefer their stylesheet, etc linkages without the /osk path component.
     const resourcePath = getResourcePath(this.config);
 
-    for(let sheetFile of OSKView.STYLESHEET_FILES) {
+    for(const sheetFile of OSKView.STYLESHEET_FILES) {
       const sheetHref = `${resourcePath}${sheetFile}`;
       this.uiStyleSheetManager.linkExternalSheet(sheetHref);
     }
@@ -321,7 +321,7 @@ export default abstract class OSKView
 
   private setBaseTouchEventListeners() {
     // To prevent touch event default behaviour on mobile devices
-    let commonPrevention = function(e: TouchEvent) {
+    const commonPrevention = function(e: TouchEvent) {
       if(e.cancelable) {
         e.preventDefault();
       }
@@ -336,7 +336,7 @@ export default abstract class OSKView
 
     this._boxBaseTouchStart = (e) => {
       for(let i = 0; i < e.changedTouches.length; i++) {
-        let promise = this.touchEventPromiseManager.promiseForTouchpoint(e.changedTouches[i].identifier);
+        const promise = this.touchEventPromiseManager.promiseForTouchpoint(e.changedTouches[i].identifier);
         this.emit('pointerinteraction', promise.corePromise);
       }
 
@@ -793,7 +793,7 @@ export default abstract class OSKView
   }
 
   private _GenerateKeyboardView(keyboard: Keyboard, keyboardMetadata: KeyboardProperties): KeyboardView {
-    let device = this.targetDevice;
+    const device = this.targetDevice;
 
     this._Box.className = "";
 
@@ -826,12 +826,12 @@ export default abstract class OSKView
    * Description  Generates the visual keyboard element and attaches it to KMW
    */
   private _GenerateVisualKeyboard(keyboard: Keyboard, keyboardMetadata: KeyboardProperties): VisualKeyboard {
-    let device = this.targetDevice;
+    const device = this.targetDevice;
 
     const resourcePath = getResourcePath(this.config);
 
     // Root element sets its own classes, one of which is 'kmw-osk-inner-frame'.
-    let vkbd = new VisualKeyboard({
+    const vkbd = new VisualKeyboard({
       keyboard: keyboard,
       keyboardMetadata: keyboardMetadata,
       device: device,
@@ -934,7 +934,7 @@ export default abstract class OSKView
 
     // If OSK still hidden, make visible only after all calculation finished
     if(this._Box.style.visibility == 'hidden') {
-      let _this = this;
+      const _this = this;
       window.setTimeout(function() {
         _this._Box.style.visibility = 'visible';
       }, 0);
@@ -1001,7 +1001,7 @@ export default abstract class OSKView
     }
 
     if(this._Box) {
-      let bs=this._Box.style;
+      const bs=this._Box.style;
       bs.display = 'none';
       bs.transition = '';
       bs.opacity = '1';
@@ -1157,7 +1157,7 @@ export default abstract class OSKView
 
     // Remove the OSK's elements from the document, allowing them to be properly cleaned up.
     // Necessary for clean engine testing.
-    var _box = this._Box;
+    const _box = this._Box;
     if(_box.parentElement) {
       _box.parentElement.removeChild(_box);
     }
@@ -1177,7 +1177,7 @@ export default abstract class OSKView
    * See https://help.keyman.com/developer/engine/web/current-version/reference/osk/getRect
    */
   public getRect(): OSKRect {		// I2405
-    var p: OSKRect = {};
+    const p: OSKRect = {};
 
     // Always return these based upon _Box; using this.vkbd will fail to account for banner and/or
     // the desktop OSK border.

--- a/web/src/engine/osk/src/views/touchEventPromiseMap.ts
+++ b/web/src/engine/osk/src/views/touchEventPromiseMap.ts
@@ -13,17 +13,17 @@ export default class TouchEventPromiseMap {
   }
 
   public maintainTouches(list: TouchList) {
-    let keys = Array.from(this.map.keys());
+    const keys = Array.from(this.map.keys());
 
     for(let i=0; i < list.length; i++) {
-      let pos = keys.indexOf(list.item(i).identifier);
+      const pos = keys.indexOf(list.item(i).identifier);
       if(pos != -1) {
         keys.splice(pos, 1);
       }
     }
 
     // Any remaining entries of `keys` are no longer in the map!
-    for(let endedKey of keys) {
+    for(const endedKey of keys) {
       this.map.get(endedKey).resolve();
       this.map.delete(endedKey);
     }

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -315,7 +315,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     this._fixedHeightScaling = this.device.touchable && !this.isStatic;
 
     // Create the collection of HTML elements from the device-dependent layout object
-    var Lkbd = document.createElement('div');
+    const Lkbd = document.createElement('div');
     this.config.styleSheetManager = config.styleSheetManager || new StylesheetManager(Lkbd);
 
     let layout: ActiveLayout;
@@ -329,7 +329,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       //
       // In KMW's current state, it'd take a major break, though - Processor always has an activeKeyboard,
       // even if it's "hollow".
-      let rawLayout = Layouts.buildDefaultLayout(null, null, config.device.formFactor);
+      const rawLayout = Layouts.buildDefaultLayout(null, null, config.device.formFactor);
       layout = this.kbdLayout = ActiveLayout.polyfill(rawLayout, null, config.device.formFactor);
       // null will probably need to be replaced with a defined value.
       this.layoutKeyboardProperties = null;
@@ -531,7 +531,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
         // Do cleanup - we'll no longer be tracking these, but that's only confirmed now.
         // Multitouch does reference tracking data for a source after its completion,
         // but only while still permitting new touches.  If we're here, that time is over.
-        for(let id of gestureSequence.allSourceIds) {
+        for(const id of gestureSequence.allSourceIds) {
           // If the original preview host lives on, ensure it's cancelled now.
           if(sourceTrackingMap[id]?.previewHost) {
             this.gesturePreviewHost = null;
@@ -562,7 +562,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
         let trackingEntry: typeof sourceTrackingMap[string];
         // Disable roaming-touch highlighting (and current highlighting) for all
         // touchpoints included in a gesture, even newly-included ones as they occur.
-        for(let id of gestureStage.allSourceIds) {
+        for(const id of gestureStage.allSourceIds) {
           const clearRoaming = (trackingEntry: typeof sourceTrackingMap['']) => {
             if(trackingEntry.key) {
               this.highlightKey(trackingEntry.key, false);
@@ -905,7 +905,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
   //#region VisualKeyboard - OSK touch handlers
   getTouchCoordinatesOnKeyboard(input: InputSample<KeyElement, string>) {
     // `input` is already in keyboard-local coordinates.  It's not scaled, though.
-    let offsetCoords = { x: input.targetX, y: input.targetY };
+    const offsetCoords = { x: input.targetX, y: input.targetY };
 
     // The layer group's element always has the proper width setting, unlike kbdDiv itself.
     offsetCoords.x /= this.layerGroup.element.offsetWidth;
@@ -923,8 +923,8 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
    */
   getSimpleTapCorrectionDistances(input: InputSample<KeyElement, string>, keySpec?: ActiveKey): Map<ActiveKeyBase, number> {
     // Note:  if subkeys are active, they will still be displayed at this time.
-    let touchKbdPos = this.getTouchCoordinatesOnKeyboard(input);
-    let layerGroup = this.layerGroup.element;  // Always has proper dimensions, unlike kbdDiv itself.
+    const touchKbdPos = this.getTouchCoordinatesOnKeyboard(input);
+    const layerGroup = this.layerGroup.element;  // Always has proper dimensions, unlike kbdDiv itself.
     const width = layerGroup.offsetWidth, height = this.kbdDiv.offsetHeight;
 
     // Prevent NaN breakages.
@@ -932,7 +932,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       return new Map();
     }
 
-    let kbdAspectRatio = width / height;
+    const kbdAspectRatio = width / height;
 
     const correctiveLayout = buildCorrectiveLayout(this.kbdLayout.getLayer(this.layerId), kbdAspectRatio);
     return keyTouchDistances(touchKbdPos, correctiveLayout);
@@ -952,7 +952,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       throw new Error(`Cannot model keypress without a selected key: \n${sequence.trace()}`);
     }
 
-    let keyEvent = this.initKeyEvent(e);
+    const keyEvent = this.initKeyEvent(e);
 
     if (input) {
       keyEvent.source = input;
@@ -975,7 +975,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     //
     // Would avoid the type shenanigans needed here because of our current type-abuse setup
     // for key spec tracking.
-    let keySpec = (e['key'] ? e['key'].spec : null) as unknown as ActiveKey;
+    const keySpec = (e['key'] ? e['key'].spec : null) as unknown as ActiveKey;
     if (!keySpec) {
       return null;
     }
@@ -988,7 +988,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     // Start:  mirrors _GetKeyEventProperties
 
     // First check the virtual key, and process shift, control, alt or function keys
-    let Lkc = this.layoutKeyboard.constructKeyEvent(keySpec, this.device, this.stateKeys);
+    const Lkc = this.layoutKeyboard.constructKeyEvent(keySpec, this.device, this.stateKeys);
 
     /* In case of "fun" edge cases caused by JS's single-threadedness & event processing queue.
       *
@@ -1015,7 +1015,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
    * Description  Updates the OSK's visual style for any toggled state keys
    */
   _UpdateVKShiftStyle(layerId?: string) {
-    var i;
+    let i;
 
     if (!layerId) {
       layerId = this.layerId;
@@ -1056,7 +1056,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
   }
 
   updateStateKeys(stateKeys: StateKeyMap) {
-    for(let key of Object.keys(this.stateKeys)) {
+    for(const key of Object.keys(this.stateKeys)) {
       this.stateKeys[key as keyof StateKeyMap] = stateKeys[key as keyof StateKeyMap];
     }
 
@@ -1110,7 +1110,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     }
 
     if (this.device.formFactor == 'desktop') {
-      let keySquareScale = 0.8; // Set in kmwosk.css, is relative.
+      const keySquareScale = 0.8; // Set in kmwosk.css, is relative.
       return this.fontSize.scaledBy(keySquareScale);
     } else {
       const emSizeStr = getComputedStyle(document.body).fontSize;
@@ -1165,9 +1165,9 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       (A single, initial reflow may happen depending on DOM manipulations before this method...,
       but no extras until phase 2.)
     */
-    let device = this.device;
+    const device = this.device;
 
-    var fs = 1.0;
+    let fs = 1.0;
     // TODO: Logically, this should be needed for Android, too - may need to be changed for the next version!
     if (device.OS == DeviceSpec.OperatingSystem.iOS && !this.isEmbedded) {
       fs = fs / getViewportScale(this.device.formFactor);
@@ -1176,7 +1176,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     /*
       Phase 2:  first self-triggered reflow - locking in the keyboard's base property styling.
     */
-    let gs = this.kbdDiv.style;
+    const gs = this.kbdDiv.style;
     if (this.usesFixedHeightScaling && this.height) {
       // Sets the layer group to the correct height.
       gs.height = gs.maxHeight = this.height + 'px';
@@ -1266,8 +1266,8 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
    *
    **/
   appendStyleSheet() {
-    var activeKeyboard = this.layoutKeyboard;
-    var activeStub = this.layoutKeyboardProperties;
+    const activeKeyboard = this.layoutKeyboard;
+    const activeStub = this.layoutKeyboardProperties;
 
     // First remove any existing keyboard style sheet
     if (this.styleSheet && this.styleSheet.parentNode) {
@@ -1277,7 +1277,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     // For help.keyman.com, sometimes we aren't given a stub for the keyboard.
     // We can't get the keyboard's fonts correct in that case, but we can
     // at least proceed safely.
-    var kfd = activeStub?.textFont, ofd = activeStub?.oskFont;
+    const kfd = activeStub?.textFont, ofd = activeStub?.oskFont;
 
     // Add and define style sheets for embedded fonts if necessary (each font-face style will only be added once)
     this.styleSheetManager.addStyleSheetForFont(kfd, this.fontRootPath, this.device.OS);
@@ -1291,7 +1291,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     // Note: Some browsers do not download the font-face font until it is applied,
     //       so must apply style before testing for font availability
     // Extended to allow keyboard-specific custom styles for Build 360
-    var customStyle = this.addFontStyle(kfd, ofd);
+    let customStyle = this.addFontStyle(kfd, ofd);
     if (activeKeyboard != null && typeof (activeKeyboard.oskStyling) == 'string')  // KMEW-129
       customStyle = customStyle + activeKeyboard.oskStyling;
 
@@ -1320,7 +1320,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
   addFontStyle(kfd: InternalKeyboardFont, ofd: InternalKeyboardFont): string {
     let s: string = '';
 
-    let family = (fd: InternalKeyboardFont) => fd.family.replace(/\u0022/g, '').replace(/,/g, '","');
+    const family = (fd: InternalKeyboardFont) => fd.family.replace(/\u0022/g, '').replace(/,/g, '","');
 
     // Set font family for OSK text, suggestion text
     if (kfd || ofd) {
@@ -1364,7 +1364,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       return null;
     }
 
-    var formFactor = (typeof (argFormFactor) == 'undefined' ? 'desktop' : argFormFactor) as DeviceSpec.FormFactor,
+    const formFactor = (typeof (argFormFactor) == 'undefined' ? 'desktop' : argFormFactor) as DeviceSpec.FormFactor,
       layerId = (typeof (argLayerId) == 'undefined' ? 'default' : argLayerId),
       device: {
         formFactor?: DeviceSpec.FormFactor,
@@ -1382,10 +1382,10 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       device.touchable = false;
     }
 
-    let layout = PKbd.layout(formFactor);
+    const layout = PKbd.layout(formFactor);
 
     const deviceSpec = new DeviceSpec('other', device.formFactor, device.OS, device.touchable);
-    let kbdObj = new VisualKeyboard({
+    const kbdObj = new VisualKeyboard({
       keyboard: PKbd,
       keyboardMetadata: kbdProperties,
       hostDevice: deviceSpec,
@@ -1403,14 +1403,14 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     kbdObj.layerGroup.element.className = kbdObj.kbdDiv.className; // may contain multiple classes
     kbdObj.layerGroup.element.classList.add(device.formFactor + '-static');
 
-    let kbd = kbdObj.kbdDiv.childNodes[0] as HTMLDivElement; // Gets the layer group.
+    const kbd = kbdObj.kbdDiv.childNodes[0] as HTMLDivElement; // Gets the layer group.
 
     // Models CSS classes hosted on the OSKView in normal operation.  We can't do this on the main
     // layer-group element because of the CSS rule structure for keyboard styling.
     //
     // For example, `.ios .kmw-keyboard-sil_cameroon_azerty` requires the element with the keyboard
     // ID to be in a child of an element with the .ios class.
-    let classWrapper = document.createElement('div');
+    const classWrapper = document.createElement('div');
     classWrapper.classList.add(device.OS.toLowerCase(), device.formFactor);
 
     // Select the layer to display, and adjust sizes
@@ -1467,7 +1467,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
            * - https://stackoverflow.com/q/63710162
            * - https://github.com/mdn/interactive-examples/issues/887#issuecomment-432418008
            */
-          for(let sheet of sheets) {
+          for(const sheet of sheets) {
             if(sheet == mainSheet) {
               // Don't need to relocate the custom stylesheet.
               continue;
@@ -1506,7 +1506,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     classWrapper.append(kbd);
 
     // Ensure that the OSK's style-sheet is included by the top-level div standing in for the OSKView.
-    for(let sheetFile of OSKView.STYLESHEET_FILES) {
+    for(const sheetFile of OSKView.STYLESHEET_FILES) {
       const sheetHref = `${pathConfig.resources}/osk/${sheetFile}`;
       const sheet = kbdObj.styleSheetManager.linkExternalSheet(sheetHref, true);
       sheet.parentNode.removeChild(sheet);
@@ -1582,7 +1582,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     if (this.keytip == null) {
       if(this.device.formFactor == 'phone') {
         // For now, should only be true (in production) when keyman.isEmbedded == true.
-        let constrainPopup = this.isEmbedded;
+        const constrainPopup = this.isEmbedded;
         this.keytip = new PhoneKeyTip(this, constrainPopup);
       } else {
         this.keytip = new TabletKeyTip(this);
@@ -1633,7 +1633,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       return {};
     }
 
-    let callbackData: KeyRuleEffects = {};
+    const callbackData: KeyRuleEffects = {};
 
     const keyEventCallback: KeyEventResultCallback = (result, error) => {
       callbackData.contextToken = result?.transcription?.token;

--- a/web/src/tools/testing/recorder/browserDriver.ts
+++ b/web/src/tools/testing/recorder/browserDriver.ts
@@ -8,7 +8,7 @@ import { ManagedPromise, timedPromise } from "@keymanapp/web-utils";
 
 import { type KeymanEngine } from 'keyman/app/browser';
 
-declare var keyman: KeymanEngine;
+declare let keyman: KeymanEngine;
 
 export type Mutable<Type> = {
   -readonly [Property in keyof Type]: Type[Property];
@@ -71,7 +71,7 @@ export class BrowserDriver {
 
   simulateHardwareEvent(eventSpec: PhysicalInputEventSpec) {
     // Yep, not KeyboardEvent.  "keyCode" is nasty-bugged in Chrome and unusable if initializing through KeyboardEvent.
-    let event: Mutable<Partial<KeyboardEvent>> = new Event(BrowserDriver.physicalEventType);
+    const event: Mutable<Partial<KeyboardEvent>> = new Event(BrowserDriver.physicalEventType);
     event['key'] = eventSpec.key;
     event['code'] = eventSpec.code;
     event['keyCode'] = eventSpec.keyCode;
@@ -99,8 +99,8 @@ export class BrowserDriver {
     }
 
     try {
-      let target = this.target;
-      let oskKeyElement = document.getElementById(eventSpec.keyID);
+      const target = this.target;
+      const oskKeyElement = document.getElementById(eventSpec.keyID);
       const boundingBox = oskKeyElement.getBoundingClientRect();
       const center = {
         clientX: boundingBox.left + boundingBox.width/2,
@@ -115,12 +115,10 @@ export class BrowserDriver {
 
       // To be safe, we replicate the MouseEvent similarly to the keystroke event.
       let downEvent: Event;
-      var upEvent: Event;
+      let upEvent: Event;
       if(keyman.config.hostDevice.touchable) {
-        let touchDownEvent: Mutable<Partial<TouchEvent>>;
-        let touchUpEvent: Mutable<Partial<TouchEvent>>;
-        touchDownEvent = new Event(BrowserDriver.oskDownTouchType);
-        touchUpEvent = new Event(BrowserDriver.oskUpTouchType);
+        const touchDownEvent: Mutable<Partial<TouchEvent>> = new Event(BrowserDriver.oskDownTouchType);
+        const touchUpEvent: Mutable<Partial<TouchEvent>> = new Event(BrowserDriver.oskUpTouchType);
         touchDownEvent['touches'] = asTouchList([{"target": oskKeyElement, ...center}]);
         // The touch should NOT show up in event.touches when a touch ends.
         touchUpEvent['touches'] = asTouchList([]);
@@ -131,10 +129,8 @@ export class BrowserDriver {
         downEvent = touchDownEvent as Event;
         upEvent = touchUpEvent as Event;
       } else {
-        let mouseDownEvent: Mutable<Partial<MouseEvent>>;
-        let mouseUpEvent: Mutable<Partial<MouseEvent>>;
-        mouseDownEvent = new Event(BrowserDriver.oskDownMouseType);
-        mouseUpEvent = new Event(BrowserDriver.oskUpMouseType);
+        const mouseDownEvent: Mutable<Partial<MouseEvent>> = new Event(BrowserDriver.oskDownMouseType);
+        const mouseUpEvent: Mutable<Partial<MouseEvent>> = new Event(BrowserDriver.oskUpMouseType);
         mouseDownEvent.clientX = center.clientX;
         mouseDownEvent.clientY = center.clientY;
         mouseDownEvent['relatedTarget'] = target;
@@ -197,9 +193,9 @@ export class BrowserDriver {
   // Execution of a test sequence depends on the testing environment; integrated
   // testing requires browser-specific code.
   async simulateSequence(sequence: InputEventSpecSequence): Promise<string> {
-    let ele = this.target;
+    const ele = this.target;
 
-    for(var i=0; i < sequence.inputs.length; i++) {
+    for(let i=0; i < sequence.inputs.length; i++) {
       await this.simulateEvent(sequence.inputs[i]);
     }
 

--- a/web/src/tools/testing/recorder/browserProctor.ts
+++ b/web/src/tools/testing/recorder/browserProctor.ts
@@ -8,7 +8,7 @@ import { type OutputTarget } from "keyman/engine/js-processor";
 
 import { type KeymanEngine } from 'keyman/app/browser';
 
-declare var keyman: KeymanEngine;
+declare let keyman: KeymanEngine;
 
 import {
   InputEventSpec,
@@ -53,7 +53,7 @@ export class BrowserProctor extends Proctor {
 
   // Performs browser-specific global test prep.
   async beforeAll() {
-    let ele = this.target;
+    const ele = this.target;
     keyman.setActiveElement(ele, true);
 
     // If the CSS isn't fully loaded, the element positions will not match their expected
@@ -82,7 +82,7 @@ export class BrowserProctor extends Proctor {
   // Execution of a test sequence depends on the testing environment; this handles
   // the browser-specific aspects.
   async simulateSequence(sequence: TestSequence<any>, outputTarget?: OutputTarget): Promise<string> {
-    let driver = new BrowserDriver(this.target);
+    const driver = new BrowserDriver(this.target);
 
     // For the version 10.0 spec
     if(sequence instanceof InputEventSpecSequence) {
@@ -90,14 +90,14 @@ export class BrowserProctor extends Proctor {
 
       // For the version 14.0+ spec
     } else if(sequence instanceof RecordedKeystrokeSequence) {
-      let inputSpecs: InputEventSpec[] = [];
+      const inputSpecs: InputEventSpec[] = [];
 
       for(let i=0; i < sequence.inputs.length; i++) {
         inputSpecs[i] = sequence.inputs[i].inputEventSpec;
       }
 
       // Converts the sequence back to version 10.0, since it's very well made for browser simulation.
-      let eventSpecSequence = new InputEventSpecSequence(inputSpecs, sequence.output, sequence.msg);
+      const eventSpecSequence = new InputEventSpecSequence(inputSpecs, sequence.output, sequence.msg);
       return driver.simulateSequence(eventSpecSequence);
     } else {
       throw new Error("Unexpected test-recording type");

--- a/web/src/tools/testing/recorder/scribe.ts
+++ b/web/src/tools/testing/recorder/scribe.ts
@@ -21,7 +21,7 @@ import { outputTargetForElement } from 'keyman/engine/attachment';
 
 import { type KeymanEngine } from 'keyman/app/browser';
 
-declare var keyman: KeymanEngine;
+declare let keyman: KeymanEngine;
 
 // // Makes sure the code below knows that the namespaces exist.
 // namespace com.keyman {
@@ -45,7 +45,7 @@ declare var keyman: KeymanEngine;
 export class Scribe extends EventEmitter {
   //#region Static methods for recording input events
   static recordKeystroke(e: KeyEvent, eventSpec: InputEventSpec) {
-    var recording: RecordedKeystroke;
+    let recording: RecordedKeystroke;
     if(e.isSynthetic) {
       recording = new RecordedSyntheticKeystroke(e);
     } else {
@@ -56,16 +56,16 @@ export class Scribe extends EventEmitter {
   }
 
   static recordKeyboardEvent(e: KeyboardEvent): PhysicalInputEventSpec {
-    let recording = new PhysicalInputEventSpec();
+    const recording = new PhysicalInputEventSpec();
 
     recording.key    = e.key;
     recording.code    = e.code;
     recording.keyCode = e.keyCode;
     recording.location = e.location;
 
-    var flagSet: number = 0;
+    let flagSet: number = 0;
 
-    for(var key in PhysicalInputEventSpec.modifierCodes) {
+    for(const key in PhysicalInputEventSpec.modifierCodes) {
       if(e.getModifierState(key)) {
         flagSet |= PhysicalInputEventSpec.modifierCodes[key];
       }
@@ -77,13 +77,13 @@ export class Scribe extends EventEmitter {
   }
 
   static recordOSKEvent(e: HTMLDivElement): OSKInputEventSpec {
-    let recording = new OSKInputEventSpec();
+    const recording = new OSKInputEventSpec();
     recording.keyID = e.id;
     return recording;
   }
 
   static recordKeyboardStub(activeStub: any, basePath: string): KeyboardStub {
-    let recording = new KeyboardStub();
+    const recording = new KeyboardStub();
 
     recording.id = activeStub.KI;
     recording.id = recording.id.replace('Keyboard_', '');
@@ -97,7 +97,7 @@ export class Scribe extends EventEmitter {
   }
 
   private static _setStubBasePath(filename: string, filePath: string, force?: boolean): string {
-    var linkParser = document.createElement<"a">("a");
+    const linkParser = document.createElement<"a">("a");
     linkParser.href = filePath;
 
     if(force === undefined) {
@@ -105,10 +105,10 @@ export class Scribe extends EventEmitter {
     }
 
     if(force || (filename.indexOf(linkParser.protocol) < 0 && filename.indexOf('/') != 0)) {
-      var file = filename.substr(filename.lastIndexOf('/')+1);
+      const file = filename.substr(filename.lastIndexOf('/')+1);
       return filePath + '/' + file;
     } else {
-      return file;
+      return filePath;
     }
   }
   //#endregion
@@ -180,16 +180,16 @@ export class Scribe extends EventEmitter {
 
   // Time for the 'magic'.  Yay, JavaScript method extension strategies...
   initHooks(recordingElement: HTMLElement) {
-    let recorderScribe = this;
+    const recorderScribe = this;
 
     keyman.hardKeyboard.on('keyevent', (e) => {
-      let in_output = outputTargetForElement(recordingElement);
+      const in_output = outputTargetForElement(recordingElement);
       if(!in_output || keyman.contextManager.activeTarget != in_output) {
         return;
       }
 
-      let event = Scribe.recordKeyboardEvent(e.source as KeyboardEvent);
-      let recording = Scribe.recordKeystroke(e, event);
+      const event = Scribe.recordKeyboardEvent(e.source as KeyboardEvent);
+      const recording = Scribe.recordKeystroke(e, event);
 
       // Record the keystroke as part of a test sequence!
       // Miniature delay in case the keyboard relies upon default backspace/delete behavior!
@@ -199,27 +199,27 @@ export class Scribe extends EventEmitter {
     });
 
     keyman.osk.on('keyevent', (e) => {
-      let in_output = outputTargetForElement(recordingElement);
+      const in_output = outputTargetForElement(recordingElement);
       if(!in_output || keyman.contextManager.activeTarget != in_output) {
         return;
       }
 
-      let event = Scribe.recordOSKEvent((e.source).target);
-      let recording = Scribe.recordKeystroke(e, event);
+      const event = Scribe.recordOSKEvent((e.source).target);
+      const recording = Scribe.recordKeystroke(e, event);
 
       // Record the click/touch as part of a test sequence!
       recorderScribe.addInputRecord(recording, in_output.getText());
     });
 
     keyman.contextManager.on('keyboardchange', (kbdTuple) => {
-      let in_output = outputTargetForElement(recordingElement);
+      const in_output = outputTargetForElement(recordingElement);
       // If it's not on our recording control, ignore the change and do nothing special.
       if(!in_output || document.activeElement != in_output.getElement()) {
         return;
       }
 
-      let testDefinition = recorderScribe.testDefinition;
-      var sameKbd = (testDefinition.keyboard && ("Keyboard_" + testDefinition.keyboard.id) == kbdTuple.keyboard.id)
+      const testDefinition = recorderScribe.testDefinition;
+      const sameKbd = (testDefinition.keyboard && ("Keyboard_" + testDefinition.keyboard.id) == kbdTuple.keyboard.id)
         && (!testDefinition.keyboard.getFirstLanguage() || (testDefinition.keyboard.getFirstLanguage() == kbdTuple.metadata.langId));
 
       // if(!testDefinition.isEmpty() && !sameKbd && !recorderScribe.keyboardJustActivated) {
@@ -229,9 +229,9 @@ export class Scribe extends EventEmitter {
       // }
 
       // What's the active stub immediately after our _SetActiveKeyboard call?
-      var internalStub = kbdTuple.metadata;
+      const internalStub = kbdTuple.metadata;
       if(internalStub && (keyman.contextManager.activeTarget == in_output)) {
-        var kbdRecord = Scribe.recordKeyboardStub(internalStub, 'resources/keyboards');
+        const kbdRecord = Scribe.recordKeyboardStub(internalStub, 'resources/keyboards');
 
         recorderScribe.emit('stub-changed', JSON.stringify(kbdRecord));
         // var ta_activeStub = document.getElementById('activeStub');


### PR DESCRIPTION
I believe that all violations for our current `eslint` settings within `web/` were that of `var`/`let`/`const` usage.  Fortunately, it could automatically fix most cases, and it wasn't too difficult to resolve the rest by hand.  As a result, we can now enable `eslint` during `web/` builds.

Fun detail:  it appears that `web/` also passes `eslint:recommended` when I temporarily add it in the base `.eslintrc.cjs` file!

Each submodule needing changes to pass linting got its own commit for said changes.

Finally, web/src/engine/common/web-utils will need further handling.  Its build is not directly triggered on `master` yet, its local build.sh doesn't (yet) use Web's common `compile` helper (which triggers web/ linting), and its kmwstring.ts is subject to the KMWString 🧶 PR sequence; it'd be best to let one or the other land first, then make the needed changes on (or immediately after) whichever is approved later.  (The bit about the `compile` helper is already fixed on the KMWString 🧶 PR sequence.)

@keymanapp-test-bot skip