### PR TITLE
fix(ios): bundle in KMW's globe-hint.css

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -13,6 +13,7 @@ samples/KMSample2/KeymanEngine.xcframework
 samples/KMSample2/build
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keymanios.js
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keymanweb-osk.ttf
+engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/globe-hint.css
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/kmwosk.css
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keyman.js.map
 engine/KMEI/KeymanEngine/resources/Keyman.bundle/Contents/Resources/keymanweb-webview.js

--- a/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Keyboard/KeymanWebViewController.swift
@@ -182,7 +182,7 @@ extension KeymanWebViewController {
     }
     view = nil
   }
-  
+
   func languageMenuPosition(_ completion: @escaping (CGRect) -> Void) {
     webView!.evaluateJavaScript("langMenuPos();") { result, _ in
       guard let result = result as? String, !result.isEmpty else {

--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/Storage.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/Storage.swift
@@ -246,6 +246,10 @@ extension Storage {
                      dstDir: baseDir,
                      excludeFromBackup: true)
     try Storage.copy(from: bundle,
+                     resourceName: "globe-hint.css",
+                     dstDir: baseDir,
+                     excludeFromBackup: true)
+    try Storage.copy(from: bundle,
                      resourceName: "keymanweb-osk.ttf",
                      dstDir: baseDir,
                      excludeFromBackup: true)

--- a/ios/engine/build.sh
+++ b/ios/engine/build.sh
@@ -102,7 +102,7 @@ function update_bundle ( ) {
   KMW_PRODUCT="$KEYMAN_ROOT/web/build/app/webview/$CONFIG"
   KMW_RESOURCES="$KEYMAN_ROOT/web/build/app/resources"
 
-  # Copy over the relevant resources!  It's easiest to do if we navigate to the resulting folder.
+  # Copy relevant KeymanWeb resources; this list is also in Storage.swift
   cp "$KMW_RESOURCES/osk/globe-hint.css"        "$BUNDLE_PATH/globe-hint.css"
   cp "$KMW_RESOURCES/osk/kmwosk.css"            "$BUNDLE_PATH/kmwosk.css"
   cp "$KMW_RESOURCES/osk/keymanweb-osk.ttf"     "$BUNDLE_PATH/keymanweb-osk.ttf"

--- a/ios/engine/build.sh
+++ b/ios/engine/build.sh
@@ -102,7 +102,8 @@ function update_bundle ( ) {
   KMW_PRODUCT="$KEYMAN_ROOT/web/build/app/webview/$CONFIG"
   KMW_RESOURCES="$KEYMAN_ROOT/web/build/app/resources"
 
-  #Copy over the relevant resources!  It's easiest to do if we navigate to the resulting folder.
+  # Copy over the relevant resources!  It's easiest to do if we navigate to the resulting folder.
+  cp "$KMW_RESOURCES/osk/globe-hint.css"        "$BUNDLE_PATH/globe-hint.css"
   cp "$KMW_RESOURCES/osk/kmwosk.css"            "$BUNDLE_PATH/kmwosk.css"
   cp "$KMW_RESOURCES/osk/keymanweb-osk.ttf"     "$BUNDLE_PATH/keymanweb-osk.ttf"
   cp "$KMW_PRODUCT/keymanweb-webview.js"        "$BUNDLE_PATH/keymanweb-webview.js"


### PR DESCRIPTION
Pretty much just what the title says; it's been silently missing this whole time.

This doesn't fix iOS keyboard's display by itself, but it is a prerequisite for the full solution offered by #16136.

Build-bot: skip build:ios
Test-bot: skip