### PR TITLE
feat(web): add unit tests to validate correction setup helpers

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -240,12 +240,10 @@ export function matchBaseContextState(
   context: Context,
   transitionId: number
 ): ContextState {
-  const lengthThreshold = contextTracker.configuration?.leftContextCodePoints ?? Number.POSITIVE_INFINITY;
-
   const contextsMatch = (a: Context, b: Context) => {
     // If either context's window is equal to or greater than the threshold
     // length, there's a good chance something slid into or out of range.
-    if(a.left.length >= lengthThreshold || b.left.length >= lengthThreshold) {
+    if(!a.startOfBuffer || !b.startOfBuffer) {
       return isSubstitutionAlignable(a.left, b.left);
     } else {
       // If both are smaller than the threshold, the text should match exactly.

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/base-context-state.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/base-context-state.tests.ts
@@ -1,0 +1,188 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
+import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
+
+import { ContextTracker, matchBaseContextState, models } from "@keymanapp/lm-worker/test-index";
+
+import CasingFunction = LexicalModelTypes.CasingFunction;
+import Context = LexicalModelTypes.Context;
+import TrieModel = models.TrieModel;
+
+const plainApplyCasing: CasingFunction = function(caseToApply, text) {
+  switch(caseToApply) {
+    case 'lower':
+      return text.toLowerCase();
+    case 'upper':
+      return text.toUpperCase();
+    case 'initial':
+      return plainApplyCasing('upper', text.charAt(0)) . concat(text.substring(1));
+    default:
+      return text;
+  }
+};
+
+const plainCasedModel = new TrieModel(
+  jsonFixture('models/tries/english-1000'), {
+    languageUsesCasing: true,
+    applyCasing: plainApplyCasing,
+    wordBreaker: defaultBreaker,
+    searchTermToKey: function(text: string) {
+      // We're dealing with very simple English text; no need to normalize or remove diacritics here.
+      return plainApplyCasing('lower', text);
+    }
+  }
+);
+
+describe('matchBaseContextState', () => {
+  it('handles simplest common-case well:  context aligns with result of last transition', () => {
+    const context: Context = {
+      left: 'this is tech',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    const contextTracker = new ContextTracker(plainCasedModel, context, 1, plainCasedModel.configuration);
+    const baseState = contextTracker.latest.final;
+
+    const transition = baseState.analyzeTransition({
+      left: 'this is tech',
+      startOfBuffer: true,
+      endOfBuffer: true
+    }, [{sample: { insert: 'n', deleteLeft: 0 }, p: 1}]);
+    contextTracker.latest = transition;
+
+    const warningSpy = sinon.spy(console, 'warn');
+    try {
+      const matchedState = matchBaseContextState(contextTracker, {
+        left: 'this is techn',
+        startOfBuffer: true,
+        endOfBuffer: true
+      }, 1);
+
+      assert.isFalse(warningSpy.called);
+      assert.equal(matchedState, transition.final);
+    } finally {
+      warningSpy.restore();
+    }
+  });
+
+  it('handles sliding common-case well:  context aligns with result of last transition', () => {
+    const context: Context = {
+      left: 'a lot of test here might cause the sliding context window to shi', // 64 chars
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    const contextTracker = new ContextTracker(plainCasedModel, context, 1, plainCasedModel.configuration);
+    const baseState = contextTracker.latest.final;
+
+    const transition = baseState.analyzeTransition({
+      left: 'a lot of test here might cause the sliding context window to shi',
+      startOfBuffer: false, // We're sliding now.
+      endOfBuffer: true
+    }, [{sample: { insert: 'f', deleteLeft: 0 }, p: 1}]);
+    contextTracker.latest = transition;
+
+    const warningSpy = sinon.spy(console, 'warn');
+    try {
+      const matchedState = matchBaseContextState(contextTracker, {
+        left: ' lot of test here might cause the sliding context window to shif',
+        startOfBuffer: false,
+        endOfBuffer: true
+      }, 1);
+
+      assert.isFalse(warningSpy.called);
+      assert.equal(matchedState, transition.final);
+    } finally {
+      warningSpy.restore();
+    }
+  });
+
+  it("handles multitap scenarios - uses prior transition's base state instead of final", () => {
+    const context: Context = {
+      left: 'meet you at the caf',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    const contextTracker = new ContextTracker(plainCasedModel, context, 1, plainCasedModel.configuration);
+    const baseState = contextTracker.latest.final;
+
+    const transition = baseState.analyzeTransition({
+      left: 'meet you at the caf',
+      startOfBuffer: true,
+      endOfBuffer: true
+    }, [{sample: { insert: 'e', deleteLeft: 0 }, p: 1}]);
+    contextTracker.latest = transition;
+
+    const matchedState = matchBaseContextState(contextTracker, {
+      left: 'meet you at the caf',  // with input:  é
+      startOfBuffer: true,
+      endOfBuffer: true
+    }, 1);
+
+    assert.equal(matchedState, transition.base);
+  });
+
+  it('handles sliding context with large jump from applying a suggestion', () => {
+    const context: Context = {
+      left: 'ot of test here might cause the sliding context window to shift ', // 64 chars
+      startOfBuffer: false,
+      endOfBuffer: true
+    };
+    const contextTracker = new ContextTracker(plainCasedModel, context, 1, plainCasedModel.configuration);
+    const baseState = contextTracker.latest.final;
+
+    const transition = baseState.analyzeTransition({
+      left: 'ot of test here might cause the sliding context window to shift ',
+      startOfBuffer: false, // We're sliding now.
+      endOfBuffer: true
+    }, [{sample: { insert: 'dramatically', deleteLeft: 0 }, p: 1}], true);
+    contextTracker.latest = transition;
+
+    const warningSpy = sinon.spy(console, 'warn');
+    try {
+      const matchedState = matchBaseContextState(contextTracker, {
+        left: 'ere might cause the sliding context window to shift dramatically',
+        startOfBuffer: false,
+        endOfBuffer: true
+      }, 1);
+
+      assert.isFalse(warningSpy.called);
+      assert.equal(matchedState, transition.final);
+    } finally {
+      warningSpy.restore();
+    }
+  });
+
+it('handles backward-sliding context after big delete', () => {
+    const context: Context = {
+      left: 'ere might cause the sliding context window to shift dramatically', // 64 chars
+      startOfBuffer: false,
+      endOfBuffer: true
+    };
+    const contextTracker = new ContextTracker(plainCasedModel, context, 1, plainCasedModel.configuration);
+    const baseState = contextTracker.latest.final;
+
+    const transition = baseState.analyzeTransition({
+      left: 'ere might cause the sliding context window to shift dramatically',
+      startOfBuffer: false, // We're sliding now.
+      endOfBuffer: true
+    }, [{sample: { insert: '', deleteLeft: 'dramatically'.length }, p: 1}], true);
+    contextTracker.latest = transition;
+
+    const warningSpy = sinon.spy(console, 'warn');
+    try {
+      const matchedState = matchBaseContextState(contextTracker, {
+        left: 'ot of test here might cause the sliding context window to shift ',
+        startOfBuffer: false,
+        endOfBuffer: true
+      }, 1);
+
+      assert.isFalse(warningSpy.called);
+      assert.equal(matchedState, transition.final);
+    } finally {
+      warningSpy.restore();
+    }
+  });
+});

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-suggestion-alignment.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-suggestion-alignment.tests.ts
@@ -1,0 +1,90 @@
+import { assert } from 'chai';
+
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
+import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
+
+import { ContextState, ContextTransition, determineSuggestionAlignment, models } from "@keymanapp/lm-worker/test-index";
+
+import CasingFunction = LexicalModelTypes.CasingFunction;
+import Context = LexicalModelTypes.Context;
+import TrieModel = models.TrieModel;
+
+const plainApplyCasing: CasingFunction = function(caseToApply, text) {
+  switch(caseToApply) {
+    case 'lower':
+      return text.toLowerCase();
+    case 'upper':
+      return text.toUpperCase();
+    case 'initial':
+      return plainApplyCasing('upper', text.charAt(0)) . concat(text.substring(1));
+    default:
+      return text;
+  }
+};
+
+const plainCasedModel = new TrieModel(
+  jsonFixture('models/tries/english-1000'), {
+    languageUsesCasing: true,
+    applyCasing: plainApplyCasing,
+    wordBreaker: defaultBreaker,
+    searchTermToKey: function(text: string) {
+      // We're dealing with very simple English text; no need to normalize or remove diacritics here.
+      return plainApplyCasing('lower', text);
+    }
+  }
+);
+
+describe('determineSuggestionAlignment', () => {
+  it('handles standard cases well - same token, no preservationTransforms', () => {
+    const context: Context = {
+      left: 'this is techn',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    const baseState = new ContextState(context, plainCasedModel);
+
+    const transition = new ContextTransition(baseState, 0);
+    transition.finalize(transition.base, [{sample: { insert: '', deleteLeft: 0 }, p: 1}]);
+
+    // transition, model
+    const results = determineSuggestionAlignment(transition, plainCasedModel);
+
+    assert.deepEqual(results.predictionContext, context);
+    assert.equal(results.deleteLeft, "techn".length);
+  });
+
+  it('handles extension of prior token after backspace', () => {
+    const context: Context = {
+      left: 'this is tech ',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    const baseState = new ContextState(context, plainCasedModel);
+
+    const transition = baseState.analyzeTransition(context, [{sample: { insert: '', deleteLeft: 1 }, p: 1}])
+
+    // transition, model
+    const results = determineSuggestionAlignment(transition, plainCasedModel);
+
+    assert.deepEqual(results.predictionContext, context);
+    assert.equal(results.deleteLeft, "tech".length + 1 /* for the deleted whitespace */);
+  });
+
+  it('handles extension of prior token after complex input with delete-left', () => {
+    const context: Context = {
+      left: 'this is tech ',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    const baseState = new ContextState(context, plainCasedModel);
+
+    const transition = baseState.analyzeTransition(context, [{sample: { insert: 'n', deleteLeft: 1 }, p: 1}])
+
+    // transition, model
+    const results = determineSuggestionAlignment(transition, plainCasedModel);
+
+    assert.deepEqual(results.predictionContext, context);
+    assert.equal(results.deleteLeft, "techn".length + 1 /* for the deleted whitespace */);
+  });
+});

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-suggestion-context-transition.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-suggestion-context-transition.tests.ts
@@ -1,0 +1,458 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
+import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
+
+import { ContextTracker, determineContextTransition, ModelCompositor, models } from "@keymanapp/lm-worker/test-index";
+
+import CasingFunction = LexicalModelTypes.CasingFunction;
+import Context = LexicalModelTypes.Context;
+import Distribution = LexicalModelTypes.Distribution;
+import Suggestion = LexicalModelTypes.Suggestion;
+import TrieModel = models.TrieModel;
+import Transform = LexicalModelTypes.Transform;
+
+const plainApplyCasing: CasingFunction = function(caseToApply, text) {
+  switch(caseToApply) {
+    case 'lower':
+      return text.toLowerCase();
+    case 'upper':
+      return text.toUpperCase();
+    case 'initial':
+      return plainApplyCasing('upper', text.charAt(0)) . concat(text.substring(1));
+    default:
+      return text;
+  }
+};
+
+const plainCasedModel = new TrieModel(
+  jsonFixture('models/tries/english-1000'), {
+    languageUsesCasing: true,
+    applyCasing: plainApplyCasing,
+    wordBreaker: defaultBreaker,
+    searchTermToKey: function(text: string) {
+      // We're dealing with very simple English text; no need to normalize or remove diacritics here.
+      return plainApplyCasing('lower', text);
+    }
+  }
+);
+
+describe('determineContextTransition', () => {
+  it('reuses last transition when empty input is received', () => {
+    const baseContext: Context = {
+      left: 'this is for tech',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    const tracker = new ContextTracker(plainCasedModel, baseContext, 0, plainCasedModel.configuration);
+
+    const targetContext: Context = {
+      left: 'this is for tech',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+
+    const inputDistribution: Distribution<Transform> = [{sample: {insert: '', deleteLeft: 0, id: 1}, p: 1}];
+
+    const warningEmitterSpy = sinon.spy(console, 'warn');
+    try {
+      const transition = determineContextTransition(
+        tracker,
+        tracker.latest.base,
+        targetContext,
+        inputDistribution
+      );
+
+      assert.isOk(transition);
+      assert.isFalse(warningEmitterSpy.called);
+      assert.equal(transition, tracker.latest);
+      assert.equal(transition.final, tracker.latest.base);
+      assert.equal(transition.final, transition.base);
+    } finally {
+      warningEmitterSpy.restore();
+    }
+  });
+
+  it('computes new transition when receiving an output key without corrections enabled', () => {
+    const baseContext: Context = {
+      left: 'this is for tech',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    const tracker = new ContextTracker(plainCasedModel, baseContext, 0, plainCasedModel.configuration);
+
+    const targetContext: Context = {
+      left: 'this is for techn',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+
+    const inputDistribution: Distribution<Transform> = [{sample: {insert: 'n', deleteLeft: 0, id: 1}, p: 1}];
+
+    const warningEmitterSpy = sinon.spy(console, 'warn');
+    try {
+      const transition = determineContextTransition(
+        tracker,
+        tracker.latest.base,
+        targetContext,
+        inputDistribution
+      );
+
+      assert.isOk(transition);
+      assert.equal(transition, tracker.latest);
+      assert.isFalse(warningEmitterSpy.called);
+      assert.sameOrderedMembers(transition.final.tokenization.exampleInput, ['this', ' ', 'is', ' ', 'for', ' ', 'techn']);
+      assert.isOk(transition.final.tokenization.alignment);
+      assert.sameDeepOrderedMembers(transition.inputDistribution, inputDistribution);
+      assert.isNotOk(transition.preservationTransform);
+      assert.equal(transition.transitionId, 1);
+    } finally {
+      warningEmitterSpy.restore();
+    }
+  });
+
+  it('reuses last transition when processing input that triggered autocorrect', () => {
+    const compositor = new ModelCompositor(plainCasedModel, true);
+
+    const baseContext: Context = {
+      left: 'this is for test',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    compositor.initContextTracker(baseContext, 0);
+    const tracker = compositor.contextTracker;
+
+    const baseTransition = tracker.latest;
+    const pred_testing: Suggestion = {
+      transform: {
+        insert: 'testing',
+        deleteLeft: 4,
+        id: 0
+      },
+      appendedTransform: {
+        insert: ' ',
+        deleteLeft: 0
+      },
+      transformId: 0,
+      displayAs: 'testing'
+    };
+    baseTransition.final.suggestions = [pred_testing];
+
+    const applied_testing = {
+      ...pred_testing,
+      appendedTransform: {
+        insert: '.',
+        deleteLeft: 0,
+        id: 1
+      }
+    };
+
+    compositor.acceptSuggestion(applied_testing, baseContext, { insert: '', deleteLeft: 0 });
+    const acceptingTransition = tracker.latest;
+
+    const inputDistribution: Distribution<Transform> = [{sample: applied_testing.appendedTransform, p: 1}];
+
+    const warningEmitterSpy = sinon.spy(console, 'warn');
+    try {
+      const reuseTransition = determineContextTransition(
+        tracker,
+        tracker.latest.base, {
+          left: 'this is for testing',
+          startOfBuffer: true,
+          endOfBuffer: true
+        },
+        inputDistribution
+      );
+
+      assert.isOk(baseTransition);
+      assert.isFalse(warningEmitterSpy.called);
+      assert.strictEqual(reuseTransition, acceptingTransition, 'Did not reuse transition as expected');
+    } finally {
+      warningEmitterSpy.restore();
+    }
+  });
+
+  it('preserves applied suggestion ids on unedited tokens when adding text', () => {
+    const compositor = new ModelCompositor(plainCasedModel, true);
+
+    const baseContext: Context = {
+      left: 'this is for test',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    compositor.initContextTracker(baseContext, 0);
+    const tracker = compositor.contextTracker;
+
+    const baseTransition = tracker.latest;
+    const pred_testing: Suggestion = {
+      transform: {
+        insert: 'testing',
+        deleteLeft: 4,
+        id: 1
+      },
+      appendedTransform: {
+        insert: ' ',
+        deleteLeft: 0,
+        id: 2
+      },
+      transformId: 0,
+      displayAs: 'testing'
+    };
+    baseTransition.final.suggestions = [pred_testing];
+
+    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0 });
+
+    const inputDistribution: Distribution<Transform> = [{sample: { insert: 'a', deleteLeft: 0, id: 5 }, p: 1}];
+
+    const warningEmitterSpy = sinon.spy(console, 'warn');
+    try {
+      const extendingTransition = determineContextTransition(
+        tracker,
+        tracker.latest.final, {
+          left: 'this is for testing ',
+          startOfBuffer: true,
+          endOfBuffer: true
+        },
+        inputDistribution
+      );
+
+      assert.isOk(baseTransition);
+      assert.isFalse(warningEmitterSpy.called);
+      assert.notEqual(extendingTransition, baseTransition);
+
+      // These values support delayed reversions.
+      assert.equal(extendingTransition.final.tokenization.tokens[6].appliedTransitionId, pred_testing.transformId);
+      assert.equal(extendingTransition.final.tokenization.tokens[7].appliedTransitionId, pred_testing.transformId);
+
+      // We start a new token here, rather than continue (and/or replace) an old one;
+      // this shouldn't be set here yet.
+      assert.isUndefined(extendingTransition.revertableTransitionId);
+    } finally {
+      warningEmitterSpy.restore();
+    }
+  });
+
+  it('indicates delayed reversion possibility when deleting up to suggestion-appended whitespace', () => {
+    const compositor = new ModelCompositor(plainCasedModel, true);
+
+    const baseContext: Context = {
+      left: 'this is for test',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    compositor.initContextTracker(baseContext, 0);
+    const tracker = compositor.contextTracker;
+
+    const baseTransition = tracker.latest;
+    const pred_testing: Suggestion = {
+      transform: {
+        insert: 'testing',
+        deleteLeft: 4,
+        id: 1
+      },
+      appendedTransform: {
+        insert: ' ',
+        deleteLeft: 0,
+        id: 2
+      },
+      transformId: 0,
+      displayAs: 'testing'
+    };
+    baseTransition.final.suggestions = [pred_testing];
+
+    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0 });
+
+    const inputDistribution: Distribution<Transform> = [{sample: { insert: 'a', deleteLeft: 0, id: 5 }, p: 1}];
+
+    const warningEmitterSpy = sinon.spy(console, 'warn');
+    try {
+      const extendingTransition = determineContextTransition(
+        tracker,
+        tracker.latest.final, {
+          left: 'this is for testing ',
+          startOfBuffer: true,
+          endOfBuffer: true
+        },
+        inputDistribution
+      );
+      tracker.latest = extendingTransition;
+
+      const extensionDeletingTransition = determineContextTransition(
+        tracker,
+        extendingTransition.final, {
+          left: 'this is for testing a',
+          startOfBuffer: true,
+          endOfBuffer: true,
+        },
+        // Backspace over the input 'a', leading to the end of the whitespace after testing.
+        [{sample: { insert: '', deleteLeft: 1 }, p: 1}]
+      );
+
+      assert.equal(extensionDeletingTransition.revertableTransitionId, pred_testing.transformId);
+    } finally {
+      warningEmitterSpy.restore();
+    }
+  });
+
+  it('indicates delayed reversion possibility when deleting up to end of applied suggestion', () => {
+    const compositor = new ModelCompositor(plainCasedModel, true);
+
+    const baseContext: Context = {
+      left: 'this is for test',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    compositor.initContextTracker(baseContext, 0);
+    const tracker = compositor.contextTracker;
+
+    const baseTransition = tracker.latest;
+    const pred_testing: Suggestion = {
+      transform: {
+        insert: 'testing',
+        deleteLeft: 4,
+        id: 1
+      },
+      appendedTransform: {
+        insert: ' ',
+        deleteLeft: 0,
+        id: 2
+      },
+      transformId: 0,
+      displayAs: 'testing'
+    };
+    baseTransition.final.suggestions = [pred_testing];
+
+    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0 });
+
+    const inputDistribution: Distribution<Transform> = [{sample: { insert: 'a', deleteLeft: 0, id: 5 }, p: 1}];
+
+    const warningEmitterSpy = sinon.spy(console, 'warn');
+    try {
+      const extendingTransition = determineContextTransition(
+        tracker,
+        tracker.latest.final, {
+          left: 'this is for testing ',
+          startOfBuffer: true,
+          endOfBuffer: true
+        },
+        inputDistribution
+      );
+      tracker.latest = extendingTransition;
+
+      const extensionDeletingTransition = determineContextTransition(
+        tracker,
+        extendingTransition.final, {
+          left: 'this is for testing a',
+          startOfBuffer: true,
+          endOfBuffer: true,
+        },
+        // Backspace over the input 'a', leading to the end of the whitespace after testing.
+        [{sample: { insert: '', deleteLeft: 1 }, p: 1}]
+      );
+      tracker.latest = extensionDeletingTransition;
+
+      const appendDeletingTransition = determineContextTransition(
+        tracker,
+        extendingTransition.final, {
+          left: 'this is for testing ',
+          startOfBuffer: true,
+          endOfBuffer: true,
+        },
+        // Backspace over the input 'a', leading to the end of the whitespace after testing.
+        [{sample: { insert: '', deleteLeft: 1 }, p: 1}]
+      );
+
+      assert.equal(appendDeletingTransition.revertableTransitionId, pred_testing.transformId);
+    } finally {
+      warningEmitterSpy.restore();
+    }
+  });
+
+  it('does not indicate delayed reversion possibility after deleting part of applied suggestion', () => {
+    const compositor = new ModelCompositor(plainCasedModel, true);
+
+    const baseContext: Context = {
+      left: 'this is for test',
+      startOfBuffer: true,
+      endOfBuffer: true
+    };
+    compositor.initContextTracker(baseContext, 0);
+    const tracker = compositor.contextTracker;
+
+    const baseTransition = tracker.latest;
+    const pred_testing: Suggestion = {
+      transform: {
+        insert: 'testing',
+        deleteLeft: 4,
+        id: 1
+      },
+      appendedTransform: {
+        insert: ' ',
+        deleteLeft: 0,
+        id: 2
+      },
+      transformId: 0,
+      displayAs: 'testing'
+    };
+    baseTransition.final.suggestions = [pred_testing];
+
+    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0 });
+
+    const inputDistribution: Distribution<Transform> = [{sample: { insert: 'a', deleteLeft: 0, id: 5 }, p: 1}];
+
+    const warningEmitterSpy = sinon.spy(console, 'warn');
+    try {
+      const extendingTransition = determineContextTransition(
+        tracker,
+        tracker.latest.final, {
+          left: 'this is for testing ',
+          startOfBuffer: true,
+          endOfBuffer: true
+        },
+        inputDistribution
+      );
+      tracker.latest = extendingTransition;
+
+      const extensionDeletingTransition = determineContextTransition(
+        tracker,
+        extendingTransition.final, {
+          left: 'this is for testing a',
+          startOfBuffer: true,
+          endOfBuffer: true,
+        },
+        // Backspace over the input 'a', leading to the end of the whitespace after testing.
+        [{sample: { insert: '', deleteLeft: 1 }, p: 1}]
+      );
+      tracker.latest = extensionDeletingTransition;
+
+      const appendDeletingTransition = determineContextTransition(
+        tracker,
+        extendingTransition.final, {
+          left: 'this is for testing ',
+          startOfBuffer: true,
+          endOfBuffer: true,
+        },
+        // Backspace over the input 'a', leading to the end of the whitespace after testing.
+        [{sample: { insert: '', deleteLeft: 1 }, p: 1}]
+      );
+      tracker.latest = appendDeletingTransition;
+
+      const editingBkspTransition = determineContextTransition(
+        tracker,
+        extendingTransition.final, {
+          left: 'this is for testing',
+          startOfBuffer: true,
+          endOfBuffer: true,
+        },
+        // Backspace over the input 'a', leading to the end of the whitespace after testing.
+        [{sample: { insert: '', deleteLeft: 1 }, p: 1}]
+      );
+
+      assert.isUndefined(editingBkspTransition.revertableTransitionId);
+    } finally {
+      warningEmitterSpy.restore();
+    }
+  });
+});


### PR DESCRIPTION
This commit adds unit tests for the methods extracted in #14716 designed to help automate testing for work done in #14700 and #14537, among other recent epic/autocorrect PRs.

There's also a very small bit of cleanup of logic that affected one of the new tests.

Build-bot: skip test:web
Test-bot: skip