### PR TITLE
chore(common): add .model_info schema

### DIFF
--- a/common/schemas/model_info/README.md
+++ b/common/schemas/model_info/README.md
@@ -1,0 +1,19 @@
+# model_info
+
+* **model_info.schema.json**
+
+Documentation at https://help.keyman.com/developer/cloud/model_info
+
+* Primary version:
+  * https://github.com/keymanapp/api.keyman.com/tree/master/schemas/model_info
+* Synchronized copies at:
+  * https://github.com/keymanapp/keyman/tree/master/common/schemas/model_info
+
+# .model_info version history
+
+## 2023-08-11 2.0 stable
+* Removed:
+    `.links`
+    `.related[].note`
+  - Source .model_info files are no longer needed, so source vs distribution
+    model_info distinction is removed

--- a/common/schemas/model_info/model_info.schema.json
+++ b/common/schemas/model_info/model_info.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$ref": "#/definitions/ModelInfo",
+
+  "definitions": {
+    "ModelInfo": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "authorName": { "type": "string" },
+        "authorEmail": { "type": "string", "format": "email" },
+        "description": { "type": "string" },
+        "license": { "type": "string", "enum": ["mit"] },
+        "languages": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "lastModifiedDate": { "type": "string", "format": "date-time" },
+        "packageFilename": { "type": "string" },
+        "packageFileSize": { "type": "number" },
+        "jsFilename": { "type": "string" },
+        "jsFileSize": { "type": "number" },
+        "isRTL": { "type": "boolean" },
+        "packageIncludes": { "type": "array", "items": { "type": "string", "enum": ["fonts"] }, "additionalItems": false },
+        "version": { "type": "string" },
+        "minKeymanVersion": { "type": "string", "pattern": "^\\d+\\.0$" },
+        "helpLink": { "type": "string", "pattern": "^http(s)?://help\\.keyman(-staging)?\\.com(.localhost)?/model/" },
+        "sourcePath": { "type": "string", "pattern": "^(release|experimental)/.+/.+$" },
+        "related": { "type": "object", "patternProperties": {
+          ".": { "$ref": "#/definitions/ModelRelatedInfo" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "license", "languages"
+      ],
+      "additionalProperties": false
+    },
+
+    "ModelRelatedInfo": {
+      "type": "object",
+      "properties": {
+        "deprecates": { "type": "boolean" },
+        "deprecatedBy": { "type": "boolean" }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Add the v2.0 .model_info schema file, from api.keyman.com. Does not add the schema to list of compiled schemas in common/types; this can be done on an as-needed basis.

Test-bot: skip
Build-bot: skip