### PR TITLE
maint(developer): add missing include file 🩹

### DIFF
--- a/resources/teamcity/developer/keyman-developer-release.sh
+++ b/resources/teamcity/developer/keyman-developer-release.sh
@@ -13,6 +13,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 # shellcheck disable=SC2154
+. "${KEYMAN_ROOT}/resources/shellHelperFunctions.sh"
 . "${KEYMAN_ROOT}/resources/teamcity/includes/tc-helpers.inc.sh"
 . "${KEYMAN_ROOT}/resources/teamcity/includes/tc-windows.inc.sh"
 


### PR DESCRIPTION
`keyman-developer-release.sh` calls the `write_download_info` function but neglected to source the `shellHelperFunctions.sh` file which defines that function. Thus this change fixes the release build.

Build-bot: skip
Test-bot: skip