### PR TITLE
fix(developer): remember presentation and layer when switching platforms in touch layout editor

### DIFF
--- a/developer/src/tike/xml/layoutbuilder/builder.js
+++ b/developer/src/tike/xml/layoutbuilder/builder.js
@@ -10,6 +10,7 @@ $(function() {
   this.yscale = 1;
   this.uniqId = 1;
 
+  this.lastPresentations = {...this.defaultPresentations};
 
   this.getPresentation = function () {
     return $('#selPlatformPresentation').val();
@@ -41,6 +42,7 @@ $(function() {
   }
 
   builder.selPlatformPresentationChange = function () {
+    builder.lastPresentations[builder.lastPlatform] = builder.getPresentation();
     let lastSelection = builder.saveSelection();
     builder.selectKey(null, false);
     builder.selectSubKey(null);
@@ -493,6 +495,9 @@ $(function() {
       }
       var option = $(document.createElement('option'));
       option.attr('value', i).text(this.presentations[i].name);
+      if(builder.lastPresentations[builder.lastPlatform] == i) {
+        option.attr('selected', true);
+      }
       listContainer.append(option);
     }
 
@@ -1079,7 +1084,8 @@ $(function() {
     var state = {
       platform: builder.lastPlatform,
       layer: builder.lastLayerIndex,
-      presentation: $('#selPlatformPresentation').val()
+      presentation: $('#selPlatformPresentation').val(),
+      lastPresentations: builder.lastPresentations,
     };
 
     var key = builder.selectedKey();
@@ -1118,6 +1124,8 @@ $(function() {
             // The last selected presentation is no longer available; select the first option instead
             $('#selPlatformPresentation').val($('#selPlatformPresentation option:first').val());
           }
+
+          builder.lastPresentations = {...(data.lastPresentations ?? this.defaultPresentations)};
 
           let selection = builder.saveSelection();
           builder.prepareLayer();

--- a/developer/src/tike/xml/layoutbuilder/builder.js
+++ b/developer/src/tike/xml/layoutbuilder/builder.js
@@ -11,6 +11,7 @@ $(function() {
   this.uniqId = 1;
 
   this.lastPresentations = {...this.defaultPresentations};
+  this.lastLayers = {};
 
   this.getPresentation = function () {
     return $('#selPlatformPresentation').val();
@@ -502,7 +503,7 @@ $(function() {
     }
 
     builder.prepareLayers();
-    builder.selectLayer(0);
+    builder.selectLayer(builder.lastLayers[builder.lastPlatform] ?? 0);
   }
 
   this.selectLayer = function (val) {
@@ -1086,6 +1087,7 @@ $(function() {
       layer: builder.lastLayerIndex,
       presentation: $('#selPlatformPresentation').val(),
       lastPresentations: builder.lastPresentations,
+      lastLayers: builder.lastLayers,
     };
 
     var key = builder.selectedKey();
@@ -1126,6 +1128,7 @@ $(function() {
           }
 
           builder.lastPresentations = {...(data.lastPresentations ?? this.defaultPresentations)};
+          builder.lastLayers = {...(data.lastLayers ?? {})};
 
           let selection = builder.saveSelection();
           builder.prepareLayer();

--- a/developer/src/tike/xml/layoutbuilder/constants.js
+++ b/developer/src/tike/xml/layoutbuilder/constants.js
@@ -631,6 +631,8 @@ $(function() {
     "desktop": { "x": 640, "y": 300, "name": "Desktop" },
   };
 
+  this.defaultPresentations = { "tablet": "tablet-ipad-landscape", "phone": "phone-iphone5-landscape", "desktop": "desktop" };
+
   this.keyMargin = 15;
 
   // from kmwosk.js:

--- a/developer/src/tike/xml/layoutbuilder/layer-controls.js
+++ b/developer/src/tike/xml/layoutbuilder/layer-controls.js
@@ -174,6 +174,7 @@ $(function() {
   });
 
   $('#selLayer').change(function () {
+    builder.lastLayers[builder.lastPlatform] = $('#selLayer').val();
     if (builder.lastPlatform) builder.generate(false,false);
     let selection = builder.saveSelection();
     builder.selectLayer();


### PR DESCRIPTION
Fixes: #11209

# User Testing

TEST_REMEMBER: Check to see if the touch layout editor remembers which View and which Layer you have selected for each Platform - you may need to add extra platforms to test. It should remember the View and the Layer selected for each platform when you switch platforms.