### PR TITLE
feat(web): support split, merge for edit-path construction

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/classical-calculation.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/classical-calculation.ts
@@ -120,7 +120,9 @@ export function visualizeCalculation<TUnit, TOpSet>(calc: ClassicalDistanceCalcu
           break;
         case 'substitute':
         case 'match':
-          const op = edit.op == 'substitute' ? '=>' : '==';
+        case 'split':
+        case 'merge':
+          const op = edit.op == 'match' ? '==' : '=>';
           tokenText = tokenText || `'${edit.input}' ${op} '${edit.match}'`;
           break;
         // transpose-start, transpose-end
@@ -129,9 +131,16 @@ export function visualizeCalculation<TUnit, TOpSet>(calc: ClassicalDistanceCalcu
       }
       return `${edit.op}(${tokenText})`;
     }
+
+    let lastEdit: string;
     do {
-      edits.push(printEdit(path.shift()));
-    } while(path.length > 0 && edits[edits.length-1].indexOf('insert') != -1);
+      if(lastEdit && lastEdit.indexOf('split') != -1 && path[0].op != 'split') {
+        break;
+      }
+
+      lastEdit = printEdit(path.shift());
+      edits.push(lastEdit);
+    } while(path.length > 0 && (lastEdit.indexOf('insert') != -1 || lastEdit.indexOf('split') != -1));
     // If final row, dump the rest of the edit path into the current row.
     if(i == calc.inputSequence.length - 1) {
       // Capture final 'insert's!

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/segmentable-calculation.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/segmentable-calculation.tests.ts
@@ -65,6 +65,18 @@ describe('Split/merge aware edit-distance calculation', () => {
     ['a', 'b', 'c', 'd', 'f', 'gh'].forEach(c => calc = calc.addMatchChar(c));
 
     assert.equal(calc.getFinalCost(), 4);
+
+    const editPaths = calc.editPath();
+    assert.equal(editPaths.length, 1);
+    assert.sameDeepOrderedMembers(editPaths[0], [
+      { op: 'split', input: 'ab', match: 'a' },
+      { op: 'split', input: 'ab', match: 'b' },
+      { op: 'transpose-start', input: 'd', match: 'c' },
+      { op: 'transpose-end', input: 'c', match: 'd' },
+      { op: 'substitute', input: 'e', match: 'f' },
+      { op: 'merge', input: 'g', match: 'gh' },
+      { op: 'merge', input: 'h', match: 'gh' }
+    ]);
   });
 
   it("abc,d,f,g,h -> a,b,c,d,fgh = 2", () => {
@@ -75,5 +87,17 @@ describe('Split/merge aware edit-distance calculation', () => {
     ['a', 'b', 'c', 'd', 'fgh'].forEach(c => calc = calc.addMatchChar(c));
 
     assert.equal(calc.getFinalCost(), 2);
+
+    const editPaths = calc.editPath();
+    assert.equal(editPaths.length, 1);
+    assert.sameDeepOrderedMembers(editPaths[0], [
+      { op: 'split', input: 'abc', match: 'a' },
+      { op: 'split', input: 'abc', match: 'b' },
+      { op: 'split', input: 'abc', match: 'c' },
+      { op: 'match', input: 'd', match: 'd' },
+      { op: 'merge', input: 'f', match: 'fgh' },
+      { op: 'merge', input: 'g', match: 'fgh' },
+      { op: 'merge', input: 'h', match: 'fgh' }
+    ]);
   });
 });


### PR DESCRIPTION
Relates-to: #14679

The goal of this PR is to facilitate better handling for token splits and token merges and implements edit-path support for the new, specially-targeted edit operation types.  However, it does not integrate the new 'split' / 'merge' oriented logic into its target use cases.

@keymanapp-test-bot skip