### PR TITLE
maint(linux): remove temporary files created during dependency installation

### DIFF
--- a/linux/scripts/deb-packaging.sh
+++ b/linux/scripts/deb-packaging.sh
@@ -39,6 +39,8 @@ fi
 
 dependencies_action() {
   sudo mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
+  sudo rm keyman-build-deps_*_all.deb
+  sudo rm keyman-build-deps_*_amd64.*
   # Additionally we need quilt to be able to create the source package.
   # Since this is not needed to build the binary package, it is not
   # (and should not be) included in `build-depends` in `debian/control`.


### PR DESCRIPTION
Until now we accidentally included three files `linux/keyman_build_deps*` in the source package that get created during installing dependencies. This change deletes the files after installing the dependencies before we create the source package.

Test-bot: skip