### PR TITLE
fix(developer): validate the number of hardware layers only in Layr compiler

### DIFF
--- a/developer/src/kmc-ldml/src/compiler/keys.ts
+++ b/developer/src/kmc-ldml/src/compiler/keys.ts
@@ -225,13 +225,9 @@ export class KeysCompiler extends SectionCompiler {
     // Finally, kmap
     // Use LayerMap + keys to generate compiled keys for hardware
     const hardwareLayers = this.hardwareLayers();
-    /* c8 ignore next 3 */
-    if (hardwareLayers.length > 1) {
-      // validation should have already caught this
-      throw Error(
-        `Internal error: Expected 0 or 1 hardware layer, not ${hardwareLayers.length}`
-      );
-    } else if (hardwareLayers.length === 1) {
+    if (hardwareLayers.length >= 1) {
+      // Only 1 hardware layer is supported; however, `LayrCompiler` will report
+      // on this error, so we can just process the first one here
       const theLayers = hardwareLayers[0];
       const { formId } = theLayers;
       for (const layer of theLayers.layer) {

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/invalid-bad-modifier.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/invalid-bad-modifier.xml
@@ -6,7 +6,7 @@
   <keys />
 
   <layers formId="us">
-    <layer id="base" modifiers="altR-shift"> <!-- invalid, should be "altR shift" -->
+    <layer modifiers="altR-shift"> <!-- invalid, should be "altR shift" -->
       <row keys="a b c" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/keys.tests.ts
+++ b/developer/src/kmc-ldml/test/keys.tests.ts
@@ -310,12 +310,6 @@ describe('keys.kmap', function () {
       },
     },
     {
-      subpath: 'sections/keys/invalid-bad-modifier.xml',
-      errors: [
-        LdmlCompilerMessages.Error_InvalidModifier({ modifiers: 'altR-shift' }),
-      ]
-    },
-    {
       subpath: 'sections/keys/invalid-missing-flick.xml',
       errors: [
         LdmlCompilerMessages.Error_MissingFlicks({flickId:'an-undefined-flick-id',id:'Q'}),

--- a/developer/src/kmc-ldml/test/layr.tests.ts
+++ b/developer/src/kmc-ldml/test/layr.tests.ts
@@ -94,7 +94,7 @@ describe('layr', function () {
       errors: [],
     },
     {
-      subpath: 'sections/keys/invalid-bad-modifier.xml',
+      subpath: 'sections/layr/invalid-bad-modifier.xml',
       errors: [
         LdmlCompilerMessages.Error_InvalidModifier({
           modifiers: 'altR-shift',


### PR DESCRIPTION
`KeysCompiler` runs before `LayrCompiler` so this verification needs to defer rather than throw. We can assume that the `LayrCompiler` will catch it.

Fixes: KEYMAN-DEVELOPER-3XD
Fixes: #16454
Test-bot: skip