### PR TITLE
feat(web): add classes for use in multi-token correction 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
@@ -29,6 +29,12 @@ export const QUEUE_NODE_COMPARATOR: QueueComparator<SearchNode> = function(arg1,
   return arg1.currentCost - arg2.currentCost;
 }
 
+/**
+ * Determines the total correction + edit cost allowed for any correction beyond
+ * the most optimistic probability for a token.
+ */
+export const MAX_EDIT_THRESHOLD_FACTOR = 2.5;
+
 // The set of search spaces corresponding to the same 'context' for search.
 // Whenever a wordbreak boundary is crossed, a new instance should be made.
 export abstract class SearchQuotientSpur implements SearchQuotientNode {
@@ -377,7 +383,7 @@ export abstract class SearchQuotientSpur implements SearchQuotientNode {
     // Allows a little 'wiggle room' + 2 "hard" edits.
     // Can be important if needed characters don't actually exist on the keyboard
     // ... or even just not the then-current layer of the keyboard.
-    if(currentNode.currentCost > this.lowestPossibleSingleCost + 2.5 * EDIT_DISTANCE_COST_SCALE) {
+    if(currentNode.currentCost > this.lowestPossibleSingleCost + MAX_EDIT_THRESHOLD_FACTOR * EDIT_DISTANCE_COST_SCALE) {
       return unmatchedResult;
     }
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/token-result-mapping.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/token-result-mapping.ts
@@ -12,6 +12,7 @@ import { LexicalModelTypes } from '@keymanapp/common-types';
 
 import { CorrectionResultMapping } from './correction-result-mapping.js';
 import { SearchNode, TraversableToken } from "./distance-modeler.js";
+import { TokenResult } from './tokenization-corrector.js';
 
 // Circular type reference; do not actually require direct use of the prototype
 // or constructor!
@@ -45,7 +46,7 @@ export function initTokenResultFilterer() {
   return closure;
 }
 
-export class TokenResultMapping implements CorrectionResultMapping<SearchNode>{
+export class TokenResultMapping implements CorrectionResultMapping<SearchNode>, TokenResult {
   readonly matchingSpace: SearchQuotientNode;
   private readonly node: SearchNode;
   readonly spaceId: number;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -37,6 +37,8 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
   private readonly _correctables: SearchQuotientNode[];
   private _predictable?: SearchQuotientNode;
 
+  private _returnedResults: TokenizationResultMapping[] = [];
+
   private selectionQueue: PriorityQueue<SearchQuotientNode>;
   private tokenCostMap: Map<number, number>;
   private _lockedTokenResults: Map<SearchQuotientNode, TokenResult>;
@@ -83,7 +85,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
   // tokenization may then flesh out the ordering of the entries to build the
   // proper corrections / predictions.
   get previousResults(): TokenizationResultMapping[] {
-    return [];
+    return this._returnedResults;
   };
 
   constructor(
@@ -182,10 +184,12 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
         // It is possible that the editable tokenization range exists entirely of
         // tokens considered to be uncorrectable.
         this.handleHasBeenCalled = true;
+        const results = this.collateResults();
+        this._returnedResults.push(results);
         return {
           'type': 'complete',
           cost: this.lastTotalCost,
-          mapping: this.collateResults()
+          mapping: results
         };
       }
     }
@@ -270,6 +274,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     }
 
     // Determine the proper return type and construct the proper return object accordingly.
+    this._returnedResults.push(correctionResults);
     return {
       type: 'complete',
       cost: tokenizationCost,

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -28,6 +28,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
   private tokenCostMap: Map<ContextToken, number>;
   private _lockedTokenResults: Map<ContextToken, TokenResult>;
   private lastTotalCost: number;
+  private handleHasBeenCalled: boolean = false;
 
   get currentCost(): number {
     const token = this.selectionQueue.peek();
@@ -140,6 +141,10 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     return this.lastTotalCost + tokenCost - (this.tokenCostMap.get(updatedToken) ?? 0);
   }
 
+  private collateResults(): TokenizationResultMapping {
+    return new TokenizationResultMapping(this.orderedTokens.map((t) => this._lockedTokenResults.get(t)), this);
+  }
+
   handleNextNode(): PathResult<TokenizationResultMapping> {
     // Notable states:
     // 1.  Unbound tokens have not yet been "locked" - no valid correction has yet been found.
@@ -153,14 +158,23 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     // 4.  Unbound token is unlocked, but all others are locked.
 
     const tokenToUpdate = this.selectionQueue.dequeue();
-    const tokenResult = tokenToUpdate.searchModule.handleNextNode();
+    const tokenResult = tokenToUpdate?.searchModule.handleNextNode();
 
-    if(tokenResult.type == 'none') {
+    if(tokenResult?.type == 'none' || (!tokenResult && this.handleHasBeenCalled)) {
       // If we reach this point, the tokenization has exhausted its search space.
       return {
         'type': 'none'
       };
+    } else if(!tokenResult) {
+      this.handleHasBeenCalled = true;
+      return {
+        'type': 'complete',
+        cost: this.lastTotalCost,
+        mapping: this.collateResults()
+      };
     }
+
+    this.handleHasBeenCalled = true;
 
     // Update the cost associated with the token.
     const cost = this.lastTotalCost = this.getUpdatedTotalCost(tokenToUpdate, tokenResult.cost);
@@ -198,13 +212,12 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
       this.selectionQueue.enqueue(this._unboundToken);
     }
 
-    const tokenCorrections: TokenResult[] = this.orderedTokens.map((t) => this._lockedTokenResults.get(t));
-
-    if(tokenCorrections.findIndex((c) => c == undefined) != -1) {
+    const correctionResults = this.collateResults();
+    if(correctionResults.matchedResult.findIndex((c) => c == undefined) != -1) {
       return {
         type: 'intermediate',
         cost
-      }
+      };
     }
 
     // Determine the proper return type and construct the proper return object accordingly.
@@ -212,7 +225,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     return {
       type: 'complete',
       cost,
-      mapping: new TokenizationResultMapping(tokenCorrections, this)
+      mapping: correctionResults
     };
   }
 }

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -94,6 +94,8 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
 
     if(tailCorrectionLength < 1) {
       throw new Error(`Length for correction near tail may not be 0.`);
+    } else if(tailCorrectionLength > tokenization.tokens.length) {
+      throw new Error(`Tail correction length must not extend actual token count`);
     }
 
     const correctables = this.orderedTokens;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -207,10 +207,14 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
       };
     }
 
+    // Note that at this stage, we do not requeue the 'predictable' - other
+    // correctables may exist and need their first corrections before we look
+    // for other corrective variations of the 'predictable'.
+
     // Assertion:  tokenResult.type == 'complete'.  We have a valid correction for
     // at least some part of the tokenization - the represented context variant.
     if(correctableToUpdate != this._predictable) {
-      // Lock the 'bound' token now that a valid correction for it has been
+      // Lock the 'correctable' token now that a valid correction for it has been
       // found. We only consider a single correction for most of a
       // tokenization's tokens, generally only allowing correction variation for
       // the last represented token.
@@ -221,9 +225,11 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     // Either way, update the token -> correction-string map with the obtained result.
     this._lockedTokenResults.set(correctableToUpdate, tokenResult.mapping);
 
-    // If we have a correction for all components in need of correction, allow
-    // searching for alternative corrections for the 'unbound' token.
-    if(this._correctables.length == 0 && this._predictable) {
+    // If we have a correction for all components in need of correction, then
+    // search for alternative corrections for the 'predictable' token - even if
+    // we previously stopped searching for more because we found its first
+    // correction before finding one for at least one other 'correctable'.
+    if(this._correctables.length == 0 && this.selectionQueue.count == 0 && this._predictable) {
       this.selectionQueue.enqueue(this._predictable);
     }
 
@@ -236,7 +242,6 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     }
 
     // Determine the proper return type and construct the proper return object accordingly.
-    // const resultMap = new Map(this.lockedTokenResults);
     return {
       type: 'complete',
       cost,

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -12,7 +12,8 @@ import { PriorityQueue } from "@keymanapp/web-utils";
 
 import { ContextToken } from "./context-token.js";
 import { CorrectionSearchable, PathResult } from "./correction-searchable.js";
-import { ContextTokenization } from "../test-index.js";
+import { ContextTokenization } from "./context-tokenization.js";
+import { SearchQuotientNode } from "./search-quotient-node.js";
 import { TokenizationResultMapping } from "./tokenization-result-mapping.js";
 
 // PathResult needs to be generic:
@@ -30,43 +31,44 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
   public readonly tokenization: ContextTokenization;
   private readonly tailCorrectionLength: number
 
-  private readonly _lockedTokens: ContextToken[];
-  private readonly _boundTokens: ContextToken[];
-  private _unboundToken?: ContextToken;
+  private readonly _uncorrectables: SearchQuotientNode[];
+  private readonly _correctables: SearchQuotientNode[];
+  private _predictable?: SearchQuotientNode;
 
-  private selectionQueue: PriorityQueue<ContextToken>;
-  private tokenCostMap: Map<ContextToken, number>;
-  private _lockedTokenResults: Map<ContextToken, TokenResult>;
+  private selectionQueue: PriorityQueue<SearchQuotientNode>;
+  private tokenCostMap: Map<number, number>;
+  private _lockedTokenResults: Map<SearchQuotientNode, TokenResult>;
   private lastTotalCost: number;
   private handleHasBeenCalled: boolean = false;
 
   get currentCost(): number {
-    const token = this.selectionQueue.peek();
-    if(!token) {
+    const correctable = this.selectionQueue.peek();
+    if(!correctable) {
       return this.lastTotalCost;
     }
 
-    return this.getUpdatedTotalCost(token, token.searchModule.currentCost);
+    return this.getUpdatedTotalCost(correctable, correctable.currentCost);
   };
 
   get orderedTokens(): ReadonlyArray<ContextToken> {
     return this.tokenization.tokens.slice(-this.tailCorrectionLength);
   }
 
-  get lockedTokens(): ReadonlyArray<ContextToken> {
-    return this._lockedTokens;
+  get uncorrectableTokens(): ReadonlyArray<ContextToken> {
+    return this.orderedTokens.filter((t) => this._uncorrectables.find((c) => c.spaceId == t.spaceId));
   }
 
-  get boundTokens(): ReadonlyArray<ContextToken> {
-    return this._boundTokens;
+  get correctableTokens(): ReadonlyArray<ContextToken> {
+    return this.orderedTokens.filter((t) => this._correctables.find((c) => c.spaceId == t.spaceId));
   }
 
-  get unboundToken(): ContextToken {
-    return this._unboundToken;
+  get predictableToken(): ContextToken {
+    return this.orderedTokens.find((t) => this._predictable?.spaceId == t.spaceId);
   }
 
   get lockedTokenResults(): ReadonlyMap<ContextToken, TokenResult> {
-    return this._lockedTokenResults;
+    return new Map([...this._lockedTokenResults.entries()]
+      .map((tuple) => [this.orderedTokens.find((t) => t.searchModule == tuple[0]), tuple[1]]));
   }
 
   // Will have actual result sequences.
@@ -96,24 +98,25 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
 
     const correctables = this.orderedTokens;
 
-    this._lockedTokens = [];
-    this._boundTokens = [];
+    this._uncorrectables = [];
+    this._correctables = [];
 
     correctables.forEach((token, index) => {
+      const searchModule = token.searchModule;
       if(!filterClosure(token)) {
-        this._lockedTokens.push(token);
+        this._uncorrectables.push(searchModule);
       } else if(index == tailCorrectionLength - 1) {
-        this._unboundToken = token;
+        this._predictable = searchModule;
       } else {
-        this._boundTokens.push(token);
+        this._correctables.push(searchModule);
       }
     });
 
     this._lockedTokenResults = new Map();
-    const lockedTokens = this._lockedTokens;
-    lockedTokens.forEach((t) => {
-      const lockedResult = t.searchModule.bestExample;
-      this._lockedTokenResults.set(t, {
+    const uncorrectables = this._uncorrectables;
+    uncorrectables.forEach((uncorrectable) => {
+      const lockedResult = uncorrectable.bestExample;
+      this._lockedTokenResults.set(uncorrectable, {
         matchString: lockedResult.text,
         inputSamplingCost: 0,
         knownCost: -Math.log(lockedResult.p),
@@ -121,20 +124,20 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
       });
     });
 
-    let totalCost = lockedTokens.reduce((accum, curr) => accum - Math.log(curr.searchModule.bestExample.p), 0);
-    const tokenCostMap = this.tokenCostMap = new Map<ContextToken, number>();
+    let totalCost = uncorrectables.reduce((accum, curr) => accum - Math.log(curr.bestExample.p), 0);
+    const tokenCostMap = this.tokenCostMap = new Map<number, number>();
 
-    const tokensToQueue = this._boundTokens.concat(this.unboundToken ?? []);
-    tokensToQueue.forEach((t) => {
-      totalCost += t.searchModule.currentCost;
-      tokenCostMap.set(t, t.searchModule.currentCost);
+    const correctablesToQueue = this._correctables.concat(this.predictableToken?.searchModule ?? []);
+    correctablesToQueue.forEach((t) => {
+      totalCost += t.currentCost;
+      tokenCostMap.set(t.spaceId, t.currentCost);
     });
 
     this.lastTotalCost = totalCost;
 
     // Compute a weighting for each token's search space based the increase in
     // tokenization cost that it represents.
-    const tokenUpdateCost = (token: ContextToken) => token.searchModule.currentCost - (tokenCostMap.get(token) ?? 0)
+    const tokenUpdateCost = (searchModule: SearchQuotientNode) => searchModule.currentCost - (tokenCostMap.get(searchModule.spaceId) ?? 0)
     this.selectionQueue = new PriorityQueue((a, b) => {
       const aUpdateCost = tokenUpdateCost(a);
       const bUpdateCost = tokenUpdateCost(b);
@@ -144,15 +147,15 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
       return aUpdateCost - bUpdateCost;
     });
 
-    this.selectionQueue.enqueueAll(tokensToQueue);
+    this.selectionQueue.enqueueAll(correctablesToQueue);
   }
 
-  private getUpdatedTotalCost(updatedToken: ContextToken, tokenCost: number): number {
-    return this.lastTotalCost + tokenCost - (this.tokenCostMap.get(updatedToken) ?? 0);
+  private getUpdatedTotalCost(updatedCorrectable: SearchQuotientNode, tokenCost: number): number {
+    return this.lastTotalCost + tokenCost - (this.tokenCostMap.get(updatedCorrectable.spaceId) ?? 0);
   }
 
   private collateResults(): TokenizationResultMapping {
-    return new TokenizationResultMapping(this.orderedTokens.map((t) => this._lockedTokenResults.get(t)), this);
+    return new TokenizationResultMapping(this.orderedTokens.map((t) => this._lockedTokenResults.get(t.searchModule)), this);
   }
 
   handleNextNode(): PathResult<TokenizationResultMapping> {
@@ -167,8 +170,8 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     //     - Produce first search result!
     // 4.  Unbound token is unlocked, but all others are locked.
 
-    const tokenToUpdate = this.selectionQueue.dequeue();
-    const tokenResult = tokenToUpdate?.searchModule.handleNextNode();
+    const correctableToUpdate = this.selectionQueue.dequeue();
+    const tokenResult = correctableToUpdate?.handleNextNode();
 
     if(tokenResult?.type == 'none' || (!tokenResult && this.handleHasBeenCalled)) {
       // If we reach this point, the tokenization has exhausted its search space.
@@ -187,13 +190,13 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     this.handleHasBeenCalled = true;
 
     // Update the cost associated with the token.
-    const cost = this.lastTotalCost = this.getUpdatedTotalCost(tokenToUpdate, tokenResult.cost);
-    this.tokenCostMap.set(tokenToUpdate, tokenResult.cost);
+    const cost = this.lastTotalCost = this.getUpdatedTotalCost(correctableToUpdate, tokenResult.cost);
+    this.tokenCostMap.set(correctableToUpdate.spaceId, tokenResult.cost);
 
     // If we haven't found a valid correction for the token with lowest-cost update,
     // just requeue it and keep searching until we find one.
     if(tokenResult.type != 'complete') {
-      this.selectionQueue.enqueue(tokenToUpdate);
+      this.selectionQueue.enqueue(correctableToUpdate);
 
       // Needs to return the 'proper' type of result.
       return {
@@ -204,22 +207,22 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
 
     // Assertion:  tokenResult.type == 'complete'.  We have a valid correction for
     // at least some part of the tokenization - the represented context variant.
-    if(tokenToUpdate != this.unboundToken) {
+    if(correctableToUpdate != this._predictable) {
       // Lock the 'bound' token now that a valid correction for it has been
       // found. We only consider a single correction for most of a
       // tokenization's tokens, generally only allowing correction variation for
       // the last represented token.
-      this._boundTokens.splice(this._boundTokens.indexOf(tokenToUpdate), 1);
-      this._lockedTokens.push(tokenToUpdate);
+      this._correctables.splice(this._correctables.indexOf(correctableToUpdate), 1);
+      this._uncorrectables.push(correctableToUpdate);
     }
 
     // Either way, update the token -> correction-string map with the obtained result.
-    this._lockedTokenResults.set(tokenToUpdate, tokenResult.mapping);
+    this._lockedTokenResults.set(correctableToUpdate, tokenResult.mapping);
 
     // If we have a correction for all components in need of correction, allow
     // searching for alternative corrections for the 'unbound' token.
-    if(this._boundTokens.length == 0 && this._unboundToken) {
-      this.selectionQueue.enqueue(this._unboundToken);
+    if(this._correctables.length == 0 && this._predictable) {
+      this.selectionQueue.enqueue(this._predictable);
     }
 
     const correctionResults = this.collateResults();

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -1,3 +1,13 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by jahorton on 2026-04-02
+ *
+ * This file defines the `TokenizationCorrector` class, which is used to
+ * prioritize optimal multi-token corrections (and predictions) within the
+ * predictive-text correction-search engine.
+ */
+
 import { PriorityQueue } from "@keymanapp/web-utils";
 
 import { ContextToken } from "./context-token.js";

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -15,6 +15,8 @@ import { CorrectionSearchable, PathResult } from "./correction-searchable.js";
 import { ContextTokenization } from "./context-tokenization.js";
 import { SearchQuotientNode } from "./search-quotient-node.js";
 import { TokenizationResultMapping } from "./tokenization-result-mapping.js";
+import { EDIT_DISTANCE_COST_SCALE } from "./distance-modeler.js";
+import { MAX_EDIT_THRESHOLD_FACTOR } from "./search-quotient-spur.js";
 
 // PathResult needs to be generic:
 // - a result for correcting a single Token - "TokenResult"?
@@ -120,8 +122,8 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
       const lockedResult = uncorrectable.bestExample;
       this._lockedTokenResults.set(uncorrectable, {
         matchString: lockedResult.text,
-        inputSamplingCost: 0,
-        knownCost: -Math.log(lockedResult.p),
+        inputSamplingCost: -Math.log(lockedResult.p),
+        knownCost: 0,
         totalCost: -Math.log(lockedResult.p)
       });
     });
@@ -172,58 +174,79 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     //     - Produce first search result!
     // 4.  Unbound token is unlocked, but all others are locked.
 
-    const correctableToUpdate = this.selectionQueue.dequeue();
-    const tokenResult = correctableToUpdate?.handleNextNode();
-
-    if(tokenResult?.type == 'none' || (!tokenResult && this.handleHasBeenCalled)) {
+    if(this.selectionQueue.count == 0) {
       // If we reach this point, the tokenization has exhausted its search space.
-      return {
-        'type': 'none'
-      };
-    } else if(!tokenResult) {
-      this.handleHasBeenCalled = true;
-      return {
-        'type': 'complete',
-        cost: this.lastTotalCost,
-        mapping: this.collateResults()
-      };
+      if(this.handleHasBeenCalled) {
+        return { type: 'none' };
+      } else {
+        // It is possible that the editable tokenization range exists entirely of
+        // tokens considered to be uncorrectable.
+        this.handleHasBeenCalled = true;
+        return {
+          'type': 'complete',
+          cost: this.lastTotalCost,
+          mapping: this.collateResults()
+        };
+      }
     }
 
     this.handleHasBeenCalled = true;
 
+    const correctableToUpdate = this.selectionQueue.dequeue();
+    const tokenResult = correctableToUpdate?.handleNextNode();
+
+    if(tokenResult.type == 'none') {
+      // Transition the node from 'correctable' to 'uncorrectable' - we were
+      // unable to find valid corrections for it.
+      const lockedResult = correctableToUpdate.bestExample;
+      this._lockedTokenResults.set(correctableToUpdate, {
+        matchString: lockedResult.text,
+        inputSamplingCost: -Math.log(lockedResult.p),
+        knownCost: MAX_EDIT_THRESHOLD_FACTOR, // we'll use the same threshold at which further search is terminated.
+        totalCost: -Math.log(lockedResult.p) + MAX_EDIT_THRESHOLD_FACTOR * EDIT_DISTANCE_COST_SCALE
+      });
+
+      // We can make no further predictions if we've exhausted all search options.
+      if(correctableToUpdate == this._predictable) {
+        this._uncorrectables.push(correctableToUpdate);
+        delete this._predictable;
+      }
+      // else - while we COULD remove the correctable from the correctables
+      // list, there's no real impact to leaving it where it is.
+    } else if(tokenResult.type == 'complete') {
+      // Note that at this stage, we do not requeue the 'predictable' - other
+      // correctables may exist and need their first corrections before we look
+      // for other corrective variations of the 'predictable'.
+      if(correctableToUpdate != this._predictable) {
+        // Lock the 'correctable' token now that a valid correction for it has been
+        // found. We only consider a single correction for most of a
+        // tokenization's tokens, generally only allowing correction variation for
+        // the last represented token.
+        this._correctables.splice(this._correctables.indexOf(correctableToUpdate), 1);
+        this._uncorrectables.push(correctableToUpdate);
+      }
+
+      // Either way, update the token -> correction-string map with the obtained result.
+      this._lockedTokenResults.set(correctableToUpdate, tokenResult.mapping);
+    }
+
+    const resultCost = tokenResult.type != 'none' ? tokenResult.cost : this._lockedTokenResults.get(correctableToUpdate).totalCost
+
     // Update the cost associated with the token.
-    const cost = this.lastTotalCost = this.getUpdatedTotalCost(correctableToUpdate, tokenResult.cost);
-    this.tokenCostMap.set(correctableToUpdate.spaceId, tokenResult.cost);
+    const tokenizationCost = this.lastTotalCost = this.getUpdatedTotalCost(correctableToUpdate, resultCost);
+    this.tokenCostMap.set(correctableToUpdate.spaceId, resultCost);
 
     // If we haven't found a valid correction for the token with lowest-cost update,
     // just requeue it and keep searching until we find one.
-    if(tokenResult.type != 'complete') {
+    if(tokenResult.type == 'intermediate') {
       this.selectionQueue.enqueue(correctableToUpdate);
 
       // Needs to return the 'proper' type of result.
       return {
         type: 'intermediate',
-        cost
+        cost: tokenizationCost
       };
     }
-
-    // Note that at this stage, we do not requeue the 'predictable' - other
-    // correctables may exist and need their first corrections before we look
-    // for other corrective variations of the 'predictable'.
-
-    // Assertion:  tokenResult.type == 'complete'.  We have a valid correction for
-    // at least some part of the tokenization - the represented context variant.
-    if(correctableToUpdate != this._predictable) {
-      // Lock the 'correctable' token now that a valid correction for it has been
-      // found. We only consider a single correction for most of a
-      // tokenization's tokens, generally only allowing correction variation for
-      // the last represented token.
-      this._correctables.splice(this._correctables.indexOf(correctableToUpdate), 1);
-      this._uncorrectables.push(correctableToUpdate);
-    }
-
-    // Either way, update the token -> correction-string map with the obtained result.
-    this._lockedTokenResults.set(correctableToUpdate, tokenResult.mapping);
 
     // If we have a correction for all components in need of correction, then
     // search for alternative corrections for the 'predictable' token - even if
@@ -237,14 +260,14 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     if(correctionResults.matchedResult.findIndex((c) => c == undefined) != -1) {
       return {
         type: 'intermediate',
-        cost
+        cost: tokenizationCost
       };
     }
 
     // Determine the proper return type and construct the proper return object accordingly.
     return {
       type: 'complete',
-      cost,
+      cost: tokenizationCost,
       mapping: correctionResults
     };
   }

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -1,0 +1,218 @@
+import { PriorityQueue } from "@keymanapp/web-utils";
+
+import { ContextToken } from "./context-token.js";
+import { CorrectionSearchable, PathResult } from "./correction-searchable.js";
+import { ContextTokenization } from "../test-index.js";
+import { TokenizationResultMapping } from "./tokenization-result-mapping.js";
+
+// PathResult needs to be generic:
+// - a result for correcting a single Token - "TokenResult"?
+// - a result for completing correction for a full Tokenization - "TokenizationResult"?
+
+export type TokenResult = {
+  matchString: string,
+  inputSamplingCost: number,
+  knownCost: number,
+  totalCost: number
+}
+
+export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray<TokenResult>, TokenizationResultMapping> {
+  public readonly tokenization: ContextTokenization;
+  private readonly tailCorrectionLength: number
+
+  private readonly _lockedTokens: ContextToken[];
+  private readonly _boundTokens: ContextToken[];
+  private _unboundToken?: ContextToken;
+
+  private selectionQueue: PriorityQueue<ContextToken>;
+  private tokenCostMap: Map<ContextToken, number>;
+  private _lockedTokenResults: Map<ContextToken, TokenResult>;
+  private lastTotalCost: number;
+
+  get currentCost(): number {
+    const token = this.selectionQueue.peek();
+    if(!token) {
+      return this.lastTotalCost;
+    }
+
+    return this.getUpdatedTotalCost(token, token.searchModule.currentCost);
+  };
+
+  get orderedTokens(): ReadonlyArray<ContextToken> {
+    return this.tokenization.tokens.slice(-this.tailCorrectionLength);
+  }
+
+  get lockedTokens(): ReadonlyArray<ContextToken> {
+    return this._lockedTokens;
+  }
+
+  get boundTokens(): ReadonlyArray<ContextToken> {
+    return this._boundTokens;
+  }
+
+  get unboundToken(): ContextToken {
+    return this._unboundToken;
+  }
+
+  get lockedTokenResults(): ReadonlyMap<ContextToken, TokenResult> {
+    return this._lockedTokenResults;
+  }
+
+  // Will have actual result sequences.
+  //
+  // Once we have an actual answer for all non-locked tokens, the first entry
+  // should appear.  The only variation among results, after that, should be the
+  // correction for the last token.
+  //
+  // Results may be a clone of the lockedTokenResults map.  The owning
+  // tokenization may then flesh out the ordering of the entries to build the
+  // proper corrections / predictions.
+  get previousResults(): TokenizationResultMapping[] {
+    return [];
+  };
+
+  constructor(
+    tokenization: ContextTokenization,
+    tailCorrectionLength: number,
+    filterClosure: (token: ContextToken) => boolean
+  ) {
+    this.tokenization = tokenization;
+    this.tailCorrectionLength = tailCorrectionLength;
+
+    if(tailCorrectionLength < 1) {
+      throw new Error(`Length for correction near tail may not be 0.`);
+    }
+
+    const correctables = this.orderedTokens;
+
+    this._lockedTokens = [];
+    this._boundTokens = [];
+
+    correctables.forEach((token, index) => {
+      if(!filterClosure(token)) {
+        this._lockedTokens.push(token);
+      } else if(index == tailCorrectionLength - 1) {
+        this._unboundToken = token;
+      } else {
+        this._boundTokens.push(token);
+      }
+    });
+
+    this._lockedTokenResults = new Map();
+    const lockedTokens = this._lockedTokens;
+    lockedTokens.forEach((t) => {
+      const lockedResult = t.searchModule.bestExample;
+      this._lockedTokenResults.set(t, {
+        matchString: lockedResult.text,
+        inputSamplingCost: 0,
+        knownCost: -Math.log(lockedResult.p),
+        totalCost: -Math.log(lockedResult.p)
+      });
+    });
+
+    let totalCost = lockedTokens.reduce((accum, curr) => accum - Math.log(curr.searchModule.bestExample.p), 0);
+    const tokenCostMap = this.tokenCostMap = new Map<ContextToken, number>();
+
+    const tokensToQueue = this._boundTokens.concat(this.unboundToken ?? []);
+    tokensToQueue.forEach((t) => {
+      totalCost += t.searchModule.currentCost;
+      tokenCostMap.set(t, t.searchModule.currentCost);
+    });
+
+    this.lastTotalCost = totalCost;
+
+    // Compute a weighting for each token's search space based the increase in
+    // tokenization cost that it represents.
+    const tokenUpdateCost = (token: ContextToken) => token.searchModule.currentCost - (tokenCostMap.get(token) ?? 0)
+    this.selectionQueue = new PriorityQueue((a, b) => {
+      const aUpdateCost = tokenUpdateCost(a);
+      const bUpdateCost = tokenUpdateCost(b);
+
+      // Division or subtraction, we get the same effect for ordering:  the
+      // operands are all positive.  Subtraction is computationally less costly.
+      return aUpdateCost - bUpdateCost;
+    });
+
+    this.selectionQueue.enqueueAll(tokensToQueue);
+  }
+
+  private getUpdatedTotalCost(updatedToken: ContextToken, tokenCost: number): number {
+    return this.lastTotalCost + tokenCost - (this.tokenCostMap.get(updatedToken) ?? 0);
+  }
+
+  handleNextNode(): PathResult<TokenizationResultMapping> {
+    // Notable states:
+    // 1.  Unbound tokens have not yet been "locked" - no valid correction has yet been found.
+    //     - Variation:  the final, "unbound" token may be locked while awaiting this case.
+    //     - If so, remember the corresponding matchString!
+    // 2.  An unbound token may become "locked" - a workable correction is found.
+    //     - Remember the correction's matchString / correction!
+    // 3.  The **last** unbound token may finally become "locked".
+    //     - If final "unbound" token is locked, unlock it!
+    //     - Produce first search result!
+    // 4.  Unbound token is unlocked, but all others are locked.
+
+    const tokenToUpdate = this.selectionQueue.dequeue();
+    const tokenResult = tokenToUpdate.searchModule.handleNextNode();
+
+    if(tokenResult.type == 'none') {
+      // If we reach this point, the tokenization has exhausted its search space.
+      return {
+        'type': 'none'
+      };
+    }
+
+    // Update the cost associated with the token.
+    const cost = this.lastTotalCost = this.getUpdatedTotalCost(tokenToUpdate, tokenResult.cost);
+    this.tokenCostMap.set(tokenToUpdate, tokenResult.cost);
+
+    // If we haven't found a valid correction for the token with lowest-cost update,
+    // just requeue it and keep searching until we find one.
+    if(tokenResult.type != 'complete') {
+      this.selectionQueue.enqueue(tokenToUpdate);
+
+      // Needs to return the 'proper' type of result.
+      return {
+        type: 'intermediate',
+        cost
+      };
+    }
+
+    // Assertion:  tokenResult.type == 'complete'.  We have a valid correction for
+    // at least some part of the tokenization - the represented context variant.
+    if(tokenToUpdate != this.unboundToken) {
+      // Lock the 'bound' token now that a valid correction for it has been
+      // found. We only consider a single correction for most of a
+      // tokenization's tokens, generally only allowing correction variation for
+      // the last represented token.
+      this._boundTokens.splice(this._boundTokens.indexOf(tokenToUpdate), 1);
+      this._lockedTokens.push(tokenToUpdate);
+    }
+
+    // Either way, update the token -> correction-string map with the obtained result.
+    this._lockedTokenResults.set(tokenToUpdate, tokenResult.mapping);
+
+    // If we have a correction for all components in need of correction, allow
+    // searching for alternative corrections for the 'unbound' token.
+    if(this._boundTokens.length == 0 && this._unboundToken) {
+      this.selectionQueue.enqueue(this._unboundToken);
+    }
+
+    const tokenCorrections: TokenResult[] = this.orderedTokens.map((t) => this._lockedTokenResults.get(t));
+
+    if(tokenCorrections.findIndex((c) => c == undefined) != -1) {
+      return {
+        type: 'intermediate',
+        cost
+      }
+    }
+
+    // Determine the proper return type and construct the proper return object accordingly.
+    // const resultMap = new Map(this.lockedTokenResults);
+    return {
+      type: 'complete',
+      cost,
+      mapping: new TokenizationResultMapping(tokenCorrections, this)
+    };
+  }
+}

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -22,6 +22,15 @@ import { MAX_EDIT_THRESHOLD_FACTOR } from "./search-quotient-spur.js";
 // - a result for correcting a single Token - "TokenResult"?
 // - a result for completing correction for a full Tokenization - "TokenizationResult"?
 
+/**
+ * Implements an interface (extended by TokenResultMapping) that represents the
+ * form (and related probability data) of a token to be utilized for generation
+ * of predictions.
+ *
+ * Notably, this can be instantiated directly from a token without use of
+ * correction-search while still adhering to an interface compatible with
+ * correction results.
+ */
 export type TokenResult = {
   matchString: string,
   inputSamplingCost: number,
@@ -29,19 +38,27 @@ export type TokenResult = {
   totalCost: number
 }
 
+/**
+ * This class is the focal point for support of whitespace and word-boundary
+ * correction.  It uses the SearchQuotientNode search-spaces of an existing
+ * tokenization's tokens to optimally prioritize the correction process among
+ * all correctable tokens, generating corrections for the full represented
+ * range.
+ */
 export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray<TokenResult>, TokenizationResultMapping> {
   public readonly tokenization: ContextTokenization;
-  private readonly tailCorrectionLength: number
+  private readonly tailCorrectionLength: number;
 
+  // public read-only via properties
   private readonly _uncorrectables: SearchQuotientNode[];
   private readonly _correctables: SearchQuotientNode[];
   private _predictable?: SearchQuotientNode;
+  private _generatedTokenResults: Map<SearchQuotientNode, TokenResult>;
+  private _previousResults: TokenizationResultMapping[] = [];
 
-  private _returnedResults: TokenizationResultMapping[] = [];
-
+  // fully private
   private selectionQueue: PriorityQueue<SearchQuotientNode>;
   private tokenCostMap: Map<number, number>;
-  private _lockedTokenResults: Map<SearchQuotientNode, TokenResult>;
   private lastTotalCost: number;
   private handleHasBeenCalled: boolean = false;
 
@@ -54,24 +71,57 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     return this.getUpdatedTotalCost(correctable, correctable.currentCost);
   };
 
+  /**
+   * Returns the tokens contributing in some manner to correction-search and its weightings.
+   */
   get orderedTokens(): ReadonlyArray<ContextToken> {
     return this.tokenization.tokens.slice(-this.tailCorrectionLength);
   }
 
+  /**
+   * Returns the tokens, in order, that are considered "uncorrectable"; correction-search will not
+   * perform no further text-correction on them.
+   *
+   * Note that some tokens may have started out this way initially, becoming "uncorrectable" after
+   * their first viable correction was found.
+   *
+   * Other tokens may have been labeled "uncorrectable" from the start.
+   */
   get uncorrectableTokens(): ReadonlyArray<ContextToken> {
     return this.orderedTokens.filter((t) => this._uncorrectables.find((c) => c.spaceId == t.spaceId));
   }
 
+  /**
+   * Returns the tokens, in order, that are considered "correctable".
+   *
+   * Correction-search will search for only the first viable correction for each
+   * and will penalize any additional codepoints not already within the token
+   * that prove necesssary to match a valid lexical entry.
+   */
   get correctableTokens(): ReadonlyArray<ContextToken> {
     return this.orderedTokens.filter((t) => this._correctables.find((c) => c.spaceId == t.spaceId));
   }
 
+  /**
+   * Returns the token, if it exists, that is considered "predictable".
+   *
+   * Correction-search will search for any number of corrections for this token
+   * provided that the list of "correctables" has been exhausted.  If the list
+   * of "correctables" still has entries, once an initial correction is found
+   * for this token, correction will be suspended until the correctables list
+   * is empty.
+   */
   get predictableToken(): ContextToken {
     return this.orderedTokens.find((t) => this._predictable?.spaceId == t.spaceId);
   }
 
-  get lockedTokenResults(): ReadonlyMap<ContextToken, TokenResult> {
-    return new Map([...this._lockedTokenResults.entries()]
+  /**
+   * Returns the current map of token-to-corrections that has been determined thus far.
+   *
+   * Tokens initially considered "uncorrectable" will have valid, pre-set entries.
+   */
+  get generatedTokenResults(): ReadonlyMap<ContextToken, TokenResult> {
+    return new Map([...this._generatedTokenResults.entries()]
       .map((tuple) => [this.orderedTokens.find((t) => t.searchModule == tuple[0]), tuple[1]]));
   }
 
@@ -85,9 +135,20 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
   // tokenization may then flesh out the ordering of the entries to build the
   // proper corrections / predictions.
   get previousResults(): TokenizationResultMapping[] {
-    return this._returnedResults;
+    return this._previousResults;
   };
 
+  /**
+   * Constructs an instance of TokenizationCorrector for finding corrections for
+   * correctable tokens within the specified section of an existing
+   * ContextTokenization.
+   * @param tokenization   The tokenization pattern under consideration,
+   * containing tokens that may be correctable
+   * @param tailCorrectionLength  The length, in tokens, at the end of the
+   * tokenization pattern that should be considered for correction
+   * @param filterClosure  A closure that indicates via boolean whether to permit correction
+   * for each token
+   */
   constructor(
     tokenization: ContextTokenization,
     tailCorrectionLength: number,
@@ -97,9 +158,9 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     this.tailCorrectionLength = tailCorrectionLength;
 
     if(tailCorrectionLength < 1) {
-      throw new Error(`Length for correction near tail may not be 0.`);
+      throw new Error(`Length for correction near tail may not be ${tailCorrectionLength} - it must be a positive number.`);
     } else if(tailCorrectionLength > tokenization.tokens.length) {
-      throw new Error(`Tail correction length must not extend actual token count`);
+      throw new Error(`Tail correction length must not extend actual token count - ${tailCorrectionLength} > ${tokenization.tokens.length}`);
     }
 
     const correctables = this.orderedTokens;
@@ -112,17 +173,20 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
       if(!filterClosure(token)) {
         this._uncorrectables.push(searchModule);
       } else if(index == tailCorrectionLength - 1) {
+        // The sole assignment case for this field.  It may only be assigned for
+        // the final token, and only if its text is of a form considered
+        // correctable by the filter.
         this._predictable = searchModule;
       } else {
         this._correctables.push(searchModule);
       }
     });
 
-    this._lockedTokenResults = new Map();
+    this._generatedTokenResults = new Map();
     const uncorrectables = this._uncorrectables;
     uncorrectables.forEach((uncorrectable) => {
       const lockedResult = uncorrectable.bestExample;
-      this._lockedTokenResults.set(uncorrectable, {
+      this._generatedTokenResults.set(uncorrectable, {
         matchString: lockedResult.text,
         inputSamplingCost: -Math.log(lockedResult.p),
         knownCost: 0,
@@ -141,8 +205,8 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
 
     this.lastTotalCost = totalCost;
 
-    // Compute a weighting for each token's search space based the increase in
-    // tokenization cost that it represents.
+    // Compute a weighting for each token's search space based upon the increase
+    // in tokenization cost that it represents.
     const tokenUpdateCost = (searchModule: SearchQuotientNode) => searchModule.currentCost - (tokenCostMap.get(searchModule.spaceId) ?? 0)
     this.selectionQueue = new PriorityQueue((a, b) => {
       const aUpdateCost = tokenUpdateCost(a);
@@ -160,10 +224,14 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     return this.lastTotalCost + tokenCost - (this.tokenCostMap.get(updatedCorrectable.spaceId) ?? 0);
   }
 
+  /**
+   * Converts the internal 'generated token results' map into the proper Tokenization-correction return type.
+   */
   private collateResults(): TokenizationResultMapping {
-    return new TokenizationResultMapping(this.orderedTokens.map((t) => this._lockedTokenResults.get(t.searchModule)), this);
+    return new TokenizationResultMapping(this.orderedTokens.map((t) => this._generatedTokenResults.get(t.searchModule)), this);
   }
 
+  // The actual method used to iteratively search for tokenization-level corrections.
   handleNextNode(): PathResult<TokenizationResultMapping> {
     // Notable states:
     // 1.  Unbound tokens have not yet been "locked" - no valid correction has yet been found.
@@ -185,7 +253,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
         // tokens considered to be uncorrectable.
         this.handleHasBeenCalled = true;
         const results = this.collateResults();
-        this._returnedResults.push(results);
+        this._previousResults.push(results);
         return {
           'type': 'complete',
           cost: this.lastTotalCost,
@@ -215,7 +283,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
       // Transition the node from 'correctable' to 'uncorrectable' - we were
       // unable to find valid corrections for it.
       const lockedResult = correctableToUpdate.bestExample;
-      this._lockedTokenResults.set(correctableToUpdate, {
+      this._generatedTokenResults.set(correctableToUpdate, {
         matchString: lockedResult.text,
         inputSamplingCost: -Math.log(lockedResult.p),
         knownCost: MAX_EDIT_THRESHOLD_FACTOR, // we'll use the same threshold at which further search is terminated.
@@ -236,10 +304,10 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
       delistCorrectable();
 
       // Either way, update the token -> correction-string map with the obtained result.
-      this._lockedTokenResults.set(correctableToUpdate, tokenResult.mapping);
+      this._generatedTokenResults.set(correctableToUpdate, tokenResult.mapping);
     }
 
-    const resultCost = tokenResult.type != 'none' ? tokenResult.cost : this._lockedTokenResults.get(correctableToUpdate).totalCost
+    const resultCost = tokenResult.type != 'none' ? tokenResult.cost : this._generatedTokenResults.get(correctableToUpdate).totalCost;
 
     // Update the cost associated with the token.
     const tokenizationCost = this.lastTotalCost = this.getUpdatedTotalCost(correctableToUpdate, resultCost);
@@ -274,7 +342,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     }
 
     // Determine the proper return type and construct the proper return object accordingly.
-    this._returnedResults.push(correctionResults);
+    this._previousResults.push(correctionResults);
     return {
       type: 'complete',
       cost: tokenizationCost,

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -195,6 +195,18 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     const correctableToUpdate = this.selectionQueue.dequeue();
     const tokenResult = correctableToUpdate?.handleNextNode();
 
+    const delistCorrectable = () => {
+      if(correctableToUpdate != this._predictable) {
+        // Lock the 'correctable' token now that either a valid correction for
+        // it has been found or all possible corrections are exhausted. We only
+        // consider a single correction for most of a tokenization's tokens,
+        // generally only allowing correction variation for the last represented
+        // token.
+        this._correctables.splice(this._correctables.indexOf(correctableToUpdate), 1);
+        this._uncorrectables.push(correctableToUpdate);
+      }
+    }
+
     if(tokenResult.type == 'none') {
       // Transition the node from 'correctable' to 'uncorrectable' - we were
       // unable to find valid corrections for it.
@@ -210,21 +222,14 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
       if(correctableToUpdate == this._predictable) {
         this._uncorrectables.push(correctableToUpdate);
         delete this._predictable;
+      } else {
+        delistCorrectable();
       }
-      // else - while we COULD remove the correctable from the correctables
-      // list, there's no real impact to leaving it where it is.
     } else if(tokenResult.type == 'complete') {
       // Note that at this stage, we do not requeue the 'predictable' - other
       // correctables may exist and need their first corrections before we look
       // for other corrective variations of the 'predictable'.
-      if(correctableToUpdate != this._predictable) {
-        // Lock the 'correctable' token now that a valid correction for it has been
-        // found. We only consider a single correction for most of a
-        // tokenization's tokens, generally only allowing correction variation for
-        // the last represented token.
-        this._correctables.splice(this._correctables.indexOf(correctableToUpdate), 1);
-        this._uncorrectables.push(correctableToUpdate);
-      }
+      delistCorrectable();
 
       // Either way, update the token -> correction-string map with the obtained result.
       this._lockedTokenResults.set(correctableToUpdate, tokenResult.mapping);

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -82,7 +82,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
    * Returns the tokens, in order, that are considered "uncorrectable"; correction-search will not
    * perform no further text-correction on them.
    *
-   * Note that some tokens may have started out this way initially, becoming "uncorrectable" after
+   * Note that some tokens may have started out as "correctable" initially, becoming "uncorrectable" after
    * their first viable correction was found.
    *
    * Other tokens may have been labeled "uncorrectable" from the start.

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-result-mapping.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-result-mapping.ts
@@ -1,0 +1,44 @@
+import { CorrectionResultMapping } from "./correction-result-mapping.js";
+import { TokenizationCorrector, TokenResult } from './tokenization-corrector.js';
+
+export class TokenizationResultMapping implements CorrectionResultMapping<ReadonlyArray<TokenResult>> {
+  readonly matchingSpace: TokenizationCorrector;
+  readonly matchedResult: ReadonlyArray<TokenResult>;
+
+  // Supports SearchPath -> SearchSpace remapping.
+  readonly spaceId: number;
+
+  constructor(tokenization: TokenResult[], corrector: TokenizationCorrector) {
+    this.matchingSpace = corrector;
+    this.matchedResult = tokenization;
+  }
+
+  // /**
+  //  * Gets the number of Damerau-Levenshtein edits needed to reach the node's
+  //  * matchString from the output induced by the input sequence used to reach it.
+  //  *
+  //  * (This is scaled by `SearchSpace.EDIT_DISTANCE_COST_SCALE` when included in
+  //  * `totalCost`.)
+  //  */
+  // get knownCost(): number {
+  //   return this.node.editCount;
+  // }
+
+  // /**
+  //  * Gets the "input sampling cost" of the edge, which should be considered as the
+  //  * negative log-likelihood of the input path taken to reach the node.
+  //  */
+  // get inputSamplingCost(): number {
+  //   return this.node.inputSamplingCost;
+  // }
+
+  /**
+   * Gets the "total cost" of the edge, which should be considered as the
+   * negative log-likelihood of the input path taken to reach the node
+   * multiplied by the 'probability' induced by needed Damerau-Levenshtein edits
+   * to the resulting output.
+   */
+  get totalCost(): number {
+    return this.matchedResult.reduce((total, curr) => total + curr.totalCost, 0);
+  }
+}

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-result-mapping.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-result-mapping.ts
@@ -5,12 +5,13 @@ export class TokenizationResultMapping implements CorrectionResultMapping<Readon
   readonly matchingSpace: TokenizationCorrector;
   readonly matchedResult: ReadonlyArray<TokenResult>;
 
-  // Supports SearchPath -> SearchSpace remapping.
-  readonly spaceId: number;
-
   constructor(tokenization: TokenResult[], corrector: TokenizationCorrector) {
     this.matchingSpace = corrector;
     this.matchedResult = tokenization;
+  }
+
+  get spaceId(): number {
+    return this.matchingSpace.tokenization.spaceId;
   }
 
   // /**

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -589,6 +589,8 @@ export async function correctAndEnumerate(
   const tokenizations = [transition.final.tokenization];
   const searchModules = tokenizations.map(t => t.tail.searchModule);
 
+  // const preppedTokenizationSearch = prepareTokenizationSearch(transition, tokenizations);
+
   // Only run the correction search when corrections are enabled.
   let rawPredictions: CorrectionPredictionTuple[] = [];
   let bestCorrectionCost: number;

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -589,8 +589,6 @@ export async function correctAndEnumerate(
   const tokenizations = [transition.final.tokenization];
   const searchModules = tokenizations.map(t => t.tail.searchModule);
 
-  // const preppedTokenizationSearch = prepareTokenizationSearch(transition, tokenizations);
-
   // Only run the correction search when corrections are enabled.
   let rawPredictions: CorrectionPredictionTuple[] = [];
   let bestCorrectionCost: number;

--- a/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
@@ -18,6 +18,7 @@ export * from './correction/tokenization-corrector.js';
 export * from './correction/tokenization-subsets.js';
 export * from './correction/transition-helpers.js';
 export * from './correction/token-result-mapping.js';
+export * from './correction/tokenization-result-mapping.js';
 export * as correction from './correction/index.js';
 export * from './model-helpers.js';
 export * as models from './models/index.js';

--- a/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
@@ -14,6 +14,7 @@ export * from './correction/legacy-quotient-root.js';
 export * from './correction/legacy-quotient-spur.js';
 export * from './correction/search-quotient-root.js';
 export { ExtendedEditOperation, SegmentableDistanceCalculation } from './correction/segmentable-calculation.js';
+export * from './correction/tokenization-corrector.js';
 export * from './correction/tokenization-subsets.js';
 export * from './correction/transition-helpers.js';
 export * from './correction/token-result-mapping.js';

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
@@ -305,8 +305,8 @@ describe('TokenizationCorrector', () => {
 
         // Now that an entry has been found, verify the corrector's state.
         assert.isOk(instance.predictableToken); // should not become bound or locked.
-        assert.isTrue(instance.lockedTokenResults.has(instance.predictableToken));
-        assert.equal(instance.lockedTokenResults.get(instance.predictableToken), tokenResults[0]);
+        assert.isTrue(instance.generatedTokenResults.has(instance.predictableToken));
+        assert.equal(instance.generatedTokenResults.get(instance.predictableToken), tokenResults[0]);
       }
 
       searchResult = instance.handleNextNode();
@@ -350,9 +350,9 @@ describe('TokenizationCorrector', () => {
 
       // Now that an entry has been found, verify the corrector's state.
       assert.isOk(instance.predictableToken); // should not become bound or locked.
-      assert.isTrue(instance.lockedTokenResults.has(instance.predictableToken));
+      assert.isTrue(instance.generatedTokenResults.has(instance.predictableToken));
       for(let i=0; i < firstResults.length; i++) {
-        assert.equal(instance.lockedTokenResults.get(instance.orderedTokens[i]), firstResults[i]);
+        assert.equal(instance.generatedTokenResults.get(instance.orderedTokens[i]), firstResults[i]);
       }
 
       searchResult = instance.handleNextNode();

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
@@ -26,13 +26,13 @@ import {
   SearchQuotientNode,
   SearchQuotientRoot,
   TokenizationCorrector,
-  TokenResult
+  TokenResult,
+  TokenizationResultMapping
 } from '@keymanapp/lm-worker/test-index';
 
 import Distribution = LexicalModelTypes.Distribution;
 import TrieModel = models.TrieModel;
 import Transform = LexicalModelTypes.Transform;
-import { TokenizationResultMapping } from '../../../../../../../engine/predictive-text/worker-thread/build/obj/correction/tokenization-result-mapping.js';
 
 const plainModel = new TrieModel(
   jsonFixture('models/tries/english-1000'), {

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
@@ -1,0 +1,424 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by jahorton on 2026-04-14
+ *
+ * This file defines tests for the `TokenizationCorrector` class, which is used
+ * to prioritize optimal multi-token corrections (and predictions) within the
+ * predictive-text correction-search engine.
+ */
+
+import { assert } from 'chai';
+
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
+import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
+
+import {
+  ContextToken,
+  ContextTokenization,
+  correctionValidForAutoSelect,
+  generateSubsetId,
+  LegacyQuotientSpur,
+  models,
+  PathInputProperties,
+  PathResult,
+  SearchQuotientNode,
+  SearchQuotientRoot,
+  TokenizationCorrector,
+  TokenResult
+} from '@keymanapp/lm-worker/test-index';
+
+import Distribution = LexicalModelTypes.Distribution;
+import TrieModel = models.TrieModel;
+import Transform = LexicalModelTypes.Transform;
+import { TokenizationResultMapping } from '../../../../../../../engine/predictive-text/worker-thread/build/obj/correction/tokenization-result-mapping.js';
+
+const plainModel = new TrieModel(
+  jsonFixture('models/tries/english-1000'), {
+    languageUsesCasing: true,
+    wordBreaker: defaultBreaker
+  }
+);
+
+function buildFixture_therefore() {
+  let ID_SEED = 11;
+
+  const distributionSrc: [string, number][][] = [
+    [ ['t', 1] ],
+    [ ['h', 1] ],
+    [ ['e', 0.6] ],
+    [ [' ', 0.8], ['r', 0.2] ],
+    [ ['e', 1] ],
+    [ ['f', 1] ]
+  ];
+
+  const distributions: Distribution<Required<Transform>>[] = distributionSrc.map((tupleArray) => {
+    const transitionId = ID_SEED++;
+    return tupleArray.map((tuple) => {
+      return {
+        p: tuple[1],
+        sample: {
+          insert: tuple[0],
+          deleteLeft: 0,
+          deleteRight: 0,
+          id: transitionId
+        }
+      }
+    });
+  });
+
+  // Assumes that the first entry in each distribution is the most likely.
+  const inputSources: PathInputProperties[] = distributions.map((dist) => {
+    return {
+      subsetId: generateSubsetId(),
+      segment: {start: 0, transitionId: dist[0].sample.id},
+      bestProbFromSet: dist[0].p
+    };
+  })
+
+  const therefTokens: ContextToken[] = []; // as in "therefore"
+  const the_efTokens: ContextToken[] = []; // as in "the effect"
+
+  // TODO:  Use SubstitutionQuotientSpur instead!
+  let firstTokenNode: SearchQuotientNode = new SearchQuotientRoot(plainModel);
+  for(let i=0; i < 3; i++) {
+    firstTokenNode = new LegacyQuotientSpur(firstTokenNode, distributions[i], inputSources[i]);
+  }
+
+  the_efTokens.push(new ContextToken(firstTokenNode, false));
+
+  firstTokenNode = new LegacyQuotientSpur(firstTokenNode, [distributions[3][1]], {
+    ...inputSources[3],
+    subsetId: generateSubsetId()
+  });
+
+  // whitespace token alternate - using the ' ' input instead.
+  const whitespaceToken = new ContextToken(
+    new LegacyQuotientSpur(
+      new SearchQuotientRoot(plainModel),
+      [distributions[3][0]],
+      { ...inputSources[3], subsetId: generateSubsetId() }
+    ), false
+  );
+  whitespaceToken.isWhitespace = true;
+  the_efTokens.push(whitespaceToken);
+
+  let secondTokenNode: SearchQuotientNode = new SearchQuotientRoot(plainModel);
+  for(let i=4; i < distributions.length; i++) {
+    firstTokenNode = new LegacyQuotientSpur(firstTokenNode, distributions[i], {
+      ...inputSources[i],
+      subsetId: generateSubsetId()
+    });
+    secondTokenNode = new LegacyQuotientSpur(secondTokenNode, distributions[i], {
+      ...inputSources[i],
+      subsetId: generateSubsetId()
+    })
+  }
+
+  therefTokens.push(new ContextToken(firstTokenNode));
+  the_efTokens.push(new ContextToken(secondTokenNode));
+
+  return {
+    filter: (token: ContextToken) => correctionValidForAutoSelect(token.exampleInput),
+    theref: new ContextTokenization(therefTokens),
+    the_ef: new ContextTokenization(the_efTokens)
+  }
+}
+
+function buildFixture_terminalWhitespace() {
+  let ID_SEED = 11;
+
+  const distributionSrc: [string, number][][] = [
+    [ ['s', 1] ],
+    [ ['p', 1] ],
+    [ ['a', 1] ],
+    [ ['c', 1] ],
+    [ ['e', 1] ],
+    [ [' ', 1] ],
+  ];
+
+  const distributions: Distribution<Required<Transform>>[] = distributionSrc.map((tupleArray) => {
+    const transitionId = ID_SEED++;
+    return tupleArray.map((tuple) => {
+      return {
+        p: tuple[1],
+        sample: {
+          insert: tuple[0],
+          deleteLeft: 0,
+          deleteRight: 0,
+          id: transitionId
+        }
+      }
+    });
+  });
+
+  // Assumes that the first entry in each distribution is the most likely.
+  const inputSources: PathInputProperties[] = distributions.map((dist) => {
+    return {
+      subsetId: generateSubsetId(),
+      segment: {start: 0, transitionId: dist[0].sample.id},
+      bestProbFromSet: dist[0].p
+    };
+  })
+
+  const fullTokens: ContextToken[] = [];
+  const lastToken: ContextToken[] = [];
+
+  // TODO:  Use SubstitutionQuotientSpur instead!
+  let firstTokenNode: SearchQuotientNode = new SearchQuotientRoot(plainModel);
+  for(let i=0; i < 5; i++) {
+    firstTokenNode = new LegacyQuotientSpur(firstTokenNode, distributions[i], inputSources[i]);
+  }
+
+  fullTokens.push(new ContextToken(firstTokenNode, false));
+
+  // whitespace token alternate - using the ' ' input instead.
+  const whitespaceToken = new ContextToken(
+    new LegacyQuotientSpur(
+      new SearchQuotientRoot(plainModel),
+      distributions[5],
+      inputSources[5],
+    ), false
+  );
+  whitespaceToken.isWhitespace = true;
+  fullTokens.push(whitespaceToken);
+  lastToken.push(whitespaceToken);
+
+  return {
+    filter: (token: ContextToken) => correctionValidForAutoSelect(token.exampleInput),
+    wordThenSpace: new ContextTokenization(fullTokens),
+    spaceOnly: new ContextTokenization(lastToken)
+  }
+}
+
+describe('TokenizationCorrector', () => {
+  describe('constructor', () => {
+    it('constructs correctly from a single correctable token', () => {
+      const fixture = buildFixture_therefore();
+
+      const tokenization = fixture.theref;
+
+      const instance = new TokenizationCorrector(
+        tokenization,
+        1,
+        fixture.filter
+      );
+
+      assert.sameOrderedMembers(instance.lockedTokens.slice(), []);
+      assert.sameOrderedMembers(instance.boundTokens.slice(), []);
+      assert.equal(instance.unboundToken, tokenization.tail);
+    });
+
+    it('constructs correctly from a single uncorrectable token', () => {
+      const fixture = buildFixture_terminalWhitespace();
+
+      const tokenization = fixture.spaceOnly;
+
+      const instance = new TokenizationCorrector(
+        tokenization,
+        tokenization.tokens.length,
+        fixture.filter
+      );
+
+      assert.sameOrderedMembers(instance.lockedTokens.slice(), [tokenization.tail]);
+      assert.sameOrderedMembers(instance.boundTokens.slice(), []);
+      assert.equal(instance.unboundToken, undefined);
+    });
+
+    it('constructs from multiple tokens, with the middle one uncorrectable', () => {
+      const fixture = buildFixture_therefore();
+
+      const tokenization = fixture.the_ef;
+      const tokenCount = tokenization.tokens.length;
+
+      const instance = new TokenizationCorrector(
+        tokenization,
+        tokenCount,
+        fixture.filter
+      );
+
+      assert.sameOrderedMembers(instance.lockedTokens.slice(), [tokenization.tokens[tokenCount-2]]);
+      assert.sameOrderedMembers(instance.boundTokens.slice(), [tokenization.tokens[tokenCount-3]]);
+      assert.equal(instance.unboundToken, tokenization.tail);
+    });
+
+    it('constructs from multiple tokens, ignoring the first due to bounds', () => {
+      const fixture = buildFixture_therefore();
+
+      const tokenization = fixture.the_ef;
+      const tokenCount = tokenization.tokens.length;
+
+      const instance = new TokenizationCorrector(
+        tokenization,
+        tokenCount-1,
+        fixture.filter
+      );
+
+      assert.sameOrderedMembers(instance.lockedTokens.slice(), [tokenization.tokens[tokenCount-2]]);
+      assert.sameOrderedMembers(instance.boundTokens.slice(), []);
+      assert.equal(instance.unboundToken, tokenization.tail);
+    });
+
+    it('constructs correctly when the final token is uncorrectable', () => {
+      const fixture = buildFixture_terminalWhitespace();
+
+      const tokenization = fixture.wordThenSpace;
+
+      const instance = new TokenizationCorrector(
+        tokenization,
+        tokenization.tokens.length,
+        fixture.filter
+      );
+
+      assert.sameOrderedMembers(instance.lockedTokens.slice(), [tokenization.tail]);
+      assert.sameOrderedMembers(instance.boundTokens.slice(), [tokenization.tokens[0]]);
+      assert.equal(instance.unboundToken, undefined);
+    });
+  });
+
+  describe('handleNextNode', () => {
+    it('finds corrections for a single correctable token', () => {
+      const fixture = buildFixture_therefore();
+
+      const tokenization = fixture.theref;
+
+      const instance = new TokenizationCorrector(
+        tokenization,
+        1,
+        fixture.filter
+      );
+
+      let searchResult: PathResult<TokenizationResultMapping>;
+      do {
+        searchResult = instance.handleNextNode();
+      } while(searchResult.type == 'intermediate');
+
+      assert.equal(searchResult.type, 'complete');
+      if(searchResult.type == 'complete') {
+        const mapping = searchResult.mapping;
+        const tokenResults = mapping.matchedResult;
+        assert.isNotNaN(searchResult.cost);
+        assert.equal(searchResult.cost, searchResult.mapping.totalCost);
+        assert.equal(tokenResults.length, 1);
+        assert.sameOrderedMembers(tokenResults.map((r) => r.matchString), ['theref']);
+
+        // Now that an entry has been found, verify the corrector's state.
+        assert.isOk(instance.unboundToken); // should not become bound or locked.
+        assert.isTrue(instance.lockedTokenResults.has(instance.unboundToken));
+        assert.equal(instance.lockedTokenResults.get(instance.unboundToken), tokenResults[0]);
+      }
+
+      searchResult = instance.handleNextNode();
+      // There should be more results that may be found.
+      assert.notEqual(searchResult.type, 'none');
+
+      do {
+        searchResult = instance.handleNextNode();
+      } while(searchResult.type == 'intermediate');
+
+      assert.notEqual(searchResult.type, 'none');
+    });
+
+    it('finds corrections for a group of tokens with two correctable', () => {
+      const fixture = buildFixture_therefore();
+
+      const tokenization = fixture.the_ef;
+
+      const instance = new TokenizationCorrector(
+        tokenization,
+        3,
+        fixture.filter
+      );
+
+      let searchResult: PathResult<TokenizationResultMapping>;
+      do {
+        searchResult = instance.handleNextNode();
+      } while(searchResult.type == 'intermediate');
+
+      assert.equal(searchResult.type, 'complete');
+      let firstResults: ReadonlyArray<TokenResult>;
+      if(searchResult.type == 'complete') {
+        const mapping = searchResult.mapping;
+        const tokenResults = mapping.matchedResult;
+        firstResults = tokenResults;
+        assert.isNotNaN(searchResult.cost);
+        assert.equal(searchResult.cost, searchResult.mapping.totalCost);
+        assert.equal(tokenResults.length, 3);
+        assert.sameOrderedMembers(tokenResults.map((r) => r.matchString), ['the', ' ', 'ef']);
+      }
+
+      // Now that an entry has been found, verify the corrector's state.
+      assert.isOk(instance.unboundToken); // should not become bound or locked.
+      assert.isTrue(instance.lockedTokenResults.has(instance.unboundToken));
+      for(let i=0; i < firstResults.length; i++) {
+        assert.equal(instance.lockedTokenResults.get(instance.orderedTokens[i]), firstResults[i]);
+      }
+
+      searchResult = instance.handleNextNode();
+      // There should be more results that may be found.
+      assert.notEqual(searchResult.type, 'none');
+
+      do {
+        searchResult = instance.handleNextNode();
+        if(searchResult.type == 'complete') {
+          const mapping = searchResult.mapping;
+          const tokenResults = mapping.matchedResult;
+
+          // Verify that the first (bound) token is not altered further.
+          // It should receive no further correction attempts.
+          assert.equal(tokenResults[0], firstResults[0]);
+          assert.equal(tokenResults[1], firstResults[1]);
+          assert.notEqual(tokenResults[2], firstResults[2]);
+        }
+      } while(searchResult.type != 'none');
+    });
+
+    it('immediately returns a single result when the only represented token is uncorrectable', () => {
+      const fixture = buildFixture_terminalWhitespace();
+
+      const tokenization = fixture.spaceOnly;
+
+      const instance = new TokenizationCorrector(
+        tokenization,
+        tokenization.tokens.length,
+        fixture.filter
+      );
+
+      const searchResult = instance.handleNextNode();
+      assert.equal(searchResult.type, 'complete');
+      if(searchResult.type == 'complete') {
+        assert.equal(searchResult.mapping.matchedResult[0].matchString, ' ');
+      }
+
+      const nilResult = instance.handleNextNode();
+      assert.equal(nilResult.type, 'none');
+    });
+
+    it('returns a single result when the final token is uncorrectable', () => {
+      const fixture = buildFixture_terminalWhitespace();
+
+      const tokenization = fixture.wordThenSpace;
+
+      const instance = new TokenizationCorrector(
+        tokenization,
+        tokenization.tokens.length,
+        fixture.filter
+      );
+
+      let searchResult: PathResult<TokenizationResultMapping>;
+      do {
+        searchResult = instance.handleNextNode();
+      } while(searchResult.type == 'intermediate');
+
+      assert.equal(searchResult.type, 'complete');
+      if(searchResult.type == 'complete') {
+        assert.equal(searchResult.mapping.matchedResult[0].matchString, 'space');
+        assert.equal(searchResult.mapping.matchedResult[1].matchString, ' ');
+      }
+
+      const nilResult = instance.handleNextNode();
+      assert.equal(nilResult.type, 'none');
+    });
+  });
+});

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
@@ -205,9 +205,9 @@ describe('TokenizationCorrector', () => {
         fixture.filter
       );
 
-      assert.sameOrderedMembers(instance.lockedTokens.slice(), []);
-      assert.sameOrderedMembers(instance.boundTokens.slice(), []);
-      assert.equal(instance.unboundToken, tokenization.tail);
+      assert.sameOrderedMembers(instance.uncorrectableTokens.slice(), []);
+      assert.sameOrderedMembers(instance.correctableTokens.slice(), []);
+      assert.equal(instance.predictableToken, tokenization.tail);
     });
 
     it('constructs correctly from a single uncorrectable token', () => {
@@ -221,9 +221,9 @@ describe('TokenizationCorrector', () => {
         fixture.filter
       );
 
-      assert.sameOrderedMembers(instance.lockedTokens.slice(), [tokenization.tail]);
-      assert.sameOrderedMembers(instance.boundTokens.slice(), []);
-      assert.equal(instance.unboundToken, undefined);
+      assert.sameOrderedMembers(instance.uncorrectableTokens.slice(), [tokenization.tail]);
+      assert.sameOrderedMembers(instance.correctableTokens.slice(), []);
+      assert.equal(instance.predictableToken, undefined);
     });
 
     it('constructs from multiple tokens, with the middle one uncorrectable', () => {
@@ -238,9 +238,9 @@ describe('TokenizationCorrector', () => {
         fixture.filter
       );
 
-      assert.sameOrderedMembers(instance.lockedTokens.slice(), [tokenization.tokens[tokenCount-2]]);
-      assert.sameOrderedMembers(instance.boundTokens.slice(), [tokenization.tokens[tokenCount-3]]);
-      assert.equal(instance.unboundToken, tokenization.tail);
+      assert.sameOrderedMembers(instance.uncorrectableTokens.slice(), [tokenization.tokens[tokenCount-2]]);
+      assert.sameOrderedMembers(instance.correctableTokens.slice(), [tokenization.tokens[tokenCount-3]]);
+      assert.equal(instance.predictableToken, tokenization.tail);
     });
 
     it('constructs from multiple tokens, ignoring the first due to bounds', () => {
@@ -255,9 +255,9 @@ describe('TokenizationCorrector', () => {
         fixture.filter
       );
 
-      assert.sameOrderedMembers(instance.lockedTokens.slice(), [tokenization.tokens[tokenCount-2]]);
-      assert.sameOrderedMembers(instance.boundTokens.slice(), []);
-      assert.equal(instance.unboundToken, tokenization.tail);
+      assert.sameOrderedMembers(instance.uncorrectableTokens.slice(), [tokenization.tokens[tokenCount-2]]);
+      assert.sameOrderedMembers(instance.correctableTokens.slice(), []);
+      assert.equal(instance.predictableToken, tokenization.tail);
     });
 
     it('constructs correctly when the final token is uncorrectable', () => {
@@ -271,9 +271,9 @@ describe('TokenizationCorrector', () => {
         fixture.filter
       );
 
-      assert.sameOrderedMembers(instance.lockedTokens.slice(), [tokenization.tail]);
-      assert.sameOrderedMembers(instance.boundTokens.slice(), [tokenization.tokens[0]]);
-      assert.equal(instance.unboundToken, undefined);
+      assert.sameOrderedMembers(instance.uncorrectableTokens.slice(), [tokenization.tail]);
+      assert.sameOrderedMembers(instance.correctableTokens.slice(), [tokenization.tokens[0]]);
+      assert.equal(instance.predictableToken, undefined);
     });
   });
 
@@ -304,9 +304,9 @@ describe('TokenizationCorrector', () => {
         assert.sameOrderedMembers(tokenResults.map((r) => r.matchString), ['theref']);
 
         // Now that an entry has been found, verify the corrector's state.
-        assert.isOk(instance.unboundToken); // should not become bound or locked.
-        assert.isTrue(instance.lockedTokenResults.has(instance.unboundToken));
-        assert.equal(instance.lockedTokenResults.get(instance.unboundToken), tokenResults[0]);
+        assert.isOk(instance.predictableToken); // should not become bound or locked.
+        assert.isTrue(instance.lockedTokenResults.has(instance.predictableToken));
+        assert.equal(instance.lockedTokenResults.get(instance.predictableToken), tokenResults[0]);
       }
 
       searchResult = instance.handleNextNode();
@@ -349,8 +349,8 @@ describe('TokenizationCorrector', () => {
       }
 
       // Now that an entry has been found, verify the corrector's state.
-      assert.isOk(instance.unboundToken); // should not become bound or locked.
-      assert.isTrue(instance.lockedTokenResults.has(instance.unboundToken));
+      assert.isOk(instance.predictableToken); // should not become bound or locked.
+      assert.isTrue(instance.lockedTokenResults.has(instance.predictableToken));
       for(let i=0; i < firstResults.length; i++) {
         assert.equal(instance.lockedTokenResults.get(instance.orderedTokens[i]), firstResults[i]);
       }


### PR DESCRIPTION
As mentioned in the description of #15814, up until now, we've always searched for corrections for just one token at a time - the current token. To better support whitespace fat-fingering, we'll need the ability to answer the following question: "Which tokenization pattern is the closest to matching the current text after corrections?"  In essence, we need the ability to correct _word boundaries_, or perhaps to correct _the engine's tokenization of the context_.  

One notable way forward is to consider what valid corrections we can find for each token in the tokenized context.  This allows us to search for phrase-level corrections not focused on a specific word, prioritizing the most likely combination of tokenization-pattern and correction-cost for one of the pattern's tokens.

----

Now, as to the implementation of the new type...

Predictive text generally should not extend words not adjacent to the caret unnecessarily; predictive text exists to predict what is _yet to be typed_, rather than adjusting what was typed.  Corrections validly may adjust what was typed, but should not aim to add to it.  To use a simple example, for text such as `the quicl brown fox`, correcting `quicl` to `quick` may well be valid, but correcting the same word to `quickly` would not make sense - those two extra characters would appear out of nowhere.

So, when doing correction across a range of context, rather than a single token, we generally will want to _correct_ all words not adjacent to the token, only allowing _prediction_ for the adjacent token.

Build-bot: skip build:web
Test-bot: skip