### PR TITLE
refactor(web): refactor ContextToken and usage pattern

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
@@ -32,9 +32,9 @@ export class ContextToken {
   /**
    * The ID of the suggestion applied to the current token, if any.
    *
-   * Is set to -1 when no such suggestion exists.
+   * Should be set to undefined when no such suggestion exists.
    */
-  appliedSuggestionId: number = -1;
+  appliedSuggestionId?: number;
 
   /**
    * Constructs a new, empty instance for use with the specified LexicalModel.

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
@@ -1,0 +1,96 @@
+import { buildMergedTransform } from "@keymanapp/models-templates";
+import { textToCharTransforms } from "./context-tracker.js";
+import { SearchSpace } from "./distance-modeler.js";
+
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import Distribution = LexicalModelTypes.Distribution;
+import LexicalModel = LexicalModelTypes.LexicalModel;
+import Suggestion = LexicalModelTypes.Suggestion;
+import Transform = LexicalModelTypes.Transform;
+
+export class ContextToken {
+  /**
+   * Indicates whether or not the token is considered whitespace.
+   */
+  isWhitespace: boolean;
+
+  /**
+   * Contains all relevant correction-search data for use in generating
+   * corrections for this ContextToken instance.
+   */
+  readonly searchSpace: SearchSpace;
+
+  /* The next two fields will **not land here** in the final version for
+     epic/autocorrect / 19.0-beta!  That said, their future location has
+     not yet been reworked, so we'll keep them here for now. */
+
+  /**
+   * The set of suggestions generated for the current token
+   */
+  suggestions: Suggestion[];
+
+  /**
+   * The ID of the suggestion applied to the current token, if any.
+   *
+   * Is set to -1 when no such suggestion exists.
+   */
+  appliedSuggestionId: number = -1;
+
+  /**
+   * Constructs a new, empty instance for use with the specified LexicalModel.
+   * @param model
+   */
+  constructor(model: LexicalModel);
+  /**
+   * Constructs a new instance with pre-existing text for use with the specified LexicalModel.
+   * @param model
+   * @param rawText
+   */
+  constructor(model: LexicalModel, rawText: string);
+  /**
+   * This constructor deep-copies the specified instance.
+   * @param baseToken
+   */
+  constructor(baseToken: ContextToken);
+  constructor(param: ContextToken | LexicalModel, rawText?: string) {
+    if(param instanceof ContextToken) {
+      const priorToken = param;
+      this.isWhitespace = priorToken.isWhitespace;
+
+      // We need to construct a separate search space from other token copies.
+      //
+      // In case we are unable to perfectly track context (say, due to multitaps)
+      // we need to ensure that only fully-utilized keystrokes are considered.
+      this.searchSpace = new SearchSpace(priorToken.searchSpace);
+      this.suggestions = priorToken.suggestions.slice();
+
+      this.appliedSuggestionId = priorToken.appliedSuggestionId;
+    } else {
+      const model = param;
+
+      // May be altered outside of the constructor.
+      this.isWhitespace = false;
+      this.searchSpace = new SearchSpace(model);
+
+      rawText ||= '';
+
+      // Supports the old pathway for: updateWithBackspace(tokenText: string, transformId: number)
+      const rawTransformDistributions: Distribution<Transform>[] = textToCharTransforms(rawText).map(function(transform) {
+        return [{sample: transform, p: 1.0}];
+      });
+      rawTransformDistributions.forEach((entry) => this.searchSpace.addInput(entry));
+
+      this.suggestions = [];
+    }
+  }
+
+  /**
+   * Displays text corresponding to the net effects of the most likely inputs received
+   * that can correspond to the current instance.
+   */
+  get exampleInput(): string {
+    const transforms = this.searchSpace.inputSequence.map((dist) => dist[0].sample)
+    const composite = transforms.reduce((accum, current) => buildMergedTransform(accum, current), { insert: '', deleteLeft: 0});
+    return composite.insert;
+  }
+}

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/distance-modeler.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/distance-modeler.ts
@@ -366,7 +366,7 @@ export class SearchSpace {
 
   private tierOrdering: SearchSpaceTier[] = [];
   private selectionQueue: PriorityQueue<SearchSpaceTier>;
-  private inputSequence: Distribution<Transform>[] = [];
+  inputSequence: Distribution<Transform>[] = [];
   private minInputCost: number[] = [];
   private rootNode: SearchNode;
 
@@ -411,9 +411,9 @@ export class SearchSpace {
 
     const model = arg1;
     if(!model) {
-      throw "The LexicalModel parameter must not be null / undefined.";
+      throw new Error("The LexicalModel parameter must not be null / undefined.");
     } else if(!model.traverseFromRoot) {
-      throw "The provided model does not implement the `traverseFromRoot` function, which is needed to support robust correction searching.";
+      throw new Error("The provided model does not implement the `traverseFromRoot` function, which is needed to support robust correction searching.");
     }
 
     this.selectionQueue = new PriorityQueue<SearchSpaceTier>(this.QUEUE_SPACE_COMPARATOR);

--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -317,7 +317,7 @@ export class ModelCompositor {
       this.contextTracker.popNewest();
     }
 
-    this.contextTracker.newest.tail.appliedSuggestionId = -1;
+    this.contextTracker.newest.tail.appliedSuggestionId = undefined;
 
     // Will need to be modified a bit if/when phrase-level suggestions are implemented.
     // Those will be tracked on the first token of the phrase, which won't be the tail

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -202,7 +202,7 @@ export async function correctAndEnumerate(
   // let's just note that right now, there will only ever be one.
   //
   // The 'eventual' logic will be significantly more complex, though still manageable.
-  let searchSpace = postContextState.searchSpace[0];
+  const searchSpace = postContextState.tail.searchSpace;
 
   // No matter the prediction, once we know the root of the prediction, we'll always 'replace' the
   // same amount of text.  We can handle this before the big 'prediction root' loop.
@@ -250,11 +250,11 @@ export async function correctAndEnumerate(
 
   // Did the wordbreaker (or similar) append a blank token before the caret?  If so,
   // preserve that by preventing corrections from triggering left-deletion.
-  if(tailToken.raw == '') {
+  if(tailToken.exampleInput == '') {
     deleteLeft = 0;
   }
 
-  const isTokenStart = tailToken.transformDistributions.length <= 1;
+  const isTokenStart = tailToken.searchSpace.inputSequence.length <= 1;
 
   // TODO:  whitespace, backspace filtering.  Do it here.
   //        Whitespace is probably fine, actually.  Less sure about backspace.

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/edit-distance/context-token.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/edit-distance/context-token.js
@@ -1,0 +1,101 @@
+import { assert } from 'chai';
+
+import { ContextToken } from '#./correction/context-token.js';
+import { ExecutionTimer } from '#./correction/execution-timer.js';
+import * as models from '#./models/index.js';
+
+import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
+
+import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
+
+var TrieModel = models.TrieModel;
+
+var plainModel = new TrieModel(jsonFixture('models/tries/english-1000'),
+  {wordBreaker: defaultBreaker});
+
+describe('ContextToken', function() {
+  describe("<constructor>", () => {
+    it("(model: LexicalModel)", async () => {
+      let token = new ContextToken(plainModel);
+
+      assert.isEmpty(token.searchSpace.inputSequence);
+      assert.isEmpty(token.exampleInput);
+      assert.isFalse(token.isWhitespace);
+      assert.isEmpty(token.suggestions);
+      assert.equal(token.appliedSuggestionId, -1);
+
+      // While searchSpace has no inputs, it _can_ match lexicon entries (via insertions).
+      let searchIterator = token.searchSpace.getBestMatches(new ExecutionTimer(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY));
+      let firstEntry = await searchIterator.next();
+      assert.isFalse(firstEntry.done);
+    });
+
+    it("(model: LexicalModel, text: string)", () => {
+      let token = new ContextToken(plainModel, "and");
+
+      assert.isNotEmpty(token.searchSpace.inputSequence);
+
+      assert.equal(token.searchSpace.inputSequence.map((entry) => entry[0].sample.insert).join(''), 'and');
+      token.searchSpace.inputSequence.forEach((entry) => assert.equal(entry[0].sample.deleteLeft, 0));
+      assert.deepEqual(token.searchSpace.inputSequence, [..."and"].map((char) => {
+        return [{
+          sample: {
+            insert: char,
+            deleteLeft: 0
+          },
+          p: 1.0
+        }];
+      }));
+      assert.equal(token.exampleInput, 'and');
+
+      assert.isFalse(token.isWhitespace);
+
+      // Is only set with a different value later, outside the constructor.
+      assert.isEmpty(token.suggestions);
+      assert.equal(token.appliedSuggestionId, -1);
+    });
+
+    it("(token: ContextToken", () => {
+      // Same as in a test above, since we verified that it works correctly.
+      let baseToken = new ContextToken(plainModel, "and");
+      baseToken.suggestions = [
+        {
+          transform: {
+            insert: 'd ',
+            deleteLeft: 0
+          },
+          id: 37,
+          transformId: 1,
+          displayAs: '"and"',
+          tag: 'keep',
+          autoAccept: true
+        },
+        {
+          transform: {
+            insert: 'Andes ',
+            deleteLeft: 2
+          },
+          id: 38,
+          transformId: 1,
+          displayAs: 'Andes',
+        }
+      ]
+      baseToken.appliedSuggestionId = 37;
+
+      let clonedToken = new ContextToken(baseToken);
+
+      assert.notEqual(clonedToken.suggestions, baseToken.suggestions);
+      assert.deepEqual(clonedToken.suggestions, baseToken.suggestions);
+
+      assert.notEqual(clonedToken.searchSpace, baseToken.searchSpace);
+      // Deep equality on .searchSpace can't be directly checked due to the internal complexities involved.
+      // We CAN check for the most important members, though.
+      assert.notEqual(clonedToken.searchSpace.inputSequence, baseToken.searchSpace.inputSequence);
+      assert.deepEqual(clonedToken.searchSpace.inputSequence, baseToken.searchSpace.inputSequence);
+
+      assert.notEqual(clonedToken, baseToken);
+      // Perfectly deep-equal when we ignore .searchSpace.
+      assert.deepEqual({...clonedToken, searchSpace: null}, {...baseToken, searchSpace: null});
+    });
+  });
+});

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/edit-distance/context-token.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/edit-distance/context-token.js
@@ -22,7 +22,7 @@ describe('ContextToken', function() {
       assert.isEmpty(token.exampleInput);
       assert.isFalse(token.isWhitespace);
       assert.isEmpty(token.suggestions);
-      assert.equal(token.appliedSuggestionId, -1);
+      assert.isUndefined(token.appliedSuggestionId);
 
       // While searchSpace has no inputs, it _can_ match lexicon entries (via insertions).
       let searchIterator = token.searchSpace.getBestMatches(new ExecutionTimer(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY));
@@ -52,7 +52,7 @@ describe('ContextToken', function() {
 
       // Is only set with a different value later, outside the constructor.
       assert.isEmpty(token.suggestions);
-      assert.equal(token.appliedSuggestionId, -1);
+      assert.isUndefined(token.appliedSuggestionId);
     });
 
     it("(token: ContextToken", () => {

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/worker-model-compositor.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/worker-model-compositor.js
@@ -1064,7 +1064,7 @@ describe('ModelCompositor', function() {
       assert.equal(compositor.contextTracker.count, 3);
 
       // The replacement should be marked on the context-tracking token.
-      assert.isOk(suggestionContextState.tail.replacement);
+      assert.isAtLeast(suggestionContextState.tail.appliedSuggestionId, 0);
 
       let appliedContext = models.applyTransform(baseSuggestion.transform, baseContext);
       compositor.applyReversion(reversion, appliedContext);
@@ -1074,7 +1074,7 @@ describe('ModelCompositor', function() {
       assert.equal(compositor.contextTracker.item(1), suggestionContextState);
 
       // The replacement should no longer be marked for the context-tracking token.
-      assert.isNotOk(suggestionContextState.tail.replacement);
+      assert.equal(suggestionContextState.tail.appliedSuggestionId, -1);
     });
   });
 });

--- a/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/worker-model-compositor.js
+++ b/web/src/engine/predictive-text/worker-thread/src/tests/mocha/cases/worker-model-compositor.js
@@ -1074,7 +1074,7 @@ describe('ModelCompositor', function() {
       assert.equal(compositor.contextTracker.item(1), suggestionContextState);
 
       // The replacement should no longer be marked for the context-tracking token.
-      assert.equal(suggestionContextState.tail.appliedSuggestionId, -1);
+      assert.equal(suggestionContextState.tail.appliedSuggestionId);
     });
   });
 });


### PR DESCRIPTION
Also places the class within its own separate source file.

This PR's changes aim to meet our _current_ needs while moving much closer to the design specified within the [Correction-Search + Context-Tracking design doc](https://docs.google.com/document/d/1RYwgW8zI8A7VLMq40BpWYkfJJQ-i6K0MIs4QcAMxglE/edit?tab=t.0).