### PR TITLE
docs(core): improve keyhandling doc

### DIFF
--- a/core/docs/api/keyhandling.md
+++ b/core/docs/api/keyhandling.md
@@ -1,42 +1,39 @@
 # Key Handling
 
-For each key press the processor will called twice, for the key down event
-as well as for the key up event. Depending on the type of key pressed the
-processor might handle the key itself or pass it on to the application.
-The value of `emit_keystroke` in `km_core_actions` struct tells if the
-processor handled the key (`emit_keystroke=0`) or not (`emit_keystroke=1`).
-It is important that the same value gets set for both key down and key up
-events, otherwise the application might miss some events which then looks
-to the user like keys are stuck.
+While Keyman Core does not generally emit actions from key up events,
+the `emit_keystroke` value for a key up event will match the corresponding
+key down event, in order to avoid 'stuck key' scenarios'.
 
 Usually the processor won't handle any frame keys and let the application
 deal with it. This allows shortcut keys like <kbd>Ctrl</kbd>+<kbd>C</kbd>
-to work. The only exception is the <kbd>Backspace</kbd> key which is
-handled internally if enough context is available. Regular keys will be
-handled by the processor.
+to work. One exception is the <kbd>Backspace</kbd> key which is
+handled internally if enough context is available. Keyboards can define
+rules for other frame keys, e.g. <kbd>Ctrl</kbd>+Key which are then
+also handled internally. Regular keys will be handled by the processor.
 
 Note that there is a difference between CLDR/LDML and KMN keyboards if
 there are no rules/transforms defined for a key: KMN keyboards will
 output the cap value of the key (e.g. pressing <kbd>a</kbd> will output
 `a` if no rule is defined), whereas CLDR/LDML keyboards will suppress
-any output for that key.
+any output for that key. However, `km_core_actions.emit_keystroke` will
+be `FALSE` for both KMN and CLR/LDML keyboards.
 
 The following table lists the state of `km_core_actions.emit_keystroke`
 on return of `km_core_process_event` when the following type of key is
 pressed:
 
-|Type                         |   KeyDown     |  KeyUp   |
-|-----------------------------|---------------|----------|
-|Key with rule                |    FALSE      |  FALSE   |
-|Key w/o rule                 |    FALSE      |  FALSE   |
-|Framekeys:                   |               |          |
-|<kbd>Enter</kbd>             |    TRUE       |  TRUE    |
-|<kbd>Backspace</kbd>¹        |    FALSE      |  FALSE   |
-|<kbd>Backspace</kbd>²        |    TRUE       |  TRUE    |
-|<kbd>Ctrl</kbd>+Key          |    TRUE       |  TRUE    |
-|Modifier key <kbd>Shift</kbd>|    TRUE       |  TRUE    |
-|Modifier key <kbd>Ctrl</kbd> |    TRUE       |  TRUE    |
-|Modifier key <kbd>LAlt</kbd> |    TRUE       |  TRUE    |
+|Type                         | KeyDown/Up |
+|-----------------------------|------------|
+|Core key with rule           |    FALSE   |
+|Core key w/o rule            |    FALSE   |
+|Framekeys:                   |            |
+|<kbd>Enter</kbd>             |    TRUE    |
+|<kbd>Backspace</kbd>¹        |    FALSE   |
+|<kbd>Backspace</kbd>²        |    TRUE    |
+|<kbd>Ctrl</kbd>+Key          |    TRUE    |
+|Modifier key <kbd>Shift</kbd>|    TRUE    |
+|Modifier key <kbd>Ctrl</kbd> |    TRUE    |
+|Modifier key <kbd>LAlt</kbd> |    TRUE    |
 
 1: context available<br/>
 2: without or with empty context


### PR DESCRIPTION
This improves the keyhandling doc according to the code review suggestions in #15629.

Follows: #15629
Build-bot: skip
Test-bot: skip