### PR TITLE
docs(windows): add context documentation for additional Advanced options

### DIFF
--- a/windows/docs/help/basic/config/options.md
+++ b/windows/docs/help/basic/config/options.md
@@ -180,6 +180,28 @@ To open the Options tab of Keyman Configuration:
     log on for short and isolated tests as specifically requested by
     Keyman Technical Support.
 
+-   Proxy Settings
+
+    In some environments, you may need to configure proxy settings in
+    order to download keyboards or updates for Keyman. Check with your
+    network administrator. More information is available in the
+    [Proxy Configuration](../../advanced/proxy_config) documentation.
+
+-   Keyman System Settings
+
+    The Keyman System Settings dialog provides access to various low-level
+    Keyman configuration settings. Generally, these settings do not need
+    to be changed, unless you instructed to do so by Keyman support staff.
+
+-   Base Keyboard
+
+    The Base Keyboard dialog allows you to select the physical Latin-script
+    layout of your keyboard, which will allow certain Keyman keyboards to remap
+    themselves dynamically to match your key caps.
+
+    [Base Keyboard dialog](../../context/base-keyboard)
+
+
 ## Related Topics
 
 -   [Keyman Configuration](../config/)


### PR DESCRIPTION
Add Base Keyboard, Proxy Settings, and Keyman System Settings documentation and links to the Options context help.

Fixes: keymanapp/help.keyman.com#10
Test-bot: skip