### PR TITLE
fix(developer): ldml: make sure .run() calls compile() for validation 🍒  🏠

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/compiler.ts
@@ -131,7 +131,7 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
     if (!source) {
       return null;
     }
-    let kmx = await this.compile(source);
+    const kmx = await this.compile(source, true);
     if (!kmx) {
       return null;
     }
@@ -344,6 +344,8 @@ export class LdmlKeyboardCompiler implements KeymanCompiler {
    * Transforms in-memory LDML keyboard xml file to an intermediate
    * representation of a .kmx file.
    * @param   source - in-memory representation of LDML keyboard xml file
+   * @param   postValidate - pass true if sections should run a 'validate' phase at the very end.
+   *                         Set this to true if you aren't calling validate() separately.
    * @returns          KMXPlusFile intermediate file
    */
   public async compile(source: LDMLKeyboardXMLSourceFile, postValidate?: boolean): Promise<KMXPlus.KMXPlusFile> {


### PR DESCRIPTION
- .run() doesn't call validate() and then compile(), so it needs to call compile() with postValidation=true

Fixes: #14067
(cherry picked from commit c70464e23f59505b409989e7d46349a7a47d08a8) and #14068

# User Testing

- TEST_COMPILE: Download [developer/src/kmc-ldml/test/fixtures/sections/strs/invalid-illegal.xml](https://github.com/keymanapp/keyman/blob/master/developer/src/kmc-ldml/test/fixtures/sections/strs/invalid-illegal.xml).  Open Keyman Developer. (May need to make a new LDML project.)  Open `invalid-illegal.xml` as a file.  Choose Compile Keyboard.   Compilation should FAIL with something like `error KM00025: File contains 5 illegal character(s), including Illegal (U+FDD0)`