### PR TITLE
refactor(resources): replace shebang for TC include files

### DIFF
--- a/resources/teamcity/android/android-actions.inc.sh
+++ b/resources/teamcity/android/android-actions.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 android_clean_action() {

--- a/resources/teamcity/developer/developer-actions.inc.sh
+++ b/resources/teamcity/developer/developer-actions.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 developer_install_dependencies_on_linux_action() {

--- a/resources/teamcity/includes/tc-actions.inc.sh
+++ b/resources/teamcity/includes/tc-actions.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 # Run the clean action in the `linux` directory.`

--- a/resources/teamcity/includes/tc-download-info.inc.sh
+++ b/resources/teamcity/includes/tc-download-info.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 # shellcheck disable=SC2154

--- a/resources/teamcity/includes/tc-helpers.inc.sh
+++ b/resources/teamcity/includes/tc-helpers.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 # Returns 0 if we're running on Ubuntu.

--- a/resources/teamcity/includes/tc-linux.inc.sh
+++ b/resources/teamcity/includes/tc-linux.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 # Returns 0 if the OS version is greater than or equal to the specified version.

--- a/resources/teamcity/includes/tc-mac.inc.sh
+++ b/resources/teamcity/includes/tc-mac.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 ba_mac_unlock_keychain() {

--- a/resources/teamcity/includes/tc-windows.inc.sh
+++ b/resources/teamcity/includes/tc-windows.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 download_symbol_server_index() {

--- a/resources/teamcity/ios/ios-actions.inc.sh
+++ b/resources/teamcity/ios/ios-actions.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 ios_build() {

--- a/resources/teamcity/macos/macos-actions.inc.sh
+++ b/resources/teamcity/macos/macos-actions.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 macos_clean_action() {

--- a/resources/teamcity/web/web-actions.inc.sh
+++ b/resources/teamcity/web/web-actions.inc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 web_install_dependencies_on_linux_action() {

--- a/resources/teamcity/windows/windows-actions.inc.sh
+++ b/resources/teamcity/windows/windows-actions.inc.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 windows_build_action() {


### PR DESCRIPTION
Include files are not directly executable, so it doesn't make sense to have the shebang line. However, shellcheck needs to know what shell we use. Turns out there is a shellcheck line that we can add instead of the shebang line.

Follow-up-of: #14253
Build-bot: skip
Test-bot: skip