### PR TITLE
tests are running with user root in the Docker container

### DIFF
--- a/resources/docker-images/base/Dockerfile
+++ b/resources/docker-images/base/Dockerfile
@@ -38,12 +38,12 @@ RUN echo "build ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN <<EOF cat > /usr/bin/bashwrapper
 #!/bin/bash
 set -eu
-if [[ "${DOCKER_RUN_AS_ROOT:-}" == "1" ]] && [[ "$(id -u)" != "0" ]] ; then
+if [[ "\${DOCKER_RUN_AS_ROOT:-}" == "1" ]] && [[ "\$(id -u)" != "0" ]] ; then
   # On Windows run as root so that the permissions are correct
   # (root in Docker container is mapped to current user on Windows,
   # whereas when Docker is run on Linux root is mapped to root)
-  sudo -u root -i "$0" "$@"
-  exit $?
+  sudo -u root -i "\$0" "\$@"
+  exit \$?
 fi
 
 export KEYMAN_USE_NVM=1

--- a/resources/docker-images/build.sh
+++ b/resources/docker-images/build.sh
@@ -87,7 +87,7 @@ test_action() {
 
   builder_echo debug "Testing image for ${platform}"
   ./run.sh --distro "${DISTRO}" --distro-version "${DISTRO_VERSION}" \
-    ":${platform}"  "${registry_parameters:-}" -- ./build.sh configure,build,test:"${platform}"
+    ":${platform}"  "${registry_parameters:-}" -- /home/build/build/build.sh configure,build,test:"${platform}"
 }
 
 check_buildx_available

--- a/resources/docker-images/run.sh
+++ b/resources/docker-images/run.sh
@@ -35,6 +35,11 @@ convert_parameters_to_args
 setup_docker
 setup_container_registry
 
+if [[ ! ${DOCKER_RUN_ARGS[*]} =~ "DOCKER_RUN_AS_ROOT=1" ]]; then
+  echo "Runnning docker as root user inside the container."
+  DOCKER_RUN_ARGS+=(--env DOCKER_RUN_AS_ROOT=1)
+fi
+
 if is_default_values; then
   image_version=default
   build_dir=default


### PR DESCRIPTION
There is an issue that the Docker containers cannot modify the files on KEYMAN_ROOT, since the user running build and tests on Docker does not have the same gid and uid as the host user starting the container.
The issue is solved by running the tests with user root in the container.

There are also some fixes to the resources/docker-images/base/Dockerfile. Some environment variables should be evaluated at runtime, and not at build time.

Test-bot: skip
Build-bot: skip