### PR TITLE
fix(web): remove scroll-to-top on page load

### DIFF
--- a/web/src/app/browser/src/context/pageIntegrationHandlers.ts
+++ b/web/src/app/browser/src/context/pageIntegrationHandlers.ts
@@ -159,15 +159,6 @@ export class PageIntegrationHandlers {
     return false;
   };
 
-
-  private _WindowLoad: (e: Event) => void = () => {
-    // Always return to top of page after a page reload
-    document.body.scrollTop=0;
-    if(typeof document.documentElement != 'undefined') {
-      document.documentElement.scrollTop=0;
-    }
-  }
-
   private attachHandlers() {
     const eventTracker = this.domEventTracker;
     const device = this.engine.config.hostDevice;
@@ -190,8 +181,6 @@ export class PageIntegrationHandlers {
       eventTracker.attachDOMEvent(docBody, 'touchmove',  this.touchMoveActivationHandler, false);
       eventTracker.attachDOMEvent(docBody, 'touchend',   this.touchEndActivationHandler,  false);
     }
-
-    eventTracker.attachDOMEvent(window, 'load',   this._WindowLoad,  false);
 
     eventTracker.attachDOMEvent(document, 'keyup', this.engine.hotkeyManager._Process, false);
   }
@@ -216,8 +205,6 @@ export class PageIntegrationHandlers {
 
       this.mobilePageTrailer?.parentElement.removeChild(this.mobilePageTrailer);
     }
-
-    eventTracker.detachDOMEvent(window, 'load',   this._WindowLoad,  false);
 
     eventTracker.detachDOMEvent(document, 'keyup', this.engine.hotkeyManager._Process, false);
   }


### PR DESCRIPTION
This is a legacy behaviour from pre KeymanWeb 2.0 days, probably to deal with buggy rendering in older browsers. Removing as an unwanted side-effect.

Fixes: #16503
Test-bot: skip