### PR TITLE
feat(developer): kmc-convert: return data in-memory artifacts instead of writing to a file

### DIFF
--- a/developer/src/kmc-convert/src/converter.ts
+++ b/developer/src/kmc-convert/src/converter.ts
@@ -65,7 +65,7 @@ export class Converter implements KeymanCompiler {
   // _S2 finds converter e.g.keylayout->kmn  ( uses converter-class-factory)
   // _S2 factory uses/instanciates child class ( ~ in C++ virtual function in base class <-> use fun of derived class)
   // _S2 loads file
-  // _S2 creates a new converter (-object)
+  // _S2 creates a new (derived) converter (-object)
   // _S2 runs conversion for this object ( run-method of this converter of keylayout-to-kmn-tonverter.ts  )
   async run(inputFilename: string, outputFilename?: string): Promise<ConverterResult> {
     const converterOptions: CompilerOptions = {
@@ -93,7 +93,8 @@ export class Converter implements KeymanCompiler {
     const converter = new ConverterClass(this.callbacks, converterOptions);
     const artifacts = await converter.run(inputFilename, outputFilename);
     // Note: any subsequent errors in conversion will have been reported by the converter
-    return artifacts ? { artifacts } : null;
+    //return artifacts ? { artifacts } : null;
+    return artifacts ?  artifacts : null;
   }
 
   /**

--- a/developer/src/kmc-convert/src/keylayout-to-kmn/keylayout-to-kmn-converter.ts
+++ b/developer/src/kmc-convert/src/keylayout-to-kmn/keylayout-to-kmn-converter.ts
@@ -89,9 +89,9 @@ export class KeylayoutToKmnConverter {
     // write to object/ConverterResult
     outputFilename = outputFilename ?? inputFilename.replace(/\.keylayout$/, '.kmn');
     const out_Uint8: Uint8Array = kmnFileWriter.writeToUint8Array(outArray);
-    const Result_toBeReturned = {
+    const Result_toBeReturned: ConverterResult = {
       artifacts: {
-        kmn: { data: out_Uint8, filename: outputFilename },
+        kmn: { data: out_Uint8, filename: outputFilename }
       }
     };
 


### PR DESCRIPTION

This PR deals with the [use of  in-memory artifacts](https://github.com/keymanapp/keyman/pull/12564/files#r2084901868) from PR 12564 kmc-convert
* #12564


https://github.com/keymanapp-test-bot skip


