### PR TITLE
maint(mac): don't run `build.sh publish` twice

### DIFF
--- a/resources/teamcity/macos/keyman-macos-release.sh
+++ b/resources/teamcity/macos/keyman-macos-release.sh
@@ -62,15 +62,7 @@ function _publish_to_downloads_keyman_com() {
   builder_echo end "publish to downloads.keyman.com" success "Finished publishing release to downloads.keyman.com"
 }
 
-function _build_publish() {
-  builder_echo start "publish" "Publishing Keyman for macOS"
-  # shellcheck disable=SC2154
-  "${KEYMAN_ROOT}/mac/build.sh" publish
-  builder_echo end success "publish" "Finished publishing Keyman for macOS"
-}
-
 function do_publish() {
-  _build_publish
   _publish_to_downloads_keyman_com
   upload_help "Keyman for macOS" mac
 }


### PR DESCRIPTION
We already run `build.sh publish` as part of the regular release build in `macos_build_action`, so we don't have to call it again.

Build-bot: skip
Test-bot: skip