### PR TITLE
fix(developer): clear message when selecting custom layer name in touch layout editor

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/layer-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/layer-controls.js
@@ -4,7 +4,7 @@ $(function() {
     var layerName = $(this).val();
     $('#addLayerList').val(layerName);
     if($('#addLayerList')[0].selectedIndex < 0) {
-      $('#addLayerList').val('(custom)');
+      $('#addLayerList').val('');
       $('#addLayerNote').text('');
     } else {
       $('#addLayerNote').text(layerName+' is a recognised modifier-aware layer name.');
@@ -13,7 +13,7 @@ $(function() {
 
   $('#addLayerList').change(function() {
     var v = $(this).val();
-    if(v == '(custom)') {
+    if(v == '') {
       $('#addLayerName').val('');
       $('#addLayerNote').text('');
     } else {


### PR DESCRIPTION
Note: the value for `(custom)` in the layer list is the empty string `''`, so this patch just corrects this bug.

Fixes: #15216
Test-bot: skip
Build-bot: skip