### PR TITLE
change(web): determine all module-paths leading to a SearchQuotientNode 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -498,7 +498,7 @@ export class ContextTokenization {
    * the transition.
    * @param bestProbFromSet The probability of the single most likely input
    * transform in the overall transformDistribution associated with the
-   * keystroke triggering theh transition.  It need not be represented by the
+   * keystroke triggering the transition.  It need not be represented by the
    * TransitionEdge to be built.
    * @returns
    */

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
@@ -115,8 +115,6 @@ export class ContextTransition {
    * by a keystroke.
    * @param state  The context state to record as the result of the transition
    * @param inputDistribution Fat-finger data corresponding to the triggering keystroke
-   * @param preservationTransform Portions of the most likely input that do not contribute to the final token
-   * in the final context's tokenization.
    */
   finalize(state: ContextState, inputDistribution: Distribution<Transform>) {
     this._final = state;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/distance-modeler.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/distance-modeler.ts
@@ -657,12 +657,14 @@ export async function *getBestMatches(searchModules: SearchQuotientNode[], timer
   do {
     const entry: SearchResult = timer.time(() => {
       if((priorResultsQueue.peek()?.totalCost ?? Number.POSITIVE_INFINITY) < spaceQueue.peek().currentCost) {
-        return priorResultsQueue.dequeue();
+        const result = priorResultsQueue.dequeue();
+        currentReturns[result.node.resultKey] = result.node;
+        return result;
       }
 
-      let bestQueue = spaceQueue.dequeue();
-      let newResult: PathResult = bestQueue.handleNextNode();
-      spaceQueue.enqueue(bestQueue);
+      let lowestCostSource = spaceQueue.dequeue();
+      let newResult: PathResult = lowestCostSource.handleNextNode();
+      spaceQueue.enqueue(lowestCostSource);
 
       if(newResult.type == 'none') {
         return null;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-node.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-node.ts
@@ -52,7 +52,7 @@ export interface InputSegment {
   /**
    * The transform / transition ID of the corresponding input event.
    */
-  transitionId: number,
+  transitionId: number | undefined,
 
   /**
    * Marks the initial index (inclusive) within the insert strings for the

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-subsets.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-subsets.ts
@@ -30,7 +30,7 @@ export interface TransitionEdge {
   /**
    * A set of incoming keystrokes with compatible effects when applied.
    *
-   * If passed to the`subsetByInterval`, the transforms should result in a single subset.
+   * If passed to the `subsetByInterval`, the transforms should result in a single subset.
    */
   inputs: Distribution<Map<number, Transform>>
 


### PR DESCRIPTION
A .split operation on a token requires splitting these paths appropriately.  Exposing this property, for use only in unit-testing, will help to validate that split operations are performed properly.

This PR will also start the proper specification of a `unitTestEndpoints` object for engine/predictive-text/worker-thread.

Build-bot: skip build:web
Test-bot: skip