### PR TITLE
feat(web): implement SearchCluster splitting 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
@@ -8,7 +8,7 @@
  * engine.
  */
 
-import { QueueComparator as Comparator, KMWString, PriorityQueue } from '@keymanapp/web-utils';
+import { QueueComparator, KMWString, PriorityQueue } from '@keymanapp/web-utils';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 import { buildMergedTransform } from '@keymanapp/models-templates';
 
@@ -23,7 +23,7 @@ import LexicalModel = LexicalModelTypes.LexicalModel;
 import ProbabilityMass = LexicalModelTypes.ProbabilityMass;
 import Transform = LexicalModelTypes.Transform;
 
-export const QUEUE_NODE_COMPARATOR: Comparator<SearchNode> = function(arg1, arg2) {
+export const QUEUE_NODE_COMPARATOR: QueueComparator<SearchNode> = function(arg1, arg2) {
   return arg1.currentCost - arg2.currentCost;
 }
 
@@ -497,7 +497,7 @@ export abstract class SearchQuotientSpur implements SearchQuotientNode {
   }
 
   isSameNode(space: SearchQuotientNode): boolean {
-    // Easiest cases:  when the instances or their ' `spaceId` matches, we have
+    // Easiest cases:  when the instances or their `spaceId` matches, we have
     // a perfect match.
     if(this == space || this.spaceId == space.spaceId) {
       return true;

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-state.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-state.tests.ts
@@ -409,7 +409,7 @@ describe('ContextState', () => {
       assert.equal(state.tokenization.tokens[state.tokenization.tokens.length - 1].searchModule.inputCount, 1);
     });
 
-    it.skip('handles case where tail token is split into three rather than two', function() {
+    it('handles case where tail token is split into three rather than two', function() {
       let baseContext = models.tokenize(defaultBreaker, {
         left: "text'", startOfBuffer: true, endOfBuffer: true
       });

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -561,7 +561,7 @@ describe('ContextTokenization', function() {
       }
     });
 
-    it.skip('handles case that triggers a token merge:  can+\'+t', () => {
+    it('handles case that triggers a token merge:  can+\'+t', () => {
       const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day', ' ', 'can', '\''];
       const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)));
 

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/search-quotient-cluster.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/search-quotient-cluster.tests.ts
@@ -3,7 +3,7 @@
  *
  * Created by jahorton on 2025-10-29
  *
- * This file defines tests for the SearchSpace class of the
+ * This file defines tests for the SearchQuotientCluster class of the
  * predictive-text correction-search engine.
  */
 


### PR DESCRIPTION
This PR serves to implement `SearchQuotientCluster.split()` in full, meeting the following criteria:

1. If two or more paths result in an identical left-hand split result, that result should be deduplicated to a single instance.
        -  This requires (live) use of the `.isSameNode()` method from #15478, which is designed to identify such cases.  It thus is no longer unit-test only.
2. The results must meet the criteria for 'convergence' as described in #15104 - even if that means returning _multiple possible split tuples_.
        - We must not group left-hand side paths (or right-hand side paths) that represent different subsets of the user's original keystrokes.
3.  The `SearchQuotientCluster` type should be leveraged for results where applicable - where two or more paths converge to the same total subset of keystroke input + codepoint length.

Build-bot: skip build:web
Test-bot: skip