### PR TITLE
refactor(web): refactor intermediate composited prediction type 🚂 🔪

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -58,6 +58,7 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
   private _previousResults: TokenizationResultMapping[] = [];
 
   // fully private
+  public readonly modelsCorrectables: boolean;
   private selectionQueue: PriorityQueue<QuotientNodeFinalizer>;
   private tokenCostMap: Map<number, number>;
   private tokenLookupMap: Map<number, ContextToken>;
@@ -172,13 +173,16 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
     this._correctables = [];
 
     this.tokenLookupMap = new Map();
+    let modelsCorrectables = false;
 
     orderedTokens.forEach((token, index) => {
       // New issue:  this mangles the space IDs!  We almost certainly need some
       // sort of proper map to the source token.
       const searchModule = new QuotientNodeFinalizer(token.searchModule, index == orderedTokens.length - 1);
       this.tokenLookupMap.set(searchModule.spaceId, token);
-      if(!filterClosure(token)) {
+      const passesFilter = filterClosure(token);
+      modelsCorrectables ||= passesFilter;
+      if(!passesFilter) {
         this._uncorrectables.push(searchModule);
       } else if(index == tailCorrectionLength - 1) {
         // The sole assignment case for this field.  It may only be assigned for
@@ -189,6 +193,8 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
         this._correctables.push(searchModule);
       }
     });
+    // Set a readonly flag indicating if this Corrector started with correctable entries.
+    this.modelsCorrectables = modelsCorrectables;
 
     this._generatedTokenResults = new Map();
     const uncorrectables = this._uncorrectables;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-corrector.ts
@@ -47,8 +47,16 @@ export type TokenResult = {
  * range.
  */
 export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray<TokenResult>, TokenizationResultMapping> {
+  /**
+   * The root ContextTokenization all generated corrections are based upon.
+   */
   public readonly tokenization: ContextTokenization;
-  private readonly tailCorrectionLength: number;
+
+  /**
+   * Indicates whether or not the correction range of this TokenizationCorrector
+   * started with any tokens considered "correctable".
+   */
+  public readonly modelsCorrectables: boolean;
 
   // public read-only via properties
   private readonly _uncorrectables: QuotientNodeFinalizer[];
@@ -58,13 +66,13 @@ export class TokenizationCorrector implements CorrectionSearchable<ReadonlyArray
   private _previousResults: TokenizationResultMapping[] = [];
 
   // fully private
-  public readonly modelsCorrectables: boolean;
   private selectionQueue: PriorityQueue<QuotientNodeFinalizer>;
   private tokenCostMap: Map<number, number>;
   private tokenLookupMap: Map<number, ContextToken>;
   private lastTotalCost: number;
   private handleHasBeenCalled: boolean = false;
   private predictableMatchFound: boolean = false;
+  private readonly tailCorrectionLength: number;
 
   get currentCost(): number {
     const correctable = this.selectionQueue.peek();

--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -162,9 +162,12 @@ export class ModelCompositor {
     // lexicon for a word.  (Example:  "Apple" the company vs "apple" the fruit.)
     for(let tuple of rawPredictions) {
       if(currentCasing && currentCasing != 'lower') {
-        applySuggestionCasing(tuple.prediction.sample, basePrefix, this.lexicalModel, currentCasing);
+        applySuggestionCasing(tuple.components.prediction, basePrefix, this.lexicalModel, currentCasing);
       }
     }
+
+    // what if... we fuse suggestions together here, after the 'apply casing' step?
+    // deduplication, etc function fine from a fused-prediction perspective here.
 
     // We want to dedupe before trimming the list so that we can present a full set
     // of viable distinct suggestions if available.

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -174,7 +174,7 @@ export interface PredictionMetadata {
   preservationTransform?: Transform;
 }
 
-export interface IntermediateCompositedPrediction {
+export interface CompositedIntermediatePrediction {
   /**
    * Contains the fully composited predictive-text Suggestion and its underlying correction string.
    */
@@ -185,7 +185,7 @@ export interface IntermediateCompositedPrediction {
   metadata: PredictionMetadata;
 }
 
-type IntermediatePrediction = IntermediateCompositedPrediction;
+type IntermediatePrediction = CompositedIntermediatePrediction;
 
 /**
  * An enum to be used when categorizing the level of similarity between
@@ -494,7 +494,7 @@ export interface PredictionParameters {
    * @param entry
    * @returns
    */
-  applyInPost: (entry: IntermediateCompositedPrediction) => void
+  applyInPost: (entry: CompositedIntermediatePrediction) => void
 }
 
 export function buildCorrectionSequence(
@@ -577,7 +577,7 @@ export function determineTokenizedCorrectionSequence(
 
   return {
     ...suggestionParams,
-    applyInPost: (entry: IntermediateCompositedPrediction) => {
+    applyInPost: (entry: CompositedIntermediatePrediction) => {
       entry.metadata.preservationTransform = tokenization.taillessTrueKeystroke;
       // // Will need an extra lookup layer if the suggestion is generated from within a cluster.
       // entry.baseTokenization = transition.final.tokenizationSourceMap.get(tokenization);
@@ -612,7 +612,7 @@ export async function correctAndEnumerate(
   /**
    * The suggestions generated based on the user's input state.
    */
-  rawPredictions: IntermediateCompositedPrediction[];
+  rawPredictions: CompositedIntermediatePrediction[];
 
   /**
    * The id of a prior ContextTransition event that triggered a Suggestion found
@@ -668,7 +668,7 @@ export async function correctAndEnumerate(
   const searchModules = tokenizations.map(t => t.tail.searchModule);
 
   // Only run the correction search when corrections are enabled.
-  let rawPredictions: IntermediateCompositedPrediction[] = [];
+  let rawPredictions: CompositedIntermediatePrediction[] = [];
   let bestCorrectionCost: number;
   for await(const match of getBestTokenMatches(searchModules, timer)) {
     // Corrections obtained:  now to predict from them!
@@ -721,7 +721,7 @@ export async function correctAndEnumerate(
 export function shouldStopSearchingEarly(
   bestCorrectionCost: number,
   currentCorrectionCost: number,
-  rawPredictions: IntermediateCompositedPrediction[]
+  rawPredictions: CompositedIntermediatePrediction[]
 ) {
   if(currentCorrectionCost >= bestCorrectionCost + CORRECTION_SEARCH_THRESHOLDS.MAX_SEARCH_THRESHOLD) {
     return true;
@@ -767,7 +767,7 @@ export function predictFromCorrectionSequence(
   corrections: ProbabilityMass<Transform>[],
   rootContext: Context,
   transitionId: number
-): IntermediateCompositedPrediction[] {
+): CompositedIntermediatePrediction[] {
   let predictionPrefixSequence: ProbabilityMass<Suggestion>[] = [];
   let tailPredictions: ProbabilityMass<Suggestion>[];
 
@@ -816,7 +816,7 @@ export function predictFromCorrectionSequence(
     return [];
   }
 
-  const predictions: IntermediateCompositedPrediction[] = tailPredictions.map((p) => {
+  const predictions: CompositedIntermediatePrediction[] = tailPredictions.map((p) => {
     // Concat corrections + predictions for their components.
     const predictionSequence = [...predictionPrefixSequence, p];
     const fullPrediction: ProbabilityMass<Suggestion> = predictionSequence.reduce((prev, curr) => {
@@ -896,13 +896,13 @@ export function applySuggestionCasing(suggestion: Suggestion, baseWord: string, 
  */
 export function dedupeSuggestions(
   lexicalModel: LexicalModel,
-  rawPredictions: IntermediateCompositedPrediction[],
+  rawPredictions: CompositedIntermediatePrediction[],
   context: Context
 ) {
   const wordbreak = determineModelWordbreaker(lexicalModel);
 
-  let suggestionDistribMap: {[key: string]: IntermediateCompositedPrediction} = {};
-  let suggestionDistribution: IntermediateCompositedPrediction[] = [];
+  let suggestionDistribMap: {[key: string]: CompositedIntermediatePrediction} = {};
+  let suggestionDistribution: CompositedIntermediatePrediction[] = [];
 
   // Deduplicator + annotator of 'keep' suggestions.
   for(let tuple of rawPredictions) {
@@ -953,7 +953,7 @@ export function dedupeSuggestions(
  */
 export function processSimilarity(
   lexicalModel: LexicalModel,
-  suggestionDistribution: IntermediateCompositedPrediction[],
+  suggestionDistribution: CompositedIntermediatePrediction[],
   context: Context,
   trueInput: ProbabilityMass<Transform>
 ): boolean {
@@ -1030,7 +1030,7 @@ export function createDefaultKeep(
   lexicalModel: LexicalModel,
   context: Context,
   trueInput: ProbabilityMass<Transform>
-): IntermediateCompositedPrediction {
+): CompositedIntermediatePrediction {
   const { sample: inputTransform, p: inputTransformProb } = trueInput;
   const wordbreak = determineModelWordbreaker(lexicalModel);
   const tokenizer = determineModelTokenizer(lexicalModel);
@@ -1111,7 +1111,7 @@ export function correctionValidForAutoSelect(correction: string) {
   return false;
 }
 
-export function predictionAutoSelect(suggestionDistribution: IntermediateCompositedPrediction[]) {
+export function predictionAutoSelect(suggestionDistribution: CompositedIntermediatePrediction[]) {
   if(suggestionDistribution.length == 0) {
     return;
   }
@@ -1205,7 +1205,7 @@ export function predictionAutoSelect(suggestionDistribution: IntermediateComposi
  */
 export function finalizeSuggestions(
   lexicalModel: LexicalModel,
-  deduplicatedSuggestionTuples: IntermediateCompositedPrediction[],
+  deduplicatedSuggestionTuples: CompositedIntermediatePrediction[],
   context: Context,
   inputTransform: Transform,
   verbose?: boolean

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -112,24 +112,53 @@ export interface SuggestionReplacement<T extends ContextTokenLike> {
   transitionId?: number
 }
 
-/**
- * Collates information related to suggestions during the suggestion generation
- * process.
- */
-export type CorrectionPredictionTuple = {
+export interface CompositedPredictionData {
   /**
    * The potential Suggestion (or Keep)
    */
-  prediction: ProbabilityMass<Suggestion | Keep>,
+  prediction: Suggestion | Keep;
   /**
    * The correction upon which the Suggestion (or Keep) is based
    */
-  correction: ProbabilityMass<string>,
+  correction: string
+}
+
+export interface PredictionProbabilities {
   /**
-   * The likelihood of the prediction - its lexical-model likelihood multiplied
-   * by the keystroke-sequence + correction likelihood.
+   * The probability of the word itself, separate from corrections, as
+   * determined by the LexicalModel itself.
    */
-  totalProb: number;
+  prediction: number;
+
+  /**
+   * The probability of text-correction steps taken to build the correction upon
+   * which the prediction is based.
+   */
+  correction: number;
+
+  /**
+   * The likelihood of the represented prediction, combining both the
+   * `prediction` and `correction` components into a single value.
+   */
+  total: number;
+}
+
+/**
+ * Tracks common intermediate prediction data, such as its underlying probabilities and its similarity to the actual context.
+ */
+export interface PredictionMetadata {
+  /**
+   * Tracks the relevant probability components contributing to a generated
+   * prediction.
+   */
+  probabilities: PredictionProbabilities;
+
+  /**
+   * Indicates that the 'suggestion' represents context changes that qualify for
+   * auto-selection.
+   */
+  autoSelectable: boolean;
+
   /**
    * How directly the prediction matches the current token in the context.
    *
@@ -137,12 +166,26 @@ export type CorrectionPredictionTuple = {
    * available upon initial construction of this type.
    */
   matchLevel?: SuggestionSimilarity;
+
   /**
    * Text from the triggering input that should _not_ be affected by the
    * prediction.
    */
   preservationTransform?: Transform;
-};
+}
+
+export interface IntermediateCompositedPrediction {
+  /**
+   * Contains the fully composited predictive-text Suggestion and its underlying correction string.
+   */
+  components: CompositedPredictionData;
+  /**
+   * Tracks common intermediate prediction data, such as its underlying probabilities and its similarity to the actual context.
+   */
+  metadata: PredictionMetadata;
+}
+
+type IntermediatePrediction = IntermediateCompositedPrediction;
 
 /**
  * An enum to be used when categorizing the level of similarity between
@@ -180,15 +223,15 @@ export enum SuggestionSimilarity {
   exact = 3
 }
 
-export function tupleDisplayOrderSort(a: CorrectionPredictionTuple, b: CorrectionPredictionTuple) {
+export function tupleDisplayOrderSort(a: IntermediatePrediction, b: IntermediatePrediction) {
   // Similarity distance
-  const simDist = (b.matchLevel ?? 0) - (a.matchLevel ?? 0);
+  const simDist = (b.metadata.matchLevel ?? 0) - (a.metadata.matchLevel ?? 0);
   if(simDist != 0) {
     return simDist;
   }
 
   // Probability distance
-  return b.totalProb - a.totalProb;
+  return b.metadata.probabilities.total - a.metadata.probabilities.total;
 }
 
 export function determineTraversallessCorrectionSequences(
@@ -251,9 +294,9 @@ export function determineTraversallessCorrectionSequences(
     returnedPredictionData.push({
       ...suggestionParams,
       applyInPost: (p) => {
-        p.preservationTransform = preservationTransform;
-        if(transformId) {
-          p.prediction.sample.transformId = transformId;
+        p.metadata.preservationTransform = preservationTransform;
+        if(transformId !== undefined) {
+          p.components.prediction.transformId = transformId;
         }
       }
     })
@@ -451,7 +494,7 @@ export interface PredictionParameters {
    * @param entry
    * @returns
    */
-  applyInPost: (entry: CorrectionPredictionTuple) => void
+  applyInPost: (entry: IntermediateCompositedPrediction) => void
 }
 
 export function buildCorrectionSequence(
@@ -534,11 +577,11 @@ export function determineTokenizedCorrectionSequence(
 
   return {
     ...suggestionParams,
-    applyInPost: (entry: CorrectionPredictionTuple) => {
-      entry.preservationTransform = tokenization.taillessTrueKeystroke;
+    applyInPost: (entry: IntermediateCompositedPrediction) => {
+      entry.metadata.preservationTransform = tokenization.taillessTrueKeystroke;
       // // Will need an extra lookup layer if the suggestion is generated from within a cluster.
       // entry.baseTokenization = transition.final.tokenizationSourceMap.get(tokenization);
-      entry.prediction.sample.transform.deleteLeft = deleteLeft;
+      entry.components.prediction.transform.deleteLeft = deleteLeft;
     }
   };
 }
@@ -569,7 +612,7 @@ export async function correctAndEnumerate(
   /**
    * The suggestions generated based on the user's input state.
    */
-  rawPredictions: CorrectionPredictionTuple[];
+  rawPredictions: IntermediateCompositedPrediction[];
 
   /**
    * The id of a prior ContextTransition event that triggered a Suggestion found
@@ -625,9 +668,8 @@ export async function correctAndEnumerate(
   const searchModules = tokenizations.map(t => t.tail.searchModule);
 
   // Only run the correction search when corrections are enabled.
-  let rawPredictions: CorrectionPredictionTuple[] = [];
+  let rawPredictions: IntermediateCompositedPrediction[] = [];
   let bestCorrectionCost: number;
-  const correctionPredictionMap: Record<string, Distribution<Suggestion>> = {};
   for await(const match of getBestTokenMatches(searchModules, timer)) {
     // Corrections obtained:  now to predict from them!
     const tokenization = tokenizations.find(t => t.spaceId == match.spaceId);
@@ -659,14 +701,6 @@ export async function correctAndEnumerate(
       bestCorrectionCost = match.totalCost;
     }
 
-    // If we're getting the same prediction again, it's lower-cost.  Update!
-    let oldPredictionSet = correctionPredictionMap[match.matchString];
-    if(oldPredictionSet) {
-      rawPredictions = rawPredictions.filter((entry) => !oldPredictionSet.find((match) => entry.prediction.sample == match.sample));
-    }
-
-    correctionPredictionMap[match.matchString] = predictions.map((entry) => entry.prediction);
-
     rawPredictions = rawPredictions.concat(predictions);
 
     if(shouldStopSearchingEarly(bestCorrectionCost, match.totalCost, rawPredictions)) {
@@ -687,7 +721,7 @@ export async function correctAndEnumerate(
 export function shouldStopSearchingEarly(
   bestCorrectionCost: number,
   currentCorrectionCost: number,
-  rawPredictions: CorrectionPredictionTuple[]
+  rawPredictions: IntermediateCompositedPrediction[]
 ) {
   if(currentCorrectionCost >= bestCorrectionCost + CORRECTION_SEARCH_THRESHOLDS.MAX_SEARCH_THRESHOLD) {
     return true;
@@ -703,7 +737,7 @@ export function shouldStopSearchingEarly(
       // If the best suggestion from the search's current tier fails to beat the worst
       // pending suggestion from previous tiers, assume all further corrections will
       // similarly fail to win; terminate the search-loop.
-      if(rawPredictions[ModelCompositor.MAX_SUGGESTIONS-1].totalProb > Math.exp(-currentCorrectionCost)) {
+      if(rawPredictions[ModelCompositor.MAX_SUGGESTIONS-1].metadata.probabilities.total > Math.exp(-currentCorrectionCost)) {
         return true;
       }
     }
@@ -733,7 +767,7 @@ export function predictFromCorrectionSequence(
   corrections: ProbabilityMass<Transform>[],
   rootContext: Context,
   transitionId: number
-): CorrectionPredictionTuple[] {
+): IntermediateCompositedPrediction[] {
   let predictionPrefixSequence: ProbabilityMass<Suggestion>[] = [];
   let tailPredictions: ProbabilityMass<Suggestion>[];
 
@@ -782,7 +816,7 @@ export function predictFromCorrectionSequence(
     return [];
   }
 
-  const predictions: CorrectionPredictionTuple[] = tailPredictions.map((p) => {
+  const predictions: IntermediateCompositedPrediction[] = tailPredictions.map((p) => {
     // Concat corrections + predictions for their components.
     const predictionSequence = [...predictionPrefixSequence, p];
     const fullPrediction: ProbabilityMass<Suggestion> = predictionSequence.reduce((prev, curr) => {
@@ -808,10 +842,19 @@ export function predictFromCorrectionSequence(
     }
 
     return {
-      prediction: fullPrediction,
-      correction: fullCorrection,
-      totalProb: fullPrediction.p * fullCorrection.p,
-      matchLevel: SuggestionSimilarity.none,
+      components: {
+        prediction: fullPrediction.sample,
+        correction: fullCorrection.sample
+      },
+      metadata: {
+        probabilities: {
+          prediction: fullPrediction.p,
+          correction: fullCorrection.p,
+          total: fullPrediction.p * fullCorrection.p
+        },
+        autoSelectable: correctionValidForAutoSelect(fullCorrection.sample),
+        matchLevel: SuggestionSimilarity.none
+      }
     };
   });
 
@@ -853,17 +896,17 @@ export function applySuggestionCasing(suggestion: Suggestion, baseWord: string, 
  */
 export function dedupeSuggestions(
   lexicalModel: LexicalModel,
-  rawPredictions: CorrectionPredictionTuple[],
+  rawPredictions: IntermediateCompositedPrediction[],
   context: Context
 ) {
   const wordbreak = determineModelWordbreaker(lexicalModel);
 
-  let suggestionDistribMap: {[key: string]: CorrectionPredictionTuple} = {};
-  let suggestionDistribution: CorrectionPredictionTuple[] = [];
+  let suggestionDistribMap: {[key: string]: IntermediateCompositedPrediction} = {};
+  let suggestionDistribution: IntermediateCompositedPrediction[] = [];
 
   // Deduplicator + annotator of 'keep' suggestions.
   for(let tuple of rawPredictions) {
-    const predictedWord = wordbreak(models.applyTransform(tuple.prediction.sample.transform, context));
+    const predictedWord = wordbreak(models.applyTransform(tuple.components.prediction.transform, context));
 
     // Assumption:  suggestions that have the same net result should have the
     // same displayAs string.  (We could try to pick the one with highest net
@@ -873,7 +916,7 @@ export function dedupeSuggestions(
     // Merge 'em!
     const existingSuggestion = suggestionDistribMap[predictedWord];
     if(existingSuggestion) {
-      existingSuggestion.totalProb += tuple.totalProb;
+      existingSuggestion.metadata.probabilities.total += tuple.metadata.probabilities.total;
     } else {
       suggestionDistribMap[predictedWord] = tuple;
     }
@@ -901,15 +944,16 @@ export function dedupeSuggestions(
  *   current text
  * - any other suggestion
  *
+ * @param lexicalModel
  * @param suggestionDistribution
- * @param context
- * @param trueInput inputTransform + its assigned probability
+ * @param baseContext
+ * @param finalContext
  * @returns true if an existing suggestion fulfills the role of 'keep';
  * otherwise, false.
  */
 export function processSimilarity(
   lexicalModel: LexicalModel,
-  suggestionDistribution: CorrectionPredictionTuple[],
+  suggestionDistribution: IntermediateCompositedPrediction[],
   context: Context,
   trueInput: ProbabilityMass<Transform>
 ): boolean {
@@ -929,38 +973,38 @@ export function processSimilarity(
   for(let tuple of suggestionDistribution) {
     // Don't set it unnecessarily; this can have side-effects in some automated tests.
     if(inputTransform.id !== undefined) {
-      tuple.prediction.sample.transformId = inputTransform.id;
+      tuple.components.prediction.transformId = inputTransform.id;
     }
 
-    const predictedWord = wordbreak(models.applyTransform(tuple.prediction.sample.transform, context));
+    const predictedWord = wordbreak(models.applyTransform(tuple.components.prediction.transform, context));
 
     // Is the suggestion an exact match (or, "similar enough") to the
     // actually-typed context?  If so, we wish to note this fact and to
     // prioritize such a suggestion over suggestions that are not.
-    if(keyed(tuple.correction.sample) == keyedPrefix) {
+    if(keyed(tuple.components.correction) == keyedPrefix) {
       if(predictedWord == truePrefix) {
         // Exact match:  it's a perfect 'keep' suggestion.
-        tuple.matchLevel = SuggestionSimilarity.exact;
-        keepOption = toAnnotatedSuggestion(lexicalModel, tuple.prediction.sample, 'keep',  models.QuoteBehavior.noQuotes);
+        tuple.metadata.matchLevel = SuggestionSimilarity.exact;
+        keepOption = toAnnotatedSuggestion(lexicalModel, tuple.components.prediction, 'keep',  models.QuoteBehavior.noQuotes);
 
         // Indicates that this suggestion exists directly within the lexical
         // model as a valid suggestion.  (We actively display it if it's an
         // exact match, but hide it if not, only preserving it for reversions
         // if/when needed.)
         keepOption.matchesModel = true;
-        Object.assign(tuple.prediction.sample, keepOption);
-        keepOption = tuple.prediction.sample as Outcome<Keep>;
+        Object.assign(tuple.components.prediction, keepOption);
+        keepOption = tuple.components.prediction as Outcome<Keep>;
       } else if(keyCased(predictedWord) == lowercasedPrefix) {
         // Case-insensitive match.  No diacritic differences; the ONLY difference is casing.
-        tuple.matchLevel = SuggestionSimilarity.sameText;
+        tuple.metadata.matchLevel = SuggestionSimilarity.sameText;
       } else if(keyed(predictedWord) == keyedPrefix) {
         // Diacritic-insensitive / exact-key match.
-        tuple.matchLevel = SuggestionSimilarity.sameKey;
+        tuple.metadata.matchLevel = SuggestionSimilarity.sameKey;
       } else {
-        tuple.matchLevel = SuggestionSimilarity.none;
+        tuple.metadata.matchLevel = SuggestionSimilarity.none;
       }
     } else {
-      tuple.matchLevel = SuggestionSimilarity.none;
+      tuple.metadata.matchLevel = SuggestionSimilarity.none;
     }
   }
 
@@ -986,7 +1030,7 @@ export function createDefaultKeep(
   lexicalModel: LexicalModel,
   context: Context,
   trueInput: ProbabilityMass<Transform>
-): CorrectionPredictionTuple {
+): IntermediateCompositedPrediction {
   const { sample: inputTransform, p: inputTransformProb } = trueInput;
   const wordbreak = determineModelWordbreaker(lexicalModel);
   const tokenizer = determineModelTokenizer(lexicalModel);
@@ -1022,19 +1066,19 @@ export function createDefaultKeep(
 
   // Insert our synthetic keepOption as a prediction tuple.
   return {
-    // Product of the two p's below.
-    totalProb: inputTransformProb * MAX_PROB,
-    prediction: {
-      sample: keepOption,
-      // We always show the keep option if it doesn't directly match,
-      // so max probability is fine.
-      p: MAX_PROB,
+    components: {
+      prediction: keepOption,
+      correction: truePrefix
     },
-    correction: {
-      sample: truePrefix,
-      p: inputTransformProb * MAX_PROB
-    },
-    matchLevel: SuggestionSimilarity.exact
+    metadata: {
+      probabilities: {
+        prediction: MAX_PROB,
+        correction: inputTransformProb,
+        total: inputTransformProb * MAX_PROB
+      },
+      autoSelectable: false,
+      matchLevel: SuggestionSimilarity.exact
+    }
   };
 }
 
@@ -1067,12 +1111,12 @@ export function correctionValidForAutoSelect(correction: string) {
   return false;
 }
 
-export function predictionAutoSelect(suggestionDistribution: CorrectionPredictionTuple[]) {
+export function predictionAutoSelect(suggestionDistribution: IntermediateCompositedPrediction[]) {
   if(suggestionDistribution.length == 0) {
     return;
   }
 
-  const keepOption = suggestionDistribution[0].prediction.sample as Outcome<Keep>;
+  const keepOption = suggestionDistribution[0].components.prediction as Outcome<Keep>;
   if(keepOption.tag == 'keep' && keepOption.matchesModel) {
     // Auto-select it for auto-acceptance; we don't correct away from perfectly-valid
     // lexical entries, even if they are comparatively low-frequency.
@@ -1086,19 +1130,19 @@ export function predictionAutoSelect(suggestionDistribution: CorrectionPredictio
 
   if(suggestionDistribution.length == 1) {
     // Prevent auto-acceptance when the root doesn't meet validation criteria.
-    if(!correctionValidForAutoSelect(suggestionDistribution[0].correction.sample)) {
+    if(!suggestionDistribution[0].metadata.autoSelectable) {
       return;
     }
 
     // Mark for auto-acceptance; there are no alternatives.
-    suggestionDistribution[0].prediction.sample.autoAccept = true;
+    suggestionDistribution[0].components.prediction.autoAccept = true;
     return;
   }
 
   // Is it reasonable to auto-accept any of our suggestions?
   const bestSuggestion = suggestionDistribution[0];
 
-  const baseCorrection = bestSuggestion.correction.sample;
+  const baseCorrection = bestSuggestion.components.correction;
   if(baseCorrection.length == 0) {
     // If the correction is rooted on an empty root, there's no basis for
     // auto-correcting to this suggestion.
@@ -1107,8 +1151,8 @@ export function predictionAutoSelect(suggestionDistribution: CorrectionPredictio
 
   // Find the highest probability for any correction that led to a valid prediction.
   // No need to full-on re-sort everything, though.
-  const bestCorrection = suggestionDistribution.reduce((prev, current) => prev?.correction.p > current.correction.p ? prev : current, null).correction;
-  if(bestCorrection.p > bestSuggestion.correction.p) {
+  const bestCorrectionP = suggestionDistribution.reduce((prev, current) => Math.max(prev, current.metadata.probabilities.correction), 0);
+  if(bestCorrectionP > bestSuggestion.metadata.probabilities.correction) {
     // Here, the best suggestion didn't come from the best correction.
     // Is it actually reasonable to auto-correct?  We're probably just very
     // biased toward its frequency.  (Maybe a threshold should be considered?)
@@ -1119,28 +1163,28 @@ export function predictionAutoSelect(suggestionDistribution: CorrectionPredictio
   // - such as replacing `cant` with `can't` if the latter is much more frequent -
   // we may wish to group matchLevel values below by 'mapping' them with an appropriate
   // function.  (Both on the next line and within the reduce functor.)
-  const bestSuggestionTier = bestSuggestion.matchLevel;
+  const bestSuggestionTier = bestSuggestion.metadata.matchLevel;
 
   // compare best vs other probabilities of compatible tier.
   const probSum = suggestionDistribution.reduce((accum, current) => {
     // If the suggestion is from a different similarity tier, do not count it against
     // the required auto-select probability ratio threshold.  That threshold should
     // only apply within the suggestion's tier.
-    return accum + (current.matchLevel == bestSuggestionTier ? current.totalProb : 0)
+    return accum + (current.metadata.matchLevel == bestSuggestionTier ? current.metadata.probabilities.total : 0)
   }, 0);
-  const proportionOfBest = bestSuggestion.totalProb / probSum;
+  const proportionOfBest = bestSuggestion.metadata.probabilities.total / probSum;
   if(proportionOfBest < AUTOSELECT_PROPORTION_THRESHOLD) {
     return;
   }
 
-  if(!correctionValidForAutoSelect(bestSuggestion.correction.sample)) {
+  if(!bestSuggestion.metadata.autoSelectable) {
     return;
   }
 
   // compare correction-cost aspects?  We disable if the base correction is lower than best,
   // but should we do other comparisons too?
 
-  bestSuggestion.prediction.sample.autoAccept = true;
+  bestSuggestion.components.prediction.autoAccept = true;
 }
 
 /**
@@ -1161,7 +1205,7 @@ export function predictionAutoSelect(suggestionDistribution: CorrectionPredictio
  */
 export function finalizeSuggestions(
   lexicalModel: LexicalModel,
-  deduplicatedSuggestionTuples: CorrectionPredictionTuple[],
+  deduplicatedSuggestionTuples: IntermediateCompositedPrediction[],
   context: Context,
   inputTransform: Transform,
   verbose?: boolean
@@ -1170,42 +1214,44 @@ export function finalizeSuggestions(
   const tokenize = determineModelTokenizer(lexicalModel);
 
   const suggestions = deduplicatedSuggestionTuples.map((tuple) => {
-    const prediction = tuple.prediction;
+    const prediction = tuple.components.prediction;
 
     // If this is a suggestion after any form of wordbreak input, make sure we preserve any components
     // from prior tokens!
     //
     // Note:  may need adjustment if/when supporting phrase-level correction.
-    if(tuple.preservationTransform) {
+    if(tuple.metadata.preservationTransform) {
       const mergedTransform = {
-        ...models.buildMergedTransform(tuple.preservationTransform, {...prediction.sample.transform, deleteLeft: 0}),
-        deleteLeft: prediction.sample.transform.deleteLeft
+        ...models.buildMergedTransform(tuple.metadata.preservationTransform, {...prediction.transform, deleteLeft: 0}),
+        deleteLeft: prediction.transform.deleteLeft
       };
 
       // Temporarily and locally drops 'readonly' semantics so that we can reassign the transform.
       // See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#improved-control-over-mapped-type-modifiers
-      let mutableSuggestion = prediction.sample as {-readonly [transform in keyof Suggestion]: Suggestion[transform]};
+      let mutableSuggestion = prediction as {-readonly [transform in keyof Suggestion]: Suggestion[transform]};
 
       // Assignment via by-reference behavior, as suggestion is an object
       mutableSuggestion.transform = mergedTransform;
     }
 
     // Is sometimes not set during unit tests.
-    if(prediction.sample.transformId !== undefined) {
-      prediction.sample.transform.id = prediction.sample.transformId;
+    if(prediction.transformId !== undefined) {
+      prediction.transform.id = prediction.transformId;
     }
+
+    const probs = tuple.metadata.probabilities;
 
     if(!verbose) {
       return {
-        ...prediction.sample,
-        p: tuple.totalProb
+        ...prediction,
+        p: probs.total
       };
     } else {
       const sample: Outcome<Suggestion | Keep> = {
-        ...prediction.sample,
-        p: tuple.totalProb,
-        "lexical-p": prediction.p,
-        "correction-p": tuple.correction.p
+        ...prediction,
+        p: probs.total,
+        "lexical-p": probs.prediction,
+        "correction-p": probs.correction
       }
 
       return sample;

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/early-correction-search-stopping.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/early-correction-search-stopping.tests.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { CORRECTION_SEARCH_THRESHOLDS, IntermediateCompositedPrediction, ModelCompositor, shouldStopSearchingEarly } from "@keymanapp/lm-worker/test-index";
+import { CORRECTION_SEARCH_THRESHOLDS, CompositedIntermediatePrediction, ModelCompositor, shouldStopSearchingEarly } from "@keymanapp/lm-worker/test-index";
 
 function mockIntermediatePrediction(value: number) {
   return {
@@ -9,7 +9,7 @@ function mockIntermediatePrediction(value: number) {
         total: value
       }
     }
-  } as IntermediateCompositedPrediction
+  } as CompositedIntermediatePrediction
 }
 
 describe('correction-search: shouldStopSearchingEarly', () => {

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/early-correction-search-stopping.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/correction-search/early-correction-search-stopping.tests.ts
@@ -1,6 +1,16 @@
 import { assert } from 'chai';
 
-import { CORRECTION_SEARCH_THRESHOLDS, CorrectionPredictionTuple, ModelCompositor, shouldStopSearchingEarly } from "@keymanapp/lm-worker/test-index";
+import { CORRECTION_SEARCH_THRESHOLDS, IntermediateCompositedPrediction, ModelCompositor, shouldStopSearchingEarly } from "@keymanapp/lm-worker/test-index";
+
+function mockIntermediatePrediction(value: number) {
+  return {
+    metadata: {
+      probabilities: {
+        total: value
+      }
+    }
+  } as IntermediateCompositedPrediction
+}
 
 describe('correction-search: shouldStopSearchingEarly', () => {
   it('stops early once new corrections are less likely than currently discovered predictions', () => {
@@ -12,12 +22,7 @@ describe('correction-search: shouldStopSearchingEarly', () => {
     assert.equal(predictionProbs.length, ModelCompositor.MAX_SUGGESTIONS, "test setup no longer valid");
 
     // The only part for each entry we actually care about here:  .totalProb.
-    /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]} */
-    const predictions = predictionProbs.map((entry) => {
-      return {
-        totalProb: entry
-      } as CorrectionPredictionTuple
-    });
+    const predictions = predictionProbs.map((entry) => mockIntermediatePrediction(entry));
 
     // Thresholding is performed in log-space.
     // 0.0501 and 0.0499 are offset on each side of 0.05, the last value in the array defined above.
@@ -33,8 +38,8 @@ describe('correction-search: shouldStopSearchingEarly', () => {
     //
     // Can technically run the method with an empty array, but the actual scenario would have
     // at least one prediction present in the "found predictions" array.
-    assert.isFalse(shouldStopSearchingEarly(baseCost, baseCost + expectedThreshold - 0.01, [{ totalProb: Math.exp(-1) } as CorrectionPredictionTuple]));
-    assert.isTrue(shouldStopSearchingEarly( baseCost, baseCost + expectedThreshold + 0.01, [{ totalProb: Math.exp(-1) } as CorrectionPredictionTuple]));
+    assert.isFalse(shouldStopSearchingEarly(baseCost, baseCost + expectedThreshold - 0.01, [mockIntermediatePrediction(Math.exp(-1))]));
+    assert.isTrue(shouldStopSearchingEarly( baseCost, baseCost + expectedThreshold + 0.01, [mockIntermediatePrediction(Math.exp(-1))]));
   });
 
   it('stops checking corrections earlier when enough predictions have been found', () => {
@@ -43,11 +48,7 @@ describe('correction-search: shouldStopSearchingEarly', () => {
 
     // The only part for each entry we actually care about here:  .totalProb.
     /** @type {import('#./predict-helpers.js').CorrectionPredictionTuple[]} */
-    const predictions = predictionProbs.map((entry) => {
-      return {
-        totalProb: entry
-      } as CorrectionPredictionTuple
-    });
+    const predictions = predictionProbs.map((entry) => mockIntermediatePrediction(entry));
 
     const baseCost = 1;
 

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/auto-correct.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/auto-correct.tests.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { AUTOSELECT_PROPORTION_THRESHOLD, CorrectionPredictionTuple, predictionAutoSelect, SuggestionSimilarity, tupleDisplayOrderSort } from "@keymanapp/lm-worker/test-index";
+import { AUTOSELECT_PROPORTION_THRESHOLD, IntermediateCompositedPrediction, predictionAutoSelect, SuggestionSimilarity, tupleDisplayOrderSort } from "@keymanapp/lm-worker/test-index";
 /*
   * Preconditions:
   * - there should always be a 'keep' option.  Now, whether or not that option
@@ -9,7 +9,7 @@ import { AUTOSELECT_PROPORTION_THRESHOLD, CorrectionPredictionTuple, predictionA
   */
 describe('predictionAutoSelect', () => {
   it(`does not throw when no suggestions are available`, () => {
-    const predictions: CorrectionPredictionTuple[] = [];
+    const predictions: IntermediateCompositedPrediction[] = [];
     const originalPredictions = [].concat(predictions);
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
 
@@ -17,14 +17,10 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`selects solitary 'keep' suggestion that does match the model`, () => {
-    const predictions: CorrectionPredictionTuple[] = [
+    const predictions: IntermediateCompositedPrediction[] = [
       {
-        correction: {
-          sample: 'apple',
-          p: 1
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             tag: 'keep',
             transform: {  // can be null / "mocked out"
               insert: 'e',
@@ -33,9 +29,16 @@ describe('predictionAutoSelect', () => {
             matchesModel: true,
             displayAs: 'apple'
           },
-          p: 1
+          correction: 'apple',
         },
-        totalProb: 1
+        metadata: {
+          probabilities: {
+            prediction: 1,
+            correction: 1,
+            total: 1
+          },
+          autoSelectable: true
+        }
       }
     ];
 
@@ -43,19 +46,15 @@ describe('predictionAutoSelect', () => {
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
     assert.sameDeepOrderedMembers(predictions, originalPredictions);
 
-    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    const autoselected = predictions.find((entry) => entry.components.prediction.autoAccept);
     assert.isOk(autoselected);
   });
 
   it(`does not select suggestions if the root correction has no letters`, () => {
-    const predictions: CorrectionPredictionTuple[] = [
+    const predictions: IntermediateCompositedPrediction[] = [
       {
-        correction: {
-          sample: '5',
-          p: 1
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             tag: 'keep',
             transform: {
               insert: '5',
@@ -64,17 +63,20 @@ describe('predictionAutoSelect', () => {
             matchesModel: false,
             displayAs: '5'
           },
-          p: 0.01
+          correction: '5'
         },
-        totalProb: 0.01
+        metadata: {
+          probabilities: {
+            prediction: 0.01,
+            correction: 1,
+            total: 0.01
+          },
+          autoSelectable: false
+        }
       },
       {
-        correction: {
-          sample: '5',
-          p: 1
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             transform: {
               insert: '5th',
               deleteLeft: 0
@@ -82,9 +84,16 @@ describe('predictionAutoSelect', () => {
             matchesModel: true,
             displayAs: '5th'
           },
-          p: 0.8
+          correction: '5'
         },
-        totalProb: 0.8
+        metadata: {
+          probabilities: {
+            prediction: 0.8,
+            correction: 1,
+            total: 0.8
+          },
+          autoSelectable: false
+        }
       }
     ];
 
@@ -92,19 +101,15 @@ describe('predictionAutoSelect', () => {
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
     assert.sameDeepOrderedMembers(predictions, originalPredictions);
 
-    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    const autoselected = predictions.find((entry) => entry.components.prediction.autoAccept);
     assert.isNotOk(autoselected);
   });
 
   it(`does not select solitary 'keep' suggestion that doesn't match the model`, () => {
-    const predictions: CorrectionPredictionTuple[] = [
+    const predictions: IntermediateCompositedPrediction[] = [
       {
-        correction: {
-          sample: 'appl',
-          p: 1
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             tag: 'keep',
             transform: { // can be null / "mocked out"
               insert: 'l',
@@ -113,9 +118,16 @@ describe('predictionAutoSelect', () => {
             matchesModel: false,
             displayAs: '"appl"'
           },
-          p: 1
+          correction: 'appl'
         },
-        totalProb: 1
+        metadata: {
+          probabilities: {
+            prediction: 1,
+            correction: 1,
+            total: 1
+          },
+          autoSelectable: true
+        }
       }
     ];
 
@@ -123,18 +135,14 @@ describe('predictionAutoSelect', () => {
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
     assert.sameDeepOrderedMembers(predictions, originalPredictions);
 
-    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    const autoselected = predictions.find((entry) => entry.components.prediction.autoAccept);
     assert.isNotOk(autoselected);
   });
 
   it(`selects 'keep' suggestion that does match the model over any alternatives`, () => {
-    const keepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'thin',
-        p: .8
-      },
-      prediction: {
-        sample: {
+    const keepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           tag: 'keep',
           transform: {  // can be null / "mocked out"
             insert: 'n',
@@ -143,65 +151,81 @@ describe('predictionAutoSelect', () => {
           matchesModel: true,
           displayAs: 'thin'
         },
-        p: .05
+        correction: 'thin'
       },
-      totalProb: .04
+      metadata: {
+        probabilities: {
+          prediction: .05,
+          correction: .8,
+          total: .05 * .8
+        },
+        autoSelectable: true
+      }
     }
 
-    const highestNonKeepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'thin',
-        p: .8
-      },
-      prediction: {
-        sample: {
+    const highestNonKeepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {  // can be null / "mocked out"
             insert: 'nk',
             deleteLeft: 0
           },
           displayAs: 'think'
         },
-        p: .55
+        correction: 'thin'
       },
-      totalProb: .44
+      metadata: {
+        probabilities: {
+          prediction: .55,
+          correction: .8,
+          total: .55 * .8
+        },
+        autoSelectable: true
+      }
     };
 
-    const predictions: CorrectionPredictionTuple[] = [
+    const predictions: IntermediateCompositedPrediction[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       {
-        correction: {
-          sample: 'thin',
-          p: .8
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             transform: {  // can be null / "mocked out"
               insert: 'ng',
               deleteLeft: 0
             },
             displayAs: 'thing'
           },
-          p: .4
+          correction: 'thin'
         },
-        totalProb: .32
+        metadata: {
+          probabilities: {
+            prediction: .4,
+            correction: .8,
+            total: .4 * .8
+          },
+          autoSelectable: true
+        }
       },
       {
-        correction: {
-          sample: 'thic',
-          p: .2
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             transform: {  // can be null / "mocked out"
               insert: 'ck',
               deleteLeft: 0
             },
             displayAs: 'thick'
           },
-          p: 1
+          correction: 'thic'
         },
-        totalProb: .2
+        metadata: {
+          probabilities: {
+            prediction: 1,
+            correction: .2,
+            total: 1 * .2
+          },
+          autoSelectable: true
+        }
       }
     ];
 
@@ -209,18 +233,14 @@ describe('predictionAutoSelect', () => {
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
     assert.sameDeepMembers(predictions, originalPredictions);
 
-    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    const autoselected = predictions.find((entry) => entry.components.prediction.autoAccept);
     assert.equal(autoselected, keepSuggestion);
   });
 
   it(`selects solitary non-'keep' suggestion when 'keep' does not match model`, () => {
-    const keepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'thin',
-        p: .8
-      },
-      prediction: {
-        sample: {
+    const keepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           tag: 'keep',
           transform: {  // can be null / "mocked out"
             insert: 'n',
@@ -229,40 +249,50 @@ describe('predictionAutoSelect', () => {
           displayAs: '"thin"',
           matchesModel: false
         },
-        p: .05
+        correction: 'thin'
       },
-      totalProb: .04
+      metadata: {
+        probabilities: {
+          prediction: .05,
+          correction: .8,
+          total: .8 * .05
+        },
+        autoSelectable: true
+      }
     }
 
     // To 'win', a suggestion (currently) needs at least twice the probability of the sum of all alternatives.
     // This threshold may be subject to change.
     //
     // Refer to AUTOSELECT_PROPORTION_THRESHOLD in predict-helpers.ts.
-    const onlyNonKeepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'thin',
-        p: .8
-      },
-      prediction: {
-        sample: {
+    const onlyNonKeepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {  // can be null / "mocked out"
             insert: 'nk',
             deleteLeft: 0
           },
           displayAs: 'think'
         },
-        p: .01
+        correction: 'thin'
       },
-      totalProb: .008
+      metadata: {
+        probabilities: {
+          prediction: .01,
+          correction: .8,
+          total: .01 * .8
+        },
+        autoSelectable: true
+      }
     };
 
-    const predictions: CorrectionPredictionTuple[] = [
+    const predictions: IntermediateCompositedPrediction[] = [
       keepSuggestion,
       onlyNonKeepSuggestion
     ];
 
-    const totalProb = predictions.reduce((accum, current) => accum + current.totalProb, 0);
-    assert.isBelow(onlyNonKeepSuggestion.totalProb, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
+    const totalProb = predictions.reduce((accum, current) => accum + current.metadata.probabilities.total, 0);
+    assert.isBelow(onlyNonKeepSuggestion.metadata.probabilities.total, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
 
     predictions.sort(tupleDisplayOrderSort);
 
@@ -270,18 +300,14 @@ describe('predictionAutoSelect', () => {
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
     assert.sameDeepOrderedMembers(predictions, originalPredictions);
 
-    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    const autoselected = predictions.find((entry) => entry.components.prediction.autoAccept);
     assert.equal(autoselected, onlyNonKeepSuggestion);
   });
 
   it(`does not select non-'keep' without sufficient winning probability`, () => {
-    const keepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'thin',
-        p: .8
-      },
-      prediction: {
-        sample: {
+    const keepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           tag: 'keep',
           transform: {  // can be null / "mocked out"
             insert: 'n',
@@ -290,74 +316,90 @@ describe('predictionAutoSelect', () => {
           displayAs: '"thin"',
           matchesModel: false
         },
-        p: .05
+        correction: 'thin'
       },
-      totalProb: .04
+      metadata: {
+        probabilities: {
+          prediction: .05,
+          correction: .8,
+          total: .05 * .8
+        },
+        autoSelectable: true
+      }
     }
 
     // To 'win', a suggestion (currently) needs at least twice the probability of the sum of all alternatives.
     // This threshold may be subject to change.
     //
     // Refer to AUTOSELECT_PROPORTION_THRESHOLD in predict-helpers.ts.
-    const highestNonKeepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'thin',
-        p: .8
-      },
-      prediction: {
-        sample: {
+    const highestNonKeepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {  // can be null / "mocked out"
             insert: 'nk',
             deleteLeft: 0
           },
           displayAs: 'think'
         },
-        p: .55
+        correction: 'thin'
       },
-      totalProb: .44
+      metadata: {
+        probabilities: {
+          prediction: .55,
+          correction: .8,
+          total: .55 * .8
+        },
+        autoSelectable: true
+      }
     };
 
-    const predictions: CorrectionPredictionTuple[] = [
+    const predictions: IntermediateCompositedPrediction[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       {
-        correction: {
-          sample: 'thin',
-          p: .8
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             transform: {  // can be null / "mocked out"
               insert: 'ng',
               deleteLeft: 0
             },
             displayAs: 'thing'
           },
-          p: .4
+          correction: 'thin'
         },
-        totalProb: .32
+        metadata: {
+          probabilities: {
+            prediction: .4,
+            correction: .8,
+            total: .4 * .8
+          },
+          autoSelectable: true
+        }
       },
       {
-        correction: {
-          sample: 'thic',
-          p: .2
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             transform: {  // can be null / "mocked out"
               insert: 'ck',
               deleteLeft: 0
             },
             displayAs: 'thick'
           },
-          p: 1
+          correction: 'thic'
         },
-        totalProb: .2
+        metadata: {
+          probabilities: {
+            prediction: 1,
+            correction: .2,
+            total: 1 * .2
+          },
+          autoSelectable: true
+        }
       }
     ];
 
-    const totalProb = predictions.reduce((accum, current) => accum + current.totalProb, 0);
-    assert.isBelow(highestNonKeepSuggestion.totalProb, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
+    const totalProb = predictions.reduce((accum, current) => accum + current.metadata.probabilities.total, 0);
+    assert.isBelow(highestNonKeepSuggestion.metadata.probabilities.total, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
 
     predictions.sort(tupleDisplayOrderSort);
 
@@ -365,18 +407,14 @@ describe('predictionAutoSelect', () => {
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
     assert.sameDeepOrderedMembers(predictions, originalPredictions);
 
-    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    const autoselected = predictions.find((entry) => entry.components.prediction.autoAccept);
     assert.isNotOk(autoselected);
   });
 
   it(`does select non-'keep' with sufficient winning probability`, () => {
-    const keepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'thin',
-        p: .8
-      },
-      prediction: {
-        sample: {
+    const keepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           tag: 'keep',
           transform: {  // can be null / "mocked out"
             insert: 'n',
@@ -385,87 +423,99 @@ describe('predictionAutoSelect', () => {
           displayAs: '"thin"',
           matchesModel: false
         },
-        p: .05
+        correction: 'thin'
       },
-      totalProb: .04
+      metadata: {
+        probabilities: {
+          prediction: .05,
+          correction: .8,
+          total: .05 * .8
+        },
+        autoSelectable: true
+      }
     }
 
-    const highestNonKeepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'thin',
-        p: .9
-      },
-      prediction: {
-        sample: {
+    const highestNonKeepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {  // can be null / "mocked out"
             insert: 'nk',
             deleteLeft: 0
           },
           displayAs: 'think'
         },
-        p: .75
+        correction: 'thin'
       },
-      totalProb: .675
+      metadata: {
+        probabilities: {
+          prediction: .75,
+          correction: .9,
+          total: .75 * .9
+        },
+        autoSelectable: true
+      }
     };
 
-    const predictions: CorrectionPredictionTuple[] = [
+    const predictions: IntermediateCompositedPrediction[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       {
-        correction: {
-          sample: 'thin',
-          p: .9
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             transform: {  // can be null / "mocked out"
               insert: 'ng',
               deleteLeft: 0
             },
             displayAs: 'thing'
           },
-          p: .2
+          correction: 'thin'
         },
-        totalProb: .18
+        metadata: {
+          probabilities: {
+            prediction: .2,
+            correction: .9,
+            total: .2 * .9
+          },
+          autoSelectable: true
+        }
       },
       {
-        correction: {
-          sample: 'thic',
-          p: .1
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             transform: {  // can be null / "mocked out"
               insert: 'ck',
               deleteLeft: 0
             },
             displayAs: 'thick'
           },
-          p: 1
+          correction: 'thic'
         },
-        totalProb: .1
+        metadata: {
+          probabilities: {
+            prediction: 1,
+            correction: .1,
+            total: 1 * .1
+          },
+          autoSelectable: true
+        }
       }
     ];
 
-    const totalProb = predictions.reduce((accum, current) => accum + current.totalProb, 0);
-    assert.isAbove(highestNonKeepSuggestion.totalProb, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
+    const totalProb = predictions.reduce((accum, current) => accum + current.metadata.probabilities.total, 0);
+    assert.isAbove(highestNonKeepSuggestion.metadata.probabilities.total, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
 
     const originalPredictions = [].concat(predictions);
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
     assert.sameDeepMembers(predictions, originalPredictions);
 
-    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    const autoselected = predictions.find((entry) => entry.components.prediction.autoAccept);
     assert.equal(autoselected, highestNonKeepSuggestion);
   });
 
   it('ignores non key-matched suggestions when key-matched suggestions exist', () => {
-    const keepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'cant',
-        p: 1
-      },
-      prediction: {
-        sample: {
+    const keepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           tag: 'keep',
           transform: {  // can be null / "mocked out"
             insert: 't',
@@ -474,51 +524,64 @@ describe('predictionAutoSelect', () => {
           displayAs: '"cant"',
           matchesModel: false
         },
-        p: 1
+        correction: 'cant'
       },
-      totalProb: 1,
-      matchLevel: SuggestionSimilarity.exact
+      metadata: {
+        probabilities: {
+          prediction: 1,
+          correction: 1,
+          total: 1 * 1
+        },
+        autoSelectable: true,
+        matchLevel: SuggestionSimilarity.exact
+      }
     }
 
-    const expectedSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'cant',
-        p: 1
-      },
-      prediction: {
-        sample: {
+    const expectedSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {  // can be null / "mocked out"
             insert: '\'t',
             deleteLeft: 0
           },
           displayAs: "can't"
         },
-        p: .2
+        correction: 'cant'
       },
-      totalProb: .2,
-      matchLevel: SuggestionSimilarity.sameKey
+      metadata: {
+        probabilities: {
+          prediction: .2,
+          correction: 1,
+          total: .2 * 1
+        },
+        autoSelectable: true,
+        matchLevel: SuggestionSimilarity.sameKey
+      }
     };
 
-    const predictions: CorrectionPredictionTuple[] = [
+    const predictions: IntermediateCompositedPrediction[] = [
       keepSuggestion,
       expectedSuggestion,
       {
-        correction: {
-          sample: 'cant',
-          p: 1
-        },
-        prediction: {
-          sample: {
+        components: {
+          prediction: {
             transform: {  // can be null / "mocked out"
               insert: 'teen',
               deleteLeft: 0
             },
             displayAs: 'canteen'
           },
-          p: .8
+          correction: 'cant'
         },
-        totalProb: .8,
-        matchLevel: SuggestionSimilarity.none
+        metadata: {
+          probabilities: {
+            prediction: .8,
+            correction: 1,
+            total: .8 * 1
+          },
+          autoSelectable: true,
+          matchLevel: SuggestionSimilarity.none
+        }
       }
     ];
 
@@ -527,20 +590,16 @@ describe('predictionAutoSelect', () => {
 
     assert.sameDeepMembers(predictions, originalPredictions);
 
-    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    const autoselected = predictions.find((entry) => entry.components.prediction.autoAccept);
     assert.equal(autoselected, expectedSuggestion);
   });
 
   // The idea:  avoid "over-correcting" when a potential correction has a
   // super-high-frequency word.
   it('does not auto-select suggestion if its root correction is not most likely', () => {
-    const keepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'thi',
-        p: .7
-      },
-      prediction: {
-        sample: {
+    const keepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           tag: 'keep',
           transform: {  // can be null / "mocked out"
             insert: 'i',
@@ -549,61 +608,74 @@ describe('predictionAutoSelect', () => {
           displayAs: '"thi"',
           matchesModel: false
         },
-        p: .05
+        correction: 'thi'
       },
-      totalProb: .035
+      metadata: {
+        probabilities: {
+          prediction: .05,
+          correction: .7,
+          total: .05 * .7
+        },
+        autoSelectable: true
+      }
     }
 
-    const highestCorrectionSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'thi',
-        p: .7
-      },
-      prediction: {
-        sample: {
+    const highestCorrectionSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {  // can be null / "mocked out"
             insert: 'in',
             deleteLeft: 0
           },
           displayAs: 'thin'
         },
-        p: .1
+        correction: 'thi',
       },
-      totalProb: .07
+      metadata: {
+        probabilities: {
+          prediction: .1,
+          correction: .7,
+          total: .1 * .7
+        },
+        autoSelectable: true
+      }
     };
 
-    const highestNonKeepSuggestion: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'the',
-        p: .3
-      },
-      prediction: {
-        sample: {
+    const highestNonKeepSuggestion: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {  // can be null / "mocked out"
             insert: 'e',
             deleteLeft: 0
           },
           displayAs: 'the'
         },
-        p: 1
+        correction: 'the'
       },
-      totalProb: .3
+      metadata: {
+        probabilities: {
+          prediction: 1,
+          correction: .3,
+          total: 1 * .3
+        },
+        autoSelectable: true
+      }
     };
 
-    const predictions: CorrectionPredictionTuple[] = [
+    const predictions: IntermediateCompositedPrediction[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       highestCorrectionSuggestion
     ];
 
-    const totalProb = predictions.reduce((accum, current) => accum + current.totalProb, 0);
-    assert.isAbove(highestNonKeepSuggestion.totalProb, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
+    const totalProb = predictions.reduce((accum, current) => accum + current.metadata.probabilities.total, 0);
+    assert.isAbove(highestNonKeepSuggestion.metadata.probabilities.total, totalProb * AUTOSELECT_PROPORTION_THRESHOLD, 'test setup is no longer valid');
 
     const originalPredictions = [].concat(predictions);
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
     assert.sameDeepMembers(predictions, originalPredictions);
 
-    const autoselected = predictions.find((entry) => entry.prediction.sample.autoAccept);
+    const autoselected = predictions.find((entry) => entry.components.prediction.autoAccept);
     assert.isNotOk(autoselected);
   });
 

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/auto-correct.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/auto-correct.tests.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { AUTOSELECT_PROPORTION_THRESHOLD, IntermediateCompositedPrediction, predictionAutoSelect, SuggestionSimilarity, tupleDisplayOrderSort } from "@keymanapp/lm-worker/test-index";
+import { AUTOSELECT_PROPORTION_THRESHOLD, CompositedIntermediatePrediction, predictionAutoSelect, SuggestionSimilarity, tupleDisplayOrderSort } from "@keymanapp/lm-worker/test-index";
 /*
   * Preconditions:
   * - there should always be a 'keep' option.  Now, whether or not that option
@@ -9,7 +9,7 @@ import { AUTOSELECT_PROPORTION_THRESHOLD, IntermediateCompositedPrediction, pred
   */
 describe('predictionAutoSelect', () => {
   it(`does not throw when no suggestions are available`, () => {
-    const predictions: IntermediateCompositedPrediction[] = [];
+    const predictions: CompositedIntermediatePrediction[] = [];
     const originalPredictions = [].concat(predictions);
     assert.doesNotThrow(() => predictionAutoSelect(predictions));
 
@@ -17,7 +17,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`selects solitary 'keep' suggestion that does match the model`, () => {
-    const predictions: IntermediateCompositedPrediction[] = [
+    const predictions: CompositedIntermediatePrediction[] = [
       {
         components: {
           prediction: {
@@ -51,7 +51,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`does not select suggestions if the root correction has no letters`, () => {
-    const predictions: IntermediateCompositedPrediction[] = [
+    const predictions: CompositedIntermediatePrediction[] = [
       {
         components: {
           prediction: {
@@ -106,7 +106,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`does not select solitary 'keep' suggestion that doesn't match the model`, () => {
-    const predictions: IntermediateCompositedPrediction[] = [
+    const predictions: CompositedIntermediatePrediction[] = [
       {
         components: {
           prediction: {
@@ -140,7 +140,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`selects 'keep' suggestion that does match the model over any alternatives`, () => {
-    const keepSuggestion: IntermediateCompositedPrediction = {
+    const keepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           tag: 'keep',
@@ -163,7 +163,7 @@ describe('predictionAutoSelect', () => {
       }
     }
 
-    const highestNonKeepSuggestion: IntermediateCompositedPrediction = {
+    const highestNonKeepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {  // can be null / "mocked out"
@@ -184,7 +184,7 @@ describe('predictionAutoSelect', () => {
       }
     };
 
-    const predictions: IntermediateCompositedPrediction[] = [
+    const predictions: CompositedIntermediatePrediction[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       {
@@ -238,7 +238,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`selects solitary non-'keep' suggestion when 'keep' does not match model`, () => {
-    const keepSuggestion: IntermediateCompositedPrediction = {
+    const keepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           tag: 'keep',
@@ -265,7 +265,7 @@ describe('predictionAutoSelect', () => {
     // This threshold may be subject to change.
     //
     // Refer to AUTOSELECT_PROPORTION_THRESHOLD in predict-helpers.ts.
-    const onlyNonKeepSuggestion: IntermediateCompositedPrediction = {
+    const onlyNonKeepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {  // can be null / "mocked out"
@@ -286,7 +286,7 @@ describe('predictionAutoSelect', () => {
       }
     };
 
-    const predictions: IntermediateCompositedPrediction[] = [
+    const predictions: CompositedIntermediatePrediction[] = [
       keepSuggestion,
       onlyNonKeepSuggestion
     ];
@@ -305,7 +305,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`does not select non-'keep' without sufficient winning probability`, () => {
-    const keepSuggestion: IntermediateCompositedPrediction = {
+    const keepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           tag: 'keep',
@@ -332,7 +332,7 @@ describe('predictionAutoSelect', () => {
     // This threshold may be subject to change.
     //
     // Refer to AUTOSELECT_PROPORTION_THRESHOLD in predict-helpers.ts.
-    const highestNonKeepSuggestion: IntermediateCompositedPrediction = {
+    const highestNonKeepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {  // can be null / "mocked out"
@@ -353,7 +353,7 @@ describe('predictionAutoSelect', () => {
       }
     };
 
-    const predictions: IntermediateCompositedPrediction[] = [
+    const predictions: CompositedIntermediatePrediction[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       {
@@ -412,7 +412,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it(`does select non-'keep' with sufficient winning probability`, () => {
-    const keepSuggestion: IntermediateCompositedPrediction = {
+    const keepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           tag: 'keep',
@@ -435,7 +435,7 @@ describe('predictionAutoSelect', () => {
       }
     }
 
-    const highestNonKeepSuggestion: IntermediateCompositedPrediction = {
+    const highestNonKeepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {  // can be null / "mocked out"
@@ -456,7 +456,7 @@ describe('predictionAutoSelect', () => {
       }
     };
 
-    const predictions: IntermediateCompositedPrediction[] = [
+    const predictions: CompositedIntermediatePrediction[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       {
@@ -513,7 +513,7 @@ describe('predictionAutoSelect', () => {
   });
 
   it('ignores non key-matched suggestions when key-matched suggestions exist', () => {
-    const keepSuggestion: IntermediateCompositedPrediction = {
+    const keepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           tag: 'keep',
@@ -537,7 +537,7 @@ describe('predictionAutoSelect', () => {
       }
     }
 
-    const expectedSuggestion: IntermediateCompositedPrediction = {
+    const expectedSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {  // can be null / "mocked out"
@@ -559,7 +559,7 @@ describe('predictionAutoSelect', () => {
       }
     };
 
-    const predictions: IntermediateCompositedPrediction[] = [
+    const predictions: CompositedIntermediatePrediction[] = [
       keepSuggestion,
       expectedSuggestion,
       {
@@ -597,7 +597,7 @@ describe('predictionAutoSelect', () => {
   // The idea:  avoid "over-correcting" when a potential correction has a
   // super-high-frequency word.
   it('does not auto-select suggestion if its root correction is not most likely', () => {
-    const keepSuggestion: IntermediateCompositedPrediction = {
+    const keepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           tag: 'keep',
@@ -620,7 +620,7 @@ describe('predictionAutoSelect', () => {
       }
     }
 
-    const highestCorrectionSuggestion: IntermediateCompositedPrediction = {
+    const highestCorrectionSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {  // can be null / "mocked out"
@@ -641,7 +641,7 @@ describe('predictionAutoSelect', () => {
       }
     };
 
-    const highestNonKeepSuggestion: IntermediateCompositedPrediction = {
+    const highestNonKeepSuggestion: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {  // can be null / "mocked out"
@@ -662,7 +662,7 @@ describe('predictionAutoSelect', () => {
       }
     };
 
-    const predictions: IntermediateCompositedPrediction[] = [
+    const predictions: CompositedIntermediatePrediction[] = [
       keepSuggestion,
       highestNonKeepSuggestion,
       highestCorrectionSuggestion

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/create-default-keep.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/create-default-keep.tests.ts
@@ -12,7 +12,7 @@ import { assert } from 'chai';
 import { LexicalModelTypes } from "@keymanapp/common-types";
 import * as wordBreakers from '@keymanapp/models-wordbreakers';
 
-import { CorrectionPredictionTuple, createDefaultKeep, models, SuggestionSimilarity } from "@keymanapp/lm-worker/test-index";
+import { IntermediateCompositedPrediction, createDefaultKeep, models, SuggestionSimilarity } from "@keymanapp/lm-worker/test-index";
 
 import CasingFunction = LexicalModelTypes.CasingFunction;
 import Context = LexicalModelTypes.Context;
@@ -108,13 +108,9 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'iphone',
-        p: 1
-      },
-      prediction: {
-        sample: {
+    const expectedKeep: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {
             insert: 'iphone',
             deleteLeft: 5
@@ -123,10 +119,17 @@ describe('createDefaultKeep', () => {
           matchesModel: false,
           tag: 'keep'
         },
-        p: 1
+        correction: 'iphone'
       },
-      totalProb: 1,
-      matchLevel: SuggestionSimilarity.exact
+      metadata: {
+        probabilities: {
+          prediction: 1,
+          correction: 1,
+          total: 1 * 1
+        },
+        autoSelectable: false,
+        matchLevel: SuggestionSimilarity.exact
+      }
     };
 
     const tuple = createDefaultKeep(testModelWithCasing, context, trueInput);
@@ -149,13 +152,9 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'iphone',
-        p: 1
-      },
-      prediction: {
-        sample: {
+    const expectedKeep: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {
             insert: 'iphone',
             deleteLeft: 7
@@ -164,10 +163,17 @@ describe('createDefaultKeep', () => {
           matchesModel: false,
           tag: 'keep'
         },
-        p: 1
+        correction: 'iphone'
       },
-      totalProb: 1,
-      matchLevel: SuggestionSimilarity.exact
+      metadata: {
+        probabilities: {
+          prediction: 1,
+          correction: 1,
+          total: 1 * 1
+        },
+        autoSelectable: false,
+        matchLevel: SuggestionSimilarity.exact
+      }
     };
 
     const tuple = createDefaultKeep(testModelWithCasing, context, trueInput);
@@ -190,13 +196,9 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'iphone',
-        p: 1
-      },
-      prediction: {
-        sample: {
+    const expectedKeep: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {
             insert: 'iphone',
             deleteLeft: 8
@@ -205,10 +207,17 @@ describe('createDefaultKeep', () => {
           matchesModel: false,
           tag: 'keep'
         },
-        p: 1
+        correction: 'iphone'
       },
-      totalProb: 1,
-      matchLevel: SuggestionSimilarity.exact
+      metadata: {
+        probabilities: {
+          prediction: 1,
+          correction: 1,
+          total: 1 * 1
+        },
+        autoSelectable: false,
+        matchLevel: SuggestionSimilarity.exact
+      }
     };
 
     const tuple = createDefaultKeep(testModelWithCasing, context, trueInput);
@@ -231,13 +240,9 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'and',
-        p: 1
-      },
-      prediction: {
-        sample: {
+    const expectedKeep: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {
             insert: 'iphones and',
             deleteLeft: 5
@@ -246,10 +251,17 @@ describe('createDefaultKeep', () => {
           matchesModel: false,
           tag: 'keep'
         },
-        p: 1
+        correction: 'and'
       },
-      totalProb: 1,
-      matchLevel: SuggestionSimilarity.exact
+      metadata: {
+        probabilities: {
+          prediction: 1,
+          correction: 1,
+          total: 1 * 1
+        },
+        autoSelectable: false,
+        matchLevel: SuggestionSimilarity.exact
+      }
     };
 
     const tuple = createDefaultKeep(testModelWithCasing, context, trueInput);
@@ -272,13 +284,9 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: CorrectionPredictionTuple = {
-      correction: {
-        sample: 'iphones',
-        p: 1
-      },
-      prediction: {
-        sample: {
+    const expectedKeep: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {
             insert: 'iphones',
             deleteLeft: 7
@@ -287,10 +295,17 @@ describe('createDefaultKeep', () => {
           matchesModel: false,
           tag: 'keep'
         },
-        p: 1
+        correction: 'iphones'
       },
-      totalProb: 1,
-      matchLevel: SuggestionSimilarity.exact
+      metadata: {
+        probabilities: {
+          prediction: 1,
+          correction: 1,
+          total: 1 * 1
+        },
+        autoSelectable: false,
+        matchLevel: SuggestionSimilarity.exact
+      }
     };
 
     const tuple = createDefaultKeep(testModelWithCasing, context, trueInput);
@@ -313,13 +328,9 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: CorrectionPredictionTuple = {
-      correction: {
-        sample: '',
-        p: 1
-      },
-      prediction: {
-        sample: {
+    const expectedKeep: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: {
             insert: 'iphone ',
             deleteLeft: 5
@@ -328,10 +339,17 @@ describe('createDefaultKeep', () => {
           matchesModel: false,
           tag: 'keep'
         },
-        p: 1
+        correction: ''
       },
-      totalProb: 1,
-      matchLevel: SuggestionSimilarity.exact
+      metadata: {
+        probabilities: {
+          prediction: 1,
+          correction: 1,
+          total: 1 * 1
+        },
+        autoSelectable: false,
+        matchLevel: SuggestionSimilarity.exact
+      }
     };
 
     const tuple = createDefaultKeep(testModelWithCasing, context, trueInput);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/create-default-keep.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/create-default-keep.tests.ts
@@ -12,7 +12,7 @@ import { assert } from 'chai';
 import { LexicalModelTypes } from "@keymanapp/common-types";
 import * as wordBreakers from '@keymanapp/models-wordbreakers';
 
-import { IntermediateCompositedPrediction, createDefaultKeep, models, SuggestionSimilarity } from "@keymanapp/lm-worker/test-index";
+import { CompositedIntermediatePrediction, createDefaultKeep, models, SuggestionSimilarity } from "@keymanapp/lm-worker/test-index";
 
 import CasingFunction = LexicalModelTypes.CasingFunction;
 import Context = LexicalModelTypes.Context;
@@ -108,7 +108,7 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: IntermediateCompositedPrediction = {
+    const expectedKeep: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {
@@ -152,7 +152,7 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: IntermediateCompositedPrediction = {
+    const expectedKeep: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {
@@ -196,7 +196,7 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: IntermediateCompositedPrediction = {
+    const expectedKeep: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {
@@ -240,7 +240,7 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: IntermediateCompositedPrediction = {
+    const expectedKeep: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {
@@ -284,7 +284,7 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: IntermediateCompositedPrediction = {
+    const expectedKeep: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {
@@ -328,7 +328,7 @@ describe('createDefaultKeep', () => {
       p: 1
     };
 
-    const expectedKeep: IntermediateCompositedPrediction = {
+    const expectedKeep: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: {

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-tokenized-correction-sequence.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-tokenized-correction-sequence.tests.ts
@@ -21,7 +21,7 @@ import {
   ContextState,
   ContextToken,
   ContextTokenization,
-  IntermediateCompositedPrediction,
+  CompositedIntermediatePrediction,
   ModelCompositor,
   TokenizationResultMapping
 } from "@keymanapp/lm-worker/test-index";
@@ -341,7 +341,7 @@ describe('determineTokenizedCorrectionSequence', () => {
     });
     assert.approximately(results.tokenizedCorrection[0].p, Math.pow(trueInput.p, ModelCompositor.SINGLE_CHAR_KEY_PROB_EXPONENT), Number.EPSILON*1000);
 
-    const dummiedTuple: IntermediateCompositedPrediction = {
+    const dummiedTuple: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: { insert: 'dog', deleteLeft: 0 },

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-tokenized-correction-sequence.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-tokenized-correction-sequence.tests.ts
@@ -21,7 +21,7 @@ import {
   ContextState,
   ContextToken,
   ContextTokenization,
-  CorrectionPredictionTuple,
+  IntermediateCompositedPrediction,
   ModelCompositor,
   TokenizationResultMapping
 } from "@keymanapp/lm-worker/test-index";
@@ -341,24 +341,27 @@ describe('determineTokenizedCorrectionSequence', () => {
     });
     assert.approximately(results.tokenizedCorrection[0].p, Math.pow(trueInput.p, ModelCompositor.SINGLE_CHAR_KEY_PROB_EXPONENT), Number.EPSILON*1000);
 
-    const dummiedTuple: CorrectionPredictionTuple = {
-      prediction: {
-        sample: {
+    const dummiedTuple: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: { insert: 'dog', deleteLeft: 0 },
           displayAs: 'dog'
         },
-        p: .25
+        correction: 'd'
       },
-      correction: {
-        sample: 'd',
-        p: trueInput.p
-      },
-      totalProb: .25 * trueInput.p
+      metadata: {
+        probabilities: {
+          prediction: .25,
+          correction: trueInput.p,
+          total: .25 * trueInput.p
+        },
+        autoSelectable: true
+      }
     };
 
     results.applyInPost(dummiedTuple);
 
-    assert.deepEqual(dummiedTuple.preservationTransform, {
+    assert.deepEqual(dummiedTuple.metadata.preservationTransform, {
       insert: trueInput.sample.insert.substring(0, KMWString.length(trueInput.sample.insert) - 1), // remove the 'd'.
       deleteLeft: trueInput.sample.deleteLeft - 1
     });

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-traversalless-correction-sequences.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-traversalless-correction-sequences.tests.ts
@@ -13,7 +13,7 @@ import { LexicalModelTypes } from "@keymanapp/common-types";
 import * as wordBreakers from '@keymanapp/models-wordbreakers';
 import { KMWString } from 'keyman/common/web-utils';
 
-import { IntermediateCompositedPrediction, ModelCompositor, determineTraversallessCorrectionSequences, models } from "@keymanapp/lm-worker/test-index";
+import { CompositedIntermediatePrediction, ModelCompositor, determineTraversallessCorrectionSequences, models } from "@keymanapp/lm-worker/test-index";
 
 import Context = LexicalModelTypes.Context;
 import DummyModel = models.DummyModel;
@@ -377,7 +377,7 @@ describe('determineTraversallessCorrectionSequences', () => {
     });
     assert.approximately(entry.tokenizedCorrection[0].p, Math.pow(trueInput.p, ModelCompositor.SINGLE_CHAR_KEY_PROB_EXPONENT), Number.EPSILON*1000);
 
-    const dummiedTuple: IntermediateCompositedPrediction = {
+    const dummiedTuple: CompositedIntermediatePrediction = {
       components: {
         prediction: {
           transform: { insert: 'dog', deleteLeft: 0 },

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-traversalless-correction-sequences.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-traversalless-correction-sequences.tests.ts
@@ -13,7 +13,7 @@ import { LexicalModelTypes } from "@keymanapp/common-types";
 import * as wordBreakers from '@keymanapp/models-wordbreakers';
 import { KMWString } from 'keyman/common/web-utils';
 
-import { CorrectionPredictionTuple, ModelCompositor, determineTraversallessCorrectionSequences, models } from "@keymanapp/lm-worker/test-index";
+import { IntermediateCompositedPrediction, ModelCompositor, determineTraversallessCorrectionSequences, models } from "@keymanapp/lm-worker/test-index";
 
 import Context = LexicalModelTypes.Context;
 import DummyModel = models.DummyModel;
@@ -377,24 +377,27 @@ describe('determineTraversallessCorrectionSequences', () => {
     });
     assert.approximately(entry.tokenizedCorrection[0].p, Math.pow(trueInput.p, ModelCompositor.SINGLE_CHAR_KEY_PROB_EXPONENT), Number.EPSILON*1000);
 
-    const dummiedTuple: CorrectionPredictionTuple = {
-      prediction: {
-        sample: {
+    const dummiedTuple: IntermediateCompositedPrediction = {
+      components: {
+        prediction: {
           transform: { insert: 'dog', deleteLeft: 0 },
           displayAs: 'dog'
         },
-        p: .25
+        correction: 'd'
       },
-      correction: {
-        sample: 'd',
-        p: trueInput.p
-      },
-      totalProb: .25 * trueInput.p
+      metadata: {
+        probabilities: {
+          prediction: .25,
+          correction: trueInput.p,
+          total: .25 * trueInput.p
+        },
+        autoSelectable: true
+      }
     };
 
     entry.applyInPost(dummiedTuple);
 
-    assert.deepEqual(dummiedTuple.preservationTransform, {
+    assert.deepEqual(dummiedTuple.metadata.preservationTransform, {
       insert: trueInput.sample.insert.substring(0, KMWString.length(trueInput.sample.insert) - 1), // remove the 'd'.
       deleteLeft: trueInput.sample.deleteLeft - 1
     });

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/predict-from-correction-sequence.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/predict-from-correction-sequence.tests.ts
@@ -116,19 +116,19 @@ describe('predictFromCorrectionSequence', () => {
 
       const transitionID = 12345;
       const predictions = predictFromCorrectionSequence(model, correctionDistribution, context, transitionID);
-      predictions.forEach((entry) => assert.equal(entry.correction.sample, 'Its'));
-      predictions.forEach((entry) => assert.equal(entry.correction.p, 0.6));
+      predictions.forEach((entry) => assert.equal(entry.components.correction, 'Its'));
+      predictions.forEach((entry) => assert.equal(entry.metadata.probabilities.correction, 0.6));
       predictions.sort(tupleDisplayOrderSort);
 
-      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.prediction.sample), dummied_suggestions.map((s) => {
+      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.components.prediction), dummied_suggestions.map((s) => {
         delete s.p;
         s.transformId = transitionID;
         s.transform.id = transitionID;
         return s;
       }));
 
-      assert.approximately(predictions[0].totalProb, 0.18 * 0.6, 0.00001);
-      assert.approximately(predictions[1].totalProb, 0.02 * 0.6, 0.00001);
+      assert.approximately(predictions[0].metadata.probabilities.total, 0.18 * 0.6, 0.00001);
+      assert.approximately(predictions[1].metadata.probabilities.total, 0.02 * 0.6, 0.00001);
     });
 
     it('constructs suggestions matching multiple lexical entries directly - with transform ID', () => {
@@ -174,12 +174,12 @@ describe('predictFromCorrectionSequence', () => {
       });
 
       const predictions = predictFromCorrectionSequence(model, correctionDistribution, context, transitionID);
-      predictions.forEach((entry) => assert.equal(entry.correction.sample, 'Its'));
-      predictions.forEach((entry) => assert.equal(entry.correction.p, 0.6));
+      predictions.forEach((entry) => assert.equal(entry.components.correction, 'Its'));
+      predictions.forEach((entry) => assert.equal(entry.metadata.probabilities.correction, 0.6));
       predictions.sort(tupleDisplayOrderSort);
 
-      assert.sameOrderedMembers(predictions.map((entry) => entry.prediction.sample.displayAs), ["it's", "its"]);
-      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.prediction.sample), dummied_suggestions.map((entry) => {
+      assert.sameOrderedMembers(predictions.map((entry) => entry.components.prediction.displayAs), ["it's", "its"]);
+      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.components.prediction), dummied_suggestions.map((entry) => {
         entry = deepCopy(entry);
         entry.transformId = transitionID;
         entry.transform.id = transitionID;
@@ -187,9 +187,9 @@ describe('predictFromCorrectionSequence', () => {
         return entry;
       }));
 
-      assert.approximately(predictions[0].totalProb, 0.18 * 0.6, 0.00001);
-      assert.approximately(predictions[1].totalProb, 0.02 * 0.6, 0.00001);
-      predictions.forEach((prediction) => assert.equal(prediction.prediction.sample.transformId, transitionID));
+      assert.approximately(predictions[0].metadata.probabilities.total, 0.18 * 0.6, 0.00001);
+      assert.approximately(predictions[1].metadata.probabilities.total, 0.02 * 0.6, 0.00001);
+      predictions.forEach((prediction) => assert.equal(prediction.components.prediction.transformId, transitionID));
     });
 
     it('constructs suggestions without input (as if after a context reset)', () => {
@@ -227,11 +227,11 @@ describe('predictFromCorrectionSequence', () => {
 
       const transitionID = 12345;
       const predictions = predictFromCorrectionSequence(model, correctionDistribution, context, transitionID);
-      predictions.forEach((entry) => assert.equal(entry.correction.sample, 'appl'));
-      predictions.forEach((entry) => assert.equal(entry.correction.p, 1));
+      predictions.forEach((entry) => assert.equal(entry.components.correction, 'appl'));
+      predictions.forEach((entry) => assert.equal(entry.metadata.probabilities.correction, 1));
       predictions.sort(tupleDisplayOrderSort);
 
-      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.prediction.sample), dummied_suggestions.map((s) => {
+      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.components.prediction), dummied_suggestions.map((s) => {
         delete s.p;
         s.transformId = transitionID;
         s.transform.id = transitionID;
@@ -318,15 +318,15 @@ describe('predictFromCorrectionSequence', () => {
       });
 
       const predictions = predictFromCorrectionSequence(model, correctionSequence, context, transitionID);
-      predictions.forEach((entry) => assert.equal(entry.correction.sample, 'golden app'));
-      predictions.forEach((entry) => assert.equal(entry.correction.p, correctionSequence.reduce((accum, curr) => accum * curr.p, 1)));
+      predictions.forEach((entry) => assert.equal(entry.components.correction, 'golden app'));
+      predictions.forEach((entry) => assert.equal(entry.metadata.probabilities.correction, correctionSequence.reduce((accum, curr) => accum * curr.p, 1)));
       predictions.sort(tupleDisplayOrderSort);
 
-      assert.equal(predictions[0].prediction.sample.transform.insert, 'golden apple');
-      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.prediction.sample), [expected_prediction.sample]);
+      assert.equal(predictions[0].components.prediction.transform.insert, 'golden apple');
+      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.components.prediction), [expected_prediction.sample]);
 
-      assert.approximately(predictions[0].prediction.p, expected_prediction.p, 0.00001);
-      assert.equal(predictions[0].prediction.sample.transformId, transitionID);
+      assert.approximately(predictions[0].metadata.probabilities.prediction, expected_prediction.p, 0.00001);
+      assert.equal(predictions[0].components.prediction.transformId, transitionID);
     });
 
     it('returns no results if all correction tokens lack predictions', () => {
@@ -468,15 +468,15 @@ describe('predictFromCorrectionSequence', () => {
       // There should be no variations with 'green' or 'gray' apples.
       assert.equal(predictions.length, 1);
 
-      predictions.forEach((entry) => assert.equal(entry.correction.sample, 'g app'));
-      predictions.forEach((entry) => assert.equal(entry.correction.p, correctionSequence.reduce((accum, curr) => accum * curr.p, 1)));
+      predictions.forEach((entry) => assert.equal(entry.components.correction, 'g app'));
+      predictions.forEach((entry) => assert.equal(entry.metadata.probabilities.correction, correctionSequence.reduce((accum, curr) => accum * curr.p, 1)));
       predictions.sort(tupleDisplayOrderSort);
 
-      assert.equal(predictions[0].prediction.sample.transform.insert, 'golden apple');
-      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.prediction.sample), [expected_prediction.sample]);
+      assert.equal(predictions[0].components.prediction.transform.insert, 'golden apple');
+      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.components.prediction), [expected_prediction.sample]);
 
-      assert.approximately(predictions[0].prediction.p, expected_prediction.p, 0.00001);
-      assert.equal(predictions[0].prediction.sample.transformId, transitionID);
+      assert.approximately(predictions[0].metadata.probabilities.prediction, expected_prediction.p, 0.00001);
+      assert.equal(predictions[0].components.prediction.transformId, transitionID);
     });
 
     it('uses all suggestions generated from context-final correction-tokens', () => {
@@ -582,19 +582,19 @@ describe('predictFromCorrectionSequence', () => {
       const predictions = predictFromCorrectionSequence(model, correctionSequence, context, transitionID);
       assert.equal(predictions.length, dummied_suggestion_sequences[dummied_suggestion_sequences.length - 1].length);
 
-      predictions.forEach((entry) => assert.equal(entry.correction.sample, 'golden app'));
-      predictions.forEach((entry) => assert.equal(entry.correction.p, correctionSequence.reduce((accum, curr) => accum * curr.p, 1)));
+      predictions.forEach((entry) => assert.equal(entry.components.correction, 'golden app'));
+      predictions.forEach((entry) => assert.equal(entry.metadata.probabilities.correction, correctionSequence.reduce((accum, curr) => accum * curr.p, 1)));
       predictions.sort(tupleDisplayOrderSort);
 
       assert.sameOrderedMembers(
-        predictions.map((t) => t.prediction.sample.transform.insert),
+        predictions.map((t) => t.components.prediction.transform.insert),
         ['golden apple', 'golden application', 'golden appetizer']
       );
-      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.prediction.sample), expected_predictions.map((p => p.sample)));
+      assert.sameDeepOrderedMembers(predictions.map((entry) => entry.components.prediction), expected_predictions.map((p => p.sample)));
 
       for(let i = 0; i < predictions.length; i++) {
-        assert.approximately(predictions[i].prediction.p, expected_predictions[i].p, 0.00001, `Expected probabilty mismatch at index ${i}`);
-        assert.equal(predictions[i].prediction.sample.transformId, transitionID);
+        assert.approximately(predictions[i].metadata.probabilities.prediction, expected_predictions[i].p, 0.00001, `Expected probabilty mismatch at index ${i}`);
+        assert.equal(predictions[i].components.prediction.transformId, transitionID);
       }
     });
   });

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-deduplication.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-deduplication.tests.ts
@@ -4,7 +4,7 @@ import * as wordBreakers from '@keymanapp/models-wordbreakers';
 import { deepCopy } from 'keyman/common/web-utils';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 
-import { IntermediateCompositedPrediction, dedupeSuggestions, models } from "@keymanapp/lm-worker/test-index";
+import { CompositedIntermediatePrediction, dedupeSuggestions, models } from "@keymanapp/lm-worker/test-index";
 
 import Context = LexicalModelTypes.Context;
 import DummyModel = models.DummyModel;
@@ -24,7 +24,7 @@ const testModel = new DummyModel({
  * @returns
  */
 const build_its_is_set = () => {
-  const its: IntermediateCompositedPrediction = {
+  const its: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {
@@ -46,7 +46,7 @@ const build_its_is_set = () => {
     }
   };
 
-  const it_is: IntermediateCompositedPrediction = {
+  const it_is: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {
@@ -67,7 +67,7 @@ const build_its_is_set = () => {
     }
   };
 
-  const is: IntermediateCompositedPrediction = {
+  const is: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {
@@ -88,7 +88,7 @@ const build_its_is_set = () => {
     }
   };
 
-  const is_not: IntermediateCompositedPrediction = {
+  const is_not: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-deduplication.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-deduplication.tests.ts
@@ -4,7 +4,7 @@ import * as wordBreakers from '@keymanapp/models-wordbreakers';
 import { deepCopy } from 'keyman/common/web-utils';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 
-import { CorrectionPredictionTuple, dedupeSuggestions, models } from "@keymanapp/lm-worker/test-index";
+import { IntermediateCompositedPrediction, dedupeSuggestions, models } from "@keymanapp/lm-worker/test-index";
 
 import Context = LexicalModelTypes.Context;
 import DummyModel = models.DummyModel;
@@ -24,77 +24,89 @@ const testModel = new DummyModel({
  * @returns
  */
 const build_its_is_set = () => {
-  const its: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'its',
-      p: 0.8
-    },
-    prediction: {
-      sample: {
+  const its: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: 's',
           deleteLeft: 0
         },
         displayAs: 'its'
       },
-      p: 0.2
+      correction: 'its'
     },
-    totalProb: 0.16
-    // matchLevel does not yet exist.
+    metadata: {
+      probabilities: {
+        prediction: .2,
+        correction: .8,
+        total: .2 * .8
+      },
+      autoSelectable: true
+      // matchLevel does not yet exist.
+    }
   };
 
-  const it_is: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'its',
-      p: 0.8
-    },
-    prediction: {
-      sample: {
+  const it_is: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: '\'s',
           deleteLeft: 0
         },
         displayAs: 'it\'s'
       },
-      p: 0.8
+      correction: 'its'
     },
-    totalProb: 0.64
+    metadata: {
+      probabilities: {
+        prediction: .8,
+        correction: .8,
+        total: .8 * .8
+      },
+      autoSelectable: true
+    }
   };
 
-  const is: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'is',
-      p: 0.2
-    },
-    prediction: {
-      sample: {
+  const is: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: 's',
           deleteLeft: 1
         },
         displayAs: 'is'
       },
-      p: 0.5
+      correction: 'is'
     },
-    totalProb: 0.1
+    metadata: {
+      probabilities: {
+        prediction: .5,
+        correction: .2,
+        total: .5 * .2
+      },
+      autoSelectable: true
+    }
   };
 
-  const is_not: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'is',
-      p: 0.2
-    },
-    prediction: {
-      sample: {
+  const is_not: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: 'sn\'t',
           deleteLeft: 1
         },
         displayAs: 'isn\'t'
       },
-      p: 0.5
+      correction: 'is'
     },
-    totalProb: 0.1
+    metadata: {
+      probabilities: {
+        prediction: .5,
+        correction: .2,
+        total: .5 * .2
+      },
+      autoSelectable: true
+    }
   };
 
   return {
@@ -145,7 +157,7 @@ describe('dedupeSuggestions', () => {
     // There's no mathematically safe way to combine the components if the
     // underlying correction sources differ between duplicated suggestions,
     // though it's mathematically safe to combine their product.
-    expected.forEach((entry) => entry.totalProb *= (entry.prediction.sample.transform.insert == '\'s') ? 3 : 2);
+    expected.forEach((entry) => entry.metadata.probabilities.total *= (entry.components.prediction.transform.insert == '\'s') ? 3 : 2);
 
     assert.deepEqual(deduplicated, expected);
   });

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-finalization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-finalization.tests.ts
@@ -5,7 +5,7 @@ import { deepCopy } from 'keyman/common/web-utils';
 import * as wordBreakers from '@keymanapp/models-wordbreakers';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 
-import { CorrectionPredictionTuple, finalizeSuggestions, models } from "@keymanapp/lm-worker/test-index";
+import { IntermediateCompositedPrediction, finalizeSuggestions, models } from "@keymanapp/lm-worker/test-index";
 
 import DummyModel = models.DummyModel;
 import Outcome = LexicalModelTypes.Outcome;
@@ -39,6 +39,7 @@ const testModelWithoutSpacing = new DummyModel({
   }
 });
 
+
 /**
  * Builds a fresh copy of test values useful for suggestion-similarity
  * testing.
@@ -47,78 +48,89 @@ const testModelWithoutSpacing = new DummyModel({
  */
 const build_its_is_set = (verbose?: string) => {
   const verboseFlag = (verbose == 'verbose' ? true : false);
-
-  const its: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'its',
-      p: 0.8
-    },
-    prediction: {
-      sample: {
+  const its: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: 's',
           deleteLeft: 0
         },
         displayAs: 'its'
       },
-      p: 0.2
+      correction: 'its'
     },
-    totalProb: 0.16
-    // matchLevel does not yet exist.
+    metadata: {
+      probabilities: {
+        prediction: .2,
+        correction: .8,
+        total: .2 * .8
+      },
+      autoSelectable: true
+      // matchLevel does not yet exist.
+    }
   };
 
-  const it_is: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'its',
-      p: 0.8
-    },
-    prediction: {
-      sample: {
+  const it_is: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: '\'s',
           deleteLeft: 0
         },
         displayAs: 'it\'s'
       },
-      p: 0.8
+      correction: 'its'
     },
-    totalProb: 0.64
+    metadata: {
+      probabilities: {
+        prediction: .8,
+        correction: .8,
+        total: .8 * .8
+      },
+      autoSelectable: true
+    }
   };
 
-  const is: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'is',
-      p: 0.2
-    },
-    prediction: {
-      sample: {
+  const is: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: 's',
           deleteLeft: 1
         },
         displayAs: 'is'
       },
-      p: 0.5
+      correction: 'is'
     },
-    totalProb: 0.1
+    metadata: {
+      probabilities: {
+        prediction: .5,
+        correction: .2,
+        total: .5 * .2
+      },
+      autoSelectable: true
+    }
   };
 
-  const is_not: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'is',
-      p: 0.2
-    },
-    prediction: {
-      sample: {
+  const is_not: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: 'sn\'t',
           deleteLeft: 1
         },
         displayAs: 'isn\'t'
       },
-      p: 0.5
+      correction: 'is'
     },
-    totalProb: 0.1
+    metadata: {
+      probabilities: {
+        prediction: .5,
+        correction: .2,
+        total: .5 * .2
+      },
+      autoSelectable: true
+    }
   };
 
   const baseDefinitions = {
@@ -132,13 +144,13 @@ const build_its_is_set = (verbose?: string) => {
   const expected = unfinalized.map((entry) => {
 
     const mapped: Outcome<Suggestion & { 'correction-p'?: number, 'lexical-p'?: number }> = {
-      ...deepCopy(entry.prediction.sample),
-      p: entry.totalProb
+      ...deepCopy(entry.components.prediction),
+      p: entry.metadata.probabilities.total
     };
 
     if(verboseFlag) {
-      mapped['correction-p'] = entry.correction.p;
-      mapped['lexical-p'] = entry.prediction.p;
+      mapped['correction-p'] = entry.metadata.probabilities.correction;
+      mapped['lexical-p'] = entry.metadata.probabilities.prediction;
     }
 
     return mapped;

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-finalization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-finalization.tests.ts
@@ -5,7 +5,7 @@ import { deepCopy } from 'keyman/common/web-utils';
 import * as wordBreakers from '@keymanapp/models-wordbreakers';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 
-import { IntermediateCompositedPrediction, finalizeSuggestions, models } from "@keymanapp/lm-worker/test-index";
+import { CompositedIntermediatePrediction, finalizeSuggestions, models } from "@keymanapp/lm-worker/test-index";
 
 import DummyModel = models.DummyModel;
 import Outcome = LexicalModelTypes.Outcome;
@@ -48,7 +48,7 @@ const testModelWithoutSpacing = new DummyModel({
  */
 const build_its_is_set = (verbose?: string) => {
   const verboseFlag = (verbose == 'verbose' ? true : false);
-  const its: IntermediateCompositedPrediction = {
+  const its: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {
@@ -70,7 +70,7 @@ const build_its_is_set = (verbose?: string) => {
     }
   };
 
-  const it_is: IntermediateCompositedPrediction = {
+  const it_is: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {
@@ -91,7 +91,7 @@ const build_its_is_set = (verbose?: string) => {
     }
   };
 
-  const is: IntermediateCompositedPrediction = {
+  const is: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {
@@ -112,7 +112,7 @@ const build_its_is_set = (verbose?: string) => {
     }
   };
 
-  const is_not: IntermediateCompositedPrediction = {
+  const is_not: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-similarity.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-similarity.tests.ts
@@ -5,7 +5,7 @@ import * as wordBreakers from '@keymanapp/models-wordbreakers';
 import { deepCopy } from 'keyman/common/web-utils';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 
-import { IntermediateCompositedPrediction, models, processSimilarity, SuggestionSimilarity, toAnnotatedSuggestion } from "@keymanapp/lm-worker/test-index";
+import { CompositedIntermediatePrediction, models, processSimilarity, SuggestionSimilarity, toAnnotatedSuggestion } from "@keymanapp/lm-worker/test-index";
 
 import CasingFunction = LexicalModelTypes.CasingFunction;
 import Context = LexicalModelTypes.Context;
@@ -109,7 +109,7 @@ const testModelWithCasing = new DummyModel({
  * @returns
  */
 const build_its_is_set = () => {
-  const its: IntermediateCompositedPrediction = {
+  const its: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {
@@ -131,7 +131,7 @@ const build_its_is_set = () => {
     }
   };
 
-  const it_is: IntermediateCompositedPrediction = {
+  const it_is: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {
@@ -152,7 +152,7 @@ const build_its_is_set = () => {
     }
   };
 
-  const is: IntermediateCompositedPrediction = {
+  const is: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {
@@ -173,7 +173,7 @@ const build_its_is_set = () => {
     }
   };
 
-  const is_not: IntermediateCompositedPrediction = {
+  const is_not: CompositedIntermediatePrediction = {
     components: {
       prediction: {
         transform: {
@@ -222,7 +222,7 @@ describe('processSimilarity', () => {
     const testSet = build_its_is_set();
     const distribution = [...Object.values(testSet)];
 
-    const expectation: IntermediateCompositedPrediction[] = [...Object.values(testSet)];
+    const expectation: CompositedIntermediatePrediction[] = [...Object.values(testSet)];
     expectation[0].metadata.matchLevel = SuggestionSimilarity.exact;    // its
     expectation[1].metadata.matchLevel = SuggestionSimilarity.sameKey;  // it_is
     expectation[2].metadata.matchLevel = SuggestionSimilarity.none;     // is
@@ -259,7 +259,7 @@ describe('processSimilarity', () => {
     const testSet = build_its_is_set();
     const distribution = [...Object.values(testSet)];
 
-    const expectation: IntermediateCompositedPrediction[] = [...Object.values(testSet)];
+    const expectation: CompositedIntermediatePrediction[] = [...Object.values(testSet)];
     expectation[0].metadata.matchLevel = SuggestionSimilarity.sameKey;  // its
     expectation[1].metadata.matchLevel = SuggestionSimilarity.exact;    // it_is
     expectation[2].metadata.matchLevel = SuggestionSimilarity.none;     // is
@@ -313,7 +313,7 @@ describe('processSimilarity', () => {
 
       const distribution = [...Object.values(testSet)];
 
-      const expectation: IntermediateCompositedPrediction[] = [...Object.values(testSet)];
+      const expectation: CompositedIntermediatePrediction[] = [...Object.values(testSet)];
       expectation[0].metadata.matchLevel = SuggestionSimilarity.sameKey;   // its
       expectation[1].metadata.matchLevel = SuggestionSimilarity.sameText;  // it_is
       expectation[2].metadata.matchLevel = SuggestionSimilarity.none;      // is
@@ -355,7 +355,7 @@ describe('processSimilarity', () => {
 
       const distribution = [...Object.values(testSet)];
 
-      const expectation: IntermediateCompositedPrediction[] = [...Object.values(testSet)];
+      const expectation: CompositedIntermediatePrediction[] = [...Object.values(testSet)];
 
       expectation.forEach((entry) => entry.metadata.matchLevel = SuggestionSimilarity.none);
       processSimilarity(testModelWithoutCasing, distribution, context, trueInput);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-similarity.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-similarity.tests.ts
@@ -5,7 +5,7 @@ import * as wordBreakers from '@keymanapp/models-wordbreakers';
 import { deepCopy } from 'keyman/common/web-utils';
 import { LexicalModelTypes } from '@keymanapp/common-types';
 
-import { CorrectionPredictionTuple, models, processSimilarity, SuggestionSimilarity, toAnnotatedSuggestion } from "@keymanapp/lm-worker/test-index";
+import { IntermediateCompositedPrediction, models, processSimilarity, SuggestionSimilarity, toAnnotatedSuggestion } from "@keymanapp/lm-worker/test-index";
 
 import CasingFunction = LexicalModelTypes.CasingFunction;
 import Context = LexicalModelTypes.Context;
@@ -109,77 +109,89 @@ const testModelWithCasing = new DummyModel({
  * @returns
  */
 const build_its_is_set = () => {
-  const its: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'its',
-      p: 0.8
-    },
-    prediction: {
-      sample: {
+  const its: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: 's',
           deleteLeft: 0
         },
         displayAs: 'its'
       },
-      p: 0.2
+      correction: 'its'
     },
-    totalProb: 0.16
-    // matchLevel does not yet exist.
+    metadata: {
+      probabilities: {
+        prediction: .2,
+        correction: .8,
+        total: .2 * .8
+      },
+      autoSelectable: true
+      // matchLevel does not yet exist.
+    }
   };
 
-  const it_is: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'its',
-      p: 0.8
-    },
-    prediction: {
-      sample: {
+  const it_is: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: '\'s',
           deleteLeft: 0
         },
         displayAs: 'it\'s'
       },
-      p: 0.8
+      correction: 'its'
     },
-    totalProb: 0.64
+    metadata: {
+      probabilities: {
+        prediction: .8,
+        correction: .8,
+        total: .8 * .8
+      },
+      autoSelectable: true
+    }
   };
 
-  const is: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'is',
-      p: 0.2
-    },
-    prediction: {
-      sample: {
+  const is: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: 's',
           deleteLeft: 1
         },
         displayAs: 'is'
       },
-      p: 0.5
+      correction: 'is'
     },
-    totalProb: 0.1
+    metadata: {
+      probabilities: {
+        prediction: .5,
+        correction: .2,
+        total: .5 * .2
+      },
+      autoSelectable: true
+    }
   };
 
-  const is_not: CorrectionPredictionTuple = {
-    correction: {
-      sample: 'is',
-      p: 0.2
-    },
-    prediction: {
-      sample: {
+  const is_not: IntermediateCompositedPrediction = {
+    components: {
+      prediction: {
         transform: {
           insert: 'sn\'t',
           deleteLeft: 1
         },
         displayAs: 'isn\'t'
       },
-      p: 0.5
+      correction: 'is'
     },
-    totalProb: 0.1
+    metadata: {
+      probabilities: {
+        prediction: .5,
+        correction: .2,
+        total: .5 * .2
+      },
+      autoSelectable: true
+    }
   };
 
   return {
@@ -210,32 +222,22 @@ describe('processSimilarity', () => {
     const testSet = build_its_is_set();
     const distribution = [...Object.values(testSet)];
 
-    const expectation: CorrectionPredictionTuple[] = [
-      {
-        ...testSet.its,
-        matchLevel: SuggestionSimilarity.exact
-      }, {
-        ...testSet.it_is,
-        matchLevel: SuggestionSimilarity.sameKey
-      }, {
-        ...testSet.is,
-        matchLevel: SuggestionSimilarity.none
-      }, {
-        ...testSet.is_not,
-        matchLevel: SuggestionSimilarity.none
-      }
-    ];
+    const expectation: IntermediateCompositedPrediction[] = [...Object.values(testSet)];
+    expectation[0].metadata.matchLevel = SuggestionSimilarity.exact;    // its
+    expectation[1].metadata.matchLevel = SuggestionSimilarity.sameKey;  // it_is
+    expectation[2].metadata.matchLevel = SuggestionSimilarity.none;     // is
+    expectation[3].metadata.matchLevel = SuggestionSimilarity.none;     // is_not
 
     const its = testSet.its;
     const original_its = deepCopy(its);
-    const keep_its = toAnnotatedSuggestion(testModelWithCasing, original_its.prediction.sample, 'keep', QuoteBehavior.noQuotes);
+    const keep_its = toAnnotatedSuggestion(testModelWithCasing, original_its.components.prediction, 'keep', QuoteBehavior.noQuotes);
     keep_its.matchesModel = true;
 
     processSimilarity(testModelWithCasing, distribution, context, trueInput);
 
     assert.sameDeepMembers(distribution, expectation);
-    assert.equal(its.prediction.sample.tag, 'keep');
-    assert.deepEqual(its.prediction.sample, keep_its);
+    assert.equal(its.components.prediction.tag, 'keep');
+    assert.deepEqual(its.components.prediction, keep_its);
   });
 
   it(`selects contraction as 'more similar' than same-keyed non-contraction when context is contraction`, () => {
@@ -257,32 +259,22 @@ describe('processSimilarity', () => {
     const testSet = build_its_is_set();
     const distribution = [...Object.values(testSet)];
 
-    const expectation: CorrectionPredictionTuple[] = [
-      {
-        ...testSet.its,
-        matchLevel: SuggestionSimilarity.sameKey
-      }, {
-        ...testSet.it_is,
-        matchLevel: SuggestionSimilarity.exact
-      }, {
-        ...testSet.is,
-        matchLevel: SuggestionSimilarity.none
-      }, {
-        ...testSet.is_not,
-        matchLevel: SuggestionSimilarity.none
-      }
-    ];
+    const expectation: IntermediateCompositedPrediction[] = [...Object.values(testSet)];
+    expectation[0].metadata.matchLevel = SuggestionSimilarity.sameKey;  // its
+    expectation[1].metadata.matchLevel = SuggestionSimilarity.exact;    // it_is
+    expectation[2].metadata.matchLevel = SuggestionSimilarity.none;     // is
+    expectation[3].metadata.matchLevel = SuggestionSimilarity.none;     // is_not
 
     const it_is = testSet.it_is;
     const original_it_is = deepCopy(it_is);
-    const keep_it_is = toAnnotatedSuggestion(testModelWithCasing, original_it_is.prediction.sample, 'keep', QuoteBehavior.noQuotes);
+    const keep_it_is = toAnnotatedSuggestion(testModelWithCasing, original_it_is.components.prediction, 'keep', QuoteBehavior.noQuotes);
     keep_it_is.matchesModel = true;
 
     processSimilarity(testModelWithCasing, distribution, context, trueInput);
 
     assert.sameDeepMembers(distribution, expectation);
-    assert.equal(it_is.prediction.sample.tag, 'keep');
-    assert.deepEqual(it_is.prediction.sample, keep_it_is);
+    assert.equal(it_is.components.prediction.tag, 'keep');
+    assert.deepEqual(it_is.components.prediction, keep_it_is);
   });
 
   describe('with casing', () => {
@@ -314,34 +306,22 @@ describe('processSimilarity', () => {
 
       // Have the predictions replace existing context parts with the lowercased equivalents.
       Object.values(testSet).forEach((entry) => {
-        const transform = entry.prediction.sample.transform;
+        const transform = entry.components.prediction.transform;
         transform.insert = transform.deleteLeft == 0 ? `it${transform.insert}` : `i${transform.insert}`;
         transform.deleteLeft = 2;
       });
 
       const distribution = [...Object.values(testSet)];
 
-      const expectation: CorrectionPredictionTuple[] = [
-        {
-          ...testSet.its,
-          matchLevel: SuggestionSimilarity.sameKey
-        }, {
-          ...testSet.it_is,
-          // case mismatch, detectable because we have access to a lowercasing/uppercasing function.
-          matchLevel: SuggestionSimilarity.sameText
-        }, {
-          ...testSet.is,
-          matchLevel: SuggestionSimilarity.none
-        }, {
-          ...testSet.is_not,
-          matchLevel: SuggestionSimilarity.none
-        }
-      ];
-
+      const expectation: IntermediateCompositedPrediction[] = [...Object.values(testSet)];
+      expectation[0].metadata.matchLevel = SuggestionSimilarity.sameKey;   // its
+      expectation[1].metadata.matchLevel = SuggestionSimilarity.sameText;  // it_is
+      expectation[2].metadata.matchLevel = SuggestionSimilarity.none;      // is
+      expectation[3].metadata.matchLevel = SuggestionSimilarity.none;      // is_not
       processSimilarity(testModelWithCasing, distribution, context, trueInput);
 
       // Because we mucked with the casing here, there is no perfect 'keep' match.
-      const keep = distribution.find((entry) => entry.prediction.sample.tag == 'keep');
+      const keep = distribution.find((entry) => entry.components.prediction.tag == 'keep');
       assert.isNotOk(keep);
       assert.sameDeepMembers(distribution, expectation);
     });
@@ -368,34 +348,20 @@ describe('processSimilarity', () => {
 
       // Have the predictions replace existing context parts with the lowercased equivalents.
       Object.values(testSet).forEach((entry) => {
-        const transform = entry.prediction.sample.transform;
+        const transform = entry.components.prediction.transform;
         transform.insert = transform.deleteLeft == 0 ? `it${transform.insert}` : `i${transform.insert}`;
         transform.deleteLeft = 2;
       });
 
       const distribution = [...Object.values(testSet)];
 
-      const expectation: CorrectionPredictionTuple[] = [
-        {
-          ...testSet.its,
-          matchLevel: SuggestionSimilarity.none
-        }, {
-          ...testSet.it_is,
-          // case mismatch, detectable because we have access to a lowercasing/uppercasing function.
-          matchLevel: SuggestionSimilarity.none
-        }, {
-          ...testSet.is,
-          matchLevel: SuggestionSimilarity.none
-        }, {
-          ...testSet.is_not,
-          matchLevel: SuggestionSimilarity.none
-        }
-      ];
+      const expectation: IntermediateCompositedPrediction[] = [...Object.values(testSet)];
 
+      expectation.forEach((entry) => entry.metadata.matchLevel = SuggestionSimilarity.none);
       processSimilarity(testModelWithoutCasing, distribution, context, trueInput);
 
       // Because we mucked with the casing here, there is no perfect 'keep' match.
-      const keep = distribution.find((entry) => entry.prediction.sample.tag == 'keep');
+      const keep = distribution.find((entry) => entry.components.prediction.tag == 'keep');
       assert.isNotOk(keep);
       assert.sameDeepMembers(distribution, expectation);
     });

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-model-compositor.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-model-compositor.tests.ts
@@ -869,6 +869,9 @@ describe('ModelCompositor', function() {
         deleteLeft: 1
       }
 
+      // Future adjustment:  add the 'baseSuggestion' to DummyModel so that it actually
+      // returns the suggestion again.
+      //  `new models.DummyModel(..., futureSuggestions: [[baseSuggestion]])`
       let model = new models.DummyModel({punctuation: englishPunctuation});
       let compositor = new ModelCompositor(model, true);
 
@@ -883,6 +886,7 @@ describe('ModelCompositor', function() {
 
       // As this test is a bit... 'hard-wired', we only get the 'keep' suggestion.
       // It should still be accurate, though.
+      // Can be fixed via the "Future adjustment" noted above.
       assert.equal(suggestions.length, 1);
 
       let expectedTransform = {


### PR DESCRIPTION
This reorganizes the type formerly known as `CorrectionPredictionTuple`, preparing it to share similarities with a new incoming type (see #15907) handling an earlier, tokenized intermediate stage that will be needed for some aspects of suggestion generation once whitespace-correction comes online.

Build-bot: skip build:web
Test-bot: skip