### PR TITLE
fix(linux): add dependency on `procps` 🏠

### DIFF
--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,9 @@
+keyman (18.0.249-1) UNRELEASED; urgency=medium
+
+  * Add procps dependency (closes: 1136515)
+
+ -- Eberhard Beilharz <eb1@sil.org>  Mon, 18 May 2026 18:06:49 +0200
+
 keyman (18.0.248-1) unstable; urgency=medium
 
   * New upstream release.

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -90,6 +90,7 @@ Depends:
  dconf-cli,
  gir1.2-webkit2-4.1 | gir1.2-webkit2-4.0,
  keyman-engine,
+ procps,
  python3-bs4,
  python3-fonttools,
  python3-gi,


### PR DESCRIPTION
In the near future `pidof` will be provided by the `procps` package which isn't installed by default. This change adds a dependency on `procps` to fix this problem. Fixes Debian bug #1136515.

Fixes: #15965
Cherry-pick-of: #15967
Build-bot: skip
Test-bot: skip