### PR TITLE
chore(web): remove outdated `*_load.js` files

### DIFF
--- a/developer/src/tike/xml/help/contexthelp.xml
+++ b/developer/src/tike/xml/help/contexthelp.xml
@@ -419,11 +419,6 @@
       <p>Choose a help file to include in the keyboard</p>
     </Control>
 
-    <Control Name="cmdCompileKeymanWeb" Title="Compile to Web">
-      <p>Compiles the keyboard for KeymanWeb.  Two output files will be generated: [filename].js and [filename]_load.js.  The KeymanWeb Tutorial
-      contains more information about the difference between the two output files.</p>
-    </Control>
-
     <Control Name="cmdTestKeymanWeb" Title="Test KeymanWeb Keyboard">
       <p>Tests your KeymanWeb keyboard in an Internet Explorer embedded window</p>
     </Control>

--- a/web/docs/engine/guide/examples/__manual-control.html
+++ b/web/docs/engine/guide/examples/__manual-control.html
@@ -3,10 +3,14 @@
 <head>
   <script src='https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js'></script>
 
-  <script type='text/javascript' src='js/laokeys_load.js'></script>
-
   <script type="text/javascript">
-    keyman.init().then(function() {
+    keyman.init().then(async function() {
+      await keyman.addKeyboards({
+        id: "laokeys",
+        name: "Lao (Phonetic)",
+        languages: { id: 'lo', name: 'Lao' },
+        filename: "./js/laokeys.js"
+      });
       keyman.setActiveKeyboard('laokeys');
       keyman.osk.hide();
     });

--- a/web/docs/engine/guide/examples/js/devanagari_inscript_load.js
+++ b/web/docs/engine/guide/examples/js/devanagari_inscript_load.js
@@ -1,2 +1,0 @@
-﻿/*(C) Copyright 1994-2006 Tavultesoft Pty Ltd. All Rights Reserved. Details: keymanweb.com*/
-KeymanWeb.KRS(new Stub_Keyboard_devanagari_inscript()); function Stub_Keyboard_devanagari_inscript() {this.KF="devanagari_inscript.js";this.KI="Keyboard_devanagari_inscript";this.KN="Devanagari (INSCRIPT)";}

--- a/web/docs/engine/guide/examples/js/european2_load.js
+++ b/web/docs/engine/guide/examples/js/european2_load.js
@@ -1,1 +1,0 @@
-KeymanWeb.KRS(new Stub_Keyboard_european2()); function Stub_Keyboard_european2() {this.KF="european2-1.6.js";this.KI="Keyboard_european2";this.KN="EuroLatin2 Keyboard";}

--- a/web/docs/engine/guide/examples/js/hebrew_load.js
+++ b/web/docs/engine/guide/examples/js/hebrew_load.js
@@ -1,2 +1,0 @@
-﻿/*(C) Copyright 1994-2006 Tavultesoft Pty Ltd. All Rights Reserved. Details: keymanweb.com*/
-KeymanWeb.KRS(new Stub_Keyboard_hebrew()); function Stub_Keyboard_hebrew() {this.KF="hebrew.js";this.KI="Keyboard_hebrew";this.KN="Hebrew";}

--- a/web/docs/engine/guide/examples/js/keymanwebtest_load.js
+++ b/web/docs/engine/guide/examples/js/keymanwebtest_load.js
@@ -1,2 +1,0 @@
-﻿/*(C) Copyright 1994-2006 Tavultesoft Pty Ltd. All Rights Reserved. Details: keymanweb.com*/
-KeymanWeb.KRS(new Stub_Keyboard_keymanwebtest()); function Stub_Keyboard_keymanwebtest() {this.KF="keymanwebtest.js";this.KI="Keyboard_keymanwebtest";this.KN="KeymanWeb Test";}

--- a/web/docs/engine/guide/examples/js/korean_korda_load.js
+++ b/web/docs/engine/guide/examples/js/korean_korda_load.js
@@ -1,2 +1,0 @@
-﻿/*(C) Copyright 1994-2006 Tavultesoft Pty Ltd. All Rights Reserved. Details: keymanweb.com*/
-KeymanWeb.KRS(new Stub_Keyboard_korean_korda()); function Stub_Keyboard_korean_korda() {this.KF="korean_korda.js";this.KI="Keyboard_korean_korda";this.KN="Korean (KORDA) - 30 Day Evaluation";}

--- a/web/docs/engine/guide/examples/js/korean_morse_load.js
+++ b/web/docs/engine/guide/examples/js/korean_morse_load.js
@@ -1,2 +1,0 @@
-﻿/*(C) Copyright 1994-2006 Tavultesoft Pty Ltd. All Rights Reserved. Details: keymanweb.com*/
-KeymanWeb.KRS(new Stub_Keyboard_korean_morse()); function Stub_Keyboard_korean_morse() {this.KF="korean_morse.js";this.KI="Keyboard_korean_morse";this.KN="Korean (Morse) - 30 Day Evaluation";}

--- a/web/docs/engine/guide/examples/js/laokeys_load.js
+++ b/web/docs/engine/guide/examples/js/laokeys_load.js
@@ -1,7 +1,0 @@
-﻿/*(C) Copyright 1994-2021 SIL International. All Rights Reserved. Details: keymanweb.com*/
-keyman.addKeyboards({
-  id: "laokeys",
-  name: "Lao (Phonetic)",
-  languages:{id:'lo',name:'Lao'},
-  filename: "./js/laokeys.js"
-});

--- a/web/docs/engine/guide/examples/manual-control.md
+++ b/web/docs/engine/guide/examples/manual-control.md
@@ -10,7 +10,13 @@ Include the following script in the HEAD of your page:
 
 ```js
 <script>
-    keyman.init().then(function() {
+    keyman.init().then(async function() {
+      await keyman.addKeyboards({
+        id: "laokeys",
+        name: "Lao (Phonetic)",
+        languages:{id:'lo',name:'Lao'},
+        filename: "./js/laokeys.js"
+      });
       keyman.setActiveKeyboard('laokeys');
       keyman.osk.hide();
     });
@@ -33,12 +39,8 @@ Also include the following HTML code:
 <head>
     <!-- Load the KeymanWeb engine -->
     <script src="https://s.keyman.com/kmw/engine/17.0.331/keymanweb.js" type="text/javascript"></script>
-    <!-- Load the LaoKeys keyboard stub -->
-    <script src="laokeys_load.js" type="text/javascript"></script>
 </head>
 ```
-
-- File: [laokeys_load.js](js/laokeys_load.js)
 
 And finally, include the control img for KeymanWeb:
 

--- a/web/src/engine/src/main/keyboardInterfaceBase.ts
+++ b/web/src/engine/src/main/keyboardInterfaceBase.ts
@@ -85,7 +85,6 @@ export class KeyboardInterfaceBase<ContextManagerType extends ContextManagerBase
     //
     // It may also be used by documented legacy API:
     // https://help.keyman.com/developer/engine/web/2.0/guide/examples/manual-control
-    // (See: referenced laokeys_load.js)
     //
     // The mobile apps typically have fully-preconfigured paths, but Developer's
     // test-host page does not.


### PR DESCRIPTION
This change removes unused `*_load.js` files and inlines the code from `laokeys_load.js`. Current Keyman versions no longer produce _load.js files when compiling a keyboard, so these files were pretty outdated.

Build-bot: skip build:web
Test-bot: skip