### PR TITLE
feat(web): add helper for tokenizing Transform.insert via tokenization of applied context 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -706,19 +706,23 @@ export function traceInsertEdits(tokens: string[], transform: Transform): {
   firstInsertPostIndex: number
 } {
   let insert = transform.insert;
+  let insertLen = KMWString.length(insert);
   const stackedInserts: string[] = [];
   let firstInsertPostIndex: number;
 
   if(insert.length > 0) {
     for(let index = tokens.length - 1; index >= 0; index--) {
+      const tokenLen = KMWString.length(tokens[index]);
+
       const currentToken = tokens[index];
-      if(KMWString.length(currentToken) >= KMWString.length(insert)) {
+      if(tokenLen >= insertLen) {
         stackedInserts.push(insert);
         firstInsertPostIndex = index;
         break;
       }
 
-      insert = insert.substring(0, insert.length - currentToken.length);
+      insert = KMWString.substring(insert, 0, insertLen - tokenLen);
+      insertLen -= tokenLen;
       stackedInserts.push(currentToken);
       firstInsertPostIndex = index;
     }

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -685,3 +685,51 @@ export function buildEdgeWindow(
     sliceIndex: i + (applyAtFront ? 0 : 1)
   }
 }
+
+/**
+ * Using the post-application tokenization of a context, traces where the
+ * components of a transform land among its tokens and computes relevant
+ * metadata for tokenization-transition analysis.
+ * @param tokens The tokenized form of the context after being edited by the
+ * transform
+ * @param transform  The edit applied to a context
+ * @returns
+ */
+export function traceInsertEdits(tokens: string[], transform: Transform): {
+  /**
+   * a tokenization of the Transform's `insert` string, in stack form.
+   */
+  stackedInserts: string[],
+  /**
+   * The index of the earliest post-application token to which the `Transform`'s
+   * `.insert` component was applied.
+   */
+  firstInsertPostIndex: number
+} {
+  let insert = transform.insert;
+  const stackedInserts: string[] = [];
+  let firstInsertPostIndex: number;
+
+  if(insert.length > 0) {
+    for(let index = tokens.length - 1; index >= 0; index--) {
+      const currentToken = tokens[index];
+      if(KMWString.length(currentToken) >= KMWString.length(insert)) {
+        stackedInserts.push(insert);
+        firstInsertPostIndex = index;
+        break;
+      }
+
+      insert = insert.substring(0, insert.length - currentToken.length);
+      stackedInserts.push(currentToken);
+      firstInsertPostIndex = index;
+    }
+  } else {
+    firstInsertPostIndex = tokens.length - 1
+    stackedInserts.push('');
+  }
+
+  return {
+    stackedInserts,
+    firstInsertPostIndex
+  };
+}

--- a/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
@@ -5,7 +5,7 @@ export * from './correction/context-tokenization.js';
 export { ContextTracker } from './correction/context-tracker.js';
 export { ContextTransition } from './correction/context-transition.js';
 export * from './correction/alignment-helpers.js';
-export { SegmentableDistanceCalculation } from './correction/segmentable-calculation.js';
+export { ExtendedEditOperation, SegmentableDistanceCalculation } from './correction/segmentable-calculation.js';
 export * as correction from './correction/index.js';
 export * from './model-helpers.js';
 export * as models from './models/index.js';

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -14,7 +14,7 @@ import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
 import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 
-import { buildEdgeWindow, ContextStateAlignment, ContextToken, ContextTokenization, models } from '@keymanapp/lm-worker/test-index';
+import { buildEdgeWindow, ContextStateAlignment, ContextToken, ContextTokenization, models, traceInsertEdits } from '@keymanapp/lm-worker/test-index';
 
 import Transform = LexicalModelTypes.Transform;
 import TrieModel = models.TrieModel;
@@ -879,6 +879,68 @@ describe('ContextTokenization', function() {
       assert.sameOrderedMembers(resultTokenization.exampleInput, ['n\'t', ...baseTokens.slice(2)]);
       assert.isTrue(resultTokenization.tokens[0].isPartial);
       resultTokenization.tokens.slice(1).forEach((token, index) => assert.isFalse(token.isPartial, `token ${index} (${token.exampleInput}) still marked partial`));
+    });
+  });
+
+  describe('traceInsertEdits', () => {
+    it('handles zero-length insert cases (1)', () => {
+      const tokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'];
+      const result = traceInsertEdits(tokens, {insert: '', deleteLeft: 0});
+
+      assert.deepEqual(result, {
+        stackedInserts: [''],
+        firstInsertPostIndex: tokens.length - 1
+      });
+    });
+
+    it('handles zero-length insert cases (2)', () => {
+      const tokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day', ' ', ''];
+      const result = traceInsertEdits(tokens, {insert: '', deleteLeft: 0});
+
+      assert.deepEqual(result, {
+        stackedInserts: [''],
+        firstInsertPostIndex: tokens.length - 1
+      });
+    });
+
+    it('ignores deleteLefts and deleteRights', () => {
+      const tokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'];
+      const result = traceInsertEdits(tokens, {insert: '', deleteLeft: 10, deleteRight: -10});
+
+      assert.deepEqual(result, {
+        stackedInserts: [''],
+        firstInsertPostIndex: tokens.length - 1
+      });
+    });
+
+    it('handles simple char output transforms', () => {
+      const tokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'];
+      const result = traceInsertEdits(tokens, {insert: 'y', deleteLeft: 0});
+
+      assert.deepEqual(result, {
+        stackedInserts: ['y'],
+        firstInsertPostIndex: tokens.length - 1
+      });
+    });
+
+    it('handles standard whitespace wordbreaks', () => {
+      const tokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day', ' ', ''];
+      const result = traceInsertEdits(tokens, {insert: ' ', deleteLeft: 0});
+
+      assert.deepEqual(result, {
+        stackedInserts: ['', ' '],
+        firstInsertPostIndex: tokens.length - 2
+      });
+    });
+
+    it('handles large insert strings', () => {
+      const tokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day', ' ', ''];
+      const result = traceInsertEdits(tokens, {insert: 'ple a day ', deleteLeft: 0});
+
+      assert.deepEqual(result, {
+        stackedInserts: ['', ' ', 'day', ' ', 'a', ' ', 'ple'],
+        firstInsertPostIndex: 2
+      });
     });
   });
 });


### PR DESCRIPTION
This PR adds a method that can determine which parts of a `Transform`'s `.insert` component landed within each post-application "token" of the context. 

When updating our context state information in order to attempt reuse of prior calculations, we need to know where the input's components align with them so that they affect the predictive-text process correctly.

Note that the `.deleteLeft` component is instead determined when building the edge window, as it takes effect on the _original_ state and tokenization of the context.  (Of particular note here:  if a token is fully deleted, there's no reason to preserve it - we can delete it instead [or replace it, if new text is set in the same place].)

Relates-to: #14679

Build-bot: skip build:web
Test-bot: skip