### PR TITLE
maint(linux): update to new version of gha-ubuntu-packaging

### DIFF
--- a/.github/actions/build-binary-packages/action.yml
+++ b/.github/actions/build-binary-packages/action.yml
@@ -31,7 +31,7 @@ runs:
         path: artifacts/keyman-srcpkg
 
     - name: Build
-      uses: sillsdev/gha-ubuntu-packaging@1ab4a5967afbadab82a480936b9e53d7190acdf2 # v2.0
+      uses: sillsdev/gha-ubuntu-packaging@556b268762be9bea0f39861a7392587211ef6a58 # v2.0.1
       with:
         dist: "${{ inputs.dist }}"
         platform: "${{ inputs.arch }}"


### PR DESCRIPTION
The previous version 2.0 of gha-ubuntu-packaging was missing `--` to separate the command to be called from `retry`, so the arguments for that command were considered arguments for `retry`. The new version 2.0.1 of gha-ubuntu-packaging fixes this.

Follow-up-of: #14089
Test-bot: skip