### PR TITLE
fix(windows): cherry use json file name against cache folder and ename Enter and Exit methods for TState Object 🍒  🏠

### DIFF
--- a/common/windows/delphi/tools/test-klog/test_klog.dpr
+++ b/common/windows/delphi/tools/test-klog/test_klog.dpr
@@ -7,13 +7,17 @@ uses
   klog in '..\..\..\..\..\common\windows\delphi\general\klog.pas',
   VersionInfo in '..\..\..\..\..\common\windows\delphi\general\VersionInfo.pas',
   ErrorControlledRegistry in '..\..\..\..\..\common\windows\delphi\vcl\ErrorControlledRegistry.pas',
-  Unicode in '..\..\..\..\..\common\windows\delphi\general\Unicode.pas';
+  Unicode in '..\..\..\..\..\common\windows\delphi\general\Unicode.pas',
+  DebugPaths in '..\..\..\..\..\common\windows\delphi\general\DebugPaths.pas',
+  KeymanPaths in '..\..\..\..\..\common\windows\delphi\general\KeymanPaths.pas',
+  RegistryKeys in '..\..\..\..\..\common\windows\delphi\general\RegistryKeys.pas',
+  KeymanVersion in '..\..\..\..\..\common\windows\delphi\general\KeymanVersion.pas';
 
 begin
   if KLEnabled then
   begin
     writeln('KLog is enabled - disable KLogging before release!');
-    ExitCode := 1;
+    ExitCode := 0;
   end
   else
   begin

--- a/common/windows/delphi/tools/test-klog/test_klog.dpr
+++ b/common/windows/delphi/tools/test-klog/test_klog.dpr
@@ -7,17 +7,13 @@ uses
   klog in '..\..\..\..\..\common\windows\delphi\general\klog.pas',
   VersionInfo in '..\..\..\..\..\common\windows\delphi\general\VersionInfo.pas',
   ErrorControlledRegistry in '..\..\..\..\..\common\windows\delphi\vcl\ErrorControlledRegistry.pas',
-  Unicode in '..\..\..\..\..\common\windows\delphi\general\Unicode.pas',
-  DebugPaths in '..\..\..\..\..\common\windows\delphi\general\DebugPaths.pas',
-  KeymanPaths in '..\..\..\..\..\common\windows\delphi\general\KeymanPaths.pas',
-  RegistryKeys in '..\..\..\..\..\common\windows\delphi\general\RegistryKeys.pas',
-  KeymanVersion in '..\..\..\..\..\common\windows\delphi\general\KeymanVersion.pas';
+  Unicode in '..\..\..\..\..\common\windows\delphi\general\Unicode.pas';
 
 begin
   if KLEnabled then
   begin
     writeln('KLog is enabled - disable KLogging before release!');
-    ExitCode := 0;
+    ExitCode := 1;
   end
   else
   begin

--- a/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
@@ -59,6 +59,7 @@ uses
   OnlineUpdateCheckMessages,
   RegistryKeys,
   Upload_Settings,
+  UtilCheckOnline,
   utilkmshell;
 
 procedure ErrorLogMessage(ErrorLogMessage: string);
@@ -133,6 +134,7 @@ begin
   Result := False;
   FSuccessfulDownloadCount := 0;
   // Keyboard Packages
+
   for i := 0 to High(Params.Packages) do
   begin
     Params.Packages[i].SavePath := SavePath + Params.Packages[i].FileName;
@@ -143,9 +145,9 @@ begin
     else
     begin
       Params.Packages[i].Install := False; // Download failed but install other files
+      TKeymanSentryClient.Breadcrumb('error', 'Download failded for keyboard: '+ Params.Packages[i].DownloadURL, 'cli.download');
     end;
   end;
-
   // Keyman Installer
   //
   if Params.Status = ucrsUpdateReady then
@@ -157,6 +159,7 @@ begin
     else
     begin
       ErrorLogMessage('DoDownloadUpdates Failed to download' + Params.InstallURL);
+      TKeymanSentryClient.Breadcrumb('error', 'Download failded for keyboard: '+  Params.InstallURL, 'cli.download');
     end;
   end;
   // If there is at least one keyboard package or version of keyman downloaded then
@@ -172,6 +175,11 @@ var
   DownloadBackGroundSavePath : String;
   ucr: TUpdateCheckResponse;
 begin
+  if not IsOnline then
+  begin
+    TKeymanSentryClient.Breadcrumb('default', 'TDownloadUpdate: Not Online, cant execute download process.', 'cli.download');
+    Exit(False);
+  end;
   DownloadBackGroundSavePath := IncludeTrailingPathDelimiter(TKeymanPaths.KeymanUpdateCachePath);
   if TUpdateCheckStorage.LoadUpdateCacheData(ucr) then
   begin
@@ -179,7 +187,11 @@ begin
     KL.Log('DownloadUpdates.DownloadUpdates: DownloadResult = '+IntToStr(Ord(Result)));
   end
   else
+  begin
     Result := False;
+    KL.Log('TDownloadUpdates.DownloadUpdates: LoadUpdateCacheData failed');
+    TKeymanSentryClient.Breadcrumb('default', 'TDownloadUpdate: LoadUpdateCacheData failed.', 'cli.download');
+  end;
 end;
 
 end.

--- a/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.DownloadUpdate.pas
@@ -161,6 +161,10 @@ begin
       ErrorLogMessage('DoDownloadUpdates Failed to download' + Params.InstallURL);
       TKeymanSentryClient.Breadcrumb('error', 'Download failded for keyboard: '+  Params.InstallURL, 'cli.download');
     end;
+  end
+  else
+  begin
+      TKeymanSentryClient.Breadcrumb('info', 'DoDownloadUpdates Params.Status !=ucrsUpdateReady', 'cli.download');
   end;
   // If there is at least one keyboard package or version of keyman downloaded then
   // the result is true
@@ -189,7 +193,6 @@ begin
   else
   begin
     Result := False;
-    KL.Log('TDownloadUpdates.DownloadUpdates: LoadUpdateCacheData failed');
     TKeymanSentryClient.Breadcrumb('default', 'TDownloadUpdate: LoadUpdateCacheData failed.', 'cli.download');
   end;
 end;

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -1023,7 +1023,7 @@ begin
   found := False;
   for FileName in FileNames do
   begin
-    if ucrFileName = ExtractFileName(FileName) then
+    if SameText(ucrFileName, ExtractFileName(FileName)) then
     begin
       found := True;
       break;

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -1010,19 +1010,20 @@ function InstallingState.DoInstallKeyman: Boolean;
 var
   FResult: Boolean;
   SavePath: String;
-  fileExt: String;
   FileName: String;
   FileNames: TStringDynArray;
+  ucr: TUpdateCheckResponse;
+  ucrFileName: String;
   found: Boolean;
 begin
-
+  TUpdateCheckStorage.LoadUpdateCacheData(ucr);
+  ucrFileName := ucr.FileName;
   SavePath := IncludeTrailingPathDelimiter(TKeymanPaths.KeymanUpdateCachePath);
   GetFileNamesInDirectory(SavePath, FileNames);
   found := False;
   for FileName in FileNames do
   begin
-    fileExt := LowerCase(ExtractFileExt(FileName));
-    if fileExt = '.exe' then
+    if ucrFileName = ExtractFileName(FileName) then
     begin
       found := True;
       break;

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -776,6 +776,7 @@ begin
     // downloading process finish.
     if not FMutex.TakeOwnership then
     begin
+      TKeymanSentryClient.Breadcrumb('default', 'DownloadingState.EnterState: Unable to get Mutex download process exists', 'update');
       Exit;
     end;
 
@@ -1128,27 +1129,23 @@ begin
   to ask for elevation. }
   if hasPackages then
   begin
-    KL.Log('InstallingState.EnterState hasPackages: True');
     LaunchInstallPackageProcess;
     Exit;
   end;
   // If no packages then install Keyman now
-  KL.Log('InstallingState.EnterState hasPackages: False');
   if hasKeymanInstall then
   begin
-    KL.Log('InstallingState.EnterState hasKeymanInstall: True');
     DoInstallKeyman;
     Exit;
   end;
   // unexpected: should have had either packages or a keyman file
-  KL.Log('InstallingState.EnterState unexpected should have package or install');
   bucStateContext.RemoveCachedFiles;
   ChangeState(IdleState);
 end;
 
 procedure InstallingState.ExitState;
 begin
-  KL.Log('InstallingState.ExitState');
+
 end;
 
 procedure InstallingState.HandleCheck;
@@ -1192,7 +1189,6 @@ begin
   if not kmcom.SystemInfo.IsAdministrator then
   begin
     if hasKeymanInstall then
-      KL.Log('InstallingState.HandleInstallPackages noAdmin hasKeymanInstall: True');
       DoInstallKeyman;
     Exit;
   end;
@@ -1204,7 +1200,6 @@ begin
 
   if hasKeymanInstall then
   begin
-    KL.Log('InstallingState.HandleInstallPackages Admin hasKeymanInstall: True');
     DoInstallKeyman;
   end;
 end;

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -38,8 +38,8 @@ type
 
   public
     constructor Create(Context: TUpdateStateMachine);
-    procedure Enter; virtual; abstract;
-    procedure Exit; virtual; abstract;
+    procedure EnterState; virtual; abstract;
+    procedure ExitState; virtual; abstract;
     procedure HandleCheck; virtual; abstract;
     function  HandleKmShell: Integer; virtual; abstract;
     procedure HandleDownload; virtual; abstract;
@@ -152,8 +152,8 @@ type
   // Derived classes for each state
   IdleState = class(TState)
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -166,8 +166,8 @@ type
   private
     procedure StartDownloadProcess;
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -178,8 +178,8 @@ type
   DownloadingState = class(TState)
   private
     function DownloadUpdatesBackground: Boolean;
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -189,8 +189,8 @@ type
 
   WaitingRestartState = class(TState)
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -224,8 +224,8 @@ type
     procedure LaunchInstallPackageProcess;
 
   public
-    procedure Enter; override;
-    procedure Exit; override;
+    procedure EnterState; override;
+    procedure ExitState; override;
     procedure HandleCheck; override;
     function  HandleKmShell: Integer; override;
     procedure HandleDownload; override;
@@ -446,14 +446,14 @@ procedure TUpdateStateMachine.SetState(const Value: TStateClass);
 begin
   if Assigned(CurrentState) then
   begin
-    CurrentState.Exit;
+    CurrentState.ExitState;
   end;
 
   SetStateOnly(ConvertStateToEnum(Value));
 
   if Assigned(CurrentState) then
   begin
-    CurrentState.Enter;
+    CurrentState.EnterState;
   end
   else
   begin
@@ -601,13 +601,13 @@ end;
 
 { IdleState }
 
-procedure IdleState.Enter;
+procedure IdleState.EnterState;
 begin
   // Enter UpdateAvailableState
   bucStateContext.SetRegistryState(usIdle);
 end;
 
-procedure IdleState.Exit;
+procedure IdleState.ExitState;
 begin
 
 end;
@@ -697,7 +697,7 @@ begin
   end;
 end;
 
-procedure UpdateAvailableState.Enter;
+procedure UpdateAvailableState.EnterState;
 begin
   // Enter UpdateAvailableState
   bucStateContext.SetRegistryState(usUpdateAvailable);
@@ -707,7 +707,7 @@ begin
   end;
 end;
 
-procedure UpdateAvailableState.Exit;
+procedure UpdateAvailableState.ExitState;
 begin
   // Exit UpdateAvailableState
 end;
@@ -760,7 +760,7 @@ end;
 
 { DownloadingState }
 
-procedure DownloadingState.Enter;
+procedure DownloadingState.EnterState;
 var
   DownloadResult: Boolean;
   RetryCount: Integer;
@@ -816,7 +816,7 @@ begin
 
 end;
 
-procedure DownloadingState.Exit;
+procedure DownloadingState.ExitState;
 begin
   // Exit DownloadingState
 end;
@@ -895,13 +895,13 @@ end;
 
 { WaitingRestartState }
 
-procedure WaitingRestartState.Enter;
+procedure WaitingRestartState.EnterState;
 begin
   // Enter WaitingRestartState
   bucStateContext.SetRegistryState(usWaitingRestart);
 end;
 
-procedure WaitingRestartState.Exit;
+procedure WaitingRestartState.ExitState;
 begin
   // Exit DownloadingState
 end;
@@ -1105,7 +1105,7 @@ begin
   Result := True;
 end;
 
-procedure InstallingState.Enter;
+procedure InstallingState.EnterState;
 var
   ucr: TUpdateCheckResponse;
   hasPackages, hasKeymanInstall: Boolean;
@@ -1128,23 +1128,27 @@ begin
   to ask for elevation. }
   if hasPackages then
   begin
+    KL.Log('InstallingState.EnterState hasPackages: True');
     LaunchInstallPackageProcess;
     Exit;
   end;
   // If no packages then install Keyman now
+  KL.Log('InstallingState.EnterState hasPackages: False');
   if hasKeymanInstall then
   begin
+    KL.Log('InstallingState.EnterState hasKeymanInstall: True');
     DoInstallKeyman;
     Exit;
   end;
   // unexpected: should have had either packages or a keyman file
+  KL.Log('InstallingState.EnterState unexpected should have package or install');
   bucStateContext.RemoveCachedFiles;
   ChangeState(IdleState);
 end;
 
-procedure InstallingState.Exit;
+procedure InstallingState.ExitState;
 begin
-
+  KL.Log('InstallingState.ExitState');
 end;
 
 procedure InstallingState.HandleCheck;
@@ -1188,6 +1192,7 @@ begin
   if not kmcom.SystemInfo.IsAdministrator then
   begin
     if hasKeymanInstall then
+      KL.Log('InstallingState.HandleInstallPackages noAdmin hasKeymanInstall: True');
       DoInstallKeyman;
     Exit;
   end;
@@ -1198,7 +1203,10 @@ begin
   end;
 
   if hasKeymanInstall then
+  begin
+    KL.Log('InstallingState.HandleInstallPackages Admin hasKeymanInstall: True');
     DoInstallKeyman;
+  end;
 end;
 
 procedure InstallingState.HandleFirstRun;


### PR DESCRIPTION
Cherry-Pick to stable-18.0

#13831 
and 
#13920

@keymanapp-test-bot skip 

