### PR TITLE
maint(linux): don't include `dockerbuild` log files

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -303,7 +303,7 @@ jobs:
         echo "::endgroup::"
 
   prepare_api_verification:
-    name: Verify API for libkeymancore.so
+    name: Prepare API verification
     needs: [sourcepackage, binary_packages_released]
     runs-on: ubuntu-latest
 
@@ -312,6 +312,7 @@ jobs:
       uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
       with:
         path: artifacts
+        pattern: keyman-*
         merge-multiple: true
 
     - name: Save environment


### PR DESCRIPTION
The recent update of one of the `docker/build-push-action` dependency referenced in the `gha-ubuntu-packaging` dependency now adds the `.dockerbuild` log files as artifacts which confuses the `prepare_api_verification` step. This change now limits the artifacts we pass to the API verification to the keyman package related ones. 

Test-bot: skip