### PR TITLE
maint(resources): add build-bot commands to increment-version auto PRs

### DIFF
--- a/.github/workflows/auto-merge-keyman-server-pr.yml
+++ b/.github/workflows/auto-merge-keyman-server-pr.yml
@@ -8,8 +8,7 @@
 #
 name: Auto Merge PRs from keyman-server
 on:
-  pull_request:
-    types: [opened]
+- pull_request
 
 jobs:
   build:
@@ -17,11 +16,11 @@ jobs:
     if: ${{ github.repository == 'keymanapp/keyman' && github.actor == 'keyman-server' && startsWith(github.event.pull_request.title, 'auto:') }}
     steps:
     - name: auto approve PR from keyman-server
-      uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363
+      uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363  # v4.0.0
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"
     - name: auto merge PR from keyman-server
-      uses: "pascalgn/automerge-action@7854d3bd607dccdaf0b2c134b699a812c8960213"
+      uses: "pascalgn/automerge-action@7854d3bd607dccdaf0b2c134b699a812c8960213"  # v0.7.3
       env:
         GITHUB_TOKEN: "${{ secrets.AUTOINC_GITHUB_TOKEN }}"
         MERGE_LABELS: "automerge"

--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -136,7 +136,7 @@ if [ "$action" == "commit" ]; then
   NEWVERSION=`cat $KEYMAN_VERSION_MD | tr -d "[:space:]"`
 
   pushd "$KEYMAN_ROOT" > /dev/null
-  message="auto: increment $base version to $NEWVERSION"
+  message="auto: increment $base version to $NEWVERSION"$'\n\nTest-bot:skip\nBuild-bot: skip'
   branch="auto/version-$base-$NEWVERSION"
   git tag -a "$KEYMAN_VERSION_GIT_TAG" -m "Keyman release $KEYMAN_VERSION_WITH_TAG"
   git checkout -b "$branch"


### PR DESCRIPTION
Note: this does not remove auto merge from the auto-merge-keyman-server-pr.yml GHA at this time, because that would require us to use graphql to mark PRs as auto-merge, and we are not quite ready to do that. So we'll continue to use the automerge action for now.

The scope for pull request events has been expanded on auto-merge-keyman-server-pr.yml so that updates to build status trigger the automerge as needed.

Fixes: #14502
Build-bot: skip
Test-bot: skip