### PR TITLE
fix(android): Cleanup layouts for Engine, Sample apps, and FirstVoices apps for edge to edge 🍒 🏠

### DIFF
--- a/android/KMEA/app/src/main/res/layout/activity_list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/activity_list_layout.xml
@@ -9,6 +9,7 @@
     android:orientation="vertical">
 
     <include layout="@layout/list_toolbar"
+      android:id="@+id/list_appbar"
       app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintStart_toStartOf="parent" />
 

--- a/android/KMEA/app/src/main/res/layout/list_layout.xml
+++ b/android/KMEA/app/src/main/res/layout/list_layout.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent" >
-    
+
+    <!-- paddingBottom so last entry doesn't get covered by navigation bar -->
     <ListView
         style="@style/AppTheme.Light.ListView"
         android:id="@+id/listView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:choiceMode="singleChoice"
-        android:clipToPadding="false" />
+        android:clipToPadding="false"
+        android:paddingBottom="?attr/actionBarSize"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"/>
 
 </RelativeLayout>

--- a/android/KMEA/app/src/main/res/layout/list_toolbar.xml
+++ b/android/KMEA/app/src/main/res/layout/list_toolbar.xml
@@ -1,45 +1,43 @@
-<com.google.android.material.appbar.AppBarLayout
+<?xml version="1.0" encoding="utf-8"?>
+    <com.google.android.material.appbar.AppBarLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/list_appbar"
     app:theme="@style/AppTheme.ToolbarBackArrow"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
     app:elevation="0dp">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/list_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize">
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/list_toolbar"
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/bar_title"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_gravity="center_horizontal"
+            android:gravity="center"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:text="@string/title_add_keyboard"
+            android:textSize="@dimen/titlebar_label_textsize"
+            android:textStyle="bold" />
 
-            <TextView
-                android:id="@+id/bar_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:gravity="center"
-                android:ellipsize="end"
-                android:singleLine="true"
-                android:text="@string/title_add_keyboard"
-                android:textSize="@dimen/titlebar_label_textsize"
-                android:textStyle="bold" />
+    </androidx.appcompat.widget.Toolbar>
 
-        </androidx.appcompat.widget.Toolbar>
+    <!-- optional accent -->
+    <View
+        android:id="@+id/bar_accent"
+        style="@style/AppTheme.Divider"
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        app:layout_constraintTop_toBottomOf="@id/list_toolbar"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-        <!-- optional accent -->
-        <View
-            android:id="@+id/bar_accent"
-            style="@style/AppTheme.Divider"
-            android:layout_width="match_parent"
-            android:layout_height="2dp"
-            app:layout_constraintTop_toBottomOf="@id/list_toolbar"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.appbar.AppBarLayout>

--- a/android/README.md
+++ b/android/README.md
@@ -34,10 +34,10 @@ analytics for Debug are associated with an App Bundle ID
 ### Compiling From Command Line
 
 1. Launch a command prompt and cd to the directory **keyman/android**
-2. Run the top level build script `./build.sh configure build:engine build:app --debug` which will:
-    * Compile KMEA (and its KMW dependency)
+2. Run the top level build script `./build.sh configure build:engine build:app` which will:
+    * Compile debug version of KMEA (and its KMW dependency)
     * Download default keyboard and dictionary resources as needed
-    * Compile KMAPro
+    * Compile debug version of KMAPro
 3. The APK will be found in **keyman/android/KMAPro/kMAPro/build/outputs/apk/debug/keyman-\${version}.apk**
    where `${version}` is the current version number.
 
@@ -98,10 +98,10 @@ There are two included sample projects that can be modified to test a keyboard.
 **android/Samples/KMSample2** app provides prompts for setting KMSample2 as a system level keyboard.
 Both sample apps include a default Tamil keyboard and sample dictionary.
 
-Building these projects follow the same steps as KMAPro:
+Building the debug versions of these projects follow the same steps as KMAPro:
 
 1. cd to the desired KMSample directory
-2. `./build.sh configure build --debug`
+2. `./build.sh configure build`
 3. Open Android Studio to run the app
 
 ### Tests: KeyboardHarness
@@ -114,14 +114,14 @@ Building these projects follow the same steps as KMAPro:
   * Build the keyboardharness.kmp keyboard package
 3. Add the keyboard in *android/Tests/KeyboardHarness/app/src/main/java/com/keyman/android/tests/keyboardHarness/MainActivity.java*
 4. cd to android/Tests/KeyboardHarness/
-5. `./build.sh configure build --debug`
+5. `./build.sh configure build`
 6. Open Android Studio to run the app
 
 --------------------------------------------------------------
 
 ## How to Build Keyman Engine for Android
 1. Open a terminal or Git Bash prompt and go to the Android project folder (e.g. `cd ~/keyman/android/`)
-2. Run `./build.sh build:engine --debug`
+2. Run `./build.sh build:engine`
 
 Keyman Engine for Android library (**keyman-engine.aar**) is now ready to be imported in any project.
 
@@ -135,7 +135,7 @@ Keyman Engine for Android library (**keyman-engine.aar**) is now ready to be imp
 4. Check that the `android{}` object, includes the following:
 ```gradle
 android {
-    compileSdkVersion 34
+    compileSdkVersion 35
 
     // Don't compress kmp files so they can be copied via AssetManager
     aaptOptions {
@@ -159,6 +159,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
     api (name:'keyman-engine', ext:'aar')
     implementation 'androidx.preference:preference:1.2.1'

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -37,6 +37,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
     api(name: 'keyman-engine', ext: 'aar')
     implementation 'androidx.preference:preference:1.2.1'

--- a/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
+++ b/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
@@ -2,7 +2,9 @@ package com.keyman.kmsample1;
 
 import android.content.Context;
 import android.content.res.Configuration;
+import android.graphics.Point;
 import android.os.Bundle;
+import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -25,6 +27,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   public static Context context;
   private ConstraintLayout constraintLayout;
   private KMTextView textView;
+  private int lastOrientation = Configuration.ORIENTATION_UNDEFINED;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -99,6 +102,18 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   protected void onResume() {
     super.onResume();
     KMManager.onResume();
+
+    // onConfigurationChanged() only triggers when device is rotated while app is in foreground
+    // This handles when device is rotated while app is in background
+    // using KMManager.getOrientation() since getConfiguration().orientation is unreliable #10241
+    int newOrientation = KMManager.getOrientation(context);
+    if (newOrientation != lastOrientation) {
+      lastOrientation = newOrientation;
+      Configuration newConfig = this.getResources().getConfiguration();
+      KMManager.onConfigurationChanged(newConfig);
+    }
+    resizeTextView(textView.isKeyboardVisible());
+
     KMManager.addKeyboardEventListener(this);
     KMKeyboardDownloaderActivity.addKeyboardDownloadEventListener(this);
   }
@@ -116,6 +131,10 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   @Override
   public void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
+  	KMManager.onConfigurationChanged(newConfig);
+	
+	  resizeTextView(textView.isKeyboardVisible());
+	  lastOrientation = newConfig.orientation;
   }
 
   @Override
@@ -131,11 +150,44 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   @Override
   public void onKeyboardShown() {
     // Handle Keyman keyboard shown event here if needed
+    resizeTextView(true);
   }
 
   @Override
   public void onKeyboardDismissed() {
     // Handle Keyman keyboard dismissed event here if needed
+    resizeTextView(false);
+  }
+
+  public void resizeTextView(boolean isKeyboardVisible) {
+    int bannerHeight = 0;
+    int keyboardHeight = 0;
+    if (isKeyboardVisible) {
+      bannerHeight = KMManager.getBannerHeight(this);
+      keyboardHeight = KMManager.getKeyboardHeight(this);
+    }
+
+    TypedValue outValue = new TypedValue();
+    getTheme().resolveAttribute(android.R.attr.actionBarSize, outValue, true);
+    int actionBarHeight = getResources().getDimensionPixelSize(outValue.resourceId);
+
+    // *** TO DO: Try to check if status bar is visible, set statusBarHeight to 0 if it is not visible ***
+    int statusBarHeight = 0;
+    int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
+    if (resourceId > 0)
+      statusBarHeight = getResources().getDimensionPixelSize(resourceId);
+
+    // Navigation bar height
+    int navigationBarHeight = 0;
+    resourceId = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
+    if (resourceId > 0) {
+      navigationBarHeight = getResources().getDimensionPixelSize(resourceId);
+    }
+
+    Point size = KMManager.getWindowSize(context);
+    int screenHeight = size.y;
+    textView.setHeight(
+      screenHeight - statusBarHeight - actionBarHeight - bannerHeight - keyboardHeight - navigationBarHeight);
   }
 
   @Override

--- a/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
+++ b/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
@@ -1,13 +1,14 @@
 package com.keyman.kmsample1;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import androidx.constraintlayout.widget.ConstraintLayout;
+
+import com.keyman.engine.BaseActivity;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.KMKeyboardDownloaderActivity;
 import com.keyman.engine.KMManager;
@@ -19,9 +20,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class MainActivity extends AppCompatActivity implements OnKeyboardEventListener, OnKeyboardDownloadEventListener {
+public class MainActivity extends BaseActivity implements OnKeyboardEventListener, OnKeyboardDownloadEventListener {
 
   public static Context context;
+  private ConstraintLayout constraintLayout;
   private KMTextView textView;
 
   @Override
@@ -34,6 +36,12 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     KMManager.initialize(this, KeyboardType.KEYBOARD_TYPE_INAPP);
 
     setContentView(R.layout.activity_main);
+    constraintLayout = findViewById(R.id.constraintLayout);
+    setupEdgeToEdge(R.id.constraintLayout);
+    setupStatusBarColors(
+      android.R.color.white,        // Color for top status bar
+      android.R.color.darker_gray); // Color for bottom navigation bar
+
     textView = (KMTextView) findViewById(R.id.kmTextView);
 
     // Add a custom keyboard

--- a/android/Samples/KMSample1/app/src/main/res/layout/activity_main.xml
+++ b/android/Samples/KMSample1/app/src/main/res/layout/activity_main.xml
@@ -1,7 +1,11 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:orientation="vertical"
     tools:context=".MainActivity">
 
     <com.keyman.engine.KMTextView
@@ -12,8 +16,10 @@
         android:ems="10"
         android:inputType="textMultiLine"
         android:gravity="top"
-        android:scrollbars="vertical" >
+        android:scrollbars="vertical"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
 
         <requestFocus />
     </com.keyman.engine.KMTextView>
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -36,6 +36,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
     api (name:'keyman-engine', ext:'aar')
     implementation 'androidx.preference:preference:1.2.1'

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/MainActivity.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/MainActivity.java
@@ -1,6 +1,5 @@
 package com.keyman.kmsample2;
 
-import androidx.appcompat.app.AppCompatActivity;
 import android.content.Context;
 import android.content.Intent;
 import android.provider.Settings;
@@ -11,13 +10,20 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 
-public class MainActivity extends AppCompatActivity {
+import com.keyman.engine.BaseActivity;
+
+public class MainActivity extends BaseActivity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     setTheme(R.style.AppTheme);
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
+    setupEdgeToEdge(R.id.constraintLayout);
+    setupStatusBarColors(    // Inset colors for Android API < 35
+      android.R.color.black, // Color for status bar on top
+      android.R.color.white  // Color for navigation bar on bottom
+    );
 
     Button button1 = (Button) findViewById(R.id.button1);
     button1.setOnClickListener(new View.OnClickListener() {

--- a/android/Samples/KMSample2/app/src/main/res/layout/activity_main.xml
+++ b/android/Samples/KMSample2/app/src/main/res/layout/activity_main.xml
@@ -1,31 +1,50 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:orientation="vertical"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin" tools:context=".MainActivity">
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context=".MainActivity">
 
-    <TextView android:text="@string/description" android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+    <TextView
         android:id="@+id/textView"
-        android:layout_centerHorizontal="true" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/description"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
-        android:layout_width="260dp"
-        android:layout_height="wrap_content"
-        android:text="Open input method settings"
         android:id="@+id/button1"
-        android:layout_below="@+id/textView"
-        android:layout_centerHorizontal="true"
-        android:layout_marginTop="16dp" />
-
-    <Button
         android:layout_width="260dp"
         android:layout_height="wrap_content"
-        android:text="Open input method menu"
-        android:id="@+id/button2"
-        android:layout_below="@+id/button1"
-        android:layout_centerHorizontal="true"
-        android:layout_marginTop="16dp" />
+        android:layout_below="@+id/textView"
+        android:layout_centerInParent="true"
+        android:layout_marginTop="16dp"
+        android:text="Open input method settings"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/textView" />
 
-</RelativeLayout>
+    <Button
+        android:id="@+id/button2"
+        android:layout_width="260dp"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/button1"
+        android:layout_marginTop="16dp"
+        android:text="Open input method menu"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button1" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -47,6 +47,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
     api (name:'keyman-engine', ext:'aar')
     implementation 'androidx.preference:preference:1.2.1'

--- a/android/Tests/KeyboardHarness/app/src/main/java/com/keyman/android/tests/keyboardHarness/MainActivity.java
+++ b/android/Tests/KeyboardHarness/app/src/main/java/com/keyman/android/tests/keyboardHarness/MainActivity.java
@@ -1,11 +1,13 @@
 package com.keyman.android.tests.keyboardHarness;
 
-import androidx.appcompat.app.AppCompatActivity;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import androidx.constraintlayout.widget.ConstraintLayout;
+
+import com.keyman.engine.BaseActivity;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.KMKeyboardDownloaderActivity;
 import com.keyman.engine.KMManager;
@@ -18,8 +20,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class MainActivity extends AppCompatActivity implements OnKeyboardEventListener, OnKeyboardDownloadEventListener {
+public class MainActivity extends BaseActivity implements OnKeyboardEventListener, OnKeyboardDownloadEventListener {
 
+  private ConstraintLayout constraintLayout;
   private KMTextView textView;
 
   @Override
@@ -31,6 +34,12 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardEventLi
     KMManager.initialize(this, KeyboardType.KEYBOARD_TYPE_INAPP);
 
     setContentView(R.layout.activity_main);
+    constraintLayout = findViewById(R.id.constraintLayout);
+    setupEdgeToEdge(R.id.constraintLayout);
+    setupStatusBarColors(
+      android.R.color.white,        // Color for top status bar
+      android.R.color.darker_gray); // Color for bottom navigation bar
+
     textView = (KMTextView) findViewById(R.id.kmTextView);
 
     // Add custom keyboards

--- a/android/Tests/KeyboardHarness/app/src/main/res/layout/activity_main.xml
+++ b/android/Tests/KeyboardHarness/app/src/main/res/layout/activity_main.xml
@@ -1,7 +1,11 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:orientation="vertical"
     tools:context=".MainActivity">
 
     <com.keyman.engine.KMTextView
@@ -12,9 +16,11 @@
         android:ems="10"
         android:inputType="textMultiLine"
         android:gravity="top"
-        android:scrollbars="vertical" >
+        android:scrollbars="vertical"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
 
         <requestFocus />
     </com.keyman.engine.KMTextView>
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -129,6 +129,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.google.android.material:material:1.12.0'
     api(name: 'keyman-engine', ext: 'aar')
     implementation 'io.sentry:sentry-android:7.22.6'

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/FVKeyboardSettingsActivity.java
@@ -17,10 +17,10 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.appcompat.widget.Toolbar;
 
+import com.keyman.engine.BaseActivity;
 import com.keyman.engine.KMKeyboardDownloaderActivity;
 import com.keyman.engine.KMManager;
 import com.keyman.engine.KeyboardPickerActivity;
@@ -45,7 +45,7 @@ import java.util.HashMap;
 /**
  * Displays an FV Keyboard enable and some lexical model switches.
  */
-public final class FVKeyboardSettingsActivity extends AppCompatActivity {
+public final class FVKeyboardSettingsActivity extends BaseActivity {
   private static Context context = null;
   private static Toolbar toolbar = null;
   private static TextView fvKeyboardTextView = null;
@@ -116,6 +116,7 @@ public final class FVKeyboardSettingsActivity extends AppCompatActivity {
     supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
     context = this;
     setContentView(R.layout.fv_keyboard_settings_list_layout);
+    setupEdgeToEdge(R.id.fvKeyboardSettingsConstraintLayout);
 
     if (getIntent() != null && getIntent().getExtras() != null) {
       intent = getIntent();

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/KeyboardListActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/KeyboardListActivity.java
@@ -23,6 +23,8 @@ public final class KeyboardListActivity extends BaseActivity {
         final Context context = this;
 
         setContentView(R.layout.activity_list_layout);
+        setupEdgeToEdge(R.id.activity_list_layout);
+
         final Toolbar toolbar = findViewById(R.id.list_toolbar);
         TextView title = findViewById(R.id.bar_title);
         title.setText(getIntent().getStringExtra("regionName"));

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/KeyboardListActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/KeyboardListActivity.java
@@ -10,10 +10,11 @@ import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
-public final class KeyboardListActivity extends AppCompatActivity {
+import com.keyman.engine.BaseActivity;
+
+public final class KeyboardListActivity extends BaseActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/MainActivity.java
@@ -13,11 +13,10 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import io.sentry.android.core.SentryAndroid;
 
 import com.keyman.engine.*;
+import com.keyman.engine.BaseActivity;
 import com.keyman.engine.data.Keyboard;
 import com.keyman.engine.util.BCP47;
 import com.keyman.engine.util.DownloadFileUtils;
@@ -28,7 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class MainActivity extends AppCompatActivity implements OnKeyboardDownloadEventListener {
+public class MainActivity extends BaseActivity implements OnKeyboardDownloadEventListener {
     public Context context;
 
     FVDownloadResultReceiver resultReceiver;
@@ -48,6 +47,10 @@ public class MainActivity extends AppCompatActivity implements OnKeyboardDownloa
         resultReceiver = new FVDownloadResultReceiver(new Handler(), context);
 
         setContentView(R.layout.activity_main);
+        setupEdgeToEdge(R.id.constraintLayout);
+        setupStatusBarColors(
+          R.color.firstvoices_gold,     // Color of top status bar
+          android.R.color.darker_gray); // Color of bottom navigation bar
 
         if (BuildConfig.DEBUG) {
           KMManager.setDebugMode(true);

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/RegionListActivity.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/RegionListActivity.java
@@ -10,10 +10,10 @@ import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import com.keyman.engine.BaseActivity;
 
-public final class RegionListActivity extends AppCompatActivity {
+public final class RegionListActivity extends BaseActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -23,6 +23,8 @@ public final class RegionListActivity extends AppCompatActivity {
 
         // Setup layout
         setContentView(R.layout.activity_list_layout);
+        setupEdgeToEdge(R.id.activity_list_layout);
+
         final Toolbar toolbar = findViewById(R.id.list_toolbar);
         final TextView textView = findViewById(R.id.bar_title);
         textView.setText(R.string.regions);

--- a/oem/firstvoices/android/app/src/main/res/layout/activity_main.xml
+++ b/oem/firstvoices/android/app/src/main/res/layout/activity_main.xml
@@ -1,7 +1,12 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:orientation="vertical"
     tools:context=".MainActivity">
 
     <WebView
@@ -11,4 +16,4 @@
         android:layout_centerVertical="true"
         android:layout_centerHorizontal="true" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/oem/firstvoices/android/app/src/main/res/layout/fv_keyboard_settings_list_layout.xml
+++ b/oem/firstvoices/android/app/src/main/res/layout/fv_keyboard_settings_list_layout.xml
@@ -1,26 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/fvKeyboardSettingsConstraintLayout"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-  <include layout="@layout/list_toolbar" />
+  <include layout="@layout/list_toolbar"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintStart_toStartOf="parent"/>
 
     <include
         android:id="@+id/keyboard_toggle"
         layout="@layout/fv_list_row_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/list_appbar"/>
+        android:layout_above="@+id/modeling_settings_layout"
+        android:layout_below="@+id/list_appbar"
+        app:layout_constraintTop_toBottomOf="@id/list_appbar"
+        app:layout_constraintStart_toStartOf="parent"/>
 
     <LinearLayout
-        android:id="@+id/modeling_settings_layout"
+        android:id="@id/modeling_settings_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_below="@id/keyboard_toggle"
+        android:layout_alignParentBottom="true"
         android:layout_marginTop="0dp"
         android:layout_marginBottom="0dp"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/keyboard_toggle"
+        app:layout_constraintVertical_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <!-- Enable predictions toggle -->
         <include
@@ -63,4 +76,4 @@
 
     </LinearLayout>
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
:cherries: pick to stable-18.0 for #14248

* Cleanup list layout in Engine and FirstVoices (ensures Wuìk̓ala is available at the bottom of the FirstVoices BC Coast region list)
* Update Sample, Test, and FirstVoices apps for edge to edge
* Update Sample1 for rotation

## User Testing
**Setup** - Install the PR build of the corresponding app on an Android emulator/device of Android API 34

* **TEST_KMSAMPLE1** - Verifies KMSample1 app is not obstructed by system insets
1. Install the KMSample1 app and launch it
2. Verify the in-app keyboard is not obstructed by bottom navigation bar
3. Verify the top menu bar is not obstructed by the top status bar or camera notch
4. Rotate the device from Portrait to Landscape orientation
5. Verify the sides of the in-app keyboard is not obstructed by navigation bar, status bar, or camera notch

* **TEST_KMSAMPLE2** - Verifies KMSample2 app is not obstructed by system insets
1. Install the KMSample2 app and launch it
2. Verify the menus to enable KMSample2 as the default system keyboard are not obstructed
3. Using the menus, enable KMSample2 as the default system keyboard
4. Launch the Chrome app and select a text area
5. With KMSample2 as the system keyboard, verify it is not obstructed by system bars

* **TEST_FIRSTVOICES** - Verifies FirstVoices app is not obstructed by system insets
1. Install FirstVoices for Android 
2. Verify the FirstVoices menu is not obstructed by the top status bar or camera notch
3. Use the FirstVoices "Select keyboards" menu --> Regions --> BC Coast --> SENCOTEN --> Enable keyboard
4. Return to the FirstVoices setup menu
5. Use the FirstVoices "Select keyboards" menu --> Regions --> BC Coast --> scroll to the bottom and select Wuìk̓ala --> Enable keyboard
6. Return to the FirstVoices setup menu
7. Setup --> enable FirstVoices as the default system keyboard
8. Launch the Chrome app and select a text area
9. With FirstVoices as the system keyboard, verify it is not obstructed by system bars

Cherry-pick-of: #14514
Cherry-pick-of: #14655 
Cherry-pick-of: #14678 
