### PR TITLE
maint(mac): use versioned filenames for PR artifacts

### DIFF
--- a/mac/Keyman4MacIM/make-km-dmg.sh
+++ b/mac/Keyman4MacIM/make-km-dmg.sh
@@ -212,7 +212,7 @@ if (( DETACH_SUCCESS < 999 )); then
 fi
 
 # Step 5 - Convert image to a compressed readonly DMG image
-DMG_FILE_PATH="$DEST_DIR/keyman-$KEYMAN_VERSION.dmg"
+DMG_FILE_PATH="$DEST_DIR/keyman-$KEYMAN_VERSION_FOR_PR_FILENAME.dmg"
 builder_echo info "Converting/compressing image to create \"$DMG_FILE_PATH\""
 if [[ -e "$DMG_FILE_PATH" ]] ; then
     if [[ "$VERBOSITY" != "-quiet" ]] ; then

--- a/mac/build.sh
+++ b/mac/build.sh
@@ -293,7 +293,7 @@ do_publish() {
   "${KM4MIM_BASE_PATH}/make-km-dmg.sh"
 
   local UPLOAD_PATH="${KM4MIM_BASE_PATH}/output/upload/${KEYMAN_VERSION}"
-  write_download_info "${UPLOAD_PATH}" "keyman-${KEYMAN_VERSION}.dmg" "Keyman4MacIM" dmg mac
+  write_download_info "${UPLOAD_PATH}" "keyman-${KEYMAN_VERSION_FOR_PR_FILENAME}.dmg" "Keyman4MacIM" dmg mac
 
   if builder_is_ci_build && builder_is_ci_build_level_release; then
     do_sentry


### PR DESCRIPTION
Note: corresponding change for test bot is on its way..

<img width="1064" height="240" alt="image" src="https://github.com/user-attachments/assets/62b194c1-efce-481f-b958-1217a53660fa" />

Relates-to: #10521
Test-bot: skip
Build-bot: skip release:mac
Fixes: #10521 (last in the series)