### PR TITLE
maint(developer): update multer to v2.0.0

### DIFF
--- a/developer/src/server/package.json
+++ b/developer/src/server/package.json
@@ -21,7 +21,7 @@
     "semver": "^7.5.4",
     "ws": "^8.17.1",
     "xmlbuilder": "~11.0.0"
-},
+  },
   "optionalDependencies": {
     "node-hide-console-window": "^2.2.0"
   },
@@ -30,7 +30,7 @@
     "@keymanapp/resources-gosh": "*",
     "@types/express": "^4.17.13",
     "@types/mocha": "^9.1.0",
-    "@types/multer": "^1.4.7",
+    "@types/multer": "^1.4.12",
     "@types/node": "^20.4.1",
     "@types/ws": "^8.2.2",
     "copyfiles": "^2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1167,7 +1167,7 @@
         "@keymanapp/resources-gosh": "*",
         "@types/express": "^4.17.13",
         "@types/mocha": "^9.1.0",
-        "@types/multer": "^1.4.7",
+        "@types/multer": "^1.4.12",
         "@types/node": "^20.4.1",
         "@types/ws": "^8.2.2",
         "copyfiles": "^2.4.1",
@@ -1184,20 +1184,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "developer/src/server/node_modules/multer": {
-      "version": "1.4.5-lts.1",
+    "developer/src/server/node_modules/@types/multer": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
+      "integrity": "sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "append-field": "^1.0.0",
-        "busboy": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.4",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
+        "@types/express": "*"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -3550,14 +3544,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/multer": {
-      "version": "1.4.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "20.12.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
@@ -4743,6 +4729,8 @@
     },
     "node_modules/append-field": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
     "node_modules/arg": {
@@ -5772,6 +5760,8 @@
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "engines": [
         "node >= 0.8"
       ],
@@ -10499,6 +10489,24 @@
       "version": "2.1.2",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.0.tgz",
+      "integrity": "sha512-bS8rPZurbAuHGAnApbM9d4h1wSoYqrOqkE+6a64KLMK9yWU7gJXBDDVklKQ3TPi9DRb85cRs6yXaC0+cjxRtRg==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/nanocolors": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.13.tgz",
@@ -10811,6 +10819,8 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13136,6 +13146,8 @@
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
     },
     "node_modules/typescript": {


### PR DESCRIPTION
Looks like dependabot did not cleanly upgrade multer (#13982). Possibly a bug with workspaces? Removed from package.json, npm install, re-added, npm install to fix the issue.

# User Testing

Apologies for the re-test on this! (I think @Meng-Heng did the last test?)

**TEST_SERVER_UPLOAD:** Open Keyman Developer, start Keyman Developer Server, open http://localhost:8008/, and in the Hamburger menu, select Upload file. Attempt to upload a keyboard .js. Verify that the keyboard and/or package uploads successfully, and is accessible in the Keyboard dropdown.

See-also: #13982