### PR TITLE
fix(windows): open chm external links in user's browser

### DIFF
--- a/resources/build/htm-link.lua
+++ b/resources/build/htm-link.lua
@@ -8,7 +8,9 @@ function Link(elem)
       return pandoc.Link(elem.content, elem.target .. '.htm', elem.title, elem.attr)
     end
   end
-  return elem
+  -- target=_blank opens external links in browser
+  table.insert(elem.content, ' ↗️')
+  return pandoc.Link(elem.content, elem.target, 'This link opens in your web browser', { target = '_blank' })
 end
 
 function isLocalLink(elem)


### PR DESCRIPTION
Transform external links to add target=_blank, and add a title and ↗️ icon to make it clear the link opens in an external browser, for example:

<img width="430" height="238" alt="image" src="https://github.com/user-attachments/assets/72c5ce45-661d-49e1-9f3d-fb74d8554dcd" />

Hovering over the link shows a tooltip with the title text.

Fixes: #16507
Test-bot: skip