### PR TITLE
change(web): lint engine/common/web-utils 🧶 

### DIFF
--- a/web/src/engine/common/web-utils/.eslintrc.cjs
+++ b/web/src/engine/common/web-utils/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  // Temporarily ignored due to noise it would cause within the refactor
+  ignorePatterns: ["**/kmwstring.ts"]
+};

--- a/web/src/engine/common/web-utils/build.sh
+++ b/web/src/engine/common/web-utils/build.sh
@@ -32,7 +32,7 @@ builder_describe_outputs \
 builder_parse "$@"
 
 function do_build() {
-  tsc --build $builder_verbose "$THIS_SCRIPT_PATH/tsconfig.json"
+  compile $SUBPROJECT_NAME
 
   # May be useful one day, for building a mass .d.ts for KMW as a whole.
   # So... tsc does declaration-bundling on its own pretty well, at least for local development.

--- a/web/src/engine/common/web-utils/src/deepCopy.ts
+++ b/web/src/engine/common/web-utils/src/deepCopy.ts
@@ -15,7 +15,7 @@ export default function deepCopy<T extends ({[key: string | number | symbol]: an
     // For arrays, skips over sparse entries.  Not that we use sparse arrays, but still.
     const keys = Object.keys(p);
 
-    for(let key of keys) {
+    for(const key of keys) {
       // @ts-ignore
       if(p[key] !== undefined) {
         // @ts-ignore

--- a/web/src/engine/common/web-utils/src/priority-queue.ts
+++ b/web/src/engine/common/web-utils/src/priority-queue.ts
@@ -80,11 +80,11 @@ export default class PriorityQueue<Type> {
     // Use of 'indices' here is a bit of a customization.
     // At the cost of (temporary) extra storage space, we can more efficiently enqueue
     // multiple elements simultaneously.
-    let queuedIndices: number[] = [];
+    const queuedIndices: number[] = [];
     let lastParent = -1;
 
     for(let i = end; i >= start; i--) {
-      let parent = PriorityQueue.parentIndex(i);
+      const parent = PriorityQueue.parentIndex(i);
       if(this.siftDown(i) && parent < start && lastParent != parent) {
         // We only need to queue examination for a heap node if its children have changed
         // and it isn't already being examined.
@@ -95,8 +95,8 @@ export default class PriorityQueue<Type> {
 
     lastParent = -1;
     while(queuedIndices.length > 0) {
-      let index = queuedIndices.shift() as number;
-      let parent = PriorityQueue.parentIndex(index);
+      const index = queuedIndices.shift() as number;
+      const parent = PriorityQueue.parentIndex(index);
       if(this.siftDown(index) && parent >= 0 && lastParent != parent) {
           // We only need to queue examination for a heap node if its children have changed.
         queuedIndices.push(parent);
@@ -131,10 +131,10 @@ export default class PriorityQueue<Type> {
     let index = this.heap.length;
     this.heap.push(element);
 
-    let parent = PriorityQueue.parentIndex;
+    const parent = PriorityQueue.parentIndex;
     let parentIndex = parent(index);
     while(index !== 0 && this.comparator(this.heap[index], this.heap[parentIndex]) < 0) {
-      let a = this.heap[index];
+      const a = this.heap[index];
       this.heap[index] = this.heap[parentIndex];
       this.heap[parentIndex] = a;
 
@@ -156,9 +156,9 @@ export default class PriorityQueue<Type> {
       return;
     }
 
-    let firstIndex = this.count
+    const firstIndex = this.count
     this.heap = this.heap.concat(elements);
-    let firstParent = PriorityQueue.parentIndex(firstIndex);
+    const firstParent = PriorityQueue.parentIndex(firstIndex);
 
     // The 'parent' of index 0 will return -1, which is illegal.
     this.heapify(firstParent >= 0 ? firstParent : 0, PriorityQueue.parentIndex(this.count-1));
@@ -175,7 +175,7 @@ export default class PriorityQueue<Type> {
     }
 
     const root = this.heap[0];
-    let tail = this.heap.pop() as Type;
+    const tail = this.heap.pop() as Type;
     if(this.heap.length > 0) {
       this.heap[0] = tail;
       this.siftDown(0);
@@ -195,8 +195,8 @@ export default class PriorityQueue<Type> {
    * @returns `true` if a swap occurred, `false` otherwise.
    */
   private siftDown(index: number): boolean {
-    let leftIndex = PriorityQueue.leftChildIndex(index);
-    let rightIndex = PriorityQueue.rightChildIndex(index);
+    const leftIndex = PriorityQueue.leftChildIndex(index);
+    const rightIndex = PriorityQueue.rightChildIndex(index);
     let topMostIndex = index;
 
     if(leftIndex < this.heap.length && this.comparator(this.heap[leftIndex], this.heap[topMostIndex]) < 0) {
@@ -208,7 +208,7 @@ export default class PriorityQueue<Type> {
     }
 
     if(topMostIndex != index) {
-      let a = this.heap[index];
+      const a = this.heap[index];
       this.heap[index] = this.heap[topMostIndex];
       this.heap[topMostIndex] = a;
 

--- a/web/src/engine/common/web-utils/src/version.ts
+++ b/web/src/engine/common/web-utils/src/version.ts
@@ -29,7 +29,7 @@ export default class Version {
     }
 
     if(Array.isArray(text)) {
-      let components = text as number[];
+      const components = text as number[];
       if(components.length < 2) {
         throw new Error("Version string must have at least a major and minor component!");
       } else {
@@ -39,15 +39,15 @@ export default class Version {
     }
 
     // else, standard constructor path.
-    let parts = text.split('.');
-    let componentArray: number[] = [];
+    const parts = text.split('.');
+    const componentArray: number[] = [];
 
     if(parts.length < 2) {
       throw new Error("Version string must have at least a major and minor component!");
     }
 
     for(let i=0; i < parts.length; i++) {
-      let value = parseInt(parts[i], 10);
+      const value = parseInt(parts[i], 10);
       if(isNaN(value)) {
         throw new Error("Version string components must be numerical!");
       }
@@ -84,18 +84,18 @@ export default class Version {
 
   compareTo(other: Version): number {
     // If the version info depth differs, we need a flag to indicate which instance is shorter.
-    var isShorter: boolean = this.components.length < other.components.length;
-    var maxDepth: number = (this.components.length < other.components.length) ? this.components.length : other.components.length;
+    const isShorter: boolean = this.components.length < other.components.length;
+    const maxDepth: number = (this.components.length < other.components.length) ? this.components.length : other.components.length;
 
-    var i: number;
+    let i: number;
     for(i = 0; i < maxDepth; i++) {
-      let delta = this.components[i] - other.components[i];
+      const delta = this.components[i] - other.components[i];
       if(delta != 0) {
         return delta;
       }
     }
 
-    var longList = isShorter ? other.components : this.components;
+    const longList = isShorter ? other.components : this.components;
     do {
       if(longList[i] > 0) {
         return isShorter ? -1 : 1;


### PR DESCRIPTION
Now that the PR linking web-utils to the main web/ build (#13714) is merged in, we can start connecting it to linting as well.  This change does not include kmwstring.ts for linting, though, as that has an existing rework.  A separate PR will be added as a followup to the refactor PR (#13726) to handle its final version.

@keymanapp-test-bot skip