### PR TITLE
maint(android): add TC build scripts for Keyman for Android 🪶

### DIFF
--- a/resources/teamcity/android/android-actions.inc.sh
+++ b/resources/teamcity/android/android-actions.inc.sh
@@ -10,6 +10,9 @@ android_clean_action() {
 
 android_build_action() {
   builder_echo start "build" "Building Keyman for Android"
-  "${KEYMAN_ROOT}/android/build.sh" configure build,test:${TARGETS} --debug --ci
+  local TARGETS="$1"
+
+  # REVIEW: is it deliberate that we `configure` all targets but only `build,test` `$TARGETS`?
+  "${KEYMAN_ROOT}/android/build.sh" configure build,test:"${TARGETS}" --debug --ci
   builder_echo end "build" success "Finished building Keyman for Android"
 }

--- a/resources/teamcity/android/android-actions.inc.sh
+++ b/resources/teamcity/android/android-actions.inc.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
+
+android_clean_action() {
+  builder_echo start "clean" "Cleaning artifact directories"
+  # shellcheck disable=SC2154
+  "${KEYMAN_ROOT}/android/build.sh" clean
+  builder_echo end "clean" success "Finished cleaning artifact directories"
+}
+
+android_build_action() {
+  builder_echo start "build" "Building Keyman for Android"
+  "${KEYMAN_ROOT}/android/build.sh" configure build,test:${TARGETS} --debug --ci
+  builder_echo end "build" success "Finished building Keyman for Android"
+}

--- a/resources/teamcity/android/keyman-android-release.sh
+++ b/resources/teamcity/android/keyman-android-release.sh
@@ -20,6 +20,11 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 ################################ Main script ################################
 
+# ENHANCE: In the future if we ever have OEM builds other than FV, we could go
+# with `--oem=OEM` instead of `--fv` where $OEM could be a comma separated
+# list, e.g. `firstvoices`.
+# See https://github.com/keymanapp/keyman/pull/14222/files#r2181208750.
+
 builder_describe \
   "Build release of Keyman for Android" \
   "all            run all actions" \
@@ -87,13 +92,9 @@ function _publish_to_playstore() {
   builder_echo end "publish to Google Play Store" success "Finished publishing release to Google Play Store"
 }
 
-function do_build() {
-  android_build_action
-}
-
 function do_publish() {
   if ! is_windows; then
-    # requires Powershell, so currently only supported on Windows
+    # currently only tested on Windows, TODO: test cross-platform
     builder_echo error "This script is intended to be run on Windows only."
     return 1
   fi
@@ -119,10 +120,10 @@ fi
 
 if builder_has_action all; then
   android_clean_action
-  do_build
+  android_build_action "${TARGETS}"
   do_publish
 else
   builder_run_action  clean    android_clean_action
-  builder_run_action  build    do_build
+  builder_run_action  build    android_build_action "${TARGETS}"
   builder_run_action  publish  do_publish
 fi

--- a/resources/teamcity/android/keyman-android-release.sh
+++ b/resources/teamcity/android/keyman-android-release.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
+#
+# TC build script to build release of Keyman for Android.
+
+# shellcheck disable=SC2164
+# shellcheck disable=SC1091
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../resources/build/builder.inc.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+# shellcheck disable=SC2154
+. "${KEYMAN_ROOT}/resources/shellHelperFunctions.sh"
+. "${KEYMAN_ROOT}/resources/teamcity/includes/tc-download-info.inc.sh"
+. "${KEYMAN_ROOT}/resources/teamcity/includes/tc-helpers.inc.sh"
+. "${KEYMAN_ROOT}/resources/teamcity/android/android-actions.inc.sh"
+
+################################ Main script ################################
+
+builder_describe \
+  "Build release of Keyman for Android" \
+  "all            run all actions" \
+  "build          configure and build Keyman for Android" \
+  "publish        publish release" \
+  "--fv                               additionally build FV Android" \
+  "--rsync-path=RSYNC_PATH            rsync path on remote server" \
+  "--rsync-user=RSYNC_USER            rsync user on remote server" \
+  "--rsync-host=RSYNC_HOST            rsync host on remote server" \
+  "--rsync-root=RSYNC_ROOT            rsync root on remote server" \
+  "--help.keyman.com=HELP_KEYMAN_COM  path to help.keyman.com repository"
+
+builder_parse "$@"
+
+cd "${KEYMAN_ROOT}/android"
+
+function _publish_to_downloads_keyman_com() {
+  # Publish to downloads.keyman.com
+  builder_echo start "publish to downloads.keyman.com" "Publishing release to downloads.keyman.com"
+
+  local UPLOAD_PATH KEYMAN_ENGINE_ANDROID_ZIP KEYMAN_APK FIRSTVOICES_APK
+  local COMPRESS_CMD
+
+  # shellcheck disable=SC2154
+  UPLOAD_PATH="upload/${KEYMAN_VERSION}"
+  KEYMAN_ENGINE_ANDROID_ZIP="keyman-engine-android-${KEYMAN_VERSION}.zip"
+  KEYMAN_APK="keyman-${KEYMAN_VERSION}.apk"
+  FIRSTVOICES_APK="firstvoices-${KEYMAN_VERSION}.apk"
+
+  # shellcheck disable=SC2154
+  COMPRESS_CMD="${SEVENZ_HOME}/7z"
+
+  rm -rf "${UPLOAD_PATH}"
+  mkdir -p "${UPLOAD_PATH}"
+
+  (
+    cd KMAPro/kMAPro/libs
+    "${COMPRESS_CMD}" a -bd -bb0 "../../../${UPLOAD_PATH}/${KEYMAN_ENGINE_ANDROID_ZIP}" keyman-engine.aar ../../../Samples '-xr!build.sh'
+  )
+
+  cp "KMAPro/kMAPro/build/outputs/apk/release/${KEYMAN_APK}" "${UPLOAD_PATH}"
+
+  write_download_info "${UPLOAD_PATH}" "${KEYMAN_ENGINE_ANDROID_ZIP}" "Keyman Engine for Android" zip android
+  write_download_info "${UPLOAD_PATH}" "${KEYMAN_APK}" "Keyman for Android" apk android
+
+  if [[ -d "../oem/firstvoices/android/app/build/outputs/apk/release" ]]; then
+    cp "../oem/firstvoices/android/app/build/outputs/apk/release/${FIRSTVOICES_APK}" "${UPLOAD_PATH}"
+    write_download_info "${UPLOAD_PATH}" "${FIRSTVOICES_APK}" "FirstVoices Keyboards" apk android
+  fi
+
+  (
+    cd upload
+    # shellcheck disable=SC2154
+    tc_rsync_upload "${KEYMAN_VERSION}" "android/${KEYMAN_TIER}"
+  )
+
+  builder_echo end "publish to downloads.keyman.com" success "Finished publishing release to downloads.keyman.com"
+}
+
+function _publish_to_playstore() {
+  builder_echo start "publish to Google Play Store" "Publishing release to Google Play Store"
+
+  "${KEYMAN_ROOT}/android/build.sh" "publish:${PUBTARGETS}" --ci
+
+  builder_echo end "publish to Google Play Store" success "Finished publishing release to Google Play Store"
+}
+
+function do_build() {
+  android_build_action
+}
+
+function do_publish() {
+  if ! is_windows; then
+    # requires Powershell, so currently only supported on Windows
+    builder_echo error "This script is intended to be run on Windows only."
+    return 1
+  fi
+
+  export RSYNC_PATH
+  export RSYNC_USER
+  export RSYNC_HOST
+  export RSYNC_ROOT
+
+  _publish_to_downloads_keyman_com
+  _publish_to_playstore
+  upload_help "Keyman for Android" android
+}
+
+if builder_has_option --fv; then
+  TARGETS="engine,app,fv"
+  PUBTARGETS="app,fv"
+else
+  # shellcheck disable=SC2034
+  TARGETS="engine,app"
+  PUBTARGETS="app"
+fi
+
+if builder_has_action all; then
+  android_clean_action
+  do_build
+  do_publish
+else
+  builder_run_action  clean    android_clean_action
+  builder_run_action  build    do_build
+  builder_run_action  publish  do_publish
+fi

--- a/resources/teamcity/android/keyman-android-test-samples.sh
+++ b/resources/teamcity/android/keyman-android-test-samples.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
+#
+# TC build script for Samples and Test projects
+
+# shellcheck disable=SC2164
+# shellcheck disable=SC1091
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../resources/build/builder.inc.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+# shellcheck disable=SC2154
+. "${KEYMAN_ROOT}/resources/shellHelperFunctions.sh"
+. "${KEYMAN_ROOT}/resources/teamcity/android/android-actions.inc.sh"
+
+################################ Main script ################################
+
+builder_describe \
+  "Build KMSample1, KMSample2, and Test projects" \
+  "all            run all actions" \
+  "clean          clean artifact directories" \
+  "build          configure, build and test Keyman for Android"
+
+builder_parse "$@"
+
+cd "${KEYMAN_ROOT}/android"
+
+function _build_kmea() {
+  builder_echo start "build" "Configuring and building KMEA"
+  "${KEYMAN_ROOT}/android/build.sh" configure:engine build:engine --debug --ci
+  builder_echo end "build" success "Finished configuring and building KMEA"
+}
+
+function _build_kmsample1() {
+  builder_echo start "build" "Building KMSample1"
+  "${KEYMAN_ROOT}/android/build.sh" build:sample1 --debug --ci
+  builder_echo end "build" success "Finished building KMSample1"
+}
+
+function _build_kmsample2() {
+  builder_echo start "build" "Building KMSample2"
+  "${KEYMAN_ROOT}/android/build.sh" build:sample2 --debug --ci
+  builder_echo end "build" success "Finished building KMSample2"
+}
+
+function _build_keyboardharness() {
+  builder_echo start "build" "Building KeyboardHarness"
+  "${KEYMAN_ROOT}/android/build.sh" build:keyboardharness --debug --ci
+  builder_echo end "build" success "Finished building KeyboardHarness"
+}
+
+function do_build() {
+  _build_kmea
+  _build_kmsample1
+  _build_kmsample2
+  _build_keyboardharness
+}
+
+if builder_has_action all; then
+  android_clean_action
+  do_build
+else
+  builder_run_action  clean   android_clean_action
+  builder_run_action  build   do_build
+fi

--- a/resources/teamcity/android/keyman-android-test-samples.sh
+++ b/resources/teamcity/android/keyman-android-test-samples.sh
@@ -30,7 +30,7 @@ cd "${KEYMAN_ROOT}/android"
 
 function do_build() {
   "${KEYMAN_ROOT}/android/build.sh" \
-    configure,build:kmea,kmsample1,kmsample2,keyboardharness \
+    configure,build:engine,sample1,sample2,keyboardharness \
     --debug --ci
 }
 

--- a/resources/teamcity/android/keyman-android-test-samples.sh
+++ b/resources/teamcity/android/keyman-android-test-samples.sh
@@ -22,41 +22,16 @@ builder_describe \
   "Build KMSample1, KMSample2, and Test projects" \
   "all            run all actions" \
   "clean          clean artifact directories" \
-  "build          configure, build and test Keyman for Android"
+  "build          configure and build Keyman for Android samples"
 
 builder_parse "$@"
 
 cd "${KEYMAN_ROOT}/android"
 
-function _build_kmea() {
-  builder_echo start "build" "Configuring and building KMEA"
-  "${KEYMAN_ROOT}/android/build.sh" configure:engine build:engine --debug --ci
-  builder_echo end "build" success "Finished configuring and building KMEA"
-}
-
-function _build_kmsample1() {
-  builder_echo start "build" "Building KMSample1"
-  "${KEYMAN_ROOT}/android/build.sh" build:sample1 --debug --ci
-  builder_echo end "build" success "Finished building KMSample1"
-}
-
-function _build_kmsample2() {
-  builder_echo start "build" "Building KMSample2"
-  "${KEYMAN_ROOT}/android/build.sh" build:sample2 --debug --ci
-  builder_echo end "build" success "Finished building KMSample2"
-}
-
-function _build_keyboardharness() {
-  builder_echo start "build" "Building KeyboardHarness"
-  "${KEYMAN_ROOT}/android/build.sh" build:keyboardharness --debug --ci
-  builder_echo end "build" success "Finished building KeyboardHarness"
-}
-
 function do_build() {
-  _build_kmea
-  _build_kmsample1
-  _build_kmsample2
-  _build_keyboardharness
+  "${KEYMAN_ROOT}/android/build.sh" \
+    configure,build:kmea,kmsample1,kmsample2,keyboardharness \
+    --debug --ci
 }
 
 if builder_has_action all; then

--- a/resources/teamcity/android/keyman-android-test.sh
+++ b/resources/teamcity/android/keyman-android-test.sh
@@ -38,8 +38,8 @@ fi
 
 if builder_has_action all; then
   android_clean_action
-  android_build_action
+  android_build_action "${TARGETS}"
 else
   builder_run_action  clean   android_clean_action
-  builder_run_action  build   android_build_action
+  builder_run_action  build   android_build_action "${TARGETS}"
 fi

--- a/resources/teamcity/android/keyman-android-test.sh
+++ b/resources/teamcity/android/keyman-android-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
+#
+# TC build script for Keyman Android/Test
+
+# shellcheck disable=SC2164
+# shellcheck disable=SC1091
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../resources/build/builder.inc.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+# shellcheck disable=SC2154
+. "${KEYMAN_ROOT}/resources/shellHelperFunctions.sh"
+. "${KEYMAN_ROOT}/resources/teamcity/android/android-actions.inc.sh"
+
+################################ Main script ################################
+
+builder_describe \
+  "Build and run tests for Keyman for Android" \
+  "--fv           additionally build and Test FV Android" \
+  "all            run all actions" \
+  "clean          clean artifact directories" \
+  "build          configure, build and test Keyman for Android"
+
+builder_parse "$@"
+
+cd "${KEYMAN_ROOT}/android"
+
+if builder_has_option --fv; then
+  TARGETS="engine,app,fv"
+else
+  # shellcheck disable=SC2034
+  TARGETS="engine,app"
+fi
+
+if builder_has_action all; then
+  android_clean_action
+  android_build_action
+else
+  builder_run_action  clean   android_clean_action
+  builder_run_action  build   android_build_action
+fi

--- a/resources/teamcity/includes/tc-helpers.inc.sh
+++ b/resources/teamcity/includes/tc-helpers.inc.sh
@@ -73,7 +73,7 @@ upload_help() {
   builder_echo start "upload help" "Uploading new ${PRODUCT} help to help.keyman.com"
 
   (
-    # shellcheck disable=SC2164
+    # shellcheck disable=SC2164,SC2154
     cd "${KEYMAN_ROOT}/resources/build"
     "${KEYMAN_ROOT}/resources/build/help-keyman-com.sh" "${PRODUCT_PATH}"
   )


### PR DESCRIPTION
There is one difference compared to the old build configurations on TC: previously we had a separate build step to build and test FV that would run only if environment variables were set.

This change combines building and testing FV with building the engine and the app. If the environment variables are set we pass an additional parameter to the TC build script.

Fixes: #14188
Part-of: #13399
Build-bot: release android
Test-bot: skip