### PR TITLE
feat(web): add method to determine the change to context resulting from a context window slide 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-state.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-state.ts
@@ -316,18 +316,21 @@ export class ContextState {
  * number of codepoints removed from its start (if sliding forward)
  */
 export function determineContextSlideTransform(srcContext: Context, dstContext: Context): Transform {
-  // Assertion: the current (sliding) context window is alignable.
+  // Assumption: the current (sliding) context window is alignable.
   // See `matchBaseContextState` in ../predict-helpers.ts.
+
+  // Assertion:  If the assumption above holds and both start-of-buffer flags
+  // are true, the contents must then match.
   if(srcContext.startOfBuffer && dstContext.startOfBuffer) {
     return { insert: '', deleteLeft: 0, deleteRight: 0 };
   }
 
-  // Assertion:  the right-hand side of the left-context strings WILL match.
+  // Assumption:  the right-hand side of the left-context strings WILL match.
   // The only change should be for the contents of the sliding-context window.
   const src = srcContext.left;
   const dst = dstContext.left;
 
-  // Assertion:  the context will always be codepoint-aligned, as the Web engine
+  // Assumption:  the context will always be codepoint-aligned, as the Web engine
   // and worker both do string ops based on codepoints, not code units.
 
   // Which way did the context window slide, if it did?  This does not
@@ -337,8 +340,14 @@ export function determineContextSlideTransform(srcContext: Context, dstContext: 
   const rawDelta = dst.length - src.length;
 
   // Validation:  does the part of both strings that should match actually match?
-  if(rawDelta > 0 ? dst.slice(rawDelta) != src : src.slice(-rawDelta) != dst) {
-    throw new Error("Invalid base context");
+  //
+  // Context operations are already code-point aligned; no need to use special
+  // non-BMP handling here.
+  const smallerIsSubstringOfOther = rawDelta > 0
+    ? dst.slice(rawDelta) == src
+    : src.slice(-rawDelta) == dst;
+  if(!smallerIsSubstringOfOther) {
+    throw new Error(`Context-slide preconditions invalidated - neither before nor after context is a substring of the other`);
   }
 
   return {

--- a/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
@@ -1,5 +1,5 @@
 export { ClassicalDistanceCalculation, EditOperation, EditTuple, forNewIndices } from './correction/classical-calculation.js';
-export { ContextState } from './correction/context-state.js';
+export * from './correction/context-state.js';
 export { ContextToken } from './correction/context-token.js';
 export { ContextTokenization } from './correction/context-tokenization.js';
 export { ContextTracker } from './correction/context-tracker.js';


### PR DESCRIPTION
To be explicit:  the method is designed to compare the context after applying a context transition's edit with the context state after a window slide takes effect, but before the next transition's edit takes effect.

Build-bot: skip build:web
Test-bot: skip