### PR TITLE
maint: update @actions/github + @octokit references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1246,26 +1246,28 @@
       }
     },
     "node_modules/@actions/github": {
-      "version": "2.2.0",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
       "license": "MIT",
       "dependencies": {
-        "@actions/http-client": "^1.0.3",
-        "@octokit/graphql": "^4.3.1",
-        "@octokit/rest": "^16.43.1"
-      }
-    },
-    "node_modules/@actions/github/node_modules/@actions/http-client": {
-      "version": "1.0.11",
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "0.0.6"
+        "@actions/http-client": "^2.2.0",
+        "@octokit/core": "^5.0.1",
+        "@octokit/plugin-paginate-rest": "^9.2.2",
+        "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "undici": "^5.28.5"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.0.1",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "license": "MIT",
       "dependencies": {
-        "tunnel": "^0.0.6"
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1495,6 +1497,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2224,260 +2235,161 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "2.5.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
       "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^6.0.3"
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.5.tgz",
-      "integrity": "sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+      "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@octokit/auth-token": "^5.0.0",
-        "@octokit/graphql": "^8.2.2",
-        "@octokit/request": "^9.2.3",
-        "@octokit/request-error": "^6.1.8",
-        "@octokit/types": "^14.0.0",
-        "before-after-hook": "^3.0.2",
-        "universal-user-agent": "^7.0.0"
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
       },
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/auth-token": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
-      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/endpoint": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
-      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@octokit/types": "^14.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/graphql": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
-      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@octokit/request": "^9.2.3",
-        "@octokit/types": "^14.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.0.0.tgz",
-      "integrity": "sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/request": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.3.tgz",
-      "integrity": "sha512-Ma+pZU8PXLOEYzsWf0cn/gY+ME57Wq8f49WTXA8FMHp2Ps9djKw//xYJ1je8Hm0pR2lU9FUGeJRWOtxq6olt4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@octokit/endpoint": "^10.1.4",
-        "@octokit/request-error": "^6.1.8",
-        "@octokit/types": "^14.0.0",
-        "fast-content-type-parse": "^2.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/request-error": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
-      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@octokit/types": "^14.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/types": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.0.0.tgz",
-      "integrity": "sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^25.0.0"
-      }
-    },
-    "node_modules/@octokit/core/node_modules/before-after-hook": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-      "license": "Apache-2.0",
-      "peer": true
-    },
-    "node_modules/@octokit/core/node_modules/universal-user-agent": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-      "license": "ISC",
-      "peer": true
     },
     "node_modules/@octokit/endpoint": {
-      "version": "6.0.12",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^6.0.3",
-        "is-plain-object": "^5.0.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "4.8.0",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/request": "^5.6.0",
-        "@octokit/types": "^6.0.3",
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "11.2.0",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "1.1.2",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^2.0.1"
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
       }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "2.16.2",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": ">= 8"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "peerDependencies": {
-        "@octokit/core": ">=3"
+        "@octokit/openapi-types": "^20.0.0"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "2.4.0",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^2.0.1",
-        "deprecation": "^2.3.1"
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
       }
     },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
+    },
     "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "2.16.2",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": ">= 8"
+        "@octokit/openapi-types": "^20.0.0"
       }
     },
     "node_modules/@octokit/request": {
-      "version": "5.6.3",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^6.0.1",
-        "@octokit/request-error": "^2.1.0",
-        "@octokit/types": "^6.16.1",
-        "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.7",
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "2.1.0",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^6.0.3",
+        "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/@octokit/rest": {
-      "version": "16.43.2",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-token": "^2.4.0",
-        "@octokit/plugin-paginate-rest": "^1.1.1",
-        "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "2.4.0",
-        "@octokit/request": "^5.2.0",
-        "@octokit/request-error": "^1.0.2",
-        "atob-lite": "^2.0.0",
-        "before-after-hook": "^2.0.0",
-        "btoa-lite": "^1.0.0",
-        "deprecation": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
-        "lodash.uniq": "^4.5.0",
-        "octokit-pagination-methods": "^1.1.0",
-        "once": "^1.4.0",
-        "universal-user-agent": "^4.0.0"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/request-error": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^2.0.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/types": {
-      "version": "2.16.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": ">= 8"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/universal-user-agent": {
-      "version": "4.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "os-name": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.34.0",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^11.2.0"
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/@peggyjs/from-mem": {
@@ -4996,10 +4908,6 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
-    "node_modules/atob-lite": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -5133,7 +5041,9 @@
       }
     },
     "node_modules/before-after-hook": {
-      "version": "2.2.2",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "license": "Apache-2.0"
     },
     "node_modules/body-parser": {
@@ -5205,10 +5115,6 @@
       "version": "1.3.1",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/btoa-lite": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -6313,6 +6219,8 @@
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "license": "ISC"
     },
     "node_modules/destroy": {
@@ -6390,6 +6298,7 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6398,6 +6307,7 @@
     },
     "node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7652,90 +7562,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
-    "node_modules/execa": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/execa/node_modules/cross-spawn": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/execa/node_modules/get-stream": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/execa/node_modules/path-key": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/execa/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/execa/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/execa/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/execa/node_modules/which": {
-      "version": "1.3.1",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/exponential-backoff": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
@@ -7845,23 +7671,6 @@
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
       }
-    },
-    "node_modules/fast-content-type-parse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
-      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -9244,13 +9053,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -9283,13 +9085,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-string": {
@@ -9392,6 +9187,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -9901,6 +9697,7 @@
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isequal": {
@@ -9920,14 +9717,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "license": "MIT"
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
-      "license": "MIT"
     },
     "node_modules/log-update": {
       "version": "4.0.0",
@@ -10041,16 +9830,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/macos-release": {
-      "version": "2.5.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir": {
@@ -10786,10 +10565,6 @@
         "hpagent": "^0.1.2"
       }
     },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "license": "MIT"
-    },
     "node_modules/nise": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
@@ -10841,6 +10616,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -11042,23 +10818,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
@@ -11126,10 +10885,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/octokit-pagination-methods": {
-      "version": "1.1.0",
-      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -11202,17 +10957,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-name": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "macos-release": "^2.2.0",
-        "windows-release": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "license": "MIT",
@@ -11238,6 +10982,7 @@
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -12442,6 +12187,7 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sinon": {
@@ -12870,13 +12616,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/strip-eof": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -13167,6 +12906,7 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
@@ -13502,6 +13242,18 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -13532,7 +13284,9 @@
       }
     },
     "node_modules/universal-user-agent": {
-      "version": "6.0.0",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
       "license": "ISC"
     },
     "node_modules/unpipe": {
@@ -13652,6 +13406,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-encoding": {
@@ -13689,6 +13444,7 @@
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -13743,19 +13499,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/windows-release": {
-      "version": "3.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/word-wrap": {
@@ -14143,7 +13886,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",
-        "@actions/github": "^2.1.0",
+        "@actions/github": "^6.0.1",
         "emoji-regex": "^10.3.0",
         "typescript": "^5.4.5",
         "yargs": "^17.7.2"

--- a/resources/build/version/package.json
+++ b/resources/build/version/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "dependencies": {
     "@actions/core": "^1.9.1",
-    "@actions/github": "^2.1.0",
+    "@actions/github": "^6.0.1",
     "emoji-regex": "^10.3.0",
     "typescript": "^5.4.5",
     "yargs": "^17.7.2"

--- a/resources/build/version/src/fixupHistory.ts
+++ b/resources/build/version/src/fixupHistory.ts
@@ -2,7 +2,9 @@ import {
     warning as logWarning
 } from '@actions/core';
 
-import { GitHub } from '@actions/github';
+import { getOctokit } from '@actions/github';
+type GitHub = ReturnType<typeof getOctokit>;
+
 import { readFileSync, writeFileSync } from 'node:fs';
 import { gt } from 'semver';
 import { reportHistory } from './reportHistory.js';
@@ -176,7 +178,7 @@ export const sendCommentToPullRequestAndRelatedIssues = async (
       // Always serially rather than in parallel
       .then(() => {
         console.log(`Creating comment on Pull Request #${pull}`);
-        return octokit.issues.createComment({
+        return octokit.rest.issues.createComment({
           owner: 'keymanapp',
           repo: 'keyman',
           issue_number: pull,

--- a/resources/build/version/src/index.ts
+++ b/resources/build/version/src/index.ts
@@ -1,5 +1,6 @@
 import { info as logInfo } from '@actions/core';
-import { GitHub } from '@actions/github';
+import { getOctokit } from '@actions/github';
+type GitHub = ReturnType<typeof getOctokit>;
 
 import { sendCommentToPullRequestAndRelatedIssues, fixupHistory } from './fixupHistory.js';
 import { incrementVersion } from './incrementVersion.js';
@@ -59,7 +60,7 @@ const argv = await yargs(hideBin(process.argv))
 
 const main = async (): Promise<void> => {
 
-  const octokit: GitHub = new GitHub(argv.token);
+  const octokit: GitHub = getOctokit(argv.token);
 
   // Pretend we have a single change. If we chain commands (as in normal usage),
   // then we use the real history change count to determine if we continue.

--- a/resources/build/version/src/reportHistory.ts
+++ b/resources/build/version/src/reportHistory.ts
@@ -1,6 +1,7 @@
 import { warning as logWarning, info as logInfo } from '@actions/core';
 
-import { GitHub } from '@actions/github';
+import { getOctokit } from '@actions/github';
+type GitHub = ReturnType<typeof getOctokit>;
 
 import { findLastHistoryPR, getAssociatedPR} from './graphql/queries.js';
 import { spawnChild } from './util/spawnAwait.js';


### PR DESCRIPTION
A large portion of the remaining `npm audit` / Dependabot security alerts after #13897 and #13899 were not automatically fixable due to breaking changes in the `@actions/github` package.  After a little work, I think I've got something that'll help resolve the issues there.

Original (after #13899):
```
10 vulnerabilities (6 moderate, 4 high)
```

Remaining:
```
3 vulnerabilities (1 moderate, 2 high)
```

@keymanapp-test-bot skip