### PR TITLE
fix(developer): transform slashes to backslashes in paths in Package Editor 🍒 🏠

### DIFF
--- a/common/windows/delphi/packages/PackageInfo.pas
+++ b/common/windows/delphi/packages/PackageInfo.pas
@@ -635,6 +635,11 @@ begin
   Result := ReplaceStr(ReplaceStr(Trim(VarToStr(v)), #$D#$A, #$A), #$A, #$D#$A);
 end;
 
+function TransformSlashes(filename: string): string;
+begin
+  Result := ReplaceStr(filename, '/', '\');
+end;
+
 {-------------------------------------------------------------------------------
  - TPackageOptions                                                             -
  ------------------------------------------------------------------------------}
@@ -697,10 +702,10 @@ procedure TPackageOptions.LoadXML(ARoot: IXMLNode);
 begin
   FileVersion :=                XmlVarToStr(ARoot.ChildNodes['System'].ChildNodes['FileVersion'].NodeValue);
   ExecuteProgram :=             XmlVarToStr(ARoot.ChildNodes['Options'].ChildNodes['ExecuteProgram'].NodeValue);
-  ReadmeFile :=                 Package.Files.FromFileName(XmlVarToStr(ARoot.ChildNodes['Options'].ChildNodes['ReadMeFile'].NodeValue));
-  GraphicFile :=                Package.Files.FromFileName(XmlVarToStr(ARoot.ChildNodes['Options'].ChildNodes['GraphicFile'].NodeValue));
-  LicenseFile :=                Package.Files.FromFileName(XmlVarToStr(ARoot.ChildNodes['Options'].ChildNodes['LicenseFile'].NodeValue));
-  WelcomeFile :=                Package.Files.FromFileName(XmlVarToStr(ARoot.ChildNodes['Options'].ChildNodes['WelcomeFile'].NodeValue));
+  ReadmeFile :=                 Package.Files.FromFileName(TransformSlashes(XmlVarToStr(ARoot.ChildNodes['Options'].ChildNodes['ReadMeFile'].NodeValue)));
+  GraphicFile :=                Package.Files.FromFileName(TransformSlashes(XmlVarToStr(ARoot.ChildNodes['Options'].ChildNodes['GraphicFile'].NodeValue)));
+  LicenseFile :=                Package.Files.FromFileName(TransformSlashes(XmlVarToStr(ARoot.ChildNodes['Options'].ChildNodes['LicenseFile'].NodeValue)));
+  WelcomeFile :=                Package.Files.FromFileName(TransformSlashes(XmlVarToStr(ARoot.ChildNodes['Options'].ChildNodes['WelcomeFile'].NodeValue)));
   if Assigned(ReadmeFile) then ReadmeFile.AddNotifyObject(ReadmeRemoved);
   if Assigned(GraphicFile) then GraphicFile.AddNotifyObject(GraphicRemoved);
   if Assigned(LicenseFile) then LicenseFile.AddNotifyObject(LicenseRemoved);
@@ -1425,7 +1430,7 @@ begin
     with ANode.ChildNodes[i] do
     begin
       subfile := TPackageContentFile.Create(Package);
-      subfile.FileName := XmlVarToStr(ChildNodes['Name'].NodeValue);
+      subfile.FileName := TransformSlashes(XmlVarToStr(ChildNodes['Name'].NodeValue));
       subfile.Description := XmlVarToStr(ChildNodes['Description'].NodeValue);
       subfile.FCopyLocation := TPackageFileCopyLocation(StrToIntDef(XmlVarToStr(ChildNodes['Location'].NodeValue), 0));
       Add(subfile);
@@ -2238,8 +2243,8 @@ begin
 
     keyboard := TPackageKeyboard.Create(Package);
     keyboard.ID := XmlVarToStr(AKeyboard.ChildValues[SXML_PackageKeyboard_ID]);
-    keyboard.OSKFont := Package.Files.FromFileNameEx(XmlVarToStr(AKeyboard.ChildValues[SXML_PackageKeyboard_OSKFont]));
-    keyboard.DisplayFont := Package.Files.FromFileNameEx(XmlVarToStr(AKeyboard.ChildValues[SXML_PackageKeyboard_DisplayFont]));
+    keyboard.OSKFont := Package.Files.FromFileNameEx(TransformSlashes(XmlVarToStr(AKeyboard.ChildValues[SXML_PackageKeyboard_OSKFont])));
+    keyboard.DisplayFont := Package.Files.FromFileNameEx(TransformSlashes(XmlVarToStr(AKeyboard.ChildValues[SXML_PackageKeyboard_DisplayFont])));
 
     keyboard.Languages.LoadXML(AKeyboard);
     keyboard.Examples.LoadXML(AKeyboard);
@@ -2877,7 +2882,7 @@ begin
   for i := 0 to ARoot.ChildNodes.Count - 1 do
   begin
     ANode := ARoot.ChildNodes[i];
-    f := Package.Files.FromFileNameEx(ANode.Attributes[SXML_PackageKeyboardFont_Filename]);
+    f := Package.Files.FromFileNameEx(TransformSlashes(XmlVarToStr(ANode.Attributes[SXML_PackageKeyboardFont_Filename])));
     if Assigned(f) then
       Add(f);
   end;


### PR DESCRIPTION
When loading package files generated by kmc or edited on non-Windows systems, the Package Editor will now convert any forward slashes in the path to backslashes. This is necessary because the path manipulation functions in Keyman Developer work only with backslashes.

Fixes: #14719
Build-bot: skip
Test-bot: skip
Cherry-pick-of: #14721