### PR TITLE
fix(developer): warn only on race when destroying TAppSourceHttpResponder

### DIFF
--- a/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
+++ b/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
@@ -76,10 +76,6 @@ var
 begin
   T := FSources.LockList;
   try
-    // Note: Unlike regular functions, Assert has short-circuit evaluation
-    // intrinsics on the first param which makes it safe to dereference T[0] in
-    // the second parameter.
-
     // There is a race where RegisterSource is called on the server side
     // where a request is started in the form but the server does not respond
     // before the form is destroyed:

--- a/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
+++ b/developer/src/tike/http/Keyman.Developer.System.HttpServer.AppSource.pas
@@ -79,8 +79,23 @@ begin
     // Note: Unlike regular functions, Assert has short-circuit evaluation
     // intrinsics on the first param which makes it safe to dereference T[0] in
     // the second parameter.
-    Assert(T.Count = 0, 'TAppSourceHttpResponder.Sources should be empty at destruction '+
-      '(T.Count='+IntToStr(T.Count)+', T[0].Filename='+T[0].Filename+')');
+
+    // There is a race where RegisterSource is called on the server side
+    // where a request is started in the form but the server does not respond
+    // before the form is destroyed:
+    //  1. http request starts on form
+    //  2. Form destroyed, calls UnregisterSource
+    //  3. http request received in TAppSourceHttpResponder,
+    //     RespondTouchEditorState calls RegisterSource
+    //  4. Ooops
+
+    // There is another race somewhere with unsaved text editors, or else a
+    // resource leak. For now, we'll report this as a message rather than crash.
+    if T.Count > 0 then
+    begin
+      TKeymanSentryClient.Instance.ReportMessage('TAppSourceHttpResponder.Sources should be empty at destruction '+
+       '(T.Count='+IntToStr(T.Count)+', T[0].Filename='+T[0].Filename+')', True);
+    end;
   finally
     FSources.UnlockList;
   end;

--- a/developer/src/tike/main/UframeTextEditor.pas
+++ b/developer/src/tike/main/UframeTextEditor.pas
@@ -486,7 +486,12 @@ procedure TframeTextEditor.LoadFileInBrowser(const AData: string);
   function GenerateNewFilename: string;
   begin
     Inc(FInitialFilenameIndex);
-    Result := '*texteditor*'+IntToStr(FInitialFilenameIndex);
+    Result := '*texteditor';
+    if Owner <> nil then
+      Result := Result + '*' + Owner.ClassName;
+    if Parent <> nil then
+      Result := Result + '*' + Parent.Name;
+    Result := Result + '*'+IntToStr(FInitialFilenameIndex);
   end;
   function EncodeFont(const prefix: string; f: TFont): string;
   begin


### PR DESCRIPTION
I uncovered one race, documented in the source. Not trying to resolve that race at this time (it is not consequential). There is a second condition which is unclear -- and may have other consequences. So report a warning to Sentry when this arises, but do not crash out on the user.

Fixes: #11916
Test-bot: skip