### PR TITLE
maint(windows): always sign code even in CI builds

### DIFF
--- a/resources/build/win/environment.inc.sh
+++ b/resources/build/win/environment.inc.sh
@@ -113,11 +113,6 @@ clean_windows_project_files() {
 }
 
 wrap-signcode() {
-  if builder_is_ci_build && builder_is_ci_build_level_build; then
-    builder_echo "Skipping code signing - buildLevel=build: $@"
-    return 0
-  fi
-
   # CI will usually pass in a full path for signtool.exe; for local builds we
   # will hopefully find what we want on the path already
   if [[ -z "${SIGNTOOL+x}" ]]; then


### PR DESCRIPTION
In PR builds we make the artifacts available for testing, so they have to be signed as well.

Fixes: #14374
Build-bot: skip
Build-bot: build windows

# User Testing

**TEST_SIGNED**: install Keyman from the artifacts of this build. Verify that it can be installed and that you don't get any warnings/errors about unrecognized app.