### PR TITLE
maint(developer): use double quotes so that variable gets replaced

### DIFF
--- a/resources/teamcity/developer/download-symbol-server-index.ps1
+++ b/resources/teamcity/developer/download-symbol-server-index.ps1
@@ -25,7 +25,7 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  '--rsync-path="$RSYNC_PATH"',             # path on remote server
+  "--rsync-path='$RSYNC_PATH'",             # path on remote server
   "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
   "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/windows/symbols/000admin/lastid.txt", # target server + path
   "."                                       # download the whole symbols 000Admin folder
@@ -38,7 +38,7 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  '--rsync-path="$RSYNC_PATH"',             # path on remote server
+  "--rsync-path='$RSYNC_PATH'",             # path on remote server
   "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
   "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/windows/symbols/000admin/history.txt", # target server + path
   "."                                       # download the whole symbols 000Admin folder
@@ -51,7 +51,7 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  '--rsync-path="$RSYNC_PATH"',             # path on remote server
+  "--rsync-path='$RSYNC_PATH'",             # path on remote server
   "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
   "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/windows/symbols/000admin/server.txt", # target server + path
   "."                                       # download the whole symbols 000Admin folder

--- a/resources/teamcity/developer/publish-new-symbols.ps1
+++ b/resources/teamcity/developer/publish-new-symbols.ps1
@@ -27,7 +27,7 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  '--rsync-path="$RSYNC_PATH"',             # path on remote server
+  "--rsync-path='$RSYNC_PATH'",             # path on remote server
   "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
   ".",                                      # upload the whole symbols folder
   "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/windows/symbols/" # target server + path

--- a/resources/teamcity/developer/publish-to-downloads-keyman-com.ps1
+++ b/resources/teamcity/developer/publish-to-downloads-keyman-com.ps1
@@ -144,7 +144,7 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  '--rsync-path="$RSYNC_PATH"',             # path on remote server
+  "--rsync-path='$RSYNC_PATH'",             # path on remote server
   "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
   "$build_number",                          # upload the whole build folder
   "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/developer/$tier/" # target server + path
@@ -204,7 +204,7 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  '--rsync-path="$RSYNC_PATH"',             # path on remote server
+  "--rsync-path='$RSYNC_PATH'",             # path on remote server
   "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
   "$build_number",                          # upload the whole build folder
   "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/developer/$tier/" # target server + path


### PR DESCRIPTION
This fixes developer release builds. Previously we used single quotes for specifying `--rsync-path`. This caused the parameter to contain the variable name instead of the content.

Also define and set the variables in a powershell script so that they can be used. This was already done for the other powershell scripts, but overlooked for `download-symbol-server-index.ps1`. Also use variables instead of hard-coding values.

Follow-up-of: #14059
Part-of: #13399
Test-bot: skip