### PR TITLE
maint(common): rollback from Typescript 5.8.2 to 5.4.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "sinon": "^17.0.1",
         "source-map-support": "^0.5.21",
         "tslib": "^2.5.2",
-        "typescript": "^5.4.5"
+        "typescript": "~5.4.5"
       },
       "engines": {
         "node": "20.16.0"
@@ -2018,6 +2018,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -13304,9 +13318,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sinon": "^17.0.1",
     "source-map-support": "^0.5.21",
     "tslib": "^2.5.2",
-    "typescript": "^5.4.5"
+    "typescript": "~5.4.5"
   },
   "scripts": {},
   "workspaces": [


### PR DESCRIPTION
Pull request #15647 bumped our version of tsc from 5.4.5 to 5.8.2, because api-extractor wanted it. We have not tested yet with 5.8.2 and there are some incompatibility warnings and a new error that was patched in #15689.

We will upgrade to a later version of Typescript in due course, but now is not the time.

With this patch, we rollback our Typescript version to 5.4.x.

Sample warning from build:

```
[web/src/engine/osk/gesture-processor/src/tools] ## build:test-module starting...
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=4.7.4 <5.5.0

YOUR TYPESCRIPT VERSION: 5.8.2

Please only submit bug reports when using the officially supported version.

=============
```

Report of typescript version usage with this patch:

```
$ npm ls typescript
root@ D:\Projects\keyman\app
├─┬ @keymanapp/auto-history-action@ -> .\resources\build\version
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/common-test-resources@ -> .\common\test\resources
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/common-types@ -> .\common\web\types
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/developer-server@ -> .\developer\src\server
│ ├─┬ tsc-watch@4.6.2
│ │ └── typescript@5.4.5 deduped
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/developer-test-helpers@ -> .\developer\src\common\web\test-helpers
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/developer-utils@ -> .\developer\src\common\web\utils
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/gesture-recognizer@ -> .\web\src\engine\osk\gesture-processor
│ ├─┬ @keymanapp/web-utils@ -> .\web\src\engine\common\web-utils
│ │ └── typescript@5.4.5 deduped
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/keyman-version@ -> .\common\web\keyman-version
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/kmc-analyze@ -> .\developer\src\kmc-analyze
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/kmc-copy@ -> .\developer\src\kmc-copy
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/kmc-generate@ -> .\developer\src\kmc-generate
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/kmc-keyboard-info@ -> .\developer\src\kmc-keyboard-info
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/kmc-kmn@ -> .\developer\src\kmc-kmn
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/kmc-ldml@ -> .\developer\src\kmc-ldml
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/kmc-model-info@ -> .\developer\src\kmc-model-info
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/kmc-model@ -> .\developer\src\kmc-model
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/kmc-package@ -> .\developer\src\kmc-package
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/kmc@ -> .\developer\src\kmc
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/langtags@ -> .\common\web\langtags
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/lexical-model-layer@ -> .\web\src\engine\predictive-text\worker-main
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/lm-message-types@ -> .\web\src\engine\predictive-text\types
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/lm-worker@ -> .\web\src\engine\predictive-text\worker-thread
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/models-templates@ -> .\web\src\engine\predictive-text\templates
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/models-wordbreakers@ -> .\web\src\engine\predictive-text\wordbreakers
│ └── typescript@5.4.5 deduped
├─┬ @keymanapp/sourcemap-path-remapper@ -> .\common\tools\sourcemap-path-remapper
│ └── typescript@5.4.5 deduped
├─┬ @microsoft/api-extractor@7.57.6
│ └── typescript@5.8.2
├─┬ @typescript-eslint/eslint-plugin@7.13.1
│ └─┬ ts-api-utils@1.3.0
│   └── typescript@5.4.5 deduped
├─┬ eslint-config-love@53.0.0
│ └── typescript@5.4.5 deduped
├─┬ keyman@ -> .\web
│ ├─┬ @keymanapp/recorder-core@ -> .\web\src\tools\testing\recorder-core
│ │ └── typescript@5.4.5 deduped
│ └─┬ @keymanapp/web-sentry-manager@ -> .\web\src\engine\sentry-manager
│   └── typescript@5.4.5 deduped
└── typescript@5.4.5
```

Test-bot: skip
Build-bot: build:common,core,web,developer

(building platforms directly affected by TSC changes, skipping indirect)