### PR TITLE
maint(windows): replace hardcoded `symbols` paths with parameters

### DIFF
--- a/resources/teamcity/developer/keyman-developer-release.sh
+++ b/resources/teamcity/developer/keyman-developer-release.sh
@@ -23,21 +23,19 @@ builder_describe \
   "all            run all actions" \
   "build          build Keyman Developer and test keyboards" \
   "publish        publish release of Keyman Developer" \
-  "--rsync-path=RSYNC_PATH            rsync path on remote server" \
-  "--rsync-user=RSYNC_USER            rsync user on remote server" \
-  "--rsync-host=RSYNC_HOST            rsync host on remote server" \
-  "--rsync-root=RSYNC_ROOT            rsync root on remote server" \
-  "--help.keyman.com=HELP_KEYMAN_COM  path to help.keyman.com repository"
+  "--rsync-path=RSYNC_PATH                    rsync path on remote server" \
+  "--rsync-user=RSYNC_USER                    rsync user on remote server" \
+  "--rsync-host=RSYNC_HOST                    rsync host on remote server" \
+  "--rsync-root=RSYNC_ROOT                    rsync root on remote server" \
+  "--help.keyman.com=HELP_KEYMAN_COM          path to help.keyman.com repository" \
+  "--symbols-local-path=LOCAL_SYMBOLS_PATH    local path to symbols directory" \
+  "--symbols-remote-path=REMOTE_SYMBOLS_PATH  remote path to symbols directory" \
+  "--symbols-subdir=SYMBOLS_SUBDIR            subdirectory containing symbols"
 
 builder_parse "$@"
 
 # shellcheck disable=SC2154
 cd "${KEYMAN_ROOT}/developer/src"
-
-# TODO: move to parameters (#14202)
-LOCAL_SYMBOLS_PATH="${KEYMAN_ROOT}/../symbols"
-REMOTE_SYMBOLS_PATH="windows/symbols"
-SYMBOLS_SUBDIR="000admin"
 
 function _build_developer() {
   builder_echo start "build developer" "Building Keyman Developer"

--- a/resources/teamcity/windows/keyman-windows-release.sh
+++ b/resources/teamcity/windows/keyman-windows-release.sh
@@ -26,11 +26,14 @@ builder_describe \
   "build          build Keyman for Windows Windows" \
   "test           run Keyman for Windows tests" \
   "publish        publish release" \
-  "--rsync-path=RSYNC_PATH            rsync path on remote server" \
-  "--rsync-user=RSYNC_USER            rsync user on remote server" \
-  "--rsync-host=RSYNC_HOST            rsync host on remote server" \
-  "--rsync-root=RSYNC_ROOT            rsync root on remote server" \
-  "--help.keyman.com=HELP_KEYMAN_COM  path to help.keyman.com repository"
+  "--rsync-path=RSYNC_PATH                    rsync path on remote server" \
+  "--rsync-user=RSYNC_USER                    rsync user on remote server" \
+  "--rsync-host=RSYNC_HOST                    rsync host on remote server" \
+  "--rsync-root=RSYNC_ROOT                    rsync root on remote server" \
+  "--help.keyman.com=HELP_KEYMAN_COM          path to help.keyman.com repository" \
+  "--symbols-local-path=LOCAL_SYMBOLS_PATH    local path to symbols directory" \
+  "--symbols-remote-path=REMOTE_SYMBOLS_PATH  remote path to symbols directory" \
+  "--symbols-subdir=SYMBOLS_SUBDIR            subdirectory containing symbols"
 
 builder_parse "$@"
 
@@ -40,11 +43,6 @@ if ! is_windows; then
   builder_echo error "This script is intended to be run on Windows only."
   exit 1
 fi
-
-# TODO: move to parameters (#14202)
-LOCAL_SYMBOLS_PATH="${KEYMAN_ROOT}/../symbols"
-REMOTE_SYMBOLS_PATH="windows/symbols"
-SYMBOLS_SUBDIR="000admin"
 
 function _publish_to_downloads_keyman_com() {
   # Publish to downloads.keyman.com


### PR DESCRIPTION
Only touches release build files, so skipping PR test builds.

Fixes: #14202
Build-bot: skip
Test-bot: skip