### PR TITLE
fix(windows): add update property to remote check

### DIFF
--- a/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
+++ b/windows/src/desktop/kmshell/main/Keyman.System.RemoteUpdateCheck.pas
@@ -158,6 +158,7 @@ begin
     try
       http.Fields.Add('version', ansistring(CKeymanVersionInfo.Version));
       http.Fields.Add('tier', ansistring(CKeymanVersionInfo.Tier));
+      http.Fields.Add('update', '1'); // This is checking for an update
       if FForce then
         http.Fields.Add('manual', '1')
       else


### PR DESCRIPTION
This just adds the update property to the HTTP request in the RemoteUpdateCheck call.

Fixes: #15433

Test-bot: skip