### PR TITLE
maint(common): remove `eslint:recommended` configuration for .ts

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,8 +5,7 @@ module.exports = {
     es2021: true,
     node: true,
   },
-  extends: [ "eslint:recommended", "plugin:@typescript-eslint/eslint-recommended"],
-  extends: ["plugin:@typescript-eslint/eslint-recommended"],
+  extends: [ "plugin:@typescript-eslint/eslint-recommended"],
   parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaVersion: "latest",


### PR DESCRIPTION
In #13788, I aimed to address a TODO about adding `eslint:recommended` as a lint setting, but missed that the following line would override it instantly.

After some testing, I realized _why_ we hadn't done it before - the `eslint:recommended` setting is designed for raw JS, not TS.  For example, it doesn't like TS type definition for function parameters or function type definitions.  We should probably just drop `eslint:recommended` against TS files.

Test-bot: skip