### PR TITLE
fix(linux): fix memory problem

### DIFF
--- a/linux/ibus-keyman/src/engine.c
+++ b/linux/ibus-keyman/src/engine.c
@@ -782,7 +782,7 @@ commit_current_queue_item(IBusKeymanEngine *keyman) {
     ibus_engine_forward_key_event(engine, current_item->keyval, current_item->keycode, current_item->state);
   }
   keyman->commit_item--;
-  memmove(keyman->commit_queue, &keyman->commit_queue[1], sizeof(commit_queue_item) * MAX_QUEUE_SIZE - 1);
+  memmove(keyman->commit_queue, &keyman->commit_queue[1], sizeof(commit_queue_item) * (MAX_QUEUE_SIZE - 1));
   initialize_queue_items(keyman, MAX_QUEUE_SIZE - 1, 1);
 }
 


### PR DESCRIPTION
This fixes a problem identified by devin.ai: Because of the operator precedence the previous code caused `memmove` to read `sizeof(commit_queue_item) - 1` bytes past the end of `commit_queue`. With this change `memmove` now reads the intended `MAX_QUEUE_SIZE - 1` `commit_queue_items`.

Test-bot: skip