### PR TITLE
chore(web): improve the KeymanWeb integration documentation

### DIFF
--- a/common/test/resources/keyboards/test_8568_deadkeys.html
+++ b/common/test/resources/keyboards/test_8568_deadkeys.html
@@ -36,22 +36,20 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      (function(kmw) {
-        kmw.init({
-          attachType:'auto'
-        }).then(function() {
-          kmw.addKeyboards({
-            id:'test_8568_deadkeys',
-            name:'Testcase for deadkeys bug (#8568)',
-            languages:{
-              id:'en',
-              name:'English'
-            },
-            filename:'./test_8568_deadkeys.js'
-          });
+      keyman.init({
+        attachType:'auto'
+      }).then(async function() {
+        await keyman.addKeyboards({
+          id:'test_8568_deadkeys',
+          name:'Testcase for deadkeys bug (#8568)',
+          languages:{
+            id:'en',
+            name:'English'
+          },
+          filename:'./test_8568_deadkeys.js'
         });
-        })(keyman);
-      </script>
+      });
+    </script>
 
 
   </head>

--- a/developer/docs/help/reference/kmc/cli/get-started.md
+++ b/developer/docs/help/reference/kmc/cli/get-started.md
@@ -110,7 +110,7 @@ hamburger menu in the Keyman app.
 **Web**: copy khmer_angkor.js to your website, then [load it with KeymanWeb][load-keymanweb-keyboard]:
 
 ```js
-keyman.addKeyboards({
+await keyman.addKeyboards({
   id:'khmer_angkor',        // The keyboard's unique identification code.
   name:'Khmer Angkor',      // The keyboard's user-readable name.
   language:{

--- a/developer/src/kmc/README.md
+++ b/developer/src/kmc/README.md
@@ -109,7 +109,7 @@ hamburger menu in the Keyman app.
 **Web**: copy khmer_angkor.js to your website, then [load it with KeymanWeb][load-keymanweb-keyboard]:
 
 ```js
-keyman.addKeyboards({
+await keyman.addKeyboards({
   id:'khmer_angkor',        // The keyboard's unique identification code.
   name:'Khmer Angkor',      // The keyboard's user-readable name.
   language:{

--- a/web/docs/engine/guide/adding-keyboards.md
+++ b/web/docs/engine/guide/adding-keyboards.md
@@ -8,8 +8,8 @@ There are multiple ways to add and install keyboards into your KeymanWeb install
 
 The most efficient way to utilize a keyboard is to obtain a local copy of it and place this copy in a static location on your website. Once this is done, it can be directly linked into KeymanWeb as follows.
 
-```c
-keyman.addKeyboards({
+```typescript
+await keyman.addKeyboards({
     id:'us',                  // The keyboard's unique identification code.
     name:'English',           // The keyboard's user-readable name.
     language:{
@@ -22,7 +22,7 @@ keyman.addKeyboards({
 
 Custom fonts may also be utilized via the `language.font` property. For example:
 
-```c
+```typescript
 font:{
     family:'LaoWeb',
     source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']
@@ -33,16 +33,16 @@ font:{
 
 To obtain the default Keyman keyboard for a given language, call the following function.
 
-```c
-keyman.addKeyboardsForLanguage('Dzongkha');
+```typescript
+await keyman.addKeyboardsForLanguage('Dzongkha');
 ```
 
 This example would find the default keyboard for the Dzongkha language. This method will fail if the name doesn't perfectly match any language found in the CDN's repository.
 
 Alternatively, languages may be looked up via their BCP 47 language code as follows:
 
-```c
-keyman.addKeyboards('@he')
+```typescript
+await keyman.addKeyboards('@he')
 ```
 
 The `@` prefix indicates the use of the BCP 47 language code, which in this case corresponds with Hebrew.
@@ -51,8 +51,8 @@ The `@` prefix indicates the use of the BCP 47 language code, which in this case
 
 To obtain a specific keyboard by name or by keyboard name and language code as a pair, see the following:
 
-```c
-keyman.addKeyboards('french','sil_euro_latin@sv','sil_euro_latin@no')
+```typescript
+await keyman.addKeyboards('french','sil_euro_latin@sv','sil_euro_latin@no')
 ```
 
 This will install three keyboards - one for French (named, quite simply, "French") and two copies of the EuroLatin keyboard - one for Swedish and one for Norwegian.

--- a/web/docs/engine/guide/adding-keyboards.md
+++ b/web/docs/engine/guide/adding-keyboards.md
@@ -42,7 +42,7 @@ This example would find the default keyboard for the Dzongkha language. This met
 Alternatively, languages may be looked up via their BCP 47 language code as follows:
 
 ```typescript
-await keyman.addKeyboards('@he')
+await keyman.addKeyboards('@he');
 ```
 
 The `@` prefix indicates the use of the BCP 47 language code, which in this case corresponds with Hebrew.
@@ -52,7 +52,7 @@ The `@` prefix indicates the use of the BCP 47 language code, which in this case
 To obtain a specific keyboard by name or by keyboard name and language code as a pair, see the following:
 
 ```typescript
-await keyman.addKeyboards('french','sil_euro_latin@sv','sil_euro_latin@no')
+await keyman.addKeyboards('french', 'sil_euro_latin@sv', 'sil_euro_latin@no');
 ```
 
 This will install three keyboards - one for French (named, quite simply, "French") and two copies of the EuroLatin keyboard - one for Swedish and one for Norwegian.

--- a/web/docs/engine/guide/examples/__auto-control.html
+++ b/web/docs/engine/guide/examples/__auto-control.html
@@ -1,20 +1,17 @@
+<!DOCTYPE html>
 <html>
 <head>
   <script src='https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js'></script>
-  <script>var kmw = keyman;</script>
-
   <script>
-    window.addEventListener('load', function () {
-      keyman.init().then(function() {
-        keyman.addKeyboards({
-          id:'laokeys',
-          name:'Lao (Phonetic)',
-          languages:{
-            id:'lo',
-            name:'Lao'
-          },
-          filename:'./js/laokeys.js'
-        });
+    keyman.init().then(function() {
+      keyman.addKeyboards({
+        id:'laokeys',
+        name:'Lao (Phonetic)',
+        languages:{
+          id:'lo',
+          name:'Lao'
+        },
+        filename:'./js/laokeys.js'
       });
     });
   </script>

--- a/web/docs/engine/guide/examples/__auto-control.html
+++ b/web/docs/engine/guide/examples/__auto-control.html
@@ -3,8 +3,8 @@
 <head>
   <script src='https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js'></script>
   <script>
-    keyman.init().then(function() {
-      keyman.addKeyboards({
+    keyman.init().then(async function() {
+      await keyman.addKeyboards({
         id:'laokeys',
         name:'Lao (Phonetic)',
         languages:{

--- a/web/docs/engine/guide/examples/__control-by-control.html
+++ b/web/docs/engine/guide/examples/__control-by-control.html
@@ -10,7 +10,7 @@
 <script type="text/javascript">
   keyman.init({
     root: './',  // Note - if drawing the latest version of KeymanWeb from the CDN, this will
-                  // default to the source folder on our servers.
+                 // default to the source folder on our servers.
     ui: 'toggle',
     resources: './'
   }).then(async function() {
@@ -19,8 +19,11 @@
 
     // Disable KeymanWeb interaction on the 'Email to' TEXT control
     keyman.disableControl(document.f.address);
-    // Set the default keyboard for the 'Subject' TEXT control to the first language
-    // added to KeymanWeb after initialization.
+    // Set the default keyboard for the 'Subject' TEXT control to 'off' (i.e.
+    // default browser keyboard). As KeymanWeb relies on the on-screen keyboard
+    // to change languages for touch-based devices, this will not work for them
+    // and will default to the first language added to KeymanWeb after
+    // initialization.
     keyman.setKeyboardForControl(document.f.subject, '', '');
     // Set the default keyboard for the 'Message body' TEXTAREA to the LaoKeys keyboard
     keyman.setKeyboardForControl(document.f.text, 'Keyboard_laokeys', 'lo');

--- a/web/docs/engine/guide/examples/__control-by-control.html
+++ b/web/docs/engine/guide/examples/__control-by-control.html
@@ -3,7 +3,6 @@
 <head>
 
 <script src='https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js'></script>
-<script>var kmw = keyman;</script>
 <script src='https://s.keyman.com/kmw/engine/17.0.331/kmwuitoggle.js'></script>
 
 <script type='text/javascript' src='js/unified_loader.js'></script>
@@ -20,8 +19,8 @@
 
     // Disable KeymanWeb interaction on the 'Email to' TEXT control
     keyman.disableControl(document.f.address);
-    // Set the default keyboard for the 'Subject' TEXT control to 'off' (i.e. default
-    // browser keyboard)
+    // Set the default keyboard for the 'Subject' TEXT control to the first language
+    // added to KeymanWeb after initialization.
     keyman.setKeyboardForControl(document.f.subject, '', '');
     // Set the default keyboard for the 'Message body' TEXTAREA to the LaoKeys keyboard
     keyman.setKeyboardForControl(document.f.text, 'Keyboard_laokeys', 'lo');

--- a/web/docs/engine/guide/examples/__control-by-control.html
+++ b/web/docs/engine/guide/examples/__control-by-control.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 
@@ -8,28 +9,23 @@
 <script type='text/javascript' src='js/unified_loader.js'></script>
 
 <script type="text/javascript">
-  function SetupDocument() {
-    keyman.init({
-      root: './',  // Note - if drawing the latest version of KeymanWeb from the CDN, this will
-                   // default to the source folder on our servers.
-      ui: 'toggle',
-      resources: './'
-    }).then(function() {
-      // Load the keyboards of your choice here.
-      loadKeyboards();
+  keyman.init({
+    root: './',  // Note - if drawing the latest version of KeymanWeb from the CDN, this will
+                  // default to the source folder on our servers.
+    ui: 'toggle',
+    resources: './'
+  }).then(async function() {
+    // Load the keyboards of your choice here.
+    await loadKeyboards();
 
-      /* Disable KeymanWeb interaction on the 'Email to' TEXT control */
-      keyman.disableControl(document.f.address);
-      /* Set the default keyboard for the 'Subject' TEXT control to 'off' (i.e. default browser keyboard) */
-      /* As KeymanWeb relies on the on-screen keyboard to change languages for touch-based devices, this will
-       * not work for them and will default to the first language added to KeymanWeb after initialization. */
-      keyman.setKeyboardForControl(document.f.subject, '', '');
-      /* Set the default keyboard for the 'Message body' TEXTAREA to the LaoKeys keyboard */
-      keyman.setKeyboardForControl(document.f.text, 'Keyboard_laokeys', 'lo');
-    });
-  }
-
-  window.addEventListener( 'load' , SetupDocument );
+    // Disable KeymanWeb interaction on the 'Email to' TEXT control
+    keyman.disableControl(document.f.address);
+    // Set the default keyboard for the 'Subject' TEXT control to 'off' (i.e. default
+    // browser keyboard)
+    keyman.setKeyboardForControl(document.f.subject, '', '');
+    // Set the default keyboard for the 'Message body' TEXTAREA to the LaoKeys keyboard
+    keyman.setKeyboardForControl(document.f.text, 'Keyboard_laokeys', 'lo');
+  });
 </script>
 </head>
 <body>

--- a/web/docs/engine/guide/examples/__first-example.html
+++ b/web/docs/engine/guide/examples/__first-example.html
@@ -6,15 +6,14 @@
 
   <!-- Start of Code -->
   <script src='https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js'></script>
-  <script>var kmw = keyman;</script>
   <script src='https://s.keyman.com/kmw/engine/17.0.331/kmwuitoggle.js'></script>
   <script>
-    (function() {
-      keyman.init({attachType:'auto'}).then(function() {
-        keyman.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
-        keyman.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
-      });
-    })(keyman);
+    keyman.init({
+      attachType:'auto'
+    }).then(function() {
+      keyman.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
+      keyman.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
+    });
   </script>
 </head>
 <body>

--- a/web/docs/engine/guide/examples/__first-example.html
+++ b/web/docs/engine/guide/examples/__first-example.html
@@ -10,9 +10,9 @@
   <script>
     keyman.init({
       attachType:'auto'
-    }).then(function() {
-      keyman.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
-      keyman.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
+    }).then(async function() {
+      await keyman.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
+      await keyman.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
     });
   </script>
 </head>

--- a/web/docs/engine/guide/examples/__full-manual-control.html
+++ b/web/docs/engine/guide/examples/__full-manual-control.html
@@ -1,44 +1,38 @@
+<!DOCTYPE html>
 <html>
 <head>
 
 <script src='https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js'></script>
-<script>var kmw = keyman;</script>
 
 <script type='text/javascript' src='js/unified_loader.js'></script>
 <script type="text/javascript">
 
 var KWControl = null;
 
-function SetupDocument()
-{
-  keyman.init().then(function(){
-    // Load the keyboards of your choice here.
-    loadKeyboards();
+keyman.init().then(async function() {
+  // Load the keyboards of your choice here.
+  await loadKeyboards();
 
-    KWControl = document.getElementById('KWControl');
-    var kbds = keyman.getKeyboards();
-    for(var kbd in kbds)
-    {
-      var opt = document.createElement('OPTION');
-      opt.value = kbds[kbd].InternalName + "$$" + kbds[kbd].LanguageCode;
-      opt.innerHTML = kbds[kbd].Name;
-      KWControl.appendChild(opt);
-    }
-    document.f.multilingual.focus();
+  KWControl = document.getElementById('KWControl');
+  var kbds = keyman.getKeyboards();
+  for(var kbd in kbds)
+  {
+    var opt = document.createElement('OPTION');
+    opt.value = kbds[kbd].InternalName + "$$" + kbds[kbd].LanguageCode;
+    opt.innerHTML = kbds[kbd].Name;
+    KWControl.appendChild(opt);
+  }
+  document.f.multilingual.focus();
 
-    keyman.setActiveKeyboard('', '');
-  });
-}
+  keyman.setActiveKeyboard('', '');
+});
 
-function KWControlChange()
-{
+function KWControlChange() {
   var name = KWControl.value.substr(0, KWControl.value.indexOf("$$"));
   var languageCode = KWControl.value.substr(KWControl.value.indexOf("$$") + 2);
   keyman.setActiveKeyboard(name, languageCode);
   document.f.multilingual.focus();
 }
-
-window.addEventListener( 'load' , SetupDocument );
 
 </script>
 </head>

--- a/web/docs/engine/guide/examples/__manual-control.html
+++ b/web/docs/engine/guide/examples/__manual-control.html
@@ -1,29 +1,23 @@
+<!DOCTYPE html>
 <html>
 <head>
   <script src='https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js'></script>
-  <script>var kmw = keyman;</script>
 
   <script type='text/javascript' src='js/laokeys_load.js'></script>
 
   <script type="text/javascript">
-    function SetupDocument()
-    {
-      keyman.init().then(function() {
-        keyman.setActiveKeyboard('laokeys');
-        keyman.osk.hide();
-      });
-    }
+    keyman.init().then(function() {
+      keyman.setActiveKeyboard('laokeys');
+      keyman.osk.hide();
+    });
 
-    function KWControlClick()
-    {
+    function KWControlClick() {
       if(keyman.osk.isEnabled()) {
         keyman.osk.hide();
       } else {
         keyman.osk.show(true); // Specifies that the OSK should display whenever a valid control has focus, re-enabling the default behavior.
       }
     }
-
-    window.addEventListener('load', SetupDocument);
   </script>
 </head>
 <body>

--- a/web/docs/engine/guide/examples/automatic-control.md
+++ b/web/docs/engine/guide/examples/automatic-control.md
@@ -13,17 +13,15 @@ In this example, we use only the LaoKey keyboard. Please click [this link](./__a
   <!-- Start of Code -->
   <script src="js/keymanweb.js" type="text/javascript"></script>
   <script>
-    window.addEventListener('load', function () {
-      keyman.init().then(function() {
-        keyman.addKeyboards({
-          id:'laokeys',
-          name:'Lao (Phonetic)',
-          languages:{
-            id:'lo',
-            name:'Lao'
-          },
-          filename:'./js/laokeys.js'
-        });
+    keyman.init().then(function() {
+      keyman.addKeyboards({
+        id:'laokeys',
+        name:'Lao (Phonetic)',
+        languages:{
+          id:'lo',
+          name:'Lao'
+        },
+        filename:'./js/laokeys.js'
       });
     });
   </script>

--- a/web/docs/engine/guide/examples/automatic-control.md
+++ b/web/docs/engine/guide/examples/automatic-control.md
@@ -11,7 +11,7 @@ In this example, we use only the LaoKey keyboard. Please click [this link](./__a
 ```html
 <head>
   <!-- Start of Code -->
-  <script src="js/keymanweb.js" type="text/javascript"></script>
+  <script src="https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js" type="text/javascript"></script>
   <script>
     keyman.init().then(async function() {
       await keyman.addKeyboards({

--- a/web/docs/engine/guide/examples/automatic-control.md
+++ b/web/docs/engine/guide/examples/automatic-control.md
@@ -13,8 +13,8 @@ In this example, we use only the LaoKey keyboard. Please click [this link](./__a
   <!-- Start of Code -->
   <script src="js/keymanweb.js" type="text/javascript"></script>
   <script>
-    keyman.init().then(function() {
-      keyman.addKeyboards({
+    keyman.init().then(async function() {
+      await keyman.addKeyboards({
         id:'laokeys',
         name:'Lao (Phonetic)',
         languages:{

--- a/web/docs/engine/guide/examples/control-by-control.md
+++ b/web/docs/engine/guide/examples/control-by-control.md
@@ -35,15 +35,11 @@ Also include the following HTML code:
 ```html
 <head>
     <!-- Load the KeymanWeb engine -->
-    <script src="js/keymanweb.js" type="text/javascript"></script>
-    <script src="js/kmwuitoggle.js" type="text/javascript"></script>
+    <script src="https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js" type="text/javascript"></script>
+    <script src="https://s.keyman.com/kmw/engine/17.0.331/kmwuitoggle.js" type="text/javascript"></script>
     <!-- // Also be sure to load your keyboards.  Note that stubs will not work with this
          // example without detailing paths precisely in the init() call's parameter.-->
 </head>
-
-
-<!-- When the page has finished loading, advise KeymanWeb of control settings, see above -->
-<body>
 ```
 
 ---

--- a/web/docs/engine/guide/examples/control-by-control.md
+++ b/web/docs/engine/guide/examples/control-by-control.md
@@ -10,28 +10,23 @@ Include the following script in the HEAD of your page:
 
 ```js
 <script type="text/javascript">
-  function SetupDocument() {
-    keyman.init({
-      root: './',  // Note - if drawing the latest version of KeymanWeb from the CDN, this will
-                   // default to the source folder on our servers.
-      ui: 'toggle',
-      resources: './'
-    }).then(function() {
-      // Load the keyboards of your choice here.
-      loadKeyboards();
+  keyman.init({
+    root: './',  // Note - if drawing the latest version of KeymanWeb from the CDN, this will
+                  // default to the source folder on our servers.
+    ui: 'toggle',
+    resources: './'
+  }).then(async function() {
+    // Load the keyboards of your choice here.
+    await loadKeyboards();
 
-      /* Disable KeymanWeb interaction on the 'Email to' TEXT control */
-      keyman.disableControl(document.f.address);
-      /* Set the default keyboard for the 'Subject' TEXT control to 'off' (i.e. default browser keyboard) */
-      /* As KeymanWeb relies on the on-screen keyboard to change languages for touch-based devices, this will
-       * not work for them and will default to the first language added to KeymanWeb after initialization. */
-      keyman.setKeyboardForControl(document.f.subject, '', '');
-      /* Set the default keyboard for the 'Message body' TEXTAREA to the LaoKeys keyboard */
-      keyman.setKeyboardForControl(document.f.text, 'Keyboard_laokeys', 'lo');
-    });
-  }
-
-  window.addEventListener( 'load' , SetupDocument );
+    // Disable KeymanWeb interaction on the 'Email to' TEXT control
+    keyman.disableControl(document.f.address);
+    // Set the default keyboard for the 'Subject' TEXT control to 'off' (i.e. default
+    // browser keyboard)
+    keyman.setKeyboardForControl(document.f.subject, '', '');
+    // Set the default keyboard for the 'Message body' TEXTAREA to the LaoKeys keyboard
+    keyman.setKeyboardForControl(document.f.text, 'Keyboard_laokeys', 'lo');
+  });
 </script>
 ```
 
@@ -48,8 +43,9 @@ Also include the following HTML code:
 
 
 <!-- When the page has finished loading, advise KeymanWeb of control settings, see above -->
-<body onload="SetupDocument()">
+<body>
 ```
+
 ---
 **Note:** In this example we disabled the first element (`document.f.address`) by API call. A later API call can re-enable KeymanWeb for this control should it fit the page's design. Alternatively, this can be done by instead adding the class `'kmw-disabled'` to the control. This will permanently block KeymanWeb from handling its input.
 

--- a/web/docs/engine/guide/examples/full-manual-control.md
+++ b/web/docs/engine/guide/examples/full-manual-control.md
@@ -12,27 +12,23 @@ Include the following script in the HEAD of your page:
 <script>
   var KWControl = null;
 
-  /* SetupDocument: Called when the page finishes loading */
-  function SetupDocument()
-  {
-    keyman.init().then(function(){
-      // Load the keyboards of your choice here.
-      loadKeyboards();
+  keyman.init().then(async function() {
+    // Load the keyboards of your choice here.
+    await loadKeyboards();
 
-      KWControl = document.getElementById('KWControl');
-      var kbds = keyman.getKeyboards();
-      for(var kbd in kbds)
-      {
-        var opt = document.createElement('OPTION');
-        opt.value = kbds[kbd].InternalName + "$$" + kbds[kbd].LanguageCode;
-        opt.innerHTML = kbds[kbd].Name;
-        KWControl.appendChild(opt);
-      }
-      document.f.multilingual.focus();
+    KWControl = document.getElementById('KWControl');
+    var kbds = keyman.getKeyboards();
+    for(var kbd in kbds)
+    {
+      var opt = document.createElement('OPTION');
+      opt.value = kbds[kbd].InternalName + "$$" + kbds[kbd].LanguageCode;
+      opt.innerHTML = kbds[kbd].Name;
+      KWControl.appendChild(opt);
+    }
+    document.f.multilingual.focus();
 
-      keyman.setActiveKeyboard('', '');
-    });
-  }
+    keyman.setActiveKeyboard('', '');
+  });
 
   /* KWControlChange: Called when user selects an item in the KWControl SELECT */
   function KWControlChange()
@@ -59,7 +55,7 @@ Also include the following HTML code:
 </head>
 
 <!-- When the page has finished loading, populate the keyboard selector, see above -->
-<body onload="SetupDocument()">
+<body>
 ```
 
 - File: [unified_loader.js](js/unified_loader.js)

--- a/web/docs/engine/guide/examples/full-manual-control.md
+++ b/web/docs/engine/guide/examples/full-manual-control.md
@@ -47,14 +47,11 @@ Also include the following HTML code:
 ```html
 <head>
     <!-- Load the KeymanWeb engine -->
-    <script src="keymanweb.js" type="text/javascript"></script>
+    <script src="https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js" type="text/javascript"></script>
     <!-- Load the your keyboard stubs here -->
     <script src="unified_loader.js" type="text/javascript"></script>
     <!-- ... -->
 </head>
-
-<!-- When the page has finished loading, populate the keyboard selector, see above -->
-<body>
 ```
 
 - File: [unified_loader.js](js/unified_loader.js)

--- a/web/docs/engine/guide/examples/full-manual-control.md
+++ b/web/docs/engine/guide/examples/full-manual-control.md
@@ -18,8 +18,7 @@ Include the following script in the HEAD of your page:
 
     KWControl = document.getElementById('KWControl');
     var kbds = keyman.getKeyboards();
-    for(var kbd in kbds)
-    {
+    for(var kbd in kbds) {
       var opt = document.createElement('OPTION');
       opt.value = kbds[kbd].InternalName + "$$" + kbds[kbd].LanguageCode;
       opt.innerHTML = kbds[kbd].Name;

--- a/web/docs/engine/guide/examples/js/unified_loader.js
+++ b/web/docs/engine/guide/examples/js/unified_loader.js
@@ -1,16 +1,18 @@
-﻿/*(C) Copyright 2021 SIL International. All Rights Reserved. Details: keymanweb.com*/
-function loadKeyboards() {
-    // Uses an older type of keyboard stub definition.
-    var KWK={
-        "devanagari_inscript":{KN:"Devanagari (INSCRIPT)", KLC:"hi", KL:"Hindi"},
-        "european2":{KN:"EuroLatin2", KLC:"en", KL:"English"},
-        "hebrew":{KN:"Hebrew", KLC:"he", KL:"Hebrew"},
-        "korean_korda":{KN:"Korean (KORDA) - 30 Day Evaluation", KLC:"ko", KL:"Korean"},
-        "korean_morse":{KN:"Korean (Morse) - 30 Day Evaluation", KLC:"ko", KL:"Korean"},
-        "laokeys":{KN:"Lao (Phonetic)", KLC:"lo", KL:"Lao"}
-    };
+﻿/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
+async function loadKeyboards() {
+  const keyboardList = [
+    { id: 'devanagari_inscript', name: 'Devanagari (INSCRIPT)', languages: { id: 'hi', name: 'Hindi' }, filename: './js/devanagari_inscript.js' },
+    { id: 'european2', name: 'EuroLatin2', languages: { id: 'en', name: 'English' }, filename: './js/european2.js' },
+    { id: 'hebrew', name: 'Hebrew', languages: { id: 'he', name: 'Hebrew' }, filename: './js/hebrew.js' },
+    { id: 'korean_korda', name: 'Korean (KORDA)', languages: { id: 'ko', name: 'Korean' }, filename: './js/korean_korda.js' },
+    { id: 'korean_morse', name: 'Korean (Morse)', languages: { id: 'ko', name: 'Korean' }, filename: './js/korean_morse.js' },
+    // using a KeyboardStub would allow to customize e.g. which font the keyboard uses
+    { KF: "./js/laokeys.js", KI: "Keyboard_laokeys", KN: "Lao (Phonetic)", KL: "Lao", KLC: "lo" }
+  ];
 
-    for(var n in KWK) {
-        KeymanWeb.registerStub({KF:"./js/" + n+".js", KI:"Keyboard_"+n, KN:KWK[n].KN, KL:KWK[n].KL, KLC:KWK[n].KLC});
-    }
+  return keyman.addKeyboards(keyboardList).catch(function(err) {
+    console.error('keyman.addKeyboards failed with '+errToString(err)+' for '+JSON.stringify(keyboardList));
+  });
 }

--- a/web/docs/engine/guide/examples/manual-control.md
+++ b/web/docs/engine/guide/examples/manual-control.md
@@ -10,17 +10,10 @@ Include the following script in the HEAD of your page:
 
 ```js
 <script>
-  /* SetupDocument: Called when the page finishes loading */
-  function SetupDocument()
-  {
-    /* Make sure that Keyman is initialized (we can't guarantee initialization order) */
-    keyman.init().then(function () {
-      /* Prevents automatic display of the onscreen keyboard. (default automatic) */
-      keyman.osk.hide();
-      /* Select the LaoKeys keyboard */
+    keyman.init().then(function() {
       keyman.setActiveKeyboard('laokeys');
+      keyman.osk.hide();
     });
-  }
 
   /* KWControlClick: Called when user clicks on the KWControl IMG */
   function KWControlClick()
@@ -46,7 +39,7 @@ Also include the following HTML code:
 </head>
 
 <!-- When the page has finished loading, activate the LaoKeys keyboard, see above -->
-<body onload="SetupDocument()">
+<body>
 ```
 
 - File: [laokeys_load.js](js/laokeys_load.js)

--- a/web/docs/engine/guide/examples/manual-control.md
+++ b/web/docs/engine/guide/examples/manual-control.md
@@ -33,13 +33,10 @@ Also include the following HTML code:
 ```html
 <head>
     <!-- Load the KeymanWeb engine -->
-    <script src="keymanweb.js" type="text/javascript"></script>
+    <script src="https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js" type="text/javascript"></script>
     <!-- Load the LaoKeys keyboard stub -->
     <script src="laokeys_load.js" type="text/javascript"></script>
 </head>
-
-<!-- When the page has finished loading, activate the LaoKeys keyboard, see above -->
-<body>
 ```
 
 - File: [laokeys_load.js](js/laokeys_load.js)

--- a/web/docs/engine/guide/get-started.md
+++ b/web/docs/engine/guide/get-started.md
@@ -22,12 +22,10 @@ The source code for the page may be seen below.
   <script src='https://s.keyman.com/kmw/engine/18.0.245/keymanweb.js'></script>
   <script src='https://s.keyman.com/kmw/engine/18.0.245/kmwuitoggle.js'></script>
   <script>
-    (function() {
-      keyman.init({attachType:'auto'}).then(function() {
-        keyman.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
-        keyman.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
-      });
-    })(keyman);
+    keyman.init({attachType:'auto'}).then(async function() {
+      await keyman.addKeyboards('@en'); // Loads default English keyboard from Keyman Cloud (CDN)
+      await keyman.addKeyboards('@th'); // Loads default Thai keyboard from Keyman Cloud (CDN)
+    });
   </script>
 </head>
 <body>

--- a/web/docs/engine/reference/core/addKeyboards.md
+++ b/web/docs/engine/reference/core/addKeyboards.md
@@ -182,10 +182,4 @@ The `spec.languages.font` object contains the following members:
 
 ### Not passing any parameter
 
-Not passing any parameter will obtain the Keyman keyboards for English
-from the CDN, i.e. these two functions calls are identical:
-
-```js
-await keyman.addKeyboards();
-await keyman.addKeyboards('@en');
-```
+Not passing any parameter will obtain all Keyman keyboards from the CDN.

--- a/web/docs/engine/reference/core/addKeyboards.md
+++ b/web/docs/engine/reference/core/addKeyboards.md
@@ -9,7 +9,7 @@ Adds keyboards to KeymanWeb.
 ## Syntax
 
 ```js
-keyman.addKeyboards(spec[, spec...])
+await keyman.addKeyboards([spec...])
 ```
 
 ### Parameters
@@ -179,3 +179,13 @@ The `spec.languages.font` object contains the following members:
 : `string` <span class="optional">optional</span>
 
   Font size (in CSS dimensions). If not specified, then `1em` is used.
+
+### Not passing any parameter
+
+Not passing any parameter will obtain the Keyman keyboards for English
+from the CDN, i.e. these two functions calls are identical:
+
+```js
+await keyman.addKeyboards();
+await keyman.addKeyboards('@en');
+```

--- a/web/docs/engine/reference/core/addKeyboardsForLanguage.md
+++ b/web/docs/engine/reference/core/addKeyboardsForLanguage.md
@@ -9,7 +9,7 @@ Add default or all keyboards for a given language to KeymanWeb.
 ## Syntax
 
 ```js
-keyman.addKeyboardsForLanguage(spec[, spec...])
+await keyman.addKeyboardsForLanguage(spec[, spec...])
 ```
 
 ### Parameters

--- a/web/docs/engine/reference/core/getKeyboard.md
+++ b/web/docs/engine/reference/core/getKeyboard.md
@@ -8,7 +8,7 @@ Get keyboard meta data for the selected keyboard and language.
 
 ## Syntax
 
-```c
+```js
 keyman.getKeyboard(keyboardName, languageCode)
 ```
 
@@ -75,5 +75,5 @@ The `keyboard` object contains the following members:
 :   `string` *optional*
 :   The font packaged with the keyboard to properly display specialized OSK characters.
 
-## See also 
+## See also
 - [keyman.addKeyboards()](addKeyboards) and its documentation about keyboard specification objects.

--- a/web/docs/engine/reference/core/getKeyboards.md
+++ b/web/docs/engine/reference/core/getKeyboards.md
@@ -8,7 +8,7 @@ Get details of currently installed keyboards.
 
 ## Syntax
 
-```c
+```js
 keyman.getKeyboards()
 ```
 
@@ -25,5 +25,5 @@ None.
 
 See [keyman.getKeyboard()](getKeyboard) for detail on the returned keyboard specification objects.
 
-## See also 
+## See also
 - [keyman.addKeyboards()](addKeyboards)

--- a/web/docs/engine/reference/interface/registerStub.md
+++ b/web/docs/engine/reference/interface/registerStub.md
@@ -8,13 +8,13 @@ Registers the keyboard stub or returns true if already registered.
 
 ## Syntax
 
-```c
+```js
 keyman.interface.registerStub(Pstub);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KRS(Pstub); // Shorthand
 ```
 

--- a/web/src/app/ui/kmwuitoolbar.ts
+++ b/web/src/app/ui/kmwuitoolbar.ts
@@ -1150,8 +1150,8 @@ if(!keymanweb) {
         internalName: string,
         languageCode: string
       }) => {  // Uses a different format than .getKeyboards(), b/c why not?
-        // https://help.keyman.com/developer/engine/web/16.0/reference/core/getKeyboards vs
-        // https://help.keyman.com/developer/engine/web/16.0/reference/events/kmw.keyboardchange
+        // https://help.keyman.com/developer/engine/web/current-version/reference/core/getKeyboards vs
+        // https://help.keyman.com/developer/engine/web/current-version/reference/events/kmw.keyboardchange
         this.lastSelectedKeyboard = null;
         const kbName=p.internalName,
             lgName=keymanweb.util.getLanguageCodes(p.languageCode)[0];

--- a/web/src/samples/complex/root/pages/index.html
+++ b/web/src/samples/complex/root/pages/index.html
@@ -44,9 +44,9 @@
         // KMW will look for them here - two folders up from root, which is the base sample directory.
         keyboards: '/../../',
         attachType:'auto'
-      }).then(function() {
+      }).then(async function() {
         // Loads keyboards from the base sample folder
-        keyman.addKeyboards({
+        await keyman.addKeyboards({
           id:'us',
           name:'English',
           languages: {
@@ -57,7 +57,7 @@
           filename: 'us-1.0.js'
         });
         // For contrast:
-        keyman.addKeyboards({
+        await keyman.addKeyboards({
           id:'lao_2008_basic',
           name:'Lao Basic',
           languages: {
@@ -73,12 +73,12 @@
         // 1. keyboard name ('french'),
         // 2. keyboard name and language code ('sil_euro_latin@no,sv'),
         // 3. or just the BCP-47 language code ('@he').
-        keyman.addKeyboards('french', 'sil_euro_latin@no,sv', '@he');
+        await keyman.addKeyboards('french', 'sil_euro_latin@no,sv', '@he');
 
         // Add a keyboard by language name.  Note that the name must be spelled
         // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
         // usually easier.)
-        doAddKeyboardsForLanguage('Dzongkha');
+        await doAddKeyboardsForLanguage('Dzongkha');
       });
     </script>
 

--- a/web/src/samples/complex/root/pages/index.html
+++ b/web/src/samples/complex/root/pages/index.html
@@ -36,8 +36,7 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         root: '..',
         // Operates from the configured root set above - the 'root' folder for this sample.
         resources: '/resources',
@@ -74,7 +73,7 @@
         // 1. keyboard name ('french'),
         // 2. keyboard name and language code ('sil_euro_latin@no,sv'),
         // 3. or just the BCP-47 language code ('@he').
-        kmw.addKeyboards('french', 'sil_euro_latin@no,sv', '@he');
+        keyman.addKeyboards('french', 'sil_euro_latin@no,sv', '@he');
 
         // Add a keyboard by language name.  Note that the name must be spelled
         // correctly, or the keyboard will not be found.  (Using BCP-47 codes is

--- a/web/src/samples/samplehdr.js
+++ b/web/src/samples/samplehdr.js
@@ -43,9 +43,9 @@
   function errToString(err) {
     // Painful?  Kinda.  But needed on un-updated Android API 21!
     if(Array.isArray(err)) {
-      var result = '';
-      for(var i = 0; i < err.length; i++) {
-        var e = err[i];
+      let result = '';
+      for(let i = 0; i < err.length; i++) {
+        const e = err[i];
         if(e.error instanceof Error) {
           result += e.error.message + '\n';
         } else {
@@ -73,13 +73,13 @@
   }
 
   async function loadKeyboards(nestLevel) {
-    var base_prefix = '../';
-    var prefix = './'; // The default - when prefix == 0.
+    const base_prefix = '../';
+    let prefix = './'; // The default - when prefix == 0.
 
     if(nestLevel !== undefined && nestLevel > 0) {
       prefix = '';
-      for(var i=0; i < nestLevel; i++) {
-        prefix = prefix + base_prefix;
+      for(let i=0; i < nestLevel; i++) {
+        prefix += base_prefix;
       }
     }
 
@@ -116,29 +116,31 @@
   }
 
   // Script to allow a user to add any keyboard to the keyboard menu
-  function addKeyboard(n) {
-    var sKbd;
+  async function addKeyboard(n) {
+    let sKbd;
     switch(n) {
       case 1:
         sKbd=document.getElementById('kbd_id1').value;
-        doAddKeyboards(sKbd);
+        await doAddKeyboards(sKbd);
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        doAddKeyboards('@'+sKbd);
+        await doAddKeyboards('@'+sKbd);
         break;
       case 3:
         // Add keyboard for comma-separated language name(s)
         sKbd=document.getElementById('kbd_id3').value;
-        doAddKeyboardsForLanguage(sKbd);
+        await doAddKeyboardsForLanguage(sKbd);
         break;
     }
   }
 
   // Add keyboard on Enter (as well as pressing button)
-  function clickOnEnter(e,id)
+  async function clickOnEnter(e,id)
   {
     e = e || window.event;
-    if(e.keyCode == 13) addKeyboard(id);
+    if (e.keyCode == 13) {
+      await addKeyboard(id);
+    }
   }
 

--- a/web/src/samples/samplehdr.js
+++ b/web/src/samples/samplehdr.js
@@ -72,9 +72,7 @@
     });
   }
 
-  function loadKeyboards(nestLevel) {
-    var kmw=keyman;
-
+  async function loadKeyboards(nestLevel) {
     var base_prefix = '../';
     var prefix = './'; // The default - when prefix == 0.
 
@@ -88,22 +86,22 @@
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    doAddKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+    await doAddKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:(prefix + 'us-1.0.js')});
 
     // Add more keyboards to the language menu by:
     // 1. keyboard name ('french'),
     // 2. keyboard name and language code ('sil_euro_latin@no,sv'),
     // 3. or just the BCP-47 language code ('@he').
-    kmw.addKeyboards('french', 'sil_euro_latin@no,sv', '@he');
+    await keyman.addKeyboards('french', 'sil_euro_latin@no,sv', '@he');
 
     // Add a keyboard by language name.  Note that the name must be spelled
     // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
-    doAddKeyboardsForLanguage('Dzongkha');
+    await doAddKeyboardsForLanguage('Dzongkha');
 
     // Add a fully-specified, locally-sourced, keyboard with custom font
-    doAddKeyboards({
+    await doAddKeyboards({
       id:'lao_2008_basic',
       name:'Lao Basic',
       languages: {

--- a/web/src/samples/samplehdr.js
+++ b/web/src/samples/samplehdr.js
@@ -1,43 +1,54 @@
-// JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Keyboard management for KeymanWeb demonstration pages
+ */
 
 /*
-    The keyboard name and/or BCP-47 language code must be specified for each keyboard that is to be available.
-    If the same keyboard is used for several languages, it must be listed for each
-    language, but the keyboard itself will only be loaded once.
-    If two (or more) keyboards are to be available for a given language, both must be listed.
-    Any number of keyboards may be specified in one or more calls.
-    Keyboard paths may be absolute (with respect to the server root) or relative to the keyboards option path.
-    The actual keyboard object will be downloaded asynchronously when first selected for use.
+    The keyboard name and/or BCP-47 language code must be specified for
+    each keyboard that is to be available. If the same keyboard is used
+    for several languages, it must be listed for each language, but the
+    keyboard itself will only be loaded once. If two (or more) keyboards
+    are to be available for a given language, both must be listed. Any
+    number of keyboards may be specified in one or more calls. Keyboard
+    paths may be absolute (with respect to the server root) or relative
+    to the keyboards option path. The actual keyboard object will be
+    downloaded asynchronously when first selected for use.
 
-    Each argument to addKeyboards() is a string, for example:
-      european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fr      loads the current version of the Eurolatin 2 keyboard for French
-      european2@fr@1.2  loads version 1.2 of the Eurolatin 2 keyboard for French
+    Each argument to addKeyboards() is a string, for example: european2
+    loads the current version of the Eurolatin 2 keyboard (for its
+    default language) european2@fr      loads the current version of
+    the Eurolatin 2 keyboard for French european2@fr@1.2  loads
+    version 1.2 of the Eurolatin 2 keyboard for French
 
-    Argument syntax also supports the following extensions:
-      @fr               load the current version of the default keyboard for French
-      @fr$              load all available keyboards (current version) for French
+    Argument syntax also supports the following extensions: @fr
+    load the current version of the default keyboard for French @fr$
+    load all available keyboards (current version) for French
 
-    Each call to addKeyboards() requires a single call to the remote server,
-    (unless all keyboards listed are local and fully specified) so it is better
-    to use multiple arguments rather than separate function calls.
+    Each call to addKeyboards() requires a single call to the remote
+    server, (unless all keyboards listed are local and fully specified)
+    so it is better to use multiple arguments rather than separate
+    function calls.
 
-    Calling addKeyboards() with no arguments returns a list of *all* available keyboards.
-    The Toolbar (desktop browser) UI is best suited for allowing users to select
-    the appropriate language and keyboard in this case.
+    Calling addKeyboards() with no arguments returns a list of *all*
+    available keyboards. The Toolbar (desktop browser) UI is best suited
+    for allowing users to select the appropriate language and keyboard
+    in this case.
 
-    Keyboards may also be specified by language name using addKeyboardsForLanguage()
-    for example:
-      keymanweb.addKeyboardsForLanguage('Burmese');
+    Keyboards may also be specified by language name using
+    addKeyboardsForLanguage() for example:
+    keymanweb.addKeyboardsForLanguage('Burmese');
 
-    Appending $ to the language name will again cause all available keyboards for that
-    language to be loaded rather than the default keyboard.
+    Appending $ to the language name will again cause all available
+    keyboards for that language to be loaded rather than the default
+    keyboard.
 
-    The first call to addKeyboardsForLanguage() makes an additional call to the
-    keyman API to load the current list of keyboard/language associations.
+    The first call to addKeyboardsForLanguage() makes an additional call
+    to the keyman API to load the current list of keyboard/language
+    associations.
 
-    In this example, the following function loads the indicated keyboards,
-    and is called when the page loads.
+    In this example, the following function loads the indicated
+    keyboards, and is called when the page loads.
 */
 
   function errToString(err) {
@@ -102,12 +113,12 @@
 
     // Add a fully-specified, locally-sourced, keyboard with custom font
     await doAddKeyboards({
-      id:'lao_2008_basic',
-      name:'Lao Basic',
+      id: 'lao_2008_basic',
+      name: 'Lao Basic',
       languages: {
-        id:'lo',name:'Lao',region:'Asia',
+        id: 'lo', name: 'Lao', region: 'Asia'
       },
-      filename:(prefix + 'lao_2008_basic-1.2.js')
+      filename: (prefix + 'lao_2008_basic-1.2.js')
     });
 
     // Note that locally specified keyboards will be listed before keyboards

--- a/web/src/samples/simplest/index.html
+++ b/web/src/samples/simplest/index.html
@@ -36,8 +36,7 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
       }).then(function() {
         // Loads the common keyboards from the previous folder

--- a/web/src/samples/subfolder_toggle/index.html
+++ b/web/src/samples/subfolder_toggle/index.html
@@ -36,8 +36,7 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
       }).then(function() {
         // Loads the common keyboards from the previous folder

--- a/web/src/samples/subfolder_toolbar/index.html
+++ b/web/src/samples/subfolder_toolbar/index.html
@@ -30,8 +30,8 @@
     <script>
       keyman.init({
         attachType:'auto'
-      }).then(function() {
-        loadKeyboards();
+      }).then(async function() {
+        await loadKeyboards();
       });
     </script>
   <!--
@@ -43,10 +43,9 @@
     Keyboard paths may be absolute (with respect to the server root) or relative to the keyboards option path.
   -->
     <script>
-      function loadKeyboards() {
-        keyman.addKeyboards().then(function() {
-          keyman.setActiveKeyboard('basic_kbdus','en');
-        });
+      async function loadKeyboards() {
+        await keyman.addKeyboards();
+        await keyman.setActiveKeyboard('basic_kbdus','en');
       }
     </script>
 

--- a/web/src/samples/subfolder_toolbar/index.html
+++ b/web/src/samples/subfolder_toolbar/index.html
@@ -28,8 +28,7 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
       }).then(function() {
         loadKeyboards();

--- a/web/src/test/manual/web/attachment-api/index.html
+++ b/web/src/test/manual/web/attachment-api/index.html
@@ -40,9 +40,10 @@
       const attachType = (new URLSearchParams(window.location.search)).get("mode");
       var attachText = attachType ? attachType : "default";
 
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType: attachType ? attachType : ''
+      }).then(function() {
+        loadKeyboards(1);
       });
     </script>
 
@@ -56,7 +57,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards(1);'>
+  <body>
     <h2>KeymanWeb Sample Page - Attachment API Testing</h2>
 	<p>This page is designed to stress-test the new attachment/enablement API model and its functions.</p>
 	<p id="modeSelect">You are currently testing under the <em id="mode"> </em> attachment mode.  Two other modes are available:

--- a/web/src/test/manual/web/attachment-api/utilities.js
+++ b/web/src/test/manual/web/attachment-api/utilities.js
@@ -1,7 +1,6 @@
 // Page-global variable definitions.
 {
 var inputCounter = 0;
-var kmw = keyman;
 }
 
 function generateDiagnosticDiv(elem) {
@@ -23,8 +22,8 @@ function generateDiagnosticDiv(elem) {
   attachBtn.type     = 'button';
   attachBtn.id       = 'attach_' + elemId;
   attachBtn.onclick = function() {
-    kmw.attachToControl(document.getElementById(elemId));
-    var attached = kmw.isAttached(elem);
+    keyman.attachToControl(document.getElementById(elemId));
+    var attached = keyman.isAttached(elem);
     document.getElementById('attachment_' + elemId).textContent = " Currently " + (attached ? "attached." : "detached.");
     const indepLabel = document.getElementById("independence_" + elemId);
     // does not exist for iframes
@@ -40,8 +39,8 @@ function generateDiagnosticDiv(elem) {
   detachBtn.type     = 'button';
   detachBtn.id       = 'detach_' + elemId;
   detachBtn.onclick = function() {
-    kmw.detachFromControl(document.getElementById(elemId));
-    var attached = kmw.isAttached(elem);
+    keyman.detachFromControl(document.getElementById(elemId));
+    var attached = keyman.isAttached(elem);
     document.getElementById('attachment_' + elemId).textContent = " Currently " + (attached ? "attached." : "detached.");
     const indepLabel = document.getElementById("independence_" + elemId);
     // does not exist for iframes
@@ -58,7 +57,7 @@ function generateDiagnosticDiv(elem) {
   var attachLabel = document.createElement("a");
   attachLabel.id  = 'attachment_' + elemId;
   window.setTimeout(function() {
-    attachLabel.textContent = " Currently " + (kmw.isAttached(elem) ? "attached." : "detached.");
+    attachLabel.textContent = " Currently " + (keyman.isAttached(elem) ? "attached." : "detached.");
   }, attachTimer);
   div.appendChild(attachLabel);
 
@@ -69,7 +68,7 @@ function generateDiagnosticDiv(elem) {
   enableBtn.type     = 'button';
   enableBtn.id       = 'enable_' + elemId;
   enableBtn.onclick = function() {
-    kmw.enableControl(document.getElementById(elemId));
+    keyman.enableControl(document.getElementById(elemId));
   };
   enableBtn.value   = 'Enable';
   div.appendChild(enableBtn);
@@ -79,7 +78,7 @@ function generateDiagnosticDiv(elem) {
   disableBtn.type     = 'button';
   disableBtn.id       = 'disable_' + elemId;
   disableBtn.onclick = function() {
-    kmw.disableControl(document.getElementById(elemId));
+    keyman.disableControl(document.getElementById(elemId));
   };
   disableBtn.value   = 'Disable';
   div.appendChild(disableBtn);
@@ -107,9 +106,9 @@ function generateDiagnosticDiv(elem) {
     setBtn.type     = 'button';
     setBtn.id       = 'set_' + elemId;
     setBtn.onclick = function() {
-      kmw.setKeyboardForControl(document.getElementById(elemId), 'dzongkha', 'dz');
+      keyman.setKeyboardForControl(document.getElementById(elemId), 'dzongkha', 'dz');
 
-      if(kmw.isAttached(elem)) {
+      if(keyman.isAttached(elem)) {
         kbdLabel.textContent = " Using independently-tracked keyboard.";
       }
     };
@@ -121,9 +120,9 @@ function generateDiagnosticDiv(elem) {
     clearBtn.type     = 'button';
     clearBtn.id       = 'clear_' + elemId;
     clearBtn.onclick = function() {
-      kmw.setKeyboardForControl(document.getElementById(elemId), null, null);
+      keyman.setKeyboardForControl(document.getElementById(elemId), null, null);
 
-      if(kmw.isAttached(elem)) {
+      if(keyman.isAttached(elem)) {
         kbdLabel.textContent = " Using globally-selected keyboard.";
       }
     };
@@ -133,8 +132,8 @@ function generateDiagnosticDiv(elem) {
     var kbdLabel = document.createElement("a");
     kbdLabel.id  = 'independence_' + elemId;
     window.setTimeout(function () {
-      if(kmw.isAttached(elem)) {
-        var attached = kmw.isAttached(elem);
+      if(keyman.isAttached(elem)) {
+        var attached = keyman.isAttached(elem);
         kbdLabel.textContent = attached ? " Using globally-selected keyboard." : '';
       }
     }, 1);

--- a/web/src/test/manual/web/basic-iframe/index.html
+++ b/web/src/test/manual/web/basic-iframe/index.html
@@ -36,8 +36,9 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init();
+      keyman.init().then(function() {
+        loadKeyboards(1);
+      });
     </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->
@@ -46,7 +47,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards(1);'>
+  <body>
     <h2>KeymanWeb:  Test IFrame connectivity</h2>
 
     <div id='DynamicTextboxes'>

--- a/web/src/test/manual/web/build-visual-keyboard/index.html
+++ b/web/src/test/manual/web/build-visual-keyboard/index.html
@@ -75,8 +75,8 @@
 
         const container = document.createElement('div');
 
-        await kmw.addKeyboards(`${kbdid}@${langid}`);
-        await kmw.setActiveKeyboard(kbdid, langid);
+        await keyman.addKeyboards(`${kbdid}@${langid}`);
+        await keyman.setActiveKeyboard(kbdid, langid);
         docBase = keyman.BuildVisualKeyboard(kbdid, 1, formFactor, layer);
 
         label.textContent = `${keyman.getKeyboard(kbdid).Name} - ${formFactor} - ${layer} layer`;
@@ -94,6 +94,7 @@
       }
 
       keyman.init().then(async function() {
+        await loadKeyboards(1);
         await documentKeyboard("gff_amharic", "am", "phone", "default");
         await documentKeyboard("sil_euro_latin", "no", "phone", "shift");
         await documentKeyboard("lao_2008_basic", "lo", "tablet", "default");

--- a/web/src/test/manual/web/build-visual-keyboard/index.html
+++ b/web/src/test/manual/web/build-visual-keyboard/index.html
@@ -37,8 +37,6 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-
       var platform = 'desktop';
 
       keyman.getOskWidth = function() {
@@ -95,7 +93,7 @@
         shadowfy(container);
       }
 
-      kmw.init().then(async function() {
+      keyman.init().then(async function() {
         await documentKeyboard("gff_amharic", "am", "phone", "default");
         await documentKeyboard("sil_euro_latin", "no", "phone", "shift");
         await documentKeyboard("lao_2008_basic", "lo", "tablet", "default");
@@ -111,7 +109,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards(1);'>
+  <body>
     <h2>KeymanWeb:  Keyboard documentation rendering</h2>
 
     <div id='DynamicTextboxes'>

--- a/web/src/test/manual/web/chirality/index.html
+++ b/web/src/test/manual/web/chirality/index.html
@@ -38,9 +38,7 @@
     <script>
   keyman.init({
     attachType: 'auto'
-  }).then(function() {
-    loadKeyboards();
-  });
+  }).then(loadKeyboards);
     </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->

--- a/web/src/test/manual/web/chirality/index.html
+++ b/web/src/test/manual/web/chirality/index.html
@@ -36,9 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-  var kmw=window.keyman;
-  kmw.init({
+  keyman.init({
     attachType: 'auto'
+  }).then(function() {
+    loadKeyboards();
   });
     </script>
 
@@ -51,7 +52,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Sample Page - Chirality Testing</h2>
   <p>This page is designed to stress-test the new support for chiral modifiers and state keys.</p>
   <p>Be sure to reference the developer console for additional feedback.  </p>

--- a/web/src/test/manual/web/chirality/utilities.js
+++ b/web/src/test/manual/web/chirality/utilities.js
@@ -1,9 +1,7 @@
-function loadKeyboards() 
-{ 
-  var kmw=keyman;
-
+async function loadKeyboards()
+{
   // A testing keyboard handwritten with chirality information.
-  kmw.addKeyboards({id:'chirality',name:'Chirality Testing',
+  await keyman.addKeyboards({id:'chirality',name:'Chirality Testing',
     languages:{
       id:'en',name:'English',region:'North America'
     },
@@ -12,8 +10,8 @@ function loadKeyboards()
     
   // A testing keyboard using 10.0 format and the KLS layout specifier
   // without the 'shift' layer properly defined.
-  // Add a fully-specified, locally-sourced, keyboard with custom font  
-  kmw.addKeyboards({id:'halfDefined',name:'Undefined Shift Layer Keyboard',
+  // Add a fully-specified, locally-sourced, keyboard with custom font
+  await keyman.addKeyboards({id:'halfDefined',name:'Undefined Shift Layer Keyboard',
     languages:{
       id:'en',name:'English',region:'North America'
     },

--- a/web/src/test/manual/web/ckeditor/index.html
+++ b/web/src/test/manual/web/ckeditor/index.html
@@ -30,9 +30,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-  var kmw=window.keyman;
-  kmw.init({
+  keyman.init({
     attachType: 'auto'
+  }).then(function () {
+    loadKeyboards();
   });
     </script>
 
@@ -44,7 +45,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Sample Page - Test CKEditor Integration</h2>
 
     <p>Test CKEditor Integration</p>

--- a/web/src/test/manual/web/ckeditor/index.html
+++ b/web/src/test/manual/web/ckeditor/index.html
@@ -32,9 +32,7 @@
     <script>
   keyman.init({
     attachType: 'auto'
-  }).then(function () {
-    loadKeyboards();
-  });
+  }).then(loadKeyboards);
     </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->

--- a/web/src/test/manual/web/ckeditor/inline.html
+++ b/web/src/test/manual/web/ckeditor/inline.html
@@ -30,9 +30,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-  var kmw=window.keyman;
-  kmw.init({
+  keyman.init({
     attachType: 'auto'
+  }).then(function () {
+    loadKeyboards();
   });
     </script>
 
@@ -44,7 +45,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Sample Page - Test CKEditor Integration</h2>
 
     <p>Test CKEditor Integration</p>

--- a/web/src/test/manual/web/ckeditor/inline.html
+++ b/web/src/test/manual/web/ckeditor/inline.html
@@ -32,9 +32,7 @@
     <script>
   keyman.init({
     attachType: 'auto'
-  }).then(function () {
-    loadKeyboards();
-  });
+  }).then(loadKeyboards);
     </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->

--- a/web/src/test/manual/web/ckeditor/utilities.js
+++ b/web/src/test/manual/web/ckeditor/utilities.js
@@ -1,15 +1,13 @@
-function loadKeyboards()
+async function loadKeyboards()
 {
-  var kmw=keyman;
-
   // Add more keyboards to the language menu, by keyboard name,
   // keyboard name and language code, or just the BCP-47 language code.
   // We use a different loading pattern here than in the samples version to provide a slightly different set of test cases.
-  kmw.addKeyboards('french','@he');
-  kmw.addKeyboards({id:'sil_euro_latin', name:'SIL EuroLatin', languages: [{id:'no'}, {id:'sv'}]}); // Loads from partial stub instead of the compact string.
+  await keyman.addKeyboards('french', '@he',
+    { id: 'sil_euro_latin', name: 'SIL EuroLatin', languages: [{ id: 'no' }, { id: 'sv' }] }); // Loads from partial stub instead of the compact string.
 
   // Add a keyboard by language name.  Note that the name must be spelled
   // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
   // usually easier.)
-  kmw.addKeyboardsForLanguage('Dzongkha');
+  await keyman.addKeyboardsForLanguage('Dzongkha');
 }

--- a/web/src/test/manual/web/commonHeader.js
+++ b/web/src/test/manual/web/commonHeader.js
@@ -74,8 +74,6 @@
 
   function loadKeyboards(nestLevel)
   {
-    var kmw=keyman;
-
     var base_prefix = '../';
     var prefix = './'; // The default - when prefix == 0.
 
@@ -133,8 +131,8 @@
     // The following two optional calls should be delayed until language menus are fully loaded:
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.
-    //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-    //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
+    //window.setTimeout(function(){keyman.setActiveElement('ta1',true);},2500);
+    //window.setTimeout(function(){keyman.setActiveKeyboard('Keyboard_french','fr');},3000);
 
     // Note that locally specified keyboards will be listed before keyboards
     // requested from the remote server by user interfaces that do not order
@@ -144,7 +142,7 @@
   // Script to allow a user to add any keyboard to the keyboard menu
   function addKeyboard(n)
   {
-    var sKbd,kmw=keyman;
+    var sKbd;
     switch(n)
     {
       case 1:

--- a/web/src/test/manual/web/commonHeader.js
+++ b/web/src/test/manual/web/commonHeader.js
@@ -1,170 +1,122 @@
-// JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
-
 /*
-    The keyboard name and/or BCP-47 language code must be specified for each keyboard that is to be available.
-    If the same keyboard is used for several languages, it must be listed for each
-    language, but the keyboard itself will only be loaded once.
-    If two (or more) keyboards are to be available for a given language, both must be listed.
-    Any number of keyboards may be specified in one or more calls.
-    Keyboard paths may be absolute (with respect to the server root) or relative to the keyboards option path.
-    The actual keyboard object will be downloaded asynchronously when first selected for use.
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
 
-    Each argument to addKeyboards() is a string, for example:
-      european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fr      loads the current version of the Eurolatin 2 keyboard for French
-      european2@fr@1.2  loads version 1.2 of the Eurolatin 2 keyboard for French
-
-    Argument syntax also supports the following extensions:
-      @fr               load the current version of the default keyboard for French
-      @fr$              load all available keyboards (current version) for French
-
-    Each call to addKeyboards() requires a single call to the remote server,
-    (unless all keyboards listed are local and fully specified) so it is better
-    to use multiple arguments rather than separate function calls.
-
-    Calling addKeyboards() with no arguments returns a list of *all* available keyboards.
-    The Toolbar (desktop browser) UI is best suited for allowing users to select
-    the appropriate language and keyboard in this case.
-
-    Keyboards may also be specified by language name using addKeyboardsForLanguage()
-    for example:
-      keymanweb.addKeyboardsForLanguage('Burmese');
-
-    Appending $ to the language name will again cause all available keyboards for that
-    language to be loaded rather than the default keyboard.
-
-    The first call to addKeyboardsForLanguage() makes an additional call to the
-    keyman API to load the current list of keyboard/language associations.
-
-    In this example, the following function loads the indicated keyboards,
-    and is called when the page loads.
-*/
-
-  function errToString(err) {
-    // Painful?  Kinda.  But needed on un-updated Android API 21!
-    if(Array.isArray(err)) {
-      var result = '';
-      for(var i = 0; i < err.length; i++) {
-        var e = err[i];
-        if(e.error instanceof Error) {
-          result += e.error.message + '\n';
-        } else {
-          result += JSON.stringify(e) + '\n';
-        }
-      }
-      return result;
-    }
-    if(err instanceof Error) {
-      return err.message;
-    }
-    return JSON.stringify(err);
-  }
-
-  function doAddKeyboards(data) {
-    return keyman.addKeyboards(data).catch(function(err) {
-      console.error('keyman.addKeyboards failed with '+errToString(err)+' for '+JSON.stringify(data));
-    });
-  }
-
-  function doAddKeyboardsForLanguage(data) {
-    return keyman.addKeyboardsForLanguage(data).catch(function(err) {
-      console.error('keyman.addKeyboardsForLanguage failed with '+errToString(err)+' for '+JSON.stringify(data));
-    });
-  }
-
-  function loadKeyboards(nestLevel)
-  {
-    var base_prefix = '../';
-    var prefix = './'; // The default - when prefix == 0.
-
-    if(nestLevel !== undefined && nestLevel > 0) {
-      prefix = '';
-      for(var i=0; i < nestLevel; i++) {
-        prefix = prefix + base_prefix;
+function errToString(err) {
+  // Painful?  Kinda.  But needed on un-updated Android API 21!
+  if(Array.isArray(err)) {
+    let result = '';
+    for(let i = 0; i < err.length; i++) {
+      const e = err[i];
+      if(e.error instanceof Error) {
+        result += e.error.message + '\n';
+      } else {
+        result += JSON.stringify(e) + '\n';
       }
     }
-
-    // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keyboard to be
-    // locally sourced.
-    doAddKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
-      filename:(prefix + 'us-1.0.js')});
-
-    doAddKeyboards({id:'web_context_tests',name:'Web Context Tests',languages:{id:'en',name:'English'},
-      filename:(prefix + 'web_context_tests.js')});
-
-    doAddKeyboards({id:'test_chirality',name:'test_chirality',languages:{id:'en',name:'English'},
-      filename:(prefix + 'test_chirality.js')});
-
-    doAddKeyboards({id:'obolo_chwerty_6351',name:'obolo_chwerty_6351',languages:{id:'en',name:'English'},
-      filename:(prefix + 'obolo_chwerty_6351.js')});
-
-    doAddKeyboards({id:'gesture_prototyping',name:'Gesture Prototyping',languages:{id:'en',name:'English'},
-      filename:(prefix + 'keyboards/gesture_prototyping/build/gesture_prototyping.js')});
-
-    doAddKeyboards({id:'diacritic_rota',name:'Diacritic 10-key Rota',languages:{id:'en',name:'English'},
-      filename:(prefix + 'keyboards/diacritic_rota/build/diacritic_rota.js')});
-
-    doAddKeyboards({id:'ye_old_ten_key',name:'Classic 10-key',languages:{id:'en',name:'English'},
-      filename:(prefix + 'keyboards/ye_old_ten_key/build/ye_old_ten_key.js')});
-
-      // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the BCP-47 language code.
-    // We use a different loading pattern here than in the samples version to provide a slightly different set of test cases.
-    doAddKeyboards('french','@he');
-    doAddKeyboards('khmer_angkor','@km');
-    doAddKeyboards({id:'sil_euro_latin', name:'SIL EuroLatin', languages: [{id:'no'}, {id:'sv'}]}); // Loads from partial stub instead of the compact string.
-
-    // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
-    // usually easier.)
-    doAddKeyboardsForLanguage('Dzongkha');
-
-    // Add a fully-specified, locally-sourced, keyboard with custom font
-    doAddKeyboards({id:'lao_2008_basic',name:'Lao Basic',
-      languages: {
-          id:'lo',name:'Lao',region:'Asia',
-        },
-      filename:(prefix + 'lao_2008_basic-1.2.js')
-      });
-
-    // The following two optional calls should be delayed until language menus are fully loaded:
-    //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
-    //  (b) a specific keyboard is loaded, rather than the keyboard last used.
-    //window.setTimeout(function(){keyman.setActiveElement('ta1',true);},2500);
-    //window.setTimeout(function(){keyman.setActiveKeyboard('Keyboard_french','fr');},3000);
-
-    // Note that locally specified keyboards will be listed before keyboards
-    // requested from the remote server by user interfaces that do not order
-    // keyboards alphabetically by language.
+    return result;
   }
+  if(err instanceof Error) {
+    return err.message;
+  }
+  return JSON.stringify(err);
+}
 
-  // Script to allow a user to add any keyboard to the keyboard menu
-  function addKeyboard(n)
-  {
-    var sKbd;
-    switch(n)
-    {
-      case 1:
-        sKbd=document.getElementById('kbd_id1').value;
-        doAddKeyboards(sKbd);
-        break;
-      case 2:
-        sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        doAddKeyboards('@'+sKbd);
-        break;
-      case 3:
-        // Add keyboard for comma-separated language name(s)
-        sKbd=document.getElementById('kbd_id3').value;
-        doAddKeyboardsForLanguage(sKbd);
-        break;
+function doAddKeyboards(data) {
+  return keyman.addKeyboards(data).catch(function(err) {
+    console.error('keyman.addKeyboards failed with '+errToString(err)+' for '+JSON.stringify(data));
+  });
+}
+
+function doAddKeyboardsForLanguage(data) {
+  return keyman.addKeyboardsForLanguage(data).catch(function(err) {
+    console.error('keyman.addKeyboardsForLanguage failed with '+errToString(err)+' for '+JSON.stringify(data));
+  });
+}
+
+async function loadKeyboards(nestLevel) {
+  const base_prefix = '../';
+  let prefix = './'; // The default - when prefix == 0.
+
+  if(nestLevel !== undefined && nestLevel > 0) {
+    prefix = '';
+    for(let i=0; i < nestLevel; i++) {
+      prefix += base_prefix;
     }
   }
 
-  // Add keyboard on Enter (as well as pressing button)
-  function clickOnEnter(e,id)
-  {
-    e = e || window.event;
-    if(e.keyCode == 13) addKeyboard(id);
+  // The first keyboard added will be the default keyboard for touch devices.
+  // For faster loading, it may be best for the default keyboard to be
+  // locally sourced.
+  await doAddKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+    filename:(prefix + 'us-1.0.js')});
+
+  await doAddKeyboards({id:'web_context_tests',name:'Web Context Tests',languages:{id:'en',name:'English'},
+    filename:(prefix + 'web_context_tests.js')});
+
+  await doAddKeyboards({id:'test_chirality',name:'test_chirality',languages:{id:'en',name:'English'},
+    filename:(prefix + 'test_chirality.js')});
+
+  await doAddKeyboards({id:'obolo_chwerty_6351',name:'obolo_chwerty_6351',languages:{id:'en',name:'English'},
+    filename:(prefix + 'obolo_chwerty_6351.js')});
+
+  await doAddKeyboards({id:'gesture_prototyping',name:'Gesture Prototyping',languages:{id:'en',name:'English'},
+    filename:(prefix + 'keyboards/gesture_prototyping/build/gesture_prototyping.js')});
+
+  await doAddKeyboards({id:'diacritic_rota',name:'Diacritic 10-key Rota',languages:{id:'en',name:'English'},
+    filename:(prefix + 'keyboards/diacritic_rota/build/diacritic_rota.js')});
+
+  await doAddKeyboards({id:'ye_old_ten_key',name:'Classic 10-key',languages:{id:'en',name:'English'},
+    filename:(prefix + 'keyboards/ye_old_ten_key/build/ye_old_ten_key.js')});
+
+  // Add more keyboards to the language menu, by keyboard name,
+  // keyboard name and language code, or just the BCP-47 language code.
+  // We use a different loading pattern here than in the samples version to provide a slightly different set of test cases.
+  await doAddKeyboards('french','@he');
+  await doAddKeyboards('khmer_angkor','@km');
+  await doAddKeyboards({id:'sil_euro_latin', name:'SIL EuroLatin', languages: [{id:'no'}, {id:'sv'}]}); // Loads from partial stub instead of the compact string.
+
+  // Add a keyboard by language name.  Note that the name must be spelled
+  // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
+  // usually easier.)
+  await doAddKeyboardsForLanguage('Dzongkha');
+
+  // Add a fully-specified, locally-sourced, keyboard with custom font
+  await doAddKeyboards({
+    id: 'lao_2008_basic',
+    name: 'Lao Basic',
+    languages: {
+        id: 'lo', name: 'Lao', region: 'Asia'
+    },
+    filename: (prefix + 'lao_2008_basic-1.2.js')
+  });
+}
+
+// Script to allow a user to add any keyboard to the keyboard menu
+async function addKeyboard(n) {
+  let sKbd;
+  switch(n) {
+    case 1:
+      sKbd=document.getElementById('kbd_id1').value;
+      await doAddKeyboards(sKbd);
+      break;
+    case 2:
+      sKbd=document.getElementById('kbd_id2').value.toLowerCase();
+      await doAddKeyboards('@'+sKbd);
+      break;
+    case 3:
+      // Add keyboard for comma-separated language name(s)
+      sKbd=document.getElementById('kbd_id3').value;
+      await doAddKeyboardsForLanguage(sKbd);
+      break;
   }
+}
+
+// Add keyboard on Enter (as well as pressing button)
+async function clickOnEnter(e,id) {
+  e = e || window.event;
+  if (e.keyCode == 13) {
+    await addKeyboard(id);
+  }
+}
 

--- a/web/src/test/manual/web/default-subkey/index.html
+++ b/web/src/test/manual/web/default-subkey/index.html
@@ -36,11 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
 		    attachType:'auto'
       }).then(function() {
-        kmw.addKeyboards({id:'default_subkey',name:'English',languages:{id:'en',name:'English'}, filename:'./default_subkey.js'});
+        keyman.addKeyboards({id:'default_subkey',name:'English',languages:{id:'en',name:'English'}, filename:'./default_subkey.js'});
 
         var pageRef = (window.location.protocol == 'file:')
           ? window.location.href.substr(0, window.location.href.lastIndexOf('/')+1)

--- a/web/src/test/manual/web/default-subkey/index.html
+++ b/web/src/test/manual/web/default-subkey/index.html
@@ -38,8 +38,8 @@
     <script>
       keyman.init({
 		    attachType:'auto'
-      }).then(function() {
-        keyman.addKeyboards({id:'default_subkey',name:'English',languages:{id:'en',name:'English'}, filename:'./default_subkey.js'});
+      }).then(async function() {
+        await keyman.addKeyboards({id:'default_subkey',name:'English',languages:{id:'en',name:'English'}, filename:'./default_subkey.js'});
 
         var pageRef = (window.location.protocol == 'file:')
           ? window.location.href.substr(0, window.location.href.lastIndexOf('/')+1)

--- a/web/src/test/manual/web/desktop-ui/button.html
+++ b/web/src/test/manual/web/desktop-ui/button.html
@@ -39,8 +39,7 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
       }).then(function() {
         loadKeyboards(1);

--- a/web/src/test/manual/web/desktop-ui/float.html
+++ b/web/src/test/manual/web/desktop-ui/float.html
@@ -39,8 +39,7 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
       }).then(function() {
         loadKeyboards(1);

--- a/web/src/test/manual/web/desktop-ui/toggle.html
+++ b/web/src/test/manual/web/desktop-ui/toggle.html
@@ -39,9 +39,8 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
-		    attachType:'auto'
+      keyman.init({
+        attachType:'auto'
       }).then(function() {
         loadKeyboards(1);
       });

--- a/web/src/test/manual/web/desktop-ui/toolbar.html
+++ b/web/src/test/manual/web/desktop-ui/toolbar.html
@@ -38,8 +38,8 @@
     <script>
       keyman.init({
         attachType:'auto'
-      }).then(function () {
-        keyman.addKeyboards();
+      }).then(async function () {
+        await keyman.addKeyboards();
       });
     </script>
   </head>

--- a/web/src/test/manual/web/desktop-ui/toolbar.html
+++ b/web/src/test/manual/web/desktop-ui/toolbar.html
@@ -36,15 +36,16 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
+      }).then(function () {
+        keyman.addKeyboards();
       });
     </script>
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='kmw.addKeyboards();'>
+  <body>
     <h2>KeymanWeb Testing Page - Desktop UI module Testing</h2>
     <p>This page is designed to facilitate testing of various aspects of the Toolbar UI for
       KeymanWeb.  Originally developed to help address issue #1275.

--- a/web/src/test/manual/web/empty-row/index.html
+++ b/web/src/test/manual/web/empty-row/index.html
@@ -36,18 +36,16 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType: 'auto'
       }).then(function() {
         // A testing keyboard with empty rows on each layer
-        kmw.addKeyboards({id:'empty_row', name: 'Empty Row',
+        keyman.addKeyboards({id:'empty_row', name: 'Empty Row',
           languages:{
             id:'en', name:'English'
           },
           filename: 'empty_row-1.0.js'
-        });
-        kmw.addKeyboards({id:'afghan_turkmen', name:'Afghan Turkmen',
+        }, {id:'afghan_turkmen', name:'Afghan Turkmen',
           languages:{
             id:'tk-Arab', name:'Turkmen (Arabic)'
           },

--- a/web/src/test/manual/web/init-race-10743/index.html
+++ b/web/src/test/manual/web/init-race-10743/index.html
@@ -36,9 +36,8 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
       window.setTimeout(() => {
-        kmw.init({
+        keyman.init({
           attachType:'auto',
         }).then(function() {
           loadKeyboards(1);

--- a/web/src/test/manual/web/inline-osk/index.html
+++ b/web/src/test/manual/web/inline-osk/index.html
@@ -49,8 +49,7 @@
         document.getElementById('ta1').focus();
       }
 
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
       }).then(function() {
         setOSK('windows');

--- a/web/src/test/manual/web/issue005/header.js
+++ b/web/src/test/manual/web/issue005/header.js
@@ -1,120 +1,63 @@
-// JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
-
 /*
-    The keyboard name and/or BCP-47 language code must be specified for each keyboard that is to be available.
-    If the same keyboard is used for several languages, it must be listed for each
-    language, but the keyboard itself will only be loaded once.
-    If two (or more) keyboards are to be available for a given language, both must be listed.
-    Any number of keyboards may be specified in one or more calls.
-    Keyboard paths may be absolute (with respect to the server root) or relative to the keyboards option path.
-    The actual keyboard object will be downloaded asynchronously when first selected for use.
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
+async function loadKeyboards()
+{
+  await keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+    filename:'../us-1.0.js'});
+  await keyman.addKeyboards('french','european2@sv','european2@no','@he');
+  await keyman.addKeyboardsForLanguage('Dzongkha');
+  await keyman.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
+    languages:{
+      id:'lo',name:'Lao',region:'Asia',
+      font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
+      },
+    filename:'../lao_2008_basic-1.2.js'
+  });
+}
 
-    Each argument to addKeyboards() is a string, for example:
-      european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fr      loads the current version of the Eurolatin 2 keyboard for French
-      european2@fr@1.2  loads version 1.2 of the Eurolatin 2 keyboard for French
-
-    Argument syntax also supports the following extensions:
-      @fr               load the current version of the default keyboard for French
-      @fr$              load all available keyboards (current version) for French
-
-    Each call to addKeyboards() requires a single call to the remote server,
-    (unless all keyboards listed are local and fully specified) so it is better
-    to use multiple arguments rather than separate function calls.
-
-    Calling addKeyboards() with no arguments returns a list of *all* available keyboards.
-    The Toolbar (desktop browser) UI is best suited for allowing users to select
-    the appropriate language and keyboard in this case.
-
-    Keyboards may also be specified by language name using addKeyboardsForLanguage()
-    for example:
-      keymanweb.addKeyboardsForLanguage('Burmese');
-
-    Appending $ to the language name will again cause all available keyboards for that
-    language to be loaded rather than the default keyboard.
-
-    The first call to addKeyboardsForLanguage() makes an additional call to the
-    keyman API to load the current list of keyboard/language associations.
-
-    In this example, the following function loads the indicated keyboards,
-    and is called when the page loads.
-*/
-
-  async function loadKeyboards()
+// Script to allow a user to add any keyboard to the keyboard menu
+async function addKeyboard(n)
+{
+  let sKbd;
+  switch(n)
   {
-    // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keyboard to be
-    // locally sourced.
-    await keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
-      filename:'../us-1.0.js'});
-
-    // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the BCP-47 language code.
-    await keyman.addKeyboards('french','european2@sv','european2@no','@he');
-
-    // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
-    // usually easier.)
-    await keyman.addKeyboardsForLanguage('Dzongkha');
-
-    // Add a fully-specified, locally-sourced, keyboard with custom font
-    await keyman.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
-      languages:{
-        id:'lo',name:'Lao',region:'Asia',
-        font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
-        },
-      filename:'../lao_2008_basic-1.2.js'
-    });
-
-    // The following two optional calls should be delayed until language menus are fully loaded:
-    //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
-    //  (b) a specific keyboard is loaded, rather than the keyboard last used.
-    //window.setTimeout(function(){keyman.setActiveElement('ta1',true);},2500);
-    //window.setTimeout(function(){keyman.setActiveKeyboard('Keyboard_french','fr');},3000);
-
-    // Note that locally specified keyboards will be listed before keyboards
-    // requested from the remote server by user interfaces that do not order
-    // keyboards alphabetically by language.
+    case 1:
+      sKbd=document.getElementById('kbd_id1').value;
+      await keyman.addKeyboards(sKbd);
+      break;
+    case 2:
+      sKbd=document.getElementById('kbd_id2').value.toLowerCase();
+      await keyman.addKeyboards('@'+sKbd);
+      break;
+    case 3:
+      sKbd=document.getElementById('kbd_id3').value;
+      await keyman.addKeyboardsForLanguage(sKbd);
+      break;
   }
+}
 
-  // Script to allow a user to add any keyboard to the keyboard menu
-  async function addKeyboard(n)
-  {
-    var sKbd;
-    switch(n)
-    {
-      case 1:
-        sKbd=document.getElementById('kbd_id1').value;
-        await keyman.addKeyboards(sKbd);
-        break;
-      case 2:
-        sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        await keyman.addKeyboards('@'+sKbd);
-        break;
-      case 3:
-        sKbd=document.getElementById('kbd_id3').value;
-        await keyman.addKeyboardsForLanguage(sKbd);
-        break;
-    }
+// Add keyboard on Enter (as well as pressing button)
+async function clickOnEnter(e,id)
+{
+  e = e || window.event;
+  if (e.keyCode == 13) {
+    await addKeyboard(id);
   }
+}
 
-  // Add keyboard on Enter (as well as pressing button)
-  async function clickOnEnter(e,id)
-  {
-    e = e || window.event;
-    if(e.keyCode == 13) await addKeyboard(id);
+async function removeKeyboard() {
+  let sKbd = document.getElementById('kbd_id4').value;
+  let result = await keyman.removeKeyboards(sKbd);
+
+  console.log("Keyboard '" + sKbd + "' removal success: " + result);
+}
+
+// Removes keyboard on Enter (as well as pressing button)
+async function removeOnEnter(e)
+{
+  e = e || window.event;
+  if(e.keyCode == 13) {
+    await removeKeyboard();
   }
-
-  async function removeKeyboard() {
-    var sKbd = document.getElementById('kbd_id4').value;
-    var result = await keyman.removeKeyboards(sKbd);
-
-    console.log("Keyboard '" + sKbd + "' removal success: " + result);
-  }
-
-  // Removes keyboard on Enter (as well as pressing button)
-  async function removeOnEnter(e)
-  {
-    e = e || window.event;
-    if(e.keyCode == 13) await removeKeyboard();
-  }
+}

--- a/web/src/test/manual/web/issue005/header.js
+++ b/web/src/test/manual/web/issue005/header.js
@@ -40,27 +40,25 @@
     and is called when the page loads.
 */
 
-  function loadKeyboards()
+  async function loadKeyboards()
   {
-    var kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
-
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+    await keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
 
     // Add more keyboards to the language menu, by keyboard name,
     // keyboard name and language code, or just the BCP-47 language code.
-    kmw.addKeyboards('french','european2@sv','european2@no','@he');
+    await keyman.addKeyboards('french','european2@sv','european2@no','@he');
 
     // Add a keyboard by language name.  Note that the name must be spelled
     // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
-    kmw.addKeyboardsForLanguage('Dzongkha');
+    await keyman.addKeyboardsForLanguage('Dzongkha');
 
     // Add a fully-specified, locally-sourced, keyboard with custom font
-    kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
+    await keyman.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
         id:'lo',name:'Lao',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
@@ -71,8 +69,8 @@
     // The following two optional calls should be delayed until language menus are fully loaded:
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.
-    //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-    //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
+    //window.setTimeout(function(){keyman.setActiveElement('ta1',true);},2500);
+    //window.setTimeout(function(){keyman.setActiveKeyboard('Keyboard_french','fr');},3000);
 
     // Note that locally specified keyboards will be listed before keyboards
     // requested from the remote server by user interfaces that do not order
@@ -80,45 +78,43 @@
   }
 
   // Script to allow a user to add any keyboard to the keyboard menu
-  function addKeyboard(n)
+  async function addKeyboard(n)
   {
-    var sKbd, kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
+    var sKbd;
     switch(n)
     {
       case 1:
         sKbd=document.getElementById('kbd_id1').value;
-        kmw.addKeyboards(sKbd);
+        await keyman.addKeyboards(sKbd);
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        kmw.addKeyboards('@'+sKbd);
+        await keyman.addKeyboards('@'+sKbd);
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;
-        kmw.addKeyboardsForLanguage(sKbd);
+        await keyman.addKeyboardsForLanguage(sKbd);
         break;
     }
   }
 
   // Add keyboard on Enter (as well as pressing button)
-  function clickOnEnter(e,id)
+  async function clickOnEnter(e,id)
   {
     e = e || window.event;
-    if(e.keyCode == 13) addKeyboard(id);
+    if(e.keyCode == 13) await addKeyboard(id);
   }
 
-  function removeKeyboard() {
-    var kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
-
+  async function removeKeyboard() {
     var sKbd = document.getElementById('kbd_id4').value;
-    var result = kmw.removeKeyboards(sKbd);
+    var result = await keyman.removeKeyboards(sKbd);
 
     console.log("Keyboard '" + sKbd + "' removal success: " + result);
   }
 
   // Removes keyboard on Enter (as well as pressing button)
-  function removeOnEnter(e)
+  async function removeOnEnter(e)
   {
     e = e || window.event;
-    if(e.keyCode == 13) removeKeyboard();
+    if(e.keyCode == 13) await removeKeyboard();
   }

--- a/web/src/test/manual/web/issue005/index.html
+++ b/web/src/test/manual/web/issue005/index.html
@@ -34,12 +34,14 @@
     -->
     <script src="../../../../../build/publish/debug/kmwuitoggle.js"></script>
 
-    <!-- Initialization: set paths to keyboards, resources and fonts as required -->
-    <script>
-      keyman.init({
-        attachType:'auto'
-      });
-    </script>
+  <!-- Initialization: set paths to keyboards, resources and fonts as required -->
+  <script>
+    keyman.init({
+      attachType: 'auto'
+    }).then(function () {
+      loadKeyboards();
+    });
+  </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->
     <script src="./header.js"></script>
@@ -47,7 +49,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb:  'Test case' for proper implementation of the removeKeyboards API function</h2>
 
     <div id='DynamicTextboxes'>

--- a/web/src/test/manual/web/issue103/index.html
+++ b/web/src/test/manual/web/issue103/index.html
@@ -38,8 +38,8 @@
     <script>
       keyman.init({
         attachType:'auto'
-      }).then(function () {
-        loadKeyboards();
+      }).then(async function () {
+        await loadKeyboards();
       });
     </script>
 

--- a/web/src/test/manual/web/issue103/index.html
+++ b/web/src/test/manual/web/issue103/index.html
@@ -36,10 +36,11 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
-        });
+      }).then(function () {
+        loadKeyboards();
+      });
     </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->
@@ -48,7 +49,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Sample Page - Keyboard Registration Check</h2>
     <p>
       This page is designed to test KeymanWeb's behavior when being told to load a keyboard multiple times, both via

--- a/web/src/test/manual/web/issue103/samplehdr.js
+++ b/web/src/test/manual/web/issue103/samplehdr.js
@@ -1,68 +1,64 @@
-// Modified version of commonHeader - contains repeated requests for the same language.
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Modified version of commonHeader.js - contains repeated requests for the same language.
+ */
 
-  async function loadKeyboards() {
-    // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keyboard to be
-    // locally sourced.
-    await keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
-      filename:'../us-1.0.js'});
+async function loadKeyboards() {
+  await keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+    filename:'../us-1.0.js'});
 
-    // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the BCP-47 language code.
-    await keyman.addKeyboards('french','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@no','@he');
-    await keyman.addKeyboards('@he');
-    await keyman.addKeyboards('@he');
+  // Intentionally request the same keyboard multiple times to test that it
+  // is not added multiple times and doesn't cause an error.
+  await keyman.addKeyboards('french', 'european2@sv', 'european2@sv', 'european2@sv',
+    'european2@sv', 'european2@sv', 'european2@sv', 'european2@no', '@he');
+  await keyman.addKeyboards('@he');
+  await keyman.addKeyboards('@he'); // intentional duplicate
 
-    // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
-    // usually easier.)
-    await keyman.addKeyboardsForLanguage('Dzongkha');
+  // Add a keyboard by language name.  Note that the name must be spelled
+  // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
+  // usually easier.)
+  await keyman.addKeyboardsForLanguage('Dzongkha');
 
-    // Add a fully-specified, locally-sourced, keyboard with custom font
-    await keyman.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
-      languages:{
-        id:'lo',name:'Lao',region:'Asia'
-        },
-      filename:'../lao_2008_basic.js'
-      });
+  // Add a fully-specified, locally-sourced, keyboard with custom font
+  await keyman.addKeyboards({
+    id: 'lao_2008_basic',
+    name: 'Lao Basic',
+    languages:{
+      id: 'lo',
+      name: 'Lao',
+      region: 'Asia'
+    },
+    filename: '../lao_2008_basic.js'
+  });
+}
 
-    // The following two optional calls should be delayed until language menus are fully loaded:
-    //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
-    //  (b) a specific keyboard is loaded, rather than the keyboard last used.
-    //window.setTimeout(function(){keyman.setActiveElement('ta1',true);},2500);
-    //window.setTimeout(function(){keyman.setActiveKeyboard('Keyboard_french','fr');},3000);
-
-    // Note that locally specified keyboards will be listed before keyboards
-    // requested from the remote server by user interfaces that do not order
-    // keyboards alphabetically by language.
-  }
-
-  // Script to allow a user to add any keyboard to the keyboard menu
-  async function addKeyboard(n)
+// Script to allow a user to add any keyboard to the keyboard menu
+async function addKeyboard(n)
+{
+  let sKbd;
+  switch(n)
   {
-    let sKbd;
-    switch(n)
-    {
-      case 1:
-        sKbd=document.getElementById('kbd_id1').value;
-        await keyman.addKeyboards(sKbd);
-        break;
-      case 2:
-        sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        await keyman.addKeyboards('@'+sKbd);
-        break;
-      case 3:
-        sKbd=document.getElementById('kbd_id3').value;
-        await keyman.addKeyboardsForLanguage(sKbd);
-        break;
-    }
+    case 1:
+      sKbd=document.getElementById('kbd_id1').value;
+      await keyman.addKeyboards(sKbd);
+      break;
+    case 2:
+      sKbd=document.getElementById('kbd_id2').value.toLowerCase();
+      await keyman.addKeyboards('@'+sKbd);
+      break;
+    case 3:
+      sKbd=document.getElementById('kbd_id3').value;
+      await keyman.addKeyboardsForLanguage(sKbd);
+      break;
   }
+}
 
-  // Add keyboard on Enter (as well as pressing button)
-  async function clickOnEnter(e,id) {
-    e = e || window.event;
-    if (e.keyCode == 13) {
-      await addKeyboard(id);
-    }
+// Add keyboard on Enter (as well as pressing button)
+async function clickOnEnter(e,id) {
+  e = e || window.event;
+  if (e.keyCode == 13) {
+    await addKeyboard(id);
   }
+}
 

--- a/web/src/test/manual/web/issue103/samplehdr.js
+++ b/web/src/test/manual/web/issue103/samplehdr.js
@@ -1,70 +1,66 @@
 // Modified version of commonHeader - contains repeated requests for the same language.
 
-  function loadKeyboards() 
-  { 
-    var kmw=keyman;
-    
+  function loadKeyboards() {
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+    keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
-      
+
     // Add more keyboards to the language menu, by keyboard name,
     // keyboard name and language code, or just the BCP-47 language code.
-    kmw.addKeyboards('french','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@no','@he');
-    kmw.addKeyboards('@he');
-    kmw.addKeyboards('@he');
-  
+    keyman.addKeyboards('french','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@no','@he');
+    keyman.addKeyboards('@he');
+    keyman.addKeyboards('@he');
+
     // Add a keyboard by language name.  Note that the name must be spelled
     // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
-    kmw.addKeyboardsForLanguage('Dzongkha');
-    
-    // Add a fully-specified, locally-sourced, keyboard with custom font  
-    kmw.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
+    keyman.addKeyboardsForLanguage('Dzongkha');
+
+    // Add a fully-specified, locally-sourced, keyboard with custom font
+    keyman.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
         id:'lo',name:'Lao',region:'Asia'
         },
       filename:'../lao_2008_basic.js'
-      });   
+      });
 
     // The following two optional calls should be delayed until language menus are fully loaded:
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
-    //  (b) a specific keyboard is loaded, rather than the keyboard last used.         
-  //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-  //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
-  
-    // Note that locally specified keyboards will be listed before keyboards 
+    //  (b) a specific keyboard is loaded, rather than the keyboard last used.
+    //window.setTimeout(function(){keyman.setActiveElement('ta1',true);},2500);
+    //window.setTimeout(function(){keyman.setActiveKeyboard('Keyboard_french','fr');},3000);
+
+    // Note that locally specified keyboards will be listed before keyboards
     // requested from the remote server by user interfaces that do not order
     // keyboards alphabetically by language.
   }
-  
-  // Script to allow a user to add any keyboard to the keyboard menu 
+
+  // Script to allow a user to add any keyboard to the keyboard menu
   function addKeyboard(n)
-  { 
-    var sKbd,kmw=keyman;
+  {
+    let sKbd;
     switch(n)
     {
       case 1:
         sKbd=document.getElementById('kbd_id1').value;
-        kmw.addKeyboards(sKbd);
+        keyman.addKeyboards(sKbd);
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        kmw.addKeyboards('@'+sKbd);
+        keyman.addKeyboards('@'+sKbd);
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;
-        kmw.addKeyboardsForLanguage(sKbd);
+        keyman.addKeyboardsForLanguage(sKbd);
         break;
     }
   }
-  
+
   // Add keyboard on Enter (as well as pressing button)
-  function clickOnEnter(e,id)
-  {                                       
+  function clickOnEnter(e,id) {
     e = e || window.event;
-    if(e.keyCode == 13) addKeyboard(id); 
+    if(e.keyCode == 13) addKeyboard(id);
   }
 

--- a/web/src/test/manual/web/issue103/samplehdr.js
+++ b/web/src/test/manual/web/issue103/samplehdr.js
@@ -1,25 +1,25 @@
 // Modified version of commonHeader - contains repeated requests for the same language.
 
-  function loadKeyboards() {
+  async function loadKeyboards() {
     // The first keyboard added will be the default keyboard for touch devices.
     // For faster loading, it may be best for the default keyboard to be
     // locally sourced.
-    keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+    await keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
 
     // Add more keyboards to the language menu, by keyboard name,
     // keyboard name and language code, or just the BCP-47 language code.
-    keyman.addKeyboards('french','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@no','@he');
-    keyman.addKeyboards('@he');
-    keyman.addKeyboards('@he');
+    await keyman.addKeyboards('french','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@sv','european2@no','@he');
+    await keyman.addKeyboards('@he');
+    await keyman.addKeyboards('@he');
 
     // Add a keyboard by language name.  Note that the name must be spelled
     // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
     // usually easier.)
-    keyman.addKeyboardsForLanguage('Dzongkha');
+    await keyman.addKeyboardsForLanguage('Dzongkha');
 
     // Add a fully-specified, locally-sourced, keyboard with custom font
-    keyman.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
+    await keyman.addKeyboards({id:'lao_2008_basic',name:'Lao Basic',
       languages:{
         id:'lo',name:'Lao',region:'Asia'
         },
@@ -38,29 +38,31 @@
   }
 
   // Script to allow a user to add any keyboard to the keyboard menu
-  function addKeyboard(n)
+  async function addKeyboard(n)
   {
     let sKbd;
     switch(n)
     {
       case 1:
         sKbd=document.getElementById('kbd_id1').value;
-        keyman.addKeyboards(sKbd);
+        await keyman.addKeyboards(sKbd);
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        keyman.addKeyboards('@'+sKbd);
+        await keyman.addKeyboards('@'+sKbd);
         break;
       case 3:
         sKbd=document.getElementById('kbd_id3').value;
-        keyman.addKeyboardsForLanguage(sKbd);
+        await keyman.addKeyboardsForLanguage(sKbd);
         break;
     }
   }
 
   // Add keyboard on Enter (as well as pressing button)
-  function clickOnEnter(e,id) {
+  async function clickOnEnter(e,id) {
     e = e || window.event;
-    if(e.keyCode == 13) addKeyboard(id);
+    if (e.keyCode == 13) {
+      await addKeyboard(id);
+    }
   }
 

--- a/web/src/test/manual/web/issue115/index.html
+++ b/web/src/test/manual/web/issue115/index.html
@@ -36,11 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
       });
-      kmw.addKeyboards({id:'issue115a',name:'Issue 115',languages:{id:'en',name:'English'},
+      keyman.addKeyboards({id:'issue115a',name:'Issue 115',languages:{id:'en',name:'English'},
         filename:'./issue115a.js'});
     </script>
 

--- a/web/src/test/manual/web/issue116/index.html
+++ b/web/src/test/manual/web/issue116/index.html
@@ -36,12 +36,12 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
+      }).then(function() {
+        keyman.addKeyboards({id:'next_layer_tests',name:'Issue 116',languages:{id:'en',name:'English'},
+          filename:'./next_layer_tests.js'});
       });
-      kmw.addKeyboards({id:'next_layer_tests',name:'Issue 116',languages:{id:'en',name:'English'},
-        filename:'./next_layer_tests.js'});
     </script>
 
 

--- a/web/src/test/manual/web/issue11785/index.html
+++ b/web/src/test/manual/web/issue11785/index.html
@@ -40,9 +40,8 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
-		    attachType:'auto',
+      keyman.init({
+        attachType:'auto',
       });
 
       // Note:  explicitly NOT deferred or waiting on the `init` Promise.  This is

--- a/web/src/test/manual/web/issue11785/load-keyboards.js
+++ b/web/src/test/manual/web/issue11785/load-keyboards.js
@@ -74,8 +74,6 @@
 
   function loadKeyboards(nestLevel)
   {
-    var kmw=keyman;
-
     var base_prefix = '../';
     var prefix = './'; // The default - when prefix == 0.
 
@@ -132,8 +130,8 @@
     // The following two optional calls should be delayed until language menus are fully loaded:
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.
-    //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-    //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
+    //window.setTimeout(function(){keyman.setActiveElement('ta1',true);},2500);
+    //window.setTimeout(function(){keyman.setActiveKeyboard('Keyboard_french','fr');},3000);
 
     // Note that locally specified keyboards will be listed before keyboards
     // requested from the remote server by user interfaces that do not order
@@ -143,7 +141,7 @@
   // Script to allow a user to add any keyboard to the keyboard menu
   function addKeyboard(n)
   {
-    var sKbd,kmw=keyman;
+    var sKbd;
     switch(n)
     {
       case 1:

--- a/web/src/test/manual/web/issue11785/load-keyboards.js
+++ b/web/src/test/manual/web/issue11785/load-keyboards.js
@@ -1,169 +1,107 @@
-// JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
-
 /*
-    The keyboard name and/or BCP-47 language code must be specified for each keyboard that is to be available.
-    If the same keyboard is used for several languages, it must be listed for each
-    language, but the keyboard itself will only be loaded once.
-    If two (or more) keyboards are to be available for a given language, both must be listed.
-    Any number of keyboards may be specified in one or more calls.
-    Keyboard paths may be absolute (with respect to the server root) or relative to the keyboards option path.
-    The actual keyboard object will be downloaded asynchronously when first selected for use.
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
 
-    Each argument to addKeyboards() is a string, for example:
-      european2         loads the current version of the Eurolatin 2 keyboard (for its default language)
-      european2@fr      loads the current version of the Eurolatin 2 keyboard for French
-      european2@fr@1.2  loads version 1.2 of the Eurolatin 2 keyboard for French
-
-    Argument syntax also supports the following extensions:
-      @fr               load the current version of the default keyboard for French
-      @fr$              load all available keyboards (current version) for French
-
-    Each call to addKeyboards() requires a single call to the remote server,
-    (unless all keyboards listed are local and fully specified) so it is better
-    to use multiple arguments rather than separate function calls.
-
-    Calling addKeyboards() with no arguments returns a list of *all* available keyboards.
-    The Toolbar (desktop browser) UI is best suited for allowing users to select
-    the appropriate language and keyboard in this case.
-
-    Keyboards may also be specified by language name using addKeyboardsForLanguage()
-    for example:
-      keymanweb.addKeyboardsForLanguage('Burmese');
-
-    Appending $ to the language name will again cause all available keyboards for that
-    language to be loaded rather than the default keyboard.
-
-    The first call to addKeyboardsForLanguage() makes an additional call to the
-    keyman API to load the current list of keyboard/language associations.
-
-    In this example, the following function loads the indicated keyboards,
-    and is called when the page loads.
-*/
-
-  function errToString(err) {
-    // Painful?  Kinda.  But needed on un-updated Android API 21!
-    if(Array.isArray(err)) {
-      var result = '';
-      for(var i = 0; i < err.length; i++) {
-        var e = err[i];
-        if(e.error instanceof Error) {
-          result += e.error.message + '\n';
-        } else {
-          result += JSON.stringify(e) + '\n';
-        }
-      }
-      return result;
-    }
-    if(err instanceof Error) {
-      return err.message;
-    }
-    return JSON.stringify(err);
-  }
-
-  function doAddKeyboards(data) {
-    return keyman.addKeyboards(data).catch(function(err) {
-      console.error('keyman.addKeyboards failed with '+errToString(err)+' for '+JSON.stringify(data));
-    });
-  }
-
-  function doAddKeyboardsForLanguage(data) {
-    return keyman.addKeyboardsForLanguage(data).catch(function(err) {
-      console.error('keyman.addKeyboardsForLanguage failed with '+errToString(err)+' for '+JSON.stringify(data));
-    });
-  }
-
-  function loadKeyboards(nestLevel)
-  {
-    var base_prefix = '../';
-    var prefix = './'; // The default - when prefix == 0.
-
-    if(nestLevel !== undefined && nestLevel > 0) {
-      prefix = '';
-      for(var i=0; i < nestLevel; i++) {
-        prefix = prefix + base_prefix;
+function errToString(err) {
+  // Painful?  Kinda.  But needed on un-updated Android API 21!
+  if(Array.isArray(err)) {
+    let result = '';
+    for(let i = 0; i < err.length; i++) {
+      const e = err[i];
+      if(e.error instanceof Error) {
+        result += e.error.message + '\n';
+      } else {
+        result += JSON.stringify(e) + '\n';
       }
     }
-
-    // The first keyboard added will be the default keyboard for touch devices.
-    // For faster loading, it may be best for the default keyboard to be
-    // locally sourced.
-    // doAddKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
-    //   filename:(prefix + 'us-1.0.js')});
-
-    // Do NOT link the us-1.0 keyboard here!
-
-    doAddKeyboards({id:'test_chirality',name:'test_chirality',languages:{id:'en',name:'English'},
-      filename:(prefix + 'test_chirality.js')});
-
-    doAddKeyboards({id:'obolo_chwerty_6351',name:'obolo_chwerty_6351',languages:{id:'en',name:'English'},
-      filename:(prefix + 'obolo_chwerty_6351.js')});
-
-    doAddKeyboards({id:'gesture_prototyping',name:'Gesture Prototyping',languages:{id:'en',name:'English'},
-      filename:(prefix + 'keyboards/gesture_prototyping/build/gesture_prototyping.js')});
-
-    doAddKeyboards({id:'diacritic_rota',name:'Diacritic 10-key Rota',languages:{id:'en',name:'English'},
-      filename:(prefix + 'keyboards/diacritic_rota/build/diacritic_rota.js')});
-
-    doAddKeyboards({id:'ye_old_ten_key',name:'Classic 10-key',languages:{id:'en',name:'English'},
-      filename:(prefix + 'keyboards/ye_old_ten_key/build/ye_old_ten_key.js')});
-
-      // Add more keyboards to the language menu, by keyboard name,
-    // keyboard name and language code, or just the BCP-47 language code.
-    // We use a different loading pattern here than in the samples version to provide a slightly different set of test cases.
-    doAddKeyboards('french','@he');
-    doAddKeyboards('khmer_angkor','@km');
-    doAddKeyboards({id:'sil_euro_latin', name:'SIL EuroLatin', languages: [{id:'no'}, {id:'sv'}]}); // Loads from partial stub instead of the compact string.
-
-    // Add a keyboard by language name.  Note that the name must be spelled
-    // correctly, or the keyboard will not be found.  (Using BCP-47 codes is
-    // usually easier.)
-    doAddKeyboardsForLanguage('Dzongkha');
-
-    // Add a fully-specified, locally-sourced, keyboard with custom font
-    doAddKeyboards({id:'lao_2008_basic',name:'Lao Basic',
-      languages: {
-          id:'lo',name:'Lao',region:'Asia',
-        },
-      filename:(prefix + 'lao_2008_basic-1.2.js')
-      });
-
-    // The following two optional calls should be delayed until language menus are fully loaded:
-    //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
-    //  (b) a specific keyboard is loaded, rather than the keyboard last used.
-    //window.setTimeout(function(){keyman.setActiveElement('ta1',true);},2500);
-    //window.setTimeout(function(){keyman.setActiveKeyboard('Keyboard_french','fr');},3000);
-
-    // Note that locally specified keyboards will be listed before keyboards
-    // requested from the remote server by user interfaces that do not order
-    // keyboards alphabetically by language.
+    return result;
   }
+  if(err instanceof Error) {
+    return err.message;
+  }
+  return JSON.stringify(err);
+}
 
-  // Script to allow a user to add any keyboard to the keyboard menu
-  function addKeyboard(n)
-  {
-    var sKbd;
-    switch(n)
-    {
-      case 1:
-        sKbd=document.getElementById('kbd_id1').value;
-        doAddKeyboards(sKbd);
-        break;
-      case 2:
-        sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        doAddKeyboards('@'+sKbd);
-        break;
-      case 3:
-        // Add keyboard for comma-separated language name(s)
-        sKbd=document.getElementById('kbd_id3').value;
-        doAddKeyboardsForLanguage(sKbd);
-        break;
+async function doAddKeyboards(data) {
+  return keyman.addKeyboards(data).catch(function(err) {
+    console.error('keyman.addKeyboards failed with '+errToString(err)+' for '+JSON.stringify(data));
+  });
+}
+
+async function doAddKeyboardsForLanguage(data) {
+  return keyman.addKeyboardsForLanguage(data).catch(function(err) {
+    console.error('keyman.addKeyboardsForLanguage failed with '+errToString(err)+' for '+JSON.stringify(data));
+  });
+}
+
+async function loadKeyboards(nestLevel) {
+  const base_prefix = '../';
+  let prefix = './'; // The default - when prefix == 0.
+
+  if(nestLevel !== undefined && nestLevel > 0) {
+    prefix = '';
+    for(let i=0; i < nestLevel; i++) {
+      prefix += base_prefix;
     }
   }
 
-  // Add keyboard on Enter (as well as pressing button)
-  function clickOnEnter(e,id)
-  {
-    e = e || window.event;
-    if(e.keyCode == 13) addKeyboard(id);
-  }
+  // Do NOT link the us-1.0 keyboard here!
 
+  await doAddKeyboards({id:'test_chirality',name:'test_chirality',languages:{id:'en',name:'English'},
+    filename:(prefix + 'test_chirality.js')});
+
+  await doAddKeyboards({id:'obolo_chwerty_6351',name:'obolo_chwerty_6351',languages:{id:'en',name:'English'},
+    filename:(prefix + 'obolo_chwerty_6351.js')});
+
+  await doAddKeyboards({id:'gesture_prototyping',name:'Gesture Prototyping',languages:{id:'en',name:'English'},
+    filename:(prefix + 'keyboards/gesture_prototyping/build/gesture_prototyping.js')});
+
+  await doAddKeyboards({id:'diacritic_rota',name:'Diacritic 10-key Rota',languages:{id:'en',name:'English'},
+    filename:(prefix + 'keyboards/diacritic_rota/build/diacritic_rota.js')});
+
+  await doAddKeyboards({id:'ye_old_ten_key',name:'Classic 10-key',languages:{id:'en',name:'English'},
+    filename:(prefix + 'keyboards/ye_old_ten_key/build/ye_old_ten_key.js')});
+
+  await doAddKeyboards('french', '@he');
+  await doAddKeyboards('khmer_angkor','@km');
+  await doAddKeyboards({id:'sil_euro_latin', name:'SIL EuroLatin', languages: [{id:'no'}, {id:'sv'}]}); // Loads from partial stub instead of the compact string.
+
+  await doAddKeyboardsForLanguage('Dzongkha');
+
+  await doAddKeyboards({
+    id: 'lao_2008_basic', name: 'Lao Basic',
+    languages: {
+        id:'lo',name:'Lao',region:'Asia',
+      },
+    filename:(prefix + 'lao_2008_basic-1.2.js')
+    });
+}
+
+// Script to allow a user to add any keyboard to the keyboard menu
+async function addKeyboard(n) {
+  let sKbd;
+  switch(n)
+  {
+    case 1:
+      sKbd=document.getElementById('kbd_id1').value;
+      await doAddKeyboards(sKbd);
+      break;
+    case 2:
+      sKbd=document.getElementById('kbd_id2').value.toLowerCase();
+      await doAddKeyboards('@'+sKbd);
+      break;
+    case 3:
+      // Add keyboard for comma-separated language name(s)
+      sKbd=document.getElementById('kbd_id3').value;
+      await doAddKeyboardsForLanguage(sKbd);
+      break;
+  }
+}
+
+// Add keyboard on Enter (as well as pressing button)
+async function clickOnEnter(e,id) {
+  e = e || window.event;
+  if (e.keyCode == 13) {
+    await addKeyboard(id);
+  }
+}

--- a/web/src/test/manual/web/issue1332/header.js
+++ b/web/src/test/manual/web/issue1332/header.js
@@ -1,13 +1,11 @@
-function loadKeyboards() 
-{ 
-  var kmw=keyman;
-
-    // Add a fully-specified, locally-sourced, keyboard with custom font  
-    kmw.addKeyboards({id:'sil_cameroon_qwerty',name:'Cameroon QWERTY (SIL)',
+function loadKeyboards()
+{
+    // Add a fully-specified, locally-sourced, keyboard with custom font
+    keyman.addKeyboards({id:'sil_cameroon_qwerty',name:'Cameroon QWERTY (SIL)',
       languages:{
         id:'aal-Latn',name:'Afade (Latin)',region:'Africa',
         font:{family:'AndikaAfr',source:['./ANDIKAAFR-R.TTF']}
         },
       filename:'./sil_cameroon_qwerty.js'
-      });   
+      });
 }

--- a/web/src/test/manual/web/issue1332/index.html
+++ b/web/src/test/manual/web/issue1332/index.html
@@ -36,9 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType: 'auto'
+      }).then(function() {
+        loadKeyboards();
       });
 
     </script>
@@ -49,7 +50,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Sample Page - Mixed Case of TTF font files</h2>
     <p>Previously, KMW was not applying .TTF fonts on mobile devices.</p>
     <p>See <a href='https://github.com/keymanapp/keyman/issues/1332'>issue #1332</a>

--- a/web/src/test/manual/web/issue160/index.html
+++ b/web/src/test/manual/web/issue160/index.html
@@ -36,12 +36,12 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
-      });
-      kmw.addKeyboards({
-        id:'issue160',name:'Issue 160',languages:{id:'en',name:'English'}, filename:'./issue160.js'
+      }).then(function() {
+        keyman.addKeyboards({
+          id: 'issue160', name: 'Issue 160', languages: { id: 'en', name: 'English' }, filename: './issue160.js'
+        });
       });
     </script>
 

--- a/web/src/test/manual/web/issue266/index.html
+++ b/web/src/test/manual/web/issue266/index.html
@@ -36,12 +36,12 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
-      });
-      kmw.addKeyboards({
-        id:'issue266',name:'Issue 266',languages:{id:'en',name:'English'}, filename:'./issue266.js'
+      }).then(function() {
+        keyman.addKeyboards({
+          id:'issue266',name:'Issue 266',languages:{id:'en',name:'English'}, filename:'./issue266.js'
+        });
       });
     </script>
 

--- a/web/src/test/manual/web/issue271/header.js
+++ b/web/src/test/manual/web/issue271/header.js
@@ -1,7 +1,5 @@
 function setActiveKeyboard() {
-  var kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
-
   var sKbd = document.getElementById('kbd_id4').value;
   var sLng = document.getElementById('lang_id4').value;
-  var result = kmw.setActiveKeyboard("Keyboard_" + sKbd, sLng);
+  var result = keyman.setActiveKeyboard("Keyboard_" + sKbd, sLng);
 }

--- a/web/src/test/manual/web/issue271/index.html
+++ b/web/src/test/manual/web/issue271/index.html
@@ -36,9 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window['keyman'] ? keyman : tavultesoft.keymanweb;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
+      }).then(function () {
+        loadKeyboards(1);
       });
     </script>
 
@@ -49,7 +50,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards(1);'>
+  <body>
     <h2>KeymanWeb:  Test page for interactions between setActiveKeyboard and the toolbar UI</h2>
 
 	<h3>This version is used to test the interactions of <code>SetActiveKeyboard</code> with the Toolbar UI.</h3>

--- a/web/src/test/manual/web/issue29/index.html
+++ b/web/src/test/manual/web/issue29/index.html
@@ -36,8 +36,9 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init();
+      keyman.init().then(function() {
+        loadKeyboards(1);
+      });
     </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->
@@ -47,7 +48,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards(1);'>
+  <body>
     <h2>KeymanWeb:  Test desktop MutationObserver functionality</h2>
 
     <div id='DynamicTextboxes'>

--- a/web/src/test/manual/web/issue3701/index.html
+++ b/web/src/test/manual/web/issue3701/index.html
@@ -36,11 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
 		    attachType:'auto'
       }).then(function() {
-        kmw.addKeyboards({id:'test3701',name:'test3701',languages:{id:'en',name:'English'}, filename:'test3701/build/test3701.js'});
+        keyman.addKeyboards({id:'test3701',name:'test3701',languages:{id:'en',name:'English'}, filename:'test3701/build/test3701.js'});
 
         var pageRef = (window.location.protocol == 'file:')
           ? window.location.href.substr(0, window.location.href.lastIndexOf('/')+1)
@@ -50,7 +49,7 @@
           languages: ['en'],
           path: (pageRef + "../prediction-mtnt/nrc.en.mtnt.model.js")
         };
-        kmw.addModel(modelStub);
+        keyman.addModel(modelStub);
       });
 
       function togglePredictions() {

--- a/web/src/test/manual/web/issue382/index.html
+++ b/web/src/test/manual/web/issue382/index.html
@@ -36,18 +36,18 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
-      });
-      kmw.addKeyboards({
-        id:'issue382',
-        name:'Keycap Scaling Test with a really long name in order to also test captions',
-        languages:{
-          id:'en',
-          name:'English'
-        },
-        filename:'./issue382.js'
+      }).then(function() {
+        keyman.addKeyboards({
+          id:'issue382',
+          name:'Keycap Scaling Test with a really long name in order to also test captions',
+          languages:{
+            id:'en',
+            name:'English'
+          },
+          filename:'./issue382.js'
+        });
       });
     </script>
 

--- a/web/src/test/manual/web/issue53/index.html
+++ b/web/src/test/manual/web/issue53/index.html
@@ -36,9 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
+      }).then(function () {
+        loadKeyboards();
       });
     </script>
 
@@ -48,7 +49,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb:  Tests layering transitions for keyboards with variable layer sizes.</h2>
     <p>This test should be run from mobile devices or with Chrome's mobile device emulation settings available within Developer Mode.</p>
     <div>

--- a/web/src/test/manual/web/issue53/issue53.js
+++ b/web/src/test/manual/web/issue53/issue53.js
@@ -1,9 +1,7 @@
 function loadKeyboards()
 {
-  var kmw=keyman;
-
   // Add a fully-specified, locally-sourced, keyboard.
-  kmw.addKeyboards({id:'layered_debug_keyboard',name:'Web_Layer_Debugging',
+  keyman.addKeyboards({id:'layered_debug_keyboard',name:'Web_Layer_Debugging',
     languages:{
       id:'dbg',name:'Debug',region:'North America'
       },
@@ -14,28 +12,28 @@ function loadKeyboards()
 // Script to allow a user to add any keyboard to the keyboard menu
 function addKeyboard(n)
 {
-  var sKbd,kmw=keyman;
+  var sKbd;
   switch(n)
   {
     case 1:
       sKbd=document.getElementById('kbd_id1').value;
-      kmw.addKeyboards(sKbd);
+      keyman.addKeyboards(sKbd);
       break;
     case 2:
       sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-      kmw.addKeyboards('@'+sKbd);
+      keyman.addKeyboards('@'+sKbd);
       break;
     case 3:
       sKbd=document.getElementById('kbd_id3').value;
-      kmw.addKeyboardsForLanguage(sKbd);
+      keyman.addKeyboardsForLanguage(sKbd);
       break;
   }
 }
 
 function removeKeyboard(n)
 {
-    var sKbd=document.getElementById('kbd_id4').value, kmw=keyman;
-    kmw["removeKeyboards"](sKbd);
+    var sKbd=document.getElementById('kbd_id4').value;
+    keyman.removeKeyboards(sKbd);
 }
 
 // Add keyboard on Enter (as well as pressing button)

--- a/web/src/test/manual/web/issue6005/index.html
+++ b/web/src/test/manual/web/issue6005/index.html
@@ -40,13 +40,11 @@
       const alertType = (new URLSearchParams(window.location.search)).get("useAlerts") != "false";
       var alertText = alertType ? 'enabled(default)' : 'disabled';
 
-      var kmw=window.keyman;
-
-      kmw.init({
+      keyman.init({
         'attachType': 'auto'
       }).then(function() {
         // if mobile device, activate pred text.
-        if(kmw.util.isTouchDevice()) {
+        if(keyman.util.isTouchDevice()) {
           var pageRef = (window.location.protocol == 'file:')
             ? window.location.href.substr(0, window.location.href.lastIndexOf('/')+1)
             : window.location.href;
@@ -60,24 +58,25 @@
             languages: ['en'],
             path: (pageRef + "prediction-mtnt/nrc.en.mtnt.model.js")
           };
-          kmw.addModel(modelStub1);
+          keyman.addModel(modelStub1);
           var modelStub2 = {'id': 'nrc.en.mtnt',
             languages: ['pny-latn'],  // yep.  Total cheat for the sake of testing.
             path: (pageRef + "prediction-mtnt/nrc.en.mtnt.model.js")
           };
-          kmw.addModel(modelStub2);
+          keyman.addModel(modelStub2);
         }
-      });
-      kmw.addKeyboards('sil_euro_latin@en',
-                       'galaxie_hebrew_positional@he',
-                       'sil_cameroon_qwerty@pny-latn');
 
-      kmw.addKeyboards({
-          id:'unmatched_final_group_model_interactions_6005',
-          name:'"Unmatched Vowel Rule"',
-          languages:{id:'en',name:'English'},
-          filename:('unmatched_final_group_model_interactions_6005.js')
-        });
+        keyman.addKeyboards('sil_euro_latin@en',
+                        'galaxie_hebrew_positional@he',
+                        'sil_cameroon_qwerty@pny-latn');
+
+        keyman.addKeyboards({
+            id:'unmatched_final_group_model_interactions_6005',
+            name:'"Unmatched Vowel Rule"',
+            languages:{id:'en',name:'English'},
+            filename:('unmatched_final_group_model_interactions_6005.js')
+          });
+      });
     </script>
 
   </head>

--- a/web/src/test/manual/web/issue62/index.html
+++ b/web/src/test/manual/web/issue62/index.html
@@ -36,9 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
+      }).then(function () {
+        loadKeyboards(1);
       });
     </script>
 
@@ -49,7 +50,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards(1);'>
+  <body>
     <h2>KeymanWeb:  Light test for touch-based MutationObserver functionality</h2>
 
     <div id='DynamicTextboxes'>

--- a/web/src/test/manual/web/issue63/index.html
+++ b/web/src/test/manual/web/issue63/index.html
@@ -36,9 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
+      }).then(function () {
+        loadKeyboards(1);
       });
     </script>
 
@@ -49,7 +50,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards(1);'>
+  <body>
     <h2>KeymanWeb:  Test/stress-test touch-based MutationObserver functionality</h2>
 
     <div id='DynamicTextboxes'>

--- a/web/src/test/manual/web/issue917-context-and-notany/index.html
+++ b/web/src/test/manual/web/issue917-context-and-notany/index.html
@@ -36,11 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
 		    attachType:'auto'
       }).then(function() {
-        kmw.addKeyboards({id:'test_917',name:'test_917',languages:{id:'en',name:'English'}, filename:'test_917/build/test_917.js'});
+        keyman.addKeyboards({id:'test_917',name:'test_917',languages:{id:'en',name:'English'}, filename:'test_917/build/test_917.js'});
       });
 
     </script>

--- a/web/src/test/manual/web/issue920/index.html
+++ b/web/src/test/manual/web/issue920/index.html
@@ -36,15 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType: 'auto'
-      });
-
-      function loadKeyboards() {
-        var kmw=keyman;
-
-        kmw.addKeyboards({
+      }).then(function() {
+        keyman.addKeyboards({
           id:'multigroup',
           name:'Multigroup Test',
           languages:{
@@ -54,12 +49,12 @@
           },
           filename:'multigroup.js'
         });
-      }
+      });
     </script>
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Sample Page - deadkeys and multiple groups Testing</h2>
     <p>See <a href='https://github.com/keymanapp/keyman/issues/920'>issue #920</a> for details on what this test
     is all about. Both ;e and .e should produce ə but ;e uses a deadkey and fails.</p>

--- a/web/src/test/manual/web/issue9469/index.html
+++ b/web/src/test/manual/web/issue9469/index.html
@@ -36,11 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
-		    attachType:'auto'
+      keyman.init({
+        attachType:'auto'
       }).then(function() {
-        kmw.addKeyboards({id:'test9469',name:'test9469',languages:{id:'en',name:'English'}, 
+        keyman.addKeyboards({id:'test9469',name:'test9469',languages:{id:'en',name:'English'},
           filename:'../../../../../build/test-resources/keyboards/test9469.js'});
 
         var pageRef = (window.location.protocol == 'file:')
@@ -51,7 +50,7 @@
           languages: ['en'],
           path: (pageRef + "../prediction-mtnt/nrc.en.mtnt.model.js")
         };
-        kmw.addModel(modelStub);
+        keyman.addModel(modelStub);
       });
 
       function togglePredictions() {

--- a/web/src/test/manual/web/keyboard-errors/errorhdr.js
+++ b/web/src/test/manual/web/keyboard-errors/errorhdr.js
@@ -4,14 +4,12 @@
 
   function loadKeyboards()
   {
-    var kmw=keyman;
-
     // We start by adding a keyboard correctly.  It's best to include a 'control' in our experiment.
-    kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+    keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
       filename:'../us-1.0.js'});
 
     // Insert a keyboard that cannot be found.
-    kmw.addKeyboards({id:'lao_2008_basic',name:'wrong-filename',
+    keyman.addKeyboards({id:'lao_2008_basic',name:'wrong-filename',
       languages:{
         id:'lo',name:'debugging',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
@@ -20,7 +18,7 @@
     });
 
     // Insert a keyboard that will generate a timing error.
-    kmw.addKeyboards({id:'unparsable',name:'non-parsable',
+    keyman.addKeyboards({id:'unparsable',name:'non-parsable',
       languages:{
         id:'lo',name:'debugging',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
@@ -32,7 +30,7 @@
     // Insert a keyboard that will generate a timing error. `timeout.js` doesn't
     // exist, but the test server (web/src/tools/testing/test-server/index.cjs)
     // has special handling for that URL and times out after 10 seconds.
-    kmw.addKeyboards({id:'timeout',name:'timeout',
+    keyman.addKeyboards({id:'timeout',name:'timeout',
       languages:{
         id:'lo',name:'debugging',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}

--- a/web/src/test/manual/web/keyboard-errors/index.html
+++ b/web/src/test/manual/web/keyboard-errors/index.html
@@ -36,9 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
+      }).then(function() {
+        loadKeyboards();
       });
     </script>
 
@@ -48,7 +49,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Sample Page - Error Testing page</h2>
 	<p>Pick one of the 'debugging' keyboards to test whether the represented error is handled correctly.
     <div>

--- a/web/src/test/manual/web/mnemonic/index.html
+++ b/web/src/test/manual/web/mnemonic/index.html
@@ -33,24 +33,21 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init();
+      keyman.init().then(function() {
+        keyman.addKeyboards({
+          id: 'mnemonic',
+          name: 'Mnemonic Test',
+          languages: {
+            id: 'en',
+            name: 'English'
+          },
+          filename: './mnemonic.js'
+        });
+      });
     </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->
     <!--<script src="../commonHeader.js"></script>-->
-
-    <script>
-      kmw.addKeyboards({
-        id:'mnemonic',
-        name:'Mnemonic Test',
-        languages: {
-          id:'en',
-          name:'English'
-        },
-        filename:'./mnemonic.js'
-      });
-    </script>
   </head>
 
   <body>

--- a/web/src/test/manual/web/options-with-save/index.html
+++ b/web/src/test/manual/web/options-with-save/index.html
@@ -33,24 +33,21 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init();
+      keyman.init().then(function() {
+        keyman.addKeyboards({
+          id: 'options_with_save',
+          name: 'Options Test',
+          languages: {
+            id: 'en',
+            name: 'English'
+          },
+          filename: './options_with_save.js'
+        });
+      });
     </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->
     <!--<script src="../commonHeader.js"></script>-->
-
-    <script>
-      kmw.addKeyboards({
-        id:'options_with_save',
-        name:'Options Test',
-        languages: {
-          id:'en',
-          name:'English'
-        },
-        filename:'./options_with_save.js'
-      });
-    </script>
   </head>
 
   <body>

--- a/web/src/test/manual/web/osk-event-buttons/index.html
+++ b/web/src/test/manual/web/osk-event-buttons/index.html
@@ -36,8 +36,7 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
       }).then(() => {
         loadKeyboards(1);

--- a/web/src/test/manual/web/osk-movement/index.html
+++ b/web/src/test/manual/web/osk-movement/index.html
@@ -36,9 +36,8 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
-		    attachType:'auto'
+      keyman.init({
+        attachType:'auto'
       }).then(function() {
         loadKeyboards(1);
       });

--- a/web/src/test/manual/web/platform/index.html
+++ b/web/src/test/manual/web/platform/index.html
@@ -36,10 +36,11 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-  var kmw=window.keyman;
-  kmw.init({
-    attachType: 'auto'
-  });
+      keyman.init({
+        attachType: 'auto'
+      }).then(function() {
+        loadKeyboards();
+      });
     </script>
 
     <!-- Add keyboard management script for local selection of keyboards to use -->
@@ -51,7 +52,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Sample Page - Platform Testing</h2>
     <p>This page is designed to test the Platform statement for consistency.
       Refer to PR <a href="https://github.com/keymanapp/keyman/pull/969">#969</a>.<br/>

--- a/web/src/test/manual/web/platform/utilities.js
+++ b/web/src/test/manual/web/platform/utilities.js
@@ -1,8 +1,6 @@
-function loadKeyboards() 
-{ 
-  var kmw=keyman;
-
-  kmw.addKeyboards({id:'platformtest',name:'Platform Testing',
+function loadKeyboards()
+{
+  keyman.addKeyboards({id:'platformtest',name:'Platform Testing',
     languages:{
       id:'en',name:'English',region:'North America'
     },

--- a/web/src/test/manual/web/pr10506/header.js
+++ b/web/src/test/manual/web/pr10506/header.js
@@ -1,11 +1,10 @@
 function loadKeyboards()
 {
-  var kmw=keyman;
-  kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+  keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
     filename:('../us-1.0.js')});
 
   // Add a fully-specified, locally-sourced, keyboard with custom font
-  kmw.addKeyboards({id:'dotty_keys',name:'Dotty Keys',
+  keyman.addKeyboards({id:'dotty_keys',name:'Dotty Keys',
     languages:{
       id:'und',name:'Special',region:'World',
       font:{family:'DejaVu Dots',source:['./DejaVu-Dots.ttf']}

--- a/web/src/test/manual/web/pr10506/index.html
+++ b/web/src/test/manual/web/pr10506/index.html
@@ -36,9 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType: 'auto'
+      }).then(function() {
+        loadKeyboards();
       });
 
     </script>
@@ -49,7 +50,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Test Page - Key-cap scaling / font-load delay interactions</h2>
     <p>To run the test, simply change from the default (English) keyboard to the "Special" keyboard.</p>
     <p>When things are working properly, the base keys on the "Special" keyboard should contain

--- a/web/src/test/manual/web/prediction-mtnt/index.html
+++ b/web/src/test/manual/web/prediction-mtnt/index.html
@@ -36,16 +36,15 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
 		    attachType:'auto'
       }).then(function() {
-        kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'}, filename:'../us-1.0.js'});
-        kmw.addKeyboards({id:'lao_2008_basic',name:'Lao',languages:{id:'lo',name:'Lao'}, filename:'../lao_2008_basic-1.2.js'});
-        kmw.addKeyboards('sil_euro_latin@en');
-        kmw.addKeyboards({id:'ye_old_ten_key',name:'Classic 10-key',languages:{id:'en',name:'English'},
+        keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'}, filename:'../us-1.0.js'});
+        keyman.addKeyboards({id:'lao_2008_basic',name:'Lao',languages:{id:'lo',name:'Lao'}, filename:'../lao_2008_basic-1.2.js'});
+        keyman.addKeyboards('sil_euro_latin@en');
+        keyman.addKeyboards({id:'ye_old_ten_key',name:'Classic 10-key',languages:{id:'en',name:'English'},
           filename:('../keyboards/ye_old_ten_key/build/ye_old_ten_key.js')});
-        kmw.addKeyboards({id:'gesture_prototyping',name:'Gesture prototyping',languages:{id:'en',name:'English'},
+        keyman.addKeyboards({id:'gesture_prototyping',name:'Gesture prototyping',languages:{id:'en',name:'English'},
           filename:('../keyboards/gesture_prototyping/build/gesture_prototyping.js')});
 
         // Ensure the URL we prefix to the page's path is the page's directory, not including
@@ -59,7 +58,7 @@
           languages: ['en'],
           path: (pageRef + "nrc.en.mtnt.model.js")
         };
-        kmw.addModel(modelStub);
+        keyman.addModel(modelStub);
       });
 
       function togglePredictions() {

--- a/web/src/test/manual/web/prediction-ui/index.html
+++ b/web/src/test/manual/web/prediction-ui/index.html
@@ -36,14 +36,13 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
 		    attachType:'auto'
       }).then(function() {
-        kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'}, filename:'../us-1.0.js'});
-        kmw.addKeyboards({id:'start_of_sentence_3621',name:'Start of Sentence test',languages:{id:'en',name:'English'}, filename:'../start-of-sentence-3621/start_of_sentence_3621.js'});
-        kmw.addKeyboards({id:'lao_2008_basic',name:'Lao',languages:{id:'lo',name:'Lao'}, filename:'../lao_2008_basic-1.2.js'});
-        kmw.addKeyboards({id:'obolo_chwerty_6351',name:'obolo_chwerty_6351',languages:{id:'en',name:'English'},
+        keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'}, filename:'../us-1.0.js'});
+        keyman.addKeyboards({id:'start_of_sentence_3621',name:'Start of Sentence test',languages:{id:'en',name:'English'}, filename:'../start-of-sentence-3621/start_of_sentence_3621.js'});
+        keyman.addKeyboards({id:'lao_2008_basic',name:'Lao',languages:{id:'lo',name:'Lao'}, filename:'../lao_2008_basic-1.2.js'});
+        keyman.addKeyboards({id:'obolo_chwerty_6351',name:'obolo_chwerty_6351',languages:{id:'en',name:'English'},
           filename:('../obolo_chwerty_6351.js')});
 
         // Ensure the URL we prefix to the page's path is the page's directory, not including
@@ -57,7 +56,7 @@
           languages: ['en'],
           path: (pageRef + "simple-en-trie.js")
         };
-        kmw.addModel(modelStub);
+        keyman.addModel(modelStub);
       });
 
       function togglePredictions() {

--- a/web/src/test/manual/web/promise-api/index.html
+++ b/web/src/test/manual/web/promise-api/index.html
@@ -45,12 +45,10 @@
       // Thank you to https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
       const alertType = (new URLSearchParams(window.location.search)).get("useAlerts") != "false";
 
-      var kmw=window.keyman;
-
-      // Test adding keyboards before kmw.init get deferred
+      // Test adding keyboards before keyman.init get deferred
       addKeyboards('french','@he');
 
-      kmw.init({
+      keyman.init({
         attachType: 'auto',
         useAlerts: alertType
       }).then(function() {

--- a/web/src/test/manual/web/promise-api/promisehdr.js
+++ b/web/src/test/manual/web/promise-api/promisehdr.js
@@ -45,8 +45,7 @@
  * @param {string | KeyboardStub | (string|KeyboardStub)[]} obj Info for adding a keyboard
  */
   function addKeyboards(...args) {
-    var kmw=keyman;
-    var promise = kmw.addKeyboards(args);
+    var promise = keyman.addKeyboards(args);
     promise.then(result => {
       if (result.length > 0 && !result[0].error) {
         console.log('Adding: ', result);
@@ -70,8 +69,7 @@
    * @param {string} languages. Could be comma-separated languages
    */
   function addKeyboardsForLanguage(languages) {
-    var kmw=keyman;
-    kmw.addKeyboardsForLanguage(languages.split(',').map(item => item.trim())).then(result => {
+    keyman.addKeyboardsForLanguage(languages.split(',').map(item => item.trim())).then(result => {
       console.log('Adding ' + languages + ': ', result);
     }).catch(errorStubs => {
       // Consumer decides how to handle errors
@@ -125,8 +123,8 @@
     // The following two optional calls should be delayed until language menus are fully loaded:
     //  (a) a specific mapped input element input is focused, to ensure that the OSK appears
     //  (b) a specific keyboard is loaded, rather than the keyboard last used.
-    //window.setTimeout(function(){kmw.setActiveElement('ta1',true);},2500);
-    //window.setTimeout(function(){kmw.setActiveKeyboard('Keyboard_french','fr');},3000);
+    //window.setTimeout(function(){keyman.setActiveElement('ta1',true);},2500);
+    //window.setTimeout(function(){keyman.setActiveKeyboard('Keyboard_french','fr');},3000);
 
     // Note that locally specified keyboards will be listed before keyboards
     // requested from the remote server by user interfaces that do not order
@@ -136,7 +134,7 @@
   // Script to allow a user to add any keyboard to the keyboard menu
   function addKeyboard(n)
   {
-    var sKbd,kmw=keyman;
+    var sKbd;
     switch(n)
     {
       case 1:
@@ -145,7 +143,7 @@
         break;
       case 2:
         sKbd=document.getElementById('kbd_id2').value.toLowerCase();
-        kmw.addKeyboards('@'+sKbd);
+        keyman.addKeyboards('@'+sKbd);
         break;
       case 3:
         // Add keyboard for comma-separated language name(s)

--- a/web/src/test/manual/web/rotation-events/index.html
+++ b/web/src/test/manual/web/rotation-events/index.html
@@ -27,16 +27,17 @@
 
   <!-- Initialization: set paths to keyboards, resources and fonts as required -->
   <script>
-    var kmw=window.keyman;
-    kmw.init({
+    keyman.init({
       attachType:'auto'
+    }).then(function() {
+      loadKeyboards(1);
     });
   </script>
 
   <!-- Add keyboard management script for local selection of keyboards to use -->
   <script src="../commonHeader.js"></script>
 </head>
-<body onload='loadKeyboards(1);'>
+<body>
 
 <textarea cols=50 rows=20 id='e' style='overflow: scroll' class='kmw-disabled'></textarea>
 <br><br>
@@ -72,8 +73,8 @@
 
     e.value = e.value + event + ': w.iw='+window.innerWidth+' w.ih='+window.innerHeight+orientText+orient+'\n';
 
-    if(event == 'kmw.ri' || event == 'kmw.rh' || event == 'kmw.re') {
-      e.value = e.value + '  osk.w=' + keyman.osk.computedWidth + ' osk.h=' + keyman.osk.computedHeight + ' kmw.vs=' + keyman.util.getViewportScale() + '\n';
+    if(event == 'keyman.ri' || event == 'keyman.rh' || event == 'keyman.re') {
+      e.value = e.value + '  osk.w=' + keyman.osk.computedWidth + ' osk.h=' + keyman.osk.computedHeight + ' keyman.vs=' + keyman.util.getViewportScale() + '\n';
     }
 
     e.scrollTop = e.scrollHeight;
@@ -89,22 +90,22 @@
   window.addEventListener('orientationchange', function() { doLog('orientationchange-b', false) }, false);
   window.addEventListener('orientationchange', function() { doLog('orientationchange-c', false) }, true);
 
-  var kmw_ri = com.keyman.RotationManager.prototype.initNewRotation;
+  var keyman_ri = com.keyman.RotationManager.prototype.initNewRotation;
   com.keyman.RotationManager.prototype.initNewRotation = function() {
-    doLog('kmw.ri');
-    kmw_ri.call(this);
+    doLog('keyman.ri');
+    keyman_ri.call(this);
   }
 
-  var kmw_rh = com.keyman.RotationManager.prototype.iOSEventHandler;
+  var keyman_rh = com.keyman.RotationManager.prototype.iOSEventHandler;
   com.keyman.RotationManager.prototype.iOSEventHandler = function() {
-    doLog('kmw.rh');
-    kmw_rh.call(this);
+    doLog('keyman.rh');
+    keyman_rh.call(this);
   }
 
-  var kmw_irh = com.keyman.RotationManager.prototype.resolve;
+  var keyman_irh = com.keyman.RotationManager.prototype.resolve;
   com.keyman.RotationManager.prototype.resolve = function() {
-    doLog('kmw.re');
-    kmw_irh.call(this);
+    doLog('keyman.re');
+    keyman_irh.call(this);
   }
 </script>
   <p><a href="../">Return to main index.</a>

--- a/web/src/test/manual/web/sentry-integration/errorhdr.js
+++ b/web/src/test/manual/web/sentry-integration/errorhdr.js
@@ -1,27 +1,25 @@
 // JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
 
-/* 
+/*
     This script is designed to test KeymanWeb error message handling.
 */
 
-function loadKeyboards() { 
-  var kmw=keyman;
-  
+function loadKeyboards() {
   // We start by adding a keyboard correctly.  It's best to include a 'control' in our experiment.
-  kmw.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+  keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
     filename:'../us-1.0.js'});
-    
+
   // Insert a keyboard that cannot be found.
-  kmw.addKeyboards({id:'lao_2008_basic',name:'wrong-filename',
+  keyman.addKeyboards({id:'lao_2008_basic',name:'wrong-filename',
     languages:{
       id:'lo',name:'debugging',region:'Asia',
       font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
       },
     filename:'./missing_file.js' // Intentional error - the file doesn't exist, so the <script> tag will raise an error event.
-    });   
-  
+    });
+
   // Insert a keyboard that is unparsable
-  kmw.addKeyboards({id:'unparsable',name:'non-parsable',
+  keyman.addKeyboards({id:'unparsable',name:'non-parsable',
     languages:{
       id:'lo',name:'debugging',region:'Asia',
       font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
@@ -30,23 +28,23 @@ function loadKeyboards() {
       // registration will fail.
     });
 
-// Insert a keyboard that will generate a timing error.  
-  kmw.addKeyboards({id:'timeout',name:'timeout',
+// Insert a keyboard that will generate a timing error.
+  keyman.addKeyboards({id:'timeout',name:'timeout',
     languages:{
       id:'lo',name:'debugging',region:'Asia',
       font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
       },
     filename:'./timeout.js' // Intentional (simulated) error - the file never loads, simulating a server timeout.
-    }); 
+    });
 }
 
 function badStubRequest(entry) {
   switch(entry) {
     case 1:
-      kmw.addKeyboards('1nval1d5tub@reque5t'); 
+      keyman.addKeyboards('1nval1d5tub@reque5t');
       break;
     case 2:
       keyman.addKeyboardsForLanguage(['PigLatn','1337sp34k']);
       break;
-  } 
+  }
 }

--- a/web/src/test/manual/web/sentry-integration/errorhdr.js
+++ b/web/src/test/manual/web/sentry-integration/errorhdr.js
@@ -1,16 +1,16 @@
-// JavaScript Document samplehdr.js: Keyboard management for KeymanWeb demonstration pages
-
 /*
-    This script is designed to test KeymanWeb error message handling.
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * This script is designed to test KeymanWeb error message handling.
 */
 
-function loadKeyboards() {
+async function loadKeyboards() {
   // We start by adding a keyboard correctly.  It's best to include a 'control' in our experiment.
-  keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
+  await keyman.addKeyboards({id:'us',name:'English',languages:{id:'en',name:'English'},
     filename:'../us-1.0.js'});
 
   // Insert a keyboard that cannot be found.
-  keyman.addKeyboards({id:'lao_2008_basic',name:'wrong-filename',
+  await keyman.addKeyboards({id:'lao_2008_basic',name:'wrong-filename',
     languages:{
       id:'lo',name:'debugging',region:'Asia',
       font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
@@ -19,7 +19,7 @@ function loadKeyboards() {
     });
 
   // Insert a keyboard that is unparsable
-  keyman.addKeyboards({id:'unparsable',name:'non-parsable',
+  await keyman.addKeyboards({id:'unparsable',name:'non-parsable',
     languages:{
       id:'lo',name:'debugging',region:'Asia',
       font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
@@ -29,7 +29,7 @@ function loadKeyboards() {
     });
 
 // Insert a keyboard that will generate a timing error.
-  keyman.addKeyboards({id:'timeout',name:'timeout',
+  await keyman.addKeyboards({id:'timeout',name:'timeout',
     languages:{
       id:'lo',name:'debugging',region:'Asia',
       font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
@@ -38,13 +38,13 @@ function loadKeyboards() {
     });
 }
 
-function badStubRequest(entry) {
+async function badStubRequest(entry) {
   switch(entry) {
     case 1:
-      keyman.addKeyboards('1nval1d5tub@reque5t');
+      await keyman.addKeyboards('1nval1d5tub@reque5t');
       break;
     case 2:
-      keyman.addKeyboardsForLanguage(['PigLatn','1337sp34k']);
+      await keyman.addKeyboardsForLanguage(['PigLatn','1337sp34k']);
       break;
   }
 }

--- a/web/src/test/manual/web/sentry-integration/index.html
+++ b/web/src/test/manual/web/sentry-integration/index.html
@@ -42,8 +42,8 @@
     <script>
       keyman.init({
         attachType:'auto'
-      }).then(function () {
-        loadKeyboards(1);
+      }).then(async function () {
+        await loadKeyboards();
       });
 
       var sentryManager = new KeymanSentryManager();

--- a/web/src/test/manual/web/sentry-integration/index.html
+++ b/web/src/test/manual/web/sentry-integration/index.html
@@ -40,9 +40,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
+      }).then(function () {
+        loadKeyboards(1);
       });
 
       var sentryManager = new KeymanSentryManager();
@@ -55,7 +56,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards(1);'>
+  <body>
     <h2>KeymanWeb Sample Page - Sentry Setup test host</h2>
 
     <div>

--- a/web/src/test/manual/web/test-updateLayer/index.html
+++ b/web/src/test/manual/web/test-updateLayer/index.html
@@ -36,9 +36,10 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-  var kmw=window.keyman;
-  kmw.init({
+  keyman.init({
     attachType: 'auto'
+  }).then(function() {
+    loadKeyboards();
   });
     </script>
 
@@ -51,7 +52,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Sample Page - Shift Testing</h2>
     <p>See <a href='https://github.com/keymanapp/keyman/issues/978'>issue #978</a> for details on what this test
     is all about.</p>

--- a/web/src/test/manual/web/test-updateLayer/utilities.js
+++ b/web/src/test/manual/web/test-updateLayer/utilities.js
@@ -1,8 +1,6 @@
-function loadKeyboards() 
-{ 
-  var kmw=keyman;
-
-  kmw.addKeyboards({id:'rac_balti',name:'RAC Balti',
+function loadKeyboards()
+{
+  keyman.addKeyboards({id:'rac_balti',name:'RAC Balti',
     languages:{
       id:'en',name:'English',region:'North America'
     },

--- a/web/src/test/manual/web/text_selection_tests_9073/index.html
+++ b/web/src/test/manual/web/text_selection_tests_9073/index.html
@@ -20,23 +20,21 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      (function(kmw) {
-        kmw.init({
-          attachType:'auto'
-        }).then(function() {
-          kmw.addKeyboards({
-            id:'text_selection_tests_keyboard_9073',
-            name:'Text selection test cases (#9073)',
-            languages:{
-              id:'en',
-              name:'English'
-            },
-            filename:'./text_selection_tests_keyboard_9073.js',
-            displayName: 'Text selection test cases (#9073)'
-          });
+      keyman.init({
+        attachType:'auto'
+      }).then(function() {
+        keyman.addKeyboards({
+          id:'text_selection_tests_keyboard_9073',
+          name:'Text selection test cases (#9073)',
+          languages:{
+            id:'en',
+            name:'English'
+          },
+          filename:'./text_selection_tests_keyboard_9073.js',
+          displayName: 'Text selection test cases (#9073)'
         });
-        })(keyman);
-      </script>
+      });
+    </script>
 
 
   </head>

--- a/web/src/test/manual/web/unminified - manual.html
+++ b/web/src/test/manual/web/unminified - manual.html
@@ -36,8 +36,7 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
 		    attachType:'manual',
       }).then(function() {
         loadKeyboards();
@@ -50,7 +49,7 @@
   </head>
 
 <!-- Sample page HTML -->
-  <body onload='loadKeyboards();'>
+  <body>
     <h2>KeymanWeb Sample Page - Unminified Source</h2>
 
     <div>

--- a/web/src/test/manual/web/unminified.html
+++ b/web/src/test/manual/web/unminified.html
@@ -36,8 +36,7 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
 		    attachType:'auto',
       }).then(function() {
         loadKeyboards();

--- a/web/src/tools/testing/bulk_rendering/index.html
+++ b/web/src/tools/testing/bulk_rendering/index.html
@@ -31,23 +31,22 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
       }).then(function() {
-        kmw.addKeyboards();
+        keyman.addKeyboards();
       });
 
 
       function runRenderer() {
         var renderer_poll = function() {
-          if(kmw.getKeyboards().length == 0) {
+          if(keyman.getKeyboards().length == 0) {
             // Waiting for KeymanWeb to load keyboards
             window.setTimeout(function() {
               renderer_poll();
             }, 1000);
           } else {
-            kmw_renderer.run(document.getElementById('allLayers').checked, document.getElementById('filter').value);
+            keyman_renderer.run(document.getElementById('allLayers').checked, document.getElementById('filter').value);
           }
         }
 

--- a/web/src/tools/testing/bulk_rendering/local-renderer.html
+++ b/web/src/tools/testing/bulk_rendering/local-renderer.html
@@ -32,8 +32,7 @@
 
     <!-- Initialization: set paths to keyboards, resources and fonts as required -->
     <script>
-      var kmw=window.keyman;
-      kmw.init({
+      keyman.init({
         attachType:'auto'
       });
 
@@ -119,7 +118,7 @@
       };
 
       async function runRenderer() {
-        kmw_renderer.run(document.getElementById('allLayers').checked, document.getElementById('filter').value);
+        keyman_renderer.run(document.getElementById('allLayers').checked, document.getElementById('filter').value);
       }
     </script>
   </head>

--- a/web/src/tools/testing/bulk_rendering/renderer_core.ts
+++ b/web/src/tools/testing/bulk_rendering/renderer_core.ts
@@ -326,5 +326,5 @@ export class BatchRenderer {
   // BatchRenderer's internal state stuff is static on the class and is not exposed with
   // the line below.
   // @ts-ignore
-  window['kmw_renderer'] = new BatchRenderer();
+  window['keyman_renderer'] = new BatchRenderer();
 })();

--- a/web/src/tools/testing/recorder/index.html
+++ b/web/src/tools/testing/recorder/index.html
@@ -57,6 +57,8 @@
       keyman.init({
         attachType: 'auto',
         keyboards: ''
+      }).then(function () {
+        loadKeyboards();
       });
 
       document.getElementById("body").focus();
@@ -67,7 +69,7 @@
 
 <!-- Sample page HTML -->
 
-<body id="body" onload='loadKeyboards();'>
+<body id="body">
   <table style="width:100%">
     <tr>
       <td colspan="2">


### PR DESCRIPTION
- replace use of `kmw` with `keyman` 
- unify pattern to load keyboards: do it in `keyman.init().then()` instead   of in the document `onload`

Part-of: keymanapp/keyman.com#449
Test-bot: skip