### PR TITLE
fix(windows): use json file name against cache folder

### DIFF
--- a/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
@@ -134,6 +134,7 @@ begin
   Result := False;
   FSuccessfulDownloadCount := 0;
   // Keyboard Packages
+
   for i := 0 to High(Params.Packages) do
   begin
     Params.Packages[i].SavePath := SavePath + Params.Packages[i].FileName;
@@ -147,7 +148,6 @@ begin
       TKeymanSentryClient.Breadcrumb('error', 'Download failded for keyboard: '+ Params.Packages[i].DownloadURL, 'cli.download');
     end;
   end;
-
   // Keyman Installer
   //
   if Params.Status = ucrsUpdateReady then
@@ -161,6 +161,10 @@ begin
       ErrorLogMessage('DoDownloadUpdates Failed to download' + Params.InstallURL);
       TKeymanSentryClient.Breadcrumb('error', 'Download failded for keyboard: '+  Params.InstallURL, 'cli.download');
     end;
+  end
+  else
+  begin
+      TKeymanSentryClient.Breadcrumb('info', 'DoDownloadUpdates Params.Status !=ucrsUpdateReady', 'cli.download');
   end;
   // If there is at least one keyboard package or version of keyman downloaded then
   // the result is true
@@ -178,7 +182,7 @@ begin
   if not IsOnline then
   begin
     TKeymanSentryClient.Breadcrumb('default', 'TDownloadUpdate: Not Online, cant execute download process.', 'cli.download');
-    Exit;
+    Exit(False);
   end;
   DownloadBackGroundSavePath := IncludeTrailingPathDelimiter(TKeymanPaths.KeymanUpdateCachePath);
   if TUpdateCheckStorage.LoadUpdateCacheData(ucr) then
@@ -187,7 +191,10 @@ begin
     KL.Log('DownloadUpdates.DownloadUpdates: DownloadResult = '+IntToStr(Ord(Result)));
   end
   else
+  begin
     Result := False;
+    TKeymanSentryClient.Breadcrumb('default', 'TDownloadUpdate: LoadUpdateCacheData failed.', 'cli.download');
+  end;
 end;
 
 end.

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -1017,19 +1017,20 @@ function InstallingState.DoInstallKeyman: Boolean;
 var
   FResult: Boolean;
   SavePath: String;
-  fileExt: String;
   FileName: String;
   FileNames: TStringDynArray;
+  ucr: TUpdateCheckResponse;
+  ucrFileName: String;
   found: Boolean;
 begin
-
+  TUpdateCheckStorage.LoadUpdateCacheData(ucr);
+  ucrFileName := ucr.FileName;
   SavePath := IncludeTrailingPathDelimiter(TKeymanPaths.KeymanUpdateCachePath);
   GetFileNamesInDirectory(SavePath, FileNames);
   found := False;
   for FileName in FileNames do
   begin
-    fileExt := LowerCase(ExtractFileExt(FileName));
-    if fileExt = '.exe' then
+    if ucrFileName = ExtractFileName(FileName) then
     begin
       found := True;
       break;

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -38,8 +38,8 @@ type
 
   public
     constructor Create(Context: TUpdateStateMachine);
-    procedure Enter; virtual; abstract;
-    procedure Exit; virtual; abstract;
+    procedure EnterState; virtual; abstract;
+    procedure ExitState; virtual; abstract;
     procedure HandleCheck; virtual; abstract;
     function  HandleKmShell: Integer; virtual; abstract;
     procedure HandleDownload; virtual; abstract;
@@ -153,8 +153,8 @@ type
   // Derived classes for each state
   IdleState = class(TState)
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -167,8 +167,8 @@ type
   private
     procedure StartDownloadProcess;
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -179,8 +179,8 @@ type
   DownloadingState = class(TState)
   private
     function DownloadUpdatesBackground: Boolean;
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -190,8 +190,8 @@ type
 
   WaitingRestartState = class(TState)
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -225,8 +225,8 @@ type
     procedure LaunchInstallPackageProcess;
 
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -447,14 +447,14 @@ procedure TUpdateStateMachine.SetState(const Value: TStateClass);
 begin
   if Assigned(CurrentState) then
   begin
-    CurrentState.Exit;
+    CurrentState.ExitState;
   end;
 
   SetStateOnly(ConvertStateToEnum(Value));
 
   if Assigned(CurrentState) then
   begin
-    CurrentState.Enter;
+    CurrentState.EnterState;
   end
   else
   begin
@@ -602,13 +602,13 @@ end;
 
 { IdleState }
 
-procedure IdleState.Enter;
+procedure IdleState.EnterState;
 begin
   // Enter UpdateAvailableState
   bucStateContext.SetRegistryState(usIdle);
 end;
 
-procedure IdleState.Exit;
+procedure IdleState.ExitState;
 begin
 
 end;
@@ -704,7 +704,7 @@ begin
   end;
 end;
 
-procedure UpdateAvailableState.Enter;
+procedure UpdateAvailableState.EnterState;
 begin
   // Enter UpdateAvailableState
   bucStateContext.SetRegistryState(usUpdateAvailable);
@@ -714,7 +714,7 @@ begin
   end;
 end;
 
-procedure UpdateAvailableState.Exit;
+procedure UpdateAvailableState.ExitState;
 begin
   // Exit UpdateAvailableState
 end;
@@ -767,7 +767,7 @@ end;
 
 { DownloadingState }
 
-procedure DownloadingState.Enter;
+procedure DownloadingState.EnterState;
 var
   DownloadResult: Boolean;
   RetryCount: Integer;
@@ -783,6 +783,7 @@ begin
     // downloading process finish.
     if not FMutex.TakeOwnership then
     begin
+      TKeymanSentryClient.Breadcrumb('default', 'DownloadingState.EnterState: Unable to get Mutex download process exists', 'update');
       Exit;
     end;
 
@@ -823,7 +824,7 @@ begin
 
 end;
 
-procedure DownloadingState.Exit;
+procedure DownloadingState.ExitState;
 begin
   // Exit DownloadingState
 end;
@@ -902,13 +903,13 @@ end;
 
 { WaitingRestartState }
 
-procedure WaitingRestartState.Enter;
+procedure WaitingRestartState.EnterState;
 begin
   // Enter WaitingRestartState
   bucStateContext.SetRegistryState(usWaitingRestart);
 end;
 
-procedure WaitingRestartState.Exit;
+procedure WaitingRestartState.ExitState;
 begin
   // Exit DownloadingState
 end;
@@ -1112,7 +1113,7 @@ begin
   Result := True;
 end;
 
-procedure InstallingState.Enter;
+procedure InstallingState.EnterState;
 var
   ucr: TUpdateCheckResponse;
   hasPackages, hasKeymanInstall: Boolean;
@@ -1149,7 +1150,7 @@ begin
   ChangeState(IdleState);
 end;
 
-procedure InstallingState.Exit;
+procedure InstallingState.ExitState;
 begin
 
 end;
@@ -1205,7 +1206,9 @@ begin
   end;
 
   if hasKeymanInstall then
+  begin
     DoInstallKeyman;
+  end;
 end;
 
 procedure InstallingState.HandleFirstRun;

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -1030,7 +1030,7 @@ begin
   found := False;
   for FileName in FileNames do
   begin
-    if ucrFileName = ExtractFileName(FileName) then
+    if SameText(ucrFileName, ExtractFileName(FileName)) then
     begin
       found := True;
       break;


### PR DESCRIPTION
Be more precise by matching the file name in the cache.json file with the downloaded file in the cache folder. This will mean any older installation versions that were not correctly cleaned up will not be installed.

fixes #13831
This test needs there to be a newer build available on the server when doing check for updates
# User Testing

## TEST_NEW_VERSION_INSTALLED
The aim of this test is that when there a two versions of keyman in the UpdateCache one the current version and one a newer version. The newer version should be installed.

1. Install the Keyman from this PR
2. Copy the Keyman executable from this PR to `C:\Users\UserName\AppData\Local\Keyman\UpdateCache`
3. Open Keyman Configuration and go to the updated tab
4. Press the "check for updates" button.
5. If an update for Keyman is found you can proceed with this test, otherwise we will need to wait for the next build which is daily if a PR has been merged.
6. Check  `C:\Users\UserName\AppData\Local\Keyman\UpdateCache` and you should see two keyman*.exe install files. The one copied in step 2 and the new version to install.
7. Restart the Machine 
8. When Windows restarts you get the prompt to install a Keyman Update select `Update`
9. Once it has finished and Keyman has installed open Keyman configuration and verify the newer version of Keyman has been installed.