### PR TITLE
refactor(web): use unitTestEndpoint pattern in OSK 🎼

### DIFF
--- a/web/src/engine/src/main/keymanEngineBase.ts
+++ b/web/src/engine/src/main/keymanEngineBase.ts
@@ -1,11 +1,10 @@
 import { type KeyEvent, JSKeyboard, Keyboard, KeyboardProperties, KeyboardKeymanGlobal, ProcessorAction, KMXKeyboard } from "keyman/engine/keyboard";
 import { ProcessorInitOptions } from 'keyman/engine/js-processor';
-// TODO-web-core: remove alias (#15292)
-import { DOMKeyboardLoader as KeyboardLoader } from "keyman/engine/keyboard";
+import { DOMKeyboardLoader } from "keyman/engine/keyboard";
 import { WorkerFactory } from "@keymanapp/lexical-model-layer/web"
 import { InputProcessor } from './headless/inputProcessor.js';
 import { OSKView, JSKeyboardData } from "keyman/engine/osk";
-import { KeyboardRequisitioner, ModelCache, toUnprefixedKeyboardId as unprefixed, DOMCloudRequester } from "keyman/engine/keyboard-storage";
+import { KeyboardRequisitioner, ModelCache, toUnprefixedKeyboardId, DOMCloudRequester } from "keyman/engine/keyboard-storage";
 import { ModelSpec, PredictionContext } from "keyman/engine/interfaces";
 
 import { EngineConfiguration, InitOptionSpec } from "./engineConfiguration.js";
@@ -242,7 +241,7 @@ export class KeymanEngineBase<
 
     // Since we're not sandboxing keyboard loads yet, we just use `window` as the jsGlobal object.
     // All components initialized below require a properly-configured `config.paths` or similar.
-    const keyboardLoader = new KeyboardLoader(this.interface, config.applyCacheBusting);
+    const keyboardLoader = new DOMKeyboardLoader(this.interface, config.applyCacheBusting);
     this.keyboardRequisitioner = new KeyboardRequisitioner(keyboardLoader, new DOMCloudRequester(), this.config.paths);
     this.modelCache = new ModelCache();
     const kbdCache = this.keyboardRequisitioner.cache;
@@ -400,7 +399,7 @@ export class KeymanEngineBase<
     const report = {
       configReport: this.config?.debugReport(),
       keyboard: {
-        id: unprefixed(activeKbd?.metadata?.id ?? ''),
+        id: toUnprefixedKeyboardId(activeKbd?.metadata?.id ?? ''),
         langId: activeKbd?.metadata?.langId || '',
         version: activeKbd?.keyboard?.version ?? ''
       },

--- a/web/src/engine/src/osk/index.ts
+++ b/web/src/engine/src/osk/index.ts
@@ -35,7 +35,13 @@ export {
     correctionKeyFilter, buildCorrectiveLayout
 } from './correctionLayout.js';
 
-// TODO-web-core: use a unitTestEndpoints pattern here (#15292)
-export * as testIndex from './test-index.js';
-
-// More things will likely need to be added.
+import { OSKBaseKey } from './keyboard-layout/oskBaseKey.js';
+import { OSKRow } from './keyboard-layout/oskRow.js';
+import { SubkeyPopup } from './input/gestures/browser/subkeyPopup.js'
+import { link } from './keyElement.js'
+export const unitTestEndpoints = {
+    OSKBaseKey,
+    OSKRow,
+    SubkeyPopup,
+    link
+};

--- a/web/src/engine/src/osk/test-index.ts
+++ b/web/src/engine/src/osk/test-index.ts
@@ -1,4 +1,0 @@
-export { OSKBaseKey } from './keyboard-layout/oskBaseKey.js';
-export { OSKRow }  from './keyboard-layout/oskRow.js';
-export { SubkeyPopup } from './input/gestures/browser/subkeyPopup.js'
-export { link } from './keyElement.js'

--- a/web/src/test/auto/headless/engine/osk/input/gestures/browser/subkeyPopup.tests.ts
+++ b/web/src/test/auto/headless/engine/osk/input/gestures/browser/subkeyPopup.tests.ts
@@ -6,12 +6,12 @@ import sinon from 'sinon';
 import { GesturePath, GestureSequence, GestureSource, GestureSourceSubview } from 'keyman/engine/gesture-processor';
 import { DeviceSpec } from 'keyman/common/web-utils';
 import { ActiveSubKey } from 'keyman/engine/keyboard';
-import { DEFAULT_GESTURE_PARAMS, KeyElement, VisualKeyboard, testIndex } from 'keyman/engine/osk';
+import { DEFAULT_GESTURE_PARAMS, KeyElement, VisualKeyboard, unitTestEndpoints } from 'keyman/engine/osk';
 
-import OSKBaseKey = testIndex.OSKBaseKey;
-import OSKRow = testIndex.OSKRow;
-import SubkeyPopup = testIndex.SubkeyPopup;
-import link = testIndex.link;
+const OSKBaseKey = unitTestEndpoints.OSKBaseKey;
+const OSKRow = unitTestEndpoints.OSKRow;
+const SubkeyPopup = unitTestEndpoints.SubkeyPopup;
+const link = unitTestEndpoints.link;
 
 // Tests for #10126
 describe('subkey menu width', () => {


### PR DESCRIPTION
This changes the exports for unit testing to the unitTestEndpoint pattern.

Part-of: #15292
Test-bot: skip