### PR TITLE
fix(windows): add values wucUpdateAvailable and wucNotChecked to TRemoteUpdateCheckResult enum 🍒 🏠

### DIFF
--- a/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
@@ -21,7 +21,15 @@ const
 type
   ERemoteUpdateCheck = class(Exception);
 
-  TRemoteUpdateCheckResult = (wucUnknown, wucSuccess, wucNoUpdates, wucFailure, wucOffline);
+  (**
+   * wucUnknown: The result of the check is unknown.
+   * wucUpdateAvailable: The check was successful and a keyboard package or Keyman Installer file is available.
+   * wucNotChecked: The check was not performed, due to time between check value
+   * wucNoUpdates: The check was successful but no updates are available.
+   * wucFailure: The check failed due to an error.
+   * wucOffline: The user is offline, so the check could not be performed.
+   *)
+  TRemoteUpdateCheckResult = (wucUnknown, wucUpdateAvailable, wucNotChecked, wucNoUpdates, wucFailure, wucOffline);
 
   TRemoteUpdateCheckDownloadParams = record
     TotalSize: Integer;
@@ -141,7 +149,7 @@ begin
   proceed := ConfigCheckContinue;
   if not proceed and not FForce then
   begin
-    Result := wucNoUpdates;
+    Result := wucNotChecked;
     Exit;
   end;
 
@@ -184,7 +192,10 @@ begin
         if ucr.Parse(http.Response.MessageBodyAsString, 'bundle', CKeymanVersionInfo.Version) then
         begin
           TUpdateCheckStorage.SaveUpdateCacheData(ucr);
-          Result := wucSuccess;
+          if TUpdateCheckStorage.HasKeyboardPackages(ucr) or TUpdateCheckStorage.HasKeymanInstallFileUpdate(ucr) then
+            Result := wucUpdateAvailable
+          else
+            Result := wucNoUpdates;
         end
         else
         begin

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -1187,6 +1187,12 @@ begin
   if hasKeymanInstall then
   begin
     DoInstallKeyman;
+  end
+  else
+  begin
+    // There is no Keyman installer we can return to the IdleState
+    bucStateContext.RemoveCachedFiles;
+    ChangeState(IdleState);
   end;
 end;
 

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -715,7 +715,7 @@ begin
   finally
     CheckForUpdates.Free;
   end;
-  if Result <> wucFailure then
+  if Result = wucFailure then
     begin
       KL.Log('UpdateAvailableState.HandleCheck CheckForUpdates not successful: '+
         GetEnumName(TypeInfo(TUpdateState), Ord(Result)));

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -617,12 +617,11 @@ begin
     CheckForUpdates.Free;
   end;
 
-  { Response wucSuccess and Update is available }
-  if (Result = wucSuccess) and (TUpdateCheckStorage.CheckMetaDataForUpdate) then
+  if (Result = wucUpdateAvailable) then
   begin
     ChangeState(UpdateAvailableState);
   end;
-  // else staty in idle state
+  // else stay in idle state
 end;
 
 function IdleState.HandleKmShell;
@@ -640,7 +639,7 @@ begin
     CheckForUpdates.Free;
   end;
   { Response OK and Update is available }
-  if (UpdateCheckResult = wucSuccess) and (TUpdateCheckStorage.CheckMetaDataForUpdate)  then
+  if UpdateCheckResult = wucUpdateAvailable then
   begin
     ChangeState(UpdateAvailableState);
   end;
@@ -716,7 +715,7 @@ begin
   finally
     CheckForUpdates.Free;
   end;
-  if Result <> wucSuccess then
+  if Result <> wucFailure then
     begin
       KL.Log('UpdateAvailableState.HandleCheck CheckForUpdates not successful: '+
         GetEnumName(TypeInfo(TUpdateState), Ord(Result)));
@@ -915,9 +914,9 @@ begin
     CheckForUpdates.Free;
   end;
   { Response OK and go back to update available so files can be downloaded }
-  // TODO: #14126 first check if already downloaded files are the same as the the latest files in
-  // the metadata, if not then we should download the new files.
-  if (Result = wucSuccess) and (TUpdateCheckStorage.CheckMetaDataForUpdate)  then
+  // TODO: This actually needs to check if the updates available are newer then the already downloaded updates
+
+  if Result = wucUpdateAvailable then
   begin
     ChangeState(UpdateAvailableState);
   end;

--- a/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.UpdateStateMachine.pas
@@ -914,7 +914,7 @@ begin
     CheckForUpdates.Free;
   end;
   { Response OK and go back to update available so files can be downloaded }
-  // TODO: This actually needs to check if the updates available are newer then the already downloaded updates
+  // TODO: This actually needs to check if the updates available are newer than the already downloaded updates
 
   if Result = wucUpdateAvailable then
   begin


### PR DESCRIPTION
Basing of [fix/windows/cherry-pick/not-downloaded-after-3-attempts](https://github.com/keymanapp/keyman/tree/fix/windows/cherry-pick/not-downloaded-after-3-attempts)
As it makes it easy to review that it is the same cherry-pick as #14123

Test-bot: skip
Cherry-pick-of: #14123