### PR TITLE
maint(common): use function to detect if running on TC

### DIFF
--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -82,7 +82,7 @@ function do_configure() {
 function do_test() {
   local MOCHA_FLAGS=
 
-  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+  if builder_is_running_on_teamcity; then
     # we're running in TeamCity
     MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
   fi

--- a/common/windows/delphi/general/DUnitX.Loggers.TeamCity.pas
+++ b/common/windows/delphi/general/DUnitX.Loggers.TeamCity.pas
@@ -14,7 +14,7 @@ var
   KeymanRoot: string;
   ReportPath: string;
 begin
-  if GetEnvironmentVariable('TEAMCITY_VERSION') <> '' then
+  if GetEnvironmentVariable('TEAMCITY_GIT_PATH') <> '' then
   begin
     KeymanRoot := ExcludeTrailingPathDelimiter(GetEnvironmentVariable('KEYMAN_ROOT'));
     ReportPath := ExtractRelativePath(KeymanRoot, ExtractFilePath(ParamStr(0)) + 'dunitx-results.xml');

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -337,7 +337,7 @@ check-markdown() {
 builder_do_typescript_tests() {
   local MOCHA_FLAGS=
 
-  if [[ "${TEAMCITY_GIT_PATH:-}" != "" ]]; then
+  if builder_is_running_on_teamcity; then
     # we're running in TeamCity
     MOCHA_FLAGS="-reporter mocha-teamcity-reporter"
   fi

--- a/web/src/test/manual/web/regression-tests/test-builder.js
+++ b/web/src/test/manual/web/regression-tests/test-builder.js
@@ -61,7 +61,7 @@ const cfg = require('karma').config;
 // Note: if karma.conf.js is invalid, then this will die with exit code 1
 // without logging the error. The easiest way to see the error is to
 // run `node_modules/bin/karma start karma.conf.js`
-const karmaConfig = cfg.parseConfig(path.resolve('./karma.conf.js'), process.env.TEAMCITY_PROJECT_NAME ? {'reporters': ['teamcity']} : {});
+const karmaConfig = cfg.parseConfig(path.resolve('./karma.conf.js'), process.env.TEAMCITY_GIT_PATH ? {'reporters': ['teamcity']} : {});
 
 let server = new Server(karmaConfig, function(exitCode) {
   console.log('Karma has exited with ' + exitCode)


### PR DESCRIPTION
This change makes use of the new builder script function to detect if the script is running on TeamCity. Also use the
`TEAMCITY_GIT_PATH` environment consistently to check if we're running on TC.

Test-bot: skip