### PR TITLE
refactor(web): move helper functions to beginning of function

### DIFF
--- a/web/src/engine/predictive-text/templates/src/trie-model.ts
+++ b/web/src/engine/predictive-text/templates/src/trie-model.ts
@@ -303,6 +303,18 @@ export default class TrieModel implements LexicalModel {
   }
 
   predict(transform: Transform, context: Context): Distribution<Suggestion> {
+    //#region Helper function
+    function makeDistribution(suggestions: WithOutcome<Suggestion>[]): Distribution<Suggestion> {
+      const distribution: Distribution<Suggestion> = [];
+
+      for (const s of suggestions) {
+        distribution.push({ sample: s, p: s.p });
+      }
+
+      return distribution;
+    }
+    //#endregion Helper function
+
     // Special-case the empty buffer/transform: return the top suggestions.
     if (!transform.insert && !context.left && !context.right && context.startOfBuffer && context.endOfBuffer) {
       return makeDistribution(this._trie.firstN(MAX_SUGGESTIONS).map(({text, p}) => ({
@@ -316,14 +328,14 @@ export default class TrieModel implements LexicalModel {
     }
 
     // Compute the results of the keystroke:
-    let newContext = applyTransform(transform, context);
+    const newContext = applyTransform(transform, context);
 
     // Computes the different in word length after applying the transform above.
-    let leftDelOffset = transform.deleteLeft - KMWString.length(transform.insert);
+    const leftDelOffset = transform.deleteLeft - KMWString.length(transform.insert);
 
     // All text to the left of the cursor INCLUDING anything that has
     // just been typed.
-    let prefix = getLastPreCaretToken(this.breakWords, newContext);
+    const prefix = getLastPreCaretToken(this.breakWords, newContext);
 
     // Return suggestions from the trie.
     return makeDistribution(this._trie.lookup(prefix).map(({text, p}) =>
@@ -336,18 +348,6 @@ export default class TrieModel implements LexicalModel {
       },
       p
     )));
-
-    /* Helper */
-
-    function makeDistribution(suggestions: WithOutcome<Suggestion>[]): Distribution<Suggestion> {
-      let distribution: Distribution<Suggestion> = [];
-
-      for(let s of suggestions) {
-        distribution.push({sample: s, p: s.p});
-      }
-
-      return distribution;
-    }
   }
 
   get wordbreaker(): WordBreakingFunction {

--- a/web/src/engine/predictive-text/wordbreakers/src/main/default/index.ts
+++ b/web/src/engine/predictive-text/wordbreakers/src/main/default/index.ts
@@ -293,6 +293,24 @@ function isNonSpace(chunk: string, options?: DefaultWordBreakerOptions): boolean
  * @param text Text to find word boundaries in.
  */
 function findBoundaries(text: string, options?: DefaultWordBreakerOptions): number[] {
+  //#region Internal utility functions
+  /**
+   * Returns the position of the start of the next scalar value. This jumps
+   * over surrogate pairs.
+   *
+   * If asked for the character AFTER the end of the string, this always
+   * returns the length of the string.
+   */
+  function positionAfter(pos: number): number {
+    if (pos >= text.length) {
+      return text.length;
+    } else if (isStartOfSurrogatePair(text[pos])) {
+      return pos + 2;
+    }
+    return pos + 1;
+  }
+  //#endregion Internal utility functions
+
   // WB1 and WB2: no boundaries if given an empty string.
   if (text.length === 0) {
     // There are no boundaries in an empty string!
@@ -321,7 +339,7 @@ function findBoundaries(text: string, options?: DefaultWordBreakerOptions): numb
   //    left, and some look at what's to the right of right. So
   //    keep track of this!
 
-  let boundaries = [];
+  const boundaries = [];
 
   let rightPos: number;
   let lookaheadPos = 0; // lookahead, one scalar value to the right of right.
@@ -526,24 +544,6 @@ function findBoundaries(text: string, options?: DefaultWordBreakerOptions): numb
   } while (rightPos < text.length);
 
   return boundaries;
-
-  ///// Internal utility functions /////
-
-  /**
-   * Returns the position of the start of the next scalar value. This jumps
-   * over surrogate pairs.
-   *
-   * If asked for the character AFTER the end of the string, this always
-   * returns the length of the string.
-   */
-  function positionAfter(pos: number): number {
-    if (pos >= text.length) {
-      return text.length;
-    } else if (isStartOfSurrogatePair(text[pos])) {
-      return pos + 2;
-    }
-    return pos + 1;
-  }
 }
 
 function isStartOfSurrogatePair(character: string) {


### PR DESCRIPTION
The previous code showed a warning in the Firefox console: "Unreachable code after return statement". Moving the helper functions to the beginning of the surrounding function solves it.

Also make some variables `const`.
