### PR TITLE
maint(linux): free disk space before running autopkgtests

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -186,6 +186,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Free disk space
+      run: |
+        # Free disk space by removing some large directories that we don't use (#15171)
+        # see https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg
+
+        # Remove Android SDKs (frees 12 GB on Ubuntu 24.04)
+        sudo rm -rf /usr/local/lib/android
+
+        # Remove Haskell (GHC) (frees 6.4 GB)
+        sudo rm -rf /usr/local/.ghcup
+
+        # Remove CodeQL and other toolcaches (frees 5.8 GB)
+        sudo rm -rf /opt/hostedtoolcache
+
+        # Remove .NET SDKs (frees 4.0 GB)
+        sudo rm -rf /usr/share/dotnet
+
     - name: Download Source Artifacts
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:


### PR DESCRIPTION
Running the autopkgtests during a Ubuntu packaging build GHA recently started to fail with an out-of-disk-space error. This change removes some large directories with tools that we don't need for the autopkgtests.

We could delete some more that are not quite as big, but this gives us more than enough space and saves a bit of build-time.

Fixes: #15171
Build-bot: skip
Test-bot: skip