### PR TITLE
chore(android): allow to build FV app in docker container

### DIFF
--- a/resources/docker-images/run.sh
+++ b/resources/docker-images/run.sh
@@ -44,6 +44,9 @@ else
 fi
 
 run_android() {
+  if [[ -n ${RELEASE_OEM:-} ]] && [[ -n ${RELEASE_OEM_FIRSTVOICES:-} ]]; then
+    DOCKER_RUN_ARGS+=(-e "RELEASE_OEM=${RELEASE_OEM:-}" -e "RELEASE_OEM_FIRSTVOICES=${RELEASE_OEM_FIRSTVOICES:-}")
+  fi
   docker_wrapper run "${DOCKER_RUN_ARGS[@]}" -i --rm -v "${KEYMAN_ROOT}":/home/build/build \
     -v "${KEYMAN_ROOT}/core/build/docker-core/${build_dir}":/home/build/build/core/build \
     "${registry_slash}keymanapp/keyman-android-ci:${image_version}" \


### PR DESCRIPTION
Building the FirstVoices app is triggered in the top-level `build.sh` if the two environment variables are set. Previously we didn't pass these variables to Docker, so the FV app was never built even when the env variables were set. This change passes the two variables to the container, thus allowing to build the FW app in the docker container.

Build-bot: skip
Test-bot: skip