### PR TITLE
docs(ios): Use /cdn/dev assets for Engine guides

### DIFF
--- a/ios/docs/engine/guides/in-app/index.md
+++ b/ios/docs/engine/guides/in-app/index.md
@@ -4,7 +4,7 @@ title: Guide: build an in-app keyboard
 
 Keyman Engine for iPhone and iPad allows you to use any Keyman touch
 keyboard in your iOS app, or even to create your own system keyboard app
-for purchase in the App Store.  
+for purchase in the App Store.
 This guide will walk you through the steps for creating your first iOS
 app with Keyman Engine for iPhone and iPad.
 
@@ -38,23 +38,23 @@ Use Keyman Developer to build a touch layout. The following documents walk throu
 
 When your keyboard is ready, you should have a compiled keyboard package. The example below shows the Thamizha Tamil99 touch layout.
 
-![Keyman-developer](/cdn/deploy/img/engine/ios/16.0/guides/in-app/keyboard-layout-in-developer-800wi.png "Keyman-developer")
+![Keyman-developer](/cdn/dev/img/engine/ios/16.0/guides/in-app/keyboard-layout-in-developer-800wi.png "Keyman-developer")
 
 Open the package tab for your keyboard and compile it. Then, open the folder containing your package
 
-![Keyman-developer-open-containing-folder](/cdn/deploy/img/engine/ios/16.0/guides/in-app/find-package-via-developer-800wi.png "Keyman-developer-open-containing-folder")
+![Keyman-developer-open-containing-folder](/cdn/dev/img/engine/ios/16.0/guides/in-app/find-package-via-developer-800wi.png "Keyman-developer-open-containing-folder")
 
-![Compiled-keyboard-file](/cdn/deploy/img/engine/ios/16.0/guides/in-app/package-file-800wi.png "Compiled-keyboard-file")
+![Compiled-keyboard-file](/cdn/dev/img/engine/ios/16.0/guides/in-app/package-file-800wi.png "Compiled-keyboard-file")
 
 ### 4. Add your keyboard package to the project
 
 Copy your compiled keyboard package (in this example **ekwtamil99uni.kmp**) to your macOS machine within the **KMSample1\Keyboards** folder.
 
-![Copy-keyboard-file](/cdn/deploy/img/engine/ios/16.0/guides/in-app/package-import.png "Copy-keyboard-file")
+![Copy-keyboard-file](/cdn/dev/img/engine/ios/16.0/guides/in-app/package-import.png "Copy-keyboard-file")
 
 When you switch back into Xcode, use the right-click context menu to "Add Files to 'KMSample1'":
 
-![Android-studio-assets](/cdn/deploy/img/engine/ios/16.0/guides/in-app/xcode-package-import-800wi.png "Android-studio-assets")
+![Android-studio-assets](/cdn/dev/img/engine/ios/16.0/guides/in-app/xcode-package-import-800wi.png "Android-studio-assets")
 
 Next, edit `ViewController.viewDidLoad()` to add the keyboard (ekwtamil99uni) with `Manager.shared` from KeymanEngine.framework.
 
@@ -73,7 +73,7 @@ Next, edit `ViewController.viewDidLoad()` to add the keyboard (ekwtamil99uni) wi
   }
 ```
 
-![Android-studio-adding-keyboard](/cdn/deploy/img/engine/ios/16.0/guides/in-app/fully-imported-800wi.png "Android-studio-adding-keyboard")
+![Android-studio-adding-keyboard](/cdn/dev/img/engine/ios/16.0/guides/in-app/fully-imported-800wi.png "Android-studio-adding-keyboard")
 
 ### 5. Build and run the app
 
@@ -82,7 +82,7 @@ emulate a number of iOS devices. Simply choose a target device to test
 against from the drop-down toward the top-left. For example, in the
 previous image, you can see "iPod Touch (7th generation)" selected.
 
-![Android-emulator-tamil](/cdn/deploy/img/engine/ios/16.0/guides/in-app/ios-simulator-tamil.png "Android-emulator-tamil")
+![Android-emulator-tamil](/cdn/dev/img/engine/ios/16.0/guides/in-app/ios-simulator-tamil.png "Android-emulator-tamil")
 
 And there you have it: your first Keyman Engine for iPhone and iPad app!
 

--- a/ios/docs/engine/guides/system-keyboard/index.md
+++ b/ios/docs/engine/guides/system-keyboard/index.md
@@ -43,14 +43,14 @@ back out to the main screen. From there, launch the Settings app and go
 to **General &gt; Keyboards &gt; Keyboards** to enable KMSample2 as a
 system keyboard.
 
-![Emulator](/cdn/deploy/img/engine/ios/16.0/guides/system-keyboard/set-sys-kbd.png "Emulator")
+![Emulator](/cdn/dev/img/engine/ios/16.0/guides/system-keyboard/set-sys-kbd.png "Emulator")
 
 Once that's done, open any app that can accept text input and select
 KMSample2 as your keyboard! Note that in this sample, the Thamizha
 Tamil99 keyboard can be accessed through the keyboard's "globe" key if
 it is not set active within KMSample2.
 
-![Emulator](/cdn/deploy/img/engine/ios/16.0/guides/system-keyboard/sys-kbd-active.png "Emulator")
+![Emulator](/cdn/dev/img/engine/ios/16.0/guides/system-keyboard/sys-kbd-active.png "Emulator")
 
 ### 3. Extending the app
 
@@ -60,7 +60,7 @@ one; again, follow the instructions from Part 1 to make this change.
 You can also customise the look and feel of the on screen keyboard by
 including a custom CSS file in your keyboard through Keyman Developer.
 
-![AddEmbeddedCSS](/cdn/deploy/img/engine/ios/16.0/guides/system-keyboard/developer-add-css-800wi.png "AddEmbeddedCSS")
+![AddEmbeddedCSS](/cdn/dev/img/engine/ios/16.0/guides/system-keyboard/developer-add-css-800wi.png "AddEmbeddedCSS")
 
 The CSS rules required to style your keyboard are beyond the scope of
 this post, but the **kmwosk.css** file included in the Keyman Developer


### PR DESCRIPTION
keymanapp/help.keyman.com#1615 converted the Keyman Engine for iPhone and iPad guides from PHP to Markdown, where image asset references changed from PHP `cdn()` calls to Markdown image links to `/cdn/deploy/`.

The Markdown references to /cdn/deploy assets work for production/staging tier, but that folder won't exist when the help.keyman.com site is built with `./build.sh build --debug`

See https://github.com/keymanapp/help.keyman.com/blob/2eeb860a21c050d5c26e126841fee105d27ef1a2/resources/init-container.sh#L11-L20

This updates the iOS guides to use /cdn/dev assets (and will get synced to the [/developer/engine/iphone-and-ipad/19.0/](https://github.com/keymanapp/help.keyman.com/tree/master/developer/19.0)) 

Test-bot: skip
