### PR TITLE
refactor(web): refactor local input cost heuristic 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-node.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-node.ts
@@ -65,6 +65,16 @@ export interface SearchQuotientNode {
   readonly currentCost: number;
 
   /**
+   * Provides a heuristic for the base cost at this path's depth if the best
+   * individual input were taken here, regardless of whether or not that's
+   * possible.
+   *
+   * This cost is based on the negative log-likelihood of the probability and
+   * includes the cost from the lowest possible parent nodes visited.
+   */
+  readonly lowestPossibleSingleCost: number;
+
+  /**
    * Returns the set of previously-processed results under this batcher's domain.
    */
   readonly previousResults: SearchResult[];


### PR DESCRIPTION
These changes were previously part of #14987 and have been extracted for ease of review.  This technically reworks part of the changes made in #14916, which was implemented before this version of the changes would be feasible to support.

Build-bot: skip build:web
Test-bot: skip