### PR TITLE
fix(android): fix setting font

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -1637,7 +1637,15 @@ public final class KMManager {
           return null;
         }
 
-        File file = new File(fontFilename);
+        // If fontFilename is a URL, replace the asset URL with the app's data directory path
+        String fontFilePath = fontFilename;
+        String rootUrl = WebViewUtils.buildAssetUrl("");
+        if (fontFilename.startsWith(rootUrl)) {
+          fontFilePath = fontFilename.replaceFirst(rootUrl,
+            context.getDir("data", Context.MODE_PRIVATE).toString() + File.separator);
+        }
+
+        File file = new File(fontFilePath);
         if (file.exists()) {
           return Typeface.createFromFile(file);
         }


### PR DESCRIPTION
The [previous PR](#16146) introduced a problem with selecting a different font for a keyboard so that we always ended up with not setting the font. This was caused by the font filenames now being a URL (which is necessary because they get processed by the web engine). However, the Android code checks for the existence of the font in order to create the typeface. This only works with local paths. This change checks if a filename is a URL and converts to a local path, thus allowing `File.exists()` to succeed.

Follows: #16146
Superseded-by: #16188
Fixes: #16187
Build-bot: release:android

# User Testing

**TEST_FONT**: 

- install the KeyboardHarness apk from this PR
- Switch to the "longpress '"\|5% +" keyboard 
- type some text and verify that the Code2001 font is used (this can be easily seen with some characters, e.g. "g" or "J"; the OSK is displaying the correct font)