### PR TITLE
chore(common): disable strictNullChecks for TypeScript for now

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,7 @@
     "noImplicitAny": true,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
+    "strictNullChecks": false,
     "noUnusedLocals": true,
     "allowJs": true,
 


### PR DESCRIPTION
As we have a lot of code that does not have comprehensive null checking, and TypeScript has moved to enable this by default in recent versions, for now, disable at top-level to avoid being spammed with unhelpful null errors in editors.

Test-bot: skip
Build-bot: skip