### PR TITLE
chore: update multi-labeler to 5.0.0

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Update labels based on changed files
-      uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+      uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
     - name: Update labels based on PR title
       id: labeler
-      uses: fuxingloh/multi-labeler@f5bd7323b53b0833c1e4ed8d7b797ae995ef75b4 # v2.0.1
+      uses: fuxingloh/multi-labeler@bcd50af464202999e57f556b4aefcf05a34abf85 # v5.0.0
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         config-path: .github/multi-labeler.yml


### PR DESCRIPTION
Also update actions/labeler to 6.1.0. This moves to node v24.

Relates-to: keymanapp/s.keyman.com#1607
Test-bot: skip
Build-bot: skip