### PR TITLE
maint(common): fix `add_zip_files` if flags come before zip filename

### DIFF
--- a/resources/build/test/zip.inc.tests.sh
+++ b/resources/build/test/zip.inc.tests.sh
@@ -245,17 +245,46 @@ function mock_builder_die() {
   LOG_MSG+="DIE: $*"
 }
 
-function test__add_zip_files__ok_for_local_files() {
+function test__add_zip_files__flags_before_zipfile() {
   # Setup
-  MOCK_ZIP_PRESENT=1
+  MOCK_ZIP_PRESENT=0
   create_mock  builder_die  mock_builder_die
 
   # Execute
-  add_zip_files -q -r "/tmp/archive.zip" file1.txt a/file2.txt
+  add_zip_files -r -q "/tmp/archive.zip" file1.txt a/file2.txt
 
   # Verify
   unmock builder_die
   assert-not-contains "${LOG_MSG}" "DIE"
+  assert-equal "${ZIP_CMD_LOG}" "7z a -r -bd -bb0 /tmp/archive.zip file1.txt a/file2.txt"
+}
+
+function test__add_zip_files__flags_between_files() {
+  # Setup
+  MOCK_ZIP_PRESENT=0
+  create_mock  builder_die  mock_builder_die
+
+  # Execute
+  add_zip_files "/tmp/archive.zip" -q file1.txt -r a/file2.txt
+
+  # Verify
+  unmock builder_die
+  assert-not-contains "${LOG_MSG}" "DIE"
+  assert-equal "${ZIP_CMD_LOG}" "7z a -bd -bb0 -r /tmp/archive.zip file1.txt a/file2.txt"
+}
+
+function test__add_zip_files__flags_at_end() {
+  # Setup
+  MOCK_ZIP_PRESENT=0
+  create_mock  builder_die  mock_builder_die
+
+  # Execute
+  add_zip_files "/tmp/archive.zip" file1.txt a/file2.txt -r -q
+
+  # Verify
+  unmock builder_die
+  assert-not-contains "${LOG_MSG}" "DIE"
+  assert-equal "${ZIP_CMD_LOG}" "7z a -r -bd -bb0 /tmp/archive.zip file1.txt a/file2.txt"
 }
 
 function test__add_zip_files__die_if_relative_path() {

--- a/resources/build/test/zip.inc.tests.sh
+++ b/resources/build/test/zip.inc.tests.sh
@@ -245,6 +245,19 @@ function mock_builder_die() {
   LOG_MSG+="DIE: $*"
 }
 
+function test__add_zip_files__ok_for_local_files() {
+  # Setup
+  MOCK_ZIP_PRESENT=1
+  create_mock  builder_die  mock_builder_die
+
+  # Execute
+  add_zip_files -q -r "/tmp/archive.zip" file1.txt a/file2.txt
+
+  # Verify
+  unmock builder_die
+  assert-not-contains "${LOG_MSG}" "DIE"
+}
+
 function test__add_zip_files__die_if_relative_path() {
   # Setup
   MOCK_ZIP_PRESENT=1

--- a/resources/build/zip.inc.sh
+++ b/resources/build/zip.inc.sh
@@ -20,12 +20,7 @@
 function add_zip_files() {
 
   # Parse parameters
-
-  # $1 for zip filename
-  local ZIP_FILE="$1"
-  shift
-
-  # Parse rest of parameters
+  local ZIP_FILE
   local ZIP_FLAGS=()
   local SEVENZ_FLAGS=('a') # 7z requires a command
   local INCLUDE=()
@@ -80,8 +75,12 @@ function add_zip_files() {
         ;;
 
       *)
-        # files to include in the archive
-        INCLUDE+=($1)
+        # files to include in the archive. First non-flag parameter is the zip file name.
+        if [[ -z "${ZIP_FILE:-}" ]]; then
+          ZIP_FILE="$1"
+        else
+          INCLUDE+=("$1")
+        fi
         shift
         ;;
     esac

--- a/resources/build/zip.inc.sh
+++ b/resources/build/zip.inc.sh
@@ -6,17 +6,27 @@
 # If zip is not available, then fall back to 7z for zipping.
 # 7z requires env SEVENZ_HOME.
 #
-# TODO: refactor with /resources/build/win/zip.inc.sh
 
-# Add files to create a zip/7z archive with the following parameters (in order)
-# [zip filename]
-# [list of flags to pass to zip command] Flags start with a single-dash
+# Add files to create a zip/7z archive
+# Parameters:
+# - [zip filename]
+# - [list of files to include in zip]
+#
+# Optional flags:
 #   -x@filename for a file containing list of files to exclude from the archive
 #   -xr!name    to exclude files matching name from the archive
+#   -r          to recursively include files in subdirectories
+#   -q          to enable quiet mode (zip) or disable progress indicator
+#               and set output log level 0 (7z)
+#   -0 to -9    for compression level with -0 indicating no compression,
+#               -1 indicating low compression (fastest) and -9 indicating
+#               ultra compression (slowest)
 #   -* all other flags
-#   Flags passed in are treated as zip parameters, and internally converterted
-#   to 7z flags as applicable
-# [list of files to include in zip]
+# Flags start with a single-dash and get passed to zip command. They can come
+# before, after or in between the zip filename and the files to include.
+# Flags passed in are treated as zip parameters, and internally converterted
+# to 7z flags as applicable
+
 function add_zip_files() {
 
   # Parse parameters


### PR DESCRIPTION
Previously `add_zip_files` didn't work if the zip filename was not specified as first parameter. This change allows it to come after flags.

This will fix web release and other builds.

Test-bot: skip