### PR TITLE
fix(developer): await copier result before reporting success or failure

### DIFF
--- a/developer/src/kmc/src/commands/copy.ts
+++ b/developer/src/kmc/src/commands/copy.ts
@@ -81,7 +81,7 @@ async function doCopy(callbacks: NodeCompilerCallbacks, sources: string | string
 
   const dest = options.outPath;
   callbacks.reportMessage(InfrastructureMessages.Info_CopyingProject({source, dest}));
-  const result = runCopier(callbacks, source, options);
+  const result = await runCopier(callbacks, source, options);
   if(result) {
     callbacks.reportMessage(InfrastructureMessages.Info_ProjectCopiedSuccessfully({source, dest}));
   } else {


### PR DESCRIPTION
Without `await`, a 'success' message is always returned, because the Promise that is returned is not nullish. While the log message was misleading, the outcome was already correct, because the parent function `copyProject()` did correctly await the call to `doCopy()`.

Fixes: #15699
Test-bot: skip