### PR TITLE
chore(web): mark async methods in UI components

### DIFF
--- a/web/src/app/ui/kmwuibutton.ts
+++ b/web/src/app/ui/kmwuibutton.ts
@@ -28,7 +28,7 @@ if(!keymanweb) {
 
   /**
    * Do not enclose in an anonymous function, as the compiler may create
-   * global scope variables to replace true, false, null, whcih can then collide
+   * global scope variables to replace true, false, null, which can then collide
    * with other variables.
    * Instead, use the --output-wrapper command during optimization, which will
    * add the anonymous function to enclose all code, including those optimized
@@ -106,7 +106,7 @@ if(!keymanweb) {
        * @param       {Event}  _id   keyboard selection event
        * @return      {boolean}
        */
-      readonly _SelectKeyboard = (_id: Event) => {
+      readonly _SelectKeyboard = async (_id: Event): Promise<boolean> => {
         let id: string = '';
         if(typeof(_id) == 'object') {
           let t: HTMLElement = null;
@@ -135,7 +135,7 @@ if(!keymanweb) {
             _k.className='selected';
           }
           this._KMWSel = _k;
-          keymanweb.setActiveKeyboard(_name,_lgc);
+          await keymanweb.setActiveKeyboard(_name,_lgc);
         } else {
           _name=null;
         }

--- a/web/src/app/ui/kmwuibutton.ts
+++ b/web/src/app/ui/kmwuibutton.ts
@@ -106,7 +106,7 @@ if(!keymanweb) {
        * @param       {Event}  _id   keyboard selection event
        * @return      {boolean}
        */
-      readonly _SelectKeyboard = async (_id: Event): Promise<boolean> => {
+      private readonly _SelectKeyboard = async (_id: Event): Promise<boolean> => {
         let id: string = '';
         if(typeof(_id) == 'object') {
           let t: HTMLElement = null;
@@ -252,7 +252,7 @@ if(!keymanweb) {
        *
        * @param       {Event}    e     event
        */
-      readonly _SelectorMouseOut = (e: MouseEvent) => {
+      private readonly _SelectorMouseOut = (e: MouseEvent) => {
         if(keymanweb.activatingUI) {
           keymanweb.activatingUI(0);
         }

--- a/web/src/app/ui/kmwuifloat.ts
+++ b/web/src/app/ui/kmwuifloat.ts
@@ -450,7 +450,7 @@ if(!keymanweb) {
        * @param       {Object}    e       event
        * Description  Change active keyboard in response to user selection event
        */
-      readonly SelectKeyboardChange = async (e: Event) => {
+      private readonly SelectKeyboardChange = async (e: Event) => {
         keymanweb.activatingUI(true);
 
         if(this.KeyboardSelector.value != '-') {

--- a/web/src/app/ui/kmwuifloat.ts
+++ b/web/src/app/ui/kmwuifloat.ts
@@ -450,15 +450,15 @@ if(!keymanweb) {
        * @param       {Object}    e       event
        * Description  Change active keyboard in response to user selection event
        */
-      readonly SelectKeyboardChange = (e: Event) => {
+      readonly SelectKeyboardChange = async (e: Event) => {
         keymanweb.activatingUI(true);
 
         if(this.KeyboardSelector.value != '-') {
           const i=this.KeyboardSelector.selectedIndex;
           const t=this.KeyboardSelector.options[i].value.split(':');
-          keymanweb.setActiveKeyboard(t[0],t[1]);
+          await keymanweb.setActiveKeyboard(t[0],t[1]);
         } else {
-          keymanweb.setActiveKeyboard('');
+          await keymanweb.setActiveKeyboard('');
         }
 
         //if(osk['show']) osk['show'](osk['isEnabled']()); handled by keyboard change event???

--- a/web/src/app/ui/kmwuitoggle.ts
+++ b/web/src/app/ui/kmwuitoggle.ts
@@ -187,7 +187,7 @@ if(!keymanweb) {
       /**
        * Toggle a single keyboard on or off - KMW button control event
        **/
-      readonly switchSingleKbd = () => {
+      readonly switchSingleKbd = async () => {
         const _v = keymanweb.getActiveKeyboard() == '';
         let nLastKbd=0, kbdName='', lgCode='';
 
@@ -202,10 +202,10 @@ if(!keymanweb) {
 
           kbdName = this.keyboards[nLastKbd]._InternalName;
           lgCode = this.keyboards[nLastKbd]._LanguageCode;
-          keymanweb.setActiveKeyboard(kbdName,lgCode);
+          await keymanweb.setActiveKeyboard(kbdName,lgCode);
           this.lastActiveKeyboard = nLastKbd;
         } else {
-          keymanweb.setActiveKeyboard('');
+          await keymanweb.setActiveKeyboard('');
         }
 
         if(this.kbdButton) {
@@ -216,7 +216,7 @@ if(!keymanweb) {
       /**
        * Switch to the next keyboard in the list - KMW button control event
        **/
-      readonly switchNextKbd = () => {
+      readonly switchNextKbd = async () => {
         let _v = (keymanweb.getActiveKeyboard() == '');
         let kbdName='', lgCode='';
 
@@ -227,16 +227,16 @@ if(!keymanweb) {
 
           kbdName = this.keyboards[0]._InternalName;
           lgCode = this.keyboards[0]._LanguageCode;
-          keymanweb.setActiveKeyboard(kbdName,lgCode);
+          await keymanweb.setActiveKeyboard(kbdName,lgCode);
           this.lastActiveKeyboard = 0;
         } else {
           if(this.lastActiveKeyboard == this.keyboards.length-1) {
-            keymanweb.setActiveKeyboard('');
+            await keymanweb.setActiveKeyboard('');
             _v = false;
           } else {
             kbdName = this.keyboards[++this.lastActiveKeyboard]._InternalName;
             lgCode = this.keyboards[this.lastActiveKeyboard]._LanguageCode;
-            keymanweb.setActiveKeyboard(kbdName,lgCode);
+            await keymanweb.setActiveKeyboard(kbdName,lgCode);
             _v = true;
           }
         }
@@ -558,7 +558,7 @@ if(!keymanweb) {
        * @param       {number}  _kbd
        * Description  Select a keyboard from the drop down menu
        **/
-      selectKbd(_kbd: number) {
+      async selectKbd(_kbd: number): Promise<boolean> {
         let _name,_lgCode;
         if(_kbd < 0) {
           _name = '';
@@ -568,7 +568,7 @@ if(!keymanweb) {
           _lgCode = this.keyboards[_kbd]._LanguageCode;
         }
 
-        keymanweb.setActiveKeyboard(_name,_lgCode);
+        await keymanweb.setActiveKeyboard(_name,_lgCode);
         keymanweb.focusLastActiveElement();
         this.kbdButton._setSelected(_name != '');
         if(_kbd >= 0) {

--- a/web/src/app/ui/kmwuitoggle.ts
+++ b/web/src/app/ui/kmwuitoggle.ts
@@ -558,7 +558,7 @@ if(!keymanweb) {
        * @param       {number}  _kbd
        * Description  Select a keyboard from the drop down menu
        **/
-      async selectKbd(_kbd: number): Promise<boolean> {
+      private async selectKbd(_kbd: number): Promise<boolean> {
         let _name,_lgCode;
         if(_kbd < 0) {
           _name = '';

--- a/web/src/app/ui/kmwuitoolbar.ts
+++ b/web/src/app/ui/kmwuitoolbar.ts
@@ -820,7 +820,7 @@ if(!keymanweb) {
        * @param       {boolean} updateKeyman
        * @return      {boolean}
        **/
-      async selectKeyboard(event: Event, lang: LanguageEntry, kbd: KeyboardDetail, updateKeyman: boolean) {
+      private async selectKeyboard(event: Event, lang: LanguageEntry, kbd: KeyboardDetail, updateKeyman: boolean) {
         keymanweb.activatingUI(true);
 
         if(this.selectedLanguage) {
@@ -943,7 +943,7 @@ if(!keymanweb) {
        * @return      {boolean}
        * Description  Update the UI when all keyboards disabled by user
        **/
-      readonly offButtonClickEvent = async (event: Event) => {
+      private readonly offButtonClickEvent = async (event: Event) => {
         if(this.toolbarNode.className != 'kmw_controls_disabled') {
           this.hideKeyboardsForLanguage(null);
           if(this.selectedLanguage) {

--- a/web/src/app/ui/kmwuitoolbar.ts
+++ b/web/src/app/ui/kmwuitoolbar.ts
@@ -820,7 +820,7 @@ if(!keymanweb) {
        * @param       {boolean} updateKeyman
        * @return      {boolean}
        **/
-      selectKeyboard(event: Event, lang: LanguageEntry, kbd: KeyboardDetail, updateKeyman: boolean) {
+      async selectKeyboard(event: Event, lang: LanguageEntry, kbd: KeyboardDetail, updateKeyman: boolean) {
         keymanweb.activatingUI(true);
 
         if(this.selectedLanguage) {
@@ -841,7 +841,7 @@ if(!keymanweb) {
         // Return focus to input area and activate the selected keyboard
         this.addKeyboardToList(lang, kbd);
         if(updateKeyman) {
-          keymanweb.setActiveKeyboard(kbd.InternalName, kbd.LanguageCode).then(() => {
+          await keymanweb.setActiveKeyboard(kbd.InternalName, kbd.LanguageCode).then(() => {
             // Restore focus _after_ the keyboard finishes loading.
             this.setLastFocus();
           });
@@ -943,7 +943,7 @@ if(!keymanweb) {
        * @return      {boolean}
        * Description  Update the UI when all keyboards disabled by user
        **/
-      readonly offButtonClickEvent = (event: Event) => {
+      readonly offButtonClickEvent = async (event: Event) => {
         if(this.toolbarNode.className != 'kmw_controls_disabled') {
           this.hideKeyboardsForLanguage(null);
           if(this.selectedLanguage) {
@@ -959,7 +959,7 @@ if(!keymanweb) {
 
         // Return the focus to the input area and set the active keyboard to nothing
         this.setLastFocus();
-        keymanweb.setActiveKeyboard('','');
+        await keymanweb.setActiveKeyboard('','');
 
         //Save current state when deselecting a keyboard (may not be needed)
         this.saveCookie();


### PR DESCRIPTION
Cherry-pick of changes in #12291. Addresses [code review comment](https://github.com/keymanapp/keyman/pull/12291/files/130e697d40d60c9f5a7767f5c574772548ac8cea#r1976381710) made in in #12291. 

This marks async methods in UI components with the `async` keyword. Also explicitly mark them as being `private`.

Test-bot: skip