### PR TITLE
chore(web): update helpURL documentation and float ui link

### DIFF
--- a/web/docs/engine/reference/core/helpURL.md
+++ b/web/docs/engine/reference/core/helpURL.md
@@ -22,7 +22,7 @@ Read only
 
 ### Return Value
 
-Presently set to [`"http://help.keymanweb.com/go"`]().
+Presently set to [`"https://help.keyman.com/go"`]().
 
 ## Description
 

--- a/web/src/app/ui/kmwuifloat.ts
+++ b/web/src/app/ui/kmwuifloat.ts
@@ -130,7 +130,7 @@ if(!keymanweb) {
         this.outerDiv = util.createElement('div');         // Container for UI (visible when KeymanWeb is active)
         this.innerDiv = util.createElement('div');         // inner div for UI
         this.kbdIcon = util.createElement('img');
-        this.outerDiv.innerHTML = "<a href='http://keyman.com/web/' target='KeymanWebHelp'>"
+        this.outerDiv.innerHTML = "<a href='https://keyman.com/developer/keymanweb/' target='KeymanWebHelp'>"
           + "<img src='"+imgPath+"kmicon.gif' border='0' style='padding: 0px 2px 0 1px; margin:0px;' title='KeymanWeb' alt='KeymanWeb' /></a>"; /* I2081 */
 
         let s=this.outerDiv.style;


### PR DESCRIPTION
Make the float UI KeymanWeb link point to the home for KeymanWeb, and https rather than http, and update the helpURL documentation to match the current endpoint.

Found when investigating http redirects for websites earlier.

Test-bot: skip
Build-bot: skip