### PR TITLE
fix(web): fix running tests on Windows machines 🎼

### DIFF
--- a/web/src/test/auto/headless/engine/loadKeyboardHelper.ts
+++ b/web/src/test/auto/headless/engine/loadKeyboardHelper.ts
@@ -3,9 +3,10 @@
  */
 
 import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
 const KEYMAN_ROOT = process.env['KEYMAN_ROOT'];
-export const coreurl = `${KEYMAN_ROOT}/web/build/engine/obj/core-adapter/import/core`;
+export const coreurl = pathToFileURL(`${KEYMAN_ROOT}/web/build/engine/obj/core-adapter/import/core`).toString();
 
 export function loadKeyboardBlob(filename: string) {
   const data = fs.readFileSync(`${KEYMAN_ROOT}${filename}`, null);


### PR DESCRIPTION
This change allows the headless core-adapter and CoreKeyboardProcessor tests to run on Windows.

Follow-up-of: #15220
Test-bot: skip