### PR TITLE
change(web): rework applied-suggestion tracking + reversions 🚂

### DIFF
--- a/web/src/engine/main/src/headless/languageProcessor.ts
+++ b/web/src/engine/main/src/headless/languageProcessor.ts
@@ -306,7 +306,10 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     outputTarget.apply(transform);
 
     // The reason we need to preserve the additive-inverse 'transformId' property on Reversions.
-    const promise = this.currentPromise = this.lmEngine.revertSuggestion(reversion, new ContextWindow(original.preInput, this.configuration, null))
+    const promise = this.currentPromise = this.lmEngine.revertSuggestion(
+      reversion,
+      new ContextWindow(final, this.configuration, null)
+    );
     // If the "current Promise" is as set above, clear it.
     // If another one has been triggered since... don't.
     promise.then(() => this.currentPromise = (this.currentPromise == promise) ? null : this.currentPromise);

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
@@ -50,6 +50,15 @@ export class ContextToken {
   readonly searchSpace: SearchSpace;
 
   /**
+   * Tokens affected by applied suggestions will indicate the transition ID of
+   * the applied suggestion here.
+   *
+   * Is `undefined` if no suggestion was applied to the context portion
+   * represented by this token.
+   */
+  appliedTransitionId?: number;
+
+  /**
    * Constructs a new, empty instance for use with the specified LexicalModel.
    * @param model
    */

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
@@ -14,7 +14,6 @@ import { SearchSpace } from "./distance-modeler.js";
 
 import Distribution = LexicalModelTypes.Distribution;
 import LexicalModel = LexicalModelTypes.LexicalModel;
-import Suggestion = LexicalModelTypes.Suggestion;
 import Transform = LexicalModelTypes.Transform;
 
 /**
@@ -50,22 +49,6 @@ export class ContextToken {
    */
   readonly searchSpace: SearchSpace;
 
-  /* The next two fields will **not land here** in the final version for
-     epic/autocorrect / 19.0-beta!  That said, their future location has
-     not yet been reworked, so we'll keep them here for now. */
-
-  /**
-   * The set of suggestions generated for the current token
-   */
-  suggestions: Suggestion[];
-
-  /**
-   * The ID of the suggestion applied to the current token, if any.
-   *
-   * Should be set to undefined when no such suggestion exists.
-   */
-  appliedSuggestionId?: number;
-
   /**
    * Constructs a new, empty instance for use with the specified LexicalModel.
    * @param model
@@ -92,12 +75,6 @@ export class ContextToken {
       // In case we are unable to perfectly track context (say, due to multitaps)
       // we need to ensure that only fully-utilized keystrokes are considered.
       this.searchSpace = new SearchSpace(priorToken.searchSpace);
-      this.suggestions = priorToken.suggestions.slice();
-
-      // because of unit tests.
-      if(priorToken.appliedSuggestionId !== undefined) {
-        this.appliedSuggestionId = priorToken.appliedSuggestionId;
-      }
     } else {
       const model = param;
 
@@ -112,8 +89,6 @@ export class ContextToken {
         return [{sample: transform, p: 1.0}];
       });
       rawTransformDistributions.forEach((entry) => this.searchSpace.addInput(entry));
-
-      this.suggestions = [];
     }
   }
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
@@ -84,6 +84,12 @@ export class ContextToken {
       // In case we are unable to perfectly track context (say, due to multitaps)
       // we need to ensure that only fully-utilized keystrokes are considered.
       this.searchSpace = new SearchSpace(priorToken.searchSpace);
+
+      // Preserve any annotated applied-suggestion transition ID data; it's useful
+      // for delayed reversion operations.
+      if(priorToken.appliedTransitionId !== undefined) {
+        this.appliedTransitionId = priorToken.appliedTransitionId
+      }
     } else {
       const model = param;
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -98,7 +98,7 @@ export class ContextTokenization {
    * @returns Alignment data that details if and how the incoming tokenization aligns with
    * the tokenization modeled by this instance.
    */
-  computeAlignment(incomingTokenization: string[]): ContextStateAlignment {
+  computeAlignment(incomingTokenization: string[], noSubVerify?: boolean): ContextStateAlignment {
     // Map the tokenized state to an edit-distance friendly version.
     const tokenizationToMatch = this.exampleInput;
 
@@ -122,7 +122,7 @@ export class ContextTokenization {
       for(let i = 0; i < editPath.length; i++) {
         if(editPath[i] == 'substitute') {
           subCount++;
-          if(!isSubstitutionAlignable(incomingTokenization[i], tokenizationToMatch[i], true)) {
+          if(!noSubVerify && !isSubstitutionAlignable(incomingTokenization[i], tokenizationToMatch[i], true)) {
             return {
               canAlign: false
             };
@@ -255,7 +255,7 @@ export class ContextTokenization {
           const matchingSub = tokenizationToMatch[i + (leadTokensRemoved < 0 ? leadTokensRemoved : 0)];
 
           // Double-check the word - does the 'substituted' word itself align?
-          if(!isSubstitutionAlignable(incomingSub, matchingSub)) {
+          if(!noSubVerify && !isSubstitutionAlignable(incomingSub, matchingSub)) {
             return {
               canAlign: false
             };

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -95,6 +95,8 @@ export class ContextTokenization {
    * Determines the alignment between a new, incoming tokenization source and the
    * tokenization modeled by the current instance.
    * @param incomingTokenization Raw strings corresponding to the tokenization of the incoming context
+   * @param noSubVerify When true, this disables inspection of 'substitute' transitions that avoids
+   * wholesale replacement of the original token.
    * @returns Alignment data that details if and how the incoming tokenization aligns with
    * the tokenization modeled by this instance.
    */

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -151,6 +151,8 @@ export class ContextTracker {
         // Assumption:  there have been no intervening keystrokes since the last well-aligned context.
         // (May not be valid with epic/dict-breaker or with complex, word-boundary crossing transforms)
         token = new ContextToken(matchedToken);
+        // Erase any applied-suggestion transition ID; it is no longer valid.
+        token.appliedTransitionId = undefined;
         token.searchSpace.addInput(tokenDistribution.map((seq) => seq[tailIndex]));
       }
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -315,7 +315,7 @@ export class ContextTracker {
               this.cache.add(transitionId, result);
             } else {
               this.cache.add(priorMatchState.transitionId, priorMatchState);
-              return this.cache.get(priorMatchState.transitionId);
+              return priorMatchState;
             }
           }
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -24,7 +24,8 @@ export class ContextTracker {
     lexicalModel: LexicalModel,
     matchState: ContextState,
     // the distribution should be tokenized already.
-    transformDistribution?: Distribution<Transform> // transform distribution is needed here.
+    transformDistribution?: Distribution<Transform>, // transform distribution is needed here.
+    isApplyingSuggestion?: boolean
   ): ContextTransition {
     const baseTransition = new ContextTransition(matchState, matchState.appliedInput?.id);
     const transformSequenceDistribution = tokenizeAndFilterDistribution(context, lexicalModel, transformDistribution);
@@ -33,7 +34,7 @@ export class ContextTracker {
       context = applyTransform(transformDistribution[0].sample, context);
     }
     const tokenizedContext = determineModelTokenizer(lexicalModel)(context).left;
-    const alignmentResults = matchState.tokenization.computeAlignment(tokenizedContext.map((token) => token.text));
+    const alignmentResults = matchState.tokenization.computeAlignment(tokenizedContext.map((token) => token.text), isApplyingSuggestion);
 
     if(!alignmentResults.canAlign) {
       return null;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -300,12 +300,19 @@ export class ContextTracker {
         let result = ContextTracker.attemptMatchContext(context, model, priorMatchState.final, transformDistribution);
 
         if(result?.final) {
+          if(priorMatchState.transitionId !== undefined) {
+            // Already has a taggedContext.
+            this.cache.get(priorMatchState.transitionId);
+          }
+
           if(transitionId !== undefined) {
-            if(priorMatchState.transitionId != transitionId) {
-              // Already has a taggedContext.
-              this.cache.get(transformDistribution.find((entry) => entry.sample.id !== undefined).sample.id);
+            // Special case:  if base and final match, we should use the old Transition instance.
+            // This is currently used in some unit tests.
+            if(result.final != result.base) {
+              this.cache.add(transitionId, result);
+            } else {
+              return this.cache.peek(priorMatchState.transitionId);
             }
-            this.cache.add(transitionId, result);
           }
 
           return result;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
@@ -156,4 +156,26 @@ export class ContextTransition {
 
     return resultTransition;
   }
+
+  /**
+   * Recreates the original context transition and its effects from before
+   * any application of suggestions based on the transition was applied.
+   * @returns
+   */
+  reproduceOriginal() {
+    // By keeping the original keystroke data and effects around even after
+    // applying the suggestion, we can easily reconstruct the original .final.
+    const original = ContextTracker.attemptMatchContext(
+      this.base.context,
+      this.base.model,
+      this.base,
+      this.inputDistribution
+    );
+
+    if(this.final.suggestions) {
+      original.final.suggestions = this.final.suggestions;
+    }
+
+    return original;
+  }
 }

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
@@ -138,6 +138,15 @@ export class ContextTransition {
       true
     ).final;
 
+    // Mark affected tokens with the applied-suggestion transition ID
+    // for easy future reference.
+    const alignment = appliedState.tokenization.alignment
+    const appliedTokenCount = (alignment.canAlign && true) && (alignment.tailEditLength + Math.max(alignment.tailTokenShift, 0));
+    const tokens = appliedState.tokenization.tokens;
+    for(let i = tokens.length - appliedTokenCount; i < tokens.length; i++) {
+      tokens[i].appliedTransitionId = suggestion.transformId;
+    }
+
     const preAppliedState = this.final;
     if(!preAppliedState.suggestions.find((s) => s.id == suggestion?.id)) {
       throw new Error("Could not find matching suggestion to apply");

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
@@ -134,7 +134,8 @@ export class ContextTransition {
       this.base.context,
       this.base.model,
       this.base,
-      [{sample: fullTransform, p: 1}]
+      [{sample: fullTransform, p: 1}],
+      true
     ).final;
 
     const preAppliedState = this.final;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
@@ -79,7 +79,9 @@ export class ContextTransition {
 
       // These need to be deep-copied.
       this.base = new ContextState(baseTransition.base);
-      this._final = new ContextState(baseTransition._final);
+      if(baseTransition._final) {
+        this._final = new ContextState(baseTransition._final);
+      }
     }
   }
 
@@ -124,6 +126,11 @@ export class ContextTransition {
    * @returns
    */
   applySuggestion(suggestion: Suggestion) {
+    const preAppliedState = this.final;
+    if(!preAppliedState.suggestions.find((s) => s.id == suggestion?.id)) {
+      throw new Error("Could not find matching suggestion to apply");
+    }
+
     const fullTransform = suggestion.appendedTransform
       ? buildMergedTransform(suggestion.transform, suggestion.appendedTransform)
       : suggestion.transform;
@@ -145,11 +152,6 @@ export class ContextTransition {
     const tokens = appliedState.tokenization.tokens;
     for(let i = tokens.length - appliedTokenCount; i < tokens.length; i++) {
       tokens[i].appliedTransitionId = suggestion.transformId;
-    }
-
-    const preAppliedState = this.final;
-    if(!preAppliedState.suggestions.find((s) => s.id == suggestion?.id)) {
-      throw new Error("Could not find matching suggestion to apply");
     }
 
     // Start from a deep copy, then replace as needed to overwrite with the context

--- a/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
@@ -3,6 +3,7 @@ export { ContextState } from './correction/context-state.js';
 export { ContextToken } from './correction/context-token.js';
 export { ContextTokenization } from './correction/context-tokenization.js';
 export { ContextTracker } from './correction/context-tracker.js';
+export { ContextTransition } from './correction/context-transition.js';
 export { EditOperation } from './correction/classical-calculation.js';
 export * from './correction/alignment-helpers.js';
 export * as correction from './correction/index.js';

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-token.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-token.tests.ts
@@ -29,8 +29,6 @@ describe('ContextToken', function() {
       assert.isEmpty(token.searchSpace.inputSequence);
       assert.isEmpty(token.exampleInput);
       assert.isFalse(token.isWhitespace);
-      assert.isEmpty(token.suggestions);
-      assert.isUndefined(token.appliedSuggestionId);
 
       // While searchSpace has no inputs, it _can_ match lexicon entries (via insertions).
       let searchIterator = token.searchSpace.getBestMatches(new ExecutionTimer(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY));
@@ -57,43 +55,12 @@ describe('ContextToken', function() {
       assert.equal(token.exampleInput, 'and');
 
       assert.isFalse(token.isWhitespace);
-
-      // Is only set with a different value later, outside the constructor.
-      assert.isEmpty(token.suggestions);
-      assert.isUndefined(token.appliedSuggestionId);
     });
 
     it("(token: ContextToken", () => {
       // Same as in a test above, since we verified that it works correctly.
       let baseToken = new ContextToken(plainModel, "and");
-      baseToken.suggestions = [
-        {
-          transform: {
-            insert: 'd ',
-            deleteLeft: 0
-          },
-          id: 37,
-          transformId: 1,
-          displayAs: '"and"',
-          tag: 'keep',
-          autoAccept: true
-        },
-        {
-          transform: {
-            insert: 'Andes ',
-            deleteLeft: 2
-          },
-          id: 38,
-          transformId: 1,
-          displayAs: 'Andes',
-        }
-      ]
-      baseToken.appliedSuggestionId = 37;
-
       let clonedToken = new ContextToken(baseToken);
-
-      assert.notEqual(clonedToken.suggestions, baseToken.suggestions);
-      assert.deepEqual(clonedToken.suggestions, baseToken.suggestions);
 
       assert.notEqual(clonedToken.searchSpace, baseToken.searchSpace);
       // Deep equality on .searchSpace can't be directly checked due to the internal complexities involved.

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -42,7 +42,6 @@ describe('ContextTokenization', function() {
       assert.isNotOk(tokenization.alignment);
       assert.equal(tokenization.tail.exampleInput, 'day');
       assert.isFalse(tokenization.tail.isWhitespace);
-      assert.isUndefined(tokenization.tail.appliedSuggestionId);
     });
 
     it("constructs from a token array + alignment data", () => {
@@ -63,7 +62,6 @@ describe('ContextTokenization', function() {
       assert.deepEqual(tokenization.alignment, alignment);
       assert.equal(tokenization.tail.exampleInput, 'day');
       assert.isFalse(tokenization.tail.isWhitespace);
-      assert.isUndefined(tokenization.tail.appliedSuggestionId);
     });
 
     it('clones', () => {

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -119,6 +119,47 @@ describe('ContextTokenization', function() {
       });
     });
 
+    it("properly matches and aligns with applied-suggestion contexts", () => {
+      const baseContext = [
+        'quick', 'brown', 'fox', 'jumped', 'o'
+      ];
+      const newContext = [...baseContext];
+      newContext[4] = 'over';
+
+      const baseTokenization = buildBaseTokenization(baseContext);
+      const computedAlignment = baseTokenization.computeAlignment(newContext);
+
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 0,
+        matchLength: 4,
+        tailEditLength: 1,
+        tailTokenShift: 0
+      });
+    });
+
+    it("properly matches and aligns with applied-suggestion at start of context", () => {
+      const baseContext = [
+        'te'
+      ];
+      const newContext = [
+        'testing',
+        ' ',
+        ''
+      ];
+
+      const baseTokenization = buildBaseTokenization(baseContext);
+      const computedAlignment = baseTokenization.computeAlignment(newContext, true);
+
+      assert.deepEqual(computedAlignment, {
+        canAlign: true,
+        leadTokenShift: 0,
+        matchLength: 0,
+        tailEditLength: 1,
+        tailTokenShift: 2
+      });
+    });
+
     it("detects unalignable contexts - no matching tokens", () => {
       const baseContext = [
         'swift', 'tan', 'wolf', 'leaped', 'across'

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tracker.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tracker.tests.ts
@@ -23,6 +23,8 @@ const plainModel = new TrieModel(jsonFixture('models/tries/english-1000'),
   {wordBreaker: defaultBreaker}
 );
 
+var emptyInput = (id: number) => [{sample: {insert: '', deleteLeft: 0, id: id}, p: 1}];
+
 describe('ContextTracker', function() {
   function toWrapperDistribution(transform: Transform) {
     return [{
@@ -388,11 +390,15 @@ describe('ContextTracker', function() {
     it('tracks an accepted suggestion', function() {
       let baseSuggestion: Suggestion = {
         transform: {
-          insert: 'world ',
+          insert: 'world',
           deleteLeft: 3,
-          id: 1
+          id: 2
         },
-        transformId: 0,
+        appendedTransform: {
+          insert: ' ',
+          deleteLeft: 0
+        },
+        transformId: 2,
         id: 1,
         displayAs: 'world'
       };
@@ -415,20 +421,20 @@ describe('ContextTracker', function() {
 
       let model = new models.TrieModel(jsonFixture('models/tries/english-1000'), options);
       let compositor = new ModelCompositor(model);
-      let baseContextMatch = compositor.contextTracker.analyzeState(model, baseContext, [{sample: {insert: '', deleteLeft: 0, id: 0}, p: 1}]);
-
-      baseContextMatch.final.tokenization.tail.suggestions = [ baseSuggestion ];
-
+      let preAppliedTransition = compositor.contextTracker.analyzeState(model, baseContext, emptyInput(0));
+      // Mocks a prior prediction request without having done it.
+      preAppliedTransition.final.suggestions = [baseSuggestion];
       let reversion = compositor.acceptSuggestion(baseSuggestion, baseContext, postTransform);
 
       // Actual test assertion - was the replacement tracked?
-      assert.equal(baseContextMatch.final.tokenization.tail.appliedSuggestionId, baseSuggestion.id);
+      assert.isUndefined(preAppliedTransition.final.appliedSuggestionId);
       assert.equal(reversion.id, -baseSuggestion.id);
       compositor.contextTracker.cache.keys().forEach((key) => assert.isDefined(key));
 
       // Next step - on the followup context, is the replacement still active?
-      let postContext = models.applyTransform(baseSuggestion.transform, baseContext);
-      let postContextMatch = compositor.contextTracker.analyzeState(model, postContext);
+      let postContext = models.applyTransform(baseSuggestion.appendedTransform, models.applyTransform(baseSuggestion.transform, baseContext));
+      let postContextMatch = compositor.contextTracker.analyzeState(model, postContext, emptyInput(2));
+      assert.equal(postContextMatch.final.appliedSuggestionId, baseSuggestion.id);
 
       // Penultimate token corresponds to whitespace, which does not have a 'raw' representation.
       assert.equal(postContextMatch.final.tokenization.tokens[postContextMatch.final.tokenization.tokens.length - 2].exampleInput, ' ');

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tracker.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tracker.tests.ts
@@ -424,8 +424,7 @@ describe('ContextTracker', function() {
       // Actual test assertion - was the replacement tracked?
       assert.equal(baseContextMatch.final.tokenization.tail.appliedSuggestionId, baseSuggestion.id);
       assert.equal(reversion.id, -baseSuggestion.id);
-      // TODO:  Restore this line!  Currently breaks a unit test.
-      //compositor.contextTracker.cache.keys().forEach((key) => assert.isDefined(key));
+      compositor.contextTracker.cache.keys().forEach((key) => assert.isDefined(key));
 
       // Next step - on the followup context, is the replacement still active?
       let postContext = models.applyTransform(baseSuggestion.transform, baseContext);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-transition.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-transition.tests.ts
@@ -1,0 +1,257 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by jahorton on 2025-07-30
+ *
+ * This file contains tests designed to validate behaviors for
+ * tracking context-transitions within the Keyman predictive-text
+ * worker - especially those supported by the ContextTransition class.
+ */
+
+import { assert } from 'chai';
+
+import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
+import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
+
+import { ContextState, ContextTracker, ContextTransition, models } from '@keymanapp/lm-worker/test-index';
+
+import TrieModel = models.TrieModel;
+
+var plainModel = new TrieModel(jsonFixture('models/tries/english-1000'),
+  {wordBreaker: defaultBreaker});
+
+function assertClonedStateMatch(a: ContextState, b: ContextState) {
+  assert.notEqual(a, b);
+  assert.notEqual(a.tokenization, b.tokenization);
+  assert.notSameOrderedMembers(a.tokenization.tokens, b.tokenization.tokens);
+  assert.sameOrderedMembers(a.tokenization.exampleInput, b.tokenization.exampleInput);
+
+  assert.deepEqual(a.suggestions, b.suggestions);
+}
+
+function assertClonedTransitionMatch(a: ContextTransition, b: ContextTransition) {
+  assert.notEqual(a, b);
+
+  assertClonedStateMatch(a.base, b.base);
+  assertClonedStateMatch(a.final, b.final);
+}
+
+describe('ContextTransition', () => {
+  describe('<constructor>', () => {
+    it('initializes from a ContextState and transition ID', () => {
+      const baseState = new ContextState({
+        left: "hello world ",
+        startOfBuffer: true,
+        endOfBuffer: true
+      }, plainModel);
+
+      const transition = new ContextTransition(baseState, 1);
+      assert.sameOrderedMembers(
+        transition.base.tokenization.tokens.map((t) => t.exampleInput),
+        ['hello', ' ', 'world', ' ', '']
+      );
+      assert.equal(transition.transitionId, 1);
+      assert.isNotOk(transition.final);
+      assert.isNotOk(transition.inputDistribution);
+      assert.isNotOk(transition.preservationTransform);
+    });
+
+    it('deep-copies when given a previous ContextState instance (no `final`)', () => {
+      const baseState = new ContextState({
+        left: "hello world ",
+        startOfBuffer: true,
+        endOfBuffer: true
+      }, plainModel);
+
+      const transition = new ContextTransition(baseState, 1);
+      assert.sameOrderedMembers(
+        transition.base.tokenization.tokens.map((t) => t.exampleInput),
+        ['hello', ' ', 'world', ' ', '']
+      );
+
+      const cloned = new ContextTransition(transition);
+      assert.notEqual(cloned, transition);
+      assertClonedStateMatch(cloned.base, transition.base);
+    });
+
+    it('deep-copies when given a previous ContextState instance (with `final`)', () => {
+      const baseState = new ContextState({
+        left: "hello world ",
+        startOfBuffer: true,
+        endOfBuffer: true
+      }, plainModel);
+
+      // currently, also calls the .finalize method internally.
+      const transition = ContextTracker.attemptMatchContext(baseState.context, plainModel, baseState, [
+        { sample: { insert: '!', deleteLeft: 0 }, p: 1 }
+      ]);
+
+      const cloned = new ContextTransition(transition);
+      assert.notEqual(cloned, transition);
+      assertClonedTransitionMatch(cloned, transition);
+    });
+  });
+
+  it('applySuggestion', () => {
+    const baseContext = {
+      left: "hello wo",
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    const baseState = new ContextState(baseContext, plainModel);
+
+    // currently, also calls the .finalize method internally.
+    const transition = ContextTracker.attemptMatchContext(baseContext, plainModel, baseState, [
+      { sample: { insert: 'r', deleteLeft: 0, id: 2 }, p: 1 }
+    ]);
+    assert.isOk(transition);
+
+    let suggestions = transition.final.suggestions = [{
+      transform: {
+        insert: 'rld',
+        deleteLeft: 0,
+        id: 2
+      },
+      appendedTransform: {
+        insert: ' ',
+        deleteLeft: 0,
+        id: 2
+      },
+      transformId: 2,
+      id: 10,
+      displayAs: 'world'
+    }, {
+      transform: {
+        insert: 'n',
+        deleteLeft: 0,
+        id: 2
+      },
+      appendedTransform: {
+        insert: ' ',
+        deleteLeft: 0,
+        id: 2
+      },
+      transformId: 2,
+      id: 11,
+      displayAs: 'won'
+    }];
+
+    const appliedTransition = transition.applySuggestion(suggestions[0]);
+    assert.notEqual(appliedTransition, transition);
+    assert.sameOrderedMembers(appliedTransition.final.tokenization.exampleInput, [
+      'hello', ' ', 'world', ' ', ''
+    ]);
+    assert.equal(appliedTransition.final.appliedSuggestionId, suggestions[0].id);
+    appliedTransition.final.tokenization.tokens.forEach((token, index) => {
+      if(index >= 2) {
+        assert.equal(token.appliedTransitionId, suggestions[0].transformId);
+      } else {
+        assert.isUndefined(token.appliedTransitionId);
+      }
+    });
+    assert.deepEqual(appliedTransition.final.suggestions, transition.final.suggestions);
+    assert.deepEqual(appliedTransition.final.inputTransforms, transition.final.inputTransforms);
+  });
+
+  describe('reproduceOriginal', () => {
+    it('replicates the base instance if no suggestion was applied', () => {
+      const baseContext = {
+        left: "hello wo",
+        startOfBuffer: true,
+        endOfBuffer: true
+      };
+      const baseState = new ContextState(baseContext, plainModel);
+
+      // currently, also calls the .finalize method internally.
+      const transition = ContextTracker.attemptMatchContext(baseContext, plainModel, baseState, [
+        { sample: { insert: 'r', deleteLeft: 0, id: 2 }, p: 1 }
+      ]);
+
+      let suggestions = transition.final.suggestions = [{
+        transform: {
+          insert: 'rld',
+          deleteLeft: 0,
+          id: 2
+        },
+        appendedTransform: {
+          insert: ' ',
+          deleteLeft: 0,
+          id: 2
+        },
+        transformId: 2,
+        id: 10,
+        displayAs: 'world'
+      }, {
+        transform: {
+          insert: 'n',
+          deleteLeft: 0,
+          id: 2
+        },
+        appendedTransform: {
+          insert: ' ',
+          deleteLeft: 0,
+          id: 2
+        },
+        transformId: 2,
+        id: 11,
+        displayAs: 'won'
+      }];
+
+      const restoredTransition = transition.reproduceOriginal();
+      assert.equal(restoredTransition.base, transition.base);
+      assertClonedStateMatch(restoredTransition.final, transition.final);
+      assert.equal(restoredTransition.final.suggestions, transition.final.suggestions);
+      assert.equal(restoredTransition.final.suggestions, suggestions);
+    });
+
+    it('restores the original, pre-application transition', () => {
+      const baseContext = {
+        left: "hello wo",
+        startOfBuffer: true,
+        endOfBuffer: true
+      };
+      const baseState = new ContextState(baseContext, plainModel);
+
+      // currently, also calls the .finalize method internally.
+      const transition = ContextTracker.attemptMatchContext(baseContext, plainModel, baseState, [
+        { sample: { insert: 'r', deleteLeft: 0, id: 2 }, p: 1 }
+      ]);
+
+      let suggestions = transition.final.suggestions = [{
+        transform: {
+          insert: 'rld',
+          deleteLeft: 0,
+          id: 2
+        },
+        appendedTransform: {
+          insert: ' ',
+          deleteLeft: 0,
+          id: 2
+        },
+        transformId: 2,
+        id: 10,
+        displayAs: 'world'
+      }, {
+        transform: {
+          insert: 'n',
+          deleteLeft: 0,
+          id: 2
+        },
+        appendedTransform: {
+          insert: ' ',
+          deleteLeft: 0,
+          id: 2
+        },
+        transformId: 2,
+        id: 11,
+        displayAs: 'won'
+      }];
+
+      const appliedTransition = transition.applySuggestion(suggestions[0]);
+      // To the point above, this matches the 'applySuggestion' test case.
+
+      const restoredTransition = appliedTransition.reproduceOriginal();
+      assertClonedTransitionMatch(restoredTransition, transition);
+    });
+  });
+});

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-model-compositor.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-model-compositor.tests.ts
@@ -826,7 +826,7 @@ describe('ModelCompositor', function() {
       });
     });
 
-    it.skip('model with traversals: returns appropriate suggestions upon reversion', async function() {
+    it('model with traversals: returns appropriate suggestions upon reversion', async function() {
       // This setup matches 'acceptSuggestion' the test case
       // it('first word of context + postTransform provided, .deleteLeft > 0')
       // seen earlier in the file.
@@ -894,7 +894,7 @@ describe('ModelCompositor', function() {
       assert.equal(compositor.contextTracker.cache.size, 2);
 
       let contextIds = compositor.contextTracker.cache.keys();
-      let transitionInstances = compositor.contextTracker.cache.keys().map((key) => compositor.contextTracker.cache.peek(key));
+      let transitionInstances = compositor.contextTracker.cache.keys().map((key) => compositor.contextTracker.cache.get(key));
 
       let baseSuggestion = initialSuggestions[1];
       let reversion = compositor.acceptSuggestion(baseSuggestion, baseContext, postTransform);
@@ -907,7 +907,7 @@ describe('ModelCompositor', function() {
       // Accepting the suggestion rewrites the latest context transition.
       assert.equal(compositor.contextTracker.cache.size, 2);
       assert.sameMembers(compositor.contextTracker.cache.keys(), contextIds);
-      assert.notSameDeepMembers(compositor.contextTracker.cache.keys().map((key) => compositor.contextTracker.cache.peek(key)), transitionInstances);
+      assert.notSameDeepMembers(compositor.contextTracker.cache.keys().map((key) => compositor.contextTracker.cache.get(key)), transitionInstances);
 
       // The replacement should be marked on the context-tracking token for the applied version of the results.
       assert.equal(suggestionContextState.final.appliedSuggestionId, undefined);
@@ -915,7 +915,7 @@ describe('ModelCompositor', function() {
 
       let appliedContext = models.applyTransform(baseSuggestion.transform, baseContext);
       await compositor.applyReversion(reversion, appliedContext);
-      assert.isUndefined(compositor.contextTracker.cache.peek(13).final.appliedSuggestionId);
+      assert.isUndefined(compositor.contextTracker.cache.get(13).final.appliedSuggestionId);
     });
   });
 });

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-model-compositor.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-model-compositor.tests.ts
@@ -809,7 +809,7 @@ describe('ModelCompositor', function() {
       let appliedContext = models.applyTransform(baseSuggestion.transform, baseContext);
       assert.equal(appliedContext.left, "hello ");
 
-      let suggestions = await compositor.applyReversion(reversion, appliedContext);
+      let suggestions = await compositor.applyReversion(reversion, models.applyTransform(postTransform, baseContext));
 
       // As this test is a bit... 'hard-wired', we only get the 'keep' suggestion.
       // It should still be accurate, though.

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-model-compositor.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-model-compositor.tests.ts
@@ -860,8 +860,7 @@ describe('ModelCompositor', function() {
       assert.deepEqual(reversionSuggestions, initialSuggestions);
     });
 
-    // TODO:  Restore this test:  currently fails due to recent structural changes.
-    it.skip('model with traversals: properly tracks context state', async function() {
+    it('model with traversals: properly tracks context state', async function() {
       // Could be merged with the previous test case, but I think it's good to have the error
       // sets flagged separately.
 


### PR DESCRIPTION
As noted on https://github.com/keymanapp/keyman/pull/14427#discussion_r2248721150, part of the new design calls for applied suggestions to be tracked at the `ContextState` level, rather than the `ContextToken` level.  Remedying this issue also provides us with a great opportunity to fix the issue that arose in #14442's handling of a few unit tests and provide a better model for tracking applied suggestions moving forward.

Sadly, we'll need to improve this model later - we need a few more improvements to actually track the intermediate context-state (before the whitespace, after the word) and to revert from that intermediate target later.  This gets us _far_ closer than we were before, though.

I also investigated exactly what `ModelCompositor.acceptReversion` needs - for all known use cases - and how those needs could best be met with the new context-caching design.  Reversions in general had been... a bit messy, it seems, until now.  It's been reasonably "covered" by our habit of caching every context, but that's going to be dropped soon (see #14470).  I've pre-emptively improved reversion logic's bookkeeping to lessen the load later on.

While this could be a perfectly "fine" spot to stop for testing, I've opted to delay testing until #14476.

@keymanapp-test-bot skip