### PR TITLE
chore(mac): put coreutils on path on mac and improve docs

### DIFF
--- a/docs/build/macos.md
+++ b/docs/build/macos.md
@@ -127,8 +127,8 @@ To install emscripten, `cd` to an appropriate path, and then:
 ```bash
 git clone https://github.com/emscripten-core/emsdk
 cd emsdk
-emsdk install 3.1.58
-emsdk activate 3.1.58
+./emsdk install 3.1.64
+./emsdk activate 3.1.64
 cd upstream/emscripten
 npm install
 export EMSCRIPTEN_BASE="$(pwd)"

--- a/resources/build/builder-basic.inc.sh
+++ b/resources/build/builder-basic.inc.sh
@@ -309,3 +309,11 @@ _builder_basic_find_should_sentry_release
 # correct version
 #
 _builder_basic_set_keyman_standard_build_path
+
+if builder_is_macos; then
+  if [[ -z "${HOMEBREW_PREFIX+x}" ]]; then
+    HOMEBREW_PREFIX=`brew --prefix`
+  fi
+
+  export PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
+fi


### PR DESCRIPTION
Ensure realpath and other coreutils tools we need are on the path when called from build.sh. And tweak documentation around Emscripten.

Test-bot: skip