### PR TITLE
maint(resources): only automatically merge keyman-server PRs with automerge label

### DIFF
--- a/.github/workflows/auto-merge-keyman-server-pr.yml
+++ b/.github/workflows/auto-merge-keyman-server-pr.yml
@@ -17,12 +17,12 @@ jobs:
     if: ${{ github.repository == 'keymanapp/keyman' && github.actor == 'keyman-server' && startsWith(github.event.pull_request.title, 'auto:') }}
     steps:
     - name: auto approve PR from keyman-server
-      uses: hmarr/auto-approve-action@v3
+      uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"
     - name: auto merge PR from keyman-server
       uses: "pascalgn/automerge-action@7854d3bd607dccdaf0b2c134b699a812c8960213"
       env:
         GITHUB_TOKEN: "${{ secrets.AUTOINC_GITHUB_TOKEN }}"
-        MERGE_LABELS: ""
+        MERGE_LABELS: "automerge"
         MERGE_FORKS: false

--- a/resources/build/ci/pull-requests.inc.sh
+++ b/resources/build/ci/pull-requests.inc.sh
@@ -107,7 +107,7 @@ function ci_open_pull_request {
   git push origin "$branch"
   builder_echo "Push complete"
 
-  hub pull-request --force --message "$commit_message" --labels auto
+  hub pull-request --force --message "$commit_message" --labels auto,automerge
   builder_echo "Pull request created"
 
   git switch "$current_branch"

--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -166,7 +166,7 @@ if [ "$action" == "commit" ]; then
 
   cd "$KEYMAN_ROOT"
   git checkout "$branch"
-  hub pull-request -f --no-edit -b $base -l auto
+  hub pull-request -f --no-edit -b $base -l auto,automerge
 
   #
   # If we are on a stable-x.y branch, then we also want to merge changes to
@@ -174,6 +174,8 @@ if [ "$action" == "commit" ]; then
   # beta changes will be merged to master periodically anyway.
   #
   if [[ "$base" =~ ^stable-[0-9]+\.[0-9]+$ ]]; then
+    # TODO: why is this not happening?
+
     git switch master
 
     # In order to avoid potential git conflicts, we run the history collater
@@ -190,8 +192,8 @@ if [ "$action" == "commit" ]; then
       git switch -c "chore/version-$base-$NEWVERSION-master-history" master
       git add HISTORY.md
       git commit -m "$message (history cherry-pick to master)"
-      # TODO: once we are sure this is stable, add `-l auto` to get the "auto:"
-      # label
+      # TODO: once we are sure this is stable, add `-l auto,automerge` to get
+      # the "auto" label
       hub pull-request -fp --no-edit
     fi
 


### PR DESCRIPTION
Prevents PRs from keyman-server from being merged unless they already have the 'automerge' label. This supports the upcoming epic-master-merge infrastructure, where we would like to automatically approve the PRs but allow maintainers to merge when ready.

We cannot specify required status checks at this point, because we don't necessarily know which status checks will be required for a given PR. A future improvement would be to define a new status check which verifies that all the expected builds for a given PR have passed, and then make that into a required status check for all master,beta,stable-x.y,epic/ branches. This status check would need to be updated automatically whenever another status check completes. Probably should be implemented as a GHA.

In the future, we could move to using GitHub's auto-merge functionality, and not use the current auto-merge action but that's a much bigger change.

Also, upgraded auto-approve to v4.0.0 to remove node deprecation warnings.

Test-bot: skip
Build-bot: skip