### PR TITLE
maint(windows): move to vs2026 arm runner for GHA

### DIFF
--- a/.github/workflows/core-arm64-windows-test.yml
+++ b/.github/workflows/core-arm64-windows-test.yml
@@ -36,7 +36,7 @@ jobs:
   core-arm64-windows-test:
     name: Keyman Core ARM64/Windows test
     if: github.repository == 'keymanapp/keyman' || github.event.client_payload.force
-    runs-on: windows-11-arm
+    runs-on: windows-11-vs2026-arm
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This will need to be tested after landing, because the workflow file runs from `master` branch.

Fixes: #16413
Test-bot: skip
Build-bot: skip build:windows