### PR TITLE
fix(ios): Revert Sentry to 8.38.0 to fix FirstVoices crash on startup with 18.0.247 🏠

### DIFF
--- a/ios/Cartfile
+++ b/ios/Cartfile
@@ -1,4 +1,4 @@
 github "weichsel/ZIPFoundation" ~> 0.9
 github "devicekit/DeviceKit" ~> 5.0
 github "ashleymills/Reachability.swift"
-github "getsentry/sentry-cocoa" ~> 8.58
+github "getsentry/sentry-cocoa" ~> 8.38

--- a/ios/Cartfile.resolved
+++ b/ios/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "ashleymills/Reachability.swift" "v5.2.4"
-github "devicekit/DeviceKit" "5.7.0"
-github "getsentry/sentry-cocoa" "8.58.0"
-github "weichsel/ZIPFoundation" "0.9.20"
+github "devicekit/DeviceKit" "5.5.0"
+github "getsentry/sentry-cocoa" "8.44.0"
+github "weichsel/ZIPFoundation" "0.9.19"


### PR DESCRIPTION
try revert to earlier version of sentry, from 8.58.0 back to 8.44.0
Reverts the Sentry part of #15614

This will fix the FirstVoices crash on startup in version 18.0.247

Test-bot: skip
