### PR TITLE
feat(ios): pass current display language to keyboard download

### DIFF
--- a/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
+++ b/ios/engine/KMEI/KeymanEngine/Classes/Resource Management/KeyboardSearchViewController.swift
@@ -79,7 +79,12 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
     // API endpoint only supports major.minor, will break if `.build` is also present
     baseURL.appendPathComponent(Version.current.majorMinor.description)
     baseURL.appendPathComponent("download-keyboards")
-
+    if #available(iOS 16.0, *) {
+      var langQueryItem = URLQueryItem(name:"lang", value:Bundle.main.preferredLocalizations[0])
+      baseURL.append(queryItems:[langQueryItem])
+    } else {
+      // We won't pass the localization on earlier versions of iOS
+    }
     return baseURL
   }
 
@@ -113,6 +118,10 @@ public class KeyboardSearchViewController: UIViewController, WKNavigationDelegat
     config.defaultWebpagePreferences = pref
 
     let webView = WKWebView.init(frame: CGRect.zero, configuration: config)
+    // For debugging:
+    // if #available(iOS 16.4, *) {
+    //   webView.isInspectable = true
+    // }
     webView.navigationDelegate = self
     if let languageCode = languageCode {
       let baseURL = KeyboardSearchViewController.ENDPOINT_ROOT


### PR DESCRIPTION
Note that this information is also passed in via the HTTP `Accept-Language` header, but for now we are using the `lang` parameter to match implementation on all platforms. (We should consider moving to use `Accept-Language` in a future version for more transparent implementation).

Fixes: #15540

# User Testing

* **TEST_IOS_SUPPORTED_LANGUAGE:** Select a different preferred UI language (French, German, Spanish or Khmer) in iOS device settings. Verify that Keyman shows its UI in that language. Then verify that the Download Keyboard page in the app shows in that language also.
* **TEST_IOS_UNSUPPORTED_LANGUAGE:** Select a different preferred UI language (e.g. Swedish) in iOS device settings. Verify that the Download Keyboard page in the app shows up in English.