### PR TITLE
maint(android): Update Android Target API to 35 🪟

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -12,7 +12,7 @@ apply from: "$rootPath/version.gradle"
 String tier = new File('../../TIER.md').getText('UTF-8').trim();
 
 android {
-    compileSdk 34
+    compileSdk 35
     namespace="com.tavultesoft.kmapro"
 
     // Don't compress kmp files so they can be copied via AssetManager

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -28,7 +28,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
 
         // KEYMAN_VERSION_CODE and KEYMAN_VERSION_NAME from version.gradle but Gradle removes them for libraries
         buildConfigField "String", "KEYMAN_ENGINE_VERSION_NAME", "\""+KEYMAN_VERSION_NAME+"\""

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         applicationId "com.keyman.kmsample1"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
     }

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         applicationId "com.keyman.kmsample2"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
     }

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         applicationId "com.keyman.android.tests.keyboardHarness"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
 
         // KEYMAN_VERSION_CODE and KEYMAN_VERSION_NAME from version.gradle
         versionCode KEYMAN_VERSION_CODE as Integer

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         applicationId "com.firstvoices.keyboards"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
 
         // KEYMAN_VERSION_CODE and KEYMAN_VERSION_NAME from version.gradle
         versionCode KEYMAN_VERSION_CODE as Integer


### PR DESCRIPTION
This is the easy portion of #14248 of updating the Android Target API to 35 to satisfy upcoming Play Store Aug 31 requirement.

Follow-on PR's to handle the complexity of the new edge-to-edge behavior where Android status bar (on top) and navigation bar (on bottom) cover up the Keyman app + in-app keyboard.

User Testing deferred to follow-on PR's

Test-bot: skip
Build-bot: skip