### PR TITLE
fix(common): add missing `default` property to keyman-touch-layout.clean.spec.json

### DIFF
--- a/common/schemas/keyman-touch-layout/README.md
+++ b/common/schemas/keyman-touch-layout/README.md
@@ -457,6 +457,10 @@ string") into the appropriate spec format.
 
 # .keyman-touch-layout version history
 
+## 2026-03-26 2.1.2 stable
+* Add missing 'default' property for longpress (sk) keys to clean spec. No other
+  changes.
+
 ## 2024-02-23 2.1.1 stable
 * Loosen `layer.id` requirements to any non-whitespace characters, recommend
   only alphanumeric, -, _. clean spec enforces this recommendation.

--- a/common/schemas/keyman-touch-layout/keyman-touch-layout.clean.spec.json
+++ b/common/schemas/keyman-touch-layout/keyman-touch-layout.clean.spec.json
@@ -85,9 +85,9 @@
         "text": { "type": "string" },
         "layer": { "$ref": "#/definitions/layer-id" },
         "nextlayer": { "$ref": "#/definitions/layer-id" },
-        "font": { "$ref": "#/definitions/font-spec" },
         "fontsize": { "$ref": "#/definitions/fontsize-spec" },
-        "sp": { "$ref": "#/definitions/key-sp" },
+        "font": { "$ref": "#/definitions/font-spec" },
+        "sp": { "$ref" : "#/definitions/key-sp" },
         "pad": { "$ref" : "#/definitions/key-pad" },
         "width": { "$ref" : "#/definitions/key-width" },
         "sk": { "$ref": "#/definitions/subkeys" },
@@ -140,11 +140,12 @@
         "text": { "type": "string" },
         "layer": { "$ref": "#/definitions/layer-id" },
         "nextlayer": { "$ref": "#/definitions/layer-id" },
-        "font": { "$ref": "#/definitions/font-spec" },
-        "fontsize": { "$ref": "#/definitions/fontsize-spec" },
-        "sp": { "$ref": "#/definitions/key-sp" },
+        "sp": { "$ref" : "#/definitions/key-sp" },
         "pad": { "$ref" : "#/definitions/key-pad" },
-        "width": { "$ref" : "#/definitions/key-width" }
+        "width": { "$ref" : "#/definitions/key-width" },
+        "fontsize": { "$ref": "#/definitions/fontsize-spec" },
+        "font": { "$ref": "#/definitions/font-spec" },
+        "default": { "type": "boolean" }
       },
       "required": ["id"],
       "additionalProperties": false


### PR DESCRIPTION
Matches property in keyman-touch-layout.spec.json. Update to version 2.1.2.

Test-bot: skip
See-also: keymanapp/api.keyman.com#338
See-also: #15613