### PR TITLE
maint(resources): use actions/setup-node to upgrade npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,14 +39,22 @@ jobs:
       with:
         ref: '${{ github.event.client_payload.buildSha }}'
 
-    - name: Upgrade npm to 11.6.2
+
+    - name: Report initial npm/node versions
       run: |
-        echo "Initial npm version"
+        echo "Initial npm/node versions"
         npm -v
-        echo "Upgrading npm to 11.6.2"
-        npm install --global npm@11.6.2
-        echo "Current npm version"
+        node -v
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 24.10
+
+    - name: Report current npm/node versions
+      run: |
+        echo "Current npm/node versions"
         npm -v
+        node -v
 
     - name: Set pending status on PR builds
       id: set_status


### PR DESCRIPTION
We [don't have permissions](https://github.com/keymanapp/keyman/actions/runs/18866714273) to use `npm install --global npm` to get a specific version, but this action is supported by GH so should be fine.

It remains to be seen if there will be other compatibility issues due to being a later version of Node than what we are using in v19.

Follows: #15029
Build-bot: skip
Test-bot: skip