### PR TITLE
maint(windows): check code signatures only in CI builds

### DIFF
--- a/resources/build/win/signtime.inc.sh
+++ b/resources/build/win/signtime.inc.sh
@@ -20,10 +20,12 @@ signtime() {
 }
 
 function verify-all-executable-signatures-in-folder() {
-  # ignore return value from sigcheck; we validate the response with verify_signatures
-  # "*" needs to be inside the quotes as it is passed as-is to sigcheck, not as an expansion
-  # note: it seems that sigcheck rejects forward-slash in paths, so cygpath is our friend
-  ("$SIGCHECK" -q -s -e -v -accepteula "$(cygpath -w "$1")\\*" || true) > sig1
-  "$VERIFY_SIGNATURES" -d "$KEYMAN_ROOT/VERSION.md" < sig1
-  rm -f sig1
+  if builder_is_ci_build; then
+    # ignore return value from sigcheck; we validate the response with verify_signatures
+    # "*" needs to be inside the quotes as it is passed as-is to sigcheck, not as an expansion
+    # note: it seems that sigcheck rejects forward-slash in paths, so cygpath is our friend
+    ("$SIGCHECK" -q -s -e -v -accepteula "$(cygpath -w "$1")\\*" || true) > sig1
+    "$VERIFY_SIGNATURES" -d "$KEYMAN_ROOT/VERSION.md" < sig1
+    rm -f sig1
+  fi
 }


### PR DESCRIPTION
When building locally, code signatures will not have SIL in the name, so will fail the build. So skip checking code signatures on local builds.

Build-bot: skip release:windows,developer
Test-bot: skip