### PR TITLE
refactor(web): change `preInput` to `SyntheticTextStore` 🎼

### DIFF
--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -34,8 +34,7 @@ export class HostTextStore extends SyntheticTextStore {
       let transform: TextTransform = null;
 
       if(transcription) {
-        //TODO-web-core: shouldn't need cast in the future?
-        const preInput = transcription.preInput as SyntheticTextStore;
+        const { preInput } = transcription;
         // If our saved state matches the `preInput` from the incoming transcription, just reuse its transform.
         // Will generally not match during multitap operations, though.
         //

--- a/web/src/engine/src/keyboard/keyboards/transcription.ts
+++ b/web/src/engine/src/keyboard/keyboards/transcription.ts
@@ -1,20 +1,20 @@
 /*
  * Keyman is copyright (C) SIL Global. MIT License.
  */
-import { TextStore } from '../textStore.js';
 import { KeyEvent } from '../keyEvent.js';
 import { Alternate, TextTransform } from './textTransform.js';
+import { SyntheticTextStore } from '../syntheticTextStore.js';
 
 export class Transcription {
   readonly token: number;
   readonly keystroke: KeyEvent;
   readonly transform: TextTransform;
   alternates: Alternate[]; // constructed after the rest of the transcription.
-  readonly preInput: TextStore;
+  readonly preInput: SyntheticTextStore;
 
   private static tokenSeed: number = 0;
 
-  constructor(keystroke: KeyEvent, transform: TextTransform, preInput: TextStore, alternates?: Alternate[]) {
+  constructor(keystroke: KeyEvent, transform: TextTransform, preInput: SyntheticTextStore, alternates?: Alternate[]) {
     const token = this.token = Transcription.tokenSeed++;
 
     this.keystroke = keystroke;

--- a/web/src/engine/src/main/headless/inputProcessor.ts
+++ b/web/src/engine/src/main/headless/inputProcessor.ts
@@ -132,11 +132,9 @@ export class InputProcessor {
           // Has there been a context change at any point during the multitap?  If so, we need
           // to revert it.  If not, we assume it's a layer-change multitap, in which case
           // no such reset is needed.
-          // TODO-web-core
-          if(!isEmptyTransform(transcription.transform) || !(transcription.preInput as SyntheticTextStore).isEqual(SyntheticTextStore.from(textStore))) {
+          if(!isEmptyTransform(transcription.transform) || !transcription.preInput.isEqual(SyntheticTextStore.from(textStore))) {
             // Restores full context, including deadkeys in their exact pre-keystroke state.
-            // TODO-web-core
-            textStore.restoreTo(transcription.preInput as SyntheticTextStore);
+            textStore.restoreTo(transcription.preInput);
           }
           /*
             else:

--- a/web/src/engine/src/main/headless/languageProcessor.ts
+++ b/web/src/engine/src/main/headless/languageProcessor.ts
@@ -234,7 +234,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
 
       // Builds the reversion option according to the loaded lexical model's known
       // syntactic properties.
-      const suggestionContext = new ContextWindow(original.preInput as SyntheticTextStore, this.configuration, getLayerId());
+      const suggestionContext = new ContextWindow(original.preInput, this.configuration, getLayerId());
 
       // We must accept the Suggestion from its original context, which was before
       // `original.transform` was applied.
@@ -297,7 +297,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     textStore.apply(transform);
 
     // The reason we need to preserve the additive-inverse 'transformId' property on Reversions.
-    const promise = this.currentPromise = this.lmEngine.revertSuggestion(reversion, new ContextWindow(original.preInput as SyntheticTextStore, this.configuration, null))
+    const promise = this.currentPromise = this.lmEngine.revertSuggestion(reversion, new ContextWindow(original.preInput, this.configuration, null))
     // If the "current Promise" is as set above, clear it.
     // If another one has been triggered since... don't.
     promise.then(() => this.currentPromise = (this.currentPromise == promise) ? null : this.currentPromise);
@@ -324,7 +324,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
       return null;
     }
 
-    const context = new ContextWindow(transcription.preInput as SyntheticTextStore, this.configuration, layerId);
+    const context = new ContextWindow(transcription.preInput, this.configuration, layerId);
     this.recordTranscription(transcription);
 
     if(resetContext) {


### PR DESCRIPTION
`preInput` always contains a `SyntheticTextStore`, so this change modifies the type of the property so that we don't have to always cast it.

Follow-up-of: #15092
Test-bot: skip