### PR TITLE
chore(web): disable DOM tests for webkit on Windows 🎼

### DIFF
--- a/web/src/test/auto/dom/cases/core-processor/basic.tests.ts
+++ b/web/src/test/auto/dom/cases/core-processor/basic.tests.ts
@@ -5,6 +5,8 @@ const coreurl = '/build/engine/core-processor/obj/import/core';
 
 // Test the CoreProcessor interface.
 describe('CoreProcessor', function () {
+  this.timeout(5000); // increased timeout for async loading
+
   async function loadKeyboardBlob(uri: string) {
     const response = await fetch(uri);
     if (!response.ok) {
@@ -16,7 +18,8 @@ describe('CoreProcessor', function () {
   }
 
   it('can initialize without errors', async function () {
-    assert.isOk(await KM_Core.createCoreProcessor(coreurl));
+    const km_core = await KM_Core.createCoreProcessor(coreurl);
+    assert.isNotNull(km_core);
   });
 
   it('can call temp function', async function () {

--- a/web/src/test/auto/dom/web-test-runner.config.mjs
+++ b/web/src/test/auto/dom/web-test-runner.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { devices, playwrightLauncher } from '@web/test-runner-playwright';
+import { /*devices,*/ playwrightLauncher } from '@web/test-runner-playwright';
 import { defaultReporter, summaryReporter } from '@web/test-runner';
 import { LauncherWrapper, sessionStabilityReporter } from '@keymanapp/common-test-resources/test-runner-stability-reporter.mjs';
 import named from '@keymanapp/common-test-resources/test-runner-rename-browser.mjs'
@@ -7,14 +7,17 @@ import { importMapsPlugin } from '@web/dev-server-import-maps';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { esbuildPlugin } from '@web/dev-server-esbuild';
+import { platform } from 'node:process';
 
 const dir = dirname(fileURLToPath(import.meta.url));
 const KEYMAN_ROOT = resolve(dir, '../../../../../');
 
-/** @type {import('@web/test-runner').TestRunnerConfig} */
-export default {
-  // debug: true,
-  browsers: [
+const allBrowsers = platform === 'win32'
+  ? [
+    new LauncherWrapper(playwrightLauncher({ product: 'chromium' })),
+    new LauncherWrapper(playwrightLauncher({ product: 'firefox' })),
+    // no testing on webkit on Windows, see #14858
+  ] : [
     new LauncherWrapper(playwrightLauncher({ product: 'chromium' })),
     new LauncherWrapper(playwrightLauncher({ product: 'firefox' })),
     new LauncherWrapper(playwrightLauncher({ product: 'webkit', concurrency: 1 })),
@@ -28,7 +31,12 @@ export default {
     //     return browser.newContext({ ...devices['Pixel 4'] })
     //   }
     // })), 'Android Phone (emulated)'),
-  ],
+  ];
+
+/** @type {import('@web/test-runner').TestRunnerConfig} */
+export default {
+  // debug: true,
+  browsers: allBrowsers,
   concurrency: 10,
   nodeResolve: true,
   // Top-level, implicit 'default' group

--- a/web/src/test/auto/integrated/web-test-runner.config.mjs
+++ b/web/src/test/auto/integrated/web-test-runner.config.mjs
@@ -1,26 +1,34 @@
 // @ts-check
-import { devices, playwrightLauncher } from '@web/test-runner-playwright';
+import { /*devices,*/ playwrightLauncher } from '@web/test-runner-playwright';
 import { defaultReporter, summaryReporter } from '@web/test-runner';
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { importMapsPlugin } from '@web/dev-server-import-maps';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { LauncherWrapper, sessionStabilityReporter } from '@keymanapp/common-test-resources/test-runner-stability-reporter.mjs';
+import { platform } from 'node:process';
 
 const dir = dirname(fileURLToPath(import.meta.url));
 const KEYMAN_ROOT = resolve(dir, '../../../../../');
 
-/** @type {import('@web/test-runner').TestRunnerConfig} */
-export default {
-  browsers: [
+const allBrowsers = platform === 'win32'
+  ? [
+    new LauncherWrapper(playwrightLauncher({ product: 'chromium' })),
+    new LauncherWrapper(playwrightLauncher({ product: 'firefox' })),
+    // no testing on webkit on Windows, see #14858
+  ] : [
     new LauncherWrapper(playwrightLauncher({ product: 'chromium' })),
     new LauncherWrapper(playwrightLauncher({ product: 'firefox' })),
     // Setting it higher makes things faster... but Webkit experiences stability
     // issues for some of the tests if this is set higher than 1.  Notably,
     // engine.tests.mjs, events.tests.mjs, and text_selection.tests.mjs.  All the
     // text-simulation ones.
-    new LauncherWrapper(playwrightLauncher({ product: 'webkit', concurrency: 1}))
-  ],
+    new LauncherWrapper(playwrightLauncher({ product: 'webkit', concurrency: 1 })),
+  ];
+
+/** @type {import('@web/test-runner').TestRunnerConfig} */
+export default {
+  browsers: allBrowsers,
   concurrency: 10,
   nodeResolve: true,
   files: [


### PR DESCRIPTION
Webkit on Windows doesn't support WASM, so several tests fail. This change disables the webkit tests when running on Windows.

Fixes: #14859
Test-bot: skip