### PR TITLE
fix(linux): fix persisting options

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -697,13 +697,17 @@ static void
 process_persist_action(IBusEngine *engine, km_core_option_item *persist_options) {
   g_assert(persist_options != NULL);
 
+  g_debug("%s: processing persist options", __FUNCTION__);
+
   IBusKeymanEngine *keyman = (IBusKeymanEngine *)engine;
   for (km_core_option_item *option = persist_options; !is_core_options_end(option); option++) {
     // Put the keyboard option into DConf
     g_assert(option->key != NULL && option->value != NULL);
-    g_message("%s: Saving keyboard option to DConf", __FUNCTION__);
+    g_autofree gchar* key   = g_utf16_to_utf8((gunichar2*)option->key, -1, NULL, NULL, NULL);
+    g_autofree gchar* value = g_utf16_to_utf8((gunichar2*)option->value, -1, NULL, NULL, NULL);
+    g_debug("%s: Saving keyboard option to DConf: %s/%s, %s=%s", __FUNCTION__, keyman->kb_name, keyman->kb_name, key, value);
     // Load the current keyboard options from DConf
-    keyman_put_keyboard_options_todconf(keyman->kb_name, keyman->kb_name, (gchar *)option->key, (gchar *)option->value);
+    keyman_put_keyboard_options_todconf(keyman->kb_name, keyman->kb_name, key, value);
   }
 }
 

--- a/linux/ibus-keyman/src/keymanutil.c
+++ b/linux/ibus-keyman/src/keymanutil.c
@@ -447,20 +447,19 @@ keyman_get_keyboard_options_fromdconf(
   const gchar *package_id,
   const gchar *keyboard_id
 ) {
-    g_message(__FUNCTION__);
+  g_debug("%s: loading keyboard options from DConf for %s/%s", __FUNCTION__, package_id, keyboard_id);
 
-    // Obtain keyboard options from DConf
-    g_autofree gchar *path = g_strdup_printf("%s%s/%s/", KEYMAN_DCONF_OPTIONS_PATH, package_id, keyboard_id);
-    GSettings *child_settings = g_settings_new_with_path(KEYMAN_DCONF_OPTIONS_CHILD_NAME, path);
-    gchar **options = NULL;
-    if (child_settings != NULL)
-    {
-        options = g_settings_get_strv(child_settings, KEYMAN_DCONF_OPTIONS_KEY);
-    }
+  // Obtain keyboard options from DConf
+  g_autofree gchar* path    = g_strdup_printf("%s%s/%s/", KEYMAN_DCONF_OPTIONS_PATH, package_id, keyboard_id);
+  GSettings* child_settings = g_settings_new_with_path(KEYMAN_DCONF_OPTIONS_CHILD_NAME, path);
+  gchar** options           = NULL;
+  if (child_settings != NULL) {
+    options = g_settings_get_strv(child_settings, KEYMAN_DCONF_OPTIONS_KEY);
+  }
 
-    g_object_unref(G_OBJECT(child_settings));
+  g_object_unref(G_OBJECT(child_settings));
 
-    return options;
+  return options;
 }
 
 /**
@@ -525,7 +524,8 @@ keyman_put_keyboard_options_todconf(
     const gchar *option_key,
     const gchar *option_value
 ) {
-  g_message(__FUNCTION__);
+  g_message("%s: saving keyboard option to DConf for %s/%s: %s=%s",
+    __FUNCTION__, package_id, keyboard_id, option_key, option_value);
   if (package_id == NULL || keyboard_id == NULL || option_key == NULL || option_value == NULL) {
     return;
   }
@@ -562,7 +562,7 @@ keyman_put_keyboard_options_todconf(
   g_autofree gchar *path              = g_strdup_printf("%s%s/%s/", KEYMAN_DCONF_OPTIONS_PATH, package_id, keyboard_id);
   g_autoptr(GSettings) child_settings = g_settings_new_with_path(KEYMAN_DCONF_OPTIONS_CHILD_NAME, path);
   if (child_settings != NULL) {
-    g_message("writing keyboard options to DConf");
+    g_debug("%s: writing keyboard options to DConf to %s", __FUNCTION__, path);
     g_settings_set_strv(child_settings, KEYMAN_DCONF_OPTIONS_KEY, (const gchar *const *)options);
   }
 


### PR DESCRIPTION
This change adds the verification of the options to the baseline tests and fixes persisting the options. Previously we treated the UTF-16 option key and value as UTF-8 so that only the first character got persisted.

Test-bot: skip