### PR TITLE
fix(developer): avoid race in page.onload vs kmw.init in Server

### DIFF
--- a/developer/src/server/build.sh
+++ b/developer/src/server/build.sh
@@ -18,6 +18,7 @@ builder_describe "Build Keyman Developer Server" \
   configure \
   build \
   test \
+  "run         Run Server in dev mode" \
   "installer   Prepare for Keyman Developer installer" \
   publish \
   ":server     Keyman Developer Server main program" \
@@ -165,11 +166,16 @@ function publish_server() {
   wrap-signcode //d "Keyman Developer" "$DEVELOPER_PROGRAM/server/build/src/win32/trayicon/addon.x64.node"
 }
 
+function run_server() {
+  node .
+}
+
 builder_run_action clean:server        clean_server
 builder_run_action configure:server    configure_server
 builder_run_action build:addins        build_addins
 builder_run_action build:server        build_server
 builder_run_action test:server         test_server
+builder_run_action run:server          run_server
 # builder_run_action test:addins       # no op
 builder_run_action installer:server    installer_server # TODO: rename to install-prep
 builder_run_action publish:server      publish_server

--- a/developer/src/server/src/site/lib/sentry/init.js.in
+++ b/developer/src/server/src/site/lib/sentry/init.js.in
@@ -7,11 +7,13 @@
 // DO NOT MODIFY init.js; instead make changes in init.js.in.
 //
 
-Sentry.init({
-  dsn: 'https://39b25a09410349a58fe12aaf721565af@o1005580.ingest.sentry.io/5983519',  // Keyman Developer
-  environment: '$KEYMAN_VERSION_ENVIRONMENT',
-  release: '$KEYMAN_VERSION_GIT_TAG'
-});
+if(typeof Sentry != 'undefined') {
+  Sentry.init({
+    dsn: 'https://39b25a09410349a58fe12aaf721565af@o1005580.ingest.sentry.io/5983519',  // Keyman Developer
+    environment: '$KEYMAN_VERSION_ENVIRONMENT',
+    release: '$KEYMAN_VERSION_GIT_TAG'
+  });
+}
 
 function keymanEnableDiagnostics() {
   var e = document.createElement('button');

--- a/developer/src/server/src/site/test.js
+++ b/developer/src/server/src/site/test.js
@@ -41,6 +41,7 @@ function enableControls(enable) {
   });
 }
 
+let shouldSetupKeyman = false;
 let keymanInitialized = false;
 enableControls(false);
 
@@ -58,7 +59,13 @@ keyman.init({
 }).then(function() {
   keyman.attachToControl(document.getElementById('ta1'));
   enableControls(true);
+
   keymanInitialized = true;
+
+  if(shouldSetupKeyman) {
+    console.log('keyman.init after window.onload');
+    setupKeyman();
+  }
 });
 
 /* Initialization */
@@ -190,6 +197,15 @@ document.getElementById('ta1').addEventListener('input', logContent, false);
 */
 
 window.onload = function() {
+  if(keymanInitialized) {
+    console.log('keyman.init before window.onload');
+    setupKeyman();
+  } else {
+    shouldSetupKeyman = true;
+  }
+}
+
+function setupKeyman() {
   window.setTimeout(
     function () {
       keyman.moveToElement('ta1');
@@ -199,6 +215,8 @@ window.onload = function() {
   let newOSK = null;
   let deviceDropdown = null;
   let currentDevice = null;
+
+  checkKeyboardsAndModels(false);
 
   buildKeyboardList();
 
@@ -333,6 +351,10 @@ function handleKeyboardsAndModelsResponse(responseText, shouldReload) {
 }
 
 function checkKeyboardsAndModels(shouldReload) {
+  if(!keymanInitialized) {
+    // setupKeyman will run the check after initialization
+    return false;
+  }
   let req=new XMLHttpRequest();
   console.log('Checking for updated keyboards and models ('+shouldReload+')');
   req.onreadystatechange = function() {
@@ -344,9 +366,8 @@ function checkKeyboardsAndModels(shouldReload) {
   }
   req.open("GET", "inc/keyboards.js", true);
   req.send(null);
+  return true;
 }
-
-checkKeyboardsAndModels(false);
 
 /* Lexical models */
 


### PR DESCRIPTION
Also adds `server:run` action for build.sh, and adds check for scenario where an ad blocker/privacy extension blocks sentry javascript loading.

Fixes: #11363
Fixes: KEYMAN-DEVELOPER-30X

# User Testing

TEST_SERVER: Please try loading the Keyman Developer Server page on various devices. Verify that the last used keyboard reloads successfully on the test page. Check the console to ensure that no errors have been generated. Try reloading and refreshing a few times to verify that it works each time.