### PR TITLE
fix(android): Convert longpress delay menu to ConstraintLayout

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustLongpressDelayActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/AdjustLongpressDelayActivity.java
@@ -57,6 +57,10 @@ public class AdjustLongpressDelayActivity extends BaseActivity {
     final Context context = this;
 
     setContentView(R.layout.activity_adjust_longpress_delay);
+
+    setupEdgeToEdge(R.id.adjust_longpress_layout);
+    setupStatusBarColors(R.color.keyman_blue, android.R.color.white);
+
     Toolbar toolbar = (Toolbar) findViewById(R.id.titlebar);
     setSupportActionBar(toolbar);
     ActionBar actionBar = getSupportActionBar();

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_adjust_longpress_delay.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_adjust_longpress_delay.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/adjust_longpress_layout"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <include layout="@layout/titlebar" />
 
@@ -13,7 +16,8 @@
         android:gravity="center"
         android:orientation="horizontal"
         android:paddingBottom="25dp"
-        android:paddingTop="60dp" >
+        android:paddingTop="60dp"
+        app:layout_constraintTop_toBottomOf="@id/titlebar" >
 
         <ImageButton
             android:id="@+id/delayTimeDownButton"
@@ -56,6 +60,6 @@
         android:layout_marginStart="@dimen/activity_horizontal_margin"
         android:text="@string/longpress_delay_time"
         android:textSize="@dimen/longpress_delay_label_textsize"
-        />
+        app:layout_constraintTop_toBottomOf="@id/linearLayout" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #14887 

The "Adjust longpress delay" menu got missed in #14463 in converting Activities from `RelativeLayout` to `ConstraintLayout` to handle Android's edge-to-edge behavior. The activity also needed the `setupEdgeToEdge()` call.

## Screenshot with change

<img width="271" height="230" alt="Screenshot_20251007_142851" src="https://github.com/user-attachments/assets/a4a6c054-b0bc-4322-9c23-f5813a8cd664" />


## User Testing

**Setup** - Install the PR build of Keyman for Android on emulator/device with a camera notch (e.g. Pixel 8+)

* **TEST_ADJUST_LONGPRESS_MENU** - verifies Adjust "Longpress Delay menu" not impacted by camera notch
1. Launch Keyman for Android in portrait orientation and dismiss the "Get Started" menu
2. From Keyman settings --> Adjust longpress delay
3. Verify on the "Adjust Longpress Delay" menu:
  a. status icons appear above the title bar
  a. title bar not covered by the camera notch
  c. the Longpress delay time can be adjusted



