### PR TITLE
maint(resources): handle unset build platform in trigger-build-bot

### DIFF
--- a/resources/build/ci/trigger-build-bot.inc.sh
+++ b/resources/build/ci/trigger-build-bot.inc.sh
@@ -172,7 +172,7 @@ function build_bot_update_commands() {
 
       local platform
       for platform in "${platforms[@]}"; do
-        if [[ "${build_platforms[$platform]}" != "${level}" ]]; then
+        if [[ "${build_platforms[$platform]+x}" != "${level}" ]]; then
           builder_echo "Build-bot: Updating build level for $platform to $level"
           build_platforms[$platform]=$level
         fi


### PR DESCRIPTION
When #14551 and #14552 merged, it resulted in a bug which was exposed by the unit tests (yay!).

Follows: #14551
Follows: #14552
Build-bot: skip:all build:common_windows,common_mac,common_linux
Test-bot: skip