### PR TITLE
docs(web): Improve empty What's New page for Web

### DIFF
--- a/web/docs/engine/whatsnew.md
+++ b/web/docs/engine/whatsnew.md
@@ -1,3 +1,7 @@
 ---
 title: What's New in KeymanWeb 19.0
 ---
+
+## See also
+
+* [Keyman Engine for Web Documentation](index)


### PR DESCRIPTION
Currently the What's New page for Web shows up as:
<img width="2087" height="489" alt="image" src="https://github.com/user-attachments/assets/4d82c02f-a430-413b-9558-7c237fb17502" />

With this change it will show up as:
<img width="2087" height="489" alt="image" src="https://github.com/user-attachments/assets/d9893cb7-48e8-4615-8eea-fbf98c5f7256" />



Build-bot: skip
Test-bot: skip