### PR TITLE
maint(resources): move npm package publishing to GitHub Actions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,81 @@
+#
+# Keyman is copyright (C) SIL Global. MIT License.
+#
+# Created by mcdurdin on 2025-10-27
+#
+# This workflow publishes all our NPM packages using Trusted Publishers OIDC
+# permissions. It is triggered by a repository_dispatch event with the types
+# `npm-publish:*`, from the trigger-builds infrastructure. For test builds, this
+# does a `npm pack` only.
+#
+# Inputs:
+#   buildSha:    The SHA of the commit to build, e.g. of the branch or
+#                refs/pull/1234/head for PR
+#   user:        The user that triggered the build or created the PR
+#   isTestBuild: false for Releases, otherwise true
+
+name: "NPM publish"
+run-name: "NPM publish - sha: ${{ github.event.client_payload.buildSha }}, user: @${{ github.event.client_payload.user }}, isTestBuild: ${{ github.event.client_payload.isTestBuild }}"
+on:
+  repository_dispatch:
+    types: ['npm-publish:*']
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  STATUS_CONTEXT: 'NPM Pack'
+
+jobs:
+  npm-publish:
+    name: Publish or pack @keymanapp packages
+    if: github.repository == 'keymanapp/keyman' || github.event.client_payload.force
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      with:
+        ref: '${{ github.event.client_payload.buildSha }}'
+
+    - name: Upgrade npm to 11.6.2
+      run: |
+        echo "Initial npm version"
+        npm -v
+        echo "Upgrading npm to 11.6.2"
+        npm install --global npm@11.6.2
+        echo "Current npm version"
+        npm -v
+
+    - name: Set pending status on PR builds
+      id: set_status
+      if: github.event.client_payload.isTestBuild == 'true'
+      shell: bash
+      run: |
+        gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          /repos/$GITHUB_REPOSITORY/statuses/${{ github.event.client_payload.buildSha }} \
+          -f state='pending' \
+          -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+          -f description='NPM pack started' \
+          -f context="$STATUS_CONTEXT"
+
+    - name: NPM pack
+      if: github.event.client_payload.isTestBuild == 'true'
+      run: |
+        if [[ -f ./resources/build/ci/npm-publish.sh ]]; then
+          ./resources/build/ci/npm-publish.sh pack
+        else
+          echo WARNING: npm-publish.sh is not yet available on this branch
+        fi
+
+    - name: NPM publish
+      if: github.event.client_payload.isTestBuild == 'false'
+      run: |
+        if [[ -f ./resources/build/ci/npm-publish.sh ]]; then
+          ./resources/build/ci/npm-publish.sh publish
+        else
+          echo WARNING: npm-publish.sh is not yet available on this branch
+        fi

--- a/common/web/keyman-version/build.sh
+++ b/common/web/keyman-version/build.sh
@@ -7,7 +7,6 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 ################################ Main script ################################
 
@@ -15,10 +14,7 @@ builder_describe "Build the include script for current Keyman version" \
   configure \
   clean \
   build \
-  test \
-  "publish                   publish to npm" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  test
 
 builder_describe_outputs \
   configure "/node_modules" \
@@ -56,4 +52,3 @@ export default KEYMAN_VERSION;
 builder_run_action clean        rm -rf version.inc.ts keyman-version.mts build/
 builder_run_action configure    node_select_version_and_npm_ci
 builder_run_action build        do_build
-builder_run_action publish      ci_publish_npm

--- a/common/web/langtags/build.sh
+++ b/common/web/langtags/build.sh
@@ -7,16 +7,12 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 builder_describe "Build Keyman langtags.js common module" \
   "clean" \
   "configure" \
   "build" \
-  "test" \
-  "publish                   publish to npm" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "test"
 
 builder_describe_outputs \
   configure   /common/web/langtags/src/imports/langtags.js \
@@ -43,4 +39,3 @@ builder_run_action clean      rm -rf ./build ./src/imports ./node_modules
 builder_run_action configure  do_configure
 builder_run_action build      tsc --build
 builder_run_action test       echo 'no tests for langtags'
-builder_run_action publish    ci_publish_npm

--- a/common/web/types/build.sh
+++ b/common/web/types/build.sh
@@ -8,7 +8,6 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/typescript.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 builder_describe "Build Keyman common file types module" \
   "@/core/include/ldml" \
@@ -16,10 +15,7 @@ builder_describe "Build Keyman common file types module" \
   "configure" \
   "build" \
   "clean" \
-  "test" \
-  "publish                   publish to npm" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "test"
 
 builder_describe_outputs \
   configure   /common/web/types/src/schemas/kpj.schema.ts \
@@ -87,4 +83,3 @@ builder_run_action clean      rm -rf ./build/ ./tsconfig.tsbuildinfo ./src/schem
 builder_run_action configure  do_configure
 builder_run_action build      tsc --build
 builder_run_action test       typescript_run_eslint_mocha_tests 60
-builder_run_action publish    ci_publish_npm

--- a/core/include/ldml/build.sh
+++ b/core/include/ldml/build.sh
@@ -10,17 +10,13 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 builder_describe "Keyman ldml-keyboard-constants package" \
   "@/common/web/keyman-version" \
   "clean" \
   "configure" \
   "build" \
-  "test" \
-  "publish                   publish to npm" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "test"
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -34,4 +30,3 @@ builder_run_action clean      rm -rf ./build/
 builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      tsc --build
 # builder_run_action test       # no tests at this time
-builder_run_action publish    ci_publish_npm

--- a/developer/src/common/web/utils/build.sh
+++ b/developer/src/common/web/utils/build.sh
@@ -8,7 +8,6 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/typescript.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 builder_describe "Build Keyman Developer web utility module" \
   "@/common/web/types" \
@@ -16,10 +15,7 @@ builder_describe "Build Keyman Developer web utility module" \
   "configure" \
   "build" \
   "api                       analyze API and prepare API documentation (no-op for now)" \
-  "test" \
-  publish \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "test"
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -52,4 +48,3 @@ builder_run_action clean       rm -rf ./build/
 builder_run_action configure   node_select_version_and_npm_ci
 builder_run_action build       do_build
 builder_run_action test        typescript_run_eslint_mocha_tests 45
-builder_run_action publish     ci_publish_npm

--- a/developer/src/kmc-analyze/build.sh
+++ b/developer/src/kmc-analyze/build.sh
@@ -8,15 +8,12 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/typescript.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 builder_describe "Keyman Developer Compiler Analysis Tools" \
   "@/common/web/types" \
   "@/developer/src/kmc-kmn" \
   "@/developer/src/common/web/utils" \
-  clean configure build api test publish \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  clean configure build api test
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -32,4 +29,3 @@ builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      tsc --build
 builder_run_action api        api-extractor run --local --verbose
 builder_run_action test       typescript_run_eslint_mocha_tests 75
-builder_run_action publish    ci_publish_npm

--- a/developer/src/kmc-copy/build.sh
+++ b/developer/src/kmc-copy/build.sh
@@ -11,16 +11,13 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/typescript.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 builder_describe "Build Keyman kmc-copy module" \
   "@/common/web/keyman-version" \
   "@/common/web/types" \
   "@/developer/src/common/web/test-helpers" \
   "@/developer/src/common/web/utils" \
-  clean configure build api test publish \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  clean configure build api test
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -42,5 +39,3 @@ builder_run_action api        api-extractor run --local --verbose
 # note: `export TEST_SAVE_FIXTURES=1` to get a copy of cloud-based fixtures saved to online/
 # TODO: -skip-full
 builder_run_action test       typescript_run_eslint_mocha_tests 75
-
-builder_run_action publish    ci_publish_npm

--- a/developer/src/kmc-generate/build.sh
+++ b/developer/src/kmc-generate/build.sh
@@ -11,7 +11,6 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/typescript.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 builder_describe "Build Keyman kmc-generate module" \
   "@/common/web/keyman-version" \
@@ -19,9 +18,7 @@ builder_describe "Build Keyman kmc-generate module" \
   "@/common/web/types" \
   "@/developer/src/common/web/test-helpers" \
   "@/developer/src/common/web/utils" \
-  clean configure build api test publish \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  clean configure build api test
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -44,4 +41,3 @@ builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      do_build
 builder_run_action api        api-extractor run --local --verbose
 builder_run_action test       typescript_run_eslint_mocha_tests
-builder_run_action publish    ci_publish_npm

--- a/developer/src/kmc-keyboard-info/build.sh
+++ b/developer/src/kmc-keyboard-info/build.sh
@@ -18,10 +18,7 @@ builder_describe "Build Keyman kmc keyboard-info Compiler module" \
   "configure" \
   "build" \
   "api                       analyze API and prepare API documentation" \
-  "test" \
-  "publish                   publish to npm" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "test"
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -39,7 +36,3 @@ builder_run_action api         api-extractor run --local --verbose
 builder_run_action test        typescript_run_eslint_mocha_tests
 
 #-------------------------------------------------------------------------------------------------------------------
-
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
-
-builder_run_action publish      ci_publish_npm

--- a/developer/src/kmc-kmn/build.sh
+++ b/developer/src/kmc-kmn/build.sh
@@ -11,7 +11,6 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/typescript.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 builder_describe "Keyman Developer Compiler Module for .kmn to .kmx" \
   "@/common/web/keyman-version" \
@@ -23,10 +22,7 @@ builder_describe "Keyman Developer Compiler Module for .kmn to .kmx" \
   "build" \
   "clean" \
   "api                       analyze API and prepare API documentation" \
-  "test" \
-  "publish                   publish to npm" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "test"
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -71,7 +67,3 @@ function do_test() {
 builder_run_action build      do_build
 builder_run_action api        api-extractor run --local --verbose
 builder_run_action test       do_test
-
-#-------------------------------------------------------------------------------------------------------------------
-
-builder_run_action publish  ci_publish_npm

--- a/developer/src/kmc-ldml/build.sh
+++ b/developer/src/kmc-ldml/build.sh
@@ -23,10 +23,7 @@ builder_describe "Keyman kmc Keyboard Compiler module" \
   "api                       analyze API and prepare API documentation" \
   "clean" \
   "test" \
-  "build-fixtures            builds test fixtures for manual examination" \
-  "publish                   publish to npm" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "build-fixtures            builds test fixtures for manual examination"
 
 builder_describe_outputs \
   configure     /developer/src/kmc-ldml/src/util/abnf/46/transform-from-required.js \
@@ -90,9 +87,3 @@ builder_run_action build           do_build
 builder_run_action build-fixtures  do_build_fixtures
 builder_run_action api             api-extractor run --local --verbose
 builder_run_action test            typescript_run_eslint_mocha_tests  90
-
-#-------------------------------------------------------------------------------------------------------------------
-
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
-
-builder_run_action publish     ci_publish_npm

--- a/developer/src/kmc-model-info/build.sh
+++ b/developer/src/kmc-model-info/build.sh
@@ -15,10 +15,7 @@ builder_describe "Build Keyman kmc Lexical Model model-info Compiler module" \
   "configure" \
   "build" \
   "api                       analyze API and prepare API documentation" \
-  "test" \
-  "publish                   publish to npm" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "test"
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -34,9 +31,3 @@ builder_run_action configure    node_select_version_and_npm_ci
 builder_run_action build        tsc --build
 builder_run_action api          api-extractor run --local --verbose
 builder_run_action test         typescript_run_eslint_mocha_tests 55
-
-#-------------------------------------------------------------------------------------------------------------------
-
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
-
-builder_run_action publish     ci_publish_npm

--- a/developer/src/kmc-model/build.sh
+++ b/developer/src/kmc-model/build.sh
@@ -8,7 +8,6 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/typescript.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 builder_describe "Keyman kmc Lexical Model Compiler module" \
   "@/common/web/keyman-version" \
@@ -18,10 +17,7 @@ builder_describe "Keyman kmc Lexical Model Compiler module" \
   "configure" \
   "build" \
   "api                       analyze API and prepare API documentation" \
-  "test" \
-  "publish                   publish to npm" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "test"
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -42,5 +38,3 @@ builder_run_action configure    node_select_version_and_npm_ci
 builder_run_action build        do_build
 builder_run_action api          api-extractor run --local --verbose
 builder_run_action test         typescript_run_eslint_mocha_tests
-builder_run_action publish      ci_publish_npm
-

--- a/developer/src/kmc-package/build.sh
+++ b/developer/src/kmc-package/build.sh
@@ -11,7 +11,6 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/typescript.inc.sh"
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 
 builder_describe "Build Keyman kmc Package Compiler module" \
   "@/common/web/keyman-version" \
@@ -21,10 +20,8 @@ builder_describe "Build Keyman kmc Package Compiler module" \
   "build" \
   "api                       analyze API and prepare API documentation" \
   "clean" \
-  "test" \
-  "publish                   publish to npm" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "test"
+
 builder_describe_outputs \
   configure     /node_modules \
   build         /developer/src/kmc-package/build/src/main.js \
@@ -39,4 +36,3 @@ builder_run_action configure  node_select_version_and_npm_ci
 builder_run_action build      tsc --build
 builder_run_action api        api-extractor run --local --verbose
 builder_run_action test       typescript_run_eslint_mocha_tests
-builder_run_action publish     ci_publish_npm

--- a/developer/src/kmc/README.md
+++ b/developer/src/kmc/README.md
@@ -175,14 +175,6 @@ The temp_path must be a path outside the repository to avoid npm getting
 confused by the root package.json. This is called by inst/download.in.mak
 normally when building the Keyman Developer installer.
 
-## Publishing to NPM
-
-```shell
-./build.sh publish [--dry-run]
-```
-
-Publishes the current release to NPM. This should only be run from CI.
-
 
 [kmc]: https://help.keyman.com/developer/current-version/reference/kmc/cli
 [file-layout]: https://help.keyman.com/developer/current-version/reference/file-layout

--- a/developer/src/kmc/build.sh
+++ b/developer/src/kmc/build.sh
@@ -8,11 +8,10 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../resources/build/builder-full.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/node.inc.sh"
 . "$KEYMAN_ROOT/resources/build/typescript.inc.sh"
-. "$KEYMAN_ROOT/developer/src/packages.inc.sh"
+. "$KEYMAN_ROOT/resources/build/ci/npm-packages.inc.sh"
 
 builder_describe "Build Keyman Keyboard Compiler kmc" \
   "@/common/include" \
@@ -35,10 +34,7 @@ builder_describe "Build Keyman Keyboard Compiler kmc" \
   "bundle                    creates a bundled version of kmc" \
   "api                       prepare compiler error documentation" \
   "test                      run automated tests for kmc" \
-  publish \
-  "--build-path=BUILD_PATH   build directory for bundle" \
-  "--npm-publish+            For publish, do a npm publish, not npm pack (only for CI)" \
-  "--dry-run,-n              don't actually publish, just dry run"
+  "--build-path=BUILD_PATH   build directory for bundle"
 
 builder_describe_outputs \
   configure     /node_modules \
@@ -114,4 +110,3 @@ builder_run_action build      do_build
 builder_run_action test       do_test
 builder_run_action api        do_api
 builder_run_action bundle     do_bundle
-builder_run_action publish    ci_publish_npm

--- a/docs/npm-packages.md
+++ b/docs/npm-packages.md
@@ -3,16 +3,21 @@
 This is a guide for how the various Keyman `npm` packages are developed
 and published.
 
-`npm` packages are published on the CI (continuous integration) server.
-Currently, we're using TeamCity for this.
+`npm` packages are published through CI (continuous integration). This is done
+through the `.github/workflows/npm-publish.yml` GitHub Action.
 
 Packages are **never** published from a developer's machine.
 
 ## List of current published npm packages
 
+* See `resources/build/ci/npm-packages.inc.sh` for an authoritative list.
+
 * `@keymanapp/common-types` -- located at `common/web/types`
 * `@keymanapp/keyman-version` -- located at `common/web/keyman-version`
 * `@keymanapp/kmc` -- located at `developer/src/kmc`
+* `@keymanapp/kmc-analyze` -- located at `developer/src/kmc-analyze`
+* `@keymanapp/kmc-copy` -- located at `developer/src/kmc-copy`
+* `@keymanapp/kmc-generate` -- located at `developer/src/kmc-generate`
 * `@keymanapp/kmc-keyboard-info` -- located at `developer/src/kmc-keyboard-unfo`
 * `@keymanapp/kmc-kmn` -- located at `developer/src/kmc-kmn`
 * `@keymanapp/kmc-ldml` -- located at `developer/src/kmc-ldml`
@@ -20,6 +25,7 @@ Packages are **never** published from a developer's machine.
 * `@keymanapp/kmc-model-info` -- located at `developer/src/kmc-model-info`
 * `@keymanapp/kmc-package` -- located at `developer/src/kmc-package`
 * `@keymanapp/langtags` -- located at `common/web/langtags`
+* `@keymanapp/ldml-keyboard-constants` -- located at `core/include/dml`
 
 ### Deprecated npm packages
 
@@ -34,22 +40,16 @@ Packages are **never** published from a developer's machine.
 
 ### In general
 
-Before publishing, a package must be **built** and **tested** on the CI
-server.
-
-This is typically done with:
+Before publishing, a package must be **built** and **tested**. This is typically
+done with:
 
 ```bash
 ./build.sh configure build test
 ```
 
-Once the build succeeds and the tests pass, you can publish! Use the following
-script for this (**only on the CI server**!); during this, the version is set in
-`package.json`:
-
-```bash
-./build.sh publish
-```
+Once the build succeeds and the tests pass, you can publish! Add the package to
+`resources/build/ci/npm-packages.inc.sh` and it will be published in the next
+alpha release build.
 
 It is then uploaded to the npm package directory. **Ensure that the compiled
 sources are included in the tarball**. For example:
@@ -94,26 +94,5 @@ npm notice 740B   tsconfig.json
 npm notice 449B   tsconfig.kmc-base.json
 ```
 
-For every release of **Keyman Developer**, the CI publishes a release of
-`@keymanapp/kmc`. The version number is locked with the particular version of
-Keyman Developer.
+For every release build, CI publishes a release of all packages.
 
-### `builder_publish_npm`
-
-Publishes the package in `cwd` to npm
-
-If the `--dry-run` option is available and specified as a command-line
-parameter, will do a dry run
-
-Note that `package.json` will be dirty after this command, as the `version`
-field will be added to it, and @keymanapp dependency versions will also be
-modified. This change should not be committed to the repository.
-
-If --npm-publish is set:
-* then builder_publish_npm publishes to the public registry
-* else builder_publish_npm creates a local tarball which can be used to test
-
-```bash
-  . "$KEYMAN_ROOT/resources/build/build-utils-ci.inc.sh"
-  builder_publish_npm
-```

--- a/resources/build/ci/cancel-builds/trigger_definitions.mjs
+++ b/resources/build/ci/cancel-builds/trigger_definitions.mjs
@@ -6,7 +6,7 @@ export const testBuildConfigurations = {
   'mac': ['Keyman_KeymanMac_PullRequests', 'Keyman_Common_KPAPI_TestPullRequests_macOS'],
   'windows': ['KeymanDesktop_TestPullRequests', 'KeymanDesktop_TestPrRenderOnScreenKeyboards', 'Keyman_Common_KPAPI_TestPullRequests_Windows'],
   'web': ['Keymanweb_TestPullRequests', 'Keyman_Common_KPAPI_TestPullRequests_WASM'],
-  'developer': ['Keyman_Developer_Test'],
+  'developer': ['Keyman_Developer_Test', 'npm-publish_GitHub'],
 
   'common_web': ['Keyman_Test_Common_Web'],
   'common_windows': ['Keyman_Test_Common_Windows'],

--- a/resources/build/ci/ci-publish.inc.sh
+++ b/resources/build/ci/ci-publish.inc.sh
@@ -8,39 +8,10 @@
 
 . "$KEYMAN_ROOT/resources/build/jq.inc.sh"
 
-#
-# Publishes the package in `cwd` to npm
-#
-# If the `--dry-run` option is available and specified as a command-line
-# parameter, will do a dry run
-#
-# Note that `package.json` will be dirty after this command, as the `version`
-# field will be added to it, and @keymanapp dependency versions will also be
-# modified. This change should not be committed to the repository.
-#
-# If --npm-publish is set:
-#  * then ci_publish_npm publishes to the public registry
-#  * else ci_publish_npm creates a local tarball which can be used to test
-#
-# Usage:
-# ```bash
-#   ci_publish_npm
-# ```
-#
-function ci_publish_npm() {
-  if builder_has_option --npm-publish; then
-    # Require --dry-run if local or test to avoid accidentally clobbering npm packages
-    if [[ $KEYMAN_VERSION_ENVIRONMENT =~ local|test ]] && ! builder_has_option --dry-run; then
-      builder_die "publish --npm-publish must use --dry-run flag for local or test builds"
-    fi
-    _ci_publish_npm_package publish
-  else
-    _ci_publish_npm_package pack
-  fi
-}
-
-function _ci_publish_npm_package() {
-  local action=$1
+# Used only by npm-publish.sh
+function ci_publish_npm_package() {
+  local action="$1"
+  local package="$2"
   local dist_tag=$KEYMAN_TIER dry_run=
 
   if [[ $KEYMAN_TIER == stable ]]; then
@@ -50,6 +21,8 @@ function _ci_publish_npm_package() {
   if builder_has_option --dry-run; then
     dry_run=--dry-run
   fi
+
+  pushd "${KEYMAN_ROOT}/${package}" >/dev/null
 
   _ci_publish_cache_package_json
   _ci_write_npm_version
@@ -62,12 +35,14 @@ function _ci_publish_npm_package() {
   if [[ $action == pack ]]; then
     # We can use --publish-to-pack to locally test a package
     # before publishing to the package registry
-    echo "Packing $dry_run npm package $THIS_SCRIPT_IDENTIFIER with tag $dist_tag"
+    echo "Packing $dry_run npm package ${package} with tag $dist_tag"
     npm pack $dry_run --access public --tag $dist_tag
   else # $action == publish
-    echo "Publishing $dry_run npm package $THIS_SCRIPT_IDENTIFIER with tag $dist_tag"
+    echo "Publishing $dry_run npm package ${package} with tag $dist_tag"
     npm publish $dry_run --access public --tag $dist_tag
   fi
+
+  popd >/dev/null
 }
 
 function _ci_write_npm_version() {

--- a/resources/build/ci/npm-packages.inc.sh
+++ b/resources/build/ci/npm-packages.inc.sh
@@ -1,7 +1,8 @@
+#
+# Keyman is copyright (C) SIL Global. MIT License.
+#
 # List of all NPM packages that need to be published
 #
-# TODO: this should really be somewhere else, but right now Developer CI is
-#       responsible for pulling the publish lever
 
 readonly PACKAGES=(
   common/web/keyman-version

--- a/resources/build/ci/npm-publish.sh
+++ b/resources/build/ci/npm-publish.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Keyman is copyright (C) SIL Global. MIT License.
+#
+# Publish all the @keymanapp packages listed in npm-packages.inc.sh
+#
+# If the `--dry-run` option is available and specified as a command-line
+# parameter, will do a dry run
+#
+# Note that `package.json` will be dirty after this command, as the `version`
+# field will be added to it, and @keymanapp dependency versions will also be
+# modified. This change should not be committed to the repository.
+#
+# If `publish` is called:
+#  * then ci_publish_npm publishes to the public registry
+#  * else ci_publish_npm creates a local tarball which can be used to test
+#
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/../../../resources/build/builder-full.inc.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+. "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
+. "$KEYMAN_ROOT/resources/build/ci/npm-packages.inc.sh"
+
+builder_describe \
+  "Publish @keymanapp packages to NPM" \
+  "pack              Pack NPM packages to a .tgz for verification" \
+  "publish           Publish NPM packages to the NPM Registry" \
+  "--dry-run         Don't publish/pack anything, just dry run"
+
+builder_parse "$@"
+
+#-------------------------------------------------------------------------------------------------------------------
+
+function do_pack() {
+  local npm_package_path
+  for npm_package_path in "${PACKAGES[@]}"; do
+    builder_heading "Packing $npm_package_path"
+    ci_publish_npm_package pack "$npm_package_path"
+  done
+}
+
+function do_publish() {
+  local npm_package_path
+
+  if [[ $KEYMAN_VERSION_ENVIRONMENT =~ local|test ]] && ! builder_has_option --dry-run; then
+    builder_die "publish must use --dry-run flag for local or test builds"
+  fi
+
+  for npm_package_path in "${PACKAGES[@]}"; do
+    builder_heading "Publishing $npm_package_path"
+    ci_publish_npm_package publish "$npm_package_path"
+  done
+}
+
+builder_run_action pack    do_pack
+builder_run_action publish do_publish

--- a/resources/build/ci/trigger-definitions.inc.sh
+++ b/resources/build/ci/trigger-definitions.inc.sh
@@ -89,7 +89,7 @@ bc_test_linux=(KeymanLinux_TestPullRequests Keyman_Linux_Test_Integration Keyman
 bc_test_mac=(Keyman_KeymanMac_PullRequests Keyman_Common_KPAPI_TestPullRequests_macOS)
 bc_test_windows=(KeymanDesktop_TestPullRequests KeymanDesktop_TestPrRenderOnScreenKeyboards Keyman_Common_KPAPI_TestPullRequests_Windows)
 bc_test_web=(Keymanweb_TestPullRequests Keyman_Common_KPAPI_TestPullRequests_WASM)
-bc_test_developer=(Keyman_Developer_Test Keyman_Test_Developer_Mac Keyman_Test_Developer_Linux)
+bc_test_developer=(Keyman_Developer_Test Keyman_Test_Developer_Mac Keyman_Test_Developer_Linux npm-publish_GitHub)
 
 bc_test_common_web=(Keyman_Test_Common_Web)
 bc_test_common_windows=(Keyman_Test_Common_Windows)
@@ -116,7 +116,7 @@ bc_master_linux=(KeymanLinux_Master deb-release-packaging_GitHub build-test-publ
 bc_master_mac=(KeymanMac_Master)
 bc_master_windows=(Keyman_Build)
 bc_master_web=(Keymanweb_Build)
-bc_master_developer=(Keyman_Developer_Release)
+bc_master_developer=(Keyman_Developer_Release npm-publish_GitHub)
 
 vcs_master=HttpsGithubComKeymanappKeyman
 
@@ -128,7 +128,7 @@ bc_beta_linux=(KeymanLinux_Master deb-release-packaging_GitHub)
 bc_beta_mac=(KeymanMac_Master)
 bc_beta_windows=(Keyman_Build)
 bc_beta_web=(Keymanweb_Build)
-bc_beta_developer=(Keyman_Developer_Release)
+bc_beta_developer=(Keyman_Developer_Release npm-publish_GitHub)
 
 vcs_beta=HttpsGithubComKeymanappKeyman
 
@@ -140,7 +140,7 @@ bc_stable_18_0_linux=(KeymanLinux_Master deb-release-packaging_GitHub)
 bc_stable_18_0_mac=(KeymanMac_Master)
 bc_stable_18_0_windows=(Keyman_Build)
 bc_stable_18_0_web=(Keymanweb_Build)
-bc_stable_18_0_developer=(Keyman_Developer_Release)
+bc_stable_18_0_developer=(Keyman_Developer_Release npm-publish_GitHub)
 
 vcs_stable_18_0=HttpsGithubComKeymanappKeyman
 
@@ -152,6 +152,6 @@ bc_stable_19_0_linux=(KeymanLinux_Master deb-release-packaging_GitHub)
 bc_stable_19_0_mac=(KeymanMac_Master)
 bc_stable_19_0_windows=(Keyman_Build)
 bc_stable_19_0_web=(Keymanweb_Build)
-bc_stable_19_0_developer=(Keyman_Developer_Release)
+bc_stable_19_0_developer=(Keyman_Developer_Release npm-publish_GitHub)
 
 vcs_stable_19_0=HttpsGithubComKeymanappKeyman

--- a/resources/teamcity/developer/keyman-developer-release.sh
+++ b/resources/teamcity/developer/keyman-developer-release.sh
@@ -41,7 +41,7 @@ cd "${KEYMAN_ROOT}/developer/src"
 function _build_developer() {
   builder_echo start "build developer" "Building Keyman Developer"
 
-  ./build.sh configure build test api publish --npm-publish
+  ./build.sh configure build test api publish
 
   builder_echo end "build developer" success "Finished building Keyman Developer"
 }

--- a/resources/teamcity/developer/keyman-developer-test-windows.sh
+++ b/resources/teamcity/developer/keyman-developer-test-windows.sh
@@ -55,12 +55,12 @@ function _build_testkeyboards() {
 }
 
 function publish_sentry_action() {
-  builder_echo start "publish" "Dry-run publish and api"
-  ./build.sh api publish --dry-run
-  builder_echo end "publish" "Dry-run publish and api"
+  builder_echo start "publish" "publish modules locally and prep api"
+  ./build.sh api publish
+  builder_echo end "publish" "publish modules locally and prep api"
 
   builder_echo start "publish sentry" "Publishing debug information files to Sentry"
-  # TODO: move this into build.sh publish? re-scope --dry-run into build.sh?
+  # TODO: move this into build.sh publish?
   "${KEYMAN_ROOT}/developer/src/tools/sentry-upload-difs.sh"
   builder_echo end "publish sentry" success "Finished publishing debug information files to Sentry"
 }

--- a/windows/src/desktop/build.sh
+++ b/windows/src/desktop/build.sh
@@ -6,7 +6,6 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
-. "$KEYMAN_ROOT/developer/src/packages.inc.sh"
 
 builder_describe \
   "Keyman for Windows (app)" \


### PR DESCRIPTION
Due to recent changes in npm package publishing security requirements, we have to move from TeamCity build to a GitHub Action to publish our npm packages, so we can take advantage of trusted publishing. This change also consolidates and centralizes the npm publishing into resources/build/ci/npm-publish.sh, which removes a lot of boilerplate from each of the build.sh scripts, and ensures consistency.

Packages will be `npm pack`ed on PR and test builds, and published in release builds.

Ref: https://docs.npmjs.com/trusted-publishers
Ref: https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/
Fixes: #14963
Test-bot: skip
Build-bot: release:developer