### PR TITLE
fix(windows): add manifest to insthelper and set trustinfo to asInvoker

### DIFF
--- a/windows/src/desktop/insthelp/build.sh
+++ b/windows/src/desktop/insthelp/build.sh
@@ -27,7 +27,7 @@ function do_build() {
   create-windows-output-folders
   build_version.res
   # TODO: why no manifest?
-  # build_manifest.res
+  build_manifest.res
   delphi_msbuild insthelp.dproj "//p:Platform=Win32"
   sentrytool_delphiprep "$WIN32_TARGET" insthelp.dpr
   tds2dbg "$WIN32_TARGET"
@@ -39,7 +39,7 @@ function do_build() {
 function do_publish() {
   # test that (a) linked manifest exists and correct
   # TODO: no manifest included?
-  # wrap-mt -nologo -inputresource:"$WINDOWS_PROGRAM_APP/insthelp.exe" -validate_manifest
+  wrap-mt -nologo -inputresource:"$WINDOWS_PROGRAM_APP/insthelp.exe" -validate_manifest
 
   wrap-signcode //d "Keyman for Windows Install Helper" "$WINDOWS_PROGRAM_APP/insthelp.exe"
   wrap-symstore "$WINDOWS_PROGRAM_APP/insthelp.exe" //t keyman-windows

--- a/windows/src/desktop/insthelp/build.sh
+++ b/windows/src/desktop/insthelp/build.sh
@@ -26,7 +26,6 @@ builder_describe_outputs \
 function do_build() {
   create-windows-output-folders
   build_version.res
-  # TODO: why no manifest?
   build_manifest.res
   delphi_msbuild insthelp.dproj "//p:Platform=Win32"
   sentrytool_delphiprep "$WIN32_TARGET" insthelp.dpr
@@ -38,7 +37,6 @@ function do_build() {
 
 function do_publish() {
   # test that (a) linked manifest exists and correct
-  # TODO: no manifest included?
   wrap-mt -nologo -inputresource:"$WINDOWS_PROGRAM_APP/insthelp.exe" -validate_manifest
 
   wrap-signcode //d "Keyman for Windows Install Helper" "$WINDOWS_PROGRAM_APP/insthelp.exe"

--- a/windows/src/desktop/insthelp/insthelp.dpr
+++ b/windows/src/desktop/insthelp/insthelp.dpr
@@ -11,7 +11,7 @@ uses
   UserMessages in '..\..\..\..\common\windows\delphi\general\UserMessages.pas';
 
 {$R version.res}
-{-R manifest.res}
+{$R manifest.res}
 
 begin
   CoInitializeEx(nil, COINIT_APARTMENTTHREADED);

--- a/windows/src/desktop/insthelp/manifest.in
+++ b/windows/src/desktop/insthelp/manifest.in
@@ -6,15 +6,13 @@
     version="$VersionWin"
     processorArchitecture="x86"/>
   <description>Keyman Installation Assistant</description>
-  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-    <security>
-      <requestedPrivileges>
-        <requestedExecutionLevel
-          level="requireAdministrator"
-          uiAccess="false"/>
-      </requestedPrivileges>
-    </security>
-  </trustInfo>
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+		<security>
+			<requestedPrivileges>
+				<requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
 
   <!-- Switch on various compatibility values -->
 


### PR DESCRIPTION
Change the manifest trustinfo to asInvoker from requireAdminstrator.
This was causing the preuninstaller to fail as it couldn't elevate.

This also adds the manifest back into the build as it was previously
removed.

Fixes: #15187 

Build-bot: release:windows