### PR TITLE
refactor(web): simple reuse of search modules 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -7,7 +7,7 @@ import { applySuggestionCasing, correctAndEnumerate, dedupeSuggestions, finalize
 import { detectCurrentCasing, determineModelTokenizer, determineModelWordbreaker, determinePunctuationFromModel } from './model-helpers.js';
 
 import { ContextTracker } from './correction/context-tracker.js';
-import { SearchQuotientSpur } from './correction/search-quotient-spur.js';
+import { DEFAULT_ALLOTTED_CORRECTION_TIME_INTERVAL } from './correction/search-quotient-spur.js';
 
 import CasingForm = LexicalModelTypes.CasingForm;
 import Configuration = LexicalModelTypes.Configuration;
@@ -146,7 +146,7 @@ export class ModelCompositor {
     // Section 1:  determine 'prediction roots' - enumerate corrections from most to least likely,
     // searching for results that yield viable predictions from the model.
 
-    const SEARCH_TIMEOUT = SearchQuotientSpur.DEFAULT_ALLOTTED_CORRECTION_TIME_INTERVAL;
+    const SEARCH_TIMEOUT = DEFAULT_ALLOTTED_CORRECTION_TIME_INTERVAL;
     const timer = this.activeTimer = new correction.ExecutionTimer(this.testMode ? Number.MAX_VALUE : SEARCH_TIMEOUT, this.testMode ? Number.MAX_VALUE : SEARCH_TIMEOUT * 1.5);
 
     const { postContextState, rawPredictions, revertableTransitionId } = await correctAndEnumerate(this.contextTracker, this.lexicalModel, timer, transformDistribution, context);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-token.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-token.tests.ts
@@ -90,7 +90,7 @@ describe('ContextToken', function() {
       let baseToken = new ContextToken(plainModel, "and");
       let clonedToken = new ContextToken(baseToken);
 
-      assert.notEqual(clonedToken.searchSpace, baseToken.searchSpace);
+      assert.equal(clonedToken.searchSpace, baseToken.searchSpace);
       // Deep equality on .searchSpace can't be directly checked due to the internal complexities involved.
       // We CAN check for the most important members, though.
       assert.notEqual(clonedToken.searchSpace.inputSequence, baseToken.searchSpace.inputSequence);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/getBestMatches.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/getBestMatches.tests.ts
@@ -109,7 +109,7 @@ describe('getBestMatches', () => {
     const rootTraversal = testModel.traverseFromRoot();
     assert.isNotEmpty(rootTraversal);
 
-    const searchSpace = new SearchQuotientSpur(testModel);
+    let searchPath = new SearchQuotientSpur(testModel);
 
     // VERY artificial distributions.
     const synthInput1 = [
@@ -126,11 +126,11 @@ describe('getBestMatches', () => {
       {sample: {insert: 'n', deleteLeft: 0}, p: 0.25}
     ];
 
-    searchSpace.addInput(synthInput1, 1);
-    searchSpace.addInput(synthInput2, .75);
-    searchSpace.addInput(synthInput3, .75);
+    searchPath = searchPath.addInput(synthInput1, 1);
+    searchPath = searchPath.addInput(synthInput2, .75);
+    searchPath = searchPath.addInput(synthInput3, .75);
 
-    const iter = getBestMatches(searchSpace, buildTestTimer()); // disables the correction-search timeout.
+    const iter = getBestMatches(searchPath, buildTestTimer()); // disables the correction-search timeout.
     await checkRepeatableResults_teh(iter);
   });
 
@@ -139,8 +139,7 @@ describe('getBestMatches', () => {
     const rootTraversal = testModel.traverseFromRoot();
     assert.isNotEmpty(rootTraversal);
 
-    const searchSpace = new SearchQuotientSpur(testModel);
-
+    let searchSpace = new SearchQuotientSpur(testModel);
 
     // VERY artificial distributions.
     const synthInput1 = [
@@ -157,9 +156,9 @@ describe('getBestMatches', () => {
       {sample: {insert: 'n', deleteLeft: 0}, p: 0.25}
     ];
 
-    searchSpace.addInput(synthInput1, 1);
-    searchSpace.addInput(synthInput2, .75);
-    searchSpace.addInput(synthInput3, .75);
+    searchSpace = searchSpace.addInput(synthInput1, 1);
+    searchSpace = searchSpace.addInput(synthInput2, .75);
+    searchSpace = searchSpace.addInput(synthInput3, .75);
 
     const iter = getBestMatches(searchSpace, buildTestTimer()); // disables the correction-search timeout.
     await checkRepeatableResults_teh(iter);


### PR DESCRIPTION
This changes SearchQuotientSpur,  our predecessor to module-based search-graph management, to construct new instances whenever the path is extended, treating SearchQuotientSpur as an immutable portion of the search graph that may be referenced by path extensions - new instances of SearchQuotientSpur.  No inputs may be added into pre-existing instances (the previous pattern) - instead, adding an input creates a new instance that references and utilizes the old one without editing what it represents.

This, in turn, removes the need to clone SearchQuotientSpur instances when new input is received for an incoming token.

Relates-to: https://github.com/keymanapp/keyman/issues/14445

Note that the class itself is transition in this PR.  This PR is focused entirely on facilitating the transition to search-space immutability.  Further work (starting in #14979 and #14987) will increase the abstraction and further alter the design into a new design pattern that will facilitate correction across word-boundary shifts, such as when fat-fingering a whitespace key.

Build-bot: skip build:web
Test-bot: skip