### PR TITLE
fix(web): fix  baseline tests 🎼

### DIFF
--- a/web/src/test/auto/e2e/baseline/baseline.tests.ts
+++ b/web/src/test/auto/e2e/baseline/baseline.tests.ts
@@ -140,7 +140,7 @@ test.describe('Baseline tests', () => {
                   value: encodeURIComponent(`${option.key}=${option.value};`),
                   domain: 'localhost',
                   path: '/',
-                  expires: 1768672167
+                  expires: Date.now() / 1000 + 60, // expire in 1 minute
                 });
               }
             }


### PR DESCRIPTION
Previously the cookies for the baseline tests were set to a fixed time which might be in the past. This change now calculates the expiration time and sets them to expire in 60s.

Test-bot: skip