### PR TITLE
feat(android): log active keyboard, model IDs with reported errors 

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -486,6 +486,8 @@ public final class KMManager {
 
   public static void initialize(final Context context, KeyboardType keyboardType) {
     appContext = context.getApplicationContext();
+    // To facilitate tagging events with current keyboard, language, model.
+    KMLog.setEngineContext(appContext);
 
     if (!didCopyAssets || isTestMode()) {
       // Copy and install assets

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -486,8 +486,6 @@ public final class KMManager {
 
   public static void initialize(final Context context, KeyboardType keyboardType) {
     appContext = context.getApplicationContext();
-    // To facilitate tagging events with current keyboard, language, model.
-    KMLog.setEngineContext(appContext);
 
     if (!didCopyAssets || isTestMode()) {
       // Copy and install assets

--- a/android/KMEA/app/src/main/java/com/keyman/engine/util/KMLog.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/util/KMLog.java
@@ -6,8 +6,6 @@ package com.keyman.engine.util;
 
 import static com.keyman.engine.KMManager.KMKey_LexicalModelID;
 
-import android.annotation.SuppressLint;
-import android.content.Context;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -15,8 +13,6 @@ import com.keyman.engine.BaseActivity;
 import com.keyman.engine.BuildConfig;
 import com.keyman.engine.KMManager;
 import com.keyman.engine.data.Keyboard;
-import com.keyman.engine.data.LexicalModel;
-import com.keyman.engine.util.DependencyUtil;
 import com.keyman.engine.util.DependencyUtil.LibraryType;
 
 import java.util.Map;
@@ -26,45 +22,40 @@ import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 
 public final class KMLog {
-  // Needed to facilitate looking up the current keyboard & model.
-  @SuppressLint("StaticFieldLeak")
-  private static Context engineContext;
-
   private static final String TAG = "KMLog";
 
   private static final String KEYBOARD_TAG = "keyboardId";
+  private static final String KEYBOARD_COUNT_TAG = "installedKeyboardCount";
   private static final String MODEL_TAG = "modelId";
   private static final String LANGCODE_TAG = "languageCode";
 
   private static boolean isLogging = false;
 
-  public static void setEngineContext(Context context) {
-    engineContext = context;
-  }
-
   private static void tagDebugInfo() {
     String kbdId = "";
     String lngCode = "";
     String modelId = "";
+    int kbdCount = 0;
     // Do not risk raising a new error while tagging info for another error.
     try {
-      if (engineContext != null) {
-        Keyboard kbd = KMManager.getCurrentKeyboardInfo(null);
-        if (kbd != null) {
-          kbdId = kbd.getKeyboardID();
-          lngCode = kbd.getLanguageCode();
-          Map<String, String> modelMap = KMManager.getAssociatedLexicalModel(kbd.getLanguageID());
-          if (modelMap != null) {
-            modelId = modelMap.get(KMKey_LexicalModelID);
-            if (modelId == null) {
-              modelId = "";
-            }
+      // Both take a context parameter... but don't actually need or use it!
+      Keyboard kbd = KMManager.getCurrentKeyboardInfo(null);
+      kbdCount = KMManager.getKeyboardsList(null).size();
+      if (kbd != null) {
+        kbdId = kbd.getKeyboardID();
+        lngCode = kbd.getLanguageCode();
+        Map<String, String> modelMap = KMManager.getAssociatedLexicalModel(kbd.getLanguageID());
+        if (modelMap != null) {
+          modelId = modelMap.get(KMKey_LexicalModelID);
+          if (modelId == null) {
+            modelId = "";
           }
         }
       }
     } catch (Exception ignored) {
     }
     Sentry.setExtra(KEYBOARD_TAG, kbdId);
+    Sentry.setExtra(KEYBOARD_COUNT_TAG, "" + kbdCount);
     Sentry.setExtra(LANGCODE_TAG, lngCode);
     Sentry.setExtra(MODEL_TAG, modelId);
   }


### PR DESCRIPTION
To facilitate code investigation and issue repro attempts, we should log the engine's current keyboard, language code, lexical model, and installed keyboard count when reporting errors.

As this adds Sentry logging, I needed a reliable error with inspectable logs for development; example reports with the new logging can be found for the issue noted below.

Fixes: KEYMAN-ANDROID-71V

Example report, as visible within Sentry:

| Additional Data                |                         |
|---------                           | -------             |
| installedKeyboardCount  | 5                      |
| keyboardId                       | khmer_angkor |
| languageCode                 | km                    |
| modelId                            | sil.km.gcc        |

<details><summary>Screenshot excerpt</summary>

![screenshot excerpt from Sentry log matching text-table above](https://github.com/user-attachments/assets/a4b2ce04-07fc-4eb8-9632-329732fda1c6)

</details>

Test-bot: skip