### PR TITLE
refactor(windows): cleanup unused wm_keyman_control values

### DIFF
--- a/windows/include/keymancontrol.h
+++ b/windows/include/keymancontrol.h
@@ -22,56 +22,43 @@
                     13 Oct 2014 - mcdurdin - I4451 - V9.0 - Language hotkeys are not working
 */
 
-//#define KMC_KEYBOARDCHANGED	1   // I3949
-//#define KMC_CHANGEUISTATE  	2
-//#define KMC_GETLOADED	    	3
-#define KMC_REFRESH			    4
-#define KMC_INTERFACEHOTKEY	5
+#define KMC_REFRESH			                   4
+#define KMC_INTERFACEHOTKEY                5
 
-//#define KMC_NOTIFYWELCOME       6       // 7.0.245.0
-//#define KMC_NOTIFYWELCOMEEVENT  7       // 7.0.245.0
-#define KMC_ONSCREENKEYBOARD    8       // 7.0.248.0
+#define KMC_NOTIFYWELCOME                  6       // 7.0.245.0
+#define KMC_ONSCREENKEYBOARD               8       // 7.0.248.0
 
-#define KMC_SETFOCUSINFO     9       // 7.1.270.0
-#define KMC_GETLASTFOCUS    10       // 7.1.270.0
-#define KMC_GETLASTACTIVE   11
+#define KMC_SETFOCUSINFO                   9       // 7.1.270.0
+#define KMC_GETLASTFOCUS                  10       // 7.1.270.0
+#define KMC_GETLASTACTIVE                 11
 
-#define KMC_GETLASTKEYMANID 12     // 7.1.274.0
-#define KMC_GETLASTHKL      13     // 7.1.274.0
+#define KMC_KEYDOWN                       16  // 8.0.291.0
+#define KMC_KEYUP                         17  // 8.0.291.0
 
-//#define KMC_LANGUAGESWITCH  14      // 8.0.290.0
-//#define KMC_HKLCHANGED 15    // 8.0.290.0   // I3949
+#define KMC_PROFILECHANGED                18  // 9.0.426.0   // I3933
 
-#define KMC_KEYDOWN 16  // 8.0.291.0
-#define KMC_KEYUP   17  // 8.0.291.0
+#define KMC_HINTRESPONSE                  19       // 14.0 HIWORD(wParam) = ModalResult, lParam = hint enum
 
-#define KMC_PROFILECHANGED  18  // 9.0.426.0   // I3933
+#define KMC_WATCHDOG_FAKEFREEZE           20  // 19.0 - pause Keyman for 5 seconds for debug purposes to test stability
+#define KMC_WATCHDOG_KEYEVENT             21  // 19.0 - let the LowLevelHookWatchDog know that input has happened on another thread
+#define KMC_WATCHDOG_HOOK_REINSTALL       22  // 19.0 - tell master controller about hook reinstall events
 
-#define KMC_HINTRESPONSE        19       // 14.0 HIWORD(wParam) = ModalResult, lParam = hint enum
+  // KMC_WATCHDOG_HOOK_REINSTALL event types
+  #define WHR_TIMING         0  // 19.0 - report on timing
+  #define WHR_INIT_FAILURE   1  // 19.0 - hook failed to (re)install
+  #define WHR_UNINIT_FAILURE 2  // 19.0 - hook failed to uninstall
 
-#define KMC_WATCHDOG_FAKEFREEZE       20  // 19.0 - pause Keyman for 5 seconds for debug purposes to test stability
-#define KMC_WATCHDOG_KEYEVENT         21  // 19.0 - let the LowLevelHookWatchDog know that input has happened on another thread
-#define KMC_WATCHDOG_HOOK_REINSTALL   22  // 19.0 - tell master controller about hook reinstall events
-
-// KMC_WATCHDOG_HOOK_REINSTALL event types
-#define WHR_TIMING         0  // 19.0 - report on timing
-#define WHR_INIT_FAILURE   1  // 19.0 - hook failed to (re)install
-#define WHR_UNINIT_FAILURE 2  // 19.0 - hook failed to uninstall
+// Cross-architecture comms
+#define KMC_REGISTER_HOST_WINDOW_X64      23
+#define KMC_REGISTER_HOST_WINDOW_ARM64    24
 
 
 #define PC_UPDATE 0                   // Tell Keyman to update its display of active keyboard
 #define PC_UPDATE_LANGUAGESWITCH 1    // Tell Keyman to update its display of active keyboard and then open language switch form
 #define PC_HOTKEYCHANGE 2             // Tell Keyman that a hotkey was pressed to switch keyboard
 
-//#define KMC_KEYBOARDHOTKEY  19  // 9.0.459.0   // I4326 Deprecated in favour of language hotkeys
-#define KMC_LANGUAGEHOTKEY  20
-//TOUCH  #define KMC_CONTEXT 19  // 9.0.450.0
 
-// Cross-architecture comms
-#define KMC_REGISTER_HOST_WINDOW_X64      23
-#define KMC_REGISTER_HOST_WINDOW_ARM64    24
-
-#define RWM_KEYMAN_CONTROL "WM_KEYMAN_CONTROL"
-#define RWM_KEYMAN_CONTROL_W L"WM_KEYMAN_CONTROL"
+#define RWM_KEYMAN_CONTROL     "WM_KEYMAN_CONTROL"
+#define RWM_KEYMAN_CONTROL_W   L"WM_KEYMAN_CONTROL"
 
 #define khLanguageSwitch  8

--- a/windows/src/desktop/kmshell/startup/help/UfrmTextEditor.pas
+++ b/windows/src/desktop/kmshell/startup/help/UfrmTextEditor.pas
@@ -154,8 +154,6 @@ type
     procedure WMUserFormShown(var Message: TMessage); message WM_USER_FormShown;
     procedure WMUserCheckFonts(var Message: TMessage); message WM_USER_CheckFonts;
     procedure PostKeymanControlMessage(msg, wParam: UINT; lParam: Cardinal);
-    {function SendKeymanControlMessage(msg, wParam: UINT;
-      lParam: Cardinal): Cardinal;}
     function CurrText: TTextAttributes;
     procedure GetFontNames;
     procedure SetEditRect;
@@ -347,18 +345,6 @@ begin
   if hKeymanControl <> 0 then
     PostMessage(hKeymanControl, wm_keyman_control, MAKELONG(msg, wParam), lParam);
 end;
-
-{function TfrmTextEditor.SendKeymanControlMessage(msg: UINT; wParam: UINT; lParam: Cardinal): Cardinal;
-var
-  hKeymanControl: THandle;
-begin
-  hKeymanControl := FindWindow('TApplication', 'keyman');
-  if hKeymanControl <> 0 then
-    Result := SendMessage(hKeymanControl, wm_keyman_control, MAKELONG(msg, wParam), lParam)
-  else
-    Result := 0;
-end;}
-
 
 procedure TfrmTextEditor.LoadWebBox(web: TframeCEFHost; const AdditionalData: WideString = '');   // I4181
 var

--- a/windows/src/engine/keyman/UfrmKeyman7Main.pas
+++ b/windows/src/engine/keyman/UfrmKeyman7Main.pas
@@ -221,8 +221,6 @@ type
     FLangSwitchRefreshWatcher: TThread;
     FLastFocus: THandle;
     FLastActive: THandle;
-    //FLastKeymanID: Integer;
-    FLastHKL: Integer;
     FLangSwitchManager: TLangSwitchManager;   // I3933
     FGlobalKeyboardChangeManager: TGlobalKeyboardChangeManager;   // I4271
     FActiveHKL: Integer;
@@ -348,7 +346,7 @@ var
   frmKeyman7Main: TfrmKeyman7Main;
   hProgramMutex: THandle;
 
-  wm_keyman_globalswitch, wm_keyman_globalswitch_process, wm_keyman_control, wm_keyman_control_internal, wm_test_keyman_functioning: Cardinal;
+  wm_keyman_control, wm_keyman_control_internal, wm_test_keyman_functioning: Cardinal;
 
   FEnableCrashTest: Boolean = False;
   wm_keyman_refresh: Cardinal;
@@ -510,9 +508,6 @@ begin
   frmKeymanMenu := TfrmKeymanMenu.Create(Self);
 
   FLangSwitchManager := TLangSwitchManager.Create;   // I3933
-
-  //FLastKeymanID := -1;
-  FLastHKL := GetKeyboardLayout(0);
 
   try
     GetDebugManager(Handle);
@@ -722,17 +717,6 @@ begin
       frmVisualKeyboard.Dispatch(Message);
     Result := False;
   end
-  else if Message.Msg = wm_keyman_globalswitch then
-  begin
-    TDebugLogClient.Instance.WriteMessage('wm_keyman_globalswitch for Application Handle: %x %x', [Message.wParam, Message.lParam]);
-
-    case Message.wParam of
-      skHKL,      // A windows language has been selected so select the most appropriate Keyman keyboard
-      skSelectHKL: // Select the requested Windows language (and therefore the most appropriate Keyman keyboard)
-        FLastHKL := Message.lParam;
-    end;
-    Result := True;
-  end
   else if Message.Msg = wm_keyman_refresh then
   begin
     if Message.WParam = KR_PRE_REFRESH then
@@ -797,10 +781,6 @@ begin
   Result := 0;
 
   case Command of
-    KMC_GETLASTHKL:
-      begin
-        Result := FLastHKL;
-      end;
 
     KMC_SETFOCUSINFO:
       begin
@@ -817,10 +797,6 @@ begin
         if LParam <> 0
           then ShowVisualKeyboard
           else HideVisualKeyboard;
-      end;
-    KMC_GETLOADED:
-      begin
-        if IsProductLoaded then Result := 1 else Result := 0;
       end;
     KMC_REFRESH:
       begin
@@ -2133,14 +2109,10 @@ end;
 
 initialization
   wm_test_keyman_functioning := RegisterWindowMessage('wm_test_keyman_functioning');
-  wm_keyman_globalswitch := RegisterWindowMessage('WM_KEYMAN_GLOBALSWITCH');
-  wm_keyman_globalswitch_process := RegisterWindowMessage('WM_KEYMAN_GLOBALSWITCH_PROCESS');
   wm_keyman_control := RegisterWindowMessage('WM_KEYMAN_CONTROL');
   wm_keyman_control_internal := RegisterWindowMessage('WM_KEYMAN_CONTROL_INTERNAL');   // I3933
   wm_keyman_refresh := RegisterWindowMessage('WM_KEYMANREFRESH');
 
   ChangeWindowMessageFilter(wm_keyman_control, MSGFLT_ADD);
-  ChangeWindowMessageFilter(wm_keyman_globalswitch, MSGFLT_ADD);
-  ChangeWindowMessageFilter(wm_keyman_globalswitch_process, MSGFLT_ADD);
   ChangeWindowMessageFilter(wm_keyman_control_internal, MSGFLT_ADD);   // I3933
 end.

--- a/windows/src/global/delphi/general/KeymanControlMessages.pas
+++ b/windows/src/global/delphi/general/KeymanControlMessages.pas
@@ -27,25 +27,25 @@ unit KeymanControlMessages;
 interface
 
 const
-  //KMC_KEYBOARDCHANGED = 1;   // I3949
-  //KMC_CHANGEUISTATE = 2;
-  KMC_GETLOADED = 3;
   KMC_REFRESH = 4;
   KMC_INTERFACEHOTKEY = 5;
 
   KMC_NOTIFYWELCOME = 6;
-  KMC_NOTIFYWELCOME_EVENT = 7;    // From Keyman to welcome window
+
+    // KMC_NOTIFYWELCOME commands
+    NW_NOTIFYHANDLE = 0;
+    NW_SENDBALLOON = 1;
+
+    // NW_SENDBALLOON options
+    NWB_IDENTIFYICON = 0;
+    NWB_TUTORIALFINISHED = 1;
+    NWB_KEYMANRUNNING = 2;
 
   KMC_ONSCREENKEYBOARD = 8;   // 7.0.248.0
 
   KMC_SETFOCUSINFO = 9; // 7.1.270.0
   KMC_GETLASTFOCUS = 10; // 7.1.270.0
   KMC_GETLASTACTIVE = 11; // 7.1.270.0
-
-  KMC_GETLASTKEYMANID = 12; // 7.1.274.0
-  KMC_GETLASTHKL = 13; // 7.1.274.0
-
-  //KMC_HKLCHANGED = 15; // 8.0.290.0   // I3949
 
   KMC_KEYDOWN = 16;
   KMC_KEYUP = 17;
@@ -58,10 +58,10 @@ const
   KMC_WATCHDOG_KEYEVENT         = 21; // 19.0 - let the LowLevelHookWatchDog know that input has happened on another thread
   KMC_WATCHDOG_HOOK_REINSTALL   = 22; // 19.0 - tell master controller about hook reinstall events
 
-  // KMC_WATCHDOG_HOOK_REINSTALL event types
-  WHR_TIMING         = 0;  // 19.0 - report on timing
-  WHR_INIT_FAILURE   = 1;  // 19.0 - hook failed to (re)install
-  WHR_UNINIT_FAILURE = 2;  // 19.0 - hook failed to uninstall
+    // KMC_WATCHDOG_HOOK_REINSTALL event types
+    WHR_TIMING         = 0;  // 19.0 - report on timing
+    WHR_INIT_FAILURE   = 1;  // 19.0 - hook failed to (re)install
+    WHR_UNINIT_FAILURE = 2;  // 19.0 - hook failed to uninstall
 
   KMC_REGISTER_HOST_WINDOW_X64   = 23;
   KMC_REGISTER_HOST_WINDOW_ARM64 = 24;
@@ -69,25 +69,6 @@ const
   PC_UPDATE = 0;
   PC_UPDATE_LANGUAGESWITCH = 1;
   PC_HOTKEYCHANGE = 2;
-
-  // KMC_KEYBOARDHOTKEY = 19;  // 9.0.459.0   // I4326 Deprecated in favour of language hotkeys
-  //KMC_LANGUAGEHOTKEY = 20;
-
-//TOUCH    KMC_CONTEXT = 19;
-
-  // KMC_NOTIFYWELCOME commands
-  NW_NOTIFYHANDLE = 0;
-  NW_SENDBALLOON = 1;
-
-  // NW_SENDBALLOON options
-  NWB_IDENTIFYICON = 0;
-  NWB_TUTORIALFINISHED = 1;
-  NWB_KEYMANRUNNING = 2;
-
-  // KMC_NOTIFYWELCOME_EVENT events
-  NWE_ICONCLICKED = 0;
-  NWE_MENUOPENED = 1;
-  NWE_MENUCLOSED = 2;
 
 implementation
 


### PR DESCRIPTION
Cleanup of unused `wm_keyman_control` and `wm_keyman_refresh` values, and some other unused messages, which were making the implementation harder to understand.

Relates-to: #15333
Follows: #16435
Test-bot: skip