### PR TITLE
maint(linux): address comments from Debian package review

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,16 +1,14 @@
 # License
 
-Copyright (c) 2017-2024 SIL Global. All rights reserved.
+Copyright (c) 2017-2025 SIL Global. All rights reserved.
 
 Licensed under the MIT License.
-
-[Keyman for Linux](./linux) is licensed under the MIT License apart from [ibus-kmfl](./linux/ibus-kmfl) which is licensed under the GNU General Public License as published by the Free Software Foundation; either [version 2](./linux/ibus-kmfl/COPYING) of the License, or (at your option) any later version.
 
 ---
 
 The MIT License
 
-Copyright (c) 2017-2024 SIL Global
+Copyright (c) 2017-2025 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -7,7 +7,7 @@ Uploaders:
  Eberhard Beilharz <eb1@sil.org>,
 Build-Depends:
  bash-completion,
- debhelper-compat (= 12),
+ debhelper-compat (= 13),
  dh-python,
  gawk,
  gir1.2-webkit2-4.1,

--- a/linux/debian/copyright
+++ b/linux/debian/copyright
@@ -2,10 +2,12 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: keyman
 Upstream-Contact: Keyman team <support@keyman.com>
 Source: https://github.com/keymanapp/keyman
+Comment: Debian's licensecheck tool uses the term `Expat` for the `MIT` license.
+         `Unicode-3.0` is identified `Unicode-DFS-2016`.
 
 Files: *
 Copyright: 2018-2025 SIL Global
-License: MIT
+License: Expat
 
 Files: linux/ibus-keyman/*
 Copyright: 2004-2025 SIL Global
@@ -16,7 +18,7 @@ Files: linux/ibus-keyman/src/keymanutil.c
        linux/ibus-keyman/src/kmpdetails.c
        linux/ibus-keyman/src/kmpdetails.h
 Copyright: 2009-2025 SIL Global
-License: GPL-2+ or MIT
+License: GPL-2+ or Expat
 
 Files: linux/ibus-keyman/src/keyman-service.c
        linux/ibus-keyman/src/keyman-service.h
@@ -42,9 +44,21 @@ Files: debian/com.keyman.config.appdata.xml
        debian/com.keyman.ibus_keyman.metainfo.xml
 Copyright: 2019 Daniel Glassey <wdg@debian.org>
            2022-2025 SIL Global
-License: MIT
+License: Expat
 
-License: MIT
+Files: resources/standards-data/ldml-keyboards/*
+Copyright: Copyright © 1991-2024 Unicode, Inc.
+License: Unicode-DFS-2016
+
+Files: resources/standards-data/unicode-character-database/*
+Copyright: Copyright © 1991-2023 Unicode, Inc.
+License: Unicode-DFS-2016
+
+Files: resources/standards-data/windows-lcid-to-bcp-47/*
+Copyright: Copyright © 1991-2017 Unicode, Inc.
+License: Unicode-DFS-2016
+
+License: Expat
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the
  "Software"), to deal in the Software without restriction, including
@@ -76,8 +90,7 @@ License: GPL-2+
  GNU General Public License for more details.
  .
  You should have received a copy of the GNU General Public License
- along with this package; if not, write to the Free Software
- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ along with this package. If not, see https://www.gnu.org/licenses/.
  .
  On Debian systems, the full text of the GNU General Public
  License version 2 can be found in the file
@@ -95,8 +108,7 @@ License: GPL-3+
  GNU General Public License for more details.
  .
  You should have received a copy of the GNU General Public License
- along with this package; if not, write to the Free Software
- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ along with this package. If not, see https://www.gnu.org/licenses/.
  .
  On Debian systems, the full text of the GNU General Public
  License version 3 can be found in the file
@@ -114,9 +126,37 @@ License: LGPL-2.1+
  details.
  .
  You should have received a copy of the GNU Lesser General Public License
- along with this library; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+ along with this library. If not, see https://www.gnu.org/licenses/.
  .
  On Debian systems, the full text of the GNU Lesser General Public
  License version 2.1 can be found in the file
  `/usr/share/common-licenses/LGPL-2.1'.
+
+License: Unicode-DFS-2016
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of data files and any associated documentation (the "Data Files") or
+ software and any associated documentation (the "Software") to deal in the
+ Data Files or Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, and/or sell
+ copies of the Data Files or Software, and to permit persons to whom the
+ Data Files or Software are furnished to do so, provided that either (a)
+ this copyright and permission notice appear with all copies of the Data
+ Files or Software, or (b) this copyright and permission notice appear in
+ associated Documentation.
+ .
+ THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+ KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ THIRD PARTY RIGHTS.
+ .
+ IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+ BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+ OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+ FILES OR SOFTWARE.
+ .
+ Except as contained in this notice, the name of a copyright holder shall
+ not be used in advertising or otherwise to promote the sale, use or other
+ dealings in these Data Files or Software without prior written
+ authorization of the copyright holder.

--- a/linux/debian/ibus-keyman.manpages
+++ b/linux/debian/ibus-keyman.manpages
@@ -1,1 +1,1 @@
-linux/ibus-keyman/man/ibus-engine-keyman.1
+linux/ibus-keyman/man/ibus-engine-keyman.8

--- a/linux/debian/keyman-system-service.manpages
+++ b/linux/debian/keyman-system-service.manpages
@@ -1,1 +1,1 @@
-linux/keyman-system-service/man/keyman-system-service.1
+linux/keyman-system-service/man/keyman-system-service.8

--- a/linux/debian/source/lintian-overrides
+++ b/linux/debian/source/lintian-overrides
@@ -1,0 +1,8 @@
+# The folders XXX.dist-info/ and XXX.egg-info/ hold metadata for
+# Python modules. Those files are not documentation even though
+# some of their names carry the .txt file extension.
+keyman source: package-contains-documentation-outside-usr-share-doc
+
+# keyman-system-service gets started by dbus, therefore it should not
+# have an [INSTALL] section
+keyman source: systemd-service-file-missing-install-key

--- a/linux/ibus-keyman/COPYING
+++ b/linux/ibus-keyman/COPYING
@@ -304,8 +304,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    with this program. If not, see https://www.gnu.org/licenses/.
 
 Also add information on how to contact you by electronic and paper mail.
 

--- a/linux/ibus-keyman/man/ibus-engine-keyman.8
+++ b/linux/ibus-keyman/man/ibus-engine-keyman.8
@@ -1,4 +1,4 @@
-.TH IBUS-ENGINE-KEYMAN "1" "September 2023" "ibus-engine-keyman" "User Commands"
+.TH IBUS-ENGINE-KEYMAN "8" "September 2023" "ibus-engine-keyman" "User Commands"
 .SH NAME
 ibus-engine-keyman \- multiple language input engine based on ibus
 .SH DESCRIPTION

--- a/linux/keyman-config/COPYING
+++ b/linux/keyman-config/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2018 SIL Global
+Copyright (c) 2018-2025 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/linux/keyman-system-service/.gitignore
+++ b/linux/keyman-system-service/.gitignore
@@ -1,1 +1,2 @@
 resources/meson.build
+resources/KEYMAN_VERSION_WITH_TAG.md

--- a/linux/keyman-system-service/man/keyman-system-service.8
+++ b/linux/keyman-system-service/man/keyman-system-service.8
@@ -1,4 +1,4 @@
-.TH KEYMAN-SYSTEM-SERVICE "1" "May 2023" "keyman-system-service" "User Commands"
+.TH KEYMAN-SYSTEM-SERVICE "8" "May 2023" "keyman-system-service" "User Commands"
 .SH NAME
 keyman-system-service \- System service for Keyman
 .SH DESCRIPTION
@@ -7,4 +7,4 @@ keyman-system-service \- System service for Keyman
 This command should not be run directly. It will be started as a DBUS
 system service by systemd.
 .SH "SEE ALSO"
-.BR ibus-engine-keyman(1)
+.BR ibus-engine-keyman(8)

--- a/linux/keyman-system-service/meson.build
+++ b/linux/keyman-system-service/meson.build
@@ -1,6 +1,6 @@
 project('keyman-system-service', 'c', 'cpp',
         version: files('../../VERSION.md'),
-        license: 'GPL-2+',
+        license: 'MIT',
         meson_version: '>=1.0')
 
 conf = configuration_data()

--- a/linux/keyman-system-service/resources/systemd-keyman.service
+++ b/linux/keyman-system-service/resources/systemd-keyman.service
@@ -4,6 +4,7 @@
 
 [Unit]
 Description=Keyman System Service
+Documentation=https://github.com/keymanapp/keyman/tree/master/linux/keyman-system-service
 
 [Service]
 Type=dbus

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -57,8 +57,19 @@ dpkg-source \
   --tar-ignore=keyman/common/models \
   --tar-ignore=keyman/common/resources \
   --tar-ignore=keyman/common/schemas \
+  --tar-ignore=keyman/common/test/keyboards/baseline/kmcomp-*.zip \
   --tar-ignore=keyman/common/test/keyboards/build.* \
+  --tar-ignore=keyman/common/test/keyboards/caps* \
+  --tar-ignore=keyman/common/test/keyboards/full* \
+  --tar-ignore=keyman/common/test/keyboards/invalid \
+  --tar-ignore=keyman/common/test/keyboards/issue \
+  --tar-ignore=keyman/common/test/keyboards/obolo* \
+  --tar-ignore=keyman/common/test/keyboards/start* \
+  --tar-ignore=keyman/common/test/keyboards/text* \
+  --tar-ignore=keyman/common/test/keyboards/u* \
+  --tar-ignore=keyman/common/test/keyboards/web* \
   --tar-ignore=keyman/common/test/resources \
+  --tar-ignore=keyman/common/tools \
   --tar-ignore=keyman/common/web \
   --tar-ignore=keyman/common/windows \
   \
@@ -76,9 +87,11 @@ dpkg-source \
   --tar-ignore=keyman/mac \
   --tar-ignore=keyman/oem \
   --tar-ignore=keyman/resources/devbox \
+  --tar-ignore=keyman/resources/docker-images \
   --tar-ignore=keyman/resources/environment.sh \
   --tar-ignore=keyman/resources/git-hooks \
   --tar-ignore=keyman/resources/scopes \
+  --tar-ignore=keyman/resources/teamcity \
   --tar-ignore=keyman/resources/build/*.lua \
   --tar-ignore=keyman/resources/build/jq* \
   --tar-ignore=keyman/results \


### PR DESCRIPTION
This fixes Lintian warnings and other comments from the Debian review of the package. It also removes unnecessary files from the source package.

Note: this PR uses `Expat` instead of `MIT` in the `debian/license` file since that is the term that Debian uses and that the Debian tools output. It doesn't really matter since the term serves only as a key in the `license` file that links the files to the full text of the license further down in the `license` file.

Fixes: #13905
Test-bot: skip