### PR TITLE
maint(common): update fast-json-patch to ^3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7701,22 +7701,11 @@
       }
     },
     "node_modules/fast-json-patch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
       "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
     "@keymanapp/keyman-version": "file:common/web/keyman-version",
     "@keymanapp/ldml-keyboard-constants": "file:core/include/ldml"
   },
+  "overrides": {
+    "ajv-cli": {
+      "fast-json-patch": "^3.1.1"
+    }
+  },
   "engines": {
     "node": "20.16.0"
   }


### PR DESCRIPTION
The `fast-json-parser` package is needed by `ajv-cli`, which is used during common/web/types/build.sh configure.

Found this approach via a comment on https://github.com/ajv-validator/ajv-cli/issues/237.

Remaining `npm audit` issues after this fix:

```
@sentry/browser  <7.119.1
Severity: moderate
Sentry SDK Prototype Pollution gadget in JavaScript SDKs - https://github.com/advisories/GHSA-593m-55hh-j8gv
fix available via `npm audit fix --force`
Will install @sentry/browser@9.17.0, which is a breaking change
node_modules/@sentry/browser

1 moderate severity vulnerability
```

... and updating Sentry (for web/) is potentially something far more involved.

Test-bot: skip