### PR TITLE
fix(linux): normalize language tags from keyboard

### DIFF
--- a/linux/keyman-config/keyman_config/canonical_language_code_utils.py
+++ b/linux/keyman-config/keyman_config/canonical_language_code_utils.py
@@ -57,3 +57,18 @@ class CanonicalLanguageCodeUtils():
             bcp47Tag.region = langTag['region']
 
         return bcp47Tag.tag
+
+    @staticmethod
+    def normalize_language(supportedLanguages, language):
+        if len(supportedLanguages) <= 0:
+            return ''
+
+        if not language:
+            language = supportedLanguages[0]['id']
+
+        language = CanonicalLanguageCodeUtils.findBestTag(language, False, False)
+        for supportedLanguage in supportedLanguages:
+            tag = CanonicalLanguageCodeUtils.findBestTag(supportedLanguage['id'], False, False)
+            if tag == language:
+                return tag
+        return None

--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -252,7 +252,7 @@ class InstallKmp():
         # TODO: add other keyboards as well (#9757)
         firstKeyboard = keyboards[0]
         if secure_lookup(firstKeyboard, 'languages') and firstKeyboard['languages']:
-            language = self._normalize_language(firstKeyboard['languages'], language)
+            language = CanonicalLanguageCodeUtils.normalize_language(firstKeyboard['languages'], language)
 
         if not language:
             language = self._add_custom_keyboard(firstKeyboard, packageDir, requested_language)

--- a/linux/keyman-config/tests/canonical_language_code_utils_tests.py
+++ b/linux/keyman-config/tests/canonical_language_code_utils_tests.py
@@ -85,3 +85,56 @@ class CanonicalLanguageCodeUtilsTests(unittest.TestCase):
                         # Verify
                         msg = "\nFor %s:\nExpected: %s\ngot:      %s " % (tag, expectedTag, bestTag)
                         self.assertEqual(expectedTag, bestTag, msg)
+
+
+class NormalizeLanguageTests(unittest.TestCase):
+    def test_normalizeLanguage(self):
+        # Setup
+        languages = [
+            {'id': 'de'},
+            {'id': 'esi-Latn'},
+            {'id': 'dyo'},
+            {'id': 'fuh-Arab'}
+        ]
+
+        for testcase in [
+            {'given': 'de', 'expected': 'de'},
+            {'given': 'esi', 'expected': 'esi'},
+            {'given': 'esi-Latn', 'expected': 'esi'},
+            {'given': 'es', 'expected': None},
+            {'given': 'en', 'expected': None},
+            {'given': None, 'expected': 'de'},
+            # #3399
+            {'given': 'dyo-latn', 'expected': 'dyo'},
+            {'given': 'dyo', 'expected': 'dyo'},
+            {'given': 'fuh-Arab', 'expected': 'fuh-Arab'},
+            {'given': 'fuh', 'expected': None},
+        ]:
+            with self.subTest(data=testcase):
+                # Execute
+                result = CanonicalLanguageCodeUtils.normalize_language(languages, testcase['given'])
+
+                # Verify
+                self.assertEqual(result, testcase['expected'])
+
+    def test_normalizeLanguage_noLanguages(self):
+        # Setup
+        languages = []
+
+        # Execute
+        result = CanonicalLanguageCodeUtils.normalize_language(languages, 'en')
+
+        # Verify
+        self.assertEqual(result, '')
+
+    def test_normalizeLanguage_useFirstLanguage(self):
+        # Setup
+        languages = [
+            {'id': 'en-Latn-US'}
+        ]
+
+        # Execute
+        result = CanonicalLanguageCodeUtils.normalize_language(languages, None)
+
+        # Verify
+        self.assertEqual(result, 'en')

--- a/linux/keyman-config/tests/install_kmp_tests.py
+++ b/linux/keyman-config/tests/install_kmp_tests.py
@@ -202,47 +202,6 @@ class InstallKeyboardsToGnomeTests(InstallKmpBase):
         self.mockRestartIbus.assert_not_called()
 
 
-class NormalizeLanguageTests(InstallKmpBase):
-    def test_normalizeLanguage(self):
-        # Setup
-        languages = [
-            {'id': 'de'},
-            {'id': 'esi-Latn'},
-            {'id': 'dyo'},
-            {'id': 'fuh-Arab'}
-        ]
-
-        for testcase in [
-            {'given': 'de', 'expected': 'de'},
-            {'given': 'esi', 'expected': 'esi'},
-            {'given': 'esi-Latn', 'expected': 'esi'},
-            {'given': 'es', 'expected': None},
-            {'given': 'en', 'expected': None},
-            {'given': None, 'expected': None},
-            # #3399
-            {'given': 'dyo-latn', 'expected': 'dyo'},
-            {'given': 'dyo', 'expected': 'dyo'},
-            {'given': 'fuh-Arab', 'expected': 'fuh-Arab'},
-            {'given': 'fuh', 'expected': None},
-        ]:
-            with self.subTest(data=testcase):
-                # Execute
-                result = InstallKmp()._normalize_language(languages, testcase['given'])
-
-                # Verify
-                self.assertEqual(result, testcase['expected'])
-
-    def test_normalizeLanguage_noLanguages(self):
-        # Setup
-        languages = []
-
-        # Execute
-        result = InstallKmp()._normalize_language(languages, 'en')
-
-        # Verify
-        self.assertEqual(result, '')
-
-
 class InstallKmpTests(InstallKmpBase):
     def _createEmptyKmp(self, workdir):
         kmpfile = os.path.join(workdir, 'foo.kmp')


### PR DESCRIPTION
This fixes a bug where a keyboard didn't show up in the language dropdown if the first language it specified wasn't a normalized language tag. Previously in that case we added a custom keyboard with whatever language tag the keyboard specified. With this change we now continue to use the first language of the first keyboard but normalize it. Since the selection of the language now happens a little earlier it is slightly possible that there will be unexpected side effects that didn't show up in my testing.

Fixes: #14465

# User Testing

**TEST_KB_AVAILABLE**:

- download [extra_english.kmp](https://drive.google.com/file/d/19jBSV3D0hirXuSx3m68D5B4t-7KgjwER/view?usp=sharing) keyboard from [community site](https://community.software.sil.org/t/ralt-and-rctrl-key-combinations-not-working-in-libreoffice/10481)
- open km-config and install the keyboard
- verify that it shows up in the keyboard dropdown