### PR TITLE
maint(resources): don't report status check on release builds for npm-publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,6 +56,7 @@ jobs:
 
     - name: Set pending status
       id: set_status
+      if: github.event.client_payload.isTestBuild == 'true'
       shell: bash
       run: |
         gh api \
@@ -131,6 +132,7 @@ jobs:
         echo "MSG=npm $NPM_ACTION failed" >> $GITHUB_ENV
 
     - name: Set final status
+      if: github.event.client_payload.isTestBuild == 'true'
       run: |
         gh api \
           --method POST \


### PR DESCRIPTION
This matches the pattern from deb-packaging.yml. It would be worth reviewing why the sha doesn't match up?

Follows: #15029
Build-bot: skip
Test-bot: skip