### PR TITLE
chore(web): update help links to use latest version

### DIFF
--- a/web/src/app/browser/src/context/focusAssistant.ts
+++ b/web/src/app/browser/src/context/focusAssistant.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "eventemitter3";
 
 /**
  * The return object documented for
- * https://help.keyman.com/developer/engine/web/16.0/reference/core/getUIState.
+ * https://help.keyman.com/developer/engine/web/current-version/reference/core/getUIState.
  *
  * As it has long been documented in this format, property names should not be adjusted!
  */

--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -408,7 +408,7 @@ export class ContextManager extends ContextManagerBase<BrowserConfiguration> {
    * context.
    *
    * This is the core method that backs
-   * https://help.keyman.com/developer/engine/web/15.0/reference/core/setKeyboardForControl.
+   * https://help.keyman.com/developer/engine/web/current-version/reference/core/setKeyboardForControl.
    * @param textStore
    * @param kbdId
    * @param langId

--- a/web/src/engine/src/osk/views/oskView.ts
+++ b/web/src/engine/src/osk/views/oskView.ts
@@ -43,7 +43,7 @@ export type OSKRect = {
 
 /**
  * Definition for OSK events documented at
- * https://help.keyman.com/developer/engine/web/16.0/reference/events/.
+ * https://help.keyman.com/developer/engine/web/current-version/reference/events/.
  */
 export interface LegacyOSKEventMap {
   'configclick'(obj: {}): void;


### PR DESCRIPTION
This updates three in-code help links to point to `current-version` instead of an outdated version page.

Build-bot: skip
Test-bot: skip