### PR TITLE
maint(web): skip unnecessary steps for `build` buildLevel

### DIFF
--- a/web/ci.sh
+++ b/web/ci.sh
@@ -4,7 +4,7 @@
 # building the Keyman Engine for Web.
 #
 
-# set -x
+# TODO: merge this with resources/teamcity/web scripts
 
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
@@ -66,16 +66,18 @@ function build_action() {
   # one option:
   ./build.sh configure clean build
 
-  # Upload the sentry-configuration engine used by the mobile apps to sentry
-  # Also, clean 'em first.
-  for sourcemap in "${KEYMAN_ROOT}/web/src/engine/sentry-manager/build/lib/"*.map; do
-    node "${KEYMAN_ROOT}/web/build/tools/building/sourcemap-root/index.js" null "${sourcemap}" --clean
-  done
-  web_sentry_upload "${KEYMAN_ROOT}/web/src/engine/sentry-manager/build/lib/"
+  if builder_is_ci_build && builder_is_ci_build_level_release; then
+    # Upload the sentry-configuration engine used by the mobile apps to sentry
+    # Also, clean 'em first.
+    for sourcemap in "${KEYMAN_ROOT}/web/src/engine/sentry-manager/build/lib/"*.map; do
+      node "${KEYMAN_ROOT}/web/build/tools/building/sourcemap-root/index.js" null "${sourcemap}" --clean
+    done
+    web_sentry_upload "${KEYMAN_ROOT}/web/src/engine/sentry-manager/build/lib/"
 
-  # And, of course, the main build-products too
-  web_sentry_upload "${KEYMAN_ROOT}/web/build/app/webview/release/"
-  web_sentry_upload "${KEYMAN_ROOT}/web/build/publish/release/"
+    # And, of course, the main build-products too
+    web_sentry_upload "${KEYMAN_ROOT}/web/build/app/webview/release/"
+    web_sentry_upload "${KEYMAN_ROOT}/web/build/publish/release/"
+  fi
 }
 
 function test_action() {


### PR DESCRIPTION
Skip Sentry upload for non-release builds. Add TODO to merge ci.sh content with resources/teamcity/web.

Fixes: #14289
Build-bot: build
Test-bot: skip