### PR TITLE
maint(linux): remove EOL Ubuntu 25.04 Plucky

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -136,7 +136,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [jammy, noble, plucky, questing]
+        dist: [jammy, noble, questing]
 
     steps:
     - name: Checkout

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -33,7 +33,7 @@ else
 fi
 echo "ppa: ${ppa}"
 
-distributions="${DIST:-jammy noble plucky questing resolute}"
+distributions="${DIST:-jammy noble questing resolute}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
Support for Ubuntu 25.04 Plucky ends on 15th January 2026 after which it is no longer possible to upload and build on Launchpad. This change removes Plucky.

Fixes: #14955
Test-bot: skip