### PR TITLE
fix(web): fix error trying to calculate style scaling effects 🍒 🏠

### DIFF
--- a/web/src/engine/osk/src/visualKeyboard.ts
+++ b/web/src/engine/osk/src/visualKeyboard.ts
@@ -802,6 +802,7 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
     if (this.usesFixedWidthScaling) {
       let baseWidth = this.width;
       baseWidth -= this._borderWidth * 2;
+      baseWidth = (isNaN(baseWidth) || baseWidth < 0) ? 0 : baseWidth;
       return ParsedLengthStyle.inPixels(baseWidth);
     } else {
       return ParsedLengthStyle.forScalar(1);
@@ -826,7 +827,9 @@ export default class VisualKeyboard extends EventEmitter<EventMap> implements Ke
       // Touch OSKs may apply internal padding to prevent row cropping at the edges.
       // ... why not precompute both, rather than recalculate each time?
       // - appears to contribute to layout reflow costs on layer swaps!
-      return ParsedLengthStyle.inPixels(this.layoutHeight.val - this._borderWidth * 2 - this.layerGroup.verticalPadding);
+      let baseHeight = this.layoutHeight.val - this._borderWidth * 2 - this.layerGroup.verticalPadding;
+      baseHeight = (isNaN(baseHeight) || baseHeight < 0) ? 0 : baseHeight;
+      return ParsedLengthStyle.inPixels(baseHeight);
     } else {
       return ParsedLengthStyle.forScalar(1);
     }

--- a/web/src/test/auto/headless/engine/osk/visualKeyboard.tests.ts
+++ b/web/src/test/auto/headless/engine/osk/visualKeyboard.tests.ts
@@ -1,0 +1,241 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
+import { assert } from 'chai';
+import sinon from 'sinon';
+// @ts-ignore  // Type info unavailable; doing a npm-install for it breaks things much worse in other ways.
+import { JSDOM } from 'jsdom';
+
+import { VisualKeyboard } from 'keyman/engine/osk';
+import { ActiveLayout, Keyboard, KeyboardProperties } from 'keyman/engine/keyboard';
+import { StylesheetManager } from 'keyman/engine/dom-utils';
+import { DeviceSpec } from "@keymanapp/web-utils";
+
+describe('VisualKeyboard', () => {
+  let dom: JSDOM;
+  let mockConfig: any;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!DOCTYPE html><p>Hello world</p>');
+    global.document = dom.window.document;
+    global.getComputedStyle = dom.window.getComputedStyle;
+
+    const mockDevice = { browser: DeviceSpec.Browser.Chrome, formFactor: DeviceSpec.FormFactor.Desktop, OS: DeviceSpec.OperatingSystem.Windows, touchable: false };
+    const mockLayout = sinon.createStubInstance(ActiveLayout) as any;
+
+    const keyboard = sinon.createStubInstance(Keyboard) as any;
+    keyboard.layout.returns(mockLayout);
+    sinon.stub(keyboard, 'isRTL').get(() => false);
+    sinon.stub(keyboard, 'id').get(() => 'test');
+    sinon.stub(keyboard, 'name').get(() => 'Test Keyboard');
+
+    mockConfig = {
+      device: mockDevice,
+      hostDevice: mockDevice,
+      pathConfig: { fonts: '', resources: '' },
+      keyboard: keyboard,
+      keyboardMetadata: sinon.createStubInstance(KeyboardProperties),
+      topContainer: document.createElement('div'),
+      styleSheetManager: sinon.createStubInstance(StylesheetManager),
+    };
+  });
+
+  function createVisualKeyboard(fixedScaling: boolean = true): VisualKeyboard {
+    const vk = new VisualKeyboard(mockConfig);
+    vk.usesFixedHeightScaling = fixedScaling;
+    vk.usesFixedWidthScaling = fixedScaling;
+    vk['_borderWidth'] = 3;
+    return vk;
+  }
+
+  describe('LayoutHeight', () => {
+    it('calculates LayoutHeight correctly for number', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = 100;
+      assert.equal(vk.layoutHeight.val, 94);
+    });
+
+    it('calculates LayoutHeight correctly for number string', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = "100";
+      assert.equal(vk.layoutHeight.val, 94);
+    });
+
+    it('accepts small heights for LayoutHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = "5";
+      assert.equal(vk.layoutHeight.val, 0);
+    });
+
+    it('ignores non-number string for LayoutHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = "100px";
+      assert.equal(vk.layoutHeight.val, 0);
+    });
+
+    it('ignores invalid string for LayoutHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = "invalid";
+      assert.equal(vk.layoutHeight.val, 0);
+    });
+
+    it('ignores undefined value for LayoutHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = undefined;
+      assert.equal(vk.layoutHeight.val, 0);
+    });
+
+    it('ignores null value for LayoutHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = null;
+      assert.equal(vk.layoutHeight.val, 0);
+    });
+
+    it('calculates LayoutHeight correctly with fixed scaling', () => {
+      const vk = createVisualKeyboard(true);
+      vk['_height'] = 100;
+      assert.equal(vk.layoutHeight.val, 94);
+    });
+
+    it('calculates LayoutHeight correctly with fixed scaling and string', () => {
+      const vk = createVisualKeyboard(true);
+      vk['_height'] = "100px";
+      assert.equal(vk.layoutHeight.val, 0);
+    });
+
+    it('ignores invalid borderWidth for LayoutHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = 100;
+      vk['_borderWidth'] = "3px";
+      assert.equal(vk.layoutHeight.val, 0);
+    });
+  });
+
+  describe('LayoutWidth', () => {
+    it('calculates LayoutWidth correctly for number', () => {
+      const vk = createVisualKeyboard();
+      vk['_width'] = 100;
+      assert.equal(vk.layoutWidth.val, 94);
+    });
+
+    it('calculates LayoutWidth correctly for number string', () => {
+      const vk = createVisualKeyboard();
+      vk['_width'] = "100";
+      assert.equal(vk.layoutWidth.val, 94);
+    });
+
+    it('accepts small heights for LayoutWidth', () => {
+      const vk = createVisualKeyboard();
+      vk['_width'] = "5";
+      assert.equal(vk.layoutWidth.val, 0);
+    });
+
+    it('ignores non-number string for LayoutWidth', () => {
+      const vk = createVisualKeyboard();
+      vk['_width'] = "100px";
+      assert.equal(vk.layoutWidth.val, 0);
+    });
+
+    it('ignores invalid string for LayoutWidth', () => {
+      const vk = createVisualKeyboard();
+      vk['_width'] = "invalid";
+      assert.equal(vk.layoutWidth.val, 0);
+    });
+
+    it('ignores undefined value for LayoutWidth', () => {
+      const vk = createVisualKeyboard();
+      vk['_width'] = undefined;
+      assert.equal(vk.layoutWidth.val, 0);
+    });
+
+    it('ignores null value for LayoutWidth', () => {
+      const vk = createVisualKeyboard();
+      vk['_width'] = null;
+      assert.equal(vk.layoutWidth.val, 0);
+    });
+
+    it('calculates LayoutWidth correctly with fixed scaling', () => {
+      const vk = createVisualKeyboard(true);
+      vk['_width'] = 100;
+      assert.equal(vk.layoutWidth.val, 94);
+    });
+
+    it('calculates LayoutWidth correctly with fixed scaling and string', () => {
+      const vk = createVisualKeyboard(true);
+      vk['_width'] = "100px";
+      assert.equal(vk.layoutWidth.val, 0);
+    });
+
+    it('ignores invalid borderWidth for LayoutWidth', () => {
+      const vk = createVisualKeyboard();
+      vk['_width'] = 100;
+      vk['_borderWidth'] = "3px";
+      assert.equal(vk.layoutWidth.val, 0);
+    });
+
+  });
+
+  describe('InternalHeight', () => {
+    it('calculates InternalHeight correctly for number', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = 100;
+      assert.equal(vk.internalHeight.val, 88);
+    });
+
+    it('calculates InternalHeight correctly for number string', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = "100";
+      assert.equal(vk.internalHeight.val, 88);
+    });
+
+    it('accepts small heights for InternalHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = "5";
+      assert.equal(vk.internalHeight.val, 0);
+    });
+
+    it('ignores non-number string for InternalHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = "100px";
+      assert.equal(vk.internalHeight.val, 0);
+    });
+
+    it('ignores invalid string for InternalHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = "invalid";
+      assert.equal(vk.internalHeight.val, 0);
+    });
+
+    it('ignores undefined value for InternalHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = undefined;
+      assert.equal(vk.internalHeight.val, 0);
+    });
+
+    it('ignores null value for InternalHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = null;
+      assert.equal(vk.internalHeight.val, 0);
+    });
+
+    it('calculates InternalHeight correctly with fixed scaling', () => {
+      const vk = createVisualKeyboard(true);
+      vk['_height'] = 100;
+      assert.equal(vk.internalHeight.val, 88);
+    });
+
+    it('calculates InternalHeight correctly with fixed scaling and string', () => {
+      const vk = createVisualKeyboard(true);
+      vk['_height'] = "100px";
+      assert.equal(vk.internalHeight.val, 0);
+    });
+
+    it('ignores invalid borderWidth for InternalHeight', () => {
+      const vk = createVisualKeyboard();
+      vk['_height'] = 100;
+      vk['_borderWidth'] = "3px";
+      assert.equal(vk.internalHeight.val, 0);
+    });
+
+  });
+});


### PR DESCRIPTION
PR #13860 fixed a similar error by adding a check for NaN. However, it missed doing it for `layoutWidth` and only changed `layoutHeight`. This PR adds a similar check to `layoutWidth` and  `internalHeight` and will thus fix the error we're still seeing in Sentry.

Also add unit tests for all three methods.

# User Testing

TEST_INUKTITUT_KEYBOARD: Using Keyman for Android, install the `inuktitut_pirurvik` and verify that no error notifications appear.

Fixes: #14108
Fixes: [KEYMAN-WEB-RA](https://keyman.sentry.io/issues/6579536471/?referrer=github_integration)
Cherry-pick-of: #14684