### PR TITLE
maint(android): use new variable name `KEYMAN_TIER`

### DIFF
--- a/android/KMAPro/build-play-store-notes.inc.sh
+++ b/android/KMAPro/build-play-store-notes.inc.sh
@@ -11,7 +11,7 @@ function generateReleaseNotes() {
   # Copy release notes for Gradle Play Publisher to upload
   # Reference: https://github.com/Triple-T/gradle-play-publisher#uploading-release-notes
   #
-  local PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/$TIER.txt"
+  local PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/${KEYMAN_TIER}.txt"
   if [ $KEYMAN_TIER = "stable" ]; then
     PLAY_RELEASE_NOTES="$KEYMAN_ROOT/android/KMAPro/kMAPro/src/main/play/release-notes/en-US/default.txt"
   fi


### PR DESCRIPTION
PR #13854 missed (at least) one place when renaming the variables from `TIER` to `KEYMAN_TIER`. This change fixes the release builds for Android.
    
Follow-up-of: #13854
Fixes: #13896
Test-bot: skip