### PR TITLE
chore(web): escape some additional values in TC service messages

### DIFF
--- a/common/test/resources/test-runner-TC-reporter.mjs
+++ b/common/test/resources/test-runner-TC-reporter.mjs
@@ -26,7 +26,10 @@ export default function teamcityReporter({ name="Web Test Runner JavaScript test
       .replace(/\|/g, '||')
       .replace(/\[/g, '|[')
       .replace(/\]/g, '|]')
-      .replace(/\'/g, '|\'');
+      .replace(/\'/g, '|\'')
+      .replace(/\n/g, '|n')
+      .replace(/\r/g, '|r')
+      .replace(/[\u0080-\uFFFF]/g, c => `|0x${c.charCodeAt(0).toString(16).padStart(4, '0')}`);
   }
 
   const e = tcReportEscaping;


### PR DESCRIPTION
See: https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values.

Follow-up-of: #15374
Build-bot: skip:all build:web
Test-bot: skip