### PR TITLE
fix(developer): disable Copy Link in Model Editor if no link to copy

### DIFF
--- a/developer/src/tike/child/Keyman.Developer.UI.UfrmModelEditor.dfm
+++ b/developer/src/tike/child/Keyman.Developer.UI.UfrmModelEditor.dfm
@@ -418,12 +418,12 @@ inherited frmModelEditor: TfrmModelEditor
             OnClick = lbDebugHostsClick
           end
           object cmdSendURLsToEmail: TButton
-            Left = 127
+            Left = 253
             Top = 286
             Width = 109
             Height = 25
             Caption = 'Send to &email...'
-            TabOrder = 6
+            TabOrder = 7
             OnClick = cmdSendURLsToEmailClick
           end
           object editTestKeyboard: TEdit
@@ -444,12 +444,12 @@ inherited frmModelEditor: TfrmModelEditor
             OnClick = cmdBrowseTestKeyboardClick
           end
           object cmdCopyDebuggerLink: TButton
-            Left = 242
+            Left = 127
             Top = 286
             Width = 109
             Height = 25
             Caption = 'Copy &link'
-            TabOrder = 7
+            TabOrder = 6
             OnClick = cmdCopyDebuggerLinkClick
           end
           object cmdConfigureWebDebugger: TButton

--- a/developer/src/tike/child/Keyman.Developer.UI.UfrmModelEditor.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.UfrmModelEditor.pas
@@ -418,6 +418,7 @@ begin
 
   { Build tab }
   cmdOpenDebugHost.Enabled := lbDebugHosts.ItemIndex >= 0;
+  cmdCopyDebuggerLink.Enabled := lbDebugHosts.ItemIndex >= 0;
   cmdSendURLsToEmail.Enabled := lbDebugHosts.Items.Count > 0;   // I4506
 
   // We use FProjectFile because we don't want to accidentally create a standalone


### PR DESCRIPTION
Also reorder the buttons more logically, so Copy Link is next to Test Keyboard, so that the Email Links button which applies to all items in the list is separate from the Test Keyboard and Copy Link buttons.

Fixes: #12669
Test-bot: skip