### PR TITLE
refactor(web): text-store: rename `getDeadkeyCaret` to `getCaret` 🎼

### DIFF
--- a/web/src/engine/src/element-text-stores/contentEditableTextStore.ts
+++ b/web/src/engine/src/element-text-stores/contentEditableTextStore.ts
@@ -103,7 +103,7 @@ export class ContentEditableElementTextStore extends AbstractElementTextStore<{}
     }
   }
 
-  getDeadkeyCaret(): number {
+  getCaret(): number {
     return KMWString.length(this.getTextBeforeCaret());
   }
 

--- a/web/src/engine/src/element-text-stores/designIFrameTextStore.ts
+++ b/web/src/engine/src/element-text-stores/designIFrameTextStore.ts
@@ -125,7 +125,7 @@ export class DesignIFrameElementTextStore extends AbstractElementTextStore<{}> {
     }
   }
 
-  getDeadkeyCaret(): number {
+  getCaret(): number {
     return KMWString.length(this.getTextBeforeCaret());
   }
 

--- a/web/src/engine/src/element-text-stores/inputTextStore.ts
+++ b/web/src/engine/src/element-text-stores/inputTextStore.ts
@@ -98,10 +98,6 @@ export class InputElementTextStore extends AbstractElementTextStore<EventMap> {
     return this.root.selectionDirection == 'forward' ? this.processedSelectionEnd : this.processedSelectionStart;
   }
 
-  getDeadkeyCaret(): number {
-    return this.getCaret();
-  }
-
   setCaret(caret: number) {
     this.setSelection(caret, caret, "none");
   }

--- a/web/src/engine/src/element-text-stores/textareaTextStore.ts
+++ b/web/src/engine/src/element-text-stores/textareaTextStore.ts
@@ -73,10 +73,6 @@ export class TextAreaElementTextStore extends AbstractElementTextStore<{}> {
     return this.root.selectionDirection == 'forward' ? this.processedSelectionEnd : this.processedSelectionStart;
   }
 
-  getDeadkeyCaret(): number {
-    return this.getCaret();
-  }
-
   setCaret(caret: number) {
     this.setSelection(caret, caret, "none");
   }

--- a/web/src/engine/src/js-processor/jsKeyboardInterface.ts
+++ b/web/src/engine/src/js-processor/jsKeyboardInterface.ts
@@ -364,7 +364,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
         cache = { valContext: [], deadContext: []};
         while(cache.valContext.length < n) {
           // As adapted from `deadkeyMatch`.
-          const sp = textStore.getDeadkeyCaret();
+          const sp = textStore.getCaret();
           const deadPos = sp - index;
           if(unmatchedDeadkeys.length > 0 && unmatchedDeadkeys[0].p > deadPos) {
             // We have deadkeys at the right-hand side of the caret!  They don't belong in the context, so pop 'em off.

--- a/web/src/engine/src/keyboard/syntheticTextStore.ts
+++ b/web/src/engine/src/keyboard/syntheticTextStore.ts
@@ -82,7 +82,7 @@ export class SyntheticTextStore extends TextStore {
     return true;
   }
 
-  getDeadkeyCaret(): number {
+  getCaret(): number {
     return this.selStart;
   }
 

--- a/web/src/engine/src/keyboard/textStore.ts
+++ b/web/src/engine/src/keyboard/textStore.ts
@@ -11,10 +11,10 @@ import { Deadkey, DeadkeyTracker } from "./deadkeys.js";
 import { LexicalModelTypes } from '@keymanapp/common-types';
 
 export abstract class TextStore {
-  private _dks: DeadkeyTracker;
+  private _deadkeys: DeadkeyTracker;
 
   constructor() {
-    this._dks = new DeadkeyTracker();
+    this._deadkeys = new DeadkeyTracker();
   }
 
   /**
@@ -30,15 +30,15 @@ export abstract class TextStore {
   }
 
   deadkeys(): DeadkeyTracker {
-    return this._dks;
+    return this._deadkeys;
   }
 
   hasDeadkeyMatch(n: number, d: number): boolean {
-    return this.deadkeys().isMatch(this.getDeadkeyCaret(), n, d);
+    return this.deadkeys().isMatch(this.getCaret(), n, d);
   }
 
   insertDeadkeyBeforeCaret(d: number) {
-    const dk: Deadkey = new Deadkey(this.getDeadkeyCaret(), d);
+    const dk: Deadkey = new Deadkey(this.getCaret(), d);
     this.deadkeys().add(dk);
   }
 
@@ -49,7 +49,7 @@ export abstract class TextStore {
    * @param {number} delta  Use negative values if characters were deleted, positive if characters were added.
    */
   protected adjustDeadkeys(delta: number) {
-    this.deadkeys().adjustPositions(this.getDeadkeyCaret(), delta);
+    this.deadkeys().adjustPositions(this.getCaret(), delta);
   }
 
   /**
@@ -57,7 +57,7 @@ export abstract class TextStore {
    * @param {object}  dks   An existing set of deadkeys to deep-copy for use by this element interface.
    */
   protected setDeadkeys(dks: DeadkeyTracker) {
-    this._dks = dks.clone();
+    this._deadkeys = dks.clone();
   }
 
   static assertIsTextStore(textStore: TextStoreLanguageProcessorInterface): asserts textStore is TextStore {
@@ -123,7 +123,8 @@ export abstract class TextStore {
     this.setTextAfterCaret(original.getTextAfterCaret());
 
     // Also, restore the deadkeys!
-    this._dks = original._dks.clone();
+    // TODO-web-core: km_core_context_set or similar?
+    this.setDeadkeys(original._deadkeys);
   }
 
   apply(transform: LexicalModelTypes.Transform) {
@@ -145,7 +146,7 @@ export abstract class TextStore {
 
     // We assume that all deadkeys are invalidated after applying a Transform, since
     // prediction implies we'll be completing a word, post-deadkeys.
-    this._dks.clear();
+    this.deadkeys().clear();
   }
 
   /**
@@ -191,9 +192,9 @@ export abstract class TextStore {
   abstract isSelectionEmpty(): boolean;
 
   /**
-   * Returns an index corresponding to the caret's position for use with deadkeys.
+   * Returns an index corresponding to the caret's position in the text store.
    */
-  abstract getDeadkeyCaret(): number;
+  abstract getCaret(): number;
 
   /**
    * Relative to the caret, gets the current context within the wrapper's element.

--- a/web/src/test/auto/dom/cases/element-text-stores/element_interfaces.tests.ts
+++ b/web/src/test/auto/dom/cases/element-text-stores/element_interfaces.tests.ts
@@ -339,7 +339,7 @@ class MockTestHelper implements TestHelper {
 
   // Implemented for completeness and generality with other tests.
   getCaret(pair: ElementPair<any>) {
-    return pair.wrapper.getDeadkeyCaret();
+    return pair.wrapper.getCaret();
   }
 
   setSelectionRange(pair: ElementPair<any>, start: number, end: number) {
@@ -962,7 +962,7 @@ class InterfaceTests {
       pair.wrapper.deadkeys().deleteMatched();
       assert.equal(pair.wrapper.deadkeys().count(), 2, "Failed to delete 'matched' deadkey");
 
-      // Failure here likely reflects incorrect logic in .getDeadkeyCaret()!
+      // Failure here likely reflects incorrect logic in .getCaret()!
       assert.isTrue(pair.wrapper.deadkeys().isMatch(4, 0, 3), "Failed to correctly note position of deadkey after an SMP character!");
       pair.wrapper.deadkeys().resetMatched();
 

--- a/web/src/test/auto/dom/cases/element-text-stores/target_mocks.tests.ts
+++ b/web/src/test/auto/dom/cases/element-text-stores/target_mocks.tests.ts
@@ -84,7 +84,7 @@ describe('SyntheticTextStore', function() {
         const mock = new SyntheticTextStore(MockTests.Apple.mixed);
 
         assert.equal(mock.getText(), MockTests.Apple.mixed);
-        assert.equal(mock.getDeadkeyCaret(), 5);
+        assert.equal(mock.getCaret(), 5);
       });
 
       it('copies an existing TextStore without a text selection', function() {


### PR DESCRIPTION
Also renames internal `_dks` to `_deadkeys`.

Test-bot: skip