### PR TITLE
maint(resources): use 'pending' instead of 'in_progress' for consolidated check

### DIFF
--- a/.github/workflows/pr-build-status.yml
+++ b/.github/workflows/pr-build-status.yml
@@ -172,14 +172,14 @@ jobs:
                 repo,
                 head_sha: sha,
                 name: 'Build Outcome',
-                status: 'in_progress',
+                status: 'pending',
               });
               return check.data.id;
             }
 
             async function updateCheck(github, owner, repo, checkRunId, status, description) {
-              const checkStatus = status == 'pending' ? 'in_progress' : 'completed';
-              const conclusion = checkStatus == 'in_progress' ? undefined : (status == 'success' ? 'success' : 'failure');
+              const checkStatus = status == 'pending' ? 'pending' : 'completed';
+              const conclusion = checkStatus == 'pending' ? undefined : (status == 'success' ? 'success' : 'failure');
 
               await github.rest.checks.update({
                 owner,

--- a/resources/build/pr-build-status/pr-build-status.mjs
+++ b/resources/build/pr-build-status/pr-build-status.mjs
@@ -144,14 +144,14 @@
                 repo,
                 head_sha: sha,
                 name: 'Build Outcome',
-                status: 'in_progress',
+                status: 'pending',
               });
               return check.data.id;
             }
 
             async function updateCheck(github, owner, repo, checkRunId, status, description) {
-              const checkStatus = status == 'pending' ? 'in_progress' : 'completed';
-              const conclusion = checkStatus == 'in_progress' ? undefined : (status == 'success' ? 'success' : 'failure');
+              const checkStatus = status == 'pending' ? 'pending' : 'completed';
+              const conclusion = checkStatus == 'pending' ? undefined : (status == 'success' ? 'success' : 'failure');
 
               await github.rest.checks.update({
                 owner,


### PR DESCRIPTION
The 'pending' state is more accurate than 'in_progress' for the build status result, and less visually distracting.

Test-bot: skip
Build-bot: skip