### PR TITLE
feat(web): precompute transform tokenization while handling when existing boundaries shift 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -343,8 +343,10 @@ export class ContextTokenization {
     // What does the edge's retokenization look like when we remove the inserted portions?
     const retokenizedEdge = postTokenization.slice(0, firstInsertPostIndex);
     const insertBoundaryToken = postTokenization[firstInsertPostIndex];
+
     // Note:  requires that helpers have not mutated `stackedInserts`.
-    const uninsertedBoundaryToken = insertBoundaryToken.slice(0, insertBoundaryToken.lastIndexOf(stackedInserts[0]));
+    const uninsertedBoundaryToken = KMWString.substring(insertBoundaryToken, 0, KMWString.lastIndexOf(insertBoundaryToken, stackedInserts[0]));
+
     // Do not preserve empty tokens here, even if tokenization normally would produce one.
     // It's redundant and replaceable for tokenization batching efforts.
     if(uninsertedBoundaryToken != '') {
@@ -364,7 +366,10 @@ export class ContextTokenization {
 
     // Determine the effects of splits & merges as applied to the original
     // cached context state.
-    const { mergeOffset, splitOffset, editPath, merges, splits } = analyzePathMergesAndSplits(preTokenization, postTokenization.slice(0, firstInsertPostIndex+1));
+    const { mergeOffset, splitOffset, editPath, merges, splits } = analyzePathMergesAndSplits(
+      preTokenization,
+      postTokenization.slice(0, firstInsertPostIndex+1)
+    );
 
     /*
      * Final steps:  We can now safely index the transforms.  Let's do it!

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -324,7 +324,7 @@ export class ContextTokenization {
     //
     // Context does not slide within this function.
     //
-    // Assertion:  this alignment cannot fail; we KNOW there's a solid
+    // Assumption:  this alignment cannot fail; we KNOW there's a solid
     // before-and-after relationship here, and we can base it on the results of
     // a prior syncToSourceWindow call.
     //

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -314,7 +314,7 @@ export class ContextTokenization {
    * @param edgeOptions
    * @returns
    */
-  precomputeTokenizationAfterInput(
+  mapWhitespacedTokenization(
     lexicalModel: LexicalModel,
     transform: Transform,
     edgeOptions?: EdgeWindowOptions

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -1500,8 +1500,8 @@ describe('ContextTokenization', function() {
         {
           input: { text: 'can\'', index: 2 /* + 4 */},
           matches: [
-            { text: 'can', index: 2 /* + 4 */ },
-            { text: '\'',  index: 3 /* + 4 */ }
+            { text: 'can', index: 2 /* + 4 */, textOffset: 0 },
+            { text: '\'',  index: 3 /* + 4 */, textOffset: 3 }
           ]
         }
       ]);
@@ -1532,8 +1532,8 @@ describe('ContextTokenization', function() {
         {
           input: { text: 'can\'', index: 2 /* + 4 */},
           matches: [
-            { text: 'can', index: 2 /* + 4 */ },
-            { text: '\'',  index: 3 /* + 4 */ }
+            { text: 'can', index: 2 /* + 4 */, textOffset: 0 },
+            { text: '\'',  index: 3 /* + 4 */, textOffset: 3 }
           ]
         }
       ]);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -1635,13 +1635,13 @@ describe('ContextTokenization', function() {
       expectedMap.set(0, { insert: 't', deleteLeft: 0 });
       assert.equal(results.tokenizedTransform.size, 1);
       assert.deepEqual(results.tokenizedTransform, expectedMap);
-      assert.equal(results.alignment.edgeWindow.sliceIndex, 4);
       assert.deepEqual(results.alignment.merges, [
         {
           inputs: [
-            { text: 'can', index: 2 /* + 4 */ },
-            { text: '\'',  index: 3 /* + 4 */ }
-          ], match: { text: 'can\'t', index: 2 /* + 4 */}
+            // The `index` values here are pre-offset from the edge window's .sliceIndex.
+            { text: 'can', index: 6 - results.alignment.edgeWindow.sliceIndex },
+            { text: '\'',  index: 7 - results.alignment.edgeWindow.sliceIndex }
+          ], match: { text: 'can\'t', index: 6 - results.alignment.edgeWindow.sliceIndex }
         }
       ]);
       assert.deepEqual(results.alignment.splits, []);
@@ -1669,14 +1669,13 @@ describe('ContextTokenization', function() {
       expectedMap.set(2, { insert: '', deleteLeft: 0 });
       assert.equal(results.tokenizedTransform.size, 2);
       assert.deepEqual(results.tokenizedTransform, expectedMap);
-      assert.equal(results.alignment.edgeWindow.sliceIndex, 4);
       assert.deepEqual(results.alignment.merges, []);
       assert.deepEqual(results.alignment.splits, [
         {
-          input: { text: 'can\'', index: 2 /* + 4 */},
+          input: { text: 'can\'', index: 6 - results.alignment.edgeWindow.sliceIndex},
           matches: [
-            { text: 'can', index: 2 /* + 4 */, textOffset: 0 },
-            { text: '\'',  index: 3 /* + 4 */, textOffset: 3 }
+            { text: 'can', index: 6 - results.alignment.edgeWindow.sliceIndex, textOffset: 0 },
+            { text: '\'',  index: 7 - results.alignment.edgeWindow.sliceIndex, textOffset: 3 }
           ]
         }
       ]);
@@ -1701,14 +1700,13 @@ describe('ContextTokenization', function() {
       expectedMap.set(1, { insert: '?', deleteLeft: 0 });
       assert.equal(results.tokenizedTransform.size, 1);
       assert.deepEqual(results.tokenizedTransform, expectedMap);
-      assert.equal(results.alignment.edgeWindow.sliceIndex, 4);
       assert.deepEqual(results.alignment.merges, []);
       assert.deepEqual(results.alignment.splits, [
         {
-          input: { text: 'can\'', index: 2 /* + 4 */},
+          input: { text: 'can\'', index: 6 - results.alignment.edgeWindow.sliceIndex},
           matches: [
-            { text: 'can', index: 2 /* + 4 */, textOffset: 0 },
-            { text: '\'',  index: 3 /* + 4 */, textOffset: 3 }
+            { text: 'can', index: 6 - results.alignment.edgeWindow.sliceIndex, textOffset: 0 },
+            { text: '\'',  index: 7 - results.alignment.edgeWindow.sliceIndex, textOffset: 3 }
           ]
         }
       ]);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -1296,9 +1296,10 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, windowResults);
+      assert.deepEqual(results.tokenMapping.edgeWindow, {...windowResults, retokenization: results.tokenMapping.edgeWindow.retokenization});
       assert.deepEqual(results.tokenMapping.edgeWindow, {
         retokenizationText: 'brown fox',
+        retokenization: ['brown', ' ', 'fox'],
         editBoundary: {
           isPartial: false,
           omitsEmptyToken: false,
@@ -1327,9 +1328,10 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, windowResults);
+      assert.deepEqual(results.tokenMapping.edgeWindow, {...windowResults, retokenization: results.tokenMapping.edgeWindow.retokenization});
       assert.deepEqual(results.tokenMapping.edgeWindow, {
         retokenizationText: 'brown fox ',
+        retokenization: ['brown', ' ', 'fox', ' '], // no final '' token
         editBoundary: {
           isPartial: false,
           omitsEmptyToken: false,
@@ -1359,9 +1361,10 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, windowResults);
+      assert.deepEqual(results.tokenMapping.edgeWindow, {...windowResults, retokenization: results.tokenMapping.edgeWindow.retokenization});
       assert.deepEqual(results.tokenMapping.edgeWindow, {
         retokenizationText: 'brown fox',
+        retokenization: ['brown', ' ', 'fox'],
         editBoundary: {
           isPartial: false,
           omitsEmptyToken: false,
@@ -1390,9 +1393,10 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, windowResults);
+      assert.deepEqual(results.tokenMapping.edgeWindow, {...windowResults, retokenization: results.tokenMapping.edgeWindow.retokenization});
       assert.deepEqual(results.tokenMapping.edgeWindow, {
         retokenizationText: ' brown f',
+        retokenization: [' ', 'brown', ' ', 'f'],
         editBoundary: {
           isPartial: true,
           omitsEmptyToken: false,
@@ -1421,9 +1425,10 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, windowResults);
+      assert.deepEqual(results.tokenMapping.edgeWindow, {...windowResults, retokenization: results.tokenMapping.edgeWindow.retokenization});
       assert.deepEqual(results.tokenMapping.edgeWindow, {
         retokenizationText: 'quick ',
+        retokenization: ['quick', ' '],
         editBoundary: {
           isPartial: false,
           omitsEmptyToken: false,

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -976,11 +976,11 @@ describe('ContextTokenization', function() {
       );
 
       // for tokenization.
-      assert.equal(results.transformMap.size, 1);
-      assert.deepEqual(results.transformMap.get(0), editTransform);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, 1);
+      assert.deepEqual(results.tokenizedTransform.get(0), editTransform);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly handles basic token-edit transform', () => {
@@ -997,11 +997,11 @@ describe('ContextTokenization', function() {
         editTransform
       );
 
-      assert.equal(results.transformMap.size, 1);
-      assert.deepEqual(results.transformMap.get(0), editTransform);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, 1);
+      assert.deepEqual(results.tokenizedTransform.get(0), editTransform);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly handles simple token-edit transform', () => {
@@ -1019,13 +1019,13 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.equal(results.transformMap.size, 1);
-      assert.deepEqual(results.transformMap.get(0), editTransform);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, 1);
+      assert.deepEqual(results.tokenizedTransform.get(0), editTransform);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, {
+      assert.deepEqual(results.alignment.edgeWindow, {
         retokenization: ['apple', ' ', 'a', ' ', 'da'],
         retokenizationText: 'apple a da',
         editBoundary: {
@@ -1054,13 +1054,13 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.equal(results.transformMap.size, 1);
-      assert.deepEqual(results.transformMap.get(0), editTransform);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, 1);
+      assert.deepEqual(results.tokenizedTransform.get(0), editTransform);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, {
+      assert.deepEqual(results.alignment.edgeWindow, {
         retokenization: ['apple', ' ', 'a', ' ', 'da'].map(t => toMathematicalSMP(t)),
         retokenizationText: toMathematicalSMP('apple a da'),
         editBoundary: {
@@ -1087,11 +1087,11 @@ describe('ContextTokenization', function() {
         editTransform
       );
 
-      assert.equal(results.transformMap.size, 1);
-      assert.deepEqual(results.transformMap.get(0), editTransform);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, 1);
+      assert.deepEqual(results.tokenizedTransform.get(0), editTransform);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('handles simple token-replacing transform with cross-token deleteLeft', () => {
@@ -1123,11 +1123,11 @@ describe('ContextTokenization', function() {
         deleteLeft: 4
       });
 
-      assert.equal(results.transformMap.size, expectedMap.size);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, expectedMap.size);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly handles a simple appended whitespace', () => {
@@ -1151,11 +1151,11 @@ describe('ContextTokenization', function() {
       // empty transform.
       expectedMap.set(2, { insert: '', deleteLeft: 0 });
 
-      assert.equal(results.transformMap.size, expectedMap.size);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, expectedMap.size);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly handles a simple appended period', () => {
@@ -1176,11 +1176,11 @@ describe('ContextTokenization', function() {
       // after standard English punctuation.
       const expectedMap = new Map<number, Transform>();
       expectedMap.set(1, editTransform);
-      assert.equal(results.transformMap.size, expectedMap.size);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, expectedMap.size);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly deletes a simple appended whitespace', () => {
@@ -1201,11 +1201,11 @@ describe('ContextTokenization', function() {
       // The whitespace belongs on the whitespace token that will be added.
       expectedMap.set(-1, editTransform);
 
-      assert.equal(results.transformMap.size, expectedMap.size);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, expectedMap.size);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('handles word-breakable transforms (case 1)', () => {
@@ -1229,13 +1229,13 @@ describe('ContextTokenization', function() {
       expectedMap.set(1, { insert: ' ', deleteLeft: 0 });
       // new 'k' token
       expectedMap.set(2, { insert: 'k', deleteLeft: 0 });
-      assert.equal(results.transformMap.size, expectedMap.size);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, expectedMap.size);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, {
+      assert.deepEqual(results.alignment.edgeWindow, {
         retokenization: ['apple', ' ', 'a', ' ', 'da'],
         retokenizationText: 'apple a da',
         editBoundary: {
@@ -1270,13 +1270,13 @@ describe('ContextTokenization', function() {
       expectedMap.set(1, { insert: toMathematicalSMP(' '), deleteLeft: 0 });
       // new 'k' token
       expectedMap.set(2, { insert: toMathematicalSMP('k'), deleteLeft: 0 });
-      assert.equal(results.transformMap.size, expectedMap.size);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, expectedMap.size);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, {
+      assert.deepEqual(results.alignment.edgeWindow, {
         retokenization: ['apple', ' ', 'a', ' ', 'da'].map(t => toMathematicalSMP(t)),
         retokenizationText: toMathematicalSMP('apple a da'),
         editBoundary: {
@@ -1309,11 +1309,11 @@ describe('ContextTokenization', function() {
       expectedMap.set(1, { insert: '.', deleteLeft: 0 });
       expectedMap.set(2, { insert: ' ', deleteLeft: 0 });
       expectedMap.set(3, { insert: '', deleteLeft: 0 });
-      assert.equal(results.transformMap.size, 4);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, 4);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('handles complex breakable cases', () => {
@@ -1338,11 +1338,11 @@ describe('ContextTokenization', function() {
       expectedMap.set(-1, { insert: ' ', deleteLeft: 1 });
       // date => day, but with full replacement due to the large deleteLeft.
       expectedMap.set( 0, { insert: 'day', deleteLeft: 4 }); // The original token before the text insertion point.
-      assert.equal(results.transformMap.size, expectedMap.size);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, expectedMap.size);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly aligns tokenization of transforms that match-replace existing tokens (1)', () => {
@@ -1365,11 +1365,11 @@ describe('ContextTokenization', function() {
       expectedMap.set(0, { insert: 'properly', deleteLeft: 8 });
       expectedMap.set(1, { insert: ' ', deleteLeft: 0 });
       expectedMap.set(2, { insert: '', deleteLeft: 0 });
-      assert.equal(results.transformMap.size, 3);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, 3);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly aligns tokenization of transforms that match-replace existing tokens (2)', () => {
@@ -1392,11 +1392,11 @@ describe('ContextTokenization', function() {
       expectedMap.set(0, { insert: 'properly', deleteLeft: 8 });
       expectedMap.set(1, { insert: ' ', deleteLeft: 0 });
       expectedMap.set(2, { insert: '', deleteLeft: 0 });
-      assert.equal(results.transformMap.size, 3);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, 3);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly places extra whitespaces on preceding whitespace token', () => {
@@ -1417,11 +1417,11 @@ describe('ContextTokenization', function() {
       const expectedMap = new Map<number, Transform>();
       expectedMap.set(-1, { insert: ' ', deleteLeft: 0 });
       expectedMap.set(0, { insert: '', deleteLeft: 0 });
-      assert.equal(results.transformMap.size, 2);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, 2);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly aligns degenerate input cases (1)', () => {
@@ -1447,11 +1447,11 @@ describe('ContextTokenization', function() {
       expectedMap.set(2, { insert: 'brown', deleteLeft: 0 });
       expectedMap.set(3, { insert: ' ', deleteLeft: 0 });
       expectedMap.set(4, { insert: 'fox', deleteLeft: 0 });
-      assert.equal(results.transformMap.size, 7);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.equal(results.tokenizedTransform.size, 7);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('returns the standard edge window for empty transform inputs', () => {
@@ -1471,8 +1471,8 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, {...windowResults, retokenization: results.tokenMapping.edgeWindow.retokenization});
-      assert.deepEqual(results.tokenMapping.edgeWindow, {
+      assert.deepEqual(results.alignment.edgeWindow, {...windowResults, retokenization: results.alignment.edgeWindow.retokenization});
+      assert.deepEqual(results.alignment.edgeWindow, {
         retokenizationText: 'brown fox',
         retokenization: ['brown', ' ', 'fox'],
         editBoundary: {
@@ -1503,8 +1503,8 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, {...windowResults, retokenization: results.tokenMapping.edgeWindow.retokenization});
-      assert.deepEqual(results.tokenMapping.edgeWindow, {
+      assert.deepEqual(results.alignment.edgeWindow, {...windowResults, retokenization: results.alignment.edgeWindow.retokenization});
+      assert.deepEqual(results.alignment.edgeWindow, {
         retokenizationText: 'brown fox ',
         retokenization: ['brown', ' ', 'fox', ' '], // no final '' token
         editBoundary: {
@@ -1536,8 +1536,8 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, {...windowResults, retokenization: results.tokenMapping.edgeWindow.retokenization});
-      assert.deepEqual(results.tokenMapping.edgeWindow, {
+      assert.deepEqual(results.alignment.edgeWindow, {...windowResults, retokenization: results.alignment.edgeWindow.retokenization});
+      assert.deepEqual(results.alignment.edgeWindow, {
         retokenizationText: 'brown fox',
         retokenization: ['brown', ' ', 'fox'],
         editBoundary: {
@@ -1568,8 +1568,8 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, {...windowResults, retokenization: results.tokenMapping.edgeWindow.retokenization});
-      assert.deepEqual(results.tokenMapping.edgeWindow, {
+      assert.deepEqual(results.alignment.edgeWindow, {...windowResults, retokenization: results.alignment.edgeWindow.retokenization});
+      assert.deepEqual(results.alignment.edgeWindow, {
         retokenizationText: ' brown f',
         retokenization: [' ', 'brown', ' ', 'f'],
         editBoundary: {
@@ -1600,8 +1600,8 @@ describe('ContextTokenization', function() {
         edgeWindowSpec
       );
 
-      assert.deepEqual(results.tokenMapping.edgeWindow, {...windowResults, retokenization: results.tokenMapping.edgeWindow.retokenization});
-      assert.deepEqual(results.tokenMapping.edgeWindow, {
+      assert.deepEqual(results.alignment.edgeWindow, {...windowResults, retokenization: results.alignment.edgeWindow.retokenization});
+      assert.deepEqual(results.alignment.edgeWindow, {
         retokenizationText: 'quick ',
         retokenization: ['quick', ' '],
         editBoundary: {
@@ -1633,10 +1633,10 @@ describe('ContextTokenization', function() {
       const expectedMap = new Map<number, Transform>();
       // index 0:  the merged `can'` token
       expectedMap.set(0, { insert: 't', deleteLeft: 0 });
-      assert.equal(results.transformMap.size, 1);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.equal(results.tokenMapping.edgeWindow.sliceIndex, 4);
-      assert.deepEqual(results.tokenMapping.merges, [
+      assert.equal(results.tokenizedTransform.size, 1);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.equal(results.alignment.edgeWindow.sliceIndex, 4);
+      assert.deepEqual(results.alignment.merges, [
         {
           inputs: [
             { text: 'can', index: 2 /* + 4 */ },
@@ -1644,8 +1644,8 @@ describe('ContextTokenization', function() {
           ], match: { text: 'can\'t', index: 2 /* + 4 */}
         }
       ]);
-      assert.deepEqual(results.tokenMapping.splits, []);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.deepEqual(results.alignment.splits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly handles English contraction transitions (2)', () => {
@@ -1667,11 +1667,11 @@ describe('ContextTokenization', function() {
       // index 0:  the split-off `'` token.
       expectedMap.set(1, { insert: ' ', deleteLeft: 0 });
       expectedMap.set(2, { insert: '', deleteLeft: 0 });
-      assert.equal(results.transformMap.size, 2);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.equal(results.tokenMapping.edgeWindow.sliceIndex, 4);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, [
+      assert.equal(results.tokenizedTransform.size, 2);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.equal(results.alignment.edgeWindow.sliceIndex, 4);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, [
         {
           input: { text: 'can\'', index: 2 /* + 4 */},
           matches: [
@@ -1680,7 +1680,7 @@ describe('ContextTokenization', function() {
           ]
         }
       ]);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
 
     it('properly handles English contraction transitions (3)', () => {
@@ -1699,11 +1699,11 @@ describe('ContextTokenization', function() {
 
       const expectedMap = new Map<number, Transform>();
       expectedMap.set(1, { insert: '?', deleteLeft: 0 });
-      assert.equal(results.transformMap.size, 1);
-      assert.deepEqual(results.transformMap, expectedMap);
-      assert.equal(results.tokenMapping.edgeWindow.sliceIndex, 4);
-      assert.deepEqual(results.tokenMapping.merges, []);
-      assert.deepEqual(results.tokenMapping.splits, [
+      assert.equal(results.tokenizedTransform.size, 1);
+      assert.deepEqual(results.tokenizedTransform, expectedMap);
+      assert.equal(results.alignment.edgeWindow.sliceIndex, 4);
+      assert.deepEqual(results.alignment.merges, []);
+      assert.deepEqual(results.alignment.splits, [
         {
           input: { text: 'can\'', index: 2 /* + 4 */},
           matches: [
@@ -1712,7 +1712,7 @@ describe('ContextTokenization', function() {
           ]
         }
       ]);
-      assert.deepEqual(results.tokenMapping.unmappedEdits, []);
+      assert.deepEqual(results.alignment.unmappedEdits, []);
     });
   });
 

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -954,7 +954,7 @@ describe('ContextTokenization', function() {
     });
   });
 
-  describe('precomputeTokenizationAfterInput', () => {
+  describe('mapWhitespacedTokenization', () => {
     const edgeWindowSpec = {
       minTokens: 3,
       minChars: 8
@@ -970,7 +970,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 0
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -992,7 +992,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 0
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1013,7 +1013,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 2
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform,
         edgeWindowSpec
@@ -1048,7 +1048,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 2
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform,
         edgeWindowSpec
@@ -1082,7 +1082,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 4
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1104,7 +1104,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 5
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1139,7 +1139,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 0
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1167,7 +1167,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 0
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1192,7 +1192,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 1
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1217,7 +1217,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 1
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1258,7 +1258,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 1
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1299,7 +1299,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 1
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1326,7 +1326,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 5
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1356,7 +1356,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 8
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1383,7 +1383,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 8
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1409,7 +1409,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 0
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );
@@ -1433,7 +1433,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 9
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform,
         edgeWindowSpec
@@ -1465,7 +1465,7 @@ describe('ContextTokenization', function() {
 
       const windowResults = buildEdgeWindow(baseTokenization.tokens, {...editTransform, deleteRight: 0}, false, edgeWindowSpec);
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform,
         edgeWindowSpec
@@ -1497,7 +1497,7 @@ describe('ContextTokenization', function() {
 
       const windowResults = buildEdgeWindow(baseTokenization.tokens, {...editTransform, deleteRight: 0}, false, edgeWindowSpec);
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform,
         edgeWindowSpec
@@ -1530,7 +1530,7 @@ describe('ContextTokenization', function() {
 
       const windowResults = buildEdgeWindow(baseTokenization.tokens, {...editTransform, deleteRight: 0}, false, edgeWindowSpec);
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform,
         edgeWindowSpec
@@ -1562,7 +1562,7 @@ describe('ContextTokenization', function() {
 
       const windowResults = buildEdgeWindow(baseTokenization.tokens, {...editTransform, deleteRight: 0}, false, edgeWindowSpec);
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform,
         edgeWindowSpec
@@ -1594,7 +1594,7 @@ describe('ContextTokenization', function() {
 
       const windowResults = buildEdgeWindow(baseTokenization.tokens, {...editTransform, deleteRight: 0}, false, edgeWindowSpec);
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform,
         edgeWindowSpec
@@ -1624,7 +1624,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 0
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform,
         edgeWindowSpec
@@ -1657,7 +1657,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 0
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform,
         edgeWindowSpec
@@ -1691,7 +1691,7 @@ describe('ContextTokenization', function() {
         deleteLeft: 0
       };
 
-      const results = baseTokenization.precomputeTokenizationAfterInput(
+      const results = baseTokenization.mapWhitespacedTokenization(
         plainModel,
         editTransform
       );

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/transform-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/transform-tokenization.tests.ts
@@ -380,6 +380,37 @@ describe('tokenizeTransform', () => {
       assert.equal(result.size, 2);
       assert.deepEqual(result, expectedMap);
     });
+
+    it('properly aligns degenerate input cases (1)', () => {
+      const context = {
+        left: 'quick brown fox', // 'quick', ' ', 'brown', ' ', 'fox'
+        right: '',
+        startOfBuffer: true,
+        endOfBuffer: true
+      };
+
+      const editTransform = {
+        insert: 'fox and brown fox',  // => quick fox and brown fox
+        deleteLeft: 9
+      };
+
+      const result = tokenizeTransform(
+        defaultTokenize,
+        context,
+        editTransform
+      );
+
+      const expectedMap = new Map<number, Transform>();
+      expectedMap.set(-2, { insert: 'fox', deleteLeft: 5 });
+      expectedMap.set(-1, { insert: ' ', deleteLeft: 1 });
+      expectedMap.set(0, { insert: 'and', deleteLeft: 3 });
+      expectedMap.set(1, { insert: ' ', deleteLeft: 0 });
+      expectedMap.set(2, { insert: 'brown', deleteLeft: 0 });
+      expectedMap.set(3, { insert: ' ', deleteLeft: 0 });
+      expectedMap.set(4, { insert: 'fox', deleteLeft: 0 });
+      assert.equal(result.size, 7);
+      assert.deepEqual(result, expectedMap);
+    });
   });
 
   describe('with mocked dictionary-based wordbreaking', () => {


### PR DESCRIPTION
This PR's change set introduces a new method - `precomputeTokenizationAfterInput` - designed to facilitate context transitions for cases that we currently do not support properly.

This method determines _both_ the tokenization for the input `Transform` _and_ its effects on the tokenization of existing context at the same time and can detect when two (or more) tokens are either merged or the result of a split edit.  The returned metadata - especially within the `tokenMapping` object and its properties - are designed to facilitate grouping cases together when they have matching effects for their transforms and final tokenizations.  

Notable advantages this PR's new method and its helpers have over the `tokenizeTransform` and `computeAlignment` methods:
- Can handle `split` and `merge` edits
- Uses the edit path much more intelligently
- Recognizes that all tokenized transforms after the first are essentially inserts, even if replacing a token that was deleted at the same relative position
- Only tokenizes the context _once_, rather than twice (one for `tokenizeTransform`, once for `computeAlignment`
- Only tokenizes _part_ of the context for each input transform, rather than all of it for each transform's calls.
    - If the first few lines of the method are 'lifted' out of the method, it may even be possible (with care) to reuse the data that determines which _part_ of the context is re-tokenized.

Related-to: #14679.

Known follow-up work to do, as the next "big push":

1. Perform the batching:
    - if new token, all tokenizations that complete a word before + start a new token here
    - else, continue existing token for the source tokenization
    - batch all transforms with similar (enough?) edit properties that maintain the token, etc.
2. Transition the relevant tokenization(s).
    - including any tokenization weighting, etc
    - forward text (merging tokenizations): maybe just use the 'best' tokenization weighting that led to the new token, if starting new one.
    - backward text (text deletion, splitting tokenizations) that delete a
      token:  the fun question
      - may require reconstruction of prior tokenization from scratch?
      - or is a way to keep bits of the lead-in paths around without memory bloat?
        - less bloat:  incoming tokenization RANGES that can be used to reconstruct from current entries
        - and discard that after a set # of tokens, locking in a single lead-in.

Build-bot: skip build:web
Test-bot: skip
