### PR TITLE
fix(windows): disable .msi shortcut advertisement 🍒 🏠

### DIFF
--- a/windows/src/desktop/inst/keymandesktop.wxs
+++ b/windows/src/desktop/inst/keymandesktop.wxs
@@ -50,6 +50,30 @@
       <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VERSION)" IncludeMinimum="no" Property="NEWERFOUND" />
     </Upgrade>
 
+    <!--
+    MD: 25 Sep 2025
+
+    Change Keyman shortcuts to standard Windows shortcuts, rather than
+    advertised shortcuts, to work around a problem with advertised shortcuts,
+    elevated custom actions, and non-admin users, as described in #14791.
+
+    The problem is related to advertised shortcuts in Windows Installer. When
+    you have an advertised shortcut, the first use of the shortcut triggers a
+    repair to prepare the app for use in the new user's context. And now, with
+    Aug 2025 Windows security patch KB5063878, tweaked in Sep 2025, this
+    triggers an elevation dialog, which the non-admin user cannot work around.
+
+    This means that the shortcuts will be regular Windows shortcut files rather
+    than advertised shortcuts, and are added to
+    `%ProgramData%\Microsoft\Windows\Start Menu\Programs\Keyman for Windows`
+    (so, available for all users on that machine, but will not follow a user
+    across machines).
+
+    * DISABLEADVTSHORTCUTS: https://learn.microsoft.com/en-us/windows/win32/msi/disableadvtshortcuts
+    * Shortcut advertisement: https://learn.microsoft.com/en-us/windows/win32/msi/advertisement
+    -->
+    <Property Id='DISABLEADVTSHORTCUTS' Value='1' />
+
     <Property Id='OLDINSTALLDIR'>
       <RegistrySearch Id='oldinstalldir_search' Key='Software\Keyman\Keyman Desktop' Root='HKLM' Name='root path' Type='raw' />
     </Property>


### PR DESCRIPTION
Change Keyman shortcuts to standard Windows shortcuts, rather than advertised shortcuts, to work around a problem with advertised shortcuts, elevated custom actions, and non-admin users, as described in #14791.

The problem is related to advertised shortcuts in Windows Installer. When you have an advertised shortcut, the first use of the shortcut triggers a repair to prepare the app for use in the new user's context. And now, with Aug 2025 Windows security patch KB5063878, tweaked in Sep 2025, this triggers an elevation dialog, which the non-admin user cannot work around.

This means that the shortcuts will be regular Windows shortcut files rather than advertised shortcuts, and are added to `%ProgramData%\Microsoft\Windows\Start Menu\Programs\Keyman for Windows` (so, available for all users on that machine, but will not follow a user across machines).

* DISABLEADVTSHORTCUTS: https://learn.microsoft.com/en-us/windows/win32/msi/disableadvtshortcuts
* Shortcut advertisement: https://learn.microsoft.com/en-us/windows/win32/msi/advertisement

Relates-to: #14809
Fixes: #14791
Cherry-pick-of: #14814
Build-bot: skip release:windows
Test-bot: skip