### PR TITLE
feat(web): implement getting keyboard details for KMX keyboards 🧼 🎼

### DIFF
--- a/web/src/app/browser/src/keyboardDetails.ts
+++ b/web/src/app/browser/src/keyboardDetails.ts
@@ -13,11 +13,12 @@ export interface KeyboardDetails {
      */
     HasLoaded: boolean,
     /**
-     * User-friendly name of the keyboard.
+     * User-friendly name of the keyboard, e.g. "IPA (SIL)"
      */
     Name: string,
     /**
-     * Internal name of the keyboard.
+     * Internal name of the keyboard in the format "Keyboard_${id}",
+     * e.g. "Keyboard_sil_ipa"
      */
     InternalName: string,
     /**

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -474,11 +474,13 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
 
     const cache = this.keyboardRequisitioner.cache;
     const keyboardStubs = cache.getStubList()
-    for(let i=0; i < keyboardStubs.length; i++) {
+    for (let i = 0; i < keyboardStubs.length; i++) {
       const stub = keyboardStubs[i];
       const keyboard = cache.getKeyboardForStub(stub);
       const keyboardDetails = this.getKeyboardDetails(stub, keyboard);
-      detailsForAllKeyboards.push(keyboardDetails);
+      if (keyboardDetails) {
+        detailsForAllKeyboards.push(keyboardDetails);
+      }
     }
     return detailsForAllKeyboards;
   }

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -390,33 +390,31 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
    *   This was defined as an array, so is kept that way, but
    *   Javascript treats it as an object anyway
    *
-   * This is a public API function documented at
-   * https://help.keyman.com/developer/engine/web/current-version/reference/core/getKeyboard.
+   * @param {KeyboardStub} stub       Keyboard stub object
+   * @param {Keyboard}     keyboard   Keyboard script object
    *
-   * @param       {Object}    Lstub      JSKeyboard stub object
-   * @param       {Object}    Lkbd       Keyboard script object
-   * @return      {Object}               Keyboard details object
+   * @return {KeyboardDetails}  Keyboard details object
    *
    */
-  // TODO-web-core: check each property of Lstub for KMXKeyboard availability
-  private _GetKeyboardDetail(Lstub: KeyboardStub, Lkbd: Keyboard): KeyboardDetails { // I2078 - Full keyboard detail
-   return {
-      Name: Lstub.KN,
-      InternalName: Lstub.KI,
-      LanguageName: Lstub.KL,  // I1300 - Add support for language names
-      LanguageCode: Lstub.KLC, // I1702 - Add support for language codes, region names, region codes, country names and country codes
-      RegionName: Lstub.KR,
-      RegionCode: Lstub.KRC,
+  private getKeyboardDetails(stub: KeyboardStub, keyboard: Keyboard): KeyboardDetails {
+    // works for both JS and KMX keyboards
+    return stub && {
+      Name: stub.KN,
+      InternalName: stub.KI,
+      LanguageName: stub.KL,  // I1300 - Add support for language names
+      LanguageCode: stub.KLC, // I1702 - Add support for language codes, region names, region codes, country names and country codes
+      RegionName: stub.KR,
+      RegionCode: stub.KRC,
       // @ts-ignore
-      CountryName: Lstub['KC'] as string,
+      CountryName: stub['KC'] as string,
       // @ts-ignore
-      CountryCode: Lstub['KCC'] as string,
+      CountryCode: stub['KCC'] as string,
       // @ts-ignore
-      KeyboardID: Lstub['KD'] as string,
-      Font: Lstub.KFont,
-      OskFont: Lstub.KOskFont,
-      HasLoaded: !!Lkbd,
-      IsRTL: Lkbd ? Lkbd.isRTL : null
+      KeyboardID: stub['KD'] as string,
+      Font: stub.KFont,
+      OskFont: stub.KOskFont,
+      HasLoaded: !!keyboard,
+      IsRTL: keyboard ? keyboard.isRTL : null
     };
   }
 
@@ -461,12 +459,7 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
     const stub = this.keyboardRequisitioner.cache.getStub(id, langCode);
     const keyboard = this.keyboardRequisitioner.cache.getKeyboardForStub(stub);
 
-    if (keyboard instanceof JSKeyboard) {
-      return stub && this._GetKeyboardDetail(stub, keyboard);
-    } else {
-      // TODO-web-core: do this work in _GetKeyboardDetail (implement for KMX keyboards)
-      return null;
-    }
+    return this.getKeyboardDetails(stub, keyboard);
   }
 
   /**
@@ -484,12 +477,8 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
     for(let i=0; i < keyboardStubs.length; i++) {
       const stub = keyboardStubs[i];
       const keyboard = cache.getKeyboardForStub(stub);
-      if (keyboard instanceof JSKeyboard) {
-        const keyboardDetails = this._GetKeyboardDetail(stub, keyboard);
-        detailsForAllKeyboards.push(keyboardDetails);
-      } else {
-        // TODO-web-core:  do this work in _GetKeyboardDetail (implement for KMX keyboards if needed)
-      }
+      const keyboardDetails = this.getKeyboardDetails(stub, keyboard);
+      detailsForAllKeyboards.push(keyboardDetails);
     }
     return detailsForAllKeyboards;
   }


### PR DESCRIPTION
Turns out that we can use `KeyboardStub` for both JS and KMX keyboards.

Follows: #15888
Build-bot: skip build:web
Test-bot: skip