### PR TITLE
chore(windows): use ✕ U+2715 consistently in localizations

### DIFF
--- a/windows/src/desktop/kmshell/locale/am-ET/strings.xml
+++ b/windows/src/desktop/kmshell/locale/am-ET/strings.xml
@@ -183,7 +183,7 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->
-  <string name="S_Languages_Uninstall" comment="Remove language profile">X</string>
+  <string name="S_Languages_Uninstall" comment="Remove language profile">✕</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->

--- a/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
+++ b/windows/src/desktop/kmshell/locale/az-AZ/strings.xml
@@ -167,7 +167,7 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->
-  <string name="S_Languages_Uninstall" comment="Remove language profile">X</string>
+  <string name="S_Languages_Uninstall" comment="Remove language profile">✕</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->

--- a/windows/src/desktop/kmshell/locale/ff-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/ff-NG/strings.xml
@@ -183,7 +183,7 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->
-  <string name="S_Languages_Uninstall" comment="Remove language profile">X</string>
+  <string name="S_Languages_Uninstall" comment="Remove language profile">✕</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->

--- a/windows/src/desktop/kmshell/locale/kn/strings.xml
+++ b/windows/src/desktop/kmshell/locale/kn/strings.xml
@@ -183,7 +183,7 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->
-  <string name="S_Languages_Uninstall" comment="Remove language profile">X</string>
+  <string name="S_Languages_Uninstall" comment="Remove language profile">✕</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->

--- a/windows/src/desktop/kmshell/locale/kr-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/kr-NG/strings.xml
@@ -167,7 +167,7 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->
-  <string name="S_Languages_Uninstall" comment="Remove language profile">X</string>
+  <string name="S_Languages_Uninstall" comment="Remove language profile">✕</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->

--- a/windows/src/desktop/kmshell/locale/mfi-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/mfi-NG/strings.xml
@@ -167,7 +167,7 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->
-  <string name="S_Languages_Uninstall" comment="Remove language profile">X</string>
+  <string name="S_Languages_Uninstall" comment="Remove language profile">✕</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->

--- a/windows/src/desktop/kmshell/locale/mrt-NG/strings.xml
+++ b/windows/src/desktop/kmshell/locale/mrt-NG/strings.xml
@@ -167,7 +167,7 @@
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->
-  <string name="S_Languages_Uninstall" comment="Remove language profile">X</string>
+  <string name="S_Languages_Uninstall" comment="Remove language profile">✕</string>
   <!-- Context: Configuration Dialog - Captions -->
   <!-- String Type: PlainText -->
   <!-- Introduced: 9.0.420.0 -->

--- a/windows/src/desktop/kmshell/locale/tr/strings.xml
+++ b/windows/src/desktop/kmshell/locale/tr/strings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <resources>
   <string name="S_Toolbar_CloseOnScreenKeyboard" comment="/PlainText: ">Ekran Klavyesi Kapat</string>
   <string name="S_Menu_Exit" comment="/PlainText: ">&amp;Çıkış</string>
@@ -121,7 +121,7 @@
   <string name="S_Languages_Install" comment="/PlainText: ">Dil ekle</string>
   <string name="S_Languages_InstalledLanguage" comment="/PlainText: ">Yüklü Dil</string>
   <string name="S_Languages_KeymanKeyboard" comment="/PlainText: ">Keyman Klavye</string>
-  <string name="S_Languages_Uninstall" comment="/PlainText: ">x</string>
+  <string name="S_Languages_Uninstall" comment="/PlainText: ">✕</string>
   <string name="S_Languages_UseWindowsLayout" comment="/PlainText: ">(Windows düzeni kullan)</string>
   <string name="S_Languages_WindowsLayout" comment="/PlainText: ">Windows Düzeni</string>
   <string name="S_LayoutType_Mnemonic" comment="/PlainText: ">Windows düzenine (Anımsatıcı) eşleştirildi</string>


### PR DESCRIPTION
Let all languages in their localization for label S_Languages_Uninstall use `✕` U+2715 instead of `x` U+0058 or `X` U+0078

Fixes: 13528
Test-bot: skip