### PR TITLE
fix(developer): handle Enter key in dialogs in Touch Layout Editor

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/builder.xsl
+++ b/developer/src/tike/xml/layoutbuilder/builder.xsl
@@ -264,7 +264,7 @@
   </div>
 
   <div id='addPlatformDialog' title='Add platform'>
-    <form>
+    <form id='addPlatformForm'>
       <fieldset>
         Platform: <select id='selAddPlatform'></select>
       </fieldset>
@@ -276,7 +276,7 @@
   </div>
 
   <div id='addLayerDialog' title='Add layer'>
-    <form>
+    <form id='addLayerForm'>
       <fieldset>
         <label for='addLayerList'>Modifier-based layer:</label> <select id='addLayerList'></select><br />
       </fieldset>
@@ -292,7 +292,7 @@
   </div>
 
   <div id='viewOptionsDialog' title='View options'>
-    <form>
+    <form id='viewOptionsForm'>
       <fieldset>
         <div>By default, only common modifiers are shown in the modifier lists. If
           access to more unusual modifier combinations are required, check this option.<br/><br/>
@@ -305,7 +305,7 @@
   </div>
 
   <div id='platformPropertiesDialog' title='Platform properties'>
-    <form>
+    <form id='platformPropertiesForm'>
       <fieldset>
         <div>Displays the underlying keyboard label on top-left of the key<br/><br/></div>
         <input type='checkbox' id='chkDisplayUnderlying'/>
@@ -337,7 +337,7 @@
   </div>
 
   <div id='layerPropertiesDialog' title='Layer properties'>
-    <form>
+    <form id='layerPropertiesForm'>
       <fieldset>
         Name: <input type='text' id='layerName' size='16' maxlength='64' />
       </fieldset>

--- a/developer/src/tike/xml/layoutbuilder/platform-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/platform-controls.js
@@ -49,26 +49,31 @@ $(function() {
   // Platform dialogs
   //
 
+  function addPlatformSubmit() {
+    builder.saveUndo();
+
+    var platform = $('#selAddPlatform').val();
+    KVKL[platform] = $.extend(true, {}, KVKL[builder.lastPlatform]);  // copy existing platform
+
+    builder.preparePlatforms();
+    $('#selPlatform').val(platform);
+    builder.selectPlatform();
+
+    builder.generate(false,true);
+
+    $('#addPlatformDialog').dialog('close');
+    return false;
+  }
+
+  $('#addPlatformForm').on('submit', addPlatformSubmit);
+
   $('#addPlatformDialog').dialog({
     autoOpen: false,
     height: 300,
     width: 350,
     modal: true,
     buttons: {
-      "OK": function () {
-        builder.saveUndo();
-
-        var platform = $('#selAddPlatform').val();
-        KVKL[platform] = $.extend(true, {}, KVKL[builder.lastPlatform]);  // copy existing platform
-
-        builder.preparePlatforms();
-        $('#selPlatform').val(platform);
-        builder.selectPlatform();
-
-        builder.generate(false,true);
-
-        $(this).dialog('close');
-      },
+      "OK": addPlatformSubmit,
       "Cancel": function () {
         $(this).dialog('close');
       }
@@ -115,6 +120,10 @@ $(function() {
     builder.generate();
     builder.prepareLayer();
     builder.restoreSelection(selection);
+  });
+
+  $('#platformPropertiesForm').on('submit', function() {
+    $('#platformPropertiesDialog').dialog('close');
   });
 
   $('#platformPropertiesDialog').dialog({

--- a/developer/src/tike/xml/layoutbuilder/view-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/view-controls.js
@@ -12,6 +12,11 @@ $(function() {
     builder.prepareKey();
   });
 
+  $('#viewOptionsForm').on('submit', function() {
+    $('#viewOptionsDialog').dialog('close');
+    return false;
+  });
+
   $('#viewOptionsDialog').dialog({
     autoOpen: false,
     height: 300,


### PR DESCRIPTION
Fixes: #15215

# User Testing

TEST_TOUCH_EDITOR_DIALOGS: For each of the dialogs available in the Touch Layout Editor, click in a field in the dialog and press Enter, and verify that you no longer receive a blank page; also check with F12 that no script errors are generated.