### PR TITLE
chore(web): update TODO comments 🎼

### DIFF
--- a/web/src/engine/src/core-processor/coreKeyboardProcessor.ts
+++ b/web/src/engine/src/core-processor/coreKeyboardProcessor.ts
@@ -290,7 +290,8 @@ export class CoreKeyboardProcessor extends EventEmitter<EventMap> implements Key
 
   /**
    * Processes post-keystroke actions for the given device and text store.
-   * Handles any actions that should occur after a keystroke is processed.
+   * Handles any actions that should occur after a keystroke is processed
+   * or after applying suggestions.
    *
    * @param {DeviceSpec}  device     The device specification.
    * @param {TextStore}   textStore  The current text store context.
@@ -298,7 +299,10 @@ export class CoreKeyboardProcessor extends EventEmitter<EventMap> implements Key
    * @returns {ProcessorAction} The resulting processor action, or null if not applicable.
    */
   public processPostKeystroke(device: DeviceSpec, textStore: TextStore): ProcessorAction {
-    // TODO-web-core: Implement this method (#15286)
+    // TODO-embed-osk-in-kmx: Implement this method (#15286)
+    // This gets called after processing a keystroke to process the PostKeystroke group
+    // (irrelevant for web-core since that is handled in Core), but also after
+    // applying a suggestion, which we do need to handle.
     return null;
   }
 
@@ -343,7 +347,7 @@ export class CoreKeyboardProcessor extends EventEmitter<EventMap> implements Key
    * @returns {boolean} True if the keyboard layer changed, false otherwise.
    */
   public selectLayer(keyEvent: KeyEvent): boolean {
-    // TODO-web-core: Implement this method (#15284)
+    // TODO-embed-osk-in-kmx: Implement this method (#15284)
     return false;
   }
 

--- a/web/src/engine/src/keyboard/keyboards/kmxKeyboard.ts
+++ b/web/src/engine/src/keyboard/keyboards/kmxKeyboard.ts
@@ -34,7 +34,7 @@ export class KMXKeyboard {
         },{
           scope: KM_CORE_OPTION_SCOPE.OPT_ENVIRONMENT,
           key: KM_CORE_KMX_ENV.SIMULATEALTGR,
-          value: "0" // TODO: We won't support simulating AltGr option in v19
+          value: "0" // TODO: We won't support simulating AltGr option in v19 - see also emulatesAltGr
         }
       ]
     const result = KM_Core.instance.state_create(_keyboard, environment_opts);
@@ -55,7 +55,7 @@ export class KMXKeyboard {
   }
 
   public constructKeyEvent(key: ActiveKey | ActiveSubKey, device: DeviceSpec, stateKeys: StateKeyMap): KeyEvent {
-    // TODO-web-core: Implement this method (#15290)
+    // TODO-embed-osk-in-kmx: Implement this method (#15290)
     return null;
   }
 
@@ -86,7 +86,8 @@ export class KMXKeyboard {
   }
 
   public get isChiral(): boolean {
-    // TODO-web-core: Implement this method (#15290)
+    // TODO-embed-osk-in-kmx: Implement this method (#15290)
+    // Only relevant for OSK
     return false;
   }
 
@@ -95,7 +96,7 @@ export class KMXKeyboard {
    * @return  {boolean}
    */
   public get emulatesAltGr(): boolean {
-    // TODO-web-core: Implement this method (#15290)
+    // TODO: We won't support simulating AltGr option in v19 - see also c'tor
     return false;
   }
 
@@ -108,8 +109,8 @@ export class KMXKeyboard {
    * @param       {number}           data          1 for KeyDown or FocusReceived,
    *                                               0 for KeyUp or FocusLost
    */
-  public notify(eventCode: NotifyEventCode, textStore: TextStore, data: number): void { // I2187
-    // TODO-web-core: do we need to support this? (#15290)
+  public notify(eventCode: NotifyEventCode, textStore: TextStore, data: number): void {
+    // TODO: implement for IMX (cf #2239 and #7928)
   }
 
 }


### PR DESCRIPTION
This changes several `TODO-web-core` to `TODO-embed-osk-in-kmx` because they are related to OSK and can't be implemented/tested without having the OSK API available.

Also updated some additional comments.

Build-bot: skip
Test-bot: skip