### PR TITLE
maint(resources): roll back builder_launch for trigger-release-builds.sh

### DIFF
--- a/resources/teamcity/triggers/trigger-release-builds.sh
+++ b/resources/teamcity/triggers/trigger-release-builds.sh
@@ -98,7 +98,7 @@ echo "trigger-release-builds.sh: building resources/build/version"
 pushd "$KEYMAN_ROOT"
 npm ci
 
-builder_launch /resources/build/version/build.sh
+"$KEYMAN_ROOT/resources/build/version/build.sh"
 
 echo "trigger-release-builds.sh: running resources/build/version"
 pushd "$KEYMAN_ROOT"


### PR DESCRIPTION
The trigger-release-builds.sh script is not a full builder script, and does not setup all the necessary environment for using `builder_launch`. This causes a script error:

```
[resources/teamcity/triggers] ## script '/resources/build/version/build.sh ' launched...
/c/BuildAgent/work/99b311828f4ee7c/keyman/resources/builder.inc.sh: line 517: _builder_build_deps: unbound variable
```

So, rolling this back to a direct call to the script, at least until we update trigger-release-builds to be a full builder script.

Test-bot: skip
Build-bot: skip