### PR TITLE
refactor(web): rename generic type variables 🎼

### DIFF
--- a/web/src/engine/main/src/keymanEngineBase.ts
+++ b/web/src/engine/main/src/keymanEngineBase.ts
@@ -36,19 +36,19 @@ export type KeyEventFullResultCallback = (result: RuleBehavior, error?: Error) =
 export type KeyEventFullHandler = (event: KeyEvent, callback?: KeyEventFullResultCallback) => void;
 
 export class KeymanEngineBase<
-  Configuration extends EngineConfiguration,
-  ContextManager extends ContextManagerBase<any>,
-  HardKeyboard extends HardKeyboardBase
+  ConfigurationT extends EngineConfiguration,
+  ContextManagerT extends ContextManagerBase<any>,
+  HardKeyboardT extends HardKeyboardBase
 > implements KeyboardKeymanGlobal {
-  readonly config: Configuration;
-  contextManager: ContextManager;
-  interface: KeyboardInterface<ContextManager>;
+  readonly config: ConfigurationT;
+  contextManager: ContextManagerT;
+  interface: KeyboardInterface<ContextManagerT>;
   readonly core: InputProcessor;
   keyboardRequisitioner: KeyboardRequisitioner;
   modelCache: ModelCache;
 
   protected legacyAPIEvents = new LegacyEventEmitter<LegacyAPIEvents>();
-  private _hardKeyboard: HardKeyboard;
+  private _hardKeyboard: HardKeyboardT;
   private _osk: OSKView;
 
   protected keyEventRefocus?: () => void;
@@ -115,16 +115,16 @@ export class KeymanEngineBase<
    */
   constructor(
     workerFactory: WorkerFactory,
-    config: Configuration,
-    contextManager: ContextManager,
-    processorConfigInitializer: (engine: KeymanEngineBase<Configuration, ContextManager, HardKeyboard>) => ProcessorConfiguration
+    config: ConfigurationT,
+    contextManager: ContextManagerT,
+    processorConfigInitializer: (engine: KeymanEngineBase<ConfigurationT, ContextManagerT, HardKeyboardT>) => ProcessorConfiguration
   ) {
     this.config = config;
     this.contextManager = contextManager;
 
     const processorConfiguration = processorConfigInitializer(this);
     processorConfiguration.baseLayout = determineBaseLayout();
-    this.interface = processorConfiguration.keyboardInterface as KeyboardInterface<ContextManager>;
+    this.interface = processorConfiguration.keyboardInterface as KeyboardInterface<ContextManagerT>;
     this.core = new InputProcessor(config.hostDevice, workerFactory, processorConfiguration);
 
     this.core.languageProcessor.on('statechange', (state) => {
@@ -354,11 +354,11 @@ export class KeymanEngineBase<
     return KEYMAN_VERSION.VERSION_RELEASE;
   }
 
-  public get hardKeyboard(): HardKeyboard {
+  public get hardKeyboard(): HardKeyboardT {
     return this._hardKeyboard;
   }
 
-  protected set hardKeyboard(keyboard: HardKeyboard) {
+  protected set hardKeyboard(keyboard: HardKeyboardT) {
     if(this._hardKeyboard) {
       this._hardKeyboard.off('keyevent', this.keyEventListener);
     }


### PR DESCRIPTION
This change renames the generic type variables in `KeymanEngineBase` to make it clearer that they are generic types rather than the actual types.

Test-bot: skip