### PR TITLE
maint(linux): show output of API check also in log file

### DIFF
--- a/.github/workflows/api-verification.yml
+++ b/.github/workflows/api-verification.yml
@@ -71,7 +71,7 @@ jobs:
     - name: "Verify API for libkeymancore*.so (${{ steps.environment_step.outputs.GIT_BRANCH }}, branch ${{ steps.environment_step.outputs.GIT_BASE_BRANCH }}, by ${{ steps.environment_step.outputs.GIT_USER }})"
       if: steps.environment_step.outputs.SKIP_API_CHECK != 'true'
       run: |
-        echo "Verify API for libkeymancore*.so (${{ steps.environment_step.outputs.GIT_BRANCH }}, branch ${{ steps.environment_step.outputs.GIT_BASE_BRANCH }}, by ${{ steps.environment_step.outputs.GIT_USER }}):" >> $GITHUB_STEP_SUMMARY
+        echo "Verify API for libkeymancore*.so (${{ steps.environment_step.outputs.GIT_BRANCH }}, branch ${{ steps.environment_step.outputs.GIT_BASE_BRANCH }}, by ${{ steps.environment_step.outputs.GIT_USER }}):" | tee -a ${GITHUB_STEP_SUMMARY}
 
         BIN_PACKAGE=$(ls "${GITHUB_WORKSPACE}/artifacts/" | grep "${PKG_NAME}[0-9]*_${{ steps.environment_step.outputs.KEYMAN_VERSION }}-1${{ steps.environment_step.outputs.PRERELEASE_TAG }}+$(lsb_release -c -s)1_amd64.deb")
         cd ${{ github.workspace }}/keyman/linux
@@ -80,7 +80,7 @@ jobs:
           --bin-pkg "${GITHUB_WORKSPACE}/artifacts/${BIN_PACKAGE}" \
           --git-sha "${{ steps.environment_step.outputs.GIT_SHA }}" \
           --git-base "${{ steps.environment_step.outputs.GIT_BASE }}" \
-          verify 2>> $GITHUB_STEP_SUMMARY
+          verify 2> >(tee -a ${GITHUB_STEP_SUMMARY} >&2)
 
     - name: Archive .symbols file
       if: steps.environment_step.outputs.SKIP_API_CHECK != 'true' && always()


### PR DESCRIPTION
Previously the output of running the API check was only shown on the summary page, but not in the log file of the step. With this change it is now also displayed in the log file.

Related: #16151
Build-bot: skip
Test-bot: skip