### PR TITLE
chore(linux): use `devel` for next Ubuntu release

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [resolute]
+        dist: [devel]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This change moves to use [`devel`[1]](https://hub.docker.com/_/ubuntu#whats-in-this-image) instead of a specific release name for the next Ubuntu release. That way it will always be able to find an image and will automatically start using the next one as soon as it becomes available.

Follow-up-of: #15137
Build-bot: skip
Test-bot: skip