### PR TITLE
maint(linux): create temporary worktree for packaging 🍒 🏠

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -42,6 +42,7 @@ dpkg-source \
   --tar-ignore=experiments \
   --tar-ignore=debian \
   --tar-ignore=.github \
+  --tar-ignore=.pc \
   --tar-ignore=.vscode \
   --tar-ignore=.devcontainer \
   --tar-ignore=__pycache__ \

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -118,16 +118,16 @@ function push_to_github_and_create_pr() {
 }
 
 function cleanup_worktree() {
-  if [[ -d "linux/debianpackage" ]]; then
-    cp -r linux/debianpackage "${KEYMAN_ROOT}/linux"
+  if [[ -d "${WORKTREE_DIR:-}/linux/debianpackage" ]]; then
+    cp -r "${WORKTREE_DIR}/linux/debianpackage" "${KEYMAN_ROOT}/linux"
   fi
 
-  cd "${PREV_DIR:-}" || true
+  cd "${PREV_DIR:-}"
 
   if [[ -n "${WORKTREE_DIR:-}" ]] && [[ -d "${WORKTREE_DIR}" ]]; then
     builder_echo "Removing temporary worktree"
-    git worktree remove -f "${WORKTREE_DIR}" || true
-    git branch -f -D "${WORKTREE_BRANCH}" || true
+    git worktree remove -f "${WORKTREE_DIR}"
+    git branch -f -D "${WORKTREE_BRANCH}"
   fi
 }
 
@@ -143,7 +143,7 @@ fi
 
 # Create a temporary worktree so that we start with a clean copy of the
 # target branch (stable/beta). Checkout stable/beta branch so that
-# `scripts/debian.sh` picks up correct version
+# scripts/debian.sh picks up correct version
 
 WORKTREE_BRANCH="maint/linux/tmp-packaging-${DEPLOY_BRANCH#origin/}"
 PREV_DIR="$PWD"
@@ -151,6 +151,7 @@ PREV_DIR="$PWD"
 WORKTREE_DIR="$(git worktree list | grep "${WORKTREE_BRANCH}" | cut -d' ' -f1)"
 if [[ -n "${WORKTREE_DIR}" ]] && [[ -d "${WORKTREE_DIR}" ]]; then
   builder_heading "Reusing existing worktree at ${WORKTREE_DIR}"
+  git checkout -B "${WORKTREE_BRANCH}" "${DEPLOY_BRANCH#origin/}"
 else
   WORKTREE_DIR="$(mktemp -d)"
   builder_heading "Creating temporary worktree at ${WORKTREE_DIR}"

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -118,6 +118,10 @@ function push_to_github_and_create_pr() {
 }
 
 function cleanup_worktree() {
+  if [[ -d "linux/debianpackage" ]]; then
+    cp -r linux/debianpackage "${KEYMAN_ROOT}/linux"
+  fi
+
   cd "${PREV_DIR:-}" || true
 
   if [[ -n "${WORKTREE_DIR:-}" ]] && [[ -d "${WORKTREE_DIR}" ]]; then

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -117,6 +117,16 @@ function push_to_github_and_create_pr() {
   fi
 }
 
+function cleanup_worktree() {
+  cd "${PREV_DIR:-}" || true
+
+  if [[ -n "${WORKTREE_DIR:-}" ]] && [[ -d "${WORKTREE_DIR}" ]]; then
+    builder_echo "Removing temporary worktree"
+    git worktree remove -f "${WORKTREE_DIR}" || true
+    git branch -f -D "${WORKTREE_BRANCH}" || true
+  fi
+}
+
 builder_heading "Fetching latest changes"
 git fetch -p origin
 
@@ -127,12 +137,32 @@ else
   DEPLOY_BRANCH=$(get_latest_stable_branch_name)
 fi
 
-# Checkout stable/beta branch so that `scripts/debian.sh` picks up correct version
-git checkout "${DEPLOY_BRANCH#origin/}"
+# Create a temporary worktree so that we start with a clean copy of the
+# target branch (stable/beta). Checkout stable/beta branch so that
+# `scripts/debian.sh` picks up correct version
+
+WORKTREE_BRANCH="maint/linux/tmp-packaging-${DEPLOY_BRANCH#origin/}"
+PREV_DIR="$PWD"
+
+WORKTREE_DIR="$(git worktree list | grep "${WORKTREE_BRANCH}" | cut -d' ' -f1)"
+if [[ -n "${WORKTREE_DIR}" ]] && [[ -d "${WORKTREE_DIR}" ]]; then
+  builder_heading "Reusing existing worktree at ${WORKTREE_DIR}"
+else
+  WORKTREE_DIR="$(mktemp -d)"
+  builder_heading "Creating temporary worktree at ${WORKTREE_DIR}"
+  if git branch | grep -q "${WORKTREE_BRANCH}"; then
+    git branch -f -D "${WORKTREE_BRANCH}"
+  fi
+  git worktree add -f -b "${WORKTREE_BRANCH}" "${WORKTREE_DIR}" "${DEPLOY_BRANCH#origin/}"
+fi
+cd "${WORKTREE_DIR}"
+
+trap cleanup_worktree EXIT
+
 git pull origin "${DEPLOY_BRANCH#origin/}"
 
 builder_heading "Building source package"
-cd "${KEYMAN_ROOT}/linux"
+cd "${WORKTREE_DIR}/linux"
 DIST=unstable DEBREVISION=${REVISION} scripts/debian.sh
 cd debianpackage/
 builder_heading "Signing source package"
@@ -159,4 +189,4 @@ push_to_github_and_create_pr chore/linux/cherry-pick/changelog master "${COMMIT_
 @keymanapp-test-bot skip"
 
 builder_heading "Finishing"
-git checkout "${CURRENT_BRANCH}"
+cleanup_worktree


### PR DESCRIPTION
This change creates a temporary worktree for creating Debian packages. This will allow us to work from a clean state of the source repo. Also exclude any generated patch directories (`.pc`).

Cherry-pick-of: #14598
Build-bot: skip
Test-bot: skip