### PR TITLE
fix(android): Check network access before trying to download keyboard

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -114,7 +114,14 @@ public class KMPBrowserActivity extends BaseActivity {
           Intent intent = new Intent(context, MainActivity.class);
           intent.setData(downloadURI);
           KMLog.LogBreadcrumb(TAG, "Successful keyboard search now triggering package install", true);
-          startActivity(intent);
+
+          // Verify network access before trying to download
+          if (KMManager.hasConnection(context)) {
+            startActivity(intent);
+          } else {
+            Toast.makeText(context, getString(R.string.no_internet_connection), Toast.LENGTH_LONG).show();
+            return true;
+          }
 
           // Finish activity
           finish();


### PR DESCRIPTION
Display a Toast notification if network is unavailable before downloading from the keyboard page
This should cut down on `UnknownHostException` errors

Fixes: #13977
Fixes: KEYMAN-ANDROID-420


## User Testing

**Setup** - Install PR build of Keyman for Android on emulator/device

* **TEST_NETWORK_CHECK** - Verifies network check when downloading keyboards
1. On the Android device, verify network access (wifi or cell data) is enabled (e.g. Airplane mode off)
2. Launch Keyman for Android and dismiss the "Getting Started" menu
3. From Keyman settings --> Install keyboard or dictionary --> Install from keyman.com
4. Search for "khmer_angkor" , and install the keyboard
5. Verify the keyboard package downloads and installs
6. From Keyman settings --> Install keyboard or dictionary --> Install from keyman.com
7. Search for "sil_ipa" but do not click the green "Install keyboard" button
8. On the Android device, disable network access (turn Airplane mode on)
9. From Keyman, click "Install keyboard"
10. Verify toast notification appears about "No internet connection"

![sil_ipa no internet connection](https://github.com/user-attachments/assets/77a65956-7235-4e91-97bf-6bc2a3d962ed)
