### PR TITLE
maint(resources): fix regression on mac triggering builds

### DIFF
--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -166,9 +166,10 @@ while IFS= read -r line; do
       # Which platform are we watching?
       eval watch='$'watch_$platform
       # Add common patterns to the watch list
-      watch="^(${platform}|(oem/[^/]+/${platform})|resources/((?!teamcity)|teamcity/(${platform}|includes))|$watch)"
-      # Since bash doesn't support negative look-aheads we use grep to test
-      if echo "${line}" | grep --quiet --perl-regexp "${watch}"; then
+      watch="^(${platform}|(oem/[^/]+/${platform})|resources/((?!teamcity)|teamcity/(${platform}|includes))|${watch})"
+      # Since bash doesn't support negative look-aheads we use perl to test
+      # (grep has a --perl-regexp option, but not the version on macOS)
+      if perl -e 'exit($ARGV[0] =~ /$ARGV[1]/ ? 0 : 1)' "${line}" "${watch}"; then
         build_platforms+=($platform)
       fi
     fi


### PR DESCRIPTION
The `grep` available on macOS doesn't have the `--perl-regexp` option, so the changes introduced in #14047 caused a regression. This change directly makes use of Perl which is available on macOS.

Fixes: #14146
Follow-up-of: #14047
Test-bot: skip