### PR TITLE
fix(web): fix `KeyboardStub.validateForCustomKeyboard`

### DIFF
--- a/web/src/engine/src/keyboard-storage/keyboardStub.ts
+++ b/web/src/engine/src/keyboard-storage/keyboardStub.ts
@@ -182,9 +182,9 @@ export class KeyboardStub extends KeyboardProperties {
     }
   }
 
-  public validateForCustomKeyboard(): Error {
-    if(super.validateForCustomKeyboard() || !this.KF || !this.KR) {
-      return new Error('To use a custom keyboard, you must specify file name, keyboard id, keyboard name, language, language code, and region.');
+  public validateForCustomKeyboard(): Error|null {
+    if(super.validateForCustomKeyboard() || !this.KF) {
+      return new Error('To use a custom keyboard, you must specify file name, keyboard id, keyboard name, language and language code.');
     } else {
       return null;
     }


### PR DESCRIPTION
This change fixes a misleading error message in `validateForCustomKeyboard` - `KR` is not the region as the error implies - furthermore it doesn't make sense to check `KR` since it is the optional   [keyboard registration function](https://help.keyman.com/developer/engine/web/18.0/reference/interface/registerKeyboard),   so this change removes it.

Test-bot: skip