### PR TITLE
maint(linux): allow to force package build on non-Keyman repo

### DIFF
--- a/.github/workflows/deb-packaging.README.md
+++ b/.github/workflows/deb-packaging.README.md
@@ -36,6 +36,7 @@ You can manually trigger a deb-packaging action on GitHub, e.g. to test changes:
       \"baseBranch\": \"master\",
       \"baseRef\": \"$(git rev-parse refs/heads/master)\",
       \"user\": \"${USER}\",
-      \"isTestBuild\": \"true\"}" \
+      \"isTestBuild\": \"true\",
+      \"force\": \"true\"}" \
     https://api.github.com/repos/<yourgithubname>/keyman/dispatches
   ```

--- a/.github/workflows/deb-packaging.README.md
+++ b/.github/workflows/deb-packaging.README.md
@@ -18,7 +18,8 @@ You can manually trigger a deb-packaging action on GitHub, e.g. to test changes:
       \"baseBranch\": \"master\",
       \"baseRef\": \"$(git rev-parse refs/heads/master^)\",
       \"user\": \"${USER}\",
-      \"isTestBuild\": \"true\"}" \
+      \"isTestBuild\": \"true\",
+      \"force\": \"true\"}" \
     https://api.github.com/repos/<yourgithubname>/keyman/dispatches
   ```
 

--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   sourcepackage:
     name: Build source package
-    if: github.repository == 'keymanapp/keyman'
+    if: github.repository == 'keymanapp/keyman' || github.event.client_payload.force
     runs-on: ubuntu-24.04
     outputs:
       KEYMAN_VERSION: ${{ steps.version_step.outputs.KEYMAN_VERSION }}


### PR DESCRIPTION
By default we skip package builds if run on a non-Keyman repo. This makes it harder to test changes, so this PR allows to pass the parameter `force: true` when triggering the build.

Build-bot: skip
Test-bot: skip