### PR TITLE
maint(common): fix use of `jq.inc.sh` in git hooks

### DIFF
--- a/resources/build/jq.inc.sh
+++ b/resources/build/jq.inc.sh
@@ -13,7 +13,9 @@ if [[ -z "${JQ+x}" ]]; then
   # . "${THIS_SCRIPT%/*}/build-utils.sh"
   ## END STANDARD BUILD SCRIPT INCLUDE
 
-  if builder_is_windows; then
+  # Don't use 'builder_is_windows' here, because this script is also
+  # used in git-hooks which don't source 'builder.inc.sh'.
+  if [[ "${OSTYPE}" == "cygwin" || "${OSTYPE}" == "msys" ]]; then
     JQ="$(dirname "${JQ_THIS_SCRIPT}")/jq-win64.exe"
   else
     JQ=jq


### PR DESCRIPTION
`jq.inc.sh` gets also used in some scripts that don't source our builder scripts, e.g. in git hooks. This means that `builder_is_windows` is not defined. This change replaces the call of that function with a slightly modified version of the previous implementation.

Follow-up-of: #14324
Build-bot: skip
Test-bot: skip