### PR TITLE
maint(web): fix working directory for zipping artifacts for Web release

### DIFF
--- a/resources/teamcity/web/keyman-web-release.sh
+++ b/resources/teamcity/web/keyman-web-release.sh
@@ -58,9 +58,7 @@ function _zip_and_upload_artifacts() {
 
   builder_echo start "zip and upload artifacts" "Zipping and uploading artifacts"
 
-  cd "${KEYMAN_ROOT}/resources/teamcity/web"
   powershell -NonInteractive -ExecutionPolicy Bypass -File zip-and-upload-artifacts.ps1
-  cd "${KEYMAN_ROOT}/web"
 
   builder_echo end "zip and upload artifacts" success "Finished zipping and uploading artifacts"
 }

--- a/resources/teamcity/web/zip-and-upload-artifacts.ps1
+++ b/resources/teamcity/web/zip-and-upload-artifacts.ps1
@@ -1,6 +1,8 @@
 #
 # This script should be the identical for nightly/beta/stable for a given platform
 #
+# Working directory should be ${KEYMAN_ROOT}/web
+#
 $ErrorActionPreference = "Stop";
 
 $tier = Get-Content ..\TIER.md


### PR DESCRIPTION
This fixes the Keyman for Web release builds - the script expects to be run from `${KEYMANROOT}/web`.

Test-bot: skip