### PR TITLE
chore(web): hide KMX keyboard test page

### DIFF
--- a/web/src/test/manual/web/index.html
+++ b/web/src/test/manual/web/index.html
@@ -20,8 +20,10 @@
   </head>
   <body>
 
-  <h1>KeymanWeb 19 Testing</h1>
+  <!--
+  <h1>KeymanWeb 20 Testing</h1>
   <h2><a href="./kmxkeyboard.html">Test KMX keyboard loaded in Keymanweb (kmxkeyboard)</a></h2>
+  -->
 
   <h1>KeymanWeb 17 Testing</h1>
   <h2><a href="./unminified.html">Test unminified Keymanweb (unminified)</a></h2>


### PR DESCRIPTION
Since we removed the .kmx keyboard loading from Keyman 19 the test page no longer works. This change hides the link to the test page.

Build-bot: skip
Test-bot: skip