### PR TITLE
fix(windows): reinstall low level keyboard hook if it gets removed 🍒 🏠

### DIFF
--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -292,6 +292,8 @@ type
     procedure UnregisterControllerWindows;   // I4731
     function IsSysTrayWindow(AHandle: THandle): Boolean;
     procedure GetTrayIconHandle;   // I4731
+    procedure WatchDogKeyEvent;
+
   protected
     procedure DoInterfaceHotkey(Target: Integer);
 
@@ -849,12 +851,27 @@ begin
         if (TKeymanHint(lParam) = KH_EXITPRODUCT) and (wParam = mrOk) then
           UnloadProduct;
       end;
+    KMC_WATCHDOG_KEYEVENT:
+      WatchDogKeyEvent;
+    KMC_WATCHDOG_FAKEFREEZE:
+      begin
+        TDebugLogClient.Instance.WriteMessage('kmc_fakefreeze begin', []);
+        Sleep(5000);
+        TDebugLogClient.Instance.WriteMessage('kmc_fakefreeze end', []);
+      end;
 //TOUCH    KMC_CONTEXT:
 //TOUCH      begin
 //TOUCH        if LParam <> 0 then
 //TOUCH          ProcessContextChange(LParam);
 //TOUCH      end;
   end;
+end;
+
+procedure TfrmKeyman7Main.WatchDogKeyEvent;
+begin
+  TDebugLogClient.Instance.WriteMessage('Attempting to send WatchDogKeyEvent', []);
+  if kmint.KeymanEngineControl <> nil then
+    kmint.KeymanEngineControl.WatchDogKeyEvent;
 end;
 
 procedure TfrmKeyman7Main.DoInterfaceHotkey(Target: Integer);

--- a/windows/src/engine/keyman32/LowLevelHookWatchDog.cpp
+++ b/windows/src/engine/keyman32/LowLevelHookWatchDog.cpp
@@ -1,0 +1,105 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by mcdurdin on 2025-11-17
+ *
+ * Handle situations where Windows silently uninstalls our low level keyboard
+ * hook, and dynamically reinstall it. The hook can be uninstalled when
+ * keyman.exe becomes unresponsive for more than 200msec (default timeout) --
+ * this can be due to something Keyman is doing, but it could also happen during
+ * high system load. The hook will only be uninstalled if a key is pressed while
+ * Keyman is unresponsive.
+ *
+ * Per Windows documentation:
+ * https://learn.microsoft.com/en-us/windows/win32/winmsg/lowlevelkeyboardproc#remarks
+ *
+ * This works by tracking last event times for both the WH_KEYBOARD_LL hook and
+ * the WH_GETMESSAGE hook. These two hooks both receive key events, but the
+ * WH_GETMESSAGE hook runs in the focused thread context, whereas WH_KEYBOARD_LL
+ * runs in keyman.exe main thread context. The WH_KEYBOARD_LL hook receives the
+ * key event first.
+ *
+ * This (static) class is only used in the keyman.exe main thread context.
+ *
+ * Notification of HookIsAlive is a straightforward call from the low level
+ * keyboard hook procedure, but the KeyEventReceivedInGetMessageProc function
+ * must be signalled across processes. We have chosen to do this with a posted
+ * message to the master controller, which is then handled by
+ * UfrmKeyman7Main.pas, and passed through Keyman_WatchDogKeyEvent.
+ *
+ * The message handler was implemented in UfrmKeyman7Main.pas rather than in
+ * kmhook_getmessage.cpp, because it appears that kmnGetMessageProc does not see
+ * messages that were posted by it or child functions (this is by observation, not
+ * documentation -- I was not able to find documentation on this, but surmise it
+ * is to prevent deadlock/infinite loop scenarios, which could easily lockup
+ * Windows entirely).
+ *
+ * No key data is passed in the event, only the information that a key was
+ * pressed.
+ */
+
+#include "pch.h"
+
+/**
+ * minimum number of milliseconds between the last LowLevel and GetMessage
+ * events before we assume the low level hook has been uninstalled, and we need
+ * to reinstall it.
+ */
+#define WATCHDOG_THRESHOLD  1000
+
+static ULONGLONG LastLowLevelEventTick = 0;
+static ULONGLONG LastGetMessageEventTick = 0;
+
+void LowLevelHookWatchDog::HookIsAlive() {
+  // ULONGLONG Previous = LastLowLevelEventTick;
+  LastLowLevelEventTick = GetTickCount64();
+  // SendDebugMessageFormat("LowLevelHookWatchDog::HookIsAlive currentLL=%llu currentGM=%llu (lastLL=%llu)", LastLowLevelEventTick, LastGetMessageEventTick, Previous);
+}
+
+void LowLevelHookWatchDog::KeyEventReceivedInGetMessageProc() {
+  // ULONGLONG Previous = LastGetMessageEventTick;
+  LastGetMessageEventTick = GetTickCount64();
+  // SendDebugMessageFormat("LowLevelHookWatchDog::KeyEventReceivedInGetMessageProc currentLL=%llu currentGM=%llu (lastGM=%llu)", LastLowLevelEventTick, LastGetMessageEventTick, Previous);
+
+  // This is a good place to check if we are still alive -- shortly after each
+  // keystroke event in the GetMessage hook, as this means at worst we'll have
+  // one or two keystrokes where Keyman must recover
+  if(!CheckIfHookIsAlive()) {
+    ReinstallHook();
+  }
+}
+
+bool LowLevelHookWatchDog::CheckIfHookIsAlive() {
+  if(LastGetMessageEventTick < LastLowLevelEventTick) {
+    // this shouldn't be possible but rather safe than sorry
+    return true;
+  }
+
+  return LastGetMessageEventTick - LastLowLevelEventTick < WATCHDOG_THRESHOLD;
+}
+
+void LowLevelHookWatchDog::ReinstallHook() {
+  //keyman32.cpp:
+  SendDebugMessageFormat(
+    "Attempting to reinstall hook because watchdog threshold exceeded by %llu msec (last LL=%llu last GM=%llu)",
+    LastGetMessageEventTick - LastLowLevelEventTick,
+    LastLowLevelEventTick,
+    LastGetMessageEventTick
+  );
+
+  if(!RestartLowLevelHook()) {
+    SendDebugMessage("Attempt to reinstall low level hook may have failed, see previous log messages");
+  } else {
+    SendDebugMessage("Attempt to reinstall low level hook succeeded");
+  }
+
+  // We should assume the hook is alive at this point to avoid repeated resets
+  HookIsAlive();
+}
+
+#ifndef _WIN64
+extern "C" void __declspec(dllexport) WINAPI Keyman_WatchDogKeyEvent() {
+  SendDebugMessageFormat("Keyman_WatchDogKeyEvent");
+  LowLevelHookWatchDog::KeyEventReceivedInGetMessageProc();
+}
+#endif

--- a/windows/src/engine/keyman32/LowLevelHookWatchDog.h
+++ b/windows/src/engine/keyman32/LowLevelHookWatchDog.h
@@ -1,0 +1,32 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by mcdurdin on 2025-11-17
+ */
+
+/**
+ * @brief Watch for scenarios where the low level keyboard hook may be
+ * uninstalled by Windows, e.g. when there is heavy system load, and
+ * reinstall it.
+ */
+class LowLevelHookWatchDog {
+public:
+  /**
+   * @brief Update the watchdog timestamp to current time, because the low
+   *        level hook is receiving messages successfully
+   */
+  static void HookIsAlive();
+
+  /**
+   * @brief Update the watchdog GetMessageProc timestamp to current time;
+   *        this is called by the Keyman_WatchDogKeyEvent function, when
+   *        a message posted from the GetMessageProc hook is received by
+   *        keyman.exe.
+   */
+  static void KeyEventReceivedInGetMessageProc();
+
+private:
+  static bool CheckIfHookIsAlive();
+  static void ReinstallHook();
+};
+

--- a/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
+++ b/windows/src/engine/keyman32/k32_lowlevelkeyboardhook.cpp
@@ -141,6 +141,8 @@ LRESULT _kmnLowLevelKeyboardProc(
 
   SendDebugEntry();
 
+  LowLevelHookWatchDog::HookIsAlive();
+
   PKBDLLHOOKSTRUCT hs = (PKBDLLHOOKSTRUCT) lParam;
 
   BOOL extended = hs->flags & LLKHF_EXTENDED ? TRUE : FALSE;

--- a/windows/src/engine/keyman32/keyman32.cpp
+++ b/windows/src/engine/keyman32/keyman32.cpp
@@ -279,6 +279,24 @@ extern "C" BOOL _declspec(dllexport) WINAPI Keyman_GetInitialised(BOOL *FSingleA
 	return Globals::get_Keyman_Initialised();
 }
 
+#ifndef _WIN64
+BOOL InitLowLevelHook() {
+  HINSTANCE hinst = GetModuleHandle(LIBRARY_NAME);
+
+  *Globals::hhookLowLevelKeyboardProc() = SetWindowsHookExW(WH_KEYBOARD_LL, (HOOKPROC) kmnLowLevelKeyboardProc, hinst, Globals::get_FSingleThread());   // I4124
+  return Globals::get_hhookLowLevelKeyboardProc() != NULL;
+}
+
+BOOL UninitLowLevelHook() {
+  BOOL RetVal = TRUE;
+  if(Globals::get_hhookLowLevelKeyboardProc() && !UnhookWindowsHookEx(Globals::get_hhookLowLevelKeyboardProc()))    // I4124
+    RetVal = FALSE;
+
+  *Globals::hhookLowLevelKeyboardProc() = NULL;
+  return RetVal;
+}
+#endif
+
 BOOL InitHooks()
 {
   HINSTANCE hinst = GetModuleHandle(LIBRARY_NAME);
@@ -286,7 +304,7 @@ BOOL InitHooks()
 	*Globals::hhookGetMessage()   = SetWindowsHookExW(WH_GETMESSAGE,  (HOOKPROC) kmnGetMessageProc, hinst, Globals::get_FSingleThread());
   *Globals::hhookCallWndProc()  = SetWindowsHookExW(WH_CALLWNDPROC, (HOOKPROC) kmnCallWndProc,    hinst, Globals::get_FSingleThread());
 #ifndef _WIN64
-  *Globals::hhookLowLevelKeyboardProc() = SetWindowsHookExW(WH_KEYBOARD_LL, (HOOKPROC) kmnLowLevelKeyboardProc, hinst, Globals::get_FSingleThread());   // I4124
+  InitLowLevelHook();
 #endif;
 
   return
@@ -304,19 +322,14 @@ BOOL UninitHooks()
 
   if(Globals::get_hhookGetMessage() && !UnhookWindowsHookEx(Globals::get_hhookGetMessage()))
       RetVal = FALSE;
-  else
-      *Globals::hhookGetMessage() = NULL;
+  *Globals::hhookGetMessage() = NULL;
 
 	if(Globals::get_hhookCallWndProc() && !UnhookWindowsHookEx(Globals::get_hhookCallWndProc()))
     RetVal = FALSE;
-  else
-    *Globals::hhookCallWndProc() = NULL;
+  *Globals::hhookCallWndProc() = NULL;
 
 #ifndef _WIN64
-  if(Globals::get_hhookLowLevelKeyboardProc() && !UnhookWindowsHookEx(Globals::get_hhookLowLevelKeyboardProc()))    // I4124
-    RetVal = FALSE;
-  else
-    *Globals::hhookLowLevelKeyboardProc() = NULL;
+  RetVal = UninitLowLevelHook() && RetVal;
 #endif
 
 	return RetVal;
@@ -471,6 +484,27 @@ extern "C" BOOL _declspec(dllexport) WINAPI Keyman_RestartEngine()
   }
 
   return TRUE;
+}
+
+BOOL RestartLowLevelHook() {
+  BOOL result=true;
+
+#ifndef _WIN64
+  if(!Globals::get_Keyman_Initialised()) {
+    return FALSE;
+  }
+
+  if(!UninitLowLevelHook()) {
+    SendDebugMessageFormat("Failed to uninstall low level hook.  GetLastError = %d", GetLastError());
+    result = FALSE;
+  }
+  if(!InitLowLevelHook()) {
+    SendDebugMessageFormat("Failed to install low level hook.  GetLastError = %d", GetLastError());
+    result = FALSE;
+  }
+
+#endif
+  return result;
 }
 
 //---------------------------------------------------------------------------------------------------------

--- a/windows/src/engine/keyman32/keyman32.def
+++ b/windows/src/engine/keyman32/keyman32.def
@@ -49,3 +49,5 @@ EXPORTS
 			Keyman_UnregisterControllerThread
 
       SetCustomPostKeyCallback
+
+			Keyman_WatchDogKeyEvent

--- a/windows/src/engine/keyman32/keyman32.vcxproj
+++ b/windows/src/engine/keyman32/keyman32.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -360,6 +360,7 @@
     <ClCompile Include="kmprocess.cpp" />
     <ClCompile Include="$(KEYMAN_ROOT)\common\windows\cpp\src\registry.cpp" />
     <ClCompile Include="kmprocessactions.cpp" />
+    <ClCompile Include="LowLevelHookWatchDog.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -448,6 +449,7 @@
     <ClInclude Include="keyman-debug-etw.h" />
     <ClInclude Include="keyeventsenderthread.h" />
     <ClInclude Include="keystate.h" />
+    <ClInclude Include="LowLevelHookWatchDog.h" />
     <ClInclude Include="$(KEYMAN_ROOT)\common\windows\cpp\include\registry.h" />
     <ClInclude Include="security.h" />
     <ClInclude Include="serialkeyeventclient.h" />

--- a/windows/src/engine/keyman32/keymancontrol.h
+++ b/windows/src/engine/keyman32/keymancontrol.h
@@ -47,6 +47,12 @@
 
 #define KMC_PROFILECHANGED  18  // 9.0.426.0   // I3933
 
+#define KMC_HINTRESPONSE        19       // 14.0 HIWORD(wParam) = ModalResult, lParam = hint enum
+
+#define KMC_WATCHDOG_FAKEFREEZE 20       // 19.0 - pause Keyman for 5 seconds for debug purposes to test stability
+#define KMC_WATCHDOG_KEYEVENT   21       // 19.0 - let the LowLevelHookWatchDog know that input has happened on another thread
+
+
 #define PC_UPDATE 0                   // Tell Keyman to update its display of active keyboard
 #define PC_UPDATE_LANGUAGESWITCH 1    // Tell Keyman to update its display of active keyboard and then open language switch form
 #define PC_HOTKEYCHANGE 2             // Tell Keyman that a hotkey was pressed to switch keyboard

--- a/windows/src/engine/keyman32/keymanengine.h
+++ b/windows/src/engine/keyman32/keymanengine.h
@@ -262,6 +262,7 @@ void keybd_shift(LPINPUT pInputs, int* n, BOOL isReset, LPBYTE const kbd);
 #include "..\..\..\..\common\windows\cpp\include\crc32.h"
 
 #include "k32_tsf.h"
+#include "LowLevelHookWatchDog.h"
 
 void ReportActiveKeyboard(WORD wCommand);   // I3933   // I3949
 void SelectKeyboardHKL(DWORD hkl, BOOL foreground);  // I3933   // I3949   // I4271
@@ -271,5 +272,7 @@ void ProcessModifierChange(UINT key, BOOL isUp, BOOL isExtended);   // I4793
 
 BOOL SetupCoreEnvironment(km_core_option_item **test_env_opts);
 void DeleteCoreEnvironment(km_core_option_item *test_env_opts);
+
+BOOL RestartLowLevelHook();
 
 #endif  // _KEYMANENGINE_H

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -146,6 +146,15 @@ LRESULT _kmnGetMessageProc(int nCode, WPARAM wParam, LPARAM lParam)
   }
 
   if ((mp->message == WM_KEYDOWN || mp->message == WM_SYSKEYDOWN || mp->message == WM_KEYUP || mp->message == WM_SYSKEYUP)) {   // I4642
+
+    // To help our low level keyboard hook recover if system load causes it to
+    // be uninstalled, we tell the controller process that we should have seen a
+    // keystroke event in the low level keyboard hook; this gets passed into the
+    // LowLevelHookWatchDog via keyman.exe
+    if(mp->message == WM_KEYDOWN || mp->message == WM_SYSKEYDOWN) {
+      Globals::PostMasterController(wm_keyman_control, KMC_WATCHDOG_KEYEVENT, 0);
+    }
+
     BYTE scan = KEYMSG_LPARAM_SCAN(mp->lParam);
     CheckScheduledRefresh();
     _td->LastScanCode = scan;

--- a/windows/src/global/delphi/general/KeymanControlMessages.pas
+++ b/windows/src/global/delphi/general/KeymanControlMessages.pas
@@ -54,6 +54,9 @@ const
 
   KMC_HINTRESPONSE = 19;  // 14.0 HIWORD(wParam) = ModalResult, lParam = hint enum
 
+  KMC_WATCHDOG_FAKEFREEZE = 20; // 19.0 - pause Keyman for 5 seconds for debug purposes to test stability
+  KMC_WATCHDOG_KEYEVENT   = 21; // 19.0 - let the LowLevelHookWatchDog know that input has happened on another thread
+
   PC_UPDATE = 0;
   PC_UPDATE_LANGUAGESWITCH = 1;
   PC_HOTKEYCHANGE = 2;

--- a/windows/src/global/delphi/general/KeymanEngineControl.pas
+++ b/windows/src/global/delphi/general/KeymanEngineControl.pas
@@ -1,18 +1,18 @@
 (*
   Name:             KeymanControlRestart
   Copyright:        Copyright (C) SIL International.
-  Documentation:    
-  Description:      
+  Documentation:
+  Description:
   Create Date:      19 Jun 2007
 
   Modified Date:    19 Jun 2007
   Authors:          mcdurdin
-  Related Files:    
-  Dependencies:     
+  Related Files:
+  Dependencies:
 
-  Bugs:             
-  Todo:             
-  Notes:            
+  Bugs:
+  Todo:
+  Notes:
   History:          19 Jun 2007 - mcdurdin - Initial version
 *)
 unit KeymanEngineControl;
@@ -43,6 +43,10 @@ type
     procedure UnregisterMasterController(Value: LongWord); safecall;
     procedure RegisterControllerThread(Value: LongWord); safecall;
     procedure UnregisterControllerThread(Value: LongWord); safecall;
+
+    // New in 19.0
+
+    procedure WatchDogKeyEvent; safecall;    // 32 bit only
   end;
 
 implementation


### PR DESCRIPTION
This change improves the stability of Keyman for Windows by monitoring the health of the low level keyboard hook. If keyman.exe is unresponsive at any time, Windows can silently uninstall its low level keyboard hook, which results in (at least) two problems:

* Keyman's hotkeys stop working
* A modifier key can become stuck, if it was pressed around the time Keyman became unresponsive.

The most common scenario in which Keyman can become unresponsive is high system load, e.g. rendering graphics, videoconference calls, compiling software.

Restarting Keyman always resolved both of these two issues in the past, but with this patch, I hope that this will no longer be necessary.

A related 'fakefreeze' project is not included in this cherry-pick; see PR #15179 for this.

Logging has been updated; look for "LowLevelHookWatchDog" in the log for related events.

One final small change in keyman32.cpp, as I refactored the WH_KEYBOARD_LL hook installation/uninstallation, was to always clear out hook variables when uninstalling a hook, because if the hook fails to uninstall, there's really nothing we can do about it anyway, and we probably shouldn't be trying again.

Fixes: #8064
Cherry-pick-of: #15179
Test-bot: skip
Build-bot: skip