### PR TITLE
chore(android): log legacy cloud keyboards 🍒 🏠

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/data/Keyboard.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/data/Keyboard.java
@@ -48,6 +48,7 @@ public class Keyboard extends LanguageResource implements Serializable {
    */
   public Keyboard(JSONObject installedObj) {
     this.fromJSON(installedObj);
+    logIfLegacyKeyboard();
   }
 
   /**
@@ -78,6 +79,8 @@ public class Keyboard extends LanguageResource implements Serializable {
 
       this.helpLink = keyboardJSON.optString(KMManager.KMKey_CustomHelpLink,
         KMString.format(HELP_URL_FORMATSTR, HELP_URL_HOST, this.resourceID, this.version));
+
+      logIfLegacyKeyboard();
     } catch (JSONException e) {
       KMLog.LogException(TAG, "Keyboard exception parsing JSON: ", e);
     }
@@ -95,6 +98,8 @@ public class Keyboard extends LanguageResource implements Serializable {
     this.isNewKeyboard = isNewKeyboard;
     this.font = (font != null) ? font : "";
     this.oskFont = (oskFont != null) ? oskFont : "";
+
+    logIfLegacyKeyboard();
   }
 
   public Keyboard(Keyboard k) {
@@ -105,6 +110,12 @@ public class Keyboard extends LanguageResource implements Serializable {
     this.font = k.getFont();
     this.oskFont = k.getOSKFont();
     this.displayName = k.getDisplayName();
+  }
+
+  private void logIfLegacyKeyboard() {
+    if (this.packageID.equals(KMManager.KMDefault_UndefinedPackageID)) {
+      KMLog.LogInfo(TAG, "Constructing legacy keyboard: " + this.resourceID);
+    }
   }
 
   public String getKeyboardID() { return getResourceID(); }


### PR DESCRIPTION
This adds a Sentry log if a user is still using legacy cloud keyboards. We do this so that we will learn if there are still users out there or if we can remove the code that deals with those keyboards.

Cherry-pick-of: #16237
Test-bot: skip