### PR TITLE
fix(linux): check for existing file before trying to install

### DIFF
--- a/linux/keyman-config/keyman_config/view_installed.py
+++ b/linux/keyman-config/keyman_config/view_installed.py
@@ -74,14 +74,18 @@ class ViewInstalledWindowBase(Gtk.Window):
         filter_text.set_name(_("KMP files"))
         filter_text.add_pattern("*.kmp")
         dlg.add_filter(filter_text)
-        response = dlg.run()
-        if response != Gtk.ResponseType.OK:
-            dlg.destroy()
-            return
+        while True:
+            response = dlg.run()
+            if response != Gtk.ResponseType.OK:
+                dlg.destroy()
+                return
 
-        file = dlg.get_filename()
-        dlg.destroy()
-        self.restart(self.install_file(file))
+            file = dlg.get_filename()
+            if file and os.path.isfile(file) and os.path.splitext(file)[1] == '.kmp':
+                dlg.destroy()
+                self.restart(self.install_file(file))
+                return
+            # Loop until we have a valid file or the user cancels the dialog
 
     def install_file(self, kmpfile, language=None):
         installDlg = InstallKmpWindow(kmpfile, viewkmp=self, language=language)


### PR DESCRIPTION
Under some circumstances it's possible that the user manages to select a directory instead of a kmp file, or manually enters a non-existing file. Is used to throw an error that we caught on Sentry; the user was able to continue to use the app. This change now checks for a valid file before trying to install the kmp file.

Fixes: #15572
Fixes: KEYMAN-LINUX-99

# User Testing

**TEST_FIX**: 

- start `km-config` and click the "Install keyboard" button
- in the "Choose a kmp file" dialog press <kbd>Ctrl</kbd>+<kbd>L</kbd> to get an input field
- enter an invalid path, e.g. `/homex`, and click Open
- verify that the file dialog stays open until you enter or select a valid file or cancel the dialog