### PR TITLE
fix(android): load KMP files from app-external sources

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -186,7 +186,7 @@
 
       </intent-filter>
 
-      <intent-filter android:priority="50" android:autoVerify="true">
+      <intent-filter android:priority="50">
         <!-- KMAPro should also be able to handle /keyboards/install links and convert to /go/package/download -->
         <action android:name="android.intent.action.VIEW" />
 

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -113,62 +113,6 @@
           android:scheme="content" />
       </intent-filter>
 
-      <!--
-                 Capture file open requests (pathPattern is honoured) where no
-                 MIME type is provided in the Intent.  An Intent with a null
-                 MIME type will never be matched by a filter with a set MIME
-                 type, so we need a second intent-filter if we wish to also
-                 match files with this extension and a non-null MIME type
-                 (even if it is non-null but zero length).
-            -->
-      <intent-filter android:priority="50">
-        <action android:name="android.intent.action.VIEW" />
-
-        <category android:name="android.intent.category.BROWSABLE" />
-        <category android:name="android.intent.category.DEFAULT" />
-
-        <data android:scheme="file" />
-        <data android:host="*" />
-        <data android:pathPattern="/.*\\.kmp" />
-      </intent-filter>
-
-      <!--
-                 Capture file open requests (pathPattern is honoured) where a
-                 (possibly blank) MIME type is provided in the Intent.  This
-                 filter may only be necessary for supporting ES File Explorer,
-                 which has the probably buggy behaviour of using an Intent
-                 with a MIME type that is set but zero-length.  It's
-                 impossible to match such a type except by using a global
-                 wildcard.
-            -->
-      <intent-filter android:priority="50">
-        <action android:name="android.intent.action.VIEW" />
-
-        <category android:name="android.intent.category.BROWSABLE" />
-        <category android:name="android.intent.category.DEFAULT" />
-
-        <data android:scheme="file" />
-        <data android:host="*" />
-        <data android:mimeType="*/*" />
-        <data android:pathPattern="/.*\\.kmp" />
-      </intent-filter>
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-
-        <!-- http:// and  https:// protocols -->
-        <data
-          android:host="*"
-          android:pathPattern="/.*\\.kmp"
-          android:scheme="http" />
-        <data
-          android:host="*"
-          android:pathPattern="/.*\\.kmp"
-          android:scheme="https" />
-      </intent-filter>
-
       <intent-filter>
         <!-- keyman:download// deep linking to https://keyman.com/keyboards/ -->
         <action android:name="android.intent.action.VIEW" />

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -96,10 +96,6 @@
         <category android:name="android.intent.category.BROWSABLE" />
         <category android:name="android.intent.category.DEFAULT" />
 
-        <!-- needed for properly formatted email messages -->
-        <data
-          android:mimeType="application/vnd.keyman"
-          android:scheme="content" />
         <!-- needed for mangled email messages -->
         <data
           android:mimeType="application/keyman"
@@ -107,9 +103,6 @@
         <!-- needed for mangled email messages -->
         <data
           android:mimeType="application/octet-stream"
-          android:scheme="content" />
-        <data
-          android:mimeType="application/x-keyman-package"
           android:scheme="content" />
         <data
           android:mimeType="application/vnd.keyman.kmp+zip"
@@ -135,16 +128,7 @@
           Backup MIME intents
         -->
         <data
-          android:mimeType="application/vnd.keyman"
-          android:scheme="content" />
-        <data
           android:mimeType="application/octet-stream"
-          android:scheme="content" />
-        <data
-          android:mimeType="application/x-keyman-package"
-          android:scheme="content" />
-        <data
-          android:mimeType="application/vnd.keyman.kmp+zip"
           android:scheme="content" />
       </intent-filter>
 

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -111,6 +111,60 @@
         <data
           android:mimeType="application/x-keyman-package"
           android:scheme="content" />
+        <data
+          android:mimeType="application/vnd.keyman.kmp+zip"
+          android:scheme="content" />
+      </intent-filter>
+
+      <intent-filter android:priority="50">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.BROWSABLE" />
+        <category android:name="android.intent.category.DEFAULT" />
+
+        <data android:scheme="file" />
+        <data android:scheme="content" />
+
+        <data android:host="*" />
+        <data android:pathPattern=".*\\.kmp" />
+        <data
+          android:mimeType="application/vnd.keyman.kmp+zip"
+          android:scheme="content" />
+
+        <!--
+          Backup MIME intents
+        -->
+        <data
+          android:mimeType="application/vnd.keyman"
+          android:scheme="content" />
+        <data
+          android:mimeType="application/octet-stream"
+          android:scheme="content" />
+        <data
+          android:mimeType="application/x-keyman-package"
+          android:scheme="content" />
+        <data
+          android:mimeType="application/vnd.keyman.kmp+zip"
+          android:scheme="content" />
+      </intent-filter>
+
+      <!--
+            Capture file open requests (pathPattern is honoured) where no
+            MIME type is provided in the Intent.  An Intent with a null
+            MIME type will never be matched by a filter with a set MIME
+            type, so we need a second intent-filter if we wish to also
+            match files with this extension and a non-null MIME type
+            (even if it is non-null but zero length).
+      -->
+      <intent-filter android:priority="50">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.BROWSABLE" />
+        <category android:name="android.intent.category.DEFAULT" />
+
+        <data android:scheme="file" />
+        <data android:host="*" />
+        <data android:pathPattern="/.*\\.kmp" />
       </intent-filter>
 
       <intent-filter>
@@ -148,7 +202,7 @@
 
       </intent-filter>
 
-      <intent-filter android:priority="50">
+      <intent-filter android:priority="50" android:autoVerify="true">
         <!-- KMAPro should also be able to handle /keyboards/install links and convert to /go/package/download -->
         <action android:name="android.intent.action.VIEW" />
 

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -174,35 +174,14 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
 
-        <data
-          android:host="keyman-staging.com"
-          android:scheme="http"
-          android:pathPrefix="/go/package/download" />
+        <data android:host="keyman-staging.com" />
+        <data android:host="keyman.com" />
 
-        <data
-          android:host="keyman.com"
-          android:scheme="https"
-          android:pathPrefix="/go/package/download" />
+        <data android:scheme="http" />
+        <data android:scheme="https" />
 
-      </intent-filter>
-
-      <intent-filter android:priority="50">
-        <!-- KMAPro should also be able to handle /keyboards/install links and convert to /go/package/download -->
-        <action android:name="android.intent.action.VIEW" />
-
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-
-        <data
-          android:host="keyman-staging.com"
-          android:scheme="http"
-          android:pathPrefix="/keyboards/install" />
-
-        <data
-          android:host="keyman.com"
-          android:scheme="https"
-          android:pathPrefix="/keyboards/install" />
-
+        <data android:pathPrefix="/go/package/download" />
+        <data android:pathPrefix="/keyboards/install" />
       </intent-filter>
 
     </activity>

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -98,13 +98,12 @@
         <category android:name="android.intent.category.BROWSABLE" />
         <category android:name="android.intent.category.DEFAULT" />
 
+        <data android:scheme="content" />
+        <data android:host="*" />
+
         <!-- needed for mangled email messages -->
-        <data
-          android:mimeType="application/vnd.keyman.kmp+zip"
-          android:scheme="content" />
-        <data
-          android:mimeType="application/octet-stream"
-          android:scheme="content" />
+        <data android:mimeType="application/vnd.keyman.kmp+zip"/>
+        <data android:mimeType="application/octet-stream"/>
       </intent-filter>
 
       <!--
@@ -119,6 +118,10 @@
         <category android:name="android.intent.category.BROWSABLE" />
         <category android:name="android.intent.category.DEFAULT" />
 
+        <data android:scheme="file" />
+        <data android:scheme="content" />
+
+        <data android:host="*" />
         <data android:pathPattern=".*\\.kmp" />
 
         <data android:mimeType="application/vnd.keyman.kmp+zip" />
@@ -174,11 +177,11 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
 
-        <data android:host="keyman-staging.com" />
-        <data android:host="keyman.com" />
-
         <data android:scheme="http" />
         <data android:scheme="https" />
+
+        <data android:host="keyman-staging.com" />
+        <data android:host="keyman.com" />
 
         <data android:pathPrefix="/go/package/download" />
         <data android:pathPrefix="/keyboards/install" />

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -120,16 +120,12 @@
 
         <data android:host="*" />
         <data android:pathPattern=".*\\.kmp" />
-        <data
-          android:mimeType="application/vnd.keyman.kmp+zip"
-          android:scheme="content" />
 
+        <data android:mimeType="application/vnd.keyman.kmp+zip" />
         <!--
           Backup MIME intents
         -->
-        <data
-          android:mimeType="application/octet-stream"
-          android:scheme="content" />
+        <data android:mimeType="application/octet-stream" />
       </intent-filter>
 
       <!--

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -89,6 +89,8 @@
         attachment open requests.  pathPattern and file extensions
         are ignored, so the MIME type *MUST* be explicit, otherwise
         we will match absolutely every file opened.
+
+        See https://developer.android.com/guide/components/intents-filters#DataTest, item 3.
       -->
       <intent-filter android:priority="50">
         <action android:name="android.intent.action.VIEW" />
@@ -106,12 +108,35 @@
       </intent-filter>
 
       <!--
+        Capture open requests (pathPattern is honoured) where MIME
+        type is provided in the Intent and a URI is provided.
+
+        See https://developer.android.com/guide/components/intents-filters#DataTest, item 4.
+      -->
+      <intent-filter android:priority="50">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.BROWSABLE" />
+        <category android:name="android.intent.category.DEFAULT" />
+
+        <data android:pathPattern=".*\\.kmp" />
+
+        <data android:mimeType="application/vnd.keyman.kmp+zip" />
+        <!--
+          Backup MIME intents
+        -->
+        <data android:mimeType="application/octet-stream" />
+      </intent-filter>
+
+      <!--
         Capture file open requests (pathPattern is honoured) where no
         MIME type is provided in the Intent.  An Intent with a null
         MIME type will never be matched by a filter with a set MIME
         type, so we need a second intent-filter if we wish to also
         match files with this extension and a non-null MIME type
         (even if it is non-null but zero length).
+
+        See https://developer.android.com/guide/components/intents-filters#DataTest, item 2.
       -->
       <intent-filter android:priority="50">
         <action android:name="android.intent.action.VIEW" />
@@ -124,12 +149,6 @@
 
         <data android:host="*" />
         <data android:pathPattern=".*\\.kmp" />
-
-        <data android:mimeType="application/vnd.keyman.kmp+zip" />
-        <!--
-          Backup MIME intents
-        -->
-        <data android:mimeType="application/octet-stream" />
       </intent-filter>
 
       <intent-filter>

--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -85,11 +85,11 @@
 
 
       <!--
-                 Capture content by MIME type, which is how Gmail broadcasts
-                 attachment open requests.  pathPattern and file extensions
-                 are ignored, so the MIME type *MUST* be explicit, otherwise
-                 we will match absolutely every file opened.
-            -->
+        Capture content by MIME type, which is how Gmail broadcasts
+        attachment open requests.  pathPattern and file extensions
+        are ignored, so the MIME type *MUST* be explicit, otherwise
+        we will match absolutely every file opened.
+      -->
       <intent-filter android:priority="50">
         <action android:name="android.intent.action.VIEW" />
 
@@ -98,17 +98,21 @@
 
         <!-- needed for mangled email messages -->
         <data
-          android:mimeType="application/keyman"
+          android:mimeType="application/vnd.keyman.kmp+zip"
           android:scheme="content" />
-        <!-- needed for mangled email messages -->
         <data
           android:mimeType="application/octet-stream"
           android:scheme="content" />
-        <data
-          android:mimeType="application/vnd.keyman.kmp+zip"
-          android:scheme="content" />
       </intent-filter>
 
+      <!--
+        Capture file open requests (pathPattern is honoured) where no
+        MIME type is provided in the Intent.  An Intent with a null
+        MIME type will never be matched by a filter with a set MIME
+        type, so we need a second intent-filter if we wish to also
+        match files with this extension and a non-null MIME type
+        (even if it is non-null but zero length).
+      -->
       <intent-filter android:priority="50">
         <action android:name="android.intent.action.VIEW" />
 
@@ -126,25 +130,6 @@
           Backup MIME intents
         -->
         <data android:mimeType="application/octet-stream" />
-      </intent-filter>
-
-      <!--
-            Capture file open requests (pathPattern is honoured) where no
-            MIME type is provided in the Intent.  An Intent with a null
-            MIME type will never be matched by a filter with a set MIME
-            type, so we need a second intent-filter if we wish to also
-            match files with this extension and a non-null MIME type
-            (even if it is non-null but zero length).
-      -->
-      <intent-filter android:priority="50">
-        <action android:name="android.intent.action.VIEW" />
-
-        <category android:name="android.intent.category.BROWSABLE" />
-        <category android:name="android.intent.category.DEFAULT" />
-
-        <data android:scheme="file" />
-        <data android:host="*" />
-        <data android:pathPattern="/.*\\.kmp" />
       </intent-filter>
 
       <intent-filter>

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/CheckPermissions.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/CheckPermissions.java
@@ -34,7 +34,7 @@ public class CheckPermissions {
       permissionsOK = Environment.isExternalStorageManager() ||
         checkPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE);
     }
-    // API 33+ needs no special permissions.
+    // API 33+ does not need any special permissions.
 
     return permissionsOK;
   }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/CheckPermissions.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/CheckPermissions.java
@@ -34,13 +34,7 @@ public class CheckPermissions {
       permissionsOK = Environment.isExternalStorageManager() ||
         checkPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE);
     }
-
-    else {
-      // API 33+
-      // No special permissions are needed.
-      // - https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE
-      // - https://stackoverflow.com/a/73630987
-    }
+    // API 33+ needs no special permissions.
 
     return permissionsOK;
   }

--- a/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/CheckPermissions.java
+++ b/android/KMAPro/kMAPro/src/main/java/com/tavultesoft/kmapro/CheckPermissions.java
@@ -33,12 +33,13 @@ public class CheckPermissions {
       // API 30-32
       permissionsOK = Environment.isExternalStorageManager() ||
         checkPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE);
-    } else {
+    }
+
+    else {
       // API 33+
-      // We had to remove these MEDIA permissions from AndroidManifest.xml so these will end up failing
-      // https://support.google.com/googleplay/android-developer/answer/14115180?hl=en
-      permissionsOK = permissionsOK && checkPermission(activity, Manifest.permission.READ_MEDIA_IMAGES);
-      permissionsOK = permissionsOK && checkPermission(activity, Manifest.permission.READ_MEDIA_VIDEO);
+      // No special permissions are needed.
+      // - https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE
+      // - https://stackoverflow.com/a/73630987
     }
 
     return permissionsOK;


### PR DESCRIPTION
This PR provides two main services:
- It allows on-device KMP file providers (such as Chrome downloads or the local Files app) to smoothly pass those KMP files into Keyman for Android for installation.
- It also removes wildcard-host http / https deep-links from the app manifest, as these are invalid.

Relates-to: #14854

Upon my investigation into related documentation, I've determined that with current versions of Android, setting up a general, "anywhere on the web" deep link for KMP files is not supported and should not be attempted.

How, then, do we facilitate external apps passing off KMP links or files to Keyman for Android?  Turns out... we've already done the work for downloaded files with `file:` and `content:` scheme deep-links.  The issue is that some of our permissions-checking code logic was bad.   With a little work to correct them - removing the bad checks that never should have existed anyway - the files load nicely!

Build-bot: skip release:android

Notes: upon reviewing #10133 and #14122, it sounds like there may be variance among devices.  Samsung is likely to be trickier to handle, while Google devices using plain Chrome may be more straightforward.  I may need to alter the user tests accordingly.

## User Testing

GROUP_API_28:  Perform these tests on devices with Android API 28 (Android 9).
GROUP_API_30:  Perform these tests on devices with Android API 30 (Android 11).
GROUP_API_33:  Perform these tests on devices with Android API 33+ (Android 13).

TEST_DOWNLOAD_AND_INSTALL:  Using Keyman for Android, download a KMP from within the Chrome app, then install it from Chrome's download section.

- Navigate to https://jahorton.github.io and click the english_punct_rota.kmp link in order to download the file.
- Once downloaded, go to the download section (if not displayed) and tap on the downloaded file.
- Verify that Keyman for Android launches and opens the package installer without displaying an error or alert.
- Install the package and verify that no errors result.

TEST_INSTALL_VIA_FILES:  Using Keyman for Android, download a KMP from within the Chrome app, then install it from the device's Files app.

- Navigate to https://jahorton.github.io and click the gesture_prototyping.kmp link in order to download the file.
- Once downloaded, exit Chrome and use the device's Files app to find and "open" the downloaded file.
- Verify that Keyman for Android launches and opens the package installer without displaying an error or alert.
- Install the package and verify that no errors result.