### PR TITLE
fix(web): match fat-finger keys via elementID, not by reference 🚂

### DIFF
--- a/web/src/engine/src/osk/visualKeyboard.ts
+++ b/web/src/engine/src/osk/visualKeyboard.ts
@@ -1647,9 +1647,12 @@ export class VisualKeyboard extends EventEmitter<EventMap> implements KeyboardVi
     // that the user actually touched.  Even if it's not the most likely key.
     const keyDistribution = keyEvent.keyDistribution;
     if(keyDistribution && keyDistribution.length > 1) {
-      const matchIndex = keyDistribution.findIndex(keySample => keySample.keySpec == keySpec);
+      // While the references should match, it appears something disrupts this
+      // within the iOS WebView.  Fortunately, we can still check against the unique
+      // element ID, fortunately.
+      const matchIndex = keyDistribution.findIndex(keySample => keySample.keySpec.elementID == keySpec.elementID);
       if(matchIndex < 0 && correctionKeyFilter(keySpec)) {
-        console.error("Could not find and prioritize output key in its fat-finger distribution");
+        console.error(`Could not find and prioritize output key in its fat-finger distribution`);
       } else if(matchIndex > 0) {
         // Possibly not ideal for easy reading during inspection, but it's
         // low-cost to just swap the entry with the most likely entry and call

--- a/web/src/engine/src/osk/visualKeyboard.ts
+++ b/web/src/engine/src/osk/visualKeyboard.ts
@@ -1648,7 +1648,7 @@ export class VisualKeyboard extends EventEmitter<EventMap> implements KeyboardVi
     const keyDistribution = keyEvent.keyDistribution;
     if(keyDistribution && keyDistribution.length > 1) {
       // While the references should match, it appears something disrupts this
-      // within the iOS WebView.  Fortunately, we can still check against the unique
+      // within the iOS WebView (#16254).  Fortunately, we can still check against the unique
       // element ID, fortunately.
       const matchIndex = keyDistribution.findIndex(keySample => keySample.keySpec.elementID == keySpec.elementID);
       if(matchIndex < 0 && correctionKeyFilter(keySpec)) {


### PR DESCRIPTION
Fixes: #16254

While I have not been able to find a definitive online reference, it appears that the key-spec instance attached to OSK elements may be replaced within the iOS Safari-based WebView despite no re-assignment existing within Keyman Engine for Web code.

The references should not change under any condition, but it appears that something external within the iOS WebView causes this anyway.  Fortunately, we can still check against the unique element ID, which provides a way around this issue.

Build-bot: skip release:web release:ios

## User Testing

TEST_GFF_AHMARIC_RESET:  Verify that the following steps generates no error when using Keyman for iPhone and iPad.

1. Install `gff_amharic`.
2. Type a correctable string: `ውስጥል`. (Positionally, QWERTY `xskl`.)  Tap the `ል` key toward its bottom.
3. Apply a displayed suggestion and type one additional letter.
4. Use the `...` drop down menu and open app Settings.
5. Back out of settings and return to the text area + keyboard.
6. Tap the backspace key three times.
7.  Verify that no erroneous behavior or alerts occur.
    - Predictive text should continue to operate normally, offering suggestions for the current state of the context.

TEST_ROBUSTNESS:  Spend at least 5 minutes trying to "break" predictive text and the gesture engine.  Report back on any issues discovered.
- Note that `gff_amharic` offers subkey menus _and_ multitap keys - be sure to try both.

_**SELF NOTE**_:  There is a chance the error may occur internally, sending a report to our Sentry dashboard, without actually displaying a user error.  Check for any matching reports before merging!