### PR TITLE
chore(web): tweak error message

### DIFF
--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -532,7 +532,7 @@ export class ContextManager extends ContextManagerBase<BrowserConfiguration> {
       this.engineConfig.alertHost?.wait(); // clear the wait message box, either way.
 
       const message = (err as Error)?.message ||
-                      'Sorry, the ' + keyboardId + ' keyboard for ' + languageCode + ' is not currently available.';
+                      `Sorry, the '${keyboardId}' keyboard for '${languageCode}' is not currently available.`;
 
       if(err instanceof KeyboardScriptError) {
         // We get signaled about error log messages if the site is connected to our Sentry error reporting

--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -531,9 +531,8 @@ export class ContextManager extends ContextManagerBase<BrowserConfiguration> {
 
       this.engineConfig.alertHost?.wait(); // clear the wait message box, either way.
 
-      
-      const message = 
-                      `Activation of '${keyboardId}' keyboard failed: ${(err as Error)?.message ?? err?.toString() ?? 'unknown error'}`;
+
+      const message = `Activation of '${keyboardId}' failed: ${(err as Error)?.message ?? err?.toString() ?? 'unknown error'}`;
 
       if(err instanceof KeyboardScriptError) {
         // We get signaled about error log messages if the site is connected to our Sentry error reporting

--- a/web/src/app/browser/src/contextManager.ts
+++ b/web/src/app/browser/src/contextManager.ts
@@ -531,8 +531,9 @@ export class ContextManager extends ContextManagerBase<BrowserConfiguration> {
 
       this.engineConfig.alertHost?.wait(); // clear the wait message box, either way.
 
-      const message = (err as Error)?.message ||
-                      `Sorry, the '${keyboardId}' keyboard for '${languageCode}' is not currently available.`;
+      
+      const message = 
+                      `Activation of '${keyboardId}' keyboard failed: ${(err as Error)?.message ?? err?.toString() ?? 'unknown error'}`;
 
       if(err instanceof KeyboardScriptError) {
         // We get signaled about error log messages if the site is connected to our Sentry error reporting

--- a/web/src/engine/src/main/contextManagerBase.ts
+++ b/web/src/engine/src/main/contextManagerBase.ts
@@ -368,7 +368,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
 
         const keyboardPromise = this.keyboardCache.fetchKeyboard(requestedStub.KI);
         const timeoutPromise = new Promise<Keyboard>((resolve, reject) => {
-          const timeoutMsg = `Sorry, the ${requestedStub.name} keyboard for ${requestedStub.langName} is not currently available.`;
+          const timeoutMsg = `The download of the '${requestedStub.name}' keyboard for '${requestedStub.langName}' timed out.`;
           window.setTimeout(() => reject(new Error(timeoutMsg)), ContextManagerBase.TIMEOUT_THRESHOLD);
         });
 

--- a/web/src/engine/src/main/contextManagerBase.ts
+++ b/web/src/engine/src/main/contextManagerBase.ts
@@ -368,7 +368,7 @@ export abstract class ContextManagerBase<MainConfig extends EngineConfiguration>
 
         const keyboardPromise = this.keyboardCache.fetchKeyboard(requestedStub.KI);
         const timeoutPromise = new Promise<Keyboard>((resolve, reject) => {
-          const timeoutMsg = `The download of the '${requestedStub.name}' keyboard for '${requestedStub.langName}' timed out.`;
+          const timeoutMsg = `Download of ${requestedStub.KI} for language ${requestedStub.langId} timed out.`;
           window.setTimeout(() => reject(new Error(timeoutMsg)), ContextManagerBase.TIMEOUT_THRESHOLD);
         });
 

--- a/web/src/test/manual/web/keyboard-errors/errorhdr.js
+++ b/web/src/test/manual/web/keyboard-errors/errorhdr.js
@@ -35,6 +35,8 @@
         id:'lo',name:'debugging',region:'Asia',
         font:{family:'LaoWeb',source:['../font/saysettha_web.ttf','../font/saysettha_web.woff','../font/saysettha_web.eot']}
         },
-      filename:'./timeout.js' // Intentional (simulated) error - the file never loads, simulating a server timeout.
+      filename: './timeout.js' // Intentional (simulated) error - the file never loads,
+      // simulating a server timeout. web/src/tools/testing/test-server/index.cjs#L12
+      // has special code when this file gets requested!
     });
   }

--- a/web/src/test/manual/web/keyboard-errors/index.html
+++ b/web/src/test/manual/web/keyboard-errors/index.html
@@ -67,15 +67,22 @@
       <li><i>timeout</i> keyboard: "Activation of 'Keyboard_timeout' failed: Download of Keyboard_timeout for language lo timed out."</li>
     </ul>
 
+    <p><b>Note:</b> This test page will only work on the local test server due to its
+    specific requirements for handling the 'timeout.js' file.</p>
+
     <h3><a href="../index.html">Return to testing home page</a></h3>
   </div>
 
     <script>
-      if (window.location.href.startsWith('file:')) {
+      if (!window.location.href.startsWith('http://localhost:3000')) {
         const body = document.getElementsByTagName('body')[0];
         body.innerHTML = `<h1>KeymanWeb Sample Page - Error Testing page</h1>
         <h2>Unable to load this test page!</h2>
-        <p>This page has to be loaded through the local test server.</p>
+        <p>This test page will only work on the local test server because it
+          requires special treatment when loading <i>timeout.js</i>
+          (see <a href="https://github.com/keymanapp/keyman/blob/a570108f8565b0110d726f1f40ffd5b6daf6f6d5/web/src/tools/testing/test-server/index.cjs#L12">
+          web/src/tools/testing/test-server/index.cjs#L12</a>). The
+          page has to be loaded through the local test server.</p>
         <p>Do the following:</p>
         <ol>
           <li>Open a terminal and navigate to the Keyman source root directory</li>

--- a/web/src/test/manual/web/keyboard-errors/index.html
+++ b/web/src/test/manual/web/keyboard-errors/index.html
@@ -71,7 +71,7 @@
   </div>
 
     <script>
-      if (!window.location.href.startsWith('http://localhost:3000') && !window.location.href.startsWith('https://')) {
+      if (window.location.href.startsWith('file:')) {
         const body = document.getElementsByTagName('body')[0];
         body.innerHTML = `<h1>KeymanWeb Sample Page - Error Testing page</h1>
         <h2>Unable to load this test page!</h2>

--- a/web/src/test/manual/web/keyboard-errors/index.html
+++ b/web/src/test/manual/web/keyboard-errors/index.html
@@ -71,7 +71,7 @@
   </div>
 
     <script>
-      if (!window.location.href.startsWith('http://localhost:3000')) {
+      if (!window.location.href.startsWith('http://localhost:3000') && !window.location.href.startsWith('https://')) {
         const body = document.getElementsByTagName('body')[0];
         body.innerHTML = `<h1>KeymanWeb Sample Page - Error Testing page</h1>
         <h2>Unable to load this test page!</h2>

--- a/web/src/test/manual/web/keyboard-errors/index.html
+++ b/web/src/test/manual/web/keyboard-errors/index.html
@@ -64,7 +64,7 @@
     <ul>
       <li><i>wrong-filename</i> keyboard: "Unable to download wrong-filename keyboard for debugging"</li>
       <li><i>non-parsable</i> keyboard: "Error registering the non-parsable keyboard for debugging; keyboard script at ./unparsable.js may contain an error."</li>
-      <li><i>timeout</i> keyboard: "The download of the 'timeout' keyboard for 'debugging' timed out."</li>
+      <li><i>timeout</i> keyboard: "Activation of 'Keyboard_timeout' failed: Download of Keyboard_timeout for language lo timed out."</li>
     </ul>
 
     <h3><a href="../index.html">Return to testing home page</a></h3>

--- a/web/src/test/manual/web/keyboard-errors/index.html
+++ b/web/src/test/manual/web/keyboard-errors/index.html
@@ -64,7 +64,7 @@
     <ul>
       <li><i>wrong-filename</i> keyboard: "Unable to download wrong-filename keyboard for debugging"</li>
       <li><i>non-parsable</i> keyboard: "Error registering the non-parsable keyboard for debugging; keyboard script at ./unparsable.js may contain an error."</li>
-      <li><i>timeout</i> keyboard: "Sorry, the timeout keyboard for debugging is not currently available."</li>
+      <li><i>timeout</i> keyboard: "The download of the 'timeout' keyboard for 'debugging' timed out."</li>
     </ul>
 
     <h3><a href="../index.html">Return to testing home page</a></h3>


### PR DESCRIPTION
Previously the browser component and web engine had the same error message which made it harder to know where the exception happened if a call stack or source map were missing. This change modifies the message in engine.

Related-to: #16190
Build-bot: skip release:android,ios,web
Test-bot: skip