### PR TITLE
change(web): define, utilize cleaner Web test-resource import paths

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -85,7 +85,8 @@
   },
   "imports": {
     "#gesture-tools": "./src/engine/osk/gesture-processor/build/tools/obj/index.js",
-    "#recorder": "./build/tools/testing/recorder/obj/index.js"
+    "#recorder": "./build/tools/testing/recorder/obj/index.js",
+    "#test-resources/*.js": "./build/test/resources/*.js"
   },
   "repository": {
     "type": "git",

--- a/web/src/test/auto/headless/engine/osk/gesture-processor/gestures/gestureMatcher.tests.ts
+++ b/web/src/test/auto/headless/engine/osk/gesture-processor/gestures/gestureMatcher.tests.ts
@@ -1,15 +1,12 @@
 import { assert } from 'chai'
 import sinon from 'sinon';
-
 import * as PromiseStatusModule from 'promise-status-async';
-const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
-import { assertingPromiseStatus as promiseStatus } from '../../../../../resources/assertingPromiseStatus.js';
 
 import { InputSample, gestures, GestureDebugPath } from '@keymanapp/gesture-recognizer';
 
+import { assertingPromiseStatus as promiseStatus } from '#test-resources/assertingPromiseStatus.js';
 import { TouchpathTurtle } from '#gesture-tools';
-
-import { simulateMultiSourceMatcherInput } from "../../../../../resources/simulateMultiSourceInput.js";
+import { simulateMultiSourceMatcherInput } from "#test-resources/simulateMultiSourceInput.js";
 
 import {
   FlickEndModel,
@@ -26,6 +23,8 @@ import {
   LongpressDistanceThreshold,
   MainLongpressSourceModel
 } from './isolatedPathSpecs.js';
+
+const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
 
 type PathInheritanceType = gestures.specs.ContactModel<string>['pathInheritance'];
 function dummyInheritanceMatcher(inheritanceType: PathInheritanceType): gestures.specs.GestureModel<string> {

--- a/web/src/test/auto/headless/engine/osk/gesture-processor/gestures/gestureSequence.tests.ts
+++ b/web/src/test/auto/headless/engine/osk/gesture-processor/gestures/gestureSequence.tests.ts
@@ -1,10 +1,14 @@
 import { assert } from 'chai'
 import sinon from 'sinon';
-
 import * as PromiseStatusModule from 'promise-status-async';
-import { assertingPromiseStatus as promiseStatus } from '../../../../../resources/assertingPromiseStatus.js';
 
 import { GestureModelDefs, buildGestureMatchInspector, gestures } from '@keymanapp/gesture-recognizer';
+import { ManagedPromise, timedPromise } from '@keymanapp/web-utils';
+
+import { HeadlessInputEngine, TouchpathTurtle } from '#gesture-tools';
+import { assertingPromiseStatus as promiseStatus } from '#test-resources/assertingPromiseStatus.js';
+import { assertGestureSequence, SequenceAssertion } from "#test-resources/sequenceAssertions.js";
+
 const { matchers } = gestures;
 
 // Huh... gotta do BOTH here?  One for constructor use, the other for generic-parameter use?
@@ -16,10 +20,7 @@ type MatcherSelection<Type> = gestures.matchers.MatcherSelection<Type>;
 const getGestureModelSet = gestures.specs.getGestureModelSet;
 const modelSetForAction = gestures.matchers.modelSetForAction;
 
-import { HeadlessInputEngine, TouchpathTurtle } from '#gesture-tools';
-import { ManagedPromise, timedPromise } from '@keymanapp/web-utils';
 
-import { assertGestureSequence, SequenceAssertion } from "../../../../../resources/sequenceAssertions.js";
 
 import {
   LongpressModel,

--- a/web/src/test/auto/headless/engine/osk/gesture-processor/gestures/matcherSelector.tests.ts
+++ b/web/src/test/auto/headless/engine/osk/gesture-processor/gestures/matcherSelector.tests.ts
@@ -2,18 +2,13 @@ import { assert } from 'chai'
 import sinon from 'sinon';
 
 import * as PromiseStatusModule from 'promise-status-async';
-const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
-import { assertingPromiseStatus as promiseStatus } from '../../../../../resources/assertingPromiseStatus.js';
-
-import { simulateMultiSourceMatcherInput, simulateSelectorInput } from "../../../../../resources/simulateMultiSourceInput.js";
 
 import { timedPromise } from '@keymanapp/web-utils';
 import { gestures } from '@keymanapp/gesture-recognizer';
 
 import { TouchpathTurtle } from '#gesture-tools';
-
-type MatcherSelection<Type> = gestures.matchers.MatcherSelection<Type>;
-type GestureModel<Type> = gestures.specs.GestureModel<Type>;
+import { assertingPromiseStatus as promiseStatus } from '#test-resources/assertingPromiseStatus.js';
+import { simulateMultiSourceMatcherInput, simulateSelectorInput } from "#test-resources/simulateMultiSourceInput.js";
 
 import {
   LongpressModel,
@@ -25,6 +20,10 @@ import {
 import {
   LongpressDistanceThreshold
 } from './isolatedPathSpecs.js';
+
+const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
+type MatcherSelection<Type> = gestures.matchers.MatcherSelection<Type>;
+type GestureModel<Type> = gestures.specs.GestureModel<Type>;
 
 describe("MatcherSelector", function () {
   beforeEach(function() {

--- a/web/src/test/auto/headless/engine/osk/gesture-processor/gestures/pathMatcher.tests.ts
+++ b/web/src/test/auto/headless/engine/osk/gesture-processor/gestures/pathMatcher.tests.ts
@@ -1,12 +1,11 @@
 import { assert } from 'chai'
 import sinon from 'sinon';
-
 import * as PromiseStatusModule from 'promise-status-async';
-const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
-import { assertingPromiseStatus as promiseStatus } from '../../../../../resources/assertingPromiseStatus.js';
 
 import { InputSample, GestureSource, gestures, CumulativePathStats } from '@keymanapp/gesture-recognizer';
 import { timedPromise } from '@keymanapp/web-utils';
+
+import { assertingPromiseStatus as promiseStatus } from '#test-resources/assertingPromiseStatus.js';
 
 import {
   InstantRejectionModel,
@@ -21,6 +20,8 @@ import {
   FlickEndContactModel,
   FlickEndThreshold
 } from './isolatedPathSpecs.js';
+
+const PromiseStatuses     = PromiseStatusModule.PromiseStatuses;
 
 async function simulateSequence(
   samples: InputSample<string>[],

--- a/web/src/test/auto/headless/engine/osk/gesture-processor/gestures/touchpointCoordinator.tests.ts
+++ b/web/src/test/auto/headless/engine/osk/gesture-processor/gestures/touchpointCoordinator.tests.ts
@@ -1,20 +1,14 @@
 import { assert } from 'chai'
 import sinon from 'sinon';
-
 import * as PromiseStatusModule from 'promise-status-async';
-import { assertingPromiseStatus as promiseStatus } from '../../../../../resources/assertingPromiseStatus.js';
+import { PROMISE_PENDING } from 'promise-status-async';
 
 import { GestureModelDefs, GestureSource, gestures, TouchpointCoordinator } from '@keymanapp/gesture-recognizer';
-const { matchers } = gestures;
-
-// Huh... gotta do BOTH here?  One for constructor use, the other for generic-parameter use?
-const { GestureSequence } = matchers;
-type GestureSequence<Type> = gestures.matchers.GestureSequence<Type>;
-
-import { HeadlessInputEngine, TouchpathTurtle } from '#gesture-tools';
 import { ManagedPromise, timedPromise } from '@keymanapp/web-utils';
 
-import { assertGestureSequence, SequenceAssertion } from "../../../../../resources/sequenceAssertions.js";
+import { HeadlessInputEngine, TouchpathTurtle } from '#gesture-tools';
+import { assertingPromiseStatus as promiseStatus } from '#test-resources/assertingPromiseStatus.js';
+import { assertGestureSequence, SequenceAssertion } from "#test-resources/sequenceAssertions.js";
 
 import {
   LongpressModel,
@@ -25,9 +19,13 @@ import {
   SubkeySelectModel
 } from './isolatedGestureSpecs.js';
 
-const LongpressDurationThreshold = LongpressModel.contacts[0].model.timer.duration;
+const { matchers } = gestures;
 
-import { PROMISE_PENDING } from 'promise-status-async';
+// Huh... gotta do BOTH here?  One for constructor use, the other for generic-parameter use?
+const { GestureSequence } = matchers;
+type GestureSequence<Type> = gestures.matchers.GestureSequence<Type>;
+
+const LongpressDurationThreshold = LongpressModel.contacts[0].model.timer.duration;
 
 const TestGestureModelDefinitions: GestureModelDefs<string> = {
   gestures: [


### PR DESCRIPTION
I never was a fan of the repeated "../../../.." import paths for certain test resources leveraged by Keyman Engine for Web components.  Finally stopped to think about it for a moment and realized we could define an import alias within the Web package to provide a much cleaner import root.

Build-bot: skip build:web
Test-bot: skip