### PR TITLE
feat(web): clarify return type of `KeymanEngine.getKeyboardDetails` 🧼 🎼

### DIFF
--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -394,9 +394,8 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
    * @param {Keyboard}     keyboard   Keyboard script object
    *
    * @return {KeyboardDetails}  Keyboard details object
-   *
    */
-  private getKeyboardDetails(stub: KeyboardStub, keyboard: Keyboard): KeyboardDetails {
+  private getKeyboardDetails(stub: KeyboardStub, keyboard: Keyboard): KeyboardDetails | null {
     // works for both JS and KMX keyboards
     return stub && {
       Name: stub.KN,


### PR DESCRIPTION
`getKeyboardDetails` can return `null` if `stub` is falsy. This PR changes the return type accordingly to improve type safety.

Follows: #15889
Build-bot: skip build:web
Test-bot: skip