### PR TITLE
refactor(web): remove defaults in keyboard-storage 🎼

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -247,7 +247,7 @@ function deregisterModel(modelID) {
 }
 
 function enableSuggestions(model, suggestionType) {
-  // Set the options first so that KMW's ModelManager can properly handle model enablement states
+  // Set the options first so that KMW's ModelCache can properly handle model enablement states
   // the moment we actually register the new model.
   // Use console_debug
   console_debug('enableSuggestions(model, maySuggest='+suggestionType+')');

--- a/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
+++ b/ios/engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/ios-host.js
@@ -327,7 +327,7 @@ function toHex(theString) {
 }
 
 function enableSuggestions(model, mayPredict, mayCorrect) {
-    // Set the options first so that KMW's ModelManager can properly handle model enablement states
+    // Set the options first so that KMW's ModelCache can properly handle model enablement states
     // the moment we actually register the new model.
     keyman.core.languageProcessor.mayPredict = mayPredict;
     keyman.core.languageProcessor.mayCorrect = mayCorrect;

--- a/web/src/engine/src/keyboard-storage/cloud/index.ts
+++ b/web/src/engine/src/keyboard-storage/cloud/index.ts
@@ -1,2 +1,2 @@
-export { CloudQueryResult, default as QueryEngine } from './queryEngine.js';
-export { default as RequesterInterface } from './requesterInterface.js';
+export { CloudQueryResult, CloudQueryEngine as QueryEngine } from './queryEngine.js';
+export { CloudRequesterInterface as RequesterInterface } from './requesterInterface.js';

--- a/web/src/engine/src/keyboard-storage/cloud/queryEngine.ts
+++ b/web/src/engine/src/keyboard-storage/cloud/queryEngine.ts
@@ -2,9 +2,9 @@ import { EventEmitter } from 'eventemitter3';
 
 import { PathConfiguration } from 'keyman/engine/interfaces';
 
-import { default as KeyboardStub, ErrorStub, KeyboardAPISpec } from '../keyboardStub.js';
+import { KeyboardStub, ErrorStub, KeyboardAPISpec } from '../keyboardStub.js';
 import { LanguageAPIPropertySpec, ManagedPromise, Version } from 'keyman/engine/keyboard';
-import CloudRequesterInterface from './requesterInterface.js';
+import { CloudRequesterInterface } from './requesterInterface.js';
 
 // For when the API call straight-up times out.
 export const CLOUD_TIMEOUT_ERR = "The Cloud API request timed out.";
@@ -56,7 +56,7 @@ interface EventMap {
   'unboundregister': (registration: ReturnType<CloudQueryEngine['_registerCore']>) => void
 }
 
-export default class CloudQueryEngine extends EventEmitter<EventMap> {
+export class CloudQueryEngine extends EventEmitter<EventMap> {
   private cloudResolutionPromises: Map<number, ManagedPromise<KeyboardStub[] | LanguageAPIPropertySpec[]>> = new Map();
 
   private _languageListPromise: ManagedPromise<LanguageAPIPropertySpec[]>;

--- a/web/src/engine/src/keyboard-storage/cloud/requesterInterface.ts
+++ b/web/src/engine/src/keyboard-storage/cloud/requesterInterface.ts
@@ -1,6 +1,6 @@
 import { ManagedPromise } from 'keyman/engine/keyboard';
 
-export default interface CloudRequesterInterface {
+export interface CloudRequesterInterface {
   request<T>(query: string): {
     promise: ManagedPromise<T>,
     queryId: number

--- a/web/src/engine/src/keyboard-storage/domCloudRequester.ts
+++ b/web/src/engine/src/keyboard-storage/domCloudRequester.ts
@@ -1,8 +1,8 @@
 import { ManagedPromise } from 'keyman/engine/keyboard';
-import CloudRequesterInterface from './cloud/requesterInterface.js';
+import { CloudRequesterInterface } from './cloud/requesterInterface.js';
 import { CLOUD_MALFORMED_OBJECT_ERR, CLOUD_TIMEOUT_ERR, CLOUD_STUB_REGISTRATION_ERR } from './cloud/queryEngine.js';
 
-export default class DOMCloudRequester implements CloudRequesterInterface {
+export class DOMCloudRequester implements CloudRequesterInterface {
   private readonly fileLocal: boolean;
 
   constructor(fileLocal: boolean = false) {

--- a/web/src/engine/src/keyboard-storage/index.ts
+++ b/web/src/engine/src/keyboard-storage/index.ts
@@ -2,15 +2,15 @@
 export {
   ErrorStub,
   type KeyboardAPISpec,
-  default as KeyboardStub,
+  KeyboardStub,
   mergeAndResolveStubPromises,
   RawKeyboardStub,
   REGIONS,
   REGION_CODES
 } from './keyboardStub.js';
-export { default as StubAndKeyboardCache, toPrefixedKeyboardId, toUnprefixedKeyboardId } from './stubAndKeyboardCache.js';
-export { CloudQueryResult, default as CloudQueryEngine } from './cloud/queryEngine.js';
-export { default as CloudRequesterInterface } from './cloud/requesterInterface.js';
-export { default as KeyboardRequisitioner } from './keyboardRequisitioner.js';
-export { default as ModelCache } from './modelCache.js';
-export { default as DOMCloudRequester } from './domCloudRequester.js';
+export { StubAndKeyboardCache, toPrefixedKeyboardId, toUnprefixedKeyboardId } from './stubAndKeyboardCache.js';
+export { CloudQueryResult, CloudQueryEngine } from './cloud/queryEngine.js';
+export { CloudRequesterInterface } from './cloud/requesterInterface.js';
+export { KeyboardRequisitioner } from './keyboardRequisitioner.js';
+export { ModelCache } from './modelCache.js';
+export { DOMCloudRequester } from './domCloudRequester.js';

--- a/web/src/engine/src/keyboard-storage/keyboardRequisitioner.ts
+++ b/web/src/engine/src/keyboard-storage/keyboardRequisitioner.ts
@@ -17,7 +17,7 @@ import {
   mergeAndResolveStubPromises,
   toUnprefixedKeyboardId as unprefixed
  } from "./index.js";
-import { default as CloudRequesterInterface } from "./cloud/requesterInterface.js";
+import { CloudRequesterInterface } from "./cloud/requesterInterface.js";
 import { rejectErrorStubs } from "./keyboardStub.js";
 
 class CloudRequestEntry {
@@ -89,7 +89,7 @@ function isUniqueRequest(cache: StubAndKeyboardCache, cloudList: {id: string, la
 };
 
 // TODO:  Move to the keyboard-cache child project - we can test it headlessly there!
-export default class KeyboardRequisitioner {
+export class KeyboardRequisitioner {
   readonly cache: StubAndKeyboardCache;
   readonly cloudQueryEngine: CloudQueryEngine;
   readonly pathConfig: PathConfiguration;

--- a/web/src/engine/src/keyboard-storage/keyboardStub.ts
+++ b/web/src/engine/src/keyboard-storage/keyboardStub.ts
@@ -48,7 +48,7 @@ function configureFilePathing(path: string, configurationBasePath: string) {
   }
 }
 
-export default class KeyboardStub extends KeyboardProperties {
+export class KeyboardStub extends KeyboardProperties {
   KR: string;
   KRC: string;
   KF: string;

--- a/web/src/engine/src/keyboard-storage/modelCache.ts
+++ b/web/src/engine/src/keyboard-storage/modelCache.ts
@@ -1,6 +1,6 @@
 import { ModelSpec } from 'keyman/engine/interfaces';
 
-export default class ModelManager {
+export class ModelCache {
   // Tracks registered models by ID.
   private registeredModels: {[id: string]: ModelSpec} = {};
 

--- a/web/src/engine/src/main/headless/languageProcessor.ts
+++ b/web/src/engine/src/main/headless/languageProcessor.ts
@@ -360,7 +360,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
   /**
    * Retrieves the context and output state of KMW immediately before the prediction with
    * token `id` was generated.  Must correspond to a 'recent' one, as only so many are stored
-   * in `ModelManager`'s history buffer.
+   * in `ModelCache`'s history buffer.
    * @param id A unique identifier corresponding to a recent `Transcription`.
    * @returns The matching `Transcription`, or `null` none is found.
    */

--- a/web/src/test/auto/resources/loader/nodeCloudRequester.ts
+++ b/web/src/test/auto/resources/loader/nodeCloudRequester.ts
@@ -1,10 +1,10 @@
 import { ManagedPromise } from 'keyman/engine/keyboard';
-import CloudRequesterInterface from '../../../../engine/src/keyboard-storage/cloud/requesterInterface.js';
+import { CloudRequesterInterface } from '../../../../engine/src/keyboard-storage/cloud/requesterInterface.js';
 import {
   CLOUD_TIMEOUT_ERR,
   CLOUD_STUB_REGISTRATION_ERR,
   CloudQueryResult,
-  default as CloudQueryEngine
+  CloudQueryEngine
 } from '../../../../engine/src/keyboard-storage/cloud/queryEngine.js';
 
 import fs from 'node:fs';


### PR DESCRIPTION
- Also renamed `prefixed` and `withoutPrefix` functions to use the name   that was aliased on most cases: `toPrefixedKeyboardId` and   `toUnprefixedKeyboardId`. 
- Renamed `ModelManager` class to `ModelCache` which was the name used   everywhere except in comments.

Part-of: #15292
Test-bot: skip