### PR TITLE
chore(web): cleanup `web/src/app/browser/src/test-index.ts` exports 🎼

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,12 +4,12 @@
   "exports": {
     "./app/browser": {
       "es6-bundling": "./src/app/browser/src/index.ts",
-      "types": "./build/app/browser/obj/index.d.js",
+      "types": "./build/app/browser/obj/index.d.ts",
       "import": "./build/app/browser/obj/index.js"
     },
     "./common/web-utils": {
       "es6-bundling": "./src/common/web-utils/src/index.ts",
-      "types": "./build/common/web-utils/obj/index.d.js",
+      "types": "./build/common/web-utils/obj/index.d.ts",
       "import": "./build/common/web-utils/obj/index.js"
     },
     "./engine/attachment": {

--- a/web/package.json
+++ b/web/package.json
@@ -3,9 +3,9 @@
   "description": "Facilitates text input in any language.",
   "exports": {
     "./app/browser": {
-      "es6-bundling": "./src/app/browser/src/test-index.ts",
-      "types": "./build/app/browser/obj/test-index.d.js",
-      "import": "./build/app/browser/obj/test-index.js"
+      "es6-bundling": "./src/app/browser/src/index.ts",
+      "types": "./build/app/browser/obj/index.d.js",
+      "import": "./build/app/browser/obj/index.js"
     },
     "./common/web-utils": {
       "es6-bundling": "./src/common/web-utils/src/index.ts",

--- a/web/src/app/browser/build.sh
+++ b/web/src/app/browser/build.sh
@@ -63,7 +63,7 @@ compile_and_copy() {
     --minify \
     --target     "es6"
 
-  node_es_bundle "${BUILD_ROOT}/obj/test-index.js" \
+  node_es_bundle "${BUILD_ROOT}/obj/index.js" \
     --out        "${BUILD_ROOT}/lib/index.mjs" \
     --charset    "utf8" \
     --sourceRoot "@keymanapp/keyman/web/build/app/browser/lib" \

--- a/web/src/app/browser/src/index.ts
+++ b/web/src/app/browser/src/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
+
+export { ContextManager, KeyboardCookie } from "./contextManager.js";
+export { KeyboardDetails } from './keyboardDetails.js';
+export { KeymanEngine } from './keymanEngine.js';
+export { UIModule } from './uiModuleInterface.js';
+
+//----------------------------------------------------------------------
+// Exports for unit testing only
+
+/** @internal */
+export { type BrowserInitOptionSpec } from './configuration.js';
+/** @internal */
+export { type KeyboardInterface } from './keyboardInterface.js';
+
+import { preprocessKeyboardEvent } from './hardwareEventKeyboard.js';
+/** @internal */
+export const unitTestEndPoints = {
+  preprocessKeyboardEvent
+}

--- a/web/src/app/browser/src/test-index.ts
+++ b/web/src/app/browser/src/test-index.ts
@@ -1,8 +1,0 @@
-export { BrowserConfiguration, BrowserInitOptionSpec } from './configuration.js';
-export { ContextManager, KeyboardCookie } from "./contextManager.js";
-export { preprocessKeyboardEvent, HardwareEventKeyboard } from './hardwareEventKeyboard.js';
-export { KeyboardDetails } from './keyboardDetails.js';
-
-export { KeymanEngine } from './keymanEngine.js';
-export { KeyboardInterface } from './keyboardInterface.js';
-export { UIModule } from './uiModuleInterface.js';

--- a/web/src/test/auto/headless/app/browser/hardware-event-processing.tests.ts
+++ b/web/src/test/auto/headless/app/browser/hardware-event-processing.tests.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { preprocessKeyboardEvent } from 'keyman/app/browser';
+import { unitTestEndPoints } from 'keyman/app/browser';
 import { processForMnemonicsAndLegacy } from 'keyman/engine/main';
 import { PhysicalInputEventSpec } from '@keymanapp/recorder-core';
 import { DeviceSpec } from 'keyman/common/web-utils';
@@ -8,6 +8,7 @@ import { Codes, JSKeyboard, KeyEvent } from 'keyman/engine/keyboard';
 
 const ModifierCodes = Codes.modifierCodes;
 const KeyCodes = Codes.keyCodes;
+const preprocessKeyboardEvent = unitTestEndPoints.preprocessKeyboardEvent;
 
 const DUMMY_DEVICE = new DeviceSpec('chrome', 'desktop', 'windows', false);
 


### PR DESCRIPTION
The exports of `test-index.ts` were intended to be used by tests only, but over time they contained also exports that were consumed elsewhere, e.g. in UI classes like `kmwuibutton.ts`. This change removes unused exports, moves test-only classes to a `unitTestEndPoints` container and marks test-only types with `@internal`.

Fixes: #15894 
Build-bot: skip build:web
Test-bot: skip