### PR TITLE
fix(linux): configurable path in `.service` file when using basu

### DIFF
--- a/linux/keyman-system-service/resources/com.keyman.SystemService1.service.basu
+++ b/linux/keyman-system-service/resources/com.keyman.SystemService1.service.basu
@@ -3,5 +3,5 @@
 
 [D-BUS Service]
 Name=com.keyman.SystemService1
-Exec=/usr/libexec/systemd-keyman.service
+Exec=@LIBEXECDIR@/systemd-keyman.service
 User=root

--- a/linux/keyman-system-service/resources/meson.build.in
+++ b/linux/keyman-system-service/resources/meson.build.in
@@ -1,11 +1,26 @@
 # This file will be appended to meson.build by build.sh
+cfg = configuration_data()
+cfg.set('LIBEXECDIR', get_option('prefix') / get_option('libexecdir'))
+
 install_data('com.keyman.SystemService1.conf', install_dir: get_option('datadir') / 'dbus-1/system.d/')
 
 if systemd.name() == 'libsystemd'
   install_data('com.keyman.SystemService1.service.systemd', install_dir: get_option('datadir') / 'dbus-1/system-services/', rename: ['com.keyman.SystemService1.service'])
 else
   # libelogind or basu
-  install_data('com.keyman.SystemService1.service.basu', install_dir: get_option('datadir') / 'dbus-1/system-services/')
+  configure_file(
+    configuration: cfg,
+    input: 'com.keyman.SystemService1.service.basu',
+    output: 'com.keyman.SystemService1.service',
+    install: true,
+    install_dir: get_option('datadir') / 'dbus-1/system-services/'
+  )
 endif
 
-install_data('systemd-keyman.service', install_dir: get_option('prefix') / 'lib/systemd/system/')
+configure_file(
+  configuration: cfg,
+  input: 'systemd-keyman.service.in',
+  output: 'systemd-keyman.service',
+  install: true,
+  install_dir: get_option('prefix') / 'lib/systemd/system/'
+)

--- a/linux/keyman-system-service/resources/systemd-keyman.service.in
+++ b/linux/keyman-system-service/resources/systemd-keyman.service.in
@@ -9,7 +9,7 @@ Documentation=https://github.com/keymanapp/keyman/tree/master/linux/keyman-syste
 [Service]
 Type=dbus
 BusName=com.keyman.SystemService1
-ExecStart=/usr/libexec/keyman-system-service
+ExecStart=@LIBEXECDIR@/keyman-system-service
 Restart=on-failure
 
 # Filesystem lockdown


### PR DESCRIPTION
This makes the path in `com.keyman.SystemService1.service` configurable when using basu (e.g. Gentoo Linux).

Fixes: #13971 
Test-bot: skip