### PR TITLE
fix(android): Update other activities for edge to edge 🪟

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustKeyboardHeightActivity.java
@@ -44,6 +44,9 @@ public class AdjustKeyboardHeightActivity extends BaseActivity {
 
     setContentView(R.layout.activity_adjust_keyboard_height);
 
+    setupEdgeToEdge(R.id.adjust_keyboard_layout);
+    setupStatusBarColors(R.color.keyman_blue, android.R.color.white);
+
     Toolbar toolbar = (Toolbar) findViewById(R.id.titlebar);
     setSupportActionBar(toolbar);
     ActionBar actionBar = getSupportActionBar();

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/InfoActivity.java
@@ -34,6 +34,7 @@ public class InfoActivity extends BaseActivity {
     final Context context = this;
 
     setContentView(R.layout.activity_info);
+    setupEdgeToEdge(R.id.info_layout);
 
     // Navigation buttons
     final ImageButton backButton = (ImageButton) findViewById(R.id.back_button);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KMPBrowserActivity.java
@@ -79,6 +79,9 @@ public class KMPBrowserActivity extends BaseActivity {
       return;
     }
 
+    setupEdgeToEdge(R.id.kmp_browser_layout);
+    setupStatusBarColors(R.color.complementary_5, android.R.color.white);
+
     webView = (WebView) findViewById(R.id.kmpBrowserWebView);
     webView.getSettings().setLayoutAlgorithm(WebSettings.LayoutAlgorithm.NORMAL);
     webView.getSettings().setJavaScriptEnabled(true);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsActivity.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import com.keyman.engine.BaseActivity;
 import com.keyman.engine.KMManager;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 public class KeymanSettingsActivity extends BaseActivity {
@@ -22,6 +21,10 @@ public class KeymanSettingsActivity extends BaseActivity {
     super.onCreate(savedInstanceState);
 
     setContentView(R.layout.keyman_settings_layout);
+
+    setupEdgeToEdge(R.id.keyman_settings_layout);
+    setupStatusBarColors(R.color.keyman_blue, android.R.color.white);
+
     Toolbar toolbar = (Toolbar) findViewById(R.id.keyman_settings_toolbar);
     toolbar.setTitleTextColor(getResources().getColor(android.R.color.white));
     toolbar.setTitle(R.string.keyman_settings);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsInstallActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/KeymanSettingsInstallActivity.java
@@ -24,11 +24,12 @@ import android.os.Bundle;
 import android.widget.SimpleAdapter;
 import android.widget.TextView;
 
+import com.keyman.engine.BaseActivity;
 import com.keyman.engine.KMManager;
 import com.keyman.engine.data.KeyboardController;
 import com.keyman.engine.util.MapCompat;
 
-public class KeymanSettingsInstallActivity extends AppCompatActivity {
+public class KeymanSettingsInstallActivity extends BaseActivity {
   private static final String TAG = "SettingsInstallActivity";
   private static ArrayList<HashMap<String, String>> installOptionList = null;
   private static Typeface titleFont = null;
@@ -45,6 +46,8 @@ public class KeymanSettingsInstallActivity extends AppCompatActivity {
     context = this;
 
     setContentView(R.layout.activity_list_layout);
+    setupEdgeToEdge(R.id.list_toolbar);
+
     final Toolbar toolbar = findViewById(R.id.list_toolbar);
     setSupportActionBar(toolbar);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/LanguageSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/LanguageSettingsActivity.java
@@ -25,10 +25,10 @@ import android.widget.TextView;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.appcompat.widget.Toolbar;
 
+import com.keyman.engine.BaseActivity;
 import com.keyman.engine.KeyboardPickerActivity;
 import com.keyman.engine.KMManager;
 import com.keyman.engine.ModelPickerActivity;
@@ -43,7 +43,7 @@ import java.util.HashMap;
  * Keyman Settings --> Languages Settings --> Language Settings
  * Displays a list of installed keyboards and some lexical model switches.
  */
-public final class LanguageSettingsActivity extends AppCompatActivity {
+public final class LanguageSettingsActivity extends BaseActivity {
   private Context context;
   private static Toolbar toolbar = null;
   private static ListView listView = null;
@@ -65,6 +65,8 @@ public final class LanguageSettingsActivity extends AppCompatActivity {
     supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
     context = this;
     setContentView(R.layout.language_settings_list_layout);
+
+    setupEdgeToEdge(R.id.list_toolbar);
 
     toolbar = (Toolbar) findViewById(R.id.list_toolbar);
     setSupportActionBar(toolbar);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/LanguagesSettingsActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/LanguagesSettingsActivity.java
@@ -19,9 +19,9 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
+import com.keyman.engine.BaseActivity;
 import com.keyman.engine.data.Dataset;
 import com.keyman.engine.data.adapters.AdapterFilter;
 import com.keyman.engine.data.adapters.NestedAdapter;
@@ -36,7 +36,7 @@ import java.util.List;
  * Keyman Settings --> Languages Settings
  * Displays a list of installed languages and a count of their associated installed keyboards.
  */
-public final class LanguagesSettingsActivity extends AppCompatActivity {
+public final class LanguagesSettingsActivity extends BaseActivity {
 
   private Context context;
   private static Toolbar toolbar = null;
@@ -52,6 +52,8 @@ public final class LanguagesSettingsActivity extends AppCompatActivity {
     supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
     context = this;
     setContentView(R.layout.languages_settings_list_layout);
+
+    setupEdgeToEdge(R.id.languages_list_layout);
 
     toolbar = (Toolbar) findViewById(R.id.list_toolbar);
     setSupportActionBar(toolbar);

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -4,7 +4,6 @@
 package com.tavultesoft.kmapro;
 
 import android.annotation.SuppressLint;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 
@@ -18,6 +17,7 @@ import android.widget.Toast;
 
 import com.stepstone.stepper.StepperLayout;
 import com.stepstone.stepper.VerificationError;
+import com.keyman.engine.BaseActivity;
 import com.keyman.engine.KMManager;
 import com.keyman.engine.KeyboardEventHandler;
 import com.keyman.engine.KmpInstallMode;
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class PackageActivity extends AppCompatActivity implements
+public class PackageActivity extends BaseActivity implements
     StepperLayout.StepperListener, WebViewFragment.OnInstallClickedListener,
     SelectLanguageFragment.OnLanguagesSelectedListener {
   private final static String TAG = "PackageActivity";
@@ -52,6 +52,7 @@ public class PackageActivity extends AppCompatActivity implements
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_package_installer);
+    setupEdgeToEdge(R.id.package_installer_layout);
 
     KmpInstallMode installMode = KmpInstallMode.Full;
     String languageID = null;

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectLanguageActivity.java
@@ -8,11 +8,11 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 
 import com.stepstone.stepper.StepperLayout;
 import com.stepstone.stepper.VerificationError;
+import com.keyman.engine.BaseActivity;
 import com.keyman.engine.KMManager;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.packages.PackageProcessor;
@@ -29,7 +29,7 @@ import java.util.List;
  * Also available during keyboard package installation that involves a language choice.
  * Displays a list of available language names for the user to add for a given installed packageID/keyboardID.
  */
-public class SelectLanguageActivity extends AppCompatActivity implements
+public class SelectLanguageActivity extends BaseActivity implements
     StepperLayout.StepperListener, SelectLanguageFragment.OnLanguagesSelectedListener {
   private final static String TAG = "SelectLanguageActivity";
   private File packagePath;
@@ -43,6 +43,7 @@ public class SelectLanguageActivity extends AppCompatActivity implements
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_select_language);
+    setupEdgeToEdge(R.id.select_language_layout);
 
     Bundle bundle = getIntent().getExtras();
     keyboard = (Keyboard)bundle.getSerializable("keyboard");

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectPackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/SelectPackageActivity.java
@@ -16,9 +16,9 @@ import android.widget.ListView;
 import android.widget.SimpleAdapter;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
+import com.keyman.engine.BaseActivity;
 import com.keyman.engine.KMManager;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.data.KeyboardController;
@@ -33,7 +33,7 @@ import java.util.List;
  * Keyman Settings --> KeymanInstallActivity --> SelectPackageActivity
  * Displays a list of installed package ID / keyboard IDs so the user can select a language from the kmp.json
  */
-public final class SelectPackageActivity extends AppCompatActivity {
+public final class SelectPackageActivity extends BaseActivity {
   private static final String TAG = "SelectPackageActivity";
   private static ArrayList<HashMap<String, String>> list = null;
   private static Typeface titleFont = null;
@@ -49,6 +49,8 @@ public final class SelectPackageActivity extends AppCompatActivity {
     context = this;
 
     setContentView(R.layout.activity_list_layout);
+    setupEdgeToEdge(R.id.activity_list_layout);
+
     final Toolbar toolbar = findViewById(R.id.list_toolbar);
     setSupportActionBar(toolbar);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_adjust_keyboard_height.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_adjust_keyboard_height.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:orientation="vertical"
+  android:id="@+id/adjust_keyboard_layout"
+  android:fitsSystemWindows="true"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
   <include layout="@layout/titlebar" />
 
@@ -15,7 +17,7 @@
     android:layout_marginStart="@dimen/activity_horizontal_margin"
     android:text="@string/drag_the_keyboard"
     android:textSize="@dimen/adjust_keyboard_height_label_textsize"
-    />
+    app:layout_constraintTop_toBottomOf="@id/titlebar" />
 
   <TextView
     android:id="@+id/rotate_the_device"
@@ -25,23 +27,35 @@
     android:layout_marginStart="@dimen/activity_horizontal_margin"
     android:text="@string/rotate_the_device"
     android:textSize="@dimen/adjust_keyboard_height_label_textsize"
-    />
+    app:layout_constraintTop_toBottomOf="@id/drag_the_keyboard" />
 
-  <Button
-    android:id="@+id/reset_to_defaults"
-    style="@style/Widget.AppCompat.Button.Colored"
-    android:background="@color/keyman_blue"
-    android:textColor="@color/ms_white"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_below="@id/rotate_the_device"
-    android:layout_centerInParent="true"
-    android:singleLine="true"
-    android:layout_marginTop="8dp"
-    android:paddingStart="8dp"
-    android:paddingEnd="8dp"
-    android:text="@string/reset_to_defaults"
-    android:textSize="@dimen/adjust_keyboard_height_label_textsize" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/button_layout"
+      android:orientation="horizontal"
+      android:layout_below="@id/rotate_the_device"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintTop_toBottomOf="@id/rotate_the_device">
+
+      <Button
+        android:id="@+id/reset_to_defaults"
+        style="@style/Widget.AppCompat.Button.Colored"
+        android:background="@color/keyman_blue"
+        android:textColor="@color/ms_white"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:singleLine="true"
+        android:layout_marginTop="8dp"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:text="@string/reset_to_defaults"
+        android:textSize="@dimen/adjust_keyboard_height_label_textsize"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <!-- Resizable keyboard "image -->
     <ImageView
@@ -56,6 +70,10 @@
       android:paddingStart="@dimen/blank_osk_padding"
       android:paddingEnd="@dimen/blank_osk_padding"
       android:paddingTop="@dimen/blank_osk_padding"
-      android:paddingBottom="@dimen/blank_osk_padding"/>
+      android:paddingBottom="@dimen/blank_osk_padding"
+      app:layout_constraintTop_toBottomOf="@id/button_layout"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintVertical_bias="1.0" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_info.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_info.xml
@@ -1,75 +1,92 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/info_layout"
+  android:fitsSystemWindows="true"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical"
-  android:background="@color/ms_white"
   tools:context=".InfoActivity" >
 
-  <androidx.appcompat.widget.Toolbar
-    android:id="@+id/titlebar"
-    android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
-    android:layout_alignParentTop="true"
-    app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/titlebar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
 
-    <LinearLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/close_button" >
 
-      <!-- Navigation buttons in a LinearLayout to mirror on RTL -->
-      <ImageButton
-        android:id="@+id/back_button"
-        style="?android:attr/actionButtonStyle"
-        app:tint="@color/image_button_color"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:contentDescription="@string/label_back"
-        android:src="@drawable/ic_action_back" />
+            <!-- Navigation buttons in a LinearLayout to mirror on RTL -->
+            <ImageButton
+                android:id="@+id/back_button"
+                style="?android:attr/actionButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="start"
+                android:contentDescription="@string/label_back"
+                android:src="@drawable/ic_action_back"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/image_button_color" />
 
-      <ImageButton
-        android:id="@+id/forward_button"
-        style="?android:attr/actionButtonStyle"
-        app:tint="@color/image_button_color"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:contentDescription="@string/label_forward"
-        android:src="@drawable/ic_action_forward" />
-    </LinearLayout>
+            <ImageButton
+                android:id="@+id/forward_button"
+                style="?android:attr/actionButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:contentDescription="@string/label_forward"
+                android:src="@drawable/ic_action_forward"
+                app:layout_constraintStart_toEndOf="@id/back_button"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/image_button_color" />
 
-    <ImageButton
-      android:id="@+id/close_button"
-      style="?android:attr/actionButtonStyle"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_gravity="end"
-      android:contentDescription="@string/label_close"
-      android:src="@drawable/ic_action_close" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-  </androidx.appcompat.widget.Toolbar>
+        <ImageButton
+            android:id="@+id/close_button"
+            style="?android:attr/actionButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_gravity="end"
+            android:contentDescription="@string/label_close"
+            android:src="@drawable/ic_action_close"
+            app:layout_constraintEnd_toEndOf="parent" />
 
-  <WebView
-    android:id="@+id/infoWebView"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_below="@id/titlebar"
-    android:layout_marginBottom="@dimen/info_label_height" />
+    </androidx.appcompat.widget.Toolbar>
+
+    <!-- layout_height 0dp to fill the remaining area -->
+    <WebView
+        android:id="@+id/infoWebView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_below="@id/titlebar"
+        android:layout_marginStart="4dp"
+	    app:layout_constraintTop_toBottomOf="@id/titlebar"
+        app:layout_constraintBottom_toTopOf="@+id/infoVersion"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <!-- Version string on the bottom of the page -->
     <TextView
-      android:id="@+id/infoVersion"
-      android:layout_width="match_parent"
-      android:layout_height="@dimen/info_label_height"
-      android:layout_gravity="center_horizontal"
-      android:gravity="center"
-      android:ellipsize="end"
-      android:singleLine="true"
-      android:text="@string/title_version"
-      android:textSize="@dimen/info_label_textsize"
-      android:layout_alignParentBottom="true" />
+    android:id="@id/infoVersion"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom"
+    android:gravity="center"
+    android:ellipsize="end"
+    android:singleLine="true"
+    android:text="@string/title_version"
+    android:textSize="@dimen/info_label_textsize"
+    android:layout_alignParentBottom="true"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_kmp_browser.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_kmp_browser.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/kmp_browser_layout"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".KMPBrowserActivity"
@@ -9,6 +12,8 @@
   <WebView
     android:id="@+id/kmpBrowserWebView"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintStart_toStartOf="parent" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_package_installer.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_package_installer.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/package_installer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -23,6 +24,17 @@
         app:ms_nextButtonText="@string/label_next"
         app:ms_completeButtonColor="@color/keyman_blue"
         app:ms_completeButtonText="@string/label_ok"
-        app:ms_stepperType="dots" />
+        app:ms_stepperType="dots"
+        app:layout_constraintTop_toBottomOf="@+id/titlebar"
+        app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"
+        app:layout_constraintStart_toStartOf="parent" />
 
-</RelativeLayout>
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@id/bottom_navigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_select_language.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_select_language.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
+  android:fitsSystemWindows="true"
+  android:id="@+id/select_language_layout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical"
@@ -15,7 +17,7 @@
     android:id="@+id/stepperLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_alignParentBottom="true"
+    android:layout_below="@+id/titlebar"
     app:ms_showBackButtonOnFirstStep="true"
     app:ms_backButtonColor="@color/keyman_blue"
     app:ms_backButtonText="@string/label_back"
@@ -23,6 +25,18 @@
     app:ms_nextButtonText="@string/label_next"
     app:ms_completeButtonColor="@color/keyman_blue"
     app:ms_completeButtonText="@string/label_ok"
-    app:ms_stepperType="dots" />
+    app:ms_stepperType="dots"
+    app:layout_constraintTop_toBottomOf="@id/titlebar"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintBottom_toTopOf="@+id/bottom_navigation" />
 
-</RelativeLayout>
+  <com.google.android.material.bottomnavigation.BottomNavigationView
+      android:id="@+id/bottom_navigation"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="@android:color/transparent"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintVertical_bias="1.0"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/KMAPro/kMAPro/src/main/res/layout/keyman_settings_layout.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/keyman_settings_layout.xml
@@ -1,23 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/keyman_settings_layout"
   android:orientation="vertical"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
-  <com.google.android.material.appbar.AppBarLayout
+  <androidx.appcompat.widget.Toolbar
+    android:id="@+id/keyman_settings_toolbar"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:elevation="0dp">
-
-    <androidx.appcompat.widget.Toolbar
-      android:id="@+id/keyman_settings_toolbar"
-      android:layout_width="match_parent"
-      android:layout_height="?attr/actionBarSize"
-      android:background="@color/keyman_blue">
-
-    </androidx.appcompat.widget.Toolbar>
-  </com.google.android.material.appbar.AppBarLayout>
+    android:layout_height="?attr/actionBarSize"
+    android:background="@color/keyman_blue"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintStart_toStartOf="parent" />
 
   <fragment
     android:layout_marginTop="?attr/actionBarSize"
@@ -26,4 +21,4 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMHelpFileActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMHelpFileActivity.java
@@ -64,6 +64,8 @@ public class KMHelpFileActivity extends BaseActivity {
     }
 
     setContentView(R.layout.activity_help_file_layout);
+    setupEdgeToEdge(R.id.help_file_layout);
+    setupStatusBarColors(android.R.color.white, android.R.color.white);
 
     Bundle bundle = getIntent().getExtras();
     pkgID = "";

--- a/android/KMEA/app/src/main/res/layout/activity_help_file_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/activity_help_file_layout.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/help_file_layout"
+  android:fitsSystemWindows="true"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
@@ -9,36 +12,28 @@
   <WebView
     android:id="@+id/kmHelpFileWebView"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="0dp"
     android:layout_below="@+id/titlebar"
-    android:layout_above="@+id/buttonBar" />
-
-  <LinearLayout
-    android:id="@+id/buttonBar"
-    style="?android:attr/buttonBarStyle"
-    android:layout_alignParentBottom="true"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="horizontal">
-
-    <!-- Spacer to pad buttons to the right -->
-    <View
-      android:layout_width="0dp"
-      android:layout_height="0dp"
-      android:layout_weight="1" />
+    app:layout_constraintTop_toBottomOf="@id/titlebar"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintBottom_toTopOf="@+id/finishButton" />
 
     <Button
-      android:id="@+id/finishButton"
+      android:id="@id/finishButton"
       style="@style/Widget.AppCompat.Button.Borderless.Colored"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:text="@string/label_ok"
+      android:layout_marginStart="10dp"
+      android:layout_marginEnd="15dp"
+      android:layout_gravity="end"
       android:elevation="1dp"
       android:singleLine="true"
-      android:layout_marginStart="10dp" android:layout_marginEnd="15dp">
-      <requestFocus/>
+      android:text="@string/label_ok"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="1.0">
+
+      <requestFocus />
     </Button>
 
-  </LinearLayout>
-
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/KMEA/app/src/main/res/layout/activity_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/activity_list_layout.xml
@@ -1,13 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    android:id="@+id/activity_list_layout"
+    android:fitsSystemWindows="true"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/list_toolbar" />
+    <include layout="@layout/list_toolbar"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintStart_toStartOf="parent" />
 
-    <include layout="@layout/list_layout" />
+    <include layout="@layout/list_layout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintTop_toBottomOf="@+id/list_appbar"
+      app:layout_constraintStart_toStartOf="parent" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/KMEA/app/src/main/res/layout/language_settings_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/language_settings_list_layout.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/list_toolbar" />
+    <include layout="@layout/list_toolbar"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <!-- ListView of installed keyboards. TODO: calculate height -->
     <include
@@ -14,45 +17,35 @@
         layout="@layout/list_layout"
         android:layout_width="match_parent"
         android:layout_height="200dp"
-        android:layout_above="@+id/keyboard_linear_layout"
-        android:layout_below="@id/list_appbar" />
+        android:layout_above="@+id/modeling_settings_layout"
+        android:layout_below="@id/list_appbar"
+        app:layout_constraintTop_toBottomOf="@id/list_appbar"/>
 
-    <LinearLayout
-        android:id="@+id/keyboard_linear_layout"
-        android:layout_width="match_parent"
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/add_button"
+        style="?android:attr/actionButtonStyle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_above="@id/modeling_settings_layout"
-        android:orientation="horizontal">
-
-        <Space
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_weight="10" />
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/add_button"
-            style="?android:attr/actionButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end|center_vertical"
-            android:layout_marginTop="@dimen/fab_margin"
-            android:layout_marginBottom="@dimen/fab_margin"
-            android:layout_weight="1"
-            android:contentDescription="@string/image_button"
-            android:src="@drawable/ic_add_white"
-            app:fabSize="normal" />
-
-    </LinearLayout>
+        android:layout_gravity="end|center_vertical"
+        android:contentDescription="@string/image_button"
+        android:src="@drawable/ic_add_white"
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:layout_marginBottom="@dimen/fab_margin"
+        app:fabSize="normal"
+        app:layout_constraintBottom_toTopOf="@+id/modeling_settings_layout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"/>
 
     <LinearLayout
-        android:id="@+id/modeling_settings_layout"
+        android:id="@id/modeling_settings_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_marginTop="0dp"
         android:layout_marginBottom="0dp"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        app:layout_constraintVertical_bias="1.0"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <View
             android:id="@+id/separator"
@@ -117,4 +110,4 @@
         android:layout_height="wrap_content"
         android:layout_below="@id/model_picker"/> -->
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/KMEA/app/src/main/res/layout/languages_settings_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/languages_settings_list_layout.xml
@@ -1,31 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/languages_list_layout"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-  <include layout="@layout/list_toolbar" />
+    <include layout="@layout/list_toolbar"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-  <include
-      android:id="@+id/keyboard_list_layout"
-      layout="@layout/list_layout"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:layout_below="@id/list_appbar" />
-
-  <LinearLayout
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      android:orientation="horizontal">
-
-    <Space
-        android:layout_width="wrap_content"
+    <include
+        android:id="@+id/keyboard_list_layout"
+        layout="@layout/list_layout"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:layout_weight="10" />
+        android:layout_below="@+id/list_appbar"
+        app:layout_constraintTop_toBottomOf="@id/list_appbar"
+        app:layout_constraintStart_toStartOf="parent"/>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/add_button"
@@ -33,12 +27,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|center_vertical"
-        android:layout_marginTop="@dimen/fab_margin"
-        android:layout_marginBottom="@dimen/fab_margin"
-        android:layout_weight="1"
         android:contentDescription="@string/image_button"
         android:src="@drawable/ic_add_white"
-        app:fabSize="normal" />
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:layout_marginBottom="@dimen/fab_margin"
+        app:fabSize="normal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"/>
 
-  </LinearLayout>
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/KMEA/app/src/main/res/layout/list_toolbar.xml
+++ b/android/KMEA/app/src/main/res/layout/list_toolbar.xml
@@ -7,31 +7,39 @@
     android:layout_height="wrap_content"
     app:elevation="0dp">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/list_toolbar"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize">
 
-        <TextView
-            android:id="@+id/bar_title"
-            android:layout_width="wrap_content"
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/list_toolbar"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:gravity="center"
-            android:ellipsize="end"
-            android:singleLine="true"
-            android:text="@string/title_add_keyboard"
-            android:textSize="@dimen/titlebar_label_textsize"
-            android:textStyle="bold" />
+            app:layout_constraintTop_toTopOf="parent">
 
-    </androidx.appcompat.widget.Toolbar>
+            <TextView
+                android:id="@+id/bar_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:gravity="center"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:text="@string/title_add_keyboard"
+                android:textSize="@dimen/titlebar_label_textsize"
+                android:textStyle="bold" />
 
-    <!-- optional accent -->
-    <View
-        android:id="@+id/bar_accent"
-        style="@style/AppTheme.Divider"
-        android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:layout_alignParentBottom="true"/>
+        </androidx.appcompat.widget.Toolbar>
 
+        <!-- optional accent -->
+        <View
+            android:id="@+id/bar_accent"
+            style="@style/AppTheme.Divider"
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            app:layout_constraintTop_toBottomOf="@id/list_toolbar"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.appbar.AppBarLayout>

--- a/android/KMEA/app/src/main/res/layout/titlebar.xml
+++ b/android/KMEA/app/src/main/res/layout/titlebar.xml
@@ -6,7 +6,9 @@
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
     android:layout_alignParentTop="true"
-    app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
+    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintStart_toStartOf="parent">
 
     <TextView
         android:id="@id/bar_title"


### PR DESCRIPTION
Relates to #14248 and follows #14396

This updates the rest of the Keyman activities to handle the edge-to-edge behavior in Android API 35+.
Some activites converted from AppCompatActivity to BaseActivity.

As needed, the activities call BaseActivity:
* setupEdgeToEdge()
* setupStatusBarColors()

As noted in the previous PR #14396 
the color changes in 
> BaseActivity.setupStatusBarColors() only works on Android API M (27) through Upsidedown Cake (34)

## User Testing

**Setup** - Install the PR build of Keyman for Android on an Android emulator/device of Android API 34

* **TEST_KEYMAN_ACTVITIES** - Verifies actvities within the Keyman app are not obstructed by system insets (camera notch, status bar, navigation bars)
1. For the entire test, if a portion of the activity is covered by system insets (camera notch, status bar on top, navigation bar on bottom), fail the test.
2. With the device in Portrait orientation, launch Keyman for Android and dismiss the Get Started menu
3. Go through the various workflows/activities and verify none of the menus are covered by system insets:
    * longpress globe key for keyboard picker menu --> EuroLatin help --> Help link --> keyboard help scrollable and can "OK" at the bottom
    * Keyman menu --> Info --> Navigate through the in-app help content and verify version remains visible at the bottom
4. Go through the various Keyman settings menus and verify none of the menus are covered by system insets:
    * Installed languages --> click through each menu
    * Install Keyboard or Dictionary -->
        * Install from keyman.com --> install keyboard and verify you can navigate through menus
        * Add languages to installed keyboard --> EuroLatin Keyboard --> add language(s) to install with EuroLatin and verify can "INSTALL"
    * Display language --> verify UI language can be changed
    * Adjust keyboard height --> verify keyboard height can be adjusted and reset
    * Adjust longpress delay --> verify longpress delay can be adjusted
5. Return the Keyman app and rotate the device to landscape orientation  (unlock orientation lock if needed)
6. Repeat test steps in landscape orientation
     