### PR TITLE
maint: add empty 'scripts' tag to package.json to silence warning

### DIFF
--- a/common/test/resources/package.json
+++ b/common/test/resources/package.json
@@ -3,6 +3,7 @@
   "description": "Common test resources for Keyman's JS & TS-based components & products",
   "type": "module",
   "license": "MIT",
+  "scripts": {},
   "devDependencies": {
     "@keymanapp/resources-gosh": "*",
     "typescript": "^5.4.5"

--- a/common/web/keyman-version/package.json
+++ b/common/web/keyman-version/package.json
@@ -11,6 +11,7 @@
     "/build/"
   ],
   "license": "MIT",
+  "scripts": {},
   "type": "module",
   "devDependencies": {
     "typescript": "^5.4.5"

--- a/core/include/ldml/package.json
+++ b/core/include/ldml/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "type": "module",
   "main": "build/keyman_core_ldml.js",
+  "scripts": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/keymanapp/keyman.git"

--- a/core/tools/api-header-extractor/package.json
+++ b/core/tools/api-header-extractor/package.json
@@ -2,5 +2,6 @@
   "name": "@keymanapp/api-header-extractor",
   "private": true,
   "type": "module",
+  "scripts": {},
   "main": "build/src/index.js"
 }

--- a/developer/src/tike/xml/app/package.json
+++ b/developer/src/tike/xml/app/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/keymanapp/keyman/issues"
   },
   "homepage": "https://keyman.com/",
+  "scripts": {},
   "dependencies": {
     "monaco-editor": "0.15.6"
   }

--- a/resources/gosh/package.json
+++ b/resources/gosh/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/keymanapp/keyman",
   "license": "MIT",
   "bin": {
-    "gosh": "./gosh.js"
+    "gosh": "gosh.js"
   },
   "private": true,
   "files": [
@@ -18,6 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/keymanapp/keyman.git"
   },
+  "scripts": {},
   "bugs": {
     "url": "https://github.com/keymanapp/keyman/issues"
   }

--- a/resources/tools/check-markdown/package.json
+++ b/resources/tools/check-markdown/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "build/index.js",
   "license": "MIT",
+  "scripts": {},
   "devDependencies": {
     "marked": "^14.1.2",
     "chalk": "^2.4.2"


### PR DESCRIPTION
Also removes './' from front of gosh.js to address another npm cleanup (from `npm pkg fix`).

Fixes: #13833
Test-bot: skip