### PR TITLE
chore(web): add filename to link text of manual web tests

### DIFF
--- a/web/src/test/manual/web/index.html
+++ b/web/src/test/manual/web/index.html
@@ -20,64 +20,63 @@
   </head>
   <body>
 
-  <h1>KeymanWeb 17 Testing</h1>
-  <h2><a href="./unminified.html">Test unminified Keymanweb</a></h2>
-  <h2><a href="./unminified - manual.html">Test unminified Keymanweb in manual-attachment mode.</a></h2>
-  <h2><a href="./prediction-mtnt/index.html">Prediction - robust testing</a></h2>
-  <h2><a href="./desktop-ui/index.html">Desktop UI module testing</a></h2>
-  <h2><a href="./build-visual-keyboard/index.html">Tests keyboard documentation rendering.</a></h2>
-  <h2><a href="./gesture-recognizer/index.html">Stand-alone gesture recognition</a></h2>
+  <h1>KeymanWeb 19 Testing</h1>
+  <h2><a href="./unminified.html">Test unminified Keymanweb (unminified)</a></h2>
+  <h2><a href="./unminified - manual.html">Test unminified Keymanweb in manual-attachment mode (unminified - manual)</a></h2>
+  <h2><a href="./prediction-mtnt/index.html">Prediction - robust testing (prediction-mtnt)</a></h2>
+  <h2><a href="./desktop-ui/index.html">Desktop UI module testing (desktop-ui)</a></h2>
+  <h2><a href="./build-visual-keyboard/index.html">Tests keyboard documentation rendering (build-visual-keyboard)</a></h2>
+  <h2><a href="./gesture-recognizer/index.html">Stand-alone gesture recognition (gesture-recognizer)</a></h2>
 
   <h1>Miscellaneous tests for smaller features</h1>
-  <h2><a href="./chirality/index.html">Chirality testing/bootstrapping</a></h2>
-  <h2><a href="./options-with-save/index.html">Tests option/variable store functionality</a></h2>
-  <h2><a href="./platform/index.html">Platform testing</a></h2>
-  <h2><a href="./prediction-ui/index.html">Prediction UI testing</a></h2>
-  <h2><a href="./promise-api/index.html">Promise API testing</a></h2>
-  <h2><a href="./sentry-integration/index.html">Tests Sentry error-reporting functionality</a></h2>
-  <h2><a href="./osk-movement/index.html">Test page for osk setRect() and restorePosition() interaction</a></h2>
-  <h2><a href="./ckeditor/index.html">Integration with CKEditor</a></h2>
-  <h2><a href="./osk-event-buttons/index.html">Tests toggling & use of desktop OSK config & help buttons</a></h2>
+  <h2><a href="./chirality/index.html">Chirality testing/bootstrapping (chirality)</a></h2>
+  <h2><a href="./options-with-save/index.html">Tests option/variable store functionality (options-with-save)</a></h2>
+  <h2><a href="./platform/index.html">Platform testing (platform)</a></h2>
+  <h2><a href="./prediction-ui/index.html">Prediction UI testing (prediction-ui)</a></h2>
+  <h2><a href="./promise-api/index.html">Promise API testing (promise-api)</a></h2>
+  <h2><a href="./sentry-integration/index.html">Tests Sentry error-reporting functionality (sentry-integration)</a></h2>
+  <h2><a href="./osk-movement/index.html">Test page for osk setRect() and restorePosition() interaction (osk-movement)</a></h2>
+  <h2><a href="./ckeditor/index.html">Integration with CKEditor (ckeditor)</a></h2>
+  <h2><a href="./osk-event-buttons/index.html">Tests toggling & use of desktop OSK config & help buttons (osk-event-buttons)</a></h2>
 
   <h1>Page integration (attachment) tests</h1>
-  <h2><a href="./attachment-api/index.html?mode=auto">Tests the Attachment/Enablement API functionality</a></h2>
-  <h2><a href="./issue29/index.html">Test desktop MutationObserver functionality</a></h2>
-  <h2><a href="./issue62/index.html">Light test for touch-based MutationObserver functionality</a></h2>
-  <h2><a href="./issue63/index.html">Test/stress-test touch-based MutationObserver functionality</a></h2>
+  <h2><a href="./attachment-api/index.html?mode=auto">Tests the Attachment/Enablement API functionality (attachment-api)</a></h2>
+  <h2><a href="./issue29/index.html">Test desktop MutationObserver functionality (issue29)</a></h2>
+  <h2><a href="./issue62/index.html">Light test for touch-based MutationObserver functionality (issue62)</a></h2>
+  <h2><a href="./issue63/index.html">Test/stress-test touch-based MutationObserver functionality (issue63)</a></h2>
 
   <h1>Issue Testing</h1>
-  <h2><a href="./empty-row/index.html">Tests OSK handling of empty rows</a></h2>
-  <h2><a href="./keyboard-errors/index.html">Tests keyboard error-handling functionality</a></h2>
-  <h2><a href="./issue005/index.html">'Test case' for proper implementation of the removeKeyboards API function.</a></h2>
-  <h2><a href="./issue53/index.html">Tests layering transitions for keyboards with variable layer sizes.</a></h2>
-  <h2><a href="./issue103/index.html">Tests keyboard loading with repeated requests</a></h2>
-  <h2><a href="./issue115/index.html">Long-press on numeric and symbolic layer testing</a></h2>
-  <h2><a href="./issue116/index.html">Next-layer processing testing</a></h2>
-  <h2><a href="./issue160/index.html">Uxxxx code testing</a></h2>
-  <h2><a href="./issue266/index.html">Test KMW beep</a></h2>
-  <h2><a href="./issue271/index.html">Test page for interactions between setActiveKeyboard and the toolbar UI.</a></h2>
-  <h2><a href="./issue1332/index.html">Test keyboard loading with upper case TTF font</a></h2>
-  <h2><a href="./basic-iframe/index.html">Test page for IFrame connectivity and class prototype management</a></h2>
-  <h2><a href="./mnemonic/index.html">Test page for mnemonic basic support on US English</a></h2>
-  <h2><a href="./rotation-events/index.html">Test page for evaluating issues with mobile device rotation events</a></h2>
-  <h2><a href="./issue382/index.html">Test page for automatic key-cap scaling</a></h2>
-  <h2><a href="./issue3701/index.html">Test page for fat-finger interaction with beep feedback</a></h2>
-  <h2><a href="./issue917-context-and-notany/index.html">Test page for context() and notany() interaction</a></h2>
-  <h2><a href="./spacebar-text/index.html">Test SpacebarText APIs (#949)</a></h2>
-  <h2><a href="./inline-osk/index.html">Test inline OSK (#5665)</a></h2>
-  <h2><a href="./issue2924/index.html">Test variable stores and predictive text (#2924)</a></h2>
-  <h2><a href="./caps-lock-layer-3620/index.html">Test Caps Lock Layer (#3620)</a></h2>
-  <h2><a href="./start-of-sentence-3621/index.html">Test Start of Sentence (#3621)</a></h2>
-  <h2><a href="./start-of-sentence-3621/index.html">Test start of sentence keyboard rules (#5963)</a></h2>
-  <h2><a href="./issue6005/index.html">Tests predictive text & other handling of rule matching when the final rule group does not match (#6005)</a></h2>
-  <h2><a href="./default-subkey/index.html">Tests handling of new default-subkey feature (#9430)</a></h2>
-  <h2><a href="./issue9469/index.html">Test special characters rendering with keymanweb-osk.ttf (#9469)</a></h2>
-  <h2><a href="./text_selection_tests_9073/index.html">Test text selection (#9073)</a></h2>
-  <h2><a href="./pr10506/index.html">Test key-cap scaling / font load interactions (#10506)</a></h2>
-  <h2><a href="./init-race-10743/index.html">Test page interaction + engine-initialization race condition handling (#10743)</a></h2>
-  <h2><a href="./issue11785/index.html">Test OSK loading with early add-keyboard calls (#11785)</a></h2>
+  <h2><a href="./empty-row/index.html">Tests OSK handling of empty rows (empty-row)</a></h2>
+  <h2><a href="./keyboard-errors/index.html">Tests keyboard error-handling functionality (keyboard-errors)</a></h2>
+  <h2><a href="./issue005/index.html">'Test case' for proper implementation of the removeKeyboards API function. (issue005)</a></h2>
+  <h2><a href="./issue53/index.html">Tests layering transitions for keyboards with variable layer sizes. (issue53)</a></h2>
+  <h2><a href="./issue103/index.html">Tests keyboard loading with repeated requests (issue103)</a></h2>
+  <h2><a href="./issue115/index.html">Long-press on numeric and symbolic layer testing (issue115)</a></h2>
+  <h2><a href="./issue116/index.html">Next-layer processing testing (issue116)</a></h2>
+  <h2><a href="./issue160/index.html">Uxxxx code testing (issue160)</a></h2>
+  <h2><a href="./issue266/index.html">Test KMW beep (issue266)</a></h2>
+  <h2><a href="./issue271/index.html">Test page for interactions between setActiveKeyboard and the toolbar UI (issue271)</a></h2>
+  <h2><a href="./issue1332/index.html">Test keyboard loading with upper case TTF font (issue1332)</a></h2>
+  <h2><a href="./basic-iframe/index.html">Test page for IFrame connectivity and class prototype management (basic-iframe)</a></h2>
+  <h2><a href="./mnemonic/index.html">Test page for mnemonic basic support on US English (mnemonic)</a></h2>
+  <h2><a href="./rotation-events/index.html">Test page for evaluating issues with mobile device rotation events (rotation-events)</a></h2>
+  <h2><a href="./issue382/index.html">Test page for automatic key-cap scaling (issue382)</a></h2>
+  <h2><a href="./issue3701/index.html">Test page for fat-finger interaction with beep feedback (issue3701)</a></h2>
+  <h2><a href="./issue917-context-and-notany/index.html">Test page for context() and notany() interaction (issue917-context-and-notany)</a></h2>
+  <h2><a href="./spacebar-text/index.html">Test SpacebarText APIs (#949) (spacebar-text)</a></h2>
+  <h2><a href="./inline-osk/index.html">Test inline OSK (#5665) (inline-osk)</a></h2>
+  <h2><a href="./issue2924/index.html">Test variable stores and predictive text (#2924) (issue2924)</a></h2>
+  <h2><a href="./caps-lock-layer-3620/index.html">Test Caps Lock Layer (#3620) (caps-lock-layer-3620)</a></h2>
+  <h2><a href="./start-of-sentence-3621/index.html">Test start of sentence keyboard rules (#3621/#5963) (start-of-sentence-3621)</a></h2>
+  <h2><a href="./issue6005/index.html">Tests predictive text & other handling of rule matching when the final rule group does not match (#6005) (issue6005)</a></h2>
+  <h2><a href="./default-subkey/index.html">Tests handling of new default-subkey feature (#9430) (default-subkey)</a></h2>
+  <h2><a href="./issue9469/index.html">Test special characters rendering with keymanweb-osk.ttf (#9469) (issue9469)</a></h2>
+  <h2><a href="./text_selection_tests_9073/index.html">Test text selection (#9073) (text_selection_tests_9073)</a></h2>
+  <h2><a href="./pr10506/index.html">Test key-cap scaling / font load interactions (#10506) (pr10506)</a></h2>
+  <h2><a href="./init-race-10743/index.html">Test page interaction + engine-initialization race condition handling (#10743) (init-race-10743)</a></h2>
+  <h2><a href="./issue11785/index.html">Test OSK loading with early add-keyboard calls (#11785) (issue11785)</a></h2>
   <h1>Other</h1>
-  <h2><a href="./regression-tests/index.html">Keystroke processing regression test engine.</a></h2>
+  <h2><a href="./regression-tests/index.html">Keystroke processing regression test engine (regression-tests)</a></h2>
   <hr>
   <p><a href="../../../../index.html">Return to main index</a>
   </body>


### PR DESCRIPTION
This change appends the filename to the description of the tests on the index page of the manual web tests. This makes it easier to find the test on the rendered index page when having the directory name of the test available.

Build-bot: skip
Test-bot: skip