### PR TITLE
fix(web): handle 'unload' message while attempting model 'load'

### DIFF
--- a/web/src/engine/predictive-text/worker-thread/src/main/index.ts
+++ b/web/src/engine/predictive-text/worker-thread/src/main/index.ts
@@ -267,7 +267,11 @@ export class LMLayerWorker {
     try {
       this._importScripts(url);
     } catch (err) {
+      // Does not catch errors thrown within the imported script.
+      // Does catch errors with the model script's file-path.
       this.error("Error occurred when attempting to load dictionary", err);
+
+      // Remain in the model-unloaded state; the load attempt was unsuccessful.
     }
   }
 
@@ -312,7 +316,14 @@ export class LMLayerWorker {
     this.state = {
       name: 'modelless',
       handleMessage: (payload) => {
-        // ...that message must have been 'load'!
+        // It is possible to remain in this state after a model loading error.
+        // In such cases, the hosting engine may signal a model-unload.
+        if (payload.message === 'unload') {
+          // We are already in a "model unloaded" state; no work needed!
+          return;
+        }
+
+        // ...otherwise, that message must have been 'load'!
         if (payload.message !== 'load') {
           throw new Error(`invalid message; expected 'load' but got ${payload.message}`);
         }

--- a/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-initialization.tests.ts
+++ b/web/src/test/auto/headless/engine/predictive-text/worker-thread/worker-initialization.tests.ts
@@ -6,7 +6,6 @@ import sinon from 'sinon';
 
 import { configWorker, createMessageEventWithData, importScriptsWith } from '@keymanapp/common-test-resources/model-helpers.mjs';
 
-// @ts-ignore
 import { LMLayerWorker } from '@keymanapp/lm-worker/test-index';
 
 const require = createRequire(import.meta.url);
@@ -167,6 +166,54 @@ describe('LMLayerWorker', function() {
       }));
 
       assert(fakePostMessage.calledOnceWith(sinon.match({
+        message: 'ready'
+      })));
+    });
+
+    it('should send back an "error" message and recover when given an invalid filepath', function () {
+      var fakePostMessage = sinon.fake();
+      var context: MockedContext = {
+        postMessage: fakePostMessage
+      };
+      context.importScripts = importScriptsWith(context);
+
+      var worker = LMLayerWorker.install(context);
+      configWorker(worker);
+
+      worker.onMessage(createMessageEventWithData({
+        message: 'load',
+        source: {
+          type: 'file',
+          file: require.resolve("@keymanapp/common-test-resources/models/simple-dummy.js") + "x"
+        }
+      }));
+
+      assert(fakePostMessage.calledOnce);
+      assert(fakePostMessage.calledWith(sinon.match({
+        message: 'error'
+      })));
+
+      // Validate internal state name - that we're still in an unloaded mode.
+      // worker.state is private, though.
+      assert.equal(worker['state'].name, 'modelless');
+      // Permit host engine 'unload' messages to pass through without error while in this state.
+      worker.onMessage(createMessageEventWithData({
+        message: 'unload'
+      }));
+
+      // No new message should be received in this case; it should pass through silently.
+      assert(fakePostMessage.calledOnce);
+
+      worker.onMessage(createMessageEventWithData({
+        message: 'load',
+        source: {
+          type: 'file',
+          file: require.resolve("@keymanapp/common-test-resources/models/simple-dummy.js")
+        }
+      }));
+
+      assert(fakePostMessage.calledTwice);
+      assert(fakePostMessage.calledWith(sinon.match({
         message: 'ready'
       })));
     });


### PR DESCRIPTION
Fixes: KEYMAN-WEB-MD
Fixes: KEYMAN-ANDROID-6W9 ([Uncaught Error: invalid message; expected 'load' but got unload](https://keyman.sentry.io/issues/6545304633/)) - it appears in Android logs and not just Web ones!

Build-bot: skip build:web
Test-bot: skip