### PR TITLE
fix(android): Change Alert Dialog instead of Toast if package missing keyboard and lexical-model files

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/PackageActivity.java
@@ -85,7 +85,8 @@ public class PackageActivity extends BaseActivity implements
       if (pkgTarget.equals(PackageProcessor.PP_TARGET_LEXICAL_MODELS)) {
         kmpProcessor = new LexicalModelPackageProcessor(resourceRoot);
       } else if (!pkgTarget.equals(PackageProcessor.PP_TARGET_KEYBOARDS)) {
-        showErrorToast(getString(R.string.no_targets_to_install));
+        // Not using showErrorToast to avoid cluttering Sentry with noise
+        showErrorDialog(context, pkgId, getString(R.string.no_targets_to_install));
         return;
       }
       tempPackagePath = kmpProcessor.unzipKMP(kmpFile);


### PR DESCRIPTION
Follows #13786 

### Background
Currently, Toast notifications displayed to the user are also sent as errors to Sentry.

### Scenario
User attempts to install a kmp package that doesn't contain Keyman keyboards or lexical-models.

### Change
This PR changes the Toast notification to an alert dialog that doesn't send the error (really warning) to Sentry.
Keyman already displays a similar alert dialog if the keyboard package is missing languages.

This way we don't clutter Sentry with noise.

Fixes: #15097

Fixes: KEYMAN-ANDROID-251

## User Testing

**Setup** - On an Android device/emulator, install the PR build of Keyman for Android. Also download a test Keyman package [sil_ethiopic](https://darcywong00.github.io/examples/invalid/sil_ethiopic.kmp) which has no keyboards or lexical-model JS files in it.

* **TEST_NO_JS** - Verifies error dialog shown if package missing keyboard and lexical-model JS files
1. Launch KEyman for Android and dismiss the "Get Started" menu
2. From Keyman settings -->  Install Keyboard or Dictionary --> Install from local file
3. Browse to where sil_ethiopic.kmp was downloaded and select it
4. Verify error dialog appears showing package missing touch optimized keyboards to install

 
![no touch optimized](https://github.com/user-attachments/assets/4fa81e58-05b5-499b-a81d-136658efe353)
