### PR TITLE
refactor(web): change default export of ContextManager 🎼

### DIFF
--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -42,7 +42,7 @@ function _SetTargDir(Ptarg: HTMLElement, activeKeyboard: Keyboard) {
   }
 }
 
-export default class ContextManager extends ContextManagerBase<BrowserConfiguration> {
+export class ContextManager extends ContextManagerBase<BrowserConfiguration> {
   private _activeKeyboard: {keyboard: JSKeyboard, metadata: KeyboardStub};
   private cookieManager = new CookieSerializer<KeyboardCookie>('KeymanWeb_Keyboard');
   readonly focusAssistant = new FocusAssistant(() => this.activeTarget?.isForcingScroll());

--- a/web/src/app/browser/src/defaultBrowserRules.ts
+++ b/web/src/app/browser/src/defaultBrowserRules.ts
@@ -6,7 +6,7 @@ import {
   type TextStore
 } from 'keyman/engine/keyboard';
 
-import ContextManager from './contextManager.js';
+import { ContextManager } from './contextManager.js';
 
 export default class DefaultBrowserRules extends DefaultRules {
   private contextManager: ContextManager;

--- a/web/src/app/browser/src/hardwareEventKeyboard.ts
+++ b/web/src/app/browser/src/hardwareEventKeyboard.ts
@@ -7,7 +7,7 @@ import { DomEventTracker } from 'keyman/engine/events';
 import { DesignIFrameElementTextStore, nestedInstanceOf } from 'keyman/engine/element-text-stores';
 import { textStoreForEvent, textStoreForElement } from 'keyman/engine/attachment';
 
-import ContextManager from './contextManager.js';
+import { ContextManager } from './contextManager.js';
 
 type KeyboardState = {
   activeKeyboard: JSKeyboard,

--- a/web/src/app/browser/src/keyboardInterface.ts
+++ b/web/src/app/browser/src/keyboardInterface.ts
@@ -2,7 +2,7 @@ import { type AbstractElementTextStore } from 'keyman/engine/element-text-stores
 import { FloatingOSKView } from 'keyman/engine/osk';
 import { KeyboardInterfaceBase } from 'keyman/engine/main';
 
-import ContextManager from './contextManager.js';
+import { ContextManager }  from './contextManager.js';
 import { KeymanEngine } from './keymanEngine.js';
 
 export class KeyboardInterface extends KeyboardInterfaceBase<ContextManager> {

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -12,7 +12,7 @@ import KeyboardObject = KeymanWebKeyboard.KeyboardObject;
 
 import * as views from './viewsAnchorpoint.js';
 import { BrowserConfiguration, BrowserInitOptionDefaults, BrowserInitOptionSpec } from './configuration.js';
-import { default as ContextManager } from './contextManager.js';
+import { ContextManager } from './contextManager.js';
 import DefaultBrowserRules from './defaultBrowserRules.js';
 import HardwareEventKeyboard from './hardwareEventKeyboard.js';
 import { FocusStateAPIObject } from './context/focusAssistant.js';

--- a/web/src/app/browser/src/oskConfiguration.ts
+++ b/web/src/app/browser/src/oskConfiguration.ts
@@ -1,6 +1,6 @@
 import { OSKView } from "keyman/engine/osk";
 import { KEYMAN_VERSION } from "@keymanapp/keyman-version";
-import ContextManager from "./contextManager.js";
+import { ContextManager } from "./contextManager.js";
 import { KeymanEngine } from "./keymanEngine.js";
 import { LanguageMenu } from "./languageMenu.js";
 

--- a/web/src/app/browser/src/test-index.ts
+++ b/web/src/app/browser/src/test-index.ts
@@ -1,5 +1,5 @@
 export { BrowserConfiguration, BrowserInitOptionSpec } from './configuration.js';
-export { default as ContextManager, KeyboardCookie } from "./contextManager.js";
+export { ContextManager, KeyboardCookie } from "./contextManager.js";
 export { preprocessKeyboardEvent, default as HardwareEventKeyboard } from './hardwareEventKeyboard.js';
 
 export { KeymanEngine } from './keymanEngine.js';

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -116,7 +116,7 @@ export class HostTextStore extends SyntheticTextStore {
   }
 }
 
-export default class ContextManager extends ContextManagerBase<WebviewConfiguration> {
+export class ContextManager extends ContextManagerBase<WebviewConfiguration> {
   // Change of context?  Just replace the SyntheticTextStore.  Context will be ENTIRELY controlled
   // by whatever is hosting the WebView.  (Some aspects of this context replacement have
   // yet to be modularized at this time, though.)

--- a/web/src/app/webview/src/keymanEngine.ts
+++ b/web/src/app/webview/src/keymanEngine.ts
@@ -5,7 +5,7 @@ import { getAbsoluteX, getAbsoluteY } from 'keyman/engine/dom-utils';
 import { toPrefixedKeyboardId, toUnprefixedKeyboardId } from 'keyman/engine/keyboard-storage';
 
 import { WebviewConfiguration, WebviewInitOptionDefaults, WebviewInitOptionSpec } from './configuration.js';
-import ContextManager, { HostTextStore } from './contextManager.js';
+import { ContextManager, HostTextStore } from './contextManager.js';
 import PassthroughKeyboard from './passthroughKeyboard.js';
 import { buildEmbeddedGestureConfig, setupEmbeddedListeners } from './oskConfiguration.js';
 import { WorkerFactory } from '@keymanapp/lexical-model-layer';


### PR DESCRIPTION
This change replaces the default export of ContextManager with a regular export.

Test-bot: skip