### PR TITLE
maint(common): fail build if adding relative file to zip

### DIFF
--- a/resources/build/zip.inc.sh
+++ b/resources/build/zip.inc.sh
@@ -85,6 +85,8 @@ function add_zip_files() {
     esac
   done
 
+  _verify_input "${INCLUDE[@]}"
+
   local COMPRESS_CMD=zip
   if ! command -v zip 2>&1 > /dev/null; then
     # Fallback to 7z
@@ -114,4 +116,21 @@ function add_zip_files() {
   if [[ -n "${EXCLUDE_FILE:-}" ]]; then
     rm "${EXCLUDE_FILE}"
   fi
+}
+
+_verify_input() {
+  local curdir file absfile
+  curdir="$(pwd)"
+
+  for file in "$@"; do
+    absfile=$(readlink --canonicalize-missing "${file}")
+    if [[ "${absfile}" != "${curdir}"* ]]; then
+      # 7z and zip behave differently if adding files that are not in the current
+      # directory. For files with relative paths, zip will add them relative to
+      # the current directory which is not what we want and can cause
+      # problems for the user. Therefore we disallow files that are not in the
+      # current directory.
+      builder_die "File ${file} is not in the current directory"
+    fi
+  done
 }


### PR DESCRIPTION
`7z` and `zip` behave differently if adding files that are not in the current directory. For files with relative paths, zip will add them relative to the current directory which is not what we want and can cause problems for the user. Therefore this change disallows files that are not in the current directory and aborts the build.

Test-bot: skip
