### PR TITLE
change(windows): use circular buffer for logging

### DIFF
--- a/windows/src/global/delphi/debug/Keyman.System.DebugLogManager.pas
+++ b/windows/src/global/delphi/debug/Keyman.System.DebugLogManager.pas
@@ -149,7 +149,7 @@ begin
   pSessionProperties.Wnode.Flags := WNODE_FLAG_TRACED_GUID;
   pSessionProperties.Wnode.ClientContext := 1; //QPC clock resolution
   pSessionProperties.Wnode.Guid := SessionGuid;
-  pSessionProperties.LogFileMode := EVENT_TRACE_FILE_MODE_SEQUENTIAL;
+  pSessionProperties.LogFileMode := EVENT_TRACE_FILE_MODE_CIRCULAR;
   pSessionProperties.MaximumFileSize := 256;  // 256 MB
   pSessionProperties.LoggerNameOffset := sizeof(EVENT_TRACE_PROPERTIES);
   pSessionProperties.LogFileNameOffset := sizeof(EVENT_TRACE_PROPERTIES) + sizeof(LOGSESSION_NAME);


### PR DESCRIPTION
Build-bot: skip release:windows
Test-bot: skip