### PR TITLE
chore(linux): remove questing, add stonking

### DIFF
--- a/.github/workflows/deb-packaging.yml
+++ b/.github/workflows/deb-packaging.yml
@@ -137,7 +137,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist: [jammy, noble, questing]
+        dist: [jammy, noble, resolute]
 
     steps:
     - name: Checkout

--- a/linux/scripts/launchpad.sh
+++ b/linux/scripts/launchpad.sh
@@ -98,7 +98,7 @@ function upload_with_retry() {
   return 1
 }
 
-distributions="${DIST:-jammy noble questing resolute}"
+distributions="${DIST:-jammy noble resolute stonking}"
 packageversion="${PACKAGEVERSION:-1~sil1}"
 retries="${RETRIES:-5}"
 


### PR DESCRIPTION
Ubuntu 25.10 Questing is EOL. Instead add upcoming Ubuntu 26.10 Stonking for Launchpad builds.

Fixes: #16235
Build-bot: skip
Test-bot: skip