### PR TITLE
refactor(web): fix return type of `currentKeyboardSrcTextStore`

### DIFF
--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -360,14 +360,13 @@ export class ContextManager extends ContextManagerBase<BrowserConfiguration> {
    *
    * This is based on the current `.activeTextStore` and its related attachment metadata.
    */
-  protected currentKeyboardSrcTextStore(): AbstractElementTextStore<any> {
+  protected currentKeyboardSrcTextStore(): AbstractElementTextStore<any> | null {
     const textStore = this.currentTextStore || this.mostRecentTextStore;
 
     if(this.isTextStoreKeyboardIndependent(textStore)) {
       return textStore;
-    } else {
-      return null;
     }
+    return null;
   }
 
   private isTextStoreKeyboardIndependent(textStore: AbstractElementTextStore<any>): boolean {

--- a/web/src/app/webview/src/contextManager.ts
+++ b/web/src/app/webview/src/contextManager.ts
@@ -152,7 +152,7 @@ export class ContextManager extends ContextManagerBase<WebviewConfiguration> {
    * Reflects the active 'textStore' upon which any `set activeKeyboard` operation will take place.
    * For app/webview... there's only one textStore, thus only a "global default" matters.
    */
-  protected currentKeyboardSrcTextStore(): SyntheticTextStore {
+  protected currentKeyboardSrcTextStore(): SyntheticTextStore | null {
     return null;
   }
 

--- a/web/src/engine/src/main/contextManagerBase.ts
+++ b/web/src/engine/src/main/contextManagerBase.ts
@@ -150,7 +150,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
    * attached elements within the app/browser textStore.  For `app/webview`, this should
    * always return a consistent value - likely, `null`.
    */
-  protected abstract currentKeyboardSrcTextStore(): TextStore;
+  protected abstract currentKeyboardSrcTextStore(): TextStore | null;
 
   /**
    * Ensures that newly activated keyboards are set correctly within managed context, possibly


### PR DESCRIPTION
`currentKeyboardSrcTextStore` can return `null` if the global `textStore` should be used. This change reflects this in the return type.

Build-bot: skip build:web
Test-bot: skip