### PR TITLE
fix(web): improve context transition handling when wordbreaking shifts at sliding-context start

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/alignment-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/alignment-helpers.ts
@@ -9,7 +9,7 @@
  */
 
 import { SENTINEL_CODE_UNIT } from '@keymanapp/models-templates';
-import { ClassicalDistanceCalculation, EditOperation } from "./classical-calculation.js";
+import { ClassicalDistanceCalculation, EditOperation, EditTuple } from "./classical-calculation.js";
 
 /**
  * Represents token-count values resulting from an alignment attempt between two
@@ -40,6 +40,15 @@ export type ContextStateAlignment = {
    * For the alignment, [base context index] + leadTokenShift = [incoming context index].
    */
   leadTokenShift: number,
+  /**
+   * Notes the number of tokens at the head of the 'incoming'/'new' context,
+   * perfectly aligned but edited for two successfully-alignable contexts. These
+   * tokens directly precede those that need no edits.
+   *
+   * When a token could be considered as either 'lead' or 'tail' edit, it will
+   * only be reported as a 'tail' edit.
+   */
+  leadEditLength: number,
   /**
    * The count of tokens perfectly aligned, with no need for edits, for two successfully-
    * alignable contexts.
@@ -236,7 +245,10 @@ export function computeAlignment(
     3
   );
 
-  let editPath = mapping.editPath()[0].map(t => t.op);
+  // Later iteration:  we could return this itself directly for use in alignment
+  // operations, rather than relying solely on the edit-op names.
+  const editPathTuples = mapping.editPath()[0] as EditTuple<string>[];
+  const editPath = editPathTuples.map(t => t.op);
 
   const failure: ContextStateAlignment = {
     canAlign: false,
@@ -272,6 +284,7 @@ export function computeAlignment(
       canAlign: true,
       matchLength: matchCount,
       leadTokenShift: 0,
+      leadEditLength: 0,
       tailEditLength: subCount,
       tailTokenShift: insertCount - deleteCount
     }
@@ -323,6 +336,7 @@ export function computeAlignment(
     return {
       canAlign: true,
       leadTokenShift: 0,
+      leadEditLength: 0,
       matchLength,
       tailEditLength: tailSubstituteLength,
       tailTokenShift: tailInsertLength - tailDeleteLength
@@ -356,14 +370,6 @@ export function computeAlignment(
         leadTokensRemoved++;
         break;
       case 'substitute':
-        // We only allow for one leading token to be substituted.
-        //
-        // Any extras in the front would be pure inserts, not substitutions, due to
-        // the sliding context window and its implications.
-        if(leadSubstitutions++ > 0) {
-          return failure;
-        }
-
         // Find the word before and after substitution.
         const incomingIndex = i - (leadTokensRemoved > 0 ? leadTokensRemoved : 0);
         const matchingIndex = i + (leadTokensRemoved < 0 ? leadTokensRemoved : 0);
@@ -380,9 +386,7 @@ export function computeAlignment(
           return failure;
         }
 
-        // There's no major need to drop parts of a token being 'slid' out of the context window.
-        // We'll leave it intact and treat it as a 'match'
-        matchLength++;
+        leadSubstitutions++;
         break;
       case 'insert':
         // Only allow an insert at the leading edge, as with 'delete's.
@@ -409,6 +413,7 @@ export function computeAlignment(
     // when aligning the contexts.  Externally, it's more helpful to think in terms of the count added
     // to the incoming context.
     leadTokenShift: -leadTokensRemoved + 0, // add 0 in case of a 'negative zero', which affects unit tests.
+    leadEditLength: leadSubstitutions,
     matchLength,
     tailEditLength: tailSubstituteLength,
     tailTokenShift: tailInsertLength - tailDeleteLength

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -98,6 +98,7 @@ export class ContextTokenization {
 
     const {
       leadTokenShift,
+      leadEditLength,
       matchLength,
       tailEditLength,
       tailTokenShift
@@ -148,9 +149,12 @@ export class ContextTokenization {
 
     // If a word is being slid out of context-window range, start trimming it - we should
     // no longer need to worry about reusing its original correction-search results.
-    if(matchLength > 0 && this.tokens[matchingOffset].exampleInput != tokenizedContext[incomingOffset].text) {
-      //this.tokens[matchingOffset]'s clone is at tokenization[0] after the splice call in a previous block.
-      tokenization[0] = new ContextToken(lexicalModel, tokenizedContext[incomingOffset].text);
+    for(let i = 0; i < leadEditLength; i++) {
+      if(this.tokens[matchingOffset+i].exampleInput != tokenizedContext[incomingOffset+i].text) {
+        //this.tokens[matchingOffset]'s clone is at tokenization[incomingOffset]
+        //after the splice call in a previous block.
+        tokenization[incomingOffset+i] = new ContextToken(lexicalModel, tokenizedContext[incomingOffset+i].text);
+      }
     }
 
     // first non-matched tail index within the incoming context

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/alignment-helpers.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/alignment-helpers.tests.ts
@@ -134,6 +134,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 0,
+      leadEditLength: 0,
       matchLength: 5,
       tailEditLength: 0,
       tailTokenShift: 0
@@ -151,6 +152,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 0,
+      leadEditLength: 0,
       matchLength: 4,
       tailEditLength: 1,
       tailTokenShift: 0
@@ -171,6 +173,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 0,
+      leadEditLength: 0,
       matchLength: 0,
       tailEditLength: 1,
       tailTokenShift: 2
@@ -237,7 +240,8 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 0,
-      matchLength: 5,
+      leadEditLength: 1,
+      matchLength: 4,
       tailEditLength: 0,
       tailTokenShift: 0
     });
@@ -255,6 +259,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: -1,
+      leadEditLength: 0,
       matchLength: 4,
       tailEditLength: 0,
       tailTokenShift: 0
@@ -273,6 +278,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 1,
+      leadEditLength: 0,
       matchLength: 4,
       tailEditLength: 0,
       tailTokenShift: 0
@@ -291,7 +297,8 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: -2,
-      matchLength: 3,
+      leadEditLength: 1,
+      matchLength: 2,
       tailEditLength: 0,
       tailTokenShift: 0
     });
@@ -309,7 +316,8 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 1,
-      matchLength: 4,
+      leadEditLength: 1,
+      matchLength: 3,
       tailEditLength: 0,
       tailTokenShift: 0
     });
@@ -327,6 +335,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: -1,
+      leadEditLength: 0,
       matchLength: 4,
       tailEditLength: 0,
       tailTokenShift: 1
@@ -345,7 +354,8 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 0,
-      matchLength: 4, // we treat 'quick' and 'uick' as the same
+      leadEditLength: 1,
+      matchLength: 3,
       tailEditLength: 1,
       tailTokenShift: 0
     });
@@ -363,7 +373,8 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 0,
-      matchLength: 4, // we treat 'quick' and 'uick' as the same
+      leadEditLength: 1,
+      matchLength: 3,
       tailEditLength: 1,
       tailTokenShift: 1
     });
@@ -381,6 +392,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 1,
+      leadEditLength: 0,
       matchLength: 4, // we treat 'quick' and 'uick' as the same
       tailEditLength: 1,
       tailTokenShift: 0
@@ -399,6 +411,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 1,
+      leadEditLength: 0,
       matchLength: 4, // we treat 'quick' and 'uick' as the same
       tailEditLength: 0,
       tailTokenShift: -1
@@ -417,6 +430,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 1,
+      leadEditLength: 0,
       matchLength: 3, // we treat 'quick' and 'uick' as the same
       tailEditLength: 1,
       tailTokenShift: -1
@@ -483,6 +497,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 0,
+      leadEditLength: 0,
       matchLength: 8,
       tailEditLength: 3,
       tailTokenShift: 0
@@ -502,6 +517,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computedAlignment, {
       canAlign: true,
       leadTokenShift: 0,
+      leadEditLength: 0,
       matchLength: 10,
       tailEditLength: 1,
       tailTokenShift: 2
@@ -534,7 +550,8 @@ describe('computeAlignment', () => {
     assert.deepEqual(computeAlignment(baseContext1, incomingContext1, true), {
       canAlign: true,
       leadTokenShift: 0,
-      matchLength: 22,
+      leadEditLength: 1,
+      matchLength: 21,
       tailEditLength: 1,
       tailTokenShift: 0
     });
@@ -561,7 +578,8 @@ describe('computeAlignment', () => {
     assert.deepEqual(computeAlignment(baseContext2, incomingContext2, true), {
       canAlign: true,
       leadTokenShift: 0,
-      matchLength: 24,
+      leadEditLength: 1,
+      matchLength: 23,
       tailEditLength: 1,
       tailTokenShift: 0
     });
@@ -584,6 +602,7 @@ describe('computeAlignment', () => {
     assert.deepEqual(computeAlignment(baseContext3, incomingContext3, true), {
       canAlign: true,
       leadTokenShift: -1,
+      leadEditLength: 0,
       matchLength: 23,
       tailEditLength: 1,
       tailTokenShift: 0

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -46,6 +46,7 @@ describe('ContextTokenization', function() {
       let alignment: ContextStateAlignment = {
         canAlign: true,
         leadTokenShift: 0,
+        leadEditLength: 0,
         matchLength: 6,
         tailEditLength: 1,
         tailTokenShift: 0
@@ -67,6 +68,7 @@ describe('ContextTokenization', function() {
       let baseTokenization = new ContextTokenization(rawTextTokens.map((text => toToken(text))), {
         canAlign: true,
         leadTokenShift: 0,
+        leadEditLength: 0,
         matchLength: 6,
         tailEditLength: 1,
         tailTokenShift: 0
@@ -111,6 +113,7 @@ describe('ContextTokenization', function() {
         targetTokens, {
           canAlign: true,
           leadTokenShift: 0,
+          leadEditLength: 0,
           matchLength: 7,
           tailEditLength: 0,
           tailTokenShift: 2
@@ -138,6 +141,7 @@ describe('ContextTokenization', function() {
         targetTokens, {
           canAlign: true,
           leadTokenShift: 0,
+          leadEditLength: 0,
           matchLength: 6,
           tailEditLength: 1,
           tailTokenShift: 0
@@ -176,6 +180,7 @@ describe('ContextTokenization', function() {
         targetTokens, {
           canAlign: true,
           leadTokenShift: 0,
+          leadEditLength: 0,
           matchLength: 22,
           tailEditLength: 1,
           tailTokenShift: 0
@@ -211,6 +216,7 @@ describe('ContextTokenization', function() {
         targetTokens, {
           canAlign: true,
           leadTokenShift: 0,
+          leadEditLength: 0,
           matchLength: 24,
           tailEditLength: 1,
           tailTokenShift: 0


### PR DESCRIPTION
This change allows the context caching engine to better handle scenarios where wordbreaking boundaries shift at the _start_ of the sliding context window.  Example case, with `|` used to denote the window's range:

```
something isn|'t happening readily.  Come on already, why do they trigger erro|r
```

(Between the two `|`s:  64 characters, the range of our predictive-text sliding window.)

When `'` is between two letters, we treat the contraction as a single word, as we should - it _is_ a contraction.  But, when the last letter before the `'` slides out of range, all we see is an opening single-quote - something that would be interpreted as its _own_ token.


Tests to do:
- repro that exact sequence above - verify no errors result from inputting the sequence.
    - With just one space after the `readily.`
    - With two spaces after the `readily.`
    - `something isn't happening readily.  Come on already, why does it trigger error `

- perhaps also robustness testing?