### PR TITLE
fix(common): some more tests running successfully in a container

### DIFF
--- a/resources/build/builder-basic.inc.sh
+++ b/resources/build/builder-basic.inc.sh
@@ -54,6 +54,7 @@ function _builder_basic_find_keyman_root() {
     KEYMAN_ROOT="${BASH_SOURCE[0]%/*/*/*}"
     KEYMAN_ROOT="$( cd "$KEYMAN_ROOT" && echo "$PWD" )"
     readonly KEYMAN_ROOT
+    export KEYMAN_ROOT
   fi
 }
 

--- a/resources/docker-images/build.sh
+++ b/resources/docker-images/build.sh
@@ -57,7 +57,8 @@ build_action() {
   # with the tag 'default'.
   if is_default_values; then
     builder_echo debug "Setting default tag for ${platform}"
-    docker_wrapper build -t "${registry_slash}keymanapp/keyman-${platform}-ci:default" "${build_args[@]}" .
+    docker_wrapper tag "${registry_slash}keymanapp/keyman-${platform}-ci:${build_version}" \
+                       "${registry_slash}keymanapp/keyman-${platform}-ci:default"
   fi
   # shellcheck disable=SC2164,SC2103
   cd -
@@ -104,7 +105,7 @@ if builder_has_action build; then
 fi
 
 builder_run_action test:core        test_action core
-builder_run_action test:linux       test_action linux
+# builder_run_action test:linux       test_action linux
 builder_run_action test:web         test_action web
 # Android uses artifacts from web, so it has to come after web
 builder_run_action test:android     test_action android

--- a/resources/docker-images/run.sh
+++ b/resources/docker-images/run.sh
@@ -42,21 +42,21 @@ else
 fi
 
 run_android() {
-  docker_wrapper run ${DOCKER_RUN_ARGS} -it --rm -v "${KEYMAN_ROOT}":/home/build/build \
+  docker_wrapper run ${DOCKER_RUN_ARGS} -i --rm -v "${KEYMAN_ROOT}":/home/build/build \
     -v "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}":/home/build/build/core/build \
     "${registry_slash}keymanapp/keyman-android-ci:${image_version}" \
     "${builder_extra_params[@]}"
 }
 
 run_core() {
-  docker_wrapper run ${DOCKER_RUN_ARGS} -it --rm -v "${KEYMAN_ROOT}":/home/build/build \
+  docker_wrapper run ${DOCKER_RUN_ARGS} -i --rm -v "${KEYMAN_ROOT}":/home/build/build \
     -v "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}":/home/build/build/core/build \
     "${registry_slash}keymanapp/keyman-core-ci:${image_version}" \
     "${builder_extra_params[@]}"
 }
 
 run_developer() {
-  docker_wrapper run ${DOCKER_RUN_ARGS} -it --rm -v "${KEYMAN_ROOT}":/home/build/build \
+  docker_wrapper run ${DOCKER_RUN_ARGS} -i --rm -v "${KEYMAN_ROOT}":/home/build/build \
     -v "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}":/home/build/build/core/build \
     "${registry_slash}keymanapp/keyman-developer-ci:${image_version}" \
     "${builder_extra_params[@]}"
@@ -65,7 +65,8 @@ run_developer() {
 run_linux() {
   mkdir -p "${KEYMAN_ROOT}/linux/build/docker-linux/${build_dir}"
   mkdir -p "${KEYMAN_ROOT}/linux/keyman-system-service/build/docker-linux/${build_dir}"
-  docker_wrapper run ${DOCKER_RUN_ARGS} -it --privileged --rm -v "${KEYMAN_ROOT}":/home/build/build \
+  docker_wrapper run ${DOCKER_RUN_ARGS} -i --privileged --network host \
+    -v "${KEYMAN_ROOT}":/home/build/build \
     -v "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}":/home/build/build/core/build \
     -v "${KEYMAN_ROOT}/linux/build/docker-linux/${build_dir}":/home/build/build/linux/build \
     -v "${KEYMAN_ROOT}/linux/keyman-system-service/build/docker-linux/${build_dir}":/home/build/build/linux/keyman-system-service/build \
@@ -75,7 +76,7 @@ run_linux() {
 }
 
 run_web() {
-  docker_wrapper run ${DOCKER_RUN_ARGS} -it --privileged --rm -v "${KEYMAN_ROOT}":/home/build/build \
+  docker_wrapper run ${DOCKER_RUN_ARGS} -i --privileged --rm -v "${KEYMAN_ROOT}":/home/build/build \
     -v "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}":/home/build/build/core/build \
     "${registry_slash}keymanapp/keyman-web-ci:${image_version}" \
     "${builder_extra_params[@]}"


### PR DESCRIPTION
setting KEYMAN_ROOT
ignoring test:linux until #13887 is fixed
removing docker "-t" option, because there is no terminal to attach while running on the GitHub server

Test-bot: skip
Build-bot: skip