### PR TITLE
change(web): stop negation of reversion transition IDs 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -239,7 +239,7 @@ export class ModelCompositor {
     // Step 1:  re-use the original input Transform as the reversion's Transform.
     // The Web engine will restore the original state of the context before accepting
     // and before reverting; all we need to do is put the original keystroke back in place.
-    let reversionTransform: Transform = originalInput ?? { insert: '', deleteLeft: 0 };
+    let reversionTransform: Transform = originalInput ?? { insert: '', deleteLeft: 0, id: suggestion.transform.id };
     // clone the transform to prevent aliasing
     reversionTransform = {...reversionTransform};
 
@@ -265,9 +265,6 @@ export class ModelCompositor {
     // Since we're outside of the standard `predict` control path, we'll need to
     // set the Reversion's ID directly.
     let reversion = toAnnotatedSuggestion(this.lexicalModel, firstConversion, 'revert');
-    if(suggestion.transform.id != null) {
-      reversion.transform.id = -suggestion.transform.id;
-    }
     if(suggestion.id != null) {
       // Since a reversion inverts its source suggestion, we set its ID to be the
       // additive inverse of the source suggestion's ID.  Makes easy mapping /
@@ -331,11 +328,8 @@ export class ModelCompositor {
     let compositor = this;
     let suggestions: Promise<Suggestion[]>;
     let fallbackSuggestions = async function() {
-      const suggestions = await compositor.predict({insert: '', deleteLeft: 0}, context);
+      const suggestions = await compositor.predict({insert: '', deleteLeft: 0, id: reversion.transform.id}, context);
       suggestions.forEach(function(suggestion) {
-        // A reversion's transform ID is the additive inverse of its original suggestion;
-        // we revert to the state of said original suggestion.
-        suggestion.transform.id = -reversion.transform.id;
         // Prevent auto-selection of any suggestion immediately after a reversion.
         // It's fine after at least one keystroke, but not before.
         suggestion.autoAccept = false;
@@ -352,7 +346,7 @@ export class ModelCompositor {
     // Note that the base reversion's .transform.id will predate the appendedTransform id
     // used to add whitespace (if one existed), so reverting to the base ID's associated
     // context also reverts the appendedTransform.
-    const baseTransitionId = -reversion.transform.id;
+    const baseTransitionId = reversion.transform.id;
     let originalTransition = this.contextTracker.findAndRevert(baseTransitionId);
 
     if(appendedOnly) {

--- a/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/model-compositor.ts
@@ -239,9 +239,9 @@ export class ModelCompositor {
     // Step 1:  re-use the original input Transform as the reversion's Transform.
     // The Web engine will restore the original state of the context before accepting
     // and before reverting; all we need to do is put the original keystroke back in place.
-    let reversionTransform: Transform = originalInput ?? { insert: '', deleteLeft: 0, id: suggestion.transform.id };
-    // clone the transform to prevent aliasing
-    reversionTransform = {...reversionTransform};
+    let reversionTransform: Transform = originalInput 
+      ? { ...originalInput } 
+      : { insert: '', deleteLeft: 0, id: suggestion.transform.id };
 
     // Step 2:  building the proper 'displayAs' string for the Reversion
     const postContext = originalInput ? models.applyTransform(originalInput, context) : context;

--- a/web/src/engine/src/main/headless/languageProcessor.ts
+++ b/web/src/engine/src/main/headless/languageProcessor.ts
@@ -306,10 +306,7 @@ export class LanguageProcessor extends EventEmitter<LanguageProcessorEventMap> {
     // Find the state of the context at the time the suggestion was generated.
     // This may refer to the context before an input keystroke or before application
     // of a predictive suggestion.
-    //
-    // Reversions use the additive inverse of the id token of the Transcription being
-    // reverted to.
-    const reversionId = appendedOnly ? reversion.appendedTransform.id : -reversion.transform.id;
+    const reversionId = appendedOnly ? reversion.appendedTransform.id : reversion.transform.id;
     const original = this.getPredictionState(reversionId);
     if(!original) {
       console.warn("Could not apply the Suggestion!");

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-suggestion-context-transition.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/determine-suggestion-context-transition.tests.ts
@@ -150,7 +150,7 @@ describe('determineContextTransition', () => {
       }
     };
 
-    compositor.acceptSuggestion(applied_testing, baseContext, { insert: '', deleteLeft: 0 });
+    compositor.acceptSuggestion(applied_testing, baseContext, { insert: '', deleteLeft: 0, id: applied_testing.transform.id });
     const acceptingTransition = tracker.latest;
 
     const inputDistribution: Distribution<Transform> = [{sample: applied_testing.appendedTransform, p: 1}];
@@ -203,7 +203,7 @@ describe('determineContextTransition', () => {
     };
     baseTransition.final.suggestions = [pred_testing];
 
-    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0 });
+    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0, id: pred_testing.transform.id });
 
     const inputDistribution: Distribution<Transform> = [{sample: { insert: 'a', deleteLeft: 0, id: 5 }, p: 1}];
 
@@ -262,7 +262,7 @@ describe('determineContextTransition', () => {
     };
     baseTransition.final.suggestions = [pred_testing];
 
-    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0 });
+    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0, id: pred_testing.transform.id });
 
     const inputDistribution: Distribution<Transform> = [{sample: { insert: 'a', deleteLeft: 0, id: 5 }, p: 1}];
 
@@ -323,7 +323,7 @@ describe('determineContextTransition', () => {
     };
     baseTransition.final.suggestions = [pred_testing];
 
-    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0 });
+    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0, id: pred_testing.transform.id });
 
     const inputDistribution: Distribution<Transform> = [{sample: { insert: 'a', deleteLeft: 0, id: 5 }, p: 1}];
 
@@ -396,7 +396,7 @@ describe('determineContextTransition', () => {
     };
     baseTransition.final.suggestions = [pred_testing];
 
-    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0 });
+    compositor.acceptSuggestion(pred_testing, baseContext, { insert: '', deleteLeft: 0, id: pred_testing.transform.id });
 
     const inputDistribution: Distribution<Transform> = [{sample: { insert: 'a', deleteLeft: 0, id: 5 }, p: 1}];
 

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-model-compositor.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-model-compositor.tests.ts
@@ -685,7 +685,8 @@ describe('ModelCompositor', function() {
       // of the Context when the suggestion is built.
       let postTransform = {
         insert: 'l',
-        deleteLeft: 0
+        deleteLeft: 0,
+        id: baseSuggestion.transform.id
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext, postTransform);
@@ -727,7 +728,8 @@ describe('ModelCompositor', function() {
       // of the Context when the suggestion is built.
       let postTransform = {
         insert: 'l',
-        deleteLeft: 0
+        deleteLeft: 0,
+        id: baseSuggestion.id
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext, postTransform);
@@ -804,7 +806,8 @@ describe('ModelCompositor', function() {
       // of the Context when the suggestion is built.
       let postTransform = {
         insert: 'i',
-        deleteLeft: 1
+        deleteLeft: 1,
+        id: baseSuggestion.transform.id
       }
 
       let reversion = acceptanceTest(englishPunctuation, baseSuggestion, baseContext, postTransform);
@@ -860,7 +863,8 @@ describe('ModelCompositor', function() {
       // of the Context when the suggestion is built.
       let postTransform = {
         insert: 'i',
-        deleteLeft: 1
+        deleteLeft: 1,
+        id: baseSuggestion.transform.id
       }
 
       let model = new models.DummyModel({punctuation: englishPunctuation});
@@ -918,7 +922,7 @@ describe('ModelCompositor', function() {
       let baseSuggestion = initialSuggestions[1];
       baseSuggestion.appendedTransform.id = 15; // set an id for the applied transform.
       let reversion = compositor.acceptSuggestion(baseSuggestion, baseContext, postTransform);
-      assert.equal(reversion.transform.id, -baseSuggestion.transform.id);
+      assert.equal(reversion.transform.id, baseSuggestion.transform.id);
       assert.equal(reversion.id, -baseSuggestion.id);
 
       let appliedContext = models.applyTransform(baseSuggestion.transform, baseContext);
@@ -965,7 +969,7 @@ describe('ModelCompositor', function() {
       assert.equal(compositor.contextTracker.unitTestEndPoints.cache().size, 2);
       let contextIds = compositor.contextTracker.unitTestEndPoints.cache().keys();
 
-      assert.equal(reversion.transform.id, -baseSuggestion.transform.id);
+      assert.equal(reversion.transform.id, baseSuggestion.transform.id);
       assert.equal(reversion.id, -baseSuggestion.id);
 
       const appliedContextState = compositor.contextTracker.unitTestEndPoints.cache().get(15);


### PR DESCRIPTION
Reversion transition-IDs will no longer be negated, simplifying an implementation detail within the predictive-text worker highlighted by https://github.com/keymanapp/keyman/pull/16148#discussion_r3490696498.  

Build-bot: skip build:web
Test-bot: skip