### PR TITLE
fix(android): Set the main app background white 🏠

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/MainActivity.java
@@ -619,11 +619,14 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
     getTheme().resolveAttribute(android.R.attr.actionBarSize, outValue, true);
     int actionBarHeight = getResources().getDimensionPixelSize(outValue.resourceId);
 
-    // *** TO DO: Try to check if status bar is visible, set statusBarHeight to 0 if it is not visible ***
+    // Status bar height only used for portrait orientation
     int statusBarHeight = 0;
-    int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
-    if (resourceId > 0) {
-      statusBarHeight = getResources().getDimensionPixelSize(resourceId);
+    if (lastOrientation == Configuration.ORIENTATION_PORTRAIT) {
+      // *** TO DO: Try to check if status bar is visible, set statusBarHeight to 0 if it is not visible ***
+      int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
+      if (resourceId > 0) {
+        statusBarHeight = getResources().getDimensionPixelSize(resourceId);
+      }
     }
     int navigationBarHeight = KMManager.getNavigationBarHeight(context, KeyboardType.KEYBOARD_TYPE_INAPP);
 

--- a/android/KMAPro/kMAPro/src/main/res/layout/activity_main.xml
+++ b/android/KMAPro/kMAPro/src/main/res/layout/activity_main.xml
@@ -8,7 +8,7 @@
     android:fitsSystemWindows="true"
     android:layout_above="@+id/KMKeyboard"
     android:orientation="vertical"
-    android:background="@color/yellow_background"
+    android:background="@android:color/white"
     tools:context=".MainActivity">
 
     <include layout="@layout/titlebar"


### PR DESCRIPTION
:cherries: of #14935 for #14934 in stable-18.0

So Android 15 (API 35) removed API calls to set the top status bar color `setStatusBarColor()` and bottom navigation bar color `setNavigationBarColor()`.

The system bars default to transparent. Fortunately, just changing the top level background to white fixes the issue and results in white status bar and white navigationbar


| **Screenshot** |
|-------------------------|
| ![white bg](https://github.com/user-attachments/assets/a1659225-3c1f-4733-8cf9-050f097126b7) |


The KMTextView background (line 31) is
```
android:background="@drawable/textview_bg"
```
which keeps the yellow text area.

## User Testing

**Setup** - Install the PR build of Keyman for Android on a device/emulator Android 15.0 (API 35)

* **TEST_SYSTEM_BARS_WHITE** - Verifies top status bar and bottom navigation bar are both white
1. Launch Keyman for Android and dismiss "Get Started" menu
2. Observe the main app and verify
  a. top status bar is white
  b. bottom navigation bar is white
  c. text area remains yellow
3. Type with the in-app keyboard
4. Verify the colors remain 
5. Rotate between portrait and landscape orientation and verify colors remain the same. You may need to scroll the text view to get to the bottom.
