### PR TITLE
fix(mac): add Microsoft Word to non-compliant app list

### DIFF
--- a/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
+++ b/mac/Keyman4MacIM/Keyman4MacIM/TextApiCompliance.m
@@ -365,7 +365,8 @@ NSString *const kKMLegacyApps = @"KMLegacyApps";
                             [clientAppId isEqual: @"org.sil.app.builder.scripture.ScriptureAppBuilder"] ||
                             [clientAppId isEqual: @"org.sil.app.builder.reading.ReadingAppBuilder"] ||
                             [clientAppId isEqual: @"org.sil.app.builder.dictionary.DictionaryAppBuilder"] ||
-                            //[clientAppId isEqual: @"com.microsoft.Word"] || // 2020-11-24[mcd]: Appears to work well in Word 16.43, disable legacy by default
+                            [clientAppId isEqual: @"com.microsoft.Word"] ||
+                            // Microsoft Word removed on 2020-11-24 but added back on 2025-10-10 for issue #14160
                             [clientAppId isEqual: @"org.openoffice.script"] ||
                             // 2023-12-13[sgs]: Adobe apps automatically detected as non-compliant
                             //[clientAppId isEqual: @"com.adobe.illustrator"] ||


### PR DESCRIPTION
Microsoft Word was removed from the internal non-compliant app list on 2020-11-24, but is added back now to address an issue with Bengali text as described in #14160. It appears that Microsoft Word is mostly compliant: it can get the current location and selection and read the text correctly, but when insert text that includes text to replace, something goes wrong.

Fixes: #14160

# User Testing

## TEST_BENGALI_TEXT

1. Install the keyboard Bengali Phonetic (ITRANS) in Keyman for Mac. 
1. Open a new document in Microsoft Word. 
1. Type the sequence: akTopaasa
1. Confirm that the resulting text is অক্টোপাস 

