### PR TITLE
fix(android): Fix insets for in-app vs system keyboard 🏠

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/BaseActivity.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/BaseActivity.java
@@ -93,19 +93,16 @@ public class BaseActivity extends AppCompatActivity {
         // Allocate insets for system bars and display cutout (notch)
         Insets insets = windowInsets.getInsets(
           WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-        ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams)view.getLayoutParams();
-        mlp.topMargin = insets.top;
-        mlp.bottomMargin = insets.bottom;
-        mlp.leftMargin = insets.left;
-        mlp.rightMargin = insets.right;
-        view.setLayoutParams(mlp);
+
+        view.setPadding(
+          insets.left,
+          insets.top,
+          insets.right,
+          insets.bottom);
 
         KMManager.applyInsetsToKeyboard(insets.left, insets.right, insets.bottom);
         return windowInsets;
       });
-
-    // Trigger an initial pass
-    ViewCompat.requestApplyInsets(anchor);
   }
 
   /**
@@ -120,13 +117,15 @@ public class BaseActivity extends AppCompatActivity {
     window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
     window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
 
-    WindowInsetsControllerCompat windowInsetsController =
-      WindowCompat.getInsetsController(window, window.getDecorView());
-    windowInsetsController.setAppearanceLightStatusBars(true);
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM &&
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      window.setStatusBarColor(getColor(statusBarColor));
-      window.setNavigationBarColor(getColor(navigationBarColor));
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      WindowInsetsControllerCompat windowInsetsController =
+        WindowCompat.getInsetsController(window, window.getDecorView());
+      windowInsetsController.setAppearanceLightStatusBars(true);
+
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        window.setStatusBarColor(getColor(statusBarColor));
+        window.setNavigationBarColor(getColor(navigationBarColor));
+      }
     }
   }
 

--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -719,12 +719,7 @@ public final class KMManager {
    * @param bottom int padding to account for navigation bar on bottom of screen
    */
   public static void applyInsetsToKeyboard(int left, int right, int bottom) {
-    // System keyboard
-    if (SystemKeyboard != null) {
-      applyInsetsPaddingToKeyboardView(SystemKeyboard, left, right, bottom);
-    }
-
-    // In-App Keyboard
+    // Only applies to In-App keyboard #14619
     if (InAppKeyboard != null) {
       applyInsetsPaddingToKeyboardView(InAppKeyboard, left, right, bottom);
     }


### PR DESCRIPTION
:cherries: pick of #14619 to stable-18.0

This PR incorporates the pattern of fixes in AlphaTiles/AlphaTiles#237
specifically https://github.com/AlphaTiles/AlphaTiles/pull/237/files#diff-ffa9782556981f30f50417410a12d591b1659c2b19873327147a9330bbc1982e changing from `setLayoutParams()` to `setPadding()`

To keep the in-app keyboard from being obscured by the bottom navigation bar, I still needed to keep the `applyInsetsToKeyboard()` call. 

## User Testing
**Setup** - Install the PR build of Keyman for Android on an Android emulator/device of Android API 34
From the Keyman "Get Started" menu, set Keyman as the default system keyboard

* **TEST_NO_BLANK_SPACE** - Verifies no blank space between the bottom navigation bar and OSK (as reported in the issue)
1. Open the Keyman app
2. On "Get Started": Checked the "Enable Keyman as system-wide keyboard" and set the "keyboard as the default keyboard" box.
3. Installed the arabic keyboard.
4. Open the chrome browser.
5. Click in the textarea or search box
6. Observer the OSK appears, and verify there's **no** blank space between the OSK and bottom navigation bar

* **TEST_INAPP_KEYBOARD** - Verifies in-app keyboard is not covered by system insets (status bar, camera notch, navigation bar)
1. Open the Keyman app with the device in portrait orientation. Dismiss the "Get Started" menu 
2. Verify the in-app keyboard is not covered by any of the system insets 
3. Verify the keyboard keys and suggestion banner function
4. Rotate the device to landscape orientation
5. Verify the in-app keyboard is not covered by any of the system insets
6. Verify the keyboard keys and suggestion banner function

* **TEST_SYSTEM_KEYBOARD** - Verifies system keyboard is not covered by system insets (status bar, camera notch, navigation bar)
1. With the device in portrait orientation, launch Chrome and select text area to type. 
2. Select Keyman as the system keyboard if not already selected.
3. Verify the Keyman system keyboard is not covered by any of the system insets
4. Verify the keyboard keys and suggestion banner function
5. Rotate the device to landscape orientation
6. Verify the Keyman system keyboard is not covered by any of the system insets
7. Verify the keyboard keys and suggestion banner function
