### PR TITLE
maint(linux): add `--no-werror` option to not report warnings as errors

### DIFF
--- a/core/build.sh
+++ b/core/build.sh
@@ -69,7 +69,8 @@ Libraries will be built in 'build/<target>/<configuration>/src'.
   "uninstall                       uninstall libraries from current system" \
   "${archtargets[@]}" \
   "--no-tests                      do not configure tests (used by other projects)" \
-  "--test,-t=opt_tests             test[s] to run (space separated)"
+  "--test,-t=opt_tests             test[s] to run (space separated)" \
+  "--no-werror                     don't report warnings as errors"
 
 builder_parse "$@"
 
@@ -114,6 +115,11 @@ builder_describe_outputs \
   build:mac-arm64           /core/build/mac-arm64/$BUILDER_CONFIGURATION/src/libkeymancore.a \
   build:arch                /core/build/arch/$BUILDER_CONFIGURATION/src/libkeymancore.a \
   build:wasm                /core/build/wasm/$BUILDER_CONFIGURATION/src/libkeymancore.a
+
+MESON_ARGS=--werror
+if builder_has_option --no-werror; then
+  MESON_ARGS=
+fi
 
 if builder_has_action configure; then
   # Import our standard compiler defines

--- a/core/commands.inc.sh
+++ b/core/commands.inc.sh
@@ -55,7 +55,7 @@ do_configure() {
   else
     pushd "$THIS_SCRIPT_PATH" > /dev/null
     # Additional arguments are used by Linux build, e.g. -Dprefix=${INSTALLDIR}
-    meson setup "$MESON_PATH" $MESON_CROSS_FILE --werror --buildtype $BUILDER_CONFIGURATION $STANDARD_MESON_ARGS "${builder_extra_params[@]}"
+    meson setup "$MESON_PATH" $MESON_CROSS_FILE ${MESON_ARGS} --buildtype $BUILDER_CONFIGURATION $STANDARD_MESON_ARGS "${builder_extra_params[@]}"
     popd > /dev/null
   fi
 

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -27,7 +27,8 @@ builder_describe \
   "--no-integration+         don't run integration tests" \
   "--coverage+               capture test coverage" \
   "--report+                 create coverage report" \
-  "--open                    open the coverage reports in the browser"
+  "--open                    open the coverage reports in the browser" \
+  "--no-werror+              don't report warnings as errors"
 
 builder_parse "$@"
 

--- a/linux/ibus-keyman/build.sh
+++ b/linux/ibus-keyman/build.sh
@@ -21,7 +21,8 @@ builder_describe \
   "@../keyman-system-service:service" \
   "--no-integration          don't run integration tests" \
   "--report                  create coverage report" \
-  "--coverage                capture test coverage"
+  "--coverage                capture test coverage" \
+  "--no-werror               don't report warnings as errors"
 
 builder_parse "$@"
 
@@ -45,6 +46,11 @@ else
   MESON_COVERAGE=
 fi
 
+MESON_ARGS=--werror
+if builder_has_option --no-werror; then
+  MESON_ARGS=
+fi
+
 if builder_has_action configure; then
   # Import our standard compiler defines
   source "$KEYMAN_ROOT/resources/build/meson/standard_meson_build.inc.sh"
@@ -53,7 +59,7 @@ fi
 
 configure_action() {
   # shellcheck disable=SC2086,SC2154
-  meson setup ${MESON_COVERAGE} --werror --buildtype $MESON_TARGET "${builder_extra_params[@]}" "$MESON_PATH"
+  meson setup ${MESON_COVERAGE} ${MESON_ARGS} --buildtype $MESON_TARGET "${builder_extra_params[@]}" "$MESON_PATH"
 }
 
 test_action() {

--- a/linux/keyman-system-service/build.sh
+++ b/linux/keyman-system-service/build.sh
@@ -19,7 +19,8 @@ builder_describe \
   "uninstall                 uninstall artifacts" \
   "--no-integration          don't run integration tests" \
   "--report                  create coverage report" \
-  "--coverage                capture test coverage"
+  "--coverage                capture test coverage" \
+  "--no-werror               don't report warnings as errors"
 
 builder_parse "$@"
 
@@ -42,6 +43,11 @@ else
 fi
 MESON_PATH="build/$(uname -m)/$MESON_TARGET"
 
+MESON_ARGS=--werror
+if builder_has_option --no-werror; then
+  MESON_ARGS=
+fi
+
 clean_action() {
   rm -rf "$THIS_SCRIPT_PATH/build/"
 }
@@ -61,7 +67,7 @@ check_missing_coverage_configuration() {
 
 configure_action() {
   # shellcheck disable=SC2086,SC2154,SC2248
-  meson setup ${MESON_COVERAGE} --werror --buildtype ${MESON_TARGET} "${builder_extra_params[@]}" "${MESON_PATH}"
+  meson setup ${MESON_COVERAGE} ${MESON_ARGS} --buildtype ${MESON_TARGET} "${builder_extra_params[@]}" "${MESON_PATH}"
 }
 
 test_action() {


### PR DESCRIPTION
By default we add the `--werror` option to meson builds. This might cause problems when compiling with a different compiler, so this option adds the `--no-werror` option to our build scripts. This enables integrators to compile with other compiler versions. 

Fixes: #13970
Test-bot: skip