### PR TITLE
fix(android): Fix bottom insets for Sample and FirstVoices apps

### DIFF
--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -184,12 +184,14 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
     Point size = KMManager.getWindowSize(getApplicationContext());
 
     int inputViewHeight = 0;
-    if (inputView != null)
+    if (inputView != null) {
       inputViewHeight = inputView.getHeight();
+    }
 
+    int navigationHeight = KMManager.getNavigationBarHeight(this);
     int bannerHeight = KMManager.getBannerHeight(this);
     int kbHeight = KMManager.getKeyboardHeight(this);
-    outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight;
+    outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight - navigationHeight;
     outInsets.visibleTopInsets = outInsets.contentTopInsets;
     outInsets.touchableInsets = InputMethodService.Insets.TOUCHABLE_INSETS_REGION;
     outInsets.touchableRegion.set(0, outInsets.contentTopInsets, size.x, size.y);

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -203,12 +203,14 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
         Point size = KMManager.getWindowSize(getApplicationContext());
 
         int inputViewHeight = 0;
-        if (inputView != null)
+        if (inputView != null) {
             inputViewHeight = inputView.getHeight();
+        }
 
+        int navigationHeight = KMManager.getNavigationBarHeight(this);
         int bannerHeight = KMManager.getBannerHeight(this);
         int kbHeight = KMManager.getKeyboardHeight(this);
-        outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight;
+        outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight - navigationHeight;
         outInsets.visibleTopInsets = outInsets.contentTopInsets;
         outInsets.touchableInsets = Insets.TOUCHABLE_INSETS_REGION;
         outInsets.touchableRegion.set(0, outInsets.contentTopInsets, size.x, size.y);


### PR DESCRIPTION
Relates to #14794 and follows #14808

This updates KMSample2 and FirstVoices for Android system keyboards to account for padding and offsets due to navigation bar height.

## User Testing

**Setup** - Install the PR build as directed on an Android emulator /device of Android API 35. In device settings --> display --> set navigation to use 3 buttons

* **TEST_KMSAMPLE2** - Verifies KMSample2 system keyboard is not obscured
1. Install the PR build of KMSample2
2. Launch KMSample2 and follow the menus to set KMSample2 as the default system keyboard
3. Launch Chrome app and select a text area
4. With KMSample2 as the system keyboard, verify the keyboard functions:
  a. base keys
  b. longpress keys
  c. suggestion banner

* **TEST_FV** - Verifies FirstVoices system keyboard is not obscured
1. Install the PR build of FirstVoices for Android
2. Launch FirstVoices app
3. Follow the menu to install keyboard --> Region --> BC Coast --> Sencoten
4. Exit back to the FirstVoices main screen
5. Continue with setup to enable FirstVoices as the default system keyboard
6. Launch Chrome app and select text area
7. with the Sencoten system keyboard, verify it functions:
  a. base keys
  b. longpress keys
  c. suggestion banner
  
