### PR TITLE
chore(linux): remove no longer needed lintian overrides 🍒 🏠

### DIFF
--- a/linux/debian/source/lintian-overrides
+++ b/linux/debian/source/lintian-overrides
@@ -1,8 +1,0 @@
-# The folders XXX.dist-info/ and XXX.egg-info/ hold metadata for
-# Python modules. Those files are not documentation even though
-# some of their names carry the .txt file extension.
-keyman source: package-contains-documentation-outside-usr-share-doc
-
-# keyman-system-service gets started by dbus, therefore it should not
-# have an [INSTALL] section
-keyman source: systemd-service-file-missing-install-key


### PR DESCRIPTION
It looks like we no longer need these lintian overrides: - `package-contains-documentation-outside-usr-share-doc` got resolved   by excluding these directories from our source package - the other one was a false positive that looks like it got fixed in   Debian

Cherry-pick-of: #14810
Test-bot: skip