### PR TITLE
fix(developer): remove package version if FollowKeyboardVersion is set in Package Editor

### DIFF
--- a/common/windows/delphi/packages/PackageInfo.pas
+++ b/common/windows/delphi/packages/PackageInfo.pas
@@ -455,6 +455,7 @@ type
     procedure DoSaveJSON(ARoot: TJSONObject); virtual;
     procedure DoLoadIni(ini: TIniFile); virtual;
     procedure DoSaveIni(ini: TIniFile); virtual;
+    procedure Cleanup; virtual;
   public
     Options: TPackageOptions;
     StartMenu: TPackageStartMenu;
@@ -1889,11 +1890,18 @@ begin
   end;
 end;
 
+procedure TPackage.Cleanup;
+begin
+  // No op in basic package
+end;
+
 procedure TPackage.SaveXML;
 var
   doc: IXMLDocument;
   root: IXMLNode;
 begin
+  Cleanup;
+
   doc := NewXMLDocument;
   doc.Encoding := 'utf-8';
 
@@ -1914,6 +1922,8 @@ var
   doc: IXMLDocument;
   root: IXMLNode;
 begin
+  Cleanup;
+
   doc := NewXMLDocument;
   doc.Encoding := 'utf-8';
 

--- a/developer/src/common/delphi/packages/kpsfile.pas
+++ b/developer/src/common/delphi/packages/kpsfile.pas
@@ -70,6 +70,7 @@ type
     procedure DoSaveJSON(ARoot: TJSONObject); override;
     procedure DoLoadIni(ini: TIniFile); override;
     procedure DoSaveIni(ini: TIniFile); override;
+    procedure Cleanup; override;
   public
 
     function KPSOptions: TKPSOptions;
@@ -108,6 +109,15 @@ begin
   inherited;
   if Source is TKPSFile then
     FStrings.Assign((Source as TKPSFile).Strings);
+end;
+
+procedure TKPSFile.Cleanup;
+begin
+  inherited;
+  if KPSOptions.FollowKeyboardVersion then
+  begin
+    Info.Desc[PackageInfo_Version] := '';
+  end;
 end;
 
 constructor TKPSFile.Create;

--- a/developer/src/tike/child/UfrmPackageEditor.pas
+++ b/developer/src/tike/child/UfrmPackageEditor.pas
@@ -635,21 +635,21 @@ end;
 procedure TfrmPackageEditor.editInfoNameChange(Sender: TObject);
 begin
   if FSetup > 0 then Exit;
-  pack.Info.Desc['Name'] := Trim(editInfoName.Text);
+  pack.Info.Desc[PackageInfo_Name] := Trim(editInfoName.Text);
   Modified := True;
 end;
 
 procedure TfrmPackageEditor.editInfoVersionChange(Sender: TObject);
 begin
   if FSetup > 0 then Exit;
-  pack.Info.Desc['Version'] := Trim(editInfoVersion.Text);
+  pack.Info.Desc[PackageInfo_Version] := Trim(editInfoVersion.Text);
   Modified := True;
 end;
 
 procedure TfrmPackageEditor.editInfoCopyrightChange(Sender: TObject);
 begin
   if FSetup > 0 then Exit;
-  pack.Info.Desc['Copyright'] := Trim(editInfoCopyright.Text);
+  pack.Info.Desc[PackageInfo_Copyright] := Trim(editInfoCopyright.Text);
   Modified := True;
 end;
 
@@ -663,7 +663,7 @@ end;
 procedure TfrmPackageEditor.editInfoAuthorChange(Sender: TObject);
 begin
   if FSetup > 0 then Exit;
-  pack.Info.Desc['Author'] := Trim(editInfoAuthor.Text);
+  pack.Info.Desc[PackageInfo_Author] := Trim(editInfoAuthor.Text);
   Modified := True;
 end;
 
@@ -671,16 +671,16 @@ procedure TfrmPackageEditor.editInfoEmailChange(Sender: TObject);
 begin
   if FSetup > 0 then Exit;
   if Trim(editInfoEmail.Text) = ''
-    then pack.Info.URL['Author'] := ''
-    else pack.Info.URL['Author'] := 'mailto:'+Trim(editInfoEmail.Text);
+    then pack.Info.URL[PackageInfo_Author] := ''
+    else pack.Info.URL[PackageInfo_Author] := 'mailto:'+Trim(editInfoEmail.Text);
   Modified := True;
 end;
 
 procedure TfrmPackageEditor.editInfoWebSiteChange(Sender: TObject);
 begin
   if FSetup > 0 then Exit;
-  pack.Info.Desc['WebSite'] := Trim(editInfoWebSite.Text);
-  pack.Info.URL['WebSite'] := Trim(editInfoWebSite.Text);
+  pack.Info.Desc[PackageInfo_WebSite] := Trim(editInfoWebSite.Text);
+  pack.Info.URL[PackageInfo_WebSite] := Trim(editInfoWebSite.Text);
   Modified := True;
 end;
 
@@ -734,7 +734,7 @@ begin
           try
             f.Description := 'Keyboard '+ki.KeyboardName;
             // Fill in some info stuff as well...
-            if pack.Info.Desc[PackageInfo_Version] = '' then   // I4690
+            if not pack.KPSOptions.FollowKeyboardVersion and (pack.Info.Desc[PackageInfo_Version] = '') then   // I4690
             begin
               pack.Info.Desc[PackageInfo_Version] := ki.KeyboardVersion;
             end;
@@ -1021,6 +1021,11 @@ procedure TfrmPackageEditor.chkFollowKeyboardVersionClick(Sender: TObject);
 begin
   if FSetup > 0 then Exit;
   pack.KPSOptions.FollowKeyboardVersion := chkFollowKeyboardVersion.Checked;
+  if chkFollowKeyboardVersion.Checked then
+  begin
+    editInfoVersion.Text := '';
+    pack.Info.Desc[PackageInfo_Version] := '';
+  end;
   EnableDetailsTabControls;
   Modified := True;
 end;
@@ -1082,7 +1087,7 @@ end;
 procedure TfrmPackageEditor.memoInfoDescriptionChange(Sender: TObject);
 begin
   if FSetup > 0 then Exit;
-  pack.Info.Desc['Description'] := Trim(memoInfoDescription.Text);
+  pack.Info.Desc[PackageInfo_Description] := Trim(memoInfoDescription.Text);
   Modified := True;
 end;
 


### PR DESCRIPTION
To reduce confusion when 'Follow Keyboard Version' is set, clear the cached package version data from UI and .kps source when saving the package or making changes to it.

Fixes: #11892
Test-bot: skip