### PR TITLE
feat(web): adds finalizer quotient-node type for facilitating multi-word corrections 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/distance-modeler.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/distance-modeler.ts
@@ -276,14 +276,17 @@ export class SearchNode {
    * character not seen in the input, as if the user accidentally skipped typing
    * it.  No new input will be expected, but the search will continue one
    * character deeper in the backing lexicon.
+   * @param spaceId
    * @returns An array of SearchNodes corresponding to lexical entries that are
    * prefixed with the lexicon entry represented by the current Node's
    * matchSequence text.
    */
-  buildInsertionEdges(): SearchNode[] {
+  buildInsertionEdges(spaceId?: number): SearchNode[] {
     if(this.hasPartialInput) {
       throw new Error("Invalid state:  will not take new input while still processing Transform subset");
     }
+
+    spaceId ??= this.spaceId;
 
     // Do not create insertion nodes after an empty transform; only before.
     // "Before" and "after" are identical for empty transforms - why duplicate?
@@ -307,9 +310,9 @@ export class SearchNode {
     let edges: SearchNode[] = [];
 
     for(let lexicalChild of this.currentTraversal.children()) {
-      let childCalc = this.calculation.addMatchChar(lexicalChild.char);
+      const childCalc = this.calculation.addMatchChar(lexicalChild.char);
 
-      let searchChild = new SearchNode(this, this.spaceId, PathEdge.INSERTION);
+      const searchChild = new SearchNode(this, spaceId, PathEdge.INSERTION);
       searchChild.calculation = childCalc;
       searchChild.priorInput = this.priorInput;
       searchChild.matchedTraversals.push(lexicalChild.traversal());

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/quotient-node-finalizer.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/quotient-node-finalizer.ts
@@ -1,0 +1,109 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by jahorton on 2025-04-16
+ *
+ * This file defines tests for a special quotient node type used to finalize
+ * corrections for correctable tokens - whether or not they are adjacent to the
+ * active caret.
+ */
+
+import { SearchNode } from './distance-modeler.js';
+import { SearchQuotientNode } from './search-quotient-node.js';
+import { SearchQuotientSpur } from './search-quotient-spur.js';
+import { TokenResultMapping } from './token-result-mapping.js';
+
+/**
+ * A variant of SearchQuotientNode designed to facilitate handling of the last
+ * spur of a context token's representation during a multi-token correction
+ * search.
+ *
+ * If `allowPredictions` is false, penalties will be applied for each additional
+ * letter that is missing and not yet otherwise modeled.
+ *
+ * Other important mechanics of this type:
+ * - Separate instances should be constructed for each token per tokenization
+ *   pattern it may be found within.  Doing so will each tokenization pattern to
+ *   receive and process the same results for the token.
+ * - It should also be constructed for a token regardless of whether it actually
+ *   does occur within multiple tokenizations.  As it is possible that one token
+ *   is a "continuation" of a different token without its terminal word
+ *   boundary, this will ensure that the "continued" token may still retrieve
+ *   results first processed by the "continuation" token.
+ */
+export class QuotientNodeFinalizer extends SearchQuotientSpur {
+  readonly insertLength: number = 0;
+  readonly leftDeleteLength: number = 0;
+
+  private allowPrediction: boolean;
+
+  /**
+   * Extends an existing SearchQuotientNode (and its correction data) by a keystroke based
+   * on a subset of the incoming keystroke's fat-finger distribution.
+   *
+   * @param parentNode
+   * @param inputs
+   * @param inputSource Either:
+   * 1.  Data about the actual context range represented by `inputs` and
+   * its underlying keystroke.
+   * 2.  The sample from the incoming distribution that represents data actually
+   * applied to the context.  It need not be included within the subset passed to `inputs`.
+   */
+  constructor(
+    parentNode: SearchQuotientNode,
+    allowPrediction: boolean
+  ) {
+    super(parentNode, null, null, parentNode.codepointLength);
+    this.allowPrediction = allowPrediction;
+  }
+
+  construct(parentNode: SearchQuotientNode): this {
+    return new QuotientNodeFinalizer(parentNode, this.allowPrediction) as this;
+  }
+
+  buildEdgesFromResults(baseResults: ReadonlyArray<TokenResultMapping>): SearchNode[] {
+    const penalizationNodes = baseResults.map((result) => {
+      const node: SearchNode = result.buildRemappedNode(this.spaceId);
+      const traversal = node.currentTraversal;
+      if(traversal.entries.length > 0 || this.allowPrediction) {
+        return node;
+      } else {
+        // Penalize each node based on the number of extra codepoints necessary to
+        // reach a completed word.
+        let penalty = 0;
+
+        let children: SearchNode[] = [node];
+        let childWithEntry: SearchNode;
+        do {
+          penalty++;
+          children = children.flatMap(child => child.buildInsertionEdges(this.spaceId));
+          childWithEntry = children.find((c) => c.currentTraversal.entries.length > 0);
+
+          if(children.length == 0) {
+            break;
+          }
+        } while (!childWithEntry && penalty <= 3);
+
+        return childWithEntry;
+      }
+    });
+
+    return penalizationNodes.filter((n) => !!n);
+  };
+
+  public get bestExample(): {text: string, p: number} {
+    return this.parents[0].bestExample;
+  }
+
+  get edgeKey(): string {
+    return `SR${this.parents[0].sourceRangeKey}L${this.codepointLength}EOT`;
+  }
+
+  public merge(space: SearchQuotientNode): SearchQuotientNode {
+    throw new Error("Merge operations are not supported on QuotientNodeFinalizer instances");
+  }
+
+  public split(splitIndex: number): [SearchQuotientNode, SearchQuotientNode][] {
+    throw new Error("Split operations are not supported on QuotientNodeFinalizer instances");
+  }
+}

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/quotient-node-finalizer.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/quotient-node-finalizer.ts
@@ -23,8 +23,8 @@ import { TokenResultMapping } from './token-result-mapping.js';
  *
  * Other important mechanics of this type:
  * - Separate instances should be constructed for each token per tokenization
- *   pattern it may be found within.  Doing so will each tokenization pattern to
- *   receive and process the same results for the token.
+ *   pattern it may be found within.  Doing so will allow each tokenization
+ *   pattern to receive and process the same results for the token.
  * - It should also be constructed for a token regardless of whether it actually
  *   does occur within multiple tokenizations.  As it is possible that one token
  *   is a "continuation" of a different token without its terminal word
@@ -38,16 +38,13 @@ export class QuotientNodeFinalizer extends SearchQuotientSpur {
   private allowPrediction: boolean;
 
   /**
-   * Extends an existing SearchQuotientNode (and its correction data) by a keystroke based
-   * on a subset of the incoming keystroke's fat-finger distribution.
+   * Extends an existing SearchQuotientNode (and its correction data) by a
+   * keystroke based on a subset of the incoming keystroke's fat-finger
+   * distribution.
    *
    * @param parentNode
-   * @param inputs
-   * @param inputSource Either:
-   * 1.  Data about the actual context range represented by `inputs` and
-   * its underlying keystroke.
-   * 2.  The sample from the incoming distribution that represents data actually
-   * applied to the context.  It need not be included within the subset passed to `inputs`.
+   * @param allowPrediction  Indicates whether this instance is allowed to
+   * extend the word for predictions or should limit its results to corrections.
    */
   constructor(
     parentNode: SearchQuotientNode,
@@ -57,6 +54,8 @@ export class QuotientNodeFinalizer extends SearchQuotientSpur {
     this.allowPrediction = allowPrediction;
   }
 
+  // Mandated by the SearchQuotientNode type (`abstract`), but only needed for
+  // splits and merges (which aren't supported by this type)
   construct(parentNode: SearchQuotientNode): this {
     return new QuotientNodeFinalizer(parentNode, this.allowPrediction) as this;
   }

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/search-quotient-spur.ts
@@ -524,9 +524,7 @@ export abstract class SearchQuotientSpur extends SearchQuotientNode {
    *    ancestry properly handle quotient-path variance in unit tests.
    */
   get edgeKey(): string {
-    const inputSrc = this.inputSource;
-    const segment = inputSrc.segment;
-    return `E${inputSrc.subsetId}:${segment.start}${segment.end !== undefined ? `-${segment.end}` : ''}`;
+    return `E${this.inputSource?.subsetId ?? ''}:${this.splitClusteringKey}`;
   }
 
   isSameNode(space: SearchQuotientNode): boolean {
@@ -553,11 +551,7 @@ export abstract class SearchQuotientSpur extends SearchQuotientNode {
 
   // Used to identify cluster-compatible components of SearchPaths during SearchCluster split operations.
   get splitClusteringKey(): string {
-    const pathSrc = this.inputSource;
-    if(!pathSrc) {
-      return '';
-    }
-
-    return `${pathSrc.segment.start}${pathSrc.segment.end == undefined ? '' : `-${pathSrc.segment.end}`}`;
+    const spurSeg = this.inputSource?.segment;
+    return `${spurSeg?.start ?? 0}${spurSeg?.end == undefined ? '' : `-${spurSeg.end}`}`;
   }
 }

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/token-result-mapping.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/token-result-mapping.ts
@@ -126,6 +126,10 @@ export class TokenResultMapping implements CorrectionResultMapping<SearchNode>{
     return this.node.currentTraversal;
   }
 
+  buildRemappedNode(spaceId: number): SearchNode {
+    return new SearchNode(this.node, spaceId);
+  }
+
   buildInsertionEdges(): SearchNode[] {
     return this.node.buildInsertionEdges();
   }

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -13,7 +13,7 @@ import { PriorityQueue } from "@keymanapp/web-utils";
 import { ContextToken } from "./context-token.js";
 import { CorrectionSearchable, PathResult } from "./correction-searchable.js";
 import { ContextTokenization } from "./context-tokenization.js";
-import { SearchQuotientNode } from "./search-quotient-node.js";
+import { QuotientNodeFinalizer } from "./quotient-node-finalizer.js";
 import { TokenizationResultMapping } from "./tokenization-result-mapping.js";
 
 // PathResult needs to be generic:
@@ -31,13 +31,14 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
   public readonly tokenization: ContextTokenization;
   private readonly tailCorrectionLength: number
 
-  private readonly _uncorrectables: SearchQuotientNode[];
-  private readonly _correctables: SearchQuotientNode[];
-  private _predictable?: SearchQuotientNode;
+  private readonly _uncorrectables: QuotientNodeFinalizer[];
+  private readonly _correctables: QuotientNodeFinalizer[];
+  private _predictable?: QuotientNodeFinalizer;
 
-  private selectionQueue: PriorityQueue<SearchQuotientNode>;
+  private selectionQueue: PriorityQueue<QuotientNodeFinalizer>;
   private tokenCostMap: Map<number, number>;
-  private _lockedTokenResults: Map<SearchQuotientNode, TokenResult>;
+  private tokenLookupMap: Map<number, ContextToken>;
+  private _lockedTokenResults: Map<number, TokenResult>;
   private lastTotalCost: number;
   private handleHasBeenCalled: boolean = false;
 
@@ -55,20 +56,20 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
   }
 
   get uncorrectableTokens(): ReadonlyArray<ContextToken> {
-    return this.orderedTokens.filter((t) => this._uncorrectables.find((c) => c.spaceId == t.spaceId));
+    return this._uncorrectables.map((c) => this.tokenLookupMap.get(c.spaceId));
   }
 
   get correctableTokens(): ReadonlyArray<ContextToken> {
-    return this.orderedTokens.filter((t) => this._correctables.find((c) => c.spaceId == t.spaceId));
+    return this._correctables.map((c) => this.tokenLookupMap.get(c.spaceId));
   }
 
   get predictableToken(): ContextToken {
-    return this.orderedTokens.find((t) => this._predictable?.spaceId == t.spaceId);
+    return this.tokenLookupMap.get(this._predictable?.spaceId);
   }
 
   get lockedTokenResults(): ReadonlyMap<ContextToken, TokenResult> {
     return new Map([...this._lockedTokenResults.entries()]
-      .map((tuple) => [this.orderedTokens.find((t) => t.searchModule == tuple[0]), tuple[1]]));
+      .map((tuple) => [this.tokenLookupMap.get(tuple[0]), tuple[1]]));
   }
 
   // Will have actual result sequences.
@@ -98,13 +99,18 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
       throw new Error(`Tail correction length must not extend actual token count`);
     }
 
-    const correctables = this.orderedTokens;
+    const orderedTokens = this.orderedTokens;
 
     this._uncorrectables = [];
     this._correctables = [];
 
-    correctables.forEach((token, index) => {
-      const searchModule = token.searchModule;
+    this.tokenLookupMap = new Map();
+
+    orderedTokens.forEach((token, index) => {
+      // New issue:  this mangles the space IDs!  We almost certainly need some
+      // sort of proper map to the source token.
+      const searchModule = new QuotientNodeFinalizer(token.searchModule, index == orderedTokens.length - 1);
+      this.tokenLookupMap.set(searchModule.spaceId, token);
       if(!filterClosure(token)) {
         this._uncorrectables.push(searchModule);
       } else if(index == tailCorrectionLength - 1) {
@@ -118,7 +124,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     const uncorrectables = this._uncorrectables;
     uncorrectables.forEach((uncorrectable) => {
       const lockedResult = uncorrectable.bestExample;
-      this._lockedTokenResults.set(uncorrectable, {
+      this._lockedTokenResults.set(uncorrectable.spaceId, {
         matchString: lockedResult.text,
         inputSamplingCost: 0,
         knownCost: -Math.log(lockedResult.p),
@@ -129,7 +135,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     let totalCost = uncorrectables.reduce((accum, curr) => accum - Math.log(curr.bestExample.p), 0);
     const tokenCostMap = this.tokenCostMap = new Map<number, number>();
 
-    const correctablesToQueue = this._correctables.concat(this.predictableToken?.searchModule ?? []);
+    const correctablesToQueue = this._correctables.concat(this._predictable ?? []);
     correctablesToQueue.forEach((t) => {
       totalCost += t.currentCost;
       tokenCostMap.set(t.spaceId, t.currentCost);
@@ -139,7 +145,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
 
     // Compute a weighting for each token's search space based the increase in
     // tokenization cost that it represents.
-    const tokenUpdateCost = (searchModule: SearchQuotientNode) => searchModule.currentCost - (tokenCostMap.get(searchModule.spaceId) ?? 0)
+    const tokenUpdateCost = (searchModule: QuotientNodeFinalizer) => searchModule.currentCost - (tokenCostMap.get(searchModule.spaceId) ?? 0)
     this.selectionQueue = new PriorityQueue((a, b) => {
       const aUpdateCost = tokenUpdateCost(a);
       const bUpdateCost = tokenUpdateCost(b);
@@ -152,12 +158,15 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     this.selectionQueue.enqueueAll(correctablesToQueue);
   }
 
-  private getUpdatedTotalCost(updatedCorrectable: SearchQuotientNode, tokenCost: number): number {
+  private getUpdatedTotalCost(updatedCorrectable: QuotientNodeFinalizer, tokenCost: number): number {
     return this.lastTotalCost + tokenCost - (this.tokenCostMap.get(updatedCorrectable.spaceId) ?? 0);
   }
 
   private collateResults(): TokenizationResultMapping {
-    return new TokenizationResultMapping(this.orderedTokens.map((t) => this._lockedTokenResults.get(t.searchModule)), this);
+    // The tokenLookupMap was constructed in the same ordering as the tokens; we can iterate the keys
+    // or entries to keep everything in order.
+    const results = [...this.tokenLookupMap.keys()].map((spaceId) => this._lockedTokenResults.get(spaceId))
+    return new TokenizationResultMapping(results, this);
   }
 
   handleNextNode(): PathResult<TokenizationResultMapping> {
@@ -223,7 +232,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     }
 
     // Either way, update the token -> correction-string map with the obtained result.
-    this._lockedTokenResults.set(correctableToUpdate, tokenResult.mapping);
+    this._lockedTokenResults.set(correctableToUpdate.spaceId, tokenResult.mapping);
 
     // If we have a correction for all components in need of correction, then
     // search for alternative corrections for the 'predictable' token - even if

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -123,7 +123,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
    */
   get generatedTokenResults(): ReadonlyMap<ContextToken, TokenResult> {
     return new Map([...this._generatedTokenResults.entries()]
-      .map((tuple) => [this.orderedTokens.find((t) => t.searchModule.spaceId == tuple[0]), tuple[1]]));
+      .map((tuple) => [this.tokenLookupMap.get(tuple[0]), tuple[1]]));
   }
 
   // Will have actual result sequences.

--- a/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/test-index.ts
@@ -12,6 +12,7 @@ export * from './correction/search-quotient-spur.js';
 export * from './correction/search-quotient-node.js';
 export * from './correction/legacy-quotient-root.js';
 export * from './correction/legacy-quotient-spur.js';
+export * from './correction/quotient-node-finalizer.js';
 export * from './correction/search-quotient-root.js';
 export { ExtendedEditOperation, SegmentableDistanceCalculation } from './correction/segmentable-calculation.js';
 export * from './correction/tokenization-corrector.js';

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/quotient-node-finalizer.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/quotient-node-finalizer.tests.ts
@@ -1,0 +1,150 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by jahorton on 2026-04-14
+ *
+ * This file defines tests for the `QuotientNodeFinalizer` class, which is used
+ * to ensure results forward properly to all tokenization patterns and can be
+ * used to enforce a correction-only state on tokens not adjacent to the caret.
+ */
+
+import { assert } from 'chai';
+
+import { LexicalModelTypes } from '@keymanapp/common-types';
+import { default as defaultBreaker } from '@keymanapp/models-wordbreakers';
+import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs';
+
+import {
+  generateSubsetId,
+  LegacyQuotientSpur,
+  models,
+  PathInputProperties,
+  PathResult,
+  QuotientNodeFinalizer,
+  SearchQuotientNode,
+  SearchQuotientRoot,
+  TokenResultMapping
+} from '@keymanapp/lm-worker/test-index';
+
+import Distribution = LexicalModelTypes.Distribution;
+import TrieModel = models.TrieModel;
+import Transform = LexicalModelTypes.Transform;
+
+const plainModel = new TrieModel(
+  jsonFixture('models/tries/english-1000'), {
+    languageUsesCasing: true,
+    wordBreaker: defaultBreaker
+  }
+);
+
+function buildFixture_therefore() {
+  let ID_SEED = 11;
+
+  const distributionSrc: [string, number][][] = [
+    [ ['t', 1] ],
+    [ ['h', 1] ],
+    [ ['e', 0.6] ],
+    [ ['r', 0.2] ],
+    [ ['e', 1] ],
+    [ ['f', 1] ],
+    [ ['o', 1] ],
+    [ ['r', 1] ],
+    [ ['e', 1] ],
+  ];
+
+  const distributions: Distribution<Required<Transform>>[] = distributionSrc.map((tupleArray) => {
+    const transitionId = ID_SEED++;
+    return tupleArray.map((tuple) => {
+      return {
+        p: tuple[1],
+        sample: {
+          insert: tuple[0],
+          deleteLeft: 0,
+          deleteRight: 0,
+          id: transitionId
+        }
+      }
+    });
+  });
+
+  // Assumes that the first entry in each distribution is the most likely.
+  const inputSources: PathInputProperties[] = distributions.map((dist) => {
+    return {
+      subsetId: generateSubsetId(),
+      segment: {start: 0, transitionId: dist[0].sample.id},
+      bestProbFromSet: dist[0].p
+    };
+  });
+
+  // TODO:  Use SubstitutionQuotientSpur instead!
+  let quotientNodes: SearchQuotientNode[] = [new SearchQuotientRoot(plainModel)];
+  for(let i=0; i < 9; i++) {
+    quotientNodes.push(new LegacyQuotientSpur(quotientNodes[i], distributions[i], inputSources[i]));
+  }
+
+  return quotientNodes;
+}
+
+describe('QuotientNodeFinalizer', () => {
+  describe('handleNextNode', () => {
+    it('finds corrections and predictions', () => {
+      const fixture = buildFixture_therefore();
+
+      const therefo = new QuotientNodeFinalizer(fixture[7], true);
+
+      let searchResult: PathResult<TokenResultMapping>;
+      do {
+        searchResult = therefo.handleNextNode();
+      } while(searchResult.type == 'intermediate');
+
+      assert.equal(searchResult.type, 'complete');
+      if(searchResult.type == 'complete') {
+        assert.equal(searchResult.mapping.totalCost, -Math.log(therefo.bestExample.p));
+        assert.isNotNaN(searchResult.cost);
+        assert.equal(searchResult.cost, searchResult.mapping.totalCost);
+      } else {
+        return;
+      }
+
+      searchResult = therefo.handleNextNode();
+      // There should be more results that may be found.
+      assert.notEqual(searchResult.type, 'none');
+
+      do {
+        searchResult = therefo.handleNextNode();
+      } while(searchResult.type == 'intermediate');
+
+      assert.notEqual(searchResult.type, 'none');
+    });
+
+    it('finds only corrections when predictions are forbidden', () => {
+      const fixture = buildFixture_therefore();
+
+      const therefo = new QuotientNodeFinalizer(fixture[7], false);
+
+      let searchResult: PathResult<TokenResultMapping>;
+      do {
+        searchResult = therefo.handleNextNode();
+      } while(searchResult.type == 'intermediate');
+
+      assert.equal(searchResult.type, 'complete');
+      if(searchResult.type == 'complete') {
+        assert.isAbove(searchResult.mapping.totalCost, -Math.log(therefo.bestExample.p));
+        assert.isNotNaN(searchResult.cost);
+        assert.equal(searchResult.cost, searchResult.mapping.totalCost);
+      } else {
+        return;
+      }
+
+      searchResult = therefo.handleNextNode();
+      // There should be more results that may be found.
+      assert.notEqual(searchResult.type, 'none');
+
+      do {
+        searchResult = therefo.handleNextNode();
+      } while(searchResult.type == 'intermediate');
+
+      assert.notEqual(searchResult.type, 'none');
+    });
+  });
+});

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/quotient-node-finalizer.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/quotient-node-finalizer.tests.ts
@@ -37,7 +37,7 @@ const plainModel = new TrieModel(
   }
 );
 
-function buildFixture_therefore() {
+function buildFixture_therefore(): SearchQuotientNode[] {
   let ID_SEED = 11;
 
   const distributionSrc: [string, number][][] = [

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
@@ -17,10 +17,8 @@ import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs'
 import {
   ContextToken,
   ContextTokenization,
-  correction,
   correctionValidForAutoSelect,
   generateSubsetId,
-  getBestMatches,
   LegacyQuotientSpur,
   models,
   PathInputProperties,
@@ -42,10 +40,6 @@ const plainModel = new TrieModel(
     wordBreaker: defaultBreaker
   }
 );
-
-function buildTestTimer() {
-  return new correction.ExecutionTimer(Number.MAX_VALUE, Number.MAX_VALUE);
-}
 
 function buildFixture_therefore() {
   let ID_SEED = 11;
@@ -425,43 +419,6 @@ describe('TokenizationCorrector', () => {
 
       const nilResult = instance.handleNextNode();
       assert.equal(nilResult.type, 'none');
-    });
-
-    describe('with getBestMatches()', () => {
-      it('finds results from each of two tokenization variants sharing lower-level SearchQuotientNodes', async () => {
-        const fixture = buildFixture_therefore();
-
-        // Issue:  `theref` is built completely off of the multi-token's `the` -
-        // and so starting on `the` later will fail! It "already produced" the
-        // result, after all.
-        //
-        // ... which is ANOTHER benefit to a prospective TerminalQuotientNode.
-        // It always gets a chance to process it!
-        const tokenizations = [fixture.theref, fixture.the_ef];
-        const correctors = tokenizations.map((t) => new TokenizationCorrector(t, t.tokens.length, fixture.filter));
-
-        let haveSeenSingleTokenCorrection = false;
-        let haveSeenThreeTokenCorrection = false;
-        for await(let phraseMatch of getBestMatches<
-          ReadonlyArray<TokenResult>,
-          TokenizationResultMapping,
-          TokenizationCorrector
-          >(correctors, buildTestTimer())) {
-
-          if(phraseMatch.matchedResult.length == 1) {
-            haveSeenSingleTokenCorrection = true;
-          } else if(phraseMatch.matchedResult.length == 3) {
-            haveSeenThreeTokenCorrection = true;
-          }
-
-          if(haveSeenSingleTokenCorrection && haveSeenThreeTokenCorrection) {
-            break;
-          }
-        }
-
-        assert.isTrue(haveSeenSingleTokenCorrection, 'A single-token correction was expected but not found');
-        assert.isTrue(haveSeenThreeTokenCorrection,  'A three-token correction was expected but not found');
-      });
     });
   });
 });

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
@@ -17,8 +17,10 @@ import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs'
 import {
   ContextToken,
   ContextTokenization,
+  correction,
   correctionValidForAutoSelect,
   generateSubsetId,
+  getBestMatches,
   LegacyQuotientSpur,
   models,
   PathInputProperties,
@@ -40,6 +42,10 @@ const plainModel = new TrieModel(
     wordBreaker: defaultBreaker
   }
 );
+
+function buildTestTimer() {
+  return new correction.ExecutionTimer(Number.MAX_VALUE, Number.MAX_VALUE);
+}
 
 function buildFixture_therefore() {
   let ID_SEED = 11;
@@ -419,6 +425,44 @@ describe('TokenizationCorrector', () => {
 
       const nilResult = instance.handleNextNode();
       assert.equal(nilResult.type, 'none');
+    });
+
+    describe('with getBestMatches()', () => {
+      it('finds results from each of two tokenization variants sharing lower-level SearchQuotientNodes', async () => {
+        const fixture = buildFixture_therefore();
+
+        const tokenizations = [fixture.theref, fixture.the_ef];
+        const correctors = tokenizations.map((t) => new TokenizationCorrector(t, t.tokens.length, fixture.filter));
+
+        let haveSeenSingleTokenCorrection = false;
+        let haveSeenThreeTokenCorrection = false;
+        for await(let phraseMatch of getBestMatches<
+          ReadonlyArray<TokenResult>,
+          TokenizationResultMapping,
+          TokenizationCorrector
+          >(correctors, buildTestTimer())) {
+
+          if(phraseMatch.matchedResult.length == 1) {
+            if(!haveSeenSingleTokenCorrection) {
+              assert.sameOrderedMembers(phraseMatch.matchedResult.map((t) => t.matchString), ['theref' /* -ore */]);
+            }
+
+            haveSeenSingleTokenCorrection = true;
+          } else if(phraseMatch.matchedResult.length == 3) {
+            if(!haveSeenThreeTokenCorrection) {
+              assert.sameOrderedMembers(phraseMatch.matchedResult.map((t) => t.matchString), ['the', ' ', 'ef' /* -fort */]);
+            }
+            haveSeenThreeTokenCorrection = true;
+          }
+
+          if(haveSeenSingleTokenCorrection && haveSeenThreeTokenCorrection) {
+            break;
+          }
+        }
+
+        assert.isTrue(haveSeenSingleTokenCorrection, 'A single-token correction was expected but not found');
+        assert.isTrue(haveSeenThreeTokenCorrection,  'A three-token correction was expected but not found');
+      });
     });
   });
 });

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/tokenization-corrector.tests.ts
@@ -17,8 +17,10 @@ import { jsonFixture } from '@keymanapp/common-test-resources/model-helpers.mjs'
 import {
   ContextToken,
   ContextTokenization,
+  correction,
   correctionValidForAutoSelect,
   generateSubsetId,
+  getBestMatches,
   LegacyQuotientSpur,
   models,
   PathInputProperties,
@@ -40,6 +42,10 @@ const plainModel = new TrieModel(
     wordBreaker: defaultBreaker
   }
 );
+
+function buildTestTimer() {
+  return new correction.ExecutionTimer(Number.MAX_VALUE, Number.MAX_VALUE);
+}
 
 function buildFixture_therefore() {
   let ID_SEED = 11;
@@ -419,6 +425,43 @@ describe('TokenizationCorrector', () => {
 
       const nilResult = instance.handleNextNode();
       assert.equal(nilResult.type, 'none');
+    });
+
+    describe('with getBestMatches()', () => {
+      it('finds results from each of two tokenization variants sharing lower-level SearchQuotientNodes', async () => {
+        const fixture = buildFixture_therefore();
+
+        // Issue:  `theref` is built completely off of the multi-token's `the` -
+        // and so starting on `the` later will fail! It "already produced" the
+        // result, after all.
+        //
+        // ... which is ANOTHER benefit to a prospective TerminalQuotientNode.
+        // It always gets a chance to process it!
+        const tokenizations = [fixture.theref, fixture.the_ef];
+        const correctors = tokenizations.map((t) => new TokenizationCorrector(t, t.tokens.length, fixture.filter));
+
+        let haveSeenSingleTokenCorrection = false;
+        let haveSeenThreeTokenCorrection = false;
+        for await(let phraseMatch of getBestMatches<
+          ReadonlyArray<TokenResult>,
+          TokenizationResultMapping,
+          TokenizationCorrector
+          >(correctors, buildTestTimer())) {
+
+          if(phraseMatch.matchedResult.length == 1) {
+            haveSeenSingleTokenCorrection = true;
+          } else if(phraseMatch.matchedResult.length == 3) {
+            haveSeenThreeTokenCorrection = true;
+          }
+
+          if(haveSeenSingleTokenCorrection && haveSeenThreeTokenCorrection) {
+            break;
+          }
+        }
+
+        assert.isTrue(haveSeenSingleTokenCorrection, 'A single-token correction was expected but not found');
+        assert.isTrue(haveSeenThreeTokenCorrection,  'A three-token correction was expected but not found');
+      });
     });
   });
 });


### PR DESCRIPTION
As noted in the description of #15818, when correcting multiple tokens together, we will want the ability to restrict some of them to use only corrections.  To facilitate this, the new `QuotientNodeFinalizer` type allows us to penalize corrections that result in incomplete words, adding one "penalty unit" of cost for each additional codepoint needed to result in an actually-completed word.

Build-bot: skip build:web
Test-bot: skip