### PR TITLE
fix(web): improve determination of default path

### DIFF
--- a/web/src/app/browser/src/debug-main.ts
+++ b/web/src/app/browser/src/debug-main.ts
@@ -5,8 +5,8 @@ import { SourcemappedWorker } from '@keymanapp/lexical-model-layer/web'
 * Determine path and protocol of executing script, setting them as
 * construction defaults.
 */
-const ss = (document.currentScript as HTMLScriptElement).src;
-const sPath = ss.substring(0, ss.lastIndexOf('/') + 1);
+const ss = (document.currentScript as HTMLScriptElement)?.src;
+const sPath = ss ? ss.substring(0, ss.lastIndexOf('/') + 1) : './';
 
 // @ts-ignore
 window['keyman'] = new KeymanEngine(SourcemappedWorker, sPath);

--- a/web/src/app/browser/src/release-main.ts
+++ b/web/src/app/browser/src/release-main.ts
@@ -5,8 +5,8 @@ import { Worker } from '@keymanapp/lexical-model-layer/web'
 * Determine path and protocol of executing script, setting them as
 * construction defaults.
 */
-const ss = (document.currentScript as HTMLScriptElement).src;
-const sPath = ss.substring(0, ss.lastIndexOf('/') + 1);
+const ss = (document.currentScript as HTMLScriptElement)?.src;
+const sPath = ss ? ss.substring(0, ss.lastIndexOf('/') + 1) : './';
 
 // @ts-ignore
 window['keyman'] = new KeymanEngine(Worker, sPath);

--- a/web/src/app/webview/src/debug-main.ts
+++ b/web/src/app/webview/src/debug-main.ts
@@ -5,8 +5,8 @@ import { SourcemappedWorker } from '@keymanapp/lexical-model-layer/web'
 * Determine path and protocol of executing script, setting them as
 * construction defaults.
 */
-const ss = (document.currentScript as HTMLScriptElement).src;
-const sPath = ss.substring(0, ss.lastIndexOf('/') + 1);
+const ss = (document.currentScript as HTMLScriptElement)?.src;
+const sPath = ss ? ss.substring(0, ss.lastIndexOf('/') + 1) : './';
 
 // @ts-ignore
 window['keyman'] = new KeymanEngine(SourcemappedWorker, sPath);

--- a/web/src/app/webview/src/release-main.ts
+++ b/web/src/app/webview/src/release-main.ts
@@ -5,8 +5,8 @@ import { Worker } from '@keymanapp/lexical-model-layer/web'
 * Determine path and protocol of executing script, setting them as
 * construction defaults.
 */
-const ss = (document.currentScript as HTMLScriptElement).src;
-const sPath = ss.substring(0, ss.lastIndexOf('/') + 1);
+const ss = (document.currentScript as HTMLScriptElement)?.src;
+const sPath = ss ? ss.substring(0, ss.lastIndexOf('/') + 1) : './';
 
 // @ts-ignore
 window['keyman'] = new KeymanEngine(Worker, sPath);


### PR DESCRIPTION
Browser extensions can dynamically insert scripts into a web page, so it's possible that the last script is not what we expected, which can cause the path to the script to be wrong. This change fixes the determination of the default path by using the `document.currentScript` property. It also replaces the use of the deprecated `substr` function in those places.

Fixes: #15158
Test-bot: skip