### PR TITLE
docs(android): Document Keyman API for keyboard font change

### DIFF
--- a/android/docs/engine/KMAPro/index.md
+++ b/android/docs/engine/KMAPro/index.md
@@ -1,0 +1,23 @@
+---
+title: Keyman for Android APIs
+---
+
+## Summary
+
+The **`Keyman for Android`** app has the following APIs for integration:
+
+
+## Description
+
+The Keyman for Android app installs as an Input Method Extension. When selected as the active system keyboard, it provides the following APIs:
+
+
+## Intents
+
+When the Keyman system keyboard changes the associated font name, the following Intent is broadcast so the integrating application can match the font:
+
+```java
+intent = new Intent("com.tavultesoft.kmapro.keyboard_changed");
+intent.putExtra("fontName", fontName);
+sendBroadcast(intent);
+```

--- a/android/docs/engine/index.md
+++ b/android/docs/engine/index.md
@@ -27,8 +27,12 @@ see [What's New](whatsnew) for breaking changes</a>
 [KeyboardEventHandler](KeyboardEventHandler/)
 : Provides keyboard and lexical-model events and methods to notify registered listeners
 
+[Keyman for Android app](KMAPro/)
+: Public APIs for integrating with the Keyman application
+
 ## See also
 
+* [Keyman Engine for Android 18.0](/developer/engine/android/18.0/)
 * [Keyman Engine for Android 17.0](/developer/engine/android/17.0/)
 * [Keyman Engine for Android 16.0](/developer/engine/android/16.0/)
 * [Keyman Engine for Android 15.0](/developer/engine/android/15.0/)

--- a/android/docs/engine/whatsnew.md
+++ b/android/docs/engine/whatsnew.md
@@ -2,5 +2,7 @@
 title: What's New in Keyman Engine 19.0 for Android
 ---
 
+* Added API for broadcasting when Keyman system keyboard font changes (#15193)
+
 ## See Also
 * [Keyman Engine for Android Documentation](index)


### PR DESCRIPTION
Documents the new Keyman for Android app API of broadcasting font name from #15193

> I think it belongs more closely with Engine docs than end user docs. It's about integration, just at another level. Let's go with putting it into the Engine docs, under a new section. If we have to reorg Engine docs, that's also okay.

Test-bot: skip
