### PR TITLE
maint(linux): Don't block merge if source verification check fails

### DIFF
--- a/.github/workflows/pr-build-status.yml
+++ b/.github/workflows/pr-build-status.yml
@@ -81,7 +81,9 @@ jobs:
                 } else if(status.context == 'Ubuntu Packaging') {
                   summary += addStatus(o, 'build', status.context, status.state);
                 } else if(status.context == 'Linux source verification') {
-                  summary += addStatus(o, 'build', status.context, status.state);
+                  // Ignore Linux source verification -- we won't block automerge
+                  // for this at this point
+                  summary += addLog(`Skipping ${status.context}`);
                 } else if(status.context == 'npm pack/publish') {
                   summary += addStatus(o, 'build', status.context, status.state);
                 } else if(status.context == 'Keyman Core - ARM64 test') {


### PR DESCRIPTION
If the Linux source verification check fails, we don't want to block merging the PR. This makes it behave similar to the web/file-size check.

Related-to: #16004
Build-bot: skip
Test-bot: skip