### PR TITLE
maint(linux): add quilt to release build configuration

### DIFF
--- a/resources/teamcity/includes/tc-actions.inc.sh
+++ b/resources/teamcity/includes/tc-actions.inc.sh
@@ -15,7 +15,7 @@ linux_install_dependencies_action() {
 }
 
 # Install additional dependencies required for determining test coverage.
-linux_additional_dependencies_action() {
+linux_additional_test_dependencies_action() {
   builder_echo start additional_dependencies "Installing additional dependencies"
   local TOINSTALL="lcov libdatetime-perl gcovr python3-venv jq"
 

--- a/resources/teamcity/keyman-linux-release.sh
+++ b/resources/teamcity/keyman-linux-release.sh
@@ -35,6 +35,17 @@ builder_parse "$@"
 
 cd "${KEYMAN_ROOT}/linux"
 
+function _install_additional_dependencies() {
+  builder_echo start additional_dependencies "Installing additional dependencies"
+
+  # Additionally we need quilt to be able to create the source package.
+  # Since this is not needed to build the binary package, it is not
+  # (and should not be) included in `build-depends` in `debian/control`.
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -q -y install quilt
+
+  builder_echo end additional_dependencies success "Finished installing additional dependencies"
+}
+
 function _cleanup_before_creating_source_package() {
   # Cleanup before creating the source package.
   builder_echo start cleanup "Cleanup before creating the source package"
@@ -165,6 +176,7 @@ function publish_action() {
 
 if builder_has_action all; then
   linux_install_dependencies_action
+  _install_additional_dependencies
 
   set_variables_for_nvm
 
@@ -173,6 +185,7 @@ if builder_has_action all; then
   publish_action
 else
   builder_run_action  configure   linux_install_dependencies_action
+  builder_run_action  configure   _install_additional_dependencies
 
   set_variables_for_nvm
 

--- a/resources/teamcity/keyman-linux-test-integration.sh
+++ b/resources/teamcity/keyman-linux-test-integration.sh
@@ -31,14 +31,14 @@ cd "${KEYMAN_ROOT}/linux"
 if builder_has_action all; then
   linux_clean_action
   linux_install_dependencies_action
-  linux_additional_dependencies_action
+  linux_additional_test_dependencies_action
   set_variables_for_nvm
   linux_build_action
   linux_unit_tests_action
 else
   builder_run_action  clean       linux_clean_action
   builder_run_action  configure   linux_install_dependencies_action
-  builder_run_action  configure   linux_additional_dependencies_action
+  builder_run_action  configure   linux_additional_test_dependencies_action
 
   set_variables_for_nvm
 

--- a/resources/teamcity/keyman-linux-test.sh
+++ b/resources/teamcity/keyman-linux-test.sh
@@ -37,7 +37,7 @@ function make_source_tarball_action() {
 
 if builder_has_action all; then
   linux_install_dependencies_action
-  linux_additional_dependencies_action
+  linux_additional_test_dependencies_action
 
   set_variables_for_nvm
 
@@ -46,7 +46,7 @@ if builder_has_action all; then
   make_source_tarball_action
 else
   builder_run_action  configure   linux_install_dependencies_action
-  builder_run_action  configure   linux_additional_dependencies_action
+  builder_run_action  configure   linux_additional_test_dependencies_action
 
   set_variables_for_nvm
 


### PR DESCRIPTION
In addition to all the other dependencies we also need quilt installed in order to be able to create a source package. Additionally renamed a function to clarify its purpose.

Test-bot: skip