### PR TITLE
fix(web): inspectable test-script mode should not be auto-enabled in local-env tests

### DIFF
--- a/web/src/engine/predictive-text/worker-main/unit_tests/test.sh
+++ b/web/src/engine/predictive-text/worker-main/unit_tests/test.sh
@@ -21,7 +21,8 @@ builder_describe "Runs all tests for the language-modeling / predictive-text lay
   "configure" \
   "test+" \
   ":headless   Runs this module's headless user tests" \
-  ":browser    Runs this module's browser-based user tests"
+  ":browser    Runs this module's browser-based user tests" \
+  "--inspect   Runs browser-based tests in a locally-inspectable mode"
 
 # TODO: consider dependencies? ideally this will be test.inc.sh?
 
@@ -46,17 +47,17 @@ fi
 
 if builder_start_action test:browser; then
   WTR_CONFIG=
-  WTR_DEBUG=
+  WTR_INSPECT=
 
   if builder_is_ci_build; then
     WTR_CONFIG=.CI
   fi
 
-  if builder_has_option --debug; then
-    WTR_DEBUG=" --manual"
+  if builder_has_option --inspect; then
+    WTR_INSPECT=" --manual"
   fi
 
-  web-test-runner --config in_browser/web-test-runner${WTR_CONFIG}.config.mjs ${WTR_DEBUG}
+  web-test-runner --config in_browser/web-test-runner${WTR_CONFIG}.config.mjs ${WTR_INSPECT}
 
   builder_finish_action success test:browser
 fi

--- a/web/src/engine/predictive-text/worker-thread/build.sh
+++ b/web/src/engine/predictive-text/worker-thread/build.sh
@@ -31,7 +31,8 @@ builder_describe \
   "@/web/src/tools/es-bundling" \
   "@../wordbreakers" \
   "@../templates" \
-  configure clean build test
+  configure clean build test \
+  "--inspect  Runs browser-based tests in a locally-inspectable mode"
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -92,20 +93,20 @@ function do_build() {
 function do_test() {
   local MOCHA_FLAGS=
   local WTR_CONFIG=
-  local WTR_DEBUG=
+  local WTR_INSPECT=
 
   if builder_is_ci_build; then
     MOCHA_FLAGS="$MOCHA_FLAGS --reporter mocha-teamcity-reporter"
     WTR_CONFIG=.CI
   fi
 
-  if builder_has_option --debug; then
-    WTR_DEBUG=" --manual"
+  if builder_has_option --inspect; then
+    WTR_INSPECT=" --manual"
   fi
 
   c8 mocha --recursive $MOCHA_FLAGS ./src/tests/mocha/cases/
 
-  web-test-runner --config ./src/tests/test-runner/web-test-runner${WTR_CONFIG}.config.mjs ${WTR_DEBUG}
+  web-test-runner --config ./src/tests/test-runner/web-test-runner${WTR_CONFIG}.config.mjs ${WTR_INSPECT}
 }
 
 builder_run_action configure  do_configure

--- a/web/test.sh
+++ b/web/test.sh
@@ -20,7 +20,8 @@ builder_describe "Runs the Keyman Engine for Web unit-testing suites" \
   "@./src/tools/testing/recorder test:integrated" \
   "test+" \
   ":dom                  Runs DOM-oriented unit tests (reduced footprint, nothing browser-specific)" \
-  ":integrated           Runs KMW's integration test suite"
+  ":integrated           Runs KMW's integration test suite" \
+  "--inspect             Runs browser-based unit tests in an inspectable mode"
 
 builder_parse "$@"
 
@@ -33,13 +34,13 @@ if builder_is_ci_build; then
 fi
 
 # Prepare the flags for the karma command.
-WTR_DEBUG=
-if builder_is_debug_build; then
-  WTR_DEBUG="--manual"
+WTR_INSPECT=
+if builder_has_option --inspect; then
+  WTR_INSPECT="--manual"
 fi
 
 # End common configs.
 
-builder_run_action test:dom web-test-runner --config "src/test/auto/dom/web-test-runner${WTR_CONFIG}.config.mjs" ${WTR_DEBUG}
+builder_run_action test:dom web-test-runner --config "src/test/auto/dom/web-test-runner${WTR_CONFIG}.config.mjs" ${WTR_INSPECT}
 
-builder_run_action test:integrated web-test-runner --config "src/test/auto/integrated/web-test-runner${WTR_CONFIG}.config.mjs" ${WTR_DEBUG}
+builder_run_action test:integrated web-test-runner --config "src/test/auto/integrated/web-test-runner${WTR_CONFIG}.config.mjs" ${WTR_INSPECT}


### PR DESCRIPTION
This is a followup to the recent #13827, which automatically adds --debug to local-environment builds.  For web/ test scripts involving browser-based scripts, that same flag had been used to enable an _inspectable_ test mode that doesn't auto-return, which doesn't match the semantics of --debug for build configurations.  As test scripts still use the common builder patterns, this "overloading" of the --debug option is now causing issues.

To rectify this, those scripts now have their --debug option renamed to --inspect, allowing them to be optionally turned on, but not automatically enabled.

Test-bot: skip