### PR TITLE
chore(web): remove implicit any type when setting processingConfig.itemIdentifier

### DIFF
--- a/web/src/engine/osk/gesture-processor/src/engine/configuration/gestureRecognizerConfiguration.ts
+++ b/web/src/engine/osk/gesture-processor/src/engine/configuration/gestureRecognizerConfiguration.ts
@@ -120,7 +120,7 @@ export function preprocessRecognizerConfig<HoveredItemType, StateToken = any>(
   processingConfig.maxRoamingBounds = processingConfig.maxRoamingBounds ?? processingConfig.targetRoot;
   processingConfig.safeBounds       = processingConfig.safeBounds       ?? new PaddedZoneSource([2]);
 
-  processingConfig.itemIdentifier   = processingConfig.itemIdentifier   ?? (() => null);
+  processingConfig.itemIdentifier   = processingConfig.itemIdentifier   ?? ((): HoveredItemType => null);
   processingConfig.recordingMode = !!processingConfig.recordingMode;
   processingConfig.historyLength = (processingConfig.historyLength ?? 0) > 0 ? processingConfig.historyLength : 0;
 


### PR DESCRIPTION
Not exactly clear what triggered [this](https://build.palaso.org/buildConfiguration/KeymanAndroid_TestPullRequests/610081?buildTab=log&linesState=136&logView=flowAware&expandAll=true&focusLine=415)? Perhaps related to npm package updates, but hard to see how.

Test-bot: skip
Build-bot: skip build:web