### PR TITLE
chore(android): Cleanup unused Extracted Text

### DIFF
--- a/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java
@@ -203,8 +203,9 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
         return value, so we test for that as well (#11479)
       */
       if (icText != null && icText.text != null) {
-        boolean didUpdateText = KMManager.updateText(KeyboardType.KEYBOARD_TYPE_SYSTEM, icText.text.toString());
-        boolean didUpdateSelection = KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_SYSTEM);
+        // Update the text selection but ignore the returned statuses
+        KMManager.updateText(KeyboardType.KEYBOARD_TYPE_SYSTEM, icText.text.toString());
+        KMManager.updateSelectionRange(KeyboardType.KEYBOARD_TYPE_SYSTEM);
       }
     }
 


### PR DESCRIPTION
While investigating #15226, afaict SystemKeyboard has an `ExtractedText extText` that never gets used. 
This existed back in the [Keyman for Android 2.8](https://github.com/keymanapp/keyman/blob/2b3fa63cea49f47201226d74d35ad57f25d2385e/android/KMAPro/kMAPro/src/main/java/com/keyman/android/SystemKeyboard.java#L29) days

KMSample2 SystemKeyboard does not have this.

May separately propagate this cleanup to FirstVoices.SystemKeyboard too...

Test-bot: skip
