### PR TITLE
fix(developer): improve scroll wheel behavior in Character Map

### DIFF
--- a/common/windows/delphi/charmap/UfrmCharacterMapNew.pas
+++ b/common/windows/delphi/charmap/UfrmCharacterMapNew.pas
@@ -896,22 +896,36 @@ end;
 procedure TfrmCharacterMapNew.gridMouseWheelDown(Sender: TObject;
   Shift: TShiftState; MousePos: TPoint; var Handled: Boolean);
 begin
+  Handled := True;
   if ssCtrl in Shift then
   begin
-    Handled := True;
+    // Zoom
     if tbSize.Position < tbSize.Max then
       tbSize.Position := tbSize.Position + tbSize.PageSize;
+  end
+  else
+  begin
+    // Scroll
+    if grid.TopRow < grid.RowCount - grid.VisibleRowCount then
+      grid.TopRow := grid.TopRow + 1;
   end;
 end;
 
 procedure TfrmCharacterMapNew.gridMouseWheelUp(Sender: TObject;
   Shift: TShiftState; MousePos: TPoint; var Handled: Boolean);
 begin
+  Handled := True;
   if ssCtrl in Shift then
   begin
-    Handled := True;
+    // Zoom
     if tbSize.Position > tbSize.Min then
       tbSize.Position := tbSize.Position - tbSize.PageSize;
+  end
+  else
+  begin
+    // Scroll
+    if grid.TopRow > 0 then
+      grid.TopRow := grid.TopRow - 1;
   end;
 end;
 


### PR DESCRIPTION
The Character Map scroll will now scroll from current scroll position when the scroll wheel is used, one row at a time, rather than moving the currently selected cell. This behavior is more natural and allows mixed use of the scrollbar and the scrollwheel.

Fixes: #14159
Test-bot: skip