### PR TITLE
fix(linux): fix source tarball verification

### DIFF
--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Build source packages from nightly builds and upload to PPA
 
+# shellcheck disable=SC2310 # -e will be disabled in if
+
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
@@ -18,6 +20,7 @@ builder_describe \
   "--upload                         Upload to launchpad." \
   "--simulate                       Simulate the upload to launchpad." \
   "--no-lintian                     Don't run lintian while creating source package." \
+  "--no-sign                        Don't sign the source package." \
   "--dist=DIST                      Only upload this distribution. Default: upload all supported dists." \
   "--packageversion=PACKAGEVERSION  String to append to the package version. Default: '1~sil1'." \
   "--outputdir=OUTPUTDIR            Directory for resulting artifacts. Default: \$KEYMAN_ROOT/linux/launchpad." \
@@ -39,10 +42,13 @@ else
   SIM=""
 fi
 
+DEBUILD_OPTS=()
 if builder_has_option --no-lintian; then
-  LINTIAN_OPTS="--no-lintian"
-else
-  LINTIAN_OPTS=""
+  DEBUILD_OPTS+=("--no-lintian")
+fi
+
+if builder_has_option --no-sign; then
+  DEBUILD_OPTS+=("--no-sign")
 fi
 
 if [[ "${KEYMAN_TIER}" == "stable" ]]; then
@@ -115,8 +121,9 @@ for dist in ${distributions}; do
   cp "../keyman-changelog" debian/changelog
   dch -v "${version}-${packageversion}~${dist}" "source package for PPA"
   dch -D "${dist}" -r ""
-  # shellcheck disable=SC2248  # no quotes for $LINTIAN_OPTS - might be empty string
-  debuild ${LINTIAN_OPTS} -d -S -sa -Zxz
+  # According to the docs, -S is equivalent to --build=source, but that causes debuild to fail.
+  # There is no long option for -sa (passed to dpkg-genchanges)
+  debuild "${DEBUILD_OPTS[@]}" --no-check-builddeps --compression=xz -S -sa
 done
 if builder_has_option --upload || builder_has_option --simulate; then
   cd ..

--- a/linux/scripts/verify_source.sh
+++ b/linux/scripts/verify_source.sh
@@ -11,6 +11,8 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../resources/build/builder-full.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
+. "${KEYMAN_ROOT}/resources/locate_emscripten.inc.sh"
+
 builder_describe \
   "Verify source tarball and source package" \
   build \
@@ -81,12 +83,24 @@ create_source_package() {
   cp -r "${KEYMAN_ROOT}/linux/debian" "keyman-${KEYMAN_VERSION}"
   cp "${target_dir}/keyman_${KEYMAN_VERSION}.pkg.tar.xz" "keyman_${KEYMAN_VERSION}.orig.tar.xz"
   "keyman-${KEYMAN_VERSION}/linux/scripts/launchpad.sh" --no-download \
-    --dist "$(lsb_release -c -s)" --outputdir "${target_dir}/launchpad" --no-lintian
+    --dist "$(lsb_release -c -s)" --outputdir "${target_dir}/launchpad" --no-lintian --no-sign
 }
 
 verify_lintian() {
   builder_echo heading "Running lintian"
   lintian "keyman_${KEYMAN_VERSION}"*source.changes
+}
+
+install_emscripten() {
+  local target_dir="$1"
+  if [[ ! -d "${target_dir}/emsdk" ]]; then
+    builder_echo heading "Installing Emscripten for build verification"
+    install_emscripten_into "${target_dir}/emsdk"
+  else
+    builder_echo heading "Emscripten already exists in ${target_dir}/emsdk, skipping installation"
+  fi
+  EMSCRIPTEN_BASE="${target_dir}/emsdk/upstream/emscripten"
+  export EMSCRIPTEN_BASE
 }
 
 cd "${KEYMAN_ROOT}/linux"
@@ -100,6 +114,9 @@ fi
 if ! builder_has_option --launchpad-only; then
   builder_echo start verifySource "Verifying source tarball"
   extract_source_tarball "${TARGET_DIR}"
+  if builder_is_ci_test_build; then
+    install_emscripten "${TARGET_DIR}"
+  fi
   verify_can_build "${TARGET_DIR}/keyman"
   rm -rf "${TARGET_DIR}/keyman"
   builder_echo end verifySource success "Finished verifying source tarball"

--- a/resources/build/ci/npm-publish.sh
+++ b/resources/build/ci/npm-publish.sh
@@ -24,6 +24,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/ci/ci-publish.inc.sh"
 . "$KEYMAN_ROOT/resources/build/ci/npm-packages.inc.sh"
 . "$KEYMAN_ROOT/resources/build/minimum-versions.inc.sh"
+. "$KEYMAN_ROOT/resources/locate_emscripten.inc.sh"
 
 builder_describe \
   "Publish @keymanapp packages to NPM" \
@@ -107,17 +108,10 @@ function install_emscripten() {
 
   local EMSDK_TEMP
   EMSDK_TEMP=$(mktemp -d)
-  pushd "${EMSDK_TEMP}"
-  git clone https://github.com/emscripten-core/emsdk.git
-  cd emsdk
-  ./emsdk install "${KEYMAN_MIN_VERSION_EMSCRIPTEN}"
-  ./emsdk activate "${KEYMAN_MIN_VERSION_EMSCRIPTEN}"
-  cd upstream/emscripten
-  npm install
-  echo "EMSCRIPTEN_BASE=$(pwd)" >> $GITHUB_ENV
-  EMSCRIPTEN_BASE="$(pwd)"
+  install_emscripten_into "${EMSDK_TEMP}"
+  EMSCRIPTEN_BASE="${EMSDK_TEMP}/upstream/emscripten"
   export EMSCRIPTEN_BASE
-  popd
+  echo "EMSCRIPTEN_BASE=${EMSCRIPTEN_BASE}" >> "${GITHUB_ENV}"
 }
 
 function install_meson() {

--- a/resources/build/zip.inc.sh
+++ b/resources/build/zip.inc.sh
@@ -124,7 +124,7 @@ function add_zip_files() {
     if [[ -z "${SEVENZ+x}" ]]; then
       if builder_is_windows; then
         if [[ -z "${SEVENZ_HOME+x}" ]]; then
-          SEVENZ="$(command -v 7z.exe)"
+          SEVENZ="$(command -v 7z.exe || true)"
         else
           SEVENZ="${SEVENZ_HOME}/7z.exe"
         fi

--- a/resources/build/zip.inc.sh
+++ b/resources/build/zip.inc.sh
@@ -125,6 +125,11 @@ function add_zip_files() {
       if builder_is_windows; then
         if [[ -z "${SEVENZ_HOME+x}" ]]; then
           SEVENZ="$(command -v 7z.exe || true)"
+          if [[ -z "${SEVENZ}" ]]; then
+            builder_die "7z.exe not found on path. Please install 7-Zip " \
+              "and ensure 7z.exe is on the path or set SEVENZ_HOME " \
+              "environment variable to the folder containing 7z.exe."
+          fi
         else
           SEVENZ="${SEVENZ_HOME}/7z.exe"
         fi

--- a/resources/locate_emscripten.inc.sh
+++ b/resources/locate_emscripten.inc.sh
@@ -117,3 +117,22 @@ _select_emscripten_version_with_emsdk() {
     fi
   )
 }
+
+install_emscripten_into() {
+  if [[ -z "${1:-}" ]]; then
+    builder_die "${FUNCNAME[0]} requires a directory argument"
+  fi
+
+  local EMSDK_DIR=$1
+  builder_heading "Installing emscripten into ${EMSDK_DIR}"
+
+  mkdir -p "${EMSDK_DIR}"
+  (
+    cd "${EMSDK_DIR}"
+    git clone https://github.com/emscripten-core/emsdk.git .
+    ./emsdk install "${KEYMAN_MIN_VERSION_EMSCRIPTEN}"
+    ./emsdk activate "${KEYMAN_MIN_VERSION_EMSCRIPTEN}"
+    cd upstream/emscripten
+    npm install
+  )
+}

--- a/resources/locate_emscripten.inc.sh
+++ b/resources/locate_emscripten.inc.sh
@@ -38,7 +38,7 @@ locate_emscripten() {
   if [[ -z "${EMSCRIPTEN_BASE:-}" ]]; then
     if [[ -z "${EMCC:-}" ]]; then
       local EMCC
-      EMCC="$(command -v "${EMCC_EXECUTABLE}")"
+      EMCC="$(command -v "${EMCC_EXECUTABLE}" || true)"
       [[ -z "${EMCC}" ]] && builder_die "locate_emscripten: Could not locate emscripten (${EMCC_EXECUTABLE}) on the path or with \$EMCC or \$EMSCRIPTEN_BASE"
     fi
     [[ -f "${EMCC}" && ! -x "${EMCC}" ]] && builder_die "locate_emscripten: Variable EMCC (${EMCC}) points to ${EMCC_EXECUTABLE} but it is not executable"


### PR DESCRIPTION
This change fixes the source tarball verification. When running on CI building `kmcmplib` executed some additional steps which failed because emscripten couldn't be set up. This PR fixes things so that we get a proper error message if `emcc` is not available, and if fixes the build itself by installing emscripten before running the source tarball verification.

Test-bot: skip