### PR TITLE
maint(core): exclude `.configured` files from source tarball 🏗️

### DIFF
--- a/linux/scripts/dist.sh
+++ b/linux/scripts/dist.sh
@@ -130,8 +130,8 @@ dpkg-source \
   --tar-ignore=experiments \
   --tar-ignore=debian \
   --tar-ignore=.github \
-  --tar-ignore=.pc \
   --tar-ignore=.vscode \
+  --tar-ignore=.configured \
   --tar-ignore=.devcontainer \
   --tar-ignore=.pc \
   --tar-ignore=__pycache__ \

--- a/linux/scripts/verify_source.sh
+++ b/linux/scripts/verify_source.sh
@@ -64,8 +64,6 @@ verify_can_build() {
   local target_dir="$1"
   builder_echo heading "Verifying build of tarball"
   cd "${target_dir}"
-  # running `npm i` should happen automatically. See #15905
-  npm i
   ./build.sh configure,build
 }
 


### PR DESCRIPTION
In the source tarball we don't want to include `.configured` files so that a build will call `npm i` first.

Fixes: #15905
Follows: #15926
Test-bot: skip