### PR TITLE
fix(developer): do not treat backslash as a string escape in syntax highlighting 🍒 🏠

### DIFF
--- a/developer/src/tike/xml/app/editor/language.keyman.js
+++ b/developer/src/tike/xml/app/editor/language.keyman.js
@@ -53,8 +53,8 @@ define("language.keyman", ["require", "exports"], function (require, exports) {
           [/\[/, { token: 'tag', bracket: '@open', next: '@virtualKey' } ],
 
           // strings
-          [/"([^"]|\\.)*$/, 'string.invalid' ],  // non-teminated string
-          [/'([^']|\\.)*$/, 'string.invalid' ],  // non-teminated string
+          [/"([^"])*$/, 'string.invalid' ],  // non-teminated string
+          [/'([^'])*$/, 'string.invalid' ],  // non-teminated string
           [/"/,  { token: 'string.quote', bracket: '@open', next: '@stringDouble' } ],
           [/'/,  { token: 'string.quote', bracket: '@open', next: '@stringSingle' } ],
         ],


### PR DESCRIPTION
Adjust two incorrect rules that caused backslash to be treated as an escape in strings in syntax highlighting in .kmn language.

Fixes: #14988
Test-bot: skip
Build-bot: skip
Cherry-pick-of: #15001