### PR TITLE
fix(windows): adjust symbol paths for publishing to symbol server

### DIFF
--- a/resources/teamcity/developer/keyman-developer-release.sh
+++ b/resources/teamcity/developer/keyman-developer-release.sh
@@ -31,7 +31,7 @@ builder_describe \
   "--help.keyman.com=HELP_KEYMAN_COM          path to help.keyman.com repository" \
   "--symbols-local-path=LOCAL_SYMBOLS_PATH    local path to symbols directory" \
   "--symbols-remote-path=REMOTE_SYMBOLS_PATH  remote path to symbols directory" \
-  "--symbols-subdir=SYMBOLS_SUBDIR            subdirectory containing symbols"
+  "--symbols-subdir=SYMBOLS_SUBDIR            subdirectory containing symbols [unused; TODO: remove in v20]"
 
 builder_parse "$@"
 
@@ -118,7 +118,6 @@ function publish_action() {
   export RSYNC_USER
   export RSYNC_HOST
   export RSYNC_ROOT
-  export KEYMAN_SYMSTOREPATH="$LOCAL_SYMBOLS_PATH"
 
   _publish_sentry
   ba_win_download_symbol_server_index
@@ -126,6 +125,8 @@ function publish_action() {
   _publish_to_downloads_keyman_com
   tc_upload_help "api documentation" developer
 }
+
+export KEYMAN_SYMSTOREPATH="$LOCAL_SYMBOLS_PATH"
 
 if builder_has_action all; then
   build_developer_action

--- a/resources/teamcity/includes/tc-windows.inc.sh
+++ b/resources/teamcity/includes/tc-windows.inc.sh
@@ -11,14 +11,14 @@ ba_win_download_symbol_server_index() {
   builder_echo start "download symbol server index" "Downloading symbol server index"
   (
     # shellcheck disable=SC2154
-    mkdir -p "${LOCAL_SYMBOLS_PATH}/${SYMBOLS_SUBDIR}"
+    mkdir -p "${LOCAL_SYMBOLS_PATH}/000admin"
     # shellcheck disable=SC2164
-    cd "${LOCAL_SYMBOLS_PATH}/${SYMBOLS_SUBDIR}"
+    cd "${LOCAL_SYMBOLS_PATH}/000admin"
 
     # shellcheck disable=SC2154
-    tc_rsync_download "${REMOTE_SYMBOLS_PATH}/${SYMBOLS_SUBDIR}/lastid.txt" "."
-    tc_rsync_download "${REMOTE_SYMBOLS_PATH}/${SYMBOLS_SUBDIR}/history.txt" "."
-    tc_rsync_download "${REMOTE_SYMBOLS_PATH}/${SYMBOLS_SUBDIR}/server.txt" "."
+    tc_rsync_download "${REMOTE_SYMBOLS_PATH}/000admin/lastid.txt" "."
+    tc_rsync_download "${REMOTE_SYMBOLS_PATH}/000admin/history.txt" "."
+    tc_rsync_download "${REMOTE_SYMBOLS_PATH}/000admin/server.txt" "."
   )
   builder_echo end "download symbol server index" success "Finished downloading symbol server index"
 }
@@ -32,6 +32,10 @@ ba_win_publish_new_symbols() {
   (
     # shellcheck disable=SC2164
     cd "${LOCAL_SYMBOLS_PATH}"
+
+    # ensure lower case 000admin (it may become capitalized from symsrv touching it)
+    mv 000Admin 000admin
+
     tc_rsync_upload "." "${REMOTE_SYMBOLS_PATH}"
   )
   builder_echo end "publish new symbols" success "Finished publishing new symbols to symbol server"

--- a/resources/teamcity/windows/keyman-windows-release.sh
+++ b/resources/teamcity/windows/keyman-windows-release.sh
@@ -33,7 +33,7 @@ builder_describe \
   "--help.keyman.com=HELP_KEYMAN_COM          path to help.keyman.com repository" \
   "--symbols-local-path=LOCAL_SYMBOLS_PATH    local path to symbols directory" \
   "--symbols-remote-path=REMOTE_SYMBOLS_PATH  remote path to symbols directory" \
-  "--symbols-subdir=SYMBOLS_SUBDIR            subdirectory containing symbols"
+  "--symbols-subdir=SYMBOLS_SUBDIR            subdirectory containing symbols [unused; TODO: remove in v20]"
 
 builder_parse "$@"
 
@@ -101,7 +101,6 @@ function windows_publish_action() {
   export RSYNC_USER
   export RSYNC_HOST
   export RSYNC_ROOT
-  export KEYMAN_SYMSTOREPATH="$LOCAL_SYMBOLS_PATH"
 
   builder_launch /windows/build.sh publish
   windows_upload_symbols_to_sentry
@@ -111,6 +110,8 @@ function windows_publish_action() {
   tc_upload_help "Keyman for Windows" windows
   builder_echo end "publish windows" success "Finished publishing Keyman for Windows"
 }
+
+export KEYMAN_SYMSTOREPATH="$LOCAL_SYMBOLS_PATH"
 
 if builder_has_action all; then
   windows_build_action


### PR DESCRIPTION
There were two issues arising from #15493 - first, `$KEYMAN_SYMSTOREPATH` was set too late, after the build, and second, symsrv renames `000admin` to `000Admin` but we need to keep it lowercase for our deployment server, so rename it back just in time before uploading.

As tidy-up, given that the folder name `000admin` is static and never changes, removed the parameter and hard-coded it instead.

* export `$KEYMAN_SYMSTOREPATH` before build
* define `000admin` folder explicitly and deprecate --symbols-subdir parameter
* rename `000Admin` to `000admin` before upload

Fixes: #14837
Follows: #15493
Test-bot: skip