### PR TITLE
fix(linux): don't crash if `kmp.json` is missing `keyboards` section 🍒 🏠

### DIFF
--- a/linux/keyman-config/keyman_config/install_kmp.py
+++ b/linux/keyman-config/keyman_config/install_kmp.py
@@ -178,9 +178,9 @@ class InstallKmp():
                 logging.info("Converting %s to LDML and installing both as as keyman file",
                              f['name'])
                 name, ext = os.path.splitext(f['name'])
-                ldml = convert_kvk_to_ldml(name, fpath)
-                ldmlfile = os.path.join(self.packageDir, f"{name}.ldml")
-                output_ldml(ldmlfile, ldml)
+                if ldml := convert_kvk_to_ldml(name, fpath):
+                    ldmlfile = os.path.join(self.packageDir, f"{name}.ldml")
+                    output_ldml(ldmlfile, ldml)
             elif ftype == KMFileTypes.KM_ICON:
                 # Special handling of icon to convert to PNG
                 logging.info("Converting %s to PNG and installing both as keyman files",

--- a/linux/keyman-config/keyman_config/kvk2ldml.py
+++ b/linux/keyman-config/keyman_config/kvk2ldml.py
@@ -366,14 +366,17 @@ def convert_ldml(keyboardName, kvkData, kmpJsonFilename):
 
     info, system, options, keyboards, files = parsemetadata(kmpJsonFilename)
 
+    if not keyboards:
+        return None
+
     ldml = etree.Element("keyboard", locale="zzz-keyman")
+
     for keyboard in keyboards:
         if keyboard['id'] != keyboardName:
             continue
         if 'oskFont' in keyboard:
             fontFile = os.path.join(os.path.dirname(kmpJsonFilename), keyboard['oskFont'])
-            font = _fontFacename(fontFile)
-            if font:
+            if font := _fontFacename(fontFile):
                 ldml.set('keymanFacename', font)
         break
 

--- a/linux/keyman-config/tests/kvk2ldml_tests.py
+++ b/linux/keyman-config/tests/kvk2ldml_tests.py
@@ -7,31 +7,34 @@ import unittest
 from keyman_config.kvk2ldml import KVKData, NFont, convert_ldml
 
 class Kvk2LdmlTests(unittest.TestCase):
-    def _createKmpJson(self, packagedir):
+    def _createKmpJson(self, packagedir, add_keyboards=True):
         kmpJsonFilename = os.path.join(packagedir, 'kmp.json')
+        system = '''"system": {
+            "keymanDeveloperVersion": "18.0",
+            "fileVersion": "7.0"
+        }'''
+        files = '''"files": [ {
+            "name": "khmer_angkor.kmx",
+            "description": "Keyboard Khmer Angkor"
+            }, {
+            "name": "kmp.json",
+            "description": "Package information (JSON)"
+        } ]'''
+        if add_keyboards:
+            keyboards = '''"keyboards": [ {
+                "name": "Khmer Angkor",
+                "id": "khmer_angkor",
+                "version": "1.5",
+                "oskFont": "keymanweb-osk.ttf",
+                "languages": [ {
+                    "name": "Central Khmer (Khmer, Cambodia)",
+                    "id": "km"
+                } ]}
+            ]'''
+        else:
+            keyboards = ''
         with open(kmpJsonFilename, 'w') as file:
-            file.write('''{
-                "system": {
-                    "keymanDeveloperVersion": "18.0",
-                    "fileVersion": "7.0"
-                },
-                "files": [ {
-                    "name": "khmer_angkor.kmx",
-                    "description": "Keyboard Khmer Angkor"
-                    }, {
-                    "name": "kmp.json",
-                    "description": "Package information (JSON)"
-                    } ],
-                "keyboards": [ {
-                    "name": "Khmer Angkor",
-                    "id": "khmer_angkor",
-                    "version": "1.5",
-                    "oskFont": "keymanweb-osk.ttf",
-                    "languages": [ {
-                        "name": "Central Khmer (Khmer, Cambodia)",
-                        "id": "km"
-                        } ]}
-                ]}''')
+            file.write(f'{{ {system}, {files}, {keyboards} }}')
         return kmpJsonFilename
 
     def test_convert_ldml__adds_keymanFacename(self):
@@ -53,5 +56,22 @@ class Kvk2LdmlTests(unittest.TestCase):
         # Verify
         self.assertEqual(ldml.get('locale'), "zzz-keyman")
         self.assertEqual(ldml.get('keymanFacename'), 'SymChar')
+
+        workdir.cleanup()
+
+    def test_convert_ldml__no_crash_without_keyboards(self):
+        # Setup
+        keyboardName = 'khmer_angkor'
+        kvkData = KVKData()
+        kvkData.AssociatedKeyboard = keyboardName
+
+        workdir = tempfile.TemporaryDirectory()
+        kmpJsonFilename = self._createKmpJson(workdir.name, add_keyboards=False)
+
+        # Execute
+        ldml = convert_ldml(keyboardName, kvkData, kmpJsonFilename)
+
+        # Verify
+        self.assertIsNone(ldml)
 
         workdir.cleanup()


### PR DESCRIPTION
Some keyboards seem to be missing the `keyboards` section in the `kmp.json` file. This change prevents a crash and instead returns `None` and thus we don't create a .ldml file and so onboard will show the default keyboard instead. The alternative would be to create an empty .ldml file, but that causes onboard to show a keyboard with all key caps being empty.

Cherry-pick-of: #14708
Fixes: #14707
Fixes: KEYMAN-LINUX-8P
Test-bot: skip