### PR TITLE
maint(core): fix option defaults for Meson >= 1.1

### DIFF
--- a/core/meson.options
+++ b/core/meson.options
@@ -1,0 +1,1 @@
+meson_options.txt

--- a/developer/meson.options
+++ b/developer/meson.options
@@ -1,0 +1,1 @@
+meson_options.txt

--- a/linux/ibus-keyman/meson.options
+++ b/linux/ibus-keyman/meson.options
@@ -1,0 +1,1 @@
+meson_options.txt


### PR DESCRIPTION
Meson 1.1 changed the name of the options file from `meson_options.txt` to `meson.options`. This change creates symlinks for these files until we can update the required min version.

One thing where the lack of the options was noticeable was that we didn't run the core WASM tests.

Test-bot: skip