### PR TITLE
maint(linux): remove several shellcheck directives

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,5 +1,6 @@
 external-sources=true
 
-# If you get SC1091 for sourced files, add the following setting to
-# your .vscode/settings.json file:
-# "shellcheck.useWorkspaceRootAsCwd": false
+source-path=resources/build/
+source-path=resources/
+source-path=SCRIPTDIR
+source-path=linux/ibus-keyman/tests/scripts/

--- a/docs/settings/linux/settings.json
+++ b/docs/settings/linux/settings.json
@@ -104,9 +104,6 @@
   "C_Cpp.clang_format_fallbackStyle": "Google",
   "bashIde.explainshellEndpoint": "http://localhost:5000",
   "bashIde.highlightParsingErrors": true,
-  "shellcheck.customArgs": [
-    "--external-sources --source-path=resources/build/"
-  ],
   "C_Cpp.errorSquiggles": "EnabledIfIncludesResolve",
-  "shellcheck.useWorkspaceRootAsCwd": false
+  "shellcheck.useWorkspaceRootAsCwd": true
 }

--- a/linux/ibus-keyman/tests/scripts/find-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/find-tests.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 set -eu
-while [ -n "$1" ]; do
-  if [ ! -d "$1" ]; then
+while [[ -n "$1" ]]; do
+  if [[ ! -d "$1" ]]; then
     shift
     continue
   fi
   pushd "$1" > /dev/null
   while IFS= read -r -d '' file; do
-    testname=$(basename "$file" .kmx)
+    testname=$(basename "${file}" .kmx)
     #shellcheck disable=SC2059
-    printf "$(basename "$file")\t${testname#k_}\n"
+    printf "$(basename "${file}")\t${testname#k_}\n"
   done < <(find . -name \*.kmx -print0 | sort -z)
   popd > /dev/null
   exit 0

--- a/linux/ibus-keyman/tests/scripts/run-single-test.sh
+++ b/linux/ibus-keyman/tests/scripts/run-single-test.sh
@@ -2,7 +2,6 @@
 set -eu
 TESTDIR=${XDG_DATA_HOME:-${HOME}/.local/share}/keyman/test_kmx
 
-# shellcheck source=linux/ibus-keyman/tests/scripts/test-helper.inc.sh
 . "$(dirname "$0")"/test-helper.inc.sh
 
 if [[ -v KEYMAN_PKG_BUILD ]]; then

--- a/linux/ibus-keyman/tests/scripts/run-tests.sh
+++ b/linux/ibus-keyman/tests/scripts/run-tests.sh
@@ -3,7 +3,6 @@
 
 set -eu
 
-# shellcheck disable=SC2034
 TOP_SRCDIR=${top_srcdir:-$(realpath "$(dirname "$0")/../..")}
 TESTBASEDIR=${XDG_DATA_HOME:-${HOME}/.local/share}/keyman
 TESTDIR=${TESTBASEDIR}/test_kmx
@@ -11,7 +10,6 @@ CLEANUP_FILE=/tmp/ibus-keyman-test-cleanup
 PID_FILE=/tmp/ibus-keyman-test.pids
 ENV_FILE=/tmp/keyman-env.txt
 
-# shellcheck disable=SC1091
 . "$(dirname "$0")"/test-helper.inc.sh
 
 local_cleanup() {
@@ -69,7 +67,7 @@ function run_tests() {
 
   G_TEST_BUILDDIR="$(dirname "$0")/../../../build/$(arch)/${CONFIG}/tests"
 
-  setup "$DISPLAY_SERVER" "$ENV_FILE" "$CLEANUP_FILE" "$PID_FILE" --standalone
+  setup "${DISPLAY_SERVER}" "${ENV_FILE}" "${CLEANUP_FILE}" "${PID_FILE}" --standalone
 
   if [[ "${DOCKER_RUNNING:-false}" == "true" ]]; then
     echo "# NOTE: When the tests fail check ibus-engine-keyman.log, ibus-daemon.log and km-test-server.log in build/docker-linux/tmp/!"

--- a/resources/docker-images/run.sh
+++ b/resources/docker-images/run.sh
@@ -3,7 +3,6 @@
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-# shellcheck source=resources/build/builder-full.inc.sh
 . "${THIS_SCRIPT%/*}/../../resources/build/builder-full.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 


### PR DESCRIPTION
This change improves our `.shellcheckrc` file so that several directives are no longer needed and source files are still found. Also remove some directives that are no longer necessary, either because the changes to `.shellcheckrc` makes them obsolete, or because the lines changed so that they no longer contain the problem.

Build-bot: skip
Test-bot: skip