### PR TITLE
chore(linux): use xz compression for source tarballs 🗜️

### DIFF
--- a/linux/scripts/deb.sh
+++ b/linux/scripts/deb.sh
@@ -15,14 +15,14 @@ mkdir -p builddebs
 
 # make the source packages
 cd builddebs
-vers=$(ls ../dist/keyman_*.orig.tar.gz)
+vers=$(ls ../dist/keyman_*.orig.tar.xz)
 #echo "vers1:${vers}"
 vers=${vers##*_}
 #echo "vers2:${vers}"
-vers=${vers%*.orig.tar.gz}
+vers=${vers%*.orig.tar.xz}
 #echo "vers3:${vers}"
-cp -a "../dist/keyman_${vers}.orig.tar.gz" .
-tar xfz "keyman_${vers}.orig.tar.gz"
+cp -a "../dist/keyman_${vers}.orig.tar.xz" .
+tar xfJ "keyman_${vers}.orig.tar.xz"
 cp -a ../../debian "keyman-${vers}"
 cd "keyman-${vers}"
 dch -v "${vers}-1" "local build"

--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -4,7 +4,7 @@
 # and put them in dist/
 
 # parameters: ./dist.sh [origdist] [proj]
-# origdist = create Debian orig.tar.gz
+# origdist = create Debian orig.tar.xz
 # proj = only make tarball for this project
 
 set -e
@@ -145,19 +145,19 @@ dpkg-source \
   \
   "${ignored_files[@]}" \
   \
-  -Zgzip -b .
+  -Zxz -b .
 
-mv ../keyman_"${KEYMAN_VERSION}".tar.gz linux/dist/keyman-"${KEYMAN_VERSION}".tar.gz
+mv ../keyman_"${KEYMAN_VERSION}".tar.xz linux/dist/keyman-"${KEYMAN_VERSION}".tar.xz
 echo "3.0 (quilt)" > debian/source/format
 cd "${BASEDIR}"
 
-# create orig.tar.gz
+# create orig.tar.xz
 if [[ ! -z "${create_origdist+x}" ]]; then
     cd "${KEYMAN_ROOT}/linux/dist"
     pkgvers="keyman-${KEYMAN_VERSION}"
-    tar xfz keyman-"${KEYMAN_VERSION}".tar.gz
+    tar xfJ keyman-"${KEYMAN_VERSION}".tar.xz
     mv -v keyman "${pkgvers}" 2>/dev/null || mv -v "$(find . -mindepth 1 -maxdepth 1 -type d)" "${pkgvers}"
-    tar cfz "keyman_${KEYMAN_VERSION}.orig.tar.gz" "${pkgvers}"
-    rm "keyman-${KEYMAN_VERSION}.tar.gz"
+    tar cfJ "keyman_${KEYMAN_VERSION}.orig.tar.xz" "${pkgvers}"
+    rm "keyman-${KEYMAN_VERSION}.tar.xz"
     rm -rf "${pkgvers}"
 fi

--- a/linux/scripts/package-build.inc.sh
+++ b/linux/scripts/package-build.inc.sh
@@ -42,8 +42,8 @@ function downloadSource() {
   uscan || (echo "ERROR: No new version available for ${proj}" >&2 && exit 1)
   cd ..
   mv "${proj}-${version}" "${BASEDIR}/${packageDir}"
-  mv "${proj}_${version}.orig.tar.gz" "${BASEDIR}/${packageDir}"
-  mv "${proj}-${version}.tar.gz" "${BASEDIR}/${packageDir}"
+  mv "${proj}_${version}.orig.tar.xz" "${BASEDIR}/${packageDir}"
+  mv "${proj}-${version}.tar.xz" "${BASEDIR}/${packageDir}"
   mv "${proj}"*.asc "${BASEDIR}/${packageDir}"
   rm "${proj}"*.debian.tar.xz
   cd "${BASEDIR}/${packageDir}" || exit

--- a/resources/build/utils.inc.sh
+++ b/resources/build/utils.inc.sh
@@ -14,7 +14,7 @@ _utils_inc_sh=1
 #   1: UPLOAD_DIR          Directory where artifact can be found
 #   2: ARTIFACT_FILENAME   Filename (without path) of artifact
 #   3: ARTIFACT_NAME       Descriptive name of artifact
-#   4: ARTIFACT_TYPE       File extension of artifact, without initial period (e.g. tar.gz)
+#   4: ARTIFACT_TYPE       File extension of artifact, without initial period (e.g. tar.xz)
 #   5: PLATFORM            Target platform for artifact
 #
 # TODO: Move to CI include?

--- a/resources/teamcity/linux/keyman-linux-release.sh
+++ b/resources/teamcity/linux/keyman-linux-release.sh
@@ -60,10 +60,10 @@ function _make_release_source_tarball() {
   ./scripts/reconf.sh
   PKG_CONFIG_PATH="${KEYMAN_ROOT}/core/build/arch/release/meson-private" ./scripts/dist.sh
   mkdir -p "upload/${KEYMAN_VERSION}"
-  cp -a dist/*.tar.gz "upload/${KEYMAN_VERSION}"
+  cp -a dist/*.tar.xz "upload/${KEYMAN_VERSION}"
   (
     cd "upload/${KEYMAN_VERSION}"
-    sha256sum ./*.tar.gz > SHA256SUMS
+    sha256sum ./*.tar.xz > SHA256SUMS
     builder_echo end "make source tarball" success "Make source tarball"
   )
 }
@@ -75,7 +75,7 @@ function _sign_source_tarball() {
 
     eval "$(gpg-agent -vv --daemon --allow-preset-passphrase --debug-level 9)"
     /usr/lib/gnupg/gpg-preset-passphrase --passphrase "${GPGKEYPW}" --preset "${GPGKEYGRIP}"
-    for f in ./*.tar.gz; do gpg --output "${f}.asc" -a --detach-sig "${f}"; done
+    for f in ./*.tar.xz; do gpg --output "${f}.asc" -a --detach-sig "${f}"; done
     /usr/lib/gnupg/gpg-preset-passphrase --forget "${GPGKEYGRIP}" || true
     builder_echo end "sign source tarball" success "Sign source tarball"
   )
@@ -84,10 +84,10 @@ function _sign_source_tarball() {
 function _publish_to_downloads() {
   builder_echo start "publish to downloads" "Publish to downloads.keyman.com"
 
-  local UPLOAD_DIR KEYMAN_TGZ
+  local UPLOAD_DIR KEYMAN_TXZ
 
   UPLOAD_DIR="upload/${KEYMAN_VERSION}"
-  KEYMAN_TGZ="keyman-${KEYMAN_VERSION}.tar.gz"
+  KEYMAN_TXZ="keyman-${KEYMAN_VERSION}.tar.xz"
 
   # Set permissions as required on download site
   builder_echo "Setting upload file permissions for downloads.keyman.com"
@@ -96,7 +96,7 @@ function _publish_to_downloads() {
   chmod g+w  "${UPLOAD_DIR}"/*
   chmod a+r  "${UPLOAD_DIR}"/*
 
-  write_download_info "${UPLOAD_DIR}" "${KEYMAN_TGZ}" "Keyman for Linux" tar.gz linux
+  write_download_info "${UPLOAD_DIR}" "${KEYMAN_TXZ}" "Keyman for Linux" tar.xz linux
   tc_rsync_upload "${UPLOAD_DIR}" "linux/${KEYMAN_TIER}"
 
   builder_echo end "publish to downloads" success "Publish to downloads.keyman.com"


### PR DESCRIPTION
Using the xz compression instead of gzip greatly reduces the size of the tarball.

Follows: #15566
Test-bot: skip