### PR TITLE
maint(android): use `--release` for release builds

### DIFF
--- a/resources/teamcity/android/android-actions.inc.sh
+++ b/resources/teamcity/android/android-actions.inc.sh
@@ -11,8 +11,9 @@ android_clean_action() {
 android_build_action() {
   builder_echo start "build" "Building Keyman for Android"
   local TARGETS="$1"
+  local ARGS="$2"
 
   # REVIEW: is it deliberate that we `configure` all targets but only `build,test` `$TARGETS`?
-  "${KEYMAN_ROOT}/android/build.sh" configure build,test:"${TARGETS}" --debug
+  "${KEYMAN_ROOT}/android/build.sh" configure build,test:"${TARGETS}" ${ARGS}
   builder_echo end "build" success "Finished building Keyman for Android"
 }

--- a/resources/teamcity/android/keyman-android-release.sh
+++ b/resources/teamcity/android/keyman-android-release.sh
@@ -120,10 +120,10 @@ fi
 
 if builder_has_action all; then
   android_clean_action
-  android_build_action "${TARGETS}"
+  android_build_action "${TARGETS}" --release
   do_publish
 else
   builder_run_action  clean    android_clean_action
-  builder_run_action  build    android_build_action "${TARGETS}"
+  builder_run_action  build    android_build_action "${TARGETS}" --release
   builder_run_action  publish  do_publish
 fi

--- a/resources/teamcity/android/keyman-android-test.sh
+++ b/resources/teamcity/android/keyman-android-test.sh
@@ -38,8 +38,8 @@ fi
 
 if builder_has_action all; then
   android_clean_action
-  android_build_action "${TARGETS}"
+  android_build_action "${TARGETS}" --debug
 else
   builder_run_action  clean   android_clean_action
-  builder_run_action  build   android_build_action "${TARGETS}"
+  builder_run_action  build   android_build_action "${TARGETS}" --debug
 fi


### PR DESCRIPTION
This will fix the Android release builds. Previously we did a debug build but then tried to copy files from the release build folder.

The original build config passed `--release` when doing a release build, which lost when moving to build scripts.

Fixes: #14302
Build-bot: skip
Build-bot: release android
Test-bot: skip