### PR TITLE
feat(developer): ldml: update errors for unparseable reorder

### DIFF
--- a/common/web/types/src/kmx/kmx-plus/element-string.ts
+++ b/common/web/types/src/kmx/kmx-plus/element-string.ts
@@ -81,9 +81,9 @@ export class ElementString extends Array<ElemElement> {
           // error. So we can just exit here.
           return null; // UnicodeSet error
         }
-        const uset = sections.usetparser.parseUnicodeSet(item.segment, needRanges);
+        const uset = sections.usetparser.parseUnicodeSet(item.segment, needRanges, options?.x);
         if (!uset) {
-          return null; // UnicodeSet error already thrown
+          return null; // UnicodeSet error already added to callback
         }
         elem.uset = sections.uset.allocUset(uset, sections, options?.x);
         elem.value = sections.strs.allocString('', {...options, singleOk: true}); // no string

--- a/common/web/types/src/ldml-keyboard/unicodeset-parser-api.ts
+++ b/common/web/types/src/ldml-keyboard/unicodeset-parser-api.ts
@@ -8,13 +8,13 @@ export interface UnicodeSetParser {
    * @param pattern string to parse such as `[a-z]`
    * @param rangeCount number of ranges to allow for
    */
-  parseUnicodeSet(pattern: string, rangeCount: number) : UnicodeSet | null;
+  parseUnicodeSet(pattern: string, rangeCount: number, x?: any) : UnicodeSet | null;
   /**
    * Calculate the number of ranges in a UnicodeSet
    * @param pattern string to parse such as `[a-z]`
    * @returns number of ranges, or -1 (with callback-reported err) on err
    */
-  sizeUnicodeSet(pattern: string) : number;
+  sizeUnicodeSet(pattern: string, x?: any) : number;
 }
 
 /**

--- a/developer/src/common/web/utils/src/compiler-interfaces.ts
+++ b/developer/src/common/web/utils/src/compiler-interfaces.ts
@@ -1,4 +1,6 @@
 import { CompilerCallbacks } from "./compiler-callbacks.js";
+import { ObjectWithMetadata } from "./symbol-utils.js";
+import { KeymanXMLReader, XML_FILENAME_SYMBOL } from "./xml-utils.js";
 
 /**
  * Abstract interface for compiler error and warning messages
@@ -205,6 +207,27 @@ export class CompilerError {
       }
     }
     return null;
+  }
+
+    /**
+   * Get an offset from o and set event's offset field
+   * @param event a compiler event, such as from functions in this class
+   * @param x any object parsed from XML or with the XML_META_DATA_SYMBOL symbol copied over
+   * @returns modified event object
+   */
+  public static setFromMetadata(event: CompilerEvent, x?: ObjectWithMetadata): CompilerEvent {
+    if(x) {
+      const metadata = KeymanXMLReader.getMetaData(x) || {};
+      const offset = metadata?.startIndex;
+      if (offset) {
+        event.offset = offset;
+      }
+      const filename = event.filename || metadata[XML_FILENAME_SYMBOL];
+      if (filename) {
+        event.filename = filename;
+      }
+    }
+    return event;
   }
 };
 
@@ -422,6 +445,40 @@ export function dedentCompilerMessageDetail(event: CompilerEvent) {
   // non-zero whitespace line as amount to dedent
   return (event.detail ?? '').replace(/^[ ]+/gm, '');
 }
+
+/**
+ * Convenience function for constructing CompilerEvents with line numbers.
+ * Use it as below: (abbreviated as mx())
+ *
+ * ```js
+ *  // Note: Indentation makes "InvalidScanCode" line up thrice
+ *  static ERROR_InvalidScanCode = SevError | 0x0009;
+ *  // Note:
+ *  //   1. All parameters are passed in 'o', the context object is only used for context even if
+ *  //      it contains redundant info.
+ *  //   2. No code execution within the arrow function other than the 'mx' call, string interpolation,
+ *  //      with `${def(o.property)}` as the max complexity of interpolation.
+ *  static Error_InvalidScanCode = (o:{id: string, invalidCodeList: string}, x: ObjectWithMetadata) => mx(
+ *    this.ERROR_InvalidScanCode, x,
+ *  `Form '${def(o.id)}' has invalid/unknown scancodes '${def(o.codes)}'`,
+ *  // Note: If detail is omitted, leave the trailing comma on the prior line to leave room for it
+ *  `…additional markdown detail…`
+ *  );
+ * ```
+ *
+ * @param code     Unique numeric value of the event
+ * @param message  A short description of the error presented to the user
+ * @param context  Object to be used as a source for line number information
+ * @param detail   Detailed Markdown-formatted description of the error
+ *                 including references to documentation, remediation options.
+ * @see CompilerMessageSpec
+ * @returns the event
+ */
+export function CompilerMessageObjectSpec(code: number, context: ObjectWithMetadata, message: string, detail?: string): CompilerEvent {
+  let evt = CompilerMessageSpec(code, message, detail); // constructs raw message
+  evt = CompilerError.setFromMetadata(evt, context); // updates with offset from context
+  return evt;
+};
 
 export const CompilerMessageDef = (param: any) => String(param ?? `<param>`);
 

--- a/developer/src/common/web/utils/src/index.ts
+++ b/developer/src/common/web/utils/src/index.ts
@@ -48,7 +48,7 @@ export {
 
 export { defaultCompilerOptions, CompilerBaseOptions, CompilerOptions, CompilerEvent, CompilerErrorNamespace,
   CompilerErrorSeverity,  CompilerCallbackOptions,
-  CompilerError, CompilerMessageSpec, CompilerMessageSpecWithException, compilerErrorSeverity, CompilerErrorMask, compilerErrorSeverityName,
+  CompilerError, CompilerMessageSpec, CompilerMessageObjectSpec, CompilerMessageSpecWithException, compilerErrorSeverity, CompilerErrorMask, compilerErrorSeverityName,
   compilerErrorFormatCode, CompilerMessageDef,
   compilerLogLevelToSeverity, CompilerLogLevel, compilerEventFormat, ALL_COMPILER_LOG_LEVELS,
   ALL_COMPILER_LOG_FORMATS, CompilerLogFormat,

--- a/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
+++ b/developer/src/kmc-kmn/src/compiler/kmn-compiler-messages.ts
@@ -1,6 +1,6 @@
 import { KeyAddress } from "../kmw-compiler/validate-layout-file.js";
 import { kmnfile } from "../kmw-compiler/compiler-globals.js";
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec as m, CompilerMessageDef as def, CompilerMessageSpecWithException, KeymanUrls } from "@keymanapp/developer-utils";
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerEvent, CompilerMessageSpec as m, CompilerMessageObjectSpec as mx, CompilerMessageDef as def, CompilerMessageSpecWithException, KeymanUrls, ObjectWithMetadata } from "@keymanapp/developer-utils";
 
 const Namespace = CompilerErrorNamespace.KmnCompiler;
 const SevInfo = CompilerErrorSeverity.Info | Namespace;
@@ -12,6 +12,9 @@ const SevFatal = CompilerErrorSeverity.Fatal | Namespace;
 // For messages from the KeymanWeb compiler, we need to construct our messages
 // slightly differently. This could be refactored in the future, as it is not
 // obvious which messages should use which function.
+// Specifically, this could perhaps use CompilerFileCallbacks which provides a
+// default filename.
+// Then, there could be a CompilerMessageSpecWithLine
 const mw = (code: number, message: string, o?: {filename?: string, line?: number}) : CompilerEvent => ({
   ...m(code, message),
   filename: o?.filename ?? kmnfile,
@@ -104,9 +107,8 @@ export class KmnCompilerMessages {
   );
 
   static FATAL_UnicodeSetOutOfRange = SevFatal | 0x904;
-  static Fatal_UnicodeSetOutOfRange = () => CompilerMessageSpecWithException(
-    this.FATAL_UnicodeSetOutOfRange,
-    null,
+  static Fatal_UnicodeSetOutOfRange = (x?: ObjectWithMetadata) => mx(
+    this.FATAL_UnicodeSetOutOfRange, x,
     `UnicodeSet buffer was too small`,
     `Raised when caller to UnicodeSet functions provides an invalid buffer. If
     you experience this error, it should be reported to the Keyman team for
@@ -116,8 +118,8 @@ export class KmnCompilerMessages {
   // TODO: rename the following functions to Error_UsetHasStrings etc
 
   static ERROR_UnicodeSetHasStrings = SevError | 0x905;
-  static Error_UnicodeSetHasStrings = () => m(
-    this.ERROR_UnicodeSetHasStrings,
+  static Error_UnicodeSetHasStrings = (x?: ObjectWithMetadata) => mx(
+    this.ERROR_UnicodeSetHasStrings, x,
     `uset contains strings, not allowed`,
     `The provided uset uses multi-character strings, (\`{}\` notation, e.g.
     \`[żġħ{ie}{għ}]\`. ). Although full UnicodeSets support strings, LDML
@@ -128,8 +130,8 @@ export class KmnCompilerMessages {
   );
 
   static ERROR_UnicodeSetHasProperties = SevError | 0x906;
-  static Error_UnicodeSetHasProperties = () => m(
-    this.ERROR_UnicodeSetHasProperties,
+  static Error_UnicodeSetHasProperties = (x?: ObjectWithMetadata) => mx(
+    this.ERROR_UnicodeSetHasProperties, x,
     `uset contains properties, not allowed`,
     `The provided uset uses property notation (\`\\p{…}\` or \`[:…:]\`). LDML
     keyboards do not support Unicode properties in usets, because that would
@@ -140,8 +142,8 @@ export class KmnCompilerMessages {
   );
 
   static ERROR_UnicodeSetSyntaxError = SevError | 0x907;
-  static Error_UnicodeSetSyntaxError = () => m(
-    this.ERROR_UnicodeSetSyntaxError,
+  static Error_UnicodeSetSyntaxError = (x?: ObjectWithMetadata) => mx(
+    this.ERROR_UnicodeSetSyntaxError, x,
     `uset had a Syntax Error while parsing`,
     `The provided uset has a syntax error and could not be parsed. Verify the
     format of the uset against the specification.

--- a/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
@@ -270,11 +270,7 @@ export class LdmlCompilerMessages {
     `File has character classes which include non-NFD characters(s), including ${util.describeCodepoint(o.lowestCh)}. These will not match any text.`,
   );
 
-  static ERROR_UnparseableReorderSet = SevError | 0x0028;
-  static Error_UnparseableReorderSet = (o: { from: string, set: string }, x?: ObjectWithMetadata) => mx(
-    this.ERROR_UnparseableReorderSet, x,
-    `Illegal UnicodeSet "${def(o.set)}" in reorder "${def(o.from)}`,
-  );
+  // Available: 0x0028
 
   static ERROR_InvalidVariableIdentifier = SevError | 0x0029;
   static Error_InvalidVariableIdentifier = (o: { id: string }, x?: ObjectWithMetadata) => mx(

--- a/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
@@ -1,5 +1,5 @@
 import { util } from "@keymanapp/common-types";
-import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageSpec as m, CompilerMessageDef as def, XML_FILENAME_SYMBOL, CompilerEvent, KeymanXMLReader, ObjectWithMetadata } from '@keymanapp/developer-utils';
+import { CompilerErrorNamespace, CompilerErrorSeverity, CompilerMessageObjectSpec as mx, CompilerMessageSpec as m, CompilerMessageDef as def, ObjectWithMetadata } from '@keymanapp/developer-utils';
 // const SevInfo = CompilerErrorSeverity.Info | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevHint = CompilerErrorSeverity.Hint | CompilerErrorNamespace.LdmlKeyboardCompiler;
 const SevWarn = CompilerErrorSeverity.Warn | CompilerErrorNamespace.LdmlKeyboardCompiler;
@@ -8,42 +8,6 @@ const SevError = CompilerErrorSeverity.Error | CompilerErrorNamespace.LdmlKeyboa
 
 // sub-numberspace for transform errors
 const SevErrorTransform = SevError | 0xF00;
-
-/**
- * Convenience function for constructing CompilerEvents with line numbers.
- * Use it as below: (abbreviated as mx())
- *
- * ```js
- *  // Note: Indentation makes "InvalidScanCode" line up thrice
- *  static ERROR_InvalidScanCode = SevError | 0x0009;
- *  // Note:
- *  //   1. All parameters are passed in 'o', the context object is only used for context even if
- *  //      it contains redundant info.
- *  //   2. No code execution within the arrow function other than the 'mx' call, string interpolation,
- *  //      with `${def(o.property)}` as the max complexity of interpolation.
- *  static Error_InvalidScanCode = (o:{id: string, invalidCodeList: string}, x: ObjectWithMetadata) => mx(
- *    this.ERROR_InvalidScanCode, x,
- *  `Form '${def(o.id)}' has invalid/unknown scancodes '${def(o.codes)}'`,
- *  // Note: If detail is omitted, leave the trailing comma on the prior line to leave room for it
- *  `…additional markdown detail…`
- *  );
- * ```
- *
- * @param code     Unique numeric value of the event
- * @param message  A short description of the error presented to the user
- * @param context  Object to be used as a source for line number information
- * @param detail   Detailed Markdown-formatted description of the error
- *                 including references to documentation, remediation options.
- * @see CompilerMessageSpec
- * @returns
- */
-function CompilerMessageObjectSpec(code: number, context: ObjectWithMetadata, message: string, detail?: string): CompilerEvent {
-  let evt = m(code, message, detail); // constructs raw message
-  evt = LdmlCompilerMessages.offset(evt, context); // updates with offset from context
-  return evt;
-};
-
-const mx = CompilerMessageObjectSpec;
 
 /**
  * @internal
@@ -408,25 +372,4 @@ export class LdmlCompilerMessages {
     this.ERROR_UnparseableTransformTo, x,
     `Invalid transform to="${def(o.to)}": "${def(o.message)}"`,
   );
-
-  /**
-   * Get an offset from o and set e's offset field
-   * @param event a compiler event, such as from functions in this class
-   * @param x any object parsed from XML or with the XML_META_DATA_SYMBOL symbol copied over
-   * @returns modified event object
-   */
-  static offset(event: CompilerEvent, x?: any): CompilerEvent {
-    if(x) {
-      const metadata = KeymanXMLReader.getMetaData(x) || {};
-      const offset = metadata?.startIndex;
-      if (offset) {
-        event.offset = offset;
-      }
-      const filename = event.filename || metadata[XML_FILENAME_SYMBOL];
-      if (filename) {
-        event.filename = filename;
-      }
-    }
-    return event;
-  }
 }


### PR DESCRIPTION
- Push CompilerMessageObjectSpec up into developer-utils
- add mx() to the unicodeset functions in kmc-kmn
- add an optional context object to unicodeset 
- [x] delete the unparseable reorder message, because it will instead be a UnicodeSet message.

Fixes: #14091

@keymanapp-test-bot skip