### PR TITLE
fix(common): merging build and publish step for docker

### DIFF
--- a/.github/workflows/build-test-publish-docker.yml
+++ b/.github/workflows/build-test-publish-docker.yml
@@ -50,17 +50,6 @@ jobs:
           else
             echo ${{ env.PASSWORD }} | resources/docker-images/build.sh build: --registry ${{ env.REGISTRY }} --username ${{ env.USERNAME }}
           fi
-
-  publish:
-    name: Publish Docker images
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Checkout repository
-        id: checkout
-        uses: actions/checkout@v4
-
       - name: Publish Docker images
         id: publish
         run: |
@@ -73,7 +62,7 @@ jobs:
   test:
     name: Test Docker images
     runs-on: ubuntu-latest
-    needs: publish
+    needs: build
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Build and push are now in one job in the build, test, publish Docker images GitHub workflow.
By default the local image registry is not available from different jobs.
Uploading and downloading the images to transfer them between the jobs
seems to be an extra effort not being worth it.

Test-bot: skip
Build-bot: skip