### PR TITLE
fix(linux): issues when running ./build.sh test:linux

### DIFF
--- a/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
+++ b/linux/ibus-keyman/tests/scripts/test-helper.inc.sh
@@ -395,7 +395,7 @@ function cleanup() {
     # So we kill the remaining lonely ibus-daemon and start ibus again.
     if [[ ! "$(ibus engine &> /dev/null)" ]]; then
       echo "# Stopping and starting ibus-daemon"
-      ibus exit &> /dev/null || true
+      ibus exit &> /dev/null || kill -9 $(pgrep -u "${USER:-$(whoami)}" ibus-daemon) &> /dev/null || true
       ibus start -d
     fi
   fi


### PR DESCRIPTION
Fixes some issues, when running "keyman/keyman/build.sh test:linux" locally.

Test-bot: skip