### PR TITLE
fix(android): Add FirstVoices preference to show on-screen keyboard 👁️

### DIFF
--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/PreferencesManager.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/PreferencesManager.java
@@ -1,0 +1,12 @@
+/**
+ * FirstVoices for Android is copyright (c) SIL Global. MIT License.
+ */
+package com.firstvoices.keyboards;
+
+public class PreferencesManager {
+
+  public static final String fv_prefs_name = "FVPreferences";
+
+  public static final String oskWithPhysicalKeyboardKey = "ShowOSK";
+
+}

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SetupActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SetupActivity.java
@@ -3,6 +3,7 @@ package com.firstvoices.keyboards;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.provider.Settings;
@@ -24,104 +25,138 @@ import java.util.List;
 
 public class SetupActivity extends AppCompatActivity {
 
-    private ListView listView = null;
-    private SimpleAdapter listAdapter = null;
-    private ArrayList<HashMap<String, String>> list = null;
+  private ListView listView = null;
+  private SimpleAdapter listAdapter = null;
+  private ArrayList<HashMap<String, String>> list = null;
+  private static SharedPreferences prefs;
+  private static SharedPreferences.Editor editor;
 
-    private final String iconKey = "icon";
-    private final String textKey = "text";
-    private final String isEnabledKey = "isEnabled";
-    
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
-        final Context context = this;
-        setContentView(R.layout.setup_list_layout);
+  private final String iconKey = "icon";
+  private final String textKey = "text";
+  private final String isEnabledKey = "isEnabled";
 
-        listView = findViewById(R.id.listView);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
+    final Context context = this;
+    setContentView(R.layout.setup_list_layout);
 
-        final ImageButton closeButton = findViewById(R.id.close_button);
-        closeButton.setOnClickListener(new View.OnClickListener() {
-            public void onClick(View v) {
-                finish();
-            }
-        });
+    prefs = context.getSharedPreferences(
+      PreferencesManager.fv_prefs_name, Context.MODE_PRIVATE);
+    editor = prefs.edit();
 
-        list = new ArrayList<>();
-        HashMap<String, String> hashMap;
+    listView = findViewById(R.id.listView);
 
-        hashMap = new HashMap<>();
-        hashMap.put(iconKey, "0");
-        hashMap.put(textKey, "Enable 'FirstVoices'");
-        hashMap.put(isEnabledKey, "true");
-        list.add(hashMap);
+    final ImageButton closeButton = findViewById(R.id.close_button);
+    closeButton.setOnClickListener(new View.OnClickListener() {
+      public void onClick(View v) {
+        finish();
+      }
+    });
 
-        hashMap = new HashMap<>();
-        hashMap.put(iconKey, "0");
-        hashMap.put(textKey, "Choose 'FirstVoices' as current input method");
-        hashMap.put(isEnabledKey, "false");
-        list.add(hashMap);
-        
-        String[] from = new String[]{ iconKey, textKey };
-        int[] to = new int[] { R.id.left_icon, R.id.text };
-        listAdapter = new SimpleAdapter(context, list, R.layout.setup_row_layout, from, to);
-        listView.setAdapter(listAdapter);
-        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                if (position == 0) {
-                    startActivity(new Intent(Settings.ACTION_INPUT_METHOD_SETTINGS));
-                }
-                else if (position == 1) {
-                    InputMethodManager imManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-                    if(imManager != null) {
-                        imManager.showInputMethodPicker();
-                    } else {
-                        Log.e("setupActivity.onCreate", "Failed to get system service INPUT_METHOD_SERVICE");
-                    }
-                }
-            }
-        });
-    }
-    
-    @Override
-    protected void onResume() {
-        super.onResume();
-    }
-    
-    @Override
-    protected void onPause() {
-        super.onPause();
-    }
-    
-    @Override
-    public void onWindowFocusChanged(boolean hasFocus) {
-        super.onWindowFocusChanged(hasFocus);
-        if (hasFocus) {
-            String checkbox_off = String.valueOf(android.R.drawable.checkbox_off_background);
-            String checkbox_on = String.valueOf(android.R.drawable.checkbox_on_background);
+    list = new ArrayList<>();
+    HashMap<String, String> hashMap;
 
-            if (isEnabledSystemWide(this)) {
-                list.get(0).put(iconKey, checkbox_on);
-                list.get(1).put(isEnabledKey, "true");
-            }
-            else {
-                list.get(0).put(iconKey, checkbox_off);
-                list.get(1).put(isEnabledKey, "false");
-            }
+    hashMap = new HashMap<>();
+    hashMap.put(iconKey, "0");
+    hashMap.put(textKey, "Enable 'FirstVoices'");
+    hashMap.put(isEnabledKey, "true");
+    list.add(hashMap);
 
-            if (isDefaultKB(this))
-                list.get(1).put(iconKey, checkbox_on);
-            else
-                list.get(1).put(iconKey, checkbox_off);
+    hashMap = new HashMap<>();
+    hashMap.put(iconKey, "0");
+    hashMap.put(textKey, "Choose 'FirstVoices' as current input method");
+    hashMap.put(isEnabledKey, "false");
+    list.add(hashMap);
 
-            String[] from = new String[]{ iconKey, textKey };
-            int[] to = new int[] { R.id.left_icon, R.id.text };
-            listAdapter = new SimpleAdapter(this, list, R.layout.setup_row_layout, from, to);
-            listView.setAdapter(listAdapter);
+    hashMap = new HashMap<>();
+    hashMap.put(iconKey, "0");
+    hashMap.put(textKey, "Show On-Screen Keyboard when physical keyboard is connected");
+    hashMap.put(isEnabledKey, "true");
+    list.add(hashMap);
+
+    String[] from = new String[]{iconKey, textKey};
+    int[] to = new int[]{R.id.left_icon, R.id.text};
+    listAdapter = new SimpleAdapter(context, list, R.layout.setup_row_layout, from, to);
+    listView.setAdapter(listAdapter);
+    listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+      @Override
+      public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        if (position == 0) {
+          startActivity(new Intent(Settings.ACTION_INPUT_METHOD_SETTINGS));
+        } else if (position == 1) {
+          InputMethodManager imManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+          if (imManager != null) {
+            imManager.showInputMethodPicker();
+          } else {
+            Log.e("setupActivity.onCreate", "Failed to get system service INPUT_METHOD_SERVICE");
+          }
+        } else if (position == 2) {
+          // Toggle Show On-Screen Keyboard setting
+          boolean showOSK = !isShowOSK();
+          if (editor != null) {
+            editor.putBoolean(PreferencesManager.oskWithPhysicalKeyboardKey,
+              showOSK);
+            editor.commit();
+          }
+
+          updateShowOSKCheckbox(showOSK);
         }
+        listAdapter.notifyDataSetChanged();
+      }
+    });
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+  }
+
+  @Override
+  public void onWindowFocusChanged(boolean hasFocus) {
+    super.onWindowFocusChanged(hasFocus);
+    if (hasFocus) {
+      String checkbox_off = String.valueOf(android.R.drawable.checkbox_off_background);
+      String checkbox_on = String.valueOf(android.R.drawable.checkbox_on_background);
+
+      if (isEnabledSystemWide(this)) {
+        list.get(0).put(iconKey, checkbox_on);
+        list.get(1).put(isEnabledKey, "true");
+      } else {
+        list.get(0).put(iconKey, checkbox_off);
+        list.get(1).put(isEnabledKey, "false");
+      }
+
+      if (isDefaultKB(this))
+        list.get(1).put(iconKey, checkbox_on);
+      else
+        list.get(1).put(iconKey, checkbox_off);
+
+      updateShowOSKCheckbox(isShowOSK());
+
+      String[] from = new String[]{iconKey, textKey};
+      int[] to = new int[]{R.id.left_icon, R.id.text};
+      listAdapter = new SimpleAdapter(this, list, R.layout.setup_row_layout, from, to);
+      listView.setAdapter(listAdapter);
     }
+  }
+
+  private void updateShowOSKCheckbox(boolean showOSK) {
+    String checkbox_off = String.valueOf(android.R.drawable.checkbox_off_background);
+    String checkbox_on = String.valueOf(android.R.drawable.checkbox_on_background);
+
+    if (showOSK) {
+      list.get(2).put(iconKey, checkbox_on);
+    } else {
+      list.get(2).put(iconKey, checkbox_off);
+    }
+  }
 
     static boolean isEnabledSystemWide(Context context) {
         InputMethodManager imManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -148,5 +183,14 @@ public class SetupActivity extends AppCompatActivity {
     static boolean isDefaultKB(Context context) {
         String inputMethod = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
         return inputMethod.equals("com.firstvoices.keyboards/.SystemKeyboard");
+    }
+
+    static boolean isShowOSK() {
+      boolean showOSK = false;
+      if (prefs != null) {
+        showOSK = prefs.getBoolean(
+          PreferencesManager.oskWithPhysicalKeyboardKey, false);
+      }
+      return showOSK;
     }
 }

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -246,9 +246,11 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
         return true;
       };
 
-      // TODO: Implement IME setting similar to Gboard "Show on-screen keyboard" with physical keyboard
-      // (default false)
-      return true;
+      SharedPreferences prefs = this.getSharedPreferences(
+        PreferencesManager.fv_prefs_name, Context.MODE_PRIVATE);
+      boolean showOSK = prefs.getBoolean(
+        PreferencesManager.oskWithPhysicalKeyboardKey, false);
+      return showOSK;
     }
 
     @Override


### PR DESCRIPTION
Follows #14539 in addressing #14533

This adds a FirstVoices app setting preference to show the on-screen keyboard while using physical keyboard.
Unlike the Keyman app, the FirstVoices app doesn't have an app-level Settings page. So I added the toggle to the "Setup" menu

<img width="240" height="533" alt="fv-show-osk" src="https://github.com/user-attachments/assets/78e4628f-a6ed-4a56-93ab-d9d36e0c2e62" />


## User Testing
**Setup** - Install the PR build of FirstVoices for Android on an Android emulator of API 36.

Configure Gboard to display on-screen keyboard:
device Settings --> Keyboard --> On-screen keyboard --> click Gboard --> Physical keyboard --> Show on-screen keyboard to "on"
back to Gboard settings --> write in text fields --> Use stylus to write in text fields , set to "off"

Configure FirstVoices --> Select keyboards --> Region --> BC Coast --> Sencoten --> Enable keyboard
FirstVoices --> Setup --> enable FirstVoices and enable as the current input method


* **TEST_PREFERENCE_OFF** - Verifies FirstVoices OSK doesn't appear by default
1. Launch FirstVoices
2. Got to Setup --> verify "Show on-screen keyboard" has a default value off
3. Launch Chrome and select a text area
4. Verify the FirstVoices system OSK does not appear

* **TEST_PREFERENCE_ON** - Verifies FirstVoices OSK appears when "Show OSK" is on
1. Launch FirstVoices
2. Got to Setup --> set "Show on-screen keyboard" to on
3. Completely close the FirstVoices app
4. Launch Chrome and select a text area
5. If the system keyboard is Gboard, longpress the globe button to switch to FirstVoices system keyboard
6. Verify the FirstVoices system OSK appears
7. Verify the FirstVoices Sencoten keyboard and suggestion banner functions