### PR TITLE
refactor(linux): remove a meson deprecation warning

### DIFF
--- a/linux/ibus-keyman/src/test/meson.build
+++ b/linux/ibus-keyman/src/test/meson.build
@@ -9,7 +9,7 @@ test_env = [
   'G_TEST_SRCDIR=' + meson.current_source_dir(),
   'G_TEST_BUILDDIR=' + meson.current_build_dir(),
   'TOP_SRCDIR=' + meson.global_source_root(),
-  'TOP_BINDIR=' + meson.build_root(),
+  'TOP_BINDIR=' + meson.global_build_root(),
 ]
 
 test_include_dirs = [


### PR DESCRIPTION
`meson.build_root()` is deprecated in Meson 1.0+.

Test-bot: skip