### PR TITLE
maint(ios): remove extra `cd` command from ios release builds

### DIFF
--- a/resources/teamcity/ios/keyman-ios-release.sh
+++ b/resources/teamcity/ios/keyman-ios-release.sh
@@ -203,7 +203,6 @@ function __do_upload_to_fastlane() {
       export PILOT_GROUPS="Alpha"
     fi
 
-    cd "upload/${KEYMAN_VERSION}"
     command -v fastlane
     # shellcheck disable=SC2154
     fastlane pilot upload \


### PR DESCRIPTION
We did already cd into that directory a few lines above.

Build-bot: skip
Test-bot: skip