### PR TITLE
feat(web): track source input ranges for the edit-boundary source token 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -687,6 +687,11 @@ const prependText = (full: string, current: string) => current + full;
  * the "edit boundary" token.
  */
 interface EdgeEditBoundaryTokenData {
+
+  /**
+   * Indicates the ContextToken sourceRangeKey corresponding to the boundary token.
+   */
+  sourceRangeKey: string;
   /**
    * The text remaining in the token after the edit's deletions are applied,
    * before applying any inserts.
@@ -853,6 +858,7 @@ export function buildEdgeWindow(
       // token, we hit the boundary; note the boundary text.
       if(deleteCnt == 0 && tokenDeleteLength != tokenLen) {
         editBoundary = {
+          sourceRangeKey: currentTokens[i].sourceRangeKey,
           text: applyAtFront ? KMWString.substring(token, tokenDeleteLength) : KMWString.substring(token, 0, tokenLen - tokenDeleteLength),
           tokenIndex: i,
           isPartial: tokenDeleteLength != 0 || tokenIsPartial
@@ -865,6 +871,7 @@ export function buildEdgeWindow(
       // if totalDeletes = 0, ensure we still construct an editBoundaryToken.
       if(!editBoundary) {
         editBoundary = {
+          sourceRangeKey: currentTokens[i].sourceRangeKey,
           text: token,
           tokenIndex: i,
           isPartial: tokenIsPartial
@@ -879,6 +886,7 @@ export function buildEdgeWindow(
   // for such cases.
   if(!editBoundary) {
     editBoundary = {
+      sourceRangeKey: currentTokens[0].sourceRangeKey,
       text: '',
       tokenIndex: i - directionSign,
       isPartial: true
@@ -889,8 +897,10 @@ export function buildEdgeWindow(
   // be editing the token one index further.
   let shouldOmitEmptyToken = editBoundary.tokenIndex != 0 && editBoundary.tokenIndex == currentTokens.length - 1 && editBoundary.text == '';
   if(shouldOmitEmptyToken) {
+    const effectiveTail = currentTokens[editBoundary.tokenIndex-1];
     editBoundary = {
-      text: currentTokens[editBoundary.tokenIndex-1].exampleInput,
+      sourceRangeKey: effectiveTail.sourceRangeKey,
+      text: effectiveTail.exampleInput,
       tokenIndex: editBoundary.tokenIndex + directionSign,
       isPartial: true
     }

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -30,6 +30,17 @@ function toToken(text: string) {
   return token;
 }
 
+let TOKEN_TRANSFORM_SEED = 0;
+function toTransformToken(text: string, transformId?: number) {
+  let idSeed = transformId === undefined ? TOKEN_TRANSFORM_SEED++ : transformId;
+  let isWhitespace = text == ' ';
+  let token = new ContextToken(plainModel);
+  const textAsTransform = { insert: text, deleteLeft: 0, id: idSeed };
+  token.addInput({trueTransform: textAsTransform, inputStartIndex: 0}, [ { sample: textAsTransform, p: 1 } ]);
+  token.isWhitespace = isWhitespace;
+  return token;
+}
+
 // https://www.compart.com/en/unicode/block/U+1D400
 const mathBoldUpperA = 0x1D400; // Mathematical Bold Capital A
 const mathBoldLowerA = 0x1D41A; //                   Small   A
@@ -669,7 +680,8 @@ describe('ContextTokenization', function() {
 
       it('handles empty contexts', () => {
         const baseTokens = [''];
-        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+        const idSeed = TOKEN_TRANSFORM_SEED;
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
         const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 0 }, true, editWindowSpec);
         assert.deepEqual(results, {
@@ -678,7 +690,8 @@ describe('ContextTokenization', function() {
             isPartial: false,
             omitsEmptyToken: false,
             text: '',
-            tokenIndex: 0
+            tokenIndex: 0,
+            sourceRangeKey: `T${idSeed}`
           },
           deleteLengths: [0],
           sliceIndex: 1
@@ -687,7 +700,8 @@ describe('ContextTokenization', function() {
 
       it('handles empty contexts and invalid Transforms', () => {
         const baseTokens = [''];
-        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+        const idSeed = TOKEN_TRANSFORM_SEED;
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
         const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 2 }, true, editWindowSpec);
         assert.deepEqual(results, {
@@ -696,7 +710,8 @@ describe('ContextTokenization', function() {
             isPartial: true,
             omitsEmptyToken: false,
             text: '',
-            tokenIndex: 0
+            tokenIndex: 0,
+            sourceRangeKey: `T${idSeed}`
           },
           deleteLengths: [0],
           sliceIndex: 1
@@ -705,7 +720,8 @@ describe('ContextTokenization', function() {
 
       it('builds edge windows for the start of context with no edits', () => {
         const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'];
-        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+        const idSeed = TOKEN_TRANSFORM_SEED;
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
         const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 0 }, true, editWindowSpec);
         assert.deepEqual(results, {
@@ -714,7 +730,8 @@ describe('ContextTokenization', function() {
             isPartial: false,
             omitsEmptyToken: false,
             text: 'an',
-            tokenIndex: 0
+            tokenIndex: 0,
+            sourceRangeKey: `T${idSeed + 0}`
           },
           deleteLengths: [0],
           sliceIndex: 3
@@ -732,7 +749,9 @@ describe('ContextTokenization', function() {
             isPartial: false,
             omitsEmptyToken: false,
             text: toMathematicalSMP('an'),
-            tokenIndex: 0
+            tokenIndex: 0,
+            // We'll not worry about matching a specific value for `sourceRangeKey`.
+            sourceRangeKey: results.editBoundary.sourceRangeKey
           },
           deleteLengths: [0],
           sliceIndex: 3
@@ -741,7 +760,8 @@ describe('ContextTokenization', function() {
 
       it('builds edge windows for the start of context with deletion edits (1)', () => {
         const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'];
-        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+        const idSeed = TOKEN_TRANSFORM_SEED;
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
         const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 2 }, true, editWindowSpec);
         assert.deepEqual(results, {
@@ -750,7 +770,8 @@ describe('ContextTokenization', function() {
             isPartial: false,
             omitsEmptyToken: false,
             text: ' ',
-            tokenIndex: 1
+            tokenIndex: 1,
+            sourceRangeKey: `T${idSeed + 1}`
           },
           deleteLengths: [2, 0],
           sliceIndex: 5
@@ -768,7 +789,9 @@ describe('ContextTokenization', function() {
             isPartial: false,
             omitsEmptyToken: false,
             text: ' ',
-            tokenIndex: 1
+            tokenIndex: 1,
+            // We'll not worry about matching a specific value for `sourceRangeKey`.
+            sourceRangeKey: results.editBoundary.sourceRangeKey
           },
           deleteLengths: [2, 0],
           sliceIndex: 5
@@ -777,7 +800,8 @@ describe('ContextTokenization', function() {
 
       it('builds edge windows for the start of context with deletion edits (2)', () => {
         const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'];
-        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+        const idSeed = TOKEN_TRANSFORM_SEED;
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
         const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 4 }, true, editWindowSpec);
         assert.deepEqual(results, {
@@ -786,7 +810,8 @@ describe('ContextTokenization', function() {
             isPartial: true,
             omitsEmptyToken: false,
             text: 'pple',
-            tokenIndex: 2
+            tokenIndex: 2,
+            sourceRangeKey: `T${idSeed + 2}`
           },
           deleteLengths: [2, 1, 1],
           sliceIndex: 7
@@ -795,7 +820,8 @@ describe('ContextTokenization', function() {
 
       it('builds edge windows for the end of context with no edits', () => {
         const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day'];
-        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+        const idSeed = TOKEN_TRANSFORM_SEED;
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
         baseTokenization.tail.isPartial = true;
 
         const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 0 }, false, editWindowSpec);
@@ -805,7 +831,8 @@ describe('ContextTokenization', function() {
             isPartial: true,
             omitsEmptyToken: false,
             text: 'day',
-            tokenIndex: 6
+            tokenIndex: 6,
+            sourceRangeKey: `T${idSeed + 6}`
           },
           deleteLengths: [0],
           sliceIndex: 2
@@ -814,7 +841,8 @@ describe('ContextTokenization', function() {
 
       it('builds edge windows for the end of context with no edits, trailing whitespace', () => {
         const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day', ' ', ''];
-        const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+        const idSeed = TOKEN_TRANSFORM_SEED;
+        const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
         const results = buildEdgeWindow(baseTokenization.tokens, { insert: '', deleteLeft: 0, deleteRight: 0 }, false, editWindowSpec);
         assert.deepEqual(results, {
@@ -823,7 +851,8 @@ describe('ContextTokenization', function() {
             isPartial: true,
             omitsEmptyToken: true,
             text: ' ',
-            tokenIndex: 7
+            tokenIndex: 7,
+            sourceRangeKey: `T${idSeed + 7}`
           },
           deleteLengths: [0],
           sliceIndex: 2
@@ -1032,7 +1061,9 @@ describe('ContextTokenization', function() {
           text: 'da',
           tokenIndex: 6,
           isPartial: true,
-          omitsEmptyToken: false
+          omitsEmptyToken: false,
+          // We'll not worry about matching a specific value for `sourceRangeKey`.
+          sourceRangeKey: results.alignment.edgeWindow.editBoundary.sourceRangeKey
         },
         deleteLengths: [2],
         sliceIndex: 2
@@ -1067,7 +1098,9 @@ describe('ContextTokenization', function() {
           text: toMathematicalSMP('da'),
           tokenIndex: 6,
           isPartial: true,
-          omitsEmptyToken: false
+          omitsEmptyToken: false,
+          // We'll not worry about matching a specific value for `sourceRangeKey`.
+          sourceRangeKey: results.alignment.edgeWindow.editBoundary.sourceRangeKey
         },
         deleteLengths: [2],
         sliceIndex: 2
@@ -1242,7 +1275,9 @@ describe('ContextTokenization', function() {
           text: 'da',
           tokenIndex: 6,
           isPartial: true,
-          omitsEmptyToken: false
+          omitsEmptyToken: false,
+          // We'll not worry about matching a specific value for `sourceRangeKey`.
+          sourceRangeKey: results.alignment.edgeWindow.editBoundary.sourceRangeKey
         },
         deleteLengths: [1],
         sliceIndex: 2
@@ -1283,7 +1318,9 @@ describe('ContextTokenization', function() {
           text: toMathematicalSMP('da'),
           tokenIndex: 6,
           isPartial: true,
-          omitsEmptyToken: false
+          omitsEmptyToken: false,
+          // We'll not worry about matching a specific value for `sourceRangeKey`.
+          sourceRangeKey: results.alignment.edgeWindow.editBoundary.sourceRangeKey
         },
         deleteLengths: [1],
         sliceIndex: 2
@@ -1456,7 +1493,8 @@ describe('ContextTokenization', function() {
 
     it('returns the standard edge window for empty transform inputs', () => {
       const baseTokens = ['quick', ' ', 'brown', ' ', 'fox'];
-      const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+      const idSeed = TOKEN_TRANSFORM_SEED;
+      const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
       const editTransform = {
         insert: '',
@@ -1479,7 +1517,8 @@ describe('ContextTokenization', function() {
           isPartial: false,
           omitsEmptyToken: false,
           text: 'fox',
-          tokenIndex: 4
+          tokenIndex: 4,
+          sourceRangeKey: `T${idSeed + 4}`
         },
         deleteLengths: [0],
         sliceIndex: 2
@@ -1488,7 +1527,8 @@ describe('ContextTokenization', function() {
 
     it('returns the standard edge window for empty transforms with context-final whitespace', () => {
       const baseTokens = ['quick', ' ', 'brown', ' ', 'fox', ' '];
-      const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+      const idSeed = TOKEN_TRANSFORM_SEED;
+      const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
       const editTransform = {
         insert: '',
@@ -1511,7 +1551,8 @@ describe('ContextTokenization', function() {
           isPartial: false,
           omitsEmptyToken: false,
           text: ' ',
-          tokenIndex: 5
+          tokenIndex: 5,
+          sourceRangeKey: `T${idSeed + 5}`
         },
         deleteLengths: [0],
         sliceIndex: 2
@@ -1521,7 +1562,8 @@ describe('ContextTokenization', function() {
 
     it('returns the standard edge window for pure transform w insert inputs', () => {
       const baseTokens = ['quick', ' ', 'brown', ' ', 'fox'];
-      const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+        const idSeed = TOKEN_TRANSFORM_SEED;
+      const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
       const editTransform = {
         insert: ' jumped',
@@ -1544,7 +1586,8 @@ describe('ContextTokenization', function() {
           isPartial: false,
           omitsEmptyToken: false,
           text: 'fox',
-          tokenIndex: 4
+          tokenIndex: 4,
+          sourceRangeKey: `T${idSeed + 4}`
         },
         deleteLengths: [0],
         sliceIndex: 2
@@ -1553,7 +1596,8 @@ describe('ContextTokenization', function() {
 
     it('returns the proper edge window for transforms w deleteLeft inputs (1)', () => {
       const baseTokens = ['quick', ' ', 'brown', ' ', 'fox'];
-      const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+      const idSeed = TOKEN_TRANSFORM_SEED;
+      const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
       const editTransform = {
         insert: 'rog',
@@ -1576,7 +1620,9 @@ describe('ContextTokenization', function() {
           isPartial: true,
           omitsEmptyToken: false,
           text: 'f',
-          tokenIndex: 4
+          tokenIndex: 4,
+          // not yet altered by deleteLeft bits or the newly-incoming transform
+          sourceRangeKey: `T${idSeed + 4}`
         },
         deleteLengths: [2],
         sliceIndex: 1
@@ -1585,7 +1631,8 @@ describe('ContextTokenization', function() {
 
     it('returns the proper edge window for transforms w deleteLeft inputs (2)', () => {
       const baseTokens = ['quick', ' ', 'brown', ' ', 'fox'];
-      const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)), null);
+      const idSeed = TOKEN_TRANSFORM_SEED;
+      const baseTokenization = new ContextTokenization(baseTokens.map(t => toTransformToken(t)), null);
 
       const editTransform = {
         insert: 'fox and brown fox',  // => quick fox and brown fox
@@ -1608,7 +1655,8 @@ describe('ContextTokenization', function() {
           isPartial: false,
           omitsEmptyToken: false,
           text: ' ',
-          tokenIndex: 1
+          tokenIndex: 1,
+          sourceRangeKey: `T${idSeed + 1}`
         },
         deleteLengths: [3, 1, 5, 0],
         sliceIndex: 0


### PR DESCRIPTION
Once we start supporting multiple tokenization paths, a very important question arises - are there scenarios in which we can safely treat tokenization paths identically?  After a significant amount of brainstorming, I have come to the conclusion that yes, there are such cases.  The main requirement:
- The _current_ (i.e. "last") token in both versions of the context (and tokenization) started due to the same keystroke.  
    - In particular, it started at the same index within that keystroke's `Transform.insert` string.
    - Note the implication - all inputs _since_ that keystroke are also part of the token.  The two versions thus were created from the same keystrokes and are safe to correct to each other.
        - However, if they did not start at the same position within the initial keystroke's `insert` string, they're _not_ safe to correct to each other - one version is missing part of the inputs.
        - Note that the two versions of the initial keystroke's distribution are no longer inherently compatible.  If one starts at index 0 within `insert` but the other at index 1... what happens with all the inputs that only had an `insert` a single codepoint long?

The tokenizations _leading up_ to the start of the "current" token may be different, but once two paths converge on the _same_ token, starting at the same position, they're then safe to treat as "the same" tokenization for operations on that token.  As a result, it is very important to recognize and remember when each context token was first created.  

This gets even more fun once deletions come into play - it could be possible to return to a prior token and add new keystroke data to it after a delay.  For such cases, it matters _when_ we resumed editing that token - again, we care about the exact set of keystrokes that contributed data to the token - even if there's technically a gap!

Build-bot: skip build:web
Test-bot: skip