### PR TITLE
maint(common): Downgrade Crowdin GHA to v1.20.4

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: crowdin action
-      uses: crowdin/github-action@v2.7.0
+      uses: crowdin/github-action@v1.20.4
       with:
         upload_sources: true
 


### PR DESCRIPTION
(updated to include current error)

I think this addresses #15392 (follows #15373 which didn't work)

See #12116, where the Crowdin CLI version 4.0+ is giving language mapping errors.
Log from a recent [failing action](https://github.com/keymanapp/keyman/actions/runs/20740142594):

```
STARTING CROWDIN ACTION
UPLOAD SOURCES
❌ Configuration file is invalid. Check the following parameters in your configuration file:
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
	- The mapping format is the following: crowdin_language_code: code_you_use. Check the full list of Crowdin language codes that can be used for mapping: https://developer.crowdin.com/language-codes.
```

Very unfortunate Crowdin doesn't tell us what langauge code it's failing on - even when I run the CLI in verbose mode. 😞 

When #12116 gets resolved where we can use Crowdin CLI 4.0+, then we can update the GHA version.

## Change

This workaround PR reverts the GitHub action to v1.20.4 which uses CLI 3.19.4.

Test-bot: skip
Build-bot: skip
