### PR TITLE
fix(developer): handle errors in .keyman-touch-layout file when loading

### DIFF
--- a/developer/src/tike/child/UfrmKeymanWizard.pas
+++ b/developer/src/tike/child/UfrmKeymanWizard.pas
@@ -461,7 +461,7 @@ type
     procedure FeatureModified(Sender: TObject);
     function SaveFeature(ID: TKeyboardParser_FeatureID): Boolean;
     procedure SelectTouchLayoutTemplate(APromptChange: Boolean);
-    function LoadTouchLayout: Boolean;   // I4034
+    procedure LoadTouchLayout;   // I4034
     function GetFontInfo(Index: TKeyboardFont): TKeyboardFontInfo;   // I4057
     procedure SetFontInfo(Index: TKeyboardFont; const Value: TKeyboardFontInfo);   // I4057
 
@@ -1659,8 +1659,7 @@ begin
       end;
     kfTouchLayout:
       begin
-        if not LoadTouchLayout then
-          Exit(False);
+        LoadTouchLayout;
       end;
     else
     begin
@@ -3202,17 +3201,15 @@ begin
   FFeature[kfTouchLayout].Modified := True;
 end;
 
-function TfrmKeymanWizard.LoadTouchLayout: Boolean;   // I4034
+procedure TfrmKeymanWizard.LoadTouchLayout;   // I4034
 begin
   if pagesTouchLayout.ActivePage = pageTouchLayoutDesign then
   begin
-    Result := frameTouchLayout.Load(FFeature[kfTouchLayout].Filename, False, False);
-  end
-  else
-  begin
-    frameTouchLayoutSource.LoadFromFile(FFeature[kfTouchLayout].Filename, tffUTF8);
-    Result := True;
+    if frameTouchLayout.Load(FFeature[kfTouchLayout].Filename, False, False) then
+      Exit;
+    pagesTouchLayout.ActivePage := pageTouchLayoutCode;
   end;
+  frameTouchLayoutSource.LoadFromFile(FFeature[kfTouchLayout].Filename, tffUTF8);
 end;
 
 procedure TfrmKeymanWizard.SaveTouchLayout;   // I3885

--- a/developer/src/tike/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/developer/src/tike/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -95,6 +95,7 @@ type
     procedure CharMapDragOver(Sender, Source: TObject; X, Y: Integer;
       State: TDragState; var Accept: Boolean);
     procedure UnregisterSources;
+    procedure TouchLayoutMessage(Sender: TObject; const Message: string);
   protected
     function GetHelpTopic: string; override;
 
@@ -140,7 +141,9 @@ uses
   xmldoc,
 
   Keyman.Developer.System.HelpTopics,
+  Keyman.Developer.System.Project.ProjectLog,
   Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter,
+  Keyman.Developer.UI.Project.ProjectFileUI,
 
   CharacterDragObject,
   CharMapDropTool,
@@ -309,6 +312,11 @@ begin
     else Result := s <> FSavedLayoutJS;
 end;
 
+procedure TframeTouchLayoutBuilder.TouchLayoutMessage(Sender: TObject; const Message: string);
+begin
+  LogMessage(plsError, FFilename, Message, 0, 0);
+end;
+
 function TframeTouchLayoutBuilder.Load(const AFilename: string; ALoadFromTemplate, ALoadFromString: Boolean): Boolean;
 var
   FLastFilename: string;
@@ -372,6 +380,7 @@ begin
 
   FTouchLayout := TTouchLayout.Create;   // I3642
   try
+    FTouchLayout.OnMessage := TouchLayoutMessage;
     if not FTouchLayout.Load(FNewLayoutJS) then
     begin
       FLastError := FTouchLayout.LoadError;   // I4083


### PR DESCRIPTION
If the .keyman-touch-layout file has validation errors, Keyman Developer will now report the first validation error in the message window, rather than silently closing the whole keyboard editor. The .keyman-touch-layout file will be loaded in Code view, and once the first validation error is addressed, switching to Design view will report the next error.

For future improvement:
* reporting multiple validation errors
* reporting line number of error

Fixes: #15242
Test-bot: skip