### PR TITLE
maint(web): use path when calling powershell script

### DIFF
--- a/resources/teamcity/web/keyman-web-release.sh
+++ b/resources/teamcity/web/keyman-web-release.sh
@@ -47,14 +47,10 @@ function _push_release_to_skeymancom() {
 }
 
 function _zip_and_upload_artifacts() {
-  if ! is_windows; then
-    # requires Powershell
-    return 0
-  fi
-
   builder_echo start "zip and upload artifacts" "Zipping and uploading artifacts"
 
-  powershell -NonInteractive -ExecutionPolicy Bypass -File zip-and-upload-artifacts.ps1
+  # shellcheck disable=SC2154
+  powershell -NonInteractive -ExecutionPolicy Bypass -File "${THIS_SCRIPT_PATH}/zip-and-upload-artifacts.ps1"
 
   builder_echo end "zip and upload artifacts" success "Finished zipping and uploading artifacts"
 }


### PR DESCRIPTION
Also remove the check if we're running on Windows since that is already happening in the calling function.

Fixes: #14151
Follow-up-of: #14049
Test-bot: skip