### PR TITLE
fix(web): clean unit test artifacts on 'test' action

### DIFF
--- a/web/common.inc.sh
+++ b/web/common.inc.sh
@@ -96,7 +96,14 @@ function test-headless() {
   if [ ! -z "${2:-}" ]; then
     TEST_BASE="${KEYMAN_ROOT}/web/build/test/headless/"
 
-    # Ensure the compiled tests are available.
+    # If a unit test spec file exists on branch A and not branch B, the test
+    # artifact should be removed to prevent errors should the test attempt to
+    # reference code specific to branch A (or similar).
+    #
+    # To do a proper clean & reset to the current branch's test set, we need to
+    # nuke the tsconfig.tsbuildinfo file specifically; tsc won't actually verify
+    # that the most recently compiled files actually still exist!
+    rm -rf "${KEYMAN_ROOT}/web/build/test/"
     tsc --project "${KEYMAN_ROOT}/web/src/test/auto/tsconfig.json"
   fi
 

--- a/web/common.inc.sh
+++ b/web/common.inc.sh
@@ -99,11 +99,13 @@ function test-headless() {
     # If a unit test spec file exists on branch A and not branch B, the test
     # artifact should be removed to prevent errors should the test attempt to
     # reference code specific to branch A (or similar).
-    #
-    # To do a proper clean & reset to the current branch's test set, we need to
-    # nuke the tsconfig.tsbuildinfo file specifically; tsc won't actually verify
-    # that the most recently compiled files actually still exist!
-    rm -rf "${KEYMAN_ROOT}/web/build/test/"
+    rm -rf "${TEST_BASE}"
+
+    # To do a proper clean & reset to the current branch's headless test set, we
+    # need to nuke the tsconfig.tsbuildinfo file specifically; tsc won't
+    # actually verify that the most recently compiled files actually still
+    # exist!
+    rm "${KEYMAN_ROOT}/web/build/test/tsconfig.tsbuildinfo"
     tsc --project "${KEYMAN_ROOT}/web/src/test/auto/tsconfig.json"
   fi
 


### PR DESCRIPTION
When swapping branches, it is possible for build artifacts for a unit test defined on one branch to exist on another.  If that unit test refers to code that does not exist on the current branch, test actions will fail due to the invalid reference.

While a simple clean would seem the easy solution, our call patterns for tsc-based builds tend to completely skip compilation for deleted unit-test artifacts if the tsconfig.buildinfo is still in place.  We need to nuke that file specifically as part of this process.

I've personally run into this scenario a _lot_ while working on epic/autocorrect, which is what motivated me to make this PR.

Build-bot: skip build:web
Test-bot: skip