### PR TITLE
fix(windows): only breadcrumb unexpected state on first run

### DIFF
--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -592,10 +592,12 @@ end;
 
 procedure TState.HandleFirstRun;
 begin
-  // If Handle First run hits base implementation
-  // something is wrong.
-  TKeymanSentryClient.Client.MessageEvent(Sentry.Client.SENTRY_LEVEL_ERROR,
-    'Handle first run called in state:"' + Self.ClassName + '"');
+  // A Keyman install file can be downloaded and installed directly therefore
+  // the state machine could be in a "unexpected" state such as UpdateAvailable.
+  // It will still be good to record the breadcrumb of the state incase there is a error
+  // during the first run.
+  TKeymanSentryClient.Breadcrumb('info',
+    'TState.HandleFirstRun first run called in state:"' + Self.ClassName + '"', 'update');
   bucStateContext.RemoveCachedFiles;
   ChangeState(IdleState);
 end;


### PR DESCRIPTION
If the configuration is set to not automatically downloadupdates and then from the configuration tab the check for update button is clicked. If an update is found the upgrade statemachine is now in state UpdateAvailable. If a updated keyman installer file is then downloaded direclty from keyman.com. Then installed by running the self installer then on firstrun the statemachine will still be in the UpdateState. This is should be fine, but it will be good to breadcrumb incase we start to see some crashes on firstrun with this interaction.

The setup executable could modify the registry state directly but it is cleaner to have the one master of the registry state value.

Fixes: #13771

# User Testing
Not sure the testers can do this test due to the sentry requirement.
## TEST_INDEPENDENT_INSTALL_UPDATEAVAILABLE

1. Download https://downloads.keyman.com/windows/alpha/19.0.38/keyman-19.0.38.exe  this will be older then the PR build
2. Install the version 19.0.38 just downloaded.
3. Open Keyman Configuration and in the Options tab uncheck `Automatically check for updates and download` 
5. From the Update tab press the `Check for new updates` and close Keyman configuration.
6. Open Regedit WinR type regedit
7. Go to the current user key `update state` found at (Computer\HKEY_CURRENT_USER\SOFTWARE\Keyman\Keyman Engine). Verify it is `usUpdateAvailable`. If it is usWaitingRestart set it back to usIdle. Goto 
Open Windows Explorer at "C:\Users"yourusername"\AppData\Local\Keyman\UpdateCache" folder.
Delete cache.json, any *.kmp and *.exe files. Then go back to step 5.
7. Download the Keyman install from this PR and run it, double click in Windows Explorer  
8. Keyman should install fine.
9. Verify that no new sentry error is reported at  [KEYMAN-WINDOWS-4X5](https://keyman.sentry.io/issues/6270153956/?referrer=github_integration) 

