### PR TITLE
fix(web): fix problem with tests if KEYMAN_ROOT is not set 🎼

### DIFF
--- a/web/src/test/auto/headless/engine/loadKeyboardHelper.ts
+++ b/web/src/test/auto/headless/engine/loadKeyboardHelper.ts
@@ -5,7 +5,11 @@
 import fs from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
-const KEYMAN_ROOT = process.env['KEYMAN_ROOT'] ?? '.';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const KEYMAN_ROOT = process.env['KEYMAN_ROOT'] ?? (__dirname + '/../../../../../../');
 export const coreurl = pathToFileURL(`${KEYMAN_ROOT}/web/build/engine/obj/core-adapter/import/core`).toString();
 
 export function loadKeyboardBlob(filename: string) {


### PR DESCRIPTION
When running mocha without starting it through `build.sh`/`test.sh` the tests failed if the `KEYMAN_ROOT` environment variable was not set. Things were almost correct, but the undefined `KEYMAN_ROOT` variable added an extra `undefined` subdirectory. This change fixes this problem by setting `KEYMAN_ROOT` relative to the current file. This gets removed by `pathToFileURL` which also adds the absolute path to the current directory since we pass a relative path as argument.

Build-bot: skip
Test-bot: skip