### PR TITLE
maint(android): remove `--ci` parameter from android builds

### DIFF
--- a/android/build.sh
+++ b/android/build.sh
@@ -39,7 +39,6 @@ builder_describe \
   test \
   "publish                                  Publishes symbols to Sentry and the APKs to the Play Store." \
   "archive                                  Copy release artifacts to upload/ and rsync to downloads.keyman" \
-  "--ci+                                    Deprecated build option. Remove in 20.0" \
   --upload-sentry+ \
   ":engine=KMEA                             Keyman Engine for Android" \
   ":app=KMAPro                              Keyman for Android" \

--- a/resources/teamcity/android/android-actions.inc.sh
+++ b/resources/teamcity/android/android-actions.inc.sh
@@ -13,6 +13,6 @@ android_build_action() {
   local TARGETS="$1"
 
   # REVIEW: is it deliberate that we `configure` all targets but only `build,test` `$TARGETS`?
-  "${KEYMAN_ROOT}/android/build.sh" configure build,test:"${TARGETS}" --debug --ci
+  "${KEYMAN_ROOT}/android/build.sh" configure build,test:"${TARGETS}" --debug
   builder_echo end "build" success "Finished building Keyman for Android"
 }

--- a/resources/teamcity/android/keyman-android-test-samples.sh
+++ b/resources/teamcity/android/keyman-android-test-samples.sh
@@ -31,7 +31,7 @@ cd "${KEYMAN_ROOT}/android"
 function do_build() {
   "${KEYMAN_ROOT}/android/build.sh" \
     configure,build:engine,sample1,sample2,keyboardharness \
-    --debug --ci
+    --debug
 }
 
 if builder_has_action all; then


### PR DESCRIPTION
`--ci` is deprecated since the current code discovers automatically when we're building on CI, so we don't have to pass that option when calling the `android/build.sh` script.

Also remove the option itself since we're no longer using it.

Build-bot: build android
Test-bot: skip