### PR TITLE
fix(developer): call 'Show Console' twice to make the console actually show on first use

### DIFF
--- a/developer/src/server/src/win32-tray.ts
+++ b/developer/src/server/src/win32-tray.ts
@@ -71,6 +71,11 @@ export class Win32Tray {
           open(ngrokAddress);
           break;
         case 'item-id-show-console':
+          // #9694 - the first time, this has to be called twice for the console
+          // window to appear. This could probably be fixed in the source
+          // node-hide-console-window component, but this works well enough and
+          // has little in the way of side-effects.
+          WindowsConsole.showConsole();
           WindowsConsole.showConsole();
           break;
         case 'item-id-hide-console':


### PR DESCRIPTION
The underlying issue may be in the node-hide-console-window component. This fix is adequate in my view, for a low-use code path.

Fixes: #9694
Test-bot: skip