### PR TITLE
fix(web): adjust sourcemap linking pattern used for error reporting within mobile apps

### DIFF
--- a/common/web/sentry-manager/src/index.ts
+++ b/common/web/sentry-manager/src/index.ts
@@ -42,7 +42,18 @@ export class KeymanSentryManager {
     switch(location.protocol) {
       case 'http:':
         return 'http://' + location.host + '/' + filename;
+      case 'https:':
+        // Keyman for Android uses https://appassets.androidplatform.net
+        // to point to local files.  See #16146.
+        if(this.keymanPlatform == 'android') {
+          return 'file:///' + filename;
+        } else {
+          return 'https://' + location.host + '/' + filename;
+        }
       case 'file:':
+        return 'file:///' + filename;
+      // Used within the iOS Keyman engine.  See #16136.
+      case 'keyman-engine:':
         return 'file:///' + filename;
       default:
         return null;


### PR DESCRIPTION
Fixes: #16367

Build-bot: skip build:web release:android release:ios
Test-bot: skip

It'll be hard to fully verify without the ability to force-trigger an error, but I believe these changes should reinstate our sourcemap linkage for high-quality error reporting data on Sentry.