### PR TITLE
test(kmc-analyze): add test for Warn_PreviousMapFileCouldNotBeLoaded

### DIFF
--- a/developer/src/kmc-analyze/test/analyzer-messages.tests.ts
+++ b/developer/src/kmc-analyze/test/analyzer-messages.tests.ts
@@ -26,4 +26,14 @@ describe('AnalyzerMessages', function () {
   });
 
   // TODO: test each message
+
+  it('Warn_PreviousMapFileCouldNotBeLoaded returns expected message', function () {
+    const msg = AnalyzerMessages.Warn_PreviousMapFileCouldNotBeLoaded({ filename: 'file.map' });
+    if (typeof msg !== 'object') throw new Error('Expected an object');
+    if (!('code' in msg)) throw new Error('Expected message to have a code');
+    if (typeof msg.message !== 'string') throw new Error('Expected message to have a message string');
+
+    if (!msg.message.includes('file.map')) throw new Error('Message does not include filename');
+    if (!msg.message.includes('missing or not a valid JSON')) throw new Error('Unexpected message format');
+  });
 });


### PR DESCRIPTION
### Summary

This PR adds a unit test for the `Warn_PreviousMapFileCouldNotBeLoaded` message in `AnalyzerMessages`.

### Context

This is related to the "good first issue" about low test coverage in `developer/src/kmc-analyze`.

I couldn't run the tests locally on Linux due to Node.js + ESM + ts-node compatibility issues, but I followed the project's existing patterns closely. Feedback welcome!