### PR TITLE
maint(linux): fix uploading to ppa 🏗️

### DIFF
--- a/docs/linux/packaging.md
+++ b/docs/linux/packaging.md
@@ -171,6 +171,17 @@ Package builds on Launchpad are triggered manually by running the Keyman script
     export DEBFULLNAME="Firstname Lastname"
     ```
 
+5. Create a `[keyman-ppa]` section in your `~/.config/dput/dput.cf` (or `~/.dput.cf`)
+   config file:
+
+    ```
+    [keyman-ppa]
+    fqdn                    = ppa.launchpad.net
+    method                  = sftp
+    incoming                = ~keymanapp/%(keyman-ppa)s
+    login                   = *
+    ```
+
 ### Building packages on Launchpad
 
 The `launchpad.sh` script downloads the current source code (beta or stable) from

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -45,11 +45,11 @@ else
 fi
 
 if [[ "${KEYMAN_TIER}" == "stable" ]]; then
-  ppa="ppa:keymanapp/keyman"
+  ppa="keyman-ppa:keyman"
 elif [[ "${KEYMAN_TIER}" == "beta" ]]; then
-  ppa="ppa:keymanapp/keyman-beta"
+  ppa="keyman-ppa:keyman-beta"
 else
-  ppa="ppa:keymanapp/keyman-alpha"
+  ppa="keyman-ppa:keyman-alpha"
 fi
 echo "ppa: ${ppa}"
 


### PR DESCRIPTION
It seems that since a recent DDOS Launchpad only accepts secure connections. This change uses the new `keyman-ppa` section (which has already been created on the TC build agents) to upload to the ppa.

Follows: #15928 
Build-bot: skip
Test-bot: skip