### PR TITLE
maint(resources): add repository record for all published packages

### DIFF
--- a/common/web/keyman-version/package.json
+++ b/common/web/keyman-version/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@keymanapp/keyman-version",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "common/web/keyman-version"
+  },
   "description": "Keyman global version data",
   "exports": {
     ".": {

--- a/common/web/langtags/package.json
+++ b/common/web/langtags/package.json
@@ -33,7 +33,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "common/web/langtags"
   },
   "sideEffects": false
 }

--- a/common/web/types/package.json
+++ b/common/web/types/package.json
@@ -54,7 +54,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "common/web/types"
   },
   "c8": {
     "all": true,

--- a/core/include/ldml/package.json
+++ b/core/include/ldml/package.json
@@ -16,6 +16,7 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "core/include/ldml"
   }
 }

--- a/developer/src/common/web/utils/package.json
+++ b/developer/src/common/web/utils/package.json
@@ -43,6 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/common/web/utils"
   }
 }

--- a/developer/src/kmc-analyze/package.json
+++ b/developer/src/kmc-analyze/package.json
@@ -43,6 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/kmc-analyze"
   }
 }

--- a/developer/src/kmc-copy/package.json
+++ b/developer/src/kmc-copy/package.json
@@ -58,6 +58,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/kmc-copy"
   }
 }

--- a/developer/src/kmc-generate/package.json
+++ b/developer/src/kmc-generate/package.json
@@ -59,6 +59,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/kmc-generate"
   }
 }

--- a/developer/src/kmc-keyboard-info/package.json
+++ b/developer/src/kmc-keyboard-info/package.json
@@ -43,6 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/kmc-keyboard-info"
   }
 }

--- a/developer/src/kmc-kmn/package.json
+++ b/developer/src/kmc-kmn/package.json
@@ -61,6 +61,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/kmc-kmn"
   }
 }

--- a/developer/src/kmc-ldml/package.json
+++ b/developer/src/kmc-ldml/package.json
@@ -65,6 +65,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/kmc-ldml"
   }
 }

--- a/developer/src/kmc-model-info/package.json
+++ b/developer/src/kmc-model-info/package.json
@@ -48,6 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/kmc-model-info"
   }
 }

--- a/developer/src/kmc-model/package.json
+++ b/developer/src/kmc-model/package.json
@@ -63,6 +63,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/kmc-model"
   }
 }

--- a/developer/src/kmc-package/package.json
+++ b/developer/src/kmc-package/package.json
@@ -61,6 +61,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/kmc-package"
   }
 }

--- a/developer/src/kmc/package.json
+++ b/developer/src/kmc/package.json
@@ -81,6 +81,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keymanapp/keyman.git"
+    "url": "git+https://github.com/keymanapp/keyman.git",
+    "directory": "developer/src/kmc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
       "fast-json-patch": "^3.1.1"
     }
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/keymanapp/keyman.git"
+  },
   "engines": {
     "node": "20.16.0"
   }


### PR DESCRIPTION
While not documented as such, it appears that the repository record is required with trusted publishing of npm packages:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@keymanapp%2fkeyman-version - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/keymanapp/keyman" from provenance
```

https://github.com/keymanapp/keyman/actions/runs/18906640000/job/53966373630

Follows: #15029
Test-bot: skip
Build-bot: skip