### PR TITLE
chore(web): fix red squiggles in .ts test files in vscode 🎼

### DIFF
--- a/web/src/test/auto/tsconfig.json
+++ b/web/src/test/auto/tsconfig.json
@@ -5,6 +5,11 @@
     "outDir": "../../../build/test",
     "tsBuildInfoFile": "../../../build/test/tsconfig.tsbuildinfo",
     "rootDir": ".",
+    "types": [
+      "mocha",
+      "chai",
+      "node"
+    ],
   },
 
   "include": [


### PR DESCRIPTION
VSCode shows red squiggles under things like `describe` or `it` in .ts test files for web. This change adds the types to the `tsconfig.json` file which fixes this problem.

Build-bot: skip build:web
Test-bot: skip