### PR TITLE
fix(developer): package compiler handle missing `info` section in .kps file

### DIFF
--- a/developer/src/kmc-package/src/compiler/kmp-compiler.ts
+++ b/developer/src/kmc-package/src/compiler/kmp-compiler.ts
@@ -206,7 +206,8 @@ export class KmpCompiler implements KeymanCompiler {
         fileVersion: null,
         keymanDeveloperVersion: KEYMAN_VERSION.VERSION
       },
-      options: {}
+      options: {},
+      info: {},
     };
 
     //


### PR DESCRIPTION
Fixes: #15619
Fixes: KEYMAN-DEVELOPER-27R
Test-bot: skip