### PR TITLE
fix(web): empty layout fontSize property should default to 1em 🍒  🏠

### DIFF
--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -522,7 +522,7 @@ export default abstract class OSKView
     // If the layer group specifies a fontsize value, we need
     // to apply that to the banner as well.
     let layerFontSizeRaw = this.vkbd?.layerGroup?.spec.fontsize;
-    if(layerFontSizeRaw == '') {
+    if(layerFontSizeRaw === '') {
       layerFontSizeRaw = "1em";
     }
     // Addresses issue with touch-layouts specifying a unitless fontsize; this

--- a/web/src/engine/osk/src/views/oskView.ts
+++ b/web/src/engine/osk/src/views/oskView.ts
@@ -521,11 +521,15 @@ export default abstract class OSKView
     // Set default OSK font size (Build 344, KMEW-90)
     // If the layer group specifies a fontsize value, we need
     // to apply that to the banner as well.
-    const layerFontSizeRaw = this.vkbd?.layerGroup?.spec.fontsize;
+    let layerFontSizeRaw = this.vkbd?.layerGroup?.spec.fontsize;
+    if(layerFontSizeRaw == '') {
+      layerFontSizeRaw = "1em";
+    }
     // Addresses issue with touch-layouts specifying a unitless fontsize; this
     // coerces them to `pt` style sizing, like how word-processors present font-size.
     //
-    // Returns NaN if not 100% a number.  "12px", "12pt", "12%" all return NaN.
+    // Number() returns NaN if not 100% a number.  "12px", "12pt", "12%" all return NaN.
+    // '' returns 0, though!
     const fsRaw = Number(layerFontSizeRaw);
     const layerFontSize = isNaN(fsRaw) ? layerFontSizeRaw : (fsRaw + 'pt');
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -1113,10 +1113,6 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
    * This function allows us to calculate the font size in those situations.
    */
   getKeyEmFontSize(): ParsedLengthStyle {
-    if (!this.fontSize) {
-      return new ParsedLengthStyle('0px');
-    }
-
     if (this.device.formFactor == 'desktop') {
       let keySquareScale = 0.8; // Set in kmwosk.css, is relative.
       return this.fontSize.scaledBy(keySquareScale);
@@ -1313,7 +1309,8 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       // All existing font-precalculations will need to be reset, as the font
       // was previously unavailable.
       this.layerGroup.resetPrecalcFontSizes();
-      this.refreshLayout()
+      // Can trigger when we're not actually layout-ready!
+      this.refreshLayout();
     });
   }
 


### PR DESCRIPTION
Fixes: #13908
Fixes: KEYMAN-WEB-RK
Cherry-pick-of: #13959

Fun fact:  `Number('')` returns 0, not NaN!  I thought it would do the latter in #13838, which is what led to the issue this PR addresses.

## User Testing

TEST_THAI_KEDMANEE: Using Keyman for Android, install and load the Thai Kedmanee Basic keyboard and verify that no errors result.