### PR TITLE
change(web): remove .sourceText property from cached context tokens 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
@@ -185,21 +185,6 @@ export class ContextToken {
   }
 
   /**
-   * Gets a simple, compact string-based representation of `inputRange`.
-   *
-   * This should only ever be used for debugging purposes.
-   */
-  get sourceText(): string {
-    const composite = this._inputRange.reduce((accum, current) => {
-      const alteredTransform = {...current.trueTransform};
-      alteredTransform.insert = alteredTransform.insert.slice(current.inputStartIndex);
-      return buildMergedTransform(accum, current.trueTransform)
-    }, { insert: '', deleteLeft: 0 });
-    const prefix = '\u{2421}'.repeat(composite.deleteLeft);
-    return prefix + composite.insert;
-  }
-
-  /**
    * Generates text corresponding to the net effects of the most likely inputs
    * received that can correspond to the current instance.
    */

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -159,16 +159,6 @@ export class ContextTokenization {
   }
 
   /**
-   * Returns plain-text strings representing the most probable representation for all
-   * tokens represented by this tokenization instance.
-   *
-   * Intended for debugging use only.
-   */
-  get sourceText() {
-    return this.tokens.map(token => token.sourceText);
-  }
-
-  /**
    * Returns a plain-text string representing the most probable representation for all
    * tokens represented by this tokenization instance.
    */

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-token.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-token.tests.ts
@@ -283,20 +283,20 @@ describe('ContextToken', function() {
       // Setup phase
       const keystrokeDistributions: Distribution<Transform>[] = [
         [
-          { sample: { insert: 'c', deleteLeft: 0 }, p: 0.75 },
-          { sample: { insert: 't', deleteLeft: 0 }, p: 0.25 }
+          { sample: { insert: 'c', deleteLeft: 0, id: 11 }, p: 0.75 },
+          { sample: { insert: 't', deleteLeft: 0, id: 11 }, p: 0.25 }
         ],
         [
-          { sample: { insert: 'a', deleteLeft: 0 }, p: 0.75 },
-          { sample: { insert: 'o', deleteLeft: 0 }, p: 0.25 }
+          { sample: { insert: 'a', deleteLeft: 0, id: 12 }, p: 0.75 },
+          { sample: { insert: 'o', deleteLeft: 0, id: 12 }, p: 0.25 }
         ],
         [
-          { sample: { insert: 'n', deleteLeft: 0 }, p: 0.75 },
-          { sample: { insert: 'r', deleteLeft: 0 }, p: 0.25 }
+          { sample: { insert: 'n', deleteLeft: 0, id: 13 }, p: 0.75 },
+          { sample: { insert: 'r', deleteLeft: 0, id: 13 }, p: 0.25 }
         ],
         [
-          { sample: { insert: '\'', deleteLeft: 0 }, p: 0.75 },
-          { sample: { insert: 't', deleteLeft: 0 }, p: 0.25 }
+          { sample: { insert: '\'', deleteLeft: 0, id: 14 }, p: 0.75 },
+          { sample: { insert: 't', deleteLeft: 0, id: 14 }, p: 0.25 }
         ]
       ]
 
@@ -305,7 +305,7 @@ describe('ContextToken', function() {
         tokenToSplit.addInput({trueTransform: keystrokeDistributions[i][0].sample, inputStartIndex: 0, bestProbFromSet: .75}, keystrokeDistributions[i]);
       };
 
-      assert.equal(tokenToSplit.sourceText, 'can\'');
+      assert.equal(tokenToSplit.sourceRangeKey, 'T11+T12+T13+T14');
       assert.isTrue(quotientPathHasInputs(tokenToSplit.searchModule, keystrokeDistributions));
 
       // And now for the "fun" part.
@@ -331,7 +331,7 @@ describe('ContextToken', function() {
       // Setup phase
       const keystrokeDistributions: Distribution<Transform>[] = [
         [
-          { sample: { insert: 'biglargetransform', deleteLeft: 0, deleteRight: 0 }, p: 1 },
+          { sample: { insert: 'biglargetransform', deleteLeft: 0, deleteRight: 0, id: 42 }, p: 1 },
         ]
       ];
       const splitTextArray = ['big', 'large', 'transform'];
@@ -341,7 +341,7 @@ describe('ContextToken', function() {
         tokenToSplit.addInput({trueTransform: keystrokeDistributions[i][0].sample, inputStartIndex: 0, bestProbFromSet: 1}, keystrokeDistributions[i]);
       };
 
-      assert.equal(tokenToSplit.sourceText, 'biglargetransform');
+      assert.equal(tokenToSplit.sourceRangeKey, `T${keystrokeDistributions[0][0].sample.id}`);
       assert.isTrue(quotientPathHasInputs(tokenToSplit.searchModule, keystrokeDistributions));
 
       // And now for the "fun" part.
@@ -364,7 +364,8 @@ describe('ContextToken', function() {
         trueTransform: {
           insert: 'biglargetransform',
           deleteLeft: 0,
-          deleteRight: 0
+          deleteRight: 0,
+          id: keystrokeDistributions[0][0].sample.id
         },
         inputStartIndex: i,
         bestProbFromSet: 1
@@ -373,7 +374,7 @@ describe('ContextToken', function() {
       for(let i = 0; i < resultsOfSplit.length; i++) {
         assert.isTrue(quotientPathHasInputs(
           resultsOfSplit[i].searchModule, [
-          [{sample: { insert: splitTextArray[i], deleteLeft: 0, deleteRight: 0 }, p: 1}]
+          [{sample: { insert: splitTextArray[i], deleteLeft: 0, deleteRight: 0, id: keystrokeDistributions[0][0].sample.id }, p: 1}]
         ]));
       }
     });


### PR DESCRIPTION
Once we enable whitespace fat-fingering, it may be possible for the 'source text' to actually _change_ after an autocorrect yet still be correctable.  `.sourceText` does not reflect this adequately.  What _does_ remain unchanged is the `.sourceRangeKey` property and its value - those provide a better source of stability and identification.  Thus, it's better to remove `.sourceText` in favor of use of `.sourceRangeKey`, even if the latter is less immediately-clear when debugging & inspecting.

Build-bot: skip build:web
Test-bot: skip