### PR TITLE
fix(web): always place true input at lead of fat-finger distribution 🚂

### DIFF
--- a/web/src/engine/main/src/headless/inputProcessor.ts
+++ b/web/src/engine/main/src/headless/inputProcessor.ts
@@ -324,9 +324,6 @@ export class InputProcessor {
         // that _appear_ very precise may otherwise not even consider directly-neighboring keys.
         const KEYSTROKE_EPSILON = Math.exp(-5);
 
-        // Sort the distribution into probability-descending order.
-        keyDistribution.sort((a, b) => b.p - a.p);
-
         alternates = [];
 
         let totalMass = 0; // Tracks sum of non-error probabilities.

--- a/web/src/engine/osk/src/input/gestures/browser/flick.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/flick.ts
@@ -1,7 +1,7 @@
 import { type KeyElement } from '../../../keyElement.js';
 import VisualKeyboard from '../../../visualKeyboard.js';
 
-import { ActiveKey, ActiveKeyBase, ActiveSubKey, KeyDistribution, KeyEvent } from 'keyman/engine/keyboard';
+import { ActiveKey, ActiveKeyBase, ActiveSubKey, KeyDistribution } from 'keyman/engine/keyboard';
 import { ConfigChangeClosure, CumulativePathStats, GestureRecognizerConfiguration, GestureSequence, GestureSource, GestureSourceSubview, InputSample, RecognitionZoneSource } from '@keymanapp/gesture-recognizer';
 import { GestureHandler } from '../gestureHandler.js';
 import { distributionFromDistanceMaps } from '../../../corrections.js';
@@ -197,20 +197,21 @@ export default class Flick implements GestureHandler {
   }
 
   private emitKey(vkbd: VisualKeyboard, selection: ActiveKeyBase, pathStats: CumulativePathStats<any>) {
-    let keyEvent: KeyEvent;
+    let finalSelection: ActiveKeyBase;
     const projectedDistance = calcLockedDistance(pathStats, this.lockedDir);
     if(projectedDistance > this.gestureParams.flick.triggerDist) {
-      keyEvent = vkbd.keyEventFromSpec(selection);
+      finalSelection = selection;
     } else {
       // Even if mid-way between base key and actual key.
-      keyEvent = vkbd.keyEventFromSpec(this.baseSpec);
+      finalSelection = this.baseSpec;
     }
 
+    const keyEvent = vkbd.keyEventFromSpec(finalSelection);
     keyEvent.keyDistribution = this.currentStageKeyDistribution(this.baseKeyDistances);
     keyEvent.inputBreadcrumb = this.sequence.trace();
 
     // emit the keystroke
-    vkbd.raiseKeyEvent(keyEvent, null);
+    vkbd.raiseKeyEvent(keyEvent, finalSelection, null);
   }
 
   private buildPopupRecognitionConfig(vkbd: VisualKeyboard): GestureRecognizerConfiguration<KeyElement, string> {

--- a/web/src/engine/osk/src/input/gestures/browser/multitap.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/multitap.ts
@@ -148,7 +148,7 @@ export default class Multitap implements GestureHandler {
       keyEvent.kNextLayer ||= this.originalLayer;
 
       keyEvent.inputBreadcrumb = this.sequence.trace();
-      vkbd.raiseKeyEvent(keyEvent, null);
+      vkbd.raiseKeyEvent(keyEvent, selection, null);
 
       // Now that the key has been processed, with a layer possibly changed as a result...
       if(tap.matchedId == 'modipress-multitap-start') {

--- a/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
+++ b/web/src/engine/osk/src/input/gestures/browser/subkeyPopup.ts
@@ -98,7 +98,7 @@ export default class SubkeyPopup implements GestureHandler {
         keyEvent.keyDistribution = this.currentStageKeyDistribution();
 
         keyEvent.inputBreadcrumb = this.source.trace();
-        vkbd.raiseKeyEvent(keyEvent, key);
+        vkbd.raiseKeyEvent(keyEvent, key.key.spec, key);
       }
     });
 

--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -965,7 +965,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     }
 
     keyEvent.inputBreadcrumb = sequence.trace();
-    return this.raiseKeyEvent(keyEvent, e);
+    return this.raiseKeyEvent(keyEvent, e.key.spec, e);
   }
 
   initKeyEvent(e: KeyElement) {
@@ -1626,11 +1626,28 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     this.layerLocked = enable;
   }
 
-  raiseKeyEvent(keyEvent: KeyEvent, e: KeyElement): KeyRuleEffects {
+  raiseKeyEvent(keyEvent: KeyEvent, keySpec: ActiveKeyBase, e: KeyElement): KeyRuleEffects {
     // Exclude menu and OSK hide keys from normal click processing
     if(keyEvent.kName == 'K_LOPT' || keyEvent.kName == 'K_ROPT') {
       this.optionKey(e, keyEvent.kName, true);
       return {};
+    }
+
+    // Ensure that no matter what, the first key in the distribution matches the "true" key
+    // that the user actually touched.  Even if it's not the most likely key.
+    const keyDistribution = keyEvent.keyDistribution;
+    if(keyDistribution && keyDistribution.length > 1) {
+      const matchIndex = keyDistribution.findIndex(keySample => keySample.keySpec == keySpec);
+      if(matchIndex < 0) {
+        console.error("Could not find and prioritize output key in its fat-finger distribution");
+      } else if(matchIndex > 0) {
+        // Possibly not ideal for easy reading during inspection, but it's
+        // low-cost to just swap the entry with the most likely entry and call
+        // it a day.  Better than full-on re-sorting.
+        const trueEntry = keyDistribution[matchIndex];
+        keyDistribution[matchIndex] = keyDistribution[0];
+        keyDistribution[0] = trueEntry;
+      }
     }
 
     const callbackData: KeyRuleEffects = {};

--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -119,12 +119,6 @@ export class ModelCompositor {
       })
     }
 
-    // Fulfill pre-condition:  the transform distribution should be sorted in
-    // descending order.
-    transformDistribution.sort(function(a, b) {
-      return b.p - a.p;
-    });
-
     // Only allow new-word suggestions if space was the most likely keypress.
     // const allowSpace = TransformUtils.isWhitespace(inputTransform);
     const inputTransform = transformDistribution[0].sample;


### PR DESCRIPTION
Due to recent internal changes, the context-caching engine now needs the effects for the actual input keystroke to be in the initial position within the fat-finger distribution.  This removes a few places where the distribution has been sorted up 'til now, as there are cases where a different key can have higher probability than the one actually tapped - displacing the actual input from the lead position.

@keymanapp-test-bot skip