### PR TITLE
refactor(linux): move dbus defines to common include

### DIFF
--- a/linux/ibus-keyman/src/KeymanSystemServiceClient.cpp
+++ b/linux/ibus-keyman/src/KeymanSystemServiceClient.cpp
@@ -5,11 +5,9 @@
 #else
 #include <basu/sd-bus.h>
 #endif
+#include <km_linux_common.h>
 #include "KeymanSystemServiceClient.h"
 
-#define KEYMAN_BUS_NAME "com.keyman.SystemService1"
-#define KEYMAN_INTERFACE_NAME "com.keyman.SystemService1.System"
-#define KEYMAN_OBJECT_PATH "/com/keyman/SystemService1/System"
 
 extern gboolean testing;
 

--- a/linux/include/km_linux_common.h
+++ b/linux/include/km_linux_common.h
@@ -4,4 +4,8 @@
 
 #define KEYMAN_F24_KEYCODE_OUTPUT_SENTINEL 194  // 0xC2
 
+#define KEYMAN_BUS_NAME "com.keyman.SystemService1"
+#define KEYMAN_INTERFACE_NAME "com.keyman.SystemService1.System"
+#define KEYMAN_OBJECT_PATH "/com/keyman/SystemService1/System"
+
 #endif // __KM_LINUX_COMMON_H__

--- a/linux/keyman-system-service/src/KeymanSystemService.cpp
+++ b/linux/keyman-system-service/src/KeymanSystemService.cpp
@@ -17,12 +17,10 @@
 #else
 #include <basu/sd-bus.h>
 #endif
+#include <km_linux_common.h>
 #include "KeymanSystemService.h"
 #include "KeyboardDevice.h"
 
-#define KEYMAN_BUS_NAME "com.keyman.SystemService1"
-#define KEYMAN_INTERFACE_NAME "com.keyman.SystemService1.System"
-#define KEYMAN_OBJECT_PATH "/com/keyman/SystemService1/System"
 
 using namespace std;
 


### PR DESCRIPTION
This got missed in #14372.

Fixes: #13281
Follow-up-of: #14372
Test-bot: skip