### PR TITLE
change(web): do not cache context states that will no longer be referenced 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/alignment-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/alignment-helpers.ts
@@ -55,10 +55,9 @@ export function isSubstitutionAlignable(
   let subEditPath = ClassicalDistanceCalculation.computeDistance(
     [...matchingToken].map(value => ({key: value})),
     [...incomingToken].map(value => ({key: value})),
-    // Diagonal width to consider must be at least 2, as adding a single
-    // whitespace after a token tends to add two tokens: one for whitespace,
-    // one for the empty token to follow it.
-    3
+    // Use max length in case the word is actually already partly out of
+    // the sliding context window.
+    Math.max(incomingToken.length, matchingToken.length)
   ).editPath();
 
   const firstInsert = subEditPath.indexOf('insert');
@@ -77,7 +76,7 @@ export function isSubstitutionAlignable(
     if(firstSubstitute > -1) {
       return false;
     } else if(firstMatch > -1) {
-      // Should not have inserts on both sides of matched text!
+      // Should not have inserts or deletes on both sides of matched text!
       if(firstInsert > -1 && firstInsert < firstMatch && subEditPath.lastIndexOf('insert') > firstMatch) {
         return false;
       } else if(firstDelete > -1 && firstDelete < firstMatch && subEditPath.lastIndexOf('delete') > firstMatch) {

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -412,6 +412,8 @@ export class ContextTokenization {
         // Assumption:  there have been no intervening keystrokes since the last well-aligned context.
         // (May not be valid with epic/dict-breaker or with complex, word-boundary crossing transforms)
         token = new ContextToken(matchedToken);
+        // Erase any applied-suggestion transition ID; it is no longer valid.
+        token.appliedTransitionId = undefined;
         token.searchSpace.addInput(tokenDistribution.map((seq) => seq[tailIndex]));
       }
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -3,6 +3,7 @@ import { RewindableCache } from '@keymanapp/web-utils';
 
 import { determineModelTokenizer } from '../model-helpers.js';
 import { LexicalModelTypes } from '@keymanapp/common-types';
+import Configuration = LexicalModelTypes.Configuration;
 import Context = LexicalModelTypes.Context;
 import Distribution = LexicalModelTypes.Distribution;
 import LexicalModel = LexicalModelTypes.LexicalModel;
@@ -11,12 +12,32 @@ import { ContextState } from './context-state.js';
 import { ContextTransition } from './context-transition.js';
 
 export class ContextTracker {
-  readonly cache = new RewindableCache<number, ContextTransition>(5);
+  private readonly cache = new RewindableCache<number, ContextTransition>(5);
+  /**
+   * Tracks the most recent transition handled by the context-tracking engine.
+   */
+  latest: ContextTransition;
+
+  /**
+   * Notes the current configuration of the model and of the sliding context window.
+   */
+  configuration: Configuration;
+
+  /**
+   * The active lexical model.
+   */
+  readonly model: LexicalModel;
 
   /** @internal */
   public unitTestEndPoints = {
     cache: () => this.cache
   };
+
+  constructor(model: LexicalModel, context: Context, transitionId: number, config: Configuration) {
+    this.model = model;
+    this.configuration = config;
+    this.reset(context, transitionId);
+  }
 
   /**
    * Compares the current, post-input context against the most recently-seen contexts from previous prediction calls, returning
@@ -52,7 +73,7 @@ export class ContextTracker {
     const transitionId = inputTransform?.sample.id;
 
     if(tokenizedPostContext.left.length > 0) {
-      for(const id of this.cache.keys()) {
+      for(const id of [...this.cache.keys()]) {
         const priorMatchState = this.cache.peek(id);
 
         // Skip intermediate multitap-produced contexts.
@@ -103,7 +124,14 @@ export class ContextTracker {
     //
     // Assumption:  as a caret needs to move to context before any actual transform distributions occur,
     // this state is only reached on caret moves; thus, transformDistribution is actually just a single null transform.
+    //
+    // If we couldn't find a good match, we need to directly apply the final transform first.
+    if(transformDistribution) {
+      context = applyTransform(transformDistribution[0].sample, context);
+    }
+
     let state = new ContextState(context, model);
+
     const transition = new ContextTransition(state, transitionId);
     // Hacky, but holds the course for now.  This should only really happen from context resets, which can
     // then use a different path.
@@ -112,16 +140,29 @@ export class ContextTracker {
     return transition;
   }
 
-  get newest() {
-    let key = this.cache.keys()[0];
-    if(key === undefined) {
-      return undefined;
-    } else {
-      return this.cache.peek(key);
-    }
+  reset(context: Context, transitionId: number) {
+    this.cache.clear();
+    this.latest = new ContextTransition(new ContextState(context, this.model), transitionId)
+    this.latest.finalize(this.latest.base, [{
+      sample: {
+        insert: '',
+        deleteLeft: 0,
+        id: transitionId
+      },
+      p: 0
+    }]);
   }
 
-  clearCache() {
-    this.cache.clear();
+  findAndRevert(id: number) {
+    const transition = this.cache.peek(id);
+    if(transition) {
+      this.cache.rewindTo(id);
+      this.cache.get(id);
+    }
+    return transition;
+  }
+
+  saveLatest() {
+    this.cache.add(this.latest.transitionId, this.latest);
   }
 }

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
@@ -137,7 +137,7 @@ export class ContextTransition {
    */
   applySuggestion(suggestion: Suggestion) {
     const preAppliedState = this.final;
-    if(!preAppliedState.suggestions.find((s) => s.id == suggestion?.id)) {
+    if(!preAppliedState.suggestions?.find((s) => s.id == suggestion?.id)) {
       throw new Error("Could not find matching suggestion to apply");
     }
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/transform-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/transform-tokenization.ts
@@ -35,6 +35,9 @@ export function tokenizeTransform(
   // Context does not slide within this function.
   const postContext = applyTransform(transform, context);
   const postTokenization = tokenize(postContext).left;
+  if(postTokenization.length == 0) {
+    postTokenization.push({text: ''});
+  }
 
   let insert = transform.insert;
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/index.ts
@@ -242,6 +242,7 @@ export default class LMLayerWorker {
       if(configuration.wordbreaksAfterSuggestions === undefined) {
         configuration.wordbreaksAfterSuggestions = (compositor.punctuation.insertAfterWord != '');
       }
+      compositor.setConfiguration(configuration);
       this.cast('ready', { configuration });
     } catch (err) {
       this.error("loadModel failed!", err);

--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -7,10 +7,10 @@ import TransformUtils from './transformUtils.js';
 import { applySuggestionCasing, correctAndEnumerate, dedupeSuggestions, finalizeSuggestions, predictionAutoSelect, processSimilarity, toAnnotatedSuggestion, tupleDisplayOrderSort } from './predict-helpers.js';
 import { detectCurrentCasing, determineModelTokenizer, determineModelWordbreaker, determinePunctuationFromModel } from './model-helpers.js';
 
-import { ContextTransition } from './correction/context-transition.js';
-import { ContextState } from './correction/context-state.js';
+import { ContextTracker } from './correction/context-tracker.js';
 
 import CasingForm = LexicalModelTypes.CasingForm;
+import Configuration = LexicalModelTypes.Configuration;
 import Context = LexicalModelTypes.Context;
 import Distribution = LexicalModelTypes.Distribution;
 import Keep = LexicalModelTypes.Keep;
@@ -66,17 +66,27 @@ export class ModelCompositor {
 
   private testMode: boolean = false;
   private verbose: boolean = true;
+  private configuration: Configuration;
 
   constructor(
     lexicalModel: LexicalModel,
     testMode?: boolean
   ) {
     this.lexicalModel = lexicalModel;
-    if(lexicalModel.traverseFromRoot) {
-      this._contextTracker = new correction.ContextTracker();
-    }
     this.punctuation = determinePunctuationFromModel(lexicalModel);
     this.testMode = !!testMode;
+  }
+
+  setConfiguration(config: Configuration) {
+    this.configuration = config;
+  }
+
+  initContextTracker(context: Context, transformId: number) {
+    if(this.contextTracker || !this.lexicalModel.traverseFromRoot) {
+      return;
+    }
+
+    this._contextTracker = new ContextTracker(this.lexicalModel, context, transformId, this.configuration);
   }
 
   async predict(transformDistribution: Transform | Distribution<Transform>, context: Context): Promise<Outcome<Suggestion|Keep>[]> {
@@ -118,6 +128,9 @@ export class ModelCompositor {
     // Only allow new-word suggestions if space was the most likely keypress.
     // const allowSpace = TransformUtils.isWhitespace(inputTransform);
     const inputTransform = transformDistribution[0].sample;
+    const transformId = inputTransform.id;
+    this.initContextTracker(context, transformId);
+
     const allowBksp = TransformUtils.isBackspace(inputTransform);
     const allowWhitespace = TransformUtils.isWhitespace(inputTransform);
 
@@ -256,13 +269,18 @@ export class ModelCompositor {
 
     // Step 3:  if we track Contexts, update the tracking data as appropriate.
     if(this.contextTracker) {
-      let originalTransition = this.contextTracker.newest;
+      let originalTransition = this.contextTracker.latest;
+      if(originalTransition.transitionId != suggestion.transformId) {
+        originalTransition = this.contextTracker.findAndRevert(suggestion.transformId);
+      }
       if(!originalTransition) {
-        originalTransition = this.contextTracker.analyzeState(this.lexicalModel, context);
+        this.contextTracker.reset(context, suggestion.transformId);
+        originalTransition = this.contextTracker.latest;
       }
 
       const appliedTransition = originalTransition.applySuggestion(suggestion);
-      this.contextTracker.cache.add(suggestion.transformId, appliedTransition);
+      this.contextTracker.latest = appliedTransition;
+      this.contextTracker.saveLatest();
     }
 
     return reversion;
@@ -299,39 +317,34 @@ export class ModelCompositor {
     }
 
     // When the context is tracked, we prefer the tracked information.
-    let originalTransition = this.contextTracker.cache.peek(-reversion.transformId);
+    let originalTransition = this.contextTracker.findAndRevert(-reversion.transformId);
 
     if(!originalTransition) {
-      // We forgot the original base state... and what suggestions we gave.  We can make
-      // decent guesses for those, though.
+      this.contextTracker.reset(context, -reversion.transformId);
+      originalTransition = this.contextTracker.latest;
+
       suggestions = fallbackSuggestions();
-      // Create a base transition from scratch to replace the lost original transition data.
-      originalTransition = new ContextTransition(new ContextState(context, this.lexicalModel), -reversion.transformId);
-      this.contextTracker.clearCache();
     } else {
-      // Remove all contexts more recent than the one we're reverting to.
-      this.contextTracker.cache.rewindTo(-reversion.transformId);
-    }
+      if(!suggestions) {
+        // Will need to be modified a bit if/when phrase-level suggestions are implemented.
+        // Those will be tracked on the first token of the phrase, which won't be the tail
+        // if they cover multiple tokens.
+        let suggests = originalTransition.final.suggestions;
 
-    // If we did actually have the original transition object...
-    if(!suggestions) {
-      // Will need to be modified a bit if/when phrase-level suggestions are implemented.
-      // Those will be tracked on the first token of the phrase, which won't be the tail
-      // if they cover multiple tokens.
-      let suggests = originalTransition.final.suggestions;
+        suggests.forEach(function(suggestion) {
+          // No need to muck around with the original associated transition ids here.
+          // But, we should clear any auto-acceptance flags.
+          suggestion.autoAccept = false;
+        });
 
-      suggests.forEach(function(suggestion) {
-        // No need to muck around with the original associated transition ids here.
-        // But, we should clear any auto-acceptance flags.
-        suggestion.autoAccept = false;
-      });
-
-      suggestions = Promise.resolve(suggests);
+        suggestions = Promise.resolve(suggests);
+      }
     }
 
     // An applied reversion should replace the original Transition's effects.
     const revertedTransition = originalTransition.reproduceOriginal();
-    this.contextTracker.cache.add(-reversion.transformId, revertedTransition);
+    this.contextTracker.latest = revertedTransition;
+    this.contextTracker.saveLatest();
 
     // In case we needed the fallback strategy.
     revertedTransition.final.suggestions = await suggestions;
@@ -356,8 +369,7 @@ export class ModelCompositor {
     // Designed for use when the caret has been directly moved and/or the context sourced from a different control
     // than before.
     if(this.contextTracker) {
-      this.contextTracker.clearCache();
-      this.contextTracker.analyzeState(this.lexicalModel, context, null);
+      this.contextTracker.reset(context, stateId);
     }
   }
 }


### PR DESCRIPTION
In order to transition to the context-reuse strategy specified in the [Correction-Search + Context-Tracking design doc](https://docs.google.com/document/d/1RYwgW8zI8A7VLMq40BpWYkfJJQ-i6K0MIs4QcAMxglE/edit?tab=t.0), this PR changes context-transition caching behavior to now only save the most recent transition and transitions caused by applied suggestions.  [This section in particular](https://docs.google.com/document/d/1RYwgW8zI8A7VLMq40BpWYkfJJQ-i6K0MIs4QcAMxglE/edit?tab=t.0#heading=h.c91x4fdrtk8) should provide a useful reference.  

Of note:  I was able to implement this _without_ requiring (or even _allowing_) that the base context ID be specified on incoming prediction requests, even for multitap key input!  That said, it might be wise to add the ID anyway for validation and robustness purposes.

**Note**:  known limitation - since we're no longer saving all intermediate contexts, once the context gets long and the context-window begins to slide, context cache reuse may break down.  This is addressed in the immediate followup, #14476.

@keymanapp-test-bot skip