### PR TITLE
chore(developer): strip out defunct printing support

### DIFF
--- a/developer/src/common/delphi/components/KMDActionInterfaces.pas
+++ b/developer/src/common/delphi/components/KMDActionInterfaces.pas
@@ -45,17 +45,6 @@ type
     function CanClearSelection: Boolean;
   end;
 
-  IKMDPrintActions = interface
-    ['{C6F05AD6-42A3-404F-944C-904393A51837}']
-    //function PageSetup: Boolean;
-    function PrintFile: Boolean;
-  end;
-
-  IKMDPrintPreviewActions = interface(IKMDPrintActions)
-    ['{B5879BC4-7A0C-4E00-AAE3-E2D48489152A}']
-    function PrintPreview: Boolean;
-  end;
-
   IKMDViewExpandEditorActions = interface
     ['{680A172E-A221-4CDA-B68C-1E2AF8487510}']
     procedure ExpandContractEditor;

--- a/developer/src/tike/actions/dmActionsMain.dfm
+++ b/developer/src/tike/actions/dmActionsMain.dfm
@@ -76,36 +76,6 @@ object modActionsMain: TmodActionsMain
       OnExecute = actFileRevertExecute
       OnUpdate = actFileRevertUpdate
     end
-    object actFilePageSetup: TFilePageSetup
-      Category = 'File'
-      Caption = 'Page Set&up...'
-      Dialog.MinMarginLeft = 0
-      Dialog.MinMarginTop = 0
-      Dialog.MinMarginRight = 0
-      Dialog.MinMarginBottom = 0
-      Dialog.MarginLeft = 2500
-      Dialog.MarginTop = 2500
-      Dialog.MarginRight = 2500
-      Dialog.MarginBottom = 2500
-      Dialog.PageWidth = 21000
-      Dialog.PageHeight = 29700
-      OnUpdate = actFilePageSetupUpdate
-    end
-    object actFilePrint: TAction
-      Category = 'File'
-      Caption = '&Print...'
-      ImageIndex = 20
-      ShortCut = 16464
-      OnExecute = actFilePrintExecute
-      OnUpdate = actFilePrintUpdate
-    end
-    object actFilePrintPreview: TAction
-      Category = 'File'
-      Caption = 'Print Pre&view'
-      ImageIndex = 19
-      OnExecute = actFilePrintPreviewExecute
-      OnUpdate = actFilePrintPreviewUpdate
-    end
     object actFileExit: TFileExit
       Category = 'File'
       Caption = 'E&xit'

--- a/developer/src/tike/actions/dmActionsMain.pas
+++ b/developer/src/tike/actions/dmActionsMain.pas
@@ -78,9 +78,6 @@ type
     actFileSaveAs: TFileSaveAs;
     actFileSaveCopyAs: TAction;
     actFileRevert: TAction;
-    actFilePageSetup: TFilePageSetup;
-    actFilePrint: TAction;
-    actFilePrintPreview: TAction;
     actFileExit: TFileExit;
     actEditCut: TKMDEditCut;
     actEditCopy: TKMDEditCopy;
@@ -144,15 +141,10 @@ type
     procedure actFileSaveExecute(Sender: TObject);
     procedure actFileSaveCopyAsExecute(Sender: TObject);
     procedure actFileRevertExecute(Sender: TObject);
-    procedure actFilePrintPreviewExecute(Sender: TObject);
-    procedure actFilePrintExecute(Sender: TObject);
-    procedure actFilePrintPreviewUpdate(Sender: TObject);
-    procedure actFilePrintUpdate(Sender: TObject);
     procedure actFileSaveAsAccept(Sender: TObject);
     procedure actFileSaveCopyAsUpdate(Sender: TObject);
     procedure actFileSaveAsUpdate(Sender: TObject);
     procedure actFileRevertUpdate(Sender: TObject);
-    procedure actFilePageSetupUpdate(Sender: TObject);
     procedure actFileSaveUpdate(Sender: TObject);
     procedure actFileSaveAsBeforeExecute(Sender: TObject);
     procedure actViewCharacterMapExecute(Sender: TObject);
@@ -256,7 +248,6 @@ uses
   Graphics,
   Messages,
   Keyman.Developer.UI.TikeOnlineUpdateCheck,
-  Printers,
   Vcl.Clipbrd,
   Keyman.System.KeyboardUtils,
   Keyman.Developer.System.Project.Project,
@@ -346,34 +337,6 @@ end;
 procedure TmodActionsMain.actFileOpenUpdate(Sender: TObject);
 begin
   actFileOpen.Enabled := IsGlobalProjectUIReady;
-end;
-
-procedure TmodActionsMain.actFilePageSetupUpdate(Sender: TObject);
-begin
-  with frmKeymanDeveloper do
-    actFilePageSetup.Enabled := IsGlobalProjectUIReady and Assigned(ActiveChild) and Supports(ActiveChild, IKMDPrintActions) and (Printer.Printers.Count > 0);
-end;
-
-procedure TmodActionsMain.actFilePrintExecute(Sender: TObject);
-begin
-  (frmKeymanDeveloper.ActiveChild as IKMDPrintActions).PrintFile;
-end;
-
-procedure TmodActionsMain.actFilePrintUpdate(Sender: TObject);
-begin
-  with frmKeymanDeveloper do
-    actFilePrint.Enabled := IsGlobalProjectUIReady and Assigned(ActiveChild) and Supports(ActiveChild, IKMDPrintActions) and (Printer.Printers.Count > 0);
-end;
-
-procedure TmodActionsMain.actFilePrintPreviewExecute(Sender: TObject);
-begin
-  (frmKeymanDeveloper.ActiveChild as IKMDPrintPreviewActions).PrintPreview;
-end;
-
-procedure TmodActionsMain.actFilePrintPreviewUpdate(Sender: TObject);
-begin
-  with frmKeymanDeveloper do
-    actFilePrintPreview.Enabled := IsGlobalProjectUIReady and Assigned(ActiveChild) and Supports(ActiveChild, IKMDPrintPreviewActions) and (Printer.Printers.Count > 0);
 end;
 
 procedure TmodActionsMain.actFileRevertExecute(Sender: TObject);

--- a/developer/src/tike/child/UfrmEditor.dfm
+++ b/developer/src/tike/child/UfrmEditor.dfm
@@ -449,14 +449,6 @@ inherited frmEditor: TfrmEditor
     Left = 450
     Top = 30
   end
-  object dlgPrint: TPrintDialog
-    Left = 450
-    Top = 58
-  end
-  object dlgPrintSetup: TPrinterSetupDialog
-    Left = 478
-    Top = 30
-  end
   object dlgFind: TFindDialog
     Left = 478
     Top = 58

--- a/developer/src/tike/child/UfrmEditor.pas
+++ b/developer/src/tike/child/UfrmEditor.pas
@@ -41,7 +41,7 @@ uses
   System.UITypes,
   Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, Menus, ToolWin, ComCtrls, ImgList, ErrorControlledRegistry,
-  RegistryKeys, UfrmMDIChild, MenuImgList, Printers,
+  RegistryKeys, UfrmMDIChild, MenuImgList,
   UfrmKeyTest,
 
   Keyman.Developer.System.Project.ProjectFile, UfrmMDIEditor,
@@ -54,11 +54,9 @@ type
   TUPCOptions = set of (upcSetError, upcClearError, upcSetBreakPoint, upcClearBreakPoint,
     upcSetExecutionPoint, upcClearExecutionPoint);
 
-  TfrmEditor = class(TfrmTikeEditor, IKMDPrintActions {TODO:, IKMDPrintPreviewActions})
+  TfrmEditor = class(TfrmTikeEditor)
     lstImages: TMenuImgList;
     dlgFonts: TFontDialog;
-    dlgPrint: TPrintDialog;
-    dlgPrintSetup: TPrinterSetupDialog;
     dlgFind: TFindDialog;
     dlgReplace: TReplaceDialog;
     lstImagesDisabled: TImageList;
@@ -73,10 +71,6 @@ type
     procedure SetTextFileFormat(const Value: TTextFileFormat);
     procedure UpdateEditorFormat;
 
-    { IKMDPrintActions }
-    function PrintFile: Boolean;
-    { IKMDPrintPreviewActions }
-    //TODO: function PrintPreview: Boolean;
     procedure EditorChanged(Sender: TObject);
     function GetEditorFormat: TEditorFormat;
     function GetTextFileFormat: TTextFileFormat;
@@ -298,11 +292,6 @@ begin
   frmKeymanDeveloper.cbTextFileFormat.ItemIndex := Ord(TextFileFormat);
 
   Modified := False;
-end;
-
-function TfrmEditor.PrintFile: Boolean;
-begin
-  Result := FEditorFrame.PrintFile(FileName);
 end;
 
 {-------------------------------------------------------------------------------

--- a/developer/src/tike/child/UfrmKeymanWizard.pas
+++ b/developer/src/tike/child/UfrmKeymanWizard.pas
@@ -159,7 +159,7 @@ type
     Filename: string;
   end;
 
-  TfrmKeymanWizard = class(TfrmTikeEditor, IKMDPrintActions {TODO:, IKMDPrintPreviewActions})
+  TfrmKeymanWizard = class(TfrmTikeEditor)
     dlgBrowseBitmap: TOpenPictureDialog;
     dlgSaveExport: TSaveDialog;
     dlgSaveBitmap: TSavePictureDialog;
@@ -523,11 +523,6 @@ type
 
     function CanChangeView(FView: TCodeDesignView): Boolean; override;   // I4678
     procedure ChangeView(FView: TCodeDesignView); override;   // I4678
-
-    { IKMDPrintActions }
-    function PrintFile: Boolean;
-    { IKMDPrintPreviewActions }
-    //TODO: function PrintPreview: Boolean;
 
     function CanReloadAsTextFileFormatClick: Boolean; override;   // I3637
     procedure ReloadAsTextFileFormatClick(TextFileFormat: TTextFileFormat);   // I3637
@@ -1507,16 +1502,6 @@ begin
 
   Result := True;
 end;
-
-function TfrmKeymanWizard.PrintFile: Boolean;
-begin
-  Result := frameSource.PrintFile(FileName);
-end;
-
-{TODO: function TfrmKeymanWizard.PrintPreview: Boolean;
-begin
-  Result := frameSource.PrintPreview(FileName);
-end;}
 
 function TfrmKeymanWizard.GetCurrentRule: TKeyboardParser_LayoutRule;
 var

--- a/developer/src/tike/main/UframeTextEditor.dfm
+++ b/developer/src/tike/main/UframeTextEditor.dfm
@@ -287,10 +287,6 @@ inherited frameTextEditor: TframeTextEditor
     Left = 450
     Top = 30
   end
-  object dlgPrintSetup: TPrinterSetupDialog
-    Left = 526
-    Top = 30
-  end
   object lstImagesDisabled: TImageList
     Left = 618
     Top = 26

--- a/developer/src/tike/main/UframeTextEditor.pas
+++ b/developer/src/tike/main/UframeTextEditor.pas
@@ -37,7 +37,6 @@ type
   TframeTextEditor = class(TTIKEForm, IKMDEditActions, IKMDSearchActions, IKMDTextEditorActions)
     lstImages: TMenuImgList;
     dlgFonts: TFontDialog;
-    dlgPrintSetup: TPrinterSetupDialog;
     lstImagesDisabled: TImageList;
     procedure FormCreate(Sender: TObject);
     procedure FormKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
@@ -161,9 +160,6 @@ type
     function OffsetToLine(Offset: Integer): Integer;   // I4083
 
     procedure SyntaxColourChange;
-
-    function PrintFile(Header: WideString = ''): Boolean;
-    function PrintPreview(Header: WideString = ''): Boolean;
 
     procedure LoadFromFile(AFileName: WideString); overload;   // I4034
     procedure LoadFromStream(AStream: TStream); overload;  // I2964
@@ -656,18 +652,6 @@ end;
 procedure TframeTextEditor.UpdateInsertState(const AMode: string);
 begin
   frmKeymanDeveloper.barStatus.Panels[1].Text := AMode;
-end;
-
-function TframeTextEditor.PrintFile(Header: WideString): Boolean;
-begin
-  ExecuteCommand('print');
-  Result := True;
-end;
-
-function TframeTextEditor.PrintPreview(Header: WideString): Boolean;
-begin
-  // TODO: print preview
-  Result := True;
 end;
 
 procedure TframeTextEditor.SetCharFont(const Value: TFont);

--- a/developer/src/tike/main/UfrmMain.dfm
+++ b/developer/src/tike/main/UfrmMain.dfm
@@ -184,7 +184,7 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
       object ToolBar1: TToolBar
         Left = 0
         Top = 0
-        Width = 301
+        Width = 270
         Height = 23
         Align = alNone
         AutoSize = True
@@ -216,36 +216,23 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
           ImageIndex = 3
           Style = tbsSeparator
         end
-        object ToolButton5: TToolButton
-          Left = 77
-          Top = 0
-          Action = modActionsMain.actFilePrint
-        end
-        object ToolButton6: TToolButton
-          Left = 100
-          Top = 0
-          Width = 8
-          Caption = 'ToolButton6'
-          ImageIndex = 4
-          Style = tbsSeparator
-        end
         object ToolButton7: TToolButton
-          Left = 108
+          Left = 77
           Top = 0
           Action = modActionsMain.actEditCut
         end
         object ToolButton8: TToolButton
-          Left = 131
+          Left = 100
           Top = 0
           Action = modActionsMain.actEditCopy
         end
         object ToolButton9: TToolButton
-          Left = 154
+          Left = 123
           Top = 0
           Action = modActionsMain.actEditPaste
         end
         object ToolButton10: TToolButton
-          Left = 177
+          Left = 146
           Top = 0
           Width = 8
           Caption = 'ToolButton10'
@@ -253,17 +240,17 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
           Style = tbsSeparator
         end
         object ToolButton11: TToolButton
-          Left = 185
+          Left = 154
           Top = 0
           Action = modActionsMain.actEditUndo
         end
         object ToolButton12: TToolButton
-          Left = 208
+          Left = 177
           Top = 0
           Action = modActionsMain.actEditRedo
         end
         object ToolButton19: TToolButton
-          Left = 231
+          Left = 200
           Top = 0
           Width = 8
           Caption = 'ToolButton19'
@@ -271,12 +258,12 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
           Style = tbsSeparator
         end
         object ToolButton14: TToolButton
-          Left = 239
+          Left = 208
           Top = 0
           Action = modActionsMain.actViewExpandEditor
         end
         object ToolButton15: TToolButton
-          Left = 262
+          Left = 231
           Top = 0
           Width = 8
           Caption = 'ToolButton15'
@@ -284,12 +271,12 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
           Style = tbsSeparator
         end
         object ToolButton16: TToolButton
-          Left = 270
+          Left = 239
           Top = 0
           Action = modActionsKeyboardEditor.actKeyboardCompile
         end
         object ToolButton13: TToolButton
-          Left = 293
+          Left = 262
           Top = 0
           Width = 8
           Caption = 'ToolButton13'
@@ -2792,18 +2779,6 @@ inherited frmKeymanDeveloper: TfrmKeymanDeveloper
         Action = modActionsMain.actWindowClose
       end
       object N6: TMenuItem
-        Caption = '-'
-      end
-      object PageSetup1: TMenuItem
-        Action = modActionsMain.actFilePageSetup
-      end
-      object PrintPreview1: TMenuItem
-        Action = modActionsMain.actFilePrintPreview
-      end
-      object Print1: TMenuItem
-        Action = modActionsMain.actFilePrint
-      end
-      object N9: TMenuItem
         Caption = '-'
       end
       object mnuFileRecent: TMenuItem

--- a/developer/src/tike/main/UfrmMain.pas
+++ b/developer/src/tike/main/UfrmMain.pas
@@ -171,8 +171,6 @@ type
     ToolButton2: TToolButton;
     ToolButton3: TToolButton;
     ToolButton4: TToolButton;
-    ToolButton5: TToolButton;
-    ToolButton6: TToolButton;
     ToolButton7: TToolButton;
     ToolButton8: TToolButton;
     ToolButton9: TToolButton;
@@ -202,12 +200,8 @@ type
     N5: TMenuItem;
     Close1: TMenuItem;
     N6: TMenuItem;
-    PageSetup1: TMenuItem;
-    PrintPreview1: TMenuItem;
-    Print1: TMenuItem;
     N8: TMenuItem;
     Exit1: TMenuItem;
-    N9: TMenuItem;
     mnuFileRecent: TMenuItem;
     Undo1: TMenuItem;
     Redo1: TMenuItem;


### PR DESCRIPTION
Printing has not been supported from Keyman Developer for quite some time. This does not appear to have been raised as a user issue. Remove printing support, and cleanup user interface. As a side-effect, this will fix #11249, as Delphi's printer support will no longer poll for default printer on start.

Review note: use 'hide whitespace changes' to dramatically reduce the changeset.

Fixes: #11249

# User Testing

* TEST_DEVELOPER: Run through a basic acceptance test of Keyman Developer (testing each major function) and verify that the removal of printing support does not have any side-effects.
* TEST_PRINT_UI: Look at Keyman Developer menus and user interface to verify that there are no references to Printing, Print Preview or Page Setup left.