### PR TITLE
maint(web): fix running web e2e tests on Windows 🎼

### DIFF
--- a/common/test/resources/mocha-teamcity-reporter/teamcity.cjs
+++ b/common/test/resources/mocha-teamcity-reporter/teamcity.cjs
@@ -135,6 +135,8 @@ function Teamcity(runner, options) {
 	const ignoredTests = {};
 	const testState = { pending: 0 };
 
+	log('Initializing Mocha TeamCity Reporter');
+
 	runner.on(EVENT_SUITE_BEGIN, function (suite) {
 		handleFlow(true, hasParentFlowId);
 		if (suite.root) {

--- a/common/test/resources/playwright-TC-reporter.ts
+++ b/common/test/resources/playwright-TC-reporter.ts
@@ -182,6 +182,7 @@ export default class PlaywrightTeamcityReporter implements Reporter {
   private root: TestNode = null;
 
   public constructor(options: { parentFlow?: string } = {}) {
+    console.log('Initializing Playwright TeamCity Reporter');
     TestNode.RootFlow = options.parentFlow ?? 'unit_tests';
   }
 

--- a/common/test/resources/test-runner-TC-reporter.mjs
+++ b/common/test/resources/test-runner-TC-reporter.mjs
@@ -94,14 +94,16 @@ export default function teamcityReporter({ name="Web Test Runner JavaScript test
 
   /** @type {import('@web/test-runner').Reporter} */
   const reporter = {
-    start({config, sessions}) {
+    start({ config, sessions }) {
+      logger = config.logger;
+      logger.log('Initializing Web Test Runner TeamCity Reporter');
+
       rootDir = config.rootDir;
 
       for(const session of sessions.all()) {
         testDefMap.set(buildSessionName(session), new Map());
       }
 
-      logger = config.logger;
       logger.log(`##teamcity[blockOpened name='${e(name)}']`);
     },
     stop(args) {

--- a/web/build.sh
+++ b/web/build.sh
@@ -205,12 +205,15 @@ function do_browser_tests() {
 
   pushd "${KEYMAN_ROOT}"
   if is_test_included dom; then
+    builder_echo "Running browser-based tests..."
     web-test-runner --config "web/src/test/auto/dom/web-test-runner${WTR_CONFIG}.config.mjs" ${WTR_INSPECT}
   fi
   if is_test_included integrated; then
+    builder_echo "Running integration tests..."
     web-test-runner --config "web/src/test/auto/integrated/web-test-runner${WTR_CONFIG}.config.mjs" ${WTR_INSPECT}
   fi
   if is_test_included e2e; then
+    builder_echo "Running end-to-end tests..."
     npx playwright test --config "web/src/test/auto/e2e/playwright.config.ts"
   fi
   popd

--- a/web/src/test/auto/e2e/playwright.config.ts
+++ b/web/src/test/auto/e2e/playwright.config.ts
@@ -76,7 +76,10 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: `"${KEYMAN_ROOT}/node_modules/.bin/gosh" "../../../../build.sh start"`,
+    // Normally we'd run `web/build.sh start` or `gosh web/build.sh start`
+    // here, but that's causing problems on Windows.
+    command: 'node web/src/tools/testing/test-server/index.cjs',
+    cwd: KEYMAN_ROOT,
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.KEYMAN_IS_CI_BUILD,
   },


### PR DESCRIPTION
Starting the local dev server before running the e2e tests with `web/build.sh start` didn't work on Windows. This change now directly calls `node` to start the server which seems to work cross-platform.

This change also outputs the name of the TC reporter used for a test. This will help in troubleshooting.

Fixes: #15895 
Build-bot: skip build:web
Test-bot: skip