### PR TITLE
fix(developer): handle window already destroyed when closing editor

### DIFF
--- a/common/windows/delphi/chromium/Keyman.UI.UframeCEFHost.pas
+++ b/common/windows/delphi/chromium/Keyman.UI.UframeCEFHost.pas
@@ -373,7 +373,7 @@ end;
 procedure TframeCEFHost.SetFocus;
 begin
   AssertVclThread;
-  if not FIsClosing and cefwp.CanFocus and Assigned(cef) then
+  if not FIsClosing and Assigned(cefwp) and Assigned(cef) and cefwp.CanFocus then
   begin
     GetParentForm(Self).ActiveControl := Self;
     cef.SetFocus(True);


### PR DESCRIPTION
Fixes: #15617
Fixes: KEYMAN-DEVELOPER-1JD
Fixes: KEYMAN-DEVELOPER-36K
Fixes: KEYMAN-DEVELOPER-2P5
Test-bot: skip