### PR TITLE
maint(linux): `sudo` not required for removing temporary files 🍒

### DIFF
--- a/linux/scripts/package-build.inc.sh
+++ b/linux/scripts/package-build.inc.sh
@@ -78,5 +78,5 @@ function checkAndInstallRequirements()
   sudo mk-build-deps debian/control
   wait_for_apt_deb && sudo DEBIAN_FRONTEND="noninteractive" \
     apt-get -qy --allow-downgrades install ./keyman-build-deps_*.deb
-  sudo rm -f keyman-build-deps_*
+  rm -f keyman-build-deps_*
 }


### PR DESCRIPTION
Since we have write access to the directory we don't need `sudo` for removing the temporary dependency files if we pass `-f` to `rm`.
    
Cherry-pick-of: commit 4f27f6e256995e4513c700eba9fa7c7b3cec0a33
Cherry-pick-of: #14085
Test-bot: skip