### PR TITLE
chore(web): fix e2e tests 🍪 🎼

### DIFF
--- a/web/src/test/auto/e2e/baseline/baseline.tests.ts
+++ b/web/src/test/auto/e2e/baseline/baseline.tests.ts
@@ -3,7 +3,7 @@
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { expect, test, /*expect, Page, Locator */} from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { KmxTestSource } from './kmxTestSource.js';
 import { pressKeys } from './keyHandling';
 

--- a/web/src/test/auto/e2e/baseline/keyHandling.ts
+++ b/web/src/test/auto/e2e/baseline/keyHandling.ts
@@ -2,7 +2,7 @@
  * Keyman is copyright (C) SIL Global. MIT License.
  */
 
-import { Page } from '@playwright/test';
+import { type Page } from '@playwright/test';
 
 function getKeycodeFromVk(vk: string): string {
   const virtualKeyToKeyCodeMap = new Map([

--- a/web/src/test/auto/e2e/baseline/kmxTestSource.ts
+++ b/web/src/test/auto/e2e/baseline/kmxTestSource.ts
@@ -2,7 +2,6 @@
  * Keyman is copyright (C) SIL Global. MIT License.
  */
 import * as fs from 'fs';
-import * as path from 'path';
 
 // Helper types
 type KmxOptionType = 'input' | 'output' | 'saved';

--- a/web/src/test/auto/e2e/keyboard.tests.ts
+++ b/web/src/test/auto/e2e/keyboard.tests.ts
@@ -1,7 +1,7 @@
 /*
  * Keyman is copyright (C) SIL Global. MIT License.
  */
-import { test, expect, Page, Locator } from '@playwright/test';
+import { test, expect, type Page, type Locator } from '@playwright/test';
 
 test.describe('KMX keyboards', function () {
   let textarea: Locator;


### PR DESCRIPTION
The Playwright tests occasionally failed complaining about `Page` and `Locator` not being defined. The solution is to import them as types.

The test failures probably happened when running the tests with a node version > 20.16.0.

Test-bot: skip