### PR TITLE
fix(developer): handle exceptions loading .keyman-touch-layout files

### DIFF
--- a/developer/src/tike/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/developer/src/tike/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -355,8 +355,16 @@ begin
 
     with TStringList.Create do
     try
-      LoadFromFile(FBaseFileName, TEncoding.UTF8);
-      FNewLayoutJS := Text;
+      try
+        LoadFromFile(FBaseFileName, TEncoding.UTF8);
+        FNewLayoutJS := Text;
+      except
+        on E:Exception do
+        begin
+          ShowMessage(E.Message);
+          Exit(False);
+        end;
+      end;
     finally
       Free;
     end;


### PR DESCRIPTION
If file is unreadable or contains invalid encoding, show a message instead of crashing.

Build-bot: skip
Test-bot: skip