### PR TITLE
maint(web): move TC configuration for Web to script 🔗

### DIFF
--- a/resources/teamcity/includes/tc-helpers.inc.sh
+++ b/resources/teamcity/includes/tc-helpers.inc.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Returns 0 if we're running on Ubuntu.
+is_ubuntu() {
+  if [[ "${OSTYPE:-}" == "linux-gnu" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Returns 0 if we're running on Windows, i.e. if the environment variable
+# `OSTYPE` is set to "msys" or "cygwin".
+is_windows() {
+  if [[ "${OSTYPE:-}" == "msys" ]] || [[ "${OSTYPE:-}" == "cygwin" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Returns 0 if we're running on macOS.
+is_macos() {
+  if [[ "${OSTYPE:-}" == "darwin" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/resources/teamcity/web/keyman-web-release.sh
+++ b/resources/teamcity/web/keyman-web-release.sh
@@ -23,7 +23,9 @@ builder_describe \
   "Run tests for native KeymanWeb" \
   "all            run all actions" \
   "build          build Web + embedded" \
-  "publish        publish release"
+  "publish        publish release" \
+  "--s.keyman.com=S_KEYMAN_COM_PATH        path to s.keyman.com repository" \
+  "--help.keyman.com=HELP_KEYMAN_COM_PATH  path to help.keyman.com repository"
 
 builder_parse "$@"
 
@@ -42,10 +44,10 @@ function _push_release_to_skeymancom() {
   # downloads.keyman.com so we can ensure files are available)
   builder_echo start publish "Publishing release to skeyman.com"
 
-  cd ../../s.keyman.com
+  cd "${S_KEYMAN_COM_PATH:=${KEYMAN_ROOT}/../s.keyman.com}"
   git pull https://github.com/keymanapp/s.keyman.com.git master
   cd ../keyman/web
-  node ../resources/gosh/gosh.js ./ci.sh prepare:s.keyman.com --s.keyman.com ../../s.keyman.com
+  "${KEYMAN_ROOT}/web/ci.sh" prepare:s.keyman.com --s.keyman.com "${S_KEYMAN_COM_PATH}"
 
   builder_echo end publish success "Finished publishing release to skeyman.com"
 }
@@ -68,6 +70,7 @@ function _zip_and_upload_artifacts() {
 function _upload_help() {
   builder_echo start "upload help" "Uploading new Keyman for Web help to help.keyman.com"
 
+  export HELP_KEYMAN_COM="${HELP_KEYMAN_COM_PATH:-${KEYMAN_ROOT}/../help.keyman.com}"
   cd "${KEYMAN_ROOT}/resources/build"
   node ../gosh/gosh.js ./help-keyman-com.sh web
   cd "${KEYMAN_ROOT}/web"

--- a/resources/teamcity/web/keyman-web-release.sh
+++ b/resources/teamcity/web/keyman-web-release.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-# Copyright (C) 2025 SIL International. All rights reserved.
-# Distributed under the MIT License. See LICENSE.md file in the project
-# root for full license information.
+#!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
 #
 # TC build script to build release of KeymanWeb.
 
@@ -24,8 +22,8 @@ builder_describe \
   "all            run all actions" \
   "build          build Web + embedded" \
   "publish        publish release" \
-  "--s.keyman.com=S_KEYMAN_COM_PATH        path to s.keyman.com repository" \
-  "--help.keyman.com=HELP_KEYMAN_COM_PATH  path to help.keyman.com repository"
+  "--s.keyman.com=S_KEYMAN_COM        path to s.keyman.com repository" \
+  "--help.keyman.com=HELP_KEYMAN_COM  path to help.keyman.com repository"
 
 builder_parse "$@"
 
@@ -44,10 +42,10 @@ function _push_release_to_skeymancom() {
   # downloads.keyman.com so we can ensure files are available)
   builder_echo start publish "Publishing release to skeyman.com"
 
-  cd "${S_KEYMAN_COM_PATH:=${KEYMAN_ROOT}/../s.keyman.com}"
+  cd "${S_KEYMAN_COM:=${KEYMAN_ROOT}/../s.keyman.com}"
   git pull https://github.com/keymanapp/s.keyman.com.git master
   cd ../keyman/web
-  "${KEYMAN_ROOT}/web/ci.sh" prepare:s.keyman.com --s.keyman.com "${S_KEYMAN_COM_PATH}"
+  "${KEYMAN_ROOT}/web/ci.sh" prepare:s.keyman.com --s.keyman.com "${S_KEYMAN_COM}"
 
   builder_echo end publish success "Finished publishing release to skeyman.com"
 }
@@ -70,7 +68,7 @@ function _zip_and_upload_artifacts() {
 function _upload_help() {
   builder_echo start "upload help" "Uploading new Keyman for Web help to help.keyman.com"
 
-  export HELP_KEYMAN_COM="${HELP_KEYMAN_COM_PATH:-${KEYMAN_ROOT}/../help.keyman.com}"
+  export HELP_KEYMAN_COM="${HELP_KEYMAN_COM:-${KEYMAN_ROOT}/../help.keyman.com}"
   cd "${KEYMAN_ROOT}/resources/build"
   node ../gosh/gosh.js ./help-keyman-com.sh web
   cd "${KEYMAN_ROOT}/web"

--- a/resources/teamcity/web/keyman-web-release.sh
+++ b/resources/teamcity/web/keyman-web-release.sh
@@ -58,7 +58,9 @@ function _zip_and_upload_artifacts() {
 
   builder_echo start "zip and upload artifacts" "Zipping and uploading artifacts"
 
+  cd "${KEYMAN_ROOT}/resources/teamcity/web"
   powershell -NonInteractive -ExecutionPolicy Bypass -File zip-and-upload-artifacts.ps1
+  cd "${KEYMAN_ROOT}/web"
 
   builder_echo end "zip and upload artifacts" success "Finished zipping and uploading artifacts"
 }
@@ -66,7 +68,9 @@ function _zip_and_upload_artifacts() {
 function _upload_help() {
   builder_echo start "upload help" "Uploading new Keyman for Web help to help.keyman.com"
 
+  cd "${KEYMAN_ROOT}/resources/build"
   node ../gosh/gosh.js ./help-keyman-com.sh web
+  cd "${KEYMAN_ROOT}/web"
 
   builder_echo end "upload help" success "Finished uploading new Keyman for Web help to help.keyman.com"
 }

--- a/resources/teamcity/web/keyman-web-test.sh
+++ b/resources/teamcity/web/keyman-web-test.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-# Copyright (C) 2025 SIL International. All rights reserved.
-# Distributed under the MIT License. See LICENSE.md file in the project
-# root for full license information.
+#!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
 #
 # TC build script for Keyman Web/Test
 

--- a/resources/teamcity/web/keyman-web-test.sh
+++ b/resources/teamcity/web/keyman-web-test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Copyright (C) 2025 SIL International. All rights reserved.
+# Distributed under the MIT License. See LICENSE.md file in the project
+# root for full license information.
+#
+# TC build script for Keyman Web/Test
+
+# shellcheck disable=SC2164
+# shellcheck disable=SC1091
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../resources/build/builder.inc.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+# shellcheck disable=SC2154
+. "${KEYMAN_ROOT}/resources/teamcity/includes/tc-helpers.inc.sh"
+
+################################ Main script ################################
+
+builder_describe \
+  "Run tests for native KeymanWeb" \
+  "all            run all actions" \
+  "configure      install dependencies" \
+  "build          build Web + embedded" \
+  "test           run native KeymanWeb tests and check build size"
+
+builder_parse "$@"
+
+cd "${KEYMAN_ROOT}/web"
+
+function install_dependencies_action() {
+  if is_windows; then
+    return 0
+  fi
+
+  builder_echo start install_dependencies "Installing dependencies"
+
+  if [[ "$(lsb_release -s -i)" == "Ubuntu" ]] && dpkg --compare-versions "$(lsb_release -r -s)" ge "24.04"; then
+    TOINSTALL=""
+      # dependencies for playwright:
+    for p in ibevent-2.1-7t64 libxslt1.1 libwoff1 libvpx9 libgstreamer-plugins-bad1.0-0 libwebpdemux2 libharfbuzz-icu0 libenchant-2-2 libsecret-1-0 libhyphen0 libmanette-0.2-0 libflite1 gstreamer1.0-libav
+    do
+      if ! dpkg -s "${p}" >/dev/null 2>&1; then
+        TOINSTALL="${TOINSTALL} ${p}"
+      fi
+    done
+      if [[ -n "${TOINSTALL}" ]]; then
+        sudo apt-get update
+          sudo DEBIAN_FRONTEND="noninteractive" apt-get install -qy ${TOINSTALL}
+      fi
+  fi
+  builder_echo end install_dependencies success "Finished installing dependencies"
+}
+
+function build_web_action() {
+  builder_echo start web_build "Building KeymanWeb"
+
+  node ../resources/gosh/gosh.js ./ci.sh build
+
+  builder_echo end web_build success "Finished building KeymanWeb"
+}
+
+function test_web_action() {
+  builder_echo start web_test "Running KeymanWeb tests"
+
+  if is_windows; then
+    node ../resources/gosh/gosh.js ./ci.sh test
+  else
+    if [[ "$(lsb_release -s -i)" == "Ubuntu" ]]; then
+      # On Linux start Xvfb etc
+      PID_FILE=/tmp/keymanweb-pids
+      echo "Starting Xvfb..."
+      Xvfb -screen 0 1024x768x24 :33 &> /dev/null &
+      echo "kill -9 $! || true" > "$PID_FILE"
+      sleep 1
+      echo "Starting Xephyr..."
+      DISPLAY=:33 Xephyr :32 -screen 1024x768 &> /dev/null &
+      echo "kill -9 $! || true" >> "$PID_FILE"
+      sleep 1
+      echo "Starting metacity"
+      metacity --display=:32 &> /dev/null &
+      echo "kill -9 $! || true" >> "$PID_FILE"
+      export DISPLAY=:32
+    else
+      # Don't know what's needed on MacOS...
+      touch /tmp/keymanweb-pids
+    fi
+    node ../resources/gosh/gosh.js ./ci.sh test
+    bash /tmp/keymanweb-pids
+  fi
+
+  node ../resources/gosh/gosh.js ./build.sh coverage
+  builder_echo end web_test success "Finished running KeymanWeb tests"
+}
+
+function check_build_size_action() {
+  builder_echo start check_build_size "Checking build size"
+
+  node ../resources/gosh/gosh.js ./ci.sh validate-size
+
+  builder_echo end check_build_size success "Finished checking build size"
+}
+
+if builder_has_action all; then
+  install_dependencies_action
+  build_web_action
+  test_web_action
+  check_build_size_action
+else
+  builder_run_action  configure   install_dependencies_action
+  builder_run_action  build       build_web_action
+  builder_run_action  test        test_web_action
+  builder_run_action  test        check_build_size_action
+fi

--- a/resources/teamcity/web/zip-and-upload-artifacts.ps1
+++ b/resources/teamcity/web/zip-and-upload-artifacts.ps1
@@ -1,0 +1,72 @@
+#
+# This script should be the identical for nightly/beta/stable for a given platform
+#
+$ErrorActionPreference = "Stop";
+
+$tier = Get-Content ..\TIER.md
+$build_number = Get-Content ..\VERSION.md
+$build_counter = $build_number -replace "^\d+\.\d+\.(\d+)$", '$1'
+
+$upload_path = "build\upload\$build_number"
+$zip = "$upload_path\keymanweb-$build_number.zip"
+
+$7Z_HOME = $env:7Z_HOME
+$RSYNC_HOME = $env:RSYNC_HOME
+$USERPROFILE = $env:USERPROFILE
+
+# Since shell-scripting doesn't like number-initial variables, we convert it to a friendlier name.
+$env:SEVEN_Z_HOME=$7Z_HOME
+
+# PowerShell fun: `--` parameters will break a PowerShell command when not escaped in some form.
+# We can build the command in string form first and then execute the string, fortunately.
+$cmd = '"C:\Program Files\Git\bin\bash.exe" --init-file "c:\Program Files\Git\etc\profile" -l ./ci.sh prepare:downloads.keyman.com'
+cmd /c $cmd
+
+$hash = get-filehash $zip -Algorithm MD5
+
+#
+# Construct .build_info
+#
+
+$download_info = @"
+{
+  "name": "KeymanWeb",
+  "version": "$build_number",
+  "date": "$([DateTime]::Now.ToString("yyyy-MM-dd"))",
+  "platform": "web",
+  "stability": "$tier",
+  "file": "keymanweb-$build_number.zip",
+  "md5": "$($hash.Hash)",
+  "type": "zip",
+  "build": "$build_counter"
+}
+"@
+
+# WriteAllLines is needed to avoid BOM
+[System.IO.File]::WriteAllLines("$pwd\$upload_path\keymanweb-$build_number.zip.download_info", $download_info)
+# $download_info | Out-File $upload_path\keymanweb-$build_number.zip.download_info -Encoding utf8
+
+#
+# Upload with rsync to downloads.keyman.com
+# (rsync requires that we are in the upload folder to get folders in
+# sync correctly; it is possible to resolve this but easier to just cd.)
+#
+
+$rsync_args = @(
+  '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
+  '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
+  '--stats',                                # show statistics for log
+  '--rsync-path="%downloads_rsync_path%"',    # path on remote server
+  "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
+  "$build_number",                          # upload the whole build folder
+  "%downloads_rsync_user%@%downloads_rsync_host%:%downloads_rsync_root%/web/$tier/" # target server + path
+)
+
+# Write-Output "rsync parameters:" $rsync_args
+
+cd "$upload_path\.."
+& $RSYNC_HOME\rsync.exe $rsync_args
+if ($LASTEXITCODE -ne 0) { throw "Exit code is $LASTEXITCODE" }
+cd ..
+
+# EOF


### PR DESCRIPTION
This matches the existing TC configuration as closely as possible. It also puts the scripts in `resources/teamcity/web`, but doesn't relocate the Linux scripts ~~until we decide where things should go~~.

Part-of: #13399
Test-bot: skip
