### PR TITLE
fix(windows): skip sending handle kmshell events to upgrade state machine for keyboard install modes 🍒  🏠

### DIFF
--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -723,11 +723,13 @@ begin
       else
       begin
         // Since Package upgrade and Keyman upgrade share the installing state
-        // the presense following package related switches means we should
-        // skip running the update state machine HandleKmShell event
-        SkipBUpdate := (FMode in [fmInstallTip,
-        fmInstallTipsForPackages, fmRegisterTip, fmUpgradeKeyboards,
-        fmUpgradeMnemonicLayout]);
+        // the presence of the following package related switches means we 
+        // should skip running the update state machine HandleKmShell event
+        SkipBUpdate := (FMode in [
+          fmInstallTip, fmInstallTipsForPackages, 
+          fmRegisterTip, fmUpgradeKeyboards,
+          fmUpgradeMnemonicLayout
+        ]);
 
         SendToBUpdateSM := ShouldSendToBUpdateSM(FSilent, BUpdateSM, FMode);
 

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -723,11 +723,11 @@ begin
       else
       begin
         // Since Package upgrade and Keyman upgrade share the installing state
-        // the following package related switches are valid in the installing
-        // state.
-        SkipBUpdate := (BUpdateSM.IsInstallingState and (FMode in [fmInstallTip,
+        // the presense following package related switches means we should
+        // skip running the update state machine HandleKmShell event
+        SkipBUpdate := (FMode in [fmInstallTip,
         fmInstallTipsForPackages, fmRegisterTip, fmUpgradeKeyboards,
-        fmUpgradeMnemonicLayout]));
+        fmUpgradeMnemonicLayout]);
 
         SendToBUpdateSM := ShouldSendToBUpdateSM(FSilent, BUpdateSM, FMode);
 


### PR DESCRIPTION
Cherry-pick-of: #13989
Test-bot: skip