### PR TITLE
chore(developer): improve kmc-ldml test messages

### DIFF
--- a/core/src/ldml/C7532_ldml_updating.md
+++ b/core/src/ldml/C7532_ldml_updating.md
@@ -71,7 +71,7 @@ working on ‘layr’, using ‘disp’ as a model from https://github.com/keyma
 
 - update basic.xml and basic.txt
     - Tweak `eveloper/src/kmc-ldml/test/fixtures/basic.xml` as needed
-    - You can use `developer/src/kmc-ldml/build.sh build-fixtures` which will generate these. The two .kmx files are supposed to match: if not, fix `basic.txt` or fix other bugs.
+    - You can use `developer/src/kmc-ldml/build.sh fixtures-build` which will generate these. The two .kmx files are supposed to match: if not, fix `basic.txt` or fix other bugs.
         - `developer/src/kmc-ldml/build/test/fixtures/basic-txt.kmx` - KMX generated from basic.txt.
         - `developer/src/kmc-ldml/build/test/fixtures/basic-xml.kmx` - KMX generated from basic.xml.
         - `developer/src/kmc-ldml/build/test/fixtures/basic-xml.kvk` - KVK generated from basic.xml.

--- a/developer/src/kmc-ldml/build.sh
+++ b/developer/src/kmc-ldml/build.sh
@@ -23,7 +23,7 @@ builder_describe "Keyman kmc Keyboard Compiler module" \
   "api                       analyze API and prepare API documentation" \
   "clean" \
   "test" \
-  "build-fixtures            builds test fixtures for manual examination"
+  "fixtures-build            builds test fixtures for manual examination"
 
 builder_describe_outputs \
   configure     /developer/src/kmc-ldml/src/util/abnf/46/transform-from-required.js \
@@ -84,6 +84,6 @@ function do_build_fixtures() {
 builder_run_action clean           do_clean
 builder_run_action configure       do_configure
 builder_run_action build           do_build
-builder_run_action build-fixtures  do_build_fixtures
+builder_run_action fixtures-build  do_build_fixtures
 builder_run_action api             typescript_run_api_extractor developer/src/kmc-ldml main.d.ts
 builder_run_action test            typescript_run_eslint_mocha_tests

--- a/developer/src/kmc-ldml/test/fixtures/basic.txt
+++ b/developer/src/kmc-ldml/test/fixtures/basic.txt
@@ -12,7 +12,7 @@
 #
 #    cd developer/src/kmc
 #    ./build.sh configure build # if needed
-#    ./build.sh build-fixtures
+#    ./build.sh fixtures-build
 #
 #  This will compile both the .xml and the .txt to build/test/fixtures and also emit the
 #  checksum for basic-xml.kmx so you can patch that into this file.

--- a/developer/src/kmc-ldml/test/helpers/index.ts
+++ b/developer/src/kmc-ldml/test/helpers/index.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url';
 import { SectionCompiler, SectionCompilerNew } from '../../src/compiler/section-compiler.js';
 import { util, KMXPlus, LdmlKeyboardTypes } from '@keymanapp/common-types';
 import { CompilerEvent, compilerEventFormat, CompilerCallbacks, LDMLKeyboardXMLSourceFileReader, LDMLKeyboardTestDataXMLSourceFile, LDMLKeyboard, CompilerError } from "@keymanapp/developer-utils";
-import { LdmlKeyboardCompiler } from '../../src/main.js'; // make sure main.js compiles
+import { LdmlCompilerMessages, LdmlKeyboardCompiler } from '../../src/main.js'; // make sure main.js compiles
 import { assert } from 'chai';
 import { KMXPlusMetadataCompiler } from '../../src/compiler/metadata-compiler.js';
 import { LdmlCompilerOptions } from '../../src/compiler/ldml-compiler-options.js';
@@ -20,7 +20,7 @@ import LDMLKeyboardXMLSourceFile = LDMLKeyboard.LDMLKeyboardXMLSourceFile;
 import DependencySections = KMXPlus.DependencySections;
 import Section = KMXPlus.Section;
 import { ElemCompiler, ListCompiler, StrsCompiler } from '../../src/compiler/empty-compiler.js';
-import { KmnCompiler } from '@keymanapp/kmc-kmn';
+import { KmnCompiler, KmnCompilerMessages } from '@keymanapp/kmc-kmn';
 import { VarsCompiler } from '../../src/compiler/vars.js';
 
 /**
@@ -279,6 +279,18 @@ export function scrubContextFromMessages(messages: CompilerEvent[]): CompilerEve
   });
 }
 
+function messagesToString(messages?: CompilerEventOrMatch[]) {
+  return messages?.length
+    ? messages
+      .map(message =>
+        Object.keys(LdmlCompilerMessages).find(key => (<any>LdmlCompilerMessages)[key] === message.code) ??
+        Object.keys(KmnCompilerMessages).find(key => (<any>KmnCompilerMessages)[key] === message.code) ??
+        'unknown message'
+      )
+      .join(', ')
+    : 'unknown';
+}
+
 /**
  * Run a bunch of cases
  * @param cases cases to run
@@ -290,8 +302,14 @@ export function testCompilationCases(compiler: SectionCompilerNew, cases : Compi
   const callbacks = new TestCompilerCallbacks();
   for (const testcase of cases) {
     const expectFailure = testcase.throws || !!(testcase.errors); // if true, we expect this to fail
-    const testHeading = expectFailure ? `should fail to compile: ${testcase.subpath}`:
-                                        `should compile: ${testcase.subpath}`;
+    const testHeading = `${testcase.subpath}: ` + (
+      testcase.throws ? `should fail to compile with an exception` :
+      typeof testcase.errors === 'boolean' ? `should fail to compile with errors` :
+      testcase.errors?.length ? `should fail to compile with errors: ${messagesToString(testcase.errors)}` :
+      testcase.warnings?.length ? `should compile with hints or warnings: ${messagesToString(testcase.warnings)}` :
+      'should compile without hints, warnings, or errors'
+    );
+
     it(testHeading, async function () {
       callbacks.clear();
       // special case for an expected exception


### PR DESCRIPTION
* Add more detail on each test name to show expected errors
* Rename `build-fixtures` action to `fixtures-build` in build.sh, to reduce confusion with `build` action and allow shorthand usage.

Test-bot: skip