### PR TITLE
maint(common): remove obsolete code from docker-images `run.sh`

### DIFF
--- a/resources/docker-images/run.sh
+++ b/resources/docker-images/run.sh
@@ -67,14 +67,6 @@ run_web() {
     "${builder_extra_params[@]}"
 }
 
-if [[ -z "${DISTRO_VERSION:-}" ]]; then
-  image_version=default
-  build_dir=default
-else
-  image_version="${DISTRO:-}-${DISTRO_VERSION}-java${KEYMAN_VERSION_JAVA}-node$(_print_expected_node_version)-emsdk${KEYMAN_MIN_VERSION_EMSCRIPTEN}"
-  build_dir="${DISTRO:-}-${DISTRO_VERSION}"
-fi
-
 mkdir -p "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}"
 
 builder_run_action android  run_android


### PR DESCRIPTION
PR #13861 missed the fact that docker-images' `run.sh` script also contains code that got re-added during a faulty merge. This change cleans this up.

Test-bot: skip