### PR TITLE
fix(android): Update Sample1 text field to resize

### DIFF
--- a/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
+++ b/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
@@ -174,15 +174,10 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     // *** TO DO: Try to check if status bar is visible, set statusBarHeight to 0 if it is not visible ***
     int statusBarHeight = 0;
     int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
-    if (resourceId > 0)
-      statusBarHeight = getResources().getDimensionPixelSize(resourceId);
-
-    // Navigation bar height
-    int navigationBarHeight = 0;
-    resourceId = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
     if (resourceId > 0) {
-      navigationBarHeight = getResources().getDimensionPixelSize(resourceId);
+      statusBarHeight = getResources().getDimensionPixelSize(resourceId);
     }
+    int navigationBarHeight = KMManager.getNavigationBarHeight(context, KeyboardType.KEYBOARD_TYPE_INAPP);
 
     Point size = KMManager.getWindowSize(context);
     int screenHeight = size.y;

--- a/android/Samples/KMSample1/app/src/main/res/layout/activity_main.xml
+++ b/android/Samples/KMSample1/app/src/main/res/layout/activity_main.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -5,16 +6,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
+    android:layout_above="@+id/KMKeyboard"
     android:orientation="vertical"
     tools:context=".MainActivity">
 
     <com.keyman.engine.KMTextView
         android:id="@+id/kmTextView"
         android:layout_width="match_parent"
-        android:layout_height="100dp"
-        android:layout_alignParentTop="true"
+        android:layout_height="wrap_content"
         android:ems="10"
-        android:inputType="textMultiLine"
+        android:inputType="textMultiLine|textNoSuggestions"
         android:gravity="top"
         android:scrollbars="vertical"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
Follows #14873

This cleans up the KMSample1 app to resize the text area with the correct bottom inset (getNavigationBarHeight)
so it'll update for gesture navigation or 3-button navigation modes

Test-bot: skip
