### PR TITLE
refactor(web): remove web-utils exports from keyboard 🎼

### DIFF
--- a/web/src/app/browser/src/hardwareEventKeyboard.ts
+++ b/web/src/app/browser/src/hardwareEventKeyboard.ts
@@ -1,4 +1,5 @@
-import { Codes, DeviceSpec, KeyEvent, KeyMapping, KeyboardProcessor, Keyboard } from 'keyman/engine/keyboard';
+import { DeviceSpec } from 'keyman/common/web-utils';
+import { Codes, KeyEvent, KeyMapping, KeyboardProcessor, Keyboard } from 'keyman/engine/keyboard';
 import { ModifierKeyConstants } from '@keymanapp/common-types';
 
 import { HardKeyboardBase, processForMnemonicsAndLegacy } from 'keyman/engine/main';

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -7,7 +7,8 @@ import {
   VisualKeyboard
 } from 'keyman/engine/osk';
 import { ErrorStub, KeyboardStub, CloudQueryResult, toPrefixedKeyboardId as prefixed } from 'keyman/engine/keyboard-storage';
-import { DeviceSpec, JSKeyboard, Keyboard, KMXKeyboard } from "keyman/engine/keyboard";
+import { DeviceSpec } from 'keyman/common/web-utils';
+import { JSKeyboard, Keyboard, KMXKeyboard } from "keyman/engine/keyboard";
 import KeyboardObject = KeymanWebKeyboard.KeyboardObject;
 
 import * as views from './viewsAnchorpoint.js';

--- a/web/src/app/webview/src/keymanEngine.ts
+++ b/web/src/app/webview/src/keymanEngine.ts
@@ -1,4 +1,5 @@
-import { DeviceSpec, DefaultRules, ProcessorAction } from 'keyman/engine/keyboard';
+import { DeviceSpec } from 'keyman/common/web-utils';
+import { DefaultRules, ProcessorAction } from 'keyman/engine/keyboard';
 import { KeymanEngineBase, KeyboardInterfaceBase } from 'keyman/engine/main';
 import { AnchoredOSKView, ViewConfiguration, StaticActivator } from 'keyman/engine/osk';
 import { getAbsoluteX, getAbsoluteY } from 'keyman/engine/dom-utils';

--- a/web/src/app/webview/src/oskConfiguration.ts
+++ b/web/src/app/webview/src/oskConfiguration.ts
@@ -1,6 +1,5 @@
-import { OSKView } from "keyman/engine/osk";
-import { DeviceSpec } from "keyman/engine/keyboard";
-import { type EmbeddedGestureConfig } from "keyman/engine/osk";
+import { OSKView, type EmbeddedGestureConfig } from "keyman/engine/osk";
+import { DeviceSpec } from 'keyman/common/web-utils';
 
 import { GlobeHint } from './osk/globeHint.js';
 import { type KeymanEngine }  from "./keymanEngine.js";

--- a/web/src/app/webview/src/passthroughKeyboard.ts
+++ b/web/src/app/webview/src/passthroughKeyboard.ts
@@ -1,4 +1,5 @@
-import { DeviceSpec, Keyboard, KeyEvent, ManagedPromise } from 'keyman/engine/keyboard';
+import { DeviceSpec, ManagedPromise } from 'keyman/common/web-utils';
+import { Keyboard, KeyEvent } from 'keyman/engine/keyboard';
 
 import { HardKeyboardBase, processForMnemonicsAndLegacy } from 'keyman/engine/main';
 

--- a/web/src/engine/src/attachment/pageContextAttachment.ts
+++ b/web/src/engine/src/attachment/pageContextAttachment.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'eventemitter3';
 
-import { DeviceSpec, InternalKeyboardFont } from "keyman/engine/keyboard";
+import { DeviceSpec } from 'keyman/common/web-utils';
+import { InternalKeyboardFont } from "keyman/engine/keyboard";
 import { InputElementTextStore, nestedInstanceOf, createTextStoreForElement } from "keyman/engine/element-text-stores";
 import {
   arrayFromNodeList,

--- a/web/src/engine/src/core-processor/coreKeyboardProcessor.ts
+++ b/web/src/engine/src/core-processor/coreKeyboardProcessor.ts
@@ -6,12 +6,13 @@ import { EventEmitter } from 'eventemitter3';
 import { KM_Core, KM_CORE_STATUS, KM_CORE_CT, km_core_context, km_core_context_items } from 'keyman/engine/core-adapter';
 import {
   BeepHandler,
-  DeviceSpec, EventMap, Keyboard, KeyboardMinimalInterface, KeyboardProcessor,
+  EventMap, Keyboard, KeyboardMinimalInterface, KeyboardProcessor,
   KeyEvent, KMXKeyboard, SyntheticTextStore, MutableSystemStore, TextStore, ProcessorAction,
   StateKeyMap,
   Deadkey
 } from "keyman/engine/keyboard";
 import { KM_CORE_EVENT_FLAG } from '../core-adapter/KM_Core.js';
+import { DeviceSpec } from 'keyman/common/web-utils';
 
 export class CoreKeyboardInterface implements KeyboardMinimalInterface {
   public activeKeyboard: Keyboard;

--- a/web/src/engine/src/keyboard-storage/cloud/queryEngine.ts
+++ b/web/src/engine/src/keyboard-storage/cloud/queryEngine.ts
@@ -3,8 +3,9 @@ import { EventEmitter } from 'eventemitter3';
 import { PathConfiguration } from 'keyman/engine/interfaces';
 
 import { KeyboardStub, ErrorStub, KeyboardAPISpec } from '../keyboardStub.js';
-import { LanguageAPIPropertySpec, ManagedPromise, Version } from 'keyman/engine/keyboard';
+import { LanguageAPIPropertySpec } from 'keyman/engine/keyboard';
 import { CloudRequesterInterface } from './requesterInterface.js';
+import { ManagedPromise, Version } from 'keyman/common/web-utils';
 
 // For when the API call straight-up times out.
 export const CLOUD_TIMEOUT_ERR = "The Cloud API request timed out.";

--- a/web/src/engine/src/keyboard-storage/cloud/requesterInterface.ts
+++ b/web/src/engine/src/keyboard-storage/cloud/requesterInterface.ts
@@ -1,4 +1,4 @@
-import { ManagedPromise } from 'keyman/engine/keyboard';
+import { ManagedPromise } from 'keyman/common/web-utils';
 
 export interface CloudRequesterInterface {
   request<T>(query: string): {

--- a/web/src/engine/src/keyboard-storage/domCloudRequester.ts
+++ b/web/src/engine/src/keyboard-storage/domCloudRequester.ts
@@ -1,4 +1,4 @@
-import { ManagedPromise } from 'keyman/engine/keyboard';
+import { ManagedPromise } from 'keyman/common/web-utils';
 import { CloudRequesterInterface } from './cloud/requesterInterface.js';
 import { CLOUD_MALFORMED_OBJECT_ERR, CLOUD_TIMEOUT_ERR, CLOUD_STUB_REGISTRATION_ERR } from './cloud/queryEngine.js';
 

--- a/web/src/engine/src/keyboard/index.ts
+++ b/web/src/engine/src/keyboard/index.ts
@@ -47,12 +47,3 @@ import { DeadkeyTracker } from './deadkeys.js';
 export const unitTestEndpoints = {
   DeadkeyTracker,
 };
-
-// TODO-web-core: why do we export these here? (#15292)
-export * from "keyman/common/web-utils";
-
-// At the top level, there should be no default export.
-
-// Without the line below... TextStore would likely be aliased there, as it's
-// the last `export { default as _ }` => `export * from` pairing seen above.
-export default undefined;

--- a/web/src/engine/src/main/contextManagerBase.ts
+++ b/web/src/engine/src/main/contextManagerBase.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'eventemitter3';
-import { ManagedPromise, type Keyboard, type TextStore } from 'keyman/engine/keyboard';
+import { ManagedPromise } from 'keyman/common/web-utils';
+import { type Keyboard, type TextStore } from 'keyman/engine/keyboard';
 import { type JSKeyboardInterface } from 'keyman/engine/js-processor';
 import { StubAndKeyboardCache, type KeyboardStub } from 'keyman/engine/keyboard-storage';
 import { PredictionContext } from 'keyman/engine/interfaces';

--- a/web/src/engine/src/main/engineConfiguration.ts
+++ b/web/src/engine/src/main/engineConfiguration.ts
@@ -1,8 +1,9 @@
 import { EventEmitter } from "eventemitter3";
 
+import { DeviceSpec, ManagedPromise, physicalKeyDeviceAlias } from 'keyman/common/web-utils';
 import {
-  DeviceSpec, KeyboardProperties, ManagedPromise, TextStore,
-  ProcessorAction, physicalKeyDeviceAlias, SpacebarText
+  KeyboardProperties, TextStore,
+  ProcessorAction, SpacebarText
 } from "keyman/engine/keyboard";
 import { PathConfiguration, PathOptionDefaults, PathOptionSpec } from "keyman/engine/interfaces";
 import { DeviceDetector } from "./headless/deviceDetector.js";

--- a/web/src/engine/src/osk/banner/suggestionBanner.ts
+++ b/web/src/engine/src/osk/banner/suggestionBanner.ts
@@ -13,7 +13,8 @@ import {
 
 import { BANNER_GESTURE_SET } from './bannerGestureSet.js';
 
-import { DeviceSpec, JSKeyboard, KeyboardProperties, timedPromise } from 'keyman/engine/keyboard';
+import { DeviceSpec, timedPromise } from 'keyman/common/web-utils';
+import { JSKeyboard, KeyboardProperties } from 'keyman/engine/keyboard';
 import { Banner } from './banner.js';
 import { ParsedLengthStyle } from '../lengthStyle.js';
 import { getFontSizeStyle } from '../fontSizeUtils.js';

--- a/web/src/engine/src/osk/index.ts
+++ b/web/src/engine/src/osk/index.ts
@@ -1,4 +1,6 @@
-export { Codes, DeviceSpec, JSKeyboard, KeyboardProperties, SpacebarText } from 'keyman/engine/keyboard';
+// TODO-web-core: why do we export these types from web-utils and keyboard here?
+export { DeviceSpec } from 'keyman/common/web-utils';
+export { Codes, JSKeyboard, KeyboardProperties, SpacebarText } from 'keyman/engine/keyboard';
 
 export { OSKView, JSKeyboardData } from './views/oskView.js';
 export { FloatingOSKView, FloatingOSKViewConfiguration } from './views/floatingOskView.js';

--- a/web/src/engine/src/osk/input/gestures/browser/subkeyPopup.ts
+++ b/web/src/engine/src/osk/input/gestures/browser/subkeyPopup.ts
@@ -3,7 +3,8 @@ import { type KeyElement } from '../../../keyElement.js';
 import { OSKBaseKey } from '../../../keyboard-layout/oskBaseKey.js';
 import { VisualKeyboard } from '../../../visualKeyboard.js';
 
-import { DeviceSpec, ActiveSubKey, KeyDistribution, ActiveKeyBase } from 'keyman/engine/keyboard';
+import { ActiveSubKey, KeyDistribution, ActiveKeyBase } from 'keyman/engine/keyboard';
+import { DeviceSpec } from 'keyman/common/web-utils';
 import { ConfigChangeClosure, GestureRecognizerConfiguration, GestureSequence, PaddedZoneSource, RecognitionZoneSource } from 'keyman/engine/gesture-processor';
 import { GestureHandler } from '../gestureHandler.js';
 import { CorrectionLayout, CorrectionLayoutEntry } from '../../../correctionLayout.js';

--- a/web/src/engine/src/osk/input/gestures/specsForLayout.ts
+++ b/web/src/engine/src/osk/input/gestures/specsForLayout.ts
@@ -9,10 +9,8 @@ import {
 } from '@keymanapp/common-types';
 import ButtonClasses = TouchLayout.TouchLayoutKeySp;
 
-import {
-  ActiveLayout,
-  deepCopy
-} from 'keyman/engine/keyboard';
+import { deepCopy } from 'keyman/common/web-utils';
+import { ActiveLayout } from 'keyman/engine/keyboard';
 
 import { type KeyElement } from '../../keyElement.js';
 

--- a/web/src/engine/src/osk/keyboard-layout/oskKey.ts
+++ b/web/src/engine/src/osk/keyboard-layout/oskKey.ts
@@ -1,4 +1,5 @@
-import { ActiveKey, ActiveSubKey, ButtonClass, ButtonClasses, DeviceSpec } from 'keyman/engine/keyboard';
+import { DeviceSpec } from 'keyman/common/web-utils';
+import { ActiveKey, ActiveSubKey, ButtonClass, ButtonClasses } from 'keyman/engine/keyboard';
 
 // At present, we don't use @keymanapp/keyman.  Just `keyman`.  (Refer to <root>/web/package.json.)
 import { specialCharacters } from '../specialCharacters.js';

--- a/web/src/engine/src/osk/keyboard-layout/oskLayerGroup.ts
+++ b/web/src/engine/src/osk/keyboard-layout/oskLayerGroup.ts
@@ -1,4 +1,5 @@
-import { type DeviceSpec, JSKeyboard, ActiveLayout, ButtonClasses } from 'keyman/engine/keyboard';
+import { JSKeyboard, ActiveLayout, ButtonClasses } from 'keyman/engine/keyboard';
+import { type DeviceSpec } from 'keyman/common/web-utils';
 
 import { InputSample } from 'keyman/engine/gesture-processor';
 

--- a/web/src/engine/src/osk/views/anchoredOskView.ts
+++ b/web/src/engine/src/osk/views/anchoredOskView.ts
@@ -1,4 +1,4 @@
-import { DeviceSpec } from 'keyman/engine/keyboard';
+import { DeviceSpec } from 'keyman/common/web-utils';
 import { landscapeView } from 'keyman/engine/dom-utils';
 
 import { OSKView, OSKPos, OSKRect } from './oskView.js';

--- a/web/src/engine/src/osk/views/floatingOskView.ts
+++ b/web/src/engine/src/osk/views/floatingOskView.ts
@@ -1,4 +1,4 @@
-import { DeviceSpec, ManagedPromise, Version } from 'keyman/engine/keyboard';
+import { DeviceSpec, ManagedPromise, Version } from 'keyman/common/web-utils';
 import { getAbsoluteX, getAbsoluteY, landscapeView } from 'keyman/engine/dom-utils';
 import { EmitterListenerSpy } from 'keyman/engine/events';
 

--- a/web/src/engine/src/osk/views/inlinedOskView.ts
+++ b/web/src/engine/src/osk/views/inlinedOskView.ts
@@ -1,4 +1,4 @@
-import { DeviceSpec } from 'keyman/engine/keyboard';
+import { DeviceSpec } from 'keyman/common/web-utils';
 
 import { OSKView, OSKPos, OSKRect } from './oskView.js';
 import { VisualKeyboard } from '../visualKeyboard.js';

--- a/web/src/engine/src/osk/views/oskView.ts
+++ b/web/src/engine/src/osk/views/oskView.ts
@@ -10,12 +10,11 @@ import { VisualKeyboard } from '../visualKeyboard.js';
 import { LengthStyle, ParsedLengthStyle } from '../lengthStyle.js';
 import { type KeyElement } from '../keyElement.js';
 
+import { DeviceSpec, ManagedPromise } from 'keyman/common/web-utils';
 import {
   Codes,
-  DeviceSpec,
   JSKeyboard,
   KeyboardProperties,
-  ManagedPromise,
   type MinimalCodesInterface,
   type MutableSystemStore, type SystemStoreMutationHandler,
 } from 'keyman/engine/keyboard';

--- a/web/src/engine/src/osk/visualKeyboard.ts
+++ b/web/src/engine/src/osk/visualKeyboard.ts
@@ -5,17 +5,16 @@ import {
   ActiveKeyBase,
   ActiveLayout,
   ActiveSubKey,
-  DeviceSpec,
   JSKeyboard,
   KeyboardProperties,
   KeyDistribution,
   KeyEvent,
   Layouts,
   StateKeyMap,
-  timedPromise,
   type InternalKeyboardFont,
 } from 'keyman/engine/keyboard';
 import { isEmptyTransform } from 'keyman/common/web-utils';
+import { DeviceSpec, timedPromise } from 'keyman/common/web-utils';
 
 import { buildCorrectiveLayout } from './correctionLayout.js';
 import { distributionFromDistanceMaps, keyTouchDistances } from './corrections.js';

--- a/web/src/test/auto/dom/cases/element-text-stores/element_interfaces.tests.ts
+++ b/web/src/test/auto/dom/cases/element-text-stores/element_interfaces.tests.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 
-import { KMWString, SyntheticTextStore } from 'keyman/engine/keyboard';
+import { KMWString } from 'keyman/common/web-utils';
+import { SyntheticTextStore } from 'keyman/engine/keyboard';
 import * as wrappers from 'keyman/engine/element-text-stores';
 
 import { DynamicElements } from '../../test_utils.js';

--- a/web/src/test/auto/dom/cases/element-text-stores/syntheticTextStore.tests.ts
+++ b/web/src/test/auto/dom/cases/element-text-stores/syntheticTextStore.tests.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 
-import { KMWString, SyntheticTextStore } from 'keyman/engine/keyboard';
+import { KMWString } from 'keyman/common/web-utils';
+import { SyntheticTextStore } from 'keyman/engine/keyboard';
 import { InputElementTextStore } from 'keyman/engine/element-text-stores';
 
 import { DEFAULT_BROWSER_TIMEOUT } from '@keymanapp/common-test-resources/test-timeouts.mjs';

--- a/web/src/test/auto/dom/cases/keyboard/domKeyboardLoader.tests.ts
+++ b/web/src/test/auto/dom/cases/keyboard/domKeyboardLoader.tests.ts
@@ -1,7 +1,8 @@
 import { assert } from 'chai';
 
 import { DOMKeyboardLoader } from 'keyman/engine/keyboard';
-import { KeyboardHarness, JSKeyboard, MinimalKeymanGlobal, DeviceSpec, KeyboardKeymanGlobal, KeyboardDownloadError, KeyboardScriptError, Keyboard, SyntheticTextStore } from 'keyman/engine/keyboard';
+import { DeviceSpec } from 'keyman/common/web-utils';
+import { KeyboardHarness, JSKeyboard, MinimalKeymanGlobal, KeyboardKeymanGlobal, KeyboardDownloadError, KeyboardScriptError, Keyboard, SyntheticTextStore } from 'keyman/engine/keyboard';
 import { JSKeyboardInterface } from 'keyman/engine/js-processor';
 import { assertThrowsAsync } from 'keyman/tools/testing/test-utils';
 

--- a/web/src/test/auto/headless/engine/js-processor/kbdInterface.tests.ts
+++ b/web/src/test/auto/headless/engine/js-processor/kbdInterface.tests.ts
@@ -3,7 +3,8 @@ import { assert } from 'chai';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
-import { DeviceSpec, JSKeyboard, MinimalKeymanGlobal, SyntheticTextStore } from 'keyman/engine/keyboard';
+import { DeviceSpec } from 'keyman/common/web-utils';
+import { JSKeyboard, MinimalKeymanGlobal, SyntheticTextStore } from 'keyman/engine/keyboard';
 import { JSKeyboardInterface } from 'keyman/engine/js-processor';
 import { NodeKeyboardLoader } from '../../../resources/loader/nodeKeyboardLoader.js';
 

--- a/web/src/test/auto/headless/engine/keyboard/keyboard.tests.ts
+++ b/web/src/test/auto/headless/engine/keyboard/keyboard.tests.ts
@@ -3,7 +3,8 @@ import { assert } from 'chai';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
-import { KeyboardHarness, MinimalKeymanGlobal, DeviceSpec, JSKeyboard } from 'keyman/engine/keyboard';
+import { DeviceSpec } from 'keyman/common/web-utils';
+import { KeyboardHarness, MinimalKeymanGlobal, JSKeyboard } from 'keyman/engine/keyboard';
 import { NodeKeyboardLoader } from '../../../resources/loader/nodeKeyboardLoader.js';
 
 

--- a/web/src/test/auto/headless/engine/keyboard/keyboardLoaderBase.tests.ts
+++ b/web/src/test/auto/headless/engine/keyboard/keyboardLoaderBase.tests.ts
@@ -3,7 +3,8 @@ import { assert } from 'chai';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
-import { KeyboardHarness, MinimalKeymanGlobal, KeyboardDownloadError, DeviceSpec, InvalidKeyboardError, JSKeyboard, SyntheticTextStore } from 'keyman/engine/keyboard';
+import { DeviceSpec } from 'keyman/common/web-utils';
+import { KeyboardHarness, MinimalKeymanGlobal, KeyboardDownloadError, InvalidKeyboardError, JSKeyboard, SyntheticTextStore } from 'keyman/engine/keyboard';
 import { JSKeyboardInterface } from 'keyman/engine/js-processor';
 import { NodeKeyboardLoader } from '../../../resources/loader/nodeKeyboardLoader.js';
 import { assertThrowsAsync, assertThrows } from 'keyman/tools/testing/test-utils';

--- a/web/src/test/auto/headless/engine/osk/input/gestures/browser/subkeyPopup.tests.ts
+++ b/web/src/test/auto/headless/engine/osk/input/gestures/browser/subkeyPopup.tests.ts
@@ -4,9 +4,9 @@ import { JSDOM } from 'jsdom';
 import sinon from 'sinon';
 
 import { GesturePath, GestureSequence, GestureSource, GestureSourceSubview } from 'keyman/engine/gesture-processor';
-import { ActiveSubKey, DeviceSpec } from 'keyman/engine/keyboard';
-import { DEFAULT_GESTURE_PARAMS, KeyElement, VisualKeyboard } from 'keyman/engine/osk';
-import { testIndex } from 'keyman/engine/osk';
+import { DeviceSpec } from 'keyman/common/web-utils';
+import { ActiveSubKey } from 'keyman/engine/keyboard';
+import { DEFAULT_GESTURE_PARAMS, KeyElement, VisualKeyboard, testIndex } from 'keyman/engine/osk';
 
 import OSKBaseKey = testIndex.OSKBaseKey;
 import OSKRow = testIndex.OSKRow;

--- a/web/src/test/auto/resources/loader/nodeCloudRequester.ts
+++ b/web/src/test/auto/resources/loader/nodeCloudRequester.ts
@@ -1,4 +1,4 @@
-import { ManagedPromise } from 'keyman/engine/keyboard';
+import { ManagedPromise } from 'keyman/common/web-utils';
 import { CloudRequesterInterface } from '../../../../engine/src/keyboard-storage/cloud/requesterInterface.js';
 import {
   CLOUD_TIMEOUT_ERR,


### PR DESCRIPTION
Types defined in keyman/common/web-utils were re-exported in keyman/engine/keyboard. This change removes the re-export.

Part-of: #15292
Test-bot: skip