### PR TITLE
maint(web): simplify worker-main test.sh

### DIFF
--- a/web/src/engine/predictive-text/worker-main/unit_tests/test.sh
+++ b/web/src/engine/predictive-text/worker-main/unit_tests/test.sh
@@ -20,7 +20,6 @@ FLAGS=""
 builder_describe "Runs all tests for the language-modeling / predictive-text layer module" \
   "configure" \
   "test+" \
-  ":libraries  Runs unit tests for in-repo libraries used by this module"\
   ":headless   Runs this module's headless user tests" \
   ":browser    Runs this module's browser-based user tests"
 
@@ -31,31 +30,6 @@ builder_parse "$@"
 if builder_start_action configure; then
   verify_npm_setup
   builder_finish_action success configure
-fi
-
-if builder_start_action test:libraries; then
-
-  # Note:  these do not yet provide TeamCity-friendly-formatted test reports.
-  # They do not have builder-based scripts, being run directly via npm package script.
-  # So, for now, we add a text header to clarify what is running at each stage, in
-  # addition to fair bit of `pushd` and `popd`.
-  echo
-  echo "### Running $(builder_term web/src/engine/predictive-text/wordbreakers) tests"
-  "$KEYMAN_ROOT/web/src/engine/predictive-text/wordbreakers/build.sh" test
-
-  pushd "$KEYMAN_ROOT/web/src/engine/predictive-text/templates/"
-  echo
-  echo "### Running $(builder_term web/src/engine/predictive-text/templates/) tests"
-  "$KEYMAN_ROOT/web/src/engine/predictive-text/templates/build.sh" test
-  popd
-
-  pushd "$KEYMAN_ROOT/web/src/engine/predictive-text/worker-thread"
-  echo
-  echo "### Running ${BUILDER_TERM_START}web/src/engine/predictive-text/worker-thread${BUILDER_TERM_END} tests"
-  ./build.sh test
-  popd
-
-  builder_finish_action success test:libraries
 fi
 
 if builder_start_action test:headless; then
@@ -69,33 +43,6 @@ if builder_start_action test:headless; then
 
   builder_finish_action success test:headless
 fi
-
-# If we are running a TeamCity test build, for now, only run BrowserStack
-# tests when on a PR branch with a title including "(web)" or with the label
-# test-browserstack. This is because the BrowserStack tests are currently
-# unreliable, and the false positive failures are masking actual failures.
-#
-# We do not run BrowserStack tests on master, beta, or stable-x.y test
-# builds.
-if [[ $VERSION_ENVIRONMENT == test ]] && builder_has_action test:browser; then
-  if builder_pull_get_details; then
-    if ! ([[ $builder_pull_title =~ \(web\) ]] || builder_pull_has_label test-browserstack); then
-
-      echo "Auto-skipping $(builder_term test:browser) for unrelated CI test build"
-      exit 0
-    fi
-  fi
-fi
-
-get_browser_set_for_OS ( ) {
-  if [[ $BUILDER_OS == mac ]]; then
-    BROWSERS="--browsers Firefox,Chrome,Safari"
-  elif [[ $BUILDER_OS == win ]]; then
-    BROWSERS="--browsers Chrome"
-  else
-    BROWSERS="--browsers Firefox,Chrome"
-  fi
-}
 
 if builder_start_action test:browser; then
   WTR_CONFIG=


### PR DESCRIPTION
I just realized that #13807 basically eliminates the need for worker-main's `test:libraries` action.  Between that and old BrowserStack-oriented code, worker-main's test script can be considerably simplified.

@keymanapp-test-bot skip