### PR TITLE
refactor(web): improve encapsulation for edit-distance calculation objects 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/segmentable-calculation.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/segmentable-calculation.ts
@@ -1,4 +1,4 @@
-import { ClassicalDistanceCalculation, EditOperation, EditTuple, forNewIndices, PathBuilder } from './classical-calculation.js';
+import { ClassicalDistanceCalculation, DistanceCalcOptions, EditOperation, EditTuple, forNewIndices, PathBuilder } from './classical-calculation.js';
 
 /**
  * The human-readable names for legal edit-operation edges on a merge-split
@@ -32,12 +32,16 @@ export class SegmentableDistanceCalculation extends ClassicalDistanceCalculation
    */
   constructor();
   /**
+   * Constructs a new calculation object instance with the specified options.
+   */
+  constructor(options: DistanceCalcOptions);
+  /**
    * Clones an already-existing instance, aliasing old data only where safe.
    * @param other
    */
   constructor(other: SegmentableDistanceCalculation);
-  constructor(other?: SegmentableDistanceCalculation) {
-    super(other);
+  constructor(param1?: DistanceCalcOptions | SegmentableDistanceCalculation) {
+    super(param1);
   }
 
   private static selectInitialCostAt(

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/classical-calculation.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/classical-calculation.tests.ts
@@ -19,16 +19,12 @@ export function prettyPrintMatrix(matrix: number[][]) {
 }
 
 function compute(input: string, match: string, mode?: string, bandSize?: number) {
-  let buffer = new ClassicalDistanceCalculation();
+  let buffer = new ClassicalDistanceCalculation({diagonalWidth: bandSize || 1});
 
   /* SUPPORTED MODES:
    * "InputThenMatch"  // adds all input chars, then all match chars.
    * "MatchThenInput"  // adds all match chars, then all input chars.
    */
-
-  // TEMP:  once diagonal expansion is implemented, do this LATER, AFTER adding the chars.
-  bandSize = bandSize || 1;
-  buffer.diagonalWidth = bandSize;
 
   switch(mode || "InputThenMatch") {
     case "InputThenMatch":
@@ -58,10 +54,9 @@ function compute(input: string, match: string, mode?: string, bandSize?: number)
 
 describe('forNewIndices', () => {
   it('iterates extended row properly (small calc)', () => {
-    const mockedCalc = sinon.createStubInstance(ClassicalDistanceCalculation);
-    mockedCalc.diagonalWidth = 2;
-    mockedCalc.inputSequence = new Array(2);
-    mockedCalc.matchSequence = new Array(3);
+    const mockedCalc = new ClassicalDistanceCalculation({diagonalWidth: 2});
+    sinon.replaceGetter(mockedCalc, 'inputSequence', () => new Array(2));
+    sinon.replaceGetter(mockedCalc, 'matchSequence', () => new Array(3));
 
     const fake = sinon.fake();
     forNewIndices(mockedCalc, true, fake);
@@ -80,10 +75,9 @@ describe('forNewIndices', () => {
   });
 
   it('iterates extended row properly (large calc)', () => {
-    const mockedCalc = sinon.createStubInstance(ClassicalDistanceCalculation);
-    mockedCalc.diagonalWidth = 2;
-    mockedCalc.inputSequence = new Array(8);
-    mockedCalc.matchSequence = new Array(9);
+    const mockedCalc = new ClassicalDistanceCalculation({diagonalWidth: 2});
+    sinon.replaceGetter(mockedCalc, 'inputSequence', () => new Array(8));
+    sinon.replaceGetter(mockedCalc, 'matchSequence', () => new Array(9));
 
     const fake = sinon.fake();
     forNewIndices(mockedCalc, true, fake);
@@ -103,10 +97,9 @@ describe('forNewIndices', () => {
   });
 
   it('iterates extended column properly (small calc)', () => {
-    const mockedCalc = sinon.createStubInstance(ClassicalDistanceCalculation);
-    mockedCalc.diagonalWidth = 2;
-    mockedCalc.inputSequence = new Array(3);
-    mockedCalc.matchSequence = new Array(2);
+    const mockedCalc = new ClassicalDistanceCalculation({diagonalWidth: 2});
+    sinon.replaceGetter(mockedCalc, 'inputSequence', () => new Array(3));
+    sinon.replaceGetter(mockedCalc, 'matchSequence', () => new Array(2));
 
     const fake = sinon.fake();
     forNewIndices(mockedCalc, false, fake);
@@ -127,10 +120,9 @@ describe('forNewIndices', () => {
   });
 
   it('iterates extended column properly (large calc) (1)', () => {
-    const mockedCalc = sinon.createStubInstance(ClassicalDistanceCalculation);
-    mockedCalc.diagonalWidth = 3;
-    mockedCalc.inputSequence = new Array(8);
-    mockedCalc.matchSequence = new Array(9);
+    const mockedCalc = new ClassicalDistanceCalculation({diagonalWidth: 3});
+    sinon.replaceGetter(mockedCalc, 'inputSequence', () => new Array(8));
+    sinon.replaceGetter(mockedCalc, 'matchSequence', () => new Array(9));
 
     const fake = sinon.fake();
     forNewIndices(mockedCalc, false, fake);
@@ -151,10 +143,9 @@ describe('forNewIndices', () => {
   });
 
   it('iterates extended column properly (large calc) (2)', () => {
-    const mockedCalc = sinon.createStubInstance(ClassicalDistanceCalculation);
-    mockedCalc.diagonalWidth = 3;
-    mockedCalc.inputSequence = new Array(9);
-    mockedCalc.matchSequence = new Array(9);
+    const mockedCalc = new ClassicalDistanceCalculation({diagonalWidth: 3});
+    sinon.replaceGetter(mockedCalc, 'inputSequence', () => new Array(9));
+    sinon.replaceGetter(mockedCalc, 'matchSequence', () => new Array(9));
 
     const fake = sinon.fake();
     forNewIndices(mockedCalc, false, fake);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/segmentable-calculation.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/segmentable-calculation.tests.ts
@@ -3,8 +3,7 @@ import { SegmentableDistanceCalculation } from '@keymanapp/lm-worker/test-index'
 
 describe('Split/merge aware edit-distance calculation', () => {
   it("a,b,c -> a,b,d = 1", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 2;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 2});
 
     ['a', 'b', 'c'].forEach(c => calc = calc.addInputChar(c));
     ['a', 'b', 'd'].forEach(c => calc = calc.addMatchChar(c));
@@ -13,8 +12,7 @@ describe('Split/merge aware edit-distance calculation', () => {
   });
 
   it("a,b,c -> a,bc = 1", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 2;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 2});
 
     ['a', 'b', 'c'].forEach(c => calc = calc.addInputChar(c));
     ['a', 'bc'].forEach(c => calc = calc.addMatchChar(c));
@@ -23,8 +21,7 @@ describe('Split/merge aware edit-distance calculation', () => {
   });
 
   it("ab,c,d -> a,b,cd = 2", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 2;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 2});
 
     ['ab', 'c', 'd'].forEach(c => calc = calc.addInputChar(c));
     ['a', 'b', 'cd'].forEach(c => calc = calc.addMatchChar(c));
@@ -33,8 +30,7 @@ describe('Split/merge aware edit-distance calculation', () => {
   });
 
   it("a,bc,d -> a,b,c,d = 1", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 2;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 2});
 
     ['a', 'bc', 'd'].forEach(c => calc = calc.addInputChar(c));
     ['a', 'b', 'c', 'd'].forEach(c => calc = calc.addMatchChar(c));
@@ -43,8 +39,7 @@ describe('Split/merge aware edit-distance calculation', () => {
   });
 
   it("a,b,c,d -> a,bc,d = 1", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 2;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 2});
 
     ['a', 'b', 'c', 'd'].forEach(c => calc = calc.addInputChar(c));
     ['a', 'bc', 'd'].forEach(c => calc = calc.addMatchChar(c));
@@ -53,8 +48,7 @@ describe('Split/merge aware edit-distance calculation', () => {
   });
 
   it("ab,d,c,e,g,h -> a,b,c,d,f,gh = 4", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 4;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 4});
 
     // 'ab' => 'a', 'b'
     // d,c transposed
@@ -80,8 +74,7 @@ describe('Split/merge aware edit-distance calculation', () => {
   });
 
   it("abc,d,f,g,h -> a,b,c,d,fgh = 2", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 4;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 4});
 
     ['abc', 'd', 'f', 'g', 'h'].forEach(c => calc = calc.addInputChar(c));
     ['a', 'b', 'c', 'd', 'fgh'].forEach(c => calc = calc.addMatchChar(c));
@@ -102,8 +95,7 @@ describe('Split/merge aware edit-distance calculation', () => {
   });
 
   it("abcde,f -> b,c,d,e,f = 2", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 4;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 4});
 
     // Partial split = cost of 2:  1 for splitting, 1 for being incomplete.
     // (The 'a' doesn't land.)
@@ -124,8 +116,7 @@ describe('Split/merge aware edit-distance calculation', () => {
   });
 
   it("a,b,c,d,e -> a, bcdef = 2", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 4;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 4});
 
     // Partial split = cost of 2:  1 for splitting, 1 for being incomplete.
     // (The 'a' doesn't land.)
@@ -146,8 +137,7 @@ describe('Split/merge aware edit-distance calculation', () => {
   });
 
   it("abc,d,e,f,g -> b,c,d,e,fgh = 4", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 4;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 4});
 
     // Partial merge = cost of 2:  1 for merging, 1 for being incomplete.
     // Partial split = cost of 2:  1 for splitting, 1 for being incomplete.
@@ -169,8 +159,7 @@ describe('Split/merge aware edit-distance calculation', () => {
   });
 
   it("abcd,e,f,g -> b,c,d,efgh = 4", () => {
-    let calc = new SegmentableDistanceCalculation();
-    calc.diagonalWidth = 4;
+    let calc = new SegmentableDistanceCalculation({diagonalWidth: 4});
 
     // Partial merge = cost of 2:  1 for merging, 1 for being incomplete.
     // Partial split = cost of 2:  1 for splitting, 1 for being incomplete.


### PR DESCRIPTION
Reviewing the edit-distance types and their uses, I noticed that their encapsulation was... rather loose, with `diagonalWidth`'s usage being particularly egregious.  That really belongs more as an initialization parameter.

This PR seeks to improve encapsulation and allow specifying initialization options, such as how wide the edit-distance algorithm will search for alternative paths for optimal edit distance.

Note that #14726 adds an extra initialization option for the types, tied to an added feature that also motivated the encapsulation improvements.

Build-bot: skip build:web
Test-bot: skip