### PR TITLE
fix(web): cleanup `loaduserinterface` and `unloaduserinterface` events

### DIFF
--- a/web/docs/engine/guide/adding-keyboards.md
+++ b/web/docs/engine/guide/adding-keyboards.md
@@ -8,7 +8,7 @@ There are multiple ways to add and install keyboards into your KeymanWeb install
 
 The most efficient way to utilize a keyboard is to obtain a local copy of it and place this copy in a static location on your website. Once this is done, it can be directly linked into KeymanWeb as follows.
 
-```typescript
+```js
 await keyman.addKeyboards({
     id:'us',                  // The keyboard's unique identification code.
     name:'English',           // The keyboard's user-readable name.
@@ -22,7 +22,7 @@ await keyman.addKeyboards({
 
 Custom fonts may also be utilized via the `language.font` property. For example:
 
-```typescript
+```js
 font:{
     family:'LaoWeb',
     source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']
@@ -33,7 +33,7 @@ font:{
 
 To obtain the default Keyman keyboard for a given language, call the following function.
 
-```typescript
+```js
 await keyman.addKeyboardsForLanguage('Dzongkha');
 ```
 
@@ -41,7 +41,7 @@ This example would find the default keyboard for the Dzongkha language. This met
 
 Alternatively, languages may be looked up via their BCP 47 language code as follows:
 
-```typescript
+```js
 await keyman.addKeyboards('@he');
 ```
 
@@ -51,7 +51,7 @@ The `@` prefix indicates the use of the BCP 47 language code, which in this case
 
 To obtain a specific keyboard by name or by keyboard name and language code as a pair, see the following:
 
-```typescript
+```js
 await keyman.addKeyboards('french', 'sil_euro_latin@sv', 'sil_euro_latin@no');
 ```
 

--- a/web/docs/engine/guide/examples/control-by-control.md
+++ b/web/docs/engine/guide/examples/control-by-control.md
@@ -11,7 +11,7 @@ to open the test page.
 
 Include the following script in the HEAD of your page:
 
-```js
+```html
 <script type="text/javascript">
   keyman.init({
     root: './',  // Note - if drawing the latest version of KeymanWeb from the CDN, this will

--- a/web/docs/engine/guide/examples/full-manual-control.md
+++ b/web/docs/engine/guide/examples/full-manual-control.md
@@ -10,7 +10,7 @@ keyboards. Please click [this link](__full-manual-control.html) to open the test
 
 Include the following script in the HEAD of your page:
 
-```js
+```html
 <script>
   var KWControl = null;
 

--- a/web/docs/engine/guide/examples/manual-control.md
+++ b/web/docs/engine/guide/examples/manual-control.md
@@ -11,7 +11,7 @@ activated by default. This example continues to use the KeymanWeb default interf
 
 Include the following script in the HEAD of your page:
 
-```js
+```html
 <script>
     keyman.init().then(async function() {
       await keyman.addKeyboards({

--- a/web/docs/engine/reference/core/BuildVisualKeyboard.md
+++ b/web/docs/engine/reference/core/BuildVisualKeyboard.md
@@ -8,7 +8,7 @@ Create a copy of the OSK for embedding in documentation or help page.
 
 ## Syntax
 
-```c
+```js
 keyman.BuildVisualKeyboard(keyboardID, staticFlag, layoutFormFactor, layerID)
 ```
 

--- a/web/docs/engine/reference/core/activatingUI.md
+++ b/web/docs/engine/reference/core/activatingUI.md
@@ -8,7 +8,7 @@ Sets an internal flag to notify KeymanWeb of change in UI activation state.
 
 ## Syntax
 
-```c
+```js
 keyman.activatingUI(state);
 ```
 

--- a/web/docs/engine/reference/core/addEventListener.md
+++ b/web/docs/engine/reference/core/addEventListener.md
@@ -8,7 +8,7 @@ Adds an event listener for user-handling of KeymanWeb events.
 
 ## Syntax
 
-```c
+```js
 keyman.addEventListener(event, func);
 ```
 
@@ -39,7 +39,7 @@ return true to allow other event handling to be processed normally.
 
 ## Example
 
-```c
+```js
 keyman.addEventListener('focus', function(e) {
   console.log("Now handling input for control " + e.target "!");
 });

--- a/web/docs/engine/reference/core/addHotKey.md
+++ b/web/docs/engine/reference/core/addHotKey.md
@@ -8,7 +8,7 @@ Add hot key handler to array of document-level hotkeys triggered by key-up event
 
 ## Syntax
 
-```c
+```js
 keyman.addHotKey(keyCode, shiftState, handler);
 ```
 

--- a/web/docs/engine/reference/core/attachToControl.md
+++ b/web/docs/engine/reference/core/attachToControl.md
@@ -8,7 +8,7 @@ Attach KeymanWeb to HTML element (or IFrame).
 
 ## Syntax
 
-```c
+```js
 keyman.attachToControl(Pelem)
 ```
 

--- a/web/docs/engine/reference/core/detachFromControl.md
+++ b/web/docs/engine/reference/core/detachFromControl.md
@@ -8,7 +8,7 @@ Detach KeymanWeb from HTML element (or IFrame).
 
 ## Syntax
 
-```c
+```js
 keyman.detachFromControl(Pelem);
 ```
 

--- a/web/docs/engine/reference/core/disableControl.md
+++ b/web/docs/engine/reference/core/disableControl.md
@@ -8,7 +8,7 @@ Disables KeymanWeb input handling for the specified control.
 
 ## Syntax
 
-```c
+```js
 keyman.disableControl(Pelem)
 ```
 

--- a/web/docs/engine/reference/core/enableControl.md
+++ b/web/docs/engine/reference/core/enableControl.md
@@ -8,7 +8,7 @@ Enables KeymanWeb input handling for the specified control.
 
 ## Syntax
 
-```c
+```js
 keyman.enableControl(Pelem)
 ```
 
@@ -40,6 +40,6 @@ If `'kmw-disabled'` is removed from the control via other means, `enableControl(
 
 If called on an element in an unattached state, the `'kmw-disabled'` tag will be removed from the element.
 
-## See also 
+## See also
 - [`keyman.attachToControl()`](attachToControl)
 - [`keyman.disableControl()`](disableControl)

--- a/web/docs/engine/reference/core/focusLastActiveElement.md
+++ b/web/docs/engine/reference/core/focusLastActiveElement.md
@@ -8,7 +8,7 @@ Restore the focus to the element active before input was moved to KeymanWeb.
 
 ## Syntax
 
-```c
+```js
 keyman.focusLastActiveElement()
 ```
 
@@ -20,6 +20,7 @@ None.
 
 `undefined`
 
-## Description
+## See also
 
-...
+* [`keyman.interface.focusLastActiveTextStore()`](../interface/focusLastActiveTextStore)
+

--- a/web/docs/engine/reference/core/getActiveKeyboard.md
+++ b/web/docs/engine/reference/core/getActiveKeyboard.md
@@ -8,7 +8,7 @@ Get the internal name of the currently active keyboard.
 
 ## Syntax
 
-```c
+```js
 keyman.getActiveKeyboard()
 ```
 

--- a/web/docs/engine/reference/core/getActiveLanguage.md
+++ b/web/docs/engine/reference/core/getActiveLanguage.md
@@ -4,23 +4,33 @@ title: getActiveLanguage
 
 ## Summary
 
-Get the language code for the currently selected language.
+Get the language tag or name for the currently selected language for the active
+keyboard.
 
 ## Syntax
 
-```c
-keyman.getActiveLanguage()
+```js
+keyman.getActiveLanguage(fullName)
 ```
 
 ### Parameters
 
-None.
+`fullName`
+:   Type: `boolean` *optional*
+:   If true, return the language name
 
 ### Return Value
 
 `string`
-:   The active language's BCP 47 language code.
+:   The active language's BCP 47 language tag or name.
 
 ## Description
 
-...
+The BCP 47 language tag returned relates to the currently active registered
+keyboard. If no keyboard is active, the return value will be an empty string.
+
+The language tag may be any well-formed
+[BCP 47](/developer/current-version/reference/bcp-47) language tag.
+
+The language name is also derived from the keyboard registration, so may not
+match language names from `Intl` or other sources.

--- a/web/docs/engine/reference/core/getKeyboardForControl.md
+++ b/web/docs/engine/reference/core/getKeyboardForControl.md
@@ -8,7 +8,7 @@ Obtain the keyboard set for a specific control, if it exists.
 
 ## Syntax
 
-```c
+```js
 keyman.getKeyboardForControl(Pelem);
 ```
 

--- a/web/docs/engine/reference/core/getLastActiveElement.md
+++ b/web/docs/engine/reference/core/getLastActiveElement.md
@@ -8,7 +8,7 @@ Return the last element activated before input was moved to KeymanWeb.
 
 ## Syntax
 
-```c
+```js
 keyman.getLastActiveElement();
 ```
 
@@ -21,6 +21,7 @@ None.
 `Element`
 :   The last element activated before KeymanWeb activated.
 
-## Description
+## See also
 
-...
+* [`keyman.interface.getLastActiveTextStore()`](../interface/getLastActiveTextStore)
+

--- a/web/docs/engine/reference/core/getSavedKeyboard.md
+++ b/web/docs/engine/reference/core/getSavedKeyboard.md
@@ -8,7 +8,7 @@ Get the (internal) keyboard name and language code of the most recently active k
 
 ## Syntax
 
-```c
+```js
 keyman.getSavedKeyboard();
 ```
 

--- a/web/docs/engine/reference/core/getUIState.md
+++ b/web/docs/engine/reference/core/getUIState.md
@@ -8,7 +8,7 @@ Get the KeymanWeb user interface activation state.
 
 ## Syntax
 
-```c
+```js
 keyman.getUIState()
 ```
 

--- a/web/docs/engine/reference/core/helpURL.md
+++ b/web/docs/engine/reference/core/helpURL.md
@@ -1,14 +1,14 @@
 ---
-title: helpURL
+title: helpURL (deprecated)
 ---
 
 ## Summary
 
-URL for keyboard help site (set by site developer).
+URL for keyboard help site.
 
 ## Syntax
 
-```keyman
+```js
 keyman.helpURL
 ```
 
@@ -22,8 +22,14 @@ Read only
 
 ### Return Value
 
-Presently set to [`"https://help.keyman.com/go"`]().
+Always returns `"https://help.keyman.com/go"`.
 
 ## Description
 
-...
+This property should not be used; full URLs for keyboard help for keyboards
+provided through Keyman Cloud are available in the
+[Keyman Cloud APIs](/developer/cloud).
+
+## History
+
+19.0: deprecated

--- a/web/docs/engine/reference/core/index.md
+++ b/web/docs/engine/reference/core/index.md
@@ -85,6 +85,10 @@ The KeymanWeb core module is exposed to the developer as `window.keyman`.
 : Get the KeymanWeb user interface activation state.
 
 
+[`helpURL` Property](helpURL) (deprecated)
+: URL for keyboard help site.
+
+
 [`init` Function](init)
 : Sets license key, selects user interface, and other KeymanWeb Options.
 

--- a/web/docs/engine/reference/core/initialized.md
+++ b/web/docs/engine/reference/core/initialized.md
@@ -2,11 +2,11 @@
 title: keyman.initialized
 ---
 
-### Summary
+## Summary
 
 Keymanweb core module initialization state flag.
 
-### Syntax
+## Syntax
 
 ```js
     keyman.initialized
@@ -26,7 +26,7 @@ Read only
 * `1`, if Keyman Engine for Web has started initialization
 * `2`, if Keyman Engine for Web is completely initialized
 
-### Description
+## Description
 
 The [`keyman.init()` function](init) is used to initialize Keyman. You can check
 this flag to see what the current initialization status is. You should not call
@@ -34,7 +34,7 @@ functions other than `keyman.init()` until Keyman initialization is complete. As
 `keyman.init()` returns a Promise, the Promise fulfilment callback is the
 appropriate place to perform post-init steps.
 
-### History
+## History
 
 * 2.0: Keyman Engine for Web supports values `0`, `1`, or `2`.
 * 16.0: Documentation updated to match implementation.

--- a/web/docs/engine/reference/core/isCJK.md
+++ b/web/docs/engine/reference/core/isCJK.md
@@ -8,7 +8,7 @@ Test if a given keyboard or keyboard stub (or the current keyboard) is for Chine
 
 ## Syntax
 
-```c
+```js
 keyman.isCJK(keyboard);
 ```
 

--- a/web/docs/engine/reference/core/isChiral.md
+++ b/web/docs/engine/reference/core/isChiral.md
@@ -9,7 +9,7 @@ left-control vs right-control.
 
 ## Syntax
 
-```c
+```js
 keyman.isChiral(keyboard);
 ```
 

--- a/web/docs/engine/reference/core/moveToElement.md
+++ b/web/docs/engine/reference/core/moveToElement.md
@@ -8,7 +8,7 @@ Move input focus to user specified element.
 
 ## Syntax
 
-```c
+```js
 keyman.moveToElement(Pelem);
 ```
 

--- a/web/docs/engine/reference/core/removeEventListener.md
+++ b/web/docs/engine/reference/core/removeEventListener.md
@@ -8,7 +8,7 @@ Removes a user-defined event handler.
 
 ## Syntax
 
-```c
+```js
 keyman.removeEventListener(event, func);
 ```
 

--- a/web/docs/engine/reference/core/removeHotKey.md
+++ b/web/docs/engine/reference/core/removeHotKey.md
@@ -8,7 +8,7 @@ Remove the hotkey handler from document's list of hotkey handlers.
 
 ## Syntax
 
-```c
+```js
 keyman.removeHotkey(keyCode, shiftState);
 ```
 

--- a/web/docs/engine/reference/core/removeKeyboards.md
+++ b/web/docs/engine/reference/core/removeKeyboards.md
@@ -8,7 +8,7 @@ Removes keyboards (by ID) from KeymanWeb.
 
 ## Syntax
 
-```c
+```js
 keyman.removeKeyboards(id[, id2, ...])
 ```
 

--- a/web/docs/engine/reference/core/resetContext.md
+++ b/web/docs/engine/reference/core/resetContext.md
@@ -4,11 +4,13 @@ title: resetContext
 
 ## Summary
 
-Revert OSK to default layer and clear any deadkeys and modifiers.
+Reverts the OSK to the default layer, clears any processing caches and modifier
+states, and clears deadkeys and prediction-processing states on the active
+element (if it exists)
 
 ## Syntax
 
-```c
+```js
 keyman.resetContext();
 ```
 
@@ -22,4 +24,7 @@ None.
 
 ## Description
 
-...
+This function can be used by a site to reset KeymanWeb's internal context state.
+This could be used after direct manipulation of a text store by the site -- for
+example, a paste command -- so that users are not presented with unexpected
+predictions or deadkeys.

--- a/web/docs/engine/reference/core/setActiveKeyboard.md
+++ b/web/docs/engine/reference/core/setActiveKeyboard.md
@@ -8,7 +8,7 @@ Change the currently active keyboard.
 
 ## Syntax
 
-```c
+```js
 keyman.setActiveKeyboard(keyboardName, languageCode);
 ```
 

--- a/web/docs/engine/reference/core/setKeyboardForControl.md
+++ b/web/docs/engine/reference/core/setKeyboardForControl.md
@@ -8,7 +8,7 @@ Associate control with independent keyboard settings initialized to a specific k
 
 ## Syntax
 
-```c
+```js
 keyman.setDefaultKeyboardForControl(Pelem, keyboard, languageCode);
 ```
 

--- a/web/docs/engine/reference/events/index.md
+++ b/web/docs/engine/reference/events/index.md
@@ -59,7 +59,7 @@ the object, using *addEventListener()*.
 For example, to define a user function to handle the KeymanWeb
 `keyboardchange` event, include:
 
-``` typescript
+```js
 keyman.addEventListener('keyboardchange',
   function(p)
   {
@@ -100,7 +100,7 @@ keyman.addEventListener('keyboardchange',
 For example, to add an event handler that modifies the user interface when the on-screen
 keyboard is displayed:
 
-``` typescript
+```js
 keyman.osk.addEventListener('show',
   function(p)
   {

--- a/web/docs/engine/reference/events/keyman/beforekeyboardchange.md
+++ b/web/docs/engine/reference/events/keyman/beforekeyboardchange.md
@@ -8,7 +8,7 @@ Called when keyboard input language is about to change.
 
 ## Syntax
 
-```javascript
+```js
 keyman.addEventListener('beforekeyboardchange', function(keyboardProperties) {
   ...
 });

--- a/web/docs/engine/reference/events/keyman/controlblurred.md
+++ b/web/docs/engine/reference/events/keyman/controlblurred.md
@@ -8,7 +8,7 @@ Called when an input element loses focus.
 
 ## Syntax
 
-```javascript
+```js
 keyman.addEventListener('controlblurred', function(eventProperties) {
   ...
 });

--- a/web/docs/engine/reference/events/keyman/controlfocused.md
+++ b/web/docs/engine/reference/events/keyman/controlfocused.md
@@ -8,7 +8,7 @@ Called when an input element receives focus.
 
 ## Syntax
 
-```javascript
+```js
 keyman.addEventListener('controlfocused', function(eventProperties) {
   ...
 });

--- a/web/docs/engine/reference/events/keyman/keyboardchange.md
+++ b/web/docs/engine/reference/events/keyman/keyboardchange.md
@@ -8,7 +8,7 @@ Called when keyboard input language changed.
 
 ## Syntax
 
-```javascript
+```js
 keyman.addEventListener('keyboardchange', function(keyboardProperties) {
   ...
 });

--- a/web/docs/engine/reference/events/keyman/keyboardloaded.md
+++ b/web/docs/engine/reference/events/keyman/keyboardloaded.md
@@ -8,7 +8,7 @@ Called when keyboard code loaded.
 
 ## Syntax
 
-```javascript
+```js
 keyman.addEventListener('keyboardloaded', function(keyboardProperties) {
   ...
 });

--- a/web/docs/engine/reference/events/keyman/keyboardregistered.md
+++ b/web/docs/engine/reference/events/keyman/keyboardregistered.md
@@ -9,7 +9,7 @@ keyboard).
 
 ## Syntax
 
-```javascript
+```js
 keyman.addEventListener('keyboardregistered', function(keyboardProperties) {
   ...
 });

--- a/web/docs/engine/reference/events/keyman/loaduserinterface.md
+++ b/web/docs/engine/reference/events/keyman/loaduserinterface.md
@@ -4,11 +4,11 @@ title: keyman.loaduserinterface Event
 
 ## Summary
 
-Called to initiate the ui initialization process.
+Called after a KeymanWeb UI has been loaded and initialized.
 
 ## Syntax
 
-```javascript
+```js
 keyman.addEventListener('loaduserinterface', function() {
   ...
 });
@@ -21,10 +21,13 @@ None.
 ### Return Value
 
 `boolean`
-:   `true` if the event should continue processing, `false` if it should
-    not. Your event handler should return `true` aside from exceptional
+:   `true` if the next event handler should be called, `false` if it should not.
+    Your event handler should return `true` aside from exceptional
     circumstances.
 
 ## Description
 
-...
+If no UI module has been loaded, then this event will not be called. If a UI is
+loaded by script before KeymanWeb, it will be initialized at the end of
+KeymanWeb's initialization sequence, but before the init promise resolves and
+before [`initialized`](../../core/initialized.md) is set to `2`.

--- a/web/docs/engine/reference/events/keyman/unloaduserinterface.md
+++ b/web/docs/engine/reference/events/keyman/unloaduserinterface.md
@@ -4,11 +4,11 @@ title: keyman.unloaduserinterface Event
 
 ## Summary
 
-Called when allow ui clean-up.
+Called when a KeymanWeb UI is about to be unloaded.
 
 ## Syntax
 
-```javascript
+```js
 keyman.addEventListener('unloaduserinterface', function() {
   ...
 });
@@ -21,11 +21,14 @@ None.
 ### Return Value
 
 `boolean`
-:   `true` if the event should continue processing, `false` if it should
-    not. Your event handler should return `true` aside from exceptional
+:   `true` if the next event handler should be called, `false` if it should not.
+    Your event handler should return `true` aside from exceptional
     circumstances.
 
 ## Description
 
-Called when the ui is to be unloaded, allowing cleanup of resources if
+Called when the ui is about to be unloaded, allowing cleanup of resources if
 necessary.
+
+It is not possible to stop the UI being unloaded; returning `false` only stops
+further event handlers from being called.

--- a/web/docs/engine/reference/events/osk/configclick.md
+++ b/web/docs/engine/reference/events/osk/configclick.md
@@ -1,7 +1,7 @@
 ---
 title: osk.configclick Event
 ---
-  
+
 ## Summary
 
 Called upon user request for the UI to present KeymanWeb configuration
@@ -9,7 +9,7 @@ options.
 
 ## Syntax
 
-```
+```js
 keyman.osk.addEventListener('configclick', function() {
   ...
 });

--- a/web/docs/engine/reference/events/osk/helpclick.md
+++ b/web/docs/engine/reference/events/osk/helpclick.md
@@ -1,14 +1,14 @@
 ---
 title: osk.helpclick Event
 ---
-  
+
 ## Summary
 
 Called upon user request for the UI to present a help page.
 
 ## Syntax
 
-```
+```js
 keyman.osk.addEventListener('helpclick', function() {
   ...
 });

--- a/web/docs/engine/reference/events/osk/hide.md
+++ b/web/docs/engine/reference/events/osk/hide.md
@@ -1,14 +1,14 @@
 ---
 title: osk.hide Event
 ---
-  
+
 ## Summary
 
 Called when the OSK is hidden.
 
 ## Syntax
 
-```
+```js
 keyman.osk.addEventListener('hide', function(param) {
   ...
 });
@@ -28,6 +28,6 @@ keyman.osk.addEventListener('hide', function(param) {
     not. Your event handler should return `true` aside from exceptional
     circumstances.
 
-## Description
+## See also
 
-...
+* [`show` event](show)

--- a/web/docs/engine/reference/events/osk/resizemove.md
+++ b/web/docs/engine/reference/events/osk/resizemove.md
@@ -1,14 +1,14 @@
 ---
 title: osk.resizemove Event
 ---
-  
+
 ## Summary
 
 Called when OSK resized or moved on desktop.
 
 ## Syntax
 
-```
+```js
 keyman.osk.addEventListener('resizemove', function() {
   ...
 });

--- a/web/docs/engine/reference/events/osk/show.md
+++ b/web/docs/engine/reference/events/osk/show.md
@@ -1,14 +1,14 @@
 ---
 title: osk.show Event
 ---
-  
+
 ## Summary
 
 Called when the OSK is displayed.
 
 ## Syntax
 
-```
+```js
 keyman.osk.addEventListener('show', function(obj) {
   ...
 });
@@ -45,6 +45,7 @@ Available display state information:
     not. Your event handler should return `true` aside from exceptional
     circumstances.
 
-## Description
+## See also
 
-...
+* [`hide` event](hide)
+

--- a/web/docs/engine/reference/interface/_nul.md
+++ b/web/docs/engine/reference/interface/_nul.md
@@ -8,13 +8,13 @@ title: nul (KN)
 
 ## Syntax
 
-```c
+```js
 keyman.interface.nul(n, Pelem);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KN(n, Pelem); // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/any.md
+++ b/web/docs/engine/reference/interface/any.md
@@ -8,13 +8,13 @@ title: any (KA) (Deprecated)
 
 ## Syntax
 
-```c
+```js
 keyman.interface.any(index, ch, storeText);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KA(index, ch, storeText); // Shorthand
 ```
 
@@ -51,7 +51,7 @@ facilitates mapping the characters `'abcde'` to their respective entry in the ou
 
 In order to check if the character `'a'` has a match in the `keys` store above, the code
 
-```c
+```js
 keyman.interface.any(0, 'a', 'abcde')
 ```
 

--- a/web/docs/engine/reference/interface/beep.md
+++ b/web/docs/engine/reference/interface/beep.md
@@ -8,13 +8,13 @@ Flash body or element as substitute for an audible feedback [`beep`](/developer/
 
 ## Syntax
 
-```c
+```js
 keyman.interface.beep(Pelem);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KB(Pelem); // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/beepReset.md
+++ b/web/docs/engine/reference/interface/beepReset.md
@@ -8,13 +8,13 @@ Cancels previous feedback [`beep`](/developer/language/reference/beep) operation
 
 ## Syntax
 
-```c
+```js
 keyman.interface.beepReset();
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KBR(); // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/context.md
+++ b/web/docs/engine/reference/interface/context.md
@@ -8,13 +8,13 @@ title: context (KC) (Deprecated)
 
 ## Syntax
 
-```c
+```js
 keyman.interface.context(n, ln, Pelem);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KC(n, ln, Pelem); // Shorthand
 ```
 
@@ -47,7 +47,7 @@ For an example from [Developer 'rules'](/developer/language/guide/rules), a keyb
 
 by first checking that the initial context (`"abc"`) matches and then using the following to fulfill the rule:
 
-```keyman
+```js
 keyman.interface.output(3, Pelem, keyman.interface.context(2, 1, Pelem));
 keyman.interface.output(0, Pelem, "D");
 ```

--- a/web/docs/engine/reference/interface/contextMatch.md
+++ b/web/docs/engine/reference/interface/contextMatch.md
@@ -8,13 +8,13 @@ title: contextMatch (KCM) (Deprecated)
 
 ## Syntax
 
-```keyman
+```js
 keyman.interface.contextMatch(n, Pelem, val, ln);
 ```
 
 or
 
-```keyman
+```js
 KeymanWeb.KCM(n, Pelem, val, ln); // Shorthand
 ```
 
@@ -51,7 +51,7 @@ This is a core element of keyboard input management within KeymanWeb in versions
 
 a keyboard would check that the initial context (`"a"`) matches by using
 
-```keyman
+```js
 keyman.interface.contextMatch(1, Pelem, "a", 1)
 ```
 

--- a/web/docs/engine/reference/interface/deadkeyMatch.md
+++ b/web/docs/engine/reference/interface/deadkeyMatch.md
@@ -4,17 +4,17 @@ title: deadkeyMatch (KDM) (Deprecated)
 
 ## Summary
 
-(Deprecated)Deadkey matching: Seeks to match the [`deadkey`](/developer/language/reference/deadkey) state `dk` at the relative caret position `n`.
+(Deprecated) Deadkey matching: Seeks to match the [`deadkey`](/developer/language/reference/deadkey) state `dk` at the relative caret position `n`.
 
 ## Syntax
 
-```c
+```js
 keyman.interface.deadkeyMatch(n, Pelem, dk);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KDM(n, Pelem, dk); // Shorthand
 ```
 
@@ -57,7 +57,7 @@ dk(backquote) + "a" > "à"
 
 The Developer compiler then generates a unique id for the deadkey state - say, `0`, and in order to detect the deadkey associated with the `` '`' `` character, compiles the `dk(backquote)` check to
 
-```c
+```js
 keyman.interface.deadkeyMatch(0, Pelem, 0)
 ```
 

--- a/web/docs/engine/reference/interface/deadkeyOutput.md
+++ b/web/docs/engine/reference/interface/deadkeyOutput.md
@@ -8,13 +8,13 @@ Deadkey output: Associates the [`deadkey`](/developer/language/reference/deadkey
 
 ## Syntax
 
-```c
+```js
 keyman.interface.deadkeyOutput(nd, Pelem, dk);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KDO(nd, Pelem, dk); // Shorthand
 ```
 
@@ -56,7 +56,7 @@ dk(backquote) + "a" > "à"
 
 The Developer compiler then generates a unique id for the deadkey state - say, `0`, and upon detecting input of the `` '`' `` character with the [`keyman.interface.deadkeyMatch()`](deadkeyMatch) function, compiles the deadkey generation to
 
-```c
+```js
 keyman.interface.deadkeyOutput(0, Pelem, 0);
 ```
 

--- a/web/docs/engine/reference/interface/deleteContext.md
+++ b/web/docs/engine/reference/interface/deleteContext.md
@@ -8,13 +8,13 @@ Context deletion - removes the specified number of deadkeys and characters from 
 
 ## Syntax
 
-```c
+```js
 keyman.interface.deleteContext(dn, Pelem);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KDC(n, Pelem); // Shorthand
 ```
 
@@ -47,7 +47,7 @@ c Lots of keyboard rules...
 
 would have a rule output as follows:
 
-```c
+```js
 // Context is length four (three characters + one deadkey), so we delete all four.
 keyman.interface.deleteContext(4, element);
 ```

--- a/web/docs/engine/reference/interface/fullContextMatch.md
+++ b/web/docs/engine/reference/interface/fullContextMatch.md
@@ -8,13 +8,13 @@ Context matching: Returns `true` if the current context matches the specified ru
 
 ## Syntax
 
-```c
+```js
 keyman.interface.fullContextMatch(n, Pelem, rule);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KFCM(n, Pelem, rule); // Shorthand
 ```
 
@@ -113,7 +113,7 @@ dk(money) 'c' any(pair_1) index(pair_2, 3) + '.' > 'taxi'
 
 would have Javascript roughly as follows:
 
-```c
+```js
 // In the keyboard store definitions:
 this.s_pair_1 = 'aA';            // store(pair_1) 'aA'
 this.s_pair_2 = 'bB';            // store(pair_2) 'bB'

--- a/web/docs/engine/reference/interface/ifStore.md
+++ b/web/docs/engine/reference/interface/ifStore.md
@@ -8,13 +8,13 @@ title: ifStore (KIFS)
 
 ## Syntax
 
-```c
+```js
 keyman.interface.ifStore(systemId, strValue, Pelem);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KIFS(systemId, strValue, Pelem);
 ```
 

--- a/web/docs/engine/reference/interface/index.md
+++ b/web/docs/engine/reference/interface/index.md
@@ -18,7 +18,7 @@ the same as `keyman.interface`. Use `keyman.interface` in preference to
 Custom user interfaces should not use these functions. These functions are intended
 for use in a keyboard context, in particular during a keystroke event cycle.
 
-[`any` Function (Deprecated)](any)
+[`any` Function](any) (deprecated)
 :   Returns whether or not the char `ch` is found within the [`any`](/developer/language/reference/any)([`store`](/developer/language/reference/store)) string, setting an internally-tracked index for use in the `indexOutput` function.
 :   Shorthand name: `keyman.interface.KA`
 
@@ -30,7 +30,7 @@ for use in a keyboard context, in particular during a keystroke event cycle.
 :   Cancels a previous feedback [`beep`](/developer/language/reference/beep) operation on a page element.
 :   Shorthand name: `keyman.interface.KBR`
 
-[`context` Function (Deprecated)](context)
+[`context` Function](context) (deprecated)
 :   Gets [`context`](/developer/language/reference/context) for an ongoing keyboard operation relative to the caret's present position.
 :   Shorthand name: `keyman.interface.KC`
 
@@ -38,11 +38,11 @@ for use in a keyboard context, in particular during a keystroke event cycle.
 :   Emits the character or object at `contextOffset` from the current matched rule's context.
 :   Shorthand name: `keyman.interface.KCXO`
 
-[`contextMatch` Function (Deprecated)](contextMatch)
+[`contextMatch` Function](contextMatch) (deprecated)
 :   Context matching: Returns `true` if the specified `context` call matches a provided string.
 :   Shorthand name: `keyman.interface.KCM`
 
-[`deadkeyMatch` Function (Deprecated)](deadkeyMatch)
+[`deadkeyMatch` Function](deadkeyMatch) (deprecated)
 :   Deadkey matching: Seeks to match the [`deadkey`](/developer/language/reference/deadkey) state `dk` at the relative caret position `n`.
 :   Shorthand name: `keyman.interface.KDM`
 
@@ -129,19 +129,19 @@ for use in a keyboard context, in particular during a keystroke event cycle.
 The following functions have been retained for compatibility with existing IME
 keyboards, but should not be used in any new keyboards or user interfaces.
 
-[`GetLastActiveElement` or `getLastActiveElement` Function (Deprecated)](GetLastActiveElement)
+[`GetLastActiveElement` or `getLastActiveElement` Function](GetLastActiveElement) (deprecated)
 :   Use [`keyman.interface.getLastActiveTextStore()`](getLastActiveTextStore)
 
-[`FocusLastActiveElement` or `focusLastActiveElement` Function (Deprecated)](FocusLastActiveElement)
+[`FocusLastActiveElement` or `focusLastActiveElement` Function](FocusLastActiveElement) (deprecated)
 :   Use [`keyman.interface.focusLastActiveTextStore()`](focusLastActiveTextStore)
 
-[`HideHelp` or `hideHelp` Function (Deprecated)](HideHelp)
+[`HideHelp` or `hideHelp` Function](HideHelp) (deprecated)
 :   Use [`keyman.osk.hide()`](../osk/hide)
 
-[`ShowHelp` or `showHelp` Function (Deprecated)](ShowHelp)
+[`ShowHelp` or `showHelp` Function](ShowHelp) (deprecated)
 :   Use [`keyman.osk.setPos()`](../osk/setPos)
 :   Use [`keyman.osk.show()`](../osk/show)
 
-[`ShowPinnedHelp` or `showPinnedHelp` Function (Deprecated)](ShowPinnedHelp)
+[`ShowPinnedHelp` or `showPinnedHelp` Function](ShowPinnedHelp) (deprecated)
 :   Use [`keyman.osk.setRect()`](../osk/setRect)
 :   Use [`keyman.osk.show()`](../osk/show)

--- a/web/docs/engine/reference/interface/indexOutput.md
+++ b/web/docs/engine/reference/interface/indexOutput.md
@@ -8,13 +8,13 @@ Index-based output: Outputs a mapped character according to a previous selection
 
 ## Syntax
 
-```c
+```js
 keyman.interface.indexOutput(nd, store, index, Pelem);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KIO(nd, store, index, Pelem);
 ```
 
@@ -50,7 +50,7 @@ facilitates mapping the characters `'abcde'` to their respective entry in the ou
 
 In order to output the desired character corresponding to `'a'` in the `output` store above, the code
 
-```c
+```js
 keyman.interface.indexOutput(0, 'αβγδε', 1, Pelem)
 ```
 

--- a/web/docs/engine/reference/interface/insertText.md
+++ b/web/docs/engine/reference/interface/insertText.md
@@ -8,13 +8,13 @@ Inserts a text string and optional [`deadkey`](/developer/language/reference/dea
 
 ## Syntax
 
-```c
+```js
 keyman.interface.insertText(text, dk);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KT(text, dk); // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/isKeypress.md
+++ b/web/docs/engine/reference/interface/isKeypress.md
@@ -8,13 +8,13 @@ Returns `true` if the input event corresponds to a keypress event resulting in c
 
 ## Syntax
 
-```c
+```js
 keyman.interface.isKeypress(e);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KIK(e); // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/keyInformation.md
+++ b/web/docs/engine/reference/interface/keyInformation.md
@@ -8,13 +8,13 @@ Returns an object with extended information about a specified keystroke event.
 
 ## Syntax
 
-```c
+```js
 keyman.interface.keyInformation(e);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KKI(e); // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/keyMatch.md
+++ b/web/docs/engine/reference/interface/keyMatch.md
@@ -8,13 +8,13 @@ Keystroke matching: Returns `true` if the event matches the rule's shift mask an
 
 ## Syntax
 
-```c
+```js
 keyman.interface.keyMatch(e, shiftCode, keyCode);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KKM(e, shiftCode, keyCode); // Shorthand
 ```
 
@@ -47,7 +47,7 @@ This is a core element of keyboard input management within KeymanWeb, typically 
 
 a keyboard would check that the triggering keystroke (`"'"`) matches by using
 
-```keyman
+```js
 keyman.interface.keyMatch(e, 0, 39)
 ```
 

--- a/web/docs/engine/reference/interface/loadStore.md
+++ b/web/docs/engine/reference/interface/loadStore.md
@@ -8,13 +8,13 @@ Load an option [`store`](/developer/language/guide/stores) value from a cookie o
 
 ## Syntax
 
-```c
+```js
 keyman.interface.loadStore(kbdName, storeName, value);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KLOAD(kbdName, storeName, value); // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/output.md
+++ b/web/docs/engine/reference/interface/output.md
@@ -8,13 +8,13 @@ Outputs the specified string to an element, overwriting `nd` characters before t
 
 ## Syntax
 
-```c
+```js
 keyman.interface.output(nd, Pelem, str);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KO(nd, Pelem, str); // Shorthand
 ```
 
@@ -46,7 +46,7 @@ This is a core element of keyboard input management within KeymanWeb, typically 
 
 a keyboard would, after checking that the initial context (`"a"`) matches, use
 
-```c
+```js
 keyman.interface.output(1, Pelem, "á");
 ```
 

--- a/web/docs/engine/reference/interface/registerKeyboard.md
+++ b/web/docs/engine/reference/interface/registerKeyboard.md
@@ -8,13 +8,13 @@ Registers and loads the keyboard.
 
 ## Syntax
 
-```c
+```js
 keyman.interface.registerKeyboard(Pk);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KR(Pk); // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/saveFocus.md
+++ b/web/docs/engine/reference/interface/saveFocus.md
@@ -8,13 +8,13 @@ Save focus: Temporarily saves keyboard processing data for the currently-focused
 
 ## Syntax
 
-```c
+```js
 keyman.interface.saveFocus()
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KSF() // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/saveStore.md
+++ b/web/docs/engine/reference/interface/saveStore.md
@@ -8,13 +8,13 @@ Save an option [`store`](/developer/language/guide/stores) value to a cookie for
 
 ## Syntax
 
-```c
+```js
 keyman.interface.saveStore(storeName, value);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KSAVE(storeName, value); // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/setStore.md
+++ b/web/docs/engine/reference/interface/setStore.md
@@ -8,13 +8,13 @@ title: setStore (KSETS)
 
 ## Syntax
 
-```c
+```js
 keyman.interface.setStore(systemId, strValue, Pelem);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KSETS(systemId, strValue, Pelem); // Shorthand
 ```
 

--- a/web/docs/engine/reference/interface/stateMatch.md
+++ b/web/docs/engine/reference/interface/stateMatch.md
@@ -8,13 +8,13 @@ State-key matching: Returns `true` if the event matches the rule's state-key req
 
 ## Syntax
 
-```c
+```js
 keyman.interface.stateMatch(e, shiftCode);
 ```
 
 or
 
-```c
+```js
 KeymanWeb.KSM(e, shiftCode); // Shorthand
 ```
 
@@ -35,7 +35,7 @@ KeymanWeb.KSM(e, shiftCode); // Shorthand
 
 ## Description
 
-As of KeymanWeb 10.0, KeymanWeb now supports keyboard rules conditioned upon 'state keys' like Caps Lock [if specified by keyboard developers](/developer/language/guide/virtual-keys#toc-caps-lock). 
+As of KeymanWeb 10.0, KeymanWeb now supports keyboard rules conditioned upon 'state keys' like Caps Lock [if specified by keyboard developers](/developer/language/guide/virtual-keys#toc-caps-lock).
 
 The `stateMatch` function examines the bit-flags to determine the state keys being tested and compares the keyboard event against them as appropriate. As such, it is designed to be a condition check alongside [`keyman.interface.keyMatch()`](keyMatch) and [`keyman.interface.contextMatch()`](contextMatch).
 
@@ -48,7 +48,7 @@ For comparison with [Developer 'rules'](/developer/language/guide/virtual-keys#t
 
 a keyboard would check which rule the triggering keystroke (`"a"`) matches by using
 
-```c
+```js
 keyman.interface.stateMatch(e, 0x100)
 ```
 

--- a/web/docs/engine/reference/osk/addEventListener.md
+++ b/web/docs/engine/reference/osk/addEventListener.md
@@ -8,7 +8,7 @@ Adds an event listener for user-handling of On-Screen keyboard events.
 
 ## Syntax
 
-```c
+```js
 keyman.osk.addEventListener(eventName, func)
 ```
 

--- a/web/docs/engine/reference/osk/getRect.md
+++ b/web/docs/engine/reference/osk/getRect.md
@@ -8,7 +8,7 @@ Get absolute position and size of OSK window.
 
 ## Syntax
 
-```c
+```js
 keyman.osk.getRect()
 ```
 

--- a/web/docs/engine/reference/osk/hide.md
+++ b/web/docs/engine/reference/osk/hide.md
@@ -8,7 +8,7 @@ Hides the OSK.
 
 ## Syntax
 
-```c
+```js
 keyman.osk.hide()
 ```
 

--- a/web/docs/engine/reference/osk/isEnabled.md
+++ b/web/docs/engine/reference/osk/isEnabled.md
@@ -8,7 +8,7 @@ Return the user-defined OSK visibility as set by prior calls to [`show`](show) o
 
 ## Syntax
 
-```c
+```js
 keyman.osk.isEnabled();
 ```
 

--- a/web/docs/engine/reference/osk/isVisible.md
+++ b/web/docs/engine/reference/osk/isVisible.md
@@ -8,7 +8,7 @@ Return the actual visibility of the On-Screen Keyboard.
 
 ## Syntax
 
-```c
+```js
 keyman.osk.isVisible();
 ```
 

--- a/web/docs/engine/reference/osk/removeEventListener.md
+++ b/web/docs/engine/reference/osk/removeEventListener.md
@@ -8,7 +8,7 @@ Removes a user-defined event handler.
 
 ## Syntax
 
-```c
+```js
 keyman.osk.removeEventListener(eventName, func);
 ```
 
@@ -29,5 +29,5 @@ keyman.osk.removeEventListener(eventName, func);
 ## Description
 
 To be implemented.
-    
+
 Will be the OSK's analogue of the to-be-implemented core function [`removeEventListener`](../core/removeEventListener).

--- a/web/docs/engine/reference/osk/setPos.md
+++ b/web/docs/engine/reference/osk/setPos.md
@@ -8,7 +8,7 @@ Set absolute position and size of desktop OSK window, limited to screen.
 
 ## Syntax
 
-```c
+```js
 keyman.osk.setPos(pt)
 ```
 

--- a/web/docs/engine/reference/osk/setRect.md
+++ b/web/docs/engine/reference/osk/setRect.md
@@ -8,7 +8,7 @@ Set absolute position and size of desktop OSK window.
 
 ## Syntax
 
-```c
+```js
 keyman.osk.setRect(p);
 ```
 

--- a/web/docs/engine/reference/osk/show.md
+++ b/web/docs/engine/reference/osk/show.md
@@ -8,7 +8,7 @@ Display, hide or toggle OSK visibility.
 
 ## Syntax
 
-```c
+```js
 keyman.osk.show(mode);
 ```
 

--- a/web/docs/engine/reference/osk/userLocated.md
+++ b/web/docs/engine/reference/osk/userLocated.md
@@ -8,7 +8,7 @@ Determine whether or not the OSK has been moved from its default position by the
 
 ## Syntax
 
-```c
+```js
 keyman.osk.userLocated();
 ```
 

--- a/web/docs/engine/reference/util/addStyleSheet.md
+++ b/web/docs/engine/reference/util/addStyleSheet.md
@@ -8,7 +8,7 @@ Generates a style sheet element for use in adding or overriding default On-Scree
 
 ## Syntax
 
-```c
+```js
 keyman.util.addStyleSheet(sheet)
 ```
 

--- a/web/docs/engine/reference/util/alert.md
+++ b/web/docs/engine/reference/util/alert.md
@@ -8,7 +8,7 @@ Generates a KeymanWeb alert window.
 
 ## Syntax
 
-```c
+```js
 keyman.util.alert(msg, fn)
 ```
 

--- a/web/docs/engine/reference/util/attachDOMEvent.md
+++ b/web/docs/engine/reference/util/attachDOMEvent.md
@@ -8,7 +8,7 @@ Attach user-defined event handler for any DOM event for an element.
 
 ## Syntax
 
-```c
+```js
 keyman.util.attachDOMEvent(Pelem, eventName, handler, useCapture);
 ```
 

--- a/web/docs/engine/reference/util/createElement.md
+++ b/web/docs/engine/reference/util/createElement.md
@@ -8,7 +8,7 @@ Create an unselectable HTML element for the *KeymanWeb* On-Screen keyboard and U
 
 ## Syntax
 
-```c
+```js
 keyman.util.createElement(nodeName);
 ```
 

--- a/web/docs/engine/reference/util/detachDOMEvent.md
+++ b/web/docs/engine/reference/util/detachDOMEvent.md
@@ -8,7 +8,7 @@ Detach DOM event handler from element to prevent memory leaks.
 
 ## Syntax
 
-```c
+```js
 keyman.util.detachDOMEvent();
 ```
 

--- a/web/docs/engine/reference/util/getAbsolute.md
+++ b/web/docs/engine/reference/util/getAbsolute.md
@@ -8,7 +8,7 @@ Get the absolute position of an element.
 
 ## Syntax
 
-```c
+```js
 keyman.util.getAbsolute(Pelem);
 ```
 
@@ -25,6 +25,6 @@ keyman.util.getAbsolute(Pelem);
 
 ## Description
 
-See also: 
+See also:
 - [`keyman.util.getAbsoluteX()`](getAbsoluteX)
 - [`keyman.util.getAbsoluteY()`](getAbsoluteY)

--- a/web/docs/engine/reference/util/getAbsoluteX.md
+++ b/web/docs/engine/reference/util/getAbsoluteX.md
@@ -8,7 +8,7 @@ Get the absolute x-coordinate of an element.
 
 ## Syntax
 
-```c
+```js
 keyman.util.getAbsoluteX(Pelem);
 ```
 
@@ -25,6 +25,6 @@ keyman.util.getAbsoluteX(Pelem);
 
 ## Description
 
-See also: 
+See also:
 - [`keyman.util.getAbsolute()`](getAbsolute)
 - [`keyman.util.getAbsoluteY()`](getAbsoluteY)

--- a/web/docs/engine/reference/util/getAbsoluteY.md
+++ b/web/docs/engine/reference/util/getAbsoluteY.md
@@ -8,7 +8,7 @@ Get the absolute y-coordinate of an element.
 
 ## Syntax
 
-```c
+```js
 keyman.util.getAbsoluteY(Pelem);
 ```
 
@@ -25,6 +25,6 @@ keyman.util.getAbsoluteY(Pelem);
 
 ## Description
 
-See also: 
+See also:
 - [`keyman.util.getAbsolute()`](getAbsolute)
 - [`keyman.util.getAbsoluteX()`](getAbsoluteX)

--- a/web/docs/engine/reference/util/getOption.md
+++ b/web/docs/engine/reference/util/getOption.md
@@ -8,7 +8,7 @@ Get a KeymanWeb, On-Screen Keyboard or User Interface option value.
 
 ## Syntax
 
-```c
+```js
 keyman.util.getOption(optionName, dflt);
 ```
 

--- a/web/docs/engine/reference/util/index.md
+++ b/web/docs/engine/reference/util/index.md
@@ -45,7 +45,7 @@ The KeymanWeb Utility Function module is exposed to the developer as `window.key
 [`removeStyleSheet` Function](removeStyleSheet)
 :   Remove user-defined style sheet.
 
-[`rgba` Function](rgba)
+[`rgba` Function](rgba) (deprecated)
 :   Browser-independent alpha-channel management.
 
 [`saveCookie` Function](saveCookie)
@@ -54,12 +54,12 @@ The KeymanWeb Utility Function module is exposed to the developer as `window.key
 [`setOption` Function](setOption)
 :   Set a KeymanWeb, On-Screen Keyboard or User Interface option value.
 
-[`toFloat` Function](toFloat)
+[`toFloat` Function](toFloat) (deprecated)
 :   Floating conversion with default.
 
-[`toNumber` Function](toNumber)
+[`toNumber` Function](toNumber) (deprecated)
 :   Integer conversion with default.
 
-[`toNzString` Function](toNzString)
+[`toNzString` Function](toNzString) (deprecated)
 :   Returns default string value if argument is null, false, an empty
     string, or undefined.

--- a/web/docs/engine/reference/util/isTouchDevice.md
+++ b/web/docs/engine/reference/util/isTouchDevice.md
@@ -8,7 +8,7 @@ Allow external callers (such as UIs) to detect if the active device is considere
 
 ## Syntax
 
-```c
+```js
 keyman.util.isTouchDevice();
 ```
 
@@ -21,9 +21,5 @@ None.
 `boolean`
 :   `true` if KMW is targetting touch-sensitivity for the device, otherwise `false`.
 
-```
-isTouchDevice ...
-```
-
-> [!Note]  
+> [!Note]
 > In current versions of KeymanWeb this function will return `false` for touchscreen laptops; current touch support is specialized for mobile phones and tablets.

--- a/web/docs/engine/reference/util/linkStyleSheet.md
+++ b/web/docs/engine/reference/util/linkStyleSheet.md
@@ -8,7 +8,7 @@ Add a reference to an external stylesheet file.
 
 ## Syntax
 
-```c
+```js
 keyman.util.linkStyleSheet(s);
 ```
 

--- a/web/docs/engine/reference/util/loadCookie.md
+++ b/web/docs/engine/reference/util/loadCookie.md
@@ -8,7 +8,7 @@ Get a document cookie, or an array of all document cookies.
 
 ## Syntax
 
-```c
+```js
 keyman.util.loadCookie(cn);
 ```
 
@@ -20,9 +20,9 @@ keyman.util.loadCookie(cn);
 
 ### Return Value
 
-`Object`
+`Array`
 :   An array of names and strings or an array of variables and values.
 
-## Description
+## See also
 
-...
+* [`keyman.util.saveCookie()`](saveCookie)

--- a/web/docs/engine/reference/util/removeStyleSheet.md
+++ b/web/docs/engine/reference/util/removeStyleSheet.md
@@ -8,7 +8,7 @@ Remove user-defined style sheet.
 
 ## Syntax
 
-```c
+```js
 keyman.util.removeStyleSheet(Pelem);
 ```
 

--- a/web/docs/engine/reference/util/rgba.md
+++ b/web/docs/engine/reference/util/rgba.md
@@ -1,5 +1,5 @@
 ---
-title: rgba
+title: rgba (deprecated)
 ---
 
 ## Summary
@@ -8,7 +8,7 @@ Browser-independent alpha-channel management.
 
 ## Syntax
 
-```c
+```js
 keyman.util.rgba(s, r, g, b, a);
 ```
 
@@ -41,4 +41,13 @@ keyman.util.rgba(s, r, g, b, a);
 
 ## Description
 
-This function returns the required string value for setting background transparency, and applies an appropriate `a` filter to the element for IE versions before IE9.
+This function returns the required string value for setting background
+transparency, and applies an appropriate `a` filter to the element for IE
+versions before IE9.
+
+This function has been deprecated and will be removed in a future version of
+KeymanWeb.
+
+## History
+
+19.0: deprecated

--- a/web/docs/engine/reference/util/saveCookie.md
+++ b/web/docs/engine/reference/util/saveCookie.md
@@ -8,7 +8,7 @@ Save document variables as a cookie.
 
 ## Syntax
 
-```c
+```js
 keyman.util.saveCookie(cn, cv);
 ```
 
@@ -26,6 +26,7 @@ keyman.util.saveCookie(cn, cv);
 
 `undefined`
 
-## Description
+## See also
 
-...
+* [`keyman.util.loadCookie()`](loadCookie)
+

--- a/web/docs/engine/reference/util/setOption.md
+++ b/web/docs/engine/reference/util/setOption.md
@@ -8,7 +8,7 @@ Set a KeymanWeb, On-Screen Keyboard or User Interface option value.
 
 ## Syntax
 
-```c
+```js
 keyman.util.setOption(optionName, value);
 ```
 

--- a/web/docs/engine/reference/util/toFloat.md
+++ b/web/docs/engine/reference/util/toFloat.md
@@ -1,5 +1,5 @@
 ---
-title: toFloat
+title: toFloat (deprecated)
 ---
 
 ## Summary
@@ -8,7 +8,7 @@ Floating conversion with default.
 
 ## Syntax
 
-```c
+```js
 keyman.util.toFloat(s, dflt);
 ```
 
@@ -29,4 +29,11 @@ keyman.util.toFloat(s, dflt);
 
 ## Description
 
-...
+This is a simple wrapper around `parseFloat` to handle invalid inputs, for which
+`dflt` will be returned instead.
+
+This function has been deprecated and will be removed in a future version of KeymanWeb.
+
+## History
+
+19.0: deprecated

--- a/web/docs/engine/reference/util/toNumber.md
+++ b/web/docs/engine/reference/util/toNumber.md
@@ -1,5 +1,5 @@
 ---
-title: toNumber
+title: toNumber (deprecated)
 ---
 
 ## Summary
@@ -8,7 +8,7 @@ String -&gt; number conversion, with default.
 
 ## Syntax
 
-```c
+```js
 keyman.util.toNumber(s, dflt);
 ```
 
@@ -29,4 +29,12 @@ keyman.util.toNumber(s, dflt);
 
 ## Description
 
-...
+This is a simple wrapper around `parseInt(s, 10)` to handle invalid inputs, for which
+`dflt` will be returned instead.
+
+This function has been deprecated and will be removed in a future version of
+KeymanWeb.
+
+## History
+
+19.0: deprecated

--- a/web/docs/engine/reference/util/toNzString.md
+++ b/web/docs/engine/reference/util/toNzString.md
@@ -1,14 +1,15 @@
 ---
-title: toNzString
+title: toNzString (deprecated)
 ---
 
 ## Summary
 
-Returns string value for the item, or the default string value if the argument is null, false, an empty string, or undefined.
+Returns string value for the item, or the default string value if the argument
+is null, false, an empty string, or undefined.
 
 ## Syntax
 
-```c
+```js
 keyman.util.toNzString(item, dflt);
 ```
 
@@ -20,7 +21,8 @@ keyman.util.toNzString(item, dflt);
 
 `dflt`
 :   Type: `*` *optional*
-:   Value to use of the converted variable is null, false, the empty string, or undefined.
+:   Value to use of the converted variable is null, false, the empty string, or
+    undefined.
 
 ### Return Value
 
@@ -29,4 +31,8 @@ keyman.util.toNzString(item, dflt);
 
 ## Description
 
-...
+This function has been deprecated and will be removed in a future version of KeymanWeb.
+
+## History
+
+19.0: deprecated

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -131,12 +131,14 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
 
   public set ui(module: UIModule) {
     if(this._ui) {
+      this.legacyAPIEvents.callEvent('unloaduserinterface', {});
       this._ui.shutdown();
     }
 
     this._ui = module;
-    if(this.config.deferForInitialization.isFulfilled) {
+    if(module && this.config.deferForInitialization.isFulfilled) {
       module.initialize();
+      this.legacyAPIEvents.callEvent('loaduserinterface', {});
     }
   }
 
@@ -716,8 +718,6 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
     this.core.languageProcessor.shutdown();
     this.hardKeyboard.shutdown();
     this.util.shutdown(); // For tracked dom events, stylesheets.
-
-    this.legacyAPIEvents.callEvent('unloaduserinterface', {});
-    this.ui?.shutdown();
+    this.ui = undefined; // will shutdown and call event listeners
   }
 }

--- a/web/src/app/browser/src/keymanEngine.ts
+++ b/web/src/app/browser/src/keymanEngine.ts
@@ -48,8 +48,8 @@ export class KeymanEngine extends KeymanEngineBase<BrowserConfiguration, Context
   public getOskWidth?: () => number = null;
 
   /**
-   * Provides a quick link to the base help page for Keyman keyboards.
-   *
+   * Public API: Provides a quick link to the base help page for Keyman keyboards. (deprecated)
+   * @deprecated
    * See https://help.keyman.com/developer/engine/web/current-version/reference/core/helpURL
    */
   public readonly helpURL = 'https://help.keyman.com/go';

--- a/web/src/app/browser/src/utilApiEndpoint.ts
+++ b/web/src/app/browser/src/utilApiEndpoint.ts
@@ -306,11 +306,12 @@ export class UtilApiEndpoint {
   }
 
   /**
-   * Function     toNzString
+   * Function     toNzString (deprecated)
    * Scope        Public
    * @param       {*}           item         variable to test
    * @param       {?*=}         dflt         default value
    * @return      {*}
+   * @deprecated
    * Description  Test if a variable is null, false, empty string, or undefined, and return as string
    */
   public nzString(item: any, dflt: string): string {
@@ -339,11 +340,12 @@ export class UtilApiEndpoint {
   }
 
   /**
-   * Function     toNumber
+   * Function     toNumber (deprecated)
    * Scope        Public
    * @param       {string}      s            numeric string
    * @param       {number}      dflt         default value
    * @return      {number}
+   * @deprecated
    * Description  Return string converted to integer or default value
    *
    * See https://help.keyman.com/developer/engine/web/current-version/reference/util/toNumber
@@ -354,11 +356,12 @@ export class UtilApiEndpoint {
   }
 
   /**
-   * Function     toFloat
+   * Function     toFloat (deprecated)
    * Scope        Public
    * @param       {string}      s            numeric string
    * @param       {number}      dflt         default value
    * @return      {number}
+   * @deprecated
    * Description  Return string converted to real value or default value
    *
    * See https://help.keyman.com/developer/engine/web/current-version/reference/util/toFloat
@@ -369,7 +372,7 @@ export class UtilApiEndpoint {
   }
 
   /**
-   * Function     rgba
+   * Function     rgba (deprecated)
    * Scope        Public
    * @param       {Object}      s           element style object
    * @param       {number}      r           red value, 0-255
@@ -377,6 +380,7 @@ export class UtilApiEndpoint {
    * @param       {number}      b           blue value, 0-255
    * @param       {number}      a           opacity value, 0-1.0
    * @return      {string}                  background colour style string
+   * @deprecated
    * Description  Browser-independent alpha-channel management
    *
    * See https://help.keyman.com/developer/engine/web/current-version/reference/util/rgba

--- a/web/src/app/ui/kmwuifloat.ts
+++ b/web/src/app/ui/kmwuifloat.ts
@@ -202,10 +202,6 @@ if(!keyman) {
         //may also want to initialize style sheet here ??
       }
 
-      readonly _UnloadUserInterface = () => {
-        this.KeyboardSelector = this.innerDiv = this.outerDiv = this.kbdIcon = null;
-      };
-
       /**
        * UI removal - resource cleanup
        */
@@ -215,7 +211,7 @@ if(!keyman) {
           root.parentNode.removeChild(root);
         }
 
-        this._UnloadUserInterface();
+        this.KeyboardSelector = this.innerDiv = this.outerDiv = this.kbdIcon = null;
 
         if(window.removeEventListener) {
           window.removeEventListener('resize', this._Resize, false);
@@ -606,9 +602,6 @@ if(!keyman) {
 
     // but also call initialization when script loaded, which is after KMW initialization for asynchronous script loading
     ui.initialize();
-
-    // is/was never actually raised.  Note that the `shutdown` method likely fulfills a similar role.
-    // keyman.addEventListener('unloaduserinterface', ui._UnloadUserInterface);
 
   } catch(err){}
 


### PR DESCRIPTION
The `loaduserinterface` and `unloaduserinterface` events were incompletely implemented, and the documentation was incomplete. This change:

1. ensures `loaduserinterface` is called any time a UI is set, either during initialization or when the property is set later.
2. ensures `unloaduserinterface` is called immediately before a UI is shutdown.
3. updates documentation
4. removes misleading commented code in kmwuifloat.ts

Test-bot: skip