### PR TITLE
fix(windows): disable MSI shortcut advertisement

### DIFF
--- a/windows/src/desktop/inst/keymandesktop.wxs
+++ b/windows/src/desktop/inst/keymandesktop.wxs
@@ -50,6 +50,30 @@
       <UpgradeVersion OnlyDetect="yes" Minimum="$(var.KEYMAN_VERSION)" IncludeMinimum="no" Property="NEWERFOUND" />
     </Upgrade>
 
+    <!--
+    MD: 25 Sep 2025
+
+    Change Keyman shortcuts to standard Windows shortcuts, rather than
+    advertised shortcuts, to work around a problem with advertised shortcuts,
+    elevated custom actions, and non-admin users, as described in #14791.
+
+    The problem is related to advertised shortcuts in Windows Installer. When
+    you have an advertised shortcut, the first use of the shortcut triggers a
+    repair to prepare the app for use in the new user's context. And now, with
+    Aug 2025 Windows security patch KB5063878, tweaked in Sep 2025, this
+    triggers an elevation dialog, which the non-admin user cannot work around.
+
+    This means that the shortcuts will be regular Windows shortcut files rather
+    than advertised shortcuts, and are added to
+    `%ProgramData%\Microsoft\Windows\Start Menu\Programs\Keyman for Windows`
+    (so, available for all users on that machine, but will not follow a user
+    across machines).
+
+    * DISABLEADVTSHORTCUTS: https://learn.microsoft.com/en-us/windows/win32/msi/disableadvtshortcuts
+    * Shortcut advertisement: https://learn.microsoft.com/en-us/windows/win32/msi/advertisement
+    -->
+    <Property Id='DISABLEADVTSHORTCUTS' Value='1' />
+
     <Property Id='OLDINSTALLDIR'>
       <RegistrySearch Id='oldinstalldir_search' Key='Software\Keyman\Keyman Desktop' Root='HKLM' Name='root path' Type='raw' />
     </Property>


### PR DESCRIPTION
Change Keyman shortcuts to standard Windows shortcuts, rather than advertised shortcuts, to work around the issue described in #14791.

This PR is an alternate to #14809. The problem is related to [advertised shortcuts](https://learn.microsoft.com/en-us/windows/win32/msi/advertisement) in Windows Installer. When you have an advertised shortcut, the first use of the shortcut triggers a repair to prepare the app for use in the new user's context.

So PR disables advertising of shortcuts with [`DISABLEADVTSHORTCUTS`](https://learn.microsoft.com/en-us/windows/win32/msi/disableadvtshortcuts). This means that the shortcuts will be regular Windows shortcut files rather than advertised shortcuts, and are added to `%ProgramData%\Microsoft\Windows\Start Menu\Programs\Keyman for Windows` (so, available for all users on that machine, but will not follow a user across machines).

I tested this locally on a clean Windows 11 VM, and this appears to resolve the elevation issue for me. I tested both with existing users, and with users added after installation of Keyman. I went through installation, keyboard installation, usage, and finally uninstallation, and as far as I can tell, it all worked correctly.

Regular shortcut files behave somewhat differently to advertised shortcuts, so we will definitely need to do more testing to validate that nothing else is impacted, and that upgrades work without issue.

We need to consider whether using `DISABLEADVTSHORTCUTS` is the right way forward, or using normal shortcuts (which requires additional engineering of the [installer source](https://github.com/keymanapp/keyman/blob/master/windows/src/desktop/inst/keymandesktop.wxs) due to the way Windows Installer handles these).

---

Relates-to: #14809
Fixes: #14791
Build-bot: skip release:windows

# User Testing

This PR changes the way that the Keyman for Windows shortcuts in the Start Menu are created. We need to verify that the shortcuts work correctly in all scenarios.

There are two shortcuts that need checking: Keyman for Windows, and Keyman Configuration.

**TEST_NORMAL_USE:** Verify that the Keyman start menu shortcuts work correctly, both for Administrator who installs/upgrades the app, and for another Windows user who does not have Administrator privileges.

**TEST_UNINSTALL:** Verify that the icons are removed from the Start Menu after uninstalling Keyman.

**TEST_UPGRADE:** Verify that after upgrading from an earlier build of Keyman (without uninstalling), to this build, that the shortcuts are available in the Start Menu and function correctly, both for the Administrator who installs/upgrades the app, and for another Windows user who does not have Administrator privileges.

**TEST_REINSTALL:** Install this build of Keyman as an Administrator and add some keyboards. Verify working correctly. Uninstall Keyman, restart Windows, then reinstall it. Add another different keyboard. Verify that only the new different keyboard is listed, and not the other keyboards from the previous installation.

**TEST_REINSTALL_STANDARD_USER:** Install this build of Keyman as an Administrator. Login as a non-Admin user and add some keyboards (you will need to elevate at keyboard install time; this is okay). Verify working correctly. Log out, log back in to the Administrator account, uninstall Keyman, restart Windows, then reinstall it. Login as the non-Admin user again, and add another different keyboard. Verify that only the new different keyboard is listed, and not the other keyboards from the previous installation.

