### PR TITLE
fix(developer): prevent duplicate layer name in Layer Properties dialog

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/layer-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/layer-controls.js
@@ -51,6 +51,12 @@ $(function() {
       alert('Layer name must contain only alphanumerics, underscore and hyphen.');
       return false;
     }
+    for(var i = 0; i < KVKL[builder.lastPlatform].layer.length; i++) {
+      if(i != builder.lastLayerIndex && KVKL[builder.lastPlatform].layer[i].id == newLayerName) {
+        alert('Layer name must not already be in use for the current platform.');
+        return false;
+      }
+    }
 
     builder.saveUndo();
     builder.generate();


### PR DESCRIPTION
Matches the test in New Layer dialog.

Fixes: #15188
Test-bot: skip
Build-bot: skip