### PR TITLE
maint(android): remove `--ci` parameter from Android release builds 🩹

### DIFF
--- a/resources/teamcity/android/keyman-android-release.sh
+++ b/resources/teamcity/android/keyman-android-release.sh
@@ -86,7 +86,7 @@ function _publish_to_downloads_keyman_com() {
 function _publish_to_playstore() {
   builder_echo start "publish to Google Play Store" "Publishing release to Google Play Store"
 
-  "${KEYMAN_ROOT}/android/build.sh" "publish:${PUBTARGETS}" --ci
+  "${KEYMAN_ROOT}/android/build.sh" "publish:${PUBTARGETS}"
 
   builder_echo end "publish to Google Play Store" success "Finished publishing release to Google Play Store"
 }


### PR DESCRIPTION
PR #14264 removed the `--ci` parameter from Android builds, but forgot to remove it for release builds. This PR fixes this.

Follow-up-of: #14264
Build-bot: skip
Test-bot: skip