### PR TITLE
fix(web): deploy `web/build/publish` folder 🍒 🏠

### DIFF
--- a/web/ci.sh
+++ b/web/ci.sh
@@ -202,9 +202,10 @@ function prepare_downloads_keyman_com_action() {
   mkdir -p "${STATIC}"
 
   mkdir -p "${STATIC}/build"
-  cp -rf build/app    "${STATIC}/build/app"
-  cp -rf build/engine "${STATIC}/build/engine"
-  cp -rf build/tools  "${STATIC}/build/tools"
+  cp -rf build/app     "${STATIC}/build/app"
+  cp -rf build/engine  "${STATIC}/build/engine"
+  cp -rf build/publish "${STATIC}/build/publish"
+  cp -rf build/tools   "${STATIC}/build/tools"
   # avoid build/upload, since that's the folder we're building!
 
   cp -f index.html "${STATIC}/index.html"


### PR DESCRIPTION
This fixes a deployment problem which seems have been around since 17.0. We also have to deploy the `web/build/publish` folder which contains all the files necessary to load and run the test keyboards.

The fix can only be tested after a release build has happened and the files have been deployed.

Fixes: #14234
Cherry-pick-of: #14237
Build-bot: skip
Test-bot: skip