### PR TITLE
maint(developer): consolidate creating KMC_ZIP file 🗜️

### DIFF
--- a/developer/src/inst/build.sh
+++ b/developer/src/inst/build.sh
@@ -242,25 +242,24 @@ function make-installer() {
   #
 }
 
-# TODO: rename this to keyman-developer-cli-$Version.zip
-KMC_ZIP="$DEVELOPER_ROOT/release/$KEYMAN_VERSION/kmcomp-$KEYMAN_VERSION.zip"
-
 function make-kmc-install-zip() {
   builder_heading make-kmc-install-zip
 
   copy-schemas
-  cd "$DEVELOPER_ROOT/bin"
+  cd "${DEVELOPER_ROOT}/bin"
 
-  wzzip -bd -bb0 "$KMC_ZIP" \
+  # TODO: rename this to keyman-developer-cli-$Version.zip
+  local KMCOMP_ZIP="${DEVELOPER_ROOT}/release/${KEYMAN_VERSION}/kmcomp-${KEYMAN_VERSION}.zip"
+
+  # shellcheck disable=SC2154
+  local COMPRESS_CMD="${SEVENZ_HOME}/7z"
+
+  "${COMPRESS_CMD}" a -bd -bb0 "${KMCOMP_ZIP}" \
     kmconvert.exe \
-    sentry.dll sentry.x64.dll \
-    kmdecomp.exe \
     keyboard_info.schema.json \
-    kmp.schema.json \
-    keyman-touch-layout.spec.json keyman-touch-layout.clean.spec.json \
     xml/layoutbuilder/*.keyman-touch-layout \
-    projects/* \
-    server/*
+    projects/ \
+    server/
 
   cd "$THIS_SCRIPT_PATH"
 }

--- a/resources/teamcity/developer/keyman-developer-release.sh
+++ b/resources/teamcity/developer/keyman-developer-release.sh
@@ -95,9 +95,9 @@ function _publish_to_downloads_keyman_com() {
   (
     cd "${KEYMAN_ROOT}/developer"
 
-    local UPLOAD_PATH KEYBOARDS_PATH KMCOMP_ZIP DEVELOPER_EXE DEBUG_ZIP COMPRESS_CMD
+    local UPLOAD_PATH KEYBOARDS_PATH KMCOMP_ZIP DEVELOPER_EXE DEBUG_ZIP
     # shellcheck disable=SC2154
-    UPLOAD_PATH="upload/${KEYMAN_VERSION}"
+    UPLOAD_PATH="${KEYMAN_ROOT}/developer/upload/${KEYMAN_VERSION}"
     KEYBOARDS_PATH="${UPLOAD_PATH}/keyboards"
     KMCOMP_ZIP="kmcomp-${KEYMAN_VERSION}.zip"
     DEVELOPER_EXE="keymandeveloper-${KEYMAN_VERSION}.exe"
@@ -106,17 +106,8 @@ function _publish_to_downloads_keyman_com() {
     rm -rf "${UPLOAD_PATH}"
     mkdir -p "${UPLOAD_PATH}"
 
-    (
-      cd bin
-      cp "${KEYMAN_ROOT}/common/schemas/keyboard_info/keyboard_info.schema.json" .
-
-      # shellcheck disable=SC2154
-      COMPRESS_CMD="${SEVENZ_HOME}/7z"
-
-      "${COMPRESS_CMD}" a -bd -bb0 "../${UPLOAD_PATH}/${KMCOMP_ZIP}" kmconvert.exe keyboard_info.schema.json xml/layoutbuilder/*.keyman-touch-layout projects/ server/
-    )
-
-    cp "release/${KEYMAN_VERSION}/${DEVELOPER_EXE}" "${UPLOAD_PATH}/"
+    cp "${KEYMAN_ROOT}/developer/release/${KEYMAN_VERSION}/${DEVELOPER_EXE}" "${UPLOAD_PATH}/"
+    cp "${KEYMAN_ROOT}/developer/release/${KEYMAN_VERSION}/${KMCOMP_ZIP}"    "${UPLOAD_PATH}/"
 
     write_download_info "${UPLOAD_PATH}" "${DEVELOPER_EXE}" "Keyman Developer" exe win
     write_download_info "${UPLOAD_PATH}" "${KMCOMP_ZIP}" "Keyman Developer Command-Line Compiler" zip win
@@ -124,12 +115,12 @@ function _publish_to_downloads_keyman_com() {
     mkdir -p "${KEYBOARDS_PATH}"
     cp -r "${KEYMAN_ROOT}/common/test/keyboards"/*/build/*.kmp "${KEYBOARDS_PATH}/"
 
-    if [[ -f "release/${KEYMAN_VERSION}/${DEBUG_ZIP}" ]]; then
-      cp "release/${KEYMAN_VERSION}/${DEBUG_ZIP}" "${UPLOAD_PATH}/"
+    if [[ -f "${KEYMAN_ROOT}/developer/release/${KEYMAN_VERSION}/${DEBUG_ZIP}" ]]; then
+      cp "${KEYMAN_ROOT}/developer/release/${KEYMAN_VERSION}/${DEBUG_ZIP}" "${UPLOAD_PATH}/"
       write_download_info "${UPLOAD_PATH}" "${DEBUG_ZIP}" "Keyman Developer debug files" zip win
     fi
 
-    cd upload
+    cd "${KEYMAN_ROOT}/developer/upload"
     # shellcheck disable=SC2154
     tc_rsync_upload "${KEYMAN_VERSION}" "developer/${KEYMAN_TIER}"
   )


### PR DESCRIPTION
Previously we created the KMC_ZIP file twice, and one of them was outdated. This change moves creating the zip file to `developer/src/inst/build.sh` so that the TC build script only does the upload.

Fixes: #14263
Test-bot: skip