### PR TITLE
fix(windows): fix sentry error message reporting

### DIFF
--- a/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
@@ -103,7 +103,7 @@ destructor TRemoteUpdateCheck.Destroy;
 begin
   if (FErrorMessage <> '') and FShowErrors then
         TKeymanSentryClient.Client.MessageEvent(Sentry.Client.SENTRY_LEVEL_ERROR,
-      '"+FErrorMessage+"');
+      'TRemoteUpdateCheck.Destroy: FErrorMessage = ' + FErrorMessage);
 
   KL.Log('TRemoteUpdateCheck.Destroy: FErrorMessage = ' + FErrorMessage);
   KL.Log('TRemoteUpdateCheck.Destroy: FRemoteResult = ' +

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -55,8 +55,6 @@ type
   private
     FForce: Boolean;
     FAutomaticUpdate: Boolean;
-    FErrorMessage: string;
-    FShowErrors: Boolean;
 
     CurrentState: TState;
     // State object for performance (could lazy create?)
@@ -101,7 +99,6 @@ type
     function ReadyToInstall: Boolean;
     function IsInstallingState: Boolean;
 
-    property ShowErrors: Boolean read FShowErrors write FShowErrors;
     function CheckRegistryState: TUpdateState;
 
   end;
@@ -241,7 +238,6 @@ type
 constructor TUpdateStateMachine.Create(AForce: Boolean);
 begin
   inherited Create;
-  FShowErrors := True;
 
   FForce := AForce;
   FAutomaticUpdate := GetAutomaticUpdates;
@@ -260,16 +256,10 @@ destructor TUpdateStateMachine.Destroy;
 var
   lpState: TUpdateState;
 begin
-  if (FErrorMessage <> '') and FShowErrors then
-    TKeymanSentryClient.Client.MessageEvent(Sentry.Client.SENTRY_LEVEL_ERROR,
-      '"+FErrorMessage+"');
-
   for lpState := Low(TUpdateState) to High(TUpdateState) do
   begin
     FreeAndNil(FStateInstance[lpState]);
   end;
-
-  // TODO: #10210 TODO: epic-windows-update remove debugging comments throughout this Unit.
 
   inherited Destroy;
 end;

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -689,7 +689,6 @@ end;
 function ProcessBackgroundUpdate(FMode: TKMShellMode; FSilent: Boolean) : Boolean;
 var
   BUpdateSM : TUpdateStateMachine;
-  frmStartInstall: TfrmStartInstall;
   SendToBUpdateSM: Boolean;
   SkipBUpdate : Boolean;
 begin


### PR DESCRIPTION
The sending of the value of the string FErrorMessage to sentry was incorrect use of quotes. It was just sending the literal string `FErrorMessage`. This has been updated. Also the pattern was never used in the module `TUpdateStateMachine` instead breadcrumbs and error messages are sent as they occur. Therefore removed it from `TUpdateStateMachine`.  
Also there was an unused variable in initprog.pas that has been removed. 

[KEYMAN-WINDOWS-4VR](https://keyman.sentry.io/issues/6227588380/events/7bd438cf47e44a0b605ac94a4c0d0d7e/?environment=beta&project=5983518&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=next-event&stream_index=0)

@keymanapp-test-bot skip
