### PR TITLE
refactor(web): refactor distance-calculation method that extends path on new input 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
@@ -1,4 +1,4 @@
-export { ClassicalDistanceCalculation, EditOperation, EditTuple } from './correction/classical-calculation.js';
+export { ClassicalDistanceCalculation, EditOperation, EditTuple, forNewIndices } from './correction/classical-calculation.js';
 export { ContextState } from './correction/context-state.js';
 export { ContextToken } from './correction/context-token.js';
 export { ContextTokenization } from './correction/context-tokenization.js';


### PR DESCRIPTION
This PR refactors an internal method for the edit-distance calculation class with two main goals in mind:
1.  It (and its logic) can now be more directly unit-tested.
2. The new version's implementation and usage should be _far_ more clear, making all affected code more easily maintainable.

Build-bot: skip build:web
Test-bot: skip