### PR TITLE
maint(resources): use VERSION variable in increment-version.sh 🏠

### DIFF
--- a/resources/build/increment-version.sh
+++ b/resources/build/increment-version.sh
@@ -184,9 +184,9 @@ if [ "$action" == "commit" ]; then
     # If HISTORY.md has been updated, then we want to create a branch and push
     # it for review
     if git status --porcelain=v1 | grep -q HISTORY.md; then
-      git switch -c "auto/cherry-pick-$KEYMAN_VERSION-history-to-alpha" master
+      git switch -c "auto/cherry-pick-$VERSION-history-to-alpha" master
       git add HISTORY.md
-      git commit -m "auto: cherry-pick $KEYMAN_VERSION history to alpha
+      git commit -m "auto: cherry-pick $VERSION history to alpha
 
 Build-bot: skip
 Test-bot: skip


### PR DESCRIPTION
The original `$KEYMAN_VERSION` variable was cherry-picked from 19.0, but we should have been using `$VERSION` for the 18.0 code.

Note: I will manually generate the PR to update HISTORY.md for 18.0.241.

Fixes: #14778
Follows: #14614
Test-bot: skip
Build-bot: skip