### PR TITLE
chore(developer): further debugging for assertion failure

### DIFF
--- a/developer/src/common/delphi/components/KeymanDeveloperDebuggerMemo.pas
+++ b/developer/src/common/delphi/components/KeymanDeveloperDebuggerMemo.pas
@@ -36,6 +36,7 @@ type
   TMemoSelection = record
     Start, Finish: Integer;
     Anchor: Integer;
+    function ToString: string;
   end;
 
   TKeymanDeveloperDebuggerMemo = class(TRichEdit41)
@@ -107,6 +108,8 @@ end;
 
 function TKeymanDeveloperDebuggerMemo.GetSelection: TMemoSelection;
 begin
+  Result.Anchor := 0;
+
   // EM_GETSEL doesn't tell us the anchor position, but we can figure
   // it out with this kludge. I am not aware of side effects from this
   // at this time.
@@ -168,6 +171,13 @@ end;
 procedure Register;
 begin
   RegisterComponents('Keyman', [TKeymanDeveloperDebuggerMemo]);
+end;
+
+{ TMemoSelection }
+
+function TMemoSelection.ToString: string;
+begin
+  Result := Format('%d %d %d', [Start, Finish, Anchor]);
 end;
 
 end.

--- a/developer/src/tike/debug/Keyman.System.Debug.DebugEvent.pas
+++ b/developer/src/tike/debug/Keyman.System.Debug.DebugEvent.pas
@@ -62,6 +62,7 @@ type
   public
     constructor Create;
     destructor Destroy; override;
+    function ToString: string; override;
     property Action: TDebugEventActionData read FAction;
     property Rule: TDebugEventRuleData read FRule;
     property EventType: TDebugEventType read FEventType write SetEventType;
@@ -94,6 +95,8 @@ type
       vk: uint16_t;
       modifier_state: uint16_t
     ): Boolean; overload;
+
+    function ToString: string; override;
   end;
 
 implementation
@@ -131,6 +134,23 @@ begin
       etAction:    FAction := TDebugEventActionData.Create;
       etRuleMatch: FRule := TDebugEventRuleData.Create;
     end;
+  end;
+end;
+
+function TDebugEvent.ToString: string;
+begin
+  // Debug string
+  if FEventType = etAction then
+  begin
+    Result := Format('A %d %d %d "%s"', [Ord(FAction.ActionType), FAction.dwData, FAction.nExpectedValue, FAction.Text]);
+  end
+  else if FEventType = etRuleMatch then
+  begin
+    Result := Format('R %d %x %x %d "%s"', [FRule.ItemType, FRule.Key.VirtualKey, FRule.Key.Modifiers, FRule.Line, FRule.Context]);
+  end
+  else
+  begin
+    Result := '?'+IntToStr(Ord(FEventType));
   end;
 end;
 
@@ -328,6 +348,15 @@ begin
     Result := Result and AddActionItem(vk, action);
     Inc(action);
   end;
+end;
+
+function TDebugEventList.ToString: string;
+var
+  I: Integer;
+begin
+  Result := '';
+  for I := 0 to Count - 1 do
+    Result := Result + '['+IntToStr(I)+': '+Items[I].ToString + '] ';
 end;
 
 function TDebugEventList.AddStateItems(


### PR DESCRIPTION
Adds breadcrumbs for debug memo to try and narrow down sequence of events leading to assertion failure with backspace.

Relates-to: #11706
Test-bot: skip