### PR TITLE
chore(linux): reorder buttons on kmp install window

### DIFF
--- a/linux/keyman-config/keyman_config/install_window.py
+++ b/linux/keyman-config/keyman_config/install_window.py
@@ -167,13 +167,14 @@ class InstallKmpWindow(Gtk.Dialog):
     def _add_buttons(self):
         hbox = Gtk.Box(spacing=6)
 
-        button = Gtk.Button.new_with_mnemonic(_("_Install"))
-        button.connect("clicked", self.on_install_clicked)
-        hbox.pack_start(button, False, False, 0)
-
         button = Gtk.Button.new_with_mnemonic(_("_Cancel"))
         button.connect("clicked", self.on_cancel_clicked)
+        hbox.pack_start(button, False, False, 0)
+
+        button = Gtk.Button.new_with_mnemonic(_("_Install"))
+        button.connect("clicked", self.on_install_clicked)
         hbox.pack_end(button, False, False, 0)
+
         bind_accelerator(self.accelerators, button, '<Control>w')
         return hbox
 


### PR DESCRIPTION
Cancel button goes on the left according to GNOME Human Interface Guidelines.
Before: <img width="939" height="830" alt="Screenshot From 2026-07-08 10-47-58" src="https://github.com/user-attachments/assets/f5e607f2-8d33-44cc-9a05-03dbd369ebf3" />
After: <img width="939" height="830" alt="Screenshot From 2026-07-08 10-48-40" src="https://github.com/user-attachments/assets/53293eef-9513-41b1-8185-e5282bed30b3" />

Test-bot: skip
