### PR TITLE
fix(web): fixes cookie unit-tests and path for OSK resources during testing

### DIFF
--- a/web/src/test/auto/dom/cases/dom-utils/cookieSerializer.tests.ts
+++ b/web/src/test/auto/dom/cases/dom-utils/cookieSerializer.tests.ts
@@ -117,7 +117,7 @@ describe('CookieSerializer', function () {
 
     it('finds all matching cookies starting with TestCookie_', () => {
       const result = CookieSerializer.loadAllMatching(/^TestCookie_/);
-      assert.deepEqual(result, [
+      assert.sameDeepMembers(result, [
         { name: COOKIE_ID_1, value: { COOKIE_ID_1: 'foobar1' } },
         { name: COOKIE_ID_2, value: { COOKIE_ID_2: 'foobar2' } }
       ]);
@@ -125,7 +125,7 @@ describe('CookieSerializer', function () {
 
     it('finds all matching cookies containing Cookie', () => {
       const result = CookieSerializer.loadAllMatching(/Cookie/);
-      assert.deepEqual(result, [
+      assert.sameDeepMembers(result, [
         { name: COOKIE_ID_1, value: { COOKIE_ID_1: 'foobar1' } },
         { name: COOKIE_ID_2, value: { COOKIE_ID_2: 'foobar2' } },
         { name: NONMATCHING_COOKIE_ID, value: { NONMATCHING_COOKIE_ID: 'foobar3' } }
@@ -134,7 +134,7 @@ describe('CookieSerializer', function () {
 
     it('returns empty array if no matching cookies', () => {
       const result = CookieSerializer.loadAllMatching(/^UnknownCookie_/);
-      assert.deepEqual(result, []);
+      assert.sameDeepMembers(result, []);
     });
   });
 });

--- a/web/src/test/auto/dom/cases/osk/events.tests.ts
+++ b/web/src/test/auto/dom/cases/osk/events.tests.ts
@@ -17,7 +17,7 @@ const TestResources = {
     isEmbedded: false,
     pathConfig: {
       fonts: '',
-      resources: '/web/build/publish/debug'
+      resources: '/web/build/publish/debug/'
     },
     hostDevice: device.coreSpec,
     allowHideAnimations: false // shortens timings.


### PR DESCRIPTION
I ran into these issues doing full Keyman Engine for Web testing on my local development machine.

I also ran into one more thing, but I'm not sure how to go about resolving it - it's in the end-to-end set of tests:

```
  1) [chromium] › baseline/baseline.tests.ts:92:9 › Baseline tests › .js tests › k_0105___vkey_input__ctrl_alt_2_.kmn 

    Error: Verify output is 'กฃ'

    Timed out 500ms waiting for expect(locator).toHaveValue(expected)

    Locator: locator('#inputarea')
    Expected string: "กฃ"
    Received string: "ฃก"
    Call log:
      - Verify output is 'กฃ' with timeout 500ms
      - waiting for locator('#inputarea')
      -   locator resolved to <textarea dir="ltr" id="inputarea" inputmode="none" placeholder="Type here" class="test keymanweb-font"></textarea>
      -   unexpected value "ฃก"
      -   locator resolved to <textarea dir="ltr" id="inputarea" inputmode="none" placeholder="Type here" class="test keymanweb-font"></textarea>
      -   unexpected value "ฃก"
      -   locator resolved to <textarea dir="ltr" id="inputarea" inputmode="none" placeholder="Type here" class="test keymanweb-font"></textarea>
      -   unexpected value "ฃก"
      -   locator resolved to <textarea dir="ltr" id="inputarea" inputmode="none" placeholder="Type here" class="test keymanweb-font"></textarea>
      -   unexpected value "ฃก"


      166 |
      167 |           // verify output
    > 168 |           await expect(textarea, `Verify output is '${testSource.expected}'`).toHaveValue(testSource.expected, { timeout: 500 });
          |                                                                               ^
      169 |
      170 |           // verify persisted options
      171 |           if (testSource.options) {

        at /Users/jahorton/keymanapp/keyman/web/src/test/auto/e2e/baseline/baseline.tests.ts:168:79

  1 failed
    [chromium] › baseline/baseline.tests.ts:92:9 › Baseline tests › .js tests › k_0105___vkey_input__ctrl_alt_2_.kmn 
```

Build-bot: skip build:web
Test-bot: skip