### PR TITLE
fix(developer): handle comment without trailing whitespace

### DIFF
--- a/developer/src/kmcmplib/src/Compiler.cpp
+++ b/developer/src/kmcmplib/src/Compiler.cpp
@@ -2079,7 +2079,7 @@ int LineTokenType(PKMX_WCHAR *str)
   switch (towupper(*p))
   {
   case 'C':
-    if (iswspace(*(p + 1))) return T_COMMENT;
+    if (iswspace(*(p + 1)) || *(p + 1) == 0) return T_COMMENT;
     break;
   case 0:
     return T_BLANK;

--- a/developer/src/kmcmplib/tests/gtest-compiler.tests.cpp
+++ b/developer/src/kmcmplib/tests/gtest-compiler.tests.cpp
@@ -663,7 +663,7 @@ TEST_F(CompilerTest, LineTokenType_test) {
     // comment without following space ... potential bug, but ReadLine() currently ensures following space
     u16cpy(str, u"c");
     p = str;
-    EXPECT_EQ(T_UNKNOWN, LineTokenType(&p));
+    EXPECT_EQ(T_COMMENT, LineTokenType(&p));
     EXPECT_EQ(0, p - str);
 
     // T_KEYTOKEY


### PR DESCRIPTION
Fixes: #12070
Test-bot: skip