### PR TITLE
maint(linux): fix typo of temporary dependency package 🏠

### DIFF
--- a/linux/scripts/package-build.inc.sh
+++ b/linux/scripts/package-build.inc.sh
@@ -78,5 +78,5 @@ function checkAndInstallRequirements()
 
 	sudo mk-build-deps debian/control
 	wait_for_apt_deb && sudo apt-get -qy --allow-downgrades install ./keyman-build-deps_*.deb
-	sudo rm -f keyman-build-deps_*
+	rm -f keyman-build-deps_*
 }


### PR DESCRIPTION
This fixes a typo when we try to remove the temporary files created during dependency installation. This caused build failures because the wrong spelling was not in the list of allowed commands, so sudo kept asking for a password.

Also remove `sudo` from command. Since we have write access to the directory we don't need `sudo` for removing the temporary dependency files if we pass `-f` to `rm`.

Test-bot: skip