### PR TITLE
maint(common): match OSTYPE correctly on macOS

### DIFF
--- a/resources/teamcity/includes/tc-helpers.inc.sh
+++ b/resources/teamcity/includes/tc-helpers.inc.sh
@@ -22,7 +22,7 @@ is_windows() {
 
 # Returns 0 if we're running on macOS.
 is_macos() {
-  if [[ "${OSTYPE:-}" == "darwin" ]]; then
+  if [[ "${OSTYPE:-}" == darwin* ]]; then
     return 0
   else
     return 1


### PR DESCRIPTION
Fixes: #14276
Test-bot: skip