### PR TITLE
fix(developer): prevent ANSI keyboards crashing debugger

### DIFF
--- a/core/src/kmx/kmx_processevent.cpp
+++ b/core/src/kmx/kmx_processevent.cpp
@@ -107,10 +107,14 @@ KMX_BOOL KMX_ProcessEvent::ProcessEvent(
 
   if (kbd->StartGroup[BEGIN_UNICODE] == (KMX_DWORD) -1) {
     DebugLog("Non-Unicode keyboards are not supported.");
+    DeleteInternalDebugItems();
+    state->debug_items().push_end(m_actions.Length(), 0);
     m_core_state = nullptr;
     return FALSE;
   }
 
+  // TODO: what about debug_item state for all shortcut return paths below?
+  // TODO: this needs to be cleaned up; see #11909
   switch (vkey) {
   case KM_CORE_VKEY_CAPS:
     if (KeyCapsLockPress(modifiers, isKeyDown))

--- a/developer/src/tike/debug/Keyman.System.Debug.DebugEvent.pas
+++ b/developer/src/tike/debug/Keyman.System.Debug.DebugEvent.pas
@@ -342,8 +342,18 @@ var
   action_index: Integer;
 begin
   Result := True;
+
+  if not Assigned(state) then
+    raise Exception.Create('TDebugEventList.AddStateItems: expected state not to be nil');
+
   debug := km_core_state_debug_items(state, nil);
+  if not Assigned(debug) then
+    raise Exception.Create('TDebugEventList.AddStateItems: expected debug not to be nil');
+
   action := km_core_state_action_items(state, nil);
+  if not Assigned(action) then
+    raise Exception.Create('TDebugEventList.AddStateItems: expected action not to be nil');
+
   action_index := 0;
   while debug._type <> KM_CORE_DEBUG_END do
   begin


### PR DESCRIPTION
Note: #11909 has some additional future cleanup we could do, but these code paths are not currently accessible, so in the interest of moving forward, am leaving them for now.

Fixes: #11909
Test-bot: skip