### PR TITLE
maint(android): use KEYMAN_TIER instead of TIER.md

### DIFF
--- a/android/KMAPro/kMAPro/build.gradle
+++ b/android/KMAPro/kMAPro/build.gradle
@@ -8,8 +8,7 @@ plugins {
 
 ext.rootPath = '../../'
 apply from: "$rootPath/version.gradle"
-
-String tier = new File('../../TIER.md').getText('UTF-8').trim();
+String tier = System.getenv("KEYMAN_TIER");
 
 java {
     toolchain {

--- a/oem/firstvoices/android/app/build.gradle
+++ b/oem/firstvoices/android/app/build.gradle
@@ -105,7 +105,7 @@ if (env_keys_json_file != null && file(env_keys_json_file).exists()) {
 
         // Deactivate lower conflicting version APKs
         resolutionStrategy.set(com.github.triplet.gradle.androidpublisher.ResolutionStrategy.IGNORE)
-        String tier = new File('../../../TIER.md').getText('UTF-8').trim();
+        String tier = System.getenv("KEYMAN_TIER");
         switch (tier) {
             case 'beta':
                 track.set("beta")


### PR DESCRIPTION
This is consistent with other version variables in build.gradle. Encountered an issue with loading TIER.md with Android Studio Quail 1 | 2026.1.1 Patch 2 version, and this was an expedient workaround.

Test-bot: skip