### PR TITLE
fix(web): prevent auto-select from keeping old autoaccept positions highlighted 🚂

### DIFF
--- a/web/src/engine/osk/src/banner/suggestionBanner.ts
+++ b/web/src/engine/osk/src/banner/suggestionBanner.ts
@@ -773,11 +773,10 @@ export class SuggestionBanner extends Banner {
       if(suggestions.length > i) {
         const suggestion = suggestions[i];
         d.update(suggestion, optionFormat);
-        if(this.predictionContext.selected == suggestion) {
-          d.highlight(true);
-        }
+        d.highlight(this.predictionContext.selected == suggestion)
       } else {
         d.update(null, optionFormat);
+        d.highlight(false);
       }
     }
 


### PR DESCRIPTION
This fixes a small bug on the epic-autocorrect feature branch in which multiple suggestions could be highlighted from autocorrect, which occurred when the autoselected suggestion position moved since the last user interaction with the banner.

## User Testing

TEST_AUTOSELECTION:  Using the "Prediction - robust testing" Web test page, verify that only one suggestion is selected (highlighted) at any specific point in time as a word is typed.  Also verify that user interactions with the banner do not cause multiple suggestions to be highlighted.
- Using `sil_euro_latin`, type "testin".
    - At `test`, the first suggestion should be highlighted.
    - At and after `testi`, the suggestion `testing` should be highlighted.
- Also try typing other words as well.  
- If, at any point, two or more suggestions are highlighted, fail this test.