### PR TITLE
maint(ios): clean carthage before builds

### DIFF
--- a/resources/teamcity/includes/tc-mac.inc.sh
+++ b/resources/teamcity/includes/tc-mac.inc.sh
@@ -12,9 +12,13 @@ ba_mac_unlock_keychain() {
 }
 
 ba_mac_clean_xcode_derived_data() {
-  builder_echo start "clean" "Cleaning XCode DerivedData mess"
+  builder_echo start "clean" "Cleaning XCode DerivedData and Carthage cache mess"
   rm -rf "${HOME}/Library/Developer/Xcode/DerivedData"
-  builder_echo end "clean" success "Finished cleaning XCode DerivedData mess"
+
+  # https://stackoverflow.com/a/45504898/1836776
+  rm -rf "${HOME}/Library/Caches/org.carthage.CarthageKit"
+
+  builder_echo end "clean" success "Finished cleaning XCode DerivedData and Carthage cache mess"
 }
 
 ba_mac_unmount_volumes_keyman() {


### PR DESCRIPTION
This change is in response to inconsistent build behavior where we observed better outcomes after manually cleaning the Carthage cache. The cache folder had clearly also become very large over time so this has the side benefit of clearing up space on the build agents. It is unclear how much time this will cost in the build, but we don't suppose it will make them dramatically slower.

Note: the same change has been applied in TC for stable-18.0 builds.

Test-bot: skip