### PR TITLE
fix(windows): rename Enter and Exit methods TState

### DIFF
--- a/common/windows/delphi/tools/test-klog/test_klog.dpr
+++ b/common/windows/delphi/tools/test-klog/test_klog.dpr
@@ -7,13 +7,17 @@ uses
   klog in '..\..\..\..\..\common\windows\delphi\general\klog.pas',
   VersionInfo in '..\..\..\..\..\common\windows\delphi\general\VersionInfo.pas',
   ErrorControlledRegistry in '..\..\..\..\..\common\windows\delphi\vcl\ErrorControlledRegistry.pas',
-  Unicode in '..\..\..\..\..\common\windows\delphi\general\Unicode.pas';
+  Unicode in '..\..\..\..\..\common\windows\delphi\general\Unicode.pas',
+  DebugPaths in '..\..\..\..\..\common\windows\delphi\general\DebugPaths.pas',
+  KeymanPaths in '..\..\..\..\..\common\windows\delphi\general\KeymanPaths.pas',
+  RegistryKeys in '..\..\..\..\..\common\windows\delphi\general\RegistryKeys.pas',
+  KeymanVersion in '..\..\..\..\..\common\windows\delphi\general\KeymanVersion.pas';
 
 begin
   if KLEnabled then
   begin
     writeln('KLog is enabled - disable KLogging before release!');
-    ExitCode := 1;
+    ExitCode := 0;
   end
   else
   begin

--- a/common/windows/delphi/tools/test-klog/test_klog.dpr
+++ b/common/windows/delphi/tools/test-klog/test_klog.dpr
@@ -7,17 +7,13 @@ uses
   klog in '..\..\..\..\..\common\windows\delphi\general\klog.pas',
   VersionInfo in '..\..\..\..\..\common\windows\delphi\general\VersionInfo.pas',
   ErrorControlledRegistry in '..\..\..\..\..\common\windows\delphi\vcl\ErrorControlledRegistry.pas',
-  Unicode in '..\..\..\..\..\common\windows\delphi\general\Unicode.pas',
-  DebugPaths in '..\..\..\..\..\common\windows\delphi\general\DebugPaths.pas',
-  KeymanPaths in '..\..\..\..\..\common\windows\delphi\general\KeymanPaths.pas',
-  RegistryKeys in '..\..\..\..\..\common\windows\delphi\general\RegistryKeys.pas',
-  KeymanVersion in '..\..\..\..\..\common\windows\delphi\general\KeymanVersion.pas';
+  Unicode in '..\..\..\..\..\common\windows\delphi\general\Unicode.pas';
 
 begin
   if KLEnabled then
   begin
     writeln('KLog is enabled - disable KLogging before release!');
-    ExitCode := 0;
+    ExitCode := 1;
   end
   else
   begin

--- a/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
@@ -161,6 +161,10 @@ begin
       ErrorLogMessage('DoDownloadUpdates Failed to download' + Params.InstallURL);
       TKeymanSentryClient.Breadcrumb('error', 'Download failded for keyboard: '+  Params.InstallURL, 'cli.download');
     end;
+  end
+  else
+  begin
+      TKeymanSentryClient.Breadcrumb('info', 'DoDownloadUpdates Params.Status !=ucrsUpdateReady', 'cli.download');
   end;
   // If there is at least one keyboard package or version of keyman downloaded then
   // the result is true
@@ -189,7 +193,6 @@ begin
   else
   begin
     Result := False;
-    KL.Log('TDownloadUpdates.DownloadUpdates: LoadUpdateCacheData failed');
     TKeymanSentryClient.Breadcrumb('default', 'TDownloadUpdate: LoadUpdateCacheData failed.', 'cli.download');
   end;
 end;

--- a/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
@@ -134,6 +134,7 @@ begin
   Result := False;
   FSuccessfulDownloadCount := 0;
   // Keyboard Packages
+
   for i := 0 to High(Params.Packages) do
   begin
     Params.Packages[i].SavePath := SavePath + Params.Packages[i].FileName;
@@ -147,7 +148,6 @@ begin
       TKeymanSentryClient.Breadcrumb('error', 'Download failded for keyboard: '+ Params.Packages[i].DownloadURL, 'cli.download');
     end;
   end;
-
   // Keyman Installer
   //
   if Params.Status = ucrsUpdateReady then
@@ -178,7 +178,7 @@ begin
   if not IsOnline then
   begin
     TKeymanSentryClient.Breadcrumb('default', 'TDownloadUpdate: Not Online, cant execute download process.', 'cli.download');
-    Exit;
+    Exit(False);
   end;
   DownloadBackGroundSavePath := IncludeTrailingPathDelimiter(TKeymanPaths.KeymanUpdateCachePath);
   if TUpdateCheckStorage.LoadUpdateCacheData(ucr) then
@@ -187,7 +187,11 @@ begin
     KL.Log('DownloadUpdates.DownloadUpdates: DownloadResult = '+IntToStr(Ord(Result)));
   end
   else
+  begin
     Result := False;
+    KL.Log('TDownloadUpdates.DownloadUpdates: LoadUpdateCacheData failed');
+    TKeymanSentryClient.Breadcrumb('default', 'TDownloadUpdate: LoadUpdateCacheData failed.', 'cli.download');
+  end;
 end;
 
 end.

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -783,6 +783,7 @@ begin
     // downloading process finish.
     if not FMutex.TakeOwnership then
     begin
+      TKeymanSentryClient.Breadcrumb('default', 'DownloadingState.EnterState: Unable to get Mutex download process exists', 'update');
       Exit;
     end;
 
@@ -1135,27 +1136,23 @@ begin
   to ask for elevation. }
   if hasPackages then
   begin
-    KL.Log('InstallingState.EnterState hasPackages: True');
     LaunchInstallPackageProcess;
     Exit;
   end;
   // If no packages then install Keyman now
-  KL.Log('InstallingState.EnterState hasPackages: False');
   if hasKeymanInstall then
   begin
-    KL.Log('InstallingState.EnterState hasKeymanInstall: True');
     DoInstallKeyman;
     Exit;
   end;
   // unexpected: should have had either packages or a keyman file
-  KL.Log('InstallingState.EnterState unexpected should have package or install');
   bucStateContext.RemoveCachedFiles;
   ChangeState(IdleState);
 end;
 
 procedure InstallingState.ExitState;
 begin
-  KL.Log('InstallingState.ExitState');
+
 end;
 
 procedure InstallingState.HandleCheck;
@@ -1199,7 +1196,6 @@ begin
   if not kmcom.SystemInfo.IsAdministrator then
   begin
     if hasKeymanInstall then
-      KL.Log('InstallingState.HandleInstallPackages noAdmin hasKeymanInstall: True');
       DoInstallKeyman;
     Exit;
   end;
@@ -1211,7 +1207,6 @@ begin
 
   if hasKeymanInstall then
   begin
-    KL.Log('InstallingState.HandleInstallPackages Admin hasKeymanInstall: True');
     DoInstallKeyman;
   end;
 end;

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -38,8 +38,8 @@ type
 
   public
     constructor Create(Context: TUpdateStateMachine);
-    procedure Enter; virtual; abstract;
-    procedure Exit; virtual; abstract;
+    procedure EnterState; virtual; abstract;
+    procedure ExitState; virtual; abstract;
     procedure HandleCheck; virtual; abstract;
     function  HandleKmShell: Integer; virtual; abstract;
     procedure HandleDownload; virtual; abstract;
@@ -153,8 +153,8 @@ type
   // Derived classes for each state
   IdleState = class(TState)
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -167,8 +167,8 @@ type
   private
     procedure StartDownloadProcess;
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -179,8 +179,8 @@ type
   DownloadingState = class(TState)
   private
     function DownloadUpdatesBackground: Boolean;
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -190,8 +190,8 @@ type
 
   WaitingRestartState = class(TState)
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -225,8 +225,8 @@ type
     procedure LaunchInstallPackageProcess;
 
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -447,14 +447,14 @@ procedure TUpdateStateMachine.SetState(const Value: TStateClass);
 begin
   if Assigned(CurrentState) then
   begin
-    CurrentState.Exit;
+    CurrentState.ExitState;
   end;
 
   SetStateOnly(ConvertStateToEnum(Value));
 
   if Assigned(CurrentState) then
   begin
-    CurrentState.Enter;
+    CurrentState.EnterState;
   end
   else
   begin
@@ -602,13 +602,13 @@ end;
 
 { IdleState }
 
-procedure IdleState.Enter;
+procedure IdleState.EnterState;
 begin
   // Enter UpdateAvailableState
   bucStateContext.SetRegistryState(usIdle);
 end;
 
-procedure IdleState.Exit;
+procedure IdleState.ExitState;
 begin
 
 end;
@@ -704,7 +704,7 @@ begin
   end;
 end;
 
-procedure UpdateAvailableState.Enter;
+procedure UpdateAvailableState.EnterState;
 begin
   // Enter UpdateAvailableState
   bucStateContext.SetRegistryState(usUpdateAvailable);
@@ -714,7 +714,7 @@ begin
   end;
 end;
 
-procedure UpdateAvailableState.Exit;
+procedure UpdateAvailableState.ExitState;
 begin
   // Exit UpdateAvailableState
 end;
@@ -767,7 +767,7 @@ end;
 
 { DownloadingState }
 
-procedure DownloadingState.Enter;
+procedure DownloadingState.EnterState;
 var
   DownloadResult: Boolean;
   RetryCount: Integer;
@@ -823,7 +823,7 @@ begin
 
 end;
 
-procedure DownloadingState.Exit;
+procedure DownloadingState.ExitState;
 begin
   // Exit DownloadingState
 end;
@@ -902,13 +902,13 @@ end;
 
 { WaitingRestartState }
 
-procedure WaitingRestartState.Enter;
+procedure WaitingRestartState.EnterState;
 begin
   // Enter WaitingRestartState
   bucStateContext.SetRegistryState(usWaitingRestart);
 end;
 
-procedure WaitingRestartState.Exit;
+procedure WaitingRestartState.ExitState;
 begin
   // Exit DownloadingState
 end;
@@ -1112,7 +1112,7 @@ begin
   Result := True;
 end;
 
-procedure InstallingState.Enter;
+procedure InstallingState.EnterState;
 var
   ucr: TUpdateCheckResponse;
   hasPackages, hasKeymanInstall: Boolean;
@@ -1135,23 +1135,27 @@ begin
   to ask for elevation. }
   if hasPackages then
   begin
+    KL.Log('InstallingState.EnterState hasPackages: True');
     LaunchInstallPackageProcess;
     Exit;
   end;
   // If no packages then install Keyman now
+  KL.Log('InstallingState.EnterState hasPackages: False');
   if hasKeymanInstall then
   begin
+    KL.Log('InstallingState.EnterState hasKeymanInstall: True');
     DoInstallKeyman;
     Exit;
   end;
   // unexpected: should have had either packages or a keyman file
+  KL.Log('InstallingState.EnterState unexpected should have package or install');
   bucStateContext.RemoveCachedFiles;
   ChangeState(IdleState);
 end;
 
-procedure InstallingState.Exit;
+procedure InstallingState.ExitState;
 begin
-
+  KL.Log('InstallingState.ExitState');
 end;
 
 procedure InstallingState.HandleCheck;
@@ -1195,6 +1199,7 @@ begin
   if not kmcom.SystemInfo.IsAdministrator then
   begin
     if hasKeymanInstall then
+      KL.Log('InstallingState.HandleInstallPackages noAdmin hasKeymanInstall: True');
       DoInstallKeyman;
     Exit;
   end;
@@ -1205,7 +1210,10 @@ begin
   end;
 
   if hasKeymanInstall then
+  begin
+    KL.Log('InstallingState.HandleInstallPackages Admin hasKeymanInstall: True');
     DoInstallKeyman;
+  end;
 end;
 
 procedure InstallingState.HandleFirstRun;


### PR DESCRIPTION
The state machine method [TState] for Exiting a state was overriding the Delphi system Exit. This meant that any intended early returns inside the TState method were just calling the TState.Exit method [or the overridden method for states that override the method.]   Then continuing execution within the method.
The `Enter` method has been updated to `EnterState` for symmetry.

Note: The downloading process would have also been affected by the Exit override. In the case when a second process was attempted to be downloaded when the mutex failed it would have still started a new download process. It may be what is occurring for #13831. My local testing doesn't do this though.
https://github.com/keymanapp/keyman/blob/2b53497046261d4fe23dfe0952d9f5ab6d3efcef/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas#L784
If we stop seeing the errors though it may turn out this was indeed the case.

There was only one other method where the Exit was called for a TState object. https://github.com/keymanapp/keyman/blob/2b53497046261d4fe23dfe0952d9f5ab6d3efcef/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas#L1198

Fixes: 13831

Also adds some more breadcrumbs for debugging #13767. In the case where the JSON file with the downloaded cache information is unable to be loaded a breadcrumb will be added. 


# User Testing

## TEST_ONLY_ASK_FOR_ELEVATION_ONCE

1. Install the Keyman from this PR
2. Install an old version of a Keyman Keyboard like euro latin keyboard  PR 3.0.0 [sil_euro_latin.zip](https://github.com/user-attachments/files/18587198/sil_euro_latin.zip)
3. Open Keyman Configuration and go to the updated tab
5. Press the "check for updates" button.
6. If an update for Keyman is found you can proceed with this test, otherwise we will need to wait for the next build which is daily if a PR has been merged. There should also be an update for the Keyboard you installed.
7. Optional step to double check look in `C:\Users\UserName\AppData\Local\Keyman\UpdateCache` you should see the new keyboard package, and the new keyman*.exe and file called `cache.json`
8. Restart the Machine 
9. When Windows restarts you get the prompt to install a Keyman Update select `Update`
10. You will then get a request for Admin permission for Keyman to make changes to your device ![PXL_20250516_130558655](https://github.com/user-attachments/assets/e2f08842-9492-4e0c-8774-df90c662ef3f).
11. For this to pass make sure you only get asked **once** for the Admin permission **not** twice
11. Once it has finished and Keyman has installed open Keyman configuration and verify the newer version of Keyman has been installed, as well as the newer keyboard version.


## TEST_KEYMAN_UPDATE_ONLY

For this test we need Keyman to be the latest alpha build

1. Download the Keyman attached to this PR 
2. Open the Keyman Configuration dialog.
3. Open Keyman Configuration and go to the updated tab
5. Press the "check for updates" button.
6. If an update for Keyman is found you can proceed with this test, otherwise we will need to wait for the next build which is daily if a PR has been merged. 
8. Restart the Machine 
9. Once it has finished and Keyman has installed open Keyman configuration and verify the newer version of Keyman has been installed,.


## TEST_INST_KBD_KEYMAN_VERSION now

1. Install the Keyman from this PR
2. Install an old version of a Keyman Keyboard like euro latin keyboard  PR 3.0.0 [sil_euro_latin.zip](https://github.com/user-attachments/files/18587198/sil_euro_latin.zip)
3. Open Keyman Configuration and go to the updated tab
5. Press the "check for updates" button.
6. If an update for Keyman is found you can proceed with this test, otherwise we will need to wait for the next build which is daily if a PR has been merged. There should also be an update for the Keyboard you installed.
7. Optional step to double check look in `C:\Users\UserName\AppData\Local\Keyman\UpdateCache` you should see the new keyboard package, and the new keyman*.exe and file called `cache.json`
8. On the Update tap press "Install Update Now" Button
10. You will then get a request for Admin permission for Keyman to make changes to your device !
11. For this to pass make sure you only get asked **once** for the Admin permission **not** twice in the one Windows session. It is a pass if it asks for permission once. Then asks to restart Windows, after restarting Windows it asks for permission again.
11. Once it has finished and Keyman has installed open Keyman configuration and verify the newer version of Keyman has been installed, as well as the newer keyboard version.