### PR TITLE
fix(developer): validate id and modifiers attributes in Layr compiler

### DIFF
--- a/core/tests/unit/ldml/invalid-keyboards/ik_001_bad_key.xml
+++ b/core/tests/unit/ldml/invalid-keyboards/ik_001_bad_key.xml
@@ -14,7 +14,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="a" /> <!-- number row -->
     </layer>
   </layers>

--- a/core/tests/unit/ldml/keyboards/k_000_minimal_keyboard.xml
+++ b/core/tests/unit/ldml/keyboards/k_000_minimal_keyboard.xml
@@ -15,7 +15,7 @@ Keys that don't show up in a row don't generate an output
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="1" />
       <row keys="q" />
     </layer>

--- a/core/tests/unit/ldml/keyboards/k_001_tiny.xml
+++ b/core/tests/unit/ldml/keyboards/k_001_tiny.xml
@@ -17,7 +17,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="hmaqtugha that" /> <!-- number row -->
     </layer>
   </layers>

--- a/core/tests/unit/ldml/keyboards/k_002_tinyu32.xml
+++ b/core/tests/unit/ldml/keyboards/k_002_tinyu32.xml
@@ -16,7 +16,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="hmaqtugha that screamcat" /> <!-- number row -->
     </layer>
   </layers>

--- a/core/tests/unit/ldml/keyboards/k_003_transform.xml
+++ b/core/tests/unit/ldml/keyboards/k_003_transform.xml
@@ -18,14 +18,14 @@ from https://github.com/unicode-org/cldr/blob/keyboard-preview/docs/ldml/tr35-ke
   </keys>
 
   <layers formId="us">
-    <layer modifiers="none" id="base">
+    <layer modifiers="none">
       <row keys="hat 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
       <row keys="q w e r t y u i o p" />
       <row keys="a s d f g h j k l" />
       <row keys="z x c v b n m" />
       <row keys="space" />
     </layer>
-    <layer modifiers="shift" id="shift">
+    <layer modifiers="shift">
       <row keys="untransformed-hat 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
       <row keys="Q W E R T Y U I O P" />
       <row keys="A S D F G H J K L" />

--- a/core/tests/unit/ldml/keyboards/k_004_tinyshift.xml
+++ b/core/tests/unit/ldml/keyboards/k_004_tinyshift.xml
@@ -18,16 +18,16 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base" modifiers="none">
+    <layer modifiers="none">
       <row keys="hmaqtugha that" /> <!-- number row -->
     </layer>
-    <layer id="shift" modifiers="shift">
+    <layer modifiers="shift">
       <row keys="seven eee" /> <!-- number row -->
     </layer>
-    <layer id="control" modifiers="ctrl">
+    <layer modifiers="ctrl">
       <row keys="that gap" /> <!-- number row -->
     </layer>
-    <layer id="catchall" modifiers="other">
+    <layer modifiers="other">
       <row keys="eee gap" /> <!-- number row -->
     </layer>
   </layers>

--- a/core/tests/unit/ldml/keyboards/k_005_modbittest.xml
+++ b/core/tests/unit/ldml/keyboards/k_005_modbittest.xml
@@ -12,7 +12,7 @@
   <keys/> <!-- implied only -->
 
   <layers formId="us">
-    <layer id="base" modifiers="none">
+    <layer modifiers="none">
       <row keys="a" /> <!-- K_BKQUOTE -->
     </layer>
     <layer modifiers="shift">

--- a/core/tests/unit/ldml/keyboards/k_006_backspace.xml
+++ b/core/tests/unit/ldml/keyboards/k_006_backspace.xml
@@ -11,14 +11,14 @@
   </keys>
 
   <layers formId="us">
-    <layer modifiers="none" id="base">
+    <layer modifiers="none">
       <row keys="hat 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
       <row keys="q w e r t y u i o p" />
       <row keys="a s d f g h j k l" />
       <row keys="z x c v b n m" />
       <row keys="space" />
     </layer>
-    <layer modifiers="shift" id="shift">
+    <layer modifiers="shift">
       <row keys="untransformed-hat 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
       <row keys="Q W E R T Y U I O P" />
       <row keys="A S D F G H J K L" />

--- a/core/tests/unit/ldml/keyboards/k_007_transform_rgx.xml
+++ b/core/tests/unit/ldml/keyboards/k_007_transform_rgx.xml
@@ -18,14 +18,14 @@ from https://github.com/unicode-org/cldr/blob/keyboard-preview/docs/ldml/tr35-ke
   </keys>
 
   <layers formId="us">
-    <layer modifiers="none" id="base">
+    <layer modifiers="none">
       <row keys="grave 1 2 3 4 5 6 7 8 9 0" />
       <row keys="q w e r t y u i o p" />
       <row keys="a s d f g h j k l" />
       <row keys="z x c v b n m" />
       <row keys="space" />
     </layer>
-    <layer modifiers="shift" id="shift">
+    <layer modifiers="shift">
       <row keys="grave 1 2 3 4 5 6 7 8 9 0" />
       <row keys="Q W E R T Y U I O P" />
       <row keys="A S D F G H J K L" />

--- a/core/tests/unit/ldml/keyboards/k_008_transform_norm.xml
+++ b/core/tests/unit/ldml/keyboards/k_008_transform_norm.xml
@@ -21,14 +21,14 @@ https://github.com/unicode-org/cldr/blob/keyboard-preview/docs/ldml/tr35-keyboar
   </keys>
 
   <layers formId="us">
-    <layer modifiers="none" id="base">
+    <layer modifiers="none">
       <row keys="u-0320 1 2 3 4 5 6 7 8 9 0" />
       <row keys="q w e r t y u i o p" />
       <row keys="a s d f g h j k l" />
       <row keys="z x c v b n m" />
       <row keys="space" />
     </layer>
-    <layer modifiers="shift" id="shift">
+    <layer modifiers="shift">
       <row keys="u-0300 u-00e8 nfd nfc not-nfd stampy lgtm u-0344" />
     </layer>
   </layers>

--- a/core/tests/unit/ldml/keyboards/k_009_transform_nfc.xml
+++ b/core/tests/unit/ldml/keyboards/k_009_transform_nfc.xml
@@ -21,14 +21,14 @@ like k_008 but in NFC (and other normalizations)
   </keys>
 
   <layers formId="us">
-    <layer modifiers="none" id="base">
+    <layer modifiers="none">
       <row keys="u-0320 1 2 3 4 5 6 7 8 9 0" />
       <row keys="q w e r t y u i o p" />
       <row keys="a s d f g h j k l" />
       <row keys="z x c v b n m" />
       <row keys="space" />
     </layer>
-    <layer modifiers="shift" id="shift">
+    <layer modifiers="shift">
       <row keys="u-0300 u-00e8 nfd nfc not-nfd stampy lgtm u-0344" />
     </layer>
   </layers>

--- a/core/tests/unit/ldml/keyboards/k_012_other.xml
+++ b/core/tests/unit/ldml/keyboards/k_012_other.xml
@@ -14,13 +14,13 @@ will match the default layer
   <keys/>
 
   <layers formId="us">
-    <layer id="base" modifiers="none">
+    <layer modifiers="none">
       <row keys="b" /> <!-- number row -->
     </layer>
-    <layer id="shift" modifiers="shift">
+    <layer modifiers="shift">
       <row keys="s" /> <!-- number row -->
     </layer>
-    <layer id="other" modifiers="other">
+    <layer modifiers="other">
       <row keys="d" /> <!-- number row -->
     </layer>
   </layers>

--- a/core/tests/unit/ldml/keyboards/k_100_keytest.xml
+++ b/core/tests/unit/ldml/keyboards/k_100_keytest.xml
@@ -14,7 +14,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="a gap"/>
     </layer>
   </layers>

--- a/core/tests/unit/ldml/keyboards/k_101_keytest.xml
+++ b/core/tests/unit/ldml/keyboards/k_101_keytest.xml
@@ -17,7 +17,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="a" /> <!-- number row -->
     </layer>
   </layers>

--- a/core/tests/unit/ldml/keyboards/k_102_keytest.xml
+++ b/core/tests/unit/ldml/keyboards/k_102_keytest.xml
@@ -33,7 +33,7 @@ Comment:     enter=not mappable, causes ctx reset.
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="a gap" /> <!-- number row -->
       <row keys="q gap" /> <!-- q w ... -->
       <row keys="gap" />

--- a/core/tests/unit/ldml/keyboards/k_200_reorder_nod_Lana.xml
+++ b/core/tests/unit/ldml/keyboards/k_200_reorder_nod_Lana.xml
@@ -21,7 +21,7 @@
   </keys>
 
   <layers formId="us">
-    <layer modifiers="none" id="base">
+    <layer modifiers="none">
       <row keys="roast" />
       <row keys="gap wa gap gap t2 gap gap gap o gap" />
       <row keys="gap sakot gap gap gap gap gap kha gap" />

--- a/core/tests/unit/ldml/keyboards/k_201_reorder_esk.xml
+++ b/core/tests/unit/ldml/keyboards/k_201_reorder_esk.xml
@@ -20,7 +20,7 @@
   </keys>
 
   <layers formId="us">
-    <layer modifiers="none" id="base">
+    <layer modifiers="none">
       <row keys="gap overbar underbar circumflex" />
       <row keys="gap gap e gap gap y u i o gap" />
       <row keys="a" />

--- a/core/tests/unit/ldml/keyboards/k_210_marker.xml
+++ b/core/tests/unit/ldml/keyboards/k_210_marker.xml
@@ -21,7 +21,7 @@
   </keys>
 
   <layers formId="us">
-    <layer modifiers="none" id="base">
+    <layer modifiers="none">
       <row keys="grave acute caret hacek squiggle" />
       <row keys="q w e" /> <!-- etc -->
       <row keys="a s d" /> <!-- etc -->

--- a/core/tests/unit/ldml/keyboards/k_211_marker_escape.xml
+++ b/core/tests/unit/ldml/keyboards/k_211_marker_escape.xml
@@ -18,7 +18,7 @@
   </keys>
 
   <layers formId="us">
-    <layer modifiers="none" id="base">
+    <layer modifiers="none">
       <row keys="B 1 2 3" />
       <row keys="q w e" /> <!-- etc -->
       <row keys="a s d" /> <!-- etc -->

--- a/core/tests/unit/ldml/keyboards/k_212_marker_11057.xml
+++ b/core/tests/unit/ldml/keyboards/k_212_marker_11057.xml
@@ -8,7 +8,7 @@
   </keys>
 
   <layers formId="us">
-    <layer modifiers="none" id="base">
+    <layer modifiers="none">
       <row keys="caret umlaut" />
       <row keys="q w e r t y" />
       <row keys="a" />

--- a/developer/src/common/web/utils/test/fixtures/xml/strs_invalid-illegal.xml
+++ b/developer/src/common/web/utils/test/fixtures/xml/strs_invalid-illegal.xml
@@ -21,7 +21,7 @@
     <key id="that" output="&#xFFFF;" /> <!-- illegal NCR (single char)-->
   </keys>
 
-  <layers formId="us" minDeviceWidth="123">
+  <layers formId="touch" minDeviceWidth="123">
     <layer id="&#xFFFE;">
       <row keys="hmaqtugha that" />
     </layer>

--- a/developer/src/common/web/utils/test/fixtures/xml/strs_invalid-illegal.xml.json
+++ b/developer/src/common/web/utils/test/fixtures/xml/strs_invalid-illegal.xml.json
@@ -41,7 +41,7 @@
    ]
   },
   "layers": {
-   "formId": "us",
+   "formId": "touch",
    "minDeviceWidth": "123",
    "layer": {
     "id": "￾",

--- a/developer/src/kmc-ldml/build.sh
+++ b/developer/src/kmc-ldml/build.sh
@@ -86,4 +86,4 @@ builder_run_action configure       do_configure
 builder_run_action build           do_build
 builder_run_action build-fixtures  do_build_fixtures
 builder_run_action api             typescript_run_api_extractor developer/src/kmc-ldml main.d.ts
-builder_run_action test            typescript_run_eslint_mocha_tests  90
+builder_run_action test            typescript_run_eslint_mocha_tests

--- a/developer/src/kmc-ldml/src/compiler/keys.ts
+++ b/developer/src/kmc-ldml/src/compiler/keys.ts
@@ -9,7 +9,7 @@ import Keys = KMXPlus.Keys;
 import KeysKeys = KMXPlus.KeysKeys;
 import ListItem = KMXPlus.ListItem;
 import KeysFlicks = KMXPlus.KeysFlicks;
-import { allUsedKeyIdsInFlick, allUsedKeyIdsInKey, allUsedKeyIdsInLayers, calculateUniqueKeys, hashFlicks, hashKeys, translateLayerAttrToModifier, validModifier } from '../util/util.js';
+import { allUsedKeyIdsInFlick, allUsedKeyIdsInKey, allUsedKeyIdsInLayers, calculateUniqueKeys, hashFlicks, hashKeys, translateLayerAttrToModifier } from '../util/util.js';
 import { SubstitutionUse, Substitutions } from './substitution-tracker.js';
 
 /** reserved name for the special gap key. space is not allowed in key ids. */
@@ -457,12 +457,6 @@ export class KeysCompiler extends SectionCompiler {
     let valid = true;
 
     const { modifiers } = layer;
-    if (!validModifier(modifiers)) {
-      this.callbacks.reportMessage(
-        LdmlCompilerMessages.Error_InvalidModifier({ modifiers }, layer)
-      );
-      valid = false;
-    }
 
     if (layer.row.length > keymap.length) {
       this.callbacks.reportMessage(
@@ -480,7 +474,7 @@ export class KeysCompiler extends SectionCompiler {
           LdmlCompilerMessages.Error_RowOnHardwareLayerHasTooManyKeys({
             row: y + 1,
             hardware: layers.formId,
-            modifiers: modifiers || 'none',
+            modifiers,
           }, row)
         );
         valid = false;
@@ -497,7 +491,7 @@ export class KeysCompiler extends SectionCompiler {
               keyId: key,
               col: x + 1,
               row: y + 1,
-              layer: layer.id,
+              layer: layer.id ?? layer.modifiers, // just to give a useful reference point in the error message
               form: "hardware",
             }, row)
           );

--- a/developer/src/kmc-ldml/src/compiler/layr.ts
+++ b/developer/src/kmc-ldml/src/compiler/layr.ts
@@ -27,6 +27,7 @@ export class LayrCompiler extends SectionCompiler {
       if (formId === 'touch') {
         touchLayers++;
         totalLayerCount += layers.layer?.length;
+        // TODO-LDML: CLDR-19754 spec does not require minDeviceWidth, but if multiple touch forms then it would be important for differentiation
         const { minDeviceWidth } = layers;
         if (!minDeviceWidth ||
           minDeviceWidth < constants.layr_min_minDeviceWidth ||
@@ -40,6 +41,17 @@ export class LayrCompiler extends SectionCompiler {
         } else {
           deviceWidths.add(minDeviceWidth);
         }
+        // For touch layers, id attr must exist, and modifiers attribute should not
+        layers.layer.forEach(layer => {
+          if(typeof layer.id === 'undefined') {
+            this.callbacks.reportMessage(LdmlCompilerMessages.Error_TouchLayerRequiresId({minDeviceWidth}, layer));
+            valid = false;
+          }
+          if(typeof layer.modifiers !== 'undefined') {
+            this.callbacks.reportMessage(LdmlCompilerMessages.Hint_TouchLayerHasModifiers({minDeviceWidth, id: layer.id}, layer));
+          }
+          totalLayerCount++;
+        });
       } else {
         // hardware
         hardwareLayers++;
@@ -47,15 +59,22 @@ export class LayrCompiler extends SectionCompiler {
           valid = false;
           this.callbacks.reportMessage(LdmlCompilerMessages.Error_ExcessHardware({formId}, layers));
         }
+        layers.layer.forEach(layer => {
+          const { modifiers } = layer;
+          if(typeof modifiers === 'undefined' || modifiers == '') {
+            this.callbacks.reportMessage(LdmlCompilerMessages.Error_HardwareLayerRequiresModifiers({ formId }, layer));
+            valid = false;
+          }
+          else if (!validModifier(modifiers)) {
+            this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidModifier({ modifiers }, layer));
+            valid = false;
+          }
+          if(typeof layer.id !== 'undefined') {
+            this.callbacks.reportMessage(LdmlCompilerMessages.Hint_HardwareLayerHasId({formId, id: layer.id}, layer));
+          }
+          totalLayerCount++;
+        });
       }
-      layers.layer.forEach((layer) => {
-        const { modifiers } = layer;
-        totalLayerCount++;
-        if (!validModifier(modifiers)) {
-          this.callbacks.reportMessage(LdmlCompilerMessages.Error_InvalidModifier({ modifiers }, layer));
-          valid = false;
-        }
-      });
     });
     if (totalLayerCount === 0) { // TODO-LDML: does not validate touch layers yet
       // no layers seen anywhere

--- a/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
+++ b/developer/src/kmc-ldml/src/compiler/ldml-compiler-messages.ts
@@ -40,7 +40,7 @@ export class LdmlCompilerMessages {
   static ERROR_KeyNotFoundInKeyBag = SevError | 0x0005;
   static Error_KeyNotFoundInKeyBag = (o: { keyId: string, col: number, row: number, layer: string, form: string }, compileContext?: ObjectWithCompileContext) => mx(
     this.ERROR_KeyNotFoundInKeyBag, compileContext,
-    `Key '${def(o.keyId)}' in position #${def(o.col)} on row #${def(o.row)} of layer ${def(o.layer)}, form '${def(o.form)}' not found in key bag`,
+    `Key '${def(o.keyId)}' in position #${def(o.col)} on row #${def(o.row)} of layer '${def(o.layer)}', form '${def(o.form)}' not found in key bag`,
   );
 
   static HINT_OneOrMoreRepeatedLocales = SevHint | 0x0006;
@@ -291,6 +291,42 @@ export class LdmlCompilerMessages {
     `Invalid escape "${def(o.cp)}"`,
     `**Hint**: Use "${def(o.recommended)}"`,
   );
+
+  static ERROR_TouchLayerRequiresId = SevError | 0x0031;
+  static Error_TouchLayerRequiresId = (o: { minDeviceWidth: number }, compileContext?: ObjectWithCompileContext) => mx(
+    this.ERROR_TouchLayerRequiresId, compileContext,
+    `Layer for touch form with minDeviceWidth=${def(o.minDeviceWidth)} requires an "id" attribute`, `
+    Touch layers must have an \`id\` attribute, but should not have a \`modifiers\`
+    attribute, and conversely, hardware layers must have a \`modifiers\` attribute
+    and should not have an \`id\` attribute.
+  `);
+
+  static HINT_TouchLayerHasModifiers = SevHint | 0x0032;
+  static Hint_TouchLayerHasModifiers = (o: { minDeviceWidth: number, id: string }, compileContext?: ObjectWithCompileContext) => mx(
+    this.HINT_TouchLayerHasModifiers, compileContext,
+    `Touch layer with id "${def(o.id)}" for touch form with minDeviceWidth=${def(o.minDeviceWidth)} should not have a "modifiers" attribute`, `
+    Touch layers must have an \`id\` attribute, but should not have a \`modifiers\`
+    attribute, and conversely, hardware layers must have a \`modifiers\` attribute
+    and should not have an \`id\` attribute.
+  `);
+
+  static HINT_HardwareLayerHasId = SevHint | 0x0033;
+  static Hint_HardwareLayerHasId = (o: { formId: string, id: string }, compileContext?: ObjectWithCompileContext) => mx(
+    this.HINT_HardwareLayerHasId, compileContext,
+    `Layer for hardware form "${def(o.formId)}" should not have an "id" attribute (currently "${def(o.id)}")`, `
+    Touch layers must have an \`id\` attribute, but should not have a \`modifiers\`
+    attribute, and conversely, hardware layers must have a \`modifiers\` attribute
+    and should not have an \`id\` attribute.
+  `);
+
+  static ERROR_HardwareLayerRequiresModifiers = SevError | 0x0034;
+  static Error_HardwareLayerRequiresModifiers = (o: { formId: string }, compileContext?: ObjectWithCompileContext) => mx(
+    this.ERROR_HardwareLayerRequiresModifiers, compileContext,
+    `Layers for hardware form "${def(o.formId)}" require a "modifiers" attribute`, `
+    Touch layers must have an \`id\` attribute, but should not have a \`modifiers\`
+    attribute, and conversely, hardware layers must have a \`modifiers\` attribute
+    and should not have an \`id\` attribute.
+  `);
 
   //
   // Transform syntax errors begin at ...F00 (SevErrorTransform)

--- a/developer/src/kmc-ldml/src/compiler/visual-keyboard-compiler.ts
+++ b/developer/src/kmc-ldml/src/compiler/visual-keyboard-compiler.ts
@@ -8,6 +8,7 @@
 import { ModifierKeyConstants, KMXPlus, VisualKeyboard } from "@keymanapp/common-types";
 import { CompilerCallbacks } from "@keymanapp/developer-utils";
 import { LdmlCompilerMessages } from "./ldml-compiler-messages.js";
+import { modifiersToString } from "../util/util.js";
 
 // This is a partial polyfill for findLast, so not polluting Array.prototype
 // https://medium.com/@stheodorejohn/findlast-method-polyfill-in-javascript-bridging-browser-gaps-c3baf6aabae1
@@ -93,7 +94,7 @@ export class LdmlKeyboardVisualKeyboardCompiler {
     layer: KMXPlus.LayrEntry,
     hardware: string,
   ) {
-    const layerId = layer.id.value;
+    const layerId = layer.id.value ?? modifiersToString(layer.mod); // used only for reference in error messages
 
     hardware = 'us'; // TODO-LDML: US Only. We need to clean this up for other hardware forms
 

--- a/developer/src/kmc-ldml/src/util/serialize.ts
+++ b/developer/src/kmc-ldml/src/util/serialize.ts
@@ -183,7 +183,7 @@ export function kmxToXml(kmx: KMXPlus.KMXPlusFile): string {
     return {
       layers: layr.lists.map(({ hardware, minDeviceWidth, layers }) => ({
         ...stringToAttr('formId', hardware),
-        ...numberToAttr('minDeviceWidth', minDeviceWidth),
+        ...numberToAttr('minDeviceWidth', minDeviceWidth === 0 ? undefined : minDeviceWidth),
         layer: layers.map(({ id, mod, rows }) => ({
           ...stringToAttr('id', id),
           ...asAttr('modifiers', modToString(mod)),

--- a/developer/src/kmc-ldml/src/util/util.ts
+++ b/developer/src/kmc-ldml/src/util/util.ts
@@ -164,6 +164,15 @@ export function translateLayerAttrToModifier(layer: LDMLKeyboard.LKLayer) : numb
   return modifiers.split(',').map(m => translateModifierSubsetToLayer(m)).sort();
 }
 
+export function modifiersToString(modifiers: number) : string {
+  if (!modifiers) return 'none';
+  const result: string[] = [];
+  for(const mod of constants.keys_mod_map) {
+    if(mod[1] != constants.keys_mod_none && modifiers & mod[1]) result.push(mod[0]);
+  }
+  return result.join(' ');
+}
+
 function translateModifierSubsetToLayer(modifiers: string) : number {
   // TODO-LDML: Default #11072
   if (modifiers) {
@@ -186,7 +195,7 @@ function translateModifierSubsetToLayer(modifiers: string) : number {
  * @returns true if valid
  */
 export function validModifier(modifier?: string) : boolean {
-  if (!modifier) return true;  // valid to have no modifier, == none
+  if (!modifier) return false;  // hardware layer must have a modifier
   // TODO-LDML: enforce illegal combinations per spec.
   for (const sub of modifier.trim().split(',')) {
     for (const str of sub.trim().split(' ')) {

--- a/developer/src/kmc-ldml/test/fixtures/basic-serialized.xml
+++ b/developer/src/kmc-ldml/test/fixtures/basic-serialized.xml
@@ -11,7 +11,7 @@
     <key id="hmaqtugha" output="ħ" longPressKeyIds="a e"/>
     <key id="that" output="ថា"/>
   </keys>
-  <layers formId="us" minDeviceWidth="123">
+  <layers formId="us">
     <layer modifiers="none">
       <row keys="hmaqtugha that"/>
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/basic.txt
+++ b/developer/src/kmc-ldml/test/fixtures/basic.txt
@@ -408,7 +408,7 @@ block(layr)                         # struct COMP_KMXPLUS_LAYR {
   index(strNull,strUs,2)            #   KMXPLUS_STR hardware = 'us'
   00 00 00 00                       #   KMX_DWORD layer;
   01 00 00 00 # count
-  7B 00 00 00                       #   KMX_DWORD minDeviceWidth; // 123
+  00 00 00 00                       #   KMX_DWORD minDeviceWidth; // 0
   # layers 0
   00 00 00 00                       #   KMXPLUS_STR id;
   00 00 00 00                       #   KMX_DWORD mod

--- a/developer/src/kmc-ldml/test/fixtures/basic.xml
+++ b/developer/src/kmc-ldml/test/fixtures/basic.xml
@@ -23,8 +23,7 @@
     <key id="that" output="ថា" />
   </keys>
 
-  <layers formId="us" minDeviceWidth="123">
-    <!-- TODO-LDML: unit test for <layers formId="us" with <layer id="base" should be illegal -->
+  <layers formId="us">
     <layer modifiers="none">
       <row keys="hmaqtugha that" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/escaped.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/escaped.xml
@@ -30,11 +30,11 @@
     </layer>
   </layers>
   <layers formId="iso">
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="Q W" />
     </layer>
-    <layer id="shift">
+    <layer modifiers="shift">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="q w" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/escaped2.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/escaped2.xml
@@ -8,7 +8,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="grave" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/gap-switch.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/gap-switch.xml
@@ -11,11 +11,11 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="Q W" />
     </layer>
-    <layer id="shift">
+    <layer modifiers="shift">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="q w" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/hardware.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/hardware.xml
@@ -11,11 +11,11 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base" modifiers="none">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="qqq www" />
     </layer>
-    <layer id="shift" modifiers="shift">
+    <layer modifiers="shift">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="QQQ WWW" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/hardware_iso.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/hardware_iso.xml
@@ -8,7 +8,7 @@
   </keys>
 
   <layers formId="iso">
-    <layer id="base" modifiers="none">
+    <layer modifiers="none">
       <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
       <row keys="q w e r t y u i o p open-square close-square" />
       <row keys="a s d f g h j k l semi-colon apos" />

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/hardware_us.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/hardware_us.xml
@@ -8,7 +8,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base" modifiers="none">
+    <layer modifiers="none">
       <row keys="grave 1 2 3 4 5 6 7 8 9 0 hyphen equal" />
       <row keys="q w e r t y u i o p open-square close-square backslash" />
       <row keys="a s d f g h j k l semi-colon apos" />

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/import-local.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/import-local.xml
@@ -8,7 +8,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="snail interrobang" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-hardware-too-many-keys.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-hardware-too-many-keys.xml
@@ -22,7 +22,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="grave one two three four five six seven eight nine ten eleven minus equal" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-hardware-too-many-rows.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-hardware-too-many-rows.xml
@@ -9,7 +9,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="Q W" />
       <row keys="Q W" />

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-key-missing-attrs.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-key-missing-attrs.xml
@@ -8,7 +8,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping `! -->
       <row keys="Q" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-missing-flick.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-missing-flick.xml
@@ -12,7 +12,7 @@
     </flick>
   </flicks>
   <layers formId="iso">
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="Q W" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-undefined-key.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-undefined-key.xml
@@ -8,7 +8,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="foo" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-undefined-var-1.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-undefined-var-1.xml
@@ -8,7 +8,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="5" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-undefined-var-1b.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/invalid-undefined-var-1b.xml
@@ -9,7 +9,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="7" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/many-modifiers.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/many-modifiers.xml
@@ -7,7 +7,7 @@
   </keys>
 
   <layers formId="iso">
-    <layer id="base" modifiers="none">
+    <layer modifiers="none">
       <row keys="a" />
     </layer>
     <layer modifiers="altR, ctrl shift">

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/markers.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/markers.xml
@@ -17,7 +17,7 @@
   </flicks>
 
   <layers formId="iso">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="ww" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/maximal-nfc.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/maximal-nfc.xml
@@ -38,11 +38,11 @@
     </layer>
   </layers>
   <layers formId="iso">
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="Q W" />
     </layer>
-    <layer id="shift" modifiers="shift">
+    <layer modifiers="shift">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="q w amarker" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/maximal.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/maximal.xml
@@ -36,11 +36,11 @@
     </layer>
   </layers>
   <layers formId="iso">
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="Q W" />
     </layer>
-    <layer id="shift" modifiers="shift">
+    <layer modifiers="shift">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="q w amarker" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/minimal.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/minimal.xml
@@ -9,7 +9,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="grave mistake" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/keys/warn-no-keycap.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/keys/warn-no-keycap.xml
@@ -20,7 +20,7 @@
   </displays>
 
   <layers formId="iso">
-    <layer id="base" modifiers="none">
+    <layer modifiers="none">
       <row keys="mark-dotbelow mark-dotabove mark-dotabovebelow mark-dotbelowabove" />
       <row keys="base rebase"/>
       <row keys="space" />

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/error-bad-width-0.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/error-bad-width-0.xml
@@ -8,7 +8,7 @@
     <key id="three" output="3" />
   </keys>
   <layers formId="iso">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="one two three" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/error-bad-width-1024.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/error-bad-width-1024.xml
@@ -8,7 +8,7 @@
     <key id="three" output="3" />
   </keys>
   <layers formId="iso">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="one two three" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/error-bad-width-1500.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/error-bad-width-1500.xml
@@ -8,7 +8,7 @@
     <key id="three" output="3" />
   </keys>
   <layers formId="iso">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="one two three" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/error-custom-us-form.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/error-custom-us-form.xml
@@ -16,7 +16,7 @@
     </form>
   </forms>
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="one two three" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/error-custom-zzz-form.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/error-custom-zzz-form.xml
@@ -16,7 +16,7 @@
     </form>
   </forms>
   <layers formId="zzz">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="one two three" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/error-dup-width.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/error-dup-width.xml
@@ -8,7 +8,7 @@
     <key id="three" output="3" />
   </keys>
   <layers formId="iso">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="one two three" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/error-hardware-layer-requires-modifiers.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/error-hardware-layer-requires-modifiers.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="und" conformsTo="45">
-  <info name="layr-error-custom-form"/>
+  <info name="error-hardware-layer-requires-modifiers"/>
   <keys>
     <key id="one" output="1" />
     <key id="two" output="2" />
     <key id="three" output="3" />
   </keys>
-  <layers formId="iso">
-    <layer modifiers="none">
+  <layers formId="us">
+    <layer> <!-- modifiers is missing -->
       <row keys="one two three" />
     </layer>
   </layers>
-  <layers formId="touch" minDeviceWidth="x">
+  <layers formId="touch" minDeviceWidth="120">
     <layer id="base">
       <row keys="one" />
       <row keys="two" />

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/error-touch-layer-requires-id.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/error-touch-layer-requires-id.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="und" conformsTo="45">
-  <info name="layr-error-custom-form"/>
+  <info name="error-touch-layer-requires-id"/>
   <keys>
     <key id="one" output="1" />
     <key id="two" output="2" />
@@ -12,8 +12,8 @@
       <row keys="one two three" />
     </layer>
   </layers>
-  <layers formId="touch" minDeviceWidth="x">
-    <layer id="base">
+  <layers formId="touch" minDeviceWidth="120">
+    <layer> <!-- id is missing -->
       <row keys="one" />
       <row keys="two" />
       <row keys="three" />

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/hint-hardware-layer-has-id.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/hint-hardware-layer-has-id.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="und" conformsTo="45">
-  <info name="layr-error-custom-form"/>
+  <info name="hint-hardware-layer-has-id"/>
   <keys>
     <key id="one" output="1" />
     <key id="two" output="2" />
     <key id="three" output="3" />
   </keys>
   <layers formId="iso">
-    <layer modifiers="none">
+    <layer modifiers="none" id="base"> <!-- hardware form should not have id -->
       <row keys="one two three" />
     </layer>
   </layers>
-  <layers formId="touch" minDeviceWidth="x">
+  <layers formId="touch" minDeviceWidth="120">
     <layer id="base">
       <row keys="one" />
       <row keys="two" />

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/hint-touch-layer-has-modifiers.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/hint-touch-layer-has-modifiers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="und" conformsTo="45">
-  <info name="layr-error-custom-form"/>
+  <info name="hint-touch-layer-has-modifiers"/>
   <keys>
     <key id="one" output="1" />
     <key id="two" output="2" />
@@ -12,8 +12,8 @@
       <row keys="one two three" />
     </layer>
   </layers>
-  <layers formId="touch" minDeviceWidth="x">
-    <layer id="base">
+  <layers formId="touch" minDeviceWidth="120">
+    <layer id="base" modifiers="shift"> <!-- touch layer has modifiers -->
       <row keys="one" />
       <row keys="two" />
       <row keys="three" />

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/invalid-invalid-form.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/invalid-invalid-form.xml
@@ -9,7 +9,7 @@
   </keys>
 
   <layers formId="holographic"> <!-- INVALID: 'holographic' is not a valid form. -->
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="grave one" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/invalid-multi-hardware.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/invalid-multi-hardware.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="und" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="en" conformsTo="45">
   <info name="layr-invalid-form"/>
 
   <keys>
@@ -9,14 +9,14 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="grave one" />
     </layer>
   </layers>
   <!-- INVALID: can't have multiple 'hardware' layers -->
   <layers formId="iso">
-    <layer id="base">
+    <layer modifiers="none">
       <!-- beware: this is mapping ` and 1! -->
       <row keys="one grave" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/row-keys-whitespace.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/row-keys-whitespace.xml
@@ -9,7 +9,7 @@
   </keys>
 
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys=" grave mistake" />
       <row keys="   grave   mistake " />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/warn-custom-us-form.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/warn-custom-us-form.xml
@@ -16,7 +16,7 @@
     </form>
   </forms>
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="one two three" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/layr/warn-custom-zzz-form.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/layr/warn-custom-zzz-form.xml
@@ -14,7 +14,7 @@
     </form>
   </forms>
   <layers formId="zzz">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="one two three" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/strs/hint-pua.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/strs/hint-pua.xml
@@ -20,8 +20,8 @@
     <key id="hmaqtugha" output="hhh" longPressKeyIds="a e" />
   </keys>
 
-  <layers formId="us" minDeviceWidth="123">
-    <layer id="zz">
+  <layers formId="us">
+    <layer modifiers="none">
       <row keys="hmaqtugha" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/strs/invalid-illegal.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/strs/invalid-illegal.xml
@@ -21,7 +21,7 @@
     <key id="that" output="&#xFFFF;" /> <!-- illegal NCR (single char)-->
   </keys>
 
-  <layers formId="us" minDeviceWidth="123">
+  <layers formId="touch" minDeviceWidth="123">
     <layer id="&#xFFFE;">
       <row keys="hmaqtugha that" />
     </layer>

--- a/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-denorm-1.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-denorm-1.xml
@@ -9,8 +9,8 @@
     <key id="ess" output="s\u{0307}\u{0323}" /> <!-- not NFD-->
   </keys>
 
-  <layers formId="us" minDeviceWidth="123">
-    <layer id="zz">
+  <layers formId="us">
+    <layer modifiers="none">
       <row keys="ess" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-denorm-2.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-denorm-2.xml
@@ -13,8 +13,8 @@
     <string id="ess" value="s\u{0307}\u{0323}" /> <!-- Not NFD -->
   </variables>
 
-  <layers formId="us" minDeviceWidth="123">
-    <layer id="zz">
+  <layers formId="us">
+    <layer modifiers="none">
       <row keys="ess" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-denorm-3.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-denorm-3.xml
@@ -17,8 +17,8 @@
     <string id="ess" value="S" />
   </variables>
 
-  <layers formId="us" minDeviceWidth="123">
-    <layer id="zz">
+  <layers formId="us">
+    <layer modifiers="none">
       <row keys="ess" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-denorm-4.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-denorm-4.xml
@@ -11,8 +11,8 @@
   </keys>
 
 
-  <layers formId="us" minDeviceWidth="123">
-    <layer id="zz">
+  <layers formId="iso">
+    <layer modifiers="none">
       <row keys="ess" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-unassigned.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/strs/warn-unassigned.xml
@@ -20,8 +20,8 @@
     <key id="hmaqtugha" output="\u{CFFFD}" longPressKeyIds="a e" />
   </keys>
 
-  <layers formId="us" minDeviceWidth="123">
-    <layer id="zz">
+  <layers formId="us">
+    <layer modifiers="none">
       <row keys="hmaqtugha" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-bad-tran-2.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/tran/fail-bad-tran-2.xml
@@ -7,7 +7,7 @@
 
   <!-- this is here because this test is used by test-compiler-e2e -->
   <layers formId="us">
-    <layer id="base">
+    <layer modifiers="none">
       <row keys="a b c" />
     </layer>
   </layers>

--- a/developer/src/kmc-ldml/test/fixtures/sections/tran/tran-escape.xml
+++ b/developer/src/kmc-ldml/test/fixtures/sections/tran/tran-escape.xml
@@ -5,7 +5,7 @@
         <key id="e" output="\m{hat}e"/>
     </keys>
     <layers formId="iso">
-        <layer id="base">
+        <layer modifiers="none">
             <row keys="e"/>
         </layer>
     </layers>

--- a/developer/src/kmc-ldml/test/keys.tests.ts
+++ b/developer/src/kmc-ldml/test/keys.tests.ts
@@ -452,7 +452,7 @@ describe('keys.kmap', function () {
     assert.isNull(keys);
     assert.equal(compilerTestCallbacks.messages.length, 1);
 
-    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_RowOnHardwareLayerHasTooManyKeys({ row: 1, hardware: 'us', modifiers: 'none' }, withOffset(785) as LDMLKeyboard.LKRow));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_RowOnHardwareLayerHasTooManyKeys({ row: 1, hardware: 'us', modifiers: 'none' }, withOffset(792) as LDMLKeyboard.LKRow));
   });
 
   it('should reject layouts with undefined keys', async function() {
@@ -460,7 +460,7 @@ describe('keys.kmap', function () {
     assert.isNull(keys);
     assert.equal(compilerTestCallbacks.messages.length, 1);
 
-    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_KeyNotFoundInKeyBag({col: 1, form: 'hardware', keyId: 'foo', layer: 'base', row: 1}, withOffset(271) as LDMLKeyboard.LKRow));
+    assert.deepEqual(compilerTestCallbacks.messages[0], LdmlCompilerMessages.Error_KeyNotFoundInKeyBag({col: 1, form: 'hardware', keyId: 'foo', layer: 'none', row: 1}, withOffset(278) as LDMLKeyboard.LKRow));
   });
   it('should reject layouts with invalid keys', async function() {
     const keys = await loadSectionFixture(KeysCompiler, 'sections/keys/invalid-key-missing-attrs.xml', compilerTestCallbacks, keysDependencies) as Keys;

--- a/developer/src/kmc-ldml/test/layr.tests.ts
+++ b/developer/src/kmc-ldml/test/layr.tests.ts
@@ -41,7 +41,7 @@ describe('layr', function () {
         assert.ok(row0);
         assert.equal(row0.keys.length, 2);
 
-        assert.equal(layer0.id.value, 'base');
+        assert.equal(layer0.id.value, '');
         assert.equal(layer0.mod, constants.keys_mod_none);
         assert.equal(row0.keys[0]?.value, 'grave');
       },
@@ -58,7 +58,7 @@ describe('layr', function () {
         assert.equal(listHardware.layers.length, 2);
         const hardware0 = listHardware.layers[0];
         assert.ok(hardware0);
-        assert.equal(hardware0.id.value, 'base');
+        assert.equal(hardware0.id.value, '');
         assert.equal(hardware0.mod, constants.keys_mod_none);
         const hardware0row0 = hardware0.rows[0];
         assert.ok(hardware0row0);
@@ -67,7 +67,7 @@ describe('layr', function () {
         const hardware1 = listHardware.layers[1];
         assert.ok(hardware1);
         assert.equal(hardware1.rows.length, 1);
-        assert.equal(hardware1.id.value, 'shift');
+        assert.equal(hardware1.id.value, '');
         assert.equal(hardware1.mod, constants.keys_mod_shift);
         const hardware1row0 = hardware1.rows[0];
         assert.ok(hardware1row0);
@@ -130,7 +130,7 @@ describe('layr', function () {
         ]));
         assert.sameDeepMembers(bymod, [
           // flatten the layers for comparison, assume a single key
-          ['base', constants.keys_mod_none, 'a'],
+          ['', constants.keys_mod_none, 'a'],
           ['', constants.keys_mod_altR, 'c'],
           ['', constants.keys_mod_ctrl | constants.keys_mod_shift, 'c'],
         ]);
@@ -157,7 +157,7 @@ describe('layr', function () {
         const layer0 = list0.layers[0];
         assert.ok(layer0);
         assert.equal(layer0.rows.length, 2);
-        assert.equal(layer0.id.value, 'base');
+        assert.equal(layer0.id.value, '');
         assert.equal(layer0.mod, constants.keys_mod_none);
         for(const row of layer0.rows) {
           assert.ok(row);
@@ -180,5 +180,29 @@ describe('layr', function () {
         LdmlCompilerMessages.Error_InvalidLayerWidth({ minDeviceWidth }),
       ]
     })),
+    {
+      subpath: 'sections/layr/error-touch-layer-requires-id.xml',
+      errors: [
+        LdmlCompilerMessages.Error_TouchLayerRequiresId({ minDeviceWidth: 120}),
+      ]
+    },
+    {
+      subpath: 'sections/layr/error-hardware-layer-requires-modifiers.xml',
+      errors: [
+        LdmlCompilerMessages.Error_HardwareLayerRequiresModifiers({ formId: 'us' }),
+      ]
+    },
+    {
+      subpath: 'sections/layr/hint-touch-layer-has-modifiers.xml',
+      warnings: [ // hints grouped under warnings
+        LdmlCompilerMessages.Hint_TouchLayerHasModifiers({id: 'base', minDeviceWidth: 120}),
+      ]
+    },
+    {
+      subpath: 'sections/layr/hint-hardware-layer-has-id.xml',
+      warnings: [ // hints grouped under warnings
+        LdmlCompilerMessages.Hint_HardwareLayerHasId({formId: 'iso', id: 'base'}),
+      ]
+    },
   ]);
 });

--- a/developer/src/kmc-ldml/test/linter.tests.ts
+++ b/developer/src/kmc-ldml/test/linter.tests.ts
@@ -7,8 +7,14 @@ import { LdmlCompilerMessages } from '../src/compiler/ldml-compiler-messages.js'
 describe('linter-tests', function() {
     this.slow(500); // 0.5 sec -- json schema validation takes a while
 
-    before(function() {
+    this.beforeEach(function() {
       compilerTestCallbacks.clear();
+    });
+
+    this.afterEach(function() {
+      if(this.currentTest.isFailed()) {
+        compilerTestCallbacks.printMessages();
+      }
     });
 
     it('should warn on mark keys with no display', async function () {

--- a/developer/src/kmc-ldml/test/utils.tests.ts
+++ b/developer/src/kmc-ldml/test/utils.tests.ts
@@ -224,11 +224,11 @@ describe('test of util/util.ts', () => {
     });
   });
   describe('isValidModifier()', () => {
-    it('should treat falsy values as valid', () => {
+    it('should treat falsy values as invalid', () => {
       for(const str of [
-        null, undefined, '', 'none'
+        null, undefined, ''
       ]) {
-        assert.ok(validModifier(str), `validModifier(${JSON.stringify(str)})`);
+        assert.notOk(validModifier(str), `validModifier(${JSON.stringify(str)})`);
       }
     });
     it('should treat bad values as invalid', () => {

--- a/developer/src/kmc-ldml/test/visual-keyboard-compiler.tests.ts
+++ b/developer/src/kmc-ldml/test/visual-keyboard-compiler.tests.ts
@@ -18,6 +18,16 @@ import { LdmlKeyboardCompiler } from '../src/main.js';
 describe('visual-keyboard-compiler', function() {
   this.slow(500); // 0.5 sec -- json schema validation takes a while
 
+  this.beforeEach(function() {
+    compilerTestCallbacks.clear();
+  });
+
+  this.afterEach(function() {
+    if(this.currentTest.isFailed()) {
+      compilerTestCallbacks.printMessages();
+    }
+  });
+
   it('should build fixtures', async function() {
     // Let's build basic.xml
 


### PR DESCRIPTION
Per the spec, the `id` attribute is required for touch layers, and `modifiers` attribute is required for hardware layers. There is ambiguity in the spec at present as to whether they should be allowed for the alternative type.

* Validate that the attributes are present where required.
* Tighten validation of `modifiers` attribute - it cannot be empty or missing for hardware; "" != "none".
* Hint if the attribute is present when it probably shouldn't be (to be potentially raised to warning or error after spec clarified, [CLDR-19755](https://unicode-org.atlassian.net/browse/CLDR-19755)).
* Fixup all keyboard3 xml files to conform to spec and eliminate hints.
* Add unit tests.
* Removed threshold warning for coverage as kmc-ldml is already > 90%.

Fixes: #12423
Test-bot: skip