### PR TITLE
fix(windows): move non ui function from ufrmbasekeyboard

### DIFF
--- a/windows/src/desktop/kmshell/kmshell.dpr
+++ b/windows/src/desktop/kmshell/kmshell.dpr
@@ -183,7 +183,8 @@ uses
   Keyman.System.DownloadUpdate in 'main\Keyman.System.DownloadUpdate.pas',
   Keyman.System.ExecutionHistory in '..\..\..\..\common\windows\delphi\general\Keyman.System.ExecutionHistory.pas',
   Keyman.Configuration.UI.UfrmStartInstall in 'main\Keyman.Configuration.UI.UfrmStartInstall.pas' {frmStartInstall},
-  Keyman.Configuration.Util.NetworkConnection in 'util\Keyman.Configuration.Util.NetworkConnection.pas';
+  Keyman.Configuration.Util.NetworkConnection in 'util\Keyman.Configuration.Util.NetworkConnection.pas',
+  Keyman.Configuration.Settings.BaseKeyboard in 'settings\Keyman.Configuration.Settings.BaseKeyboard.pas';
 
 {$R VERSION.RES}
 {$R manifest.res}

--- a/windows/src/desktop/kmshell/kmshell.dproj
+++ b/windows/src/desktop/kmshell/kmshell.dproj
@@ -358,6 +358,7 @@
             <Form>frmStartInstall</Form>
         </DCCReference>
         <DCCReference Include="util\Keyman.Configuration.Util.NetworkConnection.pas"/>
+        <DCCReference Include="settings\Keyman.Configuration.Settings.BaseKeyboard.pas"/>
         <None Include="Profiling\AQtimeModule1.aqt"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
@@ -419,6 +420,12 @@
                 <Platform value="Win64">False</Platform>
             </Platforms>
             <Deployment Version="3">
+                <DeployFile LocalName="bin\Win32\Debug\kmshell.exe" Configuration="Debug" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>kmshell.exe</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
                 <DeployFile LocalName="Profiling\AQtimeModule1.aqt" Configuration="Debug" Class="ProjectFile">
                     <Platform Name="Win32">
                         <RemoteDir>.\</RemoteDir>
@@ -428,12 +435,6 @@
                 <DeployFile LocalName="bin\Win32\Debug\kmshell.rsm" Configuration="Debug" Class="DebugSymbols">
                     <Platform Name="Win32">
                         <RemoteName>kmshell.rsm</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="bin\Win32\Debug\kmshell.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>kmshell.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>

--- a/windows/src/desktop/kmshell/main/UfrmBaseKeyboard.pas
+++ b/windows/src/desktop/kmshell/main/UfrmBaseKeyboard.pas
@@ -19,9 +19,6 @@ type
   end;
 
 function ConfigureBaseKeyboard(out BaseKeyboardID: Integer): Boolean;
-function SetBaseKeyboard(WindowHandle: THandle; BaseKeyboardID: Integer): Boolean;
-function MCompileBaseKeyboard(const BaseKeyboardIDText: string): Boolean;
-procedure CompileForBaseKeyboard(BaseKeyboardID: Integer);
 
 implementation
 
@@ -76,67 +73,5 @@ begin
   ModalResult := mrOk;
 end;
 
-function MCompileBaseKeyboard(const BaseKeyboardIDText: string): Boolean;
-var
-  BaseKeyboardID: Integer;
-begin
-  Result := False;
-  if not TryStrToInt('$' + BaseKeyboardIDText, BaseKeyboardID) or
-    not kmcom.SystemInfo.IsAdministrator then
-    Exit;
-  CompileForBaseKeyboard(BaseKeyboardID);
-  // TODO: sort out whether we need todo return a result
-  Result := True;
-end;
-
-function BaseKeyboardNeedsMCompile(BaseKeyboardID: Integer): Boolean;
-var
-  I: Integer;
-  Keyboard: IKeymanKeyboardInstalled;
-  BaseFileName: string;
-  BaseKeyboardIDHex: string;
-begin
-  BaseKeyboardIDHex := IntToHex(BaseKeyboardID, 8);
-  for I := 0 to kmcom.Keyboards.Count - 1 do
-  begin
-    Keyboard := kmcom.Keyboards.Items[I];
-    BaseFileName := Keyboard.Filename;
-    if FileExists(BaseFileName) and
-      (not FileExists(ChangeFileExt(BaseFileName, '') + '-' + BaseKeyboardIDHex + '.kmx') or
-       not FileExists(ChangeFileExt(BaseFileName, '') + '-' + BaseKeyboardIDHex + '-d.kmx')) then
-      Exit(True);
-  end;
-  Result := False;
-end;
-
-function SetBaseKeyboard(WindowHandle: THandle; BaseKeyboardID: Integer): Boolean;
-begin
-  Result := False;
-  if BaseKeyboardNeedsMCompile(BaseKeyboardID) then
-  begin
-    if not kmcom.SystemInfo.IsAdministrator then
-      begin
-        WaitForElevatedConfiguration(WindowHandle, '-mcompilekbds ' + IntToHex(BaseKeyboardID, 8));
-      end
-    else
-      CompileForBaseKeyboard(BaseKeyboardID);
-  end;
-
-  kmcom.Options['koBaseLayout'].Value := BaseKeyboardID;
-  kmcom.Options.Apply;
-  Result := True;
-end;
-
-procedure CompileForBaseKeyboard(BaseKeyboardID: Integer);
-var
-  i: Integer;
-  kbd: IKeymanKeyboardInstalled;
-begin
-  for i := 0 to kmcom.Keyboards.Count - 1 do
-    begin
-      kbd := kmcom.Keyboards[i];
-      (kbd as IKeymanKeyboardInstalled2).MCompileForBaseKeyboard(BaseKeyboardID);
-    end;
-end;
 
 end.

--- a/windows/src/desktop/kmshell/main/UfrmMain.pas
+++ b/windows/src/desktop/kmshell/main/UfrmMain.pas
@@ -174,6 +174,7 @@ uses
   Hints,
   HotkeyUtils,
   initprog,
+  Keyman.Configuration.Settings.BaseKeyboard,
   Keyman.Configuration.System.TIPMaintenance,
   Keyman.Configuration.UI.UfrmDiagnosticTests,
   KeymanOptionNames,

--- a/windows/src/desktop/kmshell/main/initprog.pas
+++ b/windows/src/desktop/kmshell/main/initprog.pas
@@ -115,6 +115,7 @@ uses
   GetOsVersion,
   help,
   HTMLHelpViewer,
+  Keyman.Configuration.Settings.BaseKeyboard,
   Keyman.Configuration.UI.InstallFile,
   Keyman.Configuration.System.TIPMaintenance,
   Keyman.Configuration.System.UImportOlderVersionKeyboards11To13,

--- a/windows/src/desktop/kmshell/settings/Keyman.Configuration.Settings.BaseKeyboard.pas
+++ b/windows/src/desktop/kmshell/settings/Keyman.Configuration.Settings.BaseKeyboard.pas
@@ -1,0 +1,83 @@
+unit Keyman.Configuration.Settings.BaseKeyboard;
+
+interface
+
+uses
+  Winapi.Windows,
+  System.SysUtils,
+  keymanapi_TLB;
+
+function SetBaseKeyboard(WindowHandle: THandle; BaseKeyboardID: Integer): Boolean;
+function MCompileBaseKeyboard(const BaseKeyboardIDText: string): Boolean;
+procedure CompileForBaseKeyboard(BaseKeyboardID: Integer);
+
+implementation
+
+uses
+  kmint,
+  utilkmshell;
+
+function BaseKeyboardNeedsMCompile(BaseKeyboardID: Integer): Boolean;
+var
+  I: Integer;
+  Keyboard: IKeymanKeyboardInstalled;
+  BaseFileName: string;
+  BaseKeyboardIDHex: string;
+begin
+  BaseKeyboardIDHex := IntToHex(BaseKeyboardID, 8);
+  for I := 0 to kmcom.Keyboards.Count - 1 do
+  begin
+    Keyboard := kmcom.Keyboards.Items[I];
+    BaseFileName := Keyboard.Filename;
+    if FileExists(BaseFileName) and
+      (not FileExists(ChangeFileExt(BaseFileName, '') + '-' + BaseKeyboardIDHex + '.kmx') or
+       not FileExists(ChangeFileExt(BaseFileName, '') + '-' + BaseKeyboardIDHex + '-d.kmx')) then
+      Exit(True);
+  end;
+  Result := False;
+end;
+
+function SetBaseKeyboard(WindowHandle: THandle; BaseKeyboardID: Integer): Boolean;
+begin
+  Result := False;
+  if BaseKeyboardNeedsMCompile(BaseKeyboardID) then
+  begin
+    if not kmcom.SystemInfo.IsAdministrator then
+    begin
+      WaitForElevatedConfiguration(WindowHandle, '-mcompilekbds ' + IntToHex(BaseKeyboardID, 8));
+    end
+    else
+      CompileForBaseKeyboard(BaseKeyboardID);
+  end;
+
+  kmcom.Options['koBaseLayout'].Value := BaseKeyboardID;
+  kmcom.Options.Apply;
+  Result := True;
+end;
+
+function MCompileBaseKeyboard(const BaseKeyboardIDText: string): Boolean;
+var
+  BaseKeyboardID: Integer;
+begin
+  Result := False;
+  if not TryStrToInt('$' + BaseKeyboardIDText, BaseKeyboardID) or
+    not kmcom.SystemInfo.IsAdministrator then
+    Exit;
+  CompileForBaseKeyboard(BaseKeyboardID);
+  // TODO: sort out whether we need todo return a result
+  Result := True;
+end;
+
+procedure CompileForBaseKeyboard(BaseKeyboardID: Integer);
+var
+  i: Integer;
+  kbd: IKeymanKeyboardInstalled;
+begin
+  for i := 0 to kmcom.Keyboards.Count - 1 do
+  begin
+    kbd := kmcom.Keyboards[i];
+    (kbd as IKeymanKeyboardInstalled2).MCompileForBaseKeyboard(BaseKeyboardID);
+  end;
+end;
+
+end.


### PR DESCRIPTION
Fixes: #15152 This is about a non-admin user installing a keyboard that has different base keyboard configured then the admin user.
