### PR TITLE
fix(developer): handle failure to create destination path when generating new project

### DIFF
--- a/developer/src/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.ImportWindowsKeyboard.pas
@@ -251,6 +251,8 @@ begin
     except
       on E:EKeyboardProjectTemplate do
         Exit(Fail('Unable to generate template: '+E.Message));
+      on E:EFOpenError do
+        Exit(Fail('Unable to create project; template files may be missing: '+E.Message));
     end;
 
     FProjectFilename := FTemplate.ProjectFilename;

--- a/developer/src/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.KeyboardProjectTemplate.pas
@@ -86,7 +86,8 @@ end;
 procedure TKeyboardProjectTemplate.Generate;
 begin
   if not ForceDirectories(BasePath + ID + '\' + SFolder_Source) then
-    raise EKeyboardProjectTemplate.Create('Could not create destination path '+BasePath+ID);
+    raise EKeyboardProjectTemplate.Create('Could not create destination path '''+BasePath+ID+'''. '+
+     'Please check the path and try again. The error was: '+SysErrorMessage(GetLastError));
 
   WriteDocumentation;
 

--- a/developer/src/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.KeymanConvertMain.pas
@@ -7,6 +7,7 @@ procedure Run;
 implementation
 
 uses
+  System.Classes,
   System.SysUtils,
   Winapi.ActiveX,
 
@@ -100,7 +101,12 @@ begin
     except
       on E:EKeyboardProjectTemplate do
       begin
-        writeln(E.Message);
+        writeln('ERROR: Unable to create project: '+E.Message);
+        Exit(False);
+      end;
+      on E:EFOpenError do
+      begin
+        writeln('ERROR: Unable to create project; template files may be missing: '+E.Message);
         Exit(False);
       end;
     end;
@@ -138,7 +144,12 @@ begin
     except
       on E:ELDMLKeyboardProjectTemplate do
       begin
-        writeln(E.Message);
+        writeln('ERROR: Unable to create project: '+E.Message);
+        Exit(False);
+      end;
+      on E:EFOpenError do
+      begin
+        writeln('ERROR: Unable to create project; template files may be missing: '+E.Message);
         Exit(False);
       end;
     end;
@@ -176,7 +187,12 @@ begin
     except
       on E:EModelProjectTemplate do
       begin
-        writeln(E.Message);
+        writeln('ERROR: Unable to create project: '+E.Message);
+        Exit(False);
+      end;
+      on E:EFOpenError do
+      begin
+        writeln('ERROR: Unable to create project; template files may be missing: '+E.Message);
         Exit(False);
       end;
     end;

--- a/developer/src/kmconvert/Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.LdmlKeyboardProjectTemplate.pas
@@ -56,7 +56,8 @@ end;
 procedure TLDMLKeyboardProjectTemplate.Generate;
 begin
   if not ForceDirectories(BasePath + ID + '\' + SFolder_Source) then
-    raise ELDMLKeyboardProjectTemplate.Create('Could not create destination path '+BasePath+ID);
+    raise ELDMLKeyboardProjectTemplate.Create('Could not create destination path '''+BasePath+ID+'''. '+
+      'Please check the path and try again. The error was: '+SysErrorMessage(GetLastError));
 
   WriteDocumentation;
 

--- a/developer/src/kmconvert/Keyman.Developer.System.ModelProjectTemplate.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.ModelProjectTemplate.pas
@@ -70,7 +70,8 @@ end;
 procedure TModelProjectTemplate.Generate;
 begin
   if not ForceDirectories(BasePath + ID + '\' + SFolder_Source) then
-    raise EModelProjectTemplate.Create('Could not create destination path '+BasePath+ID);
+    raise EModelProjectTemplate.Create('Could not create destination path '''+BasePath+ID+'''. '+
+      'Please check the path and try again. The error was: '+SysErrorMessage(GetLastError));
 
   WriteDocumentation;
 

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewLDMLKeyboardProjectParameters.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewLDMLKeyboardProjectParameters.pas
@@ -154,9 +154,14 @@ begin
       try
         pt.Generate;
       except
-        on E:EFOpenError do
+        on E:ELDMLKeyboardProjectTemplate do
         begin
           ShowMessage('Unable to create project: '+E.Message);
+          Exit(False);
+        end;
+        on E:EFOpenError do
+        begin
+          ShowMessage('Unable to create project; template files may be missing: '+E.Message);
           Exit(False);
         end;
       end;

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewModelProjectParameters.pas
@@ -166,9 +166,14 @@ begin
       try
         pt.Generate;
       except
-        on E:EFOpenError do
+        on E:EModelProjectTemplate do
         begin
           ShowMessage('Unable to create project: '+E.Message);
+          Exit(False);
+        end;
+        on E:EFOpenError do
+        begin
+          ShowMessage('Unable to create project; template files may be missing: '+E.Message);
           Exit(False);
         end;
       end;

--- a/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
+++ b/developer/src/tike/project/Keyman.Developer.UI.Project.UfrmNewProjectParameters.pas
@@ -167,9 +167,14 @@ begin
       try
         pt.Generate;
       except
-        on E:EFOpenError do
+        on E:EKeyboardProjectTemplate do
         begin
           ShowMessage('Unable to create project: '+E.Message);
+          Exit(False);
+        end;
+        on E:EFOpenError do
+        begin
+          ShowMessage('Unable to create project; template files may be missing: '+E.Message);
           Exit(False);
         end;
       end;


### PR DESCRIPTION
Add better error handling for situation where destination path cannot be created, for all project types. Also report back the Windows error message which hopefully clarifies why the directory could not be created.

Fixes: #14348
Fixes: KEYMAN-DEVELOPER-1P1
Fixes: KEYMAN-DEVELOPER-2SN
Test-bot: skip