### PR TITLE
maint(web): add some more arguments for web release build script

### DIFF
--- a/resources/teamcity/web/keyman-web-release.sh
+++ b/resources/teamcity/web/keyman-web-release.sh
@@ -26,6 +26,10 @@ builder_describe \
   "configure      install dependencies" \
   "build          build Web + embedded" \
   "publish        publish release" \
+  "--rsync-path=RSYNC_PATH            rsync path on remote server" \
+  "--rsync-user=RSYNC_USER            rsync user on remote server" \
+  "--rsync-host=RSYNC_HOST            rsync host on remote server" \
+  "--rsync-root=RSYNC_ROOT            rsync root on remote server" \
   "--s.keyman.com=S_KEYMAN_COM        path to s.keyman.com repository" \
   "--help.keyman.com=HELP_KEYMAN_COM  path to help.keyman.com repository"
 
@@ -74,6 +78,11 @@ function publish_web_action() {
     builder_echo end publish error "Publishing KeymanWeb is only supported on Windows"
     return 1
   fi
+
+  export RSYNC_PATH
+  export RSYNC_USER
+  export RSYNC_HOST
+  export RSYNC_ROOT
 
   # Push release to s.keyman.com/kmw/engine (do this before updating
   # downloads.keyman.com so we can ensure files are available)

--- a/resources/teamcity/web/zip-and-upload-artifacts.ps1
+++ b/resources/teamcity/web/zip-and-upload-artifacts.ps1
@@ -15,6 +15,10 @@ $zip = "$upload_path\keymanweb-$build_number.zip"
 
 $7Z_HOME = $env:7Z_HOME
 $RSYNC_HOME = $env:RSYNC_HOME
+$RSYNC_PATH = $env:RSYNC_PATH
+$RSYNC_USER = $env:RSYNC_USER
+$RSYNC_HOST = $env:RSYNC_HOST
+$RSYNC_ROOT = $env:RSYNC_ROOT
 $USERPROFILE = $env:USERPROFILE
 
 # Since shell-scripting doesn't like number-initial variables, we convert it to a friendlier name.
@@ -59,10 +63,10 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  '--rsync-path="%downloads_rsync_path%"',    # path on remote server
+  '--rsync-path="$RSYNC_PATH"',             # path on remote server
   "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
   "$build_number",                          # upload the whole build folder
-  "%downloads_rsync_user%@%downloads_rsync_host%:%downloads_rsync_root%/web/$tier/" # target server + path
+  "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/web/$tier/" # target server + path
 )
 
 # Write-Output "rsync parameters:" $rsync_args

--- a/resources/teamcity/web/zip-and-upload-artifacts.ps1
+++ b/resources/teamcity/web/zip-and-upload-artifacts.ps1
@@ -63,7 +63,7 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  '--rsync-path="$RSYNC_PATH"',             # path on remote server
+  "--rsync-path='$RSYNC_PATH'",             # path on remote server
   "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
   "$build_number",                          # upload the whole build folder
   "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/web/$tier/" # target server + path


### PR DESCRIPTION
Previously rsync used some TC variables. Now with the build step being a script the TC variables are no longer accessible from the script, so we add new arguments to the build script and then use these when calling rsync. A similar changer was already made previously for the developer release build.

Follow-up-of: #14049
Related: #14059
Part-of: #13399
Test-bot: skip