### PR TITLE
maint(common): add two more functions to detect if running on CI 🌇

### DIFF
--- a/docs/builder.md
+++ b/docs/builder.md
@@ -880,6 +880,53 @@ fi
 
 --------------------------------------------------------------------------------
 
+## `builder_is_running_on_ci` function
+
+Returns `true` (aka 0) if the script runs on TeamCity or as a GitHub action.
+
+### Usage
+
+```bash
+if builder_is_running_on_ci; then
+  ...
+fi
+```
+
+--------------------------------------------------------------------------------
+
+## `builder_is_running_on_docker` function
+
+Returns `true` (aka 0) if the script runs in a Docker container (i.e. if
+the `DOCKER_RUNNING` environment variable is set).
+
+**Note** that this environment variable is not set automatically, so you'll have
+to set it before starting a build, or set it in the docker image.
+
+### Usage
+
+```bash
+if builder_is_running_on_docker; then
+  ...
+fi
+```
+
+--------------------------------------------------------------------------------
+
+## `builder_is_running_on_gha` function
+
+Returns `true` (aka 0) if the script runs as a GitHub action (i.e. if the
+`GITHUB_RUN_ID` environment variable is set).
+
+### Usage
+
+```bash
+if builder_is_running_on_gha; then
+  ...
+fi
+```
+
+--------------------------------------------------------------------------------
+
 ## `builder_is_running_on_teamcity` function
 
 Returns `true` (aka 0) if the script runs on TeamCity (i.e. if the

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -880,20 +880,6 @@ fi
 
 --------------------------------------------------------------------------------
 
-## `builder_is_running_on_ci` function
-
-Returns `true` (aka 0) if the script runs on TeamCity or as a GitHub action.
-
-### Usage
-
-```bash
-if builder_is_running_on_ci; then
-  ...
-fi
-```
-
---------------------------------------------------------------------------------
-
 ## `builder_is_running_on_docker` function
 
 Returns `true` (aka 0) if the script runs in a Docker container (i.e. if
@@ -915,7 +901,7 @@ fi
 ## `builder_is_running_on_gha` function
 
 Returns `true` (aka 0) if the script runs as a GitHub action (i.e. if the
-`GITHUB_RUN_ID` environment variable is set).
+`GITHUB_ACTIONS` environment variable is set).
 
 ### Usage
 

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -2140,15 +2140,6 @@ builder_is_target_excluded_by_platform() {
   return 1
 }
 
-# Returns 0 if the script is running on a CI server (TeamCity or GitHub Actions)
-builder_is_running_on_ci() {
-  if builder_is_running_on_teamcity || builder_is_running_on_gha; then
-    return 0
-  else
-    return 1
-  fi
-}
-
 # Returns 0 if the script is running in a Docker container
 builder_is_running_on_docker() {
   if [[ -z ${DOCKER_RUNNING:-} ]]; then
@@ -2160,7 +2151,7 @@ builder_is_running_on_docker() {
 
 # Returns 0 if the script is running in a GitHub Actions environment
 builder_is_running_on_gha() {
-  if [[ -z ${GITHUB_RUN_ID:-} ]]; then
+  if [[ -z ${GITHUB_ACTIONS:-} ]]; then
     return 1
   else
     return 0

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -2140,6 +2140,33 @@ builder_is_target_excluded_by_platform() {
   return 1
 }
 
+# Returns 0 if the script is running on a CI server (TeamCity or GitHub Actions)
+builder_is_running_on_ci() {
+  if builder_is_running_on_teamcity || builder_is_running_on_gha; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Returns 0 if the script is running in a Docker container
+builder_is_running_on_docker() {
+  if [[ -z ${DOCKER_RUNNING:-} ]]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+# Returns 0 if the script is running in a GitHub Actions environment
+builder_is_running_on_gha() {
+  if [[ -z ${GITHUB_RUN_ID:-} ]]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
 # Returns 0 if the script is running on TeamCity
 builder_is_running_on_teamcity() {
   if [[ -z "${TEAMCITY_GIT_PATH:-}" ]]; then


### PR DESCRIPTION
This adds the two additional functions `builder_is_running_on_docker`, and `builder_is_running_on_gha` to be able to detect if the build is running in a CI or CI-like container environment.

Test-bot: skip