### PR TITLE
fix(developer): map shift key nextlayer property when importing OSK

### DIFF
--- a/developer/src/kmconvert/Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter.pas
+++ b/developer/src/kmconvert/Keyman.Developer.System.VisualKeyboardToTouchLayoutConverter.pas
@@ -319,6 +319,23 @@ function TVisualKeyboardToTouchLayoutConverter.SetupModifierKeysForImportedLayou
 
     for l in p.Layers do
     begin
+      // Find the Shift key and assign the next layer
+      k := l.FindKeyById('K_SHIFT');
+      if Assigned(k) then
+      begin
+        if l.id = 'default' then
+        begin
+          k.NextLayer := 'shift';
+        end
+        else
+        begin
+          // All layers other than default will return to default layer
+          // when shift is pressed, because we do not currently map
+          // shift+other mod layers with use of the Shift key in the import
+          k.NextLayer := 'default';
+        end;
+      end;
+
       // Find the Ctrl key for the layer
       k := l.FindKeyById('K_LCONTROL');
       if not Assigned(k) then


### PR DESCRIPTION
This is a minimal patch to address the problem where the imported shift key has no 'nextlayer' property. The whole import could stand to be rewritten in Typescript one day!

Fixes: #14227
Test-bot: skip