### PR TITLE
fix(web): fix var declaration affected by linter strictness + length-style fix

### DIFF
--- a/web/src/engine/osk/src/lengthStyle.ts
+++ b/web/src/engine/osk/src/lengthStyle.ts
@@ -10,7 +10,7 @@ export class ParsedLengthStyle implements LengthStyle {
   public readonly special: 'em' | 'rem';
 
   public constructor(style: LengthStyle | string) {
-    const parsed: LengthStyle = (typeof style == 'string') ? ParsedLengthStyle.parseLengthStyle(style) : style;
+    let parsed: LengthStyle = (typeof style == 'string') ? ParsedLengthStyle.parseLengthStyle(style) : style;
 
     const fallback: LengthStyle = {
       val: 1, // 100%


### PR DESCRIPTION
Forgot about having developed #13774 and #13787 in parallel.  I just merged #13774 earlier without having merged `master`'s changes in first, which caused a linter issue:  what was once possible to declare with `const` no longer is, and thus needs to be changed from `const` (from the linter work) back to `let`.

Test-bot: skip