### PR TITLE
maint(linux): generate tar-ignore in `dist.sh`

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -15,7 +15,12 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../resources/build/builder-basic.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
+# shellcheck disable=SC2154
+. "${KEYMAN_ROOT}/linux/scripts/package-build.inc.sh"
+
 BASEDIR=$(pwd)
+
+cd "${KEYMAN_ROOT}/linux"
 
 if [[ ! -z ${1+x} ]] && [[ "$1" == "origdist" ]]; then
     create_origdist=1
@@ -27,13 +32,46 @@ mkdir -p dist
 
 # dist for keyman
 cp -a debian ../
-cd ..
+cd "${KEYMAN_ROOT}"
 echo "3.0 (native)" > debian/source/format
+# shellcheck disable=SC2154
 dch keyman --newversion "${KEYMAN_VERSION}" --force-bad-version --nomultimaint
 
 # Create the tarball
-# Note: the files end up in subdirectories under `keyman`, so we can
-# include that when matching files and directories to ignore.
+
+# shellcheck disable=2034
+to_include=(
+  common/build.sh \
+  common/cpp \
+  common/include \
+  common/linux \
+  common/test/keyboards/baseline \
+  core \
+  linux \
+  resources/build/*.sh \
+  resources/build/meson \
+  resources/standards-data \
+  resources/*.sh \
+  ./*.md \
+  ./build.sh \
+  ./*.json \
+)
+
+# shellcheck disable=2034
+to_exclude=(
+  common/test/keyboards/baseline/kmcomp-*.zip \
+  core/build \
+  linux/build \
+  linux/builddebs \
+  linux/docs/help \
+  linux/keyman-config/keyman_config/version.py \
+  linux/keyman-config/buildtools/build-langtags.py \
+  linux/keyman-system-service/build
+)
+ignored_files=()
+
+generate_tar_ignore_list "./" to_include to_exclude ignored_files "$(basename "${KEYMAN_ROOT}")"
+
 dpkg-source \
   --tar-ignore=*~ \
   --tar-ignore=.git \
@@ -44,66 +82,14 @@ dpkg-source \
   --tar-ignore=.github \
   --tar-ignore=.vscode \
   --tar-ignore=.devcontainer \
+  --tar-ignore=.pc \
   --tar-ignore=__pycache__ \
   --tar-ignore=node_modules \
   --tar-ignore=keyman_1* \
   --tar-ignore=dist \
   --tar-ignore=VERSION \
   \
-  --tar-ignore=keyman/android \
-  --tar-ignore=keyman/artifacts \
-  \
-  --tar-ignore=keyman/common/mac \
-  --tar-ignore=keyman/common/models \
-  --tar-ignore=keyman/common/resources \
-  --tar-ignore=keyman/common/schemas \
-  --tar-ignore=keyman/common/test/keyboards/baseline/kmcomp-*.zip \
-  --tar-ignore=keyman/common/test/keyboards/build.* \
-  --tar-ignore=keyman/common/test/keyboards/caps* \
-  --tar-ignore=keyman/common/test/keyboards/full* \
-  --tar-ignore=keyman/common/test/keyboards/invalid \
-  --tar-ignore=keyman/common/test/keyboards/issue \
-  --tar-ignore=keyman/common/test/keyboards/obolo* \
-  --tar-ignore=keyman/common/test/keyboards/start* \
-  --tar-ignore=keyman/common/test/keyboards/text* \
-  --tar-ignore=keyman/common/test/keyboards/u* \
-  --tar-ignore=keyman/common/test/keyboards/web* \
-  --tar-ignore=keyman/common/test/resources \
-  --tar-ignore=keyman/common/tools \
-  --tar-ignore=keyman/common/web \
-  --tar-ignore=keyman/common/windows \
-  \
-  --tar-ignore=keyman/core/build \
-  --tar-ignore=keyman/developer \
-  --tar-ignore=keyman/docs \
-  --tar-ignore=keyman/ios \
-  --tar-ignore=keyman/linux/build \
-  --tar-ignore=keyman/linux/builddebs \
-  --tar-ignore=keyman/linux/docs/help \
-  --tar-ignore=keyman/linux/ibus-keyman/build \
-  --tar-ignore=keyman/linux/keyman-config/keyman_config/version.py \
-  --tar-ignore=keyman/linux/keyman-config/buildtools/build-langtags.py \
-  --tar-ignore=keyman/linux/keyman-system-service/build \
-  --tar-ignore=keyman/mac \
-  --tar-ignore=keyman/oem \
-  --tar-ignore=keyman/resources/devbox \
-  --tar-ignore=keyman/resources/docker-images \
-  --tar-ignore=keyman/resources/environment.sh \
-  --tar-ignore=keyman/resources/build/ci \
-  --tar-ignore=keyman/resources/build/history \
-  --tar-ignore=keyman/resources/build/mac \
-  --tar-ignore=keyman/resources/build/pr-build-status \
-  --tar-ignore=keyman/resources/build/version \
-  --tar-ignore=keyman/resources/build/win \
-  --tar-ignore=keyman/resources/git-hooks \
-  --tar-ignore=keyman/resources/scopes \
-  --tar-ignore=keyman/resources/teamcity \
-  --tar-ignore=keyman/resources/build/*.lua \
-  --tar-ignore=keyman/resources/build/jq-* \
-  --tar-ignore=keyman/results \
-  --tar-ignore=keyman/tmp \
-  --tar-ignore=keyman/web \
-  --tar-ignore=keyman/windows \
+  "${ignored_files[@]}" \
   \
   -Zgzip -b .
 mv ../keyman_"${KEYMAN_VERSION}".tar.gz linux/dist/keyman-"${KEYMAN_VERSION}".tar.gz
@@ -113,7 +99,7 @@ cd "${BASEDIR}"
 # create orig.tar.gz
 if [[ ! -z "${create_origdist+x}" ]]; then
     cd dist
-    pkgvers="keyman-$KEYMAN_VERSION"
+    pkgvers="keyman-${KEYMAN_VERSION}"
     tar xfz keyman-"${KEYMAN_VERSION}".tar.gz
     mv -v keyman "${pkgvers}" 2>/dev/null || mv -v "$(find . -mindepth 1 -maxdepth 1 -type d)" "${pkgvers}"
     tar cfz "keyman_${KEYMAN_VERSION}.orig.tar.gz" "${pkgvers}"

--- a/linux/scripts/package-build.inc.sh
+++ b/linux/scripts/package-build.inc.sh
@@ -80,3 +80,87 @@ function checkAndInstallRequirements()
     apt-get -qy --allow-downgrades install ./keyman-build-deps_*.deb
   rm -f keyman-build-deps_*
 }
+
+# Generate an array of files and directories to ignore, prefixed with --tar-ignore=keyman/
+function generate_tar_ignore_list() {
+  local directory="$1"
+  local includes_var="$2"
+  local excludes_var="$3"
+  local list_var="$4"
+  local prefix="$5"
+  local includes_array="${includes_var}[@]"
+  local includes=("${!includes_array}")
+  local excludes_array="${excludes_var}[@]"
+  local excludes=("${!excludes_array}")
+  local dir all_dirs found_match inc
+
+  mapfile -t all_dirs < <(find "${directory}" -mindepth 1 -maxdepth 1 -type d | sort)
+  for dir in "${all_dirs[@]}"; do
+    found_match=false
+    for inc in "${includes[@]}"; do
+      if [[ "./${inc}" =~ ^${dir} ]]; then
+        found_match=true
+        if [[ "./${inc}" != "${dir}" ]]; then
+          # check subdirectories
+          generate_tar_ignore_list "${dir}" "${includes_var}" "${excludes_var}" "${list_var}" "${prefix}"
+        fi
+        # check if files/subdir in $dir are in excludes list
+        _generate_excludes_for_dir "${dir}" "${includes_var}" "${excludes_var}" "${list_var}"
+        break
+      fi
+    done
+    if ! ${found_match}; then
+      _add_to_list "${list_var}" "${dir}"
+    fi
+  done
+}
+
+function _generate_excludes_for_dir() {
+  local directory="$1"
+  local includes_var="$2"
+  local excludes_var="$3"
+  local list_var="$4"
+  local includes_array="${includes_var}[@]"
+  local includes=("${!includes_array}")
+  local excludes_array="${excludes_var}[@]"
+  local excludes=("${!excludes_array}")
+  local file all_files excluded included is_match
+
+  mapfile -t all_files < <(find "${directory}" -mindepth 1 -maxdepth 1 | sort)
+  is_match=false
+  for file in "${all_files[@]}"; do
+    for included in "${includes[@]}"; do
+      if [[ "${file}" == ./${included} ]]; then
+        is_match=true
+        break
+      fi
+    done
+    if ${is_match} ; then
+      if [[ "${file}" != ./${included} ]] && [[ -f "${file}" ]]; then
+      _add_to_list "${list_var}" "${file}"
+      fi
+    else
+      for excluded in "${excludes[@]}"; do
+        if [[ "${file}" == ./${excluded} ]]; then
+          _add_to_list "${list_var}" "${file}"
+          break
+        elif [[ "./${excluded}" =~ ^${file} ]]; then
+          # check subdirectories
+          _generate_excludes_for_dir "${file}" "${includes_var}" "${excludes_var}" "${list_var}"
+          break
+        fi
+      done
+    fi
+  done
+}
+
+function _add_to_list() {
+  local list_var="$1"
+  local filename="$2"
+
+  # Note: the files end up in subdirectories under `keyman` (or rather
+  # the directory name of $KEYMAN_ROOT), so we can
+  # include that when matching files and directories to ignore.
+  # shellcheck disable=SC2154
+  eval "${list_var}+=(\"--tar-ignore=${prefix}/${filename#./}\")"
+}

--- a/linux/scripts/test/package-build.inc.tests.sh
+++ b/linux/scripts/test/package-build.inc.tests.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# shellcheck disable=2034,1091,2154
+set -eu
+
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../resources/build/builder-basic.inc.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+. "${KEYMAN_ROOT}/resources/build/test/testing-framework.inc.sh"
+. "${KEYMAN_ROOT}/linux/scripts/package-build.inc.sh"
+
+function setup_file() {
+  temp_dir="$(mktemp -d)"
+  # Create directory structure for testing
+  # /
+  # /subdir1
+  #         /build.sh
+  #         /README.md
+  #         /path1
+  #               /build.sh
+  #               /README.md
+  #         /path2
+  #               /build.sh
+  #         /path3
+  #               /build.sh
+  # /subdir2
+  #         /build.sh
+  #         /path1
+  # /subdir3
+  #         /build.sh
+  #         /path1
+  #         /path2
+  #         /path3
+  # /subdir4
+  #         /build.sh
+  #         /path1
+  #               /build.sh
+  #         /path2
+  #               /subpath1
+  #                        /build.sh
+  #               /subpath2
+  #                        /build.sh
+  #         /path3
+  #               /build.sh
+  # subdir1/path2, subdir2, subdir4/path1, subdir4/path2/subpath1,
+  # and subdir4/path3 will be ignored
+  mkdir -p "${temp_dir}/subdir1/path1"          # include
+  touch "${temp_dir}/subdir1/build.sh"
+  touch "${temp_dir}/subdir1/README.md"         # exclude
+  touch "${temp_dir}/subdir1/path1/build.sh"    # include
+  touch "${temp_dir}/subdir1/path1/README.md"   # exclude
+  mkdir -p "${temp_dir}/subdir1/path2"          # exclude
+  touch "${temp_dir}/subdir1/path2/build.sh"
+  mkdir -p "${temp_dir}/subdir1/path3"          # include
+  touch "${temp_dir}/subdir1/path3/build.sh"
+  mkdir -p "${temp_dir}/subdir2/path1"          # exclude
+  touch "${temp_dir}/subdir2/build.sh"
+  mkdir -p "${temp_dir}/subdir3/path1"          # include
+  touch "${temp_dir}/subdir3/build.sh"
+  mkdir -p "${temp_dir}/subdir3/path2"          # include
+  mkdir -p "${temp_dir}/subdir3/path3"          # include
+  mkdir -p "${temp_dir}/subdir4/path1"          # exclude
+  touch "${temp_dir}/subdir4/build.sh"
+  touch "${temp_dir}/subdir4/path1/build.sh"
+  mkdir -p "${temp_dir}/subdir4/path2/subpath1" # exclude
+  touch "${temp_dir}/subdir4/path2/subpath1/build.sh"
+  mkdir -p "${temp_dir}/subdir4/path2/subpath2" # include
+  touch "${temp_dir}/subdir4/path2/subpath2/build.sh"
+  mkdir -p "${temp_dir}/subdir4/path3"          # exclude
+  touch "${temp_dir}/subdir4/path3/build.sh"
+  touch "${temp_dir}/subdir4/path3/other.txt"
+}
+
+function teardown_file() {
+  rm -rf "${temp_dir}"
+}
+
+function test__generate_tar_ignore_list__basic() {
+  to_include=(subdir1/path1 subdir1/path3 subdir3 subdir4/path2)
+  to_exclude=(subdir1/README.md subdir4/path2/subpath1 subdir4/path2/subpath3)
+
+  cd "${temp_dir}"
+  ignored_files=()
+
+  # Execute
+  generate_tar_ignore_list "./" to_include to_exclude ignored_files test1
+
+  # Verify
+  expected=(
+    --tar-ignore=test1/subdir1/path2
+    --tar-ignore=test1/subdir1/README.md
+    --tar-ignore=test1/subdir2
+    --tar-ignore=test1/subdir4/path1
+    --tar-ignore=test1/subdir4/path2/subpath1
+    --tar-ignore=test1/subdir4/path3
+  )
+
+  assert-equal "${ignored_files[*]}" "${expected[*]}"
+}
+
+function test__generate_tar_ignore_list__path_wildcard_in_exclude() {
+  # Setup
+  to_include=(subdir1/path1 subdir1/path3 subdir3)
+  to_exclude=(subdir1/*/README.md subdir4/path2/subpath1 subdir4/path2/subpath3)
+
+  cd "${temp_dir}"
+  ignored_files=()
+
+  # Execute
+  generate_tar_ignore_list "./" to_include to_exclude ignored_files foo
+
+  # Verify
+  expected=(
+    --tar-ignore=foo/subdir1/path1/README.md  # in exclude
+    --tar-ignore=foo/subdir1/path2            # not in include
+    --tar-ignore=foo/subdir1/README.md        # not in include
+    --tar-ignore=foo/subdir2                  # not in include
+    --tar-ignore=foo/subdir4                  # not in include
+  )
+
+  assert-equal "${ignored_files[*]}" "${expected[*]}"
+}
+
+function test__generate_tar_ignore_list__file_wildcard_in_exclude() {
+  # Setup
+  to_include=(subdir1/path1 subdir1/path3 subdir3)
+  to_exclude=(*.sh)
+
+  cd "${temp_dir}"
+  ignored_files=()
+
+  # Execute
+  generate_tar_ignore_list "./" to_include to_exclude ignored_files keyman
+
+  # Verify
+  expected=(
+    --tar-ignore=keyman/subdir1/path1/build.sh  # in exclude
+    --tar-ignore=keyman/subdir1/path2           # not in include
+    --tar-ignore=keyman/subdir1/path3/build.sh  # in exclude
+    --tar-ignore=keyman/subdir1/build.sh        # not in include
+    --tar-ignore=keyman/subdir1/README.md       # not in include
+    --tar-ignore=keyman/subdir2                 # not in include
+    --tar-ignore=keyman/subdir3/build.sh        # in exclude
+    --tar-ignore=keyman/subdir4                 # not in include
+  )
+
+  assert-equal "${ignored_files[*]}" "${expected[*]}"
+}
+
+function test__generate_tar_ignore_list__file_wildcard_in_include() {
+  # Setup
+  to_include=(subdir1/path1 subdir1/path3 subdir3 subdir4/path3/*.sh)
+  to_exclude=(subdir1/README.md subdir4/path2/subpath1 subdir4/path2/subpath3)
+
+  cd "${temp_dir}"
+  ignored_files=()
+
+  # Execute
+  generate_tar_ignore_list "./" to_include to_exclude ignored_files xyz
+
+  # Verify
+  expected=(
+    --tar-ignore=xyz/subdir1/path2            # not in include
+    --tar-ignore=xyz/subdir1/README.md        # in exclude
+    --tar-ignore=xyz/subdir2                  # not in include
+    --tar-ignore=xyz/subdir4/path1            # not in include
+    --tar-ignore=xyz/subdir4/path2            # not in include
+    --tar-ignore=xyz/subdir4/path3/other.txt  # not in include
+    --tar-ignore=xyz/subdir4/path2/subpath1   # not necessary, but in exclude
+  )
+
+  assert-equal "${ignored_files[*]}" "${expected[*]}"
+}
+
+function test__generate_tar_ignore_list__path_wildcard_in_include() {
+  # Setup
+  to_include=(subdir1/path1 subdir1/path3 subdir3 subdir4/*/subpath2)
+  to_exclude=(subdir1/README.md)
+
+  cd "${temp_dir}"
+  ignored_files=()
+
+  # Execute
+  generate_tar_ignore_list "./" to_include to_exclude ignored_files bar
+
+  # Verify
+  expected=(
+    --tar-ignore=bar/subdir1/path2           # not in include
+    --tar-ignore=bar/subdir1/README.md       # not in include
+    --tar-ignore=bar/subdir2                 # not in include
+    --tar-ignore=bar/subdir4/path1           # not in include
+    --tar-ignore=bar/subdir4/path2/subpath1  # not in include
+    --tar-ignore=bar/subdir4/path3           # not in include
+  )
+
+  assert-equal "${ignored_files[*]}" "${expected[*]}"
+}
+
+function test__generate_tar_ignore_list__exclude_subsubdir() {
+  to_include=(subdir4)
+  to_exclude=(subdir4/path2/subpath2)
+
+  cd "${temp_dir}"
+  ignored_files=()
+
+  # Execute
+  generate_tar_ignore_list "./" to_include to_exclude ignored_files baz
+
+  # Verify
+  expected=(
+    --tar-ignore=baz/subdir1
+    --tar-ignore=baz/subdir2
+    --tar-ignore=baz/subdir3
+    --tar-ignore=baz/subdir4/path2/subpath2
+  )
+
+  assert-equal "${ignored_files[*]}" "${expected[*]}"
+}
+
+
+# shellcheck disable=2119
+run_tests

--- a/linux/scripts/test/test.sh
+++ b/linux/scripts/test/test.sh
@@ -3,3 +3,4 @@ set -eu
 
 "$(dirname "$0")/deb-packaging.tests.sh"
 "$(dirname "$0")/verify_api.tests.sh"
+"$(dirname "$0")/package-build.inc.tests.sh"


### PR DESCRIPTION
This generates the `--tar-ignore`s to avoid having to manually maintain the list when adding new files or folders for other platforms. Instead now we have a list of files and directories to include, and a list of exceptions to exclude from the includes. From that we generate the tar-ignore list.

Fixes: #14563
Test-bot: skip