### PR TITLE
fix(developer): use correct return values and nullish checks in package-validation

### DIFF
--- a/developer/src/kmc-package/src/compiler/package-validation.ts
+++ b/developer/src/kmc-package/src/compiler/package-validation.ts
@@ -70,7 +70,7 @@ export class PackageValidation {
   }
 
   private checkForModelsAndKeyboardsInSamePackage(kmpJson: KmpJsonFile.KmpJsonFile): boolean {
-    if(kmpJson.lexicalModels?.length > 0 && kmpJson.keyboards?.length > 0) {
+    if((kmpJson.lexicalModels?.length ?? 0) > 0 && (kmpJson.keyboards?.length ?? 0) > 0) {
       this.callbacks.reportMessage(PackageCompilerMessages.Error_PackageCannotContainBothModelsAndKeyboards());
       return false;
     }
@@ -120,7 +120,7 @@ export class PackageValidation {
     }
 
     for(const keyboard of kmpJson.keyboards) {
-      if(!this.checkForDuplicatedOrNonMinimalLanguages('keyboard', keyboard.id, keyboard.languages)) {
+      if(!this.checkForDuplicatedOrNonMinimalLanguages('keyboard', keyboard.id, keyboard.languages ?? [])) {
         return false;
       }
       // Note: package-version-validation verifies that there is a corresponding
@@ -131,7 +131,7 @@ export class PackageValidation {
   }
 
   private checkContentFiles(kmpJson: KmpJsonFile.KmpJsonFile, outputFilename: string): boolean {
-    for(const file of kmpJson.files) {
+    for(const file of kmpJson.files ?? []) {
       if(!this.checkContentFile(file, outputFilename)) {
         return false;
       }
@@ -202,7 +202,7 @@ export class PackageValidation {
     return true;
   }
 
-  private checkPackageInfo(file: KmpJsonFile.KmpJsonFile) {
+  private checkPackageInfo(file: KmpJsonFile.KmpJsonFile): boolean {
     if(!file.info || !file.info.name || !file.info.name.description.trim()) {
       this.callbacks.reportMessage(PackageCompilerMessages.Error_PackageNameCannotBeBlank());
       return false;
@@ -214,11 +214,11 @@ export class PackageValidation {
       /* c8 ignore next 3 */
       if (match === null) {
         this.callbacks.reportMessage(PackageCompilerMessages.Error_InvalidAuthorEmail({email:file.info.author.url}));
-        return null;
+        return false;
       }
       if(!isValidEmail(match[2])) {
         this.callbacks.reportMessage(PackageCompilerMessages.Error_InvalidAuthorEmail({email:file.info.author.url}));
-        return null;
+        return false;
       }
 
     }


### PR DESCRIPTION
Turned on strictNullChecks to verify the file and found a few other problems in this file. However, there are many null check errors reported across the kmc-package source which should be addressed in a future patch. (This is a broader problem for the entire Typescript source of Keyman.)

Fixes: #15627
Test-bot: skip
Build-bot: skip build:developer