### PR TITLE
chore(android): use gradle version catalog for dependencies and versions

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -169,20 +169,20 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'com.google.android.material:material:1.12.0'
-    implementation 'com.stepstone.stepper:material-stepper:4.3.1'
-    implementation 'androidx.webkit:webkit:1.14.0'
+    implementation libs.appcompat
+    implementation libs.constraintlayout
+    implementation libs.material
+    implementation libs.material.stepper
+    implementation libs.webkit
     implementation files('libs/keyman-engine.aar')
-    implementation 'io.sentry:sentry-android:8.19.1'
-    implementation 'androidx.preference:preference:1.2.1'
-    implementation 'com.android.installreferrer:installreferrer:2.2'
+    implementation libs.sentry
+    implementation libs.preference
+    implementation libs.installreferrer
 
     // Add dependency for generating QR Codes
     // (Even though it's embedded in KMEA, because we're manually copying keyman-engine.aar,
     // we "lose" it in the dependency management)
-    implementation ('com.github.kenglxn.QRGen:android:3.0.1') {
+    implementation (libs.qrgen) {
         transitive = true
     }
 }

--- a/android/KMAPro/settings.gradle
+++ b/android/KMAPro/settings.gradle
@@ -1,1 +1,9 @@
 include ':kMAPro'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../common/gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -64,23 +64,21 @@ android {
 }
 
 dependencies {
-    // 1.6.0-rc01 needed to resolve https://issuetracker.google.com/issues/238425626
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    // material:1.7.0 will need Gradle plugin 7.1.0+
-    implementation 'com.google.android.material:material:1.12.0'
-    implementation 'commons-io:commons-io:2.16.1'
-    implementation 'io.sentry:sentry-android:8.19.1'
-    implementation 'androidx.preference:preference:1.2.1'
-    implementation 'androidx.webkit:webkit:1.14.0'
+    implementation libs.appcompat
+    implementation libs.constraintlayout
+    implementation libs.material
+    implementation libs.commons.io
+    implementation libs.sentry
+    implementation libs.preference
+    implementation libs.webkit
 
     // Robolectric
-    testImplementation 'androidx.test.ext:junit:1.2.1'
-    testImplementation 'org.robolectric:robolectric:4.14.1'
-    testImplementation 'androidx.test:core:1.6.1'
+    testImplementation libs.junit
+    testImplementation libs.robolectric
+    testImplementation libs.core
 
     // Generate QR Codes
-    implementation ('com.github.kenglxn.QRGen:android:3.0.1') {
+    implementation (libs.qrgen) {
         transitive = true
     }
 }

--- a/android/KMEA/settings.gradle
+++ b/android/KMEA/settings.gradle
@@ -1,1 +1,9 @@
 include ':app'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../common/gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -45,9 +45,9 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation libs.appcompat
+    implementation libs.constraintlayout
+    implementation libs.material
     implementation files('libs/keyman-engine.aar')
-    implementation 'androidx.preference:preference:1.2.1'
+    implementation libs.preference
 }

--- a/android/Samples/KMSample1/settings.gradle
+++ b/android/Samples/KMSample1/settings.gradle
@@ -1,1 +1,9 @@
 include ':app'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../common/gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -44,9 +44,9 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation libs.appcompat
+    implementation libs.constraintlayout
+    implementation libs.material
     implementation files('libs/keyman-engine.aar')
-    implementation 'androidx.preference:preference:1.2.1'
+    implementation libs.preference
 }

--- a/android/Samples/KMSample2/settings.gradle
+++ b/android/Samples/KMSample2/settings.gradle
@@ -1,1 +1,9 @@
 include ':app'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../../common/gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -55,9 +55,9 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation libs.appcompat
+    implementation libs.constraintlayout
+    implementation libs.material
     implementation files('libs/keyman-engine.aar')
-    implementation 'androidx.preference:preference:1.2.1'
+    implementation libs.preference
 }

--- a/android/Tests/keycode/app/build.gradle
+++ b/android/Tests/keycode/app/build.gradle
@@ -34,10 +34,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'com.google.android.material:material:1.12.0'
-    testImplementation 'androidx.test.ext:junit:1.2.1'
-    testImplementation 'org.robolectric:robolectric:4.14.1'
-    testImplementation 'androidx.test:core:1.6.1'
+    implementation libs.appcompat
+    implementation libs.constraintlayout
+    implementation libs.material
+    testImplementation libs.junit
+    testImplementation libs.robolectric
+    testImplementation libs.core
 }

--- a/android/common/gradle/libs.versions.toml
+++ b/android/common/gradle/libs.versions.toml
@@ -1,0 +1,29 @@
+[versions]
+appcompat = "1.7.0"
+commons-io = "2.16.1"
+constraintlayout = "2.2.1"
+core = "1.6.1"
+installreferrer = "2.2"
+junit = "1.2.1"
+material = "1.12.0"
+material-stepper = "4.3.1"
+preference = "1.2.1"
+qrgen = "3.0.1"
+robolectric = "4.14.1"
+sentry = "8.19.1"
+webkit = "1.14.0"
+
+[libraries]
+appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+commons-io = { group = "commons-io", name = "commons-io", version.ref = "commons-io" }
+constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+core = { group = "androidx.test", name = "core", version.ref = "core" }
+installreferrer = { group = "com.android.installreferrer", name = "installreferrer", version.ref = "installreferrer" }
+junit = { group = "androidx.test.ext", name = "junit", version.ref = "junit" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+material-stepper = { group = "com.stepstone.stepper", name = "material-stepper", version.ref = "material-stepper" }
+preference = { group = "androidx.preference", name = "preference", version.ref = "preference" }
+qrgen = { group = "com.github.kenglxn.QRGen", name = "android", version.ref = "qrgen" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+sentry = { group = "io.sentry", name = "sentry-android", version.ref = "sentry" }
+webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }


### PR DESCRIPTION
This change moves to using Gradle's version catalog. This allows to specify the dependency details and versions only once and then reference them from the `build.gradle` files.

Test-bot: skip