### PR TITLE
maint(ios): update fv Cartfile for Xcode 26

### DIFF
--- a/oem/firstvoices/ios/Cartfile
+++ b/oem/firstvoices/ios/Cartfile
@@ -1,4 +1,4 @@
 github "weichsel/ZIPFoundation" ~> 0.9
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
-github "getsentry/sentry-cocoa" ~> 8.38.0
+github "getsentry/sentry-cocoa" ~> 8.58.0

--- a/oem/firstvoices/ios/Cartfile.resolved
+++ b/oem/firstvoices/ios/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "ashleymills/Reachability.swift" "v5.2.4"
-github "devicekit/DeviceKit" "5.5.0"
-github "getsentry/sentry-cocoa" "8.44.0"
-github "weichsel/ZIPFoundation" "0.9.19"
+github "devicekit/DeviceKit" "5.7.0"
+github "getsentry/sentry-cocoa" "8.58.0"
+github "weichsel/ZIPFoundation" "0.9.20"


### PR DESCRIPTION
Update Carthage file to specify version 8.58 of Sentry for compatible with Xcode 26.

Test-bot: skip
Build-bot: skip release:ios