### PR TITLE
change(web): tag suggestion IDs within finalization 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -21,6 +21,13 @@ import Reversion = LexicalModelTypes.Reversion;
 import Suggestion = LexicalModelTypes.Suggestion;
 import Transform = LexicalModelTypes.Transform;
 
+let SUGGESTION_ID_SEED = 0;
+export function generateSuggestionId() {
+  const id = SUGGESTION_ID_SEED;
+  SUGGESTION_ID_SEED++;
+  return id;
+}
+
 export class ModelCompositor {
   private lexicalModel: LexicalModel;
   private _contextTracker?: correction.ContextTracker;
@@ -61,8 +68,6 @@ export class ModelCompositor {
    *     behavior changes might feel arbitrary to users if we used a hard threshold instead.
    */
   static readonly SINGLE_CHAR_KEY_PROB_EXPONENT = 16;
-
-  private SUGGESTION_ID_SEED = 0;
 
   private testMode: boolean = false;
   private verbose: boolean = true;
@@ -193,11 +198,6 @@ export class ModelCompositor {
       this.verbose
     );
 
-    suggestions.forEach((suggestion) => {
-      suggestion.id = this.SUGGESTION_ID_SEED;
-      this.SUGGESTION_ID_SEED++;
-    });
-
     if(revertableTransitionId) {
       const reversion = this.contextTracker.peek(revertableTransitionId)?.reversion;
       if(reversion) {
@@ -264,8 +264,7 @@ export class ModelCompositor {
       // verification later.
       reversion.id = -suggestion.id;
     } else {
-      reversion.id = -this.SUGGESTION_ID_SEED;
-      this.SUGGESTION_ID_SEED++;
+      reversion.id = -generateSuggestionId();
     }
 
     // Step 3:  if we track Contexts, update the tracking data as appropriate.

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -10,7 +10,7 @@ import { ContextTracker } from './correction/context-tracker.js';
 import { ContextState, determineContextSlideTransform } from './correction/context-state.js';
 import { ContextTransition } from './correction/context-transition.js';
 import { ExecutionTimer } from './correction/execution-timer.js';
-import ModelCompositor from './model-compositor.js';
+import ModelCompositor, { generateSuggestionId } from './model-compositor.js';
 import { getBestMatches } from './correction/distance-modeler.js';
 
 const searchForProperty = defaultWordbreaker.searchForProperty;
@@ -1023,15 +1023,19 @@ export function finalizeSuggestions(
       mutableSuggestion.transform = mergedTransform;
     }
 
+    const suggestionId = generateSuggestionId();
+
     if(!verbose) {
       return {
         ...prediction.sample,
-        p: tuple.totalProb
+        p: tuple.totalProb,
+        id: suggestionId
       };
     } else {
       const sample: Outcome<Suggestion | Keep> = {
         ...prediction.sample,
         p: tuple.totalProb,
+        id: suggestionId,
         "lexical-p": prediction.p,
         "correction-p": tuple.correction.p
       }

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-finalization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-finalization.tests.ts
@@ -171,6 +171,10 @@ describe('finalizeSuggestions', () => {
         insert: testModelWithSpacing.punctuation.insertAfterWord,
         deleteLeft: 0
       });
+
+      // For full deep equality, we can't (or at least, shouldn't) test against
+      // specific suggestion ID values,
+      finalized.forEach((entry) => delete entry.id);
       assert.sameDeepOrderedMembers(finalized, expected);
     });
 
@@ -191,6 +195,10 @@ describe('finalizeSuggestions', () => {
 
       const { unfinalized, expected } = build_its_is_set();
       const finalized = finalizeSuggestions(testModelWithSpacing, unfinalized, context, transform, false);
+
+      // For full deep equality, we can't (or at least, shouldn't) test against
+      // specific suggestion ID values,
+      finalized.forEach((entry) => delete entry.id);
 
       // We do not add a whitespace despite not splitting a token if there's a
       // matching whitespace immediately to the caret's right.
@@ -223,6 +231,10 @@ describe('finalizeSuggestions', () => {
         insert: testModelWithSpacing.punctuation.insertAfterWord,
         deleteLeft: 0
       });
+
+      // For full deep equality, we can't (or at least, shouldn't) test against
+      // specific suggestion ID values,
+      finalized.forEach((entry) => delete entry.id);
       assert.sameDeepOrderedMembers(finalized, expected);
     });
 
@@ -251,6 +263,10 @@ describe('finalizeSuggestions', () => {
         insert: testModelWithSpacing.punctuation.insertAfterWord,
         deleteLeft: 0
       });
+
+      // For full deep equality, we can't (or at least, shouldn't) test against
+      // specific suggestion ID values,
+      finalized.forEach((entry) => delete entry.id);
       assert.sameDeepOrderedMembers(finalized, expected);
     });
   });
@@ -274,6 +290,9 @@ describe('finalizeSuggestions', () => {
       const { unfinalized, expected } = build_its_is_set();
       const finalized = finalizeSuggestions(testModelWithoutSpacing, unfinalized, context, transform, false);
 
+      // For full deep equality, we can't (or at least, shouldn't) test against
+      // specific suggestion ID values,
+      finalized.forEach((entry) => delete entry.id);
       assert.sameDeepOrderedMembers(finalized, expected);
     });
 
@@ -297,6 +316,10 @@ describe('finalizeSuggestions', () => {
 
       const { unfinalized, expected } = build_its_is_set();
       const finalized = finalizeSuggestions(testModelWithoutSpacing, unfinalized, context, transform, false);
+
+      // For full deep equality, we can't (or at least, shouldn't) test against
+      // specific suggestion ID values,
+      finalized.forEach((entry) => delete entry.id);
 
       // We do not add a whitespace despite not splitting a token if there's a
       // matching whitespace immediately to the caret's right.
@@ -325,6 +348,9 @@ describe('finalizeSuggestions', () => {
       const { unfinalized, expected } = build_its_is_set();
       const finalized = finalizeSuggestions(testModelWithoutSpacing, unfinalized, context, transform, false);
 
+      // For full deep equality, we can't (or at least, shouldn't) test against
+      // specific suggestion ID values,
+      finalized.forEach((entry) => delete entry.id);
       assert.sameDeepOrderedMembers(finalized, expected);
     });
   });
@@ -353,6 +379,10 @@ describe('finalizeSuggestions', () => {
         insert: testModelWithSpacing.punctuation.insertAfterWord,
         deleteLeft: 0
       });
+
+      // For full deep equality, we can't (or at least, shouldn't) test against
+      // specific suggestion ID values,
+      finalized.forEach((entry) => delete entry.id);
       assert.sameDeepOrderedMembers(finalized, expected);
     });
 
@@ -371,7 +401,6 @@ describe('finalizeSuggestions', () => {
         deleteLeft: 0
       };
 
-
       const { unfinalized, expected } = build_its_is_set();
       const finalized = finalizeSuggestions(testModelWithSpacing, unfinalized, context, transform, false);
 
@@ -379,6 +408,10 @@ describe('finalizeSuggestions', () => {
         insert: testModelWithSpacing.punctuation.insertAfterWord,
         deleteLeft: 0
       });
+
+      // For full deep equality, we can't (or at least, shouldn't) test against
+      // specific suggestion ID values,
+      finalized.forEach((entry) => delete entry.id);
       assert.sameDeepOrderedMembers(finalized, expected);
     });
   });


### PR DESCRIPTION
This small change helps to prepare for whitespace fat-fingering by allowing the suggestion-finalization method to produce (and thus, refer to) suggestion IDs.

Build-bot: skip build:web
Test-bot: skip