### PR TITLE
maint(web): converts worker-thread tests to TS

### DIFF
--- a/common/test/resources/model-helpers.mjs
+++ b/common/test/resources/model-helpers.mjs
@@ -19,7 +19,9 @@ import { fileURLToPath } from 'url';
 /**
  * Creates a MessageEvent (for inter-worker communication), with the given data payload.
  *
- * @param {*} data
+ * @template {T}
+ * @param {T} data
+ * @returns {T}
  */
 export function createMessageEventWithData(data) {
   return { data };

--- a/web/src/engine/predictive-text/worker-thread/build.sh
+++ b/web/src/engine/predictive-text/worker-thread/build.sh
@@ -12,6 +12,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
+. "$KEYMAN_ROOT/web/common.inc.sh"
 
 WORKER_OUTPUT=build/obj
 WORKER_OUTPUT_FILENAME=build/lib/worker-main.js
@@ -24,6 +25,8 @@ bundle_cmd="node ${KEYMAN_ROOT}/web/src/tools/es-bundling/build/common-bundle.mj
 SRCMAP_CLEANER="node $KEYMAN_ROOT/web/build/tools/building/sourcemap-root/index.js"
 
 ################################ Main script ################################
+
+SUBPROJECT_NAME=engine/predictive-text/worker-thread
 
 builder_describe \
   "Compiles the Language Modeling Layer for common use in predictive text and autocorrective applications." \
@@ -92,12 +95,10 @@ function do_build() {
 }
 
 function do_test() {
-  local MOCHA_FLAGS=
   local WTR_CONFIG=
   local WTR_INSPECT=
 
   if builder_is_ci_build; then
-    MOCHA_FLAGS="$MOCHA_FLAGS --reporter mocha-teamcity-reporter"
     WTR_CONFIG=.CI
   fi
 
@@ -105,7 +106,7 @@ function do_test() {
     WTR_INSPECT=" --manual"
   fi
 
-  c8 mocha --recursive $MOCHA_FLAGS ./src/tests/mocha/cases/
+  test-headless-typescript $SUBPROJECT_NAME
 
   web-test-runner --config ./src/tests/test-runner/web-test-runner${WTR_CONFIG}.config.mjs ${WTR_INSPECT}
 }

--- a/web/src/engine/predictive-text/worker-thread/package.json
+++ b/web/src/engine/predictive-text/worker-thread/package.json
@@ -10,6 +10,9 @@
     "./worker-main.wrapped.min.js": {
       "types": "./build/lib/worker-main.wrapped.d.ts",
       "default": "./build/lib/worker-main.wrapped.min.js"
+    },
+    "./test-index": {
+      "default": "./build/obj/test-index.js"
     }
   },
   "imports": {

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tracker.ts
@@ -629,7 +629,7 @@ export class ContextTracker extends CircularArray<TrackedContextState> {
     };
   }
 
-  private static modelContextState(
+  static modelContextState(
     tokenizedContext: Token[],
     lexicalModel: LexicalModel
   ): TrackedContextState {

--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -10,15 +10,17 @@ import { LexicalModelTypes } from '@keymanapp/common-types';
 import CasingForm = LexicalModelTypes.CasingForm;
 import Context = LexicalModelTypes.Context;
 import Distribution = LexicalModelTypes.Distribution;
+import Keep = LexicalModelTypes.Keep;
 import LexicalModel = LexicalModelTypes.LexicalModel;
 import LexicalModelPunctuation = LexicalModelTypes.LexicalModelPunctuation;
+import Outcome = LexicalModelTypes.Outcome;
 import Reversion = LexicalModelTypes.Reversion;
 import Suggestion = LexicalModelTypes.Suggestion;
 import Transform = LexicalModelTypes.Transform;
 
 export class ModelCompositor {
   private lexicalModel: LexicalModel;
-  private contextTracker?: correction.ContextTracker;
+  public contextTracker?: correction.ContextTracker;
 
   static readonly MAX_SUGGESTIONS = 12;
   readonly punctuation: LexicalModelPunctuation;
@@ -66,7 +68,7 @@ export class ModelCompositor {
     this.testMode = !!testMode;
   }
 
-  async predict(transformDistribution: Transform | Distribution<Transform>, context: Context): Promise<Suggestion[]> {
+  async predict(transformDistribution: Transform | Distribution<Transform>, context: Context): Promise<Outcome<Suggestion|Keep>[]> {
     const lexicalModel = this.lexicalModel;
 
     // If a prior prediction is still processing, signal to terminate it; we have a new
@@ -193,7 +195,7 @@ export class ModelCompositor {
   }
 
   // Responsible for applying casing rules to suggestions.
-  private applySuggestionCasing(suggestion: Suggestion, baseWord: string, casingForm: CasingForm) {
+  applySuggestionCasing(suggestion: Suggestion, baseWord: string, casingForm: CasingForm) {
     // Step 1:  does the suggestion replace the whole word?  If not, we should extend the suggestion to do so.
     let unchangedLength  = KMWString.length(baseWord) - suggestion.transform.deleteLeft;
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/models/index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/models/index.ts
@@ -1,2 +1,2 @@
 export * from '@keymanapp/models-templates';
-export { default as DummyModel } from './dummy-model.js';
+export { default as DummyModel, DummyOptions } from './dummy-model.js';

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -59,10 +59,10 @@ export const CORRECTION_SEARCH_THRESHOLDS = {
 }
 
 export type CorrectionPredictionTuple = {
-  prediction: ProbabilityMass<Suggestion>,
+  prediction: ProbabilityMass<Outcome<Suggestion | Keep>>,
   correction: ProbabilityMass<string>,
   totalProb: number;
-  matchLevel: SuggestionSimilarity;
+  matchLevel?: SuggestionSimilarity;
   preservationTransform?: Transform;
 };
 
@@ -75,7 +75,7 @@ export enum SuggestionSimilarity {
 
 export function tupleDisplayOrderSort(a: CorrectionPredictionTuple, b: CorrectionPredictionTuple) {
   // Similarity distance
-  const simDist = b.matchLevel - a.matchLevel;
+  const simDist = b.matchLevel ?? 0 - a.matchLevel ?? 0;
   if(simDist != 0) {
     return simDist;
   }

--- a/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
@@ -1,0 +1,10 @@
+export { ClassicalDistanceCalculation } from './correction/classical-calculation.js';
+export { ContextTracker } from './correction/context-tracker.js';
+export * as correction from './correction/index.js';
+export * from './model-helpers.js';
+export * as models from './models/index.js';
+export { ModelCompositor } from './model-compositor.js';
+export { tokenizeTransform, tokenizeTransformDistribution } from './correction/transform-tokenization.js';
+export * from './predict-helpers.js';
+export { default as TransformUtils } from './transformUtils.js'
+export { default as LMLayerWorker } from './index.js'

--- a/web/src/engine/predictive-text/worker-thread/src/main/worker-interfaces.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/worker-interfaces.ts
@@ -42,8 +42,8 @@ import { Token } from '@keymanapp/models-templates';
 /**
  * The signature of self.postMessage(), so that unit tests can mock it.
  */
-export type PostMessage = typeof DedicatedWorkerGlobalScope.prototype.postMessage;
-export type ImportScripts = typeof DedicatedWorkerGlobalScope.prototype.importScripts;
+export type PostMessage = (message: any, extra?: any) => void;
+export type ImportScripts = (...urls: string[]) => void;
 
 
 /**

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/classical-calculation.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/classical-calculation.tests.ts
@@ -1,7 +1,9 @@
 import { assert } from 'chai';
-import { ClassicalDistanceCalculation } from '#./correction/classical-calculation.js';
+import { ClassicalDistanceCalculation } from '@keymanapp/lm-worker/test-index';
 
-function prettyPrintMatrix(matrix) {
+// Very useful for diagnosing unit test issues when path inspection is needed.
+// Not currently used ('cause that's noisy during test runs).
+export function prettyPrintMatrix(matrix: number[][]) {
   for(let r = 0; r < matrix.length; r++) {
     console.log(JSON.stringify(matrix[r], function(key, value) {
       if(value == Number.MAX_VALUE) {
@@ -15,7 +17,7 @@ function prettyPrintMatrix(matrix) {
   }
 }
 
-function compute(input, match, mode, bandSize) {
+function compute(input: string, match: string, mode?: string, bandSize?: number) {
   let buffer = new ClassicalDistanceCalculation();
 
   /* SUPPORTED MODES:

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/early-correction-search-stopping.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/early-correction-search-stopping.tests.ts
@@ -1,7 +1,6 @@
 import { assert } from 'chai';
 
-import { CORRECTION_SEARCH_THRESHOLDS, shouldStopSearchingEarly } from "#./predict-helpers.js";
-import { ModelCompositor } from '#./model-compositor.js';
+import { CORRECTION_SEARCH_THRESHOLDS, CorrectionPredictionTuple, ModelCompositor, shouldStopSearchingEarly } from "@keymanapp/lm-worker/test-index";
 
 describe('correction-search: shouldStopSearchingEarly', () => {
   it('stops early once new corrections are less likely than currently discovered predictions', () => {
@@ -17,7 +16,7 @@ describe('correction-search: shouldStopSearchingEarly', () => {
     const predictions = predictionProbs.map((entry) => {
       return {
         totalProb: entry
-      }
+      } as CorrectionPredictionTuple
     });
 
     // Thresholding is performed in log-space.
@@ -34,8 +33,8 @@ describe('correction-search: shouldStopSearchingEarly', () => {
     //
     // Can technically run the method with an empty array, but the actual scenario would have
     // at least one prediction present in the "found predictions" array.
-    assert.isFalse(shouldStopSearchingEarly(baseCost, baseCost + expectedThreshold - 0.01, [{ totalProb: Math.exp(-1) }]));
-    assert.isTrue(shouldStopSearchingEarly( baseCost, baseCost + expectedThreshold + 0.01, [{ totalProb: Math.exp(-1) }]));
+    assert.isFalse(shouldStopSearchingEarly(baseCost, baseCost + expectedThreshold - 0.01, [{ totalProb: Math.exp(-1) } as CorrectionPredictionTuple]));
+    assert.isTrue(shouldStopSearchingEarly( baseCost, baseCost + expectedThreshold + 0.01, [{ totalProb: Math.exp(-1) } as CorrectionPredictionTuple]));
   });
 
   it('stops checking corrections earlier when enough predictions have been found', () => {
@@ -47,7 +46,7 @@ describe('correction-search: shouldStopSearchingEarly', () => {
     const predictions = predictionProbs.map((entry) => {
       return {
         totalProb: entry
-      }
+      } as CorrectionPredictionTuple
     });
 
     const baseCost = 1;

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/execution-timer.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/execution-timer.tests.ts
@@ -1,11 +1,12 @@
 import { assert } from 'chai';
-import { useFakeTimers } from 'sinon';
+import { useFakeTimers, type SinonFakeTimers } from 'sinon';
 
-import { ExecutionBucket, ExecutionTimer } from '#./correction/index.js';
+import { correction } from '@keymanapp/lm-worker/test-index';
+import ExecutionBucket = correction.ExecutionBucket;
+import ExecutionTimer = correction.ExecutionTimer;
 
 describe('ExecutionTimer', () => {
-  /** @type {import('sinon').SinonFakeTimers} */
-  let timeControl;
+  let timeControl: SinonFakeTimers;
 
   beforeEach(() => {
     timeControl = useFakeTimers();
@@ -92,7 +93,7 @@ describe('ExecutionTimer', () => {
   it('defer() - alternate setup', async () => {
     const timer = new ExecutionTimer(50, 100);
 
-    const delaySetup = new Promise(async (resolve) => {
+    const delaySetup = new Promise<void>(async (resolve) => {
       // The passed-in function does not delay by default; this will wait for
       // one microtask delay before proceeding.
       //

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/auto-correct.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/auto-correct.tests.ts
@@ -1,6 +1,6 @@
-import { AUTOSELECT_PROPORTION_THRESHOLD, SuggestionSimilarity, predictionAutoSelect, tupleDisplayOrderSort } from "#./predict-helpers.js";
 import { assert } from 'chai';
 
+import { AUTOSELECT_PROPORTION_THRESHOLD, CorrectionPredictionTuple, predictionAutoSelect, SuggestionSimilarity, tupleDisplayOrderSort } from "@keymanapp/lm-worker/test-index";
 /*
   * Preconditions:
   * - there should always be a 'keep' option.  Now, whether or not that option
@@ -9,10 +9,7 @@ import { assert } from 'chai';
   */
 describe('predictionAutoSelect', () => {
   it(`does not throw when no suggestions are available`, () => {
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
-     */
-    const predictions = [];
+    const predictions: CorrectionPredictionTuple[] = [];
     const originalPredictions = [].concat(predictions);
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
 
@@ -20,10 +17,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`selects solitary 'keep' suggestion that does match the model`, () => {
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
-     */
-    const predictions = [
+    const predictions: CorrectionPredictionTuple[] = [
       {
         correction: {
           sample: 'apple', // can be null / "mocked out"
@@ -36,7 +30,8 @@ describe('predictionAutoSelect', () => {
               insert: 'e',
               deleteLeft: 0
             },
-            matchesModel: true
+            matchesModel: true,
+            displayAs: 'apple'
           },
           p: 1
         },
@@ -53,10 +48,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`does not select solitary 'keep' suggestion that doesn't match the model`, () => {
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
-     */
-    const predictions = [
+    const predictions: CorrectionPredictionTuple[] = [
       {
         correction: {
           sample: 'appl', // can be null / "mocked out"
@@ -69,7 +61,8 @@ describe('predictionAutoSelect', () => {
               insert: 'l',
               deleteLeft: 0
             },
-            matchesModel: false
+            matchesModel: false,
+            displayAs: ''
           },
           p: 1
         },
@@ -86,10 +79,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`selects 'keep' suggestion that does match the model over any alternatives`, () => {
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
-     */
-    const keepSuggestion = {
+    const keepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'thin', // can be null / "mocked out"
         p: .8
@@ -101,14 +91,15 @@ describe('predictionAutoSelect', () => {
             insert: 'n',
             deleteLeft: 0
           },
-          matchesModel: true
+          matchesModel: true,
+          displayAs: ''
         },
         p: .05
       },
       totalProb: .04
     }
 
-    const highestNonKeepSuggestion = {
+    const highestNonKeepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'thin', // can be null / "mocked out"
         p: .8
@@ -119,16 +110,14 @@ describe('predictionAutoSelect', () => {
             insert: 'nk',
             deleteLeft: 0
           },
+          displayAs: ''
         },
         p: .55
       },
       totalProb: .44
     };
 
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
-     */
-    const predictions = [
+    const predictions: CorrectionPredictionTuple[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       {
@@ -142,6 +131,7 @@ describe('predictionAutoSelect', () => {
               insert: 'ng',
               deleteLeft: 0
             },
+            displayAs: ''
           },
           p: .4
         },
@@ -158,6 +148,7 @@ describe('predictionAutoSelect', () => {
               insert: 'ck',
               deleteLeft: 0
             },
+            displayAs: ''
           },
           p: 1
         },
@@ -176,10 +167,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`selects solitary non-'keep' suggestion when 'keep' does not match model`, () => {
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
-     */
-    const keepSuggestion = {
+    const keepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'thin', // can be null / "mocked out"
         p: .8
@@ -191,6 +179,7 @@ describe('predictionAutoSelect', () => {
             insert: 'n',
             deleteLeft: 0
           },
+          displayAs: '',
           matchesModel: false
         },
         p: .05
@@ -202,7 +191,7 @@ describe('predictionAutoSelect', () => {
     // This threshold may be subject to change.
     //
     // Refer to AUTOSELECT_PROPORTION_THRESHOLD in predict-helpers.ts.
-    const onlyNonKeepSuggestion = {
+    const onlyNonKeepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'thin', // can be null / "mocked out"
         p: .8
@@ -213,16 +202,14 @@ describe('predictionAutoSelect', () => {
             insert: 'nk',
             deleteLeft: 0
           },
+          displayAs: ''
         },
         p: .01
       },
       totalProb: .008
     };
 
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
-     */
-    const predictions = [
+    const predictions: CorrectionPredictionTuple[] = [
       keepSuggestion,
       onlyNonKeepSuggestion
     ];
@@ -241,10 +228,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`does not select non-'keep' without sufficient winning probability`, () => {
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
-     */
-    const keepSuggestion = {
+    const keepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'thin', // can be null / "mocked out"
         p: .8
@@ -256,6 +240,7 @@ describe('predictionAutoSelect', () => {
             insert: 'n',
             deleteLeft: 0
           },
+          displayAs: '',
           matchesModel: false
         },
         p: .05
@@ -267,7 +252,7 @@ describe('predictionAutoSelect', () => {
     // This threshold may be subject to change.
     //
     // Refer to AUTOSELECT_PROPORTION_THRESHOLD in predict-helpers.ts.
-    const highestNonKeepSuggestion = {
+    const highestNonKeepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'thin', // can be null / "mocked out"
         p: .8
@@ -278,16 +263,14 @@ describe('predictionAutoSelect', () => {
             insert: 'nk',
             deleteLeft: 0
           },
+          displayAs: ''
         },
         p: .55
       },
       totalProb: .44
     };
 
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
-     */
-    const predictions = [
+    const predictions: CorrectionPredictionTuple[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       {
@@ -301,6 +284,7 @@ describe('predictionAutoSelect', () => {
               insert: 'ng',
               deleteLeft: 0
             },
+            displayAs: ''
           },
           p: .4
         },
@@ -317,6 +301,7 @@ describe('predictionAutoSelect', () => {
               insert: 'ck',
               deleteLeft: 0
             },
+            displayAs: ''
           },
           p: 1
         },
@@ -338,10 +323,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`does select non-'keep' with sufficient winning probability`, () => {
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
-     */
-    const keepSuggestion = {
+    const keepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'thin', // can be null / "mocked out"
         p: .8
@@ -353,6 +335,7 @@ describe('predictionAutoSelect', () => {
             insert: 'n',
             deleteLeft: 0
           },
+          displayAs: '',
           matchesModel: false
         },
         p: .05
@@ -360,7 +343,7 @@ describe('predictionAutoSelect', () => {
       totalProb: .04
     }
 
-    const highestNonKeepSuggestion = {
+    const highestNonKeepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'thin', // can be null / "mocked out"
         p: .9
@@ -371,16 +354,14 @@ describe('predictionAutoSelect', () => {
             insert: 'nk',
             deleteLeft: 0
           },
+          displayAs: ''
         },
         p: .75
       },
       totalProb: .675
     };
 
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
-     */
-    const predictions = [
+    const predictions: CorrectionPredictionTuple[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       {
@@ -394,6 +375,7 @@ describe('predictionAutoSelect', () => {
               insert: 'ng',
               deleteLeft: 0
             },
+            displayAs: ''
           },
           p: .2
         },
@@ -410,6 +392,7 @@ describe('predictionAutoSelect', () => {
               insert: 'ck',
               deleteLeft: 0
             },
+            displayAs: ''
           },
           p: 1
         },
@@ -420,10 +403,13 @@ describe('predictionAutoSelect', () => {
     const totalProb = predictions.reduce((accum, current) => accum + current.totalProb, 0);
     assert.isAbove(highestNonKeepSuggestion.totalProb, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
 
-    predictions.sort(tupleDisplayOrderSort);
-
     const originalPredictions = [].concat(predictions);
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
+
+    // Sort after - we need the 'keep' to remain in the first position.
+    predictions.sort(tupleDisplayOrderSort);
+    originalPredictions.sort(tupleDisplayOrderSort);
+
     assert.sameDeepOrderedMembers(predictions, originalPredictions);
 
     const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
@@ -431,10 +417,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it('ignores non key-matched suggestions when key-matched suggestions exist', () => {
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
-     */
-    const keepSuggestion = {
+    const keepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'cant', // can be null / "mocked out"
         p: 1
@@ -446,6 +429,7 @@ describe('predictionAutoSelect', () => {
             insert: 't',
             deleteLeft: 0
           },
+          displayAs: '',
           matchesModel: false
         },
         p: 1
@@ -454,7 +438,7 @@ describe('predictionAutoSelect', () => {
       matchLevel: SuggestionSimilarity.exact
     }
 
-    const expectedSuggestion = {
+    const expectedSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'cant', // can be null / "mocked out"
         p: 1
@@ -465,6 +449,7 @@ describe('predictionAutoSelect', () => {
             insert: '\'t',
             deleteLeft: 0
           },
+          displayAs: ''
         },
         p: .2
       },
@@ -472,10 +457,7 @@ describe('predictionAutoSelect', () => {
       matchLevel: SuggestionSimilarity.sameKey
     };
 
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
-     */
-    const predictions = [
+    const predictions: CorrectionPredictionTuple[] = [
       keepSuggestion,
       expectedSuggestion,
       {
@@ -489,6 +471,7 @@ describe('predictionAutoSelect', () => {
               insert: 'teen',
               deleteLeft: 0
             },
+            displayAs: ''
           },
           p: .8
         },
@@ -497,10 +480,11 @@ describe('predictionAutoSelect', () => {
       }
     ];
 
-    predictions.sort(tupleDisplayOrderSort);
-
     const originalPredictions = [].concat(predictions);
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
+
+    predictions.sort(tupleDisplayOrderSort);
+    originalPredictions.sort(tupleDisplayOrderSort);
     assert.sameDeepOrderedMembers(predictions, originalPredictions);
 
     const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
@@ -510,10 +494,7 @@ describe('predictionAutoSelect', () => {
   // The idea:  avoid "over-correcting" when a potential correction has a
   // super-high-frequency word.
   it('does not auto-select suggestion if its root correction is not most likely', () => {
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple}
-     */
-    const keepSuggestion = {
+    const keepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'thi', // can be null / "mocked out"
         p: .7
@@ -525,6 +506,7 @@ describe('predictionAutoSelect', () => {
             insert: 'i',
             deleteLeft: 0
           },
+          displayAs: '',
           matchesModel: false
         },
         p: .05
@@ -532,7 +514,7 @@ describe('predictionAutoSelect', () => {
       totalProb: .035
     }
 
-    const highestCorrectionSuggestion = {
+    const highestCorrectionSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'thi', // can be null / "mocked out"
         p: .7
@@ -543,13 +525,14 @@ describe('predictionAutoSelect', () => {
             insert: 'in',
             deleteLeft: 0
           },
+          displayAs: ''
         },
         p: .1
       },
       totalProb: .07
     };
 
-    const highestNonKeepSuggestion = {
+    const highestNonKeepSuggestion: CorrectionPredictionTuple = {
       correction: {
         sample: 'the', // can be null / "mocked out"
         p: .3
@@ -560,16 +543,14 @@ describe('predictionAutoSelect', () => {
             insert: 'e',
             deleteLeft: 0
           },
+          displayAs: ''
         },
         p: 1
       },
       totalProb: .3
     };
 
-    /**
-     * @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]}
-     */
-    const predictions = [
+    const predictions: CorrectionPredictionTuple[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       highestCorrectionSuggestion
@@ -578,10 +559,12 @@ describe('predictionAutoSelect', () => {
     const totalProb = predictions.reduce((accum, current) => accum + current.totalProb, 0);
     assert.isAbove(highestNonKeepSuggestion.totalProb, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
 
-    predictions.sort(tupleDisplayOrderSort);
-
     const originalPredictions = [].concat(predictions);
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
+
+    predictions.sort(tupleDisplayOrderSort);
+    originalPredictions.sort(tupleDisplayOrderSort);
+
     assert.sameDeepOrderedMembers(predictions, originalPredictions);
 
     const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/casing-detection.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/casing-detection.tests.ts
@@ -1,8 +1,9 @@
 import { assert } from 'chai';
-import { ModelCompositor } from '#./model-compositor.js';
 
-import { detectCurrentCasing } from "#./model-helpers.js";
-import { DummyModel } from "#./models/dummy-model.js";
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import { detectCurrentCasing, ModelCompositor, models } from '@keymanapp/lm-worker/test-index';
+
+import DummyModel = models.DummyModel;
 
 const defaultCasingModel = new DummyModel({
   languageUsesCasing: true,
@@ -37,8 +38,7 @@ const defaultCasingModel = new DummyModel({
   }
 });
 
-/** @type {CasingFunction} */
-const leetCasing = (casing, text) => {
+const leetCasing: LexicalModelTypes.CasingFunction = (casing, text) => {
   // Don't know if there's a standard analogue for '9', but this'll work well enough.
   const plain = ['O', 'L', 'Z', 'E', 'A', 'S', 'G', 'T', 'B']
   const leet  = ['0', '1', '2', '3', '4', '5', '6', '7', '8']

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/predict-from-corrections.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/predict-from-corrections.tests.ts
@@ -1,11 +1,21 @@
-import { deepCopy } from "@keymanapp/web-utils";
+
 import { assert } from 'chai';
 
-import { predictFromCorrections, tupleDisplayOrderSort } from "#./predict-helpers.js";
-import { DummyModel } from "#./models/dummy-model.js";
+import { deepCopy } from "@keymanapp/web-utils";
+import { LexicalModelTypes } from '@keymanapp/common-types';
+
+import { models, predictFromCorrections, tupleDisplayOrderSort } from "@keymanapp/lm-worker/test-index";
+
+import CasingFunction = LexicalModelTypes.CasingFunction;
+import Context = LexicalModelTypes.Context;
+import Distribution = LexicalModelTypes.Distribution;
+import DummyModel = models.DummyModel;
+import Outcome = LexicalModelTypes.Outcome;
+import Suggestion = LexicalModelTypes.Suggestion;
+import Transform = LexicalModelTypes.Transform;
 
 // See: developer/src/kmc-model/model-defaults.ts, defaultApplyCasing
-const applyCasing = (casing, text) => {
+const applyCasing: CasingFunction = (casing, text) => {
   switch(casing) {
     case 'lower':
       return text.toLowerCase();
@@ -44,7 +54,7 @@ const DUMMY_MODEL_CONFIG = {
     insertAfterWord: '\u00a0' // non-breaking space
   },
   applyCasing: applyCasing,
-  searchTermToKey: (wordform) => {
+  searchTermToKey: (wordform: string) => {
     // See: developer/src/kmc-model/model-defaults.ts, defaultCasedSearchTermToKey
     return applyCasing('lower', wordform)
       .normalize('NFKD')
@@ -63,16 +73,14 @@ const DUMMY_MODEL_CONFIG = {
 
 describe('predictFromCorrections', () => {
   it('handles a single correction prefixing multiple entries - no transform ID', () => {
-    /** @type {Context} */
-    const context = {
+    const context: Context = {
       left: 'It',
       right: '',
       startOfBuffer: true,
       endOfBuffer: true
     };
 
-    /** @type {Distribution<Transform>} */
-    const correctionDistribution = [{
+    const correctionDistribution: Distribution<Transform> = [{
         sample: {
           insert: 's',
           deleteLeft: 0
@@ -81,8 +89,7 @@ describe('predictFromCorrections', () => {
       }
     ];
 
-    /** @type {ProbabilityMass<Suggestion>[]} */
-    const dummied_suggestions = [
+    const dummied_suggestions: Outcome<Suggestion>[] = [
       {
         transform: {
           insert: "it's",
@@ -117,16 +124,14 @@ describe('predictFromCorrections', () => {
   });
 
   it('handles a single correction prefixing multiple entries - with transform ID', () => {
-    /** @type {Context} */
-    const context = {
+    const context: Context = {
       left: 'It',
       right: '',
       startOfBuffer: true,
       endOfBuffer: true
     };
 
-    /** @type {Distribution<Transform>} */
-    const correctionDistribution = [{
+    const correctionDistribution: Distribution<Transform> = [{
         sample: {
           insert: 's',
           deleteLeft: 0,
@@ -136,8 +141,7 @@ describe('predictFromCorrections', () => {
       }
     ];
 
-    /** @type {ProbabilityMass<Suggestion>[]} */
-    const dummied_suggestions = [
+    const dummied_suggestions: Outcome<Suggestion>[] = [
       {
         transform: {
           insert: "it's",
@@ -177,8 +181,7 @@ describe('predictFromCorrections', () => {
   });
 
   it('handles multiple corrections at once', () => {
-    /** @type {Context} */
-    const context = {
+    const context: Context = {
       left: 'It',
       right: '',
       startOfBuffer: true,
@@ -187,7 +190,7 @@ describe('predictFromCorrections', () => {
 
     // Note:  each correction is used in order in a separate model.predict call.
     /** @type {Distribution<Transform>} */
-    const correctionDistribution = [{
+    const correctionDistribution: Distribution<Transform> = [{
         // postContext:  is
         sample: {
           insert: 's',
@@ -204,8 +207,7 @@ describe('predictFromCorrections', () => {
       }
     ];
 
-    /** @type {ProbabilityMass<Suggestion>[]} */
-    const dummied_suggestions = [
+    const dummied_suggestions: Outcome<Suggestion>[][] = [
       // postContext:  is
       [{
         transform: {

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-deduplication.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-deduplication.tests.ts
@@ -1,9 +1,13 @@
-import * as wordBreakers from '@keymanapp/models-wordbreakers';
-import { deepCopy } from '@keymanapp/web-utils';
 import { assert } from 'chai';
 
-import { dedupeSuggestions } from "#./predict-helpers.js";
-import { DummyModel } from "#./models/dummy-model.js";
+import * as wordBreakers from '@keymanapp/models-wordbreakers';
+import { deepCopy } from '@keymanapp/web-utils';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+
+import { CorrectionPredictionTuple, dedupeSuggestions, models } from "@keymanapp/lm-worker/test-index";
+
+import Context = LexicalModelTypes.Context;
+import DummyModel = models.DummyModel;
 
 /*
  * This file's tests use these parts of a lexical model:
@@ -20,8 +24,7 @@ const testModel = new DummyModel({
  * @returns
  */
 const build_its_is_set = () => {
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const its = {
+  const its: CorrectionPredictionTuple = {
     correction: {
       sample: 'its',
       p: 0.8
@@ -40,8 +43,7 @@ const build_its_is_set = () => {
     // matchLevel does not yet exist.
   };
 
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const it_is = {
+  const it_is: CorrectionPredictionTuple = {
     correction: {
       sample: 'its',
       p: 0.8
@@ -59,8 +61,7 @@ const build_its_is_set = () => {
     totalProb: 0.64
   };
 
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const is = {
+  const is: CorrectionPredictionTuple = {
     correction: {
       sample: 'is',
       p: 0.2
@@ -78,8 +79,7 @@ const build_its_is_set = () => {
     totalProb: 0.1
   };
 
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const is_not = {
+  const is_not: CorrectionPredictionTuple = {
     correction: {
       sample: 'is',
       p: 0.2
@@ -107,8 +107,7 @@ const build_its_is_set = () => {
 
 describe('dedupeSuggestions', () => {
   it('preserves all entries when there are no duplicates', () => {
-    /** @type {Context} */
-    const context = {
+    const context: Context = {
       left: 'It',
       right: '',
       startOfBuffer: true,
@@ -125,8 +124,7 @@ describe('dedupeSuggestions', () => {
   });
 
   it('removes duplicates, combining their total-probabilities', () => {
-    /** @type {Context} */
-    const context = {
+    const context: Context = {
       left: 'It',
       right: '',
       startOfBuffer: true,

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-finalization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-finalization.tests.ts
@@ -1,9 +1,15 @@
-import * as wordBreakers from '@keymanapp/models-wordbreakers';
+
 import { assert } from 'chai';
 
-import { finalizeSuggestions } from "#./predict-helpers.js";
-import { DummyModel } from "#./models/dummy-model.js";
 import { deepCopy } from '@keymanapp/web-utils';
+import * as wordBreakers from '@keymanapp/models-wordbreakers';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+
+import { CorrectionPredictionTuple, finalizeSuggestions, models } from "@keymanapp/lm-worker/test-index";
+
+import DummyModel = models.DummyModel;
+import Outcome = LexicalModelTypes.Outcome;
+import Suggestion = LexicalModelTypes.Suggestion;
 
 /*
  * This file's tests use these parts of a lexical model:
@@ -39,11 +45,10 @@ const testModelWithoutSpacing = new DummyModel({
  * @param {'verbose'=} verbose
  * @returns
  */
-const build_its_is_set = (verbose) => {
+const build_its_is_set = (verbose?: string) => {
   const verboseFlag = (verbose == 'verbose' ? true : false);
 
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const its = {
+  const its: CorrectionPredictionTuple = {
     correction: {
       sample: 'its',
       p: 0.8
@@ -62,8 +67,7 @@ const build_its_is_set = (verbose) => {
     // matchLevel does not yet exist.
   };
 
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const it_is = {
+  const it_is: CorrectionPredictionTuple = {
     correction: {
       sample: 'its',
       p: 0.8
@@ -81,8 +85,7 @@ const build_its_is_set = (verbose) => {
     totalProb: 0.64
   };
 
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const is = {
+  const is: CorrectionPredictionTuple = {
     correction: {
       sample: 'is',
       p: 0.2
@@ -100,8 +103,7 @@ const build_its_is_set = (verbose) => {
     totalProb: 0.1
   };
 
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const is_not = {
+  const is_not: CorrectionPredictionTuple = {
     correction: {
       sample: 'is',
       p: 0.2
@@ -129,7 +131,7 @@ const build_its_is_set = (verbose) => {
   const unfinalized = [...Object.values(baseDefinitions)].map((entry) => deepCopy(entry));
   const expected = unfinalized.map((entry) => {
 
-    const mapped = {
+    const mapped: Outcome<Suggestion & { 'correction-p'?: number, 'lexical-p'?: number }> = {
       ...deepCopy(entry.prediction.sample),
       p: entry.totalProb
     };

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-similarity.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-similarity.tests.ts
@@ -1,10 +1,18 @@
+import { assert } from 'chai';
+
 import { QuoteBehavior } from "@keymanapp/models-templates";
 import * as wordBreakers from '@keymanapp/models-wordbreakers';
 import { deepCopy } from '@keymanapp/web-utils';
-import { assert } from 'chai';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
-import { SuggestionSimilarity, processSimilarity, toAnnotatedSuggestion } from "#./predict-helpers.js";
-import { DummyModel } from "#./models/dummy-model.js";
+import { CorrectionPredictionTuple, models, processSimilarity, SuggestionSimilarity, toAnnotatedSuggestion } from "@keymanapp/lm-worker/test-index";
+
+import CasingFunction = LexicalModelTypes.CasingFunction;
+import Context = LexicalModelTypes.Context;
+import DummyModel = models.DummyModel;
+import DummyOptions = models.DummyOptions;
+import ProbabilityMass = LexicalModelTypes.ProbabilityMass;
+import Transform = LexicalModelTypes.Transform;
 
 /*
  * This file's tests use these parts of a lexical model:
@@ -14,8 +22,7 @@ import { DummyModel } from "#./models/dummy-model.js";
  * - model.punctuation
  */
 
-/** @type { import("#./models/dummy-model.js").DummyOptions } */
-const DUMMY_MODEL_CONFIG = {
+const DUMMY_MODEL_CONFIG: DummyOptions = {
   punctuation: {
     quotesForKeepSuggestion: {
       open: '<',
@@ -27,7 +34,7 @@ const DUMMY_MODEL_CONFIG = {
 };
 
 // See: developer/src/kmc-model/model-defaults.ts, defaultApplyCasing
-const applyCasing = (casing, text) => {
+const applyCasing: CasingFunction = (casing, text) => {
   switch(casing) {
     case 'lower':
       return text.toLowerCase();
@@ -102,8 +109,7 @@ const testModelWithCasing = new DummyModel({
  * @returns
  */
 const build_its_is_set = () => {
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const its = {
+  const its: CorrectionPredictionTuple = {
     correction: {
       sample: 'its',
       p: 0.8
@@ -122,8 +128,7 @@ const build_its_is_set = () => {
     // matchLevel does not yet exist.
   };
 
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const it_is = {
+  const it_is: CorrectionPredictionTuple = {
     correction: {
       sample: 'its',
       p: 0.8
@@ -141,8 +146,7 @@ const build_its_is_set = () => {
     totalProb: 0.64
   };
 
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const is = {
+  const is: CorrectionPredictionTuple = {
     correction: {
       sample: 'is',
       p: 0.2
@@ -160,8 +164,7 @@ const build_its_is_set = () => {
     totalProb: 0.1
   };
 
-  /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-  const is_not = {
+  const is_not: CorrectionPredictionTuple = {
     correction: {
       sample: 'is',
       p: 0.2
@@ -189,16 +192,14 @@ const build_its_is_set = () => {
 
 describe('processSimilarity', () => {
   it(`selects non-contraction as 'more similar' than same-keyed contraction when context is non-contraction`, () => {
-    /** @type {Context} */
-    const context = {
+    const context: Context = {
       left: 'It',
       right: '',
       startOfBuffer: true,
       endOfBuffer: true
     };
 
-    /** @type {ProbabilityMass<Transform>} */
-    const trueInput = {
+    const trueInput: ProbabilityMass<Transform> = {
       sample: {
         insert: 's',
         deleteLeft: 0
@@ -209,8 +210,7 @@ describe('processSimilarity', () => {
     const testSet = build_its_is_set();
     const distribution = [...Object.values(testSet)];
 
-    /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]} */
-    const expectation = [
+    const expectation: CorrectionPredictionTuple[] = [
       {
         ...testSet.its,
         matchLevel: SuggestionSimilarity.exact
@@ -239,16 +239,14 @@ describe('processSimilarity', () => {
   });
 
   it(`selects contraction as 'more similar' than same-keyed non-contraction when context is contraction`, () => {
-    /** @type {Context} */
-    const context = {
+    const context: Context = {
       left: 'It',
       right: '',
       startOfBuffer: true,
       endOfBuffer: true
     };
 
-    /** @type {ProbabilityMass<Transform>} */
-    const trueInput = {
+    const trueInput: ProbabilityMass<Transform> = {
       sample: {
         insert: '\'s',
         deleteLeft: 0
@@ -259,8 +257,7 @@ describe('processSimilarity', () => {
     const testSet = build_its_is_set();
     const distribution = [...Object.values(testSet)];
 
-    /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]} */
-    const expectation = [
+    const expectation: CorrectionPredictionTuple[] = [
       {
         ...testSet.its,
         matchLevel: SuggestionSimilarity.sameKey
@@ -289,16 +286,14 @@ describe('processSimilarity', () => {
   });
 
   it(`creates an 'exact'-match suggestion as 'keep' if no exact-match exists`, () => {
-    /** @type {Context} */
-    const context = {
+    const context: Context = {
       left: 'iphon',
       right: '',
       startOfBuffer: true,
       endOfBuffer: true
     };
 
-    /** @type {ProbabilityMass<Transform>} */
-    const trueInput = {
+    const trueInput: ProbabilityMass<Transform> = {
       sample: {
         insert: 'e',
         deleteLeft: 0
@@ -306,8 +301,7 @@ describe('processSimilarity', () => {
       p: 1
     };
 
-    /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-    const iPhone = {
+    const iPhone: CorrectionPredictionTuple = {
       correction: {
         sample: 'iphone',
         p: 0.8
@@ -326,13 +320,11 @@ describe('processSimilarity', () => {
       // matchLevel does not yet exist.
     };
 
-    /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]} */
-    const distribution = [
+    const distribution: CorrectionPredictionTuple[] = [
       iPhone
     ];
 
-    /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple} */
-    const keep_iphone = {
+    const keep_iphone: CorrectionPredictionTuple = {
       correction: {
         sample: 'iphone',
         p: 1
@@ -355,8 +347,7 @@ describe('processSimilarity', () => {
     };
 
 
-    /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]} */
-    const expectation = [
+    const expectation: CorrectionPredictionTuple[] = [
       {
         ...keep_iphone,
         matchLevel: SuggestionSimilarity.exact
@@ -380,16 +371,14 @@ describe('processSimilarity', () => {
     // keeps a separate entry for the two versions (or only has the title-cased
     // one).
     it(`differentiates same-keyed suggestions when one only mismatches due to casing`, () => {
-      /** @type {Context} */
-      const context = {
+      const context: Context = {
         left: 'It',
         right: '',
         startOfBuffer: true,
         endOfBuffer: true
       };
 
-      /** @type {ProbabilityMass<Transform>} */
-      const trueInput = {
+      const trueInput: ProbabilityMass<Transform> = {
         sample: {
           insert: '\'s',
           deleteLeft: 0
@@ -408,8 +397,7 @@ describe('processSimilarity', () => {
 
       const distribution = [...Object.values(testSet)];
 
-      /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]} */
-      const expectation = [
+      const expectation: CorrectionPredictionTuple[] = [
         {
           ...testSet.its,
           matchLevel: SuggestionSimilarity.sameKey
@@ -446,16 +434,14 @@ describe('processSimilarity', () => {
 
   describe('without casing', () => {
     it(`does not utilize casing behaviors when checking similarity`, () => {
-      /** @type {Context} */
-      const context = {
+      const context: Context = {
         left: 'It',
         right: '',
         startOfBuffer: true,
         endOfBuffer: true
       };
 
-      /** @type {ProbabilityMass<Transform>} */
-      const trueInput = {
+      const trueInput: ProbabilityMass<Transform> = {
         sample: {
           insert: '\'s',
           deleteLeft: 0
@@ -474,8 +460,7 @@ describe('processSimilarity', () => {
 
       const distribution = [...Object.values(testSet)];
 
-      /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]} */
-      const expectation = [
+      const expectation: CorrectionPredictionTuple[] = [
         {
           ...testSet.its,
           matchLevel: SuggestionSimilarity.none

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/transform-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/transform-tokenization.tests.ts
@@ -1,18 +1,23 @@
 import { assert } from 'chai';
 
 import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
+import { Token, Tokenization, tokenize } from '@keymanapp/models-templates';
+import { LexicalModelTypes } from '@keymanapp/common-types';
 
-import { tokenize } from '@keymanapp/models-templates';
-import { tokenizeTransform } from '#./correction/transform-tokenization.js';
+import { tokenizeTransform } from '@keymanapp/lm-worker/test-index';
 
-const defaultTokenize = (context) => tokenize(defaultBreaker, context);
+import Context = LexicalModelTypes.Context;
+
+const defaultTokenize = (context: Context) => tokenize(defaultBreaker, context);
 
 describe('tokenizeTransform', () => {
   describe('with default wordbreaking', () => {
     it('properly handles simple token-edit transform', () => {
-      const context = {
+      const context: Context = {
         left: 'an apple a date',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -33,7 +38,9 @@ describe('tokenizeTransform', () => {
     it('properly handles simple token-replacing transform', () => {
       const context = {
         left: 'an apple a date',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -54,7 +61,9 @@ describe('tokenizeTransform', () => {
     it('handles simple token-replacing transform with cross-token deleteLeft', () => {
       const context = {
         left: 'an apple a date',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       // 'an apple any'
@@ -76,7 +85,9 @@ describe('tokenizeTransform', () => {
     it('properly handles a simple appended whitespace', () => {
       const context = {
         left: 'an apple a day',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -103,7 +114,9 @@ describe('tokenizeTransform', () => {
     it('properly handles a simple appended period', () => {
       const context = {
         left: 'an apple a day',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -128,7 +141,9 @@ describe('tokenizeTransform', () => {
     it('handles word-breakable transforms (case 1)', () => {
       const context = {
         left: 'an apple a dat',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -153,7 +168,9 @@ describe('tokenizeTransform', () => {
     it('handles word-breakable transforms (case 2)', () => {
       const context = {
         left: 'an apple a dat',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -179,7 +196,9 @@ describe('tokenizeTransform', () => {
     it('handles complex breakable cases', () => {
       const context = {
         left: 'an apple a date',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       // 'an apple any'
@@ -204,18 +223,20 @@ describe('tokenizeTransform', () => {
   });
 
   describe('with mocked dictionary-based wordbreaking', () => {
-    function mockedTokenization(entries) {
+    function mockedTokenization(entries: string[]) {
       return {
         left: entries.map((text) => {
-          return {text: text}
+          return {text: text} as Token
         })
-      };
+      } as Tokenization;
     }
 
     it('properly handles simple token-edit transform', () => {
       const context = {
         left: 'anappleadate',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -236,7 +257,9 @@ describe('tokenizeTransform', () => {
     it('properly handles simple token-replacing transform', () => {
       const context = {
         left: 'anappleadate',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -257,7 +280,9 @@ describe('tokenizeTransform', () => {
     it('handles simple token-replacing transform with cross-token deleteLeft', () => {
       const context = {
         left: 'anappleadate',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       // 'an apple any'
@@ -279,7 +304,9 @@ describe('tokenizeTransform', () => {
     it('handles word-breakable transforms (case 1)', () => {
       const context = {
         left: 'anappleadat',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -303,7 +330,9 @@ describe('tokenizeTransform', () => {
     it('handles word-breakable transforms (case 2)', () => {
       const context = {
         left: 'anappleadat',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -327,7 +356,9 @@ describe('tokenizeTransform', () => {
     it('handles word-breakable transforms (case 2 alternate output)', () => {
       const context = {
         left: 'anappleadat',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       const editTransform = {
@@ -352,7 +383,9 @@ describe('tokenizeTransform', () => {
     it('handles complex breakable cases', () => {
       const context = {
         left: 'anappleadate',
-        right: ''
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
       };
 
       // 'an apple any'

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/transform-utils.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/transform-utils.tests.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import TransformUtils from '#./transformUtils.js';
+import { TransformUtils } from '@keymanapp/lm-worker/test-index';
 
 describe('TransformUtils', function () {
   describe('isWhitespace', function () {

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-custom-punctuation.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-custom-punctuation.tests.ts
@@ -4,8 +4,8 @@
 
 import { assert } from 'chai';
 
-import DummyModel from '#./models/dummy-model.js';
-import ModelCompositor from '#./model-compositor.js';
+import { ModelCompositor, models } from '@keymanapp/lm-worker/test-index';
+import DummyModel = models.DummyModel;
 
 describe('Custom Punctuation', function () {
   it('appears in the keep suggestion', async function () {
@@ -31,6 +31,7 @@ describe('Custom Punctuation', function () {
         quotesForKeepSuggestion: {
           open: "«", close: "»"
         },
+        insertAfterWord: ''
       }
     });
 
@@ -76,6 +77,10 @@ describe('Custom Punctuation', function () {
           // U+1680 OGHAM SPACE MARK:
           // it's technically whitespace, but it don't look it!
           insertAfterWord: " ",
+          quotesForKeepSuggestion: {
+            open: "'",
+            close: "'"
+          }
         }
       });
 

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-initialization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-initialization.tests.ts
@@ -1,13 +1,21 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
 import { assert } from 'chai';
 import sinon from 'sinon';
-import fs from 'fs';
-
-import LMLayerWorker from '#./index.js';
 
 import { configWorker, createMessageEventWithData, importScriptsWith } from '@keymanapp/common-test-resources/model-helpers.mjs';
 
-import { createRequire } from 'module';
+// @ts-ignore
+import { LMLayerWorker } from '@keymanapp/lm-worker/test-index';
+
 const require = createRequire(import.meta.url);
+
+interface MockedContext {
+  onmessage?: () => void;
+  importScripts?: () => void;
+  postMessage: sinon.SinonSpy<any, any>;
+}
 
 // Unit tests for instantiating and initializing the LMLayer Worker in isolation.
 //
@@ -18,7 +26,7 @@ describe('LMLayerWorker', function() {
   describe('#constructor()', function() {
     it('should allow for the mocking of postMessage()', function () {
       var fakePostMessage = sinon.fake();
-      var context = {
+      var context: MockedContext = {
         postMessage: fakePostMessage
       };
       context.importScripts = importScriptsWith(context);
@@ -42,7 +50,7 @@ describe('LMLayerWorker', function() {
 
   describe('#onMessage()', function() {
     it('should fail if not given the `message` attribute', function () {
-      var context = {
+      var context: MockedContext = {
         postMessage: sinon.fake()
       };
       context.importScripts = importScriptsWith(context);
@@ -60,9 +68,9 @@ describe('LMLayerWorker', function() {
 
   describe('.install()', function () {
     it('should create a new instance, installed on our global object', function () {
-      var fakeWorkerGlobal = {
+      var fakeWorkerGlobal: MockedContext = {
         onmessage: undefined,
-        postMessage: new sinon.fake(),
+        postMessage: sinon.fake(),
       };
       fakeWorkerGlobal.importScripts = importScriptsWith(fakeWorkerGlobal);
 
@@ -91,7 +99,7 @@ describe('LMLayerWorker', function() {
 
   describe('Message: config', function () {
     it('should disallow any other message', function () {
-      var context = {
+      var context: MockedContext = {
         postMessage: sinon.fake()
       };
       context.importScripts = importScriptsWith(context);
@@ -107,7 +115,7 @@ describe('LMLayerWorker', function() {
     });
 
     it('accepts a capability set and transitions to the "modelless" state', function () {
-      var context = {
+      var context: MockedContext = {
         postMessage: sinon.fake()
       };
       context.importScripts = importScriptsWith(context);
@@ -123,7 +131,7 @@ describe('LMLayerWorker', function() {
 
   describe('Message: load', function () {
     it('should disallow any other message', function () {
-      var context = {
+      var context: MockedContext = {
         postMessage: sinon.fake()
       };
       context.importScripts = importScriptsWith(context);
@@ -142,7 +150,7 @@ describe('LMLayerWorker', function() {
 
     it('should send back a "ready" message when given a file', function () {
       var fakePostMessage = sinon.fake();
-      var context = {
+      var context: MockedContext = {
         postMessage: fakePostMessage
       };
       context.importScripts = importScriptsWith(context);
@@ -165,7 +173,7 @@ describe('LMLayerWorker', function() {
 
     it('should send back a "ready" message when given raw code', function () {
       var fakePostMessage = sinon.fake();
-      var context = {
+      var context: MockedContext = {
         postMessage: fakePostMessage
       };
       context.importScripts = importScriptsWith(context);
@@ -190,7 +198,7 @@ describe('LMLayerWorker', function() {
 
     it('should send back configuration', function () {
       var fakePostMessage = sinon.fake();
-      var context = {
+      var context: MockedContext = {
         postMessage: fakePostMessage
       };
       context.importScripts = importScriptsWith(context);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-predict-dummy.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-predict-dummy.tests.ts
@@ -3,9 +3,11 @@
  */
 
 import { assert } from 'chai';
-import DummyModel from '#./models/dummy-model.js';
 
 import { emptyContext, iGotDistractedByHazel, zeroTransform } from '@keymanapp/common-test-resources/model-helpers.mjs';
+
+import { models } from '@keymanapp/lm-worker/test-index'
+import DummyModel = models.DummyModel;
 
 describe('LMLayerWorker dummy model', function() {
   describe('instantiation', function () {

--- a/web/src/test/auto/tsconfig.json
+++ b/web/src/test/auto/tsconfig.json
@@ -14,5 +14,11 @@
     "integrated/**/*.ts",
     "resources/**/*.ts",
     "predictive-text/**/*.ts"
+  ],
+  "exclude": [
+    "engine/predictive-text/worker-thread/worker-*.tests.ts"
+  ],
+  "references": [
+    { "path": "./tsconfig.worker.json" }
   ]
 }

--- a/web/src/test/auto/tsconfig.worker.json
+++ b/web/src/test/auto/tsconfig.worker.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.dom.json",
+
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "../../../build/test",
+    "tsBuildInfoFile": "../../../build/test/tsconfig.worker.tsbuildinfo",
+    "rootDir": ".",
+    "lib": ["es6", "WebWorker"]
+  },
+
+  "include": [
+    "engine/predictive-text/worker-thread/worker-*.tests.ts"
+  ]
+}


### PR DESCRIPTION
This converts the main `worker-thread` unit test suit to TypeScript.  Doing so will make it much easier to write future tests for said module in TypeScript as well.

@keymanapp-test-bot skip