### PR TITLE
refactor(web): rename field `core` to `inputProcessor` 🎼

### DIFF
--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -69,10 +69,10 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
     });
 
     this._util = new UtilApiEndpoint(config);
-    this.beepHandler = new BeepHandler(this.core.keyboardInterface);
-    this.core.keyboardProcessor.beepHandler = () => this.beepHandler.beep(this.contextManager.activeTextStore);
+    this.beepHandler = new BeepHandler(this.inputProcessor.keyboardInterface);
+    this.inputProcessor.keyboardProcessor.beepHandler = () => this.beepHandler.beep(this.contextManager.activeTextStore);
 
-    this.hardKeyboard = new HardwareEventKeyboard(config.hardDevice, this.core.keyboardProcessor, this.contextManager);
+    this.hardKeyboard = new HardwareEventKeyboard(config.hardDevice, this.inputProcessor.keyboardProcessor, this.contextManager);
 
     // Scrolls the document-body to ensure that a focused element remains visible after the OSK appears.
     this.contextManager.on('textstorechange', (textStore) => {
@@ -444,7 +444,7 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
         kbd = new JSKeyboard(k0);
       }
     } else {
-      kbd = this.core.activeKeyboard;
+      kbd = this.inputProcessor.activeKeyboard;
     }
 
     // We only support isCJK on legacy .js keyboards; see #7928
@@ -695,7 +695,7 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
       PKbd = this.keyboardRequisitioner.cache.getKeyboard(PInternalName);
     }
 
-    PKbd = PKbd || this.core.activeKeyboard;
+    PKbd = PKbd || this.inputProcessor.activeKeyboard;
     if (PKbd instanceof KMXKeyboard) {
       // TODO-web-core: implement for KMX keyboards (epic/embed-osk-in-kmx)
       return null;
@@ -733,7 +733,7 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
     this.pageIntegration.shutdown();
     this.contextManager.shutdown();
     this.osk?.shutdown();
-    this.core.languageProcessor.shutdown();
+    this.inputProcessor.languageProcessor.shutdown();
     this.hardKeyboard.shutdown();
     this.util.shutdown(); // For tracked dom events, stylesheets.
 

--- a/web/src/app/webview/src/keymanEngine.ts
+++ b/web/src/app/webview/src/keymanEngine.ts
@@ -64,7 +64,7 @@ export class KeymanEngine extends KeymanEngineBase<WebviewConfiguration, Context
     }
 
     if(this.beepKeyboard) {
-      this.core.keyboardProcessor.beepHandler = this.beepKeyboard;
+      this.inputProcessor.keyboardProcessor.beepHandler = this.beepKeyboard;
     }
 
     this.contextManager.on('keyboardchange', (kbd) => {

--- a/web/src/tools/testing/bulk_rendering/renderer_core.ts
+++ b/web/src/tools/testing/bulk_rendering/renderer_core.ts
@@ -114,7 +114,7 @@ export class BatchRenderer {
       eleDescription.appendChild(document.createTextNode('Name: ' + kbd.Name));
       eleDescription.appendChild(document.createElement('br'));
 
-      const keyboard = keyman.core.activeKeyboard;
+      const keyboard = keyman.inputProcessor.activeKeyboard;
       if (keyboard instanceof JSKeyboard) {
         // Some keyboards, such as sil_euro_latin and sil_ipa, no longer specify this property.
         if (keyboard['_legacyLayoutSpec']) {
@@ -173,12 +173,12 @@ export class BatchRenderer {
 
       // Uses 'private' APIs that may be subject to change in the future.  Keep it updated!
       let layers: string[];
-      if(!isMobile && keyman.core.activeKeyboard instanceof JSKeyboard) {
+      if(!isMobile && keyman.inputProcessor.activeKeyboard instanceof JSKeyboard) {
         // The desktop OSK will be overpopulated, with a number of blank layers to display in most cases.
         // We instead rely upon the KLS definition to ensure we keep the renders sparse.
         //
         // _legacyLayoutSpec is technically private, but it's what we've been using, so... yeah.
-        layers = Object.keys(keyman.core.activeKeyboard['_legacyLayoutSpec']?.KLS);
+        layers = Object.keys(keyman.inputProcessor.activeKeyboard['_legacyLayoutSpec']?.KLS);
       }
 
       // If mobile, or if the desktop definition lacks a `_legacyLayoutSpec` entry.
@@ -189,7 +189,7 @@ export class BatchRenderer {
         return new Promise(function(resolve) {
           // (Private API) Directly sets the keyboard layer within KMW, then uses .show to force-display it.
           if(keyman.osk.vkbd) {
-            keyman.core.keyboardProcessor.layerId = layers[i];
+            keyman.inputProcessor.keyboardProcessor.layerId = layers[i];
           } else {
             // Again, occurs for keyboards with desktop help-text.
             console.error(`Error - keyman.osk.vkbd is undefined for ${kbd.InternalName}!`);


### PR DESCRIPTION
The field of `KeymanEngineBase` that holds the `InputProcessor` used to be called `core`. This can be easily confused with Keyman Core, especially now that we're implementing web-core. This change therefore renames the field to `inputProcessor`.

Test-bot: skip