### PR TITLE
fix(android): handle blank keyboard tap properly

### DIFF
--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -22,10 +22,6 @@ sentryManager.init();
 
 window.addEventListener('load', init, false);
 
-function loadDefaultKeyboard() {
-  notifyHost('reloadAfterError');
-}
-
 function init() {
   //document.body.style.backgroundColor="transparent";
   //window.console.log('Device type = '+device);
@@ -82,7 +78,17 @@ function init() {
   keyman.addEventListener('keyboardchange', setIsChiral);
   keyman.core.languageProcessor.on('statechange', onStateChange);
 
-  document.body.addEventListener('touchend', loadDefaultKeyboard);
+  // If the keyboard fails to display, this usually indicates that a Javascript
+  // error has occurred, perhaps in the active keyboard. So we have a last-gasp
+  // fallback in that situation; if the user touches the blank document, we will
+  // attempt to reload the default keyboard.
+  document.addEventListener('touchend', () => {
+    // The error will be reported through to Sentry if the user has error
+    // reporting enabled; breadcrumbs can give us helpful details on possible
+    // root causes for the error
+    window.console.error('user touched the document body, which can only happen if the keyboard was not presented. This is usually caused by another error.');
+    notifyHost('reloadAfterError');
+  });
 
   notifyHost('pageLoaded');
 }

--- a/android/KMEA/app/src/main/assets/android-host.js
+++ b/android/KMEA/app/src/main/assets/android-host.js
@@ -82,12 +82,14 @@ function init() {
   // error has occurred, perhaps in the active keyboard. So we have a last-gasp
   // fallback in that situation; if the user touches the blank document, we will
   // attempt to reload the default keyboard.
-  document.addEventListener('touchend', () => {
-    // The error will be reported through to Sentry if the user has error
-    // reporting enabled; breadcrumbs can give us helpful details on possible
-    // root causes for the error
-    window.console.error('user touched the document body, which can only happen if the keyboard was not presented. This is usually caused by another error.');
-    notifyHost('reloadAfterError');
+  document.addEventListener('touchend', (event) => {
+    if(event.target == document.documentElement) {
+      // The error will be reported through to Sentry if the user has error
+      // reporting enabled; breadcrumbs can give us helpful details on possible
+      // root causes for the error
+      window.console.error('user touched the document body, which can only happen if the keyboard was not presented. This is usually caused by another error.');
+      notifyHost('reloadAfterError');
+    }
   });
 
   notifyHost('pageLoaded');


### PR DESCRIPTION
Previously, the event handler was attached to body, but in the event of the keyboard failing to render, the body element will typically be zero pixels high. Instead, attach the handler to the document itself. KeymanWeb, when running normally, will handle all touches on the keyboard elements which take 100% of the real estate. So the document tap will only be received in the case of an error condition.

Also, add a console error that will be reported to Sentry when user has error reporting switched on.

Test-bot: skip