### PR TITLE
maint(linux): update to new version of gha-ubuntu-packaging

### DIFF
--- a/.github/actions/build-binary-packages/action.yml
+++ b/.github/actions/build-binary-packages/action.yml
@@ -31,7 +31,7 @@ runs:
         path: artifacts/keyman-srcpkg
 
     - name: Build
-      uses: sillsdev/gha-ubuntu-packaging@b619077451b27c16dc6fd699bc1daf8d5ce07659 # v1.2
+      uses: sillsdev/gha-ubuntu-packaging@1ab4a5967afbadab82a480936b9e53d7190acdf2 # v2.0
       with:
         dist: "${{ inputs.dist }}"
         platform: "${{ inputs.arch }}"


### PR DESCRIPTION
Version 2.0 of gha-ubuntu-packaging retries 5 times to install the packages, so hopefully this will improve the reliability. 

Test-bot: skip