### PR TITLE
feat(windows): update wix to 3.14.1

### DIFF
--- a/docs/build/windows.md
+++ b/docs/build/windows.md
@@ -345,7 +345,7 @@ SETX KEYMAN_CEF4DELPHI_ROOT "c:\Projects\keyman\CEF4Delphi_Binary"
 ```ps1
 # Elevated PowerShell
 choco install 7zip html-help-workshop
-choco install wixtoolset --version=3.11.1
+choco install wixtoolset --version=3.14.1
 git clone https://github.com/keymanapp/CEF4Delphi_Binary C:\Projects\keyman\CEF4Delphi_Binary
 ```
 

--- a/resources/build/win/wix.inc.sh
+++ b/resources/build/win/wix.inc.sh
@@ -1,5 +1,5 @@
 
-WIXPATH="$ProgramFilesx86/WiX Toolset v3.11/bin"
+WIXPATH="$ProgramFilesx86/WiX Toolset v3.14/bin"
 
 # !IFDEF LINT
 WIXLIGHTLINT=()


### PR DESCRIPTION
Update the WiX toolset build version to 3.14.1 in preparation for Arm64.


Fixes: #15192

# User Testing

## TEST_KEYMAN_INSTALLS

Install the Keyman build and make sure it installs successfully.
Then move on to next basic functionality test

## TEST_KEYMAN_OPERATES_AS_EXPECTED

Install the Keyman build and make sure it installs successfully
Install two Keyman keyboards
Select one of the keyboards
Use both 64bit and 32bit text editors attached to this PR and make
sure they both work.
Test the OSK.



## TEST_KEYMAN_DEVELOPER_INSTALLS

Install the Keyman Developer build and make sure it installs successfully.
Then move on to next basic functionality test

## TEST_KEYMAN_DEVELOPER_AS_EXPECTED

Install the Keyman Developer build and make sure it installs successfully.
Create a New project 
Add some characters 
build the project and test the project.
Make sure it all operates as expected.