### PR TITLE
fix(android): Convert Keyman app layout to use ConstraintLayout for handling edge-to-edge 🪟

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -166,6 +166,9 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    // To use constraintlayout in compose
+    implementation 'androidx.constraintlayout:constraintlayout-compose:1.1.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'com.stepstone.stepper:material-stepper:4.3.1'
     api(name: 'keyman-engine', ext: 'aar')

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_main.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
@@ -9,27 +11,32 @@
     android:background="@color/yellow_background"
     tools:context=".MainActivity">
 
-    <include layout="@layout/titlebar" />
+    <include layout="@layout/titlebar"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-    <include layout="@layout/check_chrome_webview_layout"
-      android:visibility="gone"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_below="@id/titlebar"/>
+    <include
+        layout="@layout/check_chrome_webview_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/titlebar"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/titlebar" />
 
     <com.keyman.engine.KMTextView
         android:id="@+id/kmTextView"
-        android:background="@drawable/textview_bg"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/checkWebViewChromeLayout"
+        android:background="@drawable/textview_bg"
         android:ems="10"
-        android:inputType="textMultiLine|textNoSuggestions"
-        android:hint="@string/textview_hint"
         android:gravity="top"
-        android:scrollbars="vertical">
+        android:hint="@string/textview_hint"
+        android:inputType="textMultiLine|textNoSuggestions"
+        android:scrollbars="vertical"
+        app:layout_constraintTop_toBottomOf="@id/checkWebViewChromeLayout">
 
         <requestFocus />
     </com.keyman.engine.KMTextView>
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Follows #14395 for #14248

This uses Android Studio's tool to convert the top level layout from `RelativeLayout` to `ConstraintLayout`. 
Layout also updated with constraints to specify the order and boundaries. This way, the edge-to-edge doesn't cover up the top and bottom portions of the app.

Will update FirstVoices and Sample apps on a separate PR

## User Testing
**Setup** - Install the PR build of Keyman for Android on an Android device/emulator of the specified API

* **TEST_API_21** - Verifies app layout is fine on old device (displays prompt to update Chrome)
1. Install Keyman for Android on a device/emulator API 21. This has an old version of Chrome, so the app will display the prompt to update Chrome, and Keyman keyboard is disabled
2. Launch the app in the default Portrait orientation and dismiss the Get Started menu
3. Observe the Keyman app and verify:
    * app is not obscured by the top status bar or bottom navigation bar
    * under the title bar, the app has a prompt for the user to update Chrome
    * Keyboard is disabled
4. Rotate the app to landscape orientation (unlock orientation lock if necessary) and wait for the app to refresh
5. Observe the Keyman app and verify:
    * app is not obscured by the top status bar or bottom navigation bar
    * under the title bar, the app has a prompt for the user to update Chrome
    * Keyboard is disabled

* **TEST_API_36** - Verifies app layout is fine on new device
1. Install Keyman for Android on a device/emulator API 36.
2. Launch the app in the default Portrait orientation and dismiss the Get Started menu
3. Observe the Keyman app and verify:
    * app is not obscured by the top status bar
    * in-app keyboard is not obscured by the bottom navigation bar
    * in-app keyboard functions fine
4. Test all the menu options and verify none of the dialogs are obscured
5. Use Keyman settings to install khmer_angkor keyboard
6. Go through the keyboard installation and verify none of the menus are obscured 
7. Use the Keyman settings to enable Keyman as the default system keyboard.
8. Launch the Chrome app and select a text area
9. With the Keyman keyboard as the system keyboard, verify it is not obscured by the bottom navigation bar
10. Rotate the device to Landscape orientation and return to the Keyman app
11. Observe the Keyman app and verify:
    * app is not obscured by the top status bar
    * in-app keyboard is not obscured by the bottom navigation bar
    * in-app keyboard functions fine
12. Test all the menu options and verify none of the dialogs are obscured
