### PR TITLE
fix(common): Use zip.inc.sh for common test keyboards

### DIFF
--- a/common/test/keyboards/build.sh
+++ b/common/test/keyboards/build.sh
@@ -5,6 +5,8 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../resources/build/builder.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
+. "$KEYMAN_ROOT/resources/build/zip.inc.sh"
+
 targets=()
 # Build list of available targets from subfolders, if none specified
 for d in */; do
@@ -29,7 +31,8 @@ builder_parse "$@"
 function zipsource() {
   local target="$1"
   pushd "$1" > /dev/null
-  7z a -r -x!build -x"!$target.kpj.user" "${target}_source.zip" .
+  ZIP_FLAGS=("-q" "-r") # quiet, recursive
+  add_zip_files "${target}_source.zip" "-x@../zip-excludes" "${ZIP_FLAGS[@]}" .
   popd > /dev/null
 }
 

--- a/common/test/keyboards/build.sh
+++ b/common/test/keyboards/build.sh
@@ -31,8 +31,7 @@ builder_parse "$@"
 function zipsource() {
   local target="$1"
   pushd "$1" > /dev/null
-  ZIP_FLAGS=("-q" "-r") # quiet, recursive
-  add_zip_files "${target}_source.zip" "-x@../zip-excludes" "${ZIP_FLAGS[@]}" .
+  add_zip_files "${target}_source.zip" -x@../zip-excludes -q -r . # -q quiet, -r recursive
   popd > /dev/null
 }
 

--- a/common/test/keyboards/zip-excludes
+++ b/common/test/keyboards/zip-excludes
@@ -1,0 +1,3 @@
+build/
+*.kpj.user
+*_source.zip


### PR DESCRIPTION
Fixes: #14135

Updates the test keyboards build.sh script to use the refactored zip.inc.sh

Test-bot: skip
