### PR TITLE
maint(linux): ignore generate patch directories

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -42,6 +42,7 @@ dpkg-source \
   --tar-ignore=experiments \
   --tar-ignore=debian \
   --tar-ignore=.github \
+  --tar-ignore=.pc \
   --tar-ignore=.vscode \
   --tar-ignore=.devcontainer \
   --tar-ignore=__pycache__ \


### PR DESCRIPTION
During a package build a  patch directory (`.pc`) might get created. That can't and shouldn't be part of the source package. This change excludes any `.pc` directories.

Build-bot: skip
Test-bot: skip