### PR TITLE
fix(developer): do not treat backslash as a string escape in syntax highlighting

### DIFF
--- a/developer/src/tike/xml/app/editor/language.keyman.js
+++ b/developer/src/tike/xml/app/editor/language.keyman.js
@@ -53,8 +53,8 @@ define("language.keyman", ["require", "exports"], function (require, exports) {
           [/\[/, { token: 'tag', bracket: '@open', next: '@virtualKey' } ],
 
           // strings
-          [/"([^"]|\\.)*$/, 'string.invalid' ],  // non-teminated string
-          [/'([^']|\\.)*$/, 'string.invalid' ],  // non-teminated string
+          [/"([^"])*$/, 'string.invalid' ],  // non-teminated string
+          [/'([^'])*$/, 'string.invalid' ],  // non-teminated string
           [/"/,  { token: 'string.quote', bracket: '@open', next: '@stringDouble' } ],
           [/'/,  { token: 'string.quote', bracket: '@open', next: '@stringSingle' } ],
         ],


### PR DESCRIPTION
Adjust two incorrect rules that caused backslash to be treated as an escape in strings in syntax highlighting in .kmn language.

For the following examples:

```
+ '\' > U+1234  c testing
+ '\\' > U+1234 c testing
+ '\\\' > U+1234 c testing
+ '"' > U+1234 c testing
+ "\" > U+1234 c testing

'"' x20 "'" x20 '""' x20 '\' x20 '\\' x20 "\" x20 "\\" x20 '"""' x20 + 'a' > 'b\' c comment

c quote in a comment ' this is ignored
c quote in a comment " this is ignored
+ ['] > U+1234  c quote in a VK is ignored
store(') x20    c quote as a parameter is ignored
+ ["] > U+1234  c quote in a VK is ignored
store(") x20    c quote as a parameter is ignored
```

Before fix:
<img width="1246" height="413" alt="image" src="https://github.com/user-attachments/assets/fad6db77-db3e-4963-a522-c0157dd9f9f3" />

After fix:
<img width="1281" height="425" alt="image" src="https://github.com/user-attachments/assets/27ce0116-cba6-4181-a625-bfe2401c755f" />

Fixes: #14988
Test-bot: skip
Build-bot: skip