### PR TITLE
change(web): do not set deleteRight when merging Transforms without it 🚂

### DIFF
--- a/web/src/engine/predictive-text/templates/src/common.ts
+++ b/web/src/engine/predictive-text/templates/src/common.ts
@@ -55,13 +55,18 @@ export function buildMergedTransform(first: Transform, second: Transform): Trans
     }
   }
 
-  return {
+  const returnedObj: Transform = {
     insert: mergedFirstInsert + second.insert,
-    deleteLeft: first.deleteLeft + mergedSecondDelete,
+    deleteLeft: first.deleteLeft + mergedSecondDelete
+  }
+
+  if(first.deleteRight != undefined || second.deleteRight != undefined) {
     // As `first` would affect the context before `second` could take effect,
     // this is the correct way to merge `deleteRight`.
-    deleteRight: (first.deleteRight || 0) + (second.deleteRight || 0)
+    returnedObj.deleteRight = (first.deleteRight || 0) + (second.deleteRight || 0)
   }
+
+  return returnedObj;
 }
 
 /**

--- a/web/src/engine/predictive-text/templates/tests/common.tests.js
+++ b/web/src/engine/predictive-text/templates/tests/common.tests.js
@@ -22,8 +22,7 @@ describe('Common utility functions', function() {
 
       let final = {
         insert: 'applebanana',
-        deleteLeft: 0,
-        deleteRight: 0
+        deleteLeft: 0
       };
 
       let mergedTransform = models.buildMergedTransform(apple, banana);
@@ -43,8 +42,7 @@ describe('Common utility functions', function() {
 
       let final = {
         insert: 'applebanana',
-        deleteLeft: 2,
-        deleteRight: 0
+        deleteLeft: 2
       };
 
       let mergedTransform = models.buildMergedTransform(apple, banana);
@@ -64,8 +62,7 @@ describe('Common utility functions', function() {
 
       let final = {
         insert: 'bananapple',  // the 'apple' transform removes the final 'a' from 'banana'.
-        deleteLeft: 0,
-        deleteRight: 0
+        deleteLeft: 0
       };
 
       let mergedTransform = models.buildMergedTransform(banana, apple);
@@ -85,8 +82,7 @@ describe('Common utility functions', function() {
 
       let final = {
         insert: 'bananapple',  // the 'apple' transform removes the final 'a' from 'banana'.
-        deleteLeft: 2,
-        deleteRight: 0
+        deleteLeft: 2
       };
 
       let mergedTransform = models.buildMergedTransform(banana, apple);

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/edit-distance/context-tracker.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/edit-distance/context-tracker.js
@@ -209,14 +209,14 @@ describe('ContextTracker', function() {
 
       let baseContextMatch = ContextTracker.modelContextState(existingContext.left);
       let newContextMatch = ContextTracker.attemptMatchContext(
-        newContext.left, 
-        baseContextMatch, 
+        newContext.left,
+        baseContextMatch,
         tokenizeTransformDistribution(tokenizer, {left: "an"}, [{sample: transform, p: 1}])
       );
       assert.isNotNull(newContextMatch?.state);
       assert.deepEqual(newContextMatch.state.tokens.map(token => token.raw), rawTokens);
       // We want to preserve all text preceding the new token when applying a suggestion.
-      assert.deepEqual(newContextMatch.preservationTransform, { insert: 'd ', deleteLeft: 0, deleteRight: 0});
+      assert.deepEqual(newContextMatch.preservationTransform, { insert: 'd ', deleteLeft: 0});
 
       // The 'wordbreak' transform
       let state = newContextMatch.state;
@@ -242,14 +242,14 @@ describe('ContextTracker', function() {
 
       let baseContextMatch = ContextTracker.modelContextState(existingContext.left);
       let newContextMatch = ContextTracker.attemptMatchContext(
-        newContext.left, 
-        baseContextMatch, 
+        newContext.left,
+        baseContextMatch,
         tokenizeTransformDistribution(tokenizer, {left: "apple a day keeps the doc"}, [{sample: transform, p: 1}])
       );
       assert.isNotNull(newContextMatch?.state);
       assert.deepEqual(newContextMatch.state.tokens.map(token => token.raw), rawTokens);
       // We want to preserve all text preceding the new token when applying a suggestion.
-      assert.deepEqual(newContextMatch.preservationTransform, { insert: 'tor ', deleteLeft: 0, deleteRight: 0 });
+      assert.deepEqual(newContextMatch.preservationTransform, { insert: 'tor ', deleteLeft: 0 });
 
       // The 'wordbreak' transform
       let state = newContextMatch.state;
@@ -271,7 +271,7 @@ describe('ContextTracker', function() {
       let newContext = models.tokenize(defaultBreaker, {
         left: "text'\""
       });
-      // The reason it's a problem - current internal logic isn't prepared to shift 
+      // The reason it's a problem - current internal logic isn't prepared to shift
       // from 1 to 3 tokens in a single step.
       assert.equal(newContext.left.length, 3);
 
@@ -280,8 +280,8 @@ describe('ContextTracker', function() {
         deleteLeft: 0
       }
       let problemContextMatch = ContextTracker.attemptMatchContext(
-        newContext.left, 
-        baseContextMatch, 
+        newContext.left,
+        baseContextMatch,
         tokenizeTransformDistribution(tokenizer, {left: "text'"}, [{sample: transform, p: 1}])
       );
       assert.isNull(problemContextMatch);


### PR DESCRIPTION
While working on some epic/autocorrect work, I found that some unit tests got notably harder to write due to the current behavior of `buildMergedTransform`, which always emits a value for `deleteRight` even if the input transforms lack a value for it.

As some upcoming epic/autocorrect work is likely to split constructed transforms to better help track changes to the context and delayed reversion metadata (see #12884), it's best to change the behavior and only write out a `deleteRight` value when it's actually merited.

Test-bot: skip