### PR TITLE
chore(web): fire `keyboardloaded` event only once per keyboard

### DIFF
--- a/web/src/engine/src/main/keymanEngineBase.ts
+++ b/web/src/engine/src/main/keymanEngineBase.ts
@@ -330,10 +330,6 @@ export class KeymanEngineBase<
         this.config.deferForInitialization.then(eventRaiser);
       }
     });
-
-    this.keyboardRequisitioner.cache.on('keyboardadded', (keyboard) => {
-      this.legacyAPIEvents.callEvent('keyboardloaded', { keyboardName: keyboard.id });
-    });
     //
     // #endregion
 


### PR DESCRIPTION
Previously we fired `keyboardloaded` twice for each loaded keyboard. This change fixes this.

Fixes: #16292
Build-bot: skip build:web
Test-bot: skip