### PR TITLE
maint(linux): fix source tarball used for packaging 🏗️

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -70,6 +70,7 @@ to_exclude=(
   linux/docs/help \
   linux/keyman-config/keyman_config/version.py \
   linux/keyman-config/buildtools/build-langtags.py \
+  linux/upload \
 )
 
 if [[ -z "${create_origdist+x}" ]]; then

--- a/linux/scripts/package-build.inc.sh
+++ b/linux/scripts/package-build.inc.sh
@@ -43,7 +43,7 @@ function downloadSource() {
   cd ..
   mv "${proj}-${version}" "${BASEDIR}/${packageDir}"
   mv "${proj}_${version}.orig.tar.xz" "${BASEDIR}/${packageDir}"
-  mv "${proj}-${version}.tar.xz" "${BASEDIR}/${packageDir}"
+  mv "${proj}_${version}.pkg.tar.xz" "${BASEDIR}/${packageDir}"
   mv "${proj}"*.asc "${BASEDIR}/${packageDir}"
   rm "${proj}"*.debian.tar.xz
   cd "${BASEDIR}/${packageDir}" || exit

--- a/linux/scripts/watch.in
+++ b/linux/scripts/watch.in
@@ -1,3 +1,3 @@
 version=4
 # Tier replaced by package-build.inc.sh script
-opts=pgpsigurlmangle=s/$/.asc/ https://downloads.keyman.com/linux/$tier/@ANY_VERSION@/@PACKAGE@@ANY_VERSION@@ARCHIVE_EXT@ debian uupdate
+opts=pgpsigurlmangle=s/$/.asc/ https://downloads.keyman.com/linux/$tier/@ANY_VERSION@/@PACKAGE@@ANY_VERSION@.pkg@ARCHIVE_EXT@ debian uupdate

--- a/resources/teamcity/linux/keyman-linux-release.sh
+++ b/resources/teamcity/linux/keyman-linux-release.sh
@@ -57,10 +57,14 @@ function _cleanup_before_creating_source_package() {
 function _make_release_source_tarball() {
   builder_echo start "make source tarball" "Make source tarball"
   rm -rf dist
+  mkdir -p "upload/${KEYMAN_VERSION}"
   ./scripts/reconf.sh
   PKG_CONFIG_PATH="${KEYMAN_ROOT}/core/build/arch/release/meson-private" ./scripts/dist.sh
-  mkdir -p "upload/${KEYMAN_VERSION}"
-  cp -a dist/*.tar.xz "upload/${KEYMAN_VERSION}"
+  mv dist/*.tar.xz "upload/${KEYMAN_VERSION}/"
+  builder_echo heading "Make source for packaging"
+  PKG_CONFIG_PATH="${KEYMAN_ROOT}/core/build/arch/release/meson-private" ./scripts/dist.sh origdist
+  mv "dist/keyman_${KEYMAN_VERSION}.orig.tar.xz" "dist/keyman_${KEYMAN_VERSION}.pkg.tar.xz"
+  mv dist/*.tar.xz "upload/${KEYMAN_VERSION}/"
   (
     cd "upload/${KEYMAN_VERSION}"
     sha256sum ./*.tar.xz > SHA256SUMS
@@ -84,10 +88,9 @@ function _sign_source_tarball() {
 function _publish_to_downloads() {
   builder_echo start "publish to downloads" "Publish to downloads.keyman.com"
 
-  local UPLOAD_DIR KEYMAN_TXZ
+  local UPLOAD_DIR
 
   UPLOAD_DIR="upload/${KEYMAN_VERSION}"
-  KEYMAN_TXZ="keyman-${KEYMAN_VERSION}.tar.xz"
 
   # Set permissions as required on download site
   builder_echo "Setting upload file permissions for downloads.keyman.com"
@@ -96,7 +99,8 @@ function _publish_to_downloads() {
   chmod g+w  "${UPLOAD_DIR}"/*
   chmod a+r  "${UPLOAD_DIR}"/*
 
-  write_download_info "${UPLOAD_DIR}" "${KEYMAN_TXZ}" "Keyman for Linux" tar.xz linux
+  write_download_info "${UPLOAD_DIR}" "keyman-${KEYMAN_VERSION}.tar.xz" "Keyman for Linux source tarball" tar.xz linux
+  write_download_info "${UPLOAD_DIR}" "keyman_${KEYMAN_VERSION}.pkg.tar.xz" "Keyman for Linux source for packaging" tar.xz linux
   tc_rsync_upload "${UPLOAD_DIR}" "linux/${KEYMAN_TIER}"
 
   builder_echo end "publish to downloads" success "Publish to downloads.keyman.com"


### PR DESCRIPTION
The source tarball we upload to downloads.keyman.com contains all files necessary to run `${KEYMAN_ROOT}/build.sh`, i.e. it contains all projects that can be build on Linux. However, that is not the command used when building Debian packages. There we limit the build to the `linux` subfolder. Therefore we only need a subset of the files. Using the full tarball causes some lintian errors.

This change creates and uploads a second tarball on release builds that contains only the files needed for Debian packaging. The file is named `keyman_$VERSION.pkg.tar.xz`.

Build-bot: skip
Test-bot: skip