### PR TITLE
fix(developer): handle missing `begin Unicode` in KMW compiler 🍒 🏠

### DIFF
--- a/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler.ts
+++ b/developer/src/kmc-kmn/src/kmw-compiler/kmw-compiler.ts
@@ -271,7 +271,7 @@ export function WriteCompiledKeyboard(
 	// Write the groups out
 
   // I853 - begin unicode missing causes crash
-  if (keyboard.startGroup.unicode == 0xFFFFFFFF) {
+  if (keyboard.startGroup.unicode == -1 || keyboard.startGroup.unicode == 0xFFFFFFFF) {
     callbacks.reportMessage(KmwCompilerMessages.Error_InvalidBegin());
     return null;
   }

--- a/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/ansi.kmn
+++ b/developer/src/kmc-kmn/test/fixtures/invalid-keyboards/ansi.kmn
@@ -1,0 +1,13 @@
+c
+c test for ERROR_InvalidBegin in kmw-compiler ('begin Unicode' is required)
+c
+
+store(&version) '9.0'
+store(&name) 'Test ANSI'
+store(&targets) 'web'
+
+begin ANSI > use(main)
+
+group(main) using keys
+
++ 'a' > 'aah'

--- a/developer/src/kmc-kmn/test/kmw/kmw-messages.tests.ts
+++ b/developer/src/kmc-kmn/test/kmw/kmw-messages.tests.ts
@@ -45,6 +45,12 @@ describe('KmwCompilerMessages', function () {
     await testForMessage(this, ['kmw', 'validate_gesture.kmn'], KmwCompilerMessages.HINT_TouchLayoutUsesUnsupportedGesturesDownlevel);
   });
 
+  // ERROR_InvalidBegin (from KmnCompilerMessages, but in KeymanWeb compiler context)
+
+  it('should generate ERROR_InvalidBegin if the keyboard has no "begin unicode" statement', async function() {
+    await testForMessage(this, ['invalid-keyboards', 'ansi.kmn'], KmwCompilerMessages.ERROR_InvalidBegin);
+  });
+
   // TODO: other messages
 
   // WARN_ExtendedShiftFlagsNotSupportedInKeymanWeb:


### PR DESCRIPTION
This probably arose with the move to kmcmplib in WASM, and as it was never unit tested, we missed it. A simple signed vs unsigned issue.

Fixes: #14411
Test-bot: skip
Cherry-pick-of: #15002