### PR TITLE
docs(android): Document getNavigationBarHeight API

### DIFF
--- a/android/docs/engine/KMManager/getNavigationBarHeight.md
+++ b/android/docs/engine/KMManager/getNavigationBarHeight.md
@@ -1,0 +1,42 @@
+---
+title: KMManager.getNavigationBarHeight()
+---
+
+## Summary
+
+The **`getNavigationBarHeight()`** method returns the height of the navigation bar.
+
+## Syntax
+
+``` javascript
+KMManager.getNavigationBarHeight(Context context)
+```
+
+### Parameters
+
+`context`
+:   The context.
+
+### Returns
+
+Returns the height of the navigation bar in pixels.
+
+## Description
+
+Use this method to get the height of the navigation bar. The keyboard offsets must account for this height below the keyboard.
+
+## Examples
+
+### Example: Using `getNavigationBarHeight()`
+
+The following script illustrate the use of `getNavigationBarHeight()`:
+
+``` javascript
+    int navigationHeight = KMManager.getNavigationBarHeight(this);
+
+```
+
+## See Also
+
+-   [`getBannerHeight()`](getBannerHeight)
+-   [`getKeyboardHeight()`](getKeyboardHeight)

--- a/android/docs/engine/KMManager/index.md
+++ b/android/docs/engine/KMManager/index.md
@@ -149,6 +149,9 @@ The KMManager is the core class which provides most of the methods and constants
 [`getMaySendCrashReport()`](getMaySendCrashReport)
 : returns whether Keyman Engine is allowed to send crash reports over the network to Sentry
 
+[`getNavigationBarHeight()`](getNavigationBarHeight)
+: returns the height of the navigation bar system inset
+
 [`getOrientation()`](getOrientation)
 : returns the device's current orientation (Portrait vs Landscape)
 


### PR DESCRIPTION

Documents the `KMManager.getNavigationBarHeight()` API call added in #14808 to offset the Keyman keyboard for the navigation bar height.

Test-bot: skip
