### PR TITLE
fix(core): use meson subsystem and needs_exe_wrapper for cross builds on Windows

### DIFF
--- a/.github/workflows/core-arm64-windows-test.yml
+++ b/.github/workflows/core-arm64-windows-test.yml
@@ -119,7 +119,7 @@ jobs:
     - name: Install meson
       shell: bash
       run: |
-        pip3 install --user meson==1.10.1
+        pip3 install --user meson==1.11.0
 
     - name: Run test
       shell: bash

--- a/core/cross-arm64.build
+++ b/core/cross-arm64.build
@@ -1,5 +1,6 @@
 [host_machine]
 system = 'windows'
+subsystem = 'windows'
 cpu_family = 'aarch64'
 cpu = 'arm64'
 endian = 'little'

--- a/core/cross-x64.build
+++ b/core/cross-x64.build
@@ -1,5 +1,6 @@
 [host_machine]
 system = 'windows'
+subsystem = 'windows'
 cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'
@@ -11,3 +12,6 @@ ar = 'lib'
 ld = 'link'
 strip = 'llvm-strip'
 pkgconfig = 'pkg-config'
+
+[properties]
+needs_exe_wrapper = false


### PR DESCRIPTION
Relates-to: mesonbuild/meson#15840
Fixes: #15753
Test-bot: skip