### PR TITLE
fix(web): restore backspace-input token reconstruction 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-token.ts
@@ -97,7 +97,7 @@ export class ContextToken {
    * @param model
    * @param rawText
    */
-  static fromRawText(model: LexicalModel, rawText: string, isPartial?: boolean) {
+  static fromRawText(model: LexicalModel, rawText: string, isPartial?: boolean, transitionId?: number) {
     rawText ||= '';
 
     // Supports the old pathway for: updateWithBackspace(tokenText: string, transitionId: number)
@@ -108,7 +108,7 @@ export class ContextToken {
       let inputMetadata: PathInputProperties = {
         segment: {
           start: 0,
-          transitionId: undefined
+          transitionId: transitionId
         },
         bestProbFromSet: BASE_PROBABILITY,
         subsetId: generateSubsetId()

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -154,6 +154,11 @@ export interface TokenizationTransitionEdits {
    * the end of the original context's tail token.
    */
   tokenizedTransform: Map<number, Transform>;
+
+  /**
+   * Indicates that this tokenization-transition handles a backspace transform.
+   */
+  isBksp?: boolean;
 }
 
 /**
@@ -560,6 +565,7 @@ export class ContextTokenization {
         removedTokenCount
       },
       tokenizedTransform: transformMap,
+      isBksp: transform.insert == '' && transform.deleteLeft == 1
     };
   }
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -13,6 +13,7 @@ import { KMWString } from 'keyman/common/web-utils';
 import { ContextToken } from './context-token.js';
 import { TransformUtils } from '../transformUtils.js';
 import { computeDistance, EditOperation, EditTuple } from './classical-calculation.js';
+import { LegacyQuotientRoot } from './legacy-quotient-root.js';
 import { determineModelTokenizer } from '../model-helpers.js';
 import { ExtendedEditOperation, SegmentableDistanceCalculation } from './segmentable-calculation.js';
 import { PathInputProperties } from './search-quotient-node.js';
@@ -20,7 +21,6 @@ import { TransitionEdge } from './tokenization-subsets.js';
 
 import LexicalModel = LexicalModelTypes.LexicalModel;
 import Transform = LexicalModelTypes.Transform;
-import { LegacyQuotientRoot } from './legacy-quotient-root.js';
 
 // May be able to "get away" with 2 & 5 or so, but having extra will likely help
 // with edit path stability.
@@ -565,7 +565,7 @@ export class ContextTokenization {
         removedTokenCount
       },
       tokenizedTransform: transformMap,
-      isBksp: transform.insert == '' && transform.deleteLeft == 1
+      isBksp: TransformUtils.isBackspace(transform)
     };
   }
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-transition.ts
@@ -161,23 +161,30 @@ export class ContextTransition {
       transformToApply: Transform,
       inputDistribution: Distribution<Transform>
     ) => {
+      const appliesSuggestion = transformToApply == suggestion.transform;
+
       const appliedDistribution = [{sample: transformToApply, p: 1}];
-      const { subsets: applicationSubsets, keyMatchingUserContext } = precomputeTransitions(
+      const { subsets: transitionSubsets, keyMatchingUserContext } = precomputeTransitions(
         [rootTokenization], appliedDistribution
       );
 
       // Filter out insert and delete edges here!  ONLY the primary substitution
       // edge should be permitted!
-      const directSuggestionSubset: typeof applicationSubsets = new Map();
+      let applicationSubsets: typeof transitionSubsets = new Map();
 
-      // When applying suggestions, only consider the actual tokenization that would result.
-      directSuggestionSubset.set(keyMatchingUserContext, applicationSubsets.get(keyMatchingUserContext));
+      const currentContextSubset = transitionSubsets.get(keyMatchingUserContext);
+      if(appliesSuggestion) {
+        // When applying suggestions, only consider the actual tokenization that would result.
+        applicationSubsets.set(keyMatchingUserContext, currentContextSubset);
 
-      // TODO:  verify that 'insert' and 'delete' edit-spurs are ignored (once
-      // they're supported)
+        // TODO:  verify that 'insert' and 'delete' edit-spurs are ignored (once
+        // they're supported)
+      } else {
+        applicationSubsets = transitionSubsets;
+      }
 
       const resultingTokenization = transitionTokenizations(
-        directSuggestionSubset,
+        applicationSubsets,
         appliedDistribution
       ).get(keyMatchingUserContext);
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-subsets.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/tokenization-subsets.ts
@@ -35,6 +35,11 @@ export interface TransitionEdge {
   inputs: Distribution<Map<number, Transform>>
 
   /**
+   * Indicates that the modeled transition handles a raw BKSP.
+   */
+  isBksp?: boolean;
+
+  /**
    * A unique identifier associated with this TransitionEdge and its
    * transforms within `SearchSpace`s.  This ID assists with detecting when
    * split transforms are re-merged during SearchSpace merges.  Only
@@ -103,6 +108,10 @@ export function editKeyer(precomputation: TokenizationTransitionEdits): string[]
     components.push('UE:' + unmappedEdits.map((edit) => {
       return `${edit.op}(${edit.input ?? ''}-${edit.match ?? ''}`;
     }).join(','));
+  }
+
+  if(precomputation.isBksp) {
+    components.push('ISBKSP');
   }
 
   return components;
@@ -243,7 +252,8 @@ export class TokenizationSubsetBuilder {
     const forTokenization: TransitionEdge = entry.transitionEdges.get(tokenization) ?? {
       alignment: precomputation.alignment,
       inputs: [],
-      inputSubsetId: generateSubsetId()
+      inputSubsetId: generateSubsetId(),
+      isBksp: precomputation.isBksp
     };
 
     // Adds the incoming tokenized transform data for the pairing...

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/transition-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/transition-helpers.ts
@@ -46,12 +46,16 @@ export function precomputeTransitions(
    * context edited by the user.
    */
   keyMatchingUserContext: string
-  } {
+} {
   keyer ??= legacySubsetKeyer;
 
   let keyMatchingUserContext: string;
   const trueInput = transformDistribution[0].sample;
   const lexicalModel = startTokenizations[0]?.tail.searchModule.model;
+
+  if(trueInput.insert == '' && trueInput.deleteLeft == 0) {
+    transformDistribution = [transformDistribution[0]];
+  }
 
   const subsetBuilder = new TokenizationSubsetBuilder(keyer);
 
@@ -138,6 +142,18 @@ export function transitionTokenizations(
       const lastTokenIndex = tokens.length - 1;
       if(tokens[lastTokenIndex].isEmptyToken && tokens[lastTokenIndex-1]) {
         tokens[lastTokenIndex].appliedTransitionId ??= tokens[lastTokenIndex-1].appliedTransitionId
+      }
+
+      if(precomp[1].isBksp) {
+        const appliedEdge = precomp[1];
+        const affectedTokenCount = appliedEdge.inputs[0].sample.size;
+
+        for(let i = 0; i < affectedTokenCount; i++)  {
+          const index = tokens.length - affectedTokenCount + i;
+          const token = tokens[index];
+
+          remadeTokenization.tokens[index] = ContextToken.fromRawText(token.searchModule.model, token.exampleInput, token.isPartial, trueInput.id);
+        }
       }
 
       return remadeTokenization;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/transition-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/transition-helpers.ts
@@ -13,6 +13,7 @@ import { ContextToken } from './context-token.js';
 import { ContextTokenization } from './context-tokenization.js';
 import { SearchQuotientCluster } from './search-quotient-cluster.js';
 import { legacySubsetKeyer, TokenizationSubset, TokenizationSubsetBuilder } from './tokenization-subsets.js';
+import { TransformUtils } from '#./transformUtils.js';
 
 import Distribution = LexicalModelTypes.Distribution;
 import Transform = LexicalModelTypes.Transform;
@@ -53,7 +54,7 @@ export function precomputeTransitions(
   const trueInput = transformDistribution[0].sample;
   const lexicalModel = startTokenizations[0]?.tail.searchModule.model;
 
-  if(trueInput.insert == '' && trueInput.deleteLeft == 0) {
+  if(TransformUtils.isBackspace(trueInput)) {
     transformDistribution = [transformDistribution[0]];
   }
 
@@ -139,21 +140,24 @@ export function transitionTokenizations(
       // If the last token is empty and has no flag for a revertable transition,
       // attempt to copy the previous token's revertable transition flag.
       const tokens = remadeTokenization.tokens;
-      const lastTokenIndex = tokens.length - 1;
-      if(tokens[lastTokenIndex].isEmptyToken && tokens[lastTokenIndex-1]) {
-        tokens[lastTokenIndex].appliedTransitionId ??= tokens[lastTokenIndex-1].appliedTransitionId
-      }
 
+      // If we have a pure backspace operation, we should forget fat-finger data
+      // and reconstruct the token without corrective data.
       if(precomp[1].isBksp) {
         const appliedEdge = precomp[1];
-        const affectedTokenCount = appliedEdge.inputs[0].sample.size;
+        const affectedTokenCount = appliedEdge.inputs[0].sample.size - appliedEdge.alignment.removedTokenCount;
 
         for(let i = 0; i < affectedTokenCount; i++)  {
           const index = tokens.length - affectedTokenCount + i;
           const token = tokens[index];
 
-          remadeTokenization.tokens[index] = ContextToken.fromRawText(token.searchModule.model, token.exampleInput, token.isPartial, trueInput.id);
+          tokens[index] = ContextToken.fromRawText(token.searchModule.model, token.exampleInput, token.isPartial, trueInput.id);
         }
+      }
+
+      const lastTokenIndex = tokens.length - 1;
+      if(tokens[lastTokenIndex].isEmptyToken && tokens[lastTokenIndex-1]) {
+        tokens[lastTokenIndex].appliedTransitionId ??= tokens[lastTokenIndex-1].appliedTransitionId
       }
 
       return remadeTokenization;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/transition-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/transition-helpers.ts
@@ -13,7 +13,7 @@ import { ContextToken } from './context-token.js';
 import { ContextTokenization } from './context-tokenization.js';
 import { SearchQuotientCluster } from './search-quotient-cluster.js';
 import { legacySubsetKeyer, TokenizationSubset, TokenizationSubsetBuilder } from './tokenization-subsets.js';
-import { TransformUtils } from '#./transformUtils.js';
+import { TransformUtils } from '../transformUtils.js';
 
 import Distribution = LexicalModelTypes.Distribution;
 import Transform = LexicalModelTypes.Transform;

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/transition-helpers.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/transition-helpers.tests.ts
@@ -28,6 +28,7 @@ import {
   SearchQuotientCluster,
   TokenizationSubset,
   TokenizationTransitionEdits,
+  TransformUtils,
   TransitionEdge,
   transitionTokenizations
 } from '@keymanapp/lm-worker/test-index';
@@ -52,7 +53,8 @@ const plainModel = new TrieModel(
 function buildOutboundTransitionEdge (
   baseTokenization: ContextTokenization,
   inputs: Distribution<Required<Transform>>,
-  tokenizedInputs: Distribution<Map<number, Transform>>
+  tokenizedInputs: Distribution<Map<number, Transform>>,
+  isBksp: boolean
 ): TransitionEdge {
   const primaryTokenizedInput = tokenizedInputs[0].sample;
   const relativeTailIndex = [...primaryTokenizedInput.keys()][0];
@@ -77,7 +79,8 @@ function buildOutboundTransitionEdge (
       removedTokenCount: 0
     },
     inputs: tokenizedInputs,
-    inputSubsetId: generateSubsetId()
+    inputSubsetId: generateSubsetId(),
+    isBksp
   };
 }
 
@@ -132,14 +135,16 @@ function generateFixtureForTokenizationOutboundTransition (
   inputPropBase: PathInputProperties
 ) {
   return dists.map((dist) => {
+    const isBksp = TransformUtils.isBackspace(dist.raw[0].sample);
     const primaryTokenizedInput = dist.tokenized[0].sample;
-    const tokenizationEdge = buildOutboundTransitionEdge(srcTokenization, dist.raw, dist.tokenized);
+    const tokenizationEdge = buildOutboundTransitionEdge(srcTokenization, dist.raw, dist.tokenized, isBksp);
 
     // Is only built for use in constructing the subset keys.  We only need data
     // from one of the inputs here.
     const keyable: TokenizationTransitionEdits = {
       tokenizedTransform: primaryTokenizedInput,
-      alignment: tokenizationEdge.alignment
+      alignment: tokenizationEdge.alignment,
+      isBksp
     };
 
     const key = precomputationSubsetKeyer(keyable);


### PR DESCRIPTION
Before epic/autocorrect, input of a pure backspacing transform would perform special operations within the predictive-text worker, reconstructing the remainder of the token and erasing fat-finger data.  This PR fixes the regression.

This is notably useful when attempting to erase part of an applied suggestion, as applied suggestions wholesale-replace the original versions of affected tokens with a single transform input.  Backspacing into the transform will then break that unitary transform into pieces better suited for ongoing predictive-text operations.

Build-bot: skip build:web build:android

## User Testing

TEST_SUGGESTION_ERASURE:  Using Keyman for Android...
- apply a suggestion for a long word
- progressively erase it with backspace inputs
- verify that reasonable suggestions are displayed after each backspace.

TEST_SMOKE:  Using Keyman for Android, play around with a keyboard-model pair supporting predictive text for two minutes.  If any odd, unusual, or unexpected behaviors occur, fail this test and report them here.
- Do not use a Khmer-script keyboard for this, as there are separate known issues for such keyboards.