### PR TITLE
change(web): convert engine/main, engine/interfaces tests to TS 🚂

### DIFF
--- a/web/src/engine/interfaces/build.sh
+++ b/web/src/engine/interfaces/build.sh
@@ -44,4 +44,4 @@ do_build () {
 builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf "${KEYMAN_ROOT}/web/build/${SUBPROJECT_NAME}"
 builder_run_action build do_build
-builder_run_action test test-headless "${SUBPROJECT_NAME}"
+builder_run_action test test-headless-typescript "${SUBPROJECT_NAME}"

--- a/web/src/engine/interfaces/src/modelSpec.ts
+++ b/web/src/engine/interfaces/src/modelSpec.ts
@@ -18,10 +18,10 @@ export interface ModelSpec {
    * The path/URL to the file that defines the model.  If both `path` and `code` are specified,
    * `path` takes precedence.
    */
-  path: string;
+  path?: string;
 
   /**
    * The raw JS script defining the model.  Only used if `path` is not specified.
    */
-  code: string;
+  code?: string;
 }

--- a/web/src/engine/main/build.sh
+++ b/web/src/engine/main/build.sh
@@ -49,4 +49,4 @@ do_build () {
 builder_run_action configure node_select_version_and_npm_ci
 builder_run_action clean rm -rf "$KEYMAN_ROOT/web/build/$SUBPROJECT_NAME"
 builder_run_action build do_build
-builder_run_action test test-headless "${SUBPROJECT_NAME}"
+builder_run_action test test-headless-typescript "${SUBPROJECT_NAME}"

--- a/web/src/engine/main/build.sh
+++ b/web/src/engine/main/build.sh
@@ -21,7 +21,7 @@ builder_describe "Builds the Keyman Engine for Web's common top-level base class
   "@/web/src/engine/keyboard-storage build" \
   "@/web/src/engine/osk build" \
   "@/web/src/engine/predictive-text/worker-main" \
-  "@/developer/src/kmc-model test" \
+  "@/developer/src/kmc-model" \
   "clean" \
   "configure" \
   "build" \

--- a/web/src/test/auto/headless/engine/interfaces/pathConfiguration.tests.ts
+++ b/web/src/test/auto/headless/engine/interfaces/pathConfiguration.tests.ts
@@ -1,5 +1,4 @@
 import { assert } from 'chai';
-import sinon from 'sinon';
 
 import { PathOptionDefaults, PathConfiguration } from 'keyman/engine/interfaces';
 

--- a/web/src/test/auto/headless/engine/interfaces/prediction/predictionContext.tests.ts
+++ b/web/src/test/auto/headless/engine/interfaces/prediction/predictionContext.tests.ts
@@ -1,13 +1,16 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
 
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import { Worker as LMWorker } from "@keymanapp/lexical-model-layer/node";
+
 import { LanguageProcessor, TranscriptionCache } from 'keyman/engine/main';
 import { PredictionContext } from 'keyman/engine/interfaces';
-import { Worker as LMWorker } from "@keymanapp/lexical-model-layer/node";
-import { DeviceSpec } from 'keyman/engine/keyboard';
 import { Mock } from 'keyman/engine/js-processor';
 
-function compileDummyModel(suggestionSets) {
+import Suggestion = LexicalModelTypes.Suggestion;
+
+function compileDummyModel(suggestionSets: Suggestion[][]) {
   return `
 LMLayerWorker.loadModel(new models.DummyModel({
   futureSuggestions: ${JSON.stringify(suggestionSets, null, 2)},
@@ -15,7 +18,7 @@ LMLayerWorker.loadModel(new models.DummyModel({
 `;
 }
 
-const appleDummySuggestionSets = [[
+const appleDummySuggestionSets: Suggestion[][] = [[
   // Set 1:
   {
     transform: { insert: 'e', deleteLeft: 0},
@@ -64,9 +67,10 @@ function dummiedGetLayer() {
 }
 
 describe("PredictionContext", () => {
-  let langProcessor;
+  let langProcessor: LanguageProcessor;
 
   beforeEach(function() {
+    // @ts-ignore
     langProcessor = new LanguageProcessor(LMWorker, new TranscriptionCache());
   });
 
@@ -91,7 +95,7 @@ describe("PredictionContext", () => {
     assert.isEmpty(updateFake.firstCall.args[0]); // should have no suggestions. (if convenient for testing)
 
     await promise;
-    let suggestions;
+    let suggestions: Suggestion[];
 
     // Initialization results:  our first set of dummy suggestions.
     assert.equal(updateFake.callCount, 2);
@@ -130,7 +134,7 @@ describe("PredictionContext", () => {
     assert.isEmpty(updateFake.firstCall.args[0]); // should have no suggestions. (if convenient for testing)
 
     await promise;
-    let suggestions;
+    let suggestions: Suggestion[];
 
     // Initialization results:  our first set of dummy suggestions.
     assert.equal(updateFake.callCount, 2);
@@ -205,7 +209,7 @@ describe("PredictionContext", () => {
     let updateFake = sinon.fake();
     predictiveContext.on('update', updateFake);
 
-    let suggestions;
+    let suggestions: Suggestion[];
 
     let previousTextState = Mock.from(textState);
     textState.insertTextBeforeCaret('e'); // appl| + e = apple
@@ -281,7 +285,7 @@ describe("PredictionContext", () => {
 
     // We need to capture the suggestion we wish to apply.  We could hardcode a forced
     // value, but that might become brittle in the long-term.
-    const originalSuggestionSet = suggestionCaptureFake.firstCall.args[0];
+    const originalSuggestionSet: Suggestion[] = suggestionCaptureFake.firstCall.args[0];
     const suggestionApply = originalSuggestionSet.find((obj) => obj.displayAs == 'apply');
     assert.isOk(suggestionApply);
 
@@ -346,7 +350,7 @@ describe("PredictionContext", () => {
     await postRevertSuggestions;
 
     assert.equal(updateFake.callCount, 1);
-    const suggestionsPostReversion = updateFake.firstCall.args[0];
+    const suggestionsPostReversion: Suggestion[] = updateFake.firstCall.args[0];
     assert.deepEqual(suggestionsPostReversion.map((obj) => obj.displayAs), ['reverted']);
   });
 });


### PR DESCRIPTION
I'm hoping to add new unit tests and integration tests for some of the new autocorrect enhancements.  Before I do so, I'd like to convert the test suites to be extended over to TypeScript.

Build-bot: skip build:web
Test-bot: skip