### PR TITLE
chore(android): upload webview source map during android and ios build

### DIFF
--- a/android/KMEA/build.sh
+++ b/android/KMEA/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${THIS_SCRIPT%/*}/../../resources/build/builder-full.inc.sh"
 ## END STANDARD BUILD SCRIPT INCLUDE
 
+. "${KEYMAN_ROOT}/resources/build/ci/sentry-control.inc.sh"
 
 # ################################ Main script ################################
 
@@ -19,6 +20,7 @@ builder_describe "Builds Keyman Engine for Android." \
   "configure" \
   "build" \
   "test             Runs lint and unit tests." \
+  "publish-symbols  Publishes symbols to Sentry." \
   ":engine          Builds Engine"
 
 builder_parse "$@"
@@ -79,6 +81,13 @@ do_test() {
   ./gradlew $GRADLE_DAEMON $TEST_FLAGS
 }
 
-builder_run_action clean:engine    rm -rf build app/build
-builder_run_action build:engine    do_build
-builder_run_action test:engine     do_test
+do_publish_symbols() {
+  if builder_is_ci_build && builder_is_ci_build_level_release; then
+    sentry_upload_web "${KEYMAN_ROOT}/web/build/app/webview/release/"
+  fi
+}
+
+builder_run_action clean:engine     rm -rf build app/build
+builder_run_action build:engine     do_build
+builder_run_action test:engine      do_test
+builder_run_action publish-symbols  do_publish_symbols

--- a/ios/build.sh
+++ b/ios/build.sh
@@ -32,6 +32,7 @@ builder_describe "Builds Keyman Engine and the Keyman app for use on iOS devices
   "configure" \
   "build" \
   "test" \
+  "publish-symbols              Publishes symbols to Sentry" \
   ":engine                      Builds KeymanEngine.xcframework, usable by our main app and by third-party apps" \
   ":app=keyman                  Builds the Keyman app for iOS platforms" \
   ":help                        Online documentation" \
@@ -50,3 +51,4 @@ function do_test_help() {
 }
 
 builder_run_action        test:help    do_test_help
+builder_run_child_actions publish-symbols

--- a/ios/engine/build.sh
+++ b/ios/engine/build.sh
@@ -9,6 +9,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "$KEYMAN_ROOT/resources/build/utils.inc.sh"
 . "$KEYMAN_ROOT/resources/build/mac/mac.inc.sh"
 . "$KEYMAN_ROOT/resources/build/build-download-resources.sh"
+. "${KEYMAN_ROOT}/resources/build/ci/sentry-control.inc.sh"
 
 builder_describe "Builds Keyman Engine for use on iOS devices - iPhone and iPad." \
   "@/web/src/app/webview        build" \
@@ -16,7 +17,8 @@ builder_describe "Builds Keyman Engine for use on iOS devices - iPhone and iPad.
   "clean" \
   "configure" \
   "build" \
-  "--sim-artifact  Also outputs a simulator-friendly test artifact corresponding to the build"
+  "publish-symbols  Publishes symbols to Sentry." \
+  "--sim-artifact   Also outputs a simulator-friendly test artifact corresponding to the build"
 
 builder_parse "$@"
 
@@ -138,6 +140,13 @@ function build_engine() {
   fi
 }
 
-builder_run_action clean         do_clean
-builder_run_action configure     do_configure
-builder_run_action build         build_engine
+do_publish_symbols() {
+  if builder_is_ci_build && builder_is_ci_build_level_release; then
+    sentry_upload_web "${KEYMAN_ROOT}/web/build/app/webview/release/"
+  fi
+}
+
+builder_run_action clean            do_clean
+builder_run_action configure        do_configure
+builder_run_action build            build_engine
+builder_run_action publish-symbols  do_publish_symbols

--- a/resources/build/ci/sentry-control.inc.sh
+++ b/resources/build/ci/sentry-control.inc.sh
@@ -40,3 +40,17 @@ function makeSentryRelease() {
   fi
 }
 
+function sentry_upload_web () {
+  if ! isSentryConfigured; then
+    echo "Skipping Sentry upload: SENTRY_ORG and/or SENTRY_PROJECT are unset."
+    return
+  fi
+
+  echo "Uploading $1 to Sentry..."
+
+  # --strip-common-prefix does not take an argument, unlike --strip-prefix.  It auto-detects
+  # the most common prefix instead.
+  sentry-cli releases files "${KEYMAN_VERSION_GIT_TAG}" upload-sourcemaps --strip-common-prefix "$1" \
+    --rewrite --ext js --ext map --ext ts
+  echo "Upload successful."
+}

--- a/resources/build/ci/sentry-control.inc.sh
+++ b/resources/build/ci/sentry-control.inc.sh
@@ -12,7 +12,7 @@
 
 function isSentryConfigured() {
   if [ -z "${SENTRY_AUTH_TOKEN-}" ] || [ -z "${SENTRY_ORG-}" ] || [ -z "${SENTRY_URL-}" ]; then
-    echo "WARNING: Sentry environment variables SENTRY_AUTH_TOKEN, SENTRY_ORG and SENTRY_URL must be configured."
+    builder_warn "WARNING: Sentry environment variables SENTRY_AUTH_TOKEN, SENTRY_ORG and SENTRY_URL must be configured."
     return 1
   fi
   return 0
@@ -20,7 +20,7 @@ function isSentryConfigured() {
 
 function isSentryCliAvailable() {
   which sentry-cli > /dev/null && return 0
-  echo "WARNING: sentry-cli could not be found. Skipping all sentry integration."
+  builder_warn "WARNING: sentry-cli could not be found. Skipping all sentry integration."
   return 1
 }
 
@@ -28,29 +28,35 @@ function makeSentryRelease() {
   if isSentryConfigured; then
     if isSentryCliAvailable; then
       # This version tag matches the repository version tag release@x.y.z
-      echo "Making a Sentry release for tag $KEYMAN_VERSION_GIT_TAG"
+      builder_echo "Making a Sentry release for tag $KEYMAN_VERSION_GIT_TAG"
       sentry-cli releases new -p keyman-android -p keyman-developer -p keyman-ios -p keyman-linux -p keyman-mac -p keyman-web -p keyman-windows $KEYMAN_VERSION_GIT_TAG
 
-      echo "Setting commits for release tag $KEYMAN_VERSION_GIT_TAG"
+      builder_echo "Setting commits for release tag $KEYMAN_VERSION_GIT_TAG"
       sentry-cli releases set-commits --auto $KEYMAN_VERSION_GIT_TAG
 
-      echo "Finalizing release tag $KEYMAN_VERSION_GIT_TAG"
+      builder_echo "Finalizing release tag $KEYMAN_VERSION_GIT_TAG"
       sentry-cli releases finalize "$KEYMAN_VERSION_GIT_TAG"
     fi
   fi
 }
 
+#
+# Upload sourcemaps to Sentry
+#
+# Parameters:
+#   1: Directory containing sourcemaps to upload
+#
 function sentry_upload_web () {
+  local SOURCEMAP_DIR="$1"
   if ! isSentryConfigured; then
-    echo "Skipping Sentry upload: SENTRY_ORG and/or SENTRY_PROJECT are unset."
+    builder_warn "Skipping Sentry upload: SENTRY_ORG and/or SENTRY_PROJECT are unset."
     return
   fi
 
-  echo "Uploading $1 to Sentry..."
+  builder_echo "Uploading ${SOURCEMAP_DIR} to Sentry..."
 
-  # --strip-common-prefix does not take an argument, unlike --strip-prefix.  It auto-detects
-  # the most common prefix instead.
-  sentry-cli releases files "${KEYMAN_VERSION_GIT_TAG}" upload-sourcemaps --strip-common-prefix "$1" \
-    --rewrite --ext js --ext map --ext ts
-  echo "Upload successful."
+  sentry-cli releases files "${KEYMAN_VERSION_GIT_TAG}" upload-sourcemaps --strip-common-prefix \
+    "${SOURCEMAP_DIR}" --rewrite --ext js --ext map --ext ts
+
+  builder_echo "Upload successful."
 }

--- a/resources/teamcity/ios/ios-actions.inc.sh
+++ b/resources/teamcity/ios/ios-actions.inc.sh
@@ -3,21 +3,18 @@
 
 ios_build() {
   builder_echo start "build" "Building KeymanEngine + Keyman for iOS"
-  # shellcheck disable=SC2154
-  "${KEYMAN_ROOT}/ios/ci.sh" build
+  builder_launch /ios/ci.sh build
   builder_echo end "build" success "Finished building KeymanEngine + Keyman for iOS"
 }
 
 ios_capture_build_artifacts() {
   builder_echo start "prep-release" "Using prep-release script to capture build artifacts"
-  "${KEYMAN_ROOT}/ios/tools/prepRelease.sh"
+  builder_launch /ios/tools/prepRelease.sh
   builder_echo end "prep-release" success "Finished capturing build artifacts"
 }
 
 ios_publish_symbols() {
   builder_echo start "publish to Sentry" "Publishing source map to Sentry"
-
   builder_launch /ios/build.sh "publish-symbols"
-
   builder_echo end "publish to Sentry" success "Finished publishing source map to Sentry"
 }

--- a/resources/teamcity/ios/ios-actions.inc.sh
+++ b/resources/teamcity/ios/ios-actions.inc.sh
@@ -13,3 +13,11 @@ ios_capture_build_artifacts() {
   "${KEYMAN_ROOT}/ios/tools/prepRelease.sh"
   builder_echo end "prep-release" success "Finished capturing build artifacts"
 }
+
+ios_publish_symbols() {
+  builder_echo start "publish to Sentry" "Publishing source map to Sentry"
+
+  builder_launch /ios/build.sh "publish-symbols"
+
+  builder_echo end "publish to Sentry" success "Finished publishing source map to Sentry"
+}

--- a/resources/teamcity/ios/keyman-ios-release.sh
+++ b/resources/teamcity/ios/keyman-ios-release.sh
@@ -243,6 +243,7 @@ function do_build() {
 
 function do_publish() {
   _publish_to_downloads_keyman_com
+  ios_publish_symbols
   tc_upload_help "Keyman for iOS" ios
 
   if [[ "${KEYMAN_TIER}" == "stable" ]]; then

--- a/web/ci.sh
+++ b/web/ci.sh
@@ -15,6 +15,7 @@ THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 . "${KEYMAN_ROOT}/resources/build/utils.inc.sh"
 . "${KEYMAN_ROOT}/resources/build/zip.inc.sh"
 . "${KEYMAN_ROOT}/resources/build/ci/pull-requests.inc.sh"
+. "${KEYMAN_ROOT}/resources/build/ci/sentry-control.inc.sh"
 
 # This script runs from its own folder
 cd "${THIS_SCRIPT_PATH}"
@@ -42,21 +43,6 @@ builder_parse "$@"
 KEYMAN_TIER=$(cat ../TIER.md)
 BUILD_NUMBER=$(cat ../VERSION.md)
 
-function web_sentry_upload () {
-  if [[ -z "${SENTRY_ORG:-}" ]] || [[ -z "${SENTRY_PROJECT:-}" ]]; then
-    echo "Skipping Sentry upload: SENTRY_ORG and/or SENTRY_PROJECT are unset."
-    return
-  fi
-
-  echo "Uploading $1 to Sentry..."
-
-  # --strip-common-prefix does not take an argument, unlike --strip-prefix.  It auto-detects
-  # the most common prefix instead.
-  sentry-cli releases files "${KEYMAN_VERSION_GIT_TAG}" upload-sourcemaps --strip-common-prefix "$1" \
-    --rewrite --ext js --ext map --ext ts
-  echo "Upload successful."
-}
-
 function build_action() {
   # Build step:  since CI builds start (and should start) from scratch, run the following
   # three actions:
@@ -73,11 +59,10 @@ function build_action() {
     for sourcemap in "${KEYMAN_ROOT}/common/web/sentry-manager/build/lib/"*.map; do
       node "${KEYMAN_ROOT}/web/build/tools/building/sourcemap-root/index.js" null "${sourcemap}" --clean
     done
-    web_sentry_upload "${KEYMAN_ROOT}/common/web/sentry-manager/build/lib/"
+    sentry_upload_web "${KEYMAN_ROOT}/common/web/sentry-manager/build/lib/"
 
     # And, of course, the main build-products too
-    web_sentry_upload "${KEYMAN_ROOT}/web/build/app/webview/release/"
-    web_sentry_upload "${KEYMAN_ROOT}/web/build/publish/release/"
+    sentry_upload_web "${KEYMAN_ROOT}/web/build/publish/release/"
   fi
 }
 


### PR DESCRIPTION
Previously we uploaded the webview source map during a web build. This can lead to problems because that is not the actual artifact used for Android and iOS.

This change therefore moves uploading the webview source map to Sentry to the android and ios builds.

Build-bot: skip release:web,android,ios
Test-bot: skip