### PR TITLE
maint(core): batch build kmx in tests for performance

### DIFF
--- a/core/tests/unit/kmx/keyboards.kpj.in
+++ b/core/tests/unit/kmx/keyboards.kpj.in
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<KeymanDeveloperProject>
+  <Options>
+    <BuildPath>$PROJECTPATH</BuildPath>
+    <CompilerWarningsAsErrors>False</CompilerWarningsAsErrors>
+    <WarnDeprecatedCode>False</WarnDeprecatedCode>
+    <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
+  </Options>
+  <Files>
+    @keyboards_kpj@
+  </Files>
+</KeymanDeveloperProject>

--- a/core/tests/unit/kmx/meson.build
+++ b/core/tests/unit/kmx/meson.build
@@ -99,13 +99,14 @@ else
   cat_cmd = [find_program('cat', required: true)]
 endif
 
-test_keyboards = ''
+test_keyboards_kpj = ''
+test_keyboards_kmp_json = ''
 foreach kbd : tests
-  if test_keyboards.startswith('{')
-    test_keyboards += ''',
+  if test_keyboards_kmp_json.startswith('{')
+    test_keyboards_kmp_json += ''',
   '''
   endif
-  test_keyboards +=  '''{
+  test_keyboards_kmp_json +=  '''{
     "name": "''' + kbd + '''",
     "id": "''' + kbd + '''",
     "version": "0.0",
@@ -116,14 +117,44 @@ foreach kbd : tests
       }
     ]
   }'''
+
+  test_keyboards_kpj += '''
+    <File>
+      <ID>keyboard_'''+kbd+'''</ID>
+      <Filename>'''+kbd+'''.kmn</Filename>
+      <Filepath>'''+kbd+'''.kmn</Filepath>
+    </File>
+    <File>
+      <ID>package_'''+kbd+'''</ID>
+      <Filename>'''+kbd+'''.kps</Filename>
+      <Filepath>'''+kbd+'''.kps</Filepath>
+    </File>
+  '''
 endforeach
 
 cfg = configuration_data()
-cfg.set('keyboards', test_keyboards)
+cfg.set('keyboards', test_keyboards_kmp_json)
+cfg.set('keyboards_kpj', test_keyboards_kpj)
+
+# Build a single kmp.json which lists all compiled keyboards
 configure_file(
   configuration: cfg,
   input: 'kmp.json.in',
   output: 'kmp.json'
+)
+
+# Build a single keyboards.kpj which lists all keyboard + package sources
+keyboards_kpj = configure_file(
+  configuration: cfg,
+  input: 'keyboards.kpj.in',
+  output: 'keyboards.kpj'
+)
+
+all_keyboards = custom_target('all_keyboards',
+  input: keyboards_kpj,
+  output: [tests[0]+'.kmp'],
+  depfile: 'keyboards.dep',
+  command: kmc_cmd + ['build', '--debug', '--no-compiler-version', '@INPUT@']
 )
 
 foreach kbd : tests
@@ -151,24 +182,15 @@ foreach kbd : tests
     input: kbd_src_path,
     output: kbd + '.kmn'
   )
-  kbd_kpj = configure_file(
-    configuration: cfg,
-    input: join_paths('template', 'keyboard.kpj.in'),
-    output: kbd + '.kpj'
-  )
   kbd_kps = configure_file(
     configuration: cfg,
     input: join_paths('template', 'keyboard.kps.in'),
     output: kbd + '.kps'
   )
-  kbd_kmp = custom_target(kbd + '.kmp',
-    input: kbd_kpj,
-    output: [kbd + '.kmp', kbd + '.kmx'],
-    depend_files: [kbd_kps, kbd_kmn],
-    depfile: kbd + '.dep',
-    command: kmc_cmd + ['build', '--debug', '--no-compiler-version', '@INPUT@'])
+endforeach
 
-  test(kbd, kmx, depends: [kbd_kmp], args: [test_path / kbd + '.kmn', test_path / kbd + '.kmx'])
+foreach kbd : tests
+  test(kbd, kmx, depends: [all_keyboards], args: [test_path / kbd + '.kmn', test_path / kbd + '.kmx'])
 endforeach
 
 # binary file unit tests

--- a/core/tests/unit/ldml/keyboards/keyboards.kpj.in
+++ b/core/tests/unit/ldml/keyboards/keyboards.kpj.in
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<KeymanDeveloperProject>
+  <Options>
+    <BuildPath>$PROJECTPATH</BuildPath>
+    <CompilerWarningsAsErrors>False</CompilerWarningsAsErrors>
+    <WarnDeprecatedCode>False</WarnDeprecatedCode>
+    <CheckFilenameConventions>False</CheckFilenameConventions>
+    <ProjectType>keyboard</ProjectType>
+  </Options>
+  <Files>
+    @keyboards_kpj@
+  </Files>
+</KeymanDeveloperProject>

--- a/core/tests/unit/ldml/keyboards/meson.build
+++ b/core/tests/unit/ldml/keyboards/meson.build
@@ -65,13 +65,7 @@ kmc_cmd = [node, '--enable-source-maps', kmc_root]
 # Build all keyboards in output folder
 
 foreach kbd : tests_needing_copy
-  fs.copyfile(kbd + '.xml', kbd + '.xml')
-
-  configure_file(
-    command: kmc_cmd + ['build', '@INPUT@', '--out-file', '@OUTPUT@'],
-    input: kbd + '.xml',
-    output: kbd + '.kmx',
-  )
+  configure_file(input: kbd + '.xml', output: kbd + '.xml', copy: true)
 endforeach
 
 foreach kbd : tests_with_testdata
@@ -83,15 +77,40 @@ foreach kbd : tests_with_testdata
 endforeach
 
 foreach kbd : tests_from_cldr
-  fs.copyfile(ldml_data / kbd + '.xml', kbd + '.xml')
-  configure_file(
-    command: kmc_cmd + ['build', '@INPUT@', '--out-file', '@OUTPUT@'],
-    input: join_paths(ldml_data, kbd + '.xml'),
-    output: kbd + '.kmx',
-  )
+  configure_file(input: ldml_data / kbd + '.xml', output: kbd + '.xml', copy: true)
   configure_file(
     command: kmc_cmd + ['build', 'ldml-test-data', '@INPUT@', '--out-file', '@OUTPUT@'],
     input: join_paths(ldml_testdata, kbd + '-test.xml'),
     output: kbd + '-test.json',
   )
 endforeach
+
+# Build a single keyboards.kpj which lists all keyboard sources
+
+test_ldml_kmx_targets = tests_needing_copy + tests_from_cldr
+
+test_ldml_keyboards_kpj = ''
+foreach kbd : test_ldml_kmx_targets
+  test_ldml_keyboards_kpj += '''
+    <File>
+      <ID>keyboard_'''+kbd+'''</ID>
+      <Filename>'''+kbd+'''.xml</Filename>
+      <Filepath>'''+kbd+'''.xml</Filepath>
+    </File>
+  '''
+endforeach
+
+cfg = configuration_data()
+cfg.set('keyboards_kpj', test_ldml_keyboards_kpj)
+
+ldml_keyboards_kpj = configure_file(
+  configuration: cfg,
+  input: 'keyboards.kpj.in',
+  output: 'keyboards.kpj'
+)
+
+configure_file(
+  input: ldml_keyboards_kpj,
+  output: tests_from_cldr[0]+'.kmx',
+  command: kmc_cmd + ['build', '@INPUT@']
+)


### PR DESCRIPTION
Build all the .kmx files used for kmn and ldml unit tests in batch rather than one at a time. The ldml-test-data builds remain unbatched for now (and are visibly slow!).

@keymanapp-test-bot skip

Fixes: #13495