### PR TITLE
fix(windows): use Thai Kedmanee instead of Arabic 101 in RightAltEmulationCheck.tests.cpp🍒 🎼

### DIFF
--- a/windows/src/engine/keyman32/RightAltEmulationCheck.cpp
+++ b/windows/src/engine/keyman32/RightAltEmulationCheck.cpp
@@ -65,7 +65,7 @@ typedef PKBDTABLES_WOW64 (WINAPI *PKBDLAYERDESCRIPTORWOW64FUNC)(VOID);
 #endif
 
 HMODULE LoadKbdLibrary(const char* keyboardLayoutName);
-BOOL ReadAltGrFlagFromKbdDll(const char *keyboardLayoutName);
+BOOL ReadAltGrFlagFromKbdDll(const char *keyboardLayoutName, BOOL& result);
 
 typedef PKBDTABLES (WINAPI *PKBDLAYERDESCRIPTORFUNC)(VOID);
 
@@ -92,14 +92,15 @@ BOOL KeyboardGivesCtrlRAltForRAlt() {
 		char keyboardLayoutName[KL_NAMELENGTH+1];
 		GetKeyboardLayoutName(keyboardLayoutName);
 
-		altGrFlag = ReadAltGrFlagFromKbdDll(keyboardLayoutName);
+		ReadAltGrFlagFromKbdDll(keyboardLayoutName, altGrFlag);
   }
 
 	return altGrFlag;
 }
 
-BOOL ReadAltGrFlagFromKbdDll(const char *keyboardLayoutName) {
-	BOOL result = FALSE;
+BOOL ReadAltGrFlagFromKbdDll(const char *keyboardLayoutName, BOOL& result) {
+  BOOL success = FALSE;
+  result = FALSE;
 
   HMODULE hKbdLibrary = LoadKbdLibrary(keyboardLayoutName);
   if(!hKbdLibrary) {
@@ -118,6 +119,7 @@ BOOL ReadAltGrFlagFromKbdDll(const char *keyboardLayoutName) {
 			PKBDTABLES_WOW64 KbdTables = (*KbdLayerDescriptorFunc)();
 			if(KbdTables) {
 				result = (KbdTables->fLocaleFlags & KLLF_ALTGR) ? TRUE : FALSE;
+        success = TRUE;
 			}
 		}
   }	else {
@@ -130,13 +132,14 @@ BOOL ReadAltGrFlagFromKbdDll(const char *keyboardLayoutName) {
 			PKBDTABLES KbdTables = (*KbdLayerDescriptorFunc)();
 			if(KbdTables) {
 				result = (KbdTables->fLocaleFlags & KLLF_ALTGR) ? TRUE : FALSE;
+        success = TRUE;
 			}
 		}
 	}
 
   FreeLibrary(hKbdLibrary);
 
-	return result;
+	return success;
 }
 
 HMODULE LoadKbdLibrary(const char* keyboardLayoutName) {

--- a/windows/src/engine/keyman32/tests/RightAltEmulationCheck.tests.cpp
+++ b/windows/src/engine/keyman32/tests/RightAltEmulationCheck.tests.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-extern BOOL ReadAltGrFlagFromKbdDll(const char *keyboardLayoutName);
+extern BOOL ReadAltGrFlagFromKbdDll(const char *keyboardLayoutName, BOOL& result);
 
 
 TEST(RightAltEmulationCheck, ReadAltGrFlagFromKbdDll) {
@@ -9,12 +9,23 @@ TEST(RightAltEmulationCheck, ReadAltGrFlagFromKbdDll) {
   // a known keyboard layout
 
   // These keyboards do not use AltGr
+  BOOL result = FALSE;
 
-  EXPECT_EQ(ReadAltGrFlagFromKbdDll("00000409"), FALSE); // kbdus.dll - English (US)
-  EXPECT_EQ(ReadAltGrFlagFromKbdDll("00000401"), FALSE); // kbda1.dll - Arabic 101
+  // kbdus.dll - English (US)
+  EXPECT_EQ(ReadAltGrFlagFromKbdDll("00000409", result), TRUE);
+  EXPECT_EQ(result, FALSE);
+
+  // kbda1.dll - Thai Kedmanee
+  EXPECT_EQ(ReadAltGrFlagFromKbdDll("0000041e", result), TRUE);
+  EXPECT_EQ(result, FALSE);
 
   // These keyboards use AltGr
 
-  EXPECT_EQ(ReadAltGrFlagFromKbdDll("0000040C"), TRUE); // kbdfr.dll - French AZERTY (Legacy)
-  EXPECT_EQ(ReadAltGrFlagFromKbdDll("00000405"), TRUE); // kbdcz.dll - Czech
+  // kbdfr.dll - French AZERTY (Legacy)
+  EXPECT_EQ(ReadAltGrFlagFromKbdDll("0000040C", result), TRUE);
+  EXPECT_EQ(result, TRUE);
+
+  // kbdcz.dll - Czech
+  EXPECT_EQ(ReadAltGrFlagFromKbdDll("00000405", result), TRUE);
+  EXPECT_EQ(result, TRUE);
 }


### PR DESCRIPTION
Cherry-pick-of: #15346
Fixes: #15345
Test-bot: skip