### PR TITLE
chore(linux): fix dependency of Debian test suite 🍒

### DIFF
--- a/linux/debian/tests/control
+++ b/linux/debian/tests/control
@@ -1,5 +1,5 @@
 Tests: test-build test-gnome-cli test-ibus-cli
 Depends: @,
  build-essential,
- pkg-config,
+ pkgconf,
 Architecture: amd64 arm64 armel armhf i386 loong64 mips64el mipsel ppc64el riscv64


### PR DESCRIPTION
The test suite had a dependency on the deprecated `pkg-config`. This change replaces this with `pkgconf`. This fixes a lintian warning.

Cherry-pick-of: #15734
Test-bot: skip