### PR TITLE
docs(web): start internal doc on SearchSpace design, requirements, and analysis 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/docs/correction-search-graph.md
+++ b/web/src/engine/predictive-text/worker-thread/docs/correction-search-graph.md
@@ -11,9 +11,9 @@ text-correction design:  we assume that each keystroke's `Transform` is 100%
 independent from the `Transform` selected for every other keystroke.  This
 assumption is, of course, invalid: the output of keystroke A may selectively
 establish the context needed for a Keyman keyboard rule matched by one or more
-keys in keystroke B.  Efforts to address this limitation are considered
-out-of-scope at this time and will be addressed later in a future epic -
-epic/true-correction - documented as issue #14709.
+potential outputs for keystroke B.  Efforts to address this limitation are
+considered out-of-scope at this time and will be addressed later in a future
+epic - epic/true-correction - documented as issue #14709.
 
 ## Graph Structure
 


### PR DESCRIPTION
This PR aims to start an internal doc on the role of `SearchSpace`, `SearchPath`, and `SearchCluster` in the correction-search process.

At present, I don't claim it to be complete by any measure.  But, "something" is better than "nothing" here, and this provides a chance to get some eyes on things early in order to determine what works as an explanation and what doesn't.  Feedback appreciated, even while in draft mode.

Build-bot: skip
Test-bot: skip