### PR TITLE
chore(android): remove doc for non-existing deprecated functions

### DIFF
--- a/android/docs/engine/KMManager/addKeyboard.md
+++ b/android/docs/engine/KMManager/addKeyboard.md
@@ -32,39 +32,6 @@ can be selected from the keyboards menu. If the keyboard with same
 keyboard ID and language ID exists, it updates the existing keyboard
 info.
 
-  
-
-------------------------------------------------------------------------
-
-## Syntax (Deprecated)
-
-``` javascript
-KMManager.addKeyboard(Context context, HashMap<String, String> keyboardInfo)
-```
-
-### Parameters
-
-`context`
-:   The context.
-
-`keyboardInfo`
-:   A dictionary of keyboard information with keys and values defined as
-    `HashMap<String key, String value>`.
-
-### Returns
-
-Returns `true` if the keyboard was added successfully, `false`
-otherwise.
-
-## Description
-
-Use this method to include a keyboard in the keyboards list so that it
-can be selected from the keyboards menu. If the keyboard with same
-keyboard ID and language ID exists, it updates the existing keyboard
-info.
-
-  
-
 ------------------------------------------------------------------------
 
 ## Examples

--- a/android/docs/engine/KMManager/getCurrentKeyboardInfo.md
+++ b/android/docs/engine/KMManager/getCurrentKeyboardInfo.md
@@ -28,34 +28,6 @@ Use this method to get details of the currently selected keyboard.
 Details include package ID, keyboard ID, language ID, keyboard name,
 language name and fonts.
 
-  
-
-------------------------------------------------------------------------
-
-## Syntax (Deprecated)
-
-``` javascript
-KMManager.getCurrentKeyboardInfo(Context context)
-```
-
-### Parameters
-
-`context`
-:   The context.
-
-### Returns
-
-(Deprecated) Returns an information dictionary of the current keyboard
-with keys and values defined as `HashMap<String key, String value>`.
-
-## Description
-
-Use this method to get details of the currently selected keyboard.
-Details include keyboard ID, language ID, keyboard name, language name
-and fonts.
-
-  
-
 ------------------------------------------------------------------------
 
 ## Examples

--- a/android/docs/engine/KMManager/getKeyboardFontFilename.md
+++ b/android/docs/engine/KMManager/getKeyboardFontFilename.md
@@ -22,6 +22,8 @@ empty string otherwise.
 
 Use this method to get the font filename of the selected keyboard.
 
+Deprecated. Use `getKeyboardTextFontFilename()` instead.
+
 ## Examples
 
 ### Example: Using `getKeyboardFontFilename()`
@@ -34,5 +36,6 @@ The following script illustrate the use of `getKeyboardFontFilename()`:
 
 ## See also
 
+-   [`getKeyboardTextFontFilename()`](getKeyboardTextFontFilename)
 -   [`getKeyboardFontTypeface()` (Deprecated)](getKeyboardFontTypeface)
 -   [`getFontTypeface()`](getFontTypeface)

--- a/android/docs/engine/KMManager/getKeyboardFontTypeface.md
+++ b/android/docs/engine/KMManager/getKeyboardFontTypeface.md
@@ -28,6 +28,8 @@ exists, `null` otherwise.
 Use this method to create a new typeface from the selected keyboard's
 font if it has any.
 
+Deprecated. Use `getKeyboardTextFontFilename()` instead.
+
 ## Examples
 
 ### Example: Using `getKeyboardFontTypeface()`
@@ -44,3 +46,4 @@ The following script illustrate the use of `getKeyboardFontTypeface()`:
 
 -   [`getFontTypeface()`](getFontTypeface)
 -   [`getKeyboardFontFilename()` (Deprecated)](getKeyboardFontFilename)
+-   [`getKeyboardTextFontFilename()`](getKeyboardTextFontFilename)

--- a/android/docs/engine/KMManager/getKeyboardInfo.md
+++ b/android/docs/engine/KMManager/getKeyboardInfo.md
@@ -31,35 +31,6 @@ Use this method to get details of the keyboard at given position in
 keyboards list. Details include keyboard ID, language ID, keyboard name,
 language name and fonts.
 
-  
-
-------------------------------------------------------------------------
-
-## Syntax (Deprecated)
-
-``` javascript
-KMManager.getKeyboardInfo(Context context, int index)
-```
-
-### Parameters
-
-`context`
-:   The context.
-
-`index`
-:   0-based position of the keyboard in keyboards list.
-
-### Returns
-
-(Deprecated) Returns an information dictionary of the specified keyboard
-with keys and values defined as `HashMap<String key, String value>`.
-
-## Description
-
-Use this method to get details of the keyboard at given position in
-keyboards list. Details include keyboard ID, language ID, keyboard name,
-language name and fonts.
-
 ## Examples
 
 ### Example: Using `getKeyboardInfo()`

--- a/android/docs/engine/KMManager/getKeyboardsList.md
+++ b/android/docs/engine/KMManager/getKeyboardsList.md
@@ -26,33 +26,6 @@ otherwise.
 
 Use this method to get details of all keyboard's in keyboards menu.
 
-  
-
-------------------------------------------------------------------------
-
-## Syntax (Deprecated)
-
-``` javascript
-KMManager.getKeyboardsList(Context context)
-```
-
-### Parameters
-
-`context`
-:   The context.
-
-### Returns
-
-(Deprecated) Returns keyboards list as
-`ArrayList<HashMap<String key, String value>>` if it exists, `null`
-otherwise.
-
-## Description
-
-Use this method to get details of all keyboard's in keyboards menu.
-
-  
-
 ------------------------------------------------------------------------
 
 ## Examples


### PR DESCRIPTION
Several functions got deprecated in Keyman 14 and replaced with a function with same name and parameters but different return type. The original function no longer exists. This change removes the documentation for those no longer existing deprecated functions.

Also update the documentation for two deprecated functions to show what should be used instead.

Build-bot: skip
Test-bot: skip