### PR TITLE
maint(windows): fix calls of renamed functions

### DIFF
--- a/resources/teamcity/includes/tc-windows.inc.sh
+++ b/resources/teamcity/includes/tc-windows.inc.sh
@@ -4,7 +4,7 @@
 # Shared functions for any builds that run on Windows agents
 
 ba_win_download_symbol_server_index() {
-  if ! is_windows; then
+  if ! builder_is_windows; then
     builder_die "ba_win_download_symbol_server_index should only be run on Windows agents"
   fi
 
@@ -24,7 +24,7 @@ ba_win_download_symbol_server_index() {
 }
 
 ba_win_publish_new_symbols() {
-  if ! is_windows; then
+  if ! builder_is_windows; then
     builder_die "ba_win_publish_new_symbols should only be run on Windows agents"
   fi
 


### PR DESCRIPTION
A recent change (#14324) consolidated (and thus renamed) some functions that were in several places. A PR that got created earlier but merged later (#14267) added new functionality that still used the old function names. This lead to release build failures on Windows and Developer.

This change fixes the names of the called functions.

Fixes: #14412
Follow-up-of: #14324
Follow-up-of: #14267
Test-bot: skip