### PR TITLE
fix(android): Update sentry-android to 8.19.1

### DIFF
--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.9.2'
         // sentry-android-gradle-plugin 2.1.5+ requires AGP 7.0
-        classpath 'io.sentry:sentry-android-gradle-plugin:4.6.0'
+        classpath 'io.sentry:sentry-android-gradle-plugin:5.9.0'
         classpath 'name.remal:gradle-plugins:1.9.2'
 
         // From jcenter() which was deprecated August 2024

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -171,7 +171,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'com.stepstone.stepper:material-stepper:4.3.1'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation 'io.sentry:sentry-android:7.8.0'
+    implementation 'io.sentry:sentry-android:8.19.1'
     implementation 'androidx.preference:preference:1.2.1'
     implementation "com.android.installreferrer:installreferrer:2.2"
 

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     // material:1.7.0 will need Gradle plugin 7.1.0+
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'commons-io:commons-io:2.16.1'
-    implementation 'io.sentry:sentry-android:7.8.0'
+    implementation 'io.sentry:sentry-android:8.19.1'
     implementation 'androidx.preference:preference:1.2.1'
 
     // Robolectric

--- a/android/KMEA/build.gradle
+++ b/android/KMEA/build.gradle
@@ -7,7 +7,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.9.2'
         // io.sentry:sentry-android-gradle-plugin not available for library project
-        classpath 'io.sentry:sentry-android:7.8.0'
         classpath 'name.remal:gradle-plugins:1.9.2'
     }
 }

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
     api(name: 'keyman-engine', ext: 'aar')
-    implementation 'io.sentry:sentry-android:7.8.0'
+    implementation 'io.sentry:sentry-android:8.19.1'
     implementation 'androidx.preference:preference:1.2.1'
 }
 

--- a/oem/firstvoices/android/build.gradle
+++ b/oem/firstvoices/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.9.2'
-        classpath 'io.sentry:sentry-android-gradle-plugin:4.6.0'
+        classpath 'io.sentry:sentry-android-gradle-plugin:5.9.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
Fixes #14423

https://developer.android.com/guide/practices/page-sizes

> Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes on 64-bit devices.

Android changing from 4 KB memory page sizes to 16 KB to optimize for larger memory.

Apps are impacted if they use native code (e..g our Sentry dependency).
The latest Sentry libraries have been updated for 16 KB alignment.

Using the "[APK analyzer](https://developer.android.com/guide/practices/page-sizes#identify-native-code)" tool in Android Studio, I was able to verify the Keyman apk and internal .so libraries no longer have the alignment warnings.

<img width="929" height="590" alt="apk alignment" src="https://github.com/user-attachments/assets/84f55717-6d3b-494c-a302-2a4221be81f8" />

**Note:** Because KMEA is an .aar project, the android/KMEA/build.gradle ended up not needing the Sentry dependency because it's handled in android/KMEA/app/build.gradle. Only app-level projects need the sentry-android-gradle-plugin.


## User Testing

**Setup** - Create an Android emulator that uses a Pre-Release 16 KB Page Size image
* From Android Studio - Device Manager --> Add New Device --> Create Virtual Device
* Select Pixel 8a phone form factor --> 
    * API 36.0 Baklava
    * Services: Google Play Store
    * download the "Pre-Release 16 KB Page Size Google Play Intel_x86_64 Atom System image API 36.0" and select it
 * On this emulator, install the PR build of Keyman for Android

* **TEST_KEYBOARD_INSTALL** - Verifies Keyman functions and can install keyboard
1. Launch Keyman
2. From the "Get Started" menu, install sil_cameroon_qwerty keyboard from keyman.com.
3. Verify you can select a language during the keyboard installation and the sil_cameroon_qwerty keyboard can install
4. Return to Keyman and verify the sil_cameroon_qwerty keyboard functions
