### PR TITLE
maint(developer): cleanup additional TestCompilerCallbacks references

### DIFF
--- a/developer/src/common/web/utils/test/kpj/kpj-file-writer.tests.ts
+++ b/developer/src/common/web/utils/test/kpj/kpj-file-writer.tests.ts
@@ -1,4 +1,7 @@
-import * as fs from 'fs';
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
+import * as fs from 'node:fs';
 import 'mocha';
 import {assert} from 'chai';
 import { makePathToFixture } from '../helpers/index.js';
@@ -8,13 +11,13 @@ import { KPJFileWriter } from '../../src/types/kpj/kpj-file-writer.js';
 import { KeymanDeveloperProjectOptions } from '../../src/types/kpj/keyman-developer-project.js';
 import { SymbolUtils } from '../../src/symbol-utils.js';
 
-const callbacks = new TestCompilerCallbacks();
-
 describe('kpj-file-writer', function () {
+  const callbacks = new TestCompilerCallbacks(this);
+
   it('kpj-file-writer should write a valid v1.0 file', async function() {
     const kpjPath = 'khmer_angkor.kpj';
     const path = makePathToFixture('kpj', kpjPath);
-    const input = fs.readFileSync(path);
+    const input = fs.readFileSync(path) as Uint8Array;
     const reader = new KPJFileReader(callbacks);
     const inputKpj = reader.read(input);
     reader.validate(inputKpj);
@@ -53,7 +56,7 @@ describe('kpj-file-writer', function () {
   it('kpj-file-writer should write a valid v2.0 file', async function() {
     const kpjPath = 'khmer_angkor.kpj';
     const path = makePathToFixture('kpj', kpjPath);
-    const input = fs.readFileSync(path);
+    const input = fs.readFileSync(path) as Uint8Array;
     const reader = new KPJFileReader(callbacks);
     const inputKpj = reader.read(input);
     reader.validate(inputKpj);

--- a/developer/src/common/web/utils/test/kps/kps-file-reader.tests.ts
+++ b/developer/src/common/web/utils/test/kps/kps-file-reader.tests.ts
@@ -4,7 +4,7 @@
  * Created by mcdurdin on 2024-10-16
  */
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import 'mocha';
 import {assert} from 'chai';
 
@@ -20,20 +20,10 @@ import { DeveloperUtilsMessages } from '../../src/developer-utils-messages.js';
 
 describe('kps-file-reader', function () {
 
-  const callbacks = new TestCompilerCallbacks();
-
-  this.beforeEach(function() {
-    callbacks.clear();
-  });
-
-  this.afterEach(function() {
-    if(this.currentTest?.isFailed()) {
-      callbacks.printMessages();
-    }
-  });
+  const callbacks = new TestCompilerCallbacks(this);
 
   it('kps-file-reader should read a valid file', function() {
-    const input = fs.readFileSync(makePathToFixture('kps', 'khmer_angkor.kps'));
+    const input = fs.readFileSync(makePathToFixture('kps', 'khmer_angkor.kps')) as Uint8Array;
     const reader = new KpsFileReader(callbacks);
     const kps = reader.read(input);
 
@@ -70,7 +60,7 @@ describe('kps-file-reader', function () {
   });
 
   it('kps-file-reader should round-trip with kps-file-writer', function() {
-    const input = fs.readFileSync(makePathToFixture('kps', 'khmer_angkor.kps'));
+    const input = fs.readFileSync(makePathToFixture('kps', 'khmer_angkor.kps')) as Uint8Array;
     const reader = new KpsFileReader(callbacks);
     // Remove XML metadata symbols to reduce clutter for testing purposes
     const kps = SymbolUtils.removeSymbols(reader.read(input));
@@ -87,7 +77,7 @@ describe('kps-file-reader', function () {
   // ERROR_InvalidPackageFile
 
   it('should generate ERROR_InvalidPackageFile if package source file contains invalid XML', async function() {
-    const input = fs.readFileSync(makePathToFixture('kps', 'error_invalid_package_file.kps'));
+    const input = fs.readFileSync(makePathToFixture('kps', 'error_invalid_package_file.kps')) as Uint8Array;
     const reader = new KpsFileReader(callbacks);
     const kps = reader.read(input);
 
@@ -99,7 +89,7 @@ describe('kps-file-reader', function () {
   // ERROR_NotAPackageFile
 
   it(`should generate ERROR_NotAPackageFile when the package source file is valid XML but does not have a <Package> root element`, function () {
-    const input = fs.readFileSync(makePathToFixture('kps', 'error_not_a_package_file.kps'));
+    const input = fs.readFileSync(makePathToFixture('kps', 'error_not_a_package_file.kps')) as Uint8Array;
     const reader = new KpsFileReader(callbacks);
     const kps = reader.read(input);
 

--- a/developer/src/kmc-analyze/test/analyzer-messages.tests.ts
+++ b/developer/src/kmc-analyze/test/analyzer-messages.tests.ts
@@ -11,17 +11,7 @@ import { AnalyzeOskCharacterUse } from '../src/osk-character-use/index.js';
 
 describe('AnalyzerMessages', function () {
 
-  const callbacks = new TestCompilerCallbacks();
-
-  this.beforeEach(function() {
-    callbacks.clear();
-  });
-
-  this.afterEach(function() {
-    if(this.currentTest?.isFailed()) {
-      callbacks.printMessages();
-    }
-  });
+  const callbacks = new TestCompilerCallbacks(this);
 
   it('should have a valid AnalyzerMessages object', function() {
     return verifyCompilerMessagesObject(AnalyzerMessages, CompilerErrorNamespace.Analyzer);

--- a/developer/src/kmc-analyze/test/osk-character-use-format.tests.ts
+++ b/developer/src/kmc-analyze/test/osk-character-use-format.tests.ts
@@ -7,22 +7,12 @@ import { AnalyzeOskCharacterUse } from '../src/osk-character-use/index.js';
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 
 describe('AnalyzeOskCharacterUse output formats', function() {
-  const callbacks = new TestCompilerCallbacks();
+  const callbacks = new TestCompilerCallbacks(this);
 
   const dummyStrings = {
     'a': [{ filename: 'file1.kvks', count: 1 }],
     'b': [{ filename: 'file2.kvks', count: 2 }]
   };
-
-  this.beforeEach(function() {
-    callbacks.clear();
-  });
-
-  this.afterEach(function() {
-    if (this.currentTest?.isFailed()) {
-      callbacks.printMessages();
-    }
-  });
 
   it('generates .txt format correctly', function() {
     const a = new AnalyzeOskCharacterUse(callbacks, { includeCounts: true });

--- a/developer/src/kmc-analyze/test/osk-character-use-messages.tests.ts
+++ b/developer/src/kmc-analyze/test/osk-character-use-messages.tests.ts
@@ -9,7 +9,7 @@ import { AnalyzerMessages } from '../src/analyzer-messages.js';
 import { makePathToFixture } from './helpers/index.js';
 
 describe('AnalyzeOskCharacterUse warnings', function() {
-  const callbacks = new TestCompilerCallbacks();
+  const callbacks = new TestCompilerCallbacks(this);
 
   const MOCK_MAP_NO_COUNTS = makePathToFixture(
     'osk-character-use',
@@ -20,16 +20,6 @@ describe('AnalyzeOskCharacterUse warnings', function() {
     'mock-map-with-counts.json'
   );
 
-  this.beforeEach(function() {
-    callbacks.clear();
-  });
-
-  this.afterEach(function() {
-    if (this.currentTest?.isFailed()) {
-      callbacks.printMessages();
-    }
-  });
-
   it('warns if previous map did not include counts but includeCounts=true', function() {
     const a = new AnalyzeOskCharacterUse(callbacks, {
       includeCounts: true
@@ -37,7 +27,7 @@ describe('AnalyzeOskCharacterUse warnings', function() {
 
     const result = a.unitTestEndPoints.loadPreviousMap(MOCK_MAP_NO_COUNTS);
     assert.isNotNull(result, 'Expected map to be loaded successfully');
-    
+
     assert.isTrue(
       callbacks.hasMessage(AnalyzerMessages.WARN_PreviousMapDidNotIncludeCounts),
       'Expected Warn_PreviousMapDidNotIncludeCounts warning'

--- a/developer/src/kmc-analyze/test/osk-character-use.tests.ts
+++ b/developer/src/kmc-analyze/test/osk-character-use.tests.ts
@@ -17,17 +17,7 @@ const SIL_KHMER_KVKS = makePathToFixture('khmer', "sil_khmer.kvks");
 const KBDKHMR_WITH_SIL_KHMER_JSON = makePathToFixture('khmer', "KbdKhmr-with-sil_khmer.json");
 
 describe('AnalyzeOskCharacterUse', function () {
-  const callbacks = new TestCompilerCallbacks();
-
-  this.beforeEach(function() {
-    callbacks.clear();
-  });
-
-  this.afterEach(function() {
-    if(this.currentTest?.isFailed()) {
-      callbacks.printMessages();
-    }
-  });
+  const callbacks = new TestCompilerCallbacks(this);
 
   it('generates a mapping file from 2 input files', async function() {
     // functional test

--- a/developer/src/kmc-generate/test/abstract-generator.tests.ts
+++ b/developer/src/kmc-generate/test/abstract-generator.tests.ts
@@ -3,26 +3,16 @@
  */
 
 import 'mocha';
-import * as path from 'path';
-import * as os from 'os';
-import * as fs from 'fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
 import { assert } from 'chai';
 import { AbstractGenerator, GeneratorArtifacts } from '../src/abstract-generator.js';
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { options } from './shared-options.js';
 
 describe('AbstractGenerator', function () {
-  const callbacks = new TestCompilerCallbacks();
-
-  this.beforeEach(function() {
-    callbacks.clear();
-  });
-
-  this.afterEach(function() {
-    if(this.currentTest.isFailed()) {
-      callbacks.printMessages();
-    }
-  });
+  const callbacks = new TestCompilerCallbacks(this);
 
   it('should write out files successfully', async function() {
     const ag = new AbstractGenerator();
@@ -40,7 +30,7 @@ describe('AbstractGenerator', function () {
     };
     assert.isTrue(await ag.write(artifacts));
     assert.isTrue(fs.existsSync(filename));
-    const buf = fs.readFileSync(filename);
+    const buf = fs.readFileSync(filename) as Uint8Array;
     assert.deepEqual(buf, data);
 
     fs.unlinkSync(filename);

--- a/developer/src/kmc-generate/test/basic-generator.tests.ts
+++ b/developer/src/kmc-generate/test/basic-generator.tests.ts
@@ -32,9 +32,10 @@ class BasicGeneratorTest extends BasicGenerator {
 }
 
 describe('BasicGenerator', function () {
+  const callbacks = new TestCompilerCallbacks(this);
+
   it('should configure default settings', async function() {
     const bg = new BasicGenerator();
-    const callbacks = new TestCompilerCallbacks();
     assert.isTrue(await bg.init(callbacks, options));
     assert.isTrue(bg.test_preGenerate());
 
@@ -45,7 +46,6 @@ describe('BasicGenerator', function () {
     const bg = new BasicGeneratorTest();
     bg.setup();
 
-    const callbacks = new TestCompilerCallbacks();
     assert.isTrue(await bg.init(callbacks, options));
     assert.isTrue(bg.test_preGenerate());
 

--- a/developer/src/kmc-generate/test/generator-messages.tests.ts
+++ b/developer/src/kmc-generate/test/generator-messages.tests.ts
@@ -22,17 +22,7 @@ import { LexicalModelGenerator } from '../src/lexical-model-generator.js';
 import { options } from './shared-options.js';
 
 describe('GeneratorMessages', function () {
-  const callbacks = new TestCompilerCallbacks();
-
-  this.beforeEach(function() {
-    callbacks.clear();
-  });
-
-  this.afterEach(function() {
-    if(this.currentTest.isFailed()) {
-      callbacks.printMessages();
-    }
-  });
+  const callbacks = new TestCompilerCallbacks(this);
 
   it('should have a valid GeneratorMessages object', function() {
     return verifyCompilerMessagesObject(GeneratorMessages, CompilerErrorNamespace.Generator);
@@ -78,7 +68,6 @@ describe('GeneratorMessages', function () {
       targets: ['invalid']
     };
     const bg = new BasicGenerator();
-    const callbacks = new TestCompilerCallbacks();
     assert(await bg.init(callbacks, testOptions));
     assert.isFalse(bg.test_preGenerate());
     assert.isTrue(callbacks.hasMessage(GeneratorMessages.ERROR_InvalidTarget));
@@ -89,7 +78,6 @@ describe('GeneratorMessages', function () {
       id: '???invalid',
     };
     const kkg = new KeymanKeyboardGenerator();
-    const callbacks = new TestCompilerCallbacks();
     assert.isTrue(await kkg.init(callbacks, testOptions));
     assert.isNull(await kkg.run());
     assert.isTrue(callbacks.hasMessage(GeneratorMessages.ERROR_InvalidKeymanKeyboardId));
@@ -100,7 +88,6 @@ describe('GeneratorMessages', function () {
       id: '???invalid',
     };
     const lkg = new LdmlKeyboardGenerator();
-    const callbacks = new TestCompilerCallbacks();
     assert.isTrue(await lkg.init(callbacks, testOptions));
     assert.isNull(await lkg.run());
     assert.isTrue(callbacks.hasMessage(GeneratorMessages.ERROR_InvalidLdmlKeyboardId));
@@ -111,7 +98,6 @@ describe('GeneratorMessages', function () {
       id: 'example.???.invalid',
     };
     const lmg = new LexicalModelGenerator();
-    const callbacks = new TestCompilerCallbacks();
     assert.isTrue(await lmg.init(callbacks, testOptions));
     assert.isNull(await lmg.run());
     assert.isTrue(callbacks.hasMessage(GeneratorMessages.ERROR_InvalidLexicalModelId));

--- a/developer/src/kmc-generate/test/keyman-keyboard-generator.tests.ts
+++ b/developer/src/kmc-generate/test/keyman-keyboard-generator.tests.ts
@@ -33,6 +33,8 @@ function getFilenames(p: string, base?: string): string[] {
 describe('KeymanKeyboardGenerator', function () {
   let clock: sinon.SinonFakeTimers;
 
+  const callbacks = new TestCompilerCallbacks(this);
+
   before(function() {
     // We will always be 12 April 2024 to match test fixtures
     clock = sinon.useFakeTimers(new Date(2024, 3, 12));
@@ -44,7 +46,6 @@ describe('KeymanKeyboardGenerator', function () {
 
   it('should generate a Keyman keyboard from provided options', async function() {
     const generator = new KeymanKeyboardGenerator();
-    const callbacks = new TestCompilerCallbacks();
     assert(await generator.init(callbacks, options));
     const result = await generator.run();
     assert.exists(result);

--- a/developer/src/kmc-generate/test/ldml-keyboard-generator.tests.ts
+++ b/developer/src/kmc-generate/test/ldml-keyboard-generator.tests.ts
@@ -33,6 +33,8 @@ function getFilenames(p: string, base?: string): string[] {
 describe('LdmlKeyboardGenerator', function () {
   let clock: sinon.SinonFakeTimers;
 
+  const callbacks = new TestCompilerCallbacks(this);
+
   before(function() {
     // We will always be 12 April 2024 to match test fixtures
     clock = sinon.useFakeTimers(new Date(2024, 3, 12));
@@ -44,7 +46,6 @@ describe('LdmlKeyboardGenerator', function () {
 
   it('should generate a LDML keyboard from provided options', async function() {
     const generator = new LdmlKeyboardGenerator();
-    const callbacks = new TestCompilerCallbacks();
     assert(await generator.init(callbacks, options));
     const result = await generator.run();
     assert.exists(result);

--- a/developer/src/kmc-package/test/package-compiler.tests.ts
+++ b/developer/src/kmc-package/test/package-compiler.tests.ts
@@ -136,8 +136,6 @@ describe('KmpCompiler', function () {
    */
 
   it(`should transform a .kps file for a keyboard package to a correct kmp.json`, function () {
-    callbacks.clear();
-
     const kpsPath = makePathToFixture('kmp.json', 'ahom_star.kps');
     const kmpJsonRefPath = makePathToFixture('kmp.json', 'kmp.json');
 
@@ -163,12 +161,8 @@ describe('KmpCompiler', function () {
   });
 
   it(`should support .kps 17.0 metadata correctly`, function () {
-    callbacks.clear();
-
     const kpsPath = makePathToFixture('kmp_2.0', 'khmer_angkor.kps');
     const kmpJsonRefPath = makePathToFixture('kmp_2.0', 'kmp.json');
-
-    debugger;
 
     const kmpJsonActual = kmpCompiler.transformKpsToKmpObject(kpsPath);
     if(kmpJsonActual == null) {
@@ -197,8 +191,6 @@ describe('KmpCompiler', function () {
   it('should warn on absolute paths', async function() {
     this.timeout(10000); // building a zip file can sometimes be slow
 
-    callbacks.clear();
-
     const kpsPath = makePathToFixture('absolute_path', 'source', 'absolute_path.kps');
     const kmpCompiler = new KmpCompiler();
     assert.isTrue(await kmpCompiler.init(callbacks, null));
@@ -224,8 +216,6 @@ describe('KmpCompiler', function () {
 
   it('should normalize DOS pathnames from \\ to /', async function() {
     // this.timeout(10000); // building a zip file can sometimes be slow
-
-    callbacks.clear();
 
     const kpsPath = makePathToFixture('normalize_paths', 'source', 'khmer_angkor.kps');
     const kmpCompiler = new KmpCompiler();

--- a/developer/src/kmc/test/build.tests.ts
+++ b/developer/src/kmc/test/build.tests.ts
@@ -1,11 +1,12 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { clearOptions } from '../src/util/options.js';
 import { assert } from 'chai';
 import 'mocha';
 import { BuildProject } from '../src/commands/buildClasses/BuildProject.js';
 import { makePathToFixture } from './helpers/index.js';
-
-const callbacks = new TestCompilerCallbacks();
 
 interface CompilerWarningsAsErrorsTruthTable {
   cli: boolean;
@@ -14,8 +15,9 @@ interface CompilerWarningsAsErrorsTruthTable {
 };
 
 describe('compilerWarningsAsErrors', function () {
-  beforeEach(() => {
-    callbacks.clear();
+  const callbacks = new TestCompilerCallbacks(this);
+
+  this.beforeEach(function() {
     clearOptions();
   });
 

--- a/developer/src/kmc/test/extendedCompilerOptions.tests.ts
+++ b/developer/src/kmc/test/extendedCompilerOptions.tests.ts
@@ -1,3 +1,6 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { assert } from 'chai';
 import 'mocha';
@@ -10,10 +13,7 @@ interface MessageTest {input: string, result: CompilerMessageOverride};
 interface InvalidMessageTest {input: string, code: number};
 
 describe('commandOptionsMessageToCompilerOptionsMessage', function () {
-  const callbacks = new TestCompilerCallbacks();
-  this.beforeEach(function() {
-    callbacks.clear();
-  });
+  const callbacks = new TestCompilerCallbacks(this);
 
   const valid: MessageTest[] = [
     // Test the allowable coercions

--- a/developer/src/kmc/test/fileLists.tests.ts
+++ b/developer/src/kmc/test/fileLists.tests.ts
@@ -1,10 +1,11 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { assert } from 'chai';
 import 'mocha';
 import { makePathToFixture } from './helpers/index.js';
 import { expandFileList, expandFileLists } from '../src/util/fileLists.js';
-
-const callbacks = new TestCompilerCallbacks();
 
 // expandFileList expands each file name relative to the file list's supplied
 // filename, so we need to compare against the full path.
@@ -21,11 +22,9 @@ const expectedFiles = [
   'file5.kmn'
 ];
 
-beforeEach(function() {
-  callbacks.clear();
-});
-
 describe('expandFileList', function () {
+  const callbacks = new TestCompilerCallbacks(this);
+
   it('should report a missing filelist correctly', async function() {
     const path = makePathToFixture('file-lists', 'does-not-exist.txt');
 
@@ -45,6 +44,8 @@ describe('expandFileList', function () {
 });
 
 describe('expandFileLists', function () {
+  const callbacks = new TestCompilerCallbacks(this);
+
   it('should splice a filelist in correctly', async function() {
     // We just use this to test the splicing so no path resolution is made
     const files = [

--- a/developer/src/kmc/test/generateKmnKeyboard.tests.ts
+++ b/developer/src/kmc/test/generateKmnKeyboard.tests.ts
@@ -1,3 +1,6 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -28,17 +31,15 @@ describe('generateKeymanKeyboard', function() {
     description: 'Sample Keyboard Test',
   };
 
-  const callbacks: TestCompilerCallbacks = new TestCompilerCallbacks();
+  const callbacks: TestCompilerCallbacks = new TestCompilerCallbacks(this);
   let outPath: string = null;
 
   this.beforeEach(function() {
-    callbacks.clear();
     outPath = fs.mkdtempSync(path.join(os.tmpdir(), 'kmc-'));
   });
 
   this.afterEach(function() {
     if(this.currentTest.isFailed()) {
-      callbacks.printMessages();
       console.error(`Output kept at ${outPath}`);
     } else {
       if(outPath) fs.rmSync(outPath, {recursive: true, force: true});

--- a/developer/src/kmc/test/generateLdmlKeyboard.tests.ts
+++ b/developer/src/kmc/test/generateLdmlKeyboard.tests.ts
@@ -1,3 +1,6 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -28,17 +31,15 @@ describe('generateLdmlKeyboard', function() {
     description: 'Sample Keyboard Test',
   };
 
-  const callbacks: TestCompilerCallbacks = new TestCompilerCallbacks();
+  const callbacks: TestCompilerCallbacks = new TestCompilerCallbacks(this);
   let outPath: string = null;
 
   this.beforeEach(function() {
-    callbacks.clear();
     outPath = fs.mkdtempSync(path.join(os.tmpdir(), 'kmc-'));
   });
 
   this.afterEach(function() {
     if(this.currentTest.isFailed()) {
-      callbacks.printMessages();
       console.error(`Output kept at ${outPath}`);
     } else {
       if(outPath) fs.rmSync(outPath, {recursive: true, force: true});

--- a/developer/src/kmc/test/generateLexicalModel.tests.ts
+++ b/developer/src/kmc/test/generateLexicalModel.tests.ts
@@ -1,3 +1,6 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -27,17 +30,15 @@ describe('generateLexicalModel', function() {
     description: 'Sample Model Test',
   };
 
-  const callbacks: TestCompilerCallbacks = new TestCompilerCallbacks();
+  const callbacks: TestCompilerCallbacks = new TestCompilerCallbacks(this);
   let outPath: string = null;
 
   this.beforeEach(function() {
-    callbacks.clear();
     outPath = fs.mkdtempSync(path.join(os.tmpdir(), 'kmc-'));
   });
 
   this.afterEach(function() {
     if(this.currentTest.isFailed()) {
-      callbacks.printMessages();
       console.error(`Output kept at ${outPath}`);
     } else {
       if(outPath) fs.rmSync(outPath, {recursive: true, force: true});

--- a/developer/src/kmc/test/project-build.tests.ts
+++ b/developer/src/kmc/test/project-build.tests.ts
@@ -1,3 +1,6 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
 import { TestCompilerCallbacks } from '@keymanapp/developer-test-helpers';
 import { assert } from 'chai';
 import 'mocha';
@@ -6,9 +9,10 @@ import { makePathToFixture } from './helpers/index.js';
 import { InfrastructureMessages } from '../src/messages/infrastructureMessages.js';
 import { clearOptions } from '../src/util/options.js';
 
-const callbacks = new TestCompilerCallbacks();
 
 describe('BuildProject', function () {
+  const callbacks = new TestCompilerCallbacks(this);
+
   it('should build a keyboard project', async function() {
     clearOptions();
     const builder = new BuildProject();


### PR DESCRIPTION
Address a review comment from #15665 and cleanup additional references that I missed the first time around, along with the `fs.readFileSync` `Uint8Array` cast.

Follows: #15665
Test-bot: skip