### PR TITLE
change(web): remove SearchQuotientNode.inputSequence 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
@@ -203,7 +203,7 @@ export class ContextToken {
    * @param lexicalModel
    * @returns
    */
-  split(split: TokenSplitMap) {
+  split(split: TokenSplitMap): ContextToken[] {
     // Split from tail to head - leave as much 'head' intact as possible at each
     // step, rather than needing to reconstruct the tail multiple times.
     const splitSpecs = split.matches.slice();

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-node.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-node.ts
@@ -3,7 +3,7 @@
  *
  * Created by jahorton on 2025-10-09
  *
- * This file defines the predictive-text engine's SearchSpace class, which is used to
+ * This file defines the predictive-text engine's SearchQuotientNode class, which is used to
  * manage the search-space(s) for text corrections within the engine.
  */
 
@@ -205,7 +205,7 @@ export interface SearchQuotientNode {
   get sourceRangeKey(): string;
 
   /**
-   * Appends this SearchSpace with the provided SearchSpace's search properties,
+   * Appends this SearchQuotientNode with the provided SearchQuotientNode's search properties,
    * extending the represented search range accordingly.  If this operation
    * represents merging the result of a previous .split() call, the two halves
    * of any split input components will be fully re-merged.
@@ -214,7 +214,7 @@ export interface SearchQuotientNode {
   merge(space: SearchQuotientNode): SearchQuotientNode;
 
   /**
-   * Splits this SearchSpace into two halves at the specified codepoint index.
+   * Splits this SearchQuotientNode into two halves at the specified codepoint index.
    * The 'head' component will maximally re-use existing cached data, while the
    * 'tail' must be reconstructed from scratch due to the new start position.
    * @param charIndex

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
@@ -435,7 +435,7 @@ export abstract class SearchQuotientSpur implements SearchQuotientNode {
         const tailSrc = parentSources.pop();
         // Deep-copy the object and replace the segment end value.
         const extendedTailSrc = {...tailSrc, segment: {...tailSrc.segment, end: this.inputSource.segment.end}};
-        if(extendedTailSrc.segment.end) {
+        if(extendedTailSrc.segment.end === undefined) {
           delete extendedTailSrc.segment.end;
         }
         parentSources.push(extendedTailSrc);
@@ -465,7 +465,9 @@ export abstract class SearchQuotientSpur implements SearchQuotientNode {
       // left-deletions are applied without applying any of its insert string.
       const midInputStart = i != 0 || parentSegs[parentSegs.length - 1]?.segment.end !== undefined;
 
-      // If there's an entry for end, always include the start position
+      // If there's an entry for end, always include the start position.  Also
+      // include the start position if the range for the source starts after
+      // index 0.
       if(j !== undefined) {
         component = `${component}@${i}-${j}`;
       } else if(midInputStart) {

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/search-quotient-spur.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/search-quotient-spur.tests.ts
@@ -3,7 +3,7 @@
  *
  * Created by jahorton on 2025-10-29
  *
- * This file defines tests for the SearchSpace class of the
+ * This file defines tests for the SearchQuotientSpur classes of the
  * predictive-text correction-search engine.
  */
 
@@ -12,7 +12,17 @@ import { assert } from 'chai';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 import { KMWString } from '@keymanapp/web-utils';
 import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
-import { generateSubsetId, LegacyQuotientSpur, models, LegacyQuotientRoot, SearchQuotientNode, PathInputProperties, SearchQuotientSpur, unitTestEndpoints } from '@keymanapp/lm-worker/test-index';
+import {
+  generateSubsetId,
+  LegacyQuotientRoot,
+  LegacyQuotientSpur,
+  models,
+  PathInputProperties,
+  SearchQuotientNode,
+  SearchQuotientRoot,
+  SearchQuotientSpur,
+  unitTestEndpoints
+} from '@keymanapp/lm-worker/test-index';
 
 import Distribution = LexicalModelTypes.Distribution;
 import Transform = LexicalModelTypes.Transform;
@@ -560,29 +570,40 @@ describe('SearchQuotientSpur', () => {
         runSplit(8);
 
         const { path: pathToSplit } = buildPath();
-        const [head] = pathToSplit.split(8);
+        const [head, tail] = pathToSplit.split(8);
 
         assert.equal(head, pathToSplit.parents[0]);
+        assert.equal((tail as SearchQuotientSpur).inputSource, (pathToSplit as SearchQuotientSpur).inputSource);
       });
 
       it('splits properly at index 9', () => {
         runSplit(9);
 
         const { path: pathToSplit } = buildPath();
-        const [head] = pathToSplit.split(9);
+        const [head, tail] = pathToSplit.split(9);
 
         // Same parent, but not the same final step - it _was_ split, after
         // all.
         assert.equal(head.parents[0], pathToSplit.parents[0]);
+
+        const headSrc = (head as SearchQuotientSpur).inputSource;
+        const tailSrc = (tail as SearchQuotientSpur).inputSource;
+        assert.equal(headSrc.subsetId, tailSrc.subsetId);
+        assert.equal(headSrc.segment.transitionId, tailSrc.segment.transitionId);
+        assert.equal(headSrc.segment.start, 0);
+        assert.equal(tailSrc.segment.start, 1);
+        assert.equal(headSrc.segment.end, tailSrc.segment.start);
+        assert.isUndefined(tailSrc.segment.end);
       });
 
       it('splits properly at index 10', () => {
         runSplit(10);
 
         const { path: pathToSplit } = buildPath();
-        const [head] = pathToSplit.split(10);
+        const [head, tail] = pathToSplit.split(10);
 
         assert.equal(head, pathToSplit);
+        assert.isTrue(tail instanceof SearchQuotientRoot);
       });
     });
 


### PR DESCRIPTION
This property, previously marked as deprecated earlier in the PR chain, lost its last reference in #15024 and is now safe to eliminate.

Build-bot: skip build:web
Test-bot: skip