### PR TITLE
fix(common): registry clean-up enabled, no terminal in github action

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -38,7 +38,7 @@ jobs:
         id: cleanup-ghcr
         uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
-          dry-run: true
+          dry-run: false
           expand-packages: true
           packages: keyman-*-ci
           delete-untagged: true

--- a/resources/docker-images/docker-build.inc.sh
+++ b/resources/docker-images/docker-build.inc.sh
@@ -87,7 +87,7 @@ setup_docker() {
   if [[ "${MSYSTEM:-}" == "MINGW64" ]]; then
     DOCKER_RUN_ARGS+=(--env DOCKER_RUN_AS_ROOT=1)
   fi
-  if [[ -z ${DOCKER_RUNNING:-} ]] ; then
+  if ! builder_is_running_on_gha ; then
     DOCKER_RUN_ARGS+=(-t)
   fi
 }


### PR DESCRIPTION
No longer dryrun for the registry clean-up GHA workflow
docker run doesn't use a terminal in GHA (erasing -t flag)

Test-bot: skip
Build-bot: skip