### PR TITLE
maint(common): automatically set --debug option for local-environment builder-script uses

### DIFF
--- a/resources/build/test/debug-deps/test.sh
+++ b/resources/build/test/debug-deps/test.sh
@@ -17,6 +17,6 @@ function do_build() {
   echo "PASS: parent: builder_has_option --debug is true"
 }
 
-builder_parse build:child -d
+builder_parse build:child --debug
 builder_run_action build do_build
 builder_run_child_actions build

--- a/resources/build/test/test.sh
+++ b/resources/build/test/test.sh
@@ -89,6 +89,12 @@ fi
 builder_parse_test() {
   local expected="$1"
   local expected_options="$2"
+
+  # Minor override for local testing of builder-script mechanics:  --debug will always be added.
+  if [[ $VERSION_ENVIRONMENT == "local" ]]; then
+    expected_options="${expected_options} --debug"
+  fi
+
   shift
   shift
   local parameters="$@"
@@ -97,8 +103,10 @@ builder_parse_test() {
   if [[ "$expected" != "${_builder_chosen_action_targets[@]}" ]]; then
     builder_die "  Test: builder_parse $parameters action:target != \"$expected\""
   fi
-  if [[ "$expected_options" != "${_builder_chosen_options[@]}" ]]; then
-    builder_die "  Test: builder_parse $parameters, options != \"$expected\""
+  if [[ "${expected_options}" != "${_builder_chosen_options[@]}" ]]; then
+    echo "${_builder_chosen_options[@]}"
+    echo "${_builder_chosen_options[@]}"
+    builder_die "  Test: builder_parse $parameters, options != \"${expected_options}\""
   fi
 }
 
@@ -184,6 +192,14 @@ fi
 echo -e "${COLOR_BLUE}## Testing output of: builder_parse --feature xyzzy --bar abc --baz def test${COLOR_RESET}"
 parse_output=$(builder_parse --feature xyzzy --bar abc --baz def test)
 expected="$(builder_echo setmark "test.sh parameters: <--feature xyzzy --bar abc --baz def test>")"
+
+if [[ $VERSION_ENVIRONMENT == "local" ]]; then
+  expected="$(builder_echo setmark "test.sh parameters: <--feature xyzzy --bar abc --baz def test --debug>")"
+  # Yay, the fun of getting the second line... that newline before the closing brace is intentional.  :(
+  parse_output=${parse_output#*
+}
+
+fi
 if [[ "${parse_output[*]}" != "${expected}" ]]; then
   builder_die "FAIL: Wrong output for '--feature xyzzy --bar abc --baz def test':\n  Actual  : ${parse_output[*]}\n  Expected: ${expected}"
 fi

--- a/resources/build/test/test.sh
+++ b/resources/build/test/test.sh
@@ -90,7 +90,7 @@ builder_parse_test() {
   local expected="$1"
   local expected_options="$2"
 
-  # Minor override for local testing of builder-script mechanics:  --debug will always be added.
+  # When testing in a local environment, --debug will be added by default (see #11106)
   if [[ $VERSION_ENVIRONMENT == "local" ]]; then
     expected_options="${expected_options} --debug"
   fi
@@ -104,8 +104,6 @@ builder_parse_test() {
     builder_die "  Test: builder_parse $parameters action:target != \"$expected\""
   fi
   if [[ "${expected_options}" != "${_builder_chosen_options[@]}" ]]; then
-    echo "${_builder_chosen_options[@]}"
-    echo "${_builder_chosen_options[@]}"
     builder_die "  Test: builder_parse $parameters, options != \"${expected_options}\""
   fi
 }
@@ -194,11 +192,8 @@ parse_output=$(builder_parse --feature xyzzy --bar abc --baz def test)
 expected="$(builder_echo setmark "test.sh parameters: <--feature xyzzy --bar abc --baz def test>")"
 
 if [[ $VERSION_ENVIRONMENT == "local" ]]; then
-  expected="$(builder_echo setmark "test.sh parameters: <--feature xyzzy --bar abc --baz def test --debug>")"
-  # Yay, the fun of getting the second line... that newline before the closing brace is intentional.  :(
-  parse_output=${parse_output#*
-}
-
+  # When run in a local-dev environment, an extra line appears about the automatic --debug option.
+  expected="$(builder_echo grey "Local build environment detected:  setting --debug")"$'\n'"$(builder_echo setmark "test.sh parameters: <--feature xyzzy --bar abc --baz def test --debug>")"
 fi
 if [[ "${parse_output[*]}" != "${expected}" ]]; then
   builder_die "FAIL: Wrong output for '--feature xyzzy --bar abc --baz def test':\n  Actual  : ${parse_output[*]}\n  Expected: ${expected}"

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1048,7 +1048,7 @@ _builder_get_default_description() {
     :module)   description="this module" ;;
     :tools)    description="build tools for this project" ;;
     --debug)   description="debug build" ;;
-    --release) description="release build" ;;
+    --release) description="release build (prevents --debug in local-env builds)" ;;
   esac
   echo "$description"
 }
@@ -1270,7 +1270,7 @@ _builder_parse_expanded_parameters() {
   _builder_build_deps=--deps
   builder_verbose=
   builder_debug=
-  local builder_release=
+  local is_release=
   local _params=($@)
   _builder_chosen_action_targets=()
   _builder_chosen_options=()
@@ -1387,15 +1387,15 @@ _builder_parse_expanded_parameters() {
           _builder_chosen_options+=(--verbose)
           builder_verbose=--verbose
           ;;
-        --debug|-d)
+        --debug)
           _builder_chosen_options+=(--debug)
           builder_debug=--debug
           ;;
-        --release|-r)
+        --release)
           _builder_chosen_options+=(--release)
           # As of #13827, this is only checked when detecting if --debug should be auto-applied.
           # There is no `builder_is_release_build` function yet.
-          builder_release=--release
+          is_release=--release
           ;;
         --deps|--no-deps|--force-deps)
           _builder_build_deps=$key
@@ -1484,7 +1484,7 @@ _builder_parse_expanded_parameters() {
 
     # Per #11106, local builds use --debug by default.
     # Second condition prevents the block (and message) from executing when --debug is already specified explicitly.
-    if [[ $VERSION_ENVIRONMENT == "local" ]] && [[ $builder_debug != --debug ]] && [[ $builder_release != --release ]]; then
+    if [[ $VERSION_ENVIRONMENT == "local" ]] && [[ $builder_debug != --debug ]] && [[ $is_release != --release ]]; then
       builder_echo grey "Local build environment detected:  setting --debug"
       _params+=(--debug)
       _builder_chosen_options+=(--debug)

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1461,6 +1461,16 @@ _builder_parse_expanded_parameters() {
     done
   fi
 
+  # Per #11106, local builds are now automatically forced into the --debug configuration.
+  # Set now so that the automatic --debug shows up in the parameter list reported from
+  # the final 'else' block in the following if-else chain.
+  if [[ $VERSION_ENVIRONMENT == "local" ]] && [[ $builder_debug != --debug ]]; then
+    builder_echo grey "Local build environment detected:  setting --debug"
+    _params+=(--debug)
+    _builder_chosen_options+=(--debug)
+    builder_debug=--debug
+  fi
+
   if builder_is_dep_build; then
     if [[ -z ${_builder_deps_built+x} ]]; then
       builder_die "FATAL ERROR: Expected '_builder_deps_built' variable to be set"

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1270,7 +1270,7 @@ _builder_parse_expanded_parameters() {
   _builder_build_deps=--deps
   builder_verbose=
   builder_debug=
-  builder_release=
+  local builder_release=
   local _params=($@)
   _builder_chosen_action_targets=()
   _builder_chosen_options=()

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1394,7 +1394,6 @@ _builder_parse_expanded_parameters() {
         --release)
           _builder_chosen_options+=(--release)
           # As of #13827, this is only checked when detecting if --debug should be auto-applied.
-          # There is no `builder_is_release_build` function yet.
           is_release=true
           ;;
         --deps|--no-deps|--force-deps)

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1270,7 +1270,7 @@ _builder_parse_expanded_parameters() {
   _builder_build_deps=--deps
   builder_verbose=
   builder_debug=
-  local is_release=
+  local is_release=false
   local _params=($@)
   _builder_chosen_action_targets=()
   _builder_chosen_options=()
@@ -1395,7 +1395,7 @@ _builder_parse_expanded_parameters() {
           _builder_chosen_options+=(--release)
           # As of #13827, this is only checked when detecting if --debug should be auto-applied.
           # There is no `builder_is_release_build` function yet.
-          is_release=--release
+          is_release=true
           ;;
         --deps|--no-deps|--force-deps)
           _builder_build_deps=$key
@@ -1484,7 +1484,7 @@ _builder_parse_expanded_parameters() {
 
     # Per #11106, local builds use --debug by default.
     # Second condition prevents the block (and message) from executing when --debug is already specified explicitly.
-    if [[ $VERSION_ENVIRONMENT == "local" ]] && [[ $builder_debug != --debug ]] && [[ $is_release != --release ]]; then
+    if [[ $VERSION_ENVIRONMENT == "local" ]] && [[ $builder_debug != --debug ]] && ! $is_release; then
       builder_echo grey "Local build environment detected:  setting --debug"
       _params+=(--debug)
       _builder_chosen_options+=(--debug)


### PR DESCRIPTION
Fixes: #11106

This is performed by checking our `$VERSION_ENVIRONMENT` and seeing if it reports "local".  If this is the case, and `--debug` isn't already set, it will be automatically added as a selected option in builder-scripts.

Example run:

<img alt="local-env run of web's engine/dom-utils" src="https://github.com/user-attachments/assets/e6e2e98c-506d-4bfb-a1c4-58255258f0df" />

Note how both child builds and dependency builds also receive the automatically-set `--debug` flag from the top-level script.

So long as we don't mess up our scripting toolchain in a manner that makes CI agents look "local", this should be enough to accomplish the goals of the base issue.

------

There may be a little more work needed here - such as determining the best way to handle builder tests when run locally:

```
## Testing: builder_parse clean:app test:engine --power
[resources/build/test] Local build environment detected:  setting --debug
[resources/build/test] test.sh parameters: <clean:app test:engine --power --debug>

[resources/build/test]   Test: builder_parse clean:app test:engine --power, options != "clean:app test:engine"
```

Should work fine as-is during CI runs of the tester script, but local-env runs are an issue.  An "is a test" bypass of some sort might be cleaner, but for now, I wrote some workaround logic into the affected tests.

@keymanapp-test-bot skip