### PR TITLE
fix(web): change env variable name

### DIFF
--- a/web/ci.sh
+++ b/web/ci.sh
@@ -154,14 +154,14 @@ function prepare_downloads_keyman_com_action() {
 
   mkdir -p "${UPLOAD_PATH}"
 
-  # On Windows, we use 7-zip (SEVEN_Z_HOME env var).  On other platforms, we use zip.
+  # On Windows, we use 7-zip (SEVENZ_HOME env var).  On other platforms, we use zip.
 
   COMPRESS_CMD=
   COMPRESS_ADD=
 
-  # Marc's preference; use $SEVEN_Z_HOME and have the BAs set up with THAT as an env var.
-  if [[ ! -z "${SEVEN_Z_HOME+x}" ]]; then
-    COMPRESS_CMD="${SEVEN_Z_HOME}/7z"
+  # Marc's preference; use $SEVENZ_HOME and have the BAs set up with THAT as an env var.
+  if [[ ! -z "${SEVENZ_HOME+x}" ]]; then
+    COMPRESS_CMD="${SEVENZ_HOME}/7z"
     COMPRESS_ADD="a -bd -bb0 -r" # add, hide progress, log level 0, recursive
   fi
 


### PR DESCRIPTION
The build agents have the env variable `SEVENZ_HOME` set instead of `SEVEN_Z_HOME`. That name is also used elsewhere, so this PR changes it to the more widespread name.

Fixes: #14242
Follow-up-of: #14225
Build-bot: skip
Test-bot: skip