### PR TITLE
fix(windows): keyboard only install return idle

### DIFF
--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -1196,6 +1196,12 @@ begin
   if hasKeymanInstall then
   begin
     DoInstallKeyman;
+  end
+  else
+  begin
+    // There is no Keyman installer we can return to the IdleState
+    bucStateContext.RemoveCachedFiles;
+    ChangeState(IdleState);
   end;
 end;
 


### PR DESCRIPTION
There will be no `firstrun` for kmshell.exe if it is a keyboard only install. We can therefore return to the idle state in the current process.

# User Testing

## TEST_STATEMACHINE_UPDATE_KBD_ONLY

**For this test to work we need the latest alpha to the same decimal version number as this PR.**

1. Download Keyman attached the PR
2. Open the Keyman Configuration dialog.
3. 3. Install the euro latin keyboard attached to this PR 3.0.0 [sil_euro_latin.zip](https://github.com/user-attachments/files/18587198/sil_euro_latin.zip)
4. Go to the update tab and press the check for updates button. The table should populate with the new eurolatin keyboard version and the keyman version. 
5. Open Regedit <kbd>Win</kbd><kbd>R</kbd> type regedit 
6. In the Regedit window verify the `update state` has advanced to either `usUpdateAvailable` ->  `usDownloading` -> `WaitingRestart`. Press F5 to refresh the view.
7. Press Install Now
8. Verify the euro latin keyboard is in the Keyboard Layouts tab. 
9. In the Regedit window verify the `update state` transistions to `usIdle`. Press F5 to refresh.