### PR TITLE
fix(windows): add check a fix for registry datatypes 🍒 🏠

### DIFF
--- a/windows/src/engine/keyman/langswitch/LangSwitchManager.pas
+++ b/windows/src/engine/keyman/langswitch/LangSwitchManager.pas
@@ -1021,7 +1021,7 @@ procedure TLangSwitchConfiguration.DisableWindowsHotkey;
 var
   MatchValue: string;
   KeyboardToggleReg: TRegistryErrorControlled;
-  FReset, FFixed: Boolean;
+  FReset: Boolean;
   const CHotkeyNotAssigned = '3';
 begin
   if FCurrentHotkey = (HK_ALT or HK_SHIFT) then MatchValue := '1'
@@ -1031,7 +1031,6 @@ begin
   FLanguageToggle := CHotkeyNotAssigned;
   FLayoutToggle := CHotkeyNotAssigned;
 
-  //FFixed := False;
   FReset := False;
 
   KeyboardToggleReg := TRegistryErrorControlled.Create; // I2890


### PR DESCRIPTION
The Windows system level keyboard hotkeys controlled in registry have sometimes been incorrectly written as a DWORD datatype. There 106 events in sentry for just July. When opening the Windows setting dialog and the registry has DWORDS it will show unassinged in the dialog if apply is pressed it will convert the keys to REG_SZ.
This fix follows a similar pattern it will check the data type of the registry key if it is DWORD it will remove it and add a new key of the same name as REG_SZ and set it to the unassigned value.

Cherry-pick-of: #14358
Fixes: #14342
Fixes: KEYMAN-WINDOWS-4NK
Build-bot: release windows
Test-bot: skip
Co-authored-by: @rc-swag