### PR TITLE
fix(windows): resync caps lock state when Keyman keyboard is activated

### DIFF
--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -67,6 +67,9 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPIsKeymanRunning() {
 extern "C" __declspec(dllexport) BOOL WINAPI TIPActivateKeyboard(GUID *profile) {   // I3581
   PKEYMAN64THREADDATA _td = ThreadGlobals();
   if(!_td) return FALSE;
+
+  RefreshToggleState();   // #16422 - a keyboard switch does not change window focus
+
   if(profile != NULL) {
     for(int i = 0; i < _td->nKeyboards; i++) {
       for(int j = 0; j < _td->lpKeyboards[i].nProfiles; j++) {

--- a/windows/src/engine/keyman32/appint/aiTIP.cpp
+++ b/windows/src/engine/keyman32/appint/aiTIP.cpp
@@ -68,7 +68,7 @@ extern "C" __declspec(dllexport) BOOL WINAPI TIPActivateKeyboard(GUID *profile) 
   PKEYMAN64THREADDATA _td = ThreadGlobals();
   if(!_td) return FALSE;
 
-  RefreshToggleState();   // #16422 - a keyboard switch does not change window focus
+  RefreshToggleState();
 
   if(profile != NULL) {
     for(int i = 0; i < _td->nKeyboards; i++) {

--- a/windows/src/engine/keyman32/capsstate.cpp
+++ b/windows/src/engine/keyman32/capsstate.cpp
@@ -29,3 +29,21 @@
 BOOL IsCapsLockOn(void) {
   return GetKeyState(VK_CAPITAL) & 1;
 }
+
+/*
+  RefreshToggleState:
+
+  Resyncs the caps and numlock state, because it may have been changed while
+  Keyman was not aware of it
+*/
+void RefreshToggleState(void) {
+  DWORD n = Globals::get_ShiftState();
+
+  if (GetKeyState(VK_CAPITAL) & 1) *Globals::ShiftState() |= CAPITALFLAG;
+  else *Globals::ShiftState() &= ~CAPITALFLAG;
+
+  if (GetKeyState(VK_NUMLOCK) & 1) *Globals::ShiftState() |= NUMLOCKFLAG;
+  else *Globals::ShiftState() &= ~NUMLOCKFLAG;
+
+  SendDebugMessageFormat("Enter: %x Exit: %x", n, Globals::get_ShiftState());
+}

--- a/windows/src/engine/keyman32/capsstate.cpp
+++ b/windows/src/engine/keyman32/capsstate.cpp
@@ -31,8 +31,10 @@ BOOL IsCapsLockOn(void) {
 }
 
 /**
- * Resync the Caps Lock and Num Lock state, because it may have been 
- * changed while Keyman was not aware of it
+ * Resync the Caps Lock and Num Lock state cache.
+ * 
+ * Use when state may be stale after focus changes or when the toggle keys
+ * changed while this Keyman engine instance was not processing key events.
  */
 void RefreshToggleState(void) {
   DWORD previousShiftState = Globals::get_ShiftState();

--- a/windows/src/engine/keyman32/capsstate.cpp
+++ b/windows/src/engine/keyman32/capsstate.cpp
@@ -43,5 +43,5 @@ void RefreshToggleState(void) {
   if (GetKeyState(VK_NUMLOCK) & 1) *Globals::ShiftState() |= NUMLOCKFLAG;
   else *Globals::ShiftState() &= ~NUMLOCKFLAG;
 
-  SendDebugMessageFormat("Enter: %x Exit: %x", n, Globals::get_ShiftState());
+  SendDebugMessageFormat("Enter: %x Exit: %x", previousShiftState, Globals::get_ShiftState());
 }

--- a/windows/src/engine/keyman32/capsstate.cpp
+++ b/windows/src/engine/keyman32/capsstate.cpp
@@ -35,7 +35,7 @@ BOOL IsCapsLockOn(void) {
  * changed while Keyman was not aware of it
  */
 void RefreshToggleState(void) {
-  DWORD n = Globals::get_ShiftState();
+  DWORD previousShiftState = Globals::get_ShiftState();
 
   if (GetKeyState(VK_CAPITAL) & 1) *Globals::ShiftState() |= CAPITALFLAG;
   else *Globals::ShiftState() &= ~CAPITALFLAG;

--- a/windows/src/engine/keyman32/capsstate.cpp
+++ b/windows/src/engine/keyman32/capsstate.cpp
@@ -30,12 +30,10 @@ BOOL IsCapsLockOn(void) {
   return GetKeyState(VK_CAPITAL) & 1;
 }
 
-/*
-  RefreshToggleState:
-
-  Resyncs the caps and numlock state, because it may have been changed while
-  Keyman was not aware of it
-*/
+/**
+ * Resync the Caps Lock and Num Lock state, because it may have been 
+ * changed while Keyman was not aware of it
+ */
 void RefreshToggleState(void) {
   DWORD n = Globals::get_ShiftState();
 

--- a/windows/src/engine/keyman32/capsstate.h
+++ b/windows/src/engine/keyman32/capsstate.h
@@ -20,5 +20,6 @@
 #define __CAPSSTATE_H
 
 BOOL IsCapsLockOn(void);
+void RefreshToggleState(void);
 
 #endif

--- a/windows/src/engine/keyman32/kmhook_getmessage.cpp
+++ b/windows/src/engine/keyman32/kmhook_getmessage.cpp
@@ -418,11 +418,7 @@ ProcessWMKeymanControl(WPARAM wParam, LPARAM lParam) {
 void GetCapsAndNumlockState() {   // I4793
   DWORD n = Globals::get_ShiftState();
 
-  if(GetKeyState(VK_NUMLOCK) & 1) *Globals::ShiftState() |= NUMLOCKFLAG;
-  else *Globals::ShiftState() &= ~NUMLOCKFLAG;
-
-  if(GetKeyState(VK_CAPITAL) & 1) *Globals::ShiftState() |= CAPITALFLAG;
-  else *Globals::ShiftState() &= ~CAPITALFLAG;
+  RefreshToggleState();
 
   if(GetKeyState(VK_SHIFT) < 0) *Globals::ShiftState() |= K_SHIFTFLAG;
   else *Globals::ShiftState() &= ~K_SHIFTFLAG;


### PR DESCRIPTION
Here's a proposed fix for #16422 .

Full disclosure, Claude built this minimal fix. I have reviewed the result and tested it by inserting a rebuilt keyman32 and keyman64 DLLs in place. It's just displacing code, nothing new. Rereading the state of the system's locks on keyboard load makes sense to me.

I tested moving with Win+Space and via mouse between the Windows US English and Keyman Cameroon Keyboard. CAPS was detected when the Cameroon Keyboard activated and the first output letter was a capital. It worked well. I noted that switching to yoruba8 ignored the existing CAPS state without disabling it on the system, but this is expected since that keyboard doesn't have CAPS rules. 

From Claude:

> The Caps Lock and Num Lock flags in Globals::ShiftState() are updated only as key events pass through the engine, so they go stale when the toggle is changed while a non-Keyman layout is active. The existing resync in GetCapsAndNumlockState() runs on window focus change, which a keyboard switch does not trigger, so the core processor was told Caps Lock was off until the user toggled it twice.
> 
> Extract the toggle resync as RefreshToggleState() and call it from TIPActivateKeyboard(), which is the profile activation path for both Win+Space and the Windows language selector.


Fixes: #16422
Build-bot: release:windows
