### PR TITLE
fix(linux): replace `dbus-x11` dependency 🍒 🏠

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,10 @@
+keyman (18.0.242-2) UNRELEASED; urgency=medium
+
+  * replace dbus-x11 dependency with default-dbus-session-bus | dbus-session-bus
+    (closes: 1117068)
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 06 Oct 2025 16:45:18 +0200
+
 keyman (18.0.242-1) unstable; urgency=medium
 
   * New upstream release.

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -86,7 +86,7 @@ Package: python3-keyman-config
 Section: python
 Architecture: all
 Depends:
- dbus-x11,
+ default-dbus-session-bus | dbus-session-bus,
  dconf-cli,
  gir1.2-webkit2-4.1 | gir1.2-webkit2-4.0,
  keyman-engine,

--- a/linux/keyman-config/keyman_config/__init__.py
+++ b/linux/keyman-config/keyman_config/__init__.py
@@ -1,4 +1,5 @@
 import atexit
+import dbus
 import gettext
 import importlib
 import logging
@@ -110,7 +111,16 @@ def _set_dbus_started_for_session(value):
 
 
 def verify_dbus_running():
-    if not 'DBUS_SESSION_BUS_ADDRESS' in os.environ:
+    if 'DBUS_SESSION_BUS_ADDRESS' in os.environ:
+        # already running - nothing to do
+        return
+
+    try:
+        # This might already be enough to start dbus
+        bus = dbus.SessionBus()
+        bus.close()
+        return
+    except dbus.exceptions.DBusException:
         try:
             # Seems dbus isn't running for the current user. Try to start it
             # and set these environment variables

--- a/linux/keyman-config/keyman_config/gsettings.py
+++ b/linux/keyman-config/keyman_config/gsettings.py
@@ -71,7 +71,6 @@ class GSettings():
     def get(self, key):
         if self.is_sudo:
             args = ['sudo', '-H', '-u', os.environ.get('SUDO_USER'),
-                    f"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{os.environ.get('SUDO_UID')}/bus",
                     'gsettings', 'get', self.schema_id, key]
             if sys.version_info.major <= 3 and sys.version_info.minor < 7:
                 # capture_output got added in Python 3.7
@@ -124,7 +123,6 @@ class GSettings():
             variant = str(value)
             subprocess.run(
               ['sudo', '-H', '-u', os.environ.get('SUDO_USER'),
-               f"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{os.environ.get('SUDO_UID')}/bus",
                'gsettings', 'set', self.schema_id, key, variant], check=False)
         elif get_dbus_started_for_session():
             self._set_key_file(key, value, type_string)


### PR DESCRIPTION
When using a different DBus implementation `dbus-launch` might not exist, but instantiating a `SessionBus` object might start a session dbus if it's not already running. This change also replaces the `dbus-x11` dependency with `default-dbus-session-bus | dbus-session-bus` and changes the way we detect if dbus is already running.

Also remove `DBUS_SESSION_BUS_ADDRESS` from `sudo gsettings` call. It turns out we don't need this since we execute the `gsettings` command in the context of the user anyway which connects to the user's session dbus.

Cherry-pick-of: #14895
Fixes: #14888
Test-bot: skip