### PR TITLE
fix(windows): skip sending handle kmshell events to upgrade state machine  for keyboard install modes

### DIFF
--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -723,11 +723,13 @@ begin
       else
       begin
         // Since Package upgrade and Keyman upgrade share the installing state
-        // the presense following package related switches means we should
-        // skip running the update state machine HandleKmShell event
-        SkipBUpdate := (FMode in [fmInstallTip,
-        fmInstallTipsForPackages, fmRegisterTip, fmUpgradeKeyboards,
-        fmUpgradeMnemonicLayout]);
+        // the presence of the following package related switches means we 
+        // should skip running the update state machine HandleKmShell event
+        SkipBUpdate := (FMode in [
+          fmInstallTip, fmInstallTipsForPackages, 
+          fmRegisterTip, fmUpgradeKeyboards,
+          fmUpgradeMnemonicLayout
+        ]);
 
         SendToBUpdateSM := ShouldSendToBUpdateSM(FSilent, BUpdateSM, FMode);
 

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -723,11 +723,11 @@ begin
       else
       begin
         // Since Package upgrade and Keyman upgrade share the installing state
-        // the following package related switches are valid in the installing
-        // state.
-        SkipBUpdate := (BUpdateSM.IsInstallingState and (FMode in [fmInstallTip,
+        // the presense following package related switches means we should
+        // skip running the update state machine HandleKmShell event
+        SkipBUpdate := (FMode in [fmInstallTip,
         fmInstallTipsForPackages, fmRegisterTip, fmUpgradeKeyboards,
-        fmUpgradeMnemonicLayout]));
+        fmUpgradeMnemonicLayout]);
 
         SendToBUpdateSM := ShouldSendToBUpdateSM(FSilent, BUpdateSM, FMode);
 


### PR DESCRIPTION
Before we only skipped the handlekmshell checks if we were in installing state and the FMode was related to upgrading or installing the keyboard packages. However like as seen in #13984 if an upgrade is started from the standalone installer the statemachine state could be in UpdateAvailable instead of the Installing State. Due to this limitation we will skip handlekmshell when in these FModes in any state.

Fixes: #13770

# User Testing
The aims of these tests is regression tests ensuring the installation of keyboards and keyman is still working correctly. 

## TEST_INSTALL_KEYMAN_AND_KEYBOARD

1. Install the Keyman from this PR
2. Install an old version of a Keyman Keyboard like euro latin keyboard  PR 3.0.0 [sil_euro_latin.zip](https://github.com/user-attachments/files/18587198/sil_euro_latin.zip)
3. Open Keyman Configuration and go to the updated tab
5. Press the "check for updates" button.
6. If an update for Keyman is found you can proceed with this test, otherwise we will need to wait for the next build which is daily if a PR has been merged. There should also be an update for the Keyboard you installed.
7. Optional step to double check look in `C:\Users\UserName\AppData\Local\Keyman\UpdateCache` you should see the new keyboard package, and the new keyman*.exe and file called `cache.json`
8. Restart the Machine 
9. When Windows restarts you get the prompt to install a Keyman Update select `Update`
10. Once it has finished and Keyman has installed open Keyman configuration and verify the newer version of Keyman has been installed, as well as the newer keyboard version.


## TEST_KEYMAN_UPDATE_ONLY

For this test we need Keyman to be the latest alpha build

1. Download the Keyman attached to this PR 
2. Open the Keyman Configuration dialog.
3. Open Keyman Configuration and go to the updated tab
5. Press the "check for updates" button.
6. If an update for Keyman is found you can proceed with this test, otherwise we will need to wait for the next build which is daily if a PR has been merged. 
7. Double check look in `C:\Users\UserName\AppData\Local\Keyman\UpdateCache`  you should see the new  keyman*.exe and file called `cache.json. Wait until it has appears before step 9.
9. Restart the Machine 
10. Once it has finished and Keyman has installed open Keyman configuration and verify the newer version of Keyman has been installed.


## TEST_INST_KBD_KEYMAN_VERSION_NOW

1. Install the Keyman from this PR
2. Install an old version of a Keyman Keyboard like euro latin keyboard  PR 3.0.0 [sil_euro_latin.zip](https://github.com/user-attachments/files/18587198/sil_euro_latin.zip)
3. Open Keyman Configuration and go to the updated tab
5. Press the "check for updates" button.
6. If an update for Keyman is found you can proceed with this test, otherwise we will need to wait for the next build which is daily if a PR has been merged. There should also be an update for the Keyboard you installed.
8. Optional step to double check look in `C:\Users\UserName\AppData\Local\Keyman\UpdateCache` you should see the new keyboard package, and the new keyman*.exe and file called `cache.json`
9. On the Update tap press "Install Update Now" Button
11. It will most likely ask for restarts and elevation etc. 
12. Once it has finished and Keyman has installed open Keyman configuration and verify the newer version of Keyman has been installed, as well as the newer keyboard version.