### PR TITLE
maint(mac): rename `_do_publish` function to `do_publish` to fix release build

### DIFF
--- a/resources/teamcity/macos/keyman-macos-release.sh
+++ b/resources/teamcity/macos/keyman-macos-release.sh
@@ -69,7 +69,7 @@ function _build_publish() {
   builder_echo end success "publish" "Finished publishing Keyman for macOS"
 }
 
-function _do_publish() {
+function do_publish() {
   _build_publish
   _publish_to_downloads_keyman_com
   upload_help "Keyman for macOS" mac


### PR DESCRIPTION
Skipping builds since the changed code only affects TC release builds.

Build-bot: skip
Test-bot: skip