### PR TITLE
feat(web): build token-aligned edge windows 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
@@ -49,6 +49,8 @@ export class ContextToken {
    */
   readonly searchSpace: SearchSpace;
 
+  isPartial: boolean;
+
   /**
    * Tokens affected by applied suggestions will indicate the transition ID of
    * the applied suggestion here.
@@ -75,16 +77,17 @@ export class ContextToken {
    * @param model
    * @param rawText
    */
-  constructor(model: LexicalModel, rawText: string);
+  constructor(model: LexicalModel, rawText: string, isPartial?: boolean);
   /**
    * This constructor deep-copies the specified instance.
    * @param baseToken
    */
   constructor(baseToken: ContextToken);
-  constructor(param: ContextToken | LexicalModel, rawText?: string) {
+  constructor(param: ContextToken | LexicalModel, rawText?: string, isPartial?: boolean) {
     if(param instanceof ContextToken) {
       const priorToken = param;
       this.isWhitespace = priorToken.isWhitespace;
+      this.isPartial = priorToken.isPartial;
 
       // We need to construct a separate search space from other token copies.
       //
@@ -103,6 +106,7 @@ export class ContextToken {
 
       // May be altered outside of the constructor.
       this.isWhitespace = false;
+      this.isPartial = !!isPartial;
       this.searchSpace = new SearchSpace(model);
       this._inputRange = [];
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -474,7 +474,7 @@ export function buildEdgeWindow(
       // token, we hit the boundary; note the boundary text.
       if(deleteCnt == 0 && tokenDeleteLength != tokenLen) {
         editBoundary = {
-          text: applyAtFront ? KMWString.slice(token, tokenDeleteLength) : KMWString.slice(token, 0, tokenLen - tokenDeleteLength),
+          text: applyAtFront ? KMWString.substring(token, tokenDeleteLength) : KMWString.substring(token, 0, tokenLen - tokenDeleteLength),
           tokenIndex: i,
           isPartial: tokenDeleteLength != 0 || tokenIsPartial
         }

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -506,7 +506,8 @@ export function buildEdgeWindow(
     }
   }
 
-  if(totalDelete == 0) {
+  // Second half of the condition:  handles cases with bad Transforms that try to overdelete.
+  if(totalDelete == 0 || deleteCnt != 0) {
     deleteLengths.push(0);
   }
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -343,6 +343,12 @@ interface EdgeEditBoundaryTokenData {
   omitsEmptyToken?: boolean
 }
 
+/**
+ * Options that may be used to parameterize the range and scope of `buildEdgeWindow`.
+ *
+ * This is currently intended for use with unit-testing, allowing existing tests to
+ * continue unimpeded even if we change the values for our related defined constants.
+ */
 interface EdgeWindowOptions {
   /**
    * Specifies a minimum number of unaffected Tokens to include within the edge window.
@@ -355,13 +361,18 @@ interface EdgeWindowOptions {
   minChars: number
 }
 
+/**
+ * Represents data about the context edge to which an incoming `Transform` will be applied.
+ */
 interface EdgeWindow {
   /**
-   * The constructed edge window's text, intended for retokenization to detect tokenization shifts
+   * The portion of text represented by the current tokenization that should be
+   * made available for retokenization when applying the `Transform`.
    */
   retokenizationText: string,
   /**
-   * Data about the token at the boundary of applied deletions
+   * Data about the token at the boundary of deleteLeft operations specified by the
+   * `Transform`.
    */
   editBoundary: EdgeEditBoundaryTokenData,
   /**

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -355,26 +355,7 @@ interface EdgeWindowOptions {
   minChars: number
 }
 
-/**
- * Constructs a window on one side of the represented context that is aligned to
- * existing tokenization.
- * @param currentTokens  Tokens from an existing ContextTokenization
- * @param transform  A Transform specifying edits to apply to the represented
- * Context
- * @param applyAtFront  If true, applies the Transform and builds the window at
- * the start of the represented Context.
- *
- * If false, does both actions at the end
- * of the represented Context.
- * @returns
- */
-export function buildEdgeWindow(
-  currentTokens: ContextToken[],
-  // Requires deleteRight be explicitly set.
-  transform: Transform & { deleteRight: number },
-  applyAtFront: boolean,
-  windowOptions?: EdgeWindowOptions
-): {
+interface EdgeWindow {
   /**
    * The constructed edge window's text, intended for retokenization to detect tokenization shifts
    */
@@ -404,8 +385,28 @@ export function buildEdgeWindow(
    * - To retrieve tokens not included: `.slice(0, retokenizationEndIndex)`.
    */
   edgeSliceIndex: number
-} {
-  const insert = transform.insert;
+}
+
+/**
+ * Constructs a window on one side of the represented context that is aligned to
+ * existing tokenization.
+ * @param currentTokens  Tokens from an existing ContextTokenization
+ * @param transform  A Transform specifying edits to apply to the represented
+ * Context
+ * @param applyAtFront  If true, applies the Transform and builds the window at
+ * the start of the represented Context.
+ *
+ * If false, does both actions at the end
+ * of the represented Context.
+ * @returns
+ */
+export function buildEdgeWindow(
+  currentTokens: ContextToken[],
+  // Requires deleteRight be explicitly set.
+  transform: Transform & { deleteRight: number },
+  applyAtFront: boolean,
+  windowOptions?: EdgeWindowOptions
+): EdgeWindow {
   const totalDelete = applyAtFront ? transform.deleteRight : transform.deleteLeft;
   const directionSign = applyAtFront ? 1 : -1;
 
@@ -413,7 +414,7 @@ export function buildEdgeWindow(
   // applyAtFront == false:  iterates backward
   const concatText: (full: string, current: string) => string = applyAtFront ? appendText : prependText;
 
-  let retokenizationText = insert;
+  let retokenizationText = '';
   let deleteCnt = totalDelete;
 
   const deleteLengths: number[] = [];

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -395,7 +395,7 @@ interface EdgeWindow {
    * - To retrieve tokens in the edge window: `.slice(retokenizationEndIndex)`
    * - To retrieve tokens not included: `.slice(0, retokenizationEndIndex)`.
    */
-  edgeSliceIndex: number
+  sliceIndex: number
 }
 
 /**
@@ -532,6 +532,6 @@ export function buildEdgeWindow(
     // Is used for slicing and should reflect the last token considered.
     // Forward:  the value indicates the interval's end (one past it, per typical indexing)
     // Backward:  the value indicates the interval's start (precisely, not past it)
-    edgeSliceIndex: i + (applyAtFront ? 0 : 1)
+    sliceIndex: i + (applyAtFront ? 0 : 1)
   }
 }

--- a/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
@@ -1,7 +1,7 @@
 export { ClassicalDistanceCalculation, EditOperation, EditTuple, forNewIndices } from './correction/classical-calculation.js';
 export * from './correction/context-state.js';
 export { ContextToken } from './correction/context-token.js';
-export { ContextTokenization } from './correction/context-tokenization.js';
+export * from './correction/context-tokenization.js';
 export { ContextTracker } from './correction/context-tracker.js';
 export { ContextTransition } from './correction/context-transition.js';
 export * from './correction/alignment-helpers.js';

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -642,6 +642,42 @@ describe('ContextTokenization', function() {
         minChars: 8
       }
 
+      it('handles empty contexts', () => {
+        const baseTokens = [''];
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+
+        const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 0 }, true, editWindowSpec);
+        assert.deepEqual(results, {
+          retokenizationText: '',
+          editBoundary: {
+            isPartial: false,
+            omitsEmptyToken: false,
+            text: '',
+            tokenIndex: 0
+          },
+          deleteLengths: [0],
+          edgeSliceIndex: 1
+        });
+      });
+
+      it('handles empty contexts and invalid Transforms', () => {
+        const baseTokens = [''];
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+
+        const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 2 }, true, editWindowSpec);
+        assert.deepEqual(results, {
+          retokenizationText: '',
+          editBoundary: {
+            isPartial: true,
+            omitsEmptyToken: false,
+            text: '',
+            tokenIndex: 0
+          },
+          deleteLengths: [0],
+          edgeSliceIndex: 1
+        });
+      });
+
       it('builds edge windows for the start of context with no edits', () => {
         const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'];
         const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -656,7 +656,7 @@ describe('ContextTokenization', function() {
             tokenIndex: 0
           },
           deleteLengths: [0],
-          edgeSliceIndex: 1
+          sliceIndex: 1
         });
       });
 
@@ -674,7 +674,7 @@ describe('ContextTokenization', function() {
             tokenIndex: 0
           },
           deleteLengths: [0],
-          edgeSliceIndex: 1
+          sliceIndex: 1
         });
       });
 
@@ -692,7 +692,7 @@ describe('ContextTokenization', function() {
             tokenIndex: 0
           },
           deleteLengths: [0],
-          edgeSliceIndex: 3
+          sliceIndex: 3
         });
       });
 
@@ -710,7 +710,7 @@ describe('ContextTokenization', function() {
             tokenIndex: 1
           },
           deleteLengths: [2, 0],
-          edgeSliceIndex: 5
+          sliceIndex: 5
         });
       });
 
@@ -728,7 +728,7 @@ describe('ContextTokenization', function() {
             tokenIndex: 2
           },
           deleteLengths: [2, 1, 1],
-          edgeSliceIndex: 7
+          sliceIndex: 7
         });
       });
 
@@ -747,7 +747,7 @@ describe('ContextTokenization', function() {
             tokenIndex: 6
           },
           deleteLengths: [0],
-          edgeSliceIndex: 2
+          sliceIndex: 2
         });
       });
 
@@ -765,7 +765,7 @@ describe('ContextTokenization', function() {
             tokenIndex: 7
           },
           deleteLengths: [0],
-          edgeSliceIndex: 2
+          sliceIndex: 2
         });
       });
     })

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -13,6 +13,7 @@ import { assert } from 'chai';
 import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
 import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
 import { LexicalModelTypes } from '@keymanapp/common-types';
+import { KMWString } from '@keymanapp/web-utils';
 
 import { buildEdgeWindow, ContextStateAlignment, ContextToken, ContextTokenization, models } from '@keymanapp/lm-worker/test-index';
 
@@ -29,7 +30,31 @@ function toToken(text: string) {
   return token;
 }
 
+// https://www.compart.com/en/unicode/block/U+1D400
+const mathBoldUpperA = 0x1D400; // Mathematical Bold Capital A
+const mathBoldLowerA = 0x1D41A; //                   Small   A
+
+function toMathematicalSMP(text: string) {
+  const chars = [...text];
+
+  const asSMP = chars.map((c) => {
+    if(c >= 'a' && c <= 'z') {
+      return String.fromCodePoint(mathBoldLowerA + (c.charCodeAt(0) - 'a'.charCodeAt(0)));
+    } else if(c >= 'A' && c <= 'Z') {
+      return String.fromCodePoint(mathBoldUpperA + (c.charCodeAt(0) - 'A'.charCodeAt(0)));
+    } else {
+      return c;
+    }
+  });
+
+  return asSMP.join('');
+}
+
 describe('ContextTokenization', function() {
+  before(() => {
+    KMWString.enableSupplementaryPlane(true);
+  });
+
   describe("<constructor>", () => {
     it("constructs from just a token array", () => {
       const rawTextTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'];
@@ -696,6 +721,24 @@ describe('ContextTokenization', function() {
         });
       });
 
+      it('builds edge windows for the start of context with no edits - SMP strings', () => {
+        const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'].map(s => toMathematicalSMP(s));
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+
+        const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 0 }, true, editWindowSpec);
+        assert.deepEqual(results, {
+          retokenizationText: toMathematicalSMP('an apple'),
+          editBoundary: {
+            isPartial: false,
+            omitsEmptyToken: false,
+            text: toMathematicalSMP('an'),
+            tokenIndex: 0
+          },
+          deleteLengths: [0],
+          sliceIndex: 3
+        });
+      });
+
       it('builds edge windows for the start of context with deletion edits (1)', () => {
         const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'];
         const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
@@ -703,6 +746,24 @@ describe('ContextTokenization', function() {
         const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 2 }, true, editWindowSpec);
         assert.deepEqual(results, {
           retokenizationText: ' apple a',
+          editBoundary: {
+            isPartial: false,
+            omitsEmptyToken: false,
+            text: ' ',
+            tokenIndex: 1
+          },
+          deleteLengths: [2, 0],
+          sliceIndex: 5
+        });
+      });
+
+      it('builds edge windows for the start of context with deletion edits (1) - SMP strings', () => {
+        const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'].map(s => toMathematicalSMP(s));
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+
+        const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 2 }, true, editWindowSpec);
+        assert.deepEqual(results, {
+          retokenizationText: toMathematicalSMP(' apple a'),
           editBoundary: {
             isPartial: false,
             omitsEmptyToken: false,


### PR DESCRIPTION
These windows are designed for use in detecting tokenization shifts both at the start and the end of the context.  Rather than constantly retokenize the whole available context, we can be more efficient by limiting the range we permit for retokenization.

Relates-to: #14679

The following two dependent PRs leverage this method:
- #14754
- #14790

Build-bot: skip build:web
Test-bot: skip