### PR TITLE
maint(common): rename and move node-related script functions into node.inc.sh

### DIFF
--- a/resources/docker-images/docker-build.inc.sh
+++ b/resources/docker-images/docker-build.inc.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 # no hashbang for .inc.sh
 
-. "${KEYMAN_ROOT}/resources/build/utils.inc.sh"
+. "${KEYMAN_ROOT}/resources/build/node.inc.sh"
 
 _add_build_args() {
   local var=$1


### PR DESCRIPTION
Consolidates the node-related script functions into node.inc.sh, as part
of cleaning up the build scripts and making them easier to maintain into
the future.

Follows: #14540

Build-bot: skip
Test-bot: skip