### PR TITLE
maint(common): Fix crowdin sync version to v2.7.0

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: crowdin action
-      uses: crowdin/github-action@2.7.0
+      uses: crowdin/github-action@v2.7.0
       with:
         upload_sources: true
 


### PR DESCRIPTION
I just realized the GHA to upload Crowdin strings has been broken a long while (Android strings in Crowdin last got updated Mar 2, 2025)
https://github.com/keymanapp/keyman/actions/workflows/crowdin.yml

with the error
```
Unable to resolve action `crowdin/github-action@2.7.0`, unable to find version `2.7.0`
```

Last successful run 
https://github.com/keymanapp/keyman/actions/runs/14701685389

Started failing
https://github.com/keymanapp/keyman/actions/runs/14724673151

I believe we want [v2.7.0](https://github.com/crowdin/github-action/releases/tag/v2.7.0)

I won't try to update to v2.13.0 at this point

Test-bot: skip

