### PR TITLE
refactor(web): rename `OutputTarget` interface → `OutputTargetInterface` 🎼

### DIFF
--- a/web/src/app/browser/src/configuration.ts
+++ b/web/src/app/browser/src/configuration.ts
@@ -1,7 +1,7 @@
 import { EngineConfiguration, InitOptionSpec, InitOptionDefaults } from "keyman/engine/main";
 
 import { OutputTargetElementWrapper as DOMOutputTarget } from 'keyman/engine/element-wrappers';
-import { OutputTarget } from 'keyman/engine/keyboard';
+import { OutputTargetInterface } from 'keyman/engine/keyboard';
 import { isEmptyTransform, RuleBehavior } from 'keyman/engine/js-processor';
 import { AlertHost } from "./utils/alertHost.js";
 import { whenDocumentReady } from "./utils/documentReady.js";
@@ -66,7 +66,7 @@ export class BrowserConfiguration extends EngineConfiguration {
     return baseReport;
   }
 
-  onRuleFinalization(ruleBehavior: RuleBehavior, outputTarget: OutputTarget) {
+  onRuleFinalization(ruleBehavior: RuleBehavior, outputTarget: OutputTargetInterface) {
     // TODO: Patch up to modularized form.  But that doesn't exist yet for some of these...
 
     // If the transform isn't empty, we've changed text - which should produce a 'changed' event in the DOM.

--- a/web/src/app/browser/src/defaultBrowserRules.ts
+++ b/web/src/app/browser/src/defaultBrowserRules.ts
@@ -3,7 +3,7 @@ import {
   Codes,
   DefaultRules,
   type KeyEvent,
-  type OutputTarget
+  type OutputTargetInterface
 } from 'keyman/engine/keyboard';
 
 import ContextManager from './contextManager.js';
@@ -32,7 +32,7 @@ export default class DefaultBrowserRules extends DefaultRules {
   /**
    * applyCommand - used when a RuleBehavior represents a non-text "command" within the Engine.
    */
-  applyCommand(Lkc: KeyEvent, outputTarget: OutputTarget): void {
+  applyCommand(Lkc: KeyEvent, outputTarget: OutputTargetInterface): void {
     const code = this.codeForEvent(Lkc);
 
     const moveToNext = (back: boolean) => {

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -1,5 +1,5 @@
-import { JSKeyboard, Keyboard, OutputTarget } from 'keyman/engine/keyboard';
-// TODO-web-core: remove usage of OutputTargetBase, use OutputTarget instead
+import { JSKeyboard, Keyboard, OutputTargetInterface } from 'keyman/engine/keyboard';
+// TODO-web-core: remove usage of OutputTargetBase, use OutputTargetInterface instead
 import { Mock, Transcription, findCommonSubstringEndIndex, isEmptyTransform, TextTransform, OutputTargetBase } from 'keyman/engine/js-processor';
 import { KeyboardStub } from 'keyman/engine/keyboard-storage';
 import { ContextManagerBase } from 'keyman/engine/main';
@@ -59,7 +59,7 @@ export class ContextHost extends Mock {
     this.savedState = Mock.from(this);
   }
 
-  restoreTo(original: OutputTarget): void {
+  restoreTo(original: OutputTargetInterface): void {
     this.savedState = Mock.from(this);
     // TODO-web-core
     super.restoreTo(original as OutputTargetBase);
@@ -139,7 +139,7 @@ export default class ContextManager extends ContextManagerBase<WebviewConfigurat
     return this._activeKeyboard;
   }
 
-  activateKeyboardForTarget(kbd: {keyboard: JSKeyboard, metadata: KeyboardStub}, target: OutputTarget) {
+  activateKeyboardForTarget(kbd: { keyboard: JSKeyboard, metadata: KeyboardStub }, target: OutputTargetInterface) {
     // `target` is irrelevant for `app/webview`, as it'll only ever use 'global' keyboard settings.
 
     // Clone the object to prevent accidental by-reference changes.

--- a/web/src/engine/attachment/src/outputTargetForElement.ts
+++ b/web/src/engine/attachment/src/outputTargetForElement.ts
@@ -2,7 +2,7 @@ import { nestedInstanceOf } from "keyman/engine/element-wrappers";
 
 /**
  * Given a DOM event related to an KMW-attached element, this function determines
- * the corresponding OutputTarget.
+ * the corresponding OutputTargetInterface.
  * @param e
  * @returns
  */
@@ -13,7 +13,7 @@ export function eventOutputTarget(e: Event) {
 
 /**
  * Given a DOM event related to an KMW-attached element, this function determines
- * the corresponding OutputTarget.
+ * the corresponding OutputTargetInterface.
  * @param e
  * @returns
  */
@@ -42,7 +42,7 @@ export function outputTargetForElement(Ltarg: HTMLElement) {
     }
   }
 
-  // Step 2:  With the most likely host element determined, obtain the corresponding OutputTarget
+  // Step 2:  With the most likely host element determined, obtain the corresponding OutputTargetInterface
   // instance.
   return Ltarg._kmwAttachment?.interface;
 }

--- a/web/src/engine/interfaces/src/prediction/languageProcessor.interface.ts
+++ b/web/src/engine/interfaces/src/prediction/languageProcessor.interface.ts
@@ -1,6 +1,6 @@
 import { LexicalModelTypes } from '@keymanapp/common-types';
 import { EventEmitter } from "eventemitter3";
-import { OutputTarget } from "keyman/engine/keyboard";
+import { OutputTargetInterface } from "keyman/engine/keyboard";
 
 export class ReadySuggestions {
   suggestions: LexicalModelTypes.Suggestion[];
@@ -45,10 +45,10 @@ export interface LanguageProcessorEventMap {
   /**
    * Is called synchronously once suggestion application is successful and the context has been updated.
    *
-   * @param outputTarget The `OutputTarget` representation of the context the suggestion was applied to.
+   * @param outputTarget The `OutputTargetInterface` representation of the context the suggestion was applied to.
    * @returns
    */
-  'suggestionapplied': (outputTarget: OutputTarget) => boolean
+  'suggestionapplied': (outputTarget: OutputTargetInterface) => boolean
 }
 
 
@@ -56,7 +56,7 @@ export interface LanguageProcessorSpec extends EventEmitter<LanguageProcessorEve
 
   get state(): StateChangeEnum;
 
-  invalidateContext(outputTarget: OutputTarget, layerId: string): Promise<LexicalModelTypes.Suggestion[]>;
+  invalidateContext(outputTarget: OutputTargetInterface, layerId: string): Promise<LexicalModelTypes.Suggestion[]>;
 
   /**
    *
@@ -66,9 +66,9 @@ export interface LanguageProcessorSpec extends EventEmitter<LanguageProcessorEve
    *                        required because layerid can be changed by PostKeystroke
    * @returns
    */
-  applySuggestion(suggestion: LexicalModelTypes.Suggestion, outputTarget: OutputTarget, getLayerId: () => string): Promise<LexicalModelTypes.Reversion>;
+  applySuggestion(suggestion: LexicalModelTypes.Suggestion, outputTarget: OutputTargetInterface, getLayerId: () => string): Promise<LexicalModelTypes.Reversion>;
 
-  applyReversion(reversion: LexicalModelTypes.Reversion, outputTarget: OutputTarget): Promise<LexicalModelTypes.Suggestion[]>;
+  applyReversion(reversion: LexicalModelTypes.Reversion, outputTarget: OutputTargetInterface): Promise<LexicalModelTypes.Suggestion[]>;
 
   get wordbreaksAfterSuggestions(): boolean;
 

--- a/web/src/engine/interfaces/src/prediction/predictionContext.ts
+++ b/web/src/engine/interfaces/src/prediction/predictionContext.ts
@@ -4,7 +4,7 @@ import Keep = LexicalModelTypes.Keep;
 import Reversion = LexicalModelTypes.Reversion;
 import Suggestion = LexicalModelTypes.Suggestion;
 import { type LanguageProcessorSpec , ReadySuggestions, type InvalidateSourceEnum, StateChangeHandler } from './languageProcessor.interface.js';
-import { type OutputTarget } from "keyman/engine/keyboard";
+import { type OutputTargetInterface } from "keyman/engine/keyboard";
 
 interface PredictionContextEventMap {
   update: (suggestions: Suggestion[]) => void;
@@ -41,13 +41,13 @@ export default class PredictionContext extends EventEmitter<PredictionContextEve
   /**
    * Represents the active context used when requesting and applying predictive-text operations.
    */
-  private _currentTarget: OutputTarget;
+  private _currentTarget: OutputTargetInterface;
 
-  public get currentTarget(): OutputTarget {
+  public get currentTarget(): OutputTargetInterface {
     return this._currentTarget;
   }
 
-  public setCurrentTarget(target: OutputTarget): Promise<Suggestion[]> {
+  public setCurrentTarget(target: OutputTargetInterface): Promise<Suggestion[]> {
     const originalTarget = this._currentTarget;
     this._currentTarget = target;
 

--- a/web/src/engine/js-processor/src/jsKeyboardInterface.ts
+++ b/web/src/engine/js-processor/src/jsKeyboardInterface.ts
@@ -7,7 +7,7 @@
 
 import { type DeviceSpec, KMWString } from "@keymanapp/web-utils";
 import { ModifierKeyConstants } from '@keymanapp/common-types';
-import { Codes, type KeyEvent, KeyMapping, JSKeyboard, KeyboardHarness, KeyboardKeymanGlobal, type OutputTarget, VariableStoreDictionary } from "keyman/engine/keyboard";
+import { Codes, type KeyEvent, KeyMapping, JSKeyboard, KeyboardHarness, KeyboardKeymanGlobal, type OutputTargetInterface, VariableStoreDictionary } from "keyman/engine/keyboard";
 import { type OutputTargetBase }  from './outputTargetBase.js';
 import { type Deadkey } from './deadkeys.js';
 import { Mock } from "./mock.js";
@@ -174,7 +174,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
   cachedContextEx: CachedContextEx = new CachedContextEx();
   ruleContextEx: CachedContextEx;
 
-  activeTargetOutput: OutputTarget;
+  activeTargetOutput: OutputTargetInterface;
   ruleBehavior: RuleBehavior;
 
   systemStores: {[storeID: number]: SystemStore};
@@ -251,7 +251,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
    *             KC(10,10,Pelem) == "abcdef"  i.e. return as much as possible of the requested string
    */
 
-  context(n: number, ln: number, outputTarget: OutputTarget): string {
+  context(n: number, ln: number, outputTarget: OutputTargetInterface): string {
     const v = this.cachedContext.get(n, ln);
     if(v !== null) {
       return v;
@@ -275,7 +275,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
    *             KC(3,3,Pelem) == "def"
    *             KC(10,10,Pelem) == "XXXXabcdef"  i.e. return as much as possible of the requested string, where X = \uFFFE
    */
-  private KC_(n: number, ln: number, outputTarget: OutputTarget): string {
+  private KC_(n: number, ln: number, outputTarget: OutputTargetInterface): string {
     let tempContext = '';
 
     // If we have a selection, we have an empty context
@@ -301,7 +301,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
    *             KN(2,Pelem) == FALSE
    *             KN(4,Pelem) == TRUE
    */
-  nul(n: number, outputTarget: OutputTarget): boolean {
+  nul(n: number, outputTarget: OutputTargetInterface): boolean {
     const cx=this.context(n+1, 1, outputTarget);
 
     // With #31, the result will be a replacement character if context is empty.
@@ -318,7 +318,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
    * @return      {boolean}                   True if selected context matches val
    * Description  Test keyboard context for match
    */
-  contextMatch(n: number, outputTarget: OutputTarget, val: string, ln: number): boolean {
+  contextMatch(n: number, outputTarget: OutputTargetInterface, val: string, ln: number): boolean {
     const cx=this.context(n, ln, outputTarget);
     if(cx === val) {
       return true; // I3318
@@ -616,7 +616,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
    * @return      {boolean}                   True if deadkey found selected context matches val
    * Description  Match deadkey at current cursor position
    */
-  deadkeyMatch(n: number, outputTarget: OutputTarget, d: number): boolean {
+  deadkeyMatch(n: number, outputTarget: OutputTargetInterface, d: number): boolean {
     return outputTarget.hasDeadkeyMatch(n, d);
   }
 
@@ -626,7 +626,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
    * @param       {Object}      outputTarget  element to flash
    * Description  Flash body as substitute for audible beep; notify embedded device to vibrate
    */
-  beep(outputTarget: OutputTarget): void {
+  beep(outputTarget: OutputTargetInterface): void {
     this.resetContextCache();
 
     // Denote as part of the matched rule's behavior.
@@ -719,7 +719,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
    * @param       {Object}      outputTarget  element to output to
    * Description  Output a character selected from the string according to the offset in the index array
    */
-  indexOutput(Pdn: number, Ps: KeyboardStore, Pn: number, outputTarget: OutputTarget): void {
+  indexOutput(Pdn: number, Ps: KeyboardStore, Pn: number, outputTarget: OutputTargetInterface): void {
     this.resetContextCache();
 
     const assertNever = function(x: never): never {
@@ -756,7 +756,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
    * @param       {Object}      outputTarget  element to output to
    * Description  Keyboard output
    */
-  deleteContext(dn: number, outputTarget: OutputTarget): void {
+  deleteContext(dn: number, outputTarget: OutputTargetInterface): void {
     let context: CachedExEntry;
 
     // We want to control exactly which deadkeys get removed.
@@ -802,7 +802,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
    * @param       {string}      s             string to output
    * Description  Keyboard output
    */
-  output(dn: number, outputTarget: OutputTarget, s:string): void {
+  output(dn: number, outputTarget: OutputTargetInterface, s:string): void {
     this.resetContextCache();
 
     outputTarget.saveProperties();
@@ -825,11 +825,11 @@ export class JSKeyboardInterface extends KeyboardHarness {
    * @alias       KCXO
    * @public
    * @param       {number}        Pdn            number of characters to delete left of cursor
-   * @param       {OutputTarget}  outputTarget   target to output to
+   * @param       {OutputTargetInterface}  outputTarget   target to output to
    * @param       {number}        contextLength  length of current rule context to retrieve
    * @param       {number}        contextOffset  offset from start of current rule context, 1-based
    */
-  contextExOutput(Pdn: number, outputTarget: OutputTarget, contextLength: number, contextOffset: number): void {
+  contextExOutput(Pdn: number, outputTarget: OutputTargetInterface, contextLength: number, contextOffset: number): void {
     this.resetContextCache();
 
     if(Pdn >= 0) {
@@ -851,11 +851,11 @@ export class JSKeyboardInterface extends KeyboardHarness {
    * Function     deadkeyOutput KDO
    * Scope        Public
    * @param       {number}      Pdn           no of character to overwrite (delete)
-   * @param       {Object}      outputTarget  element to output to
+   * @param       {OutputTargetInterface}      outputTarget  element to output to
    * @param       {number}      Pd            deadkey id
    * Description  Record a deadkey at current cursor position, deleting Pdn characters first
    */
-  deadkeyOutput(Pdn: number, outputTarget: OutputTarget, Pd: number): void {
+  deadkeyOutput(Pdn: number, outputTarget: OutputTargetInterface, Pd: number): void {
     this.resetContextCache();
 
     if(Pdn >= 0) {
@@ -871,10 +871,10 @@ export class JSKeyboardInterface extends KeyboardHarness {
    *
    * @param       {number}      systemId      ID of the system store to test (only TSS_LAYER currently supported)
    * @param       {string}      strValue      String value to compare to
-   * @param       {Object}      outputTarget  Currently active element (may be needed by future tests)
+   * @param       {OutputTargetInterface}      outputTarget  Currently active element (may be needed by future tests)
    * @return      {boolean}                   True if the test succeeds
    */
-  ifStore(systemId: number, strValue: string, outputTarget: OutputTarget): boolean {
+  ifStore(systemId: number, strValue: string, outputTarget: OutputTargetInterface): boolean {
     let result=true;
     const store = this.systemStores[systemId];
     if(store) {
@@ -888,14 +888,14 @@ export class JSKeyboardInterface extends KeyboardHarness {
    *
    * @param       {number}      systemId      ID of the system store to set (only TSS_LAYER currently supported)
    * @param       {string}      strValue      String to set as the system store content
-   * @param       {Object}      outputTarget  Currently active element (may be needed in future tests)
+   * @param       {OutputTargetInterface}      outputTarget  Currently active element (may be needed in future tests)
    * @return      {boolean}                   True if command succeeds
    *                                          (i.e. for TSS_LAYER, if the layer is successfully selected)
    *
    * Note that option/variable stores are instead set within keyboard script code, as they only
    * affect keyboard behavior.
    */
-  setStore(systemId: number, strValue: string, outputTarget: OutputTarget): boolean {
+  setStore(systemId: number, strValue: string, outputTarget: OutputTargetInterface): boolean {
     this.resetContextCache();
     // Unique case:  we only allow set(&layer) ops from keyboard rules triggered by touch OSKs.
     if(systemId == SystemStoreIDs.TSS_LAYER && this.activeDevice.touchable) {
@@ -965,7 +965,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
     this.cachedContextEx.reset();
   }
 
-  defaultBackspace(outputTarget: OutputTarget) {
+  defaultBackspace(outputTarget: OutputTargetInterface) {
     if(outputTarget.isSelectionEmpty()) {
       // Delete the character left of the caret
       this.output(1, outputTarget, "");

--- a/web/src/engine/js-processor/src/jsKeyboardProcessor.ts
+++ b/web/src/engine/js-processor/src/jsKeyboardProcessor.ts
@@ -125,7 +125,8 @@ export class JSKeyboardProcessor extends EventEmitter<EventMap> {
    * where and when appropriate.
    *
    * @param   {object}  Lkc           The pre-analyzed KeyEvent object
-   * @param   {boolean} outputTarget  The OutputTarget receiving the KeyEvent
+   * @param   {OutputTargetInterface} outputTarget  The OutputTarget receiving the KeyEvent
+   * @param   {boolean}  readonly      True if the target is read-only
    * @return  {string}
    */
   private defaultRuleBehavior(Lkc: KeyEvent, outputTarget: OutputTargetBase, readonly: boolean): RuleBehavior {

--- a/web/src/engine/js-processor/src/jsKeyboardProcessor.ts
+++ b/web/src/engine/js-processor/src/jsKeyboardProcessor.ts
@@ -125,7 +125,7 @@ export class JSKeyboardProcessor extends EventEmitter<EventMap> {
    * where and when appropriate.
    *
    * @param   {object}  Lkc           The pre-analyzed KeyEvent object
-   * @param   {OutputTargetInterface} outputTarget  The OutputTarget receiving the KeyEvent
+   * @param   {OutputTargetBase} outputTarget  The output target receiving the KeyEvent
    * @param   {boolean}  readonly      True if the target is read-only
    * @return  {string}
    */

--- a/web/src/engine/js-processor/src/outputTargetBase.ts
+++ b/web/src/engine/js-processor/src/outputTargetBase.ts
@@ -1,7 +1,7 @@
 import { KMWString } from "@keymanapp/web-utils";
 import { findCommonSubstringEndIndex } from "./stringDivergence.js";
 import { Mock } from "./mock.js";
-import { OutputTarget } from 'keyman/engine/keyboard';
+import { OutputTargetInterface } from 'keyman/engine/keyboard';
 
 // Defines deadkey management in a manner attachable to each element interface.
 import { type KeyEvent } from 'keyman/engine/keyboard';
@@ -64,7 +64,7 @@ export class Transcription {
 
 export type Alternate = LexicalModelTypes.ProbabilityMass<LexicalModelTypes.Transform>;
 
-export abstract class OutputTargetBase implements OutputTarget {
+export abstract class OutputTargetBase implements OutputTargetInterface {
   private _dks: DeadkeyTracker;
 
   constructor() {

--- a/web/src/engine/keyboard/src/defaultRules.ts
+++ b/web/src/engine/keyboard/src/defaultRules.ts
@@ -7,7 +7,7 @@
 import { ModifierKeyConstants } from '@keymanapp/common-types';
 import Codes from './codes.js';
 import { type KeyEvent } from './keyEvent.js';
-import { type OutputTarget }  from './outputTarget.js';
+import { type OutputTargetInterface }  from './outputTargetInterface.js';
 
 export enum EmulationKeystrokes {
   Enter = '\n',
@@ -83,7 +83,7 @@ export default class DefaultRules {
    *
    * Note:  is extended by DOM-aware KeymanWeb code.
    */
-  public applyCommand(Lkc: KeyEvent, outputTarget: OutputTarget): void {
+  public applyCommand(Lkc: KeyEvent, outputTarget: OutputTargetInterface): void {
     // Notes for potential default-handling extensions:
     //
     // switch(code) {

--- a/web/src/engine/keyboard/src/index.ts
+++ b/web/src/engine/keyboard/src/index.ts
@@ -27,7 +27,7 @@ export { default as DefaultRules } from "./defaultRules.js";
 export * from "./defaultRules.js";
 export { type KeyDistribution, KeyEventSpec, KeyEvent } from "./keyEvent.js";
 export { default as KeyMapping } from "./keyMapping.js";
-export { OutputTarget } from "./outputTarget.js";
+export { OutputTargetInterface } from "./outputTargetInterface.js";
 export * from "./systemStores.js";
 
 export * from "@keymanapp/web-utils";

--- a/web/src/engine/keyboard/src/keyboards/jsKeyboard.ts
+++ b/web/src/engine/keyboard/src/keyboards/jsKeyboard.ts
@@ -2,7 +2,7 @@ import Codes from "../codes.js";
 import { Layouts } from "./defaultLayouts.js";
 import { ActiveKey, ActiveLayout, ActiveSubKey } from "./activeLayout.js";
 import { KeyEvent } from "../keyEvent.js";
-import { type OutputTarget } from "../outputTarget.js";
+import { type OutputTargetInterface } from "../outputTargetInterface.js";
 import { KeymanWebKeyboard, ModifierKeyConstants, TouchLayout } from "@keymanapp/common-types";
 
 import ComplexKeyboardStore = KeymanWebKeyboard.ComplexKeyboardStore;
@@ -53,7 +53,7 @@ type KmwKeyboardObject = KeyboardObject & {
  */
 export class JSKeyboard {
   public static DEFAULT_SCRIPT_OBJECT: KmwKeyboardObject = {
-    'gs': function(outputTarget: OutputTarget, keystroke: KeyEvent) { return false; }, // no matching rules; rely on defaultRuleOutput entirely
+    'gs': function(outputTarget: OutputTargetInterface, keystroke: KeyEvent) { return false; }, // no matching rules; rely on defaultRuleOutput entirely
     'KI': '', // The currently-existing default keyboard ID; we already have checks that focus against this.
     'KN': '',
     'KV': Layouts.DEFAULT_RAW_SPEC,
@@ -81,21 +81,21 @@ export class JSKeyboard {
   /**
    * Calls the keyboard's `gs` function, which represents the keyboard source's begin Unicode group.
    */
-  process(outputTarget: OutputTarget, keystroke: KeyEvent): boolean {
+  process(outputTarget: OutputTargetInterface, keystroke: KeyEvent): boolean {
     return this.scriptObject['gs'](outputTarget, keystroke);
   }
 
   /**
    * Calls the keyboard's `gn` function, which represents the keyboard source's begin newContext group.
    */
-  processNewContextEvent(outputTarget: OutputTarget, keystroke: KeyEvent): boolean {
+  processNewContextEvent(outputTarget: OutputTargetInterface, keystroke: KeyEvent): boolean {
     return this.scriptObject['gn'] ? this.scriptObject['gn'](outputTarget, keystroke) : false;
   }
 
   /**
    * Calls the keyboard's `gpk` function, which represents the keyboard source's begin postKeystroke group.
    */
-  processPostKeystroke(outputTarget: OutputTarget, keystroke: KeyEvent): boolean {
+  processPostKeystroke(outputTarget: OutputTargetInterface, keystroke: KeyEvent): boolean {
     return this.scriptObject['gpk'] ? this.scriptObject['gpk'](outputTarget, keystroke) : false;
   }
 
@@ -362,7 +362,7 @@ export class JSKeyboard {
    * @param       {number}    _PData        1 or 0
    * Notifies keyboard of keystroke or other event
    */
-  notify(_PCommand: number, _PTarget: OutputTarget, _PData: number) { // I2187
+  notify(_PCommand: number, _PTarget: OutputTargetInterface, _PData: number) { // I2187
     // Good example use case - the Japanese CJK-picker keyboard
     if(typeof(this.scriptObject['KNS']) == 'function') {
       this.scriptObject['KNS'](_PCommand, _PTarget, _PData);

--- a/web/src/engine/keyboard/src/outputTargetInterface.ts
+++ b/web/src/engine/keyboard/src/outputTargetInterface.ts
@@ -1,10 +1,11 @@
 /*
  * Keyman is copyright (C) SIL Global. MIT License.
  */
-export interface OutputTarget {
+export interface OutputTargetInterface {
   /**
-   * Signifies that this OutputTarget has no default key processing behaviors.  This should be false
-   * for OutputTargets backed by web elements like HTMLInputElement or HTMLTextAreaElement.
+   * Signifies that this OutputTargetInterface has no default key processing behaviors.
+   * This should be false for OutputTargets backed by web elements like HTMLInputElement
+   * or HTMLTextAreaElement.
    */
   get isSynthetic(): boolean;
 

--- a/web/src/engine/main/src/contextManagerBase.ts
+++ b/web/src/engine/main/src/contextManagerBase.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'eventemitter3';
-import { ManagedPromise, type Keyboard, type OutputTarget } from 'keyman/engine/keyboard';
+import { ManagedPromise, type Keyboard, type OutputTargetInterface } from 'keyman/engine/keyboard';
 import { type JSKeyboardInterface } from 'keyman/engine/js-processor';
 import { StubAndKeyboardCache, type KeyboardStub } from 'keyman/engine/keyboard-storage';
 import { PredictionContext } from 'keyman/engine/interfaces';
@@ -7,7 +7,7 @@ import { EngineConfiguration } from './engineConfiguration.js';
 
 interface EventMap {
   // target, then keyboard.
-  'targetchange': (target: OutputTarget) => boolean;
+  'targetchange': (target: OutputTargetInterface) => boolean;
 
   /**
    * This event is raised whenever a keyboard change is requested.
@@ -48,7 +48,7 @@ export interface ContextManagerConfiguration {
    *
    * Does not reset option-stores, variable-stores, etc.
    */
-  readonly resetContext: (outputTarget?: OutputTarget) => void;
+  readonly resetContext: (outputTarget?: OutputTargetInterface) => void;
 
   /**
    * A predictive-state management object that interfaces the predictive-text banner
@@ -64,7 +64,7 @@ export interface ContextManagerConfiguration {
 }
 
 interface PendingActivation {
-  target: OutputTarget,
+  target: OutputTargetInterface,
   keyboard: Promise<Keyboard>,
   stub: KeyboardStub;
 }
@@ -74,11 +74,11 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
 
   abstract initialize(): void;
 
-  abstract get activeTarget(): OutputTarget;
+  abstract get activeTarget(): OutputTargetInterface;
 
   private _predictionContext: PredictionContext;
   protected keyboardCache: StubAndKeyboardCache;
-  private _resetContext: (outputTarget?: OutputTarget) => void;
+  private _resetContext: (outputTarget?: OutputTargetInterface) => void;
 
   private pendingActivations: PendingActivation[] = [];
   protected engineConfig: MainConfig;
@@ -135,7 +135,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
    * attached elements within the app/browser target.  For `app/webview`, this should
    * always return a consistent value - likely, `null`.
    */
-  protected abstract currentKeyboardSrcTarget(): OutputTarget;
+  protected abstract currentKeyboardSrcTarget(): OutputTargetInterface;
 
   /**
    * Ensures that newly activated keyboards are set correctly within managed context, possibly
@@ -143,7 +143,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
    * @param kbd
    * @param target
    */
-  protected abstract activateKeyboardForTarget(kbd: {keyboard: Keyboard, metadata: KeyboardStub}, target: OutputTarget): void;
+  protected abstract activateKeyboardForTarget(kbd: { keyboard: Keyboard, metadata: KeyboardStub }, target: OutputTargetInterface): void;
 
   /**
    * Checks the pending keyboard-activation array for an entry corresponding to the specified
@@ -152,7 +152,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
    *                May be `null`, which corresponds to the global default Keyboard.
    * @returns `true` if pending activation is still valid, `false` otherwise.
    */
-  private findAndPopActivation(target: OutputTarget): PendingActivation {
+  private findAndPopActivation(target: OutputTargetInterface): PendingActivation {
     // Array.findIndex requires Chrome 45+. :(
     let activationIndex;
     for(activationIndex = 0; activationIndex < this.pendingActivations.length; activationIndex++) {
@@ -180,7 +180,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
   protected async deferredKeyboardActivation(
     kbdPromise: Promise<Keyboard>,
     metadata: KeyboardStub,
-    target: OutputTarget
+    target: OutputTargetInterface
   ): Promise<PendingActivation> {
     const activation: PendingActivation = {
       target: target,

--- a/web/src/engine/main/src/engineConfiguration.ts
+++ b/web/src/engine/main/src/engineConfiguration.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "eventemitter3";
 
-import { DeviceSpec, KeyboardProperties, ManagedPromise, OutputTarget, physicalKeyDeviceAlias, SpacebarText } from "keyman/engine/keyboard";
+import { DeviceSpec, KeyboardProperties, ManagedPromise, OutputTargetInterface, physicalKeyDeviceAlias, SpacebarText } from "keyman/engine/keyboard";
 import { RuleBehavior } from 'keyman/engine/js-processor';
 import { PathConfiguration, PathOptionDefaults, PathOptionSpec } from "keyman/engine/interfaces";
 import { DeviceDetector } from "./headless/deviceDetector.js";
@@ -110,7 +110,7 @@ export class EngineConfiguration extends EventEmitter<EventMap> {
    * @param ruleBehavior  The full effects of keystroke + postkeystroke rules from a processed keystroke.
    * @param outputTarget  The engine's current source for context
    */
-  onRuleFinalization(ruleBehavior: RuleBehavior, outputTarget: OutputTarget) {};
+  onRuleFinalization(ruleBehavior: RuleBehavior, outputTarget: OutputTargetInterface) {};
 }
 
 export interface InitOptionSpec extends PathOptionSpec {

--- a/web/src/engine/main/src/headless/inputProcessor.ts
+++ b/web/src/engine/main/src/headless/inputProcessor.ts
@@ -7,7 +7,7 @@ import { globalObject, DeviceSpec } from "@keymanapp/web-utils";
 
 import { KM_Core } from 'keyman/engine/core-processor';
 
-import { Codes, JSKeyboard, KeyboardMinimalInterface, type Keyboard, type KeyEvent, type OutputTarget, SystemStoreIDs } from "keyman/engine/keyboard";
+import { Codes, JSKeyboard, KeyboardMinimalInterface, type Keyboard, type KeyEvent, type OutputTargetInterface, SystemStoreIDs } from "keyman/engine/keyboard";
 // TODO-web-core: remove usage of OutputTargetBase
 import {
   type Alternate,
@@ -96,7 +96,7 @@ export class InputProcessor {
    * @returns     {Object}                    A RuleBehavior object describing the cumulative effects of
    *                                          all matched keyboard rules.
    */
-  processKeyEvent(keyEvent: KeyEvent, outputTarget: OutputTarget): RuleBehavior {
+  processKeyEvent(keyEvent: KeyEvent, outputTarget: OutputTargetInterface): RuleBehavior {
     const kbdMismatch = keyEvent.srcKeyboard && this.activeKeyboard != keyEvent.srcKeyboard;
     const trueActiveKeyboard = this.activeKeyboard;
 
@@ -150,7 +150,7 @@ export class InputProcessor {
    * @param outputTarget
    * @returns
    */
-  private _processKeyEvent(keyEvent: KeyEvent, outputTarget: OutputTarget): RuleBehavior {
+  private _processKeyEvent(keyEvent: KeyEvent, outputTarget: OutputTargetInterface): RuleBehavior {
     const formFactor = keyEvent.device.formFactor;
     const fromOSK = keyEvent.isSynthetic;
 
@@ -395,7 +395,7 @@ export class InputProcessor {
     return alternates;
   }
 
-  public resetContext(outputTarget?: OutputTarget) {
+  public resetContext(outputTarget?: OutputTargetInterface) {
     // Also handles new-context events, which may modify the layer
     // TODO-web-core
     this.keyboardProcessor.resetContext(outputTarget as OutputTargetBase);

--- a/web/src/engine/main/src/headless/languageProcessor.ts
+++ b/web/src/engine/main/src/headless/languageProcessor.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "eventemitter3";
 import { LMLayer, WorkerFactory } from "@keymanapp/lexical-model-layer/web";
 // TODO-web-core: remove use of OutputTargetBase
 import { Transcription, Mock, OutputTargetBase } from "keyman/engine/js-processor";
-import { OutputTarget } from 'keyman/engine/keyboard';
+import { OutputTargetInterface } from 'keyman/engine/keyboard';
 import { LanguageProcessorEventMap, ModelSpec, StateChangeEnum, ReadySuggestions } from 'keyman/engine/interfaces';
 import ContextWindow from "./contextWindow.js";
 import { TranscriptionCache } from "./transcriptionCache.js";
@@ -127,7 +127,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     });
   }
 
-  public invalidateContext(outputTarget: OutputTarget, layerId: string): Promise<Suggestion[]> {
+  public invalidateContext(outputTarget: OutputTargetInterface, layerId: string): Promise<Suggestion[]> {
     // If there's no active model, there can be no predictions.
     // We'll also be missing important data needed to even properly REQUEST the predictions.
     if(!this.currentModel || !this.configuration) {
@@ -156,7 +156,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     }
   }
 
-  public wordbreak(target: OutputTarget, layerId: string): Promise<string> {
+  public wordbreak(target: OutputTargetInterface, layerId: string): Promise<string> {
     if(!this.isActive) {
       return null;
     }
@@ -192,9 +192,9 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
    *                        required because layerid can be changed by PostKeystroke
    * @returns
    */
-  public applySuggestion(suggestion: Suggestion, outputTarget: OutputTarget, getLayerId: ()=>string): Promise<Reversion> {
+  public applySuggestion(suggestion: Suggestion, outputTarget: OutputTargetInterface, getLayerId: ()=>string): Promise<Reversion> {
     if(!outputTarget) {
-      throw "Accepting suggestions requires a destination OutputTarget instance."
+      throw "Accepting suggestions requires a destination OutputTargetInterface instance."
     }
 
     if(!this.isActive) {
@@ -269,9 +269,9 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     }
   }
 
-  public applyReversion(reversion: Reversion, outputTarget: OutputTarget) {
+  public applyReversion(reversion: Reversion, outputTarget: OutputTargetInterface) {
     if(!outputTarget) {
-      throw "Accepting suggestions requires a destination OutputTarget instance."
+      throw "Accepting suggestions requires a destination OutputTargetInterface instance."
     }
 
     if(!this.isActive) {
@@ -313,7 +313,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     return promise;
   }
 
-  public predictFromTarget(outputTarget: OutputTarget, layerId: string): Promise<Suggestion[]> {
+  public predictFromTarget(outputTarget: OutputTargetInterface, layerId: string): Promise<Suggestion[]> {
     if(!this.isActive || !outputTarget) {
       return null;
     }

--- a/web/src/tools/testing/recorder-core/src/index.ts
+++ b/web/src/tools/testing/recorder-core/src/index.ts
@@ -1,5 +1,5 @@
 import { Mock } from "keyman/engine/js-processor";
-import { KeyDistribution, KeyEvent, type OutputTarget } from "keyman/engine/keyboard";
+import { KeyDistribution, KeyEvent, type OutputTargetInterface } from "keyman/engine/keyboard";
 
 import Proctor from "./proctor.js";
 
@@ -217,7 +217,7 @@ export abstract class TestSequence<KeyRecord extends RecordedKeystroke | InputEv
 
   abstract hasOSKInteraction(): boolean;
 
-  async test(proctor: Proctor, target?: OutputTarget): Promise<{success: boolean, result: string}> {
+  async test(proctor: Proctor, target?: OutputTargetInterface): Promise<{success: boolean, result: string}> {
     // Start with an empty OutputTarget and a fresh KeyboardProcessor.
     if(!target) {
       target = new Mock();

--- a/web/src/tools/testing/recorder-core/src/nodeProctor.ts
+++ b/web/src/tools/testing/recorder-core/src/nodeProctor.ts
@@ -8,8 +8,8 @@ import {
   RecordedSyntheticKeystroke
 } from "./index.js";
 
-import { KeyEvent, KeyEventSpec, KeyboardHarness, type OutputTarget } from "keyman/engine/keyboard";
-// TODO-web-core: remove usage of OutputTargetBase, use OutputTarget instead
+import { KeyEvent, KeyEventSpec, KeyboardHarness, type OutputTargetInterface } from "keyman/engine/keyboard";
+// TODO-web-core: remove usage of OutputTargetBase, use OutputTargetInterface instead
 import { Mock, OutputTargetBase } from 'keyman/engine/js-processor';
 import { DeviceSpec } from "@keymanapp/web-utils";
 import { JSKeyboardInterface, JSKeyboardProcessor } from 'keyman/engine/js-processor';
@@ -50,7 +50,7 @@ export default class NodeProctor extends Proctor {
     return true;
   }
 
-  async simulateSequence(sequence: TestSequence<any>, target?: OutputTarget): Promise<string> {
+  async simulateSequence(sequence: TestSequence<any>, target?: OutputTargetInterface): Promise<string> {
     // Start with an empty OutputTarget and a fresh KeyboardProcessor.
     if(!target) {
       target = new Mock();

--- a/web/src/tools/testing/recorder-core/src/proctor.ts
+++ b/web/src/tools/testing/recorder-core/src/proctor.ts
@@ -1,5 +1,5 @@
 import { type DeviceSpec } from "@keymanapp/web-utils";
-import { type OutputTarget } from "keyman/engine/keyboard";
+import { type OutputTargetInterface } from "keyman/engine/keyboard";
 
 import type { KeyboardTest, TestSet, TestSequence } from "./index.js";
 
@@ -49,5 +49,5 @@ export default abstract class Proctor {
    * Simulates the specified test sequence for use in testing.
    * @param sequence The recorded sequence, generally provided by a test set.
    */
-  abstract simulateSequence(sequence: TestSequence<any>, target?: OutputTarget): Promise<string>;
+  abstract simulateSequence(sequence: TestSequence<any>, target?: OutputTargetInterface): Promise<string>;
 }

--- a/web/src/tools/testing/recorder/browserProctor.ts
+++ b/web/src/tools/testing/recorder/browserProctor.ts
@@ -4,7 +4,7 @@
 
 import { type DeviceSpec } from "@keymanapp/web-utils";
 
-import { type OutputTarget } from "keyman/engine/keyboard";
+import { type OutputTargetInterface } from "keyman/engine/keyboard";
 
 import { type KeymanEngine } from 'keyman/app/browser';
 
@@ -81,7 +81,7 @@ export class BrowserProctor extends Proctor {
 
   // Execution of a test sequence depends on the testing environment; this handles
   // the browser-specific aspects.
-  async simulateSequence(sequence: TestSequence<any>, outputTarget?: OutputTarget): Promise<string> {
+  async simulateSequence(sequence: TestSequence<any>, outputTarget?: OutputTargetInterface): Promise<string> {
     const driver = new BrowserDriver(this.target);
 
     // For the version 10.0 spec


### PR DESCRIPTION
Test-bot: skip