### PR TITLE
maint(common): move and document `builder_is_ci_*` functions

### DIFF
--- a/docs/builder.md
+++ b/docs/builder.md
@@ -928,6 +928,50 @@ fi
 
 --------------------------------------------------------------------------------
 
+## `builder_is_ci_build` function
+
+Returns `true` (aka 0) if the current build is running in CI, as a pull
+request test, as a mainline branch test, or as a release build.
+
+### Usage
+
+```bash
+if builder_is_ci_build; then
+  ...
+fi
+```
+
+--------------------------------------------------------------------------------
+
+## `builder_is_ci_release_build` function
+
+Returns `true` (aka 0) if the current build is running as a release build in CI
+
+### Usage
+
+```bash
+if builder_is_ci_release_build; then
+  ...
+fi
+```
+
+--------------------------------------------------------------------------------
+
+## `builder_is_ci_test_build` function
+
+Returns `true` (aka 0) if the current build is running in CI, as a pull
+request test, or as a mainline branch test.
+
+### Usage
+
+```bash
+if builder_is_ci_test_build; then
+  ...
+fi
+```
+
+--------------------------------------------------------------------------------
+
 ## `builder_parse` function
 
 Initializes a build.sh script, parses command line. Will abort the script if

--- a/resources/build/build-utils-ci.inc.sh
+++ b/resources/build/build-utils-ci.inc.sh
@@ -8,38 +8,6 @@
 . "$KEYMAN_ROOT/resources/build/jq.inc.sh"
 
 #
-# Returns 0 if current build is running in CI, as a pull request test, or as a
-# mainline branch test, or as a release build
-#
-builder_is_ci_build() {
-  if builder_is_ci_release_build || builder_is_ci_test_build; then
-    return 0
-  fi
-  return 1
-}
-
-#
-# Returns 0 if current build is running as a release build in CI
-#
-builder_is_ci_release_build() {
-  if [[ "$KEYMAN_VERSION_ENVIRONMENT" =~ ^alpha|beta|stable$ ]]; then
-    return 0
-  fi
-  return 1
-}
-
-#
-# Returns 0 if current build is running in CI, as a pull request test, or as a
-# mainline branch test
-#
-builder_is_ci_test_build() {
-  if [[ "$KEYMAN_VERSION_ENVIRONMENT" == test ]]; then
-    return 0
-  fi
-  return 1
-}
-
-#
 # Returns 0 if current build is in CI and triggered from a pull request. If it
 # returns 0, then a call is made to GitHub to get pull request details, and the
 # PR details are added to $builder_pull_title, $builder_pull_number, and

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -2167,6 +2167,38 @@ builder_is_running_on_teamcity() {
   fi
 }
 
+#
+# Returns 0 if current build is running in CI, as a pull request test, or as a
+# mainline branch test, or as a release build
+#
+builder_is_ci_build() {
+  if builder_is_ci_release_build || builder_is_ci_test_build; then
+    return 0
+  fi
+  return 1
+}
+
+#
+# Returns 0 if current build is running as a release build in CI
+#
+builder_is_ci_release_build() {
+  if [[ "$KEYMAN_VERSION_ENVIRONMENT" =~ ^alpha|beta|stable$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+#
+# Returns 0 if current build is running in CI, as a pull request test, or as a
+# mainline branch test
+#
+builder_is_ci_test_build() {
+  if [[ "$KEYMAN_VERSION_ENVIRONMENT" == test ]]; then
+    return 0
+  fi
+  return 1
+}
+
 ################################################################################
 # Final initialization
 ################################################################################


### PR DESCRIPTION
This change moves the `build_is_ci_*` functions from `resources/build/build-utils-ci.inc.sh` → `resources/builder.inc.sh`.
It also adds documentation for them.

Fixes: #13885 
Fixes: #13886
Test-bot: skip