### PR TITLE
feat(windows): pass UI language to keyboard download page

### DIFF
--- a/windows/src/desktop/kmshell/xml/downloadkeyboard.xsl
+++ b/windows/src/desktop/kmshell/xml/downloadkeyboard.xsl
@@ -67,7 +67,7 @@
       </head>
       <body>
         <iframe id="contentframe" frameborder="0">
-          <xsl:attribute name="src"><xsl:value-of select='/Keyman/keyman-com' />/go/windows/<xsl:value-of select="/Keyman/version-info/@versionRelease" />/download-keyboards?version=<xsl:value-of select="/Keyman/Version" /></xsl:attribute>&#160;
+          <xsl:attribute name="src"><xsl:value-of select='/Keyman/keyman-com' />/go/windows/<xsl:value-of select="/Keyman/version-info/@versionRelease" />/download-keyboards?lang=<xsl:value-of select="/Keyman/locale"/>&amp;version=<xsl:value-of select="/Keyman/Version" /></xsl:attribute>&#160;
         </iframe>
         <div id="footerframe">
           <div style="float:left; padding-left: 8px">


### PR DESCRIPTION
Fixes: #15542
Relates-to: keymanapp/keyman.com#818

# User Testing

Note: wait for keymanapp/keyman.com#818 to merge before testing.

* **TEST_LANG:** Switch to one of the supported UI languages for keyboard search (German, Spanish, French, Khmer) in Keyman Configuration, and click Download Keyboard. The dialog should appear in the target language.

* **TEST_FALLBACK:** Switch to an unsupported UI language for keyboard search, such as Czech, Turkish, or Amharic. Verify that the Download Keyboard dialog appears in English (except for the buttons, which may appear in the UI language).