### PR TITLE
fix(mac): add version metadata after building tests

### DIFF
--- a/mac/build.sh
+++ b/mac/build.sh
@@ -303,6 +303,10 @@ do_publish() {
 builder_run_action clean          do_clean
 builder_run_action configure      do_configure
 
+# Note: `xcodebuild test` rewrites info.plist, so we need to patch the metadata
+# after testing for use in install/publish, hence the multiple build:engine /
+# build:app runs
+
 builder_run_action build:engine   do_build_engine
 builder_run_action test:engine    execBuildCommand $ENGINE_NAME "xcodebuild -project \"$KME4M_PROJECT_PATH\" $BUILD_OPTIONS test -scheme $ENGINE_NAME"
 builder_run_action build:engine   do_update_engine_metadata

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -169,6 +169,9 @@ do_build_engine ( ) {
   ### Build Keyman Engine (kmx, ldml processor) ###
 
   execBuildCommand $ENGINE_NAME "xcodebuild -project \"$KME4M_PROJECT_PATH\" $BUILD_OPTIONS $BUILD_ACTIONS -scheme $ENGINE_NAME"
+}
+
+do_update_engine_metadata ( ) {
   execBuildCommand "$ENGINE_NAME dSYM file" "dsymutil \"$KME4M_BASE_PATH/build/$CONFIG/$ENGINE_NAME.framework/Versions/A/$ENGINE_NAME\" -o \"$KME4M_BASE_PATH/build/$CONFIG/$ENGINE_NAME.framework.dSYM\""
   updatePlist "$KME4M_BASE_PATH/build/$CONFIG/$ENGINE_NAME.framework/Resources/Info.plist" "Keyman Engine"
 }
@@ -181,6 +184,9 @@ do_build_app ( ) {
   builder_heading "Building Keyman.app"
 
   execBuildCommand $IM_NAME "xcodebuild -workspace \"$KMIM_WORKSPACE_PATH\" $CODESIGNING_SUPPRESSION $BUILD_OPTIONS $BUILD_ACTIONS -scheme Keyman SYMROOT=\"$KM4MIM_BASE_PATH/build\""
+}
+
+do_update_app_metadata ( ) {
   updatePlist "$KM4MIM_BASE_PATH/build/$CONFIG/Keyman.app/Contents/Info.plist" "Keyman"
 
   if builder_is_debug_build; then
@@ -298,12 +304,16 @@ builder_run_action clean          do_clean
 builder_run_action configure      do_configure
 
 builder_run_action build:engine   do_build_engine
-builder_run_action build:app      do_build_app
-builder_run_action build:testapp  do_build_testapp
-
 builder_run_action test:engine    execBuildCommand $ENGINE_NAME "xcodebuild -project \"$KME4M_PROJECT_PATH\" $BUILD_OPTIONS test -scheme $ENGINE_NAME"
+builder_run_action build:engine   do_update_engine_metadata
+
+builder_run_action build:app      do_build_app
 builder_run_action test:app       execBuildCommand "$IM_NAME-tests" "xcodebuild test -workspace \"$KMIM_WORKSPACE_PATH\" $CODESIGNING_SUPPRESSION $BUILD_OPTIONS -scheme Keyman SYMROOT=\"$KM4MIM_BASE_PATH/build\""
 builder_run_action test:help      check-markdown  "$KEYMAN_ROOT/mac/docs/help"
+builder_run_action build:app      do_update_app_metadata
+
+builder_run_action build:testapp  do_build_testapp
+
 
 builder_run_action install do_install
 


### PR DESCRIPTION
The mac build started to lose rewritten info.plist metadata in #11444 when tests were run after the build completed. When the tests were run, xcodebuild would rewrite the info.plist, losing the rewritten metadata.

This patch updates the build script to write the metadata after unit tests (if any) are run.

Fixes: https://github.com/keymanapp/keyman/issues/13791
Test-bot: skip