### PR TITLE
fix(mac): handle PackageInfo section in kmp.inf file

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMConfiguration/KMConfigurationWindowController.m
@@ -130,8 +130,15 @@
         NSArray *pArray = (NSArray *)obj;
         NSString *packageFolder = [self packageFolderFromPath:[pArray objectAtIndex:0]];
         NSString *packageName = [self.AppDelegate packageNameFromPackageInfo:packageFolder];
-        os_log_debug([KMLogs uiLog], "tableContents, packageFolder: %{public}@, packageName: %{public}@", packageFolder, packageName);
-        [_tableContents addObject:[NSDictionary dictionaryWithObjectsAndKeys:packageName, @"HeaderTitle", nil]];
+                
+        if (packageName) {
+          os_log_debug([KMLogs testLog], "tableContents, packageFolder: %{public}@, packageName: %{public}@", packageFolder, packageName);
+          [_tableContents addObject:[NSDictionary dictionaryWithObjectsAndKeys:packageName, @"HeaderTitle", nil]];
+       } else {
+         os_log_error([KMLogs testLog], "tableContents, no packageName for packageFolder: %{public}@", packageFolder);
+         NSString *noPackageName = NSLocalizedString(@"unknown-package-name", nil);
+         [_tableContents addObject:[NSDictionary dictionaryWithObjectsAndKeys:noPackageName, @"HeaderTitle", nil]];
+        }
         for (NSString *path in pArray) {
           os_log_debug([KMLogs uiLog], "tableContents, path = '%{public}@'", path);
           NSDictionary *info = [KMXFile keyboardInfoFromKmxFile:path];

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMPackageReader.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMPackageReader.m
@@ -17,11 +17,14 @@
 static NSString *const kPackageJsonFile = @"kmp.json";
 static NSString *const kPackageInfFile = @"kmp.inf";
 
+// kmp.info section names
 static NSString *const kPackage = @"[Package]";
 static NSString *const kButtons = @"[Buttons]";
 static NSString *const kStartMenu = @"[StartMenu]";
 static NSString *const kStartMenuEntries = @"[StartMenuEntries]";
 static NSString *const kInfo = @"[Info]";
+// for older kmp.inf files, [PackageInfo] may be used instead of [Info]
+static NSString *const kPackageInfo = @"[PackageInfo]";
 static NSString *const kFiles = @"[Files]";
 
 static NSString *const kAuthor = @"Author";
@@ -212,6 +215,11 @@ typedef enum {
         continue;
       }
       else if ([[line lowercaseString] hasPrefix:[kInfo lowercaseString]]) {
+        contentType = ctInfo;
+        continue;
+      }
+      // for older kmp.inf files, [PackageInfo] may be used instead of [Info]
+      else if ([[line lowercaseString] hasPrefix:[kPackageInfo lowercaseString]]) {
         contentType = ctInfo;
         continue;
       }

--- a/mac/Keyman4MacIM/Keyman4MacIM/KMPackageReader.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/KMPackageReader.m
@@ -22,9 +22,10 @@ static NSString *const kPackage = @"[Package]";
 static NSString *const kButtons = @"[Buttons]";
 static NSString *const kStartMenu = @"[StartMenu]";
 static NSString *const kStartMenuEntries = @"[StartMenuEntries]";
-static NSString *const kInfo = @"[Info]";
-// for older kmp.inf files, [PackageInfo] may be used instead of [Info]
+// kmp.inf files version 5.0 includes a [PackageInfo] section
 static NSString *const kPackageInfo = @"[PackageInfo]";
+// kmp.inf files version 6.0 and later replace [PackageInfo] with [Info]
+static NSString *const kInfo = @"[Info]";
 static NSString *const kFiles = @"[Files]";
 
 static NSString *const kAuthor = @"Author";
@@ -214,11 +215,12 @@ typedef enum {
         contentType = ctStartMenuEntries;
         continue;
       }
+      // as of version 6.0, kmp.inf files contain a section [Info]
       else if ([[line lowercaseString] hasPrefix:[kInfo lowercaseString]]) {
         contentType = ctInfo;
         continue;
       }
-      // for older kmp.inf files, [PackageInfo] may be used instead of [Info]
+      // version 5.0 kmp.inf files contain a [PackageInfo] section instead
       else if ([[line lowercaseString] hasPrefix:[kPackageInfo lowercaseString]]) {
         contentType = ctInfo;
         continue;

--- a/mac/Keyman4MacIM/Keyman4MacIM/en.lproj/Localizable.strings
+++ b/mac/Keyman4MacIM/Keyman4MacIM/en.lproj/Localizable.strings
@@ -32,6 +32,9 @@
 /* Message displayed in Configuration window when keyboard metadata cannot be loaded */
 "message-error-unknown-metadata" = "unknown";
 
+/* Configuration window section heading when keyboard has no package name */
+"unknown-package-name" = "Unnamed Keyboard Package";
+
 /* Button text to acknowledge that .kmp file could not be read  */
 "button-keyboard-file-unreadable" = "OK";
 

--- a/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMXFile.m
+++ b/mac/KeymanEngine4Mac/KeymanEngine4Mac/KME/KMXFile.m
@@ -161,7 +161,8 @@ NSString *const kKMVisualKeyboardKey = @"KMVisualKeyboardKey";
 
 + (NSDictionary *)keyboardInfoFromKmxFile:(NSString *)path {
   NSFileHandle *file = [NSFileHandle fileHandleForReadingAtPath:path];
-  
+  os_log_debug([KMELogs configLog], "keyboardInfoFromKmxFile, path: %{public}@", path);
+
   if (file == nil) {
     os_log_error([KMELogs configLog], "Failed to open file");
     return nil;


### PR DESCRIPTION
When reading the kmp.inf file, if the [Info] section is not available, then check for a [PackageInfo] section which should contain the same required fields.

Also, if no package name can be found in the kmp.inf, then fail gracefully with a placeholder for the package name.

Fixes: #13718

# User Testing

- **TEST_SANSKRIT_UNICODE**: all rows of configuration window are visible after installing keyboard
1. install the build for this PR
1. install the Sanskrit Unicode keyboard
1. confirm that you can type with the keyboard
1. open the Keyman Configuration window
1. confirm that the Sanskrit Unicode keyboard appears in the keyboard list
1. close the Configuration window and confirm that Keyman still operates as expected
