### PR TITLE
chore(linux): remove automatic installation of `onboard-keyman` 🍒 🏠

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,9 @@
+keyman (18.0.240-2) UNRELEASED; urgency=medium
+
+  * remove onboard-keyman recommends (closes: 1115423)
+
+ -- Eberhard Beilharz <eb1@sil.org>  Wed, 17 Sep 2025 15:21:31 +0200
+
 keyman (18.0.240-1) unstable; urgency=medium
 
   * New upstream release.

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -58,8 +58,6 @@ Depends:
  ibus-keyman (>= ${binary:Version}),
  ibus-keyman (<< ${binary:Version}.1~),
  ${misc:Depends},
-Recommends:
- onboard-keyman,
 Description: Type in your language with Keyman for Linux
  Keyman makes it possible for you to type in over 2,000 languages on Windows,
  macOS, Linux, iPhone, iPad, Android tablets and phones, and even instantly


### PR DESCRIPTION
`onboard-keyman` isn't available on Debian/Ubuntu and doesn't work properly with Wayland. This change removes the `onboard-keyman` recommends which used to cause `onboard-keyman` to be installed automatically together with `keyman`. The user can still manually install `onboard-keyman`.

Fixes: #14769
Fixes: #5214
Cherry-pick-of: #14772
Build-bot: skip
Test-bot: skip