### PR TITLE
fix(android): add permissions for Sentry and set default keyboard

### DIFF
--- a/android/Samples/KMSample1/app/src/main/AndroidManifest.xml
+++ b/android/Samples/KMSample1/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- allow Sentry reports -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
         android:allowBackup="true"

--- a/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
+++ b/android/Samples/KMSample1/app/src/main/java/com/keyman/kmsample1/MainActivity.java
@@ -64,6 +64,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
       KMManager.KMDefault_KeyboardFont,  // Font for KMSample1 text field
       KMManager.KMDefault_KeyboardFont); // Font for OSK
     KMManager.addKeyboard(this, kbInfo);
+    KMManager.setDefaultKeyboard(kbInfo); // Workaround for #16215
 
     // Add a dictionary
     HashMap<String, String>lexicalModelInfo = new HashMap<String, String>();
@@ -132,7 +133,7 @@ public class MainActivity extends BaseActivity implements OnKeyboardEventListene
   public void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
   	KMManager.onConfigurationChanged(newConfig);
-	
+
 	  resizeTextView(textView.isKeyboardVisible());
 	  lastOrientation = newConfig.orientation;
   }

--- a/android/Samples/KMSample2/app/src/main/AndroidManifest.xml
+++ b/android/Samples/KMSample2/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- allow Sentry reports -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
         android:allowBackup="true"

--- a/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/android/Samples/KMSample2/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -57,6 +57,7 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
       KMManager.KMDefault_KeyboardFont,  // Font for KMSample2
       KMManager.KMDefault_KeyboardFont); // Font for OSK
     KMManager.addKeyboard(this, kbInfo);
+    KMManager.setDefaultKeyboard(kbInfo); // Workaround for #16215
 
     // Add a dictionary
     HashMap<String, String>lexicalModelInfo = new HashMap<String, String>();

--- a/android/Tests/KeyboardHarness/app/src/main/AndroidManifest.xml
+++ b/android/Tests/KeyboardHarness/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- allow Sentry reports -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
This change fixes two problems that cause a script error in the sample apps: 
- add internet access permissions so that the Sentry server can be reached 
- explicitly set the default keyboard since sil_euro_latin keyboard is not   included in the sample apps. This works around #16215.

Fixes: #16180
Build-bot: release:android

# User Testing

**GROUP_SAMPLE1**
**GROUP_SAMPLE2**

**TEST_SAMPLE**: 
- Install apk from this PR
- Clear the data for the sample app if it had been installed before
- Open sample app
- Verify that no error pops up