### PR TITLE
fix(developer): mark touch layout file as modified after applying template

### DIFF
--- a/developer/src/tike/child/UfrmKeymanWizard.pas
+++ b/developer/src/tike/child/UfrmKeymanWizard.pas
@@ -3336,7 +3336,7 @@ begin
     begin
       frameTouchLayout.SaveToString;
       frameTouchLayout.TemplateFileName := TemplateFileName;
-      frameTouchLayout.Load('', True, False);   // I4034
+      frameTouchLayout.ApplyTemplate;
       Self.Modified := True;
     end;
   finally

--- a/developer/src/tike/oskbuilder/UframeTouchLayoutBuilder.pas
+++ b/developer/src/tike/oskbuilder/UframeTouchLayoutBuilder.pas
@@ -118,6 +118,7 @@ type
     { Public declarations }
     procedure SetFocus; override;
     procedure SetupCharMapDrop;
+    procedure ApplyTemplate;
     function Load(const AFilename: string; ALoadFromTemplate, ALoadFromString: Boolean): Boolean;
     procedure Save(const AFilename: string);
     function SaveToString: string;
@@ -315,6 +316,16 @@ end;
 procedure TframeTouchLayoutBuilder.TouchLayoutMessage(Sender: TObject; const Message: string);
 begin
   LogMessage(plsError, FFilename, Message, 0, 0);
+end;
+
+(**
+ * Apply the template referenced by TemplateFileName to the current
+ * layout, and mark the file as modified.
+ *)
+procedure TframeTouchLayoutBuilder.ApplyTemplate;
+begin
+  Load('', True, False);   // applies the template
+  FSavedLayoutJS := '';    // marks the file as dirty
 end;
 
 function TframeTouchLayoutBuilder.Load(const AFilename: string; ALoadFromTemplate, ALoadFromString: Boolean): Boolean;


### PR DESCRIPTION
Appreciate that the `Load()` function is quite unwieldy. However, avoiding refactoring that because this is the one narrow edge case that is not working.

Fixes: #16128
Test-bot: skip