### PR TITLE
chore: remove deprecated "X-UA-Compatible" and "apple-mobile-web-app-capable" metas

### DIFF
--- a/common/test/resources/keyboards/test_8568_deadkeys.html
+++ b/common/test/resources/keyboards/test_8568_deadkeys.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb #8568</title>
 
     <!-- Your page CSS -->

--- a/developer/src/server/src/site/app.webmanifest
+++ b/developer/src/server/src/site/app.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "Keyman Developer Server",
+  "display": "standalone",
+  "id": "com.keyman.developer.server.self-hosted",
+  "icons": [{
+    "src": "keyman-developer.svg",
+    "sizes": "any"
+  }]
+}

--- a/developer/src/server/src/site/index.html
+++ b/developer/src/server/src/site/index.html
@@ -5,7 +5,7 @@
 
     <!-- Set the viewport width to match iOS device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <link rel="manifest" href="app.webmanifest">
 
     <title>Keyman Developer Keyboard Test Site</title>
 

--- a/developer/src/tike/xml/app/editor/index.html
+++ b/developer/src/tike/xml/app/editor/index.html
@@ -9,10 +9,6 @@
     <!-- Set the viewport width to match iOS device widths
     <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" />   -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <title>Text Editor</title>
 

--- a/oem/firstvoices/windows/src/xml/onlineupdate.xsl
+++ b/oem/firstvoices/windows/src/xml/onlineupdate.xsl
@@ -10,7 +10,6 @@
 
 <html>
 <head>
-  <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <script src="/app/sentry.bundle.min.js"></script>
   <script src="/app/sentry.init.js"></script>
 <title><xsl:value-of select="$locale/string[@name='S_Update_Title']"/></title>

--- a/web/index.html
+++ b/web/index.html
@@ -6,10 +6,6 @@
     <!-- Set the viewport width to match iOS device widths -->
     <!-- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" /> -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <title>KeymanWeb Testing</title>
     <style type='text/css'>

--- a/web/src/samples/complex/root/pages/index.html
+++ b/web/src/samples/complex/root/pages/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Fully Compiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/samples/index.html
+++ b/web/src/samples/index.html
@@ -6,10 +6,6 @@
     <!-- Set the viewport width to match iOS device widths -->
     <!-- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" /> -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <title>KeymanWeb Samples</title>
     <style type='text/css'>

--- a/web/src/samples/simplest/index.html
+++ b/web/src/samples/simplest/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Fully Compiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/samples/subfolder_toggle/index.html
+++ b/web/src/samples/subfolder_toggle/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Fully Compiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/samples/subfolder_toolbar/index.html
+++ b/web/src/samples/subfolder_toolbar/index.html
@@ -6,10 +6,6 @@
     <!-- Set the viewport width to match iOS device widths -->
     <!-- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" /> -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <title>KeymanWeb Multilingual Sample Page</title>
 

--- a/web/src/test/auto/dom/cases/gesture-processor/host-page.tests.html
+++ b/web/src/test/auto/dom/cases/gesture-processor/host-page.tests.html
@@ -7,9 +7,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
     <title>Gesture Recognizer Testing Page</title>
 
     <link rel="stylesheet" href="gestureHost.css">

--- a/web/src/test/auto/e2e/baseline/baseline.tests.html
+++ b/web/src/test/auto/e2e/baseline/baseline.tests.html
@@ -3,8 +3,6 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width,user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <title>KeymanWeb Baseline Tests</title>
 

--- a/web/src/test/manual/embed/android-harness/index.html
+++ b/web/src/test/manual/embed/android-harness/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>Keyman for Android web harness</title>
     <link href="host.css" rel="stylesheet" />
 </head>

--- a/web/src/test/manual/embed/index.html
+++ b/web/src/test/manual/embed/index.html
@@ -6,10 +6,6 @@
     <!-- Set the viewport width to match iOS device widths -->
     <!-- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" /> -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <title>KeymanWeb Testing</title>
     <style type='text/css'>

--- a/web/src/test/manual/web/attachment-api/index.html
+++ b/web/src/test/manual/web/attachment-api/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/basic-iframe/index.html
+++ b/web/src/test/manual/web/basic-iframe/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Basic IFrames</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/build-visual-keyboard/index.html
+++ b/web/src/test/manual/web/build-visual-keyboard/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Basic IFrames</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/chirality/index.html
+++ b/web/src/test/manual/web/chirality/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/default-subkey/index.html
+++ b/web/src/test/manual/web/default-subkey/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Predictive Text: robust testing</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/desktop-ui/button.html
+++ b/web/src/test/manual/web/desktop-ui/button.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/desktop-ui/float.html
+++ b/web/src/test/manual/web/desktop-ui/float.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/desktop-ui/toggle.html
+++ b/web/src/test/manual/web/desktop-ui/toggle.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/desktop-ui/toolbar.html
+++ b/web/src/test/manual/web/desktop-ui/toolbar.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/empty-row/index.html
+++ b/web/src/test/manual/web/empty-row/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Test Page - Empty Row</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/gesture-recognizer/index.html
+++ b/web/src/test/manual/web/gesture-recognizer/index.html
@@ -5,9 +5,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
     <link rel="stylesheet" href="pageStyle.css">
     <link rel="stylesheet" href="gestureHost.css">
 

--- a/web/src/test/manual/web/index.html
+++ b/web/src/test/manual/web/index.html
@@ -6,10 +6,6 @@
     <!-- Set the viewport width to match iOS device widths -->
     <!-- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" /> -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <title>KeymanWeb Testing</title>
     <style type='text/css'>

--- a/web/src/test/manual/web/init-race-10743/index.html
+++ b/web/src/test/manual/web/init-race-10743/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/inline-osk/index.html
+++ b/web/src/test/manual/web/inline-osk/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Inline OSK</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue005/index.html
+++ b/web/src/test/manual/web/issue005/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue103/index.html
+++ b/web/src/test/manual/web/issue103/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Keyboard Stub + Registration Decoupling</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue115/index.html
+++ b/web/src/test/manual/web/issue115/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue116/index.html
+++ b/web/src/test/manual/web/issue116/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue11785/index.html
+++ b/web/src/test/manual/web/issue11785/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Test Page - Keyboard Quick-Load</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue1332/index.html
+++ b/web/src/test/manual/web/issue1332/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Issue 1332 - Mixed case of TTF files</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue160/index.html
+++ b/web/src/test/manual/web/issue160/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb #160</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue266/index.html
+++ b/web/src/test/manual/web/issue266/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb #160</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue271/index.html
+++ b/web/src/test/manual/web/issue271/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue29/index.html
+++ b/web/src/test/manual/web/issue29/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue3701/index.html
+++ b/web/src/test/manual/web/issue3701/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Fat-Finger interactions with Beep feedback</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue382/index.html
+++ b/web/src/test/manual/web/issue382/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb #382</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue53/index.html
+++ b/web/src/test/manual/web/issue53/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Mismatched Layer Rows</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue6005/index.html
+++ b/web/src/test/manual/web/issue6005/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Matchless Final Rule testing</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue62/index.html
+++ b/web/src/test/manual/web/issue62/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue63/index.html
+++ b/web/src/test/manual/web/issue63/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue917-context-and-notany/index.html
+++ b/web/src/test/manual/web/issue917-context-and-notany/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - context() and notany() interaction (#917)</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue920/index.html
+++ b/web/src/test/manual/web/issue920/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Issue 920 - deadkeys and multiple groups - Testing</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/issue9469/index.html
+++ b/web/src/test/manual/web/issue9469/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - keymanweb-osk.ttf</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/keyboard-errors/index.html
+++ b/web/src/test/manual/web/keyboard-errors/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/kmxkeyboard.html
+++ b/web/src/test/manual/web/kmxkeyboard.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Khmer KMX/JS test page</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/mnemonic/index.html
+++ b/web/src/test/manual/web/mnemonic/index.html
@@ -6,9 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Basic Mnemonic Support</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/options-with-save/index.html
+++ b/web/src/test/manual/web/options-with-save/index.html
@@ -6,9 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Basic Mnemonic Support</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/osk-event-buttons/index.html
+++ b/web/src/test/manual/web/osk-event-buttons/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Uncompiled Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/osk-movement/index.html
+++ b/web/src/test/manual/web/osk-movement/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/osk/scratchspace/index.html
+++ b/web/src/test/manual/web/osk/scratchspace/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>Testing Page - standalone OSK</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/platform/index.html
+++ b/web/src/test/manual/web/platform/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Platform Testing</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/pr10506/index.html
+++ b/web/src/test/manual/web/pr10506/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb PR 10506 - Key-cap scaling / font-load delay</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/prediction-mtnt/index.html
+++ b/web/src/test/manual/web/prediction-mtnt/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Predictive Text: robust testing</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/prediction-ui/index.html
+++ b/web/src/test/manual/web/prediction-ui/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Predictive Text bootstrapping</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/promise-api/index.html
+++ b/web/src/test/manual/web/promise-api/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Testing Page - Promise API when Adding Keyboards</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/regression-tests/index.html
+++ b/web/src/test/manual/web/regression-tests/index.html
@@ -4,9 +4,6 @@
   <meta charset='utf-8'>
   <!-- Set the viewport width to match phone and tablet device widths -->
   <meta name="viewport" content="width=device-width,user-scalable=no">
-  <!-- Enable IE9 Standards mode -->
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
   <title>KeymanWeb - Regression Test Interactive Harness</title>
 
   <!-- Your page CSS -->

--- a/web/src/test/manual/web/regression-tests/test.html
+++ b/web/src/test/manual/web/regression-tests/test.html
@@ -4,9 +4,6 @@
   <meta charset='utf-8'>
   <!-- Set the viewport width to match phone and tablet device widths -->
   <meta name="viewport" content="width=device-width,user-scalable=no">
-  <!-- Enable IE9 Standards mode -->
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
   <title>KeymanWeb - Regression Test Karma Harness</title>
   <script src="/web/keymanweb.js"></script>
   <script src="/web/kmwuitoggle.js"></script>
@@ -29,7 +26,7 @@
 </head>
 
 <body id="body">
-  <input type='text' id='receiver'/> 
+  <input type='text' id='receiver'/>
   <div id='progressWindow'><div id='progressPosition'></div></div>
 </body>
 

--- a/web/src/test/manual/web/sentry-integration/index.html
+++ b/web/src/test/manual/web/sentry-integration/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/test-updateLayer/index.html
+++ b/web/src/test/manual/web/test-updateLayer/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Shift Testing</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/unminified - manual.html
+++ b/web/src/test/manual/web/unminified - manual.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/test/manual/web/unminified.html
+++ b/web/src/test/manual/web/unminified.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb Sample Page - Unminified Source</title>
 
     <!-- Your page CSS -->

--- a/web/src/tools/testing/bulk_rendering/index.html
+++ b/web/src/tools/testing/bulk_rendering/index.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb - On-Screen Keyboard Renders</title>
 
     <!-- Your page CSS -->

--- a/web/src/tools/testing/bulk_rendering/local-renderer.html
+++ b/web/src/tools/testing/bulk_rendering/local-renderer.html
@@ -6,12 +6,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
     <title>KeymanWeb - On-Screen Keyboard Rendering</title>
 
     <!-- Your page CSS -->

--- a/web/src/tools/testing/gesture-processor/host-fixture/host-fixture.html
+++ b/web/src/tools/testing/gesture-processor/host-fixture/host-fixture.html
@@ -5,9 +5,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
     <title>Gesture Recognizer - Fixture Host Page</title>
 
     <link rel="stylesheet" href="gestureHost.css">

--- a/web/src/tools/testing/gesture-processor/recorder/src/index.html
+++ b/web/src/tools/testing/gesture-processor/recorder/src/index.html
@@ -5,9 +5,6 @@
     <!-- Set the viewport width to match phone and tablet device widths -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-    <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
     <link rel="stylesheet" href="pageStyle.css">
     <link rel="stylesheet" href="gestureHost.css">
 

--- a/web/src/tools/testing/index.html
+++ b/web/src/tools/testing/index.html
@@ -6,10 +6,6 @@
     <!-- Set the viewport width to match iOS device widths -->
     <!-- <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no" /> -->
     <meta name="viewport" content="width=device-width,user-scalable=no" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-
-    <!-- Enable IE9 Standards mode -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <title>KeymanWeb Resources and Tools</title>
     <style type='text/css'>

--- a/web/src/tools/testing/recorder/index.html
+++ b/web/src/tools/testing/recorder/index.html
@@ -7,12 +7,6 @@
   <!-- Set the viewport width to match phone and tablet device widths -->
   <meta name="viewport" content="width=device-width,user-scalable=no" />
 
-  <!-- Allow KeymanWeb to be saved to the iPhone home screen -->
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-
-  <!-- Enable IE9 Standards mode -->
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-
   <title>KeymanWeb - Test Input Recorder</title>
 
   <!-- Your page CSS -->

--- a/windows/src/desktop/kmshell/xml/onlineupdate.xsl
+++ b/windows/src/desktop/kmshell/xml/onlineupdate.xsl
@@ -10,7 +10,6 @@
 
 <html>
 <head>
-  <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <script src="/app/sentry.bundle.min.js"></script>
   <script src="/app/sentry.init.js"></script>
 <title><xsl:value-of select="$locale/string[@name='S_Update_Title']"/></title>


### PR DESCRIPTION
For Keyman Developer Server, add app.webmanifest so that it can be saved to the home screen; other pages should not require this.

Fixes: #16172
Test-bot: skip