### PR TITLE
maint(developer,web): use braces for variables in powershell scripts

### DIFF
--- a/resources/teamcity/developer/download-symbol-server-index.ps1
+++ b/resources/teamcity/developer/download-symbol-server-index.ps1
@@ -25,39 +25,39 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  "--rsync-path='$RSYNC_PATH'",             # path on remote server
-  "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
-  "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/windows/symbols/000admin/lastid.txt", # target server + path
+  "--rsync-path='${RSYNC_PATH}'",             # path on remote server
+  "--rsh=${RSYNC_HOME}\ssh -i ${USERPROFILE}\.ssh\id_rsa -o UserKnownHostsFile=${USERPROFILE}\.ssh\known_hosts",                  # use ssh
+  "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_ROOT}/windows/symbols/000admin/lastid.txt", # target server + path
   "."                                       # download the whole symbols 000Admin folder
 )
 
-& $RSYNC_HOME\rsync.exe $rsync_args
-if ($LASTEXITCODE -ne 0) { throw "Exit code is $LASTEXITCODE" }
+& ${RSYNC_HOME}\rsync.exe ${rsync_args}
+if (${LASTEXITCODE} -ne 0) { throw "Exit code is ${LASTEXITCODE}" }
 
 $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  "--rsync-path='$RSYNC_PATH'",             # path on remote server
-  "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
-  "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/windows/symbols/000admin/history.txt", # target server + path
+  "--rsync-path='${RSYNC_PATH}'",             # path on remote server
+  "--rsh=${RSYNC_HOME}\ssh -i ${USERPROFILE}\.ssh\id_rsa -o UserKnownHostsFile=${USERPROFILE}\.ssh\known_hosts",                  # use ssh
+  "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_ROOT}/windows/symbols/000admin/history.txt", # target server + path
   "."                                       # download the whole symbols 000Admin folder
 )
 
-& $RSYNC_HOME\rsync.exe $rsync_args
-if ($LASTEXITCODE -ne 0) { throw "Exit code is $LASTEXITCODE" }
+& ${RSYNC_HOME}\rsync.exe ${rsync_args}
+if (${LASTEXITCODE} -ne 0) { throw "Exit code is ${LASTEXITCODE}" }
 
 $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  "--rsync-path='$RSYNC_PATH'",             # path on remote server
-  "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
-  "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/windows/symbols/000admin/server.txt", # target server + path
+  "--rsync-path='${RSYNC_PATH}'",             # path on remote server
+  "--rsh=${RSYNC_HOME}\ssh -i ${USERPROFILE}\.ssh\id_rsa -o UserKnownHostsFile=${USERPROFILE}\.ssh\known_hosts",                  # use ssh
+  "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_ROOT}/windows/symbols/000admin/server.txt", # target server + path
   "."                                       # download the whole symbols 000Admin folder
 )
 
-& $RSYNC_HOME\rsync.exe $rsync_args
-if ($LASTEXITCODE -ne 0) { throw "Exit code is $LASTEXITCODE" }
+& ${RSYNC_HOME}\rsync.exe ${rsync_args}
+if (${LASTEXITCODE} -ne 0) { throw "Exit code is ${LASTEXITCODE}" }
 
 # EOF

--- a/resources/teamcity/developer/publish-new-symbols.ps1
+++ b/resources/teamcity/developer/publish-new-symbols.ps1
@@ -27,13 +27,13 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  "--rsync-path='$RSYNC_PATH'",             # path on remote server
-  "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
+  "--rsync-path='${RSYNC_PATH}'",             # path on remote server
+  "--rsh=${RSYNC_HOME}\ssh -i ${USERPROFILE}\.ssh\id_rsa -o UserKnownHostsFile=${USERPROFILE}\.ssh\known_hosts",                  # use ssh
   ".",                                      # upload the whole symbols folder
-  "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/windows/symbols/" # target server + path
+  "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_ROOT}/windows/symbols/" # target server + path
 )
 
-& $RSYNC_HOME\rsync.exe $rsync_args
-if ($LASTEXITCODE -ne 0) { throw "Exit code is $LASTEXITCODE" }
+& ${RSYNC_HOME}\rsync.exe ${rsync_args}
+if (${LASTEXITCODE} -ne 0) { throw "Exit code is ${LASTEXITCODE}" }
 
 # EOF

--- a/resources/teamcity/developer/publish-to-downloads-keyman-com.ps1
+++ b/resources/teamcity/developer/publish-to-downloads-keyman-com.ps1
@@ -4,28 +4,28 @@ $ErrorActionPreference = "Stop"
 
 $tier = Get-Content ..\TIER.md
 $build_number = Get-Content ..\VERSION.md
-$build_counter = $build_number -replace "^\d+\.\d+\.(\d+)$", '$1'
-$msi_major_version = $build_number -replace "^(\d+)\.(\d+)\.(\d+)$", '$1$2'
+$build_counter = ${build_number} -replace "^\d+\.\d+\.(\d+)$", '$1'
+#$msi_major_version = ${build_number} -replace "^(\d+)\.(\d+)\.(\d+)$", '$1$2'
 
-if ( $tier -eq "alpha" -or $tier -eq "beta") {
-  $version_tag = $tier
-  $version_with_tag = $build_number  # we may go with $build_number + "-" + $version_tag in the future one day
+if ( ${tier} -eq "alpha" -or ${tier} -eq "beta") {
+  $version_tag = ${tier}
+  $version_with_tag = ${build_number}  # we may go with ${build_number} + "-" + ${version_tag} in the future one day
 } else {
   $version_tag = ""
-  $version_with_tag = $build_number
+  $version_with_tag = ${build_number}
 }
 
-$upload_path = "upload\$build_number"
-$keyboards_path = "$upload_path\keyboards"
+$upload_path = "upload\${build_number}"
+$keyboards_path = "${upload_path}\keyboards"
 
 # Keyman Developer installers
-$kmcomp_zip = "kmcomp-$version_with_tag.zip"
-$keyman_developer_exe = "keymandeveloper-$version_with_tag.exe"
+$kmcomp_zip = "kmcomp-${version_with_tag}.zip"
+$keyman_developer_exe = "keymandeveloper-${version_with_tag}.exe"
 
-$setup_exe = "setup.exe"
+#$setup_exe = "setup.exe"
 
 # Debug files
-$debug_zip = "debug-$build_number.zip"
+$debug_zip = "debug-${build_number}.zip"
 
 $7Z_HOME = $env:7Z_HOME
 $RSYNC_HOME = $env:RSYNC_HOME
@@ -43,35 +43,35 @@ $USERPROFILE = $env:USERPROFILE
 # Preparation
 #
 
-if((Test-Path $upload_path) -ne 0) {
-  Remove-Item -Path $upload_path -Recurse
+if((Test-Path ${upload_path}) -ne 0) {
+  Remove-Item -Path ${upload_path} -Recurse
 }
 
-mkdir $upload_path
+mkdir ${upload_path}
 
 #
 # Build Keyman Compiler WINE archive
 #
 
-if((Test-Path ..\release\$kmcomp_zip) -ne 0) {
-  copy ..\release\$kmcomp_zip ..\$upload_path\$kmcomp_zip
+if((Test-Path ..\release\${kmcomp_zip}) -ne 0) {
+  copy ..\release\${kmcomp_zip} ..\${upload_path}\${kmcomp_zip}
 } else {
   cd bin
   if((Test-Path ..\..\common\schemas\keyboard_info\keyboard_info.source.json) -ne 0) {
     # Keyman versions through -16.0
     copy ..\..\common\schemas\keyboard_info\keyboard_info.source.json .
     copy ..\..\common\schemas\keyboard_info\keyboard_info.distribution.json .
-    & "$7Z_HOME\7z.exe" a -bd -bb0 ..\$upload_path\$kmcomp_zip kmcomp.exe kmcmpdll.dll kmcomp.x64.exe kmcmpdll.x64.dll kmconvert.exe keyboard_info.source.json keyboard_info.distribution.json xml\layoutbuilder\*.keyman-touch-layout projects\
+    & "${7Z_HOME}\7z.exe" a -bd -bb0 ..\${upload_path}\${kmcomp_zip} kmcomp.exe kmcmpdll.dll kmcomp.x64.exe kmcmpdll.x64.dll kmconvert.exe keyboard_info.source.json keyboard_info.distribution.json xml\layoutbuilder\*.keyman-touch-layout projects\
 
     # Add Keyman Developer Server to the archive (15.0 late alpha - after 171)
     if((Test-Path ..\src\server\build) -ne 0) {
       copy ..\src\server\build\ server\ -Recurse
-      & "$7Z_HOME\7z.exe" a -bd -bb0 ..\$upload_path\$kmcomp_zip server\
+      & "${7Z_HOME}\7z.exe" a -bd -bb0 ..\${upload_path}\${kmcomp_zip} server\
     }
   } else {
     # Keyman versions 17.0+; note, use npm install for most modules
     copy ..\..\common\schemas\keyboard_info\keyboard_info.schema.json .
-    & "$7Z_HOME\7z.exe" a -bd -bb0 ..\$upload_path\$kmcomp_zip kmconvert.exe keyboard_info.schema.json xml\layoutbuilder\*.keyman-touch-layout projects\ server\
+    & "${7Z_HOME}\7z.exe" a -bd -bb0 ..\${upload_path}\${kmcomp_zip} kmconvert.exe keyboard_info.schema.json xml\layoutbuilder\*.keyman-touch-layout projects\ server\
   }
   cd ..
 }
@@ -80,58 +80,58 @@ if((Test-Path ..\release\$kmcomp_zip) -ne 0) {
 # Copy source files
 #
 
-copy release\$build_number\$keyman_developer_exe $upload_path\$keyman_developer_exe
+copy release\${build_number}\${keyman_developer_exe} ${upload_path}\${keyman_developer_exe}
 
 #
 # Construct keyman_developer.download_info
 #
 
-$hash = get-filehash $upload_path\$keyman_developer_exe -Algorithm MD5
+$hash = get-filehash ${upload_path}\${keyman_developer_exe} -Algorithm MD5
 
 $keyman_developer_download_info = @"
 {
   "name": "Keyman Developer",
-  "version": "$version_with_tag",
+  "version": "${version_with_tag}",
   "date": "$([DateTime]::Now.ToString("yyyy-MM-dd"))",
   "platform": "win",
-  "stability": "$tier",
-  "file": "keymandeveloper-$version_with_tag.exe",
-  "md5": "$($hash.Hash)",
+  "stability": "${tier}",
+  "file": "keymandeveloper-${version_with_tag}.exe",
+  "md5": "$(${hash}.Hash)",
   "type": "exe",
-  "build": "$build_counter"
+  "build": "${build_counter}"
 }
 "@
 
-[System.IO.File]::WriteAllLines("$pwd\$upload_path\$keyman_developer_exe.download_info", $keyman_developer_download_info)
+[System.IO.File]::WriteAllLines("${pwd}\${upload_path}\${keyman_developer_exe}.download_info", ${keyman_developer_download_info})
 
 #
 # Construct kmcomp.download_info
 #
 
-$hash = get-filehash $upload_path\$kmcomp_zip -Algorithm MD5
+$hash = get-filehash ${upload_path}\${kmcomp_zip} -Algorithm MD5
 
 $kmcomp_download_info = @"
 {
   "name": "Keyman Developer Command-Line Compiler",
-  "version": "$version_with_tag",
+  "version": "${version_with_tag}",
   "date": "$([DateTime]::Now.ToString("yyyy-MM-dd"))",
   "platform": "win",
-  "stability": "$tier",
-  "file": "kmcomp-$version_with_tag.zip",
-  "md5": "$($hash.Hash)",
+  "stability": "${tier}",
+  "file": "kmcomp-${version_with_tag}.zip",
+  "md5": "$(${hash}.Hash)",
   "type": "zip",
-  "build": "$build_counter"
+  "build": "${build_counter}"
 }
 "@
 
-[System.IO.File]::WriteAllLines("$pwd\$upload_path\$kmcomp_zip.download_info", $kmcomp_download_info)
+[System.IO.File]::WriteAllLines("${pwd}\${upload_path}\${kmcomp_zip}.download_info", ${kmcomp_download_info})
 
 #
 # Copy common/test/keyboards/*/build/*.kmp to keyboards/
 #
 if((Test-Path ..\common\test\keyboards) -ne 0) {
-  mkdir $keyboards_path
-  Copy-Item ..\common\test\keyboards\*\build\*.kmp $keyboards_path\
+  mkdir ${keyboards_path}
+  Copy-Item ..\common\test\keyboards\*\build\*.kmp ${keyboards_path}\
 }
 
 #
@@ -144,17 +144,17 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  "--rsync-path='$RSYNC_PATH'",             # path on remote server
-  "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
-  "$build_number",                          # upload the whole build folder
-  "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/developer/$tier/" # target server + path
+  "--rsync-path='${RSYNC_PATH}'",             # path on remote server
+  "--rsh=${RSYNC_HOME}\ssh -i ${USERPROFILE}\.ssh\id_rsa -o UserKnownHostsFile=${USERPROFILE}\.ssh\known_hosts",                  # use ssh
+  "${build_number}",                          # upload the whole build folder
+  "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_ROOT}/developer/${tier}/" # target server + path
 )
 
-# Write-Output "rsync parameters:" $rsync_args
+# Write-Output "rsync parameters:" ${rsync_args}
 
 cd upload
-& $RSYNC_HOME\rsync.exe $rsync_args
-if( $LASTEXITCODE -ne 0 ) {
+& ${RSYNC_HOME}\rsync.exe ${rsync_args}
+if( ${LASTEXITCODE} -ne 0 ) {
   Write-Output "rsync failed."
   exit 99
 }
@@ -164,34 +164,34 @@ cd ..
 # DEBUG.ZIP
 #################
 
-if((Test-Path release\$build_number\$debug_zip) -ne 0) {
+if((Test-Path release\${build_number}\${debug_zip}) -ne 0) {
   #
   # Copy source files
   #
 
-  copy release\$build_number\$debug_zip $upload_path\$debug_zip
+  copy release\${build_number}\${debug_zip} ${upload_path}\${debug_zip}
 
   #
   # Construct debug-<version>.download_info
   #
 
-  $hash = get-filehash $upload_path\$debug_zip -Algorithm MD5
+  $hash = get-filehash ${upload_path}\${debug_zip} -Algorithm MD5
 
-  $debug_zip_download_info = @"
+  ${debug_zip}_download_info = @"
 {
   "name": "Keyman Developer debug files",
-  "version": "$version_with_tag",
+  "version": "${version_with_tag}",
   "date": "$([DateTime]::Now.ToString("yyyy-MM-dd"))",
   "platform": "win",
-  "stability": "$tier",
-  "file": "debug-$build_number.zip",
-  "md5": "$($hash.Hash)",
+  "stability": "${tier}",
+  "file": "debug-${build_number}.zip",
+  "md5": "$(${hash}.Hash)",
   "type": "zip",
-  "build": "$build_counter"
+  "build": "${build_counter}"
 }
 "@
 
-  [System.IO.File]::WriteAllLines("$pwd\$upload_path\$debug_zip.download_info", $debug_zip_download_info)
+  [System.IO.File]::WriteAllLines("${pwd}\${upload_path}\${debug_zip}.download_info", ${debug_zip}_download_info)
 }
 
 #
@@ -204,17 +204,17 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  "--rsync-path='$RSYNC_PATH'",             # path on remote server
-  "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
-  "$build_number",                          # upload the whole build folder
-  "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/developer/$tier/" # target server + path
+  "--rsync-path='${RSYNC_PATH}'",             # path on remote server
+  "--rsh=${RSYNC_HOME}\ssh -i ${USERPROFILE}\.ssh\id_rsa -o UserKnownHostsFile=${USERPROFILE}\.ssh\known_hosts",                  # use ssh
+  "${build_number}",                          # upload the whole build folder
+  "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_ROOT}/developer/${tier}/" # target server + path
 )
 
-# Write-Output "rsync parameters:" $rsync_args
+# Write-Output "rsync parameters:" ${rsync_args}
 
 cd upload
-& $RSYNC_HOME\rsync.exe $rsync_args
-if( $LASTEXITCODE -ne 0 ) {
+& ${RSYNC_HOME}\rsync.exe ${rsync_args}
+if( ${LASTEXITCODE} -ne 0 ) {
   Write-Output "rsync failed."
   exit 99
 }

--- a/resources/teamcity/web/zip-and-upload-artifacts.ps1
+++ b/resources/teamcity/web/zip-and-upload-artifacts.ps1
@@ -8,10 +8,10 @@ $ErrorActionPreference = "Stop";
 
 $tier = Get-Content ..\TIER.md
 $build_number = Get-Content ..\VERSION.md
-$build_counter = $build_number -replace "^\d+\.\d+\.(\d+)$", '$1'
+$build_counter = ${build_number} -replace "^\d+\.\d+\.(\d+)$", '$1'
 
-$upload_path = "build\upload\$build_number"
-$zip = "$upload_path\keymanweb-$build_number.zip"
+$upload_path = "build\upload\${build_number}"
+$zip = "${upload_path}\keymanweb-${build_number}.zip"
 
 $7Z_HOME = $env:7Z_HOME
 $RSYNC_HOME = $env:RSYNC_HOME
@@ -27,9 +27,9 @@ $env:SEVEN_Z_HOME=$7Z_HOME
 # PowerShell fun: `--` parameters will break a PowerShell command when not escaped in some form.
 # We can build the command in string form first and then execute the string, fortunately.
 $cmd = '"C:\Program Files\Git\bin\bash.exe" --init-file "c:\Program Files\Git\etc\profile" -l ./ci.sh prepare:downloads.keyman.com'
-cmd /c $cmd
+cmd /c ${cmd}
 
-$hash = get-filehash $zip -Algorithm MD5
+$hash = get-filehash ${zip} -Algorithm MD5
 
 #
 # Construct .build_info
@@ -38,20 +38,20 @@ $hash = get-filehash $zip -Algorithm MD5
 $download_info = @"
 {
   "name": "KeymanWeb",
-  "version": "$build_number",
+  "version": "${build_number}",
   "date": "$([DateTime]::Now.ToString("yyyy-MM-dd"))",
   "platform": "web",
-  "stability": "$tier",
-  "file": "keymanweb-$build_number.zip",
-  "md5": "$($hash.Hash)",
+  "stability": "${tier}",
+  "file": "keymanweb-${build_number}.zip",
+  "md5": "$(${hash}.Hash)",
   "type": "zip",
-  "build": "$build_counter"
+  "build": "${build_counter}"
 }
 "@
 
 # WriteAllLines is needed to avoid BOM
-[System.IO.File]::WriteAllLines("$pwd\$upload_path\keymanweb-$build_number.zip.download_info", $download_info)
-# $download_info | Out-File $upload_path\keymanweb-$build_number.zip.download_info -Encoding utf8
+[System.IO.File]::WriteAllLines("${pwd}\${upload_path}\keymanweb-${build_number}.zip.download_info", ${download_info})
+# ${download_info} | Out-File ${upload_path}\keymanweb-${build_number}.zip.download_info -Encoding utf8
 
 #
 # Upload with rsync to downloads.keyman.com
@@ -63,17 +63,17 @@ $rsync_args = @(
   '-vrzltp',                                # verbose, recurse, zip, copy symlinks, preserve times, permissions
   '--chmod=Dug=rwx,Do=rx,Fug=rw,Fo=r',      # map Windows security to host security
   '--stats',                                # show statistics for log
-  "--rsync-path='$RSYNC_PATH'",             # path on remote server
-  "--rsh=$RSYNC_HOME\ssh -i $USERPROFILE\.ssh\id_rsa -o UserKnownHostsFile=$USERPROFILE\.ssh\known_hosts",                  # use ssh
-  "$build_number",                          # upload the whole build folder
-  "$RSYNC_USER@$RSYNC_HOST:$RSYNC_ROOT/web/$tier/" # target server + path
+  "--rsync-path='${RSYNC_PATH}'",             # path on remote server
+  "--rsh=${RSYNC_HOME}\ssh -i ${USERPROFILE}\.ssh\id_rsa -o UserKnownHostsFile=${USERPROFILE}\.ssh\known_hosts",                  # use ssh
+  "${build_number}",                          # upload the whole build folder
+  "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_ROOT}/web/${tier}/" # target server + path
 )
 
-# Write-Output "rsync parameters:" $rsync_args
+# Write-Output "rsync parameters:" ${rsync_args}
 
-cd "$upload_path\.."
-& $RSYNC_HOME\rsync.exe $rsync_args
-if ($LASTEXITCODE -ne 0) { throw "Exit code is $LASTEXITCODE" }
+cd "${upload_path}\.."
+& ${RSYNC_HOME}\rsync.exe ${rsync_args}
+if (${LASTEXITCODE} -ne 0) { throw "Exit code is ${LASTEXITCODE}" }
 cd ..
 
 # EOF


### PR DESCRIPTION
This changes variable references in the powershell scripts to use braces (`${FOO}` instead of `$FOO`). This solves the problem where powershell considers the colon in the rsync command as being part of a variable. This should fix release builds for Web and Developer.

Also commented some unused variables.

Follow-up-of: #14167,#14168
Part-of: #13399
Test-bot: skip