### PR TITLE
change(web): rework penultimate token handling in tailless-keystroke method 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -1250,6 +1250,10 @@ export function assembleTransforms(stackedInserts: string[], stackedDeletes: num
  * @returns
  */
 export function determineTaillessTrueKeystroke(tokenizedInput: Map<number, Transform>) {
+  if(!tokenizedInput || tokenizedInput.size == 0) {
+    throw new Error(`tokenizedInput must not be nullish or empty; even an empty transform should have an entry`);
+  }
+
   // undefined by default; we haven't yet determined if we're still affecting
   // the same token that was the tail in the previous tokenization state.
   let taillessTrueKeystroke: Transform;

--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -1267,10 +1267,7 @@ export function determineTaillessTrueKeystroke(tokenizedInput: Map<number, Trans
 
   const transformKeys = [...tokenizedInput.keys()];
   do {
-    const penultimateKey = transformKeys[transformKeys.length - 2];
     const tailKey = transformKeys[transformKeys.length - 1];
-
-    const penultimateTransform = tokenizedInput.get(penultimateKey);
     const tailTransform = tokenizedInput.get(tailKey);
 
     // Do not treat pure-backspace transforms at the tail end of context as the
@@ -1279,9 +1276,14 @@ export function determineTaillessTrueKeystroke(tokenizedInput: Map<number, Trans
     if(TransformUtils.isBackspace(tailTransform) && transformKeys.length > 1) {
       transformKeys.pop();
       continue;
-    } else if(!penultimateTransform) {
+    } else if(transformKeys.length < 2) {
       break;
-    } else if(
+    }
+
+    const penultimateKey = transformKeys[transformKeys.length - 2];
+    const penultimateTransform = tokenizedInput.get(penultimateKey);
+
+    if(
       // Erasing a single-char whitespace requires deletion of two tokens, the
       // last of which is empty.  Check for this case and handle it accordingly
       // as well.


### PR DESCRIPTION
Addresses this post-merge review comment:  https://github.com/keymanapp/keyman/pull/16307#discussion_r3748498234

Build-bot: skip build:web
Test-bot: skip