### PR TITLE
fix(android): polyfill globalThis for API 28 devices 🍒  🏠

### DIFF
--- a/android/KMEA/app/src/main/assets/other-polyfills.js
+++ b/android/KMEA/app/src/main/assets/other-polyfills.js
@@ -18,4 +18,6 @@ if(!Array.prototype.includes){
 
 // This file is only referenced by the main Web engine; its "global" object is `window`.
 // `globalThis` is defined in Chrome 71+.
-var globalThis = window;
+if(typeof globalThis == 'undefined') {
+  var globalThis = window;
+}


### PR DESCRIPTION
Fixes: https://github.com/keymanapp/keyman/issues/14450
Cherry-pick-of: https://github.com/keymanapp/keyman/pull/14541

## User Testing

TEST_REPRO_ISSUE:  Attempt to repro the original issue and verify that the keyboard is visible.

- Install on Android device/emulator Android API 28.
- Observe the keyboard is visible after the app launches.