### PR TITLE
maint(common): Update write_download_info() to be cross-platform

### DIFF
--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -138,13 +138,13 @@ write_download_info() {
   FILE_EXTENSION="${BASE_FILE##*.}"
 
   # stat flags to get filesize in bytes
-  if [[ "$BUILDER_OS" == mac ]]; then
+  if [[ "$BUILDER_OS" == mac ]] && [[ $(which stat) == /usr/bin/stat ]]; then
     STAT_FLAGS="-f%z"
   else
     STAT_FLAGS="-c%s"
   fi
   FILE_SIZE=$(/usr/bin/stat ${STAT_FLAGS} "${BASE_PATH}/${BASE_FILE}")
-  MD5_HASH=($(md5sum "${BASE_PATH}/${BASE_FILE}")) # hash is the first element returned
+  MD5_HASH=$(md5sum "${BASE_PATH}/${BASE_FILE}" | cut -d" " -f 1 -) # hash is the first element returned
 
   if [[ -f "$DOWNLOAD_INFO_FILEPATH" ]]; then
     builder_warn "Overwriting $DOWNLOAD_INFO_FILEPATH"

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -137,8 +137,14 @@ write_download_info() {
 
   FILE_EXTENSION="${BASE_FILE##*.}"
 
-  FILE_SIZE=$(/usr/bin/stat -f"%z" "${BASE_PATH}/${BASE_FILE}")
-  MD5_HASH=$(md5 -q "${BASE_PATH}/${BASE_FILE}")
+  # stat flags to get filesize in bytes
+  if [[ "$BUILDER_OS" == mac ]]; then
+    STAT_FLAGS="-f%z"
+  else
+    STAT_FLAGS="-c%s"
+  fi
+  FILE_SIZE=$(/usr/bin/stat ${STAT_FLAGS} "${BASE_PATH}/${BASE_FILE}")
+  MD5_HASH=($(md5sum "${BASE_PATH}/${BASE_FILE}")) # hash is the first element returned
 
   if [[ -f "$DOWNLOAD_INFO_FILEPATH" ]]; then
     builder_warn "Overwriting $DOWNLOAD_INFO_FILEPATH"

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -137,6 +137,7 @@ write_download_info() {
 
   FILE_EXTENSION="${BASE_FILE##*.}"
 
+  builder_echo "BUILDER_OS: ${BUILDER_OS}"
   # stat flags to get filesize in bytes
   if [[ "$BUILDER_OS" == mac ]] && [[ $(which stat) == /usr/bin/stat ]]; then
     STAT_FLAGS="-f%z"

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -137,14 +137,14 @@ write_download_info() {
 
   FILE_EXTENSION="${BASE_FILE##*.}"
 
-  builder_echo "BUILDER_OS: ${BUILDER_OS}"
   # stat flags to get filesize in bytes
-  if [ "$BUILDER_OS" == "mac" ] && [[ $(which stat) == /usr/bin/stat ]]; then
+  if [ "$BUILDER_OS" == "mac" ] && [[ $(which stat) == /opt/homebrew/opt/coreutils/libexec/gnubin/stat ]]; then
+    # Handle coreutils flags
     STAT_FLAGS="-f%z"
   else
     STAT_FLAGS="-c%s"
   fi
-  FILE_SIZE=$(/usr/bin/stat ${STAT_FLAGS} "${BASE_PATH}/${BASE_FILE}")
+  FILE_SIZE=$(stat ${STAT_FLAGS} "${BASE_PATH}/${BASE_FILE}")
   MD5_HASH=$(md5sum "${BASE_PATH}/${BASE_FILE}" | cut -d" " -f 1 -) # hash is the first element returned
 
   if [[ -f "$DOWNLOAD_INFO_FILEPATH" ]]; then

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -139,7 +139,7 @@ write_download_info() {
 
   builder_echo "BUILDER_OS: ${BUILDER_OS}"
   # stat flags to get filesize in bytes
-  if [[ "$BUILDER_OS" == mac ]] && [[ $(which stat) == /usr/bin/stat ]]; then
+  if [ "$BUILDER_OS" == "mac" ] && [[ $(which stat) == /usr/bin/stat ]]; then
     STAT_FLAGS="-f%z"
   else
     STAT_FLAGS="-c%s"

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -138,8 +138,8 @@ write_download_info() {
   FILE_EXTENSION="${BASE_FILE##*.}"
 
   # stat flags to get filesize in bytes
-  if [ "$BUILDER_OS" == "mac" ] && [[ $(which stat) != /usr/bin/stat ]]; then
-    # BSD
+  if [ "$BUILDER_OS" == "mac" ] && [[ $(which stat) == /usr/bin/stat ]]; then
+    # /usr/bin/stat on mac is BSD
     STAT_FLAGS="-f%z"
   else
     # GNU (coreutils)

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -138,10 +138,11 @@ write_download_info() {
   FILE_EXTENSION="${BASE_FILE##*.}"
 
   # stat flags to get filesize in bytes
-  if [ "$BUILDER_OS" == "mac" ] && [[ $(which stat) == /opt/homebrew/opt/coreutils/libexec/gnubin/stat ]]; then
-    # Handle coreutils flags
+  if [ "$BUILDER_OS" == "mac" ] && [[ $(which stat) != /usr/bin/stat ]]; then
+    # BSD
     STAT_FLAGS="-f%z"
   else
+    # GNU (coreutils)
     STAT_FLAGS="-c%s"
   fi
   FILE_SIZE=$(stat ${STAT_FLAGS} "${BASE_PATH}/${BASE_FILE}")


### PR DESCRIPTION
Relates to #11595 that I needed to make progress on #12373

Update write_download_info() to be cross-platform (currently used by iOS build)
https://github.com/keymanapp/keyman/blob/73dcf200859c6692591ad856da1d0da2af86a34d/ios/tools/prepRelease.sh#L131-L132

## Changes
* Handle stat flags based on `BUILDER_OS` (macOS differs from win/Linux)
* Change from md5 (macOS only) to md5sum (all)

Test-bot: skip
