### PR TITLE
fix(web): clarify check for infinite search-path cost 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
@@ -331,13 +331,14 @@ export abstract class SearchQuotientSpur implements SearchQuotientNode {
     const parentCost = this.parentNode?.currentCost ?? Number.POSITIVE_INFINITY;
     const localCost = this.selectionQueue.peek()?.currentCost ?? Number.POSITIVE_INFINITY;
 
-    if(parentCost <= localCost) {
-      if(parentCost == Number.POSITIVE_INFINITY) {
-        return {
-          type: 'none'
-        };
-      }
+    if(localCost == Number.POSITIVE_INFINITY && parentCost == Number.POSITIVE_INFINITY) {
+      // Only occurs when there's nothing more to search.
+      return {
+        type: 'none'
+      };
+    }
 
+    if(parentCost <= localCost) {
       const result = this.parentNode.handleNextNode();
 
       if(result.type == 'complete') {


### PR DESCRIPTION
This is motivated in part by an upcoming tweak likely to be made as part of #15162 that would otherwise impact this check.

Build-bot: skip build:web
Test-bot: skip