### PR TITLE
maint(windows): fix platform name for Windows 🩹

### DIFF
--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -12,13 +12,13 @@ verify_on_mac() {
   fi
 }
 
-# The list of valid projects that our build scripts ought expect.
-projects=("android" "ios" "linux" "lmlayer" "mac" "web" "windows")
+# The list of valid platforms that our build scripts ought expect.
+platforms=("android" "ios" "linux" "lmlayer" "mac" "web" "win")
 
 # Used to validate a specified 'project' parameter.
-_verify_project() {
+_verify_platform() {
   match=false
-  for proj in "${projects[@]}"
+  for proj in "${platforms[@]}"
   do
     if [[ "${proj}" = "$1" ]]; then
       match=true
@@ -108,7 +108,7 @@ write_download_info() {
 
   local DATE HASH SIZE DOWNLOAD_INFO STAT_FLAGS
 
-  _verify_project "${PLATFORM}"
+  _verify_platform "${PLATFORM}"
 
   # shellcheck disable=SC2312
   if [[ "${BUILDER_OS}" == "mac" ]] && [[ $(command -v stat) == /usr/bin/stat ]]; then

--- a/resources/shellHelperFunctions.sh
+++ b/resources/shellHelperFunctions.sh
@@ -15,7 +15,7 @@ verify_on_mac() {
 # The list of valid platforms that our build scripts ought expect.
 platforms=("android" "ios" "linux" "lmlayer" "mac" "web" "win")
 
-# Used to validate a specified 'project' parameter.
+# Used to validate a specified 'platform' parameter.
 _verify_platform() {
   match=false
   for proj in "${platforms[@]}"


### PR DESCRIPTION
The .download_info files use the platform `win` instead of `windows`. This PR changes this, and also renames the `_verify_project` function to `_verify_platform` to better match what it's checking. Fixes Windows release builds.

Follow-up-of: #14270 
Test-bot: skip