### PR TITLE
maint(linux): properly fallback to `VERSION` in deb-packaging

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -87,7 +87,7 @@ jobs:
       run: |
         THIS_SCRIPT="$GITHUB_WORKSPACE/.github/workflows/deb-packaging.yml"
         . "${THIS_SCRIPT%/*}/../../resources/build/build-utils.sh"
-        echo "KEYMAN_VERSION=${KEYMAN_VERSION:-VERSION}" >> $GITHUB_OUTPUT
+        echo "KEYMAN_VERSION=${KEYMAN_VERSION:-${VERSION}}" >> $GITHUB_OUTPUT
 
     - name: Set prerelease tag as output parameter
       id: prerelease_tag


### PR DESCRIPTION
This change fixes the fix that #13891 implemented. However that only used the string `VERSION` instead of the variable... Fixes the package builds of `stable-18.0` branch. 

Fixes: #13891
Test-bot: skip