### PR TITLE
maint(ios): resolve compiler warnings with upgrade to 26.2

### DIFF
--- a/ios/keyman/Keyman/Keyman/Classes/SetUpViewController/SetUpViewController.swift
+++ b/ios/keyman/Keyman/Keyman/Classes/SetUpViewController/SetUpViewController.swift
@@ -49,7 +49,7 @@ class SetUpViewController: UIViewController, WKNavigationDelegate {
   func reloadKeymanHelp() {
     if let networkStatus = networkReachable?.connection {
       switch networkStatus {
-      case Reachability.Connection.none, Reachability.Connection.unavailable:
+      case Reachability.Connection.unavailable:
         loadFromLocal()
       default:
         loadFromServer()


### PR DESCRIPTION
Address compiler warnings that have appeared with Xcode and Swift version changes.

Test-bot: skip
Build-bot: skip release:ios
