### PR TITLE
fix(developer): define globalThis for compiled custom lexical models 🍒 🏠

### DIFF
--- a/developer/src/kmc-model/src/lexical-model-compiler.ts
+++ b/developer/src/kmc-model/src/lexical-model-compiler.ts
@@ -182,6 +182,7 @@ export class LexicalModelCompiler implements KeymanCompiler {
         let sources: string[] = modelSource.sources.map(function(source) {
           return new TextDecoder().decode(callbacks.loadFile(callbacks.path.join(sourcePath, source)));
         });
+        func += `globalThis.exports = globalThis.exports ?? {};\n`;
         func += this.transpileSources(sources).join('\n');
         func += `LMLayerWorker.loadModel(new ${modelSource.rootClass}());\n`;
         break;

--- a/developer/src/kmc-model/test/compile-model.tests.ts
+++ b/developer/src/kmc-model/test/compile-model.tests.ts
@@ -19,6 +19,7 @@ describe('LexicalModelCompiler', function () {
     'example.qaa.wordbreaker',
     'example.qaa.joinwordbreaker',
     'example.qaa.scriptusesspaces',
+    'example.qaa.custom',
   ];
 
   for (let modelID of MODELS) {
@@ -37,7 +38,11 @@ describe('LexicalModelCompiler', function () {
 
       assert.isFalse(compilation.hasSyntaxError, 'model code had syntax error');
       assert.isNull(compilation.error, `compilation error: ${compilation.error}`);
-      assert.equal(compilation.modelConstructorName, 'TrieModel');
+      if(modelID == 'example.qaa.custom') {
+        assert.isNull(compilation.modelConstructorName);
+      } else {
+        assert.equal(compilation.modelConstructorName, 'TrieModel');
+      }
     });
   }
 });

--- a/developer/src/kmc-model/test/fixtures/example.qaa.custom/ExampleCustomModel.ts
+++ b/developer/src/kmc-model/test/fixtures/example.qaa.custom/ExampleCustomModel.ts
@@ -1,0 +1,25 @@
+import { LexicalModelTypes } from '@keymanapp/common-types';
+
+export class ExampleCustomModel implements LexicalModelTypes.LexicalModel {
+  configure(capabilities: LexicalModelTypes.Capabilities): LexicalModelTypes.Configuration {
+    return {
+      leftContextCodePoints: 16,
+      rightContextCodePoints: 0,
+      wordbreaksAfterSuggestions: false,
+    }
+  }
+
+  languageUsesCasing: boolean = true;
+
+  predict(transform: LexicalModelTypes.Transform, context: LexicalModelTypes.Context): LexicalModelTypes.Distribution<LexicalModelTypes.Suggestion> {
+    if(transform.deleteLeft == 0 && context.left.endsWith('te') && transform.insert == 'h') {
+      return [
+        { p: 0.3, sample: { displayAs: 'the', transform: { deleteLeft: 2, insert: 'the' }, tag: 'correction' } },
+        { p: 0.2, sample: { displayAs: 'them', transform: { deleteLeft: 2, insert: 'them' }, tag: 'correction' } },
+        { p: 0.1, sample: { displayAs: 'tee hee', transform: { deleteLeft: 2, insert: 'tee hee' }, tag: 'correction' } },
+      ];
+    } else {
+      return [];
+    }
+  }
+}

--- a/developer/src/kmc-model/test/fixtures/example.qaa.custom/example.qaa.custom.model.ts
+++ b/developer/src/kmc-model/test/fixtures/example.qaa.custom/example.qaa.custom.model.ts
@@ -1,0 +1,6 @@
+const source: LexicalModelSource = {
+  format: 'custom-1.0',
+  rootClass: 'ExampleCustomModel',
+  sources: ['ExampleCustomModel.ts'],
+};
+export default source;

--- a/developer/src/test/auto/model-ts-parser/Keyman.System.Test.LexicalModelParserTest.pas
+++ b/developer/src/test/auto/model-ts-parser/Keyman.System.Test.LexicalModelParserTest.pas
@@ -91,12 +91,17 @@ var
 begin
   lm := TLexicalModelParser.Create(m.Text);
   try
+    // TODO: LexicalModelParser does not support `rootClass` which is needed for
+    // custom lexical models, and the property `Wordlists` is inappropriate for
+    // the list of sources files. This is part of a bigger project for better
+    // custom model support in TIKE
+    //
+    // For now, this test excludes the `rootClass` property in order to pass
     lm.Comment := 'Testing';
     lm.Format := lmfCustom10;
     lm.WordBreaker := lmwbAscii;
     lm.Wordlists.Clear;
-    lm.Wordlists.Add('foo.tsv');
-    lm.Wordlists.Add('bar.tsv');
+    lm.Wordlists.Add('CustomModel.ts');
     Assert.AreEqual(mcustom.Text.Trim, lm.Text.Trim); // Ignoring whitespace before/after
   finally
     lm.Free;

--- a/developer/src/test/auto/model-ts-parser/assets/custom.model.ts
+++ b/developer/src/test/auto/model-ts-parser/assets/custom.model.ts
@@ -2,7 +2,7 @@
 const source: LexicalModelSource = {
   format: 'custom-1.0',
   wordBreaker: 'ascii',
-  sources: ['foo.tsv', 'bar.tsv']
+  sources: ['CustomModel.ts']
 };
 
 export default source;


### PR DESCRIPTION
The boilerplate code for custom lexical models has never really been tested. For use in a browser/worker context, we need to define `exports`. The added unit test verifies that the model will build.

Test-bot: skip
Cherry-pick-of: #15777
See-also: https://blog.keyman.com/2026/03/creating-an-advanced-custom-lexical-model-with-keyman/
See-also: https://community.software.sil.org/t/dictionary-for-laz/11258/8