### PR TITLE
fix(common): properly use newly installed node version

### DIFF
--- a/resources/build/_builder_nvm.sh
+++ b/resources/build/_builder_nvm.sh
@@ -41,8 +41,10 @@ type -t nvm >/dev/null || {
   }
 }
 
-nvm use "$REQUIRED_NODE_VERSION" || \
-  (nvm install "$REQUIRED_NODE_VERSION" && nvm use "$REQUIRED_NODE_VERSION")
+if ! nvm use "${REQUIRED_NODE_VERSION}"; then
+  nvm install "${REQUIRED_NODE_VERSION}"
+  nvm use "${REQUIRED_NODE_VERSION}"
+fi
 
 # Beware the hardcoded path below -- it should already be in the system PATH
 


### PR DESCRIPTION
Previously, if we had to install a new node version, we activated it in the same subshell as the installation. This had the effect that `NVM_BIN` was set to the new version only in the subshell, but otherwise it still had the wrong value. This caused build failures. Subsequent builds would succeed because the node version was now available.

This change fixes things by using an explicit `if` instead of the construct with parens which opened another subshell. 

Fixes: #14056
Test-bot: skip