### PR TITLE
fix(android): fix deep links for keyman.com-based downloads

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -209,16 +209,46 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
 
-        <data
-          android:host="keyman-staging.com"
-          android:scheme="http"
-          android:pathPrefix="/keyboards/install" />
+        <!-- Our servers' initial folder represents a language code. -->
+        <data android:host="keyman-staging.com" />
+        <data android:scheme="http" />
+        <!-- Matches 2-letter language folders specifically. -->
+        <data android:pathPattern="/.._*/keyboards/install/.*" />
+        <!-- Matches 2-letter language folders specifically. -->
+        <data android:pathPattern="/..._*/keyboards/install/.*" />
+        <!-- Matches 4-letter language folders specifically. -->
+        <data android:pathPattern="/...._*/keyboards/install/.*" />
+        <!-- Matches 5-letter language folders specifically. -->
+        <data android:pathPattern="/....._*/keyboards/install/.*" />
+        <!-- Matches 6-letter language folders specifically. -->
+        <data android:pathPattern="/......_*/keyboards/install/.*" />
+        <!-- Matches 7-letter language folders specifically. -->
+        <data android:pathPattern="/......._*/keyboards/install/.*" />
+      </intent-filter>
 
-        <data
-          android:host="keyman.com"
-          android:scheme="https"
-          android:pathPrefix="/keyboards/install" />
+      <intent-filter android:priority="50" android:autoVerify="true">
+        <!-- KMAPro should also be able to handle /keyboards/install links and convert to /go/package/download -->
+        <action android:name="android.intent.action.VIEW" />
 
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <!-- Our servers' initial folder represents a language code. -->
+        <data android:host="keyman.com" />
+        <data android:scheme="https" />
+        <!-- Must rely on the .._* pattern when targetSdk < 31 -->
+        <!-- Matches 2-letter language folders specifically. -->
+        <data android:pathPattern="/.._*/keyboards/install/.*" />
+        <!-- Matches 3-letter language folders specifically. -->
+        <data android:pathPattern="/..._*/keyboards/install/.*" />
+        <!-- Matches 4-letter language folders specifically. -->
+        <data android:pathPattern="/...._*/keyboards/install/.*" />
+        <!-- Matches 5-letter language folders specifically. -->
+        <data android:pathPattern="/....._*/keyboards/install/.*" />
+        <!-- Matches 6-letter language folders specifically. -->
+        <data android:pathPattern="/......_*/keyboards/install/.*" />
+        <!-- Matches 7-letter language folders specifically. -->
+        <data android:pathPattern="/......._*/keyboards/install/.*" />
       </intent-filter>
 
     </activity>

--- a/android/KMEA/app/src/main/java/com/keyman/engine/util/KMPLink.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/util/KMPLink.java
@@ -23,7 +23,7 @@ public final class KMPLink {
   public static final String KMP_PRODUCTION_HOST = "keyman.com";
   public static final String KMP_STAGING_HOST =  "keyman.com"; // #7227 disabling: "keyman-staging.com";
 
-  private static final String KMP_INSTALL_KEYBOARDS_PATTERN_FORMATSTR = "^http(s)?://(%s|%s)/keyboards/install/([^\\?/]+)(\\?(.+))?$";
+  private static final String KMP_INSTALL_KEYBOARDS_PATTERN_FORMATSTR = "^http(s)?://(%s|%s)/[^/]*/keyboards/install/([^\\?/]+)(\\?(.+))?$";
   private static final String installPatternFormatStr = KMString.format(KMP_INSTALL_KEYBOARDS_PATTERN_FORMATSTR,
     KMP_PRODUCTION_HOST,
     KMP_STAGING_HOST);


### PR DESCRIPTION
As we've now internationalized keyman.com, placing a language code as the root path folder, we now need to accommodate this within the Android app for its deep links.

Fixes: #14854
Fixes: #16397

Build-bot: skip release:android

**NOTE**:  The keyman.com support for deep-links only supports actual Keyman app releases and does not support local compilations properly.  Per https://keyman.com/.well-known/assetlinks.json, it only supports the `com.tavultesoft.kmapro` package and not the `com.tavultesoft.keyman.debug` package.  This made testing the fix more difficult than expected.

## User Testing

GROUP_API_28:  Perform these tests on devices with Android API 28 (Android 9).
GROUP_API_30:  Perform these tests on devices with Android API 30 (Android 11).
GROUP_API_33:  Perform these tests on devices with Android API 33+ (Android 13).

TEST_SEARCH_AND_TRY_DOWNLOAD:  Using an emulated Android device with Keyman for Android installed, search for a keyboard package on keyman.com and attempt to download it.

- Within the emulated device's Chrome app, navigate to https://keyman.com and search for a keyboard of your choice.
- On the keyboard package's page, press the big green "Install Keyboard" download button.
- Keyman for Android should immediately launch, download the package, and start the package installer.