### PR TITLE
maint(resources): use a string for version, rather than number

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,20 +56,6 @@ jobs:
         npm -v
         node -v
 
-    - name: Set pending status on PR builds
-      id: set_status
-      if: github.event.client_payload.isTestBuild == 'true'
-      shell: bash
-      run: |
-        gh api \
-          --method POST \
-          -H "Accept: application/vnd.github+json" \
-          /repos/$GITHUB_REPOSITORY/statuses/${{ github.event.client_payload.buildSha }} \
-          -f state='pending' \
-          -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-          -f description='NPM pack started' \
-          -f context="$STATUS_CONTEXT"
-
     - name: NPM pack
       if: github.event.client_payload.isTestBuild == 'true'
       run: |


### PR DESCRIPTION
Follows: #15029
Test-bot: skip
Build-bot: skip