### PR TITLE
fix(linux): use `ibus` command to restart ibus 🍒 🏠

### DIFF
--- a/linux/keyman-config/keyman_config/ibus_util.py
+++ b/linux/keyman-config/keyman_config/ibus_util.py
@@ -187,20 +187,8 @@ def restart_ibus(bus=None):
         logging.info('restarting IBus by subprocess for user %s', realuser)
         subprocess.run(['sudo', '-u', realuser, 'ibus', 'restart'], check=False)
     else:
-        logging.info('restarting IBus through API')
-        try:
-            if not bus:
-                bus = get_ibus_bus()
-            if bus:
-                logging.info("restarting IBus")
-                # we no longer try to restart since we sometimes ended up with more than one
-                # ibus-daemon process (#6237). Instead we only exit ibus here, and start
-                # ibus again below.
-                bus.exit(False)
-                bus.destroy()
-        except Exception as e:
-            logging.warning("Failed to restart IBus")
-            logging.warning(e)
+        logging.info('restarting IBus by subprocess')
+        subprocess.run(['ibus', 'restart'], check=False)
     # give ibus a chance to shutdown (#6237)
     time.sleep(1)  # 1s
     verify_ibus_daemon(True)


### PR DESCRIPTION
When using Kubuntu exiting ibus sometimes used to hang (#10178). This was because ibus' `bus.exit()` doesn't shutdown properly (see https://github.com/ibus/ibus/issues/2816#issuecomment-3410473708). The recommended way is to use the `ibus exit` command. Since we no longer use the API we can directly use the `ibus restart` command, which this PR implements.

Fixes: #10178
Cherry-pick-of: #14971

# User Testing

**TEST_INST**: using Kubuntu 25.04 or Kubuntu 25.10 with Wayland, install a keyboard through Keyman Configuration and verify that it works properly, i.e. it doesn't hang at the end of the installation.