### PR TITLE
refactor(web): remove duplicate exports 🎼

### DIFF
--- a/web/src/engine/src/attachment/index.ts
+++ b/web/src/engine/src/attachment/index.ts
@@ -1,16 +1,5 @@
 export { AttachmentInfo } from './attachmentInfo.js';
 
-/*
- * Note:  for `instanceof` the attachment objects returned by the next module's
- * to match that of the actual objects within the browser when bundled, the
- * **same bundle** must contain reference points for those classes' definitions.
- */
 export { textStoreForElement } from './textStoreForElement.js';
 export { textStoreForEvent } from './textStoreForEvent.js';
 export { PageContextAttachment, PageAttachmentOptions } from './pageContextAttachment.js';
-
-/*
- * Following from the prior "Note:", we republish `engine/element-text-stores` here -
- * this matters quite strongly for certain unit tests.
- */
-export * from 'keyman/engine/element-text-stores';

--- a/web/src/test/auto/dom/cases/attachment/textStoreForElement.def.ts
+++ b/web/src/test/auto/dom/cases/attachment/textStoreForElement.def.ts
@@ -1,15 +1,16 @@
 import {
-  // Exposed within the engine/attachment bundle b/c of unit tests requiring `instanceof` relations.
-  ContentEditableElementTextStore,
-  DesignIFrameElementTextStore,
-  InputElementTextStore,
-  TextAreaElementTextStore,
-
   textStoreForEvent,
   textStoreForElement,
   PageContextAttachment,
   PageAttachmentOptions,
 } from 'keyman/engine/attachment';
+
+import {
+  ContentEditableElementTextStore,
+  DesignIFrameElementTextStore,
+  InputElementTextStore,
+  TextAreaElementTextStore,
+} from 'keyman/engine/element-text-stores';
 
 import { timedPromise } from 'keyman/common/web-utils';
 import { DEFAULT_BROWSER_TIMEOUT } from '@keymanapp/common-test-resources/test-timeouts.mjs';

--- a/web/src/test/auto/dom/cases/browser/contextManager.tests.ts
+++ b/web/src/test/auto/dom/cases/browser/contextManager.tests.ts
@@ -1,6 +1,7 @@
 // import { BrowserConfiguration, ContextManager } from 'keyman/app/browser';
 import { ContextManager } from 'keyman/app/browser';
-import { TextAreaElementTextStore, textStoreForElement } from 'keyman/engine/attachment';
+import { textStoreForElement } from 'keyman/engine/attachment';
+import { TextAreaElementTextStore } from 'keyman/engine/element-text-stores';
 import { LegacyEventEmitter } from 'keyman/engine/events';
 import { StubAndKeyboardCache, toPrefixedKeyboardId as prefixed } from 'keyman/engine/keyboard-storage';
 import { KeyboardInterfaceBase } from 'keyman/engine/main';


### PR DESCRIPTION
Previously we re-exported the exports of `element-text-stores` in `attachment` because it was needed in unit tests. This change removes this re-export - should be solved differently, but it turns out that all current tests pass even without the re-export.

This comes out of [a review comment in #15092](https://github.com/keymanapp/keyman/pull/15092#discussion_r2493048032).

Follow-up-of: #15092
Test-bot: skip