### PR TITLE
maint(common): remove platform advocates from CODEOWNERS

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,37 +1,16 @@
 #
-# Code owners - this lists first the primary dev, then second, the platform advocate for each area
-#             - in addition, it lists additional reviewers
-#
-# @darcywong00 @mcdurdin @ermshiperete @rc-swag @SabineSIL @sgschantz
+# Code owners - this lists the primary dev for each area
 #
 ## Note: Per 2025-April CODEOWNERS is not used, please add reviews manually
 ##  — contact team owners if you're unsure.
 #
 #
-#/android/                         @darcywong00  @sgschantz
-#
-#/common/                          @mcdurdin     @rc-swag         @srl295
-#/core/                            @mcdurdin     @rc-swag         @srl295
-#/common/lexical-model-types/      @jahorton     @mcdurdin
-#/common/schemas/                  @mcdurdin     @jahorton
-#/common/test/                     @mcdurdin     @ermshiperete
-#/common/web/                      @jahorton     @mcdurdin
-#
-#/developer/                       @mcdurdin     @darcywong00     @SabineSIL @markcsinclair @srl295
-#/docs/                            @mcdurdin     @jahorton
-#/ios/                             @sgschantz    @jahorton
-#/linux/                           @ermshiperete @darcywong00
-#/mac/                             @sgschantz    @SabineSIL
-#
-#/oem/firstvoices/android/         @darcywong00  @sgschantz
-#/oem/firstvoices/common/          @mcdurdin     @rc-swag
-#/oem/firstvoices/ios/             @sgschantz    @jahorton
-#/oem/firstvoices/windows/         @rc-swag      @ermshiperete
-#/resources/                       @mcdurdin     @jahorton         @srl295
-#
-# Web is currently shared between Eberhard and Joshua:
-#/web/                             @ermshiperete @jahorton
-#/web/src/engine/predictive-text/  @jahorton     @mcdurdin
-#
-#/windows/                         @rc-swag      @ermshiperete
-#
+#/android/                         @darcywong00
+#/common/                          @mcdurdin
+#/core/                            @mcdurdin
+#/developer/                       @mcdurdin
+#/ios/
+#/linux/                           @ermshiperete
+#/mac/                             @sgschantz
+#/web/                             @ermshiperete
+#/windows/                         @rc-swag


### PR DESCRIPTION
These remain commented out, but status.keyman.com will parse all lines starting with `#/<path>/` in order to find the platform owners.

@keymanapp-test-bot skip