### PR TITLE
fix(windows): export sym store path so symbols are published

### DIFF
--- a/resources/teamcity/developer/keyman-developer-release.sh
+++ b/resources/teamcity/developer/keyman-developer-release.sh
@@ -118,6 +118,7 @@ function publish_action() {
   export RSYNC_USER
   export RSYNC_HOST
   export RSYNC_ROOT
+  export KEYMAN_SYMSTOREPATH="$LOCAL_SYMBOLS_PATH"
 
   _publish_sentry
   ba_win_download_symbol_server_index

--- a/resources/teamcity/windows/keyman-windows-release.sh
+++ b/resources/teamcity/windows/keyman-windows-release.sh
@@ -101,6 +101,7 @@ function windows_publish_action() {
   export RSYNC_USER
   export RSYNC_HOST
   export RSYNC_ROOT
+  export KEYMAN_SYMSTOREPATH="$LOCAL_SYMBOLS_PATH"
 
   builder_launch /windows/build.sh publish
   windows_upload_symbols_to_sentry


### PR DESCRIPTION
`KEYMAN_SYMSTOREPATH` is used in `wrap-symstore`, and if missing, no symbols are written to the local symbol store for later publication to downloads.keyman.com.

Fixes: #14837
Test-bot: skip