### PR TITLE
fix(linux): fix version variable references in kmconfig

### DIFF
--- a/linux/keyman-config/build.sh
+++ b/linux/keyman-config/build.sh
@@ -62,14 +62,14 @@ build_action() {
   builder_echo "Create version.py"
   pushd keyman_config
   sed \
-      -e "s/_KEYMAN_VERSION_/${KEYMAN_VERSION}/g" \
-      -e "s/_KEYMAN_VERSION_WITH_TAG_/${KEYMAN_VERSION_WITH_TAG}/g" \
-      -e "s/_KEYMAN_VERSION_GIT_TAG_/${KEYMAN_VERSION_GIT_TAG}/g" \
-      -e "s/_KEYMAN_VERSION_MAJOR_/${KEYMAN_VERSION_MAJOR}/g" \
-      -e "s/_KEYMAN_VERSION_RELEASE_/${KEYMAN_VERSION_RELEASE}/g" \
-      -e "s/_KEYMAN_TIER_/${KEYMAN_TIER}/g" \
-      -e "s/_KEYMAN_VERSION_ENVIRONMENT_/${KEYMAN_VERSION_ENVIRONMENT}/g" \
-      -e "s/_UPLOAD_SENTRY_/${UPLOAD_SENTRY}/g" \
+      -e "s/__KEYMAN_VERSION__/${KEYMAN_VERSION}/g" \
+      -e "s/__KEYMAN_VERSION_WITH_TAG__/${KEYMAN_VERSION_WITH_TAG}/g" \
+      -e "s/__KEYMAN_VERSION_GIT_TAG__/${KEYMAN_VERSION_GIT_TAG}/g" \
+      -e "s/__KEYMAN_VERSION_MAJOR__/${KEYMAN_VERSION_MAJOR}/g" \
+      -e "s/__KEYMAN_VERSION_RELEASE__/${KEYMAN_VERSION_RELEASE}/g" \
+      -e "s/__KEYMAN_TIER__/${KEYMAN_TIER}/g" \
+      -e "s/__KEYMAN_VERSION_ENVIRONMENT__/${KEYMAN_VERSION_ENVIRONMENT}/g" \
+      -e "s/__UPLOAD_SENTRY__/${UPLOAD_SENTRY}/g" \
       version.py.in > version.py
   popd
   pushd buildtools

--- a/linux/keyman-config/keyman_config/version.py.in
+++ b/linux/keyman-config/keyman_config/version.py.in
@@ -4,12 +4,12 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
-__version__ = "_KEYMAN_VERSION_"
-__versionwithtag__ = "_KEYMAN_VERSION_WITH_TAG_"
-__majorversion__ = "_KEYMAN_VERSION_MAJOR_"
-__releaseversion__ = "_KEYMAN_VERSION_RELEASE_"
-__tier__ = "_KEYMAN_TIER_"
+__version__ = "__KEYMAN_VERSION__"
+__versionwithtag__ = "__KEYMAN_VERSION_WITH_TAG__"
+__majorversion__ = "__KEYMAN_VERSION_MAJOR__"
+__releaseversion__ = "__KEYMAN_VERSION_RELEASE__"
+__tier__ = "__KEYMAN_TIER__"
 __pkgversion__ = "(local)"
-__environment__ = "_KEYMAN_VERSION_ENVIRONMENT_"
-__uploadsentry__ = "_UPLOAD_SENTRY_"
-__versiongittag__ = "_KEYMAN_VERSION_GIT_TAG_"
+__environment__ = "__KEYMAN_VERSION_ENVIRONMENT__"
+__uploadsentry__ = "__UPLOAD_SENTRY__"
+__versiongittag__ = "__KEYMAN_VERSION_GIT_TAG__"

--- a/linux/scripts/reconf.sh
+++ b/linux/scripts/reconf.sh
@@ -32,14 +32,14 @@ quilt new version_py.diff
 quilt add "version.py"
 
 sed \
-    -e "s/_KEYMAN_VERSION_/${KEYMAN_VERSION}/g" \
-    -e "s/_KEYMAN_VERSION_WITH_TAG_/${KEYMAN_VERSION_WITH_TAG}/g" \
-    -e "s/_KEYMAN_VERSION_GIT_TAG_/${KEYMAN_VERSION_GIT_TAG}/g" \
-    -e "s/_KEYMAN_VERSION_MAJOR_/${KEYMAN_VERSION_MAJOR}/g" \
-    -e "s/_KEYMAN_VERSION_RELEASE_/${KEYMAN_VERSION_RELEASE}/g" \
-    -e "s/_KEYMAN_TIER_/${KEYMAN_TIER}/g" \
-    -e "s/_KEYMAN_VERSION_ENVIRONMENT_/${KEYMAN_VERSION_ENVIRONMENT}/g" \
-    -e "s/_UPLOAD_SENTRY_/${UPLOAD_SENTRY}/g" \
+    -e "s/__KEYMAN_VERSION__/${KEYMAN_VERSION}/g" \
+    -e "s/__KEYMAN_VERSION_WITH_TAG__/${KEYMAN_VERSION_WITH_TAG}/g" \
+    -e "s/__KEYMAN_VERSION_GIT_TAG__/${KEYMAN_VERSION_GIT_TAG}/g" \
+    -e "s/__KEYMAN_VERSION_MAJOR__/${KEYMAN_VERSION_MAJOR}/g" \
+    -e "s/__KEYMAN_VERSION_RELEASE__/${KEYMAN_VERSION_RELEASE}/g" \
+    -e "s/__KEYMAN_TIER__/${KEYMAN_TIER}/g" \
+    -e "s/__KEYMAN_VERSION_ENVIRONMENT__/${KEYMAN_VERSION_ENVIRONMENT}/g" \
+    -e "s/__UPLOAD_SENTRY__/${UPLOAD_SENTRY}/g" \
     version.py.in > version.py
 quilt refresh
 quilt pop -a


### PR DESCRIPTION
This fixes the version numbers in `km-config` which broke with #13854. This also fixes opening the download page in `km-config` because that uses a version number in the URL. 

Fixes: #14031
Follow-up-of: #13854

# User Testing

**TEST_VERSION**: Run `km-config --version` in a terminal.  Verify that the displayed version number looks similar to 
`km-config version 19.0.47-alpha (package version 19.0.47-1~sil1~noble)`

**TEST_DOWNLOAD**:
- Open the "Configuration" window using the "km-config" command in the terminal.
- Open the "Download Keyman Keyboards" dialog by clicking the "Download Keyboard" button.
- Verify that the search page appears in the "Download Keyman Keyboards" dialog..