### PR TITLE
maint(resources): add build timing report to builder

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -31,6 +31,7 @@ env:
   STATUS_CONTEXT: 'Ubuntu Packaging'
   DEBFULLNAME: 'Keyman GHA packager'
   DEBEMAIL: 'support@keyman.com'
+  _builder_timings: false
 
 jobs:
   sourcepackage:

--- a/linux/scripts/deb-packaging.sh
+++ b/linux/scripts/deb-packaging.sh
@@ -6,6 +6,9 @@
 set -eu
 shopt -s inherit_errexit
 
+# Avoid timing reports as we don't have node in this script
+export _builder_timings=false
+
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"

--- a/resources/build/test/test.sh
+++ b/resources/build/test/test.sh
@@ -2,6 +2,9 @@
 
 set -eu
 
+# Avoid timing reports in unit tests
+export _builder_timings=false
+
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
@@ -243,7 +246,7 @@ if [[ $KEYMAN_VERSION_ENVIRONMENT == "local" ]]; then
   expected="$(builder_echo grey "Local build environment detected:  setting --debug")"$'\n'"$(builder_echo setmark "test.sh parameters: <--feature xyzzy --bar abc --baz def test --debug>")"
 fi
 if [[ "${parse_output[*]}" != "${expected}" ]]; then
-  builder_die "FAIL: Wrong output for '--feature xyzzy --bar abc --baz def test':\n  Actual  : ${parse_output[*]}\n  Expected: ${expected}"
+  builder_die "FAIL: Wrong output for '--feature xyzzy --bar abc --baz def test':\n  Actual  : '${parse_output[*]}'\n  Expected: '${expected}'"
 fi
 
 #----------------------------------------------------------------------
@@ -436,7 +439,7 @@ echo
   # Finally, run with --help so we can see what it looks like; note:
   # builder_parse calls `exit 0` on a --help run, so running in a subshell
   echo -e "${COLOR_BLUE}## Testing --help${COLOR_RESET}"
-  builder_parse --no-color --help
+  builder_parse --no-color --help --no-timings
 ) || builder_die "FAIL: builder-parse unexpectedly returned failure code $?"
 
 echo -e "${COLOR_GREEN}======================================================${COLOR_RESET}"


### PR DESCRIPTION
This is enabled automatically for CI builds, and can be enabled with `--timing` parameter otherwise. Also, adds `builder_launch`, documentation to come; see #15129. Documentation for `--timing` to be done in #15130.

Test-bot: skip