### PR TITLE
docs(developer): Update keyboard-editor.md to clarify when entire row will be deleted

### DIFF
--- a/developer/docs/help/context/keyboard-editor.md
+++ b/developer/docs/help/context/keyboard-editor.md
@@ -322,7 +322,7 @@ on any key to edit it. There are a number of controls:
 
 Red circle with an X
 :   This button to the top right of the key will delete the key from the
-    row; if it is the last key on the row, the entire row will be
+    row; if it is the only remaining key on the row, the entire row will be
     deleted.
 
 Green arrow with a +


### PR DESCRIPTION
I think this change avoids the misunderstanding that deleting the rightmost ("last") key on the row will delete the entire row.

(@darcywong00 edit to skip user testing)
Test-bot: skip
