### PR TITLE
chore(android): Update keycode test app dependencies

### DIFF
--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -6,7 +6,7 @@ ext.rootPath = '../../../'
 apply from: "$rootPath/version.gradle"
 
 android {
-    compileSdk 34
+    compileSdk 35
     namespace="com.keyman.android.tests.keyboardHarness"
 
     // Don't compress kmp files so they can be copied via AssetManager
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         applicationId "com.keyman.android.tests.keyboardHarness"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
 
         // KEYMAN_VERSION_CODE and KEYMAN_VERSION_NAME from version.gradle
         versionCode KEYMAN_VERSION_CODE as Integer

--- a/android/Tests/KeyboardHarness/build.gradle
+++ b/android/Tests/KeyboardHarness/build.gradle
@@ -15,8 +15,8 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url uri("${projectDir}/libs") }
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/android/Tests/keycode/app/build.gradle
+++ b/android/Tests/keycode/app/build.gradle
@@ -1,11 +1,18 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 ext.rootPath = '../../../'
 apply from: "$rootPath/version.gradle"
 
 android {
     compileSdk 34
-    namespace="com.keyman.android.tests.keycode"
+    namespace "com.keyman.android.tests.keycode"
+
+    buildFeatures {
+        // needed for custom BuildConfigField values in defaultConfig
+        buildConfig = true
+    }
 
     defaultConfig {
         applicationId "com.keyman.android.tests.keycode"
@@ -27,11 +34,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-
-    testImplementation 'androidx.test:core:1.5.0'
-    testImplementation 'androidx.test.ext:junit:1.1.5'
-    testImplementation 'org.robolectric:robolectric:4.10.3'
+    testImplementation 'androidx.test.ext:junit:1.2.1'
+    testImplementation 'org.robolectric:robolectric:4.14.1'
+    testImplementation 'androidx.test:core:1.6.1'
 }

--- a/android/Tests/keycode/app/src/test/java/com/keyman/android/tests/keycode/ExampleInstrumentedTest.java
+++ b/android/Tests/keycode/app/src/test/java/com/keyman/android/tests/keycode/ExampleInstrumentedTest.java
@@ -1,25 +1,25 @@
 package com.keyman.android.tests.keycode;
 
-import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.core.app.ApplicationProvider;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import android.content.Context;
 
 import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 /**
  * Instrumented test, which will execute on an Android device.
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
-@RunWith(AndroidJUnit4.class)
+@RunWith(RobolectricTestRunner.class)
 public class ExampleInstrumentedTest {
   @Test
   public void useAppContext() {
     // Context of the app under test.
-    Context appContext = InstrumentationRegistry.getTargetContext();
+    Context appContext = ApplicationProvider.getApplicationContext();
 
     assertEquals("com.keyman.android.tests.keycode", appContext.getPackageName());
   }

--- a/android/Tests/keycode/app/src/test/java/com/keyman/android/tests/keycode/ExampleUnitTest.java
+++ b/android/Tests/keycode/app/src/test/java/com/keyman/android/tests/keycode/ExampleUnitTest.java
@@ -1,4 +1,4 @@
-package com.example.darcy.keycode;
+package com.keyman.android.tests.keycode;
 
 import org.junit.Test;
 

--- a/android/Tests/keycode/build.gradle
+++ b/android/Tests/keycode/build.gradle
@@ -4,10 +4,10 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.9.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -18,10 +18,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
 }

--- a/android/Tests/keycode/gradle.properties
+++ b/android/Tests/keycode/gradle.properties
@@ -14,4 +14,6 @@ org.gradle.jvmargs=-Xmx1024m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
+# AGP 8.0 generates R classes for resources defined in the current module only.
+android.nonTransitiveRClass=false
 


### PR DESCRIPTION
Related to #13858

The keycode test app is a standalone test project for displaying key codes. (Does not use Keyman Engine for Android).
Hence, this project doesn't really get maintained when updating project dependencies.

THis PR updates the project's dependencies so it will compile in Android Studio. No test-bot artifacts since the project doesn't get attached.
Part of the cleanup is also updating the stubbed tests to use RobolectricTestRunner (conforms to our other Android projects)

Test-bot: skip
Build-bot: skip
