### PR TITLE
fix(android): Refresh the banner theme when system keyboard is changed

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -263,6 +263,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
 
   @Override
   public void onKeyboardChanged(String newKeyboard) {
+    // Refresh banner theme
+    BannerController.setHTMLBanner(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
     KMManager.showSystemKeyboard();
   }
 


### PR DESCRIPTION
Fixes #14070 and follows #13702

The reported System keyboard issue was:
> The banner appears in black when removing a keyboard from the keyboard picker

This change ensures when a keyboard is changed (removed from the keyboard picker), the banner is refreshed.

## User Testing
**Setup** - Install the PR build of Keyman for Android on a device/emulator

* **TEST_BANNER** - Verifies banner functions when removing a keyboard from the keyboard picker
1. Install the PR build of Keyman for Android on an Android device or emulator
2. Accept all the Android permission requests for storage.
3. Open the Keyman app.
4. On the "Get Started" dialog.
5. Check the "Enable Keyman as system-wide keyboard" box.
6. Check the "Set the keyboard as the default keyboard" box.
7. Navigate to the settings page and then select "Installed Languages".
8. Add a "EuroLatin" keyboard for multiple languages(more than two) by clicking the "+" button.
9. Open the keyboard search box by clicking the "Settings"--> Install Keyboard or Dictionary --> Install from Keyman.com
10. Click in the search box. Open the keyboard picker by clicking the "Globe" key.
11. Delete a keyboard(e.g., Albanian) by holding down the keyboard and then selecting "Delete".
12. Select another keyboard(e.g., Aragonese)
13. Verify the Keyman banner appears (not the black banner as reported in the issue)
