### PR TITLE
feat(developer): kmc-convert: use objects instead of arrays for storing data while reading .keylayout files

### DIFF
--- a/developer/src/kmc-convert/src/keylayout-to-kmn/keylayout-to-kmn-converter.ts
+++ b/developer/src/kmc-convert/src/keylayout-to-kmn/keylayout-to-kmn-converter.ts
@@ -26,6 +26,41 @@ export interface convert_object {
   arrayOf_Modifiers: string[][],
   arrayOf_Rules: Rule[],
 };
+//_S2 do I need search???
+export interface ActionIdOutputBehaviourKeyModi_object {
+  search: string,
+  actionId: string,
+  outchar: string,
+  behaviour: string,
+  key: string,
+  modifier: string,
+};
+
+
+
+export interface ActionIdKeyModiOutput_object {
+  actionId: string,
+  keyCode: string,
+  key: string,
+  modifier: string,
+  outchar: string;
+};
+export interface modifierKey_object {
+  key: string;  // _S2 todo change everywhere!!!
+  modifier: number,
+};
+export interface modifier_object {
+  modifier: string,
+};
+export interface behaviourKey_object {
+  behaviour: string,
+  key: string,
+};
+export interface idStateOutput_object {
+  id: string,
+  state: string,
+  output: string,
+};
 
 export class KeylayoutToKmnConverter {
 
@@ -206,15 +241,15 @@ export class KeylayoutToKmnConverter {
 
           for (let l = 0; l < data_ukelele.arrayOf_Modifiers[i].length; l++) {
 
-            if ((this.get_Output__From__ActionId_None(jsonObj, action_id) !== undefined)
-              && (this.get_Output__From__ActionId_None(jsonObj, action_id) !== "")) {
+            if ((this.get_4_Output__From__ActionId_None(jsonObj, action_id) !== undefined)
+              && (this.get_4_Output__From__ActionId_None(jsonObj, action_id) !== "")) {
 
-              const outputchar: string = this.get_Output__From__ActionId_None(jsonObj, action_id);
-              const b1_modifierKey_arr: string[][] =
-                this.get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(jsonObj, data_ukelele.arrayOf_Modifiers, action_id, outputchar, isCapsused);
+              const outputchar: string = this.get_4_Output__From__ActionId_None(jsonObj, action_id);
 
-              for (let m = 0; m < b1_modifierKey_arr.length; m++) {
+              const b1_modifierKey_obj: ActionIdOutputBehaviourKeyModi_object[] =
+                this.get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(jsonObj, data_ukelele.arrayOf_Modifiers, action_id, outputchar, isCapsused);
 
+              for (let m = 0; m < b1_modifierKey_obj.length; m++) {
                 rule_obj = new Rule(
                   /*   rule_type */               "C1",
 
@@ -228,8 +263,8 @@ export class KeylayoutToKmnConverter {
                   /*   dk for C2*/                0,
                   /*   unique B */                0,
 
-                  /*   modifier_key*/             b1_modifierKey_arr[m][5],
-                  /*   key */                     b1_modifierKey_arr[m][4],
+                  /*   modifier_key*/             b1_modifierKey_obj[m].modifier,
+                  /*   key */                     b1_modifierKey_obj[m].key,
                   /*   output */                  new TextEncoder().encode(outputchar)
                 );
                 if ((outputchar !== undefined) && (outputchar !== "undefined") && (outputchar !== "")) {
@@ -247,7 +282,7 @@ export class KeylayoutToKmnConverter {
             // https://docs.google.com/document/d/12J3NGO6RxIthCpZDTR8FYSRjiMgXJDLwPY2z9xqKzJ0/edit?tab=t.0#heading=h.g7jwx3lx0ydd   .........
             // ...............................................................................................................................
 
-            const b1_actionIndex: number = this.get_ActionIndex__From__ActionId(jsonObj, action_id);
+            const b1_actionIndex: number = this.get_1_ActionIndex__From__ActionId(jsonObj, action_id);
 
             // with action_id from above loop all 'action' and search for a state(none)-next-pair ............................................................................................................
             // e.g. in Block 5: find <when state="none" next="1"/> for action id a18 ......................................................................................................................
@@ -264,27 +299,38 @@ export class KeylayoutToKmnConverter {
               // Data of Block Nr 4 .....................................................................................................................................................................
               // with present action_id (a18) find all keycode-behaviour-pairs that use this action (a18) => (keymapIndex 0/keycode 24 and keymapIndex 3/keycode 24) ....................................
               // from these create an array of modifier combinations  e.g. [['','caps?'], ['Caps']] .....................................................................................................
-              /* eg: [['24', 0], ['24', 3]] */        const b4_deadkey_arr: number[][] = this.get_KeyModifier_array__From__ActionID(jsonObj, action_id);
-              /* e.g. [['','caps?'], ['Caps']]*/      const b4_deadkeyModifier_arr: string[] = this.get_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b4_deadkey_arr);
+              /* eg: [['24', 0], ['24', 3]] */        // const b4_deadkey_arr: number[][] = this.get_9o_KeyModifier_array__From__ActionID_oldArrayType(jsonObj, action_id);  //_S2 remove&replace
+              /* eg: [['24', 0], ['24', 3]] */        const b4_deadkey_obj: modifierKey_object[] = this.get_9_KeyModifier_array__From__ActionID(jsonObj, action_id);
+              /* e.g. [['','caps?'], ['Caps']]*/      //const b4_deadkeyModifier_arr: string[] = this.get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(data_ukelele.arrayOf_Modifiers, b4_deadkey_arr);//_S2 remove&replace
+              /* e.g. [['','caps?'], ['Caps']]*/      const b4_deadkeyModifier_obj: string[] = this.get_3_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b4_deadkey_obj);
               // ........................................................................................................................................................................................
 
 
               // Data of Block Nr 6 .....................................................................................................................................................................
               // create an array[action id,state,output] from all state-output-pairs that use state = b5_value_next (e.g. use 1 in  <when state="1" output="â"/> ) ......................................
-              /*  eg: [ 'a9','1','â'] */              const b6_actionId_arr: string[][] = this.get_ActionStateOutput_array__From__ActionState(jsonObj, b5_value_next);
+              /*  eg: [ 'a9','1','â'] */              //const b6_actionId_arr: string[][] = this.get_6o_ActionStateOutput_array__From__ActionState_oldArrayType(jsonObj, b5_value_next);//_S2 remove&replace
+              /*  eg: [ 'a9','1','â'] */                const b6_actionId_obj: idStateOutput_object[] = this.get_6_ActionStateOutput_array__From__ActionState(jsonObj, b5_value_next);
               // ........................................................................................................................................................................................
 
 
               // Data of Block Nr 1  ....................................................................................................................................................................
               // create array[Keycode,Keyname,action id,actionIndex,output] and array[Keyname,action id,behaviour,modifier,output] ......................................................................
-              /*  eg: ['0','K_A','a9','0','â'] */     const b1_keycode_arr: string[][] = this.get_KeyActionOutput_array__From__ActionStateOutput_array(jsonObj, b6_actionId_arr);
-              /*  eg: ['K_A','a9','0','NCAPS','â']*/  const b1_modifierKey_arr: string[][] = this.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_arr, isCapsused);
+              /*  eg: ['0','K_A','a9','0','â'] */     //const b1_keycode_arr: string[][] = this.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(jsonObj, b6_actionId_arr);//_S2 remove&replace
+              /*  eg: ['0','K_A','a9','0','â'] */     const b1_keycode_obj: ActionIdKeyModiOutput_object[] = this.get_5_KeyActionOutput_array__From__ActionStateOutput_array(jsonObj, b6_actionId_obj);
+
+              /*  eg: ['K_A','a9','0','NCAPS','â']*/ // const b1_modifierKey_arr: string[][] = this.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_arr(jsonObj, b1_keycode_arr, isCapsused);//_S2 remove&replace
+              /*  eg: ['K_A','a9','0','NCAPS','â']*/  //const b1_modifierKey_obj: ActionIdOutputBehaviourKeyModi_object[] = this.get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_arr, isCapsused);//_S2 remove&replace
+              /*  eg: ['K_A','a9','0','NCAPS','â']*/  const b1_modifierKey_obj: ActionIdOutputBehaviourKeyModi_object[] = this.get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_obj, isCapsused);//_S2 remove&replace          
                 // .......................................................................................................................................................................................
 
-                for (let n1 = 0; n1 < b4_deadkeyModifier_arr.length; n1++) {
-                  for (let n2 = 0; n2 < b4_deadkeyModifier_arr[n1].length; n2++) {
-                    for (let n3 = 0; n3 < b4_deadkey_arr.length; n3++) {
-                      for (let n4 = 0; n4 < b1_modifierKey_arr.length; n4++) {
+                //for (let n1 = 0; n1 < b4_deadkeyModifier_arr.length; n1++) {
+                for (let n1 = 0; n1 < b4_deadkeyModifier_obj.length; n1++) {
+                  //for (let n2 = 0; n2 < b4_deadkeyModifier_arr[n1].length; n2++) {
+                  for (let n2 = 0; n2 < b4_deadkeyModifier_obj[n1].length; n2++) {
+                    // for (let n3 = 0; n3 < b4_deadkey_arr.length; n3++) {
+                    for (let n3 = 0; n3 < b4_deadkey_obj.length; n3++) {
+                      //for (let n4 = 0; n4 < b1_modifierKey_arr.length; n4++) {//_S2 remove&replace
+                      for (let n4 = 0; n4 < b1_modifierKey_obj.length; n4++) {
 
                         rule_obj = new Rule(
                         /*   rule_type */             "C2",
@@ -294,18 +340,30 @@ export class KeylayoutToKmnConverter {
                         /*   id_prev_deadkey */       0,
                         /*   unique A */              0,
 
-                        /*   modifier_deadkey */      this.create_kmn_modifier(b4_deadkeyModifier_arr[n1][n2], isCapsused),
-                        /*   deadkey */               this.map_UkeleleKC_To_VK(Number(b4_deadkey_arr[n3][0])),
+                        /*   modifier_deadkey */     //this.create_kmn_modifier(b4_deadkeyModifier_arr[n1][n2], isCapsused),
+                        /*   modifier_deadkey */      this.create_kmn_modifier(b4_deadkeyModifier_obj[n1][n2], isCapsused),
+                        /*   deadkey */               //this.map_UkeleleKC_To_VK(Number(b4_deadkey_arr[n3][0])),
+                        /*   deadkey */               this.map_UkeleleKC_To_VK(Number(b4_deadkey_obj[n3].key)),
                         /*   dk for C2*/              dk_counter_C2++,
                         /*   unique B */              0,
 
-                        /*   modifier_key*/           b1_modifierKey_arr[n4][3],
-                        /*   key */                   b1_modifierKey_arr[n4][0],
-                        /*   output */                new TextEncoder().encode(b1_modifierKey_arr[n4][4]),
+                        /*   modifier_key*/          // b1_modifierKey_arr[n4][3],//_S2 remove&replace
+                        /*   key */                   //b1_modifierKey_arr[n4][0],
+                        /*   output */               // new TextEncoder().encode(b1_modifierKey_arr[n4][4]),
+
+                        /*   modifier_key*/           b1_modifierKey_obj[n4].modifier,
+                        /*   key */                   b1_modifierKey_obj[n4].key,
+                        /*   output */                new TextEncoder().encode(b1_modifierKey_obj[n4].outchar),
                         );
-                        if ((b1_modifierKey_arr[n4][4] !== undefined)
-                          && (b1_modifierKey_arr[n4][4] !== "undefined")
-                          && (b1_modifierKey_arr[n4][4] !== "")) {
+                        /* if ((b1_modifierKey_arr[n4][4] !== undefined)//_S2 remove&replace
+                           && (b1_modifierKey_arr[n4][4] !== "undefined")
+                           && (b1_modifierKey_arr[n4][4] !== "")) {
+                           object_array.push(rule_obj);
+                         }*/
+
+                        if ((b1_modifierKey_obj[n4].outchar !== undefined)
+                          && (b1_modifierKey_obj[n4].outchar !== "undefined")
+                          && (b1_modifierKey_obj[n4].outchar !== "")) {
                           object_array.push(rule_obj);
                         }
                       }
@@ -341,60 +399,94 @@ export class KeylayoutToKmnConverter {
               // Data of Block Nr 4 ........................................................................................................................................................................
               // with present action_id (a16) find all keycode-behaviour-pairs that use this action (a16) => (keymapIndex 3/keycode 32) ....................................................................
               // from these create an array of modifier combinations  e.g. [ [ 'anyOption', 'Caps' ] ] .....................................................................................................
-              /* e.g. [['32', 3]] */                      const b4_deadkey_arr: number[][] = this.get_KeyModifier_array__From__ActionID(jsonObj, action_id);
-              /* e.g. [ [ 'anyOption', 'Caps' ] ]*/       const b4_deadkeyModifier_arr: string[] = this.get_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b4_deadkey_arr);
+              /* e.g. [['32', 3]] */                     // const b4_deadkey_arr: number[][] = this.get_9o_KeyModifier_array__From__ActionID_oldArrayType(jsonObj, action_id);//_S2 remove&replace
+              /* e.g. [['32', 3]] */                      const b4_deadkey_obj: modifierKey_object[] = this.get_9_KeyModifier_array__From__ActionID(jsonObj, action_id);
+              /* e.g. [ [ 'anyOption', 'Caps' ] ]*/      // const b4_deadkeyModifier_arr: string[] = this.get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(data_ukelele.arrayOf_Modifiers, b4_deadkey_arr);
+              /* e.g. [ [ 'anyOption', 'Caps' ] ]*/       const b4_deadkeyModifier_obj: string[] = this.get_3_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b4_deadkey_obj);
               // ...........................................................................................................................................................................................
 
               // Data of Block Nr 3 ........................................................................................................................................................................
               // get an action id from a state-output-pair that use state = b5_value_state (e.g. use 3 in  <when state="none" next="3"/> ) .................................................................
-              /* e.g. actioniD = a17  */                  const b3_actionId: string = this.get_ActionID__From__ActionNext(jsonObj, b5_value_state);
+              /* e.g. actioniD = a17  */                  const b3_actionId: string = this.get_2_ActionID__From__ActionNext(jsonObj, b5_value_state);
               // ...........................................................................................................................................................................................
 
               // Data of Block Nr 2  .......................................................................................................................................................................
               // with present action_id (a17) find all key names and behaviours that use this action (a17) => (keymapIndex 3/keycode 28) ....................................................................
               // from these create an array of modifier combinations  e.g. [ [ 'anyOption', 'Caps' ] ] .....................................................................................................
-              /* eg: index=3 */                           const b2_prev_deadkey_arr: number[][] = this.get_KeyModifier_array__From__ActionID(jsonObj, String(b3_actionId));   // conversion not necessary
-              /* e.g. [ [ 'anyOption', 'Caps' ] ] */      const b2_prev_deadkeyModifier_arr: string[] = this.get_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b2_prev_deadkey_arr);
+                       
+          
+             
+              /* eg: index=3 */                           //const b2_prev_deadkey_arr: number[][] = this.get_9o_KeyModifier_array__From__ActionID_oldArrayType(jsonObj, b3_actionId);   // conversion not necessary //_S2 remove&replace
+              /* eg: index=3 */                           const b2_prev_deadkey_obj: modifierKey_object[] = this.get_9_KeyModifier_array__From__ActionID(jsonObj, b3_actionId);   // conversion not necessary //_S2 remove&replace
+              /* e.g. [ [ 'anyOption', 'Caps' ] ] */     // const b2_prev_deadkeyModifier_arr: string[] = this.get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(data_ukelele.arrayOf_Modifiers, b2_prev_deadkey_arr);
+             /* e.g. [ [ 'anyOption', 'Caps' ] ] */      const b2_prev_deadkeyModifier_obj: string[] = this.get_3_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b2_prev_deadkey_obj);
               // ...........................................................................................................................................................................................
               // Data of Block Nr 6 ........................................................................................................................................................................
               // create an array[action id,state,output] from all state-output-pairs that use state = b5_value_next (e.g. use 1 in  <when state="1" output="â"/> ) .........................................
-              /*  eg:[ [ 'a9','1','â'] ]*/                const b6_actionId_arr: string[][] = this.get_ActionStateOutput_array__From__ActionState(jsonObj, b5_value_next);
+              /*  eg:[ [ 'a9','1','â'] ]*/               // const b6_actionId_arr: string[][] = this.get_6o_ActionStateOutput_array__From__ActionState_oldArrayType(jsonObj, b5_value_next);
+              /*  eg:[ [ 'a9','1','â'] ]*/                const b6_actionId_obj: idStateOutput_object[] = this.get_6_ActionStateOutput_array__From__ActionState(jsonObj, b5_value_next); /*  eg:[ [ 'a9','1','â'] ]*/
               // ...........................................................................................................................................................................................
 
               // Data of Block Nr 1  .......................................................................................................................................................................
               // create array[Keycode,Keyname,action id,actionIndex,output] and array[Keyname,action id,behaviour,modifier,output] .........................................................................
-              /*  eg: ['49','K_SPACE','a0','0','Â'] */    const b1_keycode_arr: string[][] = this.get_KeyActionOutput_array__From__ActionStateOutput_array(jsonObj, b6_actionId_arr);
-              /*  eg: ['K_SPACE','a0','0','NCAPS','Â'] */ const b1_modifierKey_arr: string[][] = this.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_arr, isCapsused);
+              /*  eg: ['49','K_SPACE','a0','0','Â'] */    //const b1_keycode_arr: string[][] = this.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(jsonObj, b6_actionId_arr);
+               /*  eg: ['0','K_A','a9','0','â'] */        const b1_keycode_obj: ActionIdKeyModiOutput_object[] = this.get_5_KeyActionOutput_array__From__ActionStateOutput_array(jsonObj, b6_actionId_obj);
+                // console.log("b1_keycode_obj ", b1_keycode_obj);
+                //this.compareBoth(b1_keycode_arr, b1_keycode_obj);
+
+                /*  eg: ['K_SPACE','a0','0','NCAPS','Â'] */ //const b1_modifierKey_arr: string[][] = this.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_arr(jsonObj, b1_keycode_arr, isCapsused);//_S2 remove&replace
+                /*  eg: ['K_SPACE','a0','0','NCAPS','Â'] */ //const b1_modifierKey_obj: ActionIdOutputBehaviourKeyModi_object[] = this.get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_arr, isCapsused);
+                const b1_modifierKey_obj: ActionIdOutputBehaviourKeyModi_object[] = this.get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_obj, isCapsused);//_S2 remove&replace         
                 // ...........................................................................................................................................................................................
 
-                for (let n1 = 0; n1 < b2_prev_deadkeyModifier_arr.length; n1++) {
-                  for (let n2 = 0; n2 < b2_prev_deadkeyModifier_arr[n1].length; n2++) {
-                    for (let n3 = 0; n3 < b2_prev_deadkey_arr.length; n3++) {
-                      for (let n4 = 0; n4 < b4_deadkeyModifier_arr.length; n4++) {
-                        for (let n5 = 0; n5 < b4_deadkeyModifier_arr[n4].length; n5++) {
-                          for (let n6 = 0; n6 < b4_deadkey_arr.length; n6++) {
-                            for (let n7 = 0; n7 < b1_modifierKey_arr.length; n7++) {
+                //for (let n1 = 0; n1 < b2_prev_deadkeyModifier_arr.length; n1++) {
+                for (let n1 = 0; n1 < b2_prev_deadkeyModifier_obj.length; n1++) {
+                  //for (let n2 = 0; n2 < b2_prev_deadkeyModifier_arr[n1].length; n2++) {
+                  for (let n2 = 0; n2 < b2_prev_deadkeyModifier_obj[n1].length; n2++) {
+                    //for (let n3 = 0; n3 < b2_prev_deadkey_arr.length; n3++) {
+                    for (let n3 = 0; n3 < b2_prev_deadkey_obj.length; n3++) {
+                      //for (let n4 = 0; n4 < b4_deadkeyModifier_arr.length; n4++) {
+                      for (let n4 = 0; n4 < b4_deadkeyModifier_obj.length; n4++) {
+                       // for (let n5 = 0; n5 < b4_deadkeyModifier_arr[n4].length; n5++) {
+                        for (let n5 = 0; n5 < b4_deadkeyModifier_obj[n4].length; n5++) {
+                          //for (let n6 = 0; n6 < b4_deadkey_arr.length; n6++) {
+                          for (let n6 = 0; n6 < b4_deadkey_obj.length; n6++) {
+                            // for (let n7 = 0; n7 < b1_modifierKey_arr.length; n7++) {//_S2 remove&replace
+                            for (let n7 = 0; n7 < b1_modifierKey_obj.length; n7++) {
 
                               rule_obj = new Rule(
                               /*   rule_type */             "C3",
-                              /*   modifier_prev_deadkey*/  this.create_kmn_modifier(b2_prev_deadkeyModifier_arr[n1][n2], isCapsused),
-                              /*   prev_deadkey */          this.map_UkeleleKC_To_VK(Number(b2_prev_deadkey_arr[n3][0])),
+                              /*   modifier_prev_deadkey*/  //this.create_kmn_modifier(b2_prev_deadkeyModifier_arr[n1][n2], isCapsused),
+                              /*   modifier_prev_deadkey*/  this.create_kmn_modifier(b2_prev_deadkeyModifier_obj[n1][n2], isCapsused),
+                              /*   prev_deadkey */          //this.map_UkeleleKC_To_VK(Number(b2_prev_deadkey_arr[n3][0])),
+                              /*   prev_deadkey */          this.map_UkeleleKC_To_VK(Number(b2_prev_deadkey_obj[n3].key)),
                               /*   id_prev_deadkey */        dk_counter_C3++,
                               /*   unique A */              0,
 
-                              /*   modifier_deadkey */      this.create_kmn_modifier(b4_deadkeyModifier_arr[n4][n5], isCapsused),
-                              /*   deadkey */               this.map_UkeleleKC_To_VK(Number(b4_deadkey_arr[n6][0])),
+                              /*   modifier_deadkey */     // this.create_kmn_modifier(b4_deadkeyModifier_arr[n4][n5], isCapsused),
+                              /*   modifier_deadkey */      this.create_kmn_modifier(b4_deadkeyModifier_obj[n4][n5], isCapsused),
+                              /*   deadkey */              // this.map_UkeleleKC_To_VK(Number(b4_deadkey_arr[n6][0])),
+                              /*   deadkey */               this.map_UkeleleKC_To_VK(Number(b4_deadkey_obj[n6].key)),
                               /*   dk for C2*/              0,
                               /*   unique B */              0,
 
-                              /*   modifier_key*/           b1_modifierKey_arr[n7][3],
-                              /*   key */                   b1_modifierKey_arr[n7][0],
-                              /*   output */                new TextEncoder().encode(b1_modifierKey_arr[n7][4]),
+                              /*   modifier_key*/           //b1_modifierKey_arr[n7][3],//_S2 remove&replace
+                              /*   key */                   //b1_modifierKey_arr[n7][0],
+                              /*   output */                //new TextEncoder().encode(b1_modifierKey_arr[n7][4]),
+
+                              /*   modifier_key*/           b1_modifierKey_obj[n7].modifier,
+                              /*   key */                   b1_modifierKey_obj[n7].key,
+                              /*   output */                new TextEncoder().encode(b1_modifierKey_obj[n7].outchar),
                               );
 
-                              if ((b1_modifierKey_arr[n7][4] !== undefined)
-                                && (b1_modifierKey_arr[n7][4] !== "undefined")
-                                && (b1_modifierKey_arr[n7][4] !== "")) {
+                              /* if ((b1_modifierKey_arr[n7][4] !== undefined)//_S2 remove&replace
+                                 && (b1_modifierKey_arr[n7][4] !== "undefined")
+                                 && (b1_modifierKey_arr[n7][4] !== "")) {
+                                 object_array.push(rule_obj);
+                               }*/
+                              if ((b1_modifierKey_obj[n7].outchar !== undefined)
+                                && (b1_modifierKey_obj[n7].outchar !== "undefined")
+                                && (b1_modifierKey_obj[n7].outchar !== "")) {
                                 object_array.push(rule_obj);
                               }
                             }
@@ -735,7 +827,8 @@ export class KeylayoutToKmnConverter {
     * @param  search :string - value 'id' to be found
     * @return a number specifying the index of an actionId
     */
-  public get_ActionIndex__From__ActionId(data: any, search: string): number {
+  // _S2 get 1 OK
+  public get_1_ActionIndex__From__ActionId(data: any, search: string): number {
     for (let i = 0; i < data.keyboard.actions.action.length; i++) {
       if (data.keyboard.actions.action[i]['@_id'] === search) {
         return i;
@@ -743,14 +836,14 @@ export class KeylayoutToKmnConverter {
     }
     return 0;
   }
-
   /**
   * @brief  member function to  find the actionID of a certain state-next pair
   * @param  data   :any an object containing all data read from a .keylayout file
   * @param  search :string value 'next' to be found
   * @return a string containing the actionId of a certain state-next pair
   */
-  public get_ActionID__From__ActionNext(data: any, search: string): string {
+  // _S2 get 2 OK
+  public get_2_ActionID__From__ActionNext(data: any, search: string): string {
     if (search !== "none") {
       for (let i = 0; i < data.keyboard.actions.action.length; i++) {
         for (let j = 0; j < data.keyboard.actions.action[i].when.length; j++) {
@@ -769,13 +862,40 @@ export class KeylayoutToKmnConverter {
    * @param  search  : (string | number)[][] - an array[keycode,modifier]  to be found
    * @return an array: string[] containing modifiers
    */
-  public get_Modifier_array__From__KeyModifier_array(data: any, search: (string | number)[][]): string[] {
+  // _S2 get 3 OK
+  public get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(data: any, search: (string | number)[][]): string[] {
     const mapIndexArray_2D: string[] = [];
+
+    //console.log("Xsearch old ",search);
     for (let i = 0; i < search.length; i++) {
       mapIndexArray_2D.push(data[search[i][1]]);
     }
     return mapIndexArray_2D;
   }
+
+  public get_3_Modifier_array__From__KeyModifier_array_retObj(data: any, search: modifierKey_object[]): modifier_object[] {
+    const returnObjarray1D = [];
+    // console.log("Xsearch 3",search);
+
+    let returnObject: modifier_object;
+    for (let i = 0; i < search.length; i++) {
+      returnObject = {
+        modifier: (data[search[i].modifier])
+      };
+      returnObjarray1D.push(returnObject);
+    }
+    return returnObjarray1D;
+  }
+
+
+  public get_3_Modifier_array__From__KeyModifier_array(data: any, search: modifierKey_object[]): string[] {
+    const returnString1D: string[] = [];
+    for (let i = 0; i < search.length; i++) {
+      returnString1D.push(data[search[i].modifier]);
+    }
+    return returnString1D;
+  }
+
 
   /**
    * @brief  member function to find the output for a certain actionID for state 'none'
@@ -783,7 +903,8 @@ export class KeylayoutToKmnConverter {
    * @param  search :string an actionId to be found
    * @return a string containing the output character
    */
-  public get_Output__From__ActionId_None(data: any, search: string): string {
+  // _S2 get 4 OK
+  public get_4_Output__From__ActionId_None(data: any, search: string): string {
     let OutputValue: string = "";
 
     for (let i = 0; i < data.keyboard.actions.action.length; i++) {
@@ -804,10 +925,12 @@ export class KeylayoutToKmnConverter {
   * @param  search :string[][] - array of [ actionID,state,output]
   * @return a string[][] containing [Keycode,Keyname,actionId,actionIDIndex, output]
   */
-  public get_KeyActionOutput_array__From__ActionStateOutput_array(data: any, search: string[][]): string[][] {
+  // _S2 get 5 OK
+  public get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(data: any, search: string[][]): string[][] {
 
     if ((search === undefined) || (search === null))
       return [];
+
 
     const returnarray2D: string[][] = [];
     for (let k = 0; k < search.length; k++) {
@@ -828,6 +951,35 @@ export class KeylayoutToKmnConverter {
     }
     return returnarray2D;
   }
+  // _S2 get 5 OK
+  public get_5_KeyActionOutput_array__From__ActionStateOutput_array(data: any, search: idStateOutput_object[]): ActionIdKeyModiOutput_object[] {
+
+    if ((search === undefined) || (search === null))
+      return [];
+
+    const returnObjarray1D = [];
+    let returnObject: ActionIdKeyModiOutput_object;
+
+    for (let k = 0; k < search.length; k++) {
+      for (let i = 0; i < data.keyboard.keyMapSet[0].keyMap.length; i++) {
+        for (let j = 0; j < data.keyboard.keyMapSet[0].keyMap[i].key.length; j++) {
+          if (data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'] === search[k].id &&
+            data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'] <= KeylayoutToKmnConverter.USED_KEYS_COUNT) {
+
+            returnObject = {
+              keyCode: data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'],
+              key: this.map_UkeleleKC_To_VK(Number(data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'])),
+              actionId: data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'],
+              modifier: data.keyboard.keyMapSet[0].keyMap[i]['@_index'],
+              outchar: search[k].output
+            };
+            returnObjarray1D.push(returnObject);
+          }
+        }
+      }
+    }
+    return returnObjarray1D;
+  }
 
   /**
    * @brief  member function to get an array of all actionId-output pairs for a certain state
@@ -835,7 +987,8 @@ export class KeylayoutToKmnConverter {
    * @param  search  : string a 'state' to be found
    * @return an array: string[][] containing all [actionId, state, output] for a certain state
    */
-  public get_ActionStateOutput_array__From__ActionState(data: any, search: string): string[][] {
+  // _S2 get 6 OK
+  public get_6o_ActionStateOutput_array__From__ActionState_oldArrayType(data: any, search: string): string[][] {
     const returnarray2D: string[][] = [];
 
     for (let i = 0; i < data.keyboard.actions.action.length; i++) {
@@ -851,6 +1004,26 @@ export class KeylayoutToKmnConverter {
     }
     return returnarray2D;
   }
+  // _S2 get 6 OK
+  public get_6_ActionStateOutput_array__From__ActionState(data: any, search: string): idStateOutput_object[] {
+    const returnObjarray1D: idStateOutput_object[] = [];
+    let returnObject: idStateOutput_object;
+
+    for (let i = 0; i < data.keyboard.actions.action.length; i++) {
+      for (let j = 0; j < data.keyboard.actions.action[i].when.length; j++) {
+        if ((data.keyboard.actions.action[i].when[j]['@_state'] === search)) {
+
+          returnObject = {
+            id: data.keyboard.actions.action[i]['@_id'],
+            state: data.keyboard.actions.action[i].when[j]['@_state'],
+            output: data.keyboard.actions.action[i].when[j]['@_output']
+          };
+          returnObjarray1D.push(returnObject);
+        }
+      }
+    }
+    return returnObjarray1D;
+  }
 
   /**
    * @brief  member function to create an 2D array of [KeyName,actionId,behaviour,modifier,output]
@@ -859,7 +1032,8 @@ export class KeylayoutToKmnConverter {
    * @param  isCAPSused  : boolean flag to indicate if CAPS is used in a keylayout file or not
    * @return an array: string[][] containing [KeyName,actionId,behaviour,modifier,output]
    */
-  public get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(data: any, search: (boolean | string)[][], isCAPSused: boolean): string[][] {
+  // _S2 get 7 OK --> tests not OK 
+  public get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(data: any, search: (boolean | string)[][], isCAPSused: boolean): string[][] {
     const returnarray: string[][] = [];
 
     if (!((search === undefined) || (search === null) || (search.length === 0))) {
@@ -894,6 +1068,97 @@ export class KeylayoutToKmnConverter {
     );
     return unique_returnarray;
   }
+  public get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(data: any, search: ((boolean | string)[])[], isCAPSused: boolean): ActionIdOutputBehaviourKeyModi_object[] {
+    const returnarray: string[][] = [];
+    const returnObjarray1D = [];
+    let returnObject: ActionIdOutputBehaviourKeyModi_object;
+
+
+    if (!((search === undefined) || (search === null) || (search.length === 0))) {
+      for (let i = 0; i < search.length; i++) {
+        const behaviour: number = Number(search[i][3]);
+        for (let j = 0; j < data.keyboard.modifierMap.keyMapSelect[behaviour].modifier.length; j++) {
+
+          returnarray.push([
+            // KeyName
+            String(search[i][1]),
+            // actionId
+            String(search[i][2]),
+            // behaviour
+            String(search[i][3]),
+            // modifier
+            String(this.create_kmn_modifier(data.keyboard.modifierMap.keyMapSelect[behaviour].modifier[j]['@_keys'], isCAPSused)),
+            // output
+            String(search[i][4])
+          ]);
+
+          returnObject = {
+            search: "",
+            actionId: String(search[i][2]),
+            behaviour: String(search[i][3]),
+            modifier: String(this.create_kmn_modifier(data.keyboard.modifierMap.keyMapSelect[behaviour].modifier[j]['@_keys'], isCAPSused)),
+            key: String(search[i][1]),
+            outchar: String(search[i][4]),
+          };
+          returnObjarray1D.push(returnObject);
+        }
+      }
+    }
+    // remove duplicates
+    const unique_Objarray = returnObjarray1D.reduce((unique, o) => {
+      if (!unique.some(obj =>
+        obj.actionId === o.actionId &&
+        obj.behaviour === o.behaviour &&
+        obj.modifier === o.modifier &&
+        obj.key === o.key &&
+        obj.outchar === o.outchar
+      )) {
+        unique.push(o);
+      }
+      return unique;
+    }, []);
+
+    return unique_Objarray;
+  }
+  public get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(data: any, search: ActionIdKeyModiOutput_object[], isCAPSused: boolean): ActionIdOutputBehaviourKeyModi_object[] {
+
+    const returnObjarray1D = [];
+    let returnObject: ActionIdOutputBehaviourKeyModi_object;
+
+
+    if (!((search === undefined) || (search === null) || (search.length === 0))) {
+      for (let i = 0; i < search.length; i++) {
+        const behaviour: number = Number(search[i].modifier);
+        for (let j = 0; j < data.keyboard.modifierMap.keyMapSelect[behaviour].modifier.length; j++) {
+
+          returnObject = {
+            search: "",
+            actionId: String(search[i].actionId),
+            behaviour: String(search[i].modifier),
+            modifier: String(this.create_kmn_modifier(data.keyboard.modifierMap.keyMapSelect[behaviour].modifier[j]['@_keys'], isCAPSused)),
+            key: String(search[i].key),
+            outchar: String(search[i].outchar),
+          };
+          returnObjarray1D.push(returnObject);
+        }
+      }
+    }
+    // remove duplicates
+    const unique_Objarray = returnObjarray1D.reduce((unique, o) => {
+      if (!unique.some(obj =>
+        obj.actionId === o.actionId &&
+        obj.behaviour === o.behaviour &&
+        obj.modifier === o.modifier &&
+        obj.key === o.key &&
+        obj.outchar === o.outchar
+      )) {
+        unique.push(o);
+      }
+      return unique;
+    }, []);
+
+    return unique_Objarray;
+  }
 
   /**
    * @brief  member function to create an array of [actionID, output, behaviour,keyname,modifier] for a given actionId
@@ -904,45 +1169,53 @@ export class KeylayoutToKmnConverter {
    * @param  isCAPSused  : boolean - flag to indicate if CAPS is used in a keylayout file or not
    * @return an array: string[][] containing [actionID,output,actionID, behaviour,keyname,modifier]
    */
-  public get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(data: any, modi: any, search: string, outchar: string, isCapsused: boolean): string[][] {
-    const returnarray2D: string[][] = [];
+  // _S2 get 8 OK
+  public get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(data: any, modi: any, search: string, outchar: string, isCapsused: boolean): ActionIdOutputBehaviourKeyModi_object[] {
+    const returnObjarray1D = [];
+    let returnObject: ActionIdOutputBehaviourKeyModi_object;
 
     if ((search === "") || (search === undefined) || !((isCapsused === true) || (isCapsused === false))) {
       return [];
     }
-
-    // loop behaviors (in ukelele it is possible to define multiple modifier combinations that behave in the same)
+    // loop behaviors (in ukelele it is possible to define multiple modifier combinations that behave in the same way)
     for (let i = 0; i < data.keyboard.keyMapSet[0].keyMap.length; i++) {
       for (let j = 0; j <= KeylayoutToKmnConverter.USED_KEYS_COUNT; j++) {
         if (data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'] === search) {
           for (let k = 0; k < modi[data.keyboard.keyMapSet[0].keyMap[i]['@_index']].length; k++) {
             const behaviour: string = data.keyboard.keyMapSet[0].keyMap[i]['@_index'];
-            const modifierkmn: string = this.create_kmn_modifier(modi[behaviour][k], isCapsused);
-            const keyName: string = this.map_UkeleleKC_To_VK(Number(data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code']));
-            returnarray2D.push([
-              search,
-              outchar,
-              data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'],
-              behaviour,
-              keyName,
-              modifierkmn]);
+
+            returnObject = {
+              search: search,
+              outchar: outchar,
+              actionId: data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'],
+              behaviour: data.keyboard.keyMapSet[0].keyMap[i]['@_index'],
+              key: this.map_UkeleleKC_To_VK(Number(data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'])),
+              modifier: this.create_kmn_modifier(modi[behaviour][k], isCapsused),
+            };
+            returnObjarray1D.push(returnObject);
           }
         }
       }
     }
-    // remove duplicates
-    const [unique_returnarray] = returnarray2D.reduce((acc, curr) => {
-      const [uniq, set] = acc;
-      if (!set.has(curr.join(','))) {
-        set.add(curr.join(','));
-        uniq.push(curr);
-      }
-      return acc;
-    },
-      [[], new Set()],
-    );
 
-    return unique_returnarray;
+    //.............................................................................
+
+    // remove duplicates
+    const unique_Objarray = returnObjarray1D.reduce((unique, o) => {
+      if (!unique.some(obj =>
+        obj.actionId === o.actionId &&
+        obj.outchar === o.outchar &&
+        obj.search === o.search &&
+        obj.behaviour === o.behaviour &&
+        obj.key === o.key &&
+        obj.modifier === o.modifier
+      )) {
+        unique.push(o);
+      }
+      return unique;
+    }, []);
+
+    return unique_Objarray;
   }
 
   /**
@@ -951,22 +1224,149 @@ export class KeylayoutToKmnConverter {
    * @param  search  : string - an actionId to be found
    * @return an array: number[][] containing [keycode,behaviour]
    */
-  public get_KeyModifier_array__From__ActionID(data: any, search: string): number[][] {
+  // _S2 get 9  OK  //_S2 remove&replace
+  public get_9o_KeyModifier_array__From__ActionID_oldArrayType(data: any, search: string): number[][] {
     const mapIndexArray_2D: number[][] = [];
+    let returnObject: modifierKey_object;
+    const mapIndexObject1D: modifierKey_object[] = [];
+
     for (let i = 0; i < data.keyboard.keyMapSet[0].keyMap.length; i++) {
       for (let j = 0; j <= KeylayoutToKmnConverter.USED_KEYS_COUNT; j++) {
         if (data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'] === search) {
+
           mapIndexArray_2D.push([data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'], i]);
+
+          returnObject = {
+            key: data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'],
+            modifier: i
+          };
+          mapIndexObject1D.push(returnObject);
         }
       }
     }
     return mapIndexArray_2D;
+  }
+  public get_9_KeyModifier_array__From__ActionID(data: any, search: string): modifierKey_object[] {
+    const mapIndexArray_2D: number[][] = [];
+    let returnObject: modifierKey_object;
+    const mapIndexObject1D: modifierKey_object[] = [];
+
+    for (let i = 0; i < data.keyboard.keyMapSet[0].keyMap.length; i++) {
+      for (let j = 0; j <= KeylayoutToKmnConverter.USED_KEYS_COUNT; j++) {
+        if (data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'] === search) {
+
+          mapIndexArray_2D.push([data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'], i]);
+
+          returnObject = {
+            key: data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'],
+            modifier: i
+          };
+          mapIndexObject1D.push(returnObject);
+        }
+      }
+    }
+    return mapIndexObject1D;
   }
 
   /** @internal */
   public convert_bound = {
     convert: this.convert.bind(this),
   };
+
+
+
+  public dummy(into: any) {
+  }
+  public compareBoth(arr: any, obj: any,) {
+
+    // compare:-----------------------------------
+    for (let k = 0; k < obj.length; k++) {
+      /*console.log("k ", k);
+
+      console.log(" arr", typeof (arr), arr, "----", typeof (arr[k]), arr[k]);
+      console.log("-------------------- ",);
+      console.log(" obj", typeof (obj), obj, "----", typeof (obj[k]), obj[k]);
+
+      console.log("arr[k  ", arr[k]);
+      console.log("obj[k].modifier ", obj[k].modifier);*/
+      if (
+        (arr.length === obj.length) &&
+
+
+        (arr[k] === obj[k].modifier)
+        // (arr[k][1] === obj[k].key) 
+
+        /*(arr[k][0] === obj[k].key) &&
+        (arr[k][1] === obj[k].actionId) &&
+        (arr[k][2] === obj[k].behaviour) &&
+        (arr[k][3] === obj[k].modifier) &&
+        (arr[k][4] === obj[k].outchar)*/
+
+      ) {
+        console.log("IS_EQUAL ",);
+      }
+      else console.log("NONONO not_EQUAL \n",
+        (arr.length === obj.length), obj.length, "<->", arr.length, "\n",
+
+        (arr[k] === obj[k].modifier), obj[k].modifier, "<->", arr[k], "\n",
+        // (arr[k][1] === obj[k].key), obj[k].key, "<->", arr[k][1], "\n",
+
+
+        /* (arr[k][0] === obj[k].key), obj[k].key, "<->", arr[k][0], "\n",
+         (arr[k][1] === obj[k].actionId), obj[k].actionId, "<->", arr[k][1], "\n",
+         (arr[k][2] === obj[k].behaviour), obj[k].behaviour, "<->", arr[k][2], "\n",
+         (arr[k][3] === obj[k].modifier), obj[k].modifier, "<->", arr[k][3], "\n",
+         (arr[k][4] === obj[k].outchar), obj[k].outchar, "<->", arr[k][4]*/
+      );
+    }
+  }
+  public compareSameType(arr1: any, arr2: any,) {
+
+
+    // compare:-----------------------------------
+    for (let k = 0; k < arr1.length; k++) {
+      /*console.log("k ", k);
+
+      console.log(" arr1", typeof (arr1), arr1, "----", typeof (arr1[k]), arr1[k]);
+      console.log("-------------------- ",);
+      console.log(" arr2", typeof (arr2), arr2, "----", typeof (arr2[k]), arr2[k]);
+
+      console.log("arr1[k  ", arr1[k]);
+      console.log("arr2[k].modifier ", arr2[k].modifier);*/
+      if (
+        (arr1.length === arr2.length) &&
+
+        (arr1[k].search === arr2[k].search) &&
+        (arr1[k].actionId === arr2[k].actionId) &&
+        (arr1[k].behaviour === arr2[k].behaviour) &&
+        (arr1[k].modifier === arr2[k].modifier) &&
+        (arr1[k].key === arr2[k].key) &&
+        (arr1[k].outchar === arr2[k].outchar)
+
+      ) {
+        console.log("compareSameType: IS_EQUAL ",);
+      }
+      else console.log("compareSameType: NONONO not_EQUAL \n",
+        (arr1.length === arr2.length), arr2.length, "<->", arr1.length, "\n",
+
+        (arr1[k] === arr2[k].modifier), arr2[k].modifier, "<->", arr1[k], "\n",
+        // (arr1[k][1] === arr2[k].key), arr2[k].key, "<->", arr1[k][1], "\n",
+
+
+        /* (arr1[k][0] === arr2[k].key), arr2[k].key, "<->", arr1[k][0], "\n",
+         (arr1[k][1] === arr2[k].actionId), arr2[k].actionId, "<->", arr1[k][1], "\n",
+         (arr1[k][2] === arr2[k].behaviour), arr2[k].behaviour, "<->", arr1[k][2], "\n",
+         (arr1[k][3] === arr2[k].modifier), arr2[k].modifier, "<->", arr1[k][3], "\n",
+         (arr1[k][4] === arr2[k].outchar), arr2[k].outchar, "<->", arr1[k][4]*/
+      );
+    }
+  }
+
+
+
+
+
+
 }
 
 /**

--- a/developer/src/kmc-convert/src/keylayout-to-kmn/keylayout-to-kmn-converter.ts
+++ b/developer/src/kmc-convert/src/keylayout-to-kmn/keylayout-to-kmn-converter.ts
@@ -26,49 +26,46 @@ export interface convert_object {
   arrayOf_Modifiers: string[][],
   arrayOf_Rules: Rule[],
 };
-//_S2 do I need search???
-export interface ActionIdOutputBehaviourKeyModi_object {
-  search: string,
-  actionId: string,
-  outchar: string,
-  behaviour: string,
-  key: string,
-  modifier: string,
+
+export interface allArrayContents_object {
+  actionId?: string,
+  keyCode?: string,
+  key?: string,
+  behaviour?: string,
+  modifier?: string,
+  outchar?: string;
 };
 
-
-
-export interface ActionIdKeyModiOutput_object {
-  actionId: string,
-  keyCode: string,
-  key: string,
-  modifier: string,
-  outchar: string;
-};
-export interface modifierKey_object {
-  key: string;  // _S2 todo change everywhere!!!
-  modifier: number,
-};
-export interface modifier_object {
-  modifier: string,
-};
-export interface behaviourKey_object {
-  behaviour: string,
-  key: string,
-};
 export interface idStateOutput_object {
   id: string,
   state: string,
   output: string,
 };
 
-export class KeylayoutToKmnConverter {
+/**
+ * @brief  member function to find the number of keys defined in a .keykayout file.
+ *         We process 'MAX_KEY_COUNT' keys at maximum. In case a keylayout has fewer keys defined, we use that smaller number of keys (USE_KEY_COUNT)
+ * @param  data data read from keylayout file
+ * @return static variable USE_KEY_COUNT holding the number of keys used in a .keykayout file.
+ */
+export function find_usedKeysCount(data: any): number {
+  let USE_KEY_COUNT = KeylayoutToKmnConverter.MAX_KEY_COUNT;
+  for (let i = 0; i < data.keyboard.keyMapSet[0].keyMap.length; i++) {
+    if (data.keyboard.keyMapSet[0].keyMap[i].key.length < USE_KEY_COUNT) {
+      // set the max to n-1 (use key 0 -> nth-1)
+      USE_KEY_COUNT = data.keyboard.keyMapSet[0].keyMap[i].key.length - 1;
+    }
+  }
+  return USE_KEY_COUNT;
+}
 
+export class KeylayoutToKmnConverter {
   static readonly INPUT_FILE_EXTENSION = '.keylayout';
   static readonly OUTPUT_FILE_EXTENSION = '.kmn';
-  static readonly USED_KEYS_COUNT = 49;               // we use key Nr 0 (A) -> key Nr 49 (Space)
-  static readonly MAX_CTRL_CHARACTER = 32;
   static readonly SKIP_COMMENTED_LINES = false;
+  static readonly MAX_CTRL_CHARACTER = 32;
+  static readonly MAX_KEY_COUNT = 49;                             // At most we use key Nr 0 (A) -> key Nr 49 (Space)
+  static USE_KEY_COUNT = KeylayoutToKmnConverter.MAX_KEY_COUNT;   // we use key Nr 0 (A) -> highest available key of .keylayout file
 
   private options: CompilerOptions;
 
@@ -91,6 +88,11 @@ export class KeylayoutToKmnConverter {
 
     if (!inputFilename) {
       this.callbacks.reportMessage(ConverterMessages.Error_FileNotFound({ inputFilename }));
+      return null;
+    }
+
+    if (outputFilename === null) {
+      this.callbacks.reportMessage(ConverterMessages.Error_OutputFilenameIsRequired());
       return null;
     }
 
@@ -162,6 +164,10 @@ export class KeylayoutToKmnConverter {
         }
         modifierBehavior.push(singleModifierSet);
       }
+
+      // fix the amount of processable keys to the maximun nr of keys of a keyMap to avoid processing more keys than defined
+      KeylayoutToKmnConverter.USE_KEY_COUNT = find_usedKeysCount(jsonObj);
+
       // fill rules into arrayOf_Rules of data_object
       return this.createRuleData(data_object, jsonObj);
     }
@@ -181,11 +187,13 @@ export class KeylayoutToKmnConverter {
     let dk_counter_C2: number = 0;
     let action_id: string;
 
+    //find_max_used_keycount(data_ukelele)
     // check if we use CAPS in a modifier throughout the .keylayout file. In this case we need to add NCAPS
     const isCapsused: boolean = this.checkIfCapsIsUsed(data_ukelele.arrayOf_Modifiers);
 
-    // loop keys 0-50 (= all keys we use)
-    for (let j = 0; j <= KeylayoutToKmnConverter.USED_KEYS_COUNT; j++) {
+
+    // loop keys 0-49 (= all keys we use)
+    for (let j = 0; j <= KeylayoutToKmnConverter.USE_KEY_COUNT; j++) {
 
       // loop behaviors (in ukelele it is possible to define multiple modifier combinations that behave in the same way)
       for (let i = 0; i < jsonObj.keyboard.keyMapSet[0].keyMap.length; i++) {
@@ -241,13 +249,13 @@ export class KeylayoutToKmnConverter {
 
           for (let l = 0; l < data_ukelele.arrayOf_Modifiers[i].length; l++) {
 
-            if ((this.get_4_Output__From__ActionId_None(jsonObj, action_id) !== undefined)
-              && (this.get_4_Output__From__ActionId_None(jsonObj, action_id) !== "")) {
+            if ((this.get_Output__From__ActionId_None(jsonObj, action_id) !== undefined)
+              && (this.get_Output__From__ActionId_None(jsonObj, action_id) !== "")) {
 
-              const outputchar: string = this.get_4_Output__From__ActionId_None(jsonObj, action_id);
+              const outputchar: string = this.get_Output__From__ActionId_None(jsonObj, action_id);
 
-              const b1_modifierKey_obj: ActionIdOutputBehaviourKeyModi_object[] =
-                this.get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(jsonObj, data_ukelele.arrayOf_Modifiers, action_id, outputchar, isCapsused);
+              const b1_modifierKey_obj: allArrayContents_object[] =
+                this.get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(jsonObj, data_ukelele.arrayOf_Modifiers, action_id, outputchar, isCapsused);
 
               for (let m = 0; m < b1_modifierKey_obj.length; m++) {
                 rule_obj = new Rule(
@@ -282,7 +290,7 @@ export class KeylayoutToKmnConverter {
             // https://docs.google.com/document/d/12J3NGO6RxIthCpZDTR8FYSRjiMgXJDLwPY2z9xqKzJ0/edit?tab=t.0#heading=h.g7jwx3lx0ydd   .........
             // ...............................................................................................................................
 
-            const b1_actionIndex: number = this.get_1_ActionIndex__From__ActionId(jsonObj, action_id);
+            const b1_actionIndex: number = this.get_ActionIndex__From__ActionId(jsonObj, action_id);
 
             // with action_id from above loop all 'action' and search for a state(none)-next-pair ............................................................................................................
             // e.g. in Block 5: find <when state="none" next="1"/> for action id a18 ......................................................................................................................
@@ -299,37 +307,26 @@ export class KeylayoutToKmnConverter {
               // Data of Block Nr 4 .....................................................................................................................................................................
               // with present action_id (a18) find all keycode-behaviour-pairs that use this action (a18) => (keymapIndex 0/keycode 24 and keymapIndex 3/keycode 24) ....................................
               // from these create an array of modifier combinations  e.g. [['','caps?'], ['Caps']] .....................................................................................................
-              /* eg: [['24', 0], ['24', 3]] */        // const b4_deadkey_arr: number[][] = this.get_9o_KeyModifier_array__From__ActionID_oldArrayType(jsonObj, action_id);  //_S2 remove&replace
-              /* eg: [['24', 0], ['24', 3]] */        const b4_deadkey_obj: modifierKey_object[] = this.get_9_KeyModifier_array__From__ActionID(jsonObj, action_id);
-              /* e.g. [['','caps?'], ['Caps']]*/      //const b4_deadkeyModifier_arr: string[] = this.get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(data_ukelele.arrayOf_Modifiers, b4_deadkey_arr);//_S2 remove&replace
-              /* e.g. [['','caps?'], ['Caps']]*/      const b4_deadkeyModifier_obj: string[] = this.get_3_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b4_deadkey_obj);
+              /* eg: [['24', 0], ['24', 3]] */        const b4_deadkey_obj: allArrayContents_object[] = this.get_KeyModifier_array__From__ActionID(jsonObj, action_id);
+              /* e.g. [['','caps?'], ['Caps']]*/      const b4_deadkeyModifier_obj: string[] = this.get_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b4_deadkey_obj);
               // ........................................................................................................................................................................................
 
 
               // Data of Block Nr 6 .....................................................................................................................................................................
               // create an array[action id,state,output] from all state-output-pairs that use state = b5_value_next (e.g. use 1 in  <when state="1" output="â"/> ) ......................................
-              /*  eg: [ 'a9','1','â'] */              //const b6_actionId_arr: string[][] = this.get_6o_ActionStateOutput_array__From__ActionState_oldArrayType(jsonObj, b5_value_next);//_S2 remove&replace
-              /*  eg: [ 'a9','1','â'] */                const b6_actionId_obj: idStateOutput_object[] = this.get_6_ActionStateOutput_array__From__ActionState(jsonObj, b5_value_next);
+              /*  eg: [ 'a9','1','â'] */              const b6_actionId_obj: idStateOutput_object[] = this.get_ActionStateOutput_array__From__ActionState(jsonObj, b5_value_next);
               // ........................................................................................................................................................................................
 
 
               // Data of Block Nr 1  ....................................................................................................................................................................
               // create array[Keycode,Keyname,action id,actionIndex,output] and array[Keyname,action id,behaviour,modifier,output] ......................................................................
-              /*  eg: ['0','K_A','a9','0','â'] */     //const b1_keycode_arr: string[][] = this.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(jsonObj, b6_actionId_arr);//_S2 remove&replace
-              /*  eg: ['0','K_A','a9','0','â'] */     const b1_keycode_obj: ActionIdKeyModiOutput_object[] = this.get_5_KeyActionOutput_array__From__ActionStateOutput_array(jsonObj, b6_actionId_obj);
-
-              /*  eg: ['K_A','a9','0','NCAPS','â']*/ // const b1_modifierKey_arr: string[][] = this.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_arr(jsonObj, b1_keycode_arr, isCapsused);//_S2 remove&replace
-              /*  eg: ['K_A','a9','0','NCAPS','â']*/  //const b1_modifierKey_obj: ActionIdOutputBehaviourKeyModi_object[] = this.get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_arr, isCapsused);//_S2 remove&replace
-              /*  eg: ['K_A','a9','0','NCAPS','â']*/  const b1_modifierKey_obj: ActionIdOutputBehaviourKeyModi_object[] = this.get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_obj, isCapsused);//_S2 remove&replace          
+              /*  eg: ['0','K_A','a9','0','â'] */    const b1_keycode_obj: allArrayContents_object[] = this.get_KeyActionOutput_array__From__ActionStateOutput_array(jsonObj, b6_actionId_obj);
+              /*  eg: ['K_A','a9','0','NCAPS','â']*/  const b1_modifierKey_obj: allArrayContents_object[] = this.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_obj, isCapsused);
                 // .......................................................................................................................................................................................
 
-                //for (let n1 = 0; n1 < b4_deadkeyModifier_arr.length; n1++) {
                 for (let n1 = 0; n1 < b4_deadkeyModifier_obj.length; n1++) {
-                  //for (let n2 = 0; n2 < b4_deadkeyModifier_arr[n1].length; n2++) {
                   for (let n2 = 0; n2 < b4_deadkeyModifier_obj[n1].length; n2++) {
-                    // for (let n3 = 0; n3 < b4_deadkey_arr.length; n3++) {
                     for (let n3 = 0; n3 < b4_deadkey_obj.length; n3++) {
-                      //for (let n4 = 0; n4 < b1_modifierKey_arr.length; n4++) {//_S2 remove&replace
                       for (let n4 = 0; n4 < b1_modifierKey_obj.length; n4++) {
 
                         rule_obj = new Rule(
@@ -340,27 +337,15 @@ export class KeylayoutToKmnConverter {
                         /*   id_prev_deadkey */       0,
                         /*   unique A */              0,
 
-                        /*   modifier_deadkey */     //this.create_kmn_modifier(b4_deadkeyModifier_arr[n1][n2], isCapsused),
                         /*   modifier_deadkey */      this.create_kmn_modifier(b4_deadkeyModifier_obj[n1][n2], isCapsused),
-                        /*   deadkey */               //this.map_UkeleleKC_To_VK(Number(b4_deadkey_arr[n3][0])),
                         /*   deadkey */               this.map_UkeleleKC_To_VK(Number(b4_deadkey_obj[n3].key)),
                         /*   dk for C2*/              dk_counter_C2++,
                         /*   unique B */              0,
-
-                        /*   modifier_key*/          // b1_modifierKey_arr[n4][3],//_S2 remove&replace
-                        /*   key */                   //b1_modifierKey_arr[n4][0],
-                        /*   output */               // new TextEncoder().encode(b1_modifierKey_arr[n4][4]),
 
                         /*   modifier_key*/           b1_modifierKey_obj[n4].modifier,
                         /*   key */                   b1_modifierKey_obj[n4].key,
                         /*   output */                new TextEncoder().encode(b1_modifierKey_obj[n4].outchar),
                         );
-                        /* if ((b1_modifierKey_arr[n4][4] !== undefined)//_S2 remove&replace
-                           && (b1_modifierKey_arr[n4][4] !== "undefined")
-                           && (b1_modifierKey_arr[n4][4] !== "")) {
-                           object_array.push(rule_obj);
-                         }*/
-
                         if ((b1_modifierKey_obj[n4].outchar !== undefined)
                           && (b1_modifierKey_obj[n4].outchar !== "undefined")
                           && (b1_modifierKey_obj[n4].outchar !== "")) {
@@ -399,91 +384,56 @@ export class KeylayoutToKmnConverter {
               // Data of Block Nr 4 ........................................................................................................................................................................
               // with present action_id (a16) find all keycode-behaviour-pairs that use this action (a16) => (keymapIndex 3/keycode 32) ....................................................................
               // from these create an array of modifier combinations  e.g. [ [ 'anyOption', 'Caps' ] ] .....................................................................................................
-              /* e.g. [['32', 3]] */                     // const b4_deadkey_arr: number[][] = this.get_9o_KeyModifier_array__From__ActionID_oldArrayType(jsonObj, action_id);//_S2 remove&replace
-              /* e.g. [['32', 3]] */                      const b4_deadkey_obj: modifierKey_object[] = this.get_9_KeyModifier_array__From__ActionID(jsonObj, action_id);
-              /* e.g. [ [ 'anyOption', 'Caps' ] ]*/      // const b4_deadkeyModifier_arr: string[] = this.get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(data_ukelele.arrayOf_Modifiers, b4_deadkey_arr);
-              /* e.g. [ [ 'anyOption', 'Caps' ] ]*/       const b4_deadkeyModifier_obj: string[] = this.get_3_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b4_deadkey_obj);
+              /* e.g. [['32', 3]] */                      const b4_deadkey_obj: allArrayContents_object[] = this.get_KeyModifier_array__From__ActionID(jsonObj, action_id);
+              /* e.g. [ [ 'anyOption', 'Caps' ] ]*/       const b4_deadkeyModifier_obj: string[] = this.get_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b4_deadkey_obj);
               // ...........................................................................................................................................................................................
 
               // Data of Block Nr 3 ........................................................................................................................................................................
               // get an action id from a state-output-pair that use state = b5_value_state (e.g. use 3 in  <when state="none" next="3"/> ) .................................................................
-              /* e.g. actioniD = a17  */                  const b3_actionId: string = this.get_2_ActionID__From__ActionNext(jsonObj, b5_value_state);
+              /* e.g. actioniD = a17  */                  const b3_actionId: string = this.get_ActionID__From__ActionNext(jsonObj, b5_value_state);
               // ...........................................................................................................................................................................................
 
               // Data of Block Nr 2  .......................................................................................................................................................................
               // with present action_id (a17) find all key names and behaviours that use this action (a17) => (keymapIndex 3/keycode 28) ....................................................................
               // from these create an array of modifier combinations  e.g. [ [ 'anyOption', 'Caps' ] ] .....................................................................................................
-                       
-          
-             
-              /* eg: index=3 */                           //const b2_prev_deadkey_arr: number[][] = this.get_9o_KeyModifier_array__From__ActionID_oldArrayType(jsonObj, b3_actionId);   // conversion not necessary //_S2 remove&replace
-              /* eg: index=3 */                           const b2_prev_deadkey_obj: modifierKey_object[] = this.get_9_KeyModifier_array__From__ActionID(jsonObj, b3_actionId);   // conversion not necessary //_S2 remove&replace
-              /* e.g. [ [ 'anyOption', 'Caps' ] ] */     // const b2_prev_deadkeyModifier_arr: string[] = this.get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(data_ukelele.arrayOf_Modifiers, b2_prev_deadkey_arr);
-             /* e.g. [ [ 'anyOption', 'Caps' ] ] */      const b2_prev_deadkeyModifier_obj: string[] = this.get_3_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b2_prev_deadkey_obj);
+              /* eg: index=3 */                           const b2_prev_deadkey_obj: allArrayContents_object[] = this.get_KeyModifier_array__From__ActionID(jsonObj, b3_actionId);
+              /* e.g. [ [ 'anyOption', 'Caps' ] ] */      const b2_prev_deadkeyModifier_obj: string[] = this.get_Modifier_array__From__KeyModifier_array(data_ukelele.arrayOf_Modifiers, b2_prev_deadkey_obj);
               // ...........................................................................................................................................................................................
               // Data of Block Nr 6 ........................................................................................................................................................................
               // create an array[action id,state,output] from all state-output-pairs that use state = b5_value_next (e.g. use 1 in  <when state="1" output="â"/> ) .........................................
-              /*  eg:[ [ 'a9','1','â'] ]*/               // const b6_actionId_arr: string[][] = this.get_6o_ActionStateOutput_array__From__ActionState_oldArrayType(jsonObj, b5_value_next);
-              /*  eg:[ [ 'a9','1','â'] ]*/                const b6_actionId_obj: idStateOutput_object[] = this.get_6_ActionStateOutput_array__From__ActionState(jsonObj, b5_value_next); /*  eg:[ [ 'a9','1','â'] ]*/
+              /*  eg:[ [ 'a9','1','â'] ]*/                const b6_actionId_obj: idStateOutput_object[] = this.get_ActionStateOutput_array__From__ActionState(jsonObj, b5_value_next); /*  eg:[ [ 'a9','1','â'] ]*/
               // ...........................................................................................................................................................................................
 
               // Data of Block Nr 1  .......................................................................................................................................................................
               // create array[Keycode,Keyname,action id,actionIndex,output] and array[Keyname,action id,behaviour,modifier,output] .........................................................................
-              /*  eg: ['49','K_SPACE','a0','0','Â'] */    //const b1_keycode_arr: string[][] = this.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(jsonObj, b6_actionId_arr);
-               /*  eg: ['0','K_A','a9','0','â'] */        const b1_keycode_obj: ActionIdKeyModiOutput_object[] = this.get_5_KeyActionOutput_array__From__ActionStateOutput_array(jsonObj, b6_actionId_obj);
-                // console.log("b1_keycode_obj ", b1_keycode_obj);
-                //this.compareBoth(b1_keycode_arr, b1_keycode_obj);
-
-                /*  eg: ['K_SPACE','a0','0','NCAPS','Â'] */ //const b1_modifierKey_arr: string[][] = this.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_arr(jsonObj, b1_keycode_arr, isCapsused);//_S2 remove&replace
-                /*  eg: ['K_SPACE','a0','0','NCAPS','Â'] */ //const b1_modifierKey_obj: ActionIdOutputBehaviourKeyModi_object[] = this.get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_arr, isCapsused);
-                const b1_modifierKey_obj: ActionIdOutputBehaviourKeyModi_object[] = this.get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_obj, isCapsused);//_S2 remove&replace         
+              /*  eg: ['49','K_SPACE','a0','0','Â'] */    const b1_keycode_obj: allArrayContents_object[] = this.get_KeyActionOutput_array__From__ActionStateOutput_array(jsonObj, b6_actionId_obj);
+              /*  eg: ['K_SPACE','a0','0','NCAPS','Â'] */ const b1_modifierKey_obj: allArrayContents_object[] = this.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(jsonObj, b1_keycode_obj, isCapsused);
                 // ...........................................................................................................................................................................................
 
-                //for (let n1 = 0; n1 < b2_prev_deadkeyModifier_arr.length; n1++) {
                 for (let n1 = 0; n1 < b2_prev_deadkeyModifier_obj.length; n1++) {
-                  //for (let n2 = 0; n2 < b2_prev_deadkeyModifier_arr[n1].length; n2++) {
                   for (let n2 = 0; n2 < b2_prev_deadkeyModifier_obj[n1].length; n2++) {
-                    //for (let n3 = 0; n3 < b2_prev_deadkey_arr.length; n3++) {
                     for (let n3 = 0; n3 < b2_prev_deadkey_obj.length; n3++) {
-                      //for (let n4 = 0; n4 < b4_deadkeyModifier_arr.length; n4++) {
                       for (let n4 = 0; n4 < b4_deadkeyModifier_obj.length; n4++) {
-                       // for (let n5 = 0; n5 < b4_deadkeyModifier_arr[n4].length; n5++) {
                         for (let n5 = 0; n5 < b4_deadkeyModifier_obj[n4].length; n5++) {
-                          //for (let n6 = 0; n6 < b4_deadkey_arr.length; n6++) {
                           for (let n6 = 0; n6 < b4_deadkey_obj.length; n6++) {
-                            // for (let n7 = 0; n7 < b1_modifierKey_arr.length; n7++) {//_S2 remove&replace
                             for (let n7 = 0; n7 < b1_modifierKey_obj.length; n7++) {
 
                               rule_obj = new Rule(
                               /*   rule_type */             "C3",
-                              /*   modifier_prev_deadkey*/  //this.create_kmn_modifier(b2_prev_deadkeyModifier_arr[n1][n2], isCapsused),
                               /*   modifier_prev_deadkey*/  this.create_kmn_modifier(b2_prev_deadkeyModifier_obj[n1][n2], isCapsused),
-                              /*   prev_deadkey */          //this.map_UkeleleKC_To_VK(Number(b2_prev_deadkey_arr[n3][0])),
                               /*   prev_deadkey */          this.map_UkeleleKC_To_VK(Number(b2_prev_deadkey_obj[n3].key)),
                               /*   id_prev_deadkey */        dk_counter_C3++,
                               /*   unique A */              0,
 
-                              /*   modifier_deadkey */     // this.create_kmn_modifier(b4_deadkeyModifier_arr[n4][n5], isCapsused),
                               /*   modifier_deadkey */      this.create_kmn_modifier(b4_deadkeyModifier_obj[n4][n5], isCapsused),
-                              /*   deadkey */              // this.map_UkeleleKC_To_VK(Number(b4_deadkey_arr[n6][0])),
                               /*   deadkey */               this.map_UkeleleKC_To_VK(Number(b4_deadkey_obj[n6].key)),
                               /*   dk for C2*/              0,
                               /*   unique B */              0,
-
-                              /*   modifier_key*/           //b1_modifierKey_arr[n7][3],//_S2 remove&replace
-                              /*   key */                   //b1_modifierKey_arr[n7][0],
-                              /*   output */                //new TextEncoder().encode(b1_modifierKey_arr[n7][4]),
 
                               /*   modifier_key*/           b1_modifierKey_obj[n7].modifier,
                               /*   key */                   b1_modifierKey_obj[n7].key,
                               /*   output */                new TextEncoder().encode(b1_modifierKey_obj[n7].outchar),
                               );
-
-                              /* if ((b1_modifierKey_arr[n7][4] !== undefined)//_S2 remove&replace
-                                 && (b1_modifierKey_arr[n7][4] !== "undefined")
-                                 && (b1_modifierKey_arr[n7][4] !== "")) {
-                                 object_array.push(rule_obj);
-                               }*/
                               if ((b1_modifierKey_obj[n7].outchar !== undefined)
                                 && (b1_modifierKey_obj[n7].outchar !== "undefined")
                                 && (b1_modifierKey_obj[n7].outchar !== "")) {
@@ -700,7 +650,7 @@ export class KeylayoutToKmnConverter {
       }
 
       else {
-        add_modifier = String(modifier_state[i]) + " ";
+        add_modifier = modifier_state[i] + " ";
       }
       kmn_modifier += kmn_ncaps + add_modifier;
     }
@@ -822,13 +772,13 @@ export class KeylayoutToKmnConverter {
     }
   }
 
-  /* @brief  member function to return an index for a given actionID
-    * @param  data   :any - an object containing all data read from a .keylayout file
-    * @param  search :string - value 'id' to be found
-    * @return a number specifying the index of an actionId
-    */
-  // _S2 get 1 OK
-  public get_1_ActionIndex__From__ActionId(data: any, search: string): number {
+  /**
+  * @brief  member function to return an index for a given actionID
+  * @param  data   :any - an object containing all data read from a .keylayout file
+  * @param  search :string - value 'id' to be found
+  * @return a number specifying the index of an actionId
+  */
+  public get_ActionIndex__From__ActionId(data: any, search: string): number {
     for (let i = 0; i < data.keyboard.actions.action.length; i++) {
       if (data.keyboard.actions.action[i]['@_id'] === search) {
         return i;
@@ -836,14 +786,14 @@ export class KeylayoutToKmnConverter {
     }
     return 0;
   }
+
   /**
   * @brief  member function to  find the actionID of a certain state-next pair
   * @param  data   :any an object containing all data read from a .keylayout file
   * @param  search :string value 'next' to be found
   * @return a string containing the actionId of a certain state-next pair
   */
-  // _S2 get 2 OK
-  public get_2_ActionID__From__ActionNext(data: any, search: string): string {
+  public get_ActionID__From__ActionNext(data: any, search: string): string {
     if (search !== "none") {
       for (let i = 0; i < data.keyboard.actions.action.length; i++) {
         for (let j = 0; j < data.keyboard.actions.action[i].when.length; j++) {
@@ -857,41 +807,15 @@ export class KeylayoutToKmnConverter {
   }
 
   /**
-   * @brief  member function to create an array of modifier behaviours for a given keycode in [keycode,modifier]
+   * @brief  member function to create an array of (modifier) behaviours for a given keycode in [{keycode,modifier}]
    * @param  data    : any - an object containing all data read from a .keylayout file
-   * @param  search  : (string | number)[][] - an array[keycode,modifier]  to be found
+   * @param  search  : allArrayContents_object[] - an array[{keycode,modifier}]  to be found
    * @return an array: string[] containing modifiers
    */
-  // _S2 get 3 OK
-  public get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(data: any, search: (string | number)[][]): string[] {
-    const mapIndexArray_2D: string[] = [];
-
-    //console.log("Xsearch old ",search);
-    for (let i = 0; i < search.length; i++) {
-      mapIndexArray_2D.push(data[search[i][1]]);
-    }
-    return mapIndexArray_2D;
-  }
-
-  public get_3_Modifier_array__From__KeyModifier_array_retObj(data: any, search: modifierKey_object[]): modifier_object[] {
-    const returnObjarray1D = [];
-    // console.log("Xsearch 3",search);
-
-    let returnObject: modifier_object;
-    for (let i = 0; i < search.length; i++) {
-      returnObject = {
-        modifier: (data[search[i].modifier])
-      };
-      returnObjarray1D.push(returnObject);
-    }
-    return returnObjarray1D;
-  }
-
-
-  public get_3_Modifier_array__From__KeyModifier_array(data: any, search: modifierKey_object[]): string[] {
+  public get_Modifier_array__From__KeyModifier_array(data: any, search: allArrayContents_object[]): string[] {
     const returnString1D: string[] = [];
     for (let i = 0; i < search.length; i++) {
-      returnString1D.push(data[search[i].modifier]);
+      returnString1D.push(data[search[i].behaviour]);
     }
     return returnString1D;
   }
@@ -903,10 +827,8 @@ export class KeylayoutToKmnConverter {
    * @param  search :string an actionId to be found
    * @return a string containing the output character
    */
-  // _S2 get 4 OK
-  public get_4_Output__From__ActionId_None(data: any, search: string): string {
+  public get_Output__From__ActionId_None(data: any, search: string): string {
     let OutputValue: string = "";
-
     for (let i = 0; i < data.keyboard.actions.action.length; i++) {
       if (data.keyboard.actions.action[i]['@_id'] === search) {
         for (let j = 0; j < data.keyboard.actions.action[i].when.length; j++) {
@@ -922,55 +844,28 @@ export class KeylayoutToKmnConverter {
   /**
   * @brief  member function to return array of [Keycode,Keyname,actionId,actionIDIndex, output] for a given actionID in of [ actionID,state,output]
   * @param  data   :any - an object containing all data read from a .keylayout file
-  * @param  search :string[][] - array of [ actionID,state,output]
-  * @return a string[][] containing [Keycode,Keyname,actionId,actionIDIndex, output]
+  * @param  search :idStateOutput_object[] - array of [{ actionID,state,output }]
+  * @return a allArrayContents_object[] containing [{Keycode,Keyname,actionId,actionID, output}]
   */
-  // _S2 get 5 OK
-  public get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(data: any, search: string[][]): string[][] {
-
-    if ((search === undefined) || (search === null))
-      return [];
-
-
-    const returnarray2D: string[][] = [];
-    for (let k = 0; k < search.length; k++) {
-      for (let i = 0; i < data.keyboard.keyMapSet[0].keyMap.length; i++) {
-        for (let j = 0; j < data.keyboard.keyMapSet[0].keyMap[i].key.length; j++) {
-          if (data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'] === search[k][0] &&
-            data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'] <= KeylayoutToKmnConverter.USED_KEYS_COUNT) {
-            returnarray2D.push([
-              data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'],
-              this.map_UkeleleKC_To_VK(Number(data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'])),
-              data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'],
-              data.keyboard.keyMapSet[0].keyMap[i]['@_index'],
-              search[k][2]
-            ]);
-          }
-        }
-      }
-    }
-    return returnarray2D;
-  }
-  // _S2 get 5 OK
-  public get_5_KeyActionOutput_array__From__ActionStateOutput_array(data: any, search: idStateOutput_object[]): ActionIdKeyModiOutput_object[] {
+  public get_KeyActionOutput_array__From__ActionStateOutput_array(data: any, search: idStateOutput_object[]): allArrayContents_object[] {
 
     if ((search === undefined) || (search === null))
       return [];
 
     const returnObjarray1D = [];
-    let returnObject: ActionIdKeyModiOutput_object;
+    let returnObject: allArrayContents_object;
 
     for (let k = 0; k < search.length; k++) {
       for (let i = 0; i < data.keyboard.keyMapSet[0].keyMap.length; i++) {
         for (let j = 0; j < data.keyboard.keyMapSet[0].keyMap[i].key.length; j++) {
           if (data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'] === search[k].id &&
-            data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'] <= KeylayoutToKmnConverter.USED_KEYS_COUNT) {
+            data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'] <= KeylayoutToKmnConverter.USE_KEY_COUNT) {
 
             returnObject = {
               keyCode: data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'],
               key: this.map_UkeleleKC_To_VK(Number(data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'])),
               actionId: data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'],
-              modifier: data.keyboard.keyMapSet[0].keyMap[i]['@_index'],
+              behaviour: data.keyboard.keyMapSet[0].keyMap[i]['@_index'],
               outchar: search[k].output
             };
             returnObjarray1D.push(returnObject);
@@ -985,27 +880,9 @@ export class KeylayoutToKmnConverter {
    * @brief  member function to get an array of all actionId-output pairs for a certain state
    * @param  data    : any an object containing all data read from a .keylayout file
    * @param  search  : string a 'state' to be found
-   * @return an array: string[][] containing all [actionId, state, output] for a certain state
+   * @return an array: idStateOutput_object[] containing all [{actionId, state, output}] for a certain state
    */
-  // _S2 get 6 OK
-  public get_6o_ActionStateOutput_array__From__ActionState_oldArrayType(data: any, search: string): string[][] {
-    const returnarray2D: string[][] = [];
-
-    for (let i = 0; i < data.keyboard.actions.action.length; i++) {
-      for (let j = 0; j < data.keyboard.actions.action[i].when.length; j++) {
-        if ((data.keyboard.actions.action[i].when[j]['@_state'] === search)) {
-          returnarray2D.push([
-            data.keyboard.actions.action[i]['@_id'],
-            data.keyboard.actions.action[i].when[j]['@_state'],
-            data.keyboard.actions.action[i].when[j]['@_output']
-          ]);
-        }
-      }
-    }
-    return returnarray2D;
-  }
-  // _S2 get 6 OK
-  public get_6_ActionStateOutput_array__From__ActionState(data: any, search: string): idStateOutput_object[] {
+  public get_ActionStateOutput_array__From__ActionState(data: any, search: string): idStateOutput_object[] {
     const returnObjarray1D: idStateOutput_object[] = [];
     let returnObject: idStateOutput_object;
 
@@ -1022,83 +899,31 @@ export class KeylayoutToKmnConverter {
         }
       }
     }
-    return returnObjarray1D;
+    return returnObjarray1D;   // _S2 ToDo rewrite/change all functio  comments to new datatypes!!!
   }
 
   /**
    * @brief  member function to create an 2D array of [KeyName,actionId,behaviour,modifier,output]
    * @param  data    : any an object containing all data read from a .keylayout file
-   * @param  search  : array of [keycode,keyname,actionId,behaviour,output] to be found
+   * @param  search  : array of [{keycode,keyname,actionId,behaviour,output}] to be found
    * @param  isCAPSused  : boolean flag to indicate if CAPS is used in a keylayout file or not
-   * @return an array: string[][] containing [KeyName,actionId,behaviour,modifier,output]
+   * @return an array: allArrayContents_object[] containing [{KeyName,actionId,behaviour,modifier,output}]
    */
-  // _S2 get 7 OK --> tests not OK 
-  public get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(data: any, search: (boolean | string)[][], isCAPSused: boolean): string[][] {
-    const returnarray: string[][] = [];
-
-    if (!((search === undefined) || (search === null) || (search.length === 0))) {
-      for (let i = 0; i < search.length; i++) {
-        const behaviour: number = Number(search[i][3]);
-        for (let j = 0; j < data.keyboard.modifierMap.keyMapSelect[behaviour].modifier.length; j++) {
-          returnarray.push([
-            // KeyName
-            String(search[i][1]),
-            // actionId
-            String(search[i][2]),
-            // behaviour
-            String(search[i][3]),
-            // modifier
-            String(this.create_kmn_modifier(data.keyboard.modifierMap.keyMapSelect[behaviour].modifier[j]['@_keys'], isCAPSused)),
-            // output
-            String(search[i][4])
-          ]);
-        }
-      }
-    }
-    // remove duplicates
-    const [unique_returnarray] = returnarray.reduce((acc, curr) => {
-      const [uniq, set] = acc;
-      if (!set.has(curr.join(','))) {
-        set.add(curr.join(','));
-        uniq.push(curr);
-      }
-      return acc;
-    },
-      [[], new Set()],
-    );
-    return unique_returnarray;
-  }
-  public get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(data: any, search: ((boolean | string)[])[], isCAPSused: boolean): ActionIdOutputBehaviourKeyModi_object[] {
-    const returnarray: string[][] = [];
+  public get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(data: any, search: allArrayContents_object[], isCAPSused: boolean): allArrayContents_object[] {
     const returnObjarray1D = [];
-    let returnObject: ActionIdOutputBehaviourKeyModi_object;
-
+    let returnObject: allArrayContents_object;
 
     if (!((search === undefined) || (search === null) || (search.length === 0))) {
       for (let i = 0; i < search.length; i++) {
-        const behaviour: number = Number(search[i][3]);
-        for (let j = 0; j < data.keyboard.modifierMap.keyMapSelect[behaviour].modifier.length; j++) {
-
-          returnarray.push([
-            // KeyName
-            String(search[i][1]),
-            // actionId
-            String(search[i][2]),
-            // behaviour
-            String(search[i][3]),
-            // modifier
-            String(this.create_kmn_modifier(data.keyboard.modifierMap.keyMapSelect[behaviour].modifier[j]['@_keys'], isCAPSused)),
-            // output
-            String(search[i][4])
-          ]);
+        const behaviour_idx: number = Number(search[i].behaviour);
+        for (let j = 0; j < data.keyboard.modifierMap.keyMapSelect[behaviour_idx].modifier.length; j++) {
 
           returnObject = {
-            search: "",
-            actionId: String(search[i][2]),
-            behaviour: String(search[i][3]),
-            modifier: String(this.create_kmn_modifier(data.keyboard.modifierMap.keyMapSelect[behaviour].modifier[j]['@_keys'], isCAPSused)),
-            key: String(search[i][1]),
-            outchar: String(search[i][4]),
+            actionId: search[i].actionId,
+            key: search[i].key,
+            behaviour: search[i].behaviour,
+            modifier: this.create_kmn_modifier(data.keyboard.modifierMap.keyMapSelect[behaviour_idx].modifier[j]['@_keys'], isCAPSused),
+            outchar: search[i].outchar,
           };
           returnObjarray1D.push(returnObject);
         }
@@ -1108,55 +933,15 @@ export class KeylayoutToKmnConverter {
     const unique_Objarray = returnObjarray1D.reduce((unique, o) => {
       if (!unique.some(obj =>
         obj.actionId === o.actionId &&
+        obj.key === o.key &&
         obj.behaviour === o.behaviour &&
         obj.modifier === o.modifier &&
-        obj.key === o.key &&
         obj.outchar === o.outchar
       )) {
         unique.push(o);
       }
       return unique;
     }, []);
-
-    return unique_Objarray;
-  }
-  public get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(data: any, search: ActionIdKeyModiOutput_object[], isCAPSused: boolean): ActionIdOutputBehaviourKeyModi_object[] {
-
-    const returnObjarray1D = [];
-    let returnObject: ActionIdOutputBehaviourKeyModi_object;
-
-
-    if (!((search === undefined) || (search === null) || (search.length === 0))) {
-      for (let i = 0; i < search.length; i++) {
-        const behaviour: number = Number(search[i].modifier);
-        for (let j = 0; j < data.keyboard.modifierMap.keyMapSelect[behaviour].modifier.length; j++) {
-
-          returnObject = {
-            search: "",
-            actionId: String(search[i].actionId),
-            behaviour: String(search[i].modifier),
-            modifier: String(this.create_kmn_modifier(data.keyboard.modifierMap.keyMapSelect[behaviour].modifier[j]['@_keys'], isCAPSused)),
-            key: String(search[i].key),
-            outchar: String(search[i].outchar),
-          };
-          returnObjarray1D.push(returnObject);
-        }
-      }
-    }
-    // remove duplicates
-    const unique_Objarray = returnObjarray1D.reduce((unique, o) => {
-      if (!unique.some(obj =>
-        obj.actionId === o.actionId &&
-        obj.behaviour === o.behaviour &&
-        obj.modifier === o.modifier &&
-        obj.key === o.key &&
-        obj.outchar === o.outchar
-      )) {
-        unique.push(o);
-      }
-      return unique;
-    }, []);
-
     return unique_Objarray;
   }
 
@@ -1167,30 +952,28 @@ export class KeylayoutToKmnConverter {
    * @param  search  : string - an actionId to be found
    * @param  outchar  : string - the output character
    * @param  isCAPSused  : boolean - flag to indicate if CAPS is used in a keylayout file or not
-   * @return an array: string[][] containing [actionID,output,actionID, behaviour,keyname,modifier]
+   * @return an array: allArrayContents_object[] containing [{actionID,output,actionID, behaviour,keyname,modifier}]
    */
-  // _S2 get 8 OK
-  public get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(data: any, modi: any, search: string, outchar: string, isCapsused: boolean): ActionIdOutputBehaviourKeyModi_object[] {
+  public get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(data: any, modi: string[][], search: string, outchar: string, isCapsused: boolean): allArrayContents_object[] {
     const returnObjarray1D = [];
-    let returnObject: ActionIdOutputBehaviourKeyModi_object;
+    let returnObject: allArrayContents_object;
 
     if ((search === "") || (search === undefined) || !((isCapsused === true) || (isCapsused === false))) {
       return [];
     }
     // loop behaviors (in ukelele it is possible to define multiple modifier combinations that behave in the same way)
     for (let i = 0; i < data.keyboard.keyMapSet[0].keyMap.length; i++) {
-      for (let j = 0; j <= KeylayoutToKmnConverter.USED_KEYS_COUNT; j++) {
+
+      for (let j = 0; j <= KeylayoutToKmnConverter.USE_KEY_COUNT; j++) {
         if (data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'] === search) {
           for (let k = 0; k < modi[data.keyboard.keyMapSet[0].keyMap[i]['@_index']].length; k++) {
-            const behaviour: string = data.keyboard.keyMapSet[0].keyMap[i]['@_index'];
-
+            const behaviour_idx: number = data.keyboard.keyMapSet[0].keyMap[i]['@_index'];
             returnObject = {
-              search: search,
               outchar: outchar,
               actionId: data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'],
               behaviour: data.keyboard.keyMapSet[0].keyMap[i]['@_index'],
               key: this.map_UkeleleKC_To_VK(Number(data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'])),
-              modifier: this.create_kmn_modifier(modi[behaviour][k], isCapsused),
+              modifier: this.create_kmn_modifier(modi[behaviour_idx][k], isCapsused),
             };
             returnObjarray1D.push(returnObject);
           }
@@ -1203,9 +986,8 @@ export class KeylayoutToKmnConverter {
     // remove duplicates
     const unique_Objarray = returnObjarray1D.reduce((unique, o) => {
       if (!unique.some(obj =>
-        obj.actionId === o.actionId &&
         obj.outchar === o.outchar &&
-        obj.search === o.search &&
+        obj.actionId === o.actionId &&
         obj.behaviour === o.behaviour &&
         obj.key === o.key &&
         obj.modifier === o.modifier
@@ -1219,47 +1001,24 @@ export class KeylayoutToKmnConverter {
   }
 
   /**
-   * @brief  member function to create an array of [keycode,behaviour] for a given actionId
+   * @brief  member function to create an array of [{keycode,behaviour}] for a given actionId
    * @param  data    : any - an object containing all data read from a .keylayout file
    * @param  search  : string - an actionId to be found
-   * @return an array: number[][] containing [keycode,behaviour]
+   * @return an array: allArrayContents_object[] containing [{keycode,behaviour}]
    */
-  // _S2 get 9  OK  //_S2 remove&replace
-  public get_9o_KeyModifier_array__From__ActionID_oldArrayType(data: any, search: string): number[][] {
+  public get_KeyModifier_array__From__ActionID(data: any, search: string): allArrayContents_object[] {
     const mapIndexArray_2D: number[][] = [];
-    let returnObject: modifierKey_object;
-    const mapIndexObject1D: modifierKey_object[] = [];
+    let returnObject: allArrayContents_object;
+    const mapIndexObject1D: allArrayContents_object[] = [];
 
     for (let i = 0; i < data.keyboard.keyMapSet[0].keyMap.length; i++) {
-      for (let j = 0; j <= KeylayoutToKmnConverter.USED_KEYS_COUNT; j++) {
+      for (let j = 0; j <= KeylayoutToKmnConverter.USE_KEY_COUNT; j++) {
         if (data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'] === search) {
 
           mapIndexArray_2D.push([data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'], i]);
-
           returnObject = {
             key: data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'],
-            modifier: i
-          };
-          mapIndexObject1D.push(returnObject);
-        }
-      }
-    }
-    return mapIndexArray_2D;
-  }
-  public get_9_KeyModifier_array__From__ActionID(data: any, search: string): modifierKey_object[] {
-    const mapIndexArray_2D: number[][] = [];
-    let returnObject: modifierKey_object;
-    const mapIndexObject1D: modifierKey_object[] = [];
-
-    for (let i = 0; i < data.keyboard.keyMapSet[0].keyMap.length; i++) {
-      for (let j = 0; j <= KeylayoutToKmnConverter.USED_KEYS_COUNT; j++) {
-        if (data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_action'] === search) {
-
-          mapIndexArray_2D.push([data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'], i]);
-
-          returnObject = {
-            key: data.keyboard.keyMapSet[0].keyMap[i].key[j]['@_code'],
-            modifier: i
+            behaviour: String(i),
           };
           mapIndexObject1D.push(returnObject);
         }
@@ -1272,101 +1031,6 @@ export class KeylayoutToKmnConverter {
   public convert_bound = {
     convert: this.convert.bind(this),
   };
-
-
-
-  public dummy(into: any) {
-  }
-  public compareBoth(arr: any, obj: any,) {
-
-    // compare:-----------------------------------
-    for (let k = 0; k < obj.length; k++) {
-      /*console.log("k ", k);
-
-      console.log(" arr", typeof (arr), arr, "----", typeof (arr[k]), arr[k]);
-      console.log("-------------------- ",);
-      console.log(" obj", typeof (obj), obj, "----", typeof (obj[k]), obj[k]);
-
-      console.log("arr[k  ", arr[k]);
-      console.log("obj[k].modifier ", obj[k].modifier);*/
-      if (
-        (arr.length === obj.length) &&
-
-
-        (arr[k] === obj[k].modifier)
-        // (arr[k][1] === obj[k].key) 
-
-        /*(arr[k][0] === obj[k].key) &&
-        (arr[k][1] === obj[k].actionId) &&
-        (arr[k][2] === obj[k].behaviour) &&
-        (arr[k][3] === obj[k].modifier) &&
-        (arr[k][4] === obj[k].outchar)*/
-
-      ) {
-        console.log("IS_EQUAL ",);
-      }
-      else console.log("NONONO not_EQUAL \n",
-        (arr.length === obj.length), obj.length, "<->", arr.length, "\n",
-
-        (arr[k] === obj[k].modifier), obj[k].modifier, "<->", arr[k], "\n",
-        // (arr[k][1] === obj[k].key), obj[k].key, "<->", arr[k][1], "\n",
-
-
-        /* (arr[k][0] === obj[k].key), obj[k].key, "<->", arr[k][0], "\n",
-         (arr[k][1] === obj[k].actionId), obj[k].actionId, "<->", arr[k][1], "\n",
-         (arr[k][2] === obj[k].behaviour), obj[k].behaviour, "<->", arr[k][2], "\n",
-         (arr[k][3] === obj[k].modifier), obj[k].modifier, "<->", arr[k][3], "\n",
-         (arr[k][4] === obj[k].outchar), obj[k].outchar, "<->", arr[k][4]*/
-      );
-    }
-  }
-  public compareSameType(arr1: any, arr2: any,) {
-
-
-    // compare:-----------------------------------
-    for (let k = 0; k < arr1.length; k++) {
-      /*console.log("k ", k);
-
-      console.log(" arr1", typeof (arr1), arr1, "----", typeof (arr1[k]), arr1[k]);
-      console.log("-------------------- ",);
-      console.log(" arr2", typeof (arr2), arr2, "----", typeof (arr2[k]), arr2[k]);
-
-      console.log("arr1[k  ", arr1[k]);
-      console.log("arr2[k].modifier ", arr2[k].modifier);*/
-      if (
-        (arr1.length === arr2.length) &&
-
-        (arr1[k].search === arr2[k].search) &&
-        (arr1[k].actionId === arr2[k].actionId) &&
-        (arr1[k].behaviour === arr2[k].behaviour) &&
-        (arr1[k].modifier === arr2[k].modifier) &&
-        (arr1[k].key === arr2[k].key) &&
-        (arr1[k].outchar === arr2[k].outchar)
-
-      ) {
-        console.log("compareSameType: IS_EQUAL ",);
-      }
-      else console.log("compareSameType: NONONO not_EQUAL \n",
-        (arr1.length === arr2.length), arr2.length, "<->", arr1.length, "\n",
-
-        (arr1[k] === arr2[k].modifier), arr2[k].modifier, "<->", arr1[k], "\n",
-        // (arr1[k][1] === arr2[k].key), arr2[k].key, "<->", arr1[k][1], "\n",
-
-
-        /* (arr1[k][0] === arr2[k].key), arr2[k].key, "<->", arr1[k][0], "\n",
-         (arr1[k][1] === arr2[k].actionId), arr2[k].actionId, "<->", arr1[k][1], "\n",
-         (arr1[k][2] === arr2[k].behaviour), arr2[k].behaviour, "<->", arr1[k][2], "\n",
-         (arr1[k][3] === arr2[k].modifier), arr2[k].modifier, "<->", arr1[k][3], "\n",
-         (arr1[k][4] === arr2[k].outchar), arr2[k].outchar, "<->", arr1[k][4]*/
-      );
-    }
-  }
-
-
-
-
-
-
 }
 
 /**

--- a/developer/src/kmc-convert/src/keylayout-to-kmn/kmn-file-writer.ts
+++ b/developer/src/kmc-convert/src/keylayout-to-kmn/kmn-file-writer.ts
@@ -149,7 +149,7 @@ export class KmnFileWriter {
 
         // lookup key nr of the key which is being processed
         let keyNr: number = 0;
-        for (let j = 0; j <= KeylayoutToKmnConverter.USED_KEYS_COUNT; j++) {
+        for (let j = 0; j <= KeylayoutToKmnConverter.USE_KEY_COUNT; j++) {
           if (keylayoutKmnConverter.map_UkeleleKC_To_VK(j) === unique_data_Rules[k].key) {
             keyNr = j;
             break;

--- a/developer/src/kmc-convert/test/keylayout-to-kmn-converter.tests.ts
+++ b/developer/src/kmc-convert/test/keylayout-to-kmn-converter.tests.ts
@@ -10,7 +10,7 @@
 import 'mocha';
 import { assert } from 'chai';
 import { compilerTestCallbacks, compilerTestOptions, makePathToFixture } from './helpers/index.js';
-import { KeylayoutToKmnConverter } from '../src/keylayout-to-kmn/keylayout-to-kmn-converter.js';
+import { /*ActionIdOutputBehaviourKeyModi_object,*/ KeylayoutToKmnConverter } from '../src/keylayout-to-kmn/keylayout-to-kmn-converter.js';
 import { KeylayoutFileReader } from '../src/keylayout-to-kmn/keylayout-file-reader.js';
 import { ConverterMessages } from '../src/converter-messages.js';
 import * as NodeAssert from 'node:assert';
@@ -21,6 +21,43 @@ describe('KeylayoutToKmnConverter', function () {
     compilerTestCallbacks.clear();
   });
 
+  // todo remove
+  describe('RunOneFile', function () {
+    const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
+    const inputFilename = makePathToFixture('../data/Test.keylayout');
+    sut.run(inputFilename);
+    assert.isTrue(true);
+  });
+
+  // todo remove
+  describe('RunOneFile', function () {
+    const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
+    const inputFilename = makePathToFixture('../data/Italian.keylayout');
+    sut.run(inputFilename);
+    assert.isTrue(true);
+  });
+
+  // todo remove
+  describe('RunAllFiles', function () {
+    const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
+    [
+      [makePathToFixture('../data/Italian.keylayout')],
+      [makePathToFixture('../data/Italian_command.keylayout')],
+      [makePathToFixture('../data/Swiss_French.keylayout')],
+      [makePathToFixture('../data/Spanish.keylayout')],
+      [makePathToFixture('../data/Swiss_German.keylayout')],
+      [makePathToFixture('../data/US.keylayout')],
+      [makePathToFixture('../data/Polish.keylayout')],
+      [makePathToFixture('../data/French.keylayout')],
+      [makePathToFixture('../data/Latin_American.keylayout')],
+      // [makePathToFixture('../data/German_complete.keylayout')],
+      [makePathToFixture('../data/German_complete_reduced.keylayout')],
+      //[makePathToFixture('../data/German_Standard.keylayout')],
+    ].forEach(function (files_) {
+      sut.run(files_[0]);
+      assert.isTrue(true);
+    });
+  });
   describe('run() ', function () {
 
     // _S2 can I do this??? - some tests of the run() function might take longer than 2000 ms
@@ -253,7 +290,7 @@ describe('KeylayoutToKmnConverter', function () {
     });
   });
 
-  describe('get_Modifier_array__From__KeyModifier_array ', function () {
+  describe('get_3o_Modifier_array__From__KeyModifier_array_oldArrayType ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -270,9 +307,9 @@ describe('KeylayoutToKmnConverter', function () {
 
     ].forEach(function (values) {
       it((values[1][0] !== null) ?
-        ("get_Modifier_array__From__KeyModifier_array(['" + values[0][0][0] + "', '" + values[0][0][1] + "'])").padEnd(68, " ") + " should return ['" + values[1][0][0] + "', '" + values[1][0][1] + "']" :
-        ("get_Modifier_array__From__KeyModifier_array(['" + values[0][0][0] + "', '" + values[0][0][1] + "'])").padEnd(68, " ") + " should return ['" + values[1][0] + "']", async function () {
-          const result = sut.get_Modifier_array__From__KeyModifier_array(converted.arrayOf_Modifiers, values[0]);
+        ("get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(['" + values[0][0][0] + "', '" + values[0][0][1] + "'])").padEnd(68, " ") + " should return ['" + values[1][0][0] + "', '" + values[1][0][1] + "']" :
+        ("get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(['" + values[0][0][0] + "', '" + values[0][0][1] + "'])").padEnd(68, " ") + " should return ['" + values[1][0] + "']", async function () {
+          const result = sut.get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(converted.arrayOf_Modifiers, values[0]);
           assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(values[1]));
         });
     });
@@ -281,14 +318,113 @@ describe('KeylayoutToKmnConverter', function () {
     [[[undefined]], [null]],
     [[[]], [null]],
     ].forEach(function (values) {
-      it(("get_Modifier_array__From__KeyModifier_array([" + values[0][0] + "])").padEnd(68, " ") + " should return ['" + values[1][0] + "']", async function () {
-        const result = sut.get_Modifier_array__From__KeyModifier_array(converted.arrayOf_Modifiers, values[0]);
+      it(("get_3o_Modifier_array__From__KeyModifier_array_oldArrayType([" + values[0][0] + "])").padEnd(68, " ") + " should return ['" + values[1][0] + "']", async function () {
+        const result = sut.get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(converted.arrayOf_Modifiers, values[0]);
         assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
+  describe('get_3_Modifier_array__From__KeyModifier_array ', function () {
+    /*const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
+     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
+     const inputFilename = makePathToFixture('../data/Test.keylayout');
+     const read = sut_r.read(inputFilename);
+     const converted = sut.convert_bound.convert(read, inputFilename.replace(/\.keylayout$/, '.kmn'));
 
-  describe('get_KeyModifier_array__From__ActionID ', function () {
+
+    //search old  [ [ '45', 5 ] ]
+    //search      [ { key: '45', modifier: 5 } ]
+
+
+    [
+
+      //search    
+      [[{ key: '0', modifier: 0 }, ['', 'shift? caps? ']]],
+      [[{ key: '3', modifier: 0 },['', 'shixft? caps? ']]],
+      [[{ key: '7', modifier: 0 },['', 'shift? caxps? ']]],
+      [[{ key: '0', modifier: 2 },['', 'shift? caps? ']]],
+      [[{ key: '0', modifier: 999 },['', 'shift? caps? ']]],
+      [[{ key: '999', modifier: null },['', 'shift? caps? ']]],
+      [[{ key: '0', modifier: -999 },['', 'shift? caps? ']]],
+      [[{ key: '0', modifier: null },['', 'shift? caps? ']]],
+
+
+
+      //[['0', 0], [['', 'shift? caps? ']]],
+      // [[['0', 2]], [['shift? leftShift caps? ', 'anyShift caps?', 'shift leftShift caps ', 'shift? rightShift caps? ']]],
+      // [[['0', 999]], [null]],
+      //  [[['999',]], [null]],
+      //  [[['0', -999]], [null]],
+      //  [[['0']], [null]],
+
+
+
+
+    ].forEach(function (values) {
+
+
+
+      console.log("values ", values);
+      console.log("values[0] ", values[0]);
+      console.log("values[1] ", values[1]);
+      //console.log("values[1][0] ", values[1][0]);
+      //  console.log("values[0][0][0] ", values[0][0][0]);
+      // console.log(" values[0][0][1]", values[0][0][1]);
+      // console.log("values[1][0][0] ", values[1][0][0]);
+      // console.log("values [1][0][1]", values[1][0][1]); 
+
+
+console.log("XXX get_3_Modifier_array__From__KeyModifier_array(['" , values[0] , "'])", " should return ['" , values[1] , "']");
+
+
+
+      it((values[1] !== null) ?
+        ("get_3_Modifier_array__From__KeyModifier_array(['" + values[0] + "'])").padEnd(68, " ") + " should return ['" + values[1] + "']" :
+        ("get_3_Modifier_array__From__KeyModifier_array(['" + values[0] + "'])").padEnd(68, " ") + " should return ['" + values[1] + "']", async function () {
+          //const result = sut.get_3_Modifier_array__From__KeyModifier_array(converted.arrayOf_Modifiers, values[0]);
+          // assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(values[1]));
+        });
+    });
+
+    /*   [[[[null]], [null]],
+       [[[undefined]], [null]],
+       [[[]], [null]],
+       ].forEach(function (values) {
+         it(("get_3_Modifier_array__From__KeyModifier_array([" + values[0][0] + "])").padEnd(68, " ") + " should return ['" + values[1][0] + "']", async function () {
+           const result = sut.get_3_Modifier_array__From__KeyModifier_array(converted.arrayOf_Modifiers, values[0]);
+           assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(values[1]));
+         });
+       });
+  */
+  });
+
+  describe('get_9_KeyModifier_array__From__ActionID ', function () {
+    const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
+    const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
+    const inputFilename = makePathToFixture('../data/Test.keylayout');
+    const read = sut_r.read(inputFilename);
+    [
+      ['A_16', [{ "key": "32", "modifier": 5 }]],
+      ['A_19', [{ "key": "45", "modifier": 5 }]],
+      ['A_18', [{ "key": "24", "modifier": 0 }, { "key": "24", "modifier": 5 }]],
+      ['unknown', []],
+      [undefined, []],
+      [null, []],
+      [' ', []],
+      ['', []],
+    ].forEach(function (values) {
+      let outstring = '[ ';
+      for (let i = 0; i < values[1].length; i++) {
+        outstring = outstring + "[ " + JSON.stringify(values[1][i]) + "], ";
+      }
+      it(("get_9_KeyModifier_array__From__ActionID('" + values[0] + "')").padEnd(57, " ") + ' should return ' + outstring.substring(0, outstring.lastIndexOf(']') + 2) + " ]", async function () {
+        //const result = sut.get_9_KeyModifier_array__From__ActionID_arr(read, String(values[0]));   //_S2 remove&replace
+        const result = sut.get_9_KeyModifier_array__From__ActionID(read, String(values[0]));
+        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
+      });
+    });
+  });
+  describe('get_9o_KeyModifier_array__From__ActionID_oldArrayType ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -298,6 +434,8 @@ describe('KeylayoutToKmnConverter', function () {
       ['A_16', [['32', 5]]],
       ['A_19', [['45', 5]]],
       ['A_18', [['24', 0], ['24', 5]]],
+
+
       ['unknown', []],
       [undefined, []],
       [null, []],
@@ -309,15 +447,14 @@ describe('KeylayoutToKmnConverter', function () {
       for (let i = 0; i < values[1].length; i++) {
         outstring = outstring + "[ '" + values[1][i][0] + "', " + values[1][i][1].toString() + "], ";
       }
-
-      it(("get_KeyModifier_array__From__ActionID('" + values[0] + "')").padEnd(57, " ") + ' should return ' + outstring.substring(0, outstring.lastIndexOf(']') + 2) + " ]", async function () {
-        const result = sut.get_KeyModifier_array__From__ActionID(read, String(values[0]));
+      it(("get_9o_KeyModifier_array__From__ActionID_oldArrayType('" + values[0] + "')").padEnd(57, " ") + ' should return ' + outstring.substring(0, outstring.lastIndexOf(']') + 2) + " ]", async function () {
+        const result = sut.get_9o_KeyModifier_array__From__ActionID_oldArrayType(read, String(values[0]));
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
 
-  describe('get_ActionID__From__ActionNext ', function () {
+  describe('get_2_ActionID__From__ActionNext ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -337,14 +474,13 @@ describe('KeylayoutToKmnConverter', function () {
       [undefined, ''],
       ['unknown', ''],
     ].forEach(function (values) {
-      it(("get_ActionID__From__ActionNext('" + values[0] + "')").padEnd(49, " ") + ' should return ' + "'" + values[1] + "'", async function () {
-        const result = sut.get_ActionID__From__ActionNext(read, String(values[0]));
+      it(("get_2_ActionID__From__ActionNext('" + values[0] + "')").padEnd(49, " ") + ' should return ' + "'" + values[1] + "'", async function () {
+        const result = sut.get_2_ActionID__From__ActionNext(read, String(values[0]));
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
-
-  describe('get_ActionIndex__From__ActionId ', function () {
+  describe('get_1_ActionIndex__From__ActionId ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -362,14 +498,14 @@ describe('KeylayoutToKmnConverter', function () {
       [undefined, 0],
       ['unknown', 0],
     ].forEach(function (values) {
-      it(("get_ActionIndex__From__ActionId('" + values[0] + "')").padEnd(50, " ") + ' should return ' + values[1], async function () {
-        const result = sut.get_ActionIndex__From__ActionId(read, String(values[0]));
+      it(("get_1_ActionIndex__From__ActionId('" + values[0] + "')").padEnd(50, " ") + ' should return ' + values[1], async function () {
+        const result = sut.get_1_ActionIndex__From__ActionId(read, String(values[0]));
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
 
-  describe('get_Output__From__ActionId_None ', function () {
+  describe('get_4_Output__From__ActionId_None ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -383,8 +519,8 @@ describe('KeylayoutToKmnConverter', function () {
       ['unknown', ''],
     ].forEach(function (values) {
       it(
-        ("get_Output__From__ActionId_None('" + values[0] + "')").padEnd(56, " ") + ' should return ' + "'" + values[1] + "'", async function () {
-          const result = sut.get_Output__From__ActionId_None(read, String(values[0]));
+        ("get_4_Output__From__ActionId_None('" + values[0] + "')").padEnd(56, " ") + ' should return ' + "'" + values[1] + "'", async function () {
+          const result = sut.get_4_Output__From__ActionId_None(read, String(values[0]));
           assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
         });
     });
@@ -393,14 +529,14 @@ describe('KeylayoutToKmnConverter', function () {
     [undefined, ''],
     [99, ''],
     ].forEach(function (values) {
-      it(("get_Output__From__ActionId_None('" + values[0] + "')").padEnd(56, " ") + ' should return ' + values[1], async function () {
-        const result = sut.get_Output__From__ActionId_None(read, String(values[0]));
+      it(("get_4_Output__From__ActionId_None('" + values[0] + "')").padEnd(56, " ") + ' should return ' + values[1], async function () {
+        const result = sut.get_4_Output__From__ActionId_None(read, String(values[0]));
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
 
-  describe('get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array ', function () {
+  describe('get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -474,12 +610,16 @@ describe('KeylayoutToKmnConverter', function () {
     ].forEach(function (values) {
 
       const isCaps_used = true;
-      const string_in = "get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(['" + "', '" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "', '" + values[0][0][3] + "', '" + values[0][0][4] + "'])";
+      const string_in = "get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(['" + "', '" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "', '" + values[0][0][3] + "', '" + values[0][0][4] + "'])";
       const string_out = "['" + "', '" + values[1][0][0] + "', '" + values[1][0][1] + "', '" + values[1][0][2] + "', '" + values[1][0][3] + "', '" + values[1][0][4] + "']";
+
+
+      //console.log("FUNCTION NEEDS  ", values[0]);
+
 
       it((JSON.stringify(values[1]).length > 60) ? 'an array of objects should return an array of objects' :
         string_in.padEnd(74, " ") + ' should return ' + string_out, async function () {
-          const result = sut.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps_used);
+          const result = sut.get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(read, values[0], isCaps_used);
           assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
         });
     });
@@ -491,11 +631,11 @@ describe('KeylayoutToKmnConverter', function () {
     ].forEach(function (values) {
 
       const isCaps_used = false;
-      const string_in = "get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(['" + "', '" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "', '" + values[0][0][3] + "', '" + values[0][0][4] + "'])";
+      const string_in = "get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(['" + "', '" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "', '" + values[0][0][3] + "', '" + values[0][0][4] + "'])";
       const string_out = "['" + "', '" + values[1][0][0] + "', '" + values[1][0][1] + "', '" + values[1][0][2] + "', '" + values[1][0][3] + "', '" + values[1][0][4] + "']";
 
       it(string_in.padEnd(74, " ") + ' should return ' + string_out, async function () {
-        const result = sut.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps_used);
+        const result = sut.get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(read, values[0], isCaps_used);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
@@ -505,14 +645,132 @@ describe('KeylayoutToKmnConverter', function () {
     [null, []],
     ].forEach(function (values) {
       const isCaps = true;
-      it(("get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array([" + values[0] + "])").padEnd(74, " ") + ' should return ' + "[" + values[1] + "]", async function () {
-        const result = sut.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps);
+      it(("get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType([" + values[0] + "])").padEnd(74, " ") + ' should return ' + "[" + values[1] + "]", async function () {
+        const result = sut.get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(read, values[0], isCaps);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
+  //_S2 Todo finish !!
+  describe('get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array ', function () {
+    /*const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
+    const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
+    const inputFilename = makePathToFixture('../data/Test.keylayout');
+    const read = sut_r.read(inputFilename);*/
 
-  describe('get_ActionStateOutput_array__From__ActionState ', function () {
+    const b1_keycode_arr = [
+      // _S2 Todo write in object-fornm
+
+      ['49', 'K_SPACE', 'A_0', '0', 'ˆ'],
+      ['49', 'K_SPACE', 'A_0', '1', 'ˆ'],
+      ['49', 'K_SPACE', 'A_0', '2', 'ˆ'],
+      ['6', 'K_Z', 'A_0', '4', 'ˆ'],
+      ['25', 'K_9', 'A_0', '4', 'ˆ'],
+      ['43', 'K_COMMA', 'A_0', '4', 'ˆ'],
+      ['49', 'K_SPACE', 'A_0', '3', 'ˆ'],
+      ['0', 'K_A', 'A_1', '2', 'Â'],
+      ['0', 'K_A', 'A_1', '1', 'Â'],
+      ['14', 'K_E', 'A_10', '0', 'ê'],
+      ['34', 'K_I', 'A_11', '0', 'î'],
+      ['31', 'K_O', 'A_13', '0', 'ô'],
+      ['32', 'K_U', 'A_14', '0', 'û'],
+      ['14', 'K_E', 'A_2', '2', 'Ê'],
+      ['14', 'K_E', 'A_2', '1', 'Ê'],
+      ['34', 'K_I', 'A_3', '2', 'Î'],
+      ['34', 'K_I', 'A_3', '1', 'Î'],
+      ['31', 'K_O', 'A_5', '2', 'Ô'],
+      ['31', 'K_O', 'A_5', '1', 'Ô'],
+      ['32', 'K_U', 'A_6', '2', 'Û'],
+      ['32', 'K_U', 'A_6', '1', 'Û'],
+      ['0', 'K_A', 'A_9', '0', 'â']/**/
+    ];
+    const b1_modifierKey_arr = [
+      /* ['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ'],
+      ...
+       ['K_A', 'A_9', '0', 'NCAPS', 'â'],*/
+      { "search": "", "actionId": "A_0", "behaviour": "0", "modifier": "NCAPS", "key": "K_SPACE", "outchar": "ˆ" },
+      { "search": "", "actionId": "A_0", "behaviour": "1", "modifier": "CAPS", "key": "K_SPACE", "outchar": "ˆ" },
+      { "search": "", "actionId": "A_0", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_SPACE", "outchar": "ˆ" },
+      { "search": "", "actionId": "A_0", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_SPACE", "outchar": "ˆ" },
+      { "search": "", "actionId": "A_0", "behaviour": "4", "modifier": "NCAPS SHIFT RALT", "key": "K_Z", "outchar": "ˆ" },
+      { "search": "", "actionId": "A_0", "behaviour": "4", "modifier": "NCAPS SHIFT RALT", "key": "K_9", "outchar": "ˆ" },
+      { "search": "", "actionId": "A_0", "behaviour": "4", "modifier": "NCAPS SHIFT RALT", "key": "K_COMMA", "outchar": "ˆ" },
+      { "search": "", "actionId": "A_0", "behaviour": "3", "modifier": "NCAPS RALT CTRL", "key": "K_SPACE", "outchar": "ˆ" },
+      { "search": "", "actionId": "A_0", "behaviour": "3", "modifier": "NCAPS CTRL", "key": "K_SPACE", "outchar": "ˆ" },
+      { "search": "", "actionId": "A_1", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_A", "outchar": "Â" },
+      { "search": "", "actionId": "A_1", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_A", "outchar": "Â" },
+      { "search": "", "actionId": "A_1", "behaviour": "1", "modifier": "CAPS", "key": "K_A", "outchar": "Â" },
+      { "search": "", "actionId": "A_10", "behaviour": "0", "modifier": "NCAPS", "key": "K_E", "outchar": "ê" },
+      { "search": "", "actionId": "A_11", "behaviour": "0", "modifier": "NCAPS", "key": "K_I", "outchar": "î" },
+      { "search": "", "actionId": "A_13", "behaviour": "0", "modifier": "NCAPS", "key": "K_O", "outchar": "ô" },
+      { "search": "", "actionId": "A_14", "behaviour": "0", "modifier": "NCAPS", "key": "K_U", "outchar": "û" },
+      { "search": "", "actionId": "A_2", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_E", "outchar": "Ê" },
+      { "search": "", "actionId": "A_2", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_E", "outchar": "Ê" },
+      { "search": "", "actionId": "A_2", "behaviour": "1", "modifier": "CAPS", "key": "K_E", "outchar": "Ê" },
+      { "search": "", "actionId": "A_3", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_I", "outchar": "Î" },
+      { "search": "", "actionId": "A_3", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_I", "outchar": "Î" },
+      { "search": "", "actionId": "A_3", "behaviour": "1", "modifier": "CAPS", "key": "K_I", "outchar": "Î" },
+      { "search": "", "actionId": "A_5", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_O", "outchar": "Ô" },
+      { "search": "", "actionId": "A_5", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_O", "outchar": "Ô" },
+      { "search": "", "actionId": "A_5", "behaviour": "1", "modifier": "CAPS", "key": "K_O", "outchar": "Ô" },
+      { "search": "", "actionId": "A_6", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_U", "outchar": "Û" },
+      { "search": "", "actionId": "A_6", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_U", "outchar": "Û" },
+      { "search": "", "actionId": "A_6", "behaviour": "1", "modifier": "CAPS", "key": "K_U", "outchar": "Û" },
+      { "search": "", "actionId": "A_9", "behaviour": "0", "modifier": "NCAPS", "key": "K_A", "outchar": "â" }
+    ];
+
+    [[b1_keycode_arr, b1_modifierKey_arr],
+    [[['49', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ']]],
+    [[['49', 'K_SPACE', 'A_0', '0', '']], [['K_SPACE', 'A_0', '0', 'NCAPS', '']]],
+    [[['49', 'K_SPACE', 'A_0', '', 'ˆ']], [['K_SPACE', 'A_0', '', 'NCAPS', 'ˆ']]],
+    [[['49', 'K_SPACE', '', '0', 'ˆ']], [['K_SPACE', '', '0', 'NCAPS', 'ˆ']]],
+    [[['49', '', 'A_0', '0', 'ˆ']], [['', 'A_0', '0', 'NCAPS', 'ˆ']]],
+    [[['', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ']]],
+    [[['', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ']]],
+    [[['', '', '', '', '']], [['', '', '', 'NCAPS', '']]],
+    ].forEach(function (values) {
+
+      /*  // _S2 const isCaps_used = true;
+       const string_in = "get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(['" + "', '" + values[0][0] + "', '" + values[0][1] + "', '" + values[0][2] + "', '" + values[0][3] + "', '" + values[0][4] + "'])";
+       const string_out = "['" + "', '" + values[1][0] + "', '" + values[1][1] + "', '" + values[1][2] + "', '" + values[1][3] + "', '" + values[1][4] + "']";
+ 
+      it((JSON.stringify(values[1]).length > 60) ? 'an array of objects should return an array of objects' :
+         string_in.padEnd(74, " ") + ' should return ' + string_out, async function () {
+           const result = sut.get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps_used);
+           assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
+         });*/
+    });
+
+    [[[['49', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', '', 'ˆ']]],
+    [[['49', 'K_SPACE', 'A_0', '0', '']], [['K_SPACE', 'A_0', '0', '', '']]],
+    [[['', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', '', 'ˆ']]],
+    [[['', '', '', '', '']], [['', '', '', '', '']]],
+    ].forEach(function (values) {
+
+      /*  const isCaps_used = false;    // _S2 add again 
+        const string_in = "get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(['" + "', '" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "', '" + values[0][0][3] + "', '" + values[0][0][4] + "'])";
+        const string_out = "['" + "', '" + values[1][0][0] + "', '" + values[1][0][1] + "', '" + values[1][0][2] + "', '" + values[1][0][3] + "', '" + values[1][0][4] + "']";
+  
+        it(string_in.padEnd(74, " ") + ' should return ' + string_out, async function () {
+          const result = sut.get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps_used);
+          assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
+        });*/
+    });
+
+    [[[], []],
+    [undefined, []],
+    [null, []],
+    ].forEach(function (values) {
+      /*  const isCaps = true;
+        it(("get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array([" + values[0] + "])").padEnd(74, " ") + ' should return ' + "[" + values[1] + "]", async function () {
+          const result = sut.get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps);
+          assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
+        });*/
+    });
+  });
+
+
+  describe('get_6o_ActionStateOutput_array__From__ActionState_oldArrayType ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -550,15 +808,64 @@ describe('KeylayoutToKmnConverter', function () {
     [undefined, [],],
     ].forEach(function (values) {
       it((JSON.stringify(values[1]).length > 30) ?
-        ("get_ActionStateOutput_array__From__ActionState('" + values[0] + "')").padEnd(60, " ") + ' should return an array of objects' :
-        ("get_ActionStateOutput_array__From__ActionState('" + values[0] + "')").padEnd(60, " ") + ' should return ' + "'" + JSON.stringify(values[1]) + "'", async function () {
-          const result = sut.get_ActionStateOutput_array__From__ActionState(read, String(values[0]));
+        ("get_6o_ActionStateOutput_array__From__ActionState_oldArrayType('" + values[0] + "')").padEnd(60, " ") + ' should return an array of objects' :
+        ("get_6o_ActionStateOutput_array__From__ActionState_oldArrayType('" + values[0] + "')").padEnd(60, " ") + ' should return ' + "'" + JSON.stringify(values[1]) + "'", async function () {
+          const result = sut.get_6o_ActionStateOutput_array__From__ActionState_oldArrayType(read, String(values[0]));
           assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
         });
     });
   });
 
-  describe('get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput ', function () {
+  describe('get_6_ActionStateOutput_array__From__ActionState ', function () {
+    const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
+    const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
+    const inputFilename = makePathToFixture('../data/Test.keylayout');
+    const read = sut_r.read(inputFilename);
+
+    [['1', [
+      { "id": "A_0", "state": "1", "output": "ˆ" },
+      { "id": "A_1", "state": "1", "output": "Â" },
+      { "id": "A_10", "state": "1", "output": "ê" },
+      { "id": "A_11", "state": "1", "output": "î" },
+      { "id": "A_13", "state": "1", "output": "ô" },
+      { "id": "A_14", "state": "1", "output": "û" },
+      { "id": "A_2", "state": "1", "output": "Ê" },
+      { "id": "A_3", "state": "1", "output": "Î" },
+      { "id": "A_5", "state": "1", "output": "Ô" },
+      { "id": "A_6", "state": "1", "output": "Û" },
+      { "id": "A_9", "state": "1", "output": "â" }
+    ],],
+    ['2', [
+      { "id": "A_0", "state": "2", "output": "`" },
+      { "id": "A_1", "state": "2", "output": "À" },
+      { "id": "A_10", "state": "2", "output": "è" },
+      { "id": "A_11", "state": "2", "output": "ì" },
+      { "id": "A_13", "state": "2", "output": "ò" },
+      { "id": "A_14", "state": "2", "output": "ù" },
+      { "id": "A_2", "state": "2", "output": "È" },
+      { "id": "A_3", "state": "2", "output": "Ì" },
+      { "id": "A_5", "state": "2", "output": "Ò" },
+      { "id": "A_6", "state": "2", "output": "Ù" },
+      { "id": "A_9", "state": "2", "output": "à" }
+    ],],
+    ['789', [],],
+    ['', [],],
+    [' ', [],],
+    [123, [],],
+    [null, [],],
+    [undefined, [],],
+    ].forEach(function (values) {
+      it((JSON.stringify(values[1]).length > 30) ?
+        ("get_6_ActionStateOutput_array__From__ActionState('" + values[0] + "')").padEnd(60, " ") + ' should return an array of objects' :
+        ("get_6_ActionStateOutput_array__From__ActionState('" + values[0] + "')").padEnd(60, " ") + ' should return ' + "'" + JSON.stringify(values[1]) + "'", async function () {
+          const result = sut.get_6_ActionStateOutput_array__From__ActionState(read, String(values[0]));
+          assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
+        });
+    });
+  });
+
+
+  describe('get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -566,37 +873,38 @@ describe('KeylayoutToKmnConverter', function () {
     const converted = sut.convert_bound.convert(read, inputFilename.replace(/\.keylayout$/, '.kmn'));
 
     [
-      ['A_1', 'A', true, [
-        ['A_1', 'A', 'A_1', '1', 'K_A', 'CAPS'],
-        ['A_1', 'A', 'A_1', '2', 'K_A', 'NCAPS SHIFT'],
-        ['A_1', 'A', 'A_1', '2', 'K_A', 'SHIFT CAPS'],
-      ]
+      ['A_1', 'A', true,
+        [{ "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "1", "key": "K_A", "modifier": "CAPS" },
+        { "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "NCAPS SHIFT" },
+        { "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "SHIFT CAPS" }]
       ],
-      ['A_1', 'A', false, [
-        ['A_1', 'A', 'A_1', '1', 'K_A', 'CAPS'],
-        ['A_1', 'A', 'A_1', '2', 'K_A', 'SHIFT'],
-        ['A_1', 'A', 'A_1', '2', 'K_A', 'SHIFT CAPS']]
+      ['A_1', 'A', false,
+        [{ "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "1", "key": "K_A", "modifier": "CAPS" },
+        { "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "SHIFT" },
+        { "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "SHIFT CAPS" }]
       ],
-      ['A_9', 'a', true, [['A_9', 'a', 'A_9', '0', 'K_A', 'NCAPS']]],
-      ['A_9', 'a', false, [['A_9', 'a', 'A_9', '0', 'K_A', '']]],
-      ['A_9', 'a', , [['A_9', 'a', 'A_9', '0', 'K_A', '']]],
-      ['A_9', '', true, [['A_9', '', 'A_9', '0', 'K_A', 'NCAPS']]],
-      ['A_9', '', false, [['A_9', '', 'A_9', '0', 'K_A', '']]],
+      ['A_9', 'a', true, [{ "search": "A_9", "outchar": "a", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "NCAPS" }]],
+      ['A_9', 'a', false, [{ "search": "A_9", "outchar": "a", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "" }]],
+      ['A_9', 'a', , [{ "search": "A_9", "outchar": "a", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "" }]],
+      ['A_9', '', true, [{ "search": "A_9", "outchar": "", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "NCAPS" }]],
+      ['A_9', '', false, [{ "search": "A_9", "outchar": "", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "" }]],
       ['', 'a', true, []],
       ['', 'a', false, []],
       ['', '', , []],
 
     ].forEach(function (values) {
       it((JSON.stringify(values[3]).length > 35) ?
-        ("get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput('" + values[0] + "', '" + values[1] + "', " + values[2] + ")").padEnd(67, " ") + ' should return an array of objects' :
-        ("get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput('" + values[0] + "', '" + values[1] + "', " + values[2] + ")").padEnd(67, " ") + ' should return ' + "'" + JSON.stringify(values[3]) + "'", async function () {
-          const result = sut.get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(read, converted.arrayOf_Modifiers, String(values[0]), String(values[1]), Boolean(values[2]));
+        ("get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput('" + values[0] + "', '" + values[1] + "', " + values[2] + ")").padEnd(67, " ") + ' should return an array of objects' :
+        ("get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput('" + values[0] + "', '" + values[1] + "', " + values[2] + ")").padEnd(67, " ") + ' should return ' + "'" + JSON.stringify(values[3]) + "'", async function () {
+          const result = sut.get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(read, converted.arrayOf_Modifiers, String(values[0]), String(values[1]), Boolean(values[2]));
+          console.log("result ", result);
+
           assert.equal(JSON.stringify(result), JSON.stringify(values[3]));
         });
     });
   });
 
-  describe('get_KeyActionOutput_array__From__ActionStateOutput_array ', function () {
+  describe('get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -643,8 +951,8 @@ describe('KeylayoutToKmnConverter', function () {
 
     [[b6_actionId_arr, b1_keycode_arr],
     ].forEach(function (values) {
-      it(("get_KeyActionOutput_array__From__ActionStateOutput_array([['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'],..])").padEnd(73, " ") + '1 should return an array of objects', async function () {
-        const result = sut.get_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
+      it(("get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType([['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'],..])").padEnd(73, " ") + '1 should return an array of objects', async function () {
+        const result = sut.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(read, values[0]);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
@@ -672,8 +980,8 @@ describe('KeylayoutToKmnConverter', function () {
     [[['A_0', '1', '']], oneEntryResultNoOutput],
     [[['A_0', '', 'ˆ']], oneEntryResult],
     ].forEach(function (values) {
-      it(("get_KeyActionOutput_array__From__ActionStateOutput_array(['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'])").padEnd(73, " ") + '2 should return an array of objects', async function () {
-        const result = sut.get_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
+      it(("get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'])").padEnd(73, " ") + '2 should return an array of objects', async function () {
+        const result = sut.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(read, values[0]);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
@@ -682,8 +990,8 @@ describe('KeylayoutToKmnConverter', function () {
     [[['', '', '']], []],
     [[[' ', ' ', '']], []],
     ].forEach(function (values) {
-      it(("get_KeyActionOutput_array__From__ActionStateOutput_array(['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'])").padEnd(73, " ") + ' should return ' + "'[" + values[1] + "]'", async function () {
-        const result = sut.get_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
+      it(("get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'])").padEnd(73, " ") + ' should return ' + "'[" + values[1] + "]'", async function () {
+        const result = sut.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(read, values[0]);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
@@ -692,11 +1000,128 @@ describe('KeylayoutToKmnConverter', function () {
     [undefined, []],
     [null, []],
     ].forEach(function (values) {
-      it(("get_KeyActionOutput_array__From__ActionStateOutput_array(" + values[0] + ")").padEnd(73, " ") + ' should return ' + "'[" + values[1] + "]'", async function () {
-        const result = sut.get_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
+      it(("get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(" + values[0] + ")").padEnd(73, " ") + ' should return ' + "'[" + values[1] + "]'", async function () {
+        const result = sut.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(read, values[0]);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
+  });
+
+  describe('get_5_KeyActionOutput_array__From__ActionStateOutput_array ', function () {
+ /*   const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
+    const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
+    const inputFilename = makePathToFixture('../data/Test.keylayout');
+    const read = sut_r.read(inputFilename);
+
+    const b6_actionId_arr = [
+*/
+
+    //  [{ "id": "A_0", "state": "1", "output": "ˆ" }],
+    //  [{ "id": "A_1", "state": "1", "output": "Â" }],
+    //  [{ "id": "A_10", "state": "1", "output": "ê" }],
+   //   [{ "id": "A_11", "state": "1", "output": "î" }],
+    //  [{ "id": "A_13", "state": "1", "output": "ô" }],
+    //  [{ "id": "A_14", "state": "1", "output": "û" }],
+   // //  [{ "id": "A_2", "state": "1", "output": "Ê" }],
+   //   [{ "id": "A_3", "state": "1", "output": "Î" }],
+    //  [{ "id": "A_5", "state": "1", "output": "Ô" }],
+    //  [{ "id": "A_6", "state": "1", "output": "Û" }],
+    //  [{ "id": "A_9", "state": "1", "output": "â" }]
+
+    /*  ['A_0', '1', 'ˆ'],
+      ['A_1', '1', 'Â'],
+      ['A_10', '1', 'ê'],
+      ['A_11', '1', 'î'],
+      ['A_13', '1', 'ô'],
+      ['A_14', '1', 'û'],
+      ['A_2', '1', 'Ê'],
+      ['A_3', '1', 'Î'],
+      ['A_5', '1', 'Ô'],
+      ['A_6', '1', 'Û'],
+      ['A_9', '1', 'â']
+    ];
+    const b1_keycode_arr = [
+      ['49', 'K_SPACE', 'A_0', '0', 'ˆ'],
+      ['49', 'K_SPACE', 'A_0', '1', 'ˆ'],
+      ['49', 'K_SPACE', 'A_0', '2', 'ˆ'],
+      ['49', 'K_SPACE', 'A_0', '3', 'ˆ'],
+      ['6', 'K_Z', 'A_0', '4', 'ˆ'],
+      ['25', 'K_9', 'A_0', '4', 'ˆ'],
+      ['43', 'K_COMMA', 'A_0', '4', 'ˆ'],
+
+      ['0', 'K_A', 'A_1', '1', 'Â'],
+      ['0', 'K_A', 'A_1', '2', 'Â'],
+      ['14', 'K_E', 'A_10', '0', 'ê'],
+      ['34', 'K_I', 'A_11', '0', 'î'],
+      ['31', 'K_O', 'A_13', '0', 'ô'],
+      ['32', 'K_U', 'A_14', '0', 'û'],
+      ['14', 'K_E', 'A_2', '1', 'Ê'],
+      ['14', 'K_E', 'A_2', '2', 'Ê'],
+      ['34', 'K_I', 'A_3', '1', 'Î'],
+      ['34', 'K_I', 'A_3', '2', 'Î'],
+      ['31', 'K_O', 'A_5', '1', 'Ô'],
+      ['31', 'K_O', 'A_5', '2', 'Ô'],
+      ['32', 'K_U', 'A_6', '1', 'Û'],
+      ['32', 'K_U', 'A_6', '2', 'Û'],
+      ['0', 'K_A', 'A_9', '0', 'â']
+    ];
+
+    [[b6_actionId_arr, b1_keycode_arr],
+    ].forEach(function (values) {
+      it(("get_5_KeyActionOutput_array__From__ActionStateOutput_array([['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'],..])").padEnd(73, " ") + '1 should return an array of objects', async function () {
+        const result = sut.get_5_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
+        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
+      });
+    });
+
+    const oneEntryResult = [
+      ['49', 'K_SPACE', 'A_0', '0', 'ˆ'],
+      ['49', 'K_SPACE', 'A_0', '1', 'ˆ'],
+      ['49', 'K_SPACE', 'A_0', '2', 'ˆ'],
+      ['49', 'K_SPACE', 'A_0', '3', 'ˆ'],
+      ['6', 'K_Z', 'A_0', '4', 'ˆ'],
+      ['25', 'K_9', 'A_0', '4', 'ˆ'],
+      ['43', 'K_COMMA', 'A_0', '4', 'ˆ']
+    ];
+    const oneEntryResultNoOutput = [
+      ['49', 'K_SPACE', 'A_0', '0', ''],
+      ['49', 'K_SPACE', 'A_0', '1', ''],
+      ['49', 'K_SPACE', 'A_0', '2', ''],
+      ['49', 'K_SPACE', 'A_0', '3', ''],
+      ['6', 'K_Z', 'A_0', '4', ''],
+      ['25', 'K_9', 'A_0', '4', ''],
+      ['43', 'K_COMMA', 'A_0', '4', '']
+    ];
+
+    [[[['A_0', '1', 'ˆ']], oneEntryResult],
+    [[['A_0', '1', '']], oneEntryResultNoOutput],
+    [[['A_0', '', 'ˆ']], oneEntryResult],
+    ].forEach(function (values) {
+      it(("get_5_KeyActionOutput_array__From__ActionStateOutput_array(['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'])").padEnd(73, " ") + '2 should return an array of objects', async function () {
+        const result = sut.get_5_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
+        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
+      });
+    });
+
+    [[[['', '1', 'ˆ']], []],
+    [[['', '', '']], []],
+    [[[' ', ' ', '']], []],
+    ].forEach(function (values) {
+      it(("get_5_KeyActionOutput_array__From__ActionStateOutput_array(['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'])").padEnd(73, " ") + ' should return ' + "'[" + values[1] + "]'", async function () {
+        const result = sut.get_5_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
+        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
+      });
+    });
+
+    [[[], []],
+    [undefined, []],
+    [null, []],
+    ].forEach(function (values) {
+      it(("get_5_KeyActionOutput_array__From__ActionStateOutput_array(" + values[0] + ")").padEnd(73, " ") + ' should return ' + "'[" + values[1] + "]'", async function () {
+        const result = sut.get_5_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
+        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
+      });
+    });*/
   });
 
 });

--- a/developer/src/kmc-convert/test/keylayout-to-kmn-converter.tests.ts
+++ b/developer/src/kmc-convert/test/keylayout-to-kmn-converter.tests.ts
@@ -10,7 +10,7 @@
 import 'mocha';
 import { assert } from 'chai';
 import { compilerTestCallbacks, compilerTestOptions, makePathToFixture } from './helpers/index.js';
-import { /*ActionIdOutputBehaviourKeyModi_object,*/ KeylayoutToKmnConverter } from '../src/keylayout-to-kmn/keylayout-to-kmn-converter.js';
+import { idStateOutput_object, allArrayContents_object, KeylayoutToKmnConverter } from '../src/keylayout-to-kmn/keylayout-to-kmn-converter.js';
 import { KeylayoutFileReader } from '../src/keylayout-to-kmn/keylayout-file-reader.js';
 import { ConverterMessages } from '../src/converter-messages.js';
 import * as NodeAssert from 'node:assert';
@@ -21,49 +21,7 @@ describe('KeylayoutToKmnConverter', function () {
     compilerTestCallbacks.clear();
   });
 
-  // todo remove
-  describe('RunOneFile', function () {
-    const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
-    const inputFilename = makePathToFixture('../data/Test.keylayout');
-    sut.run(inputFilename);
-    assert.isTrue(true);
-  });
-
-  // todo remove
-  describe('RunOneFile', function () {
-    const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
-    const inputFilename = makePathToFixture('../data/Italian.keylayout');
-    sut.run(inputFilename);
-    assert.isTrue(true);
-  });
-
-  // todo remove
-  describe('RunAllFiles', function () {
-    const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
-    [
-      [makePathToFixture('../data/Italian.keylayout')],
-      [makePathToFixture('../data/Italian_command.keylayout')],
-      [makePathToFixture('../data/Swiss_French.keylayout')],
-      [makePathToFixture('../data/Spanish.keylayout')],
-      [makePathToFixture('../data/Swiss_German.keylayout')],
-      [makePathToFixture('../data/US.keylayout')],
-      [makePathToFixture('../data/Polish.keylayout')],
-      [makePathToFixture('../data/French.keylayout')],
-      [makePathToFixture('../data/Latin_American.keylayout')],
-      // [makePathToFixture('../data/German_complete.keylayout')],
-      [makePathToFixture('../data/German_complete_reduced.keylayout')],
-      //[makePathToFixture('../data/German_Standard.keylayout')],
-    ].forEach(function (files_) {
-      sut.run(files_[0]);
-      assert.isTrue(true);
-    });
-  });
   describe('run() ', function () {
-
-    // _S2 can I do this??? - some tests of the run() function might take longer than 2000 ms
-    // see https://pramod-mallick.medium.com/mocha-with-selenium-webdriver-exception-timeout-of-2000ms-exceeded-89df7b6230c6
-    this.timeout(10000);
-
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
 
     it('run() should throw on null input file name and null output file name', async function () {
@@ -93,8 +51,16 @@ describe('KeylayoutToKmnConverter', function () {
       const inputFilename = makePathToFixture('../data/Unavailable.keylayout');
       const result = sut.run(inputFilename, null);
       assert.isNotNull(result);
-      assert.equal(compilerTestCallbacks.messages.length, 2);
-      assert.deepEqual(compilerTestCallbacks.messages[0], ConverterMessages.Error_FileNotFound({ inputFilename: inputFilename }));
+      assert.equal(compilerTestCallbacks.messages.length, 1);
+      assert.deepEqual(compilerTestCallbacks.messages[0], ConverterMessages.Error_OutputFilenameIsRequired());
+    });
+
+    it('run() should throw on and null output file name', async function () {
+      const inputFilename = makePathToFixture('../data/Test.keylayout');
+      const result = sut.run(inputFilename, null);
+      assert.isNotNull(result);
+      assert.equal(compilerTestCallbacks.messages.length, 1);
+      assert.deepEqual(compilerTestCallbacks.messages[0], ConverterMessages.Error_OutputFilenameIsRequired());
     });
 
     it('run() should return on correct input file name and empty output file name ', async function () {
@@ -290,123 +256,40 @@ describe('KeylayoutToKmnConverter', function () {
     });
   });
 
-  describe('get_3o_Modifier_array__From__KeyModifier_array_oldArrayType ', function () {
+  describe('get_Modifier_array__From__KeyModifier_array ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
     const read = sut_r.read(inputFilename);
     const converted = sut.convert_bound.convert(read, inputFilename.replace(/\.keylayout$/, '.kmn'));
-
     [
-      [[['0', 0]], [['', 'shift? caps? ']]],
-      [[['0', 2]], [['shift? leftShift caps? ', 'anyShift caps?', 'shift leftShift caps ', 'shift? rightShift caps? ']]],
-      [[['0', 999]], [null]],
-      [[['999',]], [null]],
-      [[['0', -999]], [null]],
-      [[['0']], [null]],
+      [[{ key: '0', behaviour: 0 }], [['', 'shift? caps? ']]],
+      [[{ key: '0', behaviour: 2 }], [['shift? leftShift caps? ', 'anyShift caps?', 'shift leftShift caps ', 'shift? rightShift caps? ']]],
+      [[{ key: '0', behaviour: 999 }], [null]],
+      [[{ key: '999', behaviour: null }], [null]],
+      [[{ key: '0', behaviour: -999 }], [null]],
+      [[{ key: '0', behaviour: null }], [null]],
+      [[], []],
 
     ].forEach(function (values) {
-      it((values[1][0] !== null) ?
-        ("get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(['" + values[0][0][0] + "', '" + values[0][0][1] + "'])").padEnd(68, " ") + " should return ['" + values[1][0][0] + "', '" + values[1][0][1] + "']" :
-        ("get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(['" + values[0][0][0] + "', '" + values[0][0][1] + "'])").padEnd(68, " ") + " should return ['" + values[1][0] + "']", async function () {
-          const result = sut.get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(converted.arrayOf_Modifiers, values[0]);
+      it((values[1] !== null) ?
+        ("get_Modifier_array__From__KeyModifier_array('" + JSON.stringify(values[0]) + "')").padEnd(68, " ") + " should return '" + /*values[1] +*/ JSON.stringify(values[1]) + "'" :
+        ("get_Modifier_array__From__KeyModifier_array('" + JSON.stringify(values[0]) + "')").padEnd(68, " ") + " should return '" + "null" + "'", async function () {
+          const result = sut.get_Modifier_array__From__KeyModifier_array(converted.arrayOf_Modifiers, values[0] as allArrayContents_object[]);
           assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(values[1]));
         });
     });
-
-    [[[[null]], [null]],
-    [[[undefined]], [null]],
-    [[[]], [null]],
-    ].forEach(function (values) {
-      it(("get_3o_Modifier_array__From__KeyModifier_array_oldArrayType([" + values[0][0] + "])").padEnd(68, " ") + " should return ['" + values[1][0] + "']", async function () {
-        const result = sut.get_3o_Modifier_array__From__KeyModifier_array_oldArrayType(converted.arrayOf_Modifiers, values[0]);
-        assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(values[1]));
-      });
-    });
-  });
-  describe('get_3_Modifier_array__From__KeyModifier_array ', function () {
-    /*const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
-     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
-     const inputFilename = makePathToFixture('../data/Test.keylayout');
-     const read = sut_r.read(inputFilename);
-     const converted = sut.convert_bound.convert(read, inputFilename.replace(/\.keylayout$/, '.kmn'));
-
-
-    //search old  [ [ '45', 5 ] ]
-    //search      [ { key: '45', modifier: 5 } ]
-
-
-    [
-
-      //search    
-      [[{ key: '0', modifier: 0 }, ['', 'shift? caps? ']]],
-      [[{ key: '3', modifier: 0 },['', 'shixft? caps? ']]],
-      [[{ key: '7', modifier: 0 },['', 'shift? caxps? ']]],
-      [[{ key: '0', modifier: 2 },['', 'shift? caps? ']]],
-      [[{ key: '0', modifier: 999 },['', 'shift? caps? ']]],
-      [[{ key: '999', modifier: null },['', 'shift? caps? ']]],
-      [[{ key: '0', modifier: -999 },['', 'shift? caps? ']]],
-      [[{ key: '0', modifier: null },['', 'shift? caps? ']]],
-
-
-
-      //[['0', 0], [['', 'shift? caps? ']]],
-      // [[['0', 2]], [['shift? leftShift caps? ', 'anyShift caps?', 'shift leftShift caps ', 'shift? rightShift caps? ']]],
-      // [[['0', 999]], [null]],
-      //  [[['999',]], [null]],
-      //  [[['0', -999]], [null]],
-      //  [[['0']], [null]],
-
-
-
-
-    ].forEach(function (values) {
-
-
-
-      console.log("values ", values);
-      console.log("values[0] ", values[0]);
-      console.log("values[1] ", values[1]);
-      //console.log("values[1][0] ", values[1][0]);
-      //  console.log("values[0][0][0] ", values[0][0][0]);
-      // console.log(" values[0][0][1]", values[0][0][1]);
-      // console.log("values[1][0][0] ", values[1][0][0]);
-      // console.log("values [1][0][1]", values[1][0][1]); 
-
-
-console.log("XXX get_3_Modifier_array__From__KeyModifier_array(['" , values[0] , "'])", " should return ['" , values[1] , "']");
-
-
-
-      it((values[1] !== null) ?
-        ("get_3_Modifier_array__From__KeyModifier_array(['" + values[0] + "'])").padEnd(68, " ") + " should return ['" + values[1] + "']" :
-        ("get_3_Modifier_array__From__KeyModifier_array(['" + values[0] + "'])").padEnd(68, " ") + " should return ['" + values[1] + "']", async function () {
-          //const result = sut.get_3_Modifier_array__From__KeyModifier_array(converted.arrayOf_Modifiers, values[0]);
-          // assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(values[1]));
-        });
-    });
-
-    /*   [[[[null]], [null]],
-       [[[undefined]], [null]],
-       [[[]], [null]],
-       ].forEach(function (values) {
-         it(("get_3_Modifier_array__From__KeyModifier_array([" + values[0][0] + "])").padEnd(68, " ") + " should return ['" + values[1][0] + "']", async function () {
-           const result = sut.get_3_Modifier_array__From__KeyModifier_array(converted.arrayOf_Modifiers, values[0]);
-           assert.deepStrictEqual(JSON.stringify(result), JSON.stringify(values[1]));
-         });
-       });
-  */
   });
 
-  describe('get_9_KeyModifier_array__From__ActionID ', function () {
+  describe('get_KeyModifier_array__From__ActionID ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
     const read = sut_r.read(inputFilename);
     [
-      ['A_16', [{ "key": "32", "modifier": 5 }]],
-      ['A_19', [{ "key": "45", "modifier": 5 }]],
-      ['A_18', [{ "key": "24", "modifier": 0 }, { "key": "24", "modifier": 5 }]],
+      ['A_16', [{ "key": "32", "behaviour": "5" }]],
+      ['A_19', [{ "key": "45", "behaviour": "5" }]],
+      ['A_18', [{ "key": "24", "behaviour": "0" }, { "key": "24", "behaviour": "5" }]],
       ['unknown', []],
       [undefined, []],
       [null, []],
@@ -417,44 +300,14 @@ console.log("XXX get_3_Modifier_array__From__KeyModifier_array(['" , values[0] ,
       for (let i = 0; i < values[1].length; i++) {
         outstring = outstring + "[ " + JSON.stringify(values[1][i]) + "], ";
       }
-      it(("get_9_KeyModifier_array__From__ActionID('" + values[0] + "')").padEnd(57, " ") + ' should return ' + outstring.substring(0, outstring.lastIndexOf(']') + 2) + " ]", async function () {
-        //const result = sut.get_9_KeyModifier_array__From__ActionID_arr(read, String(values[0]));   //_S2 remove&replace
-        const result = sut.get_9_KeyModifier_array__From__ActionID(read, String(values[0]));
-        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
-      });
-    });
-  });
-  describe('get_9o_KeyModifier_array__From__ActionID_oldArrayType ', function () {
-    const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
-    const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
-    const inputFilename = makePathToFixture('../data/Test.keylayout');
-    const read = sut_r.read(inputFilename);
-
-    [
-      ['A_16', [['32', 5]]],
-      ['A_19', [['45', 5]]],
-      ['A_18', [['24', 0], ['24', 5]]],
-
-
-      ['unknown', []],
-      [undefined, []],
-      [null, []],
-      [' ', []],
-      ['', []],
-    ].forEach(function (values) {
-
-      let outstring = '[ ';
-      for (let i = 0; i < values[1].length; i++) {
-        outstring = outstring + "[ '" + values[1][i][0] + "', " + values[1][i][1].toString() + "], ";
-      }
-      it(("get_9o_KeyModifier_array__From__ActionID_oldArrayType('" + values[0] + "')").padEnd(57, " ") + ' should return ' + outstring.substring(0, outstring.lastIndexOf(']') + 2) + " ]", async function () {
-        const result = sut.get_9o_KeyModifier_array__From__ActionID_oldArrayType(read, String(values[0]));
+      it(("get_KeyModifier_array__From__ActionID('" + values[0] + "')").padEnd(57, " ") + ' should return ' + outstring.substring(0, outstring.lastIndexOf(']') + 2) + " ]", async function () {
+        const result = sut.get_KeyModifier_array__From__ActionID(read, String(values[0]));
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
 
-  describe('get_2_ActionID__From__ActionNext ', function () {
+  describe('get_ActionID__From__ActionNext ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -474,13 +327,13 @@ console.log("XXX get_3_Modifier_array__From__KeyModifier_array(['" , values[0] ,
       [undefined, ''],
       ['unknown', ''],
     ].forEach(function (values) {
-      it(("get_2_ActionID__From__ActionNext('" + values[0] + "')").padEnd(49, " ") + ' should return ' + "'" + values[1] + "'", async function () {
-        const result = sut.get_2_ActionID__From__ActionNext(read, String(values[0]));
+      it(("get_ActionID__From__ActionNext('" + values[0] + "')").padEnd(49, " ") + ' should return ' + "'" + values[1] + "'", async function () {
+        const result = sut.get_ActionID__From__ActionNext(read, String(values[0]));
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
-  describe('get_1_ActionIndex__From__ActionId ', function () {
+  describe('get_ActionIndex__From__ActionId ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -498,14 +351,13 @@ console.log("XXX get_3_Modifier_array__From__KeyModifier_array(['" , values[0] ,
       [undefined, 0],
       ['unknown', 0],
     ].forEach(function (values) {
-      it(("get_1_ActionIndex__From__ActionId('" + values[0] + "')").padEnd(50, " ") + ' should return ' + values[1], async function () {
-        const result = sut.get_1_ActionIndex__From__ActionId(read, String(values[0]));
+      it(("get_ActionIndex__From__ActionId('" + values[0] + "')").padEnd(50, " ") + ' should return ' + values[1], async function () {
+        const result = sut.get_ActionIndex__From__ActionId(read, String(values[0]));
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
-
-  describe('get_4_Output__From__ActionId_None ', function () {
+  describe('get_Output__From__ActionId_None ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -519,8 +371,8 @@ console.log("XXX get_3_Modifier_array__From__KeyModifier_array(['" , values[0] ,
       ['unknown', ''],
     ].forEach(function (values) {
       it(
-        ("get_4_Output__From__ActionId_None('" + values[0] + "')").padEnd(56, " ") + ' should return ' + "'" + values[1] + "'", async function () {
-          const result = sut.get_4_Output__From__ActionId_None(read, String(values[0]));
+        ("get_Output__From__ActionId_None('" + values[0] + "')").padEnd(56, " ") + ' should return ' + "'" + values[1] + "'", async function () {
+          const result = sut.get_Output__From__ActionId_None(read, String(values[0]));
           assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
         });
     });
@@ -529,114 +381,105 @@ console.log("XXX get_3_Modifier_array__From__KeyModifier_array(['" , values[0] ,
     [undefined, ''],
     [99, ''],
     ].forEach(function (values) {
-      it(("get_4_Output__From__ActionId_None('" + values[0] + "')").padEnd(56, " ") + ' should return ' + values[1], async function () {
-        const result = sut.get_4_Output__From__ActionId_None(read, String(values[0]));
+      it(("get_Output__From__ActionId_None('" + values[0] + "')").padEnd(56, " ") + ' should return ' + values[1], async function () {
+        const result = sut.get_Output__From__ActionId_None(read, String(values[0]));
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
-
-  describe('get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType ', function () {
+  describe('get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
     const read = sut_r.read(inputFilename);
 
-    const b1_keycode_arr = [
-      ['49', 'K_SPACE', 'A_0', '0', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '1', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '2', 'ˆ'],
-      ['6', 'K_Z', 'A_0', '4', 'ˆ'],
-      ['25', 'K_9', 'A_0', '4', 'ˆ'],
-      ['43', 'K_COMMA', 'A_0', '4', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '3', 'ˆ'],
-      ['0', 'K_A', 'A_1', '2', 'Â'],
-      ['0', 'K_A', 'A_1', '1', 'Â'],
-      ['14', 'K_E', 'A_10', '0', 'ê'],
-      ['34', 'K_I', 'A_11', '0', 'î'],
-      ['31', 'K_O', 'A_13', '0', 'ô'],
-      ['32', 'K_U', 'A_14', '0', 'û'],
-      ['14', 'K_E', 'A_2', '2', 'Ê'],
-      ['14', 'K_E', 'A_2', '1', 'Ê'],
-      ['34', 'K_I', 'A_3', '2', 'Î'],
-      ['34', 'K_I', 'A_3', '1', 'Î'],
-      ['31', 'K_O', 'A_5', '2', 'Ô'],
-      ['31', 'K_O', 'A_5', '1', 'Ô'],
-      ['32', 'K_U', 'A_6', '2', 'Û'],
-      ['32', 'K_U', 'A_6', '1', 'Û'],
-      ['0', 'K_A', 'A_9', '0', 'â']/**/
+    const b1_keycode_arr: allArrayContents_object[] = [
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '0', outchar: 'ˆ' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '1', outchar: 'ˆ' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '2', outchar: 'ˆ' },
+      { keyCode: '6', key: 'K_Z', actionId: 'A_0', behaviour: '4', outchar: 'ˆ' },
+      { keyCode: '25', key: 'K_9', actionId: 'A_0', behaviour: '4', outchar: 'ˆ' },
+      { keyCode: '43', key: 'K_COMMA', actionId: 'A_0', behaviour: '4', outchar: 'ˆ' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '3', outchar: 'ˆ' },
+      { keyCode: '0', key: 'K_A', actionId: 'A_1', behaviour: '2', outchar: 'Â' },
+      { keyCode: '0', key: 'K_A', actionId: 'A_1', behaviour: '1', outchar: 'Â' },
+      { keyCode: '14', key: 'K_E', actionId: 'A_10', behaviour: '0', outchar: 'ê' },
+      { keyCode: '34', key: 'K_I', actionId: 'A_11', behaviour: '0', outchar: 'î' },
+      { keyCode: '31', key: 'K_O', actionId: 'A_13', behaviour: '0', outchar: 'ô' },
+      { keyCode: '32', key: 'K_U', actionId: 'A_14', behaviour: '0', outchar: 'û' },
+      { keyCode: '14', key: 'K_E', actionId: 'A_2', behaviour: '2', outchar: 'Ê' },
+      { keyCode: '14', key: 'K_E', actionId: 'A_2', behaviour: '1', outchar: 'Ê' },
+      { keyCode: '34', key: 'K_I', actionId: 'A_3', behaviour: '2', outchar: 'Î' },
+      { keyCode: '34', key: 'K_I', actionId: 'A_3', behaviour: '1', outchar: 'Î' },
+      { keyCode: '31', key: 'K_O', actionId: 'A_5', behaviour: '2', outchar: 'Ô' },
+      { keyCode: '31', key: 'K_O', actionId: 'A_5', behaviour: '1', outchar: 'Ô' },
+      { keyCode: '32', key: 'K_U', actionId: 'A_6', behaviour: '2', outchar: 'Û' },
+      { keyCode: '32', key: 'K_U', actionId: 'A_6', behaviour: '1', outchar: 'Û' },
+      { keyCode: '0', key: 'K_A', actionId: 'A_9', behaviour: '0', outchar: 'â' }
+
     ];
-    const b1_modifierKey_arr = [
-      ['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ'],
-      ['K_SPACE', 'A_0', '1', 'CAPS', 'ˆ'],
-      ['K_SPACE', 'A_0', '2', 'NCAPS SHIFT', 'ˆ'],
-      ['K_SPACE', 'A_0', '2', 'SHIFT CAPS', 'ˆ'],
-      ['K_Z', 'A_0', '4', 'NCAPS SHIFT RALT', 'ˆ'],
-      ['K_9', 'A_0', '4', 'NCAPS SHIFT RALT', 'ˆ'],
-      ['K_COMMA', 'A_0', '4', 'NCAPS SHIFT RALT', 'ˆ'],
-      ['K_SPACE', 'A_0', '3', 'NCAPS RALT CTRL', 'ˆ'],
-      ['K_SPACE', 'A_0', '3', 'NCAPS CTRL', 'ˆ'],
-      ['K_A', 'A_1', '2', 'NCAPS SHIFT', 'Â'],
-      ['K_A', 'A_1', '2', 'SHIFT CAPS', 'Â'],
-      ['K_A', 'A_1', '1', 'CAPS', 'Â'],
-      ['K_E', 'A_10', '0', 'NCAPS', 'ê'],
-      ['K_I', 'A_11', '0', 'NCAPS', 'î'],
-      ['K_O', 'A_13', '0', 'NCAPS', 'ô'],
-      ['K_U', 'A_14', '0', 'NCAPS', 'û'],
-      ['K_E', 'A_2', '2', 'NCAPS SHIFT', 'Ê'],
-      ['K_E', 'A_2', '2', 'SHIFT CAPS', 'Ê'],
-      ['K_E', 'A_2', '1', 'CAPS', 'Ê'],
-      ['K_I', 'A_3', '2', 'NCAPS SHIFT', 'Î'],
-      ['K_I', 'A_3', '2', 'SHIFT CAPS', 'Î'],
-      ['K_I', 'A_3', '1', 'CAPS', 'Î'],
-      ['K_O', 'A_5', '2', 'NCAPS SHIFT', 'Ô'],
-      ['K_O', 'A_5', '2', 'SHIFT CAPS', 'Ô'],
-      ['K_O', 'A_5', '1', 'CAPS', 'Ô'],
-      ['K_U', 'A_6', '2', 'NCAPS SHIFT', 'Û'],
-      ['K_U', 'A_6', '2', 'SHIFT CAPS', 'Û'],
-      ['K_U', 'A_6', '1', 'CAPS', 'Û'],
-      ['K_A', 'A_9', '0', 'NCAPS', 'â']/**/
+    const b1_modifierKey_arr: allArrayContents_object[] = [
+      { actionId: 'A_0', key: 'K_SPACE', behaviour: '0', modifier: 'NCAPS', outchar: 'ˆ' },
+      { actionId: 'A_0', key: 'K_SPACE', behaviour: '1', modifier: 'CAPS', outchar: 'ˆ' },
+      { actionId: 'A_0', key: 'K_SPACE', behaviour: '2', modifier: 'NCAPS SHIFT', outchar: 'ˆ' },
+      { actionId: 'A_0', key: 'K_SPACE', behaviour: '2', modifier: 'SHIFT CAPS', outchar: 'ˆ' },
+      { actionId: 'A_0', key: 'K_Z', behaviour: '4', modifier: 'NCAPS SHIFT RALT', outchar: 'ˆ' },
+      { actionId: 'A_0', key: 'K_9', behaviour: '4', modifier: 'NCAPS SHIFT RALT', outchar: 'ˆ' },
+      { actionId: 'A_0', key: 'K_COMMA', behaviour: '4', modifier: 'NCAPS SHIFT RALT', outchar: 'ˆ' },
+      { actionId: 'A_0', key: 'K_SPACE', behaviour: '3', modifier: 'NCAPS RALT CTRL', outchar: 'ˆ' },
+      { actionId: 'A_0', key: 'K_SPACE', behaviour: '3', modifier: 'NCAPS CTRL', outchar: 'ˆ' },
+      { actionId: 'A_1', key: 'K_A', behaviour: '2', modifier: 'NCAPS SHIFT', outchar: 'Â' },
+      { actionId: 'A_1', key: 'K_A', behaviour: '2', modifier: 'SHIFT CAPS', outchar: 'Â' },
+      { actionId: 'A_1', key: 'K_A', behaviour: '1', modifier: 'CAPS', outchar: 'Â' },
+      { actionId: 'A_10', key: 'K_E', behaviour: '0', modifier: 'NCAPS', outchar: 'ê' },
+      { actionId: 'A_11', key: 'K_I', behaviour: '0', modifier: 'NCAPS', outchar: 'î' },
+      { actionId: 'A_13', key: 'K_O', behaviour: '0', modifier: 'NCAPS', outchar: 'ô' },
+      { actionId: 'A_14', key: 'K_U', behaviour: '0', modifier: 'NCAPS', outchar: 'û' },
+      { actionId: 'A_2', key: 'K_E', behaviour: '2', modifier: 'NCAPS SHIFT', outchar: 'Ê' },
+      { actionId: 'A_2', key: 'K_E', behaviour: '2', modifier: 'SHIFT CAPS', outchar: 'Ê' },
+      { actionId: 'A_2', key: 'K_E', behaviour: '1', modifier: 'CAPS', outchar: 'Ê' },
+      { actionId: 'A_3', key: 'K_I', behaviour: '2', modifier: 'NCAPS SHIFT', outchar: 'Î' },
+      { actionId: 'A_3', key: 'K_I', behaviour: '2', modifier: 'SHIFT CAPS', outchar: 'Î' },
+      { actionId: 'A_3', key: 'K_I', behaviour: '1', modifier: 'CAPS', outchar: 'Î' },
+      { actionId: 'A_5', key: 'K_O', behaviour: '2', modifier: 'NCAPS SHIFT', outchar: 'Ô' },
+      { actionId: 'A_5', key: 'K_O', behaviour: '2', modifier: 'SHIFT CAPS', outchar: 'Ô' },
+      { actionId: 'A_5', key: 'K_O', behaviour: '1', modifier: 'CAPS', outchar: 'Ô' },
+      { actionId: 'A_6', key: 'K_U', behaviour: '2', modifier: 'NCAPS SHIFT', outchar: 'Û' },
+      { actionId: 'A_6', key: 'K_U', behaviour: '2', modifier: 'SHIFT CAPS', outchar: 'Û' },
+      { actionId: 'A_6', key: 'K_U', behaviour: '1', modifier: 'CAPS', outchar: 'Û' },
+      { actionId: 'A_9', key: 'K_A', behaviour: '0', modifier: 'NCAPS', outchar: 'â' }
     ];
 
     [[b1_keycode_arr, b1_modifierKey_arr],
-    [[['49', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ']]],
-    [[['49', 'K_SPACE', 'A_0', '0', '']], [['K_SPACE', 'A_0', '0', 'NCAPS', '']]],
-    [[['49', 'K_SPACE', 'A_0', '', 'ˆ']], [['K_SPACE', 'A_0', '', 'NCAPS', 'ˆ']]],
-    [[['49', 'K_SPACE', '', '0', 'ˆ']], [['K_SPACE', '', '0', 'NCAPS', 'ˆ']]],
-    [[['49', '', 'A_0', '0', 'ˆ']], [['', 'A_0', '0', 'NCAPS', 'ˆ']]],
-    [[['', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ']]],
-    [[['', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ']]],
-    [[['', '', '', '', '']], [['', '', '', 'NCAPS', '']]],
+    [[{ keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '0', modifier: '0', outchar: 'ˆ' }], [{ actionId: 'A_0', key: 'K_SPACE', behaviour: '0', modifier: 'NCAPS', outchar: 'ˆ' }]],
+    [[{ keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '0', modifier: '', outchar: 'ˆ' }], [{ actionId: 'A_0', key: 'K_SPACE', behaviour: '0', modifier: 'NCAPS', outchar: 'ˆ' }]],
+    [[{ keyCode: '49', key: 'K_SPACE', actionId: '', behaviour: '0', modifier: '0', outchar: 'ˆ' }], [{ actionId: '', key: 'K_SPACE', behaviour: '0', modifier: 'NCAPS', outchar: 'ˆ' }]],
+    [[{ keyCode: '49', key: '', actionId: 'A_0', behaviour: '0', modifier: '0', outchar: 'ˆ' }], [{ actionId: 'A_0', key: '', behaviour: '0', modifier: 'NCAPS', outchar: 'ˆ' }]],
+    [[{ keyCode: '', key: 'K_SPACE', actionId: 'A_0', behaviour: '0', modifier: '0', outchar: 'ˆ' }], [{ actionId: 'A_0', key: 'K_SPACE', behaviour: '0', modifier: 'NCAPS', outchar: 'ˆ' }]],
+    [[{ keyCode: '', key: '', actionId: '', behaviour: '0', modifier: '', outchar: '' }], [{ actionId: '', key: '', behaviour: '0', modifier: 'NCAPS', outchar: '' }]],
     ].forEach(function (values) {
-
       const isCaps_used = true;
-      const string_in = "get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(['" + "', '" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "', '" + values[0][0][3] + "', '" + values[0][0][4] + "'])";
-      const string_out = "['" + "', '" + values[1][0][0] + "', '" + values[1][0][1] + "', '" + values[1][0][2] + "', '" + values[1][0][3] + "', '" + values[1][0][4] + "']";
-
-
-      //console.log("FUNCTION NEEDS  ", values[0]);
-
+      const string_in = "get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(['" + "', '" + "', '" + values[0][0].keyCode + "', '" + values[0][0].key + "', '" + values[0][0].actionId + "', '" + values[0][0].modifier + "', '" + values[0][0].outchar + "'])";
+      const string_out = "['" + "', '" + "', '" + values[1][0].key + "', '" + values[1][0].actionId + "', '" + "', '" + values[1][0].modifier + "', '" + values[1][0].outchar + "']";
 
       it((JSON.stringify(values[1]).length > 60) ? 'an array of objects should return an array of objects' :
         string_in.padEnd(74, " ") + ' should return ' + string_out, async function () {
-          const result = sut.get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(read, values[0], isCaps_used);
+          const result = sut.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps_used);
           assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
         });
     });
 
-    [[[['49', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', '', 'ˆ']]],
-    [[['49', 'K_SPACE', 'A_0', '0', '']], [['K_SPACE', 'A_0', '0', '', '']]],
-    [[['', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', '', 'ˆ']]],
-    [[['', '', '', '', '']], [['', '', '', '', '']]],
+    [[{ keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '0', modifier: '0', outchar: 'ˆ' }, { actionId: 'A_0', key: 'K_SPACE', behaviour: '0', modifier: '', outchar: 'ˆ' }],
+    [{ keyCode: '', key: 'K_SPACE', actionId: 'A_0', behaviour: '0', modifier: '0', outchar: 'ˆ' }, { actionId: 'A_0', key: 'K_SPACE', behaviour: '0', modifier: '', outchar: 'ˆ' }],
+    [{ keyCode: '', key: '', actionId: '', behaviour: '0', modifier: '', outchar: '' }, { actionId: '', key: '', behaviour: '0', modifier: '', outchar: '' }],
     ].forEach(function (values) {
-
       const isCaps_used = false;
-      const string_in = "get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(['" + "', '" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "', '" + values[0][0][3] + "', '" + values[0][0][4] + "'])";
-      const string_out = "['" + "', '" + values[1][0][0] + "', '" + values[1][0][1] + "', '" + values[1][0][2] + "', '" + values[1][0][3] + "', '" + values[1][0][4] + "']";
+      const string_in = "get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array([ '" + values[0].keyCode + "', '" + values[0].key + "', '" + values[0].actionId + "', '" + values[0].modifier + "', '" + values[0].outchar + "'])";
+      const string_out = "['" + values[1].actionId + "', '" + "', '" + values[1].modifier + "', '" + values[1].key + "', '" + values[1].outchar + "']";
 
       it(string_in.padEnd(74, " ") + ' should return ' + string_out, async function () {
-        const result = sut.get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(read, values[0], isCaps_used);
-        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
+        const result = sut.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, [values[0]], isCaps_used);
+        assert.equal(JSON.stringify(result), JSON.stringify([values[1]]));
       });
     });
 
@@ -645,178 +488,13 @@ console.log("XXX get_3_Modifier_array__From__KeyModifier_array(['" , values[0] ,
     [null, []],
     ].forEach(function (values) {
       const isCaps = true;
-      it(("get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType([" + values[0] + "])").padEnd(74, " ") + ' should return ' + "[" + values[1] + "]", async function () {
-        const result = sut.get_7o_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array_oldArrayType(read, values[0], isCaps);
+      it(("get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array([" + values[0] + "])").padEnd(74, " ") + ' should return ' + "[" + values[1] + "]", async function () {
+        const result = sut.get_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
   });
-  //_S2 Todo finish !!
-  describe('get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array ', function () {
-    /*const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
-    const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
-    const inputFilename = makePathToFixture('../data/Test.keylayout');
-    const read = sut_r.read(inputFilename);*/
-
-    const b1_keycode_arr = [
-      // _S2 Todo write in object-fornm
-
-      ['49', 'K_SPACE', 'A_0', '0', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '1', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '2', 'ˆ'],
-      ['6', 'K_Z', 'A_0', '4', 'ˆ'],
-      ['25', 'K_9', 'A_0', '4', 'ˆ'],
-      ['43', 'K_COMMA', 'A_0', '4', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '3', 'ˆ'],
-      ['0', 'K_A', 'A_1', '2', 'Â'],
-      ['0', 'K_A', 'A_1', '1', 'Â'],
-      ['14', 'K_E', 'A_10', '0', 'ê'],
-      ['34', 'K_I', 'A_11', '0', 'î'],
-      ['31', 'K_O', 'A_13', '0', 'ô'],
-      ['32', 'K_U', 'A_14', '0', 'û'],
-      ['14', 'K_E', 'A_2', '2', 'Ê'],
-      ['14', 'K_E', 'A_2', '1', 'Ê'],
-      ['34', 'K_I', 'A_3', '2', 'Î'],
-      ['34', 'K_I', 'A_3', '1', 'Î'],
-      ['31', 'K_O', 'A_5', '2', 'Ô'],
-      ['31', 'K_O', 'A_5', '1', 'Ô'],
-      ['32', 'K_U', 'A_6', '2', 'Û'],
-      ['32', 'K_U', 'A_6', '1', 'Û'],
-      ['0', 'K_A', 'A_9', '0', 'â']/**/
-    ];
-    const b1_modifierKey_arr = [
-      /* ['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ'],
-      ...
-       ['K_A', 'A_9', '0', 'NCAPS', 'â'],*/
-      { "search": "", "actionId": "A_0", "behaviour": "0", "modifier": "NCAPS", "key": "K_SPACE", "outchar": "ˆ" },
-      { "search": "", "actionId": "A_0", "behaviour": "1", "modifier": "CAPS", "key": "K_SPACE", "outchar": "ˆ" },
-      { "search": "", "actionId": "A_0", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_SPACE", "outchar": "ˆ" },
-      { "search": "", "actionId": "A_0", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_SPACE", "outchar": "ˆ" },
-      { "search": "", "actionId": "A_0", "behaviour": "4", "modifier": "NCAPS SHIFT RALT", "key": "K_Z", "outchar": "ˆ" },
-      { "search": "", "actionId": "A_0", "behaviour": "4", "modifier": "NCAPS SHIFT RALT", "key": "K_9", "outchar": "ˆ" },
-      { "search": "", "actionId": "A_0", "behaviour": "4", "modifier": "NCAPS SHIFT RALT", "key": "K_COMMA", "outchar": "ˆ" },
-      { "search": "", "actionId": "A_0", "behaviour": "3", "modifier": "NCAPS RALT CTRL", "key": "K_SPACE", "outchar": "ˆ" },
-      { "search": "", "actionId": "A_0", "behaviour": "3", "modifier": "NCAPS CTRL", "key": "K_SPACE", "outchar": "ˆ" },
-      { "search": "", "actionId": "A_1", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_A", "outchar": "Â" },
-      { "search": "", "actionId": "A_1", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_A", "outchar": "Â" },
-      { "search": "", "actionId": "A_1", "behaviour": "1", "modifier": "CAPS", "key": "K_A", "outchar": "Â" },
-      { "search": "", "actionId": "A_10", "behaviour": "0", "modifier": "NCAPS", "key": "K_E", "outchar": "ê" },
-      { "search": "", "actionId": "A_11", "behaviour": "0", "modifier": "NCAPS", "key": "K_I", "outchar": "î" },
-      { "search": "", "actionId": "A_13", "behaviour": "0", "modifier": "NCAPS", "key": "K_O", "outchar": "ô" },
-      { "search": "", "actionId": "A_14", "behaviour": "0", "modifier": "NCAPS", "key": "K_U", "outchar": "û" },
-      { "search": "", "actionId": "A_2", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_E", "outchar": "Ê" },
-      { "search": "", "actionId": "A_2", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_E", "outchar": "Ê" },
-      { "search": "", "actionId": "A_2", "behaviour": "1", "modifier": "CAPS", "key": "K_E", "outchar": "Ê" },
-      { "search": "", "actionId": "A_3", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_I", "outchar": "Î" },
-      { "search": "", "actionId": "A_3", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_I", "outchar": "Î" },
-      { "search": "", "actionId": "A_3", "behaviour": "1", "modifier": "CAPS", "key": "K_I", "outchar": "Î" },
-      { "search": "", "actionId": "A_5", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_O", "outchar": "Ô" },
-      { "search": "", "actionId": "A_5", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_O", "outchar": "Ô" },
-      { "search": "", "actionId": "A_5", "behaviour": "1", "modifier": "CAPS", "key": "K_O", "outchar": "Ô" },
-      { "search": "", "actionId": "A_6", "behaviour": "2", "modifier": "NCAPS SHIFT", "key": "K_U", "outchar": "Û" },
-      { "search": "", "actionId": "A_6", "behaviour": "2", "modifier": "SHIFT CAPS", "key": "K_U", "outchar": "Û" },
-      { "search": "", "actionId": "A_6", "behaviour": "1", "modifier": "CAPS", "key": "K_U", "outchar": "Û" },
-      { "search": "", "actionId": "A_9", "behaviour": "0", "modifier": "NCAPS", "key": "K_A", "outchar": "â" }
-    ];
-
-    [[b1_keycode_arr, b1_modifierKey_arr],
-    [[['49', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ']]],
-    [[['49', 'K_SPACE', 'A_0', '0', '']], [['K_SPACE', 'A_0', '0', 'NCAPS', '']]],
-    [[['49', 'K_SPACE', 'A_0', '', 'ˆ']], [['K_SPACE', 'A_0', '', 'NCAPS', 'ˆ']]],
-    [[['49', 'K_SPACE', '', '0', 'ˆ']], [['K_SPACE', '', '0', 'NCAPS', 'ˆ']]],
-    [[['49', '', 'A_0', '0', 'ˆ']], [['', 'A_0', '0', 'NCAPS', 'ˆ']]],
-    [[['', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ']]],
-    [[['', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', 'NCAPS', 'ˆ']]],
-    [[['', '', '', '', '']], [['', '', '', 'NCAPS', '']]],
-    ].forEach(function (values) {
-
-      /*  // _S2 const isCaps_used = true;
-       const string_in = "get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(['" + "', '" + values[0][0] + "', '" + values[0][1] + "', '" + values[0][2] + "', '" + values[0][3] + "', '" + values[0][4] + "'])";
-       const string_out = "['" + "', '" + values[1][0] + "', '" + values[1][1] + "', '" + values[1][2] + "', '" + values[1][3] + "', '" + values[1][4] + "']";
- 
-      it((JSON.stringify(values[1]).length > 60) ? 'an array of objects should return an array of objects' :
-         string_in.padEnd(74, " ") + ' should return ' + string_out, async function () {
-           const result = sut.get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps_used);
-           assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
-         });*/
-    });
-
-    [[[['49', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', '', 'ˆ']]],
-    [[['49', 'K_SPACE', 'A_0', '0', '']], [['K_SPACE', 'A_0', '0', '', '']]],
-    [[['', 'K_SPACE', 'A_0', '0', 'ˆ']], [['K_SPACE', 'A_0', '0', '', 'ˆ']]],
-    [[['', '', '', '', '']], [['', '', '', '', '']]],
-    ].forEach(function (values) {
-
-      /*  const isCaps_used = false;    // _S2 add again 
-        const string_in = "get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(['" + "', '" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "', '" + values[0][0][3] + "', '" + values[0][0][4] + "'])";
-        const string_out = "['" + "', '" + values[1][0][0] + "', '" + values[1][0][1] + "', '" + values[1][0][2] + "', '" + values[1][0][3] + "', '" + values[1][0][4] + "']";
-  
-        it(string_in.padEnd(74, " ") + ' should return ' + string_out, async function () {
-          const result = sut.get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps_used);
-          assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
-        });*/
-    });
-
-    [[[], []],
-    [undefined, []],
-    [null, []],
-    ].forEach(function (values) {
-      /*  const isCaps = true;
-        it(("get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array([" + values[0] + "])").padEnd(74, " ") + ' should return ' + "[" + values[1] + "]", async function () {
-          const result = sut.get_7_KeyMBehaviourModOutputArray__from__KeyActionBehaviourOutput_array(read, values[0], isCaps);
-          assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
-        });*/
-    });
-  });
-
-
-  describe('get_6o_ActionStateOutput_array__From__ActionState_oldArrayType ', function () {
-    const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
-    const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
-    const inputFilename = makePathToFixture('../data/Test.keylayout');
-    const read = sut_r.read(inputFilename);
-
-    [['1', [
-      ['A_0', '1', 'ˆ'],
-      ['A_1', '1', 'Â'],
-      ['A_10', '1', 'ê'],
-      ['A_11', '1', 'î'],
-      ['A_13', '1', 'ô'],
-      ['A_14', '1', 'û'],
-      ['A_2', '1', 'Ê'],
-      ['A_3', '1', 'Î'],
-      ['A_5', '1', 'Ô'],
-      ['A_6', '1', 'Û'],
-      ['A_9', '1', 'â']],],
-    ['2', [
-      ['A_0', '2', '`'],
-      ['A_1', '2', 'À'],
-      ['A_10', '2', 'è'],
-      ['A_11', '2', 'ì'],
-      ['A_13', '2', 'ò'],
-      ['A_14', '2', 'ù'],
-      ['A_2', '2', 'È'],
-      ['A_3', '2', 'Ì'],
-      ['A_5', '2', 'Ò'],
-      ['A_6', '2', 'Ù'],
-      ['A_9', '2', 'à']],],
-    ['789', [],],
-    ['', [],],
-    [' ', [],],
-    [123, [],],
-    [null, [],],
-    [undefined, [],],
-    ].forEach(function (values) {
-      it((JSON.stringify(values[1]).length > 30) ?
-        ("get_6o_ActionStateOutput_array__From__ActionState_oldArrayType('" + values[0] + "')").padEnd(60, " ") + ' should return an array of objects' :
-        ("get_6o_ActionStateOutput_array__From__ActionState_oldArrayType('" + values[0] + "')").padEnd(60, " ") + ' should return ' + "'" + JSON.stringify(values[1]) + "'", async function () {
-          const result = sut.get_6o_ActionStateOutput_array__From__ActionState_oldArrayType(read, String(values[0]));
-          assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
-        });
-    });
-  });
-
-  describe('get_6_ActionStateOutput_array__From__ActionState ', function () {
+  describe('get_ActionStateOutput_array__From__ActionState ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -856,16 +534,14 @@ console.log("XXX get_3_Modifier_array__From__KeyModifier_array(['" , values[0] ,
     [undefined, [],],
     ].forEach(function (values) {
       it((JSON.stringify(values[1]).length > 30) ?
-        ("get_6_ActionStateOutput_array__From__ActionState('" + values[0] + "')").padEnd(60, " ") + ' should return an array of objects' :
-        ("get_6_ActionStateOutput_array__From__ActionState('" + values[0] + "')").padEnd(60, " ") + ' should return ' + "'" + JSON.stringify(values[1]) + "'", async function () {
-          const result = sut.get_6_ActionStateOutput_array__From__ActionState(read, String(values[0]));
+        ("get_ActionStateOutput_array__From__ActionState('" + values[0] + "')").padEnd(60, " ") + ' should return an array of objects' :
+        ("get_ActionStateOutput_array__From__ActionState('" + values[0] + "')").padEnd(60, " ") + ' should return ' + "'" + JSON.stringify(values[1]) + "'", async function () {
+          const result = sut.get_ActionStateOutput_array__From__ActionState(read, String(values[0]));
           assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
         });
     });
   });
-
-
-  describe('get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput ', function () {
+  describe('get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
@@ -874,254 +550,136 @@ console.log("XXX get_3_Modifier_array__From__KeyModifier_array(['" , values[0] ,
 
     [
       ['A_1', 'A', true,
-        [{ "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "1", "key": "K_A", "modifier": "CAPS" },
-        { "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "NCAPS SHIFT" },
-        { "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "SHIFT CAPS" }]
+        [{ "outchar": "A", "actionId": "A_1", "behaviour": "1", "key": "K_A", "modifier": "CAPS" },
+        { "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "NCAPS SHIFT" },
+        { "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "SHIFT CAPS" }]
       ],
       ['A_1', 'A', false,
-        [{ "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "1", "key": "K_A", "modifier": "CAPS" },
-        { "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "SHIFT" },
-        { "search": "A_1", "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "SHIFT CAPS" }]
+        [{ "outchar": "A", "actionId": "A_1", "behaviour": "1", "key": "K_A", "modifier": "CAPS" },
+        { "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "SHIFT" },
+        { "outchar": "A", "actionId": "A_1", "behaviour": "2", "key": "K_A", "modifier": "SHIFT CAPS" }]
       ],
-      ['A_9', 'a', true, [{ "search": "A_9", "outchar": "a", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "NCAPS" }]],
-      ['A_9', 'a', false, [{ "search": "A_9", "outchar": "a", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "" }]],
-      ['A_9', 'a', , [{ "search": "A_9", "outchar": "a", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "" }]],
-      ['A_9', '', true, [{ "search": "A_9", "outchar": "", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "NCAPS" }]],
-      ['A_9', '', false, [{ "search": "A_9", "outchar": "", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "" }]],
+      ['A_9', 'a', true, [{ "outchar": "a", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "NCAPS" }]],
+      ['A_9', 'a', false, [{ "outchar": "a", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "" }]],
+      ['A_9', 'a', , [{ "outchar": "a", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "" }]],
+      ['A_9', '', true, [{ "outchar": "", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "NCAPS" }]],
+      ['A_9', '', false, [{ "outchar": "", "actionId": "A_9", "behaviour": "0", "key": "K_A", "modifier": "" }]],
       ['', 'a', true, []],
       ['', 'a', false, []],
       ['', '', , []],
 
     ].forEach(function (values) {
       it((JSON.stringify(values[3]).length > 35) ?
-        ("get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput('" + values[0] + "', '" + values[1] + "', " + values[2] + ")").padEnd(67, " ") + ' should return an array of objects' :
-        ("get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput('" + values[0] + "', '" + values[1] + "', " + values[2] + ")").padEnd(67, " ") + ' should return ' + "'" + JSON.stringify(values[3]) + "'", async function () {
-          const result = sut.get_8_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(read, converted.arrayOf_Modifiers, String(values[0]), String(values[1]), Boolean(values[2]));
-          console.log("result ", result);
-
+        ("get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput('" + values[0] + "', '" + values[1] + "', " + values[2] + ")").padEnd(67, " ") + ' should return an array of objects' :
+        ("get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput('" + values[0] + "', '" + values[1] + "', " + values[2] + ")").padEnd(67, " ") + ' should return ' + "'" + JSON.stringify(values[3]) + "'", async function () {
+          const result = sut.get_ActionOutputBehaviourKeyModi_From__ActionIDStateOutput(read, converted.arrayOf_Modifiers, String(values[0]), String(values[1]), Boolean(values[2]));
           assert.equal(JSON.stringify(result), JSON.stringify(values[3]));
         });
     });
   });
-
-  describe('get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType ', function () {
+  describe('get_KeyActionOutput_array__From__ActionStateOutput_array ', function () {
     const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
     const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
     const inputFilename = makePathToFixture('../data/Test.keylayout');
     const read = sut_r.read(inputFilename);
 
-    const b6_actionId_arr = [
-      ['A_0', '1', 'ˆ'],
-      ['A_1', '1', 'Â'],
-      ['A_10', '1', 'ê'],
-      ['A_11', '1', 'î'],
-      ['A_13', '1', 'ô'],
-      ['A_14', '1', 'û'],
-      ['A_2', '1', 'Ê'],
-      ['A_3', '1', 'Î'],
-      ['A_5', '1', 'Ô'],
-      ['A_6', '1', 'Û'],
-      ['A_9', '1', 'â']
+    const b6_actionId_arr: idStateOutput_object[] = [
+      { "id": "A_0", "state": "1", "output": "ˆ" },
+      { "id": "A_1", "state": "1", "output": "Â" },
+      { "id": "A_10", "state": "1", "output": "ê" },
+      { "id": "A_11", "state": "1", "output": "î" },
+      { "id": "A_13", "state": "1", "output": "ô" },
+      { "id": "A_14", "state": "1", "output": "û" },
+      { "id": "A_2", "state": "1", "output": "Ê" },
+      { "id": "A_3", "state": "1", "output": "Î" },
+      { "id": "A_5", "state": "1", "output": "Ô" },
+      { "id": "A_6", "state": "1", "output": "Û" },
+      { "id": "A_9", "state": "1", "output": "â" }
     ];
-    const b1_keycode_arr = [
-      ['49', 'K_SPACE', 'A_0', '0', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '1', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '2', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '3', 'ˆ'],
-      ['6', 'K_Z', 'A_0', '4', 'ˆ'],
-      ['25', 'K_9', 'A_0', '4', 'ˆ'],
-      ['43', 'K_COMMA', 'A_0', '4', 'ˆ'],
 
-      ['0', 'K_A', 'A_1', '1', 'Â'],
-      ['0', 'K_A', 'A_1', '2', 'Â'],
-      ['14', 'K_E', 'A_10', '0', 'ê'],
-      ['34', 'K_I', 'A_11', '0', 'î'],
-      ['31', 'K_O', 'A_13', '0', 'ô'],
-      ['32', 'K_U', 'A_14', '0', 'û'],
-      ['14', 'K_E', 'A_2', '1', 'Ê'],
-      ['14', 'K_E', 'A_2', '2', 'Ê'],
-      ['34', 'K_I', 'A_3', '1', 'Î'],
-      ['34', 'K_I', 'A_3', '2', 'Î'],
-      ['31', 'K_O', 'A_5', '1', 'Ô'],
-      ['31', 'K_O', 'A_5', '2', 'Ô'],
-      ['32', 'K_U', 'A_6', '1', 'Û'],
-      ['32', 'K_U', 'A_6', '2', 'Û'],
-      ['0', 'K_A', 'A_9', '0', 'â']
+    const b1_keycode_arr: allArrayContents_object[] = [
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '0', outchar: 'ˆ' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '1', outchar: 'ˆ' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '2', outchar: 'ˆ' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '3', outchar: 'ˆ' },
+      { keyCode: '6', key: 'K_Z', actionId: 'A_0', behaviour: '4', outchar: 'ˆ' },
+      { keyCode: '25', key: 'K_9', actionId: 'A_0', behaviour: '4', outchar: 'ˆ' },
+      { keyCode: '43', key: 'K_COMMA', actionId: 'A_0', behaviour: '4', outchar: 'ˆ' },
+      { keyCode: '0', key: 'K_A', actionId: 'A_1', behaviour: '1', outchar: 'Â' },
+      { keyCode: '0', key: 'K_A', actionId: 'A_1', behaviour: '2', outchar: 'Â' },
+      { keyCode: '14', key: 'K_E', actionId: 'A_10', behaviour: '0', outchar: 'ê' },
+      { keyCode: '34', key: 'K_I', actionId: 'A_11', behaviour: '0', outchar: 'î' },
+      { keyCode: '31', key: 'K_O', actionId: 'A_13', behaviour: '0', outchar: 'ô' },
+      { keyCode: '32', key: 'K_U', actionId: 'A_14', behaviour: '0', outchar: 'û' },
+      { keyCode: '14', key: 'K_E', actionId: 'A_2', behaviour: '1', outchar: 'Ê' },
+      { keyCode: '14', key: 'K_E', actionId: 'A_2', behaviour: '2', outchar: 'Ê' },
+      { keyCode: '34', key: 'K_I', actionId: 'A_3', behaviour: '1', outchar: 'Î' },
+      { keyCode: '34', key: 'K_I', actionId: 'A_3', behaviour: '2', outchar: 'Î' },
+      { keyCode: '31', key: 'K_O', actionId: 'A_5', behaviour: '1', outchar: 'Ô' },
+      { keyCode: '31', key: 'K_O', actionId: 'A_5', behaviour: '2', outchar: 'Ô' },
+      { keyCode: '32', key: 'K_U', actionId: 'A_6', behaviour: '1', outchar: 'Û' },
+      { keyCode: '32', key: 'K_U', actionId: 'A_6', behaviour: '2', outchar: 'Û' },
+      { keyCode: '0', key: 'K_A', actionId: 'A_9', behaviour: '0', outchar: 'â' }
     ];
 
     [[b6_actionId_arr, b1_keycode_arr],
     ].forEach(function (values) {
-      it(("get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType([['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'],..])").padEnd(73, " ") + '1 should return an array of objects', async function () {
-        const result = sut.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(read, values[0]);
+      it(("get_KeyActionOutput_array__From__ActionStateOutput_array([['" + JSON.stringify(values[0]) + "'],..])").padEnd(73, " ") + '1 should return an array of objects', async function () {
+        const result = sut.get_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0] as idStateOutput_object[]);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
 
     const oneEntryResult = [
-      ['49', 'K_SPACE', 'A_0', '0', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '1', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '2', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '3', 'ˆ'],
-      ['6', 'K_Z', 'A_0', '4', 'ˆ'],
-      ['25', 'K_9', 'A_0', '4', 'ˆ'],
-      ['43', 'K_COMMA', 'A_0', '4', 'ˆ']
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '0', outchar: 'ˆ' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '1', outchar: 'ˆ' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '2', outchar: 'ˆ' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '3', outchar: 'ˆ' },
+      { keyCode: '6', key: 'K_Z', actionId: 'A_0', behaviour: '4', outchar: 'ˆ' },
+      { keyCode: '25', key: 'K_9', actionId: 'A_0', behaviour: '4', outchar: 'ˆ' },
+      { keyCode: '43', key: 'K_COMMA', actionId: 'A_0', behaviour: '4', outchar: 'ˆ' }
     ];
+
     const oneEntryResultNoOutput = [
-      ['49', 'K_SPACE', 'A_0', '0', ''],
-      ['49', 'K_SPACE', 'A_0', '1', ''],
-      ['49', 'K_SPACE', 'A_0', '2', ''],
-      ['49', 'K_SPACE', 'A_0', '3', ''],
-      ['6', 'K_Z', 'A_0', '4', ''],
-      ['25', 'K_9', 'A_0', '4', ''],
-      ['43', 'K_COMMA', 'A_0', '4', '']
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '0', outchar: '' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '1', outchar: '' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '2', outchar: '' },
+      { keyCode: '49', key: 'K_SPACE', actionId: 'A_0', behaviour: '3', outchar: '' },
+      { keyCode: '6', key: 'K_Z', actionId: 'A_0', behaviour: '4', outchar: '' },
+      { keyCode: '25', key: 'K_9', actionId: 'A_0', behaviour: '4', outchar: '' },
+      { keyCode: '43', key: 'K_COMMA', actionId: 'A_0', behaviour: '4', outchar: '' },
     ];
 
-    [[[['A_0', '1', 'ˆ']], oneEntryResult],
-    [[['A_0', '1', '']], oneEntryResultNoOutput],
-    [[['A_0', '', 'ˆ']], oneEntryResult],
+    [[[{ "id": "A_0", "state": "1", "output": "ˆ" }], oneEntryResult],
+    [[{ "id": "A_0", "state": "1", "output": "" }], oneEntryResultNoOutput],
+    [[{ "id": "A_0", "state": "", "output": "ˆ" }], oneEntryResult],
     ].forEach(function (values) {
-      it(("get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'])").padEnd(73, " ") + '2 should return an array of objects', async function () {
-        const result = sut.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(read, values[0]);
+      it(("get_KeyActionOutput_array__From__ActionStateOutput_array(['" + JSON.stringify(values[0]) + "'])").padEnd(73, " ") + '2 should return an array of objects', async function () {
+        const result = sut.get_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0] as idStateOutput_object[]);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
 
-    [[[['', '1', 'ˆ']], []],
-    [[['', '', '']], []],
-    [[[' ', ' ', '']], []],
+    [[[{ "id": "", "state": "1", "output": "ˆ" }], []],
+    [[{ "id": "", "state": "", "output": "" }], []],
+    [[{ "id": " ", "state": " ", "output": "" }], []],
+
     ].forEach(function (values) {
-      it(("get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'])").padEnd(73, " ") + ' should return ' + "'[" + values[1] + "]'", async function () {
-        const result = sut.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(read, values[0]);
+      it(("get_KeyActionOutput_array__From__ActionStateOutput_array(" + JSON.stringify(values[0]) + ")").padEnd(73, " ") + ' should return ' + "'[" + JSON.stringify(values[1]) + "]'", async function () {
+        const result = sut.get_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0] as idStateOutput_object[]);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
 
-    [[[], []],
+    [[, []],
     [undefined, []],
     [null, []],
     ].forEach(function (values) {
-      it(("get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(" + values[0] + ")").padEnd(73, " ") + ' should return ' + "'[" + values[1] + "]'", async function () {
-        const result = sut.get_5o_KeyActionOutput_array__From__ActionStateOutput_array_oldArrayType(read, values[0]);
+      it(("get_KeyActionOutput_array__From__ActionStateOutput_array(" + JSON.stringify(values[0]) + ")").padEnd(73, " ") + ' should return ' + "'[" + JSON.stringify(values[1]) + "]'", async function () {
+        const result = sut.get_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0] as idStateOutput_object[]);
         assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
       });
     });
-  });
-
-  describe('get_5_KeyActionOutput_array__From__ActionStateOutput_array ', function () {
- /*   const sut = new KeylayoutToKmnConverter(compilerTestCallbacks, compilerTestOptions);
-    const sut_r = new KeylayoutFileReader(compilerTestCallbacks);
-    const inputFilename = makePathToFixture('../data/Test.keylayout');
-    const read = sut_r.read(inputFilename);
-
-    const b6_actionId_arr = [
-*/
-
-    //  [{ "id": "A_0", "state": "1", "output": "ˆ" }],
-    //  [{ "id": "A_1", "state": "1", "output": "Â" }],
-    //  [{ "id": "A_10", "state": "1", "output": "ê" }],
-   //   [{ "id": "A_11", "state": "1", "output": "î" }],
-    //  [{ "id": "A_13", "state": "1", "output": "ô" }],
-    //  [{ "id": "A_14", "state": "1", "output": "û" }],
-   // //  [{ "id": "A_2", "state": "1", "output": "Ê" }],
-   //   [{ "id": "A_3", "state": "1", "output": "Î" }],
-    //  [{ "id": "A_5", "state": "1", "output": "Ô" }],
-    //  [{ "id": "A_6", "state": "1", "output": "Û" }],
-    //  [{ "id": "A_9", "state": "1", "output": "â" }]
-
-    /*  ['A_0', '1', 'ˆ'],
-      ['A_1', '1', 'Â'],
-      ['A_10', '1', 'ê'],
-      ['A_11', '1', 'î'],
-      ['A_13', '1', 'ô'],
-      ['A_14', '1', 'û'],
-      ['A_2', '1', 'Ê'],
-      ['A_3', '1', 'Î'],
-      ['A_5', '1', 'Ô'],
-      ['A_6', '1', 'Û'],
-      ['A_9', '1', 'â']
-    ];
-    const b1_keycode_arr = [
-      ['49', 'K_SPACE', 'A_0', '0', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '1', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '2', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '3', 'ˆ'],
-      ['6', 'K_Z', 'A_0', '4', 'ˆ'],
-      ['25', 'K_9', 'A_0', '4', 'ˆ'],
-      ['43', 'K_COMMA', 'A_0', '4', 'ˆ'],
-
-      ['0', 'K_A', 'A_1', '1', 'Â'],
-      ['0', 'K_A', 'A_1', '2', 'Â'],
-      ['14', 'K_E', 'A_10', '0', 'ê'],
-      ['34', 'K_I', 'A_11', '0', 'î'],
-      ['31', 'K_O', 'A_13', '0', 'ô'],
-      ['32', 'K_U', 'A_14', '0', 'û'],
-      ['14', 'K_E', 'A_2', '1', 'Ê'],
-      ['14', 'K_E', 'A_2', '2', 'Ê'],
-      ['34', 'K_I', 'A_3', '1', 'Î'],
-      ['34', 'K_I', 'A_3', '2', 'Î'],
-      ['31', 'K_O', 'A_5', '1', 'Ô'],
-      ['31', 'K_O', 'A_5', '2', 'Ô'],
-      ['32', 'K_U', 'A_6', '1', 'Û'],
-      ['32', 'K_U', 'A_6', '2', 'Û'],
-      ['0', 'K_A', 'A_9', '0', 'â']
-    ];
-
-    [[b6_actionId_arr, b1_keycode_arr],
-    ].forEach(function (values) {
-      it(("get_5_KeyActionOutput_array__From__ActionStateOutput_array([['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'],..])").padEnd(73, " ") + '1 should return an array of objects', async function () {
-        const result = sut.get_5_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
-        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
-      });
-    });
-
-    const oneEntryResult = [
-      ['49', 'K_SPACE', 'A_0', '0', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '1', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '2', 'ˆ'],
-      ['49', 'K_SPACE', 'A_0', '3', 'ˆ'],
-      ['6', 'K_Z', 'A_0', '4', 'ˆ'],
-      ['25', 'K_9', 'A_0', '4', 'ˆ'],
-      ['43', 'K_COMMA', 'A_0', '4', 'ˆ']
-    ];
-    const oneEntryResultNoOutput = [
-      ['49', 'K_SPACE', 'A_0', '0', ''],
-      ['49', 'K_SPACE', 'A_0', '1', ''],
-      ['49', 'K_SPACE', 'A_0', '2', ''],
-      ['49', 'K_SPACE', 'A_0', '3', ''],
-      ['6', 'K_Z', 'A_0', '4', ''],
-      ['25', 'K_9', 'A_0', '4', ''],
-      ['43', 'K_COMMA', 'A_0', '4', '']
-    ];
-
-    [[[['A_0', '1', 'ˆ']], oneEntryResult],
-    [[['A_0', '1', '']], oneEntryResultNoOutput],
-    [[['A_0', '', 'ˆ']], oneEntryResult],
-    ].forEach(function (values) {
-      it(("get_5_KeyActionOutput_array__From__ActionStateOutput_array(['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'])").padEnd(73, " ") + '2 should return an array of objects', async function () {
-        const result = sut.get_5_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
-        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
-      });
-    });
-
-    [[[['', '1', 'ˆ']], []],
-    [[['', '', '']], []],
-    [[[' ', ' ', '']], []],
-    ].forEach(function (values) {
-      it(("get_5_KeyActionOutput_array__From__ActionStateOutput_array(['" + values[0][0][0] + "', '" + values[0][0][1] + "', '" + values[0][0][2] + "'])").padEnd(73, " ") + ' should return ' + "'[" + values[1] + "]'", async function () {
-        const result = sut.get_5_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
-        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
-      });
-    });
-
-    [[[], []],
-    [undefined, []],
-    [null, []],
-    ].forEach(function (values) {
-      it(("get_5_KeyActionOutput_array__From__ActionStateOutput_array(" + values[0] + ")").padEnd(73, " ") + ' should return ' + "'[" + values[1] + "]'", async function () {
-        const result = sut.get_5_KeyActionOutput_array__From__ActionStateOutput_array(read, values[0]);
-        assert.equal(JSON.stringify(result), JSON.stringify(values[1]));
-      });
-    });*/
   });
 
 });

--- a/developer/src/kmc-convert/test/kmn-file-writer.tests.ts
+++ b/developer/src/kmc-convert/test/kmn-file-writer.tests.ts
@@ -36,7 +36,6 @@ describe('KmnFileWriter', function () {
     const converted_unavailable = sut.convert_bound.convert(read_unavailable, inputFilename_unavailable.replace(/\.keylayout$/, '.kmn'));
 
     it('write() should return true (no error) if written', async function () {
-
       const result = sut_w.write(converted);
       assert.isTrue(result);
     });


### PR DESCRIPTION
In kmc-convert we use arrays for storing data while reading a .keylayout file. 
During this process data is read, searched and mapped. In this process we use string[][] at various places. 

Due to maintainability we need to change those 2D arrays into (1D- ) arrays of objects.

see also iss. #14378 
see also PR  #12564 

@keymanapp-test-bot skip