### PR TITLE
chore(android): Specify Java language version 21

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -11,6 +11,12 @@ apply from: "$rootPath/version.gradle"
 
 String tier = new File('../../TIER.md').getText('UTF-8').trim();
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 android {
     compileSdk 34
     namespace="com.tavultesoft.kmapro"
@@ -22,11 +28,6 @@ android {
 
     buildFeatures {
         buildConfig = true
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
     }
 
     defaultConfig {

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -12,6 +12,12 @@ base {
     archivesName = "keyman-engine"
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 android {
     compileSdk 34
     namespace "com.keyman.engine"
@@ -19,11 +25,6 @@ android {
     buildFeatures {
         // needed for custom BuildConfigField values in defaultConfig
         buildConfig = true
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
     }
 
     defaultConfig {

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id 'com.android.application'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 android {
     compileSdk 34
     namespace="com.keyman.kmsample1"

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id 'com.android.application'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 android {
     compileSdk 34
     namespace="com.keyman.kmsample2"

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -5,6 +5,12 @@ plugins {
 ext.rootPath = '../../../'
 apply from: "$rootPath/version.gradle"
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 android {
     compileSdk 34
     namespace="com.keyman.android.tests.keyboardHarness"

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -7,6 +7,12 @@ plugins {
 ext.rootPath = '../../../../android'
 apply from: "$rootPath/version.gradle"
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 android {
     compileSdk 34
     namespace="com.firstvoices.keyboards"


### PR DESCRIPTION
Fixes #14486 

Resolves Gradle deprecation and language version warnings
```gradle
Java compiler version 21 has deprecated support for compiling with source/target version 8.
```

The `java.toolchain.languageVersion` syntax is a superset that covers the previous syntax `android.compileOptions` (which was missing in the Sample and FirstVoices projects)

### Reference
https://docs.gradle.org/current/userguide/toolchains.html


Verified with local Android builds
`./build.sh build`
and saw no more warnings about source/target version 8.

Test-bot: skip
