### PR TITLE
feat(web): add isSameNode for duplicate quotient-node detection 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
@@ -8,7 +8,7 @@
  * engine.
  */
 
-import { QueueComparator as Comparator, KMWString, PriorityQueue } from '@keymanapp/web-utils';
+import { QueueComparator, KMWString, PriorityQueue } from '@keymanapp/web-utils';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 import { buildMergedTransform } from '@keymanapp/models-templates';
 
@@ -23,7 +23,7 @@ import LexicalModel = LexicalModelTypes.LexicalModel;
 import ProbabilityMass = LexicalModelTypes.ProbabilityMass;
 import Transform = LexicalModelTypes.Transform;
 
-export const QUEUE_NODE_COMPARATOR: Comparator<SearchNode> = function(arg1, arg2) {
+export const QUEUE_NODE_COMPARATOR: QueueComparator<SearchNode> = function(arg1, arg2) {
   return arg1.currentCost - arg2.currentCost;
 }
 

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-state.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-state.tests.ts
@@ -409,7 +409,7 @@ describe('ContextState', () => {
       assert.equal(state.tokenization.tokens[state.tokenization.tokens.length - 1].searchModule.inputCount, 1);
     });
 
-    it.skip('handles case where tail token is split into three rather than two', function() {
+    it('handles case where tail token is split into three rather than two', function() {
       let baseContext = models.tokenize(defaultBreaker, {
         left: "text'", startOfBuffer: true, endOfBuffer: true
       });

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/context-tokenization.tests.ts
@@ -561,7 +561,7 @@ describe('ContextTokenization', function() {
       }
     });
 
-    it.skip('handles case that triggers a token merge:  can+\'+t', () => {
+    it('handles case that triggers a token merge:  can+\'+t', () => {
       const baseTokens = ['an', ' ', 'apple', ' ', 'a', ' ', 'day', ' ', 'can', '\''];
       const baseTokenization = new ContextTokenization(baseTokens.map(t => toToken(t)));
 

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/search-quotient-cluster.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/search-quotient-cluster.tests.ts
@@ -3,7 +3,7 @@
  *
  * Created by jahorton on 2025-10-29
  *
- * This file defines tests for the SearchSpace class of the
+ * This file defines tests for the SearchQuotientCluster class of the
  * predictive-text correction-search engine.
  */
 


### PR DESCRIPTION
Continuing from #15508, this defines a method useful for determining if one SearchQuotientNode is a 100% match and duplicate for another node.  While `.isSameNode` is only leveraged in unit tests within this PR, it sees use in runtime code starting with #15031.

Build-bot: skip build:web
Test-bot: skip