### PR TITLE
change(android): enable autocorrect by default

### DIFF
--- a/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
+++ b/android/KMEA/app/src/main/java/com/keyman/engine/KMManager.java
@@ -370,7 +370,7 @@ public final class KMManager {
   public static int KeyboardHeight_Context_Landscape_Current = 0; // Current landscape height
 
   // Default prediction/correction setting
-  public static final int KMDefault_Suggestion = SuggestionType.PREDICTIONS_WITH_CORRECTIONS.toInt();
+  public static final int KMDefault_Suggestion = SuggestionType.PREDICTIONS_WITH_AUTO_CORRECT.toInt();
 
   // Keyman files
   protected static final String KMFilename_KeyboardHtml = "keyboard.html";


### PR DESCRIPTION
This is a remake of #16389, which got auto-closed when epic/autocorrect merged into master.  (GitHub didn't auto-migrate it!)

Build-bot: skip build:web release:android
Test-bot: skip

(All user tests from #16389 passed, so we don't need a repeat.)