### PR TITLE
refactor(web): split ContextState.analyzeTransition 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-state.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-state.ts
@@ -16,8 +16,9 @@ import { KMWString } from '@keymanapp/web-utils';
 import { ContextToken } from './context-token.js';
 import { ContextTokenization } from './context-tokenization.js';
 import { ContextTransition } from './context-transition.js';
+import { precomputeTransitions, transitionTokenizations } from './transition-helpers.js';
+
 import { determineModelTokenizer } from '../model-helpers.js';
-import { legacySubsetKeyer, TokenizationSubsetBuilder } from './tokenization-subsets.js';
 import TransformUtils from '../transformUtils.js';
 
 import Context = LexicalModelTypes.Context;
@@ -204,12 +205,12 @@ export class ContextState {
     // From here on, we work toward the common-case - re-using old info when
     // context (and its tokenization) is changed by an input Transform.
 
-    let trueInputSubsetKey: string;
     const slideUpdateTransform = determineContextSlideTransform(this.context, context);
 
     // Goal:  allow multiple base tokenizations.
-    const startTokenizations = [this.tokenization];
-    const startTokenizationsAfterSlide = startTokenizations.map(t => t.applyContextSlide(lexicalModel, slideUpdateTransform));
+    const startTokenizations = [this.tokenization].map((t) => {
+      return t.applyContextSlide(lexicalModel, slideUpdateTransform);
+    });
 
     // Easy case - no net change to the tokenizations whatsoever; the actual request
     // aims to save-state the most recent results.
@@ -219,38 +220,13 @@ export class ContextState {
       // If the tokenizations match, clone the ContextState; we want to preserve a post-application
       // context separately from pre-application contexts for predictions based on empty roots.
       const state = new ContextState(this);
-      state.tokenization = startTokenizationsAfterSlide[0];
+      state.tokenization = [...startTokenizations.values()][0];
       transition.finalize(state, transformDistribution);
       return transition;
     }
 
-    const subsetBuilder = new TokenizationSubsetBuilder(legacySubsetKeyer);
-    for(let baseTokenization of startTokenizationsAfterSlide) {
-
-      for(let mass of transformDistribution) {
-        const tokenizationAnalysis = baseTokenization.mapWhitespacedTokenization(lexicalModel, mass.sample);
-        subsetBuilder.addPrecomputation(baseTokenization, tokenizationAnalysis, mass.p);
-
-        if(mass.sample == trueInput) {
-          trueInputSubsetKey = subsetBuilder.keyer(tokenizationAnalysis);
-        }
-      }
-    }
-
-    // And now to (partly) detransform from a multiple-tokenization paradigm.
-    const trueInputSubset = subsetBuilder.subsets.get(trueInputSubsetKey);
-    // Right now, we only have one base tokenization, so we just fetch it.
-    const baseTokenization = startTokenizationsAfterSlide[0];
-    // For multiple tokenizations, we'd retrieve each, use the "most likely" one as base,
-    // and then fold all resulting search spaces (on the final token) into one.
-    const tokenizationAnalysis = trueInputSubset.transitionEdges.get(baseTokenization);
-
-    // Determine the best probability from among ALL available inputs, before they're split
-    // into subsets.
-    const bestProb = transformDistribution.reduce((best, curr) => Math.max(best, curr.p), 0);
-    // Should gain one per subsetBuilder.subsets entry.
-    const realignedTokenization = baseTokenization.realign(tokenizationAnalysis.alignment);
-    const resultTokenization = realignedTokenization.evaluateTransition(tokenizationAnalysis, trueInput.id, bestProb);
+    const { subsets, keyMatchingUserContext: trueInputSubsetKey } = precomputeTransitions(startTokenizations, transformDistribution);
+    const resultTokenization = transitionTokenizations(subsets, transformDistribution).get(trueInputSubsetKey);
 
     // ------------
 
@@ -260,17 +236,12 @@ export class ContextState {
     // epic/dict-breaker:  if ANY decently-likely tokenization satisfies this, we still
     // have a reasonable candidate for display of a delayed reversion.  (Not 'all' -
     // 'any'.)
-    const tokens = resultTokenization.tokens;
-    const lastIndex = tokens.length - 1;
-    // Ignore a context-final empty '' token; the interesting one is what comes before.
-    const nonEmptyTail = !tokens[lastIndex].isEmptyToken ? tokens[lastIndex] : tokens[lastIndex - 1];
-    const appliedSuggestionTransitionId = nonEmptyTail?.appliedTransitionId;
 
     const state = new ContextState(applyTransform(trueInput, context), lexicalModel);
-    state.tokenization =  new ContextTokenization(resultTokenization.tokens, tokenizationAnalysis, resultTokenization.taillessTrueKeystroke);
+    state.tokenization = resultTokenization;
     state.appliedInput = transformDistribution?.[0].sample;
     transition.finalize(state, transformDistribution);
-    transition.revertableTransitionId = appliedSuggestionTransitionId;
+    transition.revertableTransitionId = state.tokenization.tail.appliedTransitionId;
     return transition;
   }
 }

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -575,8 +575,7 @@ export class ContextTokenization {
   evaluateTransition(
     transitionEdge: TransitionEdge,
     transitionId: number,
-    bestProbFromSet: number,
-    appliedSuggestionId?: number
+    bestProbFromSet: number
   ): ContextTokenization {
     const { alignment, inputs } = transitionEdge;
     const sliceIndex = alignment.edgeWindow.sliceIndex;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/transition-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/transition-helpers.ts
@@ -52,14 +52,39 @@ export function precomputeTransitions(
   const lexicalModel = startTokenizations[0]?.tail.searchModule.model;
 
   const subsetBuilder = new TokenizationSubsetBuilder(keyer);
+
   for(let baseTokenization of startTokenizations) {
     for(let mass of transformDistribution) {
       const tokenizationAnalysis = baseTokenization.mapWhitespacedTokenization(lexicalModel, mass.sample);
       const alignment = tokenizationAnalysis.alignment;
 
-      // Pre-process any splits and merges; the result of these operations may
-      // have the same properties as other base tokenizations within the
-      // subset if compatible.
+      /* Pre-process any splits and merges; the result of these operations may
+       * have the same properties as other base tokenizations within the subset
+       * if compatible.
+       *
+       * Example case:  suppose the following two variations of context (forced
+       * as they may be):
+       * - [can, '] + t
+       * - [cans] + t
+       *
+       * Both have the same total codepoint length and incoming input, but the
+       * tokenization pattern is different.  But, if we pre-merge the first
+       * version...
+       * - [can'] + t
+       * - [cans] + t
+       *
+       * Both land with the same tokenization pattern:
+       * - [can't]
+       * - [canst]
+       *     - 5 total codepoints
+       *     - same total count of input transforms
+       *     - just one token for both cases.
+       *
+       * These two cases should converge within the same tokenization-pattern
+       * "cluster"... and the key built from 'sourceTokenization' below (during
+       * the .addPrecomputation call) is the tool used internally to recognize
+       * this.
+       */
       const needsRealignment = (alignment.merges.length > 0 || alignment.splits.length > 0 || alignment.unmappedEdits.length > 0);
       const sourceTokenization = needsRealignment ? baseTokenization.realign(alignment) : baseTokenization;
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/transition-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/transition-helpers.ts
@@ -1,0 +1,133 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by jahorton on 2026-03-18
+ *
+ * Implements helper functions for transitioning the context to new states
+ * based on incoming input or applied suggestions.
+ */
+
+import { LexicalModelTypes } from '@keymanapp/common-types';
+
+import { ContextTokenization } from './context-tokenization.js';
+import { legacySubsetKeyer, TokenizationSubset, TokenizationSubsetBuilder } from './tokenization-subsets.js';
+
+import Distribution = LexicalModelTypes.Distribution;
+import Transform = LexicalModelTypes.Transform;
+
+/**
+ * Given a set of initial tokenizations and a distribution of input transforms,
+ * this method determines the resulting tokenization patterns each initial
+ * tokenization will transition into.
+ *
+ * This can be a many-to-many relationship among initial and final tokenizations
+ * if there are sufficient variations in the input Transform distribution and its
+ * constituents' effects on the represented context variants.
+ * @param startTokenizations
+ * @param transformDistribution
+ * @param keyer Designed for use in unit tests.
+ * @returns
+ */
+export function precomputeTransitions(
+  startTokenizations: ContextTokenization[],
+  transformDistribution: Distribution<Transform>,
+  keyer?: typeof legacySubsetKeyer
+): {
+  /**
+   * A Map whose values contain metadata useful for constructing the variations
+   * in context (and the tokenizations that model each) that will result from
+   * the currently-considered context variations and input.
+   */
+  subsets: ReadonlyMap<string, TokenizationSubset>,
+  /**
+   * The key matching the resulting context variation that will match the actual
+   * context edited by the user.
+   */
+  keyMatchingUserContext: string
+  } {
+  keyer ??= legacySubsetKeyer;
+
+  let keyMatchingUserContext: string;
+  const trueInput = transformDistribution[0].sample;
+  const lexicalModel = startTokenizations[0]?.tail.searchModule.model;
+
+  const subsetBuilder = new TokenizationSubsetBuilder(keyer);
+  for(let baseTokenization of startTokenizations) {
+    for(let mass of transformDistribution) {
+      const tokenizationAnalysis = baseTokenization.mapWhitespacedTokenization(lexicalModel, mass.sample);
+      const alignment = tokenizationAnalysis.alignment;
+
+      // Pre-process any splits and merges; the result of these operations may
+      // have the same properties as other base tokenizations within the
+      // subset if compatible.
+      const needsRealignment = (alignment.merges.length > 0 || alignment.splits.length > 0 || alignment.unmappedEdits.length > 0);
+      const sourceTokenization = needsRealignment ? baseTokenization.realign(alignment) : baseTokenization;
+
+      subsetBuilder.addPrecomputation(sourceTokenization, tokenizationAnalysis, mass.p);
+
+      if(mass.sample == trueInput) {
+        keyMatchingUserContext = subsetBuilder.keyer(tokenizationAnalysis);
+      }
+    }
+  }
+
+  return {
+    subsets: subsetBuilder.subsets,
+    keyMatchingUserContext
+  };
+}
+
+/**
+ * Given results from `precomputeTransitions`, this function generates the
+ * context variations that should result from the current context variants and
+ * input.  The one best matching the user's visible context will be set at index
+ * 0.
+ * @param precomputedTransitionSubsets
+ * @param transformDistribution
+ * @param keyMatchingUserContext
+ * @returns
+ */
+export function transitionTokenizations(
+  precomputedTransitionSubsets: ReadonlyMap<string, TokenizationSubset>,
+  transformDistribution: Distribution<Transform>
+) {
+  const trueInput = transformDistribution[0].sample;
+  const bestProb = transformDistribution.reduce((best, curr) => Math.max(best, curr.p), 0);
+
+  // For all target tokenizations - each transition subset...
+  const finalTokenizations: Map<string, ContextTokenization> = new Map();
+  precomputedTransitionSubsets.forEach((subset, key) => {
+    // Iterate over all _source_ tokenizations and the changes used to transition them
+    // to that target tokenization.
+    const transitionSets = [...subset.transitionEdges.entries()];
+    const independentTransitionResults = transitionSets.flatMap((precomp) => {
+      const rootTokenization = precomp[0];
+
+      // Following call:  is actually designed to build SubstitutionQuotientSpurs.
+      const transitionedTokenization = rootTokenization.evaluateTransition(precomp[1], trueInput.id, bestProb);
+      const remadeTokenization = new ContextTokenization(transitionedTokenization.tokens, subset.transitionEdges.get(rootTokenization), transitionedTokenization.taillessTrueKeystroke);
+
+      // If the last token is empty and has no flag for a revertable transition,
+      // attempt to copy the previous token's revertable transition flag.
+      const tokens = remadeTokenization.tokens;
+      const lastTokenIndex = tokens.length - 1;
+      if(tokens[lastTokenIndex].isEmptyToken && tokens[lastTokenIndex-1]) {
+        tokens[lastTokenIndex].appliedTransitionId ??= tokens[lastTokenIndex-1].appliedTransitionId
+      }
+
+      return remadeTokenization;
+    });
+
+    // Super-easy case:  there's only the one tokenization anyway.
+    if(independentTransitionResults.length == 1) {
+      finalTokenizations.set(key, independentTransitionResults[0])
+      return;
+    }
+
+    // Of particular note - there may no longer be a specific, single set of edits
+    // for the transition; there will be different paths to reach a tokenization!
+    throw new Error("Multi-tokenization transitions not yet supported.");
+  });
+
+  return finalTokenizations;
+}

--- a/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
@@ -13,6 +13,7 @@ export * from './correction/legacy-quotient-spur.js';
 export * from './correction/search-quotient-root.js';
 export { ExtendedEditOperation, SegmentableDistanceCalculation } from './correction/segmentable-calculation.js';
 export * from './correction/tokenization-subsets.js';
+export * from './correction/transition-helpers.js';
 export * as correction from './correction/index.js';
 export * from './model-helpers.js';
 export * as models from './models/index.js';

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/transition-helpers.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/transition-helpers.tests.ts
@@ -1,0 +1,472 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by jahorton on 2026-04-06.
+ *
+ * Implements unit tests against helper functions utilized for transitioning the
+ * context to new states based on incoming input or applied suggestions.
+ */
+
+import { assert } from 'chai';
+
+import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
+import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
+import { LexicalModelTypes } from '@keymanapp/common-types';
+
+import {
+  buildEdgeWindow,
+  ContextToken,
+  ContextTokenization,
+  generateSubsetId,
+  LegacyQuotientRoot,
+  LegacyQuotientSpur,
+  models,
+  PathInputProperties,
+  precomputationSubsetKeyer,
+  precomputeTransitions,
+  TokenizationSubset,
+  TokenizationTransitionEdits,
+  TransitionEdge,
+  transitionTokenizations
+} from '@keymanapp/lm-worker/test-index';
+
+import Distribution = LexicalModelTypes.Distribution;
+import Transform = LexicalModelTypes.Transform;
+import TrieModel = models.TrieModel;
+
+const plainModel = new TrieModel(
+  jsonFixture('models/tries/english-1000'),
+  {wordBreaker: defaultBreaker}
+);
+
+/**
+ * Builds the outbound "transition edge" from the specified ContextTokenization
+ * derived from the provided input distribution.
+ * @param baseTokenization
+ * @param inputs
+ * @param tokenizedInputs
+ * @returns
+ */
+function buildOutboundTransitionEdge (
+  baseTokenization: ContextTokenization,
+  inputs: Distribution<Required<Transform>>,
+  tokenizedInputs: Distribution<Map<number, Transform>>
+): TransitionEdge {
+  const primaryTokenizedInput = tokenizedInputs[0].sample;
+  const relativeTailIndex = [...primaryTokenizedInput.keys()][0];
+
+  const tokens = baseTokenization.tokens;
+  const baseTexts = tokens.map((t) => t.exampleInput);
+  const tail = relativeTailIndex <= 0 ? tokens[tokens.length - 1 + relativeTailIndex] : ContextToken.fromRawText(plainModel, '', true);
+  // Do NOT include incoming 'insert' text - it's not "retokenized", as it
+  // wasn't in the original token.
+  const newTailText = tail.exampleInput.substring(0, tail.exampleInput.length - primaryTokenizedInput.get(relativeTailIndex).deleteLeft);
+
+  const edgeWindow = buildEdgeWindow(baseTokenization.tokens, inputs[0].sample, false);
+  return {
+    alignment: {
+      merges: [],
+      splits: [],
+      unmappedEdits: [],
+      edgeWindow: {
+        ...edgeWindow,
+        retokenization: baseTexts.slice(edgeWindow.sliceIndex, baseTexts.length - 1).concat(newTailText)
+      },
+      removedTokenCount: 0
+    },
+    inputs: tokenizedInputs,
+    inputSubsetId: generateSubsetId()
+  };
+}
+
+/**
+ * Converts the incoming transform distribution into the most simple and direct
+ * "tokenized" version of itself, which assumes that no actual tokenization
+ * should occur.
+ * @param inputs
+ * @returns
+ */
+function buildTokenizationForSimpleInputs (
+  inputs: Distribution<Required<Transform>>
+) {
+  return inputs.map(({sample, p}) => {
+    const map = new Map<number, Transform>();
+    // Only the 'insert' and 'deleteLeft' fields are set during transform
+    // tokenization at this time.
+    map.set(0, { insert: sample.insert, deleteLeft: sample.deleteLeft });
+    return { sample: map, p };
+  })
+};
+
+/**
+ * Builds a tuple pairing the non-tokenized and tokenized versions of the input
+ * distribution, under the assumption that no actual tokenization should occur.
+ * @param inputs
+ * @returns
+ */
+function buildDistTupleForSimpleInputs (
+  inputs: Distribution<Required<Transform>>
+) {
+  return {
+    raw: inputs,
+    tokenized: buildTokenizationForSimpleInputs(inputs)
+  }
+};
+
+/**
+ * Generates all needed components for tokenization-transition fixtures corresponding to a _single_
+ * spur transition from one ContextTokenization to another one.
+ * @param srcTokenization
+ * @param dists
+ * @param inputPropBase
+ * @returns
+ */
+function generateFixtureForTokenizationOutboundTransition (
+  srcTokenization: ContextTokenization,
+  dists: {
+    raw: Distribution<Required<Transform>>
+    tokenized: Distribution<Map<number, Transform>>
+  }[],
+  inputPropBase: PathInputProperties
+) {
+  return dists.map((dist) => {
+    const primaryTokenizedInput = dist.tokenized[0].sample;
+    const tokenizationEdge = buildOutboundTransitionEdge(srcTokenization, dist.raw, dist.tokenized);
+
+    // Is only built for use in constructing the subset keys.  We only need data
+    // from one of the inputs here.
+    const keyable: TokenizationTransitionEdits = {
+      tokenizedTransform: primaryTokenizedInput,
+      alignment: tokenizationEdge.alignment
+    };
+
+    const key = precomputationSubsetKeyer(keyable);
+    const subset: TokenizationSubset = { key, transitionEdges: new Map() };
+
+    subset.transitionEdges.set(srcTokenization, tokenizationEdge);
+
+    // Generate full transition for the affected token.
+    const inputProp = {
+      ...inputPropBase,
+      subsetId: tokenizationEdge.inputSubsetId
+    }
+
+    const relativeTailIndex = [...primaryTokenizedInput.keys()][0];
+
+    const quotientNodeToExtend = relativeTailIndex <= 0
+      ? srcTokenization.tokens[srcTokenization.tokens.length - 1 + relativeTailIndex].searchModule
+      : new LegacyQuotientRoot(plainModel);
+
+    const token = new ContextToken(new LegacyQuotientSpur(
+      quotientNodeToExtend,
+      dist.tokenized.map((m) => {
+        return {
+          sample: m.sample.get(relativeTailIndex),
+          p: m.p
+        }
+      }),
+      inputProp
+    ));
+
+    // Assumes it's the final token.
+    token.isPartial = true;
+
+    // CURRENTLY NOT DONE:  adding new or replacement tokens for text to be placed after 'quotientNodeToExtend'.
+
+    const transitionedTokenization = new ContextTokenization(
+      srcTokenization.tokens.slice(0, srcTokenization.tokens.length - 1 + relativeTailIndex).concat(token),
+      tokenizationEdge,
+      null
+    );
+
+    return {
+      /**
+       * The first boundary token directly edited by the input's tokenization-transition.
+       */
+      token,
+      /**
+       * The tokenization resulting from the modeled SearchQuotientSpur, before
+       * it converges into a SearchQuotientCluster with any other tokenizations
+       * matching the same subset key.
+       */
+      transitionedTokenization,
+      /**
+       * The original input distribution triggering the tokenization-transition.
+       */
+      dist: dist.raw,
+      /**
+       * The subset key for the transition, as used to determine inbound convergent spurs
+       * that comprise SearchQuotientClusters.
+       */
+      key,
+      /**
+       * The expected precomputed subset metadata for this
+       * tokenization-transition, as output by `precomputeTransitions`.
+       */
+      subset,
+      /**
+       * The PathInputProperties value expected for the tokenization resulting
+       * from the modeled spur's transition.  Note, however, that `subsetId` may
+       * not match due to how it is generated.
+       */
+      inputProp
+    };
+  });
+}
+
+/**
+ * Generates all actual fixtures used in the tokenization-transition unit tests found below.
+ * @returns
+ */
+function generateFixturesForTransitionSource() {
+  const existingTokenTexts = ['I', ' ', 'ate', '', 'at', ' ', 'a', ' ', 'cafe'];
+  const cafeTokenization = new ContextTokenization(
+    existingTokenTexts.map((t) => ContextToken.fromRawText(plainModel, t, t == 'cafe'))
+  );
+  cafeTokenization.tail.isPartial = true;
+
+  const distrib1: Distribution<Required<Transform>> = [
+    // tokenized form: should not have deleteRight or id fields!
+    { sample: { insert: 'é', deleteLeft: 1, deleteRight: 0, id: 11 }, p: 0.6 },
+    { sample: { insert: 't', deleteLeft: 0, deleteRight: 0, id: 11 }, p: 0.4 }
+  ];
+  const inputPropBase1: PathInputProperties = {
+    segment: {
+      transitionId: 11,
+      start: 0
+    },
+    bestProbFromSet: distrib1[0].p,
+    subsetId: 0
+  }
+
+  const transitionSet1 = generateFixtureForTokenizationOutboundTransition(cafeTokenization, [
+    buildDistTupleForSimpleInputs([distrib1[0]]),
+    buildDistTupleForSimpleInputs([distrib1[1]])
+  ], inputPropBase1);
+
+  const distrib1Subsets: Map<string, TokenizationSubset> = new Map();
+  const distrib1Tokenizations: Map<string, ContextTokenization> = new Map();
+  transitionSet1.forEach((tuple) => {
+    distrib1Subsets.set(tuple.key, tuple.subset);
+    distrib1Tokenizations.set(tuple.key, tuple.transitionedTokenization);
+  });
+
+  const distrib2: Distribution<Required<Transform>> = [
+    // tokenized form: should not have deleteRight or id fields!
+    { sample: { insert: 's', deleteLeft: 0, deleteRight: 0, id: 12 }, p: 0.6 },
+    { sample: { insert: 's', deleteLeft: 1, deleteRight: 0, id: 12 }, p: 0.4 }
+  ];
+  const inputPropBase2: PathInputProperties = {
+    segment: {
+      transitionId: 12,
+      start: 0
+    },
+    bestProbFromSet: distrib1[0].p,
+    subsetId: 0
+  }
+
+  const transitionSet2 = transitionSet1.map(
+    (t) => generateFixtureForTokenizationOutboundTransition(
+      t.transitionedTokenization, [
+        buildDistTupleForSimpleInputs([distrib2[0]]),
+        buildDistTupleForSimpleInputs([distrib2[1]])
+      ],
+      inputPropBase2
+    )
+  );
+
+  const distrib2Subsets: Map<string, TokenizationSubset> = new Map();
+  transitionSet2.flat().forEach((tuple) => {
+    const oldEntry = distrib2Subsets.get(tuple.key);
+    if(!oldEntry) {
+      distrib2Subsets.set(tuple.key, tuple.subset)
+    } else {
+      const combinedSubset: TokenizationSubset = {
+        key: oldEntry.key,
+        transitionEdges: new Map(oldEntry.transitionEdges)
+      };
+
+      tuple.subset.transitionEdges.forEach((value, key) => {
+        combinedSubset.transitionEdges.set(key, value);
+      });
+
+      distrib2Subsets.set(tuple.key, combinedSubset);
+    }
+  });
+
+  return {
+    cafe: {
+      base: cafeTokenization,
+      key1: {
+        dist: distrib1,
+        transitionSet: transitionSet1,
+        subsets: distrib1Subsets,
+        contextKey: transitionSet1[0].key,
+        tokenizations: distrib1Tokenizations
+      },
+      key2: {
+        dist: distrib2,
+        transitionSet: transitionSet2,
+        subsets: distrib2Subsets,
+        contextKey: transitionSet2[0][0].key,
+        tokenizations: null as Map<string, ContextTokenization>
+      }
+    }
+  }
+}
+
+/**
+ * Verifies that a ContextToken result matches the critical properties of
+ * mocked, preconstructed instances while ignoring the components that may not
+ * match due solely to ID seeding.
+ * @param actual
+ * @param expected
+ * @param msg
+ */
+function assertMatchingToken(actual: ContextToken, expected: ContextToken, msg: string) {
+  assert.deepEqual(actual.inputSegments, expected.inputSegments, msg);
+  assert.deepEqual(actual.sourceRangeKey, expected.sourceRangeKey, msg);
+  assert.deepEqual(actual.searchModule.codepointLength, expected.searchModule.codepointLength, msg);
+  assert.isTrue(actual.searchModule.isSameNode(expected.searchModule), msg);
+  assert.equal(actual.isEmptyToken, expected.isEmptyToken, msg);
+  assert.equal(actual.isWhitespace, expected.isWhitespace, msg);
+  assert.equal(actual.isPartial, expected.isPartial, msg);
+}
+
+/**
+ * Verifies that a ContextTokenization result matches the critical properties of
+ * mocked, preconstructed instances while ignoring the components that may not
+ * match due solely to ID seeding.
+ * @param actual
+ * @param expected
+ * @param msg
+ */
+function assertMatchingTokenization(actual: ContextTokenization, expected: ContextTokenization, msg: string) {
+  assert.equal(actual.tokens.length, expected.tokens.length, msg);
+  assert.deepEqual(actual.exampleInput, expected.exampleInput, msg);
+  assert.deepEqual(actual.transitionEdits, expected.transitionEdits, msg);
+
+  for(let j=0; j < actual.tokens.length; j++) {
+    const nestedMsg = `${msg}, token ${j}`;
+
+    assertMatchingToken(actual.tokens[j], expected.tokens[j], nestedMsg);
+  }
+}
+
+describe('transition-helper fixture setup', () => {
+  it('builds mocked data as expected', () => {
+    const { cafe } = generateFixturesForTransitionSource();
+
+    assert.equal(cafe.key1.transitionSet.length, 2);
+    assert.notEqual(cafe.key1.transitionSet[0].key, cafe.key1.transitionSet[1].key);
+
+    assert.equal(cafe.key1.transitionSet[0].token.exampleInput, 'café');
+    assert.equal(cafe.key1.transitionSet[0].dist.length, 1);
+    assert.equal(cafe.key1.transitionSet[1].token.exampleInput, 'cafet');
+    assert.equal(cafe.key1.transitionSet[1].dist.length, 1);
+
+    assert.equal(cafe.key2.transitionSet.length, 2);
+    assert.equal(cafe.key2.transitionSet[0].length, 2);
+    assert.equal(cafe.key2.transitionSet[1].length, 2);
+    assert.notEqual(cafe.key2.transitionSet[0][0].key, cafe.key2.transitionSet[0][1].key);
+    assert.notEqual(cafe.key2.transitionSet[1][0].key, cafe.key2.transitionSet[1][1].key);
+    // The distributions are constructed so that the two different start tokenizations
+    // may converge for the inputs corresponding to the indices set below.
+    assert.equal(cafe.key2.transitionSet[0][0].key, cafe.key2.transitionSet[1][1].key);
+
+    ['cafés', 'cafs', 'cafets', 'cafes'].forEach((text, index) => {
+      const i = Math.floor(index / 2);
+      const j = index % 2;
+      assert.equal(cafe.key2.transitionSet[i][j].token.exampleInput, text);
+      assert.equal(cafe.key2.transitionSet[i][j].dist.length, 1);
+    })
+  });
+});
+
+describe('precomputeTransitions', () => {
+  it('handles the "cafe" fixture\'s first input correctly', () => {
+    const { cafe } = generateFixturesForTransitionSource();
+
+    const precomputation = precomputeTransitions([cafe.base], cafe.key1.dist, precomputationSubsetKeyer);
+    assert.sameOrderedMembers([...precomputation.subsets.keys()], [...cafe.key1.subsets.keys()]);
+
+      // Note:  subset id entries won't match due to how they're generated!
+    [...cafe.key1.subsets.keys()].forEach((key) => {
+      assert.deepEqual(
+        [...precomputation.subsets.get(key).transitionEdges.keys()],
+        [...cafe.key1.subsets.get(key).transitionEdges.keys()]
+      );
+      assert.deepEqual([...precomputation.subsets.get(key).transitionEdges.keys()], [cafe.base]);
+
+      // We coerce the id to match what is expected here by overwriting what our method call produced.
+      const expectedTransitionEdge = cafe.key1.subsets.get(key).transitionEdges.get(cafe.base);
+      const actualTransitionEdge = {
+        ...precomputation.subsets.get(key).transitionEdges.get(cafe.base),
+        inputSubsetId: expectedTransitionEdge.inputSubsetId
+      };
+
+      assert.deepEqual(actualTransitionEdge, expectedTransitionEdge, `error @ subset key ${key}`);
+    });
+  });
+
+  it('handles the "cafe" fixture\'s second input correctly', () => {
+    const { cafe } = generateFixturesForTransitionSource();
+
+    const key1Tokenizations = cafe.key1.transitionSet.map((t) => t.transitionedTokenization);
+    const precomputation = precomputeTransitions(
+      key1Tokenizations,
+      cafe.key2.dist,
+      precomputationSubsetKeyer
+    );
+    assert.sameOrderedMembers([...precomputation.subsets.keys()], [...cafe.key2.subsets.keys()]);
+
+    // Note:  subset id entries won't match due to how they're generated!
+    [...cafe.key2.subsets.keys()].forEach((key) => {
+      const expectedSubset = cafe.key2.subsets.get(key);
+      const actualSubset = precomputation.subsets.get(key);
+
+      const subsetKeys = [...expectedSubset.transitionEdges.keys()];
+      // Some destination subsets aren't reachable from all source tokenizations.
+      assert.includeDeepMembers(key1Tokenizations, subsetKeys);
+      assert.includeDeepMembers(key1Tokenizations, [...actualSubset.transitionEdges.keys()]);
+
+      // We coerce the id to match what is expected here by overwriting what our method call produced.
+      subsetKeys.forEach((srcTokenization) => {
+        const expectedTransitionEdge = expectedSubset.transitionEdges.get(srcTokenization);
+        const actualTransitionEdge = {
+          ...actualSubset.transitionEdges.get(srcTokenization),
+          inputSubsetId: expectedTransitionEdge.inputSubsetId
+        };
+
+        assert.deepEqual(actualTransitionEdge, expectedTransitionEdge, `error @ subset key ${key}`);
+      });
+    });
+  });
+});
+
+describe('transitionTokenizations', () => {
+  it('handles the "cafe" fixture\'s first input correctly', () => {
+    const { cafe } = generateFixturesForTransitionSource();
+
+    const resultTokenizationMap = transitionTokenizations(cafe.key1.subsets, cafe.key1.dist);
+
+    assert.equal(resultTokenizationMap.size, 2);
+    for(let key of resultTokenizationMap.keys()) {
+      const msg = `Invalid assumption for tokenization with key ${key}`;
+
+      const actual = resultTokenizationMap.get(key);
+      const expected = cafe.key1.tokenizations.get(key);
+
+      assertMatchingTokenization(actual, expected, msg);
+    }
+  });
+
+  // Issue:  we don't yet have converging tokenizations implemented.  That's kind of a prerequisite here.
+  it.skip('handles the "cafe" fixture\'s second input correctly', () => {
+    const { cafe } = generateFixturesForTransitionSource();
+
+    const resultTokenizationMap = transitionTokenizations(cafe.key2.subsets, cafe.key2.dist);
+
+    assert.equal(resultTokenizationMap.size, 3);
+  });
+});


### PR DESCRIPTION
The implementation of ContextState.analyzeTransition is rather long and large, comprised of multiple subsections.  We can get clearer, more maintainable code if we split it into multiple pieces - especially if we can do so in a manner that allows individual pieces to be unit-tested.

Also, with whitespace fat-finger handling coming up, special handling for applied suggestions may be needed.  This refactor may facilitate development of a suggestion-specialized variant (in #15775).

Build-bot: skip build:web
Test-bot: skip