### PR TITLE
fix(developer): remove incorrect offset for compiler error line

### DIFF
--- a/developer/src/kmcmplib/src/CompilerErrors.cpp
+++ b/developer/src/kmcmplib/src/CompilerErrors.cpp
@@ -21,7 +21,7 @@ void ReportCompilerMessage(KMX_DWORD msg, const std::vector<std::string>& parame
 
   KMCMP_COMPILER_RESULT_MESSAGE message;
   message.errorCode = msg;
-  message.lineNumber = kmcmp::currentLine + 1;
+  message.lineNumber = kmcmp::currentLine;
   message.columnNumber = kmcmp::ErrChr;
   message.parameters = parameters;
   message.filename = kmcmp::messageFilename;


### PR DESCRIPTION
Fixes: #13903

# User Testing

I would like to verify a random selection of keyboards that have hints or warning messages in the .kmn, to make sure that the line number reported is correct. The attached log file can be scanned (search for `.kmn:`) for hints and warnings with line numbers. Please choose a selection of these hints and warnings. The log file should be showing the errors off by one line. The new compiler should show the same messages for the keyboard, but this time reporting the correct line number.

For example, in the log file we can find:

```
...
sil_korda_latin.kmn - info KM05002: Building release/sil/sil_korda_latin/source/sil_korda_latin.kmn
sil_korda_latin.kmn:82 - hint KM020AE: This rule will never be matched as the rule on line 79 takes precedence
sil_korda_latin.kmn:83 - hint KM020AE: This rule will never be matched as the rule on line 80 takes precedence
sil_korda_latin.kmn:127 - hint KM020AE: This rule will never be matched as the rule on line 111 takes precedence
sil_korda_latin.kmn - info KM05006: release/sil/sil_korda_latin/source/sil_korda_latin.kmn built successfully.
...
```

But if we build with this version of kmc, we should see:

```
kmc build release/sil/sil_korda_latin
...
sil_korda_latin.kmn - info KM05002: Building release/sil/sil_korda_latin/source/sil_korda_latin.kmn
sil_korda_latin.kmn:81 - hint KM020AE: This rule will never be matched as the rule on line 79 takes precedence
sil_korda_latin.kmn:82 - hint KM020AE: This rule will never be matched as the rule on line 80 takes precedence
sil_korda_latin.kmn:126 - hint KM020AE: This rule will never be matched as the rule on line 111 takes precedence
sil_korda_latin.kmn - info KM05006: release/sil/sil_korda_latin/source/sil_korda_latin.kmn built successfully.
...
```

* **TEST_REVIEW_WARNING_LINES**: Check that a random selection of .kmn hints and warnings report the correct line number.