### PR TITLE
chore(android): cleanup Android build scripts and artifact filenames

### DIFF
--- a/android/KMAPro/build.sh
+++ b/android/KMAPro/build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Build Keyman for Android app (KMAPro)
+# Keyman is copyright (C) SIL Global. MIT License.
+#
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
@@ -9,111 +10,92 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-help.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-download-resources.sh"
-
 . "$KEYMAN_ROOT/android/KMAPro/build-play-store-notes.inc.sh"
 
 # ################################ Main script ################################
-
-# Definition of global compile constants
-
-CONFIG="release"
-BUILD_FLAGS="build -x lint -x test"                     # Gradle build w/o test
-TEST_FLAGS="-x assembleRelease lintRelease testRelease" # Gradle test w/o build
-DAEMON_FLAG=
 
 builder_describe "Builds Keyman for Android app." \
   "@/android/KMEA" \
   "clean" \
   "configure" \
   "build" \
-  "test             Runs lint and unit tests." \
-  "publish-symbols  Publishes symbols to Sentry." \
+  "test                Runs lint and unit tests." \
+  "publish-symbols     Publishes symbols to Sentry." \
   "publish-play-store  Publishes the APK to the Play Store."
 
-# parse before describe_outputs to check debug flags
 builder_parse "$@"
 
 if builder_is_debug_build; then
-  builder_heading "### Debug config ####"
-  CONFIG="debug"
   BUILD_FLAGS="assembleDebug -x lintDebug -x testDebug"
   TEST_FLAGS="-x assembleDebug lintDebug testDebug"
+else
+  BUILD_FLAGS="build -x lint -x test"                     # Gradle build w/o test
+  TEST_FLAGS="-x assembleRelease lintRelease testRelease" # Gradle test w/o build
 fi
+
+if builder_is_ci_build; then
+  GRADLE_DAEMON=--no-daemon
+else
+  GRADLE_DAEMON=
+fi
+
+# Locations for bundled keyboard and lexical model
 
 KEYBOARD_PACKAGE_ID="sil_euro_latin"
 KEYBOARDS_TARGET="android/KMAPro/kMAPro/src/main/assets/${KEYBOARD_PACKAGE_ID}.kmp"
 MODEL_PACKAGE_ID="nrc.en.mtnt"
 MODELS_TARGET="android/KMAPro/kMAPro/src/main/assets/${MODEL_PACKAGE_ID}.model.kmp"
+
 builder_describe_outputs \
   configure     "/${MODELS_TARGET}" \
-  build         /android/KMAPro/kMAPro/build/outputs/apk/$CONFIG/keyman-${KEYMAN_VERSION_FOR_FILENAME}.apk
-
-#### Build
-
-
-# Parse args
-
-if builder_is_ci_build; then
-  DAEMON_FLAG=--no-daemon
-fi
+  build         /android/KMAPro/kMAPro/build/outputs/apk/$BUILDER_CONFIGURATION/keyman-${KEYMAN_VERSION_FOR_FILENAME}.apk
 
 #### Build action definitions ####
 
-# Check about cleaning artifact paths
-if builder_start_action clean; then
-  rm -rf "$KEYMAN_ROOT/android/KMAPro/kMAPro/build/outputs"
-  builder_finish_action success clean
-fi
-
-if builder_start_action configure; then
-
+do_configure() {
   downloadKeyboardPackage "$KEYBOARD_PACKAGE_ID" "${KEYMAN_ROOT}/$KEYBOARDS_TARGET"
   downloadModelPackage "$MODEL_PACKAGE_ID" "${KEYMAN_ROOT}/$MODELS_TARGET"
+}
 
-  builder_finish_action success configure
-fi
-
-if builder_start_action build; then
-
+do_build() {
   # Copy Keyman Engine for Android
-  cp "${KEYMAN_ROOT}/android/KMEA/app/build/outputs/aar/keyman-engine-${CONFIG}.aar" "${KEYMAN_ROOT}/android/KMAPro/kMAPro/libs/keyman-engine.aar"
+  cp "${KEYMAN_ROOT}/android/KMEA/app/build/outputs/aar/keyman-engine-${BUILDER_CONFIGURATION}.aar" "${KEYMAN_ROOT}/android/KMAPro/kMAPro/libs/keyman-engine.aar"
 
   # Convert markdown to html for offline help
   build_help_html android KMAPro/kMAPro/src/main/assets/info
 
-  echo "BUILD_FLAGS $BUILD_FLAGS"
-  ./gradlew $DAEMON_FLAG clean $BUILD_FLAGS
+  builder_echo "BUILD_FLAGS $BUILD_FLAGS"
+  ./gradlew $GRADLE_DAEMON $BUILD_FLAGS
 
-  mv "${KEYMAN_ROOT}/android/KMAPro/kMAPro/build/outputs/apk/$CONFIG/keyman-${KEYMAN_VERSION}.apk" "${KEYMAN_ROOT}/android/KMAPro/kMAPro/build/outputs/apk/$CONFIG/keyman-${KEYMAN_VERSION_FOR_FILENAME}.apk"
+  mv "${KEYMAN_ROOT}/android/KMAPro/kMAPro/build/outputs/apk/$BUILDER_CONFIGURATION/keyman-${KEYMAN_VERSION}.apk" "${KEYMAN_ROOT}/android/KMAPro/kMAPro/build/outputs/apk/$BUILDER_CONFIGURATION/keyman-${KEYMAN_VERSION_FOR_FILENAME}.apk"
+}
 
-  builder_finish_action success build
-fi
+do_test() {
+  builder_echo "TEST_FLAGS $TEST_FLAGS"
+  ./gradlew $GRADLE_DAEMON $TEST_FLAGS
+}
 
-if builder_start_action test; then
-
-  echo "TEST_FLAGS $TEST_FLAGS"
-  ./gradlew $DAEMON_FLAG $TEST_FLAGS
-
-  builder_finish_action success test
-fi
-
-publish_symbols() {
+do_publish_symbols() {
   if builder_is_ci_build && builder_is_ci_build_level_release; then
     # TODO: what does publishSentry even do?
-    ./gradlew $DAEMON_FLAG publishSentry
+    ./gradlew $GRADLE_DAEMON publishSentry
     builder_echo "Making a Sentry release for tag $KEYMAN_VERSION_GIT_TAG"
     sentry-cli upload-dif -p keyman-android --include-sources
     sentry-cli releases -p keyman-android files $KEYMAN_VERSION_GIT_TAG upload-sourcemaps ./
   fi
 }
 
-publish_play_store() {
+do_publish_play_store() {
   if builder_is_ci_build && builder_is_ci_build_level_release; then
     generateReleaseNotes
     # Publish Keyman for Android to Play Store
-    ./gradlew $DAEMON_FLAG publishReleaseApk
+    ./gradlew $GRADLE_DAEMON publishReleaseApk
   fi
 }
 
-builder_run_action publish-symbols      publish_symbols
-builder_run_action publish-play-store  publish_play_store
+builder_run_action clean               rm -rf "$KEYMAN_ROOT/android/KMAPro/kMAPro/build"
+builder_run_action configure           do_configure
+builder_run_action build               do_build
+builder_run_action test                do_test
+builder_run_action publish-symbols     do_publish_symbols
+builder_run_action publish-play-store  do_publish_play_store

--- a/android/KMEA/app/build.gradle
+++ b/android/KMEA/app/build.gradle
@@ -8,7 +8,7 @@ ext.rootPath = '../../'
 apply from: "$rootPath/version.gradle"
 
 base {
-    // Specify library filename keyman-engine-$CONFIG.aar
+    // Specify library filename keyman-engine-$BUILDER_CONFIGURATION.aar
     archivesName = "keyman-engine"
 }
 

--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
+#
 # Build Keyman Engine for Android using Keyman Web artifacts
 #
 ## START STANDARD BUILD SCRIPT INCLUDE
@@ -7,19 +9,8 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../resources/build/builder-full.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-. "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 
 # ################################ Main script ################################
-
-# Definition of global compile constants
-
-KEYMAN_ANDROID_ROOT="$KEYMAN_ROOT/android"
-KEYMAN_WEB_ROOT="$KEYMAN_ROOT/web"
-ENGINE_ASSETS="$KEYMAN_ANDROID_ROOT/KMEA/app/src/main/assets"
-CONFIG="release"
-BUILD_FLAGS="aR -x lint -x test"           # Gradle build w/o test
-TEST_FLAGS="-x aR lintRelease testRelease" # Gradle test w/o build
-JUNIT_RESULTS="##teamcity[importData type='junit' path='keyman\android\KMEA\app\build\test-results\testReleaseUnitTest\']"
 
 builder_describe "Builds Keyman Engine for Android." \
   "@/web/src/app/webview" \
@@ -30,78 +21,64 @@ builder_describe "Builds Keyman Engine for Android." \
   "test             Runs lint and unit tests." \
   ":engine          Builds Engine"
 
-# parse before describe_outputs to check debug flags
 builder_parse "$@"
 
+# Definition of global compile constants
+
 if builder_is_debug_build; then
-  builder_heading "### Debug config ####"
-  CONFIG="debug"
   BUILD_FLAGS="assembleDebug -x lintDebug -x testDebug"
   TEST_FLAGS="-x assembleDebug lintDebug testDebug"
   JUNIT_RESULTS="##teamcity[importData type='junit' path='keyman\android\KMEA\app\build\test-results\testDebugUnitTest\']"
+else
+  BUILD_FLAGS="assembleRelease -x lint -x test"           # Gradle build w/o test
+  TEST_FLAGS="-x assembleRelease lintRelease testRelease" # Gradle test w/o build
+  JUNIT_RESULTS="##teamcity[importData type='junit' path='keyman\android\KMEA\app\build\test-results\testReleaseUnitTest\']"
+fi
+
+if builder_is_ci_build; then
+  GRADLE_DAEMON=--no-daemon
+else
+  GRADLE_DAEMON=
 fi
 
 builder_describe_outputs \
-  build:engine     /android/KMEA/app/build/outputs/aar/keyman-engine-${CONFIG}.aar
-
-#### Build
-
-
-# Parse args
-
-DAEMON_FLAG=
-if builder_is_ci_build; then
-  DAEMON_FLAG=--no-daemon
-fi
+  build:engine     /android/KMEA/app/build/outputs/aar/keyman-engine-${BUILDER_CONFIGURATION}.aar
 
 #### Build action definitions ####
 
-# Check about cleaning artifact paths
-if builder_start_action clean:engine; then
-  rm -rf "$KEYMAN_ROOT/android/KMEA/app/build/outputs"
-  builder_finish_action success clean:engine
-fi
-
-if builder_start_action configure:engine; then
-
-  builder_finish_action success configure:engine
-fi
-
-# Destinations that will need the keymanweb artifacts
-
-
-if builder_start_action build:engine; then
+do_build() {
+  local ENGINE_ASSETS="$KEYMAN_ROOT/android/KMEA/app/src/main/assets"
 
   # Copy KeymanWeb artifacts
-  echo "Copying Keyman Web artifacts"
-  cp "$KEYMAN_WEB_ROOT/build/app/webview/$CONFIG/keymanweb-webview.js" "$ENGINE_ASSETS/keymanweb-webview.js"
-  cp "$KEYMAN_WEB_ROOT/build/app/webview/$CONFIG/keymanweb-webview.js.map" "$ENGINE_ASSETS/keymanweb-webview.js.map"
-  cp "$KEYMAN_WEB_ROOT/build/app/webview/$CONFIG/map-polyfill.js" "$ENGINE_ASSETS/map-polyfill.js"
-  cp "$KEYMAN_WEB_ROOT/build/app/resources/osk/ajax-loader.gif" "$ENGINE_ASSETS/ajax-loader.gif"
-  cp "$KEYMAN_WEB_ROOT/build/app/resources/osk/kmwosk.css" "$ENGINE_ASSETS/kmwosk.css"
-  cp "$KEYMAN_WEB_ROOT/build/app/resources/osk/globe-hint.css" "$ENGINE_ASSETS/globe-hint.css"
-  cp "$KEYMAN_WEB_ROOT/build/app/resources/osk/keymanweb-osk.ttf" "$ENGINE_ASSETS/keymanweb-osk.ttf"
+  builder_echo "Copying Keyman Web artifacts"
+  cp "$KEYMAN_ROOT/web/build/app/webview/$BUILDER_CONFIGURATION/keymanweb-webview.js" "$ENGINE_ASSETS/"
+  cp "$KEYMAN_ROOT/web/build/app/webview/$BUILDER_CONFIGURATION/keymanweb-webview.js.map" "$ENGINE_ASSETS/"
+  cp "$KEYMAN_ROOT/web/build/app/webview/$BUILDER_CONFIGURATION/map-polyfill.js" "$ENGINE_ASSETS/"
+  cp "$KEYMAN_ROOT/web/build/app/resources/osk/ajax-loader.gif" "$ENGINE_ASSETS/"
+  cp "$KEYMAN_ROOT/web/build/app/resources/osk/kmwosk.css" "$ENGINE_ASSETS/"
+  cp "$KEYMAN_ROOT/web/build/app/resources/osk/globe-hint.css" "$ENGINE_ASSETS/"
+  cp "$KEYMAN_ROOT/web/build/app/resources/osk/keymanweb-osk.ttf" "$ENGINE_ASSETS/"
   cp "$KEYMAN_ROOT/common/web/sentry-manager/build/lib/index.js" "$ENGINE_ASSETS/keyman-sentry.js"
 
-  echo "Copying es6-shim polyfill"
-  cp "$KEYMAN_ROOT/node_modules/es6-shim/es6-shim.min.js" "$ENGINE_ASSETS/es6-shim.min.js"
+  builder_echo "Copying es6-shim polyfill"
+  cp "$KEYMAN_ROOT/node_modules/es6-shim/es6-shim.min.js" "$ENGINE_ASSETS/"
 
-  echo "BUILD_FLAGS $BUILD_FLAGS"
+  builder_echo "BUILD_FLAGS $BUILD_FLAGS"
+
   # Build without test
-  ./gradlew $DAEMON_FLAG clean $BUILD_FLAGS
+  ./gradlew $GRADLE_DAEMON $BUILD_FLAGS
+}
 
-  builder_finish_action success build:engine
-fi
-
-if builder_start_action test:engine; then
-
+do_test() {
   if builder_is_ci_build; then
     # Report JUnit test results to CI
     echo "$JUNIT_RESULTS"
   fi
 
-  echo "TEST_FLAGS: $TEST_FLAGS"
-  ./gradlew $DAEMON_FLAG $TEST_FLAGS
+  builder_echo "TEST_FLAGS: $TEST_FLAGS"
+  ./gradlew $GRADLE_DAEMON $TEST_FLAGS
+}
 
-  builder_finish_action success test:engine
-fi
+builder_run_action clean:engine    rm -rf build app/build
+builder_run_action build:engine    do_build
+builder_run_action test:engine     do_test

--- a/android/Samples/KMSample1/app/build.gradle
+++ b/android/Samples/KMSample1/app/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id 'com.android.application'
 }
 
+ext.rootPath = '../../../'
+apply from: "$rootPath/version.gradle"
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
@@ -17,13 +20,22 @@ android {
         noCompress "kmp"
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     defaultConfig {
         applicationId "com.keyman.kmsample1"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 1
-        versionName "1.0"
+
+        // KEYMAN_VERSION_CODE, KEYMAN_VERSION_NAME, KEYMAN_VERSION_FOR_FILENAME from version.gradle
+        versionCode KEYMAN_VERSION_CODE as Integer
+        versionName KEYMAN_VERSION_NAME
+        buildConfigField "String", "KEYMAN_VERSION_ENVIRONMENT", "\""+KEYMAN_VERSION_ENVIRONMENT+"\""
+        archivesBaseName = "KMSample1-$KEYMAN_VERSION_FOR_FILENAME"
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -40,7 +52,6 @@ android {
 
 repositories {
     google()
-
 }
 
 dependencies {

--- a/android/Samples/KMSample1/build.gradle
+++ b/android/Samples/KMSample1/build.gradle
@@ -3,7 +3,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -17,7 +16,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/android/Samples/KMSample1/build.sh
+++ b/android/Samples/KMSample1/build.sh
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
 #
-# Samples: KMsample1
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../resources/build/builder-full.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-. "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "${KEYMAN_ROOT}/android/android-utils.inc.sh"
 
 ################################ Main script ################################
-
-# Definition of global compile constants
-
-CONFIG="release"
-SAMPLE_FLAGS="build"
 
 builder_describe "Build KMSample1 app for Android." \
   "@/android/KMEA" \
@@ -24,55 +19,19 @@ builder_describe "Build KMSample1 app for Android." \
   "test" \
   ":app                   KMSample1"
 
-# parse before describe_outputs to check debug flags
 builder_parse "$@"
 
-ARTIFACT="app-release-unsigned.apk"
-
-if builder_is_debug_build; then
-  builder_heading "### Debug config ####"
-  CONFIG="debug"
-  SAMPLE_FLAGS="assembleDebug"
-  ARTIFACT="app-$CONFIG.apk"
-fi
-
+android_set_gradle_environment
 
 builder_describe_outputs \
-  build:app             /android/Samples/KMSample1/app/build/outputs/apk/$CONFIG/$ARTIFACT
-
-
-
-# Parse args
-
-if builder_is_ci_build; then
-  SAMPLE_FLAGS="$SAMPLE_FLAGS -no-daemon"
-fi
+  build:app    "/android/Samples/KMSample1/app/build/outputs/apk/${BUILDER_CONFIGURATION}/KMSample1-${KEYMAN_VERSION_FOR_FILENAME}-${ARCHIVE_TARGET}.apk"
 
 #### Build action definitions ####
 
-# Check about cleaning artifact paths
-if builder_start_action clean:app; then
-  rm -rf "$KEYMAN_ROOT/android/Samples/KMSample1/app/build/outputs"
-  builder_finish_action success clean:app
-fi
+do_build() {
+  cp "$KEYMAN_ROOT/android/KMEA/app/build/outputs/aar/keyman-engine-${BUILDER_CONFIGURATION}.aar" "$KEYMAN_ROOT/android/Samples/KMSample1/app/libs/keyman-engine.aar"
+  ./gradlew $GRADLE_DAEMON $GRADLE_TARGET
+}
 
-if builder_start_action configure:app; then
-
-  builder_finish_action success configure:app
-fi
-
-# Building KMSample1
-if builder_start_action build:app; then
-
-  # Copy Keyman Engine for Android
-  cp "$KEYMAN_ROOT/android/KMEA/app/build/outputs/aar/keyman-engine-${CONFIG}.aar" "$KEYMAN_ROOT/android/Samples/KMSample1/app/libs/keyman-engine.aar"
-
-  ./gradlew clean $SAMPLE_FLAGS
-
-  builder_finish_action success build:app
-fi
-
-if builder_start_action test:app; then
-  # TODO: define tests
-  builder_finish_action success test:app
-fi
+builder_run_action clean:app    rm -rf build app/build
+builder_run_action build:app    do_build

--- a/android/Samples/KMSample2/app/build.gradle
+++ b/android/Samples/KMSample2/app/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id 'com.android.application'
 }
 
+ext.rootPath = '../../../'
+apply from: "$rootPath/version.gradle"
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
@@ -17,13 +20,22 @@ android {
         noCompress "kmp"
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     defaultConfig {
         applicationId "com.keyman.kmsample2"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 1
-        versionName "1.0"
+
+        // KEYMAN_VERSION_CODE, KEYMAN_VERSION_NAME, KEYMAN_VERSION_FOR_FILENAME from version.gradle
+        versionCode KEYMAN_VERSION_CODE as Integer
+        versionName KEYMAN_VERSION_NAME
+        buildConfigField "String", "KEYMAN_VERSION_ENVIRONMENT", "\""+KEYMAN_VERSION_ENVIRONMENT+"\""
+        archivesBaseName = "KMSample2-$KEYMAN_VERSION_FOR_FILENAME"
     }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/android/Samples/KMSample2/build.gradle
+++ b/android/Samples/KMSample2/build.gradle
@@ -3,7 +3,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -17,7 +16,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/android/Samples/KMSample2/build.sh
+++ b/android/Samples/KMSample2/build.sh
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
 #
-# Samples: KMSample2
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../resources/build/builder-full.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-. "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "${KEYMAN_ROOT}/android/android-utils.inc.sh"
 
 ################################ Main script ################################
-
-# Definition of global compile constants
-
-CONFIG="release"
-SAMPLE_FLAGS="build"
 
 builder_describe "Build KMSample2 app for Android." \
   "@/android/KMEA" \
@@ -24,55 +19,19 @@ builder_describe "Build KMSample2 app for Android." \
   "test" \
   ":app                   KMSample2"
 
-# parse before describe_outputs to check debug flags
 builder_parse "$@"
 
-ARTIFACT="app-release-unsigned.apk"
-
-if builder_is_debug_build; then
-  builder_heading "### Debug config ####"
-  CONFIG="debug"
-  SAMPLE_FLAGS="assembleDebug"
-  ARTIFACT="app-$CONFIG.apk"
-fi
-
-
+android_set_gradle_environment
 
 builder_describe_outputs \
-  build:app             /android/Samples/KMSample2/app/build/outputs/apk/$CONFIG/$ARTIFACT
-
-
-
-# Parse args
-
-if builder_is_ci_build; then
-  SAMPLE_FLAGS="$SAMPLE_FLAGS -no-daemon"
-fi
+  build:app    "/android/Samples/KMSample2/app/build/outputs/apk/${BUILDER_CONFIGURATION}/KMSample2-${KEYMAN_VERSION_FOR_FILENAME}-${ARCHIVE_TARGET}.apk"
 
 #### Build action definitions ####
 
-# Check about cleaning artifact paths
-if builder_start_action clean:app; then
-  rm -rf "$KEYMAN_ROOT/android/Samples/KMSample2/app/build/outputs"
-  builder_finish_action success clean:app
-fi
+do_build() {
+  cp "$KEYMAN_ROOT/android/KMEA/app/build/outputs/aar/keyman-engine-${BUILDER_CONFIGURATION}.aar" "$KEYMAN_ROOT/android/Samples/KMSample2/app/libs/keyman-engine.aar"
+  ./gradlew $GRADLE_DAEMON $GRADLE_TARGET
+}
 
-if builder_start_action configure:app; then
-
-  builder_finish_action success configure:app
-fi
-
-# Building KMSample2
-if builder_start_action build:app; then
-  # Copy Keyman Engine for Android
-  cp "$KEYMAN_ROOT/android/KMEA/app/build/outputs/aar/keyman-engine-${CONFIG}.aar" "$KEYMAN_ROOT/android/Samples/KMSample2/app/libs/keyman-engine.aar"
-
-  ./gradlew clean $SAMPLE_FLAGS
-
-  builder_finish_action success build:app
-fi
-
-if builder_start_action test:app; then
-  # TODO: define tests
-  builder_finish_action success test:app
-fi
+builder_run_action clean:app    rm -rf build app/build
+builder_run_action build:app    do_build

--- a/android/Tests/KeyboardHarness/app/build.gradle
+++ b/android/Tests/KeyboardHarness/app/build.gradle
@@ -29,10 +29,11 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
 
-        // KEYMAN_VERSION_CODE and KEYMAN_VERSION_NAME from version.gradle
+        // KEYMAN_VERSION_CODE, KEYMAN_VERSION_NAME, KEYMAN_VERSION_FOR_FILENAME from version.gradle
         versionCode KEYMAN_VERSION_CODE as Integer
         versionName KEYMAN_VERSION_NAME
         buildConfigField "String", "KEYMAN_VERSION_ENVIRONMENT", "\""+KEYMAN_VERSION_ENVIRONMENT+"\""
+        archivesBaseName = "KeyboardHarness-$KEYMAN_VERSION_FOR_FILENAME"
     }
     buildTypes {
         release {

--- a/android/Tests/KeyboardHarness/build.sh
+++ b/android/Tests/KeyboardHarness/build.sh
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
 #
-# Build Test app: KeyboardHarness
 ## START STANDARD BUILD SCRIPT INCLUDE
 # adjust relative paths as necessary
 THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../../resources/build/builder-full.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
-. "$KEYMAN_ROOT/resources/build/utils.inc.sh"
+. "${KEYMAN_ROOT}/android/android-utils.inc.sh"
 
 ################################ Main script ################################
-
-# Definition of global compile constants
-CONFIG="release"
-BUILD_FLAGS="aR -x lint -x test"           # Gradle build w/o test
-TEST_FLAGS="-x aR lintRelease testRelease" # Gradle test w/o build
 
 builder_describe "Build KeyboardHarness test app for Android." \
   "@/android/KMEA" \
@@ -24,66 +19,19 @@ builder_describe "Build KeyboardHarness test app for Android." \
   "test" \
   ":app                   KeyboardHarness"
 
-# parse before describe outputs to check debug flags
 builder_parse "$@"
 
-ARTIFACT="app-release-unsigned.apk"
-
-if builder_is_debug_build; then
-  builder_heading "### Debug config ####"
-  CONFIG="debug"
-  BUILD_FLAGS="assembleDebug -x lintDebug -x testDebug"
-  TEST_FLAGS="-x assembleDebug lintDebug testDebug"
-  ARTIFACT="app-$CONFIG.apk"
-fi
-
+android_set_gradle_environment
 
 builder_describe_outputs \
-  build:app    /android/Tests/KeyboardHarness/app/build/outputs/apk/$CONFIG/${ARTIFACT}
-
-#### Build
-
-
-#
-# Prevents 'clear' on exit of mingw64 bash shell
-#
-SHLVL=0
-
-
-# Parse args
-
-# Build flags that apply to all targets
-if builder_is_ci_build; then
-  BUILD_FLAGS="$BUILD_FLAGS -no-daemon"
-  TEST_FLAGS="$TEST_FLAGS -no-daemon"
-fi
+  build:app    "/android/Tests/KeyboardHarness/app/build/outputs/apk/${BUILDER_CONFIGURATION}/KeyboardHarness-${KEYMAN_VERSION_FOR_FILENAME}-${ARCHIVE_TARGET}.apk"
 
 #### Build action definitions ####
 
-# Check about cleaning artifact paths
-if builder_start_action clean:app; then
-  rm -rf "$KEYMAN_ROOT/android/Tests/KeyboardHarness/app/build/outputs"
-  builder_finish_action success clean:app
-fi
+do_build() {
+  cp "$KEYMAN_ROOT/android/KMEA/app/build/outputs/aar/keyman-engine-${BUILDER_CONFIGURATION}.aar" ./app/libs/keyman-engine.aar
+  ./gradlew $GRADLE_DAEMON $GRADLE_TARGET
+}
 
-if builder_start_action configure:app; then
-
-  builder_finish_action success configure:app
-fi
-
-# Building KeyboardHarness
-if builder_start_action build:app; then
-
-  # Copy Keyman Engine for Android
-  cp "$KEYMAN_ROOT/android/KMEA/app/build/outputs/aar/keyman-engine-${CONFIG}.aar" "$KEYMAN_ROOT/android/Tests/KeyboardHarness/app/libs/keyman-engine.aar"
-
-  echo "BUILD_FLAGS: $BUILD_FLAGS"
-  ./gradlew clean $BUILD_FLAGS
-  builder_finish_action success build:app
-fi
-
-if builder_start_action test:app; then
-  echo "TEST_FLAGS $TEST_FLAGS"
-  # TODO: define tests
-  builder_finish_action success test:app
-fi
+builder_run_action  clean:app    rm -rf build app/build
+builder_run_action  build:app    do_build

--- a/android/android-utils.inc.sh
+++ b/android/android-utils.inc.sh
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+# Keyman is copyright (C) SIL Global. MIT License.
+
+function android_set_gradle_environment() {
+  if builder_is_debug_build; then
+    GRADLE_TARGET=assembleDebug
+    ARCHIVE_TARGET=debug
+  else
+    GRADLE_TARGET=build
+    ARCHIVE_TARGET=release-unsigned
+  fi
+
+  if builder_is_ci_build; then
+    GRADLE_DAEMON=-no-daemon
+  else
+    GRADLE_DAEMON=
+  fi
+
+  export GRADLE_TARGET GRADLE_DAEMON ARCHIVE_TARGET
+}

--- a/android/build.sh
+++ b/android/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Keyman is copyright (C) SIL Global. MIT License.
 #
 # Build Keyman Engine for Android, Keyman for Android, OEM FirstVoices Android app,
 # Samples: KMsample1 and KMSample2, Test - KeyboardHarness
@@ -50,11 +51,6 @@ builder_describe \
 
 builder_parse "$@"
 
-function do_clean() {
-  builder_heading "Cleanup /android/upload"
-  rm -rf "${KEYMAN_ROOT}/android/upload"
-}
-
 function do_test_help() {
   check-markdown  "${KEYMAN_ROOT}/android/docs/help"
   check-markdown  "${KEYMAN_ROOT}/android/docs/engine"
@@ -62,7 +58,6 @@ function do_test_help() {
 
 function archive_artifacts() {
   local UPLOAD_PATH KEYMAN_ENGINE_ANDROID_ZIP KEYMAN_APK FIRSTVOICES_APK
-  local KEYMAN_FULLY_VERSIONED_APK FIRSTVOICES_FULLY_VERSIONED_APK
 
   UPLOAD_PATH="${KEYMAN_ROOT}/android/upload/${KEYMAN_VERSION}"
   KEYMAN_ENGINE_ANDROID_ZIP="keyman-engine-android-${KEYMAN_VERSION}.zip"
@@ -124,12 +119,13 @@ android_set_java_home
 # This script also responsible for cleaning up /android/upload
 builder_run_child_actions clean
 
-builder_run_action        clean     do_clean
+builder_run_action        clean        rm -rf "${KEYMAN_ROOT}/android/upload"
 
 builder_run_child_actions configure build test
 
-builder_run_action        test:help  do_test_help
+builder_run_action        test:help    do_test_help
 
+# TODO: merge publish-* and archive to publish action?
 builder_run_child_actions publish-symbols publish-play-store
 
-builder_run_action        archive    archive_artifacts
+builder_run_action        archive      archive_artifacts

--- a/android/version.gradle
+++ b/android/version.gradle
@@ -88,6 +88,16 @@ def getVersionGitTag = { ->
         return "release@$KEYMAN_VERSION_NAME"
     }
 }
+
+def getVersionForFilename = { ->
+    String env_version_for_filename = System.getenv("KEYMAN_VERSION_FOR_FILENAME")
+    if(env_version_for_filename != null) {
+        return env_version_for_filename
+    }
+    // Building probably from IDE
+    return "$KEYMAN_VERSION_NAME"
+}
+
 ext {
     KEYMAN_VERSION_CODE=getVersionCode()
     KEYMAN_VERSION_MD=getVersionMD()
@@ -95,6 +105,7 @@ ext {
     KEYMAN_VERSION_ENVIRONMENT=getVersionEnvironment()
     KEYMAN_VERSION_TAG=System.getenv("KEYMAN_VERSION_TAG")
     KEYMAN_VERSION_GIT_TAG=getVersionGitTag()
+    KEYMAN_VERSION_FOR_FILENAME=getVersionForFilename()
 }
 
 //println "version.gradle: KEYMAN_VERSION_TAG: " + KEYMAN_VERSION_TAG

--- a/oem/firstvoices/android/build.gradle
+++ b/oem/firstvoices/android/build.gradle
@@ -16,7 +16,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/resources/builder.inc.sh
+++ b/resources/builder.inc.sh
@@ -1756,9 +1756,9 @@ _builder_parse_expanded_parameters() {
   fi
 
   if builder_is_debug_build; then
-    BUILDER_CONFIGURATION=debug
+    export BUILDER_CONFIGURATION=debug
   else
-    BUILDER_CONFIGURATION=release
+    export BUILDER_CONFIGURATION=release
   fi
 
   _builder_print_internal_debug_info


### PR DESCRIPTION
* Specify clearer filenames for Android samples and test KeyboardHarness
* Cleanup android/*/build.sh to match current patterns
* Remove obsolete jcenter dependency
* Export BUILDER_CONFIGURATION in builder.inc.sh
* Stop cleaning Android build folders on `build` action

Fixes: #16137
Fixes: #16181
Test-bot: skip
Build-bot: skip release:android