### PR TITLE
refactor(linux): rename linux agent specific functions

### DIFF
--- a/resources/teamcity/developer/developer-actions.inc.sh
+++ b/resources/teamcity/developer/developer-actions.inc.sh
@@ -8,7 +8,7 @@ developer_install_dependencies_on_linux_action() {
 
   builder_echo start "install dependencies" "Installing dependencies"
 
-  linux_check_and_install_packages devscripts jq meson
+  ba_linux_check_and_install_packages devscripts jq meson
   install_nvm
   install_emscripten
 

--- a/resources/teamcity/includes/tc-actions.inc.sh
+++ b/resources/teamcity/includes/tc-actions.inc.sh
@@ -26,15 +26,15 @@ linux_additional_test_dependencies_action() {
   fi
 
   # shellcheck disable=SC2086
-  linux_check_and_install_packages ${TOINSTALL}
+  ba_linux_check_and_install_packages ${TOINSTALL}
 
   if ! is_os_version_or_higher 24.04; then
     builder_heading "Installing python3-coverage from pip"
     pip3 install --user coverage
   fi
 
-  linux_install_nvm
-  linux_install_dependencies_for_tests
+  ba_linux_install_nvm
+  ba_linux_install_dependencies_for_tests
 
   builder_echo end additional_dependencies success "Finished installing additional dependencies"
 }

--- a/resources/teamcity/includes/tc-helpers.inc.sh
+++ b/resources/teamcity/includes/tc-helpers.inc.sh
@@ -34,7 +34,7 @@ install_nvm() {
     # on Windows and macOS build agents are configured manually
     return 0
   fi
-  linux_install_nvm
+  ba_linux_install_nvm
 }
 
 # Set the environment variables required to use node/nvm and set the
@@ -59,7 +59,7 @@ install_emscripten() {
     # on Windows and macOS build agents are configured manually
     return 0
   fi
-  linux_install_emscripten
+  ba_linux_install_emscripten
 }
 
 set_variables_for_emscripten() {

--- a/resources/teamcity/includes/tc-linux.inc.sh
+++ b/resources/teamcity/includes/tc-linux.inc.sh
@@ -15,7 +15,7 @@ is_os_version_or_higher() {
 # Returns 0 if the specified package is installed.
 # Parameter:
 #   $1 - Package name to check (e.g., "curl")
-is_package_installed() {
+_is_package_installed() {
   local PACKAGE=$1
 
   dpkg -s "${PACKAGE}" >/dev/null 2>&1
@@ -24,7 +24,7 @@ is_package_installed() {
 # Check if the specified packages are installed and install them if not.
 # Parameters:
 #   $* - List of package names to check and install (e.g., "lcov jq")
-linux_check_and_install_packages() {
+ba_linux_check_and_install_packages() {
   if ! is_ubuntu; then
     return 0
   fi
@@ -35,7 +35,7 @@ linux_check_and_install_packages() {
 
   for p in ${PACKAGES}
   do
-    if ! is_package_installed "${p}"; then
+    if ! _is_package_installed "${p}"; then
       TOINSTALL="${TOINSTALL} ${p}"
     fi
   done
@@ -49,7 +49,7 @@ linux_check_and_install_packages() {
 }
 
 # Install nvm if it is not already installed and install the latest LTS
-linux_install_nvm() {
+ba_linux_install_nvm() {
   builder_echo start install_nvm "Checking and installing nvm"
   if [[ -f "${HOME}/.nvm/nvm.sh" ]]; then
     builder_echo "nvm is already installed"
@@ -66,7 +66,7 @@ linux_install_nvm() {
   builder_echo end install_nvm success "Finished checking and installing nvm"
 }
 
-linux_install_emscripten() {
+ba_linux_install_emscripten() {
   builder_echo start "install emscripten" "Checking and installing emscripten"
   if { [[ ! -z "${EMSCRIPTEN_BASE:-}" ]] && [[ -f "${EMSCRIPTEN_BASE}/emcc" ]] ; } ||
     [[ -f "${HOME}/emsdk/upstream/emscripten/emcc" ]]; then
@@ -90,15 +90,15 @@ linux_install_emscripten() {
 }
 
 # Install additional dependencies required for running integration tests.
-linux_install_dependencies_for_tests() {
+ba_linux_install_dependencies_for_tests() {
   builder_echo start install_dependencies_for_tests "Installing dependencies for tests"
 
-  linux_check_and_install_packages xvfb xserver-xephyr metacity mutter dbus-x11 weston xwayland
+  ba_linux_check_and_install_packages xvfb xserver-xephyr metacity mutter dbus-x11 weston xwayland
 
   builder_echo end install_dependencies_for_tests success "Finished installing dependencies for tests"
 }
 
-linux_start_xvfb() {
+ba_linux_start_xvfb() {
   # On Linux start Xvfb etc
   local PID_FILE=/tmp/keymanweb-pids
   builder_echo "Starting Xvfb..."
@@ -115,7 +115,7 @@ linux_start_xvfb() {
   export DISPLAY=:32
 }
 
-linux_stop_xvfb() {
+ba_linux_stop_xvfb() {
   # On Linux stop Xvfb etc
   local PID_FILE=/tmp/keymanweb-pids
   if [[ -f "${PID_FILE}" ]]; then

--- a/resources/teamcity/web/web-actions.inc.sh
+++ b/resources/teamcity/web/web-actions.inc.sh
@@ -9,9 +9,9 @@ web_install_dependencies_on_linux_action() {
   builder_echo start "install dependencies" "Install dependencies"
 
   # shellcheck disable=SC2086
-  linux_check_and_install_packages devscripts jq
+  ba_linux_check_and_install_packages devscripts jq
 
-  linux_install_nvm
+  ba_linux_install_nvm
   _install_playwright_dependencies
 
   builder_echo end "install dependencies" success "Finished installing dependencies"
@@ -23,7 +23,7 @@ _install_playwright_dependencies() {
   fi
 
   # shellcheck disable=SC2086
-  linux_check_and_install_packages ibevent-2.1-7t64 libxslt1.1 libwoff1 \
+  ba_linux_check_and_install_packages ibevent-2.1-7t64 libxslt1.1 libwoff1 \
     libvpx9 libgstreamer-plugins-bad1.0-0 libwebpdemux2 libharfbuzz-icu0 \
     libenchant-2-2 libsecret-1-0 libhyphen0 libmanette-0.2-0 libflite1 \
     gstreamer1.0-libav libnss3 libnspr4 libatk1.0-0t64 libatk-bridge2.0-0t64 \
@@ -41,14 +41,14 @@ web_build_action() {
 web_test_action() {
   builder_echo start web_test "Running tests for native KeymanWeb"
   if is_ubuntu; then
-    linux_start_xvfb
-    trap "linux_stop_xvfb" ERR
+    ba_linux_start_xvfb
+    trap "ba_linux_stop_xvfb" ERR
   fi
 
   "${KEYMAN_ROOT}/web/ci.sh" test
 
   if is_ubuntu; then
-    linux_stop_xvfb
+    ba_linux_stop_xvfb
     trap ERR
   fi
 


### PR DESCRIPTION
This change prefixes functions with `ba_` that are intended to be run on a Linux build agent. That should make it easier to distinguish them from functions that deal with building Keyman for Linux.

Test-bot: skip