### PR TITLE
fix(developer): reduce km_core_keyboard_attrs size to 12

### DIFF
--- a/developer/src/tike/main/Keyman.System.KeymanCore.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCore.pas
@@ -239,7 +239,7 @@ type
   km_core_keyboard_attrs = record
     version_string: pkm_core_cu;
     id: pkm_core_cu;
-    default_optons: pkm_core_option_item
+    default_options: pkm_core_option_item
   end;
 
   pkm_core_keyboard_attrs = ^km_core_keyboard_attrs;

--- a/developer/src/tike/main/Keyman.System.KeymanCoreDebug.pas
+++ b/developer/src/tike/main/Keyman.System.KeymanCoreDebug.pas
@@ -186,7 +186,7 @@ initialization
   Assert(sizeof(km_core_context_item) = 8);
   Assert(sizeof(km_core_action_item) = 12);
   Assert(sizeof(km_core_option_item) = 12);
-  Assert(sizeof(km_core_keyboard_attrs) = 16);
+  Assert(sizeof(km_core_keyboard_attrs) = 12);
   Assert(sizeof(km_core_attr) = 16);
 
   //keyman_core_api_debug.h:


### PR DESCRIPTION
Fix regression arising from #15471, caused TIKE to crash on start. Also fix typo in fieldname default_options (not currently used in .pas sources).

Test-bot: skip