### PR TITLE
feat(web): add `Deadkey.toString` function 🎼

### DIFF
--- a/web/src/engine/src/keyboard/deadkeys.ts
+++ b/web/src/engine/src/keyboard/deadkeys.ts
@@ -43,6 +43,10 @@ export class Deadkey {
     return this.d == other.d && this.p == other.p && this.o == other.o;
   }
 
+  toString() {
+    return `Deadkey { p: ${this.p}, d: ${this.d}, o: ${this.o}, matched: ${this.matched}}`
+  }
+
   /**
    * Sorts the deadkeys in reverse order.
    */


### PR DESCRIPTION
This allows to use `console.log(deadkey.toString())` to output the values of a deadkey which is useful for debugging.

Test-bot: skip