### PR TITLE
maint(common): rename and move node-related script functions into node.inc.sh

### DIFF
--- a/resources/docker-images/build.sh
+++ b/resources/docker-images/build.sh
@@ -9,7 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ################################ Main script ################################
 
 . "${KEYMAN_ROOT}/resources/build/minimum-versions.inc.sh"
-. "${KEYMAN_ROOT}/resources/build/utils.inc.sh"
+. "${KEYMAN_ROOT}/resources/build/node.inc.sh"
 . "${KEYMAN_ROOT}/resources/docker-images/docker-build.inc.sh"
 
 builder_describe \

--- a/resources/docker-images/docker-build.inc.sh
+++ b/resources/docker-images/docker-build.inc.sh
@@ -30,7 +30,7 @@ convert_parameters_to_args() {
   build_version=
   local required_node_version keyman_default_distro
   # shellcheck disable=SC2034
-  required_node_version="$(_print_expected_node_version)"
+  required_node_version="$(_node_print_expected_version)"
   # shellcheck disable=SC2034
   keyman_default_distro="ubuntu"
 


### PR DESCRIPTION
Consolidates the node-related script functions into node.inc.sh, as part of cleaning up the build scripts and making them easier to maintain into the future. In the earlier commits some changes were missing.

Fixes: #14447
Follows: #14451
Test-bot: skip