### PR TITLE
fix(core): make coherence check a debug assert

### DIFF
--- a/core/src/action.cpp
+++ b/core/src/action.cpp
@@ -103,6 +103,10 @@ bool km::core::action_item_list_to_actions_object(
         break;
       case KM_CORE_IT_PERSIST_OPT:
       {
+        assert(action_items->option != nullptr);
+        if(action_items->option != nullptr) {
+          return false;
+        }
         // TODO: lowpri: replace existing item if already present in options vector?
         km::core::option opt(static_cast<km_core_option_scope>(action_items->option->scope),
           action_items->option->key,

--- a/core/src/action.cpp
+++ b/core/src/action.cpp
@@ -103,10 +103,10 @@ bool km::core::action_item_list_to_actions_object(
         break;
       case KM_CORE_IT_PERSIST_OPT:
       {
-        // assert(action_items->option != nullptr);
-        // if(action_items->option != nullptr) {
-        //   return false;
-        // }
+        assert(action_items->option != nullptr);
+        if(action_items->option == nullptr) {
+           return false;
+        }
         // TODO: lowpri: replace existing item if already present in options vector?
         km::core::option opt(static_cast<km_core_option_scope>(action_items->option->scope),
           action_items->option->key,

--- a/core/src/action.cpp
+++ b/core/src/action.cpp
@@ -103,10 +103,10 @@ bool km::core::action_item_list_to_actions_object(
         break;
       case KM_CORE_IT_PERSIST_OPT:
       {
-        assert(action_items->option != nullptr);
-        if(action_items->option != nullptr) {
-          return false;
-        }
+        // assert(action_items->option != nullptr);
+        // if(action_items->option != nullptr) {
+        //   return false;
+        // }
         // TODO: lowpri: replace existing item if already present in options vector?
         km::core::option opt(static_cast<km_core_option_scope>(action_items->option->scope),
           action_items->option->key,

--- a/core/src/state.cpp
+++ b/core/src/state.cpp
@@ -49,7 +49,6 @@ actions::actions(actions const &other)
     }
   }
 }
-}
 
 state::state(km::core::abstract_processor & ap, km_core_option_item const *env)
   : _processor(ap)

--- a/core/src/state.cpp
+++ b/core/src/state.cpp
@@ -44,14 +44,11 @@ actions::actions(actions const &other)
   size_t opt_index = 0;
   for (auto &item : *this) {
     if (item.type == KM_CORE_IT_PERSIST_OPT) {
-      if (opt_index < _option_items_stack.size()) {
-        item.option = &_option_items_stack[opt_index++];
-      } else {
-        // no matching item in the stack; clear pointer.
-        item.option = nullptr;
-      }
+      assert(opt_index < _option_items_stack.size());
+      item.option = &_option_items_stack[opt_index++];
     }
   }
+}
 }
 
 state::state(km::core::abstract_processor & ap, km_core_option_item const *env)

--- a/core/tests/unit/kmnkbd/state_api.tests.cpp
+++ b/core/tests/unit/kmnkbd/state_api.tests.cpp
@@ -413,42 +413,42 @@ int main(int argc, char * argv[])
     clone_state_deleted_text
   ));
 
-// Add two actions before cloning the state again
-try_status(km_core_process_event(test_state, KM_CORE_VKEY_F3, 0, 1, KM_CORE_EVENT_FLAG_DEFAULT));
-try_status(km_core_state_clone(test_state, &test_clone_2));
+  // Add two actions before cloning the state again
+  try_status(km_core_process_event(test_state, KM_CORE_VKEY_F3, 0, 1, KM_CORE_EVENT_FLAG_DEFAULT));
+  try_status(km_core_state_clone(test_state, &test_clone_2));
 
-// Now put an option in the test_clone_2 state only
-km_core_action_item action_clone = {KM_CORE_IT_PERSIST_OPT, {0,}, };
-action_clone.option = &clone_persist_opt;
-if (test_clone_2->actions().back().type == KM_CORE_IT_END) {
-      test_clone_2->actions().pop_back();
-}
+  // Now put an option in the test_clone_2 state only
+  km_core_action_item action_clone = {KM_CORE_IT_PERSIST_OPT, {0,}, };
+  action_clone.option = &clone_persist_opt;
+  if (test_clone_2->actions().back().type == KM_CORE_IT_END) {
+        test_clone_2->actions().pop_back();
+  }
 
-km_core_action_item action_clone_queue[] = {
-  action_clone,
-  {KM_CORE_IT_END}
-};
+  km_core_action_item action_clone_queue[] = {
+    action_clone,
+    {KM_CORE_IT_END}
+  };
 
-km_core_state_queue_action_items(test_clone_2, action_clone_queue);
-test_clone_2->actions().commit();
+  km_core_state_queue_action_items(test_clone_2, action_clone_queue);
+  test_clone_2->actions().commit();
 
-  // Test debug dump
-auto doc3 = get_json_doc(*test_state), doc4 = get_json_doc(*test_clone_2);
-std::cout << "doc3:" << std::endl;
-std::cout << doc3 << std::endl;
-std::cout << "doc4:" << std::endl;
-std::cout << doc4 << std::endl;
-if (doc3 == doc4)           return __LINE__;
+    // Test debug dump
+  auto doc3 = get_json_doc(*test_state), doc4 = get_json_doc(*test_clone_2);
+  std::cout << "doc3:" << std::endl;
+  std::cout << doc3 << std::endl;
+  std::cout << "doc4:" << std::endl;
+  std::cout << doc4 << std::endl;
+  if (doc3 == doc4)           return __LINE__;
 
-km_core_action_item action_tp3 = {KM_CORE_IT_PERSIST_OPT, {0,}, };
-action_tp3.option = &test_point_3_opt;
+  km_core_action_item action_tp3 = {KM_CORE_IT_PERSIST_OPT, {0,}, };
+  action_tp3.option = &test_point_3_opt;
 
-km_core_action_item action_tp4 = {KM_CORE_IT_PERSIST_OPT, {0,}, };
-action_tp4.option = &test_point_4_opt;
+  km_core_action_item action_tp4 = {KM_CORE_IT_PERSIST_OPT, {0,}, };
+  action_tp4.option = &test_point_4_opt;
 
-test_assert(action_items(test_state, {action_tp3, action_tp4, {KM_CORE_IT_END}}));
-// Check that test_clone_2 has the same persisted options plus the extra queued option.
-test_assert(action_items(test_clone_2, {action_tp3, action_tp4, action_clone, {KM_CORE_IT_END}}));
+  test_assert(action_items(test_state, {action_tp3, action_tp4, {KM_CORE_IT_END}}));
+  // Check that test_clone_2 has the same persisted options plus the extra queued option.
+  test_assert(action_items(test_clone_2, {action_tp3, action_tp4, action_clone, {KM_CORE_IT_END}}));
 
   // Destroy them
    km_core_state_dispose(test_state);


### PR DESCRIPTION
Crash in the clone operator rather then setting pointer to null for option. Keep the check for debug assert.

This also adds a null pointer check to KM_CORE_IT_PERSIST_OPT case in km::core::action_item_list_to_actions_object
Edit: turns out I needed this change for this PR #16342 so I merged it in.

Fixes: #16340

Test-bot: skip