### PR TITLE
fix(linux): fallback to `VERSION` if `KEYMAN_VERSION` isn't set during package build

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -87,7 +87,7 @@ jobs:
       run: |
         THIS_SCRIPT="$GITHUB_WORKSPACE/.github/workflows/deb-packaging.yml"
         . "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
-        echo "KEYMAN_VERSION=$KEYMAN_VERSION" >> $GITHUB_OUTPUT
+        echo "KEYMAN_VERSION=${KEYMAN_VERSION:-VERSION}" >> $GITHUB_OUTPUT
 
     - name: Set prerelease tag as output parameter
       id: prerelease_tag


### PR DESCRIPTION
This allows to build packages for Keyman 18 without having to backport the change that renames `VERSION` → `KEYMAN_VERSION`.

Test-bot: skip