### PR TITLE
fix(developer): hide keyboard uninstall confirmation

### DIFF
--- a/developer/src/tike/main/KeymanDeveloperUtils.pas
+++ b/developer/src/tike/main/KeymanDeveloperUtils.pas
@@ -285,7 +285,7 @@ begin
   if not GetKmshellPath(kmshell) then
     Exit(False);
 
-  Result := TUtilExecute.WaitForProcess('"'+kmshell+'" -uk "'+nm+'"', ExtractFilePath(kmshell));  // I3475
+  Result := TUtilExecute.WaitForProcess('"'+kmshell+'" -uk "'+nm+'" -s', ExtractFilePath(kmshell));  // I3475
 end;
 
 function UninstallPackage(const nm: string): Boolean;


### PR DESCRIPTION
This side-steps #8227 by removing an unnecessary confirmation dialog, without needing to change exit codes from kmshell, which would be a more impactful change. (Perhaps kmshell should return non-zero if the Cancel button is pressed in the uninstall confirmation dialog, but don't want to make that change at this point.)

Fixes: #8227
Test-bot: skip
Build-bot: skip