### PR TITLE
fix(web): improve determination of default path 🍒 🎼

### DIFF
--- a/web/src/app/browser/src/debug-main.ts
+++ b/web/src/app/browser/src/debug-main.ts
@@ -1,16 +1,12 @@
 import { KeymanEngine } from './keymanEngine.js'
 import { SourcemappedWorker } from '@keymanapp/lexical-model-layer/web'
 
- /**
-  * Determine path and protocol of executing script, setting them as
-  * construction defaults.
-  *
-  * This can only be done during load when the active script will be the
-  * last script loaded.  Otherwise the script must be identified by name.
- */
- const scripts = document.getElementsByTagName('script');
- const ss = scripts[scripts.length-1].src;
- const sPath = ss.substr(0,ss.lastIndexOf('/')+1);
+/**
+* Determine path and protocol of executing script, setting them as
+* construction defaults.
+*/
+const ss = (document.currentScript as HTMLScriptElement)?.src;
+const sPath = ss ? ss.substring(0, ss.lastIndexOf('/') + 1) : './';
 
 // @ts-ignore
 window['keyman'] = new KeymanEngine(SourcemappedWorker, sPath);

--- a/web/src/app/browser/src/release-main.ts
+++ b/web/src/app/browser/src/release-main.ts
@@ -1,16 +1,12 @@
 import { KeymanEngine } from './keymanEngine.js'
 import { Worker } from '@keymanapp/lexical-model-layer/web'
 
- /**
-  * Determine path and protocol of executing script, setting them as
-  * construction defaults.
-  *
-  * This can only be done during load when the active script will be the
-  * last script loaded.  Otherwise the script must be identified by name.
- */
- const scripts = document.getElementsByTagName('script');
- const ss = scripts[scripts.length-1].src;
- const sPath = ss.substr(0,ss.lastIndexOf('/')+1);
+/**
+* Determine path and protocol of executing script, setting them as
+* construction defaults.
+*/
+const ss = (document.currentScript as HTMLScriptElement)?.src;
+const sPath = ss ? ss.substring(0, ss.lastIndexOf('/') + 1) : './';
 
 // @ts-ignore
 window['keyman'] = new KeymanEngine(Worker, sPath);

--- a/web/src/app/webview/src/debug-main.ts
+++ b/web/src/app/webview/src/debug-main.ts
@@ -1,16 +1,12 @@
 import { KeymanEngine } from './keymanEngine.js'
 import { SourcemappedWorker } from '@keymanapp/lexical-model-layer/web'
 
- /**
-  * Determine path and protocol of executing script, setting them as
-  * construction defaults.
-  *
-  * This can only be done during load when the active script will be the
-  * last script loaded.  Otherwise the script must be identified by name.
- */
-const scripts = document.getElementsByTagName('script');
-const ss = scripts[scripts.length-1].src;
-const sPath = ss.substring(0,ss.lastIndexOf('/')+1);
+/**
+* Determine path and protocol of executing script, setting them as
+* construction defaults.
+*/
+const ss = (document.currentScript as HTMLScriptElement)?.src;
+const sPath = ss ? ss.substring(0, ss.lastIndexOf('/') + 1) : './';
 
 // @ts-ignore
 window['keyman'] = new KeymanEngine(SourcemappedWorker, sPath);

--- a/web/src/app/webview/src/release-main.ts
+++ b/web/src/app/webview/src/release-main.ts
@@ -1,16 +1,12 @@
 import { KeymanEngine } from './keymanEngine.js'
 import { Worker } from '@keymanapp/lexical-model-layer/web'
 
- /**
-  * Determine path and protocol of executing script, setting them as
-  * construction defaults.
-  *
-  * This can only be done during load when the active script will be the
-  * last script loaded.  Otherwise the script must be identified by name.
- */
-const scripts = document.getElementsByTagName('script');
-const ss = scripts[scripts.length-1].src;
-const sPath = ss.substring(0,ss.lastIndexOf('/')+1);
+/**
+* Determine path and protocol of executing script, setting them as
+* construction defaults.
+*/
+const ss = (document.currentScript as HTMLScriptElement)?.src;
+const sPath = ss ? ss.substring(0, ss.lastIndexOf('/') + 1) : './';
 
 // @ts-ignore
 window['keyman'] = new KeymanEngine(Worker, sPath);


### PR DESCRIPTION
Browser extensions can dynamically insert scripts into a web page, so it's possible that the last script is not what we expected, which can cause the path to the script to be wrong. This change fixes the determination of the default path by using the `document.currentScript` property. It also replaces the use of the deprecated `substr` function in those places.

Cherry-pick-of: #15159
Fixes: #15158
Test-bot: skip