### PR TITLE
maint(common): rename and move node-related script functions into node.inc.sh 🐸

### DIFF
--- a/common/tools/hextobin/build.sh
+++ b/common/tools/hextobin/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 ################################ Main script ################################
 
@@ -17,5 +18,5 @@ builder_describe_outputs \
 builder_parse "$@"
 
 builder_run_action clean      rm -rf build/ node_modules/
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      tsc --build

--- a/common/tools/sourcemap-path-remapper/build.sh
+++ b/common/tools/sourcemap-path-remapper/build.sh
@@ -10,6 +10,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 ################################ Main script ################################
 
@@ -34,7 +35,7 @@ fi
 ### CONFIGURE ACTIONS
 
 if builder_start_action configure; then
-  verify_npm_setup
+  node_select_version_and_npm_ci
   builder_finish_action success configure
 fi
 

--- a/common/web/keyman-version/build.sh
+++ b/common/web/keyman-version/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 ################################ Main script ################################
@@ -53,6 +54,6 @@ export default KEYMAN_VERSION;
 }
 
 builder_run_action clean        rm -rf version.inc.ts keyman-version.mts build/
-builder_run_action configure    verify_npm_setup
+builder_run_action configure    node_select_version_and_npm_ci
 builder_run_action build        do_build
 builder_run_action publish      builder_publish_npm

--- a/common/web/langtags/build.sh
+++ b/common/web/langtags/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 builder_describe "Build Keyman langtags.js common module" \
@@ -32,7 +33,7 @@ function compile_langtags() {
 }
 
 function do_configure() {
-  verify_npm_setup
+  node_select_version_and_npm_ci
   compile_langtags
 }
 

--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 builder_describe "Build Keyman common file types module" \
@@ -76,7 +77,7 @@ function compile_schemas() {
 
 function do_configure() {
   compile_schemas
-  verify_npm_setup
+  node_select_version_and_npm_ci
 }
 
 function do_test() {

--- a/core/include/ldml/build.sh
+++ b/core/include/ldml/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 builder_describe "Keyman ldml-keyboard-constants package" \
@@ -30,7 +31,7 @@ builder_parse "$@"
 #-------------------------------------------------------------------------------------------------------------------
 
 builder_run_action clean      rm -rf ./build/
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      tsc --build
 # builder_run_action test       # no tests at this time
 builder_run_action publish    builder_publish_npm

--- a/developer/src/common/web/test-helpers/build.sh
+++ b/developer/src/common/web/test-helpers/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 builder_describe "Keyman Developer unit test helpers" \
   "@/developer/src/common/web/utils" \
@@ -20,6 +21,6 @@ builder_parse "$@"
 #-------------------------------------------------------------------------------------------------------------------
 
 builder_run_action clean       rm -rf ./build/
-builder_run_action configure   verify_npm_setup
+builder_run_action configure   node_select_version_and_npm_ci
 builder_run_action build       tsc --build
 # builder_run_action test        # no tests at this time

--- a/developer/src/common/web/utils/build.sh
+++ b/developer/src/common/web/utils/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 builder_describe "Build Keyman Developer web utility module" \
@@ -47,7 +48,7 @@ function do_build() {
 }
 
 builder_run_action clean       rm -rf ./build/
-builder_run_action configure   verify_npm_setup
+builder_run_action configure   node_select_version_and_npm_ci
 builder_run_action build       do_build
 builder_run_action test        builder_do_typescript_tests 45
 builder_run_action publish     builder_publish_npm

--- a/developer/src/kmc-analyze/build.sh
+++ b/developer/src/kmc-analyze/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 builder_describe "Keyman Developer Compiler Analysis Tools" \
@@ -26,7 +27,7 @@ builder_parse "$@"
 #-------------------------------------------------------------------------------------------------------------------
 
 builder_run_action clean      rm -rf ./build/
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      tsc --build
 builder_run_action api        api-extractor run --local --verbose
 builder_run_action test       builder_do_typescript_tests 70

--- a/developer/src/kmc-copy/build.sh
+++ b/developer/src/kmc-copy/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 builder_describe "Build Keyman kmc-copy module" \
@@ -32,7 +33,7 @@ builder_parse "$@"
 
 
 builder_run_action clean      rm -rf ./build/
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      tsc --build
 builder_run_action api        api-extractor run --local --verbose
 

--- a/developer/src/kmc-generate/build.sh
+++ b/developer/src/kmc-generate/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 builder_describe "Build Keyman kmc-generate module" \
@@ -38,7 +39,7 @@ do_build() {
 }
 
 builder_run_action clean      rm -rf ./build/ ./tsconfig.tsbuildinfo
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      do_build
 builder_run_action api        api-extractor run --local --verbose
 builder_run_action test       builder_do_typescript_tests

--- a/developer/src/kmc-keyboard-info/build.sh
+++ b/developer/src/kmc-keyboard-info/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 builder_describe "Build Keyman kmc keyboard-info Compiler module" \
   "@/common/web/langtags" \
@@ -31,7 +32,7 @@ builder_parse "$@"
 #-------------------------------------------------------------------------------------------------------------------
 
 builder_run_action clean       rm -rf ./build/ ./tsconfig.tsbuildinfo
-builder_run_action configure   verify_npm_setup
+builder_run_action configure   node_select_version_and_npm_ci
 builder_run_action build       tsc --build
 builder_run_action api         api-extractor run --local --verbose
 builder_run_action test        builder_do_typescript_tests

--- a/developer/src/kmc-kmn/build.sh
+++ b/developer/src/kmc-kmn/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 builder_describe "Keyman Developer Compiler Module for .kmn to .kmx" \
@@ -43,7 +44,7 @@ fi
 #-------------------------------------------------------------------------------------------------------------------
 
 if builder_start_action configure; then
-  verify_npm_setup
+  node_select_version_and_npm_ci
   builder_finish_action success configure
 fi
 

--- a/developer/src/kmc-ldml/build.sh
+++ b/developer/src/kmc-ldml/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 builder_describe "Keyman kmc Keyboard Compiler module" \
   "@/common/web/keyman-version" \
@@ -38,7 +39,7 @@ function do_clean() {
 }
 
 function do_configure() {
-  verify_npm_setup
+  node_select_version_and_npm_ci
   do_build_abnf
 }
 

--- a/developer/src/kmc-model-info/build.sh
+++ b/developer/src/kmc-model-info/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 builder_describe "Build Keyman kmc Lexical Model model-info Compiler module" \
   "@/common/web/types" \
@@ -28,7 +29,7 @@ builder_parse "$@"
 #-------------------------------------------------------------------------------------------------------------------
 
 builder_run_action clean        rm -rf ./build/ ./tsconfig.tsbuildinfo
-builder_run_action configure    verify_npm_setup
+builder_run_action configure    node_select_version_and_npm_ci
 builder_run_action build        tsc --build
 builder_run_action api          api-extractor run --local --verbose
 builder_run_action test         builder_do_typescript_tests 55

--- a/developer/src/kmc-model/build.sh
+++ b/developer/src/kmc-model/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 builder_describe "Keyman kmc Lexical Model Compiler module" \
@@ -36,7 +37,7 @@ function do_build() {
 }
 
 builder_run_action clean        rm -rf ./build/ ./tsconfig.tsbuildinfo
-builder_run_action configure    verify_npm_setup
+builder_run_action configure    node_select_version_and_npm_ci
 builder_run_action build        do_build
 builder_run_action api          api-extractor run --local --verbose
 builder_run_action test         builder_do_typescript_tests

--- a/developer/src/kmc-package/build.sh
+++ b/developer/src/kmc-package/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 builder_describe "Build Keyman kmc Package Compiler module" \
@@ -33,7 +34,7 @@ builder_parse "$@"
 #-------------------------------------------------------------------------------------------------------------------
 
 builder_run_action clean      rm -rf ./build/ ./tsconfig.tsbuildinfo
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      tsc --build
 builder_run_action api        api-extractor run --local --verbose
 builder_run_action test       builder_do_typescript_tests

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -10,6 +10,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/developer/src/packages.inc.sh"
 
 builder_describe "Build Keyman Keyboard Compiler kmc" \
@@ -107,7 +108,7 @@ function do_bundle() {
 #-------------------------------------------------------------------------------------------------------------------
 
 builder_run_action clean      rm -rf ./build/ ./tsconfig.tsbuildinfo
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      do_build
 builder_run_action test       do_test
 builder_run_action api        do_api

--- a/developer/src/server/build.sh
+++ b/developer/src/server/build.sh
@@ -7,6 +7,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/jq.inc.sh"
 
 builder_describe "Build Keyman Developer Server" \
@@ -49,7 +50,7 @@ function clean_server() {
 }
 
 function configure_server() {
-  verify_npm_setup
+  node_select_version_and_npm_ci
   # See https://github.com/bubenshchykov/ngrok/issues/254, https://github.com/bubenshchykov/ngrok/pull/255
   # TODO: this is horrible; is there a way we can avoid this?
   rm -f "$KEYMAN_ROOT"/node_modules/ngrok/bin/ngrok

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -266,7 +266,7 @@ for example:
 
 ```bash
 if builder_start_action configure; then
-  verify_npm_setup
+  node_select_version_and_npm_ci
   builder_finish_action success configure
 fi
 
@@ -1089,7 +1089,7 @@ longhand form.
   }
 
   builder_run_action clean        rm -rf ./build/ ./tsconfig.tsbuildinfo
-  builder_run_action configure    verify_npm_setup
+  builder_run_action configure    node_select_version_and_npm_ci
   builder_run_action build        do_build
 ```
 

--- a/resources/build/build-utils-ci.inc.sh
+++ b/resources/build/build-utils-ci.inc.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
+# Keyman is copyright (C) SIL Global. MIT License.
 #
 # This script gets CI / pull request details for builds, part of the build-utils
 # builder_ suite of functions. All functions and variables in this file have the

--- a/resources/build/builder-full.inc.sh
+++ b/resources/build/builder-full.inc.sh
@@ -1,4 +1,5 @@
-# builder.inc.sh
+# shellcheck shell=bash
+# Keyman is copyright (C) SIL Global. MIT License.
 #
 # Wrapper for Builder scripts. Do not confuse this with
 # /resources/builder.inc.sh which has the full implementation of builder scripts

--- a/resources/build/jq.inc.sh
+++ b/resources/build/jq.inc.sh
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
+# Keyman is copyright (C) SIL Global. MIT License.
 #
 # Setup JQ environment variable according to the user's system
 #

--- a/resources/build/node.inc.sh
+++ b/resources/build/node.inc.sh
@@ -1,0 +1,79 @@
+# shellcheck shell=bash
+# Keyman is copyright (C) SIL Global. MIT License.
+
+[[ -z ${_utils_inc_sh+x} ]] && source "${KEYMAN_ROOT}/resources/build/utils.inc.sh"
+
+# Verifies that node is installed, and installs npm packages, but only once per
+# build invocation
+node_select_version_and_npm_ci() {
+  # We'll piggy-back on the builder module dependency build state to determine
+  # if npm ci has been called in the current script invocation. Adding the
+  # prefix /external/ to module name in order to differentiate between this and
+  # internal modules (although it is unlikely to ever collide!); we will also
+  # use this pattern for other similar external dependencies in future. These
+  # functions are safe to call even in a non-builder context (they do nothing or
+  # return 1 -- not built)
+  if builder_has_module_been_built /external/npm-ci; then
+    return 0
+  fi
+  builder_set_module_has_been_built /external/npm-ci
+
+  # If we are on CI environment, automatically select a node version with nvm
+  # Also, a developer can set KEYMAN_USE_NVM variable to get this behaviour
+  # automatically too (see /docs/build/node.md)
+  if [[ "$KEYMAN_VERSION_ENVIRONMENT" != local || ! -z "${KEYMAN_USE_NVM+x}" ]]; then
+    _node_select_version_with_nvm
+  fi
+
+  # Check if Node.JS/npm is installed.
+  type npm >/dev/null ||\
+    builder_die "Build environment setup error detected!  Please ensure Node.js is installed!"
+
+  pushd "$KEYMAN_ROOT" > /dev/null
+
+  offline_param=
+  if builder_try_offline; then
+    builder_echo "Trying offline build"
+    offline_param=--prefer-offline
+  fi
+  try_multiple_times npm ${offline_param} ci
+
+  popd > /dev/null
+}
+
+_node_print_expected_version() {
+  "$JQ" -r '.engines.node' "$KEYMAN_ROOT/package.json"
+}
+
+# Use nvm to select a node version according to package.json
+# see /docs/build/node.md
+_node_select_version_with_nvm() {
+  local REQUIRED_NODE_VERSION  CURRENT_NODE_VERSION
+
+  REQUIRED_NODE_VERSION="$(_node_print_expected_version)"
+  if [[ -z "$REQUIRED_NODE_VERSION" ]]; then
+    builder_die "Could not find expected Node.js version in $KEYMAN_ROOT/package.json"
+  fi
+
+  if builder_is_windows; then
+    CURRENT_NODE_VERSION="$(node --version)"
+    if [[ "${CURRENT_NODE_VERSION}" != "v${REQUIRED_NODE_VERSION}" ]]; then
+      start //wait //b nvm install "${REQUIRED_NODE_VERSION}"
+      start //wait //b nvm use "${REQUIRED_NODE_VERSION}"
+    fi
+  else
+    # launch nvm in a sub process, see _builder_nvm.sh for details
+    "${KEYMAN_ROOT}/resources/build/_builder_nvm.sh" "${REQUIRED_NODE_VERSION}"
+  fi
+
+  # Now, check that the node version is correct, on all systems
+
+  # Note: On windows, `nvm use` and `nvm install` always return success.
+  # https://github.com/coreybutler/nvm-windows/issues/738
+
+  # note the 'v' prefix that node emits (and npm doesn't!)
+  CURRENT_NODE_VERSION="$(node --version)"
+  if [[ "$CURRENT_NODE_VERSION" != "v$REQUIRED_NODE_VERSION" ]]; then
+    builder_die "Attempted to select node.js version $REQUIRED_NODE_VERSION but found $CURRENT_NODE_VERSION instead"
+  fi
+}

--- a/resources/build/utils.inc.sh
+++ b/resources/build/utils.inc.sh
@@ -1,8 +1,10 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Keyman is copyright (C) SIL Global. MIT License.
 
 # shellcheck disable=SC2154
 . "${KEYMAN_ROOT}/resources/build/jq.inc.sh"
+
+_utils_inc_sh=1
 
 # Allows for a quick macOS check for those scripts requiring a macOS environment.
 verify_on_mac() {
@@ -119,87 +121,6 @@ _try_multiple_times ( ) {
   if (( $code != 0 )); then
     builder_echo "Command failed with error $code"
     _try_multiple_times $retryCount "$@"
-  fi
-}
-
-#
-# Verifies that node is installed, and installs npm packages, but only once per
-# build invocation
-#
-# TODO: rename to builder_node_select_version_and_npm_ci, move to builder.node.inc.sh
-verify_npm_setup() {
-  # We'll piggy-back on the builder module dependency build state to determine
-  # if npm ci has been called in the current script invocation. Adding the
-  # prefix /external/ to module name in order to differentiate between this and
-  # internal modules (although it is unlikely to ever collide!); we will also
-  # use this pattern for other similar external dependencies in future. These
-  # functions are safe to call even in a non-builder context (they do nothing or
-  # return 1 -- not built)
-  if builder_has_module_been_built /external/npm-ci; then
-    return 0
-  fi
-  builder_set_module_has_been_built /external/npm-ci
-
-  # If we are on CI environment, automatically select a node version with nvm
-  # Also, a developer can set KEYMAN_USE_NVM variable to get this behaviour
-  # automatically too (see /docs/build/node.md)
-  if [[ "$KEYMAN_VERSION_ENVIRONMENT" != local || ! -z "${KEYMAN_USE_NVM+x}" ]]; then
-    _select_node_version_with_nvm
-  fi
-
-  # Check if Node.JS/npm is installed.
-  type npm >/dev/null ||\
-    builder_die "Build environment setup error detected!  Please ensure Node.js is installed!"
-
-  pushd "$KEYMAN_ROOT" > /dev/null
-
-  offline_param=
-  if builder_try_offline; then
-    builder_echo "Trying offline build"
-    offline_param=--prefer-offline
-  fi
-  try_multiple_times npm ${offline_param} ci
-
-  popd > /dev/null
-}
-
-# TODO: rename to _node_print_expected_version, move to builder.node.inc.sh
-_print_expected_node_version() {
-  "$JQ" -r '.engines.node' "$KEYMAN_ROOT/package.json"
-}
-
-# Use nvm to select a node version according to package.json
-# see /docs/build/node.md
-#
-# TODO: rename to _node_select_version_with_nvm, move to builder.node.inc.sh
-_select_node_version_with_nvm() {
-  local REQUIRED_NODE_VERSION  CURRENT_NODE_VERSION
-
-  REQUIRED_NODE_VERSION="$(_print_expected_node_version)"
-  if [[ -z "$REQUIRED_NODE_VERSION" ]]; then
-    builder_die "Could not find expected Node.js version in $KEYMAN_ROOT/package.json"
-  fi
-
-  if builder_is_windows; then
-    CURRENT_NODE_VERSION="$(node --version)"
-    if [[ "${CURRENT_NODE_VERSION}" != "v${REQUIRED_NODE_VERSION}" ]]; then
-      start //wait //b nvm install "${REQUIRED_NODE_VERSION}"
-      start //wait //b nvm use "${REQUIRED_NODE_VERSION}"
-    fi
-  else
-    # launch nvm in a sub process, see _builder_nvm.sh for details
-    "${KEYMAN_ROOT}/resources/build/_builder_nvm.sh" "${REQUIRED_NODE_VERSION}"
-  fi
-
-  # Now, check that the node version is correct, on all systems
-
-  # Note: On windows, `nvm use` and `nvm install` always return success.
-  # https://github.com/coreybutler/nvm-windows/issues/738
-
-  # note the 'v' prefix that node emits (and npm doesn't!)
-  CURRENT_NODE_VERSION="$(node --version)"
-  if [[ "$CURRENT_NODE_VERSION" != "v$REQUIRED_NODE_VERSION" ]]; then
-    builder_die "Attempted to select node.js version $REQUIRED_NODE_VERSION but found $CURRENT_NODE_VERSION instead"
   fi
 }
 

--- a/resources/build/version/build.sh
+++ b/resources/build/version/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 ################################ Main script ################################
 
@@ -17,5 +18,5 @@ builder_describe_outputs \
 builder_parse "$@"
 
 builder_run_action clean      rm -rf build/ node_modules/ dist/ lib/
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      tsc --build

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -627,7 +627,7 @@ builder_has_action() {
 #   }
 #
 #   builder_run_action clean        rm -rf ./build/ ./tsconfig.tsbuildinfo
-#   builder_run_action configure    verify_npm_setup
+#   builder_run_action configure    node_select_version_and_npm_ci
 #   builder_run_action build        do_build
 # ```
 #

--- a/resources/tools/check-markdown/build.sh
+++ b/resources/tools/check-markdown/build.sh
@@ -6,6 +6,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 ################################ Main script ################################
 
@@ -21,6 +22,6 @@ builder_describe_outputs \
 builder_parse "$@"
 
 builder_run_action clean      rm -rf build/ tsconfig.tsbuildinfo
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      tsc --build
 # builder_run_action test       mocha

--- a/web/src/app/browser/build.sh
+++ b/web/src/app/browser/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=app/browser
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # ################################ Main script ################################
 
@@ -80,7 +81,7 @@ compile_and_copy() {
   cp "$KEYMAN_ROOT/web/src/engine/predictive-text/worker-thread/build/filesize-profile.log"     "$PROFILE_DEST/lm-worker-filesize.log"
 }
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean do_clean
 builder_run_action build compile_and_copy
 builder_run_action test test-headless-typescript $SUBPROJECT_NAME

--- a/web/src/app/ui/build.sh
+++ b/web/src/app/ui/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=app/ui
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # ################################ Main script ################################
 
@@ -67,7 +68,7 @@ compile_and_copy() {
   prepare
 }
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean do_clean
 builder_run_action build compile_and_copy
 

--- a/web/src/app/webview/build.sh
+++ b/web/src/app/webview/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=app/webview
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # ################################ Main script ################################
 
@@ -80,6 +81,6 @@ compile_and_copy() {
   "$KEYMAN_ROOT/web/src/test/manual/embed/android-harness/build.sh"
 }
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
 builder_run_action build compile_and_copy

--- a/web/src/engine/attachment/build.sh
+++ b/web/src/engine/attachment/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 # Imports common Web build-script definitions & functions
 SUBPROJECT_NAME=engine/attachment
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/web/common.inc.sh"
 
 # ################################ Main script ################################
@@ -40,7 +41,7 @@ do_build () {
     --format esm
 }
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
 builder_run_action build do_build
 builder_run_action test test-headless-typescript "${SUBPROJECT_NAME}"

--- a/web/src/engine/common/web-utils/build.sh
+++ b/web/src/engine/common/web-utils/build.sh
@@ -10,6 +10,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 . "${KEYMAN_ROOT}/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 SUBPROJECT_NAME=engine/common/web-utils
 BUILD_DIR="/web/src/engine/common/web-utils/build"
@@ -56,7 +57,7 @@ function do_test() {
   c8 mocha --recursive $FLAGS ./src/tests/
 }
 
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action clean      rm -rf build/
 builder_run_action build      do_build
 builder_run_action test       do_test

--- a/web/src/engine/dom-utils/build.sh
+++ b/web/src/engine/dom-utils/build.sh
@@ -7,6 +7,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # Imports common Web build-script definitions & functions
 SUBPROJECT_NAME=engine/dom-utils
@@ -33,7 +34,7 @@ builder_parse "$@"
 
 #### Build action definitions ####
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
 builder_run_action build compile $SUBPROJECT_NAME
 

--- a/web/src/engine/element-wrappers/build.sh
+++ b/web/src/engine/element-wrappers/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=engine/element-wrappers
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # ################################ Main script ################################
 
@@ -38,7 +39,7 @@ do_build () {
     --format esm
 }
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
 builder_run_action build do_build
 

--- a/web/src/engine/events/build.sh
+++ b/web/src/engine/events/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=engine/events
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # ################################ Main script ################################
 
@@ -39,7 +40,7 @@ do_build () {
     --format esm
 }
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf "${KEYMAN_ROOT}/web/build/${SUBPROJECT_NAME}"
 builder_run_action build do_build
 builder_run_action test test-headless "${SUBPROJECT_NAME}"

--- a/web/src/engine/interfaces/build.sh
+++ b/web/src/engine/interfaces/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=engine/interfaces
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # ################################ Main script ################################
 
@@ -40,7 +41,7 @@ do_build () {
     --format esm
 }
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf "${KEYMAN_ROOT}/web/build/${SUBPROJECT_NAME}"
 builder_run_action build do_build
 builder_run_action test test-headless "${SUBPROJECT_NAME}"

--- a/web/src/engine/js-processor/build.sh
+++ b/web/src/engine/js-processor/build.sh
@@ -10,6 +10,7 @@ SUBPROJECT_NAME=engine/js-processor
 
 . "${KEYMAN_ROOT}/web/common.inc.sh"
 . "${KEYMAN_ROOT}/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # ################################ Main script ################################
 
@@ -35,7 +36,7 @@ do_build () {
     --format esm
 }
 
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action clean      rm -rf "${KEYMAN_ROOT}/web/build/${SUBPROJECT_NAME}"
 builder_run_action build      do_build
 builder_run_action test       test-headless "${SUBPROJECT_NAME}" ""

--- a/web/src/engine/keyboard-storage/build.sh
+++ b/web/src/engine/keyboard-storage/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=engine/keyboard-storage
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # ################################ Main script ################################
 
@@ -47,7 +48,7 @@ do_build () {
     --platform node
 }
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf "${KEYMAN_ROOT}/web/build/${SUBPROJECT_NAME}"
 builder_run_action build do_build
 builder_run_action test test-headless "${SUBPROJECT_NAME}"

--- a/web/src/engine/keyboard/build.sh
+++ b/web/src/engine/keyboard/build.sh
@@ -12,6 +12,7 @@ SUBPROJECT_NAME=engine/keyboard
 
 . "${KEYMAN_ROOT}/web/common.inc.sh"
 . "${KEYMAN_ROOT}/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 ################################ Main script ################################
 
@@ -34,7 +35,7 @@ builder_describe_outputs \
 builder_parse "$@"
 
 function do_configure() {
-  verify_npm_setup
+  node_select_version_and_npm_ci
 
   # Configure Web browser-engine testing environments.  As is, this should only
   # make changes when we update the dependency, even on our CI build agents.

--- a/web/src/engine/main/build.sh
+++ b/web/src/engine/main/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=engine/main
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # ################################ Main script ################################
 
@@ -45,7 +46,7 @@ do_build () {
     --format esm
 }
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
 builder_run_action build do_build
 builder_run_action test test-headless "${SUBPROJECT_NAME}"

--- a/web/src/engine/osk/build.sh
+++ b/web/src/engine/osk/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=engine/osk
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # ################################ Main script ################################
 
@@ -41,7 +42,7 @@ do_clean() {
 }
 
 do_configure() {
-  verify_npm_setup
+  node_select_version_and_npm_ci
   cp "$KEYMAN_ROOT/common/resources/fonts/keymanweb-osk.ttf" "$KEYMAN_ROOT/web/src/resources/osk/"
 }
 

--- a/web/src/engine/osk/gesture-processor/build.sh
+++ b/web/src/engine/osk/gesture-processor/build.sh
@@ -10,6 +10,7 @@ SUBPROJECT_NAME=engine/osk/gesture-processor
 
 . "${KEYMAN_ROOT}/web/common.inc.sh"
 . "${KEYMAN_ROOT}/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 BUNDLE_CMD="node $KEYMAN_ROOT/web/src/tools/es-bundling/build/common-bundle.mjs"
 
@@ -38,7 +39,7 @@ builder_parse "$@"
 # TODO: configure if npm has not been run, and build is specified
 
 function do_configure() {
-  verify_npm_setup
+  node_select_version_and_npm_ci
 }
 
 function do_build_module() {

--- a/web/src/engine/predictive-text/templates/build.sh
+++ b/web/src/engine/predictive-text/templates/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 ################################ Main script ################################
@@ -45,7 +46,7 @@ function do_test() {
   c8 mocha $FLAGS --require tests/helpers.js --recursive tests
 }
 
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action clean      rm -rf build/
 builder_run_action build      do_build
 builder_run_action test       do_test

--- a/web/src/engine/predictive-text/wordbreakers/build.sh
+++ b/web/src/engine/predictive-text/wordbreakers/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 ################################ Main script ################################
@@ -28,7 +29,7 @@ builder_describe_outputs \
 builder_parse "$@"
 
 function do_configure() {
-  verify_npm_setup
+  node_select_version_and_npm_ci
 
   # This is a script used to build the data.inc.ts file needed by the
   # default wordbreaker.  We rarely update the backing data, but it

--- a/web/src/engine/predictive-text/worker-main/build.sh
+++ b/web/src/engine/predictive-text/worker-main/build.sh
@@ -12,6 +12,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 BUNDLE_CMD="node $KEYMAN_ROOT/web/src/tools/es-bundling/build/common-bundle.mjs"
@@ -35,7 +36,7 @@ builder_describe_outputs \
 builder_parse "$@"
 
 function do_configure() {
-  verify_npm_setup
+  node_select_version_and_npm_ci
 
   # Configure Web browser-engine testing environments.  As is, this should only
   # make changes when we update the dependency, even on our CI build agents.

--- a/web/src/engine/predictive-text/worker-main/unit_tests/test.sh
+++ b/web/src/engine/predictive-text/worker-main/unit_tests/test.sh
@@ -8,6 +8,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 # This script runs from its own folder
 cd "$THIS_SCRIPT_PATH"
@@ -29,7 +30,7 @@ builder_describe "Runs all tests for the language-modeling / predictive-text lay
 builder_parse "$@"
 
 if builder_start_action configure; then
-  verify_npm_setup
+  node_select_version_and_npm_ci
   builder_finish_action success configure
 fi
 

--- a/web/src/engine/predictive-text/worker-thread/build.sh
+++ b/web/src/engine/predictive-text/worker-thread/build.sh
@@ -10,6 +10,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
 
 WORKER_OUTPUT=build/obj
@@ -41,7 +42,7 @@ builder_describe_outputs \
 builder_parse "$@"
 
 function do_configure() {
-  verify_npm_setup
+  node_select_version_and_npm_ci
 
   # Configure Web browser-engine testing environments.  As is, this should only
   # make changes when we update the dependency, even on our CI build agents.

--- a/web/src/engine/sentry-manager/build.sh
+++ b/web/src/engine/sentry-manager/build.sh
@@ -10,6 +10,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 . "${KEYMAN_ROOT}/web/common.inc.sh"
 . "${KEYMAN_ROOT}/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 builder_describe "Builds the Sentry-reporting module used with Keyman Engine for Web" \
   "@/common/web/keyman-version" \
@@ -31,7 +32,7 @@ fi
 ### CONFIGURE ACTIONS
 
 if builder_start_action configure; then
-  verify_npm_setup
+  node_select_version_and_npm_ci
   builder_finish_action success configure
 fi
 

--- a/web/src/test/manual/embed/android-harness/build.sh
+++ b/web/src/test/manual/embed/android-harness/build.sh
@@ -6,6 +6,8 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../../../../resources/build/builder-full.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
+
 builder_describe "Builds a debug-host page simulating Keyman Android's WebView setup for KMW use" \
   "@/common/web/keyman-version" \
   "@/web/src/app/webview" \
@@ -28,7 +30,7 @@ fi
 ### CONFIGURE ACTIONS
 
 if builder_start_action configure; then
-  verify_npm_setup
+  node_select_version_and_npm_ci
   builder_finish_action success configure
 fi
 

--- a/web/src/tools/building/sourcemap-root/build.sh
+++ b/web/src/tools/building/sourcemap-root/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 ################################ Main script ################################
 
@@ -26,6 +27,6 @@ builder_parse "$@"
 
 ### CONFIGURE ACTIONS
 
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action clean      rm -rf ../../../../build/tools/building/sourcemap-root
 builder_run_action build      tsc --build tsconfig.json

--- a/web/src/tools/es-bundling/build.sh
+++ b/web/src/tools/es-bundling/build.sh
@@ -7,6 +7,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 ################################ Main script ################################
 
@@ -21,6 +22,6 @@ builder_describe_outputs \
 
 builder_parse "$@"
 
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action clean      rm -rf build/
 builder_run_action build      tsc -b tsconfig.json

--- a/web/src/tools/testing/bulk_rendering/build.sh
+++ b/web/src/tools/testing/bulk_rendering/build.sh
@@ -11,6 +11,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=tools/testing/bulk_rendering
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 ################################ Main script ################################
 
@@ -39,6 +40,6 @@ function do_build ( ) {
      "${KEYMAN_ROOT}/web/build/$SUBPROJECT_NAME/lib/zip.min.js"
 }
 
-builder_run_action configure  verify_npm_setup
+builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action clean      rm -rf ../../../../build/$SUBPROJECT_NAME
 builder_run_action build      do_build

--- a/web/src/tools/testing/recorder-core/build.sh
+++ b/web/src/tools/testing/recorder-core/build.sh
@@ -11,6 +11,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 ################################ Main script ################################
 
@@ -29,7 +30,7 @@ builder_describe_outputs \
 builder_parse "$@"
 
 if builder_start_action configure; then
-  verify_npm_setup
+  node_select_version_and_npm_ci
   builder_finish_action success configure
 fi
 

--- a/web/src/tools/testing/recorder/build.sh
+++ b/web/src/tools/testing/recorder/build.sh
@@ -11,6 +11,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 SUBPROJECT_NAME=tools/testing/recorder
 . "$KEYMAN_ROOT/web/common.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "$KEYMAN_ROOT/resources/build/node.inc.sh"
 
 ################################ Main script ################################
 
@@ -37,6 +38,6 @@ do_build ( ) {
     --format esm
 }
 
-builder_run_action configure verify_npm_setup
+builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf ../../../../build/$SUBPROJECT_NAME/
 builder_run_action build do_build


### PR DESCRIPTION
Consolidates the node-related script functions into node.inc.sh, as part of cleaning up the build scripts and making them easier to maintain into the future.

Fixes: #14447
Test-bot: skip