### PR TITLE
fix(developer): trim new words entered into the wordlist editor

### DIFF
--- a/developer/src/tike/child/Keyman.Developer.UI.UframeWordlistEditor.dfm
+++ b/developer/src/tike/child/Keyman.Developer.UI.UframeWordlistEditor.dfm
@@ -19,12 +19,12 @@ inherited frameWordlistEditor: TframeWordlistEditor
     TabOrder = 0
     TabPosition = tpBottom
     OnChanging = pagesChanging
-    ExplicitWidth = 635
+ExplicitWidth = 635
     ExplicitHeight = 299
     object pageDesign: TTabSheet
       Caption = 'Design'
       ImageIndex = -1
-      ExplicitLeft = 0
+ExplicitLeft = 0
       ExplicitTop = 0
       ExplicitWidth = 627
       ExplicitHeight = 273
@@ -42,8 +42,9 @@ inherited frameWordlistEditor: TframeWordlistEditor
         TabOrder = 0
         OnClick = gridWordlistClick
         OnDrawCell = gridWordlistDrawCell
+        OnSelectCell = gridWordlistSelectCell
         OnSetEditText = gridWordlistSetEditText
-        ExplicitWidth = 627
+ExplicitWidth = 627
         ExplicitHeight = 232
       end
       object panGridControls: TPanel
@@ -53,7 +54,7 @@ inherited frameWordlistEditor: TframeWordlistEditor
         Height = 41
         Align = alBottom
         TabOrder = 1
-        ExplicitTop = 232
+ExplicitTop = 232
         ExplicitWidth = 627
         object cmdDeleteRow: TButton
           Left = 0
@@ -78,7 +79,7 @@ inherited frameWordlistEditor: TframeWordlistEditor
     object pageCode: TTabSheet
       Caption = 'Code'
       ImageIndex = -1
-      ExplicitLeft = 0
+ExplicitLeft = 0
       ExplicitTop = 0
       ExplicitWidth = 0
       ExplicitHeight = 0

--- a/developer/src/tike/child/Keyman.Developer.UI.UframeWordlistEditor.pas
+++ b/developer/src/tike/child/Keyman.Developer.UI.UframeWordlistEditor.pas
@@ -41,6 +41,8 @@ type
     procedure cmdDeleteRowClick(Sender: TObject);
     procedure gridWordlistClick(Sender: TObject);
     procedure cmdSortByFrequencyClick(Sender: TObject);
+    procedure gridWordlistSelectCell(Sender: TObject; ACol, ARow: Integer;
+      var CanSelect: Boolean);
   private
     FWordlist: TWordlistTsvFile;
     frameSource: TframeTextEditor;
@@ -313,6 +315,25 @@ begin
     ARect.Top+((ARect.Height - gridWordlist.Canvas.TextHeight(LText)) div 2), LText);
 end;
 
+procedure TframeWordlistEditor.gridWordlistSelectCell(Sender: TObject; ACol,
+  ARow: Integer; var CanSelect: Boolean);
+var
+  Value: string;
+begin
+  if gridWordlist.Col = 0 then
+  begin
+    // The value is trimmed in the backing data but trim it here also when
+    // we exit a cell, so the visible text matches
+    Value := Trim(gridWordlist.Cells[gridWordlist.Col, gridWordlist.Row]);
+    gridWordlist.Cells[gridWordlist.Col, gridWordlist.Row] := Value;
+    if (gridWordlist.Row = gridWordlist.RowCount - 1) and (Value = '') then
+    begin
+      // And if the last row was just whitespace, show the hint text again
+      FillGridNewRow;
+    end;
+  end;
+end;
+
 procedure TframeWordlistEditor.gridWordlistSetEditText(Sender: TObject; ACol,
   ARow: Integer; const Value: string);
 var
@@ -324,12 +345,14 @@ begin
 
   Inc(FSetup);
   try
+    TrimmedValue := Value.Trim;
+
     if ARow = gridWordlist.RowCount - 1 then
     begin
-      if (Value = '') or (Value = S_AddRowText) then
+      if (TrimmedValue = '') or (TrimmedValue = S_AddRowText) then
         Exit;
 
-      w.Word := Value;
+      w.Word := TrimmedValue;
       w.Frequency := 0;
       w.Comment := '';
       FWordlist.AddWord(w);
@@ -338,7 +361,6 @@ begin
     end
     else
     begin
-      TrimmedValue := Value.Trim;
       Frequency := StrToIntDef(TrimmedValue.Replace(',', '', [rfReplaceAll]), 0);
       w := FWordlist.Word[ARow-1];
       case ACol of


### PR DESCRIPTION
Fixes: #12668

# User Testing

* TEST_WORDLIST_EDITOR: Open the Wordlist Editor and try entering spaces into new rows in the editor. Upon exiting the cell, the text should be trimmed, and if only whitespace was present on the last row, it should return to being a 'Add word...' entry. Other words entered should also be trimmed of leading and following whitespace.