### PR TITLE
fix(developer): ensure that kmc doesn't skip validate phase of kmc-ldml 🙀 

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -136,7 +136,7 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
     if (!source) {
       return null;
     }
-    const kmx = await this.compile(source);
+    const kmx = await this.compile(source, true);
     if (!kmx) {
       return null;
     }
@@ -352,6 +352,8 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
    * Transforms in-memory LDML keyboard xml file to an intermediate
    * representation of a .kmx file.
    * @param   source - in-memory representation of LDML keyboard xml file
+   * @param   postValidate - pass true if sections should run a 'validate' phase at the very end.
+   *                         Set this to true if you aren't calling validate() separately.
    * @returns          KMXPlusFile intermediate file
    */
   public async compile(source: LDMLKeyboardXMLSourceFile, postValidate?: boolean): Promise<KMXPlus.KMXPlusFile> {


### PR DESCRIPTION
- there's no public API for validate()
- kmc calls `.run()`
- but `.run()` doesn't call validate() and then compile(), it only calls `compile()`
- so it needs to call compile() with postValidation=true

Fixes: #14067

@keymanapp-test-bot skip