### PR TITLE
maint(linux): improve getting PR# in `upload-to-debian.sh` 🍒 🏠

### DIFF
--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -109,6 +109,7 @@ function push_to_github_and_create_pr() {
       builder_echo "PR #${PR_NUMBER} already exists"
     else
       ${NOOP} gh pr create --draft --base "${BASE}" --title "${PR_TITLE}" --body "${PR_BODY}"
+      sleep 2s
       PR_NUMBER=$(gh pr list --draft --search "${PR_TITLE}" --base "${BASE}" --json number --jq '.[].number')
     fi
   else
@@ -190,14 +191,14 @@ cp debianpackage/keyman-*/debian/changelog debian/
 git add debian/changelog
 COMMIT_MESSAGE="chore(linux): Update debian changelog"
 git commit -m "${COMMIT_MESSAGE}"
-push_to_github_and_create_pr chore/linux/changelog "${DEPLOY_BRANCH#origin/}" "${COMMIT_MESSAGE}" "@keymanapp-test-bot skip"
+push_to_github_and_create_pr chore/linux/changelog "${DEPLOY_BRANCH#origin/}" "${COMMIT_MESSAGE} 🏠" "Test-bot: skip"
 
 # Create cherry-pick on master branch
 git checkout -B chore/linux/cherry-pick/changelog origin/master
 git cherry-pick -x chore/linux/changelog
 push_to_github_and_create_pr chore/linux/cherry-pick/changelog master "${COMMIT_MESSAGE} 🍒" \
-"Cherry-pick-of: #${PR_NUMBER}
-@keymanapp-test-bot skip"
+  "Cherry-pick-of: #${PR_NUMBER}
+Test-bot: skip"
 
 builder_heading "Finishing"
 cleanup_worktree

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -108,9 +108,9 @@ function push_to_github_and_create_pr() {
     if [[ -n ${PR_NUMBER} ]]; then
       builder_echo "PR #${PR_NUMBER} already exists"
     else
-      ${NOOP} gh pr create --draft --base "${BASE}" --title "${PR_TITLE}" --body "${PR_BODY}"
-      sleep 2s
-      PR_NUMBER=$(gh pr list --draft --search "${PR_TITLE}" --base "${BASE}" --json number --jq '.[].number')
+      local PR_URL
+      PR_URL=$(gh pr create --draft --base "${BASE}" --title "${PR_TITLE}" --body "${PR_BODY}")
+      PR_NUMBER="${PR_URL##*/}"
     fi
   else
     PR_NUMBER=""
@@ -191,13 +191,15 @@ cp debianpackage/keyman-*/debian/changelog debian/
 git add debian/changelog
 COMMIT_MESSAGE="chore(linux): Update debian changelog"
 git commit -m "${COMMIT_MESSAGE}"
-push_to_github_and_create_pr chore/linux/changelog "${DEPLOY_BRANCH#origin/}" "${COMMIT_MESSAGE} 🏠" "Test-bot: skip"
+push_to_github_and_create_pr chore/linux/changelog "${DEPLOY_BRANCH#origin/}" "${COMMIT_MESSAGE} 🏠" "Build-bot: skip
+Test-bot: skip"
 
 # Create cherry-pick on master branch
 git checkout -B chore/linux/cherry-pick/changelog origin/master
 git cherry-pick -x chore/linux/changelog
 push_to_github_and_create_pr chore/linux/cherry-pick/changelog master "${COMMIT_MESSAGE} 🍒" \
   "Cherry-pick-of: #${PR_NUMBER}
+Build-bot: skip
 Test-bot: skip"
 
 builder_heading "Finishing"


### PR DESCRIPTION
With this change we wait two seconds after creating the PR before trying to get the number of the PR so that GitHub can catch up. Previously recently it wasn't able to get the PR#.

Also adjust the commit message and use the new header for skipping tests.

Cherry-pick-of: #13890
Build-bot: skip
Test-bot: skip