### PR TITLE
change(web): narrow the range of suggestions examined to determine autocompletion

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -3,7 +3,7 @@
  *
  * Created by jahorton on 2024-07-08.
  *
- * This file defines many predictive-text engine's helper methods used for the
+ * This file defines the many predictive-text engine's helper methods used for the
  * overall process of text prediction.
  */
 

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -89,6 +89,17 @@ export interface PredictionMetadata {
    * prediction.
    */
   preservationTransform: Transform;
+  /**
+   * Indicates the number of raw Damerau-Levenshtein edits represented by
+   * the correction, not including the substitution of sufficiently-likely
+   * neighbor fat-finger keys at each step.
+   */
+  rawEditCount: number;
+  /**
+   * Indicates the codepoint length by which the current token will be
+   * extended when the Suggestion is applied.
+   */
+  predictionLength: number;
 }
 
 /**
@@ -166,12 +177,12 @@ export function tupleDisplayOrderSort(
   const matchLevelB = b.metadata.matchLevel ?? 0;
 
   // Similarity distance
-  const simDist = matchLevelB - matchLevelA;
-  if(simDist != 0) {
-    return simDist;
+  const similarityDelta = matchLevelB - matchLevelA;
+  if(similarityDelta != 0) {
+    return similarityDelta;
   }
 
-  // Probability distance
+  // Probability delta - larger is better
   return b.totalProb - a.totalProb;
 }
 
@@ -236,13 +247,17 @@ export async function correctAndEnumerateWithoutTraversals(
 
   // Running in bulk over all suggestions, duplicate entries may be possible.
   rawPredictions = predictFromCorrections(lexicalModel, predictionRoots, context);
-  const predictions = rawPredictions.map((entry) => {
+
+  const keyer = (text: string) => lexicalModel.toKey ? lexicalModel.toKey(text) : text;
+  const predictions: CorrectionPredictionTuple[] = rawPredictions.map((entry) => {
     const preservationTransform = allowSpace ? inputTransform : null;
     return {
       ...entry,
       metadata: {
         preservationTransform,
-        matchLevel: SuggestionSimilarity.none // will be overwritten later
+        matchLevel: SuggestionSimilarity.none, // will be overwritten later,
+        rawEditCount: 0,
+        predictionLength: KMWString.length(keyer(entry.prediction.sample.transform.insert)) - KMWString.length(keyer(entry.correction.sample))
       }
     };
   });
@@ -502,17 +517,19 @@ export function determineSuggestionRange(
 export function buildAndMapPredictions(
   transition: ContextTransition,
   tokenization: ContextTokenization,
-  // Originally, Readonly<TokenResultMapping> - but we only need these two components here.
-  match: Readonly<{matchString: string, totalCost: number}>,
+  // Originally, Readonly<TokenResultMapping> - but we only need these three components here.
+  match: Readonly<{matchString: string, totalCost: number, editCount: number}>,
   costFactor: number
 ): CorrectionPredictionTuple[] {
   const model = transition.final.model;
+  const keyer = (text: string) => model.toKey ? model.toKey(text) : text;
 
   // No matter the prediction, once we know the root of the prediction, we'll
   // always 'replace' the same amount of text.  We can handle this before the
   // big 'prediction root' loop.
   const { predictionContext, correctionDeleteLeft, committedDeleteLeft } = determineSuggestionAlignment(transition, tokenization, model);
 
+  // --- to move into predictFromCorrections ---
   let correction = match.matchString;
   let rootCost = match.totalCost;
 
@@ -527,18 +544,21 @@ export function buildAndMapPredictions(
     sample: correctionTransform,
     p: Math.exp(-rootCost * costFactor)
   };
+  // -- end:  "to move" --
 
   // Worth considering:  extend Traversal to allow direct prediction lookups?
   // let traversal = match.finalTraversal; // ...
   let rawPredictions = predictFromCorrections(model, [predictionRoot], predictionContext);
-  const predictions = rawPredictions.map((entry) => {
+  const predictions: CorrectionPredictionTuple[] = rawPredictions.map((entry) => {
     entry.prediction.sample.transform.deleteLeft += committedDeleteLeft;
 
     return {
       ...entry,
       metadata: {
         preservationTransform: tokenization.taillessTrueKeystroke,
-        matchLevel: SuggestionSimilarity.none // will be overwritten later
+        matchLevel: SuggestionSimilarity.none, // will be overwritten later
+        rawEditCount: match.editCount,
+        predictionLength: KMWString.length(keyer(entry.prediction.sample.transform.insert)) - KMWString.length(match.matchString)
       }
     };
   });
@@ -652,6 +672,7 @@ export async function correctAndEnumerate(
      */
     const costFactor = (tokenization.tail.inputCount <= 1) ? ModelCompositor.SINGLE_CHAR_KEY_PROB_EXPONENT : 1;
 
+    // if costFactor > 1, penalize with bonus edit cost if we're not using the most likely transform!
     const predictions = buildAndMapPredictions(transition, tokenization, match, costFactor);
 
     // Only set 'best correction' cost when a correction ACTUALLY YIELDS predictions.
@@ -972,7 +993,9 @@ export function createDefaultKeep(
     },
     metadata: {
       preservationTransform: null,
-      matchLevel: SuggestionSimilarity.exact
+      matchLevel: SuggestionSimilarity.exact,
+      rawEditCount: KMWString.length(truePrefix),
+      predictionLength: 0
     }
   };
 }
@@ -1048,7 +1071,10 @@ export function predictionAutoSelect(suggestionDistribution: CorrectionPredictio
 
   // Find the highest probability for any correction that led to a valid prediction.
   // No need to full-on re-sort everything, though.
-  const bestCorrection = suggestionDistribution.reduce((prev, current) => prev?.correction.p > current.correction.p ? prev : current, null).correction;
+  const bestCorrection = suggestionDistribution.reduce(
+    (prev, current) => prev?.correction.p > current.correction.p ? prev : current,
+    null
+  ).correction;
   if(bestCorrection.p > bestSuggestion.correction.p) {
     // Here, the best suggestion didn't come from the best correction.
     // Is it actually reasonable to auto-correct?  We're probably just very
@@ -1063,7 +1089,10 @@ export function predictionAutoSelect(suggestionDistribution: CorrectionPredictio
   const bestSuggestionTier = bestSuggestion.metadata.matchLevel;
 
   // compare best vs other probabilities of compatible tier.
-  const probSum = suggestionDistribution.reduce((accum, current) => {
+  const probSum = suggestionDistribution
+    .filter((s) => (s.metadata.predictionLength ?? 0) <= (bestSuggestion.metadata.predictionLength ?? 0))
+    .filter((s) => (s.metadata.rawEditCount ?? 0) <= (bestSuggestion.metadata.rawEditCount ?? 0))
+    .reduce((accum, current) => {
     // If the suggestion is from a different similarity tier, do not count it against
     // the required auto-select probability ratio threshold.  That threshold should
     // only apply within the suggestion's tier.

--- a/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/predict-helpers.ts
@@ -1,3 +1,12 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by jahorton on 2024-07-08.
+ *
+ * This file defines many predictive-text engine's helper methods used for the
+ * overall process of text prediction.
+ */
+
 import * as models from '@keymanapp/models-templates';
 import { KMWString } from 'keyman/common/web-utils';
 import { LexicalModelTypes } from '@keymanapp/common-types';

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/auto-correct.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/auto-correct.tests.ts
@@ -11,7 +11,9 @@ import {
 
 const defaultMetadata: PredictionMetadata = {
   matchLevel: SuggestionSimilarity.none,
-  preservationTransform: undefined
+  preservationTransform: undefined,
+  rawEditCount: 0,
+  predictionLength: 0
 }
 
 /*
@@ -49,7 +51,7 @@ describe('predictionAutoSelect', () => {
           p: 1
         },
         totalProb: 1,
-        metadata: defaultMetadata
+        metadata: {...defaultMetadata}
       }
     ];
 
@@ -81,7 +83,7 @@ describe('predictionAutoSelect', () => {
           p: 0.01
         },
         totalProb: 0.01,
-        metadata: defaultMetadata
+        metadata: {...defaultMetadata}
       },
       {
         correction: {
@@ -100,7 +102,7 @@ describe('predictionAutoSelect', () => {
           p: 0.8
         },
         totalProb: 0.8,
-        metadata: defaultMetadata
+        metadata: {...defaultMetadata}
       }
     ];
 
@@ -132,7 +134,7 @@ describe('predictionAutoSelect', () => {
           p: 1
         },
         totalProb: 1,
-        metadata: defaultMetadata
+        metadata: {...defaultMetadata}
       }
     ];
 
@@ -163,7 +165,7 @@ describe('predictionAutoSelect', () => {
         p: .05
       },
       totalProb: .04,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     }
 
     const highestNonKeepSuggestion: CorrectionPredictionTuple= {
@@ -182,7 +184,7 @@ describe('predictionAutoSelect', () => {
         p: .55
       },
       totalProb: .44,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     };
 
     const predictions: CorrectionPredictionTuple[] = [
@@ -204,7 +206,7 @@ describe('predictionAutoSelect', () => {
           p: .4
         },
         totalProb: .32,
-        metadata: defaultMetadata
+        metadata: {...defaultMetadata}
       },
       {
         correction: {
@@ -222,7 +224,7 @@ describe('predictionAutoSelect', () => {
           p: 1
         },
         totalProb: .2,
-        metadata: defaultMetadata
+        metadata: {...defaultMetadata}
       }
     ];
 
@@ -253,7 +255,7 @@ describe('predictionAutoSelect', () => {
         p: .05
       },
       totalProb: .04,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     }
 
     // To 'win', a suggestion (currently) needs at least twice the probability of the sum of all alternatives.
@@ -276,7 +278,7 @@ describe('predictionAutoSelect', () => {
         p: .01
       },
       totalProb: .008,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     };
 
     const predictions: CorrectionPredictionTuple[] = [
@@ -316,7 +318,7 @@ describe('predictionAutoSelect', () => {
         p: .05
       },
       totalProb: .04,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     }
 
     // To 'win', a suggestion (currently) needs at least twice the probability of the sum of all alternatives.
@@ -339,7 +341,7 @@ describe('predictionAutoSelect', () => {
         p: .55
       },
       totalProb: .44,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     };
 
     const predictions: CorrectionPredictionTuple[] = [
@@ -361,7 +363,7 @@ describe('predictionAutoSelect', () => {
           p: .4
         },
         totalProb: .32,
-        metadata: defaultMetadata
+        metadata: {...defaultMetadata}
       },
       {
         correction: {
@@ -379,7 +381,7 @@ describe('predictionAutoSelect', () => {
           p: 1
         },
         totalProb: .2,
-        metadata: defaultMetadata
+        metadata: {...defaultMetadata}
       }
     ];
 
@@ -415,7 +417,7 @@ describe('predictionAutoSelect', () => {
         p: .05
       },
       totalProb: .04,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     }
 
     const highestNonKeepSuggestion: CorrectionPredictionTuple= {
@@ -434,7 +436,7 @@ describe('predictionAutoSelect', () => {
         p: .75
       },
       totalProb: .675,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     };
 
     const predictions: CorrectionPredictionTuple[] = [
@@ -456,7 +458,7 @@ describe('predictionAutoSelect', () => {
           p: .2
         },
         totalProb: .18,
-        metadata: defaultMetadata
+        metadata: {...defaultMetadata}
       },
       {
         correction: {
@@ -474,7 +476,7 @@ describe('predictionAutoSelect', () => {
           p: 1
         },
         totalProb: .1,
-        metadata: defaultMetadata
+        metadata: {...defaultMetadata}
       }
     ];
 
@@ -508,7 +510,7 @@ describe('predictionAutoSelect', () => {
         p: 1
       },
       totalProb: 1,
-      metadata: { matchLevel: SuggestionSimilarity.exact, preservationTransform: null }
+      metadata: { ...defaultMetadata, matchLevel: SuggestionSimilarity.exact }
     }
 
     const expectedSuggestion: CorrectionPredictionTuple= {
@@ -527,7 +529,7 @@ describe('predictionAutoSelect', () => {
         p: .2
       },
       totalProb: .2,
-      metadata: { matchLevel: SuggestionSimilarity.sameKey, preservationTransform: null }
+      metadata: { ...defaultMetadata, matchLevel: SuggestionSimilarity.sameKey }
     };
 
     const predictions: CorrectionPredictionTuple[] = [
@@ -549,7 +551,7 @@ describe('predictionAutoSelect', () => {
           p: .8
         },
         totalProb: .8,
-        metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: null }
+        metadata: { ...defaultMetadata, matchLevel: SuggestionSimilarity.none, predictionLength: 3 }
       }
     ];
 
@@ -583,7 +585,7 @@ describe('predictionAutoSelect', () => {
         p: .05
       },
       totalProb: .035,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     }
 
     const highestCorrectionSuggestion: CorrectionPredictionTuple= {
@@ -602,7 +604,7 @@ describe('predictionAutoSelect', () => {
         p: .1
       },
       totalProb: .07,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     };
 
     const highestNonKeepSuggestion: CorrectionPredictionTuple= {
@@ -621,7 +623,7 @@ describe('predictionAutoSelect', () => {
         p: 1
       },
       totalProb: .3,
-      metadata: defaultMetadata
+      metadata: {...defaultMetadata}
     };
 
     const predictions: CorrectionPredictionTuple[] = [

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/build-and-map-predictions.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/build-and-map-predictions.tests.ts
@@ -58,7 +58,7 @@ describe('buildAndMapPredictions', () => {
     const mappedPredictions = buildAndMapPredictions(
       transition,
       transition.base.displayTokenization,
-      {matchString: 'the', totalCost: 0},
+      {matchString: 'the', totalCost: 0, editCount: 0},
       1
     );
 
@@ -104,7 +104,7 @@ describe('buildAndMapPredictions', () => {
     const mappedPredictions = buildAndMapPredictions(
       transition,
       transition.base.displayTokenization,
-      {matchString: '', totalCost: 0},
+      {matchString: '', totalCost: 0, editCount: 0},
       1
     );
 
@@ -148,7 +148,7 @@ describe('buildAndMapPredictions', () => {
     const mappedPredictions = buildAndMapPredictions(
       transition,
       transition.base.displayTokenization,
-      {matchString: '', totalCost: 0},
+      {matchString: '', totalCost: 0, editCount: 0},
       1
     );
 
@@ -210,7 +210,7 @@ describe('buildAndMapPredictions', () => {
     const mappedPredictions = buildAndMapPredictions(
       transition,
       transition.final.displayTokenization,
-      {matchString: '', totalCost: 0},
+      {matchString: '', totalCost: 0, editCount: 0},
       1
     );
 

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/create-default-keep.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/create-default-keep.tests.ts
@@ -131,7 +131,7 @@ describe('produceKeep', () => {
         p: 1
       },
       totalProb: 1,
-      metadata: { matchLevel: SuggestionSimilarity.exact, preservationTransform: null }
+      metadata: { matchLevel: SuggestionSimilarity.exact, preservationTransform: null, predictionLength: 0, rawEditCount: 'iphone'.length }
     };
 
     const tuple = createDefaultKeep(testModelWithCasing, context, trueInput);

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-deduplication.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-deduplication.tests.ts
@@ -29,7 +29,9 @@ const mockMetadata: (tc: CorrectionPredictionTupleCore) => CorrectionPredictionT
     ...t,
     metadata: {
       preservationTransform: null,
-      matchLevel: SuggestionSimilarity.none
+      matchLevel: SuggestionSimilarity.none,
+      rawEditCount: 0,    // does not matter for these tests.
+      predictionLength: 0 // does not matter for these tests.
     }
   }
 };

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-finalization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-finalization.tests.ts
@@ -50,7 +50,9 @@ const build_its_is_set = (verbose?: string) => {
 
   const metadata: PredictionMetadata = {
     matchLevel: SuggestionSimilarity.none,
-    preservationTransform: undefined
+    preservationTransform: undefined,
+    rawEditCount: 0,
+    predictionLength: 0
   };
 
   const its: CorrectionPredictionTuple = {
@@ -69,7 +71,7 @@ const build_its_is_set = (verbose?: string) => {
       p: 0.2
     },
     totalProb: 0.16,
-    metadata: {...metadata}
+    metadata: {...metadata, predictionLength: 0}
   };
 
   const it_is: CorrectionPredictionTuple = {
@@ -88,7 +90,7 @@ const build_its_is_set = (verbose?: string) => {
       p: 0.8
     },
     totalProb: 0.64,
-    metadata: {...metadata}
+    metadata: {...metadata, predictionLength: 0}
   };
 
   const is: CorrectionPredictionTuple = {
@@ -107,7 +109,7 @@ const build_its_is_set = (verbose?: string) => {
       p: 0.5
     },
     totalProb: 0.1,
-    metadata: {...metadata}
+    metadata: {...metadata, predictionLength: 0}
   };
 
   const is_not: CorrectionPredictionTuple = {
@@ -126,7 +128,7 @@ const build_its_is_set = (verbose?: string) => {
       p: 0.5
     },
     totalProb: 0.1,
-    metadata: {...metadata}
+    metadata: {...metadata, predictionLength: 2} // not counting the `'` here.
   };
 
   const baseDefinitions = {

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-similarity.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/prediction-helpers/suggestion-similarity.tests.ts
@@ -118,7 +118,9 @@ const testModelWithCasing = new DummyModel({
 const build_its_is_set = () => {
   const metadata: PredictionMetadata = {
     matchLevel: SuggestionSimilarity.none,
-    preservationTransform: undefined
+    preservationTransform: undefined,
+    rawEditCount: 0, // does not matter for these tests
+    predictionLength: 0 // does not matter for these tests
   };
 
   const its: CorrectionPredictionTuple = {
@@ -228,16 +230,16 @@ describe('processSimilarity', () => {
     const expectation: CorrectionPredictionTuple[] = [
       {
         ...testSet.its,
-        metadata: { matchLevel: SuggestionSimilarity.exact, preservationTransform: undefined }
+        metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.exact }
       }, {
         ...testSet.it_is,
-        metadata: { matchLevel: SuggestionSimilarity.sameKey, preservationTransform: undefined }
+        metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.sameKey }
       }, {
         ...testSet.is,
-        metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: undefined }
+        metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.none }
       }, {
         ...testSet.is_not,
-        metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: undefined }
+        metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.none }
       }
     ];
 
@@ -275,16 +277,16 @@ describe('processSimilarity', () => {
     const expectation: CorrectionPredictionTuple[] = [
       {
         ...testSet.its,
-        metadata: { matchLevel: SuggestionSimilarity.sameKey, preservationTransform: undefined }
+        metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.sameKey }
       }, {
         ...testSet.it_is,
-        metadata: { matchLevel: SuggestionSimilarity.exact, preservationTransform: undefined }
+        metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.exact }
       }, {
         ...testSet.is,
-        metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: undefined }
+        metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.none }
       }, {
         ...testSet.is_not,
-        metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: undefined }
+        metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.none }
       }
     ];
 
@@ -339,17 +341,17 @@ describe('processSimilarity', () => {
       const expectation: CorrectionPredictionTuple[] = [
         {
           ...testSet.its,
-          metadata: { matchLevel: SuggestionSimilarity.sameKey, preservationTransform: undefined }
+          metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.sameKey }
         }, {
           ...testSet.it_is,
           // case mismatch, detectable because we have access to a lowercasing/uppercasing function.
-          metadata: { matchLevel: SuggestionSimilarity.sameText, preservationTransform: undefined }
+          metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.sameText }
         }, {
           ...testSet.is,
-          metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: undefined }
+          metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.none }
         }, {
           ...testSet.is_not,
-          metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: undefined }
+          metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.none }
         }
       ];
 
@@ -393,17 +395,17 @@ describe('processSimilarity', () => {
       const expectation: CorrectionPredictionTuple[] = [
         {
           ...testSet.its,
-          metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: undefined }
+          metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.none }
         }, {
           ...testSet.it_is,
           // case mismatch, detectable because we have access to a lowercasing/uppercasing function.
-          metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: undefined }
+          metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.none }
         }, {
           ...testSet.is,
-          metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: undefined }
+          metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.none }
         }, {
           ...testSet.is_not,
-          metadata: { matchLevel: SuggestionSimilarity.none, preservationTransform: undefined }
+          metadata: { ...testSet.its.metadata, matchLevel: SuggestionSimilarity.none }
         }
       ];
 

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-predict.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-predict.tests.ts
@@ -1,5 +1,6 @@
 
 import { createRequire } from 'node:module';
+import { assert } from 'chai';
 import sinon from 'sinon';
 
 import { LexicalModelTypes } from '@keymanapp/common-types';
@@ -8,7 +9,7 @@ import { configWorker, createMessageEventWithData, emptyContext, iGotDistractedB
 import { timedPromise } from 'keyman/common/web-utils';
 
 import { LMLayerWorker } from '@keymanapp/lm-worker/test-index';
-import { OutgoingMessage } from '@keymanapp/lm-message-types';
+import { OutgoingMessage, SuggestionMessage } from '@keymanapp/lm-message-types';
 
 import Suggestion = LexicalModelTypes.Suggestion;
 
@@ -73,11 +74,13 @@ describe('LMLayerWorker', function () {
       // Retrieve the internal 'dummy' suggestions for comparison.
       var hazel = iGotDistractedByHazel();
 
-      sinon.assert.calledWithMatch(fakePostMessage.lastCall, {
-        message: 'suggestions',
-        token: token,
-        suggestions: hazel[0]
-      });
+      assert.isOk(fakePostMessage);
+
+      const lastCallParameters: SuggestionMessage = fakePostMessage.lastCall.args[0] as unknown as SuggestionMessage;
+
+      assert.equal(lastCallParameters.message, 'suggestions');
+      assert.equal(lastCallParameters.token, token);
+      assert.sameDeepMembers(lastCallParameters.suggestions, hazel[0]);
     });
 
     afterEach(function () {


### PR DESCRIPTION
Relates-to: #16398.

These changes should allow autocorrect to activate a bit more frequently, better handling cases where multiple forms of a word exist within the lexicon.

In order, autocorrect now:
1. Looks for a perfect match in the lexicon.
2. Failing that, it filters for suggestions with no more total raw edits than the highest-probability suggestion
3. From there, it filters for suggestions with no extra added text than the highest-probability suggestion adds with its prediction
4. From those suggestions that remain, with the same raw edit count and "extra prediction length", it determines what proportion of the probability is represented by the best suggestion.

This probably won't fully resolve all cases we've seen - if a wordlist includes both `friends` and `friend`, with the former more likely, `friends` will likely still be taken over `friend`.

Build-bot: skip release:web,android

## User Testing

TEST_TESRING:  Using Keyman for Android, type `tesring` and validate that a suggestion is autoselected.
- We expect `testing` to be autoselected, especially if `r` is typed with a tap to its right side.
- `tearing` should be possible if the `s` is tapped to its left side _and_ the `r` is also tapped to its left side.

TEST_GIVD:  Using Keyman for Android, type `givd` and verify that `give` is autoselected.
- It should also be autoselected by `giv`, before the `d` is typed.