### PR TITLE
fix(web): fix suggestion-application when preserved text prepends extra whitespace 🚂

### DIFF
--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-transition.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-transition.tests.ts
@@ -92,65 +92,128 @@ describe('ContextTransition', () => {
     });
   });
 
-  it('applySuggestion', () => {
-    const baseContext = {
-      left: "hello wo",
-      startOfBuffer: true,
-      endOfBuffer: true
-    };
-    const baseState = new ContextState(baseContext, plainModel);
+  describe('applySuggestion', () => {
+    it('properly handles standard cases without suggestion-preserved text', () => {
+      const baseContext = {
+        left: "hello wo",
+        startOfBuffer: true,
+        endOfBuffer: true
+      };
+      const baseState = new ContextState(baseContext, plainModel);
 
-    // currently, also calls the .finalize method internally.
-    const transition = baseState.analyzeTransition(baseContext, [
-      { sample: { insert: 'r', deleteLeft: 0, id: 2 }, p: 1 }
-    ]);
-    assert.isOk(transition);
+      // currently, also calls the .finalize method internally.
+      const transition = baseState.analyzeTransition(baseContext, [
+        { sample: { insert: 'r', deleteLeft: 0, id: 2 }, p: 1 }
+      ]);
+      assert.isOk(transition);
 
-    let suggestions = transition.final.suggestions = [{
-      transform: {
-        insert: 'rld',
-        deleteLeft: 0,
-        id: 2
-      },
-      appendedTransform: {
-        insert: ' ',
-        deleteLeft: 0,
-        id: 2
-      },
-      transformId: 2,
-      id: 10,
-      displayAs: 'world'
-    }, {
-      transform: {
-        insert: 'n',
-        deleteLeft: 0,
-        id: 2
-      },
-      appendedTransform: {
-        insert: ' ',
-        deleteLeft: 0,
-        id: 2
-      },
-      transformId: 2,
-      id: 11,
-      displayAs: 'won'
-    }];
+      let suggestions = transition.final.suggestions = [{
+        transform: {
+          insert: 'rld',
+          deleteLeft: 0,
+          id: 2
+        },
+        appendedTransform: {
+          insert: ' ',
+          deleteLeft: 0,
+          id: 2
+        },
+        transformId: 2,
+        id: 10,
+        displayAs: 'world'
+      }, {
+        transform: {
+          insert: 'n',
+          deleteLeft: 0,
+          id: 2
+        },
+        appendedTransform: {
+          insert: ' ',
+          deleteLeft: 0,
+          id: 2
+        },
+        transformId: 2,
+        id: 11,
+        displayAs: 'won'
+      }];
 
-    const appliedTransition = transition.applySuggestion(suggestions[0]);
-    assert.notEqual(appliedTransition, transition);
-    assert.sameOrderedMembers(appliedTransition.final.tokenization.exampleInput, [
-      'hello', ' ', 'world', ' ', ''
-    ]);
-    assert.equal(appliedTransition.final.appliedSuggestionId, suggestions[0].id);
-    appliedTransition.final.tokenization.tokens.forEach((token, index) => {
-      if(index >= 2) {
-        assert.equal(token.appliedTransitionId, suggestions[0].transformId);
-      } else {
-        assert.isUndefined(token.appliedTransitionId);
-      }
+      const appliedTransition = transition.applySuggestion(suggestions[0]);
+      assert.notEqual(appliedTransition, transition);
+      assert.sameOrderedMembers(appliedTransition.final.tokenization.exampleInput, [
+        'hello', ' ', 'world', ' ', ''
+      ]);
+      assert.equal(appliedTransition.final.appliedSuggestionId, suggestions[0].id);
+      appliedTransition.final.tokenization.tokens.forEach((token, index) => {
+        if(index >= 2) {
+          assert.equal(token.appliedTransitionId, suggestions[0].transformId);
+        } else {
+          assert.isUndefined(token.appliedTransitionId);
+        }
+      });
+      assert.deepEqual(appliedTransition.final.suggestions, transition.final.suggestions);
+      assert.deepEqual(appliedTransition.final.inputTransforms, transition.final.inputTransforms);
     });
-    assert.deepEqual(appliedTransition.final.suggestions, transition.final.suggestions);
-    assert.deepEqual(appliedTransition.final.inputTransforms, transition.final.inputTransforms);
+
+     it('properly handles cases with suggestion-preserved text', () => {
+      const baseContext = {
+        left: "hello world ",
+        startOfBuffer: true,
+        endOfBuffer: true
+      };
+      const baseState = new ContextState(baseContext, plainModel);
+
+      // currently, also calls the .finalize method internally.
+      const transition = baseState.analyzeTransition(baseContext, [
+        { sample: { insert: ' ', deleteLeft: 0, id: 2 }, p: 1 }
+      ]);
+      assert.isOk(transition);
+
+      let suggestions = transition.final.suggestions = [{
+        transform: {
+          insert: ' the',
+          deleteLeft: 0,
+          id: 2
+        },
+        appendedTransform: {
+          insert: ' ',
+          deleteLeft: 0,
+          id: 2
+        },
+        transformId: 2,
+        id: 10,
+        displayAs: 'the'
+      }, {
+        transform: {
+          insert: ' and',
+          deleteLeft: 0,
+          id: 2
+        },
+        appendedTransform: {
+          insert: ' ',
+          deleteLeft: 0,
+          id: 2
+        },
+        transformId: 2,
+        id: 11,
+        displayAs: 'and'
+      }];
+
+      const appliedTransition = transition.applySuggestion(suggestions[0]);
+      assert.notEqual(appliedTransition, transition);
+      assert.sameOrderedMembers(appliedTransition.final.tokenization.exampleInput, [
+        'hello', ' ', 'world', '  ', 'the', ' ', ''
+      ]);
+      assert.equal(appliedTransition.final.appliedSuggestionId, suggestions[0].id);
+      appliedTransition.final.tokenization.tokens.forEach((token, index) => {
+        if(index >= 3) {
+          assert.equal(token.appliedTransitionId, suggestions[0].transformId);
+        } else {
+          assert.isUndefined(token.appliedTransitionId);
+        }
+      });
+      assert.deepEqual(appliedTransition.final.suggestions, transition.final.suggestions);
+      assert.deepEqual(appliedTransition.final.inputTransforms, transition.final.inputTransforms);
+    });
   });
 
   describe('reproduceOriginal', () => {


### PR DESCRIPTION
During local-development robustness testing, I found that applying a suggestion generated by typing a _second_ whitespace in a row would generate an error.  (The error does not occur if any non-whitespace character is typed after that second whitespace.)  The error arises because this scenario requires the generated suggestions to be internally prepended with the new whitespace, thus including a word-breaking boundary within the Suggestion's transform that complicates context operations when applied.  These changes allow such prepended whitespace to be handled properly by relaxing constraints for context operations, but _only_ when applying suggestions.

There's still at least one subtle detail that might be worth revisiting - suggestions displayed after the second whitespace will show high preference to whichever bottom-row key is closest to where the spacebar was pressed, despite not replacing it.

I have identified one remaining behavior that should be addressed in due time, though it is pretty niche.  I'd like to go ahead and order a round of testing here in case there are any other behaviors yet to be discovered that will also need addressing.

## User Testing

TEST_ROBUSTNESS: Spend at least 5 minutes in the Android app trying to "break" predictive text and/or cause it to work improperly. Report back on any issues discovered, error notifications raised, or other odd behaviors.