### PR TITLE
refactor(web): new method - attemptTokenizedAlignment

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -345,6 +345,46 @@ interface ContextMatchResult {
   tailTokensAdded: number;
 }
 
+/**
+ * Represents token-count values resulting from an alignment attempt between two
+ * different modeled context states.
+ */
+type TrackedContextStateAlignment = {
+  /**
+   * Denotes whether or not alignment is possible between two contexts.
+   */
+  canAlign: false
+} | {
+  /**
+   * Denotes whether or not alignment is possible between two contexts.
+   */
+  canAlign: true,
+  /**
+   * Notes the number of tokens added to the head of the 'incoming'/'new' context
+   * of the contexts being aligned.  If negative, the incoming context deleted
+   * a token found in the 'original' / base context.
+   *
+   * For the alignment, [base context index] + leadTokenShift = [incoming context index].
+   */
+  leadTokenShift: number,
+  /**
+   * The count of tokens perfectly aligned, with no need for edits, for two successfully-
+   * alignable contexts.
+   */
+  matchLength: number,
+  /**
+   * The count of tokens at the tail perfectly aligned (existing in both contexts) but
+   * edited for two successfully-alignable contexts.  These tokens directly follow those
+   * that need no edits.
+   */
+  tailEditLength: number,
+  /**
+   * The count of new tokens added at the end of the incoming context for two aligned contexts.
+   * If negative, the incoming context deleted a previously-existing token from the original.
+   */
+  tailTokenShift: number
+};
+
 export class ContextTracker extends CircularArray<TrackedContextState> {
   /**
    * Aligns two tokens on a character-by-character basis as needed for higher, token-level alignment
@@ -432,6 +472,171 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
     return true;
   }
 
+  static attemptTokenizedAlignment(
+    incomingTokenization: string[],
+    tokenizationToMatch: string[]
+  ): TrackedContextStateAlignment {
+
+    // Inverted order, since 'match' existed before our new context.
+    let mapping = ClassicalDistanceCalculation.computeDistance(
+      tokenizationToMatch.map(value => ({key: value})),
+      incomingTokenization.map(value => ({key: value})),
+      // Diagonal width to consider must be at least 2, as adding a single
+      // whitespace after a token tends to add two tokens: one for whitespace,
+      // one for the empty token to follow it.
+      3
+    );
+
+    let editPath = mapping.editPath();
+    const firstMatch = editPath.indexOf('match');
+    const lastMatch = getEditPathLastMatch(editPath);
+    if(firstMatch == -1) {
+      // If there are no matches, there's no alignment.
+      return {
+        canAlign: false
+      };
+    }
+
+    // Transpositions are not allowed at the token level during context alignment.
+    if(editPath.find((entry) => entry.indexOf('transpose') > -1)) {
+      return {
+        canAlign: false
+      };
+    }
+
+    let matchLength = lastMatch - firstMatch + 1;
+    let tailInsertLength = 0;
+    let tailDeleteLength = 0;
+    for(let i = lastMatch; i < editPath.length; i++) {
+      if(editPath[i] == 'insert') {
+        tailInsertLength++;
+      } else if(editPath[i] == 'delete') {
+        tailDeleteLength++;
+      }
+    }
+    if(tailInsertLength > 0 && tailDeleteLength > 0) {
+      // Something's gone weird if this happens; that should appear as a substitution instead.
+      // Otherwise, we have a VERY niche edit scenario.
+      return {
+        canAlign: false
+      };
+    }
+    const tailSubstituteLength = (editPath.length - 1 - lastMatch) - tailInsertLength - tailDeleteLength;
+
+    // Assertion:  for a long context, the bulk of the edit path should be a
+    // continuous block of 'match' entries.  If there's anything else in
+    // the middle, we have a context mismatch.
+    if(firstMatch > -1) {
+      for(let i = firstMatch+1; i < lastMatch; i++) {
+        if(editPath[i] != 'match') {
+          return {
+            canAlign: false
+          };
+        }
+      }
+    }
+
+    // If we have a perfect match with a pre-existing context, no mutations have
+    // happened; we have a 100% perfect match.
+    if(firstMatch == 0 && lastMatch == editPath.length - 1) {
+      return {
+        canAlign: true,
+        leadTokenShift: 0,
+        matchLength,
+        tailEditLength: tailSubstituteLength,
+        tailTokenShift: tailInsertLength - tailDeleteLength
+      };
+    }
+
+    // The edit path calc tries to put substitutes first, before inserts.
+    // We don't want that on the leading edge.
+    const lastEarlyInsert = editPath.lastIndexOf('insert', firstMatch);
+    const firstSubstitute = editPath.indexOf('substitute');
+    if(firstSubstitute > -1 && firstSubstitute < firstMatch && firstSubstitute < lastEarlyInsert) {
+      editPath[firstSubstitute] = 'insert';
+      editPath[lastEarlyInsert] = 'substitute';
+    }
+
+    // If mutations HAVE happened, we need to double-check the context-state alignment.
+    let priorEdit: typeof editPath[0];
+    let leadTokensRemoved = 0;
+    let leadSubstitutions = 0;
+
+    // The `i` index below aligns based upon the index within the `tokenizationToMatch` sequence
+    // and how it would have to be edited to align to the `incomingTokenization` sequence.
+    for(let i = 0; i < firstMatch; i++) {
+      switch(editPath[i]) {
+        case 'delete':
+          // All deletions should appear at the sliding window edge; if a deletion appears
+          // after the edge, but before the first match, something's wrong.
+          if(priorEdit && priorEdit != 'delete') {
+            return {
+              canAlign: false
+            };
+          }
+          leadTokensRemoved++;
+          break;
+        case 'substitute':
+          // We only allow for one leading token to be substituted.
+          //
+          // Any extras in the front would be pure inserts, not substitutions, due to
+          // the sliding context window and its implications.
+          if(leadSubstitutions++ > 0) {
+            return {
+              canAlign: false
+            };
+          }
+
+          // Find the word before and after substitution.
+          const incomingSub = incomingTokenization[i - (leadTokensRemoved > 0 ? leadTokensRemoved : 0)];
+          const matchingSub = tokenizationToMatch[i + (leadTokensRemoved < 0 ? leadTokensRemoved : 0)];
+
+          // Double-check the word - does the 'substituted' word itself align?
+          if(!this.isSubstitutionAlignable(incomingSub, matchingSub)) {
+            return {
+              canAlign: false
+            };
+          }
+
+          // There's no major need to drop parts of a token being 'slid' out of the context window.
+          // We'll leave it intact and treat it as a 'match'
+          matchLength++;
+          break;
+        case 'insert':
+          // Only allow an insert at the leading edge, as with 'delete's.
+          if(priorEdit && priorEdit != 'insert') {
+            return {
+              canAlign: false
+            };
+          }
+          // In case of backspaces, it's also possible to 'insert' a 'new'
+          // token - an old one that's slid back into view.
+          leadTokensRemoved--;
+          break;
+        default:
+          // No 'match' can exist before the first found index for a 'match'.
+          // No 'transpose-' edits should exist within this section, either.
+          return {
+            canAlign: false
+          };
+      }
+      priorEdit = editPath[i];
+    }
+
+    // If we need some form of tail-token substitution verification, add that here.
+
+    return {
+      canAlign: true,
+      // leadTokensRemoved represents the number of tokens that must be removed from the base context
+      // when aligning the contexts.  Externally, it's more helpful to think in terms of the count added
+      // to the incoming context.
+      leadTokenShift: -leadTokensRemoved + 0, // add 0 in case of a 'negative zero', which affects unit tests.
+      matchLength,
+      tailEditLength: tailSubstituteLength,
+      tailTokenShift: tailInsertLength - tailDeleteLength
+    };
+  }
+
   static attemptMatchContext(
     tokenizedContext: Token[],
     matchState: TrackedContextState,
@@ -496,7 +701,7 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
           // No 'insert' should exist on the leading edge of context when the
           // context window slides.
           //
-          // No 'transform' edits should exist within this section, either.
+          // No 'transpose' edits should exist within this section, either.
           return null;
       }
     }
@@ -783,6 +988,9 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
 
     let tokenize = determineModelTokenizer(model);
 
+    if(transformDistribution?.length == 0) {
+      transformDistribution = null;
+    }
     const inputTransform = transformDistribution?.[0];
     let transformTokenLength = 0;
     let tokenizedDistribution: Distribution<Transform[]> = null;

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/edit-distance/context-tracker.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/edit-distance/context-tracker.js
@@ -95,6 +95,318 @@ describe('ContextTracker', function() {
     });
   });
 
+  describe('attemptTokenizedAlignment', () => {
+    it("properly matches and aligns when contexts match", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [...baseContext];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 0,
+        matchLength: 5,
+        tailEditLength: 0,
+        tailTokenShift: 0
+      });
+    });
+
+    it("detects unalignable contexts - no matching tokens", () => {
+      const baseContext = [
+        'swift', 'tan', 'wolf', 'leaped', 'across'
+      ];
+      const newContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {canAlign: false});
+    });
+
+    it("detects unalignable contexts - too many mismatching tokens", () => {
+      const baseContext = [
+        'swift', 'tan', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {canAlign: false});
+    });
+
+    it("fails alignment for leading-edge word substitutions", () => {
+      const baseContext = [
+        'swift', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {canAlign: false});
+    });
+
+    it("fails alignment for small leading-edge word substitutions", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'sick', 'brown', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {canAlign: false});
+    });
+
+    it("properly matches and aligns when lead token is modified", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'uick', 'brown', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 0,
+        matchLength: 5,
+        tailEditLength: 0,
+        tailTokenShift: 0
+      });
+    });
+
+    it("properly matches and aligns when lead token is removed", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'brown', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: -1,
+        matchLength: 4,
+        tailEditLength: 0,
+        tailTokenShift: 0
+      });
+    });
+
+    it("properly matches and aligns when lead token is added", () => {
+      const baseContext = [
+        'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 1,
+        matchLength: 4,
+        tailEditLength: 0,
+        tailTokenShift: 0
+      });
+    });
+
+    it("properly matches and aligns when lead tokens are removed and modified", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'ox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: -2,
+        matchLength: 3,
+        tailEditLength: 0,
+        tailTokenShift: 0
+      });
+    });
+
+    it("properly matches and aligns when lead tokens are added and modified", () => {
+      const baseContext = [
+        'rown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 1,
+        matchLength: 4,
+        tailEditLength: 0,
+        tailTokenShift: 0
+      });
+    });
+
+    it("properly matches and aligns when lead token is removed and tail token is added", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'brown', 'fox', 'jumped', 'over', 'the'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: -1,
+        matchLength: 4,
+        tailEditLength: 0,
+        tailTokenShift: 1
+      });
+    });
+
+    it("properly matches and aligns when lead token and tail token are modified", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'ove'
+      ];
+      const newContext = [
+        'uick', 'brown', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 0,
+        matchLength: 4, // we treat 'quick' and 'uick' as the same
+        tailEditLength: 1,
+        tailTokenShift: 0
+      });
+    });
+
+    it("properly matches and aligns when lead token and tail token are modified + new token appended", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'ove'
+      ];
+      const newContext = [
+        'uick', 'brown', 'fox', 'jumped', 'over', 't'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 0,
+        matchLength: 4, // we treat 'quick' and 'uick' as the same
+        tailEditLength: 1,
+        tailTokenShift: 1
+      });
+    });
+
+    it("properly handles context window sliding backward", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'e', 'quick', 'brown', 'fox', 'jumped', 'ove'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 1,
+        matchLength: 4, // we treat 'quick' and 'uick' as the same
+        tailEditLength: 1,
+        tailTokenShift: 0
+      });
+    });
+
+    it("properly handles context window sliding far backward", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'the', 'quick', 'brown', 'fox', 'jumped'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 1,
+        matchLength: 4, // we treat 'quick' and 'uick' as the same
+        tailEditLength: 0,
+        tailTokenShift: -1
+      });
+    });
+
+    it("properly handles context window sliding farther backward", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'the', 'quick', 'brown', 'fox', 'jumpe'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 1,
+        matchLength: 3, // we treat 'quick' and 'uick' as the same
+        tailEditLength: 1,
+        tailTokenShift: -1
+      });
+    });
+
+    it("fails alignment for mid-head deletion", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'quick', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {canAlign: false});
+    });
+
+    it("fails alignment for mid-head insertion", () => {
+      const baseContext = [
+        'quick', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {canAlign: false});
+    });
+
+    it("fails alignment for mid-tail deletion", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'quick', 'brown', 'fox', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {canAlign: false});
+    });
+
+    it("fails alignment for mid-tail insertion", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'over'
+      ];
+      const newContext = [
+        'quick', 'brown', 'fox', 'jumped', 'far', 'over'
+      ];
+
+      const computedAlignment = ContextTracker.attemptTokenizedAlignment(newContext, baseContext);
+      assert.deepEqual(computedAlignment, {canAlign: false});
+    });
+  });
+
   describe('attemptMatchContext', function() {
     it("properly matches and aligns when lead token is removed", function() {
       let existingContext = models.tokenize(defaultBreaker, {


### PR DESCRIPTION
Following from #14363, this method performs context alignment calculations that may be used to match forms of the context before and after an edit by aligning their tokens and validating any edits that may have occurred.

Note that no 'tracked context' states are manipulated or altered by this method - it solely calculates the alignment deltas needed to align the two contexts.  Other methods may then take these values and determine the edits that occurred during the associated context transition as needed.

Note that the `attemptTokenizedAlignment` method is not integrated into the main codebase for the predictive-text worker at this time.  That said, this method _does_ integrate the `isSubstitutionAlignable` method introduced by #14363.

@keymanapp-test-bot skip