### PR TITLE
fix(linux): don't crash on invalid languages in keyboard 🍒 🏠

### DIFF
--- a/linux/keyman-config/keyman_config/gnome_keyboards_util.py
+++ b/linux/keyman-config/keyman_config/gnome_keyboards_util.py
@@ -59,6 +59,8 @@ def get_ibus_keyboard_id(keyboard, packageDir, language=None, ignore_language=Fa
         logging.debug(language)
         return f"{language}:{kmx_file}"
     if "languages" in keyboard and len(keyboard["languages"]) > 0:
-        logging.debug(keyboard["languages"][0])
-        return f"{keyboard['languages'][0]['id']}:{kmx_file}"
+        firstLanguage = keyboard["languages"][0]
+        logging.debug(firstLanguage)
+        if 'id' in firstLanguage:
+            return f"{firstLanguage['id']}:{kmx_file}"
     return kmx_file

--- a/linux/keyman-config/tests/gnome_keyboards_util_tests.py
+++ b/linux/keyman-config/tests/gnome_keyboards_util_tests.py
@@ -4,7 +4,7 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 
-from keyman_config.gnome_keyboards_util import is_gnome_desktop, _reset_gnome_shell
+from keyman_config.gnome_keyboards_util import get_ibus_keyboard_id, is_gnome_desktop, _reset_gnome_shell
 
 
 class GnomeKeyboardsUtilTests(unittest.TestCase):
@@ -34,6 +34,37 @@ class GnomeKeyboardsUtilTests(unittest.TestCase):
         mockSystem.return_value = 1
         # Execute/Verify
         self.assertEqual(is_gnome_desktop(), True)
+
+    def test_GetIbusKeyboardId_NoKeyboard(self):
+        self.assertIsNone(get_ibus_keyboard_id(None, '/tmp'))
+
+    def test_GetIbusKeyboardId_IgnoreLanguage(self):
+        keyboard = {'id': 'foo'}
+        self.assertEqual(get_ibus_keyboard_id(keyboard, '/tmp', ignore_language=True), '/tmp/foo.kmx')
+
+    def test_GetIbusKeyboardId_NoLanguage(self):
+        keyboard = {'id': 'foo'}
+        self.assertEqual(get_ibus_keyboard_id(keyboard, '/tmp'), '/tmp/foo.kmx')
+
+    def test_GetIbusKeyboardId_EmptyLanguage(self):
+        keyboard = {'id': 'foo'}
+        self.assertEqual(get_ibus_keyboard_id(keyboard, '/tmp', ''), '/tmp/foo.kmx')
+
+    def test_GetIbusKeyboardId_Language(self):
+        keyboard = {'id': 'foo'}
+        self.assertEqual(get_ibus_keyboard_id(keyboard, '/tmp', 'en'), 'en:/tmp/foo.kmx')
+
+    def test_GetIbusKeyboardId_LanguagesInKeyboard(self):
+        keyboard = {'id': 'foo', 'languages': [ {'id': 'fr'}]}
+        self.assertEqual(get_ibus_keyboard_id(keyboard, '/tmp'), 'fr:/tmp/foo.kmx')
+
+    def test_GetIbusKeyboardId_MultipleLanguagesInKeyboard(self):
+        keyboard = {'id': 'foo', 'languages': [{'id': 'km'}, {'id': 'fr'}]}
+        self.assertEqual(get_ibus_keyboard_id(keyboard, '/tmp'), 'km:/tmp/foo.kmx')
+
+    def test_GetIbusKeyboardId_InvalidLanguagesInKeyboard(self):  # 14748
+        keyboard = {'id': 'foo', 'languages': ['es']}
+        self.assertEqual(get_ibus_keyboard_id(keyboard, '/tmp'), '/tmp/foo.kmx')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# User Testing

**TEST_INSTALL**: open `km-config` and install a keyboard. Verify that the keyboard gets added to the list of installed keyboards in `km-config` as well as to the languages dropdown in the taskbar.

Fixes: #14748 
Fixes: KEYMAN-LINUX-8Q
Cherry-pick-of: #14760
