### PR TITLE
fix(windows): disable OutputDebugString from DllMain

### DIFF
--- a/windows/src/engine/keyman32/k32_globals.cpp
+++ b/windows/src/engine/keyman32/k32_globals.cpp
@@ -133,18 +133,14 @@ PKEYMAN64THREADDATA Globals_InitThread()
 
 void Globals_UninitThread()
 {
-  OutputThreadDebugString("Globals_UninitThread");
+  // OutputThreadDebugString("Globals_UninitThread");
   if (!Globals_ProcessInitialised()) {
-    OutputThreadDebugString("Globals_UninitThread aborted without cleanup");
+    // OutputThreadDebugString("Globals_UninitThread aborted without cleanup");
     return;
   }
 
   ISerialKeyEventClient::Shutdown();
 
-  PKEYMAN64THREADDATA _td = ThreadGlobals();
-  if (_td) {
-    delete _td->pSerialKeyEventClient;
-  }
   CloseThreadSharedBufferManager();
 
   EnterCriticalSection(&csGlobals);

--- a/windows/src/engine/keyman32/keyman32.cpp
+++ b/windows/src/engine/keyman32/keyman32.cpp
@@ -119,27 +119,20 @@ BOOL __stdcall DllMain(HINSTANCE hinstDll, DWORD fdwReason, LPVOID reserved)
 	switch(fdwReason)
 	{
 	case DLL_PROCESS_ATTACH:
-    //OutputThreadDebugString("DLL_PROCESS_ATTACH");
     if(!Globals_InitProcess()) return FALSE;
 		break;
 	case DLL_PROCESS_DETACH:
     if (reserved == NULL) {
       // If reserved == NULL, that means the library is being unloaded, but
       // the process is not terminating.
-      //OutputThreadDebugString("DLL_PROCESS_DETACH not terminating");
       UninitialiseProcess(FALSE);
       Globals_UninitProcess();
     }
-    else {
-      //OutputThreadDebugString("DLL_PROCESS_DETACH terminating");
-    }
 		break;
 	case DLL_THREAD_ATTACH:
-    //OutputThreadDebugString("DLL_THREAD_ATTACH");
     Globals_InitThread();
 		break;
 	case DLL_THREAD_DETACH:
-    //OutputThreadDebugString("DLL_THREAD_DETACH");
     UninitialiseProcess(FALSE);
     Globals_UninitThread();
 		break;
@@ -838,7 +831,7 @@ void RefreshKeyboards(BOOL Initialising)
 
 void ReleaseKeyboards(BOOL Lock)
 {
-  OutputThreadDebugString("ReleaseKeyboards");
+  // OutputThreadDebugString("ReleaseKeyboards");
   PKEYMAN64THREADDATA _td = ThreadGlobals();
 	if(!_td || !_td->lpKeyboards) return;
 

--- a/windows/src/engine/keyman32/serialkeyeventclient.cpp
+++ b/windows/src/engine/keyman32/serialkeyeventclient.cpp
@@ -22,25 +22,25 @@ public:
 
     m_hKeyEvent = OpenEvent(EVENT_MODIFY_STATE, FALSE, GLOBAL_KEY_EVENT_NAME);
     if (m_hKeyEvent == 0) {
-      DebugLastError("OpenEvent");
+      // DebugLastError("OpenEvent");
       return;
     }
 
     m_hKeyMutex = OpenMutex(MUTEX_ALL_ACCESS, FALSE, GLOBAL_KEY_MUTEX_NAME);
     if (m_hKeyMutex == 0) {
-      DebugLastError("OpenMutex");
+      // DebugLastError("OpenMutex");
       return;
     }
 
     m_hMMF = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, GLOBAL_FILE_MAPPING_NAME);
     if (m_hMMF == 0) {
-      DebugLastError("OpenFileMapping");
+      // DebugLastError("OpenFileMapping");
       return;
     }
 
     m_pSharedData = (SerialKeyEventSharedData *)MapViewOfFile(m_hMMF, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(SerialKeyEventSharedData));
     if (!m_pSharedData) {
-      DebugLastError("MapViewOfFile");
+      // DebugLastError("MapViewOfFile");
       return;
     }
   }
@@ -48,25 +48,25 @@ public:
   SerialKeyEventClient::~SerialKeyEventClient() {
     if (m_pSharedData != NULL) {
       if (!UnmapViewOfFile(m_pSharedData)) {
-        DebugLastError("UnmapViewOfFile");
+        // DebugLastError("UnmapViewOfFile");
       }
     }
 
     if (m_hMMF != NULL) {
       if (!CloseHandle(m_hMMF)) {
-        DebugLastError("CloseHandle(m_hMMF)");
+        // DebugLastError("CloseHandle(m_hMMF)");
       }
     }
 
     if (m_hKeyMutex != NULL) {
       if (!CloseHandle(m_hKeyMutex)) {
-        DebugLastError("CloseHandle(m_hKeyMutex)");
+        // DebugLastError("CloseHandle(m_hKeyMutex)");
       }
     }
 
     if (m_hKeyEvent != NULL) {
       if (!CloseHandle(m_hKeyEvent)) {
-        DebugLastError("CloseHandle(m_hKeyEvent)");
+        // DebugLastError("CloseHandle(m_hKeyEvent)");
       }
     }
   }
@@ -149,7 +149,7 @@ public:
 };
 
 void ISerialKeyEventClient::Startup() {
-  OutputThreadDebugString("ISerialKeyEventClient::Startup");
+  // OutputThreadDebugString("ISerialKeyEventClient::Startup");
   PKEYMAN64THREADDATA _td = ThreadGlobals();
   if (_td) {
     _td->pSerialKeyEventClient = new SerialKeyEventClient();
@@ -157,7 +157,7 @@ void ISerialKeyEventClient::Startup() {
 }
 
 void ISerialKeyEventClient::Shutdown() {
-  OutputThreadDebugString("ISerialKeyEventClient::Shutdown");
+  // OutputThreadDebugString("ISerialKeyEventClient::Shutdown");
   PKEYMAN64THREADDATA _td = ThreadGlobals();
   if (_td && _td->pSerialKeyEventClient) {
     delete _td->pSerialKeyEventClient;


### PR DESCRIPTION
Following investigation, it seems that OutputDebugString can trigger a loader lock as it throws an exception which can be handled by a global exception handler, which may try and load/unload DLLs or perform other unsafe tasks (e.g. StackWalk). The safest solution is to remove the debug string logging altogether from code paths that run from DllMain.

It would be nice to further simplify DllMain but that would be a significant amount of additional work.

# User Testing

TEST_WINDOWS: Run through a set of standard Keyman for Windows tasks and verify that you do not experience any crashes.