### PR TITLE
fix(web): remove legacy-spur specific handling 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
@@ -362,11 +362,8 @@ export abstract class SearchQuotientSpur implements SearchQuotientNode {
 
     // Forbid a raw edit-distance of greater than 2.
     // Note:  .knownCost is not scaled, while its contribution to .currentCost _is_ scaled.
-    let substitutionsOnly = false;
     if(currentNode.editCount > 2) {
       return unmatchedResult as PathResult;
-    } else if(currentNode.editCount == 2) {
-      substitutionsOnly = true;
     }
 
     // Thresholds _any_ path, partially based on currently-traversed distance.
@@ -387,12 +384,6 @@ export abstract class SearchQuotientSpur implements SearchQuotientNode {
 
     // OK, we fully crossed a graph edge and have landed on a transition point;
     // time to build more edges / edge batches.
-
-    // Always possible, as this does not require any new input.
-    if(!substitutionsOnly) {
-      let insertionEdges = currentNode.buildInsertionEdges();
-      this.selectionQueue.enqueueAll(insertionEdges);
-    }
 
     if(currentNode.spaceId == this.spaceId) {
       if(this.returnedValues) {


### PR DESCRIPTION
The removed bits of code were already refactored into LegacyQuotientSpur's implementation.  They just... weren't removed from their original source.

There's a chance that the original removal got undone during a rebase, but either way, it's best to do this cleanup now, as this code would impact some of the specialized spur code coming up.

Build-bot: skip build:web
Test-bot: skip