### PR TITLE
maint(android): publish symbols to Sentry on release buildLevel 🦌

### DIFF
--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -28,8 +28,8 @@ builder_describe "Builds Keyman for Android app." \
   "configure" \
   "build" \
   "test             Runs lint and unit tests." \
-  "publish          Publishes symbols to Sentry and the APK to the Play Store." \
-  "--upload-sentry  Upload to sentry"
+  "publish-symbols  Publishes symbols to Sentry." \
+  "publish-play-store  Publishes the APK to the Play Store."
 
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
@@ -53,18 +53,6 @@ builder_describe_outputs \
 if builder_is_ci_build; then
   DAEMON_FLAG=--no-daemon
 fi
-
-#### Build action definitions ####
-
-function makeLocalSentryRelease() {
-  echo "Making a Sentry release for tag $KEYMAN_VERSION_GIT_TAG"
-  sentry-cli upload-dif -p keyman-android --include-sources
-  sentry-cli releases -p keyman-android files $KEYMAN_VERSION_GIT_TAG upload-sourcemaps ./
-
-  echo "Finalizing release tag $KEYMAN_VERSION_GIT_TAG"
-  sentry-cli releases finalize "$KEYMAN_VERSION_GIT_TAG"
-}
-
 
 #### Build action definitions ####
 
@@ -98,10 +86,6 @@ if builder_start_action build; then
   echo "BUILD_FLAGS $BUILD_FLAGS"
   ./gradlew $DAEMON_FLAG clean $BUILD_FLAGS
 
-  if builder_has_option --upload-sentry; then
-    makeLocalSentryRelease
-  fi
-
   builder_finish_action success build
 fi
 
@@ -113,12 +97,23 @@ if builder_start_action test; then
   builder_finish_action success test
 fi
 
-if builder_start_action publish; then
-  # Copy Release Notes
-  generateReleaseNotes
+publish_symbols() {
+  if builder_is_ci_build && builder_is_ci_build_level_release; then
+    # TODO: what does publishSentry even do?
+    ./gradlew $DAEMON_FLAG publishSentry
+    builder_echo "Making a Sentry release for tag $KEYMAN_VERSION_GIT_TAG"
+    sentry-cli upload-dif -p keyman-android --include-sources
+    sentry-cli releases -p keyman-android files $KEYMAN_VERSION_GIT_TAG upload-sourcemaps ./
+  fi
+}
 
-  # Publish symbols and Keyman for Android to Play Store
-  ./gradlew $DAEMON_FLAG publishSentry publishReleaseApk
+publish_play_store() {
+  if builder_is_ci_build && builder_is_ci_build_level_release; then
+    generateReleaseNotes
+    # Publish Keyman for Android to Play Store
+    ./gradlew $DAEMON_FLAG publishReleaseApk
+  fi
+}
 
-  builder_finish_action success publish
-fi
+builder_run_action publish-symbols      publish_symbols
+builder_run_action publish-play-store  publish_play_store

--- a/android/build.sh
+++ b/android/build.sh
@@ -38,9 +38,9 @@ builder_describe \
   configure \
   build \
   test \
-  "publish                                  Publishes symbols to Sentry and the APKs to the Play Store." \
+  "publish-symbols                          Publishes symbols to Sentry" \
+  "publish-play-store                       Publishes APKs to the Play Store" \
   "archive                                  Copy release artifacts to upload/ and create zip" \
-  --upload-sentry+ \
   ":engine=KMEA                             Keyman Engine for Android" \
   ":app=KMAPro                              Keyman for Android" \
   ":help                                    Online documentation" \
@@ -120,6 +120,6 @@ builder_run_child_actions configure build test
 
 builder_run_action        test:help  do_test_help
 
-builder_run_child_actions publish
+builder_run_child_actions publish-symbols publish-play-store
 
 builder_run_action        archive    archive_artifacts

--- a/oem/firstvoices/android/build.sh
+++ b/oem/firstvoices/android/build.sh
@@ -25,8 +25,9 @@ builder_describe "Builds FirstVoices for Android app." \
   "clean" \
   "configure" \
   "build" \
-  "test             Runs lint and tests." \
-  "publish          Publishes symbols to Sentry and the APK to the Play Store."
+  "test               Runs lint and tests." \
+  "publish-symbols    Publishes symbols to Sentry." \
+  "publish-play-store Publishes the APK to the Play Store."
 
 # parse before describe_outputs to check debug flags
 builder_parse "$@"
@@ -87,5 +88,24 @@ if builder_start_action test; then
   builder_finish_action success test
 fi
 
-builder_run_action publish    ./gradlew $DAEMON_FLAG publishSentry publishReleaseApk
+publish_symbols() {
+  if builder_is_ci_build && builder_is_ci_build_level_release; then
+    # TODO: what does publishSentry even do?
+    ./gradlew $DAEMON_FLAG publishSentry
+
+    echo "Making a Sentry release for FV Keyboards for tag $KEYMAN_VERSION_GIT_TAG"
+    sentry-cli upload-dif -p fv-android --include-sources
+    sentry-cli releases -p fv-android files $KEYMAN_VERSION_GIT_TAG upload-sourcemaps ./
+  fi
+}
+
+publish_play_store() {
+  if builder_is_ci_build && builder_is_ci_build_level_release; then
+    # Publish FV Keyboards to Play Store
+    ./gradlew $DAEMON_FLAG publishReleaseApk
+  fi
+}
+
+builder_run_action publish-symbols       publish_symbols
+builder_run_action publish-play-store    publish_play_store
 

--- a/resources/teamcity/android/android-actions.inc.sh
+++ b/resources/teamcity/android/android-actions.inc.sh
@@ -17,3 +17,12 @@ android_build_action() {
   "${KEYMAN_ROOT}/android/build.sh" configure build,test:"${TARGETS}" ${ARGS}
   builder_echo end "build" success "Finished building Keyman for Android"
 }
+
+android_publish_symbols() {
+  local PUBTARGETS="$1"
+  builder_echo start "publish to Sentry" "Publishing release to Sentry"
+
+  "${KEYMAN_ROOT}/android/build.sh" "publish-symbols:${PUBTARGETS}"
+
+  builder_echo end "publish to Sentry" success "Finished publishing release to Sentry"
+}

--- a/resources/teamcity/android/keyman-android-release.sh
+++ b/resources/teamcity/android/keyman-android-release.sh
@@ -66,7 +66,7 @@ function _publish_to_playstore() {
   local PUBTARGETS="$1"
   builder_echo start "publish to Google Play Store" "Publishing release to Google Play Store"
 
-  "${KEYMAN_ROOT}/android/build.sh" "publish:${PUBTARGETS}"
+  "${KEYMAN_ROOT}/android/build.sh" "publish-play-store:${PUBTARGETS}"
 
   builder_echo end "publish to Google Play Store" success "Finished publishing release to Google Play Store"
 }
@@ -93,6 +93,7 @@ function do_publish() {
 
   _create_zip_archive
   _publish_to_downloads_keyman_com
+  android_publish_symbols "${PUBTARGETS}"
   _publish_to_playstore "${PUBTARGETS}"
   tc_upload_help "Keyman for Android" android
 }

--- a/resources/teamcity/android/keyman-android-test.sh
+++ b/resources/teamcity/android/keyman-android-test.sh
@@ -23,7 +23,8 @@ builder_describe \
   "--fv           additionally build and Test FV Android" \
   "all            run all actions" \
   "clean          clean artifact directories" \
-  "build          configure, build and test Keyman for Android"
+  "build          configure, build and test Keyman for Android" \
+  "publish        publish symbols to Sentry (for release buildLevel)"
 
 builder_parse "$@"
 
@@ -39,7 +40,9 @@ fi
 if builder_has_action all; then
   android_clean_action
   android_build_action "${TARGETS}" --debug
+  android_publish_symbols "${TARGETS}" --debug
 else
-  builder_run_action  clean   android_clean_action
-  builder_run_action  build   android_build_action "${TARGETS}" --debug
+  builder_run_action  clean     android_clean_action
+  builder_run_action  build     android_build_action "${TARGETS}" --debug
+  builder_run_action  publish   android_publish_symbols "${TARGETS}" --debug
 fi


### PR DESCRIPTION
Refactor the publish action for Android to ensure that symbols are published to Sentry for any 'release' buildLevel -- test releases and alpha/beta/stable releases.

Splits the publish action into `publish-symbols` and `publish-play-store` so that they can be run separately as needed, as symbols can be published for test builds, but play store is only touched for actual releases.

Note: examining the build logs and Sentry server state, it looks like the publish to Sentry has not been happening for quite a while, so this commit refactors the Sentry publishing code and establishes the fv-keyboards publish target also.

Fixes: #14284
Blocked-by: #14506
Build-bot: release
Test-bot: skip