### PR TITLE
maint(linux): update to new version of gha-ubuntu-packaging 🍒 🏠

### DIFF
--- a/.github/actions/build-binary-packages/action.yml
+++ b/.github/actions/build-binary-packages/action.yml
@@ -31,7 +31,7 @@ runs:
         path: artifacts/keyman-srcpkg
 
     - name: Build
-      uses: sillsdev/gha-ubuntu-packaging@7b56f50d5d5537e9e9cafd3f6139ec6da69cfcda # v1.1
+      uses: sillsdev/gha-ubuntu-packaging@556b268762be9bea0f39861a7392587211ef6a58 # v2.0.1
       with:
         dist: "${{ inputs.dist }}"
         platform: "${{ inputs.arch }}"


### PR DESCRIPTION
Version 2.0.1 of gha-ubuntu-packaging retries 5 times to install the packages, so hopefully this will improve the reliability. 

Cherry-pick-of: #14089
Cherry-pick-of: #14094
Test-bot: skip