### PR TITLE
chore(core): update API `changes.md` document 🎼

### DIFF
--- a/core/docs/api/changes.md
+++ b/core/docs/api/changes.md
@@ -2,6 +2,17 @@
 title: Changes - Keyman Core API
 ---
 
+## Changes between 18.0 and 19.0
+
+* Removed deprecated `km_core_keyboard_attrs.folder_path`
+
+## Changes between 17.0 and 18.0
+
+* Replaced `km_core_keyboard_load` with `km_core_keyboard_load_from_blob`.
+  Keyboard loading is now done in the engine, and the content of the
+  keyboard passed to Core as a blob.
+* Deprecated `km_core_keyboard_attrs.folder_path`
+
 ## Changes between 16.0 and 17.0
 
 * The namespace identifier has changed from `km_kbp_` to `km_core_`.


### PR DESCRIPTION
Turns out we have a document for the API changes, in addition to the release notes. That document got overlooked so far. This change now updates that doc with the API changes that happened since v17.

Build-bot: skip
Test-bot: skip
Follow-up-of: #15471
Follow-up-of: #12769