### PR TITLE
maint(ios): set env variables for FirstVoices

### DIFF
--- a/resources/teamcity/ios/keyman-ios-release.sh
+++ b/resources/teamcity/ios/keyman-ios-release.sh
@@ -242,6 +242,13 @@ function do_build() {
 }
 
 function do_publish() {
+  if builder_has_option --fv; then
+    export RELEASE_OEM=true
+    export RELEASE_OEM_FIRSTVOICES=true
+  else
+    export RELEASE_OEM_FIRSTVOICES=false
+  fi
+
   _publish_to_downloads_keyman_com
   upload_help "Keyman for iOS" ios
 


### PR DESCRIPTION
If the TC script gets `--fv` passed this change sets the required `RELEASE_OEM` and `RELEASE_OEM_FIRSTVOICES` env variables.

Build-bot: skip
Test-bot: skip