### PR TITLE
feat(web): dispose KMXKeyboards on shutdown 🎼

### DIFF
--- a/web/src/engine/keyboard-storage/src/keyboardRequisitioner.ts
+++ b/web/src/engine/keyboard-storage/src/keyboardRequisitioner.ts
@@ -115,6 +115,10 @@ export default class KeyboardRequisitioner {
     });
   }
 
+  shutdown(): void{
+    this.cache.shutdown();
+  }
+
   addKeyboardArray(x: (string|RawKeyboardMetadata)[]): Promise<(KeyboardStub | ErrorStub)[]> {
     let completeStubs: KeyboardStub[] = [];
     let incompleteStubs: KeyboardStub[] = [];

--- a/web/src/engine/keyboard-storage/src/stubAndKeyboardCache.ts
+++ b/web/src/engine/keyboard-storage/src/stubAndKeyboardCache.ts
@@ -1,4 +1,4 @@
-import { type Keyboard, JSKeyboard, KeyboardLoaderBase as KeyboardLoader } from "keyman/engine/keyboard";
+import { type Keyboard, JSKeyboard, KeyboardLoaderBase as KeyboardLoader, KMXKeyboard } from "keyman/engine/keyboard";
 import { EventEmitter } from "eventemitter3";
 
 import KeyboardStub from "./keyboardStub.js";
@@ -50,6 +50,16 @@ export default class StubAndKeyboardCache extends EventEmitter<EventMap> {
   constructor(keyboardLoader?: KeyboardLoader) {
     super();
     this.keyboardLoader = keyboardLoader;
+  }
+
+  shutdown(): void {
+    for (const kbdId in this.keyboardTable) {
+      const kbd = this.keyboardTable[kbdId];
+      if (kbd instanceof KMXKeyboard) {
+        (kbd as KMXKeyboard).shutdown();
+      }
+      // TODO-web-core: do we have to do something if instanceof Promise?
+    }
   }
 
   getKeyboardForStub(stub: KeyboardStub): Keyboard {

--- a/web/src/engine/keyboard/src/keyboards/kmxKeyboard.ts
+++ b/web/src/engine/keyboard/src/keyboards/kmxKeyboard.ts
@@ -8,6 +8,13 @@ export class KMXKeyboard {
   constructor(private _keyboard: km_core_keyboard) {
   }
 
+  shutdown() {
+    if (this._keyboard) {
+      KM_Core.instance.keyboard_dispose(this._keyboard);
+      this._keyboard = null;
+    }
+  }
+
   get isMnemonic(): boolean {
     return false;
   }

--- a/web/src/engine/keyboard/tsconfig.json
+++ b/web/src/engine/keyboard/tsconfig.json
@@ -7,6 +7,9 @@
     "tsBuildInfoFile": "../../../build/engine/keyboard/obj/tsconfig.tsbuildinfo",
     "rootDir": "./src/"
   },
+  "references": [
+    { "path": "../core-processor"},
+  ],
   "include": [ "./src/**/*.ts"],
   "exclude": ["./src/keyboards/loaders/**/*.ts"]
 }

--- a/web/src/engine/main/src/hardKeyboard.ts
+++ b/web/src/engine/main/src/hardKeyboard.ts
@@ -11,7 +11,7 @@ interface EventMap {
   'keyevent': (event: KeyEvent, callback?: (result: RuleBehavior, error?: Error) => void) => void
 }
 
-export default class HardKeyboard extends EventEmitter<EventMap> implements KeyEventSourceInterface<EventMap> { }
+export class HardKeyboard extends EventEmitter<EventMap> implements KeyEventSourceInterface<EventMap> { }
 
 export function processForMnemonicsAndLegacy(s: KeyEvent, activeKeyboard: Keyboard, baseLayout: string): KeyEvent {
   if (!activeKeyboard) {

--- a/web/src/engine/main/src/index.ts
+++ b/web/src/engine/main/src/index.ts
@@ -1,6 +1,6 @@
 export { EngineConfiguration, InitOptionDefaults, InitOptionSpec } from './engineConfiguration.js';
 export { ContextManagerBase, ContextManagerConfiguration } from './contextManagerBase.js';
-export { default as HardKeyboard, processForMnemonicsAndLegacy } from './hardKeyboard.js';
+export { HardKeyboard, processForMnemonicsAndLegacy } from './hardKeyboard.js';
 export { KeyboardInterfaceBase } from './keyboardInterfaceBase.js';
 export { KeymanEngineBase } from './keymanEngineBase.js';
 export { LegacyAPIEvents } from './legacyAPIEvents.js';

--- a/web/src/engine/main/src/keymanEngineBase.ts
+++ b/web/src/engine/main/src/keymanEngineBase.ts
@@ -11,7 +11,7 @@ import { ModelSpec, PredictionContext } from "keyman/engine/interfaces";
 import { EngineConfiguration, InitOptionSpec } from "./engineConfiguration.js";
 import { KeyboardInterfaceBase } from "./keyboardInterfaceBase.js";
 import { ContextManagerBase } from "./contextManagerBase.js";
-import HardKeyboardBase from "./hardKeyboard.js";
+import { HardKeyboard as HardKeyboardBase } from "./hardKeyboard.js";
 import { LegacyAPIEvents } from "./legacyAPIEvents.js";
 import { EventNames, EventListener, LegacyEventEmitter } from "keyman/engine/events";
 import DOMCloudRequester from "keyman/engine/keyboard-storage/dom-requester";
@@ -463,6 +463,7 @@ export class KeymanEngineBase<
   shutdown() {
     this.legacyAPIEvents.shutdown();
     this.osk?.shutdown();
+    this.keyboardRequisitioner?.shutdown();
   }
 
   // API methods


### PR DESCRIPTION
This PR adds the necessary code to dispose of the KMXKeyboards when we shut down KeymanEngine.

Test-bot: skip