### PR TITLE
change(android): clean up site deep-link configuration

### DIFF
--- a/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
+++ b/android/KMAPro/kMAPro/src/main/AndroidManifest.xml
@@ -174,35 +174,14 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
 
-        <data
-          android:host="keyman-staging.com"
-          android:scheme="http"
-          android:pathPrefix="/go/package/download" />
+        <data android:host="keyman-staging.com" />
+        <data android:host="keyman.com" />
 
-        <data
-          android:host="keyman.com"
-          android:scheme="https"
-          android:pathPrefix="/go/package/download" />
+        <data android:scheme="http" />
+        <data android:scheme="https" />
 
-      </intent-filter>
-
-      <intent-filter android:priority="50">
-        <!-- KMAPro should also be able to handle /keyboards/install links and convert to /go/package/download -->
-        <action android:name="android.intent.action.VIEW" />
-
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-
-        <data
-          android:host="keyman-staging.com"
-          android:scheme="http"
-          android:pathPrefix="/keyboards/install" />
-
-        <data
-          android:host="keyman.com"
-          android:scheme="https"
-          android:pathPrefix="/keyboards/install" />
-
+        <data android:pathPrefix="/go/package/download" />
+        <data android:pathPrefix="/keyboards/install" />
       </intent-filter>
 
     </activity>


### PR DESCRIPTION
Build-bot: skip release:android

Follows up on this comment chain:  https://github.com/keymanapp/keyman/pull/16392#discussion_r3818959849

## User Testing

GROUP_API_28:  Perform these tests on devices with Android API 28 (Android 9).
GROUP_API_30:  Perform these tests on devices with Android API 30 (Android 11).
GROUP_API_33:  Perform these tests on devices with Android API 33+ (Android 13).

TEST_CHROME_SEARCH_DOWNLOAD:  With Keyman for Android installed on the test device, verify that the keyboard-search result pages' big green buttons auto-redirect to the Keyman app.

1. Navigate to keyman.com
2. Use the keyboard search (pick any language / keyboard) and select a result.
3. From that result's page, click the big green "Install Keyboard" button.
4. Verify that Keyman for Android automatically opens and attempts to install the keyboard package.