### PR TITLE
fix(resources): block unsupported platforms from running certain scripts

### DIFF
--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -2375,6 +2375,11 @@ builder_describe_platform() {
       fi
     done
   done
+
+  if [[ ${#_builder_targets[@]} == 0 ]]; then
+    builder_die "This script cannot be run on $builder_platform; supported platforms are: ${_builder_targets_excluded_by_platform[@]}"
+  fi
+
 }
 
 # Returns 0 if the specified target is excluded by platform requirements


### PR DESCRIPTION
If a builder script requires a specific platform, give a helpful error message when the script is run on an unsupported platform.

Test-bot: skip
Fixes: #15474