### PR TITLE
chore(linux): make `debian.sh` a builder script 🏗️

### DIFF
--- a/linux/scripts/debian.sh
+++ b/linux/scripts/debian.sh
@@ -1,29 +1,29 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 # Build source packages suitable to import into the Debian package repos
 # (https://salsa.debian.org/input-method-team)
-
-# must be run from linux dir
-
-# parameters: [PROJECT=<project>] [DIST=<dist>] [DEBREVISION=<no>] ./scripts/debian.sh
-# PROJECT=<project>   only process this project
-# DIST=<dist>         distribution to create packages for (unstable, experimental, etc). If not
-#                     specified UNRELEASED will be used.
-# DEBREVISION=<no>    the debian revision number. Defaults to 1.
-
-set -e
 
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-. "${THIS_SCRIPT%/*}/../../resources/build/builder-basic.inc.sh"
+# shellcheck source=resources/build/builder-full.inc.sh
+. "${THIS_SCRIPT%/*}/../../resources/build/builder-full.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-. $(dirname "$THIS_SCRIPT")/package-build.inc.sh
+# shellcheck source=linux/scripts/package-build.inc.sh
+. "$(dirname "${THIS_SCRIPT}")/package-build.inc.sh"
+
+builder_describe \
+  "Build source packages suitable to import into the Debian package repos" \
+  build \
+  "--project=PROJECT          Only process this project. Default: keyman" \
+  "--dist=DIST                Distribution to create packages for (unstable, experimental, etc). Default: UNRELEASED." \
+  "--debrevision=DEBREVISION  The debian revision number. Default: 1."
+
+builder_parse "$@"
+
+cd "${KEYMAN_ROOT}/linux"
 
 checkPrerequisites
-
-BASEDIR=$(pwd)
 
 rm -rf debianpackage
 mkdir -p debianpackage
@@ -32,11 +32,11 @@ for proj in ${projects}; do
     downloadSource debianpackage
 
     cd "${proj}-${version}"
-    if [[ -n "${DIST}" ]]; then
+    if [[ -n "${DIST:-}" ]]; then
         EXTRA_ARGS="--distribution ${DIST} --force-distribution"
     fi
     # shellcheck disable=SC2086
-    dch --newversion "${version}-${DEBREVISION-1}" ${EXTRA_ARGS} ""
+    dch --newversion "${version}-${DEBREVISION:-1}" ${EXTRA_ARGS:-} ""
     debuild -d -S -sa -Zxz
-    cd "${BASEDIR}"
+    cd "${KEYMAN_ROOT}/linux"
 done

--- a/linux/scripts/package-build.inc.sh
+++ b/linux/scripts/package-build.inc.sh
@@ -2,12 +2,6 @@
 # Keyman is copyright (C) SIL Global. MIT License.
 
 function checkPrerequisites() {
-  if [[ "${UPLOAD:=}" == "yes" ]]; then
-    SIM=""
-  else
-    SIM="-s"
-  fi
-
   # Check the tier
   if [[ -z "${KEYMAN_TIER:=}" ]]; then
     echo "TIER.md or \${KEYMAN_TIER} must be set to (alpha, beta, stable) to use this script"

--- a/linux/scripts/upload-to-debian.sh
+++ b/linux/scripts/upload-to-debian.sh
@@ -175,7 +175,7 @@ git pull origin "${DEPLOY_BRANCH}"
 
 builder_heading "Building source package"
 cd "${WORKTREE_DIR}/linux"
-DIST=unstable DEBREVISION=${REVISION} scripts/debian.sh
+scripts/debian.sh --dist unstable --debrevision "${REVISION}"
 cd debianpackage/
 builder_heading "Signing source package"
 debsign -k"${DEBKEYID}" --re-sign ./*.changes


### PR DESCRIPTION
This change modifies `debian.sh` so that it is a full builder script. This allows further cleanup in `package-build.inc.sh`.

Follows: #15916
Build-bot: skip
Test-bot: skip