### PR TITLE
fix(windows): diagnostic: remove all custom actions

### DIFF
--- a/windows/src/desktop/inst/keymandesktop.wxs
+++ b/windows/src/desktop/inst/keymandesktop.wxs
@@ -261,9 +261,10 @@
 
     <!-- Actions -->
 
-    <CustomAction Id="RollbackPostInstallCU" Execute="rollback" Impersonate="yes" ExeCommand='-rcu' BinaryKey='insthelp.exe' />
+    <!-- <CustomAction Id="RollbackPostInstallCU" Execute="rollback" Impersonate="yes" ExeCommand='-rcu' BinaryKey='insthelp.exe' />
     <CustomAction Id="RollbackPostInstallLM" Execute="rollback" Impersonate="no" ExeCommand='-rlm' BinaryKey='insthelp.exe' />
-    <CustomAction Id="PreUninstallUser" Execute="deferred" Impersonate="yes" ExeCommand='-uu' BinaryKey="insthelp.exe" />
+    <CustomAction Id="PreUninstallUser" Execute="deferred" Impersonate="yes" ExeCommand='-uu' BinaryKey="insthelp.exe" /> -->
+
     <CustomAction Id='AlreadyUpdated' Error='[ProductName] has already been updated to [ProductVersion] or newer.' />
     <CustomAction Id='NoDowngrade' Error='A later version of [ProductName] or a related edition is already installed.' />
 
@@ -289,10 +290,10 @@
            But we cannot have RemoveExistingProducts in two places in the installer! -->
       <RemoveExistingProducts After='InstallFinalize'>VERSION11FOUND</RemoveExistingProducts>
 
-      <Custom Action='RollbackPostInstallLM' After='InstallInitialize'><![CDATA[Not Installed Or REINSTALL]]></Custom>
+      <!-- <Custom Action='RollbackPostInstallLM' After='InstallInitialize'><![CDATA[Not Installed Or REINSTALL]]></Custom>
       <Custom Action='RollbackPostInstallCU' After='InstallInitialize'><![CDATA[Not Installed Or REINSTALL]]></Custom>
 
-      <Custom Action="PreUninstallUser" After="InstallInitialize"><![CDATA[REMOVE="ALL" And Not REINSTALL And Not UPGRADINGPRODUCTCODE]]></Custom>
+      <Custom Action="PreUninstallUser" After="InstallInitialize"><![CDATA[REMOVE="ALL" And Not REINSTALL And Not UPGRADINGPRODUCTCODE]]></Custom> -->
 
       <Custom Action='SaveARPInstallLocation' After='InstallValidate'><![CDATA[Not Installed Or REINSTALL]]></Custom>
     </InstallExecuteSequence>

--- a/windows/src/desktop/inst/keymandesktop.wxs
+++ b/windows/src/desktop/inst/keymandesktop.wxs
@@ -261,9 +261,9 @@
 
     <!-- Actions -->
 
-    <!-- <CustomAction Id="RollbackPostInstallCU" Execute="rollback" Impersonate="yes" ExeCommand='-rcu' BinaryKey='insthelp.exe' />
+    <CustomAction Id="RollbackPostInstallCU" Execute="rollback" Impersonate="yes" ExeCommand='-rcu' BinaryKey='insthelp.exe' />
     <CustomAction Id="RollbackPostInstallLM" Execute="rollback" Impersonate="no" ExeCommand='-rlm' BinaryKey='insthelp.exe' />
-    <CustomAction Id="PreUninstallUser" Execute="deferred" Impersonate="yes" ExeCommand='-uu' BinaryKey="insthelp.exe" /> -->
+    <CustomAction Id="PreUninstallUser" Execute="deferred" Impersonate="yes" ExeCommand='-uu' BinaryKey="insthelp.exe" />
 
     <CustomAction Id='AlreadyUpdated' Error='[ProductName] has already been updated to [ProductVersion] or newer.' />
     <CustomAction Id='NoDowngrade' Error='A later version of [ProductName] or a related edition is already installed.' />
@@ -290,10 +290,10 @@
            But we cannot have RemoveExistingProducts in two places in the installer! -->
       <RemoveExistingProducts After='InstallFinalize'>VERSION11FOUND</RemoveExistingProducts>
 
-      <!-- <Custom Action='RollbackPostInstallLM' After='InstallInitialize'><![CDATA[Not Installed Or REINSTALL]]></Custom>
+      <Custom Action='RollbackPostInstallLM' After='InstallInitialize'><![CDATA[Not Installed Or REINSTALL]]></Custom>
       <Custom Action='RollbackPostInstallCU' After='InstallInitialize'><![CDATA[Not Installed Or REINSTALL]]></Custom>
 
-      <Custom Action="PreUninstallUser" After="InstallInitialize"><![CDATA[REMOVE="ALL" And Not REINSTALL And Not UPGRADINGPRODUCTCODE]]></Custom> -->
+      <Custom Action="PreUninstallUser" After="InstallInitialize"><![CDATA[REMOVE="ALL" And Not REINSTALL And Not UPGRADINGPRODUCTCODE]]></Custom>
 
       <Custom Action='SaveARPInstallLocation' After='InstallValidate'><![CDATA[Not Installed Or REINSTALL]]></Custom>
     </InstallExecuteSequence>

--- a/windows/src/desktop/inst/keymandesktop.wxs
+++ b/windows/src/desktop/inst/keymandesktop.wxs
@@ -262,7 +262,7 @@
     <!-- Actions -->
 
     <CustomAction Id="RollbackPostInstallCU" Execute="rollback" Impersonate="yes" ExeCommand='-rcu' BinaryKey='insthelp.exe' />
-    <CustomAction Id="RollbackPostInstallLM" Execute="rollback" Impersonate="no" ExeCommand='-rlm' BinaryKey='insthelp.exe' />
+    <!-- <CustomAction Id="RollbackPostInstallLM" Execute="rollback" Impersonate="no" ExeCommand='-rlm' BinaryKey='insthelp.exe' /> -->
     <CustomAction Id="PreUninstallUser" Execute="deferred" Impersonate="yes" ExeCommand='-uu' BinaryKey="insthelp.exe" />
 
     <CustomAction Id='AlreadyUpdated' Error='[ProductName] has already been updated to [ProductVersion] or newer.' />
@@ -290,7 +290,7 @@
            But we cannot have RemoveExistingProducts in two places in the installer! -->
       <RemoveExistingProducts After='InstallFinalize'>VERSION11FOUND</RemoveExistingProducts>
 
-      <Custom Action='RollbackPostInstallLM' After='InstallInitialize'><![CDATA[Not Installed Or REINSTALL]]></Custom>
+      <!-- <Custom Action='RollbackPostInstallLM' After='InstallInitialize'><![CDATA[Not Installed Or REINSTALL]]></Custom> -->
       <Custom Action='RollbackPostInstallCU' After='InstallInitialize'><![CDATA[Not Installed Or REINSTALL]]></Custom>
 
       <Custom Action="PreUninstallUser" After="InstallInitialize"><![CDATA[REMOVE="ALL" And Not REINSTALL And Not UPGRADINGPRODUCTCODE]]></Custom>

--- a/windows/src/desktop/kmshell/kmshell.dpr
+++ b/windows/src/desktop/kmshell/kmshell.dpr
@@ -182,7 +182,10 @@ uses
   Keyman.System.UpdateStateMachine in 'main\Keyman.System.UpdateStateMachine.pas',
   Keyman.System.DownloadUpdate in 'main\Keyman.System.DownloadUpdate.pas',
   Keyman.System.ExecutionHistory in '..\..\..\..\common\windows\delphi\general\Keyman.System.ExecutionHistory.pas',
-  Keyman.Configuration.UI.UfrmStartInstall in 'main\Keyman.Configuration.UI.UfrmStartInstall.pas' {frmStartInstall};
+  Keyman.Configuration.UI.UfrmStartInstall in 'main\Keyman.Configuration.UI.UfrmStartInstall.pas' {frmStartInstall},
+  Keyman.Configuration.System.AllApplicationPackagePermissions in 'main\Keyman.Configuration.System.AllApplicationPackagePermissions.pas',
+  Keyman.System.Security in '..\..\global\delphi\general\Keyman.System.Security.pas',
+  Keyman.Winapi.VersionHelpers in '..\..\global\delphi\winapi\Keyman.Winapi.VersionHelpers.pas';
 
 {$R VERSION.RES}
 {$R manifest.res}

--- a/windows/src/desktop/kmshell/kmshell.dproj
+++ b/windows/src/desktop/kmshell/kmshell.dproj
@@ -357,6 +357,9 @@
         <DCCReference Include="main\Keyman.Configuration.UI.UfrmStartInstall.pas">
             <Form>frmStartInstall</Form>
         </DCCReference>
+        <DCCReference Include="main\Keyman.Configuration.System.AllApplicationPackagePermissions.pas"/>
+        <DCCReference Include="..\..\global\delphi\general\Keyman.System.Security.pas"/>
+        <DCCReference Include="..\..\global\delphi\winapi\Keyman.Winapi.VersionHelpers.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
@@ -418,18 +421,6 @@
                 <Platform value="Win64">False</Platform>
             </Platforms>
             <Deployment Version="3">
-                <DeployFile LocalName="bin\Win32\Debug\kmshell.rsm" Configuration="Debug" Class="DebugSymbols">
-                    <Platform Name="Win32">
-                        <RemoteName>kmshell.rsm</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="bin\Win32\Debug\kmshell.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>kmshell.exe</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
                 <DeployFile LocalName="bin\Win32\Debug\kmshell.exe" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>kmshell.exe</RemoteName>
@@ -439,6 +430,12 @@
                 <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
                     <Platform Name="Win32">
                         <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="bin\Win32\Debug\kmshell.rsm" Configuration="Debug" Class="DebugSymbols">
+                    <Platform Name="Win32">
+                        <RemoteName>kmshell.rsm</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>

--- a/windows/src/desktop/kmshell/main/Keyman.Configuration.System.AllApplicationPackagePermissions.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.Configuration.System.AllApplicationPackagePermissions.pas
@@ -1,0 +1,72 @@
+unit Keyman.Configuration.System.AllApplicationPackagePermissions;
+
+interface
+
+uses
+  System.SysUtils;
+
+type
+  EAppPackagePermissions = class(Exception)
+
+  end;
+
+function GrantPermissionToAllApplicationPackagesToKeymanProgramData: Boolean;
+
+implementation
+
+uses
+  Winapi.AccCtrl,
+  Winapi.ShlObj,
+  Winapi.Windows,
+  System.Classes,
+  Keyman.System.Security,
+  RegistryKeys,
+  utilsystem;
+
+procedure ReportFailure(const func: string; code: UINT);
+begin
+  raise EAppPackagePermissions.Create('Keyman for Windows failed to set permissions on ProgramData\Keymana in '+func+': '+SysErrorMessage(code));
+end;
+
+function GrantPermissionToAllApplicationPackagesToKeymanProgramData: Boolean;
+var
+  Path: string;
+  hFile: THandle;
+begin
+  Result := False;
+
+  Path := GetFolderPath(CSIDL_COMMON_APPDATA) + SFolderKeymanRoot;
+  if not DirectoryExists(Path) then
+    if not CreateDir(Path) then
+      ReportFailure('CreateDir', GetLastError);
+
+  hFile := CreateFile(
+    PChar(Path),
+    READ_CONTROL or WRITE_DAC,
+    0,
+    nil,
+    OPEN_EXISTING,
+    FILE_FLAG_BACKUP_SEMANTICS,
+    0);
+  if hFile = INVALID_HANDLE_VALUE then
+    ReportFailure('CreateFile', GetLastError);
+
+  try
+    try
+      GrantPermissionToAllApplicationPackages(hFile,
+        GENERIC_READ or GENERIC_EXECUTE,
+        SE_FILE_OBJECT);
+    except
+      on E:EOSError do
+        ReportFailure('GrantPermission', E.ErrorCode);
+    end;
+
+    Result := True;
+
+  finally
+    if not CloseHandle(hFile) then
+      ReportFailure('CloseHandle', GetLastError);
+  end;
+end;
+
+end.

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -115,10 +115,12 @@ uses
   help,
   HTMLHelpViewer,
   Keyman.Configuration.UI.InstallFile,
+  Keyman.Configuration.System.AllApplicationPackagePermissions,
   Keyman.Configuration.System.TIPMaintenance,
   Keyman.Configuration.System.UImportOlderVersionKeyboards11To13,
   Keyman.Configuration.UI.UfrmSettingsManager,
   Keyman.Configuration.UI.UfrmStartInstall,
+  Keyman.System.KeymanSentryClient,
   Keyman.System.KeymanStartTask,
   KeymanPaths,
   KLog,
@@ -626,7 +628,19 @@ begin
   Result := True;
   DoAdmin := kmcom.SystemInfo.IsAdministrator;
 
-  if not DoAdmin then
+  if DoAdmin then
+  begin
+    try
+      Result := GrantPermissionToAllApplicationPackagesToKeymanProgramData;
+    except
+      on E:EAppPackagePermissions do
+      begin
+        TKeymanSentryClient.ReportHandledException(E);
+        ShowMessage(E.Message);
+      end;
+    end;
+  end
+  else
   begin
     // I2651 - options not matching, case sensitivity, 8.0.309.0
     Result := FirstRunInstallDefaults(

--- a/windows/src/engine/inst/components.wxs
+++ b/windows/src/engine/inst/components.wxs
@@ -237,7 +237,7 @@
       <Component Id="etw" Guid="{2AA8D519-C9B7-4995-9496-D87DD2EF2B7D}">
         <!-- The file id needs to be short to avoid an overflow in the XmlFile table during link time -->
         <File Id="etw" Name="keyman-debug-etw.man" KeyPath="yes" Source="..\keyman32\keyman-debug-etw.man">
-          <util:EventManifest MessageFile="[#keyman32.dll]" ResourceFile="[#keyman32.dll]" />
+          <!-- <util:EventManifest MessageFile="[#keyman32.dll]" ResourceFile="[#keyman32.dll]" /> -->
         </File>
       </Component>
 

--- a/windows/src/engine/inst/components.wxs
+++ b/windows/src/engine/inst/components.wxs
@@ -212,7 +212,7 @@
 
         <RegistryValue KeyPath="yes" Id="registry_win8_keypath" Root="HKLM" Key="Software\Keyman\Keyman Engine" Name="win8 tip install" Value="installed" Type="string" />
 
-        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\CTF\TIP\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\CTF\TIP\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" ForceDeleteOnUninstall="yes">
           <RegistryKey Key="Category">
             <RegistryKey Key="Category">
               <RegistryKey ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" Key="{13A016DF-560B-46CD-947A-4C3AF1E0E35D}\{FE0420F1-38D1-4B4C-96BF-E7E20A74CFB7}" /><!-- TFCAT_TIPCAP_IMMERSIVESUPPORT -->

--- a/windows/src/engine/inst/keymanengine.wxs
+++ b/windows/src/engine/inst/keymanengine.wxs
@@ -83,7 +83,7 @@
       </Directory>
     </Directory>
 
-    <!-- <CustomAction Id="PreUninstallA" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="PreUninstall" />
+    <CustomAction Id="PreUninstallA" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="PreUninstall" />
     <CustomAction Id="EnginePostInstall" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="EnginePostInstall" />
 
     <InstallExecuteSequence>
@@ -91,7 +91,7 @@
       <Custom Action="EnginePostInstall" Before="InstallFinalize"><![CDATA[NOT Installed OR UPGRADINGPRODUCTCODE Or REINSTALL]]></Custom>
     </InstallExecuteSequence>
 
-    <Binary Id="insthelper.dll" SourceFile="..\..\..\bin\engine\insthelper.dll" /> -->
+    <Binary Id="insthelper.dll" SourceFile="..\..\..\bin\engine\insthelper.dll" />
 
   </Module>
 </Wix>

--- a/windows/src/engine/inst/keymanengine.wxs
+++ b/windows/src/engine/inst/keymanengine.wxs
@@ -83,15 +83,15 @@
       </Directory>
     </Directory>
 
-    <!-- <CustomAction Id="PreUninstallA" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="PreUninstall" />
-    <CustomAction Id="EnginePostInstall" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="EnginePostInstall" /> -->
+    <CustomAction Id="PreUninstallA" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="PreUninstall" />
+    <!-- <CustomAction Id="EnginePostInstall" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="EnginePostInstall" /> -->
 
-    <!-- <InstallExecuteSequence>
+    <InstallExecuteSequence>
       <Custom Action="PreUninstallA" After="InstallInitialize"><![CDATA[REMOVE="ALL" And Not REINSTALL And Not UPGRADINGPRODUCTCODE]]></Custom>
-      <Custom Action="EnginePostInstall" Before="InstallFinalize"><![CDATA[NOT Installed OR UPGRADINGPRODUCTCODE Or REINSTALL]]></Custom>
+      <!-- <Custom Action="EnginePostInstall" Before="InstallFinalize"><![CDATA[NOT Installed OR UPGRADINGPRODUCTCODE Or REINSTALL]]></Custom> -->
     </InstallExecuteSequence>
 
-    <Binary Id="insthelper.dll" SourceFile="..\..\..\bin\engine\insthelper.dll" /> -->
+    <Binary Id="insthelper.dll" SourceFile="..\..\..\bin\engine\insthelper.dll" />
 
   </Module>
 </Wix>

--- a/windows/src/engine/inst/keymanengine.wxs
+++ b/windows/src/engine/inst/keymanengine.wxs
@@ -83,7 +83,7 @@
       </Directory>
     </Directory>
 
-    <CustomAction Id="PreUninstallA" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="PreUninstall" />
+    <!-- <CustomAction Id="PreUninstallA" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="PreUninstall" />
     <CustomAction Id="EnginePostInstall" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="EnginePostInstall" />
 
     <InstallExecuteSequence>
@@ -91,7 +91,7 @@
       <Custom Action="EnginePostInstall" Before="InstallFinalize"><![CDATA[NOT Installed OR UPGRADINGPRODUCTCODE Or REINSTALL]]></Custom>
     </InstallExecuteSequence>
 
-    <Binary Id="insthelper.dll" SourceFile="..\..\..\bin\engine\insthelper.dll" />
+    <Binary Id="insthelper.dll" SourceFile="..\..\..\bin\engine\insthelper.dll" /> -->
 
   </Module>
 </Wix>

--- a/windows/src/engine/inst/keymanengine.wxs
+++ b/windows/src/engine/inst/keymanengine.wxs
@@ -83,15 +83,15 @@
       </Directory>
     </Directory>
 
-    <CustomAction Id="PreUninstallA" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="PreUninstall" />
-    <CustomAction Id="EnginePostInstall" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="EnginePostInstall" />
+    <!-- <CustomAction Id="PreUninstallA" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="PreUninstall" />
+    <CustomAction Id="EnginePostInstall" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="EnginePostInstall" /> -->
 
-    <InstallExecuteSequence>
+    <!-- <InstallExecuteSequence>
       <Custom Action="PreUninstallA" After="InstallInitialize"><![CDATA[REMOVE="ALL" And Not REINSTALL And Not UPGRADINGPRODUCTCODE]]></Custom>
       <Custom Action="EnginePostInstall" Before="InstallFinalize"><![CDATA[NOT Installed OR UPGRADINGPRODUCTCODE Or REINSTALL]]></Custom>
     </InstallExecuteSequence>
 
-    <Binary Id="insthelper.dll" SourceFile="..\..\..\bin\engine\insthelper.dll" />
+    <Binary Id="insthelper.dll" SourceFile="..\..\..\bin\engine\insthelper.dll" /> -->
 
   </Module>
 </Wix>

--- a/windows/src/engine/inst/keymanengine.wxs
+++ b/windows/src/engine/inst/keymanengine.wxs
@@ -83,15 +83,15 @@
       </Directory>
     </Directory>
 
-    <CustomAction Id="PreUninstallA" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="PreUninstall" />
+    <!-- <CustomAction Id="PreUninstallA" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="PreUninstall" /> -->
     <!-- <CustomAction Id="EnginePostInstall" Execute="deferred" Impersonate="no" BinaryKey="insthelper.dll" DllEntry="EnginePostInstall" /> -->
 
-    <InstallExecuteSequence>
-      <Custom Action="PreUninstallA" After="InstallInitialize"><![CDATA[REMOVE="ALL" And Not REINSTALL And Not UPGRADINGPRODUCTCODE]]></Custom>
+    <!-- <InstallExecuteSequence> -->
+      <!-- <Custom Action="PreUninstallA" After="InstallInitialize"><![CDATA[REMOVE="ALL" And Not REINSTALL And Not UPGRADINGPRODUCTCODE]]></Custom> -->
       <!-- <Custom Action="EnginePostInstall" Before="InstallFinalize"><![CDATA[NOT Installed OR UPGRADINGPRODUCTCODE Or REINSTALL]]></Custom> -->
-    </InstallExecuteSequence>
+    <!-- </InstallExecuteSequence> -->
 
-    <Binary Id="insthelper.dll" SourceFile="..\..\..\bin\engine\insthelper.dll" />
+    <!-- <Binary Id="insthelper.dll" SourceFile="..\..\..\bin\engine\insthelper.dll" /> -->
 
   </Module>
 </Wix>


### PR DESCRIPTION
This commit should not be merged - it is for diagnostic purposes only
and will build a broken Keyman for Windows install.

Relates-to: #14791
Build-bot: skip release:windows