### PR TITLE
fix(android): Show system OSK when physical keyboard connected 🍒

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -279,6 +279,20 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   }
 
   @Override
+  public boolean onEvaluateInputViewShown() {
+    // On Android API 36+, the OSK defaults to not appearing when a physical keyboard is connected.
+    // If the default implementation returns true, recommend honoring it
+    // Reference: https://android.googlesource.com/platform/frameworks/base/+/7b739a8%5E%21/
+    if (super.onEvaluateInputViewShown()) {
+      return true;
+    };
+
+    // TODO: Implement IME setting similar to Gboard "Show on-screen keyboard" with physical keyboard
+    // (default false)
+    return true;
+  }
+
+  @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
     // Determine if Physical keystroke should be passed off
     if (inputType == InputType.TYPE_NULL) {

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -216,6 +216,20 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   }
 
   @Override
+  public boolean onEvaluateInputViewShown() {
+    // On Android API 36+, the OSK defaults to not appearing when a physical keyboard is connected.
+    // If the default implementation returns true, recommend honoring it
+    // Reference: https://android.googlesource.com/platform/frameworks/base/+/7b739a8%5E%21/
+    if (super.onEvaluateInputViewShown()) {
+      return true;
+    };
+
+    // TODO: Implement IME setting similar to Gboard "Show on-screen keyboard" with physical keyboard
+    // (default false)
+    return true;
+  }
+
+  @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
     if (event.getAction() == KeyEvent.ACTION_DOWN) {
       switch (keyCode) {

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -238,6 +238,20 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     }
 
     @Override
+    public boolean onEvaluateInputViewShown() {
+      // On Android API 36+, the OSK defaults to not appearing when a physical keyboard is connected.
+      // If the default implementation returns true, recommend honoring it
+      // Reference: https://android.googlesource.com/platform/frameworks/base/+/7b739a8%5E%21/
+      if (super.onEvaluateInputViewShown()) {
+        return true;
+      };
+
+      // TODO: Implement IME setting similar to Gboard "Show on-screen keyboard" with physical keyboard
+      // (default false)
+      return true;
+    }
+
+    @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         if (event.getAction() == KeyEvent.ACTION_DOWN) {
             switch (keyCode) {


### PR DESCRIPTION
:cherries: pick of #14538 to stable-18.0 for #14533

Android emulator on API 36 (Android 16.0 Baklava) has a new behavior where the system On-Screen Keyboard doesn't appear because the physical keyboard of the host computer is connected. The Gboard keyboard has a preference toggle to "Show on-screen keyboard while using physical keyboard" (default false)

This PR overrides the SystemKeyboard handler to display the OSK while using physical keyboard (on the Keyman, Sample2, and FirstVoices apps)

## User Testing
**Setup** - Setup Android emulator for API 36. Also set Gboard to display on-screen keyboard:
device Settings --> Keyboard --> On-screen keyboard --> click Gboard --> Physical keyboard --> Show on-screen keyboard to "on"
back to Gboard settings --> write in text fields --> Use stylus to write in text fields , set to "off"

For each test, install the corresponding PR build

* **TEST_KEYMAN** - Verifies Keyman system keyboard appears and functions
1. Install Keyman for Android
2. Launch Keyman and from the "Get Started" menu, set Keyman as the default system keyboard
3. Launch Chrome and select a text field
4. With Keyman as the system keyboard, verify the OSK appears
5. Type on the Keyman system keyboard and verify typing and suggestions function

* **TEST_KMSAMPLE2** - Verifies the Sample2 system keyboard appears and functions
1. Install KMSample2 app
2. Launch KMSample2 and from the menus, set KMSample2 as the default system keyboard
3. Launch Chrome and select a text field
4. With KMSample2 as the system keyboard, verify the OSK appears
5. Type on the KMSample2 system keyboard (Amharic) and verify typing and suggestions function

* **TEST_FirstVoices** - Verifies FirstVoices system keyboard appears and functions
1. Install FirstVoices for Android
2. Launch FirstVoices
3. From the setup menu, Select keyboards --> Region --> BC Coast - -> Sencoten --> enable Sencoten keyboard
4. Return the setup menu
5. From the setup menu --> Setup --> enable FirstVoice as the default system keyboard
6. Launch Chrome and select a text field
7. With FirstVoices as the system keyboard, verify the OSK appears
8. Type on the FirstVoices Sencoten system keyboard and verify typing and suggestions function

