### PR TITLE
docs(developer): update primerprep link 🏠

### DIFF
--- a/developer/docs/help/guides/lexical-models/tutorial/step-3.md
+++ b/developer/docs/help/guides/lexical-models/tutorial/step-3.md
@@ -15,7 +15,7 @@ One simple way to create your TSV file is to use the **PrimerPrep**
 tool:
 
 1.  Install PrimerPrep (info at
-    <http://lingtransoft.info/apps/primerprep>)
+    <[https://software.sil.org/primerprep/](https://software.sil.org/primerprep/)>)
 2.  Run PrimerPrep (note that on the first run it often takes a couple
     of minutes; subsequent starts are faster)
 3.  Click on the Add Text(s) button; select one or more plain text


### PR DESCRIPTION
Follow #15426 
Together with https://github.com/keymanapp/help.keyman.com/pull/2402

This PR is ready for review.

FYI, @jeffheath-sil.

Test-bot: skip.

---
Context from Gmail:

> The change is simply to change the link http://lingtransoft.info/apps/primerprep to https://software.sil.org/primerprep/ on the page:
https://help.keyman.com/developer/18.0/guides/lexical-models/tutorial/step-3

> We could do this:
> - Submit the same change in a new pull request targeting stable-18.0 branch on keyman repo (https://github.com/keymanapp/keyman/blob/stable-18.0/developer/docs/help/guides/lexical-models/tutorial/step-3.md). This ensures that the content will persist if we do publish a new 18.0 release.
> - Also open a PR against the help repo (https://github.com/keymanapp/help.keyman.com/blob/master/developer/18.0/guides/lexical-models/tutorial/step-3.md) making the same change. This would be overwritten when we do another stable-18.0 release, but with the PR for stable-18.0 it'll be overwritten with the same content.