### PR TITLE
fix(linux): add `python3-pkg-resources` as explicit dependency

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -96,6 +96,7 @@ Depends:
  python3-fonttools,
  python3-gi,
  python3-packaging,
+ python3-pkg-resources,
  python3-sentry-sdk (>= 1.1),
  python3-xdg,
  ${misc:Depends},


### PR DESCRIPTION
Until Ubuntu 24.10/Debian 12 `python3-pkg-resources` got installed as a dependency of `python3-numpy`. With numpy version 2 (Ubuntu >= 25.04/ Debian >= 13) this is no longer the case, so we have to explicitly add it as a runtime dependency. It might be a bug that this dependency doesn't get automatically added, but this workaround will do.

Fixes: #14349
Fixes: KEYMAN-LINUX-82

# User Testing

Please run the tests on Ubuntu 25.04 Plucky.

## Tests

**TEST_DEP**: 
- [Install build artifacts of this PR](https://github.com/keymanapp/keyman/wiki/How-to-test-artifacts-from-pull-requests-for-Keyman-for-Linux)
- Reboot
- verify that you can open `km-config`