### PR TITLE
fix(android): Refactor bottom inset calculations for inapp and system keyboard 🏠

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -238,7 +238,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
       KMManager.onConfigurationChanged(newConfig);
     }
 
-    // We should extend the touchable region so that Keyman sub keys menu can receive touch events outside the keyboard frame
+    // Update the touchable region of the Keyman keyboard
     Point size = KMManager.getWindowSize(getApplicationContext());
 
     int inputViewHeight = 0;
@@ -246,7 +246,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
       inputViewHeight = inputView.getHeight();
     }
 
-    int navigationHeight = KMManager.getNavigationBarHeight(this);
+    int navigationHeight = KMManager.getNavigationBarHeight(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
     int bannerHeight = KMManager.getBannerHeight(this);
     int kbHeight = KMManager.getKeyboardHeight(this);
     outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight - navigationHeight;

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -622,19 +622,13 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     // *** TO DO: Try to check if status bar is visible, set statusBarHeight to 0 if it is not visible ***
     int statusBarHeight = 0;
     int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
-    if (resourceId > 0)
-      statusBarHeight = getResources().getDimensionPixelSize(resourceId);
-
-    // Navigation bar height
-    int navigationBarHeight = 0;
-    resourceId = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
     if (resourceId > 0) {
-      navigationBarHeight = getResources().getDimensionPixelSize(resourceId);
+      statusBarHeight = getResources().getDimensionPixelSize(resourceId);
     }
+    int navigationBarHeight = KMManager.getNavigationBarHeight(context, KeyboardType.KEYBOARD_TYPE_INAPP);
 
     Point size = KMManager.getWindowSize(context);
     int screenHeight = size.y;
-    Log.d(TAG, "Main resizeTextView bannerHeight: " + bannerHeight);
     textView.setHeight(
       screenHeight - statusBarHeight - actionBarHeight - bannerHeight - keyboardHeight - navigationBarHeight);
   }

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -188,7 +188,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
       inputViewHeight = inputView.getHeight();
     }
 
-    int navigationHeight = KMManager.getNavigationBarHeight(this);
+    int navigationHeight = KMManager.getNavigationBarHeight(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
     int bannerHeight = KMManager.getBannerHeight(this);
     int kbHeight = KMManager.getKeyboardHeight(this);
     outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight - navigationHeight;

--- a/android/docs/engine/KMManager/getNavigationBarHeight.md
+++ b/android/docs/engine/KMManager/getNavigationBarHeight.md
@@ -4,12 +4,12 @@ title: KMManager.getNavigationBarHeight()
 
 ## Summary
 
-The **`getNavigationBarHeight()`** method returns the height of the navigation bar.
+The **`getNavigationBarHeight()`** method returns the height of the navigation bar corresponding to the in-app or system keyboard.
 
 ## Syntax
 
 ``` javascript
-KMManager.getNavigationBarHeight(Context context)
+KMManager.getNavigationBarHeight(Context context, KeyboardType keyboardType)
 ```
 
 ### Parameters
@@ -17,13 +17,19 @@ KMManager.getNavigationBarHeight(Context context)
 `context`
 :   The context.
 
+`keyboardType`
+:   The keyboard type. `KEYBOARD_TYPE_INAPP` or
+    `KEYBOARD_TYPE_SYSTEM`.)
+
 ### Returns
 
 Returns the height of the navigation bar in pixels.
 
 ## Description
 
-Use this method to get the height of the navigation bar. The keyboard offsets must account for this height below the keyboard.
+Use this method to get the height of the navigation bar, which depends on 
+the keyboard type (in-app or system) and navigation mode (gesture, 2-button, or 3-button navigation).
+The keyboard offsets must account for this height below the keyboard.
 
 ## Examples
 
@@ -32,8 +38,9 @@ Use this method to get the height of the navigation bar. The keyboard offsets mu
 The following script illustrate the use of `getNavigationBarHeight()`:
 
 ``` javascript
-    int navigationHeight = KMManager.getNavigationBarHeight(this);
+    int navigationHeight = KMManager.getNavigationBarHeight(this, KeyboardType.SYSTEM_KEYBOARD);
 
+    outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight - navigationHeight;
 ```
 
 ## See Also

--- a/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
+++ b/oem/firstvoices/android/app/src/main/java/com/firstvoices/keyboards/SystemKeyboard.java
@@ -207,7 +207,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
             inputViewHeight = inputView.getHeight();
         }
 
-        int navigationHeight = KMManager.getNavigationBarHeight(this);
+        int navigationHeight = KMManager.getNavigationBarHeight(this, KeyboardType.KEYBOARD_TYPE_SYSTEM);
         int bannerHeight = KMManager.getBannerHeight(this);
         int kbHeight = KMManager.getKeyboardHeight(this);
         outInsets.contentTopInsets = inputViewHeight - bannerHeight - kbHeight - navigationHeight;


### PR DESCRIPTION
🍒 pick of #14873 to stable-18.0 for #14864

The Keyman height seems to behave differently when the navigation bar is set to gesture navigation vs 3-button navigation. Sometimes, the top of the keyboard covers up the underlying text area, or sometimes there's an extra gap above the keyboard.

Based on changes from the Keyboard App Builder team, this PR pulls in similar changes from
sillsdev/app-builders@1fc2f36797fe52051480a4f218ba23df8cd2bfef and sillsdev/app-builders@96f6ba77246d698751d7f520863a3c7cd7f0914c

to update the system keyboard insets.
Reference:
https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#(androidx.compose.foundation.layout.WindowInsets.Companion).systemGestures()

## API Change
`getNavigationBarHeight()` was a late change to adjust the keyboard for the bottom inset. This PR needs the additional parameter for KeyboardType. Documented in 7226d271456e0292a285d28b85eafc3e5f1d6aac


## User Testing

**Setup** - Install the PR build of Keyman for Android on a device/emulator Android API 35 (Android 15.0 Vanilla Ice Cream).
In Keyman settings, set "Show On-Screen Keyboard" (when a physical keyboard is connected) to ON.
**Note:** GROUP_GESTURE_2_BUTTON_NAVIGATION is optional as some devices don't offer this navigation mode.

GROUP_GESTURE_NAVIGATION - Set Device --> Display --> Navigation Mode --> Gesture navigation

GROUP_GESTURE_2_BUTTON_NAVIGATION - Set Device --> Display --> Navigation Mode --> 2-button navigation
Note: This test grouping is optional, as some devices don't have this option

GROUP_3_BUTTON_NAVIGATION - Set Device --> Display --> Navigation Mode --> 3-button navigation

* **TEST_INAPP** - Verifies in-app keyboard
1. Launch Keyman for Android and dismiss getting started menu
2. Verify the in-app keyboard works:
  a. base keys
  b. longpress keys
  c. suggestion banner

* **TEST_SYSTEM** - Verifies system keyboard
1. Lauinch Keyman for Android.
2. In the "Get Started" menu, set Keyman as the default system keyboard 
3. Launch the Contacts app and create a new contact
4. Scroll to the bottom of the new contact form and observe the bottom
5. Select a text area near the bottom and select Keyman as the keyboard (if not already)
6. Verify you can scroll the form so the text area is not obscured
7. Verify Keyman system keyboard works:
  a. base keys
  b. longpress keys
  c. suggestion banner 
