### PR TITLE
refactor(web): rename `keymanweb` to `keyman` in UI modules

### DIFF
--- a/web/src/app/ui/kmwuibutton.ts
+++ b/web/src/app/ui/kmwuibutton.ts
@@ -11,14 +11,14 @@ declare global {
   }
 }
 
-const keymanweb=window.keyman;
+const keyman=window.keyman;
 
 // If a UI module has been loaded, we can rely on the publically-published 'name' property
 // having been set as a way to short-out a UI reload.  Its parent object always exists by
 // this point in the build process.
-if(!keymanweb) {
+if(!keyman) {
   throw new Error("`keyman` global is missing; Keyman Engine for Web script has not been loaded");
-} else if(!keymanweb.ui?.name) {
+} else if(!keyman.ui?.name) {
 
   /********************************/
   /*                              */
@@ -37,8 +37,8 @@ if(!keymanweb) {
 
   try {
     // Declare KeymanWeb, OnScreen keyboard and Util objects
-    const util=keymanweb.util;
-    // var dbg=keymanweb['debug'];
+    const util=keyman.util;
+    // var dbg=keyman['debug'];
 
     // Disable UI for touch devices
     if(util.isTouchDevice()) {
@@ -78,8 +78,8 @@ if(!keymanweb) {
        * Highlight the currently active keyboard in the list of keyboards
        **/
       private _ShowSelected() {
-        const kbd=keymanweb.getActiveKeyboard();
-        const lgc=keymanweb.getActiveLanguage();
+        const kbd=keyman.getActiveKeyboard();
+        const lgc=keyman.getActiveLanguage();
         const kList = this._KeymanWeb_KbdList.childNodes;
         const _r = /^KMWSel_(.*)\$(.*)$/;
 
@@ -135,13 +135,13 @@ if(!keymanweb) {
             _k.className='selected';
           }
           this._KMWSel = _k;
-          await keymanweb.setActiveKeyboard(_name,_lgc);
+          await keyman.setActiveKeyboard(_name,_lgc);
         } else {
           _name=null;
         }
 
-        keymanweb.focusLastActiveElement();
-        const osk = keymanweb.osk;
+        keyman.focusLastActiveElement();
+        const osk = keyman.osk;
         if(osk && osk.isEnabled()) {
           osk.show(true);
         }
@@ -156,17 +156,17 @@ if(!keymanweb) {
        * @param       {Event}    e     event
        */
       readonly _SelectorMouseDown = (e: MouseEvent) => {
-        const x=keymanweb.getLastActiveElement();
+        const x=keyman.getLastActiveElement();
 
         // Set the focus to an input field, to get correct OSK display behaviour
         if(!x) {
           this._FocusFirstInput();
         } else {
-          keymanweb.focusLastActiveElement();
+          keyman.focusLastActiveElement();
         }
 
-        if(keymanweb.activatingUI) {
-          keymanweb.activatingUI(1);
+        if(keyman.activatingUI) {
+          keyman.activatingUI(1);
         }
       }
 
@@ -176,13 +176,13 @@ if(!keymanweb) {
        * @param       {Event}    e     event
        */
       readonly _SelectorMouseUp = (e: MouseEvent) => {
-        const x=keymanweb.getLastActiveElement();
+        const x=keyman.getLastActiveElement();
 
         // Set the focus to an input field, to get correct OSK display behaviour
         if(!x) {
           this._FocusFirstInput();
         } else {
-          keymanweb.focusLastActiveElement();
+          keyman.focusLastActiveElement();
         }
       }
 
@@ -195,8 +195,8 @@ if(!keymanweb) {
         // highlight the currently active keyboard
         this._ShowSelected();
 
-        if(keymanweb.activatingUI) {
-          keymanweb.activatingUI(1);
+        if(keyman.activatingUI) {
+          keyman.activatingUI(1);
         }
 
         document.getElementById("kmwico_li").className="sfhover";
@@ -253,8 +253,8 @@ if(!keymanweb) {
        * @param       {Event}    e     event
        */
       private readonly _SelectorMouseOut = (e: MouseEvent) => {
-        if(keymanweb.activatingUI) {
-          keymanweb.activatingUI(0);
+        if(keyman.activatingUI) {
+          keyman.activatingUI(0);
         }
         document.getElementById("kmwico_li").className="sfunhover";
       }
@@ -265,24 +265,24 @@ if(!keymanweb) {
        * @param       {?string=}  _name     current keyboard name
        */
       private _ShowKeyboardButton(_name?: string) {
-        let kbdName = keymanweb.getActiveKeyboard();
+        let kbdName = keyman.getActiveKeyboard();
         const kbdId = document.getElementById("KMW_Keyboard");
         if(arguments.length > 0) {
           kbdName = _name;
         }
 
         if(kbdId) {
-          if((kbdName == '') || keymanweb.isCJK()) {
+          if((kbdName == '') || keyman.isCJK()) {
             kbdId.className='kmw_disabled';
           } else {
-            const osk = keymanweb.osk;
+            const osk = keyman.osk;
             kbdId.className = osk && osk.isEnabled() ? 'kmw_show' : 'kmw_hide';
           }
         }
       }
 
       registerEvents() {
-        const osk = keymanweb.osk;
+        const osk = keyman.osk;
         if(!osk) {
           return;
         }
@@ -290,7 +290,7 @@ if(!keymanweb) {
          * UI Functions called by KeymanWeb or OSK
          */
         osk.addEventListener('show', (oskPosition) => {
-          const t=keymanweb.getLastActiveElement();
+          const t=keyman.getLastActiveElement();
           if(t) {
             if(!oskPosition['userLocated']) {
               oskPosition['x'] = util.getAbsoluteX(t);
@@ -321,7 +321,7 @@ if(!keymanweb) {
        **/
       readonly _ShowKeymanWebKeyboard = () => {
         const kbdId=document.getElementById("KMW_Keyboard");
-        const osk = keymanweb.osk;
+        const osk = keyman.osk;
 
         if((kbdId.className!='kmw_disabled') && osk && osk.show) {
           if(osk.isEnabled()) {
@@ -334,7 +334,7 @@ if(!keymanweb) {
           window.event.returnValue=false;
         }
 
-        keymanweb.focusLastActiveElement();
+        keyman.focusLastActiveElement();
         return false;
       }
 
@@ -348,7 +348,7 @@ if(!keymanweb) {
         }
 
         //Never initialize UI before KMW (parameters will be undefined)
-        if(!keymanweb.initialized) {
+        if(!keyman.initialized) {
           this.initTimer = window.setTimeout(this.initialize, 50);
           return;
         }
@@ -417,7 +417,7 @@ if(!keymanweb) {
         // Even tag `release-web-stable-2.0` turns up results only for this specific sourcefile.
         // Thus, in essence:  if(true) { /* ... */ }
         // @ts-ignore
-        if(!keymanweb['iOS']) {
+        if(!keyman['iOS']) {
           const _li = util.createElement('li');
           const _a = util.createElement('a');
           const _img = util.createElement('img');
@@ -468,7 +468,7 @@ if(!keymanweb) {
         util.attachDOMEvent(_sfEl,'mouseup',this._SelectorMouseUp);
 
         this.registerEvents();
-        keymanweb.focusLastActiveElement();  	//TODO: this needs to be extended - if no element is active, try and identify an enabled input element
+        keyman.focusLastActiveElement();  	//TODO: this needs to be extended - if no element is active, try and identify an enabled input element
       }
 
       shutdown() {
@@ -493,7 +493,7 @@ if(!keymanweb) {
           this._KeymanWeb_KbdList.removeChild(this._KeymanWeb_KbdList.childNodes[i-1]);
         }
 
-        const kbds=keymanweb.getKeyboards();
+        const kbds=keyman.getKeyboards();
         if(kbds.length > 0) {
           for(let i:number=0; i<kbds.length; i++) {
             this.registerKeyboard(
@@ -659,7 +659,7 @@ if(!keymanweb) {
 `
     }
 
-    const ui = keymanweb.ui = new UIButton();
+    const ui = keyman.ui = new UIButton();
 
     /**
      * Keyboard registration event handler
@@ -667,7 +667,7 @@ if(!keymanweb) {
      * Set a timer to update the UI keyboard list on timeout after each keyboard is registered,
      * thus updating only once when only if multiple keyboards are registered together
      */
-    keymanweb.addEventListener('keyboardregistered', function(p) {
+    keyman.addEventListener('keyboardregistered', function(p) {
       ui.updateList = true;
       if(ui.updateTimer) {
         clearTimeout(ui.updateTimer);

--- a/web/src/app/ui/kmwuifloat.ts
+++ b/web/src/app/ui/kmwuifloat.ts
@@ -11,14 +11,14 @@ declare global {
   }
 }
 
-const keymanweb=window.keyman;
+const keyman=window.keyman;
 
 // If a UI module has been loaded, we can rely on the publically-published 'name' property
 // having been set as a way to short-out a UI reload.  Its parent object always exists by
 // this point in the build process.
-if(!keymanweb) {
+if(!keyman) {
   throw new Error("`keyman` global is missing; Keyman Engine for Web script has not been loaded");
-} else if(!keymanweb.ui?.name) {
+} else if(!keyman.ui?.name) {
   /********************************/
   /*                              */
   /* Floating User Interface      */
@@ -37,7 +37,7 @@ if(!keymanweb) {
   try {
 
     // Declare KeymanWeb, OnScreen keyboard and Util objects
-    const util=keymanweb.util;
+    const util=keyman.util;
 
     // Disable UI for touch devices
     if(util.isTouchDevice()) {
@@ -87,8 +87,8 @@ if(!keymanweb) {
        * Display or hide the OSK from the OSK icon link
        */
       readonly toggleOSK = () => {
-        keymanweb.activatingUI(true);
-        const osk = keymanweb.osk;
+        keyman.activatingUI(true);
+        const osk = keyman.osk;
         if(osk && osk.show) {
           if(osk.isEnabled()) {
             osk.hide();
@@ -99,8 +99,8 @@ if(!keymanweb) {
         if(window.event) {
           window.event.returnValue=false;
         }
-        keymanweb.focusLastActiveElement();
-        keymanweb.activatingUI(false);
+        keyman.focusLastActiveElement();
+        keyman.activatingUI(false);
         return false;
       }
 
@@ -116,7 +116,7 @@ if(!keymanweb) {
         }
 
         // Must always initialize after keymanWeb itself, otherwise options are undefined
-        if(!keymanweb.initialized) {
+        if(!keyman.initialized) {
           this.initTimer = window.setTimeout(this.initialize, 50);
           return;
         }
@@ -239,7 +239,7 @@ if(!keymanweb) {
           }
 
           // Loop over installed keyboards and add to selection list
-          const Lkbds=keymanweb.getKeyboards();
+          const Lkbds=keyman.getKeyboards();
 
           for(let Ln=0; Ln<Lkbds.length; Ln++) {
             let Lopt = util.createElement('option');
@@ -262,21 +262,21 @@ if(!keymanweb) {
         this.updateList = false;
 
         // Set the menu selector to the last active keyboard
-        let activeKeyboard = keymanweb.getActiveKeyboard();
+        let activeKeyboard = keyman.getActiveKeyboard();
         let activeLanguage = '';
         if (activeKeyboard) {
-          activeLanguage = keymanweb.getActiveLanguage();
+          activeLanguage = keyman.getActiveLanguage();
         } else {
           // savedKeyboard is only correct if we use global keyboard settings,
           // otherwise it's set to the first keyboard in the list
-          const savedKeyboard = keymanweb.getSavedKeyboard().split(':');
+          const savedKeyboard = keyman.getSavedKeyboard().split(':');
           activeKeyboard = savedKeyboard[0];
           activeLanguage = savedKeyboard.length < 2 ? '' : savedKeyboard[1];
         }
         this.updateMenu(activeKeyboard, activeLanguage);
 
         // Redisplay the UI to correct width for any new language entries
-        if(keymanweb.getLastActiveElement()) {
+        if(keyman.getLastActiveElement()) {
           this.HideInterface();
           this.ShowInterface();
         }
@@ -355,7 +355,7 @@ if(!keymanweb) {
          * Set a timer to update the UI keyboard list on timeout after each keyboard is registered,
          * thus updating only once when only if multiple keyboards are registered together
          */
-        keymanweb.addEventListener('keyboardregistered', (p) => {
+        keyman.addEventListener('keyboardregistered', (p) => {
           this.updateList = true;
           if(this.updateTimer) {
             clearTimeout(this.updateTimer);
@@ -371,8 +371,8 @@ if(!keymanweb) {
          * Note: Cannot simply set it to the loaded keyboard,
          *       as more than one language may be supported by that keyboard.
          */
-        keymanweb.addEventListener('keyboardloaded', (p) => {
-          const sk = keymanweb.getSavedKeyboard().split(':');
+        keyman.addEventListener('keyboardloaded', (p) => {
+          const sk = keyman.getSavedKeyboard().split(':');
           if(sk.length > 1) {
             this.updateMenu(sk[0],sk[1]);
           }
@@ -383,7 +383,7 @@ if(!keymanweb) {
          *
          * Update menu selection and control OSK display appropriately
          */
-        keymanweb.addEventListener('keyboardchange', (p) => {
+        keyman.addEventListener('keyboardchange', (p) => {
           // Update the keyboard selector whenever a keyboard is loaded
           this.updateMenu(p.internalName, p.languageCode);
 
@@ -391,7 +391,7 @@ if(!keymanweb) {
           this.addButtonOSK();
         });
 
-        const osk = keymanweb.osk;
+        const osk = keyman.osk;
         if(!osk) {
           return;
         }
@@ -422,8 +422,8 @@ if(!keymanweb) {
        * Description  Set KMW UI activation state on mouse click
        */
       readonly _SelectorMouseDown = (e: MouseEvent) => {
-        if(keymanweb.activatingUI) {
-          keymanweb.activatingUI(1);
+        if(keyman.activatingUI) {
+          keyman.activatingUI(1);
         }
       }
 
@@ -434,8 +434,8 @@ if(!keymanweb) {
        * Description  Set KMW UI activation state on mouse over
        */
       readonly _SelectorMouseOver = (e: MouseEvent) => {
-        if(keymanweb.activatingUI) {
-          keymanweb.activatingUI(1);
+        if(keyman.activatingUI) {
+          keyman.activatingUI(1);
         }
       }
 
@@ -446,8 +446,8 @@ if(!keymanweb) {
        * Description Clear KMW UI activation state on mouse out
        */
       readonly _SelectorMouseOut = (e: MouseEvent) => {
-        if(keymanweb.activatingUI) {
-          keymanweb.activatingUI(0);
+        if(keyman.activatingUI) {
+          keyman.activatingUI(0);
         }
       }
 
@@ -458,19 +458,19 @@ if(!keymanweb) {
        * Description  Change active keyboard in response to user selection event
        */
       private readonly SelectKeyboardChange = async (e: Event): Promise<void> => {
-        keymanweb.activatingUI(true);
+        keyman.activatingUI(true);
 
         if(this.KeyboardSelector.value != '-') {
           const i=this.KeyboardSelector.selectedIndex;
           const t=this.KeyboardSelector.options[i].value.split(':');
-          await keymanweb.setActiveKeyboard(t[0],t[1]);
+          await keyman.setActiveKeyboard(t[0],t[1]);
         } else {
-          await keymanweb.setActiveKeyboard('');
+          await keyman.setActiveKeyboard('');
         }
 
         //if(osk['show']) osk['show'](osk['isEnabled']()); handled by keyboard change event???
-        keymanweb.focusLastActiveElement();
-        keymanweb.activatingUI(false);
+        keyman.focusLastActiveElement();
+        keyman.activatingUI(false);
         this.selecting = true;
       }
 
@@ -482,7 +482,7 @@ if(!keymanweb) {
        */
       readonly SelectBlur = (e: Event) => {
         if(!this.selecting) {
-          keymanweb.focusLastActiveElement();
+          keyman.focusLastActiveElement();
         }
         this.selecting = false;
       }
@@ -511,7 +511,7 @@ if(!keymanweb) {
         this.addButtonOSK();
 
         // Set the language selection to the currently active keyboard, if listed
-        this.updateMenu(keymanweb.getActiveKeyboard(), keymanweb.getActiveLanguage());
+        this.updateMenu(keyman.getActiveKeyboard(), keyman.getActiveLanguage());
       }
 
       /**
@@ -534,12 +534,12 @@ if(!keymanweb) {
        */
       readonly addButtonOSK = () => {
         if(this.oskButton != null) {
-          if(keymanweb.isCJK() || (this.KeyboardSelector.selectedIndex==0)) {
+          if(keyman.isCJK() || (this.KeyboardSelector.selectedIndex==0)) {
             this.oskButton.style.display = 'none';
             this.outerDiv.style.width = this.KeyboardSelector.offsetWidth+30+'px';
           } else {
             this.oskButton.style.display = 'block';
-            const osk = keymanweb.osk;
+            const osk = keyman.osk;
             if(osk) {
               this.oskButtonState(osk.isEnabled());
             } else {
@@ -559,7 +559,7 @@ if(!keymanweb) {
        */
       readonly _Resize = (e: Event) => {
         if(this.outerDiv.style.display =='block') {
-          const elem = keymanweb.getLastActiveElement();
+          const elem = keyman.getLastActiveElement();
           if(this.floatRight) {  // I1296
             this.ShowInterface(util.getAbsoluteX(elem) + elem.offsetWidth + 1, util.getAbsoluteY(elem) + 1);
           } else {
@@ -570,13 +570,13 @@ if(!keymanweb) {
       }
     }
 
-    const ui=keymanweb.ui = new UIFloat();
+    const ui=keyman.ui = new UIFloat();
 
     //TODO:  had to expose properties of params - what does that do? (focus event doesn't normally include these properties?)
-    keymanweb.addEventListener('controlfocused', (params) => {
+    keyman.addEventListener('controlfocused', (params) => {
       // ... this check shouldn't need to check _kmwAttachment directly.
       if(params.activeControl == null || params.activeControl['_kmwAttachment']) {
-        /*if(keymanweb.domManager._IsEditableIframe(Ltarg))
+        /*if(keyman.domManager._IsEditableIframe(Ltarg))
           Ltarg = Ltarg.defaultView.frameElement;*/
         if(ui.floatRight) {  // I1296
           ui.ShowInterface(util.getAbsoluteX(params.target) + params.target.offsetWidth + 1, util.getAbsoluteY(params.target) + 1);
@@ -588,7 +588,7 @@ if(!keymanweb) {
       return true;
     });
 
-    keymanweb.addEventListener('controlblurred', (params) => {
+    keyman.addEventListener('controlblurred', (params) => {
       if(!params.event) {
         return true;   // I2404 - Manage IE events in IFRAMEs
       }
@@ -608,7 +608,7 @@ if(!keymanweb) {
     ui.initialize();
 
     // is/was never actually raised.  Note that the `shutdown` method likely fulfills a similar role.
-    // keymanweb.addEventListener('unloaduserinterface', ui._UnloadUserInterface);
+    // keyman.addEventListener('unloaduserinterface', ui._UnloadUserInterface);
 
   } catch(err){}
 

--- a/web/src/app/ui/kmwuitoggle.ts
+++ b/web/src/app/ui/kmwuitoggle.ts
@@ -22,14 +22,14 @@ interface Owned<T> {
   _owningObject?: T;
 }
 
-const keymanweb=window.keyman;
+const keyman=window.keyman;
 
 // If a UI module has been loaded, we can rely on the publically-published 'name' property
 // having been set as a way to short-out a UI reload.  Its parent object always exists by
 // this point in the build process.
-if(!keymanweb) {
+if(!keyman) {
   throw new Error("`keyman` global is missing; Keyman Engine for Web script has not been loaded");
-} else if(!keymanweb.ui?.name) {
+} else if(!keyman.ui?.name) {
   /********************************/
   /*                              */
   /* Toggle User Interface Code   */
@@ -47,8 +47,8 @@ if(!keymanweb) {
 
   try {
     // Declare KeymanWeb, OnScreen Keyboard and Util objects
-    //var dbg=keymanweb['debug'];
-    const util = keymanweb.util;
+    //var dbg=keyman['debug'];
+    const util = keyman.util;
 
     // Disable UI for touch devices
     if(util.isTouchDevice()) {
@@ -99,14 +99,14 @@ if(!keymanweb) {
 
         // We don't want to shift the controller to something that's not an input element,
         // but do want to account for window.event's data when legitimate.
-        if(window.event && keymanweb.isAttached(window.event.srcElement as HTMLElement)) {
+        if(window.event && keyman.isAttached(window.event.srcElement as HTMLElement)) {
           someElement=window.event.srcElement as HTMLElement;
         }
 
         if(focusing) {
           this.controller.style.display = 'block';
         } else {
-          if(!(keymanweb.getUIState().activationPending) && !this.controllerHovered) {
+          if(!(keyman.getUIState().activationPending) && !this.controllerHovered) {
             this.controller.style.display = 'none';
           }
         }
@@ -145,7 +145,7 @@ if(!keymanweb) {
       }
 
       registerEvents() {
-        const osk = keymanweb.osk;
+        const osk = keyman.osk;
 
         if(!osk) {
           return;
@@ -171,13 +171,13 @@ if(!keymanweb) {
        **/
       readonly switchOsk = () => {
         // Check that user control of OSK is allowed
-        if((keymanweb.getActiveKeyboard() == '') || keymanweb.isCJK()) {
+        if((keyman.getActiveKeyboard() == '') || keyman.isCJK()) {
           return;
         }
 
-        if(keymanweb.osk) {
-          const newState = !keymanweb.osk.isEnabled();
-          keymanweb.osk.show(newState);
+        if(keyman.osk) {
+          const newState = !keyman.osk.isEnabled();
+          keyman.osk.show(newState);
 
           // Also, indicate that the OSK is intentionally hidden.
           this.oskButton._setSelected(newState);
@@ -188,7 +188,7 @@ if(!keymanweb) {
        * Toggle a single keyboard on or off - KMW button control event
        **/
       readonly switchSingleKbd = async () => {
-        const _v = keymanweb.getActiveKeyboard() == '';
+        const _v = keyman.getActiveKeyboard() == '';
         let nLastKbd=0, kbdName='', lgCode='';
 
         if(_v) {
@@ -202,10 +202,10 @@ if(!keymanweb) {
 
           kbdName = this.keyboards[nLastKbd]._InternalName;
           lgCode = this.keyboards[nLastKbd]._LanguageCode;
-          await keymanweb.setActiveKeyboard(kbdName,lgCode);
+          await keyman.setActiveKeyboard(kbdName,lgCode);
           this.lastActiveKeyboard = nLastKbd;
         } else {
-          await keymanweb.setActiveKeyboard('');
+          await keyman.setActiveKeyboard('');
         }
 
         if(this.kbdButton) {
@@ -217,7 +217,7 @@ if(!keymanweb) {
        * Switch to the next keyboard in the list - KMW button control event
        **/
       readonly switchNextKbd = async () => {
-        let _v = (keymanweb.getActiveKeyboard() == '');
+        let _v = (keyman.getActiveKeyboard() == '');
         let kbdName='', lgCode='';
 
         if(_v) {
@@ -227,16 +227,16 @@ if(!keymanweb) {
 
           kbdName = this.keyboards[0]._InternalName;
           lgCode = this.keyboards[0]._LanguageCode;
-          await keymanweb.setActiveKeyboard(kbdName,lgCode);
+          await keyman.setActiveKeyboard(kbdName,lgCode);
           this.lastActiveKeyboard = 0;
         } else {
           if(this.lastActiveKeyboard == this.keyboards.length-1) {
-            await keymanweb.setActiveKeyboard('');
+            await keyman.setActiveKeyboard('');
             _v = false;
           } else {
             kbdName = this.keyboards[++this.lastActiveKeyboard]._InternalName;
             lgCode = this.keyboards[this.lastActiveKeyboard]._LanguageCode;
-            await keymanweb.setActiveKeyboard(kbdName,lgCode);
+            await keyman.setActiveKeyboard(kbdName,lgCode);
             _v = true;
           }
         }
@@ -329,7 +329,7 @@ if(!keymanweb) {
           };
 
           private __click = () => {
-            keymanweb.activatingUI(false); // Clear activating UI flag once click is acknowledged
+            keyman.activatingUI(false); // Clear activating UI flag once click is acknowledged
             if(this._onclick != null) {
                 return this._onclick();
             }
@@ -337,7 +337,7 @@ if(!keymanweb) {
           };
 
           private __mousedown = () => {
-            keymanweb.activatingUI(true);  // Set activating UI flag (to manage focus/blur) on any UI mouse down event
+            keyman.activatingUI(true);  // Set activating UI flag (to manage focus/blur) on any UI mouse down event
             this._down = true;
             this.__updatestyle();
             return false;
@@ -350,7 +350,7 @@ if(!keymanweb) {
 
 
           _setSelected(_value: boolean) {
-            keymanweb.activatingUI(false); // Always clear activating UI flag after selecting UI
+            keyman.activatingUI(false); // Always clear activating UI flag after selecting UI
             this._selected = _value;
             this.__updatestyle();
           };
@@ -408,7 +408,7 @@ if(!keymanweb) {
        **/
       initialize() {
         //Never initialize before KMW!
-        if(!keymanweb.initialized || util.isTouchDevice()) {
+        if(!keyman.initialized || util.isTouchDevice()) {
           return;
         }
 
@@ -488,13 +488,13 @@ if(!keymanweb) {
        * Description  Rebuild the UI and keyboard list
        **/
       readonly updateKeyboardList = () => {
-        if(!(keymanweb.initialized || this.initialized)) {
+        if(!(keyman.initialized || this.initialized)) {
           return; //TODO: may want to restart the timer??
         }
 
         this.updateList = false;
 
-        const _kbds=keymanweb.getKeyboards();
+        const _kbds=keyman.getKeyboards();
         const imgPath=util.getOption('resources') +'ui/toggle/';
 
         // Check the number of installed keyboards to determine whether or not we will have a dropdown
@@ -542,14 +542,14 @@ if(!keymanweb) {
         }
 
         // Highlight the last active keyboard
-        let activeKeyboard = keymanweb.getActiveKeyboard();
+        let activeKeyboard = keyman.getActiveKeyboard();
         let activeLanguage = '';
         if (activeKeyboard) {
-          activeLanguage = keymanweb.getActiveLanguage();
+          activeLanguage = keyman.getActiveLanguage();
         } else {
           // savedKeyboard is only correct if we use global keyboard settings,
           // otherwise it's set to the first keyboard in the list
-          const savedKeyboard = keymanweb.getSavedKeyboard().split(':');
+          const savedKeyboard = keyman.getSavedKeyboard().split(':');
           activeKeyboard = savedKeyboard[0];
           activeLanguage = savedKeyboard[1];
         }
@@ -578,8 +578,8 @@ if(!keymanweb) {
           languageCode = this.keyboards[kbdIndex]._LanguageCode;
         }
 
-        await keymanweb.setActiveKeyboard(name, languageCode);
-        keymanweb.focusLastActiveElement();
+        await keyman.setActiveKeyboard(name, languageCode);
+        keyman.focusLastActiveElement();
         this.kbdButton._setSelected(name != '');
         if (kbdIndex >= 0) {
           this.lastActiveKeyboard = kbdIndex;
@@ -734,7 +734,7 @@ if(!keymanweb) {
 
         // Add loaded keyboards to the menu
         this.keyboards = [];
-        const keyboards = keymanweb.getKeyboards();
+        const keyboards = keyman.getKeyboards();
         const added: Record<string, number> = {};
         for (let kbdIndex = 0; kbdIndex < keyboards.length; kbdIndex++) {
           if (!added[keyboards[kbdIndex].InternalName]) {
@@ -761,25 +761,25 @@ if(!keymanweb) {
 
 
     // Actually assign our UI module to the active Keyman engine.
-    const ui = keymanweb.ui = new ToggleUI();
+    const ui = keyman.ui = new ToggleUI();
 
     // CTRL-K_SLASH:  toggles to and from default keyboard
-    keymanweb.addHotKey(191, 0x20, ui.switchSingleKbd);
+    keyman.addHotKey(191, 0x20, ui.switchSingleKbd);
 
     // SHIFT-CTRL-K_SLASH:  cycles among available keyboards in sequence
-    keymanweb.addHotKey(191, 0x30, ui.switchNextKbd);
+    keyman.addHotKey(191, 0x30, ui.switchNextKbd);
 
     // ALT-K_SLASH:  Hides the OSK
-    keymanweb.addHotKey(191, 0x40, ui.switchOsk);
+    keyman.addHotKey(191, 0x40, ui.switchOsk);
 
     // // Initialize after KMW is fully initialized
-    // keymanweb['addEventListener']('loaduserinterface', ui.initialize);
+    // keyman['addEventListener']('loaduserinterface', ui.initialize);
 
-    keymanweb.addEventListener('controlfocused',function(params){
+    keyman.addEventListener('controlfocused',function(params){
       ui.doFocus(params.target, true, params.activeControl);
     });
 
-    keymanweb.addEventListener('controlblurred',function(params){
+    keyman.addEventListener('controlblurred',function(params){
       ui.doFocus(params.target, false, null);
     });
 
@@ -789,7 +789,7 @@ if(!keymanweb) {
      * Set a timer to update the UI keyboard list on timeout after each keyboard is registered,
      * thus updating only once when only if multiple keyboards are registered together
      */
-    keymanweb.addEventListener('keyboardregistered', function(p) {
+    keyman.addEventListener('keyboardregistered', function(p) {
       ui.updateList = true;
       if(ui.updateTimer) {
         clearTimeout(ui.updateTimer);
@@ -803,7 +803,7 @@ if(!keymanweb) {
      *
      * Update menu selection and control OSK display appropriately
      */
-    keymanweb.addEventListener('keyboardchange', function(p) {
+    keyman.addEventListener('keyboardchange', function(p) {
       ui.updateMenu(p.internalName, p.languageCode);
     });
 

--- a/web/src/app/ui/kmwuitoolbar.ts
+++ b/web/src/app/ui/kmwuitoolbar.ts
@@ -52,14 +52,14 @@ interface ListedKeyboard {
   aNode: HTMLAnchorElement;
 }
 
-const keymanweb=window.keyman;
+const keyman=window.keyman;
 
 // If a UI module has been loaded, we can rely on the publically-published 'name' property
 // having been set as a way to short-out a UI reload.  Its parent object always exists by
 // this point in the build process.
-if(!keymanweb) {
+if(!keyman) {
   throw new Error("`keyman` global is missing; Keyman Engine for Web script has not been loaded");
-} else if(!keymanweb.ui?.name) {
+} else if(!keyman.ui?.name) {
   /********************************/
   /*                              */
   /* Toolbar User Interface       */
@@ -77,7 +77,7 @@ if(!keymanweb) {
 
   try {
     // Declare KeymanWeb, OnScreen keyboard and Util objects
-    const util=keymanweb.util;
+    const util=keyman.util;
 
     // Disable UI for touch devices
     if(util.isTouchDevice()) {
@@ -228,7 +228,7 @@ if(!keymanweb) {
        * Initialize toolbar UI
        */
       initialize() {
-        if(!keymanweb.initialized || this.init) {
+        if(!keyman.initialized || this.init) {
           return;
         }
 
@@ -367,7 +367,7 @@ if(!keymanweb) {
         aNode.href = '#';
         aNode.onclick = this.showOSK;
         aNode.onmousedown = function() {
-          keymanweb.activatingUI(true);
+          keyman.activatingUI(true);
         };
         aNode.title = this.ToolBar_Text.ShowOSK;
         aNode.appendChild(this.createNode('div', 'kmw_img_osk', 'kmw_img'));
@@ -403,7 +403,7 @@ if(!keymanweb) {
         this.registerEvents();
 
         // Restore focus
-        keymanweb.focusLastActiveElement();
+        keyman.focusLastActiveElement();
       }
 
       shutdown() {
@@ -433,7 +433,7 @@ if(!keymanweb) {
         this.regionLanguageListNodes = {};
 
         // Build list of keyboards by region and language
-        const Keyboards = keymanweb.getKeyboards();
+        const Keyboards = keyman.getKeyboards();
 
         // Sort the keyboards by region and language
         Keyboards.sort(this.sortKeyboards);
@@ -465,7 +465,7 @@ if(!keymanweb) {
             }
 
             // Get JUST the language code for this section.  BCP-47 codes can include more!
-            const bcpSubtags: string[] = keymanweb.util.getLanguageCodes(Keyboards[j].LanguageCode);
+            const bcpSubtags: string[] = keyman.util.getLanguageCodes(Keyboards[j].LanguageCode);
             if(bcpSubtags[0] == languageCode) {
               continue; // Same language as previous keyboard
             }
@@ -489,7 +489,7 @@ if(!keymanweb) {
               continue; // Not this region
             }
 
-            const bcpSubtags: string[] = keymanweb.util.getLanguageCodes(Keyboards[j].LanguageCode);
+            const bcpSubtags: string[] = keyman.util.getLanguageCodes(Keyboards[j].LanguageCode);
             if(bcpSubtags[0] == languageCode) {  // Same language as previous keyboard, so add it to that entry
               const x = this.languages[languageCode].keyboards;
 
@@ -551,7 +551,7 @@ if(!keymanweb) {
         }
 
         // Restore focus
-        keymanweb.focusLastActiveElement();
+        keyman.focusLastActiveElement();
       }
 
       /**
@@ -819,7 +819,7 @@ if(!keymanweb) {
        * @return      {boolean}
        **/
       private async selectKeyboard(event: Event, lang: LanguageEntry, kbd: KeyboardDetails, updateKeyman: boolean): Promise<boolean> {
-        keymanweb.activatingUI(true);
+        keyman.activatingUI(true);
 
         if(this.selectedLanguage) {
           const found = this.findListedKeyboard(this.selectedLanguage);
@@ -839,7 +839,7 @@ if(!keymanweb) {
         // Return focus to input area and activate the selected keyboard
         this.addKeyboardToList(lang, kbd);
         if(updateKeyman) {
-          await keymanweb.setActiveKeyboard(kbd.InternalName, kbd.LanguageCode).then(() => {
+          await keyman.setActiveKeyboard(kbd.InternalName, kbd.LanguageCode).then(() => {
             // Restore focus _after_ the keyboard finishes loading.
             this.setLastFocus();
           });
@@ -850,7 +850,7 @@ if(!keymanweb) {
         this.saveCookie();
         this.enableControls();
 
-        keymanweb.activatingUI(false);
+        keyman.activatingUI(false);
 
         return this.hideKeyboardsPopup(event) || this.hideKeyboardsForLanguage(event);
       }
@@ -869,7 +869,7 @@ if(!keymanweb) {
         ];
         let hideOskButton=false;
 
-        if(keymanweb.isCJK(this.selectedKeyboard)) {
+        if(keyman.isCJK(this.selectedKeyboard)) {
           hideOskButton = true;
         } else if(this.selectedKeyboard == null) {
           hideOskButton = (elems[2].style.display == 'none');
@@ -903,7 +903,7 @@ if(!keymanweb) {
        * Restore the focus to the last focused element
        **/
       setLastFocus() {
-        keymanweb.focusLastActiveElement();
+        keyman.focusLastActiveElement();
       }
 
       /**
@@ -915,13 +915,13 @@ if(!keymanweb) {
        * @return      {boolean}
        **/
       readonly showOSK = (event: Event) => {
-        const osk = keymanweb.osk;
+        const osk = keyman.osk;
         if(!osk) {
           return false;
         }
-        keymanweb.activatingUI(true);
+        keyman.activatingUI(true);
         //Toggle OSK on or off
-        if(osk && keymanweb.getActiveKeyboard() != '') {
+        if(osk && keyman.getActiveKeyboard() != '') {
           if(osk.isEnabled()) {
             osk.hide();
            } else {
@@ -929,7 +929,7 @@ if(!keymanweb) {
            }
         }
         this.setLastFocus();
-        keymanweb.activatingUI(false);
+        keyman.activatingUI(false);
         return this.eventCapture(event);
       }
 
@@ -957,7 +957,7 @@ if(!keymanweb) {
 
         // Return the focus to the input area and set the active keyboard to nothing
         this.setLastFocus();
-        await keymanweb.setActiveKeyboard('','');
+        await keyman.setActiveKeyboard('','');
 
         //Save current state when deselecting a keyboard (may not be needed)
         this.saveCookie();
@@ -1082,10 +1082,10 @@ if(!keymanweb) {
             }
           } else {
             if(this.selectedKeyboard != null) {
-              if(keymanweb.isCJK()) {
+              if(keyman.isCJK()) {
                 this.oskButtonNode.style.display = this.oskBarNode.style.display = 'none';
               } else {
-                const osk = keymanweb.osk;
+                const osk = keyman.osk;
                 this.oskButtonNode.className = (osk && osk.isEnabled()) ? 'kmw_button_selected' : 'kmw_button';
               }
             }
@@ -1154,7 +1154,7 @@ if(!keymanweb) {
         // https://help.keyman.com/developer/engine/web/current-version/reference/events/kmw.keyboardchange
         this.lastSelectedKeyboard = null;
         const kbName=p.internalName,
-            lgName=keymanweb.util.getLanguageCodes(p.languageCode)[0];
+            lgName=keyman.util.getLanguageCodes(p.languageCode)[0];
         if(lgName != '' && kbName != '') {
           const lg = this.languages[lgName];
           if(lg != null) {
@@ -1200,7 +1200,7 @@ if(!keymanweb) {
       }
 
       registerEvents() {
-        const osk = keymanweb.osk;
+        const osk = keyman.osk;
         if(!osk) {
           return;
         }
@@ -1282,7 +1282,7 @@ if(!keymanweb) {
        * for the popup, we stash the old event listener here and restore
        * it when we're done.
        */
-      lastDismissalCallback: (event: MouseEvent) => any = null;
+      lastDismissalCallback: (this: GlobalEventHandlers, ev: MouseEvent) => any = null;
 
       /**
        * Function     PopupDismissal
@@ -1392,8 +1392,8 @@ if(!keymanweb) {
         } else {
           // If language list and keyboard list have not yet been saved as a cookie,
           // initialize to the current (default) language and keyboard, if set by KMW
-          const kbName=keymanweb.getActiveKeyboard();
-          const lgName=keymanweb.getActiveLanguage();
+          const kbName=keyman.getActiveKeyboard();
+          const lgName=keyman.getActiveLanguage();
           if(lgName != '' && kbName != '') {
             const lg = this.languages[lgName];
             if(lg != null) {
@@ -1429,12 +1429,12 @@ if(!keymanweb) {
 
     }
 
-    const ui = keymanweb.ui = new ToolbarUI();
+    const ui = keyman.ui = new ToolbarUI();
 
-    keymanweb.addEventListener('keyboardregistered', ui.registerKeyboard);
-    keymanweb.addEventListener('controlfocused', ui.focusControlEvent);
-    keymanweb.addEventListener('controlblurred', ui.blurControlEvent);
-    keymanweb.addEventListener('keyboardchange', ui.changeKeyboardEvent);
+    keyman.addEventListener('keyboardregistered', ui.registerKeyboard);
+    keyman.addEventListener('controlfocused', ui.focusControlEvent);
+    keyman.addEventListener('controlblurred', ui.blurControlEvent);
+    keyman.addEventListener('keyboardchange', ui.changeKeyboardEvent);
 
     // Initialize when everything defined (replaces unreliable onload event handler)
     // In case the toolbar script loads a bit later than the main KMW script


### PR DESCRIPTION
The variable name `keymanweb` used in the UI modules is confusing because `KeymanWeb` also exists and points to something else. Rename to `keyman` which just mirrors `window.keyman`.

Also fixup type declaration for toolbar `lastDismissalCallback`, which did not match the assigned type.

Fixes: #16168
Test-bot: skip