### PR TITLE
fix(common): fix triggering builds if no builds to start

### DIFF
--- a/resources/build/run-required-test-builds.sh
+++ b/resources/build/run-required-test-builds.sh
@@ -259,7 +259,7 @@ fi
 # Start test builds as required
 #
 
-if (( ${#build_platforms[@]} > 0)); then
+if [[ ! -z ${build_platforms:-} ]] && (( ${#build_platforms[@]:-0} > 0)); then
   builder_echo heading "Start test builds"
   triggerTestBuilds build_platforms $PRNUM
 else


### PR DESCRIPTION
If the PR only contains files that we ignore, we previously failed to finish the trigger build. This PR fixes the problem.

The problem can be observed in #14271 which only changed a file in `resources/teamcity/common` which gets ignored in `find_platform_changes`.

Test-bot: skip