### PR TITLE
fix(android): Cleanup list layout in Engine and FirstVoices for edge to edge 🪟

### DIFF
--- a/android/KMEA/app/src/main/res/layout/activity_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/activity_list_layout.xml
@@ -9,6 +9,7 @@
     android:orientation="vertical">
 
     <include layout="@layout/list_toolbar"
+      android:id="@+id/list_appbar"
       app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintStart_toStartOf="parent" />
 

--- a/android/KMEA/app/src/main/res/layout/list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/list_layout.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent" >
-    
+
+    <!-- paddingBottom so last entry doesn't get covered by navigation bar -->
     <ListView
         style="@style/AppTheme.Light.ListView"
         android:id="@+id/listView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:choiceMode="singleChoice"
-        android:clipToPadding="false" />
+        android:clipToPadding="false"
+        android:paddingBottom="?attr/actionBarSize"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"/>
 
 </RelativeLayout>

--- a/android/KMEA/app/src/main/res/layout/list_toolbar.xml
+++ b/android/KMEA/app/src/main/res/layout/list_toolbar.xml
@@ -1,45 +1,43 @@
-<com.google.android.material.appbar.AppBarLayout
+<?xml version="1.0" encoding="utf-8"?>
+    <com.google.android.material.appbar.AppBarLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/list_appbar"
     app:theme="@style/AppTheme.ToolbarBackArrow"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
     app:elevation="0dp">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/list_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize">
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/list_toolbar"
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/bar_title"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_gravity="center_horizontal"
+            android:gravity="center"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:text="@string/title_add_keyboard"
+            android:textSize="@dimen/titlebar_label_textsize"
+            android:textStyle="bold" />
 
-            <TextView
-                android:id="@+id/bar_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:gravity="center"
-                android:ellipsize="end"
-                android:singleLine="true"
-                android:text="@string/title_add_keyboard"
-                android:textSize="@dimen/titlebar_label_textsize"
-                android:textStyle="bold" />
+    </androidx.appcompat.widget.Toolbar>
 
-        </androidx.appcompat.widget.Toolbar>
+    <!-- optional accent -->
+    <View
+        android:id="@+id/bar_accent"
+        style="@style/AppTheme.Divider"
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        app:layout_constraintTop_toBottomOf="@id/list_toolbar"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-        <!-- optional accent -->
-        <View
-            android:id="@+id/bar_accent"
-            style="@style/AppTheme.Divider"
-            android:layout_width="match_parent"
-            android:layout_height="2dp"
-            app:layout_constraintTop_toBottomOf="@id/list_toolbar"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.appbar.AppBarLayout>

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/KeyboardListActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/KeyboardListActivity.java
@@ -23,6 +23,8 @@ public final class KeyboardListActivity extends BaseActivity {
         final Context context = this;
 
         setContentView(R.layout.activity_list_layout);
+        setupEdgeToEdge(R.id.activity_list_layout);
+
         final Toolbar toolbar = findViewById(R.id.list_toolbar);
         TextView title = findViewById(R.id.bar_title);
         title.setText(getIntent().getStringExtra("regionName"));

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/RegionListActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/RegionListActivity.java
@@ -10,10 +10,10 @@ import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import com.keyman.engine.BaseActivity;
 
-public final class RegionListActivity extends AppCompatActivity {
+public final class RegionListActivity extends BaseActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -23,6 +23,8 @@ public final class RegionListActivity extends AppCompatActivity {
 
         // Setup layout
         setContentView(R.layout.activity_list_layout);
+        setupEdgeToEdge(R.id.activity_list_layout);
+
         final Toolbar toolbar = findViewById(R.id.list_toolbar);
         final TextView textView = findViewById(R.id.bar_title);
         textView.setText(R.string.regions);


### PR DESCRIPTION
Follow-on cleanup from #14248

I was preparing to :cherries: the Samples and FirstVoices layout changes to stable-18.0 when I noticed the last row in FirstVoices Region/Keyboard lists were covered by the navigation bar.

In the BC Coast keyboards list, the bottom entry **’Wuìk̓ala** was obscured by the navigation bar

<img width="378" height="840" alt="BC Coast" src="https://github.com/user-attachments/assets/5ffa7fee-5c36-495c-99c0-fd4c44f6c384" />

*Screenshot of fixed keyboard list*

### Changes

* Cleaned up unnecessary level of ConstraintLayout in list_toolbar
* Add bottom padding to the list layout so list layout isn't covered by the navigation bar
* Apply the `BaseActivity.setupEdgeToEdge()` calls in FirstVoices (missed in #14514) 



## User Testing

**Setup** - Install the PR builds for the corresponding tests on Android device/emulator 

* **TEST_KEYMAN** - Verifies lists appear fine on Keyman app
1. With the device in portrait orientation, install Keyman for Android and launch
2. On the "Get Started" menu, install a Keyman keyboard from keyman.com
3. Verify the keyboard installation goes fine and none of the next/install buttons are covered
4. Dismiss the "Get Started" menu
5. Verify in-app keyboard and suggestions function
6. From Keyman settings --> Install Keyboard or Dictionary --> Add languages to installed keyboard --> EuroLatin _SIL) keyboard --> Scroll to bottom and select **Zoogocho Zapotec** --> Install
7. Return to Keyman and longpress on the globe key to bring up keyboard picker
8. Verify Zoogocho Zapotec is now available on the keyboard picker

* **TEST_FIRSTVOICES** - Verifies lists appear fine in FirstVoices app
1. With the device in portrait orientation, install FirstVoices for Android and launch
2. On the main FirstVoices page, scroll to bottom and verify the SIL Global footer is not covered
3. Scroll back to the top and "Select Keyboards" --> BC Coast -->
4. Scroll to the bottom of the BC Coast keyboards list and select Wuìk̓ala --> Enable keyboard
5. Return to main FirstVoices page --> Setup --> 
6. From the Setup menu, set FirstVoices as the default system keyboard
7. Launch Chrome and select a text area
8. With FirstVoices as the selected system keyboard, verify Wuìk̓ala keyboard appears and functions
