### PR TITLE
chore(windows): correct kbda1 to kbdth0 in comment in unit test

### DIFF
--- a/windows/src/engine/keyman32/tests/RightAltEmulationCheck.tests.cpp
+++ b/windows/src/engine/keyman32/tests/RightAltEmulationCheck.tests.cpp
@@ -15,7 +15,7 @@ TEST(RightAltEmulationCheck, ReadAltGrFlagFromKbdDll) {
   EXPECT_EQ(ReadAltGrFlagFromKbdDll("00000409", result), TRUE);
   EXPECT_EQ(result, FALSE);
 
-  // kbda1.dll - Thai Kedmanee
+  // kbdth0.dll - Thai Kedmanee
   EXPECT_EQ(ReadAltGrFlagFromKbdDll("0000041e", result), TRUE);
   EXPECT_EQ(result, FALSE);
 


### PR DESCRIPTION
Fixes: #15345
Test-bot: skip
Build-bot: skip