### PR TITLE
fix(android): Get default sizes before initializing keyboard

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -495,6 +495,11 @@ public final class KMManager {
       didCopyAssets = true;
     }
 
+    calculateDefaultKeyboardHeights(context);
+    SharedPreferences prefs = context.getSharedPreferences(KMManager.KMEngine_PrefsKey, Context.MODE_PRIVATE);
+    KeyboardHeight_Context_Portrait_Current = prefs.getInt(KMManager.KMKey_KeyboardHeightPortrait, KMManager.KeyboardHeight_Context_Portrait_Default);
+    KeyboardHeight_Context_Landscape_Current = prefs.getInt(KMManager.KMKey_KeyboardHeightLandscape, KMManager.KeyboardHeight_Context_Landscape_Default);
+
     if (keyboardType == KeyboardType.KEYBOARD_TYPE_UNDEFINED) {
       String msg = "Cannot initialize: Invalid keyboard type";
       KMLog.LogError(TAG, msg);
@@ -508,12 +513,6 @@ public final class KMManager {
     migrateCloudKeyboards(appContext);
 
     CloudDownloadMgr.getInstance().initialize(appContext);
-
-    calculateDefaultKeyboardHeights(context);
-    SharedPreferences prefs = context.getSharedPreferences(KMManager.KMEngine_PrefsKey, Context.MODE_PRIVATE);
-    KeyboardHeight_Context_Portrait_Current = prefs.getInt(KMManager.KMKey_KeyboardHeightPortrait, KMManager.KeyboardHeight_Context_Portrait_Default);
-    KeyboardHeight_Context_Landscape_Current = prefs.getInt(KMManager.KMKey_KeyboardHeightLandscape, KMManager.KeyboardHeight_Context_Landscape_Default);
-
   }
 
   public static void executeResourceUpdate(Context aContext)


### PR DESCRIPTION
Fixes #14455 with @chrisvire's code suggestions. 
> I needed to move the last 4 lines of code above the call to initKeyboard. This seems like a legitimate bug (order of initialization) in KMEA.

This way the keyboard sizes are retrieved from preferences before the inapp and system keyboards are initialized.

I think this contributed to intermittent reports from FirstVoices about a squished keyboard (but couldn't get a repro).
The keyboard harness test app seems to be a good repro, so I will include for user testing

will need to :cherries: pick to stable-18.0

## User Testing
**Setup** - Install the PR builds of Keyman for Android and the KeyboardHarness test apps on the Android device/emulator (I suggest API 34)

* **TEST_KEYMAN** - Verifies default keyboard heights work
1. Launch Keyman for Android and dismiss the Get Started menu 
2. Observe the keyboard heights for both portrait and landscape orientation
3. From Keyman settings --> Adjust keyboard height --> adjust the keyboard height for both portrait and landscape orientation and then exit the menu back to Keyman
4. Verify the keyboard heights match the specified adjusted heights for both portrait and landscape orientation
5. Exit the app and relaunch Keyman for Android
6. Verify the keyboard heights still match the specified adjusted heights for both portrait and landscape orientation
7. Go back to Keyman settings --> Adjust keyboard height --> "Reset to defaults" in both portrait and landscape orientation
8. Exit the app and relaunch Keyman for Android
9. Observe the keyboard heights and verify they match the default heights for both portrait and landscape orientation (from step 2)

* **TEST_KEYBOARD_HARNESS** - Verifies the OSK is visible
1. Launch the KeyboardHarness test app
2. Verify the keyboard height is not squished
