### PR TITLE
fix(windows): release shift key on OSK when user releases physical right shift

### DIFF
--- a/windows/src/engine/keyman/build.sh
+++ b/windows/src/engine/keyman/build.sh
@@ -9,7 +9,9 @@ builder_describe "Keyman main host process (32-bit)" \
   @/common/include \
   @/common/windows/delphi \
   @/windows/src/global/delphi \
-  clean configure build test publish install debug-manifest edit
+  clean configure build test publish install edit \
+  "debug-manifest     Build a uiAccess=false manifest.res for debugging and build within Delphi IDE" \
+  "--debug-manifest   For 'build' action, use a uiAccess=false manifest.res"
 
 builder_parse "$@"
 
@@ -32,7 +34,12 @@ function do_clean() {
 function do_build() {
   create-windows-output-folders
   build_version.res
-  build_manifest.res
+  if builder_has_option --debug-manifest; then
+    builder_echo warning "Using a non-elevated uiAccess=false debug manifest"
+    do_build_debug_manifest
+  else
+    build_manifest.res
+  fi
   run_in_vs_env rc keymanmenuitem.rc
   run_in_vs_env rc icons.rc
   run_in_vs_env rc osktoolbar.rc

--- a/windows/src/engine/keyman/viskbd/UfrmOSKOnScreenKeyboard.pas
+++ b/windows/src/engine/keyman/viskbd/UfrmOSKOnScreenKeyboard.pas
@@ -228,13 +228,16 @@ end;
  * Handles OSK modifier events received from
  * keyman32:PostVisualKeyboardModifierEvent in k32_visualkeyboardinterface.cpp.
  *
- * This takes the chiral VK_LCONTROL / VK_RCONTROL / VK_LMENU / VK_RMENU virtual
- * key codes.
+ * This expects the chiral VK_LCONTROL / VK_RCONTROL / VK_LMENU / VK_RMENU /
+ * VK_LSHIFT / VK_RSHIFT virtual key codes (unlike most Windows contexts).
  *
- * This currently deals only with one situation: when Windows posts a simulated
- * LControl key when AltGr is pressed on a European layout. See
- * serialkeyeventserver.cpp:WndProc for a deeper discussion of the key events
- * that are generated in this scenario.
+ * This currently deals with two situations:
+ *
+ * 1. When Windows posts a simulated LControl key when AltGr is pressed on a
+ *    European layout. See serialkeyeventserver.cpp:WndProc for a deeper
+ *    discussion of the key events that are generated in this scenario.
+ * 2. When the physical RShift key is released, the OSK needs to release the
+ *    'clicked' LShift for consistency (#12611).
  *
  * @param VKCode virtual key code of the modifier key, chiral for Alt and Ctrl
  * @param Flags  as follows:

--- a/windows/src/engine/keyman/viskbd/UfrmOSKOnScreenKeyboard.pas
+++ b/windows/src/engine/keyman/viskbd/UfrmOSKOnScreenKeyboard.pas
@@ -270,7 +270,18 @@ begin
   if (scanCode = SCAN_LEFT_CONTROL_SIMULATED) and not isUp then
     IsSimulatedLControlDown := True
   else if ((scanCode = SCAN_LEFT_CONTROL) or (scanCode = SCAN_LEFT_CONTROL_SIMULATED)) and isUp then
-    IsSimulatedLControlDown := False;
+    IsSimulatedLControlDown := False
+  else if (VKCode = VK_RSHIFT) and isUp then
+  begin
+    if (GetAsyncKeyState(VK_LSHIFT) and $8000) = $8000 then
+    begin
+      // #12611: The physical right shift key has just been released by the
+      // user, but the user has previously clicked the left shift key in the
+      // OSK.  We need to force a key up for left shift as well to clear, both
+      // in the OSK and for apps that may differentiate L/R shift.
+      do_keybd_event(VK_LSHIFT, 0, KEYEVENTF_KEYUP, 0);
+    end;
+  end;
 
   // TODO: in the future, we might be able to eliminate tmrCheck and make all
   // modifier updates go through the WH_KEYBOARD_LL hook.


### PR DESCRIPTION
When the user clicks either Shift key on the OSK, that emits a VK_LSHIFT down key event. If the user subsequently presses and releases the Right Shift key on their hardware keyboard, that does not reset the isDown state for the Left Shift key, so the key is not released on the OSK, and the state becomes inconsistent for apps also.

This change emits a key up event, if when Right Shift is released, Keyman detects that Left Shift is still "down". Note that if the user presses and holds Left Shift, and presses and releases Right Shift, the left shift state will be reset before the users releases Left Shift. But that's a pathological state!

Fixes: #12611

# User Testing

TEST_MODIFIERS_BASELINE: Open the on screen keyboard in Keyman for Windows. Click a modifier key to set it. Verify that clicking a character generates the modified output as expected (for example Shift -> Shift+A = "A" rather than "a"). Do the same for pressing a character key on the hardware keyboard. Do this for each of the modifier states.

TEST_RIGHT_SHIFT: Open the on screen keyboard. Click the Left Shift key. Then press Right Shift key. Verify that the shift state is reset in the OSK, and that the next key typed also shows unmodified output.

TEST_RELEASE_MODIFIERS_OPTION: Test that the correct behaviour happens when option Release OSK modifiers is set, after clicking a key.
