### PR TITLE
maint(core): fix option defaults for Meson >= 1.1 🍒 🎼

### DIFF
--- a/core/build.bat
+++ b/core/build.bat
@@ -83,7 +83,7 @@ if "!COMMAND!" == "configure" (
   if "%1" == "--no-tests" (
     meson setup build\!ARCH!\!BUILDTYPE! !STATIC_LIBRARY! --buildtype !BUILDTYPE! -Dkeyman_core_tests=false --werror %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
   ) else (
-    meson setup build\!ARCH!\!BUILDTYPE! !STATIC_LIBRARY! --buildtype !BUILDTYPE! --werror %1 %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
+    meson setup build\!ARCH!\!BUILDTYPE! !STATIC_LIBRARY! --buildtype !BUILDTYPE! -Dkeyman_core_tests=true --werror %1 %2 %3 %4 %5 %6 %7 %8 %9 || exit !errorlevel!
   )
   shift
 )

--- a/core/build.sh
+++ b/core/build.sh
@@ -79,7 +79,7 @@ builder_parse "$@"
 # if we don't plan to run them, for example when doing a dependency build
 # in CI
 #
-MESON_OPTION_keyman_core_tests=
+MESON_OPTION_keyman_core_tests="-Dkeyman_core_tests=true"
 BUILD_BAT_keyman_core_tests=
 
 if builder_is_dep_build || builder_has_option --no-tests; then

--- a/resources/build/minimum-versions.inc.sh
+++ b/resources/build/minimum-versions.inc.sh
@@ -30,7 +30,7 @@ KEYMAN_MIN_VERSION_NODE_MAJOR=20              # node version source of truth is 
 KEYMAN_MIN_VERSION_NPM=10.5.1                 # 10.5.0 has bug, discussed in #10350
 KEYMAN_MIN_VERSION_EMSCRIPTEN=3.1.64          # Use KEYMAN_USE_EMSDK to automatically update to this version
 KEYMAN_MIN_VERSION_VISUAL_STUDIO=2022         # Visual Studio 2022, see /docs/build/windows.md for workloads and components
-KEYMAN_MIN_VERSION_MESON=1.0.0
+KEYMAN_MIN_VERSION_MESON=1.0.0                # TODO: rename meson_options.txt to meson.options when updating to >= 1.1, see #15127.
 
 KEYMAN_VERSION_GRADLE=8.12                    # See /android/KMEA/gradle/wrapper/gradle-wrapper.properties
 


### PR DESCRIPTION
Meson 1.1 changed the name of the options file from `meson_options.txt` to `meson.options`. Currently we're stuck with Meson 1.0 as minimum Meson version because we still support Ubuntu 22.04 Jammy, but on some machines a newer version of meson gets installed which causes the options to be ignored.

The first attempt to simply symlink or copy `meson_options.txt` to `meson.options` failed because git on Windows doesn't support symlinks by default, and Meson complains if it finds two options files (#15127).

Fortunately not having an options file is only a problem for Core where we have one option in the options file that defaults to true. The solution implemented in this change is to always pass the option to Meson.

Cherry-pick-of: #15131
Test-bot: skip