### PR TITLE
chore(linux): update copyright year and standards version 🏠

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -44,7 +44,7 @@ Build-Depends:
  python3-xdg,
  xserver-xephyr,
  xvfb,
-Standards-Version: 4.7.2
+Standards-Version: 4.7.3
 Vcs-Git: https://github.com/keymanapp/keyman.git -b stable-18.0 [linux/debian]
 Vcs-Browser: https://github.com/keymanapp/keyman/tree/stable-18.0/linux/debian
 Homepage: https://www.keyman.com

--- a/linux/debian/copyright
+++ b/linux/debian/copyright
@@ -6,24 +6,24 @@ Comment: Debian's licensecheck tool uses the term `Expat` for the `MIT` license.
          `Unicode-3.0` is identified `Unicode-DFS-2016`.
 
 Files: *
-Copyright: 2018-2025 SIL Global
+Copyright: 2018-2026 SIL Global
 License: Expat
 
 Files: linux/ibus-keyman/*
-Copyright: 2004-2025 SIL Global
+Copyright: 2004-2026 SIL Global
 License: GPL-2+
 
 Files: linux/ibus-keyman/src/keymanutil.c
        linux/ibus-keyman/src/keymanutil.h
        linux/ibus-keyman/src/kmpdetails.c
        linux/ibus-keyman/src/kmpdetails.h
-Copyright: 2009-2025 SIL Global
+Copyright: 2009-2026 SIL Global
 License: GPL-2+ or Expat
 
 Files: linux/ibus-keyman/src/keyman-service.c
        linux/ibus-keyman/src/keyman-service.h
        linux/keyman-config/buildtools/help2md
-Copyright: 2018-2025 SIL Global
+Copyright: 2018-2026 SIL Global
 License: GPL-3+
 
 Files: linux/ibus-keyman/tests/ibusimcontext.c
@@ -33,7 +33,7 @@ Copyright: 2008-2010, Peng Huang <shawn.p.huang@gmail.com>
            2008-2013, Peng Huang <shawn.p.huang@gmail.com>
            2008-2021, Red Hat, Inc.
            2015-2021, Takao Fujiwara <takao.fujiwara1@gmail.com>
-           2021-2025, SIL Global
+           2021-2026, SIL Global
 License: LGPL-2.1+
 
 Files: linux/keyman-config/buildtools/help2man
@@ -43,7 +43,7 @@ License: GPL-3+
 Files: debian/com.keyman.config.appdata.xml
        debian/com.keyman.ibus_keyman.metainfo.xml
 Copyright: 2019 Daniel Glassey <wdg@debian.org>
-           2022-2025 SIL Global
+           2022-2026 SIL Global
 License: Expat
 
 Files: resources/standards-data/ldml-keyboards/*


### PR DESCRIPTION
This change updates the copyright year in the `debian/copyright` file as well as the `Standards-Version` to 4.7.3 in `debian/control`.

Test-bot: skip