### PR TITLE
maint(common): use unique names for Keyman version variables  🌇

### DIFF
--- a/.github/workflows/api-verification.yml
+++ b/.github/workflows/api-verification.yml
@@ -15,7 +15,7 @@ jobs:
     name: Verify API for libkeymancore*.so
     runs-on: ubuntu-latest
     outputs:
-      VERSION: ${{ steps.environment_step.outputs.VERSION }}
+      KEYMAN_VERSION: ${{ steps.environment_step.outputs.KEYMAN_VERSION }}
       PRERELEASE_TAG: ${{ steps.environment_step.outputs.PRERELEASE_TAG }}
       GIT_SHA: ${{ steps.environment_step.outputs.GIT_SHA }}
       GIT_BASE: ${{ steps.environment_step.outputs.GIT_BASE }}
@@ -69,7 +69,7 @@ jobs:
       run: |
         echo "Verify API for libkeymancore*.so (${{ steps.environment_step.outputs.GIT_BRANCH }}, branch ${{ steps.environment_step.outputs.GIT_BASE_BRANCH }}, by ${{ steps.environment_step.outputs.GIT_USER }}):" >> $GITHUB_STEP_SUMMARY
 
-        BIN_PACKAGE=$(ls "${GITHUB_WORKSPACE}/artifacts/" | grep "${PKG_NAME}[0-9]*_${{ steps.environment_step.outputs.VERSION }}-1${{ steps.environment_step.outputs.PRERELEASE_TAG }}+$(lsb_release -c -s)1_amd64.deb")
+        BIN_PACKAGE=$(ls "${GITHUB_WORKSPACE}/artifacts/" | grep "${PKG_NAME}[0-9]*_${{ steps.environment_step.outputs.KEYMAN_VERSION }}-1${{ steps.environment_step.outputs.PRERELEASE_TAG }}+$(lsb_release -c -s)1_amd64.deb")
         cd ${{ github.workspace }}/keyman/linux
         ./scripts/deb-packaging.sh \
           --gha \

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -37,7 +37,7 @@ jobs:
     if: github.repository == 'keymanapp/keyman'
     runs-on: ubuntu-24.04
     outputs:
-      VERSION: ${{ steps.version_step.outputs.VERSION }}
+      KEYMAN_VERSION: ${{ steps.version_step.outputs.KEYMAN_VERSION }}
       PRERELEASE_TAG: ${{ steps.prerelease_tag.outputs.PRERELEASE_TAG }}
     steps:
     - name: Checkout
@@ -72,10 +72,10 @@ jobs:
     - name: Build source package
       id: build_source_package
       run: |
-        export TIER=$(cat TIER.md)
+        export KEYMAN_TIER=$(cat TIER.md)
         export GHA_TEST_BUILD="${{ github.event.client_payload.isTestBuild }}"
         export GHA_BRANCH="${{ github.event.client_payload.branch }}"
-        echo "TIER=$TIER" >> $GITHUB_ENV
+        echo "KEYMAN_TIER=$KEYMAN_TIER" >> $GITHUB_ENV
         echo "GHA_TEST_BUILD=${GHA_TEST_BUILD}" >> $GITHUB_ENV
         echo "GHA_BRANCH=${GHA_BRANCH}" >> $GITHUB_ENV
         cd linux
@@ -87,7 +87,7 @@ jobs:
       run: |
         THIS_SCRIPT="$GITHUB_WORKSPACE/.github/workflows/deb-packaging.yml"
         . "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
-        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+        echo "KEYMAN_VERSION=$KEYMAN_VERSION" >> $GITHUB_OUTPUT
 
     - name: Set prerelease tag as output parameter
       id: prerelease_tag
@@ -103,9 +103,9 @@ jobs:
     - name: Output which branch or PR we're building plus name of .dsc file
       run: |
         if [ "${{ github.event.client_payload.isTestBuild }}" == "true" ]; then
-          echo ":checkered_flag: **Test build of version ${{ steps.version_step.outputs.VERSION }} for ${{ github.event.client_payload.branch }}**" >> $GITHUB_STEP_SUMMARY
+          echo ":checkered_flag: **Test build of version ${{ steps.version_step.outputs.KEYMAN_VERSION }} for ${{ github.event.client_payload.branch }}**" >> $GITHUB_STEP_SUMMARY
         else
-          echo ":ship: **Release build of ${{ github.event.client_payload.branch }} branch (${{ github.event.client_payload.branch}}), version ${{ steps.version_step.outputs.VERSION }}**" >> $GITHUB_STEP_SUMMARY
+          echo ":ship: **Release build of ${{ github.event.client_payload.branch }} branch (${{ github.event.client_payload.branch}}), version ${{ steps.version_step.outputs.KEYMAN_VERSION }}**" >> $GITHUB_STEP_SUMMARY
         fi
         echo "" >> $GITHUB_STEP_SUMMARY
         echo ":gift: Generated source package:" >> $GITHUB_STEP_SUMMARY
@@ -140,7 +140,7 @@ jobs:
       uses: ./.github/actions/build-binary-packages
       with:
         dist: ${{ matrix.dist }}
-        version: ${{ needs.sourcepackage.outputs.VERSION }}
+        version: ${{ needs.sourcepackage.outputs.KEYMAN_VERSION }}
         prerelease_tag: ${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}
         deb_fullname: ${{env.DEBFULLNAME}}
         deb_email: ${{env.DEBEMAIL}}
@@ -166,7 +166,7 @@ jobs:
       uses: ./.github/actions/build-binary-packages
       with:
         dist: ${{ matrix.dist }}
-        version: ${{ needs.sourcepackage.outputs.VERSION }}
+        version: ${{ needs.sourcepackage.outputs.KEYMAN_VERSION }}
         prerelease_tag: ${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}
         deb_fullname: ${{env.DEBFULLNAME}}
         deb_email: ${{env.DEBEMAIL}}
@@ -211,8 +211,8 @@ jobs:
       - name: Sign packages
         uses: sillsdev/gha-deb-signing@a38dbde6bc9afabede5e07609105acc83c760ad4 # v0.6
         with:
-          src-pkg-name: "keyman_${{ needs.sourcepackage.outputs.VERSION }}-1_source.changes"
-          bin-pkg-name: "keyman_${{ needs.sourcepackage.outputs.VERSION }}-1${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}+"
+          src-pkg-name: "keyman_${{ needs.sourcepackage.outputs.KEYMAN_VERSION }}-1_source.changes"
+          bin-pkg-name: "keyman_${{ needs.sourcepackage.outputs.KEYMAN_VERSION }}-1${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}+"
           artifacts-prefix: "keyman-"
           artifacts-result-name: "keyman-signedpkgs"
           gpg-signing-key: "${{ secrets.GPG_SIGNING_KEY }}"
@@ -293,7 +293,7 @@ jobs:
         echo "::endgroup::"
 
         echo -e "::group::${COLOR_GREEN}Uploading binary packages"
-        pattern="keyman_${{ needs.sourcepackage.outputs.VERSION }}.+\+(.*)[0-9]_[^.]+.changes"
+        pattern="keyman_${{ needs.sourcepackage.outputs.KEYMAN_VERSION }}.+\+(.*)[0-9]_[^.]+.changes"
         for f in *_amd64.changes; do
           if [[ $f =~ $pattern ]]; then
             dist=${BASH_REMATCH[1]}
@@ -316,7 +316,7 @@ jobs:
 
     - name: Save environment
       run: |
-        echo "VERSION=${{ needs.sourcepackage.outputs.VERSION }}" > artifacts/env
+        echo "KEYMAN_VERSION=${{ needs.sourcepackage.outputs.KEYMAN_VERSION }}" > artifacts/env
         echo "PRERELEASE_TAG=${{ needs.sourcepackage.outputs.PRERELEASE_TAG }}" >> artifacts/env
         echo "GIT_SHA=${{ github.event.client_payload.buildSha }}" >> artifacts/env
         echo "GIT_BASE=${{ github.event.client_payload.baseRef }}" >> artifacts/env

--- a/android/KMAPro/build-play-store-notes.inc.sh
+++ b/android/KMAPro/build-play-store-notes.inc.sh
@@ -12,7 +12,7 @@ function generateReleaseNotes() {
   # Reference: https://github.com/Triple-T/gradle-play-publisher#uploading-release-notes
   #
   local PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/$TIER.txt"
-  if [ $TIER = "stable" ]; then
+  if [ $KEYMAN_TIER = "stable" ]; then
     PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/default.txt"
   fi
   builder_heading "Generating Play Store release notes to $PLAY_RELEASE_NOTES"

--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -43,7 +43,7 @@ fi
 
 builder_describe_outputs \
   configure     /android/KMAPro/kMAPro/libs/keyman-engine.aar \
-  build         /android/KMAPro/kMAPro/build/outputs/apk/$CONFIG/keyman-${VERSION}.apk
+  build         /android/KMAPro/kMAPro/build/outputs/apk/$CONFIG/keyman-${KEYMAN_VERSION}.apk
 
 #### Build
 
@@ -57,12 +57,12 @@ fi
 #### Build action definitions ####
 
 function makeLocalSentryRelease() {
-  echo "Making a Sentry release for tag $VERSION_GIT_TAG"
+  echo "Making a Sentry release for tag $KEYMAN_VERSION_GIT_TAG"
   sentry-cli upload-dif -p keyman-android --include-sources
-  sentry-cli releases -p keyman-android files $VERSION_GIT_TAG upload-sourcemaps ./
+  sentry-cli releases -p keyman-android files $KEYMAN_VERSION_GIT_TAG upload-sourcemaps ./
 
-  echo "Finalizing release tag $VERSION_GIT_TAG"
-  sentry-cli releases finalize "$VERSION_GIT_TAG"
+  echo "Finalizing release tag $KEYMAN_VERSION_GIT_TAG"
+  sentry-cli releases finalize "$KEYMAN_VERSION_GIT_TAG"
 }
 
 

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -29,11 +29,11 @@ android {
         //dumpProperties(project) // Use this to dump all external properties for debugging TeamCity integration
         //println "===END DUMP==="
 
-        // VERSION strings from version.gradle
-        versionCode VERSION_CODE as Integer
-        versionName VERSION_NAME
-        buildConfigField 'String', 'VERSION_ENVIRONMENT', '"'+VERSION_ENVIRONMENT+'"'
-        buildConfigField 'String', 'VERSION_GIT_TAG', '"'+VERSION_GIT_TAG+'"'
+        // KEYMAN_VERSION strings from version.gradle
+        versionCode KEYMAN_VERSION_CODE as Integer
+        versionName KEYMAN_VERSION_NAME
+        buildConfigField 'String', 'KEYMAN_VERSION_ENVIRONMENT', '"'+KEYMAN_VERSION_ENVIRONMENT+'"'
+        buildConfigField 'String', 'KEYMAN_VERSION_GIT_TAG', '"'+KEYMAN_VERSION_GIT_TAG+'"'
     }
 
     String env_release_store_file = System.getenv("release_store_file")
@@ -77,7 +77,7 @@ android {
         //  - PR builds also have "-test-1234" suffix (where 1234 is PR#)
         // Gradle sync will nullify these values, so have a fallback
         String appSuffix = ''
-        String tag = VERSION_TAG ? VERSION_TAG : '-' + tier;
+        String tag = KEYMAN_VERSION_TAG ? KEYMAN_VERSION_TAG : '-' + tier;
         if (tag.startsWithAny("-beta", "beta")) {
             appSuffix = ' Beta';
         } else if (tag.startsWithAny("-alpha", "alpha")) {
@@ -88,16 +88,16 @@ android {
             // -test-PR_NUMBER
             appSuffix = appSuffix + match.group(1)
         } else {
-            String environment = VERSION_ENVIRONMENT ? VERSION_ENVIRONMENT : 'local';
+            String environment = KEYMAN_VERSION_ENVIRONMENT ? KEYMAN_VERSION_ENVIRONMENT : 'local';
             if (environment.matches("local")) {
                 appSuffix = appSuffix + '-' + environment;
             }
         }
         variant.resValue "string", "app_name", 'Keyman' + appSuffix;
 
-        // Adjust output name to "keyman-${VERSION_MD}.apk"
+        // Adjust output name to "keyman-${KEYMAN_VERSION_MD}.apk"
         variant.outputs.all {
-            outputFileName = "keyman-" + VERSION_MD + ".apk"
+            outputFileName = "keyman-" + KEYMAN_VERSION_MD + ".apk"
         }
     }
     lintOptions {

--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -62,8 +62,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
       Log.d(TAG, "Initializing Sentry");
       SentryAndroid.init(getApplicationContext(), options -> {
         options.setEnableAutoSessionTracking(false);
-        options.setRelease(com.tavultesoft.kmapro.BuildConfig.VERSION_GIT_TAG);
-        options.setEnvironment(com.tavultesoft.kmapro.BuildConfig.VERSION_ENVIRONMENT);
+        options.setRelease(com.tavultesoft.kmapro.BuildConfig.KEYMAN_VERSION_GIT_TAG);
+        options.setEnvironment(com.tavultesoft.kmapro.BuildConfig.KEYMAN_VERSION_ENVIRONMENT);
       });
     }
     if (BuildConfig.DEBUG) {

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -144,8 +144,8 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     if (KMManager.getMaySendCrashReport()) {
       SentryAndroid.init(context, options -> {
         options.setEnableAutoSessionTracking(false);
-        options.setRelease(com.tavultesoft.kmapro.BuildConfig.VERSION_GIT_TAG);
-        options.setEnvironment(com.tavultesoft.kmapro.BuildConfig.VERSION_ENVIRONMENT);
+        options.setRelease(com.tavultesoft.kmapro.BuildConfig.KEYMAN_VERSION_GIT_TAG);
+        options.setEnvironment(com.tavultesoft.kmapro.BuildConfig.KEYMAN_VERSION_ENVIRONMENT);
       });
     }
 

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -14,9 +14,9 @@ android {
         minSdkVersion 21
         targetSdkVersion 34
 
-        // VERSION_CODE and VERSION_NAME from version.gradle but Gradle removes them for libraries
-        buildConfigField "String", "KEYMAN_ENGINE_VERSION_NAME", "\""+VERSION_NAME+"\""
-        buildConfigField "String", "VERSION_ENVIRONMENT", "\""+VERSION_ENVIRONMENT+"\""
+        // KEYMAN_VERSION_CODE and KEYMAN_VERSION_NAME from version.gradle but Gradle removes them for libraries
+        buildConfigField "String", "KEYMAN_ENGINE_VERSION_NAME", "\""+KEYMAN_VERSION_NAME+"\""
+        buildConfigField "String", "KEYMAN_VERSION_ENVIRONMENT", "\""+KEYMAN_VERSION_ENVIRONMENT+"\""
 
         // Sepcify library filename keyman-engine-$CONFIG.aar
         setProperty("archivesBaseName", "keyman-engine")

--- a/android/KMEA/app/src/main/java/com/keyman/engine/util/VersionUtils.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/util/VersionUtils.java
@@ -12,11 +12,11 @@ public final class VersionUtils {
   public static final String TAG = "VersionUtils";
 
   public static boolean isLocalBuild() {
-    return BuildConfig.VERSION_ENVIRONMENT.equalsIgnoreCase("local");
+    return BuildConfig.KEYMAN_VERSION_ENVIRONMENT.equalsIgnoreCase("local");
   }
 
   public static boolean isTestBuild() {
-    return BuildConfig.VERSION_ENVIRONMENT.equalsIgnoreCase("test");
+    return BuildConfig.KEYMAN_VERSION_ENVIRONMENT.equalsIgnoreCase("test");
   }
 
   // Utility for local and PR test builds - e.g. force check of keyboard updates

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -19,10 +19,10 @@ android {
         minSdkVersion 21
         targetSdkVersion 34
 
-        // VERSION_CODE and VERSION_NAME from version.gradle
-        versionCode VERSION_CODE as Integer
-        versionName VERSION_NAME
-        buildConfigField "String", "VERSION_ENVIRONMENT", "\""+VERSION_ENVIRONMENT+"\""
+        // KEYMAN_VERSION_CODE and KEYMAN_VERSION_NAME from version.gradle
+        versionCode KEYMAN_VERSION_CODE as Integer
+        versionName KEYMAN_VERSION_NAME
+        buildConfigField "String", "KEYMAN_VERSION_ENVIRONMENT", "\""+KEYMAN_VERSION_ENVIRONMENT+"\""
     }
     buildTypes {
         release {

--- a/android/Tests/keycode/app/build.gradle
+++ b/android/Tests/keycode/app/build.gradle
@@ -12,10 +12,10 @@ android {
         minSdkVersion 21
         targetSdkVersion 34
 
-        // VERSION_CODE and VERSION_NAME from version.gradle
-        versionCode VERSION_CODE as Integer
-        versionName VERSION_NAME
-        buildConfigField "String", "VERSION_ENVIRONMENT", "\""+VERSION_ENVIRONMENT+"\""
+        // KEYMAN_VERSION_CODE and KEYMAN_VERSION_NAME from version.gradle
+        versionCode KEYMAN_VERSION_CODE as Integer
+        versionName KEYMAN_VERSION_NAME
+        buildConfigField "String", "KEYMAN_VERSION_ENVIRONMENT", "\""+KEYMAN_VERSION_ENVIRONMENT+"\""
     }
     buildTypes {
         release {

--- a/android/version.gradle
+++ b/android/version.gradle
@@ -7,9 +7,9 @@
 //
 
 def getVersionCode = { ->
-    String env_version_major = System.getenv("VERSION_MAJOR")
-    String env_version_minor = System.getenv("VERSION_MINOR")
-    String env_version_patch = System.getenv("VERSION_PATCH")
+    String env_version_major = System.getenv("KEYMAN_VERSION_MAJOR")
+    String env_version_minor = System.getenv("KEYMAN_VERSION_MINOR")
+    String env_version_patch = System.getenv("KEYMAN_VERSION_PATCH")
     if(env_version_patch != null && env_version_minor != null && env_version_patch != null) {
         // Version code is, for 17.1.33: 1810033. This supports up to 9999
         // builds for a given major.minor version. We only support up to 9 minor
@@ -36,10 +36,10 @@ def getVersionCode = { ->
 }
 
 def getVersionMD = { ->
-    String env_version = System.getenv("VERSION")
+    String env_version = System.getenv("KEYMAN_VERSION")
     if (env_version != null) {
-        // If building from script, we have build number in VERSION
-        println "Using build $env_version from VERSION"
+        // If building from script, we have build number in KEYMAN_VERSION
+        println "Using build $env_version from KEYMAN_VERSION"
         return "$env_version"
     } else {
         String version_md = file("$rootPath/../VERSION.md").text.trim()
@@ -48,15 +48,15 @@ def getVersionMD = { ->
 }
 
 def getVersionName = { ->
-    String env_version = System.getenv("VERSION_WITH_TAG")
+    String env_version = System.getenv("KEYMAN_VERSION_WITH_TAG")
     if (env_version != null) {
-        // If building from script, we have build number in VERSION_WITH_TAG
-        println "Using build $env_version from VERSION_WITH_TAG"
+        // If building from script, we have build number in KEYMAN_VERSION_WITH_TAG
+        println "Using build $env_version from KEYMAN_VERSION_WITH_TAG"
         return "$env_version"
     } else {
         // Building probably from IDE, so let's use VERSION.md and TIER.md directly
-        // This is a close match with VERSION_WITH_TAG, except that 'stable' tier
-        // is not normally included with VERSION_WITH_TAG
+        // This is a close match with KEYMAN_VERSION_WITH_TAG, except that 'stable' tier
+        // is not normally included with KEYMAN_VERSION_WITH_TAG
         String version_md = file("$rootPath/../VERSION.md").text.trim()
         String tier_md = file("$rootPath/../TIER.md").text.trim()
         println "Using build $version_md-$tier_md-local from project VERSION.md/TIER.md"
@@ -65,10 +65,10 @@ def getVersionName = { ->
 }
 
 def getVersionEnvironment = { ->
-    String env_environment = System.getenv("VERSION_ENVIRONMENT")
+    String env_environment = System.getenv("KEYMAN_VERSION_ENVIRONMENT")
     if (env_environment != null) {
-        // If building from script, we have build number in VERSION_ENVIRONMENT
-        println "Using $env_environment from VERSION_ENVIRONMENT"
+        // If building from script, we have build number in KEYMAN_VERSION_ENVIRONMENT
+        println "Using $env_environment from KEYMAN_VERSION_ENVIRONMENT"
         return "$env_environment"
     } else {
         // Building probably from IDE, so use "local"
@@ -78,23 +78,23 @@ def getVersionEnvironment = { ->
 }
 
 def getVersionGitTag = { ->
-    String env_git_tag = System.getenv("VERSION_GIT_TAG")
+    String env_git_tag = System.getenv("KEYMAN_VERSION_GIT_TAG")
     if (env_git_tag != null) {
-        println "Using $env_git_tag from VERSION_GIT_TAG"
+        println "Using $env_git_tag from KEYMAN_VERSION_GIT_TAG"
         return "$env_git_tag"
     } else {
         // Building probably from IDE
-        println "Using release@$VERSION_NAME"
-        return "release@$VERSION_NAME"
+        println "Using release@$KEYMAN_VERSION_NAME"
+        return "release@$KEYMAN_VERSION_NAME"
     }
 }
 ext {
-    VERSION_CODE=getVersionCode()
-    VERSION_MD=getVersionMD()
-    VERSION_NAME=getVersionName()
-    VERSION_ENVIRONMENT=getVersionEnvironment()
-    VERSION_TAG=System.getenv("VERSION_TAG")
-    VERSION_GIT_TAG=getVersionGitTag()
+    KEYMAN_VERSION_CODE=getVersionCode()
+    KEYMAN_VERSION_MD=getVersionMD()
+    KEYMAN_VERSION_NAME=getVersionName()
+    KEYMAN_VERSION_ENVIRONMENT=getVersionEnvironment()
+    KEYMAN_VERSION_TAG=System.getenv("KEYMAN_VERSION_TAG")
+    KEYMAN_VERSION_GIT_TAG=getVersionGitTag()
 }
 
-//println "version.gradle: VERSION_TAG: " + VERSION_TAG
+//println "version.gradle: KEYMAN_VERSION_TAG: " + KEYMAN_VERSION_TAG

--- a/common/test/keyboards/build.sh
+++ b/common/test/keyboards/build.sh
@@ -40,10 +40,10 @@ function build_index() {
 <html>
   <head>
     <meta charset='utf-8'>
-    <title>Test Keyboards - $VERSION_WITH_TAG</title>
+    <title>Test Keyboards - $KEYMAN_VERSION_WITH_TAG</title>
   </head>
   <body>
-    <h1>Test Keyboards - $VERSION_WITH_TAG</h1>
+    <h1>Test Keyboards - $KEYMAN_VERSION_WITH_TAG</h1>
     <ul>
 EOF
 

--- a/common/web/keyman-version/build.sh
+++ b/common/web/keyman-version/build.sh
@@ -33,16 +33,16 @@ function do_build() {
 // Note:  does not use the 'default' keyword so that the export name is
 // correct when converted to a CommonJS module with \`esbuild\`.
 export class KEYMAN_VERSION {
-  static readonly VERSION = \"$VERSION\";
-  static readonly VERSION_RELEASE =\"$VERSION_RELEASE\";
-  static readonly VERSION_MAJOR = \"$VERSION_MAJOR\";
-  static readonly VERSION_MINOR = \"$VERSION_MINOR\";
-  static readonly VERSION_PATCH = \"$VERSION_PATCH\";
-  static readonly TIER =\"$TIER\";
-  static readonly VERSION_TAG = \"$VERSION_TAG\";
-  static readonly VERSION_WITH_TAG = \"$VERSION_WITH_TAG\";
-  static readonly VERSION_ENVIRONMENT = \"$VERSION_ENVIRONMENT\";
-  static readonly VERSION_GIT_TAG = \"$VERSION_GIT_TAG\";
+  static readonly VERSION = \"$KEYMAN_VERSION\";
+  static readonly VERSION_RELEASE =\"$KEYMAN_VERSION_RELEASE\";
+  static readonly VERSION_MAJOR = \"$KEYMAN_VERSION_MAJOR\";
+  static readonly VERSION_MINOR = \"$KEYMAN_VERSION_MINOR\";
+  static readonly VERSION_PATCH = \"$KEYMAN_VERSION_PATCH\";
+  static readonly TIER =\"$KEYMAN_TIER\";
+  static readonly VERSION_TAG = \"$KEYMAN_VERSION_TAG\";
+  static readonly VERSION_WITH_TAG = \"$KEYMAN_VERSION_WITH_TAG\";
+  static readonly VERSION_ENVIRONMENT = \"$KEYMAN_VERSION_ENVIRONMENT\";
+  static readonly VERSION_GIT_TAG = \"$KEYMAN_VERSION_GIT_TAG\";
 }
 
 // Also provides it as a 'default' export.

--- a/developer/src/inst/build.sh
+++ b/developer/src/inst/build.sh
@@ -16,7 +16,7 @@ builder_describe "Installation files for Keyman Developer" \
 # after all other builds complete
 
 builder_describe_outputs \
-  publish       /developer/src/inst/keymandeveloper-${VERSION}.exe
+  publish       /developer/src/inst/keymandeveloper-${KEYMAN_VERSION}.exe
 
 builder_parse "$@"
 
@@ -25,8 +25,8 @@ builder_parse "$@"
 . "$KEYMAN_ROOT/resources/build/win/zip.inc.sh"
 
 # In dev environments, we'll hack the tier to alpha; CI sets this for us in real builds.
-if [[ -z ${TIER+x} ]]; then
-  TIER=alpha
+if [[ -z ${KEYMAN_TIER+x} ]]; then
+  KEYMAN_TIER=alpha
 fi
 
 # We use different directories so that heat generates
@@ -90,13 +90,13 @@ function do_test() {
 function copy-kmdev() {
   builder_heading copy-kmdev
 
-  mkdir -p "$DEVELOPER_ROOT/release/${VERSION}"
+  mkdir -p "$DEVELOPER_ROOT/release/${KEYMAN_VERSION}"
 
   make-installer
   make-kmc-install-zip
 
-  cp -f "$DEVELOPER_ROOT/src/inst/keymandeveloper.msi" "$DEVELOPER_ROOT/release/${VERSION}/keymandeveloper.msi"
-  cp -f "$DEVELOPER_ROOT/src/inst/keymandeveloper-${VERSION}.exe" "$DEVELOPER_ROOT/release/${VERSION}/keymandeveloper-${VERSION}.exe"
+  cp -f "$DEVELOPER_ROOT/src/inst/keymandeveloper.msi" "$DEVELOPER_ROOT/release/${KEYMAN_VERSION}/keymandeveloper.msi"
+  cp -f "$DEVELOPER_ROOT/src/inst/keymandeveloper-${KEYMAN_VERSION}.exe" "$DEVELOPER_ROOT/release/${KEYMAN_VERSION}/keymandeveloper-${KEYMAN_VERSION}.exe"
 }
 
 function verify-program-signatures() {
@@ -108,7 +108,7 @@ function verify-program-signatures() {
 function verify-installer-signatures() {
   builder_heading verify-installer-signatures
 
-  verify-all-executable-signatures-in-folder "$DEVELOPER_ROOT/release/${VERSION}"
+  verify-all-executable-signatures-in-folder "$DEVELOPER_ROOT/release/${KEYMAN_VERSION}"
 }
 
 function verify-node-installer-version() {
@@ -126,8 +126,8 @@ function verify-node-installer-version() {
 }
 
 function test-releaseexists() {
-  if [[ -d "$DEVELOPER_ROOT/release/${VERSION}" ]]; then
-    builder_die "Release ${VERSION} already exists. Delete it or update VERSION.md and try again"
+  if [[ -d "$DEVELOPER_ROOT/release/${KEYMAN_VERSION}" ]]; then
+    builder_die "Release ${KEYMAN_VERSION} already exists. Delete it or update VERSION.md and try again"
   fi
 }
 
@@ -141,12 +141,12 @@ function candle() {
   heat-kmc
 
   builder_heading "candle: calling WIX:candle"
-  "$WIXCANDLE" -wx -nologo "-dVERSION=${VERSION_WIN}" "-dRELEASE=${VERSION_RELEASE}" kmdev.wxs
-  "$WIXCANDLE" -wx -nologo "-dVERSION=${VERSION_WIN}" "-dRELEASE=${VERSION_RELEASE}" "-dXmlSourceDir=${DEVELOPER_ROOT}/src/tike/xml" xml.wxs
-  "$WIXCANDLE" -wx -nologo "-dVERSION=${VERSION_WIN}" "-dRELEASE=${VERSION_RELEASE}" "-dCefSourceDir=${KEYMAN_CEF4DELPHI_ROOT}" cef.wxs
-  "$WIXCANDLE" -wx -nologo "-dVERSION=${VERSION_WIN}" "-dRELEASE=${VERSION_RELEASE}" "-dTemplatesSourceDir=${KEYMAN_DEVELOPER_TEMPLATES_ROOT}" templates.wxs
-  "$WIXCANDLE" -wx -nologo "-dVERSION=${VERSION_WIN}" "-dRELEASE=${VERSION_RELEASE}" "-dkmcSourceDir=${KEYMAN_WIX_TEMP_KMC}" kmc.wxs
-  "$WIXCANDLE" -wx -nologo "-dVERSION=${VERSION_WIN}" "-dRELEASE=${VERSION_RELEASE}" "-dServerSourceDir=${KEYMAN_WIX_KMDEV_SERVER}" server.wxs
+  "$WIXCANDLE" -wx -nologo "-dKEYMAN_VERSION=${KEYMAN_VERSION_WIN}" "-dRELEASE=${KEYMAN_VERSION_RELEASE}" kmdev.wxs
+  "$WIXCANDLE" -wx -nologo "-dKEYMAN_VERSION=${KEYMAN_VERSION_WIN}" "-dRELEASE=${KEYMAN_VERSION_RELEASE}" "-dXmlSourceDir=${DEVELOPER_ROOT}/src/tike/xml" xml.wxs
+  "$WIXCANDLE" -wx -nologo "-dKEYMAN_VERSION=${KEYMAN_VERSION_WIN}" "-dRELEASE=${KEYMAN_VERSION_RELEASE}" "-dCefSourceDir=${KEYMAN_CEF4DELPHI_ROOT}" cef.wxs
+  "$WIXCANDLE" -wx -nologo "-dKEYMAN_VERSION=${KEYMAN_VERSION_WIN}" "-dRELEASE=${KEYMAN_VERSION_RELEASE}" "-dTemplatesSourceDir=${KEYMAN_DEVELOPER_TEMPLATES_ROOT}" templates.wxs
+  "$WIXCANDLE" -wx -nologo "-dKEYMAN_VERSION=${KEYMAN_VERSION_WIN}" "-dRELEASE=${KEYMAN_VERSION_RELEASE}" "-dkmcSourceDir=${KEYMAN_WIX_TEMP_KMC}" kmc.wxs
+  "$WIXCANDLE" -wx -nologo "-dKEYMAN_VERSION=${KEYMAN_VERSION_WIN}" "-dRELEASE=${KEYMAN_VERSION_RELEASE}" "-dServerSourceDir=${KEYMAN_WIX_KMDEV_SERVER}" server.wxs
 }
 
 function heat-xml() {
@@ -230,12 +230,12 @@ function make-installer() {
   builder_heading make-installer
 
   echo [Setup] > setup.inf
-  echo "Version=$VERSION" >> setup.inf
+  echo "Version=$KEYMAN_VERSION" >> setup.inf
   echo "MSIFileName=keymandeveloper.msi" >> setup.inf
-  echo "Title=Keyman Developer ${VERSION_WITH_TAG}" >>setup.inf
+  echo "Title=Keyman Developer ${KEYMAN_VERSION_WITH_TAG}" >>setup.inf
   wzzip setup.zip keymandeveloper.msi setup.inf
-  cat "$DEVELOPER_PROGRAM/setup.exe" setup.zip > "keymandeveloper-$VERSION.exe"
-  wrap-signcode //d "Keyman Developer" "keymandeveloper-$VERSION.exe"
+  cat "$DEVELOPER_PROGRAM/setup.exe" setup.zip > "keymandeveloper-$KEYMAN_VERSION.exe"
+  wrap-signcode //d "Keyman Developer" "keymandeveloper-$KEYMAN_VERSION.exe"
 
   #
   # Zip the files we distribute as part of the standalone kmc distro into release\$Version\kmcomp-$Version.zip
@@ -243,7 +243,7 @@ function make-installer() {
 }
 
 # TODO: rename this to keyman-developer-cli-$Version.zip
-KMC_ZIP="$DEVELOPER_ROOT/release/$VERSION/kmcomp-$VERSION.zip"
+KMC_ZIP="$DEVELOPER_ROOT/release/$KEYMAN_VERSION/kmcomp-$KEYMAN_VERSION.zip"
 
 function make-kmc-install-zip() {
   builder_heading make-kmc-install-zip

--- a/developer/src/inst/kmdev.wxs
+++ b/developer/src/inst/kmdev.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*"
            UpgradeCode="{E99A1F1E-7046-44F9-89EF-D3A59F84B209}" Manufacturer="SIL International"
-           Name="Keyman Developer $(var.RELEASE)" Version="$(var.VERSION)" Language="1033">
+           Name="Keyman Developer $(var.RELEASE)" Version="$(var.KEYMAN_VERSION)" Language="1033">
     <Package Keywords="Keyman,Keyboard,Engine" Compressed="yes"
              Description="Keyman Developer $(var.RELEASE)" Comments="Contact:  Your local administrator"
              Manufacturer="SIL International" InstallerVersion="200" Platform="x86" Languages="1033" SummaryCodepage="1252" />
@@ -40,10 +40,10 @@
 
     <Upgrade Id="{E99A1F1E-7046-44F9-89EF-D3A59F84B209}">
       <UpgradeVersion OnlyDetect="no" Minimum="11.0.0.0" IncludeMinimum="yes"
-                      Maximum="$(var.VERSION)" IncludeMaximum="no" MigrateFeatures="yes" Property="VERSION11FOUND" />
-      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VERSION)" IncludeMinimum="yes"
-                      Maximum="$(var.VERSION)" IncludeMaximum="yes" Property="CURRENTVERSIONFOUND" />
-      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VERSION)" IncludeMinimum="no" Property="NEWERFOUND" />
+                      Maximum="$(var.KEYMAN_VERSION)" IncludeMaximum="no" MigrateFeatures="yes" Property="VERSION11FOUND" />
+      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.KEYMAN_VERSION)" IncludeMinimum="yes"
+                      Maximum="$(var.KEYMAN_VERSION)" IncludeMaximum="yes" Property="CURRENTVERSIONFOUND" />
+      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.KEYMAN_VERSION)" IncludeMinimum="no" Property="NEWERFOUND" />
     </Upgrade>
 
     <Property Id="ALLUSERS"><![CDATA[1]]></Property>
@@ -309,7 +309,7 @@
 
     <Icon Id="TIKE.ico" SourceFile="..\images\KeymanDeveloper90.ico" />
 
-    <CustomAction Id='AlreadyUpdated' Error='[ProductName] has already been updated to $(var.VERSION) or newer.' />
+    <CustomAction Id='AlreadyUpdated' Error='[ProductName] has already been updated to $(var.KEYMAN_VERSION) or newer.' />
     <CustomAction Id='NoDowngrade' Error='A later version of [ProductName] is already installed.' />
 
     <Property Id='OLDINSTALLDIR'>

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -87,7 +87,7 @@ function do_bundle() {
   sentry-cli sourcemaps inject \
     --org keyman \
     --project keyman-developer \
-    --release "$VERSION_GIT_TAG"  \
+    --release "$KEYMAN_VERSION_GIT_TAG"  \
     build/dist/ "${SOURCEMAP_PATHS[@]}"
 
   # Manually copy over kmcmplib module

--- a/developer/src/server/src/site/lib/sentry/init.js.in
+++ b/developer/src/server/src/site/lib/sentry/init.js.in
@@ -9,8 +9,8 @@
 
 Sentry.init({
   dsn: 'https://39b25a09410349a58fe12aaf721565af@o1005580.ingest.sentry.io/5983519',  // Keyman Developer
-  environment: '$VERSION_ENVIRONMENT',
-  release: '$VERSION_GIT_TAG'
+  environment: '$KEYMAN_VERSION_ENVIRONMENT',
+  release: '$KEYMAN_VERSION_GIT_TAG'
 });
 
 function keymanEnableDiagnostics() {

--- a/developer/src/server/src/version-data.ts
+++ b/developer/src/server/src/version-data.ts
@@ -1,18 +1,18 @@
 /*
   Version information from build-utils.sh:
 
-  #   VERSION:          Full current build version, e.g. "14.0.1"
-  #   [VERSION_WIN:      Full current build version for Windows, e.g. "14.0.1.0"]
-  #   VERSION_RELEASE:  Current release version, e.g. "14.0"
-  #   VERSION_MAJOR:    Major version, e.g. "14"
-  #   VERSION_MINOR:    Minor version, e.g. "0"
-  #   VERSION_PATCH:    Patch version, e.g. "1"
-  #   TIER:             Current tier, one of "alpha", "beta" or "stable"
-  #   VERSION_TAG:      Tier + Pull Request + Location of build [-alpha|-beta][-test[-1234]][-local]
-  #   VERSION_WITH_TAG: e.g. "14.0.1-alpha-test-1234" or "14.0.5-beta-local" or "14.0.1-alpha-test"
-  #   [KEYMAN_ROOT:      fully resolved root path of Keyman repository]
-  #   VERSION_ENVIRONMENT: One of: local, test, alpha, beta, stable
-  #   VERSION_GIT_TAG:  Git tag for the release, "release@$VERSION_WITH_TAG", e.g. "release@14.0.1-alpha-test-1234"
+  #   KEYMAN_VERSION:              Full current build version, e.g. "14.0.1"
+  #   [KEYMAN_VERSION_WIN:         Full current build version for Windows, e.g. "14.0.1.0"]
+  #   KEYMAN_VERSION_RELEASE:      Current release version, e.g. "14.0"
+  #   KEYMAN_VERSION_MAJOR:        Major version, e.g. "14"
+  #   KEYMAN_VERSION_MINOR:        Minor version, e.g. "0"
+  #   KEYMAN_VERSION_PATCH:        Patch version, e.g. "1"
+  #   KEYMAN_TIER:                 Current tier, one of "alpha", "beta" or "stable"
+  #   KEYMAN_VERSION_TAG:          Tier + Pull Request + Location of build [-alpha|-beta][-test[-1234]][-local]
+  #   KEYMAN_VERSION_WITH_TAG:     e.g. "14.0.1-alpha-test-1234" or "14.0.5-beta-local" or "14.0.1-alpha-test"
+  #   [KEYMAN_ROOT:                fully resolved root path of Keyman repository]
+  #   KEYMAN_VERSION_ENVIRONMENT:  One of: local, test, alpha, beta, stable
+  #   KEYMAN_VERSION_GIT_TAG:      Git tag for the release, "release@$KEYMAN_VERSION_WITH_TAG", e.g. "release@14.0.1-alpha-test-1234"
 */
 
 export interface Environment {

--- a/developer/src/tike/xml/app/lib/sentry/init.js.in
+++ b/developer/src/tike/xml/app/lib/sentry/init.js.in
@@ -9,8 +9,8 @@
 
 Sentry.init({
   dsn: 'https://39b25a09410349a58fe12aaf721565af@o1005580.ingest.sentry.io/5983519',  // Keyman Developer
-  environment: '$VERSION_ENVIRONMENT',
-  release: '$VERSION_GIT_TAG'
+  environment: '$KEYMAN_VERSION_ENVIRONMENT',
+  release: '$KEYMAN_VERSION_GIT_TAG'
 });
 
 function keymanEnableDiagnostics() {

--- a/developer/src/tools/sentry-upload-difs.sh
+++ b/developer/src/tools/sentry-upload-difs.sh
@@ -79,7 +79,7 @@ upload_sourcemap() {
     --no-dedupe \
     --org keyman \
     --project keyman-developer \
-    --release "$VERSION_GIT_TAG"  \
+    --release "$KEYMAN_VERSION_GIT_TAG"  \
     --ext js --ext mjs --ext ts --ext map \
     "$smpath"
 }

--- a/docs/linux/packaging.md
+++ b/docs/linux/packaging.md
@@ -98,8 +98,8 @@ You'll have to create the docker image.
 
   ```bash
   cd $KEYMAN_ROOT
-  TIER=$(cat TIER.md)
-  export TIER
+  KEYMAN_TIER=$(cat TIER.md)
+  export KEYMAN_TIER
   cd linux
   ./scripts/deb-packaging.sh source
   ```
@@ -149,13 +149,13 @@ for the different distros and architectures.
 To upload the packages to launchpad, run the following script from the `linux/` directory:
 
 ```bash
-./scripts/launchpad.sh [UPLOAD="yes"] [TIER="<tier>"] [PROJECT="<project>"] [DIST="<dist>"] [PACKAGEVERSION="<version>"]
+./scripts/launchpad.sh [UPLOAD="yes"] [KEYMAN_TIER="<tier>"] [PROJECT="<project>"] [DIST="<dist>"] [PACKAGEVERSION="<version>"]
 ```
 
 #### Parameters
 
 - `UPLOAD="yes"` - do the dput for real
-- `TIER="<tier>"` - alpha, beta, or stable, default from `../TIER.md`
+- `KEYMAN_TIER="<tier>"` - alpha, beta, or stable, default from `../TIER.md`
 - `PROJECT="<project>"` - only upload this package
 - `DIST="<dist>"` - only upload for this distribution
 - `PACKAGEVERSION="<version>"` - normally use the default so don't specify

--- a/ios/engine/build.sh
+++ b/ios/engine/build.sh
@@ -118,9 +118,9 @@ function build_engine() {
 
   echo
   echo "Build products will be set with the following version metadata:"
-  echo "  * VERSION=$VERSION"
-  echo "  * VERSION_WITH_TAG=$VERSION_WITH_TAG"
-  echo "  * VERSION_ENVIRONMENT=$VERSION_ENVIRONMENT"
+  echo "  * KEYMAN_VERSION=$KEYMAN_VERSION"
+  echo "  * KEYMAN_VERSION_WITH_TAG=$KEYMAN_VERSION_WITH_TAG"
+  echo "  * KEYMAN_VERSION_ENVIRONMENT=$KEYMAN_VERSION_ENVIRONMENT"
   echo "  * UPLOAD_SENTRY=$UPLOAD_SENTRY"
   echo
   echo "Building KMEI..."
@@ -130,9 +130,9 @@ function build_engine() {
   run_xcodebuild $XCODEFLAGS_EXT \
             $CODE_SIGN \
             -scheme KME-universal \
-            VERSION=$VERSION \
-            VERSION_WITH_TAG=$VERSION_WITH_TAG \
-            VERSION_ENVIRONMENT=$VERSION_ENVIRONMENT \
+            KEYMAN_VERSION=$KEYMAN_VERSION \
+            KEYMAN_VERSION_WITH_TAG=$KEYMAN_VERSION_WITH_TAG \
+            KEYMAN_VERSION_ENVIRONMENT=$KEYMAN_VERSION_ENVIRONMENT \
             UPLOAD_SENTRY=$UPLOAD_SENTRY
 
   assertDirExists "$KEYMAN_XCFRAMEWORK"

--- a/ios/keyman/build.sh
+++ b/ios/keyman/build.sh
@@ -87,9 +87,9 @@ function build_app() {
               -archivePath "$ARCHIVE_PATH" \
               archive \
               -allowProvisioningUpdates \
-              VERSION=$VERSION \
-              VERSION_WITH_TAG=$VERSION_WITH_TAG \
-              VERSION_ENVIRONMENT=$VERSION_ENVIRONMENT \
+              KEYMAN_VERSION=$KEYMAN_VERSION \
+              KEYMAN_VERSION_WITH_TAG=$KEYMAN_VERSION_WITH_TAG \
+              KEYMAN_VERSION_ENVIRONMENT=$KEYMAN_VERSION_ENVIRONMENT \
               UPLOAD_SENTRY=$UPLOAD_SENTRY
 
   assertDirExists "$ARCHIVE_PATH"
@@ -112,9 +112,9 @@ function build_app() {
                 $CODE_SIGN \
                 -scheme Keyman \
                 -sdk iphonesimulator \
-                VERSION=$VERSION \
-                VERSION_WITH_TAG=$VERSION_WITH_TAG \
-                VERSION_ENVIRONMENT=$VERSION_ENVIRONMENT \
+                KEYMAN_VERSION=$KEYMAN_VERSION \
+                KEYMAN_VERSION_WITH_TAG=$KEYMAN_VERSION_WITH_TAG \
+                KEYMAN_VERSION_ENVIRONMENT=$KEYMAN_VERSION_ENVIRONMENT \
                 UPLOAD_SENTRY=$UPLOAD_SENTRY
   fi
 }

--- a/ios/scripts/kme-universal.sh
+++ b/ios/scripts/kme-universal.sh
@@ -38,9 +38,9 @@ build_archive ( ) {
              -quiet \
              BUILD_DIR="${BUILD_DIR}" \
              BUILD_ROOT="${BUILD_ROOT}" \
-             VERSION=$VERSION \
-             VERSION_WITH_TAG=$VERSION_WITH_TAG \
-             VERSION_ENVIRONMENT=$VERSION_ENVIRONMENT \
+             KEYMAN_VERSION=$KEYMAN_VERSION \
+             KEYMAN_VERSION_WITH_TAG=$KEYMAN_VERSION_WITH_TAG \
+             KEYMAN_VERSION_ENVIRONMENT=$KEYMAN_VERSION_ENVIRONMENT \
              UPLOAD_SENTRY=$UPLOAD_SENTRY
 }
 

--- a/ios/tools/prepRelease.sh
+++ b/ios/tools/prepRelease.sh
@@ -28,9 +28,9 @@ fi
 #. ../resources/shellHelperFunctions.sh
 
 BUILD_NUMBER=`cat ../VERSION.md`
-TIER=`cat ../TIER.md`
+KEYMAN_TIER=`cat ../TIER.md`
 
-KEYMAN_CHANGELOG="changelog-${BUILD_NUMBER}-${TIER}.txt"
+KEYMAN_CHANGELOG="changelog-${BUILD_NUMBER}-${KEYMAN_TIER}.txt"
 CHANGELOG_PATH="upload/$BUILD_NUMBER/$KEYMAN_CHANGELOG"
 
 WORK_DIR=`pwd`
@@ -46,7 +46,7 @@ mkdir -p "${UPLOAD_DIR}"
 # First, we prep the files for publication: write changelog
 
 echo "Writing changelog to $CHANGELOG_PATH"
-get_version_notes "ios" "${BUILD_NUMBER}" "$TIER" > $CHANGELOG_PATH
+get_version_notes "ios" "${BUILD_NUMBER}" "$KEYMAN_TIER" > $CHANGELOG_PATH
 echo "* Minor fixes and performance improvements" >> $CHANGELOG_PATH
 assertFileExists "${CHANGELOG_PATH}"
 
@@ -128,9 +128,9 @@ fi
 
 cd "${UPLOAD_DIR}"
 
-write_download_info "Keyman Engine for iOS" "${KMEI_DST_NAME}" "${BUILD_NUMBER}" "${TIER}" "ios"
-write_download_info "Keyman for iPhone and iPad" "${KEYMANAPP_IPA_DST}" "${BUILD_NUMBER}" "${TIER}" "ios"
+write_download_info "Keyman Engine for iOS" "${KMEI_DST_NAME}" "${BUILD_NUMBER}" "${KEYMAN_TIER}" "ios"
+write_download_info "Keyman for iPhone and iPad" "${KEYMANAPP_IPA_DST}" "${BUILD_NUMBER}" "${KEYMAN_TIER}" "ios"
 
 if [ ${RELEASE_OEM_FIRSTVOICES} = true ]; then
-  write_download_info "FirstVoices Keyboards" "${FIRSTVOICESAPP_IPA_DST}" "${BUILD_NUMBER}" "${TIER}" "ios"
+  write_download_info "FirstVoices Keyboards" "${FIRSTVOICESAPP_IPA_DST}" "${BUILD_NUMBER}" "${KEYMAN_TIER}" "ios"
 fi

--- a/linux/ibus-keyman/src/keyman-version.h.in
+++ b/linux/ibus-keyman/src/keyman-version.h.in
@@ -1,5 +1,5 @@
 #ifndef __KEYMAN_VERSION_H__
 #define __KEYMAN_VERSION_H__
 
-#define KEYMAN_VERSION "@VERSION@"
+#define KEYMAN_VERSION "@KEYMAN_VERSION@"
 #endif

--- a/linux/ibus-keyman/src/keyman.xml.in
+++ b/linux/ibus-keyman/src/keyman.xml.in
@@ -3,7 +3,7 @@
 	<name>org.freedesktop.IBus.Keyman</name>
 	<description>Keyman Component</description>
 	<exec>@LIBEXECDIR@/ibus-engine-keyman --ibus</exec>
-	<version>@VERSION@</version>
+	<version>@KEYMAN_VERSION@</version>
 	<author>Keyman Team &lt;support@keyman.com&gt;</author>
 	<license>GPL</license>
 	<homepage>https://keyman.com</homepage>

--- a/linux/ibus-keyman/src/meson.build
+++ b/linux/ibus-keyman/src/meson.build
@@ -21,7 +21,7 @@ deps = [gtk, ibus, icu, json_glib, keymancore_lib, systemd]
 
 prefix = get_option('prefix')
 cfg = configuration_data()
-cfg.set('VERSION', meson.project_version())
+cfg.set('KEYMAN_VERSION', meson.project_version())
 cfg.set('LIBEXECDIR', get_option('prefix') / get_option('libexecdir'))
 
 configure_file(

--- a/linux/keyman-config/Makefile
+++ b/linux/keyman-config/Makefile
@@ -24,8 +24,8 @@ dist: clean version
 	fi
 
 deb: dist
-	@VERSION=$(shell echo `basename dist/*.gz .tar.gz|cut -d "-" -f2` > /tmp/keyman_version)
-	@echo VERSION is $(shell cat /tmp/keyman_version)
+	@KEYMAN_VERSION=$(shell echo `basename dist/*.gz .tar.gz|cut -d "-" -f2` > /tmp/keyman_version)
+	@echo KEYMAN_VERSION is $(shell cat /tmp/keyman_version)
 	@mkdir -p make_deb
 	cd make_deb && tar xf ../dist/keyman_config-$(shell cat /tmp/keyman_version).tar.gz && \
 		mv keyman_config-$(shell cat /tmp/keyman_version) keyman-config-$(shell cat /tmp/keyman_version) && \
@@ -41,7 +41,7 @@ version_reconf:
 	cd .. && ./scripts/reconf.sh
 
 version: version_reconf
-	$(eval VERSION := $(shell python3 -c "from keyman_config import __releaseversion__; print(__releaseversion__)"))
+	$(eval KEYMAN_VERSION := $(shell python3 -c "from keyman_config import __releaseversion__; print(__releaseversion__)"))
 
 # i18n
 
@@ -49,7 +49,7 @@ POFILES := $(shell find locale -name \*.po)
 MOFILES := $(POFILES:.po=/LC_MESSAGES/keyman-config.mo)
 
 update-template: version
-	xgettext --package-name "keyman" --package-version "$(VERSION)" \
+	xgettext --package-name "keyman" --package-version "$(KEYMAN_VERSION)" \
 		--msgid-bugs-address "<support@keyman.com>" --copyright-holder "SIL Global" \
 		--language=Python --directory=. --output-dir=locale --output=keyman-config.pot \
 		--add-comments=i18n: --sort-by-file --width=98 \

--- a/linux/keyman-config/build.sh
+++ b/linux/keyman-config/build.sh
@@ -62,14 +62,14 @@ build_action() {
   builder_echo "Create version.py"
   pushd keyman_config
   sed \
-      -e "s/_VERSION_/${VERSION}/g" \
-      -e "s/_VERSIONWITHTAG_/${VERSION_WITH_TAG}/g" \
-      -e "s/_VERSIONGITTAG_/${VERSION_GIT_TAG}/g" \
-      -e "s/_MAJORVERSION_/${VERSION_MAJOR}/g" \
-      -e "s/_RELEASEVERSION_/${VERSION_RELEASE}/g" \
-      -e "s/_TIER_/${TIER}/g" \
-      -e "s/_ENVIRONMENT_/${VERSION_ENVIRONMENT}/g" \
-      -e "s/_UPLOADSENTRY_/${UPLOAD_SENTRY}/g" \
+      -e "s/_KEYMAN_VERSION_/${KEYMAN_VERSION}/g" \
+      -e "s/_KEYMAN_VERSION_WITH_TAG_/${KEYMAN_VERSION_WITH_TAG}/g" \
+      -e "s/_KEYMAN_VERSION_GIT_TAG_/${KEYMAN_VERSION_GIT_TAG}/g" \
+      -e "s/_KEYMAN_VERSION_MAJOR_/${KEYMAN_VERSION_MAJOR}/g" \
+      -e "s/_KEYMAN_VERSION_RELEASE_/${KEYMAN_VERSION_RELEASE}/g" \
+      -e "s/_KEYMAN_TIER_/${KEYMAN_TIER}/g" \
+      -e "s/_KEYMAN_VERSION_ENVIRONMENT_/${KEYMAN_VERSION_ENVIRONMENT}/g" \
+      -e "s/_UPLOAD_SENTRY_/${UPLOAD_SENTRY}/g" \
       version.py.in > version.py
   popd
   pushd buildtools

--- a/linux/keyman-config/keyman_config/version.py.in
+++ b/linux/keyman-config/keyman_config/version.py.in
@@ -4,12 +4,12 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
-__version__ = "_VERSION_"
-__versionwithtag__ = "_VERSIONWITHTAG_"
-__majorversion__ = "_MAJORVERSION_"
-__releaseversion__ = "_RELEASEVERSION_"
-__tier__ = "_TIER_"
+__version__ = "_KEYMAN_VERSION_"
+__versionwithtag__ = "_KEYMAN_VERSION_WITH_TAG_"
+__majorversion__ = "_KEYMAN_VERSION_MAJOR_"
+__releaseversion__ = "_KEYMAN_VERSION_RELEASE_"
+__tier__ = "_KEYMAN_TIER_"
 __pkgversion__ = "(local)"
-__environment__ = "_ENVIRONMENT_"
-__uploadsentry__ = "_UPLOADSENTRY_"
-__versiongittag__ = "_VERSIONGITTAG_"
+__environment__ = "_KEYMAN_VERSION_ENVIRONMENT_"
+__uploadsentry__ = "_UPLOAD_SENTRY_"
+__versiongittag__ = "_KEYMAN_VERSION_GIT_TAG_"

--- a/linux/keyman-system-service/resources/VERSION_WITH_TAG.md
+++ b/linux/keyman-system-service/resources/VERSION_WITH_TAG.md
@@ -1,0 +1,1 @@
+19.0.32-alpha-local

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -29,7 +29,7 @@ mkdir -p dist
 cp -a debian ../
 cd ..
 echo "3.0 (native)" > debian/source/format
-dch keyman --newversion "${VERSION}" --force-bad-version --nomultimaint
+dch keyman --newversion "${KEYMAN_VERSION}" --force-bad-version --nomultimaint
 
 # Create the tarball
 # Note: the files end up in subdirectories under `keyman`, so we can
@@ -87,17 +87,17 @@ dpkg-source \
   --tar-ignore=keyman/windows \
   \
   -Zgzip -b .
-mv ../keyman_"${VERSION}".tar.gz linux/dist/keyman-"${VERSION}".tar.gz
+mv ../keyman_"${KEYMAN_VERSION}".tar.gz linux/dist/keyman-"${KEYMAN_VERSION}".tar.gz
 echo "3.0 (quilt)" > debian/source/format
 cd "${BASEDIR}"
 
 # create orig.tar.gz
 if [[ ! -z "${create_origdist+x}" ]]; then
     cd dist
-    pkgvers="keyman-$VERSION"
-    tar xfz keyman-"${VERSION}".tar.gz
+    pkgvers="keyman-$KEYMAN_VERSION"
+    tar xfz keyman-"${KEYMAN_VERSION}".tar.gz
     mv -v keyman "${pkgvers}" 2>/dev/null || mv -v "$(find . -mindepth 1 -maxdepth 1 -type d)" "${pkgvers}"
-    tar cfz "keyman_${VERSION}.orig.tar.gz" "${pkgvers}"
-    rm "keyman-${VERSION}.tar.gz"
+    tar cfz "keyman_${KEYMAN_VERSION}.orig.tar.gz" "${pkgvers}"
+    rm "keyman-${KEYMAN_VERSION}.tar.gz"
     rm -rf "${pkgvers}"
 fi

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -24,9 +24,9 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 checkPrerequisites
 
-if [ "${TIER}" == "stable" ]; then
+if [ "${KEYMAN_TIER}" == "stable" ]; then
     ppa="ppa:keymanapp/keyman"
-elif [ "${TIER}" == "beta" ]; then
+elif [ "${KEYMAN_TIER}" == "beta" ]; then
     ppa="ppa:keymanapp/keyman-beta"
 else
     ppa="ppa:keymanapp/keyman-alpha"

--- a/linux/scripts/package-build.inc.sh
+++ b/linux/scripts/package-build.inc.sh
@@ -8,8 +8,8 @@ function checkPrerequisites() {
     fi
 
     # Check the tier
-    if [[ -z "${TIER:=}" ]]; then
-        echo "TIER.md or \${TIER} must be set to (alpha, beta, stable) to use this script"
+    if [[ -z "${KEYMAN_TIER:=}" ]]; then
+        echo "TIER.md or \${KEYMAN_TIER} must be set to (alpha, beta, stable) to use this script"
         exit 1
     fi
 
@@ -32,7 +32,7 @@ function downloadSource() {
     fi
 
     # Update tier in Debian watch files (replacing any previously set tier) and remove comment
-    sed -e "s/\$tier\|alpha\|beta\|stable/${TIER}/g" -e "s/^# .*$//" "$BASEDIR"/scripts/watch.in > debian/watch
+    sed -e "s/\$tier\|alpha\|beta\|stable/${KEYMAN_TIER}/g" -e "s/^# .*$//" "$BASEDIR"/scripts/watch.in > debian/watch
 
     version=$(uscan --report --dehs|xmllint --xpath "//dehs/upstream-version/text()" -)
     dirversion=$(uscan --report --dehs|xmllint --xpath "//dehs/upstream-url/text()" - | cut -d/ -f6)
@@ -45,7 +45,7 @@ function downloadSource() {
     mv "${proj}"*.asc "${BASEDIR}/${packageDir}"
     rm "${proj}"*.debian.tar.xz
     cd "${BASEDIR}/${packageDir}" || exit
-    wget -N "https://downloads.keyman.com/linux/${TIER}/${dirversion}/SHA256SUMS"
+    wget -N "https://downloads.keyman.com/linux/${KEYMAN_TIER}/${dirversion}/SHA256SUMS"
     sha256sum -c --ignore-missing SHA256SUMS |grep "${proj}"
 }
 

--- a/linux/scripts/reconf.sh
+++ b/linux/scripts/reconf.sh
@@ -11,7 +11,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 BASEDIR="$KEYMAN_ROOT/linux"
 echo "basedir is $BASEDIR"
 
-echo "Found tier ${TIER}, version ${VERSION}"
+echo "Found tier ${KEYMAN_TIER}, version ${KEYMAN_VERSION}"
 
 # We need to configure+build core before we can configure ibus-keyman
 cd ../core
@@ -32,14 +32,14 @@ quilt new version_py.diff
 quilt add "version.py"
 
 sed \
-    -e "s/_VERSION_/${VERSION}/g" \
-    -e "s/_VERSIONWITHTAG_/${VERSION_WITH_TAG}/g" \
-    -e "s/_VERSIONGITTAG_/${VERSION_GIT_TAG}/g" \
-    -e "s/_MAJORVERSION_/${VERSION_MAJOR}/g" \
-    -e "s/_RELEASEVERSION_/${VERSION_RELEASE}/g" \
-    -e "s/_TIER_/${TIER}/g" \
-    -e "s/_ENVIRONMENT_/${VERSION_ENVIRONMENT}/g" \
-    -e "s/_UPLOADSENTRY_/${UPLOAD_SENTRY}/g" \
+    -e "s/_KEYMAN_VERSION_/${KEYMAN_VERSION}/g" \
+    -e "s/_KEYMAN_VERSION_WITH_TAG_/${KEYMAN_VERSION_WITH_TAG}/g" \
+    -e "s/_KEYMAN_VERSION_GIT_TAG_/${KEYMAN_VERSION_GIT_TAG}/g" \
+    -e "s/_KEYMAN_VERSION_MAJOR_/${KEYMAN_VERSION_MAJOR}/g" \
+    -e "s/_KEYMAN_VERSION_RELEASE_/${KEYMAN_VERSION_RELEASE}/g" \
+    -e "s/_KEYMAN_TIER_/${KEYMAN_TIER}/g" \
+    -e "s/_KEYMAN_VERSION_ENVIRONMENT_/${KEYMAN_VERSION_ENVIRONMENT}/g" \
+    -e "s/_UPLOAD_SENTRY_/${UPLOAD_SENTRY}/g" \
     version.py.in > version.py
 quilt refresh
 quilt pop -a

--- a/linux/scripts/test/test.inc.sh
+++ b/linux/scripts/test/test.inc.sh
@@ -20,7 +20,7 @@ mockDebPkgTools() {
 }
 
 createBase() {
-  TIER=$1
+  KEYMAN_TIER=$1
   remoteDir=$(mktemp -d)
   cd "${remoteDir}"
   git init --bare --initial-branch=master .
@@ -68,7 +68,7 @@ createBase() {
   git tag -m "16.0.145" release-16.0.145
   git push origin release-16.0.145
 
-  echo "${TIER}" > TIER.md
+  echo "${KEYMAN_TIER}" > TIER.md
   git add TIER.md
 
   echo "17.0.255" > VERSION.md

--- a/linux/scripts/verify_api.inc.sh
+++ b/linux/scripts/verify_api.inc.sh
@@ -32,7 +32,7 @@ check_api_not_changed() {
   trap "rm -rf \"${tmpDir}\"" ERR
   dpkg -x "${BIN_PKG}" "${tmpDir}"
   mkdir -p debian/tmp/DEBIAN
-  if dpkg-gensymbols -v"${VERSION}" -p"${PKG_NAME}" -e"${tmpDir}"/usr/lib/x86_64-linux-gnu/"${LIB_NAME}".so* -c4; then
+  if dpkg-gensymbols -v"${KEYMAN_VERSION}" -p"${PKG_NAME}" -e"${tmpDir}"/usr/lib/x86_64-linux-gnu/"${LIB_NAME}".so* -c4; then
     output_ok "${LIB_NAME} API didn't change"
   else
     output_error "${LIB_NAME} API changed"
@@ -205,7 +205,7 @@ get_api_version_from_core() {
 # NOTE: it is up to the caller to check if this is a major version
 # change that requires an API version update.
 is_api_version_updated() {
-  local OLD_API_VERSION NEW_API_VERSION TIER
+  local OLD_API_VERSION NEW_API_VERSION KEYMAN_TIER
   OLD_API_VERSION=$(get_api_version_in_symbols_file "${GIT_BASE}")
   NEW_API_VERSION=$(get_api_version_in_symbols_file "${GIT_SHA}")
   if (( NEW_API_VERSION > OLD_API_VERSION )); then
@@ -215,11 +215,11 @@ is_api_version_updated() {
 
   # API version didn't change. However, that might be ok if we're in alpha
   # and a major change happened previously.
-  TIER=$(cat "${REPO_ROOT}/TIER.md")
-  case ${TIER} in
+  KEYMAN_TIER=$(cat "${REPO_ROOT}/TIER.md")
+  case ${KEYMAN_TIER} in
     alpha)
       local STABLE_VERSION STABLE_API_VERSION STABLE_BRANCH
-      STABLE_VERSION=$((${VERSION%%.*} - 1))
+      STABLE_VERSION=$((${KEYMAN_VERSION%%.*} - 1))
       STABLE_BRANCH="origin/stable-${STABLE_VERSION}.0"
       STABLE_API_VERSION=$(get_api_version_in_symbols_file "${STABLE_BRANCH}")
       if (( STABLE_API_VERSION == -1 )); then

--- a/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
+++ b/mac/Keyman4MacIM/Keyman4MacIM.xcodeproj/project.pbxproj
@@ -954,7 +954,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# check that our PRODUCT_VERSION matches this git branch's VERSION from ../../VERSION.md\n(cd .. ; ./is_same_version.sh Keyman4MacIM || exit 1 ; cd -)\n";
+			shellScript = "# check that our PRODUCT_VERSION matches this git branch's KEYMAN_VERSION from ../../VERSION.md\n(cd .. ; ./is_same_version.sh Keyman4MacIM || exit 1 ; cd -)\n";
 			showEnvVarsInLog = 0;
 		};
 		D2FF67BB6C749BA6861F5E25 /* [CP] Check Pods Manifest.lock */ = {

--- a/mac/Keyman4MacIM/make-km-dmg.sh
+++ b/mac/Keyman4MacIM/make-km-dmg.sh
@@ -110,7 +110,7 @@ while [[ $# -gt 0 ]] ; do
 done
 
 # Step 0 - check parameter and initial file state
-if [ "$VERSION" = "" ]; then
+if [ "$KEYMAN_VERSION" = "" ]; then
   builder_die "Required -version parameter not specified!"
 fi
 
@@ -129,7 +129,7 @@ elif [[ ! -d "$OUTPUT_DIR" ]]; then
 fi
 
 if $ADD_VERSION_TO_DEST_DIR ; then
-    DEST_DIR="$DEST_DIR/$VERSION"
+    DEST_DIR="$DEST_DIR/$KEYMAN_VERSION"
 fi
 if [[ ! -e "$DEST_DIR" ]]; then
 	mkdir -p "$DEST_DIR"
@@ -140,7 +140,7 @@ fi
 # TODO: Check that no Keyman volume is already mounted.
 
 # Step 1 - Copy template to working copy to prevent unintended changes
-WORKING_COPY_OF_IMAGE="$OUTPUT_DIR/Keyman-temp-$VERSION.dmg"
+WORKING_COPY_OF_IMAGE="$OUTPUT_DIR/Keyman-temp-$KEYMAN_VERSION.dmg"
 displayInfo "Copying \"$TEMPLATE_IMAGE\" to \"$WORKING_COPY_OF_IMAGE\"..."
 if [[ -e "$WORKING_COPY_OF_IMAGE" && "$VERBOSITY" != "-quiet" ]] ; then
     builder_warn "Overwriting: $WORKING_COPY_OF_IMAGE"
@@ -212,7 +212,7 @@ if (( DETACH_SUCCESS < 999 )); then
 fi
 
 # Step 5 - Convert image to a compressed readonly DMG image
-DMG_FILE_PATH="$DEST_DIR/keyman-$VERSION.dmg"
+DMG_FILE_PATH="$DEST_DIR/keyman-$KEYMAN_VERSION.dmg"
 displayInfo "Converting/compressing image to create \"$DMG_FILE_PATH\""
 if [[ -e "$DMG_FILE_PATH" ]] ; then
     if [[ "$VERBOSITY" != "-quiet" ]] ; then

--- a/mac/Keyman4MacIM/write-download_info.sh
+++ b/mac/Keyman4MacIM/write-download_info.sh
@@ -39,7 +39,7 @@ popd  > /dev/null
 DEST_DIR="$KEYMAN_MACIM_BASE_PATH/output/upload"
 ADD_VERSION_TO_DEST_DIR=true
 
-KM_BLD_COUNTER="$((${VERSION##*.}))"
+KM_BLD_COUNTER="$((${KEYMAN_VERSION##*.}))"
 
 # Parse args
 shopt -s nocasematch
@@ -67,7 +67,7 @@ while [[ $# -gt 0 ]] ; do
 done
 
 if $ADD_VERSION_TO_DEST_DIR ; then
-    DEST_DIR="$DEST_DIR/$VERSION"
+    DEST_DIR="$DEST_DIR/$KEYMAN_VERSION"
 fi
 if [[ ! -e $DEST_DIR ]]; then
 	mkdir -p $DEST_DIR
@@ -75,7 +75,7 @@ elif [[ ! -d $DEST_DIR ]]; then
 	builder_die "Destination dir exists but is not a directory: $2"
 fi
 
-DMG_FILENAME="keyman-$VERSION.dmg"
+DMG_FILENAME="keyman-$KEYMAN_VERSION.dmg"
 DMG_FILEPATH="$DEST_DIR/$DMG_FILENAME"
 DOWNLOAD_INFO_FILEPATH="${DMG_FILEPATH}.download_info"
 if [[ ! -f "$DMG_FILEPATH" ]]; then
@@ -90,10 +90,10 @@ fi
 
 echo { > "$DOWNLOAD_INFO_FILEPATH"
 echo "  \"name\": \"Keyman4MacIM\"," >> "$DOWNLOAD_INFO_FILEPATH"
-echo "  \"version\": \"${VERSION}\"," >> "$DOWNLOAD_INFO_FILEPATH"
+echo "  \"version\": \"${KEYMAN_VERSION}\"," >> "$DOWNLOAD_INFO_FILEPATH"
 echo "  \"date\": \"$(date "+%Y-%m-%d")\"," >> "$DOWNLOAD_INFO_FILEPATH"
 echo "  \"platform\": \"mac\"," >> "$DOWNLOAD_INFO_FILEPATH"
-echo "  \"stability\": \"${TIER}\"," >> "$DOWNLOAD_INFO_FILEPATH"
+echo "  \"stability\": \"${KEYMAN_TIER}\"," >> "$DOWNLOAD_INFO_FILEPATH"
 echo "  \"file\": \"${DMG_FILENAME}\"," >> "$DOWNLOAD_INFO_FILEPATH"
 echo "  \"md5\": \"${DMG_MD5}\"," >> "$DOWNLOAD_INFO_FILEPATH"
 echo "  \"type\": \"dmg\"," >> "$DOWNLOAD_INFO_FILEPATH"

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj/project.pbxproj
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac.xcodeproj/project.pbxproj
@@ -494,7 +494,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# check that our PRODUCT_VERSION matches this git branch's VERSION from ../../VERSION.md\n(cd .. ; ./is_same_version.sh KeymanEngine4Mac || exit 1 ; cd -)\n";
+			shellScript = "# check that our PRODUCT_VERSION matches this git branch's KEYMAN_VERSION from ../../VERSION.md\n(cd .. ; ./is_same_version.sh KeymanEngine4Mac || exit 1 ; cd -)\n";
 			showEnvVarsInLog = 0;
 		};
 		E2588F2F1F2647A50061C9C4 /* ShellScript */ = {

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -97,7 +97,7 @@ if [[ -f "$THIS_SCRIPT_PATH/localenv.sh" ]]; then
     . "$THIS_SCRIPT_PATH/localenv.sh"
 fi
 
-BUILD_OPTIONS="-configuration $CONFIG $BUILD_OPTIONS PRODUCT_VERSION=$VERSION"
+BUILD_OPTIONS="-configuration $CONFIG $BUILD_OPTIONS PRODUCT_VERSION=$KEYMAN_VERSION"
 
 ### START OF THE BUILD ###
 
@@ -151,16 +151,16 @@ updatePlist() {
             builder_die "File not found: $KM_PLIST"
         fi
         local YEAR=`date "+%Y"`
-        echo "Setting version and related fields to $VERSION_WITH_TAG in $KM_PLIST"
-        /usr/libexec/Plistbuddy -c "Set CFBundleVersion $VERSION" "$KM_PLIST"
-        /usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString $VERSION" "$KM_PLIST"
-        /usr/libexec/Plistbuddy -c "Set :Keyman:SentryEnvironment $VERSION_ENVIRONMENT" "$KM_PLIST"
-        /usr/libexec/Plistbuddy -c "Set :Keyman:Tier $TIER" "$KM_PLIST"
-        /usr/libexec/Plistbuddy -c "Set :Keyman:VersionTag $VERSION_TAG" "$KM_PLIST"
-        /usr/libexec/Plistbuddy -c "Set :Keyman:VersionWithTag $VERSION_WITH_TAG" "$KM_PLIST"
-        /usr/libexec/Plistbuddy -c "Set :Keyman:VersionGitTag $VERSION_GIT_TAG" "$KM_PLIST"
-        /usr/libexec/Plistbuddy -c "Set :Keyman:VersionRelease $VERSION_RELEASE" "$KM_PLIST"
-        /usr/libexec/Plistbuddy -c "Set CFBundleGetInfoString $APPNAME $VERSION_WITH_TAG for macOS, Copyright © 2017-$YEAR SIL International." "$KM_PLIST"
+        echo "Setting version and related fields to $KEYMAN_VERSION_WITH_TAG in $KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set CFBundleVersion $KEYMAN_VERSION" "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString $KEYMAN_VERSION" "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set :Keyman:SentryEnvironment $KEYMAN_VERSION_ENVIRONMENT" "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set :Keyman:Tier $KEYMAN_TIER" "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set :Keyman:VersionTag $KEYMAN_VERSION_TAG" "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set :Keyman:VersionWithTag $KEYMAN_VERSION_WITH_TAG" "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set :Keyman:VersionGitTag $KEYMAN_VERSION_GIT_TAG" "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set :Keyman:VersionRelease $KEYMAN_VERSION_RELEASE" "$KM_PLIST"
+        /usr/libexec/Plistbuddy -c "Set CFBundleGetInfoString $APPNAME $KEYMAN_VERSION_WITH_TAG for macOS, Copyright © 2017-$YEAR SIL International." "$KM_PLIST"
         /usr/libexec/Plistbuddy -c "Set NSHumanReadableCopyright Copyright © 2017-$YEAR SIL International." "$KM_PLIST"
     fi
 }

--- a/mac/is_same_version.sh
+++ b/mac/is_same_version.sh
@@ -41,15 +41,15 @@ echo $PROJ_PROD_VERSION_LINE | sed /\ /s///g > ./PROJ_VERSION.md
 . ./PROJ_VERSION.md
 echo Product version in the project file PRODUCT_VERSION is $PRODUCT_VERSION
 
-echo Keyman version VERSION is $VERSION
+echo Keyman version VERSION is $KEYMAN_VERSION
 
-if [ x$VERSION = x$PRODUCT_VERSION ]
+if [ x$KEYMAN_VERSION = x$PRODUCT_VERSION ]
 then
 	echo the versions are the same, all is well.
 	# clean up
 	rm ./PROJ_VERSION.md
 	exit 0
 else
-	echo the version $VERSION and $PRODUCT_VERSION are NOT the same!
+	echo the version $KEYMAN_VERSION and $PRODUCT_VERSION are NOT the same!
 	exit 1
 fi

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -16,11 +16,11 @@ android {
         minSdkVersion 21
         targetSdkVersion 34
 
-        // VERSION_CODE and VERSION_NAME from version.gradle
-        versionCode VERSION_CODE as Integer
-        versionName VERSION_NAME
-        buildConfigField "String", "VERSION_ENVIRONMENT", "\""+VERSION_ENVIRONMENT+"\""
-        buildConfigField "String", "VERSION_GIT_TAG", "\""+VERSION_GIT_TAG+"\""
+        // KEYMAN_VERSION_CODE and KEYMAN_VERSION_NAME from version.gradle
+        versionCode KEYMAN_VERSION_CODE as Integer
+        versionName KEYMAN_VERSION_NAME
+        buildConfigField "String", "KEYMAN_VERSION_ENVIRONMENT", "\""+KEYMAN_VERSION_ENVIRONMENT+"\""
+        buildConfigField "String", "KEYMAN_VERSION_GIT_TAG", "\""+KEYMAN_VERSION_GIT_TAG+"\""
     }
 
     String env_release_store_file = System.getenv("oem_firstvoices_release_store_file")
@@ -55,9 +55,9 @@ android {
     }
 
     applicationVariants.all { variant ->
-        // Adjust output name to "firstvoices-${VERSION_MD}.apk"
+        // Adjust output name to "firstvoices-${KEYMAN_VERSION_MD}.apk"
         variant.outputs.all {
-            outputFileName = "firstvoices-" + VERSION_MD + ".apk"
+            outputFileName = "firstvoices-" + KEYMAN_VERSION_MD + ".apk"
         }
     }
     lintOptions {

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -41,8 +41,8 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardDownloa
 
         SentryAndroid.init(context, options -> {
             options.setEnableAutoSessionTracking(false);
-            options.setRelease(com.firstvoices.keyboards.BuildConfig.VERSION_GIT_TAG);
-            options.setEnvironment(com.firstvoices.keyboards.BuildConfig.VERSION_ENVIRONMENT);
+            options.setRelease(com.firstvoices.keyboards.BuildConfig.KEYMAN_VERSION_GIT_TAG);
+            options.setEnvironment(com.firstvoices.keyboards.BuildConfig.KEYMAN_VERSION_ENVIRONMENT);
         });
 
         resultReceiver = new FVDownloadResultReceiver(new Handler(), context);

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -50,8 +50,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
             Log.d(TAG, "Initializing Sentry");
             SentryAndroid.init(getApplicationContext(), options -> {
                 options.setEnableAutoSessionTracking(false);
-                options.setRelease(com.firstvoices.keyboards.BuildConfig.VERSION_GIT_TAG);
-                options.setEnvironment(com.firstvoices.keyboards.BuildConfig.VERSION_ENVIRONMENT);
+                options.setRelease(com.firstvoices.keyboards.BuildConfig.KEYMAN_VERSION_GIT_TAG);
+                options.setEnvironment(com.firstvoices.keyboards.BuildConfig.KEYMAN_VERSION_ENVIRONMENT);
             });
         }
 

--- a/oem/firstvoices/android/build.sh
+++ b/oem/firstvoices/android/build.sh
@@ -26,7 +26,7 @@ builder_describe "Builds FirstVoices for Android app." \
   "configure" \
   "build" \
   "test             Runs lint and tests." \
-  "publish          Publishes symbols to Sentry and the APK to the Play Store." 
+  "publish          Publishes symbols to Sentry and the APK to the Play Store."
 
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
@@ -38,7 +38,7 @@ if builder_is_debug_build; then
   TEST_FLAGS="-x assembleDebug lintDebug testDebug"
 fi
 
-ARTIFACT="firstvoices-$VERSION.apk"
+ARTIFACT="firstvoices-$KEYMAN_VERSION.apk"
 
 builder_describe_outputs \
   configure     /oem/firstvoices/android/app/libs/keyman-engine.aar \

--- a/oem/firstvoices/ios/build.sh
+++ b/oem/firstvoices/ios/build.sh
@@ -106,8 +106,8 @@ function do_build() {
             -archivePath "$ARCHIVE_PATH" \
             archive \
             -allowProvisioningUpdates \
-            VERSION=$VERSION \
-            VERSION_WITH_TAG=$VERSION_WITH_TAG
+            KEYMAN_VERSION=$KEYMAN_VERSION \
+            KEYMAN_VERSION_WITH_TAG=$KEYMAN_VERSION_WITH_TAG
 
     assertDirExists "$ARCHIVE_PATH"
 
@@ -120,14 +120,14 @@ function do_build() {
             -exportOptionsPlist exportAppStore.plist \
             -exportPath "$BUILD_PATH/${CONFIG}-iphoneos" \
             -allowProvisioningUpdates \
-            VERSION=$VERSION \
-            VERSION_WITH_TAG=$VERSION_WITH_TAG
+            KEYMAN_VERSION=$KEYMAN_VERSION \
+            KEYMAN_VERSION_WITH_TAG=$KEYMAN_VERSION_WITH_TAG
   else
     run_xcodebuild $CODE_SIGN \
             $XCODEFLAGS_EXT \
             -scheme "$TARGET" \
-            VERSION=$VERSION \
-            VERSION_WITH_TAG=$VERSION_WITH_TAG
+            KEYMAN_VERSION=$KEYMAN_VERSION \
+            KEYMAN_VERSION_WITH_TAG=$KEYMAN_VERSION_WITH_TAG
   fi
 
   if builder_has_option --sim-artifact; then
@@ -136,8 +136,8 @@ function do_build() {
             $XCODEFLAGS_EXT \
             -scheme "$TARGET" \
             -sdk iphonesimulator \
-            VERSION=$VERSION \
-            VERSION_WITH_TAG=$VERSION_WITH_TAG
+            KEYMAN_VERSION=$KEYMAN_VERSION \
+            KEYMAN_VERSION_WITH_TAG=$KEYMAN_VERSION_WITH_TAG
   fi
 }
 

--- a/oem/firstvoices/windows/src/inst/build.sh
+++ b/oem/firstvoices/windows/src/inst/build.sh
@@ -16,7 +16,7 @@ builder_describe "Installation files for FirstVoices Keyboards" \
 # after all other builds complete
 
 builder_describe_outputs \
-  publish       /windows/release/${VERSION}/firstvoices-${VERSION}.exe
+  publish       /windows/release/${KEYMAN_VERSION}/firstvoices-${KEYMAN_VERSION}.exe
 
 builder_parse "$@"
 
@@ -25,8 +25,8 @@ builder_parse "$@"
 . "$KEYMAN_ROOT/resources/build/win/zip.inc.sh"
 
 # In dev environments, we'll hack the tier to alpha; CI sets this for us in real builds.
-if [[ -z ${TIER+x} ]]; then
-  TIER=alpha
+if [[ -z ${KEYMAN_TIER+x} ]]; then
+  KEYMAN_TIER=alpha
 fi
 
 # TODO: why are we not bundling CEF?
@@ -61,7 +61,7 @@ function do_publish() {
 
   "$WIXHEAT" dir ../xml -o desktopui.wxs -ag -cg DesktopUI -dr INSTALLDIR -suid -var var.DESKTOPUISOURCE -wx -nologo
   "$WIXCANDLE" -dOEMNAME="FirstVoices" -dPRODUCTNAME="FirstVoices Keyboards" -dROOT="$KEYMAN_ROOT/windows" \
-     -dVERSION=$VERSION_WIN -dRELEASE=$VERSION_RELEASE \
+     -dKEYMAN_VERSION=$KEYMAN_VERSION_WIN -dRELEASE=$KEYMAN_VERSION_RELEASE \
      -dPRODUCTID=$GUID1 -dDESKTOPUISOURCE=../xml \
      firstvoices.wxs desktopui.wxs
 
@@ -101,9 +101,9 @@ function do_publish() {
 function copy-installer() {
   builder_heading copy-installer
 
-  mkdir -p "$KEYMAN_ROOT/windows/release/${VERSION}"
-  cp firstvoices.msi "$KEYMAN_ROOT/windows/release/${VERSION}/firstvoices.msi"
-  cp firstvoices.exe "$KEYMAN_ROOT/windows/release/${VERSION}/firstvoices-${VERSION}.exe"
+  mkdir -p "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}"
+  cp firstvoices.msi "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}/firstvoices.msi"
+  cp firstvoices.exe "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}/firstvoices-${KEYMAN_VERSION}.exe"
 
   verify-installer-signatures
 }
@@ -111,14 +111,14 @@ function copy-installer() {
 function verify-installer-signatures() {
   builder_heading verify-installer-signatures
 
-  verify-all-executable-signatures-in-folder "$KEYMAN_ROOT/windows/release/${VERSION}"
+  verify-all-executable-signatures-in-folder "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}"
 }
 
 function create-setup-inf() {
   builder_heading create-setup-inf
 
   echo "[Setup]" > setup.inf
-  echo "Version=$VERSION_WIN" >> setup.inf
+  echo "Version=$KEYMAN_VERSION_WIN" >> setup.inf
   echo "MSIFileName=firstvoices.msi" >> setup.inf
   echo "MSIOptions=" >> setup.inf
   echo "AppName=FirstVoices Keyboards" >> setup.inf

--- a/oem/firstvoices/windows/src/inst/firstvoices.wxs
+++ b/oem/firstvoices/windows/src/inst/firstvoices.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product UpgradeCode="f212edf7-0bef-43bb-8fc2-2625ae7bbfca" Manufacturer="SIL International"
-           Id="*" Name="$(var.PRODUCTNAME) $(var.RELEASE)" Version="$(var.VERSION)" Language="1033">
+           Id="*" Name="$(var.PRODUCTNAME) $(var.RELEASE)" Version="$(var.KEYMAN_VERSION)" Language="1033">
     <Package Keywords="Keyman,$(var.PRODUCTNAME),Keyboard,Engine"
              Description="$(var.PRODUCTNAME) $(var.RELEASE)" Comments="Contact:  Your local administrator" Compressed="yes"
              Manufacturer="SIL International" InstallerVersion="400" Platform="x86" Languages="1033" SummaryCodepage="1252" />
@@ -25,10 +25,10 @@
     <!-- PREVENT or ALLOW Upgrade from 11.0 or later versions -->
     <Upgrade Id="f212edf7-0bef-43bb-8fc2-2625ae7bbfca">
       <UpgradeVersion OnlyDetect="no" Minimum="11.0.0.0" IncludeMinimum="yes"
-                      Maximum="$(var.VERSION)" IncludeMaximum="no" MigrateFeatures="yes" Property="VERSION11FOUND" />
-      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VERSION)" IncludeMinimum="yes"
-                      Maximum="$(var.VERSION)" IncludeMaximum="yes" Property="CURRENTVERSIONFOUND" />
-      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VERSION)" IncludeMinimum="no" Property="NEWERFOUND" />
+                      Maximum="$(var.KEYMAN_VERSION)" IncludeMaximum="no" MigrateFeatures="yes" Property="VERSION11FOUND" />
+      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.KEYMAN_VERSION)" IncludeMinimum="yes"
+                      Maximum="$(var.KEYMAN_VERSION)" IncludeMaximum="yes" Property="CURRENTVERSIONFOUND" />
+      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.KEYMAN_VERSION)" IncludeMinimum="no" Property="NEWERFOUND" />
     </Upgrade>
 
     <Property Id='OLDINSTALLDIR'>
@@ -88,7 +88,7 @@
 
               <Component Id="Reg_RootPath" Guid="*">
                 <RegistryValue KeyPath="yes" Root="HKLM" Key="SOFTWARE\$(var.OEMNAME)\$(var.PRODUCTNAME)" Name="root path" Type="string" Value="[INSTALLDIR]" />
-                <RegistryValue Root="HKLM" Key="SOFTWARE\$(var.OEMNAME)\$(var.PRODUCTNAME)" Name="version" Type="string" Value="$(var.VERSION)" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\$(var.OEMNAME)\$(var.PRODUCTNAME)" Name="version" Type="string" Value="$(var.KEYMAN_VERSION)" />
                 <RegistryValue Root="HKLM" Key="SOFTWARE\$(var.OEMNAME)\$(var.PRODUCTNAME)" Name="release" Type="string" Value="$(var.RELEASE)" />
                 <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKLM" Key="Software\$(var.OEMNAME)\$(var.PRODUCTNAME)" />
               </Component>

--- a/resources/build/build-utils.sh
+++ b/resources/build/build-utils.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 #
-# This script sets build environment variables. VERSION vars are also exported:
-#   VERSION:          Full current build version, e.g. "14.0.1"
-#   VERSION_WIN:      Full current build version for Windows, e.g. "14.0.1.0"
-#   VERSION_RELEASE:  Current release version, e.g. "14.0"
-#   VERSION_MAJOR:    Major version, e.g. "14"
-#   VERSION_MINOR:    Minor version, e.g. "0"
-#   VERSION_PATCH:    Patch version, e.g. "1"
-#   TIER:             Current tier, one of "alpha", "beta" or "stable"
-#   VERSION_TAG:      Tier + Pull Request + Location of build [-alpha|-beta][-test[-1234]][-local]
-#   VERSION_WITH_TAG: e.g. "14.0.1-alpha-test-1234" or "14.0.5-beta-local" or "14.0.1-alpha-test"
-#   VERSION_GIT_TAG:  Git tag for the release, "release@$VERSION_WITH_TAG", e.g. "release@14.0.1-alpha-test-1234"
+# This script sets build environment variables. KEYMAN_VERSION vars are also exported:
+#   KEYMAN_VERSION:          Full current build version, e.g. "14.0.1"
+#   KEYMAN_VERSION_WIN:      Full current build version for Windows, e.g. "14.0.1.0"
+#   KEYMAN_VERSION_RELEASE:  Current release version, e.g. "14.0"
+#   KEYMAN_VERSION_MAJOR:    Major version, e.g. "14"
+#   KEYMAN_VERSION_MINOR:    Minor version, e.g. "0"
+#   KEYMAN_VERSION_PATCH:    Patch version, e.g. "1"
+#   KEYMAN_TIER:             Current tier, one of "alpha", "beta" or "stable"
+#   KEYMAN_VERSION_TAG:      Tier + Pull Request + Location of build [-alpha|-beta][-test[-1234]][-local]
+#   KEYMAN_VERSION_WITH_TAG: e.g. "14.0.1-alpha-test-1234" or "14.0.5-beta-local" or "14.0.1-alpha-test"
+#   KEYMAN_VERSION_GIT_TAG:  Git tag for the release, "release@$KEYMAN_VERSION_WITH_TAG", e.g. "release@14.0.1-alpha-test-1234"
 #   KEYMAN_ROOT:      fully resolved root path of Keyman repository
-#   VERSION_ENVIRONMENT: One of: local, test, alpha, beta, stable
-#   UPLOAD_SENTRY:    true - if VERSION_ENVIRONMENT is one of alpha, beta, stable
+#   KEYMAN_VERSION_ENVIRONMENT: One of: local, test, alpha, beta, stable
+#   UPLOAD_SENTRY:    true - if KEYMAN_VERSION_ENVIRONMENT is one of alpha, beta, stable
 #                     false - if local, test.  Indicates if debug artifacts should be uploaded to Sentry
 #   BUILDER_OS:       win|mac|linux -- current build environment
 #
@@ -57,20 +57,20 @@ function findKeymanRoot() {
 }
 
 function findVersion() {
-    local VERSION_MD="$KEYMAN_ROOT/VERSION.md"
-    VERSION=$(builder_trim $(<"$VERSION_MD"))
-    [[ "$VERSION" =~ ^([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)$ ]] && {
-        VERSION_MAJOR="${BASH_REMATCH[1]}"
-        VERSION_MINOR="${BASH_REMATCH[2]}"
-        VERSION_PATCH="${BASH_REMATCH[3]}"
-        VERSION_RELEASE="$VERSION_MAJOR.$VERSION_MINOR"
+    local KEYMAN_VERSION_MD="$KEYMAN_ROOT/VERSION.md"
+    KEYMAN_VERSION=$(builder_trim $(<"$KEYMAN_VERSION_MD"))
+    [[ "$KEYMAN_VERSION" =~ ^([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)$ ]] && {
+        KEYMAN_VERSION_MAJOR="${BASH_REMATCH[1]}"
+        KEYMAN_VERSION_MINOR="${BASH_REMATCH[2]}"
+        KEYMAN_VERSION_PATCH="${BASH_REMATCH[3]}"
+        KEYMAN_VERSION_RELEASE="$KEYMAN_VERSION_MAJOR.$KEYMAN_VERSION_MINOR"
     } || {
         echo "Invalid VERSION.md file: expected major.minor.patch";
         exit 1;
     }
 
     # Used for Windows, which requires a four part version string
-    VERSION_WIN="$VERSION.0"
+    KEYMAN_VERSION_WIN="$KEYMAN_VERSION.0"
 
     #
     # Build a tag to append to the version string. This is not assigned
@@ -78,70 +78,70 @@ function findVersion() {
     # display string and in TeamCity configuration
     #
 
-    if [ "$TIER" == "alpha" ] || [ "$TIER" == "beta" ]; then
-        VERSION_TAG="-$TIER"
+    if [ "$KEYMAN_TIER" == "alpha" ] || [ "$KEYMAN_TIER" == "beta" ]; then
+        KEYMAN_VERSION_TAG="-$KEYMAN_TIER"
     else
-        VERSION_TAG=
+        KEYMAN_VERSION_TAG=
     fi
 
     if [[ -z "${TEAMCITY_VERSION-}" && -z "${GITHUB_ACTIONS-}" && -z "${KEYMAN_PKG_BUILD-}" ]]; then
         # Local dev machine, not TeamCity or GitHub Action and not .deb package build
-        VERSION_TAG="$VERSION_TAG-local"
-        VERSION_ENVIRONMENT=local
+        KEYMAN_VERSION_TAG="$KEYMAN_VERSION_TAG-local"
+        KEYMAN_VERSION_ENVIRONMENT=local
     elif [ -n "${TEAMCITY_PR_NUMBER-}" ]; then
         # On TeamCity: are we running a pull request build or a master/beta/stable build?
-        VERSION_ENVIRONMENT="test"
+        KEYMAN_VERSION_ENVIRONMENT="test"
         # Note TEAMCITY_PR_NUMBER can also be 'master', 'beta', or 'stable-x.y'
         # This indicates we are running a Test build.
         if [[ $TEAMCITY_PR_NUMBER =~ ^(master|beta|stable(-[0-9]+\.[0-9]+)?)$ ]]; then
-            VERSION_TAG="$VERSION_TAG-test"
+            KEYMAN_VERSION_TAG="$KEYMAN_VERSION_TAG-test"
         else
-            VERSION_TAG="$VERSION_TAG-test-$TEAMCITY_PR_NUMBER"
+            KEYMAN_VERSION_TAG="$KEYMAN_VERSION_TAG-test-$TEAMCITY_PR_NUMBER"
         fi
     elif [ -n "${GITHUB_ACTIONS-}" ] && ${GHA_TEST_BUILD-}; then
-        VERSION_ENVIRONMENT="test"
+        KEYMAN_VERSION_ENVIRONMENT="test"
         # Note GHA_BRANCH can be 'master', 'beta', or 'stable-x.y'
         # This indicates we are running a Test build.
         if [[ ${GHA_BRANCH-} =~ ^(master|beta|stable(-[0-9]+\.[0-9]+)?)$ ]]; then
-            VERSION_TAG="${VERSION_TAG}-test"
+            KEYMAN_VERSION_TAG="${KEYMAN_VERSION_TAG}-test"
         else
-            VERSION_TAG="${VERSION_TAG}-test-${GHA_BRANCH-unset}"
+            KEYMAN_VERSION_TAG="${KEYMAN_VERSION_TAG}-test-${GHA_BRANCH-unset}"
         fi
     else
-        VERSION_ENVIRONMENT="$TIER"
+        KEYMAN_VERSION_ENVIRONMENT="$KEYMAN_TIER"
     fi
 
-    VERSION_WITH_TAG="$VERSION$VERSION_TAG"
-    VERSION_GIT_TAG="release@$VERSION_WITH_TAG"
+    KEYMAN_VERSION_WITH_TAG="$KEYMAN_VERSION$KEYMAN_VERSION_TAG"
+    KEYMAN_VERSION_GIT_TAG="release@$KEYMAN_VERSION_WITH_TAG"
 
-    readonly VERSION
-    readonly VERSION_MAJOR
-    readonly VERSION_MINOR
-    readonly VERSION_PATCH
-    readonly VERSION_RELEASE
-    readonly VERSION_WIN
-    readonly VERSION_TAG
-    readonly VERSION_WITH_TAG
-    readonly VERSION_ENVIRONMENT
-    readonly VERSION_GIT_TAG
+    readonly KEYMAN_VERSION
+    readonly KEYMAN_VERSION_MAJOR
+    readonly KEYMAN_VERSION_MINOR
+    readonly KEYMAN_VERSION_PATCH
+    readonly KEYMAN_VERSION_RELEASE
+    readonly KEYMAN_VERSION_WIN
+    readonly KEYMAN_VERSION_TAG
+    readonly KEYMAN_VERSION_WITH_TAG
+    readonly KEYMAN_VERSION_ENVIRONMENT
+    readonly KEYMAN_VERSION_GIT_TAG
 
     # Export version strings so places like version.gradle can access them
-    export VERSION
-    export VERSION_MAJOR
-    export VERSION_MINOR
-    export VERSION_PATCH
-    export VERSION_RELEASE
-    export VERSION_WIN
-    export VERSION_TAG
-    export VERSION_WITH_TAG
-    export VERSION_ENVIRONMENT
-    export VERSION_GIT_TAG
+    export KEYMAN_VERSION
+    export KEYMAN_VERSION_MAJOR
+    export KEYMAN_VERSION_MINOR
+    export KEYMAN_VERSION_PATCH
+    export KEYMAN_VERSION_RELEASE
+    export KEYMAN_VERSION_WIN
+    export KEYMAN_VERSION_TAG
+    export KEYMAN_VERSION_WITH_TAG
+    export KEYMAN_VERSION_ENVIRONMENT
+    export KEYMAN_VERSION_GIT_TAG
 }
 
 function findTier() {
-  local TIER_MD="$KEYMAN_ROOT/TIER.md"
-  TIER=$(builder_trim $(<"$TIER_MD"))
-  [[ "$TIER" =~ ^(alpha|beta|stable)$ ]] || {
+  local KEYMAN_TIER_MD="$KEYMAN_ROOT/TIER.md"
+  KEYMAN_TIER=$(builder_trim $(<"$KEYMAN_TIER_MD"))
+  [[ "$KEYMAN_TIER" =~ ^(alpha|beta|stable)$ ]] || {
       echo "Invalid TIER.md file: expected alpha, beta or stable."
       exit 1;
   }
@@ -150,39 +150,40 @@ function findTier() {
 function printBuildNumberForTeamCity() {
     if [ ! -z "${TEAMCITY_VERSION-}" ]; then
         if [ ! -z "${TEAMCITY_PR_NUMBER-}" ]; then
-            echo "##teamcity[buildNumber '$VERSION_WITH_TAG']"
+            echo "##teamcity[buildNumber '$KEYMAN_VERSION_WITH_TAG']"
         else
             # For alpha/beta builds, for now we don't append the
             # version tag as buildNumber is used in the delivery
             # of the build version. We may improve this in the
             # future.
-            echo "##teamcity[buildNumber '$VERSION']"
+            echo "##teamcity[buildNumber '$KEYMAN_VERSION']"
         fi
     fi
 }
 
 function printVersionUtilsDebug() {
-    echo "KEYMAN_ROOT:         $KEYMAN_ROOT"
-    echo "VERSION:             $VERSION"
-    echo "VERSION_WIN:         $VERSION_WIN"
-    echo "VERSION_RELEASE:     $VERSION_RELEASE"
-    echo "VERSION_MAJOR:       $VERSION_MAJOR"
-    echo "VERSION_MINOR:       $VERSION_MINOR"
-    echo "VERSION_PATCH:       $VERSION_PATCH"
-    echo "TIER:                $TIER"
-    echo "VERSION_TAG:         $VERSION_TAG"
-    echo "VERSION_WITH_TAG:    $VERSION_WITH_TAG"
-    echo "VERSION_GIT_TAG:     $VERSION_GIT_TAG"
-    echo "VERSION_ENVIRONMENT: $VERSION_ENVIRONMENT"
+    echo "KEYMAN_ROOT:                $KEYMAN_ROOT"
+    echo "KEYMAN_VERSION:             $KEYMAN_VERSION"
+    echo "KEYMAN_VERSION_WIN:         $KEYMAN_VERSION_WIN"
+    echo "KEYMAN_VERSION_RELEASE:     $KEYMAN_VERSION_RELEASE"
+    echo "KEYMAN_VERSION_MAJOR:       $KEYMAN_VERSION_MAJOR"
+    echo "KEYMAN_VERSION_MINOR:       $KEYMAN_VERSION_MINOR"
+    echo "KEYMAN_VERSION_PATCH:       $KEYMAN_VERSION_PATCH"
+    echo "KEYMAN_TIER:                $KEYMAN_TIER"
+    echo "KEYMAN_VERSION_TAG:         $KEYMAN_VERSION_TAG"
+    echo "KEYMAN_VERSION_WITH_TAG:    $KEYMAN_VERSION_WITH_TAG"
+    echo "KEYMAN_VERSION_GIT_TAG:     $KEYMAN_VERSION_GIT_TAG"
+    echo "KEYMAN_VERSION_ENVIRONMENT: $KEYMAN_VERSION_ENVIRONMENT"
 }
 
 function findShouldSentryRelease() {
-    # Default, for 'test' or 'local' environment, or in case $VERSION_ENVIRONMENT is improperly specified.
+    # Default, for 'test' or 'local' environment, or in case
+    # $KEYMAN_VERSION_ENVIRONMENT is improperly specified.
     # (May be overridden by -upload-sentry in supporting build scripts.)
     UPLOAD_SENTRY=false
 
     # Default: override to `true` for release builds.
-    case $VERSION_ENVIRONMENT in
+    case $KEYMAN_VERSION_ENVIRONMENT in
     # Actual release tiers
     alpha | beta | stable)
         UPLOAD_SENTRY=true
@@ -236,12 +237,12 @@ function exportEnvironmentDefinitionScript() {
     echo "# This file redefines critical environment variables for import to Xcode build phases." >> "$ENVIRONMENT_SH"
     echo "" >> "$ENVIRONMENT_SH"
 
-    # Defining variables for VERSION here will leave static definitions that don't automatically update when a user
+    # Defining variables for KEYMAN_VERSION here will leave static definitions that don't automatically update when a user
     # changes branches; some branches are 'similar enough' to not require full command-line based rebuilds.
-    # We want that VERSION number to properly mirror the state of its branch during development so that it matches
+    # We want that KEYMAN_VERSION number to properly mirror the state of its branch during development so that it matches
     # any error reports that get logged to Sentry.
     #
-    # As a result, we explicitly do NOT define VERSION or VERSION_TAG as part of ENVIRONMENT_SH.
+    # As a result, we explicitly do NOT define KEYMAN_VERSION or KEYMAN_VERSION_TAG as part of ENVIRONMENT_SH.
 
     echo "# Required for successful dSYM upload for Sentry error reporting" >> "$ENVIRONMENT_SH"
     echo "export SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN:-}" >> "$ENVIRONMENT_SH"
@@ -267,17 +268,17 @@ replaceVersionStrings() {
   local outfile=$2
 
   sed "
-    s/\$VERSION_WIN/$VERSION_WIN/g;
-    s/\$VERSION_RELEASE/$VERSION_RELEASE/g;
-    s/\$VERSION_MAJOR/$VERSION_MAJOR/g;
-    s/\$VERSION_MINOR/$VERSION_MINOR/g;
-    s/\$VERSION_PATCH/$VERSION_PATCH/g;
-    s/\$TIER/$TIER/g;
-    s/\$VERSION_TAG/$VERSION_TAG/g;
-    s/\$VERSION_WITH_TAG/$VERSION_WITH_TAG/g;
-    s/\$VERSION_GIT_TAG/$VERSION_GIT_TAG/g;
-    s/\$VERSION_ENVIRONMENT/$VERSION_ENVIRONMENT/g;
-    s/\$VERSION/$VERSION/g;
+    s/\$KEYMAN_VERSION_WIN/$KEYMAN_VERSION_WIN/g;
+    s/\$KEYMAN_VERSION_RELEASE/$KEYMAN_VERSION_RELEASE/g;
+    s/\$KEYMAN_VERSION_MAJOR/$KEYMAN_VERSION_MAJOR/g;
+    s/\$KEYMAN_VERSION_MINOR/$KEYMAN_VERSION_MINOR/g;
+    s/\$KEYMAN_VERSION_PATCH/$KEYMAN_VERSION_PATCH/g;
+    s/\$KEYMAN_TIER/$KEYMAN_TIER/g;
+    s/\$KEYMAN_VERSION_TAG/$KEYMAN_VERSION_TAG/g;
+    s/\$KEYMAN_VERSION_WITH_TAG/$KEYMAN_VERSION_WITH_TAG/g;
+    s/\$KEYMAN_VERSION_GIT_TAG/$KEYMAN_VERSION_GIT_TAG/g;
+    s/\$KEYMAN_VERSION_ENVIRONMENT/$KEYMAN_VERSION_ENVIRONMENT/g;
+    s/\$KEYMAN_VERSION/$KEYMAN_VERSION/g;
     " "$infile" > "$outfile"
 }
 
@@ -287,39 +288,39 @@ replaceVersionStrings_Mkver() {
   local infile=$1
   local outfile=$2
 
-  # Note that $VERSION differs between the two functions!
+  # Note that $KEYMAN_VERSION differs between the two functions!
   # We should be deprecating all the mkver strings
 
   sed "
-    s/\$VersionWin/$VERSION_WIN/g;
-    s/\$VersionRelease/$VERSION_RELEASE/g;
-    s/\$VersionMajor/$VERSION_MAJOR/g;
-    s/\$VersionMinor/$VERSION_MINOR/g;
-    s/\$VersionPatch/$VERSION_PATCH/g;
-    s/\$Tier/$TIER/g;
-    s/\$Tag/$VERSION_TAG/g;
-    s/\$VersionWithTag/$VERSION_WITH_TAG/g;
-    s/\$VersionGitTag/$VERSION_GIT_TAG/g;
-    s/\$VersionRc/$VERSION_MAJOR,$VERSION_MINOR,$VERSION_PATCH,0/g;
-    s/\$Environment/$VERSION_ENVIRONMENT/g;
-    s/\$Version/$VERSION/g;
-    s/\$VERSIONNUM/$VERSION_MAJOR,$VERSION_MINOR,$VERSION_PATCH,0/g;
-    s/\$RELEASE_MAJOR/$VERSION_MAJOR/g;
-    s/\$RELEASE_MINOR/$VERSION_MINOR/g;
-    s/\$RELEASE/$VERSION_RELEASE/g;
+    s/\$VersionWin/$KEYMAN_VERSION_WIN/g;
+    s/\$VersionRelease/$KEYMAN_VERSION_RELEASE/g;
+    s/\$VersionMajor/$KEYMAN_VERSION_MAJOR/g;
+    s/\$VersionMinor/$KEYMAN_VERSION_MINOR/g;
+    s/\$VersionPatch/$KEYMAN_VERSION_PATCH/g;
+    s/\$Tier/$KEYMAN_TIER/g;
+    s/\$Tag/$KEYMAN_VERSION_TAG/g;
+    s/\$VersionWithTag/$KEYMAN_VERSION_WITH_TAG/g;
+    s/\$VersionGitTag/$KEYMAN_VERSION_GIT_TAG/g;
+    s/\$VersionRc/$KEYMAN_VERSION_MAJOR,$KEYMAN_VERSION_MINOR,$KEYMAN_VERSION_PATCH,0/g;
+    s/\$Environment/$KEYMAN_VERSION_ENVIRONMENT/g;
+    s/\$Version/$KEYMAN_VERSION/g;
+    s/\$KEYMAN_VERSIONNUM/$KEYMAN_VERSION_MAJOR,$KEYMAN_VERSION_MINOR,$KEYMAN_VERSION_PATCH,0/g;
+    s/\$RELEASE_MAJOR/$KEYMAN_VERSION_MAJOR/g;
+    s/\$RELEASE_MINOR/$KEYMAN_VERSION_MINOR/g;
+    s/\$RELEASE/$KEYMAN_VERSION_RELEASE/g;
 
-    s/\$VERSION_WIN/$VERSION_WIN/g;
-    s/\$VERSION_RELEASE/$VERSION_RELEASE/g;
-    s/\$VERSION_MAJOR/$VERSION_MAJOR/g;
-    s/\$VERSION_MINOR/$VERSION_MINOR/g;
-    s/\$VERSION_PATCH/$VERSION_PATCH/g;
-    s/\$TIER/$TIER/g;
-    s/\$VERSION_TAG/$VERSION_TAG/g;
-    s/\$VERSION_WITH_TAG/$VERSION_WITH_TAG/g;
-    s/\$VERSION_GIT_TAG/$VERSION_GIT_TAG/g;
-    s/\$VERSION_ENVIRONMENT/$VERSION_ENVIRONMENT/g;
+    s/\$KEYMAN_VERSION_WIN/$KEYMAN_VERSION_WIN/g;
+    s/\$KEYMAN_VERSION_RELEASE/$KEYMAN_VERSION_RELEASE/g;
+    s/\$KEYMAN_VERSION_MAJOR/$KEYMAN_VERSION_MAJOR/g;
+    s/\$KEYMAN_VERSION_MINOR/$KEYMAN_VERSION_MINOR/g;
+    s/\$KEYMAN_VERSION_PATCH/$KEYMAN_VERSION_PATCH/g;
+    s/\$KEYMAN_TIER/$KEYMAN_TIER/g;
+    s/\$KEYMAN_VERSION_TAG/$KEYMAN_VERSION_TAG/g;
+    s/\$KEYMAN_VERSION_WITH_TAG/$KEYMAN_VERSION_WITH_TAG/g;
+    s/\$KEYMAN_VERSION_GIT_TAG/$KEYMAN_VERSION_GIT_TAG/g;
+    s/\$KEYMAN_VERSION_ENVIRONMENT/$KEYMAN_VERSION_ENVIRONMENT/g;
 
-    s/\$VERSION/$VERSION_WIN/g;
+    s/\$KEYMAN_VERSION/$KEYMAN_VERSION_WIN/g;
 
     " "$infile" > "$outfile"
 }

--- a/resources/build/ci/pull-requests.inc.sh
+++ b/resources/build/ci/pull-requests.inc.sh
@@ -73,7 +73,7 @@ function ci_repo_has_cached_changes {
 #   * hub
 #   * uuidgen (or TeamCity `$BUILD_NUMBER` if `uuidgen` not present on system)
 # Example:
-#   ci_open_pull_request "$S_KEYMAN_COM" auto/keymanweb/release "auto: KeymanWeb release $VERSION_RELEASE""
+#   ci_open_pull_request "$S_KEYMAN_COM" auto/keymanweb/release "auto: KeymanWeb release $KEYMAN_VERSION_RELEASE""
 #
 function ci_open_pull_request {
   local repo="$1"

--- a/resources/build/help-keyman-com.sh
+++ b/resources/build/help-keyman-com.sh
@@ -74,38 +74,38 @@ function upload {
 function upload_keyman_help {
   case $platform in
     android)
-      upload android/docs/help products/android/$VERSION_RELEASE
-      upload android/docs/engine developer/engine/android/$VERSION_RELEASE
+      upload android/docs/help products/android/$KEYMAN_VERSION_RELEASE
+      upload android/docs/engine developer/engine/android/$KEYMAN_VERSION_RELEASE
       ;;
     ios)
-      upload ios/docs/help products/iphone-and-ipad/$VERSION_RELEASE
-      upload ios/docs/engine developer/engine/iphone-and-ipad/$VERSION_RELEASE
+      upload ios/docs/help products/iphone-and-ipad/$KEYMAN_VERSION_RELEASE
+      upload ios/docs/engine developer/engine/iphone-and-ipad/$KEYMAN_VERSION_RELEASE
       ;;
     linux)
       pushd "$KEYMAN_ROOT/linux/keyman-config" > /dev/null
       ./build.sh build
       popd > /dev/null
-      upload linux/docs/help products/linux/$VERSION_RELEASE
+      upload linux/docs/help products/linux/$KEYMAN_VERSION_RELEASE
       ;;
     mac)
-      upload mac/docs/help products/mac/$VERSION_RELEASE
+      upload mac/docs/help products/mac/$KEYMAN_VERSION_RELEASE
       ;;
     web)
-      upload web/docs/engine developer/engine/web/$VERSION_RELEASE
+      upload web/docs/engine developer/engine/web/$KEYMAN_VERSION_RELEASE
       ;;
     windows)
       # Note: `/windows/src/desktop/help/build.sh web` must be run first
-      upload windows/bin/help/md/desktop products/windows/$VERSION_RELEASE
-      upload windows/docs/engine developer/engine/windows/$VERSION_RELEASE
+      upload windows/bin/help/md/desktop products/windows/$KEYMAN_VERSION_RELEASE
+      upload windows/docs/engine developer/engine/windows/$KEYMAN_VERSION_RELEASE
       ;;
     developer)
       # Note: `/developer/build.sh api` must be run first - covers both uploads
-      upload developer/docs/help developer/$VERSION_RELEASE
-      upload developer/build/docs developer/$VERSION_RELEASE/reference/api
-      upload developer/src/kmc/build/messages developer/$VERSION_RELEASE/reference/messages
+      upload developer/docs/help developer/$KEYMAN_VERSION_RELEASE
+      upload developer/build/docs developer/$KEYMAN_VERSION_RELEASE/reference/api
+      upload developer/src/kmc/build/messages developer/$KEYMAN_VERSION_RELEASE/reference/messages
       # Note: we publish the core help alongside developer because we don't have
       # a core CI release build
-      upload core/docs/api developer/core/$VERSION_RELEASE
+      upload core/docs/api developer/core/$KEYMAN_VERSION_RELEASE
       ;;
     *)
       display_usage
@@ -152,6 +152,6 @@ if ! ci_repo_has_cached_changes "$HELP_KEYMAN_COM"; then
   exit 0
 fi
 
-ci_open_pull_request "$HELP_KEYMAN_COM" "auto/$platform-help-$VERSION_WITH_TAG" "auto: Keyman for $platform help deployment"
+ci_open_pull_request "$HELP_KEYMAN_COM" "auto/$platform-help-$KEYMAN_VERSION_WITH_TAG" "auto: Keyman for $platform help deployment"
 
 exit 0

--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -111,10 +111,10 @@ fi
 
 if [[ $ABORT = 50 ]]; then
   if [[ $FORCE = 0 ]]; then
-    echo "Skipping version increment from $VERSION: no recently merged pull requests were found"
+    echo "Skipping version increment from $KEYMAN_VERSION: no recently merged pull requests were found"
     if [ ! -z "${TEAMCITY_VERSION-}" ]; then
       # Send TeamCity a build status
-      echo "##teamcity[buildStatus status='SUCCESS' text='Skipping version increment from $VERSION: no recently merged pull requests were found']"
+      echo "##teamcity[buildStatus status='SUCCESS' text='Skipping version increment from $KEYMAN_VERSION: no recently merged pull requests were found']"
     fi
     exit 0
   else
@@ -131,14 +131,14 @@ popd > /dev/null
 #
 
 if [ "$action" == "commit" ]; then
-  echo "increment-version.sh: committing to repository and tagging release version $VERSION_WITH_TAG"
-  VERSION_MD="$KEYMAN_ROOT/VERSION.md"
-  NEWVERSION=`cat $VERSION_MD | tr -d "[:space:]"`
+  echo "increment-version.sh: committing to repository and tagging release version $KEYMAN_VERSION_WITH_TAG"
+  KEYMAN_VERSION_MD="$KEYMAN_ROOT/VERSION.md"
+  NEWVERSION=`cat $KEYMAN_VERSION_MD | tr -d "[:space:]"`
 
   pushd "$KEYMAN_ROOT" > /dev/null
   message="auto: increment $base version to $NEWVERSION"
   branch="auto/version-$base-$NEWVERSION"
-  git tag -a "$VERSION_GIT_TAG" -m "Keyman release $VERSION_WITH_TAG"
+  git tag -a "$KEYMAN_VERSION_GIT_TAG" -m "Keyman release $KEYMAN_VERSION_WITH_TAG"
   git checkout -b "$branch"
   git add VERSION.md HISTORY.md
 
@@ -206,7 +206,7 @@ if [ "$action" == "commit" ]; then
   echo "Version was incremented and pull request was created, and builds were triggered"
   if [ ! -z "${TEAMCITY_VERSION-}" ]; then
     # Send TeamCity a build status
-    echo "##teamcity[buildStatus status='SUCCESS' text='Version was incremented from $VERSION to $NEWVERSION and pull request was created']"
+    echo "##teamcity[buildStatus status='SUCCESS' text='Version was incremented from $KEYMAN_VERSION to $NEWVERSION and pull request was created']"
   fi
 
   #

--- a/resources/build/meson/standard_meson_build.inc.sh
+++ b/resources/build/meson/standard_meson_build.inc.sh
@@ -8,7 +8,7 @@
 # resources/ folder (which should be git-ignored):
 #
 #   * resources/meson.build - a copy of standard.meson.build from this folder
-#   * resources/VERSION_WITH_TAG.md - the value of the env var $VERSION_WITH_TAG
+#   * resources/KEYMAN_VERSION_WITH_TAG.md - the value of the env var $KEYMAN_VERSION_WITH_TAG
 #
 # We do this because meson doesn't allow us to:
 #
@@ -31,5 +31,5 @@
 standard_meson_build() {
   mkdir -p "$THIS_SCRIPT_PATH/resources"
   cp "$KEYMAN_ROOT/resources/build/meson/standard.meson.build" "$THIS_SCRIPT_PATH/resources/meson.build"
-  echo "$VERSION_WITH_TAG" > "$THIS_SCRIPT_PATH/resources/VERSION_WITH_TAG.md"
+  echo "$KEYMAN_VERSION_WITH_TAG" > "$THIS_SCRIPT_PATH/resources/KEYMAN_VERSION_WITH_TAG.md"
 }

--- a/resources/build/publish-minimum-versions.sh
+++ b/resources/build/publish-minimum-versions.sh
@@ -31,7 +31,17 @@ generate_table() {
   # echo "${strarr[@]}"
 
   for n in ${!strarr[@]}; do
-    echo "| ${strarr[n]} | ${!strarr[n]} |"
+    case "${strarr[n]}" in
+    KEYMAN_VERSION | KEYMAN_VERSION_MAJOR | KEYMAN_VERSION_MINOR | \
+    KEYMAN_VERSION_PATCH | KEYMAN_VERSION_RELEASE | KEYMAN_VERSION_WIN | \
+    KEYMAN_VERSION_TAG | KEYMAN_VERSION_WITH_TAG | \
+    KEYMAN_VERSION_ENVIRONMENT | KEYMAN_VERSION_GIT_TAG)
+      # ignore the variables that contain the Keyman version
+      ;;
+    *)
+      echo "| ${strarr[n]} | ${!strarr[n]} |"
+      ;;
+    esac
   done
 
   echo ""

--- a/resources/build/sentry-control.inc.sh
+++ b/resources/build/sentry-control.inc.sh
@@ -27,14 +27,14 @@ function makeSentryRelease() {
   if isSentryConfigured; then
     if isSentryCliAvailable; then
       # This version tag matches the repository version tag release@x.y.z
-      echo "Making a Sentry release for tag $VERSION_GIT_TAG"
-      sentry-cli releases new -p keyman-android -p keyman-developer -p keyman-ios -p keyman-linux -p keyman-mac -p keyman-web -p keyman-windows $VERSION_GIT_TAG
+      echo "Making a Sentry release for tag $KEYMAN_VERSION_GIT_TAG"
+      sentry-cli releases new -p keyman-android -p keyman-developer -p keyman-ios -p keyman-linux -p keyman-mac -p keyman-web -p keyman-windows $KEYMAN_VERSION_GIT_TAG
 
-      echo "Setting commits for release tag $VERSION_GIT_TAG"
-      sentry-cli releases set-commits --auto $VERSION_GIT_TAG
+      echo "Setting commits for release tag $KEYMAN_VERSION_GIT_TAG"
+      sentry-cli releases set-commits --auto $KEYMAN_VERSION_GIT_TAG
 
-      echo "Finalizing release tag $VERSION_GIT_TAG"
-      sentry-cli releases finalize "$VERSION_GIT_TAG"
+      echo "Finalizing release tag $KEYMAN_VERSION_GIT_TAG"
+      sentry-cli releases finalize "$KEYMAN_VERSION_GIT_TAG"
     fi
   fi
 }

--- a/resources/build/set-bundle-versions-and-settings-tagged.sh
+++ b/resources/build/set-bundle-versions-and-settings-tagged.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Calls script in xcode-utils to update the version
-# true:  applies VERSION_WITH_TAG to custom KeymanVersionWithTag plist member used for in-app display
+# true:  applies KEYMAN_VERSION_WITH_TAG to custom KeymanVersionWithTag plist member used for in-app display
 # updates the version string for Settings
 
 source "$KEYMAN_ROOT/resources/build/xcode-utils.sh"

--- a/resources/build/set-bundle-versions-and-settings-untagged.sh
+++ b/resources/build/set-bundle-versions-and-settings-untagged.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Calls script in xcode-utils to update the version
-# true:  applies VERSION_WITH_TAG to custom KeymanVersionWithTag plist member used for in-app display
+# true:  applies KEYMAN_VERSION_WITH_TAG to custom KeymanVersionWithTag plist member used for in-app display
 # updates the version string for Settings
 
 source "$KEYMAN_ROOT/resources/build/xcode-utils.sh"

--- a/resources/build/set-bundle-versions-tagged.sh
+++ b/resources/build/set-bundle-versions-tagged.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Calls script in xcode-utils to update the version
-# true:  applies VERSION_WITH_TAG to custom KeymanVersionWithTag plist member used for in-app display
+# true:  applies KEYMAN_VERSION_WITH_TAG to custom KeymanVersionWithTag plist member used for in-app display
 
 source "$KEYMAN_ROOT/resources/build/xcode-utils.sh"
 phaseSetBundleVersions true

--- a/resources/build/test/test.sh
+++ b/resources/build/test/test.sh
@@ -91,7 +91,7 @@ builder_parse_test() {
   local expected_options="$2"
 
   # When testing in a local environment, --debug will be added by default (see #11106)
-  if [[ $VERSION_ENVIRONMENT == "local" ]]; then
+  if [[ $KEYMAN_VERSION_ENVIRONMENT == "local" ]]; then
     expected_options="${expected_options} --debug"
   fi
 
@@ -191,7 +191,7 @@ echo -e "${COLOR_BLUE}## Testing output of: builder_parse --feature xyzzy --bar 
 parse_output=$(builder_parse --feature xyzzy --bar abc --baz def test)
 expected="$(builder_echo setmark "test.sh parameters: <--feature xyzzy --bar abc --baz def test>")"
 
-if [[ $VERSION_ENVIRONMENT == "local" ]]; then
+if [[ $KEYMAN_VERSION_ENVIRONMENT == "local" ]]; then
   # When run in a local-dev environment, an extra line appears about the automatic --debug option.
   expected="$(builder_echo grey "Local build environment detected:  setting --debug")"$'\n'"$(builder_echo setmark "test.sh parameters: <--feature xyzzy --bar abc --baz def test --debug>")"
 fi

--- a/resources/build/trigger-builds.inc.sh
+++ b/resources/build/trigger-builds.inc.sh
@@ -78,9 +78,9 @@ function triggerGitHubActionsBuild() {
 
   if [ "${action:-""}" == "commit" ]; then
     # This will only be true if we created and pushed a tag
-    GIT_BUILD_SHA="$(git rev-parse "refs/tags/release@$VERSION_WITH_TAG")"
+    GIT_BUILD_SHA="$(git rev-parse "refs/tags/release@$KEYMAN_VERSION_WITH_TAG")"
     GIT_BASE_REF="$(git rev-parse "${GIT_BUILD_SHA}^")"
-    GIT_EVENT_TYPE="${GITHUB_ACTION}: release@${VERSION_WITH_TAG}"
+    GIT_EVENT_TYPE="${GITHUB_ACTION}: release@${KEYMAN_VERSION_WITH_TAG}"
   elif [[ $GIT_BRANCH != stable-* ]] && [[ $GIT_BRANCH =~ [0-9]+ ]]; then
     local JSON=$(call_curl "${GITHUB_SERVER}/pulls/${GIT_BRANCH}" --header "Authorization: token $GITHUB_TOKEN")
     GIT_BUILD_SHA="$(echo "$JSON" | $JQ -r '.head.sha')"

--- a/resources/build/version/src/fixupHistory.ts
+++ b/resources/build/version/src/fixupHistory.ts
@@ -39,7 +39,7 @@ const splicePullsIntoHistory = async (pulls: PRInformation[], base?: string): Pr
       tier = (await spawnChild('git', ['show', base+':TIER.md'])).trim();
     }
   }
-  //logInfo(`VERSION="${version}"`);
+  //logInfo(`KEYMAN_VERSION="${version}"`);
 
   //
   // Load and parse history file, looking for our version

--- a/resources/build/win/environment.inc.sh
+++ b/resources/build/win/environment.inc.sh
@@ -32,7 +32,7 @@ COMMON_ROOT="$KEYMAN_ROOT/common/windows/delphi"
 OUTLIB="$WINDOWS_ROOT/lib"
 COMMON_OUTLIB="$KEYMAN_ROOT/common/windows/lib"
 
-if builder_is_debug_build || [[ $VERSION_ENVIRONMENT == local ]] || [[ ! -z ${TEAMCITY_PR_NUMBER+x} ]]; then
+if builder_is_debug_build || [[ $KEYMAN_VERSION_ENVIRONMENT == local ]] || [[ ! -z ${TEAMCITY_PR_NUMBER+x} ]]; then
   # We do a fast build for debug builds, local builds, test PR builds but not for master/beta/stable release builds
   GO_FAST=1
 else
@@ -125,8 +125,8 @@ wrap-symstore() {
   "$ProgramFilesx86/Windows Kits/10/Debuggers/x64/symstore.exe" \
     add \
     //s "$KEYMAN_SYMSTOREPATH" \
-    //v "$VERSION_WIN" \
-    //c "Version: $VERSION_WITH_TAG" \
+    //v "$KEYMAN_VERSION_WIN" \
+    //c "Version: $KEYMAN_VERSION_WITH_TAG" \
     //compress //f "$@"
 }
 

--- a/resources/build/xcode-utils.sh
+++ b/resources/build/xcode-utils.sh
@@ -42,10 +42,10 @@ function phaseSetBundleVersions() {
     TAGGED=false
   fi
 
-  # For command-line builds, VERSION and VERSION_WITH_TAG) are forwarded through xcodebuild.
-  if [ -z "${VERSION:-}" ]; then
+  # For command-line builds, KEYMAN_VERSION and KEYMAN_VERSION_WITH_TAG) are forwarded through xcodebuild.
+  if [ -z "${KEYMAN_VERSION:-}" ]; then
     # This is likely not a command-line build at the top level; it's been triggered through Xcode.
-    # The $VERSION-loading code is in build-utils.sh, but we need $THIS_SCRIPT to be set
+    # The $KEYMAN_VERSION-loading code is in build-utils.sh, but we need $THIS_SCRIPT to be set
     # (in similar manner to the "standard build header") in order to avoid script errors therein.
     THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
@@ -53,9 +53,9 @@ function phaseSetBundleVersions() {
     # local builds triggered through Xcode's UI, which aren't part of our CI processes.
     . "$KEYMAN_ROOT/resources/build/build-utils.sh"
     echo "phaseSetBundleVersions: UI build - fetching version from repository:"
-    echo "  Plain:  $VERSION"
-    echo "  Tagged: $VERSION_WITH_TAG"
-    echo "  Environment: $VERSION_ENVIRONMENT"
+    echo "  Plain:  $KEYMAN_VERSION"
+    echo "  Tagged: $KEYMAN_VERSION_WITH_TAG"
+    echo "  Environment: $KEYMAN_VERSION_ENVIRONMENT"
   else
     echo "phaseSetBundleVersions: Command-line build - using provided version parameters"
   fi
@@ -76,48 +76,48 @@ function phaseSetBundleVersions() {
   APP_PLIST="$TARGET_BUILD_DIR/$INFOPLIST_PATH"
   echo "phaseSetBundleVersions: Setting CFBundleVersion to $BUILD_NUMBER for $APP_PLIST"
   /usr/libexec/Plistbuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$APP_PLIST"
-  echo "phaseSetBundleVersions: Setting CFBundleShortVersionString to $VERSION for $APP_PLIST"
-  /usr/libexec/Plistbuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP_PLIST"
+  echo "phaseSetBundleVersions: Setting CFBundleShortVersionString to $KEYMAN_VERSION for $APP_PLIST"
+  /usr/libexec/Plistbuddy -c "Set :CFBundleShortVersionString $KEYMAN_VERSION" "$APP_PLIST"
 
   /usr/libexec/Plistbuddy -c "Print" "$APP_PLIST"
 
   # Only attempt to write this when directly specified (otherwise, generates minor warning)
   if [ $TAGGED == true ]; then
-    echo "phaseSetBundleVersions: Setting KeymanVersionWithTag to $VERSION_WITH_TAG for tagged version for $APP_PLIST"
-    /usr/libexec/Plistbuddy -c "Set :KeymanVersionWithTag $VERSION_WITH_TAG" "$APP_PLIST"
-    echo "phaseSetBundleVersions: Setting KeymanVersionEnvironment to $VERSION_ENVIRONMENT for $APP_PLIST"
-    /usr/libexec/Plistbuddy -c "Set :KeymanVersionEnvironment $VERSION_ENVIRONMENT" "$APP_PLIST"
+    echo "phaseSetBundleVersions: Setting KeymanVersionWithTag to $KEYMAN_VERSION_WITH_TAG for tagged version for $APP_PLIST"
+    /usr/libexec/Plistbuddy -c "Set :KeymanVersionWithTag $KEYMAN_VERSION_WITH_TAG" "$APP_PLIST"
+    echo "phaseSetBundleVersions: Setting KeymanVersionEnvironment to $KEYMAN_VERSION_ENVIRONMENT for $APP_PLIST"
+    /usr/libexec/Plistbuddy -c "Set :KeymanVersionEnvironment $KEYMAN_VERSION_ENVIRONMENT" "$APP_PLIST"
   fi
 
   if [ -f "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}.dSYM/Contents/Info.plist" ]; then
     DSYM_PLIST="${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}.dSYM/Contents/Info.plist"
     echo "phaseSetBundleVersions: Setting CFBundleVersion to $BUILD_NUMBER for $DSYM_PLIST"
     /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$DSYM_PLIST"
-    echo "phaseSetBundleVersions: Setting CFBundleShortVersionString to $VERSION for $DSYM_PLIST"
-    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$DSYM_PLIST"
+    echo "phaseSetBundleVersions: Setting CFBundleShortVersionString to $KEYMAN_VERSION for $DSYM_PLIST"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $KEYMAN_VERSION" "$DSYM_PLIST"
   fi
 }
 
 # Used by Keyman for iOS to update the human-readable string for its Settings screen.
 function setSettingsBundleVersion() {
-  # For command-line builds, VERSION and VERSION_WITH_TAG) are forwarded through xcodebuild.
-  if [ -z "${VERSION:-}" ]; then
+  # For command-line builds, KEYMAN_VERSION and KEYMAN_VERSION_WITH_TAG) are forwarded through xcodebuild.
+  if [ -z "${KEYMAN_VERSION:-}" ]; then
     # We're not a command-line build... so we'll need to retrieve these values ourselves with ./build-utils.sh.
     # Note that this script's process will not have access to TC environment variables, but that's fine for
     # local builds triggered through Xcode's UI, which aren't part of our CI processes.
     . "$KEYMAN_ROOT/resources/build/build-utils.sh"
     echo "setSettingsBundleVersion: UI build - fetching version from repository:"
-    echo "  Plain:  $VERSION"
-    echo "  Tagged: $VERSION_WITH_TAG"
+    echo "  Plain:  $KEYMAN_VERSION"
+    echo "  Tagged: $KEYMAN_VERSION_WITH_TAG"
     echo "  Environment: (not setting, assume 'local')"
   else
     echo "setSettingsBundleVersion: Command-line build - using provided version parameters"
   fi
 
   SETTINGS_PLIST="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Settings.bundle/Root.plist"
-  echo "setSettingsBundleVersion: Setting $VERSION_WITH_TAG for $SETTINGS_PLIST"
+  echo "setSettingsBundleVersion: Setting $KEYMAN_VERSION_WITH_TAG for $SETTINGS_PLIST"
   # We assume that entry 0 = the version "preference" entry.
-  /usr/libexec/PlistBuddy -c "Set :PreferenceSpecifiers:0:DefaultValue $VERSION_WITH_TAG" "$SETTINGS_PLIST"
+  /usr/libexec/PlistBuddy -c "Set :PreferenceSpecifiers:0:DefaultValue $KEYMAN_VERSION_WITH_TAG" "$SETTINGS_PLIST"
 }
 
 # Build Phase:  Upload dSYM (debug) files to Sentry

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1511,7 +1511,7 @@ _builder_parse_expanded_parameters() {
 
     # Per #11106, local builds use --debug by default.
     # Second condition prevents the block (and message) from executing when --debug is already specified explicitly.
-    if [[ $VERSION_ENVIRONMENT == "local" ]] && [[ $builder_debug != --debug ]] && ! $is_release; then
+    if [[ $KEYMAN_VERSION_ENVIRONMENT == "local" ]] && [[ $builder_debug != --debug ]] && ! $is_release; then
       builder_echo grey "Local build environment detected:  setting --debug"
       _params+=(--debug)
       _builder_chosen_options+=(--debug)

--- a/resources/locate_emscripten.inc.sh
+++ b/resources/locate_emscripten.inc.sh
@@ -44,7 +44,7 @@ locate_emscripten() {
 # For developers, define KEYMAN_USE_EMSDK to do this on your
 # build machine.
 verify_emscripten_version() {
-  if [[ "$VERSION_ENVIRONMENT" != local || ! -z "${KEYMAN_USE_EMSDK+x}" ]]; then
+  if [[ "$KEYMAN_VERSION_ENVIRONMENT" != local || ! -z "${KEYMAN_USE_EMSDK+x}" ]]; then
     _select_emscripten_version_with_emsdk
   fi
 }

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -170,19 +170,19 @@ write_download_info() {
 set_version ( ) {
   PRODUCT_PATH=$1
 
-  if [ $VERSION ]; then
+  if [ $KEYMAN_VERSION ]; then
     if [ $2 ]; then  # $2 = product name.
-      echo "Setting version numbers in $2 to $VERSION."
+      echo "Setting version numbers in $2 to $KEYMAN_VERSION."
     fi
-    /usr/libexec/Plistbuddy -c "Set CFBundleVersion $VERSION" "$PRODUCT_PATH/Info.plist"
-    /usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString $VERSION" "$PRODUCT_PATH/Info.plist"
+    /usr/libexec/Plistbuddy -c "Set CFBundleVersion $KEYMAN_VERSION" "$PRODUCT_PATH/Info.plist"
+    /usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString $KEYMAN_VERSION" "$PRODUCT_PATH/Info.plist"
   fi
 }
 
 
 # Uses npm to set the current package version (package.json).
 #
-# This sets the version according to the current VERSION_WITH_TAG.
+# This sets the version according to the current KEYMAN_VERSION_WITH_TAG.
 #
 # Usage:
 #
@@ -194,7 +194,7 @@ set_npm_version () {
   # release of Keyman Developer -- these two versions should be in sync. Because this
   # is a large repo with multiple projects and build systems, it's better for us that
   # individual build systems don't take too much ownership of git tagging. :)
-  npm version --allow-same-version --no-git-tag-version --no-commit-hooks "$VERSION_WITH_TAG"
+  npm version --allow-same-version --no-git-tag-version --no-commit-hooks "$KEYMAN_VERSION_WITH_TAG"
 }
 
 #
@@ -265,7 +265,7 @@ verify_npm_setup() {
   # If we are on CI environment, automatically select a node version with nvm
   # Also, a developer can set KEYMAN_USE_NVM variable to get this behaviour
   # automatically too (see /docs/build/node.md)
-  if [[ "$VERSION_ENVIRONMENT" != local || ! -z "${KEYMAN_USE_NVM+x}" ]]; then
+  if [[ "$KEYMAN_VERSION_ENVIRONMENT" != local || ! -z "${KEYMAN_USE_NVM+x}" ]]; then
     _select_node_version_with_nvm
   fi
 

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -37,7 +37,7 @@ builder_parse "$@"
 
 ####
 
-TIER=$(cat ../TIER.md)
+KEYMAN_TIER=$(cat ../TIER.md)
 BUILD_NUMBER=$(cat ../VERSION.md)
 
 function web_sentry_upload () {
@@ -50,7 +50,7 @@ function web_sentry_upload () {
 
   # --strip-common-prefix does not take an argument, unlike --strip-prefix.  It auto-detects
   # the most common prefix instead.
-  sentry-cli releases files "${VERSION_GIT_TAG}" upload-sourcemaps --strip-common-prefix "$1" \
+  sentry-cli releases files "${KEYMAN_VERSION_GIT_TAG}" upload-sourcemaps --strip-common-prefix "$1" \
     --rewrite --ext js --ext map --ext ts
   echo "Upload successful."
 }
@@ -119,7 +119,7 @@ function prepare_s_keyman_com_action() {
   # Second phase:  copy the artifacts over
 
   # The main build products are expected to reside at the root of this folder.
-  BASE_PUBLISH_FOLDER="${S_KEYMAN_COM}/kmw/engine/${VERSION}"
+  BASE_PUBLISH_FOLDER="${S_KEYMAN_COM}/kmw/engine/${KEYMAN_VERSION}"
   echo "FOLDER: ${BASE_PUBLISH_FOLDER}"
   mkdir -p "${BASE_PUBLISH_FOLDER}"
 
@@ -130,27 +130,27 @@ function prepare_s_keyman_com_action() {
   # Third phase: tweak the sourcemaps
   # We can use an alt-mode of Web's sourcemap-root tool for this.
   for sourcemap in "${BASE_PUBLISH_FOLDER}/"*.map; do
-    node "${KEYMAN_ROOT}/web/build/tools/building/sourcemap-root/index.js" null "${sourcemap}" --sourceRoot "https://s.keyman.com/kmw/engine/${VERSION}/src"
+    node "${KEYMAN_ROOT}/web/build/tools/building/sourcemap-root/index.js" null "${sourcemap}" --sourceRoot "https://s.keyman.com/kmw/engine/${KEYMAN_VERSION}/src"
   done
 
   # Construct the PR
-  echo "Committing and pushing KeymanWeb release ${VERSION} to s.keyman.com"
+  echo "Committing and pushing KeymanWeb release ${KEYMAN_VERSION} to s.keyman.com"
 
-  ci_add_files "${S_KEYMAN_COM}" "kmw/engine/${VERSION}"
+  ci_add_files "${S_KEYMAN_COM}" "kmw/engine/${KEYMAN_VERSION}"
   if ! ci_repo_has_cached_changes "${S_KEYMAN_COM}"; then
     builder_die "No release was added to s.keyman.com, something went wrong"
   fi
 
-  ci_open_pull_request "${S_KEYMAN_COM}" auto/keymanweb/release "auto: KeymanWeb release ${VERSION}"
+  ci_open_pull_request "${S_KEYMAN_COM}" auto/keymanweb/release "auto: KeymanWeb release ${KEYMAN_VERSION}"
 }
 
 # Note:  for now, this command is used to prepare the artifacts used by the download site, but
 #        NOT to actually UPLOAD them via rsync or to produce related .download_info files.
 function prepare_downloads_keyman_com_action() {
-  UPLOAD_PATH="${KEYMAN_ROOT}/web/build/upload/${VERSION}"
+  UPLOAD_PATH="${KEYMAN_ROOT}/web/build/upload/${KEYMAN_VERSION}"
 
   # --- First action artifact - the KMW zip file ---
-  ZIP="${UPLOAD_PATH}/keymanweb-${VERSION}.zip"
+  ZIP="${UPLOAD_PATH}/keymanweb-${KEYMAN_VERSION}.zip"
 
   mkdir -p "${UPLOAD_PATH}"
 

--- a/web/src/tools/building/check-build-size.sh
+++ b/web/src/tools/building/check-build-size.sh
@@ -88,15 +88,15 @@ LOCAL_FILE=web/build/publish/release/keymanweb.js
 LOCAL_FILE_SIZE=`stat --printf="%s" $KEYMAN_ROOT/$LOCAL_FILE`
 
 #
-# Get the most recent build for $TIER from downloads.keyman.com
+# Get the most recent build for $KEYMAN_TIER from downloads.keyman.com
 #
 
 DOWNLOADS_VERSION_API=https://downloads.keyman.com/api/version/web
 REMOTE_KEYMANWEB_VERSIONS=`curl -s $DOWNLOADS_VERSION_API`
-REMOTE_VERSION=`echo $REMOTE_KEYMANWEB_VERSIONS | $JQ -r ".web.$TIER"`
+REMOTE_VERSION=`echo $REMOTE_KEYMANWEB_VERSIONS | $JQ -r ".web.$KEYMAN_TIER"`
 
-REMOTE_FILE_NEW=https://downloads.keyman.com/web/$TIER/$REMOTE_VERSION/static/build/app/browser/release/keymanweb.js
-REMOTE_FILE_OLD=https://downloads.keyman.com/web/$TIER/$REMOTE_VERSION/static/build/app/web/release/keymanweb.js
+REMOTE_FILE_NEW=https://downloads.keyman.com/web/$KEYMAN_TIER/$REMOTE_VERSION/static/build/app/browser/release/keymanweb.js
+REMOTE_FILE_OLD=https://downloads.keyman.com/web/$KEYMAN_TIER/$REMOTE_VERSION/static/build/app/web/release/keymanweb.js
 
 # If the remote file does not exist at the 'new' location, try the 'old' one instead.
 # Allows reorganization 'fallback' for the file-size check.

--- a/windows/src/buildtools/sentry-upload-difs.sh
+++ b/windows/src/buildtools/sentry-upload-difs.sh
@@ -31,7 +31,7 @@ cd "$KEYMAN_ROOT/windows/src"
 
 echo "Uploading symbols for desktop/"
 sentry-cli upload-dif -p keyman-windows -t breakpad -t pdb desktop --include-sources
-sentry-cli releases -p keyman-windows files "$VERSION_GIT_TAG" upload-sourcemaps desktop/kmshell/xml
+sentry-cli releases -p keyman-windows files "$KEYMAN_VERSION_GIT_TAG" upload-sourcemaps desktop/kmshell/xml
 
 echo "Uploading symbols for engine/"
 sentry-cli upload-dif -p keyman-windows -t breakpad -t pdb engine --include-sources

--- a/windows/src/desktop/inst/build.sh
+++ b/windows/src/desktop/inst/build.sh
@@ -15,7 +15,7 @@ builder_describe "Installation files for Keyman for Windows" \
 # after all other builds complete
 
 builder_describe_outputs \
-  publish       /windows/release/${VERSION}/keyman-${VERSION}.exe
+  publish       /windows/release/${KEYMAN_VERSION}/keyman-${KEYMAN_VERSION}.exe
 
 builder_parse "$@"
 
@@ -24,8 +24,8 @@ builder_parse "$@"
 . "$KEYMAN_ROOT/resources/build/win/zip.inc.sh"
 
 # In dev environments, we'll hack the tier to alpha; CI sets this for us in real builds.
-if [[ -z ${TIER+x} ]]; then
-  TIER=alpha
+if [[ -z ${KEYMAN_TIER+x} ]]; then
+  KEYMAN_TIER=alpha
 fi
 
 # We use different directories so that heat generates
@@ -101,15 +101,15 @@ function do_publish() {
 function copy-installer() {
   builder_heading copy-installer
 
-  mkdir -p "$KEYMAN_ROOT/windows/release/${VERSION}"
-  cp keymandesktop.msi "$KEYMAN_ROOT/windows/release/${VERSION}/keymandesktop.msi"
-  cp keymandesktop.exe "$KEYMAN_ROOT/windows/release/${VERSION}/keyman-${VERSION}.exe"
-  cp "$WINDOWS_PROGRAM_APP/setup.exe" "$KEYMAN_ROOT/windows/release/${VERSION}/setup.exe"
+  mkdir -p "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}"
+  cp keymandesktop.msi "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}/keymandesktop.msi"
+  cp keymandesktop.exe "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}/keyman-${KEYMAN_VERSION}.exe"
+  cp "$WINDOWS_PROGRAM_APP/setup.exe" "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}/setup.exe"
 
   verify-installer-signatures
 
   # Copy the unsigned setup.exe for use in bundling scenarios; zip it up for clarity
-  wzzip "$KEYMAN_ROOT/windows/release/${VERSION}/setup-redist.zip" "$WINDOWS_PROGRAM_APP/setup-redist.exe"
+  wzzip "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}/setup-redist.zip" "$WINDOWS_PROGRAM_APP/setup-redist.exe"
 }
 
 function verify-program-signatures() {
@@ -121,12 +121,12 @@ function verify-program-signatures() {
 function verify-installer-signatures() {
   builder_heading verify-installer-signatures
 
-  verify-all-executable-signatures-in-folder "$KEYMAN_ROOT/windows/release/${VERSION}"
+  verify-all-executable-signatures-in-folder "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}"
 }
 
 function test-releaseexists() {
-  if [[ -d "$KEYMAN_ROOT/windows/release/${VERSION}" ]]; then
-    builder_die "Release ${VERSION} already exists. Delete it or update VERSION.md and try again"
+  if [[ -d "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}" ]]; then
+    builder_die "Release ${KEYMAN_VERSION} already exists. Delete it or update VERSION.md and try again"
   fi
 }
 
@@ -138,7 +138,7 @@ function do_candle() {
   local GUID1=$(generate_uuid)
   "$WIXHEAT" dir ../kmshell/xml -o desktopui.wxs -ag -cg DesktopUI -dr INSTALLDIR -suid -var var.DESKTOPUISOURCE -wx -nologo
   "$WIXHEAT" dir ../kmshell/locale -o locale.wxs -ag -cg Locale -dr INSTALLDIR -var var.LOCALESOURCE -wx -nologo
-  "$WIXCANDLE" -dVERSION_WITH_TAG=${VERSION_WITH_TAG} -dVERSION=${VERSION_WIN} -dRELEASE=${VERSION_RELEASE} -dPRODUCTID=$GUID1 \
+  "$WIXCANDLE" -dKEYMAN_VERSION_WITH_TAG=${KEYMAN_VERSION_WITH_TAG} -dKEYMAN_VERSION=${KEYMAN_VERSION_WIN} -dRELEASE=${KEYMAN_VERSION_RELEASE} -dPRODUCTID=$GUID1 \
     -dDESKTOPUISOURCE=../kmshell/xml -dLOCALESOURCE=../kmshell/locale "-dCefSourceDir=$KEYMAN_CEF4DELPHI_ROOT" \
     keymandesktop.wxs desktopui.wxs locale.wxs cef.wxs
 }
@@ -160,7 +160,7 @@ function create-setup-inf() {
   builder_heading create-setup-inf
 
   echo "[Setup]" > setup.inf
-  echo "Version=${VERSION_WIN}" >> setup.inf
+  echo "Version=${KEYMAN_VERSION_WIN}" >> setup.inf
   echo "MSIFileName=keymandesktop.msi" >> setup.inf
   echo "MSIOptions=" >> setup.inf
   echo "License=license.html" >> setup.inf

--- a/windows/src/desktop/inst/keymandesktop.wxs
+++ b/windows/src/desktop/inst/keymandesktop.wxs
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product UpgradeCode="c70af17c-8b9e-47a1-a099-b65aee3dc8b4" Manufacturer="SIL International"
-           Id="*" Name="Keyman $(var.RELEASE)" Version="$(var.VERSION)" Language="1033">
+           Id="*" Name="Keyman $(var.RELEASE)" Version="$(var.KEYMAN_VERSION)" Language="1033">
     <Package Keywords="Keyman,Keyman for Windows,Keyboard,Engine"
              Description="Keyman $(var.RELEASE)" Comments="Contact:  Your local administrator" Compressed="yes"
              Manufacturer="SIL International" InstallerVersion="400" Platform="x86" Languages="1033" SummaryCodepage="1252" />
@@ -44,10 +44,10 @@
     <!-- PREVENT or ALLOW Upgrade from 11.0 or later versions -->
     <Upgrade Id="c70af17c-8b9e-47a1-a099-b65aee3dc8b4">
       <UpgradeVersion OnlyDetect="no" Minimum="11.0.0.0" IncludeMinimum="yes"
-                      Maximum="$(var.VERSION)" IncludeMaximum="no" MigrateFeatures="yes" Property="VERSION11FOUND" />
-      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VERSION)" IncludeMinimum="yes"
-                      Maximum="$(var.VERSION)" IncludeMaximum="yes" Property="CURRENTVERSIONFOUND" />
-      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VERSION)" IncludeMinimum="no" Property="NEWERFOUND" />
+                      Maximum="$(var.KEYMAN_VERSION)" IncludeMaximum="no" MigrateFeatures="yes" Property="VERSION11FOUND" />
+      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.KEYMAN_VERSION)" IncludeMinimum="yes"
+                      Maximum="$(var.KEYMAN_VERSION)" IncludeMaximum="yes" Property="CURRENTVERSIONFOUND" />
+      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.KEYMAN_VERSION)" IncludeMinimum="no" Property="NEWERFOUND" />
     </Upgrade>
 
     <Property Id='OLDINSTALLDIR'>
@@ -150,7 +150,7 @@
 
               <Component Id="Reg_RootPath" Guid="*">
                 <RegistryValue KeyPath="yes" Root="HKLM" Key="SOFTWARE\Keyman\Keyman Desktop" Name="root path" Type="string" Value="[INSTALLDIR]" />
-                <RegistryValue Root="HKLM" Key="SOFTWARE\Keyman\Keyman Desktop" Name="version" Type="string" Value="$(var.VERSION)" />
+                <RegistryValue Root="HKLM" Key="SOFTWARE\Keyman\Keyman Desktop" Name="version" Type="string" Value="$(var.KEYMAN_VERSION)" />
                 <RegistryValue Root="HKLM" Key="SOFTWARE\Keyman\Keyman Desktop" Name="release" Type="string" Value="$(var.RELEASE)" />
                 <RegistryValue Root="HKLM" Key="SOFTWARE\Keyman\Keyman Desktop" Name="charmap source data" Type="string" Value="[INSTALLDIR]" />
                 <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Root="HKLM" Key="Software\Keyman\Keyman Desktop" />
@@ -314,7 +314,7 @@
     <Property Id="ARPURLUPDATEINFO" Value="http://www.keyman.com/" />
     <Property Id="ARPHELPLINK" Value="http://help.keyman.com/" />
 
-    <Property Id="VersionWithTag" Value="$(var.VERSION_WITH_TAG)" />
+    <Property Id="VersionWithTag" Value="$(var.KEYMAN_VERSION_WITH_TAG)" />
 
   </Product>
 </Wix>

--- a/windows/src/engine/inst/build.sh
+++ b/windows/src/engine/inst/build.sh
@@ -14,7 +14,7 @@ builder_describe "Installation files for Keyman Engine for Windows" \
 # after all other builds complete
 
 builder_describe_outputs \
-  publish       /windows/release/${VERSION}/keymanengine-${VERSION}.msm
+  publish       /windows/release/${KEYMAN_VERSION}/keymanengine-${KEYMAN_VERSION}.msm
 
 builder_parse "$@"
 
@@ -23,8 +23,8 @@ builder_parse "$@"
 . "$KEYMAN_ROOT/resources/build/win/zip.inc.sh"
 
 # In dev environments, we'll hack the tier to alpha; CI sets this for us in real builds.
-if [[ -z ${TIER+x} ]]; then
-  TIER=alpha
+if [[ -z ${KEYMAN_TIER+x} ]]; then
+  KEYMAN_TIER=alpha
 fi
 
 #-------------------------------------------------------------------------------------------------------------------
@@ -35,7 +35,7 @@ function do_publish() {
   #
   # Build the installation archive
   #
-  "$WIXCANDLE" -dVERSION=$VERSION_WIN -dRELEASE=$VERSION_RELEASE -ext WixUtilExtension keymanengine.wxs components.wxs
+  "$WIXCANDLE" -dKEYMAN_VERSION=$KEYMAN_VERSION_WIN -dRELEASE=$KEYMAN_VERSION_RELEASE -ext WixUtilExtension keymanengine.wxs components.wxs
 
   # warning 1072 relates to Error table defined by WixUtilExtension. Doesn't really affect us.
   "$WIXLIGHT" -sw1072 -ext WixUtilExtension keymanengine.wixobj components.wixobj -o keymanengine.msm
@@ -50,8 +50,8 @@ function do_publish() {
 
 function copy-installer() {
   builder_heading copy-installer
-  mkdir -p "$KEYMAN_ROOT/windows/release/${VERSION}"
-  cp keymanengine.msm "$KEYMAN_ROOT/windows/release/${VERSION}/keymanengine-${VERSION}.msm"
+  mkdir -p "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}"
+  cp keymanengine.msm "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}/keymanengine-${KEYMAN_VERSION}.msm"
 }
 
 function verify-program-signatures() {
@@ -61,8 +61,8 @@ function verify-program-signatures() {
 }
 
 function test-releaseexists() {
-  if [[ -d "$KEYMAN_ROOT/windows/release/${VERSION}" ]]; then
-    builder_die "Release ${VERSION} already exists. Delete it or update VERSION.md and try again"
+  if [[ -d "$KEYMAN_ROOT/windows/release/${KEYMAN_VERSION}" ]]; then
+    builder_die "Release ${KEYMAN_VERSION} already exists. Delete it or update VERSION.md and try again"
   fi
 }
 

--- a/windows/src/engine/inst/keymanengine.wxs
+++ b/windows/src/engine/inst/keymanengine.wxs
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Module Id="engine" Version="$(var.VERSION)" Language="1033">
+  <Module Id="engine" Version="$(var.KEYMAN_VERSION)" Language="1033">
     <Package Id="{CE38CB16-4448-4432-851B-B3FCE3AF464F}" Keywords="Keyman,Keyboard,Engine"
              Description="Keyman Engine $(var.RELEASE)" Comments="Contact:  Your local administrator"
              Manufacturer="SIL International" InstallerVersion="200" Platform="x86" Languages="1033" SummaryCodepage="1252" />


### PR DESCRIPTION
Previously the builder scripts defined a readonly `VERSION` environment variable for the Keyman version. That caused problems when another (external) script tried to define a `VERSION` variable. We encountered this problem when trying to move the TC build steps of a configuration into a single script (#13399) when we tried to source `~/.nvm/nvm.sh`.

This change uses a Keyman specific prefix for the version variables and renames `VERSION` → `KEYMAN_VERSION` etc. as well as `TIER` → `KEYMAN_TIER`. Unfortunately these variables are used in a lot of places, so this turned out to be a bit of a yak shave. 

# User Testing

Please test that filenames/installer names are as expected and that the version number shown during installation as well as in the app is as expected. You'll have to compare this with an older installation. It might require some exploration since I don't know where the version number is shown in the different platforms. The expected version for this PR is 19.0.33.

If you can think of additional places where the version number is shown that are not covered by the tests below, please check those as well and maybe edit the tests below.

Note: testing on Linux is not possible since package building for this PR is impossible until this PR merged.

- GROUP_WIN
- GROUP_MAC
- GROUP_ANDROID
- GROUP_IOS
- GROUP_WEB
- GROUP_DEVELOPER

- **TEST_INSTALLER_FILENAME**: filenames didn't change compared to previous versions and show the current version number where applicable
- **TEST_INSTALLATION**: display of version number didn't change compared to previous versions (if applicable)
- **TEST_ABOUT**: in the UI of the app, the version number shows in the same way as before
- **TEST_HELP**: the version number in the installed help shows the same way as before (where applicable)