### PR TITLE
fix(android): Update Gradle files to remove flatDir warnings

### DIFF
--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -3,9 +3,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        flatDir {
-            dirs "kMAPro/libs/com/stepstone/stepper/material-stepper/4.3.1/"
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.9.2'
@@ -13,9 +10,8 @@ buildscript {
         classpath 'io.sentry:sentry-android-gradle-plugin:5.9.0'
         classpath 'name.remal:gradle-plugins:1.9.2'
 
-        // From jcenter() which was deprecated August 2024
+        // jcenter() dependencies deprecated August 2024
         // https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
-        classpath 'com.stepstone.stepper:material-stepper:4.3.1@aar'
     }
 }
 

--- a/android/KMAPro/build.gradle
+++ b/android/KMAPro/build.gradle
@@ -9,9 +9,6 @@ buildscript {
         // sentry-android-gradle-plugin 2.1.5+ requires AGP 7.0
         classpath 'io.sentry:sentry-android-gradle-plugin:5.9.0'
         classpath 'name.remal:gradle-plugins:1.9.2'
-
-        // jcenter() dependencies deprecated August 2024
-        // https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
     }
 }
 

--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -76,8 +76,8 @@ fi
 if builder_start_action build; then
 
   # Copy Keyman Engine for Android
-  cp "$KEYMAN_ROOT/android/KMEA/app/build/outputs/aar/keyman-engine-${CONFIG}.aar" "$KEYMAN_ROOT/android/KMAPro/kMAPro/libs/keyman-engine.aar"
-
+  cp "${KEYMAN_ROOT}/android/KMEA/app/build/outputs/aar/keyman-engine-${CONFIG}.aar" "${KEYMAN_ROOT}/android/KMAPro/kMAPro/libs/keyman-engine.aar"
+  
   # Convert markdown to html for offline help
   build_help_html android KMAPro/kMAPro/src/main/assets/info
 

--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -114,6 +114,12 @@ android {
         disable 'MissingQuantity', 'MissingTranslation'
         lintConfig file("lint.xml")
     }
+
+    sourceSets {
+        main {
+            jniLibs.srcDirs = ['libs']
+        }
+    }
 }
 
 // how to configure the sentry android gradle plugin
@@ -158,9 +164,6 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 }
 
 repositories {
-    flatDir {
-        dirs 'libs'
-    }
     google()
 }
 
@@ -170,7 +173,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'com.stepstone.stepper:material-stepper:4.3.1'
-    api(name: 'keyman-engine', ext: 'aar')
+    implementation files('libs/keyman-engine.aar')
     implementation 'io.sentry:sentry-android:8.19.1'
     implementation 'androidx.preference:preference:1.2.1'
     implementation "com.android.installreferrer:installreferrer:2.2"

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -30,12 +30,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    sourceSets {
+        main {
+            jniLibs.srcDirs = ['libs']
+        }
+    }
 }
 
 repositories {
-    flatDir {
-        dirs 'libs'
-    }
     google()
 
 }
@@ -45,6 +48,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
-    api(name: 'keyman-engine', ext: 'aar')
+    implementation files('libs/keyman-engine.aar')
     implementation 'androidx.preference:preference:1.2.1'
 }

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -30,12 +30,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    sourceSets {
+        main {
+            jniLibs.srcDirs = ['libs']
+        }
+    }
 }
 
 repositories {
-    flatDir {
-        dirs 'libs'
-    }
     google()
 }
 
@@ -44,6 +47,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
-    api (name:'keyman-engine', ext:'aar')
+    implementation files('libs/keyman-engine.aar')
     implementation 'androidx.preference:preference:1.2.1'
 }

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -40,12 +40,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    sourceSets {
+        main {
+            jniLibs.srcDirs = ['libs']
+        }
+    }
 }
 
 repositories {
-    flatDir {
-        dirs 'libs'
-    }
     google()
     mavenCentral()
 }
@@ -55,6 +58,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
-    api (name:'keyman-engine', ext:'aar')
+    implementation files('libs/keyman-engine.aar')
     implementation 'androidx.preference:preference:1.2.1'
 }

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -74,6 +74,12 @@ android {
         disable 'MissingTranslation'
         lintConfig file("lint.xml")
     }
+
+    sourceSets {
+        main {
+            jniLibs.srcDirs = ['libs']
+        }
+    }
 }
 
 // how to configure the sentry android gradle plugin
@@ -119,9 +125,6 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 }
 
 repositories {
-    flatDir {
-        dirs 'libs'
-    }
     google()
     mavenCentral()
 }
@@ -131,7 +134,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
-    api(name: 'keyman-engine', ext: 'aar')
+    implementation files('libs/keyman-engine.aar')
     implementation 'io.sentry:sentry-android:8.19.1'
     implementation 'androidx.preference:preference:1.2.1'
 }


### PR DESCRIPTION
Fixes #13724 about Gradle warnings

> WARNING:Using flatDir should be avoided because it doesn't support any meta-data formats.

This basically involves using newer Gradle syntax when bringing in the internal material-stepper and keyman-engine .aar libraries. I verified local builds no longer generate the flatDir warning.

Impacts the Android projects that consume keyman-engine.aar

## User Testing

**Setup** - Install the PR build of the specified apps on an Android emulator/device (API 34 good)

* **TEST_KEYMAN** - Verifies keyboard installation and keyboard works
1. Install and launch Keyman for Android
2. Dismiss the Get Started menu and from Keyman settings, install sil_cameroon_qwerty keyboard from keyman.com
3. Verify keyboard installation has the steps to pick a language for the keyboard (this uses the material-stepper library)
4. Verify sil_cameroon_qwerty keyboard installs fine
5. Verify Keyman keyboard functions

* **TEST_FIRSTVOICES** - Verifies keyboard installation and keyboard works
1. Install and launch FirstVoices for Android
2. From the FirstVoices menu, install keyboard --> Region --> BC Coast --> Sencoten --> enable keyboard
3. From the FirstVoices setup menu, set FirstVoices as the default system keyboard
4. Launch Chrome app and select FirstVoices as the keyboard
5. Verify FirstVoices Sencoten keyboard appears and functions
