### PR TITLE
chore: update fast-xml-parser to 5.8.0 🏠

### DIFF
--- a/developer/src/common/web/utils/package.json
+++ b/developer/src/common/web/utils/package.json
@@ -12,7 +12,7 @@
     "@keymanapp/common-types": "*",
     "@sentry/node": "^7.57.0",
     "eventemitter3": "^5.0.0",
-    "fast-xml-parser": "^5.7.1",
+    "fast-xml-parser": "5.8.0",
     "path-browserify": "^1.0.1",
     "restructure": "^3.0.1",
     "sax": ">=0.6.0",

--- a/developer/src/common/web/utils/package.json
+++ b/developer/src/common/web/utils/package.json
@@ -12,7 +12,7 @@
     "@keymanapp/common-types": "*",
     "@sentry/node": "^7.57.0",
     "eventemitter3": "^5.0.0",
-    "fast-xml-parser": "^5.0.9",
+    "fast-xml-parser": "^5.7.1",
     "path-browserify": "^1.0.1",
     "restructure": "^3.0.1",
     "sax": ">=0.6.0",

--- a/developer/src/common/web/utils/src/xml-utils.ts
+++ b/developer/src/common/web/utils/src/xml-utils.ts
@@ -41,7 +41,7 @@ const PARSER_OPTIONS: KeymanXMLParserOptionsBag = {
     attributeNamePrefix: '@__', // We'll use this to convert attributes to strings and subobjects to arrays, when empty.
     htmlEntities: true,
     ignoreAttributes: false, // We'd like attributes, please
-    tagValueProcessor: (_tagName: string, tagValue: string /*, jPath, hasAttributes, isLeafNode*/) => {
+    tagValueProcessor: (_tagName: string, tagValue: string /*, _jPathOrMatcher: JPathOrMatcher, _hasAttributes: boolean, _isLeafNode: boolean*/) => {
       // since trimValues: false, we need to zap any element values that would be trimmed.
       // currently, the LDML spec doesn't have any element values, but this
       // future-proofs us a little in that element values are allowed, just trimmed.
@@ -70,7 +70,7 @@ const PARSER_OPTIONS: KeymanXMLParserOptionsBag = {
       if (!isLeafNode) {
         return tagValue?.trim(); // trimmed value
       } else {
-        return null;  // no change to leaf nodes
+        return undefined;  // no change to leaf nodes
       }
     },
     trimValues: false, // preserve spaces

--- a/developer/src/common/web/utils/src/xml-utils.ts
+++ b/developer/src/common/web/utils/src/xml-utils.ts
@@ -6,7 +6,7 @@
  * Abstraction for XML reading and writing
  */
 
-import { XMLParser, XMLBuilder, XmlBuilderOptions, X2jOptions } from 'fast-xml-parser';
+import { XMLParser, XMLBuilder, XmlBuilderOptions, X2jOptions, JPathOrMatcher } from 'fast-xml-parser';
 
 export type KeymanXMLType =
   'keyboard3'           // LDML <keyboard3>
@@ -27,9 +27,9 @@ const PARSER_COMMON_OPTIONS: X2jOptions = {
   ignoreAttributes: false,
   ignorePiTags: true,
   numberParseOptions: { // TODO: query is this option really necessary?
-    eNotation: null,
-    hex: null,
-    leadingZeros: null,
+    eNotation: false,
+    hex: false,
+    leadingZeros: false,
     skipLike: /(?:)/, // parse numbers as strings
   },
   textNodeName: '_',
@@ -66,7 +66,7 @@ const PARSER_OPTIONS: KeymanXMLParserOptionsBag = {
   },
   'kvks': {
     ...PARSER_COMMON_OPTIONS,
-    tagValueProcessor: (_tagName: string, tagValue: string, _jPath: string, _hasAttributes: boolean, isLeafNode: boolean) : string | undefined => {
+    tagValueProcessor: (_tagName: string, tagValue: string, _jPathOrMatcher: JPathOrMatcher, _hasAttributes: boolean, isLeafNode: boolean) : unknown => {
       if (!isLeafNode) {
         return tagValue?.trim(); // trimmed value
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -342,7 +342,7 @@
         "@keymanapp/common-types": "*",
         "@sentry/node": "^7.57.0",
         "eventemitter3": "^5.0.0",
-        "fast-xml-parser": "^5.0.9",
+        "fast-xml-parser": "^5.7.1",
         "path-browserify": "^1.0.1",
         "restructure": "^3.0.1",
         "sax": ">=0.6.0",
@@ -3592,6 +3592,18 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -9067,10 +9079,10 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.0.9.tgz",
-      "integrity": "sha512-2mBwCiuW3ycKQQ6SOesSB8WeF+fIGb6I/GG5vU5/XEptwFFhp9PE8b9O7fbs2dpq9fXn4ULR3UsfydNUCntf5A==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -9079,7 +9091,27 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.0.5"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -12324,6 +12356,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "dev": true,
@@ -13808,9 +13855,9 @@
       "link": true
     },
     "node_modules/strnum": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.0.5.tgz",
-      "integrity": "sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -15231,6 +15278,21 @@
       "dev": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -342,7 +342,7 @@
         "@keymanapp/common-types": "*",
         "@sentry/node": "^7.57.0",
         "eventemitter3": "^5.0.0",
-        "fast-xml-parser": "^5.7.1",
+        "fast-xml-parser": "5.8.0",
         "path-browserify": "^1.0.1",
         "restructure": "^3.0.1",
         "sax": ">=0.6.0",


### PR DESCRIPTION
Cherry-picked from dependabot PR on 19.0 alpha, and adjusted for 18.0.

Test-bot: skip
Cherry-pick-of: #15868 