### PR TITLE
fix(web): fix complex backspace handling, add unit tests 🚂

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/correction/context-tokenization.ts
@@ -531,10 +531,13 @@ export class ContextTokenization {
       [...transformMap.values()].forEach((v) => v.id = transform.id);
     }
 
-    // If there's an empty transform in the 0 position and we already know we're
-    // dropping tokens - and only deleting - we're dropping an
-    // otherwise-untracked empty token - make sure it's included!
-    const droppedFinalTransform = baseRemovedTokenCount > 0 && transform.insert == '' && TransformUtils.isEmpty(transformMap.get(0));
+    // If there's an empty transform in the final token's position and we
+    // already know we're dropping tokens - and only deleting - we're dropping
+    // an otherwise-untracked empty token - make sure it's included!
+    const droppedFinalTransform = baseRemovedTokenCount > 0
+      && transform.insert == ''
+      && TransformUtils.isEmpty(transformMap.get(0))
+      && shiftDeletes;
     // Past that, if we have more delete entries than insert entries for our transforms, we
     // dropped some tokens outright.
     const removedTokenCount = baseRemovedTokenCount + (droppedFinalTransform ? 1 : 0);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/transition-helpers.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/context/transition-helpers.tests.ts
@@ -29,6 +29,7 @@ import {
   precomputationSubsetKeyer,
   precomputeTransitions,
   SearchQuotientCluster,
+  SearchQuotientNode,
   TokenizationSubset,
   TokenizationTransitionEdits,
   TransformUtils,
@@ -463,6 +464,54 @@ describe('precomputeTransitions', () => {
       });
     });
   });
+
+  it('correctly computes removed token count for multi-token-spanning backspace inputs', () => {
+    const tokens: ContextToken[] = [];
+    tokens.push(ContextToken.fromRawText(plainModel, 'an'));
+    tokens.push(ContextToken.fromRawText(plainModel, ' '));
+
+    let appleNode: SearchQuotientNode = new LegacyQuotientRoot(plainModel);
+    let appleDist1: Distribution<Transform> = [{
+      sample: {
+        insert: 'apt',
+        deleteLeft: 0,
+        id: 1
+      },
+      p: 1
+    }];
+    appleNode = new LegacyQuotientSpur(appleNode, appleDist1, appleDist1[0]);
+    let appleDist2: Distribution<Transform> = [{
+      sample: {
+        insert: 'ple',
+        deleteLeft: 1,
+        id: 2
+      },
+      p: 1
+    }];
+    appleNode = new LegacyQuotientSpur(appleNode, appleDist2, appleDist2[0]);
+    tokens.push(new ContextToken(appleNode));
+
+    // also add space token
+    tokens.push(ContextToken.fromRawText(plainModel, ' ', false, 3));
+    tokens.push(ContextToken.fromRawText(plainModel, '', true, 3));
+
+    const dist: Distribution<Transform> = [{
+      sample: {
+        insert: '',
+        deleteLeft: 2,
+        id: 4
+      },
+      p: 1
+    }]
+
+    const tokenization = new ContextTokenization(tokens);
+    const precomputedTransition = precomputeTransitions([tokenization], dist);
+    const displaySubset = precomputedTransition.subsets.get(precomputedTransition.keyMatchingUserContext);
+
+    assert.equal(displaySubset.transitionEdges.get(tokenization).alignment.removedTokenCount, 2);
+    assert.isOk(displaySubset.transitionEdges.get(tokenization).inputs[0].sample.get(-2));
+    assert.deepEqual(displaySubset.transitionEdges.get(tokenization).inputs[0].sample.get(-2), { insert: '', deleteLeft: 1, id: 4 });
+  });
 });
 
 describe('transitionTokenizations', () => {
@@ -529,6 +578,58 @@ describe('transitionTokenizations', () => {
     const resultTokenization = result.get(precomputedTransition.keyMatchingUserContext);
 
     assert.isOk(resultTokenization);
+    const resultTail = resultTokenization.tail;
+
+    assert.equal(resultTail.exampleInput, 'appl');
+    assert.equal(resultTail.inputCount, resultTail.searchModule.codepointLength);
+    assert.equal(resultTail.searchModule.codepointLength, KMWString.length(resultTail.exampleInput));
+  });
+
+  it('handles backspace transitions correctly for a context with recent complex transforms', () => {
+    const tokens: ContextToken[] = [];
+    tokens.push(ContextToken.fromRawText(plainModel, 'an'));
+    tokens.push(ContextToken.fromRawText(plainModel, ' '));
+
+    let appleNode: SearchQuotientNode = new LegacyQuotientRoot(plainModel);
+    let appleDist1: Distribution<Transform> = [{
+      sample: {
+        insert: 'apt',
+        deleteLeft: 0,
+        id: 1
+      },
+      p: 1
+    }];
+    appleNode = new LegacyQuotientSpur(appleNode, appleDist1, appleDist1[0]);
+    let appleDist2: Distribution<Transform> = [{
+      sample: {
+        insert: 'ple',
+        deleteLeft: 1,
+        id: 2
+      },
+      p: 1
+    }];
+    appleNode = new LegacyQuotientSpur(appleNode, appleDist2, appleDist2[0]);
+    tokens.push(new ContextToken(appleNode));
+
+    // also add space token
+    tokens.push(ContextToken.fromRawText(plainModel, ' ', false, 3));
+    tokens.push(ContextToken.fromRawText(plainModel, '', true, 3));
+
+    const dist: Distribution<Transform> = [{
+      sample: {
+        insert: '',
+        deleteLeft: 2,
+        id: 4
+      },
+      p: 1
+    }]
+
+    const precomputedTransition = precomputeTransitions([new ContextTokenization(tokens)], dist);
+    const result = transitionTokenizations(precomputedTransition.subsets, dist);
+    const resultTokenization = result.get(precomputedTransition.keyMatchingUserContext);
+
+    assert.isOk(resultTokenization);
+    assert.equal(resultTokenization.tokens.length, 3); // should land within the 'apple' token.
     const resultTail = resultTokenization.tail;
 
     assert.equal(resultTail.exampleInput, 'appl');


### PR DESCRIPTION
Fixes: #16335

The new unit tests here caught the behavior addressed by this PR's predecessor, #16349.

Meanwhile, a _different_ behavior was noted here that had added complexity - it so happens the test case I constructed managed to catch a bug in backspace handling!  Fortunately, a small tweak was able to resolve the issue.

Build-bot: skip build:web
Test-bot: skip