### PR TITLE
change(android): enable autocorrect by default 🚂

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -370,7 +370,7 @@ public final class KMManager {
   public static int KeyboardHeight_Context_Landscape_Current = 0; // Current landscape height
 
   // Default prediction/correction setting
-  public static final int KMDefault_Suggestion = SuggestionType.PREDICTIONS_WITH_CORRECTIONS.toInt();
+  public static final int KMDefault_Suggestion = SuggestionType.PREDICTIONS_WITH_AUTO_CORRECT.toInt();
 
   // Keyman files
   protected static final String KMFilename_KeyboardHtml = "keyboard.html";


### PR DESCRIPTION
Build-bot: skip build:web release:android

## User Testing

TEST_DEFAULT_AUTOCORRECT:  Using Keyman for Android, install the `fv_sencoten` keyboard and verify that autocorrect is enabled by default.
- Type `TTE` and verify that a suggestion for `TŦE` is automatically highlighted.
- Verify that tapping the spacebar auto-applies the `TŦE` suggestion.