### PR TITLE
refactor(web): move common code to abstract `KeyboardProcessor` base class 🎼

### DIFF
--- a/web/src/engine/src/core-processor/coreKeyboardInterface.ts
+++ b/web/src/engine/src/core-processor/coreKeyboardInterface.ts
@@ -2,11 +2,11 @@
  * Keyman is copyright (C) SIL Global. MIT License.
  */
 import { KM_Core, km_core_option_item, KM_CORE_OPTION_SCOPE } from 'keyman/engine/core-adapter';
-import { KeyboardMinimalInterface, Keyboard, VariableStoreSerializer, KMXKeyboard } from 'keyman/engine/keyboard';
+import { KeyboardMinimalInterface, VariableStoreSerializer, KMXKeyboard } from 'keyman/engine/keyboard';
 import { toPrefixedKeyboardId } from 'keyman/engine/keyboard-storage';
 
 export class CoreKeyboardInterface implements KeyboardMinimalInterface {
-  private _activeKeyboard: Keyboard;
+  private _activeKeyboard: KMXKeyboard;
 
   public constructor(public readonly variableStoreSerializer: VariableStoreSerializer) {
     if (!variableStoreSerializer) {
@@ -14,26 +14,22 @@ export class CoreKeyboardInterface implements KeyboardMinimalInterface {
     }
   }
 
-  public get activeKeyboard(): Keyboard {
+  public get activeKeyboard(): KMXKeyboard {
     return this._activeKeyboard;
   }
-  public set activeKeyboard(keyboard: Keyboard) {
+  public set activeKeyboard(keyboard: KMXKeyboard) {
     this._activeKeyboard = keyboard;
     const options = this.loadSerializedOptions();
 
     if (options.length > 0) {
-      KM_Core.instance.state_options_update(this.KmxKeyboard.state, options);
+      KM_Core.instance.state_options_update(keyboard.state, options);
     }
-  }
-
-  private get KmxKeyboard(): KMXKeyboard {
-    return this._activeKeyboard as KMXKeyboard;
   }
 
   private loadSerializedOptions(): km_core_option_item[] {
     const options: km_core_option_item[] = [];
-    const attrs = KM_Core.instance.keyboard_get_attrs(this.KmxKeyboard.keyboard);
-    const prefixedKeyboardId = toPrefixedKeyboardId(this.KmxKeyboard.id);
+    const attrs = KM_Core.instance.keyboard_get_attrs(this.activeKeyboard.keyboard);
+    const prefixedKeyboardId = toPrefixedKeyboardId(this.activeKeyboard.id);
     const defaultOptions = attrs.object.default_options as km_core_option_item[];
     for (const defaultOption of defaultOptions) {
       if (defaultOption.scope == KM_CORE_OPTION_SCOPE.OPT_KEYBOARD) {

--- a/web/src/engine/src/core-processor/coreKeyboardProcessor.ts
+++ b/web/src/engine/src/core-processor/coreKeyboardProcessor.ts
@@ -2,37 +2,30 @@
  * Keyman is copyright (C) SIL Global. MIT License.
  */
 
-import { EventEmitter } from 'eventemitter3';
 import { KM_Core, KM_CORE_STATUS, KM_CORE_CT, km_core_context, km_core_context_items, km_core_option_item } from 'keyman/engine/core-adapter';
 import {
-  BeepHandler,
-  EventMap, Keyboard, KeyboardMinimalInterface, KeyboardProcessor,
+  AbstractKeyboardProcessor,
   KeyEvent, KMXKeyboard, SyntheticTextStore, MutableSystemStore, TextStore, ProcessorAction,
-  StateKeyMap,
   Deadkey,
-  Codes,
   VariableStoreSerializer
 } from "keyman/engine/keyboard";
 import { KM_CORE_EVENT_FLAG, KM_CORE_OPTION_SCOPE } from '../core-adapter/KM_Core.js';
-import { ModifierKeyConstants } from '@keymanapp/common-types';
 import { DeviceSpec } from 'keyman/common/web-utils';
 import { CoreKeyboardInterface } from './coreKeyboardInterface.js';
 import { toPrefixedKeyboardId } from 'keyman/engine/keyboard-storage';
-
-const lockNames = ['CAPS', 'NUM_LOCK', 'SCROLL_LOCK'] as const;
-const lockKeys = ['K_CAPS', 'K_NUMLOCK', 'K_SCROLL'] as const;
-const lockModifiers = [ModifierKeyConstants.CAPITALFLAG, ModifierKeyConstants.NUMLOCKFLAG, ModifierKeyConstants.SCROLLFLAG] as const;
-const noLockModifers = [ModifierKeyConstants.NOTCAPITALFLAG, ModifierKeyConstants.NOTNUMLOCKFLAG, ModifierKeyConstants.NOTSCROLLFLAG] as const;
 
 /**
  * Implements the core keyboard processing engine that interacts with the
  * shared Keyman Core component which handles .kmx keyboards.
  */
-export class CoreKeyboardProcessor extends EventEmitter<EventMap> implements KeyboardProcessor {
+export class CoreKeyboardProcessor extends AbstractKeyboardProcessor<KMXKeyboard, CoreKeyboardInterface> {
   private _newLayerStore: MutableSystemStore = new MutableSystemStore(0, 'default');
   private _oldLayerStore: MutableSystemStore = new MutableSystemStore(0, 'default');
   private _layerStore: MutableSystemStore = new MutableSystemStore(0, 'default');
-  private _keyboardInterface: CoreKeyboardInterface;
+
+  public constructor(device: DeviceSpec, baseLayout: string) {
+    super(device, baseLayout, null);
+  }
 
   /**
    * Initialize the core processor with the provided base path.
@@ -47,75 +40,6 @@ export class CoreKeyboardProcessor extends EventEmitter<EventMap> implements Key
   public async init(basePath: string, storeSerializer: VariableStoreSerializer): Promise<void> {
     await KM_Core.createCoreProcessor(basePath);
     this._keyboardInterface = new CoreKeyboardInterface(storeSerializer);
-  }
-
-  /**
-   * Tracks the simulated value for supported state keys, allowing the OSK to
-   * mirror a physical keyboard for them. Uses the exact keyCode name from the
-   * Codes definitions to enable certain optimizations elsewhere in the code.
-   *
-   * @type {StateKeyMap}
-   */
-  public stateKeys: StateKeyMap = {
-    "K_CAPS": false,
-    "K_NUMLOCK": false,
-    "K_SCROLL": false
-  }
-
-  /**
-   * Indicates the device (platform) to be used for non-keystroke events.
-   * Used for events such as those sent to `begin postkeystroke` and
-   * `begin newcontext` entry points.
-   *
-   * @type {DeviceSpec}
-   */
-  public contextDevice: DeviceSpec;
-
-  /**
-   * Optional handler for beep events triggered by the processor.
-   * Allows custom handling of beep feedback, such as for alerts or errors.
-   *
-   * @type {BeepHandler}
-   */
-  public beepHandler?: BeepHandler;
-
-  /**
-   * Bitfield representing the most recent modifier state (Alt, Ctrl, Shift, etc.)
-   * as observed or simulated by the processor. Used to quickly detect changes in
-   * modifier state not otherwise captured by the hosting page (important for AltGr).
-   *
-   * @type {number}
-   */
-  public modStateFlags: number = 0;
-
-  /**
-   * Stores the identifier for the base keyboard layout in use.
-   * Used to determine the default layout for key mapping and processing.
-   *
-   * @type {string}
-   */
-  public baseLayout: string;
-
-  /**
-   * The currently active keyboard.
-   *
-   * @type {Keyboard}
-   */
-  public get activeKeyboard(): Keyboard {
-    return this.keyboardInterface.activeKeyboard;
-  }
-  public set activeKeyboard(keyboard: Keyboard) {
-    this.keyboardInterface.activeKeyboard = keyboard;
-  }
-
-  /**
-   * The keyboard interface used by the processor.
-   * Provides access to the keyboard interface implementation.
-   *
-   * @type {KeyboardMinimalInterface}
-   */
-  get keyboardInterface(): KeyboardMinimalInterface {
-    return this._keyboardInterface;
   }
 
   /**
@@ -160,7 +84,7 @@ export class CoreKeyboardProcessor extends EventEmitter<EventMap> implements Key
     this._layerStore.set(value);
   }
 
-  private getLayerId(modifier: number): string {
+  protected getLayerId(modifier: number): string {
     // TODO-web-core: implement
     // return Layouts.getLayerId(modifier);
     return 'default'; // TODO-web-core: put into LayerNames enum
@@ -273,19 +197,18 @@ export class CoreKeyboardProcessor extends EventEmitter<EventMap> implements Key
   public processKeystroke(keyEvent: KeyEvent, textStore: TextStore): ProcessorAction {
 
     const preInput = SyntheticTextStore.from(textStore, true);
-    const activeKeyboard = this.activeKeyboard as KMXKeyboard;
-    const coreContext = KM_Core.instance.state_context(activeKeyboard.state);
+    const coreContext = KM_Core.instance.state_context(this.activeKeyboard.state);
 
     this.applyContextFromTextStore(coreContext, textStore);
 
-    const status = KM_Core.instance.process_event(activeKeyboard.state, keyEvent.Lcode, keyEvent.Lmodifiers, keyEvent.source?.type === 'keydown', KM_CORE_EVENT_FLAG.DEFAULT);
+    const status = KM_Core.instance.process_event(this.activeKeyboard.state, keyEvent.Lcode, keyEvent.Lmodifiers, keyEvent.source?.type === 'keydown', KM_CORE_EVENT_FLAG.DEFAULT);
     // TODO-web-core: properly set flags (#15283)
     if (status != KM_CORE_STATUS.OK) {
       console.error('KeymanWeb: km_core_process_event failed with status: ' + status);
       return null;
     }
     const processorAction = new ProcessorAction();
-    const core_actions = KM_Core.instance.state_get_actions(activeKeyboard.state);
+    const core_actions = KM_Core.instance.state_get_actions(this.activeKeyboard.state);
 
     textStore.deleteCharsBeforeCaret(core_actions.code_points_to_delete);
     textStore.insertTextBeforeCaret(core_actions.output);
@@ -336,117 +259,6 @@ export class CoreKeyboardProcessor extends EventEmitter<EventMap> implements Key
     // (irrelevant for web-core since that is handled in Core), but also after
     // applying a suggestion, which we do need to handle.
     return null;
-  }
-
-  // TODO-web-core: this could be shared with JsKeyboardProcessor
-  /**
-   * Determines if the given key event is a modifier key press.
-   * Returns true if the event corresponds to a modifier key, otherwise false.
-   *
-   * @param {KeyEvent}   keyEvent    The key event to evaluate.
-   * @param {TextStore}  textStore   The current text store context.
-   * @param {boolean}    isKeyDown   Indicates if the key event is a key down event.
-   *
-   * @returns {boolean} True if the event is a modifier key press, false otherwise.
-   */
-  public doModifierPress(keyEvent: KeyEvent, textStore: TextStore, isKeyDown: boolean): boolean {
-    if(!this.activeKeyboard) {
-      return false;
-    }
-
-    if(keyEvent.isModifier) {
-      this.activeKeyboard.notify(keyEvent.Lcode, textStore, isKeyDown ? 1 : 0);
-      // For eventual integration - we bypass an OSK update for physical keystrokes when in touch mode.
-      if(!keyEvent.device.touchable) {
-        return this._UpdateVKShift(keyEvent); // I2187
-      } else {
-        return true;
-      }
-    }
-
-    if(keyEvent.LmodifierChange) {
-      this.activeKeyboard.notify(0, textStore, 1);
-      if(!keyEvent.device.touchable) {
-        this._UpdateVKShift(keyEvent);
-      }
-    }
-
-    // No modifier keypresses detected.
-    return false;
-  }
-
-
-  // TODO-web-core: this could be shared with JsKeyboardProcessor
-  /**
-   * Updates the virtual keyboard shift state based on the provided key event.
-   * Handles modifier key simulation, state key updates, and layer selection for the OSK.
-   *
-   * @param {KeyEvent} e - The key event used to update the shift state.
-   *
-   * @returns {boolean} True if the update was processed, otherwise true if no active keyboard.
-   */
-  private _UpdateVKShift(e: KeyEvent): boolean {
-    let keyShiftState=0;
-
-    if(!this.activeKeyboard) {
-      return true;
-    }
-
-    if(e) {
-      // read shift states from event
-      keyShiftState = e.Lmodifiers;
-
-      // Are we simulating AltGr?  If it's a simulation and not real, time to un-simulate for the OSK.
-      if(this.activeKeyboard.isChiral && this.activeKeyboard.emulatesAltGr &&
-          (this.modStateFlags & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM']) {
-        keyShiftState |= Codes.modifierBitmasks['ALT_GR_SIM'];
-        keyShiftState &= ~ModifierKeyConstants.RALTFLAG;
-      }
-
-      // Set stateKeys where corresponding value is passed in e.Lstates
-      let stateMutation = false;
-      for(let i=0; i < lockNames.length; i++) {
-        if((e.Lstates & Codes.stateBitmasks[lockNames[i]]) != 0) {
-          this.stateKeys[lockKeys[i]] = ((e.Lstates & lockModifiers[i]) != 0);
-          stateMutation = true;
-        }
-      }
-
-      if(stateMutation) {
-        this.emit('statekeychange', this.stateKeys);
-      }
-    }
-
-    this.updateStates();
-
-    if (this.activeKeyboard.isMnemonic && this.stateKeys['K_CAPS'] && (!e || !e.isModifier)) {
-      // Modifier keypresses don't trigger mnemonic manipulation of modifier state.
-      // Only an output key does; active use of Caps will also flip the SHIFT flag.
-      // Mnemonic keystrokes manipulate the SHIFT property based on CAPS state.
-      // We need to unflip them when tracking the OSK layer.
-      keyShiftState ^= ModifierKeyConstants.K_SHIFTFLAG;
-    }
-
-    this.layerId = this.getLayerId(keyShiftState);
-    return true;
-  }
-
-  // TODO-web-core: this could be shared with JsKeyboardProcessor
-  private updateStates(): void {
-    for (let i = 0; i < lockKeys.length; i++) {
-      const key = lockKeys[i];
-      const flag = this.stateKeys[key];
-
-      // Ensures that the current mod-state info properly matches the currently-simulated
-      // state key states.
-      if (flag) {
-        this.modStateFlags |= lockModifiers[i];
-        this.modStateFlags &= ~noLockModifers[i];
-      } else {
-        this.modStateFlags &= ~lockModifiers[i];
-        this.modStateFlags |= noLockModifers[i];
-      }
-    }
   }
 
   /**

--- a/web/src/engine/src/js-processor/jsKeyboardInterface.ts
+++ b/web/src/engine/src/js-processor/jsKeyboardInterface.ts
@@ -1,7 +1,6 @@
-/***
-   KeymanWeb 11.0
-   Copyright 2019 SIL International
-***/
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
 
 //#region Imports
 
@@ -10,9 +9,9 @@ import { ModifierKeyConstants } from '@keymanapp/common-types';
 import {
   Codes,
   JSKeyboard,
-  Keyboard,
   KeyboardHarness,
   KeyboardKeymanGlobal,
+  KeyboardMinimalInterface,
   KeyMapping,
   SyntheticTextStore,
   MutableSystemStore,
@@ -179,7 +178,7 @@ class CachedContextEx {
 
 //#endregion
 
-export class JSKeyboardInterface extends KeyboardHarness {
+export class JSKeyboardInterface extends KeyboardHarness implements KeyboardMinimalInterface {
   static readonly GLOBAL_NAME = 'KeymanWeb';
 
   cachedContext: CachedContext = new CachedContext();
@@ -194,12 +193,8 @@ export class JSKeyboardInterface extends KeyboardHarness {
   _AnyIndices:  number[] = [];    // AnyIndex - array of any/index match indices
 
   // Must be accessible to some of the keyboard API methods.
-  activeKeyboard: Keyboard;
+  activeKeyboard: JSKeyboard;
   activeDevice: DeviceSpec;
-
-  public get activeJSKeyboard(): JSKeyboard {
-    return this.activeKeyboard as JSKeyboard;
-  }
 
   // A 'reference point' that debug keyboards may use to access KMW's code constants.
   public get Codes(): typeof Codes {
@@ -573,7 +568,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
     let retVal = false; // I3318
     let keyCode = (e.Lcode == 173 ? 189 : e.Lcode);  //I3555 (Firefox hyphen issue)
 
-    const bitmask = this.activeJSKeyboard.modifierBitmask;
+    const bitmask = this.activeKeyboard.modifierBitmask;
     const modifierBitmask = bitmask & Codes.modifierBitmasks["ALL"];
     const stateBitmask = bitmask & Codes.stateBitmasks["ALL"];
 
@@ -653,7 +648,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
 
   _ExplodeStore(store: KeyboardStore): ComplexKeyboardStore {
     if(typeof(store) == 'string') {
-      const cachedStores = this.activeJSKeyboard.explodedStores;
+      const cachedStores = this.activeKeyboard.explodedStores;
 
       // Is the result cached?
       if(cachedStores[store]) {
@@ -1005,7 +1000,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
     if(!this.activeKeyboard) {
       throw "No active keyboard for keystroke processing!";
     }
-    return this.process(this.activeJSKeyboard.processNewContextEvent.bind(this.activeKeyboard), textStore, keystroke, true);
+    return this.process(this.activeKeyboard.processNewContextEvent.bind(this.activeKeyboard), textStore, keystroke, true);
   }
 
   /**
@@ -1020,7 +1015,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
     if(!this.activeKeyboard) {
       throw "No active keyboard for keystroke processing!";
     }
-    return this.process(this.activeJSKeyboard.processPostKeystroke.bind(this.activeKeyboard), textStore, keystroke, true);
+    return this.process(this.activeKeyboard.processPostKeystroke.bind(this.activeKeyboard), textStore, keystroke, true);
   }
 
   /**
@@ -1035,7 +1030,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
     if(!this.activeKeyboard) {
       throw "No active keyboard for keystroke processing!";
     }
-    return this.process(this.activeJSKeyboard.process.bind(this.activeKeyboard), textStore, keystroke, false);
+    return this.process(this.activeKeyboard.process.bind(this.activeKeyboard), textStore, keystroke, false);
   }
 
   private process(callee: (textStore: TextStore, keystroke: KeyEvent) => boolean, textStore: TextStore, keystroke: KeyEvent, readonly: boolean): ProcessorAction {
@@ -1057,7 +1052,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
     const preInput = SyntheticTextStore.from(textStore, true);
 
     // Capture the initial state of any variable stores
-    const cachedVariableStores = this.activeJSKeyboard.variableStores;
+    const cachedVariableStores = this.activeKeyboard.variableStores;
 
     // Establishes the results object, allowing corresponding commands to set values here as appropriate.
     this.ruleBehavior = new ProcessorAction();
@@ -1077,8 +1072,8 @@ export class JSKeyboardInterface extends KeyboardHarness {
     // We always backup the changes to variable stores to the ProcessorAction, to
     // be applied during finalization, then restore them to the cached initial
     // values to avoid side-effects with predictive text mocks.
-    this.ruleBehavior.variableStores = this.activeJSKeyboard.variableStores;
-    this.activeJSKeyboard.variableStores = cachedVariableStores;
+    this.ruleBehavior.variableStores = this.activeKeyboard.variableStores;
+    this.activeKeyboard.variableStores = cachedVariableStores;
 
     // `matched` refers to whether or not the FINAL rule (from any group) matched, rather than
     // whether or not ANY rule matched.  If the final rule doesn't match, we trigger the key's
@@ -1104,7 +1099,7 @@ export class JSKeyboardInterface extends KeyboardHarness {
    *               keyboard
    */
   applyVariableStores(stores: VariableStores): void {
-    this.activeJSKeyboard.variableStores = stores;
+    this.activeKeyboard.variableStores = stores;
   }
 
   /**

--- a/web/src/engine/src/js-processor/jsKeyboardProcessor.ts
+++ b/web/src/engine/src/js-processor/jsKeyboardProcessor.ts
@@ -6,15 +6,12 @@
 
 // #region Big ol' list of imports
 
-import { EventEmitter } from 'eventemitter3';
 import { ModifierKeyConstants } from '@keymanapp/common-types';
 import {
   Codes, type JSKeyboard, KeyEvent, Layouts,
   DefaultOutputRules, EmulationKeystrokes, type MutableSystemStore,
   TextStore, ProcessorAction, SystemStoreIDs, SyntheticTextStore,
-  KeyboardProcessor,
-  EventMap,
-  BeepHandler,
+  AbstractKeyboardProcessor,
 } from "keyman/engine/keyboard";
 import { JSKeyboardInterface }  from './jsKeyboardInterface.js';
 import { DeviceSpec, KMWString } from "keyman/common/web-utils";
@@ -24,58 +21,17 @@ import { ProcessorInitOptions } from './processorInitOptions.js';
 
 export type LogMessageHandler = (str: string) => void;
 
-export class JSKeyboardProcessor extends EventEmitter<EventMap> implements KeyboardProcessor {
-  // Tracks the simulated value for supported state keys, allowing the OSK to mirror a physical keyboard for them.
-  // Using the exact keyCode name from the Codes definitions will allow for certain optimizations elsewhere in the code.
-  public stateKeys = {
-    "K_CAPS":false,
-    "K_NUMLOCK":false,
-    "K_SCROLL":false
-  };
-
-  // Tracks the most recent modifier state information in order to quickly detect changes
-  // in keyboard state not otherwise captured by the hosting page in the browser.
-  // Needed for AltGr simulation.
-  public modStateFlags: number = 0;
-
-  public keyboardInterface: JSKeyboardInterface;
-
-  /**
-   * Indicates the device (platform) to be used for non-keystroke events,
-   * such as those sent to `begin postkeystroke` and `begin newcontext`
-   * entry points.
-   */
-  public contextDevice: DeviceSpec;
-
-  public baseLayout: string;
-
+export class JSKeyboardProcessor extends AbstractKeyboardProcessor<JSKeyboard, JSKeyboardInterface> {
   public defaultOutputRules: DefaultOutputRules;
 
   // Callbacks for various feedback types
-  public beepHandler?: BeepHandler;
   public warningLogger?: LogMessageHandler;
   public errorLogger?: LogMessageHandler;
 
   constructor(device: DeviceSpec, options: ProcessorInitOptions) {
-    super();
+    super(device, options.baseLayout, options.keyboardInterface);
 
-    this.contextDevice = device;
-
-    this.baseLayout = options.baseLayout;
-    this.keyboardInterface = options.keyboardInterface;
     this.defaultOutputRules = options.defaultOutputRules;
-  }
-
-  public get activeKeyboard(): JSKeyboard {
-    return this.keyboardInterface.activeJSKeyboard;
-  }
-
-  public set activeKeyboard(keyboard: JSKeyboard) {
-    this.keyboardInterface.activeKeyboard = keyboard;
-
-    // All old deadkeys and keyboard-specific cache should immediately be invalidated
-    // on a keyboard change.
-    this.resetContext();
   }
 
   public get layerStore(): MutableSystemStore {
@@ -240,90 +196,7 @@ export class JSKeyboardProcessor extends EventEmitter<EventMap> implements Keybo
     return matchBehavior;
   }
 
-  /**
-   * Function     _UpdateVKShift
-   * Scope        Private
-   * @param       {Object}            e     OSK event
-   * @return      {boolean}                 Always true
-   * Description  Updates the current shift state within KMW, updating the OSK's visualization thereof.
-   */
-  private _UpdateVKShift(e: KeyEvent): boolean {
-    let keyShiftState=0;
-
-    const lockNames  = ['CAPS', 'NUM_LOCK', 'SCROLL_LOCK'] as const;
-    const lockKeys = ['K_CAPS', 'K_NUMLOCK', 'K_SCROLL'] as const;
-    const lockModifiers = [ModifierKeyConstants.CAPITALFLAG, ModifierKeyConstants.NUMLOCKFLAG, ModifierKeyConstants.SCROLLFLAG] as const;
-
-
-    if(!this.activeKeyboard) {
-      return true;
-    }
-
-    if(e) {
-      // read shift states from Pevent
-      keyShiftState = e.Lmodifiers;
-
-      // Are we simulating AltGr?  If it's a simulation and not real, time to un-simulate for the OSK.
-      if(this.activeKeyboard.isChiral && (this.activeKeyboard.emulatesAltGr) &&
-          (this.modStateFlags & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM']) {
-        keyShiftState |= Codes.modifierBitmasks['ALT_GR_SIM'];
-        keyShiftState &= ~ModifierKeyConstants.RALTFLAG;
-      }
-
-      // Set stateKeys where corresponding value is passed in e.Lstates
-      let stateMutation = false;
-      for(let i=0; i < lockNames.length; i++) {
-        if(e.Lstates & Codes.stateBitmasks[lockNames[i]]) {
-          this.stateKeys[lockKeys[i]] = !!(e.Lstates & lockModifiers[i]);
-          stateMutation = true;
-        }
-      }
-
-      if(stateMutation) {
-        this.emit('statekeychange', this.stateKeys);
-      }
-    }
-
-    this.updateStates();
-
-    if(this.activeKeyboard.isMnemonic && this.stateKeys['K_CAPS']) {
-      // Modifier keypresses doesn't trigger mnemonic manipulation of modifier state.
-      // Only an output key does; active use of Caps will also flip the SHIFT flag.
-      if(!e || !e.isModifier) {
-        // Mnemonic keystrokes manipulate the SHIFT property based on CAPS state.
-        // We need to unflip them when tracking the OSK layer.
-        keyShiftState ^= ModifierKeyConstants.K_SHIFTFLAG;
-      }
-    }
-
-    this.layerId = this.getLayerId(keyShiftState);
-    return true;
-  }
-
-  private updateStates(): void {
-    const lockKeys = ['K_CAPS', 'K_NUMLOCK', 'K_SCROLL'] as const;
-    const lockModifiers = [ModifierKeyConstants.CAPITALFLAG, ModifierKeyConstants.NUMLOCKFLAG, ModifierKeyConstants.SCROLLFLAG] as const;
-    const noLockModifers = [ModifierKeyConstants.NOTCAPITALFLAG, ModifierKeyConstants.NOTNUMLOCKFLAG, ModifierKeyConstants.NOTSCROLLFLAG] as const;
-
-
-
-    for(let i=0; i < lockKeys.length; i++) {
-      const key = lockKeys[i];
-      const flag = this.stateKeys[key];
-
-      // Ensures that the current mod-state info properly matches the currently-simulated
-      // state key states.
-      if(flag) {
-        this.modStateFlags |= lockModifiers[i];
-        this.modStateFlags &= ~noLockModifers[i];
-      } else {
-        this.modStateFlags &= ~lockModifiers[i];
-        this.modStateFlags |= noLockModifers[i];
-      }
-    }
-  }
-
-  private getLayerId(modifier: number): string {
+  protected getLayerId(modifier: number): string {
     return Layouts.getLayerId(modifier);
   }
 
@@ -517,34 +390,6 @@ export class JSKeyboardProcessor extends EventEmitter<EventMap> implements Keybo
     this.modStateFlags = baseModifierState | keyEvent.Lstates;
   }
 
-  // Returns true if the key event is a modifier press, allowing keyPress to return selectively
-  // in those cases.
-  public doModifierPress(Levent: KeyEvent, textStore: TextStore, isKeyDown: boolean): boolean {
-    if(!this.activeKeyboard) {
-      return false;
-    }
-
-    if(Levent.isModifier) {
-      this.activeKeyboard.notify(Levent.Lcode, textStore, isKeyDown ? 1 : 0);
-      // For eventual integration - we bypass an OSK update for physical keystrokes when in touch mode.
-      if(!Levent.device.touchable) {
-        return this._UpdateVKShift(Levent); // I2187
-      } else {
-        return true;
-      }
-    }
-
-    if(Levent.LmodifierChange) {
-      this.activeKeyboard.notify(0, textStore, 1);
-      if(!Levent.device.touchable) {
-        this._UpdateVKShift(Levent);
-      }
-    }
-
-    // No modifier keypresses detected.
-    return false;
-  }
-
   /**
    * Tell the currently active keyboard that a new context has been selected,
    * e.g. by focus change, selection change, keyboard change, etc.
@@ -570,14 +415,14 @@ export class JSKeyboardProcessor extends EventEmitter<EventMap> implements Keybo
     this.keyboardInterface.resetContextCache();
 
     // May be null if it's a keyboard swap.
-    // Performed before _UpdateVKShift since the op may modify the displayed layer
+    // Performed before updateShiftState since the op may modify the displayed layer
     // Also updates the layer for predictions.
     if(textStore) {
       this.performNewContextEvent(textStore);
     }
 
     if(!this.contextDevice.touchable) {
-      this._UpdateVKShift(null);
+      this.updateShiftState(null);
     }
   };
 

--- a/web/src/engine/src/keyboard/index.ts
+++ b/web/src/engine/src/keyboard/index.ts
@@ -7,7 +7,7 @@ export { KMXKeyboard } from './keyboards/kmxKeyboard.js';
 export { KeyboardHarness, KeyboardKeymanGlobal, MinimalCodesInterface, MinimalKeymanGlobal } from "./keyboards/keyboardHarness.js";
 export { NotifyEventCode, KeyboardLoaderBase } from "./keyboards/keyboardLoaderBase.js";
 export { KeyboardLoadErrorBuilder, KeyboardMissingError, KeyboardScriptError, KeyboardDownloadError, InvalidKeyboardError } from './keyboards/keyboardLoadError.js'
-export { BeepHandler, EventMap, KeyboardProcessor } from "./keyboards/keyboardProcessor.js";
+export { AbstractKeyboardProcessor, BeepHandler, EventMap, KeyboardProcessor } from "./keyboards/keyboardProcessor.js";
 export {
   CloudKeyboardFont,
   internalizeFont,

--- a/web/src/engine/src/keyboard/keyboards/keyboardHarness.ts
+++ b/web/src/engine/src/keyboard/keyboards/keyboardHarness.ts
@@ -42,7 +42,7 @@ export const MinimalKeymanGlobal: KeyboardKeymanGlobal = {
 export class KeyboardHarness {
   public readonly _jsGlobal: any;
   public readonly keymanGlobal: KeyboardKeymanGlobal;
-  activeDevice: DeviceSpec;
+  public activeDevice: DeviceSpec;
 
 
   /**

--- a/web/src/engine/src/keyboard/keyboards/keyboardProcessor.ts
+++ b/web/src/engine/src/keyboard/keyboards/keyboardProcessor.ts
@@ -2,7 +2,9 @@
  * Keyman is copyright (C) SIL Global. MIT License.
  */
 import { EventEmitter } from 'eventemitter3';
+import { ModifierKeyConstants } from '@keymanapp/common-types';
 import { DeviceSpec } from 'keyman/common/web-utils';
+import { Codes } from '../codes.js';
 import { KeyEvent } from '../keyEvent.js';
 import { type MutableSystemStore } from "../systemStore.js";
 import { Keyboard } from './keyboard.js';
@@ -17,12 +19,19 @@ export interface EventMap {
 
 export type BeepHandler = (textStore: TextStore) => void;
 
+const lockNames = ['CAPS', 'NUM_LOCK', 'SCROLL_LOCK'] as const;
+const lockKeys = ['K_CAPS', 'K_NUMLOCK', 'K_SCROLL'] as const;
+const lockModifiers = [ModifierKeyConstants.CAPITALFLAG, ModifierKeyConstants.NUMLOCKFLAG, ModifierKeyConstants.SCROLLFLAG] as const;
+const noLockModifers = [ModifierKeyConstants.NOTCAPITALFLAG, ModifierKeyConstants.NOTNUMLOCKFLAG, ModifierKeyConstants.NOTSCROLLFLAG] as const;
+
+export type KeyboardProcessor = AbstractKeyboardProcessor<Keyboard, KeyboardMinimalInterface>;
+
 /**
- * Interface for the keyboard processing engine used by the web runtime to
+ * Abstract class for the keyboard processing engine used by the web runtime to
  * translate low-level key events and device/context signals into high-level
  * keyboard actions and text-store updates.
  *
- * This interface extends an EventEmitter of EventMap and centralizes responsibilities
+ * This class extends an EventEmitter of EventMap and centralizes responsibilities
  * such as:
  * - tracking simulated state keys so the on‑screen keyboard (OSK) can mirror hardware state,
  * - selecting and switching keyboard layers for the OSK,
@@ -32,25 +41,34 @@ export type BeepHandler = (textStore: TextStore) => void;
  * - performing keystroke and post‑keystroke processing and finalizing ProcessorAction
  *   results against a TextStore.
  */
-export interface KeyboardProcessor extends EventEmitter<EventMap> {
+export abstract class AbstractKeyboardProcessor<TKeyboard extends Keyboard, TKeyboardInterface extends KeyboardMinimalInterface> extends EventEmitter<EventMap> {
+  public constructor(device: DeviceSpec, baseLayout: string, protected _keyboardInterface: TKeyboardInterface | null) {
+    super();
+    this.contextDevice = device;
+    this.baseLayout = baseLayout;
+  }
+
   /**
-   * Tracks the simulated values for supported state keys (e.g. CapsLock, NumLock)
-   * so that the OSK can reflect a physical keyboard's state. Keys are referenced
-   * using the exact keyCode names from the Codes definitions to allow for optimized
-   * handling elsewhere.
+   * Tracks the simulated value for supported state keys, allowing the OSK to
+   * mirror a physical keyboard for them. Uses the exact keyCode name from the
+   * Codes definitions to enable certain optimizations elsewhere in the code.
    *
    * @type {StateKeyMap}
    */
-  stateKeys: StateKeyMap;
+  public stateKeys: StateKeyMap = {
+    "K_CAPS": false,
+    "K_NUMLOCK": false,
+    "K_SCROLL": false
+  };
 
   /**
-   * Indicates the device/platform to be used for non-keystroke events (for example,
-   * events dispatched to "begin postkeystroke" and "begin newcontext" entry points).
-   * This lets the processor adapt behavior or rule evaluation to the active device.
+   * Indicates the device (platform) to be used for non-keystroke events.
+   * Used for events such as those sent to `begin postkeystroke` and
+   * `begin newcontext` entry points.
    *
    * @type {DeviceSpec}
    */
-  contextDevice: DeviceSpec;
+  public contextDevice: DeviceSpec;
 
   /**
    * Optional handler used to produce an audible beep or other feedback when a rule
@@ -58,7 +76,7 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @type {BeepHandler | undefined}
    */
-  beepHandler?: BeepHandler;
+  public beepHandler?: BeepHandler;
 
   /**
    * Stores the identifier for the base physical layout in use (for
@@ -67,7 +85,7 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @type {string}
    */
-  baseLayout: string;
+  public baseLayout: string;
 
   /**
    * Bitfield representing the most recent modifier state (Alt, Ctrl, Shift, etc.)
@@ -76,33 +94,46 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @type {number}
    */
-  modStateFlags: number;
+  public modStateFlags: number = 0;
 
   /**
    * The currently active Keyboard instance. Implementations provide a getter and
    * setter to change the active keyboard at runtime. Setting a new keyboard should
    * update any associated stores and clear or reinitialize processor state as needed.
    *
-   * @type {Keyboard}
+   * @type {TKeyboard}
    */
-  get activeKeyboard(): Keyboard;
+  public get activeKeyboard(): TKeyboard {
+    return this.keyboardInterface.activeKeyboard as TKeyboard;
+  }
 
-  set activeKeyboard(keyboard: Keyboard);
+  public set activeKeyboard(keyboard: TKeyboard) {
+    this.keyboardInterface.activeKeyboard = keyboard;
 
+    // All old deadkeys and keyboard-specific cache should immediately be invalidated
+    // on a keyboard change.
+    this.resetContext();
+  }
 
   /**
-   * Read-only minimal interface for interacting with the current keyboard.
+   * The keyboard interface used by the processor.
+   * Provides access to the keyboard interface implementation.
    *
-   * @type {KeyboardMinimalInterface}
+   * @type {TKeyboardInterface}
    */
-  get keyboardInterface(): KeyboardMinimalInterface
+  public get keyboardInterface(): TKeyboardInterface {
+    if (!this._keyboardInterface) {
+      throw new Error('Keyboard interface not initialized');
+    }
+    return this._keyboardInterface;
+  }
 
   /**
    * The store representing the currently active keyboard layer.
    *
    * @type {MutableSystemStore}
    */
-  get layerStore(): MutableSystemStore;
+  public abstract get layerStore(): MutableSystemStore;
 
   /**
    * A writable store used when transitioning to a new layer; allows
@@ -110,7 +141,7 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @type {MutableSystemStore}
    */
-  get newLayerStore(): MutableSystemStore;
+  public abstract get newLayerStore(): MutableSystemStore;
 
   /**
    * A store representing the previously active layer; useful for reverting or
@@ -118,7 +149,7 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @type {MutableSystemStore}
    */
-  get oldLayerStore(): MutableSystemStore;
+  public abstract get oldLayerStore(): MutableSystemStore;
 
   /**
    * Identifier of the currently active layer. Implementations provide getter and
@@ -127,8 +158,8 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @type {string}
    */
-  get layerId(): string;
-  set layerId(value: string);
+  public abstract get layerId(): string;
+  public abstract set layerId(value: string);
 
   /**
    * Process a keystroke, i.e. the `begin Unicode` group.
@@ -140,7 +171,7 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @returns {ProcessorAction} The resulting processor action.
    */
-  processKeystroke(keyEvent: KeyEvent, textStore: TextStore): ProcessorAction;
+  public abstract processKeystroke(keyEvent: KeyEvent, textStore: TextStore): ProcessorAction;
 
   /**
    * Processes the `begin PostKeystroke` group.
@@ -153,7 +184,7 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @returns {ProcessorAction} The resulting processor action.
    */
-  processPostKeystroke(device: DeviceSpec, textStore: TextStore): ProcessorAction;
+  public abstract processPostKeystroke(device: DeviceSpec, textStore: TextStore): ProcessorAction;
 
   /**
    * Determines if the given key event is a modifier key press.
@@ -165,7 +196,104 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @returns {boolean} True if the event is a modifier key press, false otherwise.
    */
-  doModifierPress(keyEvent: KeyEvent, textStore: TextStore, isKeyDown: boolean): boolean;
+  public doModifierPress(keyEvent: KeyEvent, textStore: TextStore, isKeyDown: boolean): boolean {
+    if (!this.activeKeyboard) {
+      return false;
+    }
+
+    if (keyEvent.isModifier) {
+      this.activeKeyboard.notify(keyEvent.Lcode, textStore, isKeyDown ? 1 : 0);
+      // For eventual integration - we bypass an OSK update for physical keystrokes when in touch mode.
+      if (!keyEvent.device.touchable) {
+        return this.updateShiftState(keyEvent); // I2187
+      } else {
+        return true;
+      }
+    }
+
+    if (keyEvent.LmodifierChange) {
+      this.activeKeyboard.notify(0, textStore, 1);
+      if (!keyEvent.device.touchable) {
+        this.updateShiftState(keyEvent);
+      }
+    }
+
+    // No modifier keypresses detected.
+    return false;
+  }
+
+  /**
+   * Updates the virtual keyboard shift state based on the provided key event.
+   * Handles modifier key simulation, state key updates, and layer selection for the OSK.
+   *
+   * @param {KeyEvent | null} e - The key event used to update the shift state.
+   *
+   * @returns {boolean} True if the update was processed, otherwise true if no active keyboard.
+   */
+  protected updateShiftState(e: KeyEvent | null): boolean {
+    let keyShiftState = 0;
+
+    if (!this.activeKeyboard) {
+      return true;
+    }
+
+    if (e) {
+      // read shift states from event
+      keyShiftState = e.Lmodifiers;
+
+      // Are we simulating AltGr?  If it's a simulation and not real, time to un-simulate for the OSK.
+      if (this.activeKeyboard.isChiral && this.activeKeyboard.emulatesAltGr &&
+        (this.modStateFlags & Codes.modifierBitmasks['ALT_GR_SIM']) == Codes.modifierBitmasks['ALT_GR_SIM']) {
+        keyShiftState |= Codes.modifierBitmasks['ALT_GR_SIM'];
+        keyShiftState &= ~ModifierKeyConstants.RALTFLAG;
+      }
+
+      // Set stateKeys where corresponding value is passed in e.Lstates
+      let stateMutation = false;
+      for (let i = 0; i < lockNames.length; i++) {
+        if ((e.Lstates & Codes.stateBitmasks[lockNames[i]]) != 0) {
+          this.stateKeys[lockKeys[i]] = ((e.Lstates & lockModifiers[i]) != 0);
+          stateMutation = true;
+        }
+      }
+
+      if (stateMutation) {
+        this.emit('statekeychange', this.stateKeys);
+      }
+    }
+
+    this.updateStates();
+
+    if (this.activeKeyboard.isMnemonic && this.stateKeys['K_CAPS'] && (!e || !e.isModifier)) {
+      // Modifier keypresses don't trigger mnemonic manipulation of modifier state.
+      // Only an output key does; active use of Caps will also flip the SHIFT flag.
+      // Mnemonic keystrokes manipulate the SHIFT property based on CAPS state.
+      // We need to unflip them when tracking the OSK layer.
+      keyShiftState ^= ModifierKeyConstants.K_SHIFTFLAG;
+    }
+
+    this.layerId = this.getLayerId(keyShiftState);
+    return true;
+  }
+
+  private updateStates(): void {
+    for (let i = 0; i < lockKeys.length; i++) {
+      const key = lockKeys[i];
+      const flag = this.stateKeys[key];
+
+      // Ensures that the current mod-state info properly matches the currently-simulated
+      // state key states.
+      if (flag) {
+        this.modStateFlags |= lockModifiers[i];
+        this.modStateFlags &= ~noLockModifers[i];
+      } else {
+        this.modStateFlags &= ~lockModifiers[i];
+        this.modStateFlags |= noLockModifers[i];
+      }
+    }
+  }
+
+  protected abstract getLayerId(modifier: number): string;
 
   /**
    * Resets the processor's context to a clean state.
@@ -174,7 +302,7 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @param {TextStore} [textStore] - The optional text store to use for resetting context.
    */
-  resetContext(textStore?: TextStore): void;
+  public abstract resetContext(textStore?: TextStore): void;
 
   /**
    * Finalizes the processor action and applies any final changes to the text store.
@@ -183,7 +311,7 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    * @param {ProcessorAction}   data        The processor action to finalize.
    * @param {TextStore}         textStore   The text store to update.
    */
-  finalizeProcessorAction(data: ProcessorAction, textStore: TextStore): void;
+  public abstract finalizeProcessorAction(data: ProcessorAction, textStore: TextStore): void;
 
   /**
    * Selects the OSK's next keyboard layer based upon layer switching keys.
@@ -194,7 +322,7 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @returns {boolean} True if the keyboard layer changed.
    */
-  selectLayer(keyEvent: KeyEvent): boolean;
+  public abstract selectLayer(keyEvent: KeyEvent): boolean;
 
   /**
    *
@@ -202,6 +330,6 @@ export interface KeyboardProcessor extends EventEmitter<EventMap> {
    *
    * @param {DeviceSpec} device - The device for which the numeric layer should be set.
    */
-  setNumericLayer(device: DeviceSpec): void;
+  public abstract setNumericLayer(device: DeviceSpec): void;
 
 }

--- a/web/src/engine/src/main/headless/inputProcessor.ts
+++ b/web/src/engine/src/main/headless/inputProcessor.ts
@@ -53,7 +53,7 @@ export class InputProcessor {
     this.contextDevice = device;
     this.jsKbdProcessor = new JSKeyboardProcessor(device, options);
     this._keyboardProcessor = this.jsKbdProcessor;
-    this.coreKbdProcessor = new CoreKeyboardProcessor();
+    this.coreKbdProcessor = new CoreKeyboardProcessor(device, options.baseLayout);
     this._languageProcessor = new LanguageProcessor(predictiveWorkerFactory, this.contextCache);
   }
 

--- a/web/src/test/auto/headless/engine/core-processor/coreKeyboardProcessor.tests.ts
+++ b/web/src/test/auto/headless/engine/core-processor/coreKeyboardProcessor.tests.ts
@@ -45,10 +45,16 @@ describe('CoreKeyboardProcessor', function () {
   let context: km_core_context;
   let textStore: SyntheticTextStore;
   let sandbox: sinon.SinonSandbox;
+  const device = {
+    formFactor: 'desktop',
+    OS: 'windows',
+    browser: 'native',
+    touchable: false
+  } as DeviceSpec;
 
   describe('saveMarkersToTextStore', function () {
     beforeEach(async function () {
-      coreProcessor = new CoreKeyboardProcessor();
+      coreProcessor = new CoreKeyboardProcessor(device, 'us');
       await coreProcessor.init(coreurl, new VariableStoreCookieSerializer());
       state = createState('/common/test/resources/keyboards/test_8568_deadkeys.kmx');
       context = KM_Core.instance.state_context(state);
@@ -209,7 +215,7 @@ describe('CoreKeyboardProcessor', function () {
 
   describe('applyContextFromTextStore', function () {
     beforeEach(async function () {
-      coreProcessor = new CoreKeyboardProcessor();
+      coreProcessor = new CoreKeyboardProcessor(device, 'us');
       await coreProcessor.init(coreurl, new VariableStoreCookieSerializer());
       state = createState('/common/test/resources/keyboards/test_8568_deadkeys.kmx');
       context = KM_Core.instance.state_context(state);
@@ -492,7 +498,7 @@ describe('CoreKeyboardProcessor', function () {
     let process_event_spy: any;
 
     beforeEach(async function () {
-      coreProcessor = new CoreKeyboardProcessor();
+      coreProcessor = new CoreKeyboardProcessor(device, 'us');
       await coreProcessor.init(coreurl, new VariableStoreCookieSerializer());
       state = createState('/common/test/resources/keyboards/test_8568_deadkeys.kmx');
       context = KM_Core.instance.state_context(state);
@@ -540,7 +546,7 @@ describe('CoreKeyboardProcessor', function () {
     const nonTouchable = false;
 
     beforeEach(async function () {
-      coreProcessor = new CoreKeyboardProcessor();
+      coreProcessor = new CoreKeyboardProcessor(device, 'us');
       await coreProcessor.init(coreurl, new VariableStoreCookieSerializer());
       state = createState('/common/test/resources/keyboards/test_8568_deadkeys.kmx');
       context = KM_Core.instance.state_context(state);

--- a/web/src/test/auto/headless/engine/js-processor/engine/context.tests.js
+++ b/web/src/test/auto/headless/engine/js-processor/engine/context.tests.js
@@ -65,9 +65,11 @@ function runEngineRuleSet(ruleSet, defaultNoun) {
       var textStore = new SyntheticTextStore();
       ruleSeq.test(proctor, textStore);
 
+      const processorInitOptions = { ...DEFAULT_PROCESSOR_INIT_OPTIONS };
+      processorInitOptions.keyboardInterface = keyboardWithHarness;
+
       // Now for the real test!
-      let processor = new JSKeyboardProcessor(device, DEFAULT_PROCESSOR_INIT_OPTIONS);
-      processor.keyboardInterface = keyboardWithHarness;
+      let processor = new JSKeyboardProcessor(device, processorInitOptions);
       var res = processor.keyboardInterface.fullContextMatch(ruleDef.n, textStore, ruleDef.rule);
 
       var msg = matchTest.msg;
@@ -1121,9 +1123,11 @@ describe('Engine - Context Matching', function() {
       const textStore = new SyntheticTextStore();
       ruleSeq.test(proctor, textStore);
 
+      const processorInitOptions = { ...DEFAULT_PROCESSOR_INIT_OPTIONS };
+      processorInitOptions.keyboardInterface = keyboardWithHarness;
+
       // Now for the real test!
-      const processor = new JSKeyboardProcessor(device, DEFAULT_PROCESSOR_INIT_OPTIONS);
-      processor.keyboardInterface = keyboardWithHarness;
+      const processor = new JSKeyboardProcessor(device, processorInitOptions);
       const res = processor.keyboardInterface._BuildExtendedContext(ruleDef.n, ruleDef.ln, textStore);
 
       assert.sameOrderedMembers(res.valContext, ruleDef.contextCache);

--- a/web/src/test/auto/headless/engine/js-processor/specialized-backspace.tests.ts
+++ b/web/src/test/auto/headless/engine/js-processor/specialized-backspace.tests.ts
@@ -4,7 +4,7 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
 import { DeviceSpec, KMWString } from 'keyman/common/web-utils';
-import { Codes, DefaultOutputRules, KeyEvent, MinimalKeymanGlobal, SyntheticTextStore } from 'keyman/engine/keyboard';
+import { Codes, DefaultOutputRules, JSKeyboard, KeyEvent, MinimalKeymanGlobal, SyntheticTextStore } from 'keyman/engine/keyboard';
 import { JSKeyboardInterface, JSKeyboardProcessor } from 'keyman/engine/js-processor';
 import { NodeKeyboardLoader } from 'keyman/test/resources';
 import { VariableStoreTestSerializer } from 'keyman/test/headless-resources';
@@ -98,7 +98,7 @@ describe('Engine - specialized backspace handling', function() {
     // -- START: Standard keyboard unit test loading boilerplate --
     let harness = new JSKeyboardInterface({}, MinimalKeymanGlobal, new VariableStoreTestSerializer());
     let keyboardLoader = new NodeKeyboardLoader(harness);
-    let keyboard = await keyboardLoader.loadKeyboardFromPath(ipaPath);
+    let keyboard = await keyboardLoader.loadKeyboardFromPath(ipaPath) as JSKeyboard;
     // --  END:  Standard keyboard unit test loading boilerplate --
 
     // This part provides extra assurance that the keyboard properly loaded.
@@ -112,7 +112,7 @@ describe('Engine - specialized backspace handling', function() {
     // -- START: Standard keyboard unit test loading boilerplate --
     harness = new JSKeyboardInterface({}, MinimalKeymanGlobal, new VariableStoreTestSerializer());
     keyboardLoader = new NodeKeyboardLoader(harness);
-    keyboard = await keyboardLoader.loadKeyboardFromPath(angkorPath);
+    keyboard = await keyboardLoader.loadKeyboardFromPath(angkorPath) as JSKeyboard;
     // --  END:  Standard keyboard unit test loading boilerplate --
 
     // This part provides extra assurance that the keyboard properly loaded.
@@ -127,7 +127,7 @@ describe('Engine - specialized backspace handling', function() {
     harness.install();
     // Sets the keyboard as the harness's "loaded" keyboard, but not "active".
     harness.KR(new (DUMMIED_KEYS_KEYBOARD_SCRIPT as any)());
-    harness.activeKeyboard = harness.loadedKeyboard;
+    harness.activeKeyboard = harness.loadedKeyboard as JSKeyboard;
     assert.isOk(harness.activeKeyboard);
     dummiedWithHarness = harness;
 
@@ -137,7 +137,7 @@ describe('Engine - specialized backspace handling', function() {
     harness.install();
     // Sets the keyboard as the harness's "loaded" keyboard, but not "active".
     harness.KR(new (DOUBLED_BKSP_KEYBOARD_SCRIPT as any)());
-    harness.activeKeyboard = harness.loadedKeyboard;
+    harness.activeKeyboard = harness.loadedKeyboard as JSKeyboard;
     assert.isOk(harness.activeKeyboard);
     bksp2xWithHarness = harness;
   });

--- a/web/src/test/auto/headless/engine/main/headless/inputProcessor.tests.js
+++ b/web/src/test/auto/headless/engine/main/headless/inputProcessor.tests.js
@@ -108,10 +108,12 @@ describe('InputProcessor', function() {
     describe('without fat-fingering', function() {
       it('with minimal context (no fat-fingers)', function() {
         this.timeout(32); // ms
-        let core = new InputProcessor(device, null, DEFAULT_PROCESSOR_INIT_OPTIONS);
+        const processorInitOptions = { ...DEFAULT_PROCESSOR_INIT_OPTIONS };
+        processorInitOptions.keyboardInterface = keyboardWithHarness;
+
+        let core = new InputProcessor(device, null, processorInitOptions);
         let context = new SyntheticTextStore("", 0);
 
-        core.keyboardProcessor.keyboardInterface = keyboardWithHarness;
         let keyboard = keyboardWithHarness.activeKeyboard;
         let layout = keyboard.layout(utils.DeviceSpec.FormFactor.Phone);
         let key = layout.getLayer('default').getKey('K_A');
@@ -127,11 +129,12 @@ describe('InputProcessor', function() {
 
         this.timeout(500);                // 500 ms, excluding text import.
                                           // These often run on VMs, so we'll be a bit generous.
+        const processorInitOptions = { ...DEFAULT_PROCESSOR_INIT_OPTIONS };
+        processorInitOptions.keyboardInterface = keyboardWithHarness;
 
-        let core = new InputProcessor(device, null, DEFAULT_PROCESSOR_INIT_OPTIONS);  // I mean, it IS long context, and time
+        let core = new InputProcessor(device, null, processorInitOptions);  // I mean, it IS long context, and time
                                           // thresholding is disabled within Node.
 
-        core.keyboardProcessor.keyboardInterface = keyboardWithHarness;
         let keyboard = keyboardWithHarness.activeKeyboard;
         let layout = keyboard.layout(utils.DeviceSpec.FormFactor.Phone);
         let key = layout.getLayer('default').getKey('K_A');
@@ -145,10 +148,12 @@ describe('InputProcessor', function() {
     describe('with fat-fingering', function() {
       it('with minimal context (with fat-fingers)', function() {
         this.timeout(32); // ms
-        let core = new InputProcessor(device, null, DEFAULT_PROCESSOR_INIT_OPTIONS);
+        const processorInitOptions = { ...DEFAULT_PROCESSOR_INIT_OPTIONS };
+        processorInitOptions.keyboardInterface = keyboardWithHarness;
+
+        let core = new InputProcessor(device, null, processorInitOptions);
         let context = new SyntheticTextStore("", 0);
 
-        core.keyboardProcessor.keyboardInterface = keyboardWithHarness;
         let keyboard = keyboardWithHarness.activeKeyboard;
         let layout = keyboard.layout(utils.DeviceSpec.FormFactor.Phone);
         let key = layout.getLayer('default').getKey('K_A');
@@ -169,10 +174,12 @@ describe('InputProcessor', function() {
                                           // Keep at the same 'order of magnitude' as the
                                           // 'without fat-fingers' test.
 
-        let core = new InputProcessor(device, null, DEFAULT_PROCESSOR_INIT_OPTIONS);  // It IS long context, and time
+        const processorInitOptions = { ...DEFAULT_PROCESSOR_INIT_OPTIONS };
+        processorInitOptions.keyboardInterface = keyboardWithHarness;
+
+        let core = new InputProcessor(device, null, processorInitOptions);  // It IS long context, and time
                                           // thresholding is disabled within Node.
 
-        core.keyboardProcessor.keyboardInterface = keyboardWithHarness;
         let keyboard = keyboardWithHarness.activeKeyboard;
         let layout = keyboard.layout(utils.DeviceSpec.FormFactor.Phone);
         let key = layout.getLayer('default').getKey('K_A');
@@ -206,10 +213,12 @@ describe('InputProcessor', function() {
     for (let testSet of testDefinitions.inputTestSets[0]['testSet']) {
       it(testSet.msg ?? 'test', function() {
         this.timeout(32); // ms
-        let core = new InputProcessor(device, null, DEFAULT_PROCESSOR_INIT_OPTIONS);
+        const processorInitOptions = { ...DEFAULT_PROCESSOR_INIT_OPTIONS };
+        processorInitOptions.keyboardInterface = keyboardWithHarness;
+
+        let core = new InputProcessor(device, null, processorInitOptions);
         let context = new SyntheticTextStore("", 0);
 
-        core.keyboardProcessor.keyboardInterface = keyboardWithHarness;
         let keyboard = keyboardWithHarness.activeKeyboard;
 
         for (let keystroke of testSet.inputs) {


### PR DESCRIPTION
This change moves code that was implemented in both `JSKeyboardProcessor` and `CoreKeyboardProcessor` to the `AbstractKeyboardProcessor`. This got renamed from `KeyboardProcessor` and is now a generic abstract class.

Also removed some of the band-aids in `CoreKeyboardInterface` and `JSKeyboardInterface` that I put in before: Typescript allows implementations to have a slightly different method signature and still matches the interface as long as the used types are derived from the ones specified in the interface.

Follows: #15870
Build-bot: skip build:web
Test-bot: skip