### PR TITLE
maint(linux): add Questing to launchpad package builds

### DIFF
--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -33,7 +33,7 @@ else
 fi
 echo "ppa: ${ppa}"
 
-distributions="${DIST:-jammy noble oracular plucky}"
+distributions="${DIST:-jammy noble oracular plucky questing}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
This adds the next Ubuntu version, 25.10 Questing Quokka, to the launchpad package builds.

Test-bot: skip