### PR TITLE
fix(android): Reorder display language list

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/DisplayLanguages.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/DisplayLanguages.java
@@ -48,6 +48,8 @@ public class DisplayLanguages {
       new DisplayLanguageType("ff-NG", "Ɗemngal Fulfulde"),
       new DisplayLanguageType("de-DE", "Deutsch (German)"),
       new DisplayLanguageType("en", "English"),
+      new DisplayLanguageType("es-ES", "Español (Spanish)"),
+      new DisplayLanguageType("es-419", "Español (Spanish - Latin America)"),
       new DisplayLanguageType("fr-FR", "français (French)"),
       new DisplayLanguageType("ha-HG", "Hausa"),
       new DisplayLanguageType("in-ID", "Indonesian"),
@@ -66,10 +68,8 @@ public class DisplayLanguages {
       new DisplayLanguageType("pt-PT", "Português de Portugal"),
       new DisplayLanguageType("ff-ZA", "Pulaar-Fulfulde"), // or Fulah
       new DisplayLanguageType("ru-RU", "Русский (Russian)"),
-      new DisplayLanguageType("shu-latn", "Shuwa (Latin)"),
-      new DisplayLanguageType("es-ES", "Español (Spanish)"),
-      new DisplayLanguageType("es-419", "Español (Spanish - Latin America)"),
-      new DisplayLanguageType("sv-SE", "svenska (Swedish)"),
+      new DisplayLanguageType("shu-latn", "Shuwa (Latin script)"),
+      new DisplayLanguageType("sv-SE", "Svenska (Swedish)"),
       new DisplayLanguageType("vi-VN", "Tiếng Việt (Vietnamese)"),
       new DisplayLanguageType("uk-UA", "Українська (Ukrainian)"),
       new DisplayLanguageType("hia-NG", "Waha")

--- a/android/KMEA/app/src/main/java/com/keyman/engine/DisplayLanguages.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/DisplayLanguages.java
@@ -43,19 +43,18 @@ public class DisplayLanguages {
       new DisplayLanguageType("ar-SA", "(Arabic) العربية"),
       new DisplayLanguageType("az-AZ", "Azərbaycanca (Azəricə)"),
       new DisplayLanguageType("bwr-NG", "Bura-Pabir"),
+      new DisplayLanguageType("zh-CN", "中文(简体) (Simplified Chinese)"),
       new DisplayLanguageType("cs-CZ", "čeština (Czech)"),
       new DisplayLanguageType("ff-NG", "Ɗemngal Fulfulde"),
+      new DisplayLanguageType("de-DE", "Deutsch (German)"),
       new DisplayLanguageType("en", "English"),
-      new DisplayLanguageType("es-ES", "Español (Spanish)"),
-      new DisplayLanguageType("es-419", "Español (Spanish - Latin America)"),
-      new DisplayLanguageType("fr-FR", "French"),
+      new DisplayLanguageType("fr-FR", "français (French)"),
       new DisplayLanguageType("ha-HG", "Hausa"),
       new DisplayLanguageType("in-ID", "Indonesian"),
       new DisplayLanguageType("it-IT", "Italiana"),
-      new DisplayLanguageType("de-DE", "German"),
       new DisplayLanguageType("kn-IN", "ಕನ್ನಡ (Kannada)"),
       new DisplayLanguageType("kr-NG", "Kanuri"),
-      new DisplayLanguageType("km-KH", "Khmer"),
+      new DisplayLanguageType("km-KH", "ខ្មែរ (Khmer)"),
       new DisplayLanguageType("ckl-NG", "Kibaku"),
       new DisplayLanguageType("mfi-NG", "Mandara (Wandala)"),
       new DisplayLanguageType("mrt-NG", "Marghi"),
@@ -68,11 +67,12 @@ public class DisplayLanguages {
       new DisplayLanguageType("ff-ZA", "Pulaar-Fulfulde"), // or Fulah
       new DisplayLanguageType("ru-RU", "Русский (Russian)"),
       new DisplayLanguageType("shu-latn", "Shuwa (Latin)"),
+      new DisplayLanguageType("es-ES", "Español (Spanish)"),
+      new DisplayLanguageType("es-419", "Español (Spanish - Latin America)"),
       new DisplayLanguageType("sv-SE", "svenska (Swedish)"),
       new DisplayLanguageType("vi-VN", "Tiếng Việt (Vietnamese)"),
       new DisplayLanguageType("uk-UA", "Українська (Ukrainian)"),
-      new DisplayLanguageType("hia-NG", "Waha"),
-      new DisplayLanguageType("zh-CN", "中文(简体) (Simplified Chinese)")
+      new DisplayLanguageType("hia-NG", "Waha")
     };
     return languages;
   }


### PR DESCRIPTION
Fixes #15849

This updates the Keyman for Android "Display Language" list accordingly:
> * German" should be "Deutsch (German)" or "Deutsch", and should be in (English-like) alphabetical order (i.e. under D, not between I and K -- how on earth is that even happening??).
> * Similar happens with "(Simplified Chinese)" which currently is listed as the last item and which should be sorted under C (for Chinese)

## Screenshots of the updates Display Language list

(updated after review comments)
part 1
<img width="432" height="969" alt="display 1" src="https://github.com/user-attachments/assets/dfda8bf5-a8e0-40c4-83e8-c2a0772eb8ba" />


part 2
<img width="432" height="969" alt="display 2" src="https://github.com/user-attachments/assets/a25f721d-d2e0-41ab-bea9-14d96e5ece99" />


part 3
<img width="432" height="969" alt="display 3" src="https://github.com/user-attachments/assets/98ea85f2-c281-492c-9430-c7300c7a7723" />



Test-bot: skip


