### PR TITLE
chore(common): allow to run tests in virtual environment

### DIFF
--- a/linux/build.sh
+++ b/linux/build.sh
@@ -40,5 +40,5 @@ test_action() {
   fi
 }
 
-builder_run_action test test_action
-builder_run_action        test:help    check-markdown  "$KEYMAN_ROOT/linux/docs/help"
+builder_run_action  test        test_action
+builder_run_action  test:help   check-markdown  "${KEYMAN_ROOT}/linux/docs/help"

--- a/linux/keyman-config/tests/bcp47tag_tests.py
+++ b/linux/keyman-config/tests/bcp47tag_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import unittest
 
 from keyman_config.bcp47tag import Bcp47Tag

--- a/linux/keyman-config/tests/canonical_language_code_utils_tests.py
+++ b/linux/keyman-config/tests/canonical_language_code_utils_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import unittest
 
 from keyman_config.canonical_language_code_utils import CanonicalLanguageCodeUtils

--- a/linux/keyman-config/tests/custom_keyboards_tests.py
+++ b/linux/keyman-config/tests/custom_keyboards_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import unittest
 from unittest.mock import patch
 from keyman_config import __version__

--- a/linux/keyman-config/tests/dbus_util_tests.py
+++ b/linux/keyman-config/tests/dbus_util_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import unittest
 from unittest.mock import Mock, patch
 

--- a/linux/keyman-config/tests/dconf_util_tests.py
+++ b/linux/keyman-config/tests/dconf_util_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import unittest
 from gi.repository import Gio
 

--- a/linux/keyman-config/tests/get_kmp_tests.py
+++ b/linux/keyman-config/tests/get_kmp_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import tempfile
 import unittest

--- a/linux/keyman-config/tests/gnome_keyboards_util_tests.py
+++ b/linux/keyman-config/tests/gnome_keyboards_util_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import unittest
 from unittest import mock

--- a/linux/keyman-config/tests/gsettings_tests.py
+++ b/linux/keyman-config/tests/gsettings_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import tempfile
 import unittest

--- a/linux/keyman-config/tests/handle_install_tests.py
+++ b/linux/keyman-config/tests/handle_install_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import unittest
 from unittest.mock import patch
 

--- a/linux/keyman-config/tests/ibus_util_tests.py
+++ b/linux/keyman-config/tests/ibus_util_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import unittest
 from unittest.mock import Mock, patch
 

--- a/linux/keyman-config/tests/install_kmp_tests.py
+++ b/linux/keyman-config/tests/install_kmp_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import tempfile
 import unittest

--- a/linux/keyman-config/tests/kvk2ldml_tests.py
+++ b/linux/keyman-config/tests/kvk2ldml_tests.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import shutil
 import sys

--- a/linux/keyman-config/tests/lang_tags_map_tests.py
+++ b/linux/keyman-config/tests/lang_tags_map_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import unittest
 
 from keyman_config.standards.lang_tags_map import LangTagsMap

--- a/linux/keyman-config/tests/package_install_completion_tests.py
+++ b/linux/keyman-config/tests/package_install_completion_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import tempfile
 import unittest

--- a/linux/keyman-config/tests/uninstall_kmp_tests.py
+++ b/linux/keyman-config/tests/uninstall_kmp_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import unittest
 from unittest.mock import Mock, patch
 


### PR DESCRIPTION
This changes the shebang at the top of the file to allow use Python from a virtual environment instead of hard-coding the path. This might not be strictly necessary the way we run the tests, but reduces confusion and doesn't hurt.

@keymanapp-test-bot skip