### PR TITLE
fix(windows): add breadcrumb to download failures

### DIFF
--- a/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
@@ -59,6 +59,7 @@ uses
   OnlineUpdateCheckMessages,
   RegistryKeys,
   Upload_Settings,
+  UtilCheckOnline,
   utilkmshell;
 
 procedure ErrorLogMessage(ErrorLogMessage: string);
@@ -143,6 +144,7 @@ begin
     else
     begin
       Params.Packages[i].Install := False; // Download failed but install other files
+      TKeymanSentryClient.Breadcrumb('error', 'Download failded for keyboard: '+ Params.Packages[i].DownloadURL, 'cli.download');
     end;
   end;
 
@@ -157,6 +159,7 @@ begin
     else
     begin
       ErrorLogMessage('DoDownloadUpdates Failed to download' + Params.InstallURL);
+      TKeymanSentryClient.Breadcrumb('error', 'Download failded for keyboard: '+  Params.InstallURL, 'cli.download');
     end;
   end;
   // If there is at least one keyboard package or version of keyman downloaded then
@@ -172,6 +175,11 @@ var
   DownloadBackGroundSavePath : String;
   ucr: TUpdateCheckResponse;
 begin
+  if not IsOnline then
+  begin
+    TKeymanSentryClient.Breadcrumb('default', 'TDownloadUpdate: Not Online, cant execute download process.', 'cli.download');
+    Exit;
+  end;
   DownloadBackGroundSavePath := IncludeTrailingPathDelimiter(TKeymanPaths.KeymanUpdateCachePath);
   if TUpdateCheckStorage.LoadUpdateCacheData(ucr) then
   begin

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -126,6 +126,7 @@ uses
   KLog,
   RegistryKeys,
   utilexecute,
+  UtilCheckOnline,
   utiluac;
 
 const
@@ -685,6 +686,12 @@ var
   FResult: Boolean;
   RootPath: string;
 begin
+  // check if online
+  if not IsOnline then
+  begin
+    TKeymanSentryClient.Breadcrumb('default', 'Not Online, cant execute download process.', 'update');
+    Exit;
+  end;
   // call separate process
   RootPath := ExtractFilePath(ParamStr(0));
   FResult := TUtilExecute.ShellCurrentUser(0, ParamStr(0),


### PR DESCRIPTION
This adds keyboard URL which will identify the name of the keyboard that has failed to download.
It will do the same for the keyman update URL. This will give insight into if it is certain keyboards that are failing to download.
It also add checks to see if it\the system is online before attempting downloads. Adding breadcrumbs for this also.
