### PR TITLE
maint(core): remove leading slash on gh api call parameter

### DIFF
--- a/.github/workflows/core-arm64-windows-test.yml
+++ b/.github/workflows/core-arm64-windows-test.yml
@@ -52,7 +52,7 @@ jobs:
         gh api \
           --method POST \
           -H "Accept: application/vnd.github+json" \
-          /repos/$GITHUB_REPOSITORY/statuses/${{ github.event.client_payload.buildSha }} \
+          repos/$GITHUB_REPOSITORY/statuses/${{ github.event.client_payload.buildSha }} \
           -f state='pending' \
           -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
           -f description='Keyman Core - ARM64 test started' \
@@ -156,7 +156,7 @@ jobs:
         gh api \
           --method POST \
           -H "Accept: application/vnd.github+json" \
-          /repos/$GITHUB_REPOSITORY/statuses/${{ github.event.client_payload.buildSha }} \
+          repos/$GITHUB_REPOSITORY/statuses/${{ github.event.client_payload.buildSha }} \
           -f state="$RESULT" \
           -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
           -f description="$MSG" \


### PR DESCRIPTION
The leading slash was causing cygpath conversion to prepend and convert the path into a DOS-style path.

See for example: https://github.com/keymanapp/keyman/actions/runs/20420070390/job/58669903514

```
> Run gh api \
invalid API endpoint: "C:/Program Files/Git/repos/keymanapp/keyman/statuses/751fc79014683b4e0efd5dc017d0f5a2958ae964". Your shell might be rewriting URL paths as filesystem paths. To avoid this, omit the leading slash from the endpoint argument
Error: Process completed with exit code 1.
```

Test-bot: skip
Build-bot: skip